### PR TITLE
feat(memory): show source context provenance

### DIFF
--- a/src/app/api/coven-memory/route.ts
+++ b/src/app/api/coven-memory/route.ts
@@ -10,6 +10,7 @@ type DaemonMemoryEntry = {
   path: string;
   updated_at: string;
   excerpt?: string;
+  source_context?: string;
 };
 
 export async function GET() {

--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
-import { readdir, stat } from "node:fs/promises";
+import { readFile, readdir, stat } from "node:fs/promises";
 import path from "node:path";
 import { homedir } from "node:os";
+import { parseMemorySourceContext } from "@/lib/memory-source-context";
 
 export const dynamic = "force-dynamic";
 
@@ -29,9 +30,18 @@ export type MemoryEntry = {
   fullPath: string;
   size: number;
   modified: string;
+  sourceContext?: string;
   /** Familiar id when this entry belongs to a specific agent workspace */
   familiarId?: string;
 };
+
+async function readSourceContext(filePath: string): Promise<string | undefined> {
+  try {
+    return parseMemorySourceContext(await readFile(/* turbopackIgnore: true */ filePath, "utf8"));
+  } catch {
+    return undefined;
+  }
+}
 
 async function walk(
   dir: string,
@@ -55,6 +65,7 @@ async function walk(
     } else if (item.isFile() && /\.(md|markdown|txt|json)$/i.test(item.name)) {
       try {
         const s = await stat(full);
+        const sourceContext = await readSourceContext(full);
         acc.push({
           root,
           rootLabel,
@@ -62,6 +73,7 @@ async function walk(
           fullPath: full,
           size: s.size,
           modified: s.mtime.toISOString(),
+          ...(sourceContext ? { sourceContext } : {}),
           ...(familiarId ? { familiarId } : {}),
         });
       } catch {
@@ -87,6 +99,7 @@ async function scanFamiliarWorkspaces(acc: MemoryEntry[]) {
     const indexFile = path.join(workspacesDir, familiarId, "MEMORY.md");
     try {
       const s = await stat(/* turbopackIgnore: true */ indexFile);
+      const sourceContext = await readSourceContext(indexFile);
       acc.push({
         root: `familiar:${familiarId}`,
         rootLabel: familiarId,
@@ -94,6 +107,7 @@ async function scanFamiliarWorkspaces(acc: MemoryEntry[]) {
         fullPath: indexFile,
         size: s.size,
         modified: s.mtime.toISOString(),
+        ...(sourceContext ? { sourceContext } : {}),
         familiarId,
       });
     } catch {
@@ -118,6 +132,7 @@ export async function GET() {
   for (const idx of MEMORY_INDEX_FILES) {
     try {
       const s = await stat(/* turbopackIgnore: true */ idx);
+      const sourceContext = await readSourceContext(idx);
       entries.push({
         root: "index",
         rootLabel: "Index",
@@ -125,6 +140,7 @@ export async function GET() {
         fullPath: idx,
         size: s.size,
         modified: s.mtime.toISOString(),
+        ...(sourceContext ? { sourceContext } : {}),
       });
     } catch {
       /* missing */

--- a/src/components/agents-memory-graph.test.ts
+++ b/src/components/agents-memory-graph.test.ts
@@ -58,6 +58,18 @@ assert.match(
 
 assert.match(
   memoryViewSource,
+  /Provenance[\s\S]*selectedMemory\.sourceContext/,
+  "Selected-memory detail panel should show source_context provenance when available",
+);
+
+assert.doesNotMatch(
+  memoryViewSource,
+  /sourceContext[\s\S]*window\.location|window\.location[\s\S]*sourceContext/,
+  "source_context should be visible text in this slice, not an unverified click-through route",
+);
+
+assert.match(
+  memoryViewSource,
   /onSelectMemory=\{setSelectedMemoryId\}/,
   "Clicking a memory node in the graph should select it for the detail panel",
 );
@@ -96,6 +108,18 @@ assert.match(
   graphSource,
   /aria-label="3D familiar memory map"/,
   "MemoryGraph3D should expose an accessible canvas label",
+);
+
+assert.match(
+  graphSource,
+  /Source:[\s\S]*sourceContext/,
+  "Memory graph tooltip should show source_context provenance for traced memory nodes",
+);
+
+assert.match(
+  graphSource,
+  /hasSourceContext[\s\S]*tracked source|tracked source[\s\S]*hasSourceContext/,
+  "Memory graph legend should distinguish traced memory nodes without changing graph topology",
 );
 
 assert.match(

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -15,6 +15,7 @@ type FileMemoryEntry = {
   fullPath: string;
   size: number;
   modified: string;
+  sourceContext?: string;
 };
 
 type Props = {
@@ -61,12 +62,14 @@ function memoryMatches(entry: CovenMemoryEntry | FileMemoryEntry, query: string)
       entry.excerpt ?? "",
       entry.familiar_id,
       entry.path,
+      entry.source_context ?? "",
     ].some((value) => value.toLowerCase().includes(query));
   }
   return [
     entry.rootLabel,
     entry.relPath,
     entry.fullPath,
+    entry.sourceContext ?? "",
   ].some((value) => value.toLowerCase().includes(query));
 }
 
@@ -319,6 +322,16 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
                     <p className="mt-3 line-clamp-6 text-[12px] leading-5 text-[var(--text-secondary)]">
                       {selectedMemory.excerpt}
                     </p>
+                  ) : null}
+                  {selectedMemory.sourceContext ? (
+                    <div className="mt-3 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-elevated)]/40 px-2.5 py-2">
+                      <div className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">
+                        Provenance
+                      </div>
+                      <code className="mt-1 block break-all font-mono text-[11px] leading-4 text-[var(--text-primary)]">
+                        {selectedMemory.sourceContext}
+                      </code>
+                    </div>
                   ) : null}
                   <button
                     type="button"

--- a/src/components/agents-view-stats.ts
+++ b/src/components/agents-view-stats.ts
@@ -7,6 +7,7 @@ export type CovenMemoryEntry = {
   path: string;
   updated_at: string;
   excerpt?: string;
+  source_context?: string;
 };
 
 export type AgentCardStats = {

--- a/src/components/memory-graph-3d-smoke.tsx
+++ b/src/components/memory-graph-3d-smoke.tsx
@@ -21,6 +21,7 @@ const covenEntries = [
     path: "/Users/buns/.coven/memory/nova/memory-map.md",
     updated_at: now,
     excerpt: "Focus one agent at a time and keep the list as the retrieval surface.",
+    source_context: "session://smoke-nova-memory-map",
   },
   {
     id: "smoke-nova-2",

--- a/src/components/memory-graph-3d.tsx
+++ b/src/components/memory-graph-3d.tsx
@@ -121,6 +121,10 @@ function nodeIsDimmed(node: MemoryGraphSceneNode, selectedFamiliarId: string): b
   return node.familiarId !== selectedFamiliarId;
 }
 
+function hasSourceContext(node: MemoryGraphSceneNode): boolean {
+  return node.kind === "memory" && Boolean(node.sourceContext);
+}
+
 function compactAge(iso: string | undefined): string {
   if (!iso) return "";
   const ms = Date.now() - new Date(iso).getTime();
@@ -261,6 +265,21 @@ export function MemoryGraph3D({
       instanced.userData.nodes = leaves;
       root.add(instanced);
       pickables.push(instanced as Pickable);
+
+      leaves.filter(hasSourceContext).forEach((node) => {
+        const ring = new THREE.Mesh(
+          new THREE.PlaneGeometry(1.28, 0.58),
+          new THREE.MeshBasicMaterial({
+            color: 0x7dd3fc,
+            transparent: true,
+            opacity: 0.26,
+            side: THREE.DoubleSide,
+            depthWrite: false,
+          }),
+        );
+        ring.position.copy(asVector(node.position).add(new THREE.Vector3(0, 0, -0.035)));
+        root.add(ring);
+      });
 
       leaves.slice(0, 6).forEach((node) => {
         const label = makeLabelSprite(node.label, "#dffbea");
@@ -476,6 +495,7 @@ export function MemoryGraph3D({
       <div className="pointer-events-none absolute bottom-3 left-3 flex flex-wrap items-center gap-2 rounded-lg border border-white/10 bg-black/45 px-3 py-2 text-[10px] text-white/65 shadow-2xl backdrop-blur">
         <span className="inline-flex items-center gap-1"><i className="h-2 w-3 rounded-sm bg-[#8E3DFF]" /> agent</span>
         <span className="inline-flex items-center gap-1"><i className="h-2 w-3 rounded-sm bg-[#62d08f]" /> memory card</span>
+        <span className="inline-flex items-center gap-1"><i className="h-2 w-3 rounded-sm bg-[#7dd3fc]" /> tracked source</span>
         <span className="inline-flex items-center gap-1"><i className="h-2 w-3 rounded-sm bg-[#f59e0b]" /> older stack</span>
       </div>
       {graph.metrics.hiddenEntries > 0 ? (
@@ -512,6 +532,9 @@ function MemoryGraphTooltip({
       <div className="mt-1 text-white/65">{detail}</div>
       {node.kind === "memory" && node.excerpt ? (
         <div className="mt-2 line-clamp-3 text-white/55">{node.excerpt}</div>
+      ) : null}
+      {node.kind === "memory" && node.sourceContext ? (
+        <div className="mt-2 break-all font-mono text-[10px] text-white/50">Source: {node.sourceContext}</div>
       ) : null}
     </div>
   );

--- a/src/lib/memory-graph-3d-model.test.ts
+++ b/src/lib/memory-graph-3d-model.test.ts
@@ -20,6 +20,7 @@ const covenEntries = [
     path: "/Users/buns/.coven/memory/nova.md",
     updated_at: "2026-06-08T05:00:00.000Z",
     excerpt: "routing architecture",
+    source_context: "session://nova-routing-2026-06-08",
   },
   {
     id: "mem-2",
@@ -100,6 +101,27 @@ assert.deepEqual(
   filtered.nodes.filter((node) => node.kind === "memory" && node.source === "coven").map((node) => node.id),
   ["memory:coven:mem-1"],
   "query and familiar filters should apply to familiar memory leaves",
+);
+
+assert.equal(
+  filtered.nodes.find((node) => node.id === "memory:coven:mem-1")?.sourceContext,
+  "session://nova-routing-2026-06-08",
+  "coven memory nodes should preserve source_context as sourceContext provenance",
+);
+
+const provenanceFiltered = buildMemoryGraphModel({
+  familiars,
+  covenEntries,
+  fileEntries,
+  query: "session://nova-routing",
+  familiarFilter: "nova",
+  maxLeavesPerHub: 10,
+});
+
+assert.deepEqual(
+  provenanceFiltered.nodes.filter((node) => node.kind === "memory").map((node) => node.id),
+  ["memory:coven:mem-1"],
+  "memory graph search should match source_context provenance URIs",
 );
 
 assert.equal(

--- a/src/lib/memory-graph-3d-model.ts
+++ b/src/lib/memory-graph-3d-model.ts
@@ -7,6 +7,7 @@ export type MemoryGraphCovenEntry = {
   path: string;
   updated_at: string;
   excerpt?: string;
+  source_context?: string;
 };
 
 export type MemoryGraphFileEntry = {
@@ -16,6 +17,7 @@ export type MemoryGraphFileEntry = {
   fullPath: string;
   size: number;
   modified: string;
+  sourceContext?: string;
   /** Familiar id when this entry belongs to a specific agent workspace */
   familiarId?: string;
 };
@@ -41,6 +43,7 @@ export type MemoryGraphMemoryNode = {
   path: string;
   updatedAt: string;
   excerpt?: string;
+  sourceContext?: string;
   rootLabel?: string;
   relPath?: string;
 };
@@ -240,32 +243,32 @@ export function buildMemoryGraphModel({
 
   const selectedFamiliarId = familiarFilter !== "all"
     ? familiarFilter
-    : covenEntries.find((entry) => matchesQuery([entry.title, entry.excerpt, entry.familiar_id, entry.path], q))?.familiar_id
-      ?? fileEntries.find((entry) => entry.familiarId && matchesQuery([entry.relPath, entry.familiarId], q))?.familiarId
+    : covenEntries.find((entry) => matchesQuery([entry.title, entry.excerpt, entry.familiar_id, entry.path, entry.source_context], q))?.familiar_id
+      ?? fileEntries.find((entry) => entry.familiarId && matchesQuery([entry.relPath, entry.familiarId, entry.sourceContext], q))?.familiarId
       ?? familiars[0]?.id;
   const selectedFamiliar = familiars.find((familiar) => familiar.id === selectedFamiliarId);
 
   const matchingCovenEntries = covenEntries
     .filter((entry) => entry.familiar_id === selectedFamiliarId)
     .filter((entry) =>
-      matchesQuery([entry.title, entry.excerpt, entry.familiar_id, entry.path], q),
+      matchesQuery([entry.title, entry.excerpt, entry.familiar_id, entry.path, entry.source_context], q),
     )
     .sort((a, b) => compareIsoDesc(a.updated_at, b.updated_at));
 
   const totalMatchingForFamiliar = covenEntries.filter((entry) =>
     entry.familiar_id === selectedFamiliarId &&
-    matchesQuery([entry.title, entry.excerpt, entry.familiar_id, entry.path], q),
+    matchesQuery([entry.title, entry.excerpt, entry.familiar_id, entry.path, entry.source_context], q),
   ).length;
 
   // File entries for the selected familiar from agent workspace memory dirs
   const matchingFileEntries = fileEntries
     .filter((entry) => entry.familiarId === selectedFamiliarId)
-    .filter((entry) => matchesQuery([entry.relPath, entry.rootLabel, entry.familiarId ?? ""], q))
+    .filter((entry) => matchesQuery([entry.relPath, entry.rootLabel, entry.familiarId ?? "", entry.sourceContext], q))
     .sort((a, b) => compareIsoDesc(a.modified, b.modified));
 
   const totalFileEntries = fileEntries.filter((entry) =>
     entry.familiarId === selectedFamiliarId &&
-    matchesQuery([entry.relPath, entry.rootLabel, entry.familiarId ?? ""], q),
+    matchesQuery([entry.relPath, entry.rootLabel, entry.familiarId ?? "", entry.sourceContext], q),
   ).length;
 
   const totalMemoryCount = totalMatchingForFamiliar + totalFileEntries;
@@ -303,6 +306,7 @@ export function buildMemoryGraphModel({
           path: coven.path,
           updatedAt: coven.updated_at,
           excerpt: coven.excerpt,
+          sourceContext: coven.source_context,
         };
       },
     });
@@ -345,6 +349,7 @@ export function buildMemoryGraphModel({
             title: file.relPath,
             path: file.fullPath,
             updatedAt: file.modified,
+            sourceContext: file.sourceContext,
             rootLabel: file.rootLabel,
             relPath: file.relPath,
           };

--- a/src/lib/memory-source-context.test.ts
+++ b/src/lib/memory-source-context.test.ts
@@ -1,0 +1,31 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { parseMemorySourceContext } from "./memory-source-context.ts";
+
+assert.equal(
+  parseMemorySourceContext(`---
+title: Nova routing
+source_context: session://nova-routing-2026-06-08
+---
+
+Routing note.`),
+  "session://nova-routing-2026-06-08",
+  "memory frontmatter should expose source_context provenance",
+);
+
+assert.equal(
+  parseMemorySourceContext(`---
+title: Audit note
+source_context: "audit://release-v0.0.52"
+---
+
+Audit note.`),
+  "audit://release-v0.0.52",
+  "memory frontmatter should allow quoted source_context values",
+);
+
+assert.equal(
+  parseMemorySourceContext("# Plain memory\n\nNo provenance."),
+  undefined,
+  "plain memory files without frontmatter should stay untraced",
+);

--- a/src/lib/memory-source-context.ts
+++ b/src/lib/memory-source-context.ts
@@ -1,0 +1,26 @@
+export function parseMemorySourceContext(text: string): string | undefined {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return undefined;
+
+  for (const rawLine of match[1].split(/\r?\n/)) {
+    const line = rawLine.trim();
+    const found = line.match(/^source_context:\s*(.+?)\s*$/);
+    if (!found) continue;
+
+    const value = normalizeSourceContext(found[1]);
+    if (value) return value;
+  }
+
+  return undefined;
+}
+
+export function normalizeSourceContext(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const quote = trimmed[0];
+  if ((quote === "\"" || quote === "'") && trimmed.endsWith(quote)) {
+    return trimmed.slice(1, -1).trim() || undefined;
+  }
+  return trimmed;
+}


### PR DESCRIPTION
## Summary
- preserve daemon `source_context` and local-file `sourceContext` provenance through memory graph nodes
- parse `source_context:` from memory file frontmatter
- include provenance URIs in memory search matching
- show provenance in memory graph tooltips and selected-memory detail panel without adding click-through routing
- add a subtle tracked-source visual state and smoke fixture coverage

## Verification
- node src/lib/memory-graph-3d-model.test.ts && node src/lib/memory-source-context.test.ts && node src/components/agents-memory-graph.test.ts
- pnpm typecheck
- pnpm build
- git diff --check
- Playwright desktop + mobile /dev/memory-graph-3d screenshot pixel validation with tracked-source legend visible
