### PR TITLE
ci(release): use Xcode 16.4 for macOS notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,10 @@ jobs:
         if: matrix.platform == 'macos-15-intel'
         shell: bash
         env:
-          DEVELOPER_DIR: /Applications/Xcode_16.3.app/Contents/Developer
+          # Xcode 16.3's notarytool crashes with exit 132 on the current
+          # macos-15 Intel runner image. Use the image's default 16.4
+          # toolchain explicitly so notarization stays on the macOS 15 SDK.
+          DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
           SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -39,6 +39,8 @@ require_value "$NOTARY_ISSUER" "NOTARY_ISSUER / APPLE_API_ISSUER"
 
 echo "==> Validating App Store Connect API key"
 openssl pkey -in "$NOTARY_KEY_FILE" -noout -check >/dev/null
+echo "==> Using notarytool: $(xcrun --find notarytool)"
+xcrun notarytool --version
 
 echo "==> Building CovenCave v${VERSION}"
 rm -rf "$DMG_DIR"


### PR DESCRIPTION
## Summary
- move the macOS release script from pinned Xcode 16.3 to Xcode 16.4
- log the selected notarytool path/version before notarization

## Why
The v0.0.36 release built and signed the macOS app successfully, but Xcode 16.3 notarytool crashed with `Illegal instruction: 4` during JWT generation before the Apple API request completed. The exact GitHub macos-15 runner image lists Xcode 16.4 as the default toolchain.

## Verification
- bash -n scripts/release.sh
- ruby YAML parse for .github/workflows/release.yml
- git diff --check