### PR TITLE
fix(chat): hide startup prompt noise

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       shiki:
         specifier: ^4.1.0
         version: 4.1.0
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -853,6 +856,11 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -1539,5 +1547,7 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  yaml@2.9.0: {}
 
   zwitch@2.0.4: {}

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { join as joinPath } from "node:path";
 import { stripAnsi } from "@/lib/ansi";
 import { bindingFor, loadConfig, recordSessionFamiliar } from "@/lib/cave-config";
+import { AssistantFilter } from "@/lib/chat-assistant-filter";
 import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
 import {
   type ChatTurn,
@@ -37,71 +38,12 @@ type StreamEvent =
   | { kind: "done"; durationMs?: number; isError?: boolean; sessionId?: string }
   | { kind: "error"; message: string; code?: string };
 
-const HOOK_LINE_RE = /^hook:\s+/;
 // Hook-line shapes emitted by codex/claude harnesses while a tool runs.
 // Examples:
 //   hook: tool_use Bash {...}
 //   hook: pre_tool_use Edit { ... }
 //   hook: post_tool_use Bash {... exitCode: 0 ...}
 const TOOL_HOOK_RE = /^hook:\s+(?:pre_tool_use|post_tool_use|tool_use)\s+(\S+)(?:\s+(.*))?$/;
-const BANNER_LINE_RE = /^(?:--------|workdir:|model:|provider:|approval:|sandbox:|reasoning|session id:|tokens used|\d[\d,]*\s*$)/;
-const CODEX_START_LINE = "codex";
-const CLAUDE_ASSISTANT_RE = /^claude(?:\s+code)?$/i;
-
-/**
- * Filter raw harness stdout (after JSON event lines have been stripped) into
- * what looks like assistant-authored text. Codex prints a banner + hook lines
- * + a `codex` marker before its reply + `tokens used` after. We keep only the
- * content between the start marker and the next hook/end-of-stream.
- */
-class AssistantFilter {
-  private phase: "pre" | "assistant" | "post" = "pre";
-  private buf = "";
-
-  push(chunk: string): string {
-    this.buf += chunk;
-    let out = "";
-    let idx;
-    while ((idx = this.buf.indexOf("\n")) >= 0) {
-      const line = this.buf.slice(0, idx);
-      this.buf = this.buf.slice(idx + 1);
-      out += this.processLine(line);
-    }
-    return out;
-  }
-
-  flush(): string {
-    if (!this.buf) return "";
-    const remainder = this.processLine(this.buf);
-    this.buf = "";
-    return remainder;
-  }
-
-  private processLine(rawLine: string): string {
-    const line = rawLine.replace(/\r/g, "");
-    const trimmed = line.trim();
-
-    if (trimmed === CODEX_START_LINE || CLAUDE_ASSISTANT_RE.test(trimmed)) {
-      this.phase = "assistant";
-      return "";
-    }
-    if (HOOK_LINE_RE.test(trimmed)) {
-      if (this.phase === "assistant" && /stop/i.test(trimmed)) {
-        this.phase = "post";
-      }
-      return "";
-    }
-    if (trimmed === "user") {
-      // Codex echoes the user prompt block; skip the leading marker
-      return "";
-    }
-    if (BANNER_LINE_RE.test(trimmed)) {
-      return "";
-    }
-    if (this.phase !== "assistant") return "";
-    return line + "\n";
-  }
-}
 
 async function sleep(ms: number) {
   return new Promise<void>((resolve) => setTimeout(resolve, ms));

--- a/src/lib/chat-assistant-filter.test.ts
+++ b/src/lib/chat-assistant-filter.test.ts
@@ -1,0 +1,52 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { AssistantFilter } from "./chat-assistant-filter.ts";
+
+function feed(lines: string[]): string {
+  const filter = new AssistantFilter();
+  let out = "";
+  for (const line of lines) out += filter.push(`${line}\n`);
+  return out + filter.flush();
+}
+
+assert.equal(
+  feed([
+    "workdir: /Users/buns/.openclaw/workspace/nova",
+    "model: gpt-5.5",
+    "reasoning: medium",
+    "user",
+    "# AGENTS.md instructions for /Users/buns/.openclaw/workspace",
+    "<INSTRUCTIONS>",
+    "# AGENTS.md - Your Workspace",
+    "</INSTRUCTIONS>",
+    "codex",
+    "I can help with that.",
+  ]),
+  "I can help with that.\n",
+  "startup prompt echoes before the assistant marker should stay hidden",
+);
+
+assert.equal(
+  feed([
+    "codex",
+    "<INSTRUCTIONS>",
+    "# AGENTS.md - Your Workspace",
+    "Do not show this startup prompt in chat.",
+    "</INSTRUCTIONS>",
+    "I only show the real assistant reply.",
+  ]),
+  "I only show the real assistant reply.\n",
+  "startup prompt blocks after the assistant marker should stay hidden",
+);
+
+assert.equal(
+  feed([
+    "claude",
+    "<reasoning>",
+    "I should think privately.",
+    "</reasoning>",
+    "Visible answer.",
+  ]),
+  "<reasoning>\nI should think privately.\n</reasoning>\nVisible answer.\n",
+  "reasoning tags should remain available for the collapsible reasoning UI",
+);

--- a/src/lib/chat-assistant-filter.test.ts
+++ b/src/lib/chat-assistant-filter.test.ts
@@ -50,3 +50,9 @@ assert.equal(
   "<reasoning>\nI should think privately.\n</reasoning>\nVisible answer.\n",
   "reasoning tags should remain available for the collapsible reasoning UI",
 );
+
+assert.equal(
+  feed(["codex", "reasoning about this should stay visible."]),
+  "reasoning about this should stay visible.\n",
+  "visible assistant text that starts with reasoning should not be treated as a banner",
+);

--- a/src/lib/chat-assistant-filter.ts
+++ b/src/lib/chat-assistant-filter.ts
@@ -1,0 +1,104 @@
+const HOOK_LINE_RE = /^hook:\s+/;
+const BANNER_LINE_RE = /^(?:--------|workdir:|model:|provider:|approval:|sandbox:|reasoning|session id:|tokens used|\d[\d,]*\s*$)/;
+const CODEX_START_LINE = "codex";
+const CLAUDE_ASSISTANT_RE = /^claude(?:\s+code)?$/i;
+
+const STARTUP_BLOCK_TAGS = new Set([
+  "AGENT_SOUL",
+  "INSTRUCTIONS",
+  "apps_instructions",
+  "available_skills",
+  "collaboration_mode",
+  "conversation_context",
+  "environment_context",
+  "plugins_instructions",
+  "skills_instructions",
+]);
+
+const STARTUP_SINGLE_LINE_RE =
+  /^(?:#\s*AGENTS\.md\b|#\s*AGENTS\.md instructions\b|Conversation info \(untrusted metadata\):|Sender \(untrusted metadata\):|OpenClaw assembled context|Treat the conversation context below|Current user request:|Knowledge cutoff:|Current date:|You are (?:ChatGPT|Codex|an AI assistant)\b)/i;
+
+function startupBlockTag(trimmed: string): { tag: string; closing: boolean } | null {
+  const match = trimmed.match(/^<\/?([A-Za-z_][A-Za-z0-9_-]*)>$/);
+  if (!match) return null;
+  const tag = match[1];
+  if (!STARTUP_BLOCK_TAGS.has(tag)) return null;
+  return { tag, closing: trimmed.startsWith("</") };
+}
+
+function isStartupNoiseLine(trimmed: string): boolean {
+  return STARTUP_SINGLE_LINE_RE.test(trimmed);
+}
+
+/**
+ * Filter raw harness stdout (after JSON event lines have been stripped) into
+ * assistant-authored text. Startup context/prompt echoes are intentionally
+ * dropped so the chat only shows the user's prompt, collapsible tools, private
+ * reasoning blocks, and the assistant's actual reply.
+ */
+export class AssistantFilter {
+  private phase: "pre" | "assistant" | "post" = "pre";
+  private buf = "";
+  private suppressedStartupTag: string | null = null;
+
+  push(chunk: string): string {
+    this.buf += chunk;
+    let out = "";
+    let idx;
+    while ((idx = this.buf.indexOf("\n")) >= 0) {
+      const line = this.buf.slice(0, idx);
+      this.buf = this.buf.slice(idx + 1);
+      out += this.processLine(line);
+    }
+    return out;
+  }
+
+  flush(): string {
+    if (!this.buf) return "";
+    const remainder = this.processLine(this.buf);
+    this.buf = "";
+    return remainder;
+  }
+
+  private processLine(rawLine: string): string {
+    const line = rawLine.replace(/\r/g, "");
+    const trimmed = line.trim();
+
+    if (trimmed === CODEX_START_LINE || CLAUDE_ASSISTANT_RE.test(trimmed)) {
+      this.phase = "assistant";
+      return "";
+    }
+    if (HOOK_LINE_RE.test(trimmed)) {
+      if (this.phase === "assistant" && /stop/i.test(trimmed)) {
+        this.phase = "post";
+      }
+      return "";
+    }
+    if (trimmed === "user") {
+      return "";
+    }
+    if (BANNER_LINE_RE.test(trimmed)) {
+      return "";
+    }
+    if (this.phase !== "assistant") return "";
+
+    if (this.suppressedStartupTag) {
+      const tag = startupBlockTag(trimmed);
+      if (tag?.closing && tag.tag === this.suppressedStartupTag) {
+        this.suppressedStartupTag = null;
+      }
+      return "";
+    }
+
+    const tag = startupBlockTag(trimmed);
+    if (tag && !tag.closing) {
+      this.suppressedStartupTag = tag.tag;
+      return "";
+    }
+    if (tag?.closing || isStartupNoiseLine(trimmed)) {
+      return "";
+    }
+
+    return line + "\n";
+  }
+}

--- a/src/lib/chat-assistant-filter.ts
+++ b/src/lib/chat-assistant-filter.ts
@@ -1,5 +1,5 @@
 const HOOK_LINE_RE = /^hook:\s+/;
-const BANNER_LINE_RE = /^(?:--------|workdir:|model:|provider:|approval:|sandbox:|reasoning|session id:|tokens used|\d[\d,]*\s*$)/;
+const BANNER_LINE_RE = /^(?:--------|workdir:|model:|provider:|approval:|sandbox:|reasoning:|session id:|tokens used|\d[\d,]*\s*$)/;
 const CODEX_START_LINE = "codex";
 const CLAUDE_ASSISTANT_RE = /^claude(?:\s+code)?$/i;
 


### PR DESCRIPTION
## Summary
- Move chat assistant stdout filtering into a testable helper.
- Hide startup/system prompt blocks from the visible chat stream.
- Preserve reasoning tags and tool events so the existing collapsible reasoning/tool UI keeps working.

## Verification
- node --test src/lib/chat-assistant-filter.test.ts
- pnpm typecheck
- pnpm build
- git diff --check