### PR TITLE
ux: command-palette polish — search focus ring + role-eyebrow contrast

### DIFF
--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -319,7 +319,7 @@ export function CommandPalette({
           }}
           onKeyDown={onComposerKey}
           placeholder="Search familiars · chats · cards · memory · commands…"
-          className="w-full border-b border-[var(--border-hairline)] bg-transparent px-4 py-3 text-sm text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)]"
+          className="focus-ring-inset w-full border-b border-[var(--border-hairline)] bg-transparent px-4 py-3 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"
         />
         <ul className="max-h-[60vh] overflow-y-auto py-1">
           {rows.length === 0 ? (
@@ -343,7 +343,7 @@ export function CommandPalette({
                     <>
                       <span className="flex flex-1 flex-col">
                         <span className="text-[var(--text-primary)]">{row.familiar.display_name}</span>
-                        <span className="text-[10px] uppercase tracking-widest text-[var(--text-muted)]">
+                        <span className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">
                           {row.familiar.role}
                         </span>
                       </span>


### PR DESCRIPTION
Two-line polish pass on the command palette. The surface was already in mostly-clean shape (theme tokens, modal semantics, `focus-ring-inset` on result rows). These were the two recurring patterns still missing.

## Summary

- Search input had `outline-none` with no replacement focus indicator. Added `focus-ring-inset`. (The input is auto-focused on open so this matters less than other inputs, but still wrong.)
- Familiar-row "role" eyebrow used `text-muted` at 10px uppercase tracked-widest — same AA-fail pattern as every prior polish PR. Bumped to `text-secondary`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)