### PR TITLE
ux: home-composer polish — theme-aware send hover + card shadow

### DIFF
--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -49,13 +49,14 @@
   border: 1px solid var(--border-strong);
   border-radius: 16px;
   overflow: hidden;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18), 0 1px 0 color-mix(in oklch, var(--foreground) 4%, transparent) inset;
+  box-shadow: 0 8px 32px color-mix(in oklch, var(--text-primary) 12%, transparent),
+              0 1px 0 color-mix(in oklch, var(--foreground) 4%, transparent) inset;
   transition: box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .home-composer-card:focus-within {
   border-color: color-mix(in oklch, var(--accent-presence) 50%, var(--border-strong));
-  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.22),
+  box-shadow: 0 8px 40px color-mix(in oklch, var(--text-primary) 15%, transparent),
               0 0 0 1px color-mix(in oklch, var(--accent-presence) 20%, transparent);
 }
 
@@ -200,7 +201,7 @@
 }
 
 .hc-send-btn:hover:not(:disabled) {
-  background: oklch(0.7 0.18 280);
+  background: color-mix(in oklch, var(--accent-presence) 85%, #000);
   transform: scale(1.05);
 }
 


### PR DESCRIPTION
Two-line polish pass on the Home composer surface. Followup to #232 / #235 / #238 / #239 / #241 / #243 / #244 / #245 / #247 / #249 / #250 / #251.

## Summary

- `.hc-send-btn:hover` used `oklch(0.7 0.18 280)` — a fixed lavender that ignores the active `--accent-presence` and looks wrong on themes that override it. Replaced with `color-mix(in oklch, var(--accent-presence) 85%, #000)` so the button darkens off the *current* accent in both modes.
- `.home-composer-card` box-shadow used `rgba(0, 0, 0, 0.18)` for both the rest and `:focus-within` states. Switched to `color-mix` on `var(--text-primary)` — same theme-tracking pattern landed for the Familiar Studio drawer shadow in #241 and the calendar detail panel in #247.

Focus rings were already correctly wired for destination pills, send button, suggestions and familiar select — no work needed there.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [ ] **Manual:** open Home in light theme, hover the send button (darkens, doesn't go violet), and look at the card shadow (soft, not harsh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)