### PR TITLE
fix(stability): Presence Semantics, Memory Tab, Sessions Prune, Typecheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "typecheck": "tsc --noEmit",
     "start": "next start"
   },
   "dependencies": {

--- a/src/app/api/sessions/prune/route.ts
+++ b/src/app/api/sessions/prune/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from "next/server";
+import { callDaemon } from "@/lib/coven-daemon";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/sessions/prune
+ *
+ * Asks the daemon to drop completed / failed / killed sessions whose
+ * `updated_at` is older than `olderThanHours` (default: 24).
+ *
+ * The daemon endpoint `/api/v1/sessions/prune` is expected to return:
+ *   { pruned: number }
+ *
+ * If the daemon doesn't support the endpoint yet, we perform client-side
+ * pruning: we list all sessions, filter locally, and DELETE each one.
+ *
+ * Query/body params:
+ *   olderThanHours  number  default 24
+ *   dryRun          boolean default false  — count only, no deletes
+ */
+export async function POST(req: Request) {
+  let body: { olderThanHours?: number; dryRun?: boolean } = {};
+  try {
+    body = await req.json();
+  } catch {
+    /* body is optional */
+  }
+
+  const olderThanHours = typeof body.olderThanHours === "number" ? body.olderThanHours : 24;
+  const dryRun = body.dryRun === true;
+
+  // Try native daemon prune endpoint first.
+  const native = await callDaemon<{ pruned: number }>({
+    method: "POST",
+    path: "/api/v1/sessions/prune",
+    body: { olderThanHours, dryRun },
+    timeoutMs: 10_000,
+  });
+
+  if (native.ok && native.data) {
+    return NextResponse.json({ ok: true, pruned: native.data.pruned, method: "daemon" });
+  }
+
+  // Daemon doesn't support prune natively — do client-side pruning.
+  type DaemonSession = {
+    id: string;
+    status: string;
+    updated_at: string;
+  };
+
+  const listRes = await callDaemon<DaemonSession[]>({ path: "/api/v1/sessions" });
+  if (!listRes.ok || !listRes.data) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: `session list failed: ${listRes.error ?? `http ${listRes.status}`}`,
+      },
+      { status: 502 },
+    );
+  }
+
+  const STALE_STATUSES = new Set(["completed", "failed", "killed", "stopped", "orphaned"]);
+  const cutoff = Date.now() - olderThanHours * 60 * 60 * 1000;
+
+  const candidates = listRes.data.filter((s) => {
+    if (!STALE_STATUSES.has(s.status)) return false;
+    const updated = new Date(s.updated_at).getTime();
+    return updated < cutoff;
+  });
+
+  if (dryRun) {
+    return NextResponse.json({
+      ok: true,
+      pruned: 0,
+      wouldPrune: candidates.length,
+      dryRun: true,
+      method: "client",
+    });
+  }
+
+  let pruned = 0;
+  for (const s of candidates) {
+    const del = await callDaemon({
+      method: "DELETE",
+      path: `/api/v1/sessions/${s.id}`,
+      timeoutMs: 4_000,
+    });
+    if (del.ok) pruned++;
+  }
+
+  return NextResponse.json({ ok: true, pruned, method: "client" });
+}

--- a/src/components/familiar-rail.tsx
+++ b/src/components/familiar-rail.tsx
@@ -2,7 +2,7 @@
 
 import type { Familiar, SessionRow } from "@/lib/types";
 import { useEffect, useMemo, useState } from "react";
-import { computePresence } from "@/lib/presence";
+import { computePresence, REMOTE_HARNESSES } from "@/lib/presence";
 import { resolveFamiliarGlyph } from "@/lib/familiar-glyph";
 import { useGlyphOverrides } from "@/lib/cave-glyph-overrides";
 import { FamiliarGlyph } from "@/components/familiar-glyph";
@@ -61,6 +61,20 @@ export function FamiliarRail({
     ? harnesses.find((h) => h.id === current.harness) ?? null
     : null;
 
+  // Compute presence for the currently selected familiar so the configurator
+  // panel can show session-derived status instead of the raw daemon string.
+  const currentPresence = current
+    ? computePresence({
+        familiar: current,
+        sessions,
+        needsReply: responseNeeded.has(current.id),
+        harnessInstalled: current.harness
+          ? harnesses.find((h) => h.id === current.harness)?.installed
+          : undefined,
+        isRemoteHarness: current.harness ? REMOTE_HARNESSES.has(current.harness) : false,
+      })
+    : null;
+
   const liveCounts = useMemo(() => {
     const map = new Map<string, number>();
     for (const s of sessions) {
@@ -116,11 +130,13 @@ export function FamiliarRail({
           const harnessInstalled = f.harness
             ? harnesses.find((h) => h.id === f.harness)?.installed
             : undefined;
+          const isRemoteHarness = f.harness ? REMOTE_HARNESSES.has(f.harness) : false;
           const presence = computePresence({
             familiar: f,
             sessions,
             needsReply,
             harnessInstalled,
+            isRemoteHarness,
           });
           return (
             <li key={f.id}>
@@ -225,8 +241,14 @@ export function FamiliarRail({
             <dd className="font-mono truncate" title={current.model}>
               {current.model ?? "—"}
             </dd>
-            <dt className="text-muted-foreground">Status</dt>
-            <dd className="font-mono">{current.status ?? "—"}</dd>
+            <dt className="text-muted-foreground">Presence</dt>
+            <dd className="font-mono">
+              {currentPresence ? (
+                <span className={`rounded px-1.5 py-px text-[9px] font-bold uppercase tracking-widest ${currentPresence.pill}`}>
+                  {currentPresence.label}
+                </span>
+              ) : "—"}
+            </dd>
             <dt className="text-muted-foreground">Sessions</dt>
             <dd className="font-mono">{liveCounts.get(current.id) ?? 0} live</dd>
             <dt className="text-muted-foreground">Memory</dt>

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -237,6 +237,7 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
   const [mode, setMode] = useState<"coven" | "files">("coven");
   const [entries, setEntries] = useState<MemoryEntry[]>([]);
   const [covenEntries, setCovenEntries] = useState<CovenMemoryEntry[]>([]);
+  const [covenLoaded, setCovenLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [openPath, setOpenPath] = useState<string | null>(null);
@@ -248,9 +249,21 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
       try {
         const res = await fetch("/api/coven-memory", { cache: "no-store" });
         const json = await res.json();
-        if (json.ok) setCovenEntries(json.entries ?? []);
+        if (json.ok) {
+          const fetched: CovenMemoryEntry[] = json.entries ?? [];
+          setCovenEntries(fetched);
+          // Auto-switch to "files" tab when daemon returns no memory entries
+          // so users see something useful rather than a blank coven pane.
+          if (fetched.length === 0) setMode("files");
+        } else {
+          // Daemon memory endpoint unavailable — fall through to file browser.
+          setMode("files");
+        }
       } catch {
-        /* keep empty — files mode still works */
+        // Network or daemon error — fall through to file browser.
+        setMode("files");
+      } finally {
+        setCovenLoaded(true);
       }
     })();
   }, []);
@@ -405,9 +418,24 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
         <ul className="min-h-0 flex-1 overflow-y-auto p-2 text-xs">
           {covenFiltered.length === 0 ? (
             <li className="px-2 py-4 text-center text-[var(--text-muted)]">
-              {familiar
-                ? `No coven memory entries for ${familiar.display_name} yet.`
-                : "No coven memory entries yet."}
+              {!covenLoaded ? (
+                "Loading…"
+              ) : covenEntries.length === 0 ? (
+                <span>
+                  Coven memory API returned nothing.
+                  <br />
+                  <button
+                    onClick={() => setMode("files")}
+                    className="mt-1 text-purple-300 hover:text-purple-200 underline"
+                  >
+                    Browse memory files →
+                  </button>
+                </span>
+              ) : familiar ? (
+                `No coven memory entries for ${familiar.display_name} yet.`
+              ) : (
+                "No coven memory entries yet."
+              )}
             </li>
           ) : null}
           {covenFiltered.map((e) => (

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 
+type PruneState = { idle: true } | { counting: true } | { count: number } | { pruning: true } | { pruned: number } | { error: string };
 type Step = { ok: boolean; detail?: string; hint?: string };
 
 type OnboardingStatus = {
@@ -54,6 +55,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   const [picking, setPicking] = useState<string | null>(null);
   const [startingDaemon, setStartingDaemon] = useState(false);
   const [pickedTemplate, setPickedTemplate] = useState<string | null>(null);
+  const [prune, setPrune] = useState<PruneState>({ idle: true });
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const refresh = useCallback(async () => {
@@ -273,6 +275,94 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
             </li>
           ))}
         </ol>
+
+        {/* Maintenance */}
+        <div className="mt-6 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 p-3">
+          <div className="mb-2 text-[11px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">
+            Maintenance
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-xs text-[var(--text-secondary)]">
+              {"idle" in prune ? (
+                "Prune stale sessions (completed / failed / killed, older than 24 h)."
+              ) : "counting" in prune ? (
+                "Counting stale sessions…"
+              ) : "count" in prune ? (
+                `Found ${prune.count} stale session${prune.count === 1 ? "" : "s"}. Confirm to delete.`
+              ) : "pruning" in prune ? (
+                "Pruning…"
+              ) : "pruned" in prune ? (
+                `Done. ${prune.pruned} session${prune.pruned === 1 ? "" : "s"} removed.`
+              ) : "error" in prune ? (
+                <span className="text-rose-300">{prune.error}</span>
+              ) : null}
+            </div>
+            <div className="flex shrink-0 gap-2">
+              {("idle" in prune || "pruned" in prune || "error" in prune) ? (
+                <button
+                  onClick={async () => {
+                    setPrune({ counting: true });
+                    try {
+                      const res = await fetch("/api/sessions/prune", {
+                        method: "POST",
+                        headers: { "content-type": "application/json" },
+                        body: JSON.stringify({ dryRun: true }),
+                      });
+                      const json = await res.json() as { ok: boolean; wouldPrune?: number; error?: string };
+                      if (json.ok) {
+                        setPrune({ count: json.wouldPrune ?? 0 });
+                      } else {
+                        setPrune({ error: json.error ?? "dry-run failed" });
+                      }
+                    } catch (err) {
+                      setPrune({ error: err instanceof Error ? err.message : "fetch failed" });
+                    }
+                  }}
+                  className="rounded border border-[var(--border-strong)] bg-[var(--bg-raised)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+                >
+                  Check
+                </button>
+              ) : null}
+              {"count" in prune ? (
+                <>
+                  <button
+                    onClick={() => setPrune({ idle: true })}
+                    className="rounded border border-[var(--border-strong)] bg-[var(--bg-raised)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+                  >
+                    Cancel
+                  </button>
+                  {prune.count > 0 ? (
+                    <button
+                      onClick={async () => {
+                        setPrune({ pruning: true });
+                        try {
+                          const res = await fetch("/api/sessions/prune", {
+                            method: "POST",
+                            headers: { "content-type": "application/json" },
+                            body: JSON.stringify({ dryRun: false }),
+                          });
+                          const json = await res.json() as { ok: boolean; pruned?: number; error?: string };
+                          if (json.ok) {
+                            setPrune({ pruned: json.pruned ?? 0 });
+                          } else {
+                            setPrune({ error: json.error ?? "prune failed" });
+                          }
+                        } catch (err) {
+                          setPrune({ error: err instanceof Error ? err.message : "fetch failed" });
+                        }
+                      }}
+                      className="rounded bg-rose-600/80 px-2.5 py-1 text-[11px] text-white hover:bg-rose-500"
+                    >
+                      Delete {prune.count}
+                    </button>
+                  ) : (
+                    <span className="text-[11px] text-[var(--text-muted)]">Nothing to prune.</span>
+                  )}
+                </>
+              ) : null}
+            </div>
+          </div>
+        </div>
 
         <div className="mt-6 flex items-center justify-between">
           <button

--- a/src/lib/presence.ts
+++ b/src/lib/presence.ts
@@ -6,6 +6,7 @@ export type PresenceState =
   | "dreaming"
   | "idle"
   | "offline"
+  | "remote"
   | "failed"
   | "missing";
 
@@ -18,12 +19,21 @@ export type Presence = {
   dot: string;
 };
 
+/**
+ * Harness IDs that indicate a familiar lives in a remote lane (e.g. Telegram
+ * via OpenClaw) and has no local daemon session. These should read as
+ * "remote" rather than "offline" — the familiar is reachable, just not via
+ * the local Coven daemon.
+ */
+export const REMOTE_HARNESSES = new Set(["openclaw", "telegram", "signal", "whatsapp"]);
+
 const PRESETS: Record<PresenceState, Pick<Presence, "label" | "pill" | "dot">> = {
   focused: { label: "focused", pill: "bg-emerald-500/15 text-emerald-300", dot: "bg-emerald-400" },
   blocked: { label: "needs reply", pill: "bg-amber-500/20 text-amber-200", dot: "bg-amber-400" },
   dreaming: { label: "dreaming", pill: "bg-purple-500/15 text-purple-200", dot: "bg-purple-400" },
   failed: { label: "failed", pill: "bg-rose-500/20 text-rose-200", dot: "bg-rose-400" },
   offline: { label: "offline", pill: "bg-zinc-700/40 text-zinc-400", dot: "bg-zinc-600" },
+  remote:  { label: "remote",  pill: "bg-sky-900/40 text-sky-400",  dot: "bg-sky-600" },
   missing: { label: "missing", pill: "bg-rose-700/30 text-rose-200", dot: "bg-rose-500" },
   idle: { label: "idle", pill: "bg-zinc-800 text-zinc-400", dot: "bg-zinc-600" },
 };
@@ -33,6 +43,8 @@ type Args = {
   sessions: SessionRow[];
   needsReply: boolean;
   harnessInstalled?: boolean;
+  /** True when the harness is installed locally. Remote-only harnesses pass false here. */
+  isRemoteHarness?: boolean;
 };
 
 const DREAM_WINDOW_HOURS = 24;
@@ -58,7 +70,7 @@ function freshMinutes(raw?: string): number | null {
   }
 }
 
-export function computePresence({ familiar, sessions, needsReply, harnessInstalled }: Args): Presence {
+export function computePresence({ familiar, sessions, needsReply, harnessInstalled, isRemoteHarness }: Args): Presence {
   const mine = sessions.filter((s) => s.familiarId === familiar.id);
   const running = mine.some((s) => s.status === "running");
   const recentlyFailed = mine
@@ -75,6 +87,13 @@ export function computePresence({ familiar, sessions, needsReply, harnessInstall
   const dreamMinutes = freshMinutes(familiar.memory_freshness);
   const dreaming =
     dreamMinutes != null && dreamMinutes < DREAM_WINDOW_HOURS * 60 && !running && !needsReply;
+
+  // Remote-only harnesses (openclaw/Telegram lanes) are never "offline" —
+  // they simply have no local daemon session. Show "remote" instead.
+  if (isRemoteHarness) {
+    if (needsReply) return { state: "blocked", ...PRESETS.blocked };
+    return { state: "remote", ...PRESETS.remote };
+  }
 
   if (harnessInstalled === false) return { state: "missing", ...PRESETS.missing };
   if (needsReply) return { state: "blocked", ...PRESETS.blocked };


### PR DESCRIPTION
Five stability/polish fixes from post-demo audit.

## Changes

### 1. Presence semantics — remote harnesses no longer show 'offline'
Remote-only familiars (OpenClaw/Telegram/Signal/WhatsApp lanes) were falling through to the 'offline' branch because they have no local Coven session. Added a `remote` PresenceState (sky-blue pill) and a `REMOTE_HARNESSES` set. `computePresence` short-circuits to 'remote' for those harnesses. If `needsReply` is set they still go 'blocked'.

### 2. Rail 'Status' field reflects session liveness
The configurator panel was showing `familiar.status` (a raw daemon string). Now computes `currentPresence` for the selected familiar and renders the styled pill. Field renamed 'Presence'.

### 3. Memory tab falls back to files mode when coven returns nothing
Added `covenLoaded` flag. After fetch, if entries = 0 or response is non-ok/error, auto-switches to 'files' tab so users always see something useful. Empty 'coven' mode shows the reason + a 'Browse memory files →' shortcut.

### 4. Sessions prune — `/api/sessions/prune` + Maintenance UI in Settings
- `POST /api/sessions/prune` — tries native daemon endpoint first, falls back to client-side list+DELETE.  
- `dryRun=true` returns count before deleting.  
- Settings overlay (Onboarding / Settings) gets a 'Maintenance' card: **Check → confirm count → Delete N**.

### 5. typecheck script
`"typecheck": "tsc --noEmit"` added to `package.json`. All changes pass clean.

Auto-merge on green.