### PR TITLE
fix(desktop): allow packaged browser and terminal commands

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "enables the default permissions",
-  "local": false,
+  "local": true,
   "windows": [
     "main"
   ],

--- a/src-tauri/permissions/default.toml
+++ b/src-tauri/permissions/default.toml
@@ -6,5 +6,12 @@ permissions = [
   "allow-pty-resize",
   "allow-pty-stop",
   "allow-pty-list",
+  "allow-pty-diagnose",
+  "allow-browser-navigate",
+  "allow-browser-set-bounds",
+  "allow-browser-hide",
+  "allow-browser-hide-all-except",
+  "allow-browser-close",
+  "allow-browser-reload",
   "allow-shell-open",
 ]

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -43,10 +43,20 @@ test("packaged desktop app can use native browser and terminal commands", () => 
   assert.ok(capability.permissions.includes("default"), "default capability should include custom app permissions");
 
   for (const permissionId of requiredPermissionIds) {
-    assert.match(defaultPermissions, new RegExp(`"${permissionId}"`), `${permissionId} must be in default permission group`);
+    const escapedPermissionId = permissionId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    assert.match(
+      defaultPermissions,
+      new RegExp(String.raw`"${escapedPermissionId}"`),
+      `${permissionId} must be in default permission group`,
+    );
   }
 
   for (const command of requiredCommands) {
-    assert.match(commandPermissions, new RegExp(`commands\\.allow = \\["${command}"\\]`), `${command} must have a Tauri allow permission`);
+    const escapedCommand = command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    assert.match(
+      commandPermissions,
+      new RegExp(String.raw`commands\.allow\s*=\s*\[[^\]]*"${escapedCommand}"[^\]]*\]`),
+      `${command} must have a Tauri allow permission`,
+    );
   }
 });

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const capability = JSON.parse(readFileSync(new URL("../capabilities/default.json", import.meta.url), "utf8"));
+const defaultPermissions = readFileSync(new URL("./default.toml", import.meta.url), "utf8");
+const commandPermissions = readFileSync(new URL("./pty.toml", import.meta.url), "utf8");
+
+const requiredPermissionIds = [
+  "allow-pty-start",
+  "allow-pty-write",
+  "allow-pty-resize",
+  "allow-pty-stop",
+  "allow-pty-list",
+  "allow-pty-diagnose",
+  "allow-browser-navigate",
+  "allow-browser-set-bounds",
+  "allow-browser-hide",
+  "allow-browser-hide-all-except",
+  "allow-browser-close",
+  "allow-browser-reload",
+  "allow-shell-open",
+];
+
+const requiredCommands = [
+  "pty_start",
+  "pty_write",
+  "pty_resize",
+  "pty_stop",
+  "pty_list",
+  "pty_diagnose",
+  "browser_navigate",
+  "browser_set_bounds",
+  "browser_hide",
+  "browser_hide_all_except",
+  "browser_close",
+  "browser_reload",
+  "shell_open",
+];
+
+test("packaged desktop app can use native browser and terminal commands", () => {
+  assert.equal(capability.local, true, "packaged local app origin must receive the default capability");
+  assert.ok(capability.permissions.includes("default"), "default capability should include custom app permissions");
+
+  for (const permissionId of requiredPermissionIds) {
+    assert.match(defaultPermissions, new RegExp(`"${permissionId}"`), `${permissionId} must be in default permission group`);
+  }
+
+  for (const command of requiredCommands) {
+    assert.match(commandPermissions, new RegExp(`commands\\.allow = \\["${command}"\\]`), `${command} must have a Tauri allow permission`);
+  }
+});

--- a/src-tauri/permissions/pty.toml
+++ b/src-tauri/permissions/pty.toml
@@ -24,6 +24,41 @@ description = "Allows listing active PTY sessions."
 commands.allow = ["pty_list"]
 
 [[permission]]
+identifier = "allow-pty-diagnose"
+description = "Allows running a one-shot PTY diagnostic."
+commands.allow = ["pty_diagnose"]
+
+[[permission]]
+identifier = "allow-browser-navigate"
+description = "Allows navigating an embedded browser webview."
+commands.allow = ["browser_navigate"]
+
+[[permission]]
+identifier = "allow-browser-set-bounds"
+description = "Allows positioning an embedded browser webview."
+commands.allow = ["browser_set_bounds"]
+
+[[permission]]
+identifier = "allow-browser-hide"
+description = "Allows hiding an embedded browser webview."
+commands.allow = ["browser_hide"]
+
+[[permission]]
+identifier = "allow-browser-hide-all-except"
+description = "Allows hiding all embedded browser webviews except one."
+commands.allow = ["browser_hide_all_except"]
+
+[[permission]]
+identifier = "allow-browser-close"
+description = "Allows closing an embedded browser webview."
+commands.allow = ["browser_close"]
+
+[[permission]]
+identifier = "allow-browser-reload"
+description = "Allows reloading an embedded browser webview."
+commands.allow = ["browser_reload"]
+
+[[permission]]
 identifier = "allow-shell-open"
 description = "Allows opening a URL in the system browser."
 commands.allow = ["shell_open"]


### PR DESCRIPTION
## Summary
- enable the default Tauri capability for the packaged local app origin
- add explicit Tauri allow permissions for embedded browser commands and the PTY diagnostic command
- add a regression test that guards packaged-local browser/terminal command access

## Verification
- pnpm install --frozen-lockfile
- pnpm typecheck
- bash scripts/sidecar-bundle.sh
- cargo check (from src-tauri)
- pnpm tauri build --debug --bundles app
- node --test src-tauri/permissions/desktop-permissions.test.mjs
- git diff --check

## Manual desktop check
- launched the built debug CovenCave.app from this branch
- verified the packaged app renders from the local bundle
- verified the embedded browser view loads/navigates without the previous invoke permission denial

Note: Terminal UI automation was noisy because existing desktop windows overlapped the debug app, but the packaged terminal failure shares the same root cause: local bundled origins were excluded from the Tauri capability. The new regression guards that permission boundary explicitly.