### PR TITLE
fix(settings): align reported app version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - run: pnpm test:app
+
       - run: pnpm test:api
 
       # Next 16.2.6 / Turbopack has non-deterministic chunking errors on

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "mobile:tailscale": "bash scripts/mobile-tailscale.sh",
     "build": "next build",
     "typecheck": "tsc --noEmit",
+    "test:app": "node --experimental-strip-types src/lib/app-version.test.ts && node --experimental-strip-types src/components/settings-appearance.test.ts",
     "test:api": "node --experimental-strip-types src/app/api/api-contracts.test.ts && node --experimental-strip-types src/app/api/board/enrich-steps/route.test.ts && node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts && node --experimental-strip-types src/app/api/library/route-link/route.test.ts && node --experimental-strip-types src/lib/server/memory-file-sources.test.ts && node --experimental-strip-types src/lib/server/memory-file-paths.test.ts",
     "test:api:http": "node scripts/api-http-smoke.mjs",
     "start": "next start"

--- a/src/components/settings-appearance.test.ts
+++ b/src/components/settings-appearance.test.ts
@@ -70,3 +70,21 @@ assert.match(
   /name\.startsWith\("--"\) \? name : `--\$\{name\}`/,
   "applyCustomVars should accept tweakcn's bare-name keys by prefixing -- when missing",
 );
+
+assert.match(
+  settings,
+  /import \{ APP_VERSION \} from "@\/lib\/app-version"/,
+  "About settings must import the shared app version source",
+);
+
+assert.match(
+  settings,
+  /<SettingsKV label="App version" value=\{APP_VERSION\} \/>/,
+  "About settings must render the shared app version instead of a literal",
+);
+
+assert.doesNotMatch(
+  settings,
+  /<SettingsKV label="App version" value="[\d.]+"/,
+  "About settings must not hardcode an app version literal",
+);

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -9,6 +9,7 @@ import { THEME_IDS, THEME_META, getSwatches, type ThemeId } from "@/lib/theme-pa
 import { COVEN_THEME_KEY, COVEN_MODE_KEY, COVEN_CUSTOM_THEME_KEY, LEGACY_THEME_RENAME, type Mode } from "@/lib/theme-storage";
 import { ModeToggle } from "@/components/mode-toggle";
 import { FamiliarStudioProvider } from "@/lib/familiar-studio-context";
+import { APP_VERSION } from "@/lib/app-version";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -767,7 +768,7 @@ function AboutSection() {
   return (
     <SettingsPage title="About" description="Version and build information.">
       <SettingsGroup label="CovenCave">
-        <SettingsKV label="App version" value="0.0.46" />
+        <SettingsKV label="App version" value={APP_VERSION} />
         <SettingsKV label="Daemon version" value={version ?? "—"} />
         <SettingsKV label="Built with" value="Next.js · React · Tauri · Tailwind" />
       </SettingsGroup>

--- a/src/lib/app-version.test.ts
+++ b/src/lib/app-version.test.ts
@@ -1,0 +1,25 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const packageJson = JSON.parse(await readFile(new URL("../../package.json", import.meta.url), "utf8"));
+const tauriConfig = JSON.parse(await readFile(new URL("../../src-tauri/tauri.conf.json", import.meta.url), "utf8"));
+const cargoToml = await readFile(new URL("../../src-tauri/Cargo.toml", import.meta.url), "utf8");
+const appVersionSource = await readFile(new URL("./app-version.ts", import.meta.url), "utf8");
+
+const cargoVersion = cargoToml.match(/^version\s*=\s*"([^"]+)"/m)?.[1];
+
+assert.equal(tauriConfig.version, packageJson.version, "Tauri bundle version must match package.json");
+assert.equal(cargoVersion, packageJson.version, "Tauri Cargo package version must match package.json");
+assert.match(
+  appVersionSource,
+  /from "\.\.\/\.\.\/package\.json"/,
+  "App-reported version must be sourced from package.json",
+);
+assert.match(
+  appVersionSource,
+  /export const APP_VERSION/,
+  "App version module must export APP_VERSION for UI reporting",
+);
+
+console.log("app-version.test.ts: ok");

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -1,0 +1,3 @@
+import packageJson from "../../package.json";
+
+export const APP_VERSION = packageJson.version;


### PR DESCRIPTION
## Summary
- Source the Settings About app version from package.json instead of a hardcoded literal.
- Add app-version tests that keep package.json, Tauri config, and Cargo package versions aligned.
- Run the app-version/settings assertions in CI before the API suite and build.

## Verification
- pnpm test:app
- pnpm test:api
- pnpm typecheck
- pnpm build