### PR TITLE
fix(browser): drop white seam at tab rail / viewport boundary

### DIFF
--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -397,7 +397,11 @@ export function BrowserPane({ label = "default" }: { label?: string }) {
   return (
     <div ref={paneRef} className="flex h-full flex-row" style={{ background: "#0c0c0e" }}>
       {/* ── Vertical tab rail ─────────────────────────────────────── */}
-      <div className="browser-tab-rail flex flex-col items-center border-r border-[--border-hairline] bg-[#080809] py-1.5" style={{ width: 48, minWidth: 48 }}>
+      {/* No right border — a `--border-hairline` (5% white) on the dark
+         #0c0c0e viewport reads as a bright vertical line at the rail/page
+         seam. The rail's darker `bg-[#080809]` already provides enough
+         contrast against the viewport for visual separation. */}
+      <div className="browser-tab-rail flex flex-col items-center bg-[#080809] py-1.5" style={{ width: 48, minWidth: 48 }}>
         {tabs.map((tab) => {
           const isActive = tab.id === activeTabId;
           const title = shortTitle(tab.url, tabTitles[tab.id] ?? tab.title);
@@ -552,7 +556,7 @@ export function BrowserPane({ label = "default" }: { label?: string }) {
           <iframe
             src={activeUrl}
             title="Browser"
-            className="absolute inset-0 h-full w-full border-0 bg-white"
+            className="absolute inset-0 h-full w-full border-0 bg-[#0c0c0e]"
             sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-top-navigation"
           />
         ) : (


### PR DESCRIPTION
## Symptom

In the Cave browser pane there's a bright vertical white line running the full height of the rail/viewport seam (visible in Val's screenshot from #7108). On a narrow viewport it reads as a hard white border between the tab strip and the page.

## Cause

`<div className="... border-r border-[--border-hairline] bg-[#080809] ...">` on the vertical tab rail.

`--border-hairline` resolves to `var(--border)` → `oklch(1 0 0 / 5%)` (5% white). Against the rail's `#080809` and the viewport's `#0c0c0e`, that 1px hairline reads brighter than intended — the surrounding contrast is so low that even a 5% white pixel column looks like a hard seam.

## Fix

- Drop the rail's right border entirely. The rail's `#080809` vs the viewport's `#0c0c0e` already gives enough contrast for visual separation without the bright seam.
- Bonus: swap the no-Tauri iframe fallback's `bg-white` for the viewport color (`#0c0c0e`) so any flash-of-white before the embedded page paints does not produce a similar bright artifact through the dev (`pnpm dev`) preview path.

## Verified

- `npx tsc --noEmit` clean.
- Visual diff: rail / viewport seam is now a smooth gradient between `#080809` and `#0c0c0e` instead of a bright vertical line.

Stacked on top of the existing browser pane work; no behaviour changes beyond the seam color.