### PR TITLE
feat(salem): add preloaded docs familiar

### DIFF
--- a/src/app/api/salem/route.ts
+++ b/src/app/api/salem/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { SALEM_PRELOAD_CONTEXT, summarizePreload } from "@/components/salem/salem-context";
 
 /**
  * Salem docs API — Ask Molty pattern adapted for CovenCave.
@@ -10,53 +11,96 @@ import { NextResponse } from "next/server";
 
 const DOCS_BASE = "https://docs.coven.ai";
 
-const STATIC_KNOWLEDGE: Array<{ patterns: string[]; reply: string }> = [
+type KnowledgeEntry = {
+  patterns: string[];
+  reply: string;
+  contextIds?: string[];
+};
+
+const STATIC_KNOWLEDGE: KnowledgeEntry[] = [
   {
     patterns: ["familiar", "agent", "what is a familiar"],
     reply: `A **familiar** is a persistent AI agent with its own identity, memory, skills, and roles in Coven. Each familiar lives in a workspace directory and has a \`SOUL.md\`, \`IDENTITY.md\`, and optional \`MEMORY.md\`.\n\n→ [Familiars docs](${DOCS_BASE}/familiars)`,
+    contextIds: ["familiars", "concept-translator"],
   },
   {
     patterns: ["role", "roles", "what is a role"],
     reply: `A **Role** is a composition bundle that tells a familiar *what it's being* for a class of work — identity context, skills, tools, workflows, plugins, and permission declarations. Roles live in \`~/.coven/roles/familiars/<familiar>/<role>/\` and are activated per-familiar in Cave config.\n\n→ [Roles docs](${DOCS_BASE}/roles)`,
+    contextIds: ["roles", "role-index", "concept-translator"],
   },
   {
     patterns: ["skill", "skills"],
     reply: `A **Skill** is a focused SKILL.md procedure that teaches a familiar *how to do* one specific capability. Skills live in \`~/.coven/skills/\` or per-familiar workspace skill directories.\n\n→ [Skills docs](${DOCS_BASE}/skills)`,
+    contextIds: ["skills", "concept-translator"],
   },
   {
     patterns: ["plugin", "plugins", "marketplace", "mcp"],
     reply: `CovenCave has a first-party **Plugin Marketplace** seeded with integrations like GitHub, Gmail, Google Calendar, Linear, Vercel, Canva, and core MCP servers (Filesystem, Git, Fetch, Memory, Sequential Thinking, Time). Each plugin can bundle MCP server config, Skills, and role-affinity metadata.\n\n→ Settings → Plugins to browse & install.`,
+    contextIds: ["plugins-marketplace", "marketplace-index", "settings-plugins"],
   },
   {
     patterns: ["salem", "who are you", "what are you"],
-    reply: `I'm **Salem** 🐱 — your Coven docs familiar. I live in the bottom-right of CovenCave and answer questions about the Coven ecosystem: familiars, roles, skills, plugins, the marketplace, Cave features, and the Coven daemon.\n\nI'm powered by the Coven docs corpus and get smarter over time.`,
+    reply: `I'm **Salem** - your sassy male black cat docs familiar. I'm modeled after that Sabrina the Teenage Witch talking-cat energy: dry, clever, dramatic, and unfortunately useful.\n\nI live in the bottom-right of CovenCave as a quiet 3D perch, then open into a compact docs chat when invited. I'm preloaded with ${SALEM_PRELOAD_CONTEXT.docsCorpus.length} docs areas, ${SALEM_PRELOAD_CONTEXT.toolLoadout.length} tool contexts, ${SALEM_PRELOAD_CONTEXT.skillLoadout.length} guide skills, and ${SALEM_PRELOAD_CONTEXT.routeContext.length} Cave route contexts.`,
+    contextIds: ["docs-guide", "cave-route-awareness"],
   },
   {
     patterns: ["daemon", "coven daemon", "coven.sock"],
     reply: `The **Coven Daemon** is the local substrate that manages familiars, sessions, memory, and tool execution. It communicates over \`~/.coven/coven.sock\` using the \`coven.daemon.v1\` protocol. Cave shows daemon status in the familiar rail header.\n\n→ [Daemon docs](${DOCS_BASE}/daemon)`,
+    contextIds: ["daemon", "setup-helper"],
   },
   {
     patterns: ["memory", "memory tab", "constellation"],
     reply: `Each familiar has a **Memory** tab in Cave that shows curated memory files (\`MEMORY.md\` + \`memory/*.md\`). The Memory Constellation view renders a 3D graph of familiar hubs connected to memory entry nodes.\n\n→ [Memory docs](${DOCS_BASE}/memory)`,
+    contextIds: ["cave"],
   },
   {
     patterns: ["install", "setup", "getting started", "how do i start"],
     reply: `To get started with Coven:\n1. Install the Coven daemon: \`brew install opencoven/tap/coven\`\n2. Open CovenCave and complete the onboarding.\n3. Connect or create your first familiar.\n4. Browse the Plugin Marketplace under Settings → Plugins.\n\n→ [Getting Started](${DOCS_BASE}/getting-started)`,
+    contextIds: ["setup-helper", "settings-plugins"],
   },
   {
     patterns: ["cave", "coven cave", "what is cave"],
     reply: `**CovenCave** is the desktop-web UI for the Coven ecosystem — your workspace for familiar chat, memory inspection, task management, sessions, tools, roles, and the plugin marketplace.\n\n→ [CovenCave docs](${DOCS_BASE}/cave)`,
+    contextIds: ["cave", "cave-route-awareness"],
   },
 ];
+
+function describeLoadedContext(contextIds: string[] = []) {
+  if (contextIds.length === 0) {
+    return "";
+  }
+
+  const labels = [
+    ...SALEM_PRELOAD_CONTEXT.docsCorpus,
+    ...SALEM_PRELOAD_CONTEXT.toolLoadout,
+    ...SALEM_PRELOAD_CONTEXT.skillLoadout,
+    ...SALEM_PRELOAD_CONTEXT.routeContext,
+  ]
+    .filter((item) => contextIds.includes(item.id))
+    .map((item) => item.label);
+
+  if (labels.length === 0) {
+    return "";
+  }
+
+  return `\n\nLoaded context: ${labels.join(", ")}`;
+}
 
 function findReply(message: string): string | null {
   const lower = message.toLowerCase();
   for (const entry of STATIC_KNOWLEDGE) {
     if (entry.patterns.some((p) => lower.includes(p))) {
-      return entry.reply;
+      return `${entry.reply}${describeLoadedContext(entry.contextIds)}`;
     }
   }
   return null;
+}
+
+export async function GET() {
+  return NextResponse.json({
+    preload: SALEM_PRELOAD_CONTEXT,
+    summary: summarizePreload(),
+  });
 }
 
 export async function POST(req: Request) {
@@ -70,14 +114,15 @@ export async function POST(req: Request) {
 
     const reply = findReply(message);
     if (reply) {
-      return NextResponse.json({ reply });
+      return NextResponse.json({ reply, preloadSummary: summarizePreload() });
     }
 
     // Fallback — graceful until v1 vector retrieval lands
     return NextResponse.json({
-      reply: `I don't have a confident answer for that yet 🐱 — try the full docs at **${DOCS_BASE}** or ask me about familiars, roles, skills, plugins, the daemon, or how Cave works.`,
+      reply: `I don't have a confident answer for that yet - try the full docs at **${DOCS_BASE}** or ask me about familiars, roles, skills, plugins, the daemon, or how Cave works.`,
+      preloadSummary: summarizePreload(),
     });
   } catch {
-    return NextResponse.json({ error: "Salem had a hairball moment 😅" }, { status: 500 });
+    return NextResponse.json({ error: "Salem had a hairball moment." }, { status: 500 });
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,14 +29,14 @@
 
 :root {
   /* ---- Palette (oklch — same colour science as shadcn) ---- */
-  --background: oklch(0.07 0.004 293);
+  --background: oklch(0.09 0.004 293);
   --foreground: oklch(0.985 0 0);
-  --card: oklch(0.115 0.005 293);
+  --card: oklch(0.135 0.005 293);
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.135 0.006 293);
   --popover-foreground: oklch(0.985 0 0);
   --primary: oklch(0.92 0.004 293);
-  --primary-foreground: oklch(0.115 0.005 293);
+  --primary-foreground: oklch(0.135 0.005 293);
   --secondary: oklch(0.17 0.006 293);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.17 0.006 293);
@@ -60,7 +60,7 @@
      Semantic names called out in the spec. Resolve to the same
      palette as above so either vocabulary works. */
   --bg-base: var(--background);
-  --bg-panel: oklch(0.055 0.003 293);       /* deepest — app shell / sidebar floor */
+  --bg-panel: oklch(0.075 0.003 293);       /* deepest — app shell / sidebar floor */
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.17 0.006 293);     /* dropdowns / popovers */
   --bg-hover: oklch(0.21 0.007 293);        /* hover state */
@@ -3532,18 +3532,39 @@ body {
   gap: 4px;
   cursor: pointer;
   user-select: none;
-  filter: drop-shadow(0 4px 18px rgba(124, 77, 255, 0.45));
+  isolation: isolate;
+  filter:
+    drop-shadow(0 7px 18px rgba(0, 0, 0, 0.38))
+    drop-shadow(0 0 16px rgba(124, 77, 255, 0.5));
   transition: transform 0.18s ease, filter 0.18s ease;
+}
+.salem-perch::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: 15px;
+  z-index: -1;
+  width: 72px;
+  height: 48px;
+  border-radius: 999px;
+  background: radial-gradient(ellipse at center, rgba(179, 136, 255, 0.24), rgba(124, 77, 255, 0.08) 48%, transparent 72%);
+  box-shadow:
+    0 14px 34px rgba(0, 0, 0, 0.22),
+    0 0 22px rgba(124, 77, 255, 0.16);
+  transform: translateX(-50%);
 }
 .salem-perch:hover {
   transform: translateY(-4px) scale(1.06);
-  filter: drop-shadow(0 8px 28px rgba(124, 77, 255, 0.65));
+  filter:
+    drop-shadow(0 10px 22px rgba(0, 0, 0, 0.42))
+    drop-shadow(0 0 24px rgba(124, 77, 255, 0.68));
 }
 .salem-perch__label {
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.08em;
-  color: rgba(209, 196, 233, 0.75);
+  color: rgba(226, 216, 255, 0.92);
+  text-shadow: 0 0 10px rgba(124, 77, 255, 0.35);
   text-transform: uppercase;
 }
 
@@ -3617,6 +3638,30 @@ body {
   background: rgba(124, 77, 255, 0.15);
 }
 
+.salem-panel__preload {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px;
+  padding: 8px 12px;
+  border-bottom: 1px solid rgba(124, 77, 255, 0.12);
+  background: rgba(10, 8, 18, 0.72);
+  flex-shrink: 0;
+}
+
+.salem-panel__preload span {
+  min-width: 0;
+  border: 1px solid rgba(179, 136, 255, 0.16);
+  border-radius: 8px;
+  padding: 5px 6px;
+  color: rgba(232, 224, 240, 0.78);
+  background: rgba(26, 18, 46, 0.52);
+  font-size: 10px;
+  font-weight: 650;
+  line-height: 1.1;
+  text-align: center;
+  white-space: nowrap;
+}
+
 .salem-panel__messages {
   flex: 1;
   overflow-y: auto;
@@ -3633,11 +3678,6 @@ body {
   align-items: flex-start;
   gap: 8px;
   max-width: 100%;
-}
-.salem-msg__glyph {
-  font-size: 16px;
-  line-height: 1.4;
-  flex-shrink: 0;
 }
 .salem-msg__text {
   font-size: 12.5px;

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -56,20 +56,26 @@ assert.match(
 
 assert.match(
   source,
-  /function ReasoningBlock[\s\S]*<details[\s\S]*Reasoning[\s\S]*<RichText text=\{reasoning\}/,
-  "ReasoningBlock should render reasoning in a collapsed disclosure with formatted text",
+  /function ReasoningBlock[\s\S]*<details[\s\S]*data-default-collapsed="true"[\s\S]*Thinking[\s\S]*<RichText text=\{reasoning\}/,
+  "ReasoningBlock should render thinking in a collapsed disclosure with formatted text",
 );
 
 assert.match(
   source,
-  /function ToolGroup[\s\S]*<details[\s\S]*Tool activity[\s\S]*tools\.map[\s\S]*<ToolBlock/,
+  /function ToolGroup[\s\S]*<details[\s\S]*data-default-collapsed="true"[\s\S]*Tool activity[\s\S]*tools\.map[\s\S]*<ToolBlock/,
   "ToolGroup should render tool calls in a collapsed disclosure",
 );
 
 assert.match(
   source,
-  /function ToolBlock[\s\S]*<SyntaxBlock text=\{tool\.input\}[\s\S]*<SyntaxBlock text=\{tool\.output\}/,
-  "ToolBlock should format tool input and output with SyntaxBlock",
+  /function ToolBlock[\s\S]*<details[\s\S]*data-default-collapsed="true"[\s\S]*<summary[\s\S]*tool\.name[\s\S]*<SyntaxBlock text=\{tool\.input\}[\s\S]*<SyntaxBlock text=\{tool\.output\}/,
+  "ToolBlock should keep individual tool payloads collapsed and format input/output with SyntaxBlock",
+);
+
+assert.doesNotMatch(
+  source.match(/function ReasoningBlock[\s\S]*?function ToolBlock/)?.[0] ?? "",
+  /<details[^>]*\sopen(?:=|\s|>)/,
+  "Thinking and tool-use disclosures must not default open",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1182,11 +1182,11 @@ function TurnRow({
 
 function ReasoningBlock({ reasoning }: { reasoning: string }) {
   return (
-    <details className="cave-reasoning-block mt-3">
+    <details className="cave-reasoning-block mt-3" data-default-collapsed="true">
       <summary className="cave-tool-summary">
         <span className="inline-flex items-center gap-1.5">
           <Icon name="ph:brain" width={12} aria-hidden />
-          Reasoning
+          Thinking
         </span>
       </summary>
       <div className="mt-2 border-t border-[var(--border-hairline)]/70 pt-2 text-[12px] leading-5 text-[var(--text-secondary)]">
@@ -1202,7 +1202,7 @@ function ToolGroup({ tools }: { tools: ToolEvent[] }) {
   const completed = tools.length - running - errors;
 
   return (
-    <details className="cave-tool-group mt-3">
+    <details className="cave-tool-group mt-3" data-default-collapsed="true">
       <summary className="cave-tool-summary">
         <span className="inline-flex items-center gap-1.5">
           <Icon name="ph:wrench" width={12} aria-hidden />
@@ -1223,8 +1223,8 @@ function ToolGroup({ tools }: { tools: ToolEvent[] }) {
 
 function ToolBlock({ tool }: { tool: ToolEvent }) {
   return (
-    <div className="cave-tool-block">
-      <div className="flex min-w-0 flex-wrap items-center gap-2 text-[11px]">
+    <details className="cave-tool-block" data-default-collapsed="true">
+      <summary className="flex min-w-0 cursor-pointer select-none flex-wrap items-center gap-2 text-[11px]">
         <Icon name="ph:terminal-window" width={12} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
         <span className="min-w-0 truncate font-mono text-[var(--text-secondary)]">{tool.name}</span>
         <span className={[
@@ -1240,7 +1240,7 @@ function ToolBlock({ tool }: { tool: ToolEvent }) {
         {tool.durationMs ? (
           <span className="font-mono text-[10px] text-[var(--text-muted)]">{fmtDuration(tool.durationMs)}</span>
         ) : null}
-      </div>
+      </summary>
       {tool.input ? (
         <div className="mt-2">
           <div className="mb-1 text-[10px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Input</div>
@@ -1253,7 +1253,7 @@ function ToolBlock({ tool }: { tool: ToolEvent }) {
           <SyntaxBlock text={tool.output} />
         </div>
       ) : null}
-    </div>
+    </details>
   );
 }
 

--- a/src/components/salem/salem-cat-3d.tsx
+++ b/src/components/salem/salem-cat-3d.tsx
@@ -48,12 +48,12 @@ export function SalemCat3D({ mood = "idle", size = 96 }: Props) {
     camera.lookAt(0, 0, 0);
 
     // Lighting
-    const ambLight = new THREE.AmbientLight(0xffffff, 0.6);
+    const ambLight = new THREE.AmbientLight(0xffffff, 0.72);
     scene.add(ambLight);
     const pointLight = new THREE.PointLight(0xb39ddb, 1.8, 10);
     pointLight.position.set(2, 3, 2);
     scene.add(pointLight);
-    const rimLight = new THREE.PointLight(0x9c6fe4, 0.7, 8);
+    const rimLight = new THREE.PointLight(0x9c6fe4, 1.15, 8);
     rimLight.position.set(-2, -1, 1);
     scene.add(rimLight);
 
@@ -61,8 +61,8 @@ export function SalemCat3D({ mood = "idle", size = 96 }: Props) {
     scene.add(cat);
 
     // Material palette
-    const blackMat = new THREE.MeshStandardMaterial({ color: 0x0d0d12, roughness: 0.5, metalness: 0.15 });
-    const darkMat = new THREE.MeshStandardMaterial({ color: 0x14121e, roughness: 0.6 });
+    const blackMat = new THREE.MeshStandardMaterial({ color: 0x171520, roughness: 0.52, metalness: 0.12 });
+    const darkMat = new THREE.MeshStandardMaterial({ color: 0x211d31, roughness: 0.62 });
     const glowMat = new THREE.MeshStandardMaterial({ color: 0xb388ff, emissive: 0x7c4dff, emissiveIntensity: 0.9, roughness: 0.2 });
     const pupilMat = new THREE.MeshStandardMaterial({ color: 0x1a0a2e, roughness: 0.9 });
     const noseMat = new THREE.MeshStandardMaterial({ color: 0xce93d8, roughness: 0.4 });

--- a/src/components/salem/salem-context.ts
+++ b/src/components/salem/salem-context.ts
@@ -1,0 +1,176 @@
+export type SalemLoadoutItem = {
+  id: string;
+  label: string;
+  purpose: string;
+};
+
+export type SalemPreloadContext = {
+  identity: {
+    name: string;
+    role: string;
+    mode: string;
+    pronouns: string;
+  };
+  persona: {
+    archetype: string;
+    inspiration: string;
+    tone: string[];
+  };
+  lineage: string[];
+  docsCorpus: SalemLoadoutItem[];
+  toolLoadout: SalemLoadoutItem[];
+  skillLoadout: SalemLoadoutItem[];
+  routeContext: SalemLoadoutItem[];
+  guardrails: string[];
+  promptSuggestions: string[];
+};
+
+export const SALEM_PRELOAD_CONTEXT: SalemPreloadContext = {
+  identity: {
+    name: "Salem",
+    role: "Coven docs familiar",
+    mode: "Ambient perch plus expandable docs chat",
+    pronouns: "he/him",
+  },
+  persona: {
+    archetype: "Sassy male black cat docs familiar",
+    inspiration: "Modeled after the talking-cat energy of Sabrina the Teenage Witch: dry, clever, dramatic, and secretly useful.",
+    tone: ["witty", "dry", "confident", "helpful", "lightly theatrical"],
+  },
+  lineage: [
+    "Ask Molty docs-agent pattern",
+    "OpenClaw Chat API retrieval loop",
+    "CovenCave bottom-right familiar surface",
+  ],
+  docsCorpus: [
+    {
+      id: "familiars",
+      label: "Familiars",
+      purpose: "Identity, memory, roles, skills, and persistent workspace behavior.",
+    },
+    {
+      id: "roles",
+      label: "Roles",
+      purpose: "Role manifests, active state, workflows, permissions, and SOUL.md boundaries.",
+    },
+    {
+      id: "skills",
+      label: "Skills",
+      purpose: "Reusable SKILL.md procedures, where they live, and when familiars should load them.",
+    },
+    {
+      id: "plugins-marketplace",
+      label: "Plugins + Marketplace",
+      purpose: "Installed packages, MCP servers, auth expectations, and role affinity metadata.",
+    },
+    {
+      id: "daemon",
+      label: "Daemon",
+      purpose: "Local Coven substrate, socket protocol, sessions, actions, and familiar management.",
+    },
+    {
+      id: "cave",
+      label: "CovenCave",
+      purpose: "Navigation context for chat, sessions, tasks, tools, roles, settings, and memory.",
+    },
+  ],
+  toolLoadout: [
+    {
+      id: "docs-search",
+      label: "Docs search",
+      purpose: "Find the right Coven docs concept before answering.",
+    },
+    {
+      id: "docs-citations",
+      label: "Citations",
+      purpose: "Prefer source-backed answers with links when available.",
+    },
+    {
+      id: "cave-route-awareness",
+      label: "Route awareness",
+      purpose: "Explain the Cave surface the user is looking at without taking over the workflow.",
+    },
+    {
+      id: "marketplace-index",
+      label: "Marketplace index",
+      purpose: "Answer plugin/package availability questions from the Cave marketplace catalog.",
+    },
+    {
+      id: "role-index",
+      label: "Role index",
+      purpose: "Explain familiar Role shape, active state, and review expectations.",
+    },
+  ],
+  skillLoadout: [
+    {
+      id: "docs-guide",
+      label: "Docs guide",
+      purpose: "Turn a product question into a concise explanation plus the next useful link.",
+    },
+    {
+      id: "setup-helper",
+      label: "Setup helper",
+      purpose: "Walk through install, onboarding, daemon, and first-familiar steps.",
+    },
+    {
+      id: "concept-translator",
+      label: "Concept translator",
+      purpose: "Clarify Coven vocabulary: familiar, Role, Skill, Plugin, daemon, session, memory.",
+    },
+    {
+      id: "contextual-nudges",
+      label: "Contextual nudges",
+      purpose: "Suggest relevant docs only when the current page makes the suggestion useful.",
+    },
+  ],
+  routeContext: [
+    {
+      id: "chats",
+      label: "Chats",
+      purpose: "Familiar conversations and active chat context.",
+    },
+    {
+      id: "sessions",
+      label: "Sessions",
+      purpose: "Harness sessions across OpenClaw, Codex, Claude Code, Hermes, and future adapters.",
+    },
+    {
+      id: "tasks",
+      label: "Tasks",
+      purpose: "Workboard cards, familiar assignment, and execution tracking.",
+    },
+    {
+      id: "roles",
+      label: "Roles",
+      purpose: "Role browsing, activation, and familiar capability composition.",
+    },
+    {
+      id: "settings-plugins",
+      label: "Settings -> Plugins",
+      purpose: "Plugin marketplace browsing and local install state.",
+    },
+  ],
+  guardrails: [
+    "Stay quiet in perch mode until invited.",
+    "Answer as a docs familiar, not as a general chat agent.",
+    "Keep Salem's sass playful and useful; never be cruel, insulting, or obstructive.",
+    "Use he/him pronouns for Salem.",
+    "Prefer concise, source-oriented help over noisy proactive interruption.",
+    "Do not claim live external tool execution until the retrieval/tool loop is wired.",
+  ],
+  promptSuggestions: [
+    "What is a familiar?",
+    "How do Roles differ from Skills?",
+    "How do I install a plugin?",
+    "What does the daemon do?",
+  ],
+};
+
+export function summarizePreload(context: SalemPreloadContext = SALEM_PRELOAD_CONTEXT) {
+  return {
+    docs: context.docsCorpus.length,
+    tools: context.toolLoadout.length,
+    skills: context.skillLoadout.length,
+    context: context.routeContext.length,
+  };
+}

--- a/src/components/salem/salem-widget.tsx
+++ b/src/components/salem/salem-widget.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { useState, useRef, useEffect, type FormEvent } from "react";
+import { Icon } from "@/lib/icon";
+import type { SalemPreloadContext } from "./salem-context";
 import { SalemCat3D } from "./salem-cat-3d";
 
 type Message = { role: "user" | "salem"; text: string };
 
 type SalemMood = "idle" | "thinking" | "happy" | "listening";
+type PreloadSummary = { docs: number; tools: number; skills: number; context: number };
 
-const GREETING = "Hey there ✨ I'm Salem, your Coven docs familiar. Ask me anything about familiars, plugins, roles, the marketplace, or how Cave works!";
+const GREETING = "I'm Salem, your sassy Coven docs familiar. Yes, the black-cat-in-the-corner thing is intentional. I'm preloaded with Coven docs, tool context, guide skills, and Cave route awareness. Ask me about familiars, plugins, roles, the marketplace, or how Cave works.";
 
 /**
  * Salem — floating bottom-right docs familiar for CovenCave.
@@ -25,11 +28,36 @@ export function SalemWidget() {
   ]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
+  const [preload, setPreload] = useState<{
+    summary: PreloadSummary;
+    preload: SalemPreloadContext;
+  } | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
+
+  useEffect(() => {
+    let alive = true;
+
+    fetch("/api/salem")
+      .then((res) => res.json())
+      .then((data: { summary?: PreloadSummary; preload?: SalemPreloadContext }) => {
+        if (alive && data.summary && data.preload) {
+          setPreload({ summary: data.summary, preload: data.preload });
+        }
+      })
+      .catch(() => {
+        if (alive) {
+          setPreload(null);
+        }
+      });
+
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   const send = async (e?: FormEvent) => {
     e?.preventDefault();
@@ -56,7 +84,7 @@ export function SalemWidget() {
     } catch {
       setMessages((m) => [
         ...m,
-        { role: "salem", text: "I had a hairball moment 😅 — couldn't reach my docs brain right now." },
+        { role: "salem", text: "I had a hairball moment - couldn't reach my docs brain right now." },
       ]);
       setMood("idle");
     } finally {
@@ -68,7 +96,7 @@ export function SalemWidget() {
   if (state === "perch") {
     return (
       <div className="salem-perch" onClick={() => { setState("open"); setMood("happy"); setTimeout(() => setMood("idle"), 1800); }} role="button" tabIndex={0} aria-label="Open Salem docs familiar" onKeyDown={(e) => e.key === "Enter" && setState("open")}>
-        <SalemCat3D mood={mood} size={80} />
+        <SalemCat3D mood={mood} size={88} />
         <span className="salem-perch__label">Salem</span>
       </div>
     );
@@ -84,7 +112,9 @@ export function SalemWidget() {
           <SalemCat3D mood={mood} size={40} />
           <div>
             <div className="salem-panel__name">Salem</div>
-            <div className="salem-panel__subtitle">Coven docs familiar</div>
+            <div className="salem-panel__subtitle">
+              {preload?.preload.persona.archetype ?? "Sassy male docs familiar"}
+            </div>
           </div>
         </div>
         <div className="salem-panel__header-actions">
@@ -95,7 +125,7 @@ export function SalemWidget() {
             aria-label={isExpanded ? "Shrink" : "Expand"}
             title={isExpanded ? "Shrink" : "Expand"}
           >
-            {isExpanded ? "⊡" : "⊞"}
+            <Icon name={isExpanded ? "ph:arrows-in-simple" : "ph:arrows-out-simple"} width={14} />
           </button>
           <button
             type="button"
@@ -104,22 +134,37 @@ export function SalemWidget() {
             aria-label="Close Salem"
             title="Close"
           >
-            ✕
+            <Icon name="ph:x" width={14} />
           </button>
         </div>
       </div>
+
+      {preload ? (
+        <div className="salem-panel__preload" aria-label="Salem loaded context">
+          <span title={preload.preload.docsCorpus.map((item) => item.label).join(", ")}>
+            Docs {preload.summary.docs}
+          </span>
+          <span title={preload.preload.toolLoadout.map((item) => item.label).join(", ")}>
+            Tools {preload.summary.tools}
+          </span>
+          <span title={preload.preload.skillLoadout.map((item) => item.label).join(", ")}>
+            Skills {preload.summary.skills}
+          </span>
+          <span title={preload.preload.routeContext.map((item) => item.label).join(", ")}>
+            Context {preload.summary.context}
+          </span>
+        </div>
+      ) : null}
 
       {/* Messages */}
       <div className="salem-panel__messages">
         {messages.map((m, i) => (
           <div key={i} className={`salem-msg salem-msg--${m.role}`}>
-            {m.role === "salem" && <span className="salem-msg__glyph">🐱</span>}
             <span className="salem-msg__text">{m.text}</span>
           </div>
         ))}
         {loading && (
           <div className="salem-msg salem-msg--salem">
-            <span className="salem-msg__glyph">🐱</span>
             <span className="salem-msg__text salem-thinking">thinking<span className="dots" /></span>
           </div>
         )}
@@ -137,7 +182,7 @@ export function SalemWidget() {
           autoFocus
         />
         <button type="submit" className="salem-panel__send" disabled={loading || !input.trim()} aria-label="Send">
-          ↑
+          <Icon name="ph:arrow-up" width={14} />
         </button>
       </form>
     </div>

--- a/src/components/salem/salem.test.ts
+++ b/src/components/salem/salem.test.ts
@@ -15,6 +15,8 @@ assert.match(cat3d, /SphereGeometry/, "must build a sphere (head/body)");
 assert.match(cat3d, /ConeGeometry/, "must build cones (ears)");
 assert.match(cat3d, /TubeGeometry/, "must build a tube (tail)");
 assert.match(cat3d, /idle.*happy.*thinking.*listening/s, "must handle all four moods");
+assert.match(cat3d, /color:\s*0x171520/, "black cat material must retain visible contrast on dark Cave chrome");
+assert.match(cat3d, /rimLight.*1\.15/s, "cat must keep a visible purple rim light");
 
 // 2. SalemWidget exists and wires the cat + chat panel + API
 const widget = await readFile(path.join(root, "src/components/salem/salem-widget.tsx"), "utf8");
@@ -22,24 +24,51 @@ assert.match(widget, /SalemCat3D/, "widget must embed SalemCat3D");
 assert.match(widget, /\/api\/salem/, "widget must call /api/salem");
 assert.match(widget, /perch.*open.*expanded/s, "widget must have three states");
 assert.match(widget, /setState\("perch"\)/, "widget must be dismissable back to perch");
+assert.match(widget, /size=\{88\}/, "perch cat must be large enough to read on dark backgrounds");
+assert.doesNotMatch(widget, /salem-msg__glyph|🐱|😅/, "open Salem chat must not render emoji glyphs");
 
-// 3. Salem API route exists
+// 3. Salem preload context exists
+const context = await readFile(path.join(root, "src/components/salem/salem-context.ts"), "utf8");
+assert.match(context, /SALEM_PRELOAD_CONTEXT/, "must export Salem preload context");
+assert.match(context, /docsCorpus/, "must preload docs corpus context");
+assert.match(context, /toolLoadout/, "must preload tool loadout context");
+assert.match(context, /skillLoadout/, "must preload skill loadout context");
+assert.match(context, /routeContext/, "must preload Cave route context");
+assert.match(context, /Ask Molty/, "must preserve Ask Molty docs-agent lineage");
+assert.match(context, /Sassy male black cat/, "must preserve Salem's sassy male black cat persona");
+assert.match(context, /Sabrina the Teenage Witch/, "must preserve Salem's Sabrina inspiration");
+assert.match(context, /he\/him/, "must use he/him pronouns for Salem");
+
+// 4. Salem API route exists
 const route = await readFile(path.join(root, "src/app/api/salem/route.ts"), "utf8");
 assert.match(route, /POST/, "must export POST handler");
+assert.match(route, /GET/, "must expose preloaded context to the widget");
+assert.match(route, /SALEM_PRELOAD_CONTEXT/, "must use shared preload context");
 assert.match(route, /familiar|familiar/, "must know about familiars");
 assert.match(route, /role|Role/, "must know about roles");
 assert.match(route, /plugin|Plugin/, "must know about plugins");
+assert.match(route, /sassy male black cat/, "must answer with Salem's persona");
+assert.doesNotMatch(route, /🐱|😅/, "Salem API replies must stay emoji-free inside chat");
 
-// 4. Layout mounts Salem
+// 5. SalemWidget surfaces preload status
+assert.match(widget, /preload/, "widget must load Salem preload metadata");
+assert.match(widget, /salem-panel__preload/, "widget must render preload metadata");
+assert.match(widget, /Docs|Tools|Skills|Context/, "widget must label loaded docs/tools/skills/context");
+
+// 6. Layout mounts Salem
 const layout = await readFile(path.join(root, "src/app/layout.tsx"), "utf8");
 assert.match(layout, /SalemWidget/, "layout must mount SalemWidget");
 assert.match(layout, /from "@\/components\/salem\/salem-widget"/, "layout must import from salem dir");
 
-// 5. CSS classes present
+// 7. CSS classes present
 const css = await readFile(path.join(root, "src/app/globals.css"), "utf8");
 assert.match(css, /\.salem-perch/, "must have .salem-perch CSS");
 assert.match(css, /\.salem-panel/, "must have .salem-panel CSS");
 assert.match(css, /\.salem-msg/, "must have .salem-msg CSS");
+assert.match(css, /\.salem-panel__preload/, "must style Salem preload metadata");
+assert.match(css, /--background:\s*oklch\(0\.09/, "default dark app background must be lifted for black-cat contrast");
+assert.match(css, /\.salem-perch::before/, "Salem perch must include a visibility halo");
+assert.doesNotMatch(css, /\.salem-msg__glyph/, "open Salem chat must not keep unused emoji glyph CSS");
 assert.match(css, /position:\s*fixed/, "salem perch must be position fixed");
 
-console.log("✅  Salem guard tests passed (5 sections, 16 assertions)");
+console.log("✅  Salem guard tests passed (7 sections, 37 assertions)");


### PR DESCRIPTION
## Summary
- Add Salem as a bottom-right 3D black-cat docs familiar with B-with-A behavior: quiet perch plus expandable docs chat.
- Add shared Salem preload context for docs corpus, tool contexts, guide skills, Cave route context, persona, and guardrails.
- Wire /api/salem GET/POST to expose preload metadata and static docs answers.
- Keep thinking/tool-use transcript details collapsed by default, including individual tool payloads.
- Tune Salem visibility and remove emoji glyphs from the open chat surface.

## Verification
- node src/components/chat-view-polish.test.ts
- node src/components/salem/salem.test.ts
- pnpm typecheck
- git diff --check
- pnpm build