### PR TITLE
chore(build): silence all 7 Turbopack file-pattern warnings

### DIFF
--- a/src/app/api/library/doc/route.ts
+++ b/src/app/api/library/doc/route.ts
@@ -84,7 +84,11 @@ export async function GET(req: NextRequest) {
 
   let stat: fs.Stats;
   try {
-    stat = fs.statSync(resolved);
+    // `resolved` is validated to live under an allowed root above. The
+    // turbopackIgnore comment stops Next from tracing the dynamic path as
+    // a build-relative file pattern, which otherwise matches the entire
+    // project tree.
+    stat = fs.statSync(/* turbopackIgnore: true */ resolved);
   } catch {
     return NextResponse.json({ ok: false, error: "file not found" }, { status: 404 });
   }
@@ -102,7 +106,7 @@ export async function GET(req: NextRequest) {
 
   let content: string;
   try {
-    content = fs.readFileSync(resolved, "utf-8");
+    content = fs.readFileSync(/* turbopackIgnore: true */ resolved, "utf-8");
   } catch {
     return NextResponse.json({ ok: false, error: "read failed" }, { status: 500 });
   }

--- a/src/app/api/library/route.ts
+++ b/src/app/api/library/route.ts
@@ -219,8 +219,10 @@ export async function GET(req: NextRequest) {
     const resolvedFile = resolveResearchPath(file, researchRoot);
     if (!resolvedFile) continue;
     try {
-      const stat = fs.statSync(resolvedFile);
-      const content = fs.readFileSync(resolvedFile, "utf-8");
+      // resolvedFile is validated under researchRoot above. turbopackIgnore
+      // prevents Next from tracing the dynamic path into the build manifest.
+      const stat = fs.statSync(/* turbopackIgnore: true */ resolvedFile);
+      const content = fs.readFileSync(/* turbopackIgnore: true */ resolvedFile, "utf-8");
       const { frontmatter, body } = parseFrontmatter(content);
       docs.push({
         id: path.relative(familiar.root, resolvedFile),

--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -68,7 +68,10 @@ export async function GET() {
   }
   for (const idx of MEMORY_INDEX_FILES) {
     try {
-      const s = await stat(idx);
+      // idx is one of the absolute homedir-prefixed paths in
+      // MEMORY_INDEX_FILES. turbopackIgnore prevents bundling all matching
+      // candidates as static patterns.
+      const s = await stat(/* turbopackIgnore: true */ idx);
       entries.push({
         root: "index",
         rootLabel: "Index",

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -78,7 +78,12 @@ function candidateDirs(): string[] {
 }
 
 function loginShellPath(): string | null {
-  const shell = process.env.SHELL || "/bin/zsh";
+  // Read SHELL through a deliberately opaque accessor so Turbopack's static
+  // analysis can't union the value with a string literal like "/bin/zsh"
+  // and treat it as a file pattern that matches the whole project tree.
+  // The fallback below uses a runtime concatenation for the same reason.
+  const env = process.env as Record<string, string | undefined>;
+  const shell = env["SHELL"] ?? ["/bin", "zsh"].join("/");
   try {
     const out = execFileSync(shell, ["-ilc", "echo $PATH"], {
       encoding: "utf-8",


### PR DESCRIPTION
## Summary

- `pnpm build` warning count: **7 → 0**
- Add `/* turbopackIgnore: true */` to dynamic `fs.statSync`/`readFileSync`/`stat` calls in `src/app/api/library/{doc/,}route.ts` and `src/app/api/memory/route.ts` (paths are user-controlled and validated against allowed roots; Turbopack was treating them as build-relative patterns that matched ~21k files)
- Rewrite `loginShellPath` in `src/lib/coven-bin.ts` to read `process.env.SHELL` through an opaque Record indexer with a runtime-joined fallback — drops the static `/bin/zsh` literal Turbopack was unioning into the bundle and incidentally clears the downstream `next.config.ts` NFT-trace warning

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `node --test --experimental-strip-types src/lib/*.test.ts src/components/*.test.ts src/middleware.test.ts src/proxy-behavior.test.ts` — 77/77 pass
- [x] `pnpm build` — compiles in ~5.6s with **zero warnings**
- [ ] Manually launch the dev server, hit `/api/onboarding/status` to confirm the SHELL probe still resolves a PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)