### PR TITLE
feat(chat,top-bar): Home button, prune redundant chat-surface chrome

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3128,6 +3128,33 @@ body {
   font-weight: 600;
 }
 
+.top-bar__home-btn {
+  display: inline-flex;
+  align-items: center;
+  height: 24px;
+  padding: 0 9px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-base);
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  transition: border-color var(--duration-fast) var(--ease-standard),
+              color var(--duration-fast) var(--ease-standard),
+              background var(--duration-fast) var(--ease-standard);
+}
+
+.top-bar__home-btn:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-raised);
+  color: var(--text-primary);
+}
+
+.top-bar__home-btn:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 2px;
+}
+
 .top-bar__crumb {
   display: inline-flex;
   align-items: center;

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -12,16 +12,22 @@ assert.match(
   "ChatSurface should be the integrated top-level chat surface",
 );
 
-assert.match(
+assert.doesNotMatch(
   chatSurface,
-  /placeholder="Search"/,
-  "ChatSurface should keep chat search in the primary command row",
+  /placeholder="Search"|\bActive <span|\bDone <span|\bDate<\/button>|\bStatus<\/button>|\bFlat<\/button>/,
+  "ChatSurface should not render a redundant search/status/group command strip above the chat UI",
 );
 
 assert.match(
   chatSurface,
   /New/,
   "ChatSurface should expose the primary chat launch action without a separate composer block",
+);
+
+assert.doesNotMatch(
+  chatSurface,
+  /ph:plug|Configure plugins|onOpenMode/,
+  "ChatSurface should not render the plugin/config icon in the chat interface",
 );
 
 assert.match(
@@ -50,8 +56,20 @@ assert.doesNotMatch(
 
 assert.match(
   chatSurface,
-  /<AgentsMemoryView[\s\S]*familiars=\{familiars\}[\s\S]*activeFamiliar=\{activeFamiliar\}/,
-  "ChatSurface should surface comprehensive memory as a first-class tab",
+  /const scopedFamiliars = useMemo\(\(\) => activeFamiliar \? \[activeFamiliar\] : \[\], \[activeFamiliar\]\)/,
+  "ChatSurface should derive a one-familiar list from the active familiar",
+);
+
+assert.match(
+  chatSurface,
+  /<AgentsMemoryView[\s\S]*familiars=\{scopedFamiliars\}[\s\S]*activeFamiliar=\{activeFamiliar\}[\s\S]*lockToFamiliar/,
+  "ChatSurface memory should stay locked to the selected familiar",
+);
+
+assert.match(
+  chatSurface,
+  /<SessionsView[\s\S]*familiars=\{scopedFamiliars\}[\s\S]*activeFamiliarId=\{activeFamiliarId\}[\s\S]*hideFamiliarFilter/,
+  "ChatSurface history should not receive the redundant full familiars list",
 );
 
 assert.match(
@@ -60,18 +78,10 @@ assert.match(
   "ChatSurface should label the third primary tab Memory instead of Traces",
 );
 
-// b05fba5 dropped the redundant group-by-Familiar option (familiar scoping
-// lives in the avatar rail now). Status/Date/None remain. Lock the removal
-// in so a regression that adds "Familiar" back surfaces immediately.
-assert.match(
-  chatSurface,
-  /useState<"status" \| "date" \| "none">/,
-  "ChatSurface group-by must only support status/date/none — Familiar option removed by b05fba5",
-);
 assert.doesNotMatch(
   chatSurface,
-  /setGroupBy\("familiar"\)/,
-  "ChatSurface should not reintroduce a Familiar group-by button",
+  /groupBy|setGroupBy|filteredSessions|groupedSessions|showClosed|setShowClosed|const \[query, setQuery\]/,
+  "ChatSurface should not keep unused command-strip filtering state",
 );
 
 assert.doesNotMatch(

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useMemo, useRef, useState, type RefObject } from "react";
+import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { ChatRouter, type ChatRouterHandle } from "@/components/chat-router";
 import { AgentsMemoryView } from "@/components/agents-memory-view";
 import { SessionsView } from "@/components/sessions-view";
@@ -8,7 +8,6 @@ import { InspectorPane } from "@/components/inspector-pane";
 import { AgentPanel } from "@/components/agent-panel";
 import { Icon } from "@/lib/icon";
 import type { InboxItem } from "@/lib/cave-inbox";
-import { inferOrigin } from "@/lib/session-origin";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { PendingChatAction } from "@/lib/pending-chat-action";
 
@@ -41,49 +40,9 @@ type Props = {
   onCreateReminder: (familiarId: string) => void;
   onOpenInboxItem: (item: InboxItem) => void;
   onInboxItemChanged: () => void | Promise<void>;
-  onOpenMode: (mode: string) => void;
   onOpenSession?: (sessionId: string, familiarId?: string) => void;
   onNewChat?: (familiarId?: string) => void;
   onSessionsChanged?: () => void;
-};
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function relTime(iso: string | undefined): string {
-  if (!iso) return "";
-  const ms = Date.now() - new Date(iso).getTime();
-  if (!Number.isFinite(ms)) return "";
-  if (ms < 60_000) return "just now";
-  const m = Math.floor(ms / 60_000);
-  if (m < 60) return `${m}m ago`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
-  return `${Math.floor(h / 24)}d ago`;
-}
-
-function isClosed(s: SessionRow): boolean {
-  if (s.archived_at) return true;
-  if (s.exit_code !== null) return true;
-  return ["complete", "completed", "done", "exited", "failed", "cancelled"].includes(s.status);
-}
-
-/** Only show a pill for meaningful / attention-worthy statuses. */
-function statusPill(s: SessionRow): { label: string; cls: string } | null {
-  if (s.status === "running") return { label: "running", cls: "border-[color-mix(in_oklch,var(--color-success)_30%,transparent)] bg-[color-mix(in_oklch,var(--color-success)_15%,transparent)] text-[var(--color-success)]" };
-  if (s.status === "failed" || (s.exit_code !== null && s.exit_code !== 0))
-    return { label: "failed", cls: "border-[color-mix(in_oklch,var(--color-danger)_30%,transparent)] bg-[color-mix(in_oklch,var(--color-danger)_15%,transparent)] text-[var(--color-danger)]" };
-  return null; // orphaned / created / idle = no pill
-}
-
-// ── Origin icon map ───────────────────────────────────────────────────────────
-
-const ORIGIN_ICONS: Record<string, string> = {
-  chat: "ph:chat-circle",
-  board: "ph:kanban",
-  cron: "ph:clock",
-  heartbeat: "ph:pulse",
-  call: "ph:phone",
-  mention: "ph:at",
 };
 
 // ── Right panel (inspector / chat) ────────────────────────────────────────────
@@ -194,19 +153,12 @@ export function ChatSurface({
   onCreateReminder,
   onOpenInboxItem,
   onInboxItemChanged,
-  onOpenMode,
   onOpenSession,
   onNewChat,
   onSessionsChanged,
 }: Props) {
   const [scope, setScope] = useState<AgentsScope>("sessions");
-  const [query, setQuery] = useState("");
-  const [showClosed, setShowClosed] = useState(false);
   const consumedPendingActionNonce = useRef<number | null>(null);
-  // groupBy intentionally omits "familiar": Chats is already filtered to the
-  // active agent, so grouping by familiar would always produce one group.
-  const [groupBy, setGroupBy] = useState<"status" | "date" | "none">("date");
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
   // Right panel — prefer new prop, fall back to legacy bool
   const rightPanel: "inspector" | "chat" | null =
@@ -217,9 +169,7 @@ export function ChatSurface({
     onSetInspectorOpen(next === "inspector");
   }
 
-  const famById = useMemo(() => new Map(familiars.map((f) => [f.id, f])), [familiars]);
-  const openCount = useMemo(() => sessions.filter((s) => !isClosed(s)).length, [sessions]);
-  const closedCount = sessions.length - openCount;
+  const scopedFamiliars = useMemo(() => activeFamiliar ? [activeFamiliar] : [], [activeFamiliar]);
 
   // Window events
   useEffect(() => {
@@ -276,85 +226,6 @@ export function ChatSurface({
     onPendingChatActionHandled();
   }, [onPendingChatActionHandled, onSetActiveFamiliar, pendingChatAction, routerRef]);
 
-  const filteredSessions = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return [...sessions]
-      .filter((s) => (s.origin ?? inferOrigin(s)) === "chat")
-      .filter((s) => (showClosed ? isClosed(s) : !isClosed(s)))
-      .filter((s) => (activeFamiliarId ? s.familiarId === activeFamiliarId : true))
-      .filter((s) => {
-        if (!q) return true;
-        const f = s.familiarId ? famById.get(s.familiarId) : null;
-        return [s.title, s.status, s.harness, s.project_root, s.origin ?? "", f?.display_name ?? ""]
-          .some((v) => v?.toLowerCase().includes(q));
-      })
-      .sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1));
-  }, [activeFamiliarId, famById, query, sessions, showClosed]);
-
-  const groupedSessions = useMemo(() => {
-    if (groupBy === "none") return [{ label: null, sessions: filteredSessions }];
-    const map = new Map<string, typeof filteredSessions>();
-    for (const s of filteredSessions) {
-      let key: string;
-      if (groupBy === "status") {
-        key = s.status ?? "unknown";
-      } else {
-        const d = new Date(s.updated_at);
-        const now = new Date();
-        const diffDays = Math.floor((now.getTime() - d.getTime()) / 86_400_000);
-        if (diffDays < 1) key = "Today";
-        else if (diffDays < 2) key = "Yesterday";
-        else if (diffDays < 7) key = "This week";
-        else key = "Older";
-      }
-      if (!map.has(key)) map.set(key, []);
-      map.get(key)!.push(s);
-    }
-    return [...map.entries()].map(([label, sessions]) => ({ label, sessions }));
-  }, [filteredSessions, groupBy]);
-
-  // Clear selection when filter/group changes
-  useEffect(() => { setSelectedIds(new Set()); }, [groupBy, showClosed, query]);
-
-  const allVisibleIds = useMemo(
-    () => new Set(filteredSessions.map((s) => s.id)),
-    [filteredSessions],
-  );
-  const allSelected = allVisibleIds.size > 0 && [...allVisibleIds].every((id) => selectedIds.has(id));
-  const someSelected = selectedIds.size > 0;
-
-  function toggleSelect(id: string) {
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  }
-  function toggleSelectAll() {
-    if (allSelected) setSelectedIds(new Set());
-    else setSelectedIds(new Set(allVisibleIds));
-  }
-  async function bulkArchive() {
-    await Promise.all(
-      [...selectedIds].map((id) =>
-        fetch(`/api/sessions/${id}`, {
-          method: "PATCH",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ archived: true }),
-        }),
-      ),
-    );
-    setSelectedIds(new Set());
-    onSessionStarted();
-  }
-  async function bulkDelete() {
-    if (!window.confirm(`Sacrifice ${selectedIds.size} session${selectedIds.size === 1 ? "" : "s"}? This cannot be undone.`)) return;
-    await Promise.all([...selectedIds].map((id) => fetch(`/api/sessions/${id}`, { method: "DELETE" })));
-    setSelectedIds(new Set());
-    onSessionStarted();
-  }
-
   function startConversation(familiarId?: string | null) {
     if (familiarId) onSetActiveFamiliar(familiarId);
     setScope("conversation");
@@ -402,90 +273,24 @@ export function ChatSurface({
           </div>
 
           {/* Actions flush right — chromeless */}
-          <div className="flex items-center gap-3 py-1.5">
-            {(scope === "sessions" || scope === "conversation") && (
-              <>
-                <div className="relative">
-                  <Icon name="ph:magnifying-glass" width={12} className="pointer-events-none absolute left-0 top-1/2 -translate-y-1/2 text-[var(--text-muted)]" />
-                  <input
-                    value={query}
-                    onChange={(e) => setQuery(e.target.value)}
-                    placeholder="Search"
-                    className="h-7 w-[90px] bg-transparent pl-5 pr-1 text-[12px] outline-none placeholder:text-[var(--text-muted)] focus:w-[160px] transition-all"
-                  />
-                </div>
-
-                <div className="flex items-center gap-2 text-[11px]" role="group" aria-label="Filter sessions by state">
-                  <button
-                    type="button"
-                    onClick={() => setShowClosed(false)}
-                    aria-pressed={!showClosed}
-                    className={!showClosed ? "text-[var(--text-primary)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"}
-                  >
-                    Active <span className="opacity-50">{openCount}</span>
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setShowClosed(true)}
-                    aria-pressed={showClosed}
-                    className={showClosed ? "text-[var(--text-primary)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"}
-                  >
-                    Done <span className="opacity-50">{closedCount}</span>
-                  </button>
-                </div>
-
-                <div className="flex items-center gap-2 text-[11px]" role="group" aria-label="Group by">
-                  <button
-                    type="button"
-                    onClick={() => setGroupBy("date")}
-                    aria-pressed={groupBy === "date"}
-                    className={groupBy === "date" ? "text-[var(--text-primary)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"}
-                  >
-                    Date
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setGroupBy("status")}
-                    aria-pressed={groupBy === "status"}
-                    className={groupBy === "status" ? "text-[var(--text-primary)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"}
-                  >
-                    Status
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setGroupBy("none")}
-                    aria-pressed={groupBy === "none"}
-                    className={groupBy === "none" ? "text-[var(--text-primary)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"}
-                  >
-                    Flat
-                  </button>
-                </div>
-              </>
-            )}
+          <div className="flex items-center gap-2 py-1.5">
             <button
               type="button"
               onClick={() => startConversation(activeFamiliarId)}
               title="New chat"
-              className="inline-flex h-7 items-center gap-1 text-[11px] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+              className="inline-flex h-7 items-center gap-1 text-[11px] text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)]"
             >
               <Icon name="ph:plus-bold" width={11} />
               New
-            </button>
-            <button
-              type="button"
-              title="Configure plugins"
-              onClick={() => onOpenMode("plugins")}
-              className="inline-flex h-7 items-center text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-            >
-              <Icon name="ph:plug" width={12} />
             </button>
           </div>
         </div>
 
         {scope === "memory" ? (
           <AgentsMemoryView
-            familiars={familiars}
+            familiars={scopedFamiliars}
             activeFamiliar={activeFamiliar}
+            lockToFamiliar
             onOpenMemoryFile={(path) => {
               setRightPanel("inspector");
               window.location.hash = `memory:${encodeURIComponent(path)}`;
@@ -528,7 +333,7 @@ export function ChatSurface({
           <div className="flex min-h-0 flex-1 flex-col">
             <div className="min-h-0 flex-1 overflow-y-auto">
               <SessionsView
-                familiars={familiars}
+                familiars={scopedFamiliars}
                 sessions={sessions}
                 activeFamiliarId={activeFamiliarId}
                 activeSessionId={activeSessionId ?? null}

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -9,6 +9,7 @@ import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 type Props = {
   surfaceLabel: string;
   subContext?: string;
+  onOpenHome: () => void;
   onOpenPalette: () => void;
   onOpenInbox: () => void;
   onOpenSettings: () => void;
@@ -24,6 +25,7 @@ export function TopBar(props: Props) {
   const {
     surfaceLabel,
     subContext,
+    onOpenHome,
     onOpenPalette,
     onOpenInbox,
     onOpenSettings,
@@ -38,16 +40,21 @@ export function TopBar(props: Props) {
   return (
     <header className="top-bar">
       <span className="top-bar__brand">CovenCave</span>
-      <span className="top-bar__crumb">
-        <span className="top-bar__crumb-sep" aria-hidden="true">›</span>
-        <span className="top-bar__crumb-surface">{surfaceLabel}</span>
-        {subContext ? (
-          <>
-            <span className="top-bar__crumb-sep" aria-hidden="true">›</span>
-            <span className="top-bar__crumb-sub">{subContext}</span>
-          </>
-        ) : null}
-      </span>
+      <button type="button" className="top-bar__home-btn" onClick={onOpenHome}>
+        Home
+      </button>
+      {surfaceLabel ? (
+        <span className="top-bar__crumb">
+          <span className="top-bar__crumb-sep" aria-hidden="true">›</span>
+          <span className="top-bar__crumb-surface">{surfaceLabel}</span>
+          {subContext ? (
+            <>
+              <span className="top-bar__crumb-sep" aria-hidden="true">›</span>
+              <span className="top-bar__crumb-sub">{subContext}</span>
+            </>
+          ) : null}
+        </span>
+      ) : null}
 
       <button
         type="button"

--- a/src/components/workspace-agents-landing.test.ts
+++ b/src/components/workspace-agents-landing.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const topBar = readFileSync(new URL("./top-bar.tsx", import.meta.url), "utf8");
 const workspaceMode = readFileSync(
   new URL("../lib/workspace-mode.ts", import.meta.url),
   "utf8",
@@ -55,6 +56,30 @@ assert.match(
   workspace,
   /agents: "Familiars"/,
   "SURFACE_LABELS labels the page Familiars",
+);
+
+assert.match(
+  workspace,
+  /const surfaceLabel = \(mode === "agents" \|\| mode === "chat"\) && active\s*\?\s*active\.display_name\s*:\s*mode === "home"\s*\?\s*""\s*:\s*\(SURFACE_LABELS\[mode\] \?\? "Home"\)/,
+  "Workspace top bar uses the active familiar name as the familiar-chat surface label",
+);
+
+assert.match(
+  workspace,
+  /const subContext = \(mode !== "agents" && mode !== "chat" && mode !== "home" && active\) \? active\.display_name : undefined/,
+  "Workspace should not duplicate the familiar name as a second crumb in familiar-chat contexts",
+);
+
+assert.match(
+  workspace,
+  /onOpenHome=\{\(\) => setMode\("home"\)\}/,
+  "Workspace should wire the top-bar Home button to Home mode",
+);
+
+assert.match(
+  topBar,
+  /onOpenHome[\s\S]*className="top-bar__home-btn"[\s\S]*>\s*Home\s*<\/button>/,
+  "TopBar should expose Home as a button instead of only breadcrumb text",
 );
 
 assert.match(

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -835,8 +835,12 @@ export function Workspace() {
   // count as needing attention; resolved/dismissed do not.
   const inboxBadgeCount = escalationsUnresolved;
 
-  const surfaceLabel = SURFACE_LABELS[mode] ?? "Home";
-  const subContext = active ? active.display_name : undefined;
+  const surfaceLabel = (mode === "agents" || mode === "chat") && active
+    ? active.display_name
+    : mode === "home"
+      ? ""
+      : (SURFACE_LABELS[mode] ?? "Home");
+  const subContext = (mode !== "agents" && mode !== "chat" && mode !== "home" && active) ? active.display_name : undefined;
   const showCompanionRail = railTab === "salem" || (mode !== "browser" && mode !== "agents");
 
   const openProjectChat = useCallback((projectRoot: string) => {
@@ -939,7 +943,6 @@ export function Workspace() {
         onCreateReminder={openReminderForFamiliar}
         onOpenInboxItem={openInspectorInboxItem}
         onInboxItemChanged={refreshInbox}
-        onOpenMode={(nextMode) => setMode(nextMode as WorkspaceMode)}
         onOpenSession={(sessionId, familiarId) => {
           openAgentSession(sessionId, familiarId);
         }}
@@ -1049,6 +1052,7 @@ export function Workspace() {
           <TopBar
             surfaceLabel={surfaceLabel}
             subContext={subContext}
+            onOpenHome={() => setMode("home")}
             onOpenPalette={() => setPaletteOpen(true)}
             onOpenInbox={() => setMode("inbox")}
             onOpenSettings={() => nextRouter.push("/settings")}


### PR DESCRIPTION
## Summary

Two paired UX moves that simplify the chat surface and make the workspace navigation more direct.

### Top bar
- Adds a clickable **Home** button as the first crumb (replaces the static crumb text). Wired via a new `onOpenHome` prop into `Workspace`, which sets mode back to `home`.
- Rewrites surface-label logic: in familiar-chat contexts, the *familiar's name* is the surface label instead of being duplicated as a second crumb; Home mode renders no label at all.
- New `.top-bar__home-btn` class in `globals.css`.

### ChatSurface pruning
Drops a stack of redundant controls now that scoping and navigation live elsewhere:
- **Search / status / group command strip** — filters are SessionsView's job
- **Plugin-config icon** — configuration belongs in settings, not the chat header
- **Memory + history tabs scoped to active familiar** via a derived `scopedFamiliars = [activeFamiliar]`; SessionsView no longer receives the full familiars list or shows the familiar filter chip

ChatSurface sheds ~200 lines of dead state and helpers in the process (`relTime`, `isClosed`, `statusPill`, the unused `groupBy/showClosed` state, the `onOpenMode` prop, and the `inferOrigin` import).

## Test plan

- [x] Tests invert to lock the new shape: ChatSurface should NOT render the command strip, the plugin icon, or pass the full familiars list down
- [x] `node --experimental-strip-types src/components/chat-surface.test.ts` — all assertions pass under the same harness CI uses
- [x] `node --experimental-strip-types src/components/workspace-agents-landing.test.ts` — all assertions pass; new assertions cover the surface-label rewrite, the `subContext` no-duplication rule, the `onOpenHome` wiring, and the TopBar button shape
- [x] Pre-commit hook passes
- [ ] Eyeball in dev: click Home from any non-home surface, confirm it returns to home mode; verify chat surface no longer shows the search/status/group strip or the plugin icon; verify memory and history within the chat surface only show the active familiar's content

🤖 Generated with [Claude Code](https://claude.com/claude-code)