### PR TITLE
chore: bump version to 0.0.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Patch bump for v0.0.15 release. Includes 9 commits since v0.0.14: Capabilities tab (#44), Comux mode (#45), codex resume retry (#46), Schedules (#47), Coven Calls (#48), stability (#43), zinc cleanup, chat-list history fix.