### PR TITLE
feat(settings): keyboard footer with Esc-back + ↑↓ section nav, dim Soon rows

### DIFF
--- a/src/components/settings-shell-polish.test.ts
+++ b/src/components/settings-shell-polish.test.ts
@@ -1,0 +1,60 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./settings-shell.tsx", import.meta.url),
+  "utf8",
+);
+
+// Keyboard hint footer at the bottom of the shell.
+assert.match(
+  source,
+  /Esc back · ↑↓ navigate sections/,
+  "renders the keyboard hint footer below the content area",
+);
+
+// Esc keydown handler routes back.
+assert.match(
+  source,
+  /e\.key === "Escape"/,
+  "keydown handler gates on the Escape key",
+);
+assert.match(
+  source,
+  /router\.back\(\)/,
+  "Escape triggers router.back()",
+);
+
+// ↑↓ cycle through sections.
+assert.match(
+  source,
+  /e\.key === "ArrowDown" \|\| e\.key === "ArrowUp"/,
+  "keydown handler gates on the arrow keys for section nav",
+);
+assert.match(
+  source,
+  /SECTIONS\.findIndex\(\(s\) => s\.id === section\)/,
+  "section index is looked up from SECTIONS",
+);
+
+// Keydown handler skips inputs/textareas/selects/contentEditable.
+assert.match(
+  source,
+  /tag === "INPUT" \|\| tag === "TEXTAREA" \|\| tag === "SELECT"/,
+  "keydown handler skips form-control targets",
+);
+assert.match(
+  source,
+  /target\??\.isContentEditable/,
+  "keydown handler skips contentEditable targets",
+);
+
+// comingSoon rows are dimmed.
+assert.match(
+  source,
+  /\$\{comingSoon \? "opacity-50" : ""\}/,
+  "comingSoon rows get opacity-50",
+);
+
+console.log("settings-shell-polish.test.ts OK");

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -49,6 +49,29 @@ export function SettingsShell() {
 
   const [section, setSection] = useState<Section>(initialSection);
 
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target?.isContentEditable) return;
+      const tag = target?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      if (e.key === "Escape") {
+        e.preventDefault();
+        router.back();
+        return;
+      }
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        e.preventDefault();
+        const idx = SECTIONS.findIndex((s) => s.id === section);
+        const delta = e.key === "ArrowDown" ? 1 : -1;
+        const next = (idx + delta + SECTIONS.length) % SECTIONS.length;
+        setSection(SECTIONS[next].id);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [router, section]);
+
   return (
     <FamiliarStudioProvider>
     <div className="flex h-screen w-full flex-col overflow-hidden bg-[var(--bg-base)] text-[var(--text-primary)]">
@@ -105,6 +128,9 @@ export function SettingsShell() {
           {section === "about"    && <AboutSection />}
         </main>
       </div>
+      <footer className="shrink-0 border-t border-[var(--border-hairline)] px-4 py-1.5 text-center text-[10px] text-[var(--text-muted)]">
+        Esc back · ↑↓ navigate sections
+      </footer>
     </div>
     </FamiliarStudioProvider>
   );
@@ -822,7 +848,7 @@ function SettingsGroup({ label, children }: { label: string; children: React.Rea
 
 function SettingsRow({ label, description, comingSoon, children }: { label: string; description?: string; comingSoon?: boolean; children?: React.ReactNode }) {
   return (
-    <div className="flex items-center justify-between gap-4 px-4 py-3">
+    <div className={`flex items-center justify-between gap-4 px-4 py-3 ${comingSoon ? "opacity-50" : ""}`}>
       <div className="min-w-0">
         <p className="text-[13px] text-[var(--text-primary)]">{label}</p>
         {description && <p className="text-[11px] text-[var(--text-muted)]">{description}</p>}


### PR DESCRIPTION
## Summary

Polishes the Settings shell:

- **Keyboard hint footer** — `Esc back · ↑↓ navigate sections`, matching the pattern shipped across terminal/inbox/library/browser/capabilities/github. The empty bottom half of the surface now has an anchor
- **Esc closes Settings** — calls `router.back()`; passes through when an INPUT / TEXTAREA / SELECT / contentEditable target is focused so form controls keep their native Esc behavior
- **↑↓ cycle sections** — same gate; the side nav becomes keyboard-navigable
- **`comingSoon` rows dimmed** — `opacity-50` so "Launch at login" and "Open to" read as disabled at a glance instead of looking like fully built rows with a small Soon pill

## Test plan

- [x] `settings-shell-polish.test.ts` passes
- [x] `settings-appearance.test.ts`, `daemon-start-button.test.ts`, `roles-tools-navigation.test.ts` still pass
- [x] Dev verify on 3068: footer visible, Soon rows dimmed, Esc closes the page, ↑↓ cycles through General → Daemon → … → About → General
- [ ] CI green