### PR TITLE
fix(sidebar): default agent scope to familiars

### DIFF
--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -56,8 +56,8 @@ assert.doesNotMatch(
 
 assert.match(
   chatSurface,
-  /const scopedFamiliars = useMemo\(\(\) => activeFamiliar \? \[activeFamiliar\] : \[\], \[activeFamiliar\]\)/,
-  "ChatSurface should derive a one-familiar list from the active familiar",
+  /const scopedFamiliars = useMemo\(\(\) => activeFamiliar \? \[activeFamiliar\] : familiars, \[activeFamiliar, familiars\]\)/,
+  "ChatSurface should derive all familiars when the generic Familiars scope is selected",
 );
 
 assert.match(

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -15,6 +15,7 @@ import type { PendingChatAction } from "@/lib/pending-chat-action";
 type AgentsScope = "conversation" | "memory";
 
 type Props = {
+  familiars: Familiar[];
   sessions: SessionRow[];
   activeFamiliar: Familiar | null;
   activeFamiliarId: string | null;
@@ -127,6 +128,7 @@ function RightPanel({
 // ── Main view ─────────────────────────────────────────────────────────────────
 
 export function ChatSurface({
+  familiars,
   sessions,
   activeFamiliar,
   activeFamiliarId,
@@ -164,7 +166,7 @@ export function ChatSurface({
     onSetInspectorOpen(next === "inspector");
   }
 
-  const scopedFamiliars = useMemo(() => activeFamiliar ? [activeFamiliar] : [], [activeFamiliar]);
+  const scopedFamiliars = useMemo(() => activeFamiliar ? [activeFamiliar] : familiars, [activeFamiliar, familiars]);
 
   // Window events
   useEffect(() => {

--- a/src/components/sidebar-familiar-filter.test.ts
+++ b/src/components/sidebar-familiar-filter.test.ts
@@ -32,20 +32,20 @@ assert.match(
 
 assert.match(
   sidebar,
-  /aria-label="Active familiar"/,
-  "Familiar selector should label the dropdown after the active familiar",
+  /<span className="sidebar-familiar-filter__label">Agent<\/span>[\s\S]*aria-label="Filter workspace by agent"[\s\S]*<option value="">Familiars<\/option>/,
+  "Familiar selector should expose Familiars as the generic no-filter agent option",
 );
 
 assert.doesNotMatch(
   sidebar,
   /Coven \(all\)/,
-  "Selector should not offer an all-scope option — downstream surfaces hard-scope to a single familiar",
+  "Selector should use Familiars, not Coven (all), for the generic no-filter option",
 );
 
 assert.match(
   sidebar,
-  /if \(next\) onFamiliarScopeChange\(next\)/,
-  "Selector should only fire the callback for a real familiar id, never an empty value",
+  /onFamiliarScopeChange\(e\.currentTarget\.value \|\| null\)/,
+  "Selector should send null when Familiars is selected",
 );
 
 assert.match(
@@ -56,8 +56,14 @@ assert.match(
 
 assert.match(
   sidebar,
-  /onFamiliarScopeChange: \(id: string\) => void/,
-  "Sidebar should expose a non-null callback for changing the active familiar",
+  /onFamiliarScopeChange: \(id: string \| null\) => void/,
+  "Sidebar should expose a nullable callback for changing the active familiar scope",
+);
+
+assert.doesNotMatch(
+  workspace,
+  /setActiveId\(\(curr\) => curr \?\? (?:fallback|merged)\[0\]\?\.id \?\? null\)/,
+  "Workspace should not auto-select the first familiar; null means the generic Familiars scope",
 );
 
 assert.doesNotMatch(
@@ -86,14 +92,20 @@ assert.match(
 
 assert.match(
   workspace,
-  /onFamiliarScopeChange=\{selectFamiliar\}/,
-  "Workspace should wire the sidebar familiar selector into the existing single-familiar select handler",
+  /onFamiliarScopeChange=\{selectFamiliarScope\}/,
+  "Workspace should wire the sidebar familiar selector into nullable familiar scope state",
 );
 
 assert.match(
   chatSurface,
-  /const scopedFamiliars = useMemo\(\(\) => activeFamiliar \? \[activeFamiliar\] : \[\], \[activeFamiliar\]\)/,
-  "ChatSurface stays hard-scoped to the active familiar — no all-familiar fallback",
+  /familiars,[\s\S]*activeFamiliar,[\s\S]*activeFamiliarId,/,
+  "ChatSurface should destructure familiars so the generic scope can show all familiars",
+);
+
+assert.match(
+  chatSurface,
+  /const scopedFamiliars = useMemo\(\(\) => activeFamiliar \? \[activeFamiliar\] : familiars, \[activeFamiliar, familiars\]\)/,
+  "ChatSurface should show all familiar memory/list context when Familiars is selected",
 );
 
 assert.match(

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -49,8 +49,8 @@ assert.match(
 
 assert.match(
   source,
-  /onFamiliarScopeChange: \(id: string\) => void/,
-  "Sidebar exposes a non-null familiar scope change callback (hard-scope)",
+  /onFamiliarScopeChange: \(id: string \| null\) => void/,
+  "Sidebar exposes a nullable familiar scope change callback for the generic Familiars option",
 );
 
 assert.match(

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -52,7 +52,7 @@ export type SidebarMinimalProps = {
   inboxPrefs?: InboxPrefs;
   familiars: ResolvedFamiliar[];
   activeFamiliarId?: string | null;
-  onFamiliarScopeChange: (id: string) => void;
+  onFamiliarScopeChange: (id: string | null) => void;
   notificationBadgeCount?: number;
   onOpenInbox?: () => void;
   onOpenInboxItem?: (item: InboxItem) => void;
@@ -110,26 +110,20 @@ function FamiliarScopeSelect({
 }: {
   familiars: ResolvedFamiliar[];
   activeFamiliarId?: string | null;
-  onFamiliarScopeChange: (id: string) => void;
+  onFamiliarScopeChange: (id: string | null) => void;
 }) {
-  // Hard-scope: every downstream surface (Chat, Board, etc.) expects a single
-  // familiar selected, so the selector lists only familiars. The first
-  // familiar is bootstrapped at the workspace level; we don't expose an
-  // all-scope option because the aggregate views aren't built.
   return (
     <label className="sidebar-familiar-filter">
-      <span className="sidebar-familiar-filter__label">Scope</span>
+      <span className="sidebar-familiar-filter__label">Agent</span>
       <span className="sidebar-familiar-filter__control">
         <Icon name="ph:sparkle" width={14} className="sidebar-familiar-filter__icon" aria-hidden />
         <select
-          aria-label="Active familiar"
+          aria-label="Filter workspace by agent"
           value={activeFamiliarId ?? ""}
-          onChange={(e) => {
-            const next = e.currentTarget.value;
-            if (next) onFamiliarScopeChange(next);
-          }}
+          onChange={(e) => onFamiliarScopeChange(e.currentTarget.value || null)}
           className="sidebar-familiar-filter__select"
         >
+          <option value="">Familiars</option>
           {familiars.map((familiar) => (
             <option key={familiar.id} value={familiar.id}>
               {familiar.display_name}

--- a/src/components/workspace-agents-landing.test.ts
+++ b/src/components/workspace-agents-landing.test.ts
@@ -96,8 +96,8 @@ assert.match(
 
 assert.match(
   workspace,
-  /onFamiliarScopeChange=\{selectFamiliar\}/,
-  "Workspace wires the sidebar familiar scope selector into the single-familiar select handler",
+  /onFamiliarScopeChange=\{selectFamiliarScope\}/,
+  "Workspace wires the sidebar familiar scope selector into nullable familiar scope state",
 );
 
 assert.doesNotMatch(

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -214,7 +214,6 @@ export function Workspace() {
         const fallback = DEMO_MODE ? DEMO_FAMILIARS : [];
         setFamiliars(fallback);
         setFamiliarsError(DEMO_MODE ? null : (json.error ?? "daemon offline"));
-        if (DEMO_MODE) setActiveId((curr) => curr ?? fallback[0]?.id ?? null);
         return;
       }
       setFamiliarsError(null);
@@ -224,20 +223,23 @@ export function Workspace() {
         ? [...list, ...DEMO_FAMILIARS.filter((d) => !list.find((l) => l.id === d.id))]
         : list;
       setFamiliars(merged);
-      setActiveId((curr) => curr ?? merged[0]?.id ?? null);
     } catch (err) {
       const fallback = DEMO_MODE ? DEMO_FAMILIARS : [];
       setFamiliars(fallback);
       setFamiliarsError(DEMO_MODE ? null : (err instanceof Error ? err.message : "fetch failed"));
-      if (DEMO_MODE) setActiveId((curr) => curr ?? fallback[0]?.id ?? null);
     }
   }, []);
 
-  const selectFamiliar = useCallback((id: string) => {
+  const selectFamiliarScope = useCallback((id: string | null) => {
     setActiveId(id);
+    if (!id) return;
     const last = getLastSurface(id);
     if (last) setMode(last as WorkspaceMode);
   }, []);
+
+  const selectFamiliar = useCallback((id: string) => {
+    selectFamiliarScope(id);
+  }, [selectFamiliarScope]);
 
   const loadSessions = useCallback(async () => {
     try {
@@ -882,7 +884,7 @@ export function Workspace() {
       inboxPrefs={inboxPrefs}
       familiars={resolvedFamiliars}
       activeFamiliarId={activeId}
-      onFamiliarScopeChange={selectFamiliar}
+      onFamiliarScopeChange={selectFamiliarScope}
       notificationBadgeCount={inboxBadgeCount}
       onOpenInbox={() => setMode("inbox")}
       onOpenInboxItem={(item) => {
@@ -916,6 +918,7 @@ export function Workspace() {
       />
     ) : mode === "chat" ? (
       <ChatSurface
+        familiars={familiars}
         sessions={sessions}
         activeFamiliar={active}
         activeFamiliarId={activeId}


### PR DESCRIPTION
## Summary
- changes the sidebar agent selector default from a specific familiar to `Familiars`
- treats `Familiars` as the nullable/no-filter scope instead of auto-selecting the first loaded familiar
- restores all-familiar context for ChatSurface memory/list support when no specific familiar is selected
- updates source guards so the generic agent default cannot regress back to hard-scoped first-familiar behavior

## Verification
- RED: `node --experimental-strip-types src/components/sidebar-familiar-filter.test.ts` failed on the merged hard-scoped implementation
- `node --experimental-strip-types src/components/sidebar-familiar-filter.test.ts && node --experimental-strip-types src/components/sidebar-minimal.test.ts && node --experimental-strip-types src/components/chat-surface.test.ts`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm typecheck`
- `pnpm build`
- Playwright smoke on `http://127.0.0.1:3108`: selected text `Familiars`, empty value, no search row, no mini rails
