### PR TITLE
ci(release): fix unresolvable tauri-action SHA pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build with tauri-action
-        uses: tauri-apps/tauri-action@1f1e4476ddf2da8ec9d2dec7841e7c4ce8c25728 # v0
+        uses: tauri-apps/tauri-action@1ddc7b49b13c3038297360482fcb3e058764d7c9 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Dogfood of v0.0.12 release surfaced this immediately: PR #24 pinned tauri-action to a SHA that GitHub Actions cannot resolve. Both matrix jobs (Linux AppImage + Windows MSI) failed in the \"Prepare all required actions\" step.

Failing run: https://github.com/OpenCoven/coven-cave/actions/runs/26727614148

> ##[error]Unable to resolve action `tauri-apps/tauri-action@1f1e4476ddf2da8ec9d2dec7841e7c4ce8c25728`, unable to find version `1f1e4476ddf2da8ec9d2dec7841e7c4ce8c25728`

Re-pinned to `1ddc7b49b13c3038297360482fcb3e058764d7c9` which is the current release tag for `v0.6.2`, the latest stable tauri-action.

After merge: dispatch the workflow against the existing `v0.0.12` tag (no need to re-tag) to upload the Linux AppImage and Windows MSI alongside the locally-built notarized DMG.

Co-authored-by: OpenCoven <noreply@opencoven.io>