### PR TITLE
feat(inbox): followup polish — state pill, drop WARN/INFO badge, resolved count, hover affordance, truncate names

### DIFF
--- a/src/components/inbox-escalations-view-polish.test.ts
+++ b/src/components/inbox-escalations-view-polish.test.ts
@@ -1,0 +1,19 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("./inbox-escalations-view.tsx", import.meta.url), "utf8");
+
+// ───────── Task 1: State rendered as neutral pill ─────────
+assert.match(
+  source,
+  /<span className="ml-1\.5 inline-block rounded border border-border bg-card px-1 py-px text-\[9px\] uppercase tracking-widest text-muted-foreground align-middle">\s*\{item\.state\}\s*<\/span>/,
+  "State must render as a neutral bordered pill after the timestamp",
+);
+assert.doesNotMatch(
+  source,
+  /\? <> · <span>\{item\.state\}<\/span><\/> :/,
+  "Old `· {item.state}` middot-text shape must be removed",
+);
+
+console.log("inbox-escalations-view-polish.test.ts: ok");

--- a/src/components/inbox-escalations-view-polish.test.ts
+++ b/src/components/inbox-escalations-view-polish.test.ts
@@ -62,4 +62,16 @@ assert.match(
   "Hover affordance must use opacity-0 group-hover:opacity-100",
 );
 
+// ───────── Task 5: Familiar names truncate ─────────
+assert.match(
+  source,
+  /<span className="inline-block max-w-\[12ch\] truncate align-bottom text-foreground">\{item\.fromFamiliar\}<\/span>/,
+  "fromFamiliar span must use inline-block max-w-[12ch] truncate",
+);
+assert.match(
+  source,
+  /<span className="inline-block max-w-\[12ch\] truncate align-bottom text-foreground">\{item\.aboutFamiliar\}<\/span>/,
+  "aboutFamiliar span must use inline-block max-w-[12ch] truncate",
+);
+
 console.log("inbox-escalations-view-polish.test.ts: ok");

--- a/src/components/inbox-escalations-view-polish.test.ts
+++ b/src/components/inbox-escalations-view-polish.test.ts
@@ -40,4 +40,26 @@ assert.match(
   "Show resolved label must include count when > 0",
 );
 
+// ───────── Task 4: Per-row hover affordance ─────────
+assert.match(
+  source,
+  /onPromoteToActive:\s*\(\) => void;/,
+  "EscalationRow must accept onPromoteToActive prop",
+);
+assert.match(
+  source,
+  /aria-label="Show actions"/,
+  "Hover affordance button must carry aria-label='Show actions'",
+);
+assert.match(
+  source,
+  /onPromoteToActive=\{\(\) => onActivate\(idx\)\}/,
+  "renderRow must wire onPromoteToActive to onActivate(idx)",
+);
+assert.match(
+  source,
+  /opacity-0 group-hover:opacity-100[^"]*"[\s\S]{0,200}aria-label="Show actions"/,
+  "Hover affordance must use opacity-0 group-hover:opacity-100",
+);
+
 console.log("inbox-escalations-view-polish.test.ts: ok");

--- a/src/components/inbox-escalations-view-polish.test.ts
+++ b/src/components/inbox-escalations-view-polish.test.ts
@@ -16,4 +16,16 @@ assert.doesNotMatch(
   "Old `· {item.state}` middot-text shape must be removed",
 );
 
+// ───────── Task 2: Severity text badge gated on critical only ─────────
+assert.match(
+  source,
+  /\{item\.severity === "critical" \? \(\s*<span/,
+  "Severity text badge must be gated on item.severity === 'critical'",
+);
+assert.doesNotMatch(
+  source,
+  /^\s*<span\s+className=\{`shrink-0 rounded border px-1\.5 py-px text-\[9px\] uppercase tracking-widest \$\{sevColor\}`\}\s+title=\{item\.severityReason \?\? SEVERITY_LABEL\[item\.severity\]\}>\s*\{SEVERITY_LABEL\[item\.severity\]\}\s*<\/span>$/m,
+  "Unconditional severity badge render must be gone",
+);
+
 console.log("inbox-escalations-view-polish.test.ts: ok");

--- a/src/components/inbox-escalations-view-polish.test.ts
+++ b/src/components/inbox-escalations-view-polish.test.ts
@@ -28,4 +28,16 @@ assert.doesNotMatch(
   "Unconditional severity badge render must be gone",
 );
 
+// ───────── Task 3: Show resolved count ─────────
+assert.match(
+  source,
+  /const resolvedCount = items\.filter\(\(i\) => i\.state === "resolved"\)\.length;/,
+  "resolvedCount must be derived from items",
+);
+assert.match(
+  source,
+  /Show resolved\{resolvedCount > 0 \? ` \(\$\{resolvedCount\}\)` : ""\}/,
+  "Show resolved label must include count when > 0",
+);
+
 console.log("inbox-escalations-view-polish.test.ts: ok");

--- a/src/components/inbox-escalations-view.tsx
+++ b/src/components/inbox-escalations-view.tsx
@@ -710,12 +710,14 @@ function EscalationRow({
         />
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-1.5 text-sm text-foreground">
-            <span
-              className={`shrink-0 rounded border px-1.5 py-px text-[9px] uppercase tracking-widest ${sevColor}`}
-              title={item.severityReason ?? SEVERITY_LABEL[item.severity]}
-            >
-              {SEVERITY_LABEL[item.severity]}
-            </span>
+            {item.severity === "critical" ? (
+              <span
+                className={`shrink-0 rounded border px-1.5 py-px text-[9px] uppercase tracking-widest ${sevColor}`}
+                title={item.severityReason ?? SEVERITY_LABEL[item.severity]}
+              >
+                {SEVERITY_LABEL[item.severity]}
+              </span>
+            ) : null}
             {originChipFor(item.origin)}
             <span className="min-w-0 flex-1 truncate" title={item.title}>
               {item.title}

--- a/src/components/inbox-escalations-view.tsx
+++ b/src/components/inbox-escalations-view.tsx
@@ -307,6 +307,7 @@ export function InboxEscalationsView({
   const criticalCount = items.filter(
     (i) => i.severity === "critical" && i.state !== "resolved" && i.state !== "dismissed",
   ).length;
+  const resolvedCount = items.filter((i) => i.state === "resolved").length;
 
   return (
     <section
@@ -354,7 +355,7 @@ export function InboxEscalationsView({
                   onChange={(e) => setShowResolved(e.target.checked)}
                   className="accent-foreground"
                 />
-                Show resolved
+                Show resolved{resolvedCount > 0 ? ` (${resolvedCount})` : ""}
               </label>
               <button
                 onClick={() => void refresh()}

--- a/src/components/inbox-escalations-view.tsx
+++ b/src/components/inbox-escalations-view.tsx
@@ -728,8 +728,12 @@ function EscalationRow({
             </span>
           </div>
           <div className="mt-0.5 text-[11px] text-muted-foreground">
-            {item.fromFamiliar ? <>From <span className="text-foreground">{item.fromFamiliar}</span> · </> : null}
-            {item.aboutFamiliar ? <>about <span className="text-foreground">{item.aboutFamiliar}</span> · </> : null}
+            {item.fromFamiliar ? (
+              <>From <span className="inline-block max-w-[12ch] truncate align-bottom text-foreground">{item.fromFamiliar}</span> · </>
+            ) : null}
+            {item.aboutFamiliar ? (
+              <>about <span className="inline-block max-w-[12ch] truncate align-bottom text-foreground">{item.aboutFamiliar}</span> · </>
+            ) : null}
             <span title={item.createdAt}>{age(item.createdAt)} ago</span>
             {item.state !== "new" ? (
               <span className="ml-1.5 inline-block rounded border border-border bg-card px-1 py-px text-[9px] uppercase tracking-widest text-muted-foreground align-middle">

--- a/src/components/inbox-escalations-view.tsx
+++ b/src/components/inbox-escalations-view.tsx
@@ -601,6 +601,7 @@ function GroupedList({
           onPatch={(body) => onPatch(it.id, body)}
           onOpenSource={() => onOpenSource(it)}
           onAskSnooze={() => onAskSnooze(it.id)}
+          onPromoteToActive={() => onActivate(idx)}
         />
         {snoozeMenuFor === it.id ? (
           <SnoozeMenu
@@ -667,6 +668,7 @@ function EscalationRow({
   onPatch,
   onOpenSource,
   onAskSnooze,
+  onPromoteToActive,
 }: {
   item: Escalation;
   isActive: boolean;
@@ -675,6 +677,7 @@ function EscalationRow({
   onPatch: (body: Record<string, unknown>) => void;
   onOpenSource: () => void;
   onAskSnooze: () => void;
+  onPromoteToActive: () => void;
 }) {
   const sevColor =
     item.severity === "critical"
@@ -738,6 +741,17 @@ function EscalationRow({
             <p className="mt-1 line-clamp-2 text-[12px] text-muted-foreground">{item.excerpt}</p>
           ) : null}
         </div>
+        {!isActive ? (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); onPromoteToActive(); }}
+            className="shrink-0 opacity-0 group-hover:opacity-100 focus-ring rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-opacity"
+            aria-label="Show actions"
+            title="Show actions"
+          >
+            <Icon name="ph:dots-three-bold" width={14} />
+          </button>
+        ) : null}
       </div>
 
       {isActive ? (

--- a/src/components/inbox-escalations-view.tsx
+++ b/src/components/inbox-escalations-view.tsx
@@ -725,7 +725,11 @@ function EscalationRow({
             {item.fromFamiliar ? <>From <span className="text-foreground">{item.fromFamiliar}</span> · </> : null}
             {item.aboutFamiliar ? <>about <span className="text-foreground">{item.aboutFamiliar}</span> · </> : null}
             <span title={item.createdAt}>{age(item.createdAt)} ago</span>
-            {item.state !== "new" ? <> · <span>{item.state}</span></> : null}
+            {item.state !== "new" ? (
+              <span className="ml-1.5 inline-block rounded border border-border bg-card px-1 py-px text-[9px] uppercase tracking-widest text-muted-foreground align-middle">
+                {item.state}
+              </span>
+            ) : null}
           </div>
           {item.excerpt ? (
             <p className="mt-1 line-clamp-2 text-[12px] text-muted-foreground">{item.excerpt}</p>


### PR DESCRIPTION
## Summary
Five focused polish changes on top of \`b6c4e44 feat(inbox): severity rails, filter chips, group headers, bulk actions\`.

- **State pill**: \`acknowledged\` / \`resolved\` / \`dismissed\` render as a small neutral bordered pill on the meta line instead of trailing middot text.
- **Drop WARN/INFO text badge**: the colored left rail + live-state dot already signal severity for warn/info rows; the bordered text pill was duplicative. Keep \`CRITICAL\` text pill since it deserves the loudest treatment.
- **\`Show resolved (N)\` count**: derive \`resolvedCount\` from the full \`items\` list, include the count in the toggle label when > 0.
- **Per-row ⋯ hover affordance**: small button revealed on hover for non-active rows; click promotes the row to active so the existing action strip appears. Discovers the keyboard-actions model from the mouse path.
- **Truncate long familiar names**: cap each name span at \`max-w-[12ch]\` with \`inline-block truncate\` so the timestamp + state pill always stay visible.

All in one file: \`src/components/inbox-escalations-view.tsx\`. One new \`onPromoteToActive\` prop threaded through \`EscalationGroupedList\` → \`EscalationRow\`.

## Test plan
- [x] \`node --experimental-strip-types src/components/inbox-escalations-view-polish.test.ts\` — all five sections asserted, passes
- [x] \`npm run typecheck\` — clean for the touched file
- [x] Visual capture: state pill visible, WARN/INFO text badges gone, CRITICAL preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)