### PR TITLE
fix(sidecar): resolve dangling pnpm symlinks in .next/node_modules

### DIFF
--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -66,6 +66,38 @@ if [ -d "$STATIC" ]; then
   cp -a "$STATIC/." "$DEST/.next/static/"
 fi
 
+# Next.js + pnpm also drops symlinks under .next/node_modules/ that point at
+# ../../node_modules/.pnpm/<pkg>@<ver>/node_modules/<pkg> (e.g. shiki,
+# oniguruma-to-es). After we swap in the npm-flat top-level node_modules
+# above, those symlinks dangle, and Tauri's resource glob rejects the bundle
+# with `resource path doesn't exist`. Resolve each into a real directory.
+if [ -d "$DEST/.next/node_modules" ]; then
+  echo "==> resolving dangling pnpm symlinks in .next/node_modules"
+  while IFS= read -r link; do
+    target="$(readlink "$link" 2>/dev/null || true)"
+    [ -z "$target" ] && continue
+    resolved_target="$(cd "$(dirname "$link")" 2>/dev/null && cd "$(dirname "$target")" 2>/dev/null && pwd)/$(basename "$target")"
+    if [ -n "$resolved_target" ] && [ -e "$resolved_target" ]; then
+      continue
+    fi
+    # Strip the trailing -<16hex> webpack-content-hash suffix
+    pkg="$(basename "$link" | sed -E 's/-[a-f0-9]{16}$//')"
+    src=""
+    if [ -d "$NPM_STAGE/node_modules/$pkg" ]; then
+      src="$NPM_STAGE/node_modules/$pkg"
+    elif [ -d "$ROOT/node_modules/$pkg" ]; then
+      src="$ROOT/node_modules/$pkg"
+    fi
+    if [ -n "$src" ] && [ -d "$src" ]; then
+      rm -f "$link"
+      cp -aL "$src" "$link"
+      echo "    resolved $(basename "$link") ← $pkg"
+    else
+      echo "    ! could not resolve $(basename "$link") (pkg=$pkg)" >&2
+    fi
+  done < <(find "$DEST/.next/node_modules" -mindepth 1 -maxdepth 1 -type l)
+fi
+
 if [ -d "$PUBLIC" ]; then
   mkdir -p "$DEST/public"
   echo "==> copying public/ → $DEST/public"

--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -74,10 +74,8 @@ fi
 if [ -d "$DEST/.next/node_modules" ]; then
   echo "==> resolving dangling pnpm symlinks in .next/node_modules"
   while IFS= read -r link; do
-    target="$(readlink "$link" 2>/dev/null || true)"
-    [ -z "$target" ] && continue
-    resolved_target="$(cd "$(dirname "$link")" 2>/dev/null && cd "$(dirname "$target")" 2>/dev/null && pwd)/$(basename "$target")"
-    if [ -n "$resolved_target" ] && [ -e "$resolved_target" ]; then
+    # Only patch dangling symlinks (non-dangling ones are fine as-is).
+    if [ -e "$link" ]; then
       continue
     fi
     # Strip the trailing -<16hex> webpack-content-hash suffix


### PR DESCRIPTION
## Summary
Unblocks all signed releases (local **and** CI). Discovered while debugging why v0.0.14/v0.0.15 silently shipped unsigned DMGs from CI.

## Root cause
`pnpm next build` emits `.next/standalone/.next/node_modules/<pkg>-<hash>` as a **symlink** pointing at `../../node_modules/.pnpm/<pkg>@<ver>/node_modules/<pkg>` (verified for `shiki`, will hit any future externalized dep).

After `scripts/sidecar-bundle.sh` swaps the top-level `node_modules/` for an npm-flat copy, these inner symlinks dangle. Tauri's resource glob (`resources/server/**/*`) then rejects the bundle with:
```
resource path `resources/server/.next/node_modules/shiki-1476e3c95a68a2b2` doesn't exist
```

This was failing every local + CI build silently before the new notarize gate (`#53`) caught it.

## Fix
After the standalone copy, walk `$DEST/.next/node_modules/`, detect dangling symlinks, and replace each with a real directory copy from either the npm staging dir or the workspace `node_modules/`.

## Verification (local)
- Build log shows: `resolved shiki-1476e3c95a68a2b2 ← shiki`
- Sidecar bundle finishes: `sidecar bundle ready (389M)`
- Tauri Rust compile then proceeds normally

Co-authored-by: Nova (OpenCoven) <noreply@opencoven.ai>