### PR TITLE
ux: browser polish — focus rings + tokenize hardcoded whites

### DIFF
--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -534,7 +534,7 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
         <span
           aria-hidden
           className={[
-            "pointer-events-none absolute left-0 top-1/2 -translate-y-1/2 w-[2px] rounded-r-full bg-white/20",
+            "pointer-events-none absolute left-0 top-1/2 -translate-y-1/2 w-[2px] rounded-r-full bg-[var(--fg-base)]/20",
             "transition-opacity duration-150",
             railExpanded ? "opacity-0" : "opacity-100",
           ].join(" ")}
@@ -556,7 +556,7 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
             onClick={() => setRailPinned((v) => !v)}
             title={railPinned ? "Auto-hide tabs" : "Pin tabs open"}
             className={[
-              "mb-1 grid h-7 w-7 shrink-0 place-items-center rounded transition-colors",
+              "focus-ring mb-1 grid h-7 w-7 shrink-0 place-items-center rounded transition-colors",
               railPinned
                 ? "text-[var(--accent-presence)] hover:text-[var(--accent-presence)]"
                 : "text-[var(--text-muted)] hover:text-[var(--text-primary)]",
@@ -582,7 +582,7 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
               }}
               title={tabTitles[tab.id] ?? tab.title ?? tab.url}
               className={[
-                "browser-tab group relative flex flex-col items-center justify-center gap-0.5 w-full cursor-pointer select-none transition-colors py-2.5",
+                "focus-ring-inset browser-tab group relative flex flex-col items-center justify-center gap-0.5 w-full cursor-pointer select-none transition-colors py-2.5",
                 isActive
                   ? "bg-[var(--bg-elevated)] text-[var(--fg-base)]"
                   : "text-[var(--fg-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--fg-base)]",
@@ -590,7 +590,7 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
             >
               {/* Active indicator bar */}
               {isActive && (
-                <span className="absolute left-0 top-1/2 -translate-y-1/2 w-[2px] h-6 rounded-r-full bg-white/70" />
+                <span className="absolute left-0 top-1/2 -translate-y-1/2 w-[2px] h-6 rounded-r-full bg-[var(--accent-presence)]" />
               )}
               {/* Favicon / indicator */}
               <span className="relative flex shrink-0 items-center justify-center">
@@ -605,7 +605,7 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
               {tab.kind === "pinned" && tabs.filter((t) => t.kind === "pinned").length > 1 && (
                 <button
                   onClick={(e) => removeTab(tab.id, e)}
-                  className="absolute top-1 right-1 opacity-0 group-hover:opacity-60 hover:!opacity-100 text-[var(--fg-muted)] transition-opacity"
+                  className="focus-ring absolute top-1 right-1 rounded opacity-0 group-hover:opacity-60 hover:!opacity-100 focus-visible:opacity-100 text-[var(--fg-muted)] transition-opacity"
                   title="Close tab"
                 >
                   <Icon name="ph:x-bold" width={7} />
@@ -619,7 +619,7 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
         {/* Pin current page */}
         <button
           onClick={pinCurrentPage}
-          className="grid h-8 w-8 shrink-0 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)] transition-colors"
+          className="focus-ring grid h-8 w-8 shrink-0 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)] transition-colors"
           title="Pin current page as a tab"
         >
           <Icon name="ph:plus" width={13} />
@@ -633,13 +633,13 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
       <header className="relative z-10 flex min-h-10 shrink-0 items-center gap-1 border-b border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 py-1.5">
         {/* Back */}
         <button type="button" onClick={goBack} disabled={!canBack}
-          className="grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)] disabled:opacity-30 disabled:cursor-default"
+          className="focus-ring grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)] disabled:opacity-30 disabled:cursor-default"
           title="Back" aria-label="Back">
           <Icon name="ph:arrow-left-bold" width={13} />
         </button>
         {/* Forward */}
         <button type="button" onClick={goForward} disabled={!canForward}
-          className="grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)] disabled:opacity-30 disabled:cursor-default"
+          className="focus-ring grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)] disabled:opacity-30 disabled:cursor-default"
           title="Forward" aria-label="Forward">
           <Icon name="ph:arrow-right-bold" width={13} />
         </button>
@@ -649,7 +649,7 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
             if (bridge) void bridge.invoke("browser_reload", { label: tabLabel(activeTabId) });
             else navigateTo(activeUrl);
           }}
-          className="grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)]"
+          className="focus-ring grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)]"
           title={loading ? "Stop" : "Reload"} aria-label={loading ? "Stop" : "Reload"}>
           {loading
             ? <Icon name="ph:x-bold" width={12} />
@@ -669,12 +669,12 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
             onChange={(e) => setAddressBar(e.target.value)}
             onFocus={(e) => e.currentTarget.select()}
             placeholder="Search or enter address"
-            className="flex-1 bg-transparent text-[12px] text-[var(--fg-base)] outline-none"
+            className="focus-ring-inset flex-1 rounded bg-transparent text-[12px] text-[var(--fg-base)]"
           />
         </form>
         {/* Home */}
         <button type="button" onClick={() => navigateTo(HOME_URL)}
-          className="grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)]"
+          className="focus-ring grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)]"
           title="Home" aria-label="Home">
           <Icon name="ph:house-bold" width={13} />
         </button>
@@ -695,7 +695,7 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
               window.open(activeUrl, "_blank", "noopener");
             }
           }}
-          className="grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)]"
+          className="focus-ring grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)]"
           title="Open in system browser" aria-label="Open in system browser">
           <Icon name="ph:arrow-square-out" width={13} />
         </button>

--- a/src/components/browser-quick-open.tsx
+++ b/src/components/browser-quick-open.tsx
@@ -101,17 +101,10 @@ export function BrowserQuickOpen({ tabs, activeId, onSelect, onClose }: Props) {
       style={{ background: "transparent" }}
       onMouseDown={handleBackdrop}
     >
-      <div
-        className="w-[420px] max-w-[92vw] overflow-hidden rounded-2xl shadow-2xl"
-        style={{
-          background: "var(--bg-elevated)",
-          border: "1px solid rgba(255,255,255,0.08)",
-          boxShadow: "0 24px 64px rgba(0,0,0,0.7), 0 0 0 1px rgba(255,255,255,0.04)",
-        }}
-      >
+      <div className="w-[420px] max-w-[92vw] overflow-hidden rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] shadow-2xl">
         {/* Search input */}
-        <div className="flex items-center gap-2.5 border-b px-4 py-3" style={{ borderColor: "rgba(255,255,255,0.07)" }}>
-          <span className="text-sm" style={{ color: "rgba(255,255,255,0.3)" }}>⌘</span>
+        <div className="flex items-center gap-2.5 border-b border-[var(--border-hairline)] px-4 py-3">
+          <span className="text-sm text-[var(--text-muted)]">⌘</span>
           <input
             ref={inputRef}
             type="text"
@@ -119,8 +112,7 @@ export function BrowserQuickOpen({ tabs, activeId, onSelect, onClose }: Props) {
             onChange={(e) => { setQuery(e.target.value); setHighlightIdx(0); }}
             onKeyDown={handleKey}
             placeholder="Jump to tab…"
-            className="flex-1 bg-transparent text-sm outline-none placeholder:text-[rgba(255,255,255,0.25)]"
-            style={{ color: "rgba(255,255,255,0.9)" }}
+            className="focus-ring-inset flex-1 rounded bg-transparent text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"
             spellCheck={false}
             autoComplete="off"
           />
@@ -128,8 +120,8 @@ export function BrowserQuickOpen({ tabs, activeId, onSelect, onClose }: Props) {
             <button
               type="button"
               onClick={() => { setQuery(""); setHighlightIdx(0); inputRef.current?.focus(); }}
-              className="text-xs"
-              style={{ color: "rgba(255,255,255,0.3)" }}
+              className="focus-ring rounded text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+              aria-label="Clear search"
             >
               x
             </button>
@@ -138,7 +130,7 @@ export function BrowserQuickOpen({ tabs, activeId, onSelect, onClose }: Props) {
 
         {/* Tab list */}
         {filtered.length === 0 ? (
-          <p className="px-4 py-6 text-center text-xs" style={{ color: "rgba(255,255,255,0.3)" }}>
+          <p className="px-4 py-6 text-center text-xs text-[var(--text-muted)]">
             No tabs match &ldquo;{query}&rdquo;
           </p>
         ) : (
@@ -152,10 +144,9 @@ export function BrowserQuickOpen({ tabs, activeId, onSelect, onClose }: Props) {
                 <li key={tab.id}>
                   <button
                     type="button"
-                    className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-none"
-                    style={{
-                      background: isHighlighted ? "rgba(255,255,255,0.06)" : "transparent",
-                    }}
+                    className={`focus-ring-inset flex w-full items-center gap-3 px-4 py-2.5 text-left transition-none ${
+                      isHighlighted ? "bg-[var(--bg-hover)]" : ""
+                    }`}
                     onMouseEnter={() => setHighlightIdx(i)}
                     onClick={() => { onSelect(tab.id); onClose(); }}
                   >
@@ -168,29 +159,27 @@ export function BrowserQuickOpen({ tabs, activeId, onSelect, onClose }: Props) {
                     {/* Title + hint */}
                     <span className="min-w-0 flex-1">
                       <span
-                        className="block truncate text-sm"
-                        style={{ color: isHighlighted ? "rgba(255,255,255,0.95)" : "rgba(255,255,255,0.75)" }}
+                        className={`block truncate text-sm ${
+                          isHighlighted ? "text-[var(--text-primary)]" : "text-[var(--text-secondary)]"
+                        }`}
                       >
                         {tab.title || tabHint(tab)}
                       </span>
-                      <span className="block truncate text-[11px]" style={{ color: "rgba(255,255,255,0.3)" }}>
+                      <span className="block truncate text-[11px] text-[var(--text-muted)]">
                         {tabHint(tab)}
                       </span>
                     </span>
 
                     {/* Active indicator */}
                     {isActive && (
-                      <span
-                        className="shrink-0 rounded-full text-[10px] px-1.5 py-0.5"
-                        style={{ background: "rgba(255,255,255,0.08)", color: "rgba(255,255,255,0.4)" }}
-                      >
+                      <span className="shrink-0 rounded-full bg-[var(--bg-raised)] px-1.5 py-0.5 text-[10px] text-[var(--text-muted)]">
                         current
                       </span>
                     )}
 
                     {/* Highlight arrow */}
                     {isHighlighted && !isActive && (
-                      <span className="shrink-0 text-xs" style={{ color: "rgba(255,255,255,0.3)" }}>↵</span>
+                      <span className="shrink-0 text-xs text-[var(--text-muted)]">↵</span>
                     )}
                   </button>
                 </li>
@@ -200,10 +189,7 @@ export function BrowserQuickOpen({ tabs, activeId, onSelect, onClose }: Props) {
         )}
 
         {/* Footer hint */}
-        <div
-          className="flex items-center gap-3 border-t px-4 py-2"
-          style={{ borderColor: "rgba(255,255,255,0.06)", color: "rgba(255,255,255,0.25)" }}
-        >
+        <div className="flex items-center gap-3 border-t border-[var(--border-hairline)] px-4 py-2 text-[var(--text-muted)]">
           <span className="text-[10px]">↑↓ navigate</span>
           <span className="text-[10px]">↵ open</span>
           <span className="text-[10px]">esc close</span>


### PR DESCRIPTION
Polish pass over the Browser surface (browser-pane + browser-quick-open). Followup to the polish run (now 14 prior PRs).

## Summary

- **Focus rings** added to 9 controls in browser-pane (rail pin toggle, tab row, close-tab, pin-current-page, toolbar back/forward/reload/home/open-in-system, URL input) and 3 in quick-open (search, search-clear, every list-item button).
- **Hardcoded white literals** tokenized:
  - Tab rail active-indicator bar `bg-white/70` → `bg-[var(--accent-presence)]` (matches every selected-state bar elsewhere).
  - Collapsed-state rail hint `bg-white/20` → `bg-[var(--fg-base)]/20`.
  - Quick-open palette had ~14 inline `rgba(255,255,255,X)` literals across borders, search input, list rows, the "current" pill, and footer. All replaced with `var(--text-primary)` / `var(--text-secondary)` / `var(--text-muted)` / `var(--bg-hover)` / `var(--border-hairline)` / `var(--bg-raised)`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [ ] **Manual:** open Browser in light theme, Tab through rail + toolbar + URL bar + quick-open palette; verify quick-open palette reads correctly (no white-on-white text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)