### PR TITLE
style(sidebar): hide duplicate New Chat row + improve kbd hint contrast

### DIFF
--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -171,4 +171,10 @@ assert.match(
   "capabilities stays in Tools",
 );
 
+assert.match(
+  source,
+  /className="sidebar-new-chat-row">\s*<ActionRow/,
+  "The mobile New Chat ActionRow stays wrapped in .sidebar-new-chat-row so responsive CSS can hide it on desktop",
+);
+
 console.log("sidebar-minimal.test.ts (shell-ia-lastmile) OK");

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -693,6 +693,10 @@
   outline-offset: -1px;
 }
 
+.sidebar-new-chat-row {
+  display: none;
+}
+
 /* Desktop (>= 768px): hide the full-width "New Chat" row, keep the + icon. */
 @media (min-width: 768px) {
   .sidebar-new-chat-row {
@@ -702,6 +706,10 @@
 
 /* Mobile (<= 767px): hide the inline + icon, show the full-width button. */
 @media (max-width: 767px) {
+  .sidebar-new-chat-row {
+    display: block;
+  }
+
   .sidebar-new-chat-icon {
     display: none;
   }

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -1025,12 +1025,14 @@
   margin-left: auto;
   font-family: var(--font-geist-mono);
   font-size: 10px;
-  color: var(--text-muted);
-  opacity: 0.7;
+  color: var(--text-secondary);
+  opacity: 0.85;
+  letter-spacing: 0.02em;
 }
 
 .sidebar-folder-row:hover .sidebar-folder-kbd {
   opacity: 1;
+  color: var(--text-primary);
 }
 
 


### PR DESCRIPTION
Two polish fixes from the sidebar refactor:

- Hide the duplicate "New Chat" ActionRow on desktop (redundant at desktop width — already in the header)
- Bump `kbd` hint contrast so ⌘1–8 shortcuts are readable against the sidebar background