### PR TITLE
fix(sidebar): address Copilot review comments from PR #64

### DIFF
--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -144,7 +144,7 @@ function FolderRow({
 // Session row (inside familiar section)
 // ---------------------------------------------------------------------------
 
-function SessionRow({
+function SessionItem({
   session,
   active,
   onClick,
@@ -158,7 +158,7 @@ function SessionRow({
   return (
     <button
       type="button"
-      title={title}
+      title={relTime(session.updated_at || session.created_at) || title}
       className={`sidebar-session-row${active ? " sidebar-session-row--active" : ""}`}
       onClick={onClick}
     >
@@ -223,7 +223,7 @@ function FamiliarSection({
             <div className="sidebar-familiar-sessions-empty">No sessions</div>
           ) : (
             sessions.map((s) => (
-              <SessionRow
+              <SessionItem
                 key={s.id}
                 session={s}
                 active={s.id === activeSessionId}
@@ -287,9 +287,10 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
   }, [chatSessions, familiars]);
 
   // Sessions with no familiar → "Unassigned" bucket
+  // Exclude sessions already shown under a familiar to avoid double-counting
   const unassignedSessions = useMemo(
-    () => chatSessions.filter((s) => !s.familiarId).slice(0, 20),
-    [chatSessions],
+    () => chatSessions.filter((s) => !s.familiarId || !sessionsByFamiliar[s.familiarId]).slice(0, 20),
+    [chatSessions, sessionsByFamiliar],
   );
 
   // Which familiar section should start open (the one owning the active session)
@@ -364,7 +365,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
             </div>
             <div className="sidebar-familiar-sessions">
               {unassignedSessions.map((s) => (
-                <SessionRow
+                <SessionItem
                   key={s.id}
                   session={s}
                   active={s.id === activeSessionId}

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -274,11 +274,7 @@
 }
 
 /* ── Familiars section (left nav, replaces emoji strip) ─────────────────── */
-.sidebar-familiar-section {
-  flex-shrink: 0;
-  border-top: 1px solid var(--border-hairline);
-  padding: 4px 6px 2px;
-}
+/* duplicate .sidebar-familiar-section rule removed; see line 372 for canonical rule */
 
 .sidebar-familiar-section-label {
   padding: 5px 8px 2px;


### PR DESCRIPTION
Addresses all Copilot comments that were on PR #64 (fix/sidebar-familiar-list) which was merged without these fixes:

1. Rename `SessionRow` UI component → `SessionItem` to avoid collision with imported `SessionRow` type (lines 147, 226, 367)
2. Wire `relTime()` into session button `title` tooltip so it shows relative time
3. Fix `unassignedSessions` to exclude sessions already assigned to a familiar (avoid double-counting when familiarId points to an unknown familiar)
4. Remove duplicate `.sidebar-familiar-section` CSS rule — keep the more complete one at line 372