### PR TITLE
ux: plugins polish — focus rings, themed CTA, eyebrow contrast

### DIFF
--- a/src/components/plugin-card.tsx
+++ b/src/components/plugin-card.tsx
@@ -23,7 +23,7 @@ const CATEGORY_ICON: Record<string, IconName> = {
 };
 
 const ROW_CLASS =
-  "flex w-full items-center gap-4 px-3 py-3 border-b border-[var(--border-hairline)] last:border-b-0 transition-colors hover:bg-[var(--bg-raised)]";
+  "focus-ring flex w-full items-center gap-4 px-3 py-3 border-b border-[var(--border-hairline)] last:border-b-0 transition-colors hover:bg-[var(--bg-raised)]";
 
 function recommendedFor(plugin: MarketplacePluginWithState): string {
   const familiars = plugin.roleAffinity.map((entry) => entry.familiar);
@@ -96,7 +96,7 @@ export function PluginCard({
           Installed
         </span>
       ) : (
-        <span className="flex shrink-0 items-center gap-1 text-[11px] text-[oklch(0.65_0.18_280)]">
+        <span className="flex shrink-0 items-center gap-1 text-[11px] text-[var(--accent-presence)]">
           <Icon name="ph:plug-bold" width={10} />
           {setupLabel(plugin)}
         </span>

--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -425,7 +425,7 @@ export function PluginsView({
                 key={t}
                 type="button"
                 onClick={() => handleTabChange(t)}
-                className={`relative flex h-full shrink-0 items-center px-3 text-[13px] font-medium transition-colors after:absolute after:bottom-0 after:left-0 after:right-0 after:h-[2px] after:rounded-full after:transition-colors ${
+                className={`focus-ring relative flex h-full shrink-0 items-center px-3 text-[13px] font-medium transition-colors after:absolute after:bottom-0 after:left-0 after:right-0 after:h-[2px] after:rounded-full after:transition-colors ${
                   tab === t
                     ? "text-foreground after:bg-foreground"
                     : "text-muted-foreground hover:text-foreground after:bg-transparent"
@@ -524,14 +524,14 @@ export function PluginsView({
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
                 placeholder={HERO_SEARCH_PLACEHOLDER[tab]}
-                className="h-10 w-full rounded-lg border border-border bg-card pl-9 pr-4 text-[13px] text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-border-strong"
+                className="focus-ring h-10 w-full rounded-lg border border-border bg-card pl-9 pr-4 text-[13px] text-foreground transition-colors placeholder:text-muted-foreground focus:border-border-strong"
               />
             </div>
           </div>
 
           {/* ── Section label + grid ──────────────────────────────────────── */}
           <section>
-            <h2 className="mb-3 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+            <h2 className="mb-3 text-[11px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">
               {SECTION_LABEL[tab]}
               {tab === "plugins" && marketplaceLoaded && !marketplaceError && (
                 <span className="ml-2 font-normal normal-case tracking-normal text-[var(--text-muted)]">
@@ -768,7 +768,7 @@ function RoleGrid({
             <button
               type="button"
               onClick={() => toggleCollapse(fam)}
-              className="mb-2 flex w-full items-center gap-2 text-left"
+              className="focus-ring mb-2 flex w-full items-center gap-2 rounded text-left"
             >
               <Icon
                 name="ph:caret-right-bold"
@@ -924,7 +924,7 @@ function RoleCard({
         }
       }}
       className={[
-        "group flex min-w-0 cursor-pointer items-center gap-3 rounded-lg border px-3 py-2.5 transition-colors",
+        "focus-ring group flex min-w-0 cursor-pointer items-center gap-3 rounded-lg border px-3 py-2.5 transition-colors",
         selected
           ? "border-[var(--accent-presence)] bg-[var(--accent-presence)]/10"
           : role.active
@@ -986,7 +986,7 @@ function RoleCard({
         disabled={toggling}
         onClick={handleToggle}
         className={[
-          "ml-auto shrink-0 rounded-md p-1.5 transition-colors disabled:opacity-40",
+          "focus-ring ml-auto shrink-0 rounded-md p-1.5 transition-colors disabled:opacity-40",
           role.active
             ? "text-[var(--color-success)] hover:bg-[color-mix(in_oklch,var(--color-success)_15%,transparent)]"
             : "text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]",
@@ -1178,7 +1178,7 @@ function RoleActionsRow({ role, onOpenChat }: { role: RoleEntry; onOpenChat: () 
   };
 
   const btnClass =
-    "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]";
+    "focus-ring inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]";
 
   return (
     <div className="flex flex-wrap items-center gap-1">
@@ -1214,7 +1214,7 @@ function RoleRelationItem({
     <li className="overflow-hidden rounded-md bg-[var(--bg-elevated)]/60">
       <button
         type="button"
-        className="flex min-w-0 w-full items-center gap-2 px-2.5 py-1.5 text-left transition-colors hover:bg-[var(--bg-elevated)]"
+        className="focus-ring flex min-w-0 w-full items-center gap-2 px-2.5 py-1.5 text-left transition-colors hover:bg-[var(--bg-elevated)]"
         onClick={() => hasDetail && setOpen((v) => !v)}
         aria-expanded={hasDetail ? open : undefined}
       >
@@ -1534,7 +1534,7 @@ function CreateDropdown({
         <button
           key={item.id}
           role="menuitem"
-          className={`flex w-full items-center gap-3 px-3 py-2.5 text-left text-[12px] transition-colors hover:bg-muted ${
+          className={`focus-ring flex w-full items-center gap-3 px-3 py-2.5 text-left text-[12px] transition-colors hover:bg-muted ${
             i < CREATE_ITEMS.length - 1 ? "border-b border-border" : ""
           }`}
           onClick={() => {


### PR DESCRIPTION
Polish pass over the Plugins surface (plugins-view + plugin-card). Followup to #232 / #235 / #238 / #239 / #241 / #243. Single combined commit because all the fixes are closely related (a11y + theming).

## Summary

- **Focus rings** — Eight interactive controls were missing `:focus-visible` styling. Keyboard Tab landed invisibly across:
  - Tab nav (Plugins / Roles / Skills / Hooks / MCP)
  - Hero search input (also dropped the dead `outline-none` it had)
  - Family-collapse buttons in the role tree
  - `RoleCard` (the `role="button"` div + its activation toggle)
  - `RoleActionsRow` shared button class (Open ROLE.md / Copy id / Chat with role)
  - `RoleRelationItem` expandable button
  - `CreateMenu` dropdown items
  - `PluginCard` `ROW_CLASS` (covers both the button and link variants)
  Added the project's `.focus-ring` utility class to each.
- **Themed CTA color** — `PluginCard`'s "ready to install" CTA used a hardcoded `oklch(0.65 0.18 280)` literal — a fixed violet that doesn't track theme or user-chosen presets. Replaced with `var(--accent-presence)`.
- **Section-label contrast** — The "Roles" / "Plugins" / "Skills" section header was `text-muted` at 11px uppercase tracked — the recurring AA-fail pattern. Bumped to `text-secondary`, matching every prior polish PR.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [ ] **Manual:** open Plugins surface in light theme, Tab through the tab nav + search + role cards + dropdown — focus visible on each stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)