### PR TITLE
chore(release): stamp v0.0.52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.52] — 2026-06-08
+
+Release repair for 0.0.51.
+
+### Fixed
+
+- **Packaged sidecar startup.** Bundles the Node runtime into release artifacts
+  and generates the standalone Next.js sidecar immediately before Tauri
+  packaging, so fresh installs no longer depend on a user-installed Node binary
+  or ship placeholder-only sidecar resources.
+- **Packaged workspace/daemon status.** Stops overriding Cave's Coven workspace
+  with the OpenClaw workspace in packaged mode, and prefers the npm-installed
+  `coven` CLI over stale Rust-installed binaries when resolving daemon helpers.
+
 ## [0.0.51] — 2026-06-08
 
 Small stopping-point release for the CovenCave polish wave after 0.0.50.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.51"
+version = "0.0.52"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- stamp package, Tauri, Cargo.toml, and Cargo.lock versions to 0.0.52
- add changelog entry for the packaged sidecar/runtime repair that landed in #264

## Verification
- node version consistency check for package.json, src-tauri/tauri.conf.json, src-tauri/Cargo.toml, src-tauri/Cargo.lock, and CHANGELOG.md
- cargo check --locked (from src-tauri with resources/server and resources/node placeholders)
- git diff --check