### PR TITLE
fix(inspector): match compact rail surface

### DIFF
--- a/src/components/inspector-pane-surface.test.ts
+++ b/src/components/inspector-pane-surface.test.ts
@@ -1,0 +1,25 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./inspector-pane.tsx", import.meta.url), "utf8");
+
+assert.match(
+  source,
+  /const shellClassName = compact[\s\S]*bg-\[var\(--bg-base\)\]/,
+  "compact InspectorPane should use the same base rail surface as Chat and Memory",
+);
+
+assert.doesNotMatch(
+  source,
+  /<aside className="flex h-full flex-col border-l border-\[var\(--border-hairline\)\] bg-\[var\(--bg-raised\)\]\/40">/,
+  "compact InspectorPane must not always inherit the bordered translucent standalone shell",
+);
+
+assert.match(
+  source,
+  /inspector-memory-tab-surface flex h-full min-h-0 flex-col bg-\[var\(--bg-base\)\]/,
+  "nested MemoryTab mode shell should paint the base background behind Coven and Files empty states",
+);
+
+console.log("inspector-pane-surface.test.ts OK");

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -96,8 +96,12 @@ export function InspectorPane({
 
   const inboxBadge = familiarInbox.filter((i) => i.status === "fired").length;
 
+  const shellClassName = compact
+    ? "flex h-full min-h-0 flex-col bg-[var(--bg-base)]"
+    : "flex h-full min-h-0 flex-col border-l border-[var(--border-hairline)] bg-[var(--bg-raised)]/40";
+
   return (
-    <aside className="flex h-full flex-col border-l border-[var(--border-hairline)] bg-[var(--bg-raised)]/40">
+    <aside className={shellClassName}>
       {!compact && (
         <nav className="flex border-b border-[var(--border-hairline)] text-[11px]">
           {(["memory", "familiar", "inbox", "vault"] as const).map((t) => (
@@ -408,7 +412,7 @@ function MemoryFileView({ path, file, reveal, totalRedactions, onRevealToggle, o
   );
 
   const inlineView = (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full min-h-0 flex-col bg-[var(--bg-base)]">
       {header}
       {toolbar}
       {body}
@@ -595,7 +599,7 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
   }
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="inspector-memory-tab-surface flex h-full min-h-0 flex-col bg-[var(--bg-base)]">
       <div className="flex items-center gap-1 border-b border-[var(--border-hairline)] px-2 py-1.5">
         {(["inspector", "coven", "files"] as const).map((m) => (
           <button


### PR DESCRIPTION
## Summary
- match compact inspector rail surfaces to the base app background
- keep the standalone inspector border/translucent shell only for non-compact usage
- add regression coverage for compact shell and memory-tab surfaces

## Verification
- node src/components/inspector-pane-surface.test.ts
- pnpm typecheck
- pnpm build
- git diff --check
