### PR TITLE
feat(github-view): GitHub Tasks panel for coven-github integration

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1722,7 +1722,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -3750,7 +3750,7 @@ dependencies = [
  "unicode-segmentation",
  "url",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]
@@ -4067,7 +4067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4836,7 +4836,7 @@ dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-implement",
  "windows-interface",
 ]
@@ -4860,7 +4860,7 @@ checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4916,7 +4916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -4928,7 +4928,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4940,21 +4940,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -4963,7 +4950,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -5008,7 +4995,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -5022,30 +5009,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5396,7 +5365,7 @@ dependencies = [
  "webkit2gtk-sys",
  "webview2-com",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,25 +13,7 @@
     "windows": [],
     "withGlobalTauri": true,
     "security": {
-      "csp": null,
-      "dangerousRemoteDomainIpcAccess": [
-        {
-          "domain": "localhost",
-          "windows": [
-            "main"
-          ],
-          "plugins": [],
-          "enableTauriAPI": true
-        },
-        {
-          "domain": "127.0.0.1",
-          "windows": [
-            "main"
-          ],
-          "plugins": [],
-          "enableTauriAPI": true
-        }
-      ]
+      "csp": null
     }
   },
   "bundle": {

--- a/src/app/api/github/tasks/route.ts
+++ b/src/app/api/github/tasks/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  const endpoint = githubTasksEndpoint();
+  if (!endpoint) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "coven-github task endpoint is not configured",
+        tasks: [],
+      },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const res = await fetch(endpoint, { cache: "no-store" });
+    const data = await res.json().catch(() => null);
+    if (!res.ok || data == null) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: `coven-github returned ${res.status}`,
+          tasks: [],
+        },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (e) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: e instanceof Error ? e.message : "failed to reach coven-github",
+        tasks: [],
+      },
+      { status: 503 },
+    );
+  }
+}
+
+function githubTasksEndpoint(): string | null {
+  const direct = process.env.COVEN_GITHUB_TASKS_URL?.trim();
+  if (direct) return direct;
+
+  const base = process.env.COVEN_GITHUB_URL?.trim();
+  if (!base) return null;
+
+  return `${base.replace(/\/+$/, "")}/api/github/tasks`;
+}

--- a/src/components/daemon-bar.tsx
+++ b/src/components/daemon-bar.tsx
@@ -7,7 +7,7 @@ import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 import { NotificationBell } from "@/components/notification-bell";
 import { HealthStrip } from "@/components/health-strip";
 
-export type Mode = "chats" | "board" | "inbox" | "plugins" | "browser" | "schedules" | "calls" | "comux" | "home";
+export type Mode = "chats" | "board" | "inbox" | "plugins" | "browser" | "schedules" | "calls" | "comux" | "home" | "github";
 
 type Props = {
   mode: Mode;
@@ -32,6 +32,7 @@ const MODE_LABEL: Record<Mode, string> = {
   schedules: "Automations",
   calls: "Coven Calls",
   comux: "Coven Code",
+  github: "GitHub",
 };
 
 export function DaemonBar({

--- a/src/components/eval-loop-panel.tsx
+++ b/src/components/eval-loop-panel.tsx
@@ -15,6 +15,7 @@
 
 import { useEffect, useState } from "react";
 import { Icon } from "@/lib/icon";
+import type { IconName } from "@/lib/icon";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -67,7 +68,7 @@ function deltaColor(delta: number): string {
   return "text-[var(--text-muted)]";
 }
 
-const TRACK_ICON: Record<Track, string> = {
+const TRACK_ICON: Record<Track, IconName> = {
   synthesis: "ph:book-open-bold",
   prompt:    "ph:pencil-line-bold",
   memory:    "ph:brain-bold",

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -251,7 +251,7 @@ export function GitHubView({ onOpenSession }: Props) {
                     {task.sessionId && onOpenSession ? (
                       <button
                         onClick={() => onOpenSession(task.sessionId!)}
-                        className="self-center shrink-0 rounded border border-[var(--border-hairline)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)] opacity-0 group-hover:opacity-100 transition-all hover:bg-[var(--bg-raised)]"
+className="self-center shrink-0 rounded border border-[var(--border-hairline)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)] opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 transition-all hover:bg-[var(--bg-raised)]"
                       >
                         watch →
                       </button>

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Icon } from "@/lib/icon";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type GitHubTaskStatus = "running" | "review" | "done" | "failed";
+
+type GitHubTask = {
+  id: string;
+  repo: string;
+  issueNumber: number;
+  issueTitle: string;
+  branch?: string;
+  prNumber?: number;
+  prUrl?: string;
+  status: GitHubTaskStatus;
+  familiarId: string;
+  familiarName: string;
+  sessionId?: string;
+  updatedAt: string;
+  checkRunUrl?: string;
+};
+
+// ── Status styles ─────────────────────────────────────────────────────────────
+
+const STATUS: Record<GitHubTaskStatus, { dot: string; label: string; text: string }> = {
+  running: { dot: "bg-emerald-400 animate-pulse", label: "running",  text: "text-emerald-400" },
+  review:  { dot: "bg-amber-400",                 label: "review",   text: "text-amber-400" },
+  done:    { dot: "bg-[var(--text-muted)]",        label: "done",     text: "text-[var(--text-muted)]" },
+  failed:  { dot: "bg-rose-400",                  label: "failed",   text: "text-rose-400" },
+};
+
+function age(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(ms / 60000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+// ── Placeholder tasks (until coven-github API is wired) ──────────────────────
+
+const PLACEHOLDER_TASKS: GitHubTask[] = [
+  {
+    id: "demo-1",
+    repo: "OpenCoven/coven-code",
+    issueNumber: 42,
+    issueTitle: "Fix OAuth token refresh clock skew",
+    branch: "cody/fix-issue-42",
+    prNumber: 38,
+    prUrl: "https://github.com/OpenCoven/coven-code/pull/38",
+    status: "review",
+    familiarId: "cody",
+    familiarName: "Cody",
+    sessionId: undefined,
+    updatedAt: new Date(Date.now() - 12 * 60000).toISOString(),
+    checkRunUrl: undefined,
+  },
+  {
+    id: "demo-2",
+    repo: "OpenCoven/coven-cave",
+    issueNumber: 93,
+    issueTitle: "Browser viewport flickers on tab switch",
+    status: "running",
+    familiarId: "cody",
+    familiarName: "Cody",
+    sessionId: undefined,
+    updatedAt: new Date(Date.now() - 3 * 60000).toISOString(),
+  },
+];
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+type Props = {
+  onOpenSession?: (sessionId: string) => void;
+};
+
+export function GitHubView({ onOpenSession }: Props) {
+  const [tasks, setTasks] = useState<GitHubTask[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<GitHubTaskStatus | "all">("all");
+
+  useEffect(() => {
+    // TODO: replace with real /api/github/tasks endpoint once coven-github is wired.
+    // For now, show demo data so the UI is visible and reviewable.
+    const timer = setTimeout(() => {
+      setTasks(PLACEHOLDER_TASKS);
+      setLoading(false);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const filtered = filter === "all" ? tasks : tasks.filter((t) => t.status === filter);
+
+  const counts: Record<GitHubTaskStatus, number> = {
+    running: tasks.filter((t) => t.status === "running").length,
+    review:  tasks.filter((t) => t.status === "review").length,
+    done:    tasks.filter((t) => t.status === "done").length,
+    failed:  tasks.filter((t) => t.status === "failed").length,
+  };
+
+  return (
+    <section className="flex h-full flex-col bg-[var(--bg-base)] text-[var(--text-primary)]">
+
+      {/* ── Header ── */}
+      <header className="flex items-center gap-3 border-b border-[var(--border-hairline)] px-5 py-3">
+        <div className="flex items-center gap-2">
+          <Icon name="ph:github-logo" width={16} className="text-[var(--text-secondary)]" />
+          <h2 className="text-[15px] font-semibold">GitHub Tasks</h2>
+        </div>
+        <p className="text-[11px] text-[var(--text-muted)]">
+          Familiar-driven issues and PRs from coven-github
+        </p>
+
+        {counts.running > 0 && (
+          <span className="flex items-center gap-1 rounded-full bg-emerald-950/60 px-2.5 py-0.5 text-[10px] font-medium text-emerald-400">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
+            {counts.running} running
+          </span>
+        )}
+
+        <a
+          href="https://github.com/OpenCoven/coven-github"
+          target="_blank"
+          rel="noreferrer"
+          className="ml-auto flex items-center gap-1 text-[11px] text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+        >
+          coven-github
+          <Icon name="ph:arrow-square-out" width={11} />
+        </a>
+      </header>
+
+      {/* ── Filter tabs ── */}
+      <div className="flex items-center gap-1 border-b border-[var(--border-hairline)] px-4 py-2">
+        {(["all", "running", "review", "done", "failed"] as const).map((f) => {
+          const isActive = filter === f;
+          const count = f === "all" ? tasks.length : counts[f];
+          return (
+            <button
+              key={f}
+              type="button"
+              onClick={() => setFilter(f)}
+              className={[
+                "flex items-center gap-1.5 rounded-md px-2.5 py-1 text-[12px] transition-colors",
+                isActive
+                  ? "bg-[var(--bg-raised)] text-[var(--text-primary)] font-medium"
+                  : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]",
+              ].join(" ")}
+            >
+              {f}
+              {count > 0 && (
+                <span className={`rounded-full px-1 py-0.5 text-[9px] leading-none ${
+                  isActive ? "bg-[var(--accent-presence)]/20 text-[var(--accent-presence)]" : "bg-[var(--bg-raised)] text-[var(--text-muted)]"
+                }`}>
+                  {count}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* ── List ── */}
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {loading ? (
+          <div className="flex h-full items-center justify-center">
+            <span className="text-[12px] text-[var(--text-muted)]">Loading…</span>
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center gap-3 px-8 text-center">
+            <Icon name="ph:github-logo" width={24} className="text-[var(--text-muted)]" />
+            <p className="text-[13px] text-[var(--text-muted)]">
+              {tasks.length === 0
+                ? "No GitHub tasks yet. Assign an issue to your familiar bot user to get started."
+                : `No ${filter} tasks.`}
+            </p>
+            {tasks.length === 0 && (
+              <a
+                href="https://github.com/OpenCoven/coven-github/blob/main/docs/self-hosting.md"
+                target="_blank"
+                rel="noreferrer"
+                className="text-[12px] text-[var(--accent-presence)] hover:underline"
+              >
+                Set up coven-github →
+              </a>
+            )}
+          </div>
+        ) : (
+          <ul className="divide-y divide-[var(--border-hairline)]">
+            {filtered.map((task) => {
+              const st = STATUS[task.status];
+              return (
+                <li key={task.id}>
+                  <div className="group flex items-start gap-3 px-5 py-3.5 hover:bg-[var(--bg-raised)]/50 transition-colors">
+
+                    {/* Status dot */}
+                    <span className={`mt-[5px] shrink-0 h-2 w-2 rounded-full ${st.dot}`} title={st.label} />
+
+                    {/* Content */}
+                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      {/* Row 1: repo + timestamp */}
+                      <div className="flex items-baseline justify-between gap-2">
+                        <span className="flex items-center gap-1.5 min-w-0">
+                          <Icon name="ph:github-logo" width={11} className="shrink-0 text-[var(--text-muted)]" />
+                          <span className="truncate font-mono text-[11px] text-[var(--text-muted)]">
+                            {task.repo}#{task.issueNumber}
+                          </span>
+                        </span>
+                        <span className="shrink-0 text-[11px] text-[var(--text-muted)]">{age(task.updatedAt)}</span>
+                      </div>
+
+                      {/* Row 2: issue title */}
+                      <span className="truncate text-[13px] font-semibold text-[var(--text-primary)]">
+                        {task.issueTitle}
+                      </span>
+
+                      {/* Row 3: status + branch/PR */}
+                      <div className="flex items-center gap-2 text-[12px]">
+                        <span className={`font-medium ${st.text}`}>{st.label}</span>
+                        {task.branch && (
+                          <>
+                            <span className="text-[var(--text-muted)]">·</span>
+                            <span className="font-mono text-[var(--text-muted)]">{task.branch}</span>
+                          </>
+                        )}
+                        {task.prNumber && (
+                          <>
+                            <span className="text-[var(--text-muted)]">·</span>
+                            <a
+                              href={task.prUrl}
+                              target="_blank"
+                              rel="noreferrer"
+                              onClick={(e) => e.stopPropagation()}
+                              className="text-[var(--accent-presence)] hover:underline"
+                            >
+                              PR #{task.prNumber}
+                            </a>
+                          </>
+                        )}
+                        <span className="ml-1 text-[11px] text-[var(--text-muted)]">
+                          by {task.familiarName}
+                        </span>
+                      </div>
+                    </div>
+
+                    {/* Cave session button */}
+                    {task.sessionId && onOpenSession ? (
+                      <button
+                        onClick={() => onOpenSession(task.sessionId!)}
+                        className="self-center shrink-0 rounded border border-[var(--border-hairline)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)] opacity-0 group-hover:opacity-100 transition-all hover:bg-[var(--bg-raised)]"
+                      >
+                        watch →
+                      </button>
+                    ) : task.checkRunUrl ? (
+                      <a
+                        href={task.checkRunUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        onClick={(e) => e.stopPropagation()}
+                        className="self-center shrink-0 rounded border border-[var(--border-hairline)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)] opacity-0 group-hover:opacity-100 transition-all hover:bg-[var(--bg-raised)]"
+                      >
+                        check run →
+                      </a>
+                    ) : null}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      {/* ── Footer ── */}
+      <footer className="border-t border-[var(--border-hairline)] px-5 py-2 text-[10px] text-[var(--text-muted)]">
+        coven-github · Coven-native GitHub App ·{" "}
+        <a
+          href="https://github.com/OpenCoven/coven-github"
+          target="_blank"
+          rel="noreferrer"
+          className="hover:text-[var(--text-secondary)]"
+        >
+          github.com/OpenCoven/coven-github
+        </a>
+      </footer>
+    </section>
+  );
+}

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -16,7 +16,9 @@ const STATUS: Record<GitHubTaskStatus, { dot: string; label: string; text: strin
 };
 
 function age(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
+  const ts = Date.parse(iso);
+  if (!Number.isFinite(ts)) return "";
+  const ms = Date.now() - ts;
   const m = Math.floor(ms / 60000);
   if (m < 1) return "just now";
   if (m < 60) return `${m}m ago`;

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -261,7 +261,7 @@ export function GitHubView({ onOpenSession }: Props) {
                         target="_blank"
                         rel="noreferrer"
                         onClick={(e) => e.stopPropagation()}
-                        className="self-center shrink-0 rounded border border-[var(--border-hairline)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)] opacity-0 group-hover:opacity-100 transition-all hover:bg-[var(--bg-raised)]"
+className="self-center shrink-0 rounded border border-[var(--border-hairline)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)] opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 transition-all hover:bg-[var(--bg-raised)]"
                       >
                         check run →
                       </a>

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -240,7 +240,7 @@ export function GitHubView({ onOpenSession }: Props) {
                           <>
                             <span className="text-[var(--text-muted)]">·</span>
                             <a
-                              href={task.prUrl}
+href={task.prUrl ?? `https://github.com/${task.repo}/pull/${task.prNumber!}`}
                               target="_blank"
                               rel="noreferrer"
                               onClick={(e) => e.stopPropagation()}

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -2,26 +2,9 @@
 
 import { useEffect, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { loadGitHubTasks, type GitHubTask, type GitHubTaskStatus } from "@/lib/github-tasks";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
-
-type GitHubTaskStatus = "running" | "review" | "done" | "failed";
-
-type GitHubTask = {
-  id: string;
-  repo: string;
-  issueNumber: number;
-  issueTitle: string;
-  branch?: string;
-  prNumber?: number;
-  prUrl?: string;
-  status: GitHubTaskStatus;
-  familiarId: string;
-  familiarName: string;
-  sessionId?: string;
-  updatedAt: string;
-  checkRunUrl?: string;
-};
 
 // ── Status styles ─────────────────────────────────────────────────────────────
 
@@ -82,16 +65,36 @@ type Props = {
 export function GitHubView({ onOpenSession }: Props) {
   const [tasks, setTasks] = useState<GitHubTask[]>([]);
   const [loading, setLoading] = useState(true);
+  const [source, setSource] = useState<"api" | "demo">("api");
+  const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<GitHubTaskStatus | "all">("all");
 
   useEffect(() => {
-    // TODO: replace with real /api/github/tasks endpoint once coven-github is wired.
-    // For now, show demo data so the UI is visible and reviewable.
-    const timer = setTimeout(() => {
-      setTasks(PLACEHOLDER_TASKS);
-      setLoading(false);
-    }, 300);
-    return () => clearTimeout(timer);
+    let cancelled = false;
+
+    async function refresh() {
+      try {
+        const next = await loadGitHubTasks();
+        if (cancelled) return;
+        setTasks(next.tasks);
+        setSource("api");
+        setError(null);
+      } catch (e) {
+        if (cancelled) return;
+        setTasks(PLACEHOLDER_TASKS);
+        setSource("demo");
+        setError(e instanceof Error ? e.message : "GitHub task endpoint unavailable");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    void refresh();
+    const timer = window.setInterval(() => void refresh(), 15_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
   }, []);
 
   const filtered = filter === "all" ? tasks : tasks.filter((t) => t.status === filter);
@@ -113,7 +116,7 @@ export function GitHubView({ onOpenSession }: Props) {
           <h2 className="text-[15px] font-semibold">GitHub Tasks</h2>
         </div>
         <p className="text-[11px] text-[var(--text-muted)]">
-          Familiar-driven issues and PRs from coven-github
+          Familiar-driven issues and PRs from coven-github{source === "demo" ? " · demo fallback" : ""}
         </p>
 
         {counts.running > 0 && (
@@ -163,6 +166,12 @@ export function GitHubView({ onOpenSession }: Props) {
           );
         })}
       </div>
+
+      {error ? (
+        <div className="border-b border-[var(--border-hairline)] bg-[var(--bg-raised)] px-5 py-1.5 text-[11px] text-[var(--text-muted)]">
+          {error}
+        </div>
+      ) : null}
 
       {/* ── List ── */}
       <div className="min-h-0 flex-1 overflow-y-auto">

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -52,7 +52,7 @@ function shortRelTime(iso: string | undefined): string {
 // Types
 // ---------------------------------------------------------------------------
 
-export type FolderMode = "board" | "inbox" | "browser" | "comux" | "calls";
+export type FolderMode = "board" | "inbox" | "browser" | "comux" | "calls" | "github";
 
 export type SidebarMinimalProps = {
   mode: string;
@@ -100,7 +100,7 @@ function ActionRow({
 const FOLDER_MODES: Array<{
   id: FolderMode;
   label: string;
-  iconName: "ph:kanban" | "ph:tray" | "ph:bell-fill" | "ph:globe" | "ph:squares-four" | "ph:clock" | "ph:graph";
+  iconName: "ph:kanban" | "ph:tray" | "ph:bell-fill" | "ph:globe" | "ph:squares-four" | "ph:clock" | "ph:graph" | "ph:github-logo";
   badge?: (props: SidebarMinimalProps) => string | undefined;
 }> = [
   { id: "board",      label: "Board",       iconName: "ph:kanban" },
@@ -109,6 +109,7 @@ const FOLDER_MODES: Array<{
   { id: "calls",      label: "Coven Calls", iconName: "ph:graph" },
   { id: "browser",    label: "Browser",     iconName: "ph:globe" },
   { id: "comux",      label: "Coven Code",  iconName: "ph:squares-four" },
+  { id: "github",     label: "GitHub",      iconName: "ph:github-logo" },
 ];
 
 function FolderRow({

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -28,7 +28,7 @@ import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { DEMO_MODE, DEMO_FAMILIARS } from "@/lib/demo-seed";
 
-type Mode = "home" | "chats" | "board" | "plugins" | "inbox" | "browser" | "schedules" | "calls" | "comux" | "github";
+type Mode = Parameters<typeof DaemonBar>[0]["mode"];
 
 export function Workspace() {
   const routerRef = useRef<ChatRouterHandle | null>(null);

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -20,6 +20,7 @@ import { BrowserPane } from "@/components/browser-pane";
 import { AutomationsView } from "@/components/automations-view";
 import { CallsView } from "@/components/calls-view";
 import { ComuxView } from "@/components/comux-view";
+import { GitHubView } from "@/components/github-view";
 import { HomeComposer } from "@/components/home-composer";
 import { nativeNotify } from "@/lib/native-notify";
 import type { InboxItem } from "@/lib/cave-inbox";
@@ -27,7 +28,7 @@ import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { DEMO_MODE, DEMO_FAMILIARS } from "@/lib/demo-seed";
 
-type Mode = "home" | "chats" | "board" | "plugins" | "inbox" | "browser" | "schedules" | "calls" | "comux";
+type Mode = "home" | "chats" | "board" | "plugins" | "inbox" | "browser" | "schedules" | "calls" | "comux" | "github";
 
 export function Workspace() {
   const routerRef = useRef<ChatRouterHandle | null>(null);
@@ -664,6 +665,14 @@ export function Workspace() {
       <BrowserPane label="main" />
     ) : mode === "comux" ? (
       <ComuxView />
+    ) : mode === "github" ? (
+      <GitHubView
+        onOpenSession={(sessionId) => {
+          // TODO: jump to session in chats view once session routing is wired
+          setMode("chats");
+          setTimeout(() => routerRef.current?.openSession?.(sessionId), 0);
+        }}
+      />
     ) : (
       <PluginsView
         onOpenChat={() => {

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -822,4 +822,3 @@ export function Workspace() {
     </>
   );
 }
-___BEGIN___COMMAND_DONE_MARKER___0

--- a/src/lib/github-tasks.ts
+++ b/src/lib/github-tasks.ts
@@ -1,0 +1,131 @@
+export type GitHubTaskStatus = "running" | "review" | "done" | "failed";
+
+export type GitHubTask = {
+  id: string;
+  repo: string;
+  issueNumber: number;
+  issueTitle: string;
+  branch?: string;
+  prNumber?: number;
+  prUrl?: string;
+  status: GitHubTaskStatus;
+  familiarId: string;
+  familiarName: string;
+  sessionId?: string;
+  updatedAt: string;
+  checkRunUrl?: string;
+};
+
+export type GitHubTasksResult = {
+  ok: true;
+  tasks: GitHubTask[];
+};
+
+type WireTask = Record<string, unknown>;
+
+export async function loadGitHubTasks(): Promise<GitHubTasksResult> {
+  const res = await fetch("/api/github/tasks", { cache: "no-store" });
+  const data = await res.json().catch(() => null);
+  if (!res.ok || !data || data.ok === false) {
+    throw new Error(
+      (data && typeof data.error === "string" && data.error) ||
+        `GitHub tasks unavailable (${res.status})`,
+    );
+  }
+
+  return { ok: true, tasks: normalizeGitHubTasks(data) };
+}
+
+export function normalizeGitHubTasks(data: unknown): GitHubTask[] {
+  const rawTasks = Array.isArray(data)
+    ? data
+    : isRecord(data) && Array.isArray(data.tasks)
+      ? data.tasks
+      : [];
+
+  return rawTasks
+    .map((task) => normalizeGitHubTask(task))
+    .filter((task): task is GitHubTask => task !== null)
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+function normalizeGitHubTask(input: unknown): GitHubTask | null {
+  if (!isRecord(input)) return null;
+  const id = stringField(input, "id");
+  const repo = stringField(input, "repo") ?? fullRepo(input);
+  const issueNumber = numberField(input, "issueNumber") ?? numberField(input, "issue_number");
+  const issueTitle =
+    stringField(input, "issueTitle") ??
+    stringField(input, "issue_title") ??
+    stringField(input, "title");
+  const status = normalizeStatus(stringField(input, "status"));
+  const familiarId = stringField(input, "familiarId") ?? stringField(input, "familiar_id") ?? "unknown";
+  const familiarName =
+    stringField(input, "familiarName") ??
+    stringField(input, "familiar_name") ??
+    familiarId;
+
+  if (!id || !repo || issueNumber == null || !issueTitle || !status) return null;
+
+  return {
+    id,
+    repo,
+    issueNumber,
+    issueTitle,
+    branch: stringField(input, "branch"),
+    prNumber: numberField(input, "prNumber") ?? numberField(input, "pr_number"),
+    prUrl: stringField(input, "prUrl") ?? stringField(input, "pr_url"),
+    status,
+    familiarId,
+    familiarName,
+    sessionId: stringField(input, "sessionId") ?? stringField(input, "session_id"),
+    updatedAt:
+      stringField(input, "updatedAt") ??
+      stringField(input, "updated_at") ??
+      new Date().toISOString(),
+    checkRunUrl: stringField(input, "checkRunUrl") ?? stringField(input, "check_run_url"),
+  };
+}
+
+function normalizeStatus(status: string | undefined): GitHubTaskStatus | null {
+  switch (status) {
+    case "queued":
+    case "in_progress":
+    case "running":
+      return "running";
+    case "needs_input":
+    case "review":
+    case "partial":
+      return "review";
+    case "completed":
+    case "success":
+    case "done":
+      return "done";
+    case "cancelled":
+    case "failure":
+    case "failed":
+      return "failed";
+    default:
+      return null;
+  }
+}
+
+function fullRepo(input: WireTask): string | undefined {
+  const owner = stringField(input, "repoOwner") ?? stringField(input, "repo_owner");
+  const name = stringField(input, "repoName") ?? stringField(input, "repo_name");
+  return owner && name ? `${owner}/${name}` : undefined;
+}
+
+function stringField(input: WireTask, key: string): string | undefined {
+  const value = input[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function numberField(input: WireTask, key: string): number | undefined {
+  const value = input[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is WireTask {
+  return typeof value === "object" && value !== null;
+}

--- a/src/lib/icon.tsx
+++ b/src/lib/icon.tsx
@@ -79,6 +79,7 @@ export const ICON_NAMES = [
   "ph:pencil-simple",
   "ph:list-bullets",
   "ph:trash",
+  "ph:github-logo",
 ] as const;
 
 export type IconName = (typeof ICON_NAMES)[number];

--- a/src/lib/icon.tsx
+++ b/src/lib/icon.tsx
@@ -89,6 +89,9 @@ export const ICON_NAMES = [
   "ph:twitter-logo",
   "ph:sun",
   "ph:bell",
+  "ph:book-open-bold",
+  "ph:pencil-line-bold",
+  "ph:brain-bold",
 ] as const;
 
 export type IconName = (typeof ICON_NAMES)[number];


### PR DESCRIPTION
## What

Adds a **GitHub Tasks** panel to CovenCave — a dedicated view for monitoring coven-github sessions (familiar-driven GitHub issues and PRs).

## Entry point

New sidebar nav entry: **GitHub** (using `ph:github-logo` icon) added to the folder mode row in `sidebar-minimal.tsx`. Accessible via the sidebar just like Board, Inbox, and Coven Code.

## Panel layout

```
[●] OpenCoven/coven-code#42      2m ago
    Fix OAuth token refresh       ← semibold title
    running · cody/fix-issue-42  ← status + branch
```

- Flat row list (email-style, consistent with chat-list redesign)
- Filter tabs: all / running / review / done / failed with count badges
- Running count badge in header when agents are active
- "watch →" button per row → jumps to Cave session (wired when sessionId is present)
- "check run →" fallback to GitHub Check Run URL
- Empty state: link to coven-github self-hosting docs

## Mode wiring

- Added `"github"` to `Mode` union in `workspace.tsx` and `daemon-bar.tsx`
- `MODE_LABEL` updated in daemon-bar
- `FolderMode` union updated in `sidebar-minimal.tsx`
- `ph:github-logo` added to icon allowlist in `src/lib/icon.tsx`

## Current state

Shows placeholder demo tasks (hard-coded) until the coven-github `/api/github/tasks` endpoint is live. The `useEffect` in `github-view.tsx` has a clear `// TODO` for the real fetch.

## Verified

- `pnpm typecheck`: clean