### PR TITLE
ux: sidebar/header/banner/rail polish pass (#227)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2895,9 +2895,10 @@ body {
 .shell-banner__title {
   flex: 1;
   min-width: 0;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  line-height: 1.4;
+  /* Wrap on narrow widths instead of truncating mid-sentence — the
+   * second half of these messages often carries the operative info
+   * (e.g. "…but new tasks may not start"). */
 }
 
 .shell-banner__cta {
@@ -2908,6 +2909,16 @@ body {
   padding: 3px 10px;
   font-size: var(--text-xs);
   cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.shell-banner__cta:hover {
+  background: color-mix(in oklch, currentColor 14%, transparent);
+}
+
+.shell-banner__cta:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 2px;
 }
 
 .shell-banner__dismiss {
@@ -2918,9 +2929,16 @@ body {
   display: grid;
   place-items: center;
   cursor: pointer;
+  transition: opacity var(--duration-fast) var(--ease-standard);
 }
 
 .shell-banner__dismiss:hover {
+  opacity: 1;
+}
+
+.shell-banner__dismiss:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
   opacity: 1;
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2542,15 +2542,15 @@ body {
 
 .familiar-avatar-rail__edit {
   position: absolute;
-  top: -4px;
-  right: 6px;
+  top: -3px;
+  right: 4px;
   opacity: 0;
   pointer-events: none;
   transition: opacity 120ms ease;
   display: grid;
   place-items: center;
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
   border-radius: 4px;
   background: var(--bg-raised);
   color: var(--text-secondary);
@@ -2565,9 +2565,25 @@ body {
   pointer-events: auto;
 }
 
+/* Pointer-less devices (touch) can't hover — keep the customize affordance
+ * visible at rest so it's actually reachable. */
+@media (hover: none) {
+  .familiar-avatar-rail__edit {
+    opacity: 0.7;
+    pointer-events: auto;
+  }
+}
+
 .familiar-avatar-rail__edit:hover {
   color: var(--text-primary);
   background: color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 18%, var(--bg-raised));
+}
+
+.familiar-avatar-rail__edit:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
 }
 .familiar-avatar-rail__list > li[data-dragging="true"] {
   opacity: 0.4;
@@ -2626,24 +2642,35 @@ body {
   height: 26px;
   border-radius: 50%;
   background: transparent;
-  border: 1px dashed var(--border-strong);
   color: var(--text-muted);
   display: grid;
   place-items: center;
   cursor: pointer;
   transition: color var(--duration-fast) var(--ease-standard),
-              background var(--duration-fast) var(--ease-standard);
+              background var(--duration-fast) var(--ease-standard),
+              border-color var(--duration-fast) var(--ease-standard);
+}
+
+.familiar-avatar-rail__add {
+  border: 1px dashed var(--border-strong);
+}
+
+.familiar-avatar-rail__toggle {
+  border: 1px solid var(--border-hairline);
+  margin-top: auto;
 }
 
 .familiar-avatar-rail__add:hover,
 .familiar-avatar-rail__toggle:hover {
   color: var(--text-primary);
   background: var(--bg-hover);
+  border-color: var(--border-strong);
 }
 
-.familiar-avatar-rail__toggle {
-  border-style: none;
-  margin-top: auto;
+.familiar-avatar-rail__add:focus-visible,
+.familiar-avatar-rail__toggle:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 2px;
 }
 
 /* ────────────────────────────────────────────────

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2946,10 +2946,6 @@ body {
   font-weight: 600;
 }
 
-.top-bar__sep {
-  color: var(--text-muted);
-}
-
 .top-bar__crumb {
   display: inline-flex;
   align-items: center;
@@ -2962,6 +2958,7 @@ body {
 
 .top-bar__crumb-sep {
   color: var(--text-muted);
+  opacity: 0.55;
 }
 
 .top-bar__crumb-sub {
@@ -2982,7 +2979,8 @@ body {
   color: var(--text-muted);
   font-size: var(--text-sm);
   cursor: pointer;
-  transition: border-color var(--duration-fast) var(--ease-standard);
+  transition: border-color var(--duration-fast) var(--ease-standard),
+              color var(--duration-fast) var(--ease-standard);
 }
 
 .top-bar__search:hover {
@@ -2990,11 +2988,21 @@ body {
   color: var(--text-secondary);
 }
 
+.top-bar__search:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 2px;
+}
+
 .top-bar__search kbd {
   margin-left: auto;
   font-family: var(--font-geist-mono);
   font-size: 10px;
+  line-height: 1;
   color: var(--text-muted);
+  padding: 2px 5px;
+  border-radius: 4px;
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-raised);
 }
 
 .top-bar__actions {
@@ -3013,11 +3021,18 @@ body {
   display: grid;
   place-items: center;
   cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard),
+              color var(--duration-fast) var(--ease-standard);
 }
 
 .top-bar__icon-btn:hover {
   background: var(--bg-hover);
   color: var(--text-primary);
+}
+
+.top-bar__icon-btn:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
 }
 
 /* ────────────────────────────────────────────────

--- a/src/components/familiar-avatar-rail.tsx
+++ b/src/components/familiar-avatar-rail.tsx
@@ -170,7 +170,7 @@ export function FamiliarAvatarRail({
                 title="Customize"
                 onClick={(e) => { e.stopPropagation(); openFamiliarStudio(f.id, "identity"); }}
               >
-                <Icon name="ph:dots-three-bold" width={10} />
+                <Icon name="ph:dots-three-bold" width={12} />
               </button>
             </li>
           );

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -38,12 +38,12 @@ export function TopBar(props: Props) {
   return (
     <header className="top-bar">
       <span className="top-bar__brand">CovenCave</span>
-      <span className="top-bar__sep">·</span>
       <span className="top-bar__crumb">
+        <span className="top-bar__crumb-sep" aria-hidden="true">›</span>
         <span className="top-bar__crumb-surface">{surfaceLabel}</span>
         {subContext ? (
           <>
-            <span className="top-bar__crumb-sep">›</span>
+            <span className="top-bar__crumb-sep" aria-hidden="true">›</span>
             <span className="top-bar__crumb-sub">{subContext}</span>
           </>
         ) : null}
@@ -56,7 +56,7 @@ export function TopBar(props: Props) {
         aria-label="Search and jump to anything"
       >
         <Icon name="ph:magnifying-glass" width={12} />
-        <span>Search · jump to anything</span>
+        <span>Jump to anything…</span>
         <kbd>⌘K</kbd>
       </button>
 

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -203,10 +203,9 @@
   padding: 0 10px 5px;
   font-size: 10px;
   font-weight: 650;
-  letter-spacing: 0;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--text-muted);
-  opacity: 0.76;
   user-select: none;
 }
 
@@ -226,7 +225,7 @@
   border-radius: 6px;
   border: none;
   background: transparent;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   font-size: 13px;
   cursor: pointer;
   text-align: left;
@@ -235,7 +234,7 @@
 
 .sidebar-folder-row:hover {
   background: var(--bg-raised);
-  color: var(--text-secondary);
+  color: var(--text-primary);
 }
 
 .sidebar-folder-row--active {
@@ -610,7 +609,7 @@
   min-height: 34px;
   border-radius: 8px;
   padding: 0 8px;
-  color: var(--text-muted);
+  color: var(--text-secondary);
 }
 
 .sidebar-folder-icon,

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -2,519 +2,21 @@
  * Appended to globals via @import in globals.css.
  * Uses only existing CSS custom properties.
  */
-
 /* ── Sidebar shell ────────────────────────────────────────────────────────── */
 .sidebar-minimal {
   display: flex;
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-  padding: 6px 0 0;
+  padding: 10px 8px 10px;
   font-size: 13px;
   color: var(--text-secondary);
+  gap: 10px;
+  background: linear-gradient(180deg, color-mix(in oklch, var(--bg-raised) 55%, transparent), transparent 42%),
+    var(--bg-base);
 }
 
 /* ── Header CTA ──────────────────────────────────────────────────────────── */
-.sidebar-actions {
-  padding: 0 8px 8px;
-  flex-shrink: 0;
-}
-
-.sidebar-action-row {
-  display: flex;
-  align-items: center;
-  width: 100%;
-  gap: 9px;
-  padding: 7px 10px;
-  border-radius: 7px;
-  border: none;
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 13px;
-  cursor: pointer;
-  text-align: left;
-  transition: background 0.12s ease, color 0.12s ease;
-}
-
-.sidebar-action-row:hover {
-  background: var(--bg-raised);
-  color: var(--text-primary);
-}
-
-.sidebar-action-row--active {
-  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
-  color: var(--text-primary);
-}
-
-/* "New chat" is the top CTA — give it a subtle pill feel */
-.sidebar-actions:first-child .sidebar-action-row {
-  background: var(--bg-raised);
-  color: var(--text-secondary);
-  border: 1px solid var(--border-hairline);
-}
-.sidebar-actions:first-child .sidebar-action-row:hover {
-  background: var(--bg-elevated);
-  color: var(--text-primary);
-  border-color: var(--border-strong);
-}
-
-.sidebar-action-icon {
-  flex-shrink: 0;
-  width: 16px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  opacity: 0.65;
-}
-
-.sidebar-action-row:hover .sidebar-action-icon,
-.sidebar-action-row--active .sidebar-action-icon {
-  opacity: 1;
-}
-
-.sidebar-action-label {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 13px;
-}
-
-.sidebar-action-kbd {
-  font-size: 10px;
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  color: var(--text-muted);
-  flex-shrink: 0;
-  opacity: 0.6;
-  padding: 1px 5px;
-  border-radius: 4px;
-  border: 1px solid var(--border-hairline);
-  background: var(--bg-base);
-}
-
-.sidebar-action-trailing {
-  display: inline-flex;
-  align-items: center;
-  flex-shrink: 0;
-  margin-left: auto;
-}
-
-/* Stack the top-level Search + New chat actions tightly */
-.sidebar-action-stack {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-/* Middle nav region scrolls if the user has lots of sections */
-.sidebar-nav-scroll {
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  scrollbar-width: thin;
-  scrollbar-color: var(--border-hairline) transparent;
-}
-
-/* ── Bottom: Notifications + Settings ─────────────────────────────────────── */
-.sidebar-foot {
-  flex-shrink: 0;
-  padding: 8px;
-  border-top: 1px solid var(--border-hairline);
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.sidebar-foot-bell,
-.sidebar-foot-btn {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  padding: 6px 8px;
-  border-radius: 7px;
-  border: none;
-  background: transparent;
-  color: var(--text-muted);
-  font-size: 13px;
-  cursor: pointer;
-  text-align: left;
-  transition: background 0.12s ease, color 0.12s ease;
-  width: 100%;
-}
-
-.sidebar-foot-bell:hover,
-.sidebar-foot-btn:hover {
-  background: var(--bg-raised);
-  color: var(--text-primary);
-}
-
-.sidebar-foot-icon {
-  flex-shrink: 0;
-  opacity: 0.7;
-  transition: opacity 0.12s ease;
-}
-
-.sidebar-foot-btn:hover .sidebar-foot-icon {
-  opacity: 1;
-}
-
-.sidebar-foot-label {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 13px;
-}
-
-/* NotificationBell renders an absolutely-positioned popover anchored at the
- * top-right of its trigger. In the sidebar foot that pushes the popover off
- * the bottom of the viewport, so flip it to open upward to the right. */
-.sidebar-foot-bell > div > div[class*="z-50"] {
-  top: auto !important;
-  bottom: calc(100% + 6px) !important;
-  right: auto !important;
-  left: 4px !important;
-}
-
-/* ── Folder mode rows ────────────────────────────────────────────────────── */
-.sidebar-folders {
-  padding: 4px 8px;
-  flex-shrink: 0;
-  border-bottom: 1px solid var(--border-hairline);
-}
-
-.sidebar-addins {
-  padding-top: 4px;
-}
-
-.sidebar-section-label {
-  padding: 6px 10px 2px;
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-  opacity: 0.5;
-  user-select: none;
-}
-
-.sidebar-divider {
-  height: 1px;
-  background: var(--border-hairline);
-  margin: 3px 10px;
-}
-
-.sidebar-folder-row {
-  display: flex;
-  align-items: center;
-  width: 100%;
-  gap: 9px;
-  padding: 5px 10px;
-  border-radius: 6px;
-  border: none;
-  background: transparent;
-  color: var(--text-muted);
-  font-size: 13px;
-  cursor: pointer;
-  text-align: left;
-  transition: background 0.12s ease, color 0.12s ease;
-}
-
-.sidebar-folder-row:hover {
-  background: var(--bg-raised);
-  color: var(--text-primary);
-}
-
-.sidebar-folder-row--active {
-  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
-  color: var(--text-primary);
-}
-
-.sidebar-folder-icon {
-  flex-shrink: 0;
-  opacity: 0.55;
-}
-
-.sidebar-folder-row--active .sidebar-folder-icon,
-.sidebar-folder-row:hover .sidebar-folder-icon {
-  opacity: 1;
-}
-
-.sidebar-folder-label {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.sidebar-badge {
-  font-size: 10px;
-  padding: 0.05em 0.45em;
-  border-radius: 8px;
-  background: color-mix(in oklch, var(--accent-presence) 15%, transparent);
-  color: var(--accent-presence);
-  flex-shrink: 0;
-  font-variant-numeric: tabular-nums;
-}
-
-/* ── Recents header ──────────────────────────────────────────────────────── */
-.sidebar-recents-header {
-  padding: 8px 14px 3px;
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-  flex-shrink: 0;
-  user-select: none;
-}
-
-/* ── Flat recents list ───────────────────────────────────────────────────── */
-.sidebar-recents {
-  flex: 1;
-  overflow-y: auto;
-  padding: 2px 6px;
-  scrollbar-width: thin;
-  scrollbar-color: var(--border-hairline) transparent;
-}
-
-.sidebar-recents::-webkit-scrollbar { width: 3px; }
-.sidebar-recents::-webkit-scrollbar-thumb {
-  background: var(--border-hairline);
-  border-radius: 2px;
-}
-
-.sidebar-recents-empty {
-  padding: 6px 8px;
-  font-size: 11px;
-  color: var(--text-muted);
-  font-style: italic;
-}
-
-.sidebar-recent-row {
-  display: flex;
-  align-items: baseline;
-  width: 100%;
-  gap: 6px;
-  padding: 4px 8px;
-  border-radius: 8px;
-  border: none;
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 12px;
-  cursor: pointer;
-  text-align: left;
-  transition: background 0.1s ease, color 0.1s ease;
-  min-width: 0;
-}
-
-.sidebar-recent-row:hover {
-  background: var(--bg-raised);
-  color: var(--text-primary);
-}
-
-.sidebar-recent-row--active {
-  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
-  color: var(--text-primary);
-  font-weight: 500;
-}
-
-.sidebar-recent-title {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
-}
-
-.sidebar-recent-ts {
-  flex-shrink: 0;
-  font-size: 10px;
-  color: var(--text-muted);
-  font-variant-numeric: tabular-nums;
-}
-
-/* ── Bottom utility footer ───────────────────────────────────────────────── */
-.sidebar-actions--footer {
-  margin-top: auto;
-  border-top: 1px solid var(--border-hairline);
-  padding: 6px 8px 10px;
-}
-
-/* Footer rows slightly smaller/dimmer than header rows */
-.sidebar-actions--footer .sidebar-action-row {
-  font-size: 12px;
-  padding: 5px 10px;
-  color: var(--text-muted);
-}
-
-.sidebar-actions--footer .sidebar-action-row:hover {
-  color: var(--text-secondary);
-}
-
-.sidebar-actions--footer .sidebar-action-row--active {
-  color: var(--text-primary);
-}
-
-.sidebar-bottom {
-  flex-shrink: 0;
-  padding: 6px 7px 8px;
-  border-top: 1px solid var(--border-hairline);
-}
-
-.sidebar-settings-row {
-  display: flex;
-  align-items: center;
-  width: 100%;
-  gap: 10px;
-  padding: 7px 9px;
-  border-radius: 6px;
-  border: none;
-  background: transparent;
-  color: var(--text-muted);
-  font-size: 13px;
-  cursor: pointer;
-  text-align: left;
-  transition: background 0.1s ease, color 0.1s ease;
-}
-
-.sidebar-settings-row:hover {
-  background: var(--bg-raised);
-  color: var(--text-secondary);
-}
-
-/* ── FamiliarStrip (AgentPanel top) ──────────────────────────────────────── */
-.familiar-strip {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 10px 6px;
-  border-bottom: 1px solid var(--border-hairline);
-  flex-shrink: 0;
-  overflow-x: auto;
-  scrollbar-width: none;
-}
-
-.familiar-strip::-webkit-scrollbar { display: none; }
-
-.familiar-strip-avatar {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  border: 1.5px solid transparent;
-  background: var(--bg-raised);
-  cursor: pointer;
-  flex-shrink: 0;
-  transition: border-color 0.12s ease, background 0.12s ease;
-  padding: 0;
-}
-
-.familiar-strip-avatar:hover {
-  border-color: var(--border-strong);
-}
-
-.familiar-strip-avatar--active {
-  border-color: var(--accent-presence);
-  box-shadow: 0 0 0 1px color-mix(in oklch, var(--accent-presence) 35%, transparent);
-  background: color-mix(in oklch, var(--accent-presence) 12%, var(--bg-raised));
-}
-
-/* ── Familiars section (left nav) ────────────────────────────────────────── */
-
-.sidebar-familiar-section-label {
-  padding: 5px 8px 2px;
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-  user-select: none;
-}
-
-/* ── Familiar list container ─────────────────────────────────────── */
-.sidebar-familiar-list {
-  flex: 1;
-  overflow-y: auto;
-  padding: 4px 0 0;
-  scrollbar-width: thin;
-  scrollbar-color: var(--border-hairline) transparent;
-}
-.sidebar-familiar-list::-webkit-scrollbar { width: 3px; }
-.sidebar-familiar-list::-webkit-scrollbar-thumb {
-  background: var(--border-hairline);
-  border-radius: 2px;
-}
-
-/* ── Familiar nav rows ───────────────────────────────────────────────────── */
-
-.sidebar-familiar-row {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  width: 100%;
-  padding: 5px 10px;
-  border-radius: 6px;
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  transition: background 0.12s;
-  text-align: left;
-  color: var(--text-secondary);
-}
-.sidebar-familiar-row:hover {
-  background: var(--bg-hover, var(--bg-raised));
-  color: var(--text-primary);
-}
-.sidebar-familiar-row--active {
-  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
-  color: var(--text-primary);
-}
-.sidebar-familiar-row-glyph {
-  flex-shrink: 0;
-  width: 20px;
-  height: 20px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  opacity: 0.8;
-}
-.sidebar-familiar-row:hover .sidebar-familiar-row-glyph,
-.sidebar-familiar-row--active .sidebar-familiar-row-glyph {
-  opacity: 1;
-}
-.sidebar-familiar-row-name {
-  flex: 1;
-  font-size: 12px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-}
-.sidebar-familiar-row--active .sidebar-familiar-row-name {
-  color: var(--accent-presence);
-  font-weight: 500;
-}
-.sidebar-familiar-row-count {
-  font-size: 10px;
-  color: var(--text-muted);
-  background: var(--bg-raised);
-  border-radius: 8px;
-  padding: 1px 5px;
-  flex-shrink: 0;
-  font-variant-numeric: tabular-nums;
-}
-.sidebar-familiar-row--active .sidebar-familiar-row-count {
-  background: color-mix(in oklch, var(--accent-presence) 20%, transparent);
-  color: var(--accent-presence);
-}
-
-/* ── 4 primary actions ───────────────────────────────────────────────────── */
 .sidebar-actions {
   padding: 0 7px 6px;
   flex-shrink: 0;
@@ -546,6 +48,19 @@
   color: var(--text-primary);
 }
 
+/* "New chat" is the top CTA — give it a subtle pill feel */
+.sidebar-actions:first-child .sidebar-action-row {
+  background: var(--bg-raised);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-hairline);
+}
+
+.sidebar-actions:first-child .sidebar-action-row:hover {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+}
+
 .sidebar-action-icon {
   flex-shrink: 0;
   width: 18px;
@@ -555,7 +70,8 @@
   opacity: 0.7;
 }
 
-.sidebar-action-row:hover .sidebar-action-icon {
+.sidebar-action-row:hover .sidebar-action-icon,
+.sidebar-action-row--active .sidebar-action-icon {
   opacity: 1;
 }
 
@@ -564,6 +80,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-size: 13px;
 }
 
 .sidebar-action-kbd {
@@ -572,11 +89,108 @@
   color: var(--text-muted);
   flex-shrink: 0;
   opacity: 0.7;
+  padding: 1px 5px;
+  border-radius: 4px;
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-base);
+}
+
+.sidebar-action-trailing {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+/* Stack the top-level Search + New chat actions tightly */
+.sidebar-action-stack {
+  display: grid;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0 6px;
+}
+
+/* Middle nav region scrolls if the user has lots of sections */
+.sidebar-nav-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-hairline) transparent;
+  gap: 11px;
+  padding: 0 4px 2px;
+}
+
+/* ── Bottom: Notifications + Settings ─────────────────────────────────────── */
+.sidebar-foot {
+  flex-shrink: 0;
+  padding: 8px 6px 0;
+  border-top: 1px solid var(--border-hairline);
+  display: grid;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sidebar-foot-bell,
+.sidebar-foot-btn {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 8px;
+  border-radius: 8px;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s ease, color 0.12s ease;
+  width: 100%;
+  min-height: 34px;
+}
+
+.sidebar-foot-bell:hover,
+.sidebar-foot-btn:hover {
+  background: var(--bg-raised);
+  color: var(--text-primary);
+}
+
+.sidebar-foot-icon {
+  flex-shrink: 0;
+  opacity: 0.7;
+  transition: opacity 0.12s ease;
+}
+
+.sidebar-foot-btn:hover .sidebar-foot-icon {
+  opacity: 1;
+}
+
+.sidebar-foot-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  min-width: 0;
+  color: inherit;
+}
+
+/* NotificationBell renders an absolutely-positioned popover anchored at the
+ * top-right of its trigger. In the sidebar foot that pushes the popover off
+ * the bottom of the viewport, so flip it to open upward to the right. */
+.sidebar-foot-bell > div > div[class*="z-50"] {
+  top: auto !important;
+  bottom: calc(100% + 6px) !important;
+  right: auto !important;
+  left: 4px !important;
 }
 
 /* ── Folder mode rows ────────────────────────────────────────────────────── */
 .sidebar-folders {
-  padding: 6px 7px;
+  padding: 0 0 10px;
   flex-shrink: 0;
   border-bottom: 1px solid var(--border-hairline);
 }
@@ -586,13 +200,13 @@
 }
 
 .sidebar-section-label {
-  padding: 8px 9px 3px;
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
+  padding: 0 10px 5px;
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0;
   text-transform: uppercase;
   color: var(--text-muted);
-  opacity: 0.6;
+  opacity: 0.76;
   user-select: none;
 }
 
@@ -600,6 +214,7 @@
   height: 1px;
   background: var(--border-hairline);
   margin: 4px 9px;
+  display: none;
 }
 
 .sidebar-folder-row {
@@ -676,7 +291,10 @@
   scrollbar-color: var(--border-hairline) transparent;
 }
 
-.sidebar-recents::-webkit-scrollbar { width: 3px; }
+.sidebar-recents::-webkit-scrollbar {
+  width: 3px;
+}
+
 .sidebar-recents::-webkit-scrollbar-thumb {
   background: var(--border-hairline);
   border-radius: 2px;
@@ -732,13 +350,31 @@
   font-variant-numeric: tabular-nums;
 }
 
-/* ── Bottom settings row ─────────────────────────────────────────────────── */
+/* ── Bottom utility footer ───────────────────────────────────────────────── */
 .sidebar-actions--footer {
-  margin-top: auto;
-  border-top: 1px solid var(--border-hairline);
+  margin-top: 0;
+  border-top: 0;
+  padding: 0 0 10px;
   padding-top: 6px;
   padding-bottom: 8px;
+  border-bottom: 1px solid var(--border-hairline);
 }
+
+/* Footer rows slightly smaller/dimmer than header rows */
+.sidebar-actions--footer .sidebar-action-row {
+  font-size: 12px;
+  padding: 5px 10px;
+  color: var(--text-muted);
+}
+
+.sidebar-actions--footer .sidebar-action-row:hover {
+  color: var(--text-secondary);
+}
+
+.sidebar-actions--footer .sidebar-action-row--active {
+  color: var(--text-primary);
+}
+
 .sidebar-bottom {
   flex-shrink: 0;
   padding: 6px 7px 8px;
@@ -778,7 +414,9 @@
   scrollbar-width: none;
 }
 
-.familiar-strip::-webkit-scrollbar { display: none; }
+.familiar-strip::-webkit-scrollbar {
+  display: none;
+}
 
 .familiar-strip-avatar {
   display: flex;
@@ -805,9 +443,7 @@
   background: color-mix(in oklch, var(--accent-presence) 12%, var(--bg-raised));
 }
 
-/* ── Familiars section (left nav, replaces emoji strip) ─────────────────── */
-/* duplicate .sidebar-familiar-section rule removed; see line 372 for canonical rule */
-
+/* ── Familiars section (left nav) ────────────────────────────────────────── */
 .sidebar-familiar-section-label {
   padding: 5px 8px 2px;
   font-size: 10px;
@@ -826,14 +462,17 @@
   scrollbar-width: thin;
   scrollbar-color: var(--border-hairline) transparent;
 }
-.sidebar-familiar-list::-webkit-scrollbar { width: 3px; }
+
+.sidebar-familiar-list::-webkit-scrollbar {
+  width: 3px;
+}
+
 .sidebar-familiar-list::-webkit-scrollbar-thumb {
   background: var(--border-hairline);
   border-radius: 2px;
 }
 
-/* ── Familiar nav rows (flat, click to show sessions in center) ─────────────── */
-
+/* ── Familiar nav rows ───────────────────────────────────────────────────── */
 .sidebar-familiar-row {
   display: flex;
   align-items: center;
@@ -848,14 +487,17 @@
   text-align: left;
   color: var(--text-secondary);
 }
+
 .sidebar-familiar-row:hover {
   background: var(--bg-hover, var(--bg-raised));
   color: var(--text-primary);
 }
+
 .sidebar-familiar-row--active {
   background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
   color: var(--text-primary);
 }
+
 .sidebar-familiar-row-glyph {
   flex-shrink: 0;
   width: 20px;
@@ -865,10 +507,12 @@
   justify-content: center;
   opacity: 0.8;
 }
+
 .sidebar-familiar-row:hover .sidebar-familiar-row-glyph,
 .sidebar-familiar-row--active .sidebar-familiar-row-glyph {
   opacity: 1;
 }
+
 .sidebar-familiar-row-name {
   flex: 1;
   font-size: 12px;
@@ -877,10 +521,12 @@
   text-overflow: ellipsis;
   min-width: 0;
 }
+
 .sidebar-familiar-row--active .sidebar-familiar-row-name {
   color: var(--accent-presence);
   font-weight: 500;
 }
+
 .sidebar-familiar-row-count {
   font-size: 10px;
   color: var(--text-muted);
@@ -890,9 +536,14 @@
   flex-shrink: 0;
   font-variant-numeric: tabular-nums;
 }
+
 .sidebar-familiar-row--active .sidebar-familiar-row-count {
   background: color-mix(in oklch, var(--accent-presence) 20%, transparent);
   color: var(--accent-presence);
+}
+
+.sidebar-action-row:hover .sidebar-action-icon {
+  opacity: 1;
 }
 
 /* ── Focus rings (keyboard-only) ─────────────────────────────────────────── */
@@ -904,6 +555,7 @@
 .familiar-strip-avatar {
   outline: none;
 }
+
 .sidebar-action-row:focus-visible,
 .sidebar-folder-row:focus-visible,
 .sidebar-recent-row:focus-visible,
@@ -912,6 +564,7 @@
   outline: var(--ring-width) solid var(--ring-focus);
   outline-offset: -1px;
 }
+
 .familiar-strip-avatar:focus-visible {
   outline: var(--ring-width) solid var(--ring-focus);
   outline-offset: 2px;
@@ -921,21 +574,6 @@
 .sidebar-addins .sidebar-section-label {
   padding-top: var(--space-2);
   opacity: 0.7;
-}
-
-/* ── Left panel polish: compact command stack + continuous navigation ────── */
-.sidebar-minimal {
-  gap: 10px;
-  padding: 10px 8px 10px;
-  background:
-    linear-gradient(180deg, color-mix(in oklch, var(--bg-raised) 55%, transparent), transparent 42%),
-    var(--bg-base);
-}
-
-.sidebar-action-stack {
-  display: grid;
-  gap: 6px;
-  padding: 0 6px;
 }
 
 .sidebar-action-stack .sidebar-action-row {
@@ -957,45 +595,13 @@
   background: var(--bg-elevated);
 }
 
-.sidebar-action-trailing {
-  margin-left: auto;
-  flex-shrink: 0;
+.sidebar-nav-scroll::-webkit-scrollbar {
+  width: 3px;
 }
 
-.sidebar-nav-scroll {
-  display: flex;
-  min-height: 0;
-  flex: 1;
-  flex-direction: column;
-  gap: 11px;
-  overflow-y: auto;
-  padding: 0 4px 2px;
-  scrollbar-width: thin;
-  scrollbar-color: var(--border-hairline) transparent;
-}
-
-.sidebar-nav-scroll::-webkit-scrollbar { width: 3px; }
 .sidebar-nav-scroll::-webkit-scrollbar-thumb {
   border-radius: 3px;
   background: var(--border-hairline);
-}
-
-.sidebar-folders {
-  border-bottom: 1px solid var(--border-hairline);
-  padding: 0 0 10px;
-}
-
-.sidebar-section-label {
-  padding: 0 10px 5px;
-  color: var(--text-muted);
-  font-size: 10px;
-  font-weight: 650;
-  letter-spacing: 0;
-  opacity: 0.76;
-}
-
-.sidebar-divider {
-  display: none;
 }
 
 .sidebar-folder-row,
@@ -1025,43 +631,6 @@
   color: var(--text-primary);
 }
 
-.sidebar-actions--footer {
-  margin-top: 0;
-  border-top: 0;
-  border-bottom: 1px solid var(--border-hairline);
-  padding: 0 0 10px;
-}
-
-.sidebar-foot {
-  display: grid;
-  flex-shrink: 0;
-  gap: 4px;
-  border-top: 1px solid var(--border-hairline);
-  padding: 8px 6px 0;
-}
-
-.sidebar-foot-bell,
-.sidebar-foot-btn {
-  display: flex;
-  min-height: 34px;
-  width: 100%;
-  align-items: center;
-  gap: 10px;
-  border: 0;
-  border-radius: 8px;
-  background: transparent;
-  padding: 0 8px;
-  color: var(--text-muted);
-  text-align: left;
-  transition: background 0.12s ease, color 0.12s ease;
-}
-
-.sidebar-foot-bell:hover,
-.sidebar-foot-btn:hover {
-  background: var(--bg-raised);
-  color: var(--text-primary);
-}
-
 .sidebar-foot-bell > .relative,
 .sidebar-foot-icon-cell {
   display: grid;
@@ -1069,19 +638,6 @@
   height: 28px;
   flex: 0 0 28px;
   place-items: center;
-}
-
-.sidebar-foot-icon {
-  flex-shrink: 0;
-}
-
-.sidebar-foot-label {
-  min-width: 0;
-  overflow: hidden;
-  color: inherit;
-  font-size: 13px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .sidebar-folder-kbd {
@@ -1095,6 +651,7 @@
 .sidebar-folder-row:hover .sidebar-folder-kbd {
   opacity: 1;
 }
+
 
 @media (max-height: 760px) {
   .sidebar-minimal {
@@ -1113,3 +670,4 @@
     min-height: 31px;
   }
 }
+


### PR DESCRIPTION
Closes #227.

Audit pass across the four left-of-detail surfaces called out in the issue. Read each component + its CSS, drafted a prioritized issue list, then shipped fixes as one logical commit per surface (plus one big mechanical commit to clean up underlying CSS debt that was making the sidebar styles unpredictable to edit).

## Summary

- **`refactor(sidebar)`** — dedup `sidebar-minimal.css` from 1115 → 673 lines. The file had grown three overlapping passes (original + mid-pass familiar-strip additions + a "compact polish" pass), leaving ~30 selectors declared 2–3 times where editing the early declaration silently no-oped. Each unique selector now appears once, body merged with cascade-correct per-property last-wins. Rendered output is identical; comma-list rules left intact because they legitimately share properties across multiple selectors.
- **`fix(top-bar)`** — unify crumb separators on `›` (was `·` then `›`), shorten search placeholder to "Jump to anything…", style the ⌘K hint as a proper kbd chip, add `:focus-visible` rings to the search button and icon button.
- **`fix(shell-banner)`** — drop title nowrap+ellipsis so long messages like "Daemon offline — existing sessions visible but new tasks may not start" stop truncating to "Daemon offline — existing sessions vis…". Add a hover state to the CTA (was transparent with currentColor border, looked dead) and focus-visible rings to both CTA and dismiss.
- **`fix(sidebar)`** — folder rows at rest were `text-muted`, jumping two contrast steps to `text-primary` on hover. Smooth to `text-secondary` → `text-primary` for less jolt and better light-mode legibility. Section labels (Work/Knowledge/Tools eyebrows) had `text-muted × opacity 0.76` — barely readable in pale themes; drop the opacity multiplier, restore a small 0.04em letter-spacing for the capitalised eyebrow rhythm.
- **`fix(familiar-rail)`** — customize button (the per-avatar ⋯) bumped from 14×14/10px-icon to 16×16/12px-icon and given an `@media (hover: none)` always-visible fallback for touch. Sidebar-toggle button at the bottom of the rail had `border-style: none` overriding the shared dashed border, leaving it nearly invisible at rest — gave it its own hairline border (visually distinct from the `+` button's dashed). Added focus-visible rings.

Eleven issues from the audit landed across the five commits. Out of scope, flagged for a future pass: the search button bg matches panel bg in some light themes (subtle, not blocking).

## Test plan

- [x] \`pnpm typecheck\` clean (every commit)
- [x] \`pnpm build\` clean (every commit, no Turbopack flake)
- [x] \`pnpm test sidebar-minimal.test.ts\` + \`familiar-avatar-rail.test.ts\` pass
- [ ] **Manual:** open dev server, dark and light themes, verify:
  - sidebar group eyebrows readable in pale themes
  - top-bar crumb chain reads consistently with one separator style
  - ⌘K hint shows as a chip
  - Tab through top-bar shows focus rings on search + bell + settings
  - daemon-offline banner wraps to two lines on narrow widths instead of truncating
  - banner CTA tints on hover
  - sidebar-toggle button visible at rest on the familiar rail