### PR TITLE
fix(theme): set cave background to almost black grey

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,7 +29,7 @@
 
 :root {
   /* ---- Palette (oklch — same colour science as shadcn) ---- */
-  --background: oklch(0.07 0.004 293);
+  --background: #19191c;
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.135 0.005 293);
   --card-foreground: oklch(0.985 0 0);


### PR DESCRIPTION
## Summary
- Sets the default Cave dark background token to `#19191c` for an almost-black dark grey base.
- Keeps the existing token path so shell surfaces continue inheriting through `--bg-base`.

## Validation
- `node src/app/globals-background.test.ts`
- `node src/app/globals.css.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check HEAD~1..HEAD`