### PR TITLE
ci(release): build + notarize macOS DMG in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,36 @@
 name: Release
 
-# Builds CovenCave Linux (AppImage) and Windows (unsigned MSI) artifacts
-# and uploads them to the GitHub Release matching the pushed tag.
+# Builds all three Cave artifacts and uploads them to the GitHub Release
+# matching the pushed tag:
 #
-# macOS is intentionally NOT built here — that flow stays local via
-# scripts/release.sh, which has the Apple Developer ID + notarization
-# credentials and produces a signed/notarized DMG. The local DMG is
-# uploaded into the same GitHub Release manually (or via `gh release
-# upload <tag> release/CovenCave-v<version>.dmg`).
+#   - macOS (DMG) — signed with the Soul Protocol LLC Developer ID and
+#     notarized via the App Store Connect API. The workflow refuses to
+#     upload an un-notarized DMG: a verification step runs `spctl` after
+#     the build and fails the job if Gatekeeper does not accept it.
+#   - Linux (AppImage) — unsigned.
+#   - Windows (MSI) — unsigned (users see SmartScreen on first run; we'll
+#     wire WINDOWS_CERTIFICATE secrets when we buy a code-signing cert).
 #
-# Trigger: push a tag matching `v*` (e.g. `git tag -s v0.0.12 && git push
-# origin v0.0.12`). The release.sh script already pushes a signed tag,
-# so the manual mac flow and the CI flow both key off the same tag.
+# Trigger: push a tag matching `v*` (e.g. `git tag -s v0.0.16 && git push
+# origin v0.0.16`).
 #
-# Windows binaries are UNSIGNED in v1 — users will see a SmartScreen
-# warning on first run. When we buy a code-signing cert we'll add the
-# WINDOWS_CERTIFICATE / WINDOWS_CERTIFICATE_PASSWORD secrets and wire
-# them into the windows job.
+# Required repository secrets for the macOS job:
+#   APPLE_CERTIFICATE          base64-encoded .p12 export of the Developer
+#                              ID Application certificate.
+#   APPLE_CERTIFICATE_PASSWORD password set when exporting the .p12.
+#   APPLE_SIGNING_IDENTITY     the identity codesign should use, e.g.
+#                              "Developer ID Application: Soul Protocol LLC
+#                              (9LR8Z8UQ9X)" or the SHA1 hash. The local
+#                              release.sh uses the SHA1 because there are
+#                              two identities sharing the display name.
+#   APPLE_API_ISSUER           the App Store Connect API issuer UUID.
+#   APPLE_API_KEY              the API key id (e.g. 3822D8Z5XFI0).
+#   APPLE_API_KEY_BASE64       base64-encoded contents of the AuthKey_*.p8
+#                              private key.
+#
+# scripts/release.sh remains useful for local iteration (faster than a CI
+# round-trip when you're tuning the bundle), but the canonical release
+# path is now the tag-push.
 
 on:
   push:
@@ -24,7 +38,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to attach builds to (e.g. v0.0.12). Must already exist on origin."
+        description: "Tag to attach builds to (e.g. v0.0.16). Must already exist on origin."
         required: true
         type: string
 
@@ -42,6 +56,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - platform: macos-latest
+            label: macOS (DMG, signed + notarized)
+            args: "--bundles dmg"
           - platform: ubuntu-22.04
             label: Linux (AppImage)
             args: "--bundles appimage"
@@ -87,10 +104,31 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # Decode the App Store Connect API key onto the runner so tauri-action
+      # can pass it to `xcrun notarytool`. The path is exported into the env
+      # for the build step. Runs only on the macOS leg.
+      - name: Stage Apple API key
+        if: matrix.platform == 'macos-latest'
+        run: |
+          KEY_PATH="$RUNNER_TEMP/apple_api_key.p8"
+          echo "$APPLE_API_KEY_BASE64" | base64 --decode > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
+          echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+        env:
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+
       - name: Build with tauri-action
         uses: tauri-apps/tauri-action@1ddc7b49b13c3038297360482fcb3e058764d7c9 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Apple signing + notarization (macOS only; secrets are simply
+          # empty strings on Linux/Windows runners and tauri-action skips
+          # the signing/notarization path when no cert is present).
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
         with:
           tagName: ${{ github.event.inputs.tag || github.ref_name }}
           releaseName: "CovenCave ${{ github.event.inputs.tag || github.ref_name }}"
@@ -98,3 +136,32 @@ jobs:
           prerelease: false
           includeUpdaterJson: false
           args: ${{ matrix.args }}
+
+      # Hard gate: fail the macOS leg if the produced DMG is not accepted
+      # by Gatekeeper as a notarized Developer ID app. This is what makes
+      # "require notarization" a build-time invariant rather than a
+      # convention. Without this, a misconfigured secret would silently
+      # ship an unsigned DMG, which is exactly what regressed
+      # v0.0.13–v0.0.15.
+      - name: Verify macOS DMG is notarized
+        if: matrix.platform == 'macos-latest'
+        shell: bash
+        run: |
+          set -euo pipefail
+          DMG=$(find src-tauri/target -name "CovenCave*.dmg" -type f | head -n1)
+          if [ -z "$DMG" ]; then
+            echo "::error::No DMG produced by tauri-action"
+            exit 1
+          fi
+          echo "Verifying $DMG"
+          if ! spctl -a -t open --context context:primary-signature -vv "$DMG" 2>&1 | tee /tmp/spctl.out | grep -q "accepted"; then
+            echo "::error::DMG is not accepted by Gatekeeper. Output:"
+            cat /tmp/spctl.out
+            exit 1
+          fi
+          if ! grep -q "Notarized Developer ID" /tmp/spctl.out; then
+            echo "::error::DMG is signed but NOT notarized. Output:"
+            cat /tmp/spctl.out
+            exit 1
+          fi
+          echo "OK: $(grep 'origin=' /tmp/spctl.out)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
         if: matrix.platform == 'macos-latest'
         run: |
           KEY_PATH="$RUNNER_TEMP/apple_api_key.p8"
-          echo "$APPLE_API_KEY_BASE64" | base64 --decode > "$KEY_PATH"
+          printf '%s' "$APPLE_API_KEY_BASE64" | base64 -D > "$KEY_PATH"
           chmod 600 "$KEY_PATH"
           echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
         env:


### PR DESCRIPTION
Real commit: `ci(release): build + notarize macOS DMG in CI; fail if not notarized`

Adds a GitHub Actions workflow that builds the Tauri app, signs, and notarizes the macOS DMG. Fails the CI run if notarization doesn't pass. The `Potential fix` commit is Copilot noise — squash on merge.