### PR TITLE
fix(release): loopback-tolerant referer check for packaged sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.55] — 2026-06-08
+
+Release repair for the packaged macOS sidecar after 0.0.54.
+
+### Fixed
+
+- **Loopback-tolerant referer check.** The sidecar's CSRF guard now treats
+  `127.0.0.1`, `localhost`, and `[::1]` as the same origin when scheme and
+  port match. Tauri's WKWebView on macOS sends a referer whose loopback
+  hostname can differ from the one the sidecar bound to (e.g. webview
+  loaded at `http://127.0.0.1:<port>/`, request comes in with
+  `Referer: http://localhost:<port>/…`), which made every `/api/…` call
+  fail with `forbidden referer` once the sidecar successfully booted on
+  Apple Silicon. The loopback host gate and token check still run first,
+  so the relaxation only widens what counts as "same origin" inside the
+  already-loopback envelope.
+
 ## [0.0.54] — 2026-06-08
 
 Release repair for macOS sidecar startup after 0.0.53.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.54"
+version = "0.0.55"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",

--- a/src/proxy-behavior.test.ts
+++ b/src/proxy-behavior.test.ts
@@ -77,6 +77,43 @@ assert.equal(sameOrigin(null, expected), true, "absent origin header passes thro
 assert.equal(sameOrigin("not a url", expected), false, "malformed url is rejected");
 assert.equal(sameOrigin("", expected), true, "empty origin is treated as absent");
 
+// Loopback hostnames (127.0.0.1 / localhost / ::1) must be treated as
+// interchangeable on the same scheme + port. Tauri's WKWebView on macOS sends
+// a referer whose hostname can differ from the loopback host the sidecar
+// bound, so requiring an exact origin match falsely rejects same-machine
+// traffic. Cross-loopback variants here, with port mismatches and
+// non-loopback hosts still rejected, guards both ends.
+assert.equal(
+  sameOrigin("http://127.0.0.1:3000", expected),
+  true,
+  "127.0.0.1 ↔ localhost on same port should be treated as same origin",
+);
+assert.equal(
+  sameOrigin("http://[::1]:3000", expected),
+  true,
+  "IPv6 loopback ↔ localhost on same port should be treated as same origin",
+);
+assert.equal(
+  sameOrigin("http://localhost:3000", "http://127.0.0.1:3000"),
+  true,
+  "loopback variant tolerance is symmetric",
+);
+assert.equal(
+  sameOrigin("http://127.0.0.1:3001", expected),
+  false,
+  "loopback variant with port mismatch must still be rejected",
+);
+assert.equal(
+  sameOrigin("https://127.0.0.1:3000", expected),
+  false,
+  "loopback variant with scheme mismatch must still be rejected",
+);
+assert.equal(
+  sameOrigin("http://example.com:3000", expected),
+  false,
+  "non-loopback hostname must still be rejected",
+);
+
 // ─── bearerFromReferer ─────────────────────────────────────────────────────
 assert.equal(
   bearerFromReferer("http://localhost:3000/foo?covenCaveToken=abc", expected),

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -33,7 +33,19 @@ export function isAllowedApiHost(host: string | null, mobileAccessAuthenticated 
 export function sameOrigin(value: string | null, expectedOrigin: string) {
   if (!value) return true;
   try {
-    return new URL(value).origin === expectedOrigin;
+    const url = new URL(value);
+    if (url.origin === expectedOrigin) return true;
+    // Tauri's WKWebView on macOS occasionally normalizes the referer's
+    // loopback hostname (127.0.0.1 ↔ localhost ↔ [::1]) differently from the
+    // host the sidecar bound. The host gate above already requires a loopback
+    // request URL, so accept any same-scheme, same-port loopback referer.
+    const expected = new URL(expectedOrigin);
+    return (
+      url.protocol === expected.protocol &&
+      url.port === expected.port &&
+      isLoopbackHost(url.host) &&
+      isLoopbackHost(expected.host)
+    );
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

- **Loopback-tolerant referer check.** Tauri's WKWebView on macOS sends a `Referer` whose loopback hostname can differ from the hostname the sidecar bound to (webview loads at `http://127.0.0.1:<port>/`, header comes back as `http://localhost:<port>/…`). v0.0.54's strict `sameOrigin` rejected every `/api/*` call with `forbidden referer` once the sidecar successfully booted on Apple Silicon. `src/proxy-helpers.ts` now accepts any scheme- and port-matching pair of loopback hosts (`127.0.0.1` ↔ `localhost` ↔ `[::1]`). The `isAllowedApiHost` gate already requires loopback, and the auth-token check still runs after, so this only widens "same origin" inside an already-loopback envelope.
- **Test coverage.** `src/proxy-behavior.test.ts` adds asserts for accepted loopback variants, rejected port mismatches, rejected scheme mismatches, and rejected non-loopback hosts.
- **v0.0.55 stamp.** Bumps `package.json`, `Cargo.toml`, `Cargo.lock`, `tauri.conf.json` to 0.0.55 and adds a changelog entry.

## Context

Reported on a freshly-installed v0.0.54 `.app`:

\`\`\`
Could not load capabilities: forbidden referer
Cave couldn't reach /api/onboarding/status in 7 attempts. The coven CLI may not
be installed, or the local sidecar may be blocked.
\`\`\`

Sidecar log confirms the Next.js standalone server came up cleanly (`Ready in 0ms`), so the entitlements + arm64 fixes from v0.0.54 worked — the symptom is purely the CSRF guard rejecting the WKWebView's referer.

## Test plan

- [ ] `npx --yes tsx --test src/proxy-behavior.test.ts` passes locally.
- [ ] Push `v0.0.55` tag and confirm all four matrix legs build + the SHA256SUMS job lands.
- [ ] Install the v0.0.55 Apple Silicon DMG; sidecar boots, capabilities view loads without "forbidden referer", and the onboarding overlay stops showing "couldn't reach /api/onboarding/status".
- [ ] Install the v0.0.55 Intel DMG; same checks pass.
- [ ] `pnpm dev` in a browser at `http://localhost:3000/` still works (regression check — was the only validated path for the strict check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)