### PR TITLE
feat(board): Status/Familiar pill toggle replaces group-by dropdown

### DIFF
--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -38,20 +38,18 @@ type Props = {
 };
 
 function getGroups(cards: Card[], by: GroupBy, familiars: Familiar[]): { key: string; label: string; cards: Card[] }[] {
-  if (by === "none") return [{ key: "all", label: "", cards }];
-  if (by === "status") return [{ key: "all", label: "Status", cards }];
+  if (by === "status") return [{ key: "all", label: "", cards }];
+  // by === "familiar"
   const map = new Map<string, Card[]>();
   for (const c of cards) {
-    const key = by === "familiar" ? (c.familiarId ?? "__unassigned__") : c.priority;
+    const key = c.familiarId ?? "__unassigned__";
     if (!map.has(key)) map.set(key, []);
     map.get(key)!.push(c);
   }
-  return [...map.entries()].map(([key, cards]) => ({
+  return [...map.entries()].map(([key, grpCards]) => ({
     key,
-    label: by === "familiar"
-      ? (key === "__unassigned__" ? "Unassigned" : (familiars.find((f) => f.id === key)?.display_name ?? key))
-      : key.charAt(0).toUpperCase() + key.slice(1),
-    cards,
+    label: key === "__unassigned__" ? "Unassigned" : (familiars.find((f) => f.id === key)?.display_name ?? key),
+    cards: grpCards,
   }));
 }
 
@@ -63,7 +61,7 @@ export function BoardKanban({ cards, familiars, sessions, groupBy, selectedCardI
   const railRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
   const groups = getGroups(cards, groupBy, familiars);
-  const showSwimlanes = groupBy !== "none";
+  const showSwimlanes = true;
 
   const grouped = (gc: Card[]) => {
     const m = new Map<CardStatus, Card[]>();

--- a/src/components/board-table.tsx
+++ b/src/components/board-table.tsx
@@ -6,7 +6,7 @@ import type { Card, CardStatus, CardPriority } from "@/lib/cave-board-types";
 import { LifecycleBadge } from "@/components/ui/lifecycle-badge";
 import { Icon } from "@/lib/icon";
 
-export type GroupBy = "status" | "familiar" | "priority" | "none";
+export type GroupBy = "status" | "familiar";
 export type SortKey = "title" | "status" | "priority" | "familiar" | "cwd" | "links" | "lifecycle" | "updatedAt";
 export type SortDir = "asc" | "desc";
 
@@ -32,21 +32,19 @@ function sortCards(cards: Card[], key: SortKey, dir: SortDir, familiars: Familia
 }
 
 function groupCards(cards: Card[], by: GroupBy, familiars: Familiar[]): { key: string; label: string; cards: Card[] }[] {
-  if (by === "none") return [{ key: "all", label: "", cards }];
   const map = new Map<string, Card[]>();
   for (const c of cards) {
-    const key = by === "status" ? c.status : by === "priority" ? c.priority : (c.familiarId ?? "__unassigned__");
+    const key = by === "status" ? c.status : (c.familiarId ?? "__unassigned__");
     if (!map.has(key)) map.set(key, []);
     map.get(key)!.push(c);
   }
-  const entries = [...map.entries()].map(([key, cards]) => {
-    let label = key;
-    if (by === "familiar") label = key === "__unassigned__" ? "Unassigned" : (familiars.find((f) => f.id === key)?.display_name ?? key);
-    else label = key.charAt(0).toUpperCase() + key.slice(1);
-    return { key, label, cards };
+  const entries = [...map.entries()].map(([key, grpCards]) => {
+    const label = by === "familiar"
+      ? (key === "__unassigned__" ? "Unassigned" : (familiars.find((f) => f.id === key)?.display_name ?? key))
+      : key.charAt(0).toUpperCase() + key.slice(1);
+    return { key, label, cards: grpCards };
   });
   if (by === "status") entries.sort((a, b) => (STATUS_ORDER[a.key as CardStatus] ?? 9) - (STATUS_ORDER[b.key as CardStatus] ?? 9));
-  if (by === "priority") entries.sort((a, b) => (PRIORITY_ORDER[a.key as CardPriority] ?? 9) - (PRIORITY_ORDER[b.key as CardPriority] ?? 9));
   return entries;
 }
 

--- a/src/components/board-table.tsx
+++ b/src/components/board-table.tsx
@@ -126,7 +126,7 @@ export function BoardTable({ cards, familiars, groupBy, selectedCardId, onSelect
         <tbody>
           {groups.map(({ key, label, cards: gc }) => (
             <React.Fragment key={key}>
-              {groupBy !== "none" && (
+              {true && (
                 <tr key={`g-${key}`} className="board-table-group-row" onClick={() => toggleGroup(key)}>
                   <td colSpan={COLS.length}>
                     <span className="board-table-group-caret">

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -31,7 +31,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
   const [cards, setCards] = useState<Card[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>(() => loadPref("cave:board:viewMode", "kanban", ["kanban", "table"]));
-  const [groupBy, setGroupBy] = useState<GroupBy>(() => loadPref("cave:board:groupBy", "status", ["status", "familiar", "priority", "none"]));
+  const [groupBy, setGroupBy] = useState<GroupBy>(() => loadPref("cave:board:groupBy", "status", ["status", "familiar"]));
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
@@ -210,14 +210,24 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
           ) : null}
         </div>
         <div className="board-header-controls">
-          <label className="sr-only" htmlFor="board-groupby">Group by</label>
-          <select id="board-groupby" className="board-toolbar-select" value={groupBy}
-            onChange={(e) => setGroupBy(e.target.value as GroupBy)}>
-            <option value="status">Group: Status</option>
-            <option value="familiar">Group: Familiar</option>
-            <option value="priority">Group: Priority</option>
-            <option value="none">No grouping</option>
-          </select>
+          <div className="board-group-toggle" role="group" aria-label="Group tasks by">
+            <button
+              type="button"
+              className={`board-group-toggle-btn${groupBy === "status" ? " board-group-toggle-btn--active" : ""}`}
+              onClick={() => setGroupBy("status")}
+              aria-pressed={groupBy === "status"}
+            >
+              Status
+            </button>
+            <button
+              type="button"
+              className={`board-group-toggle-btn${groupBy === "familiar" ? " board-group-toggle-btn--active" : ""}`}
+              onClick={() => setGroupBy("familiar")}
+              aria-pressed={groupBy === "familiar"}
+            >
+              Familiar
+            </button>
+          </div>
 
           <div className="board-view-toggle" role="group" aria-label="Tasks view mode">
             <button type="button" aria-label="Kanban view"

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -20,14 +20,17 @@
 .board-toolbar-btn:hover { background:var(--bg-hover); color:var(--text-primary); }
 .board-toolbar-btn--active { background:color-mix(in oklab,oklch(0.65 0.18 280) 14%,var(--bg-raised)); border-color:color-mix(in oklab,oklch(0.65 0.18 280) 40%,transparent); color:var(--text-primary); }
 
-.board-toolbar-select { height:28px; padding:0 24px 0 8px; border-radius:7px; border:1px solid var(--border-strong); background:var(--bg-raised); color:var(--text-secondary); font-size:12px; cursor:pointer; appearance:none; -webkit-appearance:none; transition:background-color .12s,color .12s; }
-.board-toolbar-select:hover { background-color:var(--bg-hover); color:var(--text-primary); }
-.board-toolbar-select--active { background:color-mix(in oklab,oklch(0.65 0.18 280) 14%,var(--bg-raised)); border-color:color-mix(in oklab,oklch(0.65 0.18 280) 40%,transparent); color:var(--text-primary); }
+
 .board-multiselect-btn { display:inline-flex; align-items:center; gap:5px; padding:0 8px; height:28px; white-space:nowrap; }
 .board-multiselect-caret { color:var(--text-muted); transition:transform .15s; flex-shrink:0; }
 .board-multiselect-caret--open { transform:rotate(180deg); }
 .board-multiselect-popover { min-width:180px; }
 
+.board-group-toggle { display:flex; border:1px solid var(--border-strong); border-radius:7px; overflow:hidden; }
+.board-group-toggle-btn { display:flex; align-items:center; justify-content:center; padding:0 10px; height:28px; background:var(--bg-raised); color:var(--text-muted); border:none; cursor:pointer; font-size:12px; font-weight:500; transition:background .12s,color .12s; white-space:nowrap; }
+.board-group-toggle-btn+.board-group-toggle-btn { border-left:1px solid var(--border-strong); }
+.board-group-toggle-btn:hover { background:var(--bg-hover); color:var(--text-secondary); }
+.board-group-toggle-btn--active { background:color-mix(in oklab,oklch(0.65 0.18 280) 16%,var(--bg-raised)); color:var(--text-primary); }
 .board-view-toggle { display:flex; border:1px solid var(--border-strong); border-radius:7px; overflow:hidden; }
 .board-view-toggle-btn { display:flex; align-items:center; justify-content:center; width:28px; height:28px; background:var(--bg-raised); color:var(--text-muted); border:none; cursor:pointer; transition:background .12s,color .12s; }
 .board-view-toggle-btn+.board-view-toggle-btn { border-left:1px solid var(--border-strong); }


### PR DESCRIPTION
Trims the Tasks view grouping controls down to exactly what's useful.

## Changes

**GroupBy type** — narrowed from `"status" | "familiar" | "priority" | "none"` to just `"status" | "familiar"`

**Toolbar** — the `<select>` dropdown is replaced with a compact pill toggle:
```
[ Status | Familiar ]
```
Same visual language as the Kanban/Table view toggle sitting next to it. Active option highlighted with the violet tint. State persisted to `localStorage` as before.

**Board logic** — dead `"none"` and `"priority"` branches removed from `getGroups` (kanban) and `groupCards` (table). `showSwimlanes` is now always `true` (no ungrouped state).

**CSS** — new `.board-group-toggle` / `.board-group-toggle-btn` rules; old `.board-toolbar-select` rules removed.