### PR TITLE
feat(chat): Task 1 — iMessage-style lavender user bubble

### DIFF
--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -427,11 +427,11 @@ export function MessageBubble({ role, content, timestamp, pending, isError }: Me
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
       >
-        <div className="relative max-w-[80%] rounded-2xl bg-[var(--bg-raised)]/70 px-4 py-2.5">
+        <div className="relative cave-bubble-user">
           <MarkdownContent text={content} pending={pending} />
           {hovered && !pending && <CopyBubble text={content} />}
         </div>
-        <div className="mt-1 text-[10px] text-[var(--text-muted)]">{fmtBubbleTime(timestamp)}</div>
+        <div className="mt-1 text-[11px] text-[var(--text-muted)]">{fmtBubbleTime(timestamp)}</div>
       </div>
     );
   }
@@ -439,7 +439,7 @@ export function MessageBubble({ role, content, timestamp, pending, isError }: Me
   // Assistant
   return (
     <div
-      className="group relative"
+      className="group relative cave-bubble-assistant"
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -386,7 +386,7 @@
 
 /* User bubble — lavender accent, right-aligned */
 .cave-bubble-user {
-  background: var(--accent-presence);
+  background: color-mix(in oklch, var(--accent-presence) 70%, var(--bg-base));
   color: oklch(0.98 0 0);
   border-radius: 18px 18px 4px 18px;
   padding: 10px 14px;

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -379,3 +379,41 @@
 }
 .cave-syntax-block .cave-code-header { padding: 3px 10px; min-height: 24px; }
 .cave-syntax-block pre { font-size: inherit; }
+
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   BUBBLE VARIANTS
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+
+/* User bubble — lavender accent, right-aligned */
+.cave-bubble-user {
+  background: var(--accent-presence);
+  color: oklch(0.98 0 0);
+  border-radius: 18px 18px 4px 18px;
+  padding: 10px 14px;
+  max-width: min(80%, 520px);
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  box-shadow:
+    0 1px 3px oklch(0 0 0 / 25%),
+    0 0 0 1px color-mix(in oklch, var(--accent-presence) 80%, transparent);
+  -webkit-font-smoothing: antialiased;
+}
+
+.cave-bubble-user a {
+  color: oklch(0.98 0 0);
+  text-decoration-color: oklch(0.98 0 0 / 50%);
+}
+.cave-bubble-user a:hover {
+  text-decoration-color: oklch(0.98 0 0);
+}
+
+.cave-bubble-user :not(pre) > code {
+  background: oklch(0 0 0 / 18%);
+  color: oklch(0.98 0 0);
+  border-color: oklch(0 0 0 / 12%);
+}
+
+/* Assistant bubble — transparent, full width */
+.cave-bubble-assistant {
+  width: 100%;
+}


### PR DESCRIPTION
- Replaces muted glass user bubble with --accent-presence lavender background
- border-radius: 18px 18px 4px 18px (iMessage-style tail)
- White text, inner code/link overrides for contrast
- .cave-bubble-assistant class added for assistant turns

Part of Coven Cave chat presentation overhaul.