### PR TITLE
style(chat): full-width thread + visible collapsed thinking/tool blocks

### DIFF
--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -692,6 +692,7 @@
   gap: 8px;
   cursor: pointer;
   user-select: none;
+  list-style: none;
   color: var(--text-muted);
   font-size: 11px;
   font-weight: 600;
@@ -699,8 +700,32 @@
   text-transform: uppercase;
 }
 
-.cave-tool-summary::marker {
-  color: var(--text-muted);
+.cave-tool-summary::-webkit-details-marker {
+  display: none;
+}
+
+/* chevron via pseudo */
+.cave-tool-summary::before {
+  content: '';
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+  background-color: currentColor;
+  opacity: 0.5;
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M6 4l4 4-4 4' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M6 4l4 4-4 4' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  transition: transform 0.15s ease;
+}
+
+details[open] > .cave-tool-summary::before {
+  transform: rotate(90deg);
 }
 
 .cave-tool-count {
@@ -806,8 +831,8 @@
 .cave-chat-linear .cave-chat-thread {
   gap: 0;
   width: 100%;
-  max-width: 860px;
-  margin: 0 auto;
+  max-width: 100%;
+  margin: 0;
 }
 
 /* ── Turn rows ──────────────────────────────────────────────────────────── */


### PR DESCRIPTION
- Thread max-width removed — fills the panel\n- `.cave-tool-summary` gets a visible rotating chevron via CSS mask (replaces invisible `::marker`)\n- Thinking + Tool activity stay collapsed by default, expand on click\n- Chevron animates 90° on open