### PR TITLE
feat(sidebar): minimal sidebar with 4 actions, folder modes, flat recents

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "@xterm/xterm/css/xterm.css";
 @import "../styles/cave-chat.css";
+@import "../styles/sidebar-minimal.css";
 
 /* ============================================================
    Coven aesthetic tokens (Mood C — foundation, issue #14)

--- a/src/components/agent-panel.tsx
+++ b/src/components/agent-panel.tsx
@@ -2,53 +2,119 @@
 
 import { forwardRef } from "react";
 import { ChatRouter, type ChatRouterHandle } from "@/components/chat-router";
+import { FamiliarGlyph } from "@/components/familiar-glyph";
+import { resolveFamiliarGlyph } from "@/lib/familiar-glyph";
 import type { Familiar, SessionRow } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// FamiliarStrip — 28px avatar circles at the top of the AgentPanel.
+// Active familiar gets a Mood C violet ring. Badge text (QUEEN/RESEARCH/etc.)
+// appears as a native title tooltip on hover.
+// ---------------------------------------------------------------------------
+
+function FamiliarStrip({
+  familiars,
+  activeId,
+  onSelect,
+}: {
+  familiars: Familiar[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  if (familiars.length === 0) return null;
+
+  return (
+    <div className="familiar-strip">
+      {familiars.map((f) => {
+        const glyph = resolveFamiliarGlyph(f, {});
+        const isActive = f.id === activeId;
+        return (
+          <button
+            key={f.id}
+            type="button"
+            title={`${f.display_name}${f.role ? ` · ${f.role}` : ""}`}
+            aria-label={f.display_name}
+            aria-pressed={isActive}
+            onClick={() => onSelect(f.id)}
+            className={`familiar-strip-avatar${isActive ? " familiar-strip-avatar--active" : ""}`}
+          >
+            <FamiliarGlyph glyph={glyph} size="sm" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AgentPanel
+// ---------------------------------------------------------------------------
 
 type Props = {
   familiar: Familiar | null;
+  familiars: Familiar[];
+  activeId: string | null;
   sessions: SessionRow[];
   daemonRunning: boolean;
   onSessionStarted: () => void;
   onSlashFromChat: (command: string, args: string) => boolean;
   onOpenOnboarding: () => void;
+  onFamiliarSelect: (id: string) => void;
 };
 
-// AgentPanel — always-visible right-side column hosting the active
-// familiar's live chat. Replaces the floating DockChat introduced in
-// PR #25; the chat is now a first-class Shell pane rather than an
-// overlay, so it survives mode switches (Board, Inbox, Plugins) and
-// stays in the same place.
 export const AgentPanel = forwardRef<ChatRouterHandle, Props>(function AgentPanel(
   props,
   ref,
 ) {
-  if (!props.familiar) {
-    return (
-      <div className="flex h-full flex-col items-center justify-center px-6 text-center text-[12px] text-[var(--text-muted)]">
-        <p className="text-[var(--text-secondary)]">Pick a familiar from the rail.</p>
-        <p className="mt-1">Their live chat lives here.</p>
-        <button
-          type="button"
-          onClick={props.onOpenOnboarding}
-          className="mt-4 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-1 text-[11px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)]/80"
-        >
-          Open setup
-        </button>
-      </div>
-    );
-  }
+  const {
+    familiar,
+    familiars,
+    activeId,
+    onFamiliarSelect,
+    onOpenOnboarding,
+    sessions,
+    daemonRunning,
+    onSessionStarted,
+    onSlashFromChat,
+  } = props;
 
   return (
-    <div className="flex h-full min-h-0 flex-1 flex-col">
-      <ChatRouter
-        ref={ref}
-        familiar={props.familiar}
-        sessions={props.sessions}
-        daemonRunning={props.daemonRunning}
-        onSessionStarted={props.onSessionStarted}
-        onSlashFromChat={props.onSlashFromChat}
-        onOpenOnboarding={props.onOpenOnboarding}
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Familiar avatar strip — always rendered when familiars exist */}
+      <FamiliarStrip
+        familiars={familiars}
+        activeId={activeId}
+        onSelect={(id) => {
+          onFamiliarSelect(id);
+        }}
       />
+
+      {/* Chat area */}
+      {!familiar ? (
+        <div className="flex flex-1 flex-col items-center justify-center px-6 text-center text-[12px] text-[var(--text-muted)]">
+          <p className="text-[var(--text-secondary)]">Pick a familiar above.</p>
+          <p className="mt-1">Their live chat lives here.</p>
+          <button
+            type="button"
+            onClick={onOpenOnboarding}
+            className="mt-4 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-1 text-[11px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)]/80"
+          >
+            Open setup
+          </button>
+        </div>
+      ) : (
+        <div className="flex min-h-0 flex-1 flex-col">
+          <ChatRouter
+            ref={ref}
+            familiar={familiar}
+            sessions={sessions}
+            daemonRunning={daemonRunning}
+            onSessionStarted={onSessionStarted}
+            onSlashFromChat={onSlashFromChat}
+            onOpenOnboarding={onOpenOnboarding}
+          />
+        </div>
+      )}
     </div>
   );
 });

--- a/src/components/agent-panel.tsx
+++ b/src/components/agent-panel.tsx
@@ -32,6 +32,8 @@ function FamiliarStrip({
         const glyph = resolveFamiliarGlyph(f, overrides);
         const isActive = f.id === activeId;
         return (
+          <button
+            key={f.id}
             type="button"
             title={`${f.display_name}${f.role ? ` · ${f.role}` : ""}`}
             aria-label={f.display_name}

--- a/src/components/agent-panel.tsx
+++ b/src/components/agent-panel.tsx
@@ -22,16 +22,16 @@ function FamiliarStrip({
   activeId: string | null;
   onSelect: (id: string) => void;
 }) {
+  const overrides = useGlyphOverrides();
+
   if (familiars.length === 0) return null;
 
   return (
     <div className="familiar-strip">
       {familiars.map((f) => {
-        const glyph = resolveFamiliarGlyph(f, {});
+        const glyph = resolveFamiliarGlyph(f, overrides);
         const isActive = f.id === activeId;
         return (
-          <button
-            key={f.id}
             type="button"
             title={`${f.display_name}${f.role ? ` · ${f.role}` : ""}`}
             aria-label={f.display_name}

--- a/src/components/agent-panel.tsx
+++ b/src/components/agent-panel.tsx
@@ -4,6 +4,7 @@ import { forwardRef } from "react";
 import { ChatRouter, type ChatRouterHandle } from "@/components/chat-router";
 import { FamiliarGlyph } from "@/components/familiar-glyph";
 import { resolveFamiliarGlyph } from "@/lib/familiar-glyph";
+import { useGlyphOverrides } from "@/lib/cave-glyph-overrides";
 import type { Familiar, SessionRow } from "@/lib/types";
 
 // ---------------------------------------------------------------------------

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -190,7 +190,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
   const recents = useMemo(
     () =>
       sessions
-        .filter((s) => !s.archived_at)
+        .filter((s) => !s.archived_at && (!s.origin || s.origin === "chat"))
         .sort((a, b) => {
           const ta = a.updated_at || a.created_at;
           const tb = b.updated_at || b.created_at;

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+/**
+ * SidebarMinimal — the redesigned Cave sidebar.
+ *
+ * Layout (top → bottom):
+ *   1. 4 primary actions  (New chat / Search / Plugins / Automations)
+ *   2. 5 folder mode rows (Board / Inbox / Val's Inbox / Browser / Comux)
+ *   3. Flat recent-chats list with relative timestamps
+ *   4. Gear settings row (bottom, pinned)
+ *
+ * Familiars and the harness/model config block live in AgentPanel (right pane).
+ * Settings gear opens the onboarding overlay.
+ */
+
+import { useMemo, useState } from "react";
+import { Icon } from "@/lib/icon";
+import type { SessionRow } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Relative timestamp
+// ---------------------------------------------------------------------------
+
+const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto", style: "narrow" });
+
+function relTime(iso: string | undefined): string {
+  if (!iso) return "";
+  try {
+    const diffSec = (Date.now() - new Date(iso).getTime()) / 1000;
+    if (diffSec < 60)  return rtf.format(-Math.round(diffSec),       "second");
+    if (diffSec < 3600) return rtf.format(-Math.round(diffSec / 60),  "minute");
+    if (diffSec < 86400) return rtf.format(-Math.round(diffSec / 3600), "hour");
+    return rtf.format(-Math.round(diffSec / 86400), "day");
+  } catch { return ""; }
+}
+
+// Short label: "1mo", "5h", "13m"
+function shortRelTime(iso: string | undefined): string {
+  if (!iso) return "";
+  try {
+    const diffSec = (Date.now() - new Date(iso).getTime()) / 1000;
+    if (diffSec < 60)   return `${Math.round(diffSec)}s`;
+    if (diffSec < 3600)  return `${Math.round(diffSec / 60)}m`;
+    if (diffSec < 86400) return `${Math.round(diffSec / 3600)}h`;
+    const days = Math.round(diffSec / 86400);
+    if (days < 30) return `${days}d`;
+    return `${Math.round(days / 30)}mo`;
+  } catch { return ""; }
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type FolderMode = "board" | "inbox" | "vals-inbox" | "browser" | "comux" | "schedules" | "calls";
+
+export type SidebarMinimalProps = {
+  mode: string;
+  sessions: SessionRow[];
+  activeSessionId?: string | null;
+  inboxBadgeCount?: number;
+  onNewChat: () => void;
+  onOpenSearch: () => void;
+  onModeChange: (mode: string) => void;
+  onOpenSession: (id: string) => void;
+  onOpenSettings: () => void;
+};
+
+// ---------------------------------------------------------------------------
+// Action button (top 4)
+// ---------------------------------------------------------------------------
+
+function ActionRow({
+  icon,
+  label,
+  kbd,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  kbd?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="sidebar-action-row"
+      onClick={onClick}
+    >
+      <span className="sidebar-action-icon">{icon}</span>
+      <span className="sidebar-action-label">{label}</span>
+      {kbd && <span className="sidebar-action-kbd">{kbd}</span>}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Folder row (mode entries)
+// ---------------------------------------------------------------------------
+
+const FOLDER_MODES: Array<{
+  id: FolderMode;
+  label: string;
+  iconName: "ph:kanban" | "ph:tray" | "ph:bell-fill" | "ph:globe" | "ph:squares-four" | "ph:clock" | "ph:graph";
+  badge?: (props: SidebarMinimalProps) => string | undefined;
+}> = [
+  { id: "board",      label: "Board",       iconName: "ph:kanban" },
+  { id: "inbox",      label: "Inbox",       iconName: "ph:tray",
+    badge: (p) => p.inboxBadgeCount && p.inboxBadgeCount > 0 ? String(p.inboxBadgeCount) : undefined },
+  { id: "vals-inbox", label: "Val's Inbox", iconName: "ph:bell-fill" },
+  { id: "schedules",  label: "Schedules",   iconName: "ph:clock" },
+  { id: "browser",    label: "Browser",     iconName: "ph:globe" },
+  { id: "comux",      label: "Comux",       iconName: "ph:squares-four" },
+];
+
+function FolderRow({
+  id,
+  label,
+  iconName,
+  active,
+  badge,
+  onClick,
+}: {
+  id: string;
+  label: string;
+  iconName: Parameters<typeof Icon>[0]["name"];
+  active: boolean;
+  badge?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`sidebar-folder-row${active ? " sidebar-folder-row--active" : ""}`}
+      onClick={onClick}
+    >
+      <Icon name={iconName} width={13} className="sidebar-folder-icon" />
+      <span className="sidebar-folder-label">{label}</span>
+      {badge && <span className="sidebar-badge">{badge}</span>}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Recent chat row
+// ---------------------------------------------------------------------------
+
+function RecentRow({
+  session,
+  active,
+  onClick,
+}: {
+  session: SessionRow;
+  active: boolean;
+  onClick: () => void;
+}) {
+  const ts = shortRelTime(session.updated_at || session.created_at);
+  const title = session.title || "Untitled";
+
+  return (
+    <button
+      type="button"
+      title={title}
+      className={`sidebar-recent-row${active ? " sidebar-recent-row--active" : ""}`}
+      onClick={onClick}
+    >
+      <span className="sidebar-recent-title">{title}</span>
+      {ts && <span className="sidebar-recent-ts">{ts}</span>}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SidebarMinimal
+// ---------------------------------------------------------------------------
+
+export function SidebarMinimal(props: SidebarMinimalProps) {
+  const {
+    mode,
+    sessions,
+    activeSessionId,
+    onNewChat,
+    onOpenSearch,
+    onModeChange,
+    onOpenSession,
+    onOpenSettings,
+  } = props;
+
+  // Only show chat-origin sessions in recents; limit to 40
+  const recents = useMemo(
+    () =>
+      sessions
+        .filter((s) => !s.archived_at)
+        .sort((a, b) => {
+          const ta = a.updated_at || a.created_at;
+          const tb = b.updated_at || b.created_at;
+          return tb.localeCompare(ta);
+        })
+        .slice(0, 40),
+    [sessions],
+  );
+
+  return (
+    <nav className="sidebar-minimal">
+      {/* ── 4 primary actions ─────────────────────────────────── */}
+      <div className="sidebar-actions">
+        <ActionRow
+          icon={<Icon name="ph:note-pencil" width={14} />}
+          label="New chat"
+          onClick={onNewChat}
+        />
+        <ActionRow
+          icon={<Icon name="ph:magnifying-glass" width={14} />}
+          label="Search"
+          kbd="⌘K"
+          onClick={onOpenSearch}
+        />
+        <ActionRow
+          icon={<Icon name="ph:plug" width={14} />}
+          label="Plugins"
+          onClick={() => onModeChange("plugins")}
+        />
+        <ActionRow
+          icon={<Icon name="ph:calendar-blank" width={14} />}
+          label="Automations"
+          onClick={() => onModeChange("calls")}
+        />
+      </div>
+
+      {/* ── Folder mode rows ──────────────────────────────────── */}
+      <div className="sidebar-folders">
+        {FOLDER_MODES.map((fm) => (
+          <FolderRow
+            key={fm.id}
+            id={fm.id}
+            label={fm.label}
+            iconName={fm.iconName}
+            active={mode === fm.id}
+            badge={fm.badge?.(props)}
+            onClick={() => onModeChange(fm.id)}
+          />
+        ))}
+      </div>
+
+      {/* ── Flat recents list ─────────────────────────────────── */}
+      <div className="sidebar-recents-header">Recent</div>
+      <div className="sidebar-recents">
+        {recents.length === 0 ? (
+          <div className="sidebar-recents-empty">No recent chats</div>
+        ) : (
+          recents.map((s) => (
+            <RecentRow
+              key={s.id}
+              session={s}
+              active={s.id === activeSessionId}
+              onClick={() => {
+                onModeChange("chats");
+                onOpenSession(s.id);
+              }}
+            />
+          ))
+        )}
+      </div>
+
+      {/* ── Settings gear (bottom) ────────────────────────────── */}
+      <div className="sidebar-bottom">
+        <button
+          type="button"
+          className="sidebar-settings-row"
+          onClick={onOpenSettings}
+          aria-label="Settings"
+        >
+          <Icon name="ph:gear-six" width={14} />
+          <span>Settings</span>
+        </button>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { SidebarFamiliars } from "@/components/sidebar-familiars";
+import { SidebarMinimal } from "@/components/sidebar-minimal";
 import { ChatRouter, type ChatRouterHandle } from "@/components/chat-router";
 import { DaemonBar } from "@/components/daemon-bar";
 import { CommandPalette, type PaletteIntent } from "@/components/command-palette";
@@ -13,7 +13,7 @@ import { ValsInboxView } from "@/components/vals-inbox-view";
 import { NewReminderModal, draftFromSlashArgs } from "@/components/new-reminder-modal";
 import { InboxToastStack, toastFromItem, type Toast } from "@/components/inbox-toast";
 import { FamiliarGlyphPicker } from "@/components/familiar-glyph-picker";
-import { Shell, ShellNav, ShellNavHeader, type ShellNavItem } from "@/components/shell";
+import { Shell } from "@/components/shell";
 import { ChooserModal, type ChooserOption } from "@/components/ui/chooser-modal";
 import { AgentPanel } from "@/components/agent-panel";
 import { BottomTerminal } from "@/components/bottom-terminal";
@@ -510,131 +510,25 @@ export function Workspace() {
       (i.status === "pending" && i.kind === "response-needed"),
   ).length;
 
-  const navSections = [
-    {
-      items: [
-        {
-          id: "search",
-          label: "Search…",
-          icon: "ph:magnifying-glass" as const,
-          kbd: "⌘K",
-          onClick: () => setPaletteOpen(true),
-        },
-        {
-          id: "new",
-          label: "New chat",
-          icon: "ph:note-pencil" as const,
-          onClick: () => {
-            setMode("chats");
-            setTimeout(() => routerRef.current?.newChat(), 0);
-          },
-        },
-        {
-          id: "add",
-          label: "Add…",
-          icon: "ph:plus" as const,
-          onClick: () => setAddChooserOpen(true),
-        },
-      ] as ShellNavItem[],
-    },
-    {
-      label: "Workspace",
-      items: [
-        {
-          id: "chats",
-          label: "Chats",
-          icon: "ph:chat-circle-dots" as const,
-          active: mode === "chats",
-          onClick: () => setMode("chats"),
-        },
-        {
-          id: "inbox",
-          label: "Inbox",
-          icon: "ph:tray" as const,
-          active: mode === "inbox",
-          onClick: () => setMode("inbox"),
-          kbd: inboxBadgeCount > 0 ? String(inboxBadgeCount) : undefined,
-        },
-        {
-          id: "vals-inbox",
-          label: "Val's Inbox",
-          icon: "ph:bell-fill" as const,
-          active: mode === "vals-inbox",
-          onClick: () => setMode("vals-inbox"),
-        },
-        {
-          id: "board",
-          label: "Board",
-          icon: "ph:kanban" as const,
-          active: mode === "board",
-          onClick: () => setMode("board"),
-        },
-        {
-          id: "plugins",
-          label: "Plugins",
-          icon: "ph:plug" as const,
-          active: mode === "plugins",
-          onClick: () => setMode("plugins"),
-        },
-        {
-          id: "browser",
-          label: "Browser",
-          icon: "ph:globe" as const,
-          active: mode === "browser",
-          onClick: () => setMode("browser"),
-        },
-        {
-          id: "schedules",
-          label: "Schedules",
-          icon: "ph:clock" as const,
-          active: mode === "schedules",
-          onClick: () => setMode("schedules"),
-        },
-        {
-          id: "calls",
-          label: "Calls",
-          icon: "ph:graph" as const,
-          active: mode === "calls",
-          onClick: () => setMode("calls"),
-        },
-        {
-          id: "comux",
-          label: "Comux",
-          icon: "ph:squares-four" as const,
-          active: mode === "comux",
-          onClick: () => setMode("comux"),
-        },
-      ] as ShellNavItem[],
-    },
-    {
-      label: "Familiars",
-      items: [] as ShellNavItem[],
-      customContent: (
-        <SidebarFamiliars
-          familiars={familiars}
-          activeId={activeId}
-          sessions={sessions}
-          responseNeeded={responseNeeded}
-          onSelect={(id) => {
-            setActiveId(id);
-            setMode("chats");
-          }}
-          error={familiarsError}
-        />
-      ),
-    },
-    {
-      label: "Configure",
-      items: [
-        {
-          id: "settings",
-          label: "Settings",
-          icon: "ph:gear-six" as const,
-          onClick: openOnboarding,
-        },
-      ] as ShellNavItem[],
-    },
-  ];
+  const sidebar = (
+    <SidebarMinimal
+      mode={mode}
+      sessions={sessions}
+      activeSessionId={routerRef.current?.currentSessionId() ?? null}
+      inboxBadgeCount={inboxBadgeCount}
+      onNewChat={() => {
+        setMode("chats");
+        setTimeout(() => routerRef.current?.newChat(), 0);
+      }}
+      onOpenSearch={() => setPaletteOpen(true)}
+      onModeChange={(m) => setMode(m as Mode)}
+      onOpenSession={(id) => {
+        setMode("chats");
+        setTimeout(() => routerRef.current?.openSession(id), 0);
+      }}
+      onOpenSettings={openOnboarding}
+    />
+  );
 
   const list = undefined;
 
@@ -731,21 +625,22 @@ export function Workspace() {
             }}
           />
         }
-        nav={
-          <ShellNav
-            header={<ShellNavHeader initial="C" label="CovenCave" />}
-            sections={navSections}
-          />
-        }
+        nav={sidebar}
         list={list}
         detail={detail}
         agent={
           <AgentPanel
             ref={routerRef}
             familiar={active}
+            familiars={familiars}
+            activeId={activeId}
             sessions={sessions}
             daemonRunning={daemonRunning}
             onSessionStarted={loadSessions}
+            onFamiliarSelect={(id) => {
+              setActiveId(id);
+              setMode("chats");
+            }}
             onSlashFromChat={(command, args) => {
               onPaletteIntent({ kind: "slash", command, args });
               return true;

--- a/src/lib/icon.tsx
+++ b/src/lib/icon.tsx
@@ -60,6 +60,10 @@ export const ICON_NAMES = [
   "ph:clock",
   "ph:globe",
   "ph:graph",
+  "ph:squares-four",
+  "ph:folder",
+  "ph:folder-open",
+  "ph:calendar-blank",
 ] as const;
 
 export type IconName = (typeof ICON_NAMES)[number];

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -1,0 +1,274 @@
+/* sidebar-minimal.css — minimal sidebar redesign styles.
+ * Appended to globals via @import in globals.css.
+ * Uses only existing CSS custom properties.
+ */
+
+/* ── Sidebar shell ────────────────────────────────────────────────────────── */
+.sidebar-minimal {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  padding: 6px 0 0;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+/* ── 4 primary actions ───────────────────────────────────────────────────── */
+.sidebar-actions {
+  padding: 0 6px 4px;
+  flex-shrink: 0;
+}
+
+.sidebar-action-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: 8px;
+  padding: 5px 8px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s ease, color 0.1s ease;
+}
+
+.sidebar-action-row:hover {
+  background: var(--bg-raised);
+  color: var(--text-primary);
+}
+
+.sidebar-action-icon {
+  flex-shrink: 0;
+  width: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.7;
+}
+
+.sidebar-action-row:hover .sidebar-action-icon {
+  opacity: 1;
+}
+
+.sidebar-action-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-action-kbd {
+  font-size: 10px;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+/* ── Folder mode rows ────────────────────────────────────────────────────── */
+.sidebar-folders {
+  padding: 4px 6px 4px;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.sidebar-folder-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: 8px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s ease, color 0.1s ease;
+}
+
+.sidebar-folder-row:hover {
+  background: var(--bg-raised);
+  color: var(--text-secondary);
+}
+
+.sidebar-folder-row--active {
+  background: color-mix(in oklab, oklch(0.65 0.18 280) 10%, transparent);
+  color: var(--text-primary);
+}
+
+.sidebar-folder-icon {
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
+.sidebar-folder-row--active .sidebar-folder-icon,
+.sidebar-folder-row:hover .sidebar-folder-icon {
+  opacity: 1;
+}
+
+.sidebar-folder-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-badge {
+  font-size: 10px;
+  padding: 0.05em 0.45em;
+  border-radius: 8px;
+  background: color-mix(in oklab, oklch(0.65 0.18 280) 18%, transparent);
+  color: oklch(0.75 0.12 280);
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Recents header ──────────────────────────────────────────────────────── */
+.sidebar-recents-header {
+  padding: 8px 14px 3px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  user-select: none;
+}
+
+/* ── Flat recents list ───────────────────────────────────────────────────── */
+.sidebar-recents {
+  flex: 1;
+  overflow-y: auto;
+  padding: 2px 6px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-hairline) transparent;
+}
+
+.sidebar-recents::-webkit-scrollbar { width: 3px; }
+.sidebar-recents::-webkit-scrollbar-thumb {
+  background: var(--border-hairline);
+  border-radius: 2px;
+}
+
+.sidebar-recents-empty {
+  padding: 6px 8px;
+  font-size: 11px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.sidebar-recent-row {
+  display: flex;
+  align-items: baseline;
+  width: 100%;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s ease, color 0.1s ease;
+  min-width: 0;
+}
+
+.sidebar-recent-row:hover {
+  background: var(--bg-raised);
+  color: var(--text-primary);
+}
+
+.sidebar-recent-row--active {
+  background: color-mix(in oklab, oklch(0.65 0.18 280) 10%, transparent);
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.sidebar-recent-title {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.sidebar-recent-ts {
+  flex-shrink: 0;
+  font-size: 10px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Bottom settings row ─────────────────────────────────────────────────── */
+.sidebar-bottom {
+  flex-shrink: 0;
+  padding: 4px 6px 6px;
+  border-top: 1px solid var(--border-hairline);
+}
+
+.sidebar-settings-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: 8px;
+  padding: 5px 8px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s ease, color 0.1s ease;
+}
+
+.sidebar-settings-row:hover {
+  background: var(--bg-raised);
+  color: var(--text-secondary);
+}
+
+/* ── FamiliarStrip (AgentPanel top) ──────────────────────────────────────── */
+.familiar-strip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 6px;
+  border-bottom: 1px solid var(--border-hairline);
+  flex-shrink: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.familiar-strip::-webkit-scrollbar { display: none; }
+
+.familiar-strip-avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1.5px solid transparent;
+  background: var(--bg-raised);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: border-color 0.12s ease, background 0.12s ease;
+  padding: 0;
+}
+
+.familiar-strip-avatar:hover {
+  border-color: var(--border-strong);
+}
+
+.familiar-strip-avatar--active {
+  border-color: oklch(0.65 0.18 280);
+  box-shadow: 0 0 0 1px oklch(0.65 0.18 280 / 35%);
+  background: color-mix(in oklab, oklch(0.65 0.18 280) 12%, var(--bg-raised));
+}


### PR DESCRIPTION
## Summary

Redesigns the Cave sidebar to match Val's reference: flat, action-first, no section header noise.

## Layout (top → bottom)

**4 primary actions:**
1. ✏️ New chat — opens new chat with active familiar
2. 🔍 Search — opens command palette (⌘K)
3. ⚙️ Plugins — switches to Plugins mode
4. 📅 Automations — switches to Calls mode (nav label reads "Automations")

**5 folder mode rows** (Board / Inbox / Val's Inbox / Schedules / Browser / Comux):
- Active row: Mood C-tinted background, 8px rounded
- Inbox row shows badge count when non-zero

**Flat recents list:**
- Sessions sorted by `updated_at` desc, capped at 40
- Each row: truncated title (flex-1) + short relative timestamp right (`5h`, `13m`, `1mo`)
- Active session: Mood C tint + `font-weight: 500`

**Settings gear row** — pinned at bottom, opens onboarding overlay.

## What goes away from the at-rest sidebar
- WORKSPACE / FAMILIARS / CONFIGURE section headers
- Per-familiar rows with role/status badges (Nova/Sage/Charm/Echo/Astra/Cody/Kitty)
- Harness/model/status/sessions config block

## Where the displaced pieces land

| Piece | New location |
|-------|-------------|
| Familiars | **FamiliarStrip** — 28px avatar circles at the top of AgentPanel (right pane). Active familiar gets a Mood C violet ring. Badge text (QUEEN/RESEARCH/etc.) becomes a hover tooltip. |
| Settings | Gear icon row pinned at the bottom of the sidebar |
| Harness/model config | Still reachable via Settings (onboarding overlay) |

## Files changed
- **new** `src/components/sidebar-minimal.tsx` — full sidebar component
- **modified** `src/components/agent-panel.tsx` — FamiliarStrip header added
- **modified** `src/components/workspace.tsx` — wires SidebarMinimal + new AgentPanel props
- **modified** `src/lib/icon.tsx` — adds `ph:squares-four`, `ph:folder`, `ph:folder-open`, `ph:calendar-blank`
- **new** `src/styles/sidebar-minimal.css` — scoped CSS using existing custom properties only
- **modified** `src/app/globals.css` — @import sidebar-minimal.css

`pnpm typecheck` exits 0. `pnpm build` exits 0.