### PR TITLE
feat(a11y): improve focus and aria coverage

### DIFF
--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -16,6 +16,7 @@ import { Icon } from "@/lib/icon";
 import type { IconName } from "@/lib/icon";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 
 const DEFAULT_TIMEOUT_MS = 2 * 60 * 60 * 1000;
 
@@ -735,6 +736,9 @@ export function BoardInspector({ card, familiars, sessions, onClose, onPatch, on
 
   const close = () => { setClosing(true); setTimeout(onClose, 180); };
 
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  useFocusTrap(!closing, dialogRef, { onEscape: close });
+
   useEffect(() => {
     const h = (e: KeyboardEvent) => { if (e.key === "Escape") close(); };
     document.addEventListener("keydown", h);
@@ -767,7 +771,7 @@ export function BoardInspector({ card, familiars, sessions, onClose, onPatch, on
   return (
     <>
       <div className="board-drawer-backdrop" onClick={close} />
-      <div className={`board-drawer${closing ? " board-drawer--closing" : ""}`} role="dialog" aria-modal aria-label="Card inspector">
+      <div ref={dialogRef} className={`board-drawer${closing ? " board-drawer--closing" : ""}`} role="dialog" aria-modal aria-label="Card inspector" tabIndex={-1}>
         <div className="board-drawer-header">
           <input
             className="board-drawer-title-input"

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -995,6 +995,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               placeholder={busy ? "Streaming… (esc to cancel)" : `Message ${familiar.display_name}…`}
               rows={1}
               className="w-full resize-none bg-transparent px-4 pt-3 pb-2 text-sm leading-6 text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)]"
+              aria-label="Message"
             />
             <div className="flex items-center justify-between px-3 pb-2.5">
               <div className="flex items-center gap-1 text-[var(--text-muted)]">

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -870,7 +870,13 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         />
       </header>
       <div ref={scrollRef} className="cave-chat-transcript relative min-h-0 flex-1 overflow-y-auto">
-        <div className="cave-chat-thread">
+        <div
+          className="cave-chat-thread"
+          role="log"
+          aria-live="polite"
+          aria-relevant="additions"
+          aria-label="Conversation"
+        >
           {turns.length === 0 ? (
             historyState === "loading" ? (
               <ChatHistoryNotice title="Loading chat history" body="Restoring this session transcript..." />

--- a/src/components/command-palette.test.ts
+++ b/src/components/command-palette.test.ts
@@ -1,0 +1,39 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./command-palette.tsx", import.meta.url),
+  "utf8",
+);
+
+// Input is labelled.
+assert.match(
+  source,
+  /<input[\s\S]*?(aria-label|aria-labelledby)=/,
+  "command palette input has an accessible name",
+);
+
+// Results container is a listbox.
+assert.match(source, /role="listbox"/, "results container has role=listbox");
+
+// Items have role=option.
+assert.match(source, /role="option"/, "each result item has role=option");
+
+// Input is linked to listbox via aria-controls.
+assert.match(source, /aria-controls=/, "input is linked to results via aria-controls");
+
+// Active item announced via aria-activedescendant on input.
+assert.match(source, /aria-activedescendant=/, "input uses aria-activedescendant for selection");
+
+// The non-standard aria-current="true" pattern on result items is gone.
+const optionBlocks = source.match(/role="option"[\s\S]{0,300}/g) ?? [];
+for (const block of optionBlocks) {
+  assert.doesNotMatch(
+    block,
+    /aria-current="true"/,
+    "result items no longer use aria-current=true (use aria-selected via activedescendant)",
+  );
+}
+
+console.log("command-palette.test.ts OK");

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -5,6 +5,7 @@ import type { Familiar, SessionRow } from "@/lib/types";
 import { SLASH_COMMANDS } from "@/lib/slash-commands";
 import { Icon } from "@/lib/icon";
 import { platformizeHint, useKeySymbols } from "@/lib/platform-keys";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 
 type PaletteIntent =
   | { kind: "switch-familiar"; familiarId: string }
@@ -84,7 +85,10 @@ export function CommandPalette({
   const [covenMemory, setCovenMemory] = useState<CovenMemoryEntry[]>([]);
   const [fsMemory, setFsMemory] = useState<FsMemoryEntry[]>([]);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
   const keys = useKeySymbols();
+
+  useFocusTrap(open, dialogRef, { onEscape: onClose });
 
   // Fetch the searchable corpora once on first open. Cheap calls; refreshed
   // every time the palette opens so the index doesn't go stale.
@@ -114,18 +118,6 @@ export function CommandPalette({
 
     return () => clearTimeout(t);
   }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onClose();
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
 
   const rows: Row[] = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -303,10 +295,12 @@ export function CommandPalette({
       style={{ animation: "ui-modal-fade-in var(--duration-fast) var(--ease-decelerate)" }}
     >
       <div
+        ref={dialogRef}
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
         aria-label="Command palette"
+        tabIndex={-1}
         className="mt-[12vh] w-[640px] max-w-[92vw] overflow-hidden rounded-2xl border border-[var(--border-strong)] bg-[var(--bg-elevated)] shadow-2xl"
         style={{ animation: "ui-modal-enter var(--duration-base) var(--ease-decelerate)" }}
       >

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -313,20 +313,35 @@ export function CommandPalette({
           }}
           onKeyDown={onComposerKey}
           placeholder="Search familiars · chats · cards · memory · commands…"
+          aria-label="Search and jump to anything"
+          aria-controls="command-palette-listbox"
+          aria-activedescendant={
+            rows.length > 0 ? `command-palette-option-${activeIdx}` : undefined
+          }
           className="focus-ring-inset w-full border-b border-[var(--border-hairline)] bg-transparent px-4 py-3 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"
         />
-        <ul className="max-h-[60vh] overflow-y-auto py-1">
+        <ul
+          id="command-palette-listbox"
+          role="listbox"
+          className="max-h-[60vh] overflow-y-auto py-1"
+        >
           {rows.length === 0 ? (
-            <li className="px-4 py-6 text-center text-xs text-[var(--text-muted)]">No matches.</li>
+            <li role="presentation" className="px-4 py-6 text-center text-xs text-[var(--text-muted)]">No matches.</li>
           ) : null}
           {rows.map((row, i) => {
             const active = i === activeIdx;
             return (
-              <li key={row.id}>
+              <li
+                key={row.id}
+                role="option"
+                id={`command-palette-option-${i}`}
+                aria-selected={active}
+              >
                 <button
+                  type="button"
+                  tabIndex={-1}
                   onMouseEnter={() => setActiveIdx(i)}
                   onClick={() => fire(row)}
-                  aria-current={active ? "true" : undefined}
                   className={`focus-ring-inset flex w-full items-center gap-3 border-l-2 px-4 py-2 text-left text-sm transition-colors ${
                     active
                       ? "border-l-[var(--accent-presence)] bg-[var(--bg-hover)]"

--- a/src/components/familiar-avatar-rail.tsx
+++ b/src/components/familiar-avatar-rail.tsx
@@ -18,6 +18,7 @@ type Props = {
   onSelect: (id: string) => void;
   onAddFamiliar: () => void;
   onToggleSidebar: () => void;
+  sidebarOpen?: boolean;
 };
 
 export function FamiliarAvatarRail({
@@ -29,6 +30,7 @@ export function FamiliarAvatarRail({
   onSelect,
   onAddFamiliar,
   onToggleSidebar,
+  sidebarOpen,
 }: Props) {
   const { openFamiliarStudio, openFamiliarStudioListView } = useFamiliarStudio();
 
@@ -231,6 +233,7 @@ export function FamiliarAvatarRail({
         type="button"
         className="familiar-avatar-rail__toggle"
         aria-label="Toggle sidebar"
+        aria-expanded={sidebarOpen ?? true}
         title="Toggle sidebar (⌘B)"
         onClick={onToggleSidebar}
       >

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -241,6 +241,7 @@ export function HomeComposer({
           onChange={(e) => { setText(e.target.value); autoGrow(); }}
           onKeyDown={handleKeyDown}
           disabled={sending}
+          aria-label="Ask anything"
         />
 
         {/* Action bar */}

--- a/src/components/inbox-toast.tsx
+++ b/src/components/inbox-toast.tsx
@@ -40,6 +40,8 @@ export function InboxToastStack({ toasts, onDismiss, onSnooze, onOpen }: Props) 
         <div
           key={t.id}
           role="status"
+          aria-live="polite"
+          aria-atomic="true"
           className="pointer-events-auto rounded-xl border border-[var(--border-strong)] bg-[var(--bg-elevated)] p-3 shadow-2xl"
           style={{ animation: "ui-modal-enter var(--duration-base) var(--ease-decelerate)" }}
         >

--- a/src/components/labels-and-live-regions.test.ts
+++ b/src/components/labels-and-live-regions.test.ts
@@ -1,0 +1,64 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function read(file: string) {
+  return readFileSync(new URL(`./${file}`, import.meta.url), "utf8");
+}
+
+// 1. chat-view.tsx textarea has an accessible name.
+{
+  const src = read("chat-view.tsx");
+  assert.match(
+    src,
+    /<textarea[\s\S]*?aria-label="[^"]+"/,
+    "chat-view textarea has aria-label",
+  );
+}
+
+// 2. home-composer.tsx textarea has an accessible name.
+{
+  const src = read("home-composer.tsx");
+  assert.match(
+    src,
+    /<textarea[\s\S]*?aria-label="[^"]+"/,
+    "home-composer textarea has aria-label",
+  );
+}
+
+// 3. salem-widget.tsx search input has an accessible name.
+{
+  const src = read("salem/salem-widget.tsx");
+  assert.match(
+    src,
+    /<input[\s\S]*?aria-label="[^"]+"/,
+    "salem search input has aria-label",
+  );
+}
+
+// 4. library-doc-list.tsx search input has an accessible name.
+{
+  const src = read("library-doc-list.tsx");
+  assert.match(
+    src,
+    /<input[\s\S]*?aria-label="[^"]+"/,
+    "library doc-list search input has aria-label",
+  );
+}
+
+// 5. chat-view.tsx transcript container is a log with aria-live.
+{
+  const src = read("chat-view.tsx");
+  const threadBlock = src.match(/className="cave-chat-thread"[\s\S]{0,200}/)?.[0] ?? "";
+  assert.match(threadBlock, /role="log"/, "chat thread has role=log");
+  assert.match(threadBlock, /aria-live="polite"/, "chat thread has aria-live=polite");
+}
+
+// 6. inbox-toast.tsx root has aria-live + aria-atomic.
+{
+  const src = read("inbox-toast.tsx");
+  assert.match(src, /aria-live="polite"/, "inbox-toast has aria-live=polite");
+  assert.match(src, /aria-atomic="true"/, "inbox-toast has aria-atomic=true");
+}
+
+console.log("labels-and-live-regions.test.ts OK");

--- a/src/components/library-doc-list.tsx
+++ b/src/components/library-doc-list.tsx
@@ -67,6 +67,7 @@ export function LibraryDocList({
           value={searchQuery}
           onChange={(e) => onSearchChange(e.target.value)}
           spellCheck={false}
+          aria-label="Search documents"
         />
         {searchQuery && (
           <button

--- a/src/components/library-doc-preview.tsx
+++ b/src/components/library-doc-preview.tsx
@@ -13,6 +13,7 @@ import type {
   ReadingStatus,
 } from "@/lib/library-types";
 import type { Skill } from "@/components/library-collection-rail";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 
 // ── Discriminated union ──────────────────────────────────────────
 export type SelectedItem =
@@ -337,6 +338,9 @@ function DocDetail({ doc }: { doc: LibraryDocBody }) {
     setScrollPct(max > 0 ? (el.scrollTop / max) * 100 : 0);
   }
 
+  const readerDialogRef = useRef<HTMLDivElement | null>(null);
+  useFocusTrap(readerOpen, readerDialogRef, { onEscape: () => setReaderOpen(false) });
+
   const [readerScrollPct, setReaderScrollPct] = useState(0);
   function handleReaderScroll() {
     const el = readerBodyRef.current;
@@ -503,11 +507,13 @@ function DocDetail({ doc }: { doc: LibraryDocBody }) {
 
       {readerOpen && typeof document !== "undefined" && createPortal(
         <div
+          ref={readerDialogRef}
           className="library-reader-backdrop"
           onClick={(e) => { if (e.target === e.currentTarget) setReaderOpen(false); }}
           role="dialog"
           aria-modal="true"
           aria-label={`Reader: ${doc.title}`}
+          tabIndex={-1}
         >
           <div className="library-reader-modal">
             {/* Reader scroll progress bar */}

--- a/src/components/library-github-list.tsx
+++ b/src/components/library-github-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Icon } from "@/lib/icon";
 import type { CardGitHubLink, CardStatus } from "@/lib/cave-board-types";
@@ -10,6 +10,7 @@ import {
   mergeLinksWithGitHub,
   mergeTaskGitHubLinks,
 } from "@/lib/task-github";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -125,6 +126,9 @@ function AttachTaskModal({
   const [done, setDone]             = useState<string | null>(null);
   const [err, setErr]               = useState<string | null>(null);
 
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  useFocusTrap(true, dialogRef, { onEscape: onClose });
+
   useEffect(() => {
     void fetch("/api/familiars", { cache: "no-store" })
       .then((r) => r.json())
@@ -204,7 +208,14 @@ function AttachTaskModal({
       className="gh-modal-backdrop"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
-      <div className="gh-modal">
+      <div
+        ref={dialogRef}
+        className="gh-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Attach to Task"
+        tabIndex={-1}
+      >
         <div className="gh-modal-header">
           <Icon name="ph:clipboard-text" width={14} />
           <span>Attach to Task</span>
@@ -321,6 +332,9 @@ function HandoffModal({
   const [done, setDone]             = useState<{ familiar: string; session: string | null } | null>(null);
   const [err, setErr]               = useState<string | null>(null);
 
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  useFocusTrap(true, dialogRef, { onEscape: onClose });
+
   useEffect(() => {
     void fetch("/api/familiars", { cache: "no-store" })
       .then((r) => r.json())
@@ -406,7 +420,14 @@ function HandoffModal({
       className="gh-modal-backdrop"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
-      <div className="gh-modal gh-modal--wide">
+      <div
+        ref={dialogRef}
+        className="gh-modal gh-modal--wide"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Handoff to Agent"
+        tabIndex={-1}
+      >
         <div className="gh-modal-header">
           <Icon name="ph:share-network" width={14} />
           <span>Handoff to Agent</span>

--- a/src/components/misc-aria-fixes.test.ts
+++ b/src/components/misc-aria-fixes.test.ts
@@ -1,0 +1,47 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function read(file: string) {
+  return readFileSync(new URL(`./${file}`, import.meta.url), "utf8");
+}
+
+// 1. Salem perch is a real <button>, not a <div role="button">.
+{
+  const src = read("salem/salem-widget.tsx");
+  assert.doesNotMatch(
+    src,
+    /<div[\s\S]{0,200}role="button"[\s\S]{0,200}salem-perch/,
+    "salem perch must not be a div role=button (use real <button>)",
+  );
+  assert.match(
+    src,
+    /<button[\s\S]{0,200}salem-perch/,
+    "salem perch is a <button> element",
+  );
+}
+
+// 2. Plugin card status: either has aria-label, OR uses visible text only
+//    (in which case the visible text in the span serves as the label).
+{
+  const src = read("plugin-card.tsx");
+  const hasAriaLabel = /aria-label=/.test(src);
+  const visibleText = /Updating/.test(src) && /Installed/.test(src) && /setupLabel\(plugin\)/.test(src);
+  assert.ok(
+    hasAriaLabel || visibleText,
+    "plugin status badge has aria-label or visible text label",
+  );
+}
+
+// 3. Sidebar collapse toggle has aria-expanded.
+{
+  // Try both candidate files.
+  const a = read("sidebar-minimal.tsx");
+  const b = read("familiar-avatar-rail.tsx");
+  assert.ok(
+    /aria-expanded=\{/.test(a) || /aria-expanded=\{/.test(b),
+    "sidebar collapse toggle exposes aria-expanded (in sidebar-minimal.tsx or familiar-avatar-rail.tsx)",
+  );
+}
+
+console.log("misc-aria-fixes.test.ts OK");

--- a/src/components/modal-trap-adoption.test.ts
+++ b/src/components/modal-trap-adoption.test.ts
@@ -1,0 +1,35 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const FILES = [
+  "command-palette.tsx",
+  "board-inspector.tsx",
+  "library-doc-preview.tsx",
+  "library-github-list.tsx",
+  "onboarding-overlay.tsx",
+];
+
+for (const file of FILES) {
+  const source = readFileSync(new URL(`./${file}`, import.meta.url), "utf8");
+
+  assert.match(
+    source,
+    /import\s+\{[^}]*useFocusTrap[^}]*\}\s+from\s+["']@\/lib\/use-focus-trap["']/,
+    `${file} imports useFocusTrap from @/lib/use-focus-trap`,
+  );
+
+  assert.match(
+    source,
+    /useFocusTrap\(/,
+    `${file} calls useFocusTrap(...)`,
+  );
+
+  assert.match(
+    source,
+    /tabIndex=\{-1\}|tabIndex={\s*-1\s*}/,
+    `${file} sets tabIndex={-1} on the dialog/overlay container`,
+  );
+}
+
+console.log("modal-trap-adoption.test.ts OK");

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import type { IconName } from "@/lib/icon";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 
 type PruneState =
   | { idle: true }
@@ -166,6 +167,9 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   const [prune, setPrune] = useState<PruneState>({ idle: true });
   const [statusFailures, setStatusFailures] = useState(0);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+
+  useFocusTrap(open, dialogRef, { onEscape: onDismiss });
 
   const refresh = useCallback(async () => {
     try {
@@ -481,7 +485,14 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50 overflow-y-auto bg-[var(--bg-base)]/96 backdrop-blur-sm">
+    <div
+      ref={dialogRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Onboarding"
+      tabIndex={-1}
+      className="fixed inset-0 z-50 overflow-y-auto bg-[var(--bg-base)]/96 backdrop-blur-sm"
+    >
       <div className="mx-auto flex min-h-full w-full max-w-[min(1680px,100vw)] flex-col px-4 py-5 sm:px-6 lg:px-8">
         <header className="flex flex-col gap-4 border-b border-[var(--border-hairline)] pb-5 lg:flex-row lg:items-end lg:justify-between">
           <div className="max-w-3xl">

--- a/src/components/salem/salem-widget.tsx
+++ b/src/components/salem/salem-widget.tsx
@@ -77,10 +77,10 @@ export function SalemWidget() {
   if (docked) return null;
 
   return (
-    <div className="salem-perch" onClick={open} role="button" tabIndex={0} aria-label="Open Salem docs familiar" onKeyDown={(e) => e.key === "Enter" && open()}>
+    <button type="button" className="salem-perch" onClick={open} aria-label="Open Salem docs familiar">
       <SalemCat3D mood={mood} size={88} />
       <span className="salem-perch__label">Salem</span>
-    </div>
+    </button>
   );
 }
 

--- a/src/components/salem/salem-widget.tsx
+++ b/src/components/salem/salem-widget.tsx
@@ -207,6 +207,7 @@ export function SalemChatPanel() {
           onChange={(e) => { setInput(e.target.value); if (e.target.value) setMood("listening"); else setMood("idle"); }}
           disabled={loading}
           autoFocus
+          aria-label="Search Salem docs"
         />
         <button type="submit" className="salem-panel__send salem-panel__send--label" disabled={loading || !input.trim()} aria-label="Send">
           <span className="salem-panel__send-text">SALEM</span>

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -98,6 +98,7 @@ function ShellInner({
   agent,
   bottom,
   topBar,
+  onNavOpenChange,
 }: {
   familiarRail?: ReactNode;
   nav: ReactNode;
@@ -106,6 +107,7 @@ function ShellInner({
   agent?: ReactNode;
   bottom?: ReactNode;
   topBar?: ReactNode;
+  onNavOpenChange?: (open: boolean) => void;
 }, ref: ForwardedRef<ShellHandle>) {
   const navRef = useRef<PanelImperativeHandle | null>(null);
   const listRef = useRef<PanelImperativeHandle | null>(null);
@@ -166,6 +168,10 @@ function ShellInner({
     const pct = defaultLayout[navPanelIdx];
     return typeof pct !== "number" || pct > 0;
   });
+
+  useEffect(() => {
+    onNavOpenChange?.(navOpen);
+  }, [navOpen, onNavOpenChange]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -69,6 +69,7 @@ export function Workspace() {
   const nextRouter = useRouter();
   const routerRef = useRef<ChatRouterHandle | null>(null);
   const shellRef = useRef<ShellHandle | null>(null);
+  const [navOpen, setNavOpen] = useState(true);
   const [activeId, setActiveId] = useState<string | null>(() => getActiveFamiliar());
   const [familiars, setFamiliars] = useState<Familiar[]>([]);
   const resolvedFamiliars = useResolvedFamiliars(familiars);
@@ -1042,6 +1043,7 @@ export function Workspace() {
     <FamiliarStudioProvider>
       <Shell
         ref={shellRef}
+        onNavOpenChange={setNavOpen}
         topBar={
           <TopBar
             surfaceLabel={surfaceLabel}
@@ -1069,6 +1071,7 @@ export function Workspace() {
             onSelect={selectFamiliar}
             onAddFamiliar={openOnboarding}
             onToggleSidebar={() => shellRef.current?.toggleNav()}
+            sidebarOpen={navOpen}
           />
         }
         nav={sidebar}


### PR DESCRIPTION
## Summary
- Adopt the shared focus-trap hook across modal and overlay surfaces.
- Add listbox semantics to the command palette and live-region/access-label coverage for chat, Salem, inbox toast, library search, sidebar toggle, and related controls.
- Add focused source-regression tests for the aria/focus-trap surfaces.

## Validation
- `node --experimental-strip-types src/components/modal-trap-adoption.test.ts`
- `node --experimental-strip-types src/components/command-palette.test.ts`
- `node --experimental-strip-types src/components/labels-and-live-regions.test.ts`
- `node --experimental-strip-types src/components/misc-aria-fixes.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`
