### PR TITLE
feat(inbox,ui): stop-recurrence action; strip emojis from picker + chrome

### DIFF
--- a/src/app/api/onboarding/setup/route.ts
+++ b/src/app/api/onboarding/setup/route.ts
@@ -12,6 +12,11 @@ type SetupBody = {
   model?: string;
 };
 
+// The `emoji` TOML field carries the glyph string. Cave's renderer parses
+// it via parseGlyphString — values prefixed with `ph:` resolve to Phosphor
+// icons, anything else is treated as a literal emoji. We seed with Phosphor
+// names so fresh installs land on icon avatars; users can swap to emoji or
+// other icons from the picker after onboarding.
 const STARTER_FAMILIARS_TOML = `# Canonical OpenCoven familiar roster.
 # Edit, add, or remove entries to change what the coven daemon serves at
 # GET /api/v1/familiars (and what the cockpit renders on /familiars).
@@ -19,7 +24,7 @@ const STARTER_FAMILIARS_TOML = `# Canonical OpenCoven familiar roster.
 [[familiar]]
 id = "nova"
 display_name = "Nova"
-emoji = "👑"
+emoji = "ph:crown-fill"
 role = "Queen / Orchestrator"
 description = "Architect and orchestrator for the Coven, aligning the familiars around the work that matters."
 pronouns = "she/her"
@@ -27,7 +32,7 @@ pronouns = "she/her"
 [[familiar]]
 id = "sage"
 display_name = "Sage"
-emoji = "🌿"
+emoji = "ph:leaf-fill"
 role = "Research familiar"
 description = "Reads, synthesizes, checks sources, and finds the thread through evidence and uncertainty."
 pronouns = "they/them"
@@ -35,35 +40,35 @@ pronouns = "they/them"
 [[familiar]]
 id = "charm"
 display_name = "Charm"
-emoji = "✨"
+emoji = "ph:sparkle-fill"
 role = "Social / Comms"
 description = "Handles external-facing language, relationship tone, and social coordination."
 
 [[familiar]]
 id = "echo"
 display_name = "Echo"
-emoji = "🔮"
+emoji = "ph:brain-fill"
 role = "Memory / Reflection"
 description = "Maintains continuity, extracts durable lessons, and turns raw logs into useful recall."
 
 [[familiar]]
 id = "astra"
 display_name = "Astra"
-emoji = "🌟"
+emoji = "ph:star-fill"
 role = "Strategy / Navigation"
 description = "Maps options, tradeoffs, timing, and next moves across Coven and OpenCoven work."
 
 [[familiar]]
 id = "cody"
 display_name = "Cody"
-emoji = "⚡"
+emoji = "ph:lightning-fill"
 role = "Code"
 description = "Builds, debugs, tests, reviews, and ships implementation work."
 
 [[familiar]]
 id = "kitty"
 display_name = "Kitty"
-emoji = "🐱"
+emoji = "ph:cat-fill"
 role = "General Helper"
 description = "Handles flexible assistance, reminders, small errands, and everyday utility work."
 `;

--- a/src/app/mockup/page.tsx
+++ b/src/app/mockup/page.tsx
@@ -388,7 +388,7 @@ function ChatPanel() {
       <div className="multica-chat-panel-body">
         <div className="multica-chat-panel-body-title">Chat with your agents</div>
         <div style={{ fontSize: 12, marginBottom: 16 }}>
-          ✨ They know your workspace — <span style={{ color: "var(--foreground)" }}>issues, projects, skills</span>.
+          They know your workspace — <span style={{ color: "var(--foreground)" }}>issues, projects, skills</span>.
         </div>
         <div style={{ fontSize: 12 }}>Ask for a summary, plan your day, or hand off a quick task.</div>
       </div>

--- a/src/components/familiar-glyph-picker.tsx
+++ b/src/components/familiar-glyph-picker.tsx
@@ -9,8 +9,7 @@ import {
 } from "react";
 import { Icon } from "@/lib/icon";
 import {
-  ALL_EMOJI_ENTRIES,
-  categoriesFor,
+  categories,
   searchGlyphs,
   type GlyphCatalogEntry,
 } from "@/lib/glyph-catalog";
@@ -29,8 +28,6 @@ import {
 import { FamiliarGlyph as GlyphView } from "@/components/familiar-glyph";
 import type { Familiar } from "@/lib/types";
 
-type PickerTab = "emoji" | "icon";
-
 type Props = {
   open: boolean;
   familiar: Familiar | null;
@@ -41,7 +38,6 @@ export function FamiliarGlyphPicker({ open, familiar, onClose }: Props) {
   const overrides = useGlyphOverrides();
   const recent = useRecentGlyphs();
   const [query, setQuery] = useState("");
-  const [tab, setTab] = useState<PickerTab>("emoji");
   const [hovered, setHovered] = useState<GlyphCatalogEntry | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
@@ -50,16 +46,8 @@ export function FamiliarGlyphPicker({ open, familiar, onClose }: Props) {
     if (!open) return;
     setQuery("");
     setHovered(null);
-    // Default tab: emoji if the user has any recents that are emoji, else
-    // whatever the current glyph kind is.
-    const currentGlyph = familiar
-      ? resolveFamiliarGlyph(familiar, overrides)
-      : null;
-    setTab(currentGlyph?.kind === "icon" ? "icon" : "emoji");
     const t = setTimeout(() => inputRef.current?.focus(), 20);
     return () => clearTimeout(t);
-    // overrides intentionally NOT in deps — we only want this on open.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, familiar?.id]);
 
   // Esc closes; Cmd/Ctrl+Backspace clears the current override.
@@ -84,43 +72,32 @@ export function FamiliarGlyphPicker({ open, familiar, onClose }: Props) {
   }, [familiar, overrides]);
 
   const results = useMemo(() => {
-    return searchGlyphs({
-      query,
-      kinds: query.trim() ? ["emoji", "icon"] : [tab],
-    }).slice(0, 800);
-  }, [query, tab]);
+    return searchGlyphs({ query }).slice(0, 800);
+  }, [query]);
 
-  const categories = useMemo(() => {
+  const categoryList = useMemo(() => {
     if (query.trim()) return [];
-    return categoriesFor([tab]);
-  }, [tab, query]);
+    return categories();
+  }, [query]);
 
+  // Recent only includes icon picks since the picker is icon-only now.
+  // Older emoji entries in localStorage are dropped from the recent strip
+  // (still render fine on the familiar itself via the legacy renderer).
   const recentEntries: GlyphCatalogEntry[] = useMemo(() => {
-    return recent
-      .map((value) => {
-        const parsed = parseGlyphString(value);
-        if (!parsed) return null;
-        if (parsed.kind === "emoji") {
-          const found = ALL_EMOJI_ENTRIES.find((e) => e.value === parsed.char);
-          if (found) return found;
-          return {
-            value: parsed.char,
-            kind: "emoji" as const,
-            name: parsed.char,
-            category: "Recent",
-            keywords: [],
-          };
-        }
-        return {
-          value: parsed.name,
-          kind: "icon" as const,
-          name: parsed.name.replace(/^ph:/, "").replace(/-/g, " "),
-          category: "Recent",
-          keywords: [],
-        };
-      })
-      .filter((e): e is GlyphCatalogEntry => e !== null)
-      .slice(0, 12);
+    const out: GlyphCatalogEntry[] = [];
+    for (const value of recent) {
+      const parsed = parseGlyphString(value);
+      if (!parsed || parsed.kind !== "icon") continue;
+      out.push({
+        value: parsed.name,
+        kind: "icon",
+        name: parsed.name.replace(/^ph:/, "").replace(/-/g, " "),
+        category: "Recent",
+        keywords: [],
+      });
+      if (out.length >= 12) break;
+    }
+    return out;
   }, [recent]);
 
   const onPick = useCallback(
@@ -154,7 +131,7 @@ export function FamiliarGlyphPicker({ open, familiar, onClose }: Props) {
               {familiar.display_name}
             </span>
             <span className="text-[11px] text-zinc-500">
-              {hovered?.name ?? "Pick a glyph"}
+              {hovered?.name ?? "Pick an icon"}
             </span>
           </div>
           <button
@@ -213,38 +190,26 @@ export function FamiliarGlyphPicker({ open, familiar, onClose }: Props) {
           </div>
         ) : null}
 
-        {/* Tabs (hidden during free-text search since we merge both kinds) */}
-        {!query.trim() ? (
-          <div className="flex items-center gap-0.5 border-b border-zinc-900 px-4 py-1.5 text-[11px]">
-            <TabButton
-              active={tab === "emoji"}
-              onClick={() => setTab("emoji")}
-              label="Emoji"
-            />
-            <TabButton
-              active={tab === "icon"}
-              onClick={() => setTab("icon")}
-              label="Icons"
-            />
-            <div className="ml-auto text-[10px] text-zinc-600">
-              {results.length.toLocaleString()} options
-            </div>
-          </div>
-        ) : (
-          <div className="flex items-center justify-between border-b border-zinc-900 px-4 py-1.5 text-[10px] text-zinc-500">
-            <span>
-              {results.length.toLocaleString()} matches for {`"`}
-              {query.trim()}
-              {`"`}
-            </span>
-            <button
-              onClick={() => setQuery("")}
-              className="text-zinc-400 hover:text-zinc-200"
-            >
-              clear
-            </button>
-          </div>
-        )}
+        {/* Results count */}
+        <div className="flex items-center justify-between border-b border-zinc-900 px-4 py-1.5 text-[10px] text-zinc-500">
+          {query.trim() ? (
+            <>
+              <span>
+                {results.length.toLocaleString()} matches for {`"`}
+                {query.trim()}
+                {`"`}
+              </span>
+              <button
+                onClick={() => setQuery("")}
+                className="text-zinc-400 hover:text-zinc-200"
+              >
+                clear
+              </button>
+            </>
+          ) : (
+            <span>{results.length.toLocaleString()} icons</span>
+          )}
+        </div>
 
         {/* Grid */}
         <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
@@ -262,7 +227,7 @@ export function FamiliarGlyphPicker({ open, familiar, onClose }: Props) {
           ) : (
             <CategorizedGrid
               entries={results}
-              categories={categories}
+              categories={categoryList}
               currentValue={currentGlyph ? serializeGlyph(currentGlyph) : null}
               onPick={onPick}
               onHover={setHovered}
@@ -290,29 +255,6 @@ export function FamiliarGlyphPicker({ open, familiar, onClose }: Props) {
 // Sub-components
 // ---------------------------------------------------------------------------
 
-function TabButton({
-  active,
-  onClick,
-  label,
-}: {
-  active: boolean;
-  onClick: () => void;
-  label: string;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className={`rounded-md px-2.5 py-1 transition-colors ${
-        active
-          ? "bg-zinc-800 text-zinc-100"
-          : "text-zinc-400 hover:bg-zinc-900 hover:text-zinc-200"
-      }`}
-    >
-      {label}
-    </button>
-  );
-}
-
 function GlyphButton({
   entry,
   size = "sm",
@@ -327,10 +269,7 @@ function GlyphButton({
   onHover: (e: GlyphCatalogEntry | null) => void;
 }) {
   const cell = size === "md" ? "h-9 w-9" : "h-8 w-8";
-  const glyph: FamiliarGlyph =
-    entry.kind === "emoji"
-      ? { kind: "emoji", char: entry.value }
-      : { kind: "icon", name: entry.value };
+  const glyph: FamiliarGlyph = { kind: "icon", name: entry.value };
   return (
     <button
       onClick={() => onPick(entry)}
@@ -363,7 +302,7 @@ function GlyphGrid({
     <div className="grid grid-cols-[repeat(auto-fill,minmax(2.25rem,1fr))] gap-1">
       {entries.map((e) => (
         <GlyphButton
-          key={`${e.kind}:${e.value}`}
+          key={e.value}
           entry={e}
           active={e.value === currentValue}
           onPick={onPick}

--- a/src/components/inbox-view.tsx
+++ b/src/components/inbox-view.tsx
@@ -3,8 +3,33 @@
 import { useCallback, useMemo, useState } from "react";
 import type { Familiar } from "@/lib/types";
 import type { InboxItem, ItemStatus } from "@/lib/cave-inbox";
+import type { Recurrence } from "@/lib/inbox-recurrence";
 import { SnoozeMenu } from "@/components/snooze-menu";
 import { Icon } from "@/lib/icon";
+
+const DAY_INITIALS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+
+function describeRecurrence(rec: Recurrence | undefined): string | null {
+  if (!rec || rec.type === "none") return null;
+  if (rec.type === "interval") {
+    const ms = rec.everyMs;
+    if (ms < 60_000) return `every ${Math.round(ms / 1000)}s`;
+    if (ms < 3_600_000) return `every ${Math.round(ms / 60_000)}m`;
+    if (ms < 86_400_000) return `every ${Math.round(ms / 3_600_000)}h`;
+    return `every ${Math.round(ms / 86_400_000)}d`;
+  }
+  if (rec.type === "daily") {
+    return `daily ${String(rec.hour).padStart(2, "0")}:${String(rec.minute).padStart(2, "0")}`;
+  }
+  if (rec.type === "weekly") {
+    const days = rec.days.map((d) => DAY_INITIALS[d] ?? "?").join("/");
+    return `${days} ${String(rec.hour).padStart(2, "0")}:${String(rec.minute).padStart(2, "0")}`;
+  }
+  if (rec.type === "cron") {
+    return `cron: ${rec.expr}`;
+  }
+  return null;
+}
 
 type Props = {
   items: InboxItem[];
@@ -99,6 +124,26 @@ export function InboxView({
     [onRefresh],
   );
 
+  // PATCH the root inbox item — used for stop-recurrence, which sets
+  // recurrence.type to "none" so the next fire stops spawning a sibling.
+  const patch = useCallback(
+    async (id: string, body: object) => {
+      if (id.startsWith("eph:")) return;
+      setBusyId(id);
+      try {
+        await fetch(`/api/inbox/${id}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        onRefresh();
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [onRefresh],
+  );
+
   const familiarLabel = (fid: string | null | undefined) => {
     if (!fid) return null;
     const f = familiars.find((x) => x.id === fid);
@@ -156,7 +201,7 @@ export function InboxView({
                         {it.body}
                       </p>
                     ) : null}
-                    <div className="mt-1.5 flex items-center gap-2 text-[10px] text-zinc-500">
+                    <div className="mt-1.5 flex flex-wrap items-center gap-2 text-[10px] text-zinc-500">
                       {col.id === "pending" ? (
                         <span className="inline-flex items-center gap-1">
                           <Icon name="ph:alarm-bold" />
@@ -167,6 +212,15 @@ export function InboxView({
                       ) : (
                         <span>done {fmtFireAt(it.updatedAt)}</span>
                       )}
+                      {describeRecurrence(it.recurrence) ? (
+                        <span
+                          className="inline-flex items-center gap-1 rounded bg-zinc-900 px-1 py-px text-zinc-400"
+                          title="Repeats — use Stop recurrence to break the chain"
+                        >
+                          <Icon name="ph:arrows-clockwise-bold" />
+                          {describeRecurrence(it.recurrence)}
+                        </span>
+                      ) : null}
                       {familiarLabel(it.familiarId) ? (
                         <span className="rounded bg-zinc-800 px-1 py-px">
                           {familiarLabel(it.familiarId)}
@@ -188,6 +242,17 @@ export function InboxView({
                           >
                             Dismiss
                           </Btn>
+                          {describeRecurrence(it.recurrence) ? (
+                            <Btn
+                              disabled={busyId === it.id}
+                              onClick={() =>
+                                patch(it.id, { recurrence: { type: "none" } })
+                              }
+                              title="Stop this reminder from re-spawning after it fires"
+                            >
+                              Stop recurrence
+                            </Btn>
+                          ) : null}
                         </>
                       ) : null}
                       {col.id === "fired" ? (
@@ -246,15 +311,18 @@ function Btn({
   children,
   onClick,
   disabled,
+  title,
 }: {
   children: React.ReactNode;
   onClick: () => void;
   disabled?: boolean;
+  title?: string;
 }) {
   return (
     <button
       onClick={onClick}
       disabled={disabled}
+      title={title}
       className="rounded border border-zinc-800 bg-zinc-900 px-2 py-0.5 text-[10px] text-zinc-300 hover:bg-zinc-800 disabled:opacity-50"
     >
       {children}

--- a/src/lib/glyph-catalog.ts
+++ b/src/lib/glyph-catalog.ts
@@ -1,30 +1,24 @@
 /**
  * Catalogue of glyphs available in the picker.
  *
- * Two sources merge into one searchable list:
+ * Source: Phosphor's full ~1500-icon catalogue, loaded from the bundled
+ * `@iconify-json/ph` package, filtered to the "fill" variants for visual
+ * weight consistency with the rest of the cave chrome.
  *
- *   - `EMOJI_CATALOG` — a curated set of ~140 emojis that read well at
- *     small sizes and fit the "familiar persona" theme (creatures,
- *     mystical signs, simple symbols). Each entry has `char`, `name`,
- *     `category`, and `keywords` so search matches against intent
- *     ("cat", "wand", "fire") rather than the emoji codepoint name only.
- *
- *   - `phCollection.icons` — Phosphor's full ~1500-icon catalogue,
- *     loaded from the bundled `@iconify-json/ph` package, filtered to
- *     the "fill" variants for visual weight consistency with the rest
- *     of the cave chrome.
- *
- * Both shapes normalize to `GlyphCatalogEntry` so the picker can render
- * them with the same row component and search helper.
+ * Emoji entries used to live here as well, but Cave's UI standardised on
+ * Phosphor for chrome neutrality. The renderer in `familiar-glyph.tsx`
+ * still draws emoji values defensively so users with saved emoji avatars
+ * from earlier versions keep working — they just can't pick a new one
+ * from the picker.
  */
 
 import phCollection from "@iconify-json/ph/icons.json";
 
 export type GlyphCatalogEntry = {
-  /** Storage representation: emoji char OR `ph:...` icon name. */
+  /** Storage representation: `ph:...` icon name. */
   value: string;
   /** Discriminator used by the renderer + picker filters. */
-  kind: "emoji" | "icon";
+  kind: "icon";
   /** Display name used when searching + shown in the preview row. */
   name: string;
   /** Category for the tab/section grouping. */
@@ -32,145 +26,6 @@ export type GlyphCatalogEntry = {
   /** Extra search keywords beyond `name`. */
   keywords: string[];
 };
-
-// ---------------------------------------------------------------------------
-// Curated emoji
-// ---------------------------------------------------------------------------
-
-type EmojiSeed = {
-  char: string;
-  name: string;
-  category: "Creatures" | "Mystical" | "Nature" | "Symbols" | "People" | "Objects";
-  keywords?: string[];
-};
-
-const EMOJI_SEED: EmojiSeed[] = [
-  // Creatures — first instinct for "familiar"
-  { char: "🐈", name: "Cat", category: "Creatures", keywords: ["kitty", "kitten", "feline"] },
-  { char: "🐈‍⬛", name: "Black cat", category: "Creatures", keywords: ["familiar", "witch"] },
-  { char: "🐅", name: "Tiger", category: "Creatures" },
-  { char: "🦁", name: "Lion", category: "Creatures" },
-  { char: "🦊", name: "Fox", category: "Creatures", keywords: ["clever"] },
-  { char: "🐺", name: "Wolf", category: "Creatures" },
-  { char: "🐶", name: "Dog", category: "Creatures", keywords: ["puppy"] },
-  { char: "🐰", name: "Rabbit", category: "Creatures" },
-  { char: "🦝", name: "Raccoon", category: "Creatures" },
-  { char: "🐻", name: "Bear", category: "Creatures" },
-  { char: "🐼", name: "Panda", category: "Creatures" },
-  { char: "🐨", name: "Koala", category: "Creatures" },
-  { char: "🐹", name: "Hamster", category: "Creatures" },
-  { char: "🐭", name: "Mouse", category: "Creatures" },
-  { char: "🐿️", name: "Chipmunk", category: "Creatures", keywords: ["squirrel"] },
-  { char: "🦦", name: "Otter", category: "Creatures" },
-  { char: "🦔", name: "Hedgehog", category: "Creatures" },
-  { char: "🦇", name: "Bat", category: "Creatures" },
-  { char: "🐦", name: "Bird", category: "Creatures" },
-  { char: "🦅", name: "Eagle", category: "Creatures" },
-  { char: "🦉", name: "Owl", category: "Creatures", keywords: ["wise", "night"] },
-  { char: "🐉", name: "Dragon", category: "Creatures", keywords: ["mythical"] },
-  { char: "🐲", name: "Dragon face", category: "Creatures" },
-  { char: "🦄", name: "Unicorn", category: "Creatures", keywords: ["mythical", "magic"] },
-  { char: "🐙", name: "Octopus", category: "Creatures" },
-  { char: "🦑", name: "Squid", category: "Creatures" },
-  { char: "🦋", name: "Butterfly", category: "Creatures" },
-  { char: "🐢", name: "Turtle", category: "Creatures" },
-  { char: "🐍", name: "Snake", category: "Creatures" },
-  { char: "🐠", name: "Tropical fish", category: "Creatures", keywords: ["fish"] },
-  { char: "🐳", name: "Whale", category: "Creatures" },
-  { char: "🐬", name: "Dolphin", category: "Creatures" },
-
-  // Mystical
-  { char: "🧙", name: "Mage", category: "Mystical", keywords: ["wizard", "witch"] },
-  { char: "🧚", name: "Fairy", category: "Mystical" },
-  { char: "🧛", name: "Vampire", category: "Mystical" },
-  { char: "🧜", name: "Mermaid", category: "Mystical" },
-  { char: "🧝", name: "Elf", category: "Mystical" },
-  { char: "🧞", name: "Genie", category: "Mystical" },
-  { char: "🧟", name: "Zombie", category: "Mystical" },
-  { char: "👻", name: "Ghost", category: "Mystical", keywords: ["spirit", "haunt"] },
-  { char: "👽", name: "Alien", category: "Mystical" },
-  { char: "👾", name: "Alien monster", category: "Mystical", keywords: ["pixel"] },
-  { char: "🤖", name: "Robot", category: "Mystical", keywords: ["ai", "machine"] },
-  { char: "🪄", name: "Magic wand", category: "Mystical", keywords: ["wand", "spell"] },
-  { char: "🔮", name: "Crystal ball", category: "Mystical", keywords: ["fortune", "divine"] },
-  { char: "🕯️", name: "Candle", category: "Mystical" },
-  { char: "📜", name: "Scroll", category: "Mystical", keywords: ["spell", "lore"] },
-  { char: "🗝️", name: "Key", category: "Mystical" },
-  { char: "⚱️", name: "Urn", category: "Mystical" },
-
-  // Nature
-  { char: "🌙", name: "Moon", category: "Nature", keywords: ["night", "crescent"] },
-  { char: "☀️", name: "Sun", category: "Nature" },
-  { char: "⭐", name: "Star", category: "Nature" },
-  { char: "🌟", name: "Glowing star", category: "Nature", keywords: ["sparkle"] },
-  { char: "✨", name: "Sparkles", category: "Nature", keywords: ["magic", "shimmer"] },
-  { char: "💫", name: "Dizzy", category: "Nature", keywords: ["star", "spin"] },
-  { char: "☁️", name: "Cloud", category: "Nature" },
-  { char: "⚡", name: "Lightning", category: "Nature", keywords: ["bolt", "fast"] },
-  { char: "🔥", name: "Fire", category: "Nature", keywords: ["flame", "hot"] },
-  { char: "🌊", name: "Wave", category: "Nature", keywords: ["water", "ocean"] },
-  { char: "🌿", name: "Herb", category: "Nature", keywords: ["plant", "leaf"] },
-  { char: "🍀", name: "Four-leaf clover", category: "Nature", keywords: ["luck"] },
-  { char: "🌸", name: "Cherry blossom", category: "Nature", keywords: ["flower"] },
-  { char: "🌺", name: "Hibiscus", category: "Nature", keywords: ["flower"] },
-  { char: "🌻", name: "Sunflower", category: "Nature", keywords: ["flower"] },
-  { char: "🌷", name: "Tulip", category: "Nature", keywords: ["flower"] },
-  { char: "🍄", name: "Mushroom", category: "Nature" },
-  { char: "🌵", name: "Cactus", category: "Nature" },
-  { char: "🌳", name: "Tree", category: "Nature" },
-
-  // Symbols
-  { char: "♠️", name: "Spade", category: "Symbols" },
-  { char: "♥️", name: "Heart suit", category: "Symbols" },
-  { char: "♦️", name: "Diamond suit", category: "Symbols" },
-  { char: "♣️", name: "Club suit", category: "Symbols" },
-  { char: "☯️", name: "Yin yang", category: "Symbols" },
-  { char: "☮️", name: "Peace", category: "Symbols" },
-  { char: "♾️", name: "Infinity", category: "Symbols" },
-  { char: "⚛️", name: "Atom", category: "Symbols", keywords: ["science"] },
-  { char: "🌀", name: "Cyclone", category: "Symbols", keywords: ["spiral", "swirl"] },
-  { char: "❄️", name: "Snowflake", category: "Symbols" },
-  { char: "🌈", name: "Rainbow", category: "Symbols" },
-  { char: "💎", name: "Gem", category: "Symbols", keywords: ["diamond", "crystal"] },
-  { char: "👁️", name: "Eye", category: "Symbols", keywords: ["see", "watch"] },
-  { char: "🦴", name: "Bone", category: "Symbols" },
-  { char: "🩸", name: "Drop of blood", category: "Symbols" },
-  { char: "🧿", name: "Nazar amulet", category: "Symbols", keywords: ["evil eye", "protect"] },
-
-  // People
-  { char: "🥷", name: "Ninja", category: "People" },
-  { char: "🧑‍💻", name: "Technologist", category: "People", keywords: ["dev", "code"] },
-  { char: "🧑‍🎨", name: "Artist", category: "People" },
-  { char: "🧑‍🚀", name: "Astronaut", category: "People", keywords: ["space"] },
-  { char: "🧑‍🔬", name: "Scientist", category: "People" },
-  { char: "🧑‍🌾", name: "Farmer", category: "People" },
-  { char: "🧑‍🍳", name: "Cook", category: "People", keywords: ["chef"] },
-
-  // Objects
-  { char: "🪞", name: "Mirror", category: "Objects" },
-  { char: "📖", name: "Open book", category: "Objects" },
-  { char: "🪶", name: "Feather", category: "Objects", keywords: ["quill"] },
-  { char: "🧪", name: "Test tube", category: "Objects", keywords: ["potion", "lab"] },
-  { char: "🧬", name: "DNA", category: "Objects", keywords: ["genome"] },
-  { char: "🎭", name: "Performing arts", category: "Objects", keywords: ["mask", "drama"] },
-  { char: "🎨", name: "Artist palette", category: "Objects", keywords: ["paint"] },
-  { char: "🎲", name: "Die", category: "Objects", keywords: ["chance", "random"] },
-  { char: "🎯", name: "Direct hit", category: "Objects", keywords: ["target"] },
-  { char: "🔭", name: "Telescope", category: "Objects" },
-  { char: "📡", name: "Satellite", category: "Objects", keywords: ["signal"] },
-  { char: "🛰️", name: "Satellite orbit", category: "Objects" },
-  { char: "🗡️", name: "Dagger", category: "Objects", keywords: ["sword"] },
-  { char: "🛡️", name: "Shield", category: "Objects", keywords: ["defense"] },
-  { char: "🔱", name: "Trident", category: "Objects" },
-];
-
-const EMOJI_CATALOG: GlyphCatalogEntry[] = EMOJI_SEED.map((e) => ({
-  value: e.char,
-  kind: "emoji",
-  name: e.name,
-  category: e.category,
-  keywords: e.keywords ?? [],
-}));
 
 // ---------------------------------------------------------------------------
 // Phosphor — fill variants only
@@ -188,7 +43,6 @@ type PhosphorCollection = {
 };
 
 function categorizePhosphor(name: string): string {
-  // Heuristic — Phosphor's published categories aren't in the JSON.
   if (/(cat|dog|bird|fish|paw|bone|bug|spider|butterfly|rabbit|cow|horse|dolphin|fox|owl)/.test(name)) return "Animals";
   if (/(heart|smiley|user|person|ghost|skull|baby|hand)/.test(name)) return "People";
   if (/(sun|moon|cloud|fire|drop|leaf|tree|flower|mountain|lightning|wind|snowflake|tornado)/.test(name)) return "Nature";
@@ -201,9 +55,6 @@ function categorizePhosphor(name: string): string {
 }
 
 function entryForPhosphor(rawName: string): GlyphCatalogEntry | null {
-  // Strip Phosphor suffixes for the display name + keyword search; the actual
-  // value still includes `-fill` etc. so the renderer gets the variant the
-  // catalog picked.
   const base = rawName
     .replace(/-fill$|-bold$|-duotone$|-light$|-thin$/, "")
     .replace(/-/g, " ");
@@ -235,7 +86,6 @@ const PHOSPHOR_CATALOG: GlyphCatalogEntry[] = (() => {
     const e = entryForPhosphor(name);
     if (e) entries.push(e);
   }
-  // Stable alphabetical so the grid order is predictable.
   entries.sort((a, b) => a.name.localeCompare(b.name));
   return entries;
 })();
@@ -244,47 +94,36 @@ const PHOSPHOR_CATALOG: GlyphCatalogEntry[] = (() => {
 // Public API
 // ---------------------------------------------------------------------------
 
-export const ALL_EMOJI_ENTRIES = EMOJI_CATALOG;
 export const ALL_ICON_ENTRIES = PHOSPHOR_CATALOG;
 
 export type GlyphSearchOpts = {
   query?: string;
-  kinds?: ("emoji" | "icon")[];
   category?: string;
 };
 
 /**
- * Search the merged catalog. Empty query returns the full set filtered by
- * `kinds` (and `category` if provided). Non-empty query does a substring
- * match against `name`, `category`, and `keywords`.
+ * Search the icon catalog. Empty query returns the full set (optionally
+ * filtered by category). Non-empty query does a substring match against
+ * `name`, `category`, and `keywords`.
  */
 export function searchGlyphs(opts: GlyphSearchOpts): GlyphCatalogEntry[] {
-  const kinds = opts.kinds ?? ["emoji", "icon"];
   const q = (opts.query ?? "").trim().toLowerCase();
-  const pool: GlyphCatalogEntry[] = [];
-  if (kinds.includes("emoji")) pool.push(...ALL_EMOJI_ENTRIES);
-  if (kinds.includes("icon")) pool.push(...ALL_ICON_ENTRIES);
-  let filtered = pool;
+  let pool = ALL_ICON_ENTRIES;
   if (opts.category) {
-    filtered = filtered.filter((e) => e.category === opts.category);
+    pool = pool.filter((e) => e.category === opts.category);
   }
-  if (!q) return filtered;
-  return filtered.filter((e) => {
+  if (!q) return pool;
+  return pool.filter((e) => {
     if (e.name.toLowerCase().includes(q)) return true;
     if (e.category.toLowerCase().includes(q)) return true;
     return e.keywords.some((k) => k.toLowerCase().includes(q));
   });
 }
 
-/** Distinct categories present in the chosen kinds, in display order. */
-export function categoriesFor(kinds: ("emoji" | "icon")[]): string[] {
+/** Distinct categories present in the catalog, in display order. */
+export function categories(): string[] {
   const seen: string[] = [];
-  const pool = kinds.includes("emoji")
-    ? kinds.includes("icon")
-      ? [...ALL_EMOJI_ENTRIES, ...ALL_ICON_ENTRIES]
-      : ALL_EMOJI_ENTRIES
-    : ALL_ICON_ENTRIES;
-  for (const e of pool) {
+  for (const e of ALL_ICON_ENTRIES) {
     if (!seen.includes(e.category)) seen.push(e.category);
   }
   return seen;

--- a/src/lib/icon.tsx
+++ b/src/lib/icon.tsx
@@ -22,6 +22,7 @@ function ensureRegistered() {
 export const ICON_NAMES = [
   "ph:alarm-bold",
   "ph:alarm-fill",
+  "ph:arrows-clockwise-bold",
   "ph:bell-fill",
   "ph:caret-right-bold",
   "ph:chat-circle-dots-bold",


### PR DESCRIPTION
## Summary

Two related fixes that came out of an inbox loop running ~22 hours unchecked on my install.

### Inbox: stop-recurrence affordance (the real bug)

My inbox had **2,282 entries** titled "Recurrence check" spawned by a single `{interval: 20s}` reminder created the day before. Each tick `inbox-scheduler.ts` fired the pending item, marked it "fired", and **spawned a new pending sibling** carrying the same recurrence. Dismissing one occurrence does nothing to the sibling — the chain perpetuates. The only escape was editing the inbox JSON by hand.

Now:

- Each item shows a small badge describing its recurrence (`every 20s`, `daily 09:00`, `Mo/We 09:00`, `cron: …`).
- Pending recurring items get a **`Stop recurrence`** button that PATCHes the item to `{recurrence: {type: "none"}}`. The item still fires on schedule, but no sibling is spawned, so the chain ends.

### Emojis: strip from picker + chrome

Per request: Cave's UI standardises on Phosphor; emojis are gone from chrome.

- `glyph-catalog.ts`: ~140 curated emoji entries removed. Picker is Phosphor-only.
- `familiar-glyph-picker.tsx`: Emoji/Icons tab toggle removed; single icon grid.
- `onboarding/setup/route.ts`: seed roster uses Phosphor names in the `emoji =` TOML field (the parser handles `ph:` prefix). New mapping:

  | Familiar | Was | Now |
  |----------|-----|-----|
  | Nova | 👑 | `ph:crown-fill` |
  | Sage | 🌿 | `ph:leaf-fill` |
  | Charm | ✨ | `ph:sparkle-fill` |
  | Echo | 🔮 | `ph:brain-fill` (no crystal-ball-fill in Phosphor) |
  | Astra | 🌟 | `ph:star-fill` |
  | Cody | ⚡ | `ph:lightning-fill` |
  | Kitty | 🐱 | `ph:cat-fill` |
- `mockup/page.tsx`: drop decorative ✨ from chat-panel copy.
- `icon.tsx`: register `ph:arrows-clockwise-bold` for the recurrence badge.

`familiar-glyph.tsx` is intentionally unchanged — it still renders saved emoji values defensively so users who picked an emoji avatar in v0.0.11 or earlier keep their glyph until they swap it.

## Existing install note

The onboarding seed only writes `familiars.toml` on first install. **Existing users (including the maintainer) keep their previous emoji avatars** until they either:

1. Pick a Phosphor icon from the picker (now icon-only), or
2. Delete `~/.coven/familiars.toml` and re-run onboarding.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm build` clean (all routes still compile)
- [x] `pnpm dev`: `/` and `/mockup` serve 200; `/mockup` body no longer contains `✨`
- [ ] Picker opens, shows ~1500 Phosphor icons, no Emoji tab, search works
- [ ] Recurrence badge visible on items with `recurrence.type !== "none"`
- [ ] `Stop recurrence` button PATCHes the item; new sibling is not spawned on next fire
- [ ] Existing emoji avatars on the rail still render via the legacy renderer path