### PR TITLE
feat(board): card-internal lifecycle states + timeouts + retry (#18)

### DIFF
--- a/src/app/api/board/[id]/lifecycle/route.ts
+++ b/src/app/api/board/[id]/lifecycle/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { transitionCard, type CardLifecycle, LIFECYCLES } from "@/lib/cave-board";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  let body: { to?: string; reason?: string; retry?: boolean };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 });
+  }
+  if (!body.to || !LIFECYCLES.includes(body.to as CardLifecycle)) {
+    return NextResponse.json(
+      { ok: false, error: `missing or invalid 'to' (must be one of: ${LIFECYCLES.join(", ")})` },
+      { status: 400 },
+    );
+  }
+  try {
+    const card = await transitionCard(id, {
+      to: body.to as CardLifecycle,
+      reason: body.reason,
+      retry: body.retry,
+    });
+    if (!card) {
+      return NextResponse.json({ ok: false, error: "not found" }, { status: 404 });
+    }
+    return NextResponse.json({ ok: true, card });
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: err instanceof Error ? err.message : "transition failed" },
+      { status: 409 },
+    );
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -530,6 +530,59 @@ body {
   color: var(--text-muted);
 }
 
+/* ---- Lifecycle badge (card state machine) ------------------ */
+.ui-lifecycle-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: 4px;
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-base);
+  color: var(--text-secondary);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  white-space: nowrap;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+}
+
+.ui-lifecycle-badge[data-lifecycle="running"] {
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+}
+.ui-lifecycle-badge[data-lifecycle="completed"] {
+  color: var(--text-muted);
+}
+.ui-lifecycle-badge[data-lifecycle="failed"] {
+  color: #f4b8b8;
+  border-color: color-mix(in oklch, #f4b8b8 30%, var(--border-hairline));
+}
+.ui-lifecycle-badge[data-lifecycle="cancelled"] {
+  color: var(--text-muted);
+  opacity: 0.7;
+}
+.ui-lifecycle-badge[data-lifecycle="review"] {
+  color: var(--accent-presence);
+  border-color: color-mix(in oklch, var(--accent-presence) 25%, var(--border-hairline));
+}
+
+.ui-lifecycle-badge[data-needs-human="true"] {
+  color: #f4b8b8;
+  border-color: color-mix(in oklch, #f4b8b8 40%, var(--border-hairline));
+}
+
+.ui-lifecycle-needs-human {
+  padding: 0 4px;
+  border-radius: 3px;
+  background: color-mix(in oklch, #f4b8b8 18%, transparent);
+  color: #f4b8b8;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+}
+
 /* ---- Chooser list buttons (three-option chooser) ----------- */
 .ui-chooser-list {
   display: flex;

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -6,23 +6,17 @@ import { NewCardModal, type NewCardDraft } from "@/components/new-card-modal";
 import { Icon } from "@/lib/icon";
 import { TemplateCardGrid } from "@/components/ui/template-card-grid";
 import { OriginChip } from "@/components/ui/origin-chip";
-
-type CardStatus = "inbox" | "running" | "review";
-type CardPriority = "low" | "medium" | "high" | "urgent";
-
-type Card = {
-  id: string;
-  title: string;
-  notes: string;
-  status: CardStatus;
-  priority: CardPriority;
-  familiarId: string | null;
-  sessionId: string | null;
-  labels: string[];
-  template?: string | null;
-  createdAt: string;
-  updatedAt: string;
-};
+import {
+  LifecycleBadge,
+  formatTimeoutBadge,
+} from "@/components/ui/lifecycle-badge";
+import {
+  DEFAULT_TIMEOUT_MS,
+  type Card,
+  type CardLifecycle,
+  type CardPriority,
+  type CardStatus,
+} from "@/lib/cave-board-types";
 
 const COLUMNS: { id: CardStatus; label: string }[] = [
   { id: "inbox", label: "Inbox" },
@@ -121,6 +115,10 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
     });
     const json = await res.json();
     if (!json.ok) await load(); // reconcile on failure
+  };
+
+  const replaceCard = (next: Card) => {
+    setCards((prev) => prev.map((c) => (c.id === next.id ? next : c)));
   };
 
   const handleDragStart = (e: React.DragEvent, id: string) => {
@@ -335,6 +333,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
                       onDragEnd={handleDragEnd}
                       onPatch={(patch) => patchCard(card.id, patch)}
                       onDelete={() => removeCard(card.id)}
+                      onCardReplaced={replaceCard}
                       onJumpToSession={onJumpToSession}
                     />
                   ))}
@@ -368,6 +367,7 @@ function CardItem({
   onDragEnd,
   onPatch,
   onDelete,
+  onCardReplaced,
   onJumpToSession,
 }: {
   card: Card;
@@ -378,6 +378,7 @@ function CardItem({
   onDragEnd?: () => void;
   onPatch: (patch: Partial<Card>) => void;
   onDelete: () => void;
+  onCardReplaced: (card: Card) => void;
   onJumpToSession?: (sessionId: string, familiarId: string | null) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -416,18 +417,28 @@ function CardItem({
         </span>
       </div>
 
-      {card.labels.length > 0 ? (
-        <div className="mt-1.5 flex flex-wrap gap-1">
-          {card.labels.map((l) => (
-            <span
-              key={l}
-              className="rounded border border-border bg-card px-1.5 py-px text-[10px] text-foreground"
-            >
-              {l}
-            </span>
-          ))}
-        </div>
-      ) : null}
+      <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+        <LifecycleBadge lifecycle={card.lifecycle} needsHuman={card.needsHuman} />
+        {card.lifecycle === "running" ? (
+          <TimeoutBadge runningSince={card.runningSince} timeoutMs={card.timeoutMs} />
+        ) : null}
+        {card.retryCount > 0 ? (
+          <span
+            className="rounded border border-border bg-card px-1.5 py-px text-[10px] uppercase tracking-widest text-muted-foreground"
+            title="Times this card was retried after failure"
+          >
+            retry {card.retryCount}/{card.maxRetries}
+          </span>
+        ) : null}
+        {card.labels.map((l) => (
+          <span
+            key={l}
+            className="rounded border border-border bg-card px-1.5 py-px text-[10px] text-foreground"
+          >
+            {l}
+          </span>
+        ))}
+      </div>
 
       <div className="mt-2 flex items-center gap-2 text-[10px] text-muted-foreground">
         {familiar ? (
@@ -532,6 +543,13 @@ function CardItem({
               </select>
             </Mini>
           </div>
+          {card.lifecycleReason ? (
+            <p className="rounded border border-border bg-background px-2 py-1 text-[10px] text-muted-foreground">
+              <span className="uppercase tracking-widest text-[9px]">reason</span>{" "}
+              {card.lifecycleReason}
+            </p>
+          ) : null}
+          <LifecycleActions card={card} onChanged={onCardReplaced} />
           <div className="flex justify-end">
             <button
               onClick={() => {
@@ -547,6 +565,127 @@ function CardItem({
     </li>
   );
 }
+
+/** Live-updating "running 47m of 2h" badge — ticks once per minute. */
+function TimeoutBadge({
+  runningSince,
+  timeoutMs,
+}: {
+  runningSince: string | undefined;
+  timeoutMs: number | undefined;
+}) {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((n) => n + 1), 60_000);
+    return () => clearInterval(id);
+  }, []);
+  const text = formatTimeoutBadge(runningSince, timeoutMs, DEFAULT_TIMEOUT_MS);
+  if (!text) return null;
+  const elapsed = runningSince ? Date.now() - new Date(runningSince).getTime() : 0;
+  const limit = timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const overLimit = elapsed > limit;
+  return (
+    <span
+      title={overLimit ? "Running past timeout — needs attention" : text}
+      className={`rounded border px-1.5 py-px text-[10px] uppercase tracking-widest ${
+        overLimit
+          ? "border-rose-500/40 bg-rose-500/10 text-rose-200"
+          : "border-border bg-card text-muted-foreground"
+      }`}
+    >
+      {text}
+    </span>
+  );
+}
+
+/**
+ * Lifecycle transition buttons. Only renders moves valid from the current
+ * state so reviewers don't have to remember the machine in their head.
+ */
+function LifecycleActions({
+  card,
+  onChanged,
+}: {
+  card: Card;
+  onChanged: (card: Card) => void;
+}) {
+  const [busy, setBusy] = useState<CardLifecycle | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const moves = NEXT_MOVES[card.lifecycle];
+  if (!moves || moves.length === 0) return null;
+  const transition = async (to: CardLifecycle, retry?: boolean) => {
+    setBusy(to);
+    setError(null);
+    try {
+      const res = await fetch(`/api/board/${card.id}/lifecycle`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ to, retry }),
+      });
+      const json = await res.json();
+      if (!json.ok) {
+        setError(json.error ?? "transition failed");
+        return;
+      }
+      onChanged(json.card as Card);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "transition failed");
+    } finally {
+      setBusy(null);
+    }
+  };
+  return (
+    <div>
+      <div className="mb-1 text-[9px] uppercase tracking-widest text-muted-foreground">
+        Advance lifecycle
+      </div>
+      <div className="flex flex-wrap gap-1">
+        {moves.map((m) => (
+          <button
+            key={`${m.to}-${m.retry ? "retry" : "go"}`}
+            onClick={() => void transition(m.to, m.retry)}
+            disabled={busy !== null}
+            className="rounded border border-border bg-background px-2 py-0.5 text-[10px] uppercase tracking-widest text-foreground transition-colors hover:bg-muted disabled:opacity-50"
+          >
+            {busy === m.to ? "…" : m.label}
+          </button>
+        ))}
+      </div>
+      {error ? (
+        <p className="mt-1 text-[10px] text-rose-300">{error}</p>
+      ) : null}
+    </div>
+  );
+}
+
+type LifecycleMove = { to: CardLifecycle; label: string; retry?: boolean };
+const NEXT_MOVES: Record<CardLifecycle, LifecycleMove[]> = {
+  queued: [
+    { to: "dispatched", label: "dispatch" },
+    { to: "cancelled", label: "cancel" },
+  ],
+  dispatched: [
+    { to: "running", label: "running" },
+    { to: "failed", label: "fail" },
+    { to: "cancelled", label: "cancel" },
+  ],
+  running: [
+    { to: "review", label: "review" },
+    { to: "completed", label: "complete" },
+    { to: "failed", label: "fail" },
+    { to: "cancelled", label: "cancel" },
+  ],
+  review: [
+    { to: "completed", label: "complete" },
+    { to: "failed", label: "fail" },
+  ],
+  completed: [],
+  failed: [
+    { to: "queued", label: "retry", retry: true },
+    { to: "cancelled", label: "cancel" },
+  ],
+  cancelled: [{ to: "queued", label: "re-queue" }],
+};
 
 function Mini({ label, children }: { label: string; children: React.ReactNode }) {
   return (

--- a/src/components/ui/lifecycle-badge.tsx
+++ b/src/components/ui/lifecycle-badge.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import type { CardLifecycle } from "@/lib/cave-board-types";
+
+const LABEL: Record<CardLifecycle, string> = {
+  queued: "queued",
+  dispatched: "dispatched",
+  running: "running",
+  review: "review",
+  completed: "completed",
+  failed: "failed",
+  cancelled: "cancelled",
+};
+
+type Props = {
+  lifecycle: CardLifecycle;
+  needsHuman?: boolean;
+  className?: string;
+};
+
+export function LifecycleBadge({ lifecycle, needsHuman, className }: Props) {
+  return (
+    <span
+      className={`ui-lifecycle-badge${className ? ` ${className}` : ""}`}
+      data-lifecycle={lifecycle}
+      data-needs-human={needsHuman ? "true" : undefined}
+      title={needsHuman ? `${LABEL[lifecycle]} · needs human` : LABEL[lifecycle]}
+    >
+      {LABEL[lifecycle]}
+      {needsHuman ? <span className="ui-lifecycle-needs-human">needs human</span> : null}
+    </span>
+  );
+}
+
+/**
+ * Formats "running 47m of 2h" for the timeout badge. Returns null when the
+ * card isn't running, has no `runningSince`, or has no effective timeout.
+ */
+export function formatTimeoutBadge(
+  runningSince: string | undefined,
+  timeoutMs: number | undefined,
+  defaultTimeoutMs: number,
+): string | null {
+  if (!runningSince) return null;
+  const timeout = timeoutMs ?? defaultTimeoutMs;
+  if (!timeout || timeout <= 0) return null;
+  const elapsed = Date.now() - new Date(runningSince).getTime();
+  if (!Number.isFinite(elapsed) || elapsed < 0) return null;
+  return `running ${formatDuration(elapsed)} of ${formatDuration(timeout)}`;
+}
+
+function formatDuration(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 48) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}

--- a/src/lib/cave-board-types.ts
+++ b/src/lib/cave-board-types.ts
@@ -1,0 +1,47 @@
+export type CardStatus = "inbox" | "running" | "review";
+export type CardPriority = "low" | "medium" | "high" | "urgent";
+export type CardLifecycle =
+  | "queued"
+  | "dispatched"
+  | "running"
+  | "review"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export type Card = {
+  id: string;
+  title: string;
+  notes: string;
+  status: CardStatus;
+  priority: CardPriority;
+  familiarId: string | null;
+  sessionId: string | null;
+  labels: string[];
+  template?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  lifecycle: CardLifecycle;
+  lifecycleAt: string;
+  lifecycleReason?: string;
+  needsHuman?: boolean;
+  timeoutMs?: number;
+  runningSince?: string;
+  retryCount: number;
+  maxRetries: number;
+};
+
+export const STATUSES: CardStatus[] = ["inbox", "running", "review"];
+export const PRIORITIES: CardPriority[] = ["urgent", "high", "medium", "low"];
+export const LIFECYCLES: CardLifecycle[] = [
+  "queued",
+  "dispatched",
+  "running",
+  "review",
+  "completed",
+  "failed",
+  "cancelled",
+];
+
+export const DEFAULT_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2h
+export const DEFAULT_MAX_RETRIES = 2;

--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -2,27 +2,49 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { homedir } from "node:os";
 
+import {
+  DEFAULT_MAX_RETRIES,
+  type Card,
+  type CardLifecycle,
+  type CardPriority,
+  type CardStatus,
+} from "@/lib/cave-board-types";
+
+export {
+  DEFAULT_MAX_RETRIES,
+  DEFAULT_TIMEOUT_MS,
+  LIFECYCLES,
+  PRIORITIES,
+  STATUSES,
+  type Card,
+  type CardLifecycle,
+  type CardPriority,
+  type CardStatus,
+} from "@/lib/cave-board-types";
+
 const BOARD_PATH = path.join(homedir(), ".coven", "cave-board.json");
 
-export type CardStatus = "inbox" | "running" | "review";
-export type CardPriority = "low" | "medium" | "high" | "urgent";
+/**
+ * Old cards predate the lifecycle machine. Map their column `status` to the
+ * closest lifecycle state so visuals look sane the first time a user opens
+ * the Board after upgrading.
+ */
+function inferLifecycle(status: CardStatus): CardLifecycle {
+  if (status === "running") return "running";
+  if (status === "review") return "review";
+  return "queued";
+}
 
-export type Card = {
-  id: string;
-  title: string;
-  notes: string;
-  status: CardStatus;
-  priority: CardPriority;
-  familiarId: string | null;
-  sessionId: string | null;
-  labels: string[];
-  template?: string | null;
-  createdAt: string;
-  updatedAt: string;
-};
-
-export const STATUSES: CardStatus[] = ["inbox", "running", "review"];
-export const PRIORITIES: CardPriority[] = ["urgent", "high", "medium", "low"];
+function backfillCard(c: Card | (Omit<Card, "lifecycle" | "lifecycleAt" | "retryCount" | "maxRetries"> & Partial<Pick<Card, "lifecycle" | "lifecycleAt" | "retryCount" | "maxRetries">>)): Card {
+  const inferred = inferLifecycle(c.status);
+  return {
+    ...c,
+    lifecycle: c.lifecycle ?? inferred,
+    lifecycleAt: c.lifecycleAt ?? c.updatedAt,
+    retryCount: c.retryCount ?? 0,
+    maxRetries: c.maxRetries ?? DEFAULT_MAX_RETRIES,
+  } as Card;
+}
 
 type BoardFile = {
   version: number;
@@ -39,9 +61,10 @@ export async function loadBoard(): Promise<BoardFile> {
   try {
     const raw = await readFile(BOARD_PATH, "utf8");
     const parsed = JSON.parse(raw) as Partial<BoardFile>;
+    const rawCards = Array.isArray(parsed.cards) ? parsed.cards : [];
     return {
       version: parsed.version ?? 1,
-      cards: Array.isArray(parsed.cards) ? parsed.cards : [],
+      cards: rawCards.map((c) => backfillCard(c as Card)),
     };
   } catch {
     return EMPTY;
@@ -67,11 +90,12 @@ export type NewCardInput = {
 export async function createCard(input: NewCardInput): Promise<Card> {
   const board = await loadBoard();
   const now = new Date().toISOString();
+  const status: CardStatus = input.status ?? "inbox";
   const card: Card = {
     id: crypto.randomUUID(),
     title: input.title.trim(),
     notes: (input.notes ?? "").trim(),
-    status: input.status ?? "inbox",
+    status,
     priority: input.priority ?? "medium",
     familiarId: input.familiarId ?? null,
     sessionId: input.sessionId ?? null,
@@ -79,6 +103,10 @@ export async function createCard(input: NewCardInput): Promise<Card> {
     template: input.template ?? null,
     createdAt: now,
     updatedAt: now,
+    lifecycle: inferLifecycle(status),
+    lifecycleAt: now,
+    retryCount: 0,
+    maxRetries: DEFAULT_MAX_RETRIES,
   };
   board.cards.push(card);
   await saveBoard(board);
@@ -103,6 +131,89 @@ export async function updateCard(
       ? patch.labels.map((l) => l.trim()).filter(Boolean)
       : current.labels,
   };
+  board.cards[idx] = next;
+  await saveBoard(board);
+  return next;
+}
+
+/**
+ * Move a card through the lifecycle state machine. Encapsulates the rules
+ * we don't want call sites to forget — most importantly that `failed`
+ * without remaining retries auto-rolls the card back to the Inbox column
+ * with a `needs human` flag.
+ *
+ * Transitions enforced:
+ *   queued      → dispatched | cancelled
+ *   dispatched  → running | failed | cancelled
+ *   running     → review | completed | failed | cancelled
+ *   review      → completed | failed
+ *   completed   → (terminal)
+ *   failed      → queued (retry) | cancelled  (auto-rollback handles needsHuman)
+ *   cancelled   → queued
+ *
+ * `retry: true` on a failed→queued transition increments retryCount.
+ */
+const VALID_NEXT: Record<CardLifecycle, CardLifecycle[]> = {
+  queued: ["dispatched", "cancelled"],
+  dispatched: ["running", "failed", "cancelled"],
+  running: ["review", "completed", "failed", "cancelled"],
+  review: ["completed", "failed"],
+  completed: [],
+  failed: ["queued", "cancelled"],
+  cancelled: ["queued"],
+};
+
+export type TransitionInput = {
+  to: CardLifecycle;
+  reason?: string;
+  retry?: boolean;
+};
+
+export async function transitionCard(
+  id: string,
+  { to, reason, retry }: TransitionInput,
+): Promise<Card | null> {
+  const board = await loadBoard();
+  const idx = board.cards.findIndex((c) => c.id === id);
+  if (idx < 0) return null;
+  const current = board.cards[idx];
+  if (!VALID_NEXT[current.lifecycle]?.includes(to)) {
+    throw new Error(`invalid transition: ${current.lifecycle} → ${to}`);
+  }
+  const now = new Date().toISOString();
+  const next: Card = {
+    ...current,
+    lifecycle: to,
+    lifecycleAt: now,
+    lifecycleReason: reason ?? undefined,
+    updatedAt: now,
+  };
+
+  // Column-status fallouts of lifecycle transitions:
+  if (to === "running") {
+    next.status = "running";
+    next.runningSince = now;
+    next.needsHuman = false;
+  } else if (to === "review") {
+    next.status = "review";
+  } else if (to === "completed") {
+    next.status = "review"; // stay in Review column; lifecycle distinguishes
+  } else if (to === "failed") {
+    const exhausted = current.retryCount >= current.maxRetries;
+    if (exhausted) {
+      // Auto-rollback: failed without remaining retries → back to Inbox
+      // with `needs human` flag. Spec section 3 (rollback behavior).
+      next.status = "inbox";
+      next.needsHuman = true;
+    }
+  } else if (to === "queued" && retry) {
+    next.retryCount = current.retryCount + 1;
+    next.status = "inbox";
+    next.needsHuman = false;
+  } else if (to === "cancelled") {
+    next.needsHuman = false;
+  }
+
   board.cards[idx] = next;
   await saveBoard(board);
   return next;


### PR DESCRIPTION
Closes #18.

Adds a 7-state machine per card (\`queued → dispatched → running → review → completed\`, with \`failed\` and \`cancelled\` as off-paths), distinct from the 3-column board \`status\`. A \`failed\` card with no remaining retries auto-rolls back to the Inbox column with a \"needs human\" flag.

## What you'll see on each card

- **Lifecycle pill** — color-mapped (rose on \`failed\` / \`needs human\`, lavender on \`review\`, neutral elsewhere).
- **Timeout badge** — \"running 47m of 2h\" when \`running\`; flips rose once elapsed > timeout. Live-ticks once per minute.
- **Retry counter** — \"retry 1/2\" when the card has been retried.
- **Failure reason** — surfaced inline above the lifecycle actions.
- **Lifecycle actions** — small button row inside the expanded card, only renders moves valid from the current state.

## Files

- \`src/lib/cave-board-types.ts\` — pure types/constants (no node deps), so client components can import them safely.
- \`src/lib/cave-board.ts\` — \`transitionCard()\` with whitelist + auto-rollback rules.
- \`src/app/api/board/[id]/lifecycle/route.ts\` — POST endpoint; 409 on invalid transitions.
- \`src/components/ui/lifecycle-badge.tsx\` — primitive + \`formatTimeoutBadge()\`.
- \`src/components/board-view.tsx\` — badges, timeout tick, retry counter, failure reason, actions.

## Backward compatibility

Existing cards on disk are missing the new fields. \`loadBoard()\` runs each card through \`backfillCard\` which infers lifecycle from existing column status and zero-initializes retry counters. No write-back happens on read — old files stay untouched until a user-driven mutation.

## Deferred (followups, none block dogfood)

- Daemon-side hook to auto-transition card → \`failed\` when its linked session reports failure (pairs naturally with #16 Val's Inbox).
- Per-familiar timeout/retry config (constants for now; the per-card override fields are already on the model).
- Auto-monitor cron for cards running past timeout.

## Caught + fixed during dev

Client component cannot import a server-only module — \`board-view.tsx\` reaching into \`cave-board.ts\` for types pulled \`node:fs/promises\` into the browser bundle. Split types out to a pure file before the build would pass. Worth noting since it's a common Next 16 trap.

## Verification

- typecheck clean (\`tsc --noEmit\`)
- build clean (\`pnpm build\` — 3 pre-existing warnings in \`memory/route.ts\`, none introduced)

Co-authored-by: OpenCoven <noreply@opencoven.io>