### PR TITLE
feat(github): dedup header, always-on footer with kbd hint, ⌘R refresh

### DIFF
--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -1,0 +1,63 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./github-view.tsx", import.meta.url),
+  "utf8",
+);
+
+// Inner GitHub <h2> and logo removed — the workspace breadcrumb already names the surface.
+assert.doesNotMatch(
+  source,
+  /<h2 className="text-\[15px\] font-semibold">GitHub<\/h2>/,
+  "inner GitHub h2 removed",
+);
+assert.doesNotMatch(
+  source,
+  /<Icon name="ph:github-logo" width=\{16\}/,
+  "inner GitHub logo (header) removed (kept only inside the empty-state CTA)",
+);
+
+// Refresh button tooltip names the new shortcut.
+assert.match(
+  source,
+  /title="Refresh \(⌘R\)"/,
+  "refresh button tooltip includes ⌘R",
+);
+
+// Footer is no longer gated on `activity` — it always renders.
+assert.doesNotMatch(
+  source,
+  /\{activity && \(\s*<footer/,
+  "footer is no longer conditionally rendered on `activity`",
+);
+assert.match(
+  source,
+  /⌘R refresh · click a row to open in GitHub/,
+  "footer carries the keyboard hint",
+);
+
+// ⌘R keydown handler wired.
+assert.match(
+  source,
+  /e\.metaKey \|\| e\.ctrlKey/,
+  "keydown handler checks meta or ctrl modifier",
+);
+assert.match(
+  source,
+  /e\.key !== "r" && e\.key !== "R"/,
+  "keydown handler gates on the R key",
+);
+assert.match(
+  source,
+  /void fetchActivity\(\)/,
+  "keydown handler triggers fetchActivity",
+);
+assert.match(
+  source,
+  /tag === "INPUT" \|\| tag === "TEXTAREA"/,
+  "keydown handler skips when an input/textarea is focused",
+);
+
+console.log("github-view-polish.test.ts OK");

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -419,6 +419,23 @@ export function GitHubView() {
     return () => { if (timerRef.current !== null) window.clearTimeout(timerRef.current); };
   }, []);
 
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod) return;
+      if (e.key !== "r" && e.key !== "R") return;
+      const target = e.target as HTMLElement | null;
+      if (target?.isContentEditable) return;
+      const tag = target?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA") return;
+      e.preventDefault();
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+      void fetchActivity();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
   const items = activity?.items ?? [];
   const filtered = filter === "all" ? items : items.filter((i) => i.kind === filter);
 
@@ -446,12 +463,10 @@ export function GitHubView() {
       )}
 
       {/* ── Header ── */}
-      <header className="flex items-center gap-3 border-b border-[var(--border-hairline)] px-5 py-3">
+      <header className="flex items-center gap-3 border-b border-[var(--border-hairline)] px-5 py-2">
         <div className="flex items-center gap-2">
-          <Icon name="ph:github-logo" width={16} className="text-[var(--text-secondary)]" />
-          <h2 className="text-[15px] font-semibold">GitHub</h2>
           {activity?.login && (
-            <span className="text-[12px] text-[var(--text-muted)]">@{activity.login}</span>
+            <span className="text-[12px] text-[var(--text-secondary)]">@{activity.login}</span>
           )}
         </div>
 
@@ -488,7 +503,7 @@ export function GitHubView() {
               if (timerRef.current !== null) window.clearTimeout(timerRef.current);
               void fetchActivity();
             }}
-            title="Refresh"
+            title="Refresh (⌘R)"
             className="rounded-md p-1 text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] transition-colors"
           >
             <Icon name="ph:arrows-clockwise" width={13} />
@@ -590,21 +605,24 @@ export function GitHubView() {
       </div>
 
       {/* ── Footer ── */}
-      {activity && (
-        <footer className="border-t border-[var(--border-hairline)] px-5 py-2 text-[10px] text-[var(--text-muted)] flex items-center justify-between">
-          <span>
-            {activity.authed
-              ? "Authenticated — private repos included"
-              : "Public API — add a PAT for private repos + review requests"}
-          </span>
-          {activity.rateLimit && activity.rateLimit.remaining < 10 && (
+      <footer className="shrink-0 border-t border-[var(--border-hairline)] px-5 py-1.5 text-[10px] text-[var(--text-muted)] flex items-center justify-between gap-3">
+        <span>⌘R refresh · click a row to open in GitHub</span>
+        <span className="inline-flex items-center gap-3">
+          {activity?.rateLimit && activity.rateLimit.remaining < 10 && (
             <span className="inline-flex items-center gap-1 text-[var(--color-warning)]">
               <Icon name="ph:warning-fill" width={12} aria-hidden />
               {activity.rateLimit.remaining} requests remaining
             </span>
           )}
-        </footer>
-      )}
+          {activity && (
+            <span>
+              {activity.authed
+                ? "Authenticated — private repos included"
+                : "Public API — add a PAT for private repos + review requests"}
+            </span>
+          )}
+        </span>
+      </footer>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Polishes the GitHub surface (`GitHubView`):

- **Header dedup** — drop the inner `[github-logo] GitHub` h2; workspace breadcrumb already names the surface. Header keeps the identity context that breadcrumb doesn't carry: `@login`, the authenticated/public-API pill, and rate-limit remaining
- **Tighter header padding** — `py-3` → `py-2`
- **Always-on footer** — was conditionally rendered behind `{activity && ...}`, so loading/error/empty states had no footer. Now it always shows the kbd hint, with auth status sliding into the right side once data lands
- **Keyboard hint** — `⌘R refresh · click a row to open in GitHub`, matching the capabilities footer pattern
- **⌘R / Ctrl+R triggers refresh** — gated against inputs/textareas/contentEditable; refresh button tooltip names the shortcut

## Test plan

- [x] `github-view-polish.test.ts` passes
- [x] Dev verify on 3066 (with authenticated PAT): header tighter, no double h2/breadcrumb, footer visible above the items list, ⌘R triggers a re-fetch
- [ ] CI green