### PR TITLE
fix(ui): default sessions to row layout

### DIFF
--- a/src/components/sessions-view.tsx
+++ b/src/components/sessions-view.tsx
@@ -60,18 +60,6 @@ function ViewSwitcher({
       <button
         type="button"
         className={`sessions-view-switcher-btn${
-          value === "cards" ? " sessions-view-switcher-btn--active" : ""
-        }`}
-        onClick={() => onChange("cards")}
-        aria-pressed={value === "cards"}
-        aria-label="Show sessions as cards"
-        title="Cards"
-      >
-        <Icon name="ph:squares-four" width={13} />
-      </button>
-      <button
-        type="button"
-        className={`sessions-view-switcher-btn${
           value === "rows" ? " sessions-view-switcher-btn--active" : ""
         }`}
         onClick={() => onChange("rows")}
@@ -80,6 +68,18 @@ function ViewSwitcher({
         title="Rows"
       >
         <Icon name="ph:list-bullets" width={13} />
+      </button>
+      <button
+        type="button"
+        className={`sessions-view-switcher-btn${
+          value === "cards" ? " sessions-view-switcher-btn--active" : ""
+        }`}
+        onClick={() => onChange("cards")}
+        aria-pressed={value === "cards"}
+        aria-label="Show sessions as grid"
+        title="Grid"
+      >
+        <Icon name="ph:squares-four" width={13} />
       </button>
     </div>
   );
@@ -295,7 +295,7 @@ export function SessionsView({
   onNewChat,
 }: SessionsViewProps) {
   const overrides = useGlyphOverrides();
-  const [layoutMode, setLayoutMode] = useState<SessionsLayoutMode>("cards");
+  const [layoutMode, setLayoutMode] = useState<SessionsLayoutMode>("rows");
   const activeFamiliar = familiars.find((f) => f.id === activeFamiliarId) ?? null;
 
   // Sort sessions newest-first

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -12,9 +12,6 @@
 
 import { useMemo } from "react";
 import { Icon } from "@/lib/icon";
-import { FamiliarGlyph } from "@/components/familiar-glyph";
-import { resolveFamiliarGlyph } from "@/lib/familiar-glyph";
-import { useGlyphOverrides } from "@/lib/cave-glyph-overrides";
 import type { Familiar, SessionRow } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
@@ -155,18 +152,12 @@ function FamiliarRow({
   active: boolean;
   onSelect: () => void;
 }) {
-  const overrides = useGlyphOverrides();
-  const glyph = resolveFamiliarGlyph(familiar, overrides);
-
   return (
     <button
       type="button"
       className={`sidebar-familiar-row${active ? " sidebar-familiar-row--active" : ""}`}
       onClick={onSelect}
     >
-      <span className="sidebar-familiar-row-glyph">
-        <FamiliarGlyph glyph={glyph} size="sm" />
-      </span>
       <span className="sidebar-familiar-row-name">{familiar.display_name}</span>
       {sessionCount > 0 && (
         <span className="sidebar-familiar-row-count">{sessionCount}</span>


### PR DESCRIPTION
## Summary
- default Sessions to row/list layout
- keep grid available as the secondary layout option
- remove familiar glyph/emoji rendering from the left sidebar familiar selector rows

## Verification
- focused source assertion: fails before, passes after
- pnpm install --frozen-lockfile
- pnpm typecheck
- pnpm build (passes; known Turbopack NFT warning remains)
- git diff --check
- localhost:3001 HTTP smoke