### PR TITLE
fix: prevent GITHUB_PAT from leaking into coven child env

### DIFF
--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -30,6 +30,8 @@ import path from "node:path";
 let cachedBin: string | null = null;
 let cachedPath: string | null = null;
 
+const FORBIDDEN_SPAWN_ENV_KEYS = ["GITHUB_PAT"] as const;
+
 const HOME = os.homedir();
 
 function nodeNvmBinDirs(): string[] {
@@ -152,5 +154,9 @@ export function covenSpawnEnv(): NodeJS.ProcessEnv {
     }
     cachedPath = dedup.join(":");
   }
-  return { ...process.env, PATH: cachedPath };
+  const env: NodeJS.ProcessEnv = { ...process.env, PATH: cachedPath };
+  for (const key of FORBIDDEN_SPAWN_ENV_KEYS) {
+    delete env[key];
+  }
+  return env;
 }


### PR DESCRIPTION
### Motivation
- Prevent a user-supplied GitHub PAT stored by `/api/github/pat` from being inherited by spawned coven/agent child processes, which could allow untrusted agent harnesses to exfiltrate the token.

### Description
- Add a small deny-list `FORBIDDEN_SPAWN_ENV_KEYS` containing `"GITHUB_PAT"` in `src/lib/coven-bin.ts` and filter those keys out of the object returned by `covenSpawnEnv()` before spawning children.
- Preserve the existing PATH augmentation and all other environment inheritance behavior.

### Testing
- Ran type checking with `pnpm typecheck`, which succeeded.
- Ran `git diff --check`, which produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24bc66d64c8327a1b5ce9708e9dafb)