### PR TITLE
feat(sidebar): replace emoji row with familiar accordion sections

### DIFF
--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -5,12 +5,9 @@
  *
  * Layout (top → bottom):
  *   1. 4 primary actions  (New chat / Search / Plugins / Automations)
- *   2. 5 folder mode rows (Board / Inbox / Val's Inbox / Browser / Comux)
- *   3. Flat recent-chats list with relative timestamps
- *   4. Familiar switcher strip (above settings)
- *   5. Gear settings row (bottom, pinned)
- *
- * Settings gear opens the onboarding overlay.
+ *   2. Folder mode rows   (Board / Inbox / Val's Inbox / Browser / Comux / Coven Calls)
+ *   3. Familiar sections  (each familiar = header row + session list; no emoji row)
+ *   4. Settings gear (pinned bottom)
  */
 
 import { useMemo, useState } from "react";
@@ -21,7 +18,7 @@ import { useGlyphOverrides } from "@/lib/cave-glyph-overrides";
 import type { Familiar, SessionRow } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
-// Relative timestamp
+// Relative timestamp helpers
 // ---------------------------------------------------------------------------
 
 const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto", style: "narrow" });
@@ -30,19 +27,19 @@ function relTime(iso: string | undefined): string {
   if (!iso) return "";
   try {
     const diffSec = (Date.now() - new Date(iso).getTime()) / 1000;
-    if (diffSec < 60)  return rtf.format(-Math.round(diffSec),       "second");
-    if (diffSec < 3600) return rtf.format(-Math.round(diffSec / 60),  "minute");
+    if (diffSec < 60)    return rtf.format(-Math.round(diffSec),        "second");
+    if (diffSec < 3600)  return rtf.format(-Math.round(diffSec / 60),   "minute");
     if (diffSec < 86400) return rtf.format(-Math.round(diffSec / 3600), "hour");
     return rtf.format(-Math.round(diffSec / 86400), "day");
   } catch { return ""; }
 }
 
-// Short label: "1mo", "5h", "13m"
+// Short label: "5h", "13m", "2d"
 function shortRelTime(iso: string | undefined): string {
   if (!iso) return "";
   try {
     const diffSec = (Date.now() - new Date(iso).getTime()) / 1000;
-    if (diffSec < 60)   return `${Math.round(diffSec)}s`;
+    if (diffSec < 60)    return `${Math.round(diffSec)}s`;
     if (diffSec < 3600)  return `${Math.round(diffSec / 60)}m`;
     if (diffSec < 86400) return `${Math.round(diffSec / 3600)}h`;
     const days = Math.round(diffSec / 86400);
@@ -51,11 +48,7 @@ function shortRelTime(iso: string | undefined): string {
   } catch { return ""; }
 }
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export type FolderMode = "board" | "inbox" | "vals-inbox" | "browser" | "comux" | "schedules" | "calls";
+export type FolderMode = "board" | "inbox" | "vals-inbox" | "browser" | "comux" | "calls";
 
 export type SidebarMinimalProps = {
   mode: string;
@@ -73,7 +66,7 @@ export type SidebarMinimalProps = {
 };
 
 // ---------------------------------------------------------------------------
-// Action button (top 4)
+// Action button (top group)
 // ---------------------------------------------------------------------------
 
 function ActionRow({
@@ -88,11 +81,7 @@ function ActionRow({
   onClick: () => void;
 }) {
   return (
-    <button
-      type="button"
-      className="sidebar-action-row"
-      onClick={onClick}
-    >
+    <button type="button" className="sidebar-action-row" onClick={onClick}>
       <span className="sidebar-action-icon">{icon}</span>
       <span className="sidebar-action-label">{label}</span>
       {kbd && <span className="sidebar-action-kbd">{kbd}</span>}
@@ -114,9 +103,9 @@ const FOLDER_MODES: Array<{
   { id: "inbox",      label: "Inbox",       iconName: "ph:tray",
     badge: (p) => p.inboxBadgeCount && p.inboxBadgeCount > 0 ? String(p.inboxBadgeCount) : undefined },
   { id: "vals-inbox", label: "Val's Inbox", iconName: "ph:bell-fill" },
-  { id: "schedules",  label: "Schedules",   iconName: "ph:clock" },
+  { id: "calls",      label: "Coven Calls", iconName: "ph:graph" },
   { id: "browser",    label: "Browser",     iconName: "ph:globe" },
-  { id: "comux",      label: "Coven Code",   iconName: "ph:squares-four" },
+  { id: "comux",      label: "Coven Code",  iconName: "ph:squares-four" },
 ];
 
 function FolderRow({
@@ -148,10 +137,10 @@ function FolderRow({
 }
 
 // ---------------------------------------------------------------------------
-// Recent chat row
+// Session row (inside familiar section)
 // ---------------------------------------------------------------------------
 
-function RecentRow({
+function SessionRow({
   session,
   active,
   onClick,
@@ -162,57 +151,94 @@ function RecentRow({
 }) {
   const ts = shortRelTime(session.updated_at || session.created_at);
   const title = session.title || "Untitled";
-
   return (
     <button
       type="button"
       title={title}
-      className={`sidebar-recent-row${active ? " sidebar-recent-row--active" : ""}`}
+      className={`sidebar-session-row${active ? " sidebar-session-row--active" : ""}`}
       onClick={onClick}
     >
-      <span className="sidebar-recent-title">{title}</span>
-      {ts && <span className="sidebar-recent-ts">{ts}</span>}
+      <span className="sidebar-session-title">{title}</span>
+      {ts && <span className="sidebar-session-ts">{ts}</span>}
     </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Familiar section: header + collapsible session list
+// ---------------------------------------------------------------------------
+
+function FamiliarSection({
+  familiar,
+  sessions,
+  activeSessionId,
+  onOpenSession,
+  onModeChange,
+  defaultOpen,
+}: {
+  familiar: Familiar;
+  sessions: SessionRow[];
+  activeSessionId?: string | null;
+  onOpenSession: (id: string) => void;
+  onModeChange: (mode: string) => void;
+  defaultOpen: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const overrides = useGlyphOverrides();
+  const glyph = resolveFamiliarGlyph(familiar, overrides);
+
+  return (
+    <div className="sidebar-familiar-section">
+      {/* Section header — click to toggle */}
+      <button
+        type="button"
+        className="sidebar-familiar-header"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        <span className="sidebar-familiar-header-glyph">
+          <FamiliarGlyph glyph={glyph} size="sm" />
+        </span>
+        <span className="sidebar-familiar-header-name">{familiar.display_name}</span>
+        <span className="sidebar-familiar-header-meta">
+          {sessions.length > 0 && (
+            <span className="sidebar-familiar-header-count">{sessions.length}</span>
+          )}
+          <Icon
+            name={open ? "ph:caret-down" : "ph:caret-right"}
+            width={10}
+            className="sidebar-familiar-header-chevron"
+          />
+        </span>
+      </button>
+
+      {/* Session list */}
+      {open && (
+        <div className="sidebar-familiar-sessions">
+          {sessions.length === 0 ? (
+            <div className="sidebar-familiar-sessions-empty">No sessions</div>
+          ) : (
+            sessions.map((s) => (
+              <SessionRow
+                key={s.id}
+                session={s}
+                active={s.id === activeSessionId}
+                onClick={() => {
+                  onModeChange("chats");
+                  onOpenSession(s.id);
+                }}
+              />
+            ))
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 
 // ---------------------------------------------------------------------------
 // SidebarMinimal
 // ---------------------------------------------------------------------------
-
-function NavFamiliarStrip({
-  familiars,
-  activeId,
-  onSelect,
-}: {
-  familiars: Familiar[];
-  activeId: string | null;
-  onSelect: (id: string) => void;
-}) {
-  const overrides = useGlyphOverrides();
-  if (familiars.length === 0) return null;
-  return (
-    <div className="sidebar-familiar-strip">
-      {familiars.map((f) => {
-        const glyph = resolveFamiliarGlyph(f, overrides);
-        const isActive = f.id === activeId;
-        return (
-          <button
-            key={f.id}
-            type="button"
-            title={`${f.display_name}${f.role ? ` · ${f.role}` : ""}`}
-            aria-label={f.display_name}
-            aria-pressed={isActive}
-            onClick={() => onSelect(f.id)}
-            className={`sidebar-familiar-btn${isActive ? " sidebar-familiar-btn--active" : ""}`}
-          >
-            <FamiliarGlyph glyph={glyph} size="sm" />
-          </button>
-        );
-      })}
-    </div>
-  );
-}
 
 export function SidebarMinimal(props: SidebarMinimalProps) {
   const {
@@ -229,8 +255,8 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
     onOpenSettings,
   } = props;
 
-  // Only show chat-origin sessions in recents; limit to 40
-  const recents = useMemo(
+  // Chat sessions newest-first
+  const chatSessions = useMemo(
     () =>
       sessions
         .filter((s) => !s.archived_at && (!s.origin || s.origin === "chat"))
@@ -238,14 +264,40 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
           const ta = a.updated_at || a.created_at;
           const tb = b.updated_at || b.created_at;
           return tb.localeCompare(ta);
-        })
-        .slice(0, 40),
+        }),
     [sessions],
   );
 
+  // Map: familiarId → sorted sessions for that familiar (max 20 shown)
+  const sessionsByFamiliar = useMemo(() => {
+    const map: Record<string, SessionRow[]> = {};
+    for (const f of familiars) map[f.id] = [];
+    for (const s of chatSessions) {
+      if (s.familiarId && map[s.familiarId]) {
+        map[s.familiarId].push(s);
+      }
+    }
+    // Each familiar's list is already sorted (chatSessions is sorted)
+    for (const id of Object.keys(map)) map[id] = map[id].slice(0, 20);
+    return map;
+  }, [chatSessions, familiars]);
+
+  // Sessions with no familiar → "Unassigned" bucket
+  const unassignedSessions = useMemo(
+    () => chatSessions.filter((s) => !s.familiarId).slice(0, 20),
+    [chatSessions],
+  );
+
+  // Which familiar section should start open (the one owning the active session)
+  const defaultOpenId = useMemo(() => {
+    if (!activeSessionId) return null;
+    const active = chatSessions.find((s) => s.id === activeSessionId);
+    return active?.familiarId ?? null;
+  }, [chatSessions, activeSessionId]);
+
   return (
     <nav className="sidebar-minimal">
-      {/* ── 4 primary actions ─────────────────────────────────── */}
+      {/* ── Primary actions ───────────────────────────────────── */}
       <div className="sidebar-actions">
         <ActionRow
           icon={<Icon name="ph:note-pencil" width={14} />}
@@ -264,9 +316,9 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
           onClick={() => onModeChange("plugins")}
         />
         <ActionRow
-          icon={<Icon name="ph:calendar-blank" width={14} />}
+          icon={<Icon name="ph:clock" width={14} />}
           label="Automations"
-          onClick={() => onModeChange("calls")}
+          onClick={() => onModeChange("schedules")}
         />
       </div>
 
@@ -285,38 +337,45 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
         ))}
       </div>
 
-      {/* ── Flat recents list ─────────────────────────────────── */}
-      <div className="sidebar-recents-header">Recent</div>
-      <div className="sidebar-recents">
-        {recents.length === 0 ? (
-          <div className="sidebar-recents-empty">No recent chats</div>
-        ) : (
-          recents.map((s) => (
-            <RecentRow
-              key={s.id}
-              session={s}
-              active={s.id === activeSessionId}
-              onClick={() => {
-                onModeChange("chats");
-                onOpenSession(s.id);
-              }}
-            />
-          ))
+      {/* ── Familiar sections ─────────────────────────────────── */}
+      <div className="sidebar-familiar-list">
+        {familiars.map((f) => (
+          <FamiliarSection
+            key={f.id}
+            familiar={f}
+            sessions={sessionsByFamiliar[f.id] ?? []}
+            activeSessionId={activeSessionId}
+            onOpenSession={onOpenSession}
+            onModeChange={onModeChange}
+            defaultOpen={f.id === defaultOpenId}
+          />
+        ))}
+
+        {/* Unassigned sessions */}
+        {unassignedSessions.length > 0 && (
+          <div className="sidebar-familiar-section sidebar-familiar-section--unassigned">
+            <div className="sidebar-familiar-header sidebar-familiar-header--plain">
+              <span className="sidebar-familiar-header-name">Other</span>
+              <span className="sidebar-familiar-header-count">{unassignedSessions.length}</span>
+            </div>
+            <div className="sidebar-familiar-sessions">
+              {unassignedSessions.map((s) => (
+                <SessionRow
+                  key={s.id}
+                  session={s}
+                  active={s.id === activeSessionId}
+                  onClick={() => {
+                    onModeChange("chats");
+                    onOpenSession(s.id);
+                  }}
+                />
+              ))}
+            </div>
+          </div>
         )}
       </div>
 
-      {/* ── Familiar switcher (above settings) ──────────────── */}
-      {familiars.length > 0 && onFamiliarSelect && (
-        <div className="sidebar-familiar-section">
-          <NavFamiliarStrip
-            familiars={familiars}
-            activeId={activeId}
-            onSelect={onFamiliarSelect}
-          />
-        </div>
-      )}
-
-      {/* ── Settings gear (bottom) ────────────────────────────── */}
+      {/* ── Settings gear (pinned bottom) ─────────────────────── */}
       <div className="sidebar-bottom">
         <button
           type="button"

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -273,41 +273,245 @@
   background: color-mix(in oklab, oklch(0.65 0.18 280) 12%, var(--bg-raised));
 }
 
-/* ── Sidebar familiar strip (left nav) ─────────────────────────────────── */
+/* ── Familiars section (left nav, replaces emoji strip) ─────────────────── */
 .sidebar-familiar-section {
   flex-shrink: 0;
   border-top: 1px solid var(--border-hairline);
-  padding: 6px 8px;
+  padding: 4px 6px 2px;
 }
 
-.sidebar-familiar-strip {
+.sidebar-familiar-section-label {
+  padding: 5px 8px 2px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  user-select: none;
+}
+
+.sidebar-familiar-row {
   display: flex;
   align-items: center;
-  gap: 4px;
-  flex-wrap: wrap;
+  width: 100%;
+  gap: 8px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s ease, color 0.1s ease;
 }
 
-.sidebar-familiar-btn {
+.sidebar-familiar-row:hover {
+  background: var(--bg-raised);
+  color: var(--text-primary);
+}
+
+.sidebar-familiar-row--active {
+  background: color-mix(in oklab, oklch(0.65 0.18 280) 10%, transparent);
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.sidebar-familiar-row-glyph {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
-  border-radius: 50%;
-  border: 1.5px solid transparent;
-  background: var(--bg-raised);
-  cursor: pointer;
+  opacity: 0.8;
+}
+
+.sidebar-familiar-row--active .sidebar-familiar-row-glyph,
+.sidebar-familiar-row:hover .sidebar-familiar-row-glyph {
+  opacity: 1;
+}
+
+.sidebar-familiar-row-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.sidebar-familiar-row-count {
   flex-shrink: 0;
-  transition: border-color 0.12s ease, background 0.12s ease;
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+  opacity: 0.7;
+}
+
+.sidebar-familiar-row--active .sidebar-familiar-row-count {
+  color: oklch(0.75 0.12 280);
+  opacity: 1;
+}
+
+/* ── Familiar sections (accordion) ──────────────────────────────────────── */
+.sidebar-familiar-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0 0;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-hairline) transparent;
+}
+
+.sidebar-familiar-list::-webkit-scrollbar { width: 3px; }
+.sidebar-familiar-list::-webkit-scrollbar-thumb {
+  background: var(--border-hairline);
+  border-radius: 2px;
+}
+
+/* Each familiar block */
+.sidebar-familiar-section {
+  flex-shrink: 0;
+  /* override: remove the old border-top/padding from the old section rule */
+  border-top: none;
   padding: 0;
 }
 
-.sidebar-familiar-btn:hover {
-  border-color: var(--border-strong);
+.sidebar-familiar-section + .sidebar-familiar-section {
+  border-top: 1px solid var(--border-hairline);
 }
 
-.sidebar-familiar-btn--active {
-  border-color: oklch(0.65 0.18 280);
-  box-shadow: 0 0 0 1px oklch(0.65 0.18 280 / 35%);
-  background: color-mix(in oklab, oklch(0.65 0.18 280) 12%, var(--bg-raised));
+/* Header row: glyph + name + count + chevron */
+.sidebar-familiar-header {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: 8px;
+  padding: 5px 10px 5px 12px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s ease, color 0.1s ease;
+}
+
+.sidebar-familiar-header:hover {
+  background: var(--bg-raised);
+  color: var(--text-primary);
+}
+
+.sidebar-familiar-header--plain {
+  display: flex;
+  align-items: center;
+  padding: 5px 10px 5px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  user-select: none;
+}
+
+.sidebar-familiar-header-glyph {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.8;
+}
+
+.sidebar-familiar-header:hover .sidebar-familiar-header-glyph {
+  opacity: 1;
+}
+
+.sidebar-familiar-header-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.sidebar-familiar-header-meta {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.sidebar-familiar-header-count {
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+  opacity: 0.7;
+}
+
+.sidebar-familiar-header-chevron {
+  color: var(--text-muted);
+  opacity: 0.5;
+  transition: opacity 0.1s ease;
+}
+
+.sidebar-familiar-header:hover .sidebar-familiar-header-chevron {
+  opacity: 0.8;
+}
+
+/* Session list under a familiar */
+.sidebar-familiar-sessions {
+  padding: 1px 6px 6px 12px;
+}
+
+.sidebar-familiar-sessions-empty {
+  padding: 3px 8px 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* Individual session row inside familiar section */
+.sidebar-session-row {
+  display: flex;
+  align-items: baseline;
+  width: 100%;
+  gap: 6px;
+  padding: 3px 8px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s ease, color 0.1s ease;
+  min-width: 0;
+}
+
+.sidebar-session-row:hover {
+  background: var(--bg-raised);
+  color: var(--text-primary);
+}
+
+.sidebar-session-row--active {
+  background: color-mix(in oklab, oklch(0.65 0.18 280) 10%, transparent);
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.sidebar-session-title {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.sidebar-session-ts {
+  flex-shrink: 0;
+  font-size: 10px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
 }


### PR DESCRIPTION
## Summary

Removes the flat emoji-strip familiar filter from the bottom of the left sidebar. Replaces it with per-familiar **accordion sections** — each familiar is a collapsible header row (glyph + name + session count + chevron) that expands inline to show its recent sessions.

## Changes

### `sidebar-minimal.tsx`
- New `FamiliarSection` component: toggle open/closed via `useState`; defaults open for the section containing the active session
- New `SessionRow` component: compact title + relative timestamp, active state highlight
- Unassigned sessions bucket (`Other`) for sessions without a `familiarId`
- Familiar list scrolls independently (`flex: 1 / overflow-y: auto`)
- Folder rows, action rows, and settings row unchanged
- **Also fixes a parse error** from the prior edit: a duplicate `shortRelTime` fragment and an `export type` statement were accidentally placed inside a function body

### `sidebar-minimal.css`
- New rules: `.sidebar-familiar-list`, `.sidebar-familiar-header`, `.sidebar-familiar-sessions`, `.sidebar-session-row`
- Old flat `.sidebar-familiar-row` and `.sidebar-familiar-section-label` rules kept for backward compat (used elsewhere)

## Before / After

**Before:** Emoji avatars in a scrollable strip at the bottom — easy to miss, no session context visible  
**After:** Each familiar = a named accordion section; sessions visible at a glance; chevron indicates open/closed state