### PR TITLE
fix: stabilize terminal workspace and browser navigation

### DIFF
--- a/src-tauri/src/browser.rs
+++ b/src-tauri/src/browser.rs
@@ -67,7 +67,9 @@ fn ensure_browser(
     let parsed_url = Url::parse(url).map_err(|e| e.to_string())?;
     let browser_label = label.to_string();
     let app_for_load = app.clone();
-    let builder = WebviewBuilder::new(label, WebviewUrl::External(parsed_url)).on_page_load(
+    let builder = WebviewBuilder::new(label, WebviewUrl::External(parsed_url))
+        .background_color(tauri::webview::Color(12, 12, 14, 255)) // dark bg — no white flash
+        .on_page_load(
         move |webview, payload| {
             let phase = match payload.event() {
                 PageLoadEvent::Started => "started",

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { stat } from "node:fs/promises";
 import { homedir } from "node:os";
+import { join as joinPath } from "node:path";
 import { stripAnsi } from "@/lib/ansi";
 import { bindingFor, loadConfig, recordSessionFamiliar } from "@/lib/cave-config";
 import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
@@ -131,6 +132,20 @@ async function resolveCwd(requested?: string): Promise<string> {
   return homedir();
 }
 
+/** Resolve the familiar's OpenClaw workspace dir (~/.openclaw/workspace/<id>).
+ *  Falls back to undefined if the dir doesn't exist so callers can skip --cwd.
+ */
+async function resolveFamiliarWorkspace(familiarId: string): Promise<string | undefined> {
+  // Guard against path traversal: familiar IDs should be simple slugs.
+  if (!/^[a-z0-9_-]+$/i.test(familiarId)) return undefined;
+  const candidate = joinPath(homedir(), ".openclaw", "workspace", familiarId);
+  try {
+    const s = await stat(candidate);
+    if (s.isDirectory()) return candidate;
+  } catch { /* not found */ }
+  return undefined;
+}
+
 function sse(event: StreamEvent): Uint8Array {
   return new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`);
 }
@@ -155,6 +170,14 @@ export async function POST(req: Request) {
   const config = await loadConfig();
   const binding = bindingFor(config, body.familiarId);
   const cwd = await resolveCwd(body.projectRoot);
+  // Resolve familiar workspace for identity context. When a project root is
+  // explicitly set, the harness boots there (and should have the familiar's
+  // AGENTS.md injected separately). When there's no project root, boot in the
+  // familiar's own workspace so Codex/Claude picks up AGENTS.md / SOUL.md /
+  // IDENTITY.md and responds as the familiar instead of as "Codex".
+  const familiarWorkspace = !body.projectRoot
+    ? await resolveFamiliarWorkspace(body.familiarId)
+    : undefined;
 
   // coven run only knows codex|claude today. Other harnesses (openclaw,
   // copilot, opencode, gemini, hermes, …) are surfaced in /api/harnesses
@@ -178,6 +201,9 @@ export async function POST(req: Request) {
   const buildArgs = (resumeSessionId: string | null): string[] => {
     const a = ["run", binding.harness, "--stream-json"];
     if (resumeSessionId) a.push("--continue", resumeSessionId);
+    // Boot in the familiar's workspace so the harness reads AGENTS.md /
+    // SOUL.md / IDENTITY.md and responds as the familiar, not as "Codex".
+    if (familiarWorkspace) a.push("--cwd", familiarWorkspace);
     a.push("--", body.prompt);
     return a;
   };

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -161,6 +161,44 @@ body {
   overflow: hidden;
 }
 
+/* Right-rail toggle tab — Dia/Linear-style vertical pill */
+.shell-agent-tab {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  padding: 10px 5px;
+  border-radius: 8px 0 0 8px;
+  border: 1px solid var(--border-hairline);
+  border-right: none;
+  background: var(--bg-elevated);
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+  -webkit-app-region: no-drag;
+  user-select: none;
+}
+.shell-agent-tab:hover {
+  background: var(--bg-hover);
+  color: var(--fg-base);
+}
+.shell-agent-tab-label {
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  line-height: 1;
+}
+.shell-agent-tab-chevron {
+  opacity: 0.5;
+}
+
 .shell-bottom {
   display: flex;
   flex-direction: column;

--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { Icon } from "@/lib/icon";
 
 // Browser pane — uses Tauri's child WebviewBuilder under the hood. A real
@@ -10,6 +10,11 @@ import { Icon } from "@/lib/icon";
 // or layout changes.
 //
 // In `next dev` outside Tauri there's no webview — we render a fallback iframe.
+//
+// Tab design:
+// - Pinned tabs persisted in localStorage (user-customizable)
+// - Dynamic localhost tab auto-injected when a project dev server is detected
+// - Each tab uses a separate native webview label: `<paneLabel>-tab-<id>`
 
 type TauriBridge = {
   invoke: <T = unknown>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
@@ -26,29 +31,100 @@ async function loadTauri(): Promise<TauriBridge | null> {
 }
 
 const HOME_URL = "https://opencoven.ai";
+const LOCALHOST_PORTS = [3000, 3001, 5173, 8080, 4000, 4321];
+const PINNED_STORAGE_KEY = "cave.browser.pinnedTabs.v1";
+
+export type BrowserTab = {
+  id: string;
+  url: string;
+  title: string;
+  pinned: boolean;
+  /** "localhost" tabs are dynamic — auto-added/removed based on dev server detection */
+  kind: "pinned" | "localhost";
+};
 
 function normalizeUrl(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) return HOME_URL;
   if (/^https?:\/\//i.test(trimmed)) return trimmed;
-  // Bare domain (e.g. "google.com") → https://
+  if (/^localhost(:\d+)?(\/.*)?$/.test(trimmed)) return `http://${trimmed}`;
   if (/^[a-z0-9-]+\.[a-z]{2,}/i.test(trimmed)) return `https://${trimmed}`;
-  // Search query
   return `https://www.google.com/search?q=${encodeURIComponent(trimmed)}`;
+}
+
+function shortTitle(url: string, title: string): string {
+  if (title && title !== url) return title.slice(0, 22);
+  try {
+    const u = new URL(url);
+    if (u.hostname === "localhost") return `localhost:${u.port || "80"}`;
+    return u.hostname.replace(/^www\./, "").slice(0, 18);
+  } catch {
+    return url.slice(0, 18);
+  }
+}
+
+function loadPinnedTabs(): BrowserTab[] {
+  if (typeof window === "undefined") return defaultPinnedTabs();
+  try {
+    const raw = window.localStorage.getItem(PINNED_STORAGE_KEY);
+    if (raw) return JSON.parse(raw) as BrowserTab[];
+  } catch { /* ignore */ }
+  return defaultPinnedTabs();
+}
+
+function savePinnedTabs(tabs: BrowserTab[]) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(PINNED_STORAGE_KEY, JSON.stringify(tabs));
+  } catch { /* ignore */ }
+}
+
+function defaultPinnedTabs(): BrowserTab[] {
+  return [
+    { id: "home", url: HOME_URL, title: "OpenCoven", pinned: true, kind: "pinned" },
+    { id: "vercel", url: "https://vercel.com/dashboard", title: "Vercel", pinned: true, kind: "pinned" },
+    { id: "github", url: "https://github.com/OpenCoven", title: "GitHub", pinned: true, kind: "pinned" },
+  ];
+}
+
+async function probeLocalhost(port: number): Promise<boolean> {
+  try {
+    const res = await fetch(`http://localhost:${port}`, {
+      method: "HEAD",
+      signal: AbortSignal.timeout(800),
+      mode: "no-cors",
+    });
+    // no-cors always returns opaque — if it didn't throw, something is there
+    void res;
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function BrowserPane({ label = "default" }: { label?: string }) {
   const surfaceRef = useRef<HTMLDivElement | null>(null);
-  const [url, setUrl] = useState<string>(HOME_URL);
-  const [addressBar, setAddressBar] = useState<string>(HOME_URL);
   const [bridge, setBridge] = useState<TauriBridge | null>(null);
   const [unavailable, setUnavailable] = useState(false);
-  const [loading, setLoading] = useState(false);
-  // History stack for back/forward
-  const historyRef = useRef<string[]>([HOME_URL]);
-  const historyIdxRef = useRef<number>(0);
 
-  // One-time: pull in the Tauri bridge.
+  // Tab state
+  const [tabs, setTabs] = useState<BrowserTab[]>(() => loadPinnedTabs());
+  const [activeTabId, setActiveTabId] = useState<string>(() => loadPinnedTabs()[0]?.id ?? "home");
+  const [tabTitles, setTabTitles] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+  const [addressBar, setAddressBar] = useState<string>(HOME_URL);
+
+  // History per-tab
+  const historyRef = useRef<Record<string, { stack: string[]; idx: number }>>({});
+
+  const activeTab = tabs.find((t) => t.id === activeTabId) ?? tabs[0];
+  const activeUrl = activeTab?.url ?? HOME_URL;
+
+  function tabLabel(tabId: string) {
+    return `${label}-tab-${tabId}`;
+  }
+
+  // ── Tauri bridge ──────────────────────────────────────────────────
   useEffect(() => {
     let cancelled = false;
     void (async () => {
@@ -60,44 +136,55 @@ export function BrowserPane({ label = "default" }: { label?: string }) {
     return () => { cancelled = true; };
   }, []);
 
-  // Listen for page-load events from the native webview so the address bar
-  // stays in sync when the user clicks links inside the browser.
+  // ── Page-load + title events ──────────────────────────────────────
   useEffect(() => {
     if (!bridge) return;
     let unlistenLoad: (() => void) | null = null;
     let unlistenTitle: (() => void) | null = null;
+
     void bridge.listen<{ label: string; url: string; phase: string }>(
       "browser:page-load",
       (e) => {
         const { label: evLabel, url: evUrl, phase } = e.payload;
-        if (evLabel !== `cave-browser-${label}`) return;
+        // Match any of our tab labels
+        if (!evLabel.startsWith(`${label}-tab-`)) return;
+        const tabId = evLabel.slice(`${label}-tab-`.length);
         if (phase === "started") {
-          setLoading(true);
+          if (tabId === activeTabId) setLoading(true);
         } else {
-          setLoading(false);
-          // Update address bar + push to history
-          setAddressBar(evUrl);
-          setUrl(evUrl);
-          historyRef.current = [
-            ...historyRef.current.slice(0, historyIdxRef.current + 1),
-            evUrl,
-          ];
-          historyIdxRef.current = historyRef.current.length - 1;
+          if (tabId === activeTabId) {
+            setLoading(false);
+            setAddressBar(evUrl);
+          }
+          // Update tab URL
+          setTabs((prev) =>
+            prev.map((t) =>
+              t.id === tabId ? { ...t, url: evUrl } : t
+            )
+          );
+          // Push to per-tab history
+          const h = historyRef.current[tabId] ?? { stack: [evUrl], idx: 0 };
+          const next = [...h.stack.slice(0, h.idx + 1), evUrl];
+          historyRef.current[tabId] = { stack: next, idx: next.length - 1 };
         }
       },
     ).then((fn) => { unlistenLoad = fn; });
+
     void bridge.listen<{ label: string; title: string; url: string }>(
       "browser:title",
       (e) => {
-        const { label: evLabel, url: evUrl } = e.payload;
-        if (evLabel !== `cave-browser-${label}`) return;
-        setAddressBar(evUrl);
+        const { label: evLabel, title, url: evUrl } = e.payload;
+        if (!evLabel.startsWith(`${label}-tab-`)) return;
+        const tabId = evLabel.slice(`${label}-tab-`.length);
+        setTabTitles((prev) => ({ ...prev, [tabId]: title }));
+        if (tabId === activeTabId) setAddressBar(evUrl);
       },
     ).then((fn) => { unlistenTitle = fn; });
-    return () => { unlistenLoad?.(); unlistenTitle?.(); };
-  }, [bridge, label]);
 
-  // Keep the native webview's bounds in sync with the placeholder div.
+    return () => { unlistenLoad?.(); unlistenTitle?.(); };
+  }, [bridge, label, activeTabId]);
+
+  // ── Sync active tab webview bounds ────────────────────────────────
   useEffect(() => {
     if (!bridge) return;
     const surface = surfaceRef.current;
@@ -108,18 +195,24 @@ export function BrowserPane({ label = "default" }: { label?: string }) {
       cancelAnimationFrame(raf);
       raf = requestAnimationFrame(() => {
         const rect = surface.getBoundingClientRect();
-        // Panel collapsed (⌘J) — move webview offscreen instead of
-        // setting 0-size bounds which can cause a visible flash.
         if (rect.width <= 1 || rect.height <= 1) {
-          void bridge.invoke("browser_hide", { label });
+          // Hide all tab webviews when panel collapses
+          tabs.forEach((t) => {
+            void bridge.invoke("browser_hide", { label: tabLabel(t.id) });
+          });
           return;
         }
-        void bridge.invoke("browser_set_bounds", {
-          label,
-          x: rect.left,
-          y: rect.top,
-          w: rect.width,
-          h: rect.height,
+        // Show active tab, hide others
+        tabs.forEach((t) => {
+          if (t.id === activeTabId) {
+            void bridge.invoke("browser_set_bounds", {
+              label: tabLabel(t.id),
+              x: rect.left, y: rect.top,
+              w: rect.width, h: rect.height,
+            });
+          } else {
+            void bridge.invoke("browser_hide", { label: tabLabel(t.id) });
+          }
         });
       });
     };
@@ -135,112 +228,255 @@ export function BrowserPane({ label = "default" }: { label?: string }) {
       ro.disconnect();
       window.removeEventListener("resize", sync);
       window.removeEventListener("scroll", sync, true);
-      void bridge.invoke("browser_hide", { label });
+      // Hide all on unmount
+      tabs.forEach((t) => {
+        void bridge.invoke("browser_hide", { label: tabLabel(t.id) });
+      });
     };
-  }, [bridge, label]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bridge, label, activeTabId, tabs.map((t) => t.id).join(",")]);
 
-  // Navigate to `url` whenever it changes.
+  // ── Navigate active tab when URL changes ─────────────────────────
   useEffect(() => {
-    if (!bridge) return;
-    const surface = surfaceRef.current;
-    if (!surface) return;
-    const rect = surface.getBoundingClientRect();
-    setLoading(true);
-    void bridge.invoke("browser_navigate", {
-      label,
-      url,
-      x: rect.left,
-      y: rect.top,
-      w: rect.width,
-      h: rect.height,
-    });
-  }, [bridge, label, url]);
+    if (!bridge || !activeTab) return;
+    // Small delay to let panel layout fully settle before reading bounds
+    const timer = setTimeout(() => {
+      const surface = surfaceRef.current;
+      if (!surface) return;
+      const rect = surface.getBoundingClientRect();
+      if (rect.width <= 1 || rect.height <= 1) return;
+      setLoading(true);
+      void bridge.invoke("browser_navigate", {
+        label: tabLabel(activeTab.id),
+        url: activeTab.url,
+        x: rect.left, y: rect.top,
+        w: rect.width, h: rect.height,
+      });
+      setAddressBar(activeTab.url);
+    }, 80);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bridge, activeTab?.url, activeTab?.id]);
 
-  const navigateTo = (raw: string) => {
-    const next = normalizeUrl(raw);
-    historyRef.current = [
-      ...historyRef.current.slice(0, historyIdxRef.current + 1),
-      next,
-    ];
-    historyIdxRef.current = historyRef.current.length - 1;
-    setUrl(next);
-    setAddressBar(next);
+  // ── Localhost probe ───────────────────────────────────────────────
+  useEffect(() => {
+    let cancelled = false;
+    const probe = async () => {
+      for (const port of LOCALHOST_PORTS) {
+        if (cancelled) break;
+        const live = await probeLocalhost(port);
+        if (live && !cancelled) {
+          const locUrl = `http://localhost:${port}`;
+          setTabs((prev) => {
+            const existing = prev.find((t) => t.kind === "localhost");
+            if (existing?.url === locUrl) return prev;
+            const filtered = prev.filter((t) => t.kind !== "localhost");
+            return [
+              ...filtered,
+              {
+                id: `localhost-${port}`,
+                url: locUrl,
+                title: `localhost:${port}`,
+                pinned: false,
+                kind: "localhost",
+              },
+            ];
+          });
+          return;
+        }
+      }
+      if (!cancelled) {
+        // No localhost found — remove stale localhost tab
+        setTabs((prev) => prev.filter((t) => t.kind !== "localhost"));
+      }
+    };
+    void probe();
+    const interval = setInterval(() => void probe(), 8000);
+    return () => { cancelled = true; clearInterval(interval); };
+  }, []);
+
+  // ── Tab actions ───────────────────────────────────────────────────
+  const switchTab = useCallback((id: string) => {
+    setActiveTabId(id);
+    const tab = tabs.find((t) => t.id === id);
+    if (tab) {
+      setAddressBar(tab.url);
+      historyRef.current[id] ??= { stack: [tab.url], idx: 0 };
+    }
+    setLoading(false);
+  }, [tabs]);
+
+  const pinCurrentPage = () => {
+    const newId = `pin-${Date.now()}`;
+    const newTab: BrowserTab = {
+      id: newId,
+      url: activeUrl,
+      title: tabTitles[activeTabId] ?? "",
+      pinned: true,
+      kind: "pinned",
+    };
+    const next = [...tabs.filter((t) => t.kind === "pinned"), newTab, ...tabs.filter((t) => t.kind === "localhost")];
+    setTabs(next);
+    savePinnedTabs(next.filter((t) => t.kind === "pinned"));
   };
 
+  const removeTab = (id: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    const tab = tabs.find((t) => t.id === id);
+    if (!tab || tab.kind === "localhost") return; // localhost tabs aren't manually closeable
+    if (bridge) void bridge.invoke("browser_close", { label: tabLabel(id) });
+    const next = tabs.filter((t) => t.id !== id);
+    setTabs(next);
+    savePinnedTabs(next.filter((t) => t.kind === "pinned"));
+    if (activeTabId === id) setActiveTabId(next[0]?.id ?? "home");
+  };
+
+  // ── Per-tab navigation ────────────────────────────────────────────
+  const navigateTo = (raw: string) => {
+    const next = normalizeUrl(raw);
+    const nextTabs = tabs.map((t) =>
+      t.id === activeTabId ? { ...t, url: next } : t,
+    );
+    setTabs(nextTabs);
+    setAddressBar(next);
+
+    if (!bridge) {
+      const h = historyRef.current[activeTabId] ?? { stack: [activeUrl], idx: 0 };
+      if (h.stack[h.idx] !== next) {
+        const stack = [...h.stack.slice(0, h.idx + 1), next];
+        historyRef.current[activeTabId] = { stack, idx: stack.length - 1 };
+      }
+    }
+
+    const updatedActiveTab = nextTabs.find((t) => t.id === activeTabId);
+    if (updatedActiveTab?.kind === "pinned") {
+      savePinnedTabs(nextTabs.filter((t) => t.kind === "pinned"));
+    }
+  };
+
+  const h = historyRef.current[activeTabId] ?? { stack: [activeUrl], idx: 0 };
+  const canBack = h.idx > 0;
+  const canForward = h.idx < h.stack.length - 1;
+
   const goBack = () => {
-    if (historyIdxRef.current <= 0) return;
-    historyIdxRef.current -= 1;
-    const prev = historyRef.current[historyIdxRef.current];
-    setUrl(prev);
+    const hh = historyRef.current[activeTabId];
+    if (!hh || hh.idx <= 0) return;
+    hh.idx -= 1;
+    const prev = hh.stack[hh.idx];
+    setTabs((t) => t.map((tab) => tab.id === activeTabId ? { ...tab, url: prev } : tab));
     setAddressBar(prev);
   };
 
   const goForward = () => {
-    if (historyIdxRef.current >= historyRef.current.length - 1) return;
-    historyIdxRef.current += 1;
-    const next = historyRef.current[historyIdxRef.current];
-    setUrl(next);
+    const hh = historyRef.current[activeTabId];
+    if (!hh || hh.idx >= hh.stack.length - 1) return;
+    hh.idx += 1;
+    const next = hh.stack[hh.idx];
+    setTabs((t) => t.map((tab) => tab.id === activeTabId ? { ...tab, url: next } : tab));
     setAddressBar(next);
   };
 
-  const canBack = historyIdxRef.current > 0;
-  const canForward = historyIdxRef.current < historyRef.current.length - 1;
-
   return (
-    <div className="flex h-full flex-col bg-[--bg-base]">
+    <div className="flex h-full flex-row" style={{ background: "#0c0c0e" }}>
+      {/* ── Vertical tab rail ─────────────────────────────────────── */}
+      <div className="browser-tab-rail flex flex-col items-center border-r border-[--border-hairline] bg-[#080809] py-1.5" style={{ width: 48, minWidth: 48 }}>
+        {tabs.map((tab) => {
+          const isActive = tab.id === activeTabId;
+          const title = shortTitle(tab.url, tabTitles[tab.id] ?? tab.title);
+          const isLocalhost = tab.kind === "localhost";
+          return (
+            <div
+              key={tab.id}
+              role="button"
+              tabIndex={0}
+              onClick={() => switchTab(tab.id)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  switchTab(tab.id);
+                }
+              }}
+              title={tabTitles[tab.id] ?? tab.title ?? tab.url}
+              className={[
+                "browser-tab group relative flex flex-col items-center justify-center gap-0.5 w-full cursor-pointer select-none transition-colors py-2.5",
+                isActive
+                  ? "bg-[#14141a] text-[--fg-base]"
+                  : "text-[--fg-muted] hover:bg-[#0f0f13] hover:text-[--fg-base]",
+              ].join(" ")}
+            >
+              {/* Active indicator bar */}
+              {isActive && (
+                <span className="absolute left-0 top-1/2 -translate-y-1/2 w-[2px] h-6 rounded-r-full bg-white/70" />
+              )}
+              {/* Favicon / indicator */}
+              <span className="relative flex h-5 w-5 shrink-0 items-center justify-center rounded-[4px] bg-[--bg-raised]/50">
+                {isLocalhost
+                  ? <span className="h-2 w-2 rounded-full bg-green-400" />
+                  : <span className="text-[9px] font-semibold leading-none text-[--fg-muted] uppercase">{title.slice(0,2)}</span>
+                }
+              </span>
+              {/* Label */}
+              <span className="w-[36px] truncate text-center text-[9px] leading-tight">{title}</span>
+              {/* Close on hover */}
+              {tab.kind === "pinned" && tabs.filter((t) => t.kind === "pinned").length > 1 && (
+                <button
+                  onClick={(e) => removeTab(tab.id, e)}
+                  className="absolute top-1 right-1 opacity-0 group-hover:opacity-60 hover:!opacity-100 text-[--fg-muted] transition-opacity"
+                  title="Close tab"
+                >
+                  <Icon name="ph:x-bold" width={7} />
+                </button>
+              )}
+            </div>
+          );
+        })}
+        {/* Spacer */}
+        <div className="flex-1" />
+        {/* Pin current page */}
+        <button
+          onClick={pinCurrentPage}
+          className="grid h-8 w-8 shrink-0 place-items-center rounded text-[--fg-muted] hover:bg-[--bg-raised] hover:text-[--fg-base] transition-colors"
+          title="Pin current page as a tab"
+        >
+          <Icon name="ph:plus" width={13} />
+        </button>
+      </div>
+
+      {/* ── Main area (toolbar + viewport) ──────────────────────── */}
+      <div className="flex flex-1 flex-col overflow-hidden">
       {/* ── Toolbar ───────────────────────────────────────────────── */}
       <header className="flex items-center gap-1 border-b border-[--border-hairline] bg-[--bg-raised]/40 px-2 py-1.5">
         {/* Back */}
-        <button
-          type="button"
-          onClick={goBack}
-          disabled={!canBack}
-          className="grid h-7 w-7 place-items-center rounded text-[--text-secondary] hover:bg-[--bg-raised] hover:text-[--text-primary] disabled:opacity-30 disabled:cursor-default"
-          title="Back"
-          aria-label="Back"
-        >
+        <button type="button" onClick={goBack} disabled={!canBack}
+          className="grid h-7 w-7 place-items-center rounded text-[--fg-muted] hover:bg-[--bg-raised] hover:text-[--fg-base] disabled:opacity-30 disabled:cursor-default"
+          title="Back" aria-label="Back">
           <Icon name="ph:arrow-left-bold" width={13} />
         </button>
         {/* Forward */}
-        <button
-          type="button"
-          onClick={goForward}
-          disabled={!canForward}
-          className="grid h-7 w-7 place-items-center rounded text-[--text-secondary] hover:bg-[--bg-raised] hover:text-[--text-primary] disabled:opacity-30 disabled:cursor-default"
-          title="Forward"
-          aria-label="Forward"
-        >
+        <button type="button" onClick={goForward} disabled={!canForward}
+          className="grid h-7 w-7 place-items-center rounded text-[--fg-muted] hover:bg-[--bg-raised] hover:text-[--fg-base] disabled:opacity-30 disabled:cursor-default"
+          title="Forward" aria-label="Forward">
           <Icon name="ph:arrow-right-bold" width={13} />
         </button>
-        {/* Reload / Stop */}
-        <button
-          type="button"
+        {/* Reload */}
+        <button type="button"
           onClick={() => {
-            if (bridge) {
-              void bridge.invoke("browser_reload", { label });
-            } else {
-              navigateTo(url);
-            }
+            if (bridge) void bridge.invoke("browser_reload", { label: tabLabel(activeTabId) });
+            else navigateTo(activeUrl);
           }}
-          className="grid h-7 w-7 place-items-center rounded text-[--text-secondary] hover:bg-[--bg-raised] hover:text-[--text-primary]"
-          title={loading ? "Stop" : "Reload"}
-          aria-label={loading ? "Stop" : "Reload"}
-        >
+          className="grid h-7 w-7 place-items-center rounded text-[--fg-muted] hover:bg-[--bg-raised] hover:text-[--fg-base]"
+          title={loading ? "Stop" : "Reload"} aria-label={loading ? "Stop" : "Reload"}>
           {loading
             ? <Icon name="ph:x-bold" width={12} />
             : <Icon name="ph:arrows-clockwise-bold" width={12} />}
         </button>
         {/* Address bar */}
         <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            navigateTo(addressBar);
-          }}
+          onSubmit={(e) => { e.preventDefault(); navigateTo(addressBar); }}
           className="flex flex-1 items-center gap-1 rounded-md border border-[--border-hairline] bg-[--bg-raised]/40 px-2 py-1 focus-within:border-[--accent-presence]"
         >
-          {/* Security icon */}
-          {url.startsWith("https://") && (
-            <Icon name="ph:lock-simple-bold" width={11} className="shrink-0 text-[--text-tertiary]" />
+          {activeUrl.startsWith("https://") && (
+            <Icon name="ph:lock-simple-bold" width={11} className="shrink-0 text-[--fg-muted]" />
           )}
           <input
             type="text"
@@ -248,36 +484,28 @@ export function BrowserPane({ label = "default" }: { label?: string }) {
             onChange={(e) => setAddressBar(e.target.value)}
             onFocus={(e) => e.currentTarget.select()}
             placeholder="Search or enter address"
-            className="flex-1 bg-transparent text-[12px] text-[--text-primary] outline-none"
+            className="flex-1 bg-transparent text-[12px] text-[--fg-base] outline-none"
           />
         </form>
         {/* Home */}
-        <button
-          type="button"
-          onClick={() => navigateTo(HOME_URL)}
-          className="grid h-7 w-7 place-items-center rounded text-[--text-secondary] hover:bg-[--bg-raised] hover:text-[--text-primary]"
-          title="Home"
-          aria-label="Home"
-        >
+        <button type="button" onClick={() => navigateTo(HOME_URL)}
+          className="grid h-7 w-7 place-items-center rounded text-[--fg-muted] hover:bg-[--bg-raised] hover:text-[--fg-base]"
+          title="Home" aria-label="Home">
           <Icon name="ph:house-bold" width={13} />
         </button>
         {/* Open in system browser */}
-        <button
-          type="button"
+        <button type="button"
           onClick={() => {
-            // bridge.invoke shell_open if available, else window.open
             if (bridge) {
-              void bridge.invoke("shell_open", { url }).catch(() => {
-                window.open(url, "_blank", "noopener");
+              void bridge.invoke("shell_open", { url: activeUrl }).catch(() => {
+                window.open(activeUrl, "_blank", "noopener");
               });
             } else {
-              window.open(url, "_blank", "noopener");
+              window.open(activeUrl, "_blank", "noopener");
             }
           }}
-          className="grid h-7 w-7 place-items-center rounded text-[--text-secondary] hover:bg-[--bg-raised] hover:text-[--text-primary]"
-          title="Open in system browser"
-          aria-label="Open in system browser"
-        >
+          className="grid h-7 w-7 place-items-center rounded text-[--fg-muted] hover:bg-[--bg-raised] hover:text-[--fg-base]"
+          title="Open in system browser" aria-label="Open in system browser">
           <Icon name="ph:arrow-square-out" width={13} />
         </button>
       </header>
@@ -292,11 +520,11 @@ export function BrowserPane({ label = "default" }: { label?: string }) {
         </div>
       )}
 
-      {/* ── Viewport ──────────────────────────────────────────────── */}
-      <div className="relative flex-1 overflow-hidden">
+      {/* ── Viewport (webview overlay target) ─────────────────────── */}
+      <div className="relative flex-1 overflow-hidden" style={{ background: "#0c0c0e" }}>
         {unavailable ? (
           <iframe
-            src={url}
+            src={activeUrl}
             title="Browser"
             className="absolute inset-0 h-full w-full border-0 bg-white"
             sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-top-navigation"
@@ -305,6 +533,7 @@ export function BrowserPane({ label = "default" }: { label?: string }) {
           <div ref={surfaceRef} className="absolute inset-0" />
         )}
       </div>
+      </div>{/* end main area */}
     </div>
   );
 }

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useImperativeHandle, useRef, useState, type ReactNode } from "react";
+import type { ForwardedRef } from "react";
+import { forwardRef } from "react";
 import {
   Group,
   Panel,
@@ -78,11 +80,19 @@ export type ShellNavItem = {
   presence?: "active" | "idle";
 };
 
-export function Shell({
+export type ShellHandle = {
+  openAgent: () => void;
+  closeAgent: () => void;
+  toggleAgent: () => void;
+};
+
+function ShellInner({
   nav,
   list,
   detail,
   agent,
+  agentLabel,
+  agentIcon,
   bottom,
   topBar,
 }: {
@@ -90,15 +100,35 @@ export function Shell({
   list?: ReactNode;
   detail: ReactNode;
   agent?: ReactNode;
+  agentLabel?: string;
+  agentIcon?: IconName;
   bottom?: ReactNode;
   topBar?: ReactNode;
-}) {
+}, ref: ForwardedRef<ShellHandle>) {
   const navRef = useRef<PanelImperativeHandle | null>(null);
   const listRef = useRef<PanelImperativeHandle | null>(null);
   const agentRef = useRef<PanelImperativeHandle | null>(null);
   const bottomRef = useRef<PanelImperativeHandle | null>(null);
   const [mounted, setMounted] = useState(false);
+  const [agentOpen, setAgentOpen] = useState(false);
   useEffect(() => setMounted(true), []);
+
+  useImperativeHandle(ref, () => ({
+    openAgent: () => {
+      agentRef.current?.expand();
+      setAgentOpen(true);
+    },
+    closeAgent: () => {
+      agentRef.current?.collapse();
+      setAgentOpen(false);
+    },
+    toggleAgent: () => {
+      const panel = agentRef.current;
+      if (!panel) return;
+      if (panel.isCollapsed()) { panel.expand(); setAgentOpen(true); }
+      else { panel.collapse(); setAgentOpen(false); }
+    },
+  }), []);
 
   const twoPane = !list;
   const hasAgent = !!agent;
@@ -129,9 +159,17 @@ export function Shell({
         e.preventDefault();
         togglePanel(listRef.current);
       } else if (key === "j" && hasAgent) {
-        e.preventDefault();
-        togglePanel(agentRef.current);
-      }
+          e.preventDefault();
+          const panel = agentRef.current;
+          if (!panel) return;
+          if (panel.isCollapsed()) {
+            panel.expand();
+            setAgentOpen(true);
+          } else {
+            panel.collapse();
+            setAgentOpen(false);
+          }
+        }
     };
     const bottomToggle = (e: KeyboardEvent) => {
       if (!hasBottom) return;
@@ -203,52 +241,83 @@ export function Shell({
           <Panel
             id="agent"
             className="shell-agent-panel"
-            defaultSize="26%"
+            defaultSize={"0%"}
             minSize="20%"
             maxSize="38%"
             collapsible
             collapsedSize={0}
             panelRef={agentRef}
           >
-            <aside className="shell-agent">{agent}</aside>
+            <aside className="shell-agent">{agentOpen ? agent : null}</aside>
           </Panel>
         </>
       )}
     </Group>
   );
 
+  // Right-rail toggle tab (Dia/Linear-style vertical pill)
+  const agentTab = hasAgent ? (
+    <button
+      className="shell-agent-tab"
+      aria-label={agentOpen ? `Close ${agentLabel ?? "Browser"}` : `Open ${agentLabel ?? "Browser"}`}
+      title={`${agentLabel ?? "Browser"} (⌘J)`}
+      onClick={() => {
+        const panel = agentRef.current;
+        if (!panel) return;
+        if (panel.isCollapsed()) {
+          panel.expand();
+          setAgentOpen(true);
+        } else {
+          panel.collapse();
+          setAgentOpen(false);
+        }
+      }}
+    >
+      <Icon name={agentIcon ?? "ph:globe"} width={14} height={14} />
+      <span className="shell-agent-tab-label">{agentLabel ?? "Browser"}</span>
+      <span style={{ transform: agentOpen ? "rotate(0deg)" : "rotate(180deg)", transition: "transform 0.2s", display: "flex" }}>
+        <Icon name="ph:caret-right" width={10} height={10} className="shell-agent-tab-chevron" />
+      </span>
+    </button>
+  ) : null;
+
   return (
     <div className="flex h-full w-full flex-col">
       {topBar}
-      {hasBottom ? (
-        <Group
-          className="flex-1 min-h-0"
-          orientation="vertical"
-          id={BOTTOM_GROUP_ID}
-        >
-          <Panel id="main" minSize="40%">
-            {horizontalGroup}
-          </Panel>
-          <Separator className="shell-separator-h" />
-          <Panel
-            id="bottom"
-            className="shell-bottom-panel"
-            defaultSize="0"
-            minSize="8%"
-            maxSize="60%"
-            collapsible
-            collapsedSize={0}
-            panelRef={bottomRef}
+      <div className="flex flex-1 min-h-0 relative">
+        {hasBottom ? (
+          <Group
+            className="flex-1 min-h-0"
+            orientation="vertical"
+            id={BOTTOM_GROUP_ID}
           >
-            <section className="shell-bottom">{bottom}</section>
-          </Panel>
-        </Group>
-      ) : (
-        horizontalGroup
-      )}
+            <Panel id="main" minSize="40%">
+              {horizontalGroup}
+            </Panel>
+            <Separator className="shell-separator-h" />
+            <Panel
+              id="bottom"
+              className="shell-bottom-panel"
+              defaultSize="0"
+              minSize="8%"
+              maxSize="60%"
+              collapsible
+              collapsedSize={0}
+              panelRef={bottomRef}
+            >
+              <section className="shell-bottom">{bottom}</section>
+            </Panel>
+          </Group>
+        ) : (
+          horizontalGroup
+        )}
+        {agentTab}
+      </div>
     </div>
   );
 }
+
+export const Shell = forwardRef<ShellHandle, Parameters<typeof ShellInner>[0]>(ShellInner);
 
 export function ShellNav({
   header,

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -13,7 +13,7 @@ import { ValsInboxView } from "@/components/vals-inbox-view";
 import { NewReminderModal, draftFromSlashArgs } from "@/components/new-reminder-modal";
 import { InboxToastStack, toastFromItem, type Toast } from "@/components/inbox-toast";
 import { FamiliarGlyphPicker } from "@/components/familiar-glyph-picker";
-import { Shell } from "@/components/shell";
+import { Shell, type ShellHandle } from "@/components/shell";
 import { ChooserModal, type ChooserOption } from "@/components/ui/chooser-modal";
 import { AgentPanel } from "@/components/agent-panel";
 import { BottomTerminal } from "@/components/bottom-terminal";
@@ -32,6 +32,7 @@ type Mode = "home" | "chats" | "board" | "plugins" | "inbox" | "vals-inbox" | "b
 
 export function Workspace() {
   const routerRef = useRef<ChatRouterHandle | null>(null);
+  const shellRef = useRef<ShellHandle | null>(null);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [familiars, setFamiliars] = useState<Familiar[]>([]);
   const [familiarsError, setFamiliarsError] = useState<string | null>(null);
@@ -544,7 +545,13 @@ export function Workspace() {
         setTimeout(() => routerRef.current?.newChat(), 0);
       }}
       onOpenSearch={() => setPaletteOpen(true)}
-      onModeChange={(m) => setMode(m as Mode)}
+      onModeChange={(m) => {
+        if (m === "browser") {
+          setMode("browser");
+          return;
+        }
+        setMode(m as Mode);
+      }}
       onOpenSession={(id) => {
         setMode("chats");
         setTimeout(() => routerRef.current?.openSession(id), 0);
@@ -621,6 +628,8 @@ export function Workspace() {
       <SchedulesView familiars={familiars} />
     ) : mode === "calls" ? (
       <CallsView familiars={familiars} />
+    ) : mode === "browser" ? (
+      <BrowserPane label="main" />
     ) : mode === "comux" ? (
       <ComuxView />
     ) : (
@@ -635,6 +644,7 @@ export function Workspace() {
   return (
     <>
       <Shell
+        ref={shellRef}
         topBar={
           <DaemonBar
             mode={mode}
@@ -663,7 +673,9 @@ export function Workspace() {
         nav={sidebar}
         list={list}
         detail={detail}
-        agent={<BrowserPane label="default" />}
+        agent={mode === "browser" ? undefined : <BrowserPane label="default" />}
+        agentLabel="Browser"
+        agentIcon="ph:globe"
         bottom={<BottomTerminal threadId="cave.bottom.main" />}
       />
 


### PR DESCRIPTION
Cherry-picks the substantive parts of #67. The original PR was branched off pre-emoji-sweep main and would have reverted tonight's chrome work, so I picked only the parts that don't conflict.

## What this adds

### Chat / terminal workspace
- `src/app/api/chat/send/route.ts` — when no project root is supplied, resolve the familiar's own `~/.openclaw/workspace/<id>` dir and pass it as `--cwd` so Codex/Claude boot with the familiar's `AGENTS.md` / `SOUL.md` / `IDENTITY.md` and respond as the familiar instead of as the harness's default identity. Path-traversal guarded; falls back to undefined when the dir doesn't exist.

### Browser
- `src/components/browser-pane.tsx` — vertical tab rail with pinned tabs, dynamic localhost detection, dark-on-init webview to prevent white flash, layout-settling delay before reading panel bounds (+356/-127)
- `src-tauri/src/browser.rs` — small native-side adjustments to match the new pane lifecycle
- `src/components/shell.tsx` + `src/components/workspace.tsx` — right-rail browser toggle wiring (Dia/Linear style)
- `src/app/globals.css` — supporting styles for the browser tab rail

## Intentionally **not** carried over from #67
- Version bumps to 0.0.23-0.0.26 (we're on 0.0.27)
- `dev-app.sh` changes (already on main via #68)
- Sidebar/SessionItem reverts (already polished via #66)
- Pre-emoji-sweep state of chat-list, familiar-rail, home-composer, message-bubble, plugins-view, icon.tsx (would regress #69)

## Verification
- `tsc --noEmit`: ✅ 0 errors
- Unicode-range emoji sweep across `src/components`: ✅ clean
- Closes #67