### PR TITLE
fix(agents): drop hover caret + scroll memory tab in detail panel

### DIFF
--- a/src/components/agents-view.tsx
+++ b/src/components/agents-view.tsx
@@ -591,7 +591,7 @@ function AgentDetailPanel({
         ))}
       </div>
 
-      <div className="min-h-0 flex-1 overflow-hidden">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {tab === "memory" ? (
           <AgentsMemoryView
             familiars={familiars}

--- a/src/components/agents-view.tsx
+++ b/src/components/agents-view.tsx
@@ -344,11 +344,6 @@ function AgentRosterCard({
             {familiar.role || familiar.harness || familiar.id}
           </span>
         </span>
-        <Icon
-          name="ph:caret-right"
-          width={12}
-          className="text-[var(--text-muted)] opacity-0 transition-opacity group-hover:opacity-100"
-        />
       </div>
 
       <div className="flex flex-wrap items-center gap-1.5 text-[10px] uppercase tracking-widest text-[var(--text-muted)]">


### PR DESCRIPTION
## Summary
- Drop the hover-revealed `ph:caret-right` next to the familiar name in `AgentRosterCard`.
- Fix the Agents detail-panel memory tab clipping instead of scrolling: the tab-content wrapper was a block container, so `<AgentsMemoryView>`'s `flex-1` couldn't constrain its height. Long memory lists now scroll inside the panel as intended.

## Test plan
- [ ] In the Agents view, hover an agent roster card — no caret-right appears next to the name.
- [ ] Click into an agent's detail panel → Memory tab. With a familiar that has many memory entries, the list scrolls inside the tab content area without expanding the whole view.
- [ ] Files and Sessions tabs still scroll independently inside the panel.
- [ ] Global memory overlay (Memory across all agents) still renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)