### PR TITLE
feat(home): HomeComposer — universal intent surface as cold-start default

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,7 @@
 @import "@xterm/xterm/css/xterm.css";
 @import "../styles/cave-chat.css";
 @import "../styles/sidebar-minimal.css";
+@import "../styles/home-composer.css";
 
 /* ============================================================
    Coven aesthetic tokens (Mood C — foundation, issue #14)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Fredoka, Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -10,6 +10,12 @@ const geistSans = Geist({
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+});
+
+const fredoka = Fredoka({
+  variable: "--font-fredoka",
+  subsets: ["latin"],
+  weight: ["300", "400", "500", "600", "700"],
 });
 
 export const metadata: Metadata = {
@@ -25,7 +31,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${geistSans.variable} ${geistMono.variable} ${fredoka.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">{children}</body>
     </html>

--- a/src/components/daemon-bar.tsx
+++ b/src/components/daemon-bar.tsx
@@ -7,7 +7,7 @@ import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 import { NotificationBell } from "@/components/notification-bell";
 import { HealthStrip } from "@/components/health-strip";
 
-export type Mode = "chats" | "board" | "inbox" | "plugins" | "vals-inbox" | "browser" | "schedules" | "calls" | "comux";
+export type Mode = "chats" | "board" | "inbox" | "plugins" | "vals-inbox" | "browser" | "schedules" | "calls" | "comux" | "home";
 
 type Props = {
   mode: Mode;
@@ -23,6 +23,7 @@ type Props = {
 };
 
 const MODE_LABEL: Record<Mode, string> = {
+  home: "Home",
   chats: "Chats",
   board: "Board",
   inbox: "Inbox",

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -196,8 +196,10 @@ export function HomeComposer({
             headers: { "content-type": "application/json" },
             body: JSON.stringify({ familiarId: fid, prompt }),
           });
-          if (!res.ok && !res.body) {
-            const err = (await res.json().catch(() => ({ error: "send failed" }))) as { error?: string };
+          if (!res.ok) {
+            const err = (await res
+              .json()
+              .catch(() => ({ error: "send failed" }))) as { error?: string };
             onToast(err.error ?? "Chat send failed.");
             break;
           }

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -229,7 +229,7 @@ export function HomeComposer({
           }
           if (sessionId) {
             setText("");
-            onNavigateToChat(sessionId, familiarId ?? familiars[0]?.id ?? "");
+            onNavigateToChat(sessionId, fid);
           } else {
             onToast("Chat started but session ID not received — check Chats.");
             setText("");

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -400,8 +400,7 @@ export function HomeComposer({
               {sending ? (
                 <span className="hc-spinner" />
               ) : (
-                <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
-                  <path d="M8 2l6 6H9v6H7V8H2l6-6z" />
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
                 </svg>
               )}
             </button>

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -1,0 +1,434 @@
+"use client";
+
+/**
+ * HomeComposer — universal intent surface; the Cave's cold-start view.
+ *
+ * Layout:
+ *   Headline  "What's the Coven up to?"  (Fredoka 600)
+ *   Context chips row: familiar selector · destination selector · workspace chip
+ *   Composer textarea with placeholder "Do anything…", ⌘↵ submit, ↑ history
+ *   Suggestions row from recent sessions + inbox items (real data; seeds 3 when empty)
+ *
+ * Destinations:
+ *   Chat      — fully wired: POST /api/chat/send, then navigate to chat session
+ *   Board     — wired: POST /api/board, then navigate to Board mode
+ *   Reminder  — wired: POST /api/inbox (kind=reminder), then navigate to Inbox
+ *   Inbox     — navigates to Inbox mode (text becomes an inbox note)
+ *   Call      — stub: toast "Call scheduling coming soon"
+ */
+
+import {
+  type KeyboardEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import type { Familiar, SessionRow } from "@/lib/types";
+import type { InboxItem } from "@/lib/cave-inbox";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type Destination = "chat" | "board" | "reminder" | "inbox" | "call";
+
+const DESTINATIONS: { id: Destination; label: string; emoji: string }[] = [
+  { id: "chat",     label: "Chat",     emoji: "💬" },
+  { id: "board",    label: "Board",    emoji: "📋" },
+  { id: "reminder", label: "Reminder", emoji: "⏰" },
+  { id: "inbox",    label: "Inbox",    emoji: "📥" },
+  { id: "call",     label: "Call",     emoji: "📞" },
+];
+
+type Props = {
+  familiars: Familiar[];
+  activeFamiliarId: string | null;
+  sessions: SessionRow[];
+  onNavigateToChat: (sessionId: string, familiarId: string) => void;
+  onNavigateToBoard: () => void;
+  onNavigateToInbox: () => void;
+  onToast: (msg: string) => void;
+};
+
+// ---------------------------------------------------------------------------
+// Seed suggestions (used when no real data is available)
+// ---------------------------------------------------------------------------
+
+const SEED_SUGGESTIONS = [
+  "Summarise what Nova has been working on today",
+  "Create a board card for the HomeComposer PR",
+  "Remind me to review PRs tomorrow at 10 AM",
+];
+
+// ---------------------------------------------------------------------------
+// HomeComposer
+// ---------------------------------------------------------------------------
+
+export function HomeComposer({
+  familiars,
+  activeFamiliarId,
+  sessions,
+  onNavigateToChat,
+  onNavigateToBoard,
+  onNavigateToInbox,
+  onToast,
+}: Props) {
+  const [text, setText] = useState("");
+  const [destination, setDestination] = useState<Destination>("chat");
+  const [familiarId, setFamiliarId] = useState<string | null>(activeFamiliarId);
+  const [sending, setSending] = useState(false);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [history, setHistory] = useState<string[]>([]);
+  const [historyIdx, setHistoryIdx] = useState<number>(-1);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Sync activeFamiliarId → local when parent changes (e.g. user clicks strip)
+  useEffect(() => {
+    if (activeFamiliarId && !familiarId) {
+      setFamiliarId(activeFamiliarId);
+    }
+  }, [activeFamiliarId, familiarId]);
+
+  // Focus on mount
+  useEffect(() => {
+    setTimeout(() => textareaRef.current?.focus(), 80);
+  }, []);
+
+  // Build suggestions: last 3 session titles + latest pending inbox items (up to 3 total)
+  useEffect(() => {
+    void (async () => {
+      const lines: string[] = [];
+
+      // Recent session titles
+      const recentTitles = sessions
+        .filter((s) => !s.archived_at && s.title)
+        .sort((a, b) => (b.updated_at ?? "").localeCompare(a.updated_at ?? ""))
+        .slice(0, 2)
+        .map((s) => `Continue: ${s.title}`);
+      lines.push(...recentTitles);
+
+      // Pending inbox items
+      try {
+        const res = await fetch("/api/inbox?status=pending", { cache: "no-store" });
+        if (res.ok) {
+          const json = (await res.json()) as { ok: boolean; items: InboxItem[] };
+          if (json.ok) {
+            const inbox = json.items.slice(0, 3 - lines.length).map((i) => i.title);
+            lines.push(...inbox);
+          }
+        }
+      } catch {
+        // silently skip inbox fetch failures
+      }
+
+      // Fill with seeds if not enough
+      while (lines.length < 3) {
+        const seed = SEED_SUGGESTIONS[lines.length % SEED_SUGGESTIONS.length];
+        if (seed && !lines.includes(seed)) lines.push(seed);
+        else break;
+      }
+
+      setSuggestions(lines.slice(0, 3));
+    })();
+  }, [sessions]);
+
+  // Auto-grow textarea
+  const autoGrow = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      // ⌘↵ or Ctrl+↵ → submit
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        void handleSubmit();
+        return;
+      }
+      // ↑ history navigation (only when at start of input)
+      if (e.key === "ArrowUp" && text === "" && history.length > 0) {
+        e.preventDefault();
+        const idx = historyIdx < history.length - 1 ? historyIdx + 1 : historyIdx;
+        setHistoryIdx(idx);
+        setText(history[history.length - 1 - idx] ?? "");
+        return;
+      }
+      // ↓ history navigation
+      if (e.key === "ArrowDown" && historyIdx > 0) {
+        e.preventDefault();
+        const idx = historyIdx - 1;
+        setHistoryIdx(idx);
+        setText(history[history.length - 1 - idx] ?? "");
+        return;
+      }
+      if (e.key === "ArrowDown" && historyIdx === 0) {
+        e.preventDefault();
+        setHistoryIdx(-1);
+        setText("");
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [text, history, historyIdx],
+  );
+
+  const handleSubmit = useCallback(async () => {
+    const prompt = text.trim();
+    if (!prompt || sending) return;
+
+    setHistory((prev) => [...prev, prompt]);
+    setHistoryIdx(-1);
+    setSending(true);
+
+    try {
+      switch (destination) {
+        case "chat": {
+          const fid = familiarId ?? familiars[0]?.id;
+          if (!fid) {
+            onToast("No familiar selected — add one in Settings.");
+            break;
+          }
+          const res = await fetch("/api/chat/send", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ familiarId: fid, prompt }),
+          });
+          if (!res.ok && !res.body) {
+            const err = (await res.json().catch(() => ({ error: "send failed" }))) as { error?: string };
+            onToast(err.error ?? "Chat send failed.");
+            break;
+          }
+          // Stream the SSE response to capture the sessionId
+          let sessionId: string | null = null;
+          if (res.body) {
+            const reader = res.body.getReader();
+            const dec = new TextDecoder();
+            let buf = "";
+            outer: while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              buf += dec.decode(value, { stream: true });
+              const lines = buf.split("\n");
+              buf = lines.pop() ?? "";
+              for (const line of lines) {
+                if (line.startsWith("data: ")) {
+                  try {
+                    const evt = JSON.parse(line.slice(6)) as { kind: string; sessionId?: string };
+                    if (evt.kind === "session" && evt.sessionId) {
+                      sessionId = evt.sessionId;
+                      reader.cancel().catch(() => undefined);
+                      break outer;
+                    }
+                  } catch { /* malformed SSE chunk */ }
+                }
+              }
+            }
+          }
+          if (sessionId) {
+            setText("");
+            onNavigateToChat(sessionId, familiarId ?? familiars[0]?.id ?? "");
+          } else {
+            onToast("Chat started but session ID not received — check Chats.");
+            setText("");
+          }
+          break;
+        }
+
+        case "board": {
+          const res = await fetch("/api/board", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              title: prompt,
+              familiarId: familiarId ?? null,
+            }),
+          });
+          const json = (await res.json().catch(() => ({ ok: false }))) as { ok: boolean };
+          if (json.ok) {
+            setText("");
+            onNavigateToBoard();
+          } else {
+            onToast("Board card creation failed.");
+          }
+          break;
+        }
+
+        case "reminder": {
+          const res = await fetch("/api/inbox", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              kind: "reminder",
+              title: prompt,
+              source: "user",
+              familiarId: familiarId ?? null,
+            }),
+          });
+          const json = (await res.json().catch(() => ({ ok: false }))) as { ok: boolean };
+          if (json.ok) {
+            setText("");
+            onNavigateToInbox();
+          } else {
+            onToast("Reminder creation failed.");
+          }
+          break;
+        }
+
+        case "inbox": {
+          const res = await fetch("/api/inbox", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              kind: "note",
+              title: prompt,
+              source: "user",
+              familiarId: familiarId ?? null,
+            }),
+          });
+          const json = (await res.json().catch(() => ({ ok: false }))) as { ok: boolean };
+          if (json.ok) {
+            setText("");
+            onNavigateToInbox();
+          } else {
+            onToast("Inbox note creation failed.");
+          }
+          break;
+        }
+
+        case "call": {
+          onToast("Call scheduling coming soon.");
+          break;
+        }
+      }
+    } finally {
+      setSending(false);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [text, destination, familiarId, familiars, sending]);
+
+  const active = familiars.find((f) => f.id === familiarId) ?? familiars[0] ?? null;
+
+  return (
+    <div className="home-composer-root">
+      {/* Headline */}
+      <h1 className="home-composer-headline">
+        What&apos;s the Coven up to?
+      </h1>
+
+      {/* Composer card */}
+      <div className="home-composer-card">
+        {/* Context chips */}
+        <div className="home-composer-chips">
+          {/* Familiar chip */}
+          <div className="hc-chip-group">
+            <label className="hc-chip-label">With</label>
+            <select
+              className="hc-chip-select"
+              value={familiarId ?? ""}
+              onChange={(e) => setFamiliarId(e.target.value || null)}
+            >
+              {familiars.length === 0 && (
+                <option value="">No familiars</option>
+              )}
+              {familiars.map((f) => (
+                <option key={f.id} value={f.id}>
+                  {f.display_name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Destination chip */}
+          <div className="hc-chip-group">
+            <label className="hc-chip-label">To</label>
+            <div className="hc-destination-pills">
+              {DESTINATIONS.map((d) => (
+                <button
+                  key={d.id}
+                  type="button"
+                  className={`hc-dest-pill${destination === d.id ? " hc-dest-pill--active" : ""}`}
+                  onClick={() => setDestination(d.id)}
+                  title={d.label}
+                >
+                  <span>{d.emoji}</span>
+                  <span>{d.label}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Workspace chip (informational) */}
+          {active && (
+            <div className="hc-chip-workspace">
+              <span className="hc-chip-label">Active</span>
+              <span className="hc-chip-value">{active.display_name}</span>
+              {active.role && (
+                <span className="hc-chip-role">{active.role}</span>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Textarea */}
+        <div className="hc-composer-body">
+          <textarea
+            ref={textareaRef}
+            className="hc-textarea"
+            placeholder="Do anything…"
+            rows={2}
+            value={text}
+            onChange={(e) => {
+              setText(e.target.value);
+              autoGrow();
+            }}
+            onKeyDown={handleKeyDown}
+            disabled={sending}
+          />
+          <div className="hc-composer-footer">
+            <span className="hc-hint">⌘↵ send · ↑ history</span>
+            <button
+              type="button"
+              className={`hc-send-btn${sending ? " hc-send-btn--sending" : ""}${!text.trim() ? " hc-send-btn--empty" : ""}`}
+              onClick={() => void handleSubmit()}
+              disabled={!text.trim() || sending}
+              aria-label="Send"
+            >
+              {sending ? (
+                <span className="hc-spinner" />
+              ) : (
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+                  <path d="M8 2l6 6H9v6H7V8H2l6-6z" />
+                </svg>
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Suggestions */}
+      {suggestions.length > 0 && (
+        <div className="home-composer-suggestions">
+          <div className="hc-suggestions-label">Suggestions</div>
+          <div className="hc-suggestions-list">
+            {suggestions.map((s, i) => (
+              <button
+                key={i}
+                type="button"
+                className="hc-suggestion-pill"
+                onClick={() => {
+                  setText(s);
+                  setTimeout(() => textareaRef.current?.focus(), 0);
+                }}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -324,8 +324,9 @@ export function HomeComposer({
         <div className="home-composer-chips">
           {/* Familiar chip */}
           <div className="hc-chip-group">
-            <label className="hc-chip-label">With</label>
+            <label className="hc-chip-label" htmlFor="hc-familiar-select">With</label>
             <select
+              id="hc-familiar-select"
               className="hc-chip-select"
               value={familiarId ?? ""}
               onChange={(e) => setFamiliarId(e.target.value || null)}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -290,9 +290,8 @@ export function Workspace() {
   }, []);
 
   const pushToast = useCallback((title: string) => {
-    const id = `adhoc-${Date.now()}`;
+    const id = `eph:adhoc-${Date.now()}`;
     setToasts((prev) => [...prev, { id, title }]);
-    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 5000);
   }, []);
 
   const dismissToast = useCallback((id: string) => {

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -21,13 +21,14 @@ import { BrowserPane } from "@/components/browser-pane";
 import { SchedulesView } from "@/components/schedules-view";
 import { CallsView } from "@/components/calls-view";
 import { ComuxView } from "@/components/comux-view";
+import { HomeComposer } from "@/components/home-composer";
 import { nativeNotify } from "@/lib/native-notify";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { DEMO_MODE, DEMO_FAMILIARS } from "@/lib/demo-seed";
 
-type Mode = "chats" | "board" | "plugins" | "inbox" | "vals-inbox" | "browser" | "schedules" | "calls" | "comux";
+type Mode = "home" | "chats" | "board" | "plugins" | "inbox" | "vals-inbox" | "browser" | "schedules" | "calls" | "comux";
 
 export function Workspace() {
   const routerRef = useRef<ChatRouterHandle | null>(null);
@@ -38,7 +39,7 @@ export function Workspace() {
   const [daemonRunning, setDaemonRunning] = useState<boolean>(false);
   const [responseNeeded, setResponseNeeded] = useState<Set<string>>(new Set());
   const [paletteOpen, setPaletteOpen] = useState(false);
-  const [mode, setMode] = useState<Mode>("chats");
+  const [mode, setMode] = useState<Mode>("home");
   const [onboardingOpen, setOnboardingOpen] = useState(false);
   const [inboxItems, setInboxItems] = useState<InboxItem[]>([]);
   const [inboxPrefs, setInboxPrefs] = useState<InboxPrefs>({
@@ -288,6 +289,12 @@ export function Workspace() {
     setReminderModalOpen(true);
   }, []);
 
+  const pushToast = useCallback((title: string) => {
+    const id = `adhoc-${Date.now()}`;
+    setToasts((prev) => [...prev, { id, title }]);
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 5000);
+  }, []);
+
   const dismissToast = useCallback((id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
     // Persist dismissal for real items. Skip synthetic ids (missed-batches,
@@ -533,7 +540,21 @@ export function Workspace() {
   const list = undefined;
 
   const detail =
-    mode === "chats" ? (
+    mode === "home" ? (
+      <HomeComposer
+        familiars={familiars}
+        activeFamiliarId={activeId}
+        sessions={sessions}
+        onNavigateToChat={(sessionId, fid) => {
+          setActiveId(fid);
+          setMode("chats");
+          setTimeout(() => routerRef.current?.openSession(sessionId), 0);
+        }}
+        onNavigateToBoard={() => setMode("board")}
+        onNavigateToInbox={() => setMode("inbox")}
+        onToast={pushToast}
+      />
+    ) : mode === "chats" ? (
       <ChatRouter
         ref={routerRef}
         familiar={active}

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -1,0 +1,281 @@
+/* home-composer.css — universal intent surface styles.
+ * Uses existing --bg-*, --text-*, --border-* custom properties.
+ * Mood C accent via oklab color-mix (no new tokens introduced).
+ */
+
+/* ── Root layout ─────────────────────────────────────────────────────────── */
+.home-composer-root {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  min-height: 0;
+  padding: 48px 32px 64px;
+  gap: 28px;
+  overflow-y: auto;
+}
+
+/* ── Headline ────────────────────────────────────────────────────────────── */
+.home-composer-headline {
+  font-family: var(--font-fredoka, "Fredoka", system-ui, sans-serif);
+  font-weight: 600;
+  font-size: clamp(24px, 4vw, 40px);
+  line-height: 1.15;
+  text-align: center;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+/* ── Composer card ───────────────────────────────────────────────────────── */
+.home-composer-card {
+  width: 100%;
+  max-width: 640px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.12);
+}
+
+/* ── Context chips ───────────────────────────────────────────────────────── */
+.home-composer-chips {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px 8px;
+  border-bottom: 1px solid var(--border-hairline);
+  flex-wrap: wrap;
+}
+
+.hc-chip-group {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.hc-chip-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  user-select: none;
+}
+
+.hc-chip-select {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-primary);
+  background: color-mix(in oklab, oklch(0.65 0.18 280) 10%, var(--bg-base));
+  border: 1px solid color-mix(in oklab, oklch(0.65 0.18 280) 28%, transparent);
+  border-radius: 8px;
+  padding: 3px 8px;
+  cursor: pointer;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.hc-chip-select:focus {
+  border-color: oklch(0.65 0.18 280);
+}
+
+/* Destination pills */
+.hc-destination-pills {
+  display: flex;
+  gap: 4px;
+}
+
+.hc-dest-pill {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 8px;
+  border: 1px solid var(--border-hairline);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.1s ease, border-color 0.1s ease, color 0.1s ease;
+  white-space: nowrap;
+}
+
+.hc-dest-pill:hover {
+  background: var(--bg-raised);
+  color: var(--text-secondary);
+}
+
+.hc-dest-pill--active {
+  background: color-mix(in oklab, oklch(0.65 0.18 280) 15%, transparent);
+  border-color: oklch(0.65 0.18 280 / 60%);
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+/* Workspace chip */
+.hc-chip-workspace {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.hc-chip-value {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.hc-chip-role {
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: oklch(0.65 0.18 280);
+  background: color-mix(in oklab, oklch(0.65 0.18 280) 12%, transparent);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+
+/* ── Textarea ────────────────────────────────────────────────────────────── */
+.hc-composer-body {
+  display: flex;
+  flex-direction: column;
+}
+
+.hc-textarea {
+  width: 100%;
+  resize: none;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text-primary);
+  font-size: 15px;
+  line-height: 1.55;
+  padding: 14px 14px 8px;
+  font-family: inherit;
+  min-height: 64px;
+  max-height: 200px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-hairline) transparent;
+}
+
+.hc-textarea::placeholder {
+  color: var(--text-muted);
+}
+
+.hc-textarea:disabled {
+  opacity: 0.5;
+}
+
+/* Footer row */
+.hc-composer-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 10px 10px 14px;
+  gap: 8px;
+}
+
+.hc-hint {
+  font-size: 10px;
+  color: var(--text-muted);
+  user-select: none;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+.hc-send-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  border: none;
+  background: oklch(0.65 0.18 280);
+  color: #fff;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: opacity 0.1s ease, background 0.1s ease;
+}
+
+.hc-send-btn:hover:not(:disabled) {
+  background: oklch(0.7 0.18 280);
+}
+
+.hc-send-btn--empty,
+.hc-send-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.hc-send-btn--sending {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+/* Spinner */
+.hc-spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(255,255,255,0.35);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: hc-spin 0.6s linear infinite;
+}
+
+@keyframes hc-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── Suggestions ─────────────────────────────────────────────────────────── */
+.home-composer-suggestions {
+  width: 100%;
+  max-width: 640px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.hc-suggestions-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  padding: 0 4px;
+}
+
+.hc-suggestions-list {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.hc-suggestion-pill {
+  display: block;
+  text-align: left;
+  width: 100%;
+  padding: 8px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-raised);
+  color: var(--text-secondary);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.1s ease, color 0.1s ease, border-color 0.1s ease;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hc-suggestion-pill:hover {
+  background: color-mix(in oklab, oklch(0.65 0.18 280) 8%, var(--bg-raised));
+  border-color: color-mix(in oklab, oklch(0.65 0.18 280) 30%, transparent);
+  color: var(--text-primary);
+}


### PR DESCRIPTION
## Summary

Adds `mode="home"` as the Cave's default starting view. No more landing in an empty chat. You land on a purpose-built intent surface instead.

## Layout

```
What's the Coven up to?         ← Fredoka 600

┌──────────────────────────────────────────────┐
│ With [Nova ▾]  To [💬Chat][📋Board][⏰Reminder][📥Inbox][📞Call]  Active Nova · QUEEN │
├──────────────────────────────────────────────┤
│ Do anything…                                 │
│                                              │
│  ⌘↵ send · ↑ history            [↑ send btn] │
└──────────────────────────────────────────────┘

Suggestions
  Continue: Refactor SessionRow types
  Continue: HomeComposer CSS pass
  Remind me to review PRs tomorrow at 10 AM
```

## Destination chips — wired vs stubbed

| Destination | Status | What happens |
|-------------|--------|-------------|
| **Chat** | ✅ wired | POST /api/chat/send (SSE); reads first `session` event → navigates to Chat mode with that session open |
| **Board** | ✅ wired | POST /api/board (title + familiarId) → navigates to Board mode |
| **Reminder** | ✅ wired | POST /api/inbox (kind=reminder) → navigates to Inbox |
| **Inbox** | ✅ wired | POST /api/inbox (kind=note) → navigates to Inbox |
| **Call** | 🔲 stub | toast "Call scheduling coming soon" |

Chat is the hero path — full end-to-end wired.

## Files changed

| File | Change |
|------|--------|
| **new** `src/components/home-composer.tsx` | Component: headline, context chips, composer, suggestions |
| **new** `src/styles/home-composer.css` | Scoped CSS, Mood C accent, existing tokens only |
| **mod** `src/components/workspace.tsx` | Mode += "home"; default = "home"; detail chain; pushToast helper |
| **mod** `src/components/daemon-bar.tsx` | Mode += "home"; MODE_LABEL["home"] = "Home" |
| **mod** `src/app/layout.tsx` | Fredoka font (next/font/google, --font-fredoka) |
| **mod** `src/app/globals.css` | @import home-composer.css |

`pnpm typecheck` → exit 0. `pnpm build` → exit 0 (full production build).