### PR TITLE
fix(home, shell): mobile polish, symmetric panels, equidistant home

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -314,19 +314,6 @@ body {
   display: flex;
 }
 
-/* Home composer needs to visually center on the viewport, which means its
- * .home-composer-root translates left to compensate for the nav panel.
- * Allow the detail panel to overflow visible only while it contains a Home
- * composer; react-resizable-panels sets `overflow: auto` inline, so the
- * override needs `!important`. The composer's own .home-composer-root
- * keeps its own vertical scroll. */
-.shell-detail-panel:has(> .shell-detail > .cave-mode-fade > .home-composer-root) {
-  overflow: visible !important;
-}
-.shell-detail-panel:has(> .shell-detail > .cave-mode-fade > .home-composer-root) > .shell-detail {
-  overflow: visible;
-}
-
 /* Inner panel border — subtle dividing line on the right edge of side panels */
 .shell-nav-panel { border-right: 1px solid var(--border-hairline); }
 .shell-agent-panel { border-left: 1px solid var(--border-hairline); }
@@ -3323,6 +3310,30 @@ body {
   outline-offset: 1px;
 }
 
+/* Mobile top bar — collapse the search button to an icon-only affordance so
+ * the notification bell and settings cog remain visible on 375–428px phones.
+ * The full search label/kbd hint comes back on tablets at ≥640px. */
+@media (max-width: 639px) {
+  .top-bar {
+    padding: 0 10px;
+    gap: 8px;
+  }
+  .top-bar__search {
+    min-width: 0;
+    margin-right: 0;
+    padding: 5px 8px;
+    gap: 6px;
+    flex: 0 0 auto;
+  }
+  .top-bar__search > span,
+  .top-bar__search kbd {
+    display: none;
+  }
+  .top-bar__crumb-sub {
+    display: none;
+  }
+}
+
 /* ────────────────────────────────────────────────
    Settings · Familiars panel
    (Phase 5, shell-ia-redesign)
@@ -3745,10 +3756,16 @@ body {
   }
   /* Sidebar nav, list pane, companion rail: hidden on phone. The
      ⌘B / ⌘\\ / ⌘J keyboard shortcuts still toggle them programmatically
-     for accessibility, but they don't take up screen space by default. */
+     for accessibility, but they don't take up screen space by default.
+     react-resizable-panels uses a wrapper `<div data-panel>` whose inline
+     `flex: N 1 0px` style overrides our className-based hides, so we also
+     target the wrapper by id to fully remove it from the layout. */
   .shell-nav-panel,
   .shell-list-panel,
-  .shell-agent-panel {
+  .shell-agent-panel,
+  [data-panel="true"]#nav,
+  [data-panel="true"]#list,
+  [data-panel="true"]#agent {
     display: none !important;
   }
   /* Hide separators that would otherwise be orphaned. */
@@ -3756,7 +3773,8 @@ body {
     display: none !important;
   }
   /* Detail takes the full width. */
-  .shell-detail-panel {
+  .shell-detail-panel,
+  [data-panel="true"]#detail {
     flex: 1 1 100% !important;
     width: 100% !important;
     min-width: 0 !important;

--- a/src/components/home-composer-centering.test.ts
+++ b/src/components/home-composer-centering.test.ts
@@ -2,131 +2,126 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-// ───── Shell exposes panel pixel widths as CSS variables ─────
+// ───── Shell enforces symmetric min/max on the side panels ─────
 const shell = await readFile(new URL("./shell.tsx", import.meta.url), "utf8");
 
+const navPanelMatch = shell.match(
+  /<Panel\s+id="nav"[\s\S]*?<\/Panel>/,
+);
+assert.ok(navPanelMatch, "nav Panel block must exist in shell.tsx");
 assert.match(
-  shell,
-  /const \[navWidthPx, setNavWidthPx\] = useState\(0\);/,
-  "Shell tracks navWidthPx state",
+  navPanelMatch[0],
+  /minSize="16%"/,
+  "nav panel minSize is 16%",
 );
 assert.match(
-  shell,
-  /const \[agentWidthPx, setAgentWidthPx\] = useState\(0\);/,
-  "Shell tracks agentWidthPx state",
-);
-assert.match(
-  shell,
-  /setNavWidthPx\(size\.inPixels \?\? 0\)/,
-  "Nav panel onResize updates navWidthPx via size.inPixels",
-);
-assert.match(
-  shell,
-  /setAgentWidthPx\(size\.inPixels \?\? 0\)/,
-  "Agent panel onResize updates agentWidthPx via size.inPixels",
-);
-assert.match(
-  shell,
-  /"--shell-nav-px": `\$\{Math\.round\(navWidthPx\)\}px`/,
-  "Shell exposes --shell-nav-px on .shell-frame",
-);
-assert.match(
-  shell,
-  /"--shell-agent-px": `\$\{Math\.round\(agentWidthPx\)\}px`/,
-  "Shell exposes --shell-agent-px on .shell-frame",
-);
-assert.match(
-  shell,
-  /style=\{shellFrameStyle\}/,
-  ".shell-frame receives the custom-property style object",
+  navPanelMatch[0],
+  /maxSize="28%"/,
+  "nav panel maxSize is 28%",
 );
 
-// ───── Home composer reads the variables and centers on viewport ─────
+const agentPanelMatch = shell.match(
+  /<Panel\s+id="agent"[\s\S]*?<\/Panel>/,
+);
+assert.ok(agentPanelMatch, "agent Panel block must exist in shell.tsx");
+assert.match(
+  agentPanelMatch[0],
+  /minSize="16%"/,
+  "agent panel minSize is 16% (symmetric with nav)",
+);
+assert.match(
+  agentPanelMatch[0],
+  /maxSize="28%"/,
+  "agent panel maxSize is 28% (symmetric with nav)",
+);
+
+// ───── Home composer is detail-panel centered for true equidistance ─────
 const css = await readFile(
   new URL("../styles/home-composer.css", import.meta.url),
   "utf8",
 );
 
-// --hc-asymmetry: abs(nav - agent) — the cards are narrowed by this so the
-// composer can translate all the way to viewport center without overflowing
-// under a side panel.
-assert.match(
-  css,
-  /--hc-asymmetry:\s*max\(\s*calc\(var\(--shell-nav-px, 0px\) - var\(--shell-agent-px, 0px\)\),\s*calc\(var\(--shell-agent-px, 0px\) - var\(--shell-nav-px, 0px\)\)\s*\)/,
-  "--hc-asymmetry computed as abs(nav - agent)",
-);
+const rootMatch = css.match(/\.home-composer-root\s*\{([^}]*)\}/);
+assert.ok(rootMatch, ".home-composer-root rule must exist");
 
-// --hc-max-shift includes the asymmetry/2 term so the clamp upper bound
-// grows with the asymmetry once the cards have been narrowed.
-assert.match(
-  css,
-  /--hc-max-shift:\s*max\([\s\S]*?calc\(var\(--hc-asymmetry\) \/ 2\)[\s\S]*?\)/,
-  "--hc-max-shift includes asymmetry/2",
-);
-
-// --hc-ideal-shift = (agent - nav) / 2
-assert.match(
-  css,
-  /--hc-ideal-shift:\s*calc\(\s*\(var\(--shell-agent-px, 0px\) - var\(--shell-nav-px, 0px\)\) \/ 2\s*\)/,
-  "--hc-ideal-shift = (agent - nav) / 2",
-);
-
-// transform uses clamp(-max, ideal, max) so the shift is bounded.
-assert.match(
-  css,
-  /transform:\s*translateX\(\s*clamp\(\s*calc\(-1 \* var\(--hc-max-shift\)\),\s*var\(--hc-ideal-shift\),\s*var\(--hc-max-shift\)\s*\)\s*\)/,
-  "transform: translateX(clamp(-max, ideal, max))",
-);
-
-// Composer card wrap + suggestions use the widened 880px max-width minus
-// --hc-asymmetry so they don't overflow when the layout is asymmetric.
-assert.match(
-  css,
-  /\.home-composer-card-wrap\s*\{[\s\S]*?max-width:\s*min\(880px,\s*calc\(100% - var\(--hc-asymmetry, 0px\)\)\)/,
-  ".home-composer-card-wrap uses 880px asymmetry-aware max-width",
-);
-assert.match(
-  css,
-  /\.home-composer-suggestions\s*\{[\s\S]*?max-width:\s*min\(880px,\s*calc\(100% - var\(--hc-asymmetry, 0px\)\)\)/,
-  ".home-composer-suggestions uses 880px asymmetry-aware max-width",
-);
-
-// The card itself inherits the constraint from its wrap — must NOT subtract
-// --hc-asymmetry a second time (that bug was caught during development).
-const cardRuleMatch = css.match(/\.home-composer-card\s*\{([^}]*)\}/);
-assert.ok(cardRuleMatch, ".home-composer-card rule must exist");
+// No transform/asymmetry hack — the composer is just centered inside its
+// own panel. With symmetric panel min/max enforced by the Shell, that
+// naturally yields equal gaps to both side-panel edges.
 assert.doesNotMatch(
-  cardRuleMatch[1],
-  /var\(--hc-asymmetry/,
-  ".home-composer-card body must not reference --hc-asymmetry (would double-subtract)",
-);
-assert.match(
-  cardRuleMatch[1],
-  /max-width:\s*100%/,
-  ".home-composer-card body uses max-width: 100% (inherits from wrap)",
-);
-
-// Old narrow max-width is gone.
-assert.doesNotMatch(
-  css,
-  /\.home-composer-card-wrap\s*\{[\s\S]*?max-width:\s*760px/,
-  "old 760px max-width on .home-composer-card-wrap removed",
+  rootMatch[1],
+  /transform:/,
+  ".home-composer-root must not apply transform (equidistance comes from detail-panel centering)",
 );
 assert.doesNotMatch(
-  css,
-  /\.home-composer-suggestions\s*\{[\s\S]*?max-width:\s*760px/,
-  "old 760px max-width on .home-composer-suggestions removed",
+  rootMatch[1],
+  /--hc-asymmetry/,
+  ".home-composer-root must not reference --hc-asymmetry (legacy from viewport-centering attempt)",
 );
 
-// ───── globals.css lets the detail panel overflow when it's home mode ─────
+// Card wrap and suggestions cap at 880px with no asymmetry math.
+assert.match(
+  css,
+  /\.home-composer-card-wrap\s*\{[\s\S]*?max-width:\s*880px;/,
+  ".home-composer-card-wrap caps at 880px",
+);
+assert.match(
+  css,
+  /\.home-composer-suggestions\s*\{[\s\S]*?max-width:\s*880px;/,
+  ".home-composer-suggestions caps at 880px",
+);
+
+// ───── Mobile polish ─────
 const globals = await readFile(
   new URL("../app/globals.css", import.meta.url),
   "utf8",
 );
+
+// Top-bar collapses search to icon-only on phones (< 640px) so bell + cog
+// remain visible.
 assert.match(
   globals,
-  /\.shell-detail-panel:has\(> \.shell-detail > \.cave-mode-fade > \.home-composer-root\)\s*\{\s*overflow:\s*visible\s*!important/,
-  "globals.css opens .shell-detail-panel overflow when it contains the home composer",
+  /@media \(max-width: 639px\)\s*\{[\s\S]*?\.top-bar__search\s*\{[\s\S]*?min-width:\s*0;/,
+  "@media (max-width: 639px) resets .top-bar__search min-width",
+);
+assert.match(
+  globals,
+  /@media \(max-width: 639px\)\s*\{[\s\S]*?\.top-bar__search > span,[\s\S]*?\.top-bar__search kbd\s*\{[\s\S]*?display:\s*none;/,
+  "phone breakpoint hides the search label + kbd hint",
+);
+
+// Phone (max-width: 767px) hides the side panels by targeting BOTH the
+// className-bearing inner wrapper AND the `<div data-panel id="..">` outer
+// wrapper that react-resizable-panels controls via inline flex-basis.
+assert.match(
+  globals,
+  /\[data-panel="true"\]#nav,\s*\[data-panel="true"\]#list,\s*\[data-panel="true"\]#agent\s*\{\s*display:\s*none\s*!important/,
+  "phone breakpoint hides Panel outer wrappers (data-panel id targeting)",
+);
+
+// Touch devices hide the keyboard hint strip.
+assert.match(
+  css,
+  /@media \(pointer: coarse\)\s*\{[\s\S]*?\.hc-keyboard-hint\s*\{[\s\S]*?display:\s*none;/,
+  "@media (pointer: coarse) hides .hc-keyboard-hint",
+);
+
+// Suggestion chips truncate their label cleanly inside the chip's max-width.
+assert.match(
+  css,
+  /\.hc-suggestion\s*\{[\s\S]*?max-width:\s*min\(100%, 360px\);/,
+  ".hc-suggestion caps width at 360px",
+);
+assert.match(
+  css,
+  /\.hc-suggestion > span\s*\{[\s\S]*?text-overflow:\s*ellipsis;[\s\S]*?white-space:\s*nowrap;/,
+  ".hc-suggestion > span uses text-overflow: ellipsis + nowrap",
+);
+
+// Phone-portrait composer is anchored toward the top instead of dead-center.
+assert.match(
+  css,
+  /@media \(max-width: 639px\)\s*\{[\s\S]*?\.home-composer-root\s*\{[\s\S]*?justify-content:\s*flex-start;[\s\S]*?padding-top:\s*clamp\(/,
+  "phone breakpoint anchors .home-composer-root to flex-start with padding-top clamp",
 );
 
 console.log("home-composer-centering.test.ts: ok");

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useImperativeHandle, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useImperativeHandle, useRef, useState, type ReactNode } from "react";
 import type { ForwardedRef } from "react";
 import { forwardRef } from "react";
 import {
@@ -175,12 +175,6 @@ function ShellInner({
     return typeof pct !== "number" || pct > 0;
   });
 
-  // Track rendered pixel widths of the side panels so child surfaces (e.g. the
-  // Home composer) can visually center on the viewport rather than on the
-  // asymmetric .shell-detail panel.
-  const [navWidthPx, setNavWidthPx] = useState(0);
-  const [agentWidthPx, setAgentWidthPx] = useState(0);
-
   useEffect(() => {
     onNavOpenChange?.(navOpen);
   }, [navOpen, onNavOpenChange]);
@@ -251,15 +245,15 @@ function ShellInner({
         id="nav"
         className="shell-nav-panel"
         defaultSize="17%"
-        minSize="14%"
-        maxSize="25%"
+        // Symmetric with the agent panel so when both are open the layout
+        // stays visually balanced and the Home composer sits equidistant
+        // from both side panels.
+        minSize="16%"
+        maxSize="28%"
         collapsible
         collapsedSize={0}
         panelRef={navRef}
-        onResize={(size) => {
-          setNavOpen((size.asPercentage ?? 0) > 0);
-          setNavWidthPx(size.inPixels ?? 0);
-        }}
+        onResize={(size) => setNavOpen((size.asPercentage ?? 0) > 0)}
       >
         <aside className="shell-nav">{nav}</aside>
       </Panel>
@@ -294,15 +288,15 @@ function ShellInner({
             id="agent"
             className="shell-agent-panel"
             defaultSize={"0%"}
-            minSize="25%"
-            maxSize="38%"
+            // Symmetric with the nav panel so when both are open the layout
+            // stays visually balanced and the Home composer sits equidistant
+            // from both side panels.
+            minSize="16%"
+            maxSize="28%"
             collapsible
             collapsedSize={0}
             panelRef={agentRef}
-            onResize={(size) => {
-              setAgentOpen((size.asPercentage ?? 0) > 0);
-              setAgentWidthPx(size.inPixels ?? 0);
-            }}
+            onResize={(size) => setAgentOpen((size.asPercentage ?? 0) > 0)}
           >
             <aside className="shell-agent">{agentOpen ? agent : null}</aside>
           </Panel>
@@ -311,21 +305,8 @@ function ShellInner({
     </Group>
   );
 
-  const shellFrameStyle: CSSProperties & {
-    "--shell-nav-px": string;
-    "--shell-agent-px": string;
-  } = {
-    // Surfaces that need to visually center on the viewport (e.g. Home)
-    // use these to compensate for the asymmetric side-panel widths.
-    "--shell-nav-px": `${Math.round(navWidthPx)}px`,
-    "--shell-agent-px": `${Math.round(agentWidthPx)}px`,
-  };
-
   return (
-    <div
-      className="shell-frame flex h-full w-full flex-col"
-      style={shellFrameStyle}
-    >
+    <div className="shell-frame flex h-full w-full flex-col">
       {topBar}
       <div className="shell-body flex flex-1 min-h-0">
         {familiarRail}

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -16,39 +16,12 @@
   gap: 16px;
   overflow-y: auto;
   box-sizing: border-box;
-  /* Visually center on the viewport, compensating for the side-panel widths
-   * exposed by the Shell as --shell-nav-px / --shell-agent-px. The asymmetry
-   * (nav present, agent collapsed in home mode) would otherwise push the
-   * composer off to the right.
-   *
-   * Two coordinated pieces:
-   *   1. --hc-asymmetry — abs(nav - agent), used to narrow the composer
-   *      cards so there is room to translate them all the way to the
-   *      viewport's center without overflowing under a side panel.
-   *   2. transform: translateX(clamp(...)) — the actual viewport shift,
-   *      capped to the available free space (panel_width − card_width)/2
-   *      so the card never overflows even if the variables get out of sync.
-   */
-  --hc-asymmetry: max(
-    calc(var(--shell-nav-px, 0px) - var(--shell-agent-px, 0px)),
-    calc(var(--shell-agent-px, 0px) - var(--shell-nav-px, 0px))
-  );
-  --hc-max-shift: max(
-    0px,
-    calc((100% - 880px) / 2),
-    calc(var(--hc-asymmetry) / 2)
-  );
-  --hc-ideal-shift: calc(
-    (var(--shell-agent-px, 0px) - var(--shell-nav-px, 0px)) / 2
-  );
-  transform: translateX(
-    clamp(
-      calc(-1 * var(--hc-max-shift)),
-      var(--hc-ideal-shift),
-      var(--hc-max-shift)
-    )
-  );
-  transition: transform 120ms ease-out;
+  /* Home content is always equidistant from the two side panels. With the
+   * Shell enforcing symmetric min/max on .shell-nav-panel and
+   * .shell-agent-panel, "centered in the detail panel" gives equal gaps to
+   * both panel edges. When a side panel is collapsed, the gap is measured to
+   * the viewport edge instead — still equal on both sides because the
+   * composer is centered inside the detail panel that fills that space. */
 }
 
 /* ── Hero ────────────────────────────────────────────────────────────────── */
@@ -79,7 +52,7 @@
 .home-composer-card-wrap {
   position: relative;
   width: 100%;
-  max-width: min(880px, calc(100% - var(--hc-asymmetry, 0px)));
+  max-width: 880px;
 }
 
 /* ── Composer card ───────────────────────────────────────────────────────── */
@@ -288,7 +261,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  max-width: min(880px, calc(100% - var(--hc-asymmetry, 0px)));
+  max-width: 880px;
   width: 100%;
   justify-content: center;
 }
@@ -305,7 +278,12 @@
   font-size: 12px;
   cursor: pointer;
   transition: all 0.12s ease;
-  max-width: 100%;
+  /* Cap each chip so long suggestions ellipsis cleanly inside the chip
+   * instead of pushing past the suggestion row's edge. On phones this is
+   * what keeps "Continue: Task context: Title:…" from getting clipped by
+   * the viewport. */
+  max-width: min(100%, 360px);
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -320,6 +298,17 @@
 .hc-suggestion-icon {
   flex-shrink: 0;
   opacity: 0.5;
+}
+
+/* The label inside each chip handles its own text-overflow so long
+ * suggestions get an ellipsis inside the chip rather than spilling past
+ * the viewport. The chip itself is `display: inline-flex`, so the text
+ * needs its own overflow context with min-width: 0 to shrink. */
+.hc-suggestion > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* ── Focus rings (keyboard-only) ─────────────────────────────────────────── */
@@ -443,4 +432,24 @@
   text-align: center;
   font-size: 10px;
   color: var(--text-muted);
+}
+
+/* Touch devices have no physical keyboard — hide the desktop-only shortcut
+ * legend so phones don't waste vertical space on irrelevant guidance. */
+@media (pointer: coarse) {
+  .hc-keyboard-hint {
+    display: none;
+  }
+}
+
+/* Phone-portrait composer position
+ * On tall portrait phones, vertical-center positioning drops the title to
+ * ~60% of the viewport with a wide band of empty space above. Anchor the
+ * stack near the upper third so it reads as content rather than a stranded
+ * island, while keeping wider screens (tablet+) on the centered layout. */
+@media (max-width: 639px) {
+  .home-composer-root {
+    justify-content: flex-start;
+    padding-top: clamp(72px, 18vh, 160px);
+  }
 }


### PR DESCRIPTION
## Summary

Three coordinated layout changes, all motivated by the user's recent feedback on mobile + centering:

### Mobile polish (phones 375–428 portrait)
- Top bar collapses the search button to **icon-only** at `< 640px` so the notification bell and settings cog stop getting clipped (was caused by `.top-bar__search { min-width: 420px }`).
- Suggestion chips cap at `min(100%, 360px)` and the inner `<span>` ellipsis-truncates so long titles like *"Continue: Task context: Title: Create Design Palettes…"* no longer spill past the viewport.
- `.hc-keyboard-hint` hides on `@media (pointer: coarse)` — no physical keyboard, no need for the desktop shortcut legend.
- `.home-composer-root` anchors to `flex-start` with `padding-top: clamp(72px, 18vh, 160px)` on phones so the title sits near the upper third instead of stranded mid-screen.
- Nav / list / agent panels now hide on phones by targeting **both** the className inner wrapper **and** `[data-panel="true"]#id` outer wrapper. The outer is what react-resizable-panels controls via inline `flex: N 1 0px` — without targeting it, the outer kept its 17% allotment and pushed the detail panel ~64px right of the viewport.

### Symmetric side panels
- Both `.shell-nav-panel` and `.shell-agent-panel` use `minSize="16%" maxSize="28%"`. Was asymmetric before (nav 14/25, agent 25/38), which guaranteed the layout could never be balanced even with both open.

### Equidistant Home centering (replaces PR #333 viewport-shift)
- Drop the `--shell-nav-px` / `--shell-agent-px` / `--hc-asymmetry` / `translateX(clamp(...))` machinery and the matching `.shell-detail-panel:has(...) { overflow: visible }` override.
- With symmetric panel min/max, simply centering the composer in `.shell-detail` gives **equal** gaps to both side-panel edges — which is what the user actually asked for.

Measured gaps (cardLeft − navRight  ===  agentLeft − cardRight):
| Viewport | leftGap | rightGap |
|---:|---:|---:|
| 1024 | 32 | 32 |
| 1440 | 148 | 148 |
| 1920 | 348 | 348 |

## Test plan

- [x] `node --experimental-strip-types src/components/home-composer-centering.test.ts` — now asserts symmetric panels, no transform, the four mobile CSS hooks, and the data-panel outer-wrapper hide.
- [x] `home-composer.test.ts` + `home-composer-polish.test.ts` still pass.
- [x] Visual: captured at 375 / 390 / 428 / 412 phone widths AND 1024 / 1440 / 1920 desktop — composer centered on viewport at mobile, equidistant from both side panels on desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)