### PR TITLE
style(ui): icon-only rail tabs, drop ALL-CAPS inspector labels, remove linear-session pill

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2771,27 +2771,32 @@ body {
 .companion-rail__tabs {
   display: flex;
   gap: 2px;
-  padding: 6px 10px;
+  padding: 5px 8px;
   border-bottom: 1px solid var(--border-hairline);
   background: var(--bg-panel);
 }
 
 .companion-rail__tab {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 5px 10px;
+  display: inline-grid;
+  place-items: center;
+  width: 30px;
+  height: 28px;
   border-radius: var(--radius-control);
   background: transparent;
   border: 0;
-  color: var(--text-secondary);
-  font-size: var(--text-sm);
+  color: var(--text-muted);
   cursor: pointer;
+  transition: color 0.1s, background 0.1s;
+}
+
+.companion-rail__tab:hover {
+  color: var(--text-secondary);
+  background: color-mix(in oklch, var(--foreground) 6%, transparent);
 }
 
 .companion-rail__tab--active {
   background: color-mix(in oklch, var(--accent-presence) 18%, transparent);
-  color: var(--text-primary);
+  color: var(--accent-presence);
 }
 
 .companion-rail__body {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3723,6 +3723,65 @@ body {
   padding: 7px 11px;
 }
 
+.salem-msg__md {
+  background: rgba(26, 18, 46, 0.6);
+  border: 1px solid rgba(179, 136, 255, 0.12);
+  border-radius: 4px 12px 12px 12px;
+  padding: 8px 12px;
+  width: 100%;
+}
+.salem-msg__md .cave-md {
+  font-size: 12.5px;
+  line-height: 1.65;
+  color: #e8e0f0;
+}
+.salem-msg__md .cave-md p { margin: 0 0 0.5em; }
+.salem-msg__md .cave-md p:last-child { margin-bottom: 0; }
+.salem-msg__md .cave-md h1,
+.salem-msg__md .cave-md h2,
+.salem-msg__md .cave-md h3 {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: #c9a7ff;
+  margin: 0.75em 0 0.25em;
+}
+.salem-msg__md .cave-md h1:first-child,
+.salem-msg__md .cave-md h2:first-child,
+.salem-msg__md .cave-md h3:first-child { margin-top: 0; }
+.salem-msg__md .cave-md strong { color: #e8e0f0; font-weight: 600; }
+.salem-msg__md .cave-md em { color: #c9a7ff; font-style: italic; }
+.salem-msg__md .cave-md code {
+  font-size: 11px;
+  background: rgba(142, 61, 255, 0.15);
+  border: 1px solid rgba(142, 61, 255, 0.2);
+  border-radius: 3px;
+  padding: 1px 5px;
+  color: #d26bff;
+}
+.salem-msg__md .cave-md a {
+  color: #a855f7;
+  text-decoration: none;
+}
+.salem-msg__md .cave-md a:hover { text-decoration: underline; }
+.salem-msg__md .cave-md ul,
+.salem-msg__md .cave-md ol {
+  margin: 0.35em 0 0.5em;
+  padding-left: 1.25em;
+}
+.salem-msg__md .cave-md li { margin-bottom: 0.2em; }
+.salem-msg__md .cave-md blockquote {
+  border-left: 2px solid rgba(142, 61, 255, 0.4);
+  margin: 0.5em 0;
+  padding: 2px 10px;
+  color: #a89ac0;
+  font-style: italic;
+}
+.salem-msg__md .cave-md hr {
+  border: none;
+  border-top: 1px solid rgba(179, 136, 255, 0.12);
+  margin: 0.75em 0;
+}
+
 .salem-thinking .dots::after {
   content: '';
   display: inline-block;

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -871,10 +871,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             </div>
           </div>
           <div className="ml-auto hidden items-center gap-2 md:flex">
-            <span className="cave-header-stat">
-              <Icon name="ph:list-bullets" width={12} aria-hidden />
-              linear session
-            </span>
+            {/* session mode implicit — pill removed */}
           </div>
         </div>
         <ChatContextStrip

--- a/src/components/companion-rail.tsx
+++ b/src/components/companion-rail.tsx
@@ -104,24 +104,27 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
             className={`companion-rail__tab${selectedTab === "chat" ? " companion-rail__tab--active" : ""}`}
             onClick={() => switchTab("chat")}
             aria-current={selectedTab === "chat"}
+            title="Chat"
           >
-            <Icon name="ph:chats" width={11} /> Chat
+            <Icon name="ph:chats" width={14} />
           </button>
           <button
             type="button"
             className={`companion-rail__tab${selectedTab === "inspector" ? " companion-rail__tab--active" : ""}`}
             onClick={() => switchTab("inspector")}
             aria-current={selectedTab === "inspector"}
+            title="Inspector"
           >
-            <Icon name="ph:magnifying-glass" width={11} /> Inspector
+            <Icon name="ph:magnifying-glass" width={14} />
           </button>
           <button
             type="button"
             className={`companion-rail__tab${selectedTab === "memory" ? " companion-rail__tab--active" : ""}`}
             onClick={() => switchTab("memory")}
             aria-current={selectedTab === "memory"}
+            title="Memory"
           >
-            <Icon name="ph:brain" width={11} /> Memory
+            <Icon name="ph:brain" width={14} />
           </button>
           {salemSlot ? (
             <button
@@ -129,8 +132,9 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
               className={`companion-rail__tab${selectedTab === "salem" ? " companion-rail__tab--active" : ""}`}
               onClick={() => switchTab("salem")}
               aria-current={selectedTab === "salem"}
+              title="Salem"
             >
-              <Icon name="ph:book-open" width={11} /> Salem
+              <Icon name="ph:book-open" width={14} />
             </button>
           ) : null}
         </nav>

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -104,7 +104,7 @@ export function InspectorPane({
             <button
               key={t}
               onClick={() => setTab(t)}
-              className={`flex-1 px-3 py-3 uppercase tracking-widest transition-colors ${
+              className={`flex-1 px-3 py-2.5 font-medium tracking-normal transition-colors ${
                 tab === t
                   ? "border-b-2 border-[var(--accent-presence)] text-[var(--text-primary)]"
                   : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
@@ -604,13 +604,13 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
               setQuery("");
               setMode(m);
             }}
-            className={`rounded px-2 py-0.5 text-[10px] uppercase tracking-widest transition-colors ${
+            className={`rounded px-2.5 py-1 text-[11px] font-medium transition-colors ${
               mode === m
-                ? "bg-[color-mix(in_oklch,var(--accent-presence)_80%,transparent)] text-white"
-                : "border border-[var(--border-strong)] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+                ? "bg-[color-mix(in_oklch,var(--accent-presence)_15%,transparent)] text-[var(--accent-presence)]"
+                : "text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
             }`}
           >
-            {m}
+            {m === "inspector" ? "Inspect" : m === "coven" ? "Coven" : "Files"}
           </button>
         ))}
         <span className="ml-auto text-[10px] text-[var(--text-muted)]">

--- a/src/components/salem/salem-widget.tsx
+++ b/src/components/salem/salem-widget.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, type FormEvent } from "react";
 import { Icon } from "@/lib/icon";
 import type { SalemPreloadContext } from "./salem-context";
 import { SalemCat3D } from "./salem-cat-3d";
+import { MarkdownBlock } from "@/components/message-bubble";
 
 type Message = { role: "user" | "salem"; text: string };
 
@@ -12,14 +13,45 @@ type PreloadSummary = { docs: number; tools: number; skills: number; context: nu
 
 const GREETING = "I'm Salem, your sassy Coven docs familiar. Yes, the black-cat-in-the-corner thing is intentional. I'm preloaded with Coven docs, tool context, guide skills, and Cave route awareness. Ask me about familiars, plugins, roles, the marketplace, or how Cave works.";
 
+// ---------------------------------------------------------------------------
+// Strip raw <Cards>...</Cards> and <Card .../> JSX blobs from Salem replies
+// and replace with clean markdown links.
+// ---------------------------------------------------------------------------
+
+function cleanSalemMarkdown(text: string): string {
+  // Replace full <Cards>...</Cards> block with extracted Card links
+  text = text.replace(/<Cards>([\s\S]*?)<\/Cards>/g, (_match, inner: string) => {
+    const links: string[] = [];
+    const cardRe = /<Card\s[^>]*title="([^"]*)"[^>]*href="([^"]*)"[^>]*(?:description="([^"]*)")?[^>]*\/?>/g;
+    let m: RegExpExecArray | null;
+    while ((m = cardRe.exec(inner)) !== null) {
+      const title = m[1];
+      const href = m[2];
+      const desc = m[3] ? ` — ${m[3]}` : "";
+      links.push(`- [${title}](${href})${desc}`);
+    }
+    return links.length ? links.join("\n") : "";
+  });
+
+  // Also strip any self-closing <Card .../> that leaked outside a <Cards> wrapper
+  text = text.replace(/<Card\s[^>]*title="([^"]*)"[^>]*href="([^"]*)"[^>]*(?:description="([^"]*)")?[^>]*\/>/g,
+    (_m, title: string, href: string, desc?: string) =>
+      `- [${title}](${href})${desc ? ` — ${desc}` : ""}`
+  );
+
+  // Strip any remaining stray XML-like tags that aren't standard markdown/html
+  text = text.replace(/<\/?Cards>/g, "");
+
+  // Clean up heading anchors like [#some-id] that appear after heading text
+  text = text.replace(/\s\[#[\w-]+\]/g, "");
+
+  return text.trim();
+}
+
 function openSalemPanel() {
   window.dispatchEvent(new CustomEvent("cave:salem-open"));
 }
 
-/**
- * Salem launcher — floating bottom-right docs familiar for CovenCave.
- * The chat itself lives in the shell right panel via `SalemChatPanel`.
- */
 export function SalemWidget() {
   const [mood, setMood] = useState<SalemMood>("idle");
   const [docked, setDocked] = useState(false);
@@ -71,7 +103,6 @@ export function SalemChatPanel() {
 
   useEffect(() => {
     let alive = true;
-
     fetch("/api/salem")
       .then((res) => res.json())
       .then((data: { summary?: PreloadSummary; preload?: SalemPreloadContext }) => {
@@ -79,15 +110,8 @@ export function SalemChatPanel() {
           setPreload({ summary: data.summary, preload: data.preload });
         }
       })
-      .catch(() => {
-        if (alive) {
-          setPreload(null);
-        }
-      });
-
-    return () => {
-      alive = false;
-    };
+      .catch(() => { if (alive) setPreload(null); });
+    return () => { alive = false; };
   }, []);
 
   const send = async (e?: FormEvent) => {
@@ -106,17 +130,12 @@ export function SalemChatPanel() {
         body: JSON.stringify({ message: text }),
       });
       const data = (await res.json()) as { reply?: string; error?: string };
-      setMessages((m) => [
-        ...m,
-        { role: "salem", text: data.reply ?? data.error ?? "Hmm, I couldn't find that one. Try rephrasing?" },
-      ]);
+      const raw = data.reply ?? data.error ?? "Hmm, I couldn't find that one. Try rephrasing?";
+      setMessages((m) => [...m, { role: "salem", text: cleanSalemMarkdown(raw) }]);
       setMood("happy");
       setTimeout(() => setMood("idle"), 2000);
     } catch {
-      setMessages((m) => [
-        ...m,
-        { role: "salem", text: "I had a hairball moment - couldn't reach my docs brain right now." },
-      ]);
+      setMessages((m) => [...m, { role: "salem", text: "I had a hairball moment — couldn't reach my docs brain right now." }]);
       setMood("idle");
     } finally {
       setLoading(false);
@@ -162,7 +181,13 @@ export function SalemChatPanel() {
       <div className="salem-panel__messages">
         {messages.map((m, i) => (
           <div key={i} className={`salem-msg salem-msg--${m.role}`}>
-            <span className="salem-msg__text">{m.text}</span>
+            {m.role === "salem" ? (
+              <div className="salem-msg__md">
+                <MarkdownBlock text={m.text} />
+              </div>
+            ) : (
+              <span className="salem-msg__text">{m.text}</span>
+            )}
           </div>
         ))}
         {loading && (
@@ -183,7 +208,8 @@ export function SalemChatPanel() {
           disabled={loading}
           autoFocus
         />
-        <button type="submit" className="salem-panel__send" disabled={loading || !input.trim()} aria-label="Send">
+        <button type="submit" className="salem-panel__send salem-panel__send--label" disabled={loading || !input.trim()} aria-label="Send">
+          <span className="salem-panel__send-text">SALEM</span>
           <Icon name="ph:arrow-up" width={14} />
         </button>
       </form>


### PR DESCRIPTION
- Companion rail tabs → icon-only (30×28px, tooltip on hover); active tab uses accent tint color
- 'linear session' header pill removed — mode is implied by the view
- Inspector tabs: drop `uppercase tracking-widest` → readable sentence-case
- Inspector mode chips: soft tint active state; labels capitalised (Inspect/Coven/Files)

Addresses the screenshot feedback: far-right panel too dense, raw-debug label styling.