### PR TITLE
test(chat): update dossier header guard

### DIFF
--- a/src/components/chat-list-panel.test.ts
+++ b/src/components/chat-list-panel.test.ts
@@ -18,6 +18,18 @@ assert.match(
 
 assert.match(
   source,
+  /<FamiliarGlyph glyph=\{resolveFamiliarGlyph\(familiar, glyphOverrides\)\} size="md" \/>/,
+  "ChatList dossier header should render the familiar glyph as the primary avatar",
+);
+
+assert.match(
+  source,
+  /familiar\.role[\s\S]*Agent runtime/,
+  "ChatList dossier header should keep the familiar role and runtime subtitle together",
+);
+
+assert.match(
+  source,
   /const runningCount = mine\.filter\(\(s\) => s\.status === "running"\)\.length/,
   "ChatList should summarize running chats in the side-panel header",
 );


### PR DESCRIPTION
## Summary
- updates the chat-list side-panel guard to match the current dossier header behavior
- preserves the new compact header where familiar icon, role, and runtime subtitle are no longer duplicated

## Context
The Library and chat-list code commits are already present on `origin/main`. This PR keeps the remaining guard aligned with that merged behavior instead of re-opening a duplicate code-diff PR.

## Verification
- node src/components/chat-list-panel.test.ts && node src/components/library-timeline.test.ts && node src/components/library-github-row-actions.test.ts && node src/lib/library-store.test.ts && node src/app/api/library/route-link/route.test.ts
- pnpm typecheck
- pnpm build
- git diff --check

## Notes
- Existing Node .test.ts module-type warnings still print during focused guards.
- Existing Next/Turbopack worktree-root/NFT warning still prints during build.