### PR TITLE
feat(browser): embedded browser pane via Tauri child WebviewBuilder (Phase 3/3)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri-build = { version = "2.6.2", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-tauri = { version = "2.11.2", features = ["tray-icon"] }
+tauri = { version = "2.11.2", features = ["tray-icon", "unstable"] }
 tauri-plugin-log = "2"
 tauri-plugin-notification = "2"
 portable-pty = "0.8"

--- a/src-tauri/src/browser.rs
+++ b/src-tauri/src/browser.rs
@@ -1,0 +1,185 @@
+// Embedded browser pane for CovenCave.
+//
+// Ports the design from BunsDev/comux/native/macos/comux-tauri: a real
+// Chromium child webview is added to the main window via
+// `tauri::webview::WebviewBuilder`, positioned with viewport-relative
+// LogicalPosition/LogicalSize. The frontend keeps the webview's bounds
+// in sync with a placeholder <div> via ResizeObserver +
+// getBoundingClientRect, calling browser_set_bounds whenever its layout
+// changes.
+//
+// Commands:
+//   browser_navigate(label, url, x, y, w, h)
+//   browser_set_bounds(label, x, y, w, h)
+//   browser_hide(label)
+//   browser_hide_all_except(label)
+//   browser_close(label)
+//
+// Events:
+//   browser:page-load { label, url, phase: "started" | "finished" }
+
+use serde::Serialize;
+use tauri::webview::{PageLoadEvent, WebviewBuilder};
+use tauri::{AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, Url, WebviewUrl};
+
+const BROWSER_LABEL_PREFIX: &str = "cave-browser-";
+const OFFSCREEN_X: f64 = -10000.0;
+const OFFSCREEN_Y: f64 = -10000.0;
+
+fn safe_browser_label(label: Option<String>) -> String {
+    let raw = label.unwrap_or_else(|| "default".to_string());
+    let safe: String = raw
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .take(64)
+        .collect();
+    format!(
+        "{}{}",
+        BROWSER_LABEL_PREFIX,
+        if safe.is_empty() { "default" } else { &safe }
+    )
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct BrowserPageLoadEvent {
+    label: String,
+    url: String,
+    phase: String,
+}
+
+fn ensure_browser(
+    app: &AppHandle,
+    label: &str,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    url: &str,
+) -> Result<bool, String> {
+    if app.webviews().keys().any(|existing| existing == label) {
+        return Ok(false);
+    }
+
+    let main = app
+        .get_window("main")
+        .ok_or_else(|| "main window missing".to_string())?;
+
+    let parsed_url = Url::parse(url).map_err(|e| e.to_string())?;
+    let browser_label = label.to_string();
+    let app_for_load = app.clone();
+    let builder = WebviewBuilder::new(label, WebviewUrl::External(parsed_url)).on_page_load(
+        move |_webview, payload| {
+            let phase = match payload.event() {
+                PageLoadEvent::Started => "started",
+                PageLoadEvent::Finished => "finished",
+            };
+            let _ = app_for_load.emit(
+                "browser:page-load",
+                BrowserPageLoadEvent {
+                    label: browser_label.clone(),
+                    url: payload.url().to_string(),
+                    phase: phase.to_string(),
+                },
+            );
+        },
+    );
+
+    main.add_child(
+        builder,
+        LogicalPosition::new(x, y),
+        LogicalSize::new(w.max(1.0), h.max(1.0)),
+    )
+    .map_err(|e| e.to_string())?;
+
+    Ok(true)
+}
+
+fn hide_webview(webview: &tauri::Webview) -> Result<(), String> {
+    webview
+        .set_position(LogicalPosition::new(OFFSCREEN_X, OFFSCREEN_Y))
+        .map_err(|e| e.to_string())?;
+    webview
+        .set_size(LogicalSize::new(1.0, 1.0))
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn browser_navigate(
+    app: AppHandle,
+    label: Option<String>,
+    url: String,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+) -> Result<(), String> {
+    let label = safe_browser_label(label);
+    let created = ensure_browser(&app, &label, x, y, w, h, &url)?;
+    if !created {
+        let webview = app
+            .get_webview(&label)
+            .ok_or_else(|| "browser webview missing".to_string())?;
+        webview
+            .set_position(LogicalPosition::new(x, y))
+            .map_err(|e| e.to_string())?;
+        webview
+            .set_size(LogicalSize::new(w.max(1.0), h.max(1.0)))
+            .map_err(|e| e.to_string())?;
+        let parsed_url = Url::parse(&url).map_err(|e| e.to_string())?;
+        webview.navigate(parsed_url).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn browser_set_bounds(
+    app: AppHandle,
+    label: Option<String>,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+) -> Result<(), String> {
+    let label = safe_browser_label(label);
+    if let Some(webview) = app.get_webview(&label) {
+        webview
+            .set_position(LogicalPosition::new(x, y))
+            .map_err(|e| e.to_string())?;
+        webview
+            .set_size(LogicalSize::new(w.max(1.0), h.max(1.0)))
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn browser_hide(app: AppHandle, label: Option<String>) -> Result<(), String> {
+    let label = safe_browser_label(label);
+    if let Some(webview) = app.get_webview(&label) {
+        hide_webview(&webview)?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn browser_hide_all_except(app: AppHandle, label: Option<String>) -> Result<(), String> {
+    let keep = label.map(|raw| safe_browser_label(Some(raw)));
+    for (existing_label, webview) in app.webviews() {
+        if existing_label.starts_with(BROWSER_LABEL_PREFIX)
+            && Some(existing_label.clone()) != keep
+        {
+            hide_webview(&webview)?;
+        }
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn browser_close(app: AppHandle, label: Option<String>) -> Result<(), String> {
+    let label = safe_browser_label(label);
+    if let Some(webview) = app.get_webview(&label) {
+        webview.close().map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -167,6 +167,7 @@ fn wait_for_port(port: u16, timeout: Duration) -> bool {
     false
 }
 
+mod browser;
 mod pty;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -178,6 +179,11 @@ pub fn run() {
             pty::pty_resize,
             pty::pty_stop,
             pty::pty_list,
+            browser::browser_navigate,
+            browser::browser_set_bounds,
+            browser::browser_hide,
+            browser::browser_hide_all_except,
+            browser::browser_close,
         ])
         .manage(SidecarState(Mutex::new(None)))
         .setup(|app| {

--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Icon } from "@/lib/icon";
+
+// Browser pane — uses Tauri's child WebviewBuilder under the hood. A real
+// Chromium webview is overlaid on top of the placeholder <div> below; we
+// track the div's viewport-relative bounds with a ResizeObserver and call
+// `browser_set_bounds` so the overlay stays aligned during resize, scroll,
+// or layout changes.
+//
+// In `next dev` outside Tauri there's no webview — we render a small note.
+
+type TauriBridge = {
+  invoke: <T = unknown>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
+};
+
+async function loadTauri(): Promise<TauriBridge | null> {
+  if (typeof window === "undefined") return null;
+  // @ts-expect-error Tauri runtime
+  if (!window.__TAURI_INTERNALS__) return null;
+  const { invoke } = await import("@tauri-apps/api/core");
+  return { invoke };
+}
+
+const DEFAULT_URL = "https://covenmeow.com";
+
+export function BrowserPane({ label = "default" }: { label?: string }) {
+  const surfaceRef = useRef<HTMLDivElement | null>(null);
+  const [url, setUrl] = useState<string>(DEFAULT_URL);
+  const [pendingUrl, setPendingUrl] = useState<string>(DEFAULT_URL);
+  const [bridge, setBridge] = useState<TauriBridge | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
+
+  // One-time: pull in the Tauri bridge if we're inside the app.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const b = await loadTauri();
+      if (cancelled) return;
+      if (!b) setUnavailable(true);
+      else setBridge(b);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Keep the native webview's bounds in sync with the placeholder div.
+  // Run on every layout: ResizeObserver on the div, plus window resize +
+  // scroll on the whole document (the parent app can resize panes).
+  useEffect(() => {
+    if (!bridge) return;
+    const surface = surfaceRef.current;
+    if (!surface) return;
+
+    let raf = 0;
+    const sync = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        const rect = surface.getBoundingClientRect();
+        void bridge.invoke("browser_set_bounds", {
+          label,
+          x: rect.left,
+          y: rect.top,
+          w: rect.width,
+          h: rect.height,
+        });
+      });
+    };
+
+    sync();
+    const ro = new ResizeObserver(sync);
+    ro.observe(surface);
+    window.addEventListener("resize", sync);
+    window.addEventListener("scroll", sync, true);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+      window.removeEventListener("resize", sync);
+      window.removeEventListener("scroll", sync, true);
+      void bridge.invoke("browser_hide", { label });
+    };
+  }, [bridge, label]);
+
+  // First navigation when the bridge becomes available; subsequent ones via go().
+  useEffect(() => {
+    if (!bridge) return;
+    const surface = surfaceRef.current;
+    if (!surface) return;
+    const rect = surface.getBoundingClientRect();
+    void bridge.invoke("browser_navigate", {
+      label,
+      url,
+      x: rect.left,
+      y: rect.top,
+      w: rect.width,
+      h: rect.height,
+    });
+  }, [bridge, label, url]);
+
+  const go = (raw: string) => {
+    const trimmed = raw.trim();
+    if (!trimmed) return;
+    let next = trimmed;
+    if (!/^https?:\/\//i.test(next)) {
+      next = `https://${next}`;
+    }
+    setUrl(next);
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-[--bg-base]">
+      <header className="flex items-center gap-2 border-b border-[--border-hairline] bg-[--bg-raised]/40 px-3 py-1.5">
+        <button
+          type="button"
+          onClick={() => bridge && go(url)}
+          className="grid h-6 w-6 place-items-center rounded text-[--text-secondary] hover:bg-[--bg-raised] hover:text-[--text-primary]"
+          title="Reload"
+          aria-label="Reload"
+        >
+          <Icon name="ph:arrows-clockwise-bold" width={12} />
+        </button>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            go(pendingUrl);
+          }}
+          className="flex-1"
+        >
+          <input
+            type="text"
+            value={pendingUrl}
+            onChange={(e) => setPendingUrl(e.target.value)}
+            placeholder="Address"
+            className="w-full rounded-md border border-[--border-hairline] bg-[--bg-raised]/40 px-2 py-1 text-[12px] text-[--text-primary] outline-none focus:border-[--accent-presence]"
+          />
+        </form>
+      </header>
+      <div className="relative flex-1 overflow-hidden">
+        {unavailable ? (
+          <div className="flex h-full items-center justify-center text-[11px] text-[--text-muted]">
+            Browser is only available inside the CovenCave desktop app.
+          </div>
+        ) : (
+          <div ref={surfaceRef} className="absolute inset-0" />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/daemon-bar.tsx
+++ b/src/components/daemon-bar.tsx
@@ -7,7 +7,7 @@ import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 import { NotificationBell } from "@/components/notification-bell";
 import { HealthStrip } from "@/components/health-strip";
 
-export type Mode = "chats" | "board" | "inbox" | "plugins" | "vals-inbox";
+export type Mode = "chats" | "board" | "inbox" | "plugins" | "vals-inbox" | "browser";
 
 type Props = {
   mode: Mode;
@@ -28,6 +28,7 @@ const MODE_LABEL: Record<Mode, string> = {
   inbox: "Inbox",
   plugins: "Plugins",
   "vals-inbox": "Val's Inbox",
+  browser: "Browser",
 };
 
 export function DaemonBar({

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -18,13 +18,14 @@ import { Shell, ShellNav, ShellNavHeader, type ShellNavItem } from "@/components
 import { ChooserModal, type ChooserOption } from "@/components/ui/chooser-modal";
 import { AgentPanel } from "@/components/agent-panel";
 import { BottomTerminal } from "@/components/bottom-terminal";
+import { BrowserPane } from "@/components/browser-pane";
 import { nativeNotify } from "@/lib/native-notify";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { DEMO_MODE, DEMO_FAMILIARS } from "@/lib/demo-seed";
 
-type Mode = "chats" | "board" | "plugins" | "inbox" | "vals-inbox";
+type Mode = "chats" | "board" | "plugins" | "inbox" | "vals-inbox" | "browser";
 
 export function Workspace() {
   const routerRef = useRef<ChatRouterHandle | null>(null);
@@ -570,6 +571,13 @@ export function Workspace() {
           active: mode === "plugins",
           onClick: () => setMode("plugins"),
         },
+        {
+          id: "browser",
+          label: "Browser",
+          icon: "ph:globe" as const,
+          active: mode === "browser",
+          onClick: () => setMode("browser"),
+        },
       ] as ShellNavItem[],
     },
     {
@@ -661,6 +669,8 @@ export function Workspace() {
           }
         }}
       />
+    ) : mode === "browser" ? (
+      <BrowserPane label="default" />
     ) : (
       <PluginsView
         onOpenChat={() => {


### PR DESCRIPTION
Third and final layout PR. Phase 1 (#36) Agent Panel · Phase 2 (#37) Bottom Terminal · **Phase 3 (this PR) — Embedded browser pane**, ported from \`BunsDev/comux/native/macos/comux-tauri\`.

**Stacking note:** this branch sits on top of #36's commit (the AgentPanel work), so the PR diff currently shows both commits. Once #36 merges to main, this PR's diff naturally shrinks to just the browser work (commit \`60ffa7c\`). Review commit-by-commit if you want pure Phase 3.

## What this is

A real **Chromium** browser pane embedded inside Cave, addressable as the **Browser** mode in the Workspace nav.

## Rust (\`src-tauri/src/browser.rs\`)

- Commands: \`browser_navigate\`, \`browser_set_bounds\`, \`browser_hide\`, \`browser_hide_all_except\`, \`browser_close\`
- Each pane is a child Webview on the main window, labelled \`cave-browser-<id>\` so multiple instances can coexist
- Emits \`browser:page-load { label, url, phase }\`
- **Needs the tauri \`unstable\` feature** for child-webview APIs (\`WebviewBuilder\`, \`get_webview\`, \`webviews\`, \`get_window\`, \`add_child\`). Comux uses the same toggle for the same reason — sub-webviews are still gated in Tauri 2.x.

## Frontend (\`src/components/browser-pane.tsx\`)

- Placeholder \`<div>\` measured with \`getBoundingClientRect\`
- On every \`ResizeObserver\` tick / window resize / scroll → re-call \`browser_set_bounds\` so the Chromium overlay stays glued to the slot during pane drags
- URL bar with reload, auto-https for bare hostnames
- Falls back to "Browser is only available inside the CovenCave desktop app" outside Tauri

## Workspace

- New "Browser" entry in the nav (\`ph:globe\`)
- New mode \`browser\` rendered in the detail pane
- DaemonBar Mode union extended to include \`browser\`

Default landing: \`https://covenmeow.com\` — swap as needed.

## Verification

- typecheck clean · \`pnpm build\` green · \`cargo check\` green
- Smoke-test inside the desktop app pending the next \`tauri dev\` / packaged build

Co-authored-by: OpenCoven <noreply@opencoven.io>