### PR TITLE
fix(app): recover local chats and scope familiar memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "mobile:tailscale": "bash scripts/mobile-tailscale.sh",
     "build": "next build",
     "typecheck": "tsc --noEmit",
-    "test:app": "node --experimental-strip-types src/lib/app-version.test.ts && node --experimental-strip-types src/components/settings-appearance.test.ts && node --experimental-strip-types src/components/chat-header-row.test.ts",
-    "test:api": "node --experimental-strip-types src/app/api/api-contracts.test.ts && node --experimental-strip-types src/app/api/board/enrich-steps/route.test.ts && node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts && node --experimental-strip-types src/app/api/library/route-link/route.test.ts && node --experimental-strip-types src/lib/server/memory-file-sources.test.ts && node --experimental-strip-types src/lib/server/memory-file-paths.test.ts",
+    "test:app": "node --experimental-strip-types src/lib/app-version.test.ts && node --experimental-strip-types src/components/settings-appearance.test.ts && node --experimental-strip-types src/components/chat-header-row.test.ts && node --experimental-strip-types src/components/agents-view.test.ts && node --experimental-strip-types src/components/workspace-agents-landing.test.ts",
+    "test:api": "node --experimental-strip-types src/app/api/api-contracts.test.ts && node --experimental-strip-types src/app/api/board/enrich-steps/route.test.ts && node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts && node --experimental-strip-types src/app/api/library/route-link/route.test.ts && node --experimental-strip-types src/lib/session-list-merge.test.ts && node --experimental-strip-types src/lib/server/memory-file-sources.test.ts && node --experimental-strip-types src/lib/server/memory-file-paths.test.ts",
     "test:api:http": "node scripts/api-http-smoke.mjs",
     "start": "next start"
   },

--- a/src/app/api/sessions/list/route.ts
+++ b/src/app/api/sessions/list/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server";
 import { callDaemon } from "@/lib/coven-daemon";
 import { loadState } from "@/lib/cave-config";
-import { inferOrigin } from "@/lib/session-origin";
+import { listConversations } from "@/lib/cave-conversations";
+import {
+  localConversationSessionRows,
+  mergeSessionRows,
+} from "@/lib/session-list-merge";
 
 export const dynamic = "force-dynamic";
 
@@ -25,29 +29,29 @@ export async function GET(req: Request) {
     callDaemon<DaemonSession[]>({ path: "/api/v1/sessions" }),
     loadState(),
   ]);
+  const localConversations = await listConversations();
   if (!res.ok || !res.data) {
+    const localSessions = localConversationSessionRows(localConversations, state, includeArchived);
+    if (localSessions.length > 0) {
+      return NextResponse.json({
+        ok: true,
+        degraded: true,
+        error: res.error ?? `daemon http ${res.status}`,
+        sessions: localSessions,
+      });
+    }
     return NextResponse.json(
       { ok: false, error: res.error ?? `daemon http ${res.status}`, sessions: [] },
       { status: 503 },
     );
   }
 
-  const sessions = res.data
-    // Soft-delete: never surface sacrificed sessions to the UI.
-    .filter((s) => !state.sessionSacrificed[s.id])
-    .map((s) => {
-      const titleOverride = state.sessionTitles[s.id];
-      const archivedLocal = state.sessionArchived[s.id] ?? null;
-      const archived_at = archivedLocal ?? s.archived_at;
-      return {
-        ...s,
-        title: titleOverride ?? s.title,
-        archived_at,
-        familiarId: state.sessionFamiliar[s.id] ?? null,
-        origin: inferOrigin(s),
-      };
-    })
-    .filter((s) => includeArchived || !s.archived_at);
+  const sessions = mergeSessionRows({
+    daemonSessions: res.data,
+    localConversations,
+    state,
+    includeArchived,
+  });
 
   return NextResponse.json({ ok: true, sessions });
 }

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -7,6 +7,7 @@ import { MemoryGraph3D } from "@/components/memory-graph-3d";
 import { buildMemoryGraphModel, resolveMemoryFamiliarFilter } from "@/lib/memory-graph-3d-model";
 import type { MemoryGraphMemoryNode } from "@/lib/memory-graph-3d-model";
 import type { CovenMemoryEntry } from "@/components/agents-view-stats";
+import { MarkdownBlock } from "@/components/message-bubble";
 
 export type FileMemoryEntry = {
   root: string;
@@ -36,6 +37,8 @@ type Props = {
   limit?: number;
   /** Suppress the familiar <select>; render the active familiar as a chip. */
   lockToFamiliar?: boolean;
+  /** Compact header for narrow surfaces like the companion rail. */
+  compact?: boolean;
 };
 
 type CovenMemoryResponse =
@@ -86,7 +89,7 @@ function memoryMatches(entry: CovenMemoryEntry | FileMemoryEntry, query: string)
   ].some((value) => value.toLowerCase().includes(query));
 }
 
-export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, mode, limit, lockToFamiliar }: Props) {
+export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, mode, limit, lockToFamiliar, compact }: Props) {
   const [covenEntries, setCovenEntries] = useState<CovenMemoryEntry[]>([]);
   const [fileEntries, setFileEntries] = useState<FileMemoryEntry[]>([]);
   const [query, setQuery] = useState("");
@@ -212,66 +215,70 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-[var(--bg-base)]">
-      <div className="shrink-0 border-b border-[var(--border-hairline)] px-4 py-3">
-        <div className="flex flex-wrap items-end justify-between gap-3">
-          <div>
-            <div className="flex items-center gap-2">
-              <Icon name="ph:brain-bold" width={15} className="text-[var(--accent-presence)]" />
-              <h2 className="text-[14px] font-semibold text-[var(--text-primary)]">Agent Memory</h2>
-            </div>
-            <p className="mt-1 text-[11px] text-[var(--text-muted)]">
-              Focused recall for one agent at a time, with local memory files kept in the list surface.
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            {!mode && (
-              <div className="flex overflow-hidden rounded-md border border-[var(--border-hairline)]">
-                {(["list", "graph"] as const).map((m) => (
-                  <button
-                    key={m}
-                    type="button"
-                    onClick={() => setViewMode(m)}
-                    className={[
-                      "focus-ring-inset inline-flex h-7 items-center gap-1.5 px-2.5 text-[11px] capitalize transition-colors",
-                      viewMode === m
-                        ? "bg-[var(--accent-presence)] text-white"
-                        : "bg-[var(--bg-raised)]/30 text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]",
-                    ].join(" ")}
-                  >
-                    <Icon name={m === "list" ? "ph:list-bullets" : "ph:graph"} width={12} />
-                    {m}
-                  </button>
-                ))}
+      <div className={`shrink-0 border-b border-[var(--border-hairline)] ${compact ? "px-3 py-2" : "px-4 py-3"}`}>
+        {compact ? null : (
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <div className="flex items-center gap-2">
+                <Icon name="ph:brain-bold" width={15} className="text-[var(--accent-presence)]" />
+                <h2 className="text-[14px] font-semibold text-[var(--text-primary)]">Agent Memory</h2>
               </div>
-            )}
-            <button type="button" onClick={() => void load()} className="focus-ring inline-flex h-7 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]">
-              <Icon name="ph:arrows-clockwise" width={12} />
-              Refresh
-            </button>
+              <p className="mt-1 text-[11px] text-[var(--text-muted)]">
+                Focused recall for one agent at a time, with local memory files kept in the list surface.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              {!mode && (
+                <div className="flex overflow-hidden rounded-md border border-[var(--border-hairline)]">
+                  {(["list", "graph"] as const).map((m) => (
+                    <button
+                      key={m}
+                      type="button"
+                      onClick={() => setViewMode(m)}
+                      className={[
+                        "focus-ring-inset inline-flex h-7 items-center gap-1.5 px-2.5 text-[11px] capitalize transition-colors",
+                        viewMode === m
+                          ? "bg-[var(--accent-presence)] text-white"
+                          : "bg-[var(--bg-raised)]/30 text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]",
+                      ].join(" ")}
+                    >
+                      <Icon name={m === "list" ? "ph:list-bullets" : "ph:graph"} width={12} />
+                      {m}
+                    </button>
+                  ))}
+                </div>
+              )}
+              <button type="button" onClick={() => void load()} className="focus-ring inline-flex h-7 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]">
+                <Icon name="ph:arrows-clockwise" width={12} />
+                Refresh
+              </button>
+            </div>
           </div>
-        </div>
+        )}
 
-        <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-          <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
-            <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">Agent memories</div>
-            <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{visibleCoven.length}</div>
+        {compact ? null : (
+          <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
+              <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">Agent memories</div>
+              <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{visibleCoven.length}</div>
+            </div>
+            <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
+              <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">Coven origin</div>
+              <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{fileSourceCounts.covenOrigin}</div>
+            </div>
+            <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
+              <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">External harnesses</div>
+              <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{fileSourceCounts.externalHarnesses}</div>
+            </div>
+            <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
+              <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">Runtime memory</div>
+              <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{fileSourceCounts.runtimeMemory}</div>
+            </div>
           </div>
-          <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
-            <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">Coven origin</div>
-            <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{fileSourceCounts.covenOrigin}</div>
-          </div>
-          <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
-            <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">External harnesses</div>
-            <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{fileSourceCounts.externalHarnesses}</div>
-          </div>
-          <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
-            <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">Runtime memory</div>
-            <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{fileSourceCounts.runtimeMemory}</div>
-          </div>
-        </div>
+        )}
 
-        <div className="mt-3 flex flex-wrap items-center gap-2">
-          <div className="relative min-w-[220px] flex-1">
+        <div className={`${compact ? "" : "mt-3"} flex flex-wrap items-center gap-2`}>
+          <div className={`relative ${compact ? "min-w-0" : "min-w-[220px]"} flex-1`}>
             <Icon name="ph:magnifying-glass" width={12} className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-muted)]" />
             <input
               value={query}
@@ -356,14 +363,17 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
                       </code>
                     </div>
                   ) : null}
-                  <button
-                    type="button"
-                    onClick={() => onOpenMemoryFile?.(selectedMemory.path)}
-                    className="focus-ring mt-3 inline-flex h-8 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2.5 text-[12px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
-                  >
-                    <Icon name="ph:file-text" width={13} />
-                    Open memory
-                  </button>
+                  <div className="mt-3 flex flex-wrap items-center gap-1.5">
+                    <button
+                      type="button"
+                      onClick={() => onOpenMemoryFile?.(selectedMemory.path)}
+                      className="focus-ring inline-flex h-8 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2.5 text-[12px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+                    >
+                      <Icon name="ph:file-text" width={13} />
+                      Open memory
+                    </button>
+                    <ExpandMemoryButton path={selectedMemory.path} title={selectedMemory.title} />
+                  </div>
                 </div>
               ) : (
                 <div className="mt-3 rounded-md border border-dashed border-[var(--border-hairline)] px-3 py-6 text-center text-[12px] text-[var(--text-muted)]">
@@ -435,14 +445,17 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
                     {entry.excerpt ? (
                       <p className="mt-2 line-clamp-4 text-[11px] leading-5 text-[var(--text-secondary)]">{entry.excerpt}</p>
                     ) : null}
-                    <button
-                      type="button"
-                      onClick={() => onOpenMemoryFile?.(entry.path)}
-                      className="focus-ring mt-3 inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
-                    >
-                      <Icon name="ph:file-text" width={12} />
-                      Open memory
-                    </button>
+                    <div className="mt-3 flex flex-wrap items-center gap-1.5">
+                      <button
+                        type="button"
+                        onClick={() => onOpenMemoryFile?.(entry.path)}
+                        className="focus-ring inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+                      >
+                        <Icon name="ph:file-text" width={12} />
+                        Open memory
+                      </button>
+                      <ExpandMemoryButton path={entry.path} title={entry.title} />
+                    </div>
                   </article>
                 );
               })}
@@ -498,6 +511,8 @@ export function RailMemoryList({
         activeFamiliar={familiar}
         mode="list"
         limit={20}
+        compact
+        lockToFamiliar
       />
       {onOpenFullView ? (
         <button
@@ -525,6 +540,121 @@ type MemoryFilesListProps = {
   limit?: number;
 };
 
+// ────────────────────────────────────────────────────────────────────────────
+// MemoryReaderModal — fullscreen reader rendering a memory file's markdown
+// via @create-markdown/preview (through MarkdownBlock).
+// ────────────────────────────────────────────────────────────────────────────
+
+type MemoryReaderModalProps = {
+  path: string;
+  title?: string;
+  onClose: () => void;
+};
+
+export function MemoryReaderModal({ path, title, onClose }: MemoryReaderModalProps) {
+  const [text, setText] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setText(null);
+    setError(null);
+    void (async () => {
+      try {
+        const res = await fetch(`/api/memory/file?path=${encodeURIComponent(path)}`, { cache: "no-store" });
+        const json = await res.json();
+        if (cancelled) return;
+        if (json.ok) setText(typeof json.text === "string" ? json.text : "");
+        else setError(json.error ?? "Failed to load memory");
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load memory");
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [path]);
+
+  const heading = title ?? path.split("/").pop() ?? "Memory";
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/75 backdrop-blur-sm"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Memory reader: ${heading}`}
+    >
+      <div
+        className="relative flex h-[92vh] w-[94vw] max-w-[1100px] flex-col overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-panel)] shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-hairline)] px-4 py-2.5">
+          <Icon name="ph:book-open" width={13} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
+          <span className="flex-1 truncate text-[12px] text-[var(--text-secondary)]" title={path}>
+            {heading}
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            className="ml-1 flex h-7 w-7 items-center justify-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+            aria-label="Close memory reader"
+          >
+            <Icon name="ph:x-bold" width={11} aria-hidden />
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto px-8 py-6">
+          <div className="mx-auto w-full max-w-[820px]">
+            {error ? (
+              <p className="text-[12px] text-[var(--color-warning)]">{error}</p>
+            ) : text === null ? (
+              <p className="text-[12px] text-[var(--text-muted)]">Loading memory…</p>
+            ) : (
+              <MarkdownBlock text={text} className="cave-md--expanded" />
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ExpandMemoryButton({
+  path,
+  title,
+  variant = "default",
+}: {
+  path: string;
+  title?: string;
+  variant?: "default" | "compact";
+}) {
+  const [open, setOpen] = useState(false);
+  const compact = variant === "compact";
+  return (
+    <>
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); setOpen(true); }}
+        aria-label="Expand memory to reader view"
+        title="Expand to reader view"
+        className={
+          compact
+            ? "focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md border border-[var(--border-hairline)] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+            : "focus-ring inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+        }
+      >
+        <Icon name="ph:arrows-out-simple" width={compact ? 12 : 11} />
+        {compact ? null : "Expand"}
+      </button>
+      {open ? <MemoryReaderModal path={path} title={title} onClose={() => setOpen(false)} /> : null}
+    </>
+  );
+}
+
 export function MemoryFilesList({ entries, onOpen, loaded, error, limit }: MemoryFilesListProps) {
   const sliced = entries.slice(0, limit ?? entries.length);
   return (
@@ -540,11 +670,11 @@ export function MemoryFilesList({ entries, onOpen, loaded, error, limit }: Memor
       ) : (
         <ul className="max-h-[640px] divide-y divide-[var(--border-hairline)] overflow-y-auto">
           {sliced.map((entry) => (
-            <li key={entry.fullPath}>
+            <li key={entry.fullPath} className="flex items-stretch gap-1 px-1 hover:bg-[var(--bg-raised)]">
               <button
                 type="button"
                 onClick={() => onOpen?.(entry.fullPath)}
-                className="focus-ring-inset flex w-full items-start gap-2 px-3 py-2 text-left hover:bg-[var(--bg-raised)]"
+                className="focus-ring-inset flex flex-1 items-start gap-2 px-2 py-2 text-left"
               >
                 <Icon name="ph:file-text" width={13} className="mt-0.5 shrink-0 text-[var(--text-muted)]" />
                 <span className="min-w-0 flex-1">
@@ -563,6 +693,9 @@ export function MemoryFilesList({ entries, onOpen, loaded, error, limit }: Memor
                 </span>
                 <span className="shrink-0 text-[10px] text-[var(--text-muted)]">{age(entry.modified)}</span>
               </button>
+              <div className="flex items-center pr-2">
+                <ExpandMemoryButton path={entry.fullPath} title={entry.relPath} variant="compact" />
+              </div>
             </li>
           ))}
         </ul>

--- a/src/components/agents-view.test.ts
+++ b/src/components/agents-view.test.ts
@@ -56,14 +56,44 @@ assert.match(
 
 assert.match(
   source,
-  /<GlobalMemoryOverlay[\s\S]*familiars=\{familiars\}/,
-  "Global memory overlay is rendered when active",
+  /const memoryFamiliar = selectedFamiliar \?\? activeFamiliar \?\? null/,
+  "Familiar memory scope falls back to the workspace-selected familiar",
 );
 
 assert.match(
   source,
-  /setViewMode\("global-memory"\)/,
-  "Header button switches to global-memory mode",
+  /<AgentMemoryOverlay[\s\S]*familiar=\{memoryFamiliar\}/,
+  "Familiar memory overlay is scoped to the selected familiar",
+);
+
+assert.match(
+  source,
+  /setViewMode\("agent-memory"\)/,
+  "Header button switches to agent-memory mode",
+);
+
+assert.doesNotMatch(
+  source,
+  /Memory across all agents/,
+  "Familiars view should not expose global all-agents memory copy",
+);
+
+assert.match(
+  source,
+  /<h1[^>]*>Familiars<\/h1>/,
+  "Page heading uses Familiars instead of Agents",
+);
+
+assert.match(
+  source,
+  /Familiar memory/,
+  "Memory action uses singular Familiar copy",
+);
+
+assert.match(
+  source,
+  /activeFamiliar=\{familiar\}[\s\S]*lockToFamiliar/,
+  "Familiar memory overlay passes the selected familiar and locks the memory filter",
 );
 
 assert.match(

--- a/src/components/agents-view.tsx
+++ b/src/components/agents-view.tsx
@@ -19,13 +19,14 @@ type FileMemoryResponse =
   | { ok: true; entries: FileMemoryEntry[] }
   | { ok: false; entries?: FileMemoryEntry[]; error?: string };
 
-type ViewMode = "roster" | "detail" | "global-memory";
+type ViewMode = "roster" | "detail" | "agent-memory";
 
 const LAST_SELECTED_KEY = "cave:agents.lastSelected";
 
 type AgentsViewProps = {
   familiars: Familiar[];
   sessions: SessionRow[];
+  activeFamiliar?: Familiar | null;
   daemonRunning: boolean;
   responseNeeded: Set<string>;
   onStartChat: (familiarId: string) => void;
@@ -60,6 +61,7 @@ function familiarMatches(familiar: Familiar, query: string): boolean {
 export function AgentsView({
   familiars,
   sessions,
+  activeFamiliar,
   daemonRunning,
   responseNeeded,
   onStartChat,
@@ -129,6 +131,7 @@ export function AgentsView({
     () => familiars.find((f) => f.id === selectedFamiliarId) ?? null,
     [familiars, selectedFamiliarId],
   );
+  const memoryFamiliar = selectedFamiliar ?? activeFamiliar ?? null;
 
   useEffect(() => {
     if (selectedFamiliarId && !selectedFamiliar) {
@@ -154,7 +157,7 @@ export function AgentsView({
           <div>
             <div className="flex items-center gap-2">
               <Icon name="ph:users-three" width={16} className="text-[var(--accent-presence)]" />
-              <h1 className="text-[14px] font-semibold text-[var(--text-primary)]">Agents</h1>
+              <h1 className="text-[14px] font-semibold text-[var(--text-primary)]">Familiars</h1>
             </div>
             <p className="mt-1 text-[11px] text-[var(--text-muted)]">
               Roster of every familiar — identity, status, recent activity, memory at a glance.
@@ -163,11 +166,13 @@ export function AgentsView({
           <div className="flex items-center gap-2">
             <button
               type="button"
-              onClick={() => setViewMode("global-memory")}
+              onClick={() => memoryFamiliar && setViewMode("agent-memory")}
+              disabled={!memoryFamiliar}
+              title={memoryFamiliar ? `Memory for ${memoryFamiliar.display_name}` : "Select a familiar to view memory"}
               className="focus-ring inline-flex h-7 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--accent-presence)]/10 px-2.5 text-[11px] text-[var(--accent-presence)] hover:bg-[var(--accent-presence)]/15"
             >
               <Icon name="ph:graph" width={12} />
-              Memory across all agents
+              Familiar memory
             </button>
             <button
               type="button"
@@ -189,7 +194,7 @@ export function AgentsView({
             <input
               value={query}
               onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search agents…"
+              placeholder="Search familiars…"
               className="focus-ring h-8 w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 pl-7 pr-3 text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent-presence)]"
             />
           </div>
@@ -253,9 +258,10 @@ export function AgentsView({
           </div>
         )}
       </div>
-      {viewMode === "global-memory" ? (
-        <GlobalMemoryOverlay
+      {viewMode === "agent-memory" && memoryFamiliar ? (
+        <AgentMemoryOverlay
           familiars={familiars}
+          familiar={memoryFamiliar}
           onClose={() => setViewMode(selectedFamiliarId ? "detail" : "roster")}
           onOpenMemoryFile={onOpenMemoryFile}
         />
@@ -386,16 +392,17 @@ function AgentRosterCard({
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// GlobalMemoryOverlay — modal-style full-screen overlay for all-agent memory
+// AgentMemoryOverlay — modal-style full-screen overlay for selected familiar memory
 // ────────────────────────────────────────────────────────────────────────────
 
-type GlobalMemoryOverlayProps = {
+type AgentMemoryOverlayProps = {
   familiars: Familiar[];
+  familiar: Familiar;
   onClose: () => void;
   onOpenMemoryFile: (path: string) => void;
 };
 
-function GlobalMemoryOverlay({ familiars, onClose, onOpenMemoryFile }: GlobalMemoryOverlayProps) {
+function AgentMemoryOverlay({ familiars, familiar, onClose, onOpenMemoryFile }: AgentMemoryOverlayProps) {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
@@ -412,7 +419,7 @@ function GlobalMemoryOverlay({ familiars, onClose, onOpenMemoryFile }: GlobalMem
       className="agents-view__overlay fixed inset-0 z-50 grid place-items-center bg-black/40 backdrop-blur-sm"
       role="dialog"
       aria-modal="true"
-      aria-label="Memory across all agents"
+      aria-label={`Memory for ${familiar.display_name}`}
       onClick={onClose}
     >
       <div
@@ -430,8 +437,9 @@ function GlobalMemoryOverlay({ familiars, onClose, onOpenMemoryFile }: GlobalMem
         </button>
         <AgentsMemoryView
           familiars={familiars}
-          activeFamiliar={null}
+          activeFamiliar={familiar}
           mode="graph"
+          lockToFamiliar
           onOpenMemoryFile={onOpenMemoryFile}
         />
       </div>

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -67,7 +67,7 @@ const FOLDER_MODES: Array<{
 }> = [
   // Work
   { id: "home", label: "Home", iconName: "ph:house-bold", group: "work", kbd: "⌘1" },
-  { id: "agents", label: "Agents", iconName: "ph:users-three", group: "work", kbd: "⌘2" },
+  { id: "agents", label: "Familiars", iconName: "ph:users-three", group: "work", kbd: "⌘2" },
   { id: "chat", label: "Chat", iconName: "ph:chats", group: "work", kbd: "⌘3" },
   { id: "board", label: "Board", iconName: "ph:kanban", group: "work", kbd: "⌘4" },
   { id: "calendar", label: "Calendar", iconName: "ph:calendar-blank", group: "work", kbd: "⌘5" },

--- a/src/components/workspace-agents-landing.test.ts
+++ b/src/components/workspace-agents-landing.test.ts
@@ -35,32 +35,38 @@ assert.match(
 
 assert.match(
   workspace,
-  /mode === "browser" \|\| mode === "agents" \? undefined/,
-  "Companion rail is hidden on Agents (and Browser, as before)",
+  /<AgentsView[\s\S]*activeFamiliar=\{active\}/,
+  "Workspace passes the selected familiar into the Familiars page",
 );
 
 assert.match(
   workspace,
-  /const SURFACE_ORDER: WorkspaceMode\[\] = \[\s*"agents", "home", "chat", "board", "calendar", "inbox", "library", "browser",/,
-  "SURFACE_ORDER prepends agents so ⌘1 selects Agents",
+  /const showCompanionRail = railTab === "salem" \|\| \(mode !== "browser" && mode !== "agents"\)/,
+  "Companion rail is hidden on Familiars and Browser unless Salem is selected",
 );
 
 assert.match(
   workspace,
-  /agents: "Agents"/,
-  "SURFACE_LABELS has an Agents entry",
+  /const SURFACE_ORDER: WorkspaceMode\[\] = \[\s*"home", "agents", "chat", "board", "calendar", "inbox", "library", "browser",/,
+  "SURFACE_ORDER keeps Home before the Familiars surface",
+);
+
+assert.match(
+  workspace,
+  /agents: "Familiars"/,
+  "SURFACE_LABELS labels the page Familiars",
 );
 
 assert.match(
   sidebar,
-  /\{ id: "agents", label: "Agents", iconName: "ph:users-three", group: "work", kbd: "⌘1" \}/,
-  "Sidebar FOLDER_MODES lists Agents first in Work with ⌘1",
+  /\{ id: "agents", label: "Familiars", iconName: "ph:users-three", group: "work", kbd: "⌘2" \}/,
+  "Sidebar FOLDER_MODES labels the page Familiars",
 );
 
 assert.match(
   sidebar,
-  /\{ id: "home", label: "Home", iconName: "ph:house-bold", group: "work", kbd: "⌘2" \}/,
-  "Sidebar Home shifted to ⌘2",
+  /\{ id: "home", label: "Home", iconName: "ph:house-bold", group: "work", kbd: "⌘1" \}/,
+  "Sidebar Home keeps its shortcut hint",
 );
 
 assert.match(

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -51,7 +51,7 @@ import type { PendingChatAction } from "@/lib/pending-chat-action";
 type WorkspaceMode = WorkspaceModeFromDaemon;
 
 const SURFACE_LABELS: Record<WorkspaceMode, string> = {
-  agents: "Agents",
+  agents: "Familiars",
   home: "Home",
   chat: "Chat",
   board: "Board",
@@ -888,6 +888,7 @@ export function Workspace() {
       <AgentsView
         familiars={familiars}
         sessions={sessions}
+        activeFamiliar={active}
         daemonRunning={daemonRunning}
         responseNeeded={responseNeeded}
         onStartChat={(familiarId) => startAgentChat(familiarId)}

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -64,7 +64,14 @@ export async function appendTurn(sessionId: string, turn: ChatTurn): Promise<voi
 }
 
 export async function listConversations(): Promise<
-  Array<{ sessionId: string; familiarId: string; title?: string; updatedAt: string }>
+  Array<{
+    sessionId: string;
+    familiarId: string;
+    harness?: string;
+    title?: string;
+    createdAt?: string;
+    updatedAt: string;
+  }>
 > {
   await ensureDir();
   let entries;
@@ -76,7 +83,9 @@ export async function listConversations(): Promise<
   const results: Array<{
     sessionId: string;
     familiarId: string;
+    harness?: string;
     title?: string;
+    createdAt?: string;
     updatedAt: string;
   }> = [];
   for (const name of entries) {
@@ -88,7 +97,9 @@ export async function listConversations(): Promise<
         results.push({
           sessionId: conv.sessionId,
           familiarId: conv.familiarId,
+          harness: conv.harness,
           title: conv.title,
+          createdAt: conv.createdAt,
           updatedAt: conv.updatedAt,
         });
       } else {

--- a/src/lib/session-list-merge.test.ts
+++ b/src/lib/session-list-merge.test.ts
@@ -1,0 +1,98 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  localConversationSessionRows,
+  mergeSessionRows,
+} from "./session-list-merge.ts";
+
+const state = {
+  sessionFamiliar: { "local-1": "charm", "daemon-1": "cody" },
+  sessionTitles: { "local-1": "Recovered local chat" },
+  sessionArchived: {},
+  sessionSacrificed: {},
+};
+
+const localConversation = {
+  sessionId: "local-1",
+  familiarId: "nova",
+  harness: "codex",
+  title: "Saved title",
+  createdAt: "2026-06-08T20:00:00.000Z",
+  updatedAt: "2026-06-08T20:05:00.000Z",
+};
+
+const recovered = localConversationSessionRows([localConversation], state, false);
+
+assert.equal(recovered.length, 1);
+assert.deepEqual(
+  recovered[0],
+  {
+    id: "local-1",
+    project_root: "",
+    harness: "codex",
+    title: "Recovered local chat",
+    status: "completed",
+    exit_code: 0,
+    archived_at: null,
+    created_at: "2026-06-08T20:00:00.000Z",
+    updated_at: "2026-06-08T20:05:00.000Z",
+    familiarId: "charm",
+    origin: "chat",
+  },
+  "saved Cave conversations should become complete session rows when the daemon loses them",
+);
+
+const merged = mergeSessionRows({
+  daemonSessions: [
+    {
+      id: "daemon-1",
+      project_root: "/repo",
+      harness: "codex",
+      title: "Daemon chat",
+      status: "running",
+      exit_code: null,
+      archived_at: null,
+      created_at: "2026-06-08T19:00:00.000Z",
+      updated_at: "2026-06-08T19:05:00.000Z",
+    },
+  ],
+  localConversations: [localConversation],
+  state,
+  includeArchived: false,
+});
+
+assert.deepEqual(
+  merged.map((s) => s.id),
+  ["local-1", "daemon-1"],
+  "session list should include local-only saved chats alongside daemon sessions",
+);
+
+assert.equal(
+  mergeSessionRows({
+    daemonSessions: [],
+    localConversations: [localConversation],
+    state: { ...state, sessionSacrificed: { "local-1": "2026-06-08T21:00:00.000Z" } },
+    includeArchived: false,
+  }).length,
+  0,
+  "sacrificed local chats should stay hidden",
+);
+
+const archivedState = {
+  ...state,
+  sessionArchived: { "local-1": "2026-06-08T21:00:00.000Z" },
+};
+
+assert.equal(
+  localConversationSessionRows([localConversation], archivedState, false).length,
+  0,
+  "archived local chats should stay hidden from the active list",
+);
+
+assert.equal(
+  localConversationSessionRows([localConversation], archivedState, true)[0].archived_at,
+  "2026-06-08T21:00:00.000Z",
+  "archived local chats should return when includeArchived is enabled",
+);
+
+console.log("session-list-merge.test.ts: ok");

--- a/src/lib/session-list-merge.ts
+++ b/src/lib/session-list-merge.ts
@@ -1,0 +1,90 @@
+import type { CaveState } from "./cave-config.ts";
+import { inferOrigin } from "./session-origin.ts";
+import type { SessionRow } from "./types.ts";
+
+export type DaemonSessionRow = Omit<SessionRow, "familiarId" | "origin">;
+
+export type LocalConversationSummary = {
+  sessionId: string;
+  familiarId: string;
+  harness?: string;
+  title?: string;
+  createdAt?: string;
+  updatedAt: string;
+};
+
+type MergeOptions = {
+  daemonSessions: DaemonSessionRow[];
+  localConversations: LocalConversationSummary[];
+  state: CaveState;
+  includeArchived: boolean;
+};
+
+function localConversationToSession(
+  conv: LocalConversationSummary,
+  state: CaveState,
+): SessionRow {
+  const title = state.sessionTitles[conv.sessionId] ?? conv.title ?? "Chat";
+  const familiarId = state.sessionFamiliar[conv.sessionId] ?? conv.familiarId ?? null;
+  return {
+    id: conv.sessionId,
+    project_root: "",
+    harness: conv.harness ?? "chat",
+    title,
+    status: "completed",
+    exit_code: 0,
+    archived_at: state.sessionArchived[conv.sessionId] ?? null,
+    created_at: conv.createdAt ?? conv.updatedAt,
+    updated_at: conv.updatedAt,
+    familiarId,
+    origin: "chat",
+  };
+}
+
+function visibleSession(row: SessionRow, state: CaveState, includeArchived: boolean): boolean {
+  if (state.sessionSacrificed[row.id]) return false;
+  return includeArchived || !row.archived_at;
+}
+
+export function localConversationSessionRows(
+  localConversations: LocalConversationSummary[],
+  state: CaveState,
+  includeArchived: boolean,
+): SessionRow[] {
+  return localConversations
+    .map((conv) => localConversationToSession(conv, state))
+    .filter((row) => visibleSession(row, state, includeArchived))
+    .sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1));
+}
+
+export function mergeSessionRows({
+  daemonSessions,
+  localConversations,
+  state,
+  includeArchived,
+}: MergeOptions): SessionRow[] {
+  const seen = new Set<string>();
+  const rows: SessionRow[] = [];
+
+  for (const session of daemonSessions) {
+    seen.add(session.id);
+    const titleOverride = state.sessionTitles[session.id];
+    const archivedLocal = state.sessionArchived[session.id] ?? null;
+    const archived_at = archivedLocal ?? session.archived_at;
+    const row: SessionRow = {
+      ...session,
+      title: titleOverride ?? session.title,
+      archived_at,
+      familiarId: state.sessionFamiliar[session.id] ?? null,
+      origin: inferOrigin(session),
+    };
+    if (visibleSession(row, state, includeArchived)) rows.push(row);
+  }
+
+  for (const row of localConversationSessionRows(localConversations, state, includeArchived)) {
+    if (seen.has(row.id)) continue;
+    rows.push(row);
+  }
+
+  return rows.sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1));
+}


### PR DESCRIPTION
## Summary
- Recover saved Cave conversations into the sessions list when daemon sessions are missing or degraded.
- Scope Familiars memory to the selected familiar and update Agents/Familiars labels/tests.
- Add expanded memory reader actions for memory files and rail/list entries.

## Rebase
- Rebased onto current origin/main: f14d8c23dff8ea458c3cb2f93e4e03830d075daa

## Test Plan
- pnpm test:app
- pnpm test:api
- pnpm exec tsc --noEmit --pretty false
- pnpm build
- git diff --check -- package.json src/app/api/sessions/list/route.ts src/components/agents-memory-view.tsx src/components/agents-view.test.ts src/components/agents-view.tsx src/components/sidebar-minimal.tsx src/components/workspace-agents-landing.test.ts src/components/workspace.tsx src/lib/cave-conversations.ts src/lib/session-list-merge.ts src/lib/session-list-merge.test.ts