### PR TITLE
fix(board): address workflow review threads

### DIFF
--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -230,7 +230,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
         </div>
 
         <div className="ml-auto flex items-center gap-2">
-          <div className="flex items-center gap-1" aria-label="Board column navigation">
+          <div className="flex items-center gap-1" role="group" aria-label="Board column navigation">
             <button
               type="button"
               onClick={() => scrollColumns(-1)}

--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -142,9 +142,9 @@ export async function updateCard(
       ? patch.labels.map((l) => l.trim()).filter(Boolean)
       : current.labels,
   };
-  if (next.status === "running" && !next.runningSince) {
+  if (next.lifecycle === "running" && !next.runningSince) {
     next.runningSince = next.updatedAt;
-  } else if (next.status !== "running") {
+  } else if (next.lifecycle !== "running") {
     delete next.runningSince;
   }
   board.cards[idx] = next;
@@ -204,6 +204,9 @@ export async function transitionCard(
     lifecycleReason: reason ?? undefined,
     updatedAt: now,
   };
+  if (to !== "running") {
+    delete next.runningSince;
+  }
 
   // Column-status fallouts of lifecycle transitions:
   if (to === "running") {
@@ -228,8 +231,10 @@ export async function transitionCard(
     } else {
       next.status = "blocked";
     }
-  } else if (to === "queued" && retry) {
-    next.retryCount = current.retryCount + 1;
+  } else if (to === "queued") {
+    if (retry) {
+      next.retryCount = current.retryCount + 1;
+    }
     next.status = "backlog";
     next.needsHuman = false;
   } else if (to === "cancelled") {


### PR DESCRIPTION
## Summary
- fix #126 thread PRRT_kwDOSsT04M6HioVE: queued transitions now always move cards back to Backlog and clear needsHuman, including cancelled -> queued; retry still increments only when requested
- fix #126 thread PRRT_kwDOSsT04M6HioVJ: runningSince is now keyed off lifecycle === running, so dispatched cards do not get synthetic start times during unrelated edits
- fix #126 thread PRRT_kwDOSsT04M6HioVL: board column navigation label now has role="group" so the aria-label is exposed

## Verification
- focused review-thread assertions
- pnpm typecheck
- pnpm build (passes with existing Turbopack NFT warning)
- git diff --check
