### PR TITLE
feat(chat): Task 5 — system message terminal chrome

### DIFF
--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -426,9 +426,9 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
           </div>
           <pre className="cave-bubble-system-body">{content}</pre>
         </div>
-        <div className="mt-1 text-right text-[11px] text-[var(--text-muted)]">
-          {fmtBubbleTime(timestamp)}
-        </div>
+{shouldShowTs && timestamp ? (
+  <div className="mt-1 text-right text-[11px] text-[var(--text-muted)]">{fmtBubbleTime(timestamp)}</div>
+) : null}
       </div>
     );
   }

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -402,20 +402,33 @@ export type MessageBubbleProps = {
   role: "user" | "assistant" | "system";
   content: string;
   timestamp?: string;
+  showTimestamp?: boolean;
   pending?: boolean;
   isError?: boolean;
+  label?: string;
 };
 
-export function MessageBubble({ role, content, timestamp, pending, isError }: MessageBubbleProps) {
+export function MessageBubble({ role, content, timestamp, showTimestamp = true, pending, isError, label }: MessageBubbleProps) {
   const [hovered, setHovered] = useState(false);
+  const shouldShowTs = showTimestamp;
 
   if (role === "system") {
     return (
-      <div>
-        <div className="rounded-xl border border-[var(--border-hairline)]/60 bg-[var(--bg-raised)]/40 px-4 py-3 font-mono text-[12px] leading-relaxed text-[var(--text-secondary)] whitespace-pre-wrap">
-          {content}
+      <div className="group">
+        <div className="cave-bubble-system">
+          <div className="cave-bubble-system-header">
+            <span className="cave-bubble-system-sigil">$</span>
+            {label ? (
+              <span className="cave-bubble-system-label">{label}</span>
+            ) : (
+              <span className="cave-bubble-system-label cave-bubble-system-label--dim">system</span>
+            )}
+          </div>
+          <pre className="cave-bubble-system-body">{content}</pre>
         </div>
-        <div className="mt-1 text-right text-[10px] text-[var(--text-muted)]">{fmtBubbleTime(timestamp)}</div>
+        <div className="mt-1 text-right text-[11px] text-[var(--text-muted)]">
+          {fmtBubbleTime(timestamp)}
+        </div>
       </div>
     );
   }

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -379,3 +379,68 @@
 }
 .cave-syntax-block .cave-code-header { padding: 3px 10px; min-height: 24px; }
 .cave-syntax-block pre { font-size: inherit; }
+
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   SYSTEM TURN — terminal chrome
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+
+.cave-bubble-system {
+  border-radius: 9px;
+  border: 1px solid var(--border-hairline);
+  background: oklch(0.1 0.01 280 / 60%);
+  box-shadow:
+    0 1px 3px oklch(0 0 0 / 30%),
+    inset 0 1px 0 oklch(1 0 0 / 4%);
+  overflow: hidden;
+}
+
+.cave-bubble-system-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  padding: 0.3em 0.75em;
+  background: oklch(0.14 0.015 280 / 70%);
+  border-bottom: 1px solid var(--border-hairline);
+  min-height: 26px;
+  backdrop-filter: blur(4px);
+}
+
+.cave-bubble-system-sigil {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 11px;
+  color: color-mix(in oklch, var(--accent-presence) 70%, var(--text-muted));
+  flex-shrink: 0;
+}
+
+.cave-bubble-system-label {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cave-bubble-system-label--dim {
+  color: var(--text-muted);
+  opacity: 0.6;
+}
+
+.cave-bubble-system-body {
+  margin: 0;
+  padding: 0.7em 1em;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  background: transparent;
+  border: none;
+  max-height: 320px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in oklch, var(--accent-presence) 20%, transparent) transparent;
+}


### PR DESCRIPTION
- Replaces plain monospace box with cave-code-wrap-style terminal panel
- Header: $ sigil + optional command label (or dim 'system' fallback)
- Scrollable pre body, max-height 320px
- label prop added to MessageBubbleProps for future slash-command labelling

Part of Coven Cave chat presentation overhaul.