### PR TITLE
test(api): add contract suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - run: pnpm test:api
+
       # Next 16.2.6 / Turbopack has non-deterministic chunking errors on
       # the same SHA (~50% pass rate observed on this codebase). Retry up
       # to 3 times with a clean .next between attempts. Remove once we

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "mobile:tailscale": "bash scripts/mobile-tailscale.sh",
     "build": "next build",
     "typecheck": "tsc --noEmit",
+    "test:api": "node --experimental-strip-types src/app/api/api-contracts.test.ts && node --experimental-strip-types src/app/api/board/enrich-steps/route.test.ts && node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts && node --experimental-strip-types src/app/api/library/route-link/route.test.ts && node --experimental-strip-types src/lib/server/memory-file-paths.test.ts",
+    "test:api:http": "node scripts/api-http-smoke.mjs",
     "start": "next start"
   },
   "dependencies": {

--- a/scripts/api-http-smoke.mjs
+++ b/scripts/api-http-smoke.mjs
@@ -1,0 +1,78 @@
+const base = (process.env.API_BASE ?? "http://localhost:3000").replace(/\/$/, "");
+
+async function request(path, init) {
+  const url = `${base}${path}`;
+  let res;
+  try {
+    res = await fetch(url, init);
+  } catch (err) {
+    throw new Error(`request failed for ${url}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  const text = await res.text();
+  let json = null;
+  if (text) {
+    try {
+      json = JSON.parse(text);
+    } catch {
+      throw new Error(`${url} returned non-JSON body: ${text.slice(0, 160)}`);
+    }
+  }
+  return { status: res.status, json };
+}
+
+async function check(name, path, expectedStatus, validate, init) {
+  const result = await request(path, init);
+  if (result.status !== expectedStatus) {
+    throw new Error(`${name}: expected HTTP ${expectedStatus}, got ${result.status}`);
+  }
+  if (validate && !validate(result.json)) {
+    throw new Error(`${name}: response body failed validation: ${JSON.stringify(result.json)}`);
+  }
+  console.log(`ok ${name}`);
+}
+
+await check(
+  "daemon status",
+  "/api/daemon/status",
+  200,
+  (json) => typeof json?.running === "boolean" && typeof json.workspacePath === "string",
+);
+
+await check(
+  "memory file requires path",
+  "/api/memory/file",
+  400,
+  (json) => json?.ok === false && json.error === "path required",
+);
+
+await check(
+  "memory file denies outside paths",
+  `/api/memory/file?path=${encodeURIComponent("/etc/passwd")}`,
+  403,
+  (json) => json?.ok === false && json.error === "path not allowed",
+);
+
+await check(
+  "project file requires path",
+  "/api/project-file",
+  400,
+  (json) => json?.ok === false && json.error === "missing path param",
+);
+
+await check(
+  "inbox rejects non-local writes",
+  "/api/inbox",
+  403,
+  (json) => json?.ok === false && typeof json.error === "string" && json.error.startsWith("forbidden"),
+  {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      origin: "https://example.invalid",
+    },
+    body: JSON.stringify({ title: "blocked" }),
+  },
+);
+
+console.log(`api-http-smoke: ${base} passed`);

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -1,0 +1,149 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const apiRoot = path.join(root, "src", "app", "api");
+
+type RouteContract = {
+  route: string;
+  methods: string[];
+  kind: "json" | "stream";
+  readsJson?: boolean;
+  invalidJson?: "guarded" | "fallback-empty" | "legacy-unhandled";
+  pathGuard?: boolean;
+  localOriginGuard?: boolean;
+};
+
+const contracts: RouteContract[] = [
+  { route: "/board/[id]/chat", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
+  { route: "/board/[id]/lifecycle", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/board/[id]", methods: ["PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/board/enrich-steps", methods: ["POST"], kind: "json", readsJson: true },
+  { route: "/board", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/capabilities", methods: ["GET"], kind: "json" },
+  { route: "/chat/conversation/[id]", methods: ["GET"], kind: "json" },
+  { route: "/chat/send", methods: ["POST"], kind: "stream", readsJson: true },
+  { route: "/codex-automations/[id]", methods: ["GET", "PATCH"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
+  { route: "/codex-automations", methods: ["GET"], kind: "json" },
+  { route: "/config", methods: ["GET", "PATCH"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/coven-calls", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/coven-memory", methods: ["GET"], kind: "json" },
+  { route: "/coven-status", methods: ["GET"], kind: "json" },
+  { route: "/coven/exec", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/daemon/start", methods: ["POST"], kind: "json" },
+  { route: "/daemon/status", methods: ["GET"], kind: "json" },
+  { route: "/escalations/[id]", methods: ["PATCH"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/escalations", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/familiars/[id]/icon", methods: ["PUT"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
+  { route: "/familiars", methods: ["GET"], kind: "json" },
+  { route: "/github/activity", methods: ["GET"], kind: "json" },
+  { route: "/github/assigned", methods: ["GET"], kind: "json" },
+  { route: "/github/pat", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
+  { route: "/github/tasks", methods: ["GET"], kind: "json" },
+  { route: "/harnesses", methods: ["GET"], kind: "json" },
+  { route: "/inbox/[id]/dismiss", methods: ["POST"], kind: "json" },
+  { route: "/inbox/[id]/done", methods: ["POST"], kind: "json" },
+  { route: "/inbox/[id]", methods: ["PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/inbox/[id]/snooze", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/inbox/prefs", methods: ["GET", "PATCH"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/inbox", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
+  { route: "/inbox/stream", methods: ["GET"], kind: "stream" },
+  { route: "/launch", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/library/all", methods: ["GET"], kind: "json" },
+  { route: "/library/bookmarks", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true },
+  { route: "/library/doc", methods: ["GET"], kind: "json", pathGuard: true },
+  { route: "/library/github", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true },
+  { route: "/library/reading", methods: ["GET", "POST", "PATCH", "DELETE"], kind: "json", readsJson: true },
+  { route: "/library/route-link", methods: ["POST"], kind: "json", readsJson: true },
+  { route: "/library", methods: ["GET"], kind: "json" },
+  { route: "/marketplace", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/memory/file", methods: ["GET"], kind: "json", pathGuard: true },
+  { route: "/memory/inspector", methods: ["GET"], kind: "json" },
+  { route: "/memory", methods: ["GET"], kind: "json" },
+  { route: "/onboarding/setup", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
+  { route: "/onboarding/status", methods: ["GET"], kind: "json" },
+  { route: "/openclaw-agents", methods: ["GET"], kind: "json" },
+  { route: "/project-file", methods: ["GET"], kind: "json", pathGuard: true },
+  { route: "/project-tree", methods: ["GET"], kind: "json", pathGuard: true },
+  { route: "/roles", methods: ["GET", "POST"], kind: "json", readsJson: true },
+  { route: "/salem", methods: ["GET", "POST"], kind: "json", readsJson: true },
+  { route: "/sessions/[id]/events", methods: ["GET"], kind: "json" },
+  { route: "/sessions/[id]/input", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/sessions/[id]/kill", methods: ["POST"], kind: "json" },
+  { route: "/sessions/[id]", methods: ["PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/sessions/list", methods: ["GET"], kind: "json" },
+  { route: "/sessions/prune", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
+  { route: "/sessions", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/skills/eval-loop/[familiarId]", methods: ["GET"], kind: "json" },
+  { route: "/skills/eval-loop/[familiarId]/run", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
+  { route: "/skills/local", methods: ["GET"], kind: "json" },
+  { route: "/skills", methods: ["GET"], kind: "json" },
+  { route: "/vault", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
+];
+
+function walkRoutes(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) found.push(...walkRoutes(full));
+    if (stat.isFile() && entry === "route.ts") found.push(full);
+  }
+  return found.sort();
+}
+
+function routeFromFile(file: string): string {
+  const rel = path.relative(apiRoot, path.dirname(file));
+  return "/" + rel.split(path.sep).join("/");
+}
+
+function exportedMethods(source: string): string[] {
+  return [...source.matchAll(/export async function (GET|POST|PUT|PATCH|DELETE)\b/g)].map((match) => match[1]);
+}
+
+function usesJsonResponse(source: string): boolean {
+  return /NextResponse\.json|Response\.json|new Response\(/.test(source);
+}
+
+const routeFiles = walkRoutes(apiRoot);
+const actualRoutes = routeFiles.map(routeFromFile).sort();
+const contractRoutes = contracts.map((contract) => contract.route).sort();
+
+assert.deepEqual(actualRoutes, contractRoutes, "every src/app/api route must have an API contract entry");
+
+for (const contract of contracts) {
+  const file = path.join(apiRoot, ...contract.route.slice(1).split("/"), "route.ts");
+  const source = readFileSync(file, "utf8");
+
+  assert.deepEqual(exportedMethods(source), contract.methods, `${contract.route} HTTP method exports changed`);
+  assert.equal(usesJsonResponse(source), true, `${contract.route} must return an explicit Response/NextResponse`);
+
+  const readsJson = /req\.json\(\)/.test(source);
+  assert.equal(readsJson, contract.readsJson === true, `${contract.route} req.json() contract changed`);
+
+  if (contract.invalidJson === "guarded") {
+    assert.match(source, /invalid json|invalid JSON/, `${contract.route} must preserve invalid-JSON handling`);
+  }
+  if (contract.invalidJson === "fallback-empty") {
+    assert.match(source, /let body:[\s\S]{0,160}=\s*\{\}/, `${contract.route} must initialize an optional request body`);
+    assert.match(source, /try\s*\{[\s\S]{0,120}req\.json\(\)[\s\S]{0,80}\}\s*catch\s*\{/, `${contract.route} must preserve optional-body malformed JSON fallback`);
+  }
+  if (contract.invalidJson === "legacy-unhandled") {
+    assert.doesNotMatch(source, /invalid json|invalid JSON/, `${contract.route} legacy invalid-JSON behavior changed`);
+  }
+  if (contract.pathGuard) {
+    assert.match(source, /path not allowed|collection path not allowed/, `${contract.route} must preserve path-deny errors`);
+    assert.match(source, /status:\s*403/, `${contract.route} path guard must preserve 403 response`);
+  }
+  if (contract.localOriginGuard) {
+    assert.match(source, /isLocalOrigin/, `${contract.route} must preserve local-origin guard`);
+    assert.match(source, /status:\s*403/, `${contract.route} local-origin guard must preserve 403 response`);
+  }
+}
+
+const packageJson = JSON.parse(readFileSync(path.join(root, "package.json"), "utf8"));
+assert.match(packageJson.scripts?.["test:api"] ?? "", /api-contracts\.test\.ts/, "package.json must expose this API contract suite");
+
+console.log(`api-contracts.test.ts: ${contracts.length} route contracts passed`);


### PR DESCRIPTION
## Summary
- Add a `pnpm test:api` contract suite that tracks all Next API routes, exported methods, response shape expectations, JSON parsing behavior, and path/local-origin guards.
- Wire the contract suite into CI before the flaky-retried Next build step.
- Add an optional `pnpm test:api:http` smoke script for checking a running local server's key API guardrails.

## Validation
- `pnpm test:api`
- `git diff --cached --check`
