### PR TITLE
feat(familiars): hybrid emoji + Phosphor glyph picker, iMessage-style

### DIFF
--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -27,7 +27,10 @@ export async function GET() {
       { status: 503 },
     );
   }
-  const familiars = (res.data ?? []).map(({ emoji: _emoji, ...f }) => {
+  // Pass `emoji` through — it's the daemon-provided default glyph the
+  // glyph picker uses as the starting value. The Cave-local override store
+  // (`cave-glyph-overrides.ts`) wins on render when the user picks something.
+  const familiars = (res.data ?? []).map((f) => {
     const binding = bindingFor(config, f.id);
     return { ...f, harness: binding.harness, model: binding.model, note: binding.note };
   });

--- a/src/components/familiar-glyph-picker.tsx
+++ b/src/components/familiar-glyph-picker.tsx
@@ -1,0 +1,419 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Icon } from "@/lib/icon";
+import {
+  ALL_EMOJI_ENTRIES,
+  categoriesFor,
+  searchGlyphs,
+  type GlyphCatalogEntry,
+} from "@/lib/glyph-catalog";
+import {
+  clearGlyphOverride,
+  setGlyphOverride,
+  useGlyphOverrides,
+  useRecentGlyphs,
+} from "@/lib/cave-glyph-overrides";
+import {
+  parseGlyphString,
+  resolveFamiliarGlyph,
+  serializeGlyph,
+  type FamiliarGlyph,
+} from "@/lib/familiar-glyph";
+import { FamiliarGlyph as GlyphView } from "@/components/familiar-glyph";
+import type { Familiar } from "@/lib/types";
+
+type PickerTab = "emoji" | "icon";
+
+type Props = {
+  open: boolean;
+  familiar: Familiar | null;
+  onClose: () => void;
+};
+
+export function FamiliarGlyphPicker({ open, familiar, onClose }: Props) {
+  const overrides = useGlyphOverrides();
+  const recent = useRecentGlyphs();
+  const [query, setQuery] = useState("");
+  const [tab, setTab] = useState<PickerTab>("emoji");
+  const [hovered, setHovered] = useState<GlyphCatalogEntry | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Reset state each time the picker opens for a new familiar.
+  useEffect(() => {
+    if (!open) return;
+    setQuery("");
+    setHovered(null);
+    // Default tab: emoji if the user has any recents that are emoji, else
+    // whatever the current glyph kind is.
+    const currentGlyph = familiar
+      ? resolveFamiliarGlyph(familiar, overrides)
+      : null;
+    setTab(currentGlyph?.kind === "icon" ? "icon" : "emoji");
+    const t = setTimeout(() => inputRef.current?.focus(), 20);
+    return () => clearTimeout(t);
+    // overrides intentionally NOT in deps — we only want this on open.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, familiar?.id]);
+
+  // Esc closes; Cmd/Ctrl+Backspace clears the current override.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      } else if ((e.metaKey || e.ctrlKey) && e.key === "Backspace" && familiar) {
+        e.preventDefault();
+        clearGlyphOverride(familiar.id);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose, familiar]);
+
+  const currentGlyph: FamiliarGlyph | null = useMemo(() => {
+    if (!familiar) return null;
+    return resolveFamiliarGlyph(familiar, overrides);
+  }, [familiar, overrides]);
+
+  const results = useMemo(() => {
+    return searchGlyphs({
+      query,
+      kinds: query.trim() ? ["emoji", "icon"] : [tab],
+    }).slice(0, 800);
+  }, [query, tab]);
+
+  const categories = useMemo(() => {
+    if (query.trim()) return [];
+    return categoriesFor([tab]);
+  }, [tab, query]);
+
+  const recentEntries: GlyphCatalogEntry[] = useMemo(() => {
+    return recent
+      .map((value) => {
+        const parsed = parseGlyphString(value);
+        if (!parsed) return null;
+        if (parsed.kind === "emoji") {
+          const found = ALL_EMOJI_ENTRIES.find((e) => e.value === parsed.char);
+          if (found) return found;
+          return {
+            value: parsed.char,
+            kind: "emoji" as const,
+            name: parsed.char,
+            category: "Recent",
+            keywords: [],
+          };
+        }
+        return {
+          value: parsed.name,
+          kind: "icon" as const,
+          name: parsed.name.replace(/^ph:/, "").replace(/-/g, " "),
+          category: "Recent",
+          keywords: [],
+        };
+      })
+      .filter((e): e is GlyphCatalogEntry => e !== null)
+      .slice(0, 12);
+  }, [recent]);
+
+  const onPick = useCallback(
+    (entry: GlyphCatalogEntry) => {
+      if (!familiar) return;
+      setGlyphOverride(familiar.id, entry.value);
+    },
+    [familiar],
+  );
+
+  if (!open || !familiar) return null;
+
+  return (
+    <div
+      onClick={onClose}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/70 backdrop-blur-sm"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="relative flex h-[560px] w-[640px] max-w-[92vw] flex-col overflow-hidden rounded-2xl border border-zinc-800 bg-zinc-950 shadow-2xl"
+      >
+        {/* Header */}
+        <div className="flex items-center gap-3 border-b border-zinc-900 px-4 py-3">
+          {currentGlyph ? (
+            <span className="grid h-9 w-9 place-items-center rounded-lg bg-zinc-900">
+              <GlyphView glyph={currentGlyph} size="md" />
+            </span>
+          ) : null}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="truncate text-sm font-medium text-zinc-100">
+              {familiar.display_name}
+            </span>
+            <span className="text-[11px] text-zinc-500">
+              {hovered?.name ?? "Pick a glyph"}
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="grid h-7 w-7 place-items-center rounded-md text-zinc-400 hover:bg-zinc-900 hover:text-zinc-200"
+            aria-label="Close"
+            title="Close (esc)"
+          >
+            <Icon name="ph:x-bold" />
+          </button>
+        </div>
+
+        {/* Search */}
+        <div className="border-b border-zinc-900 px-4 py-2.5">
+          <div className="relative">
+            <Icon
+              name="ph:magnifying-glass-bold"
+              className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-zinc-500"
+              width="0.9rem"
+              height="0.9rem"
+            />
+            <input
+              ref={inputRef}
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search cat, wand, sparkle…"
+              className="w-full rounded-md border border-zinc-800 bg-zinc-900/50 py-1.5 pl-8 pr-3 text-sm text-zinc-100 outline-none placeholder:text-zinc-500 focus:border-zinc-700"
+            />
+          </div>
+        </div>
+
+        {/* Recent */}
+        {recentEntries.length > 0 && !query.trim() ? (
+          <div className="border-b border-zinc-900 px-4 py-2.5">
+            <div className="mb-1.5 text-[10px] uppercase tracking-wider text-zinc-600">
+              Recent
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {recentEntries.map((e) => (
+                <GlyphButton
+                  key={`recent:${e.value}`}
+                  entry={e}
+                  size="md"
+                  active={
+                    currentGlyph &&
+                    serializeGlyph(currentGlyph) === e.value
+                      ? true
+                      : false
+                  }
+                  onPick={onPick}
+                  onHover={setHovered}
+                />
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {/* Tabs (hidden during free-text search since we merge both kinds) */}
+        {!query.trim() ? (
+          <div className="flex items-center gap-0.5 border-b border-zinc-900 px-4 py-1.5 text-[11px]">
+            <TabButton
+              active={tab === "emoji"}
+              onClick={() => setTab("emoji")}
+              label="Emoji"
+            />
+            <TabButton
+              active={tab === "icon"}
+              onClick={() => setTab("icon")}
+              label="Icons"
+            />
+            <div className="ml-auto text-[10px] text-zinc-600">
+              {results.length.toLocaleString()} options
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-center justify-between border-b border-zinc-900 px-4 py-1.5 text-[10px] text-zinc-500">
+            <span>
+              {results.length.toLocaleString()} matches for {`"`}
+              {query.trim()}
+              {`"`}
+            </span>
+            <button
+              onClick={() => setQuery("")}
+              className="text-zinc-400 hover:text-zinc-200"
+            >
+              clear
+            </button>
+          </div>
+        )}
+
+        {/* Grid */}
+        <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+          {results.length === 0 ? (
+            <div className="grid h-full place-items-center text-sm text-zinc-500">
+              No matches.
+            </div>
+          ) : query.trim() ? (
+            <GlyphGrid
+              entries={results}
+              currentValue={currentGlyph ? serializeGlyph(currentGlyph) : null}
+              onPick={onPick}
+              onHover={setHovered}
+            />
+          ) : (
+            <CategorizedGrid
+              entries={results}
+              categories={categories}
+              currentValue={currentGlyph ? serializeGlyph(currentGlyph) : null}
+              onPick={onPick}
+              onHover={setHovered}
+            />
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between border-t border-zinc-900 px-4 py-2 text-[11px] text-zinc-500">
+          <button
+            onClick={() => clearGlyphOverride(familiar.id)}
+            disabled={!overrides[familiar.id]}
+            className="text-zinc-400 transition-colors hover:text-zinc-200 disabled:cursor-not-allowed disabled:text-zinc-700"
+          >
+            reset to default
+          </button>
+          <span className="font-mono text-zinc-600">esc to close</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function TabButton({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`rounded-md px-2.5 py-1 transition-colors ${
+        active
+          ? "bg-zinc-800 text-zinc-100"
+          : "text-zinc-400 hover:bg-zinc-900 hover:text-zinc-200"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+function GlyphButton({
+  entry,
+  size = "sm",
+  active,
+  onPick,
+  onHover,
+}: {
+  entry: GlyphCatalogEntry;
+  size?: "sm" | "md";
+  active: boolean;
+  onPick: (e: GlyphCatalogEntry) => void;
+  onHover: (e: GlyphCatalogEntry | null) => void;
+}) {
+  const cell = size === "md" ? "h-9 w-9" : "h-8 w-8";
+  const glyph: FamiliarGlyph =
+    entry.kind === "emoji"
+      ? { kind: "emoji", char: entry.value }
+      : { kind: "icon", name: entry.value };
+  return (
+    <button
+      onClick={() => onPick(entry)}
+      onMouseEnter={() => onHover(entry)}
+      onMouseLeave={() => onHover(null)}
+      title={entry.name}
+      className={`${cell} grid place-items-center rounded-md text-zinc-200 transition-colors ${
+        active
+          ? "bg-purple-600/30 ring-1 ring-purple-400"
+          : "hover:bg-zinc-800/70"
+      }`}
+    >
+      <GlyphView glyph={glyph} size="sm" />
+    </button>
+  );
+}
+
+function GlyphGrid({
+  entries,
+  currentValue,
+  onPick,
+  onHover,
+}: {
+  entries: GlyphCatalogEntry[];
+  currentValue: string | null;
+  onPick: (e: GlyphCatalogEntry) => void;
+  onHover: (e: GlyphCatalogEntry | null) => void;
+}) {
+  return (
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(2.25rem,1fr))] gap-1">
+      {entries.map((e) => (
+        <GlyphButton
+          key={`${e.kind}:${e.value}`}
+          entry={e}
+          active={e.value === currentValue}
+          onPick={onPick}
+          onHover={onHover}
+        />
+      ))}
+    </div>
+  );
+}
+
+function CategorizedGrid({
+  entries,
+  categories,
+  currentValue,
+  onPick,
+  onHover,
+}: {
+  entries: GlyphCatalogEntry[];
+  categories: string[];
+  currentValue: string | null;
+  onPick: (e: GlyphCatalogEntry) => void;
+  onHover: (e: GlyphCatalogEntry | null) => void;
+}) {
+  const byCategory = useMemo(() => {
+    const map = new Map<string, GlyphCatalogEntry[]>();
+    for (const e of entries) {
+      const arr = map.get(e.category);
+      if (arr) arr.push(e);
+      else map.set(e.category, [e]);
+    }
+    return map;
+  }, [entries]);
+
+  return (
+    <div className="space-y-4">
+      {categories
+        .filter((c) => byCategory.has(c))
+        .map((c) => (
+          <section key={c}>
+            <div className="mb-1.5 text-[10px] uppercase tracking-wider text-zinc-600">
+              {c}
+            </div>
+            <GlyphGrid
+              entries={byCategory.get(c) ?? []}
+              currentValue={currentValue}
+              onPick={onPick}
+              onHover={onHover}
+            />
+          </section>
+        ))}
+    </div>
+  );
+}

--- a/src/components/familiar-glyph.tsx
+++ b/src/components/familiar-glyph.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { Icon as IconifyIcon, addCollection } from "@iconify/react";
+import phCollection from "@iconify-json/ph/icons.json";
+import type { FamiliarGlyph as Glyph } from "@/lib/familiar-glyph";
+
+// ---------------------------------------------------------------------------
+// Render component
+//
+// Why this lives outside `@/lib/icon`:
+//   The chrome `<Icon>` component takes a strict `IconName` union over the
+//   short registry of icons used by the app shell. The picker lets users
+//   pick from any of Phosphor's ~1500 icons, so we'd otherwise have to dump
+//   the entire catalogue into that union (defeating its purpose). Keeping a
+//   second renderer here means user-content icons stay free-form while
+//   chrome icons stay typo-safe.
+// ---------------------------------------------------------------------------
+
+let registered = false;
+function ensureRegistered() {
+  if (registered) return;
+  addCollection(phCollection as Parameters<typeof addCollection>[0]);
+  registered = true;
+}
+
+type Size = "sm" | "md" | "lg";
+
+const SIZE_PX: Record<Size, number> = {
+  sm: 16,
+  md: 22,
+  lg: 36,
+};
+
+type Props = {
+  glyph: Glyph;
+  size?: Size;
+  className?: string;
+  title?: string;
+};
+
+export function FamiliarGlyph({ glyph, size = "md", className, title }: Props) {
+  const px = SIZE_PX[size];
+
+  if (glyph.kind === "emoji") {
+    return (
+      <span
+        className={className ?? "inline-flex items-center justify-center"}
+        style={{ fontSize: px, lineHeight: 1 }}
+        title={title}
+        aria-label={title}
+        role={title ? "img" : undefined}
+      >
+        {glyph.char}
+      </span>
+    );
+  }
+
+  ensureRegistered();
+  return (
+    <span
+      className={className ?? "inline-flex items-center justify-center text-zinc-200"}
+      title={title}
+    >
+      <IconifyIcon
+        icon={glyph.name}
+        width={px}
+        height={px}
+        aria-label={title}
+        role={title ? "img" : undefined}
+      />
+    </span>
+  );
+}

--- a/src/components/familiar-rail.tsx
+++ b/src/components/familiar-rail.tsx
@@ -3,6 +3,9 @@
 import type { Familiar, SessionRow } from "@/lib/types";
 import { useEffect, useMemo, useState } from "react";
 import { computePresence } from "@/lib/presence";
+import { resolveFamiliarGlyph } from "@/lib/familiar-glyph";
+import { useGlyphOverrides } from "@/lib/cave-glyph-overrides";
+import { FamiliarGlyph } from "@/components/familiar-glyph";
 
 type HarnessReport = {
   id: string;
@@ -16,6 +19,8 @@ type Props = {
   familiars: Familiar[];
   activeId: string | null;
   onSelect: (id: string) => void;
+  /** Right-click on a row opens the glyph picker for that familiar. */
+  onEditGlyph?: (familiar: Familiar) => void;
   error?: string | null;
   sessions: SessionRow[];
   responseNeeded: Set<string>;
@@ -26,11 +31,13 @@ export function FamiliarRail({
   familiars,
   activeId,
   onSelect,
+  onEditGlyph,
   error,
   sessions,
   responseNeeded,
   onOpenOnboarding,
 }: Props) {
+  const glyphOverrides = useGlyphOverrides();
   const current = familiars.find((f) => f.id === activeId) ?? null;
   const [harnesses, setHarnesses] = useState<HarnessReport[]>([]);
 
@@ -119,12 +126,35 @@ export function FamiliarRail({
             <li key={f.id}>
               <button
                 onClick={() => onSelect(f.id)}
+                onContextMenu={(e) => {
+                  if (!onEditGlyph) return;
+                  e.preventDefault();
+                  onEditGlyph(f);
+                }}
                 className={`flex w-full items-center gap-3 px-4 py-2 text-left transition-colors ${
                   isActive
                     ? "bg-zinc-800/80 text-zinc-50"
                     : "text-zinc-300 hover:bg-zinc-800/40"
                 }`}
+                title={onEditGlyph ? "Right-click to change glyph" : undefined}
               >
+                <span
+                  role="button"
+                  tabIndex={-1}
+                  onClick={(e) => {
+                    if (!onEditGlyph) return;
+                    e.stopPropagation();
+                    onEditGlyph(f);
+                  }}
+                  className="grid h-7 w-7 shrink-0 cursor-pointer place-items-center rounded-md bg-zinc-900/60 transition-colors hover:bg-zinc-800/90"
+                  aria-label="Change glyph"
+                  title="Change glyph"
+                >
+                  <FamiliarGlyph
+                    glyph={resolveFamiliarGlyph(f, glyphOverrides)}
+                    size="sm"
+                  />
+                </span>
                 <span className="flex flex-1 flex-col min-w-0">
                   <span className="flex items-center gap-1.5 truncate">
                     <span className="truncate">{f.display_name}</span>

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -13,6 +13,7 @@ import { OnboardingOverlay } from "@/components/onboarding-overlay";
 import { InboxView } from "@/components/inbox-view";
 import { NewReminderModal, draftFromSlashArgs } from "@/components/new-reminder-modal";
 import { InboxToastStack, toastFromItem, type Toast } from "@/components/inbox-toast";
+import { FamiliarGlyphPicker } from "@/components/familiar-glyph-picker";
 import { nativeNotify } from "@/lib/native-notify";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
@@ -45,6 +46,7 @@ export function Workspace() {
     whenText: string;
   }>({ title: "", whenText: "" });
   const [toasts, setToasts] = useState<Toast[]>([]);
+  const [glyphPickerFor, setGlyphPickerFor] = useState<Familiar | null>(null);
   const responseNeededRef = useRef(responseNeeded);
   responseNeededRef.current = responseNeeded;
 
@@ -561,6 +563,7 @@ export function Workspace() {
             familiars={familiars}
             activeId={activeId}
             onSelect={setActiveId}
+            onEditGlyph={(f) => setGlyphPickerFor(f)}
             error={familiarsError}
             sessions={sessions}
             responseNeeded={responseNeeded}
@@ -691,6 +694,12 @@ export function Workspace() {
         onDismiss={dismissToast}
         onSnooze={snoozeToast}
         onOpen={openToastTarget}
+      />
+
+      <FamiliarGlyphPicker
+        open={glyphPickerFor !== null}
+        familiar={glyphPickerFor}
+        onClose={() => setGlyphPickerFor(null)}
       />
     </div>
   );

--- a/src/lib/cave-glyph-overrides.ts
+++ b/src/lib/cave-glyph-overrides.ts
@@ -1,0 +1,174 @@
+"use client";
+
+/**
+ * Cave-local glyph override store + recent-glyph history.
+ *
+ * Lives in localStorage under `cave:glyph-overrides:v1` for per-familiar
+ * picks and `cave:glyph-recent:v1` for the recents row in the picker.
+ *
+ * This is deliberately a UI-side store, not a daemon write — the user's
+ * choices apply to *their* Cave install, not the underlying
+ * `~/.coven/familiars.toml`. When the daemon grows an `icon` field on
+ * familiars (follow-up PR), the store can opt into syncing.
+ */
+
+import { useEffect, useState, useSyncExternalStore } from "react";
+
+const OVERRIDES_KEY = "cave:glyph-overrides:v1";
+const RECENT_KEY = "cave:glyph-recent:v1";
+const RECENT_MAX = 16;
+
+type OverrideMap = Record<string, string>;
+
+// ---------------------------------------------------------------------------
+// In-memory mirror + change broadcaster
+// ---------------------------------------------------------------------------
+
+let cachedOverrides: OverrideMap | null = null;
+let cachedRecent: string[] | null = null;
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const fn of listeners) fn();
+}
+
+function readOverridesFromStorage(): OverrideMap {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(OVERRIDES_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as OverrideMap;
+    }
+  } catch {
+    /* corrupt — discard */
+  }
+  return {};
+}
+
+function readRecentFromStorage(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(RECENT_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed)) return parsed.filter((x): x is string => typeof x === "string");
+  } catch {
+    /* corrupt — discard */
+  }
+  return [];
+}
+
+function getOverrides(): OverrideMap {
+  if (cachedOverrides === null) cachedOverrides = readOverridesFromStorage();
+  return cachedOverrides;
+}
+
+function getRecent(): string[] {
+  if (cachedRecent === null) cachedRecent = readRecentFromStorage();
+  return cachedRecent;
+}
+
+function writeOverrides(next: OverrideMap) {
+  cachedOverrides = next;
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem(OVERRIDES_KEY, JSON.stringify(next));
+  }
+  notify();
+}
+
+function writeRecent(next: string[]) {
+  cachedRecent = next;
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem(RECENT_KEY, JSON.stringify(next));
+  }
+  notify();
+}
+
+// ---------------------------------------------------------------------------
+// Mutators (always go through these so listeners fire)
+// ---------------------------------------------------------------------------
+
+/** Set the glyph override for a single familiar. */
+export function setGlyphOverride(familiarId: string, glyph: string): void {
+  const next = { ...getOverrides(), [familiarId]: glyph };
+  writeOverrides(next);
+  pushRecent(glyph);
+}
+
+/** Remove the override so we fall back to daemon emoji / default. */
+export function clearGlyphOverride(familiarId: string): void {
+  const curr = getOverrides();
+  if (!(familiarId in curr)) return;
+  const next = { ...curr };
+  delete next[familiarId];
+  writeOverrides(next);
+}
+
+/** Move `glyph` to the head of the recents list, deduped, capped at RECENT_MAX. */
+export function pushRecent(glyph: string): void {
+  const curr = getRecent();
+  const next = [glyph, ...curr.filter((g) => g !== glyph)].slice(0, RECENT_MAX);
+  if (next.length === curr.length && next.every((g, i) => g === curr[i])) return;
+  writeRecent(next);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-tab + cross-component sync
+// ---------------------------------------------------------------------------
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (e) => {
+    if (e.key === OVERRIDES_KEY) {
+      cachedOverrides = null;
+      notify();
+    } else if (e.key === RECENT_KEY) {
+      cachedRecent = null;
+      notify();
+    }
+  });
+}
+
+function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+/** React hook: glyph override map. Re-renders on any mutation. */
+export function useGlyphOverrides(): OverrideMap {
+  return useSyncExternalStore(subscribe, getOverrides, getOverrides);
+}
+
+/** React hook: recents list. Re-renders on any mutation. */
+export function useRecentGlyphs(): string[] {
+  // useSyncExternalStore needs server snapshot too; recents are empty on SSR.
+  const sub = (fn: () => void) => subscribe(fn);
+  const get = () => getRecent();
+  const getServer = () => [] as string[];
+  // useSyncExternalStore is imported above; calling it directly here keeps the
+  // hook self-contained without exposing the subscribe/snapshot signatures.
+  return useSyncExternalStore(sub, get, getServer);
+}
+
+/**
+ * Tiny non-hook accessor for places (e.g. one-shot reads) that can't take a
+ * hook. Always returns the latest snapshot; will not re-render anything.
+ */
+export function readGlyphOverridesSnapshot(): OverrideMap {
+  return getOverrides();
+}
+
+/** Pre-warm the cache during initial app mount so SSR/CSR agree. */
+export function useHydrateGlyphStore(): void {
+  // The first read on the client primes both caches; this just guarantees the
+  // hydration boundary happens once and re-renders downstream consumers.
+  const [, force] = useState(0);
+  useEffect(() => {
+    if (cachedOverrides === null || cachedRecent === null) {
+      cachedOverrides = readOverridesFromStorage();
+      cachedRecent = readRecentFromStorage();
+      force((n) => n + 1);
+    }
+  }, []);
+}

--- a/src/lib/familiar-glyph.ts
+++ b/src/lib/familiar-glyph.ts
@@ -1,0 +1,66 @@
+/**
+ * Familiar glyph model.
+ *
+ * A glyph is either:
+ *   - `{ kind: "emoji", char }` — any Unicode emoji literal the user picked
+ *   - `{ kind: "icon",  name }` — a Phosphor icon name (`ph:cat-fill`)
+ *
+ * The `ph:` prefix is the discriminator on the wire (in `Familiar.emoji` or
+ * the Cave-local override store) so both kinds round-trip through a single
+ * string field. The `name` is intentionally a plain string — chrome icons
+ * stay type-checked via `IconName` in `@/lib/icon`, but user-picked icons
+ * can reference any of Phosphor's ~1500 names without needing each to land
+ * in the strict registry.
+ */
+
+import type { Familiar } from "@/lib/types";
+
+export type FamiliarGlyph =
+  | { kind: "emoji"; char: string }
+  | { kind: "icon"; name: string };
+
+/** Fallback rendered when no daemon emoji and no override are present. */
+export const DEFAULT_FAMILIAR_GLYPH: FamiliarGlyph = {
+  kind: "icon",
+  name: "ph:sparkle-fill",
+};
+
+/**
+ * Parse a raw glyph string into a structured glyph. Anything starting with
+ * `ph:` is treated as a Phosphor icon name; anything else is treated as a
+ * literal emoji char. Empty / undefined returns null so the caller can apply
+ * its own fallback.
+ */
+export function parseGlyphString(raw: string | undefined | null): FamiliarGlyph | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith("ph:")) {
+    return { kind: "icon", name: trimmed };
+  }
+  return { kind: "emoji", char: trimmed };
+}
+
+/** Serialize a glyph for storage (override store, or eventually familiars.toml). */
+export function serializeGlyph(glyph: FamiliarGlyph): string {
+  return glyph.kind === "icon" ? glyph.name : glyph.char;
+}
+
+/**
+ * Resolve the glyph to render for a familiar.
+ *
+ * Precedence (highest first):
+ *   1. Cave-local override (`overrides[familiar.id]`)
+ *   2. Daemon-provided `familiar.emoji`
+ *   3. `DEFAULT_FAMILIAR_GLYPH`
+ */
+export function resolveFamiliarGlyph(
+  familiar: Pick<Familiar, "id" | "emoji">,
+  overrides: Record<string, string>,
+): FamiliarGlyph {
+  const override = parseGlyphString(overrides[familiar.id]);
+  if (override) return override;
+  const daemon = parseGlyphString(familiar.emoji);
+  if (daemon) return daemon;
+  return DEFAULT_FAMILIAR_GLYPH;
+}

--- a/src/lib/glyph-catalog.ts
+++ b/src/lib/glyph-catalog.ts
@@ -1,0 +1,291 @@
+/**
+ * Catalogue of glyphs available in the picker.
+ *
+ * Two sources merge into one searchable list:
+ *
+ *   - `EMOJI_CATALOG` — a curated set of ~140 emojis that read well at
+ *     small sizes and fit the "familiar persona" theme (creatures,
+ *     mystical signs, simple symbols). Each entry has `char`, `name`,
+ *     `category`, and `keywords` so search matches against intent
+ *     ("cat", "wand", "fire") rather than the emoji codepoint name only.
+ *
+ *   - `phCollection.icons` — Phosphor's full ~1500-icon catalogue,
+ *     loaded from the bundled `@iconify-json/ph` package, filtered to
+ *     the "fill" variants for visual weight consistency with the rest
+ *     of the cave chrome.
+ *
+ * Both shapes normalize to `GlyphCatalogEntry` so the picker can render
+ * them with the same row component and search helper.
+ */
+
+import phCollection from "@iconify-json/ph/icons.json";
+
+export type GlyphCatalogEntry = {
+  /** Storage representation: emoji char OR `ph:...` icon name. */
+  value: string;
+  /** Discriminator used by the renderer + picker filters. */
+  kind: "emoji" | "icon";
+  /** Display name used when searching + shown in the preview row. */
+  name: string;
+  /** Category for the tab/section grouping. */
+  category: string;
+  /** Extra search keywords beyond `name`. */
+  keywords: string[];
+};
+
+// ---------------------------------------------------------------------------
+// Curated emoji
+// ---------------------------------------------------------------------------
+
+type EmojiSeed = {
+  char: string;
+  name: string;
+  category: "Creatures" | "Mystical" | "Nature" | "Symbols" | "People" | "Objects";
+  keywords?: string[];
+};
+
+const EMOJI_SEED: EmojiSeed[] = [
+  // Creatures — first instinct for "familiar"
+  { char: "🐈", name: "Cat", category: "Creatures", keywords: ["kitty", "kitten", "feline"] },
+  { char: "🐈‍⬛", name: "Black cat", category: "Creatures", keywords: ["familiar", "witch"] },
+  { char: "🐅", name: "Tiger", category: "Creatures" },
+  { char: "🦁", name: "Lion", category: "Creatures" },
+  { char: "🦊", name: "Fox", category: "Creatures", keywords: ["clever"] },
+  { char: "🐺", name: "Wolf", category: "Creatures" },
+  { char: "🐶", name: "Dog", category: "Creatures", keywords: ["puppy"] },
+  { char: "🐰", name: "Rabbit", category: "Creatures" },
+  { char: "🦝", name: "Raccoon", category: "Creatures" },
+  { char: "🐻", name: "Bear", category: "Creatures" },
+  { char: "🐼", name: "Panda", category: "Creatures" },
+  { char: "🐨", name: "Koala", category: "Creatures" },
+  { char: "🐹", name: "Hamster", category: "Creatures" },
+  { char: "🐭", name: "Mouse", category: "Creatures" },
+  { char: "🐿️", name: "Chipmunk", category: "Creatures", keywords: ["squirrel"] },
+  { char: "🦦", name: "Otter", category: "Creatures" },
+  { char: "🦔", name: "Hedgehog", category: "Creatures" },
+  { char: "🦇", name: "Bat", category: "Creatures" },
+  { char: "🐦", name: "Bird", category: "Creatures" },
+  { char: "🦅", name: "Eagle", category: "Creatures" },
+  { char: "🦉", name: "Owl", category: "Creatures", keywords: ["wise", "night"] },
+  { char: "🐉", name: "Dragon", category: "Creatures", keywords: ["mythical"] },
+  { char: "🐲", name: "Dragon face", category: "Creatures" },
+  { char: "🦄", name: "Unicorn", category: "Creatures", keywords: ["mythical", "magic"] },
+  { char: "🐙", name: "Octopus", category: "Creatures" },
+  { char: "🦑", name: "Squid", category: "Creatures" },
+  { char: "🦋", name: "Butterfly", category: "Creatures" },
+  { char: "🐢", name: "Turtle", category: "Creatures" },
+  { char: "🐍", name: "Snake", category: "Creatures" },
+  { char: "🐠", name: "Tropical fish", category: "Creatures", keywords: ["fish"] },
+  { char: "🐳", name: "Whale", category: "Creatures" },
+  { char: "🐬", name: "Dolphin", category: "Creatures" },
+
+  // Mystical
+  { char: "🧙", name: "Mage", category: "Mystical", keywords: ["wizard", "witch"] },
+  { char: "🧚", name: "Fairy", category: "Mystical" },
+  { char: "🧛", name: "Vampire", category: "Mystical" },
+  { char: "🧜", name: "Mermaid", category: "Mystical" },
+  { char: "🧝", name: "Elf", category: "Mystical" },
+  { char: "🧞", name: "Genie", category: "Mystical" },
+  { char: "🧟", name: "Zombie", category: "Mystical" },
+  { char: "👻", name: "Ghost", category: "Mystical", keywords: ["spirit", "haunt"] },
+  { char: "👽", name: "Alien", category: "Mystical" },
+  { char: "👾", name: "Alien monster", category: "Mystical", keywords: ["pixel"] },
+  { char: "🤖", name: "Robot", category: "Mystical", keywords: ["ai", "machine"] },
+  { char: "🪄", name: "Magic wand", category: "Mystical", keywords: ["wand", "spell"] },
+  { char: "🔮", name: "Crystal ball", category: "Mystical", keywords: ["fortune", "divine"] },
+  { char: "🕯️", name: "Candle", category: "Mystical" },
+  { char: "📜", name: "Scroll", category: "Mystical", keywords: ["spell", "lore"] },
+  { char: "🗝️", name: "Key", category: "Mystical" },
+  { char: "⚱️", name: "Urn", category: "Mystical" },
+
+  // Nature
+  { char: "🌙", name: "Moon", category: "Nature", keywords: ["night", "crescent"] },
+  { char: "☀️", name: "Sun", category: "Nature" },
+  { char: "⭐", name: "Star", category: "Nature" },
+  { char: "🌟", name: "Glowing star", category: "Nature", keywords: ["sparkle"] },
+  { char: "✨", name: "Sparkles", category: "Nature", keywords: ["magic", "shimmer"] },
+  { char: "💫", name: "Dizzy", category: "Nature", keywords: ["star", "spin"] },
+  { char: "☁️", name: "Cloud", category: "Nature" },
+  { char: "⚡", name: "Lightning", category: "Nature", keywords: ["bolt", "fast"] },
+  { char: "🔥", name: "Fire", category: "Nature", keywords: ["flame", "hot"] },
+  { char: "🌊", name: "Wave", category: "Nature", keywords: ["water", "ocean"] },
+  { char: "🌿", name: "Herb", category: "Nature", keywords: ["plant", "leaf"] },
+  { char: "🍀", name: "Four-leaf clover", category: "Nature", keywords: ["luck"] },
+  { char: "🌸", name: "Cherry blossom", category: "Nature", keywords: ["flower"] },
+  { char: "🌺", name: "Hibiscus", category: "Nature", keywords: ["flower"] },
+  { char: "🌻", name: "Sunflower", category: "Nature", keywords: ["flower"] },
+  { char: "🌷", name: "Tulip", category: "Nature", keywords: ["flower"] },
+  { char: "🍄", name: "Mushroom", category: "Nature" },
+  { char: "🌵", name: "Cactus", category: "Nature" },
+  { char: "🌳", name: "Tree", category: "Nature" },
+
+  // Symbols
+  { char: "♠️", name: "Spade", category: "Symbols" },
+  { char: "♥️", name: "Heart suit", category: "Symbols" },
+  { char: "♦️", name: "Diamond suit", category: "Symbols" },
+  { char: "♣️", name: "Club suit", category: "Symbols" },
+  { char: "☯️", name: "Yin yang", category: "Symbols" },
+  { char: "☮️", name: "Peace", category: "Symbols" },
+  { char: "♾️", name: "Infinity", category: "Symbols" },
+  { char: "⚛️", name: "Atom", category: "Symbols", keywords: ["science"] },
+  { char: "🌀", name: "Cyclone", category: "Symbols", keywords: ["spiral", "swirl"] },
+  { char: "❄️", name: "Snowflake", category: "Symbols" },
+  { char: "🌈", name: "Rainbow", category: "Symbols" },
+  { char: "💎", name: "Gem", category: "Symbols", keywords: ["diamond", "crystal"] },
+  { char: "👁️", name: "Eye", category: "Symbols", keywords: ["see", "watch"] },
+  { char: "🦴", name: "Bone", category: "Symbols" },
+  { char: "🩸", name: "Drop of blood", category: "Symbols" },
+  { char: "🧿", name: "Nazar amulet", category: "Symbols", keywords: ["evil eye", "protect"] },
+
+  // People
+  { char: "🥷", name: "Ninja", category: "People" },
+  { char: "🧑‍💻", name: "Technologist", category: "People", keywords: ["dev", "code"] },
+  { char: "🧑‍🎨", name: "Artist", category: "People" },
+  { char: "🧑‍🚀", name: "Astronaut", category: "People", keywords: ["space"] },
+  { char: "🧑‍🔬", name: "Scientist", category: "People" },
+  { char: "🧑‍🌾", name: "Farmer", category: "People" },
+  { char: "🧑‍🍳", name: "Cook", category: "People", keywords: ["chef"] },
+
+  // Objects
+  { char: "🪞", name: "Mirror", category: "Objects" },
+  { char: "📖", name: "Open book", category: "Objects" },
+  { char: "🪶", name: "Feather", category: "Objects", keywords: ["quill"] },
+  { char: "🧪", name: "Test tube", category: "Objects", keywords: ["potion", "lab"] },
+  { char: "🧬", name: "DNA", category: "Objects", keywords: ["genome"] },
+  { char: "🎭", name: "Performing arts", category: "Objects", keywords: ["mask", "drama"] },
+  { char: "🎨", name: "Artist palette", category: "Objects", keywords: ["paint"] },
+  { char: "🎲", name: "Die", category: "Objects", keywords: ["chance", "random"] },
+  { char: "🎯", name: "Direct hit", category: "Objects", keywords: ["target"] },
+  { char: "🔭", name: "Telescope", category: "Objects" },
+  { char: "📡", name: "Satellite", category: "Objects", keywords: ["signal"] },
+  { char: "🛰️", name: "Satellite orbit", category: "Objects" },
+  { char: "🗡️", name: "Dagger", category: "Objects", keywords: ["sword"] },
+  { char: "🛡️", name: "Shield", category: "Objects", keywords: ["defense"] },
+  { char: "🔱", name: "Trident", category: "Objects" },
+];
+
+const EMOJI_CATALOG: GlyphCatalogEntry[] = EMOJI_SEED.map((e) => ({
+  value: e.char,
+  kind: "emoji",
+  name: e.name,
+  category: e.category,
+  keywords: e.keywords ?? [],
+}));
+
+// ---------------------------------------------------------------------------
+// Phosphor — fill variants only
+//
+// Phosphor names follow a pattern: `name`, `name-bold`, `name-fill`,
+// `name-duotone`, `name-light`, `name-thin`. We pick the `-fill` variant
+// for visual weight consistency; if a glyph has no fill variant, we keep
+// the plain name. Categories inside Phosphor (Animals, Brand, Communication,
+// Design, …) aren't surfaced in the bundled JSON, so we derive a rough
+// grouping from the icon name prefix below.
+// ---------------------------------------------------------------------------
+
+type PhosphorCollection = {
+  icons: Record<string, unknown>;
+};
+
+function categorizePhosphor(name: string): string {
+  // Heuristic — Phosphor's published categories aren't in the JSON.
+  if (/(cat|dog|bird|fish|paw|bone|bug|spider|butterfly|rabbit|cow|horse|dolphin|fox|owl)/.test(name)) return "Animals";
+  if (/(heart|smiley|user|person|ghost|skull|baby|hand)/.test(name)) return "People";
+  if (/(sun|moon|cloud|fire|drop|leaf|tree|flower|mountain|lightning|wind|snowflake|tornado)/.test(name)) return "Nature";
+  if (/(star|sparkle|circle|square|diamond|triangle|hexagon|heart|infinity|asterisk|crosshair)/.test(name)) return "Shapes";
+  if (/(wrench|hammer|gear|magnifying|wand|key|lock|shield|sword|compass|map)/.test(name)) return "Tools";
+  if (/(book|note|pencil|paintbrush|palette|guitar|piano|microphone|camera|video)/.test(name)) return "Creative";
+  if (/(rocket|globe|planet|atom|gauge|graph|chart|brain|cpu|robot)/.test(name)) return "Science";
+  if (/(chat|envelope|bell|phone|share)/.test(name)) return "Communication";
+  return "All icons";
+}
+
+function entryForPhosphor(rawName: string): GlyphCatalogEntry | null {
+  // Strip Phosphor suffixes for the display name + keyword search; the actual
+  // value still includes `-fill` etc. so the renderer gets the variant the
+  // catalog picked.
+  const base = rawName
+    .replace(/-fill$|-bold$|-duotone$|-light$|-thin$/, "")
+    .replace(/-/g, " ");
+  return {
+    value: `ph:${rawName}`,
+    kind: "icon",
+    name: base,
+    category: categorizePhosphor(rawName),
+    keywords: rawName.split("-"),
+  };
+}
+
+const PHOSPHOR_NAMES: string[] = Object.keys((phCollection as PhosphorCollection).icons ?? {});
+
+// Prefer fill; if a fill doesn't exist for a base name, fall back to the bare
+// name. Build a set keyed on the base name so each icon appears once.
+const PHOSPHOR_CATALOG: GlyphCatalogEntry[] = (() => {
+  const byBase = new Map<string, string>();
+  for (const n of PHOSPHOR_NAMES) {
+    const base = n.replace(/-fill$|-bold$|-duotone$|-light$|-thin$/, "");
+    if (n.endsWith("-fill")) {
+      byBase.set(base, n);
+    } else if (!byBase.has(base)) {
+      byBase.set(base, n);
+    }
+  }
+  const entries: GlyphCatalogEntry[] = [];
+  for (const name of byBase.values()) {
+    const e = entryForPhosphor(name);
+    if (e) entries.push(e);
+  }
+  // Stable alphabetical so the grid order is predictable.
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  return entries;
+})();
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export const ALL_EMOJI_ENTRIES = EMOJI_CATALOG;
+export const ALL_ICON_ENTRIES = PHOSPHOR_CATALOG;
+
+export type GlyphSearchOpts = {
+  query?: string;
+  kinds?: ("emoji" | "icon")[];
+  category?: string;
+};
+
+/**
+ * Search the merged catalog. Empty query returns the full set filtered by
+ * `kinds` (and `category` if provided). Non-empty query does a substring
+ * match against `name`, `category`, and `keywords`.
+ */
+export function searchGlyphs(opts: GlyphSearchOpts): GlyphCatalogEntry[] {
+  const kinds = opts.kinds ?? ["emoji", "icon"];
+  const q = (opts.query ?? "").trim().toLowerCase();
+  const pool: GlyphCatalogEntry[] = [];
+  if (kinds.includes("emoji")) pool.push(...ALL_EMOJI_ENTRIES);
+  if (kinds.includes("icon")) pool.push(...ALL_ICON_ENTRIES);
+  let filtered = pool;
+  if (opts.category) {
+    filtered = filtered.filter((e) => e.category === opts.category);
+  }
+  if (!q) return filtered;
+  return filtered.filter((e) => {
+    if (e.name.toLowerCase().includes(q)) return true;
+    if (e.category.toLowerCase().includes(q)) return true;
+    return e.keywords.some((k) => k.toLowerCase().includes(q));
+  });
+}
+
+/** Distinct categories present in the chosen kinds, in display order. */
+export function categoriesFor(kinds: ("emoji" | "icon")[]): string[] {
+  const seen: string[] = [];
+  const pool = kinds.includes("emoji")
+    ? kinds.includes("icon")
+      ? [...ALL_EMOJI_ENTRIES, ...ALL_ICON_ENTRIES]
+      : ALL_EMOJI_ENTRIES
+    : ALL_ICON_ENTRIES;
+  for (const e of pool) {
+    if (!seen.includes(e.category)) seen.push(e.category);
+  }
+  return seen;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,6 +9,12 @@ export type Familiar = {
   last_seen?: string;
   active_sessions?: number;
   memory_freshness?: string;
+  /**
+   * Daemon-owned glyph hint. Either a literal emoji character (`"🐈"`) or a
+   * Phosphor icon name (`"ph:cat-fill"`). The Cave-local override store
+   * (see `cave-glyph-overrides.ts`) wins over this when both are present.
+   */
+  emoji?: string;
   // CovenCave-side enrichment from cave-config.json
   harness?: string;
   model?: string;


### PR DESCRIPTION
## Summary

An iMessage-style glyph picker that lets each familiar carry a real visual identity. Users pick **either an emoji or a Phosphor icon**, in one searchable picker, with category browsing + recents + live preview. Customization beats hardcoding — the canonical roster Val ships is just defaults, and any user-defined familiar can have its own glyph without learning Phosphor names.

This is the "(b) hybrid" path we landed on, expanded so emoji isn't second-class.

## Try it

1. `pnpm dev`, open the cave
2. Click a familiar's glyph badge in the rail (or right-click anywhere on the row)
3. Picker opens. Search "cat" / "wand" / "sparkle" — both kinds match
4. Switch tabs to browse Emoji or Icons separately. Recents show across both
5. Pick → glyph updates everywhere instantly (`useSyncExternalStore`-backed)
6. `reset to default` in the footer drops the override → fall back to daemon `emoji` field → fall back to `ph:sparkle-fill`

## How it fits together

| File | Role |
|---|---|
| `lib/familiar-glyph.ts` | Discriminated `FamiliarGlyph` union (`emoji` / `icon`), `ph:` is the wire discriminator. `resolveFamiliarGlyph(familiar, overrides)` returns the glyph with precedence: cave override > daemon `emoji` > `ph:sparkle-fill` |
| `lib/cave-glyph-overrides.ts` | localStorage-backed override + recents store. `useGlyphOverrides()` + `useRecentGlyphs()` via `useSyncExternalStore` so every glyph surface stays in sync (and updates across browser tabs via the `storage` event) |
| `lib/glyph-catalog.ts` | Merges ~140 curated emoji (tagged with names + keywords + categories) and Phosphor's full catalogue (one entry per icon, preferring `-fill` variant, heuristic category mapping). One `searchGlyphs()` API drives the picker |
| `components/familiar-glyph.tsx` | Renderer — intentionally outside `@/lib/icon` so user-picked icons can be any Phosphor name without polluting the strict chrome `IconName` registry |
| `components/familiar-glyph-picker.tsx` | The modal: search, tabs, recents, category-grouped grids, live preview, reset, esc-to-close |

## Wiring

- **Familiar rail**: each row leads with a glyph badge. Left-click on the badge or right-click anywhere on the row → picker for that familiar. Main row click still selects the familiar.
- **Workspace**: lifts the picker state so it can be opened from anywhere later (command palette `/glyph`, settings, etc.) — only the rail invokes it today.
- **`/api/familiars`**: passes `Familiar.emoji` through instead of stripping at the boundary, so a daemon-provided emoji becomes the picker's starting value.

## Schema interop with the daemon

Schema today: cave-local localStorage. Schema tomorrow (follow-up PR in `coven-code`):

```toml
[[familiar]]
id = "cody"
icon = "ph:lightning-fill"   # or "⚡"
```

When `CovenFamiliar` grows an `icon: Option<String>` field, the cave-local store opts into syncing via a single `daemonSetIcon(id, glyph)` call. The renderer already handles both `"🐈‍⬛"` and `"ph:cat-fill"` shapes from any source — nothing here blocks on the daemon change.

## Curated emoji set

The picker's emoji catalog is intentionally narrow (~140) — covers Creatures / Mystical / Nature / Symbols / People / Objects with a familiar-persona slant. Tagged with keywords so search finds intent ("wizard" → 🧙, "luck" → 🍀, "magic" → ✨/🪄). Open to additions in review — it's just a `EMOJI_SEED` array in `glyph-catalog.ts`.

## Test plan

- [x] `pnpm build` clean
- [x] `tsc --noEmit` clean
- [ ] Manual: open picker on each familiar, pick emoji, pick icon, search across both, reset
- [ ] Manual: confirm rail glyph badge updates immediately when picker writes
- [ ] Manual: open a second tab, pick a glyph in tab 1, confirm tab 2 updates via the `storage` event
- [ ] Manual: keyboard — `esc` closes, `Cmd+Backspace` (or Ctrl) clears the current override

## Notes for review

- The override store is **localStorage-only**. Cleared if the user nukes localStorage; not portable across devices. A daemon-side `icon` field gives portability — see "Schema interop" above.
- The Phosphor catalogue defaults to **fill variants** for visual weight consistency. If you want users to pick from bold/duotone/light/thin too, that's a one-line change to `glyph-catalog.ts` (drop the variant collapse).
- Glyph badge in the rail is the right tap target for "I want to change this familiar's glyph" — but it's also visual decoration. The cursor + hover bg are doing the affordance work; happy to add a tiny pencil overlay on hover if you want it more discoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
