### PR TITLE
feat(memory): graph mode polish — unified recent list, lighter empty states, compact overlay

### DIFF
--- a/src/components/agents-memory-view-graph-aside.test.ts
+++ b/src/components/agents-memory-view-graph-aside.test.ts
@@ -1,0 +1,62 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("./agents-memory-view.tsx", import.meta.url), "utf8");
+
+// ───────── G1: Unified Recent-in-view (files + coven) ─────────
+
+assert.match(
+  source,
+  /const recentInView = useMemo<RecentItem\[\]>\(/,
+  "Graph aside must compute a unified recentInView list (RecentItem[])",
+);
+
+assert.match(
+  source,
+  /visibleCoven\.map\(\(entry\) => \(\{[\s\S]*?kind: "coven"/,
+  "recentInView must include coven entries with kind: 'coven'",
+);
+
+assert.match(
+  source,
+  /visibleFiles\.map\(\(entry\) => \(\{[\s\S]*?kind: "file"/,
+  "recentInView must include file entries with kind: 'file'",
+);
+
+assert.match(
+  source,
+  /data-testid="graph-recent-list"/,
+  "Graph aside must mark the recent list with data-testid='graph-recent-list'",
+);
+
+// ───────── G2: Lighter empty states ─────────
+
+// When nothing selected, render an inline <p> hint, not a dashed box.
+assert.match(
+  source,
+  /Click any card in the map to inspect it/,
+  "Empty-selection hint must use the friendlier copy",
+);
+
+assert.doesNotMatch(
+  source,
+  /Select a memory card in the graph\./,
+  "Old 'Select a memory card in the graph.' copy must be removed",
+);
+
+// The Recent-in-view dashed empty state must be gone (we hide the section instead).
+assert.doesNotMatch(
+  source,
+  /No memories match this agent view\./,
+  "Old 'No memories match this agent view.' empty state must be removed",
+);
+
+// Recent section is only rendered when recentInView has items.
+assert.match(
+  source,
+  /\{recentInView\.length\s*>\s*0\s*\?\s*\(/,
+  "Recent in view must only render when recentInView is non-empty",
+);
+
+console.log("agents-memory-view-graph-aside.test.ts: ok");

--- a/src/components/agents-memory-view-rail.test.ts
+++ b/src/components/agents-memory-view-rail.test.ts
@@ -43,8 +43,8 @@ assert.match(
 
 assert.match(
   source,
-  /\{compact\s*&&\s*loaded\s*&&\s*visibleCoven\.length\s*===\s*0\s*&&\s*visibleFiles\.length\s*===\s*0\s*\?/,
-  "Shared empty state must only render in compact mode when both lists are empty after load",
+  /\{compact\s*&&\s*loaded\s*&&(?:\s*!error\s*&&)?\s*visibleCoven\.length\s*===\s*0\s*&&\s*visibleFiles\.length\s*===\s*0\s*\?/,
+  "Shared empty state must only render in compact mode when both lists are empty after load (optional !error guard)",
 );
 
 // ───────── Task 5: vertical stack / balanced columns ─────────

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -212,6 +212,35 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
       ) ?? null,
     [memoryGraph, selectedMemoryId],
   );
+
+  type RecentItem = {
+    id: string;
+    kind: "coven" | "file";
+    title: string;
+    subtitle: string;
+    updatedAt: string;
+    path: string;
+  };
+
+  const recentInView = useMemo<RecentItem[]>(() => {
+    const covenRows: RecentItem[] = visibleCoven.map((entry) => ({
+      id: `memory:coven:${entry.id}`,
+      kind: "coven",
+      title: entry.title,
+      subtitle: `${familiarById.get(entry.familiar_id)?.display_name ?? entry.familiar_id} · ${age(entry.updated_at)}`,
+      updatedAt: entry.updated_at,
+      path: entry.path,
+    }));
+    const fileRows: RecentItem[] = visibleFiles.map((entry) => ({
+      id: `file:${entry.fullPath}`,
+      kind: "file",
+      title: entry.relPath,
+      subtitle: `${entry.sourceKindLabel} · ${age(entry.modified)}`,
+      updatedAt: entry.modified,
+      path: entry.fullPath,
+    }));
+    return [...covenRows, ...fileRows].sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1));
+  }, [visibleCoven, visibleFiles, familiarById]);
   const firstMemoryId = useMemo(
     () => memoryGraph.nodes.find((node) => node.kind === "memory")?.id ?? null,
     [memoryGraph],
@@ -316,11 +345,11 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
             />
           </section>
           <aside className="min-h-0">
-            <section className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 p-3">
-              <div className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">
-                Selected memory
-              </div>
-              {selectedMemory ? (
+            {selectedMemory ? (
+              <section className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 p-3">
+                <div className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">
+                  Selected memory
+                </div>
                 <div className="mt-3">
                   <div className="flex items-start justify-between gap-2">
                     <h3 className="line-clamp-3 text-[15px] font-semibold leading-5 text-[var(--text-primary)]">
@@ -368,42 +397,52 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
                     <ExpandMemoryButton path={selectedMemory.path} title={selectedMemory.title} />
                   </div>
                 </div>
-              ) : (
-                <div className="mt-3 rounded-md border border-dashed border-[var(--border-hairline)] px-3 py-6 text-center text-[12px] text-[var(--text-muted)]">
-                  {loaded ? "Select a memory card in the graph." : "Loading memories..."}
-                </div>
-              )}
-            </section>
+              </section>
+            ) : (
+              <p className="px-1 text-[11px] leading-5 text-[var(--text-muted)]">
+                {loaded
+                  ? "Click any card in the map to inspect it, or pick from the list below."
+                  : "Loading memories..."}
+              </p>
+            )}
 
-            <section className="mt-4">
-              <div className="mb-2 flex items-center justify-between">
-                <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">
-                  Recent in view
-                </h3>
-                <span className="text-[10px] text-[var(--text-muted)]">{visibleCoven.length} visible</span>
-              </div>
-              <div className="max-h-[420px] overflow-y-auto rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/25">
-              {visibleCoven.slice(0, 18).map((entry) => (
-                <button
-                  key={entry.id}
-                  type="button"
-                  onClick={() => setSelectedMemoryId(`memory:coven:${entry.id}`)}
-                  className="focus-ring-inset flex w-full items-start gap-2 border-b border-[var(--border-hairline)] px-3 py-2 text-left hover:bg-[var(--bg-raised)]"
-                >
-                  <Icon name="ph:brain" width={13} className="mt-0.5 shrink-0 text-[var(--accent-presence)]" />
-                  <span className="min-w-0 flex-1">
-                    <span className="block line-clamp-2 text-[12px] text-[var(--text-primary)]">{entry.title}</span>
-                    <span className="mt-0.5 block text-[10px] text-[var(--text-muted)]">{familiarById.get(entry.familiar_id)?.display_name ?? entry.familiar_id} · {age(entry.updated_at)}</span>
-                  </span>
-                </button>
-              ))}
-              {visibleCoven.length === 0 ? (
-                <div className="px-3 py-8 text-center text-[12px] text-[var(--text-muted)]">
-                  {loaded ? (error ? "Couldn’t load memories. See the error above and try again." : "No memories match this agent view.") : "Loading memories..."}
+            {recentInView.length > 0 ? (
+              <section className={selectedMemory ? "mt-4" : "mt-3"}>
+                <div className="mb-2 flex items-center justify-between">
+                  <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">
+                    Recent in view
+                  </h3>
+                  <span className="text-[10px] text-[var(--text-muted)]">{recentInView.length} visible</span>
                 </div>
-              ) : null}
-              </div>
-            </section>
+                <div data-testid="graph-recent-list" className="max-h-[420px] overflow-y-auto rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/25">
+                  {recentInView.slice(0, 24).map((item) => {
+                    const isSelected = item.id === selectedMemoryId;
+                    return (
+                      <button
+                        key={item.id}
+                        type="button"
+                        onClick={() => setSelectedMemoryId(item.id)}
+                        className={`focus-ring-inset flex w-full min-w-0 items-start gap-2 border-b border-[var(--border-hairline)] px-3 py-2 text-left ${isSelected ? "bg-[var(--bg-raised)]/55" : "hover:bg-[var(--bg-raised)]"}`}
+                      >
+                        <Icon
+                          name={item.kind === "file" ? "ph:file-text" : "ph:brain"}
+                          width={13}
+                          className={`mt-0.5 shrink-0 ${item.kind === "file" ? "text-[var(--text-muted)]" : "text-[var(--accent-presence)]"}`}
+                        />
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-[12px] text-[var(--text-primary)]">{item.title}</span>
+                          <span className="mt-0.5 block truncate text-[10px] text-[var(--text-muted)]">{item.subtitle}</span>
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
+            ) : loaded && !error ? null : (
+              <p className="mt-3 px-1 text-[11px] leading-5 text-[var(--text-muted)]">
+                {error ? "Couldn’t load memories. See the error above and try again." : "Loading memories..."}
+              </p>
+            )}
           </aside>
         </div>
       ) : (

--- a/src/components/memory-graph-3d-overlay.test.ts
+++ b/src/components/memory-graph-3d-overlay.test.ts
@@ -1,0 +1,55 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("./memory-graph-3d.tsx", import.meta.url), "utf8");
+
+// ───────── G3: Compact top overlay ─────────
+
+assert.doesNotMatch(
+  source,
+  /Agent memory map/,
+  "Redundant 'Agent memory map' uppercase label must be removed (surface header already says it)",
+);
+
+// New one-line overlay should still surface the familiar + memory count.
+assert.match(
+  source,
+  /familiars\.get\(selectedFamiliarId\)\?\.display_name/,
+  "Top overlay must still show the familiar display name",
+);
+
+assert.match(
+  source,
+  /graph\.metrics\.visibleCovenEntries === 1 \? "memory" : "memories"/,
+  "Top overlay must pluralize 'memory' vs 'memories' for one-vs-many",
+);
+
+// ───────── G4: Compact bottom legend ─────────
+
+assert.doesNotMatch(
+  source,
+  /memory card/,
+  "Legend label 'memory card' should be shortened to 'memory'",
+);
+
+assert.doesNotMatch(
+  source,
+  /tracked source/,
+  "Legend label 'tracked source' should be shortened to 'source'",
+);
+
+assert.doesNotMatch(
+  source,
+  /older stack/,
+  "Legend label 'older stack' should be shortened to 'stack'",
+);
+
+// Smaller swatches now (h-1.5 w-2 vs h-2 w-3).
+assert.match(
+  source,
+  /h-1\.5 w-2 rounded-sm bg-\[#8E3DFF\]/,
+  "Legend swatches must use smaller h-1.5 w-2 dimensions",
+);
+
+console.log("memory-graph-3d-overlay.test.ts: ok");

--- a/src/components/memory-graph-3d.tsx
+++ b/src/components/memory-graph-3d.tsx
@@ -475,13 +475,16 @@ export function MemoryGraph3D({
       />
       <p aria-live="polite" className="sr-only">{selectedLabel}</p>
       <div className="pointer-events-none absolute inset-x-0 top-0 flex flex-wrap items-start justify-between gap-3 p-3">
-        <div className="rounded-lg border border-white/10 bg-black/45 px-3 py-2 shadow-2xl backdrop-blur">
-          <div className="text-[10px] font-semibold uppercase tracking-widest text-white/55">Agent memory map</div>
-          <div className="mt-1 flex flex-wrap gap-2 text-[10px] text-white/70">
-            <span>{familiars.get(selectedFamiliarId)?.display_name ?? selectedFamiliarId}</span>
-            <span>{graph.metrics.visibleCovenEntries} memories</span>
-            {selectedMemoryId ? <span>1 selected</span> : null}
-          </div>
+        <div className="inline-flex items-center gap-2 rounded-md border border-white/10 bg-black/45 px-2.5 py-1.5 text-[11px] text-white/75 shadow-2xl backdrop-blur">
+          <span className="font-medium text-white/90">{familiars.get(selectedFamiliarId)?.display_name ?? selectedFamiliarId}</span>
+          <span className="text-white/40">·</span>
+          <span>{graph.metrics.visibleCovenEntries} {graph.metrics.visibleCovenEntries === 1 ? "memory" : "memories"}</span>
+          {selectedMemoryId ? (
+            <>
+              <span className="text-white/40">·</span>
+              <span>1 selected</span>
+            </>
+          ) : null}
         </div>
         <button
           type="button"
@@ -492,11 +495,11 @@ export function MemoryGraph3D({
           <Icon name="ph:arrows-clockwise-bold" width={14} />
         </button>
       </div>
-      <div className="pointer-events-none absolute bottom-3 left-3 flex flex-wrap items-center gap-2 rounded-lg border border-white/10 bg-black/45 px-3 py-2 text-[10px] text-white/65 shadow-2xl backdrop-blur">
-        <span className="inline-flex items-center gap-1"><i className="h-2 w-3 rounded-sm bg-[#8E3DFF]" /> agent</span>
-        <span className="inline-flex items-center gap-1"><i className="h-2 w-3 rounded-sm bg-[#62d08f]" /> memory card</span>
-        <span className="inline-flex items-center gap-1"><i className="h-2 w-3 rounded-sm bg-[#7dd3fc]" /> tracked source</span>
-        <span className="inline-flex items-center gap-1"><i className="h-2 w-3 rounded-sm bg-[#f59e0b]" /> older stack</span>
+      <div className="pointer-events-none absolute bottom-3 left-3 inline-flex items-center gap-3 rounded-md border border-white/10 bg-black/45 px-2.5 py-1 text-[10px] text-white/60 shadow-2xl backdrop-blur">
+        <span className="inline-flex items-center gap-1"><i className="h-1.5 w-2 rounded-sm bg-[#8E3DFF]" /> agent</span>
+        <span className="inline-flex items-center gap-1"><i className="h-1.5 w-2 rounded-sm bg-[#62d08f]" /> memory</span>
+        <span className="inline-flex items-center gap-1"><i className="h-1.5 w-2 rounded-sm bg-[#7dd3fc]" /> source</span>
+        <span className="inline-flex items-center gap-1"><i className="h-1.5 w-2 rounded-sm bg-[#f59e0b]" /> stack</span>
       </div>
       {graph.metrics.hiddenEntries > 0 ? (
         <div className="pointer-events-none absolute right-3 top-16 max-w-[260px] rounded-lg border border-[color-mix(in_oklch,var(--color-warning)_25%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_18%,transparent)] px-3 py-2 text-[10px] text-[var(--color-warning)] shadow-2xl backdrop-blur">


### PR DESCRIPTION
## Summary
- **Recent in view now shows files too.** It was only counting coven entries, so the right-side list read "0 visible / No memories match" even when file cards were clearly present in the 3D map. Unified into a single `recentInView` list (sorted by date desc), with kind-appropriate icons. Selecting a row uses the same \`memory:coven:<id>\` / \`file:<path>\` IDs the graph already exposes.
- **Lighter aside empty states.** No-selection state drops the dashed box for a one-line inline hint ("Click any card in the map to inspect it, or pick from the list below."). Empty Recent section hides entirely instead of rendering a placeholder.
- **Compact top overlay on the 3D map.** The redundant "AGENT MEMORY MAP" uppercase label is gone (the surface header already says it). Familiar name + visible count + selection state collapse into a single thin chip.
- **Compact bottom legend.** Shorter labels (memory / source / stack), smaller swatches, thinner padding.
- Bonus: fix small drift between the rail empty-state regex test and the code — PR #301's Copilot Autofix added `!error` to the guard but the test didn't.

## Test plan
- [x] \`npx tsc --noEmit\` — zero errors in touched files
- [x] All 8 \`agents-memory-view*.test.ts\` + new \`memory-graph-3d-overlay.test.ts\` pass via \`node --experimental-strip-types\`
- [x] Visual capture: top overlay shows \`Nova · 0 memories · 1 selected\`, recent list shows both file entries, selected panel updates on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)