### PR TITLE
fix(home): center composer across shell layouts

### DIFF
--- a/src/components/home-composer-centering.test.ts
+++ b/src/components/home-composer-centering.test.ts
@@ -27,13 +27,18 @@ assert.match(
 );
 assert.match(
   shell,
-  /"--shell-nav-px" as const\]: `\$\{Math\.round\(navWidthPx\)\}px`/,
+  /"--shell-nav-px": `\$\{Math\.round\(navWidthPx\)\}px`/,
   "Shell exposes --shell-nav-px on .shell-frame",
 );
 assert.match(
   shell,
-  /"--shell-agent-px" as const\]: `\$\{Math\.round\(agentWidthPx\)\}px`/,
+  /"--shell-agent-px": `\$\{Math\.round\(agentWidthPx\)\}px`/,
   "Shell exposes --shell-agent-px on .shell-frame",
+);
+assert.match(
+  shell,
+  /style=\{shellFrameStyle\}/,
+  ".shell-frame receives the custom-property style object",
 );
 
 // ───── Home composer reads the variables and centers on viewport ─────

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useImperativeHandle, useRef, useState, type ReactNode } from "react";
+import { useEffect, useImperativeHandle, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import type { ForwardedRef } from "react";
 import { forwardRef } from "react";
 import {
@@ -311,15 +311,20 @@ function ShellInner({
     </Group>
   );
 
+  const shellFrameStyle: CSSProperties & {
+    "--shell-nav-px": string;
+    "--shell-agent-px": string;
+  } = {
+    // Surfaces that need to visually center on the viewport (e.g. Home)
+    // use these to compensate for the asymmetric side-panel widths.
+    "--shell-nav-px": `${Math.round(navWidthPx)}px`,
+    "--shell-agent-px": `${Math.round(agentWidthPx)}px`,
+  };
+
   return (
     <div
       className="shell-frame flex h-full w-full flex-col"
-      style={{
-        // Surfaces that need to visually center on the viewport (e.g. Home)
-        // use these to compensate for the asymmetric side-panel widths.
-        ["--shell-nav-px" as const]: `${Math.round(navWidthPx)}px`,
-        ["--shell-agent-px" as const]: `${Math.round(agentWidthPx)}px`,
-      }}
+      style={shellFrameStyle}
     >
       {topBar}
       <div className="shell-body flex flex-1 min-h-0">


### PR DESCRIPTION
## Summary
- Center the Home composer visually against the viewport even when shell side panels are asymmetric.
- Expose shell panel pixel widths as typed CSS custom properties.
- Add source-level coverage for the centering CSS contract.

## Test Plan
- node --experimental-strip-types src/components/home-composer-centering.test.ts
- npm run test:app
- npm run typecheck
- npm run build