### PR TITLE
feat(themes): light/dark mode + 8 curated themes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -200,6 +200,16 @@
   --ring-focus: color-mix(in oklch, #6F62A8 55%, transparent);
   --ring-focus-soft: color-mix(in oklch, #6F62A8 30%, transparent);
   --backdrop-scrim: oklch(0 0 0 / 40%);
+
+  /* Semantic state colors retuned for AA contrast on near-white surfaces.
+     The :root values above are tuned for dark backgrounds and read too
+     pale on light. */
+  --color-success: oklch(0.52 0.16 158);
+  --color-success-soft: oklch(0.66 0.10 158);
+  --color-warning: oklch(0.58 0.16 78);
+  --color-warning-soft: oklch(0.72 0.10 78);
+  --color-danger: oklch(0.52 0.20 24);
+  --color-danger-soft: oklch(0.70 0.12 24);
 }
 
 /* Respect OS-level reduced-motion preference by collapsing every

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,14 +21,11 @@
    Reserved for familiar presence dots and the health strip — not
    for primary CTAs.
 
-   Palette v1.2 — Mood C tuned for a professional, sleek dark UI.
-   Surface chroma drops from 0.022 → ~0.005 so the shell reads as
-   refined neutral graphite rather than tinted purple. The cave base
-   sits deep (L≈0.07) for that "near-black, low-light editor" feel,
-   with small lightness steps building hierarchy (panel → card →
-   elevated → hover). Brand hue 293 is preserved in accents so the
-   accent-presence dot still feels OpenCoven without bleeding into
-   every surface. */
+   Palette v1.2 — Coven (default) tuned for editor density at both
+   modes. Dark uses near-black panels with low chroma on surfaces;
+   light mirrors the structure with a near-white panel ladder. Brand
+   hue 293 is preserved in accents so the accent-presence dot still
+   feels OpenCoven without bleeding into every surface. */
 
 :root {
   /* ---- Palette (oklch — same colour science as shadcn) ---- */
@@ -46,9 +43,9 @@
   --muted-foreground: oklch(0.66 0.012 293);
   --accent: oklch(0.17 0.006 293);
   --accent-foreground: oklch(0.985 0 0);
-  --border: oklch(1 0 0 / 5%);
-  --border-strong: oklch(1 0 0 / 9%);
-  --input: oklch(1 0 0 / 8%);
+  --border: color-mix(in oklch, var(--foreground) 12%, transparent);
+  --border-strong: color-mix(in oklch, var(--foreground) 22%, transparent);
+  --input: color-mix(in oklch, var(--foreground) 18%, transparent);
   --ring: oklch(0.55 0.08 293);
 
   /* ---- Coven brand ----
@@ -72,7 +69,7 @@
   --fg-muted: var(--text-secondary);
   --text-primary: var(--foreground);
   --text-secondary: var(--muted-foreground);
-  --text-muted: oklch(0.985 0 0 / 40%);
+  --text-muted: color-mix(in oklch, var(--foreground) 40%, transparent);
 
   /* ---- Radii ---- */
   --radius: 0.625rem;
@@ -161,6 +158,48 @@
 
   /* ---- Surface alphas ---- */
   --backdrop-scrim: oklch(0 0 0 / 60%);
+}
+
+/* ============================================================
+   Coven (default theme) — LIGHT mode palette.
+   :root above holds the DARK palette; this override flips
+   surfaces, foreground, and accents for light mode. Hue and
+   structural tokens (radii, spacing, motion) are inherited.
+   ============================================================ */
+:root[data-mode="light"] {
+  --background: oklch(0.99 0.003 293);
+  --foreground: oklch(0.18 0.006 293);
+  --card: oklch(0.97 0.004 293);
+  --card-foreground: oklch(0.18 0.006 293);
+  --popover: oklch(1.00 0.000 0);
+  --popover-foreground: oklch(0.18 0.006 293);
+  --primary: oklch(0.20 0.006 293);
+  --primary-foreground: oklch(0.99 0.003 293);
+  --secondary: oklch(0.93 0.005 293);
+  --secondary-foreground: oklch(0.18 0.006 293);
+  --muted: oklch(0.93 0.005 293);
+  --muted-foreground: oklch(0.45 0.010 293);
+  --accent: oklch(0.93 0.005 293);
+  --accent-foreground: oklch(0.18 0.006 293);
+  --ring: oklch(0.55 0.10 293);
+
+  --accent-presence: #6F62A8;
+  --accent-presence-soft: oklch(0.55 0.08 295);
+
+  --bg-base: var(--background);
+  --bg-panel: oklch(1.00 0.000 0);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.95 0.005 293);
+  --bg-hover: oklch(0.91 0.005 293);
+
+  --text-primary: var(--foreground);
+  --text-secondary: var(--muted-foreground);
+  /* --border, --border-strong, --input, --text-muted are derived from --foreground;
+     they auto-invert. No override needed. */
+
+  --ring-focus: color-mix(in oklch, #6F62A8 55%, transparent);
+  --ring-focus-soft: color-mix(in oklch, #6F62A8 30%, transparent);
+  --backdrop-scrim: oklch(0 0 0 / 40%);
 }
 
 /* Respect OS-level reduced-motion preference by collapsing every

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2189,86 +2189,270 @@ body {
 .right-panel-close:hover { color: var(--text-primary); background: var(--bg-hover); }
 
 /* ============================================================
-   Preset themes — Midnight + Orchid + Sky
-   Applied via data-theme attribute on <html>.
-   Mood C (default) lives in :root above.
+   Theme palettes — 7 non-default themes (Coven default lives in :root).
+   Each theme ships a DARK and a LIGHT palette. Hue is held constant
+   per theme; chroma is low on surfaces and saved for the accent.
+   Border / input / text-muted derive from --foreground (set in :root)
+   so they don't need per-theme overrides in the common case.
    ============================================================ */
 
-[data-theme="midnight"] {
-  /* Slightly less dark than previous (each surface +~0.02 L) so the deepest
-     theme keeps its mood without crushing UI contrast. */
-  --background: oklch(0.12 0.004 293);
-  --card: oklch(0.15 0.005 293);
-  --muted: oklch(0.20 0.005 293);
-  --accent-presence: #7B73BD;
-
-  /* Keep aliases in sync */
-  --bg-base: var(--background);
-  --bg-raised: var(--card);
-  --bg-panel: oklch(0.11 0.004 293);
-  --bg-elevated: oklch(0.22 0.006 293);
-  --bg-hover: oklch(0.25 0.006 293);
-  --secondary: oklch(0.22 0.005 293);
-  --secondary-foreground: oklch(0.985 0 0);
-  --accent: oklch(0.22 0.005 293);
-  --popover: oklch(0.15 0.005 293);
-  --muted-foreground: oklch(0.64 0.012 293);
-  --border: oklch(1 0 0 / 5%);
-  --border-strong: oklch(1 0 0 / 9%);
-  --ring: oklch(0.52 0.07 293);
-  --ring-focus: color-mix(in oklch, #7B73BD 55%, transparent);
-  --brand: var(--accent-presence);
-}
-
-[data-theme="orchid"] {
-  --background: oklch(0.13 0.030 293);
-  --card: oklch(0.17 0.030 293);
-  --muted: oklch(0.22 0.032 293);
-  --accent-presence: #D26BFF;
-
-  /* Keep aliases in sync */
-  --bg-base: var(--background);
-  --bg-raised: var(--card);
-  --bg-panel: oklch(0.11 0.028 293);
-  --bg-elevated: oklch(0.24 0.034 293);
-  --bg-hover: oklch(0.27 0.036 293);
-  --secondary: oklch(0.24 0.032 293);
-  --secondary-foreground: oklch(0.985 0 0);
-  --accent: oklch(0.24 0.032 293);
-  --popover: oklch(0.17 0.030 293);
-  --muted-foreground: oklch(0.70 0.030 293);
-  --border: oklch(1 0 0 / 7%);
-  --border-strong: oklch(1 0 0 / 12%);
-  --ring: oklch(0.60 0.12 293);
-  --ring-focus: color-mix(in oklch, #D26BFF 55%, transparent);
-  --brand: var(--accent-presence);
-}
-
-[data-theme="sky"] {
-  /* Cool slate-blue night. Hue pinned to 245 so surfaces, panels, and the
-     daybreak accent all sit on the same blue axis (mirrors how the other
-     presets pin to 293 violet). */
-  --background: oklch(0.15 0.028 245);
-  --card: oklch(0.18 0.028 245);
-  --muted: oklch(0.23 0.030 245);
+/* ---- Tide (blue 245) ---- */
+[data-theme="tide"] {
+  --background: oklch(0.07 0.012 245);
+  --card: oklch(0.115 0.014 245);
+  --popover: oklch(0.135 0.014 245);
+  --muted: oklch(0.17 0.014 245);
+  --accent: oklch(0.17 0.014 245);
+  --secondary: oklch(0.17 0.014 245);
+  --muted-foreground: oklch(0.66 0.024 245);
   --accent-presence: #6DA9FF;
-
-  /* Keep aliases in sync */
-  --bg-base: var(--background);
-  --bg-raised: var(--card);
-  --bg-panel: oklch(0.13 0.026 245);
-  --bg-elevated: oklch(0.25 0.032 245);
-  --bg-hover: oklch(0.28 0.034 245);
-  --secondary: oklch(0.25 0.030 245);
-  --secondary-foreground: oklch(0.985 0 0);
-  --accent: oklch(0.25 0.030 245);
-  --popover: oklch(0.18 0.028 245);
-  --muted-foreground: oklch(0.70 0.028 245);
-  --border: oklch(1 0 0 / 7%);
-  --border-strong: oklch(1 0 0 / 12%);
   --ring: oklch(0.62 0.14 245);
+  --bg-base: var(--background);
+  --bg-panel: oklch(0.055 0.012 245);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.17 0.014 245);
+  --bg-hover: oklch(0.21 0.016 245);
   --ring-focus: color-mix(in oklch, #6DA9FF 55%, transparent);
-  --brand: var(--accent-presence);
+}
+[data-theme="tide"][data-mode="light"] {
+  --background: oklch(0.99 0.005 245);
+  --foreground: oklch(0.18 0.012 245);
+  --card: oklch(0.97 0.006 245);
+  --popover: oklch(1.00 0.000 0);
+  --muted: oklch(0.93 0.008 245);
+  --accent: oklch(0.93 0.008 245);
+  --secondary: oklch(0.93 0.008 245);
+  --muted-foreground: oklch(0.45 0.020 245);
+  --accent-presence: #3D7DD8;
+  --ring: oklch(0.55 0.14 245);
+  --bg-base: var(--background);
+  --bg-panel: oklch(1.00 0.000 0);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.95 0.008 245);
+  --bg-hover: oklch(0.91 0.010 245);
+  --ring-focus: color-mix(in oklch, #3D7DD8 55%, transparent);
+}
+
+/* ---- Grove (green 145) ---- */
+[data-theme="grove"] {
+  --background: oklch(0.07 0.010 145);
+  --card: oklch(0.115 0.012 145);
+  --popover: oklch(0.135 0.012 145);
+  --muted: oklch(0.17 0.012 145);
+  --accent: oklch(0.17 0.012 145);
+  --secondary: oklch(0.17 0.012 145);
+  --muted-foreground: oklch(0.66 0.020 145);
+  --accent-presence: #6DCB8E;
+  --ring: oklch(0.65 0.14 145);
+  --bg-base: var(--background);
+  --bg-panel: oklch(0.055 0.010 145);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.17 0.012 145);
+  --bg-hover: oklch(0.21 0.014 145);
+  --ring-focus: color-mix(in oklch, #6DCB8E 55%, transparent);
+}
+[data-theme="grove"][data-mode="light"] {
+  --background: oklch(0.99 0.005 145);
+  --foreground: oklch(0.18 0.010 145);
+  --card: oklch(0.97 0.006 145);
+  --popover: oklch(1.00 0.000 0);
+  --muted: oklch(0.93 0.008 145);
+  --accent: oklch(0.93 0.008 145);
+  --secondary: oklch(0.93 0.008 145);
+  --muted-foreground: oklch(0.45 0.018 145);
+  --accent-presence: #2F8C58;
+  --ring: oklch(0.55 0.14 145);
+  --bg-base: var(--background);
+  --bg-panel: oklch(1.00 0.000 0);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.95 0.008 145);
+  --bg-hover: oklch(0.91 0.010 145);
+  --ring-focus: color-mix(in oklch, #2F8C58 55%, transparent);
+}
+
+/* ---- Ember (amber 60) ---- */
+[data-theme="ember"] {
+  --background: oklch(0.07 0.010 60);
+  --card: oklch(0.115 0.012 60);
+  --popover: oklch(0.135 0.012 60);
+  --muted: oklch(0.17 0.012 60);
+  --accent: oklch(0.17 0.012 60);
+  --secondary: oklch(0.17 0.012 60);
+  --muted-foreground: oklch(0.66 0.022 60);
+  --accent-presence: #E8A85C;
+  --ring: oklch(0.72 0.14 60);
+  --bg-base: var(--background);
+  --bg-panel: oklch(0.055 0.010 60);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.17 0.012 60);
+  --bg-hover: oklch(0.21 0.014 60);
+  --ring-focus: color-mix(in oklch, #E8A85C 55%, transparent);
+}
+[data-theme="ember"][data-mode="light"] {
+  --background: oklch(0.99 0.006 60);
+  --foreground: oklch(0.18 0.010 60);
+  --card: oklch(0.97 0.008 60);
+  --popover: oklch(1.00 0.000 0);
+  --muted: oklch(0.93 0.010 60);
+  --accent: oklch(0.93 0.010 60);
+  --secondary: oklch(0.93 0.010 60);
+  --muted-foreground: oklch(0.45 0.018 60);
+  --accent-presence: #B5752A;
+  --ring: oklch(0.60 0.14 60);
+  --bg-base: var(--background);
+  --bg-panel: oklch(1.00 0.000 0);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.95 0.010 60);
+  --bg-hover: oklch(0.91 0.012 60);
+  --ring-focus: color-mix(in oklch, #B5752A 55%, transparent);
+}
+
+/* ---- Bloom (rose 15) ---- */
+[data-theme="bloom"] {
+  --background: oklch(0.07 0.010 15);
+  --card: oklch(0.115 0.012 15);
+  --popover: oklch(0.135 0.012 15);
+  --muted: oklch(0.17 0.012 15);
+  --accent: oklch(0.17 0.012 15);
+  --secondary: oklch(0.17 0.012 15);
+  --muted-foreground: oklch(0.66 0.022 15);
+  --accent-presence: #E88FA5;
+  --ring: oklch(0.70 0.14 15);
+  --bg-base: var(--background);
+  --bg-panel: oklch(0.055 0.010 15);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.17 0.012 15);
+  --bg-hover: oklch(0.21 0.014 15);
+  --ring-focus: color-mix(in oklch, #E88FA5 55%, transparent);
+}
+[data-theme="bloom"][data-mode="light"] {
+  --background: oklch(0.99 0.005 15);
+  --foreground: oklch(0.18 0.010 15);
+  --card: oklch(0.97 0.006 15);
+  --popover: oklch(1.00 0.000 0);
+  --muted: oklch(0.93 0.008 15);
+  --accent: oklch(0.93 0.008 15);
+  --secondary: oklch(0.93 0.008 15);
+  --muted-foreground: oklch(0.45 0.018 15);
+  --accent-presence: #C25A78;
+  --ring: oklch(0.58 0.14 15);
+  --bg-base: var(--background);
+  --bg-panel: oklch(1.00 0.000 0);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.95 0.008 15);
+  --bg-hover: oklch(0.91 0.010 15);
+  --ring-focus: color-mix(in oklch, #C25A78 55%, transparent);
+}
+
+/* ---- Dusk (magenta 330) ---- */
+[data-theme="dusk"] {
+  --background: oklch(0.13 0.030 330);
+  --card: oklch(0.17 0.030 330);
+  --popover: oklch(0.17 0.030 330);
+  --muted: oklch(0.22 0.032 330);
+  --accent: oklch(0.24 0.032 330);
+  --secondary: oklch(0.24 0.032 330);
+  --muted-foreground: oklch(0.70 0.030 330);
+  --accent-presence: #D26BFF;
+  --ring: oklch(0.60 0.16 330);
+  --bg-base: var(--background);
+  --bg-panel: oklch(0.11 0.028 330);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.24 0.034 330);
+  --bg-hover: oklch(0.27 0.036 330);
+  --ring-focus: color-mix(in oklch, #D26BFF 55%, transparent);
+}
+[data-theme="dusk"][data-mode="light"] {
+  --background: oklch(0.99 0.006 330);
+  --foreground: oklch(0.18 0.014 330);
+  --card: oklch(0.97 0.008 330);
+  --popover: oklch(1.00 0.000 0);
+  --muted: oklch(0.93 0.010 330);
+  --accent: oklch(0.93 0.010 330);
+  --secondary: oklch(0.93 0.010 330);
+  --muted-foreground: oklch(0.45 0.020 330);
+  --accent-presence: #9F3FCE;
+  --ring: oklch(0.50 0.18 330);
+  --bg-base: var(--background);
+  --bg-panel: oklch(1.00 0.000 0);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.95 0.010 330);
+  --bg-hover: oklch(0.91 0.012 330);
+  --ring-focus: color-mix(in oklch, #9F3FCE 55%, transparent);
+}
+
+/* ---- Mist (teal 195) ---- */
+[data-theme="mist"] {
+  --background: oklch(0.07 0.010 195);
+  --card: oklch(0.115 0.012 195);
+  --popover: oklch(0.135 0.012 195);
+  --muted: oklch(0.17 0.012 195);
+  --accent: oklch(0.17 0.012 195);
+  --secondary: oklch(0.17 0.012 195);
+  --muted-foreground: oklch(0.66 0.020 195);
+  --accent-presence: #5DD0CB;
+  --ring: oklch(0.70 0.14 195);
+  --bg-base: var(--background);
+  --bg-panel: oklch(0.055 0.010 195);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.17 0.012 195);
+  --bg-hover: oklch(0.21 0.014 195);
+  --ring-focus: color-mix(in oklch, #5DD0CB 55%, transparent);
+}
+[data-theme="mist"][data-mode="light"] {
+  --background: oklch(0.99 0.005 195);
+  --foreground: oklch(0.18 0.010 195);
+  --card: oklch(0.97 0.006 195);
+  --popover: oklch(1.00 0.000 0);
+  --muted: oklch(0.93 0.008 195);
+  --accent: oklch(0.93 0.008 195);
+  --secondary: oklch(0.93 0.008 195);
+  --muted-foreground: oklch(0.45 0.016 195);
+  --accent-presence: #1E938E;
+  --ring: oklch(0.55 0.14 195);
+  --bg-base: var(--background);
+  --bg-panel: oklch(1.00 0.000 0);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.95 0.008 195);
+  --bg-hover: oklch(0.91 0.010 195);
+  --ring-focus: color-mix(in oklch, #1E938E 55%, transparent);
+}
+
+/* ---- Slate (neutral 270) ---- */
+[data-theme="slate"] {
+  --background: oklch(0.07 0.000 270);
+  --card: oklch(0.115 0.000 270);
+  --popover: oklch(0.135 0.000 270);
+  --muted: oklch(0.17 0.000 270);
+  --accent: oklch(0.17 0.000 270);
+  --secondary: oklch(0.17 0.000 270);
+  --muted-foreground: oklch(0.66 0.000 270);
+  --accent-presence: #A0A0AB;
+  --ring: oklch(0.55 0.000 270);
+  --bg-base: var(--background);
+  --bg-panel: oklch(0.055 0.000 270);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.17 0.000 270);
+  --bg-hover: oklch(0.21 0.000 270);
+  --ring-focus: color-mix(in oklch, #A0A0AB 55%, transparent);
+}
+[data-theme="slate"][data-mode="light"] {
+  --background: oklch(0.99 0.000 270);
+  --foreground: oklch(0.18 0.000 270);
+  --card: oklch(0.97 0.000 270);
+  --popover: oklch(1.00 0.000 0);
+  --muted: oklch(0.93 0.000 270);
+  --accent: oklch(0.93 0.000 270);
+  --secondary: oklch(0.93 0.000 270);
+  --muted-foreground: oklch(0.45 0.000 270);
+  --accent-presence: #5C5C66;
+  --ring: oklch(0.45 0.000 270);
+  --bg-base: var(--background);
+  --bg-panel: oklch(1.00 0.000 0);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.95 0.000 270);
+  --bg-hover: oklch(0.91 0.000 270);
+  --ring-focus: color-mix(in oklch, #5C5C66 55%, transparent);
 }
 
 /* ────────────────────────────────────────────────

--- a/src/app/globals.css.test.ts
+++ b/src/app/globals.css.test.ts
@@ -35,3 +35,20 @@ assert.doesNotMatch(
 assert.match(css, /:root\s*\{[\s\S]*?--background\s*:\s*oklch\(0\.07/, "coven dark background");
 
 console.log("globals.css.test.ts (task 3) OK");
+
+// Task 4 assertions: the 7 non-default themes each have dark + light blocks.
+const otherThemes = ["tide", "grove", "ember", "bloom", "dusk", "mist", "slate"];
+for (const id of otherThemes) {
+  const darkRe = new RegExp(`\\[data-theme="${id}"\\]\\s*\\{`);
+  const lightRe = new RegExp(`\\[data-theme="${id}"\\]\\[data-mode="light"\\]\\s*\\{`);
+  assert.match(css, darkRe, `${id} dark block exists`);
+  assert.match(css, lightRe, `${id} light block exists`);
+}
+
+// Old preset ids no longer present as CSS selectors.
+for (const old of ["midnight", "orchid", "sky"]) {
+  const re = new RegExp(`\\[data-theme="${old}"\\]`);
+  assert.doesNotMatch(css, re, `old preset ${old} removed`);
+}
+
+console.log("globals.css.test.ts (task 4) OK");

--- a/src/app/globals.css.test.ts
+++ b/src/app/globals.css.test.ts
@@ -1,0 +1,37 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const css = readFileSync(new URL("./globals.css", import.meta.url), "utf8");
+
+// 1. :root[data-mode="light"] block exists with foreground/background.
+const lightBlock = css.match(/:root\[data-mode="light"\]\s*\{([\s\S]*?)\}/)?.[1] ?? "";
+assert.ok(lightBlock.length > 0, ":root[data-mode=light] block exists");
+assert.match(lightBlock, /--background\s*:/, "light overrides --background");
+assert.match(lightBlock, /--foreground\s*:/, "light overrides --foreground");
+
+// 2. Border vars derive from --foreground via color-mix.
+assert.match(
+  css,
+  /--border\s*:\s*color-mix\(in oklch, var\(--foreground\)/,
+  "--border derives from --foreground",
+);
+assert.match(
+  css,
+  /--border-strong\s*:\s*color-mix\(in oklch, var\(--foreground\)/,
+  "--border-strong derives from --foreground",
+);
+
+// 3. The old "the app runs dark-only" assumption comment is gone or rephrased.
+assert.doesNotMatch(
+  css,
+  /the app runs dark-only/i,
+  "removed the dark-only assertion",
+);
+
+// 4. data-theme="midnight" / "orchid" / "sky" blocks are removed
+//    (replaced by new theme ids in a later task — Task 4).
+//    For this task we just verify the default Coven structure is intact.
+assert.match(css, /:root\s*\{[\s\S]*?--background\s*:\s*oklch\(0\.07/, "coven dark background");
+
+console.log("globals.css.test.ts (task 3) OK");

--- a/src/app/mockup/mockup.css
+++ b/src/app/mockup/mockup.css
@@ -1,3 +1,8 @@
+/* TODO: light-mode-audit — this file ships hardcoded dark-mode color
+   literals (oklch(1 0 0 / N%) / rgba(255,...)) that need migrating to
+   color-mix(in oklch, var(--foreground) N%, transparent) for a clean
+   light-mode appearance. Tracked in the light-mode pass-2 follow-up. */
+
 /* mockup.css — multica-inspired design tokens, scoped to the /mockup route
    via the `.multica-theme` class on the route's root element. This keeps
    the rest of the app untouched until we decide to roll the tokens out

--- a/src/components/mode-toggle.test.ts
+++ b/src/components/mode-toggle.test.ts
@@ -1,0 +1,21 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./mode-toggle.tsx", import.meta.url), "utf8");
+
+// 1. Exports the ModeToggle component.
+assert.match(source, /export\s+function\s+ModeToggle/, "ModeToggle exported");
+
+// 2. Accepts value + onChange of Mode type.
+assert.match(source, /value\s*:\s*Mode/, "value: Mode prop");
+assert.match(source, /onChange\s*:\s*\(/, "onChange callback");
+
+// 3. Renders both Light and Dark options.
+assert.match(source, /"light"/, "light option");
+assert.match(source, /"dark"/, "dark option");
+
+// 4. Uses aria-pressed for accessibility (segmented control).
+assert.match(source, /aria-pressed/, "aria-pressed for active state");
+
+console.log("mode-toggle.test.ts OK");

--- a/src/components/mode-toggle.tsx
+++ b/src/components/mode-toggle.tsx
@@ -7,7 +7,7 @@
  * Caller is responsible for persistence + applying `data-mode` on <html>.
  */
 
-import { Icon } from "@iconify/react";
+import { Icon, type IconName } from "@/lib/icon";
 import type { Mode } from "../lib/theme-storage";
 
 interface ModeToggleProps {
@@ -15,9 +15,9 @@ interface ModeToggleProps {
   onChange: (next: Mode) => void;
 }
 
-const OPTIONS: { id: Mode; label: string; name: string }[] = [
-  { id: "light", label: "Light", name: "ph:sun" },
-  { id: "dark", label: "Dark", name: "ph:moon" },
+const OPTIONS: { id: Mode; label: string; icon: IconName }[] = [
+  { id: "light", label: "Light", icon: "ph:sun" },
+  { id: "dark", label: "Dark", icon: "ph:moon" },
 ];
 
 export function ModeToggle({ value, onChange }: ModeToggleProps) {
@@ -41,7 +41,7 @@ export function ModeToggle({ value, onChange }: ModeToggleProps) {
                 : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
             }`}
           >
-            <Icon icon={opt.name} width={14} />
+            <Icon name={opt.icon} width={14} />
             {opt.label}
           </button>
         );

--- a/src/components/mode-toggle.tsx
+++ b/src/components/mode-toggle.tsx
@@ -8,7 +8,7 @@
  */
 
 import { Icon, type IconName } from "@/lib/icon";
-import type { Mode } from "../lib/theme-storage";
+import type { Mode } from "@/lib/theme-storage";
 
 interface ModeToggleProps {
   value: Mode;

--- a/src/components/mode-toggle.tsx
+++ b/src/components/mode-toggle.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+/**
+ * ModeToggle — segmented Light / Dark control. Pure presentational.
+ *
+ * Lives in the Appearance settings section above the theme grid.
+ * Caller is responsible for persistence + applying `data-mode` on <html>.
+ */
+
+import { Icon } from "@iconify/react";
+import type { Mode } from "../lib/theme-storage";
+
+interface ModeToggleProps {
+  value: Mode;
+  onChange: (next: Mode) => void;
+}
+
+const OPTIONS: { id: Mode; label: string; name: string }[] = [
+  { id: "light", label: "Light", name: "ph:sun" },
+  { id: "dark", label: "Dark", name: "ph:moon" },
+];
+
+export function ModeToggle({ value, onChange }: ModeToggleProps) {
+  return (
+    <div
+      role="group"
+      aria-label="Color mode"
+      className="inline-flex items-center gap-0.5 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-base)] p-0.5"
+    >
+      {OPTIONS.map((opt) => {
+        const active = value === opt.id;
+        return (
+          <button
+            key={opt.id}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onChange(opt.id)}
+            className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[12px] font-medium transition-colors ${
+              active
+                ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
+                : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+            }`}
+          >
+            <Icon icon={opt.name} width={14} />
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -5,6 +5,9 @@ import { useRouter } from "next/navigation";
 import { Icon } from "@/lib/icon";
 import { PluginsView } from "@/components/plugins-view";
 import { SettingsFamiliarsPanel } from "@/components/settings-familiars-panel";
+import { THEME_IDS, THEME_META, getSwatches, type ThemeId } from "@/lib/theme-palettes";
+import { COVEN_THEME_KEY, COVEN_MODE_KEY, COVEN_CUSTOM_THEME_KEY, LEGACY_THEME_RENAME, type Mode } from "@/lib/theme-storage";
+import { ModeToggle } from "@/components/mode-toggle";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -374,7 +377,7 @@ function FamiliarsSection() {
 
 // ─── Theme helpers ───────────────────────────────────────────────────────────────────────
 
-type PresetTheme = "mood-c" | "midnight" | "orchid" | "sky";
+type PresetTheme = ThemeId;
 type ActiveTheme = PresetTheme | "custom";
 
 interface CustomThemeData {
@@ -396,88 +399,86 @@ function clearCustomCssVars(html: HTMLElement) {
 function applyPreset(theme: PresetTheme) {
   const html = document.documentElement;
   clearCustomCssVars(html);
-
-  if (theme === "mood-c") {
-    html.removeAttribute("data-theme");
-  } else {
-    html.setAttribute("data-theme", theme);
-  }
-  localStorage.setItem("coven-theme", theme);
+  html.setAttribute("data-theme", theme);
+  localStorage.setItem(COVEN_THEME_KEY, theme);
 }
 
-function applyCustomVars(cssVars: CustomThemeData["cssVars"]) {
+function applyMode(mode: Mode) {
   const html = document.documentElement;
-  html.removeAttribute("data-theme");
+  html.setAttribute("data-mode", mode);
+  localStorage.setItem(COVEN_MODE_KEY, mode);
+}
+
+function applyCustomVars(cssVars: CustomThemeData["cssVars"], mode: Mode) {
+  const html = document.documentElement;
+  html.setAttribute("data-theme", "custom");
   clearCustomCssVars(html);
 
   const apply = (group?: Record<string, string>) => {
     if (!group) return;
     for (const [name, value] of Object.entries(group)) {
       if (typeof value !== "string" || !name) continue;
-      // tweakcn returns bare names ("background", "font-sans"); shadcn schema
-      // does not prefix with --. We prefix here when needed.
       const cssName = name.startsWith("--") ? name : `--${name}`;
       html.style.setProperty(cssName, value);
     }
   };
   // theme: mode-agnostic vars (fonts, radius, shadows, tracking).
-  // dark: mode-specific colors (the app runs dark-only).
+  // light/dark: mode-specific colors. Fall back to the opposite group
+  // when the import only ships one mode.
   apply(cssVars.theme);
-  apply(cssVars.dark);
+  const modeGroup =
+    (mode === "light" ? cssVars.light : cssVars.dark) ??
+    (mode === "light" ? cssVars.dark : cssVars.light);
+  apply(modeGroup);
 }
 
 function clearCustomTheme() {
-  document.documentElement.removeAttribute("data-theme");
+  document.documentElement.setAttribute("data-theme", "coven");
   document.documentElement.removeAttribute("style");
-  localStorage.removeItem("coven-custom-theme");
-  localStorage.setItem("coven-theme", "mood-c");
+  localStorage.removeItem(COVEN_CUSTOM_THEME_KEY);
+  localStorage.setItem(COVEN_THEME_KEY, "coven");
+}
+
+function readPersistedTheme(): ActiveTheme {
+  const raw = localStorage.getItem(COVEN_THEME_KEY);
+  if (!raw) return "coven";
+  if (LEGACY_THEME_RENAME[raw]) return LEGACY_THEME_RENAME[raw] as ActiveTheme;
+  if (raw === "custom") return "custom";
+  if ((THEME_IDS as readonly string[]).includes(raw)) return raw as ActiveTheme;
+  return "coven";
+}
+
+function readPersistedMode(): Mode {
+  const raw = localStorage.getItem(COVEN_MODE_KEY);
+  return raw === "light" ? "light" : "dark";
 }
 
 // ─── Preset cards ─────────────────────────────────────────────────────────────────────────────
 
-interface ThemePreset {
-  id: PresetTheme;
+interface ThemePresetEntry {
+  id: ThemeId;
   label: string;
   description: string;
-  swatches: { bg: string; accent: string; border: string };
 }
 
-const PRESETS: ThemePreset[] = [
-  {
-    id: "mood-c",
-    label: "Mood C",
-    description: "Arcane field manual — dark violet glass",
-    swatches: { bg: "oklch(0.16 0.022 293)", accent: "#9a8ecd", border: "oklch(1 0 0 / 6%)" },
-  },
-  {
-    id: "midnight",
-    label: "Midnight",
-    description: "Deep black, near-zero chroma, minimal",
-    swatches: { bg: "oklch(0.10 0.004 293)", accent: "#7B73BD", border: "oklch(1 0 0 / 5%)" },
-  },
-  {
-    id: "orchid",
-    label: "Orchid",
-    description: "Warm violet, lighter surface",
-    swatches: { bg: "oklch(0.13 0.030 293)", accent: "#D26BFF", border: "oklch(1 0 0 / 7%)" },
-  },
-  {
-    id: "sky",
-    label: "Sky",
-    description: "Cool slate-blue night, daybreak accent",
-    swatches: { bg: "oklch(0.15 0.028 245)", accent: "#6DA9FF", border: "oklch(1 0 0 / 7%)" },
-  },
-];
+const PRESETS: ThemePresetEntry[] = THEME_IDS.map((id) => ({
+  id,
+  label: THEME_META[id].name,
+  description: THEME_META[id].description,
+}));
 
 function ThemePresetCard({
   preset,
+  mode,
   active,
   onSelect,
 }: {
-  preset: ThemePreset;
+  preset: ThemePresetEntry;
+  mode: Mode;
   active: boolean;
-  onSelect: (id: PresetTheme) => void;
+  onSelect: (id: ThemeId) => void;
 }) {
+  const swatches = getSwatches(preset.id, mode);
   return (
     <button
       type="button"
@@ -489,21 +490,20 @@ function ThemePresetCard({
           : "border-[var(--border-hairline)] bg-[var(--bg-base)] hover:border-[var(--border-strong)] hover:bg-[var(--bg-raised)]"
       }`}
     >
-      {/* Swatch row */}
       <div className="flex items-center gap-1.5">
         <span
-          className="h-5 w-5 rounded-full border border-white/10"
-          style={{ background: preset.swatches.bg }}
+          className="h-5 w-5 rounded-full border border-[var(--border-hairline)]"
+          style={{ background: swatches.bg }}
           title="Background"
         />
         <span
           className="h-5 w-5 rounded-full"
-          style={{ background: preset.swatches.accent }}
+          style={{ background: swatches.accent }}
           title="Accent"
         />
         <span
           className="h-5 w-5 rounded-full border-2"
-          style={{ background: preset.swatches.bg, borderColor: preset.swatches.accent + "40" }}
+          style={{ background: swatches.bg, borderColor: swatches.border }}
           title="Border"
         />
       </div>
@@ -525,23 +525,25 @@ function ThemePresetCard({
 // ─── Section: Appearance ───────────────────────────────────────────────────────────────────────
 
 function AppearanceSection() {
-  const [activeTheme, setActiveTheme] = useState<ActiveTheme>("mood-c");
+  const [activeTheme, setActiveTheme] = useState<ActiveTheme>("coven");
+  const [mode, setMode] = useState<Mode>("dark");
   const [customData, setCustomData] = useState<CustomThemeData | null>(null);
   const [importUrl, setImportUrl] = useState("");
   const [importing, setImporting] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
 
-  // Read persisted theme on mount
+  // Read persisted theme + mode on mount
   useEffect(() => {
-    const saved = localStorage.getItem("coven-theme") as ActiveTheme | null;
-    if (saved) setActiveTheme(saved);
+    setActiveTheme(readPersistedTheme());
+    setMode(readPersistedMode());
+    const saved = localStorage.getItem(COVEN_THEME_KEY);
     if (saved === "custom") {
-      const raw = localStorage.getItem("coven-custom-theme");
+      const raw = localStorage.getItem(COVEN_CUSTOM_THEME_KEY);
       if (raw) {
         try {
           setCustomData(JSON.parse(raw) as CustomThemeData);
         } catch {
-          // malformed — ignore
+          /* malformed — ignore */
         }
       }
     }
@@ -553,9 +555,18 @@ function AppearanceSection() {
     applyPreset(id);
   };
 
+  const handleSetMode = (next: Mode) => {
+    setMode(next);
+    applyMode(next);
+    // If a custom theme is active, re-apply with the new mode group.
+    if (activeTheme === "custom" && customData) {
+      applyCustomVars(customData.cssVars, next);
+    }
+  };
+
   const handleResetCustom = () => {
     clearCustomTheme();
-    setActiveTheme("mood-c");
+    setActiveTheme("coven");
     setCustomData(null);
   };
 
@@ -616,9 +627,9 @@ function AppearanceSection() {
         cssVars: cssVars as CustomThemeData["cssVars"],
       };
 
-      applyCustomVars(data.cssVars);
-      localStorage.setItem("coven-custom-theme", JSON.stringify(data));
-      localStorage.setItem("coven-theme", "custom");
+      applyCustomVars(data.cssVars, mode);
+      localStorage.setItem(COVEN_CUSTOM_THEME_KEY, JSON.stringify(data));
+      localStorage.setItem(COVEN_THEME_KEY, "custom");
       setCustomData(data);
       setActiveTheme("custom");
       setImportUrl("");
@@ -631,6 +642,13 @@ function AppearanceSection() {
 
   return (
     <SettingsPage title="Appearance" description="Colors and visual style.">
+      {/* ── Mode toggle ── */}
+      <SettingsGroup label="Mode">
+        <div className="px-4 py-3">
+          <ModeToggle value={mode} onChange={handleSetMode} />
+        </div>
+      </SettingsGroup>
+
       {/* ── Preset themes ── */}
       <SettingsGroup label="Theme">
         {/* Custom theme chip */}
@@ -655,12 +673,13 @@ function AppearanceSection() {
         )}
 
         {/* Preset grid */}
-        <div className="grid grid-cols-3 gap-3 p-4">
-          {PRESETS.map((p) => (
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 p-4">
+          {PRESETS.map((preset) => (
             <ThemePresetCard
-              key={p.id}
-              preset={p}
-              active={activeTheme === p.id}
+              key={preset.id}
+              preset={preset}
+              mode={mode}
+              active={activeTheme === preset.id}
               onSelect={handleSelectPreset}
             />
           ))}

--- a/src/components/theme-script.test.ts
+++ b/src/components/theme-script.test.ts
@@ -1,0 +1,39 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./theme-script.tsx", import.meta.url), "utf8");
+
+// 1. Script defaults theme to "coven" and mode to "dark".
+assert.match(source, /\|\|\s*"coven"/, "theme defaults to coven");
+assert.match(source, /\|\|\s*"dark"/, "mode defaults to dark");
+
+// 2. Script writes BOTH data-theme and data-mode.
+assert.match(source, /setAttribute\(\s*"data-theme"/, "sets data-theme");
+assert.match(source, /setAttribute\(\s*"data-mode"/, "sets data-mode");
+
+// 3. Rename map covers all 4 legacy ids and writes through localStorage.
+for (const legacy of ["mood-c", "sky", "orchid", "midnight"]) {
+  assert.ok(source.includes(`"${legacy}"`), `rename map contains ${legacy}`);
+}
+assert.ok(source.includes("setItem"), "writes renamed id back to localStorage");
+
+// 4. Custom theme path applies the mode-matching group.
+assert.match(
+  source,
+  /cssVars\.light|cssVars\[\s*["']light["']\s*\]/,
+  "custom path references light group",
+);
+assert.match(
+  source,
+  /cssVars\.dark|cssVars\[\s*["']dark["']\s*\]/,
+  "custom path references dark group",
+);
+
+// 5. Reads keys via the COVEN_*_KEY constants (or matches their values).
+assert.ok(
+  source.includes("coven-theme") && source.includes("coven-mode"),
+  "references both storage keys",
+);
+
+console.log("theme-script.test.ts OK");

--- a/src/components/theme-script.tsx
+++ b/src/components/theme-script.tsx
@@ -11,6 +11,13 @@
  *  4. Always set BOTH `data-theme` and `data-mode` on <html>.
  *  5. If theme === "custom", apply `cssVars.theme` (mode-agnostic) +
  *     `cssVars[mode]` (mode-specific) from localStorage["coven-custom-theme"].
+ *
+ * NOTE: The storage key strings ("coven-theme", "coven-mode",
+ * "coven-custom-theme") and the legacy rename map are duplicated from
+ * src/lib/theme-storage.ts. They cannot be imported here because the
+ * script body is a string literal that runs in the browser before any
+ * module code resolves. Keep both in sync when adding new keys or
+ * renames.
  */
 
 const THEME_SCRIPT = `
@@ -46,6 +53,8 @@ const THEME_SCRIPT = `
       }
       applyGroup(cssVars.theme);
       var modeGroup = mode === "light" ? cssVars.light : cssVars.dark;
+      // Fallback to the opposite group if the selected mode is absent
+      // (tweakcn imports from the dark-only era ship only cssVars.dark).
       if (!modeGroup) modeGroup = mode === "light" ? cssVars.dark : cssVars.light;
       applyGroup(modeGroup);
     }

--- a/src/components/theme-script.tsx
+++ b/src/components/theme-script.tsx
@@ -1,26 +1,33 @@
 /**
- * ThemeScript — flash-free theme restoration.
+ * ThemeScript — flash-free theme + mode restoration.
  *
  * Rendered as a <script> tag inside <head> via layout.tsx.
  * Runs before the first paint so there's no theme flash.
  *
  * Strategy:
- *  1. Read localStorage["coven-theme"]  (preset id or "custom")
- *  2. If preset — set data-theme on <html>
- *  3. If custom  — read localStorage["coven-custom-theme"] and apply
- *     every CSS var from cssVars.theme + cssVars.dark via setProperty.
+ *  1. Read localStorage["coven-theme"] (id or "custom"), default "coven".
+ *  2. Read localStorage["coven-mode"] ("light" | "dark"), default "dark".
+ *  3. One-shot rename: mood-c → coven, sky → tide, orchid → dusk, midnight → slate.
+ *  4. Always set BOTH `data-theme` and `data-mode` on <html>.
+ *  5. If theme === "custom", apply `cssVars.theme` (mode-agnostic) +
+ *     `cssVars[mode]` (mode-specific) from localStorage["coven-custom-theme"].
  */
 
 const THEME_SCRIPT = `
 (function () {
   try {
-    var theme = localStorage.getItem("coven-theme");
-    if (!theme || theme === "mood-c") return; // default :root handles it
-
-    if (theme === "midnight" || theme === "orchid" || theme === "sky") {
-      document.documentElement.setAttribute("data-theme", theme);
-      return;
+    var rename = { "mood-c": "coven", "sky": "tide", "orchid": "dusk", "midnight": "slate" };
+    var theme = localStorage.getItem("coven-theme") || "coven";
+    if (rename[theme]) {
+      theme = rename[theme];
+      localStorage.setItem("coven-theme", theme);
     }
+    var mode = localStorage.getItem("coven-mode") || "dark";
+    if (mode !== "light" && mode !== "dark") mode = "dark";
+
+    var html = document.documentElement;
+    html.setAttribute("data-theme", theme);
+    html.setAttribute("data-mode", mode);
 
     if (theme === "custom") {
       var raw = localStorage.getItem("coven-custom-theme");
@@ -28,7 +35,6 @@ const THEME_SCRIPT = `
       var data = JSON.parse(raw);
       var cssVars = data && data.cssVars;
       if (!cssVars) return;
-      var html = document.documentElement;
       function applyGroup(group) {
         if (!group || typeof group !== "object") return;
         for (var name in group) {
@@ -39,15 +45,17 @@ const THEME_SCRIPT = `
         }
       }
       applyGroup(cssVars.theme);
-      applyGroup(cssVars.dark);
+      var modeGroup = mode === "light" ? cssVars.light : cssVars.dark;
+      if (!modeGroup) modeGroup = mode === "light" ? cssVars.dark : cssVars.light;
+      applyGroup(modeGroup);
     }
   } catch (e) {}
 })();
 `.trim();
 
 /**
- * Renders an inline <script> that runs synchronously before hydration.
- * Must be placed in <head> (before any CSS-in-JS or painted content).
+ * Inline <script> that runs synchronously before hydration.
+ * Must be placed in <head>.
  */
 export function ThemeScript() {
   return (

--- a/src/components/theme-script.tsx
+++ b/src/components/theme-script.tsx
@@ -24,11 +24,15 @@ const THEME_SCRIPT = `
 (function () {
   try {
     var rename = { "mood-c": "coven", "sky": "tide", "orchid": "dusk", "midnight": "slate" };
+    var valid = ["coven","tide","grove","ember","bloom","dusk","mist","slate","custom"];
     var theme = localStorage.getItem("coven-theme") || "coven";
     if (rename[theme]) {
       theme = rename[theme];
       localStorage.setItem("coven-theme", theme);
     }
+    // Allowlist: corrupt or attacker-written localStorage values must not
+    // land as data-theme attribute content. Unknown ids fall back to coven.
+    if (valid.indexOf(theme) === -1) theme = "coven";
     var mode = localStorage.getItem("coven-mode") || "dark";
     if (mode !== "light" && mode !== "dark") mode = "dark";
 

--- a/src/lib/icon.tsx
+++ b/src/lib/icon.tsx
@@ -152,6 +152,7 @@ export const ICON_NAMES = [
   "ph:linkedin-logo",
   "ph:twitter-logo",
   "ph:sun",
+  "ph:moon",
   "ph:bell",
   "ph:book-open-bold",
   "ph:book-open",

--- a/src/lib/theme-palettes.test.ts
+++ b/src/lib/theme-palettes.test.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { THEME_IDS, THEME_META, getSwatches } from "./theme-palettes.ts";
+import { LEGACY_THEME_RENAME, COVEN_THEME_KEY, COVEN_MODE_KEY } from "./theme-storage.ts";
+
+// 8 themes, coven is the default (first).
+assert.equal(THEME_IDS.length, 8);
+assert.equal(THEME_IDS[0], "coven");
+assert.deepEqual(
+  [...THEME_IDS].sort(),
+  ["bloom", "coven", "dusk", "ember", "grove", "mist", "slate", "tide"],
+);
+
+// Every theme has a name, hue, and both accent values.
+for (const id of THEME_IDS) {
+  const meta = THEME_META[id];
+  assert.ok(meta, `metadata for ${id}`);
+  assert.equal(typeof meta.name, "string");
+  assert.equal(typeof meta.hue, "number");
+  assert.match(meta.accentDark, /^#[0-9A-Fa-f]{6}$/, `accentDark for ${id}`);
+  assert.match(meta.accentLight, /^#[0-9A-Fa-f]{6}$/, `accentLight for ${id}`);
+}
+
+// getSwatches returns distinct background swatches per mode.
+for (const id of THEME_IDS) {
+  const dark = getSwatches(id, "dark");
+  const light = getSwatches(id, "light");
+  assert.notEqual(dark.bg, light.bg, `${id} bg swatch differs by mode`);
+  assert.equal(dark.accent, THEME_META[id].accentDark);
+  assert.equal(light.accent, THEME_META[id].accentLight);
+}
+
+// Legacy rename map covers all 4 old ids.
+assert.deepEqual(LEGACY_THEME_RENAME, {
+  "mood-c": "coven",
+  "sky": "tide",
+  "orchid": "dusk",
+  "midnight": "slate",
+});
+
+// Storage keys are stable strings.
+assert.equal(COVEN_THEME_KEY, "coven-theme");
+assert.equal(COVEN_MODE_KEY, "coven-mode");
+
+console.log("theme-palettes.test.ts OK");

--- a/src/lib/theme-palettes.test.ts
+++ b/src/lib/theme-palettes.test.ts
@@ -38,6 +38,13 @@ assert.deepEqual(LEGACY_THEME_RENAME, {
   "midnight": "slate",
 });
 
+// Inverse coverage: no stray THEME_META keys outside THEME_IDS.
+assert.deepEqual(
+  Object.keys(THEME_META).sort(),
+  [...THEME_IDS].sort(),
+  "THEME_META keys must exactly match THEME_IDS",
+);
+
 // Storage keys are stable strings.
 assert.equal(COVEN_THEME_KEY, "coven-theme");
 assert.equal(COVEN_MODE_KEY, "coven-mode");

--- a/src/lib/theme-palettes.ts
+++ b/src/lib/theme-palettes.ts
@@ -1,0 +1,97 @@
+/**
+ * 8-theme roster metadata + swatch lookup for the appearance settings UI.
+ * The actual palette CSS lives in `src/app/globals.css`; this module
+ * mirrors the accent values and a representative background swatch
+ * per (theme, mode) so the settings grid can preview each card.
+ */
+
+import type { Mode } from "./theme-storage.ts";
+
+export const THEME_IDS = [
+  "coven",
+  "tide",
+  "grove",
+  "ember",
+  "bloom",
+  "dusk",
+  "mist",
+  "slate",
+] as const;
+
+export type ThemeId = (typeof THEME_IDS)[number];
+
+export interface ThemeMeta {
+  id: ThemeId;
+  name: string;
+  description: string;
+  hue: number;
+  accentDark: string;
+  accentLight: string;
+  /** Background swatch (CSS color string) for the preview card, per mode. */
+  bgDark: string;
+  bgLight: string;
+}
+
+export const THEME_META: Record<ThemeId, ThemeMeta> = {
+  coven: {
+    id: "coven", name: "Coven",
+    description: "OpenCoven violet — the default lavender field manual",
+    hue: 293, accentDark: "#9A8ECD", accentLight: "#6F62A8",
+    bgDark: "oklch(0.07 0.004 293)", bgLight: "oklch(0.99 0.003 293)",
+  },
+  tide: {
+    id: "tide", name: "Tide",
+    description: "Cool slate-blue, daybreak accent",
+    hue: 245, accentDark: "#6DA9FF", accentLight: "#3D7DD8",
+    bgDark: "oklch(0.07 0.012 245)", bgLight: "oklch(0.99 0.005 245)",
+  },
+  grove: {
+    id: "grove", name: "Grove",
+    description: "Forest green, calm and grounded",
+    hue: 145, accentDark: "#6DCB8E", accentLight: "#2F8C58",
+    bgDark: "oklch(0.07 0.010 145)", bgLight: "oklch(0.99 0.005 145)",
+  },
+  ember: {
+    id: "ember", name: "Ember",
+    description: "Warm amber, focused-work feel",
+    hue: 60, accentDark: "#E8A85C", accentLight: "#B5752A",
+    bgDark: "oklch(0.07 0.010 60)", bgLight: "oklch(0.99 0.006 60)",
+  },
+  bloom: {
+    id: "bloom", name: "Bloom",
+    description: "Soft rose, friendly",
+    hue: 15, accentDark: "#E88FA5", accentLight: "#C25A78",
+    bgDark: "oklch(0.07 0.010 15)", bgLight: "oklch(0.99 0.005 15)",
+  },
+  dusk: {
+    id: "dusk", name: "Dusk",
+    description: "Magenta pink-violet",
+    hue: 330, accentDark: "#D26BFF", accentLight: "#9F3FCE",
+    bgDark: "oklch(0.07 0.014 330)", bgLight: "oklch(0.99 0.006 330)",
+  },
+  mist: {
+    id: "mist", name: "Mist",
+    description: "Teal/cyan, clinical",
+    hue: 195, accentDark: "#5DD0CB", accentLight: "#1E938E",
+    bgDark: "oklch(0.07 0.010 195)", bgLight: "oklch(0.99 0.005 195)",
+  },
+  slate: {
+    id: "slate", name: "Slate",
+    description: "Zero-chroma neutral",
+    hue: 270, accentDark: "#A0A0AB", accentLight: "#5C5C66",
+    bgDark: "oklch(0.07 0.000 270)", bgLight: "oklch(0.99 0.000 270)",
+  },
+};
+
+export interface SwatchTuple {
+  bg: string;
+  accent: string;
+  border: string;
+}
+
+export function getSwatches(id: ThemeId, mode: Mode): SwatchTuple {
+  const m = THEME_META[id];
+  return mode === "light"
+    ? { bg: m.bgLight, accent: m.accentLight, border: `${m.accentLight}40` }
+    : { bg: m.bgDark, accent: m.accentDark, border: `${m.accentDark}40` };
+}

--- a/src/lib/theme-palettes.ts
+++ b/src/lib/theme-palettes.ts
@@ -21,7 +21,6 @@ export const THEME_IDS = [
 export type ThemeId = (typeof THEME_IDS)[number];
 
 export interface ThemeMeta {
-  id: ThemeId;
   name: string;
   description: string;
   hue: number;
@@ -34,49 +33,49 @@ export interface ThemeMeta {
 
 export const THEME_META: Record<ThemeId, ThemeMeta> = {
   coven: {
-    id: "coven", name: "Coven",
+    name: "Coven",
     description: "OpenCoven violet — the default lavender field manual",
     hue: 293, accentDark: "#9A8ECD", accentLight: "#6F62A8",
     bgDark: "oklch(0.07 0.004 293)", bgLight: "oklch(0.99 0.003 293)",
   },
   tide: {
-    id: "tide", name: "Tide",
+    name: "Tide",
     description: "Cool slate-blue, daybreak accent",
     hue: 245, accentDark: "#6DA9FF", accentLight: "#3D7DD8",
     bgDark: "oklch(0.07 0.012 245)", bgLight: "oklch(0.99 0.005 245)",
   },
   grove: {
-    id: "grove", name: "Grove",
+    name: "Grove",
     description: "Forest green, calm and grounded",
     hue: 145, accentDark: "#6DCB8E", accentLight: "#2F8C58",
     bgDark: "oklch(0.07 0.010 145)", bgLight: "oklch(0.99 0.005 145)",
   },
   ember: {
-    id: "ember", name: "Ember",
+    name: "Ember",
     description: "Warm amber, focused-work feel",
     hue: 60, accentDark: "#E8A85C", accentLight: "#B5752A",
     bgDark: "oklch(0.07 0.010 60)", bgLight: "oklch(0.99 0.006 60)",
   },
   bloom: {
-    id: "bloom", name: "Bloom",
+    name: "Bloom",
     description: "Soft rose, friendly",
     hue: 15, accentDark: "#E88FA5", accentLight: "#C25A78",
     bgDark: "oklch(0.07 0.010 15)", bgLight: "oklch(0.99 0.005 15)",
   },
   dusk: {
-    id: "dusk", name: "Dusk",
+    name: "Dusk",
     description: "Magenta pink-violet",
     hue: 330, accentDark: "#D26BFF", accentLight: "#9F3FCE",
     bgDark: "oklch(0.07 0.014 330)", bgLight: "oklch(0.99 0.006 330)",
   },
   mist: {
-    id: "mist", name: "Mist",
+    name: "Mist",
     description: "Teal/cyan, clinical",
     hue: 195, accentDark: "#5DD0CB", accentLight: "#1E938E",
     bgDark: "oklch(0.07 0.010 195)", bgLight: "oklch(0.99 0.005 195)",
   },
   slate: {
-    id: "slate", name: "Slate",
+    name: "Slate",
     description: "Zero-chroma neutral",
     hue: 270, accentDark: "#A0A0AB", accentLight: "#5C5C66",
     bgDark: "oklch(0.07 0.000 270)", bgLight: "oklch(0.99 0.000 270)",

--- a/src/lib/theme-storage.ts
+++ b/src/lib/theme-storage.ts
@@ -1,0 +1,24 @@
+/**
+ * Storage keys + legacy id-rename map for the theme system.
+ *
+ * Extracted so the rename map is unit-testable and so the inline
+ * <ThemeScript> body can stay a self-contained string while still
+ * referencing the canonical keys via build-time substitution.
+ */
+
+export const COVEN_THEME_KEY = "coven-theme";
+export const COVEN_MODE_KEY = "coven-mode";
+export const COVEN_CUSTOM_THEME_KEY = "coven-custom-theme";
+
+/**
+ * Renames from the dark-only preset roster to the 8-theme roster.
+ * Applied one-shot on first run after upgrade.
+ */
+export const LEGACY_THEME_RENAME: Record<string, string> = {
+  "mood-c": "coven",
+  "sky": "tide",
+  "orchid": "dusk",
+  "midnight": "slate",
+};
+
+export type Mode = "light" | "dark";

--- a/src/lib/theme-storage.ts
+++ b/src/lib/theme-storage.ts
@@ -1,9 +1,11 @@
 /**
  * Storage keys + legacy id-rename map for the theme system.
  *
- * Extracted so the rename map is unit-testable and so the inline
- * <ThemeScript> body can stay a self-contained string while still
- * referencing the canonical keys via build-time substitution.
+ * Extracted so the rename map is unit-testable. NOTE: the inline
+ * <ThemeScript> body in src/components/theme-script.tsx inlines the
+ * same key strings and rename map verbatim (the script body is a
+ * string literal that runs before module code resolves, so it cannot
+ * import). Keep both in sync.
  */
 
 export const COVEN_THEME_KEY = "coven-theme";

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1,3 +1,8 @@
+/* TODO: light-mode-audit — this file ships hardcoded dark-mode color
+   literals (oklch(1 0 0 / N%) / rgba(255,...)) that need migrating to
+   color-mix(in oklch, var(--foreground) N%, transparent) for a clean
+   light-mode appearance. Tracked in the light-mode pass-2 follow-up. */
+
 /* board.css — Board v2 */
 
 .board-shell { display:flex; flex-direction:column; height:100%; overflow:hidden; background:var(--bg-base); color:var(--text-primary); }

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -40,7 +40,7 @@
 .cave-md h2 {
   font-size: 1.08em;
   padding-bottom: 0.2em;
-  border-bottom: 1px solid oklch(1 0 0 / 4%);
+  border-bottom: 1px solid color-mix(in oklch, var(--foreground) 4%, transparent);
 }
 .cave-md h3 { font-size: 0.97em; }
 .cave-md h4 { font-size: 0.9em; color: var(--text-secondary); font-weight: 600; }
@@ -166,9 +166,9 @@
   background: color-mix(in oklch, var(--accent-presence) 6%, var(--bg-raised));
   color: var(--text-secondary);
 }
-.cave-md tr:nth-child(even) td { background: oklch(1 0 0 / 2%); }
+.cave-md tr:nth-child(even) td { background: color-mix(in oklch, var(--foreground) 2%, transparent); }
 .cave-md tr:hover td {
-  background: oklch(1 0 0 / 4%);
+  background: color-mix(in oklch, var(--foreground) 4%, transparent);
   transition: background 0.1s;
 }
 
@@ -198,7 +198,7 @@
   background: oklch(0.1 0.01 280 / 60%);
   box-shadow:
     0 1px 3px oklch(0 0 0 / 30%),
-    inset 0 1px 0 oklch(1 0 0 / 4%);
+    inset 0 1px 0 color-mix(in oklch, var(--foreground) 4%, transparent);
   overflow: hidden;
   font-size: 12px;
   margin: 0.6em 0;
@@ -295,7 +295,7 @@
   min-height: 1.6em;
   transition: background 0.08s;
 }
-.cave-line:hover { background: oklch(1 0 0 / 2.5%); }
+.cave-line:hover { background: color-mix(in oklch, var(--foreground) 2.5%, transparent); }
 
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    LINE NUMBERS
@@ -500,7 +500,7 @@
   background: oklch(0.1 0.01 280 / 60%);
   box-shadow:
     0 1px 3px oklch(0 0 0 / 30%),
-    inset 0 1px 0 oklch(1 0 0 / 4%);
+    inset 0 1px 0 color-mix(in oklch, var(--foreground) 4%, transparent);
   overflow: hidden;
 }
 

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -49,13 +49,13 @@
   border: 1px solid var(--border-strong);
   border-radius: 16px;
   overflow: hidden;
-  box-shadow: 0 8px 32px color-mix(in oklch, var(--foreground) 18%, transparent), 0 1px 0 color-mix(in oklch, var(--foreground) 4%, transparent) inset;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18), 0 1px 0 color-mix(in oklch, var(--foreground) 4%, transparent) inset;
   transition: box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .home-composer-card:focus-within {
   border-color: color-mix(in oklch, var(--accent-presence) 50%, var(--border-strong));
-  box-shadow: 0 8px 40px color-mix(in oklch, var(--foreground) 22%, transparent),
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.22),
               0 0 0 1px color-mix(in oklch, var(--accent-presence) 20%, transparent);
 }
 

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -49,13 +49,13 @@
   border: 1px solid var(--border-strong);
   border-radius: 16px;
   overflow: hidden;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18), 0 1px 0 rgba(255,255,255,0.04) inset;
+  box-shadow: 0 8px 32px color-mix(in oklch, var(--foreground) 18%, transparent), 0 1px 0 color-mix(in oklch, var(--foreground) 4%, transparent) inset;
   transition: box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .home-composer-card:focus-within {
   border-color: color-mix(in oklch, var(--accent-presence) 50%, var(--border-strong));
-  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.22),
+  box-shadow: 0 8px 40px color-mix(in oklch, var(--foreground) 22%, transparent),
               0 0 0 1px color-mix(in oklch, var(--accent-presence) 20%, transparent);
 }
 
@@ -222,8 +222,8 @@
   display: inline-block;
   width: 13px;
   height: 13px;
-  border: 2px solid rgba(255, 255, 255, 0.3);
-  border-top-color: #fff;
+  border: 2px solid color-mix(in oklch, var(--foreground) 30%, transparent);
+  border-top-color: var(--foreground);
   border-radius: 50%;
   animation: hc-spin 0.6s linear infinite;
 }

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -1,3 +1,8 @@
+/* TODO: light-mode-audit — this file ships hardcoded dark-mode color
+   literals (oklch(1 0 0 / N%) / rgba(255,...)) that need migrating to
+   color-mix(in oklch, var(--foreground) N%, transparent) for a clean
+   light-mode appearance. Tracked in the light-mode pass-2 follow-up. */
+
 /* library.css — Research Library Phase 1 */
 
 /* ── Shell layout ─────────────────────────────────────────────── */

--- a/src/styles/sessions-view.css
+++ b/src/styles/sessions-view.css
@@ -635,7 +635,7 @@
   position: fixed;
   inset: 0;
   z-index: 1000;
-  background: rgba(0, 0, 0, 0.55);
+  background: var(--backdrop-scrim);
   backdrop-filter: blur(2px);
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- Add Light/Dark mode toggle (independent of theme) and replace the 4 dark-only presets with **8 curated themes** that each ship a light + dark palette. Spans the hue wheel: **Coven** (violet, default), Tide (blue), Grove (green), Ember (amber), Bloom (rose), Dusk (magenta), Mist (teal), Slate (neutral).
- Mode toggle lives in **Settings → Appearance** above the theme grid; swatches re-render live when mode flips.
- Existing tweakcn custom-theme import is now mode-aware (applies `cssVars.light` in light mode, `cssVars.dark` in dark mode, with fallback to the opposite group).
- Existing users with `coven-theme = mood-c|sky|orchid|midnight` are one-shot migrated to `coven|tide|dusk|slate` in the inline pre-paint script. Flash-free restoration preserved.

## Architecture

`<html data-theme="<id>" data-mode="<light|dark>">` drives all CSS. Default Coven lives in `:root` (dark) and `:root[data-mode="light"]` (light); other themes use `[data-theme="X"]` / `[data-theme="X"][data-mode="light"]`. Border/input/text-muted vars derive from `var(--foreground)` via `color-mix(in oklch, …)` so they auto-invert with mode without per-theme overrides.

Single source of truth for the 8-theme roster: `src/lib/theme-palettes.ts`. Storage keys + legacy rename map: `src/lib/theme-storage.ts`.

## What's in

- `src/lib/theme-palettes.ts`, `src/lib/theme-storage.ts` — typed metadata + getSwatches()
- `src/components/mode-toggle.tsx` — segmented Light/Dark control
- `src/components/theme-script.tsx` — rewritten pre-paint script (both attributes, mode-aware custom themes, one-shot legacy rename)
- `src/app/globals.css` — restructured default Coven (dark + light), 7 other themes (dark + light each), retuned semantic state colors for light mode
- `src/components/settings-shell.tsx` — Mode toggle + 8-theme grid, mode-aware custom theme re-apply
- Pass-1 light-mode audit on `sidebar-minimal.css`, `home-composer.css`, `cave-chat.css`, `sessions-view.css` (drop shadows intentionally left as-is)

## What's out

- `library.css`, `board.css`, `mockup.css` carry a greppable `/* TODO: light-mode-audit */` marker for a pass-2 follow-up issue. Light mode ships looking ~95% right on those surfaces; full polish tracked separately.
- No system-preference tracking (`prefers-color-scheme` not read).
- No chrome toggle or global keybinding (settings-only by design).

## Test plan

- [ ] Fresh install → confirm Coven / Dark default, no flash on reload.
- [ ] Cycle through all 8 themes in Dark mode — confirm distinct accents + surfaces, no console errors.
- [ ] Flip Mode toggle to Light — confirm every preset swatch re-renders, app shell flips cleanly.
- [ ] Cycle through all 8 themes in Light mode.
- [ ] Import a tweakcn theme with both `light` and `dark` groups; flip mode — confirm live re-apply.
- [ ] Set `localStorage["coven-theme"] = "mood-c"`, reload → confirm rename to `coven`. Repeat for `sky → tide`, `orchid → dusk`, `midnight → slate`.
- [ ] Hard refresh in Light + non-default theme → confirm no flash of dark on load.

## Spec + plan

- Spec: `docs/superpowers/specs/2026-06-08-light-dark-mode-and-8-themes-design.md`
- Plan: `docs/superpowers/plans/2026-06-08-light-dark-mode-and-8-themes.md`

(Both are gitignored — kept locally in the worktree.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)