### PR TITLE
chore(release): standardize release-notes script + backfill empties

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,6 +319,11 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
+          # release-notes.sh resolves the previous tag for the compare link
+          # via `git tag --sort=-version:refname`, so the checksums job needs
+          # the full tag history (shallow defaults would only have HEAD).
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Resolve release tag
         shell: bash
@@ -371,3 +376,21 @@ jobs:
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           files: _release/SHA256SUMS
+
+      # Render the standardized release body — CHANGELOG.md section for
+      # the version, plus arch-aware install instructions, checksum verify
+      # snippet, and a compare link. Runs after every artifact has uploaded
+      # so the install instructions match what's actually attached. This is
+      # the only step that sets the release body, so it stays the canonical
+      # source for what users read on the release page.
+      - name: Set release notes
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          bash scripts/release-notes.sh "$RELEASE_TAG" > /tmp/release-body.md
+          echo "--- rendered body ---"
+          cat /tmp/release-body.md
+          echo "--- end body ---"
+          gh release edit "$RELEASE_TAG" --notes-file /tmp/release-body.md

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Render a standardized GitHub release body for a CovenCave tag.
+#
+# Usage:
+#   scripts/release-notes.sh v0.0.55 [previous-tag]
+#
+# Prints the rendered markdown body to stdout. Tries the CHANGELOG.md entry
+# for the version first, and falls back to a short bullet list of commit
+# subjects between the previous tag and this one when no entry exists. The
+# previous tag is auto-detected via `git tag --sort=-version:refname` when
+# the second argument is omitted.
+#
+# Designed to be run both in CI (release.yml's checksums job re-renders the
+# body after all artifacts have uploaded) and locally for backfilling old
+# releases via `gh release edit <tag> --notes-file -`.
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "usage: $0 <vX.Y.Z> [previous-tag]" >&2
+  exit 2
+fi
+
+VERSION="$1"
+VER_NUM="${VERSION#v}"
+PREV="${2:-}"
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CHANGELOG="$ROOT/CHANGELOG.md"
+REPO="${COVEN_REPO_SLUG:-OpenCoven/coven-cave}"
+
+# ── Resolve the previous tag ────────────────────────────────────────────────
+# Exclude pre-release suffixes (rc*, alpha*, etc.) so the "compare" link
+# always lines up with the prior stable cut.
+if [ -z "$PREV" ]; then
+  PREV="$(
+    cd "$ROOT" \
+      && git tag -l 'v[0-9]*' --sort=-version:refname \
+      | grep -Ev -- '-[a-zA-Z]' \
+      | awk -v cur="$VERSION" '$0==cur{f=1; next} f{print; exit}'
+  )"
+fi
+
+# ── Pull the CHANGELOG section for this version (between two `## [x.y.z]`) ──
+# Use literal-prefix matching (index == 1) so we don't fight bash/awk regex
+# escaping — the `.` characters in semver are regex metachars.
+section="$(
+  awk -v marker="## [$VER_NUM]" '
+    index($0, marker) == 1 { found=1; next }
+    found && /^## / { exit }
+    found { print }
+  ' "$CHANGELOG" 2>/dev/null || true
+)"
+
+# ── arch-suffixed DMG names landed in v0.0.54 (#269) ────────────────────────
+# Treat anything >= 0.0.54 as having two DMGs (x86_64 + aarch64); earlier
+# tags shipped a single CovenCave-v<X.Y.Z>.dmg.
+arch_split=false
+IFS=. read -r _maj _min _patch <<EOF
+$VER_NUM
+EOF
+if [ "${_patch:-0}" -ge 54 ] || [ "${_min:-0}" -gt 0 ]; then
+  arch_split=true
+fi
+
+# ── Body ────────────────────────────────────────────────────────────────────
+printf '## What'"'"'s new in %s\n\n' "$VERSION"
+
+if [ -n "${section// /}" ]; then
+  # Drop leading blank lines from the awk capture.
+  printf '%s\n' "$section" | awk 'started || NF { started=1; print }'
+elif [ -n "$PREV" ]; then
+  echo "Commits since [\`$PREV\`](https://github.com/$REPO/releases/tag/$PREV):"
+  echo
+  (
+    cd "$ROOT"
+    git log --no-merges --pretty=format:'- %s' "$PREV".."$VERSION" 2>/dev/null \
+      | sed 's/ (#\([0-9]\+\))$/ ([#\1](https:\/\/github.com\/'"$(echo "$REPO" | sed 's,/,\\/,g')"'\/pull\/\1))/'
+  )
+  echo
+else
+  echo "Initial release."
+  echo
+fi
+
+cat <<INSTALL
+
+## Install
+
+INSTALL
+
+if [ "$arch_split" = "true" ]; then
+  cat <<INSTALL_NEW
+- **macOS (Apple Silicon):** download \`CovenCave-$VERSION-aarch64.dmg\`, open it, drag CovenCave.app to Applications.
+- **macOS (Intel):** download \`CovenCave-$VERSION-x86_64.dmg\`, open it, drag CovenCave.app to Applications.
+INSTALL_NEW
+else
+  cat <<INSTALL_LEGACY
+- **macOS:** download \`CovenCave-$VERSION.dmg\`, open it, drag CovenCave.app to Applications.
+INSTALL_LEGACY
+fi
+
+cat <<INSTALL_REST
+- **Linux:** download the AppImage asset, \`chmod +x CovenCave_*.AppImage\`, then run it.
+- **Windows:** download the \`.msi\` and double-click to install.
+
+## Verify checksums
+
+\`\`\`bash
+shasum -a 256 -c SHA256SUMS
+\`\`\`
+
+INSTALL_REST
+
+if [ -n "$PREV" ]; then
+  printf '**Full changelog:** https://github.com/%s/compare/%s...%s\n' \
+    "$REPO" "$PREV" "$VERSION"
+else
+  printf '**Full changelog:** https://github.com/%s/commits/%s\n' \
+    "$REPO" "$VERSION"
+fi

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -1,0 +1,104 @@
+// Sanity test for scripts/release-notes.sh. Run with:
+//   npx --yes tsx --test scripts/release-notes.test.mjs
+//
+// Asserts the script:
+//   1. Picks up the CHANGELOG.md section when one exists for the version.
+//   2. Renders the arch-split install block for v0.0.54+.
+//   3. Falls back to the legacy single-DMG install block for pre-v0.0.54.
+//   4. Falls back to a git-log commit list when no CHANGELOG entry exists.
+//   5. Always ends with a `**Full changelog:**` compare link.
+//
+// Live git history is needed for the fallback case, so this test is
+// expected to run inside the repo's working tree (CI does not execute it
+// — see CLAUDE.md / auto-memory reference_test_runner).
+
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const SCRIPT = fileURLToPath(new URL("./release-notes.sh", import.meta.url));
+const REPO_ROOT = path.dirname(path.dirname(SCRIPT));
+
+function render(version, previous) {
+  const args = previous ? [version, previous] : [version];
+  return execFileSync(SCRIPT, args, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+test("v0.0.55 pulls its CHANGELOG section and renders the arch-split install block", () => {
+  const body = render("v0.0.55");
+  assert.match(body, /^## What's new in v0\.0\.55/m, "starts with the standard heading");
+  assert.match(
+    body,
+    /Loopback-tolerant referer check/,
+    "includes the CHANGELOG bullet for the loopback-tolerant fix",
+  );
+  assert.match(
+    body,
+    /CovenCave-v0\.0\.55-aarch64\.dmg/,
+    "arch-split install block lists the aarch64 DMG",
+  );
+  assert.match(
+    body,
+    /CovenCave-v0\.0\.55-x86_64\.dmg/,
+    "arch-split install block lists the x86_64 DMG",
+  );
+  assert.doesNotMatch(
+    body,
+    /CovenCave-v0\.0\.55\.dmg(?!-)/,
+    "arch-split block must not also list the legacy un-suffixed DMG",
+  );
+  assert.match(
+    body,
+    /\*\*Full changelog:\*\* https:\/\/github\.com\/OpenCoven\/coven-cave\/compare\/v0\.0\.54\.\.\.v0\.0\.55/,
+    "trailing compare link uses the auto-detected previous tag",
+  );
+});
+
+test("pre-v0.0.54 versions render the legacy single-DMG install block", () => {
+  const body = render("v0.0.42");
+  assert.match(
+    body,
+    /download `CovenCave-v0\.0\.42\.dmg`/,
+    "legacy install block lists the un-suffixed DMG",
+  );
+  assert.doesNotMatch(
+    body,
+    /aarch64\.dmg|x86_64\.dmg/,
+    "legacy block must not mention arch-suffixed DMGs",
+  );
+});
+
+test("versions without a CHANGELOG entry fall back to a git-log bullet list", () => {
+  // v0.0.42 is below the CHANGELOG cutoff (which starts at 0.0.50) so it
+  // must hit the fallback branch.
+  const body = render("v0.0.42", "v0.0.41");
+  assert.match(
+    body,
+    /Commits since \[`v0\.0\.41`\]/,
+    "fallback bullet list cites the previous tag",
+  );
+  assert.match(body, /^- /m, "fallback emits at least one `- ` bullet");
+});
+
+test("an explicit previous-tag argument overrides auto-detection", () => {
+  const body = render("v0.0.55", "v0.0.50");
+  assert.match(
+    body,
+    /compare\/v0\.0\.50\.\.\.v0\.0\.55/,
+    "compare link respects the explicit previous tag",
+  );
+});
+
+test("every rendered body ends with the standardized checksum + changelog footer", () => {
+  for (const v of ["v0.0.55", "v0.0.42"]) {
+    const body = render(v);
+    assert.match(body, /shasum -a 256 -c SHA256SUMS/, `${v} body has the verify-checksums block`);
+    assert.match(body, /\*\*Full changelog:\*\*/, `${v} body has the compare link`);
+  }
+});


### PR DESCRIPTION
## Summary

- **`scripts/release-notes.sh`** renders a standardized GitHub release body for any `vX.Y.Z` tag. Prefers the matching `CHANGELOG.md` section when one exists (v0.0.50+); falls back to a bullet list of commit subjects between the previous tag and the current one for older releases. Install instructions auto-switch between the legacy single `CovenCave-vX.Y.Z.dmg` and the arch-suffixed dual DMG introduced in #269.
- **Wired into `release.yml`** — a new `Set release notes` step in the checksums job calls the script after every artifact has uploaded and writes the rendered body via `gh release edit --notes-file`. `fetch-depth: 0` and `fetch-tags: true` were added to the checkout so the script can resolve the previous-tag compare link inside the runner.
- **`scripts/release-notes.test.mjs`** covers five behavioral contracts: CHANGELOG-backed body, arch-split install block, legacy install block, git-log fallback, explicit-previous override.
- **Backfilled live release pages** for the 24 historically-empty bodies (v0.0.23–v0.0.26, v0.0.31–v0.0.43, v0.0.46, v0.0.48–v0.0.49, v0.0.51, v0.0.53–v0.0.55) via `gh release edit` using this script — done before this commit landed so the public archive matches the template immediately.

## Sample output

For a CHANGELOG-backed, arch-split version (v0.0.55):

```
## What's new in v0.0.55

Release repair for the packaged macOS sidecar after 0.0.54.

### Fixed
- **Loopback-tolerant referer check.** …

## Install
- **macOS (Apple Silicon):** download `CovenCave-v0.0.55-aarch64.dmg`, …
- **macOS (Intel):** download `CovenCave-v0.0.55-x86_64.dmg`, …
- **Linux:** download the AppImage asset, …
- **Windows:** download the `.msi` and double-click to install.

## Verify checksums
\`\`\`bash
shasum -a 256 -c SHA256SUMS
\`\`\`

**Full changelog:** https://github.com/OpenCoven/coven-cave/compare/v0.0.54...v0.0.55
```

For a pre-CHANGELOG, legacy-DMG version (v0.0.42): `Commits since [v0.0.41]…` bullet list + `CovenCave-v0.0.42.dmg` install line.

## Test plan

- [ ] `npx --yes tsx --test scripts/release-notes.test.mjs` passes locally.
- [ ] Push a v0.0.56 tag (or later) and confirm the `Set release notes` step in the checksums job renders + applies the body without errors.
- [ ] Confirm the post-release-run body on the GitHub Releases page matches the template (heading, install block, checksum verify snippet, compare link).
- [ ] Spot-check a backfilled release page (e.g. v0.0.42, v0.0.46, v0.0.55) for correct formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)