### PR TITLE
feat(traces): harden 3D delegation graph

### DIFF
--- a/docs/superpowers/plans/2026-06-06-3d-trace-graph.md
+++ b/docs/superpowers/plans/2026-06-06-3d-trace-graph.md
@@ -1,0 +1,1083 @@
+# 3D Trace Graph Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the current delegation trace prototype into a production-quality 3D graph where explicit and inferred familiar handoffs are visible, selectable, accessible, performant, and visually verified.
+
+**Architecture:** Keep the graph renderer as a focused plain Three.js island inside the existing React/Next/Tauri UI. Split deterministic graph layout and render policy into pure testable helpers, keep the WebGL scene imperative, and keep all selection/filter/inspector state in React. Defer React Three Fiber and force-graph libraries until trace volume or component reuse demands them.
+
+**Tech Stack:** Next.js 16, React 19, TypeScript, Three.js 0.184, Tauri v2, Node test runner, Playwright for browser/canvas verification.
+
+---
+
+## Sage Research Brief
+
+**Recommendation:** Continue with direct Three.js, but harden the component into a small internal graph renderer. Do not add `3d-force-graph`, `react-force-graph`, or React Three Fiber for this slice.
+
+**Why direct Three.js is the right current choice:**
+- Cave already added `three` and has one specialized graph surface. Direct Three.js gives the smallest new runtime surface and exact control over camera, picking, labels, edge animation, disposal, and Tauri browser behavior.
+- Three.js first-party docs support the exact primitives this needs: `OrbitControls` for orbit/dolly/pan/reset, `Raycaster` for picking, and explicit `WebGLRenderer.dispose()` for GPU cleanup.
+- `@react-three/fiber` is strong and React 19 compatible at v9.6.1, but it adds a second renderer and several dependencies for a component that mostly needs imperative graph rendering. Use it later if Cave gains multiple reusable 3D scenes or needs the R3F ecosystem.
+- `3d-force-graph` is excellent for large generic force-directed graphs, but it brings an opinionated force engine and larger package surface. The trace graph is a temporal/provenance workflow graph, not a generic network exploration app. We need deterministic mental-map stability more than force-layout novelty.
+
+**Package check from npm on 2026-06-06:**
+- `three@0.184.0`: latest, already in branch; unpacked package size about 36.9 MB.
+- `@react-three/fiber@9.6.1`: React 19 peer range, adds about 2.18 MB unpacked plus dependencies.
+- `3d-force-graph@1.80.0`: depends on `three`, `three-forcegraph`, `three-render-objects`, `kapsule`; about 14.5 MB unpacked.
+- `react-force-graph@1.48.2`: pulls `3d-force-graph`, AR/VR variants, 2D force graph, `react-kapsule`; about 23.9 MB unpacked.
+
+**Primary sources checked:**
+- Three.js `OrbitControls`: https://threejs.org/docs/pages/OrbitControls.html
+- Three.js `WebGLRenderer.dispose()`: https://threejs.org/docs/pages/WebGLRenderer.html
+- React Three Fiber README: https://github.com/pmndrs/react-three-fiber
+- React Three Fiber Canvas docs: https://r3f.docs.pmnd.rs/api/canvas
+- `3d-force-graph` README: https://github.com/vasturiano/3d-force-graph
+- `react-force-graph` package: https://www.npmjs.com/package/react-force-graph
+
+**Current prototype gaps to fix before PR:**
+- Selection changes currently rebuild the entire scene because the scene effect depends on `selection` and `selectedKey`; selection highlighting should update materials/scale without recreating renderer state.
+- The 3D view does not visibly highlight selected nodes/routes/traces yet.
+- The 3D view has no hover tooltip, which regresses useful behavior from the 2D graph.
+- Drag/zoom is hand-rolled. Use `OrbitControls` for expected orbit/dolly/pan/reset behavior, keyboard integration, damping, and lower maintenance.
+- Edge direction is implied only by particle motion. Add arrowheads or directional glyphs so static/reduced-motion users can read flow.
+- Halo rings call `lookAt(camera.position)` only once, so they can stop facing the camera after orbiting.
+- `Focus selected` currently has no meaningful target for timeline trace selections unless the trace is resolved back to its route.
+- Particle meshes allocate repeated sphere geometry/materials instead of sharing or instancing.
+- Trackpad/touch pinch behavior should be verified in Tauri/macOS, not assumed from wheel zoom alone.
+- Canvas accessibility needs a DOM mirror: keyboard-selectable routes/nodes/traces and concise status text outside WebGL.
+- Layout is deterministic but too naive for reciprocal edges, very small graphs, and dense trace volumes. Extract layout policy and cap/cluster rules.
+- Visual verification needs actual browser/canvas proof, not only source assertions and typecheck.
+
+---
+
+## File Structure
+
+- Modify `package.json` and lockfiles: keep `three`; add direct `@playwright/test` dev dependency only if the verification script needs it.
+- Create `src/components/trace-graph-3d-model.ts`: pure layout, detail-level, selection, and color helpers.
+- Create `src/components/trace-graph-3d-model.test.ts`: deterministic unit tests for layout, caps, selection mapping, and status/provenance colors.
+- Modify `src/components/trace-graph-3d.tsx`: renderer island using model helpers, `OrbitControls`, separate selection update effect, arrowheads, keyboard, DOM mirror, and performance safeguards.
+- Modify `src/components/calls-view.tsx`: remove unused legacy 2D graph code only after the 3D graph has equivalent behavior, or keep it behind a fallback if visual verification says WebGL can fail.
+- Modify `src/components/calls-view-graph.test.ts`: replace brittle source-regex checks with focused assertions for the new architecture and accessibility contract.
+- Create `scripts/verify-trace-graph-3d.mjs`: start from an existing dev URL, navigate to Delegations, assert canvas is nonblank, click a node/route, and capture screenshots.
+
+---
+
+## Task 1: Pure Graph Layout and Render Policy
+
+**Files:**
+- Create: `src/components/trace-graph-3d-model.ts`
+- Create: `src/components/trace-graph-3d-model.test.ts`
+- Modify: `src/components/calls-view-graph.test.ts`
+
+- [ ] **Step 1: Write the failing model tests**
+
+Create `src/components/trace-graph-3d-model.test.ts`:
+
+```ts
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  buildTraceGraphSceneModel,
+  edgeKey,
+  renderPolicyForGraph,
+  traceGraphColor,
+  type TraceGraphSelection,
+} from "./trace-graph-3d-model.ts";
+
+const graph = {
+  nodes: [
+    { id: "nova", sentCount: 2, receivedCount: 1, sentExplicitCount: 2, receivedExplicitCount: 1, sentInferredCount: 0, receivedInferredCount: 0, hasRunningReceived: false, latestReceivedFailed: false, lastSeenAt: "2026-06-06T12:00:00.000Z" },
+    { id: "cody", sentCount: 1, receivedCount: 2, sentExplicitCount: 1, receivedExplicitCount: 2, sentInferredCount: 0, receivedInferredCount: 0, hasRunningReceived: true, latestReceivedFailed: false, lastSeenAt: "2026-06-06T12:01:00.000Z" },
+    { id: "sage", sentCount: 0, receivedCount: 1, sentExplicitCount: 0, receivedExplicitCount: 0, sentInferredCount: 0, receivedInferredCount: 1, hasRunningReceived: false, latestReceivedFailed: true, lastSeenAt: "2026-06-06T12:02:00.000Z" },
+  ],
+  edges: [
+    { caller: "nova", callee: "cody", count: 2, explicitCount: 2, inferredCount: 0, source: "explicit", mostRecentRequest: "Build graph", hasRunning: true, latestStatus: "running", lastSeenAt: "2026-06-06T12:01:00.000Z", traces: [] },
+    { caller: "cody", callee: "nova", count: 1, explicitCount: 1, inferredCount: 0, source: "explicit", mostRecentRequest: "Review", hasRunning: false, latestStatus: "completed", lastSeenAt: "2026-06-06T12:00:30.000Z", traces: [] },
+    { caller: "cody", callee: "sage", count: 1, explicitCount: 0, inferredCount: 1, source: "inferred", mostRecentRequest: "Research", hasRunning: false, latestStatus: "failed", lastSeenAt: "2026-06-06T12:02:00.000Z", traces: [] },
+  ],
+  traces: [],
+};
+
+const model = buildTraceGraphSceneModel(graph, new Map([
+  ["nova", "Nova"],
+  ["cody", "Cody"],
+  ["sage", "Sage"],
+]));
+
+assert.equal(model.nodes.length, 3);
+assert.equal(model.edges.length, 3);
+assert.equal(edgeKey(graph.edges[0]), "nova->cody->explicit");
+assert.notDeepEqual(model.nodes[0].position, model.nodes[1].position);
+assert.equal(model.edges[0].selected, false);
+
+const selection: TraceGraphSelection = { kind: "edge", key: "nova->cody->explicit" };
+const selectedModel = buildTraceGraphSceneModel(graph, new Map(), selection);
+assert.equal(selectedModel.edges.find((edge) => edge.key === selection.key)?.selected, true);
+
+assert.equal(traceGraphColor(graph.edges[0]), "#62d08f");
+assert.equal(traceGraphColor(graph.edges[2]), "#f87171");
+assert.equal(renderPolicyForGraph({ nodeCount: 12, edgeCount: 24 }).detail, "full");
+assert.equal(renderPolicyForGraph({ nodeCount: 80, edgeCount: 220 }).detail, "reduced");
+assert.equal(renderPolicyForGraph({ nodeCount: 140, edgeCount: 420 }).detail, "summary");
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+node --test src/components/trace-graph-3d-model.test.ts
+```
+
+Expected: fail with `Cannot find module './trace-graph-3d-model.ts'`.
+
+- [ ] **Step 3: Implement the pure model helper**
+
+Create `src/components/trace-graph-3d-model.ts`:
+
+```ts
+import type {
+  CallStatus,
+  DelegationGraph,
+  DelegationGraphEdge,
+  DelegationGraphNode,
+} from "@/lib/coven-calls-types";
+
+export type TraceGraphSelection =
+  | { kind: "edge"; key: string }
+  | { kind: "node"; id: string }
+  | { kind: "trace"; id: string }
+  | null;
+
+export type ScenePosition = { x: number; y: number; z: number };
+
+export type TraceSceneNode = DelegationGraphNode & {
+  label: string;
+  position: ScenePosition;
+  selected: boolean;
+};
+
+export type TraceSceneEdge = DelegationGraphEdge & {
+  key: string;
+  from: ScenePosition;
+  to: ScenePosition;
+  control: ScenePosition;
+  selected: boolean;
+  color: string;
+};
+
+export type TraceGraphSceneModel = {
+  nodes: TraceSceneNode[];
+  edges: TraceSceneEdge[];
+  policy: TraceRenderPolicy;
+};
+
+export type TraceRenderPolicy = {
+  detail: "full" | "reduced" | "summary";
+  animateParticles: boolean;
+  showLabels: boolean;
+  maxRenderedEdges: number;
+};
+
+export function edgeKey(edge: Pick<DelegationGraphEdge, "caller" | "callee" | "source">): string {
+  return `${edge.caller}->${edge.callee}->${edge.source}`;
+}
+
+export function traceGraphColor(edge: Pick<DelegationGraphEdge, "source" | "latestStatus" | "hasRunning">): string {
+  if (edge.latestStatus === "failed") return "#f87171";
+  if (edge.hasRunning) return "#62d08f";
+  if (edge.source === "inferred") return "#fbbf24";
+  if (edge.source === "mixed") return "#38bdf8";
+  return "#8E3DFF";
+}
+
+export function nodeStatusColor(node: Pick<DelegationGraphNode, "hasRunningReceived" | "latestReceivedFailed">): string {
+  if (node.latestReceivedFailed) return "#f87171";
+  if (node.hasRunningReceived) return "#62d08f";
+  return "#8E3DFF";
+}
+
+export function renderPolicyForGraph({ nodeCount, edgeCount }: { nodeCount: number; edgeCount: number }): TraceRenderPolicy {
+  if (nodeCount > 120 || edgeCount > 360) {
+    return { detail: "summary", animateParticles: false, showLabels: false, maxRenderedEdges: 180 };
+  }
+  if (nodeCount > 48 || edgeCount > 140) {
+    return { detail: "reduced", animateParticles: false, showLabels: true, maxRenderedEdges: 140 };
+  }
+  return { detail: "full", animateParticles: true, showLabels: true, maxRenderedEdges: 140 };
+}
+
+function selectedEdgeKey(selection: TraceGraphSelection): string | null {
+  return selection?.kind === "edge" ? selection.key : null;
+}
+
+function selectedNodeId(selection: TraceGraphSelection): string | null {
+  return selection?.kind === "node" ? selection.id : null;
+}
+
+function pos(x: number, y: number, z: number): ScenePosition {
+  return { x, y, z };
+}
+
+export function buildTraceGraphSceneModel(
+  graph: DelegationGraph,
+  labels: Map<string, string>,
+  selection: TraceGraphSelection = null,
+): TraceGraphSceneModel {
+  const policy = renderPolicyForGraph({ nodeCount: graph.nodes.length, edgeCount: graph.edges.length });
+  const count = Math.max(graph.nodes.length, 1);
+  const radius = Math.max(4.2, Math.min(8.4, 3.8 + count * 0.36));
+  const selectedNode = selectedNodeId(selection);
+  const selectedEdge = selectedEdgeKey(selection);
+
+  const nodes = graph.nodes.map((node, index): TraceSceneNode => {
+    const angle = (index / count) * Math.PI * 2 - Math.PI / 2;
+    const lane = (index % 3) - 1;
+    const activity = node.sentCount + node.receivedCount;
+    const lift = lane * 1.25 + Math.sin(index * 1.7) * 0.35;
+    const scale = 1 + Math.min(activity, 10) * 0.018;
+    return {
+      ...node,
+      label: labels.get(node.id) ?? node.id,
+      position: pos(Math.cos(angle) * radius * scale, lift, Math.sin(angle) * radius * scale),
+      selected: selectedNode === node.id,
+    };
+  });
+
+  const byId = new Map(nodes.map((node) => [node.id, node]));
+  const visibleEdges = [...graph.edges]
+    .sort((a, b) => b.count - a.count || b.lastSeenAt.localeCompare(a.lastSeenAt))
+    .slice(0, policy.maxRenderedEdges);
+
+  const edges = visibleEdges.flatMap((edge, index): TraceSceneEdge[] => {
+    const caller = byId.get(edge.caller);
+    const callee = byId.get(edge.callee);
+    if (!caller || !callee) return [];
+    const from = caller.position;
+    const to = callee.position;
+    const reciprocal = graph.edges.some((other) => other.caller === edge.callee && other.callee === edge.caller);
+    const midpoint = pos((from.x + to.x) / 2, (from.y + to.y) / 2, (from.z + to.z) / 2);
+    const reciprocalOffset = reciprocal ? (edge.caller < edge.callee ? 0.8 : -0.8) : 0;
+    const control = pos(
+      midpoint.x * 1.08 + reciprocalOffset,
+      midpoint.y + 1.25 + Math.min(edge.count, 6) * 0.22 + (index % 2) * 0.35,
+      midpoint.z * 1.08 - reciprocalOffset,
+    );
+    const key = edgeKey(edge);
+    return [{
+      ...edge,
+      key,
+      from,
+      to,
+      control,
+      selected: selectedEdge === key,
+      color: traceGraphColor(edge),
+    }];
+  });
+
+  return { nodes, edges, policy };
+}
+```
+
+- [ ] **Step 4: Run model test to verify it passes**
+
+Run:
+
+```bash
+node --test src/components/trace-graph-3d-model.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Update architecture assertion test**
+
+Modify `src/components/calls-view-graph.test.ts` so it asserts:
+
+```ts
+assert.match(
+  graph3dSource,
+  /from "three\/addons\/controls\/OrbitControls\.js"/,
+  "3D trace graph should use Three.js OrbitControls instead of custom camera controls",
+);
+
+assert.match(
+  graph3dSource,
+  /tabIndex=\{0\}/,
+  "3D trace graph canvas should be keyboard focusable",
+);
+
+assert.match(
+  graph3dSource,
+  /aria-live="polite"/,
+  "3D trace graph should expose a DOM status mirror outside WebGL",
+);
+```
+
+Keep the existing assertions for `TraceGraph3D`, canvas test id, accessible label, focus/reset controls, reduced motion, and `three` dependency.
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+node --test src/components/trace-graph-3d-model.test.ts src/components/calls-view-graph.test.ts
+```
+
+Expected: fail until Task 2 implements the renderer behavior.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/trace-graph-3d-model.ts src/components/trace-graph-3d-model.test.ts src/components/calls-view-graph.test.ts
+git commit -m "test(trace-graph): define 3d scene model contract"
+```
+
+---
+
+## Task 2: Production Three.js Renderer Island
+
+**Files:**
+- Modify: `src/components/trace-graph-3d.tsx`
+- Modify: `src/components/calls-view-graph.test.ts`
+
+- [ ] **Step 1: Replace custom camera drag with OrbitControls**
+
+In `src/components/trace-graph-3d.tsx`, import:
+
+```ts
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+import {
+  buildTraceGraphSceneModel,
+  edgeKey,
+  nodeStatusColor,
+  type TraceGraphSelection,
+} from "@/components/trace-graph-3d-model";
+```
+
+Inside the scene effect, create controls:
+
+```ts
+const controls = new OrbitControls(camera, canvas);
+controls.enableDamping = true;
+controls.dampingFactor = 0.08;
+controls.enablePan = true;
+controls.minDistance = 6.8;
+controls.maxDistance = 21;
+controls.target.set(0, 0, 0);
+controls.saveState();
+```
+
+The render loop must call:
+
+```ts
+controls.update();
+renderer.render(scene, camera);
+```
+
+Cleanup must call:
+
+```ts
+controls.dispose();
+renderer.dispose();
+```
+
+- [ ] **Step 2: Stop rebuilding the renderer on selection changes**
+
+Keep the scene-creation effect dependent on `sceneModel`, `reducedMotion`, and `onSelect`, but not raw `selection` if possible. Store pickable object maps in refs:
+
+```ts
+const objectBySelectionRef = useRef(new Map<string, THREE.Object3D[]>());
+const latestSelectionRef = useRef<TraceGraphSelection>(selection);
+
+useEffect(() => {
+  latestSelectionRef.current = selection;
+}, [selection]);
+```
+
+When creating each node or edge object, push it into `objectBySelectionRef.current` keyed by `node:${id}` or `edge:${key}`. Add a separate effect:
+
+```ts
+useEffect(() => {
+  const map = objectBySelectionRef.current;
+  for (const [key, objects] of map) {
+    const selected =
+      (selection?.kind === "node" && key === `node:${selection.id}`) ||
+      (selection?.kind === "edge" && key === `edge:${selection.key}`);
+    for (const object of objects) {
+      object.scale.setScalar(selected ? 1.18 : 1);
+      const material = (object as THREE.Mesh).material;
+      if (material && !Array.isArray(material) && "opacity" in material) {
+        material.opacity = selected ? 1 : material.opacity;
+      }
+    }
+  }
+}, [selection]);
+```
+
+- [ ] **Step 3: Add directional arrowheads**
+
+For each `TraceSceneEdge`, after creating the curve:
+
+```ts
+const arrowT = 0.82;
+const arrowPosition = edge.arc.getPoint(arrowT);
+const arrowTangent = edge.arc.getTangent(arrowT).normalize();
+const arrow = new THREE.Mesh(
+  new THREE.ConeGeometry(0.14 + Math.min(edge.count, 6) * 0.01, 0.36, 16),
+  new THREE.MeshBasicMaterial({ color }),
+);
+arrow.position.copy(arrowPosition);
+arrow.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), arrowTangent);
+root.add(arrow);
+```
+
+Add arrow objects to the same edge selection map so selected routes brighten as a group.
+
+- [ ] **Step 4: Share particle geometry and keep halos billboarding**
+
+Before the edge loop, create shared particle geometry/materials keyed by color:
+
+```ts
+const particleGeometry = new THREE.SphereGeometry(0.085, 12, 12);
+const particleMaterials = new Map<number, THREE.MeshBasicMaterial>();
+const particleMaterialFor = (color: number) => {
+  const existing = particleMaterials.get(color);
+  if (existing) return existing;
+  const material = new THREE.MeshBasicMaterial({ color });
+  particleMaterials.set(color, material);
+  return material;
+};
+```
+
+Use it inside the edge loop:
+
+```ts
+const particle = new THREE.Mesh(particleGeometry, particleMaterialFor(color));
+```
+
+When creating halos:
+
+```ts
+halo.userData.billboard = true;
+```
+
+In the animation loop:
+
+```ts
+root.traverse((child) => {
+  if (child instanceof THREE.Sprite || child.userData.billboard) {
+    child.quaternion.copy(camera.quaternion);
+  }
+});
+```
+
+Cleanup must dispose shared geometry/materials:
+
+```ts
+particleGeometry.dispose();
+for (const material of particleMaterials.values()) material.dispose();
+```
+
+- [ ] **Step 5: Add selected trace behavior**
+
+If `selection.kind === "trace"`, find its edge by matching the trace in `graph.edges[].traces`. Focus/selection should treat it as that route and the inspector should still show the selected trace:
+
+```ts
+function selectionObjectKey(selection: TraceGraphSelection, graph: DelegationGraph): string | null {
+  if (!selection) return null;
+  if (selection.kind === "node") return `node:${selection.id}`;
+  if (selection.kind === "edge") return `edge:${selection.key}`;
+  const edge = graph.edges.find((candidate) => candidate.traces.some((trace) => trace.id === selection.id));
+  return edge ? `edge:${edgeKey(edge)}` : null;
+}
+```
+
+- [ ] **Step 6: Add hover tooltip for nodes and routes**
+
+Store hover state in React:
+
+```ts
+type GraphHover =
+  | { kind: "node"; id: string; x: number; y: number }
+  | { kind: "edge"; key: string; x: number; y: number }
+  | null;
+
+const [hover, setHover] = useState<GraphHover>(null);
+```
+
+Add a throttled pointermove picker:
+
+```ts
+let lastHoverAt = 0;
+const onPointerHover = (event: PointerEvent) => {
+  const now = performance.now();
+  if (now - lastHoverAt < 50 || drag.active) return;
+  lastHoverAt = now;
+  setPointer(event);
+  raycaster.setFromCamera(pointer, camera);
+  const hit = raycaster.intersectObjects(pickables, false)[0]?.object as Pickable | undefined;
+  const selected = hit?.userData.selection;
+  if (!selected || selected.kind === "trace") {
+    setHover(null);
+    return;
+  }
+  setHover({ ...selected, x: event.clientX, y: event.clientY });
+};
+```
+
+Register and cleanup:
+
+```ts
+canvas.addEventListener("pointermove", onPointerHover);
+canvas.addEventListener("pointerleave", () => setHover(null));
+```
+
+Render the tooltip as DOM, not WebGL text:
+
+```tsx
+{hover ? (
+  <div
+    className="pointer-events-none fixed z-50 max-w-[260px] rounded-lg border border-white/10 bg-black/80 px-3 py-2 text-[11px] text-white shadow-2xl backdrop-blur"
+    style={{ left: hover.x + 12, top: hover.y + 12 }}
+  >
+    {hover.kind === "node"
+      ? familiarName(familiars, hover.id)
+      : graph.edges.find((edge) => edgeKey(edge) === hover.key)?.mostRecentRequest ?? "Delegation route"}
+  </div>
+) : null}
+```
+
+- [ ] **Step 7: Add keyboard support on the canvas**
+
+Canvas attributes:
+
+```tsx
+tabIndex={0}
+aria-label="3D delegation trace graph"
+role="img"
+```
+
+Keyboard handler:
+
+```ts
+const selectable = [...sceneModel.nodes.map((node) => ({ kind: "node" as const, id: node.id })), ...sceneModel.edges.map((edge) => ({ kind: "edge" as const, key: edge.key }))];
+
+const onKeyDown = (event: React.KeyboardEvent<HTMLCanvasElement>) => {
+  if (event.key === "Escape") onSelect(null);
+  if (event.key === "Home") resetRef.current?.();
+  if (event.key === "Enter" || event.key === " ") focusRef.current?.();
+  if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+    event.preventDefault();
+    const current = selectable.findIndex((item) => JSON.stringify(item) === JSON.stringify(selection));
+    onSelect(selectable[(current + 1 + selectable.length) % selectable.length] ?? null);
+  }
+  if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+    event.preventDefault();
+    const current = selectable.findIndex((item) => JSON.stringify(item) === JSON.stringify(selection));
+    onSelect(selectable[(current - 1 + selectable.length) % selectable.length] ?? null);
+  }
+};
+```
+
+- [ ] **Step 8: Add reduced-motion, visibility, and pinch guards**
+
+Use `IntersectionObserver` to pause animation when the graph is offscreen:
+
+```ts
+let visible = true;
+const visibilityObserver = new IntersectionObserver(([entry]) => {
+  visible = entry?.isIntersecting ?? true;
+});
+visibilityObserver.observe(shell);
+```
+
+In animation:
+
+```ts
+if (!visible) {
+  frame = requestAnimationFrame(animate);
+  return;
+}
+if (!reducedMotion && sceneModel.policy.animateParticles) {
+  // animate particles
+}
+```
+
+Cleanup:
+
+```ts
+visibilityObserver.disconnect();
+```
+
+Set touch behavior on the canvas so trackpad/touch gestures reach controls predictably:
+
+```tsx
+className="h-full min-h-[430px] w-full cursor-grab touch-none active:cursor-grabbing"
+```
+
+Add a Safari/WebKit gesture guard for Tauri macOS:
+
+```ts
+const onGestureStart = (event: Event) => event.preventDefault();
+canvas.addEventListener("gesturestart", onGestureStart);
+canvas.addEventListener("gesturechange", onGestureStart);
+```
+
+Cleanup both gesture listeners.
+
+- [ ] **Step 9: Run focused tests**
+
+Run:
+
+```bash
+node --test src/components/trace-graph-3d-model.test.ts src/components/calls-view-graph.test.ts
+pnpm typecheck
+```
+
+Expected: both tests pass and TypeScript passes.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/components/trace-graph-3d.tsx src/components/calls-view-graph.test.ts
+git commit -m "feat(trace-graph): harden 3d renderer controls"
+```
+
+---
+
+## Task 3: Accessible Graph Mirror and Inspector Interplay
+
+**Files:**
+- Modify: `src/components/trace-graph-3d.tsx`
+- Modify: `src/components/calls-view.tsx`
+- Modify: `src/components/calls-view-graph.test.ts`
+
+- [ ] **Step 1: Add a DOM status mirror below the canvas**
+
+In `TraceGraph3D`, compute:
+
+```ts
+const selectedSummary = useMemo(() => {
+  if (!selection) return `${graph.nodes.length} agents, ${graph.edges.length} routes, ${graph.traces.length} traces.`;
+  if (selection.kind === "node") return `Selected agent ${familiarName(familiars, selection.id)}.`;
+  if (selection.kind === "edge") {
+    const edge = graph.edges.find((candidate) => edgeKey(candidate) === selection.key);
+    return edge ? `Selected route ${familiarName(familiars, edge.caller)} to ${familiarName(familiars, edge.callee)}, ${edge.count} traces.` : "Selected route.";
+  }
+  const trace = graph.traces.find((candidate) => candidate.id === selection.id);
+  return trace ? `Selected ${trace.status} trace from ${familiarName(familiars, trace.callerFamiliarId)} to ${familiarName(familiars, trace.calleeFamiliarId)}.` : "Selected trace.";
+}, [familiars, graph, selection]);
+```
+
+Render:
+
+```tsx
+<p aria-live="polite" className="sr-only">
+  {selectedSummary}
+</p>
+```
+
+- [ ] **Step 2: Add keyboard-selectable route chips**
+
+Render a compact DOM mirror for the top routes:
+
+```tsx
+<div className="absolute left-3 top-16 hidden max-w-[320px] flex-wrap gap-1 md:flex">
+  {sceneModel.edges.slice(0, 6).map((edge) => (
+    <button
+      key={edge.key}
+      type="button"
+      onClick={() => onSelect({ kind: "edge", key: edge.key })}
+      className={[
+        "rounded-md border px-2 py-1 text-[10px] backdrop-blur",
+        selection?.kind === "edge" && selection.key === edge.key
+          ? "border-white/35 bg-white/15 text-white"
+          : "border-white/10 bg-black/35 text-white/65 hover:bg-white/10",
+      ].join(" ")}
+    >
+      {familiarName(familiars, edge.caller)} -> {familiarName(familiars, edge.callee)}
+    </button>
+  ))}
+</div>
+```
+
+This gives mouse and keyboard users a reliable non-WebGL selection surface.
+
+- [ ] **Step 3: Make inspector selection feel direct**
+
+In `calls-view.tsx`, keep trace timeline selection as trace selection, but allow `TraceInspector` to infer the associated edge for selected traces:
+
+```ts
+const selectedTraceEdge = selectedTrace
+  ? graph.edges.find((edge) => edge.traces.some((trace) => trace.id === selectedTrace.id)) ?? null
+  : null;
+```
+
+Pass this into `TraceInspector` as `selectedEdge={selectedEdge ?? selectedTraceEdge}` while preserving `selectedTrace`.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+node --test src/components/calls-view-graph.test.ts
+pnpm typecheck
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/trace-graph-3d.tsx src/components/calls-view.tsx src/components/calls-view-graph.test.ts
+git commit -m "feat(trace-graph): add accessible selection mirror"
+```
+
+---
+
+## Task 4: Performance and Dense-Graph Degradation
+
+**Files:**
+- Modify: `src/components/trace-graph-3d-model.ts`
+- Modify: `src/components/trace-graph-3d-model.test.ts`
+- Modify: `src/components/trace-graph-3d.tsx`
+
+- [ ] **Step 1: Add dense graph policy tests**
+
+Append to `src/components/trace-graph-3d-model.test.ts`:
+
+```ts
+const densePolicy = renderPolicyForGraph({ nodeCount: 70, edgeCount: 160 });
+assert.equal(densePolicy.detail, "reduced");
+assert.equal(densePolicy.animateParticles, false);
+assert.equal(densePolicy.showLabels, true);
+
+const extremePolicy = renderPolicyForGraph({ nodeCount: 130, edgeCount: 500 });
+assert.equal(extremePolicy.detail, "summary");
+assert.equal(extremePolicy.animateParticles, false);
+assert.equal(extremePolicy.showLabels, false);
+assert.equal(extremePolicy.maxRenderedEdges, 180);
+```
+
+- [ ] **Step 2: Add renderer-level degradation behavior**
+
+In `trace-graph-3d.tsx`, only create label sprites when:
+
+```ts
+if (sceneModel.policy.showLabels) {
+  const label = makeLabelSprite(node.label, active ? "#ffffff" : "#c9c0d8");
+  label.position.copy(node.position.clone().add(new THREE.Vector3(0, size + 0.48, 0)));
+  root.add(label);
+}
+```
+
+Only create edge particles when:
+
+```ts
+if (sceneModel.policy.animateParticles) {
+  // create particle mesh and add to particles[]
+}
+```
+
+Render a visible notice when graph is summarized:
+
+```tsx
+{sceneModel.policy.detail !== "full" ? (
+  <div className="pointer-events-none absolute right-3 top-16 max-w-[280px] rounded-lg border border-amber-400/20 bg-amber-950/45 px-3 py-2 text-[10px] text-amber-100/80 shadow-2xl backdrop-blur">
+    Dense graph mode: showing strongest routes first.
+  </div>
+) : null}
+```
+
+- [ ] **Step 3: Add renderer info debug hook in development**
+
+Inside animation loop:
+
+```ts
+if (process.env.NODE_ENV === "development" && frameCount % 180 === 0) {
+  canvas.dataset.drawCalls = String(renderer.info.render.calls);
+  canvas.dataset.triangles = String(renderer.info.render.triangles);
+}
+```
+
+Declare `let frameCount = 0;` and increment it per animation frame.
+
+- [ ] **Step 4: Run tests and typecheck**
+
+Run:
+
+```bash
+node --test src/components/trace-graph-3d-model.test.ts src/components/calls-view-graph.test.ts
+pnpm typecheck
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/trace-graph-3d-model.ts src/components/trace-graph-3d-model.test.ts src/components/trace-graph-3d.tsx
+git commit -m "feat(trace-graph): degrade gracefully for dense graphs"
+```
+
+---
+
+## Task 5: Visual Verification Script
+
+**Files:**
+- Modify: `package.json`
+- Modify: `pnpm-lock.yaml`
+- Modify: `package-lock.json`
+- Create: `scripts/verify-trace-graph-3d.mjs`
+
+- [ ] **Step 1: Add Playwright as an explicit dev dependency**
+
+Run:
+
+```bash
+pnpm add -D @playwright/test
+```
+
+Expected: `package.json`, `pnpm-lock.yaml`, and `package-lock.json` update.
+
+- [ ] **Step 2: Create the visual verification script**
+
+Create `scripts/verify-trace-graph-3d.mjs`:
+
+```js
+import { chromium } from "@playwright/test";
+import { mkdir } from "node:fs/promises";
+
+const baseUrl = process.env.CAVE_VERIFY_URL ?? "http://127.0.0.1:3000";
+const outDir = "artifacts/trace-graph-3d";
+
+await mkdir(outDir, { recursive: true });
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1440, height: 950 }, deviceScaleFactor: 1 });
+
+page.on("console", (msg) => {
+  if (["error", "warning"].includes(msg.type())) console.log(`[browser:${msg.type()}] ${msg.text()}`);
+});
+
+await page.goto(baseUrl, { waitUntil: "networkidle" });
+
+const delegationsButton = page.getByRole("button", { name: /delegations|live traces/i }).first();
+if (await delegationsButton.count()) {
+  await delegationsButton.click();
+}
+
+const canvas = page.getByTestId("trace-graph-3d-canvas");
+await canvas.waitFor({ timeout: 15_000 });
+await page.waitForTimeout(1200);
+
+const box = await canvas.boundingBox();
+if (!box || box.width < 320 || box.height < 320) {
+  throw new Error(`trace graph canvas has invalid bounds: ${JSON.stringify(box)}`);
+}
+
+const nonBlank = await canvas.evaluate((node) => {
+  const canvas = /** @type {HTMLCanvasElement} */ (node);
+  const context = canvas.getContext("2d");
+  if (!context) return true;
+  const sample = context.getImageData(0, 0, Math.min(canvas.width, 64), Math.min(canvas.height, 64)).data;
+  let lit = 0;
+  for (let i = 0; i < sample.length; i += 4) {
+    if (sample[i] + sample[i + 1] + sample[i + 2] > 20) lit++;
+  }
+  return lit > 12;
+});
+
+if (!nonBlank) throw new Error("trace graph canvas appears blank");
+
+await page.screenshot({ path: `${outDir}/desktop.png`, fullPage: true });
+
+await page.setViewportSize({ width: 390, height: 844 });
+await page.waitForTimeout(500);
+await canvas.waitFor({ timeout: 10_000 });
+await page.screenshot({ path: `${outDir}/mobile.png`, fullPage: true });
+
+await browser.close();
+console.log(`Trace graph visual verification passed: ${outDir}/desktop.png and ${outDir}/mobile.png`);
+```
+
+- [ ] **Step 3: Run visual verification against dev server**
+
+Start Cave if it is not already running:
+
+```bash
+pnpm dev
+```
+
+In another shell:
+
+```bash
+CAVE_VERIFY_URL=http://127.0.0.1:3000 node scripts/verify-trace-graph-3d.mjs
+```
+
+Expected: script prints `Trace graph visual verification passed` and writes desktop/mobile screenshots.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml package-lock.json scripts/verify-trace-graph-3d.mjs
+git commit -m "test(trace-graph): add 3d visual verification"
+```
+
+---
+
+## Task 6: Remove or Quarantine Legacy 2D Graph
+
+**Files:**
+- Modify: `src/components/calls-view.tsx`
+- Modify: `src/components/calls-view-graph.test.ts`
+
+- [ ] **Step 1: Decide fallback policy from visual verification**
+
+If Playwright confirms WebGL renders in desktop and mobile viewports, remove the unused `TraceGraph` SVG component from `calls-view.tsx` to reduce dead code. If WebGL fails on the Tauri target, keep `TraceGraph` and add an explicit runtime fallback:
+
+```tsx
+{webglAvailable ? (
+  <TraceGraph3D graph={graph} familiars={famById} selection={selection} onSelect={setSelection} />
+) : (
+  <TraceGraph graph={graph} familiars={famById} selection={selection} onSelect={setSelection} />
+)}
+```
+
+Use this WebGL detector:
+
+```ts
+function canUseWebGL(): boolean {
+  if (typeof document === "undefined") return false;
+  const canvas = document.createElement("canvas");
+  return Boolean(canvas.getContext("webgl2") ?? canvas.getContext("webgl"));
+}
+```
+
+- [ ] **Step 2: Run focused graph test**
+
+Run:
+
+```bash
+node --test src/components/calls-view-graph.test.ts
+```
+
+Expected: pass. If fallback is kept, add an assertion for `canUseWebGL`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/calls-view.tsx src/components/calls-view-graph.test.ts
+git commit -m "refactor(trace-graph): retire legacy graph surface"
+```
+
+---
+
+## Task 7: Final Verification Gate Before PR
+
+**Files:**
+- No edits unless a verification issue appears.
+
+- [ ] **Step 1: Verify all focused tests**
+
+Run:
+
+```bash
+node --test src/lib/coven-calls-types.test.ts src/components/trace-graph-3d-model.test.ts src/components/calls-view-graph.test.ts src/components/agents-view.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Verify TypeScript**
+
+Run:
+
+```bash
+pnpm typecheck
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Verify production build**
+
+Run:
+
+```bash
+pnpm build
+```
+
+Expected: build succeeds. Existing known Turbopack/NFT warnings may appear, but no new trace-graph errors.
+
+- [ ] **Step 4: Verify visual behavior**
+
+Run with dev server active:
+
+```bash
+CAVE_VERIFY_URL=http://127.0.0.1:3000 node scripts/verify-trace-graph-3d.mjs
+```
+
+Expected: desktop and mobile screenshots are created and the script reports pass.
+
+- [ ] **Step 5: Manual UX smoke**
+
+In the browser or Tauri dev app:
+
+```text
+Agents -> Delegations:
+1. Graph canvas is visible and nonblank.
+2. Drag orbits without layout jump.
+3. Scroll zooms smoothly.
+4. Click a node selects an agent and updates the inspector.
+5. Click a route selects an edge and updates the inspector.
+6. Select a trace from the timeline; the matching route focuses/highlights.
+7. Toggle Include inferred; inferred yellow routes appear/disappear.
+8. Focus selected moves the camera to the selected item.
+9. Reset view restores the camera.
+10. With prefers-reduced-motion enabled, route particles stop but direction remains readable through arrowheads.
+```
+
+- [ ] **Step 6: Check diff**
+
+Run:
+
+```bash
+git diff --check
+git status -sb
+git diff --stat origin/main...HEAD
+```
+
+Expected: no whitespace errors; branch only contains trace graph plan/implementation files.
+
+- [ ] **Step 7: Final commit if any verification fixes were needed**
+
+```bash
+git add src/components/trace-graph-3d.tsx src/components/trace-graph-3d-model.ts src/components/trace-graph-3d-model.test.ts src/components/calls-view.tsx src/components/calls-view-graph.test.ts scripts/verify-trace-graph-3d.mjs package.json pnpm-lock.yaml package-lock.json
+git commit -m "fix(trace-graph): address verification findings"
+```
+
+---
+
+## PR Notes
+
+Use this PR description shape:
+
+```md
+## Summary
+- Replaces the delegation SVG graph with a production Three.js 3D trace graph.
+- Adds deterministic scene-model helpers, OrbitControls navigation, directional routes, selection highlighting, dense-graph degradation, keyboard/DOM accessibility, and visual verification.
+- Keeps CallsView filters, inferred/explicit provenance, timeline, and inspector wired to the existing data model.
+
+## Verification
+- node --test src/lib/coven-calls-types.test.ts src/components/trace-graph-3d-model.test.ts src/components/calls-view-graph.test.ts src/components/agents-view.test.ts
+- pnpm typecheck
+- pnpm build
+- CAVE_VERIFY_URL=http://127.0.0.1:3000 node scripts/verify-trace-graph-3d.mjs
+```
+
+## Self-Review
+
+- Spec coverage: covers architecture choice, production renderer behavior, UX usefulness, accessibility, performance, and verification.
+- Placeholder scan: no implementation steps rely on "TBD" or unspecified tests.
+- Type consistency: `TraceGraphSelection`, `edgeKey`, and `DelegationGraph` names match the current branch and planned helper module.
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-06-3d-trace-graph.md`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,14 +23,17 @@
         "react-dom": "19.2.4",
         "react-resizable-panels": "^4.11.2",
         "shiki": "^4.1.0",
+        "three": "^0.184.0",
         "yaml": "^2.9.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4",
         "@tauri-apps/cli": "^2.11.2",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/three": "^0.184.1",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -90,6 +93,13 @@
         "@create-markdown/core": ">=2.0.3",
         "react": ">=18.0.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",
@@ -1185,6 +1195,72 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
@@ -1484,6 +1560,13 @@
         "@tauri-apps/api": "^2.8.0"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -1532,10 +1615,39 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.184.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.1.tgz",
+      "integrity": "sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
@@ -1695,6 +1807,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
@@ -2062,6 +2181,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/micromark-util-character": {
       "version": "2.1.1",
@@ -2527,6 +2653,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -25,14 +25,17 @@
     "react-dom": "19.2.4",
     "react-resizable-panels": "^4.11.2",
     "shiki": "^4.1.0",
+    "three": "^0.184.0",
     "yaml": "^2.9.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4",
     "@tauri-apps/cli": "^2.11.2",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/three": "^0.184.1",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 6.0.0
       next:
         specifier: 16.2.6
-        version: 16.2.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.6(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -53,10 +53,16 @@ importers:
       shiki:
         specifier: ^4.1.0
         version: 4.1.0
+      three:
+        specifier: ^0.184.0
+        version: 0.184.0
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.3.0
@@ -72,6 +78,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.15)
+      '@types/three':
+        specifier: ^0.184.1
+        version: 0.184.1
       tailwindcss:
         specifier: ^4
         version: 4.3.0
@@ -107,6 +116,9 @@ packages:
     peerDependencies:
       '@create-markdown/core': '>=2.0.3'
       react: '>=18.0.0'
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
@@ -326,6 +338,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@shikijs/core@4.1.0':
     resolution: {integrity: sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==}
     engines: {node: '>=20'}
@@ -525,6 +542,9 @@ packages:
   '@tauri-apps/plugin-notification@2.3.3':
     resolution: {integrity: sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==}
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
@@ -542,8 +562,17 @@ packages:
   '@types/react@19.2.15':
     resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.184.1':
+    resolution: {integrity: sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
@@ -597,6 +626,14 @@ packages:
   enhanced-resolve@5.22.1:
     resolution: {integrity: sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==}
     engines: {node: '>=10.13.0'}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -690,6 +727,9 @@ packages:
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
+
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
 
@@ -739,6 +779,16 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -821,6 +871,9 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  three@0.184.0:
+    resolution: {integrity: sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==}
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -879,6 +932,8 @@ snapshots:
     dependencies:
       '@create-markdown/core': 2.0.3
       react: 19.2.4
+
+  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@emnapi/runtime@1.10.0':
     dependencies:
@@ -1037,6 +1092,10 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@shikijs/core@4.1.0':
     dependencies:
@@ -1204,6 +1263,8 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.11.0
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -1224,7 +1285,20 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.184.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.3
+      meshoptimizer: 1.1.1
+
   '@types/unist@3.0.3': {}
+
+  '@types/webxr@0.5.24': {}
 
   '@ungap/structured-clone@1.3.1': {}
 
@@ -1262,6 +1336,11 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  fflate@0.8.3: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   graceful-fs@4.2.11: {}
 
@@ -1352,6 +1431,8 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
 
+  meshoptimizer@1.1.1: {}
+
   micromark-util-character@2.1.1:
     dependencies:
       micromark-util-symbol: 2.0.1
@@ -1371,7 +1452,7 @@ snapshots:
 
   nanoid@3.3.12: {}
 
-  next@16.2.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.6(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -1390,6 +1471,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.6
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
+      '@playwright/test': 1.60.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -1404,6 +1486,14 @@ snapshots:
       regex-recursion: 6.0.2
 
   picocolors@1.1.1: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.4.31:
     dependencies:
@@ -1506,6 +1596,8 @@ snapshots:
   tailwindcss@4.3.0: {}
 
   tapable@2.3.3: {}
+
+  three@0.184.0: {}
 
   trim-lines@3.0.1: {}
 

--- a/scripts/verify-trace-graph-3d.mjs
+++ b/scripts/verify-trace-graph-3d.mjs
@@ -1,0 +1,170 @@
+import { chromium } from "@playwright/test";
+import { mkdir } from "node:fs/promises";
+import { inflateSync } from "node:zlib";
+
+const baseUrl = process.env.CAVE_VERIFY_URL ?? "http://127.0.0.1:3000";
+const outDir = "artifacts/trace-graph-3d";
+
+await mkdir(outDir, { recursive: true });
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1440, height: 950 }, deviceScaleFactor: 1 });
+const browserMessages = [];
+
+page.on("console", (msg) => {
+  if (["error", "warning"].includes(msg.type())) browserMessages.push(`[browser:${msg.type()}] ${msg.text()}`);
+});
+
+await page.route("**/api/coven-calls", async (route) => {
+  await route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({
+      ok: true,
+      calls: [
+        {
+          id: "verify-call-1",
+          callerFamiliarId: "nova",
+          calleeFamiliarId: "cody",
+          request: "Verify 3D trace graph rendering",
+          status: "running",
+          createdAt: new Date().toISOString(),
+          sessionId: "verify-session-cody",
+        },
+        {
+          id: "verify-call-2",
+          callerFamiliarId: "cody",
+          calleeFamiliarId: "sage",
+          request: "Research graph behavior",
+          status: "completed",
+          createdAt: new Date(Date.now() - 60_000).toISOString(),
+          sessionId: "verify-session-sage",
+        },
+      ],
+    }),
+  });
+});
+
+await page.route("**/api/board", async (route) => {
+  await route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({
+      ok: true,
+      cards: [
+        {
+          id: "verify-card-1",
+          title: "Inferred handoff for visual verification",
+          status: "running",
+          lifecycle: "running",
+          familiarId: "sage",
+          sessionId: "verify-session-cody",
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+    }),
+  });
+});
+
+await page.goto(`${baseUrl}/dev/trace-graph-3d`, { waitUntil: "networkidle" });
+
+const canvas = page.getByTestId("trace-graph-3d-canvas");
+await canvas.waitFor({ timeout: 15_000 });
+await page.waitForTimeout(1400);
+
+const box = await canvas.boundingBox();
+if (!box || box.width < 320 || box.height < 320) {
+  throw new Error(`trace graph canvas has invalid bounds: ${JSON.stringify(box)}`);
+}
+
+const canvasPng = await canvas.screenshot();
+const nonBlank = countLitPngPixels(canvasPng) > 120;
+
+if (!nonBlank) throw new Error("trace graph canvas appears blank");
+
+await canvas.click({ position: { x: Math.min(220, box.width - 20), y: Math.min(220, box.height - 20) } });
+await page.keyboard.press("ArrowRight");
+await page.keyboard.press("Enter");
+
+await page.screenshot({ path: `${outDir}/desktop.png`, fullPage: true });
+
+await page.setViewportSize({ width: 390, height: 844 });
+await page.waitForTimeout(500);
+await canvas.waitFor({ timeout: 10_000 });
+await page.screenshot({ path: `${outDir}/mobile.png`, fullPage: true });
+
+await browser.close();
+
+for (const message of browserMessages) console.log(message);
+console.log(`Trace graph visual verification passed: ${outDir}/desktop.png and ${outDir}/mobile.png`);
+
+function countLitPngPixels(buffer) {
+  const signature = buffer.subarray(0, 8).toString("hex");
+  if (signature !== "89504e470d0a1a0a") throw new Error("canvas screenshot is not a PNG");
+
+  let offset = 8;
+  let width = 0;
+  let height = 0;
+  let bitDepth = 0;
+  let colorType = 0;
+  const idat = [];
+
+  while (offset < buffer.length) {
+    const length = buffer.readUInt32BE(offset);
+    const type = buffer.subarray(offset + 4, offset + 8).toString("ascii");
+    const data = buffer.subarray(offset + 8, offset + 8 + length);
+    if (type === "IHDR") {
+      width = data.readUInt32BE(0);
+      height = data.readUInt32BE(4);
+      bitDepth = data[8];
+      colorType = data[9];
+    } else if (type === "IDAT") {
+      idat.push(data);
+    } else if (type === "IEND") {
+      break;
+    }
+    offset += 12 + length;
+  }
+
+  if (bitDepth !== 8 || ![2, 6].includes(colorType)) {
+    throw new Error(`unsupported PNG format: bitDepth=${bitDepth} colorType=${colorType}`);
+  }
+
+  const channels = colorType === 6 ? 4 : 3;
+  const stride = width * channels;
+  const inflated = inflateSync(Buffer.concat(idat));
+  const previous = Buffer.alloc(stride);
+  const current = Buffer.alloc(stride);
+  let src = 0;
+  let lit = 0;
+
+  for (let y = 0; y < height; y++) {
+    const filter = inflated[src++];
+    for (let x = 0; x < stride; x++) {
+      const raw = inflated[src++];
+      const left = x >= channels ? current[x - channels] : 0;
+      const up = previous[x];
+      const upLeft = x >= channels ? previous[x - channels] : 0;
+      if (filter === 0) current[x] = raw;
+      else if (filter === 1) current[x] = (raw + left) & 255;
+      else if (filter === 2) current[x] = (raw + up) & 255;
+      else if (filter === 3) current[x] = (raw + Math.floor((left + up) / 2)) & 255;
+      else if (filter === 4) current[x] = (raw + paeth(left, up, upLeft)) & 255;
+      else throw new Error(`unsupported PNG filter: ${filter}`);
+    }
+    for (let x = 0; x < stride; x += channels) {
+      if (current[x] + current[x + 1] + current[x + 2] > 32) lit++;
+    }
+    current.copy(previous);
+  }
+
+  return lit;
+}
+
+function paeth(a, b, c) {
+  const p = a + b - c;
+  const pa = Math.abs(p - a);
+  const pb = Math.abs(p - b);
+  const pc = Math.abs(p - c);
+  if (pa <= pb && pa <= pc) return a;
+  if (pb <= pc) return b;
+  return c;
+}

--- a/src/app/dev/trace-graph-3d/page.tsx
+++ b/src/app/dev/trace-graph-3d/page.tsx
@@ -1,0 +1,9 @@
+import { notFound } from "next/navigation";
+import { TraceGraph3DSmoke } from "@/components/trace-graph-3d-smoke";
+
+export const dynamic = "force-dynamic";
+
+export default function TraceGraph3DDevPage() {
+  if (process.env.NODE_ENV === "production" && process.env.CAVE_TRACE_GRAPH_SMOKE !== "1") notFound();
+  return <TraceGraph3DSmoke />;
+}

--- a/src/components/agents-view.test.ts
+++ b/src/components/agents-view.test.ts
@@ -14,8 +14,8 @@ assert.match(
 
 assert.match(
   agentsView,
-  /Search sessions\.\.\./,
-  "AgentsView should keep session search in the primary command row",
+  /Search agents\.\.\./,
+  "AgentsView should keep agent search in the primary command row",
 );
 
 assert.match(
@@ -92,7 +92,7 @@ assert.match(
 
 assert.match(
   agentsView,
-  /setScope\("delegations"\)/,
+  /onClick=\{\(\) => setScope\(s\)\}/,
   "AgentsView trace preview should provide a path into the full Delegations graph",
 );
 

--- a/src/components/calls-view-graph.test.ts
+++ b/src/components/calls-view-graph.test.ts
@@ -3,18 +3,8 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const source = await readFile(new URL("./calls-view.tsx", import.meta.url), "utf8");
-
-assert.match(
-  source,
-  /<g key=\{`\$\{edge\.caller\}->\$\{edge\.callee\}->\$\{edge\.source\}`\}/,
-  "Call graph edges should use a stable caller->callee key instead of the array index",
-);
-
-assert.match(
-  source,
-  /useEffect\(\(\) => \{\s*setTooltip\(null\);\s*\}, \[graph\.edges, nodeStats\]\);/,
-  "Call graph should clear hover tooltip state when live call data refreshes",
-);
+const graph3dSource = await readFile(new URL("./trace-graph-3d.tsx", import.meta.url), "utf8");
+const packageJson = await readFile(new URL("../../package.json", import.meta.url), "utf8");
 
 assert.match(
   source,
@@ -30,6 +20,90 @@ assert.match(
 
 assert.match(
   source,
-  /data-edge-source=\{edge\.source\}/,
-  "Graph edges should mark explicit, inferred, or mixed provenance in the DOM",
+  /<TraceGraph3D[\s\S]*graph=\{graph\}/,
+  "Delegations view should render the 3D trace graph as the primary graph surface",
+);
+
+assert.match(
+  graph3dSource,
+  /import \* as THREE from "three"/,
+  "3D trace graph should use Three.js for the graph scene",
+);
+
+assert.match(
+  graph3dSource,
+  /from "three\/addons\/controls\/OrbitControls\.js"/,
+  "3D trace graph should use Three.js OrbitControls instead of custom camera controls",
+);
+
+assert.match(
+  graph3dSource,
+  /data-testid="trace-graph-3d-canvas"/,
+  "3D trace graph should expose a stable canvas test id for visual verification",
+);
+
+assert.match(
+  graph3dSource,
+  /aria-label="3D delegation trace graph"/,
+  "3D trace graph canvas should have an accessible label",
+);
+
+assert.match(
+  graph3dSource,
+  /role="application"/,
+  "3D trace graph should expose an interactive canvas role",
+);
+
+assert.match(
+  graph3dSource,
+  /tabIndex=\{0\}/,
+  "3D trace graph canvas should be keyboard focusable",
+);
+
+assert.match(
+  graph3dSource,
+  /aria-live="polite"/,
+  "3D trace graph should expose a DOM status mirror outside WebGL",
+);
+
+assert.match(
+  graph3dSource,
+  /Focus selected/,
+  "3D trace graph should include a focus control for selected traces",
+);
+
+assert.match(
+  graph3dSource,
+  /Reset view/,
+  "3D trace graph should include a reset view control",
+);
+
+assert.match(
+  graph3dSource,
+  /prefers-reduced-motion/,
+  "3D trace graph should respect reduced motion preferences",
+);
+
+assert.match(
+  graph3dSource,
+  /ConeGeometry/,
+  "3D trace graph should render directional arrowheads for route direction",
+);
+
+assert.match(
+  graph3dSource,
+  /LineDashedMaterial/,
+  "3D trace graph should preserve inferred-route dashed styling",
+);
+
+assert.doesNotMatch(
+  graph3dSource,
+  /selectedKey\]/,
+  "3D trace graph should not rebuild the renderer on every selection change",
+);
+
+assert.match(
+  packageJson,
+  /"three":/,
+  "Cave should declare Three.js as a dependency for the 3D trace graph",
 );

--- a/src/components/calls-view.tsx
+++ b/src/components/calls-view.tsx
@@ -4,9 +4,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
-  type CSSProperties,
 } from "react";
 import type { Card } from "@/lib/cave-board-types";
 import {
@@ -20,6 +18,7 @@ import {
 } from "@/lib/coven-calls-types";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { CovenFloor } from "@/components/coven-floor";
+import { TraceGraph3D } from "@/components/trace-graph-3d";
 import { Icon } from "@/lib/icon";
 
 export type CallsViewTab = "floor" | "delegations";
@@ -40,10 +39,6 @@ type Props = {
 
 type CallsResponse = { ok: true; calls: CovenCall[] } | { ok: false; error?: string };
 type BoardResponse = { ok: true; cards: Card[] } | { ok: false; error?: string };
-type TooltipState =
-  | { kind: "edge"; edge: DelegationGraphEdge; x: number; y: number }
-  | { kind: "node"; node: DelegationGraphNode; x: number; y: number }
-  | null;
 
 const TIME_WINDOWS: Array<{ id: TimeWindow; label: string }> = [
   { id: "24h", label: "24h" },
@@ -99,14 +94,6 @@ function sourceTone(source: DelegationTrace["source"] | "mixed"): string {
   if (source === "explicit") return "border-[#8E3DFF]/30 bg-[#8E3DFF]/15 text-[#c7a7ff]";
   if (source === "inferred") return "border-amber-500/30 bg-amber-500/15 text-amber-200";
   return "border-sky-500/30 bg-sky-500/15 text-sky-200";
-}
-
-function edgeStroke(edge: DelegationGraphEdge): string {
-  if (edge.latestStatus === "failed") return "#f87171";
-  if (edge.hasRunning) return "#62d08f";
-  if (edge.source === "inferred") return "#fbbf24";
-  if (edge.source === "mixed") return "#38bdf8";
-  return "#8E3DFF";
 }
 
 export function CallsView({ familiars, sessions, onOpenSession, initialTab = "floor", embedded = false }: Props) {
@@ -173,6 +160,9 @@ export function CallsView({ familiars, sessions, onOpenSession, initialTab = "fl
     : null;
   const selectedTrace = selection?.kind === "trace"
     ? graph.traces.find((trace) => trace.id === selection.id) ?? null
+    : null;
+  const selectedTraceEdge = selectedTrace
+    ? graph.edges.find((edge) => edge.traces.some((trace) => trace.id === selectedTrace.id)) ?? null
     : null;
 
   const metrics = useMemo(() => ({
@@ -270,13 +260,13 @@ export function CallsView({ familiars, sessions, onOpenSession, initialTab = "fl
 
           <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-hidden px-5 py-4 xl:grid-cols-[minmax(0,1fr)_360px]">
             <section className="flex min-w-0 flex-col gap-3 overflow-hidden">
-              <TraceGraph graph={graph} familiars={famById} selection={selection} onSelect={setSelection} />
+              <TraceGraph3D graph={graph} familiars={famById} selection={selection} onSelect={setSelection} />
               <TraceTimeline traces={graph.traces} familiars={famById} selectedTraceId={selection?.kind === "trace" ? selection.id : null} onSelect={(trace) => setSelection({ kind: "trace", id: trace.id })} />
             </section>
             <TraceInspector
               graph={graph}
               familiars={famById}
-              selectedEdge={selectedEdge}
+              selectedEdge={selectedEdge ?? selectedTraceEdge}
               selectedNode={selectedNode}
               selectedTrace={selectedTrace}
               onOpenSession={onOpenSession}
@@ -293,183 +283,6 @@ function Metric({ label, value, tone }: { label: string; value: number; tone: st
     <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 px-3 py-2">
       <div className="text-[10px] uppercase tracking-widest text-[var(--text-muted)]">{label}</div>
       <div className={`mt-1 text-lg font-semibold tabular-nums ${tone}`}>{value}</div>
-    </div>
-  );
-}
-
-function TraceGraph({
-  graph,
-  familiars,
-  selection,
-  onSelect,
-}: {
-  graph: DelegationGraph;
-  familiars: Map<string, Familiar>;
-  selection: Selection;
-  onSelect: (selection: Selection) => void;
-}) {
-  const [tooltip, setTooltip] = useState<TooltipState>(null);
-  const svgRef = useRef<SVGSVGElement>(null);
-  const nodeStats = useMemo(() => new Map(graph.nodes.map((node) => [node.id, node])), [graph.nodes]);
-  const W = 900;
-  const H = 460;
-  const cx = W / 2;
-  const cy = H / 2;
-  const nodeR = 22;
-  const r = Math.min(W, H) / 2 - 54;
-
-  const positions = useMemo(() => {
-    const map = new Map<string, { x: number; y: number }>();
-    graph.nodes.forEach((node, i) => {
-      const theta = (i / Math.max(graph.nodes.length, 1)) * Math.PI * 2 - Math.PI / 2;
-      map.set(node.id, { x: cx + r * Math.cos(theta), y: cy + r * Math.sin(theta) });
-    });
-    return map;
-  }, [graph.nodes, r]);
-
-  useEffect(() => {
-    setTooltip(null);
-  }, [graph.edges, nodeStats]);
-
-  if (graph.nodes.length === 0) {
-    return (
-      <div className="grid min-h-[360px] flex-1 place-items-center rounded-xl border border-dashed border-[var(--border-hairline)] bg-[var(--bg-raised)]/25 text-sm text-[var(--text-muted)]">
-        No delegation traces in this view.
-      </div>
-    );
-  }
-
-  const svgPoint = (x: number, y: number) => {
-    const box = svgRef.current?.getBoundingClientRect();
-    return box ? { x: (x / W) * box.width, y: (y / H) * box.height } : { x, y };
-  };
-  const maxCount = Math.max(...graph.edges.map((edge) => edge.count), 1);
-
-  return (
-    <div className="relative min-h-[360px] flex-1 overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-raised)]/20">
-      <style>{`@keyframes coven-dash { to { stroke-dashoffset: -24; } } .coven-edge-running { animation: coven-dash 1.5s linear infinite; }`}</style>
-      <svg ref={svgRef} viewBox={`0 0 ${W} ${H}`} className="h-full min-h-[360px] w-full" onMouseLeave={() => setTooltip(null)}>
-        <defs>
-          {[
-            ["explicit", "#8E3DFF"],
-            ["inferred", "#fbbf24"],
-            ["mixed", "#38bdf8"],
-            ["running", "#62d08f"],
-            ["failed", "#f87171"],
-          ].map(([id, color]) => (
-            <marker key={id} id={`coven-arrow-${id}`} markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto" markerUnits="strokeWidth">
-              <polygon points="0 0, 9 4.5, 0 9" fill={color} fillOpacity={0.9} />
-            </marker>
-          ))}
-        </defs>
-
-        {graph.edges.map((edge) => {
-          const a = positions.get(edge.caller);
-          const b = positions.get(edge.callee);
-          if (!a || !b) return null;
-          const dx = b.x - a.x;
-          const dy = b.y - a.y;
-          const len = Math.sqrt(dx * dx + dy * dy) || 1;
-          const ux = dx / len;
-          const uy = dy / len;
-          const x1 = a.x + ux * (nodeR + 4);
-          const y1 = a.y + uy * (nodeR + 4);
-          const x2 = b.x - ux * (nodeR + 6);
-          const y2 = b.y - uy * (nodeR + 6);
-          const reciprocal = graph.edges.some((other) => other.caller === edge.callee && other.callee === edge.caller);
-          const curve = reciprocal ? (edge.caller < edge.callee ? 46 : -46) : 18;
-          const mx = (x1 + x2) / 2 - uy * curve;
-          const my = (y1 + y2) / 2 + ux * curve;
-          const pathD = `M ${x1} ${y1} Q ${mx} ${my} ${x2} ${y2}`;
-          const selected = selection?.kind === "edge" && selection.key === edgeKey(edge);
-          const strokeW = 1.5 + (edge.count / maxCount) * 4;
-          const marker = edge.latestStatus === "failed"
-            ? "url(#coven-arrow-failed)"
-            : edge.hasRunning
-            ? "url(#coven-arrow-running)"
-            : `url(#coven-arrow-${edge.source})`;
-          const tip = svgPoint(mx, my);
-          return (
-            <g key={`${edge.caller}->${edge.callee}->${edge.source}`} data-edge-source={edge.source}>
-              <path
-                d={pathD}
-                stroke="transparent"
-                strokeWidth={Math.max(strokeW + 12, 16)}
-                fill="none"
-                className="cursor-pointer"
-                onClick={() => onSelect({ kind: "edge", key: edgeKey(edge) })}
-                onMouseEnter={() => setTooltip({ kind: "edge", edge, x: tip.x, y: tip.y })}
-                onMouseLeave={() => setTooltip(null)}
-              />
-              <path
-                d={pathD}
-                stroke={edgeStroke(edge)}
-                strokeOpacity={selected ? 1 : edge.source === "inferred" ? 0.58 : 0.76}
-                strokeWidth={selected ? strokeW + 1.5 : strokeW}
-                strokeLinecap="round"
-                fill="none"
-                markerEnd={marker}
-                strokeDasharray={edge.source === "inferred" ? "7 6" : edge.hasRunning ? "9 5" : undefined}
-                className={edge.hasRunning ? "coven-edge-running" : undefined}
-                style={{ pointerEvents: "none" }}
-              />
-              {edge.count > 1 ? (
-                <g style={{ pointerEvents: "none" }}>
-                  <circle cx={mx} cy={my - 8} r="10" fill="var(--bg-base)" stroke="var(--border-hairline)" />
-                  <text x={mx} y={my - 4} textAnchor="middle" fontSize="10" fill="var(--text-secondary)" fontWeight="600">{edge.count}</text>
-                </g>
-              ) : null}
-            </g>
-          );
-        })}
-
-        {graph.nodes.map((node) => {
-          const p = positions.get(node.id)!;
-          const f = familiars.get(node.id);
-          const glyph = f?.emoji ?? f?.display_name?.slice(0, 1).toUpperCase() ?? node.id.slice(0, 1).toUpperCase();
-          const selected = selection?.kind === "node" && selection.id === node.id;
-          const ring = node.hasRunningReceived ? "#62d08f" : node.latestReceivedFailed ? "#f87171" : "#8E3DFF";
-          const tip = svgPoint(p.x, p.y + nodeR);
-          return (
-            <g
-              key={node.id}
-              className="cursor-pointer"
-              onClick={() => onSelect({ kind: "node", id: node.id })}
-              onMouseEnter={() => setTooltip({ kind: "node", node, x: tip.x, y: tip.y })}
-              onMouseLeave={() => setTooltip(null)}
-            >
-              <circle cx={p.x} cy={p.y} r={selected ? nodeR + 4 : nodeR} fill="var(--bg-raised)" stroke={ring} strokeWidth={selected ? 3 : 2} strokeOpacity={selected ? 1 : 0.82} />
-              <text x={p.x} y={p.y + 5} textAnchor="middle" fontSize="14" fontWeight="650" fill="var(--text-primary)" style={{ pointerEvents: "none", userSelect: "none" }}>{glyph}</text>
-              <text x={p.x} y={p.y + 39} textAnchor="middle" fontSize="10" fill="var(--text-secondary)" style={{ pointerEvents: "none" }}>{familiarName(familiars, node.id)}</text>
-            </g>
-          );
-        })}
-      </svg>
-      {tooltip ? <GraphTooltip tooltip={tooltip} familiars={familiars} /> : null}
-    </div>
-  );
-}
-
-function GraphTooltip({ tooltip, familiars }: { tooltip: NonNullable<TooltipState>; familiars: Map<string, Familiar> }) {
-  const style: CSSProperties = { position: "absolute", left: tooltip.x + 8, top: tooltip.y + 8, maxWidth: 250, zIndex: 50, pointerEvents: "none" };
-  if (tooltip.kind === "edge") {
-    const edge = tooltip.edge;
-    return (
-      <div style={style} className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-2 text-[11px] shadow-xl">
-        <div className="font-medium text-[var(--text-primary)]">{familiarName(familiars, edge.caller)} -&gt; {familiarName(familiars, edge.callee)}</div>
-        <div className="mt-1 flex flex-wrap gap-1">
-          <span className={`rounded-full border px-1.5 py-0.5 ${sourceTone(edge.source)}`}>{edge.source}</span>
-          <span className={`rounded-full border px-1.5 py-0.5 ${statusTone(edge.latestStatus)}`}>{edge.latestStatus}</span>
-        </div>
-        <div className="mt-1 text-[var(--text-muted)]">{edge.count} trace{edge.count === 1 ? "" : "s"} · {shortTime(edge.lastSeenAt)}</div>
-      </div>
-    );
-  }
-  return (
-    <div style={style} className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-2 text-[11px] shadow-xl">
-      <div className="font-medium text-[var(--text-primary)]">{familiarName(familiars, tooltip.node.id)}</div>
-      <div className="mt-0.5 text-[var(--text-secondary)]">{tooltip.node.sentCount} sent · {tooltip.node.receivedCount} received</div>
-      <div className="mt-0.5 text-[var(--text-muted)]">{tooltip.node.sentInferredCount + tooltip.node.receivedInferredCount} inferred</div>
     </div>
   );
 }

--- a/src/components/trace-graph-3d-model.test.ts
+++ b/src/components/trace-graph-3d-model.test.ts
@@ -1,0 +1,51 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  buildTraceGraphSceneModel,
+  edgeKey,
+  renderPolicyForGraph,
+  selectionObjectKey,
+  traceGraphColor,
+} from "./trace-graph-3d-model.ts";
+
+const graph = {
+  nodes: [
+    { id: "nova", sentCount: 2, receivedCount: 1, sentExplicitCount: 2, receivedExplicitCount: 1, sentInferredCount: 0, receivedInferredCount: 0, hasRunningReceived: false, latestReceivedFailed: false, lastSeenAt: "2026-06-06T12:00:00.000Z" },
+    { id: "cody", sentCount: 1, receivedCount: 2, sentExplicitCount: 1, receivedExplicitCount: 2, sentInferredCount: 0, receivedInferredCount: 0, hasRunningReceived: true, latestReceivedFailed: false, lastSeenAt: "2026-06-06T12:01:00.000Z" },
+    { id: "sage", sentCount: 0, receivedCount: 1, sentExplicitCount: 0, receivedExplicitCount: 0, sentInferredCount: 0, receivedInferredCount: 1, hasRunningReceived: false, latestReceivedFailed: true, lastSeenAt: "2026-06-06T12:02:00.000Z" },
+  ],
+  edges: [
+    { caller: "nova", callee: "cody", count: 2, explicitCount: 2, inferredCount: 0, source: "explicit", mostRecentRequest: "Build graph", hasRunning: true, latestStatus: "running", lastSeenAt: "2026-06-06T12:01:00.000Z", traces: [{ id: "trace-1" }] },
+    { caller: "cody", callee: "nova", count: 1, explicitCount: 1, inferredCount: 0, source: "explicit", mostRecentRequest: "Review", hasRunning: false, latestStatus: "completed", lastSeenAt: "2026-06-06T12:00:30.000Z", traces: [] },
+    { caller: "cody", callee: "sage", count: 1, explicitCount: 0, inferredCount: 1, source: "inferred", mostRecentRequest: "Research", hasRunning: false, latestStatus: "failed", lastSeenAt: "2026-06-06T12:02:00.000Z", traces: [] },
+  ],
+  traces: [{ id: "trace-1" }],
+};
+
+const model = buildTraceGraphSceneModel(graph, new Map([
+  ["nova", "Nova"],
+  ["cody", "Cody"],
+  ["sage", "Sage"],
+]));
+
+assert.equal(model.nodes.length, 3);
+assert.equal(model.edges.length, 3);
+assert.equal(model.nodes[0].label, "Nova");
+assert.equal(edgeKey(graph.edges[0]), "nova->cody->explicit");
+assert.notDeepEqual(model.nodes[0].position, model.nodes[1].position);
+assert.equal(selectionObjectKey({ kind: "trace", id: "trace-1" }, graph), "edge:nova->cody->explicit");
+
+assert.equal(traceGraphColor(graph.edges[0]), "#62d08f");
+assert.equal(traceGraphColor(graph.edges[2]), "#f87171");
+assert.equal(renderPolicyForGraph({ nodeCount: 12, edgeCount: 24 }).detail, "full");
+
+const densePolicy = renderPolicyForGraph({ nodeCount: 70, edgeCount: 160 });
+assert.equal(densePolicy.detail, "reduced");
+assert.equal(densePolicy.animateParticles, false);
+assert.equal(densePolicy.showLabels, true);
+
+const extremePolicy = renderPolicyForGraph({ nodeCount: 130, edgeCount: 500 });
+assert.equal(extremePolicy.detail, "summary");
+assert.equal(extremePolicy.animateParticles, false);
+assert.equal(extremePolicy.showLabels, false);
+assert.equal(extremePolicy.maxRenderedEdges, 180);

--- a/src/components/trace-graph-3d-model.ts
+++ b/src/components/trace-graph-3d-model.ts
@@ -1,0 +1,138 @@
+import type {
+  DelegationGraph,
+  DelegationGraphEdge,
+  DelegationGraphNode,
+} from "@/lib/coven-calls-types";
+
+export type TraceGraphSelection =
+  | { kind: "edge"; key: string }
+  | { kind: "node"; id: string }
+  | { kind: "trace"; id: string }
+  | null;
+
+export type ScenePosition = { x: number; y: number; z: number };
+
+export type TraceSceneNode = DelegationGraphNode & {
+  label: string;
+  position: ScenePosition;
+};
+
+export type TraceSceneEdge = DelegationGraphEdge & {
+  key: string;
+  from: ScenePosition;
+  to: ScenePosition;
+  control: ScenePosition;
+  color: string;
+};
+
+export type TraceRenderPolicy = {
+  detail: "full" | "reduced" | "summary";
+  animateParticles: boolean;
+  showLabels: boolean;
+  maxRenderedEdges: number;
+};
+
+export type TraceGraphSceneModel = {
+  nodes: TraceSceneNode[];
+  edges: TraceSceneEdge[];
+  policy: TraceRenderPolicy;
+};
+
+export function edgeKey(edge: Pick<DelegationGraphEdge, "caller" | "callee" | "source">): string {
+  return `${edge.caller}->${edge.callee}->${edge.source}`;
+}
+
+export function traceGraphColor(edge: Pick<DelegationGraphEdge, "source" | "latestStatus" | "hasRunning">): string {
+  if (edge.latestStatus === "failed") return "#f87171";
+  if (edge.hasRunning) return "#62d08f";
+  if (edge.source === "inferred") return "#fbbf24";
+  if (edge.source === "mixed") return "#38bdf8";
+  return "#8E3DFF";
+}
+
+export function nodeStatusColor(node: Pick<DelegationGraphNode, "hasRunningReceived" | "latestReceivedFailed">): string {
+  if (node.latestReceivedFailed) return "#f87171";
+  if (node.hasRunningReceived) return "#62d08f";
+  return "#8E3DFF";
+}
+
+export function renderPolicyForGraph({
+  nodeCount,
+  edgeCount,
+}: {
+  nodeCount: number;
+  edgeCount: number;
+}): TraceRenderPolicy {
+  if (nodeCount > 120 || edgeCount > 360) {
+    return { detail: "summary", animateParticles: false, showLabels: false, maxRenderedEdges: 180 };
+  }
+  if (nodeCount > 48 || edgeCount > 140) {
+    return { detail: "reduced", animateParticles: false, showLabels: true, maxRenderedEdges: 140 };
+  }
+  return { detail: "full", animateParticles: true, showLabels: true, maxRenderedEdges: 140 };
+}
+
+function pos(x: number, y: number, z: number): ScenePosition {
+  return { x, y, z };
+}
+
+export function buildTraceGraphSceneModel(
+  graph: DelegationGraph,
+  labels: Map<string, string>,
+): TraceGraphSceneModel {
+  const policy = renderPolicyForGraph({ nodeCount: graph.nodes.length, edgeCount: graph.edges.length });
+  const count = Math.max(graph.nodes.length, 1);
+  const radius = graph.nodes.length <= 2 ? 3.8 : Math.max(4.2, Math.min(8.4, 3.8 + count * 0.36));
+
+  const nodes = graph.nodes.map((node, index): TraceSceneNode => {
+    const angle = graph.nodes.length === 1 ? -Math.PI / 2 : (index / count) * Math.PI * 2 - Math.PI / 2;
+    const lane = graph.nodes.length <= 2 ? 0 : (index % 3) - 1;
+    const activity = node.sentCount + node.receivedCount;
+    const lift = lane * 1.25 + Math.sin(index * 1.7) * 0.35;
+    const scale = 1 + Math.min(activity, 10) * 0.018;
+    return {
+      ...node,
+      label: labels.get(node.id) ?? node.id,
+      position: pos(Math.cos(angle) * radius * scale, lift, Math.sin(angle) * radius * scale),
+    };
+  });
+
+  const byId = new Map(nodes.map((node) => [node.id, node]));
+  const visibleEdges = [...graph.edges]
+    .sort((a, b) => b.count - a.count || b.lastSeenAt.localeCompare(a.lastSeenAt))
+    .slice(0, policy.maxRenderedEdges);
+
+  const edges = visibleEdges.flatMap((edge, index): TraceSceneEdge[] => {
+    const caller = byId.get(edge.caller);
+    const callee = byId.get(edge.callee);
+    if (!caller || !callee) return [];
+    const from = caller.position;
+    const to = callee.position;
+    const reciprocal = graph.edges.some((other) => other.caller === edge.callee && other.callee === edge.caller);
+    const midpoint = pos((from.x + to.x) / 2, (from.y + to.y) / 2, (from.z + to.z) / 2);
+    const reciprocalOffset = reciprocal ? (edge.caller < edge.callee ? 0.8 : -0.8) : 0;
+    const control = pos(
+      midpoint.x * 1.08 + reciprocalOffset,
+      midpoint.y + 1.25 + Math.min(edge.count, 6) * 0.22 + (index % 2) * 0.35,
+      midpoint.z * 1.08 - reciprocalOffset,
+    );
+    return [{
+      ...edge,
+      key: edgeKey(edge),
+      from,
+      to,
+      control,
+      color: traceGraphColor(edge),
+    }];
+  });
+
+  return { nodes, edges, policy };
+}
+
+export function selectionObjectKey(selection: TraceGraphSelection, graph: DelegationGraph): string | null {
+  if (!selection) return null;
+  if (selection.kind === "node") return `node:${selection.id}`;
+  if (selection.kind === "edge") return `edge:${selection.key}`;
+  const edge = graph.edges.find((candidate) => candidate.traces.some((trace) => trace.id === selection.id));
+  return edge ? `edge:${edgeKey(edge)}` : null;
+}

--- a/src/components/trace-graph-3d-smoke.tsx
+++ b/src/components/trace-graph-3d-smoke.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState } from "react";
+import { TraceGraph3D } from "@/components/trace-graph-3d";
+import type { DelegationGraph } from "@/lib/coven-calls-types";
+import type { Familiar } from "@/lib/types";
+import type { TraceGraphSelection } from "@/components/trace-graph-3d-model";
+
+const now = new Date().toISOString();
+
+const graph: DelegationGraph = {
+  nodes: [
+    {
+      id: "nova",
+      sentCount: 2,
+      receivedCount: 1,
+      sentExplicitCount: 2,
+      receivedExplicitCount: 1,
+      sentInferredCount: 0,
+      receivedInferredCount: 0,
+      hasRunningReceived: false,
+      latestReceivedFailed: false,
+      lastSeenAt: now,
+    },
+    {
+      id: "cody",
+      sentCount: 1,
+      receivedCount: 2,
+      sentExplicitCount: 1,
+      receivedExplicitCount: 1,
+      sentInferredCount: 0,
+      receivedInferredCount: 1,
+      hasRunningReceived: true,
+      latestReceivedFailed: false,
+      lastSeenAt: now,
+    },
+    {
+      id: "sage",
+      sentCount: 0,
+      receivedCount: 1,
+      sentExplicitCount: 0,
+      receivedExplicitCount: 0,
+      sentInferredCount: 0,
+      receivedInferredCount: 1,
+      hasRunningReceived: false,
+      latestReceivedFailed: true,
+      lastSeenAt: now,
+    },
+  ],
+  edges: [
+    {
+      caller: "nova",
+      callee: "cody",
+      count: 2,
+      explicitCount: 2,
+      inferredCount: 0,
+      source: "explicit",
+      mostRecentRequest: "Build the 3D trace graph",
+      hasRunning: true,
+      latestStatus: "running",
+      lastSeenAt: now,
+      traces: [
+        {
+          id: "smoke-trace-1",
+          callerFamiliarId: "nova",
+          calleeFamiliarId: "cody",
+          request: "Build the 3D trace graph",
+          status: "running",
+          createdAt: now,
+          source: "explicit",
+          sessionId: "smoke-session-cody",
+        },
+      ],
+    },
+    {
+      caller: "cody",
+      callee: "sage",
+      count: 1,
+      explicitCount: 0,
+      inferredCount: 1,
+      source: "inferred",
+      mostRecentRequest: "Research graph behavior",
+      hasRunning: false,
+      latestStatus: "failed",
+      lastSeenAt: now,
+      traces: [
+        {
+          id: "smoke-trace-2",
+          callerFamiliarId: "cody",
+          calleeFamiliarId: "sage",
+          request: "Research graph behavior",
+          status: "failed",
+          createdAt: now,
+          source: "inferred",
+          inferenceReason: "Fixture trace for canvas verification.",
+        },
+      ],
+    },
+  ],
+  traces: [
+    {
+      id: "smoke-trace-1",
+      callerFamiliarId: "nova",
+      calleeFamiliarId: "cody",
+      request: "Build the 3D trace graph",
+      status: "running",
+      createdAt: now,
+      source: "explicit",
+      sessionId: "smoke-session-cody",
+    },
+    {
+      id: "smoke-trace-2",
+      callerFamiliarId: "cody",
+      calleeFamiliarId: "sage",
+      request: "Research graph behavior",
+      status: "failed",
+      createdAt: now,
+      source: "inferred",
+      inferenceReason: "Fixture trace for canvas verification.",
+    },
+  ],
+};
+
+const familiars = new Map<string, Familiar>([
+  ["nova", { id: "nova", display_name: "Nova", role: "Guide", emoji: "N" }],
+  ["cody", { id: "cody", display_name: "Cody", role: "Builder", emoji: "C" }],
+  ["sage", { id: "sage", display_name: "Sage", role: "Researcher", emoji: "S" }],
+]);
+
+export function TraceGraph3DSmoke() {
+  const [selection, setSelection] = useState<TraceGraphSelection>(null);
+  return (
+    <main className="h-screen w-screen bg-[var(--bg-base)] p-6 text-[var(--text-primary)]">
+      <div className="h-full overflow-hidden border border-[var(--border-hairline)]">
+        <TraceGraph3D graph={graph} familiars={familiars} selection={selection} onSelect={setSelection} />
+      </div>
+    </main>
+  );
+}

--- a/src/components/trace-graph-3d.tsx
+++ b/src/components/trace-graph-3d.tsx
@@ -1,0 +1,626 @@
+"use client";
+
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+import * as THREE from "three";
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+import type {
+  DelegationGraph,
+  DelegationGraphEdge,
+  DelegationGraphNode,
+} from "@/lib/coven-calls-types";
+import type { Familiar } from "@/lib/types";
+import { Icon } from "@/lib/icon";
+import {
+  buildTraceGraphSceneModel,
+  edgeKey,
+  nodeStatusColor,
+  selectionObjectKey,
+  type TraceGraphSelection,
+} from "@/components/trace-graph-3d-model";
+
+type Props = {
+  graph: DelegationGraph;
+  familiars: Map<string, Familiar>;
+  selection: TraceGraphSelection;
+  onSelect: (selection: TraceGraphSelection) => void;
+};
+
+type Pickable = THREE.Object3D & {
+  userData: {
+    baseOpacity?: number;
+    selection?: TraceGraphSelection;
+    edge?: DelegationGraphEdge;
+    node?: DelegationGraphNode;
+  };
+};
+
+type GraphHover =
+  | { kind: "edge"; key: string; x: number; y: number }
+  | { kind: "node"; id: string; x: number; y: number }
+  | null;
+
+const EDGE_COLORS: Record<DelegationGraphEdge["source"] | "running" | "failed", number> = {
+  explicit: 0x8e3dff,
+  inferred: 0xfbbf24,
+  mixed: 0x38bdf8,
+  running: 0x62d08f,
+  failed: 0xf87171,
+};
+
+function familiarName(familiars: Map<string, Familiar>, id: string): string {
+  return familiars.get(id)?.display_name ?? id;
+}
+
+function edgeColor(edge: DelegationGraphEdge): number {
+  if (edge.latestStatus === "failed") return EDGE_COLORS.failed;
+  if (edge.hasRunning) return EDGE_COLORS.running;
+  return EDGE_COLORS[edge.source];
+}
+
+function selectionEquals(a: TraceGraphSelection, b: TraceGraphSelection): boolean {
+  if (!a || !b) return a === b;
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "node" && b.kind === "node") return a.id === b.id;
+  if (a.kind === "edge" && b.kind === "edge") return a.key === b.key;
+  if (a.kind === "trace" && b.kind === "trace") return a.id === b.id;
+  return false;
+}
+
+function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReduced(media.matches);
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, []);
+  return reduced;
+}
+
+function makeLabelSprite(text: string, color: string): THREE.Sprite {
+  const canvas = document.createElement("canvas");
+  const context = canvas.getContext("2d");
+  canvas.width = 384;
+  canvas.height = 96;
+  if (context) {
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    context.fillStyle = "rgba(12, 12, 15, 0.70)";
+    context.strokeStyle = "rgba(255, 255, 255, 0.14)";
+    roundRect(context, 10, 18, 364, 54, 16);
+    context.fill();
+    context.stroke();
+    context.font = "600 26px system-ui, -apple-system, BlinkMacSystemFont, sans-serif";
+    context.fillStyle = color;
+    context.textAlign = "center";
+    context.textBaseline = "middle";
+    context.fillText(text.slice(0, 24), canvas.width / 2, 45);
+  }
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  const material = new THREE.SpriteMaterial({ map: texture, transparent: true, depthWrite: false });
+  const sprite = new THREE.Sprite(material);
+  sprite.scale.set(2.8, 0.7, 1);
+  return sprite;
+}
+
+function roundRect(context: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number) {
+  context.beginPath();
+  context.moveTo(x + r, y);
+  context.arcTo(x + w, y, x + w, y + h, r);
+  context.arcTo(x + w, y + h, x, y + h, r);
+  context.arcTo(x, y + h, x, y, r);
+  context.arcTo(x, y, x + w, y, r);
+  context.closePath();
+}
+
+function disposeObject(object: THREE.Object3D) {
+  const geometries = new Set<THREE.BufferGeometry>();
+  const materials = new Set<THREE.Material>();
+  object.traverse((child) => {
+    const mesh = child as THREE.Mesh | THREE.Line | THREE.Sprite;
+    const geometry = (mesh as THREE.Mesh).geometry;
+    if (geometry) geometries.add(geometry);
+    const material = mesh.material;
+    if (Array.isArray(material)) material.forEach((m) => materials.add(m));
+    else if (material) materials.add(material);
+  });
+  geometries.forEach((geometry) => geometry.dispose());
+  materials.forEach((material) => material.dispose());
+}
+
+function asVector(position: { x: number; y: number; z: number }): THREE.Vector3 {
+  return new THREE.Vector3(position.x, position.y, position.z);
+}
+
+function materialList(object: THREE.Object3D): THREE.Material[] {
+  const material = (object as THREE.Mesh | THREE.Line | THREE.Sprite).material;
+  if (!material) return [];
+  return Array.isArray(material) ? material : [material];
+}
+
+export function TraceGraph3D({ graph, familiars, selection, onSelect }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const shellRef = useRef<HTMLDivElement | null>(null);
+  const objectBySelectionRef = useRef(new Map<string, THREE.Object3D[]>());
+  const latestSelectionRef = useRef<TraceGraphSelection>(selection);
+  const focusRef = useRef<(() => void) | null>(null);
+  const resetRef = useRef<(() => void) | null>(null);
+  const [hover, setHover] = useState<GraphHover>(null);
+  const reducedMotion = useReducedMotion();
+  const labels = useMemo(() => new Map(Array.from(familiars, ([id, familiar]) => [id, familiar.display_name ?? id])), [familiars]);
+  const sceneModel = useMemo(() => buildTraceGraphSceneModel(graph, labels), [graph, labels]);
+  const selectedObjectKey = selectionObjectKey(selection, graph);
+
+  useEffect(() => {
+    latestSelectionRef.current = selection;
+  }, [selection]);
+
+  useEffect(() => {
+    const activeKey = selectionObjectKey(selection, graph);
+    for (const [key, objects] of objectBySelectionRef.current) {
+      const selected = key === activeKey;
+      for (const object of objects) {
+        object.userData.selected = selected;
+        for (const material of materialList(object)) {
+          if ("opacity" in material) {
+            material.transparent = true;
+            material.opacity = selected ? 1 : object.userData.baseOpacity ?? material.opacity;
+          }
+          if ("emissiveIntensity" in material) {
+            (material as THREE.MeshStandardMaterial).emissiveIntensity = selected ? 0.74 : object.userData.active ? 0.32 : 0.16;
+          }
+        }
+      }
+    }
+  }, [graph, selection]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const shell = shellRef.current;
+    if (!canvas || !shell || sceneModel.nodes.length === 0) return;
+    canvas.dataset.effectStarted = "true";
+
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
+    canvas.dataset.rendererReady = "true";
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+
+    const scene = new THREE.Scene();
+    scene.fog = new THREE.FogExp2(0x06060a, 0.045);
+    const camera = new THREE.PerspectiveCamera(48, 1, 0.1, 90);
+    camera.position.set(0, 5.5, sceneModel.nodes.length <= 2 ? 9.5 : 13.5);
+    camera.lookAt(0, 0, 0);
+
+    const controls = new OrbitControls(camera, canvas);
+    controls.enableDamping = true;
+    controls.dampingFactor = 0.08;
+    controls.enablePan = true;
+    controls.minDistance = 5.8;
+    controls.maxDistance = 22;
+    controls.target.set(0, 0, 0);
+    controls.saveState();
+
+    const root = new THREE.Group();
+    root.rotation.x = -0.22;
+    scene.add(root);
+    scene.add(new THREE.AmbientLight(0xffffff, 1.1));
+    const key = new THREE.DirectionalLight(0xd9c7ff, 2.6);
+    key.position.set(3, 8, 8);
+    scene.add(key);
+    const fill = new THREE.PointLight(0x62d08f, 18, 22);
+    fill.position.set(-7, 3, 4);
+    scene.add(fill);
+
+    const pickables: Pickable[] = [];
+    const particles: Array<{ mesh: THREE.Mesh; arc: THREE.QuadraticBezierCurve3; offset: number; speed: number }> = [];
+    const selectionMap = new Map<string, THREE.Object3D[]>();
+    objectBySelectionRef.current = selectionMap;
+    const maxEdgeCount = Math.max(...sceneModel.edges.map((edge) => edge.count), 1);
+
+    const registerSelectable = (key: string, object: THREE.Object3D, baseOpacity?: number) => {
+      object.userData.baseOpacity = baseOpacity;
+      const objects = selectionMap.get(key) ?? [];
+      objects.push(object);
+      selectionMap.set(key, objects);
+    };
+
+    const grid = new THREE.GridHelper(16, 16, 0x2f2440, 0x15151f);
+    grid.position.y = -2.45;
+    root.add(grid);
+
+    const particleGeometry = new THREE.SphereGeometry(0.085, 12, 12);
+    const particleMaterials = new Map<number, THREE.MeshBasicMaterial>();
+    const particleMaterialFor = (color: number) => {
+      const existing = particleMaterials.get(color);
+      if (existing) return existing;
+      const material = new THREE.MeshBasicMaterial({ color });
+      particleMaterials.set(color, material);
+      return material;
+    };
+
+    for (const edge of sceneModel.edges) {
+      const color = edgeColor(edge);
+      const arc = new THREE.QuadraticBezierCurve3(asVector(edge.from), asVector(edge.control), asVector(edge.to));
+      const points = arc.getPoints(64);
+      const geometry = new THREE.BufferGeometry().setFromPoints(points);
+      const baseOpacity = edge.source === "inferred" ? 0.58 : 0.82;
+      const material = edge.source === "inferred"
+        ? new THREE.LineDashedMaterial({ color, dashSize: 0.32, gapSize: 0.18, transparent: true, opacity: baseOpacity })
+        : new THREE.LineBasicMaterial({ color, transparent: true, opacity: baseOpacity });
+      const line = new THREE.Line(geometry, material);
+      if (line instanceof THREE.Line && "computeLineDistances" in line) line.computeLineDistances();
+      line.userData.selection = { kind: "edge", key: edge.key };
+      line.userData.edge = edge;
+      root.add(line);
+      pickables.push(line as Pickable);
+      registerSelectable(`edge:${edge.key}`, line, baseOpacity);
+
+      const hitGeometry = new THREE.TubeGeometry(arc, 24, 0.08 + (edge.count / maxEdgeCount) * 0.05, 6, false);
+      const hitMaterial = new THREE.MeshBasicMaterial({ transparent: true, opacity: 0, depthWrite: false });
+      const hit = new THREE.Mesh(hitGeometry, hitMaterial);
+      hit.userData.selection = { kind: "edge", key: edge.key };
+      hit.userData.edge = edge;
+      root.add(hit);
+      pickables.push(hit as Pickable);
+
+      const arrowT = 0.82;
+      const arrowPosition = arc.getPoint(arrowT);
+      const arrowTangent = arc.getTangent(arrowT).normalize();
+      const arrow = new THREE.Mesh(
+        new THREE.ConeGeometry(0.14 + Math.min(edge.count, 6) * 0.01, 0.36, 16),
+        new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.9 }),
+      );
+      arrow.position.copy(arrowPosition);
+      arrow.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), arrowTangent);
+      root.add(arrow);
+      registerSelectable(`edge:${edge.key}`, arrow, 0.9);
+
+      if (sceneModel.policy.animateParticles) {
+        const particle = new THREE.Mesh(particleGeometry, particleMaterialFor(color));
+        particle.position.copy(arc.getPoint(0.2));
+        root.add(particle);
+        registerSelectable(`edge:${edge.key}`, particle, 1);
+        particles.push({
+          mesh: particle,
+          arc,
+          offset: Math.random(),
+          speed: edge.hasRunning ? 0.36 : 0.18,
+        });
+      }
+    }
+
+    for (const node of sceneModel.nodes) {
+      const active = node.hasRunningReceived || node.latestReceivedFailed;
+      const color = Number.parseInt(nodeStatusColor(node).slice(1), 16);
+      const size = 0.34 + Math.min(node.sentCount + node.receivedCount, 10) * 0.025;
+      const geometry = new THREE.SphereGeometry(size, 32, 24);
+      const material = new THREE.MeshStandardMaterial({
+        color: 0x17131f,
+        emissive: color,
+        emissiveIntensity: active ? 0.32 : 0.16,
+        roughness: 0.42,
+        metalness: 0.15,
+      });
+      const mesh = new THREE.Mesh(geometry, material);
+      mesh.position.copy(asVector(node.position));
+      mesh.userData.selection = { kind: "node", id: node.id };
+      mesh.userData.node = node;
+      mesh.userData.active = active;
+      root.add(mesh);
+      pickables.push(mesh as Pickable);
+      registerSelectable(`node:${node.id}`, mesh);
+
+      const halo = new THREE.Mesh(
+        new THREE.RingGeometry(size + 0.08, size + 0.13, 48),
+        new THREE.MeshBasicMaterial({ color, transparent: true, opacity: active ? 0.5 : 0.28, side: THREE.DoubleSide }),
+      );
+      halo.position.copy(asVector(node.position));
+      halo.userData.billboard = true;
+      root.add(halo);
+      registerSelectable(`node:${node.id}`, halo, active ? 0.5 : 0.28);
+
+      if (sceneModel.policy.showLabels) {
+        const label = makeLabelSprite(node.label, active ? "#ffffff" : "#c9c0d8");
+        label.position.copy(asVector(node.position).add(new THREE.Vector3(0, size + 0.48, 0)));
+        root.add(label);
+        registerSelectable(`node:${node.id}`, label, 1);
+      }
+    }
+
+    const resize = () => {
+      const box = shell.getBoundingClientRect();
+      const width = Math.max(320, Math.floor(box.width));
+      const height = Math.max(360, Math.floor(box.height));
+      renderer.setSize(width, height, false);
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+    };
+    const observer = new ResizeObserver(resize);
+    observer.observe(shell);
+    resize();
+
+    let visible = true;
+    const visibilityObserver = new IntersectionObserver(([entry]) => {
+      visible = entry?.isIntersecting ?? true;
+    });
+    visibilityObserver.observe(shell);
+
+    const raycaster = new THREE.Raycaster();
+    const pointer = new THREE.Vector2();
+    const drag = { active: false, moved: false, x: 0, y: 0 };
+    const setPointer = (event: PointerEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+      pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+    };
+
+    const resetView = () => {
+      controls.reset();
+      root.rotation.set(-0.22, 0, 0);
+      camera.position.set(0, 5.5, sceneModel.nodes.length <= 2 ? 9.5 : 13.5);
+      camera.lookAt(0, 0, 0);
+    };
+    resetRef.current = resetView;
+    focusRef.current = () => {
+      const selectionKey = selectionObjectKey(latestSelectionRef.current, graph);
+      if (!selectionKey) return resetView();
+      const selectedNode = selectionKey.startsWith("node:")
+        ? sceneModel.nodes.find((node) => `node:${node.id}` === selectionKey)
+        : null;
+      const selectedEdge = selectionKey.startsWith("edge:")
+        ? sceneModel.edges.find((edge) => `edge:${edge.key}` === selectionKey)
+        : null;
+      const target = selectedNode ? asVector(selectedNode.position) : selectedEdge ? new THREE.QuadraticBezierCurve3(asVector(selectedEdge.from), asVector(selectedEdge.control), asVector(selectedEdge.to)).getPoint(0.5) : new THREE.Vector3(0, 0, 0);
+      controls.target.copy(target);
+      camera.position.copy(target.clone().add(new THREE.Vector3(0, 3.2, 7.5)));
+      camera.lookAt(target);
+      controls.update();
+    };
+
+    const hitTest = () => {
+      raycaster.setFromCamera(pointer, camera);
+      return raycaster.intersectObjects(pickables, false)[0]?.object as Pickable | undefined;
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      drag.active = true;
+      drag.moved = false;
+      drag.x = event.clientX;
+      drag.y = event.clientY;
+      canvas.setPointerCapture(event.pointerId);
+    };
+    const onPointerMove = (event: PointerEvent) => {
+      if (!drag.active) return;
+      const dx = event.clientX - drag.x;
+      const dy = event.clientY - drag.y;
+      if (Math.abs(dx) + Math.abs(dy) > 3) drag.moved = true;
+      drag.x = event.clientX;
+      drag.y = event.clientY;
+    };
+    const onPointerHover = (event: PointerEvent) => {
+      if (drag.active) return;
+      setPointer(event);
+      const selected = hitTest()?.userData.selection;
+      if (!selected || selected.kind === "trace") {
+        setHover(null);
+        return;
+      }
+      setHover({ ...selected, x: event.clientX, y: event.clientY });
+    };
+    const onPointerUp = (event: PointerEvent) => {
+      drag.active = false;
+      try { canvas.releasePointerCapture(event.pointerId); } catch {}
+      if (drag.moved) return;
+      setPointer(event);
+      onSelect(hitTest()?.userData.selection ?? null);
+    };
+    const onGesture = (event: Event) => event.preventDefault();
+    canvas.addEventListener("pointerdown", onPointerDown);
+    canvas.addEventListener("pointermove", onPointerMove);
+    canvas.addEventListener("pointermove", onPointerHover);
+    canvas.addEventListener("pointerup", onPointerUp);
+    canvas.addEventListener("pointerleave", () => setHover(null));
+    canvas.addEventListener("gesturestart", onGesture);
+    canvas.addEventListener("gesturechange", onGesture);
+
+    let frame = 0;
+    let frameCount = 0;
+    let previousFrameAt = performance.now();
+    const startedAt = previousFrameAt;
+    const animate = () => {
+      frame = requestAnimationFrame(animate);
+      if (!visible) return;
+      const now = performance.now();
+      const elapsed = (now - startedAt) / 1000;
+      const delta = (now - previousFrameAt) / 1000;
+      previousFrameAt = now;
+      controls.update();
+      if (!reducedMotion && !drag.active) root.rotation.y += delta * 0.035;
+      for (const particle of particles) {
+        const t = reducedMotion ? particle.offset : (particle.offset + elapsed * particle.speed) % 1;
+        particle.mesh.position.copy(particle.arc.getPoint(t));
+      }
+      root.traverse((child) => {
+        if (child instanceof THREE.Sprite || child.userData.billboard) child.quaternion.copy(camera.quaternion);
+      });
+      if (process.env.NODE_ENV === "development" && frameCount % 180 === 0) {
+        canvas.dataset.drawCalls = String(renderer.info.render.calls);
+        canvas.dataset.triangles = String(renderer.info.render.triangles);
+      }
+      frameCount += 1;
+      renderer.render(scene, camera);
+    };
+    animate();
+
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+      visibilityObserver.disconnect();
+      canvas.removeEventListener("pointerdown", onPointerDown);
+      canvas.removeEventListener("pointermove", onPointerMove);
+      canvas.removeEventListener("pointermove", onPointerHover);
+      canvas.removeEventListener("pointerup", onPointerUp);
+      canvas.removeEventListener("gesturestart", onGesture);
+      canvas.removeEventListener("gesturechange", onGesture);
+      objectBySelectionRef.current = new Map();
+      resetRef.current = null;
+      focusRef.current = null;
+      controls.dispose();
+      disposeObject(root);
+      particleGeometry.dispose();
+      for (const material of particleMaterials.values()) material.dispose();
+      renderer.dispose();
+    };
+  }, [familiars, graph, labels, onSelect, reducedMotion, sceneModel]);
+
+  const selectable = useMemo<TraceGraphSelection[]>(() => [
+    ...sceneModel.nodes.map((node) => ({ kind: "node" as const, id: node.id })),
+    ...sceneModel.edges.map((edge) => ({ kind: "edge" as const, key: edge.key })),
+  ], [sceneModel.edges, sceneModel.nodes]);
+
+  const selectedSummary = useMemo(() => {
+    if (!selection) return `${graph.nodes.length} agents, ${graph.edges.length} routes, ${graph.traces.length} traces.`;
+    if (selection.kind === "node") return `Selected agent ${familiarName(familiars, selection.id)}.`;
+    if (selection.kind === "edge") {
+      const edge = graph.edges.find((candidate) => edgeKey(candidate) === selection.key);
+      return edge ? `Selected route ${familiarName(familiars, edge.caller)} to ${familiarName(familiars, edge.callee)}, ${edge.count} traces.` : "Selected route.";
+    }
+    const trace = graph.traces.find((candidate) => candidate.id === selection.id);
+    return trace ? `Selected ${trace.status} trace from ${familiarName(familiars, trace.callerFamiliarId)} to ${familiarName(familiars, trace.calleeFamiliarId)}.` : "Selected trace.";
+  }, [familiars, graph, selection]);
+
+  const onKeyDown = (event: KeyboardEvent<HTMLCanvasElement>) => {
+    if (event.key === "Escape") onSelect(null);
+    if (event.key === "Home") resetRef.current?.();
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      focusRef.current?.();
+    }
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      event.preventDefault();
+      const current = selectable.findIndex((item) => selectionEquals(item, selection));
+      onSelect(selectable[(current + 1 + selectable.length) % selectable.length] ?? null);
+    }
+    if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      event.preventDefault();
+      const current = selectable.findIndex((item) => selectionEquals(item, selection));
+      onSelect(selectable[(current - 1 + selectable.length) % selectable.length] ?? null);
+    }
+  };
+
+  if (graph.nodes.length === 0) {
+    return (
+      <div className="grid min-h-[420px] flex-1 place-items-center bg-[radial-gradient(circle_at_center,rgba(142,61,255,.12),transparent_58%)] text-sm text-[var(--text-muted)]">
+        No delegation traces in this view.
+      </div>
+    );
+  }
+
+  return (
+    <div ref={shellRef} className="relative min-h-[430px] flex-1 overflow-hidden bg-[#050509]">
+      <canvas
+        ref={canvasRef}
+        data-testid="trace-graph-3d-canvas"
+        aria-label="3D delegation trace graph"
+        role="application"
+        tabIndex={0}
+        onKeyDown={onKeyDown}
+        className="h-full min-h-[430px] w-full cursor-grab touch-none active:cursor-grabbing"
+      />
+      <p aria-live="polite" className="sr-only">{selectedSummary}</p>
+      <div className="pointer-events-none absolute inset-x-0 top-0 flex flex-wrap items-start justify-between gap-3 p-3">
+        <div className="rounded-lg border border-white/10 bg-black/45 px-3 py-2 shadow-2xl backdrop-blur">
+          <div className="text-[10px] font-semibold uppercase tracking-widest text-white/55">3D trace graph</div>
+          <div className="mt-1 flex flex-wrap gap-2 text-[10px] text-white/70">
+            <span>{graph.nodes.length} agents</span>
+            <span>{graph.edges.length} routes</span>
+            <span>{graph.traces.length} traces</span>
+          </div>
+        </div>
+        <div className="pointer-events-auto flex items-center gap-1 rounded-lg border border-white/10 bg-black/45 p-1 shadow-2xl backdrop-blur">
+          <button type="button" className="inline-flex h-7 items-center gap-1 rounded-md px-2 text-[11px] text-white/70 hover:bg-white/10 hover:text-white" onClick={() => focusRef.current?.()}>
+            <Icon name="ph:cursor-click" width={12} />
+            Focus selected
+          </button>
+          <button type="button" className="inline-flex h-7 items-center gap-1 rounded-md px-2 text-[11px] text-white/70 hover:bg-white/10 hover:text-white" onClick={() => resetRef.current?.()}>
+            <Icon name="ph:arrows-clockwise-bold" width={12} />
+            Reset view
+          </button>
+        </div>
+      </div>
+      <div className="absolute left-3 top-16 hidden max-w-[360px] flex-wrap gap-1 md:flex">
+        {sceneModel.edges.slice(0, 6).map((edge) => (
+          <button
+            key={edge.key}
+            type="button"
+            onClick={() => onSelect({ kind: "edge", key: edge.key })}
+            className={[
+              "rounded-md border px-2 py-1 text-[10px] backdrop-blur",
+              selectedObjectKey === `edge:${edge.key}`
+                ? "border-white/35 bg-white/15 text-white"
+                : "border-white/10 bg-black/35 text-white/65 hover:bg-white/10",
+            ].join(" ")}
+          >
+            {familiarName(familiars, edge.caller)} -&gt; {familiarName(familiars, edge.callee)}
+          </button>
+        ))}
+      </div>
+      {sceneModel.policy.detail !== "full" ? (
+        <div className="pointer-events-none absolute right-3 top-16 max-w-[280px] rounded-lg border border-amber-400/20 bg-amber-950/45 px-3 py-2 text-[10px] text-amber-100/80 shadow-2xl backdrop-blur">
+          Dense graph mode: showing strongest routes first.
+        </div>
+      ) : null}
+      <div className="pointer-events-none absolute bottom-3 left-3 flex flex-wrap items-center gap-2 rounded-lg border border-white/10 bg-black/45 px-3 py-2 text-[10px] text-white/65 shadow-2xl backdrop-blur">
+        <span className="inline-flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-[#8E3DFF]" /> explicit</span>
+        <span className="inline-flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-[#fbbf24]" /> inferred</span>
+        <span className="inline-flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-[#38bdf8]" /> mixed</span>
+        <span className="inline-flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-[#62d08f]" /> running</span>
+        <span className="inline-flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-[#f87171]" /> failed</span>
+      </div>
+      <div className="pointer-events-none absolute bottom-3 right-3 hidden rounded-lg border border-white/10 bg-black/45 px-3 py-2 text-[10px] text-white/55 shadow-2xl backdrop-blur md:block">
+        Drag to orbit · pinch or scroll to zoom · click nodes or routes
+      </div>
+      {hover ? <GraphHoverTooltip hover={hover} graph={graph} familiars={familiars} /> : null}
+    </div>
+  );
+}
+
+function GraphHoverTooltip({
+  hover,
+  graph,
+  familiars,
+}: {
+  hover: NonNullable<GraphHover>;
+  graph: DelegationGraph;
+  familiars: Map<string, Familiar>;
+}) {
+  const title = hover.kind === "node"
+    ? familiarName(familiars, hover.id)
+    : (() => {
+      const edge = graph.edges.find((candidate) => edgeKey(candidate) === hover.key);
+      return edge ? `${familiarName(familiars, edge.caller)} -> ${familiarName(familiars, edge.callee)}` : "Delegation route";
+    })();
+  const detail = hover.kind === "node"
+    ? graph.nodes.find((node) => node.id === hover.id)
+    : graph.edges.find((edge) => edgeKey(edge) === hover.key);
+
+  return (
+    <div
+      className="pointer-events-none fixed z-50 max-w-[280px] rounded-lg border border-white/10 bg-black/85 px-3 py-2 text-[11px] text-white shadow-2xl backdrop-blur"
+      style={{ left: hover.x + 12, top: hover.y + 12 }}
+    >
+      <div className="font-semibold">{title}</div>
+      {detail && "count" in detail ? (
+        <div className="mt-1 text-white/65">{detail.count} traces · {detail.source} · {detail.latestStatus}</div>
+      ) : detail ? (
+        <div className="mt-1 text-white/65">{detail.sentCount} sent · {detail.receivedCount} received</div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaces the delegation SVG graph path with a production Three.js 3D trace graph surface.
- Adds deterministic scene-model helpers, OrbitControls navigation, directional arrowheads, selection highlighting, hover tooltips, keyboard/DOM accessibility, and dense-graph degradation.
- Adds a development-gated smoke route and Playwright canvas/screenshot verifier for desktop and mobile visual proof.
- Saves the Sage-informed implementation plan under docs/superpowers/plans.

## Verification
- node --test src/lib/coven-calls-types.test.ts src/components/trace-graph-3d-model.test.ts src/components/calls-view-graph.test.ts src/components/agents-view.test.ts
- pnpm typecheck
- pnpm build
- CAVE_VERIFY_URL=http://127.0.0.1:3018 node scripts/verify-trace-graph-3d.mjs

Notes: build still emits the existing Turbopack NFT warning for src/app/api/library/doc/route.ts. The visual verifier emits Chromium GPU ReadPixels performance warnings while taking screenshots; the verification passes and screenshots are written locally.

Co-authored-by: Nova <nova@openclaw.local>