### PR TITLE
feat(a11y): keyboard composition — tabs, roving, listbox, table & calendar nav

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3335,7 +3335,7 @@ body {
   color: var(--text-primary);
   border-left-color: var(--familiar-accent, var(--accent-presence));
 }
-.familiar-studio__tab:disabled {
+.familiar-studio__tab[aria-disabled="true"] {
   opacity: 0.4;
   cursor: not-allowed;
 }

--- a/src/components/avatar-rail-roving.test.ts
+++ b/src/components/avatar-rail-roving.test.ts
@@ -1,0 +1,33 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./familiar-avatar-rail.tsx", import.meta.url),
+  "utf8",
+);
+
+assert.match(
+  source,
+  /import\s+\{[^}]*useRovingTabIndex[^}]*\}\s+from\s+["']@\/lib\/use-roving-tabindex["']/,
+  "imports useRovingTabIndex",
+);
+assert.match(
+  source,
+  /useRovingTabIndex\([\s\S]*?orientation:\s*["']vertical["']/,
+  "uses vertical orientation",
+);
+
+// Container should be a toolbar with an accessible name.
+assert.match(
+  source,
+  /role="toolbar"/,
+  "rail container has role=toolbar",
+);
+assert.match(
+  source,
+  /aria-label="Familiars"|aria-label=\{`Familiars/,
+  "rail toolbar has aria-label=Familiars",
+);
+
+console.log("avatar-rail-roving.test.ts OK");

--- a/src/components/board-table-keyboard.test.ts
+++ b/src/components/board-table-keyboard.test.ts
@@ -1,0 +1,38 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./board-table.tsx", import.meta.url),
+  "utf8",
+);
+
+assert.match(
+  source,
+  /import\s+\{[^}]*useRovingTabIndex[^}]*\}\s+from\s+["']@\/lib\/use-roving-tabindex["']/,
+  "imports useRovingTabIndex",
+);
+assert.match(source, /useRovingTabIndex\(/, "calls useRovingTabIndex");
+assert.match(
+  source,
+  /orientation:\s*["']vertical["']/,
+  "uses vertical orientation",
+);
+
+// Rows handle Enter and Escape.
+assert.match(source, /key === "Enter"/, "handles Enter to open");
+assert.match(source, /key === "Escape"/, "handles Escape to deselect");
+
+// Card rows are marked with the data attribute.
+assert.match(
+  source,
+  /data-board-row="true"/,
+  "card rows are marked data-board-row=true",
+);
+assert.match(
+  source,
+  /data-card-id=/,
+  "card rows expose data-card-id",
+);
+
+console.log("board-table-keyboard.test.ts OK");

--- a/src/components/board-table.tsx
+++ b/src/components/board-table.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import type { Familiar } from "@/lib/types";
 import type { Card, CardStatus, CardPriority } from "@/lib/cave-board-types";
 import { LifecycleBadge } from "@/components/ui/lifecycle-badge";
 import { Icon } from "@/lib/icon";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
+import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 
 export type GroupBy = "status" | "familiar";
 export type SortKey = "title" | "status" | "priority" | "familiar" | "cwd" | "links" | "lifecycle" | "updatedAt";
@@ -96,6 +97,34 @@ export function BoardTable({ cards, familiars, groupBy, selectedCardId, onSelect
   const sorted = useMemo(() => sortCards(cards, sortKey, sortDir, familiars), [cards, sortKey, sortDir, familiars]);
   const groups = useMemo(() => groupCards(sorted, groupBy, familiars), [sorted, groupBy, familiars]);
 
+  const tbodyRef = useRef<HTMLTableSectionElement | null>(null);
+  useRovingTabIndex({
+    containerRef: tbodyRef,
+    itemSelector: 'tr[data-board-row="true"]',
+    orientation: "vertical",
+  });
+
+  useEffect(() => {
+    const tbody = tbodyRef.current;
+    if (!tbody) return;
+    const onKey = (e: KeyboardEvent) => {
+      const target = document.activeElement as HTMLElement | null;
+      if (!target || !tbody.contains(target)) return;
+      if (e.key === "Enter") {
+        const cardId = target.dataset.cardId;
+        if (cardId) {
+          e.preventDefault();
+          onSelect(cardId);
+        }
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        onSelect("");
+      }
+    };
+    tbody.addEventListener("keydown", onKey);
+    return () => tbody.removeEventListener("keydown", onKey);
+  }, [onSelect]);
+
   const handleCol = (key: SortKey) => {
     if (sortKey === key) setSortDir((d) => (d === "asc" ? "desc" : "asc"));
     else { setSortKey(key); setSortDir("asc"); }
@@ -132,7 +161,7 @@ export function BoardTable({ cards, familiars, groupBy, selectedCardId, onSelect
             ))}
           </tr>
         </thead>
-        <tbody>
+        <tbody ref={tbodyRef}>
           {groups.map(({ key, label, cards: gc }) => (
             <React.Fragment key={key}>
               <tr key={`g-${key}`} className="board-table-group-row" onClick={() => toggleGroup(key)}>
@@ -150,7 +179,10 @@ export function BoardTable({ cards, familiars, groupBy, selectedCardId, onSelect
               {!collapsed.has(key) && gc.map((card) => {
                 const resolvedFamiliar = card.familiarId ? resolvedByIdMap.get(card.familiarId) ?? null : null;
                 return (
-                  <tr key={card.id} className={selectedCardId === card.id ? "selected" : ""}
+                  <tr key={card.id}
+                    data-board-row="true"
+                    data-card-id={card.id}
+                    className={selectedCardId === card.id ? "selected" : ""}
                     onClick={() => onSelect(card.id)}>
                     <td><span className="board-table-title">{card.title}</span></td>
                     <td>

--- a/src/components/browser-quick-open.test.ts
+++ b/src/components/browser-quick-open.test.ts
@@ -1,0 +1,16 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./browser-quick-open.tsx", import.meta.url),
+  "utf8",
+);
+
+assert.match(source, /role="listbox"/, "results container has role=listbox");
+assert.match(source, /role="option"/, "items have role=option");
+assert.match(source, /aria-controls=/, "input has aria-controls");
+assert.match(source, /aria-activedescendant=/, "input uses aria-activedescendant");
+assert.match(source, /aria-selected=/, "active item announced via aria-selected");
+
+console.log("browser-quick-open.test.ts OK");

--- a/src/components/browser-quick-open.tsx
+++ b/src/components/browser-quick-open.tsx
@@ -115,6 +115,11 @@ export function BrowserQuickOpen({ tabs, activeId, onSelect, onClose }: Props) {
             className="focus-ring-inset flex-1 rounded bg-transparent text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"
             spellCheck={false}
             autoComplete="off"
+            aria-label="Search open tabs and history"
+            aria-controls="browser-quick-open-listbox"
+            aria-activedescendant={
+              filtered.length > 0 ? `browser-quick-open-option-${safeIdx}` : undefined
+            }
           />
           {query && (
             <button
@@ -134,16 +139,27 @@ export function BrowserQuickOpen({ tabs, activeId, onSelect, onClose }: Props) {
             No tabs match &ldquo;{query}&rdquo;
           </p>
         ) : (
-          <ul ref={listRef} className="max-h-[320px] overflow-y-auto py-1.5">
+          <ul
+              id="browser-quick-open-listbox"
+              role="listbox"
+              ref={listRef}
+              className="max-h-[320px] overflow-y-auto py-1.5"
+            >
             {filtered.map((tab, i) => {
               const isActive = tab.id === activeId;
               const isHighlighted = i === safeIdx;
               const fav = favicon(tab);
 
               return (
-                <li key={tab.id}>
+                <li
+                  key={tab.id}
+                  role="option"
+                  id={`browser-quick-open-option-${i}`}
+                  aria-selected={i === safeIdx}
+                >
                   <button
                     type="button"
+                    tabIndex={-1}
                     className={`focus-ring-inset flex w-full items-center gap-3 px-4 py-2.5 text-left transition-none ${
                       isHighlighted ? "bg-[var(--bg-hover)]" : ""
                     }`}

--- a/src/components/calendar-keyboard.test.ts
+++ b/src/components/calendar-keyboard.test.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./calendar-view.tsx", import.meta.url),
+  "utf8",
+);
+
+assert.match(
+  source,
+  /import\s+\{[^}]*useRovingTabIndex[^}]*\}\s+from\s+["']@\/lib\/use-roving-tabindex["']/,
+  "imports useRovingTabIndex",
+);
+assert.match(source, /useRovingTabIndex\(/, "calls useRovingTabIndex(...)");
+assert.match(
+  source,
+  /orientation:\s*["']vertical["']/,
+  "uses vertical orientation",
+);
+
+// Events render as <button> with the data attribute.
+assert.match(
+  source,
+  /<button[\s\S]{0,400}data-calendar-event="true"/,
+  "events render as <button> with data-calendar-event for the rove selector",
+);
+
+console.log("calendar-keyboard.test.ts OK");

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -5,6 +5,7 @@ import type { InboxItem } from "@/lib/cave-inbox";
 import type { Familiar } from "@/lib/types";
 import { Icon } from "@/lib/icon";
 import type { IconName } from "@/lib/icon";
+import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -332,11 +333,18 @@ function TimeGrid({
   onOpenItem?: (item: InboxItem) => void;
 }) {
   const nowRef = useRef<HTMLDivElement>(null);
+  const gridRef = useRef<HTMLDivElement | null>(null);
   const today = new Date();
 
   useEffect(() => {
     nowRef.current?.scrollIntoView({ block: "center" });
   }, []);
+
+  useRovingTabIndex({
+    containerRef: gridRef,
+    itemSelector: '[data-calendar-event="true"]',
+    orientation: "vertical",
+  });
 
   function itemTop(item: InboxItem): number {
     const d = itemDate(item);
@@ -349,7 +357,7 @@ function TimeGrid({
   const nowTop = (nowMinutes / 60) * HOUR_HEIGHT;
 
   return (
-    <div className="flex flex-1 overflow-auto">
+    <div ref={gridRef} className="flex flex-1 overflow-auto">
       {/* Time axis */}
       <div
         className="sticky left-0 z-20 w-12 shrink-0 border-r border-[var(--border-hairline)] bg-[var(--bg-base)] relative"
@@ -401,6 +409,8 @@ function TimeGrid({
               .map((item) => (
                 <button
                   key={item.id}
+                  type="button"
+                  data-calendar-event="true"
                   onClick={() => onOpenItem?.(item)}
                   className="absolute left-1 right-1 rounded px-1.5 py-0.5 text-left text-[10px] bg-[var(--accent-presence)]/15 border border-[var(--accent-presence)]/30 hover:bg-[var(--accent-presence)]/25 transition-colors overflow-hidden"
                   style={{

--- a/src/components/familiar-avatar-rail.tsx
+++ b/src/components/familiar-avatar-rail.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { computePresence, REMOTE_HARNESSES } from "@/lib/presence";
 import { useFamiliarStudio } from "@/lib/familiar-studio-context";
 import { setFamiliarOrder } from "@/lib/cave-familiar-order";
+import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { SessionRow } from "@/lib/types";
 
@@ -37,6 +38,13 @@ export function FamiliarAvatarRail({
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [dropTargetId, setDropTargetId] = useState<string | null>(null);
   const [addMenuOpen, setAddMenuOpen] = useState(false);
+
+  const avatarListRef = useRef<HTMLUListElement | null>(null);
+  useRovingTabIndex({
+    containerRef: avatarListRef,
+    itemSelector: ".familiar-avatar-rail__avatar:not([disabled])",
+    orientation: "vertical",
+  });
 
   // Dismiss the + context menu on outside click or Esc.
   useEffect(() => {
@@ -118,7 +126,13 @@ export function FamiliarAvatarRail({
       className="familiar-avatar-rail"
       aria-label="Familiars"
     >
-      <ul className="familiar-avatar-rail__list">
+      <ul
+        ref={avatarListRef}
+        className="familiar-avatar-rail__list"
+        role="toolbar"
+        aria-orientation="vertical"
+        aria-label="Familiars"
+      >
         {familiars.map((f) => {
           const active = f.id === activeId;
           const needsReply = responseNeeded.has(f.id);

--- a/src/components/familiar-glyph-picker-panel.tsx
+++ b/src/components/familiar-glyph-picker-panel.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/lib/familiar-glyph";
 import { FamiliarGlyph as GlyphView } from "@/components/familiar-glyph";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
+import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 import type { Familiar } from "@/lib/types";
 
 type Props = {
@@ -41,6 +42,27 @@ export function FamiliarGlyphPickerPanel({ familiar, onHoverChange }: Props) {
     [onHoverChange],
   );
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const gridRef = useRef<HTMLDivElement | null>(null);
+
+  // 1D horizontal rove across every rendered glyph button (Recent + Results).
+  // Vertical/grid-aware navigation is deferred — the responsive column-count
+  // makes Up/Down ambiguous without a layout-aware design pass.
+  const { activeIndex } = useRovingTabIndex({
+    containerRef: gridRef,
+    itemSelector: '[data-glyph-button="true"]',
+    orientation: "horizontal",
+  });
+
+  // Keep the currently focused glyph in view as the rove moves.
+  useEffect(() => {
+    const grid = gridRef.current;
+    if (!grid) return;
+    const items = grid.querySelectorAll<HTMLElement>(
+      '[data-glyph-button="true"]',
+    );
+    const active = items[activeIndex];
+    active?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [activeIndex]);
 
   // Cmd/Ctrl+Backspace clears the current override.
   useEffect(() => {
@@ -160,7 +182,12 @@ export function FamiliarGlyphPickerPanel({ familiar, onHoverChange }: Props) {
       </div>
 
       {/* Grid */}
-      <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+      <div
+        ref={gridRef}
+        role="listbox"
+        aria-label="Glyph"
+        className="min-h-0 flex-1 overflow-y-auto px-3 py-3"
+      >
         {results.length === 0 ? (
           <div className="grid h-full place-items-center text-sm text-[var(--text-muted)]">
             No matches.
@@ -207,6 +234,10 @@ function GlyphButton({
   const glyph: FamiliarGlyph = { kind: "icon", name: entry.value };
   return (
     <button
+      type="button"
+      role="option"
+      aria-selected={active}
+      data-glyph-button="true"
       onClick={() => onPick(entry)}
       onMouseEnter={() => onHover(entry)}
       onMouseLeave={() => onHover(null)}

--- a/src/components/familiar-studio-tabs.test.ts
+++ b/src/components/familiar-studio-tabs.test.ts
@@ -1,0 +1,41 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./familiar-studio.tsx", import.meta.url),
+  "utf8",
+);
+
+// Tablist container exists.
+assert.match(source, /role="tablist"/, "tabstrip container has role=tablist");
+
+// Tab items use role=tab and aria-selected (not aria-current=page).
+assert.match(source, /role="tab"/, "tab buttons use role=tab");
+assert.match(source, /aria-selected=/, "tab buttons expose aria-selected");
+
+// Tabpanel area is labelled by the active tab.
+assert.match(source, /role="tabpanel"/, "tab content area is a tabpanel");
+assert.match(
+  source,
+  /aria-labelledby=/,
+  "tabpanel is labelled by its tab",
+);
+
+// Roving tabindex hook adopted.
+assert.match(
+  source,
+  /import\s+\{[^}]*useRovingTabIndex[^}]*\}\s+from\s+["']@\/lib\/use-roving-tabindex["']/,
+  "imports useRovingTabIndex",
+);
+assert.match(source, /useRovingTabIndex\(/, "calls useRovingTabIndex(...)");
+
+// Old aria-current="page" pattern on tabs is gone (still OK elsewhere in the file).
+const tabBlock = source.match(/role="tab"[\s\S]{0,200}/g)?.join("") ?? "";
+assert.doesNotMatch(
+  tabBlock,
+  /aria-current="page"/,
+  "tab buttons no longer use aria-current=page",
+);
+
+console.log("familiar-studio-tabs.test.ts OK");

--- a/src/components/familiar-studio.tsx
+++ b/src/components/familiar-studio.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useFamiliarStudio, type FamiliarStudioTab } from "@/lib/familiar-studio-context";
+import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 import { useResolvedFamiliars, type ResolvedFamiliar } from "@/lib/familiar-resolve";
 import {
   setFamiliarOverride,
@@ -83,6 +84,33 @@ export function FamiliarStudio({ familiars }: Props) {
 
   const disableNonLifecycle = listView && !familiar;
 
+  // Roving tabindex over the tablist. Arrow keys move focus across enabled
+  // tabs; Home/End jump to ends. We pair this with an effect below to also
+  // switch the active tab when focus moves (automatic activation per APG).
+  const tablistRef = useRef<HTMLDivElement | null>(null);
+  const { activeIndex } = useRovingTabIndex({
+    containerRef: tablistRef,
+    itemSelector: '[role="tab"]:not([aria-disabled="true"])',
+    // Tabstrip is visually a column (`flex-direction: column`), so vertical
+    // arrow keys move focus across tabs. aria-orientation below mirrors this.
+    orientation: "vertical",
+  });
+
+  // Automatic activation: switch activeTab whenever the roving focus lands on
+  // a new tab. Studio tab panels are cheap, so APG recommends auto activation.
+  useEffect(() => {
+    const enabledTabs = TABS.filter((t) =>
+      disableNonLifecycle ? t.id === "lifecycle" : true,
+    );
+    const target = enabledTabs[activeIndex];
+    if (target && target.id !== activeTab) {
+      setActiveTab(target.id);
+    }
+    // Intentionally omit activeTab/setActiveTab from deps: this effect drives
+    // activeTab from activeIndex, not the other way around.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeIndex, disableNonLifecycle]);
+
   return (
     <aside
       role="dialog"
@@ -90,24 +118,34 @@ export function FamiliarStudio({ familiars }: Props) {
       className="familiar-studio__drawer"
     >
       {/* Tabstrip */}
-      <nav className="familiar-studio__tabstrip" aria-label="Studio sections">
+      <div
+        role="tablist"
+        aria-label="Studio sections"
+        aria-orientation="vertical"
+        ref={tablistRef}
+        className="familiar-studio__tabstrip"
+      >
         {TABS.map((t) => {
           const disabled = disableNonLifecycle && t.id !== "lifecycle";
+          const selected = activeTab === t.id;
           return (
             <button
               key={t.id}
               type="button"
+              role="tab"
+              id={`familiar-studio-tab-${t.id}`}
+              aria-selected={selected}
+              aria-controls={`familiar-studio-panel-${t.id}`}
+              aria-disabled={disabled ? true : undefined}
               onClick={() => !disabled && setActiveTab(t.id)}
-              aria-current={activeTab === t.id ? "page" : undefined}
-              disabled={disabled}
-              className={`familiar-studio__tab${activeTab === t.id ? " familiar-studio__tab--active" : ""}`}
+              className={`familiar-studio__tab${selected ? " familiar-studio__tab--active" : ""}`}
             >
               <Icon name={t.icon} width={18} />
               <span>{t.label}</span>
             </button>
           );
         })}
-      </nav>
+      </div>
 
       {/* Main column */}
       <div className="familiar-studio__main">
@@ -132,7 +170,12 @@ export function FamiliarStudio({ familiars }: Props) {
           </button>
         </header>
 
-        <div className="familiar-studio__body">
+        <div
+          role="tabpanel"
+          id={`familiar-studio-panel-${activeTab}`}
+          aria-labelledby={`familiar-studio-tab-${activeTab}`}
+          className="familiar-studio__body"
+        >
           {/* Tab body slots — wired in later tasks. */}
           {activeTab === "identity" && familiar ? (
             <FamiliarStudioIdentityTab

--- a/src/components/glyph-picker-roving.test.ts
+++ b/src/components/glyph-picker-roving.test.ts
@@ -1,0 +1,48 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./familiar-glyph-picker-panel.tsx", import.meta.url),
+  "utf8",
+);
+
+assert.match(
+  source,
+  /import\s+\{[^}]*useRovingTabIndex[^}]*\}\s+from\s+["']@\/lib\/use-roving-tabindex["']/,
+  "imports useRovingTabIndex",
+);
+
+// Horizontal orientation explicitly — 1D rove across all glyphs.
+assert.match(
+  source,
+  /useRovingTabIndex\([\s\S]*?orientation:\s*["']horizontal["']/,
+  "uses horizontal orientation (1D rove)",
+);
+
+// scrollIntoView is called to keep the focused glyph visible.
+assert.match(
+  source,
+  /scrollIntoView\(\s*\{[\s\S]*?block:\s*["']nearest["']/,
+  "calls scrollIntoView({block:'nearest'}) on focus change",
+);
+
+// Container has a listbox/grid/toolbar role.
+assert.match(
+  source,
+  /role="(listbox|grid|toolbar)"/,
+  "grid container has an accessible role",
+);
+
+// Glyph buttons carry the data attr used as the rove selector.
+assert.match(
+  source,
+  /data-glyph-button="true"/,
+  "glyph buttons carry data-glyph-button attribute",
+);
+
+// Glyph buttons use role=option with aria-selected.
+assert.match(source, /role="option"/, "glyph buttons use role=option");
+assert.match(source, /aria-selected=/, "glyph buttons expose aria-selected");
+
+console.log("glyph-picker-roving.test.ts OK");


### PR DESCRIPTION
## Summary
Applies the `useRovingTabIndex` hook from #267 and the listbox pattern from the quickwins PR (#280) across six surfaces that previously had no keyboard composition. No new primitives; consumes what's already shipped.

- **Familiar studio:** APG tabs pattern (`role="tablist"` / `role="tab"` / `role="tabpanel"`) + **vertical** roving tabindex (the tabstrip is a left-side rail visually, so ArrowUp/Down match the visual axis). Skips `aria-disabled` tabs. Automatic activation (focus → switch tab). Replaces non-standard `aria-current="page"`.
- **Avatar rail:** vertical roving on the avatar list (one tab stop). Toolbar role. ArrowDown/Up + Home/End move focus. Sidebar toggle and "+" add button stay separate tab stops outside the rove.
- **Glyph picker:** 1D horizontal roving across the main grid's ~800 buttons + `scrollIntoView({block:"nearest"})` to keep the focused glyph visible. `role="listbox"` on the grid; `role="option"` + `aria-selected` on each `GlyphButton`. Vertical/grid-aware nav deferred (responsive column count needs design).
- **Browser quick-open:** listbox + `aria-activedescendant` (mirrors the command palette refactor from #280).
- **Board table:** vertical roving on `<tbody>` card rows. Enter opens the inspector via existing `onSelect(cardId)`; Esc clears selection via `onSelect("")`. Group rows skipped via the `data-board-row="true"` selector.
- **Calendar TimeGrid:** in-grid events become focusable `<button>`s with vertical roving. Enter activates. The macro day-anchor handler (ArrowLeft/Right shifts the focused date) is unchanged — horizontal arrows still navigate days while vertical arrows navigate events.

## Test plan
- [x] `pnpm typecheck` clean.
- [x] `pnpm build` clean.
- [x] 6/6 source-grep invariant tests pass.
- [x] Every commit signed.
- [ ] Manual per-surface keyboard smoke (Tab into each surface; arrow nav between items; Home/End; surface-specific activation: Enter on table rows, click on tabs/glyphs).

## Source
- Audit: `docs/superpowers/specs/2026-06-08-ux-audit.md` (gitignored).
- Plan: `docs/superpowers/plans/2026-06-08-a11y-keyboard.md` (gitignored).
- Foundations PR: #267. Quickwins PR: #280.

## Notable design decisions
- **Familiar studio orientation: vertical not horizontal.** Plan said horizontal but the CSS reveals the tabstrip is `flex-direction: column`. Vertical matches the visual axis per APG. `aria-orientation="vertical"` on the tablist.
- **Disabled tabs use `aria-disabled` not native `disabled`.** Per APG, disabled tabs should remain in the AT tree (announced as "tab, disabled"). Required porting one CSS rule from `:disabled` to `[aria-disabled="true"]`.
- **Glyph picker Recent strip stays outside the rove.** The Recent strip (max 12 items) sits above the main grid; including it would require restructuring the listbox to span both with semantic issues. Recent stays Tab-reachable as separate stops.

## Deferred to "A11y Composition" PR (next)
- Kanban keyboard drag-alternative (UX design — Space-to-grab vs. "Move to" menu).
- xterm SR mirror (PTY stream architecture).
- Library reader j/k heading nav (design — which headings, cycle behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)