### PR TITLE
chore: bump version to 0.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Routine version bump to cut v0.0.12 — dogfooding the new multi-platform release workflow merged in #24.

- `package.json` 0.0.11 → 0.0.12
- `src-tauri/tauri.conf.json` 0.0.11 → 0.0.12

After merge: `scripts/release.sh 0.0.12` locally for the mac DMG, then signed tag push triggers PR #24's CI matrix for the Linux AppImage + Windows MSI.

Co-authored-by: OpenCoven <noreply@opencoven.io>