### PR TITLE
fix(ci): pin release rust toolchain action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
 
       - name: Rust cache
         uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0


### PR DESCRIPTION
### Motivation
- The release workflow runs a privileged job (`permissions: contents: write`) but referenced `dtolnay/rust-toolchain@stable`, a mutable ref that could allow a compromised action to tamper release artifacts.

### Description
- Replace `dtolnay/rust-toolchain@stable` with the immutable SHA `29eef336d9b2848a0b548edc03f92a220660cdb8` in `.github/workflows/release.yml`, matching the existing CI pin and preserving behavior.

### Testing
- Ran a Python verifier that ensures every `uses:` ref in `.github/workflows/release.yml` is a 40-character SHA (passed).
- Ran `git diff --check` to ensure no whitespace or diff issues (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24d7c0d7908327bbb8530f294e9cf5)