### PR TITLE
feat(board): enrich steps — ask familiars to plan their assigned tasks

### DIFF
--- a/src/app/api/board/enrich-steps/route.ts
+++ b/src/app/api/board/enrich-steps/route.ts
@@ -144,7 +144,11 @@ export async function POST() {
           addedAt: now,
         }));
 
-        await updateCard(card.id, { steps: cardSteps });
+        const updated = await updateCard(card.id, { steps: cardSteps });
+        if (!updated) {
+          push({ kind: "skip", cardId: card.id, reason: "card_missing" });
+          continue;
+        }
         push({ kind: "done", cardId: card.id, count: cardSteps.length });
       }
 

--- a/src/app/api/board/enrich-steps/route.ts
+++ b/src/app/api/board/enrich-steps/route.ts
@@ -26,15 +26,20 @@ function enrichPrompt(card: { title: string; notes?: string; labels?: string[] }
 // Run coven CLI and collect full stdout output as a string.
 function runCoven(args: string[], familiarId: string, familiarWorkspacePath?: string): Promise<string> {
   return new Promise((resolve) => {
-    let out = "";
-    const child = spawn(covenBin(), args, {
-      cwd: familiarWorkspacePath ?? process.cwd(),
-      stdio: ["ignore", "pipe", "pipe"],
-      env: covenSpawnEnv(),
-    });
-    child.stdout.on("data", (d: Buffer) => { out += d.toString("utf8"); });
-    child.on("close", () => resolve(out));
-    child.on("error", () => resolve(""));
+    try {
+      let out = "";
+      const child = spawn(covenBin(), args, {
+        cwd: familiarWorkspacePath ?? process.cwd(),
+        stdio: ["ignore", "pipe", "pipe"],
+        env: covenSpawnEnv(),
+      });
+      child.stdout.on("data", (d: Buffer) => { out += d.toString("utf8"); });
+      child.stderr.on("data", (d: Buffer) => { out += d.toString("utf8"); });
+      child.on("close", () => resolve(out));
+      child.on("error", () => resolve(out));
+    } catch {
+      resolve("");
+    }
   });
 }
 

--- a/src/app/api/board/enrich-steps/route.ts
+++ b/src/app/api/board/enrich-steps/route.ts
@@ -46,15 +46,49 @@ function runCoven(args: string[], familiarId: string, familiarWorkspacePath?: st
 // Parse familiar response — look for a JSON array anywhere in the output.
 function parseSteps(raw: string): string[] | null {
   const clean = stripAnsi(raw);
-  // Try to find a JSON array in the response (familiar may add prose around it)
-  const match = clean.match(/\[[\s\S]*?\]/);
+
+  // When using `--stream-json`, assistant text is wrapped in JSON envelopes.
+  // Extract the assistant's text payload first so we don't accidentally match
+  // other JSON arrays like `message.content`.
+  let assistantText = "";
+  for (const line of clean.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+      try {
+        const ev = JSON.parse(trimmed) as {
+          type?: string;
+          message?: { content?: Array<{ type?: string; text?: string }> };
+        };
+        if (ev.type === "assistant" && ev.message?.content) {
+          for (const block of ev.message.content) {
+            if (block.type === "text" && typeof block.text === "string") {
+              assistantText += block.text;
+            }
+          }
+          continue;
+        }
+      } catch {
+        /* fall through */
+      }
+    }
+
+    // Fallback for harnesses that emit plain text even with --stream-json.
+    assistantText += trimmed + "\n";
+  }
+
+  const haystack = assistantText.trim() ? assistantText : clean;
+  const match = haystack.match(/\[[\s\S]*?\]/);
   if (!match) return null;
   try {
     const parsed = JSON.parse(match[0]);
     if (Array.isArray(parsed) && parsed.every((s) => typeof s === "string")) {
-      return parsed.filter((s) => s.trim().length > 0).slice(0, 10);
+      return parsed.map((s) => s.trim()).filter(Boolean).slice(0, 7);
     }
-  } catch { /* */ }
+  } catch {
+    /* */
+  }
   return null;
 }
 

--- a/src/app/api/board/enrich-steps/route.ts
+++ b/src/app/api/board/enrich-steps/route.ts
@@ -1,0 +1,123 @@
+import { loadBoard, updateCard } from "@/lib/cave-board";
+import type { CardStep } from "@/lib/cave-board-types";
+import { bindingFor, loadConfig } from "@/lib/cave-config";
+import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
+import { spawn } from "node:child_process";
+import { stripAnsi } from "@/lib/ansi";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+// Prompt the familiar to return ONLY a JSON array of step strings — nothing else.
+function enrichPrompt(card: { title: string; notes?: string; labels?: string[] }): string {
+  const labels = card.labels?.length ? `\nLabels: ${card.labels.join(", ")}` : "";
+  const notes = card.notes?.trim() ? `\n\nNotes:\n${card.notes.trim()}` : "";
+  return [
+    `You are helping plan the following task as a concrete checklist.`,
+    `Task: ${card.title.trim()}${labels}${notes}`,
+    ``,
+    `Output ONLY a JSON array of step strings — no explanation, no markdown, no extra text.`,
+    `Each step must be a short, actionable sentence (< 80 chars).`,
+    `Produce 3–7 steps that reflect your role, skills, and the ideal process for this task.`,
+    `Example output: ["Step one","Step two","Step three"]`,
+  ].join("\n");
+}
+
+// Run coven CLI and collect full stdout output as a string.
+function runCoven(args: string[], familiarId: string, familiarWorkspacePath?: string): Promise<string> {
+  return new Promise((resolve) => {
+    let out = "";
+    const child = spawn(covenBin(), args, {
+      cwd: familiarWorkspacePath ?? process.cwd(),
+      stdio: ["ignore", "pipe", "pipe"],
+      env: covenSpawnEnv(),
+    });
+    child.stdout.on("data", (d: Buffer) => { out += d.toString("utf8"); });
+    child.on("close", () => resolve(out));
+    child.on("error", () => resolve(""));
+  });
+}
+
+// Parse familiar response — look for a JSON array anywhere in the output.
+function parseSteps(raw: string): string[] | null {
+  const clean = stripAnsi(raw);
+  // Try to find a JSON array in the response (familiar may add prose around it)
+  const match = clean.match(/\[[\s\S]*?\]/);
+  if (!match) return null;
+  try {
+    const parsed = JSON.parse(match[0]);
+    if (Array.isArray(parsed) && parsed.every((s) => typeof s === "string")) {
+      return parsed.filter((s) => s.trim().length > 0).slice(0, 10);
+    }
+  } catch { /* */ }
+  return null;
+}
+
+export async function POST() {
+  const [board, config] = await Promise.all([loadBoard(), loadConfig()]);
+
+  // Only enrich tasks that:
+  // - have an assigned familiar
+  // - are not completed or cancelled
+  // - have no existing steps yet (or have 0 steps)
+  const SKIP_LIFECYCLE = new Set(["completed", "cancelled"]);
+  const candidates = board.cards.filter(
+    (c) => c.familiarId && !SKIP_LIFECYCLE.has(c.lifecycle) && (c.steps ?? []).length === 0
+  );
+
+  const stream = new ReadableStream<Uint8Array>({
+    start: async (controller) => {
+      const enc = new TextEncoder();
+      const push = (obj: object) =>
+        controller.enqueue(enc.encode(JSON.stringify(obj) + "\n"));
+
+      push({ kind: "start", total: candidates.length });
+
+      for (const card of candidates) {
+        const familiarId = card.familiarId!;
+        const binding = bindingFor(config, familiarId);
+
+        // Only codex/claude harnesses can run headlessly
+        if (!["codex", "claude"].includes(binding.harness)) {
+          push({ kind: "skip", cardId: card.id, reason: `harness:${binding.harness}` });
+          continue;
+        }
+
+        push({ kind: "progress", cardId: card.id, title: card.title });
+
+        const args: string[] = ["run", binding.harness, "--stream-json"];
+        if (/^[a-z0-9_-]+$/i.test(familiarId)) args.push("--familiar", familiarId);
+        args.push("--", enrichPrompt(card));
+
+        const raw = await runCoven(args, familiarId);
+        const steps = parseSteps(raw);
+
+        if (!steps || steps.length === 0) {
+          push({ kind: "skip", cardId: card.id, reason: "no_steps_parsed" });
+          continue;
+        }
+
+        const now = new Date().toISOString();
+        const cardSteps: CardStep[] = steps.map((text) => ({
+          id: crypto.randomUUID(),
+          text,
+          done: false,
+          addedAt: now,
+        }));
+
+        await updateCard(card.id, { steps: cardSteps });
+        push({ kind: "done", cardId: card.id, count: cardSteps.length });
+      }
+
+      push({ kind: "complete" });
+      try { controller.close(); } catch { /* */ }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "content-type": "application/x-ndjson; charset=utf-8",
+      "cache-control": "no-cache",
+    },
+  });
+}

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -231,7 +231,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
             disabled={enriching || cards.length === 0}
             title="Ask each familiar to populate steps for their assigned tasks"
           >
-            <Icon name="ph:sparkle-bold" width={13} />
+            <Icon name="ph:sparkle" width={13} />
             {enriching
               ? enrichProgress
                 ? `${enrichProgress.done}/${enrichProgress.total}`

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -144,7 +144,8 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
     setEnrichProgress(null);
     try {
       const res = await fetch("/api/board/enrich-steps", { method: "POST" });
-      if (!res.body) return;
+      if (!res.ok) throw new Error(`enrich steps failed (${res.status})`);
+      if (!res.body) throw new Error("enrich steps: missing response body");
       const reader = res.body.getReader();
       const decoder = new TextDecoder();
       let buffer = "";

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -171,6 +171,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
           } catch { /* */ }
         }
       }
+      setEnriching(false);
     } catch {
       setEnriching(false);
     }

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -162,11 +162,10 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
             const msg = JSON.parse(trimmed) as Record<string, unknown>;
             if (msg.kind === "start") {
               setEnrichProgress({ done: 0, total: (msg.total as number) ?? 0 });
-            } else if (msg.kind === "done") {
+            } else if (msg.kind === "done" || msg.kind === "skip") {
               setEnrichProgress((prev) => prev ? { ...prev, done: prev.done + 1 } : prev);
             } else if (msg.kind === "complete") {
               await load();
-              setEnriching(false);
             }
           } catch { /* */ }
         }

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -38,6 +38,8 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
   const [modalDefaultStatus, setModalDefaultStatus] = useState<CardStatus>("backlog");
   const [chatLinkingId, setChatLinkingId] = useState<string | null>(null);
   const [chatLinkError, setChatLinkError] = useState<string | null>(null);
+  const [enriching, setEnriching] = useState(false);
+  const [enrichProgress, setEnrichProgress] = useState<{ done: number; total: number } | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -137,6 +139,42 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
     }
   };
 
+  const handleEnrichSteps = async () => {
+    setEnriching(true);
+    setEnrichProgress(null);
+    try {
+      const res = await fetch("/api/board/enrich-steps", { method: "POST" });
+      if (!res.body) return;
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          try {
+            const msg = JSON.parse(trimmed) as Record<string, unknown>;
+            if (msg.kind === "start") {
+              setEnrichProgress({ done: 0, total: (msg.total as number) ?? 0 });
+            } else if (msg.kind === "done") {
+              setEnrichProgress((prev) => prev ? { ...prev, done: prev.done + 1 } : prev);
+            } else if (msg.kind === "complete") {
+              await load();
+              setEnriching(false);
+            }
+          } catch { /* */ }
+        }
+      }
+    } catch {
+      setEnriching(false);
+    }
+  };
+
   return (
     <section className="board-shell">
       {/* Header */}
@@ -186,7 +224,21 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
             </button>
           </div>
 
-          <button type="button" className="board-new-card-btn"
+          <button
+            type="button"
+            className="board-toolbar-btn"
+            onClick={handleEnrichSteps}
+            disabled={enriching || cards.length === 0}
+            title="Ask each familiar to populate steps for their assigned tasks"
+          >
+            <Icon name="ph:sparkle-bold" width={13} />
+            {enriching
+              ? enrichProgress
+                ? `${enrichProgress.done}/${enrichProgress.total}`
+                : "Starting…"
+              : "Enrich steps"}
+          </button>
+                    <button type="button" className="board-new-card-btn"
             onClick={() => { setModalDefaultStatus("backlog"); setModalOpen(true); }}>
             + New task
           </button>


### PR DESCRIPTION
Adds an **Enrich steps** button to the board header toolbar that walks through every active, assigned, step-less task and asks the familiar responsible for it to generate a concrete ordered checklist.

## How it works

1. **Button** — sits in the header controls (before + New task), shows a sparkle icon + live `X/N` progress counter while running; disabled when no cards exist or already running
2. **API route** — `POST /api/board/enrich-steps` streams NDJSON progress events (`start`, `progress`, `skip`, `done`, `complete`)
3. **Familiar prompt** — asks the assigned familiar to output *only* a JSON array of 3–7 short actionable step strings, framed around their role and the ideal process for the task
4. **Parser** — strips ANSI, finds the first JSON array in the response (handles prose wrappers gracefully)
5. **Persistence** — saves `CardStep[]` to the card via `updateCard`; board refreshes on completion

## Filters
- Skips completed / cancelled cards
- Skips cards with no assigned familiar
- Skips cards that already have steps
- Skips non-codex/non-claude harnesses (can't run headlessly yet)