### PR TITLE
fix(chat): sanitize rendered markdown to prevent XSS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,8 +91,15 @@ jobs:
 
       - name: Set release metadata
         shell: bash
+        env:
+          RAW_RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          set -euo pipefail
+          TAG="$RAW_RELEASE_TAG"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid release tag. Expected format: vMAJOR.MINOR.PATCH[-PRERELEASE]"
+            exit 1
+          fi
           echo "RELEASE_TAG=$TAG" >> "$GITHUB_ENV"
           echo "RELEASE_VERSION=${TAG#v}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
 
       - name: Rust cache
         uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "enables the default permissions",
-  "local": true,
+  "local": false,
   "windows": [
     "main"
   ],

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -6,9 +6,10 @@ const capability = JSON.parse(readFileSync(new URL("../capabilities/default.json
 const defaultPermissions = readFileSync(new URL("./default.toml", import.meta.url), "utf8");
 const commandPermissions = readFileSync(new URL("./pty.toml", import.meta.url), "utf8");
 const browserRust = readFileSync(new URL("../src/browser.rs", import.meta.url), "utf8");
+const ptyRust = readFileSync(new URL("../src/pty.rs", import.meta.url), "utf8");
+const libRust = readFileSync(new URL("../src/lib.rs", import.meta.url), "utf8");
 const browserPane = readFileSync(new URL("../../src/components/browser-pane.tsx", import.meta.url), "utf8");
 const bottomTerminal = readFileSync(new URL("../../src/components/bottom-terminal.tsx", import.meta.url), "utf8");
-const ptyRust = readFileSync(new URL("../src/pty.rs", import.meta.url), "utf8");
 
 const requiredPermissionIds = [
   "allow-pty-start",
@@ -76,6 +77,24 @@ test("packaged sidecar loopback origins can use native browser commands", () => 
   assert.ok(capabilityAllowsOrigin("http://127.0.0.1:64203/"), "packaged random 127.0.0.1 sidecar port should be allowed");
   assert.ok(capabilityAllowsOrigin("http://localhost:64203/"), "packaged random localhost sidecar port should be allowed");
   assert.equal(capabilityAllowsOrigin("http://example.com:64203/"), false, "remote non-loopback origins should stay denied");
+});
+
+test("privileged PTY commands require the trusted main webview at runtime", () => {
+  assert.match(ptyRust, /static TRUSTED_MAIN_ORIGINS:/);
+  assert.match(ptyRust, /pub fn trust_main_origin\(url: &Url\)/);
+  assert.match(libRust, /pty::trust_main_origin\(&main_url\);/);
+  assert.match(ptyRust, /if webview\.label\(\) != "main"/);
+  assert.match(ptyRust, /trusted\.clear\(\);/);
+  assert.match(ptyRust, /TRUSTED_MAIN_ORIGINS\.lock\(\)\.contains\(&origin\)/);
+
+  for (const command of ["pty_start", "pty_write", "pty_resize", "pty_stop", "pty_list", "pty_diagnose"]) {
+    const escapedCommand = command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    assert.match(
+      ptyRust,
+      new RegExp(String.raw`pub fn ${escapedCommand}\([^)]*webview: Webview[\s\S]*?ensure_trusted_pty_caller\(&webview\)\?;`),
+      `${command} must reject untrusted child webviews and localhost origins before handling PTY state`,
+    );
+  }
 });
 
 test("browser event labels use the same native prefix in Rust and React", () => {

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -8,6 +8,7 @@ const commandPermissions = readFileSync(new URL("./pty.toml", import.meta.url), 
 const browserRust = readFileSync(new URL("../src/browser.rs", import.meta.url), "utf8");
 const browserPane = readFileSync(new URL("../../src/components/browser-pane.tsx", import.meta.url), "utf8");
 const bottomTerminal = readFileSync(new URL("../../src/components/bottom-terminal.tsx", import.meta.url), "utf8");
+const ptyRust = readFileSync(new URL("../src/pty.rs", import.meta.url), "utf8");
 
 const requiredPermissionIds = [
   "allow-pty-start",
@@ -46,8 +47,8 @@ function capabilityAllowsOrigin(origin) {
   return patterns.some((pattern) => new URLPattern(pattern).test(origin));
 }
 
-test("packaged desktop app can use native browser and terminal commands", () => {
-  assert.equal(capability.local, true, "packaged local app origin must receive the default capability");
+test("local app origins do not receive terminal permissions", () => {
+  assert.equal(capability.local, false, "packaged local app origins must not receive PTY command permissions");
   assert.ok(capability.permissions.includes("default"), "default capability should include custom app permissions");
 
   for (const permissionId of requiredPermissionIds) {
@@ -83,6 +84,19 @@ test("browser event labels use the same native prefix in Rust and React", () => 
   assert.match(browserPane, /return `\$\{NATIVE_BROWSER_LABEL_PREFIX\}\$\{label\}-tab-`;/);
   assert.equal(browserPane.match(/startsWith\(eventPrefix\)/g)?.length, 2);
   assert.equal(browserPane.match(/slice\(eventPrefix\.length\)/g)?.length, 2);
+});
+
+test("pty_start only accepts terminal session metadata", () => {
+  assert.match(
+    ptyRust,
+    /#\[serde\(deny_unknown_fields\)\]\s*pub struct StartOptions \{[\s\S]*?pub thread_id: String,[\s\S]*?pub project_root: Option<String>,[\s\S]*?pub cols: Option<u16>,[\s\S]*?pub rows: Option<u16>,[\s\S]*?\}/,
+    "StartOptions should reject unknown caller-supplied fields",
+  );
+  assert.doesNotMatch(ptyRust, /pub command:/, "pty_start must not accept caller-supplied executables");
+  assert.doesNotMatch(ptyRust, /pub args:/, "pty_start must not accept caller-supplied arguments");
+  assert.doesNotMatch(ptyRust, /pub env:/, "pty_start must not accept caller-supplied environment overrides");
+  assert.match(ptyRust, /let command = default_shell\(\);/, "pty_start should always use the platform default shell");
+  assert.match(ptyRust, /let args = default_shell_args\(\);/, "pty_start should always use platform default shell args");
 });
 
 test("terminal commands use Tauri camelCase command arguments", () => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -700,10 +700,12 @@ pub fn run() {
             }
 
             let url = format!("http://127.0.0.1:{}/", port);
+            let main_url = url.parse().expect("valid url");
+            pty::trust_main_origin(&main_url);
             if let Err(e) = WebviewWindowBuilder::new(
                 app,
                 "main",
-                WebviewUrl::External(url.parse().expect("valid url")),
+                WebviewUrl::External(main_url),
             )
             .title("CovenCave")
             .inner_size(1320.0, 820.0)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,7 +8,7 @@ use tauri::{
     image::Image,
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    Emitter, Manager, WebviewUrl, WebviewWindowBuilder,
+    Emitter, Manager, Url, WebviewUrl, WebviewWindowBuilder,
 };
 
 fn coven_tray_icon() -> Image<'static> {
@@ -384,16 +384,82 @@ mod tests {
 mod browser;
 mod pty;
 
-/// Open a URL in the system default browser.
+fn validate_shell_open_url(url: &str) -> Result<(), String> {
+    let parsed = Url::parse(url).map_err(|_| "shell_open requires a valid URL".to_string())?;
+
+    match parsed.scheme() {
+        "http" | "https" => Ok(()),
+        _ => Err("shell_open only supports http(s) URLs".to_string()),
+    }
+}
+
+#[cfg_attr(not(any(target_os = "windows", test)), allow(dead_code))]
+fn windows_system32_binary(binary: &str) -> std::path::PathBuf {
+    let system_root = std::env::var_os("SystemRoot")
+        .filter(|value| !value.is_empty())
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from(r"C:\Windows"));
+    system_root.join("System32").join(binary)
+}
+
+/// Open an http(s) URL in the system default browser.
 #[tauri::command]
 fn shell_open(url: String) -> Result<(), String> {
+    validate_shell_open_url(&url)?;
+
     #[cfg(target_os = "macos")]
-    { std::process::Command::new("open").arg(&url).spawn().map_err(|e| e.to_string())?; }
+    {
+        std::process::Command::new("open")
+            .arg(&url)
+            .spawn()
+            .map_err(|e| e.to_string())?;
+    }
     #[cfg(target_os = "windows")]
-    { std::process::Command::new("cmd").args(["/c", "start", "", &url]).spawn().map_err(|e| e.to_string())?; }
+    {
+        std::process::Command::new(windows_system32_binary("rundll32.exe"))
+            .args(["url.dll,FileProtocolHandler", &url])
+            .spawn()
+            .map_err(|e| e.to_string())?;
+    }
     #[cfg(target_os = "linux")]
-    { std::process::Command::new("xdg-open").arg(&url).spawn().map_err(|e| e.to_string())?; }
+    {
+        std::process::Command::new("xdg-open")
+            .arg(&url)
+            .spawn()
+            .map_err(|e| e.to_string())?;
+    }
     Ok(())
+}
+
+#[cfg(test)]
+mod shell_open_tests {
+    use super::validate_shell_open_url;
+
+    #[test]
+    fn validates_http_and_https_urls() {
+        assert!(validate_shell_open_url("http://example.test").is_ok());
+        assert!(validate_shell_open_url("https://example.test/?x=1&calc.exe").is_ok());
+    }
+
+    #[test]
+    fn rejects_non_http_schemes() {
+        assert!(validate_shell_open_url("file:///C:/Windows/System32/calc.exe").is_err());
+        assert!(validate_shell_open_url("javascript:alert(1)").is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_urls() {
+        assert!(validate_shell_open_url("example.test").is_err());
+        assert!(validate_shell_open_url("https://").is_err());
+    }
+
+    #[test]
+    fn windows_system32_binary_uses_an_absolute_system_path() {
+        let path = super::windows_system32_binary("rundll32.exe");
+        let path = path.to_string_lossy();
+        assert!(path.starts_with(r"C:\") || path.contains(r":\"));
+        assert!(path.ends_with(r"System32\rundll32.exe") || path.ends_with("System32/rundll32.exe"));
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -26,7 +26,7 @@ use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Url, Webview};
 use log::{debug, info, warn};
 
 struct PtySession {
@@ -38,6 +38,40 @@ struct PtySession {
 static SESSIONS: Lazy<Mutex<HashMap<String, PtySession>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 static STARTING_SESSIONS: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+static TRUSTED_MAIN_ORIGINS: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+
+fn url_origin(url: &Url) -> Option<String> {
+    let host = url.host_str()?;
+    let port = url.port_or_known_default()?;
+    Some(format!("{}://{}:{}", url.scheme(), host, port))
+}
+
+pub fn trust_main_origin(url: &Url) {
+    if let Some(origin) = url_origin(url) {
+        info!("trusting main webview origin for PTY IPC: {}", origin);
+        let mut trusted = TRUSTED_MAIN_ORIGINS.lock();
+        trusted.clear();
+        trusted.insert(origin);
+    } else {
+        warn!("not trusting main webview origin for PTY IPC: {}", url);
+    }
+}
+
+fn ensure_trusted_pty_caller(webview: &Webview) -> Result<(), String> {
+    if webview.label() != "main" {
+        warn!("denied PTY IPC from non-main webview: {}", webview.label());
+        return Err("PTY commands are only available to the main app webview".to_string());
+    }
+
+    let url = webview.url().map_err(|e| format!("could not resolve caller URL: {e}"))?;
+    let origin = url_origin(&url).ok_or_else(|| format!("untrusted PTY caller URL: {url}"))?;
+    if TRUSTED_MAIN_ORIGINS.lock().contains(&origin) {
+        Ok(())
+    } else {
+        warn!("denied PTY IPC from untrusted main webview origin: {}", origin);
+        Err("PTY commands are not available to this origin".to_string())
+    }
+}
 
 /// RAII guard: makes sure a thread_id we reserved in STARTING_SESSIONS
 /// is always removed even if start fails partway through.
@@ -87,7 +121,8 @@ pub struct PtyExitEvent {
 }
 
 #[tauri::command]
-pub fn pty_start(app: AppHandle, options: StartOptions) -> Result<(), String> {
+pub fn pty_start(app: AppHandle, webview: Webview, options: StartOptions) -> Result<(), String> {
+    ensure_trusted_pty_caller(&webview)?;
     let thread_id = options.thread_id.clone();
     info!("pty_start: thread_id={} project_root={:?} cols={:?} rows={:?}",
         thread_id, options.project_root, options.cols, options.rows);
@@ -218,7 +253,8 @@ pub fn pty_start(app: AppHandle, options: StartOptions) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub fn pty_write(thread_id: String, bytes: Vec<u8>) -> Result<(), String> {
+pub fn pty_write(webview: Webview, thread_id: String, bytes: Vec<u8>) -> Result<(), String> {
+    ensure_trusted_pty_caller(&webview)?;
     debug!("pty_write[{}]: {} bytes", thread_id, bytes.len());
     let writer = {
         let sessions = SESSIONS.lock();
@@ -236,7 +272,8 @@ pub fn pty_write(thread_id: String, bytes: Vec<u8>) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub fn pty_resize(thread_id: String, cols: u16, rows: u16) -> Result<(), String> {
+pub fn pty_resize(webview: Webview, thread_id: String, cols: u16, rows: u16) -> Result<(), String> {
+    ensure_trusted_pty_caller(&webview)?;
     let sessions = SESSIONS.lock();
     let session = sessions
         .get(&thread_id)
@@ -253,17 +290,20 @@ pub fn pty_resize(thread_id: String, cols: u16, rows: u16) -> Result<(), String>
 }
 
 #[tauri::command]
-pub fn pty_stop(thread_id: String) {
+pub fn pty_stop(webview: Webview, thread_id: String) -> Result<(), String> {
+    ensure_trusted_pty_caller(&webview)?;
     // Dropping the PtySession drops the master, which closes the slave's
     // controlling tty; the child receives SIGHUP and exits. The waiter
     // thread cleans up SESSIONS and emits pty:exit.
     let mut sessions = SESSIONS.lock();
     sessions.remove(&thread_id);
+    Ok(())
 }
 
 #[tauri::command]
-pub fn pty_list() -> Vec<String> {
-    SESSIONS.lock().keys().cloned().collect()
+pub fn pty_list(webview: Webview) -> Result<Vec<String>, String> {
+    ensure_trusted_pty_caller(&webview)?;
+    Ok(SESSIONS.lock().keys().cloned().collect())
 }
 
 /// Diagnostic: spawn a one-shot known-good PTY (`/bin/echo hello && exit`),
@@ -271,7 +311,12 @@ pub fn pty_list() -> Vec<String> {
 /// the PTY plumbing works end-to-end without depending on the React layer
 /// or on any user shell config.
 #[tauri::command]
-pub fn pty_diagnose() -> Result<DiagnoseReport, String> {
+pub fn pty_diagnose(webview: Webview) -> Result<DiagnoseReport, String> {
+    ensure_trusted_pty_caller(&webview)?;
+    run_pty_diagnose()
+}
+
+fn run_pty_diagnose() -> Result<DiagnoseReport, String> {
     info!("pty_diagnose: starting");
     let pty_system = native_pty_system();
     let pair = pty_system
@@ -435,7 +480,7 @@ mod tests {
 
     #[test]
     fn pty_diagnose_spawns_shell_and_reads_output() {
-        let report = pty_diagnose().expect("pty diagnostic should run");
+        let report = run_pty_diagnose().expect("pty diagnostic should run");
 
         assert!(
             report.output.contains("coven-cave-pty-ok"),

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -66,14 +66,12 @@ impl Drop for PendingPtyStart {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct StartOptions {
     pub thread_id: String,
     pub project_root: Option<String>,
-    pub command: Option<String>,
-    pub args: Option<Vec<String>>,
     pub cols: Option<u16>,
     pub rows: Option<u16>,
-    pub env: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -105,8 +103,8 @@ pub fn pty_start(app: AppHandle, options: StartOptions) -> Result<(), String> {
         })
         .map_err(|e| e.to_string())?;
 
-    let command = options.command.unwrap_or_else(default_shell);
-    let args = options.args.unwrap_or_else(default_shell_args);
+    let command = default_shell();
+    let args = default_shell_args();
     info!("pty_start[{}]: spawning {} {:?}", thread_id, command, args);
     let mut cmd = CommandBuilder::new(&command);
     cmd.args(&args);
@@ -133,15 +131,6 @@ pub fn pty_start(app: AppHandle, options: StartOptions) -> Result<(), String> {
         }
         if std::env::var("LC_ALL").is_err() {
             cmd.env("LC_ALL", "en_US.UTF-8");
-        }
-    }
-    if let Some(extra) = options.env {
-        for (k, v) in extra {
-            if v.is_empty() {
-                cmd.env_remove(&k);
-            } else {
-                cmd.env(k, v);
-            }
         }
     }
     // Drop nesting-tripwires inherited from the Tauri parent.

--- a/src/app/api/board/enrich-steps/route.ts
+++ b/src/app/api/board/enrich-steps/route.ts
@@ -3,6 +3,7 @@ import type { CardStep } from "@/lib/cave-board-types";
 import { bindingFor, loadConfig } from "@/lib/cave-config";
 import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
 import { familiarWorkspace } from "@/lib/coven-paths";
+import { isTrustedChatHarness } from "@/lib/harness-adapters";
 import { spawn } from "node:child_process";
 import { stat } from "node:fs/promises";
 import { stripAnsi } from "@/lib/ansi";
@@ -201,9 +202,10 @@ export async function POST(req: Request) {
         const familiarId = card.familiarId!;
         const binding = bindingFor(config, familiarId);
 
-        // Local Coven harnesses can run headlessly through `coven run
-        // <harness> --stream-json`, including external adapter manifests.
-        if (binding.harness === "openclaw") {
+        // Only bundled, reviewed Coven harnesses may run headlessly through
+        // `coven run <harness> --stream-json`. OpenClaw and external adapter
+        // manifests use their own bridges instead of this privileged runner.
+        if (!isTrustedChatHarness(binding.harness)) {
           push({
             kind: "skip",
             cardId: card.id,

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -13,24 +13,18 @@ const boardRoute = await readFile(
 
 assert.match(
   chatRoute,
-  /coven run <harness> --stream-json/,
-  "Native chat should describe the generic Coven harness route instead of a fixed allow-list",
-);
-
-assert.doesNotMatch(
-  chatRoute,
-  /COVEN_RUN_HARNESSES|new Set\(\["codex", "claude"\]\)|new Set\(\["codex", "claude", "hermes"\]\)/,
-  "Native chat should not hard-code a local harness allow-list",
+  /isTrustedChatHarness\(binding\.harness\)/,
+  "Native chat should enforce the trusted Coven harness gate before spawning coven run",
 );
 
 assert.doesNotMatch(
   chatRoute,
   /binding\.harness === "openclaw"/,
-  "Native chat should not special-case OpenClaw outside the generic harness route",
+  "Native chat should not rely on an OpenClaw-only rejection",
 );
 
 assert.match(
   boardRoute,
-  /binding\.harness === "openclaw"/,
-  "Board step enrichment should skip OpenClaw bridge familiars while allowing local Coven harnesses",
+  /isTrustedChatHarness\(binding\.harness\)/,
+  "Board step enrichment should enforce the same trusted Coven harness gate",
 );

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -15,6 +15,7 @@ import {
 import { AssistantFilter } from "@/lib/chat-assistant-filter";
 import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
 import { familiarWorkspace } from "@/lib/coven-paths";
+import { isTrustedChatHarness } from "@/lib/harness-adapters";
 import {
   type ChatTurn,
   loadConversation,
@@ -188,8 +189,19 @@ export async function POST(req: Request) {
     ? await resolveFamiliarWorkspace(body.familiarId)
     : undefined;
 
-  // Native Cave chat can drive any Coven harness that resolves through
-  // `coven run <harness> --stream-json`, including external adapter manifests.
+  // Native Cave chat only drives bundled, reviewed Coven harnesses through
+  // `coven run <harness> --stream-json`. OpenClaw and external adapter
+  // manifests use their own bridges instead of this privileged local runner.
+  if (!isTrustedChatHarness(binding.harness)) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error:
+          "This familiar's harness is not supported by native Cave chat. Pick Codex, Claude Code, or Hermes here, or open the familiar from its own runtime.",
+      }),
+      { status: 501, headers: { "content-type": "application/json" } },
+    );
+  }
 
   // Build coven run argv.
   // Important: pass every flag BEFORE the prompt and add a `--` separator,

--- a/src/app/api/onboarding/setup/route.ts
+++ b/src/app/api/onboarding/setup/route.ts
@@ -10,7 +10,10 @@ import {
   type OnboardingFamiliarDraft,
   type OnboardingFamiliarInput,
 } from "@/lib/onboarding-familiars";
-import { adapterManifestScaffoldForHarness } from "@/lib/harness-adapters";
+import {
+  adapterManifestScaffoldForHarness,
+  isTrustedOnboardingHarness,
+} from "@/lib/harness-adapters";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -51,6 +54,12 @@ export async function POST(req: Request) {
     );
   }
   const harness = (draft?.harness ?? body.harness ?? "codex").trim() || "codex";
+  if (!isTrustedOnboardingHarness(harness)) {
+    return NextResponse.json(
+      { ok: false, error: `Unsupported harness: ${harness}.` },
+      { status: 400 },
+    );
+  }
   const model =
     (draft?.model ?? body.model ?? "codex-local").trim() || "codex-local";
 

--- a/src/app/api/vault/route.ts
+++ b/src/app/api/vault/route.ts
@@ -14,6 +14,7 @@ import {
   getVaultStatuses,
   loadVaultMap,
   saveVaultMap,
+  validateOpRef,
   type VaultEntry,
 } from "@/lib/vault";
 
@@ -41,7 +42,9 @@ export async function POST(req: NextRequest) {
   const ref = typeof body.ref === "string" ? body.ref.trim() : "";
 
   if (!key) return NextResponse.json({ ok: false, error: "key is required" }, { status: 400 });
-  if (!ref.startsWith("op://")) return NextResponse.json({ ok: false, error: "ref must start with op://" }, { status: 400 });
+
+  const refError = validateOpRef(ref);
+  if (refError) return NextResponse.json({ ok: false, error: refError }, { status: 400 });
 
   const map = loadVaultMap(true);
   const entry: VaultEntry = {

--- a/src/app/dev/memory-graph-3d/page.tsx
+++ b/src/app/dev/memory-graph-3d/page.tsx
@@ -1,0 +1,9 @@
+import { notFound } from "next/navigation";
+import { MemoryGraph3DSmoke } from "@/components/memory-graph-3d-smoke";
+
+export const dynamic = "force-dynamic";
+
+export default function MemoryGraph3DDevPage() {
+  if (process.env.NODE_ENV === "production" && process.env.CAVE_TRACE_GRAPH_SMOKE !== "1") notFound();
+  return <MemoryGraph3DSmoke />;
+}

--- a/src/components/agents-memory-graph.test.ts
+++ b/src/components/agents-memory-graph.test.ts
@@ -1,0 +1,93 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const memoryViewSource = await readFile(new URL("./agents-memory-view.tsx", import.meta.url), "utf8");
+const graphSource = await readFile(new URL("./memory-graph-3d.tsx", import.meta.url), "utf8");
+const modelSource = await readFile(new URL("../lib/memory-graph-3d-model.ts", import.meta.url), "utf8");
+const smokeSource = await readFile(new URL("./memory-graph-3d-smoke.tsx", import.meta.url), "utf8");
+const devPageSource = await readFile(new URL("../app/dev/memory-graph-3d/page.tsx", import.meta.url), "utf8");
+
+assert.match(
+  memoryViewSource,
+  /import \{ MemoryGraph3D \} from "@\/components\/memory-graph-3d"/,
+  "AgentsMemoryView should render the dedicated memory graph component instead of reusing TraceGraph3D",
+);
+
+assert.match(
+  memoryViewSource,
+  /from "@\/lib\/memory-graph-3d-model"[\s\S]*buildMemoryGraphModel\(\{/,
+  "AgentsMemoryView should build the memory constellation from its existing memory API data",
+);
+
+assert.match(
+  memoryViewSource,
+  /viewMode, setViewMode.*"list"/,
+  "Memory tab should keep a List/Graph view toggle with List as the default retrieval surface",
+);
+
+assert.match(
+  memoryViewSource,
+  /onSelectFamiliar=\{\(familiarId\) => setFamiliarFilter\(familiarId\)\}/,
+  "Clicking a familiar hub should sync the existing familiar filter",
+);
+
+assert.match(
+  memoryViewSource,
+  /onOpenMemoryFile=\{onOpenMemoryFile\}/,
+  "Clicking a memory node should use the existing memory-file opening path",
+);
+
+assert.doesNotMatch(
+  memoryViewSource,
+  /fetch\("\/api\/memory-graph"/,
+  "The first implementation should not add a memory graph API route",
+);
+
+assert.match(
+  graphSource,
+  /import \* as THREE from "three"/,
+  "MemoryGraph3D should render a real Three.js scene",
+);
+
+assert.match(
+  graphSource,
+  /InstancedMesh/,
+  "MemoryGraph3D should use InstancedMesh for memory leaves",
+);
+
+assert.match(
+  graphSource,
+  /aria-label="3D memory constellation"/,
+  "MemoryGraph3D should expose an accessible canvas label",
+);
+
+assert.match(
+  graphSource,
+  /prefers-reduced-motion/,
+  "MemoryGraph3D should respect reduced motion preferences",
+);
+
+assert.match(
+  modelSource,
+  /hub:memory-files/,
+  "The model should preserve filesystem memory entries under a neutral Memory Files hub",
+);
+
+assert.doesNotMatch(
+  modelSource,
+  /DelegationGraph/,
+  "The memory graph model should not depend on the calls DelegationGraph domain model",
+);
+
+assert.match(
+  smokeSource,
+  /<MemoryGraph3D[\s\S]*graph=\{graph\}/,
+  "Memory graph should have a deterministic smoke fixture for canvas verification",
+);
+
+assert.match(
+  devPageSource,
+  /MemoryGraph3DSmoke/,
+  "Memory graph should expose a dev-only smoke route like the trace graph",
+);

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
 import type { Familiar } from "@/lib/types";
+import { MemoryGraph3D } from "@/components/memory-graph-3d";
+import { buildMemoryGraphModel } from "@/lib/memory-graph-3d-model";
 
 type CovenMemoryEntry = {
   id: string;
@@ -74,6 +76,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
   const [fileEntries, setFileEntries] = useState<FileMemoryEntry[]>([]);
   const [query, setQuery] = useState("");
   const [familiarFilter, setFamiliarFilter] = useState<string>("all");
+  const [viewMode, setViewMode] = useState<"list" | "graph">("list");
   const [error, setError] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
 
@@ -136,6 +139,19 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
     return familiars.filter((familiar) => ids.has(familiar.id));
   }, [covenEntries, familiars]);
 
+  const memoryGraph = useMemo(
+    () =>
+      buildMemoryGraphModel({
+        familiars,
+        covenEntries,
+        fileEntries,
+        query,
+        familiarFilter,
+        maxLeavesPerHub: familiarFilter === "all" ? 30 : 90,
+      }),
+    [covenEntries, familiarFilter, familiars, fileEntries, query],
+  );
+
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-[var(--bg-base)]">
       <div className="shrink-0 border-b border-[var(--border-hairline)] px-4 py-3">
@@ -149,10 +165,30 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
               Comprehensive Coven memory, familiar recall, and local memory files.
             </p>
           </div>
-          <button type="button" onClick={() => void load()} className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]">
-            <Icon name="ph:arrows-clockwise" width={12} />
-            Refresh
-          </button>
+          <div className="flex items-center gap-2">
+            <div className="flex overflow-hidden rounded-md border border-[var(--border-hairline)]">
+              {(["list", "graph"] as const).map((mode) => (
+                <button
+                  key={mode}
+                  type="button"
+                  onClick={() => setViewMode(mode)}
+                  className={[
+                    "inline-flex h-7 items-center gap-1.5 px-2.5 text-[11px] capitalize transition-colors",
+                    viewMode === mode
+                      ? "bg-[var(--accent-presence)] text-white"
+                      : "bg-[var(--bg-raised)]/30 text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]",
+                  ].join(" ")}
+                >
+                  <Icon name={mode === "list" ? "ph:list-bullets" : "ph:graph"} width={12} />
+                  {mode}
+                </button>
+              ))}
+            </div>
+            <button type="button" onClick={() => void load()} className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]">
+              <Icon name="ph:arrows-clockwise" width={12} />
+              Refresh
+            </button>
+          </div>
         </div>
 
         <div className="mt-3 grid gap-2 sm:grid-cols-3">
@@ -194,6 +230,62 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
         {error ? <div className="mt-2 text-[11px] text-[var(--color-warning)]">{error}</div> : null}
       </div>
 
+      {viewMode === "graph" ? (
+        <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto p-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+          <section className="min-h-[520px] overflow-hidden rounded-lg border border-[var(--border-hairline)]">
+            <MemoryGraph3D
+              graph={memoryGraph}
+              familiars={familiarById}
+              selectedFamiliarId={familiarFilter}
+              onSelectFamiliar={(familiarId) => setFamiliarFilter(familiarId)}
+              onOpenMemoryFile={onOpenMemoryFile}
+            />
+          </section>
+          <aside className="hidden min-h-0 xl:block">
+            <div className="mb-2 flex items-center justify-between">
+              <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">
+                {familiarFilter === "all" ? "Constellation index" : familiarById.get(familiarFilter)?.display_name ?? familiarFilter}
+              </h3>
+              <span className="text-[10px] text-[var(--text-muted)]">{visibleCoven.length + visibleFiles.length} visible</span>
+            </div>
+            <div className="max-h-[640px] overflow-y-auto rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/25">
+              {visibleCoven.slice(0, 18).map((entry) => (
+                <button
+                  key={entry.id}
+                  type="button"
+                  onClick={() => onOpenMemoryFile?.(entry.path)}
+                  className="flex w-full items-start gap-2 border-b border-[var(--border-hairline)] px-3 py-2 text-left hover:bg-[var(--bg-raised)]"
+                >
+                  <Icon name="ph:brain" width={13} className="mt-0.5 shrink-0 text-[var(--accent-presence)]" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block line-clamp-2 text-[12px] text-[var(--text-primary)]">{entry.title}</span>
+                    <span className="mt-0.5 block text-[10px] text-[var(--text-muted)]">{familiarById.get(entry.familiar_id)?.display_name ?? entry.familiar_id} · {age(entry.updated_at)}</span>
+                  </span>
+                </button>
+              ))}
+              {visibleFiles.slice(0, 18).map((entry) => (
+                <button
+                  key={entry.fullPath}
+                  type="button"
+                  onClick={() => onOpenMemoryFile?.(entry.fullPath)}
+                  className="flex w-full items-start gap-2 border-b border-[var(--border-hairline)] px-3 py-2 text-left hover:bg-[var(--bg-raised)]"
+                >
+                  <Icon name="ph:file-text" width={13} className="mt-0.5 shrink-0 text-[var(--text-muted)]" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[12px] text-[var(--text-primary)]">{entry.relPath}</span>
+                    <span className="mt-0.5 block truncate text-[10px] text-[var(--text-muted)]">{entry.rootLabel} · {age(entry.modified)}</span>
+                  </span>
+                </button>
+              ))}
+              {visibleCoven.length + visibleFiles.length === 0 ? (
+                <div className="px-3 py-8 text-center text-[12px] text-[var(--text-muted)]">
+                  {loaded ? "No memories match this constellation." : "Loading memories..."}
+                </div>
+              ) : null}
+            </div>
+          </aside>
+        </div>
+      ) : (
       <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto p-4 xl:grid-cols-[minmax(0,1.25fr)_minmax(320px,0.75fr)]">
         <section className="min-h-0">
           <div className="mb-2 flex items-center justify-between">
@@ -275,6 +367,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
           </div>
         </section>
       </div>
+      )}
     </div>
   );
 }

--- a/src/components/library-doc-preview.tsx
+++ b/src/components/library-doc-preview.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Icon } from "@/lib/icon";
+import { sanitizeHtml } from "@/lib/html-sanitize";
 import type {
   LibraryDocBody,
   LibraryBookmark,
@@ -98,15 +99,7 @@ function RenderedMarkdown({ text, containerRef }: RenderedMarkdownProps) {
       const fn = await getMdFn();
       const raw = await fn(text);
       if (cancelled) return;
-      const doc = new DOMParser().parseFromString(raw, "text/html");
-      for (const el of Array.from(doc.querySelectorAll("script,iframe,object,embed,link,style"))) el.remove();
-      for (const el of Array.from(doc.querySelectorAll<HTMLElement>("*"))) {
-        for (const attr of Array.from(el.attributes)) {
-          if (/^on/i.test(attr.name)) el.removeAttribute(attr.name);
-          if ((attr.name === "href" || attr.name === "src") && /^\s*javascript:/i.test(attr.value)) el.removeAttribute(attr.name);
-        }
-      }
-      setHtml(doc.body.innerHTML);
+      setHtml(sanitizeHtml(raw));
       setLoading(false);
     })();
     return () => { cancelled = true; };

--- a/src/components/memory-graph-3d-smoke.tsx
+++ b/src/components/memory-graph-3d-smoke.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { MemoryGraph3D } from "@/components/memory-graph-3d";
+import { buildMemoryGraphModel } from "@/lib/memory-graph-3d-model";
+import type { Familiar } from "@/lib/types";
+
+const now = new Date().toISOString();
+
+const familiarsList: Familiar[] = [
+  { id: "nova", display_name: "Nova", role: "Guide", icon: "ph:sparkle" },
+  { id: "cody", display_name: "Cody", role: "Builder", icon: "ph:terminal-window" },
+  { id: "sage", display_name: "Sage", role: "Research", icon: "ph:brain" },
+];
+
+const covenEntries = [
+  {
+    id: "smoke-nova-1",
+    familiar_id: "nova",
+    title: "Nova remembers the constellation architecture",
+    path: "/Users/buns/.coven/memory/nova/constellation.md",
+    updated_at: now,
+    excerpt: "Anchor familiar hubs and keep the list as the retrieval surface.",
+  },
+  {
+    id: "smoke-cody-1",
+    familiar_id: "cody",
+    title: "Cody records the graph implementation plan",
+    path: "/Users/buns/.coven/memory/cody/graph.md",
+    updated_at: now,
+    excerpt: "Use a dedicated memory graph model and Three.js viewer.",
+  },
+  {
+    id: "smoke-sage-1",
+    familiar_id: "sage",
+    title: "Sage notes radial layout constraints",
+    path: "/Users/buns/.coven/memory/sage/layout.md",
+    updated_at: now,
+    excerpt: "Avoid free-floating force scatter for dense memory views.",
+  },
+];
+
+const fileEntries = [
+  {
+    root: "workspace",
+    rootLabel: "Workspace memory",
+    relPath: "2026-06-08.md",
+    fullPath: "/Users/buns/.openclaw/workspace/memory/2026-06-08.md",
+    size: 2400,
+    modified: now,
+  },
+];
+
+export function MemoryGraph3DSmoke() {
+  const [selectedFamiliarId, setSelectedFamiliarId] = useState("all");
+  const familiars = useMemo(() => new Map(familiarsList.map((familiar) => [familiar.id, familiar])), []);
+  const graph = useMemo(
+    () =>
+      buildMemoryGraphModel({
+        familiars: familiarsList,
+        covenEntries,
+        fileEntries,
+        familiarFilter: selectedFamiliarId,
+      }),
+    [selectedFamiliarId],
+  );
+
+  return (
+    <main className="h-screen w-screen bg-[var(--bg-base)] p-6 text-[var(--text-primary)]">
+      <div className="h-full overflow-hidden border border-[var(--border-hairline)]">
+        <MemoryGraph3D
+          graph={graph}
+          familiars={familiars}
+          selectedFamiliarId={selectedFamiliarId}
+          onSelectFamiliar={setSelectedFamiliarId}
+          onOpenMemoryFile={() => {}}
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/components/memory-graph-3d.tsx
+++ b/src/components/memory-graph-3d.tsx
@@ -1,0 +1,519 @@
+"use client";
+
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+import * as THREE from "three";
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+import { Icon } from "@/lib/icon";
+import type { Familiar } from "@/lib/types";
+import {
+  buildMemoryGraphSceneModel,
+  type MemoryGraph,
+  type MemoryGraphSceneNode,
+} from "@/lib/memory-graph-3d-model";
+
+type Props = {
+  graph: MemoryGraph;
+  familiars: Map<string, Familiar>;
+  selectedFamiliarId: string;
+  onSelectFamiliar: (familiarId: string) => void;
+  onOpenMemoryFile?: (path: string) => void;
+};
+
+type Pickable = THREE.Object3D & {
+  userData: {
+    node?: MemoryGraphSceneNode;
+    nodes?: MemoryGraphSceneNode[];
+    baseOpacity?: number;
+  };
+};
+
+type Hover = { node: MemoryGraphSceneNode; x: number; y: number } | null;
+
+function asVector(position: { x: number; y: number; z: number }): THREE.Vector3 {
+  return new THREE.Vector3(position.x, position.y, position.z);
+}
+
+function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReduced(media.matches);
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, []);
+  return reduced;
+}
+
+function roundRect(context: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number) {
+  context.beginPath();
+  context.moveTo(x + r, y);
+  context.arcTo(x + w, y, x + w, y + h, r);
+  context.arcTo(x + w, y + h, x, y + h, r);
+  context.arcTo(x, y + h, x, y, r);
+  context.arcTo(x, y, x + w, y, r);
+  context.closePath();
+}
+
+function makeLabelSprite(text: string, color: string): THREE.Sprite {
+  const canvas = document.createElement("canvas");
+  const context = canvas.getContext("2d");
+  canvas.width = 384;
+  canvas.height = 96;
+  if (context) {
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    context.fillStyle = "rgba(10, 10, 14, 0.72)";
+    context.strokeStyle = "rgba(255, 255, 255, 0.14)";
+    roundRect(context, 10, 18, 364, 54, 16);
+    context.fill();
+    context.stroke();
+    context.font = "600 26px system-ui, -apple-system, BlinkMacSystemFont, sans-serif";
+    context.fillStyle = color;
+    context.textAlign = "center";
+    context.textBaseline = "middle";
+    context.fillText(text.slice(0, 24), canvas.width / 2, 45);
+  }
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  const material = new THREE.SpriteMaterial({ map: texture, transparent: true, depthWrite: false });
+  const sprite = new THREE.Sprite(material);
+  sprite.scale.set(2.8, 0.7, 1);
+  return sprite;
+}
+
+function materialList(object: THREE.Object3D): THREE.Material[] {
+  const material = (object as THREE.Mesh | THREE.Line | THREE.Sprite | THREE.InstancedMesh).material;
+  if (!material) return [];
+  return Array.isArray(material) ? material : [material];
+}
+
+function disposeObject(object: THREE.Object3D) {
+  const geometries = new Set<THREE.BufferGeometry>();
+  const materials = new Set<THREE.Material>();
+  object.traverse((child) => {
+    const geometry = (child as THREE.Mesh | THREE.Line | THREE.Sprite | THREE.InstancedMesh).geometry;
+    if (geometry) geometries.add(geometry);
+    materialList(child).forEach((material) => materials.add(material));
+  });
+  geometries.forEach((geometry) => geometry.dispose());
+  materials.forEach((material) => material.dispose());
+}
+
+function colorFor(node: MemoryGraphSceneNode, selectedFamiliarId: string): THREE.Color {
+  const color = new THREE.Color(node.color);
+  if (selectedFamiliarId === "all") return color;
+  const belongsToSelected =
+    (node.kind === "hub" && node.familiarId === selectedFamiliarId) ||
+    (node.kind !== "hub" && node.familiarId === selectedFamiliarId);
+  if (belongsToSelected) return color;
+  return color.lerp(new THREE.Color("#1a1722"), 0.72);
+}
+
+function nodeIsDimmed(node: MemoryGraphSceneNode, selectedFamiliarId: string): boolean {
+  if (selectedFamiliarId === "all") return false;
+  if (node.kind === "hub") return node.hubKind === "familiar" && node.familiarId !== selectedFamiliarId;
+  return node.familiarId !== selectedFamiliarId;
+}
+
+function compactAge(iso: string | undefined): string {
+  if (!iso) return "";
+  const ms = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(ms)) return "";
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+export function MemoryGraph3D({
+  graph,
+  familiars,
+  selectedFamiliarId,
+  onSelectFamiliar,
+  onOpenMemoryFile,
+}: Props) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const shellRef = useRef<HTMLDivElement | null>(null);
+  const resetRef = useRef<(() => void) | null>(null);
+  const [hover, setHover] = useState<Hover>(null);
+  const reducedMotion = useReducedMotion();
+  const sceneModel = useMemo(() => buildMemoryGraphSceneModel(graph), [graph]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const shell = shellRef.current;
+    if (!canvas || !shell || sceneModel.nodes.length === 0) return;
+
+    canvas.dataset.effectStarted = "true";
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    canvas.dataset.rendererReady = "true";
+
+    const scene = new THREE.Scene();
+    scene.fog = new THREE.FogExp2(0x07070d, 0.042);
+    const camera = new THREE.PerspectiveCamera(48, 1, 0.1, 90);
+    camera.position.set(0, 5.8, sceneModel.nodes.length <= 4 ? 10 : 14);
+    camera.lookAt(0, 0, 0);
+
+    const controls = new OrbitControls(camera, canvas);
+    controls.enableDamping = true;
+    controls.dampingFactor = 0.08;
+    controls.minDistance = 5.5;
+    controls.maxDistance = 24;
+    controls.target.set(0, 0, 0);
+    controls.saveState();
+
+    const root = new THREE.Group();
+    root.rotation.x = -0.18;
+    scene.add(root);
+    scene.add(new THREE.AmbientLight(0xffffff, 1.05));
+    const key = new THREE.DirectionalLight(0xe2d6ff, 2.4);
+    key.position.set(4, 8, 7);
+    scene.add(key);
+    const fill = new THREE.PointLight(0x38bdf8, 16, 24);
+    fill.position.set(-6, 2, 5);
+    scene.add(fill);
+
+    const pickables: Pickable[] = [];
+    const hubs = sceneModel.nodes.filter((node) => node.kind === "hub");
+    const leaves = sceneModel.nodes.filter((node) => node.kind === "memory");
+    const clusters = sceneModel.nodes.filter((node) => node.kind === "cluster");
+    const hubById = new Map(hubs.map((hub) => [hub.id, hub]));
+
+    const grid = new THREE.GridHelper(18, 18, 0x2c2440, 0x151520);
+    grid.position.y = -2.35;
+    root.add(grid);
+
+    for (const edge of sceneModel.edges) {
+      const geometry = new THREE.BufferGeometry().setFromPoints([asVector(edge.from), asVector(edge.to)]);
+      const material = new THREE.LineBasicMaterial({
+        color: new THREE.Color(edge.color),
+        transparent: true,
+        opacity: edge.opacity,
+      });
+      root.add(new THREE.Line(geometry, material));
+    }
+
+    for (const hub of hubs) {
+      const geometry = hub.hubKind === "files"
+        ? new THREE.IcosahedronGeometry(hub.radius, 1)
+        : new THREE.SphereGeometry(hub.radius, 32, 24);
+      const material = new THREE.MeshStandardMaterial({
+        color: 0x17131f,
+        emissive: colorFor(hub, selectedFamiliarId),
+        emissiveIntensity: nodeIsDimmed(hub, selectedFamiliarId) ? 0.1 : 0.36,
+        roughness: 0.42,
+        metalness: 0.12,
+      });
+      const mesh = new THREE.Mesh(geometry, material) as Pickable;
+      mesh.position.copy(asVector(hub.position));
+      mesh.userData.node = hub;
+      root.add(mesh);
+      pickables.push(mesh);
+
+      const halo = new THREE.Mesh(
+        new THREE.RingGeometry(hub.radius + 0.13, hub.radius + 0.2 + Math.min(hub.memoryCount, 30) * 0.004, 56),
+        new THREE.MeshBasicMaterial({
+          color: colorFor(hub, selectedFamiliarId),
+          transparent: true,
+          opacity: nodeIsDimmed(hub, selectedFamiliarId) ? 0.16 : 0.46,
+          side: THREE.DoubleSide,
+        }),
+      );
+      halo.position.copy(asVector(hub.position));
+      halo.userData.billboard = true;
+      root.add(halo);
+
+      const label = makeLabelSprite(
+        hub.hubKind === "files" ? hub.label : familiars.get(hub.familiarId ?? "")?.display_name ?? hub.label,
+        nodeIsDimmed(hub, selectedFamiliarId) ? "#7d748c" : "#f7f1ff",
+      );
+      label.position.copy(asVector(hub.position).add(new THREE.Vector3(0, hub.radius + 0.55, 0)));
+      root.add(label);
+    }
+
+    if (leaves.length > 0) {
+      const geometry = new THREE.SphereGeometry(1, 12, 10);
+      const material = new THREE.MeshStandardMaterial({
+        color: 0xffffff,
+        emissive: 0xffffff,
+        emissiveIntensity: 0.18,
+        vertexColors: true,
+        roughness: 0.55,
+        metalness: 0.05,
+      });
+      const instanced = new THREE.InstancedMesh(geometry, material, leaves.length);
+      const matrix = new THREE.Matrix4();
+      leaves.forEach((node, index) => {
+        matrix.compose(
+          asVector(node.position),
+          new THREE.Quaternion(),
+          new THREE.Vector3(node.radius, node.radius, node.radius),
+        );
+        instanced.setMatrixAt(index, matrix);
+        instanced.setColorAt(index, colorFor(node, selectedFamiliarId));
+      });
+      instanced.instanceMatrix.needsUpdate = true;
+      if (instanced.instanceColor) instanced.instanceColor.needsUpdate = true;
+      instanced.userData.nodes = leaves;
+      root.add(instanced);
+      pickables.push(instanced as Pickable);
+    }
+
+    for (const cluster of clusters) {
+      const color = colorFor(cluster, selectedFamiliarId);
+      const mesh = new THREE.Mesh(
+        new THREE.SphereGeometry(cluster.radius, 20, 14),
+        new THREE.MeshStandardMaterial({
+          color: 0x1e1820,
+          emissive: color,
+          emissiveIntensity: nodeIsDimmed(cluster, selectedFamiliarId) ? 0.08 : 0.28,
+          roughness: 0.48,
+        }),
+      ) as Pickable;
+      mesh.position.copy(asVector(cluster.position));
+      mesh.userData.node = cluster;
+      root.add(mesh);
+      pickables.push(mesh);
+
+      const label = makeLabelSprite(cluster.label, nodeIsDimmed(cluster, selectedFamiliarId) ? "#8f7d59" : "#fbbf24");
+      label.scale.set(1.25, 0.32, 1);
+      label.position.copy(asVector(cluster.position).add(new THREE.Vector3(0, cluster.radius + 0.34, 0)));
+      root.add(label);
+    }
+
+    const resize = () => {
+      const box = shell.getBoundingClientRect();
+      const width = Math.max(320, Math.floor(box.width));
+      const height = Math.max(420, Math.floor(box.height));
+      renderer.setSize(width, height, false);
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+    };
+    const observer = new ResizeObserver(resize);
+    observer.observe(shell);
+    resize();
+
+    let visible = true;
+    const visibilityObserver = new IntersectionObserver(([entry]) => {
+      visible = entry?.isIntersecting ?? true;
+    });
+    visibilityObserver.observe(shell);
+
+    const resetView = () => {
+      controls.reset();
+      root.rotation.set(-0.18, 0, 0);
+      camera.position.set(0, 5.8, sceneModel.nodes.length <= 4 ? 10 : 14);
+      camera.lookAt(0, 0, 0);
+      controls.update();
+    };
+    resetRef.current = resetView;
+
+    const raycaster = new THREE.Raycaster();
+    const pointer = new THREE.Vector2();
+    const drag = { active: false, moved: false, x: 0, y: 0 };
+    const setPointer = (event: PointerEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+      pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+    };
+    const hitNode = (): MemoryGraphSceneNode | null => {
+      raycaster.setFromCamera(pointer, camera);
+      const hit = raycaster.intersectObjects(pickables, false)[0];
+      if (!hit) return null;
+      const object = hit.object as Pickable;
+      if (object.userData.node) return object.userData.node;
+      if (typeof hit.instanceId === "number") return object.userData.nodes?.[hit.instanceId] ?? null;
+      return null;
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      drag.active = true;
+      drag.moved = false;
+      drag.x = event.clientX;
+      drag.y = event.clientY;
+      canvas.setPointerCapture(event.pointerId);
+    };
+    const onPointerMove = (event: PointerEvent) => {
+      if (drag.active) {
+        const dx = event.clientX - drag.x;
+        const dy = event.clientY - drag.y;
+        if (Math.abs(dx) + Math.abs(dy) > 3) drag.moved = true;
+        drag.x = event.clientX;
+        drag.y = event.clientY;
+        return;
+      }
+      setPointer(event);
+      const node = hitNode();
+      setHover(node ? { node, x: event.clientX, y: event.clientY } : null);
+    };
+    const onPointerUp = (event: PointerEvent) => {
+      drag.active = false;
+      try { canvas.releasePointerCapture(event.pointerId); } catch {}
+      if (drag.moved) return;
+      setPointer(event);
+      const node = hitNode();
+      if (!node) {
+        onSelectFamiliar("all");
+      } else if (node.kind === "hub") {
+        onSelectFamiliar(node.familiarId ?? "all");
+      } else if (node.kind === "memory") {
+        onOpenMemoryFile?.(node.path);
+      } else if (node.familiarId) {
+        onSelectFamiliar(node.familiarId);
+      } else {
+        onSelectFamiliar("all");
+      }
+    };
+    const onPointerLeave = () => setHover(null);
+    const onGesture = (event: Event) => event.preventDefault();
+    canvas.addEventListener("pointerdown", onPointerDown);
+    canvas.addEventListener("pointermove", onPointerMove);
+    canvas.addEventListener("pointerup", onPointerUp);
+    canvas.addEventListener("pointerleave", onPointerLeave);
+    canvas.addEventListener("gesturestart", onGesture);
+    canvas.addEventListener("gesturechange", onGesture);
+
+    let frame = 0;
+    let previousFrameAt = performance.now();
+    const startedAt = previousFrameAt;
+    const animate = () => {
+      frame = requestAnimationFrame(animate);
+      if (!visible) return;
+      const now = performance.now();
+      const elapsed = (now - startedAt) / 1000;
+      const delta = (now - previousFrameAt) / 1000;
+      previousFrameAt = now;
+      controls.update();
+      if (!reducedMotion && !drag.active) root.rotation.y += delta * 0.025;
+      root.traverse((child) => {
+        if (child instanceof THREE.Sprite || child.userData.billboard) child.quaternion.copy(camera.quaternion);
+        if (!reducedMotion && child.userData.billboard) {
+          const pulse = (Math.sin(elapsed * 1.5) + 1) / 2;
+          for (const material of materialList(child)) {
+            if ("opacity" in material && typeof child.userData.baseOpacity === "number") {
+              material.opacity = child.userData.baseOpacity + pulse * 0.08;
+            }
+          }
+        }
+      });
+      renderer.render(scene, camera);
+    };
+    animate();
+
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+      visibilityObserver.disconnect();
+      canvas.removeEventListener("pointerdown", onPointerDown);
+      canvas.removeEventListener("pointermove", onPointerMove);
+      canvas.removeEventListener("pointerup", onPointerUp);
+      canvas.removeEventListener("pointerleave", onPointerLeave);
+      canvas.removeEventListener("gesturestart", onGesture);
+      canvas.removeEventListener("gesturechange", onGesture);
+      resetRef.current = null;
+      controls.dispose();
+      disposeObject(root);
+      renderer.dispose();
+    };
+  }, [familiars, graph, onOpenMemoryFile, onSelectFamiliar, reducedMotion, sceneModel, selectedFamiliarId]);
+
+  const selectedLabel = selectedFamiliarId === "all"
+    ? `${graph.metrics.visibleCovenEntries + graph.metrics.visibleFileEntries} memories in constellation.`
+    : `Selected familiar ${familiars.get(selectedFamiliarId)?.display_name ?? selectedFamiliarId}.`;
+
+  const onKeyDown = (event: KeyboardEvent<HTMLCanvasElement>) => {
+    if (event.key === "Escape") onSelectFamiliar("all");
+    if (event.key === "Home") resetRef.current?.();
+  };
+
+  if (sceneModel.nodes.length === 0) {
+    return (
+      <div className="grid min-h-[420px] flex-1 place-items-center bg-[oklch(0.11_0.022_293)] text-sm text-white/55">
+        No memories in this constellation.
+      </div>
+    );
+  }
+
+  return (
+    <div ref={shellRef} className="relative min-h-[520px] flex-1 overflow-hidden bg-[oklch(0.105_0.024_286)]">
+      <canvas
+        ref={canvasRef}
+        data-testid="memory-graph-3d-canvas"
+        aria-label="3D memory constellation"
+        role="application"
+        tabIndex={0}
+        onKeyDown={onKeyDown}
+        className="h-full min-h-[520px] w-full cursor-grab touch-none active:cursor-grabbing"
+      />
+      <p aria-live="polite" className="sr-only">{selectedLabel}</p>
+      <div className="pointer-events-none absolute inset-x-0 top-0 flex flex-wrap items-start justify-between gap-3 p-3">
+        <div className="rounded-lg border border-white/10 bg-black/45 px-3 py-2 shadow-2xl backdrop-blur">
+          <div className="text-[10px] font-semibold uppercase tracking-widest text-white/55">Memory constellation</div>
+          <div className="mt-1 flex flex-wrap gap-2 text-[10px] text-white/70">
+            <span>{graph.metrics.familiarHubs} familiars</span>
+            <span>{graph.metrics.visibleCovenEntries} coven</span>
+            <span>{graph.metrics.visibleFileEntries} files</span>
+          </div>
+        </div>
+        <button
+          type="button"
+          title="Reset view"
+          onClick={() => resetRef.current?.()}
+          className="pointer-events-auto inline-flex h-8 w-8 items-center justify-center rounded-md border border-white/10 bg-black/45 text-white/70 shadow-2xl backdrop-blur hover:bg-white/10 hover:text-white"
+        >
+          <Icon name="ph:arrows-clockwise-bold" width={14} />
+        </button>
+      </div>
+      <div className="pointer-events-none absolute bottom-3 left-3 flex flex-wrap items-center gap-2 rounded-lg border border-white/10 bg-black/45 px-3 py-2 text-[10px] text-white/65 shadow-2xl backdrop-blur">
+        <span className="inline-flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-[#8E3DFF]" /> familiar</span>
+        <span className="inline-flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-[#62d08f]" /> coven</span>
+        <span className="inline-flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-[#38bdf8]" /> files</span>
+        <span className="inline-flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-[#f59e0b]" /> cluster</span>
+      </div>
+      {graph.metrics.hiddenEntries > 0 ? (
+        <div className="pointer-events-none absolute right-3 top-16 max-w-[260px] rounded-lg border border-[color-mix(in_oklch,var(--color-warning)_25%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_18%,transparent)] px-3 py-2 text-[10px] text-[var(--color-warning)] shadow-2xl backdrop-blur">
+          Dense constellation: {graph.metrics.hiddenEntries} older memories are clustered.
+        </div>
+      ) : null}
+      {hover ? <MemoryGraphTooltip hover={hover} familiars={familiars} /> : null}
+    </div>
+  );
+}
+
+function MemoryGraphTooltip({
+  hover,
+  familiars,
+}: {
+  hover: NonNullable<Hover>;
+  familiars: Map<string, Familiar>;
+}) {
+  const { node } = hover;
+  const familiarName = node.familiarId ? familiars.get(node.familiarId)?.display_name ?? node.familiarId : "Memory Files";
+  const detail = node.kind === "hub"
+    ? `${node.memoryCount} memories`
+    : node.kind === "cluster"
+      ? `${node.count} older memories`
+      : `${familiarName} · ${node.source === "file" ? node.rootLabel ?? "file" : "coven"} · ${compactAge(node.updatedAt)}`;
+
+  return (
+    <div
+      className="pointer-events-none fixed z-50 max-w-[300px] rounded-lg border border-white/10 bg-black/85 px-3 py-2 text-[11px] text-white shadow-2xl backdrop-blur"
+      style={{ left: hover.x + 12, top: hover.y + 12 }}
+    >
+      <div className="font-semibold">{node.label}</div>
+      <div className="mt-1 text-white/65">{detail}</div>
+      {node.kind === "memory" && node.excerpt ? (
+        <div className="mt-2 line-clamp-3 text-white/55">{node.excerpt}</div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -224,6 +224,48 @@ export function SyntaxBlock({ text, lang, className }: SyntaxBlockProps) {
   );
 }
 
+
+const DANGEROUS_ELEMENTS_SELECTOR = "script, iframe, object, embed, link, style, meta, base";
+const URL_ATTRS = new Set(["href", "src", "xlink:href", "formaction", "poster"]);
+const SAFE_URL_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+
+function isSafeUrl(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return true;
+
+  // Browsers ignore ASCII whitespace/control chars while resolving URL schemes,
+  // so normalize before checking for javascript:/data:/vbscript: payloads.
+  const normalized = trimmed.replace(/[\u0000-\u001F\u007F\s]+/g, "");
+  const schemeMatch = /^([a-zA-Z][a-zA-Z\d+.-]*):/.exec(normalized);
+  if (!schemeMatch) return true;
+
+  return SAFE_URL_PROTOCOLS.has(`${schemeMatch[1].toLowerCase()}:`);
+}
+
+function sanitizeHtml(html: string): string {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+
+  for (const el of Array.from(doc.querySelectorAll(DANGEROUS_ELEMENTS_SELECTOR))) {
+    el.remove();
+  }
+
+  for (const el of Array.from(doc.querySelectorAll<HTMLElement>("*"))) {
+    for (const attr of Array.from(el.attributes)) {
+      const attrName = attr.name.toLowerCase();
+      if (attrName.startsWith("on")) {
+        el.removeAttribute(attr.name);
+        continue;
+      }
+
+      if (URL_ATTRS.has(attrName) && !isSafeUrl(attr.value)) {
+        el.removeAttribute(attr.name);
+      }
+    }
+  }
+
+  return doc.body.innerHTML;
+}
+
 // ---------------------------------------------------------------------------
 // Public: MarkdownBlock — renders full markdown (prose + code) via @create-markdown/preview
 // ---------------------------------------------------------------------------
@@ -235,16 +277,7 @@ export function MarkdownBlock({ text, className }: { text: string; className?: s
     if (!text) return;
     let cancelled = false;
     void mdToHtml(text).then((h) => {
-      if (cancelled) return;
-      const doc = new DOMParser().parseFromString(h, "text/html");
-      for (const el of Array.from(doc.querySelectorAll("script, iframe, object, embed, link, style"))) el.remove();
-      for (const el of Array.from(doc.querySelectorAll<HTMLElement>("*"))) {
-        for (const attr of Array.from(el.attributes)) {
-          if (/^on/i.test(attr.name)) el.removeAttribute(attr.name);
-          if ((attr.name === "href" || attr.name === "src") && /^\s*javascript:/i.test(attr.value)) el.removeAttribute(attr.name);
-        }
-      }
-      setHtml(doc.body.innerHTML);
+      if (!cancelled) setHtml(h);
     });
     return () => { cancelled = true; };
   }, [text]);
@@ -326,8 +359,9 @@ async function mdToHtml(markdown: string): Promise<string> {
     html = html.replace(re, replacement);
   }
 
-  renderCache.set(markdown, html);
-  return html;
+  const sanitizedHtml = sanitizeHtml(html);
+  renderCache.set(markdown, sanitizedHtml);
+  return sanitizedHtml;
 }
 
 function regEsc(s: string): string {
@@ -400,7 +434,7 @@ function MarkdownContent({ text, pending }: { text: string; pending?: boolean })
     <div
       ref={containerRef}
       className="cave-md"
-      // Content originates from our own Coven daemon — fully trusted.
+      // Markdown output is sanitized in mdToHtml before DOM insertion.
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{ __html: html }}
     />

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -33,6 +33,7 @@ import type { Block } from "@create-markdown/core";
 import type { Highlighter } from "shiki";
 import moodCTheme from "@/styles/shiki/mood-c-dark.json";
 import { Icon } from "@/lib/icon";
+import { sanitizeHtml } from "@/lib/html-sanitize";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -225,47 +226,6 @@ export function SyntaxBlock({ text, lang, className }: SyntaxBlockProps) {
   );
 }
 
-
-const DANGEROUS_ELEMENTS_SELECTOR = "script, iframe, object, embed, link, style, meta, base";
-const URL_ATTRS = new Set(["href", "src", "xlink:href", "formaction", "poster"]);
-const SAFE_URL_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
-
-function isSafeUrl(value: string): boolean {
-  const trimmed = value.trim();
-  if (!trimmed) return true;
-
-  // Browsers ignore ASCII whitespace/control chars while resolving URL schemes,
-  // so normalize before checking for javascript:/data:/vbscript: payloads.
-  const normalized = trimmed.replace(/[\u0000-\u001F\u007F\s]+/g, "");
-  const schemeMatch = /^([a-zA-Z][a-zA-Z\d+.-]*):/.exec(normalized);
-  if (!schemeMatch) return true;
-
-  return SAFE_URL_PROTOCOLS.has(`${schemeMatch[1].toLowerCase()}:`);
-}
-
-function sanitizeHtml(html: string): string {
-  const doc = new DOMParser().parseFromString(html, "text/html");
-
-  for (const el of Array.from(doc.querySelectorAll(DANGEROUS_ELEMENTS_SELECTOR))) {
-    el.remove();
-  }
-
-  for (const el of Array.from(doc.querySelectorAll<HTMLElement>("*"))) {
-    for (const attr of Array.from(el.attributes)) {
-      const attrName = attr.name.toLowerCase();
-      if (attrName.startsWith("on")) {
-        el.removeAttribute(attr.name);
-        continue;
-      }
-
-      if (URL_ATTRS.has(attrName) && !isSafeUrl(attr.value)) {
-        el.removeAttribute(attr.name);
-      }
-    }
-  }
-
-  return doc.body.innerHTML;
-}
 
 // ---------------------------------------------------------------------------
 // Public: MarkdownBlock — renders full markdown (prose + code) via @create-markdown/preview

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -30,6 +30,8 @@ import path from "node:path";
 let cachedBin: string | null = null;
 let cachedPath: string | null = null;
 
+const FORBIDDEN_SPAWN_ENV_KEYS = ["GITHUB_PAT"] as const;
+
 const HOME = os.homedir();
 
 function nodeNvmBinDirs(): string[] {
@@ -152,5 +154,9 @@ export function covenSpawnEnv(): NodeJS.ProcessEnv {
     }
     cachedPath = dedup.join(":");
   }
-  return { ...process.env, PATH: cachedPath };
+  const env: NodeJS.ProcessEnv = { ...process.env, PATH: cachedPath };
+  for (const key of FORBIDDEN_SPAWN_ENV_KEYS) {
+    delete env[key];
+  }
+  return env;
 }

--- a/src/lib/harness-adapters.test.ts
+++ b/src/lib/harness-adapters.test.ts
@@ -7,6 +7,8 @@ import {
   runtimeSourceSetupState,
   adapterManifestScaffoldForHarness,
   covenHelpSupportsAdapterList,
+  isTrustedChatHarness,
+  isTrustedOnboardingHarness,
   openClawAdapterReport,
 } from "./harness-adapters.ts";
 
@@ -93,6 +95,29 @@ assert.equal(
   merged.find((adapter) => adapter.id === "hermes")?.chatSupported,
   true,
 );
+
+const mergedExternal = mergeAdapterReports(
+  [],
+  [
+    {
+      id: "attacker-adapter",
+      label: "Attacker Adapter",
+      executable: "attacker",
+      available: true,
+      install_hint: "Do not run this in native chat.",
+      source: "manifest",
+      manifest_path: "/tmp/attacker.json",
+    },
+  ],
+);
+assert.equal(mergedExternal[0]?.chatSupported, false);
+assert.equal(mergedExternal[0]?.installed, true);
+assert.equal(isTrustedChatHarness("codex"), true);
+assert.equal(isTrustedChatHarness("hermes"), true);
+assert.equal(isTrustedChatHarness("openclaw"), false);
+assert.equal(isTrustedChatHarness("attacker-adapter"), false);
+assert.equal(isTrustedOnboardingHarness("openclaw"), true);
+assert.equal(isTrustedOnboardingHarness("attacker-adapter"), false);
 
 assert.deepEqual(adapterSetupState(merged), {
   ok: true,

--- a/src/lib/harness-adapters.ts
+++ b/src/lib/harness-adapters.ts
@@ -87,6 +87,24 @@ export const COMPATIBILITY_ADAPTERS: CompatibilityAdapter[] = [
   },
 ];
 
+const TRUSTED_ONBOARDING_HARNESSES = new Set(
+  COMPATIBILITY_ADAPTERS.map((adapter) => adapter.id),
+);
+
+const TRUSTED_CHAT_HARNESSES = new Set(
+  COMPATIBILITY_ADAPTERS.filter((adapter) => adapter.chatSupported).map(
+    (adapter) => adapter.id,
+  ),
+);
+
+export function isTrustedOnboardingHarness(harness: string): boolean {
+  return TRUSTED_ONBOARDING_HARNESSES.has(harness);
+}
+
+export function isTrustedChatHarness(harness: string): boolean {
+  return TRUSTED_CHAT_HARNESSES.has(harness);
+}
+
 export function openClawAdapterReport(openclawAgentCount: number): AdapterReport {
   return {
     id: "openclaw",
@@ -144,7 +162,7 @@ export function mergeAdapterReports(
       id: coven.id,
       label: coven.label,
       binary: coven.executable,
-      chatSupported: true,
+      chatSupported: existing?.chatSupported ?? isTrustedChatHarness(coven.id),
       installed: coven.available || existing?.installed === true,
       path: existing?.path ?? null,
       version: existing?.version ?? null,

--- a/src/lib/html-sanitize.test.ts
+++ b/src/lib/html-sanitize.test.ts
@@ -1,0 +1,61 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const sanitizerSource = await readFile(new URL("./html-sanitize.ts", import.meta.url), "utf8");
+const messageBubbleSource = await readFile(new URL("../components/message-bubble.tsx", import.meta.url), "utf8");
+const libraryPreviewSource = await readFile(new URL("../components/library-doc-preview.tsx", import.meta.url), "utf8");
+
+assert.match(
+  sanitizerSource,
+  /export function sanitizeHtml\(html: string\): string/,
+  "shared sanitizer should expose one sanitizer for rendered markdown HTML",
+);
+
+assert.match(
+  sanitizerSource,
+  /querySelectorAll\("\*"\)/,
+  "sanitizer should walk generic DOM Elements instead of assuming only HTMLElements",
+);
+
+assert.doesNotMatch(
+  sanitizerSource,
+  /querySelectorAll<HTMLElement>/,
+  "sanitizer should not use HTMLElement-only generics because parsed HTML can contain SVG/MathML elements",
+);
+
+assert.match(
+  sanitizerSource,
+  /"xlink:href"/,
+  "sanitizer should handle SVG URL-bearing attributes",
+);
+
+assert.match(
+  sanitizerSource,
+  /replace\(\S*\\u0000-\\u001F\\u007F\\s/,
+  "sanitizer should normalize whitespace/control characters before URL scheme checks",
+);
+
+assert.match(
+  messageBubbleSource,
+  /import \{ sanitizeHtml \} from "@\/lib\/html-sanitize"/,
+  "message markdown should use the shared sanitizer",
+);
+
+assert.match(
+  libraryPreviewSource,
+  /import \{ sanitizeHtml \} from "@\/lib\/html-sanitize"/,
+  "library markdown preview should use the shared sanitizer",
+);
+
+assert.doesNotMatch(
+  messageBubbleSource,
+  /function sanitizeHtml/,
+  "message markdown should not keep a duplicate inline sanitizer",
+);
+
+assert.doesNotMatch(
+  libraryPreviewSource,
+  /new DOMParser\(\)\.parseFromString\(raw, "text\/html"\)/,
+  "library markdown preview should not keep a duplicate inline sanitizer",
+);

--- a/src/lib/html-sanitize.ts
+++ b/src/lib/html-sanitize.ts
@@ -1,0 +1,40 @@
+const DANGEROUS_ELEMENTS_SELECTOR = "script, iframe, object, embed, link, style, meta, base";
+const URL_ATTRS = new Set(["href", "src", "xlink:href", "formaction", "poster"]);
+const SAFE_URL_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+
+function isSafeUrl(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return true;
+
+  // Browsers ignore ASCII whitespace/control chars while resolving URL schemes,
+  // so normalize before checking for javascript:/data:/vbscript: payloads.
+  const normalized = trimmed.replace(/[\u0000-\u001F\u007F\s]+/g, "");
+  const schemeMatch = /^([a-zA-Z][a-zA-Z\d+.-]*):/.exec(normalized);
+  if (!schemeMatch) return true;
+
+  return SAFE_URL_PROTOCOLS.has(`${schemeMatch[1].toLowerCase()}:`);
+}
+
+export function sanitizeHtml(html: string): string {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+
+  for (const el of Array.from(doc.querySelectorAll(DANGEROUS_ELEMENTS_SELECTOR))) {
+    el.remove();
+  }
+
+  for (const el of Array.from(doc.querySelectorAll("*"))) {
+    for (const attr of Array.from(el.attributes)) {
+      const attrName = attr.name.toLowerCase();
+      if (attrName.startsWith("on")) {
+        el.removeAttribute(attr.name);
+        continue;
+      }
+
+      if (URL_ATTRS.has(attrName) && !isSafeUrl(attr.value)) {
+        el.removeAttribute(attr.name);
+      }
+    }
+  }
+
+  return doc.body.innerHTML;
+}

--- a/src/lib/memory-graph-3d-model.test.ts
+++ b/src/lib/memory-graph-3d-model.test.ts
@@ -1,0 +1,131 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  buildMemoryGraphModel,
+  buildMemoryGraphSceneModel,
+  memorySelectionObjectKey,
+} from "./memory-graph-3d-model.ts";
+
+const familiars = [
+  { id: "nova", display_name: "Nova", role: "Guide", icon: "ph:sparkle" },
+  { id: "cody", display_name: "Cody", role: "Builder", emoji: "C" },
+];
+
+const covenEntries = [
+  {
+    id: "mem-1",
+    familiar_id: "nova",
+    title: "Nova remembers routing",
+    path: "/Users/buns/.coven/memory/nova.md",
+    updated_at: "2026-06-08T05:00:00.000Z",
+    excerpt: "routing architecture",
+  },
+  {
+    id: "mem-2",
+    familiar_id: "cody",
+    title: "Cody build note",
+    path: "/Users/buns/.coven/memory/cody.md",
+    updated_at: "2026-06-08T04:00:00.000Z",
+  },
+  {
+    id: "mem-3",
+    familiar_id: "nova",
+    title: "Older Nova note",
+    path: "/Users/buns/.coven/memory/nova-old.md",
+    updated_at: "2026-06-07T04:00:00.000Z",
+  },
+];
+
+const fileEntries = [
+  {
+    root: "workspace",
+    rootLabel: "Workspace memory",
+    relPath: "2026-06-08.md",
+    fullPath: "/Users/buns/.openclaw/workspace/memory/2026-06-08.md",
+    size: 1200,
+    modified: "2026-06-08T05:10:00.000Z",
+  },
+];
+
+const graph = buildMemoryGraphModel({
+  familiars,
+  covenEntries,
+  fileEntries,
+  query: "",
+  familiarFilter: "all",
+  maxLeavesPerHub: 1,
+});
+
+const familiarHubs = graph.nodes.filter((node) => node.kind === "hub" && node.hubKind === "familiar");
+assert.deepEqual(
+  familiarHubs.map((node) => node.id),
+  ["familiar:nova", "familiar:cody"],
+  "all familiar hubs should render even when their visible memory leaf count is capped",
+);
+
+assert.ok(
+  graph.nodes.some((node) => node.kind === "hub" && node.hubKind === "files" && node.label === "Memory Files"),
+  "filesystem memory entries should be represented under a neutral Memory Files hub",
+);
+
+assert.ok(
+  graph.edges.some((edge) => edge.source === "memory:coven:mem-1" && edge.target === "familiar:nova"),
+  "coven memory leaves should connect to their familiar hub",
+);
+
+assert.ok(
+  graph.edges.some((edge) => edge.source.startsWith("memory:file:") && edge.target === "hub:memory-files"),
+  "filesystem memory leaves should connect to the neutral files hub",
+);
+
+assert.equal(
+  graph.nodes.find((node) => node.kind === "memory" && node.source === "file")?.familiarId,
+  undefined,
+  "filesystem memory leaves must not fake a familiar relationship",
+);
+
+assert.equal(
+  graph.nodes.find((node) => node.kind === "cluster" && node.hubId === "familiar:nova")?.count,
+  1,
+  "overflow familiar memories should collapse into a cluster node",
+);
+
+const filtered = buildMemoryGraphModel({
+  familiars,
+  covenEntries,
+  fileEntries,
+  query: "routing",
+  familiarFilter: "nova",
+  maxLeavesPerHub: 10,
+});
+
+assert.deepEqual(
+  filtered.nodes.filter((node) => node.kind === "memory" && node.source === "coven").map((node) => node.id),
+  ["memory:coven:mem-1"],
+  "query and familiar filters should apply to familiar memory leaves",
+);
+
+assert.equal(
+  memorySelectionObjectKey({ kind: "familiar", id: "nova" }),
+  "hub:familiar:nova",
+);
+assert.equal(
+  memorySelectionObjectKey({ kind: "memory", id: "memory:coven:mem-1" }),
+  "memory:memory:coven:mem-1",
+);
+
+const scene = buildMemoryGraphSceneModel(graph);
+const novaHub = scene.nodes.find((node) => node.id === "familiar:nova");
+const novaLeaf = scene.nodes.find((node) => node.id === "memory:coven:mem-1");
+assert.ok(novaHub, "scene model should include familiar hub positions");
+assert.ok(novaLeaf, "scene model should include memory leaf positions");
+assert.notDeepEqual(
+  novaHub?.position,
+  novaLeaf?.position,
+  "memory leaves should be positioned on a shell around their hub, not on top of it",
+);
+assert.equal(
+  scene.nodes.find((node) => node.id === "familiar:nova")?.memoryCount,
+  2,
+  "hub memory count should reflect total matching entries before visual leaf caps",
+);

--- a/src/lib/memory-graph-3d-model.ts
+++ b/src/lib/memory-graph-3d-model.ts
@@ -1,0 +1,459 @@
+import type { Familiar } from "@/lib/types";
+
+export type MemoryGraphCovenEntry = {
+  id: string;
+  familiar_id: string;
+  title: string;
+  path: string;
+  updated_at: string;
+  excerpt?: string;
+};
+
+export type MemoryGraphFileEntry = {
+  root: string;
+  rootLabel: string;
+  relPath: string;
+  fullPath: string;
+  size: number;
+  modified: string;
+};
+
+export type MemoryGraphHubNode = {
+  kind: "hub";
+  hubKind: "familiar" | "files";
+  id: string;
+  label: string;
+  glyph?: string;
+  familiarId?: string;
+  memoryCount: number;
+  latestAt?: string;
+};
+
+export type MemoryGraphMemoryNode = {
+  kind: "memory";
+  id: string;
+  source: "coven" | "file";
+  hubId: string;
+  familiarId?: string;
+  title: string;
+  path: string;
+  updatedAt: string;
+  excerpt?: string;
+  rootLabel?: string;
+  relPath?: string;
+};
+
+export type MemoryGraphClusterNode = {
+  kind: "cluster";
+  id: string;
+  hubId: string;
+  familiarId?: string;
+  source: "coven" | "file";
+  label: string;
+  count: number;
+  latestAt?: string;
+};
+
+export type MemoryGraphNode =
+  | MemoryGraphHubNode
+  | MemoryGraphMemoryNode
+  | MemoryGraphClusterNode;
+
+type MemoryGraphChildNode = MemoryGraphMemoryNode | MemoryGraphClusterNode;
+
+export type MemoryGraphEdge = {
+  id: string;
+  kind: "belongs_to";
+  source: string;
+  target: string;
+  count: number;
+};
+
+export type MemoryGraph = {
+  nodes: MemoryGraphNode[];
+  edges: MemoryGraphEdge[];
+  metrics: {
+    familiarHubs: number;
+    fileHubs: number;
+    visibleCovenEntries: number;
+    visibleFileEntries: number;
+    hiddenEntries: number;
+  };
+};
+
+export type MemoryGraphSelection =
+  | { kind: "familiar"; id: string }
+  | { kind: "memory"; id: string }
+  | { kind: "cluster"; id: string }
+  | { kind: "files" }
+  | null;
+
+export type MemoryGraphSceneNode = MemoryGraphNode & {
+  label: string;
+  position: ScenePosition;
+  radius: number;
+  color: string;
+  memoryCount: number;
+};
+
+export type MemoryGraphSceneEdge = MemoryGraphEdge & {
+  from: ScenePosition;
+  to: ScenePosition;
+  color: string;
+  opacity: number;
+};
+
+export type MemoryGraphSceneModel = {
+  nodes: MemoryGraphSceneNode[];
+  edges: MemoryGraphSceneEdge[];
+};
+
+export type ScenePosition = { x: number; y: number; z: number };
+
+const FILE_HUB_ID = "hub:memory-files";
+
+function matchesQuery(values: Array<string | undefined>, query: string): boolean {
+  if (!query) return true;
+  return values.some((value) => (value ?? "").toLowerCase().includes(query));
+}
+
+function compareIsoDesc(a?: string, b?: string): number {
+  return (b ?? "").localeCompare(a ?? "");
+}
+
+function compactFileTitle(entry: MemoryGraphFileEntry): string {
+  return entry.relPath || entry.fullPath.split("/").pop() || entry.fullPath;
+}
+
+function memoryIdForFile(entry: MemoryGraphFileEntry): string {
+  return `memory:file:${entry.fullPath}`;
+}
+
+function memoryIdForCoven(entry: MemoryGraphCovenEntry): string {
+  return `memory:coven:${entry.id}`;
+}
+
+function edgeId(source: string, target: string): string {
+  return `${source}->${target}`;
+}
+
+function pos(x: number, y: number, z: number): ScenePosition {
+  return { x, y, z };
+}
+
+function addCappedLeaves({
+  hubId,
+  familiarId,
+  source,
+  entries,
+  maxLeavesPerHub,
+  toMemoryNode,
+  nodes,
+  edges,
+}: {
+  hubId: string;
+  familiarId?: string;
+  source: "coven" | "file";
+  entries: Array<MemoryGraphCovenEntry | MemoryGraphFileEntry>;
+  maxLeavesPerHub: number;
+  toMemoryNode: (entry: MemoryGraphCovenEntry | MemoryGraphFileEntry) => MemoryGraphMemoryNode;
+  nodes: MemoryGraphNode[];
+  edges: MemoryGraphEdge[];
+}) {
+  const visible = entries.slice(0, maxLeavesPerHub);
+  const hidden = entries.slice(maxLeavesPerHub);
+
+  for (const entry of visible) {
+    const node = toMemoryNode(entry);
+    nodes.push(node);
+    edges.push({
+      id: edgeId(node.id, hubId),
+      kind: "belongs_to",
+      source: node.id,
+      target: hubId,
+      count: 1,
+    });
+  }
+
+  if (hidden.length > 0) {
+    const cluster: MemoryGraphClusterNode = {
+      kind: "cluster",
+      id: `cluster:${hubId}`,
+      hubId,
+      familiarId,
+      source,
+      label: `+${hidden.length} older`,
+      count: hidden.length,
+      latestAt:
+        source === "coven"
+          ? (hidden[0] as MemoryGraphCovenEntry | undefined)?.updated_at
+          : (hidden[0] as MemoryGraphFileEntry | undefined)?.modified,
+    };
+    nodes.push(cluster);
+    edges.push({
+      id: edgeId(cluster.id, hubId),
+      kind: "belongs_to",
+      source: cluster.id,
+      target: hubId,
+      count: hidden.length,
+    });
+  }
+}
+
+export function buildMemoryGraphModel({
+  familiars,
+  covenEntries,
+  fileEntries,
+  query = "",
+  familiarFilter = "all",
+  maxLeavesPerHub = 30,
+}: {
+  familiars: Familiar[];
+  covenEntries: MemoryGraphCovenEntry[];
+  fileEntries: MemoryGraphFileEntry[];
+  query?: string;
+  familiarFilter?: string;
+  maxLeavesPerHub?: number;
+}): MemoryGraph {
+  const q = query.trim().toLowerCase();
+  const nodes: MemoryGraphNode[] = [];
+  const edges: MemoryGraphEdge[] = [];
+  let hiddenEntries = 0;
+
+  const matchingCovenEntries = covenEntries
+    .filter((entry) => familiarFilter === "all" || entry.familiar_id === familiarFilter)
+    .filter((entry) =>
+      matchesQuery([entry.title, entry.excerpt, entry.familiar_id, entry.path], q),
+    )
+    .sort((a, b) => compareIsoDesc(a.updated_at, b.updated_at));
+
+  const matchingFiles = fileEntries
+    .filter((entry) =>
+      matchesQuery([entry.rootLabel, entry.relPath, entry.fullPath], q),
+    )
+    .sort((a, b) => compareIsoDesc(a.modified, b.modified));
+
+  const covenByFamiliar = new Map<string, MemoryGraphCovenEntry[]>();
+  for (const entry of matchingCovenEntries) {
+    const bucket = covenByFamiliar.get(entry.familiar_id) ?? [];
+    bucket.push(entry);
+    covenByFamiliar.set(entry.familiar_id, bucket);
+  }
+
+  const totalCovenByFamiliar = new Map<string, number>();
+  for (const entry of covenEntries) {
+    if (!matchesQuery([entry.title, entry.excerpt, entry.familiar_id, entry.path], q)) continue;
+    totalCovenByFamiliar.set(
+      entry.familiar_id,
+      (totalCovenByFamiliar.get(entry.familiar_id) ?? 0) + 1,
+    );
+  }
+
+  for (const familiar of familiars) {
+    const hubId = `familiar:${familiar.id}`;
+    const entries = covenByFamiliar.get(familiar.id) ?? [];
+    const latestAt = entries[0]?.updated_at;
+    nodes.push({
+      kind: "hub",
+      hubKind: "familiar",
+      id: hubId,
+      label: familiar.display_name ?? familiar.name ?? familiar.id,
+      glyph: familiar.icon ?? familiar.emoji,
+      familiarId: familiar.id,
+      memoryCount: totalCovenByFamiliar.get(familiar.id) ?? 0,
+      latestAt,
+    });
+    addCappedLeaves({
+      hubId,
+      familiarId: familiar.id,
+      source: "coven",
+      entries,
+      maxLeavesPerHub,
+      nodes,
+      edges,
+      toMemoryNode: (entry) => {
+        const coven = entry as MemoryGraphCovenEntry;
+        return {
+          kind: "memory",
+          id: memoryIdForCoven(coven),
+          source: "coven",
+          hubId,
+          familiarId: coven.familiar_id,
+          title: coven.title,
+          path: coven.path,
+          updatedAt: coven.updated_at,
+          excerpt: coven.excerpt,
+        };
+      },
+    });
+    hiddenEntries += Math.max(entries.length - maxLeavesPerHub, 0);
+  }
+
+  if (matchingFiles.length > 0 || fileEntries.length > 0) {
+    nodes.push({
+      kind: "hub",
+      hubKind: "files",
+      id: FILE_HUB_ID,
+      label: "Memory Files",
+      glyph: "ph:file-text",
+      memoryCount: matchingFiles.length,
+      latestAt: matchingFiles[0]?.modified,
+    });
+    addCappedLeaves({
+      hubId: FILE_HUB_ID,
+      source: "file",
+      entries: matchingFiles,
+      maxLeavesPerHub,
+      nodes,
+      edges,
+      toMemoryNode: (entry) => {
+        const file = entry as MemoryGraphFileEntry;
+        return {
+          kind: "memory",
+          id: memoryIdForFile(file),
+          source: "file",
+          hubId: FILE_HUB_ID,
+          title: compactFileTitle(file),
+          path: file.fullPath,
+          updatedAt: file.modified,
+          rootLabel: file.rootLabel,
+          relPath: file.relPath,
+        };
+      },
+    });
+    hiddenEntries += Math.max(matchingFiles.length - maxLeavesPerHub, 0);
+  }
+
+  return {
+    nodes,
+    edges,
+    metrics: {
+      familiarHubs: familiars.length,
+      fileHubs: fileEntries.length > 0 ? 1 : 0,
+      visibleCovenEntries: matchingCovenEntries.length,
+      visibleFileEntries: matchingFiles.length,
+      hiddenEntries,
+    },
+  };
+}
+
+export function memorySelectionObjectKey(selection: MemoryGraphSelection): string | null {
+  if (!selection) return null;
+  if (selection.kind === "familiar") return `hub:familiar:${selection.id}`;
+  if (selection.kind === "files") return `hub:${FILE_HUB_ID}`;
+  if (selection.kind === "memory") return `memory:${selection.id}`;
+  return `cluster:${selection.id}`;
+}
+
+function hubSortKey(node: MemoryGraphHubNode): string {
+  return node.hubKind === "files" ? "zzzz" : node.label.toLowerCase();
+}
+
+function fibonacciHemispherePosition({
+  center,
+  index,
+  count,
+  radius,
+  phase,
+  orbitScale = 1,
+}: {
+  center: ScenePosition;
+  index: number;
+  count: number;
+  radius: number;
+  phase: number;
+  orbitScale?: number;
+}): ScenePosition {
+  const goldenAngle = Math.PI * (3 - Math.sqrt(5));
+  const normalized = count <= 1 ? 0.5 : (index + 0.5) / count;
+  const y = 1 - normalized * 0.92;
+  const horizontal = Math.sqrt(Math.max(0, 1 - y * y));
+  const theta = goldenAngle * index + phase;
+  const scaledRadius = radius * orbitScale;
+  return pos(
+    positionAdd(center.x, Math.cos(theta) * horizontal * scaledRadius),
+    positionAdd(center.y, y * scaledRadius - 0.28),
+    positionAdd(center.z, Math.sin(theta) * horizontal * scaledRadius),
+  );
+}
+
+export function buildMemoryGraphSceneModel(graph: MemoryGraph): MemoryGraphSceneModel {
+  const hubs = graph.nodes
+    .filter((node): node is MemoryGraphHubNode => node.kind === "hub")
+    .sort((a, b) => hubSortKey(a).localeCompare(hubSortKey(b)));
+  const hubCount = Math.max(hubs.length, 1);
+  const ringRadius = hubCount <= 2 ? 3.5 : Math.max(4.2, Math.min(8.2, 3.2 + hubCount * 0.52));
+  const hubPositions = new Map<string, ScenePosition>();
+
+  hubs.forEach((hub, index) => {
+    const angle = hubCount === 1 ? -Math.PI / 2 : (index / hubCount) * Math.PI * 2 - Math.PI / 2;
+    const filesLift = hub.hubKind === "files" ? -0.8 : 0;
+    hubPositions.set(
+      hub.id,
+      pos(Math.cos(angle) * ringRadius, filesLift + Math.sin(index * 1.2) * 0.24, Math.sin(angle) * ringRadius),
+    );
+  });
+
+  const childrenByHub = new Map<string, MemoryGraphChildNode[]>();
+  for (const node of graph.nodes) {
+    if (node.kind === "hub") continue;
+    const bucket = childrenByHub.get(node.hubId) ?? [];
+    bucket.push(node);
+    childrenByHub.set(node.hubId, bucket);
+  }
+
+  const sceneNodes: MemoryGraphSceneNode[] = [];
+  for (const hub of hubs) {
+    const hubPosition = hubPositions.get(hub.id) ?? pos(0, 0, 0);
+    sceneNodes.push({
+      ...hub,
+      label: hub.label,
+      position: hubPosition,
+      radius: hub.hubKind === "files" ? 0.48 : 0.56 + Math.min(hub.memoryCount, 24) * 0.01,
+      color: hub.hubKind === "files" ? "#38bdf8" : "#8E3DFF",
+      memoryCount: hub.memoryCount,
+    });
+
+    const children = childrenByHub.get(hub.id) ?? [];
+    const shellRadius = hub.hubKind === "files" ? 1.65 : 1.35 + Math.min(children.length, 18) * 0.025;
+    children.forEach((child, index) => {
+      const orbitScale = child.kind === "cluster" ? 1.16 : 1;
+      const position = fibonacciHemispherePosition({
+        center: hubPosition,
+        index,
+        count: Math.max(children.length, 1),
+        radius: shellRadius,
+        phase: hub.id.length * 0.17,
+        orbitScale,
+      });
+      sceneNodes.push({
+        ...child,
+        label: child.kind === "memory" ? child.title : child.label,
+        position,
+        radius: child.kind === "memory" && child.source === "file" ? 0.18 : child.kind === "memory" ? 0.2 : 0.32,
+        color: child.kind === "memory" && child.source === "file" ? "#38bdf8" : child.kind === "memory" ? "#62d08f" : "#f59e0b",
+        memoryCount: child.kind === "cluster" ? child.count : 1,
+      });
+    });
+  }
+
+  const nodeById = new Map(sceneNodes.map((node) => [node.id, node]));
+  const sceneEdges = graph.edges.flatMap((edge): MemoryGraphSceneEdge[] => {
+    const source = nodeById.get(edge.source);
+    const target = nodeById.get(edge.target);
+    if (!source || !target) return [];
+    return [{
+      ...edge,
+      from: source.position,
+      to: target.position,
+      color: source.kind === "memory" && source.source === "file" ? "#38bdf8" : source.kind === "memory" ? "#62d08f" : "#f59e0b",
+      opacity: source.kind === "cluster" ? 0.42 : 0.28,
+    }];
+  });
+
+  return { nodes: sceneNodes, edges: sceneEdges };
+}
+
+function positionAdd(base: number, offset: number): number {
+  return Math.round((base + offset) * 1000) / 1000;
+}

--- a/src/lib/onboarding-familiars.test.ts
+++ b/src/lib/onboarding-familiars.test.ts
@@ -77,3 +77,14 @@ assert.deepEqual(hermesDraft, {
 });
 
 assert.match(buildFamiliarsToml(hermesDraft), /harness = "hermes"/);
+
+
+assert.throws(
+  () =>
+    normalizeFamiliarDraft({
+      displayName: "Evil",
+      harness: "attacker-adapter",
+      model: "evil-local",
+    }),
+  /Unsupported harness: attacker-adapter\./,
+);

--- a/src/lib/onboarding-familiars.ts
+++ b/src/lib/onboarding-familiars.ts
@@ -1,3 +1,4 @@
+import { isTrustedOnboardingHarness } from "./harness-adapters.ts";
 export type OnboardingFamiliarDraft = {
   id: string;
   displayName: string;
@@ -45,6 +46,9 @@ export function normalizeFamiliarDraft(input: OnboardingFamiliarInput): Onboardi
 
   const openclawAgentId = slugify(cleanText(input.openclawAgentId));
   const harness = cleanText(input.harness) || (openclawAgentId ? "openclaw" : "codex");
+  if (!isTrustedOnboardingHarness(harness)) {
+    throw new Error(`Unsupported harness: ${harness}.`);
+  }
   const model = cleanText(input.model) || openclawAgentId || id;
 
   return {

--- a/src/lib/vault.test.ts
+++ b/src/lib/vault.test.ts
@@ -1,0 +1,11 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { validateOpRef } from "./vault.ts";
+
+assert.equal(validateOpRef("op://Personal/GitHub/token"), null);
+assert.equal(validateOpRef(42), "ref must be a string");
+assert.equal(validateOpRef(null), "ref must be a string");
+assert.equal(validateOpRef({ ref: "op://Personal/GitHub/token" }), "ref must be a string");
+assert.equal(validateOpRef("https://example.test"), "ref must start with op://");
+assert.equal(validateOpRef("op://Personal/GitHub"), "ref must include vault, item, and field segments");
+assert.equal(validateOpRef("op://Personal/GitHub/token;rm -rf"), "ref contains invalid characters");

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -13,7 +13,7 @@
  * any file — it lives only in process memory.
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
@@ -91,10 +91,31 @@ export function saveVaultMap(map: VaultMap): void {
 
 // ── op resolver ───────────────────────────────────────────────────────────────
 
+const OP_REF_PREFIX = "op://";
+const OP_REF_MAX_LENGTH = 2048;
+const OP_REF_FORBIDDEN_CHARS = /[\0\r\n`"$\\<>|;&]/;
+
+export function validateOpRef(ref: unknown): string | null {
+  if (typeof ref !== "string") return "ref must be a string";
+  if (!ref.startsWith(OP_REF_PREFIX)) return "ref must start with op://";
+  if (ref.length > OP_REF_MAX_LENGTH) return "ref is too long";
+  if (OP_REF_FORBIDDEN_CHARS.test(ref)) return "ref contains invalid characters";
+
+  const path = ref.slice(OP_REF_PREFIX.length);
+  const segments = path.split("/");
+  if (segments.length < 3 || segments.some((segment) => !segment.trim())) {
+    return "ref must include vault, item, and field segments";
+  }
+
+  return null;
+}
+
 /** Call `op read` to fetch a secret reference. Returns null on failure. */
 function opRead(ref: string): string | null {
+  if (validateOpRef(ref)) return null;
+
   try {
-    const value = execSync(`op read "${ref}"`, {
+    const value = execFileSync("op", ["read", ref], {
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 8000,


### PR DESCRIPTION
### Motivation
- Close a critical XSS vector where rendered markdown HTML from `@create-markdown/preview` was inserted into the DOM via `dangerouslySetInnerHTML` without adequate sanitization. 
- Prevent attacker-controlled assistant/daemon content from reaching privileged local APIs (Tauri IPC / `pty_start`) by removing executable elements and unsafe URL schemes before insertion. 

### Description
- Added a small DOM-based sanitizer in `src/components/message-bubble.tsx` (`isSafeUrl`, `sanitizeHtml`, and related constants) that removes dangerous elements, strips `on*` event attributes, and removes URL attributes with unsafe schemes. 
- Integrated sanitization into the central rendering pipeline by calling `sanitizeHtml` in `mdToHtml` before writing to `renderCache` and returning HTML. 
- Updated `MarkdownBlock` and `MessageBubble` to consume the sanitized `mdToHtml` output (removed the previous narrower inline sanitizer and replaced the “trusted daemon” comment with an explicit note about sanitization). 
- The change is minimal and keeps the existing rendering architecture and Shiki code-paths intact while adding the sanitizer step to the output sink.

### Testing
- Ran `pnpm typecheck`, which completed successfully. 
- Ran `pnpm build`, which failed in this environment due to Next/Turbopack being unable to fetch Google Fonts (network/font fetch failures), and not because of the sanitizer changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24d326c4c08327a7f4a59f190dd65d)