### PR TITLE
ux: board polish — focus rings, light-mode theming, selected-state cue

### DIFF
--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -118,13 +118,21 @@ export function BoardKanban({ cards, familiars, sessions, groupBy, selectedCardI
                 {label}
                 <span className="board-swimlane-badge">{gc.length}</span>
                 {isMultiSwimlane && (
-                  <div style={{ marginLeft: "auto", display: "flex", gap: 4 }}>
-                    <button type="button" onClick={(e) => { e.stopPropagation(); scroll(key, -1); }}
-                      style={{ display: "grid", placeItems: "center", width: 20, height: 20, borderRadius: 4, border: "none", background: "transparent", color: "var(--text-muted)", cursor: "pointer" }}>
+                  <div className="board-swimlane-scroll-group">
+                    <button
+                      type="button"
+                      className="board-swimlane-scroll-btn"
+                      aria-label="Scroll lane left"
+                      onClick={(e) => { e.stopPropagation(); scroll(key, -1); }}
+                    >
                       <Icon name="ph:arrow-left-bold" width={10} />
                     </button>
-                    <button type="button" onClick={(e) => { e.stopPropagation(); scroll(key, 1); }}
-                      style={{ display: "grid", placeItems: "center", width: 20, height: 20, borderRadius: 4, border: "none", background: "transparent", color: "var(--text-muted)", cursor: "pointer" }}>
+                    <button
+                      type="button"
+                      className="board-swimlane-scroll-btn"
+                      aria-label="Scroll lane right"
+                      onClick={(e) => { e.stopPropagation(); scroll(key, 1); }}
+                    >
                       <Icon name="ph:arrow-right-bold" width={10} />
                     </button>
                   </div>

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -77,7 +77,7 @@
 .board-table-sort-icon { display:inline-flex; align-items:center; margin-left:3px; vertical-align:middle; opacity:0.6; }
 .board-table tbody tr { border-bottom:1px solid var(--border-hairline); cursor:pointer; transition:background .1s; }
 .board-table tbody tr:hover { background:var(--bg-hover); }
-.board-table tbody tr.selected { background:color-mix(in oklch,var(--accent-presence) 8%,var(--bg-base)); box-shadow:inset 2px 0 0 var(--accent-presence); }
+.board-table tbody tr.selected { background:color-mix(in oklch,var(--accent-presence) 14%,var(--bg-base)); box-shadow:inset 3px 0 0 var(--accent-presence); }
 .board-table td { padding:8px 10px; vertical-align:middle; }
 .board-table-title { font-weight:500; color:var(--text-primary); max-width:300px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .board-table-muted { color:var(--text-muted); font-size:11px; }
@@ -164,7 +164,7 @@
 .board-kanban-card:hover { border-color:var(--border-strong); background:color-mix(in oklch,var(--bg-hover) 50%,var(--bg-base)); }
 .board-kanban-card:active { cursor:grabbing; }
 .board-kanban-card:focus-visible { box-shadow:0 0 0 3px color-mix(in oklch,var(--accent-presence) 22%,transparent); border-color:color-mix(in oklch,var(--accent-presence) 55%,transparent); }
-.board-kanban-card--selected { background:color-mix(in oklch,var(--accent-presence) 9%,var(--bg-base)); border-color:color-mix(in oklch,var(--accent-presence) 45%,var(--border-strong)); box-shadow:inset 0 0 0 1px color-mix(in oklch,var(--accent-presence) 25%,transparent); }
+.board-kanban-card--selected { background:color-mix(in oklch,var(--accent-presence) 13%,var(--bg-base)); border-color:color-mix(in oklch,var(--accent-presence) 55%,var(--border-strong)); box-shadow:inset 0 0 0 1px color-mix(in oklch,var(--accent-presence) 35%,transparent); }
 .board-kanban-card--dragging { opacity:.35; cursor:grabbing; }
 
 .board-kanban-card::before { content:""; position:absolute; left:0; top:8px; bottom:8px; width:3px; border-radius:0 2px 2px 0; }
@@ -314,7 +314,7 @@
 .floor-table-wrap { border:1px solid var(--border-hairline); border-radius:8px; background:var(--bg-raised); }
 .floor-table thead th:last-child { width:104px; }
 .floor-table tbody tr.floor-familiar-row { cursor:pointer; }
-.floor-table tbody tr.floor-familiar-row.selected { background:color-mix(in oklab,var(--accent-presence) 9%,var(--bg-base)); box-shadow:inset 2px 0 0 var(--accent-presence); }
+.floor-table tbody tr.floor-familiar-row.selected { background:color-mix(in oklch,var(--accent-presence) 14%,var(--bg-base)); box-shadow:inset 3px 0 0 var(--accent-presence); }
 .floor-familiar-cell { display:flex; min-width:0; align-items:center; gap:8px; }
 .floor-expand-button { display:inline-flex; height:22px; width:22px; shrink:0; align-items:center; justify-content:center; border-radius:6px; color:var(--text-muted); transition:background .12s,color .12s,transform .12s; }
 .floor-familiar-row:hover .floor-expand-button,.floor-expand-button:hover { background:var(--bg-hover); color:var(--text-primary); }

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -20,9 +20,11 @@
 .board-search-input:focus { border-color:color-mix(in oklch,var(--accent-presence) 52%,transparent); background:var(--bg-hover); }
 .board-search-clear { position:absolute; right:5px; display:flex; align-items:center; justify-content:center; width:20px; height:20px; border:0; border-radius:5px; background:transparent; color:var(--text-muted); cursor:pointer; transition:background .1s,color .1s; }
 .board-search-clear:hover { background:var(--bg-hover); color:var(--text-primary); }
+.board-search-clear:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }
 
 .board-toolbar-btn { display:inline-flex; align-items:center; gap:5px; height:28px; padding:0 10px; border-radius:7px; border:1px solid var(--border-strong); background:var(--bg-raised); color:var(--text-secondary); font-size:12px; font-weight:450; cursor:pointer; transition:background .12s,color .12s,border-color .12s; white-space:nowrap; }
 .board-toolbar-btn:hover { background:var(--bg-hover); color:var(--text-primary); }
+.board-toolbar-btn:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }
 .board-toolbar-btn--active { background:color-mix(in oklch,var(--accent-presence) 14%,var(--bg-raised)); border-color:color-mix(in oklch,var(--accent-presence) 40%,transparent); color:var(--text-primary); }
 
 
@@ -35,22 +37,27 @@
 .board-group-toggle-btn { display:flex; align-items:center; justify-content:center; padding:0 10px; height:28px; background:var(--bg-raised); color:var(--text-muted); border:none; cursor:pointer; font-size:12px; font-weight:500; transition:background .12s,color .12s; white-space:nowrap; }
 .board-group-toggle-btn+.board-group-toggle-btn { border-left:1px solid var(--border-strong); }
 .board-group-toggle-btn:hover { background:var(--bg-hover); color:var(--text-secondary); }
+.board-group-toggle-btn:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:-1px; z-index:1; position:relative; }
 .board-group-toggle-btn--active { background:color-mix(in oklch,var(--accent-presence) 16%,var(--bg-raised)); color:var(--text-primary); }
 .board-view-toggle { display:flex; border:1px solid var(--border-strong); border-radius:7px; overflow:hidden; }
 .board-view-toggle-btn { display:flex; align-items:center; justify-content:center; width:28px; height:28px; background:var(--bg-raised); color:var(--text-muted); border:none; cursor:pointer; transition:background .12s,color .12s; }
 .board-view-toggle-btn+.board-view-toggle-btn { border-left:1px solid var(--border-strong); }
 .board-view-toggle-btn:hover { background:var(--bg-hover); color:var(--text-secondary); }
+.board-view-toggle-btn:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:-1px; z-index:1; position:relative; }
 .board-view-toggle-btn--active { background:color-mix(in oklch,var(--accent-presence) 16%,var(--bg-raised)); color:var(--text-primary); }
 
 .board-new-card-btn { height:28px; padding:0 12px; border-radius:7px; border:1px solid var(--border-strong); background:var(--accent-presence); color:var(--text-primary); font-size:12px; font-weight:500; cursor:pointer; transition:background .12s,transform .1s; white-space:nowrap; }
 .board-new-card-btn:hover { background:oklch(0.70 0.18 280); transform:scale(1.02); }
+.board-new-card-btn:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:2px; }
 
 .board-filter-chips { display:flex; flex-wrap:wrap; align-items:center; gap:5px; padding:6px 16px; border-bottom:1px solid var(--border-hairline); flex-shrink:0; }
 .board-filter-chip { display:inline-flex; align-items:center; gap:4px; padding:2px 8px; border-radius:20px; border:1px solid var(--border-strong); background:var(--bg-raised); color:var(--text-secondary); font-size:11px; cursor:default; }
 .board-filter-chip-remove { display:flex; align-items:center; justify-content:center; width:14px; height:14px; border-radius:4px; border:none; background:transparent; color:var(--text-muted); cursor:pointer; padding:0; margin-left:1px; transition:background .1s,color .1s; }
 .board-filter-chip-remove:hover { background:var(--bg-hover); color:var(--text-primary); }
-.board-filter-chip--clear-all { background:transparent; border:none; color:var(--text-muted); cursor:pointer; font-size:11px; padding:2px 6px; }
+.board-filter-chip-remove:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }
+.board-filter-chip--clear-all { background:transparent; border:none; color:var(--text-muted); cursor:pointer; font-size:11px; padding:2px 6px; border-radius:5px; }
 .board-filter-chip--clear-all:hover { color:var(--text-primary); }
+.board-filter-chip--clear-all:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }
 
 .board-filter-popover-anchor { position:relative; }
 .board-filter-popover { position:absolute; top:calc(100% + 6px); right:0; z-index:200; width:260px; background:var(--bg-raised); border:1px solid var(--border-strong); border-radius:12px; box-shadow:0 12px 40px rgba(0,0,0,.25); overflow:hidden; }
@@ -140,6 +147,14 @@
 .board-kanban-column-count { display:inline-flex; align-items:center; justify-content:center; min-width:18px; height:16px; padding:0 5px; border-radius:8px; background:var(--bg-raised); border:1px solid var(--border-hairline); color:var(--text-secondary); font-size:10px; font-weight:600; }
 .board-kanban-column-add { display:grid; place-items:center; width:22px; height:22px; border-radius:6px; border:none; background:transparent; color:var(--text-muted); cursor:pointer; transition:background .12s,color .12s; }
 .board-kanban-column-add:hover { background:var(--bg-hover); color:var(--text-primary); }
+.board-kanban-column-add:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }
+
+/* Swimlane horizontal scroll buttons (extracted from inline styles in
+   board-kanban.tsx so they pick up consistent hover + focus states). */
+.board-swimlane-scroll-btn { display:grid; place-items:center; width:20px; height:20px; border-radius:4px; border:none; background:transparent; color:var(--text-muted); cursor:pointer; transition:background .1s,color .1s; }
+.board-swimlane-scroll-btn:hover { background:var(--bg-hover); color:var(--text-primary); }
+.board-swimlane-scroll-btn:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }
+.board-swimlane-scroll-group { margin-left:auto; display:flex; gap:4px; }
 
 .board-kanban-list { flex:1; min-height:0; overflow-y:auto; padding:9px 9px 11px; display:flex; flex-direction:column; gap:7px; scrollbar-width:thin; scrollbar-color:var(--border-hairline) transparent; margin:0; list-style:none; }
 .board-kanban-empty { padding:18px 12px; border:1.5px dashed var(--border-hairline); border-radius:10px; display:flex; flex-direction:column; align-items:center; gap:6px; text-align:center; font-size:11px; color:var(--text-muted); line-height:1.45; }
@@ -197,6 +212,7 @@
 .board-drawer-title-input:focus { border-color:color-mix(in oklch,var(--accent-presence) 60%,transparent); background:var(--bg-base); box-shadow:0 0 0 3px color-mix(in oklch,var(--accent-presence) 16%,transparent); }
 .board-drawer-close { display:flex; align-items:center; justify-content:center; width:28px; height:28px; border-radius:7px; border:1px solid var(--border-strong); background:var(--bg-base); color:var(--text-muted); cursor:pointer; flex-shrink:0; transition:background .1s,color .1s; }
 .board-drawer-close:hover { background:var(--bg-hover); color:var(--text-primary); }
+.board-drawer-close:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }
 .board-drawer-body { flex:1; overflow-y:auto; padding:16px; display:flex; flex-direction:column; gap:18px; scrollbar-width:thin; scrollbar-color:var(--border-hairline) transparent; }
 .board-drawer-field { display:flex; flex-direction:column; gap:6px; }
 .board-drawer-field-label { display:inline-flex; align-items:center; gap:5px; font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.08em; color:var(--text-muted); }

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -47,7 +47,7 @@
 .board-view-toggle-btn--active { background:color-mix(in oklch,var(--accent-presence) 16%,var(--bg-raised)); color:var(--text-primary); }
 
 .board-new-card-btn { height:28px; padding:0 12px; border-radius:7px; border:1px solid var(--border-strong); background:var(--accent-presence); color:var(--text-primary); font-size:12px; font-weight:500; cursor:pointer; transition:background .12s,transform .1s; white-space:nowrap; }
-.board-new-card-btn:hover { background:oklch(0.70 0.18 280); transform:scale(1.02); }
+.board-new-card-btn:hover { background:color-mix(in oklch, var(--accent-presence) 85%, #000); transform:scale(1.02); }
 .board-new-card-btn:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:2px; }
 
 .board-filter-chips { display:flex; flex-wrap:wrap; align-items:center; gap:5px; padding:6px 16px; border-bottom:1px solid var(--border-hairline); flex-shrink:0; }
@@ -63,7 +63,7 @@
 .board-filter-popover { position:absolute; top:calc(100% + 6px); right:0; z-index:200; width:260px; background:var(--bg-raised); border:1px solid var(--border-strong); border-radius:12px; box-shadow:0 12px 40px rgba(0,0,0,.25); overflow:hidden; }
 .board-filter-popover-section { padding:10px 12px 6px; }
 .board-filter-popover-section+.board-filter-popover-section { border-top:1px solid var(--border-hairline); }
-.board-filter-popover-label { font-size:10px; font-weight:600; letter-spacing:.06em; text-transform:uppercase; color:var(--text-muted); margin-bottom:6px; }
+.board-filter-popover-label { font-size:10px; font-weight:600; letter-spacing:.06em; text-transform:uppercase; color:var(--text-secondary); margin-bottom:6px; }
 .board-filter-option { display:flex; align-items:center; gap:7px; padding:4px 2px; border-radius:5px; cursor:pointer; font-size:12px; color:var(--text-secondary); background:transparent; border:none; width:100%; text-align:left; transition:background .1s,color .1s; }
 .board-filter-option:hover { background:var(--bg-hover); color:var(--text-primary); }
 .board-filter-check { width:14px; height:14px; border-radius:4px; border:1px solid var(--border-strong); background:var(--bg-base); display:flex; align-items:center; justify-content:center; flex-shrink:0; transition:background .1s,border-color .1s; }
@@ -123,7 +123,7 @@
 .board-table-cell-time { color:var(--text-muted); font-size:11px; font-variant-numeric:tabular-nums; }
 
 .board-swimlane { flex-shrink:0; border-bottom:1px solid var(--border-hairline); }
-.board-swimlane-header { display:flex; align-items:center; gap:8px; padding:8px 16px 6px; font-size:11px; font-weight:600; color:var(--text-muted); letter-spacing:.05em; text-transform:uppercase; cursor:pointer; user-select:none; }
+.board-swimlane-header { display:flex; align-items:center; gap:8px; padding:8px 16px 6px; font-size:11px; font-weight:600; color:var(--text-secondary); letter-spacing:.05em; text-transform:uppercase; cursor:pointer; user-select:none; }
 .board-swimlane-header:hover { color:var(--text-primary); }
 .board-swimlane-badge { display:inline-flex; align-items:center; justify-content:center; min-width:18px; height:16px; padding:0 5px; border-radius:8px; background:var(--bg-raised); border:1px solid var(--border-hairline); color:var(--text-muted); font-size:10px; font-weight:500; }
 .board-swimlane-rail { overflow-x:auto; overflow-y:hidden; scroll-behavior:smooth; }
@@ -215,7 +215,7 @@
 .board-drawer-close:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }
 .board-drawer-body { flex:1; overflow-y:auto; padding:16px; display:flex; flex-direction:column; gap:18px; scrollbar-width:thin; scrollbar-color:var(--border-hairline) transparent; }
 .board-drawer-field { display:flex; flex-direction:column; gap:6px; }
-.board-drawer-field-label { display:inline-flex; align-items:center; gap:5px; font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.08em; color:var(--text-muted); }
+.board-drawer-field-label { display:inline-flex; align-items:center; gap:5px; font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.08em; color:var(--text-secondary); }
 .board-drawer-field-label svg { opacity:.85; }
 .board-drawer-count-pill { display:inline-flex; align-items:center; justify-content:center; min-width:16px; height:14px; padding:0 5px; border-radius:7px; background:var(--bg-elevated); border:1px solid var(--border-hairline); color:var(--text-secondary); font-size:9.5px; font-weight:600; letter-spacing:0; text-transform:none; }
 .board-drawer-field-select,.board-drawer-field-input { width:100%; padding:7px 10px; border-radius:8px; border:1px solid var(--border-strong); background:var(--bg-base); color:var(--text-primary); font-size:13px; outline:none; transition:border-color .12s,box-shadow .12s; }


### PR DESCRIPTION
Polish pass over the Board surface (kanban + table + drawer + floor table). Followup to #232 (sidebar/header/banner/rail). Same audit shape: read every component + CSS, prioritise into Critical / Important / Nice, ship the Critical items in three logical commits.

## Summary

- **\`fix(board): focus-visible rings on every interactive control\`** — Keyboard Tab through the Board was invisible across most buttons. Added \`:focus-visible\` to the toolbar buttons, search clear, group/view segmented toggles, new card button, filter chip remove + clear-all, kanban column add, drawer close. Also extracted the inline-styled swimlane scroll buttons from \`board-kanban.tsx\` into a \`.board-swimlane-scroll-btn\` class so they pick up consistent hover + focus alongside everyone else.
- **\`fix(board): light-mode theming — drop hardcoded oklch + bump small-text contrast\`** — Two distinct light-mode bugs in one commit:
  - \`.board-new-card-btn:hover\` used a fixed \`oklch(0.70 0.18 280)\` literal (dark-mode-only purple) for its hover background. Replaced with \`color-mix(in oklch, var(--accent-presence) 85%, #000)\` — darken-on-hover convention in both themes.
  - Three small-uppercase labels (\`.board-swimlane-header\`, \`.board-filter-popover-label\`, \`.board-drawer-field-label\`) were \`text-muted\`, which falls under AA against raised surfaces in pale themes. Bumped to \`text-secondary\`; hover/active still escalate to \`text-primary\` so the feedback ladder stays.
- **\`fix(board): stronger selected-state cue across table, kanban, floor\`** — Selected rows/cards used 8–9% accent tint + 2px inset bar. Subtle in dark, near-invisible in pale. Bumped table+floor to 14% / 3px; kanban card to 13% tint / 55% accent border / 35% inner ring. Still well below "loud" — readable, no longer guessable.

## Out of scope (flagged for followup)

- **Magic-number padding tokenization.** \`board.css\` has many hand-tuned \`padding: 7px 11px 6px\` -style values that should probably become spacing tokens. Real debt, but it's a tokenization refactor and not a polish change — would dwarf this PR.
- **\`board-inspector.tsx\` inline-style cleanup.** ~68 inline \`style={{...}}\` declarations in a 1018-line component. Pure refactor; no visible bug; deserves its own PR.
- **Empty-state opacity in light mode** (\`board-view.tsx:281\` \`bg-[var(--bg-raised)]/35\`). Reviewer flagged but unverified visually; safer to look in a browser first.

## Test plan

- [x] \`pnpm typecheck\` clean (every commit)
- [x] \`pnpm build\` clean (every commit)
- [ ] **Manual:** open dev server, walk through Board in dark and light themes; verify:
  - Tab through every header button + drawer + chips shows a focus ring
  - Hover the "New card" button — should darken in both themes (no purple jump in light)
  - Swimlane eyebrows + drawer field eyebrows readable in pale themes
  - Selected card (click) and selected table row look obviously selected at a glance
  - Swimlane scroll arrows still scroll the lane and now show hover/focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)