### PR TITLE
chore(release): stamp v0.0.43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coven-cave",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coven-cave",
-      "version": "0.0.42",
+      "version": "0.0.43",
       "dependencies": {
         "@create-markdown/core": "2.0.3",
         "@create-markdown/preview": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary

Prepare Coven Cave v0.0.43 by stamping the app/package versions after the post-v0.0.42 mainline work.

Changes:
- `package.json`: `0.0.42` -> `0.0.43`
- `package-lock.json`: `0.0.42` -> `0.0.43`
- `src-tauri/tauri.conf.json`: `0.0.42` -> `0.0.43`

## Release Delta Since v0.0.42

Includes the mainline changes already merged after the last release, including local adapter onboarding, Codex automation editing/activation, and the Research Library collection work.

## Verification

- `git diff --check`
- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm build`
- `bash scripts/sidecar-bundle.sh`
- `cargo check` from `src-tauri/`

Note: `pnpm build` and `sidecar-bundle.sh` still show the existing Turbopack NFT warning for the library/doc route trace, but both builds completed successfully.
