### PR TITLE
chore(release): stamp v0.0.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.56] — 2026-06-09
+
+Cross-surface polish, memory provenance + a11y groundwork, and a
+standardized release-notes pipeline. No public-API breaks.
+
+### Added
+
+- **Memory file source metadata.** `/api/memory` now exposes per-file
+  `source` and `context` provenance so the inspector and the 3D graph
+  can surface where a memory entry originated. (#278)
+- **API contract test suite.** Sanity-checks the surface area of the
+  workspace-driving routes so future refactors can't silently break
+  callers. (#277)
+- **Accessibility quickwins.** Focus rings, ARIA labels, and keyboard
+  traversal repaired across the agents, inspector, capabilities, and
+  command-palette surfaces. (#280)
+
+### Fixed
+
+- **Inspector pane surface.** Inspector now matches the compact rail
+  surface tokens instead of drifting on its own palette. (#273)
+- **Familiar memory file reads.** The packaged sidecar can now read the
+  per-familiar memory tree it was previously refusing. (#274)
+- **Agents hover caret + memory tab scroll.** Roster card name + the
+  agents-detail memory tab no longer show a hover caret, and the memory
+  tab scrolls within its detail panel instead of pushing siblings
+  off-screen. (#275, #276)
+- **Salem surface tokens.** Salem perch and chat panel inherit shared
+  Cave tokens (`--bg-panel`, `--accent-presence`, `--text-*`) instead of
+  hardcoded purple literals — theme tuning now reaches the rail and
+  perch consistently. (#279)
+- **Settings reported app version.** About / settings now reports the
+  version embedded in the bundle metadata instead of a stale literal.
+- **Chat header context row.** Chat keeps its context row inside the
+  header instead of letting it reflow below on tighter viewports.
+
+### Changed
+
+- **Standardized release notes.** New `scripts/release-notes.sh` renders
+  a consistent GitHub Release body (CHANGELOG section + arch-aware
+  install block + checksum verify snippet + compare link), wired into
+  `release.yml`'s checksums job. Backfilled all 24 historically-empty
+  release pages (`v0.0.23`–`v0.0.55`) with the standardized template.
+  (#282)
+
 ## [0.0.55] — 2026-06-08
 
 Release repair for the packaged macOS sidecar after 0.0.54.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.55"
+version = "0.0.56"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary

Stamps the v0.0.56 release.

- Bumps `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json` from `0.0.55` to `0.0.56`.
- Adds the v0.0.56 `CHANGELOG.md` entry covering the 11 commits since v0.0.55, grouped Added / Fixed / Changed.

## Included in v0.0.56

### Added
- Memory file source metadata (#278)
- API contract test suite (#277)
- Accessibility focus rings + ARIA coverage (#280)

### Fixed
- Inspector pane surface tokens (#273)
- Familiar memory file reads (#274)
- Agents hover caret + memory tab scroll (#275, #276)
- Salem shared surface tokens (#279)
- Settings reported app version
- Chat header context row

### Changed
- Standardized release-notes pipeline + 24 backfilled release pages (#282)

## Test plan

- [ ] CI green (frontend build + rust check).
- [ ] Merge.
- [ ] Tag `v0.0.56` on the squash-merge commit; release workflow builds all four matrix legs.
- [ ] Confirm release page body renders from the v0.0.56 CHANGELOG entry via the new `scripts/release-notes.sh` step in the checksums job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)