### PR TITLE
fix: app icon size + home page layout tightening

### DIFF
--- a/src/components/coven-floor-mini.tsx
+++ b/src/components/coven-floor-mini.tsx
@@ -99,7 +99,7 @@ export function CovenFloorMini({ onSelectFamiliar }: Props) {
   // Skeleton while loading
   if (loading) {
     return (
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap gap-2 w-full max-w-[600px]">
         {[1, 2, 3].map((i) => (
           <div
             key={i}

--- a/src/components/coven-floor-mini.tsx
+++ b/src/components/coven-floor-mini.tsx
@@ -99,7 +99,7 @@ export function CovenFloorMini({ onSelectFamiliar }: Props) {
   // Skeleton while loading
   if (loading) {
     return (
-      <div className="flex flex-wrap gap-2 mt-4">
+      <div className="flex flex-wrap gap-2">
         {[1, 2, 3].map((i) => (
           <div
             key={i}
@@ -118,7 +118,7 @@ export function CovenFloorMini({ onSelectFamiliar }: Props) {
   const sorted = [...active, ...rest];
 
   return (
-    <div className="mt-5 select-none">
+    <div className="select-none w-full" style={{ maxWidth: "600px" }}>
       <p className="mb-2 text-[11px] uppercase tracking-widest" style={{ color: "rgba(255,255,255,0.2)" }}>
         Coven
       </p>

--- a/src/components/coven-floor-mini.tsx
+++ b/src/components/coven-floor-mini.tsx
@@ -118,7 +118,7 @@ export function CovenFloorMini({ onSelectFamiliar }: Props) {
   const sorted = [...active, ...rest];
 
   return (
-    <div className="select-none w-full" style={{ maxWidth: "600px" }}>
+    <div className="select-none w-full max-w-[600px]">
       <p className="mb-2 text-[11px] uppercase tracking-widest" style={{ color: "rgba(255,255,255,0.2)" }}>
         Coven
       </p>

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -11,8 +11,8 @@
   justify-content: center;
   flex: 1;
   min-height: 0;
-  padding: 48px 32px 64px;
-  gap: 28px;
+  padding: 32px 32px 48px;
+  gap: 20px;
   overflow-y: auto;
 }
 
@@ -20,7 +20,7 @@
 .home-composer-headline {
   font-family: var(--font-fredoka, "Fredoka", system-ui, sans-serif);
   font-weight: 600;
-  font-size: clamp(24px, 4vw, 40px);
+  font-size: clamp(22px, 3.5vw, 36px);
   line-height: 1.15;
   text-align: center;
   color: var(--text-primary);
@@ -31,7 +31,7 @@
 /* ── Composer card ───────────────────────────────────────────────────────── */
 .home-composer-card {
   width: 100%;
-  max-width: 640px;
+  max-width: 600px;
   background: var(--bg-raised);
   border: 1px solid var(--border-strong);
   border-radius: 14px;
@@ -236,7 +236,7 @@
 /* ── Suggestions ─────────────────────────────────────────────────────────── */
 .home-composer-suggestions {
   width: 100%;
-  max-width: 640px;
+  max-width: 600px;
   display: flex;
   flex-direction: column;
   gap: 8px;


### PR DESCRIPTION
## What
Two visual fixes from Val's review:

### 🖼 App icon
The icon glyph was occupying only ~22% of the canvas — tiny logo floating in a big black square. Fixed to ~82% fill (macOS recommended).
- Rescaled all `.icns` sizes from corrected `icon.png`
- Updated app bundle + DMG icon

### 🏠 Home page layout
Tighter, better-proportioned vertical rhythm:
- Root padding: 48→32px top, 64→48px bottom
- Gap: 28→20px
- Composer + suggestions max-width: 640→600px
- Headline max font-size: 40→36px
- `CovenFloorMini`: removed `mt-5` (gap now handled by parent), aligned to composer width (max-w 600px), removed skeleton `mt-4`