### PR TITLE
chore(preview): board-inspector isolation route + capture script

### DIFF
--- a/scripts/screenshot-inspector.mjs
+++ b/scripts/screenshot-inspector.mjs
@@ -1,0 +1,28 @@
+import { chromium } from "playwright";
+
+const out = process.argv[2] ?? "/tmp/board-inspector.png";
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({
+  viewport: { width: 1100, height: 900 },
+  deviceScaleFactor: 2,
+  colorScheme: "dark",
+});
+const page = await ctx.newPage();
+const errors = [];
+page.on("pageerror", (e) => errors.push("[pageerror] " + e.message));
+page.on("console", (m) => {
+  if (m.type() === "error") errors.push("[console.error] " + m.text());
+});
+
+await page.goto("http://localhost:3000/preview/board-inspector", { waitUntil: "networkidle" });
+await page.waitForSelector(".board-drawer", { timeout: 15000 });
+await page.waitForTimeout(400);
+await page.screenshot({ path: out, fullPage: false });
+
+console.log("OK", out);
+if (errors.length) {
+  console.log("---errors---");
+  for (const e of errors) console.log(e);
+}
+await browser.close();

--- a/src/app/preview/board-inspector/page.tsx
+++ b/src/app/preview/board-inspector/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import { BoardInspector } from "@/components/board-inspector";
+import type { Card } from "@/lib/cave-board-types";
+import type { Familiar, SessionRow } from "@/lib/types";
+import "@/styles/board.css";
+
+const FAMILIARS: Familiar[] = [
+  { id: "fam-sage", display_name: "Sage", role: "Strategist", icon: "ph:cat-fill" },
+  { id: "fam-ember", display_name: "Ember", role: "Builder", icon: "ph:fire-fill" },
+  { id: "fam-tide", display_name: "Tide", role: "Reviewer", icon: "ph:wave-sine-bold" },
+];
+
+const SESSIONS: SessionRow[] = [];
+
+const NOW = new Date("2026-06-06T15:00:00Z").toISOString();
+
+const CARD: Card = {
+  id: "card-demo",
+  title: "Smoke test card",
+  notes: "",
+  status: "done",
+  priority: "high",
+  familiarId: "fam-sage",
+  sessionId: null,
+  cwd: null,
+  links: [],
+  github: [],
+  labels: [],
+  createdAt: NOW,
+  updatedAt: NOW,
+  lifecycle: "completed",
+  lifecycleAt: NOW,
+  retryCount: 0,
+  maxRetries: 2,
+  steps: [],
+};
+
+export default function Page() {
+  const [card, setCard] = useState<Card>(CARD);
+  return (
+    <div style={{ minHeight: "100vh", background: "var(--bg-base, #111)" }}>
+      <BoardInspector
+        card={card}
+        familiars={FAMILIARS}
+        sessions={SESSIONS}
+        onClose={() => {}}
+        onPatch={(_id, patch) => setCard((c) => ({ ...c, ...patch }))}
+        onMoveStatus={(_id, status) => setCard((c) => ({ ...c, status }))}
+        onDelete={async () => {}}
+        onCardReplaced={(next) => setCard(next)}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a \`/preview/board-inspector\` Next.js route that mounts \`BoardInspector\` against hardcoded demo familiars + a single demo card, so the component can be visually reviewed in isolation.
- Adds \`scripts/screenshot-inspector.mjs\`, a 28-line Playwright script that drives that route and saves a 2× retina PNG.

Pattern matches the existing \`/dev\`, \`/aesthetic\`, \`/mockup\` helper routes already in \`src/app\` — they're harmless dev-aid endpoints that ship with the app.

## Why

Lets us screenshot just the board inspector (e.g. for visual regression review of the recent task-inspector refinement in [\`61318fb\`](../commit/61318fb)) without spinning up sample sessions in the full Cave shell.

## Usage

\`\`\`bash
pnpm dev
node scripts/screenshot-inspector.mjs /tmp/inspector.png
\`\`\`

## Test plan

- [ ] \`pnpm typecheck\` clean (verified locally)
- [ ] \`pnpm dev\` → visit \`/preview/board-inspector\` → inspector renders with the demo card

🤖 Generated with [Claude Code](https://claude.com/claude-code)