### PR TITLE
feat(memory): memory constellation — 3D hub ring, leaf shells, List/Graph toggle

### DIFF
--- a/src/app/dev/memory-graph-3d/page.tsx
+++ b/src/app/dev/memory-graph-3d/page.tsx
@@ -1,0 +1,9 @@
+import { notFound } from "next/navigation";
+import { MemoryGraph3DSmoke } from "@/components/memory-graph-3d-smoke";
+
+export const dynamic = "force-dynamic";
+
+export default function MemoryGraph3DDevPage() {
+  if (process.env.NODE_ENV === "production" && process.env.CAVE_TRACE_GRAPH_SMOKE !== "1") notFound();
+  return <MemoryGraph3DSmoke />;
+}

--- a/src/components/agents-memory-graph.test.ts
+++ b/src/components/agents-memory-graph.test.ts
@@ -1,0 +1,93 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const memoryViewSource = await readFile(new URL("./agents-memory-view.tsx", import.meta.url), "utf8");
+const graphSource = await readFile(new URL("./memory-graph-3d.tsx", import.meta.url), "utf8");
+const modelSource = await readFile(new URL("../lib/memory-graph-3d-model.ts", import.meta.url), "utf8");
+const smokeSource = await readFile(new URL("./memory-graph-3d-smoke.tsx", import.meta.url), "utf8");
+const devPageSource = await readFile(new URL("../app/dev/memory-graph-3d/page.tsx", import.meta.url), "utf8");
+
+assert.match(
+  memoryViewSource,
+  /import \{ MemoryGraph3D \} from "@\/components\/memory-graph-3d"/,
+  "AgentsMemoryView should render the dedicated memory graph component instead of reusing TraceGraph3D",
+);
+
+assert.match(
+  memoryViewSource,
+  /from "@\/lib\/memory-graph-3d-model"[\s\S]*buildMemoryGraphModel\(\{/,
+  "AgentsMemoryView should build the memory constellation from its existing memory API data",
+);
+
+assert.match(
+  memoryViewSource,
+  /viewMode, setViewMode.*"list"/,
+  "Memory tab should keep a List/Graph view toggle with List as the default retrieval surface",
+);
+
+assert.match(
+  memoryViewSource,
+  /onSelectFamiliar=\{\(familiarId\) => setFamiliarFilter\(familiarId\)\}/,
+  "Clicking a familiar hub should sync the existing familiar filter",
+);
+
+assert.match(
+  memoryViewSource,
+  /onOpenMemoryFile=\{onOpenMemoryFile\}/,
+  "Clicking a memory node should use the existing memory-file opening path",
+);
+
+assert.doesNotMatch(
+  memoryViewSource,
+  /fetch\("\/api\/memory-graph"/,
+  "The first implementation should not add a memory graph API route",
+);
+
+assert.match(
+  graphSource,
+  /import \* as THREE from "three"/,
+  "MemoryGraph3D should render a real Three.js scene",
+);
+
+assert.match(
+  graphSource,
+  /InstancedMesh/,
+  "MemoryGraph3D should use InstancedMesh for memory leaves",
+);
+
+assert.match(
+  graphSource,
+  /aria-label="3D memory constellation"/,
+  "MemoryGraph3D should expose an accessible canvas label",
+);
+
+assert.match(
+  graphSource,
+  /prefers-reduced-motion/,
+  "MemoryGraph3D should respect reduced motion preferences",
+);
+
+assert.match(
+  modelSource,
+  /hub:memory-files/,
+  "The model should preserve filesystem memory entries under a neutral Memory Files hub",
+);
+
+assert.doesNotMatch(
+  modelSource,
+  /DelegationGraph/,
+  "The memory graph model should not depend on the calls DelegationGraph domain model",
+);
+
+assert.match(
+  smokeSource,
+  /<MemoryGraph3D[\s\S]*graph=\{graph\}/,
+  "Memory graph should have a deterministic smoke fixture for canvas verification",
+);
+
+assert.match(
+  devPageSource,
+  /MemoryGraph3DSmoke/,
+  "Memory graph should expose a dev-only smoke route like the trace graph",
+);

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
 import type { Familiar } from "@/lib/types";
+import { MemoryGraph3D } from "@/components/memory-graph-3d";
+import { buildMemoryGraphModel } from "@/lib/memory-graph-3d-model";
 
 type CovenMemoryEntry = {
   id: string;
@@ -74,6 +76,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
   const [fileEntries, setFileEntries] = useState<FileMemoryEntry[]>([]);
   const [query, setQuery] = useState("");
   const [familiarFilter, setFamiliarFilter] = useState<string>("all");
+  const [viewMode, setViewMode] = useState<"list" | "graph">("list");
   const [error, setError] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
 
@@ -136,6 +139,19 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
     return familiars.filter((familiar) => ids.has(familiar.id));
   }, [covenEntries, familiars]);
 
+  const memoryGraph = useMemo(
+    () =>
+      buildMemoryGraphModel({
+        familiars,
+        covenEntries,
+        fileEntries,
+        query,
+        familiarFilter,
+        maxLeavesPerHub: familiarFilter === "all" ? 30 : 90,
+      }),
+    [covenEntries, familiarFilter, familiars, fileEntries, query],
+  );
+
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-[var(--bg-base)]">
       <div className="shrink-0 border-b border-[var(--border-hairline)] px-4 py-3">
@@ -149,10 +165,30 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
               Comprehensive Coven memory, familiar recall, and local memory files.
             </p>
           </div>
-          <button type="button" onClick={() => void load()} className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]">
-            <Icon name="ph:arrows-clockwise" width={12} />
-            Refresh
-          </button>
+          <div className="flex items-center gap-2">
+            <div className="flex overflow-hidden rounded-md border border-[var(--border-hairline)]">
+              {(["list", "graph"] as const).map((mode) => (
+                <button
+                  key={mode}
+                  type="button"
+                  onClick={() => setViewMode(mode)}
+                  className={[
+                    "inline-flex h-7 items-center gap-1.5 px-2.5 text-[11px] capitalize transition-colors",
+                    viewMode === mode
+                      ? "bg-[var(--accent-presence)] text-white"
+                      : "bg-[var(--bg-raised)]/30 text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]",
+                  ].join(" ")}
+                >
+                  <Icon name={mode === "list" ? "ph:list-bullets" : "ph:graph"} width={12} />
+                  {mode}
+                </button>
+              ))}
+            </div>
+            <button type="button" onClick={() => void load()} className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]">
+              <Icon name="ph:arrows-clockwise" width={12} />
+              Refresh
+            </button>
+          </div>
         </div>
 
         <div className="mt-3 grid gap-2 sm:grid-cols-3">
@@ -194,6 +230,62 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
         {error ? <div className="mt-2 text-[11px] text-[var(--color-warning)]">{error}</div> : null}
       </div>
 
+      {viewMode === "graph" ? (
+        <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto p-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+          <section className="min-h-[520px] overflow-hidden rounded-lg border border-[var(--border-hairline)]">
+            <MemoryGraph3D
+              graph={memoryGraph}
+              familiars={familiarById}
+              selectedFamiliarId={familiarFilter}
+              onSelectFamiliar={(familiarId) => setFamiliarFilter(familiarId)}
+              onOpenMemoryFile={onOpenMemoryFile}
+            />
+          </section>
+          <aside className="hidden min-h-0 xl:block">
+            <div className="mb-2 flex items-center justify-between">
+              <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">
+                {familiarFilter === "all" ? "Constellation index" : familiarById.get(familiarFilter)?.display_name ?? familiarFilter}
+              </h3>
+              <span className="text-[10px] text-[var(--text-muted)]">{visibleCoven.length + visibleFiles.length} visible</span>
+            </div>
+            <div className="max-h-[640px] overflow-y-auto rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/25">
+              {visibleCoven.slice(0, 18).map((entry) => (
+                <button
+                  key={entry.id}
+                  type="button"
+                  onClick={() => onOpenMemoryFile?.(entry.path)}
+                  className="flex w-full items-start gap-2 border-b border-[var(--border-hairline)] px-3 py-2 text-left hover:bg-[var(--bg-raised)]"
+                >
+                  <Icon name="ph:brain" width={13} className="mt-0.5 shrink-0 text-[var(--accent-presence)]" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block line-clamp-2 text-[12px] text-[var(--text-primary)]">{entry.title}</span>
+                    <span className="mt-0.5 block text-[10px] text-[var(--text-muted)]">{familiarById.get(entry.familiar_id)?.display_name ?? entry.familiar_id} · {age(entry.updated_at)}</span>
+                  </span>
+                </button>
+              ))}
+              {visibleFiles.slice(0, 18).map((entry) => (
+                <button
+                  key={entry.fullPath}
+                  type="button"
+                  onClick={() => onOpenMemoryFile?.(entry.fullPath)}
+                  className="flex w-full items-start gap-2 border-b border-[var(--border-hairline)] px-3 py-2 text-left hover:bg-[var(--bg-raised)]"
+                >
+                  <Icon name="ph:file-text" width={13} className="mt-0.5 shrink-0 text-[var(--text-muted)]" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[12px] text-[var(--text-primary)]">{entry.relPath}</span>
+                    <span className="mt-0.5 block truncate text-[10px] text-[var(--text-muted)]">{entry.rootLabel} · {age(entry.modified)}</span>
+                  </span>
+                </button>
+              ))}
+              {visibleCoven.length + visibleFiles.length === 0 ? (
+                <div className="px-3 py-8 text-center text-[12px] text-[var(--text-muted)]">
+                  {loaded ? "No memories match this constellation." : "Loading memories..."}
+                </div>
+              ) : null}
+            </div>
+          </aside>
+        </div>
+      ) : (
       <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto p-4 xl:grid-cols-[minmax(0,1.25fr)_minmax(320px,0.75fr)]">
         <section className="min-h-0">
           <div className="mb-2 flex items-center justify-between">
@@ -275,6 +367,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
           </div>
         </section>
       </div>
+      )}
     </div>
   );
 }

--- a/src/components/memory-graph-3d-smoke.tsx
+++ b/src/components/memory-graph-3d-smoke.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { MemoryGraph3D } from "@/components/memory-graph-3d";
+import { buildMemoryGraphModel } from "@/lib/memory-graph-3d-model";
+import type { Familiar } from "@/lib/types";
+
+const now = new Date().toISOString();
+
+const familiarsList: Familiar[] = [
+  { id: "nova", display_name: "Nova", role: "Guide", icon: "ph:sparkle" },
+  { id: "cody", display_name: "Cody", role: "Builder", icon: "ph:terminal-window" },
+  { id: "sage", display_name: "Sage", role: "Research", icon: "ph:brain" },
+];
+
+const covenEntries = [
+  {
+    id: "smoke-nova-1",
+    familiar_id: "nova",
+    title: "Nova remembers the constellation architecture",
+    path: "/Users/buns/.coven/memory/nova/constellation.md",
+    updated_at: now,
+    excerpt: "Anchor familiar hubs and keep the list as the retrieval surface.",
+  },
+  {
+    id: "smoke-cody-1",
+    familiar_id: "cody",
+    title: "Cody records the graph implementation plan",
+    path: "/Users/buns/.coven/memory/cody/graph.md",
+    updated_at: now,
+    excerpt: "Use a dedicated memory graph model and Three.js viewer.",
+  },
+  {
+    id: "smoke-sage-1",
+    familiar_id: "sage",
+    title: "Sage notes radial layout constraints",
+    path: "/Users/buns/.coven/memory/sage/layout.md",
+    updated_at: now,
+    excerpt: "Avoid free-floating force scatter for dense memory views.",
+  },
+];
+
+const fileEntries = [
+  {
+    root: "workspace",
+    rootLabel: "Workspace memory",
+    relPath: "2026-06-08.md",
+    fullPath: "/Users/buns/.openclaw/workspace/memory/2026-06-08.md",
+    size: 2400,
+    modified: now,
+  },
+];
+
+export function MemoryGraph3DSmoke() {
+  const [selectedFamiliarId, setSelectedFamiliarId] = useState("all");
+  const familiars = useMemo(() => new Map(familiarsList.map((familiar) => [familiar.id, familiar])), []);
+  const graph = useMemo(
+    () =>
+      buildMemoryGraphModel({
+        familiars: familiarsList,
+        covenEntries,
+        fileEntries,
+        familiarFilter: selectedFamiliarId,
+      }),
+    [selectedFamiliarId],
+  );
+
+  return (
+    <main className="h-screen w-screen bg-[var(--bg-base)] p-6 text-[var(--text-primary)]">
+      <div className="h-full overflow-hidden border border-[var(--border-hairline)]">
+        <MemoryGraph3D
+          graph={graph}
+          familiars={familiars}
+          selectedFamiliarId={selectedFamiliarId}
+          onSelectFamiliar={setSelectedFamiliarId}
+          onOpenMemoryFile={() => {}}
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/components/memory-graph-3d.tsx
+++ b/src/components/memory-graph-3d.tsx
@@ -1,0 +1,519 @@
+"use client";
+
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+import * as THREE from "three";
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+import { Icon } from "@/lib/icon";
+import type { Familiar } from "@/lib/types";
+import {
+  buildMemoryGraphSceneModel,
+  type MemoryGraph,
+  type MemoryGraphSceneNode,
+} from "@/lib/memory-graph-3d-model";
+
+type Props = {
+  graph: MemoryGraph;
+  familiars: Map<string, Familiar>;
+  selectedFamiliarId: string;
+  onSelectFamiliar: (familiarId: string) => void;
+  onOpenMemoryFile?: (path: string) => void;
+};
+
+type Pickable = THREE.Object3D & {
+  userData: {
+    node?: MemoryGraphSceneNode;
+    nodes?: MemoryGraphSceneNode[];
+    baseOpacity?: number;
+  };
+};
+
+type Hover = { node: MemoryGraphSceneNode; x: number; y: number } | null;
+
+function asVector(position: { x: number; y: number; z: number }): THREE.Vector3 {
+  return new THREE.Vector3(position.x, position.y, position.z);
+}
+
+function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReduced(media.matches);
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, []);
+  return reduced;
+}
+
+function roundRect(context: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number) {
+  context.beginPath();
+  context.moveTo(x + r, y);
+  context.arcTo(x + w, y, x + w, y + h, r);
+  context.arcTo(x + w, y + h, x, y + h, r);
+  context.arcTo(x, y + h, x, y, r);
+  context.arcTo(x, y, x + w, y, r);
+  context.closePath();
+}
+
+function makeLabelSprite(text: string, color: string): THREE.Sprite {
+  const canvas = document.createElement("canvas");
+  const context = canvas.getContext("2d");
+  canvas.width = 384;
+  canvas.height = 96;
+  if (context) {
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    context.fillStyle = "rgba(10, 10, 14, 0.72)";
+    context.strokeStyle = "rgba(255, 255, 255, 0.14)";
+    roundRect(context, 10, 18, 364, 54, 16);
+    context.fill();
+    context.stroke();
+    context.font = "600 26px system-ui, -apple-system, BlinkMacSystemFont, sans-serif";
+    context.fillStyle = color;
+    context.textAlign = "center";
+    context.textBaseline = "middle";
+    context.fillText(text.slice(0, 24), canvas.width / 2, 45);
+  }
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  const material = new THREE.SpriteMaterial({ map: texture, transparent: true, depthWrite: false });
+  const sprite = new THREE.Sprite(material);
+  sprite.scale.set(2.8, 0.7, 1);
+  return sprite;
+}
+
+function materialList(object: THREE.Object3D): THREE.Material[] {
+  const material = (object as THREE.Mesh | THREE.Line | THREE.Sprite | THREE.InstancedMesh).material;
+  if (!material) return [];
+  return Array.isArray(material) ? material : [material];
+}
+
+function disposeObject(object: THREE.Object3D) {
+  const geometries = new Set<THREE.BufferGeometry>();
+  const materials = new Set<THREE.Material>();
+  object.traverse((child) => {
+    const geometry = (child as THREE.Mesh | THREE.Line | THREE.Sprite | THREE.InstancedMesh).geometry;
+    if (geometry) geometries.add(geometry);
+    materialList(child).forEach((material) => materials.add(material));
+  });
+  geometries.forEach((geometry) => geometry.dispose());
+  materials.forEach((material) => material.dispose());
+}
+
+function colorFor(node: MemoryGraphSceneNode, selectedFamiliarId: string): THREE.Color {
+  const color = new THREE.Color(node.color);
+  if (selectedFamiliarId === "all") return color;
+  const belongsToSelected =
+    (node.kind === "hub" && node.familiarId === selectedFamiliarId) ||
+    (node.kind !== "hub" && node.familiarId === selectedFamiliarId);
+  if (belongsToSelected) return color;
+  return color.lerp(new THREE.Color("#1a1722"), 0.72);
+}
+
+function nodeIsDimmed(node: MemoryGraphSceneNode, selectedFamiliarId: string): boolean {
+  if (selectedFamiliarId === "all") return false;
+  if (node.kind === "hub") return node.hubKind === "familiar" && node.familiarId !== selectedFamiliarId;
+  return node.familiarId !== selectedFamiliarId;
+}
+
+function compactAge(iso: string | undefined): string {
+  if (!iso) return "";
+  const ms = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(ms)) return "";
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+export function MemoryGraph3D({
+  graph,
+  familiars,
+  selectedFamiliarId,
+  onSelectFamiliar,
+  onOpenMemoryFile,
+}: Props) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const shellRef = useRef<HTMLDivElement | null>(null);
+  const resetRef = useRef<(() => void) | null>(null);
+  const [hover, setHover] = useState<Hover>(null);
+  const reducedMotion = useReducedMotion();
+  const sceneModel = useMemo(() => buildMemoryGraphSceneModel(graph), [graph]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const shell = shellRef.current;
+    if (!canvas || !shell || sceneModel.nodes.length === 0) return;
+
+    canvas.dataset.effectStarted = "true";
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    canvas.dataset.rendererReady = "true";
+
+    const scene = new THREE.Scene();
+    scene.fog = new THREE.FogExp2(0x07070d, 0.042);
+    const camera = new THREE.PerspectiveCamera(48, 1, 0.1, 90);
+    camera.position.set(0, 5.8, sceneModel.nodes.length <= 4 ? 10 : 14);
+    camera.lookAt(0, 0, 0);
+
+    const controls = new OrbitControls(camera, canvas);
+    controls.enableDamping = true;
+    controls.dampingFactor = 0.08;
+    controls.minDistance = 5.5;
+    controls.maxDistance = 24;
+    controls.target.set(0, 0, 0);
+    controls.saveState();
+
+    const root = new THREE.Group();
+    root.rotation.x = -0.18;
+    scene.add(root);
+    scene.add(new THREE.AmbientLight(0xffffff, 1.05));
+    const key = new THREE.DirectionalLight(0xe2d6ff, 2.4);
+    key.position.set(4, 8, 7);
+    scene.add(key);
+    const fill = new THREE.PointLight(0x38bdf8, 16, 24);
+    fill.position.set(-6, 2, 5);
+    scene.add(fill);
+
+    const pickables: Pickable[] = [];
+    const hubs = sceneModel.nodes.filter((node) => node.kind === "hub");
+    const leaves = sceneModel.nodes.filter((node) => node.kind === "memory");
+    const clusters = sceneModel.nodes.filter((node) => node.kind === "cluster");
+    const hubById = new Map(hubs.map((hub) => [hub.id, hub]));
+
+    const grid = new THREE.GridHelper(18, 18, 0x2c2440, 0x151520);
+    grid.position.y = -2.35;
+    root.add(grid);
+
+    for (const edge of sceneModel.edges) {
+      const geometry = new THREE.BufferGeometry().setFromPoints([asVector(edge.from), asVector(edge.to)]);
+      const material = new THREE.LineBasicMaterial({
+        color: new THREE.Color(edge.color),
+        transparent: true,
+        opacity: edge.opacity,
+      });
+      root.add(new THREE.Line(geometry, material));
+    }
+
+    for (const hub of hubs) {
+      const geometry = hub.hubKind === "files"
+        ? new THREE.IcosahedronGeometry(hub.radius, 1)
+        : new THREE.SphereGeometry(hub.radius, 32, 24);
+      const material = new THREE.MeshStandardMaterial({
+        color: 0x17131f,
+        emissive: colorFor(hub, selectedFamiliarId),
+        emissiveIntensity: nodeIsDimmed(hub, selectedFamiliarId) ? 0.1 : 0.36,
+        roughness: 0.42,
+        metalness: 0.12,
+      });
+      const mesh = new THREE.Mesh(geometry, material) as Pickable;
+      mesh.position.copy(asVector(hub.position));
+      mesh.userData.node = hub;
+      root.add(mesh);
+      pickables.push(mesh);
+
+      const halo = new THREE.Mesh(
+        new THREE.RingGeometry(hub.radius + 0.13, hub.radius + 0.2 + Math.min(hub.memoryCount, 30) * 0.004, 56),
+        new THREE.MeshBasicMaterial({
+          color: colorFor(hub, selectedFamiliarId),
+          transparent: true,
+          opacity: nodeIsDimmed(hub, selectedFamiliarId) ? 0.16 : 0.46,
+          side: THREE.DoubleSide,
+        }),
+      );
+      halo.position.copy(asVector(hub.position));
+      halo.userData.billboard = true;
+      root.add(halo);
+
+      const label = makeLabelSprite(
+        hub.hubKind === "files" ? hub.label : familiars.get(hub.familiarId ?? "")?.display_name ?? hub.label,
+        nodeIsDimmed(hub, selectedFamiliarId) ? "#7d748c" : "#f7f1ff",
+      );
+      label.position.copy(asVector(hub.position).add(new THREE.Vector3(0, hub.radius + 0.55, 0)));
+      root.add(label);
+    }
+
+    if (leaves.length > 0) {
+      const geometry = new THREE.SphereGeometry(1, 12, 10);
+      const material = new THREE.MeshStandardMaterial({
+        color: 0xffffff,
+        emissive: 0xffffff,
+        emissiveIntensity: 0.18,
+        vertexColors: true,
+        roughness: 0.55,
+        metalness: 0.05,
+      });
+      const instanced = new THREE.InstancedMesh(geometry, material, leaves.length);
+      const matrix = new THREE.Matrix4();
+      leaves.forEach((node, index) => {
+        matrix.compose(
+          asVector(node.position),
+          new THREE.Quaternion(),
+          new THREE.Vector3(node.radius, node.radius, node.radius),
+        );
+        instanced.setMatrixAt(index, matrix);
+        instanced.setColorAt(index, colorFor(node, selectedFamiliarId));
+      });
+      instanced.instanceMatrix.needsUpdate = true;
+      if (instanced.instanceColor) instanced.instanceColor.needsUpdate = true;
+      instanced.userData.nodes = leaves;
+      root.add(instanced);
+      pickables.push(instanced as Pickable);
+    }
+
+    for (const cluster of clusters) {
+      const color = colorFor(cluster, selectedFamiliarId);
+      const mesh = new THREE.Mesh(
+        new THREE.SphereGeometry(cluster.radius, 20, 14),
+        new THREE.MeshStandardMaterial({
+          color: 0x1e1820,
+          emissive: color,
+          emissiveIntensity: nodeIsDimmed(cluster, selectedFamiliarId) ? 0.08 : 0.28,
+          roughness: 0.48,
+        }),
+      ) as Pickable;
+      mesh.position.copy(asVector(cluster.position));
+      mesh.userData.node = cluster;
+      root.add(mesh);
+      pickables.push(mesh);
+
+      const label = makeLabelSprite(cluster.label, nodeIsDimmed(cluster, selectedFamiliarId) ? "#8f7d59" : "#fbbf24");
+      label.scale.set(1.25, 0.32, 1);
+      label.position.copy(asVector(cluster.position).add(new THREE.Vector3(0, cluster.radius + 0.34, 0)));
+      root.add(label);
+    }
+
+    const resize = () => {
+      const box = shell.getBoundingClientRect();
+      const width = Math.max(320, Math.floor(box.width));
+      const height = Math.max(420, Math.floor(box.height));
+      renderer.setSize(width, height, false);
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+    };
+    const observer = new ResizeObserver(resize);
+    observer.observe(shell);
+    resize();
+
+    let visible = true;
+    const visibilityObserver = new IntersectionObserver(([entry]) => {
+      visible = entry?.isIntersecting ?? true;
+    });
+    visibilityObserver.observe(shell);
+
+    const resetView = () => {
+      controls.reset();
+      root.rotation.set(-0.18, 0, 0);
+      camera.position.set(0, 5.8, sceneModel.nodes.length <= 4 ? 10 : 14);
+      camera.lookAt(0, 0, 0);
+      controls.update();
+    };
+    resetRef.current = resetView;
+
+    const raycaster = new THREE.Raycaster();
+    const pointer = new THREE.Vector2();
+    const drag = { active: false, moved: false, x: 0, y: 0 };
+    const setPointer = (event: PointerEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+      pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+    };
+    const hitNode = (): MemoryGraphSceneNode | null => {
+      raycaster.setFromCamera(pointer, camera);
+      const hit = raycaster.intersectObjects(pickables, false)[0];
+      if (!hit) return null;
+      const object = hit.object as Pickable;
+      if (object.userData.node) return object.userData.node;
+      if (typeof hit.instanceId === "number") return object.userData.nodes?.[hit.instanceId] ?? null;
+      return null;
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      drag.active = true;
+      drag.moved = false;
+      drag.x = event.clientX;
+      drag.y = event.clientY;
+      canvas.setPointerCapture(event.pointerId);
+    };
+    const onPointerMove = (event: PointerEvent) => {
+      if (drag.active) {
+        const dx = event.clientX - drag.x;
+        const dy = event.clientY - drag.y;
+        if (Math.abs(dx) + Math.abs(dy) > 3) drag.moved = true;
+        drag.x = event.clientX;
+        drag.y = event.clientY;
+        return;
+      }
+      setPointer(event);
+      const node = hitNode();
+      setHover(node ? { node, x: event.clientX, y: event.clientY } : null);
+    };
+    const onPointerUp = (event: PointerEvent) => {
+      drag.active = false;
+      try { canvas.releasePointerCapture(event.pointerId); } catch {}
+      if (drag.moved) return;
+      setPointer(event);
+      const node = hitNode();
+      if (!node) {
+        onSelectFamiliar("all");
+      } else if (node.kind === "hub") {
+        onSelectFamiliar(node.familiarId ?? "all");
+      } else if (node.kind === "memory") {
+        onOpenMemoryFile?.(node.path);
+      } else if (node.familiarId) {
+        onSelectFamiliar(node.familiarId);
+      } else {
+        onSelectFamiliar("all");
+      }
+    };
+    const onPointerLeave = () => setHover(null);
+    const onGesture = (event: Event) => event.preventDefault();
+    canvas.addEventListener("pointerdown", onPointerDown);
+    canvas.addEventListener("pointermove", onPointerMove);
+    canvas.addEventListener("pointerup", onPointerUp);
+    canvas.addEventListener("pointerleave", onPointerLeave);
+    canvas.addEventListener("gesturestart", onGesture);
+    canvas.addEventListener("gesturechange", onGesture);
+
+    let frame = 0;
+    let previousFrameAt = performance.now();
+    const startedAt = previousFrameAt;
+    const animate = () => {
+      frame = requestAnimationFrame(animate);
+      if (!visible) return;
+      const now = performance.now();
+      const elapsed = (now - startedAt) / 1000;
+      const delta = (now - previousFrameAt) / 1000;
+      previousFrameAt = now;
+      controls.update();
+      if (!reducedMotion && !drag.active) root.rotation.y += delta * 0.025;
+      root.traverse((child) => {
+        if (child instanceof THREE.Sprite || child.userData.billboard) child.quaternion.copy(camera.quaternion);
+        if (!reducedMotion && child.userData.billboard) {
+          const pulse = (Math.sin(elapsed * 1.5) + 1) / 2;
+          for (const material of materialList(child)) {
+            if ("opacity" in material && typeof child.userData.baseOpacity === "number") {
+              material.opacity = child.userData.baseOpacity + pulse * 0.08;
+            }
+          }
+        }
+      });
+      renderer.render(scene, camera);
+    };
+    animate();
+
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+      visibilityObserver.disconnect();
+      canvas.removeEventListener("pointerdown", onPointerDown);
+      canvas.removeEventListener("pointermove", onPointerMove);
+      canvas.removeEventListener("pointerup", onPointerUp);
+      canvas.removeEventListener("pointerleave", onPointerLeave);
+      canvas.removeEventListener("gesturestart", onGesture);
+      canvas.removeEventListener("gesturechange", onGesture);
+      resetRef.current = null;
+      controls.dispose();
+      disposeObject(root);
+      renderer.dispose();
+    };
+  }, [familiars, graph, onOpenMemoryFile, onSelectFamiliar, reducedMotion, sceneModel, selectedFamiliarId]);
+
+  const selectedLabel = selectedFamiliarId === "all"
+    ? `${graph.metrics.visibleCovenEntries + graph.metrics.visibleFileEntries} memories in constellation.`
+    : `Selected familiar ${familiars.get(selectedFamiliarId)?.display_name ?? selectedFamiliarId}.`;
+
+  const onKeyDown = (event: KeyboardEvent<HTMLCanvasElement>) => {
+    if (event.key === "Escape") onSelectFamiliar("all");
+    if (event.key === "Home") resetRef.current?.();
+  };
+
+  if (sceneModel.nodes.length === 0) {
+    return (
+      <div className="grid min-h-[420px] flex-1 place-items-center bg-[oklch(0.11_0.022_293)] text-sm text-white/55">
+        No memories in this constellation.
+      </div>
+    );
+  }
+
+  return (
+    <div ref={shellRef} className="relative min-h-[520px] flex-1 overflow-hidden bg-[oklch(0.105_0.024_286)]">
+      <canvas
+        ref={canvasRef}
+        data-testid="memory-graph-3d-canvas"
+        aria-label="3D memory constellation"
+        role="application"
+        tabIndex={0}
+        onKeyDown={onKeyDown}
+        className="h-full min-h-[520px] w-full cursor-grab touch-none active:cursor-grabbing"
+      />
+      <p aria-live="polite" className="sr-only">{selectedLabel}</p>
+      <div className="pointer-events-none absolute inset-x-0 top-0 flex flex-wrap items-start justify-between gap-3 p-3">
+        <div className="rounded-lg border border-white/10 bg-black/45 px-3 py-2 shadow-2xl backdrop-blur">
+          <div className="text-[10px] font-semibold uppercase tracking-widest text-white/55">Memory constellation</div>
+          <div className="mt-1 flex flex-wrap gap-2 text-[10px] text-white/70">
+            <span>{graph.metrics.familiarHubs} familiars</span>
+            <span>{graph.metrics.visibleCovenEntries} coven</span>
+            <span>{graph.metrics.visibleFileEntries} files</span>
+          </div>
+        </div>
+        <button
+          type="button"
+          title="Reset view"
+          onClick={() => resetRef.current?.()}
+          className="pointer-events-auto inline-flex h-8 w-8 items-center justify-center rounded-md border border-white/10 bg-black/45 text-white/70 shadow-2xl backdrop-blur hover:bg-white/10 hover:text-white"
+        >
+          <Icon name="ph:arrows-clockwise-bold" width={14} />
+        </button>
+      </div>
+      <div className="pointer-events-none absolute bottom-3 left-3 flex flex-wrap items-center gap-2 rounded-lg border border-white/10 bg-black/45 px-3 py-2 text-[10px] text-white/65 shadow-2xl backdrop-blur">
+        <span className="inline-flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-[#8E3DFF]" /> familiar</span>
+        <span className="inline-flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-[#62d08f]" /> coven</span>
+        <span className="inline-flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-[#38bdf8]" /> files</span>
+        <span className="inline-flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-[#f59e0b]" /> cluster</span>
+      </div>
+      {graph.metrics.hiddenEntries > 0 ? (
+        <div className="pointer-events-none absolute right-3 top-16 max-w-[260px] rounded-lg border border-[color-mix(in_oklch,var(--color-warning)_25%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_18%,transparent)] px-3 py-2 text-[10px] text-[var(--color-warning)] shadow-2xl backdrop-blur">
+          Dense constellation: {graph.metrics.hiddenEntries} older memories are clustered.
+        </div>
+      ) : null}
+      {hover ? <MemoryGraphTooltip hover={hover} familiars={familiars} /> : null}
+    </div>
+  );
+}
+
+function MemoryGraphTooltip({
+  hover,
+  familiars,
+}: {
+  hover: NonNullable<Hover>;
+  familiars: Map<string, Familiar>;
+}) {
+  const { node } = hover;
+  const familiarName = node.familiarId ? familiars.get(node.familiarId)?.display_name ?? node.familiarId : "Memory Files";
+  const detail = node.kind === "hub"
+    ? `${node.memoryCount} memories`
+    : node.kind === "cluster"
+      ? `${node.count} older memories`
+      : `${familiarName} · ${node.source === "file" ? node.rootLabel ?? "file" : "coven"} · ${compactAge(node.updatedAt)}`;
+
+  return (
+    <div
+      className="pointer-events-none fixed z-50 max-w-[300px] rounded-lg border border-white/10 bg-black/85 px-3 py-2 text-[11px] text-white shadow-2xl backdrop-blur"
+      style={{ left: hover.x + 12, top: hover.y + 12 }}
+    >
+      <div className="font-semibold">{node.label}</div>
+      <div className="mt-1 text-white/65">{detail}</div>
+      {node.kind === "memory" && node.excerpt ? (
+        <div className="mt-2 line-clamp-3 text-white/55">{node.excerpt}</div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/memory-graph-3d-model.test.ts
+++ b/src/lib/memory-graph-3d-model.test.ts
@@ -1,0 +1,131 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  buildMemoryGraphModel,
+  buildMemoryGraphSceneModel,
+  memorySelectionObjectKey,
+} from "./memory-graph-3d-model.ts";
+
+const familiars = [
+  { id: "nova", display_name: "Nova", role: "Guide", icon: "ph:sparkle" },
+  { id: "cody", display_name: "Cody", role: "Builder", emoji: "C" },
+];
+
+const covenEntries = [
+  {
+    id: "mem-1",
+    familiar_id: "nova",
+    title: "Nova remembers routing",
+    path: "/Users/buns/.coven/memory/nova.md",
+    updated_at: "2026-06-08T05:00:00.000Z",
+    excerpt: "routing architecture",
+  },
+  {
+    id: "mem-2",
+    familiar_id: "cody",
+    title: "Cody build note",
+    path: "/Users/buns/.coven/memory/cody.md",
+    updated_at: "2026-06-08T04:00:00.000Z",
+  },
+  {
+    id: "mem-3",
+    familiar_id: "nova",
+    title: "Older Nova note",
+    path: "/Users/buns/.coven/memory/nova-old.md",
+    updated_at: "2026-06-07T04:00:00.000Z",
+  },
+];
+
+const fileEntries = [
+  {
+    root: "workspace",
+    rootLabel: "Workspace memory",
+    relPath: "2026-06-08.md",
+    fullPath: "/Users/buns/.openclaw/workspace/memory/2026-06-08.md",
+    size: 1200,
+    modified: "2026-06-08T05:10:00.000Z",
+  },
+];
+
+const graph = buildMemoryGraphModel({
+  familiars,
+  covenEntries,
+  fileEntries,
+  query: "",
+  familiarFilter: "all",
+  maxLeavesPerHub: 1,
+});
+
+const familiarHubs = graph.nodes.filter((node) => node.kind === "hub" && node.hubKind === "familiar");
+assert.deepEqual(
+  familiarHubs.map((node) => node.id),
+  ["familiar:nova", "familiar:cody"],
+  "all familiar hubs should render even when their visible memory leaf count is capped",
+);
+
+assert.ok(
+  graph.nodes.some((node) => node.kind === "hub" && node.hubKind === "files" && node.label === "Memory Files"),
+  "filesystem memory entries should be represented under a neutral Memory Files hub",
+);
+
+assert.ok(
+  graph.edges.some((edge) => edge.source === "memory:coven:mem-1" && edge.target === "familiar:nova"),
+  "coven memory leaves should connect to their familiar hub",
+);
+
+assert.ok(
+  graph.edges.some((edge) => edge.source.startsWith("memory:file:") && edge.target === "hub:memory-files"),
+  "filesystem memory leaves should connect to the neutral files hub",
+);
+
+assert.equal(
+  graph.nodes.find((node) => node.kind === "memory" && node.source === "file")?.familiarId,
+  undefined,
+  "filesystem memory leaves must not fake a familiar relationship",
+);
+
+assert.equal(
+  graph.nodes.find((node) => node.kind === "cluster" && node.hubId === "familiar:nova")?.count,
+  1,
+  "overflow familiar memories should collapse into a cluster node",
+);
+
+const filtered = buildMemoryGraphModel({
+  familiars,
+  covenEntries,
+  fileEntries,
+  query: "routing",
+  familiarFilter: "nova",
+  maxLeavesPerHub: 10,
+});
+
+assert.deepEqual(
+  filtered.nodes.filter((node) => node.kind === "memory" && node.source === "coven").map((node) => node.id),
+  ["memory:coven:mem-1"],
+  "query and familiar filters should apply to familiar memory leaves",
+);
+
+assert.equal(
+  memorySelectionObjectKey({ kind: "familiar", id: "nova" }),
+  "hub:familiar:nova",
+);
+assert.equal(
+  memorySelectionObjectKey({ kind: "memory", id: "memory:coven:mem-1" }),
+  "memory:memory:coven:mem-1",
+);
+
+const scene = buildMemoryGraphSceneModel(graph);
+const novaHub = scene.nodes.find((node) => node.id === "familiar:nova");
+const novaLeaf = scene.nodes.find((node) => node.id === "memory:coven:mem-1");
+assert.ok(novaHub, "scene model should include familiar hub positions");
+assert.ok(novaLeaf, "scene model should include memory leaf positions");
+assert.notDeepEqual(
+  novaHub?.position,
+  novaLeaf?.position,
+  "memory leaves should be positioned on a shell around their hub, not on top of it",
+);
+assert.equal(
+  scene.nodes.find((node) => node.id === "familiar:nova")?.memoryCount,
+  2,
+  "hub memory count should reflect total matching entries before visual leaf caps",
+);

--- a/src/lib/memory-graph-3d-model.ts
+++ b/src/lib/memory-graph-3d-model.ts
@@ -1,0 +1,459 @@
+import type { Familiar } from "@/lib/types";
+
+export type MemoryGraphCovenEntry = {
+  id: string;
+  familiar_id: string;
+  title: string;
+  path: string;
+  updated_at: string;
+  excerpt?: string;
+};
+
+export type MemoryGraphFileEntry = {
+  root: string;
+  rootLabel: string;
+  relPath: string;
+  fullPath: string;
+  size: number;
+  modified: string;
+};
+
+export type MemoryGraphHubNode = {
+  kind: "hub";
+  hubKind: "familiar" | "files";
+  id: string;
+  label: string;
+  glyph?: string;
+  familiarId?: string;
+  memoryCount: number;
+  latestAt?: string;
+};
+
+export type MemoryGraphMemoryNode = {
+  kind: "memory";
+  id: string;
+  source: "coven" | "file";
+  hubId: string;
+  familiarId?: string;
+  title: string;
+  path: string;
+  updatedAt: string;
+  excerpt?: string;
+  rootLabel?: string;
+  relPath?: string;
+};
+
+export type MemoryGraphClusterNode = {
+  kind: "cluster";
+  id: string;
+  hubId: string;
+  familiarId?: string;
+  source: "coven" | "file";
+  label: string;
+  count: number;
+  latestAt?: string;
+};
+
+export type MemoryGraphNode =
+  | MemoryGraphHubNode
+  | MemoryGraphMemoryNode
+  | MemoryGraphClusterNode;
+
+type MemoryGraphChildNode = MemoryGraphMemoryNode | MemoryGraphClusterNode;
+
+export type MemoryGraphEdge = {
+  id: string;
+  kind: "belongs_to";
+  source: string;
+  target: string;
+  count: number;
+};
+
+export type MemoryGraph = {
+  nodes: MemoryGraphNode[];
+  edges: MemoryGraphEdge[];
+  metrics: {
+    familiarHubs: number;
+    fileHubs: number;
+    visibleCovenEntries: number;
+    visibleFileEntries: number;
+    hiddenEntries: number;
+  };
+};
+
+export type MemoryGraphSelection =
+  | { kind: "familiar"; id: string }
+  | { kind: "memory"; id: string }
+  | { kind: "cluster"; id: string }
+  | { kind: "files" }
+  | null;
+
+export type MemoryGraphSceneNode = MemoryGraphNode & {
+  label: string;
+  position: ScenePosition;
+  radius: number;
+  color: string;
+  memoryCount: number;
+};
+
+export type MemoryGraphSceneEdge = MemoryGraphEdge & {
+  from: ScenePosition;
+  to: ScenePosition;
+  color: string;
+  opacity: number;
+};
+
+export type MemoryGraphSceneModel = {
+  nodes: MemoryGraphSceneNode[];
+  edges: MemoryGraphSceneEdge[];
+};
+
+export type ScenePosition = { x: number; y: number; z: number };
+
+const FILE_HUB_ID = "hub:memory-files";
+
+function matchesQuery(values: Array<string | undefined>, query: string): boolean {
+  if (!query) return true;
+  return values.some((value) => (value ?? "").toLowerCase().includes(query));
+}
+
+function compareIsoDesc(a?: string, b?: string): number {
+  return (b ?? "").localeCompare(a ?? "");
+}
+
+function compactFileTitle(entry: MemoryGraphFileEntry): string {
+  return entry.relPath || entry.fullPath.split("/").pop() || entry.fullPath;
+}
+
+function memoryIdForFile(entry: MemoryGraphFileEntry): string {
+  return `memory:file:${entry.fullPath}`;
+}
+
+function memoryIdForCoven(entry: MemoryGraphCovenEntry): string {
+  return `memory:coven:${entry.id}`;
+}
+
+function edgeId(source: string, target: string): string {
+  return `${source}->${target}`;
+}
+
+function pos(x: number, y: number, z: number): ScenePosition {
+  return { x, y, z };
+}
+
+function addCappedLeaves({
+  hubId,
+  familiarId,
+  source,
+  entries,
+  maxLeavesPerHub,
+  toMemoryNode,
+  nodes,
+  edges,
+}: {
+  hubId: string;
+  familiarId?: string;
+  source: "coven" | "file";
+  entries: Array<MemoryGraphCovenEntry | MemoryGraphFileEntry>;
+  maxLeavesPerHub: number;
+  toMemoryNode: (entry: MemoryGraphCovenEntry | MemoryGraphFileEntry) => MemoryGraphMemoryNode;
+  nodes: MemoryGraphNode[];
+  edges: MemoryGraphEdge[];
+}) {
+  const visible = entries.slice(0, maxLeavesPerHub);
+  const hidden = entries.slice(maxLeavesPerHub);
+
+  for (const entry of visible) {
+    const node = toMemoryNode(entry);
+    nodes.push(node);
+    edges.push({
+      id: edgeId(node.id, hubId),
+      kind: "belongs_to",
+      source: node.id,
+      target: hubId,
+      count: 1,
+    });
+  }
+
+  if (hidden.length > 0) {
+    const cluster: MemoryGraphClusterNode = {
+      kind: "cluster",
+      id: `cluster:${hubId}`,
+      hubId,
+      familiarId,
+      source,
+      label: `+${hidden.length} older`,
+      count: hidden.length,
+      latestAt:
+        source === "coven"
+          ? (hidden[0] as MemoryGraphCovenEntry | undefined)?.updated_at
+          : (hidden[0] as MemoryGraphFileEntry | undefined)?.modified,
+    };
+    nodes.push(cluster);
+    edges.push({
+      id: edgeId(cluster.id, hubId),
+      kind: "belongs_to",
+      source: cluster.id,
+      target: hubId,
+      count: hidden.length,
+    });
+  }
+}
+
+export function buildMemoryGraphModel({
+  familiars,
+  covenEntries,
+  fileEntries,
+  query = "",
+  familiarFilter = "all",
+  maxLeavesPerHub = 30,
+}: {
+  familiars: Familiar[];
+  covenEntries: MemoryGraphCovenEntry[];
+  fileEntries: MemoryGraphFileEntry[];
+  query?: string;
+  familiarFilter?: string;
+  maxLeavesPerHub?: number;
+}): MemoryGraph {
+  const q = query.trim().toLowerCase();
+  const nodes: MemoryGraphNode[] = [];
+  const edges: MemoryGraphEdge[] = [];
+  let hiddenEntries = 0;
+
+  const matchingCovenEntries = covenEntries
+    .filter((entry) => familiarFilter === "all" || entry.familiar_id === familiarFilter)
+    .filter((entry) =>
+      matchesQuery([entry.title, entry.excerpt, entry.familiar_id, entry.path], q),
+    )
+    .sort((a, b) => compareIsoDesc(a.updated_at, b.updated_at));
+
+  const matchingFiles = fileEntries
+    .filter((entry) =>
+      matchesQuery([entry.rootLabel, entry.relPath, entry.fullPath], q),
+    )
+    .sort((a, b) => compareIsoDesc(a.modified, b.modified));
+
+  const covenByFamiliar = new Map<string, MemoryGraphCovenEntry[]>();
+  for (const entry of matchingCovenEntries) {
+    const bucket = covenByFamiliar.get(entry.familiar_id) ?? [];
+    bucket.push(entry);
+    covenByFamiliar.set(entry.familiar_id, bucket);
+  }
+
+  const totalCovenByFamiliar = new Map<string, number>();
+  for (const entry of covenEntries) {
+    if (!matchesQuery([entry.title, entry.excerpt, entry.familiar_id, entry.path], q)) continue;
+    totalCovenByFamiliar.set(
+      entry.familiar_id,
+      (totalCovenByFamiliar.get(entry.familiar_id) ?? 0) + 1,
+    );
+  }
+
+  for (const familiar of familiars) {
+    const hubId = `familiar:${familiar.id}`;
+    const entries = covenByFamiliar.get(familiar.id) ?? [];
+    const latestAt = entries[0]?.updated_at;
+    nodes.push({
+      kind: "hub",
+      hubKind: "familiar",
+      id: hubId,
+      label: familiar.display_name ?? familiar.name ?? familiar.id,
+      glyph: familiar.icon ?? familiar.emoji,
+      familiarId: familiar.id,
+      memoryCount: totalCovenByFamiliar.get(familiar.id) ?? 0,
+      latestAt,
+    });
+    addCappedLeaves({
+      hubId,
+      familiarId: familiar.id,
+      source: "coven",
+      entries,
+      maxLeavesPerHub,
+      nodes,
+      edges,
+      toMemoryNode: (entry) => {
+        const coven = entry as MemoryGraphCovenEntry;
+        return {
+          kind: "memory",
+          id: memoryIdForCoven(coven),
+          source: "coven",
+          hubId,
+          familiarId: coven.familiar_id,
+          title: coven.title,
+          path: coven.path,
+          updatedAt: coven.updated_at,
+          excerpt: coven.excerpt,
+        };
+      },
+    });
+    hiddenEntries += Math.max(entries.length - maxLeavesPerHub, 0);
+  }
+
+  if (matchingFiles.length > 0 || fileEntries.length > 0) {
+    nodes.push({
+      kind: "hub",
+      hubKind: "files",
+      id: FILE_HUB_ID,
+      label: "Memory Files",
+      glyph: "ph:file-text",
+      memoryCount: matchingFiles.length,
+      latestAt: matchingFiles[0]?.modified,
+    });
+    addCappedLeaves({
+      hubId: FILE_HUB_ID,
+      source: "file",
+      entries: matchingFiles,
+      maxLeavesPerHub,
+      nodes,
+      edges,
+      toMemoryNode: (entry) => {
+        const file = entry as MemoryGraphFileEntry;
+        return {
+          kind: "memory",
+          id: memoryIdForFile(file),
+          source: "file",
+          hubId: FILE_HUB_ID,
+          title: compactFileTitle(file),
+          path: file.fullPath,
+          updatedAt: file.modified,
+          rootLabel: file.rootLabel,
+          relPath: file.relPath,
+        };
+      },
+    });
+    hiddenEntries += Math.max(matchingFiles.length - maxLeavesPerHub, 0);
+  }
+
+  return {
+    nodes,
+    edges,
+    metrics: {
+      familiarHubs: familiars.length,
+      fileHubs: fileEntries.length > 0 ? 1 : 0,
+      visibleCovenEntries: matchingCovenEntries.length,
+      visibleFileEntries: matchingFiles.length,
+      hiddenEntries,
+    },
+  };
+}
+
+export function memorySelectionObjectKey(selection: MemoryGraphSelection): string | null {
+  if (!selection) return null;
+  if (selection.kind === "familiar") return `hub:familiar:${selection.id}`;
+  if (selection.kind === "files") return `hub:${FILE_HUB_ID}`;
+  if (selection.kind === "memory") return `memory:${selection.id}`;
+  return `cluster:${selection.id}`;
+}
+
+function hubSortKey(node: MemoryGraphHubNode): string {
+  return node.hubKind === "files" ? "zzzz" : node.label.toLowerCase();
+}
+
+function fibonacciHemispherePosition({
+  center,
+  index,
+  count,
+  radius,
+  phase,
+  orbitScale = 1,
+}: {
+  center: ScenePosition;
+  index: number;
+  count: number;
+  radius: number;
+  phase: number;
+  orbitScale?: number;
+}): ScenePosition {
+  const goldenAngle = Math.PI * (3 - Math.sqrt(5));
+  const normalized = count <= 1 ? 0.5 : (index + 0.5) / count;
+  const y = 1 - normalized * 0.92;
+  const horizontal = Math.sqrt(Math.max(0, 1 - y * y));
+  const theta = goldenAngle * index + phase;
+  const scaledRadius = radius * orbitScale;
+  return pos(
+    positionAdd(center.x, Math.cos(theta) * horizontal * scaledRadius),
+    positionAdd(center.y, y * scaledRadius - 0.28),
+    positionAdd(center.z, Math.sin(theta) * horizontal * scaledRadius),
+  );
+}
+
+export function buildMemoryGraphSceneModel(graph: MemoryGraph): MemoryGraphSceneModel {
+  const hubs = graph.nodes
+    .filter((node): node is MemoryGraphHubNode => node.kind === "hub")
+    .sort((a, b) => hubSortKey(a).localeCompare(hubSortKey(b)));
+  const hubCount = Math.max(hubs.length, 1);
+  const ringRadius = hubCount <= 2 ? 3.5 : Math.max(4.2, Math.min(8.2, 3.2 + hubCount * 0.52));
+  const hubPositions = new Map<string, ScenePosition>();
+
+  hubs.forEach((hub, index) => {
+    const angle = hubCount === 1 ? -Math.PI / 2 : (index / hubCount) * Math.PI * 2 - Math.PI / 2;
+    const filesLift = hub.hubKind === "files" ? -0.8 : 0;
+    hubPositions.set(
+      hub.id,
+      pos(Math.cos(angle) * ringRadius, filesLift + Math.sin(index * 1.2) * 0.24, Math.sin(angle) * ringRadius),
+    );
+  });
+
+  const childrenByHub = new Map<string, MemoryGraphChildNode[]>();
+  for (const node of graph.nodes) {
+    if (node.kind === "hub") continue;
+    const bucket = childrenByHub.get(node.hubId) ?? [];
+    bucket.push(node);
+    childrenByHub.set(node.hubId, bucket);
+  }
+
+  const sceneNodes: MemoryGraphSceneNode[] = [];
+  for (const hub of hubs) {
+    const hubPosition = hubPositions.get(hub.id) ?? pos(0, 0, 0);
+    sceneNodes.push({
+      ...hub,
+      label: hub.label,
+      position: hubPosition,
+      radius: hub.hubKind === "files" ? 0.48 : 0.56 + Math.min(hub.memoryCount, 24) * 0.01,
+      color: hub.hubKind === "files" ? "#38bdf8" : "#8E3DFF",
+      memoryCount: hub.memoryCount,
+    });
+
+    const children = childrenByHub.get(hub.id) ?? [];
+    const shellRadius = hub.hubKind === "files" ? 1.65 : 1.35 + Math.min(children.length, 18) * 0.025;
+    children.forEach((child, index) => {
+      const orbitScale = child.kind === "cluster" ? 1.16 : 1;
+      const position = fibonacciHemispherePosition({
+        center: hubPosition,
+        index,
+        count: Math.max(children.length, 1),
+        radius: shellRadius,
+        phase: hub.id.length * 0.17,
+        orbitScale,
+      });
+      sceneNodes.push({
+        ...child,
+        label: child.kind === "memory" ? child.title : child.label,
+        position,
+        radius: child.kind === "memory" && child.source === "file" ? 0.18 : child.kind === "memory" ? 0.2 : 0.32,
+        color: child.kind === "memory" && child.source === "file" ? "#38bdf8" : child.kind === "memory" ? "#62d08f" : "#f59e0b",
+        memoryCount: child.kind === "cluster" ? child.count : 1,
+      });
+    });
+  }
+
+  const nodeById = new Map(sceneNodes.map((node) => [node.id, node]));
+  const sceneEdges = graph.edges.flatMap((edge): MemoryGraphSceneEdge[] => {
+    const source = nodeById.get(edge.source);
+    const target = nodeById.get(edge.target);
+    if (!source || !target) return [];
+    return [{
+      ...edge,
+      from: source.position,
+      to: target.position,
+      color: source.kind === "memory" && source.source === "file" ? "#38bdf8" : source.kind === "memory" ? "#62d08f" : "#f59e0b",
+      opacity: source.kind === "cluster" ? 0.42 : 0.28,
+    }];
+  });
+
+  return { nodes: sceneNodes, edges: sceneEdges };
+}
+
+function positionAdd(base: number, offset: number): number {
+  return Math.round((base + offset) * 1000) / 1000;
+}


### PR DESCRIPTION
## Summary

Adds a dedicated **Memory Constellation** 3D graph view to the Memories panel, alongside the existing list mode.

### What's new

**Model layer** `src/lib/memory-graph-3d-model.ts`
- Two-stage build: semantic graph (`buildMemoryGraphModel`) → layout scene (`buildMemoryGraphSceneModel`)
- Familiar hub nodes arranged in a ring; neutral `Memory Files` hub for local file entries
- Capped leaves per hub (default 30) with cluster overflow nodes ("+N older")
- Fibonacci-style upper hemisphere placement for child shells
- Familiar filter with dimming — non-selected nodes fade back
- Selection key helper (`memorySelectionObjectKey`) for raycaster ↔ data sync

**3D Viewer** `src/components/memory-graph-3d.tsx`
- Three.js canvas: OrbitControls, raycaster picking, InstancedMesh for leaf performance
- Hover tooltip with title + excerpt preview
- Constellation legend (familiar / coven / files / cluster color keys)
- Density warning overlay when entries exceed leaf cap
- Reduced-motion guard, full dispose-on-unmount, reset-view button

**Memory view integration** `src/components/agents-memory-view.tsx`
- List / Graph toggle in panel header
- Graph mode: canvas left, xl right-rail index panel with scrollable entry list
- Filter synced bidirectionally (graph hub click ↔ dropdown)
- No regressions to list mode

**Dev tooling**
- Smoke component `src/components/memory-graph-3d-smoke.tsx`
- Dev route `src/app/dev/memory-graph-3d/`
- Model unit tests: `src/lib/memory-graph-3d-model.test.ts` + `src/components/agents-memory-graph.test.ts`

### Verification
- `pnpm typecheck` clean
- Model tests pass (`npx tsx`)
- `pnpm build` clean
- No conflicts with `main` (`77ad67f`)