### PR TITLE
fix(automations): prevent Create via chat button text from wrapping

### DIFF
--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -944,7 +944,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder }: Pro
             <button
               type="button"
               onClick={onNewReminder}
-              className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[12px] font-medium transition-colors hover:bg-white/5"
+              className="inline-flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-1.5 text-[12px] font-medium whitespace-nowrap transition-colors hover:bg-white/5"
               style={{
                 background: "var(--bg-raised)",
                 border: "1px solid var(--border-hairline)",


### PR DESCRIPTION
Adds `whitespace-nowrap` and `shrink-0` to the Create via chat button so it stays on one line instead of wrapping into a two-line tooltip shape.