### PR TITLE
fix(inspector): wire familiar inbox actions

### DIFF
--- a/src/components/agents-view.tsx
+++ b/src/components/agents-view.tsx
@@ -36,6 +36,9 @@ type Props = {
   onSlashFromChat: (command: string, args: string) => boolean;
   onOpenOnboarding: () => void;
   onOpenInbox: () => void;
+  onCreateReminder: (familiarId: string) => void;
+  onOpenInboxItem: (item: InboxItem) => void;
+  onInboxItemChanged: () => void | Promise<void>;
   onOpenMode: (mode: string) => void;
 };
 
@@ -105,6 +108,9 @@ function RightPanel({
   onOpenOnboarding,
   onSetActiveFamiliar,
   onOpenInbox,
+  onCreateReminder,
+  onOpenInboxItem,
+  onInboxItemChanged,
 }: {
   panel: "inspector" | "chat";
   activeFamiliar: Familiar | null;
@@ -119,6 +125,9 @@ function RightPanel({
   onOpenOnboarding: () => void;
   onSetActiveFamiliar: (id: string) => void;
   onOpenInbox: () => void;
+  onCreateReminder: (familiarId: string) => void;
+  onOpenInboxItem: (item: InboxItem) => void;
+  onInboxItemChanged: () => void | Promise<void>;
 }) {
   return (
     <aside className="relative hidden h-full min-h-0 w-[320px] shrink-0 border-l border-[var(--border-hairline)] lg:flex lg:flex-col">
@@ -145,7 +154,14 @@ function RightPanel({
       </div>
       <div className="min-h-0 flex-1 overflow-hidden">
         {panel === "inspector" && (
-          <InspectorPane familiar={activeFamiliar} inboxItems={inboxItems} onOpenInbox={onOpenInbox} />
+          <InspectorPane
+            familiar={activeFamiliar}
+            inboxItems={inboxItems}
+            onOpenInbox={onOpenInbox}
+            onCreateReminder={onCreateReminder}
+            onOpenInboxItem={onOpenInboxItem}
+            onInboxItemChanged={onInboxItemChanged}
+          />
         )}
         {panel === "chat" && (
           <AgentPanel
@@ -188,6 +204,9 @@ export function AgentsView({
   onSlashFromChat,
   onOpenOnboarding,
   onOpenInbox,
+  onCreateReminder,
+  onOpenInboxItem,
+  onInboxItemChanged,
   onOpenMode,
 }: Props) {
   const [scope, setScope] = useState<AgentsScope>("sessions");
@@ -491,6 +510,9 @@ export function AgentsView({
                 onOpenOnboarding={onOpenOnboarding}
                 onSetActiveFamiliar={onSetActiveFamiliar}
                 onOpenInbox={onOpenInbox}
+                onCreateReminder={onCreateReminder}
+                onOpenInboxItem={onOpenInboxItem}
+                onInboxItemChanged={onInboxItemChanged}
               />
             )}
           </div>

--- a/src/components/inspector-inbox.test.ts
+++ b/src/components/inspector-inbox.test.ts
@@ -1,0 +1,73 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const inspectorPane = await readFile(new URL("./inspector-pane.tsx", import.meta.url), "utf8");
+const agentsView = await readFile(new URL("./agents-view.tsx", import.meta.url), "utf8");
+const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
+
+assert.match(
+  inspectorPane,
+  /import \{ SnoozeMenu \} from "@\/components\/snooze-menu";/,
+  "Inspector Inbox should use the shared snooze menu instead of a fixed 10-minute-only action",
+);
+
+assert.match(
+  inspectorPane,
+  /onCreateReminder\?: \(familiarId: string\) => void;/,
+  "InspectorPane should expose a familiar-scoped reminder creation callback",
+);
+
+assert.match(
+  inspectorPane,
+  /onOpenInboxItem\?: \(item: InboxItem\) => void;/,
+  "InspectorPane should expose item routing for session-backed Inbox items",
+);
+
+assert.match(
+  inspectorPane,
+  /onInboxItemChanged\?: \(\) => void \| Promise<void>;/,
+  "Inspector Inbox actions should be able to refresh parent Inbox state after writes",
+);
+
+assert.match(
+  inspectorPane,
+  /onCreateReminder\(familiar\.id\)/,
+  "Inspector Inbox should create reminders already scoped to the selected familiar",
+);
+
+assert.match(
+  inspectorPane,
+  /<SnoozeMenu[\s\S]*size="xs"[\s\S]*onSnooze=\{\(untilIso\) => runItemAction\(it, "snooze",/,
+  "Inspector Inbox should expose the same snooze presets as the toast/full Inbox surfaces",
+);
+
+assert.match(
+  inspectorPane,
+  /onOpenInboxItem\?\.\(it\)/,
+  "Inspector Inbox rows should route through the parent instead of dead-ending in the side pane",
+);
+
+assert.match(
+  inspectorPane,
+  /await onInboxItemChanged\?\.\(\);/,
+  "Inspector Inbox write actions should refresh the parent after the API call resolves",
+);
+
+assert.match(
+  agentsView,
+  /onCreateReminder=\{onCreateReminder\}[\s\S]*onOpenInboxItem=\{onOpenInboxItem\}[\s\S]*onInboxItemChanged=\{onInboxItemChanged\}/,
+  "AgentsView should thread Inspector Inbox callbacks into the right panel",
+);
+
+assert.match(
+  workspace,
+  /const openReminderForFamiliar = useCallback\(\(familiarId: string\) => \{[\s\S]*setActiveId\(familiarId\);[\s\S]*openReminderModal\(\);/,
+  "Workspace should open the reminder modal with the Inspector familiar selected",
+);
+
+assert.match(
+  workspace,
+  /const openInspectorInboxItem = useCallback\(\(item: InboxItem\) => \{[\s\S]*openAgentSession\(sessionId, item\.familiarId\)[\s\S]*setMode\("schedules"\)/,
+  "Workspace should route Inspector Inbox items to chat sessions when possible and Schedules otherwise",
+);

--- a/src/components/inspector-inbox.test.ts
+++ b/src/components/inspector-inbox.test.ts
@@ -55,6 +55,12 @@ assert.match(
 );
 
 assert.match(
+  inspectorPane,
+  /fetch\(`\/api\/inbox\/\$\{encodeURIComponent\(item\.id\)\}\/\$\{action\}`/,
+  "Inspector Inbox should URL-encode item ids before calling per-item action routes",
+);
+
+assert.match(
   agentsView,
   /onCreateReminder=\{onCreateReminder\}[\s\S]*onOpenInboxItem=\{onOpenInboxItem\}[\s\S]*onInboxItemChanged=\{onInboxItemChanged\}/,
   "AgentsView should thread Inspector Inbox callbacks into the right panel",

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -8,6 +8,7 @@ import { SyntaxBlock, MarkdownBlock } from "@/components/message-bubble";
 import { EvalLoopPanel } from "@/components/eval-loop-panel";
 import { MemoryInspectorPanel } from "@/components/memory-inspector-panel";
 import { VaultPanel } from "@/components/vault-panel";
+import { SnoozeMenu } from "@/components/snooze-menu";
 import { Icon } from "@/lib/icon";
 import type { HarnessCapabilityManifest } from "@/app/api/capabilities/route";
 import type { RoleEntry } from "@/app/api/roles/route";
@@ -42,6 +43,9 @@ type Props = {
   familiar: Familiar | null;
   inboxItems?: InboxItem[];
   onOpenInbox?: () => void;
+  onCreateReminder?: (familiarId: string) => void;
+  onOpenInboxItem?: (item: InboxItem) => void;
+  onInboxItemChanged?: () => void | Promise<void>;
 };
 
 const TAB_LABEL: Record<Tab, string> = {
@@ -62,7 +66,14 @@ function age(iso: string): string {
   return `${Math.floor(h / 24)}d`;
 }
 
-export function InspectorPane({ familiar, inboxItems = [], onOpenInbox }: Props) {
+export function InspectorPane({
+  familiar,
+  inboxItems = [],
+  onOpenInbox,
+  onCreateReminder,
+  onOpenInboxItem,
+  onInboxItemChanged,
+}: Props) {
   const [tab, setTab] = useState<Tab>("memory");
 
   const familiarInbox = useMemo(() => {
@@ -113,6 +124,9 @@ export function InspectorPane({ familiar, inboxItems = [], onOpenInbox }: Props)
             familiar={familiar}
             items={familiarInbox}
             onOpenInbox={onOpenInbox}
+            onCreateReminder={onCreateReminder}
+            onOpenInboxItem={onOpenInboxItem}
+            onInboxItemChanged={onInboxItemChanged}
           />
         ) : null}
         {tab === "vault" ? <VaultPanel /> : null}
@@ -127,11 +141,54 @@ function InboxTab({
   familiar,
   items,
   onOpenInbox,
+  onCreateReminder,
+  onOpenInboxItem,
+  onInboxItemChanged,
 }: {
   familiar: Familiar | null;
   items: InboxItem[];
   onOpenInbox?: () => void;
+  onCreateReminder?: (familiarId: string) => void;
+  onOpenInboxItem?: (item: InboxItem) => void;
+  onInboxItemChanged?: () => void | Promise<void>;
 }) {
+  const [busyItemId, setBusyItemId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function runItemAction(
+    item: InboxItem,
+    action: "snooze" | "dismiss" | "done",
+    untilIso?: string,
+  ) {
+    if (item.id.startsWith("eph:")) {
+      onOpenInboxItem?.(item);
+      return;
+    }
+
+    setBusyItemId(item.id);
+    setError(null);
+    try {
+      const init: RequestInit =
+        action === "snooze"
+          ? {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify(untilIso ? { untilIso } : { minutes: 10 }),
+            }
+          : { method: "POST" };
+      const res = await fetch(`/api/inbox/${item.id}/${action}`, init);
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || json?.ok === false) {
+        throw new Error(json?.error ?? `${action} failed`);
+      }
+      await onInboxItemChanged?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : `${action} failed`);
+    } finally {
+      setBusyItemId(null);
+    }
+  }
+
   if (!familiar) {
     return (
       <p className="p-4 text-xs text-[var(--text-muted)]">
@@ -139,91 +196,144 @@ function InboxTab({
       </p>
     );
   }
-  if (items.length === 0) {
-    return (
-      <div className="p-4 text-xs text-[var(--text-muted)]">
-        Nothing scheduled for {familiar.display_name}.
+
+  const header = (
+    <div className="flex items-center justify-between gap-2 border-b border-[var(--border-hairline)] px-3 py-2">
+      <div className="min-w-0">
+        <div className="truncate text-[11px] font-medium text-[var(--text-primary)]">
+          {familiar.display_name} Inbox
+        </div>
+        <div className="text-[10px] text-[var(--text-muted)]">
+          {items.length} active item{items.length === 1 ? "" : "s"}
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
         {onOpenInbox ? (
           <button
+            type="button"
             onClick={onOpenInbox}
-            className="ml-1 text-[var(--accent-presence)] hover:text-[var(--accent-presence)]"
+            className="rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2 py-1 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
           >
-            Create →
+            Schedules
           </button>
         ) : null}
+        {onCreateReminder ? (
+          <button
+            type="button"
+            onClick={() => onCreateReminder(familiar.id)}
+            className="rounded bg-[var(--accent-presence)] px-2 py-1 text-[10px] font-semibold text-[var(--text-primary)] hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,white)]"
+          >
+            New
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+
+  if (items.length === 0) {
+    return (
+      <div className="text-xs">
+        {header}
+        <div className="p-4 text-[var(--text-muted)]">
+          Nothing scheduled for {familiar.display_name}.
+          {onCreateReminder ? (
+            <button
+              type="button"
+              onClick={() => onCreateReminder(familiar.id)}
+              className="ml-1 text-[var(--accent-presence)] hover:text-[var(--text-primary)]"
+            >
+              Create one
+            </button>
+          ) : null}
+        </div>
       </div>
     );
   }
   return (
-    <ul className="p-2 text-xs">
-      {items.map((it) => (
-        <li
-          key={it.id}
-          className="mb-2 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 py-2"
-        >
-          <div className="flex items-start justify-between gap-2">
-            <span className="flex-1 truncate text-[var(--text-primary)]">{it.title}</span>
-            <span
-              className={`shrink-0 rounded px-1 py-px text-[9px] uppercase tracking-widest ${
-                it.status === "fired"
-                  ? "bg-[color-mix(in_oklch,var(--color-warning)_20%,transparent)] text-[var(--color-warning)]"
-                  : "bg-[color-mix(in_oklch,var(--accent-presence-soft)_20%,transparent)] text-[var(--accent-presence-soft)]"
-              }`}
+    <div className="text-xs">
+      {header}
+      {error ? (
+        <div className="border-b border-[color-mix(in_oklch,var(--color-danger)_35%,transparent)] bg-[color-mix(in_oklch,var(--color-danger)_12%,transparent)] px-3 py-1.5 text-[10px] text-[var(--color-danger)]">
+          {error}
+        </div>
+      ) : null}
+      <ul className="p-2">
+        {items.map((it) => {
+          const busy = busyItemId === it.id;
+          const canOpen = !!onOpenInboxItem;
+          return (
+            <li
+              key={it.id}
+              className="mb-2 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 py-2"
             >
-              {it.status}
-            </span>
-          </div>
-          {it.body ? (
-            <p className="mt-1 line-clamp-2 text-[10px] text-[var(--text-muted)]">{it.body}</p>
-          ) : null}
-          <div className="mt-1 text-[10px] text-[var(--text-muted)]">
-            {it.status === "fired"
-              ? `fired ${age(it.firedAt ?? it.updatedAt)} ago`
-              : `in ${age(it.fireAt ?? it.updatedAt)}`}
-          </div>
-          <div className="mt-1.5 flex gap-1">
-            {it.id.startsWith("eph:") ? (
-              <span className="text-[10px] italic text-[var(--text-muted)]">
-                respond in chat to clear
-              </span>
-            ) : (
-              <>
-                <button
-                  onClick={() =>
-                    void fetch(`/api/inbox/${it.id}/snooze`, {
-                      method: "POST",
-                      headers: { "content-type": "application/json" },
-                      body: JSON.stringify({ minutes: 10 }),
-                    })
-                  }
-                  className="rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+              <div className="flex items-start justify-between gap-2">
+                <span className="flex-1 truncate text-[var(--text-primary)]">{it.title}</span>
+                <span
+                  className={`shrink-0 rounded px-1 py-px text-[9px] uppercase tracking-widest ${
+                    it.status === "fired"
+                      ? "bg-[color-mix(in_oklch,var(--color-warning)_20%,transparent)] text-[var(--color-warning)]"
+                      : "bg-[color-mix(in_oklch,var(--accent-presence-soft)_20%,transparent)] text-[var(--accent-presence-soft)]"
+                  }`}
                 >
-                  Snooze 10m
-                </button>
-                <button
-                  onClick={() =>
-                    void fetch(`/api/inbox/${it.id}/dismiss`, { method: "POST" })
-                  }
-                  className="rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
-                >
-                  Dismiss
-                </button>
-                {it.status === "fired" ? (
+                  {it.status}
+                </span>
+              </div>
+              {it.body ? (
+                <p className="mt-1 line-clamp-2 text-[10px] text-[var(--text-muted)]">{it.body}</p>
+              ) : null}
+              <div className="mt-1 text-[10px] text-[var(--text-muted)]">
+                {it.status === "fired"
+                  ? `fired ${age(it.firedAt ?? it.updatedAt)} ago`
+                  : it.kind === "response-needed"
+                    ? "waiting on you"
+                    : `in ${age(it.fireAt ?? it.updatedAt)}`}
+              </div>
+              <div className="mt-1.5 flex flex-wrap gap-1">
+                {canOpen ? (
                   <button
-                    onClick={() =>
-                      void fetch(`/api/inbox/${it.id}/done`, { method: "POST" })
-                    }
+                    type="button"
+                    onClick={() => onOpenInboxItem?.(it)}
                     className="rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
                   >
-                    Done
+                    Open
                   </button>
                 ) : null}
-              </>
-            )}
-          </div>
-        </li>
-      ))}
-    </ul>
+                {it.id.startsWith("eph:") ? (
+                  <span className="text-[10px] italic text-[var(--text-muted)]">
+                    respond in chat to clear
+                  </span>
+                ) : (
+                  <>
+                    <SnoozeMenu
+                      size="xs"
+                      onSnooze={(untilIso) => runItemAction(it, "snooze", untilIso)}
+                    />
+                    <button
+                      type="button"
+                      disabled={busy}
+                      onClick={() => void runItemAction(it, "dismiss")}
+                      className="rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] disabled:opacity-50"
+                    >
+                      Dismiss
+                    </button>
+                    {it.status === "fired" ? (
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => void runItemAction(it, "done")}
+                        className="rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] disabled:opacity-50"
+                      >
+                        Done
+                      </button>
+                    ) : null}
+                  </>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
   );
 }
 

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -176,7 +176,7 @@ function InboxTab({
               body: JSON.stringify(untilIso ? { untilIso } : { minutes: 10 }),
             }
           : { method: "POST" };
-      const res = await fetch(`/api/inbox/${item.id}/${action}`, init);
+      const res = await fetch(`/api/inbox/${encodeURIComponent(item.id)}/${action}`, init);
       const json = await res.json().catch(() => ({}));
       if (!res.ok || json?.ok === false) {
         throw new Error(json?.error ?? `${action} failed`);

--- a/src/components/workspace-inspector-mount.test.ts
+++ b/src/components/workspace-inspector-mount.test.ts
@@ -12,8 +12,8 @@ assert.match(
 
 assert.match(
   workspace,
-  /<AgentsView[\s\S]*inboxItems=\{inboxItemsWithEphemeral\}[\s\S]*onOpenInbox=\{\(\) => setMode\("inbox"\)\}/,
-  "Agents mode should mount the integrated view with the inbox-backed inspector data",
+  /<AgentsView[\s\S]*inboxItems=\{inboxItemsWithEphemeral\}[\s\S]*onOpenInbox=\{\(\) => setMode\("schedules"\)\}[\s\S]*onCreateReminder=\{openReminderForFamiliar\}[\s\S]*onOpenInboxItem=\{openInspectorInboxItem\}[\s\S]*onInboxItemChanged=\{refreshInbox\}/,
+  "Agents mode should mount the integrated view with fully wired familiar Inbox controls",
 );
 
 assert.match(

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -405,6 +405,11 @@ export function Workspace() {
     setReminderModalOpen(true);
   }, []);
 
+  const openReminderForFamiliar = useCallback((familiarId: string) => {
+    setActiveId(familiarId);
+    openReminderModal();
+  }, [openReminderModal]);
+
   const pushToast = useCallback((title: string) => {
     const id = `eph:adhoc-${Date.now()}`;
     setToasts((prev) => [...prev, { id, title }]);
@@ -441,6 +446,17 @@ export function Workspace() {
       );
     }, 0);
   }, []);
+
+  const openInspectorInboxItem = useCallback((item: InboxItem) => {
+    const sessionId =
+      item.sessionId ?? (item.link?.kind === "session" ? item.link.ref : null);
+    if (sessionId) {
+      openAgentSession(sessionId, item.familiarId);
+      return;
+    }
+    if (item.familiarId) setActiveId(item.familiarId);
+    setMode("schedules");
+  }, [openAgentSession]);
 
   const startAgentChat = useCallback((familiarId?: string | null, projectRoot?: string | null) => {
     if (familiarId) setActiveId(familiarId);
@@ -762,7 +778,10 @@ export function Workspace() {
           return true;
         }}
         onOpenOnboarding={openOnboarding}
-        onOpenInbox={() => setMode("inbox")}
+        onOpenInbox={() => setMode("schedules")}
+        onCreateReminder={openReminderForFamiliar}
+        onOpenInboxItem={openInspectorInboxItem}
+        onInboxItemChanged={refreshInbox}
         onOpenMode={(nextMode) => setMode(nextMode as WorkspaceMode)}
       />
     ) : mode === "library" ? (


### PR DESCRIPTION
## Summary
- make the Inspector Inbox a familiar-scoped action surface for reminders and response-needed items
- add familiar-scoped reminder creation plus Open, Snooze, Dismiss, and Done actions in the Inspector pane
- route session-backed Inspector Inbox items into the familiar chat and non-session reminders to Schedules

## Verification
- node src/components/inspector-inbox.test.ts && node src/components/agents-view.test.ts && node src/components/workspace-inspector-mount.test.ts && node src/components/agents-chat-switching.test.ts
- pnpm typecheck
- pnpm build
- git diff --check

## Notes
- Existing Node .test.ts module-type warnings still print during focused guards.
- Existing Next/Turbopack worktree-root/NFT warning still prints during build.