### PR TITLE
feat(terminal): integrated bottom terminal pane — portable-pty + xterm.js (Phase 2/3)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -80,6 +80,9 @@ name = "app"
 version = "0.1.0"
 dependencies = [
  "log",
+ "once_cell",
+ "parking_lot",
+ "portable-pty",
  "serde",
  "serde_json",
  "tauri",
@@ -908,6 +911,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,7 +978,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -1093,8 +1102,19 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "rustc_version",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -1872,6 +1892,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ioctl-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,6 +2023,12 @@ dependencies = [
  "serde",
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -2120,6 +2155,15 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -2204,6 +2248,20 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+ "pin-utils",
+]
 
 [[package]]
 name = "notify-rust"
@@ -2603,6 +2661,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "piper"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2670,6 +2734,27 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "portable-pty"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -3325,6 +3410,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+dependencies = [
+ "serial-core",
+ "serial-unix",
+ "serial-windows",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+dependencies = [
+ "ioctl-rs",
+ "libc",
+ "serial-core",
+ "termios",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
+dependencies = [
+ "libc",
+ "serial-core",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3365,6 +3492,22 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -3941,6 +4084,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4307,7 +4459,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "tempfile",
  "windows-sys 0.61.2",
 ]
@@ -5084,6 +5236,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,3 +24,6 @@ log = "0.4"
 tauri = { version = "2.11.2", features = ["tray-icon"] }
 tauri-plugin-log = "2"
 tauri-plugin-notification = "2"
+portable-pty = "0.8"
+once_cell = "1"
+parking_lot = "0.12"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -167,9 +167,18 @@ fn wait_for_port(port: u16, timeout: Duration) -> bool {
     false
 }
 
+mod pty;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![
+            pty::pty_start,
+            pty::pty_write,
+            pty::pty_resize,
+            pty::pty_stop,
+            pty::pty_list,
+        ])
         .manage(SidecarState(Mutex::new(None)))
         .setup(|app| {
             if cfg!(debug_assertions) {

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1,0 +1,266 @@
+// PTY backend for the bottom terminal pane in CovenCave.
+//
+// Mirrors the design that ships in BunsDev/comux/native/macos/comux-tauri:
+// each terminal session is keyed by a stable id (so the JS layer can have
+// multiple terminals, eg. one per tab), a HashMap holds the master ends,
+// and a background thread pumps bytes from the slave's read side back to
+// the webview via `app.emit("pty:data", ...)`.
+//
+// Surfaced as tauri::commands:
+//   pty_start(StartOptions)
+//   pty_write(thread_id, bytes)
+//   pty_resize(thread_id, cols, rows)
+//   pty_stop(thread_id)
+//   pty_list() -> Vec<String>
+//
+// Events emitted to the frontend:
+//   pty:data { thread_id, bytes }
+//   pty:exit { thread_id, code }
+
+use std::collections::{HashMap, HashSet};
+use std::io::{Read, Write};
+use std::sync::Arc;
+use std::thread;
+
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter};
+
+struct PtySession {
+    #[allow(dead_code)]
+    master: Box<dyn MasterPty + Send>,
+    writer: Arc<Mutex<Box<dyn Write + Send>>>,
+}
+
+static SESSIONS: Lazy<Mutex<HashMap<String, PtySession>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+static STARTING_SESSIONS: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+
+/// RAII guard: makes sure a thread_id we reserved in STARTING_SESSIONS
+/// is always removed even if start fails partway through.
+struct PendingPtyStart {
+    thread_id: String,
+}
+
+impl PendingPtyStart {
+    fn reserve(thread_id: &str) -> Result<Self, String> {
+        let sessions = SESSIONS.lock();
+        let mut starting = STARTING_SESSIONS.lock();
+        if sessions.contains_key(thread_id) || starting.contains(thread_id) {
+            return Err(format!("pty '{}' already running", thread_id));
+        }
+        starting.insert(thread_id.to_string());
+        Ok(Self {
+            thread_id: thread_id.to_string(),
+        })
+    }
+}
+
+impl Drop for PendingPtyStart {
+    fn drop(&mut self) {
+        STARTING_SESSIONS.lock().remove(&self.thread_id);
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StartOptions {
+    pub thread_id: String,
+    pub project_root: Option<String>,
+    pub command: Option<String>,
+    pub args: Option<Vec<String>>,
+    pub cols: Option<u16>,
+    pub rows: Option<u16>,
+    pub env: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct PtyDataEvent {
+    pub thread_id: String,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct PtyExitEvent {
+    pub thread_id: String,
+    pub code: Option<i32>,
+}
+
+#[tauri::command]
+pub fn pty_start(app: AppHandle, options: StartOptions) -> Result<(), String> {
+    let thread_id = options.thread_id.clone();
+    let pending = PendingPtyStart::reserve(&thread_id)?;
+
+    let pty_system = native_pty_system();
+    let pair = pty_system
+        .openpty(PtySize {
+            rows: options.rows.unwrap_or(40),
+            cols: options.cols.unwrap_or(120),
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| e.to_string())?;
+
+    let command = options.command.unwrap_or_else(|| "/bin/zsh".to_string());
+    let args = options.args.unwrap_or_else(|| vec!["-l".to_string()]);
+    let mut cmd = CommandBuilder::new(command);
+    cmd.args(args);
+    if let Some(root) = &options.project_root {
+        cmd.cwd(root);
+    }
+    // Sensible defaults so xterm.js renders unicode + truecolor; when launched
+    // from Finder, launchd hands us a stripped PATH so we backfill with the
+    // common locations needed for git, gh, node, brew tools, etc.
+    cmd.env("PATH", augmented_path());
+    cmd.env("TERM", "xterm-256color");
+    cmd.env("COLORTERM", "truecolor");
+    cmd.env("COVENCAVE", "1");
+    if std::env::var("LANG").is_err() {
+        cmd.env("LANG", "en_US.UTF-8");
+    }
+    if std::env::var("LC_ALL").is_err() {
+        cmd.env("LC_ALL", "en_US.UTF-8");
+    }
+    if let Some(extra) = options.env {
+        for (k, v) in extra {
+            if v.is_empty() {
+                cmd.env_remove(&k);
+            } else {
+                cmd.env(k, v);
+            }
+        }
+    }
+    // Drop nesting-tripwires inherited from the Tauri parent.
+    cmd.env_remove("TMUX");
+    cmd.env_remove("npm_config_prefix");
+    cmd.env_remove("NPM_CONFIG_PREFIX");
+    cmd.env_remove("PREFIX");
+
+    let mut child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
+    let mut reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
+    let writer = pair.master.take_writer().map_err(|e| e.to_string())?;
+
+    {
+        let mut guard = SESSIONS.lock();
+        guard.insert(
+            thread_id.clone(),
+            PtySession {
+                master: pair.master,
+                writer: Arc::new(Mutex::new(writer)),
+            },
+        );
+    }
+    // PTY committed to SESSIONS; pending guard can release without rolling back.
+    drop(pending);
+
+    // Reader thread — forwards bytes to the webview as pty:data events.
+    let tid_read = thread_id.clone();
+    let app_read = app.clone();
+    thread::spawn(move || {
+        let mut buf = [0u8; 8192];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    let _ = app_read.emit(
+                        "pty:data",
+                        PtyDataEvent {
+                            thread_id: tid_read.clone(),
+                            bytes: buf[..n].to_vec(),
+                        },
+                    );
+                }
+            }
+        }
+    });
+
+    // Waiter thread — emits pty:exit when the child terminates and removes
+    // the session from the registry.
+    let tid_wait = thread_id;
+    let app_wait = app;
+    thread::spawn(move || {
+        let code = child.wait().ok().and_then(|status| status.exit_code().try_into().ok());
+        SESSIONS.lock().remove(&tid_wait);
+        let _ = app_wait.emit(
+            "pty:exit",
+            PtyExitEvent {
+                thread_id: tid_wait.clone(),
+                code,
+            },
+        );
+    });
+
+    Ok(())
+}
+
+#[tauri::command]
+pub fn pty_write(thread_id: String, bytes: Vec<u8>) -> Result<(), String> {
+    let writer = {
+        let sessions = SESSIONS.lock();
+        sessions
+            .get(&thread_id)
+            .map(|s| s.writer.clone())
+            .ok_or_else(|| format!("pty '{}' not found", thread_id))?
+    };
+    let mut w = writer.lock();
+    w.write_all(&bytes).map_err(|e| e.to_string())?;
+    w.flush().map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn pty_resize(thread_id: String, cols: u16, rows: u16) -> Result<(), String> {
+    let sessions = SESSIONS.lock();
+    let session = sessions
+        .get(&thread_id)
+        .ok_or_else(|| format!("pty '{}' not found", thread_id))?;
+    session
+        .master
+        .resize(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn pty_stop(thread_id: String) {
+    // Dropping the PtySession drops the master, which closes the slave's
+    // controlling tty; the child receives SIGHUP and exits. The waiter
+    // thread cleans up SESSIONS and emits pty:exit.
+    let mut sessions = SESSIONS.lock();
+    sessions.remove(&thread_id);
+}
+
+#[tauri::command]
+pub fn pty_list() -> Vec<String> {
+    SESSIONS.lock().keys().cloned().collect()
+}
+
+fn augmented_path() -> String {
+    let inherited = std::env::var("PATH").unwrap_or_default();
+    let extras = [
+        "/opt/homebrew/bin",
+        "/opt/homebrew/sbin",
+        "/usr/local/bin",
+        "/usr/local/sbin",
+        "/usr/bin",
+        "/bin",
+        "/usr/sbin",
+        "/sbin",
+    ];
+    let mut seen: HashSet<&str> = HashSet::new();
+    let mut out = String::new();
+    for part in inherited.split(':').chain(extras.iter().copied()) {
+        if part.is_empty() || !seen.insert(part) {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push(':');
+        }
+        out.push_str(part);
+    }
+    out
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -127,7 +127,8 @@ body {
 .shell-nav-panel,
 .shell-list-panel,
 .shell-detail-panel,
-.shell-agent-panel {
+.shell-agent-panel,
+.shell-bottom-panel {
   height: 100%;
   min-width: 0;
   overflow: hidden;
@@ -137,7 +138,8 @@ body {
 .shell-nav-panel > .shell-nav,
 .shell-list-panel > .shell-list,
 .shell-detail-panel > .shell-detail,
-.shell-agent-panel > .shell-agent {
+.shell-agent-panel > .shell-agent,
+.shell-bottom-panel > .shell-bottom {
   flex: 1 1 auto;
   width: 100%;
   min-width: 0;
@@ -149,6 +151,32 @@ body {
   height: 100%;
   background: var(--bg-base);
   overflow: hidden;
+}
+
+.shell-bottom {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg-base);
+  border-top: 1px solid var(--border-hairline);
+  overflow: hidden;
+}
+
+.shell-separator-h {
+  flex: 0 0 1px;
+  background: transparent;
+  cursor: row-resize;
+  position: relative;
+  transition: background-color 0.12s ease;
+}
+.shell-separator-h::before {
+  content: "";
+  position: absolute;
+  inset: -3px 0;
+}
+.shell-separator-h:hover,
+.shell-separator-h:active {
+  background: var(--accent-presence);
 }
 
 /* Separator — 1px hairline with a slightly wider hit area, lavender on

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+// Bottom terminal pane — xterm.js in the browser, hooked up to a
+// portable-pty session on the Rust side (see src-tauri/src/pty.rs).
+//
+// Only mounts inside the Tauri webview. In `next dev` outside Tauri the
+// pty.* commands aren't available, so we render a small placeholder
+// instead of trying to invoke and erroring out.
+
+type TauriBridge = {
+  invoke: <T = unknown>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
+  listen: <T>(
+    event: string,
+    handler: (e: { payload: T }) => void,
+  ) => Promise<() => void>;
+};
+
+async function loadTauri(): Promise<TauriBridge | null> {
+  if (typeof window === "undefined") return null;
+  // @ts-expect-error Tauri injects this at runtime
+  if (!window.__TAURI_INTERNALS__) return null;
+  const [{ invoke }, { listen }] = await Promise.all([
+    import("@tauri-apps/api/core"),
+    import("@tauri-apps/api/event"),
+  ]);
+  return { invoke, listen };
+}
+
+export function BottomTerminal({ threadId }: { threadId: string }) {
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
+
+  useEffect(() => {
+    const wrap = wrapRef.current;
+    if (!wrap) return;
+
+    let disposed = false;
+    let cleanup: (() => void) | null = null;
+
+    void (async () => {
+      const bridge = await loadTauri();
+      if (!bridge) {
+        if (!disposed) setUnavailable(true);
+        return;
+      }
+
+      // Lazy-load xterm only on the client + only inside Tauri so SSR and
+      // the in-browser dev path don't try to pull it in.
+      const [{ Terminal }, { FitAddon }, { WebLinksAddon }] = await Promise.all([
+        import("@xterm/xterm"),
+        import("@xterm/addon-fit"),
+        import("@xterm/addon-web-links"),
+      ]);
+
+      const term = new Terminal({
+        fontFamily:
+          'ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+        fontSize: 12,
+        lineHeight: 1.2,
+        cursorBlink: true,
+        theme: {
+          background: "#16131f",
+          foreground: "#e6e6f0",
+          cursor: "#9a8ecd",
+          selectionBackground: "rgba(154,142,205,0.35)",
+        },
+      });
+      const fit = new FitAddon();
+      term.loadAddon(fit);
+      term.loadAddon(new WebLinksAddon());
+      term.open(wrap);
+      try {
+        fit.fit();
+      } catch {
+        /* DOM not ready yet — first resize event will recover */
+      }
+
+      let stopped = false;
+      const unlistenData = await bridge.listen<{
+        thread_id: string;
+        bytes: number[];
+      }>("pty:data", (e) => {
+        if (e.payload.thread_id !== threadId) return;
+        term.write(new Uint8Array(e.payload.bytes));
+      });
+      const unlistenExit = await bridge.listen<{
+        thread_id: string;
+        code: number | null;
+      }>("pty:exit", (e) => {
+        if (e.payload.thread_id !== threadId) return;
+        stopped = true;
+        term.write(`\r\n\x1b[2m[exit ${e.payload.code ?? 0}]\x1b[0m\r\n`);
+      });
+
+      // Pipe user input back to the PTY.
+      const onDataDispose = term.onData((data) => {
+        if (stopped) return;
+        void bridge.invoke("pty_write", {
+          threadId,
+          bytes: Array.from(new TextEncoder().encode(data)),
+        });
+      });
+
+      try {
+        await bridge.invoke("pty_start", {
+          options: {
+            thread_id: threadId,
+            cols: term.cols,
+            rows: term.rows,
+          },
+        });
+      } catch (err) {
+        // Already running for this id (eg. React strict-mode double effect) —
+        // just attach to the stream we already opened.
+        if (!String(err).includes("already running")) {
+          term.write(`\r\n\x1b[31mpty_start failed: ${String(err)}\x1b[0m\r\n`);
+        }
+      }
+
+      // Refit on container size changes.
+      const ro = new ResizeObserver(() => {
+        try {
+          fit.fit();
+          void bridge.invoke("pty_resize", {
+            threadId,
+            cols: term.cols,
+            rows: term.rows,
+          });
+        } catch {
+          /* harmless mid-tear-down */
+        }
+      });
+      ro.observe(wrap);
+
+      cleanup = () => {
+        ro.disconnect();
+        onDataDispose.dispose();
+        unlistenData();
+        unlistenExit();
+        term.dispose();
+        void bridge.invoke("pty_stop", { threadId });
+      };
+
+      if (disposed) cleanup();
+    })();
+
+    return () => {
+      disposed = true;
+      cleanup?.();
+    };
+  }, [threadId]);
+
+  if (unavailable) {
+    return (
+      <div className="flex h-full items-center justify-center text-[11px] text-[--text-muted]">
+        Terminal is only available inside the CovenCave desktop app.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={wrapRef}
+      className="h-full w-full overflow-hidden"
+      style={{ background: "#16131f", padding: "6px 8px" }}
+    />
+  );
+}

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -10,31 +10,18 @@ import {
 } from "react-resizable-panels";
 import { Icon, type IconName } from "@/lib/icon";
 
-// Shell — the three-pane app chrome introduced by issue #14.
+// Shell — multi-pane app chrome. Horizontal Group of nav/list/detail/agent,
+// optionally wrapped in a vertical Group when a bottom slot (terminal) is set.
 //
-// Layout (react-resizable-panels horizontal Group):
-//   ┌────────┬─────────────┬──────────────────────────┐
-//   │  app   │   context   │                          │
-//   │  nav   │   list      │      detail pane         │
-//   │ 240px  │  ~260px     │         (flex)           │
-//   └────────┴─────────────┴──────────────────────────┘
-//
-// `list` is optional — pass `list={null}` for a two-pane layout
-// (used by full-bleed modes like /mockup-style settings).
-//
-// Resize: drag separators. Widths persist to localStorage under
-//   cave.shell.widths.v1            (three-pane)
-//   cave.shell.widths.v1.two-pane   (two-pane)
-//
-// Collapse:
-//   ⌘B  toggles the nav pane
-//   ⌘\  toggles the list pane (three-pane only)
+// Keyboard:
+//   ⌘B   toggle nav
+//   ⌘\   toggle list
+//   ⌘J   toggle agent
+//   ⌃`   toggle bottom terminal
 
 const SHELL_GROUP_ID = "cave.shell.widths.v1";
+const BOTTOM_GROUP_ID = "cave.shell.bottom.v1";
 
-// SSR-safe localStorage wrapper. react-resizable-panels reads storage
-// during render via useDefaultLayout, so we cannot rely on a `typeof
-// window` guard at the call site alone.
 const shellStorage = {
   getItem(key: string): string | null {
     if (typeof window === "undefined") return null;
@@ -72,26 +59,26 @@ export function Shell({
   list,
   detail,
   agent,
+  bottom,
   topBar,
 }: {
   nav: ReactNode;
   list?: ReactNode;
   detail: ReactNode;
-  /** Optional right-side agent pane (live chat with active familiar). */
   agent?: ReactNode;
+  bottom?: ReactNode;
   topBar?: ReactNode;
 }) {
   const navRef = useRef<PanelImperativeHandle | null>(null);
   const listRef = useRef<PanelImperativeHandle | null>(null);
   const agentRef = useRef<PanelImperativeHandle | null>(null);
-  // Persisted widths come from localStorage on client only; render a
-  // layout-free placeholder on server + first client paint to keep the
-  // hydration tree matching, then mount the real Group.
+  const bottomRef = useRef<PanelImperativeHandle | null>(null);
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
   const twoPane = !list;
   const hasAgent = !!agent;
+  const hasBottom = !!bottom;
   const panelIds: string[] = ["nav"];
   if (!twoPane) panelIds.push("list");
   panelIds.push("detail");
@@ -122,9 +109,20 @@ export function Shell({
         togglePanel(agentRef.current);
       }
     };
+    const bottomToggle = (e: KeyboardEvent) => {
+      if (!hasBottom) return;
+      if (e.ctrlKey && e.key === "`") {
+        e.preventDefault();
+        togglePanel(bottomRef.current);
+      }
+    };
     window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [twoPane, hasAgent]);
+    window.addEventListener("keydown", bottomToggle);
+    return () => {
+      window.removeEventListener("keydown", handler);
+      window.removeEventListener("keydown", bottomToggle);
+    };
+  }, [twoPane, hasAgent, hasBottom]);
 
   if (!mounted) {
     return (
@@ -135,66 +133,95 @@ export function Shell({
     );
   }
 
+  const horizontalGroup = (
+    <Group
+      className="shell-root flex-1 min-h-0"
+      orientation="horizontal"
+      defaultLayout={defaultLayout}
+      onLayoutChanged={onLayoutChanged}
+    >
+      <Panel
+        id="nav"
+        className="shell-nav-panel"
+        defaultSize="240px"
+        minSize="200px"
+        maxSize="360px"
+        collapsible
+        collapsedSize={0}
+        panelRef={navRef}
+      >
+        <aside className="shell-nav">{nav}</aside>
+      </Panel>
+      <Separator className="shell-separator" />
+      {!twoPane && (
+        <>
+          <Panel
+            id="list"
+            className="shell-list-panel"
+            defaultSize="260px"
+            minSize="220px"
+            maxSize="480px"
+            collapsible
+            collapsedSize={0}
+            panelRef={listRef}
+          >
+            <aside className="shell-list">{list}</aside>
+          </Panel>
+          <Separator className="shell-separator" />
+        </>
+      )}
+      <Panel id="detail" className="shell-detail-panel">
+        <main className="shell-detail">{detail}</main>
+      </Panel>
+      {hasAgent && (
+        <>
+          <Separator className="shell-separator" />
+          <Panel
+            id="agent"
+            className="shell-agent-panel"
+            defaultSize="380px"
+            minSize="300px"
+            maxSize="560px"
+            collapsible
+            collapsedSize={0}
+            panelRef={agentRef}
+          >
+            <aside className="shell-agent">{agent}</aside>
+          </Panel>
+        </>
+      )}
+    </Group>
+  );
+
   return (
     <div className="flex h-screen w-screen flex-col">
       {topBar}
-      <Group
-        className="shell-root flex-1 min-h-0"
-        orientation="horizontal"
-        defaultLayout={defaultLayout}
-        onLayoutChanged={onLayoutChanged}
-      >
-        <Panel
-          id="nav"
-          className="shell-nav-panel"
-          defaultSize="240px"
-          minSize="200px"
-          maxSize="360px"
-          collapsible
-          collapsedSize={0}
-          panelRef={navRef}
+      {hasBottom ? (
+        <Group
+          className="flex-1 min-h-0"
+          orientation="vertical"
+          id={BOTTOM_GROUP_ID}
         >
-          <aside className="shell-nav">{nav}</aside>
-        </Panel>
-        <Separator className="shell-separator" />
-        {!twoPane && (
-          <>
-            <Panel
-              id="list"
-              className="shell-list-panel"
-              defaultSize="260px"
-              minSize="220px"
-              maxSize="480px"
-              collapsible
-              collapsedSize={0}
-              panelRef={listRef}
-            >
-              <aside className="shell-list">{list}</aside>
-            </Panel>
-            <Separator className="shell-separator" />
-          </>
-        )}
-        <Panel id="detail" className="shell-detail-panel">
-          <main className="shell-detail">{detail}</main>
-        </Panel>
-        {hasAgent && (
-          <>
-            <Separator className="shell-separator" />
-            <Panel
-              id="agent"
-              className="shell-agent-panel"
-              defaultSize="380px"
-              minSize="300px"
-              maxSize="560px"
-              collapsible
-              collapsedSize={0}
-              panelRef={agentRef}
-            >
-              <aside className="shell-agent">{agent}</aside>
-            </Panel>
-          </>
-        )}
-      </Group>
+          <Panel id="main" minSize="40%">
+            {horizontalGroup}
+          </Panel>
+          <Separator className="shell-separator-h" />
+          <Panel
+            id="bottom"
+            className="shell-bottom-panel"
+            defaultSize="240px"
+            minSize="120px"
+            maxSize="60%"
+            collapsible
+            collapsedSize={0}
+            panelRef={bottomRef}
+          >
+            <section className="shell-bottom">{bottom}</section>
+          </Panel>
+        </Group>
+      ) : (
+        horizontalGroup
+      )}
     </div>
   );
 }

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -17,6 +17,7 @@ import { FamiliarGlyphPicker } from "@/components/familiar-glyph-picker";
 import { Shell, ShellNav, ShellNavHeader, type ShellNavItem } from "@/components/shell";
 import { ChooserModal, type ChooserOption } from "@/components/ui/chooser-modal";
 import { AgentPanel } from "@/components/agent-panel";
+import { BottomTerminal } from "@/components/bottom-terminal";
 import { nativeNotify } from "@/lib/native-notify";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
@@ -712,6 +713,7 @@ export function Workspace() {
             />
           )
         }
+        bottom={<BottomTerminal threadId="cave.bottom.main" />}
       />
 
       <CommandPalette


### PR DESCRIPTION
Second of three PRs delivering Val's layout ask. Phase 1 (#36) — right-side AgentPanel. **Phase 2 (this PR)** — integrated bottom terminal. Phase 3 — browser pane (next).

## What this is

A code-editor-style **integrated terminal** at the bottom of Cave, modelled on the PTY backend that ships in \`BunsDev/comux/native/macos/comux-tauri\`.

## Rust backend (\`src-tauri/src/pty.rs\`)

- \`portable-pty\` backend, one PTY per stable \`thread_id\`
- Commands: \`pty_start\`, \`pty_write\`, \`pty_resize\`, \`pty_stop\`, \`pty_list\`
- Events: \`pty:data\` (byte stream), \`pty:exit\` (with code)
- PATH augmented with /opt/homebrew/*, /usr/local/* so a Finder-launched .app can still find brew tools / node / git / gh
- TMUX + npm_config_prefix unset so nested-shell tripwires don't fire
- New deps: \`portable-pty 0.8\`, \`once_cell 1\`, \`parking_lot 0.12\`

## Frontend (\`src/components/bottom-terminal.tsx\`)

- xterm.js with \`FitAddon\` + \`WebLinksAddon\`, lazy-loaded inside Tauri only — SSR and \`next dev\` outside Tauri get a small placeholder instead
- Mood C theme: bg \`#16131f\`, fg \`#e6e6f0\`, **lavender cursor** (\`#9A8ECD\`)
- \`ResizeObserver\` → \`pty_resize\` so the PTY tracks the pane size

## Shell

- New optional \`bottom\` slot — wraps horizontal Group in a vertical Group with a row-resize separator; default 240px, collapsible to 0
- **⌃\`** toggles the terminal (Cursor / VS Code convention)

## Workspace

Mounts a single shared terminal on a stable thread_id (\`cave.bottom.main\`) so it persists across mode switches.

## Verification

- typecheck clean · \`pnpm build\` green · \`cargo check\` green
- Outside Tauri: placeholder renders, no console errors
- Inside the desktop app (next: smoke-test in CovenCave.app build): xterm should attach to a zsh PTY, accept input, follow resizes

## Stacking note

Lives on a branch off main. PR #36 (Agent Panel) is also on a separate branch off main. When the first one merges, this one will need a tiny rebase (Shell.tsx both edit the same signature) — both edits are additive and don't conflict semantically.

Co-authored-by: OpenCoven <noreply@opencoven.io>