### PR TITLE
feat(memory): memory view redesign — rail polish, list-mode drawer, balanced layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2980,17 +2980,29 @@ body {
   flex-direction: column;
   min-height: 0;
   flex: 1;
+  overflow: hidden;
+}
+
+.rail-memory__scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
 }
 
 .rail-memory__open-full {
+  flex-shrink: 0;
   padding: 8px 12px;
   border-top: 1px solid var(--border-hairline);
+  border-left: 0;
+  border-right: 0;
+  border-bottom: 0;
   background: transparent;
   color: var(--text-secondary);
   font-size: var(--text-sm);
   text-align: left;
   cursor: pointer;
-  border: 0;
 }
 
 .rail-memory__open-full:hover {

--- a/src/components/agents-memory-view-compact-path.test.ts
+++ b/src/components/agents-memory-view-compact-path.test.ts
@@ -1,0 +1,52 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("./agents-memory-view.tsx", import.meta.url), "utf8");
+
+// Static-source assertions: the function must define a threshold + take the last 3 segments.
+assert.match(
+  source,
+  /function compactPath\(path: string\): string \{/,
+  "compactPath function must exist",
+);
+assert.match(
+  source,
+  /const THRESHOLD\s*=\s*52/,
+  "compactPath must define a 52-char threshold for middle-ellipsis",
+);
+assert.match(
+  source,
+  /segments\.slice\(-3\)/,
+  "compactPath must keep the last 3 segments when ellipsizing",
+);
+assert.match(
+  source,
+  /\/…\//,
+  "compactPath must use the literal ellipsis between head and tail segments",
+);
+
+// Functional check via dynamic eval of the extracted body.
+const fnMatch = source.match(/function compactPath\(path: string\): string \{([\s\S]*?)\n\}/);
+assert.ok(fnMatch, "compactPath source body must be extractable for runtime check");
+// Strip TypeScript type annotations to make body evaluatable as plain JS.
+const body = fnMatch[1].replace(/: string/g, "");
+const compactPath = new Function("path", body);
+
+assert.equal(
+  compactPath("/Users/buns/.openclaw/familiars/nova/memory/2026-06-03.md"),
+  "~/.openclaw/familiars/nova/memory/2026-06-03.md",
+  "Under-threshold path keeps full structure",
+);
+assert.equal(
+  compactPath("/Users/buns/.openclaw/data/very/long/nested/path/familiars/nova/memory/2026-06-03.md"),
+  "~/…/nova/memory/2026-06-03.md",
+  "Over-threshold path collapses interior segments to ellipsis",
+);
+assert.equal(
+  compactPath("/Users/buns/short.md"),
+  "~/short.md",
+  "Trivial path round-trips through the ~ replacement",
+);
+
+console.log("agents-memory-view-compact-path.test.ts: ok");

--- a/src/components/agents-memory-view-full-tab.test.ts
+++ b/src/components/agents-memory-view-full-tab.test.ts
@@ -1,0 +1,25 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("./agents-memory-view.tsx", import.meta.url), "utf8");
+
+// ───────── Task 7: inline stats row ─────────
+
+assert.match(
+  source,
+  /data-testid="memory-stats-inline"/,
+  "Inline stats row must be marked with data-testid='memory-stats-inline'",
+);
+
+assert.doesNotMatch(
+  source,
+  /grid gap-2 sm:grid-cols-2 lg:grid-cols-4/,
+  "Old four-card stats grid must be removed",
+);
+
+for (const label of ["Agent memories", "Coven origin", "External harnesses", "Runtime memory"]) {
+  assert.ok(source.includes(label), `Inline stats row must keep label: ${label}`);
+}
+
+console.log("agents-memory-view-full-tab.test.ts: ok");

--- a/src/components/agents-memory-view-full-tab.test.ts
+++ b/src/components/agents-memory-view-full-tab.test.ts
@@ -22,6 +22,38 @@ for (const label of ["Agent memories", "Coven origin", "External harnesses", "Ru
   assert.ok(source.includes(label), `Inline stats row must keep label: ${label}`);
 }
 
+// ───────── Task 9: list-mode selection drawer ─────────
+
+assert.match(
+  source,
+  /const \[selectedRowId, setSelectedRowId\] = useState<string \| null>\(null\);/,
+  "AgentsMemoryView must keep a selectedRowId state",
+);
+
+assert.match(
+  source,
+  /data-testid="memory-list-drawer"/,
+  "List-mode drawer must be marked with data-testid='memory-list-drawer'",
+);
+
+assert.match(
+  source,
+  /!compact && selectedRowId\s*\?\s*\(/,
+  "Drawer renders only in non-compact mode when selectedRowId is set",
+);
+
+assert.match(
+  source,
+  /selectedRowId\s*\?\s*"grid gap-4 overflow-y-auto p-4 xl:grid-cols-\[minmax\(0,1fr\)_minmax\(0,1fr\)_minmax\(280px,360px\)\]"/,
+  "Container grid must use a 3-track layout when the drawer is open",
+);
+
+assert.match(
+  source,
+  /setSelectedRowId\(null\)/,
+  "Drawer must provide a way to clear the selection",
+);
+
 // ───────── Task 8: empty-state min-height collapsed ─────────
 
 assert.doesNotMatch(

--- a/src/components/agents-memory-view-full-tab.test.ts
+++ b/src/components/agents-memory-view-full-tab.test.ts
@@ -22,4 +22,18 @@ for (const label of ["Agent memories", "Coven origin", "External harnesses", "Ru
   assert.ok(source.includes(label), `Inline stats row must keep label: ${label}`);
 }
 
+// ───────── Task 8: empty-state min-height collapsed ─────────
+
+assert.doesNotMatch(
+  source,
+  /grid min-h-\[180px\] place-items-center rounded-lg border border-dashed/,
+  "Familiar memory empty-state card must not enforce min-h-[180px]",
+);
+
+assert.match(
+  source,
+  /grid place-items-center rounded-lg border border-dashed border-\[var\(--border-hairline\)\] px-4 py-6/,
+  "Empty-state card must use py-6 padding instead of min-h",
+);
+
 console.log("agents-memory-view-full-tab.test.ts: ok");

--- a/src/components/agents-memory-view-overflow.test.ts
+++ b/src/components/agents-memory-view-overflow.test.ts
@@ -1,0 +1,21 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("./agents-memory-view.tsx", import.meta.url), "utf8");
+
+// The <li> wrapping each memory file row must clamp its inner button.
+assert.match(
+  source,
+  /<li\s+key=\{entry\.fullPath\}\s+className="[^"]*\bmin-w-0\b/,
+  "Memory file <li> must include min-w-0 to prevent horizontal overflow",
+);
+
+// The <button> inside the <li> must also have min-w-0 so its child truncate clamps.
+assert.match(
+  source,
+  /className="focus-ring-inset flex min-w-0 flex-1 items-start/,
+  "Memory file row <button> must include min-w-0 so truncate clamps",
+);
+
+console.log("agents-memory-view-overflow.test.ts: ok");

--- a/src/components/agents-memory-view-overflow.test.ts
+++ b/src/components/agents-memory-view-overflow.test.ts
@@ -5,9 +5,10 @@ import { readFile } from "node:fs/promises";
 const source = await readFile(new URL("./agents-memory-view.tsx", import.meta.url), "utf8");
 
 // The <li> wrapping each memory file row must clamp its inner button.
+// Unique fingerprint: this is the only place we have `flex min-w-0 items-stretch gap-1 px-1`.
 assert.match(
   source,
-  /<li\s+key=\{entry\.fullPath\}\s+className="[^"]*\bmin-w-0\b/,
+  /flex min-w-0 items-stretch gap-1 px-1/,
   "Memory file <li> must include min-w-0 to prevent horizontal overflow",
 );
 

--- a/src/components/agents-memory-view-rail.test.ts
+++ b/src/components/agents-memory-view-rail.test.ts
@@ -1,0 +1,30 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("./agents-memory-view.tsx", import.meta.url), "utf8");
+
+// ───────── Task 4: placeholder + pill ─────────
+
+// Placeholder uses the locked familiar's display name when present.
+assert.match(
+  source,
+  /selectedFamiliar\.display_name\}'s memory/,
+  "Placeholder must include `${selectedFamiliar.display_name}'s memory` template",
+);
+
+// Generic fallback still present.
+assert.match(
+  source,
+  /"Search memory\.\.\."/,
+  "Generic placeholder fallback 'Search memory...' must remain",
+);
+
+// The standalone <span aria-label="Locked to familiar"> must be gone.
+assert.doesNotMatch(
+  source,
+  /aria-label="Locked to familiar"/,
+  "Redundant locked-familiar pill must be removed",
+);
+
+console.log("agents-memory-view-rail.test.ts: ok");

--- a/src/components/agents-memory-view-rail.test.ts
+++ b/src/components/agents-memory-view-rail.test.ts
@@ -67,4 +67,32 @@ assert.doesNotMatch(
   "Old asymmetric 1.25/0.75 grid must be removed",
 );
 
+// ───────── Task 10: sticky rail footer ─────────
+
+const cssSource = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
+
+assert.match(
+  cssSource,
+  /\.rail-memory\s*\{[^}]*overflow:\s*hidden/,
+  "rail-memory container must hide overflow so the inner scroll pane handles it",
+);
+
+assert.match(
+  cssSource,
+  /\.rail-memory__scroll\s*\{[^}]*flex:\s*1[\s\S]*?min-height:\s*0[\s\S]*?overflow-y:\s*auto/,
+  "rail-memory__scroll must define the inner scroll surface",
+);
+
+assert.match(
+  cssSource,
+  /\.rail-memory__open-full\s*\{[^}]*flex-shrink:\s*0/,
+  "rail-memory__open-full must be pinned (flex-shrink: 0)",
+);
+
+assert.match(
+  source,
+  /<div className="rail-memory__scroll">\s*<AgentsMemoryView/,
+  "RailMemoryList must wrap AgentsMemoryView in a .rail-memory__scroll div",
+);
+
 console.log("agents-memory-view-rail.test.ts: ok");

--- a/src/components/agents-memory-view-rail.test.ts
+++ b/src/components/agents-memory-view-rail.test.ts
@@ -27,6 +27,26 @@ assert.doesNotMatch(
   "Redundant locked-familiar pill must be removed",
 );
 
+// ───────── Task 6: unified rail empty state ─────────
+
+assert.match(
+  source,
+  /No memories yet for/,
+  "Rail must render a unified empty state title when both sections are empty",
+);
+
+assert.match(
+  source,
+  /Familiar memories are saved during chats/,
+  "Shared empty state must explain what familiar memories are",
+);
+
+assert.match(
+  source,
+  /\{compact\s*&&\s*loaded\s*&&\s*visibleCoven\.length\s*===\s*0\s*&&\s*visibleFiles\.length\s*===\s*0\s*\?/,
+  "Shared empty state must only render in compact mode when both lists are empty after load",
+);
+
 // ───────── Task 5: vertical stack / balanced columns ─────────
 
 assert.match(

--- a/src/components/agents-memory-view-rail.test.ts
+++ b/src/components/agents-memory-view-rail.test.ts
@@ -27,4 +27,24 @@ assert.doesNotMatch(
   "Redundant locked-familiar pill must be removed",
 );
 
+// ───────── Task 5: vertical stack / balanced columns ─────────
+
+assert.match(
+  source,
+  /compact\s*\?\s*"flex flex-col gap-4 overflow-y-auto p-4"/,
+  "List-mode container must stack vertically when compact",
+);
+
+assert.match(
+  source,
+  /xl:grid-cols-\[minmax\(0,1fr\)_minmax\(0,1fr\)\]/,
+  "List-mode container (non-compact) must use a balanced 1fr/1fr grid",
+);
+
+assert.doesNotMatch(
+  source,
+  /xl:grid-cols-\[minmax\(0,1\.25fr\)_minmax\(320px,0\.75fr\)\]/,
+  "Old asymmetric 1.25/0.75 grid must be removed",
+);
+
 console.log("agents-memory-view-rail.test.ts: ok");

--- a/src/components/agents-memory-view-redundant-tags.test.ts
+++ b/src/components/agents-memory-view-redundant-tags.test.ts
@@ -1,0 +1,35 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("./agents-memory-view.tsx", import.meta.url), "utf8");
+
+// Prop on the type.
+assert.match(
+  source,
+  /type MemoryFilesListProps = \{[\s\S]*?activeFamiliarId\?:\s*string\s*\|\s*null/,
+  "MemoryFilesListProps must declare activeFamiliarId",
+);
+
+// Prop destructured in the component signature.
+assert.match(
+  source,
+  /export function MemoryFilesList\(\{[\s\S]*?activeFamiliarId,?[\s\S]*?\}: MemoryFilesListProps\)/,
+  "MemoryFilesList must destructure activeFamiliarId",
+);
+
+// Conditional render that hides the familiar badge when it matches the filter.
+assert.match(
+  source,
+  /entry\.familiarId\s*&&\s*entry\.familiarId\s*!==\s*activeFamiliarId\s*\?\s*<span/,
+  "MemoryFilesList must hide the familiar:<id> badge when it matches the active filter",
+);
+
+// The internal call site in AgentsMemoryView must thread the filter through.
+assert.match(
+  source,
+  /<MemoryFilesList[\s\S]*?activeFamiliarId=\{familiarFilter\}/,
+  "AgentsMemoryView must pass familiarFilter as activeFamiliarId to MemoryFilesList",
+);
+
+console.log("agents-memory-view-redundant-tags.test.ts: ok");

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -596,14 +596,16 @@ export function RailMemoryList({
   }
   return (
     <div className="rail-memory">
-      <AgentsMemoryView
-        familiars={familiars}
-        activeFamiliar={familiar}
-        mode="list"
-        limit={20}
-        compact
-        lockToFamiliar
-      />
+      <div className="rail-memory__scroll">
+        <AgentsMemoryView
+          familiars={familiars}
+          activeFamiliar={familiar}
+          mode="list"
+          limit={20}
+          compact
+          lockToFamiliar
+        />
+      </div>
       {onOpenFullView ? (
         <button
           type="button"

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -291,18 +291,11 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
             <input
               value={query}
               onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search memory..."
+              placeholder={lockToFamiliar && selectedFamiliar?.display_name ? `Search ${selectedFamiliar.display_name}'s memory...` : "Search memory..."}
               className="focus-ring h-8 w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 pl-7 pr-3 text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent-presence)]"
             />
           </div>
-          {lockToFamiliar ? (
-            <span
-              className="inline-flex h-8 items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 text-[12px] text-[var(--text-secondary)]"
-              aria-label="Locked to familiar"
-            >
-              {selectedFamiliar?.display_name ?? "—"}
-            </span>
-          ) : (
+          {lockToFamiliar ? null : (
             <select
               value={familiarFilter}
               onChange={(event) => setFamiliarFilter(event.target.value)}

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -415,7 +415,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
           </aside>
         </div>
       ) : (
-      <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto p-4 xl:grid-cols-[minmax(0,1.25fr)_minmax(320px,0.75fr)]">
+      <div className={`min-h-0 flex-1 ${compact ? "flex flex-col gap-4 overflow-y-auto p-4" : "grid gap-4 overflow-y-auto p-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]"}`}>
         <section className="min-h-0">
           <div className="mb-2 flex items-center justify-between">
             <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">Familiar memory</h3>

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -62,7 +62,14 @@ function age(iso: string | undefined): string {
 }
 
 function compactPath(path: string): string {
-  return path.replace(/^\/Users\/[^/]+/, "~");
+  const collapsed = path.replace(/^\/Users\/[^/]+/, "~");
+  const THRESHOLD = 52;
+  if (collapsed.length <= THRESHOLD) return collapsed;
+  const segments = collapsed.split("/").filter(Boolean);
+  if (segments.length <= 4) return collapsed;
+  const first = collapsed.startsWith("~") ? "~" : `/${segments[0]}`;
+  const last = segments.slice(-3);
+  return `${first}/…/${last.join("/")}`;
 }
 
 function memoryMatches(entry: CovenMemoryEntry | FileMemoryEntry, query: string): boolean {

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -103,6 +103,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
   const [familiarFilter, setFamiliarFilter] = useState<string>(activeFamiliar?.id ?? familiars[0]?.id ?? "");
   const [viewMode, setViewMode] = useState<"list" | "graph">("graph");
   const [selectedMemoryId, setSelectedMemoryId] = useState<string | null>(null);
+  const [selectedRowId, setSelectedRowId] = useState<string | null>(null);
   const effectiveViewMode = mode ?? viewMode;
   const effectiveLimit = limit ?? Infinity;
   const [error, setError] = useState<string | null>(null);
@@ -406,7 +407,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
           </aside>
         </div>
       ) : (
-      <div className={`min-h-0 flex-1 ${compact ? "flex flex-col gap-4 overflow-y-auto p-4" : "grid gap-4 overflow-y-auto p-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]"}`}>
+      <div className={`min-h-0 flex-1 ${compact ? "flex flex-col gap-4 overflow-y-auto p-4" : selectedRowId ? "grid gap-4 overflow-y-auto p-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(280px,360px)]" : "grid gap-4 overflow-y-auto p-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]"}`}>
         {compact && loaded && visibleCoven.length === 0 && visibleFiles.length === 0 ? (
           <div className="grid place-items-center rounded-lg border border-dashed border-[var(--border-hairline)] bg-[var(--bg-raised)]/25 px-4 py-10 text-center">
             <Icon name="ph:brain" width={22} className="text-[var(--text-muted)]" />
@@ -433,7 +434,11 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
               {visibleCoven.slice(0, effectiveLimit === Infinity ? 80 : effectiveLimit).map((entry) => {
                 const familiar = familiarById.get(entry.familiar_id);
                 return (
-                  <article key={entry.id} className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 p-3">
+                  <article
+                    key={entry.id}
+                    onClick={() => { if (!compact) setSelectedRowId(`coven:${entry.id}`); }}
+                    className={`rounded-lg border p-3 transition-colors ${compact ? "border-[var(--border-hairline)] bg-[var(--bg-raised)]/35" : selectedRowId === `coven:${entry.id}` ? "cursor-pointer border-[var(--accent-presence)] bg-[var(--bg-raised)]/55" : "cursor-pointer border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 hover:bg-[var(--bg-raised)]/50"}`}
+                  >
                     <div className="flex items-start justify-between gap-2">
                       <div className="min-w-0">
                         <div className="flex items-center gap-1.5 text-[10px] text-[var(--text-muted)]">
@@ -452,7 +457,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
                     <div className="mt-3 flex flex-wrap items-center gap-1.5">
                       <button
                         type="button"
-                        onClick={() => onOpenMemoryFile?.(entry.path)}
+                        onClick={(e) => { e.stopPropagation(); onOpenMemoryFile?.(entry.path); }}
                         className="focus-ring inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
                       >
                         <Icon name="ph:file-text" width={12} />
@@ -479,8 +484,86 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
             error={error}
             limit={effectiveLimit === Infinity ? 160 : effectiveLimit}
             activeFamiliarId={familiarFilter}
+            onSelect={compact ? undefined : (rowId) => setSelectedRowId(rowId)}
+            selectedRowId={compact ? null : selectedRowId}
           />
         </section>
+        {!compact && selectedRowId ? (
+          <aside data-testid="memory-list-drawer" className="min-h-0 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 p-3">
+            <div className="flex items-center justify-between gap-2">
+              <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">Selected</h3>
+              <button
+                type="button"
+                onClick={() => setSelectedRowId(null)}
+                className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+                aria-label="Close drawer"
+              >
+                <Icon name="ph:x-bold" width={11} />
+              </button>
+            </div>
+            {(() => {
+              if (selectedRowId.startsWith("coven:")) {
+                const id = selectedRowId.slice("coven:".length);
+                const entry = visibleCoven.find((c) => c.id === id);
+                if (!entry) return <div className="mt-3 text-[12px] text-[var(--text-muted)]">Memory no longer in view.</div>;
+                const familiar = familiarById.get(entry.familiar_id);
+                return (
+                  <div className="mt-3">
+                    <h4 className="line-clamp-3 text-[14px] font-semibold leading-5 text-[var(--text-primary)]">{entry.title}</h4>
+                    <div className="mt-2 flex flex-wrap gap-1.5 text-[10px] text-[var(--text-muted)]">
+                      <span className="rounded bg-[var(--bg-elevated)] px-1.5 py-0.5 text-[var(--text-secondary)]">{familiar?.display_name ?? entry.familiar_id}</span>
+                      <span className="rounded bg-[var(--bg-elevated)] px-1.5 py-0.5">Coven memory</span>
+                      <span className="rounded bg-[var(--bg-elevated)] px-1.5 py-0.5">{age(entry.updated_at)}</span>
+                    </div>
+                    {entry.excerpt ? <p className="mt-3 line-clamp-6 text-[12px] leading-5 text-[var(--text-secondary)]">{entry.excerpt}</p> : null}
+                    <div className="mt-3 flex flex-wrap items-center gap-1.5">
+                      <button
+                        type="button"
+                        onClick={() => onOpenMemoryFile?.(entry.path)}
+                        className="focus-ring inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+                      >
+                        <Icon name="ph:file-text" width={12} />
+                        Open memory
+                      </button>
+                      <ExpandMemoryButton path={entry.path} title={entry.title} />
+                    </div>
+                  </div>
+                );
+              }
+              if (selectedRowId.startsWith("file:")) {
+                const fullPath = selectedRowId.slice("file:".length);
+                const entry = visibleFiles.find((f) => f.fullPath === fullPath);
+                if (!entry) return <div className="mt-3 text-[12px] text-[var(--text-muted)]">File no longer in view.</div>;
+                return (
+                  <div className="mt-3">
+                    <h4 className="line-clamp-3 text-[14px] font-semibold leading-5 text-[var(--text-primary)]">{entry.relPath}</h4>
+                    <div className="mt-2 flex flex-wrap gap-1.5 text-[10px] text-[var(--text-muted)]">
+                      <span className="rounded bg-[var(--bg-elevated)] px-1.5 py-0.5 text-[var(--text-secondary)]">{entry.sourceKindLabel}</span>
+                      <span className="rounded bg-[var(--bg-elevated)] px-1.5 py-0.5">{entry.rootLabel}</span>
+                      <span className="rounded bg-[var(--bg-elevated)] px-1.5 py-0.5">{age(entry.modified)}</span>
+                    </div>
+                    <div className="mt-3 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-elevated)]/40 px-2.5 py-2">
+                      <div className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">Path</div>
+                      <code className="mt-1 block break-all font-mono text-[11px] leading-4 text-[var(--text-primary)]">{compactPath(entry.fullPath)}</code>
+                    </div>
+                    <div className="mt-3 flex flex-wrap items-center gap-1.5">
+                      <button
+                        type="button"
+                        onClick={() => onOpenMemoryFile?.(entry.fullPath)}
+                        className="focus-ring inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+                      >
+                        <Icon name="ph:file-text" width={12} />
+                        Open file
+                      </button>
+                      <ExpandMemoryButton path={entry.fullPath} title={entry.relPath} />
+                    </div>
+                  </div>
+                );
+              }
+              return null;
+            })()}
+          </aside>
+        ) : null}
           </>
         )}
       </div>
@@ -548,6 +631,8 @@ type MemoryFilesListProps = {
   className?: string;
   listClassName?: string;
   activeFamiliarId?: string | null;
+  onSelect?: (rowId: string) => void;
+  selectedRowId?: string | null;
 };
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -674,6 +759,8 @@ export function MemoryFilesList({
   className,
   listClassName,
   activeFamiliarId,
+  onSelect,
+  selectedRowId,
 }: MemoryFilesListProps) {
   const sliced = entries.slice(0, limit ?? entries.length);
   return (
@@ -694,10 +781,13 @@ export function MemoryFilesList({
       ) : (
         <ul className={listClassName ?? "max-h-[640px] divide-y divide-[var(--border-hairline)] overflow-y-auto"}>
           {sliced.map((entry) => (
-            <li key={entry.fullPath} className="flex min-w-0 items-stretch gap-1 px-1 hover:bg-[var(--bg-raised)]">
+            <li
+              key={entry.fullPath}
+              className={`flex min-w-0 items-stretch gap-1 px-1 ${selectedRowId === `file:${entry.fullPath}` ? "bg-[var(--bg-raised)]/60" : "hover:bg-[var(--bg-raised)]"}`}
+            >
               <button
                 type="button"
-                onClick={() => onOpen?.(entry.fullPath)}
+                onClick={() => (onSelect ? onSelect(`file:${entry.fullPath}`) : onOpen?.(entry.fullPath))}
                 className="focus-ring-inset flex min-w-0 flex-1 items-start gap-2 px-2 py-2 text-left"
               >
                 <Icon name="ph:file-text" width={13} className="mt-0.5 shrink-0 text-[var(--text-muted)]" />

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -416,6 +416,18 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
         </div>
       ) : (
       <div className={`min-h-0 flex-1 ${compact ? "flex flex-col gap-4 overflow-y-auto p-4" : "grid gap-4 overflow-y-auto p-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]"}`}>
+        {compact && loaded && visibleCoven.length === 0 && visibleFiles.length === 0 ? (
+          <div className="grid place-items-center rounded-lg border border-dashed border-[var(--border-hairline)] bg-[var(--bg-raised)]/25 px-4 py-10 text-center">
+            <Icon name="ph:brain" width={22} className="text-[var(--text-muted)]" />
+            <div className="mt-3 text-[13px] font-medium text-[var(--text-primary)]">
+              No memories yet for {selectedFamiliar?.display_name ?? "this familiar"}
+            </div>
+            <p className="mt-1 max-w-[280px] text-[11px] leading-5 text-[var(--text-muted)]">
+              Familiar memories are saved during chats. Memory files appear when the agent's harness writes to disk.
+            </p>
+          </div>
+        ) : (
+          <>
         <section className="min-h-0">
           <div className="mb-2 flex items-center justify-between">
             <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">Familiar memory</h3>
@@ -478,6 +490,8 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
             activeFamiliarId={familiarFilter}
           />
         </section>
+          </>
+        )}
       </div>
       )}
     </div>

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -686,11 +686,11 @@ export function MemoryFilesList({
       ) : (
         <ul className={listClassName ?? "max-h-[640px] divide-y divide-[var(--border-hairline)] overflow-y-auto"}>
           {sliced.map((entry) => (
-            <li key={entry.fullPath} className="flex items-stretch gap-1 px-1 hover:bg-[var(--bg-raised)]">
+            <li key={entry.fullPath} className="flex min-w-0 items-stretch gap-1 px-1 hover:bg-[var(--bg-raised)]">
               <button
                 type="button"
                 onClick={() => onOpen?.(entry.fullPath)}
-                className="focus-ring-inset flex flex-1 items-start gap-2 px-2 py-2 text-left"
+                className="focus-ring-inset flex min-w-0 flex-1 items-start gap-2 px-2 py-2 text-left"
               >
                 <Icon name="ph:file-text" width={13} className="mt-0.5 shrink-0 text-[var(--text-muted)]" />
                 <span className="min-w-0 flex-1">

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -482,6 +482,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
             loaded={loaded}
             error={error}
             limit={effectiveLimit === Infinity ? 160 : effectiveLimit}
+            activeFamiliarId={familiarFilter}
           />
         </section>
       </div>
@@ -548,6 +549,7 @@ type MemoryFilesListProps = {
   limit?: number;
   className?: string;
   listClassName?: string;
+  activeFamiliarId?: string | null;
 };
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -673,6 +675,7 @@ export function MemoryFilesList({
   limit,
   className,
   listClassName,
+  activeFamiliarId,
 }: MemoryFilesListProps) {
   const sliced = entries.slice(0, limit ?? entries.length);
   return (
@@ -705,12 +708,12 @@ export function MemoryFilesList({
                   <span className="mt-0.5 block truncate font-mono text-[10px] text-[var(--text-muted)]">
                     {entry.sourceKindLabel} · {entry.rootLabel} · {compactPath(entry.fullPath)}
                   </span>
-                  {(entry.harnessId || entry.runtimeId || entry.origin || entry.familiarId) ? (
+                  {(entry.harnessId || entry.runtimeId || entry.origin || (entry.familiarId && entry.familiarId !== activeFamiliarId)) ? (
                     <span className="mt-1 flex flex-wrap gap-1 text-[10px] text-[var(--text-muted)]">
                       {entry.origin ? <span className="rounded bg-[var(--bg-elevated)] px-1 py-0.5">origin:{entry.origin}</span> : null}
                       {entry.harnessId ? <span className="rounded bg-[var(--bg-elevated)] px-1 py-0.5">harness:{entry.harnessId}</span> : null}
                       {entry.runtimeId ? <span className="rounded bg-[var(--bg-elevated)] px-1 py-0.5">runtime:{entry.runtimeId}</span> : null}
-                      {entry.familiarId ? <span className="rounded bg-[var(--bg-elevated)] px-1 py-0.5">familiar:{entry.familiarId}</span> : null}
+                      {entry.familiarId && entry.familiarId !== activeFamiliarId ? <span className="rounded bg-[var(--bg-elevated)] px-1 py-0.5">familiar:{entry.familiarId}</span> : null}
                     </span>
                   ) : null}
                 </span>

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -408,7 +408,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
         </div>
       ) : (
       <div className={`min-h-0 flex-1 ${compact ? "flex flex-col gap-4 overflow-y-auto p-4" : selectedRowId ? "grid gap-4 overflow-y-auto p-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(280px,360px)]" : "grid gap-4 overflow-y-auto p-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]"}`}>
-        {compact && loaded && visibleCoven.length === 0 && visibleFiles.length === 0 ? (
+        {compact && loaded && !error && visibleCoven.length === 0 && visibleFiles.length === 0 ? (
           <div className="grid place-items-center rounded-lg border border-dashed border-[var(--border-hairline)] bg-[var(--bg-raised)]/25 px-4 py-10 text-center">
             <Icon name="ph:brain" width={22} className="text-[var(--text-muted)]" />
             <div className="mt-3 text-[13px] font-medium text-[var(--text-primary)]">

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -425,7 +425,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
             <span className="text-[10px] text-[var(--text-muted)]">{visibleCoven.length} visible</span>
           </div>
           {visibleCoven.length === 0 ? (
-            <div className="grid min-h-[180px] place-items-center rounded-lg border border-dashed border-[var(--border-hairline)] text-center text-[12px] text-[var(--text-muted)]">
+            <div className="grid place-items-center rounded-lg border border-dashed border-[var(--border-hairline)] px-4 py-6 text-center text-[12px] text-[var(--text-muted)]">
               {loaded ? (error ? "Couldn’t load familiar memories. See the error above and try again." : "No familiar memories match this view.") : "Loading memories..."}
             </div>
           ) : (

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -265,23 +265,14 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
         )}
 
         {compact ? null : (
-          <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-            <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
-              <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">Agent memories</div>
-              <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{visibleCoven.length}</div>
-            </div>
-            <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
-              <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">Coven origin</div>
-              <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{fileSourceCounts.covenOrigin}</div>
-            </div>
-            <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
-              <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">External harnesses</div>
-              <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{fileSourceCounts.externalHarnesses}</div>
-            </div>
-            <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-3 py-2">
-              <div className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">Runtime memory</div>
-              <div className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{fileSourceCounts.runtimeMemory}</div>
-            </div>
+          <div
+            data-testid="memory-stats-inline"
+            className="mt-3 flex flex-wrap items-baseline gap-x-5 gap-y-1 text-[11px] text-[var(--text-secondary)]"
+          >
+            <span><span className="text-[var(--text-muted)]">Agent memories</span> <span className="ml-1 font-semibold text-[var(--text-primary)]">{visibleCoven.length}</span></span>
+            <span><span className="text-[var(--text-muted)]">Coven origin</span> <span className="ml-1 font-semibold text-[var(--text-primary)]">{fileSourceCounts.covenOrigin}</span></span>
+            <span><span className="text-[var(--text-muted)]">External harnesses</span> <span className="ml-1 font-semibold text-[var(--text-primary)]">{fileSourceCounts.externalHarnesses}</span></span>
+            <span><span className="text-[var(--text-muted)]">Runtime memory</span> <span className="ml-1 font-semibold text-[var(--text-primary)]">{fileSourceCounts.runtimeMemory}</span></span>
           </div>
         )}
 

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -436,7 +436,16 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
                 return (
                   <article
                     key={entry.id}
+                    role={compact ? undefined : "button"}
+                    tabIndex={compact ? undefined : 0}
                     onClick={() => { if (!compact) setSelectedRowId(`coven:${entry.id}`); }}
+                    onKeyDown={(e) => {
+                      if (compact) return;
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        setSelectedRowId(`coven:${entry.id}`);
+                      }
+                    }}
                     className={`rounded-lg border p-3 transition-colors ${compact ? "border-[var(--border-hairline)] bg-[var(--bg-raised)]/35" : selectedRowId === `coven:${entry.id}` ? "cursor-pointer border-[var(--accent-presence)] bg-[var(--bg-raised)]/55" : "cursor-pointer border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 hover:bg-[var(--bg-raised)]/50"}`}
                   >
                     <div className="flex items-start justify-between gap-2">


### PR DESCRIPTION
## Summary
- Reworks the agent memory view across the rail (compact) and full tab (balanced columns) layouts
- Adds list-mode selection drawer with peek of the selected row, unified empty state, and inline hero stat strip
- Polishes the rail: dynamic search placeholder, hides familiar tag when it matches the active filter, middle-ellipsizes long paths, clamps overflowing rows
- 7 files changed, +435 / −45

## Commits
- fix(memory): pin 'Open full memory' footer with explicit scroll wrapper
- feat(memory): list-mode selection drawer with peek of selected row
- fix(memory): let empty-state column adopt populated peer's height
- feat(memory): collapse hero stat tiles into an inline strip
- feat(memory): unified empty state for rail when no memories exist
- feat(memory): vertical stack in rail, balanced columns in full tab
- fix(memory): dynamic search placeholder, drop redundant locked-familiar pill
- feat(memory): hide familiar tag when it matches the active filter
- feat(memory): middle-ellipsize long file paths to keep filename visible
- fix(memory): clamp memory file rows with min-w-0 to kill horizontal overflow

## Test plan
- [ ] Memory view renders cleanly in the rail with no horizontal overflow on long paths
- [ ] Full memory tab shows balanced columns when both sides have content
- [ ] Empty state appears when no memories exist for the active familiar
- [ ] List-mode drawer opens/peeks the selected row
- [ ] Hero stat strip collapses to inline format
- [ ] Search placeholder updates dynamically when a familiar is locked
- [ ] Footer "Open full memory" pins correctly in the rail scroll container

🤖 Generated with [Claude Code](https://claude.com/claude-code)