### PR TITLE
fix(board): harden step enrichment runs

### DIFF
--- a/src/app/api/board/enrich-steps/route.test.ts
+++ b/src/app/api/board/enrich-steps/route.test.ts
@@ -1,0 +1,47 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
+
+assert.match(
+  source,
+  /export async function POST\(req: Request\)/,
+  "Enrich route should receive the Request so it can validate intent and observe aborts",
+);
+
+assert.match(
+  source,
+  /req\.headers\.get\("x-coven-cave-intent"\) !== "board-enrich-steps"/,
+  "Enrich route should reject requests without the non-simple intent header",
+);
+
+assert.match(
+  source,
+  /await req\.json\(\)[\s\S]*body\.intent === "board-enrich-steps"/,
+  "Enrich route should require the matching JSON intent body",
+);
+
+assert.match(
+  source,
+  /signal\.addEventListener\("abort", onAbort, \{ once: true \}\)/,
+  "Coven child process should be killed if the client aborts",
+);
+
+assert.match(
+  source,
+  /if \(req\.signal\.aborted\) break;/,
+  "Enrich route should stop iterating cards after abort",
+);
+
+assert.match(
+  source,
+  /await resolveFamiliarWorkspace\(familiarId\)/,
+  "Enrich route should run each familiar from its familiar workspace",
+);
+
+assert.match(
+  source,
+  /"--archive"[\s\S]*"--labels"[\s\S]*"board,enrich-steps"/,
+  "One-shot enrichment runs should be archived and labeled",
+);

--- a/src/app/api/board/enrich-steps/route.ts
+++ b/src/app/api/board/enrich-steps/route.ts
@@ -2,11 +2,15 @@ import { loadBoard, updateCard } from "@/lib/cave-board";
 import type { CardStep } from "@/lib/cave-board-types";
 import { bindingFor, loadConfig } from "@/lib/cave-config";
 import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
+import { familiarWorkspace } from "@/lib/coven-paths";
 import { spawn } from "node:child_process";
+import { stat } from "node:fs/promises";
 import { stripAnsi } from "@/lib/ansi";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+const ENRICH_INTENT = "board-enrich-steps";
 
 // Prompt the familiar to return ONLY a JSON array of step strings — nothing else.
 function enrichPrompt(card: { title: string; notes?: string; labels?: string[] }): string {
@@ -23,20 +27,56 @@ function enrichPrompt(card: { title: string; notes?: string; labels?: string[] }
   ].join("\n");
 }
 
+async function hasIntent(req: Request): Promise<boolean> {
+  if (req.headers.get("x-coven-cave-intent") !== "board-enrich-steps") return false;
+  try {
+    const body = (await req.json()) as { intent?: unknown };
+    return body.intent === "board-enrich-steps";
+  } catch {
+    return false;
+  }
+}
+
+async function resolveFamiliarWorkspace(familiarId: string): Promise<string | undefined> {
+  if (!/^[a-z0-9_-]+$/i.test(familiarId)) return undefined;
+  const candidate = await familiarWorkspace(familiarId);
+  try {
+    const entry = await stat(candidate);
+    return entry.isDirectory() ? candidate : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 // Run coven CLI and collect full stdout output as a string.
-function runCoven(args: string[], familiarId: string, familiarWorkspacePath?: string): Promise<string> {
+function runCoven(args: string[], signal: AbortSignal, familiarWorkspacePath?: string): Promise<string> {
   return new Promise((resolve) => {
     try {
       let out = "";
+      let settled = false;
       const child = spawn(covenBin(), args, {
         cwd: familiarWorkspacePath ?? process.cwd(),
         stdio: ["ignore", "pipe", "pipe"],
         env: covenSpawnEnv(),
       });
+
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener("abort", onAbort);
+        resolve(out);
+      };
+      const onAbort = () => {
+        try { child.kill("SIGTERM"); } catch { /* ignore */ }
+      };
+
+      if (signal.aborted) onAbort();
+      signal.addEventListener("abort", onAbort, { once: true });
+
       child.stdout.on("data", (d: Buffer) => { out += d.toString("utf8"); });
       child.stderr.on("data", (d: Buffer) => { out += d.toString("utf8"); });
-      child.on("close", () => resolve(out));
-      child.on("error", () => resolve(out));
+      child.on("close", finish);
+      child.on("error", finish);
     } catch {
       resolve("");
     }
@@ -92,7 +132,14 @@ function parseSteps(raw: string): string[] | null {
   return null;
 }
 
-export async function POST() {
+export async function POST(req: Request) {
+  if (!(await hasIntent(req))) {
+    return new Response(JSON.stringify({ ok: false, error: "missing enrich intent" }), {
+      status: 403,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
   const [board, config] = await Promise.all([loadBoard(), loadConfig()]);
 
   // Only enrich tasks that:
@@ -107,12 +154,20 @@ export async function POST() {
   const stream = new ReadableStream<Uint8Array>({
     start: async (controller) => {
       const enc = new TextEncoder();
-      const push = (obj: object) =>
-        controller.enqueue(enc.encode(JSON.stringify(obj) + "\n"));
+      let closed = false;
+      const push = (obj: object) => {
+        if (closed) return;
+        try {
+          controller.enqueue(enc.encode(JSON.stringify(obj) + "\n"));
+        } catch {
+          closed = true;
+        }
+      };
 
       push({ kind: "start", total: candidates.length });
 
       for (const card of candidates) {
+        if (req.signal.aborted) break;
         const familiarId = card.familiarId!;
         const binding = bindingFor(config, familiarId);
 
@@ -124,11 +179,23 @@ export async function POST() {
 
         push({ kind: "progress", cardId: card.id, title: card.title });
 
-        const args: string[] = ["run", binding.harness, "--stream-json"];
+        const title = `Plan task steps: ${card.title.trim().slice(0, 80) || card.id}`;
+        const args: string[] = [
+          "run",
+          binding.harness,
+          "--stream-json",
+          "--archive",
+          "--title",
+          title,
+          "--labels",
+          "board,enrich-steps",
+        ];
         if (/^[a-z0-9_-]+$/i.test(familiarId)) args.push("--familiar", familiarId);
         args.push("--", enrichPrompt(card));
 
-        const raw = await runCoven(args, familiarId);
+        const workspace = await resolveFamiliarWorkspace(familiarId);
+        const raw = await runCoven(args, req.signal, workspace);
+        if (req.signal.aborted) break;
         const steps = parseSteps(raw);
 
         if (!steps || steps.length === 0) {
@@ -153,7 +220,7 @@ export async function POST() {
       }
 
       push({ kind: "complete" });
-      try { controller.close(); } catch { /* */ }
+      try { closed = true; controller.close(); } catch { /* */ }
     },
   });
 

--- a/src/components/board-enrich-steps.test.ts
+++ b/src/components/board-enrich-steps.test.ts
@@ -1,0 +1,11 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./board-view.tsx", import.meta.url), "utf8");
+
+assert.match(
+  source,
+  /fetch\("\/api\/board\/enrich-steps", \{[\s\S]*method: "POST"[\s\S]*"content-type": "application\/json"[\s\S]*"x-coven-cave-intent": "board-enrich-steps"[\s\S]*body: JSON\.stringify\(\{ intent: "board-enrich-steps" \}\)/,
+  "Board enrich client should send an intentional JSON request with a non-simple header",
+);

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -143,7 +143,14 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
     setEnriching(true);
     setEnrichProgress(null);
     try {
-      const res = await fetch("/api/board/enrich-steps", { method: "POST" });
+      const res = await fetch("/api/board/enrich-steps", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-coven-cave-intent": "board-enrich-steps",
+        },
+        body: JSON.stringify({ intent: "board-enrich-steps" }),
+      });
       if (!res.ok) throw new Error(`enrich steps failed (${res.status})`);
       if (!res.body) throw new Error("enrich steps: missing response body");
       const reader = res.body.getReader();


### PR DESCRIPTION
Follow-up to #167 after PR processing.

Changes:
- Require an intentional JSON request with `x-coven-cave-intent: board-enrich-steps` before the batch endpoint runs.
- Kill the spawned `coven run` child when the request is aborted and stop iterating remaining cards.
- Run each familiar from its familiar workspace instead of the Cave server process cwd.
- Archive and label one-shot enrichment sessions with `board,enrich-steps` to avoid cluttering active session lists.
- Add focused regression/source tests for the route and client request contract.

Verification:
- `node --test src/app/api/board/enrich-steps/route.test.ts src/components/board-enrich-steps.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check origin/main...HEAD`