### PR TITLE
feat(chat): sessions list polish — compact rows, recency grouping, inline filter

### DIFF
--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -338,6 +338,8 @@ export function ChatSurface({
                 activeFamiliarId={activeFamiliarId}
                 activeSessionId={activeSessionId ?? null}
                 hideFamiliarFilter
+                compact
+                groupByRecency
                 onOpenSession={(sessionId, familiarId) => {
                   if (onOpenSession) {
                     onOpenSession(sessionId, familiarId);

--- a/src/components/sessions-view-chat-polish.test.ts
+++ b/src/components/sessions-view-chat-polish.test.ts
@@ -11,4 +11,17 @@ assert.match(
   "Sub-header sessions-view-title-wrap must be gated on !hideFamiliarFilter",
 );
 
+// ───────── Task 2: In-list NewChatRow only when no sessions ─────────
+assert.match(
+  source,
+  /\{showNewChat\s*&&\s*visible\.length\s*===\s*0\s*&&\s*<NewChatRow\s+onClick=\{onNewChat\}\s*\/>\}/,
+  "NewChatRow inside SessionGroup must only render when sessions are empty",
+);
+
+assert.match(
+  source,
+  /\{showNewChat\s*&&\s*visible\.length\s*===\s*0\s*&&\s*<NewChatCard\s+onClick=\{onNewChat\}\s*\/>\}/,
+  "NewChatCard inside SessionGroup must only render when sessions are empty",
+);
+
 console.log("sessions-view-chat-polish.test.ts: ok");

--- a/src/components/sessions-view-chat-polish.test.ts
+++ b/src/components/sessions-view-chat-polish.test.ts
@@ -61,4 +61,49 @@ assert.match(
   "originLabel must hide when compact + origin === 'chat'",
 );
 
+// ───────── Task 4: recency grouping ─────────
+assert.match(
+  source,
+  /export function bucketByRecency\(/,
+  "bucketByRecency helper must be exported for unit testability",
+);
+
+assert.match(
+  source,
+  /bucketByRecency[\s\S]*?today[\s\S]*?yesterday[\s\S]*?thisWeek[\s\S]*?older/,
+  "bucketByRecency must define today/yesterday/thisWeek/older buckets",
+);
+
+for (const label of ["Today", "Yesterday", "This week", "Older"]) {
+  assert.ok(source.includes(label), `Recency grouping must render the '${label}' section label`);
+}
+
+assert.match(
+  source,
+  /groupByRecency\s*&&\s*hideFamiliarFilter/,
+  "Recency grouping must be gated on groupByRecency && hideFamiliarFilter",
+);
+
+const fnMatch = source.match(/export function bucketByRecency\([^)]*\)[^{]*\{([\s\S]*?)\n\}/);
+assert.ok(fnMatch, "bucketByRecency body must be extractable");
+const body = fnMatch[1]
+  .replace(/: SessionRow\[\]/g, "")
+  .replace(/: number/g, "")
+  .replace(/: Date/g, "");
+const bucketByRecency = new Function("sessions", "now", body);
+
+const now = new Date("2026-06-08T12:00:00Z").getTime();
+const dayMs = 24 * 60 * 60 * 1000;
+const sessions = [
+  { id: "a", title: "today",     updated_at: new Date(now - 1 * 60 * 60 * 1000).toISOString(), created_at: "" },
+  { id: "b", title: "yesterday", updated_at: new Date(now - 1.2 * dayMs).toISOString(),         created_at: "" },
+  { id: "c", title: "thisweek",  updated_at: new Date(now - 4 * dayMs).toISOString(),           created_at: "" },
+  { id: "d", title: "older",     updated_at: new Date(now - 14 * dayMs).toISOString(),          created_at: "" },
+];
+const out = bucketByRecency(sessions, now);
+assert.deepEqual(out.today.map((s) => s.id),     ["a"], "today bucket");
+assert.deepEqual(out.yesterday.map((s) => s.id), ["b"], "yesterday bucket");
+assert.deepEqual(out.thisWeek.map((s) => s.id),  ["c"], "thisWeek bucket");
+assert.deepEqual(out.older.map((s) => s.id),     ["d"], "older bucket");
+
 console.log("sessions-view-chat-polish.test.ts: ok");

--- a/src/components/sessions-view-chat-polish.test.ts
+++ b/src/components/sessions-view-chat-polish.test.ts
@@ -24,4 +24,41 @@ assert.match(
   "NewChatCard inside SessionGroup must only render when sessions are empty",
 );
 
+// ───────── Task 3: compact prop + row densification ─────────
+assert.match(
+  source,
+  /type SessionsViewProps = \{[\s\S]*?compact\?:\s*boolean/,
+  "SessionsViewProps must declare optional compact",
+);
+
+assert.match(
+  source,
+  /export function SessionsView\(\{[\s\S]*?compact\s*=\s*false,[\s\S]*?\}: SessionsViewProps\)/,
+  "SessionsView must default compact to false",
+);
+
+assert.match(
+  source,
+  /function SessionRowItem\(\{[\s\S]*?compact[\s\S]*?\}: \{[\s\S]*?compact\?:\s*boolean/,
+  "SessionRowItem must accept compact",
+);
+
+assert.match(
+  source,
+  /\{!compact\s*&&\s*\(\s*<div className="session-row-familiar-chip">/,
+  "session-row-familiar-chip must be hidden when compact",
+);
+
+assert.match(
+  source,
+  /\{\(!compact\s*\|\|\s*session\.status\s*!==\s*"completed"\s*\|\|\s*archived\)\s*&&\s*\(\s*<div className="session-row-status-line">/,
+  "Status line must hide when compact + status===completed + not archived",
+);
+
+assert.match(
+  source,
+  /\{label\s*&&\s*!\(compact\s*&&\s*session\.origin\s*===\s*"chat"\)\s*&&\s*<span className="session-card-origin">/,
+  "originLabel must hide when compact + origin === 'chat'",
+);
+
 console.log("sessions-view-chat-polish.test.ts: ok");

--- a/src/components/sessions-view-chat-polish.test.ts
+++ b/src/components/sessions-view-chat-polish.test.ts
@@ -106,4 +106,29 @@ assert.deepEqual(out.yesterday.map((s) => s.id), ["b"], "yesterday bucket");
 assert.deepEqual(out.thisWeek.map((s) => s.id),  ["c"], "thisWeek bucket");
 assert.deepEqual(out.older.map((s) => s.id),     ["d"], "older bucket");
 
+// ───────── Task 5: inline title filter ─────────
+assert.match(
+  source,
+  /const \[titleQuery, setTitleQuery\] = useState\(""\);/,
+  "SessionsView must own a titleQuery state",
+);
+
+assert.match(
+  source,
+  /sessions\.length\s*>=\s*6/,
+  "Inline filter input must be gated on sessions.length >= 6",
+);
+
+assert.match(
+  source,
+  /placeholder="Filter chats…"/,
+  "Filter input placeholder must read 'Filter chats…'",
+);
+
+assert.match(
+  source,
+  /titleQuery\.toLowerCase\(\)/,
+  "Title query filter must be case-insensitive",
+);
+
 console.log("sessions-view-chat-polish.test.ts: ok");

--- a/src/components/sessions-view-chat-polish.test.ts
+++ b/src/components/sessions-view-chat-polish.test.ts
@@ -1,0 +1,14 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("./sessions-view.tsx", import.meta.url), "utf8");
+
+// ───────── Task 1: Header hidden when hideFamiliarFilter is true ─────────
+assert.match(
+  source,
+  /\{!hideFamiliarFilter\s*&&\s*\(\s*<div className="sessions-view-title-wrap">/,
+  "Sub-header sessions-view-title-wrap must be gated on !hideFamiliarFilter",
+);
+
+console.log("sessions-view-chat-polish.test.ts: ok");

--- a/src/components/sessions-view-chat-polish.test.ts
+++ b/src/components/sessions-view-chat-polish.test.ts
@@ -131,4 +131,12 @@ assert.match(
   "Title query filter must be case-insensitive",
 );
 
+// ───────── Task 6: chat-surface passes compact + groupByRecency ─────────
+const chatSurface = await readFile(new URL("./chat-surface.tsx", import.meta.url), "utf8");
+assert.match(
+  chatSurface,
+  /<SessionsView[\s\S]*?compact[\s\S]*?groupByRecency[\s\S]*?\/>/,
+  "chat-surface.tsx must pass compact and groupByRecency to SessionsView",
+);
+
 console.log("sessions-view-chat-polish.test.ts: ok");

--- a/src/components/sessions-view.tsx
+++ b/src/components/sessions-view.tsx
@@ -525,7 +525,7 @@ function SessionGroup({
       )}
       {layoutMode === "cards" ? (
         <div className="sessions-grid">
-          {showNewChat && <NewChatCard onClick={onNewChat} />}
+          {showNewChat && visible.length === 0 && <NewChatCard onClick={onNewChat} />}
           {visible.map((s) => (
             <SessionCard
               key={s.id}
@@ -545,7 +545,7 @@ function SessionGroup({
         </div>
       ) : (
         <div className="sessions-list">
-          {showNewChat && <NewChatRow onClick={onNewChat} />}
+          {showNewChat && visible.length === 0 && <NewChatRow onClick={onNewChat} />}
           {visible.map((s) => (
             <SessionRowItem
               key={s.id}

--- a/src/components/sessions-view.tsx
+++ b/src/components/sessions-view.tsx
@@ -722,6 +722,7 @@ export function SessionsView({
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [pendingSacrifice, setPendingSacrifice] = useState<SessionRow | null>(null);
   const [showArchived, setShowArchived] = useState(false);
+  const [titleQuery, setTitleQuery] = useState("");
   const [archivedSessions, setArchivedSessions] = useState<SessionRow[]>([]);
   // Local per-familiar filter — defaults to null (show all). Takes precedence
   // over the workspace's activeFamiliarId so the Sessions view always lands on
@@ -845,13 +846,16 @@ export function SessionsView({
     [sessions]
   );
 
-  const filtered = useMemo(
-    () =>
-      effectiveFilterId
-        ? sorted.filter((s) => s.familiarId === effectiveFilterId)
-        : sorted,
-    [sorted, effectiveFilterId]
-  );
+  const filtered = useMemo(() => {
+    let list = effectiveFilterId
+      ? sorted.filter((s) => s.familiarId === effectiveFilterId)
+      : sorted;
+    if (titleQuery.trim()) {
+      const q = titleQuery.toLowerCase();
+      list = list.filter((s) => (s.title ?? "").toLowerCase().includes(q));
+    }
+    return list;
+  }, [sorted, effectiveFilterId, titleQuery]);
 
   const archivedFiltered = useMemo(() => {
     const sortedArch = [...archivedSessions].sort((a, b) =>
@@ -1005,6 +1009,19 @@ export function SessionsView({
           </button>
         </div>
       </div>
+
+      {sessions.length >= 6 && (
+        <div className="border-b border-[var(--border-hairline)] px-3 py-2">
+          <input
+            type="text"
+            value={titleQuery}
+            onChange={(e) => setTitleQuery(e.target.value)}
+            placeholder="Filter chats…"
+            className="focus-ring h-8 w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-3 text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent-presence)]"
+            aria-label="Filter chats by title"
+          />
+        </div>
+      )}
 
       {/* Content */}
       <div className="sessions-view-scroll">

--- a/src/components/sessions-view.tsx
+++ b/src/components/sessions-view.tsx
@@ -357,6 +357,7 @@ function SessionRowItem({
   session,
   familiar,
   active,
+  compact,
   menuOpen,
   renaming,
   onClick,
@@ -369,6 +370,7 @@ function SessionRowItem({
   session: SessionRow;
   familiar: Familiar | undefined;
   active: boolean;
+  compact?: boolean;
   menuOpen: boolean;
   renaming: boolean;
   onClick: () => void;
@@ -402,13 +404,15 @@ function SessionRowItem({
       }}
       title={title}
     >
-      <div className="session-row-familiar-chip">
-        {resolvedFamiliar ? (
-          <FamiliarAvatar familiar={resolvedFamiliar} size="sm" />
-        ) : (
-          <Icon name="ph:user" width={11} />
-        )}
-      </div>
+      {!compact && (
+        <div className="session-row-familiar-chip">
+          {resolvedFamiliar ? (
+            <FamiliarAvatar familiar={resolvedFamiliar} size="sm" />
+          ) : (
+            <Icon name="ph:user" width={11} />
+          )}
+        </div>
+      )}
       <div className="session-row-main">
         {renaming ? (
           <RenameInput
@@ -419,15 +423,17 @@ function SessionRowItem({
         ) : (
           <div className="session-row-title">{title}</div>
         )}
-        <div className="session-row-status-line">
-          <span className={statusDotClass(session.status)} />
-          <span className="session-row-status-label">{session.status}</span>
-          {archived && <span className="session-row-archived-badge">archived</span>}
-        </div>
+        {(!compact || session.status !== "completed" || archived) && (
+          <div className="session-row-status-line">
+            <span className={statusDotClass(session.status)} />
+            <span className="session-row-status-label">{session.status}</span>
+            {archived && <span className="session-row-archived-badge">archived</span>}
+          </div>
+        )}
       </div>
       <div className="session-row-meta">
         {harness && <span className="session-card-harness">{harness}</span>}
-        {label && <span className="session-card-origin">{label}</span>}
+        {label && !(compact && session.origin === "chat") && <span className="session-card-origin">{label}</span>}
         {ts && <span className="session-card-ts">{ts}</span>}
         <div className="session-row-menu-wrap">
           <button
@@ -490,6 +496,7 @@ function SessionGroup({
   onNewChat,
   showNewChat,
   layoutMode,
+  compact,
   openMenuId,
   setOpenMenuId,
   renamingId,
@@ -504,6 +511,7 @@ function SessionGroup({
   onNewChat: () => void;
   showNewChat: boolean;
   layoutMode: SessionsLayoutMode;
+  compact?: boolean;
   openMenuId: string | null;
   setOpenMenuId: (id: string | null) => void;
   renamingId: string | null;
@@ -552,6 +560,7 @@ function SessionGroup({
               session={s}
               familiar={familiar}
               active={s.id === activeSessionId}
+              compact={compact}
               menuOpen={openMenuId === s.id}
               renaming={renamingId === s.id}
               onClick={() => onOpenSession(s.id)}
@@ -657,6 +666,12 @@ export type SessionsViewProps = {
   /** Hide the per-familiar filter dropdown. Used by the Chats surface where the
    *  list is already scoped to the active agent. */
   hideFamiliarFilter?: boolean;
+  /** Drop redundant per-row chrome (familiar avatar, default-completed status,
+   *  "Chat" origin badge). Used by the chat-surface Chats tab. */
+  compact?: boolean;
+  /** Render Today/Yesterday/This week/Older section headers in place of the
+   *  per-familiar grouping. Requires hideFamiliarFilter to be true. */
+  groupByRecency?: boolean;
 };
 
 export function SessionsView({
@@ -668,6 +683,8 @@ export function SessionsView({
   onNewChat,
   onSessionsChanged,
   hideFamiliarFilter = false,
+  compact = false,
+  groupByRecency = false,
 }: SessionsViewProps) {
   const [layoutMode, setLayoutMode] = useState<SessionsLayoutMode>("rows");
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
@@ -998,6 +1015,7 @@ export function SessionsView({
               onNewChat={() => onNewChat(effectiveFilterId)}
               showNewChat
               layoutMode={layoutMode}
+              compact={compact}
               openMenuId={openMenuId}
               setOpenMenuId={setOpenMenuId}
               renamingId={renamingId}
@@ -1020,6 +1038,7 @@ export function SessionsView({
                   onNewChat={() => onNewChat(effectiveFilterId)}
                   showNewChat={false}
                   layoutMode={layoutMode}
+                  compact={compact}
                   openMenuId={openMenuId}
                   setOpenMenuId={setOpenMenuId}
                   renamingId={renamingId}
@@ -1044,6 +1063,7 @@ export function SessionsView({
                   onNewChat={() => onNewChat(f.id)}
                   showNewChat={false}
                   layoutMode={layoutMode}
+                  compact={compact}
                   openMenuId={openMenuId}
                   setOpenMenuId={setOpenMenuId}
                   renamingId={renamingId}
@@ -1084,6 +1104,7 @@ export function SessionsView({
                   onNewChat={() => onNewChat(undefined)}
                   showNewChat={false}
                   layoutMode={layoutMode}
+                  compact={compact}
                   openMenuId={openMenuId}
                   setOpenMenuId={setOpenMenuId}
                   renamingId={renamingId}

--- a/src/components/sessions-view.tsx
+++ b/src/components/sessions-view.tsx
@@ -836,10 +836,12 @@ export function SessionsView({
     <div className="sessions-view">
       {/* Header */}
       <div className="sessions-view-header">
-        <div className="sessions-view-title-wrap">
-          <span className="sessions-view-title">{title}</span>
-          {subtitle && <span className="sessions-view-subtitle">{subtitle}</span>}
-        </div>
+        {!hideFamiliarFilter && (
+          <div className="sessions-view-title-wrap">
+            <span className="sessions-view-title">{title}</span>
+            {subtitle && <span className="sessions-view-subtitle">{subtitle}</span>}
+          </div>
+        )}
         <div className="sessions-view-actions">
           {!hideFamiliarFilter && familiars.length > 0 && (
             <div ref={filterRef} className="relative inline-block">

--- a/src/components/sessions-view.tsx
+++ b/src/components/sessions-view.tsx
@@ -421,7 +421,7 @@ function SessionRowItem({
 
   return (
     <div
-      className={`session-row${active ? " session-row--active" : ""}${
+      className={`session-row${compact ? " session-row--compact" : ""}${active ? " session-row--active" : ""}${
         archived ? " session-row--archived" : ""
       }`}
       onClick={renaming ? undefined : onClick}

--- a/src/components/sessions-view.tsx
+++ b/src/components/sessions-view.tsx
@@ -13,6 +13,37 @@ import { stripLeadingTrailingEmoji } from "@/lib/cave-chat-titles";
 
 type SessionsLayoutMode = "cards" | "rows";
 
+type RecencyBuckets = {
+  today: SessionRow[];
+  yesterday: SessionRow[];
+  thisWeek: SessionRow[];
+  older: SessionRow[];
+};
+
+export function bucketByRecency(sessions: SessionRow[], now: number): RecencyBuckets {
+  const today: SessionRow[] = [];
+  const yesterday: SessionRow[] = [];
+  const thisWeek: SessionRow[] = [];
+  const older: SessionRow[] = [];
+  const startOfToday = new Date(now);
+  startOfToday.setHours(0, 0, 0, 0);
+  const startOfTodayMs = startOfToday.getTime();
+  const startOfYesterdayMs = startOfTodayMs - 24 * 60 * 60 * 1000;
+  const sevenDaysAgoMs = now - 7 * 24 * 60 * 60 * 1000;
+  for (const s of sessions) {
+    const ts = Date.parse(s.updated_at || s.created_at || "");
+    if (!Number.isFinite(ts)) {
+      older.push(s);
+      continue;
+    }
+    if (ts >= startOfTodayMs) today.push(s);
+    else if (ts >= startOfYesterdayMs) yesterday.push(s);
+    else if (ts >= sevenDaysAgoMs) thisWeek.push(s);
+    else older.push(s);
+  }
+  return { today, yesterday, thisWeek, older };
+}
+
 function shortRelTime(iso: string | undefined): string {
   if (!iso) return "";
   try {
@@ -977,7 +1008,44 @@ export function SessionsView({
 
       {/* Content */}
       <div className="sessions-view-scroll">
-        {filtered.length === 0 && archivedFiltered.length === 0 ? (
+        {groupByRecency && hideFamiliarFilter && filtered.length > 0 ? (
+          (() => {
+            const buckets = bucketByRecency(filtered, Date.now());
+            const sections: Array<{ label: string; rows: SessionRow[] }> = [
+              { label: "Today", rows: buckets.today },
+              { label: "Yesterday", rows: buckets.yesterday },
+              { label: "This week", rows: buckets.thisWeek },
+              { label: "Older", rows: buckets.older },
+            ];
+            return (
+              <div className="sessions-recency-groups">
+                {sections.filter((s) => s.rows.length > 0).map((section) => (
+                  <div key={section.label} className="sessions-recency-group">
+                    <div className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">
+                      {section.label}
+                    </div>
+                    <SessionGroup
+                      familiar={undefined}
+                      sessions={section.rows}
+                      activeSessionId={activeSessionId}
+                      onOpenSession={(id) => onOpenSession(id)}
+                      onNewChat={() => onNewChat(effectiveFilterId ?? undefined)}
+                      showNewChat={false}
+                      layoutMode={layoutMode}
+                      compact={compact}
+                      openMenuId={openMenuId}
+                      setOpenMenuId={setOpenMenuId}
+                      renamingId={renamingId}
+                      setRenamingId={setRenamingId}
+                      onRenameSubmit={handleRenameSubmit}
+                      onAction={handleAction}
+                    />
+                  </div>
+                ))}
+              </div>
+            );
+          })()
+        ) : filtered.length === 0 && archivedFiltered.length === 0 ? (
           <div className="sessions-empty">
             <div className="sessions-empty-glyph">
               {resolvedActiveFamiliar ? (

--- a/src/styles/sessions-view.css
+++ b/src/styles/sessions-view.css
@@ -315,6 +315,12 @@
   background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-raised));
 }
 
+.session-row--compact {
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-height: 36px;
+  padding: 6px 10px;
+}
+
 .session-row-familiar-chip,
 .session-row-new-icon {
   width: 24px;


### PR DESCRIPTION
## Summary
Tightens the sessions list inside the Chats tab.

- **Densified rows** (compact prop): drop the familiar avatar chip, drop the "Completed" status label for default-state sessions (still shown for running/failed/archived), drop the "Chat" origin badge when origin === "chat". Titles now have the full row width.
- **Recency grouping** (groupByRecency prop): \`Today / Yesterday / This week / Older\` section headers replace the flat scroll. Backed by a tiny pure helper \`bucketByRecency(sessions, now)\` so the day-boundary math is unit-testable in isolation.
- **Inline title filter**: case-insensitive substring filter, visible when sessions.length >= 6. Local state, no debounce — N is small.
- **Header cleanup**: drop the redundant \`{display_name} — Sessions / {harness}\` sub-header when the caller already conveys familiar context (gated on \`hideFamiliarFilter\`).
- **De-duped "New chat" CTA**: the in-list \`+ New chat\` row only renders for empty groups; the toolbar buttons stay primary.
- **CSS fix**: \`.session-row\` uses a 3-col grid (\`24px 1fr auto\`). When the avatar is hidden in compact mode the title was flowing into the 24px slot and clamping to ~3 chars. Added \`.session-row--compact\` that drops the avatar slot and tightens padding.

Standalone \`SessionsView\` callers (props default to \`false\`) keep current behavior.

## Test plan
- [x] \`node --experimental-strip-types src/components/sessions-view-chat-polish.test.ts\` — all assertions pass, includes a functional check of \`bucketByRecency\` day-boundary math
- [x] \`npm run typecheck\` — clean for \`sessions-view.tsx\` and \`chat-surface.tsx\`
- [x] Visual capture confirms: recency sections, full-width titles, no avatar/Completed/Chat badge, filter input, "Optimized" status (non-default) still shown on the row that has it

🤖 Generated with [Claude Code](https://claude.com/claude-code)