### PR TITLE
fix(home, mobile): chip ellipsis, kb-hint on touch, Panel outer hide

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3827,10 +3827,26 @@ select {
   .shell-root > [data-resizable-handle] {
     display: none !important;
   }
-  /* Detail takes the full width. */
-  .shell-detail-panel {
+  /* Detail takes the full width.
+   *
+   * react-resizable-panels wraps each Panel in a `<div data-panel id="...">`
+   * whose inline `flex: N 1 0px` (from defaultSize) controls the layout. The
+   * .shell-*-panel className lives on an inner div, so making just the inner
+   * full-width leaves the OUTER nav/list/agent wrappers still claiming their
+   * percent of the row — at 375px that's ~68px of dead space shoved before
+   * the detail panel. Override the outer wrappers by id so detail truly
+   * fills the viewport on phones. */
+  .shell-detail-panel,
+  [data-panel="true"]#detail {
     flex: 1 1 100% !important;
     width: 100% !important;
+    min-width: 0 !important;
+  }
+  [data-panel="true"]#nav,
+  [data-panel="true"]#list,
+  [data-panel="true"]#agent {
+    flex: 0 0 0 !important;
+    width: 0 !important;
     min-width: 0 !important;
   }
   /* Reserve room at the bottom of the detail surface for the bottom tab

--- a/src/components/home-composer-mobile-gaps.test.ts
+++ b/src/components/home-composer-mobile-gaps.test.ts
@@ -1,0 +1,61 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const css = await readFile(
+  new URL("../styles/home-composer.css", import.meta.url),
+  "utf8",
+);
+const globals = await readFile(
+  new URL("../app/globals.css", import.meta.url),
+  "utf8",
+);
+
+// ───── Suggestion chips ellipsis cleanly inside their max-width ─────
+// Without these, long chip titles ("Continue: Task context: Title: …") spill
+// past the suggestion-row edge and clip at the viewport on phones.
+const chipMatch = css.match(/\.hc-suggestion\s*\{([^}]*)\}/);
+assert.ok(chipMatch, ".hc-suggestion rule must exist");
+assert.match(
+  chipMatch[1],
+  /max-width:\s*min\(100%, 360px\);/,
+  ".hc-suggestion caps chip width at 360px",
+);
+assert.match(
+  chipMatch[1],
+  /min-width:\s*0;/,
+  ".hc-suggestion has min-width: 0 so flex children can shrink for ellipsis",
+);
+
+assert.match(
+  css,
+  /\.hc-suggestion > span\s*\{[\s\S]*?min-width:\s*0;[\s\S]*?overflow:\s*hidden;[\s\S]*?text-overflow:\s*ellipsis;[\s\S]*?white-space:\s*nowrap;/,
+  ".hc-suggestion > span ellipsis chain (min-width: 0 + overflow + text-overflow + nowrap)",
+);
+
+// ───── Keyboard hint hides on touch ─────
+// Touch devices have no physical keyboard — hide the desktop-only legend.
+assert.match(
+  css,
+  /@media \(pointer: coarse\)\s*\{[\s\S]*?\.hc-keyboard-hint\s*\{[\s\S]*?display:\s*none;/,
+  "@media (pointer: coarse) hides .hc-keyboard-hint",
+);
+
+// ───── Data-panel outer wrapper hide on mobile ─────
+// react-resizable-panels wraps each <Panel> in `<div data-panel id="..">`
+// whose inline `flex: N 1 0px` claims layout space even when the inner
+// .shell-*-panel has position:fixed (drawer pattern). Without this rule the
+// outer nav wrapper kept its 17%/14% allotment and pushed the detail panel
+// ~64–68px right of the viewport on phones.
+assert.match(
+  globals,
+  /\[data-panel="true"\]#nav,\s*\[data-panel="true"\]#list,\s*\[data-panel="true"\]#agent\s*\{\s*flex:\s*0\s+0\s+0\s*!important;/,
+  "phone breakpoint zeroes the nav/list/agent outer-wrapper flex",
+);
+assert.match(
+  globals,
+  /\.shell-detail-panel,\s*\[data-panel="true"\]#detail\s*\{\s*flex:\s*1\s+1\s+100%\s*!important;/,
+  "phone breakpoint promotes the detail outer wrapper to flex: 1 1 100%",
+);
+
+console.log("home-composer-mobile-gaps.test.ts: ok");

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -321,7 +321,21 @@
   font-size: 12px;
   cursor: pointer;
   transition: all 0.12s ease;
-  max-width: 100%;
+  /* Cap each chip so long suggestions ellipsis inside the chip instead of
+   * extending past the suggestion row's edge — without this the chip stays
+   * one wide line and clips its tail at the viewport on phones. */
+  max-width: min(100%, 360px);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The label inside each chip needs its own overflow context with min-width: 0
+ * because the chip is `display: inline-flex` — text-overflow on the flex
+ * parent doesn't reach individual flex children. */
+.hc-suggestion > span {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -459,4 +473,12 @@
   text-align: center;
   font-size: 10px;
   color: var(--text-muted);
+}
+
+/* Touch devices have no physical keyboard — hide the desktop-only shortcut
+ * legend so phones don't waste vertical space on irrelevant guidance. */
+@media (pointer: coarse) {
+  .hc-keyboard-hint {
+    display: none;
+  }
 }


### PR DESCRIPTION
## Summary

Three small gaps left behind by the mobile-readiness pass (#334) and home-composer follow-ups:

1. **Suggestion-chip ellipsis** — chip was `display: inline-flex` with `text-overflow: ellipsis` on the chip itself, but ellipsis doesn't cross into inline-flex children. Long titles ("Continue: Task context: Title: …") rendered as a single nowrap line clipped at the viewport. Cap each chip at `min(100%, 360px)` + `min-width: 0`, and add `.hc-suggestion > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap }` so the label truncates inside the chip.
2. **Keyboard hint on touch** — `.hc-keyboard-hint` ("⏎ send · ⇧⏎ newline · ↑↓ history · / commands") shows on every viewport. Hide under `@media (pointer: coarse)`.
3. **Panel outer-wrapper hide on phones** — the mobile drawer rules make `.shell-nav-panel` `position: fixed`, but the OUTER `<div data-panel id="nav">` that react-resizable-panels controls keeps its inline `flex: 14 1 0px` (or 18, whichever the defaultSize). Measured at 375px: nav outer was claiming **68px** of dead space, shoving the detail panel right. After the fix: nav outer `flex: 0 0 0`, detail outer `flex: 1 1 100%`, card center at viewport center.

## Test plan

- [x] `node --experimental-strip-types src/components/home-composer-mobile-gaps.test.ts` (new) — asserts the three CSS hooks.
- [x] Existing `home-composer-centering.test.ts` + `home-composer-polish.test.ts` still pass.
- [x] Verified at 375 / 390 / 428 (mobile) and 1024 / 1440 (desktop): detail fills viewport on phones, chips ellipsis cleanly, kb hint absent on touch, no desktop regression.

## Context

Replaces #339 (closed). That PR pre-dated #334 / #336 / #337 / #338 landing in parallel, which covered most of its scope. This is the minimal residual delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)