### PR TITLE
feat(themes): add Hex (true red) and Bane (lime green)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2476,6 +2476,80 @@ body {
   --ring-focus: color-mix(in oklch, #1A857F 55%, transparent);
 }
 
+/* ---- Hex (bloodletter 25) — the mark that doesn't wash off ---- */
+[data-theme="hex"] {
+  --background: oklch(0.09 0.060 25);
+  --card: oklch(0.125 0.062 25);
+  --popover: oklch(0.125 0.062 25);
+  --muted: oklch(0.17 0.066 25);
+  --accent: oklch(0.17 0.066 25);
+  --secondary: oklch(0.17 0.066 25);
+  --muted-foreground: oklch(0.72 0.044 25);
+  --accent-presence: #E04848;
+  --ring: oklch(0.64 0.20 25);
+  --bg-base: var(--background);
+  --bg-panel: oklch(0.07 0.054 25);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.17 0.066 25);
+  --bg-hover: oklch(0.21 0.068 25);
+  --ring-focus: color-mix(in oklch, #E04848 55%, transparent);
+}
+[data-theme="hex"][data-mode="light"] {
+  --background: oklch(0.97 0.022 25);
+  --foreground: oklch(0.20 0.034 25);
+  --card: oklch(0.94 0.024 25);
+  --popover: oklch(0.96 0.024 25);
+  --muted: oklch(0.90 0.030 25);
+  --accent: oklch(0.90 0.030 25);
+  --secondary: oklch(0.90 0.030 25);
+  --muted-foreground: oklch(0.44 0.040 25);
+  --accent-presence: #A41C24;
+  --ring: oklch(0.52 0.22 25);
+  --bg-base: var(--background);
+  --bg-panel: oklch(0.99 0.016 25);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.91 0.026 25);
+  --bg-hover: oklch(0.87 0.030 25);
+  --ring-focus: color-mix(in oklch, #A41C24 55%, transparent);
+}
+
+/* ---- Bane (wolfsbane 125) — bright; deeply unwise ---- */
+[data-theme="bane"] {
+  --background: oklch(0.09 0.050 125);
+  --card: oklch(0.125 0.052 125);
+  --popover: oklch(0.125 0.052 125);
+  --muted: oklch(0.17 0.054 125);
+  --accent: oklch(0.17 0.054 125);
+  --secondary: oklch(0.17 0.054 125);
+  --muted-foreground: oklch(0.70 0.040 125);
+  --accent-presence: #A5F050;
+  --ring: oklch(0.78 0.18 125);
+  --bg-base: var(--background);
+  --bg-panel: oklch(0.07 0.044 125);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.17 0.054 125);
+  --bg-hover: oklch(0.21 0.056 125);
+  --ring-focus: color-mix(in oklch, #A5F050 55%, transparent);
+}
+[data-theme="bane"][data-mode="light"] {
+  --background: oklch(0.97 0.022 125);
+  --foreground: oklch(0.18 0.030 125);
+  --card: oklch(0.94 0.024 125);
+  --popover: oklch(0.96 0.024 125);
+  --muted: oklch(0.90 0.030 125);
+  --accent: oklch(0.90 0.030 125);
+  --secondary: oklch(0.90 0.030 125);
+  --muted-foreground: oklch(0.42 0.034 125);
+  --accent-presence: #4A7C18;
+  --ring: oklch(0.52 0.18 125);
+  --bg-base: var(--background);
+  --bg-panel: oklch(0.99 0.016 125);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.91 0.026 125);
+  --bg-hover: oklch(0.87 0.030 125);
+  --ring-focus: color-mix(in oklch, #4A7C18 55%, transparent);
+}
+
 /* ---- Slate (ink-and-bone 270) — no color, no mercy ---- */
 [data-theme="slate"] {
   --background: oklch(0.05 0.000 0);

--- a/src/app/globals.css.test.ts
+++ b/src/app/globals.css.test.ts
@@ -39,8 +39,8 @@ assert.match(covenRootBlock, /--background\s*:\s*oklch\(0\.13 0\.022 293\)/, "co
 
 console.log("globals.css.test.ts (task 3) OK");
 
-// Task 4 assertions: the 7 non-default themes each have dark + light blocks.
-const otherThemes = ["tide", "grove", "ember", "bloom", "dusk", "mist", "slate"];
+// Task 4 assertions: the 9 non-default themes each have dark + light blocks.
+const otherThemes = ["tide", "grove", "ember", "bloom", "dusk", "mist", "hex", "bane", "slate"];
 for (const id of otherThemes) {
   const darkRe = new RegExp(`\\[data-theme="${id}"\\]\\s*\\{`);
   const lightRe = new RegExp(`\\[data-theme="${id}"\\]\\[data-mode="light"\\]\\s*\\{`);

--- a/src/lib/theme-palettes.test.ts
+++ b/src/lib/theme-palettes.test.ts
@@ -3,12 +3,12 @@ import assert from "node:assert/strict";
 import { THEME_IDS, THEME_META, getSwatches } from "./theme-palettes.ts";
 import { LEGACY_THEME_RENAME, COVEN_THEME_KEY, COVEN_MODE_KEY } from "./theme-storage.ts";
 
-// 8 themes, coven is the default (first).
-assert.equal(THEME_IDS.length, 8);
+// 10 themes, coven is the default (first).
+assert.equal(THEME_IDS.length, 10);
 assert.equal(THEME_IDS[0], "coven");
 assert.deepEqual(
   [...THEME_IDS].sort(),
-  ["bloom", "coven", "dusk", "ember", "grove", "mist", "slate", "tide"],
+  ["bane", "bloom", "coven", "dusk", "ember", "grove", "hex", "mist", "slate", "tide"],
 );
 
 // Every theme has a name, hue, and both accent values.

--- a/src/lib/theme-palettes.ts
+++ b/src/lib/theme-palettes.ts
@@ -1,5 +1,5 @@
 /**
- * 8-theme roster metadata + swatch lookup for the appearance settings UI.
+ * 10-theme roster metadata + swatch lookup for the appearance settings UI.
  * The actual palette CSS lives in `src/app/globals.css`; this module
  * mirrors the accent values and a representative background swatch
  * per (theme, mode) so the settings grid can preview each card.
@@ -15,6 +15,8 @@ export const THEME_IDS = [
   "bloom",
   "dusk",
   "mist",
+  "hex",
+  "bane",
   "slate",
 ] as const;
 
@@ -73,6 +75,18 @@ export const THEME_META: Record<ThemeId, ThemeMeta> = {
     description: "Scrying-pool teal. Cold as a question without an answer.",
     hue: 198, accentDark: "#6BD8D3", accentLight: "#1A857F",
     bgDark: "oklch(0.09 0.030 198)", bgLight: "oklch(0.97 0.015 195)",
+  },
+  hex: {
+    name: "Hex",
+    description: "Bloodletter's brand. The mark that doesn't wash off.",
+    hue: 25, accentDark: "#E04848", accentLight: "#A41C24",
+    bgDark: "oklch(0.09 0.060 25)", bgLight: "oklch(0.97 0.022 25)",
+  },
+  bane: {
+    name: "Bane",
+    description: "Wolfsbane bloom. Bright; deeply unwise.",
+    hue: 125, accentDark: "#A5F050", accentLight: "#4A7C18",
+    bgDark: "oklch(0.09 0.050 125)", bgLight: "oklch(0.97 0.022 125)",
   },
   slate: {
     name: "Slate",


### PR DESCRIPTION
## Summary

Two new defaults to fill the coverage gaps left by v0.0.57:

- **Hex** (true red, hue 25°) — *"Bloodletter's brand. The mark that doesn't wash off."* Distinct from Bloom's pink-rose by ~3× higher background chroma (`0.060` vs `0.040`) and a darker base lightness (`0.09` vs `0.115`). Dark accent `#E04848`, light `#A41C24`.
- **Bane** (lime green, hue 125°) — *"Wolfsbane bloom. Bright; deeply unwise."* Distinct from Grove's mossy 150° forest by a yellower hue and a sharper accent. Dark accent `#A5F050`, light `#4A7C18`.

`THEME_IDS` count goes 8 → 10; Coven stays first/default and Slate stays last (the neutral closer).

## Files

- `src/app/globals.css` — new `[data-theme="hex"]` + `[data-theme="bane"]` blocks (dark + light), inserted before the Slate block
- `src/lib/theme-palettes.ts` — append `hex` + `bane` to `THEME_IDS` and `THEME_META`
- `src/lib/theme-palettes.test.ts` — count bump (8 → 10) + new sorted list
- `src/app/globals.css.test.ts` — `otherThemes` array picks up `hex` + `bane`

## Test plan

- [x] `npx --yes tsx --test src/lib/theme-palettes.test.ts src/app/globals.css.test.ts src/components/theme-script.test.ts` — all pass
- [x] Eyeballed in dev: cycled Hex + Bane in dark and light, both modes look distinct from neighbors (Bloom, Grove). Confirmed by the human at the keyboard ("ship it")
- [ ] Settings appearance preview cards render both new themes with their accent + bg swatches correctly
- [ ] Spot-check Bane light contrast — the chartreuse can be tough on text legibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)