### PR TITLE
ux: calendar polish — detail panel, focus rings, eyebrow contrast

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3189,6 +3189,43 @@ body {
 }
 
 /* ────────────────────────────────────────────────
+   Calendar item detail panel
+   Sits over the right edge of the calendar surface
+   when an event is selected. The container is just
+   a sibling div in calendar-view.tsx — these rules
+   give it a real side-pane affordance.
+   ──────────────────────────────────────────────── */
+.cave-cal-detail-panel {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: min(320px, 100%);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-raised);
+  border-left: 1px solid var(--border-hairline);
+  box-shadow: -8px 0 24px color-mix(in oklch, var(--text-primary) 10%, transparent);
+  z-index: 10;
+  animation: cave-cal-detail-slide 160ms ease-out;
+}
+
+@keyframes cave-cal-detail-slide {
+  from { transform: translateX(8px); opacity: 0; }
+  to   { transform: translateX(0);   opacity: 1; }
+}
+
+.cave-cal-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-hairline);
+  flex-shrink: 0;
+}
+
+/* ────────────────────────────────────────────────
    Familiar Studio drawer
    ──────────────────────────────────────────────── */
 

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -129,7 +129,7 @@ function ItemChip({
   return (
     <button
       onClick={onClick}
-      className="flex w-full items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2 py-1 text-left text-[11px] hover:bg-[var(--bg-elevated)] transition-colors group"
+      className="focus-ring flex w-full items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2 py-1 text-left text-[11px] hover:bg-[var(--bg-elevated)] transition-colors group"
     >
       <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${urgencyColor(item)}`} />
       <Icon
@@ -272,7 +272,7 @@ function AllDayStrip({
     <div className="flex shrink-0 overflow-x-auto border-b border-[var(--border-hairline)] bg-[var(--bg-panel)]">
       {/* Label */}
       <div className="sticky left-0 z-10 flex w-12 shrink-0 items-center justify-end border-r border-[var(--border-hairline)] bg-[var(--bg-panel)] py-1 pr-1.5">
-        <span className="text-[9px] uppercase tracking-wider text-[var(--text-muted)] leading-tight text-right">
+        <span className="text-[9px] uppercase tracking-wider text-[var(--text-secondary)] leading-tight text-right">
           All
           <br />
           day
@@ -547,7 +547,7 @@ function WeekView({
                 col.isToday ? "bg-[color-mix(in_oklch,var(--accent-presence)_10%,transparent)]" : ""
               }`}
             >
-              <div className="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
+              <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)]">
                 {WEEKDAYS[col.date.getDay()]}
               </div>
               <div
@@ -623,7 +623,7 @@ function MonthView({
             {WEEKDAYS.map((wd) => (
               <div
                 key={wd}
-                className="py-1 text-center text-[10px] uppercase tracking-wider text-[var(--text-muted)]"
+                className="py-1 text-center text-[10px] uppercase tracking-wider text-[var(--text-secondary)]"
               >
                 {wd}
               </div>
@@ -666,7 +666,7 @@ function MonthView({
                           e.stopPropagation();
                           onOpenItem?.(item);
                         }}
-                        className="flex w-full items-center gap-1 rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-1 py-0.5 text-left text-[9px] hover:bg-[var(--bg-elevated)]"
+                        className="focus-ring flex w-full items-center gap-1 rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-1 py-0.5 text-left text-[9px] hover:bg-[var(--bg-elevated)]"
                       >
                         <span className={`h-1 w-1 shrink-0 rounded-full ${urgencyColor(item)}`} />
                         <span className="truncate text-[var(--text-primary)]">{item.title}</span>
@@ -678,7 +678,7 @@ function MonthView({
                           e.stopPropagation();
                           onDayClick?.(day);
                         }}
-                        className="w-full px-1 text-left text-[9px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
+                        className="focus-ring w-full rounded px-1 text-left text-[9px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
                         title={`${dayItems.length - 3} more items — click to see all`}
                       >
                         +{dayItems.length - 3} more
@@ -723,7 +723,8 @@ function ItemDetailPanel({
         </div>
         <button
           onClick={onClose}
-          className="shrink-0 text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+          aria-label="Close"
+          className="focus-ring shrink-0 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
         >
           <Icon name="ph:x" width={14} />
         </button>
@@ -757,14 +758,14 @@ function ItemDetailPanel({
       <div className="px-4 py-3 border-t border-[var(--border-hairline)] flex gap-2">
         <button
           onClick={onClose}
-          className="flex-1 rounded-md border border-[var(--border-hairline)] px-3 py-1.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] transition-colors"
+          className="focus-ring flex-1 rounded-md border border-[var(--border-hairline)] px-3 py-1.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] transition-colors"
         >
           Dismiss
         </button>
         <div className="relative flex-1">
           <button
             onClick={() => setSnoozeOpen((v) => !v)}
-            className="w-full rounded-md bg-[var(--accent-presence)] px-3 py-1.5 text-[11px] text-white hover:opacity-90 transition-opacity"
+            className="focus-ring w-full rounded-md bg-[var(--accent-presence)] px-3 py-1.5 text-[11px] text-white transition-colors hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)]"
           >
             Snooze →
           </button>
@@ -774,7 +775,7 @@ function ItemDetailPanel({
                 <button
                   key={opt.label}
                   onClick={() => { setSnoozeOpen(false); onClose(); }}
-                  className="w-full px-3 py-2 text-left text-[11px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)] transition-colors"
+                  className="focus-ring w-full px-3 py-2 text-left text-[11px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)] transition-colors"
                 >
                   {opt.label}
                 </button>
@@ -870,20 +871,20 @@ export function CalendarView({ items, familiars, onAddEntry, onOpenItem }: Props
           <button
             onClick={() => navigate(-1)}
             aria-label="Previous"
-            className="grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+            className="focus-ring grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
           >
             <Icon name="ph:arrow-left-bold" width={12} />
           </button>
           <button
             onClick={() => setAnchor(new Date())}
-            className="rounded-md border border-[var(--border-hairline)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)]"
+            className="focus-ring rounded-md border border-[var(--border-hairline)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)]"
           >
             Today
           </button>
           <button
             onClick={() => navigate(1)}
             aria-label="Next"
-            className="grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+            className="focus-ring grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
           >
             <Icon name="ph:arrow-right-bold" width={12} />
           </button>
@@ -907,7 +908,7 @@ export function CalendarView({ items, familiars, onAddEntry, onOpenItem }: Props
             <button
               key={id}
               onClick={() => setViewMode(id)}
-              className={`px-2.5 py-1 text-[11px] transition-colors sm:px-3 ${
+              className={`focus-ring-inset px-2.5 py-1 text-[11px] transition-colors sm:px-3 ${
                 viewMode === id
                   ? "bg-[var(--accent-presence)] text-white"
                   : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"


### PR DESCRIPTION
Polish pass over the Calendar surface. Followup to the polish run (#232 / #235 / #238 / #239 / #241 / #243 / #244 / #245). Single commit covering four closely-related concerns on the same view.

## Summary

- **Detail panel structure** — `ItemDetailPanel` renders with two semantic BEM class names (`.cave-cal-detail-panel`, `.cave-cal-detail-header`) that had ZERO matching CSS anywhere. The panel was a bare div stacked at the bottom of the calendar surface in column-flex, not the right-side pane that the JSX (close button, slide-up snooze popover) clearly intends. Added the missing rules to `globals.css`: pinned to the right edge as a 320px-wide raised panel with left border, soft drop shadow, and a 160ms slide-in. Header gets proper padding + divider.
- **Focus rings** — Header nav (prev/today/next), view-mode tabs (with the `focus-ring-inset` variant since they sit inside a bordered chip), `ItemChip` (the row reused across Agenda/Day/Week), month day-cell inline items and the "+N more" overflow button, plus the detail panel's close/dismiss/snooze + snooze preset menu — all picked up `.focus-ring`.
- **Snooze button hover** — Was `hover:opacity-90` (flat desaturation, doesn't darken in light themes). Swapped to the house darken-toward-black mix that landed in #235 / #239 / #244 / #245.
- **Eyebrow contrast** — Three small uppercase labels (AllDayStrip "All / day", WeekView weekday headers, MonthView weekday headers) bumped `text-muted` → `text-secondary`. Recurring AA-fail pattern.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [ ] **Manual:** open Calendar in light theme, switch views, open an event detail panel, Tab through; verify the panel slides in on the right (not below), focus rings visible, snooze button visibly darkens

🤖 Generated with [Claude Code](https://claude.com/claude-code)