### PR TITLE
fix: terminal IPC + calendar view — v0.0.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,6 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "enables the default permissions",
+  "local": false,
   "windows": [
     "main"
   ],

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -375,6 +375,7 @@ pub fn run() {
             pty::pty_resize,
             pty::pty_stop,
             pty::pty_list,
+            pty::pty_diagnose,
             browser::browser_navigate,
             browser::browser_set_bounds,
             browser::browser_hide,
@@ -388,7 +389,7 @@ pub fn run() {
             if cfg!(debug_assertions) {
                 app.handle().plugin(
                     tauri_plugin_log::Builder::default()
-                        .level(log::LevelFilter::Info)
+                        .level(log::LevelFilter::Debug)
                         .build(),
                 )?;
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -366,6 +366,20 @@ fn shell_open(url: String) -> Result<(), String> {
     Ok(())
 }
 
+#[tauri::command]
+fn webview_probe_report(report: String) -> Result<(), String> {
+    let path = std::env::temp_dir().join("covencave-webview-probe.log");
+    use std::io::Write as _;
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .map_err(|e| e.to_string())?;
+    let _ = writeln!(f, "{}", report);
+    log::info!("[webview-probe] {}", report);
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -376,6 +390,7 @@ pub fn run() {
             pty::pty_stop,
             pty::pty_list,
             pty::pty_diagnose,
+            webview_probe_report,
             browser::browser_navigate,
             browser::browser_set_bounds,
             browser::browser_hide,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -368,6 +368,21 @@ fn shell_open(url: String) -> Result<(), String> {
 
 #[tauri::command]
 fn webview_probe_report(report: String) -> Result<(), String> {
+    // Dev-only diagnostic hook. In release builds, keep this as a no-op to avoid
+    // creating a writable IPC sink for arbitrary/unbounded data.
+    if !cfg!(debug_assertions) {
+        return Ok(());
+    }
+
+    // Prevent unbounded growth if something chatty forwards logs.
+    let report = if report.chars().count() > 16_384 {
+        let mut s: String = report.chars().take(16_384).collect();
+        s.push_str("…<truncated>");
+        s
+    } else {
+        report
+    };
+
     let path = std::env::temp_dir().join("covencave-webview-probe.log");
     use std::io::Write as _;
     let mut f = std::fs::OpenOptions::new()
@@ -375,8 +390,8 @@ fn webview_probe_report(report: String) -> Result<(), String> {
         .append(true)
         .open(&path)
         .map_err(|e| e.to_string())?;
-    let _ = writeln!(f, "{}", report);
-    log::info!("[webview-probe] {}", report);
+    writeln!(f, "{}", report).map_err(|e| e.to_string())?;
+    log::debug!("[webview-probe] {}", report);
     Ok(())
 }
 

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -27,6 +27,7 @@ use parking_lot::Mutex;
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter};
+use log::{debug, info, warn};
 
 struct PtySession {
     #[allow(dead_code)]
@@ -90,6 +91,8 @@ pub struct PtyExitEvent {
 #[tauri::command]
 pub fn pty_start(app: AppHandle, options: StartOptions) -> Result<(), String> {
     let thread_id = options.thread_id.clone();
+    info!("pty_start: thread_id={} project_root={:?} cols={:?} rows={:?}",
+        thread_id, options.project_root, options.cols, options.rows);
     let pending = PendingPtyStart::reserve(&thread_id)?;
 
     let pty_system = native_pty_system();
@@ -104,12 +107,14 @@ pub fn pty_start(app: AppHandle, options: StartOptions) -> Result<(), String> {
 
     let command = options.command.unwrap_or_else(|| default_shell());
     let args = options.args.unwrap_or_else(|| default_shell_args());
+    info!("pty_start[{}]: spawning {} {:?}", thread_id, command, args);
     let mut cmd = CommandBuilder::new(&command);
     cmd.args(&args);
     if let Some(root) = &options.project_root {
         // Normalize bare Windows drive letters like "C:" → "C:\"
         // so portable-pty / Node's lstat doesn't hit EISDIR on the root.
         let normalized = normalize_cwd(root);
+        info!("pty_start[{}]: cwd={}", thread_id, normalized);
         cmd.cwd(&normalized);
     }
     // Sensible defaults so xterm.js renders unicode + truecolor; when launched
@@ -145,7 +150,16 @@ pub fn pty_start(app: AppHandle, options: StartOptions) -> Result<(), String> {
     cmd.env_remove("NPM_CONFIG_PREFIX");
     cmd.env_remove("PREFIX");
 
-    let mut child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
+    let mut child = match pair.slave.spawn_command(cmd) {
+        Ok(c) => {
+            info!("pty_start[{}]: child spawned, pid={:?}", thread_id, c.process_id());
+            c
+        }
+        Err(e) => {
+            warn!("pty_start[{}]: spawn failed: {}", thread_id, e);
+            return Err(e.to_string());
+        }
+    };
     let mut reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
     let writer = pair.master.take_writer().map_err(|e| e.to_string())?;
 
@@ -166,11 +180,22 @@ pub fn pty_start(app: AppHandle, options: StartOptions) -> Result<(), String> {
     let tid_read = thread_id.clone();
     let app_read = app.clone();
     thread::spawn(move || {
+        info!("pty_start[{}]: reader thread started", tid_read);
         let mut buf = [0u8; 8192];
+        let mut total = 0usize;
         loop {
             match reader.read(&mut buf) {
-                Ok(0) | Err(_) => break,
+                Ok(0) => {
+                    info!("pty_start[{}]: reader EOF after {} bytes", tid_read, total);
+                    break;
+                }
+                Err(e) => {
+                    warn!("pty_start[{}]: reader error after {} bytes: {}", tid_read, total, e);
+                    break;
+                }
                 Ok(n) => {
+                    total = total.saturating_add(n);
+                    debug!("pty_start[{}]: emit pty:data {} bytes (total {})", tid_read, n, total);
                     let _ = app_read.emit(
                         "pty:data",
                         PtyDataEvent {
@@ -189,6 +214,7 @@ pub fn pty_start(app: AppHandle, options: StartOptions) -> Result<(), String> {
     let app_wait = app;
     thread::spawn(move || {
         let code = child.wait().ok().and_then(|status| status.exit_code().try_into().ok());
+        warn!("pty_start[{}]: child exited code={:?}", tid_wait, code);
         SESSIONS.lock().remove(&tid_wait);
         let _ = app_wait.emit(
             "pty:exit",
@@ -204,12 +230,16 @@ pub fn pty_start(app: AppHandle, options: StartOptions) -> Result<(), String> {
 
 #[tauri::command]
 pub fn pty_write(thread_id: String, bytes: Vec<u8>) -> Result<(), String> {
+    debug!("pty_write[{}]: {} bytes", thread_id, bytes.len());
     let writer = {
         let sessions = SESSIONS.lock();
         sessions
             .get(&thread_id)
             .map(|s| s.writer.clone())
-            .ok_or_else(|| format!("pty '{}' not found", thread_id))?
+            .ok_or_else(|| {
+                warn!("pty_write[{}]: session not found", thread_id);
+                format!("pty '{}' not found", thread_id)
+            })?
     };
     let mut w = writer.lock();
     w.write_all(&bytes).map_err(|e| e.to_string())?;
@@ -245,6 +275,57 @@ pub fn pty_stop(thread_id: String) {
 #[tauri::command]
 pub fn pty_list() -> Vec<String> {
     SESSIONS.lock().keys().cloned().collect()
+}
+
+/// Diagnostic: spawn a one-shot known-good PTY (`/bin/echo hello && exit`),
+/// read all output synchronously, and return what came back. Lets us prove
+/// the PTY plumbing works end-to-end without depending on the React layer
+/// or on any user shell config.
+#[tauri::command]
+pub fn pty_diagnose() -> Result<DiagnoseReport, String> {
+    info!("pty_diagnose: starting");
+    let pty_system = native_pty_system();
+    let pair = pty_system
+        .openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
+        .map_err(|e| format!("openpty: {e}"))?;
+
+    #[cfg(target_os = "windows")]
+    let mut cmd = CommandBuilder::new("cmd.exe");
+    #[cfg(target_os = "windows")]
+    cmd.args(["/C", "echo coven-cave-pty-ok"]);
+
+    #[cfg(not(target_os = "windows"))]
+    let mut cmd = {
+        let mut c = CommandBuilder::new("/bin/sh");
+        c.args(["-c", "echo coven-cave-pty-ok"]);
+        c
+    };
+    cmd.env("PATH", augmented_path());
+    #[cfg(not(target_os = "windows"))]
+    cmd.env("TERM", "xterm-256color");
+
+    let mut child = pair.slave.spawn_command(cmd).map_err(|e| format!("spawn: {e}"))?;
+    let pid = child.process_id();
+    let mut reader = pair.master.try_clone_reader().map_err(|e| format!("reader: {e}"))?;
+    drop(pair.master);
+    drop(pair.slave);
+
+    let mut buf = Vec::with_capacity(256);
+    let _ = reader.read_to_end(&mut buf);
+    let exit = child.wait().ok().and_then(|s| s.exit_code().try_into().ok());
+
+    let output = String::from_utf8_lossy(&buf).to_string();
+    info!("pty_diagnose: pid={:?} exit={:?} bytes={} output={:?}",
+        pid, exit, buf.len(), output);
+    Ok(DiagnoseReport { pid, exit, bytes: buf.len(), output })
+}
+
+#[derive(Debug, Serialize)]
+pub struct DiagnoseReport {
+    pub pid: Option<u32>,
+    pub exit: Option<i32>,
+    pub bytes: usize,
+    pub output: String,
 }
 
 /// Normalize a working directory path so portable-pty / Node's lstat

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,8 +11,17 @@
   },
   "app": {
     "windows": [],
+    "withGlobalTauri": true,
     "security": {
-      "csp": null
+      "csp": null,
+      "dangerousRemoteDomainIpcAccess": [
+        {
+          "domain": "localhost",
+          "windows": ["main"],
+          "plugins": [],
+          "enableTauriAPI": true
+        }
+      ]
     }
   },
   "bundle": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,17 @@
       "dangerousRemoteDomainIpcAccess": [
         {
           "domain": "localhost",
-          "windows": ["main"],
+          "windows": [
+            "main"
+          ],
+          "plugins": [],
+          "enableTauriAPI": true
+        },
+        {
+          "domain": "127.0.0.1",
+          "windows": [
+            "main"
+          ],
           "plugins": [],
           "enableTauriAPI": true
         }

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -44,7 +44,6 @@ export function BottomTerminal({
   const log = (...a: unknown[]) => {
     console.info(`[BottomTerminal:${threadId}]`, ...a);
     try {
-      // @ts-expect-error Tauri injects this
       const inv = (typeof window !== "undefined" ? window : ({} as any))
         .__TAURI_INTERNALS__?.invoke;
       if (typeof inv === "function") {

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -41,8 +41,28 @@ export function BottomTerminal({
   const fitRef = useRef<(() => void) | null>(null);
   const termRef = useRef<import("@xterm/xterm").Terminal | null>(null);
   const [unavailable, setUnavailable] = useState(false);
-  const log = (...a: unknown[]) =>
+  const log = (...a: unknown[]) => {
     console.info(`[BottomTerminal:${threadId}]`, ...a);
+    try {
+      // @ts-expect-error Tauri injects this
+      const inv = (typeof window !== "undefined" ? window : ({} as any))
+        .__TAURI_INTERNALS__?.invoke;
+      if (typeof inv === "function") {
+        inv("webview_probe_report", {
+          report: JSON.stringify({
+            kind: "bottom-terminal-log",
+            threadId,
+            msg: a
+              .map((x) => (typeof x === "string" ? x : JSON.stringify(x)))
+              .join(" "),
+            ts: new Date().toISOString(),
+          }),
+        }).catch(() => {});
+      }
+    } catch { /* ignore */ }
+  };
+  // Also forward every BottomTerminal log line back to Rust so we can read
+  // them in the tauri-dev stderr without needing WebView devtools.
 
   // Re-fit + refocus whenever this terminal becomes the active tab.
   useEffect(() => {

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -40,6 +40,10 @@ export function BottomTerminal({
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const fitRef = useRef<(() => void) | null>(null);
   const termRef = useRef<import("@xterm/xterm").Terminal | null>(null);
+  // Keep a ref to projectRoot so the PTY-start effect always reads the latest
+  // value, even when it arrives asynchronously after initial mount.
+  const projectRootRef = useRef<string | undefined>(projectRoot);
+  useEffect(() => { projectRootRef.current = projectRoot; }, [projectRoot]);
   const [unavailable, setUnavailable] = useState(false);
   const log = (...a: unknown[]) => {
     console.info(`[BottomTerminal:${threadId}]`, ...a);
@@ -130,7 +134,6 @@ export function BottomTerminal({
         bytes: number[];
       }>("pty:data", (e) => {
         if (e.payload.thread_id !== threadId) return;
-        log("pty:data", e.payload.bytes.length, "bytes");
         term.write(new Uint8Array(e.payload.bytes));
       });
       const unlistenExit = await bridge.listen<{
@@ -149,7 +152,6 @@ export function BottomTerminal({
       // param names must match the Rust fn signature exactly.
       const onDataDispose = term.onData((data) => {
         if (stopped) return;
-        log("onData → pty_write", data.length, "chars");
         void bridge.invoke("pty_write", {
           thread_id: threadId,
           bytes: Array.from(new TextEncoder().encode(data)),
@@ -162,12 +164,12 @@ export function BottomTerminal({
       });
       log("pty_list →", running);
       if (!running.includes(threadId)) {
-        log("pty_start: invoking with projectRoot=", projectRoot);
+        log("pty_start: invoking with projectRoot=", projectRootRef.current);
         try {
           await bridge.invoke("pty_start", {
             options: {
               thread_id: threadId,
-              project_root: projectRoot ?? null,
+              project_root: projectRootRef.current ?? null,
               cols: term.cols,
               rows: term.rows,
             },

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -41,6 +41,8 @@ export function BottomTerminal({
   const fitRef = useRef<(() => void) | null>(null);
   const termRef = useRef<import("@xterm/xterm").Terminal | null>(null);
   const [unavailable, setUnavailable] = useState(false);
+  const log = (...a: unknown[]) =>
+    console.info(`[BottomTerminal:${threadId}]`, ...a);
 
   // Re-fit + refocus whenever this terminal becomes the active tab.
   useEffect(() => {
@@ -61,11 +63,14 @@ export function BottomTerminal({
     let cleanup: (() => void) | null = null;
 
     void (async () => {
+      log("mount: loading tauri bridge");
       const bridge = await loadTauri();
       if (!bridge) {
+        log("mount: no tauri bridge — running outside Cave; rendering placeholder");
         if (!disposed) setUnavailable(true);
         return;
       }
+      log("mount: tauri bridge ready");
 
       // Lazy-load xterm only on the client + only inside Tauri so SSR and
       // the in-browser dev path don't try to pull it in.
@@ -98,6 +103,7 @@ export function BottomTerminal({
       } catch {
         /* DOM not ready yet — first resize event will recover */
       }
+      log("xterm opened", { cols: term.cols, rows: term.rows });
 
       let stopped = false;
       const unlistenData = await bridge.listen<{
@@ -105,6 +111,7 @@ export function BottomTerminal({
         bytes: number[];
       }>("pty:data", (e) => {
         if (e.payload.thread_id !== threadId) return;
+        log("pty:data", e.payload.bytes.length, "bytes");
         term.write(new Uint8Array(e.payload.bytes));
       });
       const unlistenExit = await bridge.listen<{
@@ -112,23 +119,31 @@ export function BottomTerminal({
         code: number | null;
       }>("pty:exit", (e) => {
         if (e.payload.thread_id !== threadId) return;
+        log("pty:exit", e.payload);
         stopped = true;
         term.write(`\r\n\x1b[2m[exit ${e.payload.code ?? 0}]\x1b[0m\r\n`);
       });
+      log("pty:data + pty:exit listeners registered");
 
       // Pipe user input back to the PTY.
       // NOTE: Tauri v2 invoke does NOT auto-convert camelCase → snake_case;
       // param names must match the Rust fn signature exactly.
       const onDataDispose = term.onData((data) => {
         if (stopped) return;
+        log("onData → pty_write", data.length, "chars");
         void bridge.invoke("pty_write", {
           thread_id: threadId,
           bytes: Array.from(new TextEncoder().encode(data)),
-        });
+        }).catch((err) => log("pty_write FAILED", err));
       });
 
-      const running = await bridge.invoke<string[]>("pty_list");
+      const running = await bridge.invoke<string[]>("pty_list").catch((err) => {
+        log("pty_list FAILED", err);
+        return [] as string[];
+      });
+      log("pty_list →", running);
       if (!running.includes(threadId)) {
+        log("pty_start: invoking with projectRoot=", projectRoot);
         try {
           await bridge.invoke("pty_start", {
             options: {
@@ -138,12 +153,18 @@ export function BottomTerminal({
               rows: term.rows,
             },
           });
+          log("pty_start: ok");
         } catch (err) {
           // Rare race: another mount beat us between pty_list and pty_start.
           if (!String(err).includes("already running")) {
+            log("pty_start FAILED", err);
             term.write(`\r\n\x1b[31mpty_start failed: ${String(err)}\x1b[0m\r\n`);
+          } else {
+            log("pty_start: already running for this id (ok)");
           }
         }
+      } else {
+        log("pty_start: skipped, already in pty_list");
       }
       term.focus();
 

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -1,0 +1,543 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { InboxItem } from "@/lib/cave-inbox";
+import type { Familiar } from "@/lib/types";
+import { Icon } from "@/lib/icon";
+import type { IconName } from "@/lib/icon";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type ViewMode = "agenda" | "day" | "week" | "month";
+
+type Props = {
+  items: InboxItem[];
+  familiars: Familiar[];
+  onOpenItem?: (item: InboxItem) => void;
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const MONTHS = [
+  "January","February","March","April","May","June",
+  "July","August","September","October","November","December",
+];
+
+function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+function startOfWeek(d: Date): Date {
+  const s = startOfDay(d);
+  s.setDate(s.getDate() - s.getDay());
+  return s;
+}
+
+function startOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), 1);
+}
+
+function addDays(d: Date, n: number): Date {
+  const r = new Date(d);
+  r.setDate(r.getDate() + n);
+  return r;
+}
+
+function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function fmtTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function fmtDateHeading(d: Date): string {
+  return d.toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function itemDate(item: InboxItem): Date | null {
+  const iso = item.fireAt ?? item.firedAt ?? item.createdAt;
+  if (!iso) return null;
+  return new Date(iso);
+}
+
+function urgencyColor(item: InboxItem): string {
+  const meta = (item as unknown as { comms?: { urgency?: string } }).comms;
+  if (!meta) return "bg-[var(--text-muted)]";
+  if (meta.urgency === "expiring") return "bg-[#8E3DFF]";
+  if (meta.urgency === "time-sensitive") return "bg-amber-400";
+  return "bg-[var(--text-muted)]";
+}
+
+function platformIcon(item: InboxItem): IconName {
+  const meta = (item as unknown as { comms?: { platform?: string } }).comms;
+  if (!meta?.platform) return "ph:bell";
+  const map: Record<string, IconName> = {
+    twitter: "ph:twitter-logo",
+    linkedin: "ph:linkedin-logo",
+    instagram: "ph:instagram-logo",
+    tiktok: "ph:tiktok-logo",
+    discord: "ph:discord-logo",
+    telegram: "ph:telegram-logo",
+    bluesky: "ph:butterfly",
+  };
+  return (map[meta.platform] ?? "ph:bell") as IconName;
+}
+
+// ─── Item chip (shared across views) ──────────────────────────────────────────
+
+function ItemChip({
+  item,
+  onClick,
+}: {
+  item: InboxItem;
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex w-full items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-raised)] px-2 py-1 text-left text-[11px] hover:bg-[var(--bg-elevated)] transition-colors group"
+    >
+      <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${urgencyColor(item)}`} />
+      <Icon
+        name={platformIcon(item)}
+        className="shrink-0 text-[var(--text-muted)] text-[12px]"
+      />
+      <span className="flex-1 truncate text-[var(--text-primary)]">{item.title}</span>
+      {(item.fireAt ?? item.firedAt) && (
+        <span className="shrink-0 text-[var(--text-muted)]">
+          {fmtTime((item.fireAt ?? item.firedAt)!)}
+        </span>
+      )}
+    </button>
+  );
+}
+
+// ─── Agenda view ──────────────────────────────────────────────────────────────
+
+function AgendaView({
+  items,
+  anchor,
+  onOpenItem,
+}: {
+  items: InboxItem[];
+  anchor: Date;
+  onOpenItem?: (item: InboxItem) => void;
+}) {
+  // Group items by date, sorted ascending from anchor
+  const groups = useMemo(() => {
+    const map = new Map<string, { date: Date; items: InboxItem[] }>();
+    for (const item of items) {
+      const d = itemDate(item);
+      if (!d) continue;
+      const key = startOfDay(d).toISOString();
+      if (!map.has(key)) map.set(key, { date: startOfDay(d), items: [] });
+      map.get(key)!.items.push(item);
+    }
+    return Array.from(map.values())
+      .sort((a, b) => a.date.getTime() - b.date.getTime())
+      .filter((g) => g.date >= startOfDay(anchor));
+  }, [items, anchor]);
+
+  if (groups.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-[var(--text-muted)] text-sm gap-2">
+        <Icon name="ph:calendar-blank" className="text-3xl opacity-30" />
+        <span>Nothing scheduled</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 px-6 py-4 overflow-y-auto">
+      {groups.map(({ date, items: groupItems }) => (
+        <div key={date.toISOString()}>
+          <div className="mb-2 flex items-center gap-3">
+            <span
+              className={`text-[11px] font-semibold uppercase tracking-wider ${
+                isSameDay(date, new Date())
+                  ? "text-[#8E3DFF]"
+                  : "text-[var(--text-muted)]"
+              }`}
+            >
+              {isSameDay(date, new Date()) ? "Today" : fmtDateHeading(date)}
+            </span>
+            <div className="flex-1 h-px bg-[var(--border-subtle)]" />
+            <span className="text-[10px] text-[var(--text-muted)]">
+              {groupItems.length} item{groupItems.length !== 1 ? "s" : ""}
+            </span>
+          </div>
+          <div className="flex flex-col gap-1">
+            {groupItems
+              .sort((a, b) => {
+                const ta = new Date(a.fireAt ?? a.createdAt).getTime();
+                const tb = new Date(b.fireAt ?? b.createdAt).getTime();
+                return ta - tb;
+              })
+              .map((item) => (
+                <ItemChip
+                  key={item.id}
+                  item={item}
+                  onClick={() => onOpenItem?.(item)}
+                />
+              ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─── Day view ─────────────────────────────────────────────────────────────────
+
+function DayView({
+  items,
+  anchor,
+  onOpenItem,
+}: {
+  items: InboxItem[];
+  anchor: Date;
+  onOpenItem?: (item: InboxItem) => void;
+}) {
+  const dayItems = useMemo(
+    () =>
+      items
+        .filter((it) => {
+          const d = itemDate(it);
+          return d && isSameDay(d, anchor);
+        })
+        .sort((a, b) => {
+          const ta = new Date(a.fireAt ?? a.createdAt).getTime();
+          const tb = new Date(b.fireAt ?? b.createdAt).getTime();
+          return ta - tb;
+        }),
+    [items, anchor]
+  );
+
+  return (
+    <div className="flex flex-col px-6 py-4 gap-4 overflow-y-auto">
+      <h2 className="text-sm font-medium text-[var(--text-primary)]">
+        {fmtDateHeading(anchor)}
+      </h2>
+      {dayItems.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-12 text-[var(--text-muted)] text-sm gap-2">
+          <Icon name="ph:sun" className="text-3xl opacity-30" />
+          <span>Nothing scheduled for this day</span>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1">
+          {dayItems.map((item) => (
+            <ItemChip key={item.id} item={item} onClick={() => onOpenItem?.(item)} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Week view ────────────────────────────────────────────────────────────────
+
+function WeekView({
+  items,
+  anchor,
+  onOpenItem,
+}: {
+  items: InboxItem[];
+  anchor: Date;
+  onOpenItem?: (item: InboxItem) => void;
+}) {
+  const weekStart = startOfWeek(anchor);
+  const days = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+  const today = new Date();
+
+  const byDay = useMemo(() => {
+    const map = new Map<number, InboxItem[]>();
+    for (let i = 0; i < 7; i++) map.set(i, []);
+    for (const item of items) {
+      const d = itemDate(item);
+      if (!d) continue;
+      const idx = days.findIndex((day) => isSameDay(day, d));
+      if (idx >= 0) map.get(idx)!.push(item);
+    }
+    return map;
+  }, [items, days]);
+
+  return (
+    <div className="grid grid-cols-7 flex-1 overflow-hidden divide-x divide-[var(--border-subtle)]">
+      {days.map((day, i) => {
+        const dayItems = byDay.get(i) ?? [];
+        const isToday = isSameDay(day, today);
+        return (
+          <div key={i} className="flex flex-col overflow-hidden">
+            {/* Day header */}
+            <div
+              className={`px-2 py-2 text-center border-b border-[var(--border-subtle)] ${
+                isToday ? "bg-[#8E3DFF]/10" : ""
+              }`}
+            >
+              <div className="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
+                {WEEKDAYS[day.getDay()]}
+              </div>
+              <div
+                className={`text-sm font-semibold ${
+                  isToday ? "text-[#8E3DFF]" : "text-[var(--text-primary)]"
+                }`}
+              >
+                {day.getDate()}
+              </div>
+            </div>
+            {/* Items */}
+            <div className="flex flex-col gap-1 overflow-y-auto p-1.5">
+              {dayItems.map((item) => (
+                <button
+                  key={item.id}
+                  onClick={() => onOpenItem?.(item)}
+                  className="flex items-center gap-1 rounded px-1.5 py-1 text-left text-[10px] bg-[var(--bg-raised)] border border-[var(--border-subtle)] hover:bg-[var(--bg-elevated)] transition-colors w-full"
+                >
+                  <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${urgencyColor(item)}`} />
+                  <span className="truncate text-[var(--text-primary)]">{item.title}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Month view ───────────────────────────────────────────────────────────────
+
+function MonthView({
+  items,
+  anchor,
+  onOpenItem,
+  onDayClick,
+}: {
+  items: InboxItem[];
+  anchor: Date;
+  onOpenItem?: (item: InboxItem) => void;
+  onDayClick?: (day: Date) => void;
+}) {
+  const today = new Date();
+  const monthStart = startOfMonth(anchor);
+  const gridStart = startOfWeek(monthStart);
+
+  // 6 weeks × 7 days grid
+  const cells = Array.from({ length: 42 }, (_, i) => addDays(gridStart, i));
+
+  const byDay = useMemo(() => {
+    const map = new Map<string, InboxItem[]>();
+    for (const item of items) {
+      const d = itemDate(item);
+      if (!d) continue;
+      const key = startOfDay(d).toISOString();
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(item);
+    }
+    return map;
+  }, [items]);
+
+  return (
+    <div className="flex flex-col flex-1 overflow-hidden px-4 pb-4">
+      {/* Weekday headers */}
+      <div className="grid grid-cols-7 mb-1">
+        {WEEKDAYS.map((wd) => (
+          <div
+            key={wd}
+            className="py-1 text-center text-[10px] uppercase tracking-wider text-[var(--text-muted)]"
+          >
+            {wd}
+          </div>
+        ))}
+      </div>
+      {/* Day cells */}
+      <div className="grid grid-cols-7 grid-rows-6 flex-1 gap-px bg-[var(--border-subtle)] rounded-lg overflow-hidden">
+        {cells.map((day, i) => {
+          const key = startOfDay(day).toISOString();
+          const dayItems = byDay.get(key) ?? [];
+          const isCurrentMonth = day.getMonth() === anchor.getMonth();
+          const isToday = isSameDay(day, today);
+
+          return (
+            <div
+              key={i}
+              onClick={() => onDayClick?.(day)}
+              className={`flex flex-col p-1.5 cursor-pointer transition-colors overflow-hidden ${
+                isCurrentMonth
+                  ? "bg-[var(--bg-panel)] hover:bg-[var(--bg-raised)]"
+                  : "bg-[var(--bg-base)] hover:bg-[var(--bg-panel)]"
+              }`}
+            >
+              <span
+                className={`text-[11px] font-medium mb-1 w-5 h-5 flex items-center justify-center rounded-full ${
+                  isToday
+                    ? "bg-[#8E3DFF] text-white"
+                    : isCurrentMonth
+                    ? "text-[var(--text-primary)]"
+                    : "text-[var(--text-muted)]"
+                }`}
+              >
+                {day.getDate()}
+              </span>
+              <div className="flex flex-col gap-0.5 overflow-hidden">
+                {dayItems.slice(0, 3).map((item) => (
+                  <button
+                    key={item.id}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onOpenItem?.(item);
+                    }}
+                    className="flex items-center gap-1 rounded px-1 py-0.5 text-[9px] bg-[var(--bg-raised)] border border-[var(--border-subtle)] hover:bg-[var(--bg-elevated)] w-full text-left"
+                  >
+                    <span className={`h-1 w-1 shrink-0 rounded-full ${urgencyColor(item)}`} />
+                    <span className="truncate text-[var(--text-primary)]">{item.title}</span>
+                  </button>
+                ))}
+                {dayItems.length > 3 && (
+                  <span className="text-[9px] text-[var(--text-muted)] px-1">
+                    +{dayItems.length - 3} more
+                  </span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ─── Main CalendarView ────────────────────────────────────────────────────────
+
+export function CalendarView({ items, familiars, onOpenItem }: Props) {
+  const [viewMode, setViewMode] = useState<ViewMode>("week");
+  const [anchor, setAnchor] = useState<Date>(new Date());
+
+  function navigate(dir: -1 | 1) {
+    setAnchor((prev) => {
+      if (viewMode === "day") return addDays(prev, dir);
+      if (viewMode === "week") return addDays(prev, dir * 7);
+      if (viewMode === "month") {
+        const d = new Date(prev);
+        d.setMonth(d.getMonth() + dir);
+        return d;
+      }
+      // agenda: jump by 2 weeks
+      return addDays(prev, dir * 14);
+    });
+  }
+
+  function headingLabel(): string {
+    if (viewMode === "day") return fmtDateHeading(anchor);
+    if (viewMode === "week") {
+      const ws = startOfWeek(anchor);
+      const we = addDays(ws, 6);
+      if (ws.getMonth() === we.getMonth()) {
+        return `${MONTHS[ws.getMonth()]} ${ws.getDate()}–${we.getDate()}, ${ws.getFullYear()}`;
+      }
+      return `${MONTHS[ws.getMonth()]} ${ws.getDate()} – ${MONTHS[we.getMonth()]} ${we.getDate()}, ${ws.getFullYear()}`;
+    }
+    if (viewMode === "month") {
+      return `${MONTHS[anchor.getMonth()]} ${anchor.getFullYear()}`;
+    }
+    return "Upcoming";
+  }
+
+  const VIEW_MODES: { id: ViewMode; label: string }[] = [
+    { id: "agenda", label: "Agenda" },
+    { id: "day", label: "Day" },
+    { id: "week", label: "Week" },
+    { id: "month", label: "Month" },
+  ];
+
+  return (
+    <div className="flex flex-col h-full bg-[var(--bg-base)]">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-6 py-3 border-b border-[var(--border-subtle)] shrink-0">
+        {/* Nav arrows */}
+        <button
+          onClick={() => navigate(-1)}
+          className="grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] transition-colors"
+        >
+          <Icon name="ph:arrow-left-bold" />
+        </button>
+        <button
+          onClick={() => setAnchor(new Date())}
+          className="rounded-md border border-[var(--border-subtle)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] transition-colors"
+        >
+          Today
+        </button>
+        <button
+          onClick={() => navigate(1)}
+          className="grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] transition-colors"
+        >
+          <Icon name="ph:arrow-right-bold" />
+        </button>
+
+        {/* Heading */}
+        <h2 className="flex-1 text-sm font-semibold text-[var(--text-primary)]">
+          {headingLabel()}
+        </h2>
+
+        {/* Item count */}
+        <span className="text-[11px] text-[var(--text-muted)]">
+          {items.filter((i) => i.status === "pending").length} pending
+        </span>
+
+        {/* View mode toggle */}
+        <div className="flex items-center rounded-lg border border-[var(--border-subtle)] overflow-hidden">
+          {VIEW_MODES.map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setViewMode(id)}
+              className={`px-3 py-1 text-[11px] transition-colors ${
+                viewMode === id
+                  ? "bg-[#8E3DFF] text-white"
+                  : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* View body */}
+      <div className="flex-1 overflow-hidden flex flex-col">
+        {viewMode === "agenda" && (
+          <AgendaView items={items} anchor={anchor} onOpenItem={onOpenItem} />
+        )}
+        {viewMode === "day" && (
+          <DayView items={items} anchor={anchor} onOpenItem={onOpenItem} />
+        )}
+        {viewMode === "week" && (
+          <WeekView items={items} anchor={anchor} onOpenItem={onOpenItem} />
+        )}
+        {viewMode === "month" && (
+          <MonthView
+            items={items}
+            anchor={anchor}
+            onOpenItem={onOpenItem}
+            onDayClick={(day) => {
+              setAnchor(day);
+              setViewMode("day");
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -473,6 +473,8 @@ export function CalendarView({ items, familiars, onOpenItem }: Props) {
           aria-label="Previous"
           className="grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] transition-colors"
         >
+          <Icon name="ph:arrow-left-bold" width={12} />
+        </button>
         <button
           onClick={() => setAnchor(new Date())}
           className="rounded-md border border-[var(--border-subtle)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] transition-colors"

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -470,10 +470,9 @@ export function CalendarView({ items, familiars, onOpenItem }: Props) {
         {/* Nav arrows */}
         <button
           onClick={() => navigate(-1)}
+          aria-label="Previous"
           className="grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] transition-colors"
         >
-          <Icon name="ph:arrow-left-bold" />
-        </button>
         <button
           onClick={() => setAnchor(new Date())}
           className="rounded-md border border-[var(--border-subtle)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] transition-colors"

--- a/src/components/daemon-bar.tsx
+++ b/src/components/daemon-bar.tsx
@@ -7,7 +7,7 @@ import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 import { NotificationBell } from "@/components/notification-bell";
 import { HealthStrip } from "@/components/health-strip";
 
-export type Mode = "chats" | "board" | "inbox" | "plugins" | "browser" | "schedules" | "calls" | "comux" | "home";
+export type Mode = "chats" | "board" | "inbox" | "plugins" | "browser" | "schedules" | "calls" | "comux" | "home" | "calendar";
 
 type Props = {
   mode: Mode;
@@ -32,6 +32,7 @@ const MODE_LABEL: Record<Mode, string> = {
   schedules: "Automations",
   calls: "Coven Calls",
   comux: "Coven Code",
+  calendar: "Calendar",
 };
 
 export function DaemonBar({

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -246,8 +246,8 @@ function ShellInner({
             maxSize="38%"
             collapsible
             collapsedSize={0}
-            onExpand={() => setAgentOpen(true)}
-            onCollapse={() => setAgentOpen(false)}
+            panelRef={agentRef}
+            onResize={(size) => setAgentOpen((size.asPercentage ?? 0) > 0)}
           >
             <aside className="shell-agent">{agentOpen ? agent : null}</aside>
           </Panel>

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -324,6 +324,11 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
           label="Automations"
           onClick={() => onModeChange("schedules")}
         />
+        <ActionRow
+          icon={<Icon name="ph:calendar-blank" width={14} />}
+          label="Calendar"
+          onClick={() => onModeChange("calendar")}
+        />
       </div>
 
       {/* ── Folder mode rows ──────────────────────────────────── */}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -666,7 +666,19 @@ export function Workspace() {
     ) : mode === "comux" ? (
       <ComuxView />
     ) : mode === "calendar" ? (
-      <CalendarView items={inboxItems} familiars={familiars} />
+      <CalendarView
+        items={inboxItems}
+        familiars={familiars}
+        onOpenItem={(item) => {
+          if (item.sessionId) {
+            if (item.familiarId) setActiveId(item.familiarId);
+            setMode("chats");
+            setTimeout(() => routerRef.current?.openSession(item.sessionId!), 0);
+          } else {
+            setMode("inbox");
+          }
+        }}
+      />
     ) : (
       <PluginsView
         onOpenChat={() => {

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -7,6 +7,7 @@ import { DaemonBar } from "@/components/daemon-bar";
 import { CommandPalette, type PaletteIntent } from "@/components/command-palette";
 import { BoardView } from "@/components/board-view";
 import { PluginsView } from "@/components/plugins-view";
+import { CalendarView } from "@/components/calendar-view";
 import { OnboardingOverlay } from "@/components/onboarding-overlay";
 import { InboxEscalationsView } from "@/components/inbox-escalations-view";
 import { NewReminderModal, draftFromSlashArgs } from "@/components/new-reminder-modal";
@@ -27,7 +28,7 @@ import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { DEMO_MODE, DEMO_FAMILIARS } from "@/lib/demo-seed";
 
-type Mode = "home" | "chats" | "board" | "plugins" | "inbox" | "browser" | "schedules" | "calls" | "comux";
+type Mode = "home" | "chats" | "board" | "plugins" | "inbox" | "browser" | "schedules" | "calls" | "comux" | "calendar";
 
 export function Workspace() {
   const routerRef = useRef<ChatRouterHandle | null>(null);
@@ -664,6 +665,8 @@ export function Workspace() {
       <BrowserPane label="main" />
     ) : mode === "comux" ? (
       <ComuxView />
+    ) : mode === "calendar" ? (
+      <CalendarView items={inboxItems} familiars={familiars} />
     ) : (
       <PluginsView
         onOpenChat={() => {

--- a/src/lib/icon.tsx
+++ b/src/lib/icon.tsx
@@ -79,6 +79,15 @@ export const ICON_NAMES = [
   "ph:pencil-simple",
   "ph:list-bullets",
   "ph:trash",
+  "ph:butterfly",
+  "ph:telegram-logo",
+  "ph:discord-logo",
+  "ph:tiktok-logo",
+  "ph:instagram-logo",
+  "ph:linkedin-logo",
+  "ph:twitter-logo",
+  "ph:sun",
+  "ph:bell",
 ] as const;
 
 export type IconName = (typeof ICON_NAMES)[number];


### PR DESCRIPTION
## What

- **Root cause fixed:** Tauri v2 was not injecting `__TAURI_INTERNALS__` into the webview because `withGlobalTauri` was missing and the capability had no `local: false` flag for external-origin dev URLs. BottomTerminal silently fell into the placeholder path — xterm.js never mounted, PTY events had no listener.
- **Calendar view:** new sidebar nav entry + CalendarView component wired into workspace.
- **Debug utility:** `webview_probe_report` Tauri command for forwarding JS logs to Rust stderr (dev builds).
- **Cleanup:** stripped startup probe blocks from lib.rs; bumped v0.0.28 → v0.0.29.

## Files changed
- `src-tauri/tauri.conf.json` — `withGlobalTauri: true` + `dangerousRemoteDomainIpcAccess` for localhost
- `src-tauri/capabilities/default.json` — `local: false`
- `src-tauri/src/lib.rs` — add `webview_probe_report` cmd, remove probe scaffolding
- `src/components/bottom-terminal.tsx` — forward log lines to Rust via probe cmd
- `src/components/calendar-view.tsx` — new view
- `src/components/workspace.tsx` + `daemon-bar.tsx` + `sidebar-minimal.tsx` — calendar mode wiring
- `src/lib/icon.tsx` — calendar + social icons