### PR TITLE
chore(release): stamp v0.0.44

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coven-cave",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coven-cave",
-      "version": "0.0.43",
+      "version": "0.0.44",
       "dependencies": {
         "@create-markdown/core": "2.0.3",
         "@create-markdown/preview": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- Stamp CovenCave v0.0.44 in package metadata and Tauri config.

## Verification
- pnpm install --frozen-lockfile
- version/tag assertions for v0.0.44
- git diff --check
- pnpm typecheck
- pnpm build
- bash scripts/sidecar-bundle.sh
- cargo check --locked