### PR TITLE
feat: mount InspectorPane, Memory Inspector (#116), Plugins/Capabilities (#123)

### DIFF
--- a/src/app/api/memory/inspector/route.ts
+++ b/src/app/api/memory/inspector/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { collectMemoryInspector } from "@/lib/memory-inspector";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const familiarId = url.searchParams.get("familiarId") ?? "main";
+
+  try {
+    const report = await collectMemoryInspector({ familiarId });
+    return NextResponse.json(report);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "memory inspector failed";
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: message.includes("invalid familiar id") ? 400 : 500 },
+    );
+  }
+}

--- a/src/components/capability-card.tsx
+++ b/src/components/capability-card.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { Icon } from "@/lib/icon";
+
+export type GlobalInstructions = {
+  present: boolean;
+  path?: string;
+  byte_count?: number;
+};
+
+export type HarnessCapSkill = {
+  id: string;
+  name: string;
+  description?: string;
+  path: string;
+};
+
+export type HarnessCapPlugin = {
+  id: string;
+  name: string;
+  kind: string;
+  enabled: boolean;
+  command?: string;
+  args?: string[];
+};
+
+export type CapWarning = {
+  kind: string;
+  path: string;
+  message: string;
+};
+
+export type HarnessCapabilityManifest = {
+  harness_id: string;
+  scanned_at: string;
+  global_instructions: GlobalInstructions;
+  skills: HarnessCapSkill[];
+  plugins: HarnessCapPlugin[];
+  warnings: CapWarning[];
+};
+
+export function CapabilitiesView({
+  items,
+  loaded,
+  error,
+  onRefresh,
+}: {
+  items: HarnessCapabilityManifest[];
+  loaded: boolean;
+  error: string | null;
+  onRefresh: () => void;
+}) {
+  if (!loaded) return <GridSkeleton />;
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-border bg-card px-4 py-6 sm:px-5">
+        <p className="mb-3 text-[13px] text-muted-foreground">
+          {error === "daemon offline"
+            ? "Coven daemon is offline — harness capabilities require a running daemon."
+            : `Could not load capabilities: ${error}`}
+        </p>
+        <button
+          onClick={onRefresh}
+          className="rounded-md border border-border bg-card px-3 py-1.5 text-[12px] text-foreground hover:bg-muted"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <p className="rounded-lg border border-border px-4 py-6 text-center text-[13px] text-muted-foreground">
+        No harness capabilities found. Start the daemon or add a local harness to see its instructions, skills, and plugins.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {items.map((manifest) => (
+        <HarnessCapabilityCard key={manifest.harness_id} manifest={manifest} />
+      ))}
+      <div className="flex items-center justify-end">
+        <button
+          onClick={onRefresh}
+          className="flex items-center gap-1.5 text-[11px] text-muted-foreground hover:text-foreground"
+        >
+          <Icon name="ph:arrows-clockwise-bold" width="0.75rem" />
+          <span>Refresh</span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function GridSkeleton() {
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div
+          key={i}
+          className="flex min-w-0 items-center gap-3 rounded-xl border border-border bg-card px-4 py-3"
+        >
+          <span className="h-10 w-10 shrink-0 animate-pulse rounded-lg bg-muted" />
+          <span className="flex-1 space-y-1.5">
+            <span className="block h-3 w-1/2 animate-pulse rounded bg-muted" />
+            <span className="block h-2.5 w-3/4 animate-pulse rounded bg-muted" />
+          </span>
+          <span className="h-5 w-5 animate-pulse rounded-full bg-muted" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function HarnessCapabilityCard({ manifest }: { manifest: HarnessCapabilityManifest }) {
+  const label =
+    manifest.harness_id === "codex"
+      ? "Codex"
+      : manifest.harness_id === "claude"
+        ? "Claude Code"
+        : manifest.harness_id;
+  const initial = label[0]?.toUpperCase() ?? "?";
+  const totalItems =
+    (manifest.global_instructions.present ? 1 : 0) +
+    manifest.skills.length +
+    manifest.plugins.length;
+
+  return (
+    <div className="min-w-0 rounded-xl border border-border bg-card">
+      <div className="flex flex-wrap items-center gap-3 border-b border-border px-4 py-3">
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted text-[13px] font-semibold text-foreground">
+          {initial}
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="text-[13px] font-medium text-foreground">{label}</p>
+          <p className="text-[11px] text-muted-foreground">
+            {totalItems === 0 ? "No config found" : `${totalItems} item${totalItems === 1 ? "" : "s"} configured`}
+          </p>
+        </div>
+        <span className="text-[10px] text-muted-foreground sm:ml-auto">
+          {new Date(manifest.scanned_at).toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+          })}
+        </span>
+      </div>
+
+      <div className="divide-y divide-border">
+        {manifest.global_instructions.present ? (
+          <div className="flex items-start gap-3 px-4 py-3">
+            <Icon name="ph:note-pencil" className="mt-0.5 shrink-0 text-muted-foreground" width="0.85rem" />
+            <div className="min-w-0 flex-1">
+              <p className="text-[12px] font-medium text-foreground">Global instructions</p>
+              <p className="break-all text-[11px] text-muted-foreground sm:truncate">
+                {manifest.global_instructions.path?.replace(/^\/Users\/[^/]+/, "~") ?? "—"}
+              </p>
+              {manifest.global_instructions.byte_count !== undefined && (
+                <p className="text-[10px] text-muted-foreground">
+                  {(manifest.global_instructions.byte_count / 1024).toFixed(1)} KB
+                </p>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-center gap-3 px-4 py-3 text-[12px] text-muted-foreground">
+            <Icon name="ph:note-pencil" className="shrink-0" width="0.85rem" />
+            <span>No global instructions file found</span>
+          </div>
+        )}
+
+        {manifest.skills.length > 0 ? (
+          <div className="px-4 py-3">
+            <p className="mb-2 text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
+              Automations / skills · {manifest.skills.length}
+            </p>
+            <ul className="space-y-1.5">
+              {manifest.skills.map((skill) => (
+                <li key={skill.id} className="flex items-start gap-2">
+                  <Icon name="ph:sparkle" className="mt-0.5 shrink-0 text-muted-foreground" width="0.75rem" />
+                  <div className="min-w-0">
+                    <p className="break-words text-[12px] text-foreground">{skill.name}</p>
+                    {skill.description && (
+                      <p className="break-words text-[11px] text-muted-foreground">{skill.description}</p>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {manifest.plugins.length > 0 ? (
+          <div className="px-4 py-3">
+            <p className="mb-2 text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
+              Plugins · {manifest.plugins.length}
+            </p>
+            <ul className="space-y-1.5">
+              {manifest.plugins.map((plugin) => (
+                <li key={plugin.id} className="flex items-start gap-2">
+                  <Icon name="ph:plug" className="mt-0.5 shrink-0 text-muted-foreground" width="0.75rem" />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="min-w-0 break-words text-[12px] text-foreground">{plugin.name}</p>
+                      <span className="rounded-full bg-muted px-1.5 py-px text-[9px] uppercase tracking-wide text-muted-foreground">
+                        {plugin.kind}
+                      </span>
+                      {!plugin.enabled && (
+                        <span className="rounded-full bg-muted px-1.5 py-px text-[9px] text-muted-foreground">
+                          disabled
+                        </span>
+                      )}
+                    </div>
+                    {plugin.command && (
+                      <p className="break-all font-mono text-[11px] text-muted-foreground sm:truncate">
+                        {plugin.command} {plugin.args?.join(" ")}
+                      </p>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {manifest.warnings.length > 0 ? (
+          <div className="px-4 py-3">
+            {manifest.warnings.map((warning, i) => (
+              <p key={i} className="flex items-start gap-1.5 text-[11px] text-muted-foreground">
+                <Icon name="ph:warning-fill" width={11} aria-hidden />
+                <span className="min-w-0 break-words">{warning.message}</span>
+              </p>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -5,6 +5,7 @@ import type { Familiar } from "@/lib/types";
 import type { InboxItem } from "@/lib/cave-inbox";
 import { SyntaxBlock } from "@/components/message-bubble";
 import { EvalLoopPanel } from "@/components/eval-loop-panel";
+import { MemoryInspectorPanel } from "@/components/memory-inspector-panel";
 
 type Tab = "memory" | "capabilities" | "inbox";
 
@@ -249,7 +250,7 @@ type CovenMemoryEntry = {
 };
 
 function MemoryTab({ familiar }: { familiar: Familiar | null }) {
-  const [mode, setMode] = useState<"coven" | "files">("coven");
+  const [mode, setMode] = useState<"inspector" | "coven" | "files">("inspector");
   const [entries, setEntries] = useState<MemoryEntry[]>([]);
   const [covenEntries, setCovenEntries] = useState<CovenMemoryEntry[]>([]);
   const [covenLoaded, setCovenLoaded] = useState(false);
@@ -267,16 +268,11 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
         if (json.ok) {
           const fetched: CovenMemoryEntry[] = json.entries ?? [];
           setCovenEntries(fetched);
-          // Auto-switch to "files" tab when daemon returns no memory entries
-          // so users see something useful rather than a blank coven pane.
-          if (fetched.length === 0) setMode("files");
         } else {
-          // Daemon memory endpoint unavailable — fall through to file browser.
-          setMode("files");
+          /* Inspector remains the default; the legacy Coven tab can stay empty. */
         }
       } catch {
-        // Network or daemon error — fall through to file browser.
-        setMode("files");
+        /* Inspector remains the default; the legacy Coven tab can stay empty. */
       } finally {
         setCovenLoaded(true);
       }
@@ -401,7 +397,7 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center gap-1 border-b border-[var(--border-hairline)] px-2 py-1.5">
-        {(["coven", "files"] as const).map((m) => (
+        {(["inspector", "coven", "files"] as const).map((m) => (
           <button
             key={m}
             onClick={() => {
@@ -418,9 +414,10 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
           </button>
         ))}
         <span className="ml-auto text-[10px] text-[var(--text-muted)]">
-          {mode === "coven" ? covenFiltered.length : filtered.length}
+          {mode === "inspector" ? "read-only" : mode === "coven" ? covenFiltered.length : filtered.length}
         </span>
       </div>
+      {mode !== "inspector" ? (
       <div className="border-b border-[var(--border-hairline)] p-2">
         <input
           value={query}
@@ -429,6 +426,13 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
           className="w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1 text-xs text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)] focus:border-purple-600"
         />
       </div>
+      ) : null}
+
+      {mode === "inspector" ? (
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <MemoryInspectorPanel familiar={familiar} />
+        </div>
+      ) : null}
 
       {mode === "coven" ? (
         <ul className="min-h-0 flex-1 overflow-y-auto p-2 text-xs">
@@ -725,4 +729,3 @@ function scopeFor(owner: string | undefined): string {
   if (owner === "local" || owner === "user") return "local";
   return owner;
 }
-

--- a/src/components/memory-inspector-panel.tsx
+++ b/src/components/memory-inspector-panel.tsx
@@ -1,0 +1,388 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { Familiar } from "@/lib/types";
+
+type FailureDistillation = {
+  id: string;
+  type: string;
+  title: string;
+  date: string;
+  severity: string;
+  domain: string;
+  status: string;
+  path: string;
+  body: string;
+  sections: Record<string, string>;
+  wikilinks: string[];
+};
+
+type MemoryTierHealth = {
+  path: string;
+  exists: boolean;
+  modified: string | null;
+  size: number | null;
+  writeAuthority: "workspace" | "familiar";
+};
+
+type DreamArtifactSummary = {
+  path: string;
+  exists: boolean;
+  modified: string | null;
+  updatedAt: string | null;
+  entryCount: number;
+  topLevelKeys: string[];
+};
+
+type MemoryInspectorReport = {
+  ok: true;
+  familiarId: string;
+  workspacePath: string;
+  failures: FailureDistillation[];
+  memoryTier: MemoryTierHealth;
+  dreams: {
+    active: boolean;
+    phaseSignals: DreamArtifactSummary | null;
+    shortTermRecall: DreamArtifactSummary | null;
+  };
+};
+
+type FilterKey = "severity" | "domain" | "status";
+type Filters = Record<FilterKey, string>;
+
+const BODY_SECTIONS = ["Signal", "What happened", "Root cause", "Lesson", "Watch for"];
+
+const EMPTY_FILTERS: Filters = {
+  severity: "all",
+  domain: "all",
+  status: "all",
+};
+
+function compactPath(filePath: string): string {
+  return filePath.replace(/^\/Users\/[^/]+/, "~");
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "missing";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString([], { month: "short", day: "numeric", year: "numeric" });
+}
+
+export function MemoryInspectorPanel({ familiar }: { familiar: Familiar | null }) {
+  const familiarId = familiar?.id ?? "main";
+  const [report, setReport] = useState<MemoryInspectorReport | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoaded(false);
+    setError(null);
+    setSelectedId(null);
+    setFilters(EMPTY_FILTERS);
+    void (async () => {
+      try {
+        const res = await fetch(`/api/memory/inspector?familiarId=${encodeURIComponent(familiarId)}`, {
+          cache: "no-store",
+        });
+        const json = await res.json();
+        if (cancelled) return;
+        if (json.ok) {
+          setReport(json as MemoryInspectorReport);
+          setSelectedId(((json as MemoryInspectorReport).failures[0] ?? null)?.id ?? null);
+        } else {
+          setError(json.error ?? "memory inspector failed");
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "fetch failed");
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [familiarId]);
+
+  const failures = report?.failures ?? [];
+  const options = useMemo(() => {
+    const by = (key: FilterKey) => [...new Set(failures.map((entry) => entry[key]).filter(Boolean))].sort();
+    return {
+      severity: by("severity"),
+      domain: by("domain"),
+      status: by("status"),
+    };
+  }, [failures]);
+
+  const filtered = useMemo(() => {
+    return failures.filter((entry) => {
+      return (
+        (filters.severity === "all" || entry.severity === filters.severity) &&
+        (filters.domain === "all" || entry.domain === filters.domain) &&
+        (filters.status === "all" || entry.status === filters.status)
+      );
+    });
+  }, [failures, filters]);
+
+  const selected = useMemo(() => {
+    return filtered.find((entry) => entry.id === selectedId) ?? filtered[0] ?? null;
+  }, [filtered, selectedId]);
+
+  if (!loaded) {
+    return <p className="p-4 text-xs text-[var(--text-muted)]">Loading memory inspector…</p>;
+  }
+
+  if (error) {
+    return <p className="p-4 text-xs text-amber-300">Memory Inspector unavailable: {error}</p>;
+  }
+
+  if (!report) {
+    return <p className="p-4 text-xs text-[var(--text-muted)]">No memory inspector report.</p>;
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col text-xs">
+      <div className="border-b border-[var(--border-hairline)] p-3">
+        <p className="text-[11px] uppercase tracking-widest text-[var(--text-muted)]">
+          {familiar?.display_name ?? "Main"} memory
+        </p>
+        <p className="mt-1 truncate font-mono text-[10px] text-[var(--text-muted)]">
+          {compactPath(report.workspacePath)}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-2 border-b border-[var(--border-hairline)] p-2">
+        <MemoryTierCard tier={report.memoryTier} />
+        <DreamsCard dreams={report.dreams} />
+      </div>
+
+      <FilterBar filters={filters} options={options} onChange={setFilters} />
+
+      <div className="grid min-h-0 flex-1 grid-rows-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+        <FailureList
+          failures={filtered}
+          selectedId={selected?.id ?? null}
+          onSelect={setSelectedId}
+        />
+        <FailureDetail
+          failure={selected}
+          allFailures={failures}
+          onNavigate={setSelectedId}
+        />
+      </div>
+    </div>
+  );
+}
+
+function MemoryTierCard({ tier }: { tier: MemoryTierHealth }) {
+  return (
+    <div className="rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11px] font-medium text-[var(--text-primary)]">MEMORY.md tier</span>
+        <span className="rounded bg-[var(--bg-raised)] px-1 py-px text-[9px] uppercase tracking-widest text-[var(--text-muted)]">
+          {tier.writeAuthority}
+        </span>
+      </div>
+      <p className="mt-1 truncate font-mono text-[10px] text-[var(--text-muted)]">{compactPath(tier.path)}</p>
+      <p className="mt-1 text-[10px] text-[var(--text-secondary)]">
+        {tier.exists
+          ? `last modified ${formatDate(tier.modified)} · ${Math.round((tier.size ?? 0) / 1024)} KB`
+          : "not created yet"}
+      </p>
+    </div>
+  );
+}
+
+function DreamsCard({ dreams }: { dreams: MemoryInspectorReport["dreams"] }) {
+  return (
+    <div className="rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11px] font-medium text-[var(--text-primary)]">Dream cycle</span>
+        <span className="rounded bg-[var(--bg-raised)] px-1 py-px text-[9px] uppercase tracking-widest text-[var(--text-muted)]">
+          {dreams.active ? "active" : "inactive"}
+        </span>
+      </div>
+      {!dreams.active ? (
+        <p className="mt-1 text-[10px] text-[var(--text-muted)]">dream cycle inactive</p>
+      ) : (
+        <div className="mt-1 grid grid-cols-2 gap-1">
+          <DreamArtifact label="Phase" artifact={dreams.phaseSignals} />
+          <DreamArtifact label="Recall" artifact={dreams.shortTermRecall} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DreamArtifact({ label, artifact }: { label: string; artifact: DreamArtifactSummary | null }) {
+  if (!artifact?.exists) {
+    return <span className="rounded bg-[var(--bg-base)] px-2 py-1 text-[10px] text-[var(--text-muted)]">{label}: missing</span>;
+  }
+  return (
+    <span className="rounded bg-[var(--bg-base)] px-2 py-1 text-[10px] text-[var(--text-secondary)]">
+      {label}: {artifact.entryCount} signal{artifact.entryCount === 1 ? "" : "s"}
+    </span>
+  );
+}
+
+function FilterBar({
+  filters,
+  options,
+  onChange,
+}: {
+  filters: Filters;
+  options: Record<FilterKey, string[]>;
+  onChange: (filters: Filters) => void;
+}) {
+  return (
+    <div className="grid grid-cols-3 gap-1 border-b border-[var(--border-hairline)] p-2">
+      {(["severity", "domain", "status"] as const).map((key) => (
+        <select
+          key={key}
+          value={filters[key]}
+          onChange={(e) => onChange({ ...filters, [key]: e.target.value })}
+          className="min-w-0 rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-1 py-1 text-[10px] text-[var(--text-primary)] outline-none"
+          aria-label={`Filter by ${key}`}
+        >
+          <option value="all">{key}</option>
+          {options[key].map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+      ))}
+    </div>
+  );
+}
+
+function FailureList({
+  failures,
+  selectedId,
+  onSelect,
+}: {
+  failures: FailureDistillation[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <ul className="min-h-0 overflow-y-auto border-b border-[var(--border-hairline)] p-2">
+      {failures.length === 0 ? (
+        <li className="px-2 py-4 text-center text-[var(--text-muted)]">
+          No failure-distillation entries found.
+        </li>
+      ) : null}
+      {failures.map((entry) => (
+        <li key={entry.id}>
+          <button
+            onClick={() => onSelect(entry.id)}
+            className={`mb-1 w-full rounded-md border px-2 py-1.5 text-left transition-colors ${
+              selectedId === entry.id
+                ? "border-purple-500/60 bg-purple-500/10"
+                : "border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 hover:bg-[var(--bg-raised)]"
+            }`}
+          >
+            <span className="line-clamp-2 text-[11px] font-medium text-[var(--text-primary)]">{entry.title}</span>
+            <span className="mt-1 flex flex-wrap items-center gap-1 text-[9px] uppercase tracking-wider text-[var(--text-muted)]">
+              <span>{entry.date}</span>
+              <Badge>{entry.severity}</Badge>
+              <Badge>{entry.status}</Badge>
+              <Badge>{entry.domain}</Badge>
+            </span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function FailureDetail({
+  failure,
+  allFailures,
+  onNavigate,
+}: {
+  failure: FailureDistillation | null;
+  allFailures: FailureDistillation[];
+  onNavigate: (id: string) => void;
+}) {
+  if (!failure) {
+    return <p className="p-4 text-center text-[var(--text-muted)]">Select an entry.</p>;
+  }
+
+  const resolveLink = (link: string) => {
+    return allFailures.find((entry) => entry.id === link || entry.title === link);
+  };
+
+  return (
+    <article className="min-h-0 overflow-y-auto p-3">
+      <h3 className="text-[13px] font-semibold leading-snug text-[var(--text-primary)]">{failure.title}</h3>
+      <p className="mt-1 truncate font-mono text-[10px] text-[var(--text-muted)]">{compactPath(failure.path)}</p>
+      <div className="mt-2 flex flex-wrap gap-1 text-[9px] uppercase tracking-wider text-[var(--text-muted)]">
+        <Badge>{failure.severity}</Badge>
+        <Badge>{failure.status}</Badge>
+        <Badge>{failure.domain}</Badge>
+      </div>
+      <div className="mt-3 space-y-3">
+        {BODY_SECTIONS.map((section) => (
+          <section key={section}>
+            <p className="mb-1 text-[10px] font-medium uppercase tracking-widest text-[var(--text-muted)]">{section}</p>
+            <WikilinkText
+              text={failure.sections[section] ?? "Not captured."}
+              resolveLink={resolveLink}
+              onNavigate={onNavigate}
+            />
+          </section>
+        ))}
+      </div>
+    </article>
+  );
+}
+
+function WikilinkText({
+  text,
+  resolveLink,
+  onNavigate,
+}: {
+  text: string;
+  resolveLink: (link: string) => FailureDistillation | undefined;
+  onNavigate: (id: string) => void;
+}) {
+  const parts = text.split(/(\[\[[^\]]+\]\])/g);
+  return (
+    <p className="whitespace-pre-wrap text-[11px] leading-relaxed text-[var(--text-secondary)]">
+      {parts.map((part, index) => {
+        const match = part.match(/^\[\[([^\]#|]+)(?:[#|][^\]]*)?\]\]$/);
+        if (!match) return <span key={index}>{part}</span>;
+        const target = resolveLink(match[1].trim());
+        if (!target) {
+          return (
+            <span key={index} className="text-purple-300">
+              {part}
+            </span>
+          );
+        }
+        return (
+          <button
+            key={index}
+            type="button"
+            onClick={() => onNavigate(target.id)}
+            className="text-purple-300 underline decoration-purple-300/40 underline-offset-2 hover:text-purple-200"
+          >
+            {part}
+          </button>
+        );
+      })}
+    </p>
+  );
+}
+
+function Badge({ children }: { children: string }) {
+  return (
+    <span className="rounded bg-[var(--bg-raised)] px-1 py-px text-[9px] text-[var(--text-muted)]">
+      {children}
+    </span>
+  );
+}

--- a/src/components/plugin-card.tsx
+++ b/src/components/plugin-card.tsx
@@ -104,7 +104,7 @@ export function PluginCard({
             rel="noopener noreferrer"
             className="ml-auto flex items-center gap-1 text-[11px] text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
           >
-            <Icon name="ph:arrow-square-out" width={11} />
+            <Icon name="ph:arrow-square-out-bold" width={11} />
             Docs
           </a>
         </div>

--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -6,6 +6,10 @@ import type { IconName } from "@/lib/icon";
 import { PluginCard } from "@/components/plugin-card";
 import { SkillCard } from "@/components/skill-card";
 import {
+  CapabilitiesView,
+  type HarnessCapabilityManifest,
+} from "@/components/capability-card";
+import {
   SkillDetailDrawer,
   type SkillEntry as SkillEntryWithDetail,
   type FamiliarForSkill,
@@ -13,25 +17,6 @@ import {
 
 type Tab = "plugins" | "skills" | "capabilities";
 type FilterChip = "curated" | "shared" | "created" | "more";
-
-// ── Capability types (mirrors /api/capabilities) ──────────────────────────
-type GlobalInstructions = {
-  present: boolean;
-  path?: string;
-  byte_count?: number;
-};
-type HarnessCapSkill = { id: string; name: string; description?: string; path: string };
-type HarnessCapPlugin = { id: string; name: string; kind: string; enabled: boolean; command?: string; args?: string[] };
-type CapWarning = { kind: string; path: string; message: string };
-type HarnessCapabilityManifest = {
-  harness_id: string;
-  scanned_at: string;
-  global_instructions: GlobalInstructions;
-  skills: HarnessCapSkill[];
-  plugins: HarnessCapPlugin[];
-  warnings: CapWarning[];
-};
-// ───────────────────────────────────────────────────────────────────────────
 
 type HarnessReport = {
   id: string;
@@ -512,186 +497,6 @@ function CreateDropdown({
           </span>
         </button>
       ))}
-    </div>
-  );
-}
-
-// ── CapabilitiesView ────────────────────────────────────────────────────────
-
-function CapabilitiesView({
-  items,
-  loaded,
-  error,
-  onRefresh,
-}: {
-  items: HarnessCapabilityManifest[];
-  loaded: boolean;
-  error: string | null;
-  onRefresh: () => void;
-}) {
-  if (!loaded) return <GridSkeleton />;
-
-  if (error) {
-    return (
-      <div className="rounded-lg border border-border bg-card px-4 py-6 sm:px-5">
-        <p className="mb-3 text-[13px] text-muted-foreground">
-          {error === "daemon offline"
-            ? "Coven daemon is offline — harness capabilities require a running daemon."
-            : `Could not load capabilities: ${error}`}
-        </p>
-        <button
-          onClick={onRefresh}
-          className="rounded-md border border-border bg-card px-3 py-1.5 text-[12px] text-foreground hover:bg-muted"
-        >
-          Retry
-        </button>
-      </div>
-    );
-  }
-
-  if (items.length === 0) {
-    return (
-      <p className="rounded-lg border border-border px-4 py-6 text-center text-[13px] text-muted-foreground">
-        No harness capabilities found. Install Codex or Claude Code and restart the daemon.
-      </p>
-    );
-  }
-
-  return (
-    <div className="flex flex-col gap-6">
-      {items.map((manifest) => (
-        <HarnessCapabilityCard key={manifest.harness_id} manifest={manifest} />
-      ))}
-      <div className="flex items-center justify-end">
-        <button
-          onClick={onRefresh}
-          className="flex items-center gap-1.5 text-[11px] text-muted-foreground hover:text-foreground"
-        >
-          <Icon name="ph:arrows-clockwise-bold" width="0.75rem" />
-          <span>Refresh</span>
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function HarnessCapabilityCard({ manifest }: { manifest: HarnessCapabilityManifest }) {
-  const label = manifest.harness_id === "codex" ? "Codex" : manifest.harness_id === "claude" ? "Claude Code" : manifest.harness_id;
-  const initial = label[0]?.toUpperCase() ?? "?";
-  const totalItems =
-    (manifest.global_instructions.present ? 1 : 0) +
-    manifest.skills.length +
-    manifest.plugins.length;
-
-  return (
-    <div className="min-w-0 rounded-xl border border-border bg-card">
-      {/* Header */}
-      <div className="flex flex-wrap items-center gap-3 border-b border-border px-4 py-3">
-        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted text-[13px] font-semibold text-foreground">
-          {initial}
-        </span>
-        <div className="min-w-0 flex-1">
-          <p className="text-[13px] font-medium text-foreground">{label}</p>
-          <p className="text-[11px] text-muted-foreground">
-            {totalItems === 0 ? "No config found" : `${totalItems} item${totalItems === 1 ? "" : "s"} configured`}
-          </p>
-        </div>
-        <span className="text-[10px] text-muted-foreground sm:ml-auto">
-          {new Date(manifest.scanned_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
-        </span>
-      </div>
-
-      {/* Body */}
-      <div className="divide-y divide-border">
-        {/* Global instructions */}
-        {manifest.global_instructions.present ? (
-          <div className="flex items-start gap-3 px-4 py-3">
-            <Icon name="ph:note-pencil" className="mt-0.5 shrink-0 text-muted-foreground" width="0.85rem" />
-            <div className="min-w-0 flex-1">
-              <p className="text-[12px] font-medium text-foreground">Global instructions</p>
-              <p className="break-all text-[11px] text-muted-foreground sm:truncate">
-                {manifest.global_instructions.path?.replace(/^\/Users\/[^/]+/, "~") ?? "—"}
-              </p>
-              {manifest.global_instructions.byte_count !== undefined && (
-                <p className="text-[10px] text-muted-foreground">
-                  {(manifest.global_instructions.byte_count / 1024).toFixed(1)} KB
-                </p>
-              )}
-            </div>
-          </div>
-        ) : (
-          <div className="flex items-center gap-3 px-4 py-3 text-[12px] text-muted-foreground">
-            <Icon name="ph:note-pencil" className="shrink-0" width="0.85rem" />
-            <span>No global instructions file found</span>
-          </div>
-        )}
-
-        {/* Skills (automations) */}
-        {manifest.skills.length > 0 ? (
-          <div className="px-4 py-3">
-            <p className="mb-2 text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
-              Automations / skills · {manifest.skills.length}
-            </p>
-            <ul className="space-y-1.5">
-              {manifest.skills.map((s) => (
-                <li key={s.id} className="flex items-start gap-2">
-                  <Icon name="ph:sparkle" className="mt-0.5 shrink-0 text-muted-foreground" width="0.75rem" />
-                  <div className="min-w-0">
-                    <p className="break-words text-[12px] text-foreground">{s.name}</p>
-                    {s.description && (
-                      <p className="break-words text-[11px] text-muted-foreground">{s.description}</p>
-                    )}
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </div>
-        ) : null}
-
-        {/* Plugins (MCP etc) */}
-        {manifest.plugins.length > 0 ? (
-          <div className="px-4 py-3">
-            <p className="mb-2 text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
-              Plugins · {manifest.plugins.length}
-            </p>
-            <ul className="space-y-1.5">
-              {manifest.plugins.map((p) => (
-                <li key={p.id} className="flex items-start gap-2">
-                  <Icon name="ph:plug" className="mt-0.5 shrink-0 text-muted-foreground" width="0.75rem" />
-                  <div className="min-w-0 flex-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <p className="min-w-0 break-words text-[12px] text-foreground">{p.name}</p>
-                      <span className="rounded-full bg-muted px-1.5 py-px text-[9px] text-muted-foreground uppercase tracking-wide">
-                        {p.kind}
-                      </span>
-                      {!p.enabled && (
-                        <span className="rounded-full bg-muted px-1.5 py-px text-[9px] text-muted-foreground">disabled</span>
-                      )}
-                    </div>
-                    {p.command && (
-                      <p className="break-all font-mono text-[11px] text-muted-foreground sm:truncate">
-                        {p.command} {p.args?.join(" ")}
-                      </p>
-                    )}
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </div>
-        ) : null}
-
-        {/* Warnings */}
-        {manifest.warnings.length > 0 ? (
-          <div className="px-4 py-3">
-            {manifest.warnings.map((w, i) => (
-              <p key={i} className="flex items-start gap-1.5 text-[11px] text-muted-foreground">
-                <Icon name="ph:warning-fill" width={11} aria-hidden />
-                <span className="min-w-0 break-words">{w.message}</span>
-              </p>
-            ))}
-          </div>
-        ) : null}
-      </div>
     </div>
   );
 }

--- a/src/components/workspace-inspector-mount.test.ts
+++ b/src/components/workspace-inspector-mount.test.ts
@@ -1,0 +1,17 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
+
+assert.match(
+  workspace,
+  /import \{ InspectorPane \} from "@\/components\/inspector-pane";/,
+  "Workspace should import InspectorPane so the right-pane tabs are reachable",
+);
+
+assert.match(
+  workspace,
+  /<InspectorPane\s+familiar=\{active\}\s+inboxItems=\{inboxItemsWithEphemeral\}\s+onOpenInbox=\{\(\) => setMode\("inbox"\)\}\s+\/>/,
+  "Chats mode should mount InspectorPane with the active familiar and inbox items",
+);

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -10,6 +10,7 @@ import { PluginsView } from "@/components/plugins-view";
 import { CalendarView } from "@/components/calendar-view";
 import { OnboardingOverlay } from "@/components/onboarding-overlay";
 import { InboxEscalationsView } from "@/components/inbox-escalations-view";
+import { InspectorPane } from "@/components/inspector-pane";
 import { NewReminderModal, draftFromSlashArgs } from "@/components/new-reminder-modal";
 import { InboxToastStack, toastFromItem, type Toast } from "@/components/inbox-toast";
 import { FamiliarGlyphPicker } from "@/components/familiar-glyph-picker";
@@ -25,6 +26,7 @@ import { GitHubView } from "@/components/github-view";
 import { HomeComposer } from "@/components/home-composer";
 import { nativeNotify } from "@/lib/native-notify";
 import { SessionsView } from "@/components/sessions-view";
+import { Icon } from "@/lib/icon";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 import type { Familiar, SessionRow } from "@/lib/types";
@@ -48,6 +50,7 @@ export function Workspace() {
   const [responseNeeded, setResponseNeeded] = useState<Set<string>>(new Set());
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [mode, setMode] = useState<WorkspaceMode>("home");
+  const [inspectorOpen, setInspectorOpen] = useState(true);
   const [onboardingOpen, setOnboardingOpen] = useState(false);
   const [inboxItems, setInboxItems] = useState<InboxItem[]>([]);
   const [escalationsUnresolved, setEscalationsUnresolved] = useState(0);
@@ -642,18 +645,46 @@ export function Workspace() {
         }}
       />
     ) : mode === "chats" ? (
-      <ChatRouter
-        ref={routerRef}
-        familiar={active}
-        sessions={sessions}
-        daemonRunning={daemonRunning}
-        onSessionStarted={loadSessions}
-        onSlashFromChat={(command, args) => {
-          onPaletteIntent({ kind: "slash", command, args });
-          return true;
-        }}
-        onOpenOnboarding={openOnboarding}
-      />
+      <div className="flex h-full min-w-0">
+        <div className="min-w-0 flex-1">
+          <ChatRouter
+            ref={routerRef}
+            familiar={active}
+            sessions={sessions}
+            daemonRunning={daemonRunning}
+            onSessionStarted={loadSessions}
+            onSlashFromChat={(command, args) => {
+              onPaletteIntent({ kind: "slash", command, args });
+              return true;
+            }}
+            onOpenOnboarding={openOnboarding}
+          />
+        </div>
+        {inspectorOpen ? (
+          <aside className="relative hidden h-full w-[340px] shrink-0 lg:block">
+            <button
+              type="button"
+              onClick={() => setInspectorOpen(false)}
+              className="absolute right-2 top-2 z-10 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] p-1.5 text-[var(--text-muted)] shadow-sm transition-colors hover:text-[var(--text-primary)]"
+              title="Close inspector"
+              aria-label="Close inspector"
+            >
+              <Icon name="ph:x-bold" width={12} />
+            </button>
+            <InspectorPane familiar={active} inboxItems={inboxItemsWithEphemeral} onOpenInbox={() => setMode("inbox")} />
+          </aside>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setInspectorOpen(true)}
+            className="hidden h-full w-9 shrink-0 items-start justify-center border-l border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 pt-3 text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)] lg:flex"
+            title="Open inspector"
+            aria-label="Open inspector"
+          >
+            <Icon name="ph:brain-bold" width={15} />
+          </button>
+        )}
+      </div>
     ) : mode === "board" ? (
       <BoardView
         familiars={familiars}

--- a/src/lib/icon.tsx
+++ b/src/lib/icon.tsx
@@ -57,6 +57,7 @@ export const ICON_NAMES = [
   "ph:x-bold",
   "ph:x-circle-fill",
   "ph:arrow-square-out",
+  "ph:arrow-square-out-bold",
   "ph:arrow-left-bold",
   "ph:arrow-right-bold",
   "ph:house-bold",

--- a/src/lib/memory-inspector.test.ts
+++ b/src/lib/memory-inspector.test.ts
@@ -1,0 +1,89 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  collectMemoryInspector,
+  parseFailureDistillation,
+  workspacePathForFamiliar,
+} from "./memory-inspector.ts";
+
+const failureText = `---
+type: failure
+id: failure-alpha
+title: Alpha failure
+date: 2026-06-05
+severity: P2
+domain: tooling
+status: resolved
+---
+
+## Signal
+
+Something broke.
+
+## What happened
+
+It failed and linked to [[failure-beta]].
+
+## Root cause
+
+Bad fallback.
+
+## Lesson
+
+Check the fallback.
+
+## Watch for
+
+Empty results.
+`;
+
+const parsed = parseFailureDistillation(failureText, "/tmp/failure-alpha.md");
+assert.equal(parsed.id, "failure-alpha");
+assert.equal(parsed.title, "Alpha failure");
+assert.equal(parsed.severity, "P2");
+assert.equal(parsed.domain, "tooling");
+assert.equal(parsed.status, "resolved");
+assert.equal(parsed.sections.Signal.trim(), "Something broke.");
+assert.equal(parsed.sections["What happened"].includes("[[failure-beta]]"), true);
+assert.deepEqual(parsed.wikilinks, ["failure-beta"]);
+
+const tempRoot = await mkdtemp(path.join(os.tmpdir(), "cave-memory-inspector-"));
+const echoWorkspace = path.join(tempRoot, "echo");
+await mkdir(path.join(echoWorkspace, "memory", "failures"), { recursive: true });
+await mkdir(path.join(echoWorkspace, "memory", ".dreams"), { recursive: true });
+await writeFile(path.join(echoWorkspace, "MEMORY.md"), "# Echo memory\n", "utf8");
+await writeFile(
+  path.join(echoWorkspace, "memory", "failures", "failure-alpha.md"),
+  failureText,
+  "utf8",
+);
+await writeFile(
+  path.join(echoWorkspace, "memory", ".dreams", "phase-signals.json"),
+  JSON.stringify({ version: 1, updatedAt: "2026-06-05T20:00:00.000Z", entries: { one: { lightHits: 2 } } }),
+  "utf8",
+);
+
+assert.equal(workspacePathForFamiliar(tempRoot, "main"), tempRoot);
+assert.equal(workspacePathForFamiliar(tempRoot, "echo"), echoWorkspace);
+assert.throws(() => workspacePathForFamiliar(tempRoot, "../echo"), /invalid familiar id/);
+
+const inspector = await collectMemoryInspector({ workspaceRoot: tempRoot, familiarId: "echo" });
+assert.equal(inspector.ok, true);
+assert.equal(inspector.failures.length, 1);
+assert.equal(inspector.failures[0].id, "failure-alpha");
+assert.equal(inspector.memoryTier.exists, true);
+assert.equal(inspector.memoryTier.writeAuthority, "familiar");
+assert.equal(inspector.dreams.active, true);
+assert.equal(inspector.dreams.phaseSignals?.entryCount, 1);
+assert.equal(inspector.dreams.shortTermRecall?.exists, false);
+
+const codyWorkspace = path.join(tempRoot, "cody");
+await mkdir(codyWorkspace, { recursive: true });
+const emptyInspector = await collectMemoryInspector({ workspaceRoot: tempRoot, familiarId: "cody" });
+assert.equal(emptyInspector.ok, true);
+assert.deepEqual(emptyInspector.failures, []);
+assert.equal(emptyInspector.memoryTier.exists, false);
+assert.equal(emptyInspector.dreams.active, false);

--- a/src/lib/memory-inspector.ts
+++ b/src/lib/memory-inspector.ts
@@ -1,0 +1,233 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { homedir } from "node:os";
+
+export type FailureDistillation = {
+  id: string;
+  type: string;
+  title: string;
+  date: string;
+  severity: string;
+  domain: string;
+  status: string;
+  path: string;
+  body: string;
+  sections: Record<string, string>;
+  wikilinks: string[];
+};
+
+export type MemoryTierHealth = {
+  path: string;
+  exists: boolean;
+  modified: string | null;
+  size: number | null;
+  writeAuthority: "workspace" | "familiar";
+};
+
+export type DreamArtifactSummary = {
+  path: string;
+  exists: boolean;
+  modified: string | null;
+  updatedAt: string | null;
+  entryCount: number;
+  topLevelKeys: string[];
+};
+
+export type MemoryInspectorReport = {
+  ok: true;
+  familiarId: string;
+  workspacePath: string;
+  failures: FailureDistillation[];
+  memoryTier: MemoryTierHealth;
+  dreams: {
+    active: boolean;
+    phaseSignals: DreamArtifactSummary | null;
+    shortTermRecall: DreamArtifactSummary | null;
+  };
+};
+
+export const DEFAULT_WORKSPACE_ROOT = path.join(homedir(), ".openclaw", "workspace");
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+const REQUIRED_FRONTMATTER = ["id", "type", "title", "date", "severity", "domain", "status"] as const;
+
+export function workspacePathForFamiliar(workspaceRoot: string, familiarId: string): string {
+  if (!/^[a-zA-Z0-9_-]+$/.test(familiarId)) {
+    throw new Error("invalid familiar id");
+  }
+  return familiarId === "main" ? workspaceRoot : path.join(workspaceRoot, familiarId);
+}
+
+export function parseFailureDistillation(text: string, filePath: string): FailureDistillation {
+  const match = text.match(FRONTMATTER_RE);
+  if (!match) {
+    throw new Error(`failure entry missing frontmatter: ${filePath}`);
+  }
+  const frontmatter = parseFrontmatter(match[1]);
+  const missing = REQUIRED_FRONTMATTER.filter((key) => !frontmatter[key]);
+  if (missing.length > 0) {
+    throw new Error(`failure entry missing ${missing.join(", ")}: ${filePath}`);
+  }
+  const body = text.slice(match[0].length).trim();
+  return {
+    id: frontmatter.id,
+    type: frontmatter.type,
+    title: frontmatter.title,
+    date: frontmatter.date,
+    severity: frontmatter.severity,
+    domain: frontmatter.domain,
+    status: frontmatter.status,
+    path: filePath,
+    body,
+    sections: parseSections(body),
+    wikilinks: parseWikilinks(body),
+  };
+}
+
+export async function collectMemoryInspector({
+  workspaceRoot = DEFAULT_WORKSPACE_ROOT,
+  familiarId,
+}: {
+  workspaceRoot?: string;
+  familiarId: string;
+}): Promise<MemoryInspectorReport> {
+  const workspacePath = workspacePathForFamiliar(workspaceRoot, familiarId);
+  const [failures, memoryTier, phaseSignals, shortTermRecall] = await Promise.all([
+    collectFailures(path.join(workspacePath, "memory", "failures")),
+    collectMemoryTier(path.join(workspacePath, "MEMORY.md"), familiarId),
+    collectDreamArtifact(path.join(workspacePath, "memory", ".dreams", "phase-signals.json")),
+    collectDreamArtifact(path.join(workspacePath, "memory", ".dreams", "short-term-recall.json")),
+  ]);
+
+  return {
+    ok: true,
+    familiarId,
+    workspacePath,
+    failures,
+    memoryTier,
+    dreams: {
+      active: !!phaseSignals.exists || !!shortTermRecall.exists,
+      phaseSignals,
+      shortTermRecall,
+    },
+  };
+}
+
+function parseFrontmatter(text: string): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!match) continue;
+    const raw = match[2].trim();
+    values[match[1]] = raw.replace(/^["']|["']$/g, "");
+  }
+  return values;
+}
+
+function parseSections(body: string): Record<string, string> {
+  const sections: Record<string, string> = {};
+  let current: string | null = null;
+  let lines: string[] = [];
+
+  const flush = () => {
+    if (!current) return;
+    sections[current] = lines.join("\n").trim();
+  };
+
+  for (const line of body.split(/\r?\n/)) {
+    const heading = line.match(/^##\s+(.+?)\s*$/);
+    if (heading) {
+      flush();
+      current = heading[1];
+      lines = [];
+      continue;
+    }
+    if (current) lines.push(line);
+  }
+  flush();
+  return sections;
+}
+
+function parseWikilinks(body: string): string[] {
+  const links = new Set<string>();
+  const re = /\[\[([^\]#|]+)(?:[#|][^\]]*)?\]\]/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(body))) {
+    links.add(match[1].trim());
+  }
+  return [...links];
+}
+
+async function collectFailures(failuresDir: string): Promise<FailureDistillation[]> {
+  let names: string[];
+  try {
+    names = await readdir(failuresDir);
+  } catch {
+    return [];
+  }
+
+  const entries: FailureDistillation[] = [];
+  for (const name of names) {
+    if (!name.endsWith(".md")) continue;
+    const fullPath = path.join(failuresDir, name);
+    try {
+      const text = await readFile(fullPath, "utf8");
+      entries.push(parseFailureDistillation(text, fullPath));
+    } catch {
+      /* Skip malformed entries; the inspector is read-only and should stay calm. */
+    }
+  }
+  entries.sort((a, b) => (a.date < b.date ? 1 : -1));
+  return entries;
+}
+
+async function collectMemoryTier(memoryPath: string, familiarId: string): Promise<MemoryTierHealth> {
+  try {
+    const s = await stat(memoryPath);
+    return {
+      path: memoryPath,
+      exists: true,
+      modified: s.mtime.toISOString(),
+      size: s.size,
+      writeAuthority: familiarId === "main" ? "workspace" : "familiar",
+    };
+  } catch {
+    return {
+      path: memoryPath,
+      exists: false,
+      modified: null,
+      size: null,
+      writeAuthority: familiarId === "main" ? "workspace" : "familiar",
+    };
+  }
+}
+
+async function collectDreamArtifact(filePath: string): Promise<DreamArtifactSummary> {
+  try {
+    const [raw, s] = await Promise.all([readFile(filePath, "utf8"), stat(filePath)]);
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const entries = parsed.entries;
+    return {
+      path: filePath,
+      exists: true,
+      modified: s.mtime.toISOString(),
+      updatedAt: typeof parsed.updatedAt === "string" ? parsed.updatedAt : null,
+      entryCount:
+        entries && typeof entries === "object" && !Array.isArray(entries)
+          ? Object.keys(entries).length
+          : Array.isArray(entries)
+            ? entries.length
+            : 0,
+      topLevelKeys: Object.keys(parsed).slice(0, 8),
+    };
+  } catch {
+    return {
+      path: filePath,
+      exists: false,
+      modified: null,
+      updatedAt: null,
+      entryCount: 0,
+      topLevelKeys: [],
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Fixes two open issues in one pass.

### #116 — Memory Inspector right-pane panel
- **Root cause of block**: `InspectorPane` was a complete orphan — built, exported, never mounted. Echo caught this.
- **Fix**: import and mount `InspectorPane` in `workspace.tsx` inside the `chats` mode right rail (the comment at line ~570 described the intent; it was just never wired).
- **Memory Inspector API**: new `/api/memory/inspector?familiarId=` endpoint backed by `src/lib/memory-inspector.ts` — reads `memory/failures/*.md` YAML frontmatter, MEMORY.md tier health, dream-cycle phase signals; graceful empty states for missing dirs.
- **UI**: `memory-inspector-panel.tsx` — failure list, detail view, wikilink navigation, filter bar (severity/domain/status), tier health row, dream summary row.
- **Regression test**: `workspace-inspector-mount.test.ts` catches a re-orphaned `InspectorPane`.

### #123 — Plugins / Skills / Capabilities view
- Extracted `capability-card.tsx` from inlined plugins-view code.
- Fixed icon allowlist (toggle, rocket, info, x, tag, arrow-square-out).
- Wired `CapabilitiesView` cleanly into `plugins-view.tsx`.
- Removed inlined card code from plugins-view.

## Verification
- `node --test src/lib/memory-inspector.test.ts src/lib/onboarding-familiars.test.ts src/lib/openclaw-agents.test.ts src/lib/comux-projects.test.ts` — 4/4 pass
- `pnpm typecheck` — clean
- `git diff --check` — clean

Closes #116
Closes #123