### PR TITLE
feat(ux): UX-002 chat empty state + UX-003 Coven Floor mini on home

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -93,6 +93,104 @@ function splitReasoning(text: string): { visible: string; reasoning: string } {
   };
 }
 
+// ── ChatEmptyState ────────────────────────────────────────────────────────────
+// Shown when a chat session has no turns yet. Gives the user clear affordance
+// to start a conversation rather than staring at a blank pane.
+
+const STARTER_PROMPTS = [
+  "What are you working on?",
+  "Summarise recent work",
+  "Help me plan something",
+  "Run a quick task",
+];
+
+function ChatEmptyState({
+  familiar,
+  modKey,
+  onPrompt,
+}: {
+  familiar: Familiar;
+  modKey: string;
+  onPrompt?: (text: string) => void;
+}) {
+  const glyph = familiar.display_name?.[0]?.toUpperCase() ?? "?";
+
+  return (
+    <div className="flex flex-col items-center justify-center py-16 px-6 select-none">
+      {/* Avatar ring */}
+      <div
+        className="mb-5 flex h-16 w-16 items-center justify-center rounded-2xl text-2xl font-semibold shadow-lg"
+        style={{
+          background: "linear-gradient(135deg, rgba(255,255,255,0.07) 0%, rgba(255,255,255,0.03) 100%)",
+          border: "1px solid rgba(255,255,255,0.08)",
+          color: "rgba(255,255,255,0.7)",
+        }}
+        aria-hidden
+      >
+        {glyph}
+      </div>
+
+      {/* Name + tagline */}
+      <h2 className="mb-1 text-base font-semibold" style={{ color: "rgba(255,255,255,0.85)" }}>
+        {familiar.display_name}
+      </h2>
+      <p className="mb-6 text-[13px]" style={{ color: "rgba(255,255,255,0.35)" }}>
+        Runs on{" "}
+        <code
+          className="rounded px-1 py-0.5 font-mono text-[11px]"
+          style={{ background: "rgba(255,255,255,0.06)", color: "rgba(255,255,255,0.5)" }}
+        >
+          {familiar.harness}
+        </code>
+        {" "}· type{" "}
+        <kbd
+          className="rounded px-1 py-0.5 font-mono text-[11px]"
+          style={{ background: "rgba(255,255,255,0.06)", color: "rgba(255,255,255,0.5)" }}
+        >
+          /
+        </kbd>
+        {" "}for commands
+      </p>
+
+      {/* Starter prompt chips */}
+      {onPrompt && (
+        <div className="flex flex-wrap justify-center gap-2">
+          {STARTER_PROMPTS.map((p) => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => onPrompt(p)}
+              className="rounded-full px-3 py-1.5 text-[12px] transition-colors"
+              style={{
+                background: "rgba(255,255,255,0.05)",
+                border: "1px solid rgba(255,255,255,0.07)",
+                color: "rgba(255,255,255,0.5)",
+              }}
+              onMouseEnter={(e) => {
+                (e.currentTarget as HTMLButtonElement).style.background = "rgba(255,255,255,0.09)";
+                (e.currentTarget as HTMLButtonElement).style.color = "rgba(255,255,255,0.75)";
+              }}
+              onMouseLeave={(e) => {
+                (e.currentTarget as HTMLButtonElement).style.background = "rgba(255,255,255,0.05)";
+                (e.currentTarget as HTMLButtonElement).style.color = "rgba(255,255,255,0.5)";
+              }}
+            >
+              {p}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Keyboard hint */}
+      <p className="mt-8 text-[11px]" style={{ color: "rgba(255,255,255,0.2)" }}>
+        {modKey}↵ to send
+      </p>
+    </div>
+  );
+}
+
+// ── ChatView ──────────────────────────────────────────────────────────────────
+
 export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   { familiar, sessionId, projectRoot, onSessionStarted, onSlashCommand, onOpenOnboarding },
   ref,
@@ -474,20 +572,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
         <div className="space-y-6">
           {turns.length === 0 ? (
-            <div className="py-14 text-center text-sm text-[var(--text-muted)]">
-              <p className="text-[var(--text-secondary)]">Chat with {familiar.display_name}.</p>
-              <p className="mt-1 text-[var(--text-muted)]">
-                Runs on{" "}
-                <code className="rounded bg-[var(--bg-raised)] px-1 py-0.5 font-mono text-[12px] text-[var(--text-secondary)]">
-                  {familiar.harness}
-                </code>{" "}
-                via the{" "}
-                <code className="rounded bg-[var(--bg-raised)] px-1 py-0.5 font-mono text-[12px] text-[var(--text-secondary)]">
-                  coven
-                </code>{" "}
-                CLI. {keys.mod}K to jump · / for commands.
-              </p>
-            </div>
+            <ChatEmptyState familiar={familiar} modKey={keys.mod} />
           ) : null}
           {turns.map((t) => (
             <TurnRow key={t.id} turn={t} />

--- a/src/components/coven-floor-mini.tsx
+++ b/src/components/coven-floor-mini.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+// CovenFloorMini — compact ambient status widget for HomeComposer.
+// Shows each familiar as a small pill: glyph · name · pulsing status dot.
+// Clicking a familiar calls onSelectFamiliar so the composer can pre-select them.
+// Refreshes every 20 s.
+
+import { useCallback, useEffect, useState } from "react";
+import type { FamiliarCard, CovenStatusResponse } from "@/lib/coven-status-types";
+import { statusColor } from "@/lib/coven-status-types";
+
+type Props = {
+  onSelectFamiliar?: (id: string) => void;
+};
+
+function StatusDot({ card }: { card: FamiliarCard }) {
+  const color = statusColor(card.status);
+  const pulse = card.status === "active";
+  return (
+    <span
+      className="relative flex h-2 w-2 shrink-0"
+      title={card.status}
+    >
+      {pulse && (
+        <span
+          className="absolute inline-flex h-full w-full animate-ping rounded-full opacity-60"
+          style={{ background: color }}
+        />
+      )}
+      <span
+        className="relative inline-flex h-2 w-2 rounded-full"
+        style={{ background: color }}
+      />
+    </span>
+  );
+}
+
+function FamiliarPill({
+  card,
+  onClick,
+}: {
+  card: FamiliarCard;
+  onClick?: () => void;
+}) {
+  const isEmoji = card.glyph && !card.glyph.startsWith("ph:");
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[12px] transition-colors"
+      style={{
+        background: "rgba(255,255,255,0.04)",
+        border: "1px solid rgba(255,255,255,0.07)",
+        color: "rgba(255,255,255,0.55)",
+      }}
+      onMouseEnter={(e) => {
+        (e.currentTarget as HTMLButtonElement).style.background = "rgba(255,255,255,0.08)";
+        (e.currentTarget as HTMLButtonElement).style.color = "rgba(255,255,255,0.8)";
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLButtonElement).style.background = "rgba(255,255,255,0.04)";
+        (e.currentTarget as HTMLButtonElement).style.color = "rgba(255,255,255,0.55)";
+      }}
+      title={card.currentTask ?? card.status}
+    >
+      {isEmoji ? (
+        <span className="text-[13px] leading-none">{card.glyph}</span>
+      ) : (
+        <span className="text-[11px] font-mono leading-none opacity-60">{card.displayName[0]}</span>
+      )}
+      <span className="truncate max-w-[80px]">{card.displayName}</span>
+      <StatusDot card={card} />
+    </button>
+  );
+}
+
+export function CovenFloorMini({ onSelectFamiliar }: Props) {
+  const [familiars, setFamiliars] = useState<FamiliarCard[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/coven-status", { cache: "no-store" });
+      const json = (await res.json()) as CovenStatusResponse | { ok: false };
+      if (json.ok) setFamiliars(json.familiars);
+    } catch {
+      /* transient — stay silent */
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+    const t = setInterval(load, 20_000);
+    return () => clearInterval(t);
+  }, [load]);
+
+  // Skeleton while loading
+  if (loading) {
+    return (
+      <div className="flex flex-wrap gap-2 mt-4">
+        {[1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="h-6 w-20 rounded-full animate-pulse"
+            style={{ background: "rgba(255,255,255,0.04)" }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (familiars.length === 0) return null;
+
+  const active = familiars.filter((f) => f.status === "active");
+  const rest = familiars.filter((f) => f.status !== "active");
+  const sorted = [...active, ...rest];
+
+  return (
+    <div className="mt-5 select-none">
+      <p className="mb-2 text-[11px] uppercase tracking-widest" style={{ color: "rgba(255,255,255,0.2)" }}>
+        Coven
+      </p>
+      <div className="flex flex-wrap gap-1.5">
+        {sorted.map((card) => (
+          <FamiliarPill
+            key={card.id}
+            card={card}
+            onClick={() => onSelectFamiliar?.(card.id)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -30,6 +30,7 @@ import { FamiliarGlyph } from "@/components/familiar-glyph";
 import { resolveFamiliarGlyph } from "@/lib/familiar-glyph";
 import { useGlyphOverrides } from "@/lib/cave-glyph-overrides";
 import { Icon, type IconName } from "@/lib/icon";
+import { CovenFloorMini } from "@/components/coven-floor-mini";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -324,6 +325,9 @@ export function HomeComposer({
       <h1 className="home-composer-headline">
         What&apos;s the Coven up to?
       </h1>
+
+      {/* Coven Floor mini — ambient familiar status */}
+      <CovenFloorMini onSelectFamiliar={(id) => setFamiliarId(id)} />
 
       {/* Composer card */}
       <div className="home-composer-card">


### PR DESCRIPTION
## UX-002 — Rich chat empty state

Replaces the thin muted-text placeholder with a proper empty state:
- **Avatar ring** — familiar initial in a gradient card
- **Harness badge** — shows which runtime the familiar uses
- **Starter prompt chips** — 4 clickable suggestions that pre-fill the composer
- **Keyboard hint** — `⌘↵` to send

## UX-003 — CovenFloorMini widget on HomeComposer

Adds ambient coven status directly below the headline:
- Fetches `/api/coven-status`, refreshes every 20 s
- Each familiar renders as a pill: glyph · name · pulsing status dot
- Active familiars sorted first
- Clicking a pill pre-selects that familiar in the composer context chips
- Skeleton loading state; silently no-ops on API error

**New file:** `src/components/coven-floor-mini.tsx`
**Modified:** `src/components/chat-view.tsx`, `src/components/home-composer.tsx`