### PR TITLE
fix(theme): restore darker cave background

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,7 +29,7 @@
 
 :root {
   /* ---- Palette (oklch — same colour science as shadcn) ---- */
-  --background: oklch(0.09 0.004 293);
+  --background: oklch(0.07 0.004 293);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.135 0.005 293);
   --card-foreground: oklch(0.985 0 0);


### PR DESCRIPTION
## Summary
- Restores the default dark Cave background token to the darker Mood C foundation.
- Keeps the shell bg on the existing token path: `--bg-base` inherits `--background`.

## Why
The default dark background had drifted from `oklch(0.07 0.004 293)` to `0.09`, making the Cave background a little too lifted instead of almost-black dark grey.

## Validation
- `node src/app/globals-background.test.ts`
- `node src/app/globals.css.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check HEAD~1..HEAD`