### PR TITLE
docs(changelog): correct v0.0.57 theme names + record #290

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,13 @@ and a small PTY guard.
 ### Changed
 
 - **Distinct theme personalities.** The eight default palettes
-  (Midnight, Dusk, Slate, Moss, Sky, Dawn, Latte, Storm) now read as
-  meaningfully different — each gets accent, surface, and contrast
-  values tuned to its mood instead of all converging on a similar
-  purple-blue middle. (#285)
+  (Coven, Tide, Grove, Ember, Bloom, Dusk, Mist, Slate) now carry
+  their hue in the chrome — background chroma is pushed 2–4× and
+  base lightness is staggered, so each theme reads as a different
+  mood (lavender grimoire, moontide blue, hexenwald moss, brazier
+  parchment, bewitching rose, witching-hour magenta, scrying-pool
+  teal, ink-and-bone) instead of the previous flat dark/light gray
+  with only a tinted accent button. (#285)
 
 ### Fixed
 
@@ -33,6 +36,10 @@ and a small PTY guard.
   session list when the daemon is offline, and the familiar memory
   view is scoped to the active familiar so other familiars' files no
   longer bleed into the surface. (#287)
+- **Ember light contrast.** Pulls Ember light background chroma back
+  and darkens the burnt-orange accent so body text reads cleanly on
+  the parchment surface; foreground and muted-foreground lightness
+  tightened to match. Ember dark untouched. (#290)
 - **PTY zero-size guard.** Clamps PTY dimensions to a safe minimum
   when the host terminal pane reports a zero-pixel area, preventing
   the desktop from crashing when chat or terminal panes are collapsed


### PR DESCRIPTION
## Summary

The CHANGELOG entry shipped with v0.0.57 (#291) was inaccurate in two places. **This PR is documentation-only; the v0.0.57 tag and the release artifacts being built from `a683bc7` are unchanged.**

### Theme names

The eight default palettes were listed as *Midnight, Dusk, Slate, Moss, Sky, Dawn, Latte, Storm*. None of those names exist in this codebase. The actual eight are **Coven, Tide, Grove, Ember, Bloom, Dusk, Mist, Slate**.

The description ("instead of all converging on a similar purple-blue middle") was also inaccurate — the real problem the patch solved was that all eight themes shared `oklch(0.07 / 0.99 lightness, 0.010–0.014 chroma)` backgrounds, so the chrome looked identical and only the accent button reflected the theme. The rewritten entry says that explicitly.

### Missing #290

PR #290 (`fix(themes): tone down Ember light for readable contrast`) merged ~2 minutes before the stamp commit but the release-notes generator didn't catch it. Added to the Fixed section.

## Test plan

- [x] Diff the rewritten entry against the actual eight `THEME_META.name` values in `src/lib/theme-palettes.ts` — all eight match
- [x] Confirm the new "Ember light" Fixed entry references #290 and describes the patch from PR #290 accurately
- [x] Pre-commit hook passes
- [ ] Eyeball the rendered CHANGELOG on the PR before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)