### PR TITLE
feat(roles): inline role detail panel below selected role card

### DIFF
--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -616,7 +616,7 @@ function RoleGrid({
   onSelect: (role: RoleEntry) => void;
   onToggle: (role: RoleEntry) => Promise<void>;
   skillsById: Map<string, SkillEntry>;
-  capabilitiesByPlugin: Map<string, string[]>;
+  capabilitiesByPlugin: Map<string, { harness: string; plugin: HarnessCapabilityManifest["plugins"][number] }[]>;
   capabilitiesLoaded: boolean;
 }) {
   const [collapsed, setCollapsed] = React.useState<Set<string>>(new Set());

--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -494,22 +494,17 @@ export function PluginsView({ onOpenChat, onCreateSkill, onCreatePlugin, familia
             ) : tab === "skills" ? (
               <SkillGrid items={filteredSkills} loaded={skillsLoaded} error={skillsError} onSelect={(s) => setSelectedSkill(s)} />
             ) : tab === "roles" ? (
-              <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-start">
-                <RoleGrid
-                  items={filteredRoles}
-                  loaded={rolesLoaded}
-                  error={rolesError}
-                  selectedRole={selectedRole}
-                  onSelect={setSelectedRole}
-                  onToggle={handleRoleToggle}
-                />
-                <RoleCapabilityMap
-                  role={selectedRole}
-                  skillsById={skillsById}
-                  capabilitiesByPlugin={capabilitiesByPlugin}
-                  capabilitiesLoaded={capabilitiesLoaded}
-                />
-              </div>
+              <RoleGrid
+                items={filteredRoles}
+                loaded={rolesLoaded}
+                error={rolesError}
+                selectedRole={selectedRole}
+                onSelect={setSelectedRole}
+                onToggle={handleRoleToggle}
+                skillsById={skillsById}
+                capabilitiesByPlugin={capabilitiesByPlugin}
+                capabilitiesLoaded={capabilitiesLoaded}
+              />
             ) : (
               <CapabilitiesView
                 items={capabilities.filter((c) => {
@@ -610,6 +605,9 @@ function RoleGrid({
   selectedRole,
   onSelect,
   onToggle,
+  skillsById,
+  capabilitiesByPlugin,
+  capabilitiesLoaded,
 }: {
   items: RoleEntry[];
   loaded: boolean;
@@ -617,6 +615,9 @@ function RoleGrid({
   selectedRole: RoleEntry | null;
   onSelect: (role: RoleEntry) => void;
   onToggle: (role: RoleEntry) => Promise<void>;
+  skillsById: Map<string, SkillEntry>;
+  capabilitiesByPlugin: Map<string, string[]>;
+  capabilitiesLoaded: boolean;
 }) {
   const [collapsed, setCollapsed] = React.useState<Set<string>>(new Set());
 
@@ -687,15 +688,29 @@ function RoleGrid({
             </button>
             {isOpen && (
               <div className="space-y-1.5">
-                {roles.map((r) => (
-                  <RoleCard
-                    key={`${r.familiar}:${r.id}`}
-                    role={r}
-                    selected={selectedRole?.id === r.id && selectedRole?.familiar === r.familiar}
-                    onSelect={onSelect}
-                    onToggle={onToggle}
-                  />
-                ))}
+                {roles.map((r) => {
+                  const isSelected = selectedRole?.id === r.id && selectedRole?.familiar === r.familiar;
+                  return (
+                    <React.Fragment key={`${r.familiar}:${r.id}`}>
+                      <RoleCard
+                        role={r}
+                        selected={isSelected}
+                        onSelect={onSelect}
+                        onToggle={onToggle}
+                      />
+                      {isSelected && (
+                        <div className="ml-4 overflow-hidden rounded-b-lg border border-t-0 border-[var(--accent-presence)]/30 bg-[var(--accent-presence)]/5 px-4 pb-4 pt-3">
+                          <RoleCapabilityMap
+                            role={selectedRole}
+                            skillsById={skillsById}
+                            capabilitiesByPlugin={capabilitiesByPlugin}
+                            capabilitiesLoaded={capabilitiesLoaded}
+                          />
+                        </div>
+                      )}
+                    </React.Fragment>
+                  );
+                })}
               </div>
             )}
           </div>


### PR DESCRIPTION
Moves the `RoleCapabilityMap` from a fixed right-column sidebar into an inline panel that expands directly below the selected role card.

- Selecting a role opens the capability map flush below it, bordered with the accent colour and a subtle violet tint
- Deselecting (clicking again) collapses it cleanly
- The outer two-column grid is removed — full-width single column layout
- No layout shift when switching between role groups
- Props (`skillsById`, `capabilitiesByPlugin`, `capabilitiesLoaded`) passed down through `RoleGrid` to keep the inline panel reactive