### PR TITLE
chore(ci): multi-platform release workflow — Linux AppImage + Windows MSI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: Release
+
+# Builds CovenCave Linux (AppImage) and Windows (unsigned MSI) artifacts
+# and uploads them to the GitHub Release matching the pushed tag.
+#
+# macOS is intentionally NOT built here — that flow stays local via
+# scripts/release.sh, which has the Apple Developer ID + notarization
+# credentials and produces a signed/notarized DMG. The local DMG is
+# uploaded into the same GitHub Release manually (or via `gh release
+# upload <tag> release/CovenCave-v<version>.dmg`).
+#
+# Trigger: push a tag matching `v*` (e.g. `git tag -s v0.0.12 && git push
+# origin v0.0.12`). The release.sh script already pushes a signed tag,
+# so the manual mac flow and the CI flow both key off the same tag.
+#
+# Windows binaries are UNSIGNED in v1 — users will see a SmartScreen
+# warning on first run. When we buy a code-signing cert we'll add the
+# WINDOWS_CERTIFICATE / WINDOWS_CERTIFICATE_PASSWORD secrets and wire
+# them into the windows job.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to attach builds to (e.g. v0.0.12). Must already exist on origin."
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ubuntu-22.04
+            label: Linux (AppImage)
+            args: "--bundles appimage"
+          - platform: windows-latest
+            label: Windows (MSI, unsigned)
+            args: "--bundles msi"
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Install Linux dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          version: 11
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          workspaces: "src-tauri -> target"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build with tauri-action
+        uses: tauri-apps/tauri-action@1f1e4476ddf2da8ec9d2dec7841e7c4ce8c25728 # v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: ${{ github.event.inputs.tag || github.ref_name }}
+          releaseName: "CovenCave ${{ github.event.inputs.tag || github.ref_name }}"
+          releaseDraft: false
+          prerelease: false
+          includeUpdaterJson: false
+          args: ${{ matrix.args }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml`. On `v*` tag push (or manual `workflow_dispatch`), builds CovenCave for Linux (AppImage) and Windows (unsigned MSI) and uploads the bundles to the GitHub Release matching the tag.

**macOS is intentionally NOT built in CI** — that flow stays local via `scripts/release.sh`, which holds the Apple Developer ID cert + the App Store Connect notarization key and produces the signed/notarized DMG. `release.sh` already pushes a signed tag at the end of its run, which is the trigger that fires this workflow; the local DMG is uploaded into the same release manually (or with `gh release upload <tag> release/CovenCave-v<v>.dmg`).

## Decisions (per follow-up direction on #14)

- **macOS**: keep local `scripts/release.sh` (signed + notarized DMG)
- **Linux**: AppImage only — universal portable
- **Windows**: **unsigned MSI** for v1 — SmartScreen warning acceptable until we buy a code-signing cert. To sign later: add `WINDOWS_CERTIFICATE` / `WINDOWS_CERTIFICATE_PASSWORD` secrets and wire them into the windows job.

## Trigger paths

1. **Tag push** (the normal flow): `git tag -s v0.0.12 && git push origin v0.0.12`. macOS local + CI Linux + CI Windows all attach to the same release.
2. **Manual** (`workflow_dispatch`): pass an existing tag name. Useful for re-running a build without re-cutting the version.

## How it works

- Uses `tauri-apps/tauri-action@v0` for the actual build + upload.
- Matrix: `ubuntu-22.04` (AppImage) + `windows-latest` (MSI).
- Rust cache via `swatinem/rust-cache` so re-runs are fast.
- `pnpm install --frozen-lockfile` (matches `ci.yml`).

## Test plan

- [ ] Cut next release: `bash scripts/release.sh 0.0.12` locally, observe DMG published.
- [ ] Tag push fires the workflow; verify both Linux + Windows jobs go green.
- [ ] Verify AppImage + MSI both land on the release page next to the DMG.
- [ ] On a Windows machine: confirm MSI installs (with SmartScreen warning) and CovenCave launches.
- [ ] On Linux: confirm AppImage is executable and launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Cody)