### PR TITLE
feat(board): task steps — ordered checklist with progress tracking

### DIFF
--- a/src/app/api/board/[id]/route.ts
+++ b/src/app/api/board/[id]/route.ts
@@ -6,6 +6,7 @@ import {
   type CardPriority,
   type CardStatus,
 } from "@/lib/cave-board";
+import type { CardStep } from "@/lib/cave-board-types";
 
 export const dynamic = "force-dynamic";
 
@@ -28,6 +29,7 @@ export async function PATCH(
     labels: string[];
     needsHuman: boolean;
     runningSince: string | undefined;
+    steps: CardStep[];
   }>;
   try {
     body = await req.json();

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { Card, CardLifecycle, CardPriority, CardStatus } from "@/lib/cave-board-types";
 import { STATUSES, PRIORITIES } from "@/lib/cave-board-types";

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -5,6 +5,7 @@ import type { Familiar, SessionRow } from "@/lib/types";
 import type { Card, CardLifecycle, CardPriority, CardStatus } from "@/lib/cave-board-types";
 import { STATUSES, PRIORITIES } from "@/lib/cave-board-types";
 import { LifecycleBadge, formatTimeoutBadge } from "@/components/ui/lifecycle-badge";
+import type { CardStep } from "@/lib/cave-board-types";
 import type { LibraryGitHubItem } from "@/lib/library-types";
 import { Icon } from "@/lib/icon";
 import type { IconName } from "@/lib/icon";
@@ -254,6 +255,219 @@ function GitHubAttachSection({
 }
 
 
+
+// ── Steps ─────────────────────────────────────────────────────────────────────
+function StepsSection({
+  card,
+  onPatch,
+}: {
+  card: Card;
+  onPatch: (id: string, patch: Partial<Card>) => void;
+}) {
+  const [draft, setDraft] = useState("");
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const steps = card.steps ?? [];
+  const doneCount = steps.filter((s) => s.done).length;
+  const total = steps.length;
+  const pct = total > 0 ? Math.round((doneCount / total) * 100) : 0;
+
+  function addStep() {
+    const text = draft.trim();
+    if (!text) return;
+    const now = new Date().toISOString();
+    const next: CardStep = {
+      id: crypto.randomUUID(),
+      text,
+      done: false,
+      addedAt: now,
+    };
+    onPatch(card.id, { steps: [...steps, next] });
+    setDraft("");
+    inputRef.current?.focus();
+  }
+
+  function toggleStep(id: string) {
+    const now = new Date().toISOString();
+    onPatch(card.id, {
+      steps: steps.map((s) =>
+        s.id === id
+          ? { ...s, done: !s.done, doneAt: !s.done ? now : undefined }
+          : s
+      ),
+    });
+  }
+
+  function deleteStep(id: string) {
+    onPatch(card.id, { steps: steps.filter((s) => s.id !== id) });
+  }
+
+  function reorderStep(id: string, dir: -1 | 1) {
+    const idx = steps.findIndex((s) => s.id === id);
+    if (idx < 0) return;
+    const next = [...steps];
+    const swap = idx + dir;
+    if (swap < 0 || swap >= next.length) return;
+    [next[idx], next[swap]] = [next[swap], next[idx]];
+    onPatch(card.id, { steps: next });
+  }
+
+  return (
+    <div className="board-drawer-field">
+      {/* Header row */}
+      <div className="board-drawer-field-label" style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+        <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <Icon name="ph:list-checks-bold" width={12} />
+          Steps
+          {total > 0 && (
+            <span style={{
+              fontSize: 10,
+              color: "var(--text-muted)",
+              background: "var(--bg-elevated)",
+              borderRadius: 8,
+              padding: "1px 6px",
+            }}>
+              {doneCount}/{total}
+            </span>
+          )}
+        </span>
+        {total > 0 && (
+          <span style={{ fontSize: 10, color: pct === 100 ? "var(--color-emerald-400, #34d399)" : "var(--text-muted)" }}>
+            {pct}%
+          </span>
+        )}
+      </div>
+
+      {/* Progress bar */}
+      {total > 0 && (
+        <div style={{
+          height: 2,
+          borderRadius: 2,
+          background: "var(--border-hairline)",
+          marginBottom: 8,
+          overflow: "hidden",
+        }}>
+          <div style={{
+            height: "100%",
+            width: pct + "%",
+            background: pct === 100 ? "oklch(0.76 0.18 150)" : "oklch(0.65 0.18 280)",
+            transition: "width 0.2s ease, background 0.2s ease",
+          }} />
+        </div>
+      )}
+
+      {/* Step list */}
+      {steps.length > 0 && (
+        <ul style={{ display: "flex", flexDirection: "column", gap: 2, marginBottom: 8 }}>
+          {steps.map((step, i) => (
+            <li
+              key={step.id}
+              style={{
+                display: "flex",
+                alignItems: "flex-start",
+                gap: 8,
+                padding: "6px 8px",
+                borderRadius: 6,
+                background: step.done ? "color-mix(in oklab, oklch(0.76 0.18 150) 6%, var(--bg-elevated))" : "var(--bg-elevated)",
+                border: "1px solid var(--border-hairline)",
+              }}
+            >
+              {/* Checkbox */}
+              <button
+                type="button"
+                onClick={() => toggleStep(step.id)}
+                style={{
+                  flexShrink: 0,
+                  marginTop: 1,
+                  width: 15,
+                  height: 15,
+                  borderRadius: 4,
+                  border: step.done ? "none" : "1.5px solid var(--border-strong)",
+                  background: step.done ? "oklch(0.76 0.18 150)" : "transparent",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  cursor: "pointer",
+                  transition: "background 0.15s",
+                }}
+                title={step.done ? "Mark incomplete" : "Mark complete"}
+              >
+                {step.done && <Icon name="ph:check-bold" width={9} className="text-white" />}
+              </button>
+
+              {/* Text */}
+              <span style={{
+                flex: 1,
+                fontSize: 12,
+                lineHeight: 1.5,
+                color: step.done ? "var(--text-muted)" : "var(--text-primary)",
+                textDecoration: step.done ? "line-through" : "none",
+                wordBreak: "break-word",
+              }}>
+                {step.text}
+              </span>
+
+              {/* Actions */}
+              <span style={{ display: "flex", gap: 2, flexShrink: 0, opacity: 0 }} className="step-actions">
+                {i > 0 && (
+                  <button type="button" className="board-toolbar-btn" style={{ padding: "1px 4px" }}
+                    onClick={() => reorderStep(step.id, -1)} title="Move up">
+                    <Icon name="ph:arrow-up-bold" width={9} />
+                  </button>
+                )}
+                {i < steps.length - 1 && (
+                  <button type="button" className="board-toolbar-btn" style={{ padding: "1px 4px" }}
+                    onClick={() => reorderStep(step.id, 1)} title="Move down">
+                    <Icon name="ph:arrow-down-bold" width={9} />
+                  </button>
+                )}
+                <button type="button" className="board-toolbar-btn" style={{ padding: "1px 4px", color: "#f87171" }}
+                  onClick={() => deleteStep(step.id)} title="Delete step">
+                  <Icon name="ph:x-bold" width={9} />
+                </button>
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Add step input */}
+      <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+        <input
+          ref={inputRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); addStep(); } }}
+          placeholder="Add a step…"
+          style={{
+            flex: 1,
+            background: "var(--bg-elevated)",
+            border: "1px solid var(--border-hairline)",
+            borderRadius: 6,
+            padding: "5px 9px",
+            fontSize: 12,
+            color: "var(--text-primary)",
+            outline: "none",
+          }}
+        />
+        <button
+          type="button"
+          className="board-toolbar-btn"
+          onClick={addStep}
+          disabled={!draft.trim()}
+          style={{ padding: "4px 10px", fontSize: 11 }}
+        >
+          <Icon name="ph:plus-bold" width={11} />
+          Add
+        </button>
+      </div>
+
+      {/* CSS for hover reveal on step actions */}
+      <style>{".step-actions { opacity: 0; transition: opacity 0.1s; } li:hover .step-actions { opacity: 1; }"}</style>
+    </div>
+  );
+}
+
 export function BoardInspector({ card, familiars, sessions, onClose, onPatch, onMoveStatus, onDelete, onCardReplaced, onJumpToSession, onOpenTaskChat, chatLinking = false }: Props) {
   const [closing, setClosing] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState(false);
@@ -378,6 +592,8 @@ export function BoardInspector({ card, familiars, sessions, onClose, onPatch, on
                 if (next !== card.cwd) onPatch(card.id, { cwd: next });
               }} />
           </div>
+
+          <StepsSection card={card} onPatch={onPatch} />
 
           <div className="board-drawer-field">
             <div className="board-drawer-field-label">Links</div>

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -265,7 +265,7 @@ function StepsSection({
   onPatch: (id: string, patch: Partial<Card>) => void;
 }) {
   const [draft, setDraft] = useState("");
-  const inputRef = React.useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const steps = card.steps ?? [];
   const doneCount = steps.filter((s) => s.done).length;

--- a/src/lib/cave-board-types.ts
+++ b/src/lib/cave-board-types.ts
@@ -9,6 +9,14 @@ export type CardLifecycle =
   | "failed"
   | "cancelled";
 
+export type CardStep = {
+  id: string;        // nanoid — stable across edits
+  text: string;      // what needs to be done
+  done: boolean;     // completed?
+  addedAt: string;   // ISO timestamp when step was created
+  doneAt?: string;   // ISO timestamp when step was checked off
+};
+
 export type Card = {
   id: string;
   title: string;
@@ -31,6 +39,7 @@ export type Card = {
   runningSince?: string;
   retryCount: number;
   maxRetries: number;
+  steps: CardStep[];
 };
 
 export const STATUSES: CardStatus[] = ["backlog", "inbox", "running", "review", "blocked", "done"];

--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -60,12 +60,12 @@ function normalizeCwd(value: string | null | undefined): string | null {
 
 type LegacyCard = Omit<
   Card,
-  "cwd" | "links" | "lifecycle" | "lifecycleAt" | "retryCount" | "maxRetries"
+  "cwd" | "links" | "lifecycle" | "lifecycleAt" | "retryCount" | "maxRetries" | "steps"
 > &
   Partial<
     Pick<
       Card,
-      "cwd" | "links" | "lifecycle" | "lifecycleAt" | "retryCount" | "maxRetries"
+      "cwd" | "links" | "lifecycle" | "lifecycleAt" | "retryCount" | "maxRetries" | "steps"
     >
   >;
 
@@ -81,6 +81,7 @@ function backfillCard(c: Card | LegacyCard): Card {
     lifecycleAt: c.lifecycleAt ?? c.updatedAt,
     retryCount: c.retryCount ?? 0,
     maxRetries: c.maxRetries ?? DEFAULT_MAX_RETRIES,
+    steps: c.steps ?? [],
   } as Card;
 }
 
@@ -149,6 +150,7 @@ export async function createCard(input: NewCardInput): Promise<Card> {
     lifecycleAt: now,
     retryCount: 0,
     maxRetries: DEFAULT_MAX_RETRIES,
+    steps: [],
   };
   board.cards.push(card);
   await saveBoard(board);
@@ -177,6 +179,7 @@ export async function updateCard(
       : current.links,
     cwd: "cwd" in patch ? normalizeCwd(patch.cwd) : current.cwd,
     sessionId: "sessionId" in patch ? patch.sessionId ?? null : current.sessionId,
+    steps: patch.steps ?? current.steps,
   };
   if (next.lifecycle === "running" && !next.runningSince) {
     next.runningSince = next.updatedAt;

--- a/src/lib/demo-seed.ts
+++ b/src/lib/demo-seed.ts
@@ -186,6 +186,7 @@ export const DEMO_BOARD_CARDS: Card[] = [
     lifecycleAt: ago(60),
     retryCount: 0,
     maxRetries: 2,
+    steps: [],
   },
   {
     id: "demo-card-2",
@@ -204,6 +205,7 @@ export const DEMO_BOARD_CARDS: Card[] = [
     lifecycleAt: ago(90),
     retryCount: 0,
     maxRetries: 2,
+    steps: [],
   },
   {
     id: "demo-card-3",
@@ -222,6 +224,7 @@ export const DEMO_BOARD_CARDS: Card[] = [
     lifecycleAt: ago(30),
     retryCount: 0,
     maxRetries: 2,
+    steps: [],
   },
   {
     id: "demo-card-4",
@@ -240,6 +243,7 @@ export const DEMO_BOARD_CARDS: Card[] = [
     lifecycleAt: ago(30),
     retryCount: 0,
     maxRetries: 2,
+    steps: [],
   },
   {
     id: "demo-card-5",
@@ -258,6 +262,7 @@ export const DEMO_BOARD_CARDS: Card[] = [
     lifecycleAt: ago(20),
     retryCount: 0,
     maxRetries: 2,
+    steps: [],
   },
 ];
 

--- a/src/lib/icon.tsx
+++ b/src/lib/icon.tsx
@@ -181,6 +181,8 @@ export const ICON_NAMES = [
   "ph:chat-centered-text",
   "ph:dots-three",
   "ph:minus-circle",
+  "ph:arrow-down-bold",
+  "ph:list-checks-bold",
   "ph:pencil-bold",
   "ph:rocket-bold",
   "ph:arrow-clockwise-bold",


### PR DESCRIPTION
Adds a fully-fleshed Steps field to task cards.

## Data shape (`CardStep`)
```ts
type CardStep = {
  id: string;      // UUID — stable across edits
  text: string;    // what needs to be done
  done: boolean;   // completed?
  addedAt: string; // ISO — when step was created
  doneAt?: string; // ISO — when checked off
};
```
Steps live on `Card.steps: CardStep[]`. Legacy cards backfill to `[]`.

## Inspector UI
- **Progress bar** — thin violet bar filling left→right as steps complete; turns emerald at 100%
- **Counter** — `X/N` badge + percentage in header
- **Step rows** — checkbox (green fill when done), step text (strikethrough when done), subtle green tint on done rows
- **Actions on hover** — up/down reorder arrows, delete button (red)
- **Add step** — inline input, Enter to confirm, or Add button
- Whole section lives between CWD and Links in the drawer

## Backend
- `CardStep` type exported from `cave-board-types.ts`
- `createCard` defaults steps to `[]`
- `backfillCard` coerces missing steps to `[]` for old cards
- `updateCard` passes steps through from patch
- `PATCH /api/board/[id]` accepts `steps: CardStep[]`