### PR TITLE
feat(browser): polish — keyboard hints, favicon-only collapsed rail, tab-count badge, quick-open backdrop

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "log",
  "once_cell",

--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -536,25 +536,24 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
         className={[
           "browser-tab-rail group/rail relative flex flex-col items-center bg-[var(--bg-panel)] py-1.5",
           "transition-[width] duration-150 ease-out",
-          "w-1.5 hover:w-12 focus-within:w-12",
+          "w-3.5 hover:w-12 focus-within:w-12",
           railExpanded ? "!w-12" : "",
         ].join(" ")}
-        style={{ minWidth: railExpanded ? 48 : 6 }}
+        style={{ minWidth: railExpanded ? 48 : 14 }}
         onMouseEnter={() => setRailHover(true)}
         onMouseLeave={() => setRailHover(false)}
         aria-label="Browser tabs"
       >
-        {/* Collapsed-state hint: a subtle vertical accent so the rail is
-            still discoverable when hidden. */}
-        <span
-          aria-hidden
-          className={[
-            "pointer-events-none absolute left-0 top-1/2 -translate-y-1/2 w-[2px] rounded-r-full bg-[var(--fg-base)]/20",
-            "transition-opacity duration-150",
-            railExpanded ? "opacity-0" : "opacity-100",
-          ].join(" ")}
-          style={{ height: 18 }}
-        />
+        {/* Collapsed-state hint: tab-count badge — communicates "tabs exist,
+            here's how many" without taking iframe space. */}
+        {!railExpanded ? (
+          <span
+            aria-hidden
+            className="pointer-events-none absolute left-0 top-1/2 -translate-y-1/2 grid h-5 min-w-5 place-items-center rounded-r-full bg-[var(--bg-elevated)] px-1 text-[10px] font-semibold text-[var(--text-muted)] transition-opacity duration-150"
+          >
+            {tabs.length}
+          </span>
+        ) : null}
         {/* Tabs only render their content when the rail is expanded so
             collapsed-state mouse targets stay tiny and the page is not
             visually crowded. The rail itself remains hoverable in both

--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -614,8 +614,10 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
                   : <TabFavicon url={tab.url} title={tabTitles[tab.id] ?? tab.title ?? title} size={20} />
                 }
               </span>
-              {/* Label */}
-              <span className="w-[44px] truncate text-center text-[9px] leading-tight">{title}</span>
+              {/* Label — only when rail is expanded; favicon-only when collapsed */}
+              {railExpanded ? (
+                <span className="w-[44px] truncate text-center text-[10px] leading-tight">{title}</span>
+              ) : null}
               {/* Close on hover */}
               {tab.kind === "pinned" && tabs.filter((t) => t.kind === "pinned").length > 1 && (
                 <button

--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -509,6 +509,21 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
     return () => window.removeEventListener("keydown", onKeyDown, true);
   }, []);
 
+  // `[` → toggle rail pin (scoped to pane focus, mirroring Cmd+K).
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "[") return;
+      if (!paneRef.current?.contains(e.target as Node)) return;
+      const target = e.target as HTMLElement;
+      const tag = target.tagName?.toLowerCase();
+      if (["input", "textarea", "select"].includes(tag) || target.isContentEditable) return;
+      e.preventDefault();
+      setRailPinned((v) => !v);
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, []);
+
   return (
     <div ref={paneRef} className="flex h-full flex-row" style={{ background: "var(--bg-base)" }}>
       {/* ── Vertical tab rail (auto-hide) ─────────────────────── */}
@@ -732,6 +747,11 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
           <div ref={surfaceRef} className="absolute inset-0" />
         )}
       </div>
+      <footer
+        className="shrink-0 border-t border-[var(--border-hairline)] px-3 py-1.5 text-center text-[10px] text-[var(--text-muted)]"
+      >
+        ⌘K tabs · ⌘[ back · ⌘] forward · ⌘R reload · [ pin rail
+      </footer>
       </div>{/* end main area */}
     </div>
   );

--- a/src/components/browser-polish.test.ts
+++ b/src/components/browser-polish.test.ts
@@ -53,4 +53,10 @@ assert.doesNotMatch(
   "Old 2px accent dot must be removed",
 );
 
+// ───────── Task 4: Quick-open backdrop ─────────
+const qo = await readFile(new URL("./browser-quick-open.tsx", import.meta.url), "utf8");
+assert.match(qo, /bg-black\/40 backdrop-blur-sm/, "Backdrop must use bg-black/40 + backdrop-blur-sm");
+assert.match(qo, /onClick=\{onClose\}/, "Outer container must handle onClick={onClose}");
+assert.match(qo, /onClick=\{\(e\) => e\.stopPropagation\(\)\}/, "Inner card must stopPropagation on click");
+
 console.log("browser-polish.test.ts: ok");

--- a/src/components/browser-polish.test.ts
+++ b/src/components/browser-polish.test.ts
@@ -26,4 +26,16 @@ assert.match(
   "[ handler must be scoped to focus inside the pane",
 );
 
+// ───────── Task 2: Tab label legibility ─────────
+assert.match(
+  pane,
+  /\{railExpanded \? \(\s*<span className="w-\[44px\] truncate text-center text-\[10px\] leading-tight">\{title\}<\/span>\s*\) : null\}/,
+  "Tab label gated on railExpanded + text-[10px]",
+);
+assert.doesNotMatch(
+  pane,
+  /<span className="w-\[44px\] truncate text-center text-\[9px\] leading-tight">/,
+  "Old text-[9px] label must be removed",
+);
+
 console.log("browser-polish.test.ts: ok");

--- a/src/components/browser-polish.test.ts
+++ b/src/components/browser-polish.test.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const pane = await readFile(new URL("./browser-pane.tsx", import.meta.url), "utf8");
+
+// ───────── Task 1: Keyboard hint footer + [ shortcut ─────────
+assert.match(
+  pane,
+  /⌘K tabs · ⌘\[ back · ⌘\] forward · ⌘R reload · \[ pin rail/,
+  "Footer hint string must list the keyboard shortcuts",
+);
+assert.match(
+  pane,
+  /if \(e\.key !== "\["\) return;/,
+  "[ keyboard handler must filter on e.key === '['",
+);
+assert.match(
+  pane,
+  /setRailPinned\(\(v\) => !v\)/,
+  "[ handler must call setRailPinned((v) => !v)",
+);
+assert.match(
+  pane,
+  /paneRef\.current\?\.contains\(e\.target as Node\)/,
+  "[ handler must be scoped to focus inside the pane",
+);
+
+console.log("browser-polish.test.ts: ok");

--- a/src/components/browser-polish.test.ts
+++ b/src/components/browser-polish.test.ts
@@ -38,4 +38,19 @@ assert.doesNotMatch(
   "Old text-[9px] label must be removed",
 );
 
+// ───────── Task 3: Wider rail + tab-count badge ─────────
+assert.match(pane, /w-3\.5 hover:w-12 focus-within:w-12/, "Collapsed rail width must be w-3.5");
+assert.doesNotMatch(pane, /w-1\.5 hover:w-12 focus-within:w-12/, "Old w-1.5 width must be removed");
+assert.match(pane, /minWidth: railExpanded \? 48 : 14/, "minWidth must be 14 when collapsed");
+assert.match(
+  pane,
+  /!railExpanded \? \(\s*<span[\s\S]*?>\s*\{tabs\.length\}\s*<\/span>\s*\) : null/,
+  "Tab-count badge renders {tabs.length} when rail collapsed",
+);
+assert.doesNotMatch(
+  pane,
+  /w-\[2px\] rounded-r-full bg-\[var\(--fg-base\)\]\/20/,
+  "Old 2px accent dot must be removed",
+);
+
 console.log("browser-polish.test.ts: ok");

--- a/src/components/browser-quick-open.tsx
+++ b/src/components/browser-quick-open.tsx
@@ -97,11 +97,14 @@ export function BrowserQuickOpen({ tabs, activeId, onSelect, onClose }: Props) {
   return (
     <div
       ref={backdropRef}
-      className="absolute inset-0 z-50 flex items-start justify-center pt-[72px]"
-      style={{ background: "transparent" }}
+      className="absolute inset-0 z-50 flex items-start justify-center pt-[72px] bg-black/40 backdrop-blur-sm"
       onMouseDown={handleBackdrop}
+      onClick={onClose}
     >
-      <div className="w-[420px] max-w-[92vw] overflow-hidden rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] shadow-2xl">
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="w-[420px] max-w-[92vw] overflow-hidden rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] shadow-2xl"
+      >
         {/* Search input */}
         <div className="flex items-center gap-2.5 border-b border-[var(--border-hairline)] px-4 py-3">
           <span className="text-sm text-[var(--text-muted)]">⌘</span>


### PR DESCRIPTION
## Summary
Four focused polish changes to the browser surface.

- **Keyboard hint footer** below the viewport: \`⌘K tabs · ⌘[ back · ⌘] forward · ⌘R reload · [ pin rail\`. New \`[\` handler toggles \`setRailPinned\`, scoped to focus inside the pane (matches the existing Cmd+K pattern, ignores inputs/textareas/contentEditable).
- **Favicon-only collapsed rail / larger label expanded**: the 9px truncated label under each tab favicon (\`OpenC…\`, \`X\`) is gated on \`railExpanded\` and bumped to 10px. Collapsed rail is favicon-only (Chrome-style).
- **Wider collapsed rail + tab-count badge**: bump rail from 6px to 14px; replace the 2px accent dot with a tab-count badge that renders \`{tabs.length}\`. Discoverability up without eating meaningful iframe space (8px diff).
- **Quick-open backdrop**: add \`bg-black/40 backdrop-blur-sm\` behind the popup so it pops against the underlying iframe; outer click closes, inner click stops propagation.

Touches \`src/components/browser-pane.tsx\` and \`src/components/browser-quick-open.tsx\`.

## Test plan
- [x] \`node --experimental-strip-types src/components/browser-polish.test.ts\` — all four sections asserted
- [x] All 5 \`browser-*.test.ts\` files exit 0
- [x] \`npm run typecheck\` — clean for both touched files
- [x] Visual: tab-count badge in collapsed rail, footer hint line, 10px labels in expanded rail, quick-open backdrop dims iframe