### PR TITLE
feat(familiars): persist glyph picks to the daemon via PUT /api/v1/familiars/{id}/icon

### DIFF
--- a/src/app/api/familiars/[id]/icon/route.ts
+++ b/src/app/api/familiars/[id]/icon/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { callDaemon } from "@/lib/coven-daemon";
+
+export const dynamic = "force-dynamic";
+
+type Body = { icon?: string | null };
+
+/**
+ * Proxy `PUT /api/v1/familiars/{id}/icon` on the daemon. The daemon owns the
+ * canonical write to `~/.coven/familiars.toml`; this route just relays the
+ * request from the browser-side override store.
+ *
+ * The body matches the daemon contract:
+ *   `{ "icon": "ph:cat-fill" }` — insert/replace
+ *   `{ "icon": "🐈" }`           — emoji literal works too
+ *   `{ "icon": null }` / `{}`    — clear the field
+ */
+export async function PUT(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+  let body: Body;
+  try {
+    body = (await req.json()) as Body;
+  } catch {
+    body = {};
+  }
+  const res = await callDaemon({
+    method: "PUT",
+    path: `/api/v1/familiars/${encodeURIComponent(id)}/icon`,
+    body: { icon: body.icon ?? null },
+  });
+  if (!res.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: res.error ?? `daemon http ${res.status}`,
+      },
+      { status: res.status >= 400 ? res.status : 503 },
+    );
+  }
+  return NextResponse.json({ ok: true, ...((res.data as object) ?? {}) });
+}

--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -18,7 +18,9 @@ type DaemonFamiliar = {
 
 export async function GET() {
   const [res, config] = await Promise.all([
-    callDaemon<(DaemonFamiliar & { emoji?: string })[]>({ path: "/api/v1/familiars" }),
+    callDaemon<(DaemonFamiliar & { emoji?: string; icon?: string })[]>({
+      path: "/api/v1/familiars",
+    }),
     loadConfig(),
   ]);
   if (!res.ok) {

--- a/src/lib/cave-glyph-overrides.ts
+++ b/src/lib/cave-glyph-overrides.ts
@@ -90,20 +90,48 @@ function writeRecent(next: string[]) {
 // Mutators (always go through these so listeners fire)
 // ---------------------------------------------------------------------------
 
+/**
+ * Fire-and-forget daemon write. The localStorage override is the source of
+ * truth for the UI's immediate render, so we don't await — but a successful
+ * daemon write means `familiars.toml` carries the user's pick across devices
+ * and reinstalls, which is the durable home.
+ */
+async function syncToDaemon(familiarId: string, glyph: string | null): Promise<void> {
+  if (typeof window === "undefined") return;
+  try {
+    await fetch(`/api/familiars/${encodeURIComponent(familiarId)}/icon`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ icon: glyph }),
+    });
+  } catch {
+    // Daemon offline or transient network blip — the localStorage override
+    // still wins on render until the next pick or until it's manually cleared.
+  }
+}
+
 /** Set the glyph override for a single familiar. */
 export function setGlyphOverride(familiarId: string, glyph: string): void {
   const next = { ...getOverrides(), [familiarId]: glyph };
   writeOverrides(next);
   pushRecent(glyph);
+  void syncToDaemon(familiarId, glyph);
 }
 
-/** Remove the override so we fall back to daemon emoji / default. */
+/** Remove the override so we fall back to daemon icon / emoji / default. */
 export function clearGlyphOverride(familiarId: string): void {
   const curr = getOverrides();
-  if (!(familiarId in curr)) return;
-  const next = { ...curr };
-  delete next[familiarId];
-  writeOverrides(next);
+  const hadLocal = familiarId in curr;
+  if (hadLocal) {
+    const next = { ...curr };
+    delete next[familiarId];
+    writeOverrides(next);
+  }
+  // Also clear on the daemon side so the canonical `familiars.toml` reflects
+  // "no override," even if the user never had a localStorage entry to begin
+  // with (e.g., cleared via the picker's "reset to default" button after a
+  // pick that was already synced).
+  void syncToDaemon(familiarId, null);
 }
 
 /** Move `glyph` to the head of the recents list, deduped, capped at RECENT_MAX. */

--- a/src/lib/familiar-glyph.ts
+++ b/src/lib/familiar-glyph.ts
@@ -50,17 +50,23 @@ export function serializeGlyph(glyph: FamiliarGlyph): string {
  * Resolve the glyph to render for a familiar.
  *
  * Precedence (highest first):
- *   1. Cave-local override (`overrides[familiar.id]`)
- *   2. Daemon-provided `familiar.emoji`
- *   3. `DEFAULT_FAMILIAR_GLYPH`
+ *   1. Cave-local override (`overrides[familiar.id]`) — picks that haven't
+ *      finished syncing to the daemon yet, or that exist on this Cave only.
+ *   2. Daemon-provided `familiar.icon` — the canonical source written by the
+ *      `PUT /api/v1/familiars/{id}/icon` endpoint and persisted to TOML.
+ *   3. Legacy daemon `familiar.emoji` — older field, kept as a fallback so
+ *      pre-icon `familiars.toml` configs render correctly.
+ *   4. `DEFAULT_FAMILIAR_GLYPH` — sparkle.
  */
 export function resolveFamiliarGlyph(
-  familiar: Pick<Familiar, "id" | "emoji">,
+  familiar: Pick<Familiar, "id" | "emoji" | "icon">,
   overrides: Record<string, string>,
 ): FamiliarGlyph {
   const override = parseGlyphString(overrides[familiar.id]);
   if (override) return override;
-  const daemon = parseGlyphString(familiar.emoji);
-  if (daemon) return daemon;
+  const daemonIcon = parseGlyphString(familiar.icon);
+  if (daemonIcon) return daemonIcon;
+  const daemonEmoji = parseGlyphString(familiar.emoji);
+  if (daemonEmoji) return daemonEmoji;
   return DEFAULT_FAMILIAR_GLYPH;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,11 +10,18 @@ export type Familiar = {
   active_sessions?: number;
   memory_freshness?: string;
   /**
-   * Daemon-owned glyph hint. Either a literal emoji character (`"🐈"`) or a
-   * Phosphor icon name (`"ph:cat-fill"`). The Cave-local override store
-   * (see `cave-glyph-overrides.ts`) wins over this when both are present.
+   * Legacy daemon emoji field. Treated as a glyph hint of last resort —
+   * `icon` wins when both are present.
    */
   emoji?: string;
+  /**
+   * Daemon-owned glyph. Either a literal emoji character (`"🐈"`) or a
+   * Phosphor icon name (`"ph:cat-fill"`). Written by `PUT /api/v1/familiars/{id}/icon`.
+   * Wins over `emoji` and is the primary daemon source of truth for the
+   * familiar's glyph. The Cave-local override store still wins on render
+   * while it has a value, but its writes flow back into this field.
+   */
+  icon?: string;
   // CovenCave-side enrichment from cave-config.json
   harness?: string;
   model?: string;


### PR DESCRIPTION
## Summary

Closes the loop on the glyph picker. Picks now persist to the daemon's `~/.coven/familiars.toml` via the new `PUT /api/v1/familiars/{id}/icon` endpoint (OpenCoven/coven#151, merged), so they survive across devices, reinstalls, and other Cave surfaces — not just localStorage on one machine.

## What changed

- **`Familiar.icon`** (TypeScript): the daemon's new canonical glyph field. Wins over `emoji` on the wire and in `resolveFamiliarGlyph`.
- **`/api/familiars` GET**: relays `icon` from the daemon JSON alongside the existing `emoji`. Cave-side enrichment (harness, model, note) is unchanged.
- **`/api/familiars/[id]/icon` PUT** (new): thin proxy onto the daemon's PUT. Body shape matches the daemon contract — `{ "icon": "ph:cat-fill" | "🐈" | null }` and empty body. Daemon HTTP errors bubble up with the same status code so the picker can render meaningful failures later.
- **`cave-glyph-overrides.ts`**: `setGlyphOverride` and `clearGlyphOverride` now fire-and-forget a `PUT` against the new route. localStorage is still the source of truth for the immediate render — the daemon write is the durable home.

## Render precedence

`resolveFamiliarGlyph` now:

1. Cave-local override (localStorage)
2. **Daemon `icon`** — the new field, written by the picker
3. Daemon `emoji` — legacy fallback for pre-icon `familiars.toml`
4. `ph:sparkle-fill` default

## Daemon-offline behaviour

The daemon write uses `fetch` without `await` on the picker side, so a slow or unreachable daemon never blocks the UI. If the write fails, the localStorage override still wins on render until the next pick or until "reset to default" is invoked — which itself retries the daemon clear. No retry queue is added intentionally: persistence is best-effort during normal operation, and the daemon owns the schema once it's back.

## Test plan

- [x] `pnpm build` clean
- [x] `tsc --noEmit` clean
- [ ] Manual: open picker → pick a glyph → restart Cave → confirm the glyph persists (came from daemon `icon`, not localStorage)
- [ ] Manual: pick a glyph → "reset to default" → confirm `~/.coven/familiars.toml` `icon` field is removed
- [ ] Manual: with daemon stopped → pick a glyph → confirm picker UI still updates instantly (localStorage path), no error toast

## Follow-up

- Optional UX tweak: when `Familiar.icon` updates from the daemon (e.g., a sibling Cave wrote a pick), the rail should reflect it. Today the `useGlyphOverrides` listener doesn't subscribe to daemon polls; that's a follow-up "live sync" PR if the multi-Cave story matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
