### PR TITLE
fix(desktop): harden PTY capability exposure

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "enables the default permissions",
-  "local": true,
+  "local": false,
   "windows": [
     "main"
   ],

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -8,6 +8,7 @@ const commandPermissions = readFileSync(new URL("./pty.toml", import.meta.url), 
 const browserRust = readFileSync(new URL("../src/browser.rs", import.meta.url), "utf8");
 const browserPane = readFileSync(new URL("../../src/components/browser-pane.tsx", import.meta.url), "utf8");
 const bottomTerminal = readFileSync(new URL("../../src/components/bottom-terminal.tsx", import.meta.url), "utf8");
+const ptyRust = readFileSync(new URL("../src/pty.rs", import.meta.url), "utf8");
 
 const requiredPermissionIds = [
   "allow-pty-start",
@@ -46,8 +47,8 @@ function capabilityAllowsOrigin(origin) {
   return patterns.some((pattern) => new URLPattern(pattern).test(origin));
 }
 
-test("packaged desktop app can use native browser and terminal commands", () => {
-  assert.equal(capability.local, true, "packaged local app origin must receive the default capability");
+test("local app origins do not receive terminal permissions", () => {
+  assert.equal(capability.local, false, "packaged local app origins must not receive PTY command permissions");
   assert.ok(capability.permissions.includes("default"), "default capability should include custom app permissions");
 
   for (const permissionId of requiredPermissionIds) {
@@ -83,6 +84,19 @@ test("browser event labels use the same native prefix in Rust and React", () => 
   assert.match(browserPane, /return `\$\{NATIVE_BROWSER_LABEL_PREFIX\}\$\{label\}-tab-`;/);
   assert.equal(browserPane.match(/startsWith\(eventPrefix\)/g)?.length, 2);
   assert.equal(browserPane.match(/slice\(eventPrefix\.length\)/g)?.length, 2);
+});
+
+test("pty_start only accepts terminal session metadata", () => {
+  assert.match(
+    ptyRust,
+    /#\[serde\(deny_unknown_fields\)\]\s*pub struct StartOptions \{[\s\S]*?pub thread_id: String,[\s\S]*?pub project_root: Option<String>,[\s\S]*?pub cols: Option<u16>,[\s\S]*?pub rows: Option<u16>,[\s\S]*?\}/,
+    "StartOptions should reject unknown caller-supplied fields",
+  );
+  assert.doesNotMatch(ptyRust, /pub command:/, "pty_start must not accept caller-supplied executables");
+  assert.doesNotMatch(ptyRust, /pub args:/, "pty_start must not accept caller-supplied arguments");
+  assert.doesNotMatch(ptyRust, /pub env:/, "pty_start must not accept caller-supplied environment overrides");
+  assert.match(ptyRust, /let command = default_shell\(\);/, "pty_start should always use the platform default shell");
+  assert.match(ptyRust, /let args = default_shell_args\(\);/, "pty_start should always use platform default shell args");
 });
 
 test("terminal commands use Tauri camelCase command arguments", () => {

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -66,14 +66,12 @@ impl Drop for PendingPtyStart {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct StartOptions {
     pub thread_id: String,
     pub project_root: Option<String>,
-    pub command: Option<String>,
-    pub args: Option<Vec<String>>,
     pub cols: Option<u16>,
     pub rows: Option<u16>,
-    pub env: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -105,8 +103,8 @@ pub fn pty_start(app: AppHandle, options: StartOptions) -> Result<(), String> {
         })
         .map_err(|e| e.to_string())?;
 
-    let command = options.command.unwrap_or_else(default_shell);
-    let args = options.args.unwrap_or_else(default_shell_args);
+    let command = default_shell();
+    let args = default_shell_args();
     info!("pty_start[{}]: spawning {} {:?}", thread_id, command, args);
     let mut cmd = CommandBuilder::new(&command);
     cmd.args(&args);
@@ -133,15 +131,6 @@ pub fn pty_start(app: AppHandle, options: StartOptions) -> Result<(), String> {
         }
         if std::env::var("LC_ALL").is_err() {
             cmd.env("LC_ALL", "en_US.UTF-8");
-        }
-    }
-    if let Some(extra) = options.env {
-        for (k, v) in extra {
-            if v.is_empty() {
-                cmd.env_remove(&k);
-            } else {
-                cmd.env(k, v);
-            }
         }
     }
     // Drop nesting-tripwires inherited from the Tauri parent.


### PR DESCRIPTION
### Motivation
- Prevent packaged local renderer origins from inheriting broad native PTY/browser command permissions which enable arbitrary OS command execution from a compromised renderer.
- Reduce the attack surface of `pty_start` by removing caller-controlled executable/args/env so only session metadata is accepted.

### Description
- Set `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24bd5bf2888327a60ee736ec42e39b)