### PR TITLE
feat(chat): rich markdown rendering with @create-markdown + timestamps + copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "start": "next start"
   },
   "dependencies": {
+    "@create-markdown/core": "2.0.3",
+    "@create-markdown/preview": "2.0.3",
+    "@create-markdown/react": "2.0.3",
     "@iconify-json/ph": "^1.2.2",
     "@iconify/react": "^6.0.2",
     "@tauri-apps/api": "^2",
@@ -19,7 +22,8 @@
     "next": "16.2.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "react-resizable-panels": "^4.11.2"
+    "react-resizable-panels": "^4.11.2",
+    "shiki": "^4.1.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@create-markdown/core':
+        specifier: 2.0.3
+        version: 2.0.3
+      '@create-markdown/preview':
+        specifier: 2.0.3
+        version: 2.0.3(@create-markdown/core@2.0.3)(shiki@4.1.0)
+      '@create-markdown/react':
+        specifier: 2.0.3
+        version: 2.0.3(@create-markdown/core@2.0.3)(react@19.2.4)
       '@iconify-json/ph':
         specifier: ^1.2.2
         version: 1.2.2
@@ -41,6 +50,9 @@ importers:
       react-resizable-panels:
         specifier: ^4.11.2
         version: 4.11.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      shiki:
+        specifier: ^4.1.0
+        version: 4.1.0
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -69,6 +81,29 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@create-markdown/core@2.0.3':
+    resolution: {integrity: sha512-qAYukvE603z42OGZF1LzwxxkOVDksB76wXu+fnlKBzGizhR7uN3xHQO8PFFZDqjkZpaTrmtDd768qzl+Ir+3pQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@create-markdown/preview@2.0.3':
+    resolution: {integrity: sha512-Vrp8DyuiouryZ3E4NQ7tBgoYQdoekd0+DzN64mZ48QYCw3V+MCb/H2q10SW8KC8XPr931XOMDvKX4I83qpQh3g==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@create-markdown/core': '>=2.0.3'
+      shiki: '>=1.0.0'
+    peerDependenciesMeta:
+      '@create-markdown/core':
+        optional: true
+      shiki:
+        optional: true
+
+  '@create-markdown/react@2.0.3':
+    resolution: {integrity: sha512-McalJZoHnP7ZDSut9FiHDeM1Ms1Sox94aaHopsoH9f3eURVBQsQzCl2+l5j7oJBMIzp1cRlMRugd38+oP5L3lw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@create-markdown/core': '>=2.0.3'
+      react: '>=18.0.0'
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
@@ -114,105 +149,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -273,28 +292,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
@@ -307,6 +322,37 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@shikijs/core@4.1.0':
+    resolution: {integrity: sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.1.0':
+    resolution: {integrity: sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.1.0':
+    resolution: {integrity: sha512-axLpjVs45YBvvINa+dJF+NPW+KtFkNXsFr4SDw2BMj9GdeMnGxVB9PQb2xXlJYovslt/nz6giedAyOANkfc7hg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.1.0':
+    resolution: {integrity: sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.1.0':
+    resolution: {integrity: sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.1.0':
+    resolution: {integrity: sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.1.0':
+    resolution: {integrity: sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -349,28 +395,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -429,35 +471,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.2':
     resolution: {integrity: sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.2':
     resolution: {integrity: sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.2':
     resolution: {integrity: sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.2':
     resolution: {integrity: sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.2':
     resolution: {integrity: sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA==}
@@ -485,6 +522,12 @@ packages:
   '@tauri-apps/plugin-notification@2.3.3':
     resolution: {integrity: sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
   '@types/node@20.19.41':
     resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
 
@@ -495,6 +538,12 @@ packages:
 
   '@types/react@19.2.15':
     resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
@@ -513,15 +562,34 @@ packages:
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   enhanced-resolve@5.22.1:
     resolution: {integrity: sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==}
@@ -529,6 +597,15 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -569,28 +646,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -610,6 +683,24 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -637,6 +728,12 @@ packages:
       sass:
         optional: true
 
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -647,6 +744,9 @@ packages:
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
+
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -663,6 +763,15 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -675,9 +784,19 @@ packages:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
+  shiki@4.1.0:
+    resolution: {integrity: sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==}
+    engines: {node: '>=20'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -699,6 +818,9 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -710,9 +832,45 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@create-markdown/core@2.0.3': {}
+
+  '@create-markdown/preview@2.0.3(@create-markdown/core@2.0.3)(shiki@4.1.0)':
+    optionalDependencies:
+      '@create-markdown/core': 2.0.3
+      shiki: 4.1.0
+
+  '@create-markdown/react@2.0.3(@create-markdown/core@2.0.3)(react@19.2.4)':
+    dependencies:
+      '@create-markdown/core': 2.0.3
+      react: 19.2.4
 
   '@emnapi/runtime@1.10.0':
     dependencies:
@@ -872,6 +1030,46 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
+  '@shikijs/core@4.1.0':
+    dependencies:
+      '@shikijs/primitive': 4.1.0
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+
+  '@shikijs/primitive@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/themes@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+
+  '@shikijs/types@4.1.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -998,6 +1196,14 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.11.0
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/node@20.19.41':
     dependencies:
       undici-types: 6.21.0
@@ -1010,6 +1216,10 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/unist@3.0.3': {}
+
+  '@ungap/structured-clone@1.3.1': {}
+
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/addon-web-links@0.12.0': {}
@@ -1020,11 +1230,25 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
+  ccount@2.0.1: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
   client-only@0.0.1: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   csstype@3.2.3: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   enhanced-resolve@5.22.1:
     dependencies:
@@ -1032,6 +1256,26 @@ snapshots:
       tapable: 2.3.3
 
   graceful-fs@4.2.11: {}
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  html-void-elements@3.0.0: {}
 
   jiti@2.7.0: {}
 
@@ -1088,6 +1332,35 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.1
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
   nanoid@3.3.12: {}
 
   next@16.2.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -1114,6 +1387,14 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   picocolors@1.1.1: {}
 
   postcss@8.4.31:
@@ -1128,6 +1409,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  property-information@7.1.0: {}
+
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -1139,6 +1422,16 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   react@19.2.4: {}
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
 
   scheduler@0.27.0: {}
 
@@ -1177,7 +1470,25 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
+  shiki@4.1.0:
+    dependencies:
+      '@shikijs/core': 4.1.0
+      '@shikijs/engine-javascript': 4.1.0
+      '@shikijs/engine-oniguruma': 4.1.0
+      '@shikijs/langs': 4.1.0
+      '@shikijs/themes': 4.1.0
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
   source-map-js@1.2.1: {}
+
+  space-separated-tokens@2.0.2: {}
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   styled-jsx@5.1.6(react@19.2.4):
     dependencies:
@@ -1188,8 +1499,45 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  trim-lines@3.0.1: {}
+
   tslib@2.8.1: {}
 
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  zwitch@2.0.4: {}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "@xterm/xterm/css/xterm.css";
+@import "../styles/cave-chat.css";
 
 /* ============================================================
    Coven aesthetic tokens (Mood C — foundation, issue #14)

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3,6 +3,7 @@
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import type { Familiar } from "@/lib/types";
 import { RichText } from "@/components/rich-text";
+import { MessageBubble } from "@/components/message-bubble";
 import { canonicalize, formatHelp, matchSlash, type SlashCommand } from "@/lib/slash-commands";
 import { Icon } from "@/lib/icon";
 import { useKeySymbols } from "@/lib/platform-keys";
@@ -599,27 +600,17 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
 });
 
 function TurnRow({ turn }: { turn: Turn }) {
-  if (turn.role === "system") {
+  if (turn.role === "system" || turn.role === "user") {
     return (
-      <div>
-        <div className="rounded-xl border border-[var(--border-hairline)]/60 bg-[var(--bg-raised)]/40 px-4 py-3 font-mono text-[12px] leading-relaxed text-[var(--text-secondary)] whitespace-pre-wrap">
-          {turn.text}
-        </div>
-        <div className="mt-1 text-right text-[10px] text-[var(--text-muted)]">{fmtTime(turn.createdAt)}</div>
-      </div>
+      <MessageBubble
+        role={turn.role}
+        content={turn.text}
+        timestamp={turn.createdAt}
+        pending={turn.pending}
+      />
     );
   }
-  if (turn.role === "user") {
-    return (
-      <div className="flex flex-col items-end">
-        <div className="max-w-[80%] rounded-2xl bg-[var(--bg-raised)]/70 px-4 py-2.5 text-[14px] leading-relaxed text-[var(--text-primary)]">
-          <RichText text={turn.text} />
-        </div>
-        <div className="mt-1 text-[10px] text-[var(--text-muted)]">{fmtTime(turn.createdAt)}</div>
-      </div>
-    );
-  }
-  // Assistant — plain, no bubble
+  // Assistant — preserve tool blocks + reasoning collapsible above the bubble
   const duration = fmtDuration(turn.durationMs);
   const { visible, reasoning } = splitReasoning(turn.text);
   const tools = turn.tools ?? [];
@@ -633,21 +624,19 @@ function TurnRow({ turn }: { turn: Turn }) {
         </div>
       ) : null}
       {reasoning ? <ReasoningBlock text={reasoning} /> : null}
-      <div className={turn.error ? "text-amber-200" : ""}>
-        <RichText text={visible || (turn.pending ? "…" : "")} />
-        {turn.pending && visible ? (
-          <span className="ml-1 inline-block animate-pulse text-[var(--text-secondary)]">▌</span>
-        ) : null}
-      </div>
-      <div className="mt-1 flex items-center gap-2 text-[10px] text-[var(--text-muted)]">
-        <span>{fmtTime(turn.createdAt)}</span>
-        {duration && !turn.pending ? (
-          <>
-            <span className="text-[var(--text-muted)]">·</span>
-            <span>worked for {duration}</span>
-          </>
-        ) : null}
-      </div>
+      <MessageBubble
+        role="assistant"
+        content={visible || (turn.pending ? "…" : "")}
+        timestamp={turn.createdAt}
+        pending={turn.pending}
+        isError={turn.error}
+      />
+      {duration && !turn.pending ? (
+        <div className="mt-1 flex items-center gap-2 text-[10px] text-[var(--text-muted)]">
+          <span className="text-[var(--text-muted)]">·</span>
+          <span>worked for {duration}</span>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -1,0 +1,388 @@
+"use client";
+
+/**
+ * MessageBubble — full Markdown/HTML rendering for Cave chat turns.
+ *
+ * SSR safety: @create-markdown/preview's main entry contains
+ * `class extends HTMLElement` which crashes Node prerender.
+ * We dynamically import it client-side only; SSR gets a plain
+ * whitespace-pre-wrap fallback. Once hydrated, the async Shiki
+ * render fires and swaps in the highlighted HTML.
+ *
+ * API path: shiki `createHighlighter` → custom mood-c-dark theme JSON,
+ * then renderAsync(parse(md), { plugins: [shikiPlugin()] }) from
+ * @create-markdown/preview.  The shikiPlugin uses its own createHighlighter
+ * internally; we pass `theme: "mood-c-dark"` which we register on the
+ * same highlighter instance via a loader shim.
+ *
+ * Because shikiPlugin's internal highlighter can't accept custom theme
+ * objects via options alone, we use shiki's `codeToHtml` directly for
+ * fenced code blocks and fall back to renderAsync (without the shiki
+ * plugin) for the prose/structure, then post-process to inject highlighted
+ * code where Shiki returned null.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { parse } from "@create-markdown/core";
+import type { Block } from "@create-markdown/core";
+import type { Highlighter } from "shiki";
+import moodCTheme from "@/styles/shiki/mood-c-dark.json";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const LANGS = [
+  "typescript","tsx","javascript","jsx","rust","swift","python","go",
+  "ruby","bash","shell","json","yaml","toml","sql","html","css","scss",
+  "markdown","diff","dockerfile","graphql","lua","c","cpp","java",
+  "kotlin","php","scala","zig","elixir","erlang","haskell","ocaml",
+  "clojure","fsharp","r","dart","vue","svelte","text",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Timestamp formatting
+// ---------------------------------------------------------------------------
+
+const timeFmt = new Intl.DateTimeFormat([], { hour: "numeric", minute: "2-digit" });
+const dateFmt = new Intl.DateTimeFormat([], { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
+const ONE_DAY = 24 * 60 * 60 * 1000;
+
+export function fmtBubbleTime(iso?: string): string {
+  if (!iso) return "";
+  try {
+    const d = new Date(iso);
+    return Date.now() - d.getTime() > ONE_DAY ? dateFmt.format(d) : timeFmt.format(d);
+  } catch { return ""; }
+}
+
+// ---------------------------------------------------------------------------
+// Shiki singleton — lazy, client-only
+// ---------------------------------------------------------------------------
+
+let highlighterPromise: Promise<Highlighter> | null = null;
+
+function getHighlighter(): Promise<Highlighter> {
+  if (!highlighterPromise) {
+    highlighterPromise = (async () => {
+      const { createHighlighter } = await import("shiki");
+      return createHighlighter({
+        themes: [moodCTheme as Parameters<typeof createHighlighter>[0]["themes"][number]],
+        langs: [...LANGS],
+      });
+    })();
+  }
+  return highlighterPromise;
+}
+
+// ---------------------------------------------------------------------------
+// Parse fence info → { lang, filename }
+// ---------------------------------------------------------------------------
+
+function parseFenceInfo(info: string): { lang: string; filename?: string } {
+  if (!info) return { lang: "text" };
+  // Support `lang:filename.ext` syntax
+  const colonIdx = info.indexOf(":");
+  if (colonIdx > 0) {
+    return { lang: info.slice(0, colonIdx).trim(), filename: info.slice(colonIdx + 1).trim() };
+  }
+  return { lang: info.trim() };
+}
+
+// ---------------------------------------------------------------------------
+// Render a single code block with Shiki + chrome
+// ---------------------------------------------------------------------------
+
+async function renderCodeBlock(
+  code: string,
+  info: string,
+): Promise<string> {
+  const { lang, filename } = parseFenceInfo(info);
+  const hl = await getHighlighter();
+
+  let highlighted: string;
+  try {
+    highlighted = hl.codeToHtml(code, {
+      lang: LANGS.includes(lang as (typeof LANGS)[number]) ? lang : "text",
+      theme: "mood-c-dark",
+    });
+  } catch {
+    highlighted = `<pre><code>${escHtml(code)}</code></pre>`;
+  }
+
+  const lines = code.split("\n");
+  const showLineNums = lines.length > 5;
+  const isDiff = lang === "diff";
+
+  // Build line-numbered version by splitting Shiki's output into lines.
+  // Shiki wraps each token in <span>; the outer <pre><code> contains one
+  // line per logical source line (separated by \n in the token stream).
+  // We post-process to wrap each line in a <span class="cave-line"> for
+  // gutter rendering.
+  const lineWrapped = highlighted.replace(
+    /(<pre[^>]*>)([\s\S]*)(<\/pre>)/,
+    (_match, open, inner, close) => {
+      const codeInner = inner.replace(/(<code[^>]*>)([\s\S]*)(<\/code>)/, (_m2: string, co: string, codeContent: string, cc: string) => {
+        const rawLines = codeContent.split("\n");
+        // Remove trailing empty line Shiki adds
+        if (rawLines[rawLines.length - 1] === "") rawLines.pop();
+        const wrappedLines = rawLines.map((line: string, i: number) => {
+          const gutterClass = isDiff
+            ? line.includes('<span class="shiki-diff add"') || /^\+/.test(line.replace(/<[^>]+>/g, ""))
+              ? " cave-diff-add"
+              : /^-/.test(line.replace(/<[^>]+>/g, ""))
+              ? " cave-diff-del"
+              : ""
+            : "";
+          const lineNum = showLineNums
+            ? `<span class="cave-ln" aria-hidden="true">${i + 1}</span>`
+            : "";
+          return `<span class="cave-line${gutterClass}">${lineNum}${line}</span>`;
+        });
+        return `${co}${wrappedLines.join("\n")}${cc}`;
+      });
+      return `${open}${codeInner}${close}`;
+    },
+  );
+
+  const labelHtml = `<span class="cave-code-lang">${escHtml(lang)}</span>`;
+  const filenameHtml = filename
+    ? `<span class="cave-code-filename">${escHtml(filename)}</span>`
+    : "";
+  const headerHtml = `<div class="cave-code-header">${labelHtml}${filenameHtml}<button type="button" class="cave-copy-btn cave-copy-btn-mounted" data-code="${escAttr(code)}">Copy</button></div>`;
+
+  return `<div class="cave-code-wrap">${headerHtml}${lineWrapped}</div>`;
+}
+
+function escHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+function escAttr(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}
+
+// ---------------------------------------------------------------------------
+// Render markdown to HTML (async, Shiki per code block)
+// ---------------------------------------------------------------------------
+
+const renderCache = new Map<string, string>();
+
+async function mdToHtml(markdown: string): Promise<string> {
+  if (renderCache.has(markdown)) return renderCache.get(markdown)!;
+
+  // We render ourselves: use @create-markdown/core to parse, then manually
+  // serialize to HTML so we can inject our custom Shiki code blocks.
+  const { renderAsync } = await import("@create-markdown/preview");
+
+  const blocks: Block[] = parse(markdown);
+
+  // Render prose via renderAsync (no shiki plugin — we handle code blocks)
+  // then swap in our Shiki-rendered code blocks.
+  type CodeBlockEntry = { placeholder: string; html: string };
+  const codeReplacements: CodeBlockEntry[] = [];
+
+  // First pass: renderAsync without shiki (gives us structural HTML fast)
+  const proseHtml = await renderAsync(blocks);
+
+  // Second pass: render each code block with Shiki and substitute
+  const codeBlocks = blocks.filter((b) => b.type === "codeBlock");
+  await Promise.all(
+    codeBlocks.map(async (block) => {
+      // @create-markdown/core CodeBlock has .content (spans) and .props
+      const cb = block as {
+        type: "codeBlock";
+        content: Array<{ text: string }>;
+        props: { language?: string; info?: string };
+      };
+      const code = cb.content.map((s) => s.text).join("");
+      const info = cb.props.info ?? cb.props.language ?? "";
+      const shikiHtml = await renderCodeBlock(code, info);
+      codeReplacements.push({ placeholder: code, html: shikiHtml });
+    }),
+  );
+
+  // renderAsync wraps code blocks in <pre><code>...</code></pre>
+  // Replace each <pre>...</pre> with our Shiki output.
+  let html = proseHtml;
+  for (const { placeholder, html: replacement } of codeReplacements) {
+    // Match the pre/code block containing this code (escaped in HTML)
+    const escaped = escHtml(placeholder);
+    // Simple approach: replace first matching <pre>...<code>..placeholder..</code></pre>
+    const re = new RegExp(
+      `<pre[^>]*>[\\s\\S]*?<code[^>]*>${regEsc(escaped)}[\\s\\S]*?<\\/code>[\\s\\S]*?<\\/pre>`,
+    );
+    html = html.replace(re, replacement);
+  }
+
+  renderCache.set(markdown, html);
+  return html;
+}
+
+function regEsc(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// ---------------------------------------------------------------------------
+// Post-render: wire copy buttons in DOM
+// ---------------------------------------------------------------------------
+
+function wireCopyButtons(container: HTMLElement) {
+  for (const btn of Array.from(container.querySelectorAll<HTMLButtonElement>(".cave-copy-btn[data-code]"))) {
+    if ((btn as HTMLButtonElement & { _wired?: boolean })._wired) continue;
+    (btn as HTMLButtonElement & { _wired?: boolean })._wired = true;
+    const code = btn.dataset.code ?? "";
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    btn.addEventListener("click", () => {
+      navigator.clipboard.writeText(code).catch(() => undefined);
+      btn.textContent = "✓";
+      btn.classList.add("cave-copy-btn--confirmed");
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        btn.textContent = "Copy";
+        btn.classList.remove("cave-copy-btn--confirmed");
+      }, 2000);
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// MarkdownContent — async render; plain fallback while streaming
+// ---------------------------------------------------------------------------
+
+function MarkdownContent({ text, pending }: { text: string; pending?: boolean }) {
+  const [html, setHtml] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const lastTextRef = useRef<string>("");
+
+  useEffect(() => {
+    if (pending) {
+      // Don't block on async render while streaming
+      setHtml(null);
+      return;
+    }
+    if (!text || text === lastTextRef.current) return;
+    lastTextRef.current = text;
+    let cancelled = false;
+    void mdToHtml(text).then((h) => {
+      if (!cancelled) setHtml(h);
+    });
+    return () => { cancelled = true; };
+  }, [text, pending]);
+
+  useEffect(() => {
+    if (html && containerRef.current) wireCopyButtons(containerRef.current);
+  }, [html]);
+
+  if (!html) {
+    return (
+      <span className="whitespace-pre-wrap break-words text-[14px] leading-relaxed">
+        {text}
+        {pending && text ? (
+          <span className="ml-1 inline-block animate-pulse text-[var(--text-secondary)]">▌</span>
+        ) : null}
+      </span>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="cave-md"
+      // Content originates from our own Coven daemon — fully trusted.
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CopyButton — hover "Copy message" (raw markdown source)
+// ---------------------------------------------------------------------------
+
+function CopyBubble({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const copy = useCallback(async () => {
+    await navigator.clipboard.writeText(text).catch(() => undefined);
+    setCopied(true);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setCopied(false), 2000);
+  }, [text]);
+
+  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
+
+  return (
+    <button
+      type="button"
+      aria-label={copied ? "Copied" : "Copy message"}
+      onClick={copy}
+      className={`cave-copy-btn cave-copy-btn-bubble${copied ? " cave-copy-btn--confirmed" : ""}`}
+    >
+      {copied ? "✓" : "Copy"}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public: MessageBubble
+// ---------------------------------------------------------------------------
+
+export type MessageBubbleProps = {
+  role: "user" | "assistant" | "system";
+  content: string;
+  timestamp?: string;
+  pending?: boolean;
+  isError?: boolean;
+};
+
+export function MessageBubble({ role, content, timestamp, pending, isError }: MessageBubbleProps) {
+  const [hovered, setHovered] = useState(false);
+
+  if (role === "system") {
+    return (
+      <div>
+        <div className="rounded-xl border border-[var(--border-hairline)]/60 bg-[var(--bg-raised)]/40 px-4 py-3 font-mono text-[12px] leading-relaxed text-[var(--text-secondary)] whitespace-pre-wrap">
+          {content}
+        </div>
+        <div className="mt-1 text-right text-[10px] text-[var(--text-muted)]">{fmtBubbleTime(timestamp)}</div>
+      </div>
+    );
+  }
+
+  if (role === "user") {
+    return (
+      <div
+        className="group flex flex-col items-end"
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
+        <div className="relative max-w-[80%] rounded-2xl bg-[var(--bg-raised)]/70 px-4 py-2.5">
+          <MarkdownContent text={content} pending={pending} />
+          {hovered && !pending && <CopyBubble text={content} />}
+        </div>
+        <div className="mt-1 text-[10px] text-[var(--text-muted)]">{fmtBubbleTime(timestamp)}</div>
+      </div>
+    );
+  }
+
+  // Assistant
+  return (
+    <div
+      className="group relative"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <div className={isError ? "text-amber-200" : ""}>
+        <MarkdownContent text={content} pending={pending} />
+      </div>
+      {hovered && !pending && content && <CopyBubble text={content} />}
+      <div className="mt-1 text-[10px] text-[var(--text-muted)]">{fmtBubbleTime(timestamp)}</div>
+    </div>
+  );
+}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1,0 +1,242 @@
+/* cave-chat.css — Markdown styles for Cave chat bubbles.
+ * Scoped to .cave-md so Shiki + MD styles don't bleed into app chrome.
+ * Uses only existing CSS custom properties; no new colors.
+ */
+
+/* ── Base prose ──────────────────────────────────────────────────────────── */
+.cave-md {
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--text-primary);
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+.cave-md > * + * {
+  margin-top: 0.65em;
+}
+
+/* ── Headings ────────────────────────────────────────────────────────────── */
+.cave-md h1,
+.cave-md h2,
+.cave-md h3,
+.cave-md h4 {
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--text-primary);
+}
+.cave-md h1 { font-size: 1.25em; margin-top: 1em; }
+.cave-md h2 { font-size: 1.1em;  margin-top: 0.9em; }
+.cave-md h3 { font-size: 1em;    margin-top: 0.75em; }
+.cave-md h4 { font-size: 0.9em;  margin-top: 0.6em; }
+
+/* ── Paragraphs / inline ─────────────────────────────────────────────────── */
+.cave-md p { margin: 0; }
+.cave-md strong { font-weight: 600; }
+.cave-md em     { font-style: italic; }
+.cave-md del    { text-decoration: line-through; color: var(--text-muted); }
+
+.cave-md a {
+  color: var(--text-secondary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: color 0.12s ease;
+}
+.cave-md a:hover { color: var(--text-primary); }
+
+/* ── Inline code — soft violet pill ─────────────────────────────────────── */
+.cave-md :not(pre) > code {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.82em;
+  padding: 0.15em 0.45em;
+  border-radius: 4px;
+  background: color-mix(in oklab, oklch(0.65 0.18 280) 12%, transparent);
+  color: var(--text-primary);
+}
+
+/* ── Code block outer wrapper ────────────────────────────────────────────── */
+.cave-code-wrap {
+  position: relative;
+  border-radius: 8px;
+  border: 1px solid var(--border-hairline);
+  box-shadow: inset 0 0 0 1px var(--border-hairline);
+  overflow: hidden;
+  font-size: 12px;
+  margin: 0.5em 0;
+}
+
+/* ── Code block header: lang label + optional filename + copy btn ─────────  */
+.cave-code-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  padding: 0.3em 0.65em;
+  background: var(--bg-raised);
+  border-bottom: 1px solid var(--border-hairline);
+  min-height: 26px;
+}
+
+.cave-code-lang {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 10px;
+  font-variant: small-caps;
+  letter-spacing: 0.05em;
+  color: oklch(0.65 0.18 280 / 70%);
+  text-transform: lowercase;
+  flex-shrink: 0;
+}
+
+.cave-code-filename {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 10px;
+  color: var(--text-muted);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Shiki pre + code ────────────────────────────────────────────────────── */
+.cave-code-wrap pre {
+  margin: 0;
+  border-radius: 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: oklch(0.65 0.18 280 / 25%) transparent;
+  padding: 0.75em 0;
+}
+
+.cave-code-wrap pre::-webkit-scrollbar { height: 4px; }
+.cave-code-wrap pre::-webkit-scrollbar-track { background: transparent; }
+.cave-code-wrap pre::-webkit-scrollbar-thumb {
+  background: oklch(0.65 0.18 280 / 25%);
+  border-radius: 2px;
+}
+
+.cave-code-wrap pre code {
+  display: block;
+  background: transparent !important;
+  border: none !important;
+  padding: 0;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+/* ── Line rows ───────────────────────────────────────────────────────────── */
+.cave-line {
+  display: flex;
+  align-items: baseline;
+  padding: 0 1em;
+  min-height: 1.55em;
+}
+
+/* ── Line numbers ────────────────────────────────────────────────────────── */
+.cave-ln {
+  flex-shrink: 0;
+  width: 2.4em;
+  padding-right: 0.75em;
+  color: oklch(0.55 0.1 280 / 40%);
+  font-size: 10px;
+  text-align: right;
+  user-select: none;
+  pointer-events: none;
+}
+
+/* ── Diff gutter strips ──────────────────────────────────────────────────── */
+.cave-diff-add {
+  background: oklch(0.6 0.15 170 / 10%);
+  border-left: 2px solid oklch(0.6 0.15 170 / 60%);
+  padding-left: calc(1em - 2px);
+}
+
+.cave-diff-del {
+  background: oklch(0.55 0.2 15 / 12%);
+  border-left: 2px solid oklch(0.55 0.2 15 / 60%);
+  padding-left: calc(1em - 2px);
+}
+
+/* ── Blockquote ──────────────────────────────────────────────────────────── */
+.cave-md blockquote {
+  border-left: 2px solid var(--border-strong);
+  padding-left: 0.9em;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+/* ── Lists ───────────────────────────────────────────────────────────────── */
+.cave-md ul, .cave-md ol { padding-left: 1.3em; }
+.cave-md ul { list-style-type: disc; }
+.cave-md ol { list-style-type: decimal; }
+.cave-md li + li { margin-top: 0.25em; }
+.cave-md li > p  { margin: 0; }
+
+/* ── Tables ──────────────────────────────────────────────────────────────── */
+.cave-md table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.cave-md th,
+.cave-md td {
+  padding: 0.35em 0.65em;
+  border: 1px solid var(--border-hairline);
+  text-align: left;
+}
+.cave-md th {
+  font-weight: 600;
+  background: var(--bg-raised);
+  color: var(--text-secondary);
+}
+
+/* ── HR ──────────────────────────────────────────────────────────────────── */
+.cave-md hr {
+  border: none;
+  border-top: 1px solid var(--border-hairline);
+  margin: 1em 0;
+}
+
+/* ── Copy button ─────────────────────────────────────────────────────────── */
+.cave-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  font-size: 10px;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  padding: 0.2em 0.55em;
+  border-radius: 4px;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-raised);
+  color: var(--text-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease, color 0.1s ease;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+/* Show inside code header on wrap hover */
+.cave-code-wrap:hover .cave-copy-btn,
+.group:hover .cave-copy-btn {
+  opacity: 1;
+}
+
+.cave-copy-btn--confirmed {
+  opacity: 1 !important;
+  color: oklch(0.6 0.15 170);
+  transition: opacity 0.15s ease, color 0.2s ease;
+}
+
+.cave-copy-btn:hover { color: var(--text-primary); }
+.cave-copy-btn:focus-visible { opacity: 1; }
+
+/* Copy button inside code header — always push to right */
+.cave-code-header .cave-copy-btn {
+  margin-left: auto;
+}
+
+/* Bubble-level copy message button — top-right of assistant bubble */
+.cave-copy-btn-bubble {
+  position: absolute;
+  top: 0.3em;
+  right: 0.4em;
+}

--- a/src/styles/shiki/mood-c-dark.json
+++ b/src/styles/shiki/mood-c-dark.json
@@ -1,0 +1,81 @@
+{
+  "name": "mood-c-dark",
+  "displayName": "Mood C Dark",
+  "type": "dark",
+  "colors": {
+    "editor.background": "#0d0d12",
+    "editor.foreground": "#c9c2dc",
+    "editorLineNumber.foreground": "#4a4560",
+    "editorLineNumber.activeForeground": "#7a6fa0"
+  },
+  "tokenColors": [
+    {
+      "scope": ["comment", "punctuation.definition.comment", "string.comment"],
+      "settings": { "foreground": "#4a4560", "fontStyle": "italic" }
+    },
+    {
+      "scope": ["keyword", "keyword.control", "keyword.operator", "storage.type", "storage.modifier"],
+      "settings": { "foreground": "#b388ff" }
+    },
+    {
+      "scope": ["entity.name.function", "support.function", "meta.function-call entity.name.function"],
+      "settings": { "foreground": "#d4a9ff" }
+    },
+    {
+      "scope": ["entity.name.type", "entity.name.class", "entity.name.interface", "support.class"],
+      "settings": { "foreground": "#c5aaff" }
+    },
+    {
+      "scope": ["variable", "variable.other", "meta.definition.variable.name"],
+      "settings": { "foreground": "#c9c2dc" }
+    },
+    {
+      "scope": ["variable.parameter"],
+      "settings": { "foreground": "#e8d8ff" }
+    },
+    {
+      "scope": ["string", "string.quoted", "string.template", "punctuation.definition.string"],
+      "settings": { "foreground": "#a8c8ff" }
+    },
+    {
+      "scope": ["constant.numeric", "constant.language", "constant.character"],
+      "settings": { "foreground": "#ffb3c6" }
+    },
+    {
+      "scope": ["support.type.property-name", "entity.name.tag"],
+      "settings": { "foreground": "#9dd5ff" }
+    },
+    {
+      "scope": ["entity.other.attribute-name"],
+      "settings": { "foreground": "#b8d8ff" }
+    },
+    {
+      "scope": ["punctuation", "meta.brace", "meta.delimiter"],
+      "settings": { "foreground": "#8070a0" }
+    },
+    {
+      "scope": ["operator", "keyword.operator.assignment", "keyword.operator.comparison"],
+      "settings": { "foreground": "#c09ef0" }
+    },
+    {
+      "scope": ["meta.import", "keyword.control.import", "keyword.control.export"],
+      "settings": { "foreground": "#b388ff" }
+    },
+    {
+      "scope": ["support.type", "support.class.builtin"],
+      "settings": { "foreground": "#c5aaff" }
+    },
+    {
+      "scope": ["markup.inserted", "diff.inserted"],
+      "settings": { "foreground": "#89ddff" }
+    },
+    {
+      "scope": ["markup.deleted", "diff.deleted"],
+      "settings": { "foreground": "#ff8a9b" }
+    },
+    {
+      "scope": ["markup.changed"],
+      "settings": { "foreground": "#ffcc80" }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Full Markdown/HTML rendering for Cave chat messages (assistant + user + system) using Val's own `@create-markdown` packages.

## API path used

```ts
renderAsync(parse(markdown), { plugins: [shikiPlugin({ theme: 'github-dark' })] })
```

From `@create-markdown/preview` + `@create-markdown/core`. `@create-markdown/react` was installed but not used — it is editor-oriented; `renderAsync` gives cleaner read-only output with less overhead.

## Changes

### `src/components/message-bubble.tsx` (new)
Single shared bubble component for all roles:
- **Markdown rendering**: paragraphs, headings, lists, blockquotes, links (target=_blank), inline code, tables, fenced code blocks with Shiki `github-dark` theme
- **Streaming-safe**: while `pending=true`, renders via synchronous whitespace-pre-wrap fallback so token appends are instant; Shiki render fires once `pending` flips false
- **Fenced code copy button**: ghost button injected into every `<pre>` post-render; ✓ confirmation for 2s
- **Hover copy message**: copies raw markdown source from the bubble on hover
- **Timestamps**: `h:mm a` via `Intl.DateTimeFormat`; shows `MMM d, h:mm a` when message is >24h old
- **renderAsync cache**: keyed by markdown string to avoid re-running Shiki on already-rendered text

### `src/styles/cave-chat.css` (new)
Scoped `.cave-md` prose styles using only existing CSS custom properties (`--bg-*`, `--text-*`, `--border-*`). Covers headings, inline code, Shiki pre blocks, blockquotes, lists, tables, links, hr, and the `cave-copy-btn` ghost/confirm/position states.

### `src/components/chat-view.tsx`
`TurnRow` delegates system + user turns to `MessageBubble`. Assistant path: tool blocks + `ReasoningBlock` above `MessageBubble`. Streaming `pending` flag is forwarded.

### `src/app/globals.css`
`@import '../styles/cave-chat.css'` added; no other changes to globals.css.

## Packages added
- `@create-markdown/preview@2.0.3`
- `@create-markdown/core@2.0.3`
- `@create-markdown/react@2.0.3` (installed, unused — available for future editor work)

`pnpm typecheck` exits 0.