### PR TITLE
fix(release): sign macOS DMG before notarization

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -157,9 +157,8 @@ xcrun stapler staple "$DMG_PATH"
 xcrun stapler staple "$APP_PATH"
 
 echo "==> Verifying Gatekeeper acceptance"
-spctl -a -vvv "$APP_PATH"
-spctl -a -t open --context context:primary-signature -vv "$DMG_PATH"
-
+spctl -a -vvv "$APP_PATH" || true
+spctl -a -t open --context context:primary-signature -vv "$DMG_PATH" || true
 if ! spctl -a -vvv "$APP_PATH" 2>&1 | grep -q "Notarized Developer ID"; then
   echo "Gatekeeper verification failed: app is not accepted as a notarized Developer ID app" >&2
   exit 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -126,6 +126,13 @@ cp -R "$APP_PATH" "$DMG_STAGE/"
 ln -s /Applications "$DMG_STAGE/Applications"
 hdiutil create -volname "${APP_NAME}" -srcfolder "$DMG_STAGE" -ov -format UDZO "$DMG_PATH" >/dev/null
 
+echo "==> Signing DMG envelope"
+codesign --force --timestamp \
+  --sign "$SIGNING_IDENTITY" "$DMG_PATH"
+
+echo "==> Verifying DMG signature"
+codesign -vvv "$DMG_PATH" 2>&1 | tail -n 5
+
 echo "==> Submitting DMG for notarization"
 if [ "$NOTARY_AUTH_MODE" = "apple-id" ]; then
   xcrun notarytool submit "$DMG_PATH" \
@@ -151,9 +158,14 @@ xcrun stapler staple "$APP_PATH"
 
 echo "==> Verifying Gatekeeper acceptance"
 spctl -a -vvv "$APP_PATH"
+spctl -a -t open --context context:primary-signature -vv "$DMG_PATH"
 
 if ! spctl -a -vvv "$APP_PATH" 2>&1 | grep -q "Notarized Developer ID"; then
   echo "Gatekeeper verification failed: app is not accepted as a notarized Developer ID app" >&2
+  exit 1
+fi
+if ! spctl -a -t open --context context:primary-signature -vv "$DMG_PATH" 2>&1 | grep -q "Notarized Developer ID"; then
+  echo "Gatekeeper verification failed: DMG is not accepted as a notarized Developer ID disk image" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- sign the generated macOS DMG with the Developer ID Application identity before notarization
- verify the DMG code signature before submit
- make release.sh fail on the same Gatekeeper DMG acceptance invariant as the workflow

## Root cause
The fallback release lane now gets notarization accepted and staples successfully, but the workflow gate still rejects the DMG with `source=no usable signature`. The .app is signed/notarized; the disk image envelope also needs a Developer ID signature before submission.

## Verification
- bash -n scripts/release.sh
- git diff --check
