### PR TITLE
feat(coven-floor): Coven Floor — live familiar status board

### DIFF
--- a/src/app/api/coven-status/route.ts
+++ b/src/app/api/coven-status/route.ts
@@ -1,6 +1,5 @@
 // /api/coven-status — aggregates familiar activity from the OpenClaw session
-// index files at ~/.openclaw/agents/<id>/sessions/*.jsonl and the familiars
-// list from the coven daemon.
+// index files at ~/.openclaw/agents/<id>/sessions/*.jsonl.
 //
 // Returns a CovenStatusResponse: one FamiliarCard per familiar with derived
 // status, session summaries, and task label. Designed for the Coven Floor
@@ -10,7 +9,6 @@ import { NextResponse } from "next/server";
 import { readdir, stat } from "node:fs/promises";
 import path from "node:path";
 import { homedir } from "node:os";
-import { callDaemon } from "@/lib/coven-daemon";
 import {
   deriveStatus,
   type CovenStatusResponse,
@@ -19,16 +17,6 @@ import {
 } from "@/lib/coven-status-types";
 
 export const dynamic = "force-dynamic";
-
-// ── Familiar metadata from daemon ────────────────────────────────────────────
-
-type DaemonFamiliar = {
-  id: string;
-  display_name: string;
-  role: string;
-  emoji?: string;
-  icon?: string;
-};
 
 // ── Session file parsing ──────────────────────────────────────────────────────
 
@@ -242,25 +230,27 @@ async function scanAgentSessions(agentId: string, now: number): Promise<SessionS
 export async function GET() {
   const now = Date.now();
 
-  // Load familiars from daemon (non-fatal if daemon is down)
-  const daemonRes = await callDaemon<DaemonFamiliar[]>({
-    path: "/api/v1/familiars",
-    timeoutMs: 3000,
-  });
+  // Build familiar ids from local agent directories plus known defaults.
+  const agentsRoot = path.join(homedir(), ".openclaw", "agents");
+  let diskIds: string[] = [];
+  try {
+    const entries = await readdir(agentsRoot, { withFileTypes: true });
+    diskIds = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+  } catch {
+    // ignore
+  }
 
-  // Fall back to a known set of familiar ids if daemon is unreachable
   const knownIds = ["kitty", "cody", "sage", "charm", "astra", "echo", "nova"];
-  const daemonFamiliars: DaemonFamiliar[] = daemonRes.ok && daemonRes.data
-    ? daemonRes.data
-    : knownIds.map((id) => ({
-        id,
-        display_name: id.charAt(0).toUpperCase() + id.slice(1),
-        role: "familiar",
-      }));
+  const familiarIds = Array.from(new Set([...diskIds, ...knownIds]));
+  const familiarMeta = familiarIds.map((id) => ({
+    id,
+    display_name: id.charAt(0).toUpperCase() + id.slice(1),
+    role: "familiar",
+  }));
 
   // Scan sessions for each familiar in parallel
   const cards: FamiliarCard[] = await Promise.all(
-    daemonFamiliars.map(async (f): Promise<FamiliarCard> => {
+    familiarMeta.map(async (f): Promise<FamiliarCard> => {
       const sessions = await scanAgentSessions(f.id, now);
 
       const status = deriveStatus(sessions, now);
@@ -279,7 +269,7 @@ export async function GET() {
         id: f.id,
         displayName: f.display_name,
         role: f.role,
-        glyph: f.icon ?? f.emoji ?? f.display_name.charAt(0).toUpperCase(),
+        glyph: f.display_name.charAt(0).toUpperCase(),
         status,
         lastActiveAt,
         currentTask,

--- a/src/app/api/coven-status/route.ts
+++ b/src/app/api/coven-status/route.ts
@@ -1,0 +1,285 @@
+// /api/coven-status — aggregates familiar activity from the OpenClaw session
+// index files at ~/.openclaw/agents/<id>/sessions/*.jsonl and the familiars
+// list from the coven daemon.
+//
+// Returns a CovenStatusResponse: one FamiliarCard per familiar with derived
+// status, session summaries, and task label. Designed for the Coven Floor
+// status board.
+
+import { NextResponse } from "next/server";
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { homedir } from "node:os";
+import { callDaemon } from "@/lib/coven-daemon";
+import {
+  deriveStatus,
+  type CovenStatusResponse,
+  type FamiliarCard,
+  type SessionSummary,
+} from "@/lib/coven-status-types";
+
+export const dynamic = "force-dynamic";
+
+// ── Familiar metadata from daemon ────────────────────────────────────────────
+
+type DaemonFamiliar = {
+  id: string;
+  display_name: string;
+  role: string;
+  emoji?: string;
+  icon?: string;
+};
+
+// ── Session file parsing ──────────────────────────────────────────────────────
+
+/** First line of a .jsonl session file — the session header. */
+type SessionHeader = {
+  type: "session";
+  version: number;
+  id: string;
+  timestamp: string; // ISO
+  cwd?: string;
+};
+
+/** First matching trajectory event for session.started / session.ended. */
+type TrajectoryEvent = {
+  type: "session.started" | "session.ended" | "run.completed" | string;
+  ts: string;
+  sessionKey?: string;
+  /** Populated for run.completed */
+  status?: string;
+  data?: {
+    label?: string;
+    taskName?: string;
+    trigger?: string;
+    exitReason?: string;
+  };
+};
+
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+/** Read the first N bytes of a file and return lines. */
+async function headLines(filePath: string, maxBytes = 4096): Promise<string[]> {
+  try {
+    const handle = await import("node:fs").then((fs) =>
+      fs.promises.open(filePath, "r"),
+    );
+    const buf = Buffer.alloc(maxBytes);
+    const { bytesRead } = await handle.read(buf, 0, maxBytes, 0);
+    await handle.close();
+    return buf.subarray(0, bytesRead).toString("utf8").split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Scan an agent's sessions directory and return summarised sessions from the
+ * last 24 hours.
+ */
+async function scanAgentSessions(agentId: string, now: number): Promise<SessionSummary[]> {
+  const sessionsDir = path.join(homedir(), ".openclaw", "agents", agentId, "sessions");
+  let entries: string[];
+  try {
+    entries = await readdir(sessionsDir);
+  } catch {
+    return [];
+  }
+
+  // Only consider .jsonl files (not .trajectory.jsonl, not .json)
+  const sessionFiles = entries
+    .filter((e) => e.endsWith(".jsonl") && !e.includes(".trajectory."))
+    .map((e) => path.join(sessionsDir, e));
+
+  const summaries: SessionSummary[] = [];
+
+  for (const filePath of sessionFiles) {
+    try {
+      // Check mtime first — skip if clearly older than 24h
+      const s = await stat(filePath);
+      if (now - s.mtimeMs > TWENTY_FOUR_HOURS_MS * 2) continue;
+
+      const lines = await headLines(filePath, 2048);
+      if (lines.length === 0) continue;
+
+      let header: SessionHeader | null = null;
+      try {
+        const parsed = JSON.parse(lines[0]) as Partial<SessionHeader>;
+        if (parsed.type === "session" && parsed.id) {
+          header = parsed as SessionHeader;
+        }
+      } catch {
+        continue;
+      }
+      if (!header) continue;
+
+      const sessionStartMs = new Date(header.timestamp).getTime();
+      if (now - sessionStartMs > TWENTY_FOUR_HOURS_MS) continue;
+
+      // Try to read the trajectory file for richer status + label
+      const trajectoryPath = filePath.replace(".jsonl", ".trajectory.jsonl");
+      const trajLines = await headLines(trajectoryPath, 8192);
+
+      let status = "unknown";
+      let label = "";
+      let runtimeMs: number | undefined;
+      let isSubagent = false;
+      let parentId: string | undefined;
+      let sessionKey = "";
+      let model: string | undefined;
+      let channel: string | undefined;
+      let lastTs = header.timestamp;
+
+      for (const line of trajLines) {
+        try {
+          const ev = JSON.parse(line) as TrajectoryEvent;
+          if (ev.ts) lastTs = ev.ts;
+
+          if (ev.type === "session.started") {
+            status = "running";
+            if (ev.sessionKey) sessionKey = ev.sessionKey;
+            // Detect subagent from sessionKey pattern
+            if (sessionKey.includes(":subagent:")) {
+              isSubagent = true;
+              // parent is the non-subagent portion — we don't know the exact
+              // session id without scanning but that's OK for display
+            }
+          }
+          if (ev.type === "session.ended") {
+            status = "done";
+            if (ev.data?.label) label = ev.data.label;
+          }
+          if (ev.type === "run.completed") {
+            const exitReason = ev.data?.exitReason ?? "";
+            if (exitReason === "error" || exitReason === "exception") status = "failed";
+            else if (exitReason === "timeout") status = "timeout";
+            else status = "done";
+          }
+          if (ev.type === "trace.metadata") {
+            const d = ev.data as Record<string, unknown> | undefined;
+            if (d) {
+              const modelId = (d as Record<string, string>)?.modelId;
+              if (modelId) model = modelId;
+              // channel from sessionKey
+              if (ev.sessionKey) {
+                const parts = ev.sessionKey.split(":");
+                // agent:kitty:telegram:direct:xxx → channel = telegram
+                if (parts.length >= 3) channel = parts[2];
+              }
+            }
+          }
+        } catch {
+          // skip malformed lines
+        }
+      }
+
+      // Fallback label: extract from sessionKey
+      if (!label && sessionKey) {
+        // agent:kitty:cron:uuid → "cron"
+        // agent:kitty:telegram:direct:xxx → "telegram"
+        // agent:kitty:subagent:uuid → "subagent"
+        const parts = sessionKey.split(":");
+        if (parts.length >= 3) {
+          label = parts[2];
+          if (parts[2] === "cron" && parts.length >= 4) label = `cron`;
+          if (parts[2] === "subagent") {
+            isSubagent = true;
+            label = "subagent";
+          }
+        }
+      }
+
+      // Last seen from mtime
+      const mtimeISO = new Date(s.mtimeMs).toISOString();
+
+      summaries.push({
+        id: header.id,
+        label: label || header.id.slice(0, 8),
+        status,
+        updatedAt: mtimeISO,
+        runtimeMs,
+        isSubagent,
+        parentId,
+        model,
+        channel,
+      });
+    } catch {
+      // skip unreadable files
+    }
+  }
+
+  // Sort newest first
+  summaries.sort(
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+  );
+
+  return summaries;
+}
+
+// ── Route handler ─────────────────────────────────────────────────────────────
+
+export async function GET() {
+  const now = Date.now();
+
+  // Load familiars from daemon (non-fatal if daemon is down)
+  const daemonRes = await callDaemon<DaemonFamiliar[]>({
+    path: "/api/v1/familiars",
+    timeoutMs: 3000,
+  });
+
+  // Fall back to a known set of familiar ids if daemon is unreachable
+  const knownIds = ["kitty", "cody", "sage", "charm", "astra", "echo", "nova"];
+  const daemonFamiliars: DaemonFamiliar[] = daemonRes.ok && daemonRes.data
+    ? daemonRes.data
+    : knownIds.map((id) => ({
+        id,
+        display_name: id.charAt(0).toUpperCase() + id.slice(1),
+        role: "familiar",
+      }));
+
+  // Scan sessions for each familiar in parallel
+  const cards: FamiliarCard[] = await Promise.all(
+    daemonFamiliars.map(async (f): Promise<FamiliarCard> => {
+      const sessions = await scanAgentSessions(f.id, now);
+
+      const status = deriveStatus(sessions, now);
+      const runningCount = sessions.filter((s) => s.status === "running").length;
+      const stuckCount = sessions.filter(
+        (s) => s.status === "failed" || s.status === "timeout",
+      ).length;
+
+      // Current task: prefer running session label, then most recent
+      const running = sessions.find((s) => s.status === "running");
+      const currentTask = running?.label ?? sessions[0]?.label ?? null;
+
+      const lastActiveAt = sessions[0]?.updatedAt ?? null;
+
+      return {
+        id: f.id,
+        displayName: f.display_name,
+        role: f.role,
+        glyph: f.icon ?? f.emoji ?? f.display_name.charAt(0).toUpperCase(),
+        status,
+        lastActiveAt,
+        currentTask,
+        sessions,
+        runningCount,
+        stuckCount,
+      };
+    }),
+  );
+
+  // Sort: active first, then stuck, then idle, then quiet
+  const order: Record<string, number> = { active: 0, stuck: 1, idle: 2, quiet: 3 };
+  cards.sort((a, b) => (order[a.status] ?? 4) - (order[b.status] ?? 4));
+
+  const response: CovenStatusResponse = {
+    ok: true,
+    familiars: cards,
+    computedAt: new Date(now).toISOString(),
+  };
+
+  return NextResponse.json(response, {
+    headers: { "Cache-Control": "no-store" },
+  });
+}

--- a/src/app/api/coven-status/route.ts
+++ b/src/app/api/coven-status/route.ts
@@ -205,14 +205,19 @@ async function scanAgentSessions(agentId: string, now: number): Promise<SessionS
         }
       }
 
-      // Last seen from mtime
-      const mtimeISO = new Date(s.mtimeMs).toISOString();
+      // Prefer the latest event timestamp we observed in the trajectory, but
+      // never go older than the session file mtime.
+      const lastEventMs = Date.parse(lastTs);
+      const updatedAtMs = Number.isFinite(lastEventMs)
+        ? Math.max(lastEventMs, s.mtimeMs)
+        : s.mtimeMs;
+      const updatedAt = new Date(updatedAtMs).toISOString();
 
       summaries.push({
         id: header.id,
         label: label || header.id.slice(0, 8),
         status,
-        updatedAt: mtimeISO,
+        updatedAt,
         runtimeMs,
         isSubagent,
         parentId,

--- a/src/app/api/coven-status/route.ts
+++ b/src/app/api/coven-status/route.ts
@@ -155,9 +155,17 @@ async function scanAgentSessions(agentId: string, now: number): Promise<SessionS
           }
           if (ev.type === "session.ended") {
             status = "done";
-            if (ev.data?.label) label = ev.data.label;
+            const task = ev.data?.taskName?.trim();
+            const lbl = ev.data?.label?.trim();
+            if (task) label = task;
+            else if (lbl) label = lbl;
           }
           if (ev.type === "run.completed") {
+            const task = ev.data?.taskName?.trim();
+            const lbl = ev.data?.label?.trim();
+            if (task) label = task;
+            else if (lbl) label = lbl;
+
             const exitReason = ev.data?.exitReason ?? "";
             if (exitReason === "error" || exitReason === "exception") status = "failed";
             else if (exitReason === "timeout") status = "timeout";

--- a/src/app/api/coven-status/route.ts
+++ b/src/app/api/coven-status/route.ts
@@ -78,7 +78,15 @@ async function headLines(filePath: string, maxBytes = 4096): Promise<string[]> {
  * last 24 hours.
  */
 async function scanAgentSessions(agentId: string, now: number): Promise<SessionSummary[]> {
-  const sessionsDir = path.join(homedir(), ".openclaw", "agents", agentId, "sessions");
+  const agentsRoot = path.join(homedir(), ".openclaw", "agents");
+  const sessionsDir = path.join(agentsRoot, agentId, "sessions");
+
+  const resolved = path.resolve(sessionsDir);
+  const rootResolved = path.resolve(agentsRoot);
+  if (resolved !== rootResolved && !resolved.startsWith(rootResolved + path.sep)) {
+    return [];
+  }
+
   let entries: string[];
   try {
     entries = await readdir(sessionsDir);

--- a/src/app/api/coven-status/route.ts
+++ b/src/app/api/coven-status/route.ts
@@ -7,7 +7,7 @@
 // status board.
 
 import { NextResponse } from "next/server";
-import { readdir, readFile, stat } from "node:fs/promises";
+import { readdir, stat } from "node:fs/promises";
 import path from "node:path";
 import { homedir } from "node:os";
 import { callDaemon } from "@/lib/coven-daemon";

--- a/src/components/calls-view.tsx
+++ b/src/components/calls-view.tsx
@@ -37,10 +37,11 @@ export function CallsView({ familiars }: Props) {
   }, []);
 
   useEffect(() => {
+    if (tab !== "delegations") return;
     void load();
     const t = setInterval(load, 10000);
     return () => clearInterval(t);
-  }, [load]);
+  }, [load, tab]);
 
   const famById = useMemo(() => {
     const m = new Map<string, Familiar>();

--- a/src/components/calls-view.tsx
+++ b/src/components/calls-view.tsx
@@ -4,17 +4,20 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Familiar } from "@/lib/types";
 import { aggregateEdges, type CallEdge, type CovenCall } from "@/lib/coven-calls-types";
 import { DelegationCard } from "@/components/delegation-card";
+import { CovenFloor } from "@/components/coven-floor";
 
-// Coven Calls view (issue #21) — read-only delegation timeline + a
-// simple circular-layout graph showing who called whom across the
-// current call log. Daemon-side delegation events are forthcoming;
-// until then this lights up an empty state.
+// Coven Calls view — two tabs:
+//   1. "The Floor" — live familiar status board (Coven Floor)
+//   2. "Delegations" — delegation timeline + call graph (original view)
+
+type Tab = "floor" | "delegations";
 
 type Props = {
   familiars: Familiar[];
 };
 
 export function CallsView({ familiars }: Props) {
+  const [tab, setTab] = useState<Tab>("floor");
   const [calls, setCalls] = useState<CovenCall[]>([]);
   const [error, setError] = useState<string | null>(null);
 
@@ -49,26 +52,52 @@ export function CallsView({ familiars }: Props) {
 
   return (
     <section className="flex h-full flex-col bg-[var(--bg-base)]">
+      {/* Top-level header + tab bar */}
       <header className="border-b border-[var(--border-hairline)] px-5 py-3">
         <h1 className="text-sm font-medium text-[var(--text-primary)]">
           Coven Calls
         </h1>
-        <p className="mt-0.5 text-[11px] text-[var(--text-muted)]">
-          Delegation timeline + who-called-whom across familiars.
-        </p>
+        {/* Tab bar */}
+        <div className="mt-2 flex gap-1">
+          {([
+            ["floor", "The Floor"] as const,
+            ["delegations", "Delegations"] as const,
+          ] as [Tab, string][]).map(([id, label]) => (
+            <button
+              key={id}
+              type="button"
+              onClick={() => setTab(id)}
+              className={[
+                "rounded-lg px-3 py-1 text-[11px] font-medium transition-colors",
+                tab === id
+                  ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
+                  : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]",
+              ].join(" ")}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
       </header>
 
-      {error ? (
-        <div className="border-b border-amber-700/40 bg-amber-900/20 px-5 py-1.5 text-[11px] text-amber-200">
-          {error}
+      {/* Tab content */}
+      {tab === "floor" ? (
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <CovenFloor />
         </div>
-      ) : null}
+      ) : (
+        <>
+          {error ? (
+            <div className="border-b border-amber-700/40 bg-amber-900/20 px-5 py-1.5 text-[11px] text-amber-200">
+              {error}
+            </div>
+          ) : null}
 
-      <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-y-auto px-5 py-4 lg:grid-cols-[1fr_360px]">
-        <section className="min-w-0">
-          <h2 className="mb-2 text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">
-            Recent delegations
-          </h2>
+          <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-y-auto px-5 py-4 lg:grid-cols-[1fr_360px]">
+            <section className="min-w-0">
+              <h2 className="mb-2 text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">
+                Recent delegations
+              </h2>
           {calls.length === 0 ? (
             <div className="rounded-2xl border border-dashed border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 px-5 py-10 text-center text-sm text-[var(--text-secondary)]">
               No coven calls yet. The daemon will emit a delegation event
@@ -100,6 +129,8 @@ export function CallsView({ familiars }: Props) {
           />
         </aside>
       </div>
+        </>
+      )}
     </section>
   );
 }

--- a/src/components/coven-floor.tsx
+++ b/src/components/coven-floor.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { FamiliarCard, CovenStatusResponse } from "@/lib/coven-status-types";
+import { FamiliarStatusCard } from "@/components/familiar-status-card";
+
+// Coven Floor — live status board showing all familiars.
+// Each card shows derived status, current task, and session activity.
+// Cards can be expanded to see the session tree.
+//
+// Refreshes every 15 seconds. Sits inside the "calls" route as the
+// first tab alongside the Delegations timeline.
+
+export function CovenFloor() {
+  const [familiars, setFamiliars] = useState<FamiliarCard[]>([]);
+  const [computedAt, setComputedAt] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/coven-status", { cache: "no-store" });
+      const json = (await res.json()) as CovenStatusResponse | { ok: false; error: string };
+      if (!json.ok) {
+        setError((json as { ok: false; error: string }).error ?? "status load failed");
+        return;
+      }
+      const data = json as CovenStatusResponse;
+      setFamiliars(data.familiars);
+      setComputedAt(data.computedAt);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "fetch failed");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+    const t = setInterval(load, 15_000);
+    return () => clearInterval(t);
+  }, [load]);
+
+  const toggleExpand = (id: string) =>
+    setExpandedId((prev) => (prev === id ? null : id));
+
+  return (
+    <div className="flex h-full flex-col bg-[var(--bg-base)]">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-[var(--border-hairline)] px-5 py-3">
+        <div>
+          <h2 className="text-sm font-medium text-[var(--text-primary)]">
+            The Floor
+          </h2>
+          <p className="mt-0.5 text-[11px] text-[var(--text-muted)]">
+            What everyone&apos;s working on right now.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {computedAt && (
+            <span className="text-[10px] text-[var(--text-muted)]">
+              updated {new Date(computedAt).toLocaleTimeString()}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => void load()}
+            className="rounded-lg px-2 py-1 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] transition-colors"
+            aria-label="Refresh"
+          >
+            ↺
+          </button>
+        </div>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="border-b border-amber-700/40 bg-amber-900/20 px-5 py-1.5 text-[11px] text-amber-200">
+          {error}
+        </div>
+      )}
+
+      {/* Cards */}
+      <div className="flex-1 overflow-y-auto px-4 py-4">
+        {loading && familiars.length === 0 ? (
+          <div className="flex items-center justify-center py-16 text-sm text-[var(--text-muted)]">
+            Loading…
+          </div>
+        ) : familiars.length === 0 ? (
+          <div className="flex items-center justify-center rounded-2xl border border-dashed border-[var(--border-hairline)] py-16 text-sm text-[var(--text-secondary)]">
+            No familiar activity found.
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {familiars.map((card) => (
+              <FamiliarStatusCard
+                key={card.id}
+                card={card}
+                expanded={expandedId === card.id}
+                onToggle={() => toggleExpand(card.id)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/familiar-status-card.tsx
+++ b/src/components/familiar-status-card.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useMemo } from "react";
+import { FamiliarGlyph } from "@/components/familiar-glyph";
+import { parseGlyphString } from "@/lib/familiar-glyph";
 import type { FamiliarCard, SessionSummary } from "@/lib/coven-status-types";
 import { statusColor, statusLabel } from "@/lib/coven-status-types";
 
@@ -82,8 +84,10 @@ export function FamiliarStatusCard({ card, expanded, onToggle }: Props) {
     return [...running, ...rest].slice(0, 8);
   }, [card.sessions, expanded]);
 
-  const glyphIsPhosphor = card.glyph.startsWith("ph:");
-  const glyphChar = glyphIsPhosphor ? card.displayName.charAt(0).toUpperCase() : card.glyph;
+  const glyph = parseGlyphString(card.glyph) ?? {
+    kind: "emoji" as const,
+    char: card.displayName.charAt(0).toUpperCase(),
+  };
 
   const badgeText =
     card.runningCount > 0
@@ -119,7 +123,7 @@ export function FamiliarStatusCard({ card, expanded, onToggle }: Props) {
           }}
           aria-hidden
         >
-          {glyphChar}
+          <FamiliarGlyph glyph={glyph} size="md" className="inline-flex items-center justify-center" />
         </span>
 
         {/* Name + task */}

--- a/src/components/familiar-status-card.tsx
+++ b/src/components/familiar-status-card.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useMemo } from "react";
+import type { FamiliarCard, SessionSummary } from "@/lib/coven-status-types";
+import { statusColor, statusLabel } from "@/lib/coven-status-types";
+
+// ── Relative time ─────────────────────────────────────────────────────────────
+
+function relTime(iso: string | null): string {
+  if (!iso) return "never";
+  const diffMs = Date.now() - new Date(iso).getTime();
+  if (diffMs < 60_000) return "just now";
+  if (diffMs < 3_600_000) return `${Math.floor(diffMs / 60_000)}m ago`;
+  if (diffMs < 86_400_000) return `${Math.floor(diffMs / 3_600_000)}h ago`;
+  return `${Math.floor(diffMs / 86_400_000)}d ago`;
+}
+
+// ── Status dot ────────────────────────────────────────────────────────────────
+
+function StatusDot({ status }: { status: FamiliarCard["status"] }) {
+  const color = statusColor(status);
+  const pulse = status === "active";
+  return (
+    <span className="relative inline-flex items-center justify-center" style={{ width: 10, height: 10 }}>
+      {pulse && (
+        <span
+          className="absolute inline-flex h-full w-full animate-ping rounded-full opacity-60"
+          style={{ backgroundColor: color }}
+        />
+      )}
+      <span
+        className="relative inline-flex rounded-full"
+        style={{ width: 8, height: 8, backgroundColor: color }}
+      />
+    </span>
+  );
+}
+
+// ── Session row ───────────────────────────────────────────────────────────────
+
+function SessionItem({ session }: { session: SessionSummary }) {
+  const statusCls =
+    session.status === "running"
+      ? "text-emerald-400"
+      : session.status === "failed" || session.status === "timeout"
+        ? "text-amber-400"
+        : "text-[var(--text-muted)]";
+
+  return (
+    <li className="flex items-center gap-2 py-0.5 text-[11px]">
+      {session.isSubagent && (
+        <span className="text-[var(--text-muted)] opacity-50">↳</span>
+      )}
+      <span className={`shrink-0 font-mono ${statusCls}`}>{session.status}</span>
+      <span className="min-w-0 truncate text-[var(--text-secondary)]">
+        {session.label}
+      </span>
+      <span className="ml-auto shrink-0 text-[var(--text-muted)]">
+        {relTime(session.updatedAt)}
+      </span>
+    </li>
+  );
+}
+
+// ── FamiliarStatusCard ────────────────────────────────────────────────────────
+
+type Props = {
+  card: FamiliarCard;
+  expanded: boolean;
+  onToggle: () => void;
+};
+
+export function FamiliarStatusCard({ card, expanded, onToggle }: Props) {
+  const statusClr = statusColor(card.status);
+  const label = statusLabel(card.status);
+
+  // Show at most 8 sessions in expanded view, but always show running ones
+  const visibleSessions = useMemo(() => {
+    if (!expanded) return [];
+    const running = card.sessions.filter((s) => s.status === "running");
+    const rest = card.sessions.filter((s) => s.status !== "running");
+    return [...running, ...rest].slice(0, 8);
+  }, [card.sessions, expanded]);
+
+  const glyphIsPhosphor = card.glyph.startsWith("ph:");
+  const glyphChar = glyphIsPhosphor ? card.displayName.charAt(0).toUpperCase() : card.glyph;
+
+  const badgeText =
+    card.runningCount > 0
+      ? `${card.runningCount} running`
+      : card.stuckCount > 0
+        ? `${card.stuckCount} stuck`
+        : null;
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className={[
+        "group w-full rounded-2xl border text-left transition-all",
+        "bg-[var(--bg-raised)]/50 hover:bg-[var(--bg-raised)]",
+        "border-[var(--border-hairline)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-presence)]/50",
+        card.status === "stuck" ? "border-amber-700/40" : "",
+        card.status === "active" ? "border-emerald-700/30" : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      aria-expanded={expanded}
+    >
+      {/* Header row */}
+      <div className="flex items-center gap-3 px-4 py-3">
+        {/* Avatar */}
+        <span
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl text-base font-semibold"
+          style={{
+            background: `color-mix(in srgb, ${statusClr} 12%, var(--bg-raised))`,
+            color: statusClr,
+            border: `1px solid color-mix(in srgb, ${statusClr} 25%, transparent)`,
+          }}
+          aria-hidden
+        >
+          {glyphChar}
+        </span>
+
+        {/* Name + task */}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-[var(--text-primary)]">
+              {card.displayName}
+            </span>
+            {badgeText && (
+              <span
+                className="rounded-full px-1.5 py-0.5 text-[10px] font-medium"
+                style={{
+                  background: `color-mix(in srgb, ${statusClr} 15%, transparent)`,
+                  color: statusClr,
+                }}
+              >
+                {badgeText}
+              </span>
+            )}
+          </div>
+          {card.currentTask && (
+            <p className="mt-0.5 truncate text-[11px] text-[var(--text-secondary)]">
+              {card.currentTask}
+            </p>
+          )}
+        </div>
+
+        {/* Status + time */}
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          <div className="flex items-center gap-1.5">
+            <StatusDot status={card.status} />
+            <span className="text-[11px] text-[var(--text-secondary)]">{label}</span>
+          </div>
+          {card.lastActiveAt && (
+            <span className="text-[10px] text-[var(--text-muted)]">
+              {relTime(card.lastActiveAt)}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Expanded session list */}
+      {expanded && visibleSessions.length > 0 && (
+        <div
+          className="border-t border-[var(--border-hairline)] px-4 pb-3 pt-2"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <ul className="space-y-0.5">
+            {visibleSessions.map((s) => (
+              <SessionItem key={s.id} session={s} />
+            ))}
+          </ul>
+          {card.sessions.length > 8 && (
+            <p className="mt-1.5 text-[10px] text-[var(--text-muted)]">
+              +{card.sessions.length - 8} more sessions today
+            </p>
+          )}
+        </div>
+      )}
+    </button>
+  );
+}

--- a/src/lib/coven-status-types.ts
+++ b/src/lib/coven-status-types.ts
@@ -66,20 +66,22 @@ const SIX_HOURS_MS = 6 * 60 * 60 * 1000;
 const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
 
 export function deriveStatus(sessions: SessionSummary[], now: number): FamiliarStatus {
-  const recent24 = sessions.filter(
-    (s) => now - new Date(s.updatedAt).getTime() < TWENTY_FOUR_HOURS_MS,
-  );
+  const recent24 = sessions.filter((s) => {
+    const t = Date.parse(s.updatedAt);
+    return Number.isFinite(t) && now - t < TWENTY_FOUR_HOURS_MS;
+  });
 
-  const running = recent24.some((s) => s.status === "running");
-  if (running) return "active";
+  if (recent24.some((s) => s.status === "running")) return "active";
 
-  const recent6 = recent24.filter(
-    (s) => now - new Date(s.updatedAt).getTime() < SIX_HOURS_MS,
-  );
-  const stuck = recent6.some((s) => s.status === "failed" || s.status === "timeout");
-  if (stuck) return "stuck";
+  const recent6 = recent24.filter((s) => {
+    const t = Date.parse(s.updatedAt);
+    return now - t < SIX_HOURS_MS;
+  });
 
-  if (recent6.some((s) => s.status === "done" || s.status === "completed")) return "idle";
+  if (recent6.some((s) => s.status === "failed" || s.status === "timeout")) return "stuck";
+
+  // Any non-running, non-stuck activity within the last 6h counts as "idle".
+  if (recent6.length > 0) return "idle";
 
   return "quiet";
 }

--- a/src/lib/coven-status-types.ts
+++ b/src/lib/coven-status-types.ts
@@ -1,0 +1,103 @@
+// Pure types for Coven Floor — the familiar status board.
+// Split from server code so client components can import without pulling
+// in node:fs. Same pattern as coven-calls-types.ts.
+
+/**
+ * Derived familiar-level status. Roll-up rules:
+ *   active  — any session with status "running" in the last 24 h
+ *   stuck   — any session with status "failed" or "timeout" in the last
+ *             6 h, and no "running" session supersedes it
+ *   idle    — all sessions done/completed, most recent activity < 6 h ago
+ *   quiet   — no session activity in the last 6 h
+ */
+export type FamiliarStatus = "active" | "stuck" | "idle" | "quiet";
+
+export type SessionSummary = {
+  id: string;
+  /** Human label or title. Prefer taskName > label > title. */
+  label: string;
+  /** Raw daemon/openclaw status string. */
+  status: string;
+  /** ISO timestamp of last update. */
+  updatedAt: string;
+  /** Runtime in ms, if known. */
+  runtimeMs?: number;
+  /** True if this is a spawned subagent. */
+  isSubagent: boolean;
+  /** Parent session id for subagents. */
+  parentId?: string;
+  /** Model used. */
+  model?: string;
+  /** Channel the session is on. */
+  channel?: string;
+};
+
+export type FamiliarCard = {
+  id: string;
+  displayName: string;
+  role: string;
+  /** Emoji or Phosphor icon name, e.g. "🐾" or "ph:cat-fill". */
+  glyph: string;
+  /** Derived roll-up status. */
+  status: FamiliarStatus;
+  /** ISO timestamp of most recent session activity. */
+  lastActiveAt: string | null;
+  /** Label/task of the most recent or currently-running session. */
+  currentTask: string | null;
+  /** All recent sessions (last 24 h), newest first. */
+  sessions: SessionSummary[];
+  /** Count of currently running sessions (including subagents). */
+  runningCount: number;
+  /** Count of sessions in failed/timeout state in the last 6 h. */
+  stuckCount: number;
+};
+
+/** What the /api/coven-status endpoint returns. */
+export type CovenStatusResponse = {
+  ok: true;
+  familiars: FamiliarCard[];
+  /** ISO timestamp of when this snapshot was computed. */
+  computedAt: string;
+};
+
+// ── Status rollup helper ──────────────────────────────────────────────────────
+
+const SIX_HOURS_MS = 6 * 60 * 60 * 1000;
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+export function deriveStatus(sessions: SessionSummary[], now: number): FamiliarStatus {
+  const recent24 = sessions.filter(
+    (s) => now - new Date(s.updatedAt).getTime() < TWENTY_FOUR_HOURS_MS,
+  );
+
+  const running = recent24.some((s) => s.status === "running");
+  if (running) return "active";
+
+  const recent6 = recent24.filter(
+    (s) => now - new Date(s.updatedAt).getTime() < SIX_HOURS_MS,
+  );
+  const stuck = recent6.some((s) => s.status === "failed" || s.status === "timeout");
+  if (stuck) return "stuck";
+
+  if (recent6.some((s) => s.status === "done" || s.status === "completed")) return "idle";
+
+  return "quiet";
+}
+
+export function statusLabel(s: FamiliarStatus): string {
+  switch (s) {
+    case "active": return "active";
+    case "stuck":  return "needs attention";
+    case "idle":   return "idle";
+    case "quiet":  return "quiet";
+  }
+}
+
+export function statusColor(s: FamiliarStatus): string {
+  switch (s) {
+    case "active": return "var(--accent-green, #4ade80)";
+    case "stuck":  return "var(--accent-amber, #fbbf24)";
+    case "idle":   return "var(--text-secondary)";
+    case "quiet":  return "var(--border-hairline)";
+  }
+}


### PR DESCRIPTION
## Coven Floor

Adds **The Floor** as the primary tab inside Coven Calls — a live mission-control board showing what every familiar is doing right now.

### What it does

Each familiar gets a card showing:
- **Avatar** tinted by live status
- **Name** + current task label
- **Status badge** — active (pulsing green dot) / needs attention (amber) / idle / quiet
- **Running/stuck counts** when relevant
- **Last active** relative time
- **Expandable session list** — click any card to drill into today's session tree, with subagent hierarchy, status colors, and per-session timestamps

Auto-refreshes every 15 seconds. Manual refresh button. Falls back gracefully if the coven daemon is unreachable.

### Architecture (Nova's design, implemented here)

- **Familiar-centric** not session-centric — one card per familiar, sessions are evidence of what they're doing
- **Derived status** — `active / stuck / idle / quiet` rolled up from raw session statuses (defined in `coven-status-types.ts` for reuse)
- **Data source** — reads `~/.openclaw/agents/<id>/sessions/*.jsonl` + trajectory files directly; no new daemon socket calls
- **Status rollup rules** live in pure functions, not the component (Echo's Failure Radar can use the same dictionary)

### Files

| File | Role |
|------|------|
| `src/lib/coven-status-types.ts` | Pure types + `deriveStatus()` rollup logic |
| `src/app/api/coven-status/route.ts` | Server route — scans session files, aggregates per familiar |
| `src/components/familiar-status-card.tsx` | Card component with expandable session list |
| `src/components/coven-floor.tsx` | Board view with 15s polling |
| `src/components/calls-view.tsx` | Updated to tab between The Floor and Delegations |

### What's next (separate PRs)

- Wire `familiarId` into card click → open that familiar's chat/session
- Echo's Failure Radar reusing `deriveStatus()` from `coven-status-types`
- The Delegations tab gets data once the daemon emits delegation events