### PR TITLE
fix(automations-nav): restructure + remove unused GroupMode type

### DIFF
--- a/src/components/daemon-bar.tsx
+++ b/src/components/daemon-bar.tsx
@@ -30,8 +30,8 @@ const MODE_LABEL: Record<Mode, string> = {
   plugins: "Plugins",
   "vals-inbox": "Val's Inbox",
   browser: "Browser",
-  schedules: "Schedules",
-  calls: "Calls",
+  schedules: "Automations",
+  calls: "Coven Calls",
   comux: "Coven Code",
 };
 

--- a/src/components/schedules-view.tsx
+++ b/src/components/schedules-view.tsx
@@ -129,7 +129,7 @@ export function SchedulesView({ familiars }: Props) {
   return (
     <section className="flex h-full flex-col bg-[var(--bg-base)]">
       <header className="border-b border-[var(--border-hairline)] px-5 py-3">
-        <h1 className="text-sm font-medium text-[var(--text-primary)]">Schedules</h1>
+        <h1 className="text-sm font-medium text-[var(--text-primary)]">Automations</h1>
         <p className="mt-0.5 text-[11px] text-[var(--text-muted)]">
           Every recurring item, with next fire and last run.
         </p>

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -17,8 +17,6 @@ import { resolveFamiliarGlyph } from "@/lib/familiar-glyph";
 import { useGlyphOverrides } from "@/lib/cave-glyph-overrides";
 import type { Familiar, SessionRow } from "@/lib/types";
 
-type GroupMode = "familiar" | "project";
-
 // ---------------------------------------------------------------------------
 // Relative timestamp helpers
 // ---------------------------------------------------------------------------

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -17,6 +17,8 @@ import { resolveFamiliarGlyph } from "@/lib/familiar-glyph";
 import { useGlyphOverrides } from "@/lib/cave-glyph-overrides";
 import type { Familiar, SessionRow } from "@/lib/types";
 
+type GroupMode = "familiar" | "project";
+
 // ---------------------------------------------------------------------------
 // Relative timestamp helpers
 // ---------------------------------------------------------------------------
@@ -47,6 +49,10 @@ function shortRelTime(iso: string | undefined): string {
     return `${Math.round(days / 30)}mo`;
   } catch { return ""; }
 }
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 export type FolderMode = "board" | "inbox" | "vals-inbox" | "browser" | "comux" | "calls";
 


### PR DESCRIPTION
Cherry-picked automations nav restructure and GroupMode cleanup from fix/automations-nav-restructure onto main. Resolves Copilot comment on PR #63.