### PR TITLE
feat(chat): simplify chrome, widen transcript, surface tool use + reasoning

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -23,10 +23,25 @@ type StreamEvent =
   | { kind: "session"; sessionId: string }
   | { kind: "user"; text: string }
   | { kind: "assistant_chunk"; text: string }
+  | {
+      kind: "tool_use";
+      id?: string;
+      name: string;
+      input?: string;
+      output?: string;
+      status?: "running" | "ok" | "error";
+      durationMs?: number;
+    }
   | { kind: "done"; durationMs?: number; isError?: boolean; sessionId?: string }
   | { kind: "error"; message: string; code?: string };
 
 const HOOK_LINE_RE = /^hook:\s+/;
+// Hook-line shapes emitted by codex/claude harnesses while a tool runs.
+// Examples:
+//   hook: tool_use Bash {...}
+//   hook: pre_tool_use Edit { ... }
+//   hook: post_tool_use Bash {... exitCode: 0 ...}
+const TOOL_HOOK_RE = /^hook:\s+(?:pre_tool_use|post_tool_use|tool_use)\s+(\S+)(?:\s+(.*))?$/;
 const BANNER_LINE_RE = /^(?:--------|workdir:|model:|provider:|approval:|sandbox:|reasoning|session id:|tokens used|\d[\d,]*\s*$)/;
 const CODEX_START_LINE = "codex";
 const CLAUDE_ASSISTANT_RE = /^claude(?:\s+code)?$/i;
@@ -171,6 +186,18 @@ export async function POST(req: Request) {
       let assistantText = "";
       let jsonBuf = "";
       let result: { duration_ms?: number; is_error?: boolean } = {};
+      // Per-tool start times so post_tool_use can compute durationMs and
+      // associate output with the matching pre_tool_use event.
+      const toolStartTimes = new Map<string, { startedAt: number; id: string }>();
+      let toolSeq = 0;
+      const toolIdFor = (name: string): string => {
+        const existing = toolStartTimes.get(name);
+        if (existing) return existing.id;
+        toolSeq += 1;
+        const id = `tool-${toolSeq}-${name}`;
+        toolStartTimes.set(name, { startedAt: Date.now(), id });
+        return id;
+      };
       // Keep stderr off the assistant stream — surface it only on failure
       // or empty-success so users don't see raw 401 traces mid-bubble.
       const stderrTail: string[] = [];
@@ -227,6 +254,38 @@ export async function POST(req: Request) {
         if (trimmed && ERR_LINE_RE.test(trimmed)) {
           stdoutErrTail.push(trimmed);
           if (stdoutErrTail.length > STDOUT_ERR_KEEP) stdoutErrTail.shift();
+        }
+        // Surface tool-use hook lines as structured events so the chat can
+        // render a tool block. Hooks are still discarded by AssistantFilter
+        // below, so this is purely additive.
+        const toolMatch = trimmed.match(TOOL_HOOK_RE);
+        if (toolMatch) {
+          const isPost = trimmed.startsWith("hook: post_tool_use");
+          const name = toolMatch[1];
+          const rest = (toolMatch[2] ?? "").trim();
+          const id = toolIdFor(name);
+          if (isPost) {
+            const meta = toolStartTimes.get(name);
+            const durationMs = meta ? Date.now() - meta.startedAt : undefined;
+            const isError = /error|fail|denied|exit\s*[1-9]/i.test(rest);
+            push({
+              kind: "tool_use",
+              id,
+              name,
+              output: rest || undefined,
+              status: isError ? "error" : "ok",
+              durationMs,
+            });
+            toolStartTimes.delete(name);
+          } else {
+            push({
+              kind: "tool_use",
+              id,
+              name,
+              input: rest || undefined,
+              status: "running",
+            });
+          }
         }
         const filtered = assistantFilter.push(cleaned + "\n");
         if (filtered) {

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -7,10 +7,22 @@ import { canonicalize, formatHelp, matchSlash, type SlashCommand } from "@/lib/s
 import { Icon } from "@/lib/icon";
 import { useKeySymbols } from "@/lib/platform-keys";
 
+type ToolEvent = {
+  id: string;
+  name: string;
+  input?: string;
+  output?: string;
+  status: "running" | "ok" | "error";
+  durationMs?: number;
+};
+
 type Turn = {
   id: string;
   role: "user" | "assistant" | "system";
   text: string;
+  reasoning?: string;
+  tools?: ToolEvent[];
+  createdAt: string;
   pending?: boolean;
   error?: boolean;
   durationMs?: number;
@@ -35,6 +47,7 @@ type StreamEvent =
   | { kind: "session"; sessionId: string }
   | { kind: "user"; text: string }
   | { kind: "assistant_chunk"; text: string }
+  | { kind: "tool_use"; id?: string; name: string; input?: string; output?: string; status?: "running" | "ok" | "error"; durationMs?: number }
   | { kind: "done"; durationMs?: number; isError?: boolean; sessionId?: string }
   | { kind: "error"; message: string; code?: string };
 
@@ -47,8 +60,39 @@ function fmtDuration(ms?: number): string | null {
   return `${m}m ${rem}s`;
 }
 
+function fmtTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Split assistant text into visible body + accumulated reasoning. We treat any
+ * `<thinking>...</thinking>` or `<reasoning>...</reasoning>` block (both
+ * commonly emitted by Claude/Codex harnesses) as reasoning to be collapsed.
+ * Unclosed blocks fall through as visible text — they become reasoning once
+ * the closing tag arrives in a later chunk.
+ */
+function splitReasoning(text: string): { visible: string; reasoning: string } {
+  const reasoningParts: string[] = [];
+  const visible = text.replace(
+    /<(thinking|reasoning)>([\s\S]*?)<\/\1>/g,
+    (_m, _tag, inner) => {
+      reasoningParts.push(inner.trim());
+      return "";
+    },
+  );
+  return {
+    visible: visible.replace(/\n{3,}/g, "\n\n").trimStart(),
+    reasoning: reasoningParts.join("\n\n").trim(),
+  };
+}
+
 export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
-  { familiar, sessionId, daemonRunning, onSessionStarted, onBack, onSlashCommand, onOpenOnboarding },
+  { familiar, sessionId, onSessionStarted, onSlashCommand, onOpenOnboarding },
   ref,
 ) {
   const [turns, setTurns] = useState<Turn[]>([]);
@@ -82,6 +126,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           id: "help-bootstrap",
           role: "system",
           text: formatHelp(),
+          createdAt: new Date().toISOString(),
         },
       ]);
       return;
@@ -99,11 +144,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             json.conversation.turns
               .filter((t: { role: string }) => t.role === "user" || t.role === "assistant")
               .map(
-                (t: { id: string; role: "user" | "assistant"; text: string; durationMs?: number }) => ({
+                (t: { id: string; role: "user" | "assistant"; text: string; durationMs?: number; createdAt?: string }) => ({
                   id: t.id,
                   role: t.role,
                   text: t.text,
                   durationMs: t.durationMs,
+                  createdAt: t.createdAt ?? new Date().toISOString(),
                 }),
               ),
           );
@@ -125,7 +171,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const appendSystem = (text: string) => {
     setTurns((prev) => [
       ...prev,
-      { id: crypto.randomUUID(), role: "system", text },
+      {
+        id: crypto.randomUUID(),
+        role: "system",
+        text,
+        createdAt: new Date().toISOString(),
+      },
     ]);
   };
 
@@ -197,9 +248,22 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     setBusy(true);
     setError(null);
 
-    const userTurn: Turn = { id: crypto.randomUUID(), role: "user", text };
+    const now = new Date().toISOString();
+    const userTurn: Turn = {
+      id: crypto.randomUUID(),
+      role: "user",
+      text,
+      createdAt: now,
+    };
     const assistantId = crypto.randomUUID();
-    const assistantTurn: Turn = { id: assistantId, role: "assistant", text: "", pending: true };
+    const assistantTurn: Turn = {
+      id: assistantId,
+      role: "assistant",
+      text: "",
+      pending: true,
+      createdAt: now,
+      tools: [],
+    };
     setTurns((prev) => [...prev, userTurn, assistantTurn]);
 
     const controller = new AbortController();
@@ -293,6 +357,40 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         );
         return;
       }
+      case "tool_use": {
+        const incoming: ToolEvent = {
+          id: ev.id ?? crypto.randomUUID(),
+          name: ev.name,
+          input: ev.input,
+          output: ev.output,
+          status: ev.status ?? "running",
+          durationMs: ev.durationMs,
+        };
+        setTurns((prev) =>
+          prev.map((t) => {
+            if (t.id !== assistantId) return t;
+            const tools = t.tools ?? [];
+            const existingIdx = tools.findIndex((x) => x.id === incoming.id);
+            const nextTools =
+              existingIdx >= 0
+                ? tools.map((x, i) =>
+                    i === existingIdx
+                      ? {
+                          ...x,
+                          ...incoming,
+                          // Preserve previously captured input/output if the
+                          // update doesn't supply them.
+                          input: incoming.input ?? x.input,
+                          output: incoming.output ?? x.output,
+                        }
+                      : x,
+                  )
+                : [...tools, incoming];
+            return { ...t, tools: nextTools };
+          }),
+        );
+        return;
+      }
       case "done": {
         setTurns((prev) =>
           prev.map((t) =>
@@ -352,8 +450,6 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     }
   };
 
-  const projectName = "home";
-
   useImperativeHandle(
     ref,
     () => ({
@@ -378,48 +474,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
 
   return (
     <section className="flex h-full flex-col bg-zinc-950 text-zinc-200">
-      {/* Compact status row */}
-      <header className="flex items-center gap-2 border-b border-zinc-900 px-5 py-2.5 text-[11px] text-zinc-400">
-        {onBack ? (
-          <button
-            onClick={onBack}
-            className="rounded border border-zinc-800 px-1.5 py-0.5 text-zinc-300 transition-colors hover:bg-zinc-900"
-            title="Back to chats"
-          >
-            ← chats
-          </button>
-        ) : null}
-        <span className="flex items-center gap-1.5">
-          <span className="font-medium text-zinc-100">{familiar.display_name}</span>
-        </span>
-        <span className="text-zinc-700">·</span>
-        <span className="font-mono text-zinc-500">{familiar.harness ?? "codex"}</span>
-        <span className="text-zinc-700">·</span>
-        <span className="truncate font-mono text-zinc-500">{projectName}</span>
-        <span className="text-zinc-700">·</span>
-        <span className="text-zinc-500">
-          daemon{" "}
-          <span className={daemonRunning ? "text-emerald-400" : "text-rose-400"}>
-            {daemonRunning ? "running" : "offline"}
-          </span>
-        </span>
-        <span className="ml-auto text-zinc-500">
-          {busy ? (
-            <span className="text-amber-400">streaming…</span>
-          ) : currentSessionRef.current ? (
-            <span className="inline-flex items-center gap-1 text-emerald-400">
-              <Icon name="ph:circle-fill" width="0.5rem" height="0.5rem" />
-              live
-            </span>
-          ) : (
-            <span>new</span>
-          )}
-        </span>
-      </header>
-
       {/* Transcript */}
-      <div className="min-h-0 flex-1 overflow-y-auto px-5 py-6">
-        <div className="mx-auto max-w-3xl space-y-6">
+      <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
+        <div className="space-y-6">
           {turns.length === 0 ? (
             <div className="py-14 text-center text-sm text-zinc-500">
               <p className="text-zinc-300">Chat with {familiar.display_name}.</p>
@@ -450,8 +507,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       ) : null}
 
       {/* Composer — Codex style */}
-      <footer className="px-5 pb-5 pt-2">
-        <div className="relative mx-auto max-w-3xl">
+      <footer className="px-6 pb-5 pt-2">
+        <div className="relative">
           {slashSuggestions.length > 0 ? (
             <div className="absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-xl border border-zinc-800 bg-zinc-950 shadow-xl">
               <ul className="max-h-64 overflow-y-auto py-1">
@@ -535,12 +592,6 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               </div>
             </div>
           </div>
-          <div className="mt-2 flex items-center justify-between text-[10px] text-zinc-600">
-            <span>↵ send · ⇧↵ newline · / commands · ⌘K palette</span>
-            <span className="font-mono">
-              {familiar.harness} · {familiar.model ?? ""}
-            </span>
-          </div>
         </div>
       </footer>
     </section>
@@ -550,36 +601,134 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
 function TurnRow({ turn }: { turn: Turn }) {
   if (turn.role === "system") {
     return (
-      <div className="rounded-xl border border-zinc-800/60 bg-zinc-900/40 px-4 py-3 font-mono text-[12px] leading-relaxed text-zinc-400 whitespace-pre-wrap">
-        {turn.text}
+      <div>
+        <div className="rounded-xl border border-zinc-800/60 bg-zinc-900/40 px-4 py-3 font-mono text-[12px] leading-relaxed text-zinc-400 whitespace-pre-wrap">
+          {turn.text}
+        </div>
+        <div className="mt-1 text-right text-[10px] text-zinc-600">{fmtTime(turn.createdAt)}</div>
       </div>
     );
   }
   if (turn.role === "user") {
     return (
-      <div className="flex justify-end">
+      <div className="flex flex-col items-end">
         <div className="max-w-[80%] rounded-2xl bg-zinc-800/70 px-4 py-2.5 text-[14px] leading-relaxed text-zinc-100">
           <RichText text={turn.text} />
         </div>
+        <div className="mt-1 text-[10px] text-zinc-600">{fmtTime(turn.createdAt)}</div>
       </div>
     );
   }
   // Assistant — plain, no bubble
   const duration = fmtDuration(turn.durationMs);
+  const { visible, reasoning } = splitReasoning(turn.text);
+  const tools = turn.tools ?? [];
   return (
     <div className="text-[14px] leading-relaxed text-zinc-200">
-      {duration && !turn.pending ? (
-        <div className="mb-2 flex items-center gap-1 text-[11px] text-zinc-500">
-          <span>Worked for {duration}</span>
-          <span>›</span>
+      {tools.length > 0 ? (
+        <div className="mb-3 space-y-1.5">
+          {tools.map((t) => (
+            <ToolBlock key={t.id} tool={t} />
+          ))}
         </div>
       ) : null}
+      {reasoning ? <ReasoningBlock text={reasoning} /> : null}
       <div className={turn.error ? "text-amber-200" : ""}>
-        <RichText text={turn.text || (turn.pending ? "…" : "")} />
-        {turn.pending && turn.text ? (
+        <RichText text={visible || (turn.pending ? "…" : "")} />
+        {turn.pending && visible ? (
           <span className="ml-1 inline-block animate-pulse text-zinc-400">▌</span>
         ) : null}
       </div>
+      <div className="mt-1 flex items-center gap-2 text-[10px] text-zinc-600">
+        <span>{fmtTime(turn.createdAt)}</span>
+        {duration && !turn.pending ? (
+          <>
+            <span className="text-zinc-700">·</span>
+            <span>worked for {duration}</span>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function ReasoningBlock({ text }: { text: string }) {
+  const [open, setOpen] = useState(false);
+  const lineCount = text.split("\n").length;
+  return (
+    <div className="mb-3 overflow-hidden rounded-lg border border-zinc-800/70 bg-zinc-900/30 text-[12px]">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-zinc-400 transition-colors hover:bg-zinc-900/60"
+      >
+        <Icon
+          name="ph:caret-right-bold"
+          width="0.7rem"
+          height="0.7rem"
+          className={`transition-transform ${open ? "rotate-90" : ""}`}
+        />
+        <span className="text-zinc-300">reasoning</span>
+        <span className="text-zinc-600">· {lineCount} line{lineCount === 1 ? "" : "s"}</span>
+      </button>
+      {open ? (
+        <div className="border-t border-zinc-800/70 px-3 py-2 font-mono text-[12px] leading-relaxed whitespace-pre-wrap text-zinc-400">
+          {text}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ToolBlock({ tool }: { tool: ToolEvent }) {
+  const [open, setOpen] = useState(false);
+  const statusDot =
+    tool.status === "running"
+      ? "bg-amber-400 animate-pulse"
+      : tool.status === "error"
+      ? "bg-rose-400"
+      : "bg-emerald-400";
+  const hasBody = !!(tool.input || tool.output);
+  const dur = fmtDuration(tool.durationMs);
+  return (
+    <div className="overflow-hidden rounded-lg border border-zinc-800/70 bg-zinc-900/30 text-[12px]">
+      <button
+        onClick={() => hasBody && setOpen((v) => !v)}
+        disabled={!hasBody}
+        className={`flex w-full items-center gap-2 px-3 py-1.5 text-left ${
+          hasBody ? "transition-colors hover:bg-zinc-900/60" : "cursor-default"
+        }`}
+      >
+        <Icon
+          name="ph:caret-right-bold"
+          width="0.7rem"
+          height="0.7rem"
+          className={`text-zinc-600 transition-transform ${open ? "rotate-90" : ""} ${
+            hasBody ? "" : "opacity-30"
+          }`}
+        />
+        <Icon name="ph:wrench-bold" width="0.85rem" height="0.85rem" className="text-purple-300" />
+        <span className="font-mono text-zinc-200">{tool.name}</span>
+        <span className={`ml-auto h-1.5 w-1.5 rounded-full ${statusDot}`} />
+        {dur && tool.status !== "running" ? (
+          <span className="font-mono text-zinc-500">{dur}</span>
+        ) : null}
+      </button>
+      {open && hasBody ? (
+        <div className="space-y-2 border-t border-zinc-800/70 px-3 py-2 font-mono text-[12px] leading-relaxed">
+          {tool.input ? (
+            <div>
+              <div className="mb-0.5 text-[10px] uppercase tracking-wider text-zinc-600">input</div>
+              <pre className="whitespace-pre-wrap text-zinc-300">{tool.input}</pre>
+            </div>
+          ) : null}
+          {tool.output ? (
+            <div>
+              <div className="mb-0.5 text-[10px] uppercase tracking-wider text-zinc-600">output</div>
+              <pre className="whitespace-pre-wrap text-zinc-400">{tool.output}</pre>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/components/daemon-bar.tsx
+++ b/src/components/daemon-bar.tsx
@@ -1,17 +1,18 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import type { DaemonStatus, Familiar, SessionRow } from "@/lib/types";
+import { useEffect } from "react";
+import type { DaemonStatus, Familiar } from "@/lib/types";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 import { NotificationBell } from "@/components/notification-bell";
 
+export type Mode = "chats" | "board" | "inbox" | "plugins";
+
 type Props = {
-  onDaemonStarted?: () => void;
-  sessions?: SessionRow[];
-  responseNeededCount?: number;
+  mode: Mode;
+  onModeChange: (mode: Mode) => void;
+  inboxBadgeCount?: number;
   onRunningChange?: (running: boolean) => void;
-  onOpenOnboarding?: () => void;
   inboxItems?: InboxItem[];
   inboxPrefs?: InboxPrefs;
   familiars?: Familiar[];
@@ -20,12 +21,18 @@ type Props = {
   onPrefsChanged?: () => void;
 };
 
+const MODE_LABEL: Record<Mode, string> = {
+  chats: "Chats",
+  board: "Board",
+  inbox: "Inbox",
+  plugins: "Plugins",
+};
+
 export function DaemonBar({
-  onDaemonStarted,
-  sessions = [],
-  responseNeededCount = 0,
+  mode,
+  onModeChange,
+  inboxBadgeCount = 0,
   onRunningChange,
-  onOpenOnboarding,
   inboxItems = [],
   inboxPrefs,
   familiars = [],
@@ -33,98 +40,58 @@ export function DaemonBar({
   onOpenInboxItem,
   onPrefsChanged,
 }: Props) {
-  const [status, setStatus] = useState<DaemonStatus | null>(null);
-  const [busy, setBusy] = useState(false);
-
-  const refresh = async () => {
-    try {
-      const res = await fetch("/api/daemon/status", { cache: "no-store" });
-      const json = (await res.json()) as DaemonStatus;
-      setStatus(json);
-      onRunningChange?.(json.running === true);
-    } catch {
-      setStatus({ running: false, reason: "fetch failed" });
-      onRunningChange?.(false);
-    }
-  };
-
+  // Daemon status is polled silently so other panes (chat list, familiar rail)
+  // can react via `onRunningChange`. The header no longer renders the status —
+  // start/stop happens via /doctor or the CLI.
   useEffect(() => {
-    refresh();
-    const t = setInterval(refresh, 5000);
-    return () => clearInterval(t);
-  }, []);
-
-  const stats = useMemo(() => {
-    const running = sessions.filter((s) => s.status === "running").length;
-    return { total: sessions.length, running };
-  }, [sessions]);
-
-  const start = async () => {
-    setBusy(true);
-    try {
-      await fetch("/api/daemon/start", { method: "POST" });
-      await refresh();
-      onDaemonStarted?.();
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const running = status?.running === true;
-  const dotClass = running ? "bg-emerald-400" : "bg-zinc-500";
-  const label = running ? "daemon running" : "daemon offline";
+    if (!onRunningChange) return;
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const res = await fetch("/api/daemon/status", { cache: "no-store" });
+        const json = (await res.json()) as DaemonStatus;
+        if (!cancelled) onRunningChange(json.running === true);
+      } catch {
+        if (!cancelled) onRunningChange(false);
+      }
+    };
+    void tick();
+    const t = setInterval(tick, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, [onRunningChange]);
 
   return (
     <header className="flex items-center justify-between border-b border-zinc-800 bg-zinc-900/60 px-3 py-1.5 text-xs">
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-3">
         <span className="font-semibold tracking-tight">CovenCave</span>
+        <nav className="flex items-center gap-0.5">
+          {(["chats", "board", "inbox", "plugins"] as const).map((m) => {
+            const active = mode === m;
+            const label =
+              m === "inbox" && inboxBadgeCount > 0
+                ? `${MODE_LABEL[m]} · ${inboxBadgeCount}`
+                : MODE_LABEL[m];
+            return (
+              <button
+                key={m}
+                onClick={() => onModeChange(m)}
+                className={`rounded-md px-2.5 py-1 text-[11px] transition-colors ${
+                  active
+                    ? "bg-zinc-800 text-zinc-100"
+                    : "text-zinc-400 hover:bg-zinc-900 hover:text-zinc-200"
+                }`}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </nav>
       </div>
 
-      <div className="flex items-center gap-3">
-        <div className="flex items-center gap-1.5 text-zinc-300">
-          <span className={`h-2 w-2 rounded-full ${dotClass}`} />
-          <span>{label}</span>
-          {running && status?.daemon ? (
-            <span className="text-zinc-500">· pid {status.daemon.pid}</span>
-          ) : null}
-          {!running && status?.reason ? (
-            <span className="text-zinc-500">· {status.reason}</span>
-          ) : null}
-        </div>
-
-        {running ? (
-          <div className="flex items-center gap-3 text-zinc-400">
-            <span className="flex items-center gap-1">
-              <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
-              <span className="font-mono">{stats.running}</span>
-              <span className="text-zinc-500">live</span>
-            </span>
-            <span className="font-mono text-zinc-500">{stats.total} total</span>
-            {responseNeededCount > 0 ? (
-              <span className="flex items-center gap-1 rounded bg-amber-500/80 px-1.5 py-[1px] font-bold uppercase tracking-widest text-zinc-900">
-                {responseNeededCount} reply
-              </span>
-            ) : null}
-          </div>
-        ) : null}
-
-        {!running ? (
-          <button
-            onClick={start}
-            disabled={busy}
-            className="rounded-md bg-purple-600 px-2.5 py-1 text-[11px] font-medium text-white transition-colors hover:bg-purple-500 disabled:opacity-50"
-          >
-            {busy ? "starting…" : "start daemon"}
-          </button>
-        ) : (
-          <button
-            onClick={refresh}
-            className="rounded-md border border-zinc-700 px-2.5 py-1 text-[11px] text-zinc-300 hover:bg-zinc-800"
-          >
-            refresh
-          </button>
-        )}
-
+      <div className="flex items-center gap-2">
         {onOpenInbox && inboxPrefs && onPrefsChanged ? (
           <NotificationBell
             items={inboxItems}
@@ -134,16 +101,6 @@ export function DaemonBar({
             onOpenItem={onOpenInboxItem}
             onPrefsChanged={onPrefsChanged}
           />
-        ) : null}
-
-        {onOpenOnboarding ? (
-          <button
-            onClick={onOpenOnboarding}
-            className="rounded-md border border-zinc-800 px-2 py-1 text-[11px] text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200"
-            title="Open setup"
-          >
-            setup
-          </button>
         ) : null}
       </div>
     </header>

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -489,11 +489,14 @@ export function Workspace() {
   return (
     <div className="flex h-screen w-screen flex-col bg-zinc-950 text-zinc-100">
       <DaemonBar
-        onDaemonStarted={loadFamiliars}
-        sessions={sessions}
-        responseNeededCount={responseNeeded.size}
+        mode={mode}
+        onModeChange={setMode}
+        inboxBadgeCount={inboxItemsWithEphemeral.filter(
+          (i) =>
+            i.status === "fired" ||
+            (i.status === "pending" && i.kind === "response-needed"),
+        ).length}
         onRunningChange={setDaemonRunning}
-        onOpenOnboarding={openOnboarding}
         inboxItems={inboxItemsWithEphemeral}
         inboxPrefs={inboxPrefs}
         familiars={familiars}
@@ -509,43 +512,6 @@ export function Workspace() {
           }
         }}
       />
-
-      <nav className="flex items-center gap-1 border-b border-zinc-900 bg-zinc-950 px-3 py-1.5 text-[11px]">
-        {(["chats", "board", "inbox", "plugins"] as const).map((m) => (
-          <button
-            key={m}
-            onClick={() => setMode(m)}
-            className={`rounded-md px-3 py-1 transition-colors ${
-              mode === m
-                ? "bg-zinc-800 text-zinc-100"
-                : "text-zinc-400 hover:bg-zinc-900 hover:text-zinc-200"
-            }`}
-          >
-            {m === "chats"
-              ? "Chats"
-              : m === "board"
-              ? "Board"
-              : m === "inbox"
-              ? `Inbox${
-                  inboxItemsWithEphemeral.filter(
-                    (i) =>
-                      i.status === "fired" ||
-                      (i.status === "pending" && i.kind === "response-needed"),
-                  ).length
-                    ? ` · ${
-                        inboxItemsWithEphemeral.filter(
-                          (i) =>
-                            i.status === "fired" ||
-                            (i.status === "pending" && i.kind === "response-needed"),
-                        ).length
-                      }`
-                    : ""
-                }`
-              : "Plugins"}
-          </button>
-        ))}
-        <span className="ml-auto text-[10px] text-zinc-600">⌘K palette · ⌘B rail · ⇧⌘B inspector</span>
-      </nav>
 
       <Group orientation="horizontal" className="flex-1 min-h-0 flex">
         <Panel
@@ -635,20 +601,6 @@ export function Workspace() {
           />
         </Panel>
       </Group>
-
-      <footer className="flex items-center justify-between border-t border-zinc-800 px-3 py-1 text-[10px] text-zinc-500">
-        <span>CovenCave · v0</span>
-        <span>
-          mode ·{" "}
-          {mode === "chats"
-            ? "Chats"
-            : mode === "board"
-            ? "Coven Board"
-            : mode === "inbox"
-            ? "Inbox"
-            : "Plugins"}
-        </span>
-      </footer>
 
       <CommandPalette
         open={paletteOpen}


### PR DESCRIPTION
## Summary

UX pass on the new Cave chat surface — strips chrome you said you didn't want, widens the transcript, and surfaces what the agent is actually doing.

> **Stacks on [#4](https://github.com/OpenCoven/coven-cave/pull/4) (iconify).** Branch is cut from `feat/iconify-icons`. Rebase onto `main` after #4 lands, or merge #4 first.

### Removed

| What | Where |
|---|---|
| Per-chat header row: back button, familiar name, harness, project name, daemon status, live/streaming pill | `ChatView` |
| Two-line footer under composer: `↵ send · ⇧↵ newline · / commands · ⌘K palette` + `harness · model` | `ChatView` |
| Bottom workspace footer: `CovenCave · v0` + `mode · Chats` | `Workspace` |
| Secondary nav row with mode tabs + `⌘K palette · ⌘B rail · ⇧⌘B inspector` shortcut text | `Workspace` |
| Header text: daemon status, pid, live/total session counts, `N reply` badge, start/refresh daemon button, setup button | `DaemonBar` |

### Migrated

- **Mode tabs** (Chats / Board / Inbox / Plugins) moved into the top header row, immediately right of the `CovenCave` brand. Inbox keeps the `· N` count when there are fired/response-needed items.
- **Daemon status polling** stays in `DaemonBar` but silent — `onRunningChange` still fires for downstream consumers.

### Added

- **Timestamps** under each message, `HH:MM` localized.
- **Reasoning collapsible** — any `<thinking>…</thinking>` or `<reasoning>…</reasoning>` block emitted by Claude/Codex harnesses is split out and rendered as a collapsed-by-default disclosure with a caret + line count. The visible reply text stays clean.
- **Tool use rendering** —
  - New SSE event kind on `/api/chat/send`: `{ kind: "tool_use", id, name, input?, output?, status, durationMs? }`.
  - Backend now parses `hook: tool_use|pre_tool_use|post_tool_use <Name> <rest>` lines out of the harness stdout (previously discarded by `AssistantFilter`) and emits structured events with timing.
  - Frontend renders each tool as a row above the assistant text: caret + 🔧 wrench icon + tool name + status dot (amber pulse / emerald / rose) + duration. Body collapses to show input + output when available; rows with no body are non-clickable.

### Widened

The transcript no longer constrains to `max-w-3xl`. It fills the chat panel width with consistent padding. Same for the composer.

## Test plan

- [x] `tsc --noEmit` clean across the four files.
- [ ] `next dev` — header shows only Brand + Tabs + 🔔; chat transcript fills panel width; messages show timestamps; long replies stay clean while reasoning collapses.
- [ ] Run a `coven` prompt that does tool use — verify the wrench row appears, stays amber-pulse during the call, turns emerald + shows duration on completion, and that the body expands to show input/output.
- [ ] Run a prompt with `<thinking>...</thinking>` content — verify it folds into the reasoning collapsible.
- [ ] Switch modes via the new header tabs.

## Notes

- `ChatView` still accepts `onBack` and `daemonRunning` props for backwards compat with `ChatRouter` but no longer reads them. Can be removed in a follow-up alongside the router signature.
- Tool-use parser is best-effort against the hook line format codex/claude currently emit. When the harnesses gain structured JSON tool events, the backend should switch to those instead of regex on hook lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
