### PR TITLE
feat(mockup): multica-style aesthetic demo at /mockup

### DIFF
--- a/src/app/mockup/mockup.css
+++ b/src/app/mockup/mockup.css
@@ -1,0 +1,632 @@
+/* mockup.css — multica-inspired design tokens, scoped to the /mockup route
+   via the `.multica-theme` class on the route's root element. This keeps
+   the rest of the app untouched until we decide to roll the tokens out
+   globally.
+
+   Tokens are oklch — same colour-science basis as shadcn's defaults so
+   we're aligned with the broader ecosystem rather than inventing new
+   values. Clean-room rewrite; no multica source code copied. */
+
+.multica-theme {
+  /* ---- Palette ---- */
+  --background: oklch(0.18 0.005 285.823);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.21 0.006 285.885);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.21 0.006 285.885);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.92 0.004 286.32);
+  --primary-foreground: oklch(0.21 0.006 285.885);
+  --secondary: oklch(0.274 0.006 286.033);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.274 0.006 286.033);
+  --muted-foreground: oklch(0.705 0.015 286.067);
+  --accent: oklch(0.274 0.006 286.033);
+  --accent-foreground: oklch(0.985 0 0);
+  --border: oklch(1 0 0 / 10%);
+  --border-strong: oklch(1 0 0 / 18%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.552 0.016 285.938);
+  --brand: oklch(0.65 0.16 255);
+  --brand-foreground: oklch(0.985 0 0);
+
+  /* ---- Radii ---- */
+  --radius: 0.625rem;
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) * 1.4);
+
+  /* ---- Spacing scale ---- */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+
+  background: var(--background);
+  color: var(--foreground);
+  min-height: 100vh;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Inter, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ---- Layout primitives ---- */
+
+.multica-layout {
+  display: grid;
+  grid-template-columns: 240px 240px 1fr;
+  min-height: 100vh;
+}
+
+.multica-layout--two-pane {
+  grid-template-columns: 240px 1fr;
+}
+
+/* ---- Sidebar (main, left) ---- */
+
+.multica-sidebar {
+  border-right: 1px solid var(--border);
+  padding: var(--space-3) var(--space-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.multica-sidebar-org {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background-color 0.12s ease;
+}
+
+.multica-sidebar-org:hover {
+  background: var(--muted);
+}
+
+.multica-sidebar-org-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--radius-sm);
+  background: var(--muted);
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.multica-sidebar-eyebrow {
+  margin: var(--space-4) var(--space-2) var(--space-1);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--muted-foreground);
+  text-transform: none;
+}
+
+.multica-sidebar-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  color: var(--muted-foreground);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  transition: background-color 0.12s ease, color 0.12s ease;
+  border: none;
+  background: none;
+  width: 100%;
+  text-align: left;
+  font-family: inherit;
+}
+
+.multica-sidebar-item:hover {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.multica-sidebar-item--active {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.multica-sidebar-item-icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+}
+
+.multica-sidebar-item-kbd {
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--muted-foreground);
+  background: var(--muted);
+  padding: 2px 5px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+}
+
+/* ---- Sub-sidebar (settings/agents nested nav) ---- */
+
+.multica-subsidebar {
+  border-right: 1px solid var(--border);
+  padding: var(--space-3) var(--space-2);
+}
+
+.multica-subsidebar-title {
+  padding: var(--space-2) var(--space-3) var(--space-4);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.multica-subsidebar-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  color: var(--muted-foreground);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  transition: background-color 0.12s ease, color 0.12s ease;
+}
+
+.multica-subsidebar-item:hover {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.multica-subsidebar-item--active {
+  color: var(--foreground);
+  font-weight: 600;
+}
+
+.multica-subsidebar-item--active::after {
+  content: "";
+  position: absolute;
+  right: -2px;
+  top: 4px;
+  bottom: 4px;
+  width: 2px;
+  border-radius: 2px;
+  background: var(--foreground);
+}
+
+/* ---- Content area ---- */
+
+.multica-content {
+  padding: var(--space-8) var(--space-10);
+  overflow-y: auto;
+}
+
+.multica-content-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-6);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.multica-content-header-icon {
+  color: var(--muted-foreground);
+}
+
+.multica-content-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-10) 0;
+  color: var(--muted-foreground);
+  text-align: center;
+}
+
+.multica-content-empty-icon {
+  margin-bottom: var(--space-3);
+  color: var(--muted-foreground);
+  opacity: 0.6;
+}
+
+.multica-content-empty-title {
+  font-size: 14px;
+  color: var(--foreground);
+  font-weight: 500;
+  margin-bottom: var(--space-2);
+}
+
+.multica-content-empty-subtitle {
+  font-size: 13px;
+  max-width: 380px;
+}
+
+/* ---- Card grid (for template cards under "No autopilots yet") ---- */
+
+.multica-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-3);
+  max-width: 720px;
+  margin: var(--space-6) auto 0;
+}
+
+.multica-card {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: var(--card);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.12s ease;
+  font-family: inherit;
+  color: inherit;
+}
+
+.multica-card:hover {
+  border-color: var(--border-strong);
+}
+
+.multica-card-icon {
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+  margin-top: 2px;
+}
+
+.multica-card-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--foreground);
+  margin-bottom: 4px;
+}
+
+.multica-card-subtitle {
+  font-size: 12px;
+  color: var(--muted-foreground);
+  line-height: 1.45;
+}
+
+.multica-card-grid-footer {
+  margin: var(--space-4) auto 0;
+  text-align: center;
+  max-width: 720px;
+}
+
+/* ---- Buttons ---- */
+
+.multica-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--foreground);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  transition: background-color 0.12s ease, border-color 0.12s ease;
+}
+
+.multica-btn:hover {
+  background: var(--muted);
+  border-color: var(--border-strong);
+}
+
+.multica-btn--primary {
+  background: var(--primary);
+  color: var(--primary-foreground);
+  border-color: var(--primary);
+}
+
+.multica-btn--primary:hover {
+  background: var(--primary);
+  opacity: 0.92;
+}
+
+.multica-btn--ghost {
+  background: transparent;
+  border-color: transparent;
+}
+
+.multica-btn--ghost:hover {
+  background: var(--muted);
+}
+
+/* Top-right action chip in content header (matches "+ New autopilot") */
+.multica-content-action {
+  margin-left: auto;
+}
+
+/* ---- Settings card ---- */
+
+.multica-settings-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--card);
+  padding: var(--space-5);
+  max-width: 720px;
+  margin-bottom: var(--space-4);
+}
+
+.multica-settings-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.multica-settings-card-title {
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: var(--space-1);
+}
+
+.multica-settings-card-description {
+  font-size: 12px;
+  color: var(--muted-foreground);
+}
+
+.multica-settings-card-empty {
+  color: var(--muted-foreground);
+  font-style: italic;
+  font-size: 13px;
+  margin-bottom: var(--space-3);
+}
+
+/* ---- Modal (matches "Create Agent" screenshot) ---- */
+
+.multica-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-6);
+  z-index: 50;
+}
+
+.multica-modal {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  width: 100%;
+  max-width: 680px;
+  max-height: 88vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.multica-modal-header {
+  padding: var(--space-5) var(--space-6) var(--space-4);
+  border-bottom: 1px solid var(--border);
+}
+
+.multica-modal-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: var(--space-1);
+}
+
+.multica-modal-description {
+  font-size: 13px;
+  color: var(--muted-foreground);
+}
+
+.multica-modal-body {
+  padding: var(--space-5) var(--space-6);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.multica-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  padding: var(--space-4) var(--space-6);
+  border-top: 1px solid var(--border);
+}
+
+.multica-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.multica-field-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted-foreground);
+}
+
+.multica-field-input,
+.multica-field-textarea,
+.multica-field-select {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  color: var(--foreground);
+  font-size: 13px;
+  font-family: inherit;
+  transition: border-color 0.12s ease;
+}
+
+.multica-field-input:focus,
+.multica-field-textarea:focus,
+.multica-field-select:focus {
+  border-color: var(--border-strong);
+  outline: 2px solid var(--ring);
+  outline-offset: -1px;
+}
+
+.multica-field-textarea {
+  min-height: 80px;
+  resize: vertical;
+  font-family: inherit;
+}
+
+.multica-field-visibility {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-2);
+}
+
+.multica-visibility-option {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  background: transparent;
+  text-align: left;
+  font-family: inherit;
+  color: inherit;
+  transition: border-color 0.12s ease, background-color 0.12s ease;
+}
+
+.multica-visibility-option:hover {
+  border-color: var(--border-strong);
+}
+
+.multica-visibility-option--active {
+  border-color: var(--foreground);
+}
+
+.multica-visibility-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.multica-visibility-subtitle {
+  font-size: 11px;
+  color: var(--muted-foreground);
+}
+
+/* ---- Floating chat panel (bottom-right) ---- */
+
+.multica-chat-panel {
+  position: fixed;
+  right: var(--space-6);
+  bottom: var(--space-6);
+  width: 340px;
+  height: 440px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  background: var(--card);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 30px 60px -20px rgba(0, 0, 0, 0.6);
+  z-index: 40;
+}
+
+.multica-chat-panel-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.multica-chat-panel-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-6);
+  text-align: center;
+  color: var(--muted-foreground);
+}
+
+.multica-chat-panel-body-title {
+  color: var(--foreground);
+  font-weight: 500;
+  margin-bottom: var(--space-2);
+}
+
+.multica-chat-panel-input-row {
+  border-top: 1px solid var(--border);
+  padding: var(--space-3) var(--space-4);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.multica-chat-panel-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--foreground);
+  font-size: 13px;
+  font-family: inherit;
+}
+
+.multica-chat-panel-input::placeholder {
+  color: var(--muted-foreground);
+}
+
+/* ---- View-switcher pills (top of the mockup page) ---- */
+
+.multica-view-switcher {
+  position: fixed;
+  top: var(--space-3);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: var(--space-1);
+  padding: 4px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  border-radius: var(--radius-xl);
+  z-index: 30;
+}
+
+.multica-view-switcher-btn {
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: none;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.multica-view-switcher-btn--active {
+  background: var(--muted);
+  color: var(--foreground);
+}

--- a/src/app/mockup/page.tsx
+++ b/src/app/mockup/page.tsx
@@ -1,0 +1,425 @@
+"use client";
+
+// mockup: clean-room demonstration of a multica-style desktop aesthetic
+// applied to coven-cave surfaces. Token + component primitives live in
+// `./mockup.css` (scoped by the `.multica-theme` class on the root) so
+// the rest of the app is unaffected.
+//
+// Three view modes via the top-center switcher:
+//   1. autopilot — main sidebar + content with a 6-card template grid
+//   2. settings  — three-pane layout (main sidebar + sub-sidebar + content)
+//   3. agent     — autopilot view with the "Create Agent" modal open
+//
+// Phosphor icons come straight from @iconify/react with the `ph`
+// collection registered via the existing helper in `lib/icon.tsx`.
+// We bypass the typed `ICON_NAMES` whitelist here because the mockup
+// uses ~30 icons that aren't part of the production allowlist yet —
+// we can promote them once the aesthetic ships.
+
+import { Icon as IconifyIcon, addCollection } from "@iconify/react";
+import phCollection from "@iconify-json/ph/icons.json";
+import { useEffect, useState } from "react";
+import "./mockup.css";
+
+let registered = false;
+function ensurePhRegistered() {
+  if (registered) return;
+  addCollection(phCollection as Parameters<typeof addCollection>[0]);
+  registered = true;
+}
+
+type IconProps = { name: string; width?: number | string; className?: string; style?: React.CSSProperties };
+function Icon({ name, width = "1em", className, style }: IconProps) {
+  ensurePhRegistered();
+  return <IconifyIcon icon={name} width={width} height={width} className={className} style={style} aria-hidden />;
+}
+
+type View = "autopilot" | "settings" | "agent";
+
+const TEMPLATES = [
+  { icon: "ph:newspaper", title: "Daily news digest", subtitle: "Search and summarize today's news for the team" },
+  { icon: "ph:git-pull-request", title: "PR review reminder", subtitle: "Flag stale pull requests that need review" },
+  { icon: "ph:bug", title: "Bug triage", subtitle: "Assess and prioritize new bug reports" },
+  { icon: "ph:chart-bar", title: "Weekly progress report", subtitle: "Compile a weekly summary of team progress" },
+  { icon: "ph:shield-check", title: "Dependency audit", subtitle: "Scan for security vulnerabilities and outdated packages" },
+  { icon: "ph:file-text", title: "Documentation check", subtitle: "Review recent changes for documentation gaps" },
+];
+
+const SIDEBAR_NAV = [
+  { id: "inbox", label: "Inbox", icon: "ph:tray" },
+  { id: "issues", label: "My Issues", icon: "ph:ticket" },
+];
+
+const WORKSPACE_NAV: Array<{ id: string; label: string; icon: string; view?: View }> = [
+  { id: "issues-ws", label: "Issues", icon: "ph:kanban" },
+  { id: "projects", label: "Projects", icon: "ph:folder" },
+  { id: "autopilot", label: "Autopilot", icon: "ph:lightning", view: "autopilot" },
+  { id: "agents", label: "Agents", icon: "ph:robot" },
+  { id: "squads", label: "Squads", icon: "ph:users-three" },
+  { id: "usage", label: "Usage", icon: "ph:chart-bar" },
+];
+
+const CONFIGURE_NAV: Array<{ id: string; label: string; icon: string; view?: View }> = [
+  { id: "runtimes", label: "Runtimes", icon: "ph:desktop-tower" },
+  { id: "skills", label: "Skills", icon: "ph:book" },
+  { id: "settings", label: "Settings", icon: "ph:gear-six", view: "settings" },
+];
+
+const SETTINGS_NAV: Array<{ group: string; items: Array<{ id: string; label: string; icon: string; active?: boolean }> }> = [
+  {
+    group: "My Account",
+    items: [
+      { id: "profile", label: "Profile", icon: "ph:user" },
+      { id: "preferences", label: "Preferences", icon: "ph:sliders" },
+      { id: "notifications", label: "Notifications", icon: "ph:bell" },
+      { id: "api-tokens", label: "API Tokens", icon: "ph:key" },
+    ],
+  },
+  {
+    group: "OpenMeow",
+    items: [
+      { id: "general", label: "General", icon: "ph:gear-six" },
+      { id: "repositories", label: "Repositories", icon: "ph:git-branch", active: true },
+      { id: "github", label: "GitHub", icon: "ph:github-logo" },
+      { id: "integrations", label: "Integrations", icon: "ph:plug" },
+      { id: "labs", label: "Labs", icon: "ph:flask" },
+      { id: "members", label: "Members", icon: "ph:users-three" },
+    ],
+  },
+];
+
+function MainSidebar({ activeView, onView }: { activeView: View; onView: (v: View) => void }) {
+  return (
+    <aside className="multica-sidebar">
+      <button className="multica-sidebar-org">
+        <span className="multica-sidebar-org-avatar">C</span>
+        <span style={{ fontWeight: 600, fontSize: 13 }}>CovenCave</span>
+        <Icon name="ph:caret-down" width={12} style={{ marginLeft: "auto", color: "var(--muted-foreground)" }} />
+      </button>
+      <button className="multica-sidebar-item">
+        <span className="multica-sidebar-item-icon"><Icon name="ph:magnifying-glass" width={14} /></span>
+        Search…
+        <span className="multica-sidebar-item-kbd">⌘K</span>
+      </button>
+      <button className="multica-sidebar-item">
+        <span className="multica-sidebar-item-icon"><Icon name="ph:note-pencil" width={14} /></span>
+        New Issue
+        <span className="multica-sidebar-item-kbd">C</span>
+      </button>
+
+      <div style={{ height: 8 }} />
+
+      {SIDEBAR_NAV.map((item) => (
+        <button key={item.id} className="multica-sidebar-item">
+          <span className="multica-sidebar-item-icon"><Icon name={item.icon} width={14} /></span>
+          {item.label}
+        </button>
+      ))}
+
+      <div className="multica-sidebar-eyebrow">Workspace</div>
+      {WORKSPACE_NAV.map((item) => {
+        const isActive = item.view === activeView;
+        return (
+          <button
+            key={item.id}
+            className={`multica-sidebar-item${isActive ? " multica-sidebar-item--active" : ""}`}
+            onClick={() => item.view && onView(item.view)}
+          >
+            <span className="multica-sidebar-item-icon"><Icon name={item.icon} width={14} /></span>
+            {item.label}
+          </button>
+        );
+      })}
+
+      <div className="multica-sidebar-eyebrow">Configure</div>
+      {CONFIGURE_NAV.map((item) => {
+        const isActive = item.view === activeView;
+        return (
+          <button
+            key={item.id}
+            className={`multica-sidebar-item${isActive ? " multica-sidebar-item--active" : ""}`}
+            onClick={() => item.view && onView(item.view)}
+          >
+            <span className="multica-sidebar-item-icon"><Icon name={item.icon} width={14} /></span>
+            {item.label}
+          </button>
+        );
+      })}
+    </aside>
+  );
+}
+
+function ViewSwitcher({ view, onView }: { view: View; onView: (v: View) => void }) {
+  const opts: Array<{ id: View; label: string }> = [
+    { id: "autopilot", label: "Autopilot" },
+    { id: "settings", label: "Settings" },
+    { id: "agent", label: "Create Agent" },
+  ];
+  return (
+    <div className="multica-view-switcher">
+      {opts.map((o) => (
+        <button
+          key={o.id}
+          className={`multica-view-switcher-btn${view === o.id ? " multica-view-switcher-btn--active" : ""}`}
+          onClick={() => onView(o.id)}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function AutopilotView() {
+  return (
+    <main className="multica-content">
+      <div className="multica-content-header">
+        <Icon name="ph:lightning" width={14} className="multica-content-header-icon" />
+        Autopilot
+        <div className="multica-content-action">
+          <button className="multica-btn">
+            <Icon name="ph:plus" width={12} />
+            New autopilot
+          </button>
+        </div>
+      </div>
+
+      <div className="multica-content-empty">
+        <div className="multica-content-empty-icon">
+          <Icon name="ph:lightning" width={40} />
+        </div>
+        <div className="multica-content-empty-title">No autopilots yet</div>
+        <div className="multica-content-empty-subtitle">
+          Schedule recurring tasks for your AI agents. Pick a template or start from scratch.
+        </div>
+      </div>
+
+      <div className="multica-card-grid">
+        {TEMPLATES.map((t) => (
+          <button key={t.title} className="multica-card">
+            <Icon name={t.icon} width={18} className="multica-card-icon" />
+            <div>
+              <div className="multica-card-title">{t.title}</div>
+              <div className="multica-card-subtitle">{t.subtitle}</div>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      <div className="multica-card-grid-footer">
+        <button className="multica-btn">
+          <Icon name="ph:plus" width={12} />
+          Start from scratch
+        </button>
+      </div>
+    </main>
+  );
+}
+
+function SettingsView() {
+  return (
+    <>
+      <aside className="multica-subsidebar">
+        <div className="multica-subsidebar-title">Settings</div>
+        {SETTINGS_NAV.map((group) => (
+          <div key={group.group}>
+            <div className="multica-sidebar-eyebrow" style={{ margin: "12px 12px 6px" }}>{group.group}</div>
+            {group.items.map((item) => (
+              <button
+                key={item.id}
+                className={`multica-subsidebar-item${item.active ? " multica-subsidebar-item--active" : ""}`}
+              >
+                <span className="multica-sidebar-item-icon"><Icon name={item.icon} width={14} /></span>
+                {item.label}
+              </button>
+            ))}
+          </div>
+        ))}
+      </aside>
+
+      <main className="multica-content">
+        <div className="multica-content-header">Repositories</div>
+
+        <div className="multica-settings-card">
+          <div className="multica-settings-card-header">
+            <div>
+              <div className="multica-settings-card-description">
+                Git repositories associated with this workspace. Agents use these to clone and work on code.
+              </div>
+            </div>
+            <button className="multica-btn multica-btn--ghost" style={{ padding: "6px 10px" }}>
+              <Icon name="ph:floppy-disk" width={13} />
+              Save
+            </button>
+          </div>
+          <div className="multica-settings-card-empty">No repositories yet.</div>
+          <button className="multica-btn">
+            <Icon name="ph:plus" width={12} />
+            Add repository
+          </button>
+        </div>
+      </main>
+    </>
+  );
+}
+
+function CreateAgentModal({ onClose }: { onClose: () => void }) {
+  const [visibility, setVisibility] = useState<"workspace" | "personal">("workspace");
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div className="multica-modal-backdrop" onClick={onClose}>
+      <div className="multica-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="multica-modal-header">
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16 }}>
+            <div>
+              <div className="multica-modal-title">Create Agent</div>
+              <div className="multica-modal-description">Create a new AI agent for your workspace.</div>
+            </div>
+            <button className="multica-btn multica-btn--ghost" onClick={onClose} aria-label="Close">
+              <Icon name="ph:x" width={14} />
+            </button>
+          </div>
+        </div>
+
+        <div className="multica-modal-body">
+          <div style={{ display: "flex", gap: 20 }}>
+            <button
+              style={{
+                width: 72,
+                height: 72,
+                borderRadius: "var(--radius-md)",
+                border: "1px dashed var(--border)",
+                background: "transparent",
+                color: "var(--muted-foreground)",
+                cursor: "pointer",
+              }}
+              aria-label="Upload avatar"
+            >
+              <Icon name="ph:image-square" width={20} />
+            </button>
+            <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 16 }}>
+              <div className="multica-field">
+                <label className="multica-field-label">Name</label>
+                <input className="multica-field-input" placeholder="e.g. Deep Research Agent" />
+              </div>
+              <div className="multica-field">
+                <label className="multica-field-label">Description</label>
+                <input className="multica-field-input" placeholder="What does this agent do?" />
+                <div style={{ alignSelf: "flex-end", fontSize: 11, color: "var(--muted-foreground)" }}>0 / 255</div>
+              </div>
+            </div>
+          </div>
+
+          <div className="multica-field">
+            <label className="multica-field-label">Visibility</label>
+            <div className="multica-field-visibility">
+              <button
+                className={`multica-visibility-option${visibility === "workspace" ? " multica-visibility-option--active" : ""}`}
+                onClick={() => setVisibility("workspace")}
+              >
+                <Icon name="ph:globe" width={16} />
+                <div>
+                  <div className="multica-visibility-title">Workspace</div>
+                  <div className="multica-visibility-subtitle">All members can assign</div>
+                </div>
+              </button>
+              <button
+                className={`multica-visibility-option${visibility === "personal" ? " multica-visibility-option--active" : ""}`}
+                onClick={() => setVisibility("personal")}
+              >
+                <Icon name="ph:lock-simple" width={16} />
+                <div>
+                  <div className="multica-visibility-title">Personal</div>
+                  <div className="multica-visibility-subtitle">Only you and workspace admins can assign</div>
+                </div>
+              </button>
+            </div>
+          </div>
+
+          <div className="multica-field">
+            <label className="multica-field-label">Runtime</label>
+            <select className="multica-field-select" defaultValue=""><option value="">No runtime available</option></select>
+          </div>
+
+          <div className="multica-field">
+            <label className="multica-field-label">Model</label>
+            <select className="multica-field-select" defaultValue=""><option value="">Select a runtime first</option></select>
+          </div>
+
+          <div className="multica-field">
+            <label className="multica-field-label" style={{ textTransform: "uppercase", fontSize: 11, letterSpacing: "0.04em" }}>Instructions</label>
+            <textarea className="multica-field-textarea" placeholder="Click to write instructions…" />
+          </div>
+
+          <div className="multica-field">
+            <label className="multica-field-label" style={{ textTransform: "uppercase", fontSize: 11, letterSpacing: "0.04em" }}>Skills</label>
+            <button className="multica-btn multica-btn--ghost" style={{ justifyContent: "flex-start", border: "1px solid var(--border)" }}>
+              <Icon name="ph:plus" width={12} />
+              Add skills from workspace
+            </button>
+          </div>
+        </div>
+
+        <div className="multica-modal-footer">
+          <button className="multica-btn multica-btn--ghost" onClick={onClose}>Cancel</button>
+          <button className="multica-btn multica-btn--primary">Create</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ChatPanel() {
+  return (
+    <div className="multica-chat-panel">
+      <div className="multica-chat-panel-header">
+        <Icon name="ph:plus" width={12} />
+        New chat
+        <Icon name="ph:caret-down" width={10} style={{ marginLeft: 4, color: "var(--muted-foreground)" }} />
+      </div>
+      <div className="multica-chat-panel-body">
+        <div className="multica-chat-panel-body-title">Chat with your agents</div>
+        <div style={{ fontSize: 12, marginBottom: 16 }}>
+          ✨ They know your workspace — <span style={{ color: "var(--foreground)" }}>issues, projects, skills</span>.
+        </div>
+        <div style={{ fontSize: 12 }}>Ask for a summary, plan your day, or hand off a quick task.</div>
+      </div>
+      <div className="multica-chat-panel-input-row">
+        <Icon name="ph:robot" width={14} style={{ color: "var(--muted-foreground)" }} />
+        <input className="multica-chat-panel-input" placeholder="Tell me what to do…" />
+        <button className="multica-btn multica-btn--ghost" style={{ padding: "4px 6px" }} aria-label="Send">
+          <Icon name="ph:paper-plane-tilt" width={14} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function MockupPage() {
+  const [view, setView] = useState<View>("autopilot");
+  const showSubsidebar = view === "settings";
+
+  return (
+    <div className={`multica-theme multica-layout${showSubsidebar ? "" : " multica-layout--two-pane"}`}>
+      <MainSidebar activeView={view} onView={setView} />
+      {view === "settings" && <SettingsView />}
+      {view === "autopilot" && <AutopilotView />}
+      {view === "agent" && (
+        <>
+          <AutopilotView />
+          <CreateAgentModal onClose={() => setView("autopilot")} />
+        </>
+      )}
+      <ViewSwitcher view={view} onView={setView} />
+      {view !== "agent" && <ChatPanel />}
+    </div>
+  );
+}


### PR DESCRIPTION
Clean-room mockup of the multica desktop aesthetic on a new `/mockup` route. Lets us compare side-by-side with the existing cave surfaces before committing to a global redesign.

Multica's source is modified Apache 2.0 with a commercial-embedding restriction — this PR adopts only the design language (palette, spacing, layout patterns); every line of CSS/TSX is freshly written.

## Try it

`pnpm tauri dev` (already running for you) → navigate to `http://localhost:3000/mockup` in the cave window. Three views via the top-center pill switcher:

1. **Autopilot** — main sidebar + 6-card template grid ("No autopilots yet")
2. **Settings** — three-pane layout with the right-bar active indicator + italic empty-state
3. **Create Agent** — autopilot view + the centered modal (avatar, name/desc, visibility cards, runtime/model selects, instructions, skills picker)

Plus a bottom-right floating chat panel on Autopilot and Settings.

## Scope

- New files only: `src/app/mockup/{mockup.css,page.tsx}`
- Tokens scoped to a `.multica-theme` class so nothing leaks into existing screens
- Uses existing Phosphor / Iconify setup (PR #4); bypasses typed `ICON_NAMES` whitelist because the mockup pulls ~30 new glyphs we can promote later if the aesthetic ships globally

## Next steps (separate PRs)

If you like the look:
1. Promote mockup tokens to global `globals.css` (replacing the current 2-variable stub)
2. Convert one production surface at a time — agents/familiars view first since it's the closest 1:1 to the Create Agent modal
3. Then inbox, board, command palette, settings

## Test plan

- [ ] Visit `/mockup` in dev — three views render
- [ ] Modal closes via Esc, backdrop click, X button, and Cancel
- [ ] Switch between views via the top pill switcher
- [ ] Confirm the rest of the app (root `/`) looks identical to before this PR — no token bleed