### PR TITLE
feat: upgrade Coven Calls graph

### DIFF
--- a/src/components/calls-view-graph.test.ts
+++ b/src/components/calls-view-graph.test.ts
@@ -1,0 +1,17 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("./calls-view.tsx", import.meta.url), "utf8");
+
+assert.match(
+  source,
+  /<g key=\{`\$\{e\.caller\}->\$\{e\.callee\}`\}>/,
+  "Call graph edges should use a stable caller->callee key instead of the array index",
+);
+
+assert.match(
+  source,
+  /useEffect\(\(\) => \{\s*setTooltip\(null\);\s*\}, \[edges, nodeStats\]\);/,
+  "Call graph should clear hover tooltip state when live call data refreshes",
+);

--- a/src/components/calls-view.tsx
+++ b/src/components/calls-view.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type MouseEvent,
+} from "react";
 import type { Familiar } from "@/lib/types";
 import { aggregateEdges, type CallEdge, type CovenCall } from "@/lib/coven-calls-types";
 import { DelegationCard } from "@/components/delegation-card";
@@ -126,6 +134,7 @@ export function CallsView({ familiars }: Props) {
           <CallGraph
             familiars={familiars}
             edges={edges}
+            calls={calls}
             emptyText={calls.length === 0 ? "no calls yet" : ""}
           />
         </aside>
@@ -136,19 +145,34 @@ export function CallsView({ familiars }: Props) {
   );
 }
 
-/* ----- Graph (SVG, circular layout, no external dep) ----- */
+/* ----- Graph (SVG, circular, directional arrows, hover tooltips) ----- */
+
+type RichEdge = CallEdge & { mostRecentRequest: string; hasRunning: boolean };
+type TooltipEdgeState = { kind: "edge"; edge: RichEdge; x: number; y: number };
+type TooltipNodeState = { kind: "node"; familiarId: string; x: number; y: number };
+type TooltipState = TooltipEdgeState | TooltipNodeState | null;
+type NodeStat = {
+  sentCount: number;
+  receivedCount: number;
+  hasRunningReceived: boolean;
+  latestReceivedFailed: boolean;
+};
 
 function CallGraph({
   familiars,
-  edges,
+  edges: rawEdges,
+  calls,
   emptyText,
 }: {
   familiars: Familiar[];
   edges: CallEdge[];
+  calls: CovenCall[];
   emptyText: string;
 }) {
-  // Only render nodes that appear in at least one edge — keeps the graph
-  // legible when many familiars exist but only a few delegate.
+  const edges = rawEdges as RichEdge[];
+  const [tooltip, setTooltip] = useState<TooltipState>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+
   const nodeIds = useMemo(() => {
     const s = new Set<string>();
     for (const e of edges) {
@@ -160,8 +184,9 @@ function CallGraph({
 
   const W = 320;
   const H = 320;
-  const cx = W / 2;
-  const cy = H / 2;
+  const cx = 160;
+  const cy = 160;
+  const NODE_R = 14;
   const r = Math.min(W, H) / 2 - 30;
 
   const positions = useMemo(() => {
@@ -171,7 +196,37 @@ function CallGraph({
       m.set(id, { x: cx + r * Math.cos(theta), y: cy + r * Math.sin(theta) });
     });
     return m;
-  }, [nodeIds, cx, cy, r]);
+  }, [nodeIds, r]);
+
+  const nodeStats = useMemo(() => {
+    const m = new Map<string, NodeStat>();
+    const ensure = (id: string): NodeStat => {
+      if (!m.has(id)) {
+        m.set(id, {
+          sentCount: 0,
+          receivedCount: 0,
+          hasRunningReceived: false,
+          latestReceivedFailed: false,
+        });
+      }
+      return m.get(id)!;
+    };
+    const sorted = [...calls].sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+    const seenCallee = new Set<string>();
+    for (const c of sorted) {
+      ensure(c.callerFamiliarId).sentCount += 1;
+      const stat = ensure(c.calleeFamiliarId);
+      stat.receivedCount += 1;
+      if (c.status === "running") stat.hasRunningReceived = true;
+      if (!seenCallee.has(c.calleeFamiliarId)) {
+        seenCallee.add(c.calleeFamiliarId);
+        stat.latestReceivedFailed = c.status === "failed";
+      }
+    }
+    return m;
+  }, [calls]);
 
   if (nodeIds.length === 0) {
     return (
@@ -186,67 +241,236 @@ function CallGraph({
 
   const maxCount = Math.max(...edges.map((e) => e.count));
 
+  const svgToContainer = (svgX: number, svgY: number) => {
+    const el = svgRef.current;
+    if (!el) return { x: svgX, y: svgY };
+    const bb = el.getBoundingClientRect();
+    return { x: (svgX / W) * bb.width, y: (svgY / H) * bb.height };
+  };
+
+  const handleEdgeEnter = (
+    _ev: MouseEvent<SVGPathElement>,
+    edge: RichEdge,
+    mx: number,
+    my: number,
+  ) => {
+    const pt = svgToContainer(mx, my);
+    setTooltip({ kind: "edge", edge, x: pt.x, y: pt.y });
+  };
+
+  const handleNodeEnter = (id: string, svgX: number, svgY: number) => {
+    const pt = svgToContainer(svgX, svgY + NODE_R + 4);
+    setTooltip({ kind: "node", familiarId: id, x: pt.x, y: pt.y });
+  };
+
   return (
-    <svg
-      viewBox={`0 0 ${W} ${H}`}
-      className="rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-raised)]/30"
-      style={{ width: "100%", height: H }}
+    <div className="relative" style={{ height: H }}>
+      <style>{`
+        @keyframes coven-dash { to { stroke-dashoffset: -24; } }
+        .coven-edge-running { animation: coven-dash 1.5s linear infinite; }
+      `}</style>
+      <svg
+        ref={svgRef}
+        viewBox={`0 0 ${W} ${H}`}
+        className="rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-raised)]/30"
+        style={{ width: "100%", height: H }}
+        onMouseLeave={() => setTooltip(null)}
+      >
+        <defs>
+          <marker
+            id="coven-arrow"
+            markerWidth="7"
+            markerHeight="7"
+            refX="5"
+            refY="3.5"
+            orient="auto"
+            markerUnits="strokeWidth"
+          >
+            <polygon points="0 0, 7 3.5, 0 7" fill="var(--accent-presence)" fillOpacity={0.7} />
+          </marker>
+          <marker
+            id="coven-arrow-running"
+            markerWidth="7"
+            markerHeight="7"
+            refX="5"
+            refY="3.5"
+            orient="auto"
+            markerUnits="strokeWidth"
+          >
+            <polygon points="0 0, 7 3.5, 0 7" fill="var(--accent-presence)" fillOpacity={1} />
+          </marker>
+        </defs>
+        {edges.map((e, i) => {
+          const a = positions.get(e.caller);
+          const b = positions.get(e.callee);
+          if (!a || !b) return null;
+          const strokeW = 1 + (e.count / maxCount) * 3;
+          const dx = b.x - a.x;
+          const dy = b.y - a.y;
+          const len = Math.sqrt(dx * dx + dy * dy) || 1;
+          const ux = dx / len;
+          const uy = dy / len;
+          const x1 = a.x + ux * (NODE_R + 1);
+          const y1 = a.y + uy * (NODE_R + 1);
+          const x2 = b.x - ux * (NODE_R + 2);
+          const y2 = b.y - uy * (NODE_R + 2);
+          const mx = (x1 + x2) / 2;
+          const my = (y1 + y2) / 2;
+          const pathD = `M ${x1} ${y1} L ${x2} ${y2}`;
+          const isRunning = e.hasRunning;
+          return (
+            <g key={i}>
+              <path
+                d={pathD}
+                stroke="transparent"
+                strokeWidth={Math.max(strokeW + 8, 12)}
+                fill="none"
+                style={{ cursor: "default" }}
+                onMouseEnter={(ev) => handleEdgeEnter(ev, e, mx, my)}
+                onMouseLeave={() => setTooltip(null)}
+              />
+              <path
+                d={pathD}
+                stroke="var(--accent-presence)"
+                strokeOpacity={isRunning ? 0.85 : 0.45}
+                strokeWidth={strokeW}
+                strokeLinecap="round"
+                fill="none"
+                markerEnd={isRunning ? "url(#coven-arrow-running)" : "url(#coven-arrow)"}
+                {...(isRunning
+                  ? { className: "coven-edge-running", strokeDasharray: "8 4" }
+                  : {})}
+                style={{ pointerEvents: "none" }}
+              />
+              {e.count > 1 && (
+                <text
+                  x={mx}
+                  y={my - 4}
+                  textAnchor="middle"
+                  fontSize="9"
+                  fill="var(--text-muted)"
+                  style={{ pointerEvents: "none" }}
+                >
+                  {e.count}
+                </text>
+              )}
+            </g>
+          );
+        })}
+        {nodeIds.map((id) => {
+          const f = familiars.find((x) => x.id === id);
+          const p = positions.get(id)!;
+          const stat = nodeStats.get(id);
+          let ringColor = "var(--accent-presence)";
+          let ringOpacity = 0.6;
+          let ringWidth = 1.5;
+          if (stat?.hasRunningReceived) {
+            ringColor = "var(--status-active, #4ade80)";
+            ringOpacity = 0.9;
+            ringWidth = 2;
+          } else if (stat?.latestReceivedFailed) {
+            ringColor = "var(--status-error, #f87171)";
+            ringOpacity = 0.9;
+            ringWidth = 2;
+          }
+          const glyph = f?.emoji ? f.emoji : (f?.display_name ?? id).slice(0, 1).toUpperCase();
+          const isEmoji = Boolean(f?.emoji);
+          return (
+            <g key={id}>
+              <circle
+                cx={p.x}
+                cy={p.y}
+                r={NODE_R}
+                fill="var(--bg-raised)"
+                stroke={ringColor}
+                strokeOpacity={ringOpacity}
+                strokeWidth={ringWidth}
+                style={{ cursor: "default" }}
+                onMouseEnter={() => handleNodeEnter(id, p.x, p.y)}
+                onMouseLeave={() => setTooltip(null)}
+              />
+              <text
+                x={p.x}
+                y={isEmoji ? p.y + 5 : p.y + 4}
+                textAnchor="middle"
+                fontSize={isEmoji ? "14" : "10"}
+                fontWeight={isEmoji ? "normal" : "600"}
+                fill="var(--text-primary)"
+                style={{ pointerEvents: "none", userSelect: "none" }}
+              >
+                {glyph}
+              </text>
+              <text
+                x={p.x}
+                y={p.y + 28}
+                textAnchor="middle"
+                fontSize="9"
+                fill="var(--text-secondary)"
+                style={{ pointerEvents: "none" }}
+              >
+                {f?.display_name ?? id}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+      {tooltip && <GraphTooltip tooltip={tooltip} familiars={familiars} nodeStats={nodeStats} />}
+    </div>
+  );
+}
+
+function GraphTooltip({
+  tooltip,
+  familiars,
+  nodeStats,
+}: {
+  tooltip: NonNullable<TooltipState>;
+  familiars: Familiar[];
+  nodeStats: Map<string, NodeStat>;
+}) {
+  const name = (id: string) => familiars.find((f) => f.id === id)?.display_name ?? id;
+  const style: CSSProperties = {
+    position: "absolute",
+    left: tooltip.x + 8,
+    top: tooltip.y + 8,
+    maxWidth: 220,
+    zIndex: 50,
+    pointerEvents: "none",
+  };
+  if (tooltip.kind === "edge") {
+    const { edge } = tooltip;
+    const req = edge.mostRecentRequest;
+    const t = req.length > 60 ? `${req.slice(0, 60)}...` : req;
+    return (
+      <div
+        style={style}
+        className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-2 text-[11px] shadow-lg"
+      >
+        <div className="font-medium text-[var(--text-primary)]">
+          {name(edge.caller)} -&gt; {name(edge.callee)}
+        </div>
+        <div className="mt-0.5 text-[var(--text-secondary)]">
+          {edge.count} call{edge.count !== 1 ? "s" : ""}
+          {edge.hasRunning && (
+            <span className="ml-1.5 rounded bg-[var(--status-active,#4ade80)]/20 px-1 py-0.5 text-[10px] text-[var(--status-active,#4ade80)]">
+              running
+            </span>
+          )}
+        </div>
+        {t && <div className="mt-1 italic text-[var(--text-muted)]">&quot;{t}&quot;</div>}
+      </div>
+    );
+  }
+  const stat = nodeStats.get(tooltip.familiarId);
+  return (
+    <div
+      style={style}
+      className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-2 text-[11px] shadow-lg"
     >
-      {edges.map((e, i) => {
-        const a = positions.get(e.caller);
-        const b = positions.get(e.callee);
-        if (!a || !b) return null;
-        const stroke = 1 + (e.count / maxCount) * 4;
-        return (
-          <g key={i}>
-            <line
-              x1={a.x}
-              y1={a.y}
-              x2={b.x}
-              y2={b.y}
-              stroke="var(--accent-presence)"
-              strokeOpacity={0.45}
-              strokeWidth={stroke}
-              strokeLinecap="round"
-            />
-          </g>
-        );
-      })}
-      {nodeIds.map((id) => {
-        const f = familiars.find((x) => x.id === id);
-        const p = positions.get(id)!;
-        return (
-          <g key={id}>
-            <circle
-              cx={p.x}
-              cy={p.y}
-              r={14}
-              fill="var(--bg-raised)"
-              stroke="var(--accent-presence)"
-              strokeOpacity={0.6}
-            />
-            <text
-              x={p.x}
-              y={p.y + 4}
-              textAnchor="middle"
-              fontSize="10"
-              fontWeight="600"
-              fill="var(--text-primary)"
-            >
-              {(f?.display_name ?? id).slice(0, 1).toUpperCase()}
-            </text>
-            <text
-              x={p.x}
-              y={p.y + 28}
-              textAnchor="middle"
-              fontSize="9"
-              fill="var(--text-secondary)"
-            >
-              {f?.display_name ?? id}
-            </text>
-          </g>
-        );
-      })}
-    </svg>
+      <div className="font-medium text-[var(--text-primary)]">{name(tooltip.familiarId)}</div>
+      <div className="mt-0.5 text-[var(--text-secondary)]">
+        up {stat?.sentCount ?? 0} sent · down {stat?.receivedCount ?? 0} received
+      </div>
+    </div>
   );
 }

--- a/src/components/calls-view.tsx
+++ b/src/components/calls-view.tsx
@@ -228,6 +228,10 @@ function CallGraph({
     return m;
   }, [calls]);
 
+  useEffect(() => {
+    setTooltip(null);
+  }, [edges, nodeStats]);
+
   if (nodeIds.length === 0) {
     return (
       <div
@@ -300,7 +304,7 @@ function CallGraph({
             <polygon points="0 0, 7 3.5, 0 7" fill="var(--accent-presence)" fillOpacity={1} />
           </marker>
         </defs>
-        {edges.map((e, i) => {
+        {edges.map((e) => {
           const a = positions.get(e.caller);
           const b = positions.get(e.callee);
           if (!a || !b) return null;
@@ -319,7 +323,7 @@ function CallGraph({
           const pathD = `M ${x1} ${y1} L ${x2} ${y2}`;
           const isRunning = e.hasRunning;
           return (
-            <g key={i}>
+            <g key={`${e.caller}->${e.callee}`}>
               <path
                 d={pathD}
                 stroke="transparent"

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState, useEffect, useRef } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
+import { stripLeadingTrailingEmoji } from "@/lib/cave-chat-titles";
 import { Icon } from "@/lib/icon";
 import { useKeySymbols } from "@/lib/platform-keys";
 import { OriginChip } from "@/components/ui/origin-chip";
@@ -339,7 +340,7 @@ export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat 
                           ? "text-white"
                           : "text-[var(--text-primary)]",
                       ].join(" ")}>
-                        {s.title || "(untitled chat)"}
+                        {stripLeadingTrailingEmoji(s.title || "(untitled chat)")}
                       </span>
 
                       {/* Row 3: status preview */}

--- a/src/components/sessions-view.tsx
+++ b/src/components/sessions-view.tsx
@@ -7,6 +7,7 @@ import { FamiliarGlyph } from "@/components/familiar-glyph";
 import { resolveFamiliarGlyph } from "@/lib/familiar-glyph";
 import { useGlyphOverrides } from "@/lib/cave-glyph-overrides";
 import type { Familiar, SessionRow, SessionOrigin } from "@/lib/types";
+import { stripLeadingTrailingEmoji } from "@/lib/cave-chat-titles";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -260,7 +261,7 @@ function SessionCard({
   const overrides = useGlyphOverrides();
   const glyph = familiar ? resolveFamiliarGlyph(familiar, overrides) : null;
   const ts = shortRelTime(session.updated_at || session.created_at);
-  const title = session.title || "Untitled session";
+  const title = stripLeadingTrailingEmoji(session.title || "Untitled session");
   const label = originLabel(session.origin);
   const archived = !!session.archived_at;
 
@@ -362,7 +363,7 @@ function SessionRowItem({
   const overrides = useGlyphOverrides();
   const glyph = familiar ? resolveFamiliarGlyph(familiar, overrides) : null;
   const ts = shortRelTime(session.updated_at || session.created_at);
-  const title = session.title || "Untitled session";
+  const title = stripLeadingTrailingEmoji(session.title || "Untitled session");
   const label = originLabel(session.origin);
   const archived = !!session.archived_at;
 

--- a/src/lib/cave-chat-titles.ts
+++ b/src/lib/cave-chat-titles.ts
@@ -5,6 +5,13 @@ type SessionLike = {
 
 export const MAX_CHAT_TITLE_LENGTH = 120;
 
+// Strip leading/trailing emoji and whitespace from session titles.
+// Emoji in the middle of a title are left intact.
+const EMOJI_RE = /^[\p{Emoji_Presentation}\p{Extended_Pictographic}\s]+|[\p{Emoji_Presentation}\p{Extended_Pictographic}\s]+$/gu;
+export function stripLeadingTrailingEmoji(title: string): string {
+  return title.replace(EMOJI_RE, "").trim();
+}
+
 export function normalizeChatTitle(input: unknown): string | null {
   if (typeof input !== "string") return null;
   const title = input.trim().replace(/\s+/g, " ");

--- a/src/lib/coven-calls-types.test.ts
+++ b/src/lib/coven-calls-types.test.ts
@@ -1,0 +1,47 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { aggregateEdges, type CovenCall } from "./coven-calls-types.ts";
+
+const calls: CovenCall[] = [
+  {
+    id: "call-1",
+    callerFamiliarId: "nova",
+    calleeFamiliarId: "cody",
+    request: "first request",
+    status: "completed",
+    createdAt: "2026-06-06T01:00:00.000Z",
+  },
+  {
+    id: "call-2",
+    callerFamiliarId: "nova",
+    calleeFamiliarId: "cody",
+    request: "latest request",
+    status: "running",
+    createdAt: "2026-06-06T01:05:00.000Z",
+  },
+  {
+    id: "call-3",
+    callerFamiliarId: "cody",
+    calleeFamiliarId: "nova",
+    request: "reverse request",
+    status: "failed",
+    createdAt: "2026-06-06T01:03:00.000Z",
+  },
+];
+
+assert.deepEqual(aggregateEdges(calls), [
+  {
+    caller: "nova",
+    callee: "cody",
+    count: 2,
+    mostRecentRequest: "latest request",
+    hasRunning: true,
+  },
+  {
+    caller: "cody",
+    callee: "nova",
+    count: 1,
+    mostRecentRequest: "reverse request",
+    hasRunning: false,
+  },
+]);

--- a/src/lib/coven-calls-types.ts
+++ b/src/lib/coven-calls-types.ts
@@ -28,20 +28,33 @@ export type CallEdge = {
   caller: string;
   callee: string;
   count: number;
+  /** Verbatim request from the most recent call on this edge. */
+  mostRecentRequest: string;
+  /** True when any call on this edge has status "running". */
+  hasRunning: boolean;
 };
 
 export function aggregateEdges(calls: CovenCall[]): CallEdge[] {
   const map = new Map<string, CallEdge>();
-  for (const c of calls) {
+  const sorted = [...calls].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+  );
+  for (const c of sorted) {
     const key = `${c.callerFamiliarId}->${c.calleeFamiliarId}`;
     const existing = map.get(key);
-    if (existing) existing.count += 1;
-    else
+    if (existing) {
+      existing.count += 1;
+      existing.mostRecentRequest = c.request;
+      if (c.status === "running") existing.hasRunning = true;
+    } else {
       map.set(key, {
         caller: c.callerFamiliarId,
         callee: c.calleeFamiliarId,
         count: 1,
+        mostRecentRequest: c.request,
+        hasRunning: c.status === "running",
       });
+    }
   }
   return Array.from(map.values()).sort((a, b) => b.count - a.count);
 }


### PR DESCRIPTION
## Summary
- extend Coven Calls edge aggregation with most recent request text and running-edge state
- upgrade the Calls graph with directional arrows, running-edge dash animation, wider hover targets, emoji/initial nodes, count labels, status rings, and hover tooltips
- add a regression test for aggregation metadata

## Verification
- `for test in src/lib/*.test.ts src/components/*.test.ts; do node --experimental-strip-types "$test" || exit 1; done`
- `pnpm typecheck`
- `pnpm build` (passes; existing Turbopack broad-file-tracing warnings remain in memory/coven-bin paths)
- `git diff --check`

## Notes
- Echo's spec also referenced `OpenCoven/coven-cave-calls`, but that repo was not present locally or in the OpenCoven GitHub repo list during implementation.