### PR TITLE
fix(chat): inject familiar identity via coven --familiar + spawn cwd

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -201,9 +201,13 @@ export async function POST(req: Request) {
   const buildArgs = (resumeSessionId: string | null): string[] => {
     const a = ["run", binding.harness, "--stream-json"];
     if (resumeSessionId) a.push("--continue", resumeSessionId);
-    // Boot in the familiar's workspace so the harness reads AGENTS.md /
-    // SOUL.md / IDENTITY.md and responds as the familiar, not as "Codex".
-    if (familiarWorkspace) a.push("--cwd", familiarWorkspace);
+    // Inject identity preamble. coven-cli renders this as a [Identity: ...]
+    // bracketed prefix for harnesses without a --system-prompt flag (Codex)
+    // or via --system-prompt for those that do (Claude). Without this,
+    // the harness answers as "Codex"/"Claude" instead of as the familiar.
+    if (/^[a-z0-9_-]+$/i.test(body.familiarId)) {
+      a.push("--familiar", body.familiarId);
+    }
     a.push("--", body.prompt);
     return a;
   };
@@ -353,7 +357,12 @@ export async function POST(req: Request) {
       const runAttempt = (spawnArgs: string[]): Promise<void> =>
         new Promise((resolve) => {
           const child = spawn(covenBin(), spawnArgs, {
-            cwd,
+            // Spawn IN the familiar's workspace when no project root was
+            // supplied, so coven's project-root resolver picks that dir as
+            // root and Codex/Claude pick up AGENTS.md / SOUL.md / IDENTITY.md
+            // from the familiar's home. When a project root IS supplied,
+            // honor that instead.
+            cwd: familiarWorkspace ?? cwd,
             stdio: ["ignore", "pipe", "pipe"],
             env: covenSpawnEnv(),
           });

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -96,6 +96,21 @@ function loginShellPath(): string | null {
 export function covenBin(): string {
   if (cachedBin) return cachedBin;
 
+  // Explicit override always wins. Useful for local dev when a checkout-built
+  // ~/.cargo/bin/coven is newer than the npm-bundled one in ~/.nvm/.../bin.
+  const envBin = process.env.COVEN_BIN;
+  if (envBin) {
+    try {
+      const st = statSync(envBin);
+      if (st.isFile() || st.isSymbolicLink()) {
+        cachedBin = envBin;
+        return cachedBin;
+      }
+    } catch {
+      /* fall through to discovery */
+    }
+  }
+
   for (const dir of candidateDirs()) {
     const candidate = path.join(dir, "coven");
     try {


### PR DESCRIPTION
## The bug

[Image] of #72 testing showed Nova answering as **"Codex"** instead of as **Nova**, even though her session was correctly booting in `/Users/buns/.openclaw/workspace/nova`. The previous fix wired `--cwd`, but cwd alone doesn't change harness identity — Codex's system prompt overrides whatever's in the working directory.

## The fix

Use coven-cli's existing identity-injection machinery: `coven run --familiar <id>` renders a short `[Identity: You are Nova, ...]` preamble that's prepended to the prompt for harnesses without `--system-prompt` (Codex), or passed via `--system-prompt` for ones that have it (Claude). This is the same machinery the Coven Code TUI uses.

### `src/app/api/chat/send/route.ts`
- Drop `--cwd` flag (coven-cli rejected absolute paths outside the resolved project root with "cwd is outside the Coven project root")
- Add `--familiar <id>` to coven argv (with simple slug validation guard)
- Pass `familiarWorkspace` as the **spawn process cwd** so coven's own project-root resolver picks the familiar's home as root, which makes AGENTS.md / SOUL.md / IDENTITY.md / USER.md visible to the harness's tool layer

### `src/lib/coven-bin.ts`
- Honor a `COVEN_BIN` env var override at the top of the resolver
- Useful for local dev when a checkout-built `~/.cargo/bin/coven` is newer than the npm-bundled one in `~/.nvm/.../bin`

## Verification

```
COVEN_BIN=/Users/buns/.cargo/bin/coven pnpm dev
```

**Nova:**
> "I'm Nova, Val's Queen/Orchestrator, working from `/Users/buns/.openclaw/workspace/nova`."

**Sage:**
> "I'm Sage, Val's Research familiar, here to gather context, verify truth, and turn ambiguity into clear next steps."

## Follow-up

- The npm-bundled `@opencoven/cli` needs a release that includes the `--familiar` flag (commit `1ab1d7e`); until then `COVEN_BIN` must be set, or v0.0.27+ DMG users will hit the same identity issue
- Consider lifting the familiar-aware spawn into a shared helper if more API routes start invoking coven on behalf of a familiar