### PR TITLE
feat(terminal): polish empty state, keyboard footer, labeled tab-add

### DIFF
--- a/src/components/comux-view-terminal.test.ts
+++ b/src/components/comux-view-terminal.test.ts
@@ -1,0 +1,68 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./comux-view.tsx", import.meta.url),
+  "utf8",
+);
+
+// Keyboard hint footer (matches the inbox/calendar/library/home/browser pattern).
+assert.match(
+  source,
+  /⌘N new · ⌘W close · double-click tab name to rename/,
+  "renders the keyboard hint footer below the terminal area",
+);
+
+// `+` tab-add button is labeled for screen readers and has a tooltip.
+assert.match(
+  source,
+  /aria-label="New terminal"/,
+  "tab-strip add button has aria-label",
+);
+assert.match(
+  source,
+  /title="New terminal \(⌘N\)"/,
+  "tab-strip add button has tooltip with shortcut",
+);
+
+// Empty-state copy + ⌘N kbd hint.
+assert.match(
+  source,
+  /No terminal sessions/,
+  "empty state shows heading",
+);
+assert.match(
+  source,
+  /Start one to run commands inside the cave\./,
+  "empty state shows helper sentence",
+);
+assert.match(
+  source,
+  /<kbd[\s\S]{0,200}⌘N[\s\S]{0,20}<\/kbd>/,
+  "empty state shows the ⌘N kbd hint",
+);
+
+// ⌘N / ⌘W keydown handler is wired and respects modifier + contentEditable gate.
+assert.match(
+  source,
+  /metaKey\s*\|\|\s*e\.ctrlKey/,
+  "keydown handler checks meta or ctrl modifier",
+);
+assert.match(
+  source,
+  /target\??\.isContentEditable/,
+  "keydown handler skips contentEditable targets",
+);
+assert.match(
+  source,
+  /e\.key === "n"[\s\S]{0,80}addSession\(\)/,
+  "⌘N triggers addSession",
+);
+assert.match(
+  source,
+  /e\.key === "w"[\s\S]{0,120}removeSession\(currentIdx\)/,
+  "⌘W triggers removeSession of the current index",
+);
+
+console.log("comux-view-terminal.test.ts OK");

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -174,6 +174,26 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
     );
   }, []);
 
+  useEffect(() => {
+    if (view !== "terminal") return;
+    const onKey = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod) return;
+      const target = e.target as HTMLElement | null;
+      if (target?.isContentEditable) return;
+      if (e.key === "n" || e.key === "N") {
+        e.preventDefault();
+        addSession();
+      } else if (e.key === "w" || e.key === "W") {
+        if (sessions.length === 0) return;
+        e.preventDefault();
+        removeSession(currentIdx);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [view, addSession, removeSession, currentIdx, sessions.length]);
+
   const openFilePreview = useCallback(async (path: string) => {
     setPreviewPath(path);
     setPreviewLoading(true);
@@ -271,6 +291,8 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
             <button
               type="button"
               onClick={() => addSession()}
+              aria-label="New terminal"
+              title="New terminal (⌘N)"
               className="rounded px-1.5 py-0.5 text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)]"
             >
               +
@@ -280,15 +302,25 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
           {/* Terminal area */}
           <div className="flex-1 min-h-0 relative">
             {sessions.length === 0 ? (
-              <div className="flex h-full flex-col items-center justify-center gap-2 text-xs text-[var(--text-muted)]">
-                <p>No terminal sessions.</p>
-                <button
-                  type="button"
-                  onClick={() => addSession()}
-                  className="rounded border border-[var(--border-hairline)] px-3 py-1 text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
-                >
-                  + New terminal
-                </button>
+              <div className="flex h-full flex-col items-center justify-center gap-3">
+                <div className="flex flex-col items-center gap-1 text-center">
+                  <p className="text-sm text-[var(--text-secondary)]">No terminal sessions</p>
+                  <p className="text-xs text-[var(--text-muted)]">
+                    Start one to run commands inside the cave.
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => addSession()}
+                    className="rounded border border-[var(--border-hairline)] px-3 py-1 text-xs text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+                  >
+                    + New terminal
+                  </button>
+                  <kbd className="rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-1.5 py-0.5 text-[10px] text-[var(--text-muted)]">
+                    ⌘N
+                  </kbd>
+                </div>
               </div>
             ) : (
               sessions.map((s, i) => (
@@ -311,6 +343,9 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
               ))
             )}
           </div>
+          <footer className="shrink-0 border-t border-[var(--border-hairline)] px-3 py-1.5 text-center text-[10px] text-[var(--text-muted)]">
+            ⌘N new · ⌘W close · double-click tab name to rename
+          </footer>
         </div>
       ) : (
         /* Project tab */


### PR DESCRIPTION
## Summary

Polishes the sidebar Terminal mode (`ComuxView view=\"terminal\"`):

- **Empty state** — heading + helper sentence + `⌘N` kbd badge next to the `+ New terminal` button (was: lone "No terminal sessions." + button)
- **Tab-strip `+` button** — `aria-label=\"New terminal\"` and `title=\"New terminal (⌘N)\"` so it's no longer orphaned for keyboard/SR users
- **Keyboard hint footer** — `⌘N new · ⌘W close · double-click tab name to rename`, matches `browser-pane.tsx`
- **⌘N / ⌘W shortcuts** — scoped to `view === \"terminal\"`, skip when a contentEditable target is focused (so rename-mode ⌘W doesn't close the tab)
- **Test** — `comux-view-terminal.test.ts` asserts footer copy, aria-label, kbd badge, and keydown handler shape

## Test plan

- [x] `node --experimental-strip-types src/components/comux-view-terminal.test.ts` passes
- [x] Dev server: empty-state, footer, and labeled `+` button render as designed
- [ ] CI green