### PR TITLE
Harden release tag metadata handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,8 +91,15 @@ jobs:
 
       - name: Set release metadata
         shell: bash
+        env:
+          RAW_RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          set -euo pipefail
+          TAG="$RAW_RELEASE_TAG"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid release tag. Expected format: vMAJOR.MINOR.PATCH[-PRERELEASE]"
+            exit 1
+          fi
           echo "RELEASE_TAG=$TAG" >> "$GITHUB_ENV"
           echo "RELEASE_VERSION=${TAG#v}" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
### Motivation
- Prevent command-injection from untrusted GitHub release tag or `workflow_dispatch` input that was previously interpolated into bash source in the `Set release metadata` step.
- Ensure release metadata exports cannot be used to persist attacker-controlled commands into later steps that handle sensitive Apple signing material.

### Description
- Stop embedding the tag expression directly in shell source by passing it into the step via an environment variable `RAW_RELEASE_TAG` instead of inline interpolation. 
- Add strict validation of `TAG` against the pattern `^vMAJOR.MINOR.PATCH(-PRERELEASE)?$` and fail the job if the tag does not match the expected format.
- Continue to export `RELEASE_TAG` and `RELEASE_VERSION` into `$GITHUB_ENV` after validation to preserve existing downstream behavior.

### Testing
- Ran `git diff --check` to ensure there are no whitespace/error issues and it passed. (success)
- Executed a bash metadata simulation that verified valid tags (`v1.2.3`, `v1.2.3-rc.1`) produce the expected `RELEASE_TAG`/`RELEASE_VERSION` and a crafted tag containing command-substitution is rejected and does not execute. (success)
- Ran a Python assertion to ensure the old vulnerable interpolation is removed and the hardened metadata handling block is present. (success)
- Tried `actionlint` against the workflow but `actionlint` is not installed in the environment, so that check was not run. (skipped)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24c69cb7b8832798bb5acea539ee27)