### PR TITLE
chore(release): stamp v0.0.42

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coven-cave",
-  "version": "0.0.30",
+  "version": "0.0.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coven-cave",
-      "version": "0.0.30",
+      "version": "0.0.42",
       "dependencies": {
         "@create-markdown/core": "2.0.3",
         "@create-markdown/preview": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- Stamp Coven Cave package metadata to 0.0.42.
- Align package-lock root metadata with the release version.
- Stamp Tauri app version to 0.0.42.

## Verification
- pnpm install --frozen-lockfile
- pnpm typecheck
- pnpm build
- git diff --check
- version metadata assertion for package.json, package-lock.json, and src-tauri/tauri.conf.json
- mkdir -p src-tauri/resources/server && touch src-tauri/resources/server/.cargo-check-placeholder && cargo check --locked (from src-tauri)