### PR TITLE
fix(tauri): allow dev IPC for localhost

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,12 @@
   "windows": [
     "main"
   ],
+  "remote": {
+    "urls": [
+      "http://localhost:3000/*",
+      "http://127.0.0.1:3000/*"
+    ]
+  },
   "permissions": [
     "core:default",
     "default",


### PR DESCRIPTION
## Summary
- allow the main Tauri window to use app permissions from the localhost dev frontend
- cover both localhost and 127.0.0.1 on port 3000 so dev-app attachment keeps native terminal/browser IPC

## Verification
- jq . src-tauri/tauri.conf.json
- jq . src-tauri/capabilities/default.json
- pnpm typecheck
- pnpm build
- bash ../scripts/sidecar-bundle.sh && cargo check (from src-tauri)
- pnpm dev:app attached to existing localhost:3000 and launched the dev app

## Notes
- Tauri v2 uses remote capabilities for this; the older dangerousRemoteDomainIpcAccess field is rejected by tauri-build.