### PR TITLE
chore(ui): sweep emoji from Cave chrome — icons/text only

### DIFF
--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -202,8 +202,8 @@ export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat 
         {!hasAny ? (
           /* Empty state */
           <div className="flex h-full flex-col items-center justify-center gap-4 px-8 text-center">
-            <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-raised)]/60 text-2xl">
-              ✦
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-raised)]/60 text-[var(--text-muted)]">
+              <Icon name="ph:sparkle" width={20} aria-hidden />
             </div>
             <div>
               <p className="text-sm font-medium text-[var(--text-secondary)]">No chats yet</p>

--- a/src/components/familiar-rail.tsx
+++ b/src/components/familiar-rail.tsx
@@ -6,6 +6,7 @@ import { computePresence, REMOTE_HARNESSES } from "@/lib/presence";
 import { resolveFamiliarGlyph } from "@/lib/familiar-glyph";
 import { useGlyphOverrides } from "@/lib/cave-glyph-overrides";
 import { FamiliarGlyph } from "@/components/familiar-glyph";
+import { Icon } from "@/lib/icon";
 
 type HarnessReport = {
   id: string;
@@ -170,7 +171,9 @@ export function FamiliarRail({
                     glyph={resolveFamiliarGlyph(f, glyphOverrides)}
                     size="sm"
                   />
-                  <span className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-md text-[10px] opacity-0 transition-opacity group-hover/glyph:opacity-100" aria-hidden>✏</span>
+                  <span className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-md opacity-0 transition-opacity group-hover/glyph:opacity-100" aria-hidden>
+                    <Icon name="ph:pencil-simple" width={11} />
+                  </span>
                 </span>
                 <span className="flex flex-1 flex-col min-w-0">
                   <span className="flex items-center gap-1.5 truncate">

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -29,6 +29,7 @@ import type { InboxItem } from "@/lib/cave-inbox";
 import { FamiliarGlyph } from "@/components/familiar-glyph";
 import { resolveFamiliarGlyph } from "@/lib/familiar-glyph";
 import { useGlyphOverrides } from "@/lib/cave-glyph-overrides";
+import { Icon, type IconName } from "@/lib/icon";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -36,12 +37,12 @@ import { useGlyphOverrides } from "@/lib/cave-glyph-overrides";
 
 export type Destination = "chat" | "board" | "reminder" | "inbox" | "call";
 
-const DESTINATIONS: { id: Destination; label: string; emoji: string }[] = [
-  { id: "chat",     label: "Chat",     emoji: "💬" },
-  { id: "board",    label: "Board",    emoji: "📋" },
-  { id: "reminder", label: "Reminder", emoji: "⏰" },
-  { id: "inbox",    label: "Inbox",    emoji: "📥" },
-  { id: "call",     label: "Call",     emoji: "📞" },
+const DESTINATIONS: { id: Destination; label: string; icon: IconName }[] = [
+  { id: "chat",     label: "Chat",     icon: "ph:chat-circle-dots" },
+  { id: "board",    label: "Board",    icon: "ph:kanban" },
+  { id: "reminder", label: "Reminder", icon: "ph:alarm-fill" },
+  { id: "inbox",    label: "Inbox",    icon: "ph:tray" },
+  { id: "call",     label: "Call",     icon: "ph:phone" },
 ];
 
 type Props = {
@@ -365,7 +366,7 @@ export function HomeComposer({
                   onClick={() => setDestination(d.id)}
                   title={d.label}
                 >
-                  <span>{d.emoji}</span>
+                  <Icon name={d.icon} width={13} aria-hidden />
                   <span>{d.label}</span>
                 </button>
               ))}

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -304,7 +304,7 @@ function wireCopyButtons(container: HTMLElement) {
     let timer: ReturnType<typeof setTimeout> | null = null;
     btn.addEventListener("click", () => {
       navigator.clipboard.writeText(code).catch(() => undefined);
-      btn.textContent = "✓";
+      btn.textContent = "Copied";
       btn.classList.add("cave-copy-btn--confirmed");
       if (timer) clearTimeout(timer);
       timer = setTimeout(() => {
@@ -389,7 +389,7 @@ function CopyBubble({ text }: { text: string }) {
       onClick={copy}
       className={`cave-copy-btn cave-copy-btn-bubble${copied ? " cave-copy-btn--confirmed" : ""}`}
     >
-      {copied ? "✓" : "Copy"}
+      {copied ? "Copied" : "Copy"}
     </button>
   );
 }

--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -729,8 +729,9 @@ function HarnessCapabilityCard({ manifest }: { manifest: HarnessCapabilityManife
         {manifest.warnings.length > 0 ? (
           <div className="px-4 py-3">
             {manifest.warnings.map((w, i) => (
-              <p key={i} className="text-[11px] text-muted-foreground">
-                ⚠ {w.message}
+              <p key={i} className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                <Icon name="ph:warning-fill" width={11} aria-hidden />
+                <span>{w.message}</span>
               </p>
             ))}
           </div>

--- a/src/lib/icon.tsx
+++ b/src/lib/icon.tsx
@@ -72,6 +72,12 @@ export const ICON_NAMES = [
   "ph:puzzle-piece-bold",
   "ph:sparkle-bold",
   "ph:bell-bold",
+  "ph:phone",
+  "ph:warning-fill",
+  "ph:check",
+  "ph:copy",
+  "ph:pencil-simple",
+  "ph:list-bullets",
 ] as const;
 
 export type IconName = (typeof ICON_NAMES)[number];


### PR DESCRIPTION
Per Val's standing policy: **zero emojis in Cave product UI**. Replace with Phosphor icons via the `<Icon>` allowlist or plain text labels.

## Swaps

| File | Before | After |
|---|---|---|
| `home-composer.tsx` | 💬 📋 ⏰ 📥 📞 (destination pills) | `ph:chat-circle-dots` / `ph:kanban` / `ph:alarm-fill` / `ph:tray` / `ph:phone` |
| `chat-list.tsx` | ✦ empty-state | `ph:sparkle` |
| `familiar-rail.tsx` | ✏ hover-edit overlay | `ph:pencil-simple` |
| `plugins-view.tsx` | ⚠ warning bullet | `ph:warning-fill` |
| `message-bubble.tsx` | ✓ copy confirmation | text "Copied" |

## Allowlist additions (`src/lib/icon.tsx`)

`ph:phone`, `ph:warning-fill`, `ph:check`, `ph:copy`, `ph:pencil-simple`, `ph:list-bullets`.

## What's intentionally **not** changed

- **Mac keyboard glyphs** (⌘ ⌥ ⌃ ⇧ ↵ ↑) — platform-correct kbd hints, not emojis
- **Source-code comments** mentioning emoji-as-data
- **`/aesthetic` and `/mockup` pages** — design references
- **Familiar identity glyphs** (daemon-supplied avatars) — explicitly carved out by the policy as user/data controlled

## Verify

`tsc --noEmit`: ✅ clean