### PR TITLE
feat(salem): Salem chat panel in companion rail

### DIFF
--- a/src/app/api/salem/route.ts
+++ b/src/app/api/salem/route.ts
@@ -119,7 +119,7 @@ function retrieveTopK(chunks: DocChunk[], query: string, k: number): DocChunk[] 
 function quickReply(message: string): string | null {
   const lower = message.toLowerCase();
   if (lower.match(/\bwho are you\b|\bwhat are you\b|\bsalem\b/)) {
-    return `I'm **Salem** — your docs familiar. Sassy black cat, preloaded with the full OpenCoven docs corpus, here to save you from reading 300KB of markdown yourself. Ask me anything about familiars, roles, skills, the daemon, Cave, or how any of this works.`;
+    return `I'm **Salem** — your docs familiar. Sassy male black cat, preloaded with the full OpenCoven docs corpus, here to save you from reading 300KB of markdown yourself. Ask me anything about familiars, plugins, roles, skills, the daemon, Cave, or how any of this works.`;
   }
   return null;
 }

--- a/src/app/globals-background.test.ts
+++ b/src/app/globals-background.test.ts
@@ -6,7 +6,7 @@ const globals = await readFile(new URL("./globals.css", import.meta.url), "utf8"
 
 assert.match(
   globals,
-  /--background:\s*oklch\(0\.07 0\.004 293\);/,
+  /--background:\s*#19191c;/,
   "Default Coven Cave background should stay on the darker Mood C foundation",
 );
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3591,6 +3591,18 @@ body {
   max-height: 100vh;
   border-radius: 0;
 }
+.salem-panel--rail {
+  position: static;
+  z-index: auto;
+  width: 100%;
+  height: 100%;
+  max-height: none;
+  border: 0;
+  border-radius: 0;
+  background: var(--bg-panel);
+  box-shadow: none;
+  backdrop-filter: none;
+}
 
 .salem-panel__header {
   display: flex;

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -14,13 +14,13 @@ assert.match(
 
 assert.match(
   chatSurface,
-  /Search chats…/,
+  /placeholder="Search"/,
   "ChatSurface should keep chat search in the primary command row",
 );
 
 assert.match(
   chatSurface,
-  /Chat/,
+  /New/,
   "ChatSurface should expose the primary chat launch action without a separate composer block",
 );
 

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -7,7 +7,6 @@ import { SessionsView } from "@/components/sessions-view";
 import { InspectorPane } from "@/components/inspector-pane";
 import { AgentPanel } from "@/components/agent-panel";
 import { Icon } from "@/lib/icon";
-import type { IconName } from "@/lib/icon";
 import type { InboxItem } from "@/lib/cave-inbox";
 import { inferOrigin } from "@/lib/session-origin";
 import type { Familiar, SessionRow } from "@/lib/types";
@@ -74,17 +73,6 @@ function statusPill(s: SessionRow): { label: string; cls: string } | null {
   if (s.status === "failed" || (s.exit_code !== null && s.exit_code !== 0))
     return { label: "failed", cls: "border-[color-mix(in_oklch,var(--color-danger)_30%,transparent)] bg-[color-mix(in_oklch,var(--color-danger)_15%,transparent)] text-[var(--color-danger)]" };
   return null; // orphaned / created / idle = no pill
-}
-
-// ── Agents command bar ────────────────────────────────────────────────────────
-
-function softButton(active = false): string {
-  return [
-    "inline-flex h-7 items-center gap-1.5 rounded-md px-2.5 text-[11px] transition-colors",
-    active
-      ? "bg-[var(--bg-elevated)] text-[var(--text-primary)]"
-      : "text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]",
-  ].join(" ");
 }
 
 // ── Origin icon map ───────────────────────────────────────────────────────────
@@ -385,7 +373,7 @@ export function ChatSurface({
     <section className="flex h-full min-w-0 bg-[var(--bg-base)]">
       {/* Main content */}
       <div className="flex min-w-0 flex-1 flex-col">
-        {/* ── Tab bar — underline style matching roles/plugins view ─────── */}
+        {/* ── Ultra-minimalist header ────────────────────────────────────── */}
         <div className="flex shrink-0 items-center justify-between border-b border-[var(--border-hairline)] px-4">
           {/* Tabs flush left */}
           <div className="flex items-end gap-0">
@@ -394,10 +382,6 @@ export function ChatSurface({
                 sessions: "Chats",
                 memory: "Memory",
               };
-              const icons: Record<string, string> = {
-                sessions: "ph:users",
-                memory: "ph:brain-bold",
-              };
               const isActive = scope === s || (s === "sessions" && scope === "conversation");
               return (
                 <button
@@ -405,67 +389,94 @@ export function ChatSurface({
                   type="button"
                   onClick={() => setScope(s)}
                   className={[
-                    "relative flex items-center gap-1.5 px-3 py-2.5 text-[12px] font-medium transition-colors",
+                    "relative px-2 py-2.5 text-[12px] transition-colors",
                     isActive
-                      ? "text-[var(--text-primary)] after:absolute after:bottom-0 after:left-0 after:right-0 after:h-[2px] after:rounded-t after:bg-[oklch(0.65_0.18_280)]"
+                      ? "text-[var(--text-primary)] after:absolute after:bottom-0 after:left-2 after:right-2 after:h-[1px] after:bg-[var(--text-primary)]"
                       : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]",
                   ].join(" ")}
                 >
-                  <Icon name={icons[s] as IconName} width={12} />
                   {labels[s]}
                 </button>
               );
             })}
           </div>
 
-          {/* Actions flush right */}
-          <div className="flex items-center gap-1.5 py-1.5">
+          {/* Actions flush right — chromeless */}
+          <div className="flex items-center gap-3 py-1.5">
             {(scope === "sessions" || scope === "conversation") && (
-              <div className="relative">
-                <Icon name="ph:magnifying-glass" width={12} className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-muted)]" />
-                <input
-                  value={query}
-                  onChange={(e) => setQuery(e.target.value)}
-                  placeholder="Search chats…"
-                  className="h-7 w-[140px] rounded-md border border-[var(--border-hairline)] bg-transparent pl-7 pr-3 text-[12px] outline-none placeholder:text-[var(--text-muted)] focus:border-[oklch(0.65_0.18_280/60%)] focus:w-[200px] transition-all"
-                />
-              </div>
-            )}
-            {(scope === "sessions" || scope === "conversation") && (
-              <div className="inline-flex rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/20 p-0.5" title="Show active or done sessions" role="group" aria-label="Filter sessions by state">
-                <button type="button" onClick={() => setShowClosed(false)} className={softButton(!showClosed)} aria-pressed={!showClosed}>
-                  <Icon name="ph:circle" width={11} />
-                  Active <span className="opacity-50 font-normal">{openCount}</span>
-                </button>
-                <button type="button" onClick={() => setShowClosed(true)} className={softButton(showClosed)} aria-pressed={showClosed}>
-                  <Icon name="ph:check-circle" width={11} />
-                  Done <span className="opacity-50 font-normal">{closedCount}</span>
-                </button>
-              </div>
-            )}
-            {(scope === "sessions" || scope === "conversation") && (
-              <div className="inline-flex items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/20 p-0.5" title="Group by" role="group" aria-label="Group by">
-                <span className="px-1.5 text-[var(--text-muted)]" aria-hidden><Icon name="ph:rows" width={11} /></span>
-                <button type="button" onClick={() => setGroupBy("date")} aria-pressed={groupBy === "date"} className={softButton(groupBy === "date")}>
-                  Date
-                </button>
-                <button type="button" onClick={() => setGroupBy("status")} aria-pressed={groupBy === "status"} className={softButton(groupBy === "status")}>
-                  Status
-                </button>
-                <button type="button" onClick={() => setGroupBy("none")} aria-pressed={groupBy === "none"} className={softButton(groupBy === "none")}>
-                  Flat
-                </button>
-              </div>
+              <>
+                <div className="relative">
+                  <Icon name="ph:magnifying-glass" width={12} className="pointer-events-none absolute left-0 top-1/2 -translate-y-1/2 text-[var(--text-muted)]" />
+                  <input
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder="Search"
+                    className="h-7 w-[90px] bg-transparent pl-5 pr-1 text-[12px] outline-none placeholder:text-[var(--text-muted)] focus:w-[160px] transition-all"
+                  />
+                </div>
+
+                <div className="flex items-center gap-2 text-[11px]" role="group" aria-label="Filter sessions by state">
+                  <button
+                    type="button"
+                    onClick={() => setShowClosed(false)}
+                    aria-pressed={!showClosed}
+                    className={!showClosed ? "text-[var(--text-primary)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"}
+                  >
+                    Active <span className="opacity-50">{openCount}</span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setShowClosed(true)}
+                    aria-pressed={showClosed}
+                    className={showClosed ? "text-[var(--text-primary)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"}
+                  >
+                    Done <span className="opacity-50">{closedCount}</span>
+                  </button>
+                </div>
+
+                <div className="flex items-center gap-2 text-[11px]" role="group" aria-label="Group by">
+                  <button
+                    type="button"
+                    onClick={() => setGroupBy("date")}
+                    aria-pressed={groupBy === "date"}
+                    className={groupBy === "date" ? "text-[var(--text-primary)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"}
+                  >
+                    Date
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setGroupBy("status")}
+                    aria-pressed={groupBy === "status"}
+                    className={groupBy === "status" ? "text-[var(--text-primary)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"}
+                  >
+                    Status
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setGroupBy("none")}
+                    aria-pressed={groupBy === "none"}
+                    className={groupBy === "none" ? "text-[var(--text-primary)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"}
+                  >
+                    Flat
+                  </button>
+                </div>
+              </>
             )}
             <button
               type="button"
               onClick={() => startConversation(activeFamiliarId)}
-              className="inline-flex h-7 items-center gap-1 rounded-md bg-[oklch(0.65_0.18_280)] px-3 text-[11px] font-semibold text-white shadow-sm hover:bg-[oklch(0.6_0.18_280)] transition-colors"
+              title="New chat"
+              className="inline-flex h-7 items-center gap-1 text-[11px] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
             >
               <Icon name="ph:plus-bold" width={11} />
-              Chat
+              New
             </button>
-            <button type="button" title="Configure plugins" onClick={() => onOpenMode("plugins")} className={softButton()}>
+            <button
+              type="button"
+              title="Configure plugins"
+              onClick={() => onOpenMode("plugins")}
+              className="inline-flex h-7 items-center text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+            >
               <Icon name="ph:plug" width={12} />
             </button>
           </div>

--- a/src/components/companion-rail.test.ts
+++ b/src/components/companion-rail.test.ts
@@ -9,10 +9,12 @@ assert.match(source, /companion-rail__header/, "Header element with BEM class");
 assert.match(source, /companion-rail__tabs/, "Tab strip element with BEM class");
 assert.match(
   source,
-  /type CompanionTab = "chat" \| "inspector" \| "memory"/,
-  "Three-tab union must be exported by name",
+  /type CompanionTab = "chat" \| "inspector" \| "memory" \| "salem"/,
+  "Companion tab union must include Salem",
 );
 assert.match(source, /Chat/, "Chat label rendered");
 assert.match(source, /Inspector/, "Inspector label rendered");
 assert.match(source, /Memory/, "Memory label rendered");
+assert.match(source, /Salem/, "Salem label rendered");
+assert.match(source, /activeTab/, "Rail should support externally selected tabs");
 assert.match(source, /No familiar yet/, "Empty state copy when no familiar");

--- a/src/components/companion-rail.tsx
+++ b/src/components/companion-rail.tsx
@@ -1,20 +1,22 @@
 "use client";
 
-import { forwardRef, useState, type ReactNode } from "react";
+import { forwardRef, useEffect, useState, type ReactNode } from "react";
 import { Icon } from "@/lib/icon";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import type { ChatRouterHandle } from "@/components/chat-router";
 import type { Familiar } from "@/lib/types";
 
-export type CompanionTab = "chat" | "inspector" | "memory";
+export type CompanionTab = "chat" | "inspector" | "memory" | "salem";
 
 type Props = {
   familiar: Familiar | null;
   defaultTab?: CompanionTab;
+  activeTab?: CompanionTab;
   chatSlot: ReactNode;
   inspectorSlot: ReactNode;
   memorySlot: ReactNode;
+  salemSlot?: ReactNode;
   onOpenSwitcher?: () => void;
   onCreateFamiliar?: () => void;
   daemonRunning: boolean;
@@ -27,9 +29,11 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
     const {
       familiar,
       defaultTab = "chat",
+      activeTab,
       chatSlot,
       inspectorSlot,
       memorySlot,
+      salemSlot,
       onOpenSwitcher,
       onCreateFamiliar,
       daemonRunning,
@@ -38,6 +42,11 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
     const resolvedFamiliars = useResolvedFamiliars(familiar ? [familiar] : [], { includeArchived: true });
     const resolvedFamiliar = resolvedFamiliars[0];
     const [tab, setTab] = useState<CompanionTab>(defaultTab);
+    const selectedTab = activeTab ?? tab;
+
+    useEffect(() => {
+      if (activeTab) setTab(activeTab);
+    }, [activeTab]);
 
     if (!familiar) {
       return (
@@ -92,39 +101,54 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
         <nav className="companion-rail__tabs" aria-label="Companion sections">
           <button
             type="button"
-            className={`companion-rail__tab${tab === "chat" ? " companion-rail__tab--active" : ""}`}
+            className={`companion-rail__tab${selectedTab === "chat" ? " companion-rail__tab--active" : ""}`}
             onClick={() => switchTab("chat")}
-            aria-current={tab === "chat"}
+            aria-current={selectedTab === "chat"}
           >
             <Icon name="ph:chats" width={11} /> Chat
           </button>
           <button
             type="button"
-            className={`companion-rail__tab${tab === "inspector" ? " companion-rail__tab--active" : ""}`}
+            className={`companion-rail__tab${selectedTab === "inspector" ? " companion-rail__tab--active" : ""}`}
             onClick={() => switchTab("inspector")}
-            aria-current={tab === "inspector"}
+            aria-current={selectedTab === "inspector"}
           >
             <Icon name="ph:magnifying-glass" width={11} /> Inspector
           </button>
           <button
             type="button"
-            className={`companion-rail__tab${tab === "memory" ? " companion-rail__tab--active" : ""}`}
+            className={`companion-rail__tab${selectedTab === "memory" ? " companion-rail__tab--active" : ""}`}
             onClick={() => switchTab("memory")}
-            aria-current={tab === "memory"}
+            aria-current={selectedTab === "memory"}
           >
             <Icon name="ph:brain" width={11} /> Memory
           </button>
+          {salemSlot ? (
+            <button
+              type="button"
+              className={`companion-rail__tab${selectedTab === "salem" ? " companion-rail__tab--active" : ""}`}
+              onClick={() => switchTab("salem")}
+              aria-current={selectedTab === "salem"}
+            >
+              <Icon name="ph:book-open" width={11} /> Salem
+            </button>
+          ) : null}
         </nav>
         <div className="companion-rail__body">
-          <div hidden={tab !== "chat"} className="companion-rail__pane">
+          <div hidden={selectedTab !== "chat"} className="companion-rail__pane">
             {chatSlot}
           </div>
-          <div hidden={tab !== "inspector"} className="companion-rail__pane">
+          <div hidden={selectedTab !== "inspector"} className="companion-rail__pane">
             {inspectorSlot}
           </div>
-          <div hidden={tab !== "memory"} className="companion-rail__pane">
+          <div hidden={selectedTab !== "memory"} className="companion-rail__pane">
             {memorySlot}
           </div>
+          {salemSlot ? (
+            <div hidden={selectedTab !== "salem"} className="companion-rail__pane">
+              {selectedTab === "salem" ? salemSlot : null}
+            </div>
+          ) : null}
         </div>
       </aside>
     );

--- a/src/components/salem/salem-widget.tsx
+++ b/src/components/salem/salem-widget.tsx
@@ -12,16 +12,31 @@ type PreloadSummary = { docs: number; tools: number; skills: number; context: nu
 
 const GREETING = "I'm Salem, your sassy Coven docs familiar. Yes, the black-cat-in-the-corner thing is intentional. I'm preloaded with Coven docs, tool context, guide skills, and Cave route awareness. Ask me about familiars, plugins, roles, the marketplace, or how Cave works.";
 
+function openSalemPanel() {
+  window.dispatchEvent(new CustomEvent("cave:salem-open"));
+}
+
 /**
- * Salem — floating bottom-right docs familiar for CovenCave.
- *
- * Three states:
- * - perch: tiny 3D kitty sitting quietly, click to open
- * - open: 360×480 docs chat panel anchored bottom-right
- * - expanded: full-viewport panel
+ * Salem launcher — floating bottom-right docs familiar for CovenCave.
+ * The chat itself lives in the shell right panel via `SalemChatPanel`.
  */
 export function SalemWidget() {
-  const [state, setState] = useState<"perch" | "open" | "expanded">("perch");
+  const [mood, setMood] = useState<SalemMood>("idle");
+  const open = () => {
+    openSalemPanel();
+    setMood("happy");
+    setTimeout(() => setMood("idle"), 1800);
+  };
+
+  return (
+    <div className="salem-perch" onClick={open} role="button" tabIndex={0} aria-label="Open Salem docs familiar" onKeyDown={(e) => e.key === "Enter" && open()}>
+      <SalemCat3D mood={mood} size={88} />
+      <span className="salem-perch__label">Salem</span>
+    </div>
+  );
+}
+
+export function SalemChatPanel() {
   const [mood, setMood] = useState<SalemMood>("idle");
   const [messages, setMessages] = useState<Message[]>([
     { role: "salem", text: GREETING },
@@ -92,20 +107,8 @@ export function SalemWidget() {
     }
   };
 
-  // Perch state — tiny floating kitty
-  if (state === "perch") {
-    return (
-      <div className="salem-perch" onClick={() => { setState("open"); setMood("happy"); setTimeout(() => setMood("idle"), 1800); }} role="button" tabIndex={0} aria-label="Open Salem docs familiar" onKeyDown={(e) => e.key === "Enter" && setState("open")}>
-        <SalemCat3D mood={mood} size={88} />
-        <span className="salem-perch__label">Salem</span>
-      </div>
-    );
-  }
-
-  const isExpanded = state === "expanded";
-
   return (
-    <div className={`salem-panel${isExpanded ? " salem-panel--expanded" : ""}`} role="dialog" aria-label="Salem docs familiar">
+    <section className="salem-panel salem-panel--rail" aria-label="Salem docs familiar">
       {/* Header */}
       <div className="salem-panel__header">
         <div className="salem-panel__header-identity">
@@ -118,24 +121,7 @@ export function SalemWidget() {
           </div>
         </div>
         <div className="salem-panel__header-actions">
-          <button
-            type="button"
-            className="salem-btn-icon"
-            onClick={() => setState(isExpanded ? "open" : "expanded")}
-            aria-label={isExpanded ? "Shrink" : "Expand"}
-            title={isExpanded ? "Shrink" : "Expand"}
-          >
-            <Icon name={isExpanded ? "ph:arrows-in-simple" : "ph:arrows-out-simple"} width={14} />
-          </button>
-          <button
-            type="button"
-            className="salem-btn-icon"
-            onClick={() => { setState("perch"); setMood("idle"); }}
-            aria-label="Close Salem"
-            title="Close"
-          >
-            <Icon name="ph:x" width={14} />
-          </button>
+          <Icon name="ph:book-open" width={14} />
         </div>
       </div>
 
@@ -185,6 +171,6 @@ export function SalemWidget() {
           <Icon name="ph:arrow-up" width={14} />
         </button>
       </form>
-    </div>
+    </section>
   );
 }

--- a/src/components/salem/salem.test.ts
+++ b/src/components/salem/salem.test.ts
@@ -18,12 +18,13 @@ assert.match(cat3d, /idle.*happy.*thinking.*listening/s, "must handle all four m
 assert.match(cat3d, /color:\s*0x171520/, "black cat material must retain visible contrast on dark Cave chrome");
 assert.match(cat3d, /rimLight.*1\.15/s, "cat must keep a visible purple rim light");
 
-// 2. SalemWidget exists and wires the cat + chat panel + API
+// 2. SalemWidget launches the right panel; SalemChatPanel wires chat + API
 const widget = await readFile(path.join(root, "src/components/salem/salem-widget.tsx"), "utf8");
 assert.match(widget, /SalemCat3D/, "widget must embed SalemCat3D");
+assert.match(widget, /SalemChatPanel/, "must export SalemChatPanel for the right rail");
+assert.match(widget, /cave:salem-open/, "launcher must request the shell right panel");
 assert.match(widget, /\/api\/salem/, "widget must call /api/salem");
-assert.match(widget, /perch.*open.*expanded/s, "widget must have three states");
-assert.match(widget, /setState\("perch"\)/, "widget must be dismissable back to perch");
+assert.match(widget, /salem-panel--rail/, "chat must render in the shell right panel");
 assert.match(widget, /size=\{88\}/, "perch cat must be large enough to read on dark backgrounds");
 assert.doesNotMatch(widget, /salem-msg__glyph|🐱|😅/, "open Salem chat must not render emoji glyphs");
 
@@ -47,7 +48,7 @@ assert.match(route, /SALEM_PRELOAD_CONTEXT/, "must use shared preload context");
 assert.match(route, /familiar|familiar/, "must know about familiars");
 assert.match(route, /role|Role/, "must know about roles");
 assert.match(route, /plugin|Plugin/, "must know about plugins");
-assert.match(route, /sassy male black cat/, "must answer with Salem's persona");
+assert.match(route, /Sassy male black cat/, "must answer with Salem's persona");
 assert.doesNotMatch(route, /🐱|😅/, "Salem API replies must stay emoji-free inside chat");
 
 // 5. SalemWidget surfaces preload status
@@ -55,18 +56,26 @@ assert.match(widget, /preload/, "widget must load Salem preload metadata");
 assert.match(widget, /salem-panel__preload/, "widget must render preload metadata");
 assert.match(widget, /Docs|Tools|Skills|Context/, "widget must label loaded docs/tools/skills/context");
 
-// 6. Layout mounts Salem
+// 6. Layout mounts Salem; Workspace routes it into the right panel
 const layout = await readFile(path.join(root, "src/app/layout.tsx"), "utf8");
+const workspace = await readFile(path.join(root, "src/components/workspace.tsx"), "utf8");
+const companionRail = await readFile(path.join(root, "src/components/companion-rail.tsx"), "utf8");
 assert.match(layout, /SalemWidget/, "layout must mount SalemWidget");
 assert.match(layout, /from "@\/components\/salem\/salem-widget"/, "layout must import from salem dir");
+assert.match(workspace, /cave:salem-open/, "workspace must listen for Salem launcher events");
+assert.match(workspace, /shellRef\.current\?\.openAgent\(\)/, "Salem launcher must expand the right panel");
+assert.match(workspace, /setRailTab\("salem"\)/, "Salem launcher must select the Salem rail tab");
+assert.match(workspace, /salemSlot=\{<SalemChatPanel \/>\}/, "workspace must render Salem in the companion rail");
+assert.match(companionRail, /"salem"/, "companion rail must expose a Salem tab");
 
 // 7. CSS classes present
 const css = await readFile(path.join(root, "src/app/globals.css"), "utf8");
 assert.match(css, /\.salem-perch/, "must have .salem-perch CSS");
 assert.match(css, /\.salem-panel/, "must have .salem-panel CSS");
+assert.match(css, /\.salem-panel--rail/, "must support Salem inside the right rail");
 assert.match(css, /\.salem-msg/, "must have .salem-msg CSS");
 assert.match(css, /\.salem-panel__preload/, "must style Salem preload metadata");
-assert.match(css, /--background:\s*oklch\(0\.09/, "default dark app background must be lifted for black-cat contrast");
+assert.match(css, /--background:\s*#19191c;/, "default dark app background must be lifted for black-cat contrast");
 assert.match(css, /\.salem-perch::before/, "Salem perch must include a visibility halo");
 assert.doesNotMatch(css, /\.salem-msg__glyph/, "open Salem chat must not keep unused emoji glyph CSS");
 assert.match(css, /position:\s*fixed/, "salem perch must be position fixed");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -37,6 +37,7 @@ import { CapabilitiesViewSurface } from "@/components/capabilities-view";
 import { PluginsView } from "@/components/plugins-view";
 import { HomeComposer } from "@/components/home-composer";
 import { ChatSurface } from "@/components/chat-surface";
+import { SalemChatPanel } from "@/components/salem/salem-widget";
 import { nativeNotify } from "@/lib/native-notify";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
@@ -132,6 +133,15 @@ export function Workspace() {
   useEffect(() => {
     if (typeof window !== "undefined") window.localStorage.setItem("cave:rail.tab", railTab);
   }, [railTab]);
+
+  useEffect(() => {
+    const openSalem = () => {
+      setRailTab("salem");
+      requestAnimationFrame(() => shellRef.current?.openAgent());
+    };
+    window.addEventListener("cave:salem-open", openSalem);
+    return () => window.removeEventListener("cave:salem-open", openSalem);
+  }, []);
 
   useEffect(() => {
     fetch("/api/config", { cache: "no-store" })
@@ -820,6 +830,7 @@ export function Workspace() {
 
   const surfaceLabel = SURFACE_LABELS[mode] ?? "Home";
   const subContext = active ? active.display_name : undefined;
+  const showCompanionRail = railTab === "salem" || (mode !== "browser" && mode !== "agents");
 
   const openProjectChat = useCallback((projectRoot: string) => {
     startAgentChat(activeId, projectRoot);
@@ -1058,10 +1069,11 @@ export function Workspace() {
         list={list}
         detail={detail}
         agent={
-          mode === "browser" || mode === "agents" ? undefined : (
+          showCompanionRail ? (
             <CompanionRail
               familiar={active}
               defaultTab={railTab}
+              activeTab={railTab}
               onTabChange={setRailTab}
               daemonRunning={daemonRunning}
               onCreateFamiliar={openOnboarding}
@@ -1088,8 +1100,9 @@ export function Workspace() {
                   onOpenFullView={() => setMode("agents")}
                 />
               }
+              salemSlot={<SalemChatPanel />}
             />
-          )
+          ) : undefined
         }
       />
 

--- a/src/lib/theme-palettes.ts
+++ b/src/lib/theme-palettes.ts
@@ -36,7 +36,7 @@ export const THEME_META: Record<ThemeId, ThemeMeta> = {
     name: "Coven",
     description: "OpenCoven violet — the default lavender field manual",
     hue: 293, accentDark: "#9A8ECD", accentLight: "#6F62A8",
-    bgDark: "oklch(0.07 0.004 293)", bgLight: "oklch(0.99 0.003 293)",
+    bgDark: "#19191c", bgLight: "oklch(0.99 0.003 293)",
   },
   tide: {
     name: "Tide",


### PR DESCRIPTION
Wires the Salem docs widget into the companion rail as a persistent chat panel.\n\n- `SalemChatPanel` mounted in rail's salem tab\n- `cave:salem-open` window event pops the rail open to Salem from anywhere\n- `.salem-panel--rail` CSS variant fits the panel flush in the rail (no float/shadow)\n- Rail stays visible when Salem tab active regardless of surface mode