### PR TITLE
feat(library): polish — localeCompare crash fix, narrow-rail placeholder, Timeline rename, section-aware empty state, [ shortcut

### DIFF
--- a/src/components/library-bookmarks-list.tsx
+++ b/src/components/library-bookmarks-list.tsx
@@ -24,9 +24,9 @@ function relTime(iso: string): string {
 function sortItems(items: LibraryBookmark[], key: SortKey, dir: SortDir): LibraryBookmark[] {
   return [...items].sort((a, b) => {
     let cmp = 0;
-    if (key === "title") cmp = a.title.localeCompare(b.title);
-    else if (key === "domain") cmp = a.domain.localeCompare(b.domain);
-    else cmp = a.savedAt.localeCompare(b.savedAt);
+    if (key === "title") cmp = (a.title ?? "").localeCompare(b.title ?? "");
+    else if (key === "domain") cmp = (a.domain ?? "").localeCompare(b.domain ?? "");
+    else cmp = (a.savedAt ?? "").localeCompare(b.savedAt ?? "");
     return dir === "asc" ? cmp : -cmp;
   });
 }

--- a/src/components/library-collection-rail.tsx
+++ b/src/components/library-collection-rail.tsx
@@ -23,7 +23,7 @@ type ListSection = {
 };
 
 const STATIC_LIST_SECTIONS: ListSection[] = [
-  { id: "all",       label: "All",       icon: "ph:link" },
+  { id: "all",       label: "Timeline",  icon: "ph:link" },
   { id: "bookmarks", label: "Bookmarks", icon: "ph:bookmark-simple" },
   { id: "reading",   label: "Reading",   icon: "ph:book-open" },
   { id: "github",    label: "GitHub",    icon: "ph:github-logo" },

--- a/src/components/library-doc-preview.tsx
+++ b/src/components/library-doc-preview.tsx
@@ -11,6 +11,7 @@ import type {
   LibraryReadingItem,
   LibraryGitHubItem,
   ReadingStatus,
+  LibrarySectionKind,
 } from "@/lib/library-types";
 import type { Skill } from "@/components/library-collection-rail";
 import { useFocusTrap } from "@/lib/use-focus-trap";
@@ -24,7 +25,17 @@ export type SelectedItem =
   | { kind: "skill"; skill: Skill }
   | null;
 
-type Props = { selected: SelectedItem; loading: boolean };
+type Props = { selected: SelectedItem; loading: boolean; activeSection?: LibrarySectionKind };
+
+const EMPTY_TEXT: Record<LibrarySectionKind, string> = {
+  all: "Select an item to preview",
+  docs: "Select a doc to preview",
+  bookmarks: "Select a bookmark to preview",
+  reading: "Select a reading item to preview",
+  github: "Select a GitHub item to preview",
+  projects: "Select a project to preview",
+  skills: "Select a skill to view",
+};
 
 // ── Helpers ──────────────────────────────────────────────────────
 const dateFmt = new Intl.DateTimeFormat([], { year: "numeric", month: "short", day: "numeric" });
@@ -674,7 +685,7 @@ function SkillDetail({ skill }: { skill: Skill }) {
 }
 
 // ── Dispatcher ───────────────────────────────────────────────────
-export function LibraryDocPreview({ selected, loading }: Props) {
+export function LibraryDocPreview({ selected, loading, activeSection }: Props) {
   if (loading) {
     return (
       <div className="library-preview library-preview--empty">
@@ -686,7 +697,9 @@ export function LibraryDocPreview({ selected, loading }: Props) {
     return (
       <div className="library-preview library-preview--empty">
         <Icon name="ph:book-open" width={32} className="library-preview-empty-icon" />
-        <span className="library-preview-empty-text">Select a document to preview</span>
+        <span className="library-preview-empty-text">
+          {activeSection ? EMPTY_TEXT[activeSection] : "Select an item to preview"}
+        </span>
       </div>
     );
   }

--- a/src/components/library-github-list.tsx
+++ b/src/components/library-github-list.tsx
@@ -32,9 +32,9 @@ function relTime(iso: string): string {
 function sortItems(items: LibraryGitHubItem[], key: SortKey, dir: SortDir): LibraryGitHubItem[] {
   return [...items].sort((a, b) => {
     let cmp = 0;
-    if (key === "title") cmp = a.title.localeCompare(b.title);
-    else if (key === "repo") cmp = a.repo.localeCompare(b.repo);
-    else cmp = a.savedAt.localeCompare(b.savedAt);
+    if (key === "title") cmp = (a.title ?? "").localeCompare(b.title ?? "");
+    else if (key === "repo") cmp = (a.repo ?? "").localeCompare(b.repo ?? "");
+    else cmp = (a.savedAt ?? "").localeCompare(b.savedAt ?? "");
     return dir === "asc" ? cmp : -cmp;
   });
 }

--- a/src/components/library-polish.test.ts
+++ b/src/components/library-polish.test.ts
@@ -28,4 +28,8 @@ assert.match(timeline, /placeholder="Search links…"/, "Timeline placeholder mu
 assert.match(timeline, /title="Search links — try chat: github: sage:"/, "Verbose hint must live in title=");
 assert.doesNotMatch(timeline, /placeholder="Search links — try chat: github: sage:"/, "Old long placeholder must be removed");
 
+// ───────── Task 3: Lists "All" renamed to "Timeline" ─────────
+const rail = await readFile(new URL("./library-collection-rail.tsx", import.meta.url), "utf8");
+assert.match(rail, /\{ id: "all",\s+label: "Timeline",\s+icon: "ph:link" \}/, "STATIC_LIST_SECTIONS first row label must be 'Timeline'");
+
 console.log("library-polish.test.ts: ok");

--- a/src/components/library-polish.test.ts
+++ b/src/components/library-polish.test.ts
@@ -44,4 +44,10 @@ for (const section of ["all", "docs", "bookmarks", "reading", "github", "project
 assert.match(preview, /activeSection \? EMPTY_TEXT\[activeSection\] : "Select an item to preview"/, "Empty render uses EMPTY_TEXT[activeSection]");
 assert.match(view, /<LibraryDocPreview\s+selected=\{selectedItem\}\s+loading=\{previewLoading\}\s+activeSection=\{activeSection\}/, "library-view passes activeSection");
 
+// ───────── Task 5: [ shortcut toggles list panel ─────────
+const view2 = await readFile(new URL("./library-view.tsx", import.meta.url), "utf8");
+assert.match(view2, /if \(e\.key !== "\["\) return;/, "library-view must filter keydown events for '['");
+assert.match(view2, /setListPinned\(\(v\) => !v\)/, "library-view must call setListPinned((v) => !v)");
+assert.match(view2, /\["input", "textarea", "select"\]\.includes\(tag\)/, "library-view must skip when focus is in an input");
+
 console.log("library-polish.test.ts: ok");

--- a/src/components/library-polish.test.ts
+++ b/src/components/library-polish.test.ts
@@ -1,0 +1,25 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const bookmarks = await readFile(new URL("./library-bookmarks-list.tsx", import.meta.url), "utf8");
+const reading   = await readFile(new URL("./library-reading-list.tsx",   import.meta.url), "utf8");
+const github    = await readFile(new URL("./library-github-list.tsx",    import.meta.url), "utf8");
+
+// ───────── Task 1: localeCompare null-guards ─────────
+// bookmarks — title, domain, savedAt
+assert.match(bookmarks, /\(a\.title \?\? ""\)\.localeCompare\(b\.title \?\? ""\)/,    "bookmarks title null-guard");
+assert.match(bookmarks, /\(a\.domain \?\? ""\)\.localeCompare\(b\.domain \?\? ""\)/,  "bookmarks domain null-guard");
+assert.match(bookmarks, /\(a\.savedAt \?\? ""\)\.localeCompare\(b\.savedAt \?\? ""\)/,"bookmarks savedAt null-guard");
+
+// reading — title, addedAt, label
+assert.match(reading, /\(a\.title \?\? ""\)\.localeCompare\(b\.title \?\? ""\)/,     "reading title null-guard");
+assert.match(reading, /\(a\.addedAt \?\? ""\)\.localeCompare\(b\.addedAt \?\? ""\)/, "reading addedAt null-guard");
+assert.match(reading, /\(a\.label \?\? ""\)\.localeCompare\(b\.label \?\? ""\)/,     "reading label null-guard");
+
+// github — title, repo, savedAt
+assert.match(github, /\(a\.title \?\? ""\)\.localeCompare\(b\.title \?\? ""\)/,   "github title null-guard");
+assert.match(github, /\(a\.repo \?\? ""\)\.localeCompare\(b\.repo \?\? ""\)/,     "github repo null-guard");
+assert.match(github, /\(a\.savedAt \?\? ""\)\.localeCompare\(b\.savedAt \?\? ""\)/,"github savedAt null-guard");
+
+console.log("library-polish.test.ts: ok");

--- a/src/components/library-polish.test.ts
+++ b/src/components/library-polish.test.ts
@@ -22,4 +22,10 @@ assert.match(github, /\(a\.title \?\? ""\)\.localeCompare\(b\.title \?\? ""\)/, 
 assert.match(github, /\(a\.repo \?\? ""\)\.localeCompare\(b\.repo \?\? ""\)/,     "github repo null-guard");
 assert.match(github, /\(a\.savedAt \?\? ""\)\.localeCompare\(b\.savedAt \?\? ""\)/,"github savedAt null-guard");
 
+// ───────── Task 2: Timeline placeholder shortened ─────────
+const timeline = await readFile(new URL("./library-timeline.tsx", import.meta.url), "utf8");
+assert.match(timeline, /placeholder="Search links…"/, "Timeline placeholder must be 'Search links…'");
+assert.match(timeline, /title="Search links — try chat: github: sage:"/, "Verbose hint must live in title=");
+assert.doesNotMatch(timeline, /placeholder="Search links — try chat: github: sage:"/, "Old long placeholder must be removed");
+
 console.log("library-polish.test.ts: ok");

--- a/src/components/library-polish.test.ts
+++ b/src/components/library-polish.test.ts
@@ -32,4 +32,16 @@ assert.doesNotMatch(timeline, /placeholder="Search links — try chat: github: s
 const rail = await readFile(new URL("./library-collection-rail.tsx", import.meta.url), "utf8");
 assert.match(rail, /\{ id: "all",\s+label: "Timeline",\s+icon: "ph:link" \}/, "STATIC_LIST_SECTIONS first row label must be 'Timeline'");
 
+// ───────── Task 4: Section-aware preview empty state ─────────
+const preview = await readFile(new URL("./library-doc-preview.tsx", import.meta.url), "utf8");
+const view    = await readFile(new URL("./library-view.tsx",        import.meta.url), "utf8");
+
+assert.match(preview, /LibrarySectionKind[\s\S]{0,200}?from "@\/lib\/library-types"/, "LibrarySectionKind must be imported from library-types");
+assert.match(preview, /const EMPTY_TEXT: Record<LibrarySectionKind, string> = \{/, "EMPTY_TEXT typed Record<LibrarySectionKind, string>");
+for (const section of ["all", "docs", "bookmarks", "reading", "github", "projects", "skills"]) {
+  assert.ok(new RegExp(`${section}:\\s*"Select`).test(preview), `EMPTY_TEXT entry for ${section}`);
+}
+assert.match(preview, /activeSection \? EMPTY_TEXT\[activeSection\] : "Select an item to preview"/, "Empty render uses EMPTY_TEXT[activeSection]");
+assert.match(view, /<LibraryDocPreview\s+selected=\{selectedItem\}\s+loading=\{previewLoading\}\s+activeSection=\{activeSection\}/, "library-view passes activeSection");
+
 console.log("library-polish.test.ts: ok");

--- a/src/components/library-reading-list.tsx
+++ b/src/components/library-reading-list.tsx
@@ -31,9 +31,9 @@ function relTime(iso: string): string {
 function sortItems(items: LibraryReadingItem[], key: SortKey, dir: SortDir): LibraryReadingItem[] {
   return [...items].sort((a, b) => {
     let cmp = 0;
-    if (key === "title") cmp = a.title.localeCompare(b.title);
+    if (key === "title") cmp = (a.title ?? "").localeCompare(b.title ?? "");
     else if (key === "status") cmp = STATUS_ORDER[a.status] - STATUS_ORDER[b.status];
-    else cmp = a.addedAt.localeCompare(b.addedAt);
+    else cmp = (a.addedAt ?? "").localeCompare(b.addedAt ?? "");
     return dir === "asc" ? cmp : -cmp;
   });
 }
@@ -52,7 +52,7 @@ function groupItems(items: LibraryReadingItem[], by: GroupBy): { key: string; la
     items,
   }));
   if (by === "status") entries.sort((a, b) => (STATUS_ORDER[a.key as ReadingStatus] ?? 9) - (STATUS_ORDER[b.key as ReadingStatus] ?? 9));
-  else entries.sort((a, b) => a.label.localeCompare(b.label));
+  else entries.sort((a, b) => (a.label ?? "").localeCompare(b.label ?? ""));
   return entries;
 }
 

--- a/src/components/library-timeline.tsx
+++ b/src/components/library-timeline.tsx
@@ -101,7 +101,8 @@ export function LibraryTimeline({
           <SearchInput
             value={search}
             onValueChange={setSearch}
-            placeholder="Search links — try chat: github: sage:"
+            placeholder="Search links…"
+            title="Search links — try chat: github: sage:"
             onClear={() => setSearch("")}
           />
         }

--- a/src/components/library-view.tsx
+++ b/src/components/library-view.tsx
@@ -125,7 +125,7 @@ export function LibraryView({ onOpenUrl, sessions, onOpenSession, onNewProjectCh
       />
       <div className="library-divider" />
       {/* Preview pane — dominant left content area */}
-      <LibraryDocPreview selected={selectedItem} loading={previewLoading} />
+      <LibraryDocPreview selected={selectedItem} loading={previewLoading} activeSection={activeSection} />
 
       {/* Collapsible list panel — matches browser rail expand/collapse pattern */}
       <div

--- a/src/components/library-view.tsx
+++ b/src/components/library-view.tsx
@@ -54,6 +54,19 @@ export function LibraryView({ onOpenUrl, sessions, onOpenSession, onNewProjectCh
       .catch(() => undefined);
   }, []);
 
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "[") return;
+      const target = e.target as HTMLElement;
+      const tag = target.tagName?.toLowerCase();
+      if (["input", "textarea", "select"].includes(tag) || target.isContentEditable) return;
+      e.preventDefault();
+      setListPinned((v) => !v);
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
   const [docsError, setDocsError] = useState<string | null>(null);
 
   const loadDocs = useCallback(async (collectionId: string) => {


### PR DESCRIPTION
## Summary
Five focused polish changes in the Library, including one P0 crash fix.

- **P0 bug fix**: \`localeCompare\` on undefined fields crashed the whole Library page when the bookmarks section rendered with any item missing \`savedAt\`. Same unguarded pattern existed across title/domain/savedAt (bookmarks), title/addedAt/label (reading), and title/repo/savedAt (github). Coerce each operand to \`""\` before \`.localeCompare\`.
- **Narrow-rail placeholder**: timeline search placeholder \`Search links — try chat: github: sage:\` truncated badly in the collapsible rail. Shortened to \`Search links…\`; verbose hint moved to \`title=\` tooltip.
- **Disambiguate two \`All\` rows**: \`Library > All\` (collection of docs) and \`Lists > All\` (cross-section timeline) read identically but mean different things. Rename the second to \`Timeline\`.
- **Section-aware preview empty state**: \`Select a document to preview\` was shown for every section. Add an \`EMPTY_TEXT\` table keyed by \`LibrarySectionKind\` (bookmarks → 'Select a bookmark…', github → 'Select a GitHub item…', etc.).
- **\`[\` keyboard shortcut** toggles the collapsible list panel. Mirrors the calendar's T/D/W/M/A pattern; skipped when focus is in an input.

Touches 7 files in \`src/components/library-*\`. One new \`EMPTY_TEXT\` table, one new \`useEffect\`.

## Test plan
- [x] \`node --experimental-strip-types src/components/library-polish.test.ts\` — all 5 sections asserted
- [x] \`npm run typecheck\` — clean for all touched files
- [x] Visual confirmed: bookmarks no longer crashes; rail reads 'Timeline'; placeholder fits; empty preview is section-aware (verified for all/bookmarks/reading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)