### PR TITLE
[codex] Make linear chat full width

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "log",
  "once_cell",

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -96,6 +96,12 @@ assert.match(
   "Chat turns should use the dense linear transcript anatomy",
 );
 
+assert.match(
+  source,
+  /<div className="cave-composer-shell">/,
+  "Composer should use the CSS-controlled shell so linear chat can run full width",
+);
+
 assert.doesNotMatch(
   source,
   /FamiliarSwitcher/,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -937,7 +937,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       ) : null}
 
       <footer className="cave-composer-dock">
-        <div className="relative mx-auto w-full max-w-[1180px]">
+        <div className="cave-composer-shell">
           {slashSuggestions.length > 0 ? (
             <div className="absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-xl">
               <ul className="max-h-64 overflow-y-auto py-1">

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -801,7 +801,7 @@
 
 .cave-chat-linear .cave-chat-thread {
   gap: 0;
-  width: min(100%, 1180px);
+  width: 100%;
 }
 
 .cave-linear-turn {
@@ -877,6 +877,17 @@
 
 .cave-chat-linear .cave-composer-dock {
   padding: 10px clamp(16px, 3vw, 34px) 16px;
+}
+
+.cave-composer-shell {
+  position: relative;
+  width: 100%;
+  max-width: 1180px;
+  margin: 0 auto;
+}
+
+.cave-chat-linear .cave-composer-shell {
+  max-width: none;
 }
 
 .cave-chat-linear .cave-composer-panel {


### PR DESCRIPTION
## Summary
- Let the dense linear chat transcript span the full available chat detail pane.
- Move the composer width control into a reusable `cave-composer-shell` wrapper.
- Add a focused polish assertion so linear chat keeps full-width composer behavior.
- Sync `src-tauri/Cargo.lock` package version from `0.0.49` to `0.0.50` so the existing Rust CI `cargo check --locked` step can run.

## Impact
This keeps the B/dense-linear chat direction while removing the remaining constrained-column feel from the transcript and composer. The lockfile change is a one-line CI hygiene fix for the current release version.

## Validation
- `node src/components/chat-view-polish.test.ts` passes (Node module-type warning only)
- `pnpm typecheck` passes
- `pnpm build` passes
- `cargo check --locked` passes
- Playwright desktop sanity confirmed full-width transcript/composer and no horizontal overflow

## Notes
- Left unrelated untracked file `assets/salem-perch-smoke.png` out of the commit.
