### PR TITLE
feat(a11y): add keyboard drag for kanban cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "mobile:tailscale": "bash scripts/mobile-tailscale.sh",
     "build": "next build",
     "typecheck": "tsc --noEmit",
-    "test:app": "node --experimental-strip-types src/lib/app-version.test.ts && node --experimental-strip-types src/components/settings-appearance.test.ts && node --experimental-strip-types src/components/chat-header-row.test.ts && node --experimental-strip-types src/components/agents-view.test.ts && node --experimental-strip-types src/components/workspace-agents-landing.test.ts",
+    "test:app": "node --experimental-strip-types src/lib/app-version.test.ts && node --experimental-strip-types src/components/settings-appearance.test.ts && node --experimental-strip-types src/components/chat-header-row.test.ts && node --experimental-strip-types src/components/agents-view.test.ts && node --experimental-strip-types src/components/workspace-agents-landing.test.ts && node --experimental-strip-types src/components/board-kanban-keyboard.test.ts",
     "test:api": "node --experimental-strip-types src/app/api/api-contracts.test.ts && node --experimental-strip-types src/app/api/board/enrich-steps/route.test.ts && node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts && node --experimental-strip-types src/app/api/library/route-link/route.test.ts && node --experimental-strip-types src/lib/session-list-merge.test.ts && node --experimental-strip-types src/lib/server/memory-file-sources.test.ts && node --experimental-strip-types src/lib/server/memory-file-paths.test.ts",
     "test:api:http": "node scripts/api-http-smoke.mjs",
     "start": "next start"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3923,3 +3923,13 @@ body {
   white-space: nowrap;
   border: 0;
 }
+
+/* Composition PR — keyboard drag affordance.
+   Visually distinct from --dragging so users can tell mouse-drag from
+   keyboard-grab. Uses --ring-focus for the lift; box-shadow for the float. */
+.board-kanban-card--grabbed {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 2px;
+  box-shadow: 0 8px 16px color-mix(in oklch, var(--accent-presence) 30%, transparent);
+  transform: translateY(-1px);
+}

--- a/src/components/board-kanban-keyboard.test.ts
+++ b/src/components/board-kanban-keyboard.test.ts
@@ -1,0 +1,58 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./board-kanban.tsx", import.meta.url),
+  "utf8",
+);
+
+// Consumes the foundations announcer.
+assert.match(
+  source,
+  /import\s+\{[^}]*useAnnouncer[^}]*\}\s+from\s+["']@\/components\/ui\/live-region["']/,
+  "imports useAnnouncer",
+);
+assert.match(source, /useAnnouncer\(\)/, "calls useAnnouncer()");
+
+// Grab-mode state.
+assert.match(
+  source,
+  /(grabbedCardId|keyboardGrabbedId)/,
+  "tracks the keyboard-grabbed card id in state",
+);
+
+// Key handlers.
+assert.match(source, /key === " "|e\.key === " "/, "handles Space (grab/drop)");
+assert.match(
+  source,
+  /key === "ArrowLeft"|key === "ArrowRight"/,
+  "handles ArrowLeft/Right for column nav while grabbed",
+);
+assert.match(source, /key === "Escape"/, "handles Escape to cancel grab");
+
+// Visual affordance class.
+assert.match(
+  source,
+  /board-kanban-card--grabbed/,
+  "applies the --grabbed class to the grabbed card",
+);
+
+// Announcements fire.
+assert.match(source, /announce\(/, "calls announce(...) for grab/move/drop");
+
+// Column containers are marked.
+assert.match(
+  source,
+  /data-kanban-column=/,
+  "column containers are marked with data-kanban-column",
+);
+
+// Card rows expose data-card-id.
+assert.match(
+  source,
+  /data-card-id=/,
+  "card rows expose data-card-id",
+);
+
+console.log("board-kanban-keyboard.test.ts OK");

--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { Card, CardStatus, CardPriority } from "@/lib/cave-board-types";
 import { LifecycleBadge } from "@/components/ui/lifecycle-badge";
@@ -8,6 +8,7 @@ import { Icon } from "@/lib/icon";
 import type { GroupBy } from "@/components/board-table";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
+import { useAnnouncer } from "@/components/ui/live-region";
 
 const COLUMNS: { id: CardStatus; label: string; hint: string }[] = [
   { id: "backlog",  label: "Backlog",  hint: "Ideas and work not ready to dispatch." },
@@ -59,8 +60,104 @@ export function BoardKanban({ cards, familiars, sessions, groupBy, selectedCardI
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<CardStatus | null>(null);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+  const [grabbedCardId, setGrabbedCardId] = useState<string | null>(null);
+  const { announce } = useAnnouncer();
   const draggingIdRef = useRef<string | null>(null);
   const railRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+  const columnIndex = useCallback(
+    (id: string) => COLUMNS.findIndex((c) => c.id === id),
+    [],
+  );
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const target = document.activeElement as HTMLElement | null;
+      const focusedCardId = target?.dataset?.cardId ?? null;
+
+      // Toggle grab on Space.
+      if (e.key === " ") {
+        if (grabbedCardId) {
+          // DROP. Find target column from the focused element.
+          const dropTargetStatus =
+            (target?.closest("[data-kanban-column]") as HTMLElement | null)
+              ?.dataset?.kanbanColumn as CardStatus | undefined;
+          const card = cards.find((c) => c.id === grabbedCardId);
+          if (card && dropTargetStatus && card.status !== dropTargetStatus) {
+            const col = COLUMNS.find((c) => c.id === dropTargetStatus);
+            onMoveStatus(grabbedCardId, dropTargetStatus);
+            announce(
+              `Moved '${card.title}' to ${col?.label ?? dropTargetStatus}.`,
+            );
+          } else if (card) {
+            announce("Drop cancelled — same column.");
+          }
+          setGrabbedCardId(null);
+          e.preventDefault();
+          return;
+        }
+        // GRAB.
+        if (focusedCardId) {
+          const card = cards.find((c) => c.id === focusedCardId);
+          if (!card) return;
+          setGrabbedCardId(focusedCardId);
+          announce(
+            `Picked up '${card.title}'. Use arrow keys to move; Space to drop; Escape to cancel.`,
+          );
+          e.preventDefault();
+        }
+        return;
+      }
+
+      // Escape cancels.
+      if (e.key === "Escape" && grabbedCardId) {
+        const card = cards.find((c) => c.id === grabbedCardId);
+        setGrabbedCardId(null);
+        announce(card ? `Cancelled moving '${card.title}'.` : "Cancelled.");
+        e.preventDefault();
+        return;
+      }
+
+      // Column nav while grabbed.
+      if (
+        (e.key === "ArrowLeft" || e.key === "ArrowRight") &&
+        grabbedCardId
+      ) {
+        const card = cards.find((c) => c.id === grabbedCardId);
+        if (!card) return;
+        // Read tentative current column from focus, NOT card.status, because
+        // card.status does not mutate during the grab session — we walk
+        // columns by where focus currently is.
+        const currentColEl =
+          (target?.closest("[data-kanban-column]") as HTMLElement | null) ??
+          null;
+        const currentStatus =
+          (currentColEl?.dataset?.kanbanColumn as CardStatus | undefined) ??
+          card.status;
+        const currentIdx = columnIndex(currentStatus);
+        if (currentIdx < 0) return;
+        const delta = e.key === "ArrowRight" ? 1 : -1;
+        const nextIdx = Math.max(
+          0,
+          Math.min(COLUMNS.length - 1, currentIdx + delta),
+        );
+        if (nextIdx === currentIdx) {
+          e.preventDefault();
+          return;
+        }
+        const nextCol = COLUMNS[nextIdx];
+        const colEl = document.querySelector<HTMLElement>(
+          `[data-kanban-column="${nextCol.id}"]`,
+        );
+        const firstCard = colEl?.querySelector<HTMLElement>("[data-card-id]");
+        (firstCard ?? colEl)?.focus();
+        announce(`Moving '${card.title}' over ${nextCol.label}.`);
+        e.preventDefault();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [grabbedCardId, cards, columnIndex, onMoveStatus, announce]);
 
   const groups = getGroups(cards, groupBy, familiars);
   const showSwimlanes = true;
@@ -150,6 +247,8 @@ export function BoardKanban({ cards, familiars, sessions, groupBy, selectedCardI
                     const isDrop = dropTarget === col.id;
                     return (
                       <div key={col.id}
+                        data-kanban-column={col.id}
+                        tabIndex={-1}
                         onDragEnter={(e) => handleDragEnter(e, col.id)}
                         onDragOver={(e) => handleDragOver(e, col.id)}
                         onDragLeave={(e) => handleDragLeave(e, col.id)}
@@ -185,6 +284,7 @@ export function BoardKanban({ cards, familiars, sessions, groupBy, selectedCardI
                           {rows.map((card) => (
                             <KanbanCard key={card.id} card={card} familiars={familiars} sessions={sessions}
                               isDragging={draggingId === card.id} isSelected={selectedCardId === card.id}
+                              isGrabbed={grabbedCardId === card.id}
                               onSelect={() => onSelect(card.id)}
                               onDragStart={(e) => handleDragStart(e, card.id)}
                               onDragEnd={handleDragEnd}
@@ -206,9 +306,9 @@ export function BoardKanban({ cards, familiars, sessions, groupBy, selectedCardI
   );
 }
 
-function KanbanCard({ card, familiars, sessions, isDragging, isSelected, onSelect, onDragStart, onDragEnd, onJumpToSession, onOpenTaskChat, chatLinking = false }: {
+function KanbanCard({ card, familiars, sessions, isDragging, isSelected, isGrabbed, onSelect, onDragStart, onDragEnd, onJumpToSession, onOpenTaskChat, chatLinking = false }: {
   card: Card; familiars: Familiar[]; sessions: SessionRow[];
-  isDragging: boolean; isSelected: boolean;
+  isDragging: boolean; isSelected: boolean; isGrabbed: boolean;
   onSelect: () => void; onDragStart: (e: React.DragEvent) => void; onDragEnd: () => void;
   onJumpToSession?: (sessionId: string, familiarId: string | null) => void;
   onOpenTaskChat?: (id: string) => Promise<void>;
@@ -224,14 +324,17 @@ function KanbanCard({ card, familiars, sessions, isDragging, isSelected, onSelec
 
   return (
     <li draggable
+      data-card-id={card.id}
       onDragStart={(e) => { draggedRef.current = true; onDragStart(e); }}
       onDragEnd={() => { setTimeout(() => { draggedRef.current = false; }, 0); onDragEnd(); }}
       onClick={() => { if (draggedRef.current) return; onSelect(); }}
-      onKeyDown={(e) => { if (e.key !== "Enter" && e.key !== " ") return; e.preventDefault(); onSelect(); }}
-      tabIndex={0} aria-selected={isSelected}
+      onKeyDown={(e) => { if (e.key !== "Enter") return; e.preventDefault(); onSelect(); }}
+      tabIndex={0} aria-selected={isSelected} aria-grabbed={isGrabbed}
       className={`board-kanban-card board-kanban-card--priority-${card.priority}${
         isSelected ? " board-kanban-card--selected" : ""
-      }${isDragging ? " board-kanban-card--dragging" : ""}`}
+      }${isDragging ? " board-kanban-card--dragging" : ""}${
+        isGrabbed ? " board-kanban-card--grabbed" : ""
+      }`}
     >
       <div className="board-kanban-card-top">
         <span className={`board-kanban-priority-pill board-kanban-priority-pill--${card.priority}`}>{pri.label}</span>

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -166,6 +166,7 @@
 .board-kanban-card:focus-visible { box-shadow:0 0 0 3px color-mix(in oklch,var(--accent-presence) 22%,transparent); border-color:color-mix(in oklch,var(--accent-presence) 55%,transparent); }
 .board-kanban-card--selected { background:color-mix(in oklch,var(--accent-presence) 13%,var(--bg-base)); border-color:color-mix(in oklch,var(--accent-presence) 55%,var(--border-strong)); box-shadow:inset 0 0 0 1px color-mix(in oklch,var(--accent-presence) 35%,transparent); }
 .board-kanban-card--dragging { opacity:.35; cursor:grabbing; }
+.board-kanban-card--grabbed { border-color:color-mix(in oklch,var(--accent-presence) 72%,var(--border-strong)); box-shadow:0 0 0 2px color-mix(in oklch,var(--accent-presence) 28%,transparent),inset 0 0 0 1px color-mix(in oklch,var(--accent-presence) 44%,transparent); }
 
 .board-kanban-card::before { content:""; position:absolute; left:0; top:8px; bottom:8px; width:3px; border-radius:0 2px 2px 0; }
 .board-kanban-card--priority-urgent::before { background:var(--color-danger); box-shadow:0 0 5px color-mix(in oklch,var(--color-danger) 50%,transparent); }


### PR DESCRIPTION
## Summary
- Add keyboard grab/drop behavior for Kanban cards using Space, ArrowLeft/ArrowRight, and Escape.
- Mark Kanban columns/cards with data attributes for focus movement and add live announcements.
- Add grabbed-card visual affordance and wire the static regression into test:app.

## Rebase
- Rebased onto current origin/main before push.

## Test Plan
- node --experimental-strip-types src/components/board-kanban-keyboard.test.ts
- pnpm test:app
- pnpm exec tsc --noEmit --pretty false
- pnpm build
- git diff --check origin/main..HEAD