### PR TITLE
fix(nav): Home ⌘1, Agents ⌘2

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "log",
  "once_cell",

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -96,6 +96,12 @@ assert.match(
   "Chat turns should use the dense linear transcript anatomy",
 );
 
+assert.match(
+  source,
+  /<div className="cave-composer-shell">/,
+  "Composer should use the CSS-controlled shell so linear chat can run full width",
+);
+
 assert.doesNotMatch(
   source,
   /FamiliarSwitcher/,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -937,7 +937,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       ) : null}
 
       <footer className="cave-composer-dock">
-        <div className="relative mx-auto w-full max-w-[1180px]">
+        <div className="cave-composer-shell">
           {slashSuggestions.length > 0 ? (
             <div className="absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-xl">
               <ul className="max-h-64 overflow-y-auto py-1">

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -66,8 +66,8 @@ const FOLDER_MODES: Array<{
   kbd?: string;
 }> = [
   // Work
-  { id: "agents", label: "Agents", iconName: "ph:users-three", group: "work", kbd: "⌘1" },
-  { id: "home", label: "Home", iconName: "ph:house-bold", group: "work", kbd: "⌘2" },
+  { id: "home", label: "Home", iconName: "ph:house-bold", group: "work", kbd: "⌘1" },
+  { id: "agents", label: "Agents", iconName: "ph:users-three", group: "work", kbd: "⌘2" },
   { id: "chat", label: "Chat", iconName: "ph:chats", group: "work", kbd: "⌘3" },
   { id: "board", label: "Board", iconName: "ph:kanban", group: "work", kbd: "⌘4" },
   { id: "calendar", label: "Calendar", iconName: "ph:calendar-blank", group: "work", kbd: "⌘5" },

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -551,7 +551,7 @@ export function Workspace() {
 
   useEffect(() => {
     const SURFACE_ORDER: WorkspaceMode[] = [
-      "agents", "home", "chat", "board", "calendar", "inbox", "library", "browser",
+      "home", "agents", "chat", "board", "calendar", "inbox", "library", "browser",
     ];
 
     const onKey = (e: KeyboardEvent) => {

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -801,7 +801,7 @@
 
 .cave-chat-linear .cave-chat-thread {
   gap: 0;
-  width: min(100%, 1180px);
+  width: 100%;
 }
 
 .cave-linear-turn {
@@ -877,6 +877,17 @@
 
 .cave-chat-linear .cave-composer-dock {
   padding: 10px clamp(16px, 3vw, 34px) 16px;
+}
+
+.cave-composer-shell {
+  position: relative;
+  width: 100%;
+  max-width: 1180px;
+  margin: 0 auto;
+}
+
+.cave-chat-linear .cave-composer-shell {
+  max-width: none;
 }
 
 .cave-chat-linear .cave-composer-panel {


### PR DESCRIPTION
Swaps the two in both `FOLDER_MODES` (sidebar display + kbd hints) and `SURFACE_ORDER` (⌘1–⌘8 keyboard shortcuts).