### PR TITLE
feat(memory): expose file source metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "mobile:tailscale": "bash scripts/mobile-tailscale.sh",
     "build": "next build",
     "typecheck": "tsc --noEmit",
-    "test:api": "node --experimental-strip-types src/app/api/api-contracts.test.ts && node --experimental-strip-types src/app/api/board/enrich-steps/route.test.ts && node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts && node --experimental-strip-types src/app/api/library/route-link/route.test.ts && node --experimental-strip-types src/lib/server/memory-file-paths.test.ts",
+    "test:api": "node --experimental-strip-types src/app/api/api-contracts.test.ts && node --experimental-strip-types src/app/api/board/enrich-steps/route.test.ts && node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts && node --experimental-strip-types src/app/api/library/route-link/route.test.ts && node --experimental-strip-types src/lib/server/memory-file-sources.test.ts && node --experimental-strip-types src/lib/server/memory-file-paths.test.ts",
     "test:api:http": "node scripts/api-http-smoke.mjs",
     "start": "next start"
   },

--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -3,25 +3,13 @@ import { readFile, readdir, stat } from "node:fs/promises";
 import path from "node:path";
 import { homedir } from "node:os";
 import { parseMemorySourceContext } from "@/lib/memory-source-context";
+import {
+  classifyMemoryFilePath,
+  memoryFileSourcesForHome,
+  type MemorySourceKind,
+} from "@/lib/server/memory-file-sources";
 
 export const dynamic = "force-dynamic";
-
-const SHARED_MEMORY_ROOTS: Array<{ id: string; label: string; path: string }> = [
-  {
-    id: "workspace",
-    label: "Workspace memory",
-    path: path.join(homedir(), ".openclaw", "workspace", "memory"),
-  },
-  {
-    id: "coven",
-    label: "Coven memory",
-    path: path.join(homedir(), ".coven", "memory"),
-  },
-];
-
-const MEMORY_INDEX_FILES = [
-  path.join(homedir(), ".openclaw", "workspace", "MEMORY.md"),
-];
 
 export type MemoryEntry = {
   root: string;
@@ -30,6 +18,13 @@ export type MemoryEntry = {
   fullPath: string;
   size: number;
   modified: string;
+  sourceId: string;
+  sourceKind: MemorySourceKind;
+  sourceKindLabel: string;
+  rootPath: string;
+  origin?: "coven";
+  harnessId?: string;
+  runtimeId?: string;
   sourceContext?: string;
   /** Familiar id when this entry belongs to a specific agent workspace */
   familiarId?: string;
@@ -45,11 +40,8 @@ async function readSourceContext(filePath: string): Promise<string | undefined> 
 
 async function walk(
   dir: string,
-  root: string,
-  rootLabel: string,
   acc: MemoryEntry[],
   baseDir: string,
-  familiarId?: string,
 ) {
   let items;
   try {
@@ -61,20 +53,29 @@ async function walk(
     if (item.name.startsWith(".")) continue;
     const full = path.join(dir, item.name);
     if (item.isDirectory()) {
-      await walk(full, root, rootLabel, acc, baseDir, familiarId);
+      await walk(full, acc, baseDir);
     } else if (item.isFile() && /\.(md|markdown|txt|json)$/i.test(item.name)) {
       try {
         const s = await stat(full);
+        const classification = classifyMemoryFilePath(full);
+        if (!classification) continue;
         const sourceContext = await readSourceContext(full);
         acc.push({
-          root,
-          rootLabel,
+          root: classification.root,
+          rootLabel: classification.rootLabel,
           relPath: path.relative(baseDir, full),
           fullPath: full,
           size: s.size,
           modified: s.mtime.toISOString(),
+          sourceId: classification.sourceId,
+          sourceKind: classification.sourceKind,
+          sourceKindLabel: classification.sourceKindLabel,
+          rootPath: classification.rootPath,
+          ...(classification.origin ? { origin: classification.origin } : {}),
+          ...(classification.harnessId ? { harnessId: classification.harnessId } : {}),
+          ...(classification.runtimeId ? { runtimeId: classification.runtimeId } : {}),
           ...(sourceContext ? { sourceContext } : {}),
-          ...(familiarId ? { familiarId } : {}),
+          ...(classification.familiarId ? { familiarId: classification.familiarId } : {}),
         });
       } catch {
         /* skip */
@@ -99,53 +100,69 @@ async function scanFamiliarWorkspaces(acc: MemoryEntry[]) {
     const indexFile = path.join(workspacesDir, familiarId, "MEMORY.md");
     try {
       const s = await stat(/* turbopackIgnore: true */ indexFile);
+      const classification = classifyMemoryFilePath(indexFile);
+      if (!classification) continue;
       const sourceContext = await readSourceContext(indexFile);
       acc.push({
-        root: `familiar:${familiarId}`,
-        rootLabel: familiarId,
+        root: classification.root,
+        rootLabel: classification.rootLabel,
         relPath: "MEMORY.md",
         fullPath: indexFile,
         size: s.size,
         modified: s.mtime.toISOString(),
+        sourceId: classification.sourceId,
+        sourceKind: classification.sourceKind,
+        sourceKindLabel: classification.sourceKindLabel,
+        rootPath: classification.rootPath,
+        ...(classification.harnessId ? { harnessId: classification.harnessId } : {}),
         ...(sourceContext ? { sourceContext } : {}),
-        familiarId,
+        familiarId: classification.familiarId ?? familiarId,
       });
     } catch {
       /* no MEMORY.md for this familiar */
     }
-    await walk(memDir, `familiar:${familiarId}`, familiarId, acc, memDir, familiarId);
+    await walk(memDir, acc, memDir);
   }
 }
 
 export async function GET() {
   const entries: MemoryEntry[] = [];
 
-  // Shared workspace/coven memory dirs
-  for (const root of SHARED_MEMORY_ROOTS) {
-    await walk(root.path, root.id, root.label, entries, root.path);
+  for (const source of memoryFileSourcesForHome()) {
+    try {
+      const s = await stat(/* turbopackIgnore: true */ source.rootPath);
+      if (s.isDirectory()) {
+        await walk(source.rootPath, entries, source.rootPath);
+        continue;
+      }
+      if (!s.isFile()) continue;
+      const classification = classifyMemoryFilePath(source.rootPath);
+      if (!classification) continue;
+      const sourceContext = await readSourceContext(source.rootPath);
+      entries.push({
+        root: classification.root,
+        rootLabel: classification.rootLabel,
+        relPath: path.basename(source.rootPath),
+        fullPath: source.rootPath,
+        size: s.size,
+        modified: s.mtime.toISOString(),
+        sourceId: classification.sourceId,
+        sourceKind: classification.sourceKind,
+        sourceKindLabel: classification.sourceKindLabel,
+        rootPath: classification.rootPath,
+        ...(classification.origin ? { origin: classification.origin } : {}),
+        ...(classification.harnessId ? { harnessId: classification.harnessId } : {}),
+        ...(classification.runtimeId ? { runtimeId: classification.runtimeId } : {}),
+        ...(sourceContext ? { sourceContext } : {}),
+      });
+    } catch {
+      /* missing memory source */
+      continue;
+    }
   }
 
   // Per-familiar agent workspace memory dirs
   await scanFamiliarWorkspaces(entries);
-
-  // Top-level shared MEMORY.md index
-  for (const idx of MEMORY_INDEX_FILES) {
-    try {
-      const s = await stat(/* turbopackIgnore: true */ idx);
-      const sourceContext = await readSourceContext(idx);
-      entries.push({
-        root: "index",
-        rootLabel: "Index",
-        relPath: path.basename(idx),
-        fullPath: idx,
-        size: s.size,
-        modified: s.mtime.toISOString(),
-        ...(sourceContext ? { sourceContext } : {}),
-      });
-    } catch {
-      /* missing */
-    }
-  }
 
   entries.sort((a, b) => (a.modified < b.modified ? 1 : -1));
   return NextResponse.json({ ok: true, entries });

--- a/src/components/agents-memory-view-sources.test.ts
+++ b/src/components/agents-memory-view-sources.test.ts
@@ -1,0 +1,31 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("./agents-memory-view.tsx", import.meta.url), "utf8");
+
+assert.match(
+  source,
+  /sourceKind:\s*"coven-origin"\s*\|\s*"external-harness"\s*\|\s*"runtime"/,
+  "AgentsMemoryView should accept memory API source-kind metadata",
+);
+
+assert.match(
+  source,
+  /sourceKindLabel/,
+  "AgentsMemoryView should render a human label for native, harness, and runtime memory sources",
+);
+
+assert.match(
+  source,
+  /External harnesses/,
+  "AgentsMemoryView should separately count external harness memory files",
+);
+
+assert.match(
+  source,
+  /Runtime memory/,
+  "AgentsMemoryView should separately count runtime memory files",
+);
+
+console.log("agents-memory-view-sources.test.ts: ok");

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -8,14 +8,22 @@ import { buildMemoryGraphModel, resolveMemoryFamiliarFilter } from "@/lib/memory
 import type { MemoryGraphMemoryNode } from "@/lib/memory-graph-3d-model";
 import type { CovenMemoryEntry } from "@/components/agents-view-stats";
 
-type FileMemoryEntry = {
+export type FileMemoryEntry = {
   root: string;
   rootLabel: string;
   relPath: string;
   fullPath: string;
   size: number;
   modified: string;
+  sourceId: string;
+  sourceKind: "coven-origin" | "external-harness" | "runtime";
+  sourceKindLabel: string;
+  rootPath: string;
+  origin?: "coven";
+  harnessId?: string;
+  runtimeId?: string;
   sourceContext?: string;
+  familiarId?: string;
 };
 
 type Props = {
@@ -67,6 +75,11 @@ function memoryMatches(entry: CovenMemoryEntry | FileMemoryEntry, query: string)
   }
   return [
     entry.rootLabel,
+    entry.sourceKindLabel,
+    entry.harnessId ?? "",
+    entry.runtimeId ?? "",
+    entry.origin ?? "",
+    entry.familiarId ?? "",
     entry.relPath,
     entry.fullPath,
     entry.sourceContext ?? "",
@@ -143,6 +156,12 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
     const ids = new Set(covenEntries.map((entry) => entry.familiar_id));
     return familiars.filter((familiar) => ids.has(familiar.id));
   }, [covenEntries, familiars]);
+
+  const fileSourceCounts = useMemo(() => ({
+    covenOrigin: fileEntries.filter((entry) => entry.sourceKind === "coven-origin").length,
+    externalHarnesses: fileEntries.filter((entry) => entry.sourceKind === "external-harness").length,
+    runtimeMemory: fileEntries.filter((entry) => entry.sourceKind === "runtime").length,
+  }), [fileEntries]);
 
   useEffect(() => {
     const next = resolveMemoryFamiliarFilter({
@@ -232,18 +251,22 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
           </div>
         </div>
 
-        <div className="mt-3 grid gap-2 sm:grid-cols-3">
+        <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
           <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
             <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">Agent memories</div>
             <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{visibleCoven.length}</div>
           </div>
           <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
-            <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">Memory files</div>
-            <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{fileEntries.length}</div>
+            <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">Coven origin</div>
+            <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{fileSourceCounts.covenOrigin}</div>
           </div>
           <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
-            <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">Agents with memory</div>
-            <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{familiarsWithMemory.length}</div>
+            <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">External harnesses</div>
+            <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{fileSourceCounts.externalHarnesses}</div>
+          </div>
+          <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
+            <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">Runtime memory</div>
+            <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{fileSourceCounts.runtimeMemory}</div>
           </div>
         </div>
 
@@ -527,8 +550,16 @@ export function MemoryFilesList({ entries, onOpen, loaded, error, limit }: Memor
                 <span className="min-w-0 flex-1">
                   <span className="block truncate text-[12px] text-[var(--text-primary)]">{entry.relPath}</span>
                   <span className="mt-0.5 block truncate font-mono text-[10px] text-[var(--text-muted)]">
-                    {entry.rootLabel} · {compactPath(entry.fullPath)}
+                    {entry.sourceKindLabel} · {entry.rootLabel} · {compactPath(entry.fullPath)}
                   </span>
+                  {(entry.harnessId || entry.runtimeId || entry.origin || entry.familiarId) ? (
+                    <span className="mt-1 flex flex-wrap gap-1 text-[10px] text-[var(--text-muted)]">
+                      {entry.origin ? <span className="rounded bg-[var(--bg-elevated)] px-1 py-0.5">origin:{entry.origin}</span> : null}
+                      {entry.harnessId ? <span className="rounded bg-[var(--bg-elevated)] px-1 py-0.5">harness:{entry.harnessId}</span> : null}
+                      {entry.runtimeId ? <span className="rounded bg-[var(--bg-elevated)] px-1 py-0.5">runtime:{entry.runtimeId}</span> : null}
+                      {entry.familiarId ? <span className="rounded bg-[var(--bg-elevated)] px-1 py-0.5">familiar:{entry.familiarId}</span> : null}
+                    </span>
+                  ) : null}
                 </span>
                 <span className="shrink-0 text-[10px] text-[var(--text-muted)]">{age(entry.modified)}</span>
               </button>

--- a/src/components/agents-view.tsx
+++ b/src/components/agents-view.tsx
@@ -4,20 +4,12 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { AgentsMemoryView, MemoryFilesList } from "@/components/agents-memory-view";
+import type { FileMemoryEntry } from "@/components/agents-memory-view";
 import {
   buildAgentCardStats,
   type AgentCardStats,
   type CovenMemoryEntry,
 } from "@/components/agents-view-stats";
-
-type FileMemoryEntry = {
-  root: string;
-  rootLabel: string;
-  relPath: string;
-  fullPath: string;
-  size: number;
-  modified: string;
-};
 
 type CovenMemoryResponse =
   | { ok: true; entries: CovenMemoryEntry[] }

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -100,8 +100,8 @@ assert.match(
 
 assert.match(
   agentsMemoryView,
-  /Agent memories[\s\S]*Memory files[\s\S]*Agents with memory/,
-  "Agents memory view should summarize the focused agent surface and supporting file source",
+  /Agent memories[\s\S]*Coven origin[\s\S]*External harnesses[\s\S]*Runtime memory/,
+  "Agents memory view should summarize native Coven, external harness, and runtime memory sources",
 );
 
 assert.match(

--- a/src/lib/server/memory-file-paths.ts
+++ b/src/lib/server/memory-file-paths.ts
@@ -1,31 +1,5 @@
-import path from "node:path";
-import { homedir } from "node:os";
-
-const OPENCLAW_WORKSPACE_ROOT = path.join(homedir(), ".openclaw", "workspace");
-
-const ALLOWED_ROOTS = [
-  path.join(OPENCLAW_WORKSPACE_ROOT, "memory"),
-  path.join(homedir(), ".coven", "memory"),
-  path.join(OPENCLAW_WORKSPACE_ROOT, "MEMORY.md"),
-];
-
-function isWithinRoot(resolved: string, root: string): boolean {
-  return resolved === root || resolved.startsWith(root + path.sep);
-}
-
-function isAllowedFamiliarMemoryPath(resolved: string): boolean {
-  if (!isWithinRoot(resolved, OPENCLAW_WORKSPACE_ROOT)) return false;
-  const rel = path.relative(OPENCLAW_WORKSPACE_ROOT, resolved);
-  const parts = rel.split(path.sep);
-  if (parts.length < 2 || parts[0] === ".." || parts[0] === "") return false;
-  if (parts.length === 2 && parts[1] === "MEMORY.md") return true;
-  return parts.length >= 3 && parts[1] === "memory";
-}
+import { isMemoryFilePathAllowed } from "./memory-file-sources.ts";
 
 export function isAllowedMemoryFilePath(fullPath: string): boolean {
-  const resolved = path.resolve(fullPath);
-  return (
-    ALLOWED_ROOTS.some((root) => isWithinRoot(resolved, root)) ||
-    isAllowedFamiliarMemoryPath(resolved)
-  );
+  return isMemoryFilePathAllowed(fullPath);
 }

--- a/src/lib/server/memory-file-sources.test.ts
+++ b/src/lib/server/memory-file-sources.test.ts
@@ -1,0 +1,76 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import path from "node:path";
+import {
+  classifyMemoryFilePath,
+  memoryFileSourcesForHome,
+} from "./memory-file-sources.ts";
+
+const home = "/Users/val";
+const sources = memoryFileSourcesForHome(home);
+
+assert.deepEqual(
+  sources.map((source) => ({
+    id: source.id,
+    kind: source.kind,
+    label: source.label,
+    rootPath: source.rootPath,
+  })),
+  [
+    {
+      id: "coven-origin",
+      kind: "coven-origin",
+      label: "Coven native memory",
+      rootPath: path.join(home, ".coven", "memory"),
+    },
+    {
+      id: "openclaw-workspace",
+      kind: "external-harness",
+      label: "OpenClaw harness memory",
+      rootPath: path.join(home, ".openclaw", "workspace", "memory"),
+    },
+    {
+      id: "openclaw-index",
+      kind: "external-harness",
+      label: "OpenClaw workspace index",
+      rootPath: path.join(home, ".openclaw", "workspace", "MEMORY.md"),
+    },
+    {
+      id: "codex-runtime",
+      kind: "runtime",
+      label: "Codex runtime memory",
+      rootPath: path.join(home, ".codex", "memories"),
+    },
+  ],
+  "memory file sources should separate native Coven origin memory from external harness and runtime roots",
+);
+
+const native = classifyMemoryFilePath(path.join(home, ".coven", "memory", "nova.md"), home);
+assert.equal(native?.kind, "coven-origin");
+assert.equal(native?.origin, "coven");
+assert.equal(native?.root, "coven-origin");
+assert.equal(native?.rootLabel, "Coven native memory");
+
+const familiar = classifyMemoryFilePath(
+  path.join(home, ".openclaw", "workspace", "echo", "memory", "failure.md"),
+  home,
+);
+assert.equal(familiar?.kind, "external-harness");
+assert.equal(familiar?.harnessId, "openclaw");
+assert.equal(familiar?.familiarId, "echo");
+assert.equal(familiar?.root, "familiar:echo");
+assert.equal(familiar?.rootLabel, "Echo harness memory");
+
+const runtime = classifyMemoryFilePath(path.join(home, ".codex", "memories", "MEMORY.md"), home);
+assert.equal(runtime?.kind, "runtime");
+assert.equal(runtime?.runtimeId, "codex");
+assert.equal(runtime?.root, "codex-runtime");
+assert.equal(runtime?.rootLabel, "Codex runtime memory");
+
+assert.equal(
+  classifyMemoryFilePath(path.join(home, ".ssh", "config"), home),
+  null,
+  "unrelated local files should not be treated as memory API sources",
+);
+
+console.log("memory-file-sources.test.ts: ok");

--- a/src/lib/server/memory-file-sources.ts
+++ b/src/lib/server/memory-file-sources.ts
@@ -1,0 +1,137 @@
+import path from "node:path";
+import { homedir } from "node:os";
+
+export type MemorySourceKind = "coven-origin" | "external-harness" | "runtime";
+
+export type MemoryFileSource = {
+  id: string;
+  kind: MemorySourceKind;
+  label: string;
+  rootPath: string;
+  root: string;
+  rootLabel: string;
+  origin?: "coven";
+  harnessId?: string;
+  runtimeId?: string;
+};
+
+export type MemoryFileClassification = {
+  sourceId: string;
+  sourceKind: MemorySourceKind;
+  sourceKindLabel: string;
+  kind: MemorySourceKind;
+  root: string;
+  rootLabel: string;
+  rootPath: string;
+  origin?: "coven";
+  harnessId?: string;
+  runtimeId?: string;
+  familiarId?: string;
+};
+
+function isWithinRoot(resolved: string, root: string): boolean {
+  return resolved === root || resolved.startsWith(root + path.sep);
+}
+
+function displayId(id: string): string {
+  return id
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join(" ") || id;
+}
+
+function sourceKindLabel(kind: MemorySourceKind): string {
+  if (kind === "coven-origin") return "Coven origin";
+  if (kind === "external-harness") return "External harness";
+  return "Runtime";
+}
+
+export function memoryFileSourcesForHome(home = homedir()): MemoryFileSource[] {
+  const openclawWorkspace = path.join(home, ".openclaw", "workspace");
+  return [
+    {
+      id: "coven-origin",
+      kind: "coven-origin",
+      label: "Coven native memory",
+      rootPath: path.join(home, ".coven", "memory"),
+      root: "coven-origin",
+      rootLabel: "Coven native memory",
+      origin: "coven",
+    },
+    {
+      id: "openclaw-workspace",
+      kind: "external-harness",
+      label: "OpenClaw harness memory",
+      rootPath: path.join(openclawWorkspace, "memory"),
+      root: "workspace",
+      rootLabel: "OpenClaw harness memory",
+      harnessId: "openclaw",
+    },
+    {
+      id: "openclaw-index",
+      kind: "external-harness",
+      label: "OpenClaw workspace index",
+      rootPath: path.join(openclawWorkspace, "MEMORY.md"),
+      root: "index",
+      rootLabel: "OpenClaw workspace index",
+      harnessId: "openclaw",
+    },
+    {
+      id: "codex-runtime",
+      kind: "runtime",
+      label: "Codex runtime memory",
+      rootPath: path.join(home, ".codex", "memories"),
+      root: "codex-runtime",
+      rootLabel: "Codex runtime memory",
+      runtimeId: "codex",
+    },
+  ];
+}
+
+export function classifyMemoryFilePath(fullPath: string, home = homedir()): MemoryFileClassification | null {
+  const resolved = path.resolve(/* turbopackIgnore: true */ fullPath);
+  for (const source of memoryFileSourcesForHome(home)) {
+    const rootPath = path.resolve(/* turbopackIgnore: true */ source.rootPath);
+    if (!isWithinRoot(resolved, rootPath)) continue;
+    return {
+      sourceId: source.id,
+      sourceKind: source.kind,
+      sourceKindLabel: sourceKindLabel(source.kind),
+      kind: source.kind,
+      root: source.root,
+      rootLabel: source.rootLabel,
+      rootPath,
+      ...(source.origin ? { origin: source.origin } : {}),
+      ...(source.harnessId ? { harnessId: source.harnessId } : {}),
+      ...(source.runtimeId ? { runtimeId: source.runtimeId } : {}),
+    };
+  }
+
+  const openclawWorkspace = path.resolve(
+    /* turbopackIgnore: true */ path.join(home, ".openclaw", "workspace"),
+  );
+  if (!isWithinRoot(resolved, openclawWorkspace)) return null;
+  const rel = path.relative(openclawWorkspace, resolved);
+  const parts = rel.split(path.sep);
+  const familiarId = parts[0];
+  if (!familiarId || familiarId === ".." || familiarId === "memory" || familiarId === "MEMORY.md") return null;
+  const isFamiliarIndex = parts.length === 2 && parts[1] === "MEMORY.md";
+  const isFamiliarMemory = parts.length >= 3 && parts[1] === "memory";
+  if (!isFamiliarIndex && !isFamiliarMemory) return null;
+  return {
+    sourceId: "openclaw-familiar",
+    sourceKind: "external-harness",
+    sourceKindLabel: "External harness",
+    kind: "external-harness",
+    root: `familiar:${familiarId}`,
+    rootLabel: `${displayId(familiarId)} harness memory`,
+    rootPath: path.join(openclawWorkspace, familiarId),
+    harnessId: "openclaw",
+    familiarId,
+  };
+}
+
+export function isMemoryFilePathAllowed(fullPath: string, home = homedir()): boolean {
+  return classifyMemoryFilePath(fullPath, home) !== null;
+}


### PR DESCRIPTION
## Summary
- Classify memory files by provenance source: Coven native origin, OpenClaw harness/familiar memory, and Codex runtime memory.
- Preserve source metadata through `/api/memory`, the Agents memory view, file search, and memory file list badges.
- Extend `pnpm test:api` with direct coverage for memory source classification.

## Validation
- `pnpm test:api`
- `node --experimental-strip-types src/components/agents-memory-view-sources.test.ts`
- `node --experimental-strip-types src/components/chat-surface.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `git diff --cached --check`
