### PR TITLE
feat(settings): add sky theme preset

### DIFF
--- a/src/app/globals-background.test.ts
+++ b/src/app/globals-background.test.ts
@@ -1,0 +1,17 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const globals = await readFile(new URL("./globals.css", import.meta.url), "utf8");
+
+assert.match(
+  globals,
+  /--background:\s*oklch\(0\.07 0\.004 293\);/,
+  "Default Coven Cave background should stay on the darker Mood C foundation",
+);
+
+assert.match(
+  globals,
+  /--bg-base:\s*var\(--background\);/,
+  "Base shell surfaces should inherit the default background token",
+);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2140,7 +2140,7 @@ body {
 .right-panel-close:hover { color: var(--text-primary); background: var(--bg-hover); }
 
 /* ============================================================
-   Preset themes — Midnight + Orchid
+   Preset themes — Midnight + Orchid + Sky
    Applied via data-theme attribute on <html>.
    Mood C (default) lives in :root above.
    ============================================================ */
@@ -2192,5 +2192,32 @@ body {
   --border-strong: oklch(1 0 0 / 12%);
   --ring: oklch(0.60 0.12 293);
   --ring-focus: color-mix(in oklch, #D26BFF 55%, transparent);
+  --brand: var(--accent-presence);
+}
+
+[data-theme="sky"] {
+  /* Cool slate-blue night. Hue pinned to 245 so surfaces, panels, and the
+     daybreak accent all sit on the same blue axis (mirrors how the other
+     presets pin to 293 violet). */
+  --background: oklch(0.15 0.028 245);
+  --card: oklch(0.18 0.028 245);
+  --muted: oklch(0.23 0.030 245);
+  --accent-presence: #6DA9FF;
+
+  /* Keep aliases in sync */
+  --bg-base: var(--background);
+  --bg-raised: var(--card);
+  --bg-panel: oklch(0.13 0.026 245);
+  --bg-elevated: oklch(0.25 0.032 245);
+  --bg-hover: oklch(0.28 0.034 245);
+  --secondary: oklch(0.25 0.030 245);
+  --secondary-foreground: oklch(0.985 0 0);
+  --accent: oklch(0.25 0.030 245);
+  --popover: oklch(0.18 0.028 245);
+  --muted-foreground: oklch(0.70 0.028 245);
+  --border: oklch(1 0 0 / 7%);
+  --border-strong: oklch(1 0 0 / 12%);
+  --ring: oklch(0.62 0.14 245);
+  --ring-focus: color-mix(in oklch, #6DA9FF 55%, transparent);
   --brand: var(--accent-presence);
 }

--- a/src/components/settings-appearance.test.ts
+++ b/src/components/settings-appearance.test.ts
@@ -43,6 +43,30 @@ assert.match(
 
 assert.match(
   themeScript,
-  /existingStyle\.endsWith\(";"\)/,
-  "ThemeScript should preserve valid CSS when appending custom vars to existing inline style",
+  /html\.style\.setProperty\(cssName, group\[name\]\)/,
+  "ThemeScript should apply custom vars via setProperty so existing inline styles are preserved",
+);
+
+assert.match(
+  themeScript,
+  /applyGroup\(cssVars\.theme\)[\s\S]*applyGroup\(cssVars\.dark\)/,
+  "ThemeScript should apply both theme-level (fonts/radius) and dark-mode CSS var groups",
+);
+
+assert.match(
+  themeScript,
+  /name\.indexOf\("--"\) === 0 \? name : "--" \+ name/,
+  "ThemeScript should accept tweakcn's bare-name keys by prefixing -- when missing",
+);
+
+assert.match(
+  settings,
+  /apply\(cssVars\.theme\)[\s\S]*apply\(cssVars\.dark\)/,
+  "applyCustomVars should apply both theme-level and dark-mode CSS var groups, not just a whitelist",
+);
+
+assert.match(
+  settings,
+  /name\.startsWith\("--"\) \? name : `--\$\{name\}`/,
+  "applyCustomVars should accept tweakcn's bare-name keys by prefixing -- when missing",
 );

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -335,33 +335,28 @@ function FamiliarsSection() {
 
 // ─── Theme helpers ───────────────────────────────────────────────────────────────────────
 
-type PresetTheme = "mood-c" | "midnight" | "orchid";
+type PresetTheme = "mood-c" | "midnight" | "orchid" | "sky";
 type ActiveTheme = PresetTheme | "custom";
 
 interface CustomThemeData {
   name: string;
-  cssVars: { light?: Record<string, string>; dark?: Record<string, string> };
+  cssVars: {
+    theme?: Record<string, string>;
+    light?: Record<string, string>;
+    dark?: Record<string, string>;
+  };
 }
 
-const CSS_VAR_MAP: Record<string, string> = {
-  "--background": "--background",
-  "--foreground": "--foreground",
-  "--card": "--card",
-  "--primary": "--primary",
-  "--muted": "--muted",
-  "--muted-foreground": "--muted-foreground",
-  "--border": "--border",
-  "--accent": "--accent",
-  "--ring": "--ring",
-  "--secondary": "--secondary",
-};
+function clearCustomCssVars(html: HTMLElement) {
+  const style = html.getAttribute("style") ?? "";
+  const cleaned = style.replace(/--[\w-]+\s*:[^;]+;?/g, "").trim();
+  if (cleaned) html.setAttribute("style", cleaned);
+  else html.removeAttribute("style");
+}
 
 function applyPreset(theme: PresetTheme) {
   const html = document.documentElement;
-  const style = html.getAttribute("style") ?? "";
-  const cleaned = style.replace(/--[\w-]+:[^;]+;/g, "").trim();
-  if (cleaned) html.setAttribute("style", cleaned);
-  else html.removeAttribute("style");
+  clearCustomCssVars(html);
 
   if (theme === "mood-c") {
     html.removeAttribute("data-theme");
@@ -371,14 +366,25 @@ function applyPreset(theme: PresetTheme) {
   localStorage.setItem("coven-theme", theme);
 }
 
-function applyCustomVars(vars: Record<string, string>) {
+function applyCustomVars(cssVars: CustomThemeData["cssVars"]) {
   const html = document.documentElement;
   html.removeAttribute("data-theme");
-  let style = "";
-  for (const [src, dest] of Object.entries(CSS_VAR_MAP)) {
-    if (vars[src]) style += `${dest}:${vars[src]};`;
-  }
-  html.setAttribute("style", style);
+  clearCustomCssVars(html);
+
+  const apply = (group?: Record<string, string>) => {
+    if (!group) return;
+    for (const [name, value] of Object.entries(group)) {
+      if (typeof value !== "string" || !name) continue;
+      // tweakcn returns bare names ("background", "font-sans"); shadcn schema
+      // does not prefix with --. We prefix here when needed.
+      const cssName = name.startsWith("--") ? name : `--${name}`;
+      html.style.setProperty(cssName, value);
+    }
+  };
+  // theme: mode-agnostic vars (fonts, radius, shadows, tracking).
+  // dark: mode-specific colors (the app runs dark-only).
+  apply(cssVars.theme);
+  apply(cssVars.dark);
 }
 
 function clearCustomTheme() {
@@ -415,6 +421,12 @@ const PRESETS: ThemePreset[] = [
     label: "Orchid",
     description: "Warm violet, lighter surface",
     swatches: { bg: "oklch(0.13 0.030 293)", accent: "#D26BFF", border: "oklch(1 0 0 / 7%)" },
+  },
+  {
+    id: "sky",
+    label: "Sky",
+    description: "Cool slate-blue night, daybreak accent",
+    swatches: { bg: "oklch(0.15 0.028 245)", accent: "#6DA9FF", border: "oklch(1 0 0 / 7%)" },
   },
 ];
 
@@ -519,6 +531,11 @@ function AppearanceSection() {
         if (themeId)
           return `https://tweakcn.com/r/themes/${encodeURIComponent(themeId)}`;
       }
+      if (url.pathname.startsWith("/themes/")) {
+        const themeId = url.pathname.replace("/themes/", "").split("/")[0];
+        if (themeId)
+          return `https://tweakcn.com/r/themes/${encodeURIComponent(themeId)}`;
+      }
       if (url.pathname.startsWith("/editor/theme")) {
         const themeName = url.searchParams.get("theme")?.trim();
         if (themeName)
@@ -535,7 +552,7 @@ function AppearanceSection() {
     const canonical = normalizeTweakcnUrl(importUrl);
     if (!canonical) {
       setImportError(
-        "Invalid tweakcn URL. Expected https://tweakcn.com/r/themes/{id} or /editor/theme?theme={name}.",
+        "Invalid tweakcn URL. Expected https://tweakcn.com/themes/{id}, /r/themes/{id}, or /editor/theme?theme={name}.",
       );
       return;
     }
@@ -547,19 +564,20 @@ function AppearanceSection() {
 
       // biome-ignore lint/suspicious/noExplicitAny: tweakcn response shape
       const json = (await res.json()) as any;
-      if (!json?.cssVars?.dark || typeof json.cssVars.dark !== "object") {
-        throw new Error("Response missing cssVars.dark — not a valid tweakcn theme JSON.");
+      const cssVars = json?.cssVars;
+      const hasTheme = cssVars?.theme && typeof cssVars.theme === "object";
+      const hasDark = cssVars?.dark && typeof cssVars.dark === "object";
+      const hasLight = cssVars?.light && typeof cssVars.light === "object";
+      if (!cssVars || (!hasTheme && !hasDark && !hasLight)) {
+        throw new Error("Response missing cssVars — not a valid tweakcn theme JSON.");
       }
 
       const data: CustomThemeData = {
         name: (json.name as string) || canonical.split("/").pop() || "custom",
-        cssVars: json.cssVars as {
-          light?: Record<string, string>;
-          dark?: Record<string, string>;
-        },
+        cssVars: cssVars as CustomThemeData["cssVars"],
       };
 
-      applyCustomVars(data.cssVars.dark as Record<string, string>);
+      applyCustomVars(data.cssVars);
       localStorage.setItem("coven-custom-theme", JSON.stringify(data));
       localStorage.setItem("coven-theme", "custom");
       setCustomData(data);
@@ -616,9 +634,13 @@ function AppearanceSection() {
           <p className="text-[12px] text-[var(--text-muted)]">
             Paste a tweakcn URL to apply a community theme. Supports{" "}
             <code className="rounded bg-[var(--bg-raised)] px-1 py-0.5 font-mono text-[11px]">
+              /themes/&#123;id&#125;
+            </code>
+            ,{" "}
+            <code className="rounded bg-[var(--bg-raised)] px-1 py-0.5 font-mono text-[11px]">
               /r/themes/&#123;id&#125;
-            </code>{" "}
-            and{" "}
+            </code>
+            , and{" "}
             <code className="rounded bg-[var(--bg-raised)] px-1 py-0.5 font-mono text-[11px]">
               /editor/theme?theme=&#123;name&#125;
             </code>

--- a/src/components/theme-script.tsx
+++ b/src/components/theme-script.tsx
@@ -7,8 +7,8 @@
  * Strategy:
  *  1. Read localStorage["coven-theme"]  (preset id or "custom")
  *  2. If preset — set data-theme on <html>
- *  3. If custom  — read localStorage["coven-custom-theme"] and inject
- *     the dark CSS vars as inline style on <html>
+ *  3. If custom  — read localStorage["coven-custom-theme"] and apply
+ *     every CSS var from cssVars.theme + cssVars.dark via setProperty.
  */
 
 const THEME_SCRIPT = `
@@ -17,7 +17,7 @@ const THEME_SCRIPT = `
     var theme = localStorage.getItem("coven-theme");
     if (!theme || theme === "mood-c") return; // default :root handles it
 
-    if (theme === "midnight" || theme === "orchid") {
+    if (theme === "midnight" || theme === "orchid" || theme === "sky") {
       document.documentElement.setAttribute("data-theme", theme);
       return;
     }
@@ -26,33 +26,20 @@ const THEME_SCRIPT = `
       var raw = localStorage.getItem("coven-custom-theme");
       if (!raw) return;
       var data = JSON.parse(raw);
-      var vars = data.cssVars && data.cssVars.dark ? data.cssVars.dark : null;
-      if (!vars) return;
-      var MAP = {
-        "--background": "--background",
-        "--foreground": "--foreground",
-        "--card": "--card",
-        "--primary": "--primary",
-        "--muted": "--muted",
-        "--muted-foreground": "--muted-foreground",
-        "--border": "--border",
-        "--accent": "--accent",
-        "--ring": "--ring",
-        "--secondary": "--secondary"
-      };
-      var style = "";
-      for (var src in MAP) {
-        if (vars[src]) {
-          style += MAP[src] + ":" + vars[src] + ";";
+      var cssVars = data && data.cssVars;
+      if (!cssVars) return;
+      var html = document.documentElement;
+      function applyGroup(group) {
+        if (!group || typeof group !== "object") return;
+        for (var name in group) {
+          if (!Object.prototype.hasOwnProperty.call(group, name)) continue;
+          if (typeof group[name] !== "string" || !name) continue;
+          var cssName = name.indexOf("--") === 0 ? name : "--" + name;
+          try { html.style.setProperty(cssName, group[name]); } catch (e) {}
         }
       }
-      if (style) {
-        var existingStyle = document.documentElement.getAttribute("style") || "";
-        if (existingStyle && !existingStyle.endsWith(";")) existingStyle += ";";
-        document.documentElement.setAttribute("style",
-          existingStyle + style
-        );
-      }
+      applyGroup(cssVars.theme);
+      applyGroup(cssVars.dark);
     }
   } catch (e) {}
 })();


### PR DESCRIPTION
## Summary
- add the Sky preset to Appearance alongside Mood C, Midnight, and Orchid
- support current tweakcn theme URLs and apply theme-level plus dark CSS vars
- preserve custom vars through startup ThemeScript using style.setProperty

## Verification
- node --experimental-strip-types src/components/settings-appearance.test.ts
- node --experimental-strip-types src/app/globals-background.test.ts
- pnpm typecheck
- git diff --check
- pnpm build

Note: pnpm build still reports the existing Turbopack NFT warning from next.config.ts -> api/library/doc.