### PR TITLE
feat(chat): Task 3 — ChatEmptyState uses real FamiliarGlyph

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -115,7 +115,7 @@ function ChatEmptyState({
   modKey: string;
   onPrompt?: (text: string) => void;
 }) {
-  const glyph = parseGlyphString(familiar.icon ?? familiar.emoji) ?? DEFAULT_FAMILIAR_GLYPH;
+  const glyph = parseGlyphString(familiar.icon) ?? parseGlyphString(familiar.emoji) ?? DEFAULT_FAMILIAR_GLYPH;
 
   return (
     <div className="flex flex-col items-center justify-center py-16 px-6 select-none">

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -7,6 +7,8 @@ import { MessageBubble, SyntaxBlock } from "@/components/message-bubble";
 import { canonicalize, formatHelp, matchSlash, type SlashCommand } from "@/lib/slash-commands";
 import { Icon } from "@/lib/icon";
 import { useKeySymbols } from "@/lib/platform-keys";
+import { FamiliarGlyph } from "@/components/familiar-glyph";
+import { parseGlyphString, DEFAULT_FAMILIAR_GLYPH } from "@/lib/familiar-glyph";
 
 type ToolEvent = {
   id: string;
@@ -113,21 +115,21 @@ function ChatEmptyState({
   modKey: string;
   onPrompt?: (text: string) => void;
 }) {
-  const glyph = familiar.display_name?.[0]?.toUpperCase() ?? "?";
+  const glyph = parseGlyphString(familiar.icon ?? familiar.emoji) ?? DEFAULT_FAMILIAR_GLYPH;
 
   return (
     <div className="flex flex-col items-center justify-center py-16 px-6 select-none">
       {/* Avatar ring */}
       <div
-        className="mb-5 flex h-16 w-16 items-center justify-center rounded-2xl text-2xl font-semibold shadow-lg"
+        className="mb-5 flex h-16 w-16 items-center justify-center rounded-2xl shadow-lg"
         style={{
           background: "linear-gradient(135deg, rgba(255,255,255,0.07) 0%, rgba(255,255,255,0.03) 100%)",
           border: "1px solid rgba(255,255,255,0.08)",
-          color: "rgba(255,255,255,0.7)",
+          color: "var(--accent-presence)",
         }}
         aria-hidden
       >
-        {glyph}
+        <FamiliarGlyph glyph={glyph} size="lg" />
       </div>
 
       {/* Name + tagline */}

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -129,7 +129,7 @@ function ChatEmptyState({
         }}
         aria-hidden
       >
-        <FamiliarGlyph glyph={glyph} size="lg" />
+        <FamiliarGlyph glyph={glyph} size="lg" className="inline-flex items-center justify-center" />
       </div>
 
       {/* Name + tagline */}

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -427,11 +427,11 @@ export function MessageBubble({ role, content, timestamp, pending, isError }: Me
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
       >
-        <div className="relative max-w-[80%] rounded-2xl bg-[var(--bg-raised)]/70 px-4 py-2.5">
+        <div className="relative cave-bubble-user">
           <MarkdownContent text={content} pending={pending} />
           {hovered && !pending && <CopyBubble text={content} />}
         </div>
-        <div className="mt-1 text-[10px] text-[var(--text-muted)]">{fmtBubbleTime(timestamp)}</div>
+        <div className="mt-1 text-[11px] text-[var(--text-muted)]">{fmtBubbleTime(timestamp)}</div>
       </div>
     );
   }
@@ -439,7 +439,7 @@ export function MessageBubble({ role, content, timestamp, pending, isError }: Me
   // Assistant
   return (
     <div
-      className="group relative"
+      className="group relative cave-bubble-assistant"
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -385,6 +385,7 @@
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
 
 /* User bubble — lavender accent, right-aligned */
+/* User bubble — lavender accent, right-aligned */
 .cave-bubble-user {
   background: var(--accent-presence);
   color: oklch(0.98 0 0);
@@ -397,6 +398,16 @@
     0 1px 3px oklch(0 0 0 / 25%),
     0 0 0 1px color-mix(in oklch, var(--accent-presence) 80%, transparent);
   -webkit-font-smoothing: antialiased;
+}
+
+/* Ensure markdown body inherits the bubble text color (cave-md sets its own color by default). */
+.cave-bubble-user .cave-md { color: inherit; }
+.cave-bubble-user .cave-md h1,
+.cave-bubble-user .cave-md h2,
+.cave-bubble-user .cave-md h3,
+.cave-bubble-user .cave-md h4,
+.cave-bubble-user .cave-md strong {
+  color: inherit;
 }
 
 .cave-bubble-user a {

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -379,3 +379,41 @@
 }
 .cave-syntax-block .cave-code-header { padding: 3px 10px; min-height: 24px; }
 .cave-syntax-block pre { font-size: inherit; }
+
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   BUBBLE VARIANTS
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+
+/* User bubble — lavender accent, right-aligned */
+.cave-bubble-user {
+  background: var(--accent-presence);
+  color: oklch(0.98 0 0);
+  border-radius: 18px 18px 4px 18px;
+  padding: 10px 14px;
+  max-width: min(80%, 520px);
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  box-shadow:
+    0 1px 3px oklch(0 0 0 / 25%),
+    0 0 0 1px color-mix(in oklch, var(--accent-presence) 80%, transparent);
+  -webkit-font-smoothing: antialiased;
+}
+
+.cave-bubble-user a {
+  color: oklch(0.98 0 0);
+  text-decoration-color: oklch(0.98 0 0 / 50%);
+}
+.cave-bubble-user a:hover {
+  text-decoration-color: oklch(0.98 0 0);
+}
+
+.cave-bubble-user :not(pre) > code {
+  background: oklch(0 0 0 / 18%);
+  color: oklch(0.98 0 0);
+  border-color: oklch(0 0 0 / 12%);
+}
+
+/* Assistant bubble — transparent, full width */
+.cave-bubble-assistant {
+  width: 100%;
+}


### PR DESCRIPTION
- Replaces hand-rolled letter glyph (first char of display_name) with parseGlyphString → FamiliarGlyph\n- Falls back to DEFAULT_FAMILIAR_GLYPH (ph:sparkle-fill) when no icon/emoji set\n- Avatar ring colour changed to --accent-presence\n\nPart of Coven Cave chat presentation overhaul.