### PR TITLE
fix(chat): keep terminal code header label clear

### DIFF
--- a/src/components/message-bubble-code-header.test.ts
+++ b/src/components/message-bubble-code-header.test.ts
@@ -1,0 +1,35 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const css = await readFile(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
+
+assert.doesNotMatch(
+  css,
+  /\.cave-code-header::before/,
+  "Terminal code chrome should not inject traffic lights before the language label",
+);
+
+assert.match(
+  css,
+  /\.cave-code-header::after[\s\S]*box-shadow:/,
+  "Terminal code chrome should render traffic lights after the language label",
+);
+
+assert.match(
+  css,
+  /\.cave-code-lang[\s\S]*order:\s*0/,
+  "The language label should be first in terminal code headers",
+);
+
+assert.match(
+  css,
+  /\.cave-code-header::after[\s\S]*order:\s*1/,
+  "Traffic lights should sit immediately to the right of the language label",
+);
+
+assert.match(
+  css,
+  /\.cave-code-header \.cave-copy-btn[\s\S]*order:\s*3[\s\S]*margin-left:\s*auto/,
+  "The copy button should stay at the far edge after the label and traffic lights",
+);

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -218,10 +218,11 @@
   backdrop-filter: blur(4px);
 }
 
-/* decorative traffic-light dots */
-.cave-code-header::before {
+/* decorative traffic-light dots; BASH/lang stays first, then the dots. */
+.cave-code-header::after {
   content: "";
   display: block;
+  order: 1;
   width: 8px;
   height: 8px;
   border-radius: 50%;
@@ -230,11 +231,13 @@
   box-shadow:
     16px 0 0 color-mix(in oklch, oklch(0.75 0.18 60) 40%, oklch(0.4 0 0)),
     32px 0 0 color-mix(in oklch, oklch(0.65 0.18 170) 40%, oklch(0.4 0 0));
-  margin-right: 8px;
+  margin-left: 2px;
+  margin-right: 34px;
   opacity: 0.65;
 }
 
 .cave-code-lang {
+  order: 0;
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   font-size: 10px;
   letter-spacing: 0.06em;
@@ -245,6 +248,7 @@
 }
 
 .cave-code-filename {
+  order: 2;
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   font-size: 10px;
   color: var(--text-muted);
@@ -361,7 +365,10 @@
 .cave-copy-btn:focus-visible { opacity: 1; }
 
 /* push copy btn to right inside header */
-.cave-code-header .cave-copy-btn { margin-left: auto; }
+.cave-code-header .cave-copy-btn {
+  order: 3;
+  margin-left: auto;
+}
 
 /* bubble-level copy — top-right corner */
 .cave-copy-btn-bubble {


### PR DESCRIPTION
## Summary
- move markdown code-block traffic lights after the language label so `BASH` stays readable on the left
- lock code header flex order as language label, traffic lights, filename, copy button
- add a regression test for the terminal code-header ordering

## Verification
- node src/components/message-bubble-code-header.test.ts
- pnpm typecheck
- pnpm build
- git diff --check
- Playwright layout check for code header flex order and overflow
