### PR TITLE
feat(shell): right-side AgentPanel — first-class chat pane (Phase 1/3)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -126,7 +126,8 @@ body {
    width and hand vertical layout to the inner aside/main. */
 .shell-nav-panel,
 .shell-list-panel,
-.shell-detail-panel {
+.shell-detail-panel,
+.shell-agent-panel {
   height: 100%;
   min-width: 0;
   overflow: hidden;
@@ -135,10 +136,19 @@ body {
 
 .shell-nav-panel > .shell-nav,
 .shell-list-panel > .shell-list,
-.shell-detail-panel > .shell-detail {
+.shell-detail-panel > .shell-detail,
+.shell-agent-panel > .shell-agent {
   flex: 1 1 auto;
   width: 100%;
   min-width: 0;
+}
+
+.shell-agent {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg-base);
+  overflow: hidden;
 }
 
 /* Separator — 1px hairline with a slightly wider hit area, lavender on

--- a/src/components/agent-panel.tsx
+++ b/src/components/agent-panel.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { forwardRef } from "react";
+import { ChatRouter, type ChatRouterHandle } from "@/components/chat-router";
+import type { Familiar, SessionRow } from "@/lib/types";
+
+type Props = {
+  familiar: Familiar | null;
+  sessions: SessionRow[];
+  daemonRunning: boolean;
+  onSessionStarted: () => void;
+  onSlashFromChat: (command: string, args: string) => boolean;
+  onOpenOnboarding: () => void;
+};
+
+// AgentPanel — always-visible right-side column hosting the active
+// familiar's live chat. Replaces the floating DockChat introduced in
+// PR #25; the chat is now a first-class Shell pane rather than an
+// overlay, so it survives mode switches (Board, Inbox, Plugins) and
+// stays in the same place.
+export const AgentPanel = forwardRef<ChatRouterHandle, Props>(function AgentPanel(
+  props,
+  ref,
+) {
+  if (!props.familiar) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center px-6 text-center text-[12px] text-[--text-muted]">
+        <p className="text-[--text-secondary]">Pick a familiar from the rail.</p>
+        <p className="mt-1">Their live chat lives here.</p>
+        <button
+          type="button"
+          onClick={props.onOpenOnboarding}
+          className="mt-4 rounded-md border border-[--border-hairline] bg-[--bg-raised] px-3 py-1 text-[11px] text-[--text-primary] hover:bg-[--bg-raised]/80"
+        >
+          Open setup
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-1 flex-col">
+      <ChatRouter
+        ref={ref}
+        familiar={props.familiar}
+        sessions={props.sessions}
+        daemonRunning={props.daemonRunning}
+        onSessionStarted={props.onSessionStarted}
+        onSlashFromChat={props.onSlashFromChat}
+        onOpenOnboarding={props.onOpenOnboarding}
+      />
+    </div>
+  );
+});

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -71,15 +71,19 @@ export function Shell({
   nav,
   list,
   detail,
+  agent,
   topBar,
 }: {
   nav: ReactNode;
   list?: ReactNode;
   detail: ReactNode;
+  /** Optional right-side agent pane (live chat with active familiar). */
+  agent?: ReactNode;
   topBar?: ReactNode;
 }) {
   const navRef = useRef<PanelImperativeHandle | null>(null);
   const listRef = useRef<PanelImperativeHandle | null>(null);
+  const agentRef = useRef<PanelImperativeHandle | null>(null);
   // Persisted widths come from localStorage on client only; render a
   // layout-free placeholder on server + first client paint to keep the
   // hydration tree matching, then mount the real Group.
@@ -87,8 +91,14 @@ export function Shell({
   useEffect(() => setMounted(true), []);
 
   const twoPane = !list;
-  const panelIds = twoPane ? ["nav", "detail"] : ["nav", "list", "detail"];
-  const groupId = twoPane ? `${SHELL_GROUP_ID}.two-pane` : SHELL_GROUP_ID;
+  const hasAgent = !!agent;
+  const panelIds: string[] = ["nav"];
+  if (!twoPane) panelIds.push("list");
+  panelIds.push("detail");
+  if (hasAgent) panelIds.push("agent");
+  const groupId =
+    (twoPane ? `${SHELL_GROUP_ID}.two-pane` : SHELL_GROUP_ID) +
+    (hasAgent ? ".agent" : "");
 
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
     id: groupId,
@@ -107,11 +117,14 @@ export function Shell({
       } else if (key === "\\" && !twoPane) {
         e.preventDefault();
         togglePanel(listRef.current);
+      } else if (key === "j" && hasAgent) {
+        e.preventDefault();
+        togglePanel(agentRef.current);
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [twoPane]);
+  }, [twoPane, hasAgent]);
 
   if (!mounted) {
     return (
@@ -164,6 +177,23 @@ export function Shell({
         <Panel id="detail" className="shell-detail-panel">
           <main className="shell-detail">{detail}</main>
         </Panel>
+        {hasAgent && (
+          <>
+            <Separator className="shell-separator" />
+            <Panel
+              id="agent"
+              className="shell-agent-panel"
+              defaultSize="380px"
+              minSize="300px"
+              maxSize="560px"
+              collapsible
+              collapsedSize={0}
+              panelRef={agentRef}
+            >
+              <aside className="shell-agent">{agent}</aside>
+            </Panel>
+          </>
+        )}
       </Group>
     </div>
   );

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -16,7 +16,7 @@ import { InboxToastStack, toastFromItem, type Toast } from "@/components/inbox-t
 import { FamiliarGlyphPicker } from "@/components/familiar-glyph-picker";
 import { Shell, ShellNav, ShellNavHeader, type ShellNavItem } from "@/components/shell";
 import { ChooserModal, type ChooserOption } from "@/components/ui/chooser-modal";
-import { DockChat } from "@/components/ui/dock-chat";
+import { AgentPanel } from "@/components/agent-panel";
 import { nativeNotify } from "@/lib/native-notify";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
@@ -696,6 +696,22 @@ export function Workspace() {
         }
         list={list}
         detail={detail}
+        agent={
+          mode === "chats" ? undefined : (
+            <AgentPanel
+              ref={routerRef}
+              familiar={active}
+              sessions={sessions}
+              daemonRunning={daemonRunning}
+              onSessionStarted={loadSessions}
+              onSlashFromChat={(command, args) => {
+                onPaletteIntent({ kind: "slash", command, args });
+                return true;
+              }}
+              onOpenOnboarding={openOnboarding}
+            />
+          )
+        }
       />
 
       <CommandPalette
@@ -780,12 +796,6 @@ export function Workspace() {
         }}
       />
 
-      <DockChat
-        onSubmit={() => {
-          setMode("chats");
-          setTimeout(() => routerRef.current?.newChat(), 0);
-        }}
-      />
     </>
   );
 }


### PR DESCRIPTION
First of three PRs delivering Val's layout ask: right-side agent panel + bottom terminal + browser pane (the latter two ported from \`BunsDev/comux/native/macos/comux-tauri\`).

## What this is

Replaces the floating **DockChat** overlay with a real Shell column. The active familiar's live chat now lives in a dedicated **right pane** that survives mode switches (Board, Inbox, Val's Inbox, Plugins), so you can be on the Board and still chat with Cody in the same place.

## Surface

- Shell gains an optional \`agent\` slot — 4th resizable column
- Defaults: **380px**, bounds **300–560px**, persists to \`localStorage\` under \`cave.shell.widths.v1.agent\`
- **⌘J** toggles the pane (sits beside ⌘B nav / ⌘\\ list)
- AgentPanel renders ChatRouter for the active familiar with an empty state when none is picked

## Notes / known limits

- Agent panel is **hidden in chats mode** (middle pane is already the chat there) to avoid rendering two ChatRouters at once. Cleanup of chats-mode middle (folding the list + view into the right column) is a small follow-up.
- DockChat removed from Workspace; the dock-chat component file is left in place in case anything else still references it. Safe to delete in a sweep PR.

## Phase 2 (next PR)

Bottom terminal — port \`comux-tauri\`'s \`portable-pty\` backend (\`pty_start/write/resize/stop/list\` + \`pty_data\`/\`pty_exit\` events) into \`coven-cave/src-tauri\`, plus an xterm.js component. Collapsible bottom split, ⌃\` toggle.

## Phase 3 (after #2)

Browser pane — port \`comux-tauri\`'s \`browser_navigate/set_bounds/hide/hide_all_except\` (real Chromium child WebviewWindow via \`tauri::webview::WebviewBuilder\`).

## Verification

- typecheck clean · \`pnpm build\` green · dev / serves 200
- Signed commit \`0ad06c1\` (ED25519)

Co-authored-by: OpenCoven <noreply@opencoven.io>