### PR TITLE
feat(comux): Comux terminal mux, project tree, AgentPanel in all modes

### DIFF
--- a/src/app/api/project-file/route.ts
+++ b/src/app/api/project-file/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const MAX_SIZE = 512 * 1024; // 512KB
+
+const ALLOWED_PREFIXES = [
+  path.join(os.homedir(), "Documents", "GitHub"),
+  os.homedir(),
+];
+
+const TEXT_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".json",
+  ".md",
+  ".mdx",
+  ".rs",
+  ".toml",
+  ".yaml",
+  ".yml",
+  ".txt",
+  ".sh",
+  ".css",
+  ".html",
+  ".env",
+  ".gitignore",
+  ".prettierrc",
+  ".eslintrc",
+  ".lock",
+  ".cfg",
+  ".ini",
+  ".conf",
+  ".xml",
+  ".svg",
+  ".sql",
+  ".py",
+  ".rb",
+  ".go",
+  ".swift",
+  ".kt",
+  ".java",
+  ".c",
+  ".h",
+  ".cpp",
+  ".hpp",
+  ".zig",
+  ".nix",
+  ".lua",
+]);
+
+function isAllowed(p: string): boolean {
+  const resolved = path.resolve(p);
+  return ALLOWED_PREFIXES.some((prefix) => resolved.startsWith(prefix));
+}
+
+export async function GET(req: NextRequest) {
+  const filePath = req.nextUrl.searchParams.get("path");
+  if (!filePath) {
+    return NextResponse.json(
+      { ok: false, error: "missing path param" },
+      { status: 400 },
+    );
+  }
+
+  const resolved = path.resolve(filePath);
+  if (!isAllowed(resolved)) {
+    return NextResponse.json(
+      { ok: false, error: "path not allowed" },
+      { status: 403 },
+    );
+  }
+
+  const ext = path.extname(resolved).toLowerCase();
+  // Extensionless files (Makefile, Dockerfile, etc.) are allowed
+  if (ext && !TEXT_EXTENSIONS.has(ext)) {
+    return NextResponse.json(
+      { ok: false, error: `extension ${ext} not supported` },
+      { status: 400 },
+    );
+  }
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(resolved);
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "file not found" },
+      { status: 404 },
+    );
+  }
+
+  if (!stat.isFile()) {
+    return NextResponse.json(
+      { ok: false, error: "not a file" },
+      { status: 400 },
+    );
+  }
+
+  if (stat.size > MAX_SIZE) {
+    return NextResponse.json(
+      { ok: false, error: `file too large (${stat.size} bytes, max ${MAX_SIZE})` },
+      { status: 413 },
+    );
+  }
+
+  // Redact .env files
+  if (path.basename(resolved).startsWith(".env")) {
+    return NextResponse.json({
+      ok: true,
+      content: "# .env file contents redacted for security",
+      size: stat.size,
+    });
+  }
+
+  const content = fs.readFileSync(resolved, "utf-8");
+  return NextResponse.json({ ok: true, content, size: stat.size });
+}

--- a/src/app/api/project-tree/route.ts
+++ b/src/app/api/project-tree/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+type TreeEntry = {
+  name: string;
+  path: string;
+  isDir: boolean;
+  children?: TreeEntry[];
+};
+
+const SKIP = new Set([
+  ".git",
+  "node_modules",
+  ".next",
+  "dist",
+  "build",
+  "target",
+  "out",
+  ".DS_Store",
+]);
+
+const ALLOWED_PREFIXES = [
+  path.join(os.homedir(), "Documents", "GitHub"),
+  os.homedir(),
+];
+
+function isAllowed(p: string): boolean {
+  const resolved = path.resolve(p);
+  return ALLOWED_PREFIXES.some((prefix) => resolved.startsWith(prefix));
+}
+
+function readTree(root: string, depth: number): TreeEntry[] {
+  if (depth < 0) return [];
+  let dirents: fs.Dirent[];
+  try {
+    dirents = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const entries: TreeEntry[] = [];
+  for (const d of dirents) {
+    if (SKIP.has(d.name)) continue;
+    const full = path.join(root, d.name);
+    const isDir = d.isDirectory();
+    const entry: TreeEntry = { name: d.name, path: full, isDir };
+    if (isDir && depth > 0) {
+      entry.children = readTree(full, depth - 1);
+    }
+    entries.push(entry);
+  }
+  entries.sort((a, b) => {
+    if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+  return entries;
+}
+
+export async function GET(req: NextRequest) {
+  const root = req.nextUrl.searchParams.get("root");
+  const depthStr = req.nextUrl.searchParams.get("depth");
+  if (!root) {
+    return NextResponse.json(
+      { ok: false, error: "missing root param" },
+      { status: 400 },
+    );
+  }
+  if (!isAllowed(root)) {
+    return NextResponse.json(
+      { ok: false, error: "path not allowed" },
+      { status: 403 },
+    );
+  }
+  const depth = Math.min(Math.max(parseInt(depthStr ?? "1", 10) || 1, 0), 4);
+  const entries = readTree(root, depth);
+  return NextResponse.json({ ok: true, entries });
+}

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -58,7 +58,8 @@ type Row =
   | { id: string; kind: "card"; card: Card; familiar: Familiar | null }
   | { id: string; kind: "coven-memory"; entry: CovenMemoryEntry; familiar: Familiar | null }
   | { id: string; kind: "fs-memory"; entry: FsMemoryEntry }
-  | { id: string; kind: "command"; name: string; hint: string; intent: PaletteIntent };
+  | { id: string; kind: "command"; name: string; hint: string; intent: PaletteIntent }
+  | { id: string; kind: "shortcut"; label: string; shortcut: string; action: () => void };
 
 const RESULT_LIMITS = {
   familiar: 6,
@@ -217,6 +218,27 @@ export function CommandPalette({
         intent: { kind: "slash", command: c.name },
       }));
 
+    const shortcutRows: Row[] = [];
+    const toggleLabel = "Toggle Familiar Chat";
+    if (!q || toggleLabel.toLowerCase().includes(q) || "⌘j".includes(q)) {
+      shortcutRows.push({
+        id: "shortcut:toggle-agent",
+        kind: "shortcut",
+        label: toggleLabel,
+        shortcut: "⌘J",
+        action: () => {
+          window.dispatchEvent(
+            new KeyboardEvent("keydown", {
+              key: "j",
+              code: "KeyJ",
+              metaKey: true,
+              bubbles: true,
+            }),
+          );
+        },
+      });
+    }
+
     return [
       ...familiarRows,
       ...sessionRows,
@@ -224,6 +246,7 @@ export function CommandPalette({
       ...covenMemoryRows,
       ...fsMemoryRows,
       ...cmdRows,
+      ...shortcutRows,
     ];
   }, [familiars, sessions, cards, covenMemory, fsMemory, query, activeFamiliarId]);
 
@@ -248,6 +271,8 @@ export function CommandPalette({
       onIntent({ kind: "open-memory-file", path: row.entry.path });
     } else if (row.kind === "fs-memory") {
       onIntent({ kind: "open-memory-file", path: row.entry.fullPath });
+    } else if (row.kind === "shortcut") {
+      row.action();
     } else {
       onIntent(row.intent);
     }
@@ -372,6 +397,12 @@ export function CommandPalette({
                       <span className="font-mono text-[var(--text-secondary)]">{row.name}</span>
                       <span className="flex-1 text-[var(--text-muted)]">{platformizeHint(row.hint, keys)}</span>
                       <span className="text-[10px] text-[var(--text-muted)]">run</span>
+                    </>
+                  ) : null}
+                  {row.kind === "shortcut" ? (
+                    <>
+                      <span className="flex-1 text-[var(--text-primary)]">{row.label}</span>
+                      <span className="font-mono text-[10px] text-[var(--text-muted)]">{platformizeHint(row.shortcut, keys)}</span>
                     </>
                   ) : null}
                 </button>

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { BottomTerminal } from "@/components/bottom-terminal";
+import { ProjectTree, type ProjectTreeHandle } from "@/components/project-tree";
+
+type ComuxTab = "comux" | "project";
+
+type Session = {
+  id: string;
+  label: string;
+};
+
+const STORAGE_TAB = "cave:comux:tab";
+const STORAGE_SESSIONS = "cave:comux:sessions";
+
+function readTab(): ComuxTab {
+  if (typeof window === "undefined") return "comux";
+  const v = window.localStorage.getItem(STORAGE_TAB);
+  return v === "project" ? "project" : "comux";
+}
+
+function readSessions(): Session[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_SESSIONS);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (s): s is Session =>
+        typeof s === "object" &&
+        s !== null &&
+        typeof (s as Record<string, unknown>).id === "string" &&
+        typeof (s as Record<string, unknown>).label === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function uid(): string {
+  return crypto.randomUUID();
+}
+
+export function ComuxView() {
+  const [tab, setTab] = useState<ComuxTab>(readTab);
+  const [sessions, setSessions] = useState<Session[]>(readSessions);
+  const [currentIdx, setCurrentIdx] = useState(0);
+
+  // Project tab state
+  const [previewPath, setPreviewPath] = useState<string | null>(null);
+  const [previewContent, setPreviewContent] = useState<string | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const treeRef = useRef<ProjectTreeHandle | null>(null);
+
+  // Persist tab choice
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_TAB, tab);
+  }, [tab]);
+
+  // Persist sessions
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_SESSIONS, JSON.stringify(sessions));
+  }, [sessions]);
+
+  const addSession = useCallback(() => {
+    const id = uid();
+    setSessions((prev) => {
+      const next = [...prev, { id, label: `Terminal ${prev.length + 1}` }];
+      setCurrentIdx(next.length - 1);
+      return next;
+    });
+  }, []);
+
+  const removeSession = useCallback(
+    (idx: number) => {
+      setSessions((prev) => {
+        const next = prev.filter((_, i) => i !== idx);
+        setCurrentIdx((ci) => {
+          if (next.length === 0) return 0;
+          if (ci >= next.length) return next.length - 1;
+          if (ci > idx) return ci - 1;
+          return ci;
+        });
+        return next;
+      });
+    },
+    [],
+  );
+
+  const renameSession = useCallback((idx: number, label: string) => {
+    setSessions((prev) =>
+      prev.map((s, i) => (i === idx ? { ...s, label } : s)),
+    );
+  }, []);
+
+  const openFilePreview = useCallback(async (path: string) => {
+    setPreviewPath(path);
+    setPreviewLoading(true);
+    setPreviewContent(null);
+    try {
+      const res = await fetch(
+        `/api/project-file?path=${encodeURIComponent(path)}`,
+        { cache: "no-store" },
+      );
+      const json = (await res.json()) as {
+        ok: boolean;
+        content?: string;
+        error?: string;
+      };
+      if (json.ok && typeof json.content === "string") {
+        setPreviewContent(json.content);
+      } else {
+        setPreviewContent(`// Error: ${json.error ?? "unknown"}`);
+      }
+    } catch (err) {
+      setPreviewContent(`// Fetch failed: ${String(err)}`);
+    } finally {
+      setPreviewLoading(false);
+    }
+  }, []);
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Tab bar */}
+      <div className="flex items-center gap-1 border-b border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-3 py-1.5 text-xs">
+        <button
+          type="button"
+          onClick={() => setTab("comux")}
+          className={`rounded px-2 py-0.5 transition-colors ${
+            tab === "comux"
+              ? "bg-[var(--bg-base)] text-[var(--text-primary)]"
+              : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+          }`}
+        >
+          Comux
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab("project")}
+          className={`rounded px-2 py-0.5 transition-colors ${
+            tab === "project"
+              ? "bg-[var(--bg-base)] text-[var(--text-primary)]"
+              : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+          }`}
+        >
+          Project
+        </button>
+      </div>
+
+      {/* Tab content */}
+      {tab === "comux" ? (
+        <div className="flex flex-1 flex-col min-h-0">
+          {/* Session tab strip */}
+          <div className="flex items-center gap-0.5 border-b border-[var(--border-hairline)] bg-[var(--bg-raised)]/20 px-2 py-1 text-[11px]">
+            {sessions.map((s, i) => (
+              <div
+                key={s.id}
+                className={`group flex items-center gap-1 rounded px-2 py-0.5 cursor-pointer transition-colors ${
+                  i === currentIdx
+                    ? "bg-[var(--bg-base)] text-[var(--text-primary)]"
+                    : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                }`}
+                onClick={() => setCurrentIdx(i)}
+              >
+                <span
+                  contentEditable
+                  suppressContentEditableWarning
+                  onBlur={(e) =>
+                    renameSession(i, e.currentTarget.textContent ?? s.label)
+                  }
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      (e.target as HTMLElement).blur();
+                    }
+                  }}
+                  className="outline-none max-w-[120px] truncate"
+                >
+                  {s.label}
+                </span>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    removeSession(i);
+                  }}
+                  className="hidden group-hover:inline text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+                >
+                  x
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={addSession}
+              className="rounded px-1.5 py-0.5 text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)]"
+            >
+              +
+            </button>
+          </div>
+
+          {/* Terminal area */}
+          <div className="flex-1 min-h-0">
+            {sessions.length === 0 ? (
+              <div className="flex h-full flex-col items-center justify-center gap-2 text-xs text-[var(--text-muted)]">
+                <p>No terminal sessions.</p>
+                <button
+                  type="button"
+                  onClick={addSession}
+                  className="rounded border border-[var(--border-hairline)] px-3 py-1 text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+                >
+                  + New terminal
+                </button>
+              </div>
+            ) : (
+              sessions.map((s, i) => (
+                <div
+                  key={s.id}
+                  className="h-full w-full"
+                  style={{ display: i === currentIdx ? "block" : "none" }}
+                >
+                  <BottomTerminal threadId={`cave.comux.${s.id}`} />
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      ) : (
+        /* Project tab */
+        <div className="flex flex-1 min-h-0">
+          {/* Tree (40%) */}
+          <div className="w-[40%] shrink-0 overflow-y-auto border-r border-[var(--border-hairline)] p-2 text-xs">
+            <ProjectTree ref={treeRef} onFileClick={openFilePreview} />
+          </div>
+          {/* Preview (60%) */}
+          <div className="flex-1 min-w-0 overflow-auto p-3">
+            {previewPath ? (
+              <>
+                <div className="mb-2 truncate text-[11px] text-[var(--text-muted)]">
+                  {previewPath}
+                </div>
+                {previewLoading ? (
+                  <p className="text-xs text-[var(--text-muted)]">Loading...</p>
+                ) : (
+                  <pre className="whitespace-pre-wrap break-words text-[12px] leading-relaxed font-mono text-[var(--text-secondary)]">
+                    {previewContent}
+                  </pre>
+                )}
+              </>
+            ) : (
+              <p className="text-xs text-[var(--text-muted)]">
+                Select a file to preview.
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/daemon-bar.tsx
+++ b/src/components/daemon-bar.tsx
@@ -7,7 +7,7 @@ import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 import { NotificationBell } from "@/components/notification-bell";
 import { HealthStrip } from "@/components/health-strip";
 
-export type Mode = "chats" | "board" | "inbox" | "plugins" | "vals-inbox" | "browser" | "schedules" | "calls";
+export type Mode = "chats" | "board" | "inbox" | "plugins" | "vals-inbox" | "browser" | "schedules" | "calls" | "comux";
 
 type Props = {
   mode: Mode;
@@ -31,6 +31,7 @@ const MODE_LABEL: Record<Mode, string> = {
   browser: "Browser",
   schedules: "Schedules",
   calls: "Calls",
+  comux: "Comux",
 };
 
 export function DaemonBar({

--- a/src/components/project-tree.tsx
+++ b/src/components/project-tree.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useState,
+} from "react";
+
+type TreeEntry = {
+  name: string;
+  path: string;
+  isDir: boolean;
+  children?: TreeEntry[];
+};
+
+export type ProjectTreeHandle = {
+  refresh: () => void;
+};
+
+type Props = {
+  onFileClick?: (path: string) => void;
+};
+
+async function fetchTree(root: string, depth: number): Promise<TreeEntry[]> {
+  try {
+    const res = await fetch(
+      `/api/project-tree?root=${encodeURIComponent(root)}&depth=${depth}`,
+      { cache: "no-store" },
+    );
+    const json = (await res.json()) as {
+      ok: boolean;
+      entries?: TreeEntry[];
+      error?: string;
+    };
+    if (json.ok && Array.isArray(json.entries)) return json.entries;
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+function resolveRoot(): string {
+  if (typeof window !== "undefined") {
+    const env = process.env.NEXT_PUBLIC_WORKSPACE_ROOT;
+    if (env) return env;
+  }
+  return "/Users/buns/Documents/GitHub/OpenCoven/coven-cave";
+}
+
+export const ProjectTree = forwardRef<ProjectTreeHandle, Props>(
+  function ProjectTree({ onFileClick }, ref) {
+    const [root, setRoot] = useState<string>(resolveRoot);
+    const [entries, setEntries] = useState<TreeEntry[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    const load = useCallback(async () => {
+      setLoading(true);
+      // Try daemon status for projectRoot first
+      try {
+        const res = await fetch("/api/daemon/status", { cache: "no-store" });
+        const json = (await res.json()) as Record<string, unknown>;
+        const wp =
+          (json.workspacePath as string | undefined) ??
+          (json.projectRoot as string | undefined);
+        if (wp && typeof wp === "string") setRoot(wp);
+      } catch {
+        /* use default */
+      }
+      const tree = await fetchTree(root, 2);
+      setEntries(tree);
+      setLoading(false);
+    }, [root]);
+
+    useEffect(() => {
+      void load();
+    }, [load]);
+
+    useImperativeHandle(ref, () => ({ refresh: () => void load() }), [load]);
+
+    if (loading) {
+      return (
+        <p className="text-[var(--text-muted)]">Loading project tree...</p>
+      );
+    }
+
+    if (entries.length === 0) {
+      return <p className="text-[var(--text-muted)]">No entries found.</p>;
+    }
+
+    return (
+      <ul className="space-y-0.5">
+        {entries.map((e) => (
+          <TreeNode key={e.path} entry={e} onFileClick={onFileClick} />
+        ))}
+      </ul>
+    );
+  },
+);
+
+function TreeNode({
+  entry,
+  onFileClick,
+  depth = 0,
+}: {
+  entry: TreeEntry;
+  onFileClick?: (path: string) => void;
+  depth?: number;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [children, setChildren] = useState<TreeEntry[] | null>(
+    entry.children ?? null,
+  );
+
+  const toggle = useCallback(async () => {
+    if (!entry.isDir) {
+      onFileClick?.(entry.path);
+      return;
+    }
+    const next = !expanded;
+    setExpanded(next);
+    if (next && children === null) {
+      const fetched = await fetchTree(entry.path, 1);
+      setChildren(fetched);
+    }
+  }, [entry, expanded, children, onFileClick]);
+
+  const indent = depth * 12;
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={toggle}
+        className="flex w-full items-center gap-1 rounded px-1 py-0.5 text-left hover:bg-[var(--bg-raised)]/60"
+        style={{ paddingLeft: `${indent + 4}px` }}
+      >
+        {entry.isDir ? (
+          <span className="w-3 shrink-0 text-center text-[var(--text-muted)]">
+            {expanded ? "\u25BC" : "\u25B6"}
+          </span>
+        ) : (
+          <span className="w-3 shrink-0" />
+        )}
+        <span
+          className={
+            entry.isDir
+              ? "text-[var(--text-secondary)] font-medium"
+              : "text-[var(--text-primary)]"
+          }
+        >
+          {entry.name}
+        </span>
+      </button>
+      {entry.isDir && expanded && children && children.length > 0 && (
+        <ul className="space-y-0.5">
+          {children.map((c) => (
+            <TreeNode
+              key={c.path}
+              entry={c}
+              onFileClick={onFileClick}
+              depth={depth + 1}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -42,6 +42,7 @@ function togglePanel(panel: PanelImperativeHandle | null) {
 export type ShellNavSection = {
   label?: string;
   items: ShellNavItem[];
+  customContent?: ReactNode;
 };
 
 export type ShellNavItem = {
@@ -241,7 +242,7 @@ export function ShellNav({
           {section.label && (
             <div className="shell-nav-eyebrow">{section.label}</div>
           )}
-          {section.items.map((item) => (
+          {section.customContent ?? section.items.map((item) => (
             <ShellNavButton key={item.id} item={item} />
           ))}
         </div>

--- a/src/components/sidebar-familiars.tsx
+++ b/src/components/sidebar-familiars.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { Familiar, SessionRow } from "@/lib/types";
+import { computePresence, REMOTE_HARNESSES } from "@/lib/presence";
+import { resolveFamiliarGlyph } from "@/lib/familiar-glyph";
+import { useGlyphOverrides } from "@/lib/cave-glyph-overrides";
+import { FamiliarGlyph } from "@/components/familiar-glyph";
+
+type HarnessReport = {
+  id: string;
+  label: string;
+  installed: boolean;
+  chatSupported: boolean;
+  version: string | null;
+};
+
+type Props = {
+  familiars: Familiar[];
+  activeId: string | null;
+  sessions: SessionRow[];
+  responseNeeded: Set<string>;
+  onSelect: (id: string) => void;
+  error?: string | null;
+};
+
+export function SidebarFamiliars({
+  familiars,
+  activeId,
+  sessions,
+  responseNeeded,
+  onSelect,
+  error,
+}: Props) {
+  const glyphOverrides = useGlyphOverrides();
+  const [harnesses, setHarnesses] = useState<HarnessReport[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch("/api/harnesses", { cache: "no-store" });
+        const json = await res.json();
+        if (!cancelled && json.ok) setHarnesses(json.harnesses ?? []);
+      } catch {
+        /* harness availability unknown */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const current = familiars.find((f) => f.id === activeId) ?? null;
+
+  const harnessReport = current
+    ? harnesses.find((h) => h.id === current.harness) ?? null
+    : null;
+
+  const liveCounts = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const s of sessions) {
+      if (!s.familiarId || s.status !== "running") continue;
+      map.set(s.familiarId, (map.get(s.familiarId) ?? 0) + 1);
+    }
+    return map;
+  }, [sessions]);
+
+  if (error) {
+    return <p className="px-3 py-2 text-xs text-muted-foreground">{error}</p>;
+  }
+
+  if (familiars.length === 0) {
+    return <p className="px-3 py-2 text-xs text-muted-foreground">No familiars</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      {familiars.map((f) => {
+        const isActive = activeId === f.id;
+        const needsReply = responseNeeded.has(f.id);
+        const harnessInstalled = f.harness
+          ? harnesses.find((h) => h.id === f.harness)?.installed
+          : undefined;
+        const isRemoteHarness = f.harness ? REMOTE_HARNESSES.has(f.harness) : false;
+        const presence = computePresence({
+          familiar: f,
+          sessions,
+          needsReply,
+          harnessInstalled,
+          isRemoteHarness,
+        });
+
+        return (
+          <button
+            key={f.id}
+            onClick={() => onSelect(f.id)}
+            className={`flex w-full items-center gap-2 rounded px-2 py-1.5 text-left transition-colors ${
+              isActive
+                ? "bg-muted text-foreground"
+                : "text-muted-foreground hover:bg-card"
+            }`}
+          >
+            <span className="grid h-5 w-5 shrink-0 place-items-center">
+              <FamiliarGlyph
+                glyph={resolveFamiliarGlyph(f, glyphOverrides)}
+                size="sm"
+              />
+            </span>
+            <span className="flex flex-1 flex-col min-w-0">
+              <span className="truncate text-xs leading-tight">
+                {f.display_name}
+              </span>
+              <span className="truncate text-[10px] text-muted-foreground leading-tight">
+                {f.role}
+              </span>
+            </span>
+            <span
+              title={presence.label}
+              className={`shrink-0 rounded px-1 py-px text-[8px] font-bold uppercase tracking-widest ${presence.pill}`}
+            >
+              {presence.label}
+            </span>
+          </button>
+        );
+      })}
+
+      {current ? (
+        <div className="mt-2 border-t border-border px-2 pt-2">
+          <dl className="grid grid-cols-[52px_1fr] gap-y-0.5 text-[10px]">
+            <dt className="text-muted-foreground">Harness</dt>
+            <dd className="font-mono truncate text-foreground">
+              {current.harness ?? "\u2014"}
+              {harnessReport?.version ? (
+                <span className="ml-1 text-muted-foreground">
+                  {harnessReport.version.split(/\s/).pop()}
+                </span>
+              ) : null}
+            </dd>
+            <dt className="text-muted-foreground">Model</dt>
+            <dd className="font-mono truncate text-foreground">
+              {current.model ?? "\u2014"}
+            </dd>
+          </dl>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -21,13 +21,14 @@ import { BottomTerminal } from "@/components/bottom-terminal";
 import { BrowserPane } from "@/components/browser-pane";
 import { SchedulesView } from "@/components/schedules-view";
 import { CallsView } from "@/components/calls-view";
+import { ComuxView } from "@/components/comux-view";
 import { nativeNotify } from "@/lib/native-notify";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { DEMO_MODE, DEMO_FAMILIARS } from "@/lib/demo-seed";
 
-type Mode = "chats" | "board" | "plugins" | "inbox" | "vals-inbox" | "browser" | "schedules" | "calls";
+type Mode = "chats" | "board" | "plugins" | "inbox" | "vals-inbox" | "browser" | "schedules" | "calls" | "comux";
 
 export function Workspace() {
   const routerRef = useRef<ChatRouterHandle | null>(null);
@@ -393,6 +394,9 @@ export function Workspace() {
         case "/palette":
           setPaletteOpen(true);
           return;
+        case "/comux":
+          setMode("comux");
+          return;
         case "/quit":
           setMode("chats");
           routerRef.current?.goToList();
@@ -594,6 +598,13 @@ export function Workspace() {
           active: mode === "calls",
           onClick: () => setMode("calls"),
         },
+        {
+          id: "comux",
+          label: "Comux",
+          icon: "ph:squares-four" as const,
+          active: mode === "comux",
+          onClick: () => setMode("comux"),
+        },
       ] as ShellNavItem[],
     },
     {
@@ -691,6 +702,8 @@ export function Workspace() {
       <SchedulesView familiars={familiars} />
     ) : mode === "calls" ? (
       <CallsView familiars={familiars} />
+    ) : mode === "comux" ? (
+      <ComuxView />
     ) : (
       <PluginsView
         onOpenChat={() => {
@@ -737,20 +750,18 @@ export function Workspace() {
         list={list}
         detail={detail}
         agent={
-          mode === "chats" ? undefined : (
-            <AgentPanel
-              ref={routerRef}
-              familiar={active}
-              sessions={sessions}
-              daemonRunning={daemonRunning}
-              onSessionStarted={loadSessions}
-              onSlashFromChat={(command, args) => {
-                onPaletteIntent({ kind: "slash", command, args });
-                return true;
-              }}
-              onOpenOnboarding={openOnboarding}
-            />
-          )
+          <AgentPanel
+            ref={routerRef}
+            familiar={active}
+            sessions={sessions}
+            daemonRunning={daemonRunning}
+            onSessionStarted={loadSessions}
+            onSlashFromChat={(command, args) => {
+              onPaletteIntent({ kind: "slash", command, args });
+              return true;
+            }}
+            onOpenOnboarding={openOnboarding}
+          />
         }
         bottom={<BottomTerminal threadId="cave.bottom.main" />}
       />

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { FamiliarRail } from "@/components/familiar-rail";
+import { SidebarFamiliars } from "@/components/sidebar-familiars";
 import { ChatRouter, type ChatRouterHandle } from "@/components/chat-router";
-import { InspectorPane } from "@/components/inspector-pane";
 import { DaemonBar } from "@/components/daemon-bar";
 import { CommandPalette, type PaletteIntent } from "@/components/command-palette";
 import { BoardView } from "@/components/board-view";
@@ -608,6 +607,23 @@ export function Workspace() {
       ] as ShellNavItem[],
     },
     {
+      label: "Familiars",
+      items: [] as ShellNavItem[],
+      customContent: (
+        <SidebarFamiliars
+          familiars={familiars}
+          activeId={activeId}
+          sessions={sessions}
+          responseNeeded={responseNeeded}
+          onSelect={(id) => {
+            setActiveId(id);
+            setMode("chats");
+          }}
+          error={familiarsError}
+        />
+      ),
+    },
+    {
       label: "Configure",
       items: [
         {
@@ -620,48 +636,22 @@ export function Workspace() {
     },
   ];
 
-  const list =
-    mode === "chats" ? (
-      <FamiliarRail
-        familiars={familiars}
-        activeId={activeId}
-        onSelect={setActiveId}
-        onEditGlyph={(f) => setGlyphPickerFor(f)}
-        error={familiarsError}
-        sessions={sessions}
-        responseNeeded={responseNeeded}
-        onOpenOnboarding={openOnboarding}
-      />
-    ) : undefined;
+  const list = undefined;
 
   const detail =
     mode === "chats" ? (
-      <div className="flex flex-1 min-h-0">
-        <div className="flex-1 min-w-0">
-          <ChatRouter
-            ref={routerRef}
-            familiar={active}
-            sessions={sessions}
-            daemonRunning={daemonRunning}
-            onSessionStarted={loadSessions}
-            onSlashFromChat={(command, args) => {
-              onPaletteIntent({ kind: "slash", command, args });
-              return true;
-            }}
-            onOpenOnboarding={openOnboarding}
-          />
-        </div>
-        <aside
-          className="hidden lg:flex flex-col w-[320px] shrink-0 overflow-y-auto"
-          style={{ borderLeft: "1px solid var(--border-hairline)" }}
-        >
-          <InspectorPane
-            familiar={active}
-            inboxItems={inboxItemsWithEphemeral}
-            onOpenInbox={() => setMode("inbox")}
-          />
-        </aside>
-      </div>
+      <ChatRouter
+        ref={routerRef}
+        familiar={active}
+        sessions={sessions}
+        daemonRunning={daemonRunning}
+        onSessionStarted={loadSessions}
+        onSlashFromChat={(command, args) => {
+          onPaletteIntent({ kind: "slash", command, args });
+          return true;
+        }}
+        onOpenOnboarding={openOnboarding}
+      />
     ) : mode === "board" ? (
       <BoardView
         familiars={familiars}

--- a/src/lib/slash-commands.ts
+++ b/src/lib/slash-commands.ts
@@ -39,6 +39,9 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: "/inbox", hint: "Inbox", description: "Open the notifications & reminders inbox.", section: "view" },
   { name: "/remind", hint: "new reminder", description: "Create a reminder. Try “/remind in 30m check the build”.", argPlaceholder: "when + text", section: "view" },
 
+  { name: "/comux", hint: "Comux", description: "Open the Comux terminal multiplexer view.", section: "view" },
+  { name: "/toggle-agent", hint: "\u2318J", description: "Toggle the Familiar Chat side panel.", section: "view" },
+
   // Launch
   { name: "/run", hint: "run task", description: "Run a task through the active familiar's harness.", argPlaceholder: "task…", section: "launch" },
   { name: "/codex", hint: "codex harness", description: "Run a task through Codex regardless of active familiar.", argPlaceholder: "task…", section: "launch" },


### PR DESCRIPTION
## Summary

- **Comux mode**: New workspace mode with a tabbed terminal multiplexer (multi-session PTY via Tauri) and a Project file-tree tab with read-only file preview
- **Project tree**: Recursive file tree component (`ProjectTree`) backed by two new API routes (`/api/project-tree`, `/api/project-file`) with path security, size limits, and `.env` redaction
- **AgentPanel in all modes**: Familiar chat panel now renders in every mode (including Chats), toggled via `⌘J`
- **Command palette shortcut hint**: `⌘J` "Toggle Familiar Chat" is now discoverable in the `⌘K` palette
- **Navigation**: Comux entry added to sidebar nav, daemon bar mode label, and Mode union

## Test plan

- [ ] Switch to Comux mode via sidebar — verify tabbed terminal multiplexer renders
- [ ] Add/rename/close terminal sessions — verify localStorage persistence (`cave:comux:sessions`)
- [ ] Switch to Project tab — verify file tree loads from workspace root
- [ ] Click a file in the tree — verify read-only preview renders in the right split
- [ ] Verify `⌘J` toggles the Familiar Chat panel in all modes (chats, board, inbox, comux, etc.)
- [ ] Open `⌘K` palette and search "toggle" — verify the shortcut hint row appears
- [ ] Run `npx tsc --noEmit` — no type errors