### PR TITLE
fix(aesthetic): wrap CSS-var Tailwind classes in var() — REAL fix for white borders

### DIFF
--- a/src/components/agent-panel.tsx
+++ b/src/components/agent-panel.tsx
@@ -24,13 +24,13 @@ export const AgentPanel = forwardRef<ChatRouterHandle, Props>(function AgentPane
 ) {
   if (!props.familiar) {
     return (
-      <div className="flex h-full flex-col items-center justify-center px-6 text-center text-[12px] text-[--text-muted]">
-        <p className="text-[--text-secondary]">Pick a familiar from the rail.</p>
+      <div className="flex h-full flex-col items-center justify-center px-6 text-center text-[12px] text-[var(--text-muted)]">
+        <p className="text-[var(--text-secondary)]">Pick a familiar from the rail.</p>
         <p className="mt-1">Their live chat lives here.</p>
         <button
           type="button"
           onClick={props.onOpenOnboarding}
-          className="mt-4 rounded-md border border-[--border-hairline] bg-[--bg-raised] px-3 py-1 text-[11px] text-[--text-primary] hover:bg-[--bg-raised]/80"
+          className="mt-4 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-1 text-[11px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)]/80"
         >
           Open setup
         </button>

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -154,7 +154,7 @@ export function BottomTerminal({ threadId }: { threadId: string }) {
 
   if (unavailable) {
     return (
-      <div className="flex h-full items-center justify-center text-[11px] text-[--text-muted]">
+      <div className="flex h-full items-center justify-center text-[11px] text-[var(--text-muted)]">
         Terminal is only available inside the CovenCave desktop app.
       </div>
     );

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -62,17 +62,17 @@ export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat 
   const projectName = PROJECT_ROOT.split("/").slice(-2).join("/");
 
   return (
-    <section className="flex h-full flex-col bg-[--bg-base] text-[--text-primary]">
-      <header className="flex items-center gap-2 border-b border-[--border-hairline] px-5 py-2.5 text-[11px] text-[--text-secondary]">
+    <section className="flex h-full flex-col bg-[var(--bg-base)] text-[var(--text-primary)]">
+      <header className="flex items-center gap-2 border-b border-[var(--border-hairline)] px-5 py-2.5 text-[11px] text-[var(--text-secondary)]">
         <span className="flex items-center gap-1.5">
-          <span className="font-medium text-[--text-primary]">{familiar.display_name}</span>
+          <span className="font-medium text-[var(--text-primary)]">{familiar.display_name}</span>
         </span>
-        <span className="text-[--text-muted]">·</span>
-        <span className="font-mono text-[--text-muted]">{familiar.harness ?? "codex"}</span>
-        <span className="text-[--text-muted]">·</span>
-        <span className="truncate font-mono text-[--text-muted]">{projectName}</span>
-        <span className="text-[--text-muted]">·</span>
-        <span className="text-[--text-muted]">
+        <span className="text-[var(--text-muted)]">·</span>
+        <span className="font-mono text-[var(--text-muted)]">{familiar.harness ?? "codex"}</span>
+        <span className="text-[var(--text-muted)]">·</span>
+        <span className="truncate font-mono text-[var(--text-muted)]">{projectName}</span>
+        <span className="text-[var(--text-muted)]">·</span>
+        <span className="text-[var(--text-muted)]">
           daemon{" "}
           <span className={daemonRunning ? "text-emerald-400" : "text-rose-400"}>
             {daemonRunning ? "running" : "offline"}
@@ -81,7 +81,7 @@ export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat 
         <span className="ml-auto flex items-center gap-2">
           <button
             onClick={onNewChat}
-            className="rounded-full bg-[--accent-presence] px-3 py-1 text-[11px] font-medium text-white transition-colors hover:bg-[--accent-presence-soft]"
+            className="rounded-full bg-[var(--accent-presence)] px-3 py-1 text-[11px] font-medium text-white transition-colors hover:bg-[var(--accent-presence-soft)]"
           >
             + New chat
           </button>
@@ -96,33 +96,33 @@ export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat 
 
       <div className="min-h-0 flex-1 overflow-y-auto px-5 py-6">
         <div className="mx-auto max-w-3xl">
-          <h2 className="mb-4 text-xs uppercase tracking-widest text-[--text-muted]">
+          <h2 className="mb-4 text-xs uppercase tracking-widest text-[var(--text-muted)]">
             Chats with {familiar.display_name}
           </h2>
 
           {mine.length === 0 ? (
-            <div className="rounded-2xl border border-[--border-hairline] bg-[--bg-raised]/40 px-5 py-10 text-center">
-              <p className="text-sm text-[--text-secondary]">No chats with {familiar.display_name} yet.</p>
-              <p className="mt-1 text-[12px] text-[--text-muted]">
+            <div className="rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-5 py-10 text-center">
+              <p className="text-sm text-[var(--text-secondary)]">No chats with {familiar.display_name} yet.</p>
+              <p className="mt-1 text-[12px] text-[var(--text-muted)]">
                 Runs on{" "}
-                <code className="rounded bg-[--bg-raised] px-1 py-0.5 font-mono text-[11px] text-[--text-secondary]">
+                <code className="rounded bg-[var(--bg-raised)] px-1 py-0.5 font-mono text-[11px] text-[var(--text-secondary)]">
                   {familiar.harness}
                 </code>{" "}
                 with{" "}
-                <code className="rounded bg-[--bg-raised] px-1 py-0.5 font-mono text-[11px] text-[--text-secondary]">
+                <code className="rounded bg-[var(--bg-raised)] px-1 py-0.5 font-mono text-[11px] text-[var(--text-secondary)]">
                   {familiar.model}
                 </code>
                 .
               </p>
               <button
                 onClick={onNewChat}
-                className="mt-5 rounded-full bg-[--accent-presence] px-4 py-1.5 text-xs font-medium text-white transition-colors hover:bg-[--accent-presence-soft]"
+                className="mt-5 rounded-full bg-[var(--accent-presence)] px-4 py-1.5 text-xs font-medium text-white transition-colors hover:bg-[var(--accent-presence-soft)]"
               >
                 + New chat
               </button>
             </div>
           ) : (
-            <ul className="divide-y divide-[--border-hairline]">
+            <ul className="divide-y divide-[var(--border-hairline)]">
               {mine.map((s) => {
                 const running = s.status === "running";
                 return (
@@ -134,12 +134,12 @@ export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat 
                       onKeyDown={(e) => {
                         if (e.key === "Enter") onOpen(s.id);
                       }}
-                      className="group flex cursor-pointer items-center gap-3 py-3 transition-colors hover:bg-[--bg-raised]/30"
+                      className="group flex cursor-pointer items-center gap-3 py-3 transition-colors hover:bg-[var(--bg-raised)]/30"
                     >
                       <Icon
                         name={running ? "ph:circle-fill" : "ph:circle"}
                         className={
-                          running ? "text-emerald-400 animate-pulse" : "text-[--text-muted]"
+                          running ? "text-emerald-400 animate-pulse" : "text-[var(--text-muted)]"
                         }
                         title={running ? "running" : "idle"}
                         width="0.6rem"
@@ -147,23 +147,23 @@ export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat 
                       />
                       <span className="flex min-w-0 flex-1 flex-col">
                         <span className="flex min-w-0 items-center gap-2">
-                          <span className="truncate text-sm text-[--text-primary]">
+                          <span className="truncate text-sm text-[var(--text-primary)]">
                             {s.title || "(untitled chat)"}
                           </span>
                           {s.origin ? <OriginChip origin={s.origin} /> : null}
                         </span>
-                        <span className="truncate text-[11px] text-[--text-muted]">
-                          <span className="font-mono text-[--text-secondary]">{s.harness}</span>
-                          <span className="mx-1.5 text-[--text-muted]">·</span>
+                        <span className="truncate text-[11px] text-[var(--text-muted)]">
+                          <span className="font-mono text-[var(--text-secondary)]">{s.harness}</span>
+                          <span className="mx-1.5 text-[var(--text-muted)]">·</span>
                           <span className="truncate">{s.project_root}</span>
                         </span>
                       </span>
-                      <span className="shrink-0 text-[11px] text-[--text-muted]">{age(s.updated_at)}</span>
+                      <span className="shrink-0 text-[11px] text-[var(--text-muted)]">{age(s.updated_at)}</span>
                       <button
                         onClick={(e) => openInTui(e, s.id)}
                         disabled={busyTuiId === s.id}
                         title="Open this session in Coven Code TUI (external terminal)"
-                        className="shrink-0 rounded border border-[--border-hairline] px-2 py-0.5 text-[10px] text-[--text-secondary] opacity-0 transition-opacity hover:bg-[--bg-raised] group-hover:opacity-100 disabled:opacity-40"
+                        className="shrink-0 rounded border border-[var(--border-hairline)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)] opacity-0 transition-opacity hover:bg-[var(--bg-raised)] group-hover:opacity-100 disabled:opacity-40"
                       >
                         {busyTuiId === s.id ? "…" : "tui"}
                       </button>
@@ -176,7 +176,7 @@ export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat 
         </div>
       </div>
 
-      <footer className="border-t border-[--border-hairline] px-5 py-2 text-[10px] text-[--text-muted]">
+      <footer className="border-t border-[var(--border-hairline)] px-5 py-2 text-[10px] text-[var(--text-muted)]">
         {keys.enter} open · {keys.mod}K palette · / commands in chat
       </footer>
     </section>

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -59,12 +59,12 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
 
   if (!familiar) {
     return (
-      <section className="flex h-full flex-col items-center justify-center gap-3 bg-[--bg-base] text-sm text-[--text-muted]">
+      <section className="flex h-full flex-col items-center justify-center gap-3 bg-[var(--bg-base)] text-sm text-[var(--text-muted)]">
         <p>Pick a familiar from the rail to start chatting.</p>
         {onOpenOnboarding ? (
           <button
             onClick={onOpenOnboarding}
-            className="rounded-md border border-[--border-hairline] bg-[--bg-raised] px-3 py-1 text-[12px] text-[--text-primary] hover:bg-[--bg-raised]"
+            className="rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-1 text-[12px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
           >
             Open setup
           </button>

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -473,20 +473,20 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   );
 
   return (
-    <section className="flex h-full flex-col bg-[--bg-base] text-[--text-primary]">
+    <section className="flex h-full flex-col bg-[var(--bg-base)] text-[var(--text-primary)]">
       {/* Transcript */}
       <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
         <div className="space-y-6">
           {turns.length === 0 ? (
-            <div className="py-14 text-center text-sm text-[--text-muted]">
-              <p className="text-[--text-secondary]">Chat with {familiar.display_name}.</p>
-              <p className="mt-1 text-[--text-muted]">
+            <div className="py-14 text-center text-sm text-[var(--text-muted)]">
+              <p className="text-[var(--text-secondary)]">Chat with {familiar.display_name}.</p>
+              <p className="mt-1 text-[var(--text-muted)]">
                 Runs on{" "}
-                <code className="rounded bg-[--bg-raised] px-1 py-0.5 font-mono text-[12px] text-[--text-secondary]">
+                <code className="rounded bg-[var(--bg-raised)] px-1 py-0.5 font-mono text-[12px] text-[var(--text-secondary)]">
                   {familiar.harness}
                 </code>{" "}
                 via the{" "}
-                <code className="rounded bg-[--bg-raised] px-1 py-0.5 font-mono text-[12px] text-[--text-secondary]">
+                <code className="rounded bg-[var(--bg-raised)] px-1 py-0.5 font-mono text-[12px] text-[var(--text-secondary)]">
                   coven
                 </code>{" "}
                 CLI. {keys.mod}K to jump · / for commands.
@@ -510,7 +510,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       <footer className="px-6 pb-5 pt-2">
         <div className="relative">
           {slashSuggestions.length > 0 ? (
-            <div className="absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-xl border border-[--border-hairline] bg-[--bg-base] shadow-xl">
+            <div className="absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-xl">
               <ul className="max-h-64 overflow-y-auto py-1">
                 {slashSuggestions.map((cmd, i) => {
                   const active = i === slashIdx;
@@ -523,15 +523,15 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                           inputRef.current?.focus();
                         }}
                         className={`flex w-full items-center gap-3 px-3 py-2 text-left text-sm transition-colors ${
-                          active ? "bg-[--bg-raised]/60" : "hover:bg-[--bg-raised]/50"
+                          active ? "bg-[var(--bg-raised)]/60" : "hover:bg-[var(--bg-raised)]/50"
                         }`}
                       >
-                        <span className="font-mono text-[--text-primary]">{cmd.name}</span>
-                        <span className="flex-1 truncate text-xs text-[--text-muted]">
+                        <span className="font-mono text-[var(--text-primary)]">{cmd.name}</span>
+                        <span className="flex-1 truncate text-xs text-[var(--text-muted)]">
                           {cmd.description}
                         </span>
                         {cmd.argPlaceholder ? (
-                          <span className="font-mono text-[10px] text-[--text-muted]">
+                          <span className="font-mono text-[10px] text-[var(--text-muted)]">
                             {cmd.argPlaceholder}
                           </span>
                         ) : null}
@@ -540,13 +540,13 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   );
                 })}
               </ul>
-              <div className="border-t border-[--border-hairline] px-3 py-1.5 text-[10px] text-[--text-muted]">
+              <div className="border-t border-[var(--border-hairline)] px-3 py-1.5 text-[10px] text-[var(--text-muted)]">
                 {keys.up}{keys.down} navigate · {keys.enter} run · Tab complete · esc cancel
               </div>
             </div>
           ) : null}
 
-          <div className="rounded-2xl border border-[--border-hairline] bg-[--bg-raised]/50 shadow-lg">
+          <div className="rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-raised)]/50 shadow-lg">
             <textarea
               ref={inputRef}
               value={input}
@@ -554,22 +554,22 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               onKeyDown={onComposerKey}
               placeholder={busy ? "Streaming… (esc to cancel)" : "Ask for follow-up changes"}
               rows={1}
-              className="w-full resize-none bg-transparent px-4 pt-4 pb-2 text-sm text-[--text-primary] outline-none placeholder:text-[--text-muted]"
+              className="w-full resize-none bg-transparent px-4 pt-4 pb-2 text-sm text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)]"
             />
             <div className="flex items-center justify-between px-3 pb-2.5">
-              <div className="flex items-center gap-1 text-[--text-muted]">
+              <div className="flex items-center gap-1 text-[var(--text-muted)]">
                 <button
-                  className="grid h-7 w-7 place-items-center rounded-full border border-[--border-hairline] hover:bg-[--bg-raised]"
+                  className="grid h-7 w-7 place-items-center rounded-full border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)]"
                   title="Attach (coming soon)"
                   disabled
                 >
                   +
                 </button>
               </div>
-              <div className="flex items-center gap-2 text-[--text-muted]">
-                <span className="flex items-center gap-1 rounded-full border border-[--border-hairline] px-2 py-1 text-[11px]">
+              <div className="flex items-center gap-2 text-[var(--text-muted)]">
+                <span className="flex items-center gap-1 rounded-full border border-[var(--border-hairline)] px-2 py-1 text-[11px]">
                   <span className="text-purple-300">◆</span>
-                  <span className="font-mono text-[--text-secondary]">{familiar.model ?? "—"}</span>
+                  <span className="font-mono text-[var(--text-secondary)]">{familiar.model ?? "—"}</span>
                 </span>
                 {busy ? (
                   <button
@@ -583,7 +583,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   <button
                     onClick={() => void send()}
                     disabled={!input.trim()}
-                    className="grid h-7 w-7 place-items-center rounded-full bg-[--accent-presence] text-white transition-colors hover:bg-[--accent-presence-soft] disabled:opacity-40"
+                    className="grid h-7 w-7 place-items-center rounded-full bg-[var(--accent-presence)] text-white transition-colors hover:bg-[var(--accent-presence-soft)] disabled:opacity-40"
                     title={`Send (${keys.enter})`}
                   >
                     ↑
@@ -602,20 +602,20 @@ function TurnRow({ turn }: { turn: Turn }) {
   if (turn.role === "system") {
     return (
       <div>
-        <div className="rounded-xl border border-[--border-hairline]/60 bg-[--bg-raised]/40 px-4 py-3 font-mono text-[12px] leading-relaxed text-[--text-secondary] whitespace-pre-wrap">
+        <div className="rounded-xl border border-[var(--border-hairline)]/60 bg-[var(--bg-raised)]/40 px-4 py-3 font-mono text-[12px] leading-relaxed text-[var(--text-secondary)] whitespace-pre-wrap">
           {turn.text}
         </div>
-        <div className="mt-1 text-right text-[10px] text-[--text-muted]">{fmtTime(turn.createdAt)}</div>
+        <div className="mt-1 text-right text-[10px] text-[var(--text-muted)]">{fmtTime(turn.createdAt)}</div>
       </div>
     );
   }
   if (turn.role === "user") {
     return (
       <div className="flex flex-col items-end">
-        <div className="max-w-[80%] rounded-2xl bg-[--bg-raised]/70 px-4 py-2.5 text-[14px] leading-relaxed text-[--text-primary]">
+        <div className="max-w-[80%] rounded-2xl bg-[var(--bg-raised)]/70 px-4 py-2.5 text-[14px] leading-relaxed text-[var(--text-primary)]">
           <RichText text={turn.text} />
         </div>
-        <div className="mt-1 text-[10px] text-[--text-muted]">{fmtTime(turn.createdAt)}</div>
+        <div className="mt-1 text-[10px] text-[var(--text-muted)]">{fmtTime(turn.createdAt)}</div>
       </div>
     );
   }
@@ -624,7 +624,7 @@ function TurnRow({ turn }: { turn: Turn }) {
   const { visible, reasoning } = splitReasoning(turn.text);
   const tools = turn.tools ?? [];
   return (
-    <div className="text-[14px] leading-relaxed text-[--text-primary]">
+    <div className="text-[14px] leading-relaxed text-[var(--text-primary)]">
       {tools.length > 0 ? (
         <div className="mb-3 space-y-1.5">
           {tools.map((t) => (
@@ -636,14 +636,14 @@ function TurnRow({ turn }: { turn: Turn }) {
       <div className={turn.error ? "text-amber-200" : ""}>
         <RichText text={visible || (turn.pending ? "…" : "")} />
         {turn.pending && visible ? (
-          <span className="ml-1 inline-block animate-pulse text-[--text-secondary]">▌</span>
+          <span className="ml-1 inline-block animate-pulse text-[var(--text-secondary)]">▌</span>
         ) : null}
       </div>
-      <div className="mt-1 flex items-center gap-2 text-[10px] text-[--text-muted]">
+      <div className="mt-1 flex items-center gap-2 text-[10px] text-[var(--text-muted)]">
         <span>{fmtTime(turn.createdAt)}</span>
         {duration && !turn.pending ? (
           <>
-            <span className="text-[--text-muted]">·</span>
+            <span className="text-[var(--text-muted)]">·</span>
             <span>worked for {duration}</span>
           </>
         ) : null}
@@ -656,10 +656,10 @@ function ReasoningBlock({ text }: { text: string }) {
   const [open, setOpen] = useState(false);
   const lineCount = text.split("\n").length;
   return (
-    <div className="mb-3 overflow-hidden rounded-lg border border-[--border-hairline]/70 bg-[--bg-raised]/30 text-[12px]">
+    <div className="mb-3 overflow-hidden rounded-lg border border-[var(--border-hairline)]/70 bg-[var(--bg-raised)]/30 text-[12px]">
       <button
         onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[--text-secondary] transition-colors hover:bg-[--bg-raised]/60"
+        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)]/60"
       >
         <Icon
           name="ph:caret-right-bold"
@@ -667,11 +667,11 @@ function ReasoningBlock({ text }: { text: string }) {
           height="0.7rem"
           className={`transition-transform ${open ? "rotate-90" : ""}`}
         />
-        <span className="text-[--text-secondary]">reasoning</span>
-        <span className="text-[--text-muted]">· {lineCount} line{lineCount === 1 ? "" : "s"}</span>
+        <span className="text-[var(--text-secondary)]">reasoning</span>
+        <span className="text-[var(--text-muted)]">· {lineCount} line{lineCount === 1 ? "" : "s"}</span>
       </button>
       {open ? (
-        <div className="border-t border-[--border-hairline]/70 px-3 py-2 font-mono text-[12px] leading-relaxed whitespace-pre-wrap text-[--text-secondary]">
+        <div className="border-t border-[var(--border-hairline)]/70 px-3 py-2 font-mono text-[12px] leading-relaxed whitespace-pre-wrap text-[var(--text-secondary)]">
           {text}
         </div>
       ) : null}
@@ -690,41 +690,41 @@ function ToolBlock({ tool }: { tool: ToolEvent }) {
   const hasBody = !!(tool.input || tool.output);
   const dur = fmtDuration(tool.durationMs);
   return (
-    <div className="overflow-hidden rounded-lg border border-[--border-hairline]/70 bg-[--bg-raised]/30 text-[12px]">
+    <div className="overflow-hidden rounded-lg border border-[var(--border-hairline)]/70 bg-[var(--bg-raised)]/30 text-[12px]">
       <button
         onClick={() => hasBody && setOpen((v) => !v)}
         disabled={!hasBody}
         className={`flex w-full items-center gap-2 px-3 py-1.5 text-left ${
-          hasBody ? "transition-colors hover:bg-[--bg-raised]/60" : "cursor-default"
+          hasBody ? "transition-colors hover:bg-[var(--bg-raised)]/60" : "cursor-default"
         }`}
       >
         <Icon
           name="ph:caret-right-bold"
           width="0.7rem"
           height="0.7rem"
-          className={`text-[--text-muted] transition-transform ${open ? "rotate-90" : ""} ${
+          className={`text-[var(--text-muted)] transition-transform ${open ? "rotate-90" : ""} ${
             hasBody ? "" : "opacity-30"
           }`}
         />
         <Icon name="ph:wrench-bold" width="0.85rem" height="0.85rem" className="text-purple-300" />
-        <span className="font-mono text-[--text-primary]">{tool.name}</span>
+        <span className="font-mono text-[var(--text-primary)]">{tool.name}</span>
         <span className={`ml-auto h-1.5 w-1.5 rounded-full ${statusDot}`} />
         {dur && tool.status !== "running" ? (
-          <span className="font-mono text-[--text-muted]">{dur}</span>
+          <span className="font-mono text-[var(--text-muted)]">{dur}</span>
         ) : null}
       </button>
       {open && hasBody ? (
-        <div className="space-y-2 border-t border-[--border-hairline]/70 px-3 py-2 font-mono text-[12px] leading-relaxed">
+        <div className="space-y-2 border-t border-[var(--border-hairline)]/70 px-3 py-2 font-mono text-[12px] leading-relaxed">
           {tool.input ? (
             <div>
-              <div className="mb-0.5 text-[10px] uppercase tracking-wider text-[--text-muted]">input</div>
-              <pre className="whitespace-pre-wrap text-[--text-secondary]">{tool.input}</pre>
+              <div className="mb-0.5 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">input</div>
+              <pre className="whitespace-pre-wrap text-[var(--text-secondary)]">{tool.input}</pre>
             </div>
           ) : null}
           {tool.output ? (
             <div>
-              <div className="mb-0.5 text-[10px] uppercase tracking-wider text-[--text-muted]">output</div>
-              <pre className="whitespace-pre-wrap text-[--text-secondary]">{tool.output}</pre>
+              <div className="mb-0.5 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">output</div>
+              <pre className="whitespace-pre-wrap text-[var(--text-secondary)]">{tool.output}</pre>
             </div>
           ) : null}
         </div>

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -277,7 +277,7 @@ export function CommandPalette({
     >
       <div
         onClick={(e) => e.stopPropagation()}
-        className="mt-[12vh] w-[640px] max-w-[92vw] overflow-hidden rounded-2xl border border-[--border-hairline] bg-[--bg-base] shadow-2xl"
+        className="mt-[12vh] w-[640px] max-w-[92vw] overflow-hidden rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-2xl"
       >
         <input
           ref={inputRef}
@@ -288,11 +288,11 @@ export function CommandPalette({
           }}
           onKeyDown={onComposerKey}
           placeholder="Search familiars · chats · cards · memory · commands…"
-          className="w-full border-b border-[--border-hairline] bg-transparent px-4 py-3 text-sm text-[--text-primary] outline-none placeholder:text-[--text-muted]"
+          className="w-full border-b border-[var(--border-hairline)] bg-transparent px-4 py-3 text-sm text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)]"
         />
         <ul className="max-h-[60vh] overflow-y-auto py-1">
           {rows.length === 0 ? (
-            <li className="px-4 py-6 text-center text-xs text-[--text-muted]">No matches.</li>
+            <li className="px-4 py-6 text-center text-xs text-[var(--text-muted)]">No matches.</li>
           ) : null}
           {rows.map((row, i) => {
             const active = i === activeIdx;
@@ -302,76 +302,76 @@ export function CommandPalette({
                   onMouseEnter={() => setActiveIdx(i)}
                   onClick={() => fire(row)}
                   className={`flex w-full items-center gap-3 px-4 py-2 text-left text-sm transition-colors ${
-                    active ? "bg-[--bg-raised]/60" : "hover:bg-[--bg-raised]/50"
+                    active ? "bg-[var(--bg-raised)]/60" : "hover:bg-[var(--bg-raised)]/50"
                   }`}
                 >
                   {row.kind === "familiar" ? (
                     <>
                       <span className="flex flex-1 flex-col">
-                        <span className="text-[--text-primary]">{row.familiar.display_name}</span>
-                        <span className="text-[10px] uppercase tracking-widest text-[--text-muted]">
+                        <span className="text-[var(--text-primary)]">{row.familiar.display_name}</span>
+                        <span className="text-[10px] uppercase tracking-widest text-[var(--text-muted)]">
                           {row.familiar.role}
                         </span>
                       </span>
-                      <span className="text-[10px] text-[--text-muted]">switch</span>
+                      <span className="text-[10px] text-[var(--text-muted)]">switch</span>
                     </>
                   ) : null}
                   {row.kind === "session" ? (
                     <>
-                      <Icon name="ph:chat-circle-dots-bold" className="text-[--text-secondary]" width="1.1rem" height="1.1rem" />
+                      <Icon name="ph:chat-circle-dots-bold" className="text-[var(--text-secondary)]" width="1.1rem" height="1.1rem" />
                       <span className="flex min-w-0 flex-1 flex-col">
-                        <span className="truncate text-[--text-primary]">
+                        <span className="truncate text-[var(--text-primary)]">
                           {row.session.title || "(untitled chat)"}
                         </span>
-                        <span className="truncate text-[10px] text-[--text-muted]">
+                        <span className="truncate text-[10px] text-[var(--text-muted)]">
                           {row.familiar?.display_name ?? row.session.familiarId} ·{" "}
                           {row.session.harness}
                         </span>
                       </span>
-                      <span className="text-[10px] text-[--text-muted]">open</span>
+                      <span className="text-[10px] text-[var(--text-muted)]">open</span>
                     </>
                   ) : null}
                   {row.kind === "card" ? (
                     <>
                       <span className="flex min-w-0 flex-1 flex-col">
-                        <span className="truncate text-[--text-primary]">{row.card.title}</span>
-                        <span className="truncate text-[10px] text-[--text-muted]">
+                        <span className="truncate text-[var(--text-primary)]">{row.card.title}</span>
+                        <span className="truncate text-[10px] text-[var(--text-muted)]">
                           {row.card.status} · {row.card.priority}
                           {row.familiar ? ` · ${row.familiar.display_name}` : ""}
                           {row.card.labels.length ? ` · ${row.card.labels.join(", ")}` : ""}
                         </span>
                       </span>
-                      <span className="text-[10px] text-[--text-muted]">card</span>
+                      <span className="text-[10px] text-[var(--text-muted)]">card</span>
                     </>
                   ) : null}
                   {row.kind === "coven-memory" ? (
                     <>
                       <span className="flex min-w-0 flex-1 flex-col">
-                        <span className="truncate text-[--text-primary]">{row.entry.title}</span>
-                        <span className="truncate text-[10px] text-[--text-muted]">
+                        <span className="truncate text-[var(--text-primary)]">{row.entry.title}</span>
+                        <span className="truncate text-[10px] text-[var(--text-muted)]">
                           {row.entry.familiar_id} · {row.entry.updated_at}
                           {row.entry.excerpt ? ` · ${row.entry.excerpt.slice(0, 70)}` : ""}
                         </span>
                       </span>
-                      <span className="text-[10px] text-[--text-muted]">memory</span>
+                      <span className="text-[10px] text-[var(--text-muted)]">memory</span>
                     </>
                   ) : null}
                   {row.kind === "fs-memory" ? (
                     <>
                       <span className="flex min-w-0 flex-1 flex-col">
-                        <span className="truncate text-[--text-primary]">{row.entry.relPath}</span>
-                        <span className="truncate text-[10px] text-[--text-muted]">
+                        <span className="truncate text-[var(--text-primary)]">{row.entry.relPath}</span>
+                        <span className="truncate text-[10px] text-[var(--text-muted)]">
                           {row.entry.rootLabel}
                         </span>
                       </span>
-                      <span className="text-[10px] text-[--text-muted]">file</span>
+                      <span className="text-[10px] text-[var(--text-muted)]">file</span>
                     </>
                   ) : null}
                   {row.kind === "command" ? (
                     <>
-                      <span className="font-mono text-[--text-secondary]">{row.name}</span>
-                      <span className="flex-1 text-[--text-muted]">{platformizeHint(row.hint, keys)}</span>
-                      <span className="text-[10px] text-[--text-muted]">run</span>
+                      <span className="font-mono text-[var(--text-secondary)]">{row.name}</span>
+                      <span className="flex-1 text-[var(--text-muted)]">{platformizeHint(row.hint, keys)}</span>
+                      <span className="text-[10px] text-[var(--text-muted)]">run</span>
                     </>
                   ) : null}
                 </button>
@@ -379,7 +379,7 @@ export function CommandPalette({
             );
           })}
         </ul>
-        <div className="flex items-center justify-between border-t border-[--border-hairline] px-4 py-2 text-[10px] text-[--text-muted]">
+        <div className="flex items-center justify-between border-t border-[var(--border-hairline)] px-4 py-2 text-[10px] text-[var(--text-muted)]">
           <span>{keys.up}{keys.down} navigate · {keys.enter} select · esc close</span>
           <span>{keys.mod}K</span>
         </div>

--- a/src/components/daemon-bar.tsx
+++ b/src/components/daemon-bar.tsx
@@ -66,7 +66,7 @@ export function DaemonBar({
   }, [onRunningChange]);
 
   return (
-    <header className="flex items-center justify-between border-b border-[--border-hairline] bg-[--bg-raised]/60 px-3 py-1.5 text-xs">
+    <header className="flex items-center justify-between border-b border-[var(--border-hairline)] bg-[var(--bg-raised)]/60 px-3 py-1.5 text-xs">
       <div className="flex items-center gap-3">
         <span className="font-semibold tracking-tight">CovenCave</span>
         <nav className="flex items-center gap-0.5">
@@ -82,8 +82,8 @@ export function DaemonBar({
                 onClick={() => onModeChange(m)}
                 className={`rounded-md px-2.5 py-1 text-[11px] transition-colors ${
                   active
-                    ? "bg-[--bg-raised] text-[--text-primary]"
-                    : "text-[--text-secondary] hover:bg-[--bg-raised] hover:text-[--text-primary]"
+                    ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
+                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
                 }`}
               >
                 {label}

--- a/src/components/familiar-glyph-picker.tsx
+++ b/src/components/familiar-glyph-picker.tsx
@@ -113,30 +113,30 @@ export function FamiliarGlyphPicker({ open, familiar, onClose }: Props) {
   return (
     <div
       onClick={onClose}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-[--bg-base]/70 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--bg-base)]/70 backdrop-blur-sm"
     >
       <div
         onClick={(e) => e.stopPropagation()}
-        className="relative flex h-[560px] w-[640px] max-w-[92vw] flex-col overflow-hidden rounded-2xl border border-[--border-hairline] bg-[--bg-base] shadow-2xl"
+        className="relative flex h-[560px] w-[640px] max-w-[92vw] flex-col overflow-hidden rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-2xl"
       >
         {/* Header */}
-        <div className="flex items-center gap-3 border-b border-[--border-hairline] px-4 py-3">
+        <div className="flex items-center gap-3 border-b border-[var(--border-hairline)] px-4 py-3">
           {currentGlyph ? (
-            <span className="grid h-9 w-9 place-items-center rounded-lg bg-[--bg-raised]">
+            <span className="grid h-9 w-9 place-items-center rounded-lg bg-[var(--bg-raised)]">
               <GlyphView glyph={currentGlyph} size="md" />
             </span>
           ) : null}
           <div className="flex min-w-0 flex-1 flex-col">
-            <span className="truncate text-sm font-medium text-[--text-primary]">
+            <span className="truncate text-sm font-medium text-[var(--text-primary)]">
               {familiar.display_name}
             </span>
-            <span className="text-[11px] text-[--text-muted]">
+            <span className="text-[11px] text-[var(--text-muted)]">
               {hovered?.name ?? "Pick an icon"}
             </span>
           </div>
           <button
             onClick={onClose}
-            className="grid h-7 w-7 place-items-center rounded-md text-[--text-secondary] hover:bg-[--bg-raised] hover:text-[--text-primary]"
+            className="grid h-7 w-7 place-items-center rounded-md text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
             aria-label="Close"
             title="Close (esc)"
           >
@@ -145,11 +145,11 @@ export function FamiliarGlyphPicker({ open, familiar, onClose }: Props) {
         </div>
 
         {/* Search */}
-        <div className="border-b border-[--border-hairline] px-4 py-2.5">
+        <div className="border-b border-[var(--border-hairline)] px-4 py-2.5">
           <div className="relative">
             <Icon
               name="ph:magnifying-glass-bold"
-              className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-[--text-muted]"
+              className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-muted)]"
               width="0.9rem"
               height="0.9rem"
             />
@@ -159,15 +159,15 @@ export function FamiliarGlyphPicker({ open, familiar, onClose }: Props) {
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search cat, wand, sparkle…"
-              className="w-full rounded-md border border-[--border-hairline] bg-[--bg-raised]/50 py-1.5 pl-8 pr-3 text-sm text-[--text-primary] outline-none placeholder:text-[--text-muted] focus:border-[--border-strong]"
+              className="w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/50 py-1.5 pl-8 pr-3 text-sm text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)] focus:border-[var(--border-strong)]"
             />
           </div>
         </div>
 
         {/* Recent */}
         {recentEntries.length > 0 && !query.trim() ? (
-          <div className="border-b border-[--border-hairline] px-4 py-2.5">
-            <div className="mb-1.5 text-[10px] uppercase tracking-wider text-[--text-muted]">
+          <div className="border-b border-[var(--border-hairline)] px-4 py-2.5">
+            <div className="mb-1.5 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
               Recent
             </div>
             <div className="flex flex-wrap gap-1">
@@ -191,7 +191,7 @@ export function FamiliarGlyphPicker({ open, familiar, onClose }: Props) {
         ) : null}
 
         {/* Results count */}
-        <div className="flex items-center justify-between border-b border-[--border-hairline] px-4 py-1.5 text-[10px] text-[--text-muted]">
+        <div className="flex items-center justify-between border-b border-[var(--border-hairline)] px-4 py-1.5 text-[10px] text-[var(--text-muted)]">
           {query.trim() ? (
             <>
               <span>
@@ -201,7 +201,7 @@ export function FamiliarGlyphPicker({ open, familiar, onClose }: Props) {
               </span>
               <button
                 onClick={() => setQuery("")}
-                className="text-[--text-secondary] hover:text-[--text-primary]"
+                className="text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
               >
                 clear
               </button>
@@ -214,7 +214,7 @@ export function FamiliarGlyphPicker({ open, familiar, onClose }: Props) {
         {/* Grid */}
         <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
           {results.length === 0 ? (
-            <div className="grid h-full place-items-center text-sm text-[--text-muted]">
+            <div className="grid h-full place-items-center text-sm text-[var(--text-muted)]">
               No matches.
             </div>
           ) : query.trim() ? (
@@ -236,15 +236,15 @@ export function FamiliarGlyphPicker({ open, familiar, onClose }: Props) {
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between border-t border-[--border-hairline] px-4 py-2 text-[11px] text-[--text-muted]">
+        <div className="flex items-center justify-between border-t border-[var(--border-hairline)] px-4 py-2 text-[11px] text-[var(--text-muted)]">
           <button
             onClick={() => clearGlyphOverride(familiar.id)}
             disabled={!overrides[familiar.id]}
-            className="text-[--text-secondary] transition-colors hover:text-[--text-primary] disabled:cursor-not-allowed disabled:text-[--text-muted]"
+            className="text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)] disabled:cursor-not-allowed disabled:text-[var(--text-muted)]"
           >
             reset to default
           </button>
-          <span className="font-mono text-[--text-muted]">esc to close</span>
+          <span className="font-mono text-[var(--text-muted)]">esc to close</span>
         </div>
       </div>
     </div>
@@ -276,10 +276,10 @@ function GlyphButton({
       onMouseEnter={() => onHover(entry)}
       onMouseLeave={() => onHover(null)}
       title={entry.name}
-      className={`${cell} grid place-items-center rounded-md text-[--text-primary] transition-colors ${
+      className={`${cell} grid place-items-center rounded-md text-[var(--text-primary)] transition-colors ${
         active
           ? "bg-purple-600/30 ring-1 ring-purple-400"
-          : "hover:bg-[--bg-raised]/70"
+          : "hover:bg-[var(--bg-raised)]/70"
       }`}
     >
       <GlyphView glyph={glyph} size="sm" />
@@ -342,7 +342,7 @@ function CategorizedGrid({
         .filter((c) => byCategory.has(c))
         .map((c) => (
           <section key={c}>
-            <div className="mb-1.5 text-[10px] uppercase tracking-wider text-[--text-muted]">
+            <div className="mb-1.5 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
               {c}
             </div>
             <GlyphGrid

--- a/src/components/familiar-glyph.tsx
+++ b/src/components/familiar-glyph.tsx
@@ -58,7 +58,7 @@ export function FamiliarGlyph({ glyph, size = "md", className, title }: Props) {
   ensureRegistered();
   return (
     <span
-      className={className ?? "inline-flex items-center justify-center text-[--text-primary]"}
+      className={className ?? "inline-flex items-center justify-center text-[var(--text-primary)]"}
       title={title}
     >
       <IconifyIcon

--- a/src/components/inbox-toast.tsx
+++ b/src/components/inbox-toast.tsx
@@ -39,26 +39,26 @@ export function InboxToastStack({ toasts, onDismiss, onSnooze, onOpen }: Props) 
       {toasts.map((t) => (
         <div
           key={t.id}
-          className="pointer-events-auto rounded-xl border border-[--border-strong] bg-[--bg-raised] p-3 shadow-2xl"
+          className="pointer-events-auto rounded-xl border border-[var(--border-strong)] bg-[var(--bg-raised)] p-3 shadow-2xl"
         >
           <div className="mb-1 flex items-start gap-2">
             <Icon name="ph:alarm-fill" className="mt-0.5 shrink-0 text-amber-300" />
-            <span className="flex-1 text-sm font-medium text-[--text-primary]">{t.title}</span>
+            <span className="flex-1 text-sm font-medium text-[var(--text-primary)]">{t.title}</span>
             <button
               onClick={() => onDismiss(t.id)}
-              className="grid h-5 w-5 place-items-center text-[--text-muted] hover:text-[--text-primary]"
+              className="grid h-5 w-5 place-items-center text-[var(--text-muted)] hover:text-[var(--text-primary)]"
               aria-label="Dismiss"
             >
               <Icon name="ph:x-bold" />
             </button>
           </div>
           {t.body ? (
-            <p className="mb-2 line-clamp-3 text-[11px] text-[--text-secondary]">{t.body}</p>
+            <p className="mb-2 line-clamp-3 text-[11px] text-[var(--text-secondary)]">{t.body}</p>
           ) : null}
           <div className="flex gap-1.5">
             <button
               onClick={() => onDismiss(t.id)}
-              className="rounded border border-[--border-strong] px-2 py-0.5 text-[10px] text-[--text-secondary] hover:bg-[--bg-raised]"
+              className="rounded border border-[var(--border-strong)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
             >
               Dismiss
             </button>

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -79,16 +79,16 @@ export function InspectorPane({ familiar, inboxItems = [], onOpenInbox }: Props)
   const inboxBadge = familiarInbox.filter((i) => i.status === "fired").length;
 
   return (
-    <aside className="flex h-full flex-col border-l border-[--border-hairline] bg-[--bg-raised]/40">
-      <nav className="flex border-b border-[--border-hairline] text-[11px]">
+    <aside className="flex h-full flex-col border-l border-[var(--border-hairline)] bg-[var(--bg-raised)]/40">
+      <nav className="flex border-b border-[var(--border-hairline)] text-[11px]">
         {(["memory", "tools", "inbox"] as const).map((t) => (
           <button
             key={t}
             onClick={() => setTab(t)}
             className={`flex-1 px-3 py-3 uppercase tracking-widest transition-colors ${
               tab === t
-                ? "border-b-2 border-purple-500 text-[--text-primary]"
-                : "text-[--text-muted] hover:text-[--text-secondary]"
+                ? "border-b-2 border-purple-500 text-[var(--text-primary)]"
+                : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
             }`}
           >
             {TAB_LABEL[t]}
@@ -129,14 +129,14 @@ function InboxTab({
 }) {
   if (!familiar) {
     return (
-      <p className="p-4 text-xs text-[--text-muted]">
+      <p className="p-4 text-xs text-[var(--text-muted)]">
         Select a familiar to see its reminders.
       </p>
     );
   }
   if (items.length === 0) {
     return (
-      <div className="p-4 text-xs text-[--text-muted]">
+      <div className="p-4 text-xs text-[var(--text-muted)]">
         Nothing scheduled for {familiar.display_name}.
         {onOpenInbox ? (
           <button
@@ -154,10 +154,10 @@ function InboxTab({
       {items.map((it) => (
         <li
           key={it.id}
-          className="mb-2 rounded-md border border-[--border-hairline] bg-[--bg-raised]/40 px-2 py-2"
+          className="mb-2 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 py-2"
         >
           <div className="flex items-start justify-between gap-2">
-            <span className="flex-1 truncate text-[--text-primary]">{it.title}</span>
+            <span className="flex-1 truncate text-[var(--text-primary)]">{it.title}</span>
             <span
               className={`shrink-0 rounded px-1 py-px text-[9px] uppercase tracking-widest ${
                 it.status === "fired"
@@ -169,16 +169,16 @@ function InboxTab({
             </span>
           </div>
           {it.body ? (
-            <p className="mt-1 line-clamp-2 text-[10px] text-[--text-muted]">{it.body}</p>
+            <p className="mt-1 line-clamp-2 text-[10px] text-[var(--text-muted)]">{it.body}</p>
           ) : null}
-          <div className="mt-1 text-[10px] text-[--text-muted]">
+          <div className="mt-1 text-[10px] text-[var(--text-muted)]">
             {it.status === "fired"
               ? `fired ${age(it.firedAt ?? it.updatedAt)} ago`
               : `in ${age(it.fireAt ?? it.updatedAt)}`}
           </div>
           <div className="mt-1.5 flex gap-1">
             {it.id.startsWith("eph:") ? (
-              <span className="text-[10px] italic text-[--text-muted]">
+              <span className="text-[10px] italic text-[var(--text-muted)]">
                 respond in chat to clear
               </span>
             ) : (
@@ -191,7 +191,7 @@ function InboxTab({
                       body: JSON.stringify({ minutes: 10 }),
                     })
                   }
-                  className="rounded border border-[--border-hairline] bg-[--bg-raised] px-1.5 py-0.5 text-[10px] text-[--text-secondary] hover:bg-[--bg-raised]"
+                  className="rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
                 >
                   Snooze 10m
                 </button>
@@ -199,7 +199,7 @@ function InboxTab({
                   onClick={() =>
                     void fetch(`/api/inbox/${it.id}/dismiss`, { method: "POST" })
                   }
-                  className="rounded border border-[--border-hairline] bg-[--bg-raised] px-1.5 py-0.5 text-[10px] text-[--text-secondary] hover:bg-[--bg-raised]"
+                  className="rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
                 >
                   Dismiss
                 </button>
@@ -208,7 +208,7 @@ function InboxTab({
                     onClick={() =>
                       void fetch(`/api/inbox/${it.id}/done`, { method: "POST" })
                     }
-                    className="rounded border border-[--border-hairline] bg-[--bg-raised] px-1.5 py-0.5 text-[10px] text-[--text-secondary] hover:bg-[--bg-raised]"
+                    className="rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
                   >
                     Done
                   </button>
@@ -328,25 +328,25 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
       : 0;
     return (
       <div className="flex h-full flex-col">
-        <div className="flex items-center gap-2 border-b border-[--border-hairline] px-3 py-2 text-xs">
+        <div className="flex items-center gap-2 border-b border-[var(--border-hairline)] px-3 py-2 text-xs">
           <button
             onClick={() => {
               setOpenPath(null);
               setReveal(false);
             }}
-            className="rounded border border-[--border-strong] px-2 py-0.5 text-[--text-secondary] hover:bg-[--bg-raised]"
+            className="rounded border border-[var(--border-strong)] px-2 py-0.5 text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
           >
             ← back
           </button>
-          <div className="flex-1 truncate text-[--text-secondary]">{openPath.split("/").slice(-2).join("/")}</div>
+          <div className="flex-1 truncate text-[var(--text-secondary)]">{openPath.split("/").slice(-2).join("/")}</div>
         </div>
 
-        <div className="flex items-center justify-between border-b border-[--border-hairline] bg-[--bg-raised]/60 px-3 py-1.5 text-[11px]">
-          <div className="text-[--text-secondary]">
+        <div className="flex items-center justify-between border-b border-[var(--border-hairline)] bg-[var(--bg-raised)]/60 px-3 py-1.5 text-[11px]">
+          <div className="text-[var(--text-secondary)]">
             {totalRedactions > 0 ? (
               <span className="text-amber-300">{totalRedactions} secret{totalRedactions === 1 ? "" : "s"} redacted</span>
             ) : (
-              <span className="text-[--text-muted]">no secrets matched</span>
+              <span className="text-[var(--text-muted)]">no secrets matched</span>
             )}
           </div>
           <button
@@ -354,7 +354,7 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
             className={`rounded px-2 py-0.5 text-[10px] uppercase tracking-widest transition-colors ${
               reveal
                 ? "bg-rose-600/80 text-white hover:bg-rose-500"
-                : "border border-[--border-strong] text-[--text-secondary] hover:bg-[--bg-raised]"
+                : "border border-[var(--border-strong)] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
             }`}
             title={reveal ? "Hide secrets again" : "Reveal raw file (dangerous)"}
           >
@@ -362,7 +362,7 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
           </button>
         </div>
 
-        <pre className="min-h-0 flex-1 overflow-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-[11px] leading-relaxed text-[--text-primary]">
+        <pre className="min-h-0 flex-1 overflow-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-[11px] leading-relaxed text-[var(--text-primary)]">
           {openFile?.text ?? "loading…"}
         </pre>
       </div>
@@ -371,7 +371,7 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center gap-1 border-b border-[--border-hairline] px-2 py-1.5">
+      <div className="flex items-center gap-1 border-b border-[var(--border-hairline)] px-2 py-1.5">
         {(["coven", "files"] as const).map((m) => (
           <button
             key={m}
@@ -382,49 +382,49 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
             className={`rounded px-2 py-0.5 text-[10px] uppercase tracking-widest transition-colors ${
               mode === m
                 ? "bg-purple-600/80 text-white"
-                : "border border-[--border-strong] text-[--text-secondary] hover:bg-[--bg-raised]"
+                : "border border-[var(--border-strong)] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
             }`}
           >
             {m}
           </button>
         ))}
-        <span className="ml-auto text-[10px] text-[--text-muted]">
+        <span className="ml-auto text-[10px] text-[var(--text-muted)]">
           {mode === "coven" ? covenFiltered.length : filtered.length}
         </span>
       </div>
-      <div className="border-b border-[--border-hairline] p-2">
+      <div className="border-b border-[var(--border-hairline)] p-2">
         <input
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder={mode === "coven" ? "Filter coven memory…" : "Filter memory files…"}
-          className="w-full rounded-md border border-[--border-hairline] bg-[--bg-base] px-2 py-1 text-xs text-[--text-primary] outline-none placeholder:text-[--text-muted] focus:border-purple-600"
+          className="w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1 text-xs text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)] focus:border-purple-600"
         />
       </div>
 
       {mode === "coven" ? (
         <ul className="min-h-0 flex-1 overflow-y-auto p-2 text-xs">
           {covenFiltered.length === 0 ? (
-            <li className="px-2 py-4 text-center text-[--text-muted]">
+            <li className="px-2 py-4 text-center text-[var(--text-muted)]">
               {familiar
                 ? `No coven memory entries for ${familiar.display_name} yet.`
                 : "No coven memory entries yet."}
             </li>
           ) : null}
           {covenFiltered.map((e) => (
-            <li key={e.id} className="mb-2 rounded-md border border-[--border-hairline] bg-[--bg-raised]/40 px-2 py-1.5">
+            <li key={e.id} className="mb-2 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 py-1.5">
               <div className="flex items-center justify-between gap-2">
                 <span className="flex items-center gap-1.5 truncate">
-                  <span className="rounded bg-[--bg-raised] px-1 py-px text-[10px] text-[--text-secondary]">
+                  <span className="rounded bg-[var(--bg-raised)] px-1 py-px text-[10px] text-[var(--text-secondary)]">
                     {e.familiar_id}
                   </span>
-                  <span className="truncate text-[--text-primary]">{e.title}</span>
+                  <span className="truncate text-[var(--text-primary)]">{e.title}</span>
                 </span>
-                <span className="shrink-0 font-mono text-[10px] text-[--text-muted]">
+                <span className="shrink-0 font-mono text-[10px] text-[var(--text-muted)]">
                   {e.updated_at}
                 </span>
               </div>
               {e.excerpt ? (
-                <p className="mt-1 line-clamp-3 text-[10px] leading-snug text-[--text-secondary]">
+                <p className="mt-1 line-clamp-3 text-[10px] leading-snug text-[var(--text-secondary)]">
                   {e.excerpt}
                 </p>
               ) : null}
@@ -449,26 +449,26 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
       {mode === "files" ? (
       <ul className="min-h-0 flex-1 overflow-y-auto p-2 text-xs">
         {filtered.length === 0 ? (
-          <li className="px-2 py-4 text-center text-[--text-muted]">No matches.</li>
+          <li className="px-2 py-4 text-center text-[var(--text-muted)]">No matches.</li>
         ) : null}
         {filtered.slice(0, 200).map((e) => (
           <li key={e.fullPath}>
             <button
               onClick={() => setOpenPath(e.fullPath)}
-              className="flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-[--bg-raised]/60"
+              className="flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-[var(--bg-raised)]/60"
             >
               <span className="flex min-w-0 flex-col">
-                <span className="truncate text-[--text-primary]">{e.relPath}</span>
-                <span className="truncate text-[10px] uppercase tracking-widest text-[--text-muted]">
+                <span className="truncate text-[var(--text-primary)]">{e.relPath}</span>
+                <span className="truncate text-[10px] uppercase tracking-widest text-[var(--text-muted)]">
                   {e.rootLabel}
                 </span>
               </span>
-              <span className="shrink-0 font-mono text-[10px] text-[--text-muted]">{age(e.modified)}</span>
+              <span className="shrink-0 font-mono text-[10px] text-[var(--text-muted)]">{age(e.modified)}</span>
             </button>
           </li>
         ))}
         {filtered.length > 200 ? (
-          <li className="px-2 py-2 text-center text-[10px] text-[--text-muted]">
+          <li className="px-2 py-2 text-center text-[10px] text-[var(--text-muted)]">
             +{filtered.length - 200} more — filter to narrow
           </li>
         ) : null}
@@ -505,7 +505,7 @@ function ToolsTab() {
   }
 
   if (skills.length === 0) {
-    return <p className="p-4 text-xs text-[--text-muted]">No skills registered with the daemon yet.</p>;
+    return <p className="p-4 text-xs text-[var(--text-muted)]">No skills registered with the daemon yet.</p>;
   }
 
   return (
@@ -513,10 +513,10 @@ function ToolsTab() {
       {skills.map((s) => (
         <li
           key={s.id}
-          className="rounded-md border border-[--border-hairline] bg-[--bg-raised]/40 px-2 py-2"
+          className="rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 py-2"
         >
           <div className="flex items-center justify-between">
-            <span className="font-semibold text-[--text-primary]">{s.name}</span>
+            <span className="font-semibold text-[var(--text-primary)]">{s.name}</span>
             {s.category ? (
               <span className="rounded bg-purple-600/30 px-1.5 py-0.5 text-[10px] text-purple-200">
                 {s.category}
@@ -524,14 +524,14 @@ function ToolsTab() {
             ) : null}
           </div>
           {s.description ? (
-            <p className="mt-1 text-[11px] leading-snug text-[--text-secondary]">{s.description}</p>
+            <p className="mt-1 text-[11px] leading-snug text-[var(--text-secondary)]">{s.description}</p>
           ) : null}
           {s.tags && s.tags.length ? (
             <div className="mt-1.5 flex flex-wrap gap-1">
               {s.tags.map((t) => (
                 <span
                   key={t}
-                  className="rounded bg-[--bg-raised] px-1.5 py-0.5 text-[10px] text-[--text-secondary]"
+                  className="rounded bg-[var(--bg-raised)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)]"
                 >
                   {t}
                 </span>

--- a/src/components/new-reminder-modal.tsx
+++ b/src/components/new-reminder-modal.tsx
@@ -204,18 +204,18 @@ export function NewReminderModal({
     >
       <div
         onClick={(e) => e.stopPropagation()}
-        className="w-[560px] max-w-[94vw] max-h-[90vh] overflow-y-auto rounded-2xl border border-[--border-hairline] bg-[--bg-base] p-6 shadow-2xl"
+        className="w-[560px] max-w-[94vw] max-h-[90vh] overflow-y-auto rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-base)] p-6 shadow-2xl"
       >
         <div className="mb-5 flex items-start justify-between">
           <div>
-            <h2 className="text-lg font-semibold text-[--text-primary]">New reminder</h2>
-            <p className="text-[12px] text-[--text-muted]">
+            <h2 className="text-lg font-semibold text-[var(--text-primary)]">New reminder</h2>
+            <p className="text-[12px] text-[var(--text-muted)]">
               Type a natural phrase like “in 30m” or pick a date.
             </p>
           </div>
           <button
             onClick={onClose}
-            className="grid h-7 w-7 place-items-center rounded border border-[--border-hairline] text-[--text-secondary] hover:bg-[--bg-raised]"
+            className="grid h-7 w-7 place-items-center rounded border border-[var(--border-hairline)] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
             aria-label="Close"
           >
             <Icon name="ph:x-bold" />
@@ -228,7 +228,7 @@ export function NewReminderModal({
             onChange={(e) => setTitle(e.target.value)}
             placeholder="check the deploy"
             autoFocus
-            className="w-full rounded-md border border-[--border-hairline] bg-[--bg-raised]/40 px-3 py-2 text-sm text-[--text-primary] outline-none placeholder:text-[--text-muted] focus:border-purple-600"
+            className="w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-3 py-2 text-sm text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)] focus:border-purple-600"
           />
         </Field>
 
@@ -240,13 +240,13 @@ export function NewReminderModal({
               if (e.target.value.trim()) setManualFireAt("");
             }}
             placeholder="in 30m · in 2h · today 17:30 · tomorrow 9am"
-            className={`w-full rounded-md border bg-[--bg-raised]/40 px-3 py-2 text-sm text-[--text-primary] outline-none placeholder:text-[--text-muted] ${
+            className={`w-full rounded-md border bg-[var(--bg-raised)]/40 px-3 py-2 text-sm text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)] ${
               whenText && !parsed
                 ? "border-amber-600/60"
-                : "border-[--border-hairline] focus:border-purple-600"
+                : "border-[var(--border-hairline)] focus:border-purple-600"
             }`}
           />
-          <div className="mt-1 flex items-center justify-between text-[10px] text-[--text-muted]">
+          <div className="mt-1 flex items-center justify-between text-[10px] text-[var(--text-muted)]">
             <span>
               {whenText && !parsed
                 ? "Couldn't parse — try “in 30m”, “today 9pm”, or use the picker below."
@@ -266,7 +266,7 @@ export function NewReminderModal({
               if (e.target.value) setWhenText("");
             }}
             min={toLocalInput(new Date().toISOString())}
-            className="w-full rounded-md border border-[--border-hairline] bg-[--bg-raised]/40 px-3 py-2 text-sm text-[--text-primary] outline-none focus:border-purple-600"
+            className="w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-3 py-2 text-sm text-[var(--text-primary)] outline-none focus:border-purple-600"
           />
         </Field>
 
@@ -299,13 +299,13 @@ export function NewReminderModal({
               value={cronExpr}
               onChange={(e) => setCronExpr(e.target.value)}
               placeholder="*/15 * * * *"
-              className={`w-full rounded-md border bg-[--bg-raised]/40 px-3 py-2 font-mono text-sm text-[--text-primary] outline-none placeholder:text-[--text-muted] ${
+              className={`w-full rounded-md border bg-[var(--bg-raised)]/40 px-3 py-2 font-mono text-sm text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)] ${
                 cronExpr && !cronFields
                   ? "border-amber-600/60"
-                  : "border-[--border-hairline] focus:border-purple-600"
+                  : "border-[var(--border-hairline)] focus:border-purple-600"
               }`}
             />
-            <div className="mt-1 text-[10px] text-[--text-muted]">
+            <div className="mt-1 text-[10px] text-[var(--text-muted)]">
               {cronExpr && !cronFields
                 ? "Invalid cron expression."
                 : cronNextFire
@@ -337,7 +337,7 @@ export function NewReminderModal({
           </button>
           <button
             onClick={onClose}
-            className="rounded-md border border-[--border-hairline] bg-[--bg-raised] px-4 py-1.5 text-sm text-[--text-primary] hover:bg-[--bg-raised]"
+            className="rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-4 py-1.5 text-sm text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
           >
             Cancel
           </button>
@@ -350,7 +350,7 @@ export function NewReminderModal({
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <label className="mb-4 block">
-      <div className="mb-1.5 text-[10px] uppercase tracking-widest text-[--text-muted]">
+      <div className="mb-1.5 text-[10px] uppercase tracking-widest text-[var(--text-muted)]">
         {label}
       </div>
       {children}
@@ -372,15 +372,15 @@ function Select({
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="w-full appearance-none rounded-md border border-[--border-hairline] bg-[--bg-raised]/40 px-3 py-2 pr-8 text-sm text-[--text-primary] outline-none focus:border-purple-600"
+        className="w-full appearance-none rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-3 py-2 pr-8 text-sm text-[var(--text-primary)] outline-none focus:border-purple-600"
       >
         {options.map((o) => (
-          <option key={o.value} value={o.value} className="bg-[--bg-raised]">
+          <option key={o.value} value={o.value} className="bg-[var(--bg-raised)]">
             {o.label}
           </option>
         ))}
       </select>
-      <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[--text-muted]">
+      <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)]">
         ▾
       </span>
     </div>

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -119,7 +119,7 @@ export function NotificationBell({
         className={`relative grid h-7 w-7 place-items-center rounded-md border transition-colors ${
           badgeCount > 0
             ? "border-amber-500/60 bg-amber-500/10 text-amber-200 hover:bg-amber-500/20"
-            : "border-[--border-hairline] text-[--text-secondary] hover:bg-[--bg-raised] hover:text-[--text-primary]"
+            : "border-[var(--border-hairline)] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
         }`}
         title={`${badgeCount} unread`}
       >
@@ -133,15 +133,15 @@ export function NotificationBell({
       </button>
 
       {open ? (
-        <div className="absolute right-0 top-full z-50 mt-1 w-[360px] rounded-xl border border-[--border-hairline] bg-[--bg-base] shadow-2xl">
-          <div className="flex items-center justify-between border-b border-[--border-hairline] px-3 py-2">
-            <span className="text-[10px] uppercase tracking-widest text-[--text-muted]">
+        <div className="absolute right-0 top-full z-50 mt-1 w-[360px] rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-2xl">
+          <div className="flex items-center justify-between border-b border-[var(--border-hairline)] px-3 py-2">
+            <span className="text-[10px] uppercase tracking-widest text-[var(--text-muted)]">
               Notifications
             </span>
             <div className="flex items-center gap-2">
               <button
                 onClick={() => setSettingsOpen((v) => !v)}
-                className="grid h-5 w-5 place-items-center text-[--text-secondary] hover:text-[--text-primary]"
+                className="grid h-5 w-5 place-items-center text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
                 title="Notification settings"
                 aria-label="Notification settings"
               >
@@ -160,8 +160,8 @@ export function NotificationBell({
           </div>
 
           {settingsOpen ? (
-            <div className="border-b border-[--border-hairline] bg-[--bg-raised]/40 p-3 text-[11px]">
-              <div className="mb-2 text-[10px] uppercase tracking-widest text-[--text-muted]">
+            <div className="border-b border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 p-3 text-[11px]">
+              <div className="mb-2 text-[10px] uppercase tracking-widest text-[var(--text-muted)]">
                 Sound
               </div>
               <div className="mb-3 flex flex-wrap gap-1">
@@ -187,7 +187,7 @@ export function NotificationBell({
                       className={`rounded border px-2 py-0.5 text-[10px] ${
                         active
                           ? "border-purple-500 bg-purple-500/20 text-purple-100"
-                          : "border-[--border-strong] text-[--text-secondary] hover:bg-[--bg-raised]"
+                          : "border-[var(--border-strong)] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
                       }`}
                     >
                       {opt.label}
@@ -196,24 +196,24 @@ export function NotificationBell({
                 })}
               </div>
 
-              <div className="mb-1.5 text-[10px] uppercase tracking-widest text-[--text-muted]">
+              <div className="mb-1.5 text-[10px] uppercase tracking-widest text-[var(--text-muted)]">
                 Muted familiars
               </div>
               <ul className="max-h-32 space-y-0.5 overflow-y-auto">
                 {familiars.length === 0 ? (
-                  <li className="text-[10px] text-[--text-muted]">No familiars yet.</li>
+                  <li className="text-[10px] text-[var(--text-muted)]">No familiars yet.</li>
                 ) : null}
                 {familiars.map((f) => {
                   const muted = prefs.mutedFamiliars.includes(f.id);
                   return (
                     <li key={f.id} className="flex items-center justify-between">
-                      <span className="truncate text-[--text-secondary]">{f.display_name}</span>
+                      <span className="truncate text-[var(--text-secondary)]">{f.display_name}</span>
                       <button
                         onClick={() => toggleMute(f.id)}
                         className={`rounded border px-1.5 py-0.5 text-[10px] ${
                           muted
                             ? "border-amber-600 bg-amber-500/15 text-amber-200"
-                            : "border-[--border-strong] text-[--text-secondary] hover:bg-[--bg-raised]"
+                            : "border-[var(--border-strong)] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
                         }`}
                       >
                         {muted ? "muted" : "mute"}
@@ -226,14 +226,14 @@ export function NotificationBell({
           ) : null}
           <ul className="max-h-[420px] overflow-y-auto p-2 text-xs">
             {recent.length === 0 ? (
-              <li className="px-2 py-6 text-center text-[11px] text-[--text-muted]">
+              <li className="px-2 py-6 text-center text-[11px] text-[var(--text-muted)]">
                 No notifications.
               </li>
             ) : null}
             {recent.map((it) => (
               <li
                 key={it.id}
-                className="mb-1 rounded-md border border-[--border-hairline] bg-[--bg-raised]/40 p-2"
+                className="mb-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 p-2"
               >
                 <div className="flex items-start gap-2">
                   <Icon
@@ -244,18 +244,18 @@ export function NotificationBell({
                         ? "ph:magic-wand-fill"
                         : "ph:alarm-fill"
                     }
-                    className="mt-0.5 shrink-0 text-[--text-secondary]"
+                    className="mt-0.5 shrink-0 text-[var(--text-secondary)]"
                     width="0.95rem"
                     height="0.95rem"
                   />
                   <div className="min-w-0 flex-1">
-                    <div className="truncate text-[--text-primary]">{it.title}</div>
+                    <div className="truncate text-[var(--text-primary)]">{it.title}</div>
                     {it.body ? (
-                      <div className="mt-0.5 line-clamp-2 text-[10px] text-[--text-muted]">
+                      <div className="mt-0.5 line-clamp-2 text-[10px] text-[var(--text-muted)]">
                         {it.body}
                       </div>
                     ) : null}
-                    <div className="mt-0.5 text-[9px] text-[--text-muted]">
+                    <div className="mt-0.5 text-[9px] text-[var(--text-muted)]">
                       {it.status === "fired"
                         ? `fired ${relTime(it.firedAt)}`
                         : it.kind === "response-needed"
@@ -308,7 +308,7 @@ function BellBtn({
   return (
     <button
       onClick={onClick}
-      className="rounded border border-[--border-hairline] bg-[--bg-raised] px-1.5 py-0.5 text-[10px] text-[--text-secondary] hover:bg-[--bg-raised]"
+      className="rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
     >
       {children}
     </button>

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -138,19 +138,19 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
         detail: s?.covenCli.detail ?? s?.covenCli.hint ?? "checking…",
         action: s?.covenCli.ok ? null : (
           <div className="mt-2 space-y-2">
-            <div className="flex items-center gap-2 rounded-md border border-[--border-hairline] bg-[--bg-base] px-3 py-2 font-mono text-[12px] text-[--text-primary]">
-              <span className="text-[--text-muted]">$</span>
+            <div className="flex items-center gap-2 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-2 font-mono text-[12px] text-[var(--text-primary)]">
+              <span className="text-[var(--text-muted)]">$</span>
               <code className="flex-1">{installCmd}</code>
               <button
                 onClick={copyInstall}
-                className="rounded border border-[--border-hairline] px-2 py-0.5 text-[11px] text-[--text-secondary] hover:bg-[--bg-raised]"
+                className="rounded border border-[var(--border-hairline)] px-2 py-0.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
               >
                 copy
               </button>
             </div>
-            <p className="text-[11px] text-[--text-muted]">
+            <p className="text-[11px] text-[var(--text-muted)]">
               Or see{" "}
-              <span className="font-mono text-[--text-secondary]">github.com/OpenCoven/coven</span>{" "}
+              <span className="font-mono text-[var(--text-secondary)]">github.com/OpenCoven/coven</span>{" "}
               for other install paths. Re-checks every 2s.
             </p>
           </div>
@@ -165,7 +165,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
           <button
             onClick={scaffoldOnly}
             disabled={picking === "scaffold"}
-            className="mt-2 rounded-md border border-[--border-hairline] bg-[--bg-raised] px-3 py-1.5 text-[12px] text-[--text-primary] hover:bg-[--bg-raised] disabled:opacity-50"
+            className="mt-2 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-1.5 text-[12px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)] disabled:opacity-50"
           >
             {picking === "scaffold" ? "creating…" : "Create ~/.coven"}
           </button>
@@ -188,11 +188,11 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                   className={`rounded-lg border bg-gradient-to-br p-3 text-left transition disabled:opacity-50 ${
                     active
                       ? `${tmpl.accent} ring-1 ring-white/20`
-                      : "border-[--border-hairline] from-[--bg-raised]/40 to-[--bg-raised]/10 hover:border-[--border-strong]"
+                      : "border-[var(--border-hairline)] from-[var(--bg-raised)]/40 to-[var(--bg-raised)]/10 hover:border-[var(--border-strong)]"
                   }`}
                 >
-                  <div className="text-[13px] font-medium text-[--text-primary]">{tmpl.label}</div>
-                  <div className="mt-0.5 text-[11px] text-[--text-secondary]">{tmpl.blurb}</div>
+                  <div className="text-[13px] font-medium text-[var(--text-primary)]">{tmpl.label}</div>
+                  <div className="mt-0.5 text-[11px] text-[var(--text-secondary)]">{tmpl.blurb}</div>
                   {active ? (
                     <div className="mt-1.5 flex items-center gap-1 font-mono text-[10px] text-emerald-300">
                       <Icon name="ph:check-bold" />
@@ -214,7 +214,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
           <button
             onClick={startDaemon}
             disabled={startingDaemon || !s?.covenCli.ok}
-            className="mt-2 rounded-md border border-[--border-hairline] bg-[--bg-raised] px-3 py-1.5 text-[12px] text-[--text-primary] hover:bg-[--bg-raised] disabled:opacity-50"
+            className="mt-2 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-1.5 text-[12px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)] disabled:opacity-50"
             title={!s?.covenCli.ok ? "Install coven CLI first" : "Run `coven daemon start`"}
           >
             {startingDaemon ? "starting…" : "Start daemon"}
@@ -234,12 +234,12 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[--bg-base]/95 backdrop-blur-sm">
-      <div className="w-[540px] max-w-[94vw] max-h-[92vh] overflow-y-auto rounded-2xl border border-[--border-hairline] bg-[--bg-base] p-7 shadow-2xl">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--bg-base)]/95 backdrop-blur-sm">
+      <div className="w-[540px] max-w-[94vw] max-h-[92vh] overflow-y-auto rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-base)] p-7 shadow-2xl">
         <div className="mb-5">
           <div className="text-[11px] uppercase tracking-wider text-purple-300/80">Welcome</div>
-          <h1 className="mt-1 text-xl font-semibold text-[--text-primary]">Let's wake your Coven.</h1>
-          <p className="mt-1 text-[13px] text-[--text-secondary]">
+          <h1 className="mt-1 text-xl font-semibold text-[var(--text-primary)]">Let's wake your Coven.</h1>
+          <p className="mt-1 text-[13px] text-[var(--text-secondary)]">
             Five quick checks. Cave handles what it can; you handle the rest. Status refreshes automatically.
           </p>
         </div>
@@ -249,7 +249,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
             <li
               key={s.key}
               className={`rounded-xl border p-4 transition-colors ${
-                s.ok ? "border-emerald-700/40 bg-emerald-950/15" : "border-[--border-hairline] bg-[--bg-raised]/30"
+                s.ok ? "border-emerald-700/40 bg-emerald-950/15" : "border-[var(--border-hairline)] bg-[var(--bg-raised)]/30"
               }`}
             >
               <div className="flex items-start gap-3">
@@ -257,16 +257,16 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                   className={`mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-full border text-[12px] font-medium ${
                     s.ok
                       ? "border-emerald-600 bg-emerald-600/20 text-emerald-300"
-                      : "border-[--border-strong] bg-[--bg-raised] text-[--text-secondary]"
+                      : "border-[var(--border-strong)] bg-[var(--bg-raised)] text-[var(--text-secondary)]"
                   }`}
                 >
                   {s.ok ? <Icon name="ph:check-bold" /> : i + 1}
                 </span>
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
-                    <span className="text-[13px] font-medium text-[--text-primary]">{s.title}</span>
+                    <span className="text-[13px] font-medium text-[var(--text-primary)]">{s.title}</span>
                   </div>
-                  <div className="mt-0.5 text-[11px] text-[--text-muted] truncate">{s.detail}</div>
+                  <div className="mt-0.5 text-[11px] text-[var(--text-muted)] truncate">{s.detail}</div>
                   {s.action}
                 </div>
               </div>
@@ -284,7 +284,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
               }
               onDismiss();
             }}
-            className="text-[11px] text-[--text-muted] hover:text-[--text-secondary]"
+            className="text-[11px] text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
           >
             Skip for now
           </button>
@@ -296,7 +296,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
               Open Cave →
             </button>
           ) : (
-            <span className="text-[11px] text-[--text-muted]">
+            <span className="text-[11px] text-[var(--text-muted)]">
               {Object.values(status?.steps ?? {}).filter((s) => s.ok).length}/5 ready
             </span>
           )}

--- a/src/components/rich-text.tsx
+++ b/src/components/rich-text.tsx
@@ -27,7 +27,7 @@ export function RichText({ text }: { text: string }) {
     nodes.push(
       <code
         key={key++}
-        className="rounded bg-[--bg-raised]/80 px-1.5 py-0.5 font-mono text-[12px] text-[--text-primary]"
+        className="rounded bg-[var(--bg-raised)]/80 px-1.5 py-0.5 font-mono text-[12px] text-[var(--text-primary)]"
       >
         {code}
       </code>,

--- a/src/components/snooze-menu.tsx
+++ b/src/components/snooze-menu.tsx
@@ -39,8 +39,8 @@ export function SnoozeMenu({ onSnooze, className, size = "sm" }: Props) {
 
   const btnCls =
     size === "xs"
-      ? "rounded border border-[--border-hairline] bg-[--bg-raised] px-1.5 py-0.5 text-[10px] text-[--text-secondary] hover:bg-[--bg-raised]"
-      : "rounded border border-[--border-strong] px-2 py-0.5 text-[10px] text-[--text-secondary] hover:bg-[--bg-raised]";
+      ? "rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+      : "rounded border border-[var(--border-strong)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]";
 
   return (
     <div ref={wrapRef} className={`relative ${className ?? ""}`}>
@@ -48,7 +48,7 @@ export function SnoozeMenu({ onSnooze, className, size = "sm" }: Props) {
         Snooze ▾
       </button>
       {open ? (
-        <div className="absolute bottom-full left-0 z-50 mb-1 w-32 overflow-hidden rounded-md border border-[--border-strong] bg-[--bg-raised] shadow-xl">
+        <div className="absolute bottom-full left-0 z-50 mb-1 w-32 overflow-hidden rounded-md border border-[var(--border-strong)] bg-[var(--bg-raised)] shadow-xl">
           {OPTIONS.map((o) => (
             <button
               key={o.label}
@@ -56,7 +56,7 @@ export function SnoozeMenu({ onSnooze, className, size = "sm" }: Props) {
                 setOpen(false);
                 onSnooze(o.resolve());
               }}
-              className="block w-full px-2 py-1 text-left text-[11px] text-[--text-primary] hover:bg-[--bg-raised]"
+              className="block w-full px-2 py-1 text-left text-[11px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
             >
               {o.label}
             </button>


### PR DESCRIPTION
## The real bug

#39 tuned token opacity but **didn't actually fix the white borders** — those are still showing in the live app.

Diagnosed by inspecting the served CSS bundle:

```
--border-hairline\]\{border-color:--border-hairline\}
```

That's `border-color: --border-hairline` — the **literal token name**, not `var(--border-hairline)`. Tailwind 4 does NOT auto-`var()` arbitrary tokens that start with `--`. The bare ident is invalid as a color, so browsers fall back to `currentColor` — which on light text against dark bg renders as **bright white**. That's what we've been seeing for hours.

## Fix

Mechanical perl-replace across `src/`:

```
(border|bg|text|outline|fill|stroke|ring)-[--xxx]  →  $1-[var(--xxx)]
```

**234 occurrences across 16 components.** Same intent, syntax Tailwind 4 actually honors.

## Validation

- `grep -rn '(border|bg|text|outline)-\[--[a-z]' src/` → 0 results after the fix
- Mood C tokens (`--border-hairline`, `--bg-raised`, `--text-primary`, etc.) now resolve as designed → subtle 5%/8% hairlines instead of white-on-white walls.

## Urgency

Open Coven in <10 min. Auto-merging on green CI.