### PR TITLE
[codex] fix(title-enricher): stop arbitrary server-side URL fetches

### DIFF
--- a/src/lib/title-enricher.test.ts
+++ b/src/lib/title-enricher.test.ts
@@ -1,0 +1,74 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { enrichTitle, fallbackTitle } from "./title-enricher.ts";
+
+const originalFetch = globalThis.fetch;
+const calls: string[] = [];
+
+globalThis.fetch = async (url: string | URL) => {
+  const href = String(url);
+  calls.push(href);
+
+  if (href.startsWith("https://api.github.com/repos/OpenCoven/coven-cave")) {
+    return new Response(
+      JSON.stringify({
+        full_name: "OpenCoven/coven-cave",
+        description: "Cave desktop workspace",
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }
+
+  if (href.startsWith("https://export.arxiv.org/api/query")) {
+    return new Response(
+      "<feed><entry><title>Safe Paper Title</title><summary>Paper summary</summary></entry></feed>",
+      { status: 200, headers: { "content-type": "application/xml" } },
+    );
+  }
+
+  return new Response(
+    "<!doctype html><title>Server-side HTML fetch should not run</title>",
+    { status: 200, headers: { "content-type": "text/html" } },
+  );
+};
+
+try {
+  calls.length = 0;
+  assert.equal(
+    await enrichTitle("https://example.com/blog/server-side-fetch"),
+    null,
+    "generic public URLs should not trigger server-side HTML title fetching",
+  );
+  assert.deepStrictEqual(calls, []);
+  assert.equal(fallbackTitle("https://example.com/blog/server-side-fetch"), "Server Side Fetch");
+
+  for (const unsafeUrl of [
+    "http://localhost:3000/admin",
+    "http://127.0.0.1:3000/admin",
+    "http://[::1]:3000/admin",
+  ]) {
+    calls.length = 0;
+    assert.equal(await enrichTitle(unsafeUrl), null);
+    assert.deepStrictEqual(calls, [], `${unsafeUrl} should not be fetched server-side`);
+  }
+
+  calls.length = 0;
+  const github = await enrichTitle("https://github.com/OpenCoven/coven-cave");
+  assert.deepStrictEqual(github, {
+    title: "OpenCoven/coven-cave",
+    description: "Cave desktop workspace",
+  });
+  assert.deepStrictEqual(calls, ["https://api.github.com/repos/OpenCoven/coven-cave"]);
+
+  calls.length = 0;
+  const arxiv = await enrichTitle("https://arxiv.org/abs/2603.12345");
+  assert.deepStrictEqual(arxiv, {
+    title: "Safe Paper Title",
+    description: "Paper summary",
+  });
+  assert.deepStrictEqual(calls, ["https://export.arxiv.org/api/query?id_list=2603.12345&max_results=1"]);
+} finally {
+  globalThis.fetch = originalFetch;
+}
+
+console.log("title-enricher: allowlisted fetch behavior passed");

--- a/src/lib/title-enricher.ts
+++ b/src/lib/title-enricher.ts
@@ -1,14 +1,13 @@
 /**
  * title-enricher.ts
  *
- * Fetches real page titles for URLs during library ingestion.
+ * Fetches allowlisted page titles for URLs during library ingestion.
  * Used by route-link and the bookmarks POST endpoint.
  *
  * Strategy (in order):
  *  1. GitHub API — for github.com URLs (no auth needed for public repos)
  *  2. arXiv API  — for arxiv.org URLs (returns XML with clean title)
- *  3. HTML fetch — parse <title> tag from page HTML (works for most sites)
- *  4. Slug fallback — derive from URL path segments (already in route-link)
+ *  3. Slug fallback — derive from URL path segments (already in route-link)
  *
  * All fetches are best-effort: on any error, returns null so callers
  * fall back gracefully.
@@ -99,54 +98,6 @@ async function enrichArxiv(url: URL): Promise<EnrichedMeta | null> {
   return null;
 }
 
-// ── HTML title fetch ─────────────────────────────────────────────────────────
-
-async function enrichHtml(rawUrl: string): Promise<EnrichedMeta | null> {
-  try {
-    const res = await fetch(rawUrl, {
-      signal: AbortSignal.timeout(5000),
-      headers: {
-        "User-Agent": "Mozilla/5.0 (compatible; CovenCave/1.0; +https://opencoven.dev)",
-        Accept: "text/html,application/xhtml+xml",
-      },
-      redirect: "follow",
-    });
-    if (!res.ok) return null;
-    const ct = res.headers.get("content-type") ?? "";
-    if (!ct.includes("text/html")) return null;
-
-    // Read only the first 16KB — enough to find <title> and <meta description>
-    const reader = res.body?.getReader();
-    if (!reader) return null;
-    let html = "";
-    while (html.length < 16384) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      html += new TextDecoder().decode(value);
-      if (html.includes("</title>")) break;
-    }
-    reader.cancel().catch(() => {});
-
-    const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i);
-    const descMatch  = html.match(/<meta[^>]+name=["']description["'][^>]+content=["']([^"']+)["']/i)
-                    ?? html.match(/<meta[^>]+content=["']([^"']+)["'][^>]+name=["']description["']/i)
-                    ?? html.match(/<meta[^>]+property=["']og:description["'][^>]+content=["']([^"']+)["']/i);
-
-    const rawTitle = titleMatch?.[1]?.replace(/\s+/g, " ").trim();
-    const description = descMatch?.[1]?.replace(/\s+/g, " ").trim().slice(0, 300);
-    if (!rawTitle) return null;
-
-    // Strip common site-name suffixes: "Title | Site" or "Title - Site" or "Title | Site Name"
-    const cleaned = rawTitle
-      .replace(/\s*[|–—-]\s*[^|–—-]{1,60}$/, "")
-      .replace(/\s+/g, " ")
-      .trim() || rawTitle;
-
-    return { title: cleaned, description };
-  } catch { /* fall through */ }
-  return null;
-}
-
 // ── Main export ──────────────────────────────────────────────────────────────
 
 /**
@@ -172,8 +123,9 @@ export async function enrichTitle(rawUrl: string): Promise<EnrichedMeta | null> 
     if (ax) return ax;
   }
 
-  // HTML fetch for everything else
-  return enrichHtml(rawUrl);
+  // Do not fetch arbitrary user-supplied URLs server-side. Callers fall back
+  // to a local slug/domain title for non-allowlisted hosts.
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Stop `enrichTitle()` from fetching arbitrary user-supplied URLs server-side.
- Keep title enrichment for explicit allowlisted API paths only: GitHub repository/issue/PR metadata and arXiv metadata.
- Add a focused regression test proving generic URLs and loopback URLs fall back locally without network fetches.

## Root Cause

Library ingestion used `enrichTitle()` for route-link and bookmark saves. For non-GitHub/non-arXiv URLs, the old implementation called `fetch(rawUrl)` and parsed the returned HTML title. That meant a saved URL could make the server perform an outbound request to an arbitrary host, including loopback/private targets.

## User Impact

Saved links still get useful local fallback titles from the URL slug/domain. GitHub and arXiv links keep richer metadata. The app no longer performs generic server-side HTML fetching for arbitrary saved URLs.

## Validation

- `node --no-warnings src\lib\title-enricher.test.ts`
- `node --no-warnings src\app\api\library\route-link\route.test.ts`
- `pnpm typecheck`
- `git diff --check HEAD~1..HEAD`