### PR TITLE
fix(ui): make calendar and plugins responsive

### DIFF
--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -161,7 +161,7 @@ function AgendaView({
   }
 
   return (
-    <div className="flex flex-col gap-6 px-6 py-4 overflow-y-auto">
+    <div className="flex flex-col gap-6 overflow-y-auto px-3 py-4 sm:px-6">
       {groups.map(({ date, items: groupItems }) => (
         <div key={date.toISOString()}>
           <div className="mb-2 flex items-center gap-3">
@@ -214,9 +214,9 @@ function AllDayStrip({
   onDayClick?: (day: Date) => void;
 }) {
   return (
-    <div className="flex shrink-0 border-b border-[var(--border-hairline)] bg-[var(--bg-panel)]">
+    <div className="flex shrink-0 overflow-x-auto border-b border-[var(--border-hairline)] bg-[var(--bg-panel)]">
       {/* Label */}
-      <div className="w-12 shrink-0 border-r border-[var(--border-hairline)] flex items-center justify-end pr-1.5 py-1">
+      <div className="sticky left-0 z-10 flex w-12 shrink-0 items-center justify-end border-r border-[var(--border-hairline)] bg-[var(--bg-panel)] py-1 pr-1.5">
         <span className="text-[9px] uppercase tracking-wider text-[var(--text-muted)] leading-tight text-right">
           All
           <br />
@@ -224,7 +224,11 @@ function AllDayStrip({
         </span>
       </div>
       {/* Per-column chips */}
-      <div className="flex flex-1 divide-x divide-[var(--border-hairline)]">
+      <div
+        className={`flex flex-1 divide-x divide-[var(--border-hairline)] ${
+          columns.length > 1 ? "min-w-[560px]" : "min-w-[180px]"
+        }`}
+      >
         {columns.map((col, i) => (
           <div key={i} className="flex-1 min-w-[80px] flex flex-col gap-0.5 p-1">
             {col.items.slice(0, MAX_ALLDAY_VISIBLE).map((item) => (
@@ -292,7 +296,10 @@ function TimeGrid({
   return (
     <div className="flex flex-1 overflow-auto">
       {/* Time axis */}
-      <div className="shrink-0 w-12 border-r border-[var(--border-hairline)] relative" style={{ height: totalHeight }}>
+      <div
+        className="sticky left-0 z-20 w-12 shrink-0 border-r border-[var(--border-hairline)] bg-[var(--bg-base)] relative"
+        style={{ height: totalHeight }}
+      >
         {HOURS.map((h) => (
           <div
             key={h}
@@ -305,7 +312,11 @@ function TimeGrid({
       </div>
 
       {/* Columns */}
-      <div className="flex flex-1 divide-x divide-[var(--border-hairline)]">
+      <div
+        className={`flex flex-1 divide-x divide-[var(--border-hairline)] ${
+          columns.length > 1 ? "min-w-[560px]" : "min-w-[220px]"
+        }`}
+      >
         {columns.map((col, ci) => (
           <div key={ci} className="flex-1 relative min-w-[80px]" style={{ height: totalHeight }}>
             {/* Hour lines */}
@@ -392,7 +403,7 @@ function DayView({
   return (
     <div className="flex flex-col flex-1 overflow-hidden">
       {/* Header */}
-      <div className="px-6 py-3 border-b border-[var(--border-hairline)] shrink-0">
+      <div className="shrink-0 border-b border-[var(--border-hairline)] px-3 py-3 sm:px-6">
         <h2 className="text-sm font-medium text-[var(--text-primary)]">
           {fmtDateHeading(anchor)}
         </h2>
@@ -457,10 +468,10 @@ function WeekView({
   return (
     <div className="flex flex-col flex-1 overflow-hidden">
       {/* Sticky column headers */}
-      <div className="flex shrink-0 border-b border-[var(--border-hairline)]">
+      <div className="flex shrink-0 overflow-x-auto border-b border-[var(--border-hairline)]">
         {/* Spacer for the time axis */}
-        <div className="w-12 shrink-0 border-r border-[var(--border-hairline)]" />
-        <div className="flex flex-1 min-w-[320px] divide-x divide-[var(--border-hairline)] overflow-x-auto">
+        <div className="sticky left-0 z-10 w-12 shrink-0 border-r border-[var(--border-hairline)] bg-[var(--bg-base)]" />
+        <div className="flex min-w-[560px] flex-1 divide-x divide-[var(--border-hairline)]">
           {columns.map((col, i) => (
             <div
               key={i}
@@ -524,77 +535,81 @@ function MonthView({
   }, [items]);
 
   return (
-    <div className="flex flex-col flex-1 overflow-hidden px-4 pb-4">
+    <div className="flex flex-1 flex-col overflow-hidden px-2 pb-3 sm:px-4 sm:pb-4">
       {/* Weekday headers */}
-      <div className="grid grid-cols-7 mb-1">
-        {WEEKDAYS.map((wd) => (
-          <div
-            key={wd}
-            className="py-1 text-center text-[10px] uppercase tracking-wider text-[var(--text-muted)]"
-          >
-            {wd}
-          </div>
-        ))}
-      </div>
-      {/* Day cells */}
-      <div className="grid grid-cols-7 grid-rows-6 flex-1 gap-px bg-[var(--border-hairline)] rounded-lg overflow-hidden">
-        {cells.map((day, i) => {
-          const key = startOfDay(day).toISOString();
-          const dayItems = byDay.get(key) ?? [];
-          const isCurrentMonth = day.getMonth() === anchor.getMonth();
-          const isToday = isSameDay(day, today);
-
-          return (
-            <div
-              key={i}
-              onClick={() => onDayClick?.(day)}
-              className={`flex flex-col p-1.5 cursor-pointer transition-colors overflow-hidden ${
-                isCurrentMonth
-                  ? "bg-[var(--bg-panel)] hover:bg-[var(--bg-raised)]"
-                  : "bg-[var(--bg-base)] hover:bg-[var(--bg-panel)]"
-              }`}
-            >
-              <span
-                className={`text-[11px] font-medium mb-1 w-5 h-5 flex items-center justify-center rounded-full ${
-                  isToday
-                    ? "bg-[#8E3DFF] text-white"
-                    : isCurrentMonth
-                    ? "text-[var(--text-primary)]"
-                    : "text-[var(--text-muted)]"
-                }`}
+      <div className="min-h-0 flex-1 overflow-x-auto">
+        <div className="flex h-full min-w-[560px] flex-col">
+          <div className="mb-1 grid grid-cols-7">
+            {WEEKDAYS.map((wd) => (
+              <div
+                key={wd}
+                className="py-1 text-center text-[10px] uppercase tracking-wider text-[var(--text-muted)]"
               >
-                {day.getDate()}
-              </span>
-              <div className="flex flex-col gap-0.5 overflow-hidden">
-                {dayItems.slice(0, 3).map((item) => (
-                  <button
-                    key={item.id}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onOpenItem?.(item);
-                    }}
-                    className="flex items-center gap-1 rounded px-1 py-0.5 text-[9px] bg-[var(--bg-raised)] border border-[var(--border-hairline)] hover:bg-[var(--bg-elevated)] w-full text-left"
-                  >
-                    <span className={`h-1 w-1 shrink-0 rounded-full ${urgencyColor(item)}`} />
-                    <span className="truncate text-[var(--text-primary)]">{item.title}</span>
-                  </button>
-                ))}
-                {dayItems.length > 3 && (
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onDayClick?.(day);
-                    }}
-                    className="text-[9px] text-[var(--text-muted)] px-1 hover:text-[var(--accent-presence)] transition-colors text-left w-full"
-                    title={`${dayItems.length - 3} more items — click to see all`}
-                  >
-                    +{dayItems.length - 3} more
-                  </button>
-                )}
+                {wd}
               </div>
-            </div>
-          );
-        })}
+            ))}
+          </div>
+          {/* Day cells */}
+          <div className="grid flex-1 grid-cols-7 grid-rows-6 gap-px overflow-hidden rounded-lg bg-[var(--border-hairline)]">
+            {cells.map((day, i) => {
+              const key = startOfDay(day).toISOString();
+              const dayItems = byDay.get(key) ?? [];
+              const isCurrentMonth = day.getMonth() === anchor.getMonth();
+              const isToday = isSameDay(day, today);
+
+              return (
+                <div
+                  key={i}
+                  onClick={() => onDayClick?.(day)}
+                  className={`flex cursor-pointer flex-col overflow-hidden p-1.5 transition-colors ${
+                    isCurrentMonth
+                      ? "bg-[var(--bg-panel)] hover:bg-[var(--bg-raised)]"
+                      : "bg-[var(--bg-base)] hover:bg-[var(--bg-panel)]"
+                  }`}
+                >
+                  <span
+                    className={`mb-1 flex h-5 w-5 items-center justify-center rounded-full text-[11px] font-medium ${
+                      isToday
+                        ? "bg-[#8E3DFF] text-white"
+                        : isCurrentMonth
+                        ? "text-[var(--text-primary)]"
+                        : "text-[var(--text-muted)]"
+                    }`}
+                  >
+                    {day.getDate()}
+                  </span>
+                  <div className="flex flex-col gap-0.5 overflow-hidden">
+                    {dayItems.slice(0, 3).map((item) => (
+                      <button
+                        key={item.id}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onOpenItem?.(item);
+                        }}
+                        className="flex w-full items-center gap-1 rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-1 py-0.5 text-left text-[9px] hover:bg-[var(--bg-elevated)]"
+                      >
+                        <span className={`h-1 w-1 shrink-0 rounded-full ${urgencyColor(item)}`} />
+                        <span className="truncate text-[var(--text-primary)]">{item.title}</span>
+                      </button>
+                    ))}
+                    {dayItems.length > 3 && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onDayClick?.(day);
+                        }}
+                        className="w-full px-1 text-left text-[9px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
+                        title={`${dayItems.length - 3} more items — click to see all`}
+                      >
+                        +{dayItems.length - 3} more
+                      </button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
       </div>
     </div>
   );
@@ -767,52 +782,53 @@ export function CalendarView({ items, familiars, onOpenItem }: Props) {
   ];
 
   return (
-    <div ref={containerRef} className="flex flex-col h-full bg-[var(--bg-base)] relative">
+    <div ref={containerRef} className="relative flex h-full min-w-0 flex-col bg-[var(--bg-base)]">
       {/* Header */}
-      <div className="flex items-center gap-3 px-6 py-3 border-b border-[var(--border-hairline)] shrink-0">
-        {/* Nav arrows */}
-        <button
-          onClick={() => navigate(-1)}
-          aria-label="Previous"
-          className="grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] transition-colors"
-        >
-          <Icon name="ph:arrow-left-bold" width={12} />
-        </button>
-        <button
-          onClick={() => setAnchor(new Date())}
-          className="rounded-md border border-[var(--border-hairline)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] transition-colors"
-        >
-          Today
-        </button>
-        <button
-          onClick={() => navigate(1)}
-          className="grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] transition-colors"
-        >
-          <Icon name="ph:arrow-right-bold" />
-        </button>
+      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-[var(--border-hairline)] px-3 py-3 sm:gap-3 sm:px-6">
+        <div className="flex shrink-0 items-center gap-1">
+          {/* Nav arrows */}
+          <button
+            onClick={() => navigate(-1)}
+            aria-label="Previous"
+            className="grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+          >
+            <Icon name="ph:arrow-left-bold" width={12} />
+          </button>
+          <button
+            onClick={() => setAnchor(new Date())}
+            className="rounded-md border border-[var(--border-hairline)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)]"
+          >
+            Today
+          </button>
+          <button
+            onClick={() => navigate(1)}
+            aria-label="Next"
+            className="grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+          >
+            <Icon name="ph:arrow-right-bold" />
+          </button>
+        </div>
 
-        {/* Heading */}
-        <h2 className="flex-1 text-sm font-semibold text-[var(--text-primary)]">
-          {headingLabel()}
-        </h2>
-
-        {/* Item count */}
-        <span className="text-[11px] text-[var(--text-muted)]">
-          {items.filter((i) => i.status === "pending").length} pending
-        </span>
-
-        {/* Keyboard hint */}
-        <span className="text-[10px] text-[var(--text-muted)] hidden md:block">
-          ← → navigate · T today · D W M A views
-        </span>
+        <div className="min-w-[180px] flex-1">
+          {/* Heading */}
+          <h2 className="truncate text-sm font-semibold text-[var(--text-primary)]">
+            {headingLabel()}
+          </h2>
+          <div className="flex items-center gap-2 text-[11px] text-[var(--text-muted)]">
+            <span>{items.filter((i) => i.status === "pending").length} pending</span>
+            <span className="hidden md:inline">
+              ← → navigate · T today · D W M A views
+            </span>
+          </div>
+        </div>
 
         {/* View mode toggle */}
-        <div className="flex items-center rounded-lg border border-[var(--border-hairline)] overflow-hidden">
+        <div className="flex max-w-full shrink-0 items-center overflow-hidden rounded-lg border border-[var(--border-hairline)]">
           {VIEW_MODES.map(({ id, label }) => (
             <button
               key={id}
               onClick={() => setViewMode(id)}
-              className={`px-3 py-1 text-[11px] transition-colors ${
+              className={`px-2.5 py-1 text-[11px] transition-colors sm:px-3 ${
                 viewMode === id
                   ? "bg-[#8E3DFF] text-white"
                   : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"

--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -176,15 +176,15 @@ export function PluginsView({ onOpenChat, onCreateReminder, onCreateSkill, onCre
   }, [skills, query]);
 
   return (
-    <div className="flex h-full flex-col bg-background text-foreground">
+    <div className="flex h-full min-w-0 flex-col bg-background text-foreground">
       {/* Top tab strip */}
-      <header className="flex items-center justify-between border-b border-border px-5 py-3">
-        <div className="flex items-center gap-5 text-[13px]">
+      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-3 py-3 sm:px-5">
+        <div className="flex min-w-0 max-w-full items-center gap-5 overflow-x-auto text-[13px]">
           {(["plugins", "skills", "capabilities"] as const).map((t) => (
             <button
               key={t}
               onClick={() => setTab(t)}
-              className={`relative pb-2 transition-colors ${
+              className={`relative shrink-0 pb-2 transition-colors ${
                 tab === t ? "text-foreground" : "text-muted-foreground hover:text-foreground"
               }`}
             >
@@ -195,7 +195,7 @@ export function PluginsView({ onOpenChat, onCreateReminder, onCreateSkill, onCre
             </button>
           ))}
         </div>
-        <div className="flex items-center gap-2 text-[12px]">
+        <div className="flex shrink-0 items-center gap-2 text-[12px]">
           <button
             className="flex items-center gap-1.5 rounded-md border border-border bg-card px-3 py-1.5 text-foreground transition-colors hover:bg-muted"
             title="Manage plugins (not wired in v1)"
@@ -237,15 +237,15 @@ export function PluginsView({ onOpenChat, onCreateReminder, onCreateSkill, onCre
 
       {/* Scrolling content */}
       <div className="flex-1 overflow-y-auto">
-        <div className="mx-auto w-full max-w-[860px] px-6 pt-12 pb-16">
+        <div className="mx-auto w-full max-w-[860px] px-3 pb-12 pt-8 sm:px-6 sm:pb-16 sm:pt-12">
           {/* Headline */}
-          <h1 className="text-center text-[34px] font-normal tracking-tight text-foreground">
+          <h1 className="text-center text-[26px] font-normal tracking-tight text-foreground sm:text-[34px]">
             Make Cave work your way
           </h1>
 
           {/* Filter row */}
-          <div className="mt-10 flex items-center justify-between gap-4">
-            <div className="flex items-center gap-1 text-[13px]">
+          <div className="mt-8 flex flex-col gap-3 sm:mt-10 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+            <div className="-mx-1 flex items-center gap-1 overflow-x-auto px-1 text-[13px]">
               {([
                 { id: "curated" as const, label: "Curated by Cave" },
                 { id: "shared" as const, label: "Shared with you" },
@@ -254,7 +254,7 @@ export function PluginsView({ onOpenChat, onCreateReminder, onCreateSkill, onCre
                 <button
                   key={chip.id}
                   onClick={() => setFilter(chip.id)}
-                  className={`rounded-md px-3 py-1.5 transition-colors ${
+                  className={`shrink-0 rounded-md px-3 py-1.5 transition-colors ${
                     filter === chip.id
                       ? "bg-muted text-foreground"
                       : "text-muted-foreground hover:bg-card hover:text-foreground"
@@ -265,7 +265,7 @@ export function PluginsView({ onOpenChat, onCreateReminder, onCreateSkill, onCre
               ))}
               <button
                 onClick={() => setFilter("more")}
-                className={`flex items-center gap-1 rounded-md px-3 py-1.5 transition-colors ${
+                className={`flex shrink-0 items-center gap-1 rounded-md px-3 py-1.5 transition-colors ${
                   filter === "more"
                     ? "bg-muted text-foreground"
                     : "text-muted-foreground hover:bg-card hover:text-foreground"
@@ -276,7 +276,7 @@ export function PluginsView({ onOpenChat, onCreateReminder, onCreateSkill, onCre
               </button>
             </div>
 
-            <div className="relative">
+            <div className="relative w-full sm:w-auto">
               <Icon
                 name="ph:magnifying-glass-bold"
                 className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
@@ -288,7 +288,7 @@ export function PluginsView({ onOpenChat, onCreateReminder, onCreateSkill, onCre
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
                 placeholder={tab === "plugins" ? "Search plugins" : tab === "skills" ? "Search skills" : "Search capabilities"}
-                className="w-56 rounded-md border border-border bg-card py-1.5 pl-7 pr-3 text-[12px] text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-border-strong"
+                className="w-full rounded-md border border-border bg-card py-1.5 pl-7 pr-3 text-[12px] text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-border-strong sm:w-56"
               />
             </div>
           </div>
@@ -331,7 +331,7 @@ function PluginGrid({
     );
   }
   return (
-    <div className="grid grid-cols-2 gap-3">
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
       {items.map((h) => {
         const initial = (h.label.match(/[a-z0-9]/i)?.[0] ?? "?").toUpperCase();
         const tagline = HARNESS_TAGLINE[h.id] ?? `Run ${h.label} from a familiar`;
@@ -347,7 +347,7 @@ function PluginGrid({
                   ? `Open a chat with ${h.label}`
                   : `${h.label} is installed but native chat isn't wired yet`
             }
-            className={`group flex items-center gap-3 rounded-xl border border-border bg-card px-4 py-3 text-left transition-colors ${
+            className={`group flex min-w-0 items-center gap-3 rounded-xl border border-border bg-card px-4 py-3 text-left transition-colors ${
               h.installed
                 ? "hover:border-border-strong hover:bg-muted"
                 : "cursor-default opacity-70"
@@ -416,14 +416,14 @@ function SkillGrid({
     );
   }
   return (
-    <div className="grid grid-cols-2 gap-3">
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
       {items.map((s) => {
         const initial = (s.name.match(/[a-z0-9]/i)?.[0] ?? "?").toUpperCase();
         const tagline = [s.owner, s.category].filter(Boolean).join(" · ") || "Skill";
         return (
           <div
             key={s.id}
-            className="flex items-center gap-3 rounded-xl border border-border bg-card px-4 py-3"
+            className="flex min-w-0 items-center gap-3 rounded-xl border border-border bg-card px-4 py-3"
           >
             <span className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-[15px] font-semibold ${HARNESS_TILE}`}>
               {initial}
@@ -450,11 +450,11 @@ function SkillGrid({
 
 function GridSkeleton() {
   return (
-    <div className="grid grid-cols-2 gap-3">
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
       {Array.from({ length: 6 }).map((_, i) => (
         <div
           key={i}
-          className="flex items-center gap-3 rounded-xl border border-border bg-card px-4 py-3"
+          className="flex min-w-0 items-center gap-3 rounded-xl border border-border bg-card px-4 py-3"
         >
           <span className="h-10 w-10 shrink-0 animate-pulse rounded-lg bg-muted" />
           <span className="flex-1 space-y-1.5">
@@ -533,7 +533,7 @@ function CreateDropdown({
 
   return (
     <div
-      className="absolute right-0 top-[calc(100%+6px)] z-50 w-52 overflow-hidden rounded-xl border border-border bg-card shadow-lg"
+      className="absolute right-0 top-[calc(100%+6px)] z-50 w-52 max-w-[calc(100vw-1.5rem)] overflow-hidden rounded-xl border border-border bg-card shadow-lg"
       role="menu"
     >
       {CREATE_ITEMS.map((item, i) => (
@@ -551,7 +551,7 @@ function CreateDropdown({
           <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
             <Icon name={item.icon} className="text-[13px]" />
           </span>
-          <span className="flex flex-col">
+          <span className="flex min-w-0 flex-col">
             <span className="font-medium text-foreground">{item.label}</span>
             <span className="text-[10px] text-muted-foreground">{item.desc}</span>
           </span>
@@ -578,7 +578,7 @@ function CapabilitiesView({
 
   if (error) {
     return (
-      <div className="rounded-lg border border-border bg-card px-5 py-6">
+      <div className="rounded-lg border border-border bg-card px-4 py-6 sm:px-5">
         <p className="mb-3 text-[13px] text-muted-foreground">
           {error === "daemon offline"
             ? "Coven daemon is offline — harness capabilities require a running daemon."
@@ -629,9 +629,9 @@ function HarnessCapabilityCard({ manifest }: { manifest: HarnessCapabilityManife
     manifest.plugins.length;
 
   return (
-    <div className="rounded-xl border border-border bg-card">
+    <div className="min-w-0 rounded-xl border border-border bg-card">
       {/* Header */}
-      <div className="flex items-center gap-3 border-b border-border px-4 py-3">
+      <div className="flex flex-wrap items-center gap-3 border-b border-border px-4 py-3">
         <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted text-[13px] font-semibold text-foreground">
           {initial}
         </span>
@@ -641,7 +641,7 @@ function HarnessCapabilityCard({ manifest }: { manifest: HarnessCapabilityManife
             {totalItems === 0 ? "No config found" : `${totalItems} item${totalItems === 1 ? "" : "s"} configured`}
           </p>
         </div>
-        <span className="text-[10px] text-muted-foreground">
+        <span className="text-[10px] text-muted-foreground sm:ml-auto">
           {new Date(manifest.scanned_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
         </span>
       </div>
@@ -654,7 +654,7 @@ function HarnessCapabilityCard({ manifest }: { manifest: HarnessCapabilityManife
             <Icon name="ph:note-pencil" className="mt-0.5 shrink-0 text-muted-foreground" width="0.85rem" />
             <div className="min-w-0 flex-1">
               <p className="text-[12px] font-medium text-foreground">Global instructions</p>
-              <p className="truncate text-[11px] text-muted-foreground">
+              <p className="break-all text-[11px] text-muted-foreground sm:truncate">
                 {manifest.global_instructions.path?.replace(/^\/Users\/[^/]+/, "~") ?? "—"}
               </p>
               {manifest.global_instructions.byte_count !== undefined && (
@@ -682,9 +682,9 @@ function HarnessCapabilityCard({ manifest }: { manifest: HarnessCapabilityManife
                 <li key={s.id} className="flex items-start gap-2">
                   <Icon name="ph:sparkle" className="mt-0.5 shrink-0 text-muted-foreground" width="0.75rem" />
                   <div className="min-w-0">
-                    <p className="text-[12px] text-foreground">{s.name}</p>
+                    <p className="break-words text-[12px] text-foreground">{s.name}</p>
                     {s.description && (
-                      <p className="text-[11px] text-muted-foreground">{s.description}</p>
+                      <p className="break-words text-[11px] text-muted-foreground">{s.description}</p>
                     )}
                   </div>
                 </li>
@@ -704,8 +704,8 @@ function HarnessCapabilityCard({ manifest }: { manifest: HarnessCapabilityManife
                 <li key={p.id} className="flex items-start gap-2">
                   <Icon name="ph:plug" className="mt-0.5 shrink-0 text-muted-foreground" width="0.75rem" />
                   <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <p className="text-[12px] text-foreground">{p.name}</p>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="min-w-0 break-words text-[12px] text-foreground">{p.name}</p>
                       <span className="rounded-full bg-muted px-1.5 py-px text-[9px] text-muted-foreground uppercase tracking-wide">
                         {p.kind}
                       </span>
@@ -714,7 +714,7 @@ function HarnessCapabilityCard({ manifest }: { manifest: HarnessCapabilityManife
                       )}
                     </div>
                     {p.command && (
-                      <p className="truncate text-[11px] text-muted-foreground font-mono">
+                      <p className="break-all font-mono text-[11px] text-muted-foreground sm:truncate">
                         {p.command} {p.args?.join(" ")}
                       </p>
                     )}
@@ -729,9 +729,9 @@ function HarnessCapabilityCard({ manifest }: { manifest: HarnessCapabilityManife
         {manifest.warnings.length > 0 ? (
           <div className="px-4 py-3">
             {manifest.warnings.map((w, i) => (
-              <p key={i} className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+              <p key={i} className="flex items-start gap-1.5 text-[11px] text-muted-foreground">
                 <Icon name="ph:warning-fill" width={11} aria-hidden />
-                <span>{w.message}</span>
+                <span className="min-w-0 break-words">{w.message}</span>
               </p>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- make Calendar headers, agenda/day/week/month layouts fit narrow screens with internal grid scrolling where needed
- make Plugins tabs, filters, search, cards, dropdowns, and capability rows wrap/scroll cleanly on mobile
- preserve desktop density while avoiding page-level horizontal overflow

## Verification
- pnpm typecheck
- pnpm build
- git diff --check
- Headless Chrome viewport checks at 390x844, 768x800, and 1440x900 for Calendar and Plugins
- Screenshots captured in /tmp/coven-cave-responsive-shots
