### PR TITLE
fix(home): keep composer centered without clipping on short viewports

### DIFF
--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -7,8 +7,14 @@
 .home-composer-root {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
+  /* `safe` keeps the cross-axis / main-axis centering from clipping
+     the top of the content when the viewport is shorter than the
+     composer + hero + suggestions stack (common on phones and on
+     narrow desktop windows). When everything fits, content is
+     centered as before; when it overflows, alignment falls back to
+     `flex-start` so the user can scroll to see the top. */
+  align-items: safe center;
+  justify-content: safe center;
   width: 100%;
   height: 100%;
   min-height: 0;
@@ -16,6 +22,13 @@
   gap: 16px;
   overflow-y: auto;
   box-sizing: border-box;
+}
+
+@media (max-width: 520px) {
+  .home-composer-root {
+    padding: 20px 16px 28px;
+    gap: 12px;
+  }
 }
 
 /* ── Hero ────────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- `.home-composer-root` now uses `align-items: safe center` + `justify-content: safe center` so flex centering doesn't clip the top of the hero/composer/suggestions stack when the viewport is shorter than the content. When content fits, layout looks identical; when it overflows, alignment degrades to `flex-start` and the user can scroll to the top.
- Adds a `@media (max-width: 520px)` rule that tightens the root padding (40/32/56 → 20/16/28) and the flex gap (16 → 12) so the composer claims more of the visible area on phone-width devices.

## Test plan

- [ ] Open home on a normal desktop window — layout unchanged, hero + composer card + suggestions stay centered
- [ ] Resize the window vertically until it's shorter than the content — top of hero stays reachable via scroll (no clipping)
- [ ] Toggle the Salem right rail open — content re-centers within the shrunken detail panel
- [ ] DevTools → iPhone SE / 360×640 — padding shrinks, composer fills more of the viewport, still centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)