### PR TITLE
fix(chat): keep context in header row

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "mobile:tailscale": "bash scripts/mobile-tailscale.sh",
     "build": "next build",
     "typecheck": "tsc --noEmit",
-    "test:app": "node --experimental-strip-types src/lib/app-version.test.ts && node --experimental-strip-types src/components/settings-appearance.test.ts",
+    "test:app": "node --experimental-strip-types src/lib/app-version.test.ts && node --experimental-strip-types src/components/settings-appearance.test.ts && node --experimental-strip-types src/components/chat-header-row.test.ts",
     "test:api": "node --experimental-strip-types src/app/api/api-contracts.test.ts && node --experimental-strip-types src/app/api/board/enrich-steps/route.test.ts && node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts && node --experimental-strip-types src/app/api/library/route-link/route.test.ts && node --experimental-strip-types src/lib/server/memory-file-sources.test.ts && node --experimental-strip-types src/lib/server/memory-file-paths.test.ts",
     "test:api:http": "node scripts/api-http-smoke.mjs",
     "start": "next start"

--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -1,0 +1,41 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const styles = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
+
+const linearHeader = source.match(/<header className="cave-chat-linear-header"[\s\S]*?<\/header>/)?.[0] ?? "";
+const linearHeaderRule = styles.match(/\.cave-chat-linear-header\s*\{(?<body>[^}]*)\}/)?.groups?.body ?? "";
+
+assert.match(
+  linearHeader,
+  /<div className="cave-chat-linear-header-row"[\s\S]*<ChatContextStrip/,
+  "Task/session context should render inside the single chat header row",
+);
+
+assert.doesNotMatch(
+  linearHeader,
+  /<\/div>\s*<ChatContextStrip[\s\S]*?\/>\s*<\/header>/,
+  "Task/session context should not sit on a second row below the identity bar",
+);
+
+assert.match(
+  linearHeaderRule,
+  /flex-direction\s*:\s*row/,
+  "Linear chat header should keep identity and task context on one row",
+);
+
+assert.match(
+  styles,
+  /\.cave-chat-linear-header-row\s*\{[\s\S]*min-width\s*:\s*0[\s\S]*\}/,
+  "Header row should be able to shrink without forcing overflow",
+);
+
+assert.match(
+  styles,
+  /\.cave-chat-linear-header-context\s*\{[\s\S]*overflow\s*:\s*hidden[\s\S]*\}/,
+  "Header context area should truncate instead of wrapping the header taller",
+);
+
+console.log("chat-header-row.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -294,7 +294,7 @@ function ChatContextStrip({
   if (!session && !task && github.length === 0 && historyState === "idle") return null;
 
   return (
-    <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+    <div className="cave-chat-linear-header-context">
       {session ? (
         <span className="inline-flex min-w-0 max-w-[22rem] items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 py-1 text-[11px] text-[var(--text-secondary)]">
           <Icon name="ph:chats-circle" width={12} className="shrink-0 text-[var(--text-muted)]" />
@@ -840,34 +840,36 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     <section className="cave-chat-linear flex h-full flex-col bg-[var(--bg-base)] text-[var(--text-primary)]">
       <header className="cave-chat-linear-header">
         {/* Single compact bar: avatar · name · status · meta · context strip */}
-        <div className="flex min-w-0 items-center gap-2">
-          <div className="cave-agent-marker cave-agent-marker--xs" aria-hidden>
-            <FamiliarIcon familiar={familiar} size="sm" />
+        <div className="cave-chat-linear-header-row">
+          <div className="cave-chat-linear-header-identity">
+            <div className="cave-agent-marker cave-agent-marker--xs" aria-hidden>
+              <FamiliarIcon familiar={familiar} size="sm" />
+            </div>
+            <h2 className="shrink-0 text-[13px] font-semibold text-[var(--text-primary)] leading-none">
+              {familiar.display_name}
+            </h2>
+            <span className={[
+              "inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium",
+              daemonRunning === false
+                ? "bg-[color-mix(in_oklch,var(--color-danger)_18%,transparent)] text-[var(--color-danger)]"
+                : "bg-[color-mix(in_oklch,var(--color-success)_16%,transparent)] text-[var(--color-success)]",
+            ].join(" ")}>
+              <span className="h-1.5 w-1.5 rounded-full bg-current" />
+              {daemonRunning === false ? "offline" : "ready"}
+            </span>
+            <span className="text-[var(--border-hairline)]" aria-hidden>|</span>
+            <span className="min-w-0 truncate text-[11px] text-[var(--text-muted)] font-mono">
+              {familiar.harness ?? ""}
+              {familiar.model ? <> · {familiar.model}</> : null}
+              {(session?.project_root ?? projectRoot) ? <> · {repoName(session?.project_root ?? projectRoot)}</> : null}
+            </span>
           </div>
-          <h2 className="shrink-0 text-[13px] font-semibold text-[var(--text-primary)] leading-none">
-            {familiar.display_name}
-          </h2>
-          <span className={[
-            "inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium",
-            daemonRunning === false
-              ? "bg-[color-mix(in_oklch,var(--color-danger)_18%,transparent)] text-[var(--color-danger)]"
-              : "bg-[color-mix(in_oklch,var(--color-success)_16%,transparent)] text-[var(--color-success)]",
-          ].join(" ")}>
-            <span className="h-1.5 w-1.5 rounded-full bg-current" />
-            {daemonRunning === false ? "offline" : "ready"}
-          </span>
-          <span className="text-[var(--border-hairline)]" aria-hidden>|</span>
-          <span className="min-w-0 truncate text-[11px] text-[var(--text-muted)] font-mono">
-            {familiar.harness ?? ""}
-            {familiar.model ? <> · {familiar.model}</> : null}
-            {(session?.project_root ?? projectRoot) ? <> · {repoName(session?.project_root ?? projectRoot)}</> : null}
-          </span>
+          <ChatContextStrip
+            session={session ?? null}
+            linkedContext={linkedContext}
+            historyState={historyState}
+          />
         </div>
-        <ChatContextStrip
-          session={session ?? null}
-          linkedContext={linkedContext}
-          historyState={historyState}
-        />
       </header>
       <div ref={scrollRef} className="cave-chat-transcript relative min-h-0 flex-1 overflow-y-auto">
         <div

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -807,15 +807,46 @@ details[open] > .cave-tool-summary::before {
 
 .cave-chat-linear-header {
   display: flex;
-  flex-direction: column;
-  gap: 5px;
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
   width: 100%;
   border-bottom: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--bg-panel) 76%, transparent);
-  padding: 8px 14px 7px;
+  padding: 8px 14px;
   box-shadow: 0 1px 0 color-mix(in oklch, var(--foreground) 4%, transparent) inset;
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
+}
+
+.cave-chat-linear-header-row {
+  display: flex;
+  min-width: 0;
+  width: 100%;
+  align-items: center;
+  gap: 10px;
+}
+
+.cave-chat-linear-header-identity {
+  display: flex;
+  min-width: 0;
+  flex: 0 1 auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.cave-chat-linear-header-context {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.cave-chat-linear-header-context > * {
+  flex: 0 1 auto;
 }
 
 .cave-agent-marker {


### PR DESCRIPTION
## Summary
- keep the chat task/session context inside the compact header row
- add a regression test so the context strip cannot move back to a second row

## Verification
- pnpm test:app
- pnpm typecheck
- pnpm build
- git diff --check -- package.json src/components/chat-header-row.test.ts src/components/chat-view.tsx src/styles/cave-chat.css
- local Playwright visual check on http://localhost:3000 for Charm chat header at desktop and resized mobile viewports