### PR TITLE
ux: inbox polish — focus rings, toast hover, eyebrow contrast

### DIFF
--- a/src/components/inbox-escalations-view.tsx
+++ b/src/components/inbox-escalations-view.tsx
@@ -247,7 +247,7 @@ export function InboxEscalationsView({
               </label>
               <button
                 onClick={() => void refresh()}
-                className="rounded border border-border px-2 py-0.5 transition-colors hover:bg-muted"
+                className="focus-ring rounded border border-border px-2 py-0.5 transition-colors hover:bg-muted"
                 title="Refresh"
               >
                 <Icon name="ph:arrows-clockwise-bold" width={11} height={11} aria-hidden />
@@ -257,8 +257,8 @@ export function InboxEscalationsView({
 
           {error ? (
             <div
-              className="px-5 py-1.5 text-xs text-[var(--color-danger)]"
-              style={{ background: "rgba(244,184,184,0.08)", borderBottom: "1px solid var(--border-hairline)" }}
+              className="border-b border-[var(--border-hairline)] px-5 py-1.5 text-xs text-[var(--color-danger)]"
+              style={{ background: "color-mix(in oklch, var(--color-danger) 10%, var(--bg-base))" }}
             >
               {error}
             </div>
@@ -426,7 +426,7 @@ function ActionButton({
         onClick();
       }}
       disabled={disabled}
-      className={`rounded border px-2 py-0.5 transition-colors disabled:opacity-40 ${
+      className={`focus-ring rounded border px-2 py-0.5 transition-colors disabled:opacity-40 ${
         primary
           ? "border-border-strong bg-muted text-foreground hover:bg-card"
           : "border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground"
@@ -451,21 +451,21 @@ function SnoozeMenu({
       className="mt-2 flex flex-col gap-1 rounded border bg-card p-2 text-[11px]"
       style={{ borderColor: "var(--border-hairline)" }}
     >
-      <div className="px-1 text-[9px] uppercase tracking-widest text-muted-foreground">
+      <div className="px-1 text-[9px] uppercase tracking-widest text-[var(--text-secondary)]">
         Snooze until
       </div>
       {SNOOZE_PRESETS.map((p) => (
         <button
           key={p.id}
           onClick={() => onPick(p.id)}
-          className="rounded px-2 py-1 text-left text-foreground transition-colors hover:bg-muted"
+          className="focus-ring rounded px-2 py-1 text-left text-foreground transition-colors hover:bg-muted"
         >
           {p.label}
         </button>
       ))}
       <button
         onClick={onClose}
-        className="mt-1 rounded px-2 py-1 text-left text-muted-foreground transition-colors hover:bg-muted"
+        className="focus-ring mt-1 rounded px-2 py-1 text-left text-muted-foreground transition-colors hover:bg-muted"
       >
         Cancel
       </button>

--- a/src/components/inbox-toast.tsx
+++ b/src/components/inbox-toast.tsx
@@ -70,7 +70,7 @@ export function InboxToastStack({ toasts, onDismiss, onSnooze, onOpen }: Props) 
             {onOpen ? (
               <button
                 onClick={() => onOpen(t)}
-                className="focus-ring rounded bg-[var(--accent-presence)] px-2 py-0.5 text-[10px] font-semibold text-[var(--text-primary)] transition-colors hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,white)]"
+                className="focus-ring rounded bg-[var(--accent-presence)] px-2 py-0.5 text-[10px] font-semibold text-[var(--text-primary)] transition-colors hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)]"
               >
                 Open
               </button>

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -142,7 +142,7 @@ export function NotificationBell({
       {open ? (
         <div className="absolute right-0 top-full z-50 mt-1 w-[360px] rounded-xl border border-[var(--border-strong)] bg-[var(--bg-elevated)] shadow-2xl">
           <div className="flex items-center justify-between border-b border-[var(--border-hairline)] px-3 py-2">
-            <span className="text-[10px] uppercase tracking-widest text-[var(--text-muted)]">
+            <span className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">
               Notifications
             </span>
             <div className="flex items-center gap-2">
@@ -168,7 +168,7 @@ export function NotificationBell({
 
           {settingsOpen ? (
             <div className="border-b border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 p-3 text-[11px]">
-              <div className="mb-2 text-[10px] uppercase tracking-widest text-[var(--text-muted)]">
+              <div className="mb-2 text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">
                 Sound
               </div>
               <div className="mb-3 flex flex-wrap gap-1">
@@ -203,7 +203,7 @@ export function NotificationBell({
                 })}
               </div>
 
-              <div className="mb-1.5 text-[10px] uppercase tracking-widest text-[var(--text-muted)]">
+              <div className="mb-1.5 text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">
                 Muted familiars
               </div>
               <ul className="max-h-32 space-y-0.5 overflow-y-auto">


### PR DESCRIPTION
Polish pass over the Inbox surface (escalations view, toast stack, notification bell). Followup to #232 (sidebar/header/banner/rail), #235 (board), #238 (library). Same audit shape, three commits — one per file touched.

## Summary

- **`fix(inbox): focus rings + contrast + themed error banner`** (`inbox-escalations-view.tsx`)
  - Refresh button (header), `ActionButton` (Open / Acknowledge / Snooze / Resolve / Dismiss on each row), and `SnoozeMenu` buttons (preset rows + Cancel) lacked the `focus-ring` utility. Keyboard Tab landed invisibly across 30+ buttons. Added `focus-ring` everywhere so they pick up the standard `--ring-focus` outline on `:focus-visible`.
  - "Snooze until" eyebrow was `text-muted-foreground` at 9px uppercase — the recurring AA-fail pattern. Bumped to `text-secondary`.
  - Error banner used a hardcoded `rgba(244,184,184,0.08)` background that doesn't track theme. Replaced with `color-mix(in oklch, var(--color-danger) 10%, var(--bg-base))`.
- **`fix(inbox-toast): darken-on-hover instead of lighten-toward-white`** (`inbox-toast.tsx`)
  - The toast's primary "Open" button hover used `color-mix(... 85%, white)`. In light themes the bg is already light, so darkening "toward white" is a no-op and the button looks non-interactive on hover. Switched the mix partner to `#000` — same convention landed in #235 (new-card-btn) and #238 (gh-modal-btn--primary).
- **`fix(notification-bell): bump uppercase eyebrow contrast for light mode`** (`notification-bell.tsx`)
  - Three 10px-uppercase-tracked labels in the bell popover (Notifications header, Sound, Muted familiars) were `text-muted`. Bumped to `text-secondary` so they meet AA against the popover's raised surface in pale themes.

## Out of scope (flagged for followup)

- Toast and bell-popover already use the project's `focus-ring` utility class consistently — no missing keyboard support there (the initial audit suggested otherwise but verification during edit confirmed they're fine).

## Test plan

- [x] `pnpm typecheck` clean (every commit)
- [x] `pnpm build` clean (every commit)
- [ ] **Manual:** switch to light theme, fire a test reminder, verify:
  - All action buttons on the escalation rows show a focus ring on Tab
  - "Open" button on the toast clearly darkens on hover (not invisible)
  - Bell popover labels (Notifications / Sound / Muted familiars) readable
  - Error banner reads as a danger tint, not as a hardcoded pink wash

🤖 Generated with [Claude Code](https://claude.com/claude-code)