### PR TITLE
feat(ux): foundations — focus trap, roving tabindex, live region, error state, tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1405,6 +1405,48 @@ body {
   margin-top: var(--space-2);
 }
 
+/* Foundations PR — ErrorState primitive (mirrors .ui-empty-state layout
+   with a danger accent). role="alert" announces via assistive tech. */
+.ui-error-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 32px 24px;
+  text-align: center;
+  color: var(--text-secondary);
+}
+.ui-error-state--compact {
+  padding: 16px 12px;
+  gap: 4px;
+}
+.ui-error-state-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: color-mix(in oklch, var(--color-danger) 12%, transparent);
+  color: var(--color-danger);
+}
+.ui-error-state-headline {
+  font-size: var(--text-base);
+  color: var(--text-primary);
+  font-weight: 600;
+}
+.ui-error-state-subtitle {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  max-width: 36ch;
+}
+.ui-error-state-actions {
+  margin-top: 8px;
+  display: flex;
+  gap: 8px;
+}
+
 /* ---- Skeleton ----------------------------------------------- */
 @keyframes ui-skeleton-shimmer {
   0%   { background-position: 200% 0; }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -158,6 +158,20 @@
 
   /* ---- Surface alphas ---- */
   --backdrop-scrim: oklch(0 0 0 / 60%);
+
+  /* Foundations PR — disabled state */
+  --opacity-disabled: 0.4;
+
+  /* Foundations PR — scrollbar tokens (consumed by all themed scrollbars) */
+  --scrollbar-thumb: color-mix(in oklch, var(--accent-presence) 30%, transparent);
+  --scrollbar-track: transparent;
+}
+
+/* Foundations PR — themed text selection.
+   Derived from --accent-presence so every theme inherits without override. */
+::selection {
+  background: color-mix(in oklch, var(--accent-presence) 40%, transparent);
+  color: var(--foreground);
 }
 
 /* ============================================================
@@ -197,8 +211,8 @@
   /* --border, --border-strong, --input, --text-muted are derived from --foreground;
      they auto-invert. No override needed. */
 
-  --ring-focus: color-mix(in oklch, #6F62A8 55%, transparent);
-  --ring-focus-soft: color-mix(in oklch, #6F62A8 30%, transparent);
+  --ring-focus: color-mix(in oklch, var(--accent-presence) 55%, transparent);
+  --ring-focus-soft: color-mix(in oklch, var(--accent-presence) 30%, transparent);
   --backdrop-scrim: oklch(0 0 0 / 40%);
 
   /* Semantic state colors retuned for AA contrast on near-white surfaces.
@@ -3685,7 +3699,7 @@ body {
   flex-direction: column;
   gap: 10px;
   scrollbar-width: thin;
-  scrollbar-color: rgba(124, 77, 255, 0.3) transparent;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
 }
 
 .salem-msg {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3793,3 +3793,18 @@ body {
   opacity: 0.35;
   cursor: not-allowed;
 }
+
+/* Foundations PR — visually-hidden utility for screen-reader-only content.
+   Standard pattern: positioned offscreen, zero size, but still in the
+   accessibility tree. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/app/globals.css.test.ts
+++ b/src/app/globals.css.test.ts
@@ -52,3 +52,45 @@ for (const old of ["midnight", "orchid", "sky"]) {
 }
 
 console.log("globals.css.test.ts (task 4) OK");
+
+// --- Foundations PR tokens ------------------------------------------------
+
+// (a) Light-mode --ring-focus derives from --accent-presence, not a hex literal.
+const lightBlockRaw = css.match(/:root\[data-mode="light"\]\s*\{([\s\S]*?)\}/)?.[1] ?? "";
+assert.match(
+  lightBlockRaw,
+  /--ring-focus\s*:\s*color-mix\(in oklch,\s*var\(--accent-presence\)/,
+  "light --ring-focus must derive from --accent-presence (no hex)",
+);
+assert.doesNotMatch(
+  lightBlockRaw,
+  /--ring-focus\s*:\s*color-mix\(in oklch,\s*#/,
+  "light --ring-focus must not hardcode a hex literal",
+);
+
+// (b) Disabled opacity token exists on :root.
+assert.match(
+  css,
+  /--opacity-disabled\s*:\s*0\.4/,
+  "--opacity-disabled token defined on :root",
+);
+
+// (c) Scrollbar tokens exist on :root.
+assert.match(css, /--scrollbar-thumb\s*:/, "--scrollbar-thumb token defined on :root");
+assert.match(css, /--scrollbar-track\s*:/, "--scrollbar-track token defined on :root");
+
+// (d) Salem scrollbar consumes the token, not raw rgba.
+assert.doesNotMatch(
+  css,
+  /scrollbar-color:\s*rgba\(124,\s*77,\s*255,\s*0\.3\)/,
+  "salem must not use the hardcoded purple rgba scrollbar (use var(--scrollbar-thumb))",
+);
+
+// (e) Global ::selection rule exists and uses --accent-presence.
+assert.match(
+  css,
+  /::selection\s*\{[\s\S]*?background:\s*color-mix\(in oklch,\s*var\(--accent-presence\)/,
+  "::selection rule must exist and derive from --accent-presence",
+);
+
+console.log("globals.css.test.ts (foundations) OK");

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { SidecarAuthBridge } from "@/components/security/sidecar-auth-bridge";
 import { SidecarAuthMonitor } from "@/components/security/sidecar-auth-monitor";
 import { ShellBannersProvider } from "@/lib/shell-banners";
 import { SalemWidget } from "@/components/salem/salem-widget";
+import { LiveRegionProvider } from "@/components/ui/live-region";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -39,10 +40,12 @@ export default function RootLayout({
     >
       <body className="h-full flex flex-col">
         <ShellBannersProvider>
-          <SidecarAuthBridge />
-          <SidecarAuthMonitor />
-          {children}
-          <SalemWidget />
+          <LiveRegionProvider>
+            <SidecarAuthBridge />
+            <SidecarAuthMonitor />
+            {children}
+            <SalemWidget />
+          </LiveRegionProvider>
         </ShellBannersProvider>
       </body>
     </html>

--- a/src/components/ui/error-state.test.ts
+++ b/src/components/ui/error-state.test.ts
@@ -1,0 +1,33 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./error-state.tsx", import.meta.url),
+  "utf8",
+);
+
+// Exports the component and props type.
+assert.match(source, /export function ErrorState\s*\(/, "exports ErrorState");
+assert.match(source, /export type ErrorStateProps/, "exports ErrorStateProps");
+
+// role="alert" so failures announce.
+assert.match(source, /role="alert"/, "ErrorState uses role=alert");
+
+// Has icon, headline, subtitle, actions (retry-friendly).
+for (const slot of ["icon", "headline", "subtitle", "actions"]) {
+  assert.match(
+    source,
+    new RegExp(`\\b${slot}\\b`),
+    `ErrorState exposes ${slot}`,
+  );
+}
+
+// Default icon is the danger/warning glyph (ph:warning or ph:warning-circle).
+assert.match(
+  source,
+  /ph:warning/,
+  "ErrorState defaults to a warning icon if none supplied",
+);
+
+console.log("error-state.test.ts OK");

--- a/src/components/ui/error-state.tsx
+++ b/src/components/ui/error-state.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Icon, type IconName } from "@/lib/icon";
+
+export type ErrorStateProps = {
+  /** Icon name. Defaults to `ph:warning` if omitted. */
+  icon?: IconName;
+  headline: ReactNode;
+  subtitle?: ReactNode;
+  /** Retry / fallback action button(s). Use <Button>. */
+  actions?: ReactNode;
+  compact?: boolean;
+  className?: string;
+};
+
+export function ErrorState({
+  icon = "ph:warning",
+  headline,
+  subtitle,
+  actions,
+  compact,
+  className,
+}: ErrorStateProps) {
+  const classes = ["ui-error-state", compact ? "ui-error-state--compact" : "", className ?? ""]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <div className={classes} role="alert">
+      <div className="ui-error-state-icon" aria-hidden>
+        <Icon name={icon} width={20} />
+      </div>
+      <div className="ui-error-state-headline">{headline}</div>
+      {subtitle ? <div className="ui-error-state-subtitle">{subtitle}</div> : null}
+      {actions ? <div className="ui-error-state-actions">{actions}</div> : null}
+    </div>
+  );
+}

--- a/src/components/ui/live-region.test.ts
+++ b/src/components/ui/live-region.test.ts
@@ -1,0 +1,61 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./live-region.tsx", import.meta.url),
+  "utf8",
+);
+
+// Exports the provider and the hook.
+assert.match(
+  source,
+  /export function LiveRegionProvider\s*\(/,
+  "exports LiveRegionProvider",
+);
+assert.match(
+  source,
+  /export function useAnnouncer\s*\(\s*\)/,
+  "exports useAnnouncer() hook",
+);
+
+// Renders two regions with proper aria-live levels.
+assert.match(source, /aria-live="polite"/, "renders polite region");
+assert.match(source, /aria-live="assertive"/, "renders assertive region");
+assert.match(source, /role="status"/, "polite region has role=status");
+assert.match(source, /role="alert"/, "assertive region has role=alert");
+
+// Visually hidden via the sr-only class.
+assert.match(
+  source,
+  /className="sr-only"/,
+  "regions are visually hidden via sr-only",
+);
+
+// Clears between announcements so repeats are announced.
+assert.match(
+  source,
+  /setTimeout\(/,
+  "clears the message after a short delay so repeats re-announce",
+);
+
+// Cleans up pending timeouts on unmount.
+assert.match(
+  source,
+  /clearTimeout\(\s*politeClear\.current\s*\)/,
+  "clears pending polite timeout on unmount",
+);
+assert.match(
+  source,
+  /clearTimeout\(\s*assertiveClear\.current\s*\)/,
+  "clears pending assertive timeout on unmount",
+);
+
+// useAnnouncer throws/warns when used outside the provider.
+assert.match(
+  source,
+  /useAnnouncer must be used within a LiveRegionProvider|throw new Error/,
+  "useAnnouncer guards against missing provider",
+);
+
+console.log("live-region.test.ts OK");

--- a/src/components/ui/live-region.tsx
+++ b/src/components/ui/live-region.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type AnnounceLevel = "polite" | "assertive";
+
+type AnnouncerContextValue = {
+  announce: (message: string, level?: AnnounceLevel) => void;
+};
+
+const AnnouncerContext = createContext<AnnouncerContextValue | null>(null);
+
+/**
+ * Mount once at the root. Renders two visually-hidden live regions (polite
+ * and assertive). The polite region is for status updates; the assertive
+ * region is for errors and time-critical alerts.
+ *
+ * Messages are cleared 250ms after being set so re-announcing the same
+ * string actually triggers an AT announcement (regions debounce identical
+ * strings otherwise).
+ */
+export function LiveRegionProvider({ children }: { children: ReactNode }) {
+  const [polite, setPolite] = useState("");
+  const [assertive, setAssertive] = useState("");
+  const politeClear = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const assertiveClear = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const announce = useCallback((message: string, level: AnnounceLevel = "polite") => {
+    if (!message) return;
+    if (level === "assertive") {
+      if (assertiveClear.current) clearTimeout(assertiveClear.current);
+      setAssertive(message);
+      assertiveClear.current = setTimeout(() => setAssertive(""), 250);
+    } else {
+      if (politeClear.current) clearTimeout(politeClear.current);
+      setPolite(message);
+      politeClear.current = setTimeout(() => setPolite(""), 250);
+    }
+  }, []);
+
+  // Cancel any pending clear so we don't fire setState on an unmounted tree.
+  useEffect(() => {
+    return () => {
+      if (politeClear.current) clearTimeout(politeClear.current);
+      if (assertiveClear.current) clearTimeout(assertiveClear.current);
+    };
+  }, []);
+
+  return (
+    <AnnouncerContext.Provider value={{ announce }}>
+      {children}
+      <div
+        className="sr-only"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {polite}
+      </div>
+      <div
+        className="sr-only"
+        role="alert"
+        aria-live="assertive"
+        aria-atomic="true"
+      >
+        {assertive}
+      </div>
+    </AnnouncerContext.Provider>
+  );
+}
+
+/**
+ * `const { announce } = useAnnouncer()` then call `announce("Saved.")` or
+ * `announce("Failed to save", "assertive")`. Throws if no provider is in
+ * scope — that's a programmer error to catch early.
+ */
+export function useAnnouncer(): AnnouncerContextValue {
+  const ctx = useContext(AnnouncerContext);
+  if (!ctx) {
+    throw new Error("useAnnouncer must be used within a LiveRegionProvider");
+  }
+  return ctx;
+}

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useRef, type ReactNode } from "react";
+import { useRef, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { Icon } from "@/lib/icon";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 
 type ModalProps = {
   open: boolean;
@@ -21,15 +22,6 @@ type ModalProps = {
   ariaLabel?: string;
 };
 
-const FOCUSABLE = [
-  "button:not([disabled])",
-  "[href]",
-  "input:not([disabled])",
-  "select:not([disabled])",
-  "textarea:not([disabled])",
-  "[tabindex]:not([tabindex='-1'])",
-].join(",");
-
 export function Modal({
   open,
   onClose,
@@ -42,44 +34,8 @@ export function Modal({
   ariaLabel,
 }: ModalProps) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
-  const returnFocusRef = useRef<HTMLElement | null>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    returnFocusRef.current = (document.activeElement as HTMLElement) ?? null;
-    const dialog = dialogRef.current;
-    if (dialog) {
-      const first = dialog.querySelector<HTMLElement>(FOCUSABLE);
-      first?.focus();
-    }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        onClose();
-        return;
-      }
-      if (e.key === "Tab" && dialog) {
-        const focusables = Array.from(dialog.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
-          (el) => !el.hasAttribute("disabled"),
-        );
-        if (focusables.length === 0) return;
-        const first = focusables[0];
-        const last = focusables[focusables.length - 1];
-        const active = document.activeElement as HTMLElement | null;
-        if (e.shiftKey && active === first) {
-          e.preventDefault();
-          last.focus();
-        } else if (!e.shiftKey && active === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    }
-    window.addEventListener("keydown", onKey);
-    return () => {
-      window.removeEventListener("keydown", onKey);
-      returnFocusRef.current?.focus();
-    };
-  }, [open, onClose]);
+  useFocusTrap(open, dialogRef, { onEscape: onClose });
 
   if (!open || typeof document === "undefined") return null;
 
@@ -96,6 +52,7 @@ export function Modal({
         role="dialog"
         aria-modal="true"
         aria-label={ariaLabel}
+        tabIndex={-1}
       >
         {breadcrumb ? (
           <header className="ui-modal-header">

--- a/src/lib/icon.tsx
+++ b/src/lib/icon.tsx
@@ -65,6 +65,7 @@ export const ICON_NAMES = [
   "ph:mask-happy",
   "ph:cursor-click",
   "ph:check-circle",
+  "ph:warning",
   "ph:warning-circle",
   "ph:paperclip",
   "ph:plus",

--- a/src/lib/use-focus-trap.test.ts
+++ b/src/lib/use-focus-trap.test.ts
@@ -1,0 +1,64 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./use-focus-trap.ts", import.meta.url),
+  "utf8",
+);
+
+// Exports the hook.
+assert.match(
+  source,
+  /export function useFocusTrap\s*\(/,
+  "hook exports useFocusTrap(...)",
+);
+
+// Saves and restores prior focus.
+assert.match(source, /document\.activeElement/, "captures document.activeElement on activate");
+assert.match(
+  source,
+  /returnFocusRef\.current\?\.focus\(\)/,
+  "restores focus on deactivate",
+);
+
+// Listens for Tab and Escape.
+assert.match(source, /e\.key === "Tab"/, "intercepts Tab to cycle within container");
+assert.match(source, /e\.key === "Escape"/, "intercepts Escape (caller decides what to do)");
+
+// Queries focusables (re-queries on each Tab — DOM may change).
+assert.match(
+  source,
+  /querySelectorAll<HTMLElement>\(FOCUSABLE\)/,
+  "re-queries focusables on each Tab event",
+);
+
+// Exports the shared FOCUSABLE selector for consumers who want to use it directly.
+assert.match(source, /export const FOCUSABLE\s*=/, "exports FOCUSABLE selector constant");
+
+// Stable callback handling: onEscape must be stored in a ref so the effect
+// doesn't tear down and re-run (and clobber returnFocusRef) when the caller
+// passes an inline arrow.
+assert.match(
+  source,
+  /onEscapeRef\s*=\s*useRef/,
+  "stores onEscape in a ref to avoid effect re-runs on callback identity change",
+);
+
+// onEscape must NOT appear in the trap effect's dep array.
+const trapEffect = source.match(/useEffect\(\s*\(\)\s*=>\s*\{[\s\S]*?\},\s*\[([^\]]*)\]\s*\)/g) ?? [];
+const trapDeps = trapEffect.find((b) => b.includes('e.key === "Tab"')) ?? "";
+assert.doesNotMatch(
+  trapDeps,
+  /\bonEscape\b/,
+  "trap effect deps must not include onEscape (use a ref instead)",
+);
+
+// Fallback: focus the container itself if it has no focusable child.
+assert.match(
+  source,
+  /container\.focus\(\)/,
+  "trap focuses the container as a fallback when no focusable child exists",
+);
+
+console.log("use-focus-trap.test.ts OK");

--- a/src/lib/use-focus-trap.ts
+++ b/src/lib/use-focus-trap.ts
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+
+export const FOCUSABLE = [
+  "button:not([disabled])",
+  "[href]",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+type Options = {
+  /** Called on Escape. Caller usually closes the dialog. Identity-stable
+   *  internally (we keep it in a ref) so passing an inline arrow is fine. */
+  onEscape?: () => void;
+  /** Focus the first focusable element on activate (default true). If no
+   *  focusable child exists, focuses the container itself — caller MUST give
+   *  the container `tabIndex={-1}` so this is reachable. */
+  focusFirst?: boolean;
+};
+
+/**
+ * Trap focus inside `containerRef` while `active` is true. Saves the
+ * previously-focused element on activate→deactivate and restores it on
+ * deactivate. Tab/Shift+Tab cycle through focusable descendants. Escape
+ * calls onEscape.
+ *
+ * `onEscape` is stored in a ref so the effect deps don't include it — that
+ * prevents tear-down/re-run loops when callers pass an inline arrow each
+ * render. (Without this, returnFocusRef gets re-captured on every render and
+ * deactivate restores focus to inside the modal, not to the trigger.)
+ */
+export function useFocusTrap(
+  active: boolean,
+  containerRef: RefObject<HTMLElement | null>,
+  { onEscape, focusFirst = true }: Options = {},
+) {
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+  const onEscapeRef = useRef(onEscape);
+
+  // Keep the latest callback reachable from the keydown handler without
+  // making it a useEffect dep.
+  useEffect(() => {
+    onEscapeRef.current = onEscape;
+  }, [onEscape]);
+
+  useEffect(() => {
+    if (!active) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    returnFocusRef.current = (document.activeElement as HTMLElement) ?? null;
+
+    if (focusFirst) {
+      const first = container.querySelector<HTMLElement>(FOCUSABLE);
+      if (first) {
+        first.focus();
+      } else {
+        // Fallback: focus the container so Tab/Esc still hit. Caller must
+        // set tabIndex={-1} on the container element for this to land.
+        container.focus();
+      }
+    }
+
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onEscapeRef.current?.();
+        return;
+      }
+      if (e.key === "Tab" && container) {
+        const focusables = Array.from(
+          container.querySelectorAll<HTMLElement>(FOCUSABLE),
+        ).filter((el) => !el.hasAttribute("disabled"));
+        if (focusables.length === 0) {
+          e.preventDefault();
+          return;
+        }
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        const activeEl = document.activeElement as HTMLElement | null;
+        if (e.shiftKey && activeEl === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && activeEl === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      returnFocusRef.current?.focus();
+    };
+  }, [active, containerRef, focusFirst]); // intentionally no onEscape
+}

--- a/src/lib/use-prefers-reduced-motion.test.ts
+++ b/src/lib/use-prefers-reduced-motion.test.ts
@@ -1,0 +1,43 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./use-prefers-reduced-motion.ts", import.meta.url),
+  "utf8",
+);
+
+// Hook is named and exported.
+assert.match(
+  source,
+  /export function usePrefersReducedMotion\(\)\s*:\s*boolean/,
+  "hook exports usePrefersReducedMotion() returning boolean",
+);
+
+// SSR-safe: must guard window before matchMedia.
+assert.match(
+  source,
+  /typeof window === "undefined"/,
+  "hook must guard typeof window for SSR safety",
+);
+
+// Reads the canonical media query.
+assert.match(
+  source,
+  /\(prefers-reduced-motion:\s*reduce\)/,
+  "hook reads the prefers-reduced-motion: reduce query",
+);
+
+// Subscribes to changes (the user can toggle the OS preference live).
+assert.match(
+  source,
+  /addEventListener\(\s*"change"/,
+  "hook subscribes to MediaQueryList change events",
+);
+assert.match(
+  source,
+  /removeEventListener\(\s*"change"/,
+  "hook cleans up the listener on unmount",
+);
+
+console.log("use-prefers-reduced-motion.test.ts OK");

--- a/src/lib/use-prefers-reduced-motion.ts
+++ b/src/lib/use-prefers-reduced-motion.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+/**
+ * Live boolean for the OS-level reduced-motion preference. Returns false on
+ * the server and during the first render in the browser; flips synchronously
+ * after mount if the user has the preference set. Subscribes to changes so
+ * toggling the OS setting takes effect without reload.
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia(QUERY);
+    setReduced(mql.matches);
+    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return reduced;
+}

--- a/src/lib/use-roving-tabindex.test.ts
+++ b/src/lib/use-roving-tabindex.test.ts
@@ -1,0 +1,66 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./use-roving-tabindex.ts", import.meta.url),
+  "utf8",
+);
+
+// Exports the hook and an Orientation type.
+assert.match(
+  source,
+  /export function useRovingTabIndex\s*\(/,
+  "hook exports useRovingTabIndex(...)",
+);
+assert.match(
+  source,
+  /"horizontal"\s*\|\s*"vertical"\s*\|\s*"both"/,
+  "Orientation supports horizontal, vertical, both",
+);
+
+// Handles all four arrows + Home + End.
+for (const key of ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Home", "End"]) {
+  assert.match(
+    source,
+    new RegExp(`"${key}"`),
+    `hook handles ${key}`,
+  );
+}
+
+// Manages tabindex: 0 on active, -1 on rest.
+assert.match(
+  source,
+  /tabIndex\s*=\s*-1|setAttribute\(\s*"tabindex"/,
+  "hook sets tabindex on items",
+);
+
+// Loop is opt-in (default false to match WAI-ARIA APG composite-widget guidance).
+assert.match(
+  source,
+  /loop\s*[:=]\s*(false|boolean)/,
+  "hook exposes loop option, default false",
+);
+
+// Filters disabled items so the tab stop never lands on one.
+assert.match(
+  source,
+  /hasAttribute\(\s*"disabled"\s*\)|:not\(\[disabled\]\)/,
+  "filters disabled items out of the rove set",
+);
+
+// Filters hidden items (offsetParent === null) so the tab stop is visible.
+assert.match(
+  source,
+  /offsetParent/,
+  "filters hidden items out of the rove set",
+);
+
+// Clamps activeIndex when the item list shrinks.
+assert.match(
+  source,
+  /activeRef\.current\s*>=\s*items\.length|Math\.min\(\s*items\.length\s*-\s*1/,
+  "clamps activeIndex when the item list shrinks",
+);
+
+console.log("use-roving-tabindex.test.ts OK");

--- a/src/lib/use-roving-tabindex.ts
+++ b/src/lib/use-roving-tabindex.ts
@@ -1,0 +1,136 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+
+export type Orientation = "horizontal" | "vertical" | "both";
+
+type Options = {
+  /** Container element holding the items. */
+  containerRef: RefObject<HTMLElement | null>;
+  /** CSS selector for the items inside the container. */
+  itemSelector: string;
+  /** Which arrow keys move focus. Default "both". */
+  orientation?: Orientation;
+  /** Wrap from last → first / first → last. Default false. */
+  loop?: boolean;
+};
+
+/**
+ * Roving tabindex per WAI-ARIA APG. One item in the set has tabindex=0 (the
+ * "tab stop"), every other is tabindex=-1. Arrow keys move the tab stop and
+ * focus the new item. Home/End jump to ends. The container is the keydown
+ * target — items themselves don't need handlers.
+ *
+ * Returns `setActiveIndex` so the caller can programmatically jump (e.g.,
+ * after selecting an item to restore the tab stop).
+ */
+export function useRovingTabIndex({
+  containerRef,
+  itemSelector,
+  orientation = "both",
+  loop = false,
+}: Options) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const activeRef = useRef(0);
+  activeRef.current = activeIndex;
+
+  const getItems = useCallback((): HTMLElement[] => {
+    const container = containerRef.current;
+    if (!container) return [];
+    return Array.from(container.querySelectorAll<HTMLElement>(itemSelector))
+      // Don't rove onto disabled controls.
+      .filter((el) => !el.hasAttribute("disabled"))
+      // Don't rove onto hidden elements. offsetParent === null catches
+      // display:none and visibility:hidden ancestors. We keep the currently
+      // focused element in the set even if hidden, to avoid yanking focus
+      // mid-keystroke if a list animation hides it for a frame.
+      .filter((el) => el.offsetParent !== null || el === document.activeElement);
+  }, [containerRef, itemSelector]);
+
+  // Sync tabindex on items whenever they change or active moves. Also clamp
+  // activeIndex if the list shrunk below it — without this, a dynamic list
+  // can leave the tab stop out of range (next ArrowDown lands on nothing).
+  useEffect(() => {
+    const items = getItems();
+    if (items.length === 0) return;
+    if (activeRef.current >= items.length) {
+      const clamped = Math.min(items.length - 1, activeRef.current);
+      setActiveIndex(clamped);
+      return; // State update re-triggers this effect; let it land properly.
+    }
+    items.forEach((item, i) => {
+      if (i === activeRef.current) {
+        item.tabIndex = 0;
+      } else {
+        item.tabIndex = -1;
+      }
+    });
+  }, [getItems, activeIndex]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const horiz = orientation !== "vertical";
+    const vert = orientation !== "horizontal";
+
+    function move(delta: number) {
+      const items = getItems();
+      if (items.length === 0) return;
+      let next = activeRef.current + delta;
+      if (loop) {
+        next = (next + items.length) % items.length;
+      } else {
+        next = Math.max(0, Math.min(items.length - 1, next));
+      }
+      setActiveIndex(next);
+      items[next]?.focus();
+    }
+
+    function jumpTo(i: number) {
+      const items = getItems();
+      if (items.length === 0) return;
+      const next = Math.max(0, Math.min(items.length - 1, i));
+      setActiveIndex(next);
+      items[next]?.focus();
+    }
+
+    function onKey(e: KeyboardEvent) {
+      switch (e.key) {
+        case "ArrowDown":
+          if (!vert) return;
+          e.preventDefault();
+          move(1);
+          break;
+        case "ArrowUp":
+          if (!vert) return;
+          e.preventDefault();
+          move(-1);
+          break;
+        case "ArrowRight":
+          if (!horiz) return;
+          e.preventDefault();
+          move(1);
+          break;
+        case "ArrowLeft":
+          if (!horiz) return;
+          e.preventDefault();
+          move(-1);
+          break;
+        case "Home":
+          e.preventDefault();
+          jumpTo(0);
+          break;
+        case "End":
+          e.preventDefault();
+          jumpTo(getItems().length - 1);
+          break;
+      }
+    }
+
+    container.addEventListener("keydown", onKey);
+    return () => container.removeEventListener("keydown", onKey);
+  }, [containerRef, getItems, loop, orientation]);
+
+  return { activeIndex, setActiveIndex };
+}


### PR DESCRIPTION
## Summary
- Shared UX primitives for the polish sweep called out in `docs/superpowers/specs/2026-06-08-ux-audit.md`. No user-visible surface change; the follow-up a11y P0 PR adopts them across command palette, board, library reader, GitHub modals, glyph picker, onboarding, chat, etc.
- **Hooks** (`src/lib/`): `usePrefersReducedMotion`, `useFocusTrap`, `useRovingTabIndex`.
- **Providers / primitives** (`src/components/ui/`): `LiveRegionProvider` + `useAnnouncer()` mounted at root in `app/layout.tsx`; `<ErrorState>` companion to existing `<EmptyState>`.
- **Tokens** (`app/globals.css`): `--opacity-disabled`, `--scrollbar-thumb`/`--scrollbar-track`, themed `::selection` rule derived from `--accent-presence`; light-mode `--ring-focus` now derives from `--accent-presence` instead of hardcoded `#6F62A8`; Salem scrollbar tokenised (was raw purple rgba).
- **Refactor:** `Modal` consumes `useFocusTrap`. Hardening over the prior inline trap: `onEscape` ref-stored to avoid effect tear-down loops; empty-focusables case now `preventDefault`s Tab and falls back to focusing the container (Modal gets `tabIndex={-1}`) instead of silently letting focus escape. Behaviour on populated modals unchanged.
- Adds `ph:warning` to the icon registry so `<ErrorState>`'s default prop is a valid `IconName`.

## Test plan
- [x] `pnpm typecheck` clean.
- [x] `pnpm build` clean.
- [x] 6/6 source-grep invariant tests pass (`globals.css.test.ts`, the four hook tests, `live-region.test.ts`, `error-state.test.ts`).
- [x] Every commit signed (`git log %G?` shows `G`).
- [ ] Manual: open any `<Modal>` consumer (e.g., `/board` → "New task"). Confirm Tab/Shift+Tab cycle, Esc closes, focus restores to trigger.
- [ ] Manual: in any route, `document.querySelectorAll('[aria-live]')` returns the polite + assertive regions.
- [ ] Manual: light-mode `--ring-focus` cascades from `--accent-presence` (toggle themes in `/aesthetic`).

## Source
- Audit: `docs/superpowers/specs/2026-06-08-ux-audit.md` (gitignored).
- Plan: `docs/superpowers/plans/2026-06-08-ux-foundations.md` (gitignored).