### PR TITLE
[codex] edit Codex automation schedules in Cave

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -324,6 +324,11 @@ export async function POST(req: Request) {
           const name = toolMatch[1];
           const rest = (toolMatch[2] ?? "").trim();
           const id = toolIdFor(name);
+          // Try to pretty-print JSON payloads; fall back to raw string.
+          const fmtPayload = (raw: string): string | undefined => {
+            if (!raw) return undefined;
+            try { return JSON.stringify(JSON.parse(raw), null, 2); } catch { return raw; }
+          };
           if (isPost) {
             const meta = toolStartTimes.get(name);
             const durationMs = meta ? Date.now() - meta.startedAt : undefined;
@@ -332,7 +337,7 @@ export async function POST(req: Request) {
               kind: "tool_use",
               id,
               name,
-              output: rest || undefined,
+              output: fmtPayload(rest),
               status: isError ? "error" : "ok",
               durationMs,
             });
@@ -342,7 +347,7 @@ export async function POST(req: Request) {
               kind: "tool_use",
               id,
               name,
-              input: rest || undefined,
+              input: fmtPayload(rest),
               status: "running",
             });
           }

--- a/src/app/api/codex-automations/[id]/route.ts
+++ b/src/app/api/codex-automations/[id]/route.ts
@@ -3,6 +3,7 @@ import {
   type AutomationStatus,
   type CodexAutomationPatch,
   getCodexAutomation,
+  toCodexAutomationPayload,
   updateCodexAutomation,
 } from "@/lib/codex-automations";
 
@@ -10,16 +11,26 @@ export const dynamic = "force-dynamic";
 
 type Params = { params: Promise<{ id: string }> };
 
+function isLocalOrigin(req: Request): boolean {
+  const host = req.headers.get("host") ?? "";
+  const bare = host.split(":")[0];
+  return bare === "127.0.0.1" || bare === "localhost" || bare === "[::1]";
+}
+
 export async function GET(_req: Request, { params }: Params) {
   const { id } = await params;
   const auto = await getCodexAutomation(id);
   if (!auto) {
     return NextResponse.json({ ok: false, error: "not found" }, { status: 404 });
   }
-  return NextResponse.json({ ok: true, automation: auto });
+  return NextResponse.json({ ok: true, automation: toCodexAutomationPayload(auto) });
 }
 
 export async function PATCH(req: Request, { params }: Params) {
+  if (!isLocalOrigin(req)) {
+    return NextResponse.json({ ok: false, error: "forbidden" }, { status: 403 });
+  }
+
   const { id } = await params;
   let body: Record<string, unknown>;
   try {
@@ -84,5 +95,5 @@ export async function PATCH(req: Request, { params }: Params) {
   if (!updated) {
     return NextResponse.json({ ok: false, error: "not found" }, { status: 404 });
   }
-  return NextResponse.json({ ok: true, automation: updated });
+  return NextResponse.json({ ok: true, automation: toCodexAutomationPayload(updated) });
 }

--- a/src/app/api/codex-automations/[id]/route.ts
+++ b/src/app/api/codex-automations/[id]/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { setCodexAutomationStatus, getCodexAutomation } from "@/lib/codex-automations";
+
+export const dynamic = "force-dynamic";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(_req: Request, { params }: Params) {
+  const { id } = await params;
+  const auto = await getCodexAutomation(id);
+  if (!auto) {
+    return NextResponse.json({ ok: false, error: "not found" }, { status: 404 });
+  }
+  return NextResponse.json({ ok: true, automation: auto });
+}
+
+export async function PATCH(req: Request, { params }: Params) {
+  const { id } = await params;
+  let body: { status?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json" }, { status: 400 });
+  }
+
+  const status = body.status;
+  if (status !== "ACTIVE" && status !== "PAUSED") {
+    return NextResponse.json(
+      { ok: false, error: 'status must be "ACTIVE" or "PAUSED"' },
+      { status: 422 },
+    );
+  }
+
+  const updated = await setCodexAutomationStatus(id, status);
+  if (!updated) {
+    return NextResponse.json({ ok: false, error: "not found" }, { status: 404 });
+  }
+  return NextResponse.json({ ok: true, automation: updated });
+}

--- a/src/app/api/codex-automations/[id]/route.ts
+++ b/src/app/api/codex-automations/[id]/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from "next/server";
-import { setCodexAutomationStatus, getCodexAutomation } from "@/lib/codex-automations";
+import {
+  type AutomationStatus,
+  type CodexAutomationPatch,
+  getCodexAutomation,
+  updateCodexAutomation,
+} from "@/lib/codex-automations";
 
 export const dynamic = "force-dynamic";
 
@@ -16,22 +21,66 @@ export async function GET(_req: Request, { params }: Params) {
 
 export async function PATCH(req: Request, { params }: Params) {
   const { id } = await params;
-  let body: { status?: string };
+  let body: Record<string, unknown>;
   try {
     body = await req.json();
   } catch {
     return NextResponse.json({ ok: false, error: "invalid json" }, { status: 400 });
   }
 
-  const status = body.status;
-  if (status !== "ACTIVE" && status !== "PAUSED") {
-    return NextResponse.json(
-      { ok: false, error: 'status must be "ACTIVE" or "PAUSED"' },
-      { status: 422 },
-    );
+  const patch: CodexAutomationPatch = {};
+  const stringFields: Array<keyof CodexAutomationPatch> = [
+    "name",
+    "prompt",
+    "rrule",
+    "model",
+    "reasoning_effort",
+    "execution_environment",
+    "skill_path",
+  ];
+
+  for (const field of stringFields) {
+    const value = body[field] ?? body[field.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())];
+    if (value === undefined) continue;
+    if (typeof value !== "string") {
+      return NextResponse.json({ ok: false, error: `${field} must be a string` }, { status: 422 });
+    }
+    if (field !== "prompt" && /\r|\n/.test(value)) {
+      return NextResponse.json({ ok: false, error: `${field} must be one line` }, { status: 422 });
+    }
+    if (field === "name" && value.trim().length === 0) {
+      return NextResponse.json({ ok: false, error: "name cannot be empty" }, { status: 422 });
+    }
+    if (field === "rrule" && !value.startsWith("RRULE:")) {
+      return NextResponse.json({ ok: false, error: "rrule must start with RRULE:" }, { status: 422 });
+    }
+    (patch as Record<string, unknown>)[field] = value;
   }
 
-  const updated = await setCodexAutomationStatus(id, status);
+  if (body.status !== undefined) {
+    if (body.status !== "ACTIVE" && body.status !== "PAUSED") {
+      return NextResponse.json(
+        { ok: false, error: 'status must be "ACTIVE" or "PAUSED"' },
+        { status: 422 },
+      );
+    }
+    patch.status = body.status as AutomationStatus;
+  }
+
+  for (const field of ["cwds", "tags"] as const) {
+    const value = body[field];
+    if (value === undefined) continue;
+    if (!Array.isArray(value) || value.some((item) => typeof item !== "string" || /\r|\n/.test(item))) {
+      return NextResponse.json({ ok: false, error: `${field} must be an array of one-line strings` }, { status: 422 });
+    }
+    (patch as Record<string, unknown>)[field] = value;
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return NextResponse.json({ ok: false, error: "no supported fields provided" }, { status: 422 });
+  }
+
+  const updated = await updateCodexAutomation(id, patch);
   if (!updated) {
     return NextResponse.json({ ok: false, error: "not found" }, { status: 404 });
   }

--- a/src/app/api/codex-automations/route.ts
+++ b/src/app/api/codex-automations/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { listCodexAutomations } from "@/lib/codex-automations";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const automations = await listCodexAutomations();
+    return NextResponse.json({ ok: true, automations });
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: err instanceof Error ? err.message : "unknown" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/codex-automations/route.ts
+++ b/src/app/api/codex-automations/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
-import { listCodexAutomations } from "@/lib/codex-automations";
+import { listCodexAutomations, toCodexAutomationPayload } from "@/lib/codex-automations";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
   try {
-    const automations = await listCodexAutomations();
+    const automations = (await listCodexAutomations()).map(toCodexAutomationPayload);
     return NextResponse.json({ ok: true, automations });
   } catch (err) {
     return NextResponse.json(

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -166,23 +166,19 @@ body {
   overflow: hidden;
 }
 
-/* Right-rail toggle tab — Dia/Linear-style vertical pill */
+/* Right-rail toggle tab — full-height strip, matches inspector closed state */
 .shell-agent-tab {
-  position: absolute;
-  right: 0;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 10;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 5px;
-  padding: 10px 5px;
-  border-radius: 8px 0 0 8px;
-  border: 1px solid var(--border-hairline);
-  border-right: none;
-  background: var(--bg-elevated);
-  color: var(--fg-muted);
+  justify-content: flex-start;
+  padding-top: 12px;
+  width: 36px;
+  flex-shrink: 0;
+  height: 100%;
+  border-left: 1px solid var(--border-hairline);
+  background: var(--bg-raised);
+  color: var(--text-muted);
   cursor: pointer;
   transition: color 0.15s, background 0.15s;
   -webkit-app-region: no-drag;
@@ -190,18 +186,22 @@ body {
 }
 .shell-agent-tab:hover {
   background: var(--bg-hover);
-  color: var(--fg-base);
+  color: var(--text-primary);
+}
+.shell-agent-tab--open {
+  color: var(--accent-presence);
+  background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-raised));
+  border-left-color: color-mix(in oklch, var(--accent-presence) 35%, var(--border-hairline));
+}
+.shell-agent-tab--open:hover {
+  background: color-mix(in oklch, var(--accent-presence) 13%, var(--bg-raised));
+  color: var(--accent-presence);
 }
 .shell-agent-tab-label {
-  writing-mode: vertical-rl;
-  text-orientation: mixed;
-  font-size: 10px;
-  font-weight: 500;
-  letter-spacing: 0.04em;
-  line-height: 1;
+  display: none;
 }
 .shell-agent-tab-chevron {
-  opacity: 0.5;
+  display: none;
 }
 
 .shell-bottom {

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
 import type { Familiar } from "@/lib/types";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { Recurrence } from "@/lib/inbox-recurrence";
@@ -15,10 +16,26 @@ type CodexAutomation = {
   status: AutomationStatus;
   rrule: string | null;
   model: string | null;
+  reasoningEffort: string | null;
+  executionEnvironment: string | null;
+  cwds: string[];
   tags: string[];
   prompt: string;
+  skillPath: string | null;
   scheduleHuman: string;
   tomlPath: string;
+};
+
+type CodexAutomationPatch = {
+  name?: string;
+  prompt?: string;
+  status?: AutomationStatus;
+  rrule?: string;
+  model?: string;
+  reasoning_effort?: string;
+  execution_environment?: string;
+  cwds?: string[];
+  tags?: string[];
 };
 
 // AutomationsView — redesigned June 2026
@@ -36,6 +53,16 @@ type Props = {
 
 const WEEKDAY = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 const DAY_INITIALS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+const RRULE_DAY_ORDER = ["SU", "MO", "TU", "WE", "TH", "FR", "SA"];
+const RRULE_DAY_LABEL: Record<string, string> = {
+  SU: "Sun",
+  MO: "Mon",
+  TU: "Tue",
+  WE: "Wed",
+  TH: "Thu",
+  FR: "Fri",
+  SA: "Sat",
+};
 
 function pad(n: number) {
   return n.toString().padStart(2, "0");
@@ -72,6 +99,76 @@ function relTime(iso: string | undefined | null): string {
   const d = Math.round(h / 24);
   return delta > 0 ? `in ${d}d` : `${d}d ago`;
 }
+
+function parseCodexRrule(rrule: string | null): {
+  mode: "daily" | "weekly" | "raw";
+  days: string[];
+  time: string;
+  raw: string;
+} {
+  const raw = rrule ?? "";
+  const freq = raw.match(/FREQ=(\w+)/)?.[1];
+  const hour = raw.match(/BYHOUR=(\d+)/)?.[1];
+  const min = raw.match(/BYMINUTE=(\d+)/)?.[1];
+  const days = raw.match(/BYDAY=([^;]+)/)?.[1]?.split(",").filter(Boolean) ?? [];
+  const time = `${(hour ?? "9").padStart(2, "0")}:${(min ?? "0").padStart(2, "0")}`;
+
+  if (freq === "DAILY" && hour !== undefined) return { mode: "daily", days: [], time, raw };
+  if (freq === "WEEKLY" && hour !== undefined) {
+    return {
+      mode: "weekly",
+      days: days.length > 0 ? days : RRULE_DAY_ORDER,
+      time,
+      raw,
+    };
+  }
+  return { mode: "raw", days: RRULE_DAY_ORDER, time, raw };
+}
+
+function buildCodexRrule(mode: "daily" | "weekly" | "raw", time: string, days: string[], raw: string): string {
+  if (mode === "raw") return raw.trim();
+  const [hour = "9", minute = "0"] = time.split(":");
+  const parts = [
+    "RRULE:FREQ=" + (mode === "daily" ? "DAILY" : "WEEKLY"),
+    `BYHOUR=${Number(hour)}`,
+    `BYMINUTE=${Number(minute)}`,
+  ];
+  if (mode === "weekly") {
+    const ordered = RRULE_DAY_ORDER.filter((day) => days.includes(day));
+    parts.push(`BYDAY=${ordered.join(",")}`);
+  }
+  return parts.join(";");
+}
+
+function listInput(values: string[]): string {
+  return values.join("\n");
+}
+
+function commaInput(values: string[]): string {
+  return values.join(", ");
+}
+
+function parseListInput(value: string): string[] {
+  return value
+    .split(/\n|,/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function FieldLabel({ children }: { children: ReactNode }) {
+  return (
+    <label className="mb-1 block text-[10px] font-semibold uppercase tracking-widest"
+      style={{ color: "var(--text-muted)" }}>
+      {children}
+    </label>
+  );
+}
+
+const fieldStyle = {
+  background: "var(--bg-base)",
+  borderColor: "var(--border-hairline)",
+  color: "var(--text-primary)",
+} as const;
 
 // ── Status icon ──────────────────────────────────────────────────────────────
 function StatusIcon({ item }: { item: InboxItem }) {
@@ -162,31 +259,27 @@ function DetailPanel({
           </div>
         )}
 
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 gap-4">
           <div>
-            <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest"
-              style={{ color: "var(--text-muted)" }}>Schedule</p>
+            <FieldLabel>Schedule</FieldLabel>
             <p className="text-[12px]" style={{ color: "var(--text-primary)" }}>
               {humanSchedule(item.recurrence)}
             </p>
           </div>
           <div>
-            <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest"
-              style={{ color: "var(--text-muted)" }}>Status</p>
+            <FieldLabel>Status</FieldLabel>
             <p className="text-[12px] capitalize" style={{ color: paused ? "var(--text-muted)" : "var(--text-primary)" }}>
               {paused ? "Paused" : item.status}
             </p>
           </div>
           <div>
-            <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest"
-              style={{ color: "var(--text-muted)" }}>Next run</p>
+            <FieldLabel>Next run</FieldLabel>
             <p className="text-[12px]" style={{ color: "var(--text-primary)" }}>
               {relTime(item.fireAt)}
             </p>
           </div>
           <div>
-            <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest"
-              style={{ color: "var(--text-muted)" }}>Last run</p>
+            <FieldLabel>Last run</FieldLabel>
             <p className="text-[12px]" style={{ color: item.firedAt ? "oklch(0.75 0.1 150)" : "var(--text-muted)" }}>
               {item.firedAt ? relTime(item.firedAt) : "Never"}
             </p>
@@ -313,13 +406,79 @@ function CodexDetailPanel({
   busy,
   onClose,
   onToggle,
+  onSave,
 }: {
   auto: CodexAutomation;
   busy: boolean;
   onClose: () => void;
   onToggle: (auto: CodexAutomation) => void;
+  onSave: (auto: CodexAutomation, patch: CodexAutomationPatch) => void;
 }) {
   const isActive = auto.status === "ACTIVE";
+  const parsedSchedule = useMemo(() => parseCodexRrule(auto.rrule), [auto.rrule]);
+  const [name, setName] = useState(auto.name);
+  const [prompt, setPrompt] = useState(auto.prompt);
+  const [model, setModel] = useState(auto.model ?? "");
+  const [reasoningEffort, setReasoningEffort] = useState(auto.reasoningEffort ?? "medium");
+  const [executionEnvironment, setExecutionEnvironment] = useState(auto.executionEnvironment ?? "worktree");
+  const [tagsText, setTagsText] = useState(commaInput(auto.tags));
+  const [cwdsText, setCwdsText] = useState(listInput(auto.cwds));
+  const [scheduleMode, setScheduleMode] = useState<"daily" | "weekly" | "raw">(parsedSchedule.mode);
+  const [scheduleTime, setScheduleTime] = useState(parsedSchedule.time);
+  const [scheduleDays, setScheduleDays] = useState(parsedSchedule.days);
+  const [rawRrule, setRawRrule] = useState(parsedSchedule.raw);
+
+  useEffect(() => {
+    const nextSchedule = parseCodexRrule(auto.rrule);
+    setName(auto.name);
+    setPrompt(auto.prompt);
+    setModel(auto.model ?? "");
+    setReasoningEffort(auto.reasoningEffort ?? "medium");
+    setExecutionEnvironment(auto.executionEnvironment ?? "worktree");
+    setTagsText(commaInput(auto.tags));
+    setCwdsText(listInput(auto.cwds));
+    setScheduleMode(nextSchedule.mode);
+    setScheduleTime(nextSchedule.time);
+    setScheduleDays(nextSchedule.days);
+    setRawRrule(nextSchedule.raw);
+  }, [auto]);
+
+  const nextRrule = buildCodexRrule(scheduleMode, scheduleTime, scheduleDays, rawRrule);
+  const tags = parseListInput(tagsText);
+  const cwds = parseListInput(cwdsText);
+  const invalidSchedule =
+    !nextRrule.startsWith("RRULE:") || (scheduleMode === "weekly" && scheduleDays.length === 0);
+  const dirty =
+    name !== auto.name ||
+    prompt !== auto.prompt ||
+    model !== (auto.model ?? "") ||
+    reasoningEffort !== (auto.reasoningEffort ?? "medium") ||
+    executionEnvironment !== (auto.executionEnvironment ?? "worktree") ||
+    tagsText !== commaInput(auto.tags) ||
+    cwdsText !== listInput(auto.cwds) ||
+    nextRrule !== (auto.rrule ?? "");
+  const canSave = !busy && dirty && name.trim().length > 0 && !invalidSchedule;
+
+  const toggleDay = (day: string) => {
+    setScheduleDays((prev) =>
+      prev.includes(day) ? prev.filter((item) => item !== day) : [...prev, day],
+    );
+  };
+
+  const save = () => {
+    if (!canSave) return;
+    onSave(auto, {
+      name: name.trim(),
+      prompt,
+      rrule: nextRrule,
+      model: model.trim(),
+      reasoning_effort: reasoningEffort,
+      execution_environment: executionEnvironment,
+      tags,
+      cwds,
+    });
+  };
+
   return (
     <div className="flex h-full flex-col"
       style={{ background: "var(--bg-raised)", borderLeft: "1px solid var(--border-hairline)" }}>
@@ -339,54 +498,163 @@ function CodexDetailPanel({
       {/* Body */}
       <div className="flex-1 overflow-y-auto px-5 py-5 space-y-5">
         <div>
-          <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest"
-            style={{ color: "var(--text-muted)" }}>Name</p>
-          <p className="text-[14px] font-medium" style={{ color: "var(--text-primary)" }}>
-            {auto.name}
+          <FieldLabel>Name</FieldLabel>
+          <input
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            className="h-8 w-full rounded-md border px-2 text-[12px] outline-none focus:border-white/30"
+            style={fieldStyle}
+          />
+        </div>
+
+        <div>
+          <FieldLabel>Prompt</FieldLabel>
+          <textarea
+            value={prompt}
+            onChange={(event) => setPrompt(event.target.value)}
+            rows={9}
+            className="w-full resize-y rounded-md border px-2 py-2 text-[12px] leading-relaxed outline-none focus:border-white/30"
+            style={fieldStyle}
+          />
+        </div>
+
+        <div>
+          <FieldLabel>Schedule</FieldLabel>
+          <div className="mb-2 inline-flex rounded-md border p-0.5"
+            style={{ borderColor: "var(--border-hairline)", background: "var(--bg-base)" }}>
+            {(["weekly", "daily", "raw"] as const).map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => setScheduleMode(mode)}
+                className="rounded px-2 py-1 text-[11px] capitalize transition-colors"
+                style={{
+                  background: scheduleMode === mode ? "rgba(255,255,255,0.08)" : "transparent",
+                  color: scheduleMode === mode ? "var(--text-primary)" : "var(--text-muted)",
+                }}
+              >
+                {mode}
+              </button>
+            ))}
+          </div>
+
+          {scheduleMode === "raw" ? (
+            <textarea
+              value={rawRrule}
+              onChange={(event) => setRawRrule(event.target.value)}
+              rows={3}
+              className="w-full resize-y rounded-md border px-2 py-2 font-mono text-[11px] leading-relaxed outline-none focus:border-white/30"
+              style={fieldStyle}
+            />
+          ) : (
+            <div className="space-y-3">
+              {scheduleMode === "weekly" && (
+                <div className="flex flex-wrap gap-1.5">
+                  {RRULE_DAY_ORDER.map((day) => {
+                    const selected = scheduleDays.includes(day);
+                    return (
+                      <button
+                        key={day}
+                        type="button"
+                        onClick={() => toggleDay(day)}
+                        className="rounded-md border px-2 py-1 text-[11px] transition-colors"
+                        style={{
+                          background: selected ? "oklch(0.65 0.18 280 / 0.18)" : "var(--bg-base)",
+                          borderColor: selected ? "oklch(0.65 0.18 280 / 0.5)" : "var(--border-hairline)",
+                          color: selected ? "var(--text-primary)" : "var(--text-muted)",
+                        }}
+                      >
+                        {RRULE_DAY_LABEL[day]}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+              <input
+                type="time"
+                value={scheduleTime}
+                onChange={(event) => setScheduleTime(event.target.value)}
+                className="h-8 w-full rounded-md border px-2 text-[12px] outline-none focus:border-white/30"
+                style={fieldStyle}
+              />
+            </div>
+          )}
+          <p className="mt-2 break-all font-mono text-[10px]" style={{ color: invalidSchedule ? "oklch(0.7 0.16 35)" : "var(--text-muted)" }}>
+            {nextRrule || "RRULE required"}
           </p>
         </div>
 
-        {auto.prompt && (
+        <div className="grid grid-cols-1 gap-4">
           <div>
-            <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest"
-              style={{ color: "var(--text-muted)" }}>Prompt</p>
-            <p className="text-[12px] leading-relaxed whitespace-pre-wrap line-clamp-6"
-              style={{ color: "var(--text-secondary)" }}>
-              {auto.prompt}
-            </p>
-          </div>
-        )}
-
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest"
-              style={{ color: "var(--text-muted)" }}>Schedule</p>
-            <p className="text-[12px]" style={{ color: "var(--text-primary)" }}>
-              {auto.scheduleHuman}
-            </p>
-          </div>
-          <div>
-            <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest"
-              style={{ color: "var(--text-muted)" }}>Status</p>
+            <FieldLabel>Status</FieldLabel>
             <p className="text-[12px]" style={{ color: isActive ? "oklch(0.75 0.1 150)" : "var(--text-muted)" }}>
               {isActive ? "Active" : "Paused"}
             </p>
           </div>
-          {auto.model && (
+          <div>
+            <FieldLabel>Model</FieldLabel>
+            <input
+              value={model}
+              onChange={(event) => setModel(event.target.value)}
+              className="h-8 w-full rounded-md border px-2 text-[12px] outline-none focus:border-white/30"
+              style={fieldStyle}
+            />
+          </div>
+          <div>
+            <FieldLabel>Reasoning</FieldLabel>
+            <select
+              value={reasoningEffort}
+              onChange={(event) => setReasoningEffort(event.target.value)}
+              className="h-8 w-full rounded-md border px-2 text-[12px] outline-none focus:border-white/30"
+              style={fieldStyle}
+            >
+              {!["low", "medium", "high"].includes(reasoningEffort) && (
+                <option value={reasoningEffort}>{reasoningEffort}</option>
+              )}
+              <option value="low">low</option>
+              <option value="medium">medium</option>
+              <option value="high">high</option>
+            </select>
+          </div>
+          <div>
+            <FieldLabel>Environment</FieldLabel>
+            <select
+              value={executionEnvironment}
+              onChange={(event) => setExecutionEnvironment(event.target.value)}
+              className="h-8 w-full rounded-md border px-2 text-[12px] outline-none focus:border-white/30"
+              style={fieldStyle}
+            >
+              {!["worktree", "repo"].includes(executionEnvironment) && (
+                <option value={executionEnvironment}>{executionEnvironment}</option>
+              )}
+              <option value="worktree">worktree</option>
+              <option value="repo">repo</option>
+            </select>
+          </div>
+          <div>
+            <FieldLabel>Working directories</FieldLabel>
+            <textarea
+              value={cwdsText}
+              onChange={(event) => setCwdsText(event.target.value)}
+              rows={3}
+              className="w-full resize-y rounded-md border px-2 py-2 font-mono text-[11px] leading-relaxed outline-none focus:border-white/30"
+              style={fieldStyle}
+            />
+          </div>
+          <div>
+            <FieldLabel>Tags</FieldLabel>
+            <input
+              value={tagsText}
+              onChange={(event) => setTagsText(event.target.value)}
+              className="h-8 w-full rounded-md border px-2 text-[12px] outline-none focus:border-white/30"
+              style={fieldStyle}
+            />
+          </div>
+          {auto.skillPath && (
             <div>
-              <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest"
-                style={{ color: "var(--text-muted)" }}>Model</p>
-              <p className="text-[12px]" style={{ color: "var(--text-primary)" }}>
-                {auto.model}
-              </p>
-            </div>
-          )}
-          {auto.tags.length > 0 && (
-            <div>
-              <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest"
-                style={{ color: "var(--text-muted)" }}>Tags</p>
-              <p className="text-[12px]" style={{ color: "var(--text-secondary)" }}>
-                {auto.tags.join(", ")}
+              <FieldLabel>Skill</FieldLabel>
+              <p className="break-all font-mono text-[10px]" style={{ color: "var(--text-muted)" }}>
+                {auto.skillPath}
               </p>
             </div>
           )}
@@ -396,6 +664,15 @@ function CodexDetailPanel({
       {/* Actions */}
       <div className="border-t px-5 py-4 space-y-2"
         style={{ borderColor: "var(--border-hairline)" }}>
+        <button
+          type="button"
+          disabled={!canSave}
+          onClick={save}
+          className="w-full rounded-lg py-2 text-[12px] font-medium text-white transition-colors disabled:opacity-40"
+          style={{ background: "oklch(0.65 0.18 280)" }}
+        >
+          {busy ? "Saving..." : "Save changes"}
+        </button>
         <button
           type="button"
           disabled={busy}
@@ -619,6 +896,25 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder }: Pro
     }
   }, [load]);
 
+  const saveCodex = useCallback(async (auto: CodexAutomation, patch: CodexAutomationPatch) => {
+    setBusyId(auto.id);
+    try {
+      const res = await fetch(`/api/codex-automations/${encodeURIComponent(auto.id)}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      const json = await res.json().catch(() => null);
+      if (!res.ok || !json?.ok) throw new Error(json?.error ?? `http ${res.status}`);
+      if (json.automation) setSelectedCodex(json.automation);
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "codex save failed");
+    } finally {
+      setBusyId(null);
+    }
+  }, [load]);
+
   // ── Sections ──────────────────────────────────────────────────────────────
   const current = useMemo(() =>
     items.filter((it) =>
@@ -730,7 +1026,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder }: Pro
 
       {/* ── Detail panel ───────────────────────────────────────────────────── */}
       {(selectedItem || selectedCodex) && (
-        <div className="w-72 shrink-0 overflow-hidden" style={{ borderLeft: "1px solid var(--border-hairline)" }}>
+        <div className="w-[380px] max-w-[42vw] shrink-0 overflow-hidden" style={{ borderLeft: "1px solid var(--border-hairline)" }}>
           {selectedItem && (
             <DetailPanel
               item={selectedItem}
@@ -749,6 +1045,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder }: Pro
               busy={busyId === selectedCodex.id}
               onClose={() => setSelectedCodex(null)}
               onToggle={toggleCodex}
+              onSave={saveCodex}
             />
           )}
         </div>

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -5,38 +5,12 @@ import type { ReactNode } from "react";
 import type { Familiar } from "@/lib/types";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { Recurrence } from "@/lib/inbox-recurrence";
+import type {
+  AutomationStatus,
+  CodexAutomation,
+  CodexAutomationPatch,
+} from "@/lib/codex-automations-types";
 import { Icon } from "@/lib/icon";
-
-// ── Codex automation types (mirrored from lib/codex-automations.ts) ──────────
-type AutomationStatus = "ACTIVE" | "PAUSED";
-type CodexAutomation = {
-  id: string;
-  name: string;
-  kind: string;
-  status: AutomationStatus;
-  rrule: string | null;
-  model: string | null;
-  reasoningEffort: string | null;
-  executionEnvironment: string | null;
-  cwds: string[];
-  tags: string[];
-  prompt: string;
-  skillPath: string | null;
-  scheduleHuman: string;
-  tomlPath: string;
-};
-
-type CodexAutomationPatch = {
-  name?: string;
-  prompt?: string;
-  status?: AutomationStatus;
-  rrule?: string;
-  model?: string;
-  reasoning_effort?: string;
-  execution_environment?: string;
-  cwds?: string[];
-  tags?: string[];
-};
 
 // AutomationsView — redesigned June 2026
 // Clean list layout matching the sleek/professional reference design:
@@ -811,6 +785,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder }: Pro
     if (!selectedCodex) return;
     const fresh = codexAutos.find((a) => a.id === selectedCodex.id);
     if (fresh) setSelectedCodex(fresh);
+    else setSelectedCodex(null);
   }, [codexAutos, selectedCodex?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const famById = useMemo(() => {

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -6,6 +6,21 @@ import type { InboxItem } from "@/lib/cave-inbox";
 import type { Recurrence } from "@/lib/inbox-recurrence";
 import { Icon } from "@/lib/icon";
 
+// ── Codex automation types (mirrored from lib/codex-automations.ts) ──────────
+type AutomationStatus = "ACTIVE" | "PAUSED";
+type CodexAutomation = {
+  id: string;
+  name: string;
+  kind: string;
+  status: AutomationStatus;
+  rrule: string | null;
+  model: string | null;
+  tags: string[];
+  prompt: string;
+  scheduleHuman: string;
+  tomlPath: string;
+};
+
 // AutomationsView — redesigned June 2026
 // Clean list layout matching the sleek/professional reference design:
 //   • No tabs — items grouped by status section (Current / Paused / Pending / History)
@@ -292,19 +307,216 @@ function Section({
   );
 }
 
+// ── Codex automation detail panel ────────────────────────────────────────────
+function CodexDetailPanel({
+  auto,
+  busy,
+  onClose,
+  onToggle,
+}: {
+  auto: CodexAutomation;
+  busy: boolean;
+  onClose: () => void;
+  onToggle: (auto: CodexAutomation) => void;
+}) {
+  const isActive = auto.status === "ACTIVE";
+  return (
+    <div className="flex h-full flex-col"
+      style={{ background: "var(--bg-raised)", borderLeft: "1px solid var(--border-hairline)" }}>
+      {/* Header */}
+      <div className="flex items-center justify-between border-b px-5 py-3"
+        style={{ borderColor: "var(--border-hairline)" }}>
+        <h2 className="text-[13px] font-semibold" style={{ color: "var(--text-primary)" }}>
+          Automation details
+        </h2>
+        <button type="button" onClick={onClose}
+          className="rounded p-1 transition-colors hover:bg-white/5"
+          style={{ color: "var(--text-muted)" }}>
+          <Icon name="ph:x" width={14} />
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto px-5 py-5 space-y-5">
+        <div>
+          <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest"
+            style={{ color: "var(--text-muted)" }}>Name</p>
+          <p className="text-[14px] font-medium" style={{ color: "var(--text-primary)" }}>
+            {auto.name}
+          </p>
+        </div>
+
+        {auto.prompt && (
+          <div>
+            <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest"
+              style={{ color: "var(--text-muted)" }}>Prompt</p>
+            <p className="text-[12px] leading-relaxed whitespace-pre-wrap line-clamp-6"
+              style={{ color: "var(--text-secondary)" }}>
+              {auto.prompt}
+            </p>
+          </div>
+        )}
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest"
+              style={{ color: "var(--text-muted)" }}>Schedule</p>
+            <p className="text-[12px]" style={{ color: "var(--text-primary)" }}>
+              {auto.scheduleHuman}
+            </p>
+          </div>
+          <div>
+            <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest"
+              style={{ color: "var(--text-muted)" }}>Status</p>
+            <p className="text-[12px]" style={{ color: isActive ? "oklch(0.75 0.1 150)" : "var(--text-muted)" }}>
+              {isActive ? "Active" : "Paused"}
+            </p>
+          </div>
+          {auto.model && (
+            <div>
+              <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest"
+                style={{ color: "var(--text-muted)" }}>Model</p>
+              <p className="text-[12px]" style={{ color: "var(--text-primary)" }}>
+                {auto.model}
+              </p>
+            </div>
+          )}
+          {auto.tags.length > 0 && (
+            <div>
+              <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest"
+                style={{ color: "var(--text-muted)" }}>Tags</p>
+              <p className="text-[12px]" style={{ color: "var(--text-secondary)" }}>
+                {auto.tags.join(", ")}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="border-t px-5 py-4 space-y-2"
+        style={{ borderColor: "var(--border-hairline)" }}>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => onToggle(auto)}
+          className="w-full rounded-lg py-2 text-[12px] font-medium text-white transition-colors disabled:opacity-40"
+          style={{ background: isActive ? "oklch(0.45 0.12 20)" : "oklch(0.65 0.18 280)" }}
+        >
+          {busy ? (isActive ? "Pausing…" : "Activating…") : (isActive ? "Pause" : "Activate")}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Codex automation row ──────────────────────────────────────────────────────
+function CodexRow({
+  auto,
+  selected,
+  onSelect,
+}: {
+  auto: CodexAutomation;
+  selected: boolean;
+  onSelect: (auto: CodexAutomation) => void;
+}) {
+  const isActive = auto.status === "ACTIVE";
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onSelect(auto)}
+        className="group flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors"
+        style={{ background: selected ? "rgba(255,255,255,0.05)" : "transparent" }}
+        onMouseEnter={(e) => { if (!selected) (e.currentTarget as HTMLButtonElement).style.background = "rgba(255,255,255,0.03)"; }}
+        onMouseLeave={(e) => { if (!selected) (e.currentTarget as HTMLButtonElement).style.background = "transparent"; }}
+      >
+        {/* Status dot */}
+        {isActive ? (
+          <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full"
+            style={{ background: "oklch(0.65 0.18 280)" }} />
+        ) : (
+          <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full border"
+            style={{ borderColor: "rgba(255,255,255,0.18)", color: "rgba(255,255,255,0.35)" }}>
+            <Icon name="ph:minus" width={8} />
+          </span>
+        )}
+        <span className="flex-1 min-w-0 flex items-baseline gap-2">
+          <span className="text-[13px] truncate" style={{ color: "var(--text-primary)" }}>
+            {auto.name}
+          </span>
+          {auto.tags.includes("coven") && (
+            <span className="shrink-0 text-[11px]" style={{ color: "var(--text-muted)" }}>coven</span>
+          )}
+        </span>
+        <span className="shrink-0 text-[12px] tabular-nums" style={{ color: "var(--text-muted)" }}>
+          {auto.scheduleHuman}
+        </span>
+      </button>
+    </li>
+  );
+}
+
+// ── Codex Section ─────────────────────────────────────────────────────────────
+function CodexSection({
+  title,
+  items,
+  selectedId,
+  onSelect,
+}: {
+  title: string;
+  items: CodexAutomation[];
+  selectedId: string | null;
+  onSelect: (auto: CodexAutomation) => void;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <div className="mb-6">
+      <div className="flex items-center gap-3 mb-1 pb-2"
+        style={{ borderBottom: "1px solid var(--border-hairline)" }}>
+        <span className="text-[12px] font-semibold" style={{ color: "var(--text-secondary)" }}>
+          {title}
+        </span>
+        <span className="text-[10px] px-1.5 py-0.5 rounded"
+          style={{ background: "var(--bg-raised)", color: "var(--text-muted)" }}>
+          Codex
+        </span>
+      </div>
+      <ul>
+        {items.map((auto) => (
+          <CodexRow
+            key={auto.id}
+            auto={auto}
+            selected={selectedId === auto.id}
+            onSelect={onSelect}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 // ── Root ──────────────────────────────────────────────────────────────────────
 export function AutomationsView({ familiars, onOpenSession, onNewReminder }: Props) {
   const [items, setItems] = useState<InboxItem[]>([]);
+  const [codexAutos, setCodexAutos] = useState<CodexAutomation[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
+  // Selected item is either an InboxItem or a CodexAutomation — track by kind
   const [selectedItem, setSelectedItem] = useState<InboxItem | null>(null);
+  const [selectedCodex, setSelectedCodex] = useState<CodexAutomation | null>(null);
 
   const load = useCallback(async () => {
     try {
-      const res = await fetch("/api/inbox", { cache: "no-store" });
-      const json = await res.json();
-      if (!json.ok) { setError(json.error ?? "load failed"); return; }
-      setItems(json.items ?? []);
+      const [inboxRes, codexRes] = await Promise.all([
+        fetch("/api/inbox", { cache: "no-store" }),
+        fetch("/api/codex-automations", { cache: "no-store" }),
+      ]);
+      const inboxJson = await inboxRes.json();
+      if (!inboxJson.ok) { setError(inboxJson.error ?? "load failed"); return; }
+      setItems(inboxJson.items ?? []);
+      const codexJson = await codexRes.json();
+      if (codexJson.ok) setCodexAutos(codexJson.automations ?? []);
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "fetch failed");
@@ -316,6 +528,13 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder }: Pro
     const t = setInterval(load, 15000);
     return () => clearInterval(t);
   }, [load]);
+
+  // Keep selectedCodex in sync after reload
+  useEffect(() => {
+    if (!selectedCodex) return;
+    const fresh = codexAutos.find((a) => a.id === selectedCodex.id);
+    if (fresh) setSelectedCodex(fresh);
+  }, [codexAutos, selectedCodex?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const famById = useMemo(() => {
     const m = new Map<string, Familiar>();
@@ -381,6 +600,25 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder }: Pro
   const stopRecurrence = (id: string) =>
     patchItem(id, { recurrence: { type: "none" } });
 
+  // ── Codex toggle ──────────────────────────────────────────────────────────
+  const toggleCodex = useCallback(async (auto: CodexAutomation) => {
+    setBusyId(auto.id);
+    try {
+      const newStatus: AutomationStatus = auto.status === "ACTIVE" ? "PAUSED" : "ACTIVE";
+      const res = await fetch(`/api/codex-automations/${encodeURIComponent(auto.id)}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ status: newStatus }),
+      });
+      if (!res.ok) throw new Error(`http ${res.status}`);
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "codex patch failed");
+    } finally {
+      setBusyId(null);
+    }
+  }, [load]);
+
   // ── Sections ──────────────────────────────────────────────────────────────
   const current = useMemo(() =>
     items.filter((it) =>
@@ -410,7 +648,17 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder }: Pro
       .slice(0, 20),
     [items]);
 
-  const isEmpty = current.length + paused.length + oneShots.length === 0;
+  const codexActive = useMemo(
+    () => codexAutos.filter((a) => a.status === "ACTIVE"),
+    [codexAutos],
+  );
+  const codexPaused = useMemo(
+    () => codexAutos.filter((a) => a.status === "PAUSED"),
+    [codexAutos],
+  );
+
+  const isEmpty =
+    current.length + paused.length + oneShots.length + codexAutos.length === 0;
 
   return (
     <section className="flex h-full" style={{ background: "var(--bg-base)" }}>
@@ -460,14 +708,20 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder }: Pro
           ) : (
             <>
               <Section title="Current" items={current} selectedId={selectedItem?.id ?? null}
-                familiarLabel={familiarLabel} onSelect={setSelectedItem} />
+                familiarLabel={familiarLabel} onSelect={(item) => { setSelectedItem(item); setSelectedCodex(null); }} />
+              <CodexSection title="Active Schedules" items={codexActive}
+                selectedId={selectedCodex?.id ?? null}
+                onSelect={(auto) => { setSelectedCodex(auto); setSelectedItem(null); }} />
               <Section title="Paused" items={paused} selectedId={selectedItem?.id ?? null}
-                familiarLabel={familiarLabel} onSelect={setSelectedItem} />
+                familiarLabel={familiarLabel} onSelect={(item) => { setSelectedItem(item); setSelectedCodex(null); }} />
+              <CodexSection title="Paused Schedules" items={codexPaused}
+                selectedId={selectedCodex?.id ?? null}
+                onSelect={(auto) => { setSelectedCodex(auto); setSelectedItem(null); }} />
               <Section title="Pending" items={oneShots} selectedId={selectedItem?.id ?? null}
-                familiarLabel={familiarLabel} onSelect={setSelectedItem} />
+                familiarLabel={familiarLabel} onSelect={(item) => { setSelectedItem(item); setSelectedCodex(null); }} />
               {history.length > 0 && (
                 <Section title="History" items={history} selectedId={selectedItem?.id ?? null}
-                  familiarLabel={familiarLabel} onSelect={setSelectedItem} />
+                  familiarLabel={familiarLabel} onSelect={(item) => { setSelectedItem(item); setSelectedCodex(null); }} />
               )}
             </>
           )}
@@ -475,18 +729,28 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder }: Pro
       </div>
 
       {/* ── Detail panel ───────────────────────────────────────────────────── */}
-      {selectedItem && (
+      {(selectedItem || selectedCodex) && (
         <div className="w-72 shrink-0 overflow-hidden" style={{ borderLeft: "1px solid var(--border-hairline)" }}>
-          <DetailPanel
-            item={selectedItem}
-            familiarLabel={familiarLabel}
-            busyId={busyId}
-            onClose={() => setSelectedItem(null)}
-            runNow={runNow}
-            togglePaused={togglePaused}
-            stopRecurrence={stopRecurrence}
-            removeItem={removeItem}
-          />
+          {selectedItem && (
+            <DetailPanel
+              item={selectedItem}
+              familiarLabel={familiarLabel}
+              busyId={busyId}
+              onClose={() => setSelectedItem(null)}
+              runNow={runNow}
+              togglePaused={togglePaused}
+              stopRecurrence={stopRecurrence}
+              removeItem={removeItem}
+            />
+          )}
+          {selectedCodex && (
+            <CodexDetailPanel
+              auto={selectedCodex}
+              busy={busyId === selectedCodex.id}
+              onClose={() => setSelectedCodex(null)}
+              onToggle={toggleCodex}
+            />
+          )}
         </div>
       )}
     </section>

--- a/src/components/board-filter-popover.tsx
+++ b/src/components/board-filter-popover.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useRef } from "react";
 import type { CardPriority, CardStatus } from "@/lib/cave-board-types";
-import type { Familiar } from "@/lib/types";
 import { Icon } from "@/lib/icon";
 
 export type FilterState = {
@@ -14,6 +13,11 @@ export type FilterState = {
 
 export function emptyFilter(): FilterState {
   return { priorities: new Set(), familiarIds: new Set(), statuses: new Set(), labels: new Set() };
+}
+
+/** True when the filter popover itself has active selections (priority or status only). */
+export function hasActivePopoverFilters(f: FilterState): boolean {
+  return f.priorities.size > 0 || f.statuses.size > 0;
 }
 
 export function hasActiveFilters(f: FilterState): boolean {
@@ -38,8 +42,6 @@ const STATUS_OPTIONS: { id: CardStatus; label: string }[] = [
 
 type Props = {
   filter: FilterState;
-  familiars: Familiar[];
-  allLabels: string[];
   onChange: (f: FilterState) => void;
   onClose: () => void;
 };
@@ -61,7 +63,7 @@ function toggle<T extends string>(set: Set<T>, value: T): Set<T> {
   return next;
 }
 
-export function BoardFilterPopover({ filter, familiars, allLabels, onChange, onClose }: Props) {
+export function BoardFilterPopover({ filter, onChange, onClose }: Props) {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -86,29 +88,12 @@ export function BoardFilterPopover({ filter, familiars, allLabels, onChange, onC
         ))}
       </div>
       <div className="board-filter-popover-section">
-        <div className="board-filter-popover-label">Familiar</div>
-        {familiars.map((f) => (
-          <CheckOption key={f.id} checked={filter.familiarIds.has(f.id)} label={f.display_name}
-            onToggle={() => onChange({ ...filter, familiarIds: toggle(filter.familiarIds, f.id) })} />
-        ))}
-        {familiars.length === 0 && <p className="board-table-muted" style={{ padding: "4px 2px" }}>No familiars</p>}
-      </div>
-      <div className="board-filter-popover-section">
         <div className="board-filter-popover-label">Status</div>
         {STATUS_OPTIONS.map((o) => (
           <CheckOption key={o.id} checked={filter.statuses.has(o.id)} label={o.label}
             onToggle={() => onChange({ ...filter, statuses: toggle(filter.statuses, o.id) })} />
         ))}
       </div>
-      {allLabels.length > 0 && (
-        <div className="board-filter-popover-section">
-          <div className="board-filter-popover-label">Labels</div>
-          {allLabels.map((l) => (
-            <CheckOption key={l} checked={filter.labels.has(l)} label={l}
-              onToggle={() => onChange({ ...filter, labels: toggle(filter.labels, l) })} />
-          ))}
-        </div>
-      )}
       <div className="board-filter-popover-footer">
         <button type="button" className="board-toolbar-btn" onClick={() => onChange(emptyFilter())}>Clear all</button>
         <button type="button" className="board-new-card-btn" onClick={onClose}>Done</button>

--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -36,7 +36,8 @@ type Props = {
 };
 
 function getGroups(cards: Card[], by: GroupBy, familiars: Familiar[]): { key: string; label: string; cards: Card[] }[] {
-  if (by === "status" || by === "none") return [{ key: "all", label: "", cards }];
+  if (by === "none") return [{ key: "all", label: "", cards }];
+  if (by === "status") return [{ key: "all", label: "Status", cards }];
   const map = new Map<string, Card[]>();
   for (const c of cards) {
     const key = by === "familiar" ? (c.familiarId ?? "__unassigned__") : c.priority;
@@ -60,7 +61,7 @@ export function BoardKanban({ cards, familiars, sessions, groupBy, selectedCardI
   const railRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
   const groups = getGroups(cards, groupBy, familiars);
-  const showSwimlanes = groupBy !== "status" && groupBy !== "none";
+  const showSwimlanes = groupBy !== "none";
 
   const grouped = (gc: Card[]) => {
     const m = new Map<CardStatus, Card[]>();
@@ -105,31 +106,35 @@ export function BoardKanban({ cards, familiars, sessions, groupBy, selectedCardI
       {groups.map(({ key, label, cards: gc }) => {
         const isCollapsed = collapsedGroups.has(key);
         const grpGrouped = grouped(gc);
+        const isStatusGroup = groupBy === "status"; // single-group, full-height
+        const isMultiSwimlane = showSwimlanes && !isStatusGroup;
         return (
-          <div key={key} className={showSwimlanes ? "board-swimlane" : ""} style={showSwimlanes ? {} : { display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
+          <div key={key} className={isMultiSwimlane ? "board-swimlane" : ""} style={isMultiSwimlane ? {} : { display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
             {showSwimlanes && (
               <div className="board-swimlane-header" onClick={() => toggleGroup(key)}>
                 <Icon name={isCollapsed ? "ph:caret-right" : "ph:caret-down"} width={10} />
                 {label}
                 <span className="board-swimlane-badge">{gc.length}</span>
-                <div style={{ marginLeft: "auto", display: "flex", gap: 4 }}>
-                  <button type="button" onClick={(e) => { e.stopPropagation(); scroll(key, -1); }}
-                    style={{ display: "grid", placeItems: "center", width: 20, height: 20, borderRadius: 4, border: "none", background: "transparent", color: "var(--text-muted)", cursor: "pointer" }}>
-                    <Icon name="ph:arrow-left-bold" width={10} />
-                  </button>
-                  <button type="button" onClick={(e) => { e.stopPropagation(); scroll(key, 1); }}
-                    style={{ display: "grid", placeItems: "center", width: 20, height: 20, borderRadius: 4, border: "none", background: "transparent", color: "var(--text-muted)", cursor: "pointer" }}>
-                    <Icon name="ph:arrow-right-bold" width={10} />
-                  </button>
-                </div>
+                {isMultiSwimlane && (
+                  <div style={{ marginLeft: "auto", display: "flex", gap: 4 }}>
+                    <button type="button" onClick={(e) => { e.stopPropagation(); scroll(key, -1); }}
+                      style={{ display: "grid", placeItems: "center", width: 20, height: 20, borderRadius: 4, border: "none", background: "transparent", color: "var(--text-muted)", cursor: "pointer" }}>
+                      <Icon name="ph:arrow-left-bold" width={10} />
+                    </button>
+                    <button type="button" onClick={(e) => { e.stopPropagation(); scroll(key, 1); }}
+                      style={{ display: "grid", placeItems: "center", width: 20, height: 20, borderRadius: 4, border: "none", background: "transparent", color: "var(--text-muted)", cursor: "pointer" }}>
+                      <Icon name="ph:arrow-right-bold" width={10} />
+                    </button>
+                  </div>
+                )}
               </div>
             )}
             {!isCollapsed && (
               <div
-                className={showSwimlanes ? "board-swimlane-rail" : "h-full overflow-x-auto overflow-y-hidden scroll-smooth"}
-                style={showSwimlanes ? {} : { flex: 1, minHeight: 0 }}
+                className={isMultiSwimlane ? "board-swimlane-rail" : "h-full overflow-x-auto overflow-y-hidden scroll-smooth"}
+                style={isMultiSwimlane ? {} : { flex: 1, minHeight: 0 }}
                 ref={(el) => { if (el) railRefs.current.set(key, el); }}>
-                <div className="flex gap-3 px-5 py-4" style={showSwimlanes ? { height: 320, minWidth: "max-content" } : { height: "100%", minWidth: "max-content" }}>
+                <div className="flex gap-3 px-5 py-4" style={isMultiSwimlane ? { height: 320, minWidth: "max-content" } : { height: "100%", minWidth: "max-content" }}>
                   {COLUMNS.map((col) => {
                     const rows = grpGrouped.get(col.id) ?? [];
                     const isDrop = dropTarget === col.id;

--- a/src/components/board-multi-select.tsx
+++ b/src/components/board-multi-select.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Icon } from "@/lib/icon";
+import type { IconName } from "@/lib/icon";
+
+type Option = { id: string; label: string };
+
+type Props = {
+  label: string;
+  options: Option[];
+  selected: Set<string>;
+  onChange: (next: Set<string>) => void;
+  /** Icon name (Phosphor) shown before the label */
+  icon?: IconName;
+  emptyLabel?: string;
+};
+
+export function BoardMultiSelect({ label, options, selected, onChange, icon, emptyLabel }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const h = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", h);
+    return () => document.removeEventListener("mousedown", h);
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const h = (e: KeyboardEvent) => { if (e.key === "Escape") setOpen(false); };
+    document.addEventListener("keydown", h);
+    return () => document.removeEventListener("keydown", h);
+  }, [open]);
+
+  const toggle = (id: string) => {
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    onChange(next);
+  };
+
+  const active = selected.size > 0;
+
+  return (
+    <div ref={ref} className="board-filter-popover-anchor">
+      <button
+        type="button"
+        className={`board-toolbar-select board-multiselect-btn${active ? " board-toolbar-select--active" : ""}`}
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        {icon && <Icon name={icon} width={12} height={12} />}
+        <span>{active ? `${label} · ${selected.size}` : label}</span>
+        <Icon
+          name="ph:caret-down-bold"
+          width={9}
+          height={9}
+          className={`board-multiselect-caret${open ? " board-multiselect-caret--open" : ""}`}
+        />
+      </button>
+
+      {open && (
+        <div className="board-filter-popover board-multiselect-popover">
+          {options.length === 0 ? (
+            <div className="board-filter-popover-section">
+              <p className="board-table-muted" style={{ padding: "4px 2px", fontSize: 12 }}>
+                {emptyLabel ?? "No options"}
+              </p>
+            </div>
+          ) : (
+            <div className="board-filter-popover-section">
+              {options.map((o) => {
+                const checked = selected.has(o.id);
+                return (
+                  <button
+                    key={o.id}
+                    type="button"
+                    className="board-filter-option"
+                    onClick={() => toggle(o.id)}
+                  >
+                    <span className={`board-filter-check${checked ? " board-filter-check--on" : ""}`}>
+                      {checked && <Icon name="ph:check" width={10} className="text-white" />}
+                    </span>
+                    {o.label}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+          {selected.size > 0 && (
+            <div className="board-filter-popover-footer">
+              <button
+                type="button"
+                className="board-toolbar-btn"
+                onClick={() => { onChange(new Set()); setOpen(false); }}
+              >
+                Clear
+              </button>
+              <button
+                type="button"
+                className="board-new-card-btn"
+                onClick={() => setOpen(false)}
+              >
+                Done
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/board-table.tsx
+++ b/src/components/board-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import type { Familiar } from "@/lib/types";
 import type { Card, CardStatus, CardPriority } from "@/lib/cave-board-types";
 import { LifecycleBadge } from "@/components/ui/lifecycle-badge";
@@ -123,7 +123,7 @@ export function BoardTable({ cards, familiars, groupBy, selectedCardId, onSelect
         </thead>
         <tbody>
           {groups.map(({ key, label, cards: gc }) => (
-            <>
+            <React.Fragment key={key}>
               {groupBy !== "none" && (
                 <tr key={`g-${key}`} className="board-table-group-row" onClick={() => toggleGroup(key)}>
                   <td colSpan={COLS.length}>
@@ -149,7 +149,7 @@ export function BoardTable({ cards, familiars, groupBy, selectedCardId, onSelect
                   </tr>
                 );
               })}
-            </>
+            </React.Fragment>
           ))}
         </tbody>
       </table>

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -8,9 +8,10 @@ import { NewCardModal, type NewCardDraft } from "@/components/new-card-modal";
 import { Icon } from "@/lib/icon";
 import { type Card, type CardStatus } from "@/lib/cave-board-types";
 import {
-  BoardFilterPopover, type FilterState,
-  emptyFilter, hasActiveFilters,
+  type FilterState,
+  emptyFilter,
 } from "@/components/board-filter-popover";
+import { BoardMultiSelect } from "@/components/board-multi-select";
 import { BoardKanban } from "@/components/board-kanban";
 import { BoardTable, type GroupBy } from "@/components/board-table";
 import { BoardInspector } from "@/components/board-inspector";
@@ -36,7 +37,6 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
   const [viewMode, setViewMode] = useState<ViewMode>(() => loadPref("cave:board:viewMode", "kanban", ["kanban", "table"]));
   const [groupBy, setGroupBy] = useState<GroupBy>(() => loadPref("cave:board:groupBy", "status", ["status", "familiar", "priority", "none"]));
   const [filter, setFilter] = useState<FilterState>(emptyFilter());
-  const [filterOpen, setFilterOpen] = useState(false);
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [modalDefaultStatus, setModalDefaultStatus] = useState<CardStatus>("backlog");
@@ -153,18 +153,52 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
             <option value="none">No grouping</option>
           </select>
 
-          <div className="board-filter-popover-anchor">
-            <button type="button"
-              className={`board-toolbar-btn${hasActiveFilters(filter) ? " board-toolbar-btn--active" : ""}`}
-              onClick={() => setFilterOpen((v) => !v)}>
-              <Icon name={hasActiveFilters(filter) ? "ph:funnel-fill" : "ph:funnel"} width={13} />
-              Filter
-            </button>
-            {filterOpen && (
-              <BoardFilterPopover filter={filter} familiars={familiars} allLabels={allLabels}
-                onChange={setFilter} onClose={() => setFilterOpen(false)} />
-            )}
-          </div>
+          <BoardMultiSelect
+            label="Priority"
+            icon="ph:dots-three-vertical"
+            options={[
+              { id: "urgent", label: "Urgent" },
+              { id: "high",   label: "High" },
+              { id: "medium", label: "Medium" },
+              { id: "low",    label: "Low" },
+            ]}
+            selected={filter.priorities}
+            onChange={(next) => setFilter((f) => ({ ...f, priorities: next as Set<import("@/lib/cave-board-types").CardPriority> }))}
+          />
+
+          <BoardMultiSelect
+            label="Status"
+            icon="ph:circle-fill"
+            options={[
+              { id: "backlog", label: "Backlog" },
+              { id: "inbox",   label: "Inbox" },
+              { id: "running", label: "Running" },
+              { id: "review",  label: "Review" },
+              { id: "blocked", label: "Blocked" },
+              { id: "done",    label: "Done" },
+            ]}
+            selected={filter.statuses}
+            onChange={(next) => setFilter((f) => ({ ...f, statuses: next as Set<import("@/lib/cave-board-types").CardStatus> }))}
+          />
+
+          <BoardMultiSelect
+            label="Familiar"
+            icon="ph:sparkle"
+            options={familiars.map((f) => ({ id: f.id, label: f.display_name }))}
+            selected={filter.familiarIds}
+            onChange={(next) => setFilter((f) => ({ ...f, familiarIds: next }))}
+            emptyLabel="No familiars configured"
+          />
+
+          {allLabels.length > 0 && (
+            <BoardMultiSelect
+              label="Labels"
+              icon="ph:tag-bold"
+              options={allLabels.map((l) => ({ id: l, label: l }))}
+              selected={filter.labels}
+              onChange={(next) => setFilter((f) => ({ ...f, labels: next }))}
+            />
+          )}
 
           <div className="board-view-toggle" role="group" aria-label="Tasks view mode">
             <button type="button" aria-label="Kanban view"

--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -170,9 +170,10 @@ export function BrowserPane({ label = "default" }: { label?: string }) {
   const [addressBar, setAddressBar] = useState<string>(HOME_URL);
   const [quickOpen, setQuickOpen] = useState(false);
   const [railHover, setRailHover] = useState(false);
+  const [railPinned, setRailPinned] = useState(false);
   // Rail expands on hover/focus and stays expanded while the quick-open
   // palette is up so users can verify the active tab visually.
-  const railExpanded = railHover || quickOpen;
+  const railExpanded = railPinned || railHover || quickOpen;
 
   // History per-tab
   const historyRef = useRef<Record<string, { stack: string[]; idx: number }>>({});
@@ -492,6 +493,20 @@ export function BrowserPane({ label = "default" }: { label?: string }) {
             railExpanded ? "opacity-100" : "pointer-events-none opacity-0",
           ].join(" ")}
         >
+          {/* Pin/unpin toggle at the very top of the rail */}
+          <button
+            type="button"
+            onClick={() => setRailPinned((v) => !v)}
+            title={railPinned ? "Auto-hide tabs" : "Pin tabs open"}
+            className={[
+              "mb-1 grid h-7 w-7 shrink-0 place-items-center rounded transition-colors",
+              railPinned
+                ? "text-[var(--accent-presence)] hover:text-[var(--accent-presence)]"
+                : "text-[var(--fg-muted)] hover:text-[var(--fg-base)]",
+            ].join(" ")}
+          >
+            <Icon name={railPinned ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={13} />
+          </button>
         {tabs.map((tab) => {
           const isActive = tab.id === activeTabId;
           const title = shortTitle(tab.url, tabTitles[tab.id] ?? tab.title);

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -203,6 +203,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const [error, setError] = useState<string | null>(null);
   const currentSessionRef = useRef<string | null>(sessionId);
   const tailRef = useRef<HTMLDivElement | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [atBottom, setAtBottom] = useState(true);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const keys = useKeySymbols();
@@ -256,8 +258,19 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   }, [sessionId]);
 
   useEffect(() => {
-    tailRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
-  }, [turns]);
+    if (atBottom) tailRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [turns, atBottom]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const threshold = 80;
+      setAtBottom(el.scrollHeight - el.scrollTop - el.clientHeight < threshold);
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, []);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -571,7 +584,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   return (
     <section className="flex h-full flex-col bg-[var(--bg-base)] text-[var(--text-primary)]">
       {/* Transcript */}
-      <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
+      <div ref={scrollRef} className="relative min-h-0 flex-1 overflow-y-auto px-6 py-6">
         <div className="space-y-6">
           {turns.length === 0 ? (
             <ChatEmptyState familiar={familiar} modKey={keys.mod} />
@@ -592,6 +605,21 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           })}
           <div ref={tailRef} />
         </div>
+
+        {/* Scroll-to-bottom FAB */}
+        {!atBottom && (
+          <button
+            type="button"
+            onClick={() => {
+              setAtBottom(true);
+              tailRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+            }}
+            aria-label="Scroll to bottom"
+            className="sticky bottom-4 float-right z-20 flex h-7 w-7 items-center justify-center rounded-md border border-[var(--accent-presence)]/40 bg-[var(--bg-raised)] text-[var(--accent-presence)] shadow-[0_2px_12px_var(--accent-presence)/20] transition-all hover:border-[var(--accent-presence)]/70 hover:bg-[color-mix(in_oklch,var(--accent-presence)_10%,var(--bg-raised))] hover:shadow-[0_2px_18px_var(--accent-presence)/35]"
+          >
+            <Icon name="ph:caret-down-bold" width={12} />
+          </button>
+        )}
       </div>
 
       {error ? (
@@ -653,7 +681,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             <div className="flex items-center justify-between px-3 pb-2.5">
               <div className="flex items-center gap-1 text-[var(--text-muted)]">
                 <button
-                  className="grid h-7 w-7 place-items-center rounded-full border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)]"
+                  className="grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)]"
                   title="Attach (coming soon)"
                   disabled
                 >
@@ -668,7 +696,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 {busy ? (
                   <button
                     onClick={cancelSend}
-                    className="grid h-7 w-7 place-items-center rounded-full bg-rose-500/90 text-white transition-colors hover:bg-rose-500"
+                    className="grid h-7 w-7 place-items-center rounded-md bg-rose-500/90 text-white transition-colors hover:bg-rose-500"
                     title="Cancel (esc)"
                   >
                     ■
@@ -677,7 +705,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   <button
                     onClick={() => void send()}
                     disabled={!input.trim()}
-                    className="grid h-7 w-7 place-items-center rounded-full bg-[var(--accent-presence)] text-white transition-colors hover:bg-[var(--accent-presence-soft)] disabled:opacity-40"
+                    className="grid h-7 w-7 place-items-center rounded-md bg-[var(--accent-presence)] text-white transition-colors hover:bg-[var(--accent-presence-soft)] disabled:opacity-40"
                     title={`Send (${keys.enter})`}
                   >
                     ↑
@@ -876,6 +904,53 @@ function ToolGroup({ tools }: { tools: ToolEvent[] }) {
 
 // ── ToolBlock ──────────────────────────────────────────────────────────────────
 
+/** Lines above this threshold get a max-height + fade + expand toggle */
+const TOOL_BODY_COLLAPSE_LINES = 12;
+
+function ToolBodySection({ label, text }: { label: string; text: string }) {
+  const lineCount = text.split("\n").length;
+  const isLong = lineCount > TOOL_BODY_COLLAPSE_LINES;
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div>
+      <div className="mb-0.5 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">{label}</div>
+      <div className="relative">
+        <div
+          style={isLong && !expanded
+            ? { maxHeight: "12rem", overflow: "hidden" }
+            : undefined}
+        >
+          <SyntaxBlock text={text} />
+        </div>
+        {isLong && !expanded && (
+          <div
+            className="absolute inset-x-0 bottom-0 flex items-end justify-center"
+            style={{ height: "3.5rem", background: "linear-gradient(to bottom, transparent, var(--bg-raised, #1a1a1a) 85%)" }}
+          >
+            <button
+              type="button"
+              onClick={() => setExpanded(true)}
+              className="mb-1 rounded border border-[var(--border-hairline)]/70 px-2.5 py-0.5 text-[10px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)]/60 hover:text-[var(--text-primary)]"
+            >
+              Show {lineCount - TOOL_BODY_COLLAPSE_LINES} more lines
+            </button>
+          </div>
+        )}
+        {isLong && expanded && (
+          <button
+            type="button"
+            onClick={() => setExpanded(false)}
+            className="mt-1 text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--text-secondary)]"
+          >
+            ↑ collapse
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function ToolBlock({ tool }: { tool: ToolEvent }) {
   const [open, setOpen] = useState(false);
   const statusDot =
@@ -912,18 +987,8 @@ function ToolBlock({ tool }: { tool: ToolEvent }) {
       </button>
       {open && hasBody ? (
         <div className="space-y-2 border-t border-[var(--border-hairline)]/70 px-3 py-2 font-mono text-[12px] leading-relaxed">
-          {tool.input ? (
-            <div>
-              <div className="mb-0.5 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">input</div>
-              <SyntaxBlock text={tool.input} />
-            </div>
-          ) : null}
-          {tool.output ? (
-            <div>
-              <div className="mb-0.5 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">output</div>
-              <SyntaxBlock text={tool.output} />
-            </div>
-          ) : null}
+          {tool.input ? <ToolBodySection label="input" text={tool.input} /> : null}
+          {tool.output ? <ToolBodySection label="output" text={tool.output} /> : null}
         </div>
       ) : null}
     </div>

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { Familiar } from "@/lib/types";
 import type { InboxItem } from "@/lib/cave-inbox";
-import { SyntaxBlock } from "@/components/message-bubble";
+import { SyntaxBlock, MarkdownBlock } from "@/components/message-bubble";
 import { EvalLoopPanel } from "@/components/eval-loop-panel";
 import { MemoryInspectorPanel } from "@/components/memory-inspector-panel";
 
@@ -386,10 +386,17 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
           </button>
         </div>
 
-        <SyntaxBlock
-          text={openFile?.text ?? "loading…"}
-          className="min-h-0 flex-1 overflow-auto px-3 py-3 text-[11px]"
-        />
+        {openPath.endsWith(".md") ? (
+          <MarkdownBlock
+            text={openFile?.text ?? "loading…"}
+            className="min-h-0 flex-1 overflow-auto px-4 py-4"
+          />
+        ) : (
+          <SyntaxBlock
+            text={openFile?.text ?? "loading…"}
+            className="min-h-0 flex-1 overflow-auto px-3 py-3 text-[11px]"
+          />
+        )}
       </div>
     );
   }

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -224,6 +224,37 @@ export function SyntaxBlock({ text, lang, className }: SyntaxBlockProps) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Public: MarkdownBlock — renders full markdown (prose + code) via @create-markdown/preview
+// ---------------------------------------------------------------------------
+
+export function MarkdownBlock({ text, className }: { text: string; className?: string }) {
+  const [html, setHtml] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!text) return;
+    let cancelled = false;
+    void mdToHtml(text).then((h) => { if (!cancelled) setHtml(h); });
+    return () => { cancelled = true; };
+  }, [text]);
+
+  if (!html) {
+    return (
+      <pre className={`whitespace-pre-wrap break-words font-mono text-[12px] leading-relaxed text-[var(--text-secondary)] ${className ?? ""}`}>
+        {text}
+      </pre>
+    );
+  }
+
+  return (
+    <div
+      className={`cave-md ${className ?? ""}`}
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}
+
 function escHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -265,32 +265,6 @@ function ShellInner({
     </Group>
   );
 
-  // Right-rail toggle tab (Dia/Linear-style vertical pill)
-  const agentTab = hasAgent ? (
-    <button
-      className="shell-agent-tab"
-      aria-label={agentOpen ? `Close ${agentLabel ?? "Browser"}` : `Open ${agentLabel ?? "Browser"}`}
-      title={`${agentLabel ?? "Browser"} (⌘J)`}
-      onClick={() => {
-        const panel = agentRef.current;
-        if (!panel) return;
-        if (panel.isCollapsed()) {
-          panel.expand();
-          setAgentOpen(true);
-        } else {
-          panel.collapse();
-          setAgentOpen(false);
-        }
-      }}
-    >
-      <Icon name={agentIcon ?? "ph:globe"} width={14} height={14} />
-      <span className="shell-agent-tab-label">{agentLabel ?? "Browser"}</span>
-      <span style={{ transform: agentOpen ? "rotate(0deg)" : "rotate(180deg)", transition: "transform 0.2s", display: "flex" }}>
-        <Icon name="ph:caret-right" width={10} height={10} className="shell-agent-tab-chevron" />
-      </span>
-    </button>
-  ) : null;
-
   return (
     <div className="flex h-full w-full flex-col">
       {topBar}
@@ -321,7 +295,22 @@ function ShellInner({
         ) : (
           horizontalGroup
         )}
-        {agentTab}
+        {hasAgent && (
+          <button
+            type="button"
+            className={`shell-agent-tab${agentOpen ? " shell-agent-tab--open" : ""}`}
+            aria-label={agentOpen ? `Close ${agentLabel ?? "Browser"}` : `Open ${agentLabel ?? "Browser"}`}
+            title={`${agentLabel ?? "Browser"} (⌘J)`}
+            onClick={() => {
+              const panel = agentRef.current;
+              if (!panel) return;
+              if (panel.isCollapsed()) { panel.expand(); setAgentOpen(true); }
+              else { panel.collapse(); setAgentOpen(false); }
+            }}
+          >
+            <Icon name={agentIcon ?? "ph:globe"} width={15} />
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -4,11 +4,12 @@
  * SidebarMinimal — the redesigned Cave sidebar.
  *
  * Layout (top → bottom):
- *   1. Primary actions (new chat, plugins, automations, calendar)
- *   2. App destinations (Chat / Board / Inbox / Terminal / Projects / etc.)
- *   3. Settings gear (pinned bottom)
+ *   1. New chat CTA
+ *   2. App destinations (Chat / Inbox / Tasks · Terminal / Projects / Browser · Calls / GitHub)
+ *   3. Utility actions footer (Plugins / Automations / Calendar)
  */
 
+import React from "react";
 import { Icon } from "@/lib/icon";
 import type { SessionRow } from "@/lib/types";
 
@@ -38,7 +39,7 @@ export type SidebarMinimalProps = {
 };
 
 // ---------------------------------------------------------------------------
-// Action button (top group)
+// Action button
 // ---------------------------------------------------------------------------
 
 function ActionRow({
@@ -70,16 +71,19 @@ const FOLDER_MODES: Array<{
   label: string;
   iconName: Parameters<typeof Icon>[0]["name"];
   badge?: (props: SidebarMinimalProps) => string | undefined;
+  dividerBefore?: boolean;
 }> = [
-  { id: "chats",      label: "Chat",        iconName: "ph:chat-circle-dots" },
-  { id: "board",      label: "Tasks",       iconName: "ph:kanban" },
-  { id: "inbox",      label: "Inbox",       iconName: "ph:bell-fill",
+  // ── Primary loop ────────────────────────────────────────────────────────
+  { id: "chats",    label: "Chat",        iconName: "ph:chat-circle-dots" },
+  { id: "inbox",    label: "Inbox",       iconName: "ph:bell-fill",
     badge: (p) => p.inboxBadgeCount && p.inboxBadgeCount > 0 ? String(p.inboxBadgeCount) : undefined },
-  { id: "terminal",   label: "Terminal",    iconName: "ph:terminal-window" },
-  { id: "projects",   label: "Projects",    iconName: "ph:folder-open" },
-  { id: "calls",      label: "Coven Calls", iconName: "ph:graph" },
-  { id: "browser",    label: "Browser",     iconName: "ph:globe" },
-  { id: "github",     label: "GitHub",      iconName: "ph:github-logo" },
+  { id: "board",    label: "Tasks",       iconName: "ph:kanban" },
+  // ── Tools ───────────────────────────────────────────────────────────────
+  { id: "terminal",  label: "Terminal",    iconName: "ph:terminal-window", dividerBefore: true },
+  { id: "browser",   label: "Browser",     iconName: "ph:globe" },
+  // ── Integrations ────────────────────────────────────────────────────────
+  { id: "calls",   label: "Coven Calls", iconName: "ph:graph",       dividerBefore: true },
+  { id: "github",  label: "GitHub",      iconName: "ph:github-logo" },
 ];
 
 function FolderRow({
@@ -123,13 +127,34 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
 
   return (
     <nav className="sidebar-minimal">
-      {/* ── Primary actions ───────────────────────────────────── */}
+      {/* ── New chat (top CTA) ──────────────────────────────── */}
       <div className="sidebar-actions">
         <ActionRow
           icon={<Icon name="ph:note-pencil" width={14} />}
           label="New chat"
           onClick={onNewChat}
         />
+      </div>
+
+      {/* ── Folder mode rows ────────────────────────────────── */}
+      <div className="sidebar-folders">
+        {FOLDER_MODES.map((fm) => (
+          <React.Fragment key={fm.id}>
+            {fm.dividerBefore && <div className="sidebar-divider" />}
+            <FolderRow
+              id={fm.id}
+              label={fm.label}
+              iconName={fm.iconName}
+              active={mode === fm.id}
+              badge={fm.badge?.(props)}
+              onClick={() => onModeChange(fm.id)}
+            />
+          </React.Fragment>
+        ))}
+      </div>
+
+      {/* ── Utility actions (footer) ────────────────────────── */}
+      <div className="sidebar-actions sidebar-actions--footer">
         <ActionRow
           icon={<Icon name="ph:plug" width={14} />}
           label="Plugins"
@@ -145,21 +170,6 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
           label="Calendar"
           onClick={() => onModeChange("calendar")}
         />
-      </div>
-
-      {/* ── Folder mode rows ──────────────────────────────────── */}
-      <div className="sidebar-folders">
-        {FOLDER_MODES.map((fm) => (
-          <FolderRow
-            key={fm.id}
-            id={fm.id}
-            label={fm.label}
-            iconName={fm.iconName}
-            active={mode === fm.id}
-            badge={fm.badge?.(props)}
-            onClick={() => onModeChange(fm.id)}
-          />
-        ))}
       </div>
     </nav>
   );

--- a/src/lib/codex-automations-types.ts
+++ b/src/lib/codex-automations-types.ts
@@ -1,0 +1,34 @@
+export type AutomationStatus = "ACTIVE" | "PAUSED";
+
+export type CodexAutomation = {
+  id: string;
+  name: string;
+  kind: string;
+  status: AutomationStatus;
+  rrule: string | null;
+  model: string | null;
+  reasoningEffort: string | null;
+  executionEnvironment: string | null;
+  cwds: string[];
+  tags: string[];
+  prompt: string;
+  skillPath: string | null;
+  scheduleHuman: string;
+};
+
+export type CodexAutomationRecord = CodexAutomation & {
+  tomlPath: string;
+};
+
+export type CodexAutomationPatch = {
+  name?: string;
+  prompt?: string;
+  status?: AutomationStatus;
+  rrule?: string;
+  model?: string;
+  reasoning_effort?: string;
+  execution_environment?: string;
+  cwds?: string[];
+  tags?: string[];
+  skill_path?: string;
+};

--- a/src/lib/codex-automations.test.ts
+++ b/src/lib/codex-automations.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { patchTomlAutomationFields } from "./codex-automations.ts";
+import { patchTomlAutomationFields, patchTomlStatus } from "./codex-automations.ts";
 
 const original = `version = 1
 id = "ios-application-priority-audit"
@@ -41,3 +41,25 @@ assert.match(patched, /^tags = \["ios", "priority", "audit"\]/m);
 assert.ok(patched.includes("prompt = '''Daily task: iOS Application Priority Audit\n\nLook for drift.\n'''"));
 assert.ok(!patched.includes("Old prompt"));
 assert.ok(patched.includes('skill_path = "/Users/buns/.coven/skills/coven-task-manager"'));
+
+const oddlyFormatted = `version = 1
+  status = 'PAUSED' # keep old comment
+  prompt = '''Old prompt
+still old
+'''
+`;
+
+const patchedOdd = patchTomlAutomationFields(oddlyFormatted, {
+  status: "ACTIVE",
+  prompt: "New prompt",
+});
+
+assert.match(patchedOdd, /^  status = "ACTIVE"$/m);
+assert.ok(patchedOdd.includes("  prompt = '''New prompt\n'''"));
+assert.ok(!patchedOdd.includes("still old"));
+assert.equal((patchedOdd.match(/^\s*status\s*=/gm) ?? []).length, 1);
+assert.equal((patchedOdd.match(/^\s*prompt\s*=/gm) ?? []).length, 1);
+
+const bareStatus = patchTomlStatus("status = PAUSED # old\n", "ACTIVE");
+assert.match(bareStatus, /^status = "ACTIVE"$/m);
+assert.equal((bareStatus.match(/^\s*status\s*=/gm) ?? []).length, 1);

--- a/src/lib/codex-automations.test.ts
+++ b/src/lib/codex-automations.test.ts
@@ -1,0 +1,43 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { patchTomlAutomationFields } from "./codex-automations.ts";
+
+const original = `version = 1
+id = "ios-application-priority-audit"
+kind = "cron"
+name = "iOS Application Priority Audit"
+prompt = '''Old prompt
+with multiple lines'''
+status = "PAUSED"
+rrule = "RRULE:FREQ=WEEKLY;BYHOUR=2;BYMINUTE=0;BYDAY=SU,MO,TU,WE,TH,FR,SA"
+model = "gpt-5.4"
+reasoning_effort = "medium"
+execution_environment = "worktree"
+cwds = ["/tmp/old"]
+tags = ["ios", "audit"]
+skill_path = "/Users/buns/.coven/skills/coven-task-manager"
+`;
+
+const patched = patchTomlAutomationFields(original, {
+  name: 'Priority "Audit"',
+  prompt: "Daily task: iOS Application Priority Audit\n\nLook for drift.",
+  status: "ACTIVE",
+  rrule: "RRULE:FREQ=WEEKLY;BYHOUR=6;BYMINUTE=30;BYDAY=MO,WE,FR",
+  model: "gpt-5.5",
+  reasoning_effort: "high",
+  execution_environment: "worktree",
+  cwds: ["/Users/buns/Documents/GitHub/OpenCoven/coven-cave"],
+  tags: ["ios", "priority", "audit"],
+});
+
+assert.match(patched, /^name = "Priority \\"Audit\\""/m);
+assert.match(patched, /^status = "ACTIVE"/m);
+assert.match(patched, /^rrule = "RRULE:FREQ=WEEKLY;BYHOUR=6;BYMINUTE=30;BYDAY=MO,WE,FR"/m);
+assert.match(patched, /^model = "gpt-5.5"/m);
+assert.match(patched, /^reasoning_effort = "high"/m);
+assert.match(patched, /^execution_environment = "worktree"/m);
+assert.match(patched, /^cwds = \["\/Users\/buns\/Documents\/GitHub\/OpenCoven\/coven-cave"\]/m);
+assert.match(patched, /^tags = \["ios", "priority", "audit"\]/m);
+assert.ok(patched.includes("prompt = '''Daily task: iOS Application Priority Audit\n\nLook for drift.\n'''"));
+assert.ok(!patched.includes("Old prompt"));
+assert.ok(patched.includes('skill_path = "/Users/buns/.coven/skills/coven-task-manager"'));

--- a/src/lib/codex-automations.ts
+++ b/src/lib/codex-automations.ts
@@ -22,11 +22,28 @@ export type CodexAutomation = {
   status: AutomationStatus;
   rrule: string | null;
   model: string | null;
+  reasoningEffort: string | null;
+  executionEnvironment: string | null;
+  cwds: string[];
   tags: string[];
   prompt: string;
+  skillPath: string | null;
   /** Parsed from rrule for display */
   scheduleHuman: string;
   tomlPath: string;
+};
+
+export type CodexAutomationPatch = {
+  name?: string;
+  prompt?: string;
+  status?: AutomationStatus;
+  rrule?: string;
+  model?: string;
+  reasoning_effort?: string;
+  execution_environment?: string;
+  cwds?: string[];
+  tags?: string[];
+  skill_path?: string;
 };
 
 const AUTOMATIONS_DIR = path.join(homedir(), ".codex", "automations");
@@ -35,36 +52,56 @@ const AUTOMATIONS_DIR = path.join(homedir(), ".codex", "automations");
 
 function parseTomlString(raw: string): Record<string, string> {
   const result: Record<string, string> = {};
-  // Handle multiline: collapse ''' ... ''' blocks into a single placeholder
-  // so line iteration works cleanly.
   const lines = raw.split(/\r?\n/);
   let i = 0;
   while (i < lines.length) {
     const line = lines[i];
-    // Multiline string: key = '''
-    const mlMatch = line.match(/^(\w[\w-]*)\s*=\s*'''\s*$/);
+    // Multiline literal string: key = '''content can start here
+    const mlMatch = line.match(/^(\w[\w-]*)\s*=\s*'''(.*)$/);
     if (mlMatch) {
       const key = mlMatch[1];
+      const first = mlMatch[2] ?? "";
       const parts: string[] = [];
+      if (first.endsWith("'''")) {
+        result[key] = first.slice(0, -3);
+        i++;
+        continue;
+      }
+      parts.push(first);
       i++;
-      while (i < lines.length && lines[i] !== "'''") {
-        parts.push(lines[i]);
+      while (i < lines.length) {
+        const current = lines[i];
+        if (current.endsWith("'''")) {
+          parts.push(current.slice(0, -3));
+          i++;
+          break;
+        }
+        parts.push(current);
         i++;
       }
       result[key] = parts.join("\n");
-      i++; // skip closing '''
       continue;
     }
     // Normal key = "value" or key = 'value' or key = bare
-    const match = line.match(/^(\w[\w-]*)\s*=\s*(?:"([^"\\]*)"|'([^']*)'|(.*))$/);
+    const match = line.match(/^(\w[\w-]*)\s*=\s*(?:"((?:[^"\\]|\\.)*)"|'([^']*)'|(.*))$/);
     if (match) {
       const key = match[1];
-      const val = match[2] ?? match[3] ?? (match[4] ?? "").trim();
+      const val = match[2] !== undefined
+        ? unescapeTomlBasicString(match[2])
+        : match[3] ?? (match[4] ?? "").trim();
       result[key] = val;
     }
     i++;
   }
   return result;
+}
+
+function unescapeTomlBasicString(value: string): string {
+  return value
+    .replace(/\\n/g, "\n")
+    .replace(/\\t/g, "\t")
+    .replace(/\\"/g, '"')
+    .replace(/\\\\/g, "\\");
 }
 
 function parseTags(raw: string): string[] {
@@ -76,6 +113,27 @@ function parseTags(raw: string): string[] {
     .split(",")
     .map((t) => t.trim().replace(/^["']|["']$/g, ""))
     .filter(Boolean);
+}
+
+function escapeTomlBasicString(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\t/g, "\\t");
+}
+
+function tomlString(value: string): string {
+  return `"${escapeTomlBasicString(value)}"`;
+}
+
+function tomlStringArray(values: string[]): string {
+  return `[${values.map(tomlString).join(", ")}]`;
+}
+
+function tomlPrompt(value: string): string {
+  const normalized = value.replace(/\r\n?/g, "\n").replace(/'''/g, "''\\'");
+  return `'''${normalized.replace(/\n*$/g, "")}\n'''`;
 }
 
 function humanRrule(rrule: string | null): string {
@@ -117,6 +175,63 @@ export function patchTomlStatus(raw: string, newStatus: AutomationStatus): strin
   return raw.trimEnd() + `\nstatus = "${newStatus}"\n`;
 }
 
+function replaceTomlKey(raw: string, key: string, value: string): string {
+  const lines = raw.split(/\r?\n/);
+  const next: string[] = [];
+  let replaced = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const keyMatch = line.match(/^(\w[\w-]*)\s*=/);
+    if (keyMatch?.[1] !== key) {
+      next.push(line);
+      continue;
+    }
+
+    next.push(`${key} = ${value}`);
+    replaced = true;
+
+    if (/^\w[\w-]*\s*=\s*'''/.test(line) && !line.endsWith("'''")) {
+      while (i + 1 < lines.length) {
+        i++;
+        if (lines[i].endsWith("'''")) break;
+      }
+    }
+  }
+
+  if (!replaced) {
+    if (next.length > 0 && next[next.length - 1] !== "") next.push("");
+    next.push(`${key} = ${value}`);
+  }
+
+  return next.join("\n");
+}
+
+export function patchTomlAutomationFields(
+  raw: string,
+  patch: CodexAutomationPatch,
+): string {
+  const entries: [keyof CodexAutomationPatch, string, (value: never) => string][] = [
+    ["name", "name", tomlString as (value: never) => string],
+    ["prompt", "prompt", tomlPrompt as (value: never) => string],
+    ["status", "status", tomlString as (value: never) => string],
+    ["rrule", "rrule", tomlString as (value: never) => string],
+    ["model", "model", tomlString as (value: never) => string],
+    ["reasoning_effort", "reasoning_effort", tomlString as (value: never) => string],
+    ["execution_environment", "execution_environment", tomlString as (value: never) => string],
+    ["cwds", "cwds", tomlStringArray as (value: never) => string],
+    ["tags", "tags", tomlStringArray as (value: never) => string],
+    ["skill_path", "skill_path", tomlString as (value: never) => string],
+  ];
+
+  let next = raw;
+  for (const [patchKey, tomlKey, formatter] of entries) {
+    const value = patch[patchKey];
+    if (value === undefined) continue;
+    next = replaceTomlKey(next, tomlKey, formatter(value as never));
+  }
+  return next;
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
 
 export async function listCodexAutomations(): Promise<CodexAutomation[]> {
@@ -148,8 +263,12 @@ export async function listCodexAutomations(): Promise<CodexAutomation[]> {
         status,
         rrule,
         model: kv["model"] ?? null,
+        reasoningEffort: kv["reasoning_effort"] ?? null,
+        executionEnvironment: kv["execution_environment"] ?? null,
+        cwds: parseTags(kv["cwds"] ?? ""),
         tags: parseTags(kv["tags"] ?? ""),
         prompt: kv["prompt"] ?? "",
+        skillPath: kv["skill_path"] ?? null,
         scheduleHuman: humanRrule(rrule),
         tomlPath,
       });
@@ -178,4 +297,18 @@ export async function setCodexAutomationStatus(
   await writeFile(auto.tomlPath, patched, "utf8");
 
   return { ...auto, status };
+}
+
+export async function updateCodexAutomation(
+  id: string,
+  patch: CodexAutomationPatch,
+): Promise<CodexAutomation | null> {
+  const auto = await getCodexAutomation(id);
+  if (!auto) return null;
+
+  const raw = await readFile(auto.tomlPath, "utf8");
+  const patched = patchTomlAutomationFields(raw, patch);
+  await writeFile(auto.tomlPath, patched, "utf8");
+
+  return getCodexAutomation(id);
 }

--- a/src/lib/codex-automations.ts
+++ b/src/lib/codex-automations.ts
@@ -3,7 +3,7 @@
  *
  * TOML is handled with a minimal line-level approach (no external dep):
  *   - Reads key = "value" / key = 'value' / key = BARE pairs.
- *   - Patching sets exactly `status = "ACTIVE"` or `status = "PAUSED"` inline.
+ *   - Patching replaces recognized top-level keys inline.
  *   - Multiline values (''') are treated as opaque blobs and preserved.
  *
  * Files live at:  ~/.codex/automations/<id>/automation.toml
@@ -12,39 +12,14 @@
 import { readdir, readFile, writeFile, access } from "node:fs/promises";
 import path from "node:path";
 import { homedir } from "node:os";
+import type {
+  AutomationStatus,
+  CodexAutomation,
+  CodexAutomationPatch,
+  CodexAutomationRecord,
+} from "./codex-automations-types";
 
-export type AutomationStatus = "ACTIVE" | "PAUSED";
-
-export type CodexAutomation = {
-  id: string;
-  name: string;
-  kind: string;
-  status: AutomationStatus;
-  rrule: string | null;
-  model: string | null;
-  reasoningEffort: string | null;
-  executionEnvironment: string | null;
-  cwds: string[];
-  tags: string[];
-  prompt: string;
-  skillPath: string | null;
-  /** Parsed from rrule for display */
-  scheduleHuman: string;
-  tomlPath: string;
-};
-
-export type CodexAutomationPatch = {
-  name?: string;
-  prompt?: string;
-  status?: AutomationStatus;
-  rrule?: string;
-  model?: string;
-  reasoning_effort?: string;
-  execution_environment?: string;
-  cwds?: string[];
-  tags?: string[];
-  skill_path?: string;
-};
+export type { AutomationStatus, CodexAutomation, CodexAutomationPatch };
 
 const AUTOMATIONS_DIR = path.join(homedir(), ".codex", "automations");
 
@@ -57,7 +32,7 @@ function parseTomlString(raw: string): Record<string, string> {
   while (i < lines.length) {
     const line = lines[i];
     // Multiline literal string: key = '''content can start here
-    const mlMatch = line.match(/^(\w[\w-]*)\s*=\s*'''(.*)$/);
+    const mlMatch = line.match(/^\s*(\w[\w-]*)\s*=\s*'''(.*)$/);
     if (mlMatch) {
       const key = mlMatch[1];
       const first = mlMatch[2] ?? "";
@@ -83,7 +58,7 @@ function parseTomlString(raw: string): Record<string, string> {
       continue;
     }
     // Normal key = "value" or key = 'value' or key = bare
-    const match = line.match(/^(\w[\w-]*)\s*=\s*(?:"((?:[^"\\]|\\.)*)"|'([^']*)'|(.*))$/);
+    const match = line.match(/^\s*(\w[\w-]*)\s*=\s*(?:"((?:[^"\\]|\\.)*)"|'([^']*)'|(.*))$/);
     if (match) {
       const key = match[1];
       const val = match[2] !== undefined
@@ -167,12 +142,7 @@ function humanRrule(rrule: string | null): string {
 // ── Patch status in TOML preserving file structure ────────────────────────────
 
 export function patchTomlStatus(raw: string, newStatus: AutomationStatus): string {
-  const statusLine = /^status\s*=\s*"(ACTIVE|PAUSED)"/m;
-  if (statusLine.test(raw)) {
-    return raw.replace(statusLine, `status = "${newStatus}"`);
-  }
-  // Append if missing
-  return raw.trimEnd() + `\nstatus = "${newStatus}"\n`;
+  return patchTomlAutomationFields(raw, { status: newStatus });
 }
 
 function replaceTomlKey(raw: string, key: string, value: string): string {
@@ -181,19 +151,19 @@ function replaceTomlKey(raw: string, key: string, value: string): string {
   let replaced = false;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    const keyMatch = line.match(/^(\w[\w-]*)\s*=/);
-    if (keyMatch?.[1] !== key) {
+    const keyMatch = line.match(/^(\s*)(\w[\w-]*)\s*=/);
+    if (keyMatch?.[2] !== key) {
       next.push(line);
       continue;
     }
 
-    next.push(`${key} = ${value}`);
+    next.push(`${keyMatch[1]}${key} = ${value}`);
     replaced = true;
 
-    if (/^\w[\w-]*\s*=\s*'''/.test(line) && !line.endsWith("'''")) {
+    if (/^\s*\w[\w-]*\s*=\s*'''/.test(line) && !line.trimEnd().endsWith("'''")) {
       while (i + 1 < lines.length) {
         i++;
-        if (lines[i].endsWith("'''")) break;
+        if (lines[i].trimEnd().endsWith("'''")) break;
       }
     }
   }
@@ -234,7 +204,27 @@ export function patchTomlAutomationFields(
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
-export async function listCodexAutomations(): Promise<CodexAutomation[]> {
+export function toCodexAutomationPayload(auto: CodexAutomationRecord): CodexAutomation {
+  const { tomlPath: _tomlPath, ...payload } = auto;
+  return payload;
+}
+
+// Serialize read-modify-write sequences against automation TOMLs. Multiple
+// route handlers may patch the same file concurrently when the UI autosaves or
+// toggles status; the chain prevents last-writer-wins clobbering.
+declare global {
+  // eslint-disable-next-line no-var
+  var __codexAutomationWriteChain: Promise<unknown> | undefined;
+}
+
+function withCodexAutomationLock<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = globalThis.__codexAutomationWriteChain ?? Promise.resolve();
+  const next = prev.then(fn, fn);
+  globalThis.__codexAutomationWriteChain = next.catch(() => undefined);
+  return next;
+}
+
+export async function listCodexAutomations(): Promise<CodexAutomationRecord[]> {
   let entries: string[];
   try {
     entries = await readdir(AUTOMATIONS_DIR);
@@ -242,7 +232,7 @@ export async function listCodexAutomations(): Promise<CodexAutomation[]> {
     return [];
   }
 
-  const results: CodexAutomation[] = [];
+  const results: CodexAutomationRecord[] = [];
 
   for (const entry of entries.sort()) {
     const tomlPath = path.join(AUTOMATIONS_DIR, entry, "automation.toml");
@@ -280,7 +270,7 @@ export async function listCodexAutomations(): Promise<CodexAutomation[]> {
   return results;
 }
 
-export async function getCodexAutomation(id: string): Promise<CodexAutomation | null> {
+export async function getCodexAutomation(id: string): Promise<CodexAutomationRecord | null> {
   const list = await listCodexAutomations();
   return list.find((a) => a.id === id) ?? null;
 }
@@ -288,27 +278,22 @@ export async function getCodexAutomation(id: string): Promise<CodexAutomation | 
 export async function setCodexAutomationStatus(
   id: string,
   status: AutomationStatus,
-): Promise<CodexAutomation | null> {
-  const auto = await getCodexAutomation(id);
-  if (!auto) return null;
-
-  const raw = await readFile(auto.tomlPath, "utf8");
-  const patched = patchTomlStatus(raw, status);
-  await writeFile(auto.tomlPath, patched, "utf8");
-
-  return { ...auto, status };
+): Promise<CodexAutomationRecord | null> {
+  return updateCodexAutomation(id, { status });
 }
 
 export async function updateCodexAutomation(
   id: string,
   patch: CodexAutomationPatch,
-): Promise<CodexAutomation | null> {
-  const auto = await getCodexAutomation(id);
-  if (!auto) return null;
+): Promise<CodexAutomationRecord | null> {
+  return withCodexAutomationLock(async () => {
+    const auto = await getCodexAutomation(id);
+    if (!auto) return null;
 
-  const raw = await readFile(auto.tomlPath, "utf8");
-  const patched = patchTomlAutomationFields(raw, patch);
-  await writeFile(auto.tomlPath, patched, "utf8");
+    const raw = await readFile(auto.tomlPath, "utf8");
+    const patched = patchTomlAutomationFields(raw, patch);
+    await writeFile(auto.tomlPath, patched, "utf8");
 
-  return getCodexAutomation(id);
+    return getCodexAutomation(id);
+  });
 }

--- a/src/lib/codex-automations.ts
+++ b/src/lib/codex-automations.ts
@@ -1,0 +1,181 @@
+/**
+ * codex-automations.ts — read + patch Codex automation TOML files.
+ *
+ * TOML is handled with a minimal line-level approach (no external dep):
+ *   - Reads key = "value" / key = 'value' / key = BARE pairs.
+ *   - Patching sets exactly `status = "ACTIVE"` or `status = "PAUSED"` inline.
+ *   - Multiline values (''') are treated as opaque blobs and preserved.
+ *
+ * Files live at:  ~/.codex/automations/<id>/automation.toml
+ */
+
+import { readdir, readFile, writeFile, access } from "node:fs/promises";
+import path from "node:path";
+import { homedir } from "node:os";
+
+export type AutomationStatus = "ACTIVE" | "PAUSED";
+
+export type CodexAutomation = {
+  id: string;
+  name: string;
+  kind: string;
+  status: AutomationStatus;
+  rrule: string | null;
+  model: string | null;
+  tags: string[];
+  prompt: string;
+  /** Parsed from rrule for display */
+  scheduleHuman: string;
+  tomlPath: string;
+};
+
+const AUTOMATIONS_DIR = path.join(homedir(), ".codex", "automations");
+
+// ── TOML minimal parser ──────────────────────────────────────────────────────
+
+function parseTomlString(raw: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  // Handle multiline: collapse ''' ... ''' blocks into a single placeholder
+  // so line iteration works cleanly.
+  const lines = raw.split(/\r?\n/);
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    // Multiline string: key = '''
+    const mlMatch = line.match(/^(\w[\w-]*)\s*=\s*'''\s*$/);
+    if (mlMatch) {
+      const key = mlMatch[1];
+      const parts: string[] = [];
+      i++;
+      while (i < lines.length && lines[i] !== "'''") {
+        parts.push(lines[i]);
+        i++;
+      }
+      result[key] = parts.join("\n");
+      i++; // skip closing '''
+      continue;
+    }
+    // Normal key = "value" or key = 'value' or key = bare
+    const match = line.match(/^(\w[\w-]*)\s*=\s*(?:"([^"\\]*)"|'([^']*)'|(.*))$/);
+    if (match) {
+      const key = match[1];
+      const val = match[2] ?? match[3] ?? (match[4] ?? "").trim();
+      result[key] = val;
+    }
+    i++;
+  }
+  return result;
+}
+
+function parseTags(raw: string): string[] {
+  if (!raw) return [];
+  // ["a", "b", "c"] or [a, b, c]
+  const inner = raw.replace(/^\[|\]$/g, "").trim();
+  if (!inner) return [];
+  return inner
+    .split(",")
+    .map((t) => t.trim().replace(/^["']|["']$/g, ""))
+    .filter(Boolean);
+}
+
+function humanRrule(rrule: string | null): string {
+  if (!rrule) return "Scheduled";
+  // RRULE:FREQ=WEEKLY;BYHOUR=8;BYMINUTE=30;BYDAY=MO,TU,WE,TH,FR
+  const freq = rrule.match(/FREQ=(\w+)/)?.[1];
+  const days = rrule.match(/BYDAY=([^;]+)/)?.[1];
+  const hour = rrule.match(/BYHOUR=(\d+)/)?.[1];
+  const min  = rrule.match(/BYMINUTE=(\d+)/)?.[1];
+
+  const WEEKDAY: Record<string, string> = {
+    MO: "Mon", TU: "Tue", WE: "Wed", TH: "Thu", FR: "Fri", SA: "Sat", SU: "Sun",
+  };
+
+  const timeStr = hour !== undefined
+    ? `${hour.padStart(2, "0")}:${(min ?? "0").padStart(2, "0")}`
+    : null;
+
+  if (freq === "WEEKLY") {
+    const dayStr = days
+      ? days.split(",").map((d) => WEEKDAY[d] ?? d).join("/")
+      : "Daily";
+    return timeStr ? `${dayStr} at ${timeStr}` : dayStr;
+  }
+  if (freq === "DAILY") {
+    return timeStr ? `Daily at ${timeStr}` : "Daily";
+  }
+  return rrule;
+}
+
+// ── Patch status in TOML preserving file structure ────────────────────────────
+
+export function patchTomlStatus(raw: string, newStatus: AutomationStatus): string {
+  const statusLine = /^status\s*=\s*"(ACTIVE|PAUSED)"/m;
+  if (statusLine.test(raw)) {
+    return raw.replace(statusLine, `status = "${newStatus}"`);
+  }
+  // Append if missing
+  return raw.trimEnd() + `\nstatus = "${newStatus}"\n`;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export async function listCodexAutomations(): Promise<CodexAutomation[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(AUTOMATIONS_DIR);
+  } catch {
+    return [];
+  }
+
+  const results: CodexAutomation[] = [];
+
+  for (const entry of entries.sort()) {
+    const tomlPath = path.join(AUTOMATIONS_DIR, entry, "automation.toml");
+    try {
+      await access(tomlPath);
+      const raw = await readFile(tomlPath, "utf8");
+      const kv = parseTomlString(raw);
+
+      const id = kv["id"] ?? entry;
+      const name = kv["name"] ?? id;
+      const status: AutomationStatus = kv["status"] === "ACTIVE" ? "ACTIVE" : "PAUSED";
+      const rrule = kv["rrule"] ?? null;
+
+      results.push({
+        id,
+        name,
+        kind: kv["kind"] ?? "cron",
+        status,
+        rrule,
+        model: kv["model"] ?? null,
+        tags: parseTags(kv["tags"] ?? ""),
+        prompt: kv["prompt"] ?? "",
+        scheduleHuman: humanRrule(rrule),
+        tomlPath,
+      });
+    } catch {
+      // skip dirs without a valid toml
+    }
+  }
+
+  return results;
+}
+
+export async function getCodexAutomation(id: string): Promise<CodexAutomation | null> {
+  const list = await listCodexAutomations();
+  return list.find((a) => a.id === id) ?? null;
+}
+
+export async function setCodexAutomationStatus(
+  id: string,
+  status: AutomationStatus,
+): Promise<CodexAutomation | null> {
+  const auto = await getCodexAutomation(id);
+  if (!auto) return null;
+
+  const raw = await readFile(auto.tomlPath, "utf8");
+  const patched = patchTomlStatus(raw, status);
+  await writeFile(auto.tomlPath, patched, "utf8");
+
+  return { ...auto, status };
+}

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -15,6 +15,11 @@
 
 .board-toolbar-select { height:28px; padding:0 24px 0 8px; border-radius:7px; border:1px solid var(--border-strong); background:var(--bg-raised); color:var(--text-secondary); font-size:12px; cursor:pointer; appearance:none; -webkit-appearance:none; transition:background-color .12s,color .12s; }
 .board-toolbar-select:hover { background-color:var(--bg-hover); color:var(--text-primary); }
+.board-toolbar-select--active { background:color-mix(in oklab,oklch(0.65 0.18 280) 14%,var(--bg-raised)); border-color:color-mix(in oklab,oklch(0.65 0.18 280) 40%,transparent); color:var(--text-primary); }
+.board-multiselect-btn { display:inline-flex; align-items:center; gap:5px; padding:0 8px; height:28px; white-space:nowrap; }
+.board-multiselect-caret { color:var(--text-muted); transition:transform .15s; flex-shrink:0; }
+.board-multiselect-caret--open { transform:rotate(180deg); }
+.board-multiselect-popover { min-width:180px; }
 
 .board-view-toggle { display:flex; border:1px solid var(--border-strong); border-radius:7px; overflow:hidden; }
 .board-view-toggle-btn { display:flex; align-items:center; justify-content:center; width:28px; height:28px; background:var(--bg-raised); color:var(--text-muted); border:none; cursor:pointer; transition:background .12s,color .12s; }
@@ -27,7 +32,7 @@
 
 .board-filter-chips { display:flex; flex-wrap:wrap; align-items:center; gap:5px; padding:6px 16px; border-bottom:1px solid var(--border-hairline); flex-shrink:0; }
 .board-filter-chip { display:inline-flex; align-items:center; gap:4px; padding:2px 8px; border-radius:20px; border:1px solid var(--border-strong); background:var(--bg-raised); color:var(--text-secondary); font-size:11px; cursor:default; }
-.board-filter-chip-remove { display:flex; align-items:center; justify-content:center; width:14px; height:14px; border-radius:50%; border:none; background:transparent; color:var(--text-muted); cursor:pointer; padding:0; margin-left:1px; transition:background .1s,color .1s; }
+.board-filter-chip-remove { display:flex; align-items:center; justify-content:center; width:14px; height:14px; border-radius:4px; border:none; background:transparent; color:var(--text-muted); cursor:pointer; padding:0; margin-left:1px; transition:background .1s,color .1s; }
 .board-filter-chip-remove:hover { background:var(--bg-hover); color:var(--text-primary); }
 .board-filter-chip--clear-all { background:transparent; border:none; color:var(--text-muted); cursor:pointer; font-size:11px; padding:2px 6px; }
 .board-filter-chip--clear-all:hover { color:var(--text-primary); }
@@ -90,7 +95,7 @@
 
 .board-label-chips { display:flex; flex-wrap:wrap; gap:5px; }
 .board-label-chip { display:inline-flex; align-items:center; gap:4px; padding:2px 8px; border-radius:20px; border:1px solid var(--border-strong); background:var(--bg-base); color:var(--text-secondary); font-size:11px; }
-.board-label-chip-remove { display:flex; align-items:center; justify-content:center; width:12px; height:12px; border-radius:50%; border:none; background:transparent; color:var(--text-muted); cursor:pointer; padding:0; transition:color .1s; }
+.board-label-chip-remove { display:flex; align-items:center; justify-content:center; width:12px; height:12px; border-radius:4px; border:none; background:transparent; color:var(--text-muted); cursor:pointer; padding:0; transition:color .1s; }
 .board-label-chip-remove:hover { color:var(--text-primary); }
 
 .board-empty { display:flex; flex-direction:column; align-items:center; justify-content:center; flex:1; gap:8px; padding:48px 24px; color:var(--text-muted); font-size:13px; }

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -187,7 +187,7 @@
   justify-content: center;
   width: 32px;
   height: 32px;
-  border-radius: 9px;
+  border-radius: 6px;
   border: none;
   background: oklch(0.65 0.18 280);
   color: #fff;

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -76,6 +76,12 @@
   border-bottom: 1px solid var(--border-hairline);
 }
 
+.sidebar-divider {
+  height: 1px;
+  background: var(--border-hairline);
+  margin: 4px 9px;
+}
+
 .sidebar-folder-row {
   display: flex;
   align-items: center;
@@ -207,6 +213,12 @@
 }
 
 /* ── Bottom settings row ─────────────────────────────────────────────────── */
+.sidebar-actions--footer {
+  margin-top: auto;
+  border-top: 1px solid var(--border-hairline);
+  padding-top: 6px;
+  padding-bottom: 8px;
+}
 .sidebar-bottom {
   flex-shrink: 0;
   padding: 6px 7px 8px;


### PR DESCRIPTION
## What changed

- Surfaces Codex automation TOMLs in Cave Automations and lets them be activated/paused.
- Fixes the automation detail side panel layout so schedule/status/model do not overlap.
- Adds editing for Codex automation name, prompt, RRULE schedule, model, reasoning effort, execution environment, working directories, and tags.
- Adds TOML patching coverage for multi-field automation updates.

## Why

The Codex automation rows were visible but the detail panel was cramped and status-only. Val needs to activate and tune scheduled Codex work directly from Automations without hand-editing TOML.

## Validation

- `node src/lib/codex-automations.test.ts`
- `npm run typecheck`
- `npm run build` (passes with existing Turbopack broad-filesystem warnings)
