### PR TITLE
chore(release): stamp v0.0.45

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coven-cave",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coven-cave",
-      "version": "0.0.44",
+      "version": "0.0.45",
       "dependencies": {
         "@create-markdown/core": "2.0.3",
         "@create-markdown/preview": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- Bump Coven Cave app/package metadata from 0.0.44 to 0.0.45 before rebuilding release assets.

## Verification
- node version assertion for package/package-lock/Tauri metadata
- tag absence check for v0.0.45
- pnpm install --frozen-lockfile
- pnpm typecheck
- pnpm build
- bash scripts/sidecar-bundle.sh
- (cd src-tauri && cargo check)
- git diff --check