### PR TITLE
feat(home): polish — destination-aware placeholder, keyboard hint, visible Send label

### DIFF
--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -26,4 +26,11 @@ assert.doesNotMatch(
   "Redundant subtitle must be removed",
 );
 
+// ───────── Task 2: Keyboard hint strip ─────────
+assert.match(source, /<div className="hc-keyboard-hint">/, "hc-keyboard-hint div in JSX");
+assert.match(source, /⏎ send · ⇧⏎ newline · ↑↓ history · \/ commands/, "Hint copy: send/newline/history/commands");
+
+const css = await readFile(new URL("../styles/home-composer.css", import.meta.url), "utf8");
+assert.match(css, /\.hc-keyboard-hint\s*\{[\s\S]*?color:\s*var\(--text-muted\)/, ".hc-keyboard-hint CSS with --text-muted");
+
 console.log("home-composer-polish.test.ts: ok");

--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -33,4 +33,11 @@ assert.match(source, /⏎ send · ⇧⏎ newline · ↑↓ history · \/ command
 const css = await readFile(new URL("../styles/home-composer.css", import.meta.url), "utf8");
 assert.match(css, /\.hc-keyboard-hint\s*\{[\s\S]*?color:\s*var\(--text-muted\)/, ".hc-keyboard-hint CSS with --text-muted");
 
+// ───────── Task 3: Visible Send label ─────────
+assert.match(source, /<span className="hc-send-label">Send<\/span>/, "Send label in button body");
+assert.match(source, /aria-label="Send"/, "Button keeps aria-label='Send'");
+assert.match(css, /\.hc-send-btn\s*\{[\s\S]*?gap:\s*5px/, ".hc-send-btn uses gap: 5px");
+assert.doesNotMatch(css, /\.hc-send-btn\s*\{[\s\S]*?width:\s*32px;[\s\S]*?height:\s*32px;[\s\S]*?\}/, "Old fixed 32x32 size removed");
+assert.match(css, /\.hc-send-label\s*\{/, ".hc-send-label rule defined");
+
 console.log("home-composer-polish.test.ts: ok");

--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("./home-composer.tsx", import.meta.url), "utf8");
+
+// ───────── Task 1: Destination-aware placeholder + drop subtitle ─────────
+assert.match(
+  source,
+  /const PLACEHOLDERS: Record<Destination, string> = \{[\s\S]*?chat:[\s\S]*?board:[\s\S]*?reminder:[\s\S]*?\}/,
+  "PLACEHOLDERS must be a Record<Destination, string> with chat/board/reminder keys",
+);
+assert.match(
+  source,
+  /placeholder=\{PLACEHOLDERS\[destination\]\}/,
+  "textarea must use placeholder={PLACEHOLDERS[destination]}",
+);
+assert.doesNotMatch(
+  source,
+  /placeholder="Ask anything, start a task, set a reminder…"/,
+  "Old static placeholder must be removed",
+);
+assert.doesNotMatch(
+  source,
+  /Pick a destination, and go\./,
+  "Redundant subtitle must be removed",
+);
+
+console.log("home-composer-polish.test.ts: ok");

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -384,7 +384,10 @@ export function HomeComposer({
             {sending ? (
               <span className="hc-spinner" />
             ) : (
-              <Icon name="ph:arrow-up-bold" width={14} aria-hidden />
+              <>
+                <Icon name="ph:arrow-up-bold" width={11} aria-hidden />
+                <span className="hc-send-label">Send</span>
+              </>
             )}
           </button>
         </div>

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -391,6 +391,10 @@ export function HomeComposer({
         </div>
       </div>
 
+      <div className="hc-keyboard-hint">
+        ⏎ send · ⇧⏎ newline · ↑↓ history · / commands
+      </div>
+
       {/* Suggestions */}
       {suggestionsLoading ? (
         <div className="home-composer-suggestions" aria-hidden>

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -31,6 +31,12 @@ const DESTINATIONS: { id: Destination; label: string; icon: IconName }[] = [
   { id: "reminder", label: "Reminder", icon: "ph:alarm-fill" },
 ];
 
+const PLACEHOLDERS: Record<Destination, string> = {
+  chat: "Ask anything in Chat…",
+  board: "Describe a new task…",
+  reminder: "Remind me about…",
+};
+
 type Props = {
   familiars: Familiar[];
   activeFamiliarId: string | null;
@@ -293,7 +299,6 @@ export function HomeComposer({
       {/* Headline */}
       <div className="home-composer-hero">
         <h1 className="home-composer-headline">What can the Coven do?</h1>
-        <p className="home-composer-sub">Pick a destination, and go.</p>
       </div>
 
       {/* Composer card — wrapped so the slash menu can render above the
@@ -340,7 +345,7 @@ export function HomeComposer({
         <textarea
           ref={textareaRef}
           className="hc-textarea"
-          placeholder="Ask anything, start a task, set a reminder…"
+          placeholder={PLACEHOLDERS[destination]}
           rows={3}
           value={text}
           onChange={(e) => { setText(e.target.value); autoGrow(); }}

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -193,11 +193,12 @@
 
 /* ── Send button ─────────────────────────────────────────────────────────── */
 .hc-send-btn {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  gap: 5px;
+  min-height: 32px;
+  padding: 0 12px;
   border-radius: 6px;
   border: none;
   background: var(--accent-presence);
@@ -206,6 +207,12 @@
   flex-shrink: 0;
   margin-left: auto;
   transition: background 0.15s ease, opacity 0.15s ease, transform 0.1s ease;
+}
+
+.hc-send-label {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
 }
 
 .hc-send-btn:hover:not(:disabled) {

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -395,3 +395,10 @@
   font-size: 10px;
   color: var(--text-muted);
 }
+
+.hc-keyboard-hint {
+  margin-top: 12px;
+  text-align: center;
+  font-size: 10px;
+  color: var(--text-muted);
+}


### PR DESCRIPTION
## Summary
Three focused polish changes to the Home composer (on top of \`fb07b44 feat(home): slash command autocomplete\`).

- **Destination-aware textarea placeholder** + drop the redundant \`Pick a destination, and go.\` subtitle. Placeholder now reads \`Ask anything in Chat…\` / \`Describe a new task…\` / \`Remind me about…\` and updates reactively as the user picks a destination pill. The instruction-target relationship is direct instead of muddled.
- **Keyboard hint strip below the composer** surfaces \`⏎ send · ⇧⏎ newline · ↑↓ history · / commands\` — all already wired in \`handleKeyDown\` but invisible until now. Matches the inbox/calendar footer pattern.
- **Visible \`Send\` label on the submit button** — was a 32x32 icon-only square reading as decoration. Now a labeled pill (\`↑ Send\`). \`aria-label\` retained for screen readers; \`.hc-send-btn\` relaxed from fixed 32x32 to a flex pill with min-height + padding.

Touches \`src/components/home-composer.tsx\` and \`src/styles/home-composer.css\`.

## Test plan
- [x] \`node --experimental-strip-types src/components/home-composer-polish.test.ts\` — all three sections asserted
- [x] \`node --experimental-strip-types src/components/home-composer.test.ts\` — pre-existing test still passes
- [x] \`npm run typecheck\` — clean for the touched file
- [x] Visual confirmed: subtitle gone, placeholder updates on Chat → Tasks switch, keyboard hint visible, Send pill replaces icon-only square

🤖 Generated with [Claude Code](https://claude.com/claude-code)