### PR TITLE
fix(aesthetic): tone down border opacity to match Mood C mockup (5%/8%)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,9 +34,9 @@
   --muted-foreground: oklch(0.705 0.015 286.067);
   --accent: oklch(0.274 0.006 286.033);
   --accent-foreground: oklch(0.985 0 0);
-  --border: oklch(1 0 0 / 10%);
-  --border-strong: oklch(1 0 0 / 18%);
-  --input: oklch(1 0 0 / 15%);
+  --border: oklch(1 0 0 / 5%);
+  --border-strong: oklch(1 0 0 / 8%);
+  --input: oklch(1 0 0 / 10%);
   --ring: oklch(0.552 0.016 285.938);
 
   /* ---- Coven brand ----


### PR DESCRIPTION
## Problem

Val reported aggressive white borders everywhere in the live Cave. Inspecting the rendered DOM showed everything using `var(--border-hairline)` resolving to **`oklch(1 0 0 / 10%)`** — roughly **2× the mockup's intended value**.

## Diff vs mockup

| Token | Live (before) | Mockup ground truth | This PR |
|---|---|---|---|
| `--border` | `oklch(1 0 0 / 10%)` | `rgba(255,255,255,0.05)` | `oklch(1 0 0 / 5%)` |
| `--border-strong` | `oklch(1 0 0 / 18%)` | `rgba(255,255,255,0.08)` | `oklch(1 0 0 / 8%)` |
| `--input` | `oklch(1 0 0 / 15%)` | (n/a — derived) | `oklch(1 0 0 / 10%)` |

Source: `mockups/cave-moods/index.html` line ~~CSS root~~ block.

## Effect

Hairlines now read as the intended subtle dark-glassmorphism edges instead of harsh white outlines, matching the locked Mood C foundation (#14 / merged via #23). No component code changes — pure token correction.

## Urgency

Demo prep for Weekly Open Coven tonight. Hot-reload picks this up immediately on `localhost:3000`.