### PR TITLE
fix(comux): restore workspace root for terminal project view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",

--- a/src/app/api/daemon/status/route.ts
+++ b/src/app/api/daemon/status/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server";
+import { homedir } from "node:os";
+import path from "node:path";
 import { callDaemon } from "@/lib/coven-daemon";
 
 export const dynamic = "force-dynamic";
@@ -10,15 +12,31 @@ type Health = {
   daemon?: { pid: number; startedAt: string; socket: string };
 };
 
+function workspaceRoot(): string {
+  return (
+    process.env.WORKSPACE_ROOT ||
+    process.env.NEXT_PUBLIC_WORKSPACE_ROOT ||
+    path.join(homedir(), ".openclaw")
+  );
+}
+
 export async function GET() {
   const res = await callDaemon<Health>({ path: "/api/v1/health", timeoutMs: 1500 });
+  const root = workspaceRoot();
   if (!res.ok || !res.data) {
-    return NextResponse.json({ running: false, reason: res.error ?? `http ${res.status}` });
+    return NextResponse.json({
+      running: false,
+      reason: res.error ?? `http ${res.status}`,
+      workspacePath: root,
+      projectRoot: root,
+    });
   }
   return NextResponse.json({
     running: true,
     apiVersion: res.data.apiVersion,
     covenVersion: res.data.covenVersion,
     daemon: res.data.daemon,
+    workspacePath: root,
+    projectRoot: root,
   });
 }

--- a/src/lib/server/project-paths.ts
+++ b/src/lib/server/project-paths.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 
 function realpathOrResolve(value: string): string {
@@ -15,6 +16,7 @@ const ALLOWED_ROOTS = Array.from(
     [
       process.env.WORKSPACE_ROOT,
       process.env.NEXT_PUBLIC_WORKSPACE_ROOT,
+      path.join(homedir(), ".openclaw"),
       process.cwd(),
     ]
       .filter((value): value is string => Boolean(value))
@@ -32,4 +34,3 @@ export function resolveAllowedProjectPath(value: string): string | null {
     ? candidate
     : null;
 }
-


### PR DESCRIPTION
## Summary
- restore workspacePath/projectRoot in /api/daemon/status so the Coven Code project tab can list the workspace and terminals inherit the intended CWD
- allow the default ~/.openclaw workspace root through the project-tree server allowlist
- stamp v0.0.36 because v0.0.35 already exists

## Verification
- pnpm install --frozen-lockfile
- dev API smoke: /api/daemon/status returns workspacePath/projectRoot for ~/.openclaw
- dev API smoke: /api/project-tree?root=/Users/buns/.openclaw&depth=1 returns ok:true
- pnpm typecheck
- pnpm build
- git diff --check
- version assertion: package.json and src-tauri/tauri.conf.json are both 0.0.36
- tag absence check: refs/tags/v0.0.36 is absent before release