### PR TITLE
chore: bump version to 0.0.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.22",
+  "version": "0.0.27",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.22",
+  "version": "0.0.27",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Rolls up tonight's wins for the new DMG cut:

- **#64** sidebar familiar accordion (replaced emoji strip with collapsible per-familiar sections)
- **#60** board UX (template buttons removed from empty state and modal)
- **#65** automations nav restructure
- **#66** sidebar polish (SessionItem rename, relTime tooltip, unassigned dedup, duplicate CSS rule removed)
- **#68** pnpm dev:app Tauri dev mode
- **#69** emoji sweep — zero emojis in Cave product chrome (icons + text only)