### PR TITLE
feat: support local adapter onboarding

### DIFF
--- a/src/app/api/harnesses/route.ts
+++ b/src/app/api/harnesses/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 import { spawn } from "node:child_process";
+import { COMPATIBILITY_ADAPTERS, mergeAdapterReports, type AdapterReport, type CovenAdapterSummary } from "@/lib/harness-adapters";
+import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
 
 export const dynamic = "force-dynamic";
 
@@ -16,18 +18,6 @@ type HarnessSpec = {
   versionArgs?: string[];
 };
 
-const HARNESSES: HarnessSpec[] = [
-  { id: "codex", label: "Codex", binary: "codex", chatSupported: true },
-  { id: "claude", label: "Claude Code", binary: "claude", chatSupported: true, versionArgs: ["--version"] },
-  { id: "openclaw", label: "OpenClaw", binary: "openclaw", chatSupported: false },
-  { id: "copilot", label: "GitHub Copilot", binary: "copilot", chatSupported: false },
-  { id: "opencode", label: "OpenCode", binary: "opencode", chatSupported: false },
-  { id: "gemini", label: "Gemini CLI", binary: "gemini", chatSupported: false },
-  { id: "hermes", label: "Hermes", binary: "hermes", chatSupported: false },
-  { id: "openhands", label: "OpenHands", binary: "openhands", chatSupported: false },
-  { id: "aider", label: "Aider", binary: "aider", chatSupported: false },
-];
-
 type HarnessReport = HarnessSpec & {
   installed: boolean;
   path: string | null;
@@ -36,7 +26,8 @@ type HarnessReport = HarnessSpec & {
 
 function which(binary: string): Promise<string | null> {
   return new Promise((resolve) => {
-    const child = spawn("/usr/bin/which", [binary], { stdio: ["ignore", "pipe", "ignore"] });
+    const command = process.platform === "win32" ? "where" : "which";
+    const child = spawn(command, [binary], { env: covenSpawnEnv(), stdio: ["ignore", "pipe", "ignore"] });
     let out = "";
     child.stdout.on("data", (d) => (out += d.toString()));
     child.on("close", (code) => resolve(code === 0 ? out.trim() || null : null));
@@ -46,7 +37,7 @@ function which(binary: string): Promise<string | null> {
 
 function probeVersion(binary: string, args: string[]): Promise<string | null> {
   return new Promise((resolve) => {
-    const child = spawn(binary, args, { stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(binary, args, { env: covenSpawnEnv(), stdio: ["ignore", "pipe", "pipe"] });
     let out = "";
     child.stdout.on("data", (d) => (out += d.toString()));
     child.stderr.on("data", (d) => (out += d.toString()));
@@ -65,9 +56,35 @@ function probeVersion(binary: string, args: string[]): Promise<string | null> {
   });
 }
 
+function loadCovenAdapterSummaries(): Promise<CovenAdapterSummary[]> {
+  return new Promise((resolve) => {
+    const child = spawn(covenBin(), ["adapter", "list", "--json"], { env: covenSpawnEnv(), stdio: ["ignore", "pipe", "ignore"] });
+    let out = "";
+    const t = setTimeout(() => {
+      child.kill("SIGTERM");
+      resolve([]);
+    }, 3000);
+    child.stdout.on("data", (d) => (out += d.toString()));
+    child.on("close", (code) => {
+      clearTimeout(t);
+      if (code !== 0) return resolve([]);
+      try {
+        const parsed = JSON.parse(out);
+        resolve(Array.isArray(parsed) ? parsed as CovenAdapterSummary[] : []);
+      } catch {
+        resolve([]);
+      }
+    });
+    child.on("error", () => {
+      clearTimeout(t);
+      resolve([]);
+    });
+  });
+}
+
 export async function GET() {
   const reports: HarnessReport[] = await Promise.all(
-    HARNESSES.map(async (h) => {
+    COMPATIBILITY_ADAPTERS.map(async (h) => {
       const path = await which(h.binary);
       if (!path) {
         return { ...h, installed: false, path: null, version: null };
@@ -76,5 +93,7 @@ export async function GET() {
       return { ...h, installed: true, path, version };
     }),
   );
-  return NextResponse.json({ ok: true, harnesses: reports });
+  const covenReports = await loadCovenAdapterSummaries();
+  const harnesses: AdapterReport[] = mergeAdapterReports(reports, covenReports);
+  return NextResponse.json({ ok: true, harnesses });
 }

--- a/src/app/api/onboarding/setup/route.ts
+++ b/src/app/api/onboarding/setup/route.ts
@@ -46,8 +46,8 @@ export async function POST(req: Request) {
       { status: 400 },
     );
   }
-  const harness = (draft?.harness ?? body.harness ?? "openclaw").trim() || "openclaw";
-  const model = (draft?.model ?? body.model ?? "openclaw").trim() || "openclaw";
+  const harness = (draft?.harness ?? body.harness ?? "codex").trim() || "codex";
+  const model = (draft?.model ?? body.model ?? "codex-local").trim() || "codex-local";
 
   const home = homedir();
   const covenDir = path.join(home, ".coven");
@@ -75,8 +75,8 @@ export async function POST(req: Request) {
     }
   }
 
-  // Always update cave-config.json defaults so the user's chosen OpenClaw
-  // agent binding takes effect even if they re-run setup.
+  // Always update cave-config.json defaults so the user's chosen adapter
+  // binding takes effect even if they re-run setup.
   const existing = await loadConfig();
   const nextConfig = {
     version: existing.version || 1,

--- a/src/app/api/onboarding/status/route.ts
+++ b/src/app/api/onboarding/status/route.ts
@@ -6,6 +6,8 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { callDaemon } from "@/lib/coven-daemon";
 import { loadConfig } from "@/lib/cave-config";
+import { covenSpawnEnv } from "@/lib/coven-bin";
+import { adapterSetupState, COMPATIBILITY_ADAPTERS, type AdapterReport } from "@/lib/harness-adapters";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -15,19 +17,43 @@ const execFileAsync = promisify(execFile);
 type Step = { ok: boolean; detail?: string; hint?: string };
 
 async function checkCovenCli(): Promise<Step> {
-  const command = process.platform === "win32" ? "where" : "command";
-  const args = process.platform === "win32" ? ["coven"] : ["-v", "coven"];
-  try {
-    const { stdout } = await execFileAsync(command, args, { timeout: 1500 });
-    const found = stdout.trim();
-    if (found) return { ok: true, detail: found };
-  } catch {
-    /* not found */
-  }
+  const found = await commandPath("coven");
+  if (found) return { ok: true, detail: found };
   return {
     ok: false,
     hint: "Install the coven CLI from OpenCoven/coven, make sure it is on PATH, then re-check.",
   };
+}
+
+async function commandPath(binary: string): Promise<string | null> {
+  const command = process.platform === "win32" ? "where" : "which";
+  try {
+    const { stdout } = await execFileAsync(command, [binary], { env: covenSpawnEnv(), timeout: 1500 });
+    return stdout.trim().split(/\r?\n/)[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+async function checkHarnessAdapters(): Promise<Step> {
+  const reports: AdapterReport[] = await Promise.all(
+    COMPATIBILITY_ADAPTERS.map(async (adapter) => {
+      const found = await commandPath(adapter.binary);
+      return {
+        id: adapter.id,
+        label: adapter.label,
+        binary: adapter.binary,
+        chatSupported: adapter.chatSupported,
+        installed: !!found,
+        path: found,
+        version: null,
+        installHint: adapter.installHint,
+        source: adapter.source,
+        manifestPath: null,
+      };
+    }),
+  );
+  return adapterSetupState(reports);
 }
 
 async function checkCovenHome(): Promise<Step> {
@@ -66,7 +92,7 @@ async function checkBinding(familiarsAvailable: boolean): Promise<Step> {
   const config = await loadConfig();
   const hasDefaults = !!config.defaults.harness && !!config.defaults.model;
   if (!hasDefaults) {
-    return { ok: false, hint: "Connect an OpenClaw agent so Cave can create a familiar binding." };
+    return { ok: false, hint: "Create a local Codex/Claude familiar or connect an OpenClaw agent." };
   }
   if (!familiarsAvailable) {
     return { ok: false, hint: "Bindings set but no familiars to bind." };
@@ -81,11 +107,13 @@ export async function GET() {
     checkDaemon(),
     checkFamiliars(),
   ]);
+  const adapters = await checkHarnessAdapters();
   const binding = await checkBinding(familiarsRes.count > 0);
 
   const steps = {
     covenCli,
     covenHome,
+    adapters,
     daemon,
     familiars: familiarsRes.step,
     binding,

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -13,10 +13,24 @@ type OnboardingStatus = {
   steps: {
     covenCli: Step;
     covenHome: Step;
+    adapters: Step;
     daemon: Step;
     familiars: Step;
     binding: Step;
   };
+};
+
+type HarnessReport = {
+  id: string;
+  label: string;
+  binary: string;
+  chatSupported: boolean;
+  installed: boolean;
+  path: string | null;
+  version: string | null;
+  installHint: string;
+  source: string;
+  manifestPath: string | null;
 };
 
 type OpenClawAgent = {
@@ -122,6 +136,8 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   const [familiarDescription, setFamiliarDescription] = useState("");
   const [familiarGlyph, setFamiliarGlyph] = useState("ph:sparkle-fill");
   const [openclawAgents, setOpenclawAgents] = useState<OpenClawAgent[]>([]);
+  const [harnesses, setHarnesses] = useState<HarnessReport[]>([]);
+  const [selectedHarnessId, setSelectedHarnessId] = useState<string | null>(null);
   const [agentsLoading, setAgentsLoading] = useState(false);
   const [agentsError, setAgentsError] = useState<string | null>(null);
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
@@ -164,16 +180,35 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
     }
   }, []);
 
+  const loadHarnesses = useCallback(async () => {
+    try {
+      const res = await fetch("/api/harnesses", { cache: "no-store" });
+      const json = await res.json() as { ok?: boolean; harnesses?: HarnessReport[] };
+      if (!res.ok || json.ok === false) return;
+      const next = json.harnesses ?? [];
+      setHarnesses(next);
+      setSelectedHarnessId((current) => {
+        if (current && next.some((adapter) => adapter.id === current && adapter.installed)) return current;
+        return next.find((adapter) => adapter.installed && adapter.chatSupported)?.id
+          ?? next.find((adapter) => adapter.installed)?.id
+          ?? current;
+      });
+    } catch {
+      /* harness availability is advisory; status cards carry setup hints */
+    }
+  }, []);
+
   useEffect(() => {
     if (!open) return;
     void refresh();
+    void loadHarnesses();
     void loadOpenClawAgents();
     pollRef.current = setInterval(refresh, 2000);
     return () => {
       if (pollRef.current) clearInterval(pollRef.current);
       pollRef.current = null;
     };
-  }, [open, refresh, loadOpenClawAgents]);
+  }, [open, refresh, loadHarnesses, loadOpenClawAgents]);
 
   useEffect(() => {
     if (!open || !status?.complete) return;
@@ -239,6 +274,40 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
     }
   };
 
+  const createLocalFamiliar = async () => {
+    const selectedHarness = harnesses.find((adapter) => adapter.id === selectedHarnessId && adapter.installed) ?? null;
+    if (!selectedHarness) {
+      setSetupError("Pick an installed local adapter first.");
+      return;
+    }
+    setPicking("local");
+    setSetupError(null);
+    try {
+      const res = await fetch("/api/onboarding/setup", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          familiar: {
+            id: `${selectedHarness.id}-local`,
+            displayName: familiarName.trim() || selectedHarness.label,
+            role: familiarRole.trim() || "Code Familiar",
+            description: familiarDescription.trim() || `Local ${selectedHarness.label} adapter on this machine.`,
+            glyph: familiarGlyph,
+            harness: selectedHarness.id,
+            model: `${selectedHarness.id}-local`,
+          },
+        }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || json.ok === false) throw new Error(json.error ?? "setup failed");
+      await refresh();
+    } catch (err) {
+      setSetupError(err instanceof Error ? err.message : "setup failed");
+    } finally {
+      setPicking(null);
+    }
+  };
+
   const startDaemon = async () => {
     setStartingDaemon(true);
     setSetupError(null);
@@ -272,8 +341,15 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
         icon: "ph:folder",
       },
       {
+        key: "adapters",
+        title: "Find local adapter",
+        ok: !!s?.adapters.ok,
+        detail: s?.adapters.detail ?? s?.adapters.hint ?? "checking...",
+        icon: "ph:terminal-window",
+      },
+      {
         key: "binding",
-        title: "Connect OpenClaw agent",
+        title: "Create familiar",
         ok: !!s?.binding.ok,
         detail: s?.binding.detail ?? s?.binding.hint ?? "checking...",
         icon: "ph:sparkle",
@@ -329,7 +405,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
               Re-check
             </button>
             <div className="rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-2 text-[12px] text-[var(--text-secondary)]">
-              {stepCount(status)}/5 ready
+              {stepCount(status)}/6 ready
             </div>
           </div>
         </header>
@@ -419,9 +495,9 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
             <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 p-4">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div>
-                  <h2 className="text-[14px] font-semibold text-[var(--text-primary)]">Connect an OpenClaw agent</h2>
+                  <h2 className="text-[14px] font-semibold text-[var(--text-primary)]">Create a local familiar</h2>
                   <p className="mt-1 text-[12px] leading-5 text-[var(--text-secondary)]">
-                    Choose one of your local OpenClaw agents. Cave writes only the selected agent as a familiar in `~/.coven/familiars.toml`.
+                    Use Codex, Claude Code, or any detected Coven adapter already installed on this machine.
                   </p>
                 </div>
                 <button
@@ -431,6 +507,69 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                 >
                   {picking === "scaffold" ? "Creating..." : "Create folder only"}
                 </button>
+              </div>
+
+              <div className="mt-4 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-base)]/45 p-3">
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <div className="text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]">
+                    Local adapters
+                  </div>
+                  <button
+                    onClick={() => void loadHarnesses()}
+                    className="rounded border border-[var(--border-hairline)] px-2 py-1 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+                  >
+                    Refresh
+                  </button>
+                </div>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {harnesses.map((adapter) => {
+                    const active = selectedHarnessId === adapter.id;
+                    return (
+                      <button
+                        key={adapter.id}
+                        onClick={() => {
+                          if (!adapter.installed) return;
+                          setSelectedHarnessId(adapter.id);
+                          setFamiliarName(adapter.label);
+                          setFamiliarRole("Code Familiar");
+                          setFamiliarDescription(`Local ${adapter.label} adapter on this machine.`);
+                        }}
+                        disabled={!adapter.installed}
+                        className={`rounded-lg border p-3 text-left ${
+                          active
+                            ? "border-purple-500/55 bg-purple-500/12 text-[var(--text-primary)]"
+                            : adapter.installed
+                              ? "border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 text-[var(--text-secondary)] hover:border-[var(--border-strong)]"
+                              : "border-[var(--border-hairline)] bg-[var(--bg-base)]/40 text-[var(--text-muted)] opacity-70"
+                        }`}
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="truncate text-[13px] font-medium">{adapter.label}</span>
+                          {active ? <Icon name="ph:check-bold" className="text-purple-200" /> : null}
+                        </div>
+                        <div className="mt-1 truncate font-mono text-[11px]">{adapter.binary}</div>
+                        <div className="mt-1 line-clamp-2 text-[11px] leading-4 text-[var(--text-muted)]">
+                          {adapter.installed ? adapter.path ?? "installed" : adapter.installHint}
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+                <button
+                  onClick={createLocalFamiliar}
+                  disabled={picking !== null || !selectedHarnessId}
+                  className="mt-3 inline-flex items-center gap-2 rounded-md bg-purple-600 px-4 py-2 text-[13px] font-medium text-white hover:bg-purple-500 disabled:opacity-50"
+                >
+                  <Icon name="ph:terminal-window" />
+                  {picking === "local" ? "Creating..." : "Use local adapter"}
+                </button>
+              </div>
+
+              <div className="mt-5 border-t border-[var(--border-hairline)] pt-4">
+                <h3 className="text-[13px] font-semibold text-[var(--text-primary)]">Or connect an OpenClaw agent</h3>
+                <p className="mt-1 text-[12px] leading-5 text-[var(--text-secondary)]">
+                  Choose one of your local OpenClaw agents. Cave writes only the selected agent as a familiar in `~/.coven/familiars.toml`.
+                </p>
               </div>
 
               <div className="mt-4 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-base)]/45 p-3">

--- a/src/lib/harness-adapters.test.ts
+++ b/src/lib/harness-adapters.test.ts
@@ -1,0 +1,53 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  COMPATIBILITY_ADAPTERS,
+  mergeAdapterReports,
+  adapterSetupState,
+} from "./harness-adapters.ts";
+
+assert.deepEqual(
+  COMPATIBILITY_ADAPTERS.map((adapter) => adapter.id),
+  ["codex", "claude"],
+);
+
+const merged = mergeAdapterReports(
+  [
+    { id: "codex", label: "Codex", binary: "codex", installed: true, path: "/usr/bin/codex", version: "codex 1.0.0" },
+    { id: "claude", label: "Claude Code", binary: "claude", installed: false, path: null, version: null },
+  ],
+  [
+    {
+      id: "hermes",
+      label: "Hermes Agent",
+      executable: "hermes",
+      available: true,
+      install_hint: "Install Hermes.",
+      source: "manifest",
+      manifest_path: "/tmp/adapters.json",
+    },
+    {
+      id: "codex",
+      label: "Codex",
+      executable: "codex",
+      available: true,
+      install_hint: "Install Codex.",
+      source: "bundled",
+    },
+  ],
+);
+
+assert.equal(merged.length, 3);
+assert.equal(merged.find((adapter) => adapter.id === "codex")?.source, "bundled");
+assert.equal(merged.find((adapter) => adapter.id === "hermes")?.source, "manifest");
+assert.equal(merged.find((adapter) => adapter.id === "hermes")?.manifestPath, "/tmp/adapters.json");
+
+assert.deepEqual(adapterSetupState(merged), {
+  ok: true,
+  detail: "Codex, Hermes Agent",
+});
+
+assert.deepEqual(adapterSetupState(merged.filter((adapter) => !adapter.installed)), {
+  ok: false,
+  hint: "Install Codex or Claude Code, then re-check. External adapters can also be added with Coven adapter manifests.",
+});

--- a/src/lib/harness-adapters.ts
+++ b/src/lib/harness-adapters.ts
@@ -1,0 +1,115 @@
+export type CompatibilityAdapter = {
+  id: string;
+  label: string;
+  binary: string;
+  chatSupported: boolean;
+  versionArgs?: string[];
+  installHint: string;
+  source: "bundled";
+};
+
+export type LocalAdapterReport = CompatibilityAdapter & {
+  installed: boolean;
+  path: string | null;
+  version: string | null;
+  manifestPath?: null;
+};
+
+export type CovenAdapterSummary = {
+  id: string;
+  label: string;
+  executable: string;
+  available: boolean;
+  install_hint: string;
+  source: string;
+  manifest_path?: string | null;
+};
+
+export type AdapterReport = {
+  id: string;
+  label: string;
+  binary: string;
+  chatSupported: boolean;
+  installed: boolean;
+  path: string | null;
+  version: string | null;
+  installHint: string;
+  source: string;
+  manifestPath: string | null;
+};
+
+export type AdapterSetupState = { ok: true; detail: string } | { ok: false; hint: string };
+
+export const COMPATIBILITY_ADAPTERS: CompatibilityAdapter[] = [
+  {
+    id: "codex",
+    label: "Codex",
+    binary: "codex",
+    chatSupported: true,
+    installHint: "Install Codex with `npm install -g @openai/codex`, then run `codex login`.",
+    source: "bundled",
+  },
+  {
+    id: "claude",
+    label: "Claude Code",
+    binary: "claude",
+    chatSupported: true,
+    versionArgs: ["--version"],
+    installHint: "Install Claude Code with `npm install -g @anthropic-ai/claude-code`, then run `claude doctor`.",
+    source: "bundled",
+  },
+];
+
+export function mergeAdapterReports(
+  localReports: Array<Partial<AdapterReport> & { id: string; label: string; binary: string; installed: boolean; path: string | null; version: string | null }>,
+  covenReports: CovenAdapterSummary[],
+): AdapterReport[] {
+  const merged = new Map<string, AdapterReport>();
+
+  for (const local of localReports) {
+    merged.set(local.id, {
+      id: local.id,
+      label: local.label,
+      binary: local.binary,
+      chatSupported: local.chatSupported ?? false,
+      installed: local.installed,
+      path: local.path,
+      version: local.version,
+      installHint: local.installHint ?? "",
+      source: local.source ?? "bundled",
+      manifestPath: local.manifestPath ?? null,
+    });
+  }
+
+  for (const coven of covenReports) {
+    const existing = merged.get(coven.id);
+    merged.set(coven.id, {
+      id: coven.id,
+      label: coven.label,
+      binary: coven.executable,
+      chatSupported: existing?.chatSupported ?? (coven.id === "codex" || coven.id === "claude"),
+      installed: coven.available || existing?.installed === true,
+      path: existing?.path ?? null,
+      version: existing?.version ?? null,
+      installHint: coven.install_hint || existing?.installHint || "",
+      source: coven.source || existing?.source || "manifest",
+      manifestPath: coven.manifest_path ?? existing?.manifestPath ?? null,
+    });
+  }
+
+  return [...merged.values()].sort((a, b) => {
+    const rank = (id: string) => (id === "codex" ? 0 : id === "claude" ? 1 : 2);
+    return rank(a.id) - rank(b.id) || a.label.localeCompare(b.label);
+  });
+}
+
+export function adapterSetupState(reports: AdapterReport[]): AdapterSetupState {
+  const ready = reports.filter((adapter) => adapter.installed);
+  if (ready.length > 0) {
+    return { ok: true, detail: ready.map((adapter) => adapter.label).join(", ") };
+  }
+  return {
+    ok: false,
+    hint: "Install Codex or Claude Code, then re-check. External adapters can also be added with Coven adapter manifests.",
+  };
+}

--- a/src/lib/onboarding-familiars.test.ts
+++ b/src/lib/onboarding-familiars.test.ts
@@ -34,3 +34,23 @@ assert.match(toml, /model = "riley"/);
 assert.match(toml, /openclaw_agent = "riley"/);
 
 assert.equal(normalizeFamiliarDraft({ displayName: "Cody", openclawAgentId: "cody" }).id, "cody");
+
+const localDraft = normalizeFamiliarDraft({
+  displayName: "Codex Local",
+  role: "Code",
+  harness: "codex",
+  model: "local-codex",
+});
+
+assert.deepEqual(localDraft, {
+  id: "codex-local",
+  displayName: "Codex Local",
+  role: "Code",
+  description: "",
+  glyph: "ph:sparkle-fill",
+  harness: "codex",
+  model: "local-codex",
+  openclawAgentId: undefined,
+});
+
+assert.equal(normalizeFamiliarDraft({ displayName: "Solo" }).harness, "codex");

--- a/src/lib/onboarding-familiars.ts
+++ b/src/lib/onboarding-familiars.ts
@@ -44,7 +44,7 @@ export function normalizeFamiliarDraft(input: OnboardingFamiliarInput): Onboardi
   if (!id) throw new Error("Familiar id is required.");
 
   const openclawAgentId = slugify(cleanText(input.openclawAgentId));
-  const harness = cleanText(input.harness) || (openclawAgentId ? "openclaw" : "openclaw");
+  const harness = cleanText(input.harness) || (openclawAgentId ? "openclaw" : "codex");
   const model = cleanText(input.model) || openclawAgentId || id;
 
   return {


### PR DESCRIPTION
## Summary
- add shared local harness adapter helpers for Codex/Claude and Coven adapter-list output
- make /api/harnesses resolve tools with Cave's augmented PATH and merge Coven adapter registry output
- add onboarding status for local adapters and a local familiar creation path
- default new non-OpenClaw familiars/scaffold setup to Codex instead of OpenClaw

## Verification
- pnpm install --frozen-lockfile
- node --experimental-strip-types --test src/lib/onboarding-familiars.test.ts src/lib/harness-adapters.test.ts
- pnpm typecheck
- pnpm build (passes with existing Turbopack/NFT warning on next.config.ts)
- git diff --check