### PR TITLE
feat(ia): shell IA spec last-mile — sidebar cleanup + rail persistence

### DIFF
--- a/src/components/companion-rail-persistence.test.ts
+++ b/src/components/companion-rail-persistence.test.ts
@@ -1,0 +1,60 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// 1. Shell exposes onAgentOpenChange prop and fires it on agentOpen state changes.
+{
+  const src = readFileSync(
+    new URL("./shell.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    src,
+    /onAgentOpenChange\?:\s*\(open:\s*boolean\)\s*=>\s*void/,
+    "Shell declares onAgentOpenChange prop",
+  );
+  assert.match(
+    src,
+    /onAgentOpenChange\?\.\(agentOpen\)/,
+    "Shell calls onAgentOpenChange(agentOpen) in an effect",
+  );
+}
+
+// 2. Workspace imports getRailOpen + setRailOpen from familiar-memory.
+{
+  const src = readFileSync(
+    new URL("./workspace.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    src,
+    /import\s+\{[\s\S]*?getRailOpen[\s\S]*?\}\s+from\s+["']@\/lib\/familiar-memory["']/,
+    "Workspace imports getRailOpen",
+  );
+  assert.match(
+    src,
+    /import\s+\{[\s\S]*?setRailOpen[\s\S]*?\}\s+from\s+["']@\/lib\/familiar-memory["']/,
+    "Workspace imports setRailOpen",
+  );
+
+  // 3. Workspace passes onAgentOpenChange to Shell.
+  assert.match(
+    src,
+    /onAgentOpenChange=\{/,
+    "Workspace passes onAgentOpenChange to Shell",
+  );
+  assert.match(
+    src,
+    /setRailOpen\(/,
+    "Workspace calls setRailOpen(...) somewhere",
+  );
+
+  // 4. Workspace restores rail state on activeId change.
+  assert.match(
+    src,
+    /getRailOpen\(/,
+    "Workspace calls getRailOpen(...) somewhere (for restore)",
+  );
+}
+
+console.log("companion-rail-persistence.test.ts OK");

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -99,6 +99,7 @@ function ShellInner({
   bottom,
   topBar,
   onNavOpenChange,
+  onAgentOpenChange,
 }: {
   familiarRail?: ReactNode;
   nav: ReactNode;
@@ -108,6 +109,7 @@ function ShellInner({
   bottom?: ReactNode;
   topBar?: ReactNode;
   onNavOpenChange?: (open: boolean) => void;
+  onAgentOpenChange?: (open: boolean) => void;
 }, ref: ForwardedRef<ShellHandle>) {
   const navRef = useRef<PanelImperativeHandle | null>(null);
   const listRef = useRef<PanelImperativeHandle | null>(null);
@@ -172,6 +174,10 @@ function ShellInner({
   useEffect(() => {
     onNavOpenChange?.(navOpen);
   }, [navOpen, onNavOpenChange]);
+
+  useEffect(() => {
+    onAgentOpenChange?.(agentOpen);
+  }, [agentOpen, onAgentOpenChange]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -65,10 +65,11 @@ assert.match(
   "Terminal remains a Tools surface",
 );
 
-assert.match(
+// NOTE: assertion updated by shell-ia-lastmile S1 — Capabilities removed from sidebar per 2026-06-08 spec.
+assert.doesNotMatch(
   source,
   /\{ id: "capabilities", label: "Capabilities"/,
-  "Capabilities is a Tools surface routing to the daemon /v1/capabilities endpoint",
+  "Capabilities is no longer a sidebar entry (removed per 2026-06-08 Shell IA spec)",
 );
 
 assert.doesNotMatch(
@@ -106,3 +107,30 @@ assert.match(
   /\.sidebar-foot-bell > \.relative,\n\.sidebar-foot-icon-cell/,
   "Footer rows should align labels from matching icon cells",
 );
+
+// S1 shell-ia-lastmile: roles + capabilities removed from sidebar entries.
+assert.doesNotMatch(
+  source,
+  /\{[^}]*id:\s*"roles"[^}]*\}/,
+  "roles is not a sidebar entry",
+);
+
+assert.doesNotMatch(
+  source,
+  /\{[^}]*id:\s*"capabilities"[^}]*\}/,
+  "capabilities is not a sidebar entry",
+);
+
+// S1: surviving Tools-group entries still include browser + terminal.
+assert.match(
+  source,
+  /id:\s*"browser"[^}]*group:\s*"tools"/,
+  "browser stays in Tools",
+);
+assert.match(
+  source,
+  /id:\s*"terminal"[^}]*group:\s*"tools"/,
+  "terminal stays in Tools",
+);
+
+console.log("sidebar-minimal.test.ts (shell-ia-lastmile) OK");

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -77,8 +77,6 @@ const FOLDER_MODES: Array<{
   // Tools
   { id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘8" },
   { id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools" },
-  { id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools" },
-  { id: "capabilities", label: "Capabilities", iconName: "ph:lightning-bold", group: "tools" },
   // Add-ons (gated)
   { id: "github", label: "GitHub", iconName: "ph:github-logo", group: "addons" },
 ];

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -26,6 +26,8 @@ import {
   setActiveFamiliar,
   getLastSurface,
   setLastSurface,
+  getRailOpen,
+  setRailOpen,
 } from "@/lib/familiar-memory";
 import { ChooserModal, type ChooserOption } from "@/components/ui/chooser-modal";
 import { AgentPanel } from "@/components/agent-panel";
@@ -129,6 +131,15 @@ export function Workspace() {
 
   useEffect(() => {
     setActiveFamiliar(activeId);
+  }, [activeId]);
+
+  useEffect(() => {
+    if (!activeId) return;
+    const desired = getRailOpen(activeId);
+    queueMicrotask(() => {
+      if (desired) shellRef.current?.openAgent();
+      else shellRef.current?.closeAgent();
+    });
   }, [activeId]);
 
   useEffect(() => {
@@ -1045,6 +1056,9 @@ export function Workspace() {
       <Shell
         ref={shellRef}
         onNavOpenChange={setNavOpen}
+        onAgentOpenChange={(open) => {
+          if (activeId) setRailOpen(activeId, open);
+        }}
         topBar={
           <TopBar
             surfaceLabel={surfaceLabel}


### PR DESCRIPTION
## Summary
Closes the three remaining items from the 2026-06-08 Shell IA spec; the fundamentals shipped quietly across recent PRs (#267 foundations + #280 quickwins did most of the IA work).

- **Sidebar:** drop `Roles` and `Capabilities` entries from the SURFACES list. The `mode === "roles"` and `mode === "capabilities"` route branches in `workspace.tsx` stay in place — `PluginsView`'s internal `setMode("capabilities")` (from "Create skill"/"Create plugin") still works. The matching `sidebar-minimal.test.ts` assertion that pinned Capabilities as a Tools surface is inverted to `doesNotMatch` with a note tying the change to this PR.
- **Companion rail per-familiar persistence:** wires the `cave:familiar:{id}:rail.open` helpers from `familiar-memory.ts` that have been exported but had no callers. Shell gains `onAgentOpenChange` (mirrors `onNavOpenChange` from #280). Workspace persists via `setRailOpen(activeId, open)` on every toggle and restores on `activeId` change via `getRailOpen` + `shellRef.openAgent()/closeAgent()` (deferred to a microtask so `shellRef` is mounted).

The global pane-width store (`cave.shell.widths.v1`) still drives initial geometry; the per-familiar key only overrides open/closed when an active familiar is known.

## Explicitly NOT in scope
- The spec's `agents → chat` consolidation. The "Familiars" sidebar entry routes to a real surface (roster, glyph picker entry, memory graph). Removing it would be a regression, not cleanup.
- Rerouting `PluginsView`'s internal `setMode("capabilities")` actions into Settings sections. Bigger refactor; future polish.

## Test plan
- [x] `pnpm typecheck` clean.
- [x] `pnpm build` clean.
- [x] 3/3 source-grep tests pass: `sidebar-minimal.test.ts` (no roles/capabilities), `companion-rail-persistence.test.ts` (Shell + Workspace wiring), `familiar-memory.test.ts` (no regression).
- [x] Every commit signed.
- [ ] Manual: sidebar no longer shows Roles/Capabilities; PluginsView's "Create skill"/"Create plugin" still navigates. Switching between two familiars with different rail preferences restores the right state for each.

## Source
- Spec: `docs/superpowers/specs/2026-06-08-ui-ux-shell-ia-design.md` (gitignored, status was "Approved (design); plan pending" — pending no longer).
- Plan: `docs/superpowers/plans/2026-06-08-shell-ia-lastmile.md` (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)