### PR TITLE
fix(coven-bin): resolve coven binary against user's interactive PATH (finder-launched .app)

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -3,6 +3,7 @@ import { stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { stripAnsi } from "@/lib/ansi";
 import { bindingFor, loadConfig, recordSessionFamiliar } from "@/lib/cave-config";
+import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
 import {
   type ChatTurn,
   loadConversation,
@@ -182,9 +183,10 @@ export async function POST(req: Request) {
       const STDOUT_ERR_KEEP = 10;
       const ERR_LINE_RE = /\b(error|failed|denied|unauthori[sz]ed|invalid|refused|missing|not found|401|403|500)\b/i;
 
-      const child = spawn("coven", args, {
+      const child = spawn(covenBin(), args, {
         cwd,
         stdio: ["ignore", "pipe", "pipe"],
+        env: covenSpawnEnv(),
       });
 
       // Client-side abort (cancel button) → kill the subprocess.

--- a/src/app/api/coven/exec/route.ts
+++ b/src/app/api/coven/exec/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { spawn } from "node:child_process";
 import { stripAnsi } from "@/lib/ansi";
+import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
 
 export const dynamic = "force-dynamic";
 
@@ -29,7 +30,10 @@ export async function POST(req: Request) {
   const args = [body.command, ...(SUBCOMMAND_ARGS[body.command] ?? [])];
 
   return new Promise<Response>((resolve) => {
-    const child = spawn("coven", args, { stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(covenBin(), args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: covenSpawnEnv(),
+    });
     let out = "";
     let err = "";
     child.stdout.on("data", (d) => (out += d.toString()));

--- a/src/app/api/daemon/start/route.ts
+++ b/src/app/api/daemon/start/route.ts
@@ -1,13 +1,15 @@
 import { NextResponse } from "next/server";
 import { spawn } from "node:child_process";
+import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
 
 export const dynamic = "force-dynamic";
 
 export async function POST() {
   return new Promise<Response>((resolve) => {
-    const child = spawn("coven", ["daemon", "start"], {
+    const child = spawn(covenBin(), ["daemon", "start"], {
       stdio: ["ignore", "pipe", "pipe"],
       detached: false,
+      env: covenSpawnEnv(),
     });
 
     let stdout = "";

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -1,0 +1,141 @@
+// coven-bin: resolve the `coven` binary and spawn env for child processes.
+//
+// Why this exists: when the Tauri-bundled cave .app is launched from Finder
+// or Spotlight, macOS gives it a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin).
+// Interactive-only shell setup (nvm, fnm, asdf, …) isn't applied, so the
+// up-to-date `coven` symlinked into ~/.nvm/versions/node/<v>/bin doesn't get
+// found — and if a stale Rust-installed `coven` lives at ~/.cargo/bin (or
+// /usr/local/bin) it gets picked instead, often missing flags the cave
+// relies on (--stream-json, --continue, etc.) and producing cryptic clap
+// errors.
+//
+// Strategy:
+//   1. Probe a small list of well-known coven install locations in priority
+//      order (nvm/fnm node bin dirs, pnpm global, bun global, homebrew,
+//      ~/.local/bin, /usr/local/bin, then ~/.cargo/bin as a last resort
+//      because it tends to be the stale one).
+//   2. If none exist, fall back to the user's login-shell PATH by exec-ing
+//      `$SHELL -ilc 'echo $PATH'` so anything the user has in their interactive
+//      profile (custom rc edits, asdf, mise, etc.) still works.
+//   3. Cache the result for the lifetime of the server process.
+//
+// All cave spawn sites of `coven` should use `covenBin()` for argv[0] and
+// `covenSpawnEnv()` for the env option.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+let cachedBin: string | null = null;
+let cachedPath: string | null = null;
+
+const HOME = os.homedir();
+
+function nodeNvmBinDirs(): string[] {
+  const nvmRoot = path.join(HOME, ".nvm", "versions", "node");
+  if (!existsSync(nvmRoot)) return [];
+  try {
+    return readdirSync(nvmRoot)
+      .map((v) => path.join(nvmRoot, v, "bin"))
+      .filter((d) => existsSync(d))
+      .sort()
+      .reverse(); // newest version first by lexicographic sort
+  } catch {
+    return [];
+  }
+}
+
+function fnmBinDirs(): string[] {
+  const fnmRoot = path.join(HOME, ".fnm", "node-versions");
+  if (!existsSync(fnmRoot)) return [];
+  try {
+    return readdirSync(fnmRoot)
+      .map((v) => path.join(fnmRoot, v, "installation", "bin"))
+      .filter((d) => existsSync(d))
+      .sort()
+      .reverse();
+  } catch {
+    return [];
+  }
+}
+
+function candidateDirs(): string[] {
+  return [
+    ...nodeNvmBinDirs(),
+    ...fnmBinDirs(),
+    path.join(HOME, "Library", "pnpm"),
+    path.join(HOME, ".bun", "bin"),
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+    path.join(HOME, ".local", "bin"),
+    // ~/.cargo/bin last: often holds a stale `cargo install` of coven that's
+    // missing flags. Prefer the npm-published binary when both exist.
+    path.join(HOME, ".cargo", "bin"),
+  ].filter((d) => existsSync(d));
+}
+
+function loginShellPath(): string | null {
+  const shell = process.env.SHELL || "/bin/zsh";
+  try {
+    const out = execFileSync(shell, ["-ilc", "echo $PATH"], {
+      encoding: "utf-8",
+      timeout: 4000,
+    }).trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the absolute path to the `coven` binary. If nothing is found,
+ * returns the literal string "coven" so callers can still spawn — the OS
+ * will resolve via PATH and surface a "not found" error to the user.
+ */
+export function covenBin(): string {
+  if (cachedBin) return cachedBin;
+
+  for (const dir of candidateDirs()) {
+    const candidate = path.join(dir, "coven");
+    try {
+      const st = statSync(candidate);
+      if (st.isFile() || st.isSymbolicLink()) {
+        cachedBin = candidate;
+        return cachedBin;
+      }
+    } catch {
+      /* not here; keep looking */
+    }
+  }
+
+  cachedBin = "coven";
+  return cachedBin;
+}
+
+/**
+ * Augmented spawn env with PATH containing the user's interactive-shell PATH
+ * plus the candidate dirs (in priority order), so subprocesses launched from
+ * a Finder-spawned cave can still resolve nested tooling (codex, claude,
+ * git, gh, …).
+ */
+export function covenSpawnEnv(): NodeJS.ProcessEnv {
+  if (cachedPath === null) {
+    const fromShell = loginShellPath();
+    const prependedDirs = candidateDirs();
+    const parts = [
+      ...prependedDirs,
+      ...(fromShell ? fromShell.split(":") : []),
+      ...(process.env.PATH ? process.env.PATH.split(":") : []),
+    ];
+    const seen = new Set<string>();
+    const dedup: string[] = [];
+    for (const p of parts) {
+      if (!p || seen.has(p)) continue;
+      seen.add(p);
+      dedup.push(p);
+    }
+    cachedPath = dedup.join(":");
+  }
+  return { ...process.env, PATH: cachedPath };
+}


### PR DESCRIPTION
## Symptom

A `coven run codex --stream-json …` invocation from a Finder-launched
cave .app surfaced this clap error mid-chat:

\`\`\`
error: unexpected argument '--stream-json' found
tip: to pass '--stream-json' as a value, use '-- --stream-json'
Usage: coven run <HARNESS> <PROMPT>...
\`\`\`

Followed by:

> _The "codex" harness completed but produced no output._

## Root cause

When the bundled cave .app is launched from Finder/Spotlight, macOS
launchd hands it a **minimal PATH** (`/usr/bin:/bin:/usr/sbin:/sbin`).
Interactive-only shell setup (nvm, fnm, asdf, mise, etc.) doesn't run.

On this dev box that means:

- ✅ `~/.nvm/versions/node/v24.13.0/bin/coven` — fresh, symlink into the
  npm `@opencoven/cli` v0.0.30 (has `--stream-json`, `--continue`, …)
- ❌ `~/.cargo/bin/coven` — stale `cargo install` from May 20, version
  0.0.17, doesn't know `--stream-json`

If `~/.cargo/bin` is in launchd's PATH (e.g. via `/etc/paths.d/cargo`)
but `~/.nvm/...` is not, the .app spawn picks the stale Rust binary and
chokes on the `--stream-json` flag.

## Fix

New `src/lib/coven-bin.ts` exposes two helpers every cave spawn site
of `coven` must use:

- **`covenBin()`** — probes a priority-ordered list of well-known coven
  install locations (nvm/fnm node bins, `~/Library/pnpm`, `~/.bun/bin`,
  `/opt/homebrew/bin`, `/usr/local/bin`, `~/.local/bin`, then
  `~/.cargo/bin` last so a stale Rust install never wins by default).
  Returns the literal `"coven"` if nothing is found, so spawn still
  surfaces a clean "not found" error.

- **`covenSpawnEnv()`** — builds a deduped PATH from the candidate dirs
  plus the user's login-shell PATH (resolved via
  `$SHELL -ilc 'echo $PATH'`) so any further nested tooling (codex,
  claude, git, gh) the harness reaches for is also reachable.

Both are memoized for the lifetime of the server process.

## Wired into

- `src/app/api/chat/send/route.ts` — the original failure path
- `src/app/api/daemon/start/route.ts`
- `src/app/api/coven/exec/route.ts`

## Test plan

- [ ] On a dev box that has both an outdated `~/.cargo/bin/coven` and a
      fresh `~/.nvm/.../bin/coven`: launch cave from Finder → start a chat
      with a `codex`-bound familiar → verify the response streams instead
      of erroring with the `--stream-json` clap message.
- [ ] Run `pnpm tsc --noEmit` clean (verified locally).
- [ ] Confirm `~/.cargo/bin/coven` being absent on a fresh box still works
      (falls through to nvm-installed binary).
- [ ] Confirm a box with no `coven` at all surfaces a clean
      "command not found" rather than crashing.