### PR TITLE
fix(memory): focus graph on one agent

### DIFF
--- a/src/components/agents-memory-graph.test.ts
+++ b/src/components/agents-memory-graph.test.ts
@@ -28,8 +28,20 @@ assert.match(
 
 assert.match(
   memoryViewSource,
-  /onSelectFamiliar=\{\(familiarId\) => setFamiliarFilter\(familiarId\)\}/,
-  "Clicking a familiar hub should sync the existing familiar filter",
+  /<option key=\{familiar\.id\} value=\{familiar\.id\}>/,
+  "Memory graph should choose one familiar at a time instead of offering an all-familiars graph",
+);
+
+assert.match(
+  memoryViewSource,
+  /resolveMemoryFamiliarFilter/,
+  "Memory graph should repair blank initial selections when another familiar has memory",
+);
+
+assert.match(
+  memoryViewSource,
+  /maxLeavesPerHub:\s*24/,
+  "Memory graph should cluster dense agent memories before the first-frame card field gets too tall",
 );
 
 assert.match(
@@ -56,9 +68,15 @@ assert.match(
   "MemoryGraph3D should use InstancedMesh for memory leaves",
 );
 
+assert.doesNotMatch(
+  graphSource,
+  /SphereGeometry/,
+  "MemoryGraph3D should avoid sphere geometry for the memory map",
+);
+
 assert.match(
   graphSource,
-  /aria-label="3D memory constellation"/,
+  /aria-label="3D familiar memory map"/,
   "MemoryGraph3D should expose an accessible canvas label",
 );
 
@@ -68,10 +86,10 @@ assert.match(
   "MemoryGraph3D should respect reduced motion preferences",
 );
 
-assert.match(
+assert.doesNotMatch(
   modelSource,
   /hub:memory-files/,
-  "The model should preserve filesystem memory entries under a neutral Memory Files hub",
+  "The graph model should not render a cross-agent/global memory files hub",
 );
 
 assert.doesNotMatch(

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
 import type { Familiar } from "@/lib/types";
 import { MemoryGraph3D } from "@/components/memory-graph-3d";
-import { buildMemoryGraphModel } from "@/lib/memory-graph-3d-model";
+import { buildMemoryGraphModel, resolveMemoryFamiliarFilter } from "@/lib/memory-graph-3d-model";
 
 type CovenMemoryEntry = {
   id: string;
@@ -75,7 +75,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
   const [covenEntries, setCovenEntries] = useState<CovenMemoryEntry[]>([]);
   const [fileEntries, setFileEntries] = useState<FileMemoryEntry[]>([]);
   const [query, setQuery] = useState("");
-  const [familiarFilter, setFamiliarFilter] = useState<string>("all");
+  const [familiarFilter, setFamiliarFilter] = useState<string>(activeFamiliar?.id ?? familiars[0]?.id ?? "");
   const [viewMode, setViewMode] = useState<"list" | "graph">("list");
   const [error, setError] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
@@ -120,7 +120,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
   const visibleCoven = useMemo(
     () =>
       covenEntries
-        .filter((entry) => familiarFilter === "all" || entry.familiar_id === familiarFilter)
+        .filter((entry) => entry.familiar_id === familiarFilter)
         .filter((entry) => memoryMatches(entry, q))
         .sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1)),
     [covenEntries, familiarFilter, q],
@@ -139,6 +139,23 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
     return familiars.filter((familiar) => ids.has(familiar.id));
   }, [covenEntries, familiars]);
 
+  useEffect(() => {
+    const next = resolveMemoryFamiliarFilter({
+      familiars,
+      covenEntries,
+      currentFamiliarId: familiarFilter,
+      activeFamiliarId: activeFamiliar?.id ?? null,
+    });
+    if (next && next !== familiarFilter) setFamiliarFilter(next);
+  }, [activeFamiliar?.id, covenEntries, familiarFilter, familiars]);
+
+  const selectedFamiliar = familiarById.get(familiarFilter) ?? null;
+  const familiarOptions = useMemo(() => {
+    const options = familiarsWithMemory.length > 0 ? familiarsWithMemory : familiars;
+    if (!selectedFamiliar || options.some((familiar) => familiar.id === selectedFamiliar.id)) return options;
+    return [selectedFamiliar, ...options];
+  }, [familiars, familiarsWithMemory, selectedFamiliar]);
+
   const memoryGraph = useMemo(
     () =>
       buildMemoryGraphModel({
@@ -147,7 +164,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
         fileEntries,
         query,
         familiarFilter,
-        maxLeavesPerHub: familiarFilter === "all" ? 30 : 90,
+        maxLeavesPerHub: 24,
       }),
     [covenEntries, familiarFilter, familiars, fileEntries, query],
   );
@@ -159,10 +176,10 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
           <div>
             <div className="flex items-center gap-2">
               <Icon name="ph:brain-bold" width={15} className="text-[var(--accent-presence)]" />
-              <h2 className="text-[14px] font-semibold text-[var(--text-primary)]">Memories</h2>
+              <h2 className="text-[14px] font-semibold text-[var(--text-primary)]">Agent Memory</h2>
             </div>
             <p className="mt-1 text-[11px] text-[var(--text-muted)]">
-              Comprehensive Coven memory, familiar recall, and local memory files.
+              Focused recall for one agent at a time, with local memory files kept in the list surface.
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -193,15 +210,15 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
 
         <div className="mt-3 grid gap-2 sm:grid-cols-3">
           <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
-            <div className="text-[10px] uppercase tracking-widest text-[var(--text-muted)]">Coven entries</div>
-            <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{covenEntries.length}</div>
+            <div className="text-[10px] uppercase tracking-widest text-[var(--text-muted)]">Agent memories</div>
+            <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{visibleCoven.length}</div>
           </div>
           <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
             <div className="text-[10px] uppercase tracking-widest text-[var(--text-muted)]">Memory files</div>
             <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{fileEntries.length}</div>
           </div>
           <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
-            <div className="text-[10px] uppercase tracking-widest text-[var(--text-muted)]">Familiars</div>
+            <div className="text-[10px] uppercase tracking-widest text-[var(--text-muted)]">Agents with memory</div>
             <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{familiarsWithMemory.length}</div>
           </div>
         </div>
@@ -221,8 +238,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
             onChange={(event) => setFamiliarFilter(event.target.value)}
             className="h-8 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 text-[12px] text-[var(--text-secondary)] outline-none focus:border-[var(--accent-presence)]"
           >
-            <option value="all">All familiars</option>
-            {familiarsWithMemory.map((familiar) => (
+            {familiarOptions.map((familiar) => (
               <option key={familiar.id} value={familiar.id}>{familiar.display_name}</option>
             ))}
           </select>
@@ -244,9 +260,9 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
           <aside className="hidden min-h-0 xl:block">
             <div className="mb-2 flex items-center justify-between">
               <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">
-                {familiarFilter === "all" ? "Constellation index" : familiarById.get(familiarFilter)?.display_name ?? familiarFilter}
+                {selectedFamiliar?.display_name ?? "Selected agent"}
               </h3>
-              <span className="text-[10px] text-[var(--text-muted)]">{visibleCoven.length + visibleFiles.length} visible</span>
+              <span className="text-[10px] text-[var(--text-muted)]">{visibleCoven.length} visible</span>
             </div>
             <div className="max-h-[640px] overflow-y-auto rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/25">
               {visibleCoven.slice(0, 18).map((entry) => (
@@ -263,23 +279,9 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile }
                   </span>
                 </button>
               ))}
-              {visibleFiles.slice(0, 18).map((entry) => (
-                <button
-                  key={entry.fullPath}
-                  type="button"
-                  onClick={() => onOpenMemoryFile?.(entry.fullPath)}
-                  className="flex w-full items-start gap-2 border-b border-[var(--border-hairline)] px-3 py-2 text-left hover:bg-[var(--bg-raised)]"
-                >
-                  <Icon name="ph:file-text" width={13} className="mt-0.5 shrink-0 text-[var(--text-muted)]" />
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate text-[12px] text-[var(--text-primary)]">{entry.relPath}</span>
-                    <span className="mt-0.5 block truncate text-[10px] text-[var(--text-muted)]">{entry.rootLabel} · {age(entry.modified)}</span>
-                  </span>
-                </button>
-              ))}
-              {visibleCoven.length + visibleFiles.length === 0 ? (
+              {visibleCoven.length === 0 ? (
                 <div className="px-3 py-8 text-center text-[12px] text-[var(--text-muted)]">
-                  {loaded ? "No memories match this constellation." : "Loading memories..."}
+                  {loaded ? "No memories match this agent view." : "Loading memories..."}
                 </div>
               ) : null}
             </div>

--- a/src/components/agents-view.test.ts
+++ b/src/components/agents-view.test.ts
@@ -92,8 +92,8 @@ assert.match(
 
 assert.match(
   agentsMemoryView,
-  /Coven entries[\s\S]*Memory files[\s\S]*Familiars/,
-  "Agents memory view should summarize all memory sources",
+  /Agent memories[\s\S]*Memory files[\s\S]*Agents with memory/,
+  "Agents memory view should summarize the focused agent surface and supporting file source",
 );
 
 assert.match(

--- a/src/components/memory-graph-3d-smoke.tsx
+++ b/src/components/memory-graph-3d-smoke.tsx
@@ -17,10 +17,18 @@ const covenEntries = [
   {
     id: "smoke-nova-1",
     familiar_id: "nova",
-    title: "Nova remembers the constellation architecture",
-    path: "/Users/buns/.coven/memory/nova/constellation.md",
+    title: "Nova remembers the agent memory map architecture",
+    path: "/Users/buns/.coven/memory/nova/memory-map.md",
     updated_at: now,
-    excerpt: "Anchor familiar hubs and keep the list as the retrieval surface.",
+    excerpt: "Focus one agent at a time and keep the list as the retrieval surface.",
+  },
+  {
+    id: "smoke-nova-2",
+    familiar_id: "nova",
+    title: "Nova remembers the review decision",
+    path: "/Users/buns/.coven/memory/nova/review.md",
+    updated_at: now,
+    excerpt: "Avoid spheres and show memory as cards in a focused field.",
   },
   {
     id: "smoke-cody-1",
@@ -52,7 +60,7 @@ const fileEntries = [
 ];
 
 export function MemoryGraph3DSmoke() {
-  const [selectedFamiliarId, setSelectedFamiliarId] = useState("all");
+  const [selectedFamiliarId, setSelectedFamiliarId] = useState("nova");
   const familiars = useMemo(() => new Map(familiarsList.map((familiar) => [familiar.id, familiar])), []);
   const graph = useMemo(
     () =>

--- a/src/components/memory-graph-3d.tsx
+++ b/src/components/memory-graph-3d.tsx
@@ -107,16 +107,14 @@ function disposeObject(object: THREE.Object3D) {
 
 function colorFor(node: MemoryGraphSceneNode, selectedFamiliarId: string): THREE.Color {
   const color = new THREE.Color(node.color);
-  if (selectedFamiliarId === "all") return color;
   const belongsToSelected =
     (node.kind === "hub" && node.familiarId === selectedFamiliarId) ||
     (node.kind !== "hub" && node.familiarId === selectedFamiliarId);
   if (belongsToSelected) return color;
-  return color.lerp(new THREE.Color("#1a1722"), 0.72);
+  return color.lerp(new THREE.Color("#201927"), 0.42);
 }
 
 function nodeIsDimmed(node: MemoryGraphSceneNode, selectedFamiliarId: string): boolean {
-  if (selectedFamiliarId === "all") return false;
   if (node.kind === "hub") return node.hubKind === "familiar" && node.familiarId !== selectedFamiliarId;
   return node.familiarId !== selectedFamiliarId;
 }
@@ -161,15 +159,15 @@ export function MemoryGraph3D({
     const scene = new THREE.Scene();
     scene.fog = new THREE.FogExp2(0x07070d, 0.042);
     const camera = new THREE.PerspectiveCamera(48, 1, 0.1, 90);
-    camera.position.set(0, 5.8, sceneModel.nodes.length <= 4 ? 10 : 14);
-    camera.lookAt(0, 0, 0);
+    camera.position.set(0.3, 4.5, sceneModel.nodes.length <= 4 ? 8.2 : 10.2);
+    camera.lookAt(-0.45, 0.22, 0);
 
     const controls = new OrbitControls(camera, canvas);
     controls.enableDamping = true;
     controls.dampingFactor = 0.08;
-    controls.minDistance = 5.5;
-    controls.maxDistance = 24;
-    controls.target.set(0, 0, 0);
+    controls.minDistance = 4.8;
+    controls.maxDistance = 18;
+    controls.target.set(-0.45, 0.22, 0);
     controls.saveState();
 
     const root = new THREE.Group();
@@ -187,9 +185,7 @@ export function MemoryGraph3D({
     const hubs = sceneModel.nodes.filter((node) => node.kind === "hub");
     const leaves = sceneModel.nodes.filter((node) => node.kind === "memory");
     const clusters = sceneModel.nodes.filter((node) => node.kind === "cluster");
-    const hubById = new Map(hubs.map((hub) => [hub.id, hub]));
-
-    const grid = new THREE.GridHelper(18, 18, 0x2c2440, 0x151520);
+    const grid = new THREE.GridHelper(12, 12, 0x2c2440, 0x151520);
     grid.position.y = -2.35;
     root.add(grid);
 
@@ -204,9 +200,7 @@ export function MemoryGraph3D({
     }
 
     for (const hub of hubs) {
-      const geometry = hub.hubKind === "files"
-        ? new THREE.IcosahedronGeometry(hub.radius, 1)
-        : new THREE.SphereGeometry(hub.radius, 32, 24);
+      const geometry = new THREE.BoxGeometry(1.18, 1.72, 0.28);
       const material = new THREE.MeshStandardMaterial({
         color: 0x17131f,
         emissive: colorFor(hub, selectedFamiliarId),
@@ -221,20 +215,20 @@ export function MemoryGraph3D({
       pickables.push(mesh);
 
       const halo = new THREE.Mesh(
-        new THREE.RingGeometry(hub.radius + 0.13, hub.radius + 0.2 + Math.min(hub.memoryCount, 30) * 0.004, 56),
+        new THREE.PlaneGeometry(1.58 + Math.min(hub.memoryCount, 28) * 0.012, 2.1),
         new THREE.MeshBasicMaterial({
           color: colorFor(hub, selectedFamiliarId),
           transparent: true,
-          opacity: nodeIsDimmed(hub, selectedFamiliarId) ? 0.16 : 0.46,
+          opacity: nodeIsDimmed(hub, selectedFamiliarId) ? 0.08 : 0.18,
           side: THREE.DoubleSide,
         }),
       );
-      halo.position.copy(asVector(hub.position));
+      halo.position.copy(asVector(hub.position).add(new THREE.Vector3(0, 0, -0.08)));
       halo.userData.billboard = true;
       root.add(halo);
 
       const label = makeLabelSprite(
-        hub.hubKind === "files" ? hub.label : familiars.get(hub.familiarId ?? "")?.display_name ?? hub.label,
+        familiars.get(hub.familiarId ?? "")?.display_name ?? hub.label,
         nodeIsDimmed(hub, selectedFamiliarId) ? "#7d748c" : "#f7f1ff",
       );
       label.position.copy(asVector(hub.position).add(new THREE.Vector3(0, hub.radius + 0.55, 0)));
@@ -242,37 +236,40 @@ export function MemoryGraph3D({
     }
 
     if (leaves.length > 0) {
-      const geometry = new THREE.SphereGeometry(1, 12, 10);
-      const material = new THREE.MeshStandardMaterial({
-        color: 0xffffff,
-        emissive: 0xffffff,
-        emissiveIntensity: 0.18,
-        vertexColors: true,
-        roughness: 0.55,
-        metalness: 0.05,
+      const geometry = new THREE.BoxGeometry(1.14, 0.44, 0.08);
+      const material = new THREE.MeshBasicMaterial({
+        color: 0x62d08f,
+        transparent: true,
+        opacity: 0.86,
       });
       const instanced = new THREE.InstancedMesh(geometry, material, leaves.length);
       const matrix = new THREE.Matrix4();
       leaves.forEach((node, index) => {
+        const tilt = new THREE.Quaternion().setFromEuler(new THREE.Euler(0.02 * Math.cos(index), 0.08 * Math.sin(index), 0.02 * Math.cos(index)));
         matrix.compose(
           asVector(node.position),
-          new THREE.Quaternion(),
-          new THREE.Vector3(node.radius, node.radius, node.radius),
+          tilt,
+          new THREE.Vector3(1, 1, 1),
         );
         instanced.setMatrixAt(index, matrix);
-        instanced.setColorAt(index, colorFor(node, selectedFamiliarId));
       });
       instanced.instanceMatrix.needsUpdate = true;
-      if (instanced.instanceColor) instanced.instanceColor.needsUpdate = true;
       instanced.userData.nodes = leaves;
       root.add(instanced);
       pickables.push(instanced as Pickable);
+
+      leaves.slice(0, 6).forEach((node) => {
+        const label = makeLabelSprite(node.label, "#dffbea");
+        label.scale.set(1.72, 0.42, 1);
+        label.position.copy(asVector(node.position).add(new THREE.Vector3(0, 0.46, 0)));
+        root.add(label);
+      });
     }
 
     for (const cluster of clusters) {
       const color = colorFor(cluster, selectedFamiliarId);
       const mesh = new THREE.Mesh(
-        new THREE.SphereGeometry(cluster.radius, 20, 14),
+        new THREE.BoxGeometry(1.24, 0.16, 0.64),
         new THREE.MeshStandardMaterial({
           color: 0x1e1820,
           emissive: color,
@@ -312,8 +309,8 @@ export function MemoryGraph3D({
     const resetView = () => {
       controls.reset();
       root.rotation.set(-0.18, 0, 0);
-      camera.position.set(0, 5.8, sceneModel.nodes.length <= 4 ? 10 : 14);
-      camera.lookAt(0, 0, 0);
+      camera.position.set(0.3, 4.5, sceneModel.nodes.length <= 4 ? 8.2 : 10.2);
+      camera.lookAt(-0.45, 0.22, 0);
       controls.update();
     };
     resetRef.current = resetView;
@@ -362,15 +359,15 @@ export function MemoryGraph3D({
       setPointer(event);
       const node = hitNode();
       if (!node) {
-        onSelectFamiliar("all");
+        resetRef.current?.();
       } else if (node.kind === "hub") {
-        onSelectFamiliar(node.familiarId ?? "all");
+        if (node.familiarId) onSelectFamiliar(node.familiarId);
       } else if (node.kind === "memory") {
         onOpenMemoryFile?.(node.path);
       } else if (node.familiarId) {
         onSelectFamiliar(node.familiarId);
       } else {
-        onSelectFamiliar("all");
+        resetRef.current?.();
       }
     };
     const onPointerLeave = () => setHover(null);
@@ -426,19 +423,17 @@ export function MemoryGraph3D({
     };
   }, [familiars, graph, onOpenMemoryFile, onSelectFamiliar, reducedMotion, sceneModel, selectedFamiliarId]);
 
-  const selectedLabel = selectedFamiliarId === "all"
-    ? `${graph.metrics.visibleCovenEntries + graph.metrics.visibleFileEntries} memories in constellation.`
-    : `Selected familiar ${familiars.get(selectedFamiliarId)?.display_name ?? selectedFamiliarId}.`;
+  const selectedLabel = `Selected agent ${familiars.get(selectedFamiliarId)?.display_name ?? selectedFamiliarId}; ${graph.metrics.visibleCovenEntries} memories in view.`;
 
   const onKeyDown = (event: KeyboardEvent<HTMLCanvasElement>) => {
-    if (event.key === "Escape") onSelectFamiliar("all");
+    if (event.key === "Escape") resetRef.current?.();
     if (event.key === "Home") resetRef.current?.();
   };
 
   if (sceneModel.nodes.length === 0) {
     return (
       <div className="grid min-h-[420px] flex-1 place-items-center bg-[oklch(0.11_0.022_293)] text-sm text-white/55">
-        No memories in this constellation.
+        No memories for this agent.
       </div>
     );
   }
@@ -448,7 +443,7 @@ export function MemoryGraph3D({
       <canvas
         ref={canvasRef}
         data-testid="memory-graph-3d-canvas"
-        aria-label="3D memory constellation"
+        aria-label="3D familiar memory map"
         role="application"
         tabIndex={0}
         onKeyDown={onKeyDown}
@@ -457,11 +452,10 @@ export function MemoryGraph3D({
       <p aria-live="polite" className="sr-only">{selectedLabel}</p>
       <div className="pointer-events-none absolute inset-x-0 top-0 flex flex-wrap items-start justify-between gap-3 p-3">
         <div className="rounded-lg border border-white/10 bg-black/45 px-3 py-2 shadow-2xl backdrop-blur">
-          <div className="text-[10px] font-semibold uppercase tracking-widest text-white/55">Memory constellation</div>
+          <div className="text-[10px] font-semibold uppercase tracking-widest text-white/55">Agent memory map</div>
           <div className="mt-1 flex flex-wrap gap-2 text-[10px] text-white/70">
-            <span>{graph.metrics.familiarHubs} familiars</span>
-            <span>{graph.metrics.visibleCovenEntries} coven</span>
-            <span>{graph.metrics.visibleFileEntries} files</span>
+            <span>{familiars.get(selectedFamiliarId)?.display_name ?? selectedFamiliarId}</span>
+            <span>{graph.metrics.visibleCovenEntries} memories</span>
           </div>
         </div>
         <button
@@ -474,14 +468,13 @@ export function MemoryGraph3D({
         </button>
       </div>
       <div className="pointer-events-none absolute bottom-3 left-3 flex flex-wrap items-center gap-2 rounded-lg border border-white/10 bg-black/45 px-3 py-2 text-[10px] text-white/65 shadow-2xl backdrop-blur">
-        <span className="inline-flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-[#8E3DFF]" /> familiar</span>
-        <span className="inline-flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-[#62d08f]" /> coven</span>
-        <span className="inline-flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-[#38bdf8]" /> files</span>
-        <span className="inline-flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-[#f59e0b]" /> cluster</span>
+        <span className="inline-flex items-center gap-1"><i className="h-2 w-3 rounded-sm bg-[#8E3DFF]" /> agent</span>
+        <span className="inline-flex items-center gap-1"><i className="h-2 w-3 rounded-sm bg-[#62d08f]" /> memory card</span>
+        <span className="inline-flex items-center gap-1"><i className="h-2 w-3 rounded-sm bg-[#f59e0b]" /> older stack</span>
       </div>
       {graph.metrics.hiddenEntries > 0 ? (
         <div className="pointer-events-none absolute right-3 top-16 max-w-[260px] rounded-lg border border-[color-mix(in_oklch,var(--color-warning)_25%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_18%,transparent)] px-3 py-2 text-[10px] text-[var(--color-warning)] shadow-2xl backdrop-blur">
-          Dense constellation: {graph.metrics.hiddenEntries} older memories are clustered.
+          Dense memory: {graph.metrics.hiddenEntries} older entries are stacked.
         </div>
       ) : null}
       {hover ? <MemoryGraphTooltip hover={hover} familiars={familiars} /> : null}
@@ -497,12 +490,12 @@ function MemoryGraphTooltip({
   familiars: Map<string, Familiar>;
 }) {
   const { node } = hover;
-  const familiarName = node.familiarId ? familiars.get(node.familiarId)?.display_name ?? node.familiarId : "Memory Files";
+  const familiarName = node.familiarId ? familiars.get(node.familiarId)?.display_name ?? node.familiarId : "Memory";
   const detail = node.kind === "hub"
     ? `${node.memoryCount} memories`
     : node.kind === "cluster"
       ? `${node.count} older memories`
-      : `${familiarName} · ${node.source === "file" ? node.rootLabel ?? "file" : "coven"} · ${compactAge(node.updatedAt)}`;
+      : `${familiarName} · ${compactAge(node.updatedAt)}`;
 
   return (
     <div

--- a/src/lib/memory-graph-3d-model.test.ts
+++ b/src/lib/memory-graph-3d-model.test.ts
@@ -4,6 +4,7 @@ import {
   buildMemoryGraphModel,
   buildMemoryGraphSceneModel,
   memorySelectionObjectKey,
+  resolveMemoryFamiliarFilter,
 } from "./memory-graph-3d-model.ts";
 
 const familiars = [
@@ -52,20 +53,21 @@ const graph = buildMemoryGraphModel({
   covenEntries,
   fileEntries,
   query: "",
-  familiarFilter: "all",
+  familiarFilter: "nova",
   maxLeavesPerHub: 1,
 });
 
 const familiarHubs = graph.nodes.filter((node) => node.kind === "hub" && node.hubKind === "familiar");
 assert.deepEqual(
   familiarHubs.map((node) => node.id),
-  ["familiar:nova", "familiar:cody"],
-  "all familiar hubs should render even when their visible memory leaf count is capped",
+  ["familiar:nova"],
+  "memory graph should render one selected familiar hub instead of a cross-agent constellation",
 );
 
-assert.ok(
-  graph.nodes.some((node) => node.kind === "hub" && node.hubKind === "files" && node.label === "Memory Files"),
-  "filesystem memory entries should be represented under a neutral Memory Files hub",
+assert.equal(
+  graph.nodes.some((node) => node.kind === "hub" && node.hubKind === "files"),
+  false,
+  "agent-level memory graph should not render a global Memory Files hub",
 );
 
 assert.ok(
@@ -73,15 +75,10 @@ assert.ok(
   "coven memory leaves should connect to their familiar hub",
 );
 
-assert.ok(
-  graph.edges.some((edge) => edge.source.startsWith("memory:file:") && edge.target === "hub:memory-files"),
-  "filesystem memory leaves should connect to the neutral files hub",
-);
-
 assert.equal(
-  graph.nodes.find((node) => node.kind === "memory" && node.source === "file")?.familiarId,
-  undefined,
-  "filesystem memory leaves must not fake a familiar relationship",
+  graph.nodes.some((node) => node.kind === "memory" && node.source === "file"),
+  false,
+  "agent-level memory graph should not render filesystem leaves",
 );
 
 assert.equal(
@@ -122,10 +119,76 @@ assert.ok(novaLeaf, "scene model should include memory leaf positions");
 assert.notDeepEqual(
   novaHub?.position,
   novaLeaf?.position,
-  "memory leaves should be positioned on a shell around their hub, not on top of it",
+  "memory leaves should be positioned in a focused agent-level field, not on top of the hub",
 );
 assert.equal(
   scene.nodes.find((node) => node.id === "familiar:nova")?.memoryCount,
   2,
   "hub memory count should reflect total matching entries before visual leaf caps",
+);
+assert.ok(
+  Math.min(...scene.nodes.filter((node) => node.kind !== "hub").map((node) => node.position.x)) > (novaHub?.position.x ?? 0),
+  "memory cards should fan forward from the selected familiar instead of orbiting around multiple agents",
+);
+
+assert.equal(
+  resolveMemoryFamiliarFilter({
+    familiars: [
+      { id: "empty", display_name: "Empty", role: "Quiet" },
+      ...familiars,
+    ],
+    covenEntries,
+    currentFamiliarId: "empty",
+    activeFamiliarId: null,
+  }),
+  "nova",
+  "initial memory selection should prefer a familiar with memory over a blank default familiar",
+);
+
+assert.equal(
+  resolveMemoryFamiliarFilter({
+    familiars: [
+      { id: "empty", display_name: "Empty", role: "Quiet" },
+      ...familiars,
+    ],
+    covenEntries,
+    currentFamiliarId: "empty",
+    activeFamiliarId: "empty",
+  }),
+  "empty",
+  "explicit active familiar selection should be preserved even when that familiar has no memory",
+);
+
+const denseEntries = Array.from({ length: 96 }, (_, index) => ({
+  id: `dense-${index}`,
+  familiar_id: "nova",
+  title: `Dense memory ${index}`,
+  path: `/Users/buns/.coven/memory/nova/dense-${index}.md`,
+  updated_at: `2026-06-08T05:${String(59 - (index % 60)).padStart(2, "0")}:00.000Z`,
+}));
+
+const denseGraph = buildMemoryGraphModel({
+  familiars,
+  covenEntries: denseEntries,
+  fileEntries,
+  query: "",
+  familiarFilter: "nova",
+  maxLeavesPerHub: 24,
+});
+const denseScene = buildMemoryGraphSceneModel(denseGraph);
+const denseCardY = denseScene.nodes.filter((node) => node.kind === "memory").map((node) => node.position.y);
+
+assert.equal(
+  denseGraph.nodes.filter((node) => node.kind === "memory").length,
+  24,
+  "dense memory maps should cluster before the card field exceeds the initial camera framing",
+);
+assert.equal(
+  denseGraph.nodes.find((node) => node.kind === "cluster")?.count,
+  72,
+  "dense memory maps should expose older entries as a stack when cards are capped",
+);
+assert.ok(
+  Math.max(...denseCardY) <= 3,
+  "dense memory card fields should stay within the first-frame vertical framing",
 );

--- a/src/lib/memory-graph-3d-model.ts
+++ b/src/lib/memory-graph-3d-model.ts
@@ -110,8 +110,6 @@ export type MemoryGraphSceneModel = {
 
 export type ScenePosition = { x: number; y: number; z: number };
 
-const FILE_HUB_ID = "hub:memory-files";
-
 function matchesQuery(values: Array<string | undefined>, query: string): boolean {
   if (!query) return true;
   return values.some((value) => (value ?? "").toLowerCase().includes(query));
@@ -121,16 +119,34 @@ function compareIsoDesc(a?: string, b?: string): number {
   return (b ?? "").localeCompare(a ?? "");
 }
 
-function compactFileTitle(entry: MemoryGraphFileEntry): string {
-  return entry.relPath || entry.fullPath.split("/").pop() || entry.fullPath;
-}
-
-function memoryIdForFile(entry: MemoryGraphFileEntry): string {
-  return `memory:file:${entry.fullPath}`;
-}
-
 function memoryIdForCoven(entry: MemoryGraphCovenEntry): string {
   return `memory:coven:${entry.id}`;
+}
+
+export function resolveMemoryFamiliarFilter({
+  familiars,
+  covenEntries,
+  currentFamiliarId,
+  activeFamiliarId,
+}: {
+  familiars: Familiar[];
+  covenEntries: MemoryGraphCovenEntry[];
+  currentFamiliarId: string;
+  activeFamiliarId?: string | null;
+}): string {
+  const familiarIds = new Set(familiars.map((familiar) => familiar.id));
+  if (activeFamiliarId && familiarIds.has(activeFamiliarId)) return activeFamiliarId;
+
+  const familiarsWithMemory = new Set(covenEntries.map((entry) => entry.familiar_id));
+  if (
+    currentFamiliarId &&
+    familiarIds.has(currentFamiliarId) &&
+    (familiarsWithMemory.size === 0 || familiarsWithMemory.has(currentFamiliarId))
+  ) {
+    return currentFamiliarId;
+  }
+
+  return familiars.find((familiar) => familiarsWithMemory.has(familiar.id))?.id ?? familiars[0]?.id ?? "";
 }
 
 function edgeId(source: string, target: string): string {
@@ -203,7 +219,7 @@ function addCappedLeaves({
 export function buildMemoryGraphModel({
   familiars,
   covenEntries,
-  fileEntries,
+  fileEntries: _fileEntries,
   query = "",
   familiarFilter = "all",
   maxLeavesPerHub = 30,
@@ -220,54 +236,40 @@ export function buildMemoryGraphModel({
   const edges: MemoryGraphEdge[] = [];
   let hiddenEntries = 0;
 
+  const selectedFamiliarId = familiarFilter !== "all"
+    ? familiarFilter
+    : covenEntries.find((entry) => matchesQuery([entry.title, entry.excerpt, entry.familiar_id, entry.path], q))?.familiar_id ?? familiars[0]?.id;
+  const selectedFamiliar = familiars.find((familiar) => familiar.id === selectedFamiliarId);
+
   const matchingCovenEntries = covenEntries
-    .filter((entry) => familiarFilter === "all" || entry.familiar_id === familiarFilter)
+    .filter((entry) => entry.familiar_id === selectedFamiliarId)
     .filter((entry) =>
       matchesQuery([entry.title, entry.excerpt, entry.familiar_id, entry.path], q),
     )
     .sort((a, b) => compareIsoDesc(a.updated_at, b.updated_at));
 
-  const matchingFiles = fileEntries
-    .filter((entry) =>
-      matchesQuery([entry.rootLabel, entry.relPath, entry.fullPath], q),
-    )
-    .sort((a, b) => compareIsoDesc(a.modified, b.modified));
+  const totalMatchingForFamiliar = covenEntries.filter((entry) =>
+    entry.familiar_id === selectedFamiliarId &&
+    matchesQuery([entry.title, entry.excerpt, entry.familiar_id, entry.path], q),
+  ).length;
 
-  const covenByFamiliar = new Map<string, MemoryGraphCovenEntry[]>();
-  for (const entry of matchingCovenEntries) {
-    const bucket = covenByFamiliar.get(entry.familiar_id) ?? [];
-    bucket.push(entry);
-    covenByFamiliar.set(entry.familiar_id, bucket);
-  }
-
-  const totalCovenByFamiliar = new Map<string, number>();
-  for (const entry of covenEntries) {
-    if (!matchesQuery([entry.title, entry.excerpt, entry.familiar_id, entry.path], q)) continue;
-    totalCovenByFamiliar.set(
-      entry.familiar_id,
-      (totalCovenByFamiliar.get(entry.familiar_id) ?? 0) + 1,
-    );
-  }
-
-  for (const familiar of familiars) {
-    const hubId = `familiar:${familiar.id}`;
-    const entries = covenByFamiliar.get(familiar.id) ?? [];
-    const latestAt = entries[0]?.updated_at;
+  if (selectedFamiliar) {
+    const hubId = `familiar:${selectedFamiliar.id}`;
     nodes.push({
       kind: "hub",
       hubKind: "familiar",
       id: hubId,
-      label: familiar.display_name ?? familiar.name ?? familiar.id,
-      glyph: familiar.icon ?? familiar.emoji,
-      familiarId: familiar.id,
-      memoryCount: totalCovenByFamiliar.get(familiar.id) ?? 0,
-      latestAt,
+      label: selectedFamiliar.display_name ?? selectedFamiliar.name ?? selectedFamiliar.id,
+      glyph: selectedFamiliar.icon ?? selectedFamiliar.emoji,
+      familiarId: selectedFamiliar.id,
+      memoryCount: totalMatchingForFamiliar,
+      latestAt: matchingCovenEntries[0]?.updated_at,
     });
     addCappedLeaves({
       hubId,
-      familiarId: familiar.id,
+      familiarId: selectedFamiliar.id,
       source: "coven",
-      entries,
+      entries: matchingCovenEntries,
       maxLeavesPerHub,
       nodes,
       edges,
@@ -286,52 +288,17 @@ export function buildMemoryGraphModel({
         };
       },
     });
-    hiddenEntries += Math.max(entries.length - maxLeavesPerHub, 0);
-  }
-
-  if (matchingFiles.length > 0 || fileEntries.length > 0) {
-    nodes.push({
-      kind: "hub",
-      hubKind: "files",
-      id: FILE_HUB_ID,
-      label: "Memory Files",
-      glyph: "ph:file-text",
-      memoryCount: matchingFiles.length,
-      latestAt: matchingFiles[0]?.modified,
-    });
-    addCappedLeaves({
-      hubId: FILE_HUB_ID,
-      source: "file",
-      entries: matchingFiles,
-      maxLeavesPerHub,
-      nodes,
-      edges,
-      toMemoryNode: (entry) => {
-        const file = entry as MemoryGraphFileEntry;
-        return {
-          kind: "memory",
-          id: memoryIdForFile(file),
-          source: "file",
-          hubId: FILE_HUB_ID,
-          title: compactFileTitle(file),
-          path: file.fullPath,
-          updatedAt: file.modified,
-          rootLabel: file.rootLabel,
-          relPath: file.relPath,
-        };
-      },
-    });
-    hiddenEntries += Math.max(matchingFiles.length - maxLeavesPerHub, 0);
+    hiddenEntries += Math.max(matchingCovenEntries.length - maxLeavesPerHub, 0);
   }
 
   return {
     nodes,
     edges,
     metrics: {
-      familiarHubs: familiars.length,
-      fileHubs: fileEntries.length > 0 ? 1 : 0,
+      familiarHubs: selectedFamiliar ? 1 : 0,
+      fileHubs: 0,
       visibleCovenEntries: matchingCovenEntries.length,
-      visibleFileEntries: matchingFiles.length,
+      visibleFileEntries: 0,
       hiddenEntries,
     },
   };
@@ -340,58 +307,18 @@ export function buildMemoryGraphModel({
 export function memorySelectionObjectKey(selection: MemoryGraphSelection): string | null {
   if (!selection) return null;
   if (selection.kind === "familiar") return `hub:familiar:${selection.id}`;
-  if (selection.kind === "files") return `hub:${FILE_HUB_ID}`;
+  if (selection.kind === "files") return null;
   if (selection.kind === "memory") return `memory:${selection.id}`;
   return `cluster:${selection.id}`;
 }
 
-function hubSortKey(node: MemoryGraphHubNode): string {
-  return node.hubKind === "files" ? "zzzz" : node.label.toLowerCase();
-}
-
-function fibonacciHemispherePosition({
-  center,
-  index,
-  count,
-  radius,
-  phase,
-  orbitScale = 1,
-}: {
-  center: ScenePosition;
-  index: number;
-  count: number;
-  radius: number;
-  phase: number;
-  orbitScale?: number;
-}): ScenePosition {
-  const goldenAngle = Math.PI * (3 - Math.sqrt(5));
-  const normalized = count <= 1 ? 0.5 : (index + 0.5) / count;
-  const y = 1 - normalized * 0.92;
-  const horizontal = Math.sqrt(Math.max(0, 1 - y * y));
-  const theta = goldenAngle * index + phase;
-  const scaledRadius = radius * orbitScale;
-  return pos(
-    positionAdd(center.x, Math.cos(theta) * horizontal * scaledRadius),
-    positionAdd(center.y, y * scaledRadius - 0.28),
-    positionAdd(center.z, Math.sin(theta) * horizontal * scaledRadius),
-  );
-}
-
 export function buildMemoryGraphSceneModel(graph: MemoryGraph): MemoryGraphSceneModel {
   const hubs = graph.nodes
-    .filter((node): node is MemoryGraphHubNode => node.kind === "hub")
-    .sort((a, b) => hubSortKey(a).localeCompare(hubSortKey(b)));
-  const hubCount = Math.max(hubs.length, 1);
-  const ringRadius = hubCount <= 2 ? 3.5 : Math.max(4.2, Math.min(8.2, 3.2 + hubCount * 0.52));
+    .filter((node): node is MemoryGraphHubNode => node.kind === "hub");
   const hubPositions = new Map<string, ScenePosition>();
 
-  hubs.forEach((hub, index) => {
-    const angle = hubCount === 1 ? -Math.PI / 2 : (index / hubCount) * Math.PI * 2 - Math.PI / 2;
-    const filesLift = hub.hubKind === "files" ? -0.8 : 0;
-    hubPositions.set(
-      hub.id,
-      pos(Math.cos(angle) * ringRadius, filesLift + Math.sin(index * 1.2) * 0.24, Math.sin(angle) * ringRadius),
-    );
+  hubs.forEach((hub) => {
+    hubPositions.set(hub.id, pos(-2.25, 0, 0));
   });
 
   const childrenByHub = new Map<string, MemoryGraphChildNode[]>();
@@ -409,29 +336,31 @@ export function buildMemoryGraphSceneModel(graph: MemoryGraph): MemoryGraphScene
       ...hub,
       label: hub.label,
       position: hubPosition,
-      radius: hub.hubKind === "files" ? 0.48 : 0.56 + Math.min(hub.memoryCount, 24) * 0.01,
-      color: hub.hubKind === "files" ? "#38bdf8" : "#8E3DFF",
+      radius: 0.72 + Math.min(hub.memoryCount, 24) * 0.008,
+      color: "#8E3DFF",
       memoryCount: hub.memoryCount,
     });
 
     const children = childrenByHub.get(hub.id) ?? [];
-    const shellRadius = hub.hubKind === "files" ? 1.65 : 1.35 + Math.min(children.length, 18) * 0.025;
+    const columns = Math.min(4, Math.max(1, Math.ceil(Math.sqrt(children.length || 1))));
+    const rowGap = 0.82;
+    const colGap = 1.28;
     children.forEach((child, index) => {
-      const orbitScale = child.kind === "cluster" ? 1.16 : 1;
-      const position = fibonacciHemispherePosition({
-        center: hubPosition,
-        index,
-        count: Math.max(children.length, 1),
-        radius: shellRadius,
-        phase: hub.id.length * 0.17,
-        orbitScale,
-      });
+      const row = Math.floor(index / columns);
+      const col = index % columns;
+      const rowWidth = Math.min(columns, children.length - row * columns);
+      const colOffset = col - (rowWidth - 1) / 2;
+      const position = pos(
+        positionAdd(hubPosition.x, 1.75 + row * rowGap * 0.42),
+        positionAdd(hubPosition.y, -0.35 + row * rowGap * 0.72),
+        positionAdd(hubPosition.z, colOffset * colGap + Math.sin(index * 1.7) * 0.08),
+      );
       sceneNodes.push({
         ...child,
         label: child.kind === "memory" ? child.title : child.label,
         position,
-        radius: child.kind === "memory" && child.source === "file" ? 0.18 : child.kind === "memory" ? 0.2 : 0.32,
-        color: child.kind === "memory" && child.source === "file" ? "#38bdf8" : child.kind === "memory" ? "#62d08f" : "#f59e0b",
+        radius: child.kind === "memory" ? 0.36 : 0.48,
+        color: child.kind === "memory" ? "#62d08f" : "#f59e0b",
         memoryCount: child.kind === "cluster" ? child.count : 1,
       });
     });
@@ -446,7 +375,7 @@ export function buildMemoryGraphSceneModel(graph: MemoryGraph): MemoryGraphScene
       ...edge,
       from: source.position,
       to: target.position,
-      color: source.kind === "memory" && source.source === "file" ? "#38bdf8" : source.kind === "memory" ? "#62d08f" : "#f59e0b",
+      color: source.kind === "memory" ? "#62d08f" : "#f59e0b",
       opacity: source.kind === "cluster" ? 0.42 : 0.28,
     }];
   });


### PR DESCRIPTION
## Summary
- Reworks the Memory graph from a cross-agent constellation into a one-agent-at-a-time memory map driven by the selected familiar.
- Removes the global Memory Files hub and keeps filesystem memory files in the list surface instead of the 3D graph.
- Replaces sphere-style graph objects with agent slabs, memory cards, and older-entry stacks, with updated copy, ARIA, and focused guards.

## Verification
- `node src/lib/memory-graph-3d-model.test.ts && node src/components/agents-memory-graph.test.ts && node src/components/agents-view.test.ts && node src/components/calls-view-graph.test.ts && node src/components/trace-graph-3d-model.test.ts`
- `pnpm typecheck`
- `git diff --check`
- `pnpm build`
- Playwright smoke screenshots on `/dev/memory-graph-3d` at 1280x800 and 390x844 using the local webpack dev server

## Notes
- Build still prints the repo's existing worktree-root / NFT warning and the guard scripts still print the existing Node module-type warning; the commands exited 0.
