### PR TITLE
feat(roles): slim hero, drop duplicate count, keyboard footer + / focus

### DIFF
--- a/src/components/plugins-view-polish.test.ts
+++ b/src/components/plugins-view-polish.test.ts
@@ -1,0 +1,75 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./plugins-view.tsx", import.meta.url),
+  "utf8",
+);
+
+// Keyboard hint footer (matches the terminal/inbox/calendar/library/home/browser pattern).
+assert.match(
+  source,
+  /\/ focus search · click a role to manage · toggle the eye to activate/,
+  "renders the keyboard hint footer below the scrolling content",
+);
+
+// Hero headline slimmed from 22px to 18px.
+assert.match(
+  source,
+  /text-\[18px\] font-semibold text-\[var\(--text-primary\)\][\s\S]{0,160}HERO_HEADLINE\[tab\]/,
+  "hero headline uses text-[18px]",
+);
+assert.doesNotMatch(
+  source,
+  /text-\[22px\] font-semibold text-\[var\(--text-primary\)\][\s\S]{0,160}HERO_HEADLINE\[tab\]/,
+  "hero headline no longer uses text-[22px]",
+);
+
+// Section header no longer duplicates the count.
+assert.doesNotMatch(
+  source,
+  /\{roles\.length\} installed[\s\S]{0,50}<\/span>/,
+  "section header no longer renders the duplicate roles-count span",
+);
+assert.doesNotMatch(
+  source,
+  /\{skills\.length\} installed[\s\S]{0,50}<\/span>/,
+  "section header no longer renders the duplicate skills-count span",
+);
+assert.doesNotMatch(
+  source,
+  /\{marketplacePlugins\.length\} available[\s\S]{0,50}<\/span>/,
+  "section header no longer renders the duplicate plugins-count span",
+);
+
+// `/` keydown handler is wired and focuses the search input.
+assert.match(
+  source,
+  /searchRef\s*=\s*useRef<HTMLInputElement/,
+  "search input ref is declared",
+);
+assert.match(
+  source,
+  /e\.key !== "\/"/,
+  "keydown handler gates on the `/` key",
+);
+assert.match(
+  source,
+  /searchRef\.current\?\.focus\(\)/,
+  "keydown handler focuses the search input",
+);
+assert.match(
+  source,
+  /tag === "INPUT" \|\| tag === "TEXTAREA"/,
+  "keydown handler skips when an input/textarea is already focused",
+);
+
+// The search input picks up the ref.
+assert.match(
+  source,
+  /ref=\{searchRef\}[\s\S]{0,160}type="search"/,
+  "search input wires ref={searchRef}",
+);
+
+console.log("plugins-view-polish.test.ts OK");

--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -158,6 +158,22 @@ export function PluginsView({
   const [selectedSkill, setSelectedSkill] = useState<SkillEntryWithDetail | null>(null);
   const [selectedRole, setSelectedRole] = useState<RoleEntry | null>(null);
   const createRef = useRef<HTMLDivElement | null>(null);
+  const searchRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "/") return;
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      if (target.isContentEditable) return;
+      const tag = target.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA") return;
+      e.preventDefault();
+      searchRef.current?.focus();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
   // Reset query when switching tabs
   const handleTabChange = (t: Tab) => {
@@ -482,10 +498,10 @@ export function PluginsView({
         <div className="mx-auto w-full max-w-[1200px] px-4 pb-12 sm:px-8">
 
           {/* ── Overview section ─────────────────────────────────────────── */}
-          <div className="pb-6 pt-6">
-            <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div className="pb-4 pt-5">
+            <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
               <div className="min-w-0">
-                <h1 className="text-[22px] font-semibold text-[var(--text-primary)]">
+                <h1 className="text-[18px] font-semibold text-[var(--text-primary)]">
                   {HERO_HEADLINE[tab]}
                 </h1>
                 {tab === "plugins" && marketplaceLoaded && marketplacePlugins.length === 0 ? (
@@ -520,6 +536,7 @@ export function PluginsView({
                 height="0.9rem"
               />
               <input
+                ref={searchRef}
                 type="search"
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
@@ -533,21 +550,6 @@ export function PluginsView({
           <section>
             <h2 className="mb-3 text-[11px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">
               {SECTION_LABEL[tab]}
-              {tab === "plugins" && marketplaceLoaded && !marketplaceError && (
-                <span className="ml-2 font-normal normal-case tracking-normal text-[var(--text-muted)]">
-                  {marketplacePlugins.length} available
-                </span>
-              )}
-              {tab === "skills" && skillsLoaded && !skillsError && (
-                <span className="ml-2 font-normal normal-case tracking-normal text-[var(--text-muted)]">
-                  {skills.length} installed
-                </span>
-              )}
-              {tab === "roles" && rolesLoaded && !rolesError && (
-                <span className="ml-2 font-normal normal-case tracking-normal text-[var(--text-muted)]">
-                  {roles.length} installed
-                </span>
-              )}
             </h2>
 
             {tab === "plugins" ? (
@@ -585,6 +587,10 @@ export function PluginsView({
           </section>
         </div>
       </div>
+
+      <footer className="shrink-0 border-t border-border px-3 py-1.5 text-center text-[10px] text-muted-foreground">
+        / focus search · click a role to manage · toggle the eye to activate
+      </footer>
 
       <SkillDetailDrawer
         skill={selectedSkill}


### PR DESCRIPTION
## Summary

Polishes the Roles tab (rendered by `PluginsView`):

- **Slim hero** — headline `text-[22px]` → `text-[18px]`, section padding `pt-6/pb-6` → `pt-5/pb-4`
- **Drop duplicate count** — the section header `INSTALLED ROLES · 14 installed` repeated the hero subtitle; removed the three count spans (plugins/skills/roles) so the hero is the single source of truth
- **Keyboard hint footer** — `/ focus search · click a role to manage · toggle the eye to activate`, matching the browser/terminal pattern
- **`/` focuses search** — GitHub/Linear convention; gated against inputs, textareas, and contentEditable targets so it does not steal keystrokes from the search box itself

## Test plan

- [x] `node --experimental-strip-types src/components/plugins-view-polish.test.ts` passes
- [x] Existing `plugins-roles-detail.test.ts` and `roles-tools-navigation.test.ts` still pass
- [x] Dev verify on 3062: hero slimmed, INSTALLED ROLES section header no longer carries the count, footer visible at the bottom of the scroll region
- [ ] CI green