### PR TITLE
ux: agents-view polish — focus rings + eyebrow contrast

### DIFF
--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -191,7 +191,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
                     type="button"
                     onClick={() => setViewMode(m)}
                     className={[
-                      "inline-flex h-7 items-center gap-1.5 px-2.5 text-[11px] capitalize transition-colors",
+                      "focus-ring-inset inline-flex h-7 items-center gap-1.5 px-2.5 text-[11px] capitalize transition-colors",
                       viewMode === m
                         ? "bg-[var(--accent-presence)] text-white"
                         : "bg-[var(--bg-raised)]/30 text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]",
@@ -203,7 +203,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
                 ))}
               </div>
             )}
-            <button type="button" onClick={() => void load()} className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]">
+            <button type="button" onClick={() => void load()} className="focus-ring inline-flex h-7 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]">
               <Icon name="ph:arrows-clockwise" width={12} />
               Refresh
             </button>
@@ -212,15 +212,15 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
 
         <div className="mt-3 grid gap-2 sm:grid-cols-3">
           <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
-            <div className="text-[10px] uppercase tracking-widest text-[var(--text-muted)]">Agent memories</div>
+            <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">Agent memories</div>
             <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{visibleCoven.length}</div>
           </div>
           <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
-            <div className="text-[10px] uppercase tracking-widest text-[var(--text-muted)]">Memory files</div>
+            <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">Memory files</div>
             <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{fileEntries.length}</div>
           </div>
           <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
-            <div className="text-[10px] uppercase tracking-widest text-[var(--text-muted)]">Agents with memory</div>
+            <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">Agents with memory</div>
             <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{familiarsWithMemory.length}</div>
           </div>
         </div>
@@ -232,7 +232,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="Search memory..."
-              className="h-8 w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 pl-7 pr-3 text-[12px] text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)] focus:border-[var(--accent-presence)]"
+              className="focus-ring h-8 w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 pl-7 pr-3 text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent-presence)]"
             />
           </div>
           {lockToFamiliar ? (
@@ -246,7 +246,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
             <select
               value={familiarFilter}
               onChange={(event) => setFamiliarFilter(event.target.value)}
-              className="h-8 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 text-[12px] text-[var(--text-secondary)] outline-none focus:border-[var(--accent-presence)]"
+              className="focus-ring h-8 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 text-[12px] text-[var(--text-secondary)] focus:border-[var(--accent-presence)]"
             >
               {familiarOptions.map((familiar) => (
                 <option key={familiar.id} value={familiar.id}>{familiar.display_name}</option>
@@ -270,7 +270,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
           </section>
           <aside className="hidden min-h-0 xl:block">
             <div className="mb-2 flex items-center justify-between">
-              <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">
+              <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">
                 {selectedFamiliar?.display_name ?? "Selected agent"}
               </h3>
               <span className="text-[10px] text-[var(--text-muted)]">{visibleCoven.length} visible</span>
@@ -281,7 +281,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
                   key={entry.id}
                   type="button"
                   onClick={() => onOpenMemoryFile?.(entry.path)}
-                  className="flex w-full items-start gap-2 border-b border-[var(--border-hairline)] px-3 py-2 text-left hover:bg-[var(--bg-raised)]"
+                  className="focus-ring-inset flex w-full items-start gap-2 border-b border-[var(--border-hairline)] px-3 py-2 text-left hover:bg-[var(--bg-raised)]"
                 >
                   <Icon name="ph:brain" width={13} className="mt-0.5 shrink-0 text-[var(--accent-presence)]" />
                   <span className="min-w-0 flex-1">
@@ -302,7 +302,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
       <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto p-4 xl:grid-cols-[minmax(0,1.25fr)_minmax(320px,0.75fr)]">
         <section className="min-h-0">
           <div className="mb-2 flex items-center justify-between">
-            <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">Familiar memory</h3>
+            <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">Familiar memory</h3>
             <span className="text-[10px] text-[var(--text-muted)]">{visibleCoven.length} visible</span>
           </div>
           {visibleCoven.length === 0 ? (
@@ -333,7 +333,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
                     <button
                       type="button"
                       onClick={() => onOpenMemoryFile?.(entry.path)}
-                      className="mt-3 inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+                      className="focus-ring mt-3 inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
                     >
                       <Icon name="ph:file-text" width={12} />
                       Open memory
@@ -347,7 +347,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
 
         <section className="min-h-0">
           <div className="mb-2 flex items-center justify-between">
-            <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">Memory files</h3>
+            <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">Memory files</h3>
             <span className="text-[10px] text-[var(--text-muted)]">{visibleFiles.length} visible</span>
           </div>
           <MemoryFilesList
@@ -397,7 +397,7 @@ export function RailMemoryList({
       {onOpenFullView ? (
         <button
           type="button"
-          className="rail-memory__open-full"
+          className="focus-ring rail-memory__open-full"
           onClick={onOpenFullView}
         >
           Open full memory →
@@ -439,7 +439,7 @@ export function MemoryFilesList({ entries, onOpen, loaded, error, limit }: Memor
               <button
                 type="button"
                 onClick={() => onOpen?.(entry.fullPath)}
-                className="flex w-full items-start gap-2 px-3 py-2 text-left hover:bg-[var(--bg-raised)]"
+                className="focus-ring-inset flex w-full items-start gap-2 px-3 py-2 text-left hover:bg-[var(--bg-raised)]"
               >
                 <Icon name="ph:file-text" width={13} className="mt-0.5 shrink-0 text-[var(--text-muted)]" />
                 <span className="min-w-0 flex-1">

--- a/src/components/agents-view.tsx
+++ b/src/components/agents-view.tsx
@@ -172,7 +172,7 @@ export function AgentsView({
             <button
               type="button"
               onClick={() => setViewMode("global-memory")}
-              className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--accent-presence)]/10 px-2.5 text-[11px] text-[var(--accent-presence)] hover:bg-[var(--accent-presence)]/15"
+              className="focus-ring inline-flex h-7 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--accent-presence)]/10 px-2.5 text-[11px] text-[var(--accent-presence)] hover:bg-[var(--accent-presence)]/15"
             >
               <Icon name="ph:graph" width={12} />
               Memory across all agents
@@ -180,7 +180,7 @@ export function AgentsView({
             <button
               type="button"
               onClick={() => void loadMemory()}
-              className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+              className="focus-ring inline-flex h-7 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
             >
               <Icon name="ph:arrows-clockwise" width={12} />
               Refresh
@@ -198,7 +198,7 @@ export function AgentsView({
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="Search agents…"
-              className="h-8 w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 pl-7 pr-3 text-[12px] text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)] focus:border-[var(--accent-presence)]"
+              className="focus-ring h-8 w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 pl-7 pr-3 text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent-presence)]"
             />
           </div>
           {memoryError ? (
@@ -331,7 +331,7 @@ function AgentRosterCard({
     <button
       type="button"
       onClick={onSelect}
-      className="agents-view__card group flex h-full flex-col items-stretch gap-2 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 p-3 text-left transition-colors hover:border-[var(--accent-presence)]/50 hover:bg-[var(--bg-raised)]/60"
+      className="focus-ring agents-view__card group flex h-full flex-col items-stretch gap-2 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 p-3 text-left transition-colors hover:border-[var(--accent-presence)]/50 hover:bg-[var(--bg-raised)]/60"
       aria-label={`Open ${familiar.display_name}`}
     >
       <div className="flex items-center gap-2">
@@ -340,7 +340,7 @@ function AgentRosterCard({
           <span className="block truncate text-[13px] font-semibold text-[var(--text-primary)]">
             {familiar.display_name}
           </span>
-          <span className="block truncate text-[10px] uppercase tracking-widest text-[var(--text-muted)]">
+          <span className="block truncate text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">
             {familiar.role || familiar.harness || familiar.id}
           </span>
         </span>
@@ -435,7 +435,7 @@ function GlobalMemoryOverlay({ familiars, onClose, onOpenMemoryFile }: GlobalMem
         <button
           type="button"
           onClick={onClose}
-          className="absolute right-3 top-3 z-10 inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]/80"
+          className="focus-ring absolute right-3 top-3 z-10 inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]/80"
           aria-label="Close"
         >
           <Icon name="ph:x" width={12} />
@@ -469,7 +469,7 @@ function AgentDetailRail({ familiars, selectedId, onSelect, onBack }: AgentDetai
       <button
         type="button"
         onClick={onBack}
-        className="agents-view__rail-back inline-flex h-8 w-8 items-center justify-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+        className="focus-ring agents-view__rail-back inline-flex h-8 w-8 items-center justify-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
         aria-label="Back to roster"
         title="Back to roster"
       >
@@ -484,7 +484,7 @@ function AgentDetailRail({ familiars, selectedId, onSelect, onBack }: AgentDetai
               <button
                 type="button"
                 onClick={() => onSelect(f.id)}
-                className={`agents-view__rail-avatar inline-flex h-9 w-9 items-center justify-center rounded-full border ${
+                className={`focus-ring agents-view__rail-avatar inline-flex h-9 w-9 items-center justify-center rounded-full border ${
                   active
                     ? "border-[var(--accent-presence)] bg-[var(--accent-presence)]/15 text-[var(--accent-presence)]"
                     : "border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
@@ -552,7 +552,7 @@ function AgentDetailPanel({
             <h2 className="truncate text-[14px] font-semibold text-[var(--text-primary)]">
               {familiar.display_name}
             </h2>
-            <p className="truncate text-[10px] uppercase tracking-widest text-[var(--text-muted)]">
+            <p className="truncate text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">
               {familiar.role || familiar.harness || familiar.id}
             </p>
           </div>
@@ -561,7 +561,7 @@ function AgentDetailPanel({
           <button
             type="button"
             onClick={onStartChat}
-            className="inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2 text-[11px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)]/80"
+            className="focus-ring inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2 text-[11px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)]/80"
           >
             <Icon name="ph:chat-circle-dots" width={12} />
             Start chat
@@ -569,7 +569,7 @@ function AgentDetailPanel({
           <button
             type="button"
             onClick={onClose}
-            className="inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+            className="focus-ring inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
             aria-label="Back to roster"
           >
             <Icon name="ph:x" width={12} />
@@ -584,7 +584,7 @@ function AgentDetailPanel({
             key={id}
             type="button"
             onClick={() => setTab(id)}
-            className={`agents-view__tab inline-flex h-9 items-center gap-1.5 px-3 text-[12px] capitalize transition-colors ${
+            className={`focus-ring agents-view__tab inline-flex h-9 items-center gap-1.5 px-3 text-[12px] capitalize transition-colors ${
               tab === id
                 ? "border-b-2 border-[var(--accent-presence)] text-[var(--text-primary)]"
                 : "border-b-2 border-transparent text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
@@ -608,7 +608,7 @@ function AgentDetailPanel({
         ) : tab === "files" ? (
           <div className="h-full overflow-y-auto p-4">
             <div className="mb-2 flex items-center justify-between">
-              <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">
+              <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">
                 Memory files
               </h3>
               <span className="text-[10px] text-[var(--text-muted)]">
@@ -628,7 +628,7 @@ function AgentDetailPanel({
         ) : (
           <div className="h-full overflow-y-auto p-4">
             <div className="mb-2 flex items-center justify-between">
-              <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">
+              <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">
                 Sessions
               </h3>
               <span className="text-[10px] text-[var(--text-muted)]">
@@ -646,7 +646,7 @@ function AgentDetailPanel({
                     <button
                       type="button"
                       onClick={() => onOpenSession(s.id)}
-                      className="flex w-full items-start gap-2 px-3 py-2 text-left hover:bg-[var(--bg-raised)]"
+                      className="focus-ring-inset flex w-full items-start gap-2 px-3 py-2 text-left hover:bg-[var(--bg-raised)]"
                     >
                       <Icon name="ph:terminal-window" width={13} className="mt-0.5 shrink-0 text-[var(--text-muted)]" />
                       <span className="min-w-0 flex-1">


### PR DESCRIPTION
Closes the loop on the polish run by applying the same patterns to the Agents view itself. This file was created earlier in this session — before the polish patterns crystallised — so it had accumulated the same gaps every other surface had. Followup to #232 / #235 / #238 / #239 / #241 / #243 / #244 / #245 / #247 / #249 / #250.

## Summary

- **Focus rings** added to 15+ interactive controls (header buttons + search, roster card itself, detail rail + panel + tabs + session rows + close, overlay close, plus refresh / toggle / select / memory rows / file rows inside `AgentsMemoryView` which is reused as both the detail-tab Memory body and the global overlay).
- **Eyebrow contrast** — Bumped 9 small uppercase tracked-widest labels from `text-muted` → `text-secondary` (recurring AA-fail pattern from every prior polish PR).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [ ] **Manual:** open Agents (the default landing), switch to light theme, Tab through roster + drill in + tabs + global memory overlay; all focus stops visible, all eyebrows readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)