### PR TITLE
fix(sidebar): avoid double add-ins divider

### DIFF
--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -1,0 +1,15 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const styles = readFileSync(new URL("../styles/sidebar-minimal.css", import.meta.url), "utf8");
+
+const addinsRule = styles.match(/\.sidebar-addins\s*\{(?<body>[^}]*)\}/)?.groups?.body ?? "";
+
+assert.ok(addinsRule, "Sidebar add-ins styles should exist");
+
+assert.doesNotMatch(
+  addinsRule,
+  /border-top\s*:/,
+  "Add-ins should rely on the primary sidebar-folders bottom border instead of adding a second divider",
+);

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -82,7 +82,6 @@
 }
 
 .sidebar-addins {
-  border-top: 1px solid var(--border-hairline);
   margin-top: auto; /* push to bottom of folder area */
 }
 


### PR DESCRIPTION
## Summary
- remove the extra Add-ins top border that stacked with the primary sidebar divider
- add a regression test for the sidebar Add-ins rule

## Verification
- node --test src/components/sidebar-minimal.test.ts
- pnpm typecheck
- pnpm build
- git diff --check