### PR TITLE
fix(chat): harden attachment lightbox followups

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -1,0 +1,42 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const reasoningBlock = source.match(/function ReasoningBlock[\s\S]*?\n}\n\n\/\/ ── ToolGroup/)?.[0] ?? "";
+
+assert.match(
+  source,
+  /fetch\("\/api\/chat\/send"[\s\S]*body: JSON\.stringify\(\{[\s\S]*attachments: stripPreviewOnlyAttachmentFields\(outgoingAttachments\)/,
+  "Chat send should strip preview-only attachment fields before POSTing",
+);
+
+assert.match(
+  source,
+  /const isImage = \(attachment\.mimeType \?\? attachment\.type\)\?\.startsWith\("image\/"\)/,
+  "Attachment lightbox should fall back to legacy attachment.type for images",
+);
+
+assert.match(
+  source,
+  /role="dialog"[\s\S]*aria-modal="true"/,
+  "Attachment lightbox should expose modal dialog semantics",
+);
+
+assert.doesNotMatch(
+  reasoningBlock,
+  /setManuallyToggled/,
+  "ReasoningBlock should not reference tool-group manual toggle state",
+);
+
+assert.match(
+  source,
+  /const \[open, setOpen\] = useState\(anyRunning\)/,
+  "Tool groups that mount while running should start open",
+);
+
+assert.match(
+  source,
+  /onClick=\{\(\) => \{ setManuallyToggled\(true\); setOpen\(\(v\) => !v\); \}\}/,
+  "Tool group header clicks should pin manual open/closed state",
+);

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -11,6 +11,7 @@ import { FamiliarGlyph } from "@/components/familiar-glyph";
 import { parseGlyphString, DEFAULT_FAMILIAR_GLYPH } from "@/lib/familiar-glyph";
 import {
   MAX_ATTACHMENT_TEXT_CHARS,
+  stripPreviewOnlyAttachmentFields,
   type ChatAttachment,
 } from "@/lib/chat-attachments";
 
@@ -439,7 +440,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         body: JSON.stringify({
           familiarId: familiar.id,
           prompt: trimmed,
-          ...(outgoingAttachments.length ? { attachments: outgoingAttachments } : {}),
+          ...(outgoingAttachments.length ? { attachments: stripPreviewOnlyAttachmentFields(outgoingAttachments) } : {}),
           sessionId: currentSessionRef.current,
           ...(projectRoot && !currentSessionRef.current ? { projectRoot } : {}),
         }),
@@ -918,7 +919,7 @@ function TurnRow({ turn, familiar, showTimestamp = true }: { turn: Turn; familia
 }
 
 function AttachmentLightbox({ attachment, onClose }: { attachment: ChatAttachment; onClose: () => void }) {
-  const isImage = attachment.mimeType?.startsWith("image/");
+  const isImage = (attachment.mimeType ?? attachment.type)?.startsWith("image/");
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
     window.addEventListener("keydown", onKey);
@@ -928,6 +929,9 @@ function AttachmentLightbox({ attachment, onClose }: { attachment: ChatAttachmen
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
       onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Preview ${attachment.name}`}
     >
       <div
         className="relative max-h-[90vh] max-w-[90vw] overflow-auto rounded-xl border border-[var(--border-hairline)] bg-[#050409] shadow-2xl"
@@ -1045,7 +1049,7 @@ function ReasoningBlock({ text }: { text: string }) {
 function ToolGroup({ tools }: { tools: ToolEvent[] }) {
   const anyRunning = tools.some((t) => t.status === "running");
   const anyError   = tools.some((t) => t.status === "error");
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(anyRunning);
   const [manuallyToggled, setManuallyToggled] = useState(false);
 
   // Auto-open while running; auto-close when all settle (unless user manually toggled)

--- a/src/lib/chat-attachments.test.ts
+++ b/src/lib/chat-attachments.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   buildPromptWithAttachments,
   normalizeChatAttachments,
+  stripPreviewOnlyAttachmentFields,
 } from "./chat-attachments.ts";
 
 const attachments = normalizeChatAttachments([
@@ -53,3 +54,22 @@ const [truncated] = normalizeChatAttachments([
 
 assert.equal(truncated.text.length, 64_000);
 assert.equal(truncated.truncated, true);
+
+assert.deepEqual(
+  stripPreviewOnlyAttachmentFields([
+    {
+      name: "diagram.png",
+      type: "image/png",
+      mimeType: "image/png",
+      size: 128,
+      dataUrl: "data:image/png;base64,abc123",
+    },
+  ]),
+  [
+    {
+      name: "diagram.png",
+      type: "image/png",
+      size: 128,
+    },
+  ],
+);

--- a/src/lib/chat-attachments.ts
+++ b/src/lib/chat-attachments.ts
@@ -47,6 +47,10 @@ export function normalizeChatAttachments(input: unknown): ChatAttachment[] {
     });
 }
 
+export function stripPreviewOnlyAttachmentFields(attachments: ChatAttachment[]): ChatAttachment[] {
+  return attachments.map(({ dataUrl: _dataUrl, mimeType: _mimeType, ...attachment }) => attachment);
+}
+
 function formatBytes(size?: number): string {
   if (size == null) return "unknown size";
   if (size < 1024) return `${size} B`;


### PR DESCRIPTION
Follow-up to #169.

Changes:
- Keep local image preview data in the UI turn but strip preview-only `dataUrl`/`mimeType` before posting to `/api/chat/send`.
- Fall back from `mimeType` to legacy `type` when detecting image previews.
- Add modal dialog ARIA semantics to the attachment lightbox.
- Start tool groups open when they mount with running tools.
- Add focused regression/source tests for the chat polish behavior.

Verification:
- `node --test src/lib/chat-attachments.test.ts src/components/chat-view-polish.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`