### PR TITLE
fix(board): expand familiar workflow lanes

### DIFF
--- a/src/app/api/board/[id]/route.ts
+++ b/src/app/api/board/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import {
   deleteCard,
   updateCard,
+  type CardLifecycle,
   type CardPriority,
   type CardStatus,
 } from "@/lib/cave-board";
@@ -17,10 +18,14 @@ export async function PATCH(
     title: string;
     notes: string;
     status: CardStatus;
+    lifecycle: CardLifecycle;
+    lifecycleReason: string | undefined;
     priority: CardPriority;
     familiarId: string | null;
     sessionId: string | null;
     labels: string[];
+    needsHuman: boolean;
+    runningSince: string | undefined;
   }>;
   try {
     body = await req.json();

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -18,12 +18,6 @@ import {
   type CardStatus,
 } from "@/lib/cave-board-types";
 
-const COLUMNS: { id: CardStatus; label: string }[] = [
-  { id: "inbox", label: "Inbox" },
-  { id: "running", label: "Running" },
-  { id: "review", label: "Review" },
-];
-
 // Priority chrome stays neutral per Mood C — visual emphasis comes from
 // border + text weight, not saturated fills. Reserves accent for presence.
 const PRIORITIES: { id: CardPriority; label: string; pill: string }[] = [
@@ -40,16 +34,50 @@ type Props = {
   onJumpToSession?: (sessionId: string, familiarId: string | null) => void;
 };
 
+type BoardColumn = {
+  id: CardStatus;
+  label: string;
+  hint: string;
+};
+
+const COLUMNS: BoardColumn[] = [
+  { id: "backlog", label: "Backlog", hint: "Ideas and work not ready to dispatch." },
+  { id: "inbox", label: "Inbox", hint: "Ready for a familiar to pick up." },
+  { id: "running", label: "Running", hint: "In use by a familiar right now." },
+  { id: "review", label: "Review", hint: "Needs human or maintainer review." },
+  { id: "blocked", label: "Blocked", hint: "Waiting, failed, cancelled, or needs help." },
+  { id: "done", label: "Done", hint: "Completed work." },
+];
+
+function lifecycleForStatus(status: CardStatus): CardLifecycle {
+  if (status === "running") return "running";
+  if (status === "review") return "review";
+  if (status === "blocked") return "failed";
+  if (status === "done") return "completed";
+  return "queued";
+}
+
+function patchForStatus(status: CardStatus): Partial<Card> {
+  const patch: Partial<Card> = {
+    status,
+    lifecycle: lifecycleForStatus(status),
+    needsHuman: status === "blocked" ? true : false,
+  };
+  if (status === "running") patch.runningSince = new Date().toISOString();
+  return patch;
+}
+
 export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSession }: Props) {
   const [cards, setCards] = useState<Card[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
-  const [modalDefaultStatus, setModalDefaultStatus] = useState<CardStatus>("inbox");
+  const [modalDefaultStatus, setModalDefaultStatus] = useState<CardStatus>("backlog");
   const [priorityFilter, setPriorityFilter] = useState<Set<CardPriority>>(new Set());
   const [scopeToFamiliar, setScopeToFamiliar] = useState<boolean>(false);
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<CardStatus | null>(null);
   const draggingIdRef = useRef<string | null>(null);
+  const boardRailRef = useRef<HTMLDivElement | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -124,6 +152,17 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
     setCards((prev) => prev.map((c) => (c.id === next.id ? next : c)));
   };
 
+  const moveCardToStatus = (id: string, status: CardStatus) => {
+    void patchCard(id, patchForStatus(status));
+  };
+
+  const scrollColumns = (direction: -1 | 1) => {
+    const rail = boardRailRef.current;
+    if (!rail) return;
+    const step = Math.max(rail.clientWidth * 0.72, 280);
+    rail.scrollBy({ left: step * direction, behavior: "smooth" });
+  };
+
   const handleDragStart = (e: React.DragEvent, id: string) => {
     draggingIdRef.current = id;
     setDraggingId(id);
@@ -170,7 +209,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
     if (!id) return;
     const card = cards.find((c) => c.id === id);
     if (!card || card.status === status) return;
-    void patchCard(id, { status });
+    moveCardToStatus(id, status);
   };
 
   const removeCard = async (id: string) => {
@@ -191,6 +230,26 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
         </div>
 
         <div className="ml-auto flex items-center gap-2">
+          <div className="flex items-center gap-1" aria-label="Board column navigation">
+            <button
+              type="button"
+              onClick={() => scrollColumns(-1)}
+              aria-label="Show previous board columns"
+              title="Show previous board columns"
+              className="grid h-7 w-7 place-items-center rounded-md border border-border bg-card text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <Icon name="ph:arrow-left-bold" width={12} />
+            </button>
+            <button
+              type="button"
+              onClick={() => scrollColumns(1)}
+              aria-label="Show next board columns"
+              title="Show next board columns"
+              className="grid h-7 w-7 place-items-center rounded-md border border-border bg-card text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <Icon name="ph:arrow-right-bold" width={12} />
+            </button>
+          </div>
           {activeFamiliarId ? (
             <button
               onClick={() => setScopeToFamiliar((v) => !v)}
@@ -206,7 +265,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
           ) : null}
           <button
             onClick={() => {
-              setModalDefaultStatus("inbox");
+              setModalDefaultStatus("backlog");
               setModalOpen(true);
             }}
             className="rounded-md border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted"
@@ -253,7 +312,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
           <p className="text-[13px] text-muted-foreground">No cards yet.</p>
           <button
             onClick={() => {
-              setModalDefaultStatus("inbox");
+              setModalDefaultStatus("backlog");
               setModalOpen(true);
             }}
             className="rounded-md border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted"
@@ -262,76 +321,84 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
           </button>
         </div>
       ) : (
-      <div className="min-h-0 flex-1 overflow-hidden">
-        <div className="flex h-full w-full gap-3 px-5 py-4">
-          {COLUMNS.map((col) => {
-            const rows = grouped.get(col.id) ?? [];
-            const isDropTarget = dropTarget === col.id;
-            return (
-              <div
-                key={col.id}
-                onDragEnter={(e) => handleDragEnter(e, col.id)}
-                onDragOver={(e) => handleDragOver(e, col.id)}
-                onDragLeave={(e) => handleDragLeave(e, col.id)}
-                onDrop={(e) => handleDrop(e, col.id)}
-                className={`flex h-full min-w-0 flex-1 basis-0 flex-col rounded-xl border bg-card transition-colors ${
-                  isDropTarget
-                    ? "border-border-strong bg-muted"
-                    : "border-border"
-                }`}
-              >
-                <div className="flex items-center justify-between border-b border-border px-3 py-2">
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm font-medium text-foreground">{col.label}</span>
-                    <span className="rounded-full bg-muted px-1.5 py-px text-[10px] text-muted-foreground">
-                      {rows.length}
-                    </span>
-                  </div>
-                  <button
-                    onClick={() => {
-                      setModalDefaultStatus(col.id);
-                      setModalOpen(true);
-                    }}
-                    title={`Add card to ${col.label}`}
-                    className="grid h-5 w-5 place-items-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <div
+            ref={boardRailRef}
+            className="h-full overflow-x-auto overflow-y-hidden scroll-smooth"
+          >
+            <div className="flex h-full min-w-max gap-3 px-5 py-4">
+              {COLUMNS.map((col) => {
+                const rows = grouped.get(col.id) ?? [];
+                const isDropTarget = dropTarget === col.id;
+                return (
+                  <div
+                    key={col.id}
+                    onDragEnter={(e) => handleDragEnter(e, col.id)}
+                    onDragOver={(e) => handleDragOver(e, col.id)}
+                    onDragLeave={(e) => handleDragLeave(e, col.id)}
+                    onDrop={(e) => handleDrop(e, col.id)}
+                    className={`flex h-full w-[260px] flex-shrink-0 flex-col rounded-xl border bg-card transition-colors sm:w-[280px] xl:w-[300px] ${
+                      isDropTarget
+                        ? "border-border-strong bg-muted"
+                        : "border-border"
+                    }`}
                   >
-                    +
-                  </button>
-                </div>
+                    <div className="flex items-center justify-between border-b border-border px-3 py-2">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-foreground" title={col.hint}>
+                          {col.label}
+                        </span>
+                        <span className="rounded-full bg-muted px-1.5 py-px text-[10px] text-muted-foreground">
+                          {rows.length}
+                        </span>
+                      </div>
+                      <button
+                        onClick={() => {
+                          setModalDefaultStatus(col.id);
+                          setModalOpen(true);
+                        }}
+                        title={`Add card to ${col.label}`}
+                        className="grid h-5 w-5 place-items-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                      >
+                        +
+                      </button>
+                    </div>
 
-                <ul className="min-h-0 flex-1 space-y-2 overflow-y-auto p-2">
-                  {rows.length === 0 ? (
-                    <li
-                      className={`rounded-md border border-dashed px-3 py-4 text-center text-[11px] transition-colors ${
-                        isDropTarget
-                          ? "border-border-strong text-foreground"
-                          : "border-border text-muted-foreground"
-                      }`}
-                    >
-                      {isDropTarget ? "Drop here" : "Empty"}
-                    </li>
-                  ) : null}
-                  {rows.map((card) => (
-                    <CardItem
-                      key={card.id}
-                      card={card}
-                      familiars={familiars}
-                      sessions={sessions}
-                      isDragging={draggingId === card.id}
-                      onDragStart={(e) => handleDragStart(e, card.id)}
-                      onDragEnd={handleDragEnd}
-                      onPatch={(patch) => patchCard(card.id, patch)}
-                      onDelete={() => removeCard(card.id)}
-                      onCardReplaced={replaceCard}
-                      onJumpToSession={onJumpToSession}
-                    />
-                  ))}
-                </ul>
-              </div>
-            );
-          })}
+                    <ul className="min-h-0 flex-1 space-y-2 overflow-y-auto p-2">
+                      {rows.length === 0 ? (
+                        <li
+                          className={`rounded-md border border-dashed px-3 py-4 text-center text-[11px] transition-colors ${
+                            isDropTarget
+                              ? "border-border-strong text-foreground"
+                              : "border-border text-muted-foreground"
+                          }`}
+                        >
+                          {isDropTarget ? "Drop here" : "Empty"}
+                        </li>
+                      ) : null}
+                      {rows.map((card) => (
+                        <CardItem
+                          key={card.id}
+                          card={card}
+                          familiars={familiars}
+                          sessions={sessions}
+                          isDragging={draggingId === card.id}
+                          onDragStart={(e) => handleDragStart(e, card.id)}
+                          onDragEnd={handleDragEnd}
+                          onPatch={(patch) => patchCard(card.id, patch)}
+                          onMoveStatus={(status) => moveCardToStatus(card.id, status)}
+                          onDelete={() => removeCard(card.id)}
+                          onCardReplaced={replaceCard}
+                          onJumpToSession={onJumpToSession}
+                        />
+                      ))}
+                    </ul>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
         </div>
-      </div>
       )}
 
       <NewCardModal
@@ -355,6 +422,7 @@ function CardItem({
   onDragStart,
   onDragEnd,
   onPatch,
+  onMoveStatus,
   onDelete,
   onCardReplaced,
   onJumpToSession,
@@ -366,6 +434,7 @@ function CardItem({
   onDragStart?: (e: React.DragEvent) => void;
   onDragEnd?: () => void;
   onPatch: (patch: Partial<Card>) => void;
+  onMoveStatus: (status: CardStatus) => void;
   onDelete: () => void;
   onCardReplaced: (card: Card) => void;
   onJumpToSession?: (sessionId: string, familiarId: string | null) => void;
@@ -477,7 +546,7 @@ function CardItem({
             <Mini label="Status">
               <select
                 value={card.status}
-                onChange={(e) => onPatch({ status: e.target.value as CardStatus })}
+                onChange={(e) => onMoveStatus(e.target.value as CardStatus)}
                 className="w-full rounded border border-border bg-background px-1.5 py-1 text-[11px] text-foreground"
               >
                 {COLUMNS.map((c) => (

--- a/src/components/new-card-modal.tsx
+++ b/src/components/new-card-modal.tsx
@@ -4,12 +4,12 @@ import { useEffect, useState } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { Modal } from "@/components/ui/modal";
 import { PropertyPill } from "@/components/ui/property-pill";
-
-const STATUSES: CardStatus[] = ["inbox", "running", "review"];
-const PRIORITIES: CardPriority[] = ["urgent", "high", "medium", "low"];
-
-type CardStatus = "inbox" | "running" | "review";
-type CardPriority = "low" | "medium" | "high" | "urgent";
+import {
+  STATUSES,
+  PRIORITIES,
+  type CardPriority,
+  type CardStatus,
+} from "@/lib/cave-board-types";
 
 export type NewCardDraft = {
   title: string;

--- a/src/lib/cave-board-types.ts
+++ b/src/lib/cave-board-types.ts
@@ -1,4 +1,4 @@
-export type CardStatus = "inbox" | "running" | "review";
+export type CardStatus = "backlog" | "inbox" | "running" | "review" | "blocked" | "done";
 export type CardPriority = "low" | "medium" | "high" | "urgent";
 export type CardLifecycle =
   | "queued"
@@ -31,7 +31,7 @@ export type Card = {
   maxRetries: number;
 };
 
-export const STATUSES: CardStatus[] = ["inbox", "running", "review"];
+export const STATUSES: CardStatus[] = ["backlog", "inbox", "running", "review", "blocked", "done"];
 export const PRIORITIES: CardPriority[] = ["urgent", "high", "medium", "low"];
 export const LIFECYCLES: CardLifecycle[] = [
   "queued",

--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -32,14 +32,25 @@ const BOARD_PATH = path.join(homedir(), ".coven", "cave-board.json");
 function inferLifecycle(status: CardStatus): CardLifecycle {
   if (status === "running") return "running";
   if (status === "review") return "review";
+  if (status === "done") return "completed";
+  if (status === "blocked") return "failed";
   return "queued";
 }
 
+function statusForLifecycle(lifecycle: CardLifecycle, currentStatus: CardStatus): CardStatus {
+  if (lifecycle === "dispatched" || lifecycle === "running") return "running";
+  if (lifecycle === "review") return "review";
+  if (lifecycle === "completed") return "done";
+  if (lifecycle === "failed" || lifecycle === "cancelled") return "blocked";
+  return currentStatus;
+}
+
 function backfillCard(c: Card | (Omit<Card, "lifecycle" | "lifecycleAt" | "retryCount" | "maxRetries"> & Partial<Pick<Card, "lifecycle" | "lifecycleAt" | "retryCount" | "maxRetries">>)): Card {
-  const inferred = inferLifecycle(c.status);
+  const lifecycle = c.lifecycle ?? inferLifecycle(c.status);
   return {
     ...c,
-    lifecycle: c.lifecycle ?? inferred,
+    status: statusForLifecycle(lifecycle, c.status),
+    lifecycle,
     lifecycleAt: c.lifecycleAt ?? c.updatedAt,
     retryCount: c.retryCount ?? 0,
     maxRetries: c.maxRetries ?? DEFAULT_MAX_RETRIES,
@@ -90,7 +101,7 @@ export type NewCardInput = {
 export async function createCard(input: NewCardInput): Promise<Card> {
   const board = await loadBoard();
   const now = new Date().toISOString();
-  const status: CardStatus = input.status ?? "inbox";
+  const status: CardStatus = input.status ?? "backlog";
   const card: Card = {
     id: crypto.randomUUID(),
     title: input.title.trim(),
@@ -131,6 +142,11 @@ export async function updateCard(
       ? patch.labels.map((l) => l.trim()).filter(Boolean)
       : current.labels,
   };
+  if (next.status === "running" && !next.runningSince) {
+    next.runningSince = next.updatedAt;
+  } else if (next.status !== "running") {
+    delete next.runningSince;
+  }
   board.cards[idx] = next;
   await saveBoard(board);
   return next;
@@ -139,8 +155,8 @@ export async function updateCard(
 /**
  * Move a card through the lifecycle state machine. Encapsulates the rules
  * we don't want call sites to forget — most importantly that `failed`
- * without remaining retries auto-rolls the card back to the Inbox column
- * with a `needs human` flag.
+ * without remaining retries moves the card into the Blocked column with a
+ * `needs human` flag.
  *
  * Transitions enforced:
  *   queued      → dispatched | cancelled
@@ -194,23 +210,30 @@ export async function transitionCard(
     next.status = "running";
     next.runningSince = now;
     next.needsHuman = false;
+  } else if (to === "dispatched") {
+    next.status = "running";
+    next.needsHuman = false;
   } else if (to === "review") {
     next.status = "review";
   } else if (to === "completed") {
-    next.status = "review"; // stay in Review column; lifecycle distinguishes
+    next.status = "done";
+    next.needsHuman = false;
   } else if (to === "failed") {
     const exhausted = current.retryCount >= current.maxRetries;
     if (exhausted) {
-      // Auto-rollback: failed without remaining retries → back to Inbox
-      // with `needs human` flag. Spec section 3 (rollback behavior).
-      next.status = "inbox";
+      // Auto-rollback: failed without remaining retries → Blocked with
+      // `needs human` flag. Spec section 3 (rollback behavior).
+      next.status = "blocked";
       next.needsHuman = true;
+    } else {
+      next.status = "blocked";
     }
   } else if (to === "queued" && retry) {
     next.retryCount = current.retryCount + 1;
-    next.status = "inbox";
+    next.status = "backlog";
     next.needsHuman = false;
   } else if (to === "cancelled") {
+    next.status = "blocked";
     next.needsHuman = false;
   }
 


### PR DESCRIPTION
## Summary
- expand the board from the old three lanes to Backlog, Inbox, Running, Review, Blocked, and Done
- make top-level new cards start in Backlog while per-column add buttons keep their column default
- keep manual moves in sync with lifecycle/needsHuman/runningSince so familiar work moves between lanes cleanly
- normalize older lifecycle cards into the new lanes and add left/right board scroll controls

## Verification
- focused board workflow assertions
- pnpm typecheck
- pnpm build (passes with existing Turbopack NFT warning)
- git diff --check

Note: a throwaway dev server on port 3010 responded for / and /api/board; Chrome headless screenshot automation hung and was killed rather than left running.