### PR TITLE
feat(chat-list): email-style flat list with search and unreads toggle

### DIFF
--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, useEffect } from "react";
+import { useMemo, useState, useEffect, useRef } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { Icon } from "@/lib/icon";
 import { useKeySymbols } from "@/lib/platform-keys";
@@ -21,8 +21,13 @@ function age(iso: string): string {
   const m = Math.floor(s / 60);
   if (m < 60) return `${m}m ago`;
   const h = Math.floor(m / 60);
-  if (h < 48) return `${h}h ago`;
-  return `${Math.floor(h / 24)}d ago`;
+  if (h < 24) return `${h}h ago`;
+  if (h < 48) return "Yesterday";
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d} days ago`;
+  if (d < 14) return "1 week ago";
+  if (d < 21) return "2 weeks ago";
+  return `${Math.floor(d / 7)} weeks ago`;
 }
 
 /** Repo name — last non-empty path segment. */
@@ -32,43 +37,16 @@ function repoName(p: string): string {
   return parts[parts.length - 1] ?? p;
 }
 
-/** Two-segment short path for subtle secondary label. */
-function shortPath(p: string): string {
-  if (!p) return "";
-  const parts = p.replace(/\\/g, "/").split("/").filter(Boolean);
-  return parts.length > 2 ? `…/${parts.slice(-2).join("/")}` : parts.join("/");
-}
-
-const STATUS_STYLES: Record<string, { dot: string; label: string; text: string }> = {
-  running:   { dot: "bg-emerald-400 animate-pulse", label: "running",   text: "text-emerald-400" },
-  completed: { dot: "bg-[var(--text-muted)]",        label: "done",      text: "text-[var(--text-muted)]" },
-  failed:    { dot: "bg-rose-400",                   label: "failed",    text: "text-rose-400" },
-  queued:    { dot: "bg-amber-400",                  label: "queued",    text: "text-amber-400" },
-  paused:    { dot: "bg-sky-400",                    label: "paused",    text: "text-sky-400" },
+const STATUS_STYLES: Record<string, { dot: string; label: string; preview: string }> = {
+  running:   { dot: "bg-emerald-400 animate-pulse", label: "running",   preview: "text-emerald-400" },
+  completed: { dot: "bg-[var(--text-muted)]",        label: "done",      preview: "text-[var(--text-muted)]" },
+  failed:    { dot: "bg-rose-400",                   label: "failed",    preview: "text-rose-400" },
+  queued:    { dot: "bg-amber-400",                  label: "queued",    preview: "text-amber-400" },
+  paused:    { dot: "bg-sky-400",                    label: "paused",    preview: "text-sky-400" },
 };
 
 function statusStyle(s: string) {
   return STATUS_STYLES[s] ?? STATUS_STYLES.completed;
-}
-
-// ── Persisted collapse state ─────────────────────────────────────────────────
-
-const LS_KEY = "cave:chat-list:collapsed";
-
-function loadCollapsed(): Set<string> {
-  try {
-    const raw = localStorage.getItem(LS_KEY);
-    if (!raw) return new Set();
-    return new Set(JSON.parse(raw) as string[]);
-  } catch {
-    return new Set();
-  }
-}
-
-function saveCollapsed(set: Set<string>) {
-  try {
-    localStorage.setItem(LS_KEY, JSON.stringify([...set]));
-  } catch { /* storage full / SSR */ }
 }
 
 // ── Main component ────────────────────────────────────────────────────────────
@@ -76,23 +54,25 @@ function saveCollapsed(set: Set<string>) {
 export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat }: Props) {
   const [busyTuiId, setBusyTuiId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [search, setSearch] = useState("");
+  const [unreadsOnly, setUnreadsOnly] = useState(false);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
   const keys = useKeySymbols();
 
-  // Hydrate collapse state from localStorage after mount.
-  useEffect(() => { setCollapsed(loadCollapsed()); }, []);
+  // Focus search on Cmd+F / Ctrl+F
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "f") {
+        e.preventDefault();
+        searchRef.current?.focus();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
 
-  const toggleCollapse = (key: string) => {
-    setCollapsed((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      saveCollapsed(next);
-      return next;
-    });
-  };
-
-  // ── Data: filter → group ──────────────────────────────────────────────────
+  // ── Data: filter ──────────────────────────────────────────────────────────
 
   const mine = useMemo(() => {
     const DEAD = new Set(["killed", "orphaned", "stopped", "archived"]);
@@ -101,36 +81,19 @@ export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat 
       .sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1));
   }, [sessions, familiar.id]);
 
-  // Group by project_root. Sessions with no root go into the "general" bucket.
-  const { projectGroups, general } = useMemo(() => {
-    const map = new Map<string, SessionRow[]>();
-    const noProject: SessionRow[] = [];
-
-    for (const s of mine) {
-      const root = s.project_root?.trim() ?? "";
-      if (!root) {
-        noProject.push(s);
-      } else {
-        const existing = map.get(root) ?? [];
-        existing.push(s);
-        map.set(root, existing);
-      }
+  const filtered = useMemo(() => {
+    let rows = mine;
+    if (unreadsOnly) rows = rows.filter((s) => s.status === "running");
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      rows = rows.filter(
+        (s) =>
+          (s.title ?? "").toLowerCase().includes(q) ||
+          (s.project_root ?? "").toLowerCase().includes(q)
+      );
     }
-
-    // Sort groups by most recent session activity.
-    const groups = [...map.entries()]
-      .map(([root, rows]) => ({
-        root,
-        name: repoName(root),
-        path: shortPath(root),
-        rows,
-        latestAt: rows[0]?.updated_at ?? "",
-        hasRunning: rows.some((r) => r.status === "running"),
-      }))
-      .sort((a, b) => (a.latestAt < b.latestAt ? 1 : -1));
-
-    return { projectGroups: groups, general: noProject };
-  }, [mine]);
+    return rows;
+  }, [mine, search, unreadsOnly]);
 
   const hasAny = mine.length > 0;
 
@@ -159,36 +122,73 @@ export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat 
 
   return (
     <section className="flex h-full flex-col bg-[var(--bg-base)] text-[var(--text-primary)]">
-      {/* ── Header ── */}
-      <header className="flex items-center gap-2 border-b border-[var(--border-hairline)] px-4 py-2.5 text-[11px]">
-        <span className="font-semibold text-[var(--text-primary)]">{familiar.display_name}</span>
-        <span className="text-[var(--text-muted)]">·</span>
-        <span className="font-mono text-[var(--text-muted)]">{familiar.harness ?? "codex"}</span>
 
+      {/* ── Header ── */}
+      <header className="flex items-center gap-3 border-b border-[var(--border-hairline)] px-4 py-3">
+        <h2 className="text-[15px] font-semibold text-[var(--text-primary)]">
+          {familiar.display_name}
+        </h2>
+
+        {/* Unreads toggle */}
+        <button
+          type="button"
+          onClick={() => setUnreadsOnly((v) => !v)}
+          className={[
+            "flex items-center gap-1.5 rounded-full border px-3 py-1 text-[12px] font-medium transition-colors",
+            unreadsOnly
+              ? "border-emerald-500/40 bg-emerald-950/40 text-emerald-400"
+              : "border-[var(--border-hairline)] text-[var(--text-muted)] hover:border-[var(--text-muted)] hover:text-[var(--text-secondary)]",
+          ].join(" ")}
+        >
+          {unreadsOnly && (
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
+          )}
+          Unreads
+        </button>
+
+        {/* Daemon badge */}
         <span
-          className={`ml-1 flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ${
+          className={`flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[10px] font-medium ${
             daemonRunning
               ? "bg-emerald-950/60 text-emerald-400"
               : "bg-rose-950/60 text-rose-400"
           }`}
         >
           <span className={`inline-block h-1.5 w-1.5 rounded-full ${daemonRunning ? "bg-emerald-400 animate-pulse" : "bg-rose-400"}`} />
-          {daemonRunning ? "daemon running" : "daemon offline"}
+          {daemonRunning ? "daemon running" : "offline"}
         </span>
-
-        {mine.length > 0 && (
-          <span className="rounded-full bg-[var(--bg-raised)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">
-            {mine.length} {mine.length === 1 ? "chat" : "chats"}
-          </span>
-        )}
 
         <button
           onClick={() => onNewChat()}
-          className="ml-auto flex items-center gap-1 rounded-full bg-[var(--accent-presence)] px-3 py-1 text-[11px] font-medium text-white transition-opacity hover:opacity-80 active:scale-95"
+          className="ml-auto flex items-center gap-1 rounded-full bg-[var(--accent-presence)] px-3 py-1 text-[12px] font-medium text-white transition-opacity hover:opacity-80 active:scale-95"
         >
-          <span className="text-base leading-none">+</span> New chat
+          <span className="text-sm leading-none">+</span> New chat
         </button>
       </header>
+
+      {/* ── Search ── */}
+      <div className="border-b border-[var(--border-hairline)] px-3 py-2">
+        <label className="flex items-center gap-2 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-1.5 focus-within:border-[var(--accent-presence)]/60 transition-colors">
+          <Icon name="ph:magnifying-glass" width={14} className="shrink-0 text-[var(--text-muted)]" />
+          <input
+            ref={searchRef}
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Type to search…"
+            className="min-w-0 flex-1 bg-transparent text-[13px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none"
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => setSearch("")}
+              className="shrink-0 text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+            >
+              <Icon name="ph:x" width={12} />
+            </button>
+          )}
+        </label>
+      </div>
 
       {/* ── Error banner ── */}
       {error && (
@@ -197,7 +197,7 @@ export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat 
         </div>
       )}
 
-      {/* ── Body ── */}
+      {/* ── List ── */}
       <div className="min-h-0 flex-1 overflow-y-auto">
         {!hasAny ? (
           /* Empty state */
@@ -210,7 +210,7 @@ export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat 
               <p className="mt-1 text-[12px] text-[var(--text-muted)]">
                 {familiar.display_name} runs on{" "}
                 <code className="rounded bg-[var(--bg-raised)] px-1 font-mono text-[11px] text-[var(--text-secondary)]">
-                  {familiar.harness}
+                  {familiar.harness ?? "codex"}
                 </code>
                 {familiar.model ? (
                   <>
@@ -230,133 +230,104 @@ export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat 
               + New chat
             </button>
           </div>
+        ) : filtered.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-2 py-16 text-center">
+            <Icon name="ph:magnifying-glass" width={20} className="text-[var(--text-muted)]" />
+            <p className="text-sm text-[var(--text-muted)]">No results for "{search}"</p>
+            <button
+              type="button"
+              onClick={() => { setSearch(""); setUnreadsOnly(false); }}
+              className="text-[12px] text-[var(--accent-presence)] hover:underline"
+            >
+              Clear filters
+            </button>
+          </div>
         ) : (
-          <div className="px-3 py-3 flex flex-col gap-4">
-
-            {/* ── Project groups ── */}
-            {projectGroups.map((group) => {
-              const isCollapsed = collapsed.has(group.root);
-              const running = group.rows.filter((s) => s.status === "running");
-              const idle    = group.rows.filter((s) => s.status !== "running");
+          <ul className="divide-y divide-[var(--border-hairline)]">
+            {filtered.map((s) => {
+              const st = statusStyle(s.status);
+              const project = repoName(s.project_root ?? "");
+              const isActive = activeId === s.id;
 
               return (
-                <div key={group.root}>
-                  {/* Group header */}
-                  <div className="group/hdr mb-1.5 flex items-center gap-1.5 px-1">
-                    <button
-                      type="button"
-                      onClick={() => toggleCollapse(group.root)}
-                      className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
-                    >
-                      <Icon
-                        name="ph:caret-right-bold"
-                        width={10}
-                        className={`shrink-0 text-[var(--text-muted)] transition-transform duration-150 ${isCollapsed ? "" : "rotate-90"}`}
-                      />
-                      <Icon name="ph:folder" width={13} className="shrink-0 text-[var(--text-muted)]" />
-                      <span className="truncate text-[11px] font-semibold text-[var(--text-secondary)]">
-                        {group.name}
-                      </span>
-                      {group.hasRunning && (
-                        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-400 animate-pulse" />
-                      )}
-                      <span className="ml-1 rounded-full bg-[var(--bg-raised)] px-1.5 py-0.5 text-[9px] text-[var(--text-muted)]">
-                        {group.rows.length}
-                      </span>
-                    </button>
+                <li key={s.id}>
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => { setActiveId(s.id); onOpen(s.id); }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") { setActiveId(s.id); onOpen(s.id); }
+                    }}
+                    className={[
+                      "group relative flex cursor-pointer gap-3 px-4 py-3.5 transition-colors",
+                      isActive
+                        ? "bg-[var(--bg-raised)]"
+                        : "hover:bg-[var(--bg-raised)]/50",
+                    ].join(" ")}
+                  >
+                    {/* Active indicator */}
+                    {isActive && (
+                      <span className="absolute left-0 top-1/2 -translate-y-1/2 w-[2px] h-8 rounded-r-full bg-[var(--accent-presence)]" />
+                    )}
 
-                    {/* New chat in project — revealed on hover */}
+                    {/* Status dot (top-aligned) */}
+                    <span className="mt-[5px] shrink-0">
+                      <span
+                        className={`block h-2 w-2 rounded-full ${st.dot}`}
+                        title={st.label}
+                      />
+                    </span>
+
+                    {/* Content */}
+                    <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      {/* Row 1: familiar/project name + timestamp */}
+                      <span className="flex items-baseline justify-between gap-2">
+                        <span className="flex items-center gap-1.5 min-w-0">
+                          <span className="truncate text-[12px] font-medium text-[var(--text-secondary)]">
+                            {project || familiar.display_name}
+                          </span>
+                          {s.origin ? <OriginChip origin={s.origin} /> : null}
+                        </span>
+                        <span className="shrink-0 text-[11px] text-[var(--text-muted)]">
+                          {age(s.updated_at)}
+                        </span>
+                      </span>
+
+                      {/* Row 2: session title (bold subject line) */}
+                      <span className="truncate text-[13px] font-semibold text-[var(--text-primary)]">
+                        {s.title || "(untitled chat)"}
+                      </span>
+
+                      {/* Row 3: status preview */}
+                      <span className={`truncate text-[12px] ${st.preview}`}>
+                        {st.label === "running"
+                          ? "Active now…"
+                          : st.label === "failed"
+                            ? "Ended with an error"
+                            : st.label === "queued"
+                              ? "Waiting to start"
+                              : st.label === "paused"
+                                ? "Paused"
+                                : project
+                                  ? `${familiar.display_name} · ${project}`
+                                  : `${familiar.display_name}`}
+                      </span>
+                    </span>
+
+                    {/* TUI button — revealed on hover */}
                     <button
-                      type="button"
-                      onClick={() => onNewChat(group.root)}
-                      title={`New chat in ${group.name}`}
-                      className="shrink-0 rounded px-1.5 py-0.5 text-[10px] text-[var(--text-muted)] opacity-0 transition-opacity hover:bg-[var(--bg-raised)] hover:text-[var(--accent-presence)] group-hover/hdr:opacity-100"
+                      onClick={(e) => openInTui(e, s.id)}
+                      disabled={busyTuiId === s.id}
+                      title="Open in Coven Code TUI"
+                      className="self-center shrink-0 rounded border border-[var(--border-hairline)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)] opacity-0 transition-all hover:bg-[var(--bg-raised)] group-hover:opacity-100 disabled:opacity-40"
                     >
-                      + new
+                      {busyTuiId === s.id ? "…" : "tui →"}
                     </button>
                   </div>
-
-                  {/* Rows */}
-                  {!isCollapsed && (
-                    <div className="flex flex-col gap-2">
-                      {running.length > 0 && (
-                        <ChatRows
-                          rows={running}
-                          onOpen={onOpen}
-                          busyTuiId={busyTuiId}
-                          openInTui={openInTui}
-                          hideProjectPath
-                        />
-                      )}
-                      {idle.length > 0 && (
-                        <ChatRows
-                          rows={idle}
-                          onOpen={onOpen}
-                          busyTuiId={busyTuiId}
-                          openInTui={openInTui}
-                          hideProjectPath
-                        />
-                      )}
-                    </div>
-                  )}
-                </div>
+                </li>
               );
             })}
-
-            {/* ── General (no project) ── */}
-            {general.length > 0 && (
-              <div>
-                <div className="group/hdr mb-1.5 flex items-center gap-1.5 px-1">
-                  <button
-                    type="button"
-                    onClick={() => toggleCollapse("__general__")}
-                    className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
-                  >
-                    <Icon
-                      name="ph:caret-right-bold"
-                      width={10}
-                      className={`shrink-0 text-[var(--text-muted)] transition-transform duration-150 ${collapsed.has("__general__") ? "" : "rotate-90"}`}
-                    />
-                    <Icon name="ph:chat-circle-dots" width={13} className="shrink-0 text-[var(--text-muted)]" />
-                    <span className="truncate text-[11px] font-semibold text-[var(--text-secondary)]">
-                      General
-                    </span>
-                    <span className="ml-1 rounded-full bg-[var(--bg-raised)] px-1.5 py-0.5 text-[9px] text-[var(--text-muted)]">
-                      {general.length}
-                    </span>
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => onNewChat()}
-                    title="New general chat"
-                    className="shrink-0 rounded px-1.5 py-0.5 text-[10px] text-[var(--text-muted)] opacity-0 transition-opacity hover:bg-[var(--bg-raised)] hover:text-[var(--accent-presence)] group-hover/hdr:opacity-100"
-                  >
-                    + new
-                  </button>
-                </div>
-
-                {!collapsed.has("__general__") && (
-                  <ChatRows
-                    rows={general}
-                    onOpen={onOpen}
-                    busyTuiId={busyTuiId}
-                    openInTui={openInTui}
-                    hideProjectPath={false}
-                  />
-                )}
-              </div>
-            )}
-
-            {/* Sparse nudge */}
-            {mine.length <= 3 && (
-              <button
-                onClick={() => onNewChat()}
-                className="w-full rounded-xl border border-dashed border-[var(--border-hairline)] py-3 text-[12px] text-[var(--text-muted)] transition-colors hover:border-[var(--accent-presence)] hover:text-[var(--accent-presence)]"
-              >
-                + start a new conversation
-              </button>
-            )}
-          </div>
+          </ul>
         )}
       </div>
 
@@ -365,71 +336,5 @@ export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat 
         {keys.enter} open · {keys.mod}K palette · / commands in chat
       </footer>
     </section>
-  );
-}
-
-// ── Row sub-component ────────────────────────────────────────────────────────
-
-type RowProps = {
-  rows: SessionRow[];
-  onOpen: (id: string) => void;
-  busyTuiId: string | null;
-  openInTui: (e: React.MouseEvent, id: string) => void;
-  hideProjectPath?: boolean;
-};
-
-function ChatRows({ rows, onOpen, busyTuiId, openInTui, hideProjectPath }: RowProps) {
-  return (
-    <ul className="overflow-hidden rounded-xl border border-[var(--border-hairline)] divide-y divide-[var(--border-hairline)]">
-      {rows.map((s) => {
-        const st = statusStyle(s.status);
-        return (
-          <li key={s.id}>
-            <div
-              role="button"
-              tabIndex={0}
-              onClick={() => onOpen(s.id)}
-              onKeyDown={(e) => { if (e.key === "Enter") onOpen(s.id); }}
-              className="group flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-[var(--bg-raised)]/50"
-            >
-              {/* Status dot */}
-              <span className={`mt-0.5 h-2 w-2 shrink-0 rounded-full ${st.dot}`} title={st.label} />
-
-              {/* Title + meta */}
-              <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                <span className="flex min-w-0 items-center gap-2">
-                  <span className="truncate text-[13px] font-medium text-[var(--text-primary)]">
-                    {s.title || "(untitled chat)"}
-                  </span>
-                  {s.origin ? <OriginChip origin={s.origin} /> : null}
-                </span>
-                <span className="flex items-center gap-1.5 text-[10px] text-[var(--text-muted)]">
-                  <span className={`font-mono ${st.text}`}>{st.label}</span>
-                  {!hideProjectPath && s.project_root && (
-                    <>
-                      <span>·</span>
-                      <span className="truncate font-mono">{shortPath(s.project_root)}</span>
-                    </>
-                  )}
-                </span>
-              </span>
-
-              {/* Age */}
-              <span className="shrink-0 text-[10px] text-[var(--text-muted)]">{age(s.updated_at)}</span>
-
-              {/* TUI button — revealed on hover */}
-              <button
-                onClick={(e) => openInTui(e, s.id)}
-                disabled={busyTuiId === s.id}
-                title="Open in Coven Code TUI"
-                className="shrink-0 rounded border border-[var(--border-hairline)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)] opacity-0 transition-all hover:bg-[var(--bg-raised)] group-hover:opacity-100 disabled:opacity-40"
-              >
-                {busyTuiId === s.id ? "…" : "tui →"}
-              </button>
-            </div>
-          </li>
-        );
-      })}
-    </ul>
   );
 }

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -293,8 +293,15 @@ export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat 
                         </span>
                       </span>
 
-                      {/* Row 2: session title (bold subject line) */}
-                      <span className="truncate text-[13px] font-semibold text-[var(--text-primary)]">
+                      {/* Row 2: session title (bold subject line)
+                           Running sessions get full white; others are slightly muted
+                           — mirrors the unread/read convention in email clients. */}
+                      <span className={[
+                        "truncate text-[13px] font-semibold",
+                        s.status === "running"
+                          ? "text-white"
+                          : "text-[var(--text-primary)]",
+                      ].join(" ")}>
                         {s.title || "(untitled chat)"}
                       </span>
 


### PR DESCRIPTION
## What

Replaces the collapsible project-group layout in the chat list with a flat, email-inbox style list matching Val's reference screenshot.

## Layout per row

```
[status dot]  project/familiar          timestamp
              Session title (bold)
              status preview line
```

- **Row 1:** project name (or familiar name if no project) left-aligned + relative age right-aligned
- **Row 2:** session title in semibold — the "subject line"
- **Row 3:** color-coded status preview (running → "Active now…", failed → "Ended with an error", done → familiar·project, etc.)

## New chrome

- **Inline search bar** at top (Cmd+F to focus; clears with ×)
- **Unreads toggle** (filters to `running` sessions only — shows a pulsing dot when active)
- **Active-session highlight** — left accent bar + raised background
- Empty search state with "Clear filters" nudge

## Removed

- Collapsible project group headers
- LocalStorage collapse state key (`cave:chat-list:collapsed`)

## Kept

- Daemon badge + New-chat button in header
- TUI button on hover per row
- Empty state (no sessions)
- All existing `onOpen` / `onNewChat` / `openInTui` wiring unchanged

## Verified

- `pnpm typecheck` — clean