### PR TITLE
chore(release): v0.0.54 — native arm64 DMG, JIT entitlements, release runtime test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,12 +75,19 @@ jobs:
           - platform: macos-15-intel
             label: macOS Intel (DMG, signed + notarized)
             args: "--bundles dmg"
+            arch_suffix: x86_64
+          - platform: macos-15
+            label: macOS Apple Silicon (DMG, signed + notarized)
+            args: "--bundles dmg"
+            arch_suffix: aarch64
           - platform: ubuntu-22.04
             label: Linux (AppImage)
             args: "--bundles appimage"
+            arch_suffix: ""
           - platform: windows-latest
             label: Windows (MSI)
             args: "--bundles msi"
+            arch_suffix: ""
 
     runs-on: ${{ matrix.platform }}
 
@@ -139,7 +146,7 @@ jobs:
       # steps. Runs only on the macOS leg.
       - name: Stage Apple API key
         if: >-
-          matrix.platform == 'macos-15-intel' &&
+          startsWith(matrix.platform, 'macos-') &&
           (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'macos')
         shell: bash
         run: |
@@ -160,7 +167,7 @@ jobs:
 
       - name: Import Apple signing certificate
         if: >-
-          matrix.platform == 'macos-15-intel' &&
+          startsWith(matrix.platform, 'macos-') &&
           (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'macos')
         shell: bash
         run: |
@@ -224,7 +231,7 @@ jobs:
 
       - name: Build macOS DMG with custom release script
         if: >-
-          matrix.platform == 'macos-15-intel' &&
+          startsWith(matrix.platform, 'macos-') &&
           (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'macos')
         shell: bash
         env:
@@ -242,6 +249,27 @@ jobs:
           set -euo pipefail
           bash scripts/release.sh "$RELEASE_VERSION"
 
+      # Disambiguate the produced DMG by host arch so the Intel and Apple
+      # Silicon legs upload distinct artifacts. v0.0.53 shipped an x86_64-only
+      # node sidecar that crashed under Rosetta on M-series Macs; running both
+      # legs gives users a native binary per arch.
+      - name: Suffix macOS DMG with arch
+        if: >-
+          startsWith(matrix.platform, 'macos-') &&
+          (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'macos')
+        shell: bash
+        run: |
+          set -euo pipefail
+          SRC="release/CovenCave-v${RELEASE_VERSION}.dmg"
+          DST="release/CovenCave-v${RELEASE_VERSION}-${{ matrix.arch_suffix }}.dmg"
+          if [ ! -f "$SRC" ]; then
+            echo "::error::Expected $SRC from release.sh but it was not produced"
+            ls -la release/ || true
+            exit 1
+          fi
+          mv "$SRC" "$DST"
+          echo "Renamed to $DST"
+
       # Hard gate: fail the macOS leg if the produced DMG is not accepted
       # by Gatekeeper as a notarized Developer ID app. This is what makes
       # "require notarization" a build-time invariant rather than a
@@ -250,7 +278,7 @@ jobs:
       # v0.0.13–v0.0.15.
       - name: Verify macOS DMG is notarized
         if: >-
-          matrix.platform == 'macos-15-intel' &&
+          startsWith(matrix.platform, 'macos-') &&
           (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'macos')
         shell: bash
         run: |
@@ -275,12 +303,12 @@ jobs:
 
       - name: Upload macOS DMG to GitHub Release
         if: >-
-          matrix.platform == 'macos-15-intel' &&
+          startsWith(matrix.platform, 'macos-') &&
           (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'macos')
         uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.3.3
         with:
           tag_name: ${{ env.RELEASE_TAG }}
-          files: release/CovenCave-v${{ env.RELEASE_VERSION }}.dmg
+          files: release/CovenCave-v${{ env.RELEASE_VERSION }}-${{ matrix.arch_suffix }}.dmg
 
   checksums:
     name: Publish SHA256SUMS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.54] — 2026-06-08
+
+Release repair for macOS sidecar startup after 0.0.53.
+
+### Fixed
+
+- **Signed macOS sidecar Node startup.** Re-signs the bundled Node runtime with
+  the hardened-runtime executable-memory entitlements V8 needs, so the packaged
+  sidecar can bind its local port instead of crashing before producing server
+  output. Thanks @BunsDev
+- **Native Apple Silicon DMG.** Adds an `macos-15` (aarch64) leg to the release
+  matrix alongside the existing `macos-15-intel` (x86_64) leg and tags each
+  produced DMG with its arch suffix (`-x86_64.dmg`, `-aarch64.dmg`). M-series
+  Macs no longer run the bundled Node through Rosetta, where V8 baseline-JIT
+  tier-up could crash the sidecar before it bound its port.
+
 ## [0.0.53] — 2026-06-08
 
 Release repair for clean CI packaging after 0.0.52.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,6 +16,7 @@ NOTARY_ISSUER="${NOTARY_ISSUER:-${APPLE_API_ISSUER:-}}"
 NOTARY_APPLE_ID="${NOTARY_APPLE_ID:-${APPLE_ID:-}}"
 NOTARY_APPLE_PASSWORD="${NOTARY_APPLE_PASSWORD:-${APPLE_PASSWORD:-}}"
 NOTARY_TEAM_ID="${NOTARY_TEAM_ID:-${APPLE_TEAM_ID:-}}"
+NODE_ENTITLEMENTS="src-tauri/entitlements/node.plist"
 
 require_tool() {
   command -v "$1" >/dev/null 2>&1 || { echo "Missing required tool: $1" >&2; exit 1; }
@@ -36,6 +37,7 @@ require_tool hdiutil
 require_tool spctl
 require_tool shasum
 require_tool openssl
+require_file "$NODE_ENTITLEMENTS"
 
 if [ -n "$NOTARY_APPLE_ID" ] && [ -n "$NOTARY_APPLE_PASSWORD" ] && [ -n "$NOTARY_TEAM_ID" ]; then
   NOTARY_AUTH_MODE="apple-id"
@@ -103,10 +105,18 @@ find "$APP_PATH" \
 NATIVE_COUNT=$(wc -l < "$NATIVE_FILES_TMP" | tr -d ' ')
 echo "    found $NATIVE_COUNT native files"
 while IFS= read -r f; do
-  codesign --force --options runtime --timestamp \
-    --sign "$SIGNING_IDENTITY" "$f" >/dev/null 2>&1 || {
-      echo "    ! failed to sign: $f" >&2
-    }
+  if [ "$f" = "$APP_PATH/Contents/Resources/resources/node/bin/node" ]; then
+    codesign --force --options runtime --timestamp \
+      --entitlements "$NODE_ENTITLEMENTS" \
+      --sign "$SIGNING_IDENTITY" "$f" >/dev/null 2>&1 || {
+        echo "    ! failed to sign bundled Node with entitlements: $f" >&2
+      }
+  else
+    codesign --force --options runtime --timestamp \
+      --sign "$SIGNING_IDENTITY" "$f" >/dev/null 2>&1 || {
+        echo "    ! failed to sign: $f" >&2
+      }
+  fi
 done < "$NATIVE_FILES_TMP"
 rm "$NATIVE_FILES_TMP"
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.53"
+version = "0.0.54"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/entitlements/node.plist
+++ b/src-tauri/entitlements/node.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+</dict>
+</plist>

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -83,3 +83,31 @@ test("macOS release signing includes nested executables like bundled Node", asyn
     "release signing must include executable files, not only dylib/so/node modules",
   );
 });
+
+test("macOS release signing preserves bundled Node JIT entitlement", async () => {
+  const [releaseScript, nodeEntitlements] = await Promise.all([
+    readFile(new URL("../scripts/release.sh", import.meta.url), "utf8"),
+    readFile(new URL("./entitlements/node.plist", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(
+    releaseScript,
+    /NODE_ENTITLEMENTS=/,
+    "release signing must have a dedicated entitlement file for the bundled Node runtime",
+  );
+  assert.match(
+    releaseScript,
+    /--entitlements "\$NODE_ENTITLEMENTS"/,
+    "bundled Node must be re-signed with its JIT entitlements instead of plain hardened runtime",
+  );
+  assert.match(
+    nodeEntitlements,
+    /com\.apple\.security\.cs\.allow-jit/,
+    "Node needs allow-jit under hardened runtime or V8 crashes before the sidecar can bind",
+  );
+  assert.match(
+    nodeEntitlements,
+    /com\.apple\.security\.cs\.allow-unsigned-executable-memory/,
+    "Node needs executable memory permission under hardened runtime for V8-generated code",
+  );
+});

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary

- **Bundled Node now has JIT entitlements.** Re-signs the bundled Node runtime with `com.apple.security.cs.allow-jit` and `com.apple.security.cs.allow-unsigned-executable-memory` during release codesign so V8's baseline JIT can allocate executable memory under macOS hardened runtime. v0.0.53's sidecar crashed mid-`Compiler::CompileBaseline` because we'd asked for hardened runtime without granting V8 the entitlements it needs.
- **Native Apple Silicon DMG.** Adds a `macos-15` (aarch64) leg alongside `macos-15-intel` (x86_64) in the release matrix and tags each produced DMG with its arch suffix: `CovenCave-vX.Y.Z-x86_64.dmg`, `CovenCave-vX.Y.Z-aarch64.dmg`. M-series Macs stop running the bundled Node through Rosetta, where V8 baseline-JIT tier-up is unstable regardless of entitlements.
- **Release-runtime test coverage.** `src-tauri/release-runtime.test.mjs` now asserts the bundled Node is re-signed with the JIT entitlements file and that the plist carries both `allow-jit` and `allow-unsigned-executable-memory`, so this can't silently regress.
- **v0.0.54 stamp.** Bumps `package.json`, `Cargo.toml`, `Cargo.lock`, `tauri.conf.json` to 0.0.54 and adds a Changelog entry covering both fixes.

## Context

User report on v0.0.53 (Apple Silicon):

\`\`\`
Sidecar (node /Applications/CovenCave.app/Contents/Resources/resources/node/bin/node)
did not become ready on port 49485 within 20s.

…16: v8::internal::Compiler::CompileSharedWithBaseline(…)
17: v8::internal::Compiler::CompileBaseline(…)
18: v8::internal::baseline::BaselineBatchCompiler::EnqueueFunction(…)
19: v8::internal::TieringManager::OnInterruptTick(…)
\`\`\`

Stack frames are V8's baseline JIT tier-up path. v0.0.53's DMG shipped an x86_64-only \`node\` binary, so on Apple Silicon it ran under Rosetta — where Rosetta-translated V8 baseline JIT is famously unstable. The same path can crash on Intel under hardened runtime without `allow-jit`. Both fixes ship together so neither population is left exposed.

## Test plan

- [ ] Push the `v0.0.54` tag and confirm all four matrix legs run green: Linux (AppImage), Windows (MSI), macOS Intel DMG, macOS Apple Silicon DMG.
- [ ] Confirm the GitHub Release exposes both `CovenCave-v0.0.54-x86_64.dmg` and `CovenCave-v0.0.54-aarch64.dmg`, plus the existing AppImage and MSI.
- [ ] Confirm the `Publish SHA256SUMS` job catches both DMGs in its glob and writes them to `SHA256SUMS`.
- [ ] Spot-check codesign on a downloaded macOS DMG: `codesign -d --entitlements - "/Applications/CovenCave.app/Contents/Resources/resources/node/bin/node"` prints `com.apple.security.cs.allow-jit` and `com.apple.security.cs.allow-unsigned-executable-memory`.
- [ ] Install the aarch64 DMG on an Apple Silicon Mac; sidecar comes up within the 20s readiness window with no V8 crash in `~/Library/Logs/CovenCave/sidecar.log`.
- [ ] Install the x86_64 DMG on an Intel Mac; sidecar comes up within the 20s readiness window.
- [ ] `npx --yes tsx --test src-tauri/release-runtime.test.mjs` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)