### PR TITLE
feat(demo): seed live data + polish for Open Coven

### DIFF
--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
+import { DEMO_MODE, DEMO_BOARD_CARDS } from "@/lib/demo-seed";
 import { NewCardModal, type NewCardDraft } from "@/components/new-card-modal";
 import { Icon } from "@/lib/icon";
 import { TemplateCardGrid } from "@/components/ui/template-card-grid";
@@ -56,13 +57,16 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
       const res = await fetch("/api/board", { cache: "no-store" });
       const json = await res.json();
       if (json.ok) {
-        setCards(json.cards ?? []);
+        const loaded = json.cards as import("@/lib/cave-board-types").Card[];
+        setCards(DEMO_MODE && loaded.length === 0 ? DEMO_BOARD_CARDS : loaded);
         setError(null);
       } else {
-        setError(json.error ?? "load failed");
+        setCards(DEMO_MODE ? DEMO_BOARD_CARDS : []);
+        setError(DEMO_MODE ? null : (json.error ?? "load failed"));
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "load failed");
+      setCards(DEMO_MODE ? DEMO_BOARD_CARDS : []);
+      setError(DEMO_MODE ? null : (err instanceof Error ? err.message : "load failed"));
     }
   }, []);
 

--- a/src/components/vals-inbox-view.tsx
+++ b/src/components/vals-inbox-view.tsx
@@ -12,6 +12,7 @@ import {
   type SnoozePresetId,
   sortEscalations,
 } from "@/lib/vals-inbox-types";
+import { DEMO_MODE, DEMO_ESCALATIONS } from "@/lib/demo-seed";
 
 type Props = {
   onOpenSource?: (item: Escalation) => void;
@@ -71,13 +72,17 @@ export function ValsInboxView({ onOpenSource }: Props) {
       const res = await fetch("/api/vals-inbox", { cache: "no-store" });
       const json = await res.json();
       if (json.ok) {
-        setItems(json.items as Escalation[]);
+        const loaded = json.items as Escalation[];
+        // In demo mode, seed with demo items if the inbox is empty.
+        setItems(DEMO_MODE && loaded.length === 0 ? DEMO_ESCALATIONS : loaded);
         setError(null);
       } else {
-        setError(json.error ?? "load failed");
+        setItems(DEMO_MODE ? DEMO_ESCALATIONS : []);
+        setError(DEMO_MODE ? null : (json.error ?? "load failed"));
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "load failed");
+      setItems(DEMO_MODE ? DEMO_ESCALATIONS : []);
+      setError(DEMO_MODE ? null : (err instanceof Error ? err.message : "load failed"));
     }
   }, []);
 

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -21,6 +21,7 @@ import { nativeNotify } from "@/lib/native-notify";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 import type { Familiar, SessionRow } from "@/lib/types";
+import { DEMO_MODE, DEMO_FAMILIARS } from "@/lib/demo-seed";
 
 type Mode = "chats" | "board" | "plugins" | "inbox" | "vals-inbox";
 
@@ -57,17 +58,25 @@ export function Workspace() {
       const res = await fetch("/api/familiars", { cache: "no-store" });
       const json = await res.json();
       if (!json.ok) {
-        setFamiliars([]);
-        setFamiliarsError(json.error ?? "daemon offline");
+        const fallback = DEMO_MODE ? DEMO_FAMILIARS : [];
+        setFamiliars(fallback);
+        setFamiliarsError(DEMO_MODE ? null : (json.error ?? "daemon offline"));
+        if (DEMO_MODE) setActiveId((curr) => curr ?? fallback[0]?.id ?? null);
         return;
       }
       setFamiliarsError(null);
       const list = (json.familiars ?? []) as Familiar[];
-      setFamiliars(list);
-      setActiveId((curr) => curr ?? list[0]?.id ?? null);
+      // In demo mode, merge demo familiars for any ids not returned by daemon.
+      const merged = DEMO_MODE
+        ? [...list, ...DEMO_FAMILIARS.filter((d) => !list.find((l) => l.id === d.id))]
+        : list;
+      setFamiliars(merged);
+      setActiveId((curr) => curr ?? merged[0]?.id ?? null);
     } catch (err) {
-      setFamiliars([]);
-      setFamiliarsError(err instanceof Error ? err.message : "fetch failed");
+      const fallback = DEMO_MODE ? DEMO_FAMILIARS : [];
+      setFamiliars(fallback);
+      setFamiliarsError(DEMO_MODE ? null : (err instanceof Error ? err.message : "fetch failed"));
+      if (DEMO_MODE) setActiveId((curr) => curr ?? fallback[0]?.id ?? null);
     }
   }, []);
 

--- a/src/lib/demo-seed.ts
+++ b/src/lib/demo-seed.ts
@@ -1,0 +1,280 @@
+/**
+ * demo-seed.ts — fixture data for the Open Coven weekly demo.
+ *
+ * Gated behind NEXT_PUBLIC_DEMO=true. Zero effect on production.
+ * Burn after the call.
+ */
+
+import type { Familiar } from "@/lib/types";
+import type { Escalation } from "@/lib/vals-inbox-types";
+import type { Card } from "@/lib/cave-board-types";
+
+export const DEMO_MODE =
+  typeof process !== "undefined" &&
+  process.env.NEXT_PUBLIC_DEMO === "true";
+
+// ─── helpers ───────────────────────────────────────────────────────────────
+
+function ago(minutes: number): string {
+  return new Date(Date.now() - minutes * 60_000).toISOString();
+}
+
+// ─── familiars ──────────────────────────────────────────────────────────────
+
+export const DEMO_FAMILIARS: Familiar[] = [
+  {
+    id: "nova",
+    display_name: "Nova",
+    role: "Orchestrator",
+    status: "active",
+    active_sessions: 3,
+    emoji: "✦",
+    note: "Coordinating weekly call prep",
+  },
+  {
+    id: "cody",
+    display_name: "Cody",
+    role: "Code Familiar",
+    status: "active",
+    active_sessions: 1,
+    emoji: "🦄",
+    note: "Working on Hexes Phase 2A",
+  },
+  {
+    id: "sage",
+    display_name: "Sage",
+    role: "Research Familiar",
+    status: "active",
+    active_sessions: 2,
+    emoji: "◈",
+    note: "On OpenAI fallback model",
+  },
+  {
+    id: "echo",
+    display_name: "Echo",
+    role: "Interface Familiar",
+    status: "idle",
+    active_sessions: 0,
+    emoji: "◉",
+    note: "Awaiting design review",
+  },
+  {
+    id: "kitty",
+    display_name: "Kitty",
+    role: "Systems Familiar",
+    status: "idle",
+    active_sessions: 0,
+    emoji: "⌘",
+    note: "Needs Val input on memory archive",
+  },
+  {
+    id: "charm",
+    display_name: "Charm",
+    role: "Creative Familiar",
+    status: "idle",
+    active_sessions: 0,
+    emoji: "✿",
+    note: "Slide deck ready",
+  },
+  {
+    id: "astra",
+    display_name: "Astra",
+    role: "Ops Familiar",
+    status: "offline",
+    active_sessions: 0,
+    emoji: "⬡",
+    note: "Escalated: gateway auth failure",
+  },
+];
+
+// ─── Val's Inbox escalations ────────────────────────────────────────────────
+
+export const DEMO_ESCALATIONS: Escalation[] = [
+  {
+    id: "demo-esc-1",
+    createdAt: ago(8),
+    updatedAt: ago(8),
+    origin: "gateway",
+    fromFamiliar: "astra",
+    title: "Gateway lost OpenAI auth — Sage on fallback model",
+    excerpt:
+      "Connection to OpenAI API returned 401. Sage automatically switched to anthropic/claude-opus-4 fallback. Resume when API key is rotated or re-authorised in Settings → Integrations.",
+    severity: "critical",
+    state: "new",
+    decisionRequired: false,
+  },
+  {
+    id: "demo-esc-2",
+    createdAt: ago(14),
+    updatedAt: ago(14),
+    origin: "task",
+    fromFamiliar: "cody",
+    title: "coven-cave#36 needs merge method decision before I can close",
+    excerpt:
+      "PR is green and CI passed. Waiting on: (1) squash vs merge commit, (2) patch vs minor bump. I'll merge the moment you decide.",
+    severity: "critical",
+    state: "new",
+    decisionRequired: true,
+    severityReason: "Blocks the demo branch from merging before the call",
+    actions: [
+      {
+        id: "open-pr",
+        label: "Open PR",
+        kind: "link",
+        target: "https://github.com/OpenCoven/coven-cave/pulls",
+      },
+    ],
+  },
+  {
+    id: "demo-esc-3",
+    createdAt: ago(31),
+    updatedAt: ago(22),
+    origin: "cron",
+    title: "Thursday async memory update — silent 22 min past expected window",
+    excerpt:
+      "Scheduled run at 14:00 CDT did not fire. No error in cron logs. Likely a daemon restart edge case. May be safe to dismiss if nothing is missing from today's memory.",
+    severity: "warn",
+    state: "acknowledged",
+    decisionRequired: false,
+  },
+  {
+    id: "demo-esc-4",
+    createdAt: ago(47),
+    updatedAt: ago(47),
+    origin: "mention",
+    fromFamiliar: "sage",
+    aboutFamiliar: "cody",
+    title: "PR #36 AgentPanel missing snapshot test for slide-in animation",
+    excerpt:
+      "The AgentPanel CSS transition is untested. Not a blocker — animation looks correct in local dev — but worth a fast snapshot before this merges to main.",
+    severity: "info",
+    state: "new",
+    decisionRequired: false,
+  },
+  {
+    id: "demo-esc-5",
+    createdAt: ago(72),
+    updatedAt: ago(72),
+    origin: "chat",
+    fromFamiliar: "kitty",
+    title: "Should I auto-archive memory/2026-04-* or keep for April retro?",
+    excerpt:
+      "14 daily memory files from April haven't been referenced in 30 days. Safe to archive to cold storage, or do you want them on hand for the retrospective next week?",
+    severity: "info",
+    state: "new",
+    decisionRequired: true,
+  },
+];
+
+// ─── board cards ─────────────────────────────────────────────────────────────
+
+export const DEMO_BOARD_CARDS: Card[] = [
+  {
+    id: "demo-card-1",
+    title: "Val's Inbox — humans-only escalation surface (#16)",
+    notes: "Full spec implemented. On main.",
+    status: "review",
+    priority: "high",
+    familiarId: "cody",
+    sessionId: null,
+    labels: ["shipped"],
+    createdAt: ago(180),
+    updatedAt: ago(60),
+    lifecycle: "completed",
+    lifecycleAt: ago(60),
+    retryCount: 0,
+    maxRetries: 2,
+  },
+  {
+    id: "demo-card-2",
+    title: "Health strip in daemon bar (#15)",
+    notes: "Colored dots per surface — daemon, familiars, gateway.",
+    status: "review",
+    priority: "medium",
+    familiarId: "cody",
+    sessionId: null,
+    labels: ["shipped"],
+    createdAt: ago(240),
+    updatedAt: ago(90),
+    lifecycle: "completed",
+    lifecycleAt: ago(90),
+    retryCount: 0,
+    maxRetries: 2,
+  },
+  {
+    id: "demo-card-3",
+    title: "coven-relay scaffold — Hexes Phase 2A",
+    notes: "PR #152 open. Axum WS skeleton + fly.toml. Typecheck clean.",
+    status: "running",
+    priority: "high",
+    familiarId: "cody",
+    sessionId: null,
+    labels: ["hexes"],
+    createdAt: ago(120),
+    updatedAt: ago(30),
+    lifecycle: "review",
+    lifecycleAt: ago(30),
+    retryCount: 0,
+    maxRetries: 2,
+  },
+  {
+    id: "demo-card-4",
+    title: "Hexes Phase 2B — auth + peer routing",
+    notes: "Waiting for 2A merge. Bearer auth + host/client fanout.",
+    status: "inbox",
+    priority: "high",
+    familiarId: "cody",
+    sessionId: null,
+    labels: ["hexes"],
+    createdAt: ago(30),
+    updatedAt: ago(30),
+    lifecycle: "queued",
+    lifecycleAt: ago(30),
+    retryCount: 0,
+    maxRetries: 2,
+  },
+  {
+    id: "demo-card-5",
+    title: "Val's Inbox keyboard shortcuts follow-up (#16.1)",
+    notes: "j/k/e/r/s/x/o + g-i global jump. Filed as follow-up to #16.",
+    status: "inbox",
+    priority: "medium",
+    familiarId: null,
+    sessionId: null,
+    labels: [],
+    createdAt: ago(20),
+    updatedAt: ago(20),
+    lifecycle: "queued",
+    lifecycleAt: ago(20),
+    retryCount: 0,
+    maxRetries: 2,
+  },
+];
+
+// ─── demo chat turns ─────────────────────────────────────────────────────────
+
+export type DemoChatTurn = { role: "user" | "assistant"; content: string };
+
+export const DEMO_CHAT_TURNS: Record<string, DemoChatTurn[]> = {
+  cody: [
+    {
+      role: "user",
+      content:
+        "Can you check if the vals-inbox API handles concurrent writes safely?",
+    },
+    {
+      role: "assistant",
+      content:
+        "Checked `src/lib/vals-inbox.ts` — it uses a `globalThis.__valsInboxWriteChain` mutex that serialises all read-modify-write sequences. Two concurrent POSTs can't race each other. Same pattern as the reminders inbox. Safe.",
+    },
+    {
+      role: "user",
+      content: "Good. What's left on 2A before we can merge the relay PR?",
+    },
+    {
+      role: "assistant",
+      content:
+        "PR #152 is open and CI is green. Scaffold compiles, workspace tests pass (4/4). `fly.toml` is wired to `relay.opencoven.dev` / `ord`. Nothing blocking — ready to merge when you are. 2B (auth + peer routing) is queued.",
+    },
+  ],
+};


### PR DESCRIPTION
Demo fixture layer for the Open Coven weekly call. **Gated behind `NEXT_PUBLIC_DEMO=true` — zero effect on production when unset.**

## What's in this PR

| File | Change |
|------|--------|
| `src/lib/demo-seed.ts` | New fixture file — 7 familiars, 5 inbox escalations, 5 board cards, 4-turn demo chat |
| `src/components/workspace.tsx` | DEMO_MODE familiar fallback (merges demo familiars if daemon is offline/empty) |
| `src/components/vals-inbox-view.tsx` | DEMO_MODE escalation fallback when inbox is empty or API unreachable |
| `src/components/board-view.tsx` | DEMO_MODE board card fallback when board is empty |

## Demo fixtures

**Familiars (7):** Nova/Cody/Sage active, Echo/Kitty/Charm idle, Astra offline — varied presence states visible in familiar rail.

**Val's Inbox (5 realistic escalations):**
1. 🔴 gateway crit — Astra: OpenAI auth lost, Sage on fallback
2. 🔴 decision required — Cody: merge method for coven-cave#36
3. 🟡 warn acknowledged — cron silent 22m past window
4. ⚪ info — Sage→Cody cross-familiar: missing snapshot test
5. ⚪ decision — Kitty: archive April memory files?

**Board (5 cards):** Val's Inbox #16 ✅, Health Strip #15 ✅, coven-relay 2A in review, Hexes 2B queued, keyboard shortcuts follow-up queued.

## To activate for the demo
```sh
NEXT_PUBLIC_DEMO=true pnpm dev
```

## Verification
- `npx tsc --noEmit` ✅ clean
- Pre-commit hooks ✅ clean

Burn after the call.