### PR TITLE
fix(ui): add chats and sessions navigation

### DIFF
--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -7,9 +7,6 @@ import { Icon } from "@/lib/icon";
 import { useKeySymbols } from "@/lib/platform-keys";
 import { OriginChip } from "@/components/ui/origin-chip";
 import { FamiliarSwitcher } from "@/components/familiar-switcher";
-import { FamiliarGlyph } from "@/components/familiar-glyph";
-import { resolveFamiliarGlyph } from "@/lib/familiar-glyph";
-import { useGlyphOverrides } from "@/lib/cave-glyph-overrides";
 
 type Props = {
   familiar: Familiar;
@@ -66,8 +63,6 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   const [activeId, setActiveId] = useState<string | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
   const keys = useKeySymbols();
-  const glyphOverrides = useGlyphOverrides();
-  const glyph = resolveFamiliarGlyph(familiar, glyphOverrides);
 
   // Focus search on Cmd+F / Ctrl+F
   useEffect(() => {
@@ -151,12 +146,6 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
       {/* ── Agent dossier + command strip ── */}
       <header className="agent-panel-dossier border-b border-[var(--border-hairline)] bg-[var(--bg-base)] px-4 py-3">
         <div className="flex min-w-0 items-start gap-3">
-          <span
-            className="grid h-10 w-10 shrink-0 place-items-center rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]"
-            aria-hidden
-          >
-            <FamiliarGlyph glyph={glyph} size="md" />
-          </span>
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 items-center gap-2">
               <FamiliarSwitcher familiar={familiar} familiars={familiars} onSelect={onFamiliarSelect} />

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -40,3 +40,15 @@ assert.match(
   /onClick=\{\(\) => \{ setManuallyToggled\(true\); setOpen\(\(v\) => !v\); \}\}/,
   "Tool group header clicks should pin manual open/closed state",
 );
+
+assert.match(
+  source,
+  /<header className="flex w-full items-center gap-2/,
+  "Chat header should span the full side-panel width",
+);
+
+assert.match(
+  source,
+  /<FamiliarSwitcher familiar=\{familiar\} familiars=\{familiars\} onSelect=\{onFamiliarSelect\} \/>/,
+  "Chat header should expose familiar switching through the side-panel picker",
+);

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -682,7 +682,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   return (
     <section className="flex h-full flex-col bg-[var(--bg-base)] text-[var(--text-primary)]">
       {/* Chat header: familiar switcher + harness badge */}
-      <header className="flex items-center gap-2 border-b border-[var(--border-hairline)] px-4 py-2.5">
+      <header className="flex w-full items-center gap-2 border-b border-[var(--border-hairline)] px-4 py-2.5">
         <FamiliarSwitcher familiar={familiar} familiars={familiars} onSelect={onFamiliarSelect} />
         <div className="ml-auto flex items-center gap-2">
           <span className={[

--- a/src/components/coven-code-navigation.test.ts
+++ b/src/components/coven-code-navigation.test.ts
@@ -8,8 +8,14 @@ const comuxView = await readFile(new URL("./comux-view.tsx", import.meta.url), "
 
 assert.match(
   sidebar,
-  /\{ id: "agents",\s+label: "Familiars"/,
-  "Sidebar should expose Familiars as the first-class familiar work destination",
+  /\{ id: "agents",\s+label: "Chats"/,
+  "Sidebar should expose Chats as the first-class familiar chat destination",
+);
+
+assert.match(
+  sidebar,
+  /\{ id: "sessions",\s+label: "Sessions"/,
+  "Sidebar should expose Sessions as a cross-harness session destination",
 );
 
 assert.doesNotMatch(
@@ -126,7 +132,7 @@ assert.match(
 
 assert.match(
   workspace,
-  /shellAgentPane === "chat" \? \([\s\S]*<AgentPanel[\s\S]*\) : \([\s\S]*<BrowserPane label="default" \/>/,
+  /shellAgentPane === "chat" \? \([\s\S]*<AgentPanel[\s\S]*\) : \([\s\S]*<BrowserPane[\s\S]*label="default"[\s\S]*\/>/,
   "Workspace should render chat directly in the shell sidepanel instead of routing through Agents",
 );
 

--- a/src/components/familiar-switcher.test.ts
+++ b/src/components/familiar-switcher.test.ts
@@ -48,6 +48,24 @@ assert.match(
 
 assert.match(
   source,
+  /className="relative min-w-0 flex-1"/,
+  "FamiliarSwitcher should fill the available top header row",
+);
+
+assert.match(
+  source,
+  /className=\{triggerClassName\}/,
+  "FamiliarSwitcher trigger should use the full-width trigger class",
+);
+
+assert.match(
+  source,
+  /"focus-ring group flex w-full min-w-0 items-center justify-between/,
+  "FamiliarSwitcher trigger should stretch full width while preserving text truncation",
+);
+
+assert.match(
+  source,
   /role="menu"/,
   "Switcher popup should use menu semantics",
 );

--- a/src/components/familiar-switcher.tsx
+++ b/src/components/familiar-switcher.tsx
@@ -24,6 +24,10 @@ export function FamiliarSwitcher({ familiar, familiars = [], onSelect }: Props) 
   const ref = useRef<HTMLDivElement>(null);
   const glyphOverrides = useGlyphOverrides();
   const glyph = resolveFamiliarGlyph(familiar, glyphOverrides);
+  const triggerClassName = [
+    "focus-ring group flex w-full min-w-0 items-center justify-between gap-3 rounded-lg px-2 py-1.5 -ml-2 transition-colors",
+    "hover:bg-[var(--bg-raised)]/60",
+  ].join(" ");
 
   // Close on outside click / Esc
   useEffect(() => {
@@ -45,25 +49,47 @@ export function FamiliarSwitcher({ familiar, familiars = [], onSelect }: Props) 
   // Don't render a switcher if there's only one familiar
   if (familiars.length <= 1) {
     return (
-      <h2 className="text-[15px] font-semibold text-[var(--text-primary)]">
-        {familiar.display_name}
-      </h2>
+      <div className="relative min-w-0 flex-1">
+        <div className="flex min-w-0 items-center gap-2">
+          <span
+            className="grid h-6 w-6 shrink-0 place-items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]"
+            aria-hidden
+          >
+            <FamiliarGlyph glyph={glyph} size="sm" />
+          </span>
+          <h2 className="min-w-0 truncate text-[15px] font-semibold text-[var(--text-primary)]">
+            {familiar.display_name}
+          </h2>
+        </div>
+      </div>
     );
   }
 
   return (
-    <div ref={ref} className="relative">
+    <div ref={ref} className="relative min-w-0 flex-1">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="focus-ring group flex items-center gap-2 rounded-lg px-2 py-1 -ml-2 transition-colors hover:bg-[var(--bg-raised)]/60"
+        className={triggerClassName}
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label={`Switch familiar from ${familiar.display_name}`}
       >
-        <FamiliarGlyph glyph={glyph} size="sm" className="shrink-0 text-[var(--text-muted)]" />
-        <span className="text-[15px] font-semibold text-[var(--text-primary)]">
-          {familiar.display_name}
+        <span className="flex min-w-0 items-center gap-2">
+          <span
+            className="grid h-6 w-6 shrink-0 place-items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]"
+            aria-hidden
+          >
+            <FamiliarGlyph glyph={glyph} size="sm" />
+          </span>
+          <span className="min-w-0">
+            <span className="block truncate text-[15px] font-semibold leading-tight text-[var(--text-primary)]">
+              {familiar.display_name}
+            </span>
+            <span className="block truncate text-[10px] leading-tight text-[var(--text-muted)]">
+              {familiar.role || familiar.harness || "Familiar"}
+            </span>
+          </span>
         </span>
         <Icon
           name="ph:caret-up-down-bold"
@@ -75,7 +101,7 @@ export function FamiliarSwitcher({ familiar, familiars = [], onSelect }: Props) 
       {open ? (
         <div
           role="menu"
-          className="absolute left-0 top-full z-40 mt-1.5 min-w-[200px] overflow-hidden rounded-xl border border-[var(--border-strong)] bg-[var(--bg-elevated)] shadow-2xl"
+          className="absolute left-0 right-0 top-full z-40 mt-1.5 min-w-[220px] overflow-hidden rounded-xl border border-[var(--border-strong)] bg-[var(--bg-elevated)] shadow-2xl"
         >
           <div className="px-2 py-1.5 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
             Switch familiar
@@ -100,7 +126,12 @@ export function FamiliarSwitcher({ familiar, familiars = [], onSelect }: Props) 
                     : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]",
                 ].join(" ")}
               >
-                <FamiliarGlyph glyph={fGlyph} size="sm" className="shrink-0 text-[var(--text-muted)]" />
+                <span
+                  className="grid h-7 w-7 shrink-0 place-items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]"
+                  aria-hidden
+                >
+                  <FamiliarGlyph glyph={fGlyph} size="sm" />
+                </span>
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-[13px] font-medium leading-tight">
                     {f.display_name}

--- a/src/components/sessions-view.tsx
+++ b/src/components/sessions-view.tsx
@@ -47,6 +47,22 @@ function originLabel(origin: SessionOrigin | undefined): string {
   return map[origin] ?? origin;
 }
 
+function harnessLabel(harness: string | undefined): string {
+  if (!harness) return "";
+  const key = harness.toLowerCase().replace(/[^a-z0-9]/g, "");
+  if (key === "openclaw" || key === "coven" || key === "covendaemon") return "OpenClaw";
+  if (key === "hermes") return "Hermes";
+  if (key === "codex" || key === "openaicodex") return "Codex";
+  if (key === "claude" || key === "claudecode" || key === "anthropicclaude") return "Claude Code";
+  return harness
+    .split(/[-_\s/]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+const ALL_HARNESS_SCOPE = "OpenClaw · Hermes · Codex · Claude Code";
+
 // ── ViewSwitcher ──────────────────────────────────────────────────────────────
 
 function ViewSwitcher({
@@ -263,6 +279,7 @@ function SessionCard({
   const ts = shortRelTime(session.updated_at || session.created_at);
   const title = stripLeadingTrailingEmoji(session.title || "Untitled session");
   const label = originLabel(session.origin);
+  const harness = harnessLabel(session.harness);
   const archived = !!session.archived_at;
 
   return (
@@ -326,6 +343,7 @@ function SessionCard({
       )}
       <div className="session-card-footer">
         {archived && <span className="session-card-archived-badge">archived</span>}
+        {harness && <span className="session-card-harness">{harness}</span>}
         {label && <span className="session-card-origin">{label}</span>}
         {ts && <span className="session-card-ts">{ts}</span>}
       </div>
@@ -365,6 +383,7 @@ function SessionRowItem({
   const ts = shortRelTime(session.updated_at || session.created_at);
   const title = stripLeadingTrailingEmoji(session.title || "Untitled session");
   const label = originLabel(session.origin);
+  const harness = harnessLabel(session.harness);
   const archived = !!session.archived_at;
 
   return (
@@ -407,6 +426,7 @@ function SessionRowItem({
         </div>
       </div>
       <div className="session-row-meta">
+        {harness && <span className="session-card-harness">{harness}</span>}
         {label && <span className="session-card-origin">{label}</span>}
         {ts && <span className="session-card-ts">{ts}</span>}
         <div className="session-row-menu-wrap">
@@ -774,12 +794,18 @@ export function SessionsView({
   const title = activeFamiliar
     ? `${activeFamiliar.display_name} — Sessions`
     : "All Sessions";
+  const subtitle = activeFamiliar
+    ? harnessLabel(activeFamiliar.harness)
+    : ALL_HARNESS_SCOPE;
 
   return (
     <div className="sessions-view">
       {/* Header */}
       <div className="sessions-view-header">
-        <span className="sessions-view-title">{title}</span>
+        <div className="sessions-view-title-wrap">
+          <span className="sessions-view-title">{title}</span>
+          {subtitle && <span className="sessions-view-subtitle">{subtitle}</span>}
+        </div>
         <div className="sessions-view-actions">
           <button
             type="button"

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -31,6 +31,24 @@ assert.match(
 
 assert.match(
   source,
+  /\{ id: "agents",\s+label: "Chats"/,
+  "Sidebar should expose Chats as the familiar chat browser",
+);
+
+assert.match(
+  source,
+  /\{ id: "sessions",\s+label: "Sessions"/,
+  "Sidebar should expose Sessions as a top-level cross-harness session browser",
+);
+
+assert.match(
+  source,
+  /fm\.id === "agents" \|\| fm\.id === "sessions" \|\| fm\.id === "board"/,
+  "Sidebar Work section should include Chats, Sessions, and Tasks",
+);
+
+assert.match(
+  source,
   /<SidebarSection label="Manage" className="sidebar-actions sidebar-actions--footer">/,
   "Utility navigation should sit with the main sidebar sections instead of floating at the bottom",
 );

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -5,7 +5,7 @@
  *
  * Layout (top to bottom):
  *   1. New chat CTA
- *   2. App destinations (Agents / Inbox / Tasks -- Terminal / Browser -- GitHub)
+ *   2. App destinations (Chats / Sessions / Tasks -- Terminal / Browser -- GitHub)
  *   3. Utility actions footer (Plugins / Automations / Calendar)
  */
 
@@ -18,6 +18,7 @@ import { NotificationBell } from "@/components/notification-bell";
 
 export type FolderMode =
   | "agents"
+  | "sessions"
   | "board"
   | "terminal"
   | "projects"
@@ -58,8 +59,9 @@ const FOLDER_MODES: Array<{
   dividerBefore?: boolean;
 }> = [
   // Primary loop
-  { id: "agents",  label: "Familiars",   iconName: "ph:robot" },
-  { id: "board",   label: "Tasks",       iconName: "ph:kanban" },
+  { id: "agents", label: "Chats", iconName: "ph:chats" },
+  { id: "sessions", label: "Sessions", iconName: "ph:rows" },
+  { id: "board", label: "Tasks", iconName: "ph:kanban" },
   // Tools
   { id: "terminal", label: "Terminal",   iconName: "ph:terminal-window", dividerBefore: true },
   { id: "browser",  label: "Browser",    iconName: "ph:globe" },
@@ -180,7 +182,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
 
   const showNotifications =
     !!onOpenInbox && !!onNotificationPrefsChanged && !!inboxPrefs;
-  const primaryFolderModes = visibleFolderModes.filter((fm) => fm.id === "agents" || fm.id === "board");
+  const primaryFolderModes = visibleFolderModes.filter((fm) => fm.id === "agents" || fm.id === "sessions" || fm.id === "board");
   const toolFolderModes = visibleFolderModes.filter((fm) => fm.id === "terminal" || fm.id === "browser");
   const addinFolderModes = visibleFolderModes.filter((fm) => fm.id === "github" || fm.id === "library");
 

--- a/src/components/workspace-sessions-navigation.test.ts
+++ b/src/components/workspace-sessions-navigation.test.ts
@@ -1,0 +1,62 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
+const modes = await readFile(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
+const sessionsView = await readFile(new URL("./sessions-view.tsx", import.meta.url), "utf8");
+const slashCommands = await readFile(new URL("../lib/slash-commands.ts", import.meta.url), "utf8");
+
+assert.match(
+  modes,
+  /\|\s+"sessions"/,
+  "WorkspaceMode should include a dedicated Sessions mode",
+);
+
+assert.match(
+  workspace,
+  /import \{ SessionsView \} from "@\/components\/sessions-view";/,
+  "Workspace should import SessionsView for the Sessions navigation entry",
+);
+
+assert.match(
+  workspace,
+  /case "\/sessions":[\s\S]*setMode\("sessions"\)/,
+  "The /sessions slash command should route to the cross-harness Sessions view",
+);
+
+assert.match(
+  workspace,
+  /mode === "sessions" \? \([\s\S]*<SessionsView[\s\S]*activeFamiliarId=\{null\}/,
+  "Workspace should mount SessionsView in all-session mode from the Sessions nav entry",
+);
+
+assert.match(
+  workspace,
+  /onOpenSession=\{\(sessionId, familiarId\) => \{[\s\S]*openAgentSession\(sessionId, familiarId\)/,
+  "SessionsView should open the selected session with its familiar context",
+);
+
+assert.match(
+  sessionsView,
+  /function harnessLabel\(harness: string \| undefined\): string/,
+  "SessionsView should normalize harness names for display",
+);
+
+assert.match(
+  sessionsView,
+  /OpenClaw[\s\S]*Hermes[\s\S]*Codex[\s\S]*Claude Code/,
+  "SessionsView should advertise the supported all-harness session scope",
+);
+
+assert.match(
+  sessionsView,
+  /const harness = harnessLabel\(session\.harness\)/,
+  "Session rows/cards should include each session's harness label",
+);
+
+assert.match(
+  slashCommands,
+  /name: "\/sessions"[\s\S]*description: "Open all sessions across familiars and harnesses\."/,
+  "Slash command help should describe Sessions as cross-familiar and cross-harness",
+);

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -25,6 +25,7 @@ import { GitHubView } from "@/components/github-view";
 import { LibraryView } from "@/components/library-view";
 import { HomeComposer } from "@/components/home-composer";
 import { AgentsView } from "@/components/agents-view";
+import { SessionsView } from "@/components/sessions-view";
 import { nativeNotify } from "@/lib/native-notify";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
@@ -583,7 +584,7 @@ export function Workspace() {
           showAgentChatList();
           return;
         case "/sessions":
-          showAgentChatList();
+          setMode("sessions");
           return;
         case "/familiar": {
           const name = (intent.args ?? "").trim().toLowerCase();
@@ -783,6 +784,20 @@ export function Workspace() {
         onOpenInboxItem={openInspectorInboxItem}
         onInboxItemChanged={refreshInbox}
         onOpenMode={(nextMode) => setMode(nextMode as WorkspaceMode)}
+      />
+    ) : mode === "sessions" ? (
+      <SessionsView
+        familiars={familiars}
+        sessions={sessions}
+        activeFamiliarId={null}
+        activeSessionId={routerRef.current?.currentSessionId() ?? null}
+        onOpenSession={(sessionId, familiarId) => {
+          openAgentSession(sessionId, familiarId);
+        }}
+        onNewChat={(familiarId) => {
+          startAgentChat(familiarId ?? activeId);
+        }}
+        onSessionsChanged={loadSessions}
       />
     ) : mode === "library" ? (
       <LibraryView />

--- a/src/lib/slash-commands.ts
+++ b/src/lib/slash-commands.ts
@@ -31,7 +31,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: "/daemon", hint: "daemon status", description: "Show `coven daemon status` inline.", section: "daemon" },
 
   // Sessions
-  { name: "/sessions", hint: "open list", description: "Back to the chat list (this familiar's sessions).", section: "view" },
+  { name: "/sessions", hint: "all sessions", description: "Open all sessions across familiars and harnesses.", section: "view" },
   { name: "/attach", hint: "open session", description: "Open a specific daemon session by id.", argPlaceholder: "session-id", section: "view" },
   { name: "/tui", hint: "open in Coven Code", description: "Open the current session in the external Coven Code TUI.", section: "view" },
   { name: "/board", hint: "Tasks", description: "Open the Tasks kanban and table view.", section: "view" },

--- a/src/lib/workspace-mode.ts
+++ b/src/lib/workspace-mode.ts
@@ -1,5 +1,6 @@
 export type WorkspaceMode =
   | "agents"
+  | "sessions"
   | "board"
   | "inbox"
   | "plugins"

--- a/src/styles/sessions-view.css
+++ b/src/styles/sessions-view.css
@@ -16,12 +16,30 @@
   border-bottom: 1px solid var(--border-hairline);
 }
 
+.sessions-view-title-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
 .sessions-view-title {
   font-size: 13px;
   font-weight: 600;
   color: var(--text-primary);
-  flex: 1;
+  display: block;
   min-width: 0;
+}
+
+.sessions-view-subtitle {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 10px;
+  color: var(--text-muted);
 }
 
 .sessions-view-actions {
@@ -253,6 +271,15 @@
   border-radius: 4px;
   padding: 1px 5px;
   text-transform: capitalize;
+}
+.session-card-harness {
+  font-size: 10px;
+  color: var(--text-secondary);
+  background: color-mix(in oklch, var(--accent-presence) 9%, var(--bg-panel));
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 18%, transparent);
+  border-radius: 4px;
+  padding: 1px 5px;
+  white-space: nowrap;
 }
 .session-card-ts {
   font-size: 10px;


### PR DESCRIPTION
## Summary
- Adds Chats and Sessions as separate Work navigation entries.
- Routes Sessions to an all-session view across familiars and harnesses.
- Shows OpenClaw/Hermes/Codex/Claude Code scope and per-session harness labels.
- Keeps the side chat familiar switcher full-width and wired to active familiar switching.

## Verification
- node --test src/components/sidebar-minimal.test.ts src/components/workspace-sessions-navigation.test.ts src/components/coven-code-navigation.test.ts src/components/familiar-switcher.test.ts src/components/chat-view-polish.test.ts src/components/chat-view.test.ts src/components/chat-list-panel.test.ts src/components/agents-view.test.ts
- pnpm typecheck
- git diff --check
- pnpm build
- Browser smoke at http://localhost:3014 for Chats, Sessions, and side chat panel
