### PR TITLE
fix(terminal): correct CWD, project-tree allowlist, pty_list guard

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -510,6 +510,19 @@ pub fn run() {
                 .env("HOSTNAME", "127.0.0.1")
                 .env("NODE_ENV", "production")
                 .env("COVEN_CAVE_BUNDLE", "1");
+
+            // Inject the openclaw workspace root so the Next.js project-tree
+            // and project-file API routes allow paths under ~/.openclaw in the
+            // packaged app (where process.cwd() is the bundle dir, not the
+            // user's workspace).
+            if let Some(home) = std::env::var("HOME")
+                .ok()
+                .or_else(|| std::env::var("USERPROFILE").ok())
+            {
+                let workspace_root = format!("{}/.openclaw", home);
+                cmd.env("WORKSPACE_ROOT", &workspace_root);
+                log::info!("[cave] sidecar WORKSPACE_ROOT -> {}", workspace_root);
+            }
             if let Some(out) = stdout_log {
                 cmd.stdout(Stdio::from(out));
             } else {

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -28,7 +28,15 @@ async function loadTauri(): Promise<TauriBridge | null> {
   return { invoke, listen };
 }
 
-export function BottomTerminal({ threadId, active = true }: { threadId: string; active?: boolean }) {
+export function BottomTerminal({
+  threadId,
+  active = true,
+  projectRoot,
+}: {
+  threadId: string;
+  active?: boolean;
+  projectRoot?: string;
+}) {
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const fitRef = useRef<(() => void) | null>(null);
   const termRef = useRef<import("@xterm/xterm").Terminal | null>(null);
@@ -119,25 +127,25 @@ export function BottomTerminal({ threadId, active = true }: { threadId: string; 
         });
       });
 
-      try {
-        await bridge.invoke("pty_start", {
-          options: {
-            thread_id: threadId,
-            cols: term.cols,
-            rows: term.rows,
-          },
-        });
-        // Focus so keyboard input is routed to the terminal immediately.
-        term.focus();
-      } catch (err) {
-        // Already running for this id (eg. React strict-mode double effect) —
-        // just attach to the stream we already opened.
-        if (!String(err).includes("already running")) {
-          term.write(`\r\n\x1b[31mpty_start failed: ${String(err)}\x1b[0m\r\n`);
-        } else {
-          term.focus();
+      const running = await bridge.invoke<string[]>("pty_list");
+      if (!running.includes(threadId)) {
+        try {
+          await bridge.invoke("pty_start", {
+            options: {
+              thread_id: threadId,
+              project_root: projectRoot ?? null,
+              cols: term.cols,
+              rows: term.rows,
+            },
+          });
+        } catch (err) {
+          // Rare race: another mount beat us between pty_list and pty_start.
+          if (!String(err).includes("already running")) {
+            term.write(`\r\n\x1b[31mpty_start failed: ${String(err)}\x1b[0m\r\n`);
+          }
         }
       }
+      term.focus();
 
       const doResize = () => {
         try {

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -55,6 +55,27 @@ export function ComuxView() {
   const [previewLoading, setPreviewLoading] = useState(false);
   const treeRef = useRef<ProjectTreeHandle | null>(null);
 
+  // Daemon project root — forwarded to BottomTerminal so terminals open in
+  // the right CWD instead of the app bundle dir.
+  const [projectRoot, setProjectRoot] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const res = await fetch("/api/daemon/status", { cache: "no-store" });
+        const json = (await res.json()) as Record<string, unknown>;
+        const root =
+          (json.workspacePath as string | undefined) ??
+          (json.projectRoot as string | undefined);
+        if (root && typeof root === "string") {
+          setProjectRoot(root);
+        }
+      } catch {
+        // non-fatal — terminal will open in default shell dir
+      }
+    })();
+  }, []);
+
   // Persist tab choice
   useEffect(() => {
     window.localStorage.setItem(STORAGE_TAB, tab);
@@ -227,7 +248,11 @@ export function ComuxView() {
                     pointerEvents: i === currentIdx ? "auto" : "none",
                   }}
                 >
-                  <BottomTerminal threadId={`cave.comux.${s.id}`} active={i === currentIdx} />
+                  <BottomTerminal
+                    threadId={`cave.comux.${s.id}`}
+                    active={i === currentIdx}
+                    projectRoot={projectRoot}
+                  />
                 </div>
               ))
             )}


### PR DESCRIPTION
Cherry-picked terminal correctness fixes from the original branch (which had accumulated unrelated commits):
- `fix(terminal): accept projectRoot prop, check pty_list before pty_start`
- `fix(terminal): fetch daemon projectRoot on mount and pass to BottomTerminal`
- `fix(sidecar): inject WORKSPACE_ROOT=~/.openclaw so project-tree API works in packaged app`

Supersedes #67.