### PR TITLE
fix(salem): strip MDX/JSX leakage upstream in /api/salem retrieval

### DIFF
--- a/src/app/api/salem/route.ts
+++ b/src/app/api/salem/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { SALEM_PRELOAD_CONTEXT, summarizePreload } from "@/components/salem/salem-context";
+import { stripMdxLeakage } from "./strip-mdx";
 
 /**
  * Salem docs API — v1: live retrieval from llms-full.txt
@@ -53,12 +54,15 @@ function parseChunks(raw: string): DocChunk[] {
     const rest = lines.slice(1).join("\n").trim();
     if (!rest) continue;
 
-    // Extract leading heading (first # line)
-    const headingMatch = rest.match(/^#+\s+(.+)/m);
+    // Strip MDX/JSX tags before extracting heading & truncating, so the chunk
+    // text we hand to retrieval and the chat panel is plain markdown.
+    const cleaned = stripMdxLeakage(rest);
+    if (!cleaned) continue;
+
+    const headingMatch = cleaned.match(/^#+\s+(.+)/m);
     const heading = headingMatch?.[1] ?? source;
 
-    // Truncate for context budget
-    const text = rest.slice(0, MAX_CHUNK_CHARS);
+    const text = cleaned.slice(0, MAX_CHUNK_CHARS);
     chunks.push({ source, heading, text, tokens: tokenize(heading + " " + text) });
   }
 

--- a/src/app/api/salem/strip-mdx.test.ts
+++ b/src/app/api/salem/strip-mdx.test.ts
@@ -1,0 +1,115 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { stripMdxLeakage } from "./strip-mdx.ts";
+
+// <Cards>/<Card /> → markdown link list.
+{
+  const out = stripMdxLeakage([
+    "<Cards>",
+    "  <Card title=\"Getting Started\" href=\"/docs/guide/getting-started\" description=\"Set up your first familiar.\" />",
+    "  <Card title=\"Concepts\" href=\"/docs/guide/concepts\" />",
+    "</Cards>",
+  ].join("\n"));
+  assert.match(out, /- \[Getting Started\]\(\/docs\/guide\/getting-started\) — Set up your first familiar\./);
+  assert.match(out, /- \[Concepts\]\(\/docs\/guide\/concepts\)/);
+  assert.doesNotMatch(out, /<Cards>/);
+  assert.doesNotMatch(out, /<Card\s/);
+}
+
+// <Mermaid …multi-line chart…/> wholesale strip — including arrows that
+// contain `>` (`-->`) inside the quoted chart attribute, which the previous
+// `[^<>]` regex stopped at and leaked the rest of the chart body.
+{
+  const out = stripMdxLeakage([
+    "## Architecture",
+    "<Mermaid",
+    "  chart=\"`",
+    "flowchart LR",
+    "  UI[CastCodes UI] --> Agent[Cast Agent\\nsubstrate + session backend]",
+    "  Agent --> Gateway[Coven Gateway]",
+    "`\"",
+    "/>",
+    "Some prose after.",
+  ].join("\n"));
+  assert.doesNotMatch(out, /<Mermaid/);
+  assert.doesNotMatch(out, /flowchart LR/);
+  assert.doesNotMatch(out, /chart=/);
+  assert.doesNotMatch(out, /Cast Agent\\nsubstrate/, "no chart body residue must survive past the `-->` arrows");
+  assert.doesNotMatch(out, /Coven Gateway/);
+  assert.match(out, /## Architecture/);
+  assert.match(out, /Some prose after\./);
+}
+
+// <DocsDataTable> with multi-line array attributes.
+{
+  const out = stripMdxLeakage([
+    "<DocsDataTable",
+    "  caption=\"Coven differentiators\"",
+    "  columns=\"[ { key: 'pillar' } ]\"",
+    "/>",
+    "Trailing prose.",
+  ].join("\n"));
+  assert.doesNotMatch(out, /<DocsDataTable/);
+  assert.doesNotMatch(out, /Coven differentiators/);
+  assert.match(out, /Trailing prose\./);
+}
+
+// <GraphView /> + <HubCards />.
+{
+  const out = stripMdxLeakage([
+    "## Docs Map",
+    "<GraphView graph=\"buildGraph()\" />",
+    "<HubCards href=\"/docs/familiars\" />",
+    "After.",
+  ].join("\n"));
+  assert.doesNotMatch(out, /<GraphView/);
+  assert.doesNotMatch(out, /<HubCards/);
+  assert.doesNotMatch(out, /buildGraph/);
+  assert.match(out, /## Docs Map/);
+  assert.match(out, /After\./);
+}
+
+// Wrapping component preserves inner prose (<Callout>…</Callout>).
+{
+  const out = stripMdxLeakage([
+    "<Callout type=\"warn\">",
+    "Watch out for stale caches.",
+    "</Callout>",
+  ].join("\n"));
+  assert.doesNotMatch(out, /<Callout/);
+  assert.match(out, /Watch out for stale caches\./);
+}
+
+// Truncated/dangling opener at end-of-text.
+{
+  const out = stripMdxLeakage("Prose.\n\n<Mermaid\n  chart=\"`\nflowchart LR\n  UI --> Agent");
+  assert.doesNotMatch(out, /<Mermaid/);
+  assert.match(out, /Prose\./);
+}
+
+// MDX import/export and {/* … */} comments.
+{
+  const out = stripMdxLeakage([
+    "import { Mermaid } from 'fumadocs-ui/components/mermaid';",
+    "export const meta = { title: 'Foo' };",
+    "",
+    "# Heading",
+    "{/* TODO */}",
+    "Body.",
+  ].join("\n"));
+  assert.doesNotMatch(out, /import \{ Mermaid/);
+  assert.doesNotMatch(out, /export const meta/);
+  assert.doesNotMatch(out, /TODO/);
+  assert.match(out, /# Heading/);
+  assert.match(out, /Body\./);
+}
+
+// Heading anchors removed; lowercase HTML untouched.
+{
+  const out = stripMdxLeakage("## Docs Map [#docs-map]\n\nSome <em>emphasis</em>.");
+  assert.match(out, /## Docs Map\n/);
+  assert.doesNotMatch(out, /\[#docs-map\]/);
+  assert.match(out, /<em>emphasis<\/em>/);
+}
+
+console.log("✅  stripMdxLeakage tests passed (8 sections)");

--- a/src/app/api/salem/strip-mdx.ts
+++ b/src/app/api/salem/strip-mdx.ts
@@ -1,0 +1,67 @@
+// Strip MDX/JSX leakage from the docs corpus served to Salem.
+//
+// llms-full.txt preserves Fumadocs component tags (<Mermaid>, <Cards>,
+// <Card />, <DocsDataTable>, <GraphView />, <HubCards />, …) verbatim;
+// without sanitization those tags render as broken markup in the chat panel —
+// especially multi-line `chart="..."` attributes that dump raw flowchart
+// syntax, and 800-char truncation that slices tags in half.
+//
+// Lives at the retrieval/corpus layer (not the client) so retrieval, scoring,
+// and truncation all operate on plain markdown.
+
+// A JSX attribute: name, optionally followed by =value where value is a
+// "..."-quoted string (which may contain unescaped `>` — e.g. mermaid arrows
+// like `-->` inside a chart attribute), a '...'-quoted string, a {…}
+// expression, or a bare token. Multi-line attribute bodies are allowed
+// because the quoted forms tolerate any char except the matching quote.
+const ATTR = "\\s+[A-Za-z_$][\\w-]*(?:=(?:\"[^\"]*\"|'[^']*'|\\{[^}]*\\}|[^\\s>\"'{]+))?";
+// Whole PascalCase JSX element openers, with quote-aware attribute matching.
+const SELF_CLOSING_TAG = new RegExp(`<[A-Z][A-Za-z0-9]*(?:${ATTR})*\\s*/>`, "g");
+const OPEN_TAG = new RegExp(`<[A-Z][A-Za-z0-9]*(?:${ATTR})*\\s*>`, "g");
+const CLOSE_TAG = /<\/[A-Z][A-Za-z0-9]*\s*>/g;
+// Dangling/truncated opener at end-of-text (retrieval cut mid-tag at 800
+// chars before a closing `>` or `/>` arrived). Greedy `[\s\S]*` is safe
+// because the `$` anchor pins us to the very end of the string.
+const DANGLING_EOF = /<[A-Z][A-Za-z0-9]*\b[\s\S]*$/;
+
+export function stripMdxLeakage(text: string): string {
+  function cardToLink(attrs: string): string | null {
+    const title = /\btitle="([^"]*)"/.exec(attrs)?.[1];
+    const href = /\bhref="([^"]*)"/.exec(attrs)?.[1];
+    const desc = /\bdescription="([^"]*)"/.exec(attrs)?.[1];
+    if (!title || !href) return null;
+    return `- [${title}](${href})${desc ? ` — ${desc}` : ""}`;
+  }
+
+  // <Cards>…</Cards> → markdown link list (extract every nested <Card />).
+  text = text.replace(/<Cards>([\s\S]*?)<\/Cards>/g, (_match, inner: string) => {
+    const links: string[] = [];
+    const cardRe = /<Card\s+([^>]*?)\/?>/g;
+    let m: RegExpExecArray | null;
+    while ((m = cardRe.exec(inner)) !== null) {
+      const link = cardToLink(m[1]);
+      if (link) links.push(link);
+    }
+    return links.length ? links.join("\n") : "";
+  });
+
+  // Stray self-closing <Card .../> outside a <Cards> wrapper.
+  text = text.replace(/<Card\s+([^>]*?)\/>/g, (_m, attrs: string) => cardToLink(attrs) ?? "");
+
+  // MDX import/export lines and {/* … */} comments.
+  text = text.replace(/^\s*(?:import|export)\s[^\n]*$/gm, "");
+  text = text.replace(/\{\/\*[\s\S]*?\*\/\}/g, "");
+
+  text = text.replace(SELF_CLOSING_TAG, "");
+  text = text.replace(OPEN_TAG, "");
+  text = text.replace(CLOSE_TAG, "");
+  text = text.replace(DANGLING_EOF, "");
+
+  // Heading anchors like " [#docs-map]" after heading text.
+  text = text.replace(/\s\[#[\w-]+\]/g, "");
+
+  // Collapse runs of blank lines left behind by stripping.
+  text = text.replace(/\n{3,}/g, "\n\n");
+
+  return text.trim();
+}


### PR DESCRIPTION
## Summary

- Re-introduces the MDX/JSX sanitizer that #303 removed, but at the retrieval layer per #303's note: *"if Salem replies start showing raw component tags again, the right fix is upstream (in the retrieval / corpus pipeline), not a client-side sanitizer."*
- Adds `stripMdxLeakage` in `src/app/api/salem/strip-mdx.ts`; `parseChunks` runs it on each chunk body before heading extraction, tokenization, and the 800-char slice — so retrieval, scoring, and the wire payload all operate on plain markdown. Client (`salem-widget.tsx`) is unchanged from the post-#303 state.
- Regex is quote-aware (`"[^"]*"`) so `chart="...flowchart LR\n  X --> Y..."` attributes are stripped as a single tag. The earlier `[^<>]` form bailed at the first `-->` arrow and leaked the rest of the chart body into Salem's reply — a dedicated regression test pins that case.

## Escalation context

I pushed an earlier version of this commit (`46f3573`) directly to `main`. To route it through review like #303, I reverted on main (`131686e`, signed) and re-applied the same fix on this branch (`9a66868`).

## Test plan

- [x] `node --experimental-strip-types src/app/api/salem/strip-mdx.test.ts` — 8/8 (Cards link list, multi-line Mermaid with `-->` arrows, DocsDataTable, GraphView/HubCards, wrapping Callout, truncated/dangling opener, MDX import/export + `{/* */}` comments, lowercase HTML preserved)
- [x] `curl -X POST /api/salem` with "architecture diagram cast agent gateway": 0 PascalCase tags, 0 heading anchors, 0 chart residue in 1042-char reply
- [x] Headless Chromium drives the Salem chat panel — 6/6 DOM assertions pass, 0 console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)