### PR TITLE
fix(familiar-studio): clear merge blockers

### DIFF
--- a/scripts/smoke-familiar-studio-extras.mjs
+++ b/scripts/smoke-familiar-studio-extras.mjs
@@ -13,7 +13,7 @@
 // Run: node scripts/smoke-familiar-studio-extras.mjs
 // Pre-flight: caller MUST have backed up ~/.coven/cave-config.json.
 
-import { chromium } from "playwright";
+import { chromium } from "@playwright/test";
 import { writeFile, readFile, mkdir } from "node:fs/promises";
 import { resolve, join } from "node:path";
 import { homedir } from "node:os";
@@ -21,6 +21,7 @@ import { homedir } from "node:os";
 const OUT = "/tmp/familiar-studio-smoke-extras";
 const CONFIG_PATH = join(homedir(), ".coven", "cave-config.json");
 const BACKUP_PATH = "/tmp/cave-config.backup.json";
+const BASE_URL = process.env.COVEN_CAVE_SMOKE_URL ?? "http://localhost:3000";
 
 const results = [];
 function rec(step, status, detail = "") {
@@ -91,7 +92,7 @@ async function main() {
     if (msg.type() === "error") consoleErrors.push(msg.text());
   });
 
-  await page.goto("http://localhost:3000", {
+  await page.goto(BASE_URL, {
     waitUntil: "domcontentloaded",
     timeout: 60_000,
   });

--- a/scripts/smoke-familiar-studio.mjs
+++ b/scripts/smoke-familiar-studio.mjs
@@ -1,23 +1,24 @@
-// Drive a headless Chromium against http://localhost:3000 and run the
+// Drive a headless Chromium against a running Cave dev server and run the
 // Familiar Studio smoke checklist from the PR description for
 // feat/familiar-studio (#218).
 //
 // Run: node scripts/smoke-familiar-studio.mjs
 //
 // Requires:
-//   - pnpm dev already running on :3000
+//   - pnpm dev already running on :3000, or set COVEN_CAVE_SMOKE_URL
 //   - NEXT_PUBLIC_DEMO=true so the rail has seeded familiars
 //
 // Output: prints PASS/FAIL per checklist step. Screenshots are written to
 // /tmp/familiar-studio-smoke/ for forensic inspection.
 
-import { chromium } from "playwright";
+import { chromium } from "@playwright/test";
 import { mkdir, writeFile, readFile } from "node:fs/promises";
 import { resolve, join } from "node:path";
 import { homedir } from "node:os";
 
 const OUT = "/tmp/familiar-studio-smoke";
 const VIEWPORT = { width: 1440, height: 900 };
+const BASE_URL = process.env.COVEN_CAVE_SMOKE_URL ?? "http://localhost:3000";
 
 const results = [];
 function rec(step, status, detail = "") {
@@ -67,7 +68,7 @@ async function main() {
     if (msg.type() === "error") consoleErrors.push("[console] " + msg.text());
   });
 
-  await page.goto("http://localhost:3000", { waitUntil: "domcontentloaded", timeout: 60_000 });
+  await page.goto(BASE_URL, { waitUntil: "domcontentloaded", timeout: 60_000 });
   await page.waitForTimeout(3500); // hydrate + initial data
 
   // Dismiss any onboarding "Open Cave" if it slipped through.
@@ -219,7 +220,7 @@ async function main() {
   await page.waitForTimeout(300);
 
   // ─── Step 9: Archive hides familiar from rail ───────────────────────
-  const archiveBtn = page.locator(".familiar-studio-lifecycle__btn").filter({ hasText: /^archive$/i }).first();
+  const archiveBtn = page.locator(".familiar-studio-lifecycle__btn").filter({ hasText: /^\s*archive\s*$/i }).first();
   const railBefore = await avatars.count();
   if (await archiveBtn.count() > 0) {
     await archiveBtn.click();
@@ -277,21 +278,30 @@ async function main() {
   await page.waitForTimeout(200);
   await shot(page, "12-right-click");
 
-  // ─── Step 12: Right-click + button opens list view ──────────────────
+  // ─── Step 12: Right-click + button exposes manage action ────────────
   const addBtn = page.locator(".familiar-avatar-rail__add").first();
   if (await addBtn.count() > 0) {
     await addBtn.click({ button: "right" });
     await page.waitForTimeout(300);
+    const addMenu = page.locator(".familiar-avatar-rail__add-menu").first();
+    const manageItem = page.locator(".familiar-avatar-rail__add-menu-item").filter({ hasText: /manage familiars/i }).first();
+    if (await addMenu.isVisible().catch(() => false) && await manageItem.count() > 0) {
+      rec("Right-click + opens actions menu", "PASS");
+      await manageItem.click();
+      await page.waitForTimeout(300);
+    } else {
+      rec("Right-click + opens actions menu", "FAIL");
+    }
     if (await drawer.isVisible()) {
       const activeTabText3 = (await activeTab.first().textContent() || "").trim();
-      if (/lifecycle/i.test(activeTabText3)) rec("Right-click + opens list view (Lifecycle tab)", "PASS");
-      else rec("Right-click + opens list view (Lifecycle tab)", "FAIL", `active=${activeTabText3}`);
+      if (/lifecycle/i.test(activeTabText3)) rec("Manage familiars opens list view (Lifecycle tab)", "PASS");
+      else rec("Manage familiars opens list view (Lifecycle tab)", "FAIL", `active=${activeTabText3}`);
       // Non-lifecycle tabs should be disabled
       const identityDisabled = await page.locator(".familiar-studio__tab").filter({ hasText: /identity/i }).first().isDisabled();
       if (identityDisabled) rec("List view disables non-Lifecycle tabs", "PASS");
       else rec("List view disables non-Lifecycle tabs", "FAIL");
     } else {
-      rec("Right-click + opens list view", "FAIL");
+      rec("Manage familiars opens list view", "FAIL");
     }
   } else {
     rec("Add (+) button present", "FAIL");

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -37,6 +37,13 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
   const [capsOpen, setCapsOpen] = useState(false);
 
   useEffect(() => {
+    setDraftHarness(familiar.harness ?? "");
+    setDraftModel(familiar.model ?? "");
+    setDraftNote(familiar.note ?? "");
+    setToast(null);
+  }, [familiar.id, familiar.harness, familiar.model, familiar.note]);
+
+  useEffect(() => {
     let cancelled = false;
     void (async () => {
       try {

--- a/src/components/familiar-studio-identity-tab.tsx
+++ b/src/components/familiar-studio-identity-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Icon } from "@/lib/icon";
 import {
   setFamiliarOverride,
@@ -35,7 +35,7 @@ export function FamiliarStudioIdentityTab({ familiar, rawDaemonValues }: Props) 
     <div className="familiar-studio-identity">
       {FIELDS.map((f) => (
         <IdentityField
-          key={f.key}
+          key={`${familiar.id}:${f.key}`}
           field={f.key}
           label={f.label}
           textarea={f.textarea}
@@ -69,6 +69,10 @@ function IdentityField({
   const [draft, setDraft] = useState(value ?? "");
   const placeholder = daemonValue ?? "—";
   const hasOverride = value !== undefined;
+
+  useEffect(() => {
+    setDraft(value ?? "");
+  }, [field, value]);
 
   function commit() {
     if (draft.trim() === "") {

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -14,6 +14,7 @@ assert.match(source, /process\.env\.COVEN_CAVE_AUTH_TOKEN/, "proxy should requir
 assert.match(source, /process\.env\.COVEN_CAVE_BUNDLE === "1"[\s\S]*missing sidecar auth token/, "bundled sidecar mode should fail closed when its auth token is missing");
 assert.match(source, /req\.headers\.get\("origin"\)/, "middleware should reject unsafe origins");
 assert.match(source, /req\.headers\.get\("host"\)/, "middleware should reject unsafe hosts");
+assert.match(source, /isAllowedApiHost\(req\.headers\.get\("host"\), mobileAccessAuthenticated\)/, "valid mobile access should satisfy the API host gate");
 assert.match(source, /unsupported content-type/, "middleware should reject unsafe content types before body parsing");
 
 // Ordering guard: dev-mode token-bypass (NextResponse.next() when no token is set)
@@ -21,7 +22,7 @@ assert.match(source, /unsupported content-type/, "middleware should reject unsaf
 // the bypass ran first and silently let non-loopback callers through during
 // `pnpm dev` if anything ever bound the dev server outside 127.0.0.1.
 {
-  const hostIdx = source.indexOf('isLoopbackHost(req.headers.get("host"))');
+  const hostIdx = source.indexOf('isAllowedApiHost(req.headers.get("host"), mobileAccessAuthenticated)');
   const originIdx = source.indexOf('sameOrigin(req.headers.get("origin")');
   const refererIdx = source.indexOf('sameOrigin(req.headers.get("referer")');
   const contentTypeIdx = source.indexOf("unsupported content-type");

--- a/src/proxy-behavior.test.ts
+++ b/src/proxy-behavior.test.ts
@@ -16,6 +16,7 @@
 import assert from "node:assert/strict";
 import {
   isLoopbackHost,
+  isAllowedApiHost,
   sameOrigin,
   bearerFromReferer,
   timingSafeEqualString,
@@ -47,6 +48,21 @@ assert.equal(
   isLoopbackHost("localhost.evil.com"),
   false,
   "must not be fooled by subdomain smuggling",
+);
+
+// ─── isAllowedApiHost ──────────────────────────────────────────────────────
+assert.equal(isAllowedApiHost("localhost:3000", false), true);
+assert.equal(isAllowedApiHost("127.0.0.1:3000", false), true);
+assert.equal(isAllowedApiHost("cave.tailnet.example.ts.net", false), false);
+assert.equal(
+  isAllowedApiHost("cave.tailnet.example.ts.net", true),
+  true,
+  "valid mobile access token should allow documented Tailscale hostnames",
+);
+assert.equal(
+  isAllowedApiHost(null, true),
+  true,
+  "mobile token authentication should not depend on a loopback Host header",
 );
 
 // ─── sameOrigin ────────────────────────────────────────────────────────────

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -26,6 +26,10 @@ export function isLoopbackHost(host: string | null) {
   return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1";
 }
 
+export function isAllowedApiHost(host: string | null, mobileAccessAuthenticated = false) {
+  return mobileAccessAuthenticated || isLoopbackHost(host);
+}
+
 export function sameOrigin(value: string | null, expectedOrigin: string) {
   if (!value) return true;
   try {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,6 +8,7 @@ import {
   SAFE_CONTENT_TYPES,
   timingSafeEqualString,
   isLoopbackHost,
+  isAllowedApiHost,
   sameOrigin,
   bearerFromReferer,
 } from "./proxy-helpers";
@@ -17,6 +18,7 @@ import {
 export {
   timingSafeEqualString,
   isLoopbackHost,
+  isAllowedApiHost,
   sameOrigin,
   bearerFromReferer,
 };
@@ -87,6 +89,7 @@ function hasSafeContentType(req: NextRequest) {
 }
 
 export function proxy(req: NextRequest) {
+  const mobileAccessToken = configuredMobileAccessToken();
   const mobileRes = mobileAccessGate(req);
   if (mobileRes) return mobileRes;
 
@@ -102,7 +105,10 @@ export function proxy(req: NextRequest) {
   // 127.0.0.1. The token equality check below is the only thing
   // legitimately optional in browser-dev mode.
   const expectedOrigin = req.nextUrl.origin;
-  if (!isLoopbackHost(req.headers.get("host"))) {
+  const mobileAccessAuthenticated = mobileAccessToken
+    ? hasValidMobileAccessToken(req, mobileAccessToken)
+    : false;
+  if (!isAllowedApiHost(req.headers.get("host"), mobileAccessAuthenticated)) {
     return jsonError(403, "forbidden host");
   }
   if (!sameOrigin(req.headers.get("origin"), expectedOrigin)) {


### PR DESCRIPTION
## Summary

Follow-up after PR #218/#221 were merged while review was still active. This carries the verified blocker fixes onto current main:

- allow valid `COVEN_CAVE_ACCESS_TOKEN` mobile sessions through the API host gate for documented Tailscale hostnames
- reset Familiar Studio Identity and Brain draft state when switching familiars
- make Familiar Studio smoke drivers import the installed Playwright package and support `COVEN_CAVE_SMOKE_URL`
- update the smoke driver for the new `+` actions menu before opening Manage familiars

## Verification

- `node --experimental-strip-types --no-warnings src/proxy-behavior.test.ts`
- `node --experimental-strip-types --no-warnings src/middleware.test.ts`
- `node --experimental-strip-types --no-warnings src/components/familiar-studio-identity-tab.test.ts`
- `node --experimental-strip-types --no-warnings src/components/familiar-studio-brain-tab.test.ts`
- `node --experimental-strip-types --no-warnings src/components/familiar-studio-lifecycle-tab.test.ts`
- `node --experimental-strip-types --no-warnings src/components/familiar-avatar-rail.test.ts`
- `pnpm typecheck`
- `rm -rf .next && pnpm build`
- `HOME=/tmp/coven-cave-blocker-home PLAYWRIGHT_BROWSERS_PATH=/Users/buns/Library/Caches/ms-playwright COVEN_CAVE_SMOKE_URL=http://localhost:3108 node scripts/smoke-familiar-studio.mjs`
- `HOME=/tmp/coven-cave-blocker-home PLAYWRIGHT_BROWSERS_PATH=/Users/buns/Library/Caches/ms-playwright COVEN_CAVE_SMOKE_URL=http://localhost:3108 node scripts/smoke-familiar-studio-extras.mjs`