### PR TITLE
style(reader): Lora font, 820px width, airy padding

### DIFF
--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -3,6 +3,8 @@
    color-mix(in oklch, var(--foreground) N%, transparent) for a clean
    light-mode appearance. Tracked in the light-mode pass-2 follow-up. */
 
+@import url('https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,600;1,400&display=swap');
+
 /* library.css — Research Library Phase 1 */
 
 /* ── Shell layout ─────────────────────────────────────────────── */
@@ -932,7 +934,7 @@ tr:hover .library-row-delete,
 .library-reader-modal {
   position: relative;
   width: 100%;
-  max-width: 780px;
+  max-width: 820px;
   max-height: calc(100vh - 64px);
   background: var(--bg-base);
   border: 1px solid rgba(255, 255, 255, 0.08);
@@ -954,7 +956,7 @@ tr:hover .library-row-delete,
   display: flex;
   flex-direction: column;
   gap: 4px;
-  padding: 20px 24px 14px;
+  padding: 28px 32px 20px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
   background: var(--bg-panel);
   flex-shrink: 0;
@@ -962,11 +964,12 @@ tr:hover .library-row-delete,
 }
 
 .library-reader-title {
-  font-size: 20px;
-  font-weight: 680;
+  font-family: 'Lora', Georgia, serif;
+  font-size: 22px;
+  font-weight: 600;
   color: var(--text-primary);
   line-height: 1.25;
-  padding-right: 36px; /* room for close btn */
+  padding-right: 40px; /* room for close btn */
 }
 
 .library-reader-meta {
@@ -981,8 +984,8 @@ tr:hover .library-row-delete,
 /* Close button — top-right corner */
 .library-reader-close {
   position: absolute;
-  top: 16px;
-  right: 16px;
+  top: 24px;
+  right: 24px;
   display: grid;
   place-items: center;
   width: 28px;
@@ -1003,12 +1006,13 @@ tr:hover .library-row-delete,
 .library-reader-body {
   flex: 1;
   overflow-y: auto;
-  padding: 32px 40px;
+  padding: 44px 48px 56px;
   background: var(--bg-base);
 }
 
 .library-reader-body .cave-md.library-preview-md {
   max-width: 100%; /* fill the reader column */
+  font-family: 'Lora', Georgia, serif;
   font-size: 16px;
   line-height: 1.85;
 }


### PR DESCRIPTION
## Reader Visual Polish

Applies the approved design spec from `docs/specs/2026-06-08-reader-visual-polish-design.md`.

### Changes
- **Font:** Lora (serif) imported from Google Fonts, applied to reader title + body prose
- **Width:** Modal max-width 780px → 820px
- **Header:** Padding 20/24/14 → 28/32/20 (airy); title 20px → 22px weight 600; close button repositioned
- **Body:** Padding 32/40 → 44/48/56 (airy); `font-family: Lora` added to prose

### Scope
CSS-only. Single file: `src/styles/library.css`. No component/logic changes. No regressions to other library views (rail, doclist, preview, board).

### Verification
- ✅ Build passes (`pnpm build` exit 0)
- ✅ All 4 changes confirmed in CSS
- ✅ TODO light-mode-audit comment preserved