### PR TITLE
fix(agents): drop hover caret on roster card familiar name

### DIFF
--- a/src/components/agents-view.tsx
+++ b/src/components/agents-view.tsx
@@ -344,11 +344,6 @@ function AgentRosterCard({
             {familiar.role || familiar.harness || familiar.id}
           </span>
         </span>
-        <Icon
-          name="ph:caret-right"
-          width={12}
-          className="text-[var(--text-muted)] opacity-0 transition-opacity group-hover:opacity-100"
-        />
       </div>
 
       <div className="flex flex-wrap items-center gap-1.5 text-[10px] uppercase tracking-widest text-[var(--text-muted)]">


### PR DESCRIPTION
## Summary
- remove the roster-card hover caret from familiar names
- keep the agent card header quieter and avoid visual jitter on hover

## Verification
- node src/components/agents-view.test.ts && node src/components/agent-roster-card.test.ts
- pnpm typecheck
- git diff --check
- GitHub CI will run full frontend and Rust checks on the clean pushed commit
