### PR TITLE
feat(shell,home): even translucent side panels, mobile/tablet bottom tabs, wider composer

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -370,7 +370,9 @@ select {
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: var(--bg-base);
+  background: color-mix(in oklch, var(--bg-raised) 88%, transparent);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
   overflow: hidden;
 }
 
@@ -544,7 +546,9 @@ select {
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
-  background: var(--bg-base);
+  background: color-mix(in oklch, var(--bg-raised) 88%, transparent);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
   overflow-y: auto;
 }
 
@@ -3737,15 +3741,17 @@ select {
 }
 
 /* ─── Mobile shell collapse ────────────────────────────────────────────
-   Below 768px (phone-class viewports), the avatar rail flips to a top
-   horizontal strip and the detail pane takes the full width. The nav,
-   list, and agent panels stay mounted (preserves their content state
-   and avoids `panel.collapse()` fighting react-resizable-panels'
-   persisted layout) but slide off-screen, becoming drawers driven by
-   the `[data-mobile-drawer]` attribute on `.shell-root`. The
+   Below 1024px (phone- and tablet-class viewports), the avatar rail
+   flips to a top horizontal strip and the detail pane takes the full
+   width. The nav, list, and agent panels stay mounted (preserves their
+   content state and avoids `panel.collapse()` fighting react-resizable-
+   panels' persisted layout) but slide off-screen, becoming drawers
+   driven by the `[data-mobile-drawer]` attribute on `.shell-root`. The
    ⌘B / ⌘\\ / ⌘J keyboard shortcuts and the top-bar hamburger buttons
-   both flip that attribute. */
-@media (max-width: 767px) {
+   both flip that attribute. At this breakpoint the shell also surfaces
+   a bottom tab bar (`<MobileBottomTabs>`) for the top-five destinations,
+   which is why `.shell-detail` reserves bottom padding here. */
+@media (max-width: 1023px) {
   .shell-body {
     flex-direction: column;
   }
@@ -3827,6 +3833,12 @@ select {
     width: 100% !important;
     min-width: 0 !important;
   }
+  /* Reserve room at the bottom of the detail surface for the bottom tab
+     bar so the last line of scrollable content isn't obscured. The bar
+     itself adds its own safe-area inset on top of this 56px. */
+  .shell-detail {
+    padding-bottom: calc(56px + env(safe-area-inset-bottom, 0px));
+  }
 }
 
 /* Mobile top-bar — reveal drawer toggles, compress the search box so the
@@ -3834,7 +3846,7 @@ select {
    the surface name reads fine without it at narrow widths, and respect
    the notch on the top edge. The desktop Home button stays but
    gets a tighter padding. */
-@media (max-width: 767px) {
+@media (max-width: 1023px) {
   .top-bar {
     padding: 0 calc(8px + var(--sai-right)) 0 calc(8px + var(--sai-left));
     padding-top: var(--sai-top);
@@ -3882,7 +3894,7 @@ select {
 
 /* Reduced-motion users get the drawer position change without the
    slide animation. */
-@media (max-width: 767px) and (prefers-reduced-motion: reduce) {
+@media (max-width: 1023px) and (prefers-reduced-motion: reduce) {
   .shell-nav-panel,
   .shell-list-panel,
   .shell-agent-panel {
@@ -3905,6 +3917,90 @@ select {
 }
 @media (prefers-reduced-motion: reduce) {
   .mobile-drawer-backdrop { animation: none; }
+}
+
+/* ─── Mobile bottom tabs ───────────────────────────────────────────────
+   Sticky bottom navigation strip rendered by the Shell on mobile/tablet
+   viewports (≤1023px). Five fixed destinations (Home / Chat / Board /
+   Inbox / Library); active tab adopts var(--accent-presence). Sits above
+   the detail panel and below any modal/drawer scrim. */
+.mobile-bottom-tabs {
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 150;
+  display: flex;
+  align-items: stretch;
+  justify-content: space-around;
+  gap: 0;
+  min-height: 56px;
+  padding: 0 calc(4px + var(--sai-left, 0px)) 0 calc(4px + var(--sai-right, 0px));
+  padding-bottom: max(8px, env(safe-area-inset-bottom));
+  background: color-mix(in oklch, var(--bg-raised) 92%, transparent);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border-top: 1px solid var(--border-hairline);
+}
+.mobile-bottom-tab {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  padding: 6px 10px;
+  background: transparent;
+  border: 0;
+  color: var(--text-muted);
+  font: inherit;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: color var(--duration-fast) var(--ease-standard);
+}
+.mobile-bottom-tab:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: -2px;
+  border-radius: var(--radius-control);
+}
+.mobile-bottom-tab__icon-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  line-height: 0;
+}
+.mobile-bottom-tab__label {
+  font-size: 11px;
+  line-height: 1.1;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+.mobile-bottom-tab--active {
+  color: var(--accent-presence);
+}
+.mobile-bottom-tab--active .mobile-bottom-tab__label {
+  font-weight: 600;
+}
+.mobile-bottom-tab__badge {
+  position: absolute;
+  top: -4px;
+  right: -8px;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 3px;
+  border-radius: 7px;
+  background: var(--color-danger);
+  color: #fff;
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 14px;
+  text-align: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* Touch / coarse-pointer surface. On devices with no hover capability,

--- a/src/components/home-composer-centering.test.ts
+++ b/src/components/home-composer-centering.test.ts
@@ -78,17 +78,17 @@ assert.match(
   "transform: translateX(clamp(-max, ideal, max))",
 );
 
-// Composer card wrap + suggestions use the widened 880px max-width minus
+// Composer card wrap + suggestions use the widened 1200px max-width minus
 // --hc-asymmetry so they don't overflow when the layout is asymmetric.
 assert.match(
   css,
-  /\.home-composer-card-wrap\s*\{[\s\S]*?max-width:\s*min\(880px,\s*calc\(100% - var\(--hc-asymmetry, 0px\)\)\)/,
-  ".home-composer-card-wrap uses 880px asymmetry-aware max-width",
+  /\.home-composer-card-wrap\s*\{[\s\S]*?max-width:\s*min\(1200px,\s*calc\(100% - var\(--hc-asymmetry, 0px\)\)\)/,
+  ".home-composer-card-wrap uses 1200px asymmetry-aware max-width",
 );
 assert.match(
   css,
-  /\.home-composer-suggestions\s*\{[\s\S]*?max-width:\s*min\(880px,\s*calc\(100% - var\(--hc-asymmetry, 0px\)\)\)/,
-  ".home-composer-suggestions uses 880px asymmetry-aware max-width",
+  /\.home-composer-suggestions\s*\{[\s\S]*?max-width:\s*min\(1200px,\s*calc\(100% - var\(--hc-asymmetry, 0px\)\)\)/,
+  ".home-composer-suggestions uses 1200px asymmetry-aware max-width",
 );
 
 // The card itself inherits the constraint from its wrap — must NOT subtract

--- a/src/components/mobile-bottom-tabs.tsx
+++ b/src/components/mobile-bottom-tabs.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+/**
+ * MobileBottomTabs — fixed/sticky bottom navigation strip for mobile/tablet
+ * viewports. Surfaces the five most-used destinations (Home, Chat, Board,
+ * Inbox, Library) as a tablist with icon + label and an active highlight.
+ *
+ * Renders only when the parent shell is in mobile mode (≤1023px); Shell is
+ * responsible for that conditional render — this component itself doesn't
+ * check viewport.
+ */
+
+import { Icon, type IconName } from "@/lib/icon";
+
+type TabId = "home" | "chat" | "board" | "inbox" | "library";
+
+type TabDef = {
+  id: TabId;
+  label: string;
+  iconName: IconName;
+};
+
+const TABS: TabDef[] = [
+  { id: "home", label: "Home", iconName: "ph:house-bold" },
+  { id: "chat", label: "Chat", iconName: "ph:chats" },
+  { id: "board", label: "Board", iconName: "ph:kanban" },
+  { id: "inbox", label: "Inbox", iconName: "ph:tray" },
+  { id: "library", label: "Library", iconName: "ph:books" },
+];
+
+export type MobileBottomTabsProps = {
+  mode: string;
+  onSelect: (id: string) => void;
+  inboxBadgeCount?: number;
+};
+
+export function MobileBottomTabs({
+  mode,
+  onSelect,
+  inboxBadgeCount = 0,
+}: MobileBottomTabsProps) {
+  return (
+    <nav
+      className="mobile-bottom-tabs"
+      role="tablist"
+      aria-label="Primary"
+    >
+      {TABS.map((tab) => {
+        const active = mode === tab.id;
+        const showBadge = tab.id === "inbox" && inboxBadgeCount > 0;
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            aria-current={active ? "page" : undefined}
+            className={
+              "mobile-bottom-tab" +
+              (active ? " mobile-bottom-tab--active" : "")
+            }
+            onClick={() => onSelect(tab.id)}
+          >
+            <span className="mobile-bottom-tab__icon-wrap" aria-hidden>
+              <Icon name={tab.iconName} width={20} />
+              {showBadge ? (
+                <span className="mobile-bottom-tab__badge" aria-hidden>
+                  {inboxBadgeCount > 99 ? "99+" : inboxBadgeCount}
+                </span>
+              ) : null}
+            </span>
+            <span className="mobile-bottom-tab__label">{tab.label}</span>
+            {showBadge ? (
+              <span className="sr-only">
+                {inboxBadgeCount} unread
+              </span>
+            ) : null}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -104,6 +104,7 @@ function ShellInner({
   agent,
   bottom,
   topBar,
+  mobileTabs,
   onNavOpenChange,
   onAgentOpenChange,
 }: {
@@ -117,6 +118,10 @@ function ShellInner({
   agent?: ReactNode;
   bottom?: ReactNode;
   topBar?: ReactNode;
+  /** Mobile/tablet-only bottom tab bar. Rendered after `.shell-body`
+   *  inside `.shell-frame`, but only when the viewport matches the
+   *  mobile breakpoint (≤1023px). */
+  mobileTabs?: ReactNode;
   onNavOpenChange?: (open: boolean) => void;
   onAgentOpenChange?: (open: boolean) => void;
 }, ref: ForwardedRef<ShellHandle>) {
@@ -319,7 +324,7 @@ function ShellInner({
       <Panel
         id="nav"
         className="shell-nav-panel"
-        defaultSize="17%"
+        defaultSize="18%"
         minSize="14%"
         maxSize="25%"
         collapsible
@@ -362,9 +367,9 @@ function ShellInner({
           <Panel
             id="agent"
             className="shell-agent-panel"
-            defaultSize={"0%"}
-            minSize="25%"
-            maxSize="38%"
+            defaultSize={"18%"}
+            minSize="14%"
+            maxSize="25%"
             collapsible
             collapsedSize={0}
             panelRef={agentRef}
@@ -426,6 +431,7 @@ function ShellInner({
         )}
         {agentRail}
       </div>
+      {isMobile && mobileTabs ? mobileTabs : null}
       <MobileDrawer
         open={isMobile ? mobileDrawer : null}
         onClose={() => setMobileDrawer(null)}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -14,6 +14,7 @@ import { NewReminderModal, draftFromSlashArgs } from "@/components/new-reminder-
 import { InboxToastStack, toastFromItem, type Toast } from "@/components/inbox-toast";
 import { FamiliarGlyphPicker } from "@/components/familiar-glyph-picker";
 import { Shell, type ShellHandle } from "@/components/shell";
+import { MobileBottomTabs } from "@/components/mobile-bottom-tabs";
 import { Icon } from "@/lib/icon";
 import { FamiliarStudioProvider } from "@/lib/familiar-studio-context";
 import { FamiliarStudio } from "@/components/familiar-studio";
@@ -1045,10 +1046,19 @@ export function Workspace() {
     </div>
   );
 
+  const mobileTabs = (
+    <MobileBottomTabs
+      mode={mode}
+      onSelect={(id) => setMode(id as WorkspaceMode)}
+      inboxBadgeCount={inboxBadgeCount}
+    />
+  );
+
   return (
     <FamiliarStudioProvider>
       <Shell
         ref={shellRef}
+        mobileTabs={mobileTabs}
         onAgentOpenChange={(open) => {
           if (activeId) setRailOpen(activeId, open);
         }}

--- a/src/lib/use-viewport.ts
+++ b/src/lib/use-viewport.ts
@@ -2,14 +2,14 @@
 
 import { useEffect, useState } from "react";
 
-const MOBILE_QUERY = "(max-width: 767px)";
+const MOBILE_QUERY = "(max-width: 1023px)";
 const COARSE_POINTER_QUERY = "(pointer: coarse)";
 
 /**
  * Live boolean for "viewport narrower than the desktop shell breakpoint."
  * SSR-safe: returns false on the server and during the first browser render,
  * then flips synchronously after mount and subscribes to viewport changes.
- * Pair with CSS @media (max-width: 767px) so server-rendered markup matches.
+ * Pair with CSS @media (max-width: 1023px) so server-rendered markup matches.
  */
 export function useIsMobile(): boolean {
   const [mobile, setMobile] = useState(false);

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -41,7 +41,7 @@
   );
   --hc-max-shift: max(
     0px,
-    calc((100% - 880px) / 2),
+    calc((100% - 1200px) / 2),
     calc(var(--hc-asymmetry) / 2)
   );
   --hc-ideal-shift: calc(
@@ -92,7 +92,7 @@
 .home-composer-card-wrap {
   position: relative;
   width: 100%;
-  max-width: min(880px, calc(100% - var(--hc-asymmetry, 0px)));
+  max-width: min(1200px, calc(100% - var(--hc-asymmetry, 0px)));
 }
 
 /* ── Composer card ───────────────────────────────────────────────────────── */
@@ -304,7 +304,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  max-width: min(880px, calc(100% - var(--hc-asymmetry, 0px)));
+  max-width: min(1200px, calc(100% - var(--hc-asymmetry, 0px)));
   width: 100%;
   justify-content: center;
 }


### PR DESCRIPTION
## Summary

Three coordinated layout adjustments to the desktop and mobile/tablet shells:

**Side panels (desktop):**
- Nav and agent panels now default to the same 18% width with the same 14–25% resize range (previously: nav 17% (14–25), agent 0% collapsed (25–38)). Removes the asymmetry that was causing Home to need translateX compensation.
- `.shell-nav` and `.shell-agent` get a frosted-glass treatment: `color-mix(in oklch, var(--bg-raised) 88%, transparent)` + `backdrop-filter: blur(14px) saturate(140%)`.

**Mobile / tablet (≤ 1023px):**
- New `MobileBottomTabs` (Home, Chat, Board, Inbox, Library) with role=tablist semantics, aria-current=page on active, inbox badge driven by `inboxBadgeCount`. Safe-area aware.
- `useIsMobile()` breakpoint moved 767px → 1023px so tablets count as mobile. The existing `@media` blocks that hide `.shell-nav-panel`/`.shell-list-panel`/`.shell-agent-panel` and reflow the familiar rail to a top strip now apply at the same threshold. `.shell-detail` gets bottom padding for the tab bar.
- Workspace passes `<MobileBottomTabs/>` as a new shell prop; shell renders it only when `isMobile`.

**Composer width:**
- `.home-composer-card-wrap`, `.home-composer-suggestions`, and the `--hc-max-shift` floor all bump 880px → 1200px.
- `home-composer-centering.test.ts` updated to assert 1200px.

## Test plan

- [ ] Desktop ≥1024px: both side panels visible, equal width, frosted background visible
- [ ] Resize either side panel — opposite still draggable in the same 14–25% range
- [ ] Home composer card hits its new 1200px cap (was 880)
- [ ] Tablet width (~900px): side panels hidden, bottom tab strip appears
- [ ] Phone width (≤520px): side panels hidden, bottom tab strip appears, hero/card padding tightens
- [ ] Bottom tab strip: tapping Home/Chat/Board/Inbox/Library navigates; active tab is highlighted with accent color and `aria-current="page"`
- [ ] Inbox badge appears when there are unresolved escalations
- [ ] Safe-area inset respected on iOS (bottom strip not under home indicator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)