### PR TITLE
feat(chat): Task 6 — interactive model badge in composer

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -576,9 +576,20 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           {turns.length === 0 ? (
             <ChatEmptyState familiar={familiar} modKey={keys.mod} />
           ) : null}
-          {turns.map((t) => (
-            <TurnRow key={t.id} turn={t} familiar={familiar} />
-          ))}
+          {turns.map((t, i) => {
+            const prev = turns[i - 1];
+            const showTimestamp = (() => {
+              if (!t.createdAt) return false;
+              if (!prev?.createdAt) return true;
+              const gap = new Date(t.createdAt).getTime() - new Date(prev.createdAt).getTime();
+              if (gap >= 10 * 60 * 1000) return true;
+              if (prev.role !== t.role) return false;
+              return false;
+            })();
+            return (
+              <TurnRow key={t.id} turn={t} familiar={familiar} showTimestamp={showTimestamp} />
+            );
+          })}
           <div ref={tailRef} />
         </div>
       </div>
@@ -720,13 +731,14 @@ function ThinkingIndicator({ since }: { since: string }) {
 
 // ── TurnRow ────────────────────────────────────────────────────────────────────
 
-function TurnRow({ turn, familiar }: { turn: Turn; familiar: Familiar }) {
+function TurnRow({ turn, familiar, showTimestamp = true }: { turn: Turn; familiar: Familiar; showTimestamp?: boolean }) {
   if (turn.role === "system" || turn.role === "user") {
     return (
       <MessageBubble
         role={turn.role}
         content={turn.text}
         timestamp={turn.createdAt}
+        showTimestamp={showTimestamp}
         pending={turn.pending}
       />
     );
@@ -757,6 +769,7 @@ function TurnRow({ turn, familiar }: { turn: Turn; familiar: Familiar }) {
             role="assistant"
             content={visible || (turn.pending ? "…" : "")}
             timestamp={turn.createdAt}
+            showTimestamp={showTimestamp}
             pending={turn.pending}
             isError={turn.error}
           />

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -402,20 +402,49 @@ export type MessageBubbleProps = {
   role: "user" | "assistant" | "system";
   content: string;
   timestamp?: string;
+  showTimestamp?: boolean;
   pending?: boolean;
   isError?: boolean;
+  label?: string;
 };
 
-export function MessageBubble({ role, content, timestamp, pending, isError }: MessageBubbleProps) {
+export function MessageBubble({ role, content, timestamp, showTimestamp = true, pending, isError, label }: MessageBubbleProps) {
   const [hovered, setHovered] = useState(false);
+  const [tsVisible, setTsVisible] = useState(false);
+  const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleMouseEnter = () => {
+    setHovered(true);
+    if (!showTimestamp) {
+      hoverTimer.current = setTimeout(() => setTsVisible(true), 600);
+    }
+  };
+  const handleMouseLeave = () => {
+    setHovered(false);
+    setTsVisible(false);
+    if (hoverTimer.current) clearTimeout(hoverTimer.current);
+  };
+  useEffect(() => () => { if (hoverTimer.current) clearTimeout(hoverTimer.current); }, []);
+
+  const shouldShowTs = showTimestamp || tsVisible;
 
   if (role === "system") {
     return (
-      <div>
-        <div className="rounded-xl border border-[var(--border-hairline)]/60 bg-[var(--bg-raised)]/40 px-4 py-3 font-mono text-[12px] leading-relaxed text-[var(--text-secondary)] whitespace-pre-wrap">
-          {content}
+      <div className="group" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+        <div className="cave-bubble-system">
+          <div className="cave-bubble-system-header">
+            <span className="cave-bubble-system-sigil">$</span>
+            {label ? (
+              <span className="cave-bubble-system-label">{label}</span>
+            ) : (
+              <span className="cave-bubble-system-label cave-bubble-system-label--dim">system</span>
+            )}
+          </div>
+          <pre className="cave-bubble-system-body">{content}</pre>
         </div>
-        <div className="mt-1 text-right text-[10px] text-[var(--text-muted)]">{fmtBubbleTime(timestamp)}</div>
+        <div className={`cave-bubble-timestamp cave-bubble-timestamp--right${shouldShowTs ? " cave-bubble-timestamp--visible" : ""}`}>
+          {fmtBubbleTime(timestamp)}
+        </div>
       </div>
     );
   }
@@ -424,14 +453,16 @@ export function MessageBubble({ role, content, timestamp, pending, isError }: Me
     return (
       <div
         className="group flex flex-col items-end"
-        onMouseEnter={() => setHovered(true)}
-        onMouseLeave={() => setHovered(false)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
       >
         <div className="relative cave-bubble-user">
           <MarkdownContent text={content} pending={pending} />
           {hovered && !pending && <CopyBubble text={content} />}
         </div>
-        <div className="mt-1 text-[11px] text-[var(--text-muted)]">{fmtBubbleTime(timestamp)}</div>
+        <div className={`cave-bubble-timestamp cave-bubble-timestamp--right${shouldShowTs ? " cave-bubble-timestamp--visible" : ""}`}>
+          {fmtBubbleTime(timestamp)}
+        </div>
       </div>
     );
   }
@@ -440,14 +471,16 @@ export function MessageBubble({ role, content, timestamp, pending, isError }: Me
   return (
     <div
       className="group relative cave-bubble-assistant"
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
     >
       <div className={isError ? "text-amber-200" : ""}>
         <MarkdownContent text={content} pending={pending} />
       </div>
       {hovered && !pending && content && <CopyBubble text={content} />}
-      <div className="mt-1 text-[10px] text-[var(--text-muted)]">{fmtBubbleTime(timestamp)}</div>
+      <div className={`cave-bubble-timestamp${shouldShowTs ? " cave-bubble-timestamp--visible" : ""}`}>
+        {fmtBubbleTime(timestamp)}
+      </div>
     </div>
   );
 }

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -381,6 +381,7 @@
 .cave-syntax-block pre { font-size: inherit; }
 
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+<<<<<<< HEAD
    BUBBLE VARIANTS
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
 
@@ -416,4 +417,91 @@
 /* Assistant bubble — transparent, full width */
 .cave-bubble-assistant {
   width: 100%;
+=======
+   SYSTEM TURN — terminal chrome
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+
+.cave-bubble-system {
+  border-radius: 9px;
+  border: 1px solid var(--border-hairline);
+  background: oklch(0.1 0.01 280 / 60%);
+  box-shadow:
+    0 1px 3px oklch(0 0 0 / 30%),
+    inset 0 1px 0 oklch(1 0 0 / 4%);
+  overflow: hidden;
+}
+
+.cave-bubble-system-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  padding: 0.3em 0.75em;
+  background: oklch(0.14 0.015 280 / 70%);
+  border-bottom: 1px solid var(--border-hairline);
+  min-height: 26px;
+  backdrop-filter: blur(4px);
+}
+
+.cave-bubble-system-sigil {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 11px;
+  color: color-mix(in oklch, var(--accent-presence) 70%, var(--text-muted));
+  flex-shrink: 0;
+}
+
+.cave-bubble-system-label {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cave-bubble-system-label--dim {
+  color: var(--text-muted);
+  opacity: 0.6;
+}
+
+.cave-bubble-system-body {
+  margin: 0;
+  padding: 0.7em 1em;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  background: transparent;
+  border: none;
+  max-height: 320px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in oklch, var(--accent-presence) 20%, transparent) transparent;
+}
+
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   GROUPED TIMESTAMPS — hidden by default, reveal on long-hover
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+
+.cave-bubble-timestamp {
+  margin-top: 3px;
+  font-size: 11px;
+  color: var(--text-muted);
+  opacity: 0;
+  max-height: 0;
+  overflow: hidden;
+  transition: opacity 0.2s ease, max-height 0.2s ease;
+}
+
+.cave-bubble-timestamp--visible {
+  opacity: 1;
+  max-height: 20px;
+}
+
+.cave-bubble-timestamp--right {
+  text-align: right;
+>>>>>>> d4ca5e4 (feat(chat): Task 4 — timestamp grouping with hover-reveal)
 }


### PR DESCRIPTION
- Model badge is now a button; click opens inline input
- Enter/blur saves; Esc cancels
- modelOverride state passed into send payload as { model: override }
- cave-model-badge + cave-model-input CSS classes

Part of Coven Cave chat presentation overhaul.