### PR TITLE
fix(home): widen composer max width

### DIFF
--- a/src/components/home-composer-centering.test.ts
+++ b/src/components/home-composer-centering.test.ts
@@ -78,17 +78,17 @@ assert.match(
   "transform: translateX(clamp(-max, ideal, max))",
 );
 
-// Composer card wrap + suggestions use the widened 880px max-width minus
+// Composer card wrap + suggestions use the widened 1200px max-width minus
 // --hc-asymmetry so they don't overflow when the layout is asymmetric.
 assert.match(
   css,
-  /\.home-composer-card-wrap\s*\{[\s\S]*?max-width:\s*min\(880px,\s*calc\(100% - var\(--hc-asymmetry, 0px\)\)\)/,
-  ".home-composer-card-wrap uses 880px asymmetry-aware max-width",
+  /\.home-composer-card-wrap\s*\{[\s\S]*?max-width:\s*min\(1200px,\s*calc\(100% - var\(--hc-asymmetry, 0px\)\)\)/,
+  ".home-composer-card-wrap uses 1200px asymmetry-aware max-width",
 );
 assert.match(
   css,
-  /\.home-composer-suggestions\s*\{[\s\S]*?max-width:\s*min\(880px,\s*calc\(100% - var\(--hc-asymmetry, 0px\)\)\)/,
-  ".home-composer-suggestions uses 880px asymmetry-aware max-width",
+  /\.home-composer-suggestions\s*\{[\s\S]*?max-width:\s*min\(1200px,\s*calc\(100% - var\(--hc-asymmetry, 0px\)\)\)/,
+  ".home-composer-suggestions uses 1200px asymmetry-aware max-width",
 );
 
 // The card itself inherits the constraint from its wrap — must NOT subtract

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -41,7 +41,7 @@
   );
   --hc-max-shift: max(
     0px,
-    calc((100% - 880px) / 2),
+    calc((100% - 1200px) / 2),
     calc(var(--hc-asymmetry) / 2)
   );
   --hc-ideal-shift: calc(
@@ -92,7 +92,7 @@
 .home-composer-card-wrap {
   position: relative;
   width: 100%;
-  max-width: min(880px, calc(100% - var(--hc-asymmetry, 0px)));
+  max-width: min(1200px, calc(100% - var(--hc-asymmetry, 0px)));
 }
 
 /* ── Composer card ───────────────────────────────────────────────────────── */
@@ -304,7 +304,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  max-width: min(880px, calc(100% - var(--hc-asymmetry, 0px)));
+  max-width: min(1200px, calc(100% - var(--hc-asymmetry, 0px)));
   width: 100%;
   justify-content: center;
 }


### PR DESCRIPTION
## Summary
- Widen the home composer card and suggestions max width from 880px to 1200px.
- Keep the asymmetry-aware shell centering math and update its source-level test.

## Test Plan
- node --experimental-strip-types src/components/home-composer-centering.test.ts