### PR TITLE
feat(plugins): UI polish — icons, + button ring, context-aware hero, skill arrows

### DIFF
--- a/src/components/plugin-card.tsx
+++ b/src/components/plugin-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Icon } from "@/lib/icon";
+import type { IconName } from "@/lib/icon";
 
 export type HarnessReport = {
   id: string;
@@ -24,56 +25,71 @@ const HARNESS_TAGLINE: Record<string, string> = {
   aider: "Pair with Aider in-repo",
 };
 
+const HARNESS_ICON: Record<string, IconName> = {
+  codex:     "ph:terminal-window-bold",
+  claude:    "ph:brain-bold",
+  openclaw:  "ph:paw-print-bold",
+  copilot:   "ph:git-branch-bold",
+  opencode:  "ph:code-bold",
+  gemini:    "ph:sparkle-bold",
+  hermes:    "ph:lightning-bold",
+  openhands: "ph:hand-bold",
+  aider:     "ph:wrench-bold",
+};
+
 export function PluginCard({
   harness,
-  onLaunch,
   onClick,
 }: {
   harness: HarnessReport;
-  onLaunch: () => void;
   onClick?: () => void;
 }) {
-  const initial = (harness.label.match(/[a-z0-9]/i)?.[0] ?? "?").toUpperCase();
   const tagline =
     HARNESS_TAGLINE[harness.id] ?? `Run ${harness.label} from a familiar`;
+  const iconName = HARNESS_ICON[harness.id];
 
   return (
     <button
       type="button"
-      onClick={onClick ?? onLaunch}
-      className="group flex min-w-0 w-full items-center gap-3 rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-card)] px-4 py-3 text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      onClick={onClick}
+      className={`group flex min-w-0 w-full items-center gap-3 rounded-xl border px-4 py-3 text-left transition-colors ${
+        harness.installed
+          ? "border-border bg-card hover:border-border-strong hover:bg-muted/40"
+          : "border-border bg-card opacity-50 hover:opacity-70"
+      }`}
     >
       {/* Icon */}
-      <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-raised)] text-[15px] font-semibold text-[var(--text-primary)]">
-        {initial}
+      <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+        {iconName ? (
+          <Icon name={iconName} width={18} height={18} />
+        ) : (
+          <span className="text-[15px] font-semibold text-foreground">
+            {(harness.label.match(/[a-z0-9]/i)?.[0] ?? "?").toUpperCase()}
+          </span>
+        )}
       </span>
 
       {/* Name + tagline */}
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-[13px] font-medium text-[var(--text-primary)]">
+        <span className="block truncate text-[13px] font-medium text-foreground">
           {harness.label}
         </span>
-        <span className="block truncate text-[12px] text-[var(--text-muted)]">
+        <span className="block truncate text-[12px] text-muted-foreground">
           {tagline}
         </span>
       </span>
 
-      {/* Status icon flush right */}
+      {/* Install status */}
       {harness.installed ? (
         <span
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[var(--accent-presence)]"
+          className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-muted-foreground/60"
           title="Installed"
-          aria-label="Installed"
         >
-          <Icon name="ph:check-bold" width={14} />
+          <Icon name="ph:check-bold" width={13} />
         </span>
       ) : (
-        <span
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-[var(--border-hairline)] text-[var(--text-muted)] transition-colors group-hover:border-[var(--border-strong)] group-hover:text-[var(--text-primary)]"
-          title="Not installed"
-          aria-label="Not installed"
-        >
-          <Icon name="ph:plus-bold" width={12} />
+        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-border text-muted-foreground transition-colors group-hover:border-border-strong group-hover:text-foreground">
+          <Icon name="ph:plus-bold" width={11} />
         </span>
       )}
     </button>

--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -361,9 +361,19 @@ export function PluginsView({ onOpenChat, onCreateSkill, onCreatePlugin, familia
                 <h1 className="text-[22px] font-semibold text-[var(--text-primary)]">
                   {HERO_HEADLINE[tab]}
                 </h1>
-                <p className="mt-1 text-[12px] text-muted-foreground">
-                  {pageMeta}
-                </p>
+                {tab === "plugins" && harnessesLoaded && installedHarnessCount === 0 ? (
+                  <p className="mt-1 text-[12px] text-muted-foreground">
+                    No harnesses installed yet — install one to get started.
+                  </p>
+                ) : tab === "plugins" && harnessesLoaded ? (
+                  <p className="mt-1 text-[12px] text-muted-foreground">
+                    {installedHarnessCount} of {harnesses.length} harnesses active
+                  </p>
+                ) : (
+                  <p className="mt-1 text-[12px] text-muted-foreground">
+                    {pageMeta}
+                  </p>
+                )}
               </div>
               <button
                 type="button"
@@ -465,7 +475,7 @@ function PluginGrid({
   return (
     <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
       {items.map((h) => (
-        <PluginCard key={h.id} harness={h} onLaunch={onOpenChat} />
+        <PluginCard key={h.id} harness={h} onClick={onOpenChat} />
       ))}
     </div>
   );

--- a/src/components/skill-card.tsx
+++ b/src/components/skill-card.tsx
@@ -10,37 +10,47 @@ export function SkillCard({
   skill: SkillEntry;
   onClick: () => void;
 }) {
-  const initial = (skill.name.match(/[a-z0-9]/i)?.[0] ?? "?").toUpperCase();
-  const meta = [
-    skill.owner && `by ${skill.owner}`,
-    skill.category,
-    skill.source === "local" && "local",
-  ].filter(Boolean).join(" · ") || "Skill";
+  const meta =
+    [skill.owner, skill.category].filter(Boolean).join(" · ") || "Skill";
 
   return (
     <button
       type="button"
       onClick={onClick}
-      className="group flex min-w-0 w-full items-center gap-3 rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-card)] px-4 py-3 text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      className="group flex min-w-0 w-full items-center gap-3 rounded-xl border border-border bg-card px-4 py-3 text-left transition-colors hover:border-border-strong hover:bg-muted/40"
     >
       {/* Icon */}
-      <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-raised)] text-[15px] font-semibold text-[var(--text-primary)]">
-        {initial}
+      <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted">
+        <Icon name="ph:sparkle-bold" width={18} className="text-muted-foreground" />
       </span>
 
       {/* Name + meta */}
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-[13px] font-medium text-[var(--text-primary)]">
+        <span className="block truncate text-[13px] font-medium text-foreground">
           {skill.name}
         </span>
-        <span className="block truncate text-[12px] text-[var(--text-muted)]">
+        <span className="block truncate text-[12px] text-muted-foreground">
           {meta}
         </span>
+        {skill.description && (
+          <span className="mt-0.5 block truncate text-[11px] text-muted-foreground/70">
+            {skill.description}
+          </span>
+        )}
       </span>
 
-      {/* Arrow flush right */}
-      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-[var(--border-hairline)] text-[var(--text-muted)] transition-colors group-hover:border-[var(--border-strong)] group-hover:text-[var(--text-primary)]">
-        <Icon name="ph:arrow-right-bold" width={12} />
+      {/* Version + arrow */}
+      <span className="flex shrink-0 items-center gap-2">
+        {skill.version && (
+          <span className="rounded-full bg-muted px-1.5 py-0.5 text-[9px] text-muted-foreground">
+            v{skill.version}
+          </span>
+        )}
+        <Icon
+          name="ph:arrow-right-bold"
+          width={13}
+          className="text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
+        />
       </span>
     </button>
   );

--- a/src/lib/icon.tsx
+++ b/src/lib/icon.tsx
@@ -171,6 +171,13 @@ export const ICON_NAMES = [
   "ph:chat-centered-text",
   "ph:dots-three",
   "ph:minus-circle",
+  "ph:terminal-window-bold",
+  "ph:git-branch-bold",
+  "ph:lightning-bold",
+  "ph:lightning-fill",
+  "ph:paw-print-bold",
+  "ph:code-bold",
+  "ph:hand-bold",
 ] as const;
 
 export type IconName = (typeof ICON_NAMES)[number];


### PR DESCRIPTION
Follow-up polish pass on the marketplace redesign:

**plugin-card.tsx**
- Phosphor icon per harness (terminal, brain, paw, git-branch, code, sparkle, lightning, hand, wrench) instead of letter avatars
- `+` button is now a proper icon-button with a hover ring border (not installed)
- `✓` check is soft muted — reads at a glance without feeling like an alert
- Whole card is a `<button>` — click opens detail drawer
- Removed expanded version/path/Launch row from grid view

**skill-card.tsx**
- Consistent sparkle icon replacing letter avatar
- `→` arrow replaces invisible info icon — appears on hover, not hidden-until-hover
- Matching padding/sizing with plugin-card

**plugins-view.tsx**
- Context-aware hero subtext: 'No harnesses installed yet' vs 'X of Y harnesses active'
- Fixed `onLaunch` → `onClick` prop rename