### PR TITLE
ux: capabilities polish — focus rings + eyebrow contrast

### DIFF
--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -118,7 +118,7 @@ export function CapabilitiesViewSurface({
               type="button"
               onClick={() => void load(true)}
               disabled={refreshing}
-              className="flex h-7 items-center gap-1.5 rounded-md border border-border bg-card px-2.5 text-foreground transition-colors hover:bg-muted disabled:opacity-50"
+              className="focus-ring flex h-7 items-center gap-1.5 rounded-md border border-border bg-card px-2.5 text-foreground transition-colors hover:bg-muted disabled:opacity-50"
             >
               <Icon
                 name="ph:arrows-clockwise-bold"
@@ -205,7 +205,7 @@ export function CapabilitiesViewSurface({
 
           {loaded && !error && covenSkills.length > 0 && filter === null && (
             <section className="mt-8">
-              <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+              <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">
                 Coven skills · {covenSkills.length}
               </h3>
               <p className="mb-3 text-[12px] text-muted-foreground">
@@ -259,7 +259,7 @@ function SummaryTile({
 }) {
   return (
     <div className="rounded-lg border border-border bg-card px-3 py-2">
-      <div className="flex items-center gap-1.5 text-muted-foreground">
+      <div className="flex items-center gap-1.5 text-[var(--text-secondary)]">
         <Icon name={icon} width={11} />
         <span className="text-[10px] uppercase tracking-widest">{label}</span>
       </div>
@@ -285,7 +285,7 @@ function FilterPill({
     <button
       type="button"
       onClick={onClick}
-      className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] transition-colors ${
+      className={`focus-ring flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] transition-colors ${
         active
           ? "border-foreground bg-foreground text-background"
           : "border-border bg-card text-muted-foreground hover:bg-muted hover:text-foreground"

--- a/src/components/capability-card.tsx
+++ b/src/components/capability-card.tsx
@@ -62,7 +62,7 @@ export function CapabilitiesView({
         </p>
         <button
           onClick={onRefresh}
-          className="rounded-md border border-border bg-card px-3 py-1.5 text-[12px] text-foreground hover:bg-muted"
+          className="focus-ring rounded-md border border-border bg-card px-3 py-1.5 text-[12px] text-foreground hover:bg-muted"
         >
           Retry
         </button>
@@ -86,7 +86,7 @@ export function CapabilitiesView({
       <div className="flex items-center justify-end">
         <button
           onClick={onRefresh}
-          className="flex items-center gap-1.5 text-[11px] text-muted-foreground hover:text-foreground"
+          className="focus-ring flex items-center gap-1.5 rounded text-[11px] text-muted-foreground hover:text-foreground"
         >
           <Icon name="ph:arrows-clockwise-bold" width="0.75rem" />
           <span>Refresh</span>
@@ -174,7 +174,7 @@ function HarnessCapabilityCard({ manifest }: { manifest: HarnessCapabilityManife
 
         {manifest.skills.length > 0 ? (
           <div className="px-4 py-3">
-            <p className="mb-2 text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
+            <p className="mb-2 text-[11px] font-medium uppercase tracking-widest text-[var(--text-secondary)]">
               Automations / skills · {manifest.skills.length}
             </p>
             <ul className="space-y-1.5">
@@ -195,7 +195,7 @@ function HarnessCapabilityCard({ manifest }: { manifest: HarnessCapabilityManife
 
         {manifest.plugins.length > 0 ? (
           <div className="px-4 py-3">
-            <p className="mb-2 text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
+            <p className="mb-2 text-[11px] font-medium uppercase tracking-widest text-[var(--text-secondary)]">
               Plugins · {manifest.plugins.length}
             </p>
             <ul className="space-y-1.5">


### PR DESCRIPTION
Small polish pass over the Capabilities surface. Followup to the polish run (#232 / #235 / #238 / #239 / #241 / #243 / #244 / #245 / #247). Single commit.

## Summary

- **Focus rings** — Four buttons lacked `.focus-ring`: header refresh, FilterPill (the "All / Codex / Claude…" row), the Retry button on the error state, and the footer Refresh button inside `CapabilitiesView`. Added the utility on each.
- **Eyebrow contrast** — Four small uppercase tracked labels were `text-muted-foreground`, the recurring AA-fail pattern: `SummaryTile` labels, the "Coven skills" header, plus the "Automations / skills" and "Plugins" labels inside each `HarnessCapabilityCard`. Bumped to `text-secondary`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [ ] **Manual:** open Capabilities in light theme, Tab through the header + filter pills + harness cards — focus visible on each

🤖 Generated with [Claude Code](https://claude.com/claude-code)