### PR TITLE
fix: address Comux review follow-ups

### DIFF
--- a/src/app/api/project-file/route.ts
+++ b/src/app/api/project-file/route.ts
@@ -1,14 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import fs from "node:fs";
 import path from "node:path";
-import os from "node:os";
+import { resolveAllowedProjectPath } from "@/lib/server/project-paths";
 
 const MAX_SIZE = 512 * 1024; // 512KB
-
-const ALLOWED_PREFIXES = [
-  path.join(os.homedir(), "Documents", "GitHub"),
-  os.homedir(),
-];
 
 const TEXT_EXTENSIONS = new Set([
   ".ts",
@@ -52,11 +47,6 @@ const TEXT_EXTENSIONS = new Set([
   ".lua",
 ]);
 
-function isAllowed(p: string): boolean {
-  const resolved = path.resolve(p);
-  return ALLOWED_PREFIXES.some((prefix) => resolved.startsWith(prefix));
-}
-
 export async function GET(req: NextRequest) {
   const filePath = req.nextUrl.searchParams.get("path");
   if (!filePath) {
@@ -66,8 +56,8 @@ export async function GET(req: NextRequest) {
     );
   }
 
-  const resolved = path.resolve(filePath);
-  if (!isAllowed(resolved)) {
+  const resolved = resolveAllowedProjectPath(filePath);
+  if (!resolved) {
     return NextResponse.json(
       { ok: false, error: "path not allowed" },
       { status: 403 },

--- a/src/app/api/project-tree/route.ts
+++ b/src/app/api/project-tree/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import fs from "node:fs";
 import path from "node:path";
-import os from "node:os";
+import { resolveAllowedProjectPath } from "@/lib/server/project-paths";
 
 type TreeEntry = {
   name: string;
@@ -20,16 +20,6 @@ const SKIP = new Set([
   "out",
   ".DS_Store",
 ]);
-
-const ALLOWED_PREFIXES = [
-  path.join(os.homedir(), "Documents", "GitHub"),
-  os.homedir(),
-];
-
-function isAllowed(p: string): boolean {
-  const resolved = path.resolve(p);
-  return ALLOWED_PREFIXES.some((prefix) => resolved.startsWith(prefix));
-}
 
 function readTree(root: string, depth: number): TreeEntry[] {
   if (depth < 0) return [];
@@ -66,13 +56,14 @@ export async function GET(req: NextRequest) {
       { status: 400 },
     );
   }
-  if (!isAllowed(root)) {
+  const allowedRoot = resolveAllowedProjectPath(root);
+  if (!allowedRoot) {
     return NextResponse.json(
       { ok: false, error: "path not allowed" },
       { status: 403 },
     );
   }
   const depth = Math.min(Math.max(parseInt(depthStr ?? "1", 10) || 1, 0), 4);
-  const entries = readTree(root, depth);
+  const entries = readTree(allowedRoot, depth);
   return NextResponse.json({ ok: true, entries });
 }

--- a/src/components/project-tree.tsx
+++ b/src/components/project-tree.tsx
@@ -46,7 +46,7 @@ function resolveRoot(): string {
     const env = process.env.NEXT_PUBLIC_WORKSPACE_ROOT;
     if (env) return env;
   }
-  return "/Users/buns/Documents/GitHub/OpenCoven/coven-cave";
+  return "";
 }
 
 export const ProjectTree = forwardRef<ProjectTreeHandle, Props>(
@@ -64,9 +64,20 @@ export const ProjectTree = forwardRef<ProjectTreeHandle, Props>(
         const wp =
           (json.workspacePath as string | undefined) ??
           (json.projectRoot as string | undefined);
-        if (wp && typeof wp === "string") setRoot(wp);
+        if (wp && typeof wp === "string") {
+          const tree = await fetchTree(wp, 2);
+          setRoot(wp);
+          setEntries(tree);
+          setLoading(false);
+          return;
+        }
       } catch {
         /* use default */
+      }
+      if (!root) {
+        setEntries([]);
+        setLoading(false);
+        return;
       }
       const tree = await fetchTree(root, 2);
       setEntries(tree);

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -325,6 +325,17 @@ export function Workspace() {
     }
   }, []);
 
+  const toggleAgentPanel = useCallback(() => {
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "j",
+        code: "KeyJ",
+        metaKey: true,
+        bubbles: true,
+      }),
+    );
+  }, []);
+
   const onPaletteIntent = (intent: PaletteIntent) => {
     if (intent.kind === "switch-familiar") {
       setActiveId(intent.familiarId);
@@ -401,6 +412,9 @@ export function Workspace() {
           return;
         case "/comux":
           setMode("comux");
+          return;
+        case "/toggle-agent":
+          toggleAgentPanel();
           return;
         case "/quit":
           setMode("chats");
@@ -652,24 +666,26 @@ export function Workspace() {
         list={list}
         detail={detail}
         agent={
-          <AgentPanel
-            ref={routerRef}
-            familiar={active}
-            familiars={familiars}
-            activeId={activeId}
-            sessions={sessions}
-            daemonRunning={daemonRunning}
-            onSessionStarted={loadSessions}
-            onFamiliarSelect={(id) => {
-              setActiveId(id);
-              setMode("chats");
-            }}
-            onSlashFromChat={(command, args) => {
-              onPaletteIntent({ kind: "slash", command, args });
-              return true;
-            }}
-            onOpenOnboarding={openOnboarding}
-          />
+          mode === "chats" ? undefined : (
+            <AgentPanel
+              ref={routerRef}
+              familiar={active}
+              familiars={familiars}
+              activeId={activeId}
+              sessions={sessions}
+              daemonRunning={daemonRunning}
+              onSessionStarted={loadSessions}
+              onFamiliarSelect={(id) => {
+                setActiveId(id);
+                setMode("chats");
+              }}
+              onSlashFromChat={(command, args) => {
+                onPaletteIntent({ kind: "slash", command, args });
+                return true;
+              }}
+              onOpenOnboarding={openOnboarding}
+            />
+          )
         }
         bottom={<BottomTerminal threadId="cave.bottom.main" />}
       />

--- a/src/lib/server/project-paths.ts
+++ b/src/lib/server/project-paths.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function realpathOrResolve(value: string): string {
+  const resolved = path.resolve(value);
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+const ALLOWED_ROOTS = Array.from(
+  new Set(
+    [
+      process.env.WORKSPACE_ROOT,
+      process.env.NEXT_PUBLIC_WORKSPACE_ROOT,
+      process.cwd(),
+    ]
+      .filter((value): value is string => Boolean(value))
+      .map(realpathOrResolve),
+  ),
+);
+
+function isWithinRoot(candidate: string, root: string): boolean {
+  return candidate === root || candidate.startsWith(root + path.sep);
+}
+
+export function resolveAllowedProjectPath(value: string): string | null {
+  const candidate = realpathOrResolve(value);
+  return ALLOWED_ROOTS.some((root) => isWithinRoot(candidate, root))
+    ? candidate
+    : null;
+}
+


### PR DESCRIPTION
## Summary
- avoid duplicate ChatRouter mounts by hiding the side AgentPanel in chats mode
- wire /toggle-agent through the existing Cmd+J panel toggle path
- remove the hard-coded project-tree root and fetch with the daemon-reported root immediately
- restrict project file/tree APIs to real paths under the configured workspace root

## Verification
- /opt/homebrew/bin/pnpm run typecheck
- /opt/homebrew/bin/pnpm run build
- local API probes: in-tree file read ok, prefix-bypass 403, symlink escape 403, home-dir read 403
- Playwright opened http://localhost:3137/ and rendered CovenCave