### PR TITLE
fix(calendar): +N more drill-through, week min-width, TS cleanup

### DIFF
--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -275,7 +275,7 @@ function WeekView({
   }, [items, days]);
 
   return (
-    <div className="grid grid-cols-7 flex-1 overflow-hidden divide-x divide-[var(--border-subtle)]">
+    <div className="grid grid-cols-7 flex-1 overflow-auto min-w-[360px] divide-x divide-[var(--border-subtle)]">
       {days.map((day, i) => {
         const dayItems = byDay.get(i) ?? [];
         const isToday = isSameDay(day, today);
@@ -407,9 +407,16 @@ function MonthView({
                   </button>
                 ))}
                 {dayItems.length > 3 && (
-                  <span className="text-[9px] text-[var(--text-muted)] px-1">
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onDayClick?.(day);
+                    }}
+                    className="text-[9px] text-[var(--text-muted)] px-1 hover:text-[var(--accent-presence)] transition-colors text-left"
+                    title={`${dayItems.length - 3} more items — click to see all`}
+                  >
                     +{dayItems.length - 3} more
-                  </span>
+                  </button>
                 )}
               </div>
             </div>


### PR DESCRIPTION
Closes #101, #105, #108

- #105: +N more pill in month view is now a button that calls onDayClick → drills into day view with tooltip
- #108: Week grid gets min-w-[360px] + overflow-auto — stays usable at narrow pane widths
- #101: TS errors already resolved (all icon names are valid IconName entries — confirmed in ICON_NAMES array)