### PR TITLE
fix(security): gate coven harness execution

### DIFF
--- a/src/app/api/board/enrich-steps/route.ts
+++ b/src/app/api/board/enrich-steps/route.ts
@@ -3,6 +3,7 @@ import type { CardStep } from "@/lib/cave-board-types";
 import { bindingFor, loadConfig } from "@/lib/cave-config";
 import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
 import { familiarWorkspace } from "@/lib/coven-paths";
+import { isTrustedChatHarness } from "@/lib/harness-adapters";
 import { spawn } from "node:child_process";
 import { stat } from "node:fs/promises";
 import { stripAnsi } from "@/lib/ansi";
@@ -201,9 +202,10 @@ export async function POST(req: Request) {
         const familiarId = card.familiarId!;
         const binding = bindingFor(config, familiarId);
 
-        // Local Coven harnesses can run headlessly through `coven run
-        // <harness> --stream-json`, including external adapter manifests.
-        if (binding.harness === "openclaw") {
+        // Only bundled, reviewed Coven harnesses may run headlessly through
+        // `coven run <harness> --stream-json`. OpenClaw and external adapter
+        // manifests use their own bridges instead of this privileged runner.
+        if (!isTrustedChatHarness(binding.harness)) {
           push({
             kind: "skip",
             cardId: card.id,

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -13,24 +13,18 @@ const boardRoute = await readFile(
 
 assert.match(
   chatRoute,
-  /coven run <harness> --stream-json/,
-  "Native chat should describe the generic Coven harness route instead of a fixed allow-list",
-);
-
-assert.doesNotMatch(
-  chatRoute,
-  /COVEN_RUN_HARNESSES|new Set\(\["codex", "claude"\]\)|new Set\(\["codex", "claude", "hermes"\]\)/,
-  "Native chat should not hard-code a local harness allow-list",
+  /isTrustedChatHarness\(binding\.harness\)/,
+  "Native chat should enforce the trusted Coven harness gate before spawning coven run",
 );
 
 assert.doesNotMatch(
   chatRoute,
   /binding\.harness === "openclaw"/,
-  "Native chat should not special-case OpenClaw outside the generic harness route",
+  "Native chat should not rely on an OpenClaw-only rejection",
 );
 
 assert.match(
   boardRoute,
-  /binding\.harness === "openclaw"/,
-  "Board step enrichment should skip OpenClaw bridge familiars while allowing local Coven harnesses",
+  /isTrustedChatHarness\(binding\.harness\)/,
+  "Board step enrichment should enforce the same trusted Coven harness gate",
 );

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -15,6 +15,7 @@ import {
 import { AssistantFilter } from "@/lib/chat-assistant-filter";
 import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
 import { familiarWorkspace } from "@/lib/coven-paths";
+import { isTrustedChatHarness } from "@/lib/harness-adapters";
 import {
   type ChatTurn,
   loadConversation,
@@ -188,8 +189,19 @@ export async function POST(req: Request) {
     ? await resolveFamiliarWorkspace(body.familiarId)
     : undefined;
 
-  // Native Cave chat can drive any Coven harness that resolves through
-  // `coven run <harness> --stream-json`, including external adapter manifests.
+  // Native Cave chat only drives bundled, reviewed Coven harnesses through
+  // `coven run <harness> --stream-json`. OpenClaw and external adapter
+  // manifests use their own bridges instead of this privileged local runner.
+  if (!isTrustedChatHarness(binding.harness)) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error:
+          "This familiar's harness is not supported by native Cave chat. Pick Codex, Claude Code, or Hermes here, or open the familiar from its own runtime.",
+      }),
+      { status: 501, headers: { "content-type": "application/json" } },
+    );
+  }
 
   // Build coven run argv.
   // Important: pass every flag BEFORE the prompt and add a `--` separator,

--- a/src/app/api/onboarding/setup/route.ts
+++ b/src/app/api/onboarding/setup/route.ts
@@ -10,7 +10,10 @@ import {
   type OnboardingFamiliarDraft,
   type OnboardingFamiliarInput,
 } from "@/lib/onboarding-familiars";
-import { adapterManifestScaffoldForHarness } from "@/lib/harness-adapters";
+import {
+  adapterManifestScaffoldForHarness,
+  isTrustedOnboardingHarness,
+} from "@/lib/harness-adapters";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -51,6 +54,12 @@ export async function POST(req: Request) {
     );
   }
   const harness = (draft?.harness ?? body.harness ?? "codex").trim() || "codex";
+  if (!isTrustedOnboardingHarness(harness)) {
+    return NextResponse.json(
+      { ok: false, error: `Unsupported harness: ${harness}.` },
+      { status: 400 },
+    );
+  }
   const model =
     (draft?.model ?? body.model ?? "codex-local").trim() || "codex-local";
 

--- a/src/lib/harness-adapters.test.ts
+++ b/src/lib/harness-adapters.test.ts
@@ -7,6 +7,8 @@ import {
   runtimeSourceSetupState,
   adapterManifestScaffoldForHarness,
   covenHelpSupportsAdapterList,
+  isTrustedChatHarness,
+  isTrustedOnboardingHarness,
   openClawAdapterReport,
 } from "./harness-adapters.ts";
 
@@ -93,6 +95,29 @@ assert.equal(
   merged.find((adapter) => adapter.id === "hermes")?.chatSupported,
   true,
 );
+
+const mergedExternal = mergeAdapterReports(
+  [],
+  [
+    {
+      id: "attacker-adapter",
+      label: "Attacker Adapter",
+      executable: "attacker",
+      available: true,
+      install_hint: "Do not run this in native chat.",
+      source: "manifest",
+      manifest_path: "/tmp/attacker.json",
+    },
+  ],
+);
+assert.equal(mergedExternal[0]?.chatSupported, false);
+assert.equal(mergedExternal[0]?.installed, true);
+assert.equal(isTrustedChatHarness("codex"), true);
+assert.equal(isTrustedChatHarness("hermes"), true);
+assert.equal(isTrustedChatHarness("openclaw"), false);
+assert.equal(isTrustedChatHarness("attacker-adapter"), false);
+assert.equal(isTrustedOnboardingHarness("openclaw"), true);
+assert.equal(isTrustedOnboardingHarness("attacker-adapter"), false);
 
 assert.deepEqual(adapterSetupState(merged), {
   ok: true,

--- a/src/lib/harness-adapters.ts
+++ b/src/lib/harness-adapters.ts
@@ -87,6 +87,24 @@ export const COMPATIBILITY_ADAPTERS: CompatibilityAdapter[] = [
   },
 ];
 
+const TRUSTED_ONBOARDING_HARNESSES = new Set(
+  COMPATIBILITY_ADAPTERS.map((adapter) => adapter.id),
+);
+
+const TRUSTED_CHAT_HARNESSES = new Set(
+  COMPATIBILITY_ADAPTERS.filter((adapter) => adapter.chatSupported).map(
+    (adapter) => adapter.id,
+  ),
+);
+
+export function isTrustedOnboardingHarness(harness: string): boolean {
+  return TRUSTED_ONBOARDING_HARNESSES.has(harness);
+}
+
+export function isTrustedChatHarness(harness: string): boolean {
+  return TRUSTED_CHAT_HARNESSES.has(harness);
+}
+
 export function openClawAdapterReport(openclawAgentCount: number): AdapterReport {
   return {
     id: "openclaw",
@@ -144,7 +162,7 @@ export function mergeAdapterReports(
       id: coven.id,
       label: coven.label,
       binary: coven.executable,
-      chatSupported: true,
+      chatSupported: existing?.chatSupported ?? isTrustedChatHarness(coven.id),
       installed: coven.available || existing?.installed === true,
       path: existing?.path ?? null,
       version: existing?.version ?? null,

--- a/src/lib/onboarding-familiars.test.ts
+++ b/src/lib/onboarding-familiars.test.ts
@@ -77,3 +77,14 @@ assert.deepEqual(hermesDraft, {
 });
 
 assert.match(buildFamiliarsToml(hermesDraft), /harness = "hermes"/);
+
+
+assert.throws(
+  () =>
+    normalizeFamiliarDraft({
+      displayName: "Evil",
+      harness: "attacker-adapter",
+      model: "evil-local",
+    }),
+  /Unsupported harness: attacker-adapter\./,
+);

--- a/src/lib/onboarding-familiars.ts
+++ b/src/lib/onboarding-familiars.ts
@@ -1,3 +1,4 @@
+import { isTrustedOnboardingHarness } from "./harness-adapters.ts";
 export type OnboardingFamiliarDraft = {
   id: string;
   displayName: string;
@@ -45,6 +46,9 @@ export function normalizeFamiliarDraft(input: OnboardingFamiliarInput): Onboardi
 
   const openclawAgentId = slugify(cleanText(input.openclawAgentId));
   const harness = cleanText(input.harness) || (openclawAgentId ? "openclaw" : "codex");
+  if (!isTrustedOnboardingHarness(harness)) {
+    throw new Error(`Unsupported harness: ${harness}.`);
+  }
   const model = cleanText(input.model) || openclawAgentId || id;
 
   return {


### PR DESCRIPTION
### Motivation
- Close an allowlist bypass where onboarding could persist arbitrary `harness` values and chat/board paths would spawn `coven run <harness>` for untrusted adapters, enabling local command execution of attacker-controlled adapters.
- Restore a principled, minimal trust boundary so only reviewed/local harnesses are runnable by native chat/board flows while still surfacing external adapters in UI/reporting.

### Description
- Add trusted-harness helpers and sets in `src/lib/harness-adapters.ts` (`TRUSTED_ONBOARDING_HARNESSES`, `TRUSTED_CHAT_HARNESSES`, `isTrustedOnboardingHarness`, `isTrustedChatHarness`) and stop auto-marking every `coven adapter list` entry as chat-capable. `mergeAdapterReports` now uses existing metadata or the trusted gate for `chatSupported` instead of unconditionally `true` for remote manifests.
- Enforce onboarding-time validation by calling `isTrustedOnboardingHarness` from `src/lib/onboarding-familiars.ts` to reject unsupported `harness` values during draft normalization.
- Validate `harness` in the setup API (`src/app/api/onboarding/setup/route.ts`) and return `400` on unsupported harness values before persisting `cave-config.json` defaults.
- Gate execution sinks: `src/app/api/chat/send/route.ts` now returns `501` for non-trusted chat harnesses, and `src/app/api/board/enrich-steps/route.ts` skips non-trusted harnesses instead of invoking `coven run`.
- Update targeted unit tests to assert the new behavior: `src/lib/harness-adapters.test.ts` verifies external manifests are not `chatSupported` by default and checks the new trusted helpers, `src/lib/onboarding-familiars.test.ts` asserts onboarding rejects unknown harnesses, and `src/app/api/chat/send/harness-routing.test.ts` checks the routes enforce the trusted gate.

### Testing
- Ran type checking with `pnpm typecheck` which completed successfully.
- Executed targeted tests with `node --experimental-strip-types src/lib/harness-adapters.test.ts && node --experimental-strip-types src/lib/onboarding-familiars.test.ts && node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts`, and they all passed.
- Verified the repository builds cleanly under the project `tsc --noEmit` configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24fa393e1c832780a88b9914b8ff0c)