### PR TITLE
feat(chat): familiar switcher in chat panel

### DIFF
--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -6,13 +6,16 @@ import { stripLeadingTrailingEmoji } from "@/lib/cave-chat-titles";
 import { Icon } from "@/lib/icon";
 import { useKeySymbols } from "@/lib/platform-keys";
 import { OriginChip } from "@/components/ui/origin-chip";
+import { FamiliarSwitcher } from "@/components/familiar-switcher";
 
 type Props = {
   familiar: Familiar;
+  familiars?: Familiar[];
   sessions: SessionRow[];
   daemonRunning?: boolean;
   onOpen: (sessionId: string) => void;
   onNewChat: (projectRoot?: string) => void;
+  onFamiliarSelect?: (id: string) => void;
 };
 
 function age(iso: string): string {
@@ -52,7 +55,7 @@ function statusStyle(s: string) {
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat }: Props) {
+export function ChatList({ familiar, familiars = [], sessions, daemonRunning, onOpen, onNewChat, onFamiliarSelect }: Props) {
   const [busyTuiId, setBusyTuiId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
@@ -140,9 +143,7 @@ export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat 
 
       {/* ── Header ── */}
       <header className="flex items-center gap-3 border-b border-[var(--border-hairline)] px-4 py-3">
-        <h2 className="text-[15px] font-semibold text-[var(--text-primary)]">
-          {familiar.display_name}
-        </h2>
+        <FamiliarSwitcher familiar={familiar} familiars={familiars} onSelect={onFamiliarSelect} />
 
         {/* Unreads toggle */}
         <button

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -118,10 +118,12 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     return (
       <ChatList
         familiar={familiar}
+        familiars={familiars}
         sessions={sessions}
         daemonRunning={daemonRunning}
         onOpen={(sessionId) => setView({ kind: "chat", sessionId })}
         onNewChat={(projectRoot) => setView({ kind: "chat", sessionId: null, projectRoot })}
+        onFamiliarSelect={onFamiliarSelect}
       />
     );
   }
@@ -130,10 +132,12 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     <ChatView
       ref={viewHandle}
       familiar={familiar}
+      familiars={familiars}
       sessionId={view.sessionId}
       projectRoot={view.kind === "chat" ? view.projectRoot : undefined}
       daemonRunning={daemonRunning}
       onBack={() => setView({ kind: "list" })}
+      onFamiliarSelect={onFamiliarSelect}
       onSessionStarted={(sid) => {
         // Only promote the sessionId in the view state when the current chat
         // has no session yet (null). If a session is already set, leave the

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2,6 +2,7 @@
 
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import type { Familiar } from "@/lib/types";
+import { FamiliarSwitcher } from "@/components/familiar-switcher";
 import { RichText } from "@/components/rich-text";
 import { MessageBubble, SyntaxBlock } from "@/components/message-bubble";
 import { canonicalize, formatHelp, matchSlash, type SlashCommand } from "@/lib/slash-commands";

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -39,6 +39,7 @@ type Turn = {
 
 type Props = {
   familiar: Familiar;
+  familiars?: Familiar[];
   sessionId: string | null;
   projectRoot?: string;
   daemonRunning?: boolean;
@@ -46,6 +47,7 @@ type Props = {
   onBack?: () => void;
   onSlashCommand?: (command: string, args: string) => boolean;
   onOpenOnboarding?: () => void;
+  onFamiliarSelect?: (id: string) => void;
 };
 
 export type ChatViewHandle = {
@@ -246,7 +248,7 @@ function ChatEmptyState({
 // ── ChatView ──────────────────────────────────────────────────────────────────
 
 export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
-  { familiar, sessionId, projectRoot, onSessionStarted, onSlashCommand, onOpenOnboarding },
+  { familiar, familiars = [], sessionId, projectRoot, onSessionStarted, onSlashCommand, onOpenOnboarding, onFamiliarSelect },
   ref,
 ) {
   const [turns, setTurns] = useState<Turn[]>([]);
@@ -653,6 +655,18 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
 
   return (
     <section className="flex h-full flex-col bg-[var(--bg-base)] text-[var(--text-primary)]">
+      {/* Chat header — familiar switcher + back */}
+      <header className="flex items-center gap-2 border-b border-[var(--border-hairline)] px-4 py-2.5">
+        <FamiliarSwitcher familiar={familiar} familiars={familiars} onSelect={onFamiliarSelect} />
+        <div className="ml-auto flex items-center gap-2">
+          <span className={[
+            "flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium",
+            "bg-[var(--bg-raised)]/60 text-[var(--text-muted)]",
+          ].join(" ")}>
+            <span className="font-mono">{familiar.harness ?? "—"}</span>
+          </span>
+        </div>
+      </header>
       {/* Transcript */}
       <div ref={scrollRef} className="relative min-h-0 flex-1 overflow-y-auto px-6 py-6">
         <div className="space-y-6">

--- a/src/components/familiar-switcher.tsx
+++ b/src/components/familiar-switcher.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { Familiar } from "@/lib/types";
+import { FamiliarGlyph } from "@/components/familiar-glyph";
+import { parseGlyphString, DEFAULT_FAMILIAR_GLYPH } from "@/lib/familiar-glyph";
+import { Icon } from "@/lib/icon";
+
+type Props = {
+  familiar: Familiar;
+  familiars?: Familiar[];
+  onSelect?: (id: string) => void;
+};
+
+/**
+ * FamiliarSwitcher
+ * Renders the active familiar's name as a clickable pill. Clicking opens
+ * a compact dropdown listing all familiars so the user can switch without
+ * leaving the chat panel.
+ */
+export function FamiliarSwitcher({ familiar, familiars = [], onSelect }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const glyph =
+    parseGlyphString(familiar.icon) ??
+    parseGlyphString(familiar.emoji) ??
+    DEFAULT_FAMILIAR_GLYPH;
+
+  // Close on outside click / Esc
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setOpen(false); };
+    const onMouse = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("mousedown", onMouse);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("mousedown", onMouse);
+    };
+  }, [open]);
+
+  // Don't render a switcher if there's only one familiar
+  if (familiars.length <= 1) {
+    return (
+      <h2 className="text-[15px] font-semibold text-[var(--text-primary)]">
+        {familiar.display_name}
+      </h2>
+    );
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="group flex items-center gap-2 rounded-lg px-2 py-1 -ml-2 transition-colors hover:bg-[var(--bg-raised)]/60"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md" style={{ background: "rgba(255,255,255,0.07)", border: "1px solid rgba(255,255,255,0.08)" }}>
+          <FamiliarGlyph glyph={glyph} size="sm" />
+        </span>
+        <span className="text-[15px] font-semibold text-[var(--text-primary)]">
+          {familiar.display_name}
+        </span>
+        <Icon
+          name="ph:caret-up-down-bold"
+          width={11}
+          className="shrink-0 text-[var(--text-muted)] opacity-60 transition-opacity group-hover:opacity-100"
+        />
+      </button>
+
+      {open ? (
+        <div
+          role="listbox"
+          className="absolute left-0 top-full z-40 mt-1.5 min-w-[200px] overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[#111018] shadow-2xl"
+        >
+          <div className="px-2 py-1.5 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
+            Switch familiar
+          </div>
+          {familiars.map((f) => {
+            const fGlyph =
+              parseGlyphString(f.icon) ??
+              parseGlyphString(f.emoji) ??
+              DEFAULT_FAMILIAR_GLYPH;
+            const isActive = f.id === familiar.id;
+            return (
+              <button
+                key={f.id}
+                role="option"
+                aria-selected={isActive}
+                type="button"
+                onClick={() => {
+                  setOpen(false);
+                  if (!isActive) onSelect?.(f.id);
+                }}
+                className={[
+                  "flex w-full items-center gap-2.5 px-2.5 py-2 text-left transition-colors",
+                  isActive
+                    ? "bg-[var(--accent-presence)]/10 text-[var(--text-primary)]"
+                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]/60 hover:text-[var(--text-primary)]",
+                ].join(" ")}
+              >
+                <span
+                  className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md"
+                  style={{ background: "rgba(255,255,255,0.07)", border: "1px solid rgba(255,255,255,0.08)" }}
+                >
+                  <FamiliarGlyph glyph={fGlyph} size="sm" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[13px] font-medium leading-tight">
+                    {f.display_name}
+                  </div>
+                  {f.role ? (
+                    <div className="truncate text-[11px] text-[var(--text-muted)]">{f.role}</div>
+                  ) : null}
+                </div>
+                {isActive ? (
+                  <Icon name="ph:check-bold" width={11} className="shrink-0 text-[var(--accent-presence)]" />
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/icon.tsx
+++ b/src/lib/icon.tsx
@@ -37,6 +37,7 @@ export const ICON_NAMES = [
   "ph:rows",
   "ph:columns",
   "ph:caret-up-down",
+  "ph:caret-up-down-bold",
   "ph:caret-up",
   "ph:caret-down-fill",
   "ph:check",


### PR DESCRIPTION
Adds a **FamiliarSwitcher** component to the chat panel so you can switch the active familiar without navigating away.

## Where it appears
- **Chat list header** — replaces the static familiar name with a clickable pill
- **Chat view header** — new slim header bar above the transcript with the switcher + harness badge

## Behaviour
- Click the familiar name → compact dropdown with all familiars, each showing their avatar glyph and role
- Active familiar is highlighted with a violet tint + checkmark
- Click any other familiar → triggers `onFamiliarSelect` which updates `activeId` in workspace state instantly, resets to the new familiar's chat list
- Esc or click-outside closes the dropdown
- If there's only one familiar, renders a plain h2 (no dropdown noise for solo setups)

## New component: `familiar-switcher.tsx`
Self-contained, accepts `familiar` (current) + `familiars` (all) + `onSelect` callback. Uses existing `FamiliarGlyph` + `parseGlyphString` so avatars match the rest of the app.

## Props threaded
`familiars` + `onFamiliarSelect` added to `ChatList`, `ChatView`, and passed through `ChatRouter`.