### PR TITLE
chore: bump version to 0.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Bumps `package.json` + `src-tauri/tauri.conf.json` from `0.0.9` → `0.0.10` in prep for the next notarized DMG cut.

`pnpm build` clean. Cargo crate version left at `0.1.0` (untouched — Tauri uses `tauri.conf.json`'s version for the bundle).

## Draft release notes for `v0.0.10`

> Paste into `gh release create v0.0.10` after merging this PR and running `scripts/release.sh 0.0.10`.

### Title
**Cave v0.0.10 — Icons, tool use, chrome diet**

### Body

**Highlights**

- **Iconify everywhere.** UI glyphs swapped for Phosphor icons via `@iconify/react`, bundled offline so the Tauri app needs no network for chrome. Type-safe `IconName` so `pnpm build` catches typos at compile time.
- **Tool use you can actually watch.** Backend parses `hook: tool_use|pre_tool_use|post_tool_use` lines out of the harness stream and emits structured SSE events with timing. Each tool renders inline above the assistant text with a wrench, status dot (amber pulse → emerald / rose), duration, and a collapsible input/output body.
- **Reasoning folded out of the way.** `<thinking>` / `<reasoning>` blocks Claude and Codex emit are split out into a collapsed-by-default disclosure with line count — the visible reply text stays clean.
- **Chrome diet.** Per-chat header, composer footer, workspace footer, and the secondary nav row are gone. Mode tabs moved into the top header. Transcript widens to fill the panel.
- **Daemon status keeps polling silently** so other panes still react via `onRunningChange`; start/stop now happens via `/doctor` or the CLI.
- **Hybrid familiar glyphs.** Each familiar can carry an emoji or a Phosphor icon — picker is iMessage-style; daemon-side data stays unchanged.
- **Hooded-familiar app icon.** Every Tauri icon slot (4 PNG sizes, 11 Windows Square*Logo variants, StoreLogo, icns, ico, master) swapped for the cat-eared-hood + trident silhouette.
- **Platform-aware keyboard glyphs.** Mac keeps \`⌘ ⌥ ⌃ ⇧ ↵\`; Windows/Linux get \`Ctrl Alt Ctrl Shift Enter\` so shortcut hints read natively where the cave runs.

**Fixes**

- **Coven binary resolves against the user's interactive PATH.** Finder-launched cave .apps get only \`/usr/bin:/bin:/usr/sbin:/sbin\` from launchd, which historically picked up a stale \`~/.cargo/bin/coven\` missing \`--stream-json\`/\`--continue\`. The cave now probes a priority-ordered candidate list (nvm/fnm → pnpm → bun → homebrew → /usr/local → ~/.local → cargo last) and falls back to a login-shell PATH so all three spawn sites (\`chat/send\`, \`coven/exec\`, \`daemon/start\`) resolve the right binary.

**Internal / housekeeping**

- \`.gitignore\` ignores \`.comux*\` workspace metadata.
- 4 PRs merged: [#2](https://github.com/OpenCoven/coven-cave/pull/2), [#3](https://github.com/OpenCoven/coven-cave/pull/3), [#4](https://github.com/OpenCoven/coven-cave/pull/4), [#5](https://github.com/OpenCoven/coven-cave/pull/5).

## Release commands

\`\`\`bash
# After this PR is merged and \`main\` shows version 0.0.10:
git checkout main && git pull --ff-only
git tag -s v0.0.10 -m "Cave v0.0.10 — Icons, tool use, chrome diet"
git push origin v0.0.10

# Build, sign, notarize, staple → release/CovenCave-v0.0.10.dmg
bash scripts/release.sh 0.0.10

# Create the GitHub release and upload the DMG
gh release create v0.0.10 \\
  --title "Cave v0.0.10 — Icons, tool use, chrome diet" \\
  --notes "..." \\
  release/CovenCave-v0.0.10.dmg
\`\`\`

## Test plan

- [x] \`pnpm build\` clean against this branch.
- [ ] Once merged, \`bash scripts/release.sh 0.0.10\` produces a notarized + stapled DMG.
- [ ] \`spctl --assess --type open --context context:primary-signature\` accepts the resulting \`.app\`.

Co-authored-by: OpenCoven <noreply@opencoven.ai>