### PR TITLE
fix(chat/send): extract assistant text from claude stream-json envelopes

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -237,6 +237,9 @@ export async function POST(req: Request) {
               session_id?: string;
               duration_ms?: number;
               is_error?: boolean;
+              message?: {
+                content?: Array<{ type?: string; text?: string }>;
+              };
             };
             if (ev.session_id && !sessionId) {
               sessionId = ev.session_id;
@@ -244,6 +247,16 @@ export async function POST(req: Request) {
             }
             if (ev.type === "result") {
               result = { duration_ms: ev.duration_ms, is_error: ev.is_error };
+            } else if (ev.type === "assistant" && ev.message?.content) {
+              // Claude stream-json wraps assistant text inside a message envelope.
+              // Extract every text chunk and surface it as an assistant_chunk so
+              // the chat bubble renders.
+              for (const block of ev.message.content) {
+                if (block.type === "text" && block.text) {
+                  assistantText += block.text;
+                  push({ kind: "assistant_chunk", text: block.text });
+                }
+              }
             }
             return;
           } catch {


### PR DESCRIPTION
## What this fixes

Claude's stream-json output wraps assistant text inside

\`\`\`json
{"type":"assistant","message":{"content":[{"type":"text","text":"..."}]}}
\`\`\`

The handleLine path recognised any JSON line, did `session_id` capture + `result` capture, then `return`ed — so it never surfaced the actual assistant text. The bubble stayed empty even when the harness produced real output, showing up as:

> _The "claude" harness completed but produced no output._

(This was the second half of the chat-broken story. The first half — coven not actually invoking claude with a useful stdin/argv combo — is fixed in OpenCoven/coven#153.)

## Fix

Walk `ev.message.content[]` and push each `type:"text"` block as an `assistant_chunk` event (the chat view already streams these).

## Verification

After both this and OpenCoven/coven#153 are deployed:

```
data: {"kind":"user","text":"reply with one word: ok"}
data: {"kind":"session","sessionId":"..."}
data: {"kind":"assistant_chunk","text":"ok"}
data: {"kind":"done","durationMs":2561,"isError":false,"sessionId":"..."}
```

Co-authored-by: OpenCoven <noreply@opencoven.io>