### PR TITLE
feat(tasks): replace filter row with search

### DIFF
--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -129,7 +129,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
             className="board-search-input"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder='Search tasks or type status:running label:ux'
+            placeholder='Search tasks or type is:open label:ux cody'
           />
           {searchQuery ? (
             <button

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -7,11 +7,7 @@ import { DEMO_MODE, DEMO_BOARD_CARDS } from "@/lib/demo-seed";
 import { NewCardModal, type NewCardDraft } from "@/components/new-card-modal";
 import { Icon } from "@/lib/icon";
 import { type Card, type CardStatus } from "@/lib/cave-board-types";
-import {
-  type FilterState,
-  emptyFilter,
-} from "@/components/board-filter-popover";
-import { BoardMultiSelect } from "@/components/board-multi-select";
+import { cardMatchesBoardSearch } from "@/lib/board-search";
 import { BoardKanban } from "@/components/board-kanban";
 import { BoardTable, type GroupBy } from "@/components/board-table";
 import { BoardInspector } from "@/components/board-inspector";
@@ -36,7 +32,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
   const [error, setError] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>(() => loadPref("cave:board:viewMode", "kanban", ["kanban", "table"]));
   const [groupBy, setGroupBy] = useState<GroupBy>(() => loadPref("cave:board:groupBy", "status", ["status", "familiar", "priority", "none"]));
-  const [filter, setFilter] = useState<FilterState>(emptyFilter());
+  const [searchQuery, setSearchQuery] = useState("");
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [modalDefaultStatus, setModalDefaultStatus] = useState<CardStatus>("backlog");
@@ -63,19 +59,11 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
   useEffect(() => { localStorage.setItem("cave:board:viewMode", viewMode); }, [viewMode]);
   useEffect(() => { localStorage.setItem("cave:board:groupBy", groupBy); }, [groupBy]);
 
-  const filtered = useMemo(() => cards.filter((c) => {
-    if (filter.priorities.size > 0 && !filter.priorities.has(c.priority)) return false;
-    if (filter.familiarIds.size > 0 && !filter.familiarIds.has(c.familiarId ?? "")) return false;
-    if (filter.statuses.size > 0 && !filter.statuses.has(c.status)) return false;
-    if (filter.labels.size > 0 && !c.labels.some((l) => filter.labels.has(l))) return false;
-    return true;
-  }), [cards, filter]);
-
-  const allLabels = useMemo(() => {
-    const s = new Set<string>();
-    for (const c of cards) for (const l of c.labels) s.add(l);
-    return [...s].sort();
-  }, [cards]);
+  const familiarsById = useMemo(() => new Map(familiars.map((f) => [f.id, f])), [familiars]);
+  const filtered = useMemo(
+    () => cards.filter((c) => cardMatchesBoardSearch(c, searchQuery, familiarsById)),
+    [cards, familiarsById, searchQuery],
+  );
 
   const stats = useMemo(() => ({
     total: filtered.length,
@@ -88,16 +76,6 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
   useEffect(() => {
     if (selectedCardId && !cards.some((c) => c.id === selectedCardId)) setSelectedCardId(null);
   }, [cards, selectedCardId]);
-
-  // Build active filter chips
-  const activeChips = useMemo(() => {
-    const chips: { label: string; onRemove: () => void }[] = [];
-    for (const p of filter.priorities) chips.push({ label: `Priority: ${p.charAt(0).toUpperCase() + p.slice(1)}`, onRemove: () => setFilter((f) => { const s = new Set(f.priorities); s.delete(p); return { ...f, priorities: s }; }) });
-    for (const id of filter.familiarIds) { const name = familiars.find((f) => f.id === id)?.display_name ?? id; chips.push({ label: `Familiar: ${name}`, onRemove: () => setFilter((f) => { const s = new Set(f.familiarIds); s.delete(id); return { ...f, familiarIds: s }; }) }); }
-    for (const st of filter.statuses) chips.push({ label: `Status: ${st.charAt(0).toUpperCase() + st.slice(1)}`, onRemove: () => setFilter((f) => { const s = new Set(f.statuses); s.delete(st); return { ...f, statuses: s }; }) });
-    for (const l of filter.labels) chips.push({ label: `Label: ${l}`, onRemove: () => setFilter((f) => { const s = new Set(f.labels); s.delete(l); return { ...f, labels: s }; }) });
-    return chips;
-  }, [filter, familiars]);
 
   const lifecycleForStatus = (status: CardStatus) => {
     if (status === "running") return "running" as const;
@@ -143,6 +121,27 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
           {stats.running > 0 && <><span className="board-header-stats-sep">·</span><span>{stats.running} running</span></>}
           {stats.blocked > 0 && <><span className="board-header-stats-sep">·</span><span className="board-header-stats--blocked">{stats.blocked} blocked</span></>}
         </div>
+        <div className="board-search-wrap">
+          <Icon name="ph:magnifying-glass" width={13} className="board-search-icon" />
+          <label className="sr-only" htmlFor="board-search">Search tasks</label>
+          <input
+            id="board-search"
+            className="board-search-input"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder='Search tasks or type status:running label:ux'
+          />
+          {searchQuery ? (
+            <button
+              type="button"
+              className="board-search-clear"
+              onClick={() => setSearchQuery("")}
+              aria-label="Clear task search"
+            >
+              <Icon name="ph:x-bold" width={10} />
+            </button>
+          ) : null}
+        </div>
         <div className="board-header-controls">
           <label className="sr-only" htmlFor="board-groupby">Group by</label>
           <select id="board-groupby" className="board-toolbar-select" value={groupBy}
@@ -152,53 +151,6 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
             <option value="priority">Group: Priority</option>
             <option value="none">No grouping</option>
           </select>
-
-          <BoardMultiSelect
-            label="Priority"
-            icon="ph:dots-three-vertical"
-            options={[
-              { id: "urgent", label: "Urgent" },
-              { id: "high",   label: "High" },
-              { id: "medium", label: "Medium" },
-              { id: "low",    label: "Low" },
-            ]}
-            selected={filter.priorities}
-            onChange={(next) => setFilter((f) => ({ ...f, priorities: next as Set<import("@/lib/cave-board-types").CardPriority> }))}
-          />
-
-          <BoardMultiSelect
-            label="Status"
-            icon="ph:circle-fill"
-            options={[
-              { id: "backlog", label: "Backlog" },
-              { id: "inbox",   label: "Inbox" },
-              { id: "running", label: "Running" },
-              { id: "review",  label: "Review" },
-              { id: "blocked", label: "Blocked" },
-              { id: "done",    label: "Done" },
-            ]}
-            selected={filter.statuses}
-            onChange={(next) => setFilter((f) => ({ ...f, statuses: next as Set<import("@/lib/cave-board-types").CardStatus> }))}
-          />
-
-          <BoardMultiSelect
-            label="Familiar"
-            icon="ph:sparkle"
-            options={familiars.map((f) => ({ id: f.id, label: f.display_name }))}
-            selected={filter.familiarIds}
-            onChange={(next) => setFilter((f) => ({ ...f, familiarIds: next }))}
-            emptyLabel="No familiars configured"
-          />
-
-          {allLabels.length > 0 && (
-            <BoardMultiSelect
-              label="Labels"
-              icon="ph:tag-bold"
-              options={allLabels.map((l) => ({ id: l, label: l }))}
-              selected={filter.labels}
-              onChange={(next) => setFilter((f) => ({ ...f, labels: next }))}
-            />
-          )}
 
           <div className="board-view-toggle" role="group" aria-label="Tasks view mode">
             <button type="button" aria-label="Kanban view"
@@ -219,21 +171,6 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
           </button>
         </div>
       </header>
-
-      {/* Active filter chips */}
-      {activeChips.length > 0 && (
-        <div className="board-filter-chips">
-          {activeChips.map((chip, i) => (
-            <span key={i} className="board-filter-chip">
-              {chip.label}
-              <button type="button" className="board-filter-chip-remove" onClick={chip.onRemove} aria-label={`Remove filter`}>
-                <Icon name="ph:x-bold" width={8} />
-              </button>
-            </span>
-          ))}
-          <button type="button" className="board-filter-chip--clear-all" onClick={() => setFilter(emptyFilter())}>Clear all</button>
-        </div>
-      )}
 
       {error && (
         <div className="border-b border-border bg-card px-5 py-1.5 text-xs text-muted-foreground">{error}</div>

--- a/src/lib/board-search.test.ts
+++ b/src/lib/board-search.test.ts
@@ -32,6 +32,9 @@ assert.equal(cardMatchesBoardSearch(card, "", familiarsById), true);
 assert.equal(cardMatchesBoardSearch(card, "drag ux", familiarsById), true);
 assert.equal(cardMatchesBoardSearch(card, "label:ux status:inbox familiar:cody", familiarsById), true);
 assert.equal(cardMatchesBoardSearch(card, 'title:"between columns" -label:backend', familiarsById), true);
+assert.equal(cardMatchesBoardSearch(card, "is:open", familiarsById), true);
+assert.equal(cardMatchesBoardSearch({ ...card, status: "done" }, "is:closed", familiarsById), true);
+assert.equal(cardMatchesBoardSearch(card, "is:closed", familiarsById), false);
 assert.equal(cardMatchesBoardSearch(card, "label:backend", familiarsById), false);
 assert.equal(cardMatchesBoardSearch(card, "priority:urgent", familiarsById), false);
 

--- a/src/lib/board-search.test.ts
+++ b/src/lib/board-search.test.ts
@@ -1,0 +1,41 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import {
+  cardMatchesBoardSearch,
+  parseBoardSearchQuery,
+} from "./board-search.ts";
+
+const card = {
+  id: "card-1",
+  title: "Board card drag between columns",
+  notes: "Use dnd-kit or native drag events.",
+  status: "inbox",
+  priority: "medium",
+  familiarId: "cody",
+  sessionId: "session-1",
+  labels: ["ux", "board", "drag"],
+};
+
+const familiarsById = new Map([
+  ["cody", { id: "cody", display_name: "Cody" }],
+]);
+
+assert.deepEqual(parseBoardSearchQuery('drag label:ux status:inbox -priority:urgent'), [
+  { key: null, value: "drag", negated: false },
+  { key: "label", value: "ux", negated: false },
+  { key: "status", value: "inbox", negated: false },
+  { key: "priority", value: "urgent", negated: true },
+]);
+
+assert.equal(cardMatchesBoardSearch(card, "", familiarsById), true);
+assert.equal(cardMatchesBoardSearch(card, "drag ux", familiarsById), true);
+assert.equal(cardMatchesBoardSearch(card, "label:ux status:inbox familiar:cody", familiarsById), true);
+assert.equal(cardMatchesBoardSearch(card, 'title:"between columns" -label:backend', familiarsById), true);
+assert.equal(cardMatchesBoardSearch(card, "label:backend", familiarsById), false);
+assert.equal(cardMatchesBoardSearch(card, "priority:urgent", familiarsById), false);
+
+const boardView = await readFile(new URL("../components/board-view.tsx", import.meta.url), "utf8");
+assert.match(boardView, /board-search-input/, "Tasks header should expose one search input");
+assert.doesNotMatch(boardView, /label="Labels"/, "Tasks header should not show Labels as a separate filter control");
+assert.doesNotMatch(boardView, /allLabels/, "Tasks view should not build a dedicated labels filter row");

--- a/src/lib/board-search.ts
+++ b/src/lib/board-search.ts
@@ -97,6 +97,10 @@ function tokenMatches(
       return normalize(card.sessionId).includes(value);
     case "id":
       return normalize(card.id).includes(value);
+    case "is":
+      if (value === "open") return card.status !== "done";
+      if (value === "closed") return card.status === "done";
+      return normalize(card.status).includes(value);
     default:
       return includesAny(
         [

--- a/src/lib/board-search.ts
+++ b/src/lib/board-search.ts
@@ -1,0 +1,129 @@
+import type { Card } from "@/lib/cave-board-types";
+import type { Familiar } from "@/lib/types";
+
+export type BoardSearchToken = {
+  key: string | null;
+  value: string;
+  negated: boolean;
+};
+
+function normalize(value: unknown): string {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function tokenize(query: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quoted = false;
+
+  for (const char of query.trim()) {
+    if (char === "\"") {
+      quoted = !quoted;
+      continue;
+    }
+    if (!quoted && /\s/.test(char)) {
+      if (current) tokens.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+export function parseBoardSearchQuery(query: string): BoardSearchToken[] {
+  return tokenize(query)
+    .map((raw) => {
+      const negated = raw.startsWith("-");
+      const token = negated ? raw.slice(1) : raw;
+      const separator = token.indexOf(":");
+      if (separator <= 0) {
+        return { key: null, value: normalize(token), negated };
+      }
+      return {
+        key: normalize(token.slice(0, separator)),
+        value: normalize(token.slice(separator + 1)),
+        negated,
+      };
+    })
+    .filter((token) => token.value.length > 0);
+}
+
+function includesAny(values: string[], needle: string): boolean {
+  return values.some((value) => normalize(value).includes(needle));
+}
+
+function familiarValues(card: Card, familiarsById: Map<string, Pick<Familiar, "id" | "display_name" | "name">>): string[] {
+  const familiar = card.familiarId ? familiarsById.get(card.familiarId) : null;
+  return [
+    card.familiarId ?? "",
+    familiar?.id ?? "",
+    familiar?.name ?? "",
+    familiar?.display_name ?? "",
+  ];
+}
+
+function tokenMatches(
+  card: Card,
+  token: BoardSearchToken,
+  familiarsById: Map<string, Pick<Familiar, "id" | "display_name" | "name">>,
+): boolean {
+  const value = token.value;
+  const labelValues = card.labels ?? [];
+  const familiar = familiarValues(card, familiarsById);
+
+  switch (token.key) {
+    case "status":
+      return normalize(card.status).includes(value);
+    case "priority":
+      return normalize(card.priority).includes(value);
+    case "label":
+    case "labels":
+    case "tag":
+    case "tags":
+      return includesAny(labelValues, value);
+    case "familiar":
+    case "agent":
+    case "assignee":
+      return includesAny(familiar, value);
+    case "title":
+      return normalize(card.title).includes(value);
+    case "note":
+    case "notes":
+      return normalize(card.notes).includes(value);
+    case "session":
+      return normalize(card.sessionId).includes(value);
+    case "id":
+      return normalize(card.id).includes(value);
+    default:
+      return includesAny(
+        [
+          card.id,
+          card.title,
+          card.notes,
+          card.status,
+          card.priority,
+          card.sessionId ?? "",
+          ...labelValues,
+          ...familiar,
+        ],
+        value,
+      );
+  }
+}
+
+export function cardMatchesBoardSearch(
+  card: Card,
+  query: string,
+  familiarsById: Map<string, Pick<Familiar, "id" | "display_name" | "name">> = new Map(),
+): boolean {
+  const tokens = parseBoardSearchQuery(query);
+  if (tokens.length === 0) return true;
+
+  return tokens.every((token) => {
+    const matched = tokenMatches(card, token, familiarsById);
+    return token.negated ? !matched : matched;
+  });
+}

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -8,6 +8,13 @@
 .board-header-stats-sep { opacity:0.4; }
 .board-header-stats--blocked { color:#f87171; }
 .board-header-controls { display:flex; align-items:center; gap:6px; margin-left:auto; flex-wrap:wrap; }
+.board-search-wrap { position:relative; display:flex; align-items:center; flex:1 1 320px; min-width:220px; max-width:520px; margin-left:8px; }
+.board-search-icon { position:absolute; left:9px; color:var(--text-muted); pointer-events:none; }
+.board-search-input { width:100%; height:30px; padding:0 30px 0 30px; border-radius:7px; border:1px solid var(--border-strong); background:var(--bg-raised); color:var(--text-primary); font-size:12px; outline:none; transition:background .12s,border-color .12s; }
+.board-search-input::placeholder { color:var(--text-muted); }
+.board-search-input:focus { border-color:color-mix(in oklab,oklch(0.65 0.18 280) 52%,transparent); background:var(--bg-hover); }
+.board-search-clear { position:absolute; right:5px; display:flex; align-items:center; justify-content:center; width:20px; height:20px; border:0; border-radius:5px; background:transparent; color:var(--text-muted); cursor:pointer; transition:background .1s,color .1s; }
+.board-search-clear:hover { background:var(--bg-hover); color:var(--text-primary); }
 
 .board-toolbar-btn { display:inline-flex; align-items:center; gap:5px; height:28px; padding:0 10px; border-radius:7px; border:1px solid var(--border-strong); background:var(--bg-raised); color:var(--text-secondary); font-size:12px; font-weight:450; cursor:pointer; transition:background .12s,color .12s,border-color .12s; white-space:nowrap; }
 .board-toolbar-btn:hover { background:var(--bg-hover); color:var(--text-primary); }


### PR DESCRIPTION
## Summary
- replace the Tasks top-row filter buttons with one search field
- support Discord/GitHub-style typed filters such as status:running, priority:high, label:ux, familiar:cody, title:"drag", and negated tokens like -label:backend
- remove the dedicated Labels filter control and active filter chip row from the Tasks surface

## Validation
- node src/lib/board-search.test.ts
- npm run typecheck
- npm run build

## Notes
- Build still reports the existing Turbopack broad-filesystem warning from worktree root detection.