### PR TITLE
feat(onboarding): support equal runtime sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,23 @@ Download the matching asset from [Releases](https://github.com/OpenCoven/coven-c
 - **Linux:** download the `.AppImage`, run `chmod +x CovenCave_*.AppImage`, then launch it from your file manager or terminal.
 - **macOS:** download the `.dmg`, open it, and drag CovenCave to Applications.
 
-You'll also need the local [`coven`](https://github.com/OpenCoven/coven) CLI/daemon. On first launch, Cave opens a full-width setup screen that checks for the CLI, creates your local `~/.coven` folder, lets you connect one of your local OpenClaw agents as a familiar, and starts the daemon.
+You'll also need a local runtime source: Codex, Claude Code, Hermes, an existing OpenClaw agent, or another Coven adapter manifest. On first launch, Cave opens a full-width setup screen that checks the `coven` CLI/daemon, creates your local `~/.coven` folder, lets you choose whichever runtime you already have, writes the first familiar binding, creates a Hermes adapter manifest when needed, and starts the daemon.
+
+### First familiar without OpenClaw
+
+OpenClaw is not required to use CovenCave. A fresh Windows user can start with any installed harness:
+
+1. Install CovenCave from the official release asset.
+2. Install or expose the `coven` CLI so `coven` works from a new terminal.
+3. Install and authenticate at least one runtime:
+   - Codex: `npm install -g @openai/codex`, then `codex login`
+   - Claude Code: `npm install -g @anthropic-ai/claude-code`, then `claude doctor`
+   - Hermes: install Hermes, then make sure `hermes --version` works
+   - OpenClaw: keep using an existing agent under `~/.openclaw/agents`
+4. Open CovenCave and choose the runtime source that is already healthy on your machine. If you pick Hermes, Cave writes `~/.coven/adapters/hermes.json` so the Coven daemon can launch it through the external adapter path.
+5. Name the familiar, click the matching setup button, start the daemon, then open Cave.
+
+The setup screen treats Codex, Claude Code, Hermes, and OpenClaw as peer sources. If setup stalls, click **Copy diagnostics** and include the output with the relevant Cave or Coven sidecar logs.
 
 ### Demo mode for testers
 
@@ -38,6 +54,7 @@ Use demo mode only for local testing or demos. It intentionally injects sample f
 ## Screenshots
 
 <!-- Cave desktop interface -->
+
 ![Cave — Shell view](screenshots/shell.png)
 ![Cave — Chat view](screenshots/chat.png)
 ![Cave — Terminal](screenshots/terminal.png)
@@ -91,22 +108,22 @@ Bypass a confirmed false positive with `git commit --no-verify`.
 
 ## Keybinds
 
-| Shortcut | Action |
-|----------|--------|
-| `⌘B` | Toggle familiar rail |
-| `⇧⌘B` | Toggle inspector pane |
-| _drag handles_ | Resize side panels |
+| Shortcut       | Action                |
+| -------------- | --------------------- |
+| `⌘B`           | Toggle familiar rail  |
+| `⇧⌘B`          | Toggle inspector pane |
+| _drag handles_ | Resize side panels    |
 
 ## Stack
 
-| Layer | Tech |
-|-------|------|
-| Native shell | Tauri 2 |
-| Frontend | Next.js 16 (App Router, Turbopack) |
-| Styles | Tailwind v4 |
-| Markdown | Shiki (syntax highlighting) |
-| Terminal | xterm.js |
-| IPC | Unix socket → `~/.coven/coven.sock` |
+| Layer        | Tech                                |
+| ------------ | ----------------------------------- |
+| Native shell | Tauri 2                             |
+| Frontend     | Next.js 16 (App Router, Turbopack)  |
+| Styles       | Tailwind v4                         |
+| Markdown     | Shiki (syntax highlighting)         |
+| Terminal     | xterm.js                            |
+| IPC          | Unix socket → `~/.coven/coven.sock` |
 
 ## App identity
 
@@ -135,6 +152,7 @@ _The Coven lives in the Cave._
 ## Release standard
 
 Every release ships with:
+
 - A comprehensive changelog describing features, fixes, and install instructions
 - Screenshots updated to reflect the current UI
 - SHA256 checksums for all artifacts

--- a/src/app/api/board/enrich-steps/route.ts
+++ b/src/app/api/board/enrich-steps/route.ts
@@ -13,8 +13,14 @@ export const runtime = "nodejs";
 const ENRICH_INTENT = "board-enrich-steps";
 
 // Prompt the familiar to return ONLY a JSON array of step strings — nothing else.
-function enrichPrompt(card: { title: string; notes?: string; labels?: string[] }): string {
-  const labels = card.labels?.length ? `\nLabels: ${card.labels.join(", ")}` : "";
+function enrichPrompt(card: {
+  title: string;
+  notes?: string;
+  labels?: string[];
+}): string {
+  const labels = card.labels?.length
+    ? `\nLabels: ${card.labels.join(", ")}`
+    : "";
   const notes = card.notes?.trim() ? `\n\nNotes:\n${card.notes.trim()}` : "";
   return [
     `You are helping plan the following task as a concrete checklist.`,
@@ -28,7 +34,8 @@ function enrichPrompt(card: { title: string; notes?: string; labels?: string[] }
 }
 
 async function hasIntent(req: Request): Promise<boolean> {
-  if (req.headers.get("x-coven-cave-intent") !== "board-enrich-steps") return false;
+  if (req.headers.get("x-coven-cave-intent") !== "board-enrich-steps")
+    return false;
   try {
     const body = (await req.json()) as { intent?: unknown };
     return body.intent === "board-enrich-steps";
@@ -37,7 +44,9 @@ async function hasIntent(req: Request): Promise<boolean> {
   }
 }
 
-async function resolveFamiliarWorkspace(familiarId: string): Promise<string | undefined> {
+async function resolveFamiliarWorkspace(
+  familiarId: string,
+): Promise<string | undefined> {
   if (!/^[a-z0-9_-]+$/i.test(familiarId)) return undefined;
   const candidate = await familiarWorkspace(familiarId);
   try {
@@ -49,7 +58,11 @@ async function resolveFamiliarWorkspace(familiarId: string): Promise<string | un
 }
 
 // Run coven CLI and collect full stdout output as a string.
-function runCoven(args: string[], signal: AbortSignal, familiarWorkspacePath?: string): Promise<string> {
+function runCoven(
+  args: string[],
+  signal: AbortSignal,
+  familiarWorkspacePath?: string,
+): Promise<string> {
   return new Promise((resolve) => {
     try {
       let out = "";
@@ -67,14 +80,22 @@ function runCoven(args: string[], signal: AbortSignal, familiarWorkspacePath?: s
         resolve(out);
       };
       const onAbort = () => {
-        try { child.kill("SIGTERM"); } catch { /* ignore */ }
+        try {
+          child.kill("SIGTERM");
+        } catch {
+          /* ignore */
+        }
       };
 
       if (signal.aborted) onAbort();
       signal.addEventListener("abort", onAbort, { once: true });
 
-      child.stdout.on("data", (d: Buffer) => { out += d.toString("utf8"); });
-      child.stderr.on("data", (d: Buffer) => { out += d.toString("utf8"); });
+      child.stdout.on("data", (d: Buffer) => {
+        out += d.toString("utf8");
+      });
+      child.stderr.on("data", (d: Buffer) => {
+        out += d.toString("utf8");
+      });
       child.on("close", finish);
       child.on("error", finish);
     } catch {
@@ -124,7 +145,10 @@ function parseSteps(raw: string): string[] | null {
   try {
     const parsed = JSON.parse(match[0]);
     if (Array.isArray(parsed) && parsed.every((s) => typeof s === "string")) {
-      return parsed.map((s) => s.trim()).filter(Boolean).slice(0, 7);
+      return parsed
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .slice(0, 7);
     }
   } catch {
     /* */
@@ -134,10 +158,13 @@ function parseSteps(raw: string): string[] | null {
 
 export async function POST(req: Request) {
   if (!(await hasIntent(req))) {
-    return new Response(JSON.stringify({ ok: false, error: "missing enrich intent" }), {
-      status: 403,
-      headers: { "content-type": "application/json" },
-    });
+    return new Response(
+      JSON.stringify({ ok: false, error: "missing enrich intent" }),
+      {
+        status: 403,
+        headers: { "content-type": "application/json" },
+      },
+    );
   }
 
   const [board, config] = await Promise.all([loadBoard(), loadConfig()]);
@@ -148,7 +175,10 @@ export async function POST(req: Request) {
   // - have no existing steps yet (or have 0 steps)
   const SKIP_LIFECYCLE = new Set(["completed", "cancelled"]);
   const candidates = board.cards.filter(
-    (c) => c.familiarId && !SKIP_LIFECYCLE.has(c.lifecycle) && (c.steps ?? []).length === 0
+    (c) =>
+      c.familiarId &&
+      !SKIP_LIFECYCLE.has(c.lifecycle) &&
+      (c.steps ?? []).length === 0,
   );
 
   const stream = new ReadableStream<Uint8Array>({
@@ -171,9 +201,14 @@ export async function POST(req: Request) {
         const familiarId = card.familiarId!;
         const binding = bindingFor(config, familiarId);
 
-        // Only codex/claude harnesses can run headlessly
-        if (!["codex", "claude"].includes(binding.harness)) {
-          push({ kind: "skip", cardId: card.id, reason: `harness:${binding.harness}` });
+        // Local Coven harnesses can run headlessly through `coven run
+        // <harness> --stream-json`, including external adapter manifests.
+        if (binding.harness === "openclaw") {
+          push({
+            kind: "skip",
+            cardId: card.id,
+            reason: `harness:${binding.harness}`,
+          });
           continue;
         }
 
@@ -190,7 +225,8 @@ export async function POST(req: Request) {
           "--labels",
           "board,enrich-steps",
         ];
-        if (/^[a-z0-9_-]+$/i.test(familiarId)) args.push("--familiar", familiarId);
+        if (/^[a-z0-9_-]+$/i.test(familiarId))
+          args.push("--familiar", familiarId);
         args.push("--", enrichPrompt(card));
 
         const workspace = await resolveFamiliarWorkspace(familiarId);
@@ -220,7 +256,12 @@ export async function POST(req: Request) {
       }
 
       push({ kind: "complete" });
-      try { closed = true; controller.close(); } catch { /* */ }
+      try {
+        closed = true;
+        controller.close();
+      } catch {
+        /* */
+      }
     },
   });
 

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -1,0 +1,30 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const chatRoute = await readFile(
+  new URL("./route.ts", import.meta.url),
+  "utf8",
+);
+const boardRoute = await readFile(
+  new URL("../../board/enrich-steps/route.ts", import.meta.url),
+  "utf8",
+);
+
+assert.match(
+  chatRoute,
+  /coven run <harness> --stream-json/,
+  "Native chat should describe the generic Coven harness route instead of a fixed allow-list",
+);
+
+assert.doesNotMatch(
+  chatRoute,
+  /COVEN_RUN_HARNESSES|new Set\(\["codex", "claude"\]\)|new Set\(\["codex", "claude", "hermes"\]\)/,
+  "Native chat should not hard-code a local harness allow-list",
+);
+
+assert.match(
+  boardRoute,
+  /binding\.harness === "openclaw"/,
+  "Board step enrichment should skip OpenClaw bridge familiars while allowing local Coven harnesses",
+);

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -2,7 +2,11 @@ import { spawn } from "node:child_process";
 import { stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { stripAnsi } from "@/lib/ansi";
-import { bindingFor, loadConfig, recordSessionFamiliar } from "@/lib/cave-config";
+import {
+  bindingFor,
+  loadConfig,
+  recordSessionFamiliar,
+} from "@/lib/cave-config";
 import {
   buildPromptWithAttachments,
   normalizeChatAttachments,
@@ -16,7 +20,10 @@ import {
   loadConversation,
   saveConversation,
 } from "@/lib/cave-conversations";
-import { buildTaskAwarePrompt, taskContextForSession } from "@/lib/task-chat-context";
+import {
+  buildTaskAwarePrompt,
+  taskContextForSession,
+} from "@/lib/task-chat-context";
 import { extractLinks } from "@/lib/link-extractor";
 import { routeLinkHandler } from "@/app/api/library/route-link/route";
 
@@ -52,7 +59,8 @@ type StreamEvent =
 //   hook: tool_use Bash {...}
 //   hook: pre_tool_use Edit { ... }
 //   hook: post_tool_use Bash {... exitCode: 0 ...}
-const TOOL_HOOK_RE = /^hook:\s+(?:pre_tool_use|post_tool_use|tool_use)\s+(\S+)(?:\s+(.*))?$/;
+const TOOL_HOOK_RE =
+  /^hook:\s+(?:pre_tool_use|post_tool_use|tool_use)\s+(\S+)(?:\s+(.*))?$/;
 
 async function sleep(ms: number) {
   return new Promise<void>((resolve) => setTimeout(resolve, ms));
@@ -88,14 +96,18 @@ async function resolveCwd(requested?: string): Promise<string> {
  *  ~/.coven/familiars/<id>. Falls back to undefined if the dir doesn't exist
  *  so callers can skip --cwd.
  */
-async function resolveFamiliarWorkspace(familiarId: string): Promise<string | undefined> {
+async function resolveFamiliarWorkspace(
+  familiarId: string,
+): Promise<string | undefined> {
   // Guard against path traversal: familiar IDs should be simple slugs.
   if (!/^[a-z0-9_-]+$/i.test(familiarId)) return undefined;
   const candidate = await familiarWorkspace(familiarId);
   try {
     const s = await stat(candidate);
     if (s.isDirectory()) return candidate;
-  } catch { /* not found */ }
+  } catch {
+    /* not found */
+  }
   return undefined;
 }
 
@@ -138,21 +150,30 @@ export async function POST(req: Request) {
   try {
     body = (await req.json()) as SendBody;
   } catch {
-    return new Response(JSON.stringify({ ok: false, error: "invalid json body" }), {
-      status: 400,
-      headers: { "content-type": "application/json" },
-    });
+    return new Response(
+      JSON.stringify({ ok: false, error: "invalid json body" }),
+      {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      },
+    );
   }
   const attachments = normalizeChatAttachments(body.attachments);
   const promptText = body.prompt?.trim() ?? "";
   if (!body.familiarId || (!promptText && attachments.length === 0)) {
     return new Response(
-      JSON.stringify({ ok: false, error: "familiarId and prompt or attachments are required" }),
+      JSON.stringify({
+        ok: false,
+        error: "familiarId and prompt or attachments are required",
+      }),
       { status: 400, headers: { "content-type": "application/json" } },
     );
   }
   const taskContext = await taskContextForSession(body.sessionId);
-  const harnessPrompt = buildTaskAwarePrompt(buildPromptWithAttachments(promptText, attachments), taskContext);
+  const harnessPrompt = buildTaskAwarePrompt(
+    buildPromptWithAttachments(promptText, attachments),
+    taskContext,
+  );
 
   const config = await loadConfig();
   const binding = bindingFor(config, body.familiarId);
@@ -160,22 +181,22 @@ export async function POST(req: Request) {
   // Resolve familiar workspace for identity context. When a project root is
   // explicitly set, the harness boots there (and should have the familiar's
   // AGENTS.md injected separately). When there's no project root, boot in the
-  // familiar's own workspace so Codex/Claude picks up AGENTS.md / SOUL.md /
-  // IDENTITY.md and responds as the familiar instead of as "Codex".
+  // familiar's own workspace so the selected harness picks up AGENTS.md /
+  // SOUL.md / IDENTITY.md and responds as the familiar instead of as the
+  // generic CLI identity.
   const familiarWorkspace = !body.projectRoot
     ? await resolveFamiliarWorkspace(body.familiarId)
     : undefined;
 
-  // coven run only knows codex|claude today. Other harnesses (openclaw,
-  // copilot, opencode, gemini, hermes, …) are surfaced in /api/harnesses
-  // and the rail configurator but can't be driven from native chat yet —
-  // open them via Coven Code TUI through /api/launch.
-  const COVEN_RUN_HARNESSES = new Set(["codex", "claude"]);
-  if (!COVEN_RUN_HARNESSES.has(binding.harness)) {
+  // Native Cave chat can drive any Coven harness that resolves through
+  // `coven run <harness> --stream-json`. OpenClaw-backed familiars use the
+  // OpenClaw agent bridge instead of the local harness runner.
+  if (binding.harness === "openclaw") {
     return new Response(
       JSON.stringify({
         ok: false,
-        error: `Native chat isn't wired for the "${binding.harness}" harness yet — open this familiar in the Coven Code TUI instead.`,
+        error:
+          "OpenClaw-backed familiars need the OpenClaw bridge. Pick a local harness familiar here, or open the agent from OpenClaw.",
       }),
       { status: 501, headers: { "content-type": "application/json" } },
     );
@@ -188,10 +209,9 @@ export async function POST(req: Request) {
   const buildArgs = (resumeSessionId: string | null): string[] => {
     const a = ["run", binding.harness, "--stream-json"];
     if (resumeSessionId) a.push("--continue", resumeSessionId);
-    // Inject identity preamble. coven-cli renders this as a [Identity: ...]
-    // bracketed prefix for harnesses without a --system-prompt flag (Codex)
-    // or via --system-prompt for those that do (Claude). Without this,
-    // the harness answers as "Codex"/"Claude" instead of as the familiar.
+    // Inject identity preamble. coven-cli renders this through the best
+    // available identity channel for the chosen harness. Without this, the
+    // harness answers as its generic CLI identity instead of as the familiar.
     if (/^[a-z0-9_-]+$/i.test(body.familiarId)) {
       a.push("--familiar", body.familiarId);
     }
@@ -200,7 +220,7 @@ export async function POST(req: Request) {
   };
   const args = buildArgs(body.sessionId ?? null);
 
-  // Resume failures from either harness. Codex emits
+  // Resume failures from common harnesses. Codex emits
   // "thread/resume failed: no rollout found ... (code -32600)" when the
   // rollout DB no longer has the thread. Claude Code emits
   // "Session ID <uuid> is already in use" when --resume hits a session
@@ -251,7 +271,8 @@ export async function POST(req: Request) {
       // lines that look like errors as a fallback for the diagnostic.
       const stdoutErrTail: string[] = [];
       const STDOUT_ERR_KEEP = 10;
-      const ERR_LINE_RE = /\b(error|failed|denied|unauthori[sz]ed|invalid|refused|missing|not found|401|403|500)\b/i;
+      const ERR_LINE_RE =
+        /\b(error|failed|denied|unauthori[sz]ed|invalid|refused|missing|not found|401|403|500)\b/i;
 
       // Set to true when the harness reports its resume failed (rollout DB
       // miss). Triggers a single transparent retry without --continue.
@@ -314,7 +335,11 @@ export async function POST(req: Request) {
           // Try to pretty-print JSON payloads; fall back to raw string.
           const fmtPayload = (raw: string): string | undefined => {
             if (!raw) return undefined;
-            try { return JSON.stringify(JSON.parse(raw), null, 2); } catch { return raw; }
+            try {
+              return JSON.stringify(JSON.parse(raw), null, 2);
+            } catch {
+              return raw;
+            }
           };
           if (isPost) {
             const meta = toolStartTimes.get(name);
@@ -461,7 +486,11 @@ export async function POST(req: Request) {
         const now = new Date().toISOString();
         const userTurnId = crypto.randomUUID();
         const assistantTurnId = crypto.randomUUID();
-        const chatTitle = (promptText || attachments[0]?.name || "Attached files").slice(0, 60);
+        const chatTitle = (
+          promptText ||
+          attachments[0]?.name ||
+          "Attached files"
+        ).slice(0, 60);
         const userTurn: ChatTurn = {
           id: userTurnId,
           role: "user",

--- a/src/app/api/onboarding/setup/route.ts
+++ b/src/app/api/onboarding/setup/route.ts
@@ -10,6 +10,7 @@ import {
   type OnboardingFamiliarDraft,
   type OnboardingFamiliarInput,
 } from "@/lib/onboarding-familiars";
+import { adapterManifestScaffoldForHarness } from "@/lib/harness-adapters";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -42,12 +43,16 @@ export async function POST(req: Request) {
     draft = body.familiar ? normalizeFamiliarDraft(body.familiar) : null;
   } catch (err) {
     return NextResponse.json(
-      { ok: false, error: err instanceof Error ? err.message : "Invalid familiar." },
+      {
+        ok: false,
+        error: err instanceof Error ? err.message : "Invalid familiar.",
+      },
       { status: 400 },
     );
   }
   const harness = (draft?.harness ?? body.harness ?? "codex").trim() || "codex";
-  const model = (draft?.model ?? body.model ?? "codex-local").trim() || "codex-local";
+  const model =
+    (draft?.model ?? body.model ?? "codex-local").trim() || "codex-local";
 
   const home = homedir();
   const covenDir = path.join(home, ".coven");
@@ -55,12 +60,23 @@ export async function POST(req: Request) {
   const configJson = path.join(covenDir, "cave-config.json");
   const conversationsDir = path.join(covenDir, "cave-conversations");
   const memoryDir = path.join(covenDir, "memory");
+  const adaptersDir = path.join(covenDir, "adapters");
 
   const wrote: string[] = [];
 
   await mkdir(covenDir, { recursive: true });
   await mkdir(conversationsDir, { recursive: true });
   await mkdir(memoryDir, { recursive: true });
+  await mkdir(adaptersDir, { recursive: true });
+
+  const adapterManifest = adapterManifestScaffoldForHarness(harness);
+  if (adapterManifest) {
+    const manifestPath = path.join(adaptersDir, adapterManifest.filename);
+    if (!(await pathExists(manifestPath))) {
+      await writeFile(manifestPath, adapterManifest.contents, "utf8");
+      wrote.push(`adapters/${adapterManifest.filename}`);
+    }
+  }
 
   const familiarsExists = await pathExists(familiarsToml);
   if (!familiarsExists) {
@@ -70,7 +86,11 @@ export async function POST(req: Request) {
     const existingToml = await readFile(familiarsToml, "utf8");
     if (!familiarsTomlContainsId(existingToml, draft.id)) {
       const separator = existingToml.endsWith("\n") ? "\n" : "\n\n";
-      await writeFile(familiarsToml, `${existingToml}${separator}${buildFamiliarsToml(draft).replace(/^# User familiars for this Coven\.\n+/, "")}`, "utf8");
+      await writeFile(
+        familiarsToml,
+        `${existingToml}${separator}${buildFamiliarsToml(draft).replace(/^# User familiars for this Coven\.\n+/, "")}`,
+        "utf8",
+      );
       wrote.push("familiars.toml");
     }
   }
@@ -86,7 +106,7 @@ export async function POST(req: Request) {
           ...(existing.familiars ?? {}),
           [draft.id]: { harness: draft.harness, model: draft.model },
         }
-      : existing.familiars ?? {},
+      : (existing.familiars ?? {}),
   };
   await writeFile(configJson, JSON.stringify(nextConfig, null, 2), "utf8");
   wrote.push("cave-config.json");

--- a/src/app/api/onboarding/status/route.ts
+++ b/src/app/api/onboarding/status/route.ts
@@ -1,13 +1,20 @@
 import { NextResponse } from "next/server";
 import { execFile } from "node:child_process";
-import { stat } from "node:fs/promises";
+import { readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { callDaemon } from "@/lib/coven-daemon";
 import { loadConfig } from "@/lib/cave-config";
-import { covenSpawnEnv } from "@/lib/coven-bin";
-import { adapterSetupState, COMPATIBILITY_ADAPTERS, type AdapterReport } from "@/lib/harness-adapters";
+import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
+import {
+  COMPATIBILITY_ADAPTERS,
+  covenHelpSupportsAdapterList,
+  mergeAdapterReports,
+  runtimeSourceSetupState,
+  type AdapterReport,
+  type CovenAdapterSummary,
+} from "@/lib/harness-adapters";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -28,15 +35,30 @@ async function checkCovenCli(): Promise<Step> {
 async function commandPath(binary: string): Promise<string | null> {
   const command = process.platform === "win32" ? "where" : "which";
   try {
-    const { stdout } = await execFileAsync(command, [binary], { env: covenSpawnEnv(), timeout: 1500 });
+    const { stdout } = await execFileAsync(command, [binary], {
+      env: covenSpawnEnv(),
+      timeout: 1500,
+    });
     return stdout.trim().split(/\r?\n/)[0] || null;
   } catch {
     return null;
   }
 }
 
-async function checkHarnessAdapters(): Promise<Step> {
-  const reports: AdapterReport[] = await Promise.all(
+async function countOpenClawAgents(): Promise<number> {
+  const agentsRoot = path.join(homedir(), ".openclaw", "agents");
+  try {
+    const entries = await readdir(agentsRoot, { withFileTypes: true });
+    return entries.filter(
+      (entry) => entry.isDirectory() && !entry.name.startsWith("."),
+    ).length;
+  } catch {
+    return 0;
+  }
+}
+
+async function checkHarnessAdapters(openclawAgentCount: number): Promise<Step> {
+  const localReports: AdapterReport[] = await Promise.all(
     COMPATIBILITY_ADAPTERS.map(async (adapter) => {
       const found = await commandPath(adapter.binary);
       return {
@@ -53,7 +75,33 @@ async function checkHarnessAdapters(): Promise<Step> {
       };
     }),
   );
-  return adapterSetupState(reports);
+  const reports = mergeAdapterReports(
+    localReports,
+    await loadCovenAdapterSummaries(),
+  );
+  return runtimeSourceSetupState(reports, openclawAgentCount);
+}
+
+async function loadCovenAdapterSummaries(): Promise<CovenAdapterSummary[]> {
+  try {
+    const { stdout: helpText } = await execFileAsync(covenBin(), ["--help"], {
+      env: covenSpawnEnv(),
+      timeout: 1500,
+    });
+    if (!covenHelpSupportsAdapterList(helpText)) return [];
+    const { stdout } = await execFileAsync(
+      covenBin(),
+      ["adapter", "list", "--json"],
+      {
+        env: covenSpawnEnv(),
+        timeout: 3000,
+      },
+    );
+    const parsed = JSON.parse(stdout);
+    return Array.isArray(parsed) ? (parsed as CovenAdapterSummary[]) : [];
+  } catch {
+    return [];
+  }
 }
 
 async function checkCovenHome(): Promise<Step> {
@@ -68,21 +116,35 @@ async function checkCovenHome(): Promise<Step> {
 }
 
 async function checkDaemon(): Promise<Step> {
-  const res = await callDaemon<{ ok?: boolean }>({ path: "/api/v1/health", timeoutMs: 800 });
+  const res = await callDaemon<{ ok?: boolean }>({
+    path: "/api/v1/health",
+    timeoutMs: 800,
+  });
   if (res.ok) return { ok: true, detail: "daemon socket reachable" };
   return { ok: false, hint: res.error ?? `daemon http ${res.status}` };
 }
 
 async function checkFamiliars(): Promise<{ step: Step; count: number }> {
-  const res = await callDaemon<unknown[]>({ path: "/api/v1/familiars", timeoutMs: 800 });
+  const res = await callDaemon<unknown[]>({
+    path: "/api/v1/familiars",
+    timeoutMs: 800,
+  });
   const count = Array.isArray(res.data) ? res.data.length : 0;
   if (res.ok && count > 0) {
-    return { step: { ok: true, detail: `${count} familiar${count === 1 ? "" : "s"} loaded` }, count };
+    return {
+      step: {
+        ok: true,
+        detail: `${count} familiar${count === 1 ? "" : "s"} loaded`,
+      },
+      count,
+    };
   }
   return {
     step: {
       ok: false,
-      hint: res.ok ? "Connect an OpenClaw agent as a familiar, or add one to ~/.coven/familiars.toml." : "daemon offline",
+      hint: res.ok
+        ? "Create a familiar from any available runtime source, or add one to ~/.coven/familiars.toml."
+        : "daemon offline",
     },
     count,
   };
@@ -92,22 +154,29 @@ async function checkBinding(familiarsAvailable: boolean): Promise<Step> {
   const config = await loadConfig();
   const hasDefaults = !!config.defaults.harness && !!config.defaults.model;
   if (!hasDefaults) {
-    return { ok: false, hint: "Create a local Codex/Claude familiar or connect an OpenClaw agent." };
+    return {
+      ok: false,
+      hint: "Create a familiar from Codex, Claude Code, Hermes, or an OpenClaw agent.",
+    };
   }
   if (!familiarsAvailable) {
     return { ok: false, hint: "Bindings set but no familiars to bind." };
   }
-  return { ok: true, detail: `${config.defaults.harness} · ${config.defaults.model}` };
+  return {
+    ok: true,
+    detail: `${config.defaults.harness} · ${config.defaults.model}`,
+  };
 }
 
 export async function GET() {
+  const openclawAgentCount = await countOpenClawAgents();
   const [covenCli, covenHome, daemon, familiarsRes] = await Promise.all([
     checkCovenCli(),
     checkCovenHome(),
     checkDaemon(),
     checkFamiliars(),
   ]);
-  const adapters = await checkHarnessAdapters();
+  const adapters = await checkHarnessAdapters(openclawAgentCount);
   const binding = await checkBinding(familiarsRes.count > 0);
 
   const steps = {

--- a/src/components/onboarding-bento-layout.test.ts
+++ b/src/components/onboarding-bento-layout.test.ts
@@ -2,7 +2,10 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-const source = await readFile(new URL("./onboarding-overlay.tsx", import.meta.url), "utf8");
+const source = await readFile(
+  new URL("./onboarding-overlay.tsx", import.meta.url),
+  "utf8",
+);
 
 assert.match(
   source,
@@ -36,14 +39,20 @@ assert.match(
 
 assert.match(
   source,
-  /xl:col-span-4[\s\S]*Local adapters/,
-  "Local adapters should occupy a peer bento card in the same grid",
+  /xl:col-span-4[\s\S]*Available harnesses/,
+  "Local harnesses should occupy a peer bento card in the same grid",
 );
 
 assert.match(
   source,
-  /xl:col-span-4[\s\S]*OpenClaw agents/,
+  /xl:col-span-4[\s\S]*Existing OpenClaw agents/,
   "OpenClaw agents should occupy a peer bento card in the same grid",
+);
+
+assert.match(
+  source,
+  /Codex[\s\S]*Claude Code[\s\S]*Hermes[\s\S]*OpenClaw/,
+  "Setup copy should present Codex, Claude Code, Hermes, and OpenClaw as peer ways to create a first familiar",
 );
 
 assert.match(

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -4,7 +4,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import type { IconName } from "@/lib/icon";
 
-type PruneState = { idle: true } | { counting: true } | { count: number } | { pruning: true } | { pruned: number } | { error: string };
+type PruneState =
+  | { idle: true }
+  | { counting: true }
+  | { count: number }
+  | { pruning: true }
+  | { pruned: number }
+  | { error: string };
 type Step = { ok: boolean; detail?: string; hint?: string };
 type PlatformId = "windows" | "linux" | "mac" | "unknown";
 
@@ -40,26 +46,30 @@ type OpenClawAgent = {
   workspacePath: string | null;
 };
 
-const PLATFORM_COPY: Record<PlatformId, {
-  label: string;
-  installCommand: string;
-  caveInstall: string[];
-  cliInstall: string[];
-  warning?: string;
-}> = {
+const PLATFORM_COPY: Record<
+  PlatformId,
+  {
+    label: string;
+    installCommand: string;
+    caveInstall: string[];
+    cliInstall: string[];
+    warning?: string;
+  }
+> = {
   windows: {
     label: "Windows",
     installCommand: "where coven",
-    warning: "For now, turn off Smart App Control before downloading or opening the Windows build.",
+    warning:
+      "For now, turn off Smart App Control before downloading or opening the Windows build.",
     caveInstall: [
       "Download the MSI from the official GitHub Release.",
       "Before downloading/opening, go to Settings > Privacy & security > Windows Security > App & browser control > Smart App Control, then turn Smart App Control off for now.",
       "Install CovenCave, then open it from Start.",
     ],
     cliInstall: [
-      "Install the coven CLI from OpenCoven/coven.",
-      "Make sure coven.exe is on PATH.",
-      "Click Re-check here after a new terminal can run coven.",
+      "Install the coven CLI from OpenCoven/coven or use the bundled CLI when available.",
+      "Make sure coven.exe is on PATH if you installed it separately.",
+      "Click Re-check after Windows can run coven from a new terminal.",
     ],
   },
   linux: {
@@ -113,8 +123,11 @@ type Props = {
 
 function detectPlatform(): PlatformId {
   if (typeof navigator === "undefined") return "unknown";
-  const nav = navigator as Navigator & { userAgentData?: { platform?: string } };
-  const raw = `${nav.userAgentData?.platform ?? navigator.platform ?? navigator.userAgent}`.toLowerCase();
+  const nav = navigator as Navigator & {
+    userAgentData?: { platform?: string };
+  };
+  const raw =
+    `${nav.userAgentData?.platform ?? navigator.platform ?? navigator.userAgent}`.toLowerCase();
   if (raw.includes("win")) return "windows";
   if (raw.includes("linux")) return "linux";
   if (raw.includes("mac")) return "mac";
@@ -125,8 +138,10 @@ function stepCount(status: OnboardingStatus | null): number {
   return Object.values(status?.steps ?? {}).filter((s) => s.ok).length;
 }
 
-const BENTO_CARD = "rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 p-4";
-const BENTO_CARD_SOFT = "rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/25 p-4";
+const BENTO_CARD =
+  "rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 p-4";
+const BENTO_CARD_SOFT =
+  "rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/25 p-4";
 
 export function OnboardingOverlay({ open, onDismiss }: Props) {
   const [status, setStatus] = useState<OnboardingStatus | null>(null);
@@ -140,7 +155,9 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   const [familiarGlyph, setFamiliarGlyph] = useState("ph:sparkle-fill");
   const [openclawAgents, setOpenclawAgents] = useState<OpenClawAgent[]>([]);
   const [harnesses, setHarnesses] = useState<HarnessReport[]>([]);
-  const [selectedHarnessId, setSelectedHarnessId] = useState<string | null>(null);
+  const [selectedHarnessId, setSelectedHarnessId] = useState<string | null>(
+    null,
+  );
   const [agentsLoading, setAgentsLoading] = useState(false);
   const [agentsError, setAgentsError] = useState<string | null>(null);
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
@@ -165,19 +182,28 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
     setAgentsError(null);
     try {
       const res = await fetch("/api/openclaw-agents", { cache: "no-store" });
-      const json = await res.json() as { ok?: boolean; agents?: OpenClawAgent[]; error?: string };
-      if (!res.ok || json.ok === false) throw new Error(json.error ?? "failed to load OpenClaw agents");
+      const json = (await res.json()) as {
+        ok?: boolean;
+        agents?: OpenClawAgent[];
+        error?: string;
+      };
+      if (!res.ok || json.ok === false)
+        throw new Error(json.error ?? "failed to load OpenClaw agents");
       const agents = json.agents ?? [];
       setOpenclawAgents(agents);
       setSelectedAgentId((current) => {
         if (current || !agents[0]) return current;
         setFamiliarName(agents[0].displayName);
         setFamiliarRole(agents[0].role);
-        setFamiliarDescription(`Connected to OpenClaw agent "${agents[0].id}".`);
+        setFamiliarDescription(
+          `Connected to OpenClaw agent "${agents[0].id}".`,
+        );
         return agents[0].id;
       });
     } catch (err) {
-      setAgentsError(err instanceof Error ? err.message : "failed to load OpenClaw agents");
+      setAgentsError(
+        err instanceof Error ? err.message : "failed to load OpenClaw agents",
+      );
     } finally {
       setAgentsLoading(false);
     }
@@ -186,15 +212,25 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   const loadHarnesses = useCallback(async () => {
     try {
       const res = await fetch("/api/harnesses", { cache: "no-store" });
-      const json = await res.json() as { ok?: boolean; harnesses?: HarnessReport[] };
+      const json = (await res.json()) as {
+        ok?: boolean;
+        harnesses?: HarnessReport[];
+      };
       if (!res.ok || json.ok === false) return;
       const next = json.harnesses ?? [];
       setHarnesses(next);
       setSelectedHarnessId((current) => {
-        if (current && next.some((adapter) => adapter.id === current && adapter.installed)) return current;
-        return next.find((adapter) => adapter.installed && adapter.chatSupported)?.id
-          ?? next.find((adapter) => adapter.installed)?.id
-          ?? current;
+        if (
+          current &&
+          next.some((adapter) => adapter.id === current && adapter.installed)
+        )
+          return current;
+        return (
+          next.find((adapter) => adapter.installed && adapter.chatSupported)
+            ?.id ??
+          next.find((adapter) => adapter.installed)?.id ??
+          current
+        );
       });
     } catch {
       /* harness availability is advisory; status cards carry setup hints */
@@ -229,13 +265,44 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
     }
   };
 
+  const copyDiagnostics = async () => {
+    await copyText(
+      JSON.stringify(
+        {
+          platform,
+          setupComplete: status?.complete ?? false,
+          steps: status?.steps ?? null,
+          harnesses: harnesses.map((adapter) => ({
+            id: adapter.id,
+            label: adapter.label,
+            installed: adapter.installed,
+            path: adapter.path,
+            version: adapter.version,
+            chatSupported: adapter.chatSupported,
+            installHint: adapter.installHint,
+            source: adapter.source,
+            manifestPath: adapter.manifestPath,
+          })),
+          openclawAgents: openclawAgents.map((agent) => ({
+            id: agent.id,
+            displayName: agent.displayName,
+            workspacePath: agent.workspacePath,
+          })),
+        },
+        null,
+        2,
+      ),
+    );
+  };
+
   const scaffoldOnly = async () => {
     setPicking("scaffold");
     setSetupError(null);
     try {
       const res = await fetch("/api/onboarding/setup", { method: "POST" });
       const json = await res.json().catch(() => ({}));
-      if (!res.ok || json.ok === false) throw new Error(json.error ?? "setup failed");
+      if (!res.ok || json.ok === false)
+        throw new Error(json.error ?? "setup failed");
       await refresh();
     } catch (err) {
       setSetupError(err instanceof Error ? err.message : "setup failed");
@@ -245,9 +312,12 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   };
 
   const createFamiliar = async () => {
-    const selectedAgent = openclawAgents.find((agent) => agent.id === selectedAgentId) ?? null;
+    const selectedAgent =
+      openclawAgents.find((agent) => agent.id === selectedAgentId) ?? null;
     if (!selectedAgent) {
-      setSetupError("Pick an OpenClaw agent to connect first.");
+      setSetupError(
+        "Pick an existing OpenClaw agent, or choose Codex, Claude Code, or Hermes from Available harnesses.",
+      );
       return;
     }
     setPicking("familiar");
@@ -268,7 +338,8 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
         }),
       });
       const json = await res.json().catch(() => ({}));
-      if (!res.ok || json.ok === false) throw new Error(json.error ?? "setup failed");
+      if (!res.ok || json.ok === false)
+        throw new Error(json.error ?? "setup failed");
       await refresh();
     } catch (err) {
       setSetupError(err instanceof Error ? err.message : "setup failed");
@@ -278,9 +349,14 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   };
 
   const createLocalFamiliar = async () => {
-    const selectedHarness = harnesses.find((adapter) => adapter.id === selectedHarnessId && adapter.installed) ?? null;
+    const selectedHarness =
+      harnesses.find(
+        (adapter) => adapter.id === selectedHarnessId && adapter.installed,
+      ) ?? null;
     if (!selectedHarness) {
-      setSetupError("Pick an installed local adapter first.");
+      setSetupError(
+        "Pick an installed harness first, or choose an existing OpenClaw agent.",
+      );
       return;
     }
     setPicking("local");
@@ -294,7 +370,9 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
             id: `${selectedHarness.id}-local`,
             displayName: familiarName.trim() || selectedHarness.label,
             role: familiarRole.trim() || "Code Familiar",
-            description: familiarDescription.trim() || `Local ${selectedHarness.label} adapter on this machine.`,
+            description:
+              familiarDescription.trim() ||
+              `Local ${selectedHarness.label} adapter on this machine.`,
             glyph: familiarGlyph,
             harness: selectedHarness.id,
             model: `${selectedHarness.id}-local`,
@@ -302,7 +380,8 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
         }),
       });
       const json = await res.json().catch(() => ({}));
-      if (!res.ok || json.ok === false) throw new Error(json.error ?? "setup failed");
+      if (!res.ok || json.ok === false)
+        throw new Error(json.error ?? "setup failed");
       await refresh();
     } catch (err) {
       setSetupError(err instanceof Error ? err.message : "setup failed");
@@ -317,7 +396,8 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
     try {
       const res = await fetch("/api/daemon/start", { method: "POST" });
       const json = await res.json().catch(() => ({}));
-      if (!res.ok || json.ok === false) throw new Error(json.error ?? "daemon start failed");
+      if (!res.ok || json.ok === false)
+        throw new Error(json.error ?? "daemon start failed");
       await refresh();
     } catch (err) {
       setSetupError(err instanceof Error ? err.message : "daemon start failed");
@@ -345,7 +425,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
       },
       {
         key: "adapters",
-        title: "Find local adapter",
+        title: "Find runtime source",
         ok: !!s?.adapters.ok,
         detail: s?.adapters.detail ?? s?.adapters.hint ?? "checking...",
         icon: "ph:terminal-window",
@@ -371,7 +451,13 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
         detail: s?.familiars.detail ?? s?.familiars.hint ?? "checking...",
         icon: "ph:user",
       },
-    ] satisfies Array<{ key: string; title: string; ok: boolean; detail: string; icon: IconName }>;
+    ] satisfies Array<{
+      key: string;
+      title: string;
+      ok: boolean;
+      detail: string;
+      icon: IconName;
+    }>;
   }, [status]);
 
   if (!open) return null;
@@ -396,7 +482,10 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
               Set up CovenCave on this machine.
             </h1>
             <p className="mt-2 max-w-2xl text-[13px] leading-6 text-[var(--text-secondary)]">
-              Cave checks your local runtime, creates only your Coven files, and helps you add a first familiar that belongs to you.
+              Cave checks Codex, Claude Code, Hermes, and OpenClaw as equal ways
+              to create your first functional familiar. It creates only your
+              Coven files and shows exactly what still needs setup on this
+              machine.
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
@@ -407,6 +496,13 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
               <Icon name="ph:arrows-clockwise-bold" />
               Re-check
             </button>
+            <button
+              onClick={() => void copyDiagnostics()}
+              className="inline-flex items-center gap-2 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-2 text-[12px] text-[var(--text-primary)] hover:border-[var(--border-strong)]"
+            >
+              <Icon name="ph:clipboard-text" />
+              Copy diagnostics
+            </button>
             <div className="rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-2 text-[12px] text-[var(--text-secondary)]">
               {stepCount(status)}/6 ready
             </div>
@@ -416,7 +512,11 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
         {platformCopy.warning ? (
           <section className="mt-5 rounded-lg border border-[color-mix(in_oklch,var(--color-warning)_50%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_12%,transparent)] p-4 text-[13px] text-[var(--color-warning)]">
             <div className="flex items-start gap-3">
-              <Icon name="ph:warning-fill" width={18} className="mt-0.5 shrink-0 text-[var(--color-warning)]" />
+              <Icon
+                name="ph:warning-fill"
+                width={18}
+                className="mt-0.5 shrink-0 text-[var(--color-warning)]"
+              />
               <div>
                 <div className="font-semibold">Windows download notice</div>
                 <p className="mt-1 leading-6">{platformCopy.warning}</p>
@@ -435,19 +535,26 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
           <section className={`${BENTO_CARD} lg:col-span-12`}>
             <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
               <div>
-                <h2 className="text-[13px] font-semibold text-[var(--text-primary)]">Setup progress</h2>
+                <h2 className="text-[13px] font-semibold text-[var(--text-primary)]">
+                  Setup progress
+                </h2>
                 <p className="mt-1 text-[12px] leading-5 text-[var(--text-secondary)]">
-                  Complete each local prerequisite once; Cave keeps checking while you work.
+                  Bring whichever runtime you already use. Cave keeps checking
+                  and turns the first healthy source into a working familiar.
                 </p>
               </div>
-              <span className="font-mono text-[11px] text-[var(--text-muted)]">{stepCount(status)}/6 ready</span>
+              <span className="font-mono text-[11px] text-[var(--text-muted)]">
+                {stepCount(status)}/6 ready
+              </span>
             </div>
             <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
               {steps.map((s, i) => (
                 <div
                   key={s.key}
                   className={`rounded-lg border p-3 ${
-                    s.ok ? "border-[color-mix(in_oklch,var(--color-success)_50%,transparent)] bg-[color-mix(in_oklch,var(--color-success)_20%,transparent)]" : "border-[var(--border-hairline)] bg-[var(--bg-raised)]/30"
+                    s.ok
+                      ? "border-[color-mix(in_oklch,var(--color-success)_50%,transparent)] bg-[color-mix(in_oklch,var(--color-success)_20%,transparent)]"
+                      : "border-[var(--border-hairline)] bg-[var(--bg-raised)]/30"
                   }`}
                 >
                   <div className="flex items-center justify-between gap-2">
@@ -458,12 +565,22 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                           : "border-[var(--border-strong)] text-[var(--text-secondary)]"
                       }`}
                     >
-                      {s.ok ? <Icon name="ph:check-bold" /> : <Icon name={s.icon} />}
+                      {s.ok ? (
+                        <Icon name="ph:check-bold" />
+                      ) : (
+                        <Icon name={s.icon} />
+                      )}
                     </span>
-                    <span className="font-mono text-[11px] text-[var(--text-muted)]">{i + 1}</span>
+                    <span className="font-mono text-[11px] text-[var(--text-muted)]">
+                      {i + 1}
+                    </span>
                   </div>
-                  <div className="mt-3 text-[12px] font-medium text-[var(--text-primary)]">{s.title}</div>
-                  <div className="mt-1 line-clamp-2 text-[11px] leading-4 text-[var(--text-muted)]">{s.detail}</div>
+                  <div className="mt-3 text-[12px] font-medium text-[var(--text-primary)]">
+                    {s.title}
+                  </div>
+                  <div className="mt-1 line-clamp-2 text-[11px] leading-4 text-[var(--text-muted)]">
+                    {s.detail}
+                  </div>
                 </div>
               ))}
             </div>
@@ -472,9 +589,12 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
           <section className={`${BENTO_CARD} lg:col-span-6 xl:col-span-4`}>
             <div className="flex items-center justify-between gap-3">
               <div>
-                <h2 className="text-[13px] font-semibold text-[var(--text-primary)]">Install path</h2>
+                <h2 className="text-[13px] font-semibold text-[var(--text-primary)]">
+                  Install path
+                </h2>
                 <p className="mt-1 text-[12px] leading-5 text-[var(--text-secondary)]">
-                  Follow the path for {platformCopy.label}, then re-check once the CLI is available.
+                  Follow the path for {platformCopy.label}, then re-check once
+                  the CLI is available.
                 </p>
               </div>
               <button
@@ -488,17 +608,26 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
               {platformCopy.installCommand}
             </div>
             <div className="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-1">
-              <InstructionList title="Install CovenCave" items={platformCopy.caveInstall} />
-              <InstructionList title="Install coven CLI" items={platformCopy.cliInstall} />
+              <InstructionList
+                title="Install CovenCave"
+                items={platformCopy.caveInstall}
+              />
+              <InstructionList
+                title="Install coven CLI"
+                items={platformCopy.cliInstall}
+              />
             </div>
           </section>
 
           <section className={`${BENTO_CARD} lg:col-span-6 xl:col-span-4`}>
             <div className="mb-3 flex items-center justify-between gap-3">
               <div>
-                <h2 className="text-[13px] font-semibold text-[var(--text-primary)]">Local adapters</h2>
+                <h2 className="text-[13px] font-semibold text-[var(--text-primary)]">
+                  Available harnesses
+                </h2>
                 <p className="mt-1 text-[12px] leading-5 text-[var(--text-secondary)]">
-                  Pick an installed harness that can back your first local familiar.
+                  Pick Codex, Claude Code, Hermes, or any installed Coven
+                  adapter already on this machine.
                 </p>
               </div>
               <button
@@ -519,7 +648,9 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                       setSelectedHarnessId(adapter.id);
                       setFamiliarName(adapter.label);
                       setFamiliarRole("Code Familiar");
-                      setFamiliarDescription(`Local ${adapter.label} adapter on this machine.`);
+                      setFamiliarDescription(
+                        `Local ${adapter.label} adapter on this machine.`,
+                      );
                     }}
                     disabled={!adapter.installed}
                     className={`rounded-lg border p-3 text-left ${
@@ -531,12 +662,23 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                     }`}
                   >
                     <div className="flex items-center justify-between gap-2">
-                      <span className="truncate text-[13px] font-medium">{adapter.label}</span>
-                      {active ? <Icon name="ph:check-bold" className="text-[var(--accent-presence)]" /> : null}
+                      <span className="truncate text-[13px] font-medium">
+                        {adapter.label}
+                      </span>
+                      {active ? (
+                        <Icon
+                          name="ph:check-bold"
+                          className="text-[var(--accent-presence)]"
+                        />
+                      ) : null}
                     </div>
-                    <div className="mt-1 truncate font-mono text-[11px]">{adapter.binary}</div>
+                    <div className="mt-1 truncate font-mono text-[11px]">
+                      {adapter.binary}
+                    </div>
                     <div className="mt-1 line-clamp-2 text-[11px] leading-4 text-[var(--text-muted)]">
-                      {adapter.installed ? adapter.path ?? "installed" : adapter.installHint}
+                      {adapter.installed
+                        ? (adapter.path ?? "installed")
+                        : adapter.installHint}
                     </div>
                   </button>
                 );
@@ -548,16 +690,19 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
               className="mt-3 inline-flex items-center gap-2 rounded-md bg-[var(--accent-presence)] px-4 py-2 text-[13px] font-medium text-white hover:bg-[var(--accent-presence)] disabled:opacity-50"
             >
               <Icon name="ph:terminal-window" />
-              {picking === "local" ? "Creating..." : "Use local adapter"}
+              {picking === "local" ? "Creating..." : "Use selected harness"}
             </button>
           </section>
 
           <section className={`${BENTO_CARD} lg:col-span-6 xl:col-span-4`}>
             <div className="mb-3 flex items-center justify-between gap-3">
               <div>
-                <h2 className="text-[13px] font-semibold text-[var(--text-primary)]">OpenClaw agents</h2>
+                <h2 className="text-[13px] font-semibold text-[var(--text-primary)]">
+                  Existing OpenClaw agents
+                </h2>
                 <p className="mt-1 text-[12px] leading-5 text-[var(--text-secondary)]">
-                  Connect one existing agent as a Coven familiar when you want continuity.
+                  Pick an existing OpenClaw agent instead when that is the
+                  runtime you already have.
                 </p>
               </div>
               <button
@@ -587,7 +732,9 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                         setSelectedAgentId(agent.id);
                         setFamiliarName(agent.displayName);
                         setFamiliarRole(agent.role);
-                        setFamiliarDescription(`Connected to OpenClaw agent "${agent.id}".`);
+                        setFamiliarDescription(
+                          `Connected to OpenClaw agent "${agent.id}".`,
+                        );
                       }}
                       className={`rounded-lg border p-3 text-left ${
                         active
@@ -596,11 +743,22 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                       }`}
                     >
                       <div className="flex items-center justify-between gap-2">
-                        <span className="truncate text-[13px] font-medium">{agent.displayName}</span>
-                        {active ? <Icon name="ph:check-bold" className="text-[var(--accent-presence)]" /> : null}
+                        <span className="truncate text-[13px] font-medium">
+                          {agent.displayName}
+                        </span>
+                        {active ? (
+                          <Icon
+                            name="ph:check-bold"
+                            className="text-[var(--accent-presence)]"
+                          />
+                        ) : null}
                       </div>
-                      <div className="mt-1 truncate font-mono text-[11px]">{agent.id}</div>
-                      <div className="mt-1 line-clamp-2 text-[11px] leading-4 text-[var(--text-muted)]">{agent.role}</div>
+                      <div className="mt-1 truncate font-mono text-[11px]">
+                        {agent.id}
+                      </div>
+                      <div className="mt-1 line-clamp-2 text-[11px] leading-4 text-[var(--text-muted)]">
+                        {agent.role}
+                      </div>
                     </button>
                   );
                 })}
@@ -611,9 +769,14 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
           <section className={`${BENTO_CARD} lg:col-span-8 xl:col-span-8`}>
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div>
-                <h2 className="text-[14px] font-semibold text-[var(--text-primary)]">Familiar details</h2>
+                <h2 className="text-[14px] font-semibold text-[var(--text-primary)]">
+                  Familiar details
+                </h2>
                 <p className="mt-1 text-[12px] leading-5 text-[var(--text-secondary)]">
-                  Name the familiar, describe the job, then either bind it to a local adapter or connect the selected OpenClaw agent.
+                  Name the familiar, describe the job, then bind it to the
+                  selected harness or OpenClaw agent. This is the same setup
+                  path no matter whether the source is Codex, Claude Code,
+                  Hermes, or OpenClaw.
                 </p>
               </div>
               <button
@@ -627,7 +790,9 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
 
             <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
               <label className="block">
-                <span className="text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]">Name</span>
+                <span className="text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]">
+                  Name
+                </span>
                 <input
                   value={familiarName}
                   onChange={(e) => setFamiliarName(e.target.value)}
@@ -636,7 +801,9 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                 />
               </label>
               <label className="block">
-                <span className="text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]">Role</span>
+                <span className="text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]">
+                  Role
+                </span>
                 <input
                   value={familiarRole}
                   onChange={(e) => setFamiliarRole(e.target.value)}
@@ -645,7 +812,9 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                 />
               </label>
               <label className="block">
-                <span className="text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]">Glyph</span>
+                <span className="text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]">
+                  Glyph
+                </span>
                 <input
                   value={familiarGlyph}
                   onChange={(e) => setFamiliarGlyph(e.target.value)}
@@ -654,7 +823,9 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                 />
               </label>
               <label className="block">
-                <span className="text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]">Description</span>
+                <span className="text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]">
+                  Description
+                </span>
                 <input
                   value={familiarDescription}
                   onChange={(e) => setFamiliarDescription(e.target.value)}
@@ -667,17 +838,27 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
             <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
               <button
                 onClick={createFamiliar}
-                disabled={picking !== null || !selectedAgentId || familiarName.trim().length === 0}
+                disabled={
+                  picking !== null ||
+                  !selectedAgentId ||
+                  familiarName.trim().length === 0
+                }
                 className="inline-flex items-center gap-2 rounded-md bg-[var(--accent-presence)] px-4 py-2 text-[13px] font-medium text-white hover:bg-[var(--accent-presence)] disabled:opacity-50"
               >
                 <Icon name="ph:sparkle" />
-                {picking === "familiar" ? "Connecting..." : "Connect as familiar"}
+                {picking === "familiar"
+                  ? "Connecting..."
+                  : "Connect as familiar"}
               </button>
               <button
                 onClick={startDaemon}
                 disabled={startingDaemon || !status?.steps.covenCli.ok}
                 className="inline-flex items-center gap-2 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-4 py-2 text-[13px] text-[var(--text-primary)] hover:border-[var(--border-strong)] disabled:opacity-50"
-                title={!status?.steps.covenCli.ok ? "Install coven CLI first" : "coven daemon start"}
+                title={
+                  !status?.steps.covenCli.ok
+                    ? "Install coven CLI first"
+                    : "coven daemon start"
+                }
               >
                 <Icon name="ph:rocket-launch-bold" />
                 {startingDaemon ? "Starting..." : "Start daemon"}
@@ -688,19 +869,29 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
           <section className={`${BENTO_CARD_SOFT} lg:col-span-4 xl:col-span-2`}>
             <div className="flex items-center justify-between gap-3">
               <div>
-                <h2 className="text-[13px] font-semibold text-[var(--text-primary)]">Tester demo mode</h2>
+                <h2 className="text-[13px] font-semibold text-[var(--text-primary)]">
+                  Tester demo mode
+                </h2>
                 <p className="mt-1 text-[12px] leading-5 text-[var(--text-secondary)]">
-                  Demo data is opt-in for testers and never appears in normal installs.
+                  Demo data is opt-in for testers and never appears in normal
+                  installs.
                 </p>
               </div>
-              <Icon name="ph:toggle-right-bold" className="text-[var(--text-muted)]" />
+              <Icon
+                name="ph:toggle-right-bold"
+                className="text-[var(--text-muted)]"
+              />
             </div>
             <div className="mt-3 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-2 font-mono text-[12px] text-[var(--text-primary)]">
               NEXT_PUBLIC_DEMO=true pnpm dev
             </div>
           </section>
 
-          <MaintenancePanel prune={prune} setPrune={setPrune} className="lg:col-span-4 xl:col-span-2" />
+          <MaintenancePanel
+            prune={prune}
+            setPrune={setPrune}
+            className="lg:col-span-4 xl:col-span-2"
+          />
         </main>
 
         <footer className="flex items-center justify-between border-t border-[var(--border-hairline)] py-4">
@@ -738,10 +929,15 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
 function InstructionList({ title, items }: { title: string; items: string[] }) {
   return (
     <div>
-      <h3 className="text-[12px] font-semibold text-[var(--text-primary)]">{title}</h3>
+      <h3 className="text-[12px] font-semibold text-[var(--text-primary)]">
+        {title}
+      </h3>
       <ol className="mt-2 space-y-2">
         {items.map((item, index) => (
-          <li key={item} className="flex gap-2 text-[12px] leading-5 text-[var(--text-secondary)]">
+          <li
+            key={item}
+            className="flex gap-2 text-[12px] leading-5 text-[var(--text-secondary)]"
+          >
             <span className="mt-0.5 grid h-5 w-5 shrink-0 place-items-center rounded-full border border-[var(--border-hairline)] text-[10px] text-[var(--text-muted)]">
               {index + 1}
             </span>
@@ -794,10 +990,20 @@ function MaintenancePanel({
                     headers: { "content-type": "application/json" },
                     body: JSON.stringify({ dryRun: true }),
                   });
-                  const json = await res.json() as { ok: boolean; wouldPrune?: number; error?: string };
-                  setPrune(json.ok ? { count: json.wouldPrune ?? 0 } : { error: json.error ?? "dry-run failed" });
+                  const json = (await res.json()) as {
+                    ok: boolean;
+                    wouldPrune?: number;
+                    error?: string;
+                  };
+                  setPrune(
+                    json.ok
+                      ? { count: json.wouldPrune ?? 0 }
+                      : { error: json.error ?? "dry-run failed" },
+                  );
                 } catch (err) {
-                  setPrune({ error: err instanceof Error ? err.message : "fetch failed" });
+                  setPrune({
+                    error: err instanceof Error ? err.message : "fetch failed",
+                  });
                 }
               }}
               className="rounded border border-[var(--border-strong)] bg-[var(--bg-raised)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
@@ -823,10 +1029,21 @@ function MaintenancePanel({
                         headers: { "content-type": "application/json" },
                         body: JSON.stringify({ dryRun: false }),
                       });
-                      const json = await res.json() as { ok: boolean; pruned?: number; error?: string };
-                      setPrune(json.ok ? { pruned: json.pruned ?? 0 } : { error: json.error ?? "prune failed" });
+                      const json = (await res.json()) as {
+                        ok: boolean;
+                        pruned?: number;
+                        error?: string;
+                      };
+                      setPrune(
+                        json.ok
+                          ? { pruned: json.pruned ?? 0 }
+                          : { error: json.error ?? "prune failed" },
+                      );
                     } catch (err) {
-                      setPrune({ error: err instanceof Error ? err.message : "fetch failed" });
+                      setPrune({
+                        error:
+                          err instanceof Error ? err.message : "fetch failed",
+                      });
                     }
                   }}
                   className="rounded bg-[color-mix(in_oklch,var(--color-danger)_80%,transparent)] px-2.5 py-1 text-[11px] text-white hover:bg-[color-mix(in_oklch,var(--color-danger)_85%,white)]"
@@ -834,7 +1051,9 @@ function MaintenancePanel({
                   Delete {prune.count}
                 </button>
               ) : (
-                <span className="text-[11px] text-[var(--text-muted)]">Nothing to prune.</span>
+                <span className="text-[11px] text-[var(--text-muted)]">
+                  Nothing to prune.
+                </span>
               )}
             </>
           ) : null}

--- a/src/lib/harness-adapters.test.ts
+++ b/src/lib/harness-adapters.test.ts
@@ -4,18 +4,34 @@ import {
   COMPATIBILITY_ADAPTERS,
   mergeAdapterReports,
   adapterSetupState,
+  runtimeSourceSetupState,
+  adapterManifestScaffoldForHarness,
   covenHelpSupportsAdapterList,
 } from "./harness-adapters.ts";
 
 assert.deepEqual(
   COMPATIBILITY_ADAPTERS.map((adapter) => adapter.id),
-  ["codex", "claude"],
+  ["codex", "claude", "hermes"],
 );
 
 const merged = mergeAdapterReports(
   [
-    { id: "codex", label: "Codex", binary: "codex", installed: true, path: "/usr/bin/codex", version: "codex 1.0.0" },
-    { id: "claude", label: "Claude Code", binary: "claude", installed: false, path: null, version: null },
+    {
+      id: "codex",
+      label: "Codex",
+      binary: "codex",
+      installed: true,
+      path: "/usr/bin/codex",
+      version: "codex 1.0.0",
+    },
+    {
+      id: "claude",
+      label: "Claude Code",
+      binary: "claude",
+      installed: false,
+      path: null,
+      version: null,
+    },
   ],
   [
     {
@@ -39,19 +55,94 @@ const merged = mergeAdapterReports(
 );
 
 assert.equal(merged.length, 3);
-assert.equal(merged.find((adapter) => adapter.id === "codex")?.source, "bundled");
-assert.equal(merged.find((adapter) => adapter.id === "hermes")?.source, "manifest");
-assert.equal(merged.find((adapter) => adapter.id === "hermes")?.manifestPath, "/tmp/adapters.json");
+assert.equal(
+  merged.find((adapter) => adapter.id === "codex")?.source,
+  "bundled",
+);
+assert.equal(
+  merged.find((adapter) => adapter.id === "hermes")?.source,
+  "manifest",
+);
+assert.equal(
+  merged.find((adapter) => adapter.id === "hermes")?.manifestPath,
+  "/tmp/adapters.json",
+);
+assert.equal(
+  merged.find((adapter) => adapter.id === "hermes")?.chatSupported,
+  true,
+);
 
 assert.deepEqual(adapterSetupState(merged), {
   ok: true,
   detail: "Codex, Hermes Agent",
 });
 
-assert.deepEqual(adapterSetupState(merged.filter((adapter) => !adapter.installed)), {
-  ok: false,
-  hint: "Install Codex or Claude Code, then re-check. External adapters can also be added with Coven adapter manifests.",
+assert.deepEqual(
+  adapterSetupState(merged.filter((adapter) => !adapter.installed)),
+  {
+    ok: false,
+    hint: "Install Codex, Claude Code, Hermes, or connect an OpenClaw agent, then re-check. External adapters can also be added with Coven adapter manifests.",
+  },
+);
+
+assert.deepEqual(
+  runtimeSourceSetupState(
+    merged.map((adapter) => ({ ...adapter, installed: false })),
+    2,
+  ),
+  {
+    ok: true,
+    detail: "2 OpenClaw agents",
+  },
+);
+
+const hermesManifest = adapterManifestScaffoldForHarness("hermes");
+assert.equal(hermesManifest?.filename, "hermes.json");
+assert.deepEqual(JSON.parse(hermesManifest?.contents ?? "{}"), {
+  adapters: [
+    {
+      id: "hermes",
+      label: "Hermes",
+      executable: "hermes",
+      interactive_prompt_prefix_args: ["chat", "--source", "coven", "-q"],
+      non_interactive_prompt_prefix_args: [
+        "chat",
+        "--source",
+        "coven",
+        "-Q",
+        "-q",
+      ],
+      install_hint:
+        "Install Hermes, make sure `hermes` is on PATH, and complete Hermes setup before using this adapter.",
+      system_prompt_flag: null,
+    },
+  ],
 });
+assert.equal(adapterManifestScaffoldForHarness("codex"), null);
+
+assert.deepEqual(
+  runtimeSourceSetupState(
+    [
+      {
+        id: "hermes",
+        label: "Hermes",
+        binary: "hermes",
+        chatSupported: true,
+        installed: true,
+        path: "/usr/bin/hermes",
+        version: "hermes 0.1.0",
+        installHint: "",
+        source: "bundled",
+        manifestPath: null,
+      },
+    ],
+    0,
+  ),
+  {
+    ok: true,
+    detail: "Hermes",
+  },
+);
 
 assert.equal(
   covenHelpSupportsAdapterList(`Coven runs Codex, Claude Code, and future harnesses inside a local, project-scoped session ledger.

--- a/src/lib/harness-adapters.ts
+++ b/src/lib/harness-adapters.ts
@@ -38,7 +38,14 @@ export type AdapterReport = {
   manifestPath: string | null;
 };
 
-export type AdapterSetupState = { ok: true; detail: string } | { ok: false; hint: string };
+export type AdapterSetupState =
+  | { ok: true; detail: string }
+  | { ok: false; hint: string };
+
+export type AdapterManifestScaffold = {
+  filename: string;
+  contents: string;
+};
 
 export const COMPATIBILITY_ADAPTERS: CompatibilityAdapter[] = [
   {
@@ -46,7 +53,8 @@ export const COMPATIBILITY_ADAPTERS: CompatibilityAdapter[] = [
     label: "Codex",
     binary: "codex",
     chatSupported: true,
-    installHint: "Install Codex with `npm install -g @openai/codex`, then run `codex login`.",
+    installHint:
+      "Install Codex with `npm install -g @openai/codex`, then run `codex login`.",
     source: "bundled",
   },
   {
@@ -55,7 +63,18 @@ export const COMPATIBILITY_ADAPTERS: CompatibilityAdapter[] = [
     binary: "claude",
     chatSupported: true,
     versionArgs: ["--version"],
-    installHint: "Install Claude Code with `npm install -g @anthropic-ai/claude-code`, then run `claude doctor`.",
+    installHint:
+      "Install Claude Code with `npm install -g @anthropic-ai/claude-code`, then run `claude doctor`.",
+    source: "bundled",
+  },
+  {
+    id: "hermes",
+    label: "Hermes",
+    binary: "hermes",
+    chatSupported: true,
+    versionArgs: ["--version"],
+    installHint:
+      "Install Hermes, make sure `hermes` is on PATH, then let Cave create its Coven adapter manifest.",
     source: "bundled",
   },
 ];
@@ -65,7 +84,16 @@ export function covenHelpSupportsAdapterList(helpText: string): boolean {
 }
 
 export function mergeAdapterReports(
-  localReports: Array<Partial<AdapterReport> & { id: string; label: string; binary: string; installed: boolean; path: string | null; version: string | null }>,
+  localReports: Array<
+    Partial<AdapterReport> & {
+      id: string;
+      label: string;
+      binary: string;
+      installed: boolean;
+      path: string | null;
+      version: string | null;
+    }
+  >,
   covenReports: CovenAdapterSummary[],
 ): AdapterReport[] {
   const merged = new Map<string, AdapterReport>();
@@ -91,7 +119,7 @@ export function mergeAdapterReports(
       id: coven.id,
       label: coven.label,
       binary: coven.executable,
-      chatSupported: existing?.chatSupported ?? (coven.id === "codex" || coven.id === "claude"),
+      chatSupported: true,
       installed: coven.available || existing?.installed === true,
       path: existing?.path ?? null,
       version: existing?.version ?? null,
@@ -102,7 +130,8 @@ export function mergeAdapterReports(
   }
 
   return [...merged.values()].sort((a, b) => {
-    const rank = (id: string) => (id === "codex" ? 0 : id === "claude" ? 1 : 2);
+    const rank = (id: string) =>
+      id === "codex" ? 0 : id === "claude" ? 1 : id === "hermes" ? 2 : 3;
     return rank(a.id) - rank(b.id) || a.label.localeCompare(b.label);
   });
 }
@@ -110,10 +139,61 @@ export function mergeAdapterReports(
 export function adapterSetupState(reports: AdapterReport[]): AdapterSetupState {
   const ready = reports.filter((adapter) => adapter.installed);
   if (ready.length > 0) {
-    return { ok: true, detail: ready.map((adapter) => adapter.label).join(", ") };
+    return {
+      ok: true,
+      detail: ready.map((adapter) => adapter.label).join(", "),
+    };
   }
   return {
     ok: false,
-    hint: "Install Codex or Claude Code, then re-check. External adapters can also be added with Coven adapter manifests.",
+    hint: "Install Codex, Claude Code, Hermes, or connect an OpenClaw agent, then re-check. External adapters can also be added with Coven adapter manifests.",
+  };
+}
+
+export function runtimeSourceSetupState(
+  reports: AdapterReport[],
+  openclawAgentCount: number,
+): AdapterSetupState {
+  const local = adapterSetupState(reports);
+  if (local.ok) return local;
+  if (openclawAgentCount > 0) {
+    return {
+      ok: true,
+      detail: `${openclawAgentCount} OpenClaw agent${openclawAgentCount === 1 ? "" : "s"}`,
+    };
+  }
+  return local;
+}
+
+export function adapterManifestScaffoldForHarness(
+  harnessId: string,
+): AdapterManifestScaffold | null {
+  if (harnessId !== "hermes") return null;
+  return {
+    filename: "hermes.json",
+    contents: `${JSON.stringify(
+      {
+        adapters: [
+          {
+            id: "hermes",
+            label: "Hermes",
+            executable: "hermes",
+            interactive_prompt_prefix_args: ["chat", "--source", "coven", "-q"],
+            non_interactive_prompt_prefix_args: [
+              "chat",
+              "--source",
+              "coven",
+              "-Q",
+              "-q",
+            ],
+            install_hint:
+              "Install Hermes, make sure `hermes` is on PATH, and complete Hermes setup before using this adapter.",
+            system_prompt_flag: null,
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
   };
 }

--- a/src/lib/onboarding-familiars.test.ts
+++ b/src/lib/onboarding-familiars.test.ts
@@ -33,7 +33,10 @@ assert.match(toml, /harness = "openclaw"/);
 assert.match(toml, /model = "riley"/);
 assert.match(toml, /openclaw_agent = "riley"/);
 
-assert.equal(normalizeFamiliarDraft({ displayName: "Cody", openclawAgentId: "cody" }).id, "cody");
+assert.equal(
+  normalizeFamiliarDraft({ displayName: "Cody", openclawAgentId: "cody" }).id,
+  "cody",
+);
 
 const localDraft = normalizeFamiliarDraft({
   displayName: "Codex Local",
@@ -54,3 +57,23 @@ assert.deepEqual(localDraft, {
 });
 
 assert.equal(normalizeFamiliarDraft({ displayName: "Solo" }).harness, "codex");
+
+const hermesDraft = normalizeFamiliarDraft({
+  displayName: "Hermes Local",
+  role: "Planning",
+  harness: "hermes",
+  model: "hermes-local",
+});
+
+assert.deepEqual(hermesDraft, {
+  id: "hermes-local",
+  displayName: "Hermes Local",
+  role: "Planning",
+  description: "",
+  glyph: "ph:sparkle-fill",
+  harness: "hermes",
+  model: "hermes-local",
+  openclawAgentId: undefined,
+});
+
+assert.match(buildFamiliarsToml(hermesDraft), /harness = "hermes"/);


### PR DESCRIPTION
## Summary
- treats Codex, Claude Code, Hermes, external Coven adapters, and existing OpenClaw agents as peer onboarding sources
- scaffolds a Hermes external adapter manifest during setup when Hermes is selected
- adds Copy diagnostics output and clearer Windows/no-OpenClaw README setup guidance
- routes local Coven harness chat/board enrichment through the generic `coven run <harness> --stream-json` path while skipping OpenClaw bridge familiars

## Verification
- `node --test src/lib/harness-adapters.test.ts src/lib/onboarding-familiars.test.ts src/components/onboarding-bento-layout.test.ts src/app/api/chat/send/harness-routing.test.ts src/app/api/board/enrich-steps/route.test.ts`
- `pnpm typecheck`
- `bunx prettier --check README.md src/app/api/onboarding/status/route.ts src/app/api/onboarding/setup/route.ts src/app/api/chat/send/route.ts src/app/api/board/enrich-steps/route.ts src/components/onboarding-overlay.tsx src/components/onboarding-bento-layout.test.ts src/lib/harness-adapters.ts src/lib/harness-adapters.test.ts src/lib/onboarding-familiars.test.ts src/app/api/chat/send/harness-routing.test.ts`
- `git diff --check`
- `pnpm build` (passes with existing Turbopack NFT warning)
- temp-home browser smoke on `http://127.0.0.1:3025` for onboarding peer-source copy/cards/diagnostics
