### PR TITLE
fix(chat): polish linear conversation layout

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -8,6 +8,9 @@ import { canonicalize, formatHelp, matchSlash, type SlashCommand } from "@/lib/s
 import { slashSaveParse } from "@/lib/slash-save-parser";
 import { Icon, type IconName } from "@/lib/icon";
 import { useKeySymbols } from "@/lib/platform-keys";
+import { FamiliarGlyph } from "@/components/familiar-glyph";
+import { useGlyphOverrides } from "@/lib/cave-glyph-overrides";
+import { resolveFamiliarGlyph } from "@/lib/familiar-glyph";
 import type { ChatLinkedContext } from "@/lib/chat-linked-context";
 import {
   MAX_ATTACHMENT_TEXT_CHARS,
@@ -838,7 +841,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       <header className="cave-chat-linear-header">
         <div className="flex min-w-0 items-start gap-3">
           <div className="cave-agent-marker" aria-hidden>
-            <Icon name="ph:sparkle-bold" width={15} />
+            <FamiliarIcon familiar={familiar} size="sm" />
           </div>
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
@@ -1096,6 +1099,12 @@ function ThinkingIndicator({ since }: { since: string }) {
 
 // ── TurnRow ────────────────────────────────────────────────────────────────────
 
+function FamiliarIcon({ familiar, size = "sm" }: { familiar: Familiar; size?: "sm" | "md" | "lg" }) {
+  const overrides = useGlyphOverrides();
+  const glyph = resolveFamiliarGlyph(familiar, overrides);
+  return <FamiliarGlyph glyph={glyph} size={size} />;
+}
+
 function TurnRow({
   turn,
   familiar,
@@ -1107,19 +1116,14 @@ function TurnRow({
   showTimestamp?: boolean;
   index: number;
 }) {
-  const turnNumber = String(index + 1).padStart(2, "0");
-
   if (turn.role === "system" || turn.role === "user") {
     return (
       <div className={`cave-linear-turn cave-linear-turn--${turn.role}`}>
-        <aside className="cave-linear-turn-index" aria-label={`Turn ${turnNumber}`}>
-          {turnNumber}
-        </aside>
         <div className="cave-linear-turn-content">
           <div className="cave-linear-turn-meta">
-            <span>{turn.role === "user" ? "You" : "System"}</span>
-            {showTimestamp && turn.createdAt ? <span>{fmtTime(turn.createdAt)}</span> : null}
-            {turn.attachments?.length ? <span>{turn.attachments.length} files</span> : null}
+            <span className="font-medium text-[var(--text-secondary)]">{turn.role === "user" ? "You" : "System"}</span>
+            {showTimestamp && turn.createdAt ? <span className="opacity-60">{fmtTime(turn.createdAt)}</span> : null}
+            {turn.attachments?.length ? <span className="opacity-60">{turn.attachments.length} file{turn.attachments.length === 1 ? "" : "s"}</span> : null}
           </div>
           <MessageBubble
             role={turn.role}
@@ -1133,6 +1137,7 @@ function TurnRow({
       </div>
     );
   }
+
   const duration = fmtDuration(turn.durationMs);
   const { visible, reasoning: inlineReasoning } = splitReasoning(turn.text);
   const reasoning = turn.reasoning?.trim() || inlineReasoning;
@@ -1141,38 +1146,42 @@ function TurnRow({
 
   return (
     <div className="cave-linear-turn cave-linear-turn--assistant">
-      <aside className="cave-linear-turn-index" aria-label={`Turn ${turnNumber}`}>
-        {turnNumber}
-      </aside>
-
       <div className="cave-linear-turn-content text-[14px] leading-relaxed text-[var(--text-primary)] group/turn">
-        <div className="cave-linear-turn-meta">
-          <span className="truncate text-[13px] font-semibold text-[var(--text-primary)]">{familiar.display_name}</span>
-          <span className={`cave-turn-status cave-turn-status--${turnStatus}`}>
-            {turnStatus}
-          </span>
-          {showTimestamp && turn.createdAt ? <span>{fmtTime(turn.createdAt)}</span> : null}
-          {duration && !turn.pending ? <span>worked {duration}</span> : null}
-          {toolCount ? <span>{toolCount} tool{toolCount === 1 ? "" : "s"}</span> : null}
-          {reasoning ? <span>reasoning</span> : null}
+        {/* Avatar + right column */}
+        <div className="cave-linear-turn-avatar" aria-hidden>
+          <FamiliarIcon familiar={familiar} size="sm" />
         </div>
+        <div className="cave-linear-turn-right">
+          <div className="cave-linear-turn-meta">
+            <span className="cave-linear-turn-name">{familiar.display_name}</span>
+            {turnStatus === "error" && (
+              <span className="cave-turn-status cave-turn-status--error">error</span>
+            )}
+            {turnStatus === "running" && (
+              <span className="cave-turn-status cave-turn-status--running">writing…</span>
+            )}
+            {showTimestamp && turn.createdAt ? <span className="opacity-60">{fmtTime(turn.createdAt)}</span> : null}
+            {duration && !turn.pending ? <span className="opacity-50">{duration}</span> : null}
+            {toolCount ? <span className="opacity-60">{toolCount} tool{toolCount === 1 ? "" : "s"}</span> : null}
+          </div>
 
-        <div className="cave-linear-turn-body">
-          {turn.pending && !visible ? (
-            <ThinkingIndicator since={turn.createdAt} />
-          ) : (
-            <MessageBubble
-              role="assistant"
-              content={visible || (turn.pending ? "…" : "")}
-              timestamp={turn.createdAt}
-              showTimestamp={false}
-              pending={turn.pending}
-              isError={turn.error}
-              label={familiar.display_name}
-            />
-          )}
-          {reasoning ? <ReasoningBlock reasoning={reasoning} /> : null}
-          {turn.tools?.length ? <ToolGroup tools={turn.tools} /> : null}
+          <div className="cave-linear-turn-body">
+            {turn.pending && !visible ? (
+              <ThinkingIndicator since={turn.createdAt} />
+            ) : (
+              <MessageBubble
+                role="assistant"
+                content={visible || (turn.pending ? "…" : "")}
+                timestamp={turn.createdAt}
+                showTimestamp={false}
+                pending={turn.pending}
+                isError={turn.error}
+                label={familiar.display_name}
+              />
+            )}
+            {reasoning ? <ReasoningBlock reasoning={reasoning} /> : null}
+            {turn.tools?.length ? <ToolGroup tools={turn.tools} /> : null}
+          </div>
         </div>
       </div>
     </div>

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -782,53 +782,117 @@
   background: color-mix(in oklch, var(--bg-panel) 76%, transparent);
   padding: 12px 18px 10px;
   box-shadow: 0 1px 0 color-mix(in oklch, var(--foreground) 4%, transparent) inset;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 }
 
 .cave-agent-marker {
   display: grid;
   place-items: center;
-  width: 30px;
-  height: 30px;
+  width: 32px;
+  height: 32px;
   border: 1px solid color-mix(in oklch, var(--accent-presence) 28%, transparent);
-  border-radius: 7px;
+  border-radius: 8px;
   background: color-mix(in oklch, var(--accent-presence) 9%, var(--bg-raised));
   color: var(--accent-presence);
+  overflow: hidden;
+  flex-shrink: 0;
 }
 
 .cave-chat-linear .cave-chat-transcript {
-  padding: 18px clamp(16px, 3vw, 34px) 22px;
+  padding: 22px clamp(16px, 3vw, 34px) 22px;
 }
 
 .cave-chat-linear .cave-chat-thread {
   gap: 0;
   width: 100%;
+  max-width: 860px;
+  margin: 0 auto;
 }
 
+/* ── Turn rows ──────────────────────────────────────────────────────────── */
+
 .cave-linear-turn {
-  display: grid;
-  grid-template-columns: 44px minmax(0, 1fr);
-  gap: 12px;
-  border-bottom: 1px solid color-mix(in oklch, var(--foreground) 6%, transparent);
-  padding: 13px 0;
+  display: flex;
+  flex-direction: column;
+  padding: 14px 0 12px;
+  border-bottom: 1px solid color-mix(in oklch, var(--foreground) 5%, transparent);
+  transition: background 0.1s;
+}
+
+.cave-linear-turn:last-child {
+  border-bottom: 0;
 }
 
 .cave-linear-turn:hover {
-  background: color-mix(in oklch, var(--foreground) 2%, transparent);
+  background: color-mix(in oklch, var(--foreground) 1.5%, transparent);
+}
+
+/* User turn — right-aligned bubble */
+.cave-linear-turn--user {
+  align-items: flex-end;
+}
+
+/* Assistant turn — full width with avatar rail */
+.cave-linear-turn--assistant {
+  align-items: stretch;
 }
 
 .cave-linear-turn-index {
-  padding-top: 2px;
-  color: color-mix(in oklch, var(--text-muted) 78%, transparent);
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 11px;
-  line-height: 20px;
-  text-align: right;
-  user-select: none;
+  display: none; /* removed — clutters the visual; ordinal lives in meta if needed */
 }
 
 .cave-linear-turn-content {
   min-width: 0;
   max-width: 100%;
+  width: 100%;
+}
+
+/* ── User turn meta + bubble ────────────────────────────────────────────── */
+
+.cave-linear-turn--user .cave-linear-turn-meta {
+  justify-content: flex-end;
+  margin-bottom: 5px;
+}
+
+.cave-chat-linear .cave-bubble-user {
+  max-width: min(72%, 600px);
+  width: auto;
+  border: 1px solid var(--border-hairline);
+  border-radius: 14px 14px 4px 14px;
+  background: color-mix(in oklch, var(--accent-presence) 13%, var(--bg-raised));
+  color: var(--text-primary);
+  box-shadow:
+    0 1px 4px oklch(0 0 0 / 12%),
+    0 0 0 1px color-mix(in oklch, var(--accent-presence) 16%, transparent);
+  padding: 10px 14px;
+}
+
+/* ── Assistant turn — avatar + content ─────────────────────────────────── */
+
+.cave-linear-turn--assistant .cave-linear-turn-content {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+}
+
+.cave-linear-turn-avatar {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 22%, transparent);
+  border-radius: 9px;
+  background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-raised));
+  color: var(--accent-presence);
+  overflow: hidden;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.cave-linear-turn-right {
+  min-width: 0;
 }
 
 .cave-linear-turn-meta {
@@ -836,28 +900,23 @@
   min-width: 0;
   flex-wrap: wrap;
   align-items: center;
-  gap: 7px;
-  min-height: 20px;
-  margin-bottom: 4px;
+  gap: 6px;
+  min-height: 22px;
+  margin-bottom: 5px;
   color: var(--text-muted);
   font-size: 11px;
+  line-height: 1.4;
+}
+
+.cave-linear-turn-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
 }
 
 .cave-linear-turn-body {
   min-width: 0;
-  border-left: 1px solid color-mix(in oklch, var(--accent-presence) 22%, transparent);
-  padding-left: 12px;
-}
-
-.cave-chat-linear .cave-bubble-user {
-  width: 100%;
-  max-width: 100%;
-  border: 0;
-  border-left: 1px solid color-mix(in oklch, var(--accent-presence) 28%, transparent);
-  border-radius: 0;
-  background: transparent;
-  box-shadow: none;
-  padding: 0 0 0 12px;
 }
 
 .cave-chat-linear .cave-bubble-assistant {


### PR DESCRIPTION
## Summary
- Uses familiar glyphs in the linear chat header and assistant turns.
- Reworks linear chat turns into a cleaner centered transcript with user bubbles and assistant avatar rail.
- Tightens turn metadata, spacing, hover treatment, and pending/error labels.

## Validation
- `git diff --check`
- `pnpm typecheck`
- `pnpm build`