### PR TITLE
chore(release): stamp v0.0.39

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coven-cave",
-  "version": "0.0.28",
+  "version": "0.0.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coven-cave",
-      "version": "0.0.28",
+      "version": "0.0.39",
       "dependencies": {
         "@create-markdown/core": "2.0.3",
         "@create-markdown/preview": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- bump CovenCave package + Tauri versions to 0.0.39
- align package-lock root version metadata with the release stamp

## Includes since v0.0.38
- post-release calendar top-bar polish from current main
- #121 dev IPC capability fix for localhost Tauri dev app terminal/browser commands

## Verification
- pnpm install --frozen-lockfile
- version assertions for package.json, package-lock.json, and src-tauri/tauri.conf.json
- confirmed GitHub release v0.0.39 does not exist yet
- pnpm typecheck
- pnpm build
- bash ../scripts/sidecar-bundle.sh && cargo check (from src-tauri)
- git diff --check