### PR TITLE
chore: bump version to 0.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Bumps `package.json` + `src-tauri/tauri.conf.json` from `0.0.10` → `0.0.11` in prep for the next notarized DMG cut.

Follows PR #8 which added the `/mockup` multica aesthetic surface. Cargo crate version left at `0.1.0` (untouched — Tauri uses `tauri.conf.json`'s version for the bundle).

## What's in v0.0.11 over v0.0.10

- **#8 — Multica aesthetic mockup at `/mockup`.** Demo surface with rounded chrome, soft shadows, and the multica color palette. Tokens scoped to `.multica-theme` so existing surfaces stay untouched.

## Release commands

```bash
# After this PR is merged and main shows version 0.0.11:
git checkout main && git pull --ff-only
bash scripts/release.sh 0.0.11

# Create the GitHub release with the new DMG
gh release create v0.0.11 \
  --title "Cave v0.0.11 — Multica mockup" \
  --notes "..." \
  release/CovenCave-v0.0.11.dmg
```

## Test plan

- [ ] Once merged, `bash scripts/release.sh 0.0.11` produces a notarized + stapled DMG.
- [ ] `spctl --assess --type open --context context:primary-signature` accepts the resulting `.app`.