### PR TITLE
feat(calls): Coven Calls view — delegation cards + call graph (#21)

### DIFF
--- a/src/app/api/coven-calls/route.ts
+++ b/src/app/api/coven-calls/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { loadCalls, recordCall, type CovenCallInput } from "@/lib/coven-calls";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  const file = await loadCalls();
+  // Newest first — graph view + recent-edge popover both want this.
+  const sorted = [...file.calls].sort((a, b) =>
+    b.createdAt.localeCompare(a.createdAt),
+  );
+  return NextResponse.json({ ok: true, calls: sorted });
+}
+
+export async function POST(req: Request) {
+  let body: CovenCallInput;
+  try {
+    body = (await req.json()) as CovenCallInput;
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "invalid json body" },
+      { status: 400 },
+    );
+  }
+  if (!body.callerFamiliarId || !body.calleeFamiliarId || !body.request?.trim()) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "callerFamiliarId, calleeFamiliarId, and request are required",
+      },
+      { status: 400 },
+    );
+  }
+  const call = await recordCall(body);
+  return NextResponse.json({ ok: true, call });
+}

--- a/src/components/calls-view.tsx
+++ b/src/components/calls-view.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { Familiar } from "@/lib/types";
+import { aggregateEdges, type CallEdge, type CovenCall } from "@/lib/coven-calls-types";
+import { DelegationCard } from "@/components/delegation-card";
+
+// Coven Calls view (issue #21) — read-only delegation timeline + a
+// simple circular-layout graph showing who called whom across the
+// current call log. Daemon-side delegation events are forthcoming;
+// until then this lights up an empty state.
+
+type Props = {
+  familiars: Familiar[];
+};
+
+export function CallsView({ familiars }: Props) {
+  const [calls, setCalls] = useState<CovenCall[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/coven-calls", { cache: "no-store" });
+      const json = await res.json();
+      if (!json.ok) {
+        setError(json.error ?? "calls load failed");
+        return;
+      }
+      setCalls(json.calls ?? []);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "fetch failed");
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+    const t = setInterval(load, 10000);
+    return () => clearInterval(t);
+  }, [load]);
+
+  const famById = useMemo(() => {
+    const m = new Map<string, Familiar>();
+    for (const f of familiars) m.set(f.id, f);
+    return m;
+  }, [familiars]);
+
+  const edges = useMemo(() => aggregateEdges(calls), [calls]);
+
+  return (
+    <section className="flex h-full flex-col bg-[var(--bg-base)]">
+      <header className="border-b border-[var(--border-hairline)] px-5 py-3">
+        <h1 className="text-sm font-medium text-[var(--text-primary)]">
+          Coven Calls
+        </h1>
+        <p className="mt-0.5 text-[11px] text-[var(--text-muted)]">
+          Delegation timeline + who-called-whom across familiars.
+        </p>
+      </header>
+
+      {error ? (
+        <div className="border-b border-amber-700/40 bg-amber-900/20 px-5 py-1.5 text-[11px] text-amber-200">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-y-auto px-5 py-4 lg:grid-cols-[1fr_360px]">
+        <section className="min-w-0">
+          <h2 className="mb-2 text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">
+            Recent delegations
+          </h2>
+          {calls.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 px-5 py-10 text-center text-sm text-[var(--text-secondary)]">
+              No coven calls yet. The daemon will emit a delegation event
+              each time one familiar calls another ({" "}
+              <code className="rounded bg-[var(--bg-raised)] px-1 py-0.5 font-mono text-[11px]">
+                :cody &quot;task&quot;
+              </code>{" "}
+              etc.) and they will appear here.
+            </div>
+          ) : (
+            <ul className="space-y-2">
+              {calls.map((c) => (
+                <li key={c.id}>
+                  <DelegationCard call={c} familiars={famById} />
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <aside className="min-w-0">
+          <h2 className="mb-2 text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">
+            Call graph
+          </h2>
+          <CallGraph
+            familiars={familiars}
+            edges={edges}
+            emptyText={calls.length === 0 ? "no calls yet" : ""}
+          />
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+/* ----- Graph (SVG, circular layout, no external dep) ----- */
+
+function CallGraph({
+  familiars,
+  edges,
+  emptyText,
+}: {
+  familiars: Familiar[];
+  edges: CallEdge[];
+  emptyText: string;
+}) {
+  // Only render nodes that appear in at least one edge — keeps the graph
+  // legible when many familiars exist but only a few delegate.
+  const nodeIds = useMemo(() => {
+    const s = new Set<string>();
+    for (const e of edges) {
+      s.add(e.caller);
+      s.add(e.callee);
+    }
+    return Array.from(s);
+  }, [edges]);
+
+  const W = 320;
+  const H = 320;
+  const cx = W / 2;
+  const cy = H / 2;
+  const r = Math.min(W, H) / 2 - 30;
+
+  const positions = useMemo(() => {
+    const m = new Map<string, { x: number; y: number }>();
+    nodeIds.forEach((id, i) => {
+      const theta = (i / Math.max(nodeIds.length, 1)) * Math.PI * 2 - Math.PI / 2;
+      m.set(id, { x: cx + r * Math.cos(theta), y: cy + r * Math.sin(theta) });
+    });
+    return m;
+  }, [nodeIds, cx, cy, r]);
+
+  if (nodeIds.length === 0) {
+    return (
+      <div
+        className="grid place-items-center rounded-2xl border border-dashed border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 text-[11px] text-[var(--text-muted)]"
+        style={{ height: H }}
+      >
+        {emptyText || "no graph"}
+      </div>
+    );
+  }
+
+  const maxCount = Math.max(...edges.map((e) => e.count));
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      className="rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-raised)]/30"
+      style={{ width: "100%", height: H }}
+    >
+      {edges.map((e, i) => {
+        const a = positions.get(e.caller);
+        const b = positions.get(e.callee);
+        if (!a || !b) return null;
+        const stroke = 1 + (e.count / maxCount) * 4;
+        return (
+          <g key={i}>
+            <line
+              x1={a.x}
+              y1={a.y}
+              x2={b.x}
+              y2={b.y}
+              stroke="var(--accent-presence)"
+              strokeOpacity={0.45}
+              strokeWidth={stroke}
+              strokeLinecap="round"
+            />
+          </g>
+        );
+      })}
+      {nodeIds.map((id) => {
+        const f = familiars.find((x) => x.id === id);
+        const p = positions.get(id)!;
+        return (
+          <g key={id}>
+            <circle
+              cx={p.x}
+              cy={p.y}
+              r={14}
+              fill="var(--bg-raised)"
+              stroke="var(--accent-presence)"
+              strokeOpacity={0.6}
+            />
+            <text
+              x={p.x}
+              y={p.y + 4}
+              textAnchor="middle"
+              fontSize="10"
+              fontWeight="600"
+              fill="var(--text-primary)"
+            >
+              {(f?.display_name ?? id).slice(0, 1).toUpperCase()}
+            </text>
+            <text
+              x={p.x}
+              y={p.y + 28}
+              textAnchor="middle"
+              fontSize="9"
+              fill="var(--text-secondary)"
+            >
+              {f?.display_name ?? id}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/src/components/daemon-bar.tsx
+++ b/src/components/daemon-bar.tsx
@@ -7,7 +7,7 @@ import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 import { NotificationBell } from "@/components/notification-bell";
 import { HealthStrip } from "@/components/health-strip";
 
-export type Mode = "chats" | "board" | "inbox" | "plugins" | "vals-inbox" | "browser" | "schedules";
+export type Mode = "chats" | "board" | "inbox" | "plugins" | "vals-inbox" | "browser" | "schedules" | "calls";
 
 type Props = {
   mode: Mode;
@@ -30,6 +30,7 @@ const MODE_LABEL: Record<Mode, string> = {
   "vals-inbox": "Val's Inbox",
   browser: "Browser",
   schedules: "Schedules",
+  calls: "Calls",
 };
 
 export function DaemonBar({

--- a/src/components/delegation-card.tsx
+++ b/src/components/delegation-card.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Icon } from "@/lib/icon";
+import type { Familiar } from "@/lib/types";
+import type { CovenCall } from "@/lib/coven-calls-types";
+
+// DelegationCard — primitive that renders a single Coven Call as
+// caller → callee · request · status · return artifact link.
+// Used in the calls list, the cross-familiar timeline, and (future)
+// the inspector's calls tab.
+
+type Props = {
+  call: CovenCall;
+  familiars: Map<string, Familiar>;
+  /** Optional click handler for the artifact link (file path, session, etc.). */
+  onOpenArtifact?: (call: CovenCall) => void;
+};
+
+function avatar(f: Familiar | undefined): string {
+  if (!f) return "?";
+  return (f.display_name ?? f.id).slice(0, 1).toUpperCase();
+}
+
+function statusPill(status: CovenCall["status"]): string {
+  switch (status) {
+    case "running":
+      return "bg-emerald-500/15 text-emerald-300";
+    case "completed":
+      return "bg-[var(--bg-raised)] text-[var(--text-secondary)]";
+    case "failed":
+      return "bg-rose-500/20 text-rose-200";
+    case "cancelled":
+      return "bg-amber-500/20 text-amber-200";
+  }
+}
+
+export function DelegationCard({ call, familiars, onOpenArtifact }: Props) {
+  const caller = familiars.get(call.callerFamiliarId);
+  const callee = familiars.get(call.calleeFamiliarId);
+  return (
+    <div className="rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-3 py-2.5">
+      <div className="flex items-center gap-2 text-[12px]">
+        <span
+          className="grid h-6 w-6 place-items-center rounded-full bg-[var(--bg-raised)] text-[10px] font-semibold text-[var(--text-primary)]"
+          title={caller?.display_name ?? call.callerFamiliarId}
+        >
+          {avatar(caller)}
+        </span>
+        <span className="text-[var(--text-secondary)]">
+          {caller?.display_name ?? call.callerFamiliarId}
+        </span>
+        <Icon
+          name="ph:caret-right-bold"
+          width={10}
+          className="text-[var(--text-muted)]"
+        />
+        <span
+          className="grid h-6 w-6 place-items-center rounded-full bg-[var(--accent-presence)]/30 text-[10px] font-semibold text-[var(--text-primary)]"
+          title={callee?.display_name ?? call.calleeFamiliarId}
+        >
+          {avatar(callee)}
+        </span>
+        <span className="font-medium text-[var(--text-primary)]">
+          {callee?.display_name ?? call.calleeFamiliarId}
+        </span>
+        <span
+          className={`ml-auto rounded-full px-2 py-0.5 text-[10px] uppercase tracking-wider ${statusPill(call.status)}`}
+        >
+          {call.status}
+        </span>
+      </div>
+      <p className="mt-1.5 line-clamp-2 text-[12px] leading-snug text-[var(--text-secondary)]">
+        {call.request}
+      </p>
+      {call.artifact ? (
+        <button
+          type="button"
+          onClick={() => onOpenArtifact?.(call)}
+          className="mt-1.5 flex items-center gap-1 text-[11px] text-[var(--accent-presence-soft)] hover:underline"
+        >
+          <Icon name="ph:arrow-square-out" width={10} />
+          <span className="truncate">{call.artifact}</span>
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -20,13 +20,14 @@ import { AgentPanel } from "@/components/agent-panel";
 import { BottomTerminal } from "@/components/bottom-terminal";
 import { BrowserPane } from "@/components/browser-pane";
 import { SchedulesView } from "@/components/schedules-view";
+import { CallsView } from "@/components/calls-view";
 import { nativeNotify } from "@/lib/native-notify";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { DEMO_MODE, DEMO_FAMILIARS } from "@/lib/demo-seed";
 
-type Mode = "chats" | "board" | "plugins" | "inbox" | "vals-inbox" | "browser" | "schedules";
+type Mode = "chats" | "board" | "plugins" | "inbox" | "vals-inbox" | "browser" | "schedules" | "calls";
 
 export function Workspace() {
   const routerRef = useRef<ChatRouterHandle | null>(null);
@@ -586,6 +587,13 @@ export function Workspace() {
           active: mode === "schedules",
           onClick: () => setMode("schedules"),
         },
+        {
+          id: "calls",
+          label: "Calls",
+          icon: "ph:graph" as const,
+          active: mode === "calls",
+          onClick: () => setMode("calls"),
+        },
       ] as ShellNavItem[],
     },
     {
@@ -681,6 +689,8 @@ export function Workspace() {
       <BrowserPane label="default" />
     ) : mode === "schedules" ? (
       <SchedulesView familiars={familiars} />
+    ) : mode === "calls" ? (
+      <CallsView familiars={familiars} />
     ) : (
       <PluginsView
         onOpenChat={() => {

--- a/src/lib/coven-calls-types.ts
+++ b/src/lib/coven-calls-types.ts
@@ -1,0 +1,47 @@
+// Pure types + pure-function helpers for Coven Calls — extracted out of
+// coven-calls.ts so client components can import without dragging
+// node:fs/promises into the browser bundle. Same split-pattern as
+// vals-inbox-types vs vals-inbox.
+
+export type CallStatus = "running" | "completed" | "failed" | "cancelled";
+
+export type CovenCall = {
+  id: string;
+  callerFamiliarId: string;
+  calleeFamiliarId: string;
+  request: string;
+  artifact?: string;
+  status: CallStatus;
+  createdAt: string;
+  endedAt?: string;
+  sessionId?: string;
+};
+
+export type CovenCallInput = {
+  callerFamiliarId: string;
+  calleeFamiliarId: string;
+  request: string;
+  sessionId?: string;
+};
+
+export type CallEdge = {
+  caller: string;
+  callee: string;
+  count: number;
+};
+
+export function aggregateEdges(calls: CovenCall[]): CallEdge[] {
+  const map = new Map<string, CallEdge>();
+  for (const c of calls) {
+    const key = `${c.callerFamiliarId}->${c.calleeFamiliarId}`;
+    const existing = map.get(key);
+    if (existing) existing.count += 1;
+    else
+      map.set(key, {
+        caller: c.callerFamiliarId,
+        callee: c.calleeFamiliarId,
+        count: 1,
+      });
+  }
+  return Array.from(map.values()).sort((a, b) => b.count - a.count);
+}

--- a/src/lib/coven-calls.ts
+++ b/src/lib/coven-calls.ts
@@ -1,0 +1,85 @@
+// Coven Calls store (issue #21) — appended to by the daemon when one
+// familiar delegates to another. Cave reads and surfaces the events.
+// Pure types + aggregator live in coven-calls-types so client code
+// can import without pulling in node:fs.
+
+import { mkdir, readFile, writeFile, rename } from "node:fs/promises";
+import path from "node:path";
+import { homedir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import type {
+  CovenCall,
+  CovenCallInput,
+} from "@/lib/coven-calls-types";
+
+export type {
+  CallStatus,
+  CovenCall,
+  CovenCallInput,
+  CallEdge,
+} from "@/lib/coven-calls-types";
+export { aggregateEdges } from "@/lib/coven-calls-types";
+
+const FILE_PATH = path.join(homedir(), ".coven", "cave-coven-calls.json");
+
+type CallsFile = {
+  version: number;
+  calls: CovenCall[];
+};
+
+const EMPTY: CallsFile = { version: 1, calls: [] };
+
+async function ensureDir() {
+  await mkdir(path.dirname(FILE_PATH), { recursive: true });
+}
+
+export async function loadCalls(): Promise<CallsFile> {
+  try {
+    const raw = await readFile(FILE_PATH, "utf8");
+    const parsed = JSON.parse(raw) as Partial<CallsFile>;
+    return {
+      version: parsed.version ?? 1,
+      calls: Array.isArray(parsed.calls) ? parsed.calls : [],
+    };
+  } catch {
+    return EMPTY;
+  }
+}
+
+export async function saveCalls(file: CallsFile): Promise<void> {
+  await ensureDir();
+  const tmp = `${FILE_PATH}.${process.pid}.tmp`;
+  await writeFile(tmp, JSON.stringify(file, null, 2), "utf8");
+  await rename(tmp, FILE_PATH);
+}
+
+export async function recordCall(input: CovenCallInput): Promise<CovenCall> {
+  const file = await loadCalls();
+  const call: CovenCall = {
+    id: randomUUID(),
+    callerFamiliarId: input.callerFamiliarId,
+    calleeFamiliarId: input.calleeFamiliarId,
+    request: input.request,
+    status: "running",
+    createdAt: new Date().toISOString(),
+    sessionId: input.sessionId,
+  };
+  file.calls.push(call);
+  await saveCalls(file);
+  return call;
+}
+
+export async function completeCall(
+  id: string,
+  artifact?: string,
+): Promise<CovenCall | null> {
+  const file = await loadCalls();
+  const call = file.calls.find((c) => c.id === id);
+  if (!call) return null;
+  call.status = "completed";
+  call.endedAt = new Date().toISOString();
+  if (artifact) call.artifact = artifact;
+  await saveCalls(file);
+  return call;
+}

--- a/src/lib/icon.tsx
+++ b/src/lib/icon.tsx
@@ -56,6 +56,10 @@ export const ICON_NAMES = [
   "ph:x",
   "ph:x-bold",
   "ph:x-circle-fill",
+  "ph:arrow-square-out",
+  "ph:clock",
+  "ph:globe",
+  "ph:graph",
 ] as const;
 
 export type IconName = (typeof ICON_NAMES)[number];


### PR DESCRIPTION
Closes #21 (frontend scaffold). New **Calls** mode (`ph:graph`) in the Workspace nav:

- **Recent delegations** — list of DelegationCard primitives (caller → callee, status pill, request, return-artifact link)
- **Call graph** — read-only SVG circular layout; edge stroke scales with call volume; nodes only for familiars that appear in at least one edge
- New `/api/coven-calls` GET/POST backed by `~/.coven/cave-coven-calls.json`
- Types split into `coven-calls-types.ts` so client components don't pull `node:fs` into the browser bundle

Empty state in the UI explains the daemon hasn't started emitting delegation events yet — view lights up on its own when it does.

Out of scope (separate): daemon-side delegation emission · origin chip `🪄 from <caller>` (already merged) · inline session jump from a DelegationCard.

typecheck clean · `pnpm build` green · signed.

Co-authored-by: OpenCoven <noreply@opencoven.io>