### PR TITLE
fix(board): use pressed state for card selection

### DIFF
--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -509,7 +509,8 @@ function CardItem({
         onSelect();
       }}
       tabIndex={0}
-      aria-selected={isSelected}
+      role="button"
+      aria-pressed={isSelected}
       className={`cursor-grab rounded-lg border bg-background p-3 outline-none transition-all active:cursor-grabbing ${
         isSelected
           ? "border-border-strong bg-muted/60 ring-1 ring-border-strong"


### PR DESCRIPTION
## Summary
- address #130 review thread PRRT_kwDOSsT04M6Hi14b
- change selectable board cards from aria-selected on a focusable li to role="button" with aria-pressed

## Verification
- focused board a11y assertion
- pnpm typecheck
- pnpm build (passes with existing Turbopack NFT warning)
- git diff --check
