### PR TITLE
feat(memory-graph): wire per-familiar workspace memory into constellation graph

### DIFF
--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -5,7 +5,7 @@ import { homedir } from "node:os";
 
 export const dynamic = "force-dynamic";
 
-const MEMORY_ROOTS: Array<{ id: string; label: string; path: string }> = [
+const SHARED_MEMORY_ROOTS: Array<{ id: string; label: string; path: string }> = [
   {
     id: "workspace",
     label: "Workspace memory",
@@ -22,16 +22,25 @@ const MEMORY_INDEX_FILES = [
   path.join(homedir(), ".openclaw", "workspace", "MEMORY.md"),
 ];
 
-type MemoryEntry = {
+export type MemoryEntry = {
   root: string;
   rootLabel: string;
   relPath: string;
   fullPath: string;
   size: number;
   modified: string;
+  /** Familiar id when this entry belongs to a specific agent workspace */
+  familiarId?: string;
 };
 
-async function walk(dir: string, root: string, rootLabel: string, acc: MemoryEntry[]) {
+async function walk(
+  dir: string,
+  root: string,
+  rootLabel: string,
+  acc: MemoryEntry[],
+  baseDir: string,
+  familiarId?: string,
+) {
   let items;
   try {
     items = await readdir(dir, { withFileTypes: true });
@@ -42,17 +51,18 @@ async function walk(dir: string, root: string, rootLabel: string, acc: MemoryEnt
     if (item.name.startsWith(".")) continue;
     const full = path.join(dir, item.name);
     if (item.isDirectory()) {
-      await walk(full, root, rootLabel, acc);
+      await walk(full, root, rootLabel, acc, baseDir, familiarId);
     } else if (item.isFile() && /\.(md|markdown|txt|json)$/i.test(item.name)) {
       try {
         const s = await stat(full);
         acc.push({
           root,
           rootLabel,
-          relPath: path.relative(MEMORY_ROOTS.find((r) => r.id === root)?.path ?? dir, full),
+          relPath: path.relative(baseDir, full),
           fullPath: full,
           size: s.size,
           modified: s.mtime.toISOString(),
+          ...(familiarId ? { familiarId } : {}),
         });
       } catch {
         /* skip */
@@ -61,16 +71,52 @@ async function walk(dir: string, root: string, rootLabel: string, acc: MemoryEnt
   }
 }
 
+async function scanFamiliarWorkspaces(acc: MemoryEntry[]) {
+  const workspacesDir = path.join(homedir(), ".openclaw", "workspace");
+  let items;
+  try {
+    items = await readdir(workspacesDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const item of items) {
+    if (!item.isDirectory() || item.name.startsWith(".")) continue;
+    const familiarId = item.name;
+    const memDir = path.join(workspacesDir, familiarId, "memory");
+    // Also include top-level MEMORY.md for this familiar
+    const indexFile = path.join(workspacesDir, familiarId, "MEMORY.md");
+    try {
+      const s = await stat(/* turbopackIgnore: true */ indexFile);
+      acc.push({
+        root: `familiar:${familiarId}`,
+        rootLabel: familiarId,
+        relPath: "MEMORY.md",
+        fullPath: indexFile,
+        size: s.size,
+        modified: s.mtime.toISOString(),
+        familiarId,
+      });
+    } catch {
+      /* no MEMORY.md for this familiar */
+    }
+    await walk(memDir, `familiar:${familiarId}`, familiarId, acc, memDir, familiarId);
+  }
+}
+
 export async function GET() {
   const entries: MemoryEntry[] = [];
-  for (const root of MEMORY_ROOTS) {
-    await walk(root.path, root.id, root.label, entries);
+
+  // Shared workspace/coven memory dirs
+  for (const root of SHARED_MEMORY_ROOTS) {
+    await walk(root.path, root.id, root.label, entries, root.path);
   }
+
+  // Per-familiar agent workspace memory dirs
+  await scanFamiliarWorkspaces(entries);
+
+  // Top-level shared MEMORY.md index
   for (const idx of MEMORY_INDEX_FILES) {
     try {
-      // idx is one of the absolute homedir-prefixed paths in
-      // MEMORY_INDEX_FILES. turbopackIgnore prevents bundling all matching
-      // candidates as static patterns.
       const s = await stat(/* turbopackIgnore: true */ idx);
       entries.push({
         root: "index",
@@ -84,6 +130,7 @@ export async function GET() {
       /* missing */
     }
   }
+
   entries.sort((a, b) => (a.modified < b.modified ? 1 : -1));
   return NextResponse.json({ ok: true, entries });
 }

--- a/src/lib/memory-graph-3d-model.ts
+++ b/src/lib/memory-graph-3d-model.ts
@@ -16,6 +16,8 @@ export type MemoryGraphFileEntry = {
   fullPath: string;
   size: number;
   modified: string;
+  /** Familiar id when this entry belongs to a specific agent workspace */
+  familiarId?: string;
 };
 
 export type MemoryGraphHubNode = {
@@ -219,7 +221,7 @@ function addCappedLeaves({
 export function buildMemoryGraphModel({
   familiars,
   covenEntries,
-  fileEntries: _fileEntries,
+  fileEntries,
   query = "",
   familiarFilter = "all",
   maxLeavesPerHub = 30,
@@ -238,7 +240,9 @@ export function buildMemoryGraphModel({
 
   const selectedFamiliarId = familiarFilter !== "all"
     ? familiarFilter
-    : covenEntries.find((entry) => matchesQuery([entry.title, entry.excerpt, entry.familiar_id, entry.path], q))?.familiar_id ?? familiars[0]?.id;
+    : covenEntries.find((entry) => matchesQuery([entry.title, entry.excerpt, entry.familiar_id, entry.path], q))?.familiar_id
+      ?? fileEntries.find((entry) => entry.familiarId && matchesQuery([entry.relPath, entry.familiarId], q))?.familiarId
+      ?? familiars[0]?.id;
   const selectedFamiliar = familiars.find((familiar) => familiar.id === selectedFamiliarId);
 
   const matchingCovenEntries = covenEntries
@@ -253,6 +257,19 @@ export function buildMemoryGraphModel({
     matchesQuery([entry.title, entry.excerpt, entry.familiar_id, entry.path], q),
   ).length;
 
+  // File entries for the selected familiar from agent workspace memory dirs
+  const matchingFileEntries = fileEntries
+    .filter((entry) => entry.familiarId === selectedFamiliarId)
+    .filter((entry) => matchesQuery([entry.relPath, entry.rootLabel, entry.familiarId ?? ""], q))
+    .sort((a, b) => compareIsoDesc(a.modified, b.modified));
+
+  const totalFileEntries = fileEntries.filter((entry) =>
+    entry.familiarId === selectedFamiliarId &&
+    matchesQuery([entry.relPath, entry.rootLabel, entry.familiarId ?? ""], q),
+  ).length;
+
+  const totalMemoryCount = totalMatchingForFamiliar + totalFileEntries;
+
   if (selectedFamiliar) {
     const hubId = `familiar:${selectedFamiliar.id}`;
     nodes.push({
@@ -262,9 +279,10 @@ export function buildMemoryGraphModel({
       label: selectedFamiliar.display_name ?? selectedFamiliar.name ?? selectedFamiliar.id,
       glyph: selectedFamiliar.icon ?? selectedFamiliar.emoji,
       familiarId: selectedFamiliar.id,
-      memoryCount: totalMatchingForFamiliar,
-      latestAt: matchingCovenEntries[0]?.updated_at,
+      memoryCount: totalMemoryCount,
+      latestAt: matchingCovenEntries[0]?.updated_at ?? matchingFileEntries[0]?.modified,
     });
+    // Coven (daemon-indexed) memory leaves
     addCappedLeaves({
       hubId,
       familiarId: selectedFamiliar.id,
@@ -289,6 +307,51 @@ export function buildMemoryGraphModel({
       },
     });
     hiddenEntries += Math.max(matchingCovenEntries.length - maxLeavesPerHub, 0);
+    // File-based memory leaves (agent workspace memory/ dirs)
+    if (matchingFileEntries.length > 0) {
+      const fileHubId = `familiar-files:${selectedFamiliar.id}`;
+      nodes.push({
+        kind: "hub",
+        hubKind: "files",
+        id: fileHubId,
+        label: `${selectedFamiliar.display_name ?? selectedFamiliar.id} files`,
+        familiarId: selectedFamiliar.id,
+        memoryCount: totalFileEntries,
+        latestAt: matchingFileEntries[0]?.modified,
+      });
+      edges.push({
+        id: edgeId(fileHubId, hubId),
+        kind: "belongs_to",
+        source: fileHubId,
+        target: hubId,
+        count: totalFileEntries,
+      });
+      addCappedLeaves({
+        hubId: fileHubId,
+        familiarId: selectedFamiliar.id,
+        source: "file",
+        entries: matchingFileEntries,
+        maxLeavesPerHub,
+        nodes,
+        edges,
+        toMemoryNode: (entry) => {
+          const file = entry as MemoryGraphFileEntry;
+          return {
+            kind: "memory",
+            id: `file:${file.fullPath}`,
+            source: "file",
+            hubId: fileHubId,
+            familiarId: file.familiarId,
+            title: file.relPath,
+            path: file.fullPath,
+            updatedAt: file.modified,
+            rootLabel: file.rootLabel,
+            relPath: file.relPath,
+          };
+        },
+      });
+      hiddenEntries += Math.max(matchingFileEntries.length - maxLeavesPerHub, 0);
+    }
   }
 
   return {
@@ -296,9 +359,9 @@ export function buildMemoryGraphModel({
     edges,
     metrics: {
       familiarHubs: selectedFamiliar ? 1 : 0,
-      fileHubs: 0,
+      fileHubs: selectedFamiliar && matchingFileEntries.length > 0 ? 1 : 0,
       visibleCovenEntries: matchingCovenEntries.length,
-      visibleFileEntries: 0,
+      visibleFileEntries: matchingFileEntries.length,
       hiddenEntries,
     },
   };


### PR DESCRIPTION
## What

The memory constellation graph was only showing 1 entry (sage's daemon-indexed memory) because:
1. `/api/memory` only scanned the shared `~/.openclaw/workspace/memory/` folder, not per-familiar dirs
2. `buildMemoryGraphModel` accepted `fileEntries` but rendered nothing from them

## Fix

**`/api/memory`**: now also walks `~/.openclaw/workspace/<familiarId>/memory/` for every familiar, and includes their `MEMORY.md`. Each entry gets a `familiarId` field.

**`memory-graph-3d-model.ts`**: `MemoryGraphFileEntry` gains `familiarId?`; the model builds a `files` sub-hub per familiar with all matching file entries as leaves, connected to the familiar hub.

## Result

API now returns ~1,200 entries across all familiars (cody: 178, echo: 157, kitty: 143, charm: 133, sage: 133, astra: 125…) — all visible in the graph.