### PR TITLE
chore(release): stamp v0.0.57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.57] — 2026-06-09
+
+Theme personality, recovered local chats with familiar-scoped memory,
+and a small PTY guard.
+
+### Added
+
+- **Expanded memory reader.** Memory inspector exposes a fuller
+  per-file reader so longer entries stay legible inside the panel
+  instead of clipping at the rail. (#287)
+
+### Changed
+
+- **Distinct theme personalities.** The eight default palettes
+  (Midnight, Dusk, Slate, Moss, Sky, Dawn, Latte, Storm) now read as
+  meaningfully different — each gets accent, surface, and contrast
+  values tuned to its mood instead of all converging on a similar
+  purple-blue middle. (#285)
+
+### Fixed
+
+- **Local chat recovery + familiar-scoped memory.** Chats stored in
+  the Cave-local conversation store are now recovered into the
+  session list when the daemon is offline, and the familiar memory
+  view is scoped to the active familiar so other familiars' files no
+  longer bleed into the surface. (#287)
+- **PTY zero-size guard.** Clamps PTY dimensions to a safe minimum
+  when the host terminal pane reports a zero-pixel area, preventing
+  the desktop from crashing when chat or terminal panes are collapsed
+  to nothing.
+
 ## [0.0.56] — 2026-06-09
 
 Cross-surface polish, memory provenance + a11y groundwork, and a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.56"
+version = "0.0.57"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary

Stamps the v0.0.57 release.

- Bumps `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json` from `0.0.56` to `0.0.57`.
- Adds the v0.0.57 `CHANGELOG.md` entry covering the three commits since v0.0.56.

## Included in v0.0.57

### Added
- Expanded memory reader inside the inspector (#287)

### Changed
- Distinct theme personalities for the 8 default palettes (#285)

### Fixed
- Local chat recovery + familiar-scoped memory (#287)
- PTY zero-size guard against zero-pixel panes

## Test plan

- [ ] CI green (frontend build + rust check).
- [ ] Merge.
- [ ] Tag `v0.0.57`; release workflow builds all four matrix legs and the `Set release notes` step renders the body from the new CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)