### PR TITLE
ux: chat polish — send hover, focus rings, ThinkingIndicator theming

### DIFF
--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -248,7 +248,7 @@ export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat 
             type="button"
             onClick={() => setUnreadsOnly((v) => !v)}
             className={[
-              "flex h-8 shrink-0 items-center gap-1.5 rounded-lg border px-2.5 text-[11px] font-medium transition-colors",
+              "focus-ring flex h-8 shrink-0 items-center gap-1.5 rounded-lg border px-2.5 text-[11px] font-medium transition-colors",
               unreadsOnly
                 ? "border-[color-mix(in_oklch,var(--color-success)_40%,transparent)] bg-[color-mix(in_oklch,var(--color-success)_15%,transparent)] text-[var(--color-success)]"
                 : "border-[var(--border-hairline)] text-[var(--text-muted)] hover:border-[var(--border-strong)] hover:text-[var(--text-secondary)]",
@@ -362,7 +362,7 @@ export function ChatList({ familiar, sessions, daemonRunning, onOpen, onNewChat 
                             if (e.key === "Enter") { setActiveId(s.id); onOpen(s.id); }
                           }}
                           className={[
-                            "group relative flex cursor-pointer gap-3 px-4 py-3.5 transition-colors",
+                            "focus-ring-inset group relative flex cursor-pointer gap-3 px-4 py-3.5 transition-colors",
                             isActive
                               ? "bg-[var(--bg-raised)]"
                               : "hover:bg-[var(--bg-raised)]/50",

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -989,7 +989,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                     <button
                       type="button"
                       onClick={() => setAttachments((prev) => prev.filter((item) => item.id !== attachment.id))}
-                      className="grid h-4 w-4 shrink-0 place-items-center rounded text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+                      className="focus-ring grid h-4 w-4 shrink-0 place-items-center rounded text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
                       title={`Remove ${attachment.name}`}
                     >
                       <Icon name="ph:x-bold" width={9} />
@@ -1018,7 +1018,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 />
                 <button
                   type="button"
-                  className="grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)]"
+                  className="focus-ring grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)]"
                   title="Attach files"
                   disabled={busy || attachments.length >= 10}
                   onClick={() => fileInputRef.current?.click()}
@@ -1034,7 +1034,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 {busy ? (
                   <button
                     onClick={cancelSend}
-                    className="grid h-7 w-7 place-items-center rounded-md bg-[color-mix(in_oklch,var(--color-danger)_90%,transparent)] text-white transition-colors hover:bg-[var(--color-danger)]"
+                    className="focus-ring grid h-7 w-7 place-items-center rounded-md bg-[color-mix(in_oklch,var(--color-danger)_90%,transparent)] text-white transition-colors hover:bg-[var(--color-danger)]"
                     title="Cancel (esc)"
                   >
                     ■
@@ -1043,7 +1043,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   <button
                     onClick={() => void send()}
                     disabled={!input.trim() && attachments.length === 0}
-                    className="grid h-7 w-7 place-items-center rounded-md bg-[var(--accent-presence)] text-white transition-colors hover:bg-[var(--accent-presence-soft)] disabled:opacity-40"
+                    className="focus-ring grid h-7 w-7 place-items-center rounded-md bg-[var(--accent-presence)] text-white transition-colors hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-40"
                     title={`Send (${keys.enter})`}
                   >
                     ↑
@@ -1073,22 +1073,21 @@ function ThinkingIndicator({ since }: { since: string }) {
   }, [since]);
 
   return (
-    <div className="flex items-center gap-2 py-2 text-[13px]" style={{ color: "rgba(255,255,255,0.35)" }}>
+    <div className="flex items-center gap-2 py-2 text-[13px] text-[var(--text-muted)]">
       {/* Animated dots */}
       <span className="flex items-center gap-0.5">
         {[0, 1, 2].map((i) => (
           <span
             key={i}
-            className="inline-block h-1.5 w-1.5 rounded-full animate-bounce"
+            className="inline-block h-1.5 w-1.5 rounded-full animate-bounce bg-current"
             style={{
-              background: "rgba(255,255,255,0.35)",
               animationDelay: `${i * 150}ms`,
               animationDuration: "900ms",
             }}
           />
         ))}
       </span>
-      <span className="text-[11px] tabular-nums" style={{ color: "rgba(255,255,255,0.2)" }}>
+      <span className="text-[11px] tabular-nums opacity-60">
         {elapsed}s
       </span>
     </div>


### PR DESCRIPTION
Polish pass over the Chat surface. Final entry in the polish run (#232 / #235 / #238 / #239 / #241 / #243 / #244 / #245 / #247 / #249). Chat already had two recent polish passes (#228 / #237) so the surface was largely clean — this commit closes the three remaining interactive-state gaps.

## Summary

- **Send button hover direction** — Used `hover:bg-[var(--accent-presence-soft)]`. In light mode `--accent-presence-soft` is *lighter* than `--accent-presence` (oklch 0.72 vs 0.6), so hover went the wrong direction (button got lighter against a light bg, looking dead). Replaced with the house darken-toward-`#000` mix.
- **ThinkingIndicator hardcoded white** — Inline `style={{ color: "rgba(255,255,255,0.35)" }}` on the dots and elapsed-timer. Invisible against the light bg in pale themes. Switched to `text-[var(--text-muted)]` with the dots using `bg-current` and the timer `opacity-60`.
- **Focus rings** — Six interactive controls in the chat surface lacked the `.focus-ring` utility: composer attach button, send + cancel buttons, attachment-chip delete (×), chat-list "Unreads" filter toggle, and chat-list session row (uses `focus-ring-inset` since the row is borderless and full-width).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [ ] **Manual:** switch to light theme, start a chat, hover the Send button (visibly darkens), trigger a thinking state (dots + timer readable), Tab through composer + chat list — focus visible on each stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)