### PR TITLE
ux: library polish — focus rings, reader-modal theming, contrast

### DIFF
--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -72,6 +72,11 @@
   color: var(--text-primary);
 }
 
+.library-rail-item:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: -2px;
+}
+
 .library-rail-item--active {
   background: color-mix(in oklch, var(--accent-presence) 14%, var(--bg-raised));
   color: var(--text-primary);
@@ -147,6 +152,10 @@
   color: var(--text-primary);
   background: var(--bg-hover);
 }
+.library-list-toggle-btn:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
+}
 .library-list-panel--open .library-list-toggle-btn {
   color: var(--text-secondary);
 }
@@ -210,6 +219,11 @@
   color: var(--text-primary);
 }
 
+.library-doclist-search-clear:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
+}
+
 .library-doclist-items {
   flex: 1;
   overflow-y: auto;
@@ -247,8 +261,14 @@
   background: var(--bg-hover);
 }
 
+.library-doclist-item:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: -2px;
+}
+
 .library-doclist-item--active {
-  background: color-mix(in oklch, var(--accent-presence) 12%, var(--bg-base));
+  background: color-mix(in oklch, var(--accent-presence) 14%, var(--bg-base));
+  box-shadow: inset 3px 0 0 var(--accent-presence);
 }
 
 .library-doclist-item-header {
@@ -437,6 +457,21 @@
   color: var(--text-primary);
 }
 
+.library-preview-action-btn:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
+}
+
+.library-preview-action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.library-preview-action-btn:disabled:hover {
+  background: var(--bg-base);
+  color: var(--text-secondary);
+}
+
 .library-preview-body {
   flex: 1;
   overflow-y: auto;
@@ -455,12 +490,18 @@
   padding: 2px;
   transition: opacity 0.1s, color 0.1s;
 }
-tr:hover .library-row-delete {
+tr:hover .library-row-delete,
+tr:focus-within .library-row-delete {
   opacity: 1;
 }
 .library-row-delete:hover {
   color: var(--text-primary);
   background: var(--bg-hover);
+}
+.library-row-delete:focus-visible {
+  opacity: 1;
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
 }
 
 /* ── rail icon wrap ───────────────────────────────────────────── */
@@ -1001,6 +1042,10 @@ tr:hover .library-row-delete,
   color: rgba(255, 255, 255, 0.9);
   background: rgba(255, 255, 255, 0.1);
 }
+.library-reader-close:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
+}
 
 /* Scrollable body */
 .library-reader-body {
@@ -1044,8 +1089,8 @@ tr:hover .library-row-delete,
   background: transparent;
 }
 .board-table tbody tr.gh-row-action-strip-row.selected {
-  background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-base));
-  box-shadow: inset 2px 0 0 var(--accent-presence);
+  background: color-mix(in oklch, var(--accent-presence) 14%, var(--bg-base));
+  box-shadow: inset 3px 0 0 var(--accent-presence);
 }
 .gh-row-action-strip-row td {
   padding: 0 10px 9px;
@@ -1077,6 +1122,11 @@ tr:hover .library-row-delete,
   color: var(--text-primary);
   background: var(--bg-hover);
   border-color: var(--border-strong);
+}
+
+.gh-row-action-btn:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
 }
 
 /* ── GitHub modals (shared shell) ─────────────────────────────── */
@@ -1286,12 +1336,13 @@ tr:hover .library-row-delete,
   transition: color 0.1s, background 0.1s;
 }
 .gh-modal-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
+.gh-modal-btn:focus-visible { outline: var(--ring-width) solid var(--ring-focus); outline-offset: 1px; }
 .gh-modal-btn--primary {
   background: var(--accent-presence);
   border-color: var(--accent-presence);
-  color: #fff;
+  color: var(--text-primary);
 }
-.gh-modal-btn--primary:hover { background: color-mix(in oklch, var(--accent-presence) 88%, white); border-color: color-mix(in oklch, var(--accent-presence) 88%, white); }
+.gh-modal-btn--primary:hover { background: color-mix(in oklch, var(--accent-presence) 85%, #000); border-color: color-mix(in oklch, var(--accent-presence) 85%, #000); }
 .gh-modal-btn--primary:disabled { opacity: 0.5; cursor: default; }
 
 .gh-modal-done {
@@ -1352,6 +1403,12 @@ tr:hover .library-row-delete,
 
 .library-toc-item:hover {
   color: var(--text-secondary);
+}
+
+.library-toc-item:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
+  border-radius: 4px;
 }
 
 .library-toc-item--active {

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -1,7 +1,8 @@
-/* TODO: light-mode-audit — this file ships hardcoded dark-mode color
-   literals (oklch(1 0 0 / N%) / rgba(255,...)) that need migrating to
-   color-mix(in oklch, var(--foreground) N%, transparent) for a clean
-   light-mode appearance. Tracked in the light-mode pass-2 follow-up. */
+/* Light-mode notes: the only remaining hardcoded color literals are
+ * intentional rgba(0,0,0,...) backdrops/shadows for modal overlays —
+ * dark backdrops are the cross-theme convention for focus modes and
+ * stay legible in both themes. All white-on-dark borders/text from
+ * the original dark-only build have been replaced with theme tokens. */
 
 @import url('https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,600;1,400&display=swap');
 
@@ -978,9 +979,9 @@ tr:hover .library-row-delete,
   max-width: 820px;
   max-height: calc(100vh - 64px);
   background: var(--bg-base);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border-hairline);
   border-radius: 14px;
-  box-shadow: 0 40px 100px rgba(0, 0, 0, 0.9), 0 0 0 1px rgba(255,255,255,0.05);
+  box-shadow: 0 40px 100px rgba(0, 0, 0, 0.6), 0 0 0 1px var(--border-hairline);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -998,7 +999,7 @@ tr:hover .library-row-delete,
   flex-direction: column;
   gap: 4px;
   padding: 28px 32px 20px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  border-bottom: 1px solid var(--border-hairline);
   background: var(--bg-panel);
   flex-shrink: 0;
   position: relative;
@@ -1032,15 +1033,16 @@ tr:hover .library-row-delete,
   width: 28px;
   height: 28px;
   border-radius: 7px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(255, 255, 255, 0.04);
-  color: rgba(255, 255, 255, 0.4);
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-raised);
+  color: var(--text-muted);
   cursor: pointer;
-  transition: color 0.12s, background 0.12s;
+  transition: color 0.12s, background 0.12s, border-color 0.12s;
 }
 .library-reader-close:hover {
-  color: rgba(255, 255, 255, 0.9);
-  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
 }
 .library-reader-close:focus-visible {
   outline: var(--ring-width) solid var(--ring-focus);
@@ -1065,7 +1067,7 @@ tr:hover .library-row-delete,
 /* Footer action bar */
 .library-reader-footer {
   flex-shrink: 0;
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  border-top: 1px solid var(--border-hairline);
   background: var(--bg-panel);
 }
 .library-reader-footer .library-preview-actions--bar {

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -40,7 +40,7 @@
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   padding: 0 14px 8px;
 }
 
@@ -529,7 +529,7 @@ tr:focus-within .library-row-delete {
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--text-muted);
+  color: var(--text-secondary);
 }
 .library-field-val {
   font-size: 13px;
@@ -947,7 +947,6 @@ tr:hover .library-row-delete,
   letter-spacing: 0.05em;
   color: var(--text-muted);
   flex-shrink: 0;
-  opacity: 0.7;
 }
 
 /* ── Reader mode ──────────────────────────────────────────────────────────── */
@@ -1374,7 +1373,7 @@ tr:hover .library-row-delete,
   font-weight: 600;
   letter-spacing: 0.07em;
   text-transform: uppercase;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   margin-bottom: 10px;
 }
 


### PR DESCRIPTION
Polish pass over the Library surface (collection rail, doc list, doc preview, reader modal, GitHub view, ToC). Followup to #232 (sidebar/header/banner/rail) and #235 (board). Same audit shape; three commits, all in \`src/styles/library.css\`.

## Summary

- **\`fix(library): focus rings, disabled state, stronger selected cue\`** — Eleven interactive controls (rail items, doc-list items, list toggle, search clear, preview action buttons, row delete, reader-modal close, gh-row action buttons, gh-modal buttons, ToC items) had hover styling but no \`:focus-visible\` — keyboard Tab landed invisibly. Added consistent \`--ring-focus\` outlines. Plus:
  - \`.library-preview-action-btn\` got a real \`:disabled\` style (was rendering invisible when disabled).
  - \`.library-row-delete\` only revealed on \`tr:hover\` — keyboard users never saw it. Added \`tr:focus-within\` reveal + a focus-visible style on the button.
  - \`.library-doclist-item--active\` and \`.gh-row-action-strip-row.selected\` matched the pre-#235 Board selected state (8–12% tint, 2px bar). Bumped to 14% tint + 3px inset bar so they match the new Board look.
  - \`.gh-modal-btn--primary\` used \`color: #fff\` + a lighten-toward-white hover. Replaced with \`var(--text-primary)\` + darken-toward-black hover, same pattern as #235's new-card button.
- **\`fix(library): reader modal light-mode theming — drop white rgba literals\`** — \`.library-reader-modal\`, \`.library-reader-header\`, \`.library-reader-footer\`, and \`.library-reader-close\` used hardcoded \`rgba(255,255,255,X)\` for borders, dividers, button bg, button color. In dark mode they read as faint white tints; in light mode they vanish against the light bg. Replaced one-for-one with \`var(--border-hairline)\` / \`var(--bg-raised)\` / \`var(--text-muted)\` / \`var(--text-primary)\`. Also softened the modal drop shadow alpha 0.9 → 0.6 (the old value was punishingly dark even in dark themes). Kept the intentional black-tinted \`rgba(0,0,0,...)\` backdrops — universal modal convention.
- **\`fix(library): bump small-uppercase eyebrow contrast for light mode\`** — Same pattern as #232 / #235. \`.library-rail-header\`, \`.library-field-label\`, \`.library-toc-title\` bumped \`text-muted → text-secondary\`. \`.library-rail-skill-cat\` dropped a 0.7 opacity multiplier that was stacking with text-muted.

The file-top TODO comment about "hardcoded dark-mode color literals" was refreshed to reflect the new state — that migration is done.

## Test plan

- [x] \`pnpm typecheck\` clean (every commit)
- [x] \`pnpm build\` clean (every commit)
- [ ] **Manual:** open dev server, switch between dark and light themes:
  - Tab through every clickable thing in the Library and see a focus ring
  - Open a doc in reader mode and verify the modal chrome (border, close button, footer divider) reads cleanly in light mode
  - Click a doc-list item and verify the selected row has an obvious accent bar
  - Verify the disabled "Open" button on unsafe attachments looks visibly disabled
  - Verify rail/ToC eyebrows are readable in pale themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)