### PR TITLE
feat(github): inline PAT setup in board panel + sidebar add-ins grouping

### DIFF
--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -146,9 +146,10 @@ function GitHubAttachSection({
   const [query, setQuery] = useState("");
   const [err, setErr] = useState<string | null>(null);
   const [configured, setConfigured] = useState<boolean | null>(null);
+  const [fetchKey, setFetchKey] = useState(0);
 
   useEffect(() => {
-    if (!open || items.length > 0) return;
+    if (!open) return;
     setLoading(true);
     fetch("/api/github/assigned", { cache: "no-store" })
       .then((r) => r.json())
@@ -162,7 +163,7 @@ function GitHubAttachSection({
       })
       .catch(() => setErr("fetch failed"))
       .finally(() => setLoading(false));
-  }, [open, items.length]);
+  }, [open, fetchKey]); // fetchKey bumped to force refetch after PAT save
 
   const attachedUrls = new Set(card.links);
 
@@ -263,7 +264,7 @@ function GitHubAttachSection({
               <div style={{ padding: "10px", fontSize: 11, color: "#f87171" }}>{err}</div>
             )}
             {!loading && !err && configured === false && (
-              <InlinePATSetup onSaved={() => { setConfigured(null); loadItems(); }} />
+              <InlinePATSetup onSaved={() => { setItems([]); setConfigured(null); setFetchKey((k) => k + 1); }} />
             )}
             {!loading && !err && configured !== false && filtered.length === 0 && items.length === 0 && (
               <div style={{ padding: "12px 10px", fontSize: 11, color: "var(--text-muted)", textAlign: "center" }}>

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -196,10 +196,7 @@ function GitHubAttachSection({
               <div style={{ padding: "10px", fontSize: 11, color: "#f87171" }}>{err}</div>
             )}
             {!loading && !err && configured === false && (
-              <div style={{ padding: "12px 10px", fontSize: 11, color: "var(--text-muted)", textAlign: "center", display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}>
-                <Icon name="ph:github-logo" width={18} className="text-[var(--text-muted)]" />
-                Connect a GitHub token to see your assigned items.
-              </div>
+              <InlinePATSetup onSaved={() => { setConfigured(null); loadItems(); }} />
             )}
             {!loading && !err && configured !== false && filtered.length === 0 && items.length === 0 && (
               <div style={{ padding: "12px 10px", fontSize: 11, color: "var(--text-muted)", textAlign: "center" }}>

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -50,6 +50,73 @@ function TimeoutBadge({ runningSince, timeoutMs }: { runningSince?: string; time
   );
 }
 
+// ── Inline PAT Setup ─────────────────────────────────────────────────────────
+function InlinePATSetup({ onSaved }: { onSaved: () => void }) {
+  const [pat, setPat] = useState("");
+  const [usernameInput, setUsernameInput] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function save() {
+    const trimmedPat = pat.trim();
+    const trimmedUser = usernameInput.trim();
+    if (!trimmedPat && !trimmedUser) { setError("Enter a GitHub username or PAT."); return; }
+    setSaving(true); setError(null);
+    try {
+      const body: Record<string, string> = {};
+      if (trimmedPat) body.pat = trimmedPat;
+      if (trimmedUser) body.username = trimmedUser;
+      const res = await fetch("/api/github/pat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json().catch(() => null);
+      if (!res.ok || !data?.ok) { setError(data?.error ?? "Failed to save."); return; }
+      onSaved();
+    } catch { setError("Network error — please try again."); }
+    finally { setSaving(false); }
+  }
+
+  return (
+    <div style={{ padding: "10px 10px 8px", display: "flex", flexDirection: "column", gap: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 2 }}>
+        <Icon name="ph:github-logo" width={14} className="text-[var(--text-muted)]" />
+        <span style={{ fontSize: 11, fontWeight: 600, color: "var(--text-secondary)" }}>Connect GitHub</span>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <label style={{ fontSize: 10, color: "var(--text-muted)", fontWeight: 500 }}>GitHub username</label>
+        <input type="text" value={usernameInput} onChange={(e) => setUsernameInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && void save()} placeholder="your-username"
+          style={{ background: "var(--bg-base)", border: "1px solid var(--border-hairline)", borderRadius: 6,
+            padding: "5px 8px", fontSize: 11, color: "var(--text-primary)", outline: "none", width: "100%", boxSizing: "border-box" }} />
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <label style={{ fontSize: 10, color: "var(--text-muted)", fontWeight: 500 }}>
+          Personal Access Token <span style={{ fontWeight: 400 }}>(optional)</span>
+        </label>
+        <input type="password" value={pat} onChange={(e) => setPat(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && void save()} placeholder="ghp_…"
+          style={{ background: "var(--bg-base)", border: "1px solid var(--border-hairline)", borderRadius: 6,
+            padding: "5px 8px", fontSize: 11, color: "var(--text-primary)", outline: "none", width: "100%", boxSizing: "border-box" }} />
+      </div>
+      {error && <p style={{ fontSize: 10, color: "#f87171", margin: 0 }}>{error}</p>}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: 2 }}>
+        <a href="https://github.com/settings/tokens/new?scopes=read:user,repo,notifications&description=Cave+local"
+          target="_blank" rel="noreferrer"
+          style={{ fontSize: 10, color: "oklch(0.65 0.18 280)", textDecoration: "none" }}>
+          Generate PAT →
+        </a>
+        <button type="button" disabled={(!pat.trim() && !usernameInput.trim()) || saving} onClick={() => void save()}
+          style={{ background: "oklch(0.65 0.18 280)", color: "#fff", border: "none", borderRadius: 6,
+            padding: "4px 12px", fontSize: 11, fontWeight: 500, cursor: "pointer", opacity: saving ? 0.6 : 1 }}>
+          {saving ? "Verifying…" : "Save"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 // ── GitHub attach ─────────────────────────────────────────────────────────────
 const KIND_ICON: Record<string, string> = {
   pr: "ph:git-pull-request",

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -141,12 +141,33 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
         />
       </div>
 
-      {/* Folder mode rows */}
+      {/* Primary nav rows: Agents / Tasks / Terminal / Browser */}
       <div className="sidebar-folders">
-        {visibleFolderModes.map((fm) => (
-          <React.Fragment key={fm.id}>
-            {fm.dividerBefore && <div className="sidebar-divider" />}
+        {visibleFolderModes
+          .filter((fm) => fm.id !== "github" && fm.id !== "library")
+          .map((fm) => (
+            <React.Fragment key={fm.id}>
+              {fm.dividerBefore && <div className="sidebar-divider" />}
+              <FolderRow
+                id={fm.id}
+                label={fm.label}
+                iconName={fm.iconName}
+                active={mode === fm.id}
+                badge={fm.badge?.(props)}
+                onClick={() => onModeChange(fm.id)}
+              />
+            </React.Fragment>
+          ))}
+      </div>
+
+      {/* Add-ins section: GitHub · Library · Roles · Automations */}
+      <div className="sidebar-folders sidebar-addins">
+        <div className="sidebar-section-label">Add-ins</div>
+        {visibleFolderModes
+          .filter((fm) => fm.id === "github" || fm.id === "library")
+          .map((fm) => (
             <FolderRow
+              key={fm.id}
               id={fm.id}
               label={fm.label}
               iconName={fm.iconName}
@@ -154,13 +175,21 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
               badge={fm.badge?.(props)}
               onClick={() => onModeChange(fm.id)}
             />
-          </React.Fragment>
+          ))}
+        {UTILITY_MODES.filter((u) => u.id === "plugins" || u.id === "schedules").map((item) => (
+          <ActionRow
+            key={item.id}
+            icon={<Icon name={item.iconName} width={14} />}
+            label={item.label}
+            active={mode === item.id}
+            onClick={() => onModeChange(item.id)}
+          />
         ))}
       </div>
 
-      {/* Utility actions footer */}
+      {/* Utility footer: Calendar only */}
       <div className="sidebar-actions sidebar-actions--footer">
-        {UTILITY_MODES.map((item) => (
+        {UTILITY_MODES.filter((u) => u.id === "calendar").map((item) => (
           <ActionRow
             key={item.id}
             icon={<Icon name={item.iconName} width={14} />}

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -81,6 +81,22 @@
   border-bottom: 1px solid var(--border-hairline);
 }
 
+.sidebar-addins {
+  border-top: 1px solid var(--border-hairline);
+  margin-top: auto; /* push to bottom of folder area */
+}
+
+.sidebar-section-label {
+  padding: 8px 9px 3px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  opacity: 0.6;
+  user-select: none;
+}
+
 .sidebar-divider {
   height: 1px;
   background: var(--border-hairline);


### PR DESCRIPTION
Two UX improvements from Val's feedback.

## Inline PAT setup in GitHub board panel
When no GitHub token is configured, instead of a static `Connect a GitHub token` message the panel now shows an inline form matching the PAT acquisition pattern on the GitHub page:
- Username field
- PAT field (password input, optional)
- `Generate PAT →` link
- Save button (disabled until at least one field has content)
- On save → refreshes the item list inline, no page nav required

## Add-ins grouping in left sidebar
GitHub, Library, Roles (Plugins), and Automations are now visually grouped together under a small **Add-ins** section label, sitting between the primary nav (Agents/Tasks/Terminal/Browser) and the Calendar footer. Reduces the scattered divider noise and makes the sidebar read as three clear tiers: Work → Add-ins → Calendar.