### PR TITLE
Protect mobile Tailscale access with app token

### DIFF
--- a/scripts/mobile-tailscale.sh
+++ b/scripts/mobile-tailscale.sh
@@ -6,6 +6,7 @@ cd "$(dirname "$0")/.."
 PORT="${PORT:-3000}"
 HOST="${HOST:-127.0.0.1}"
 TAILSCALE_TIMEOUT_MS="${TAILSCALE_TIMEOUT_MS:-8000}"
+COVEN_MOBILE_ACCESS_TOKEN="${COVEN_MOBILE_ACCESS_TOKEN:-}"
 
 need() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -45,28 +46,35 @@ need pnpm
 need node
 need tailscale
 
+if [ -z "$COVEN_MOBILE_ACCESS_TOKEN" ]; then
+  COVEN_MOBILE_ACCESS_TOKEN="$(node -e 'console.log(require("crypto").randomBytes(24).toString("base64url"))')"
+fi
+export COVEN_MOBILE_ACCESS_TOKEN
+
 if ! tailscale_cmd status --self >/dev/null 2>&1; then
   echo "tailscale is not connected or did not respond. Run: tailscale up" >&2
   exit 1
 fi
 
 if port_is_listening >/dev/null 2>&1; then
-  echo "Next server already listening on ${HOST}:${PORT}"
-else
-  echo "Starting Next server on ${HOST}:${PORT}"
-  pnpm dev -- -H "$HOST" -p "$PORT" >"/tmp/coven-cave-mobile-${PORT}.log" 2>&1 &
-  NEXT_PID="$!"
-  for _ in $(seq 1 40); do
-    if port_is_listening >/dev/null 2>&1; then
-      break
-    fi
-    sleep 0.25
-  done
-  if ! port_is_listening >/dev/null 2>&1; then
-    echo "Next server did not start. See /tmp/coven-cave-mobile-${PORT}.log" >&2
-    kill "$NEXT_PID" >/dev/null 2>&1 || true
-    exit 1
+  echo "Refusing to expose an already-running server on ${HOST}:${PORT}." >&2
+  echo "Stop that server or choose a different PORT so the mobile launcher can start one with a mobile access token." >&2
+  exit 1
+fi
+
+echo "Starting token-protected Next server on ${HOST}:${PORT}"
+pnpm exec next dev -H "$HOST" -p "$PORT" >"/tmp/coven-cave-mobile-${PORT}.log" 2>&1 &
+NEXT_PID="$!"
+for _ in $(seq 1 40); do
+  if port_is_listening >/dev/null 2>&1; then
+    break
   fi
+  sleep 0.25
+done
+if ! port_is_listening >/dev/null 2>&1; then
+  echo "Next server did not start. See /tmp/coven-cave-mobile-${PORT}.log" >&2
+  kill "$NEXT_PID" >/dev/null 2>&1 || true
+  exit 1
 fi
 
 tailscale_cmd serve --bg "$PORT"
@@ -75,5 +83,7 @@ echo
 echo "CovenCave mobile is available inside your tailnet."
 echo "Run this to see the exact URL:"
 echo "  tailscale serve status"
+echo "Then open that URL with this access query:"
+echo "  ?coven_mobile_token=${COVEN_MOBILE_ACCESS_TOKEN}"
 echo
 tailscale_cmd serve status || true

--- a/src/lib/mobile-access-token.test.ts
+++ b/src/lib/mobile-access-token.test.ts
@@ -1,0 +1,22 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  bearerToken,
+  MOBILE_ACCESS_TOKEN_ENV,
+  mobileAccessToken,
+  tokensMatch,
+} from "./mobile-access-token.ts";
+
+process.env[MOBILE_ACCESS_TOKEN_ENV] = "  secret-token  ";
+assert.equal(mobileAccessToken(), "secret-token");
+
+assert.equal(tokensMatch("secret-token", "secret-token"), true);
+assert.equal(tokensMatch("secret-token", "wrong-token"), false);
+assert.equal(tokensMatch("secret-token", "secret-token-extra"), false);
+assert.equal(tokensMatch("", ""), false);
+assert.equal(tokensMatch("secret-token", null), false);
+
+assert.equal(bearerToken("Bearer secret-token"), "secret-token");
+assert.equal(bearerToken("bearer secret-token"), "secret-token");
+assert.equal(bearerToken("Basic secret-token"), null);
+assert.equal(bearerToken(null), null);

--- a/src/lib/mobile-access-token.ts
+++ b/src/lib/mobile-access-token.ts
@@ -1,0 +1,24 @@
+export const MOBILE_ACCESS_TOKEN_ENV = "COVEN_MOBILE_ACCESS_TOKEN";
+export const MOBILE_ACCESS_TOKEN_QUERY = "coven_mobile_token";
+export const MOBILE_ACCESS_TOKEN_COOKIE = "coven_mobile_token";
+export const MOBILE_ACCESS_TOKEN_HEADER = "x-coven-mobile-token";
+
+export function mobileAccessToken(): string {
+  return process.env.COVEN_MOBILE_ACCESS_TOKEN?.trim() ?? "";
+}
+
+export function tokensMatch(expected: string, actual: string | null | undefined): boolean {
+  if (!expected || !actual || expected.length !== actual.length) return false;
+
+  let diff = 0;
+  for (let i = 0; i < expected.length; i += 1) {
+    diff |= expected.charCodeAt(i) ^ actual.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+export function bearerToken(authorization: string | null): string | null {
+  if (!authorization) return null;
+  const match = authorization.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || null;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  bearerToken,
+  MOBILE_ACCESS_TOKEN_COOKIE,
+  MOBILE_ACCESS_TOKEN_HEADER,
+  MOBILE_ACCESS_TOKEN_QUERY,
+  mobileAccessToken,
+  tokensMatch,
+} from "@/lib/mobile-access-token";
+
+function isAuthorized(req: NextRequest, expected: string): boolean {
+  return (
+    tokensMatch(expected, req.nextUrl.searchParams.get(MOBILE_ACCESS_TOKEN_QUERY)) ||
+    tokensMatch(expected, req.headers.get(MOBILE_ACCESS_TOKEN_HEADER)) ||
+    tokensMatch(expected, bearerToken(req.headers.get("authorization"))) ||
+    tokensMatch(expected, req.cookies.get(MOBILE_ACCESS_TOKEN_COOKIE)?.value)
+  );
+}
+
+function unauthorized(req: NextRequest): NextResponse {
+  if (req.nextUrl.pathname.startsWith("/api/")) {
+    return NextResponse.json({ ok: false, error: "mobile access token required" }, { status: 401 });
+  }
+  return new NextResponse("mobile access token required", {
+    status: 401,
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+}
+
+export function proxy(req: NextRequest) {
+  const expected = mobileAccessToken();
+  if (!expected) return NextResponse.next();
+  if (!isAuthorized(req, expected)) return unauthorized(req);
+
+  const queryToken = req.nextUrl.searchParams.get(MOBILE_ACCESS_TOKEN_QUERY);
+  if (queryToken && req.method === "GET" && !req.nextUrl.pathname.startsWith("/api/")) {
+    const cleanUrl = req.nextUrl.clone();
+    cleanUrl.searchParams.delete(MOBILE_ACCESS_TOKEN_QUERY);
+    const res = NextResponse.redirect(cleanUrl);
+    res.cookies.set(MOBILE_ACCESS_TOKEN_COOKIE, expected, {
+      httpOnly: true,
+      sameSite: "strict",
+      secure: req.nextUrl.protocol === "https:",
+      path: "/",
+    });
+    return res;
+  }
+
+  const res = NextResponse.next();
+  if (queryToken || req.headers.get(MOBILE_ACCESS_TOKEN_HEADER) || req.headers.get("authorization")) {
+    res.cookies.set(MOBILE_ACCESS_TOKEN_COOKIE, expected, {
+      httpOnly: true,
+      sameSite: "strict",
+      secure: req.nextUrl.protocol === "https:",
+      path: "/",
+    });
+  }
+  return res;
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};


### PR DESCRIPTION
### Motivation
- The `mobile:tailscale` helper exposed an unauthenticated localhost Next.js API surface over Tailscale, allowing remote tailnet clients to access privileged endpoints designed for loopback-only use.  

### Description
- Add `src/lib/mobile-access-token.ts` with token constants, environment lookup (`COVEN_MOBILE_ACCESS_TOKEN`), constant-time token comparison, and bearer parsing.  
- Add `src/proxy.ts` (Next Proxy) that enforces the mobile access token when `COVEN_MOBILE_ACCESS_TOKEN` is set and accepts the token via query (`?coven_mobile_token`), header (`x-coven-mobile-token`), Bearer auth, or cookie.  
- Update `scripts/mobile-tailscale.sh` to generate/export a one-time `COVEN_MOBILE_ACCESS_TOKEN` when not provided, refuse to publish an already-running (unprotected) server, start a token-protected dev server, and print the access query for the Tailscale URL.  
- Add a small unit script `src/lib/mobile-access-token.test.ts` to validate token helpers.  

### Testing
- Ran `pnpm typecheck` with no type errors.  
- Executed the token helper test via `node --experimental-strip-types src/lib/mobile-access-token.test.ts` which passed.  
- Launched a dev Next server with `PORT=43231 COVEN_MOBILE_ACCESS_TOKEN=test-token pnpm exec next dev -H 127.0.0.1 -p 43231` and verified `/api/memory` returned `401` without the token and `200` when called with `x-coven-mobile-token: test-token`.  
- Verified the modified launcher with a fake `tailscale` binary and an occupied port refuses to expose an already-running server and does not call `tailscale serve`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24fc04c4bc8327bf63da93402b497b)