### PR TITLE
fix(chat): empty-state copy, rail dedupe, tab strip, touch-aware hint

### DIFF
--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -3,6 +3,7 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { ChatList } from "@/components/chat-list";
 import { ChatView } from "@/components/chat-view";
+import { useIsMobile } from "@/lib/use-viewport";
 import type { Familiar, SessionRow } from "@/lib/types";
 
 type View =
@@ -54,6 +55,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
   const [view, setView] = useState<View>({ kind: "list" });
   const viewHandle = useRef<ChatViewHandle | null>(null);
   const previousFamiliarIdRef = useRef<string | null>(null);
+  const isMobile = useIsMobile();
   const activeSession = view.kind === "chat" && view.sessionId
     ? sessions.find((s) => s.id === view.sessionId) ?? null
     : null;
@@ -86,16 +88,26 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
   );
 
   if (!familiar) {
+    // Empty-state copy is mode-aware: on phones the nav/sidebar/agent panels
+    // are drawers behind a toggle, so "from the sidebar selector" / "left
+    // panel" reads as broken. Point users at the drawer or the setup CTA
+    // instead.
+    const heading = isMobile
+      ? "Choose a familiar to start chatting"
+      : "Choose a familiar from the sidebar selector";
+    const subline = pendingProjectRoot
+      ? "Selecting one will start this chat in the pending project."
+      : isMobile
+        ? "Open the menu to pick a familiar, or set one up below."
+        : "Pick who should handle the conversation from the left panel.";
     return (
       <section className="flex h-full flex-col items-center justify-center gap-4 bg-[var(--bg-base)] px-6 text-center text-sm text-[var(--text-muted)]">
         <div>
           <p className="text-[15px] font-medium text-[var(--text-secondary)]">
-            Choose a familiar from the sidebar selector
+            {heading}
           </p>
           <p className="mt-1 text-[12px]">
-            {pendingProjectRoot
-              ? "Selecting one will start this chat in the pending project."
-              : "Pick who should handle the conversation from the left panel."}
+            {subline}
           </p>
         </div>
         {onOpenOnboarding ? (

--- a/src/components/chat-surface-polish.test.ts
+++ b/src/components/chat-surface-polish.test.ts
@@ -1,0 +1,52 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (p: string) => readFileSync(resolve(here, p), "utf8");
+
+test("chat-router renders mobile-aware empty-state copy", () => {
+  const src = read("./chat-router.tsx");
+  assert.match(src, /useIsMobile/, "imports useIsMobile");
+  assert.match(src, /Choose a familiar to start chatting/, "mobile heading present");
+  assert.match(src, /Choose a familiar from the sidebar selector/, "desktop heading present");
+  assert.match(src, /Open the menu to pick a familiar/, "mobile subline present");
+  assert.match(src, /Pick who should handle the conversation from the left panel/, "desktop subline present");
+});
+
+test("companion-rail accepts suppressEmpty and short-circuits", () => {
+  const src = read("./companion-rail.tsx");
+  assert.match(src, /suppressEmpty\?:\s*boolean/, "suppressEmpty prop typed");
+  assert.match(src, /suppressEmpty\s*=\s*false/, "default value declared");
+  assert.match(src, /if\s*\(suppressEmpty\)\s*return null/, "early return when suppressed");
+});
+
+test("workspace passes suppressEmpty={mode === 'chat'} to CompanionRail", () => {
+  const src = read("./workspace.tsx");
+  assert.match(src, /suppressEmpty=\{mode === "chat"\}/, "suppressEmpty wired for chat mode");
+});
+
+test("chat-surface tab strip uses ARIA roles and the rounded underline", () => {
+  const src = read("./chat-surface.tsx");
+  assert.match(src, /role="tablist"/, "tablist role present");
+  assert.match(src, /role="tab"/, "tab role present");
+  assert.match(src, /aria-selected=\{isActive\}/, "aria-selected wired");
+  assert.match(src, /after:h-\[2px\]/, "2px underline pseudo-element present");
+  assert.match(src, /after:rounded-full/, "rounded underline present");
+});
+
+test("chat-view empty state hint is tagged for touch-device hiding", () => {
+  const src = read("./chat-view.tsx");
+  assert.match(src, /cave-chat-empty-hint/, "hint class applied to {modKey}↵ paragraph");
+});
+
+test("cave-chat.css hides the kb hint on coarse pointers", () => {
+  const src = read("../styles/cave-chat.css");
+  assert.match(
+    src,
+    /@media\s*\(pointer:\s*coarse\)\s*\{[\s\S]*?\.cave-chat-empty-hint\s*\{[\s\S]*?display:\s*none/,
+    "coarse-pointer rule hides .cave-chat-empty-hint",
+  );
+});

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -238,7 +238,7 @@ export function ChatSurface({
         {/* ── Ultra-minimalist header ────────────────────────────────────── */}
         <div className="flex shrink-0 items-center justify-between border-b border-[var(--border-hairline)] px-4">
           {/* Tabs flush left */}
-          <div className="flex items-end gap-0">
+          <div role="tablist" className="flex items-end gap-1">
             {(["conversation", "memory"] as const).map((s) => {
               const labels: Record<string, string> = {
                 conversation: "Chats",
@@ -249,6 +249,8 @@ export function ChatSurface({
                 <button
                   key={s}
                   type="button"
+                  role="tab"
+                  aria-selected={isActive}
                   onClick={() => {
                     setScope(s);
                     if (s === "conversation") {
@@ -256,10 +258,14 @@ export function ChatSurface({
                     }
                   }}
                   className={[
-                    "relative px-2 py-2.5 text-[12px] transition-colors",
+                    "relative px-3 py-2.5 text-[12px] font-medium transition-colors outline-none",
+                    // 2px underline for the active tab + faint underline on
+                    // hover so the affordance is visible before click.
+                    "after:absolute after:bottom-0 after:left-3 after:right-3 after:h-[2px] after:rounded-full after:transition-colors",
                     isActive
-                      ? "text-[var(--text-primary)] after:absolute after:bottom-0 after:left-2 after:right-2 after:h-[1px] after:bg-[var(--text-primary)]"
-                      : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]",
+                      ? "text-[var(--text-primary)] after:bg-[var(--text-primary)]"
+                      : "text-[var(--text-muted)] hover:text-[var(--text-secondary)] after:bg-transparent hover:after:bg-[color-mix(in_oklch,var(--text-muted)_45%,transparent)]",
+                    "focus-visible:ring-2 focus-visible:ring-[var(--ring-focus)] focus-visible:ring-offset-0 rounded-t-sm",
                   ].join(" ")}
                 >
                   {labels[s]}

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -325,7 +325,9 @@ function ChatEmptyState({
         </div>
       )}
 
-      <p className="mt-8 text-[11px] text-[var(--text-muted)]">
+      {/* Keyboard-shortcut hint is desktop-only; touch devices have no Cmd
+       * key and on-screen keyboards send via a separate button. */}
+      <p className="cave-chat-empty-hint mt-8 text-[11px] text-[var(--text-muted)]">
         {modKey}↵ to send
       </p>
     </div>

--- a/src/components/companion-rail.tsx
+++ b/src/components/companion-rail.tsx
@@ -21,6 +21,10 @@ type Props = {
   onCreateFamiliar?: () => void;
   daemonRunning: boolean;
   onTabChange?: (tab: CompanionTab) => void;
+  /** When the main detail panel is already showing a "pick a familiar"
+   * empty state (e.g. the chat surface), set this true so the rail doesn't
+   * render a second redundant CTA. */
+  suppressEmpty?: boolean;
 };
 
 // forwardRef handle is wired in Task 2.3; ref is forwarded to the chatSlot consumer.
@@ -38,6 +42,7 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
       onCreateFamiliar,
       daemonRunning,
       onTabChange,
+      suppressEmpty = false,
     } = props;
     const resolvedFamiliars = useResolvedFamiliars(familiar ? [familiar] : [], { includeArchived: true });
     const resolvedFamiliar = resolvedFamiliars[0];
@@ -49,6 +54,9 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
     }, [activeTab]);
 
     if (!familiar) {
+      // Skip rendering anything when the main panel already prompts for a
+      // familiar — two side-by-side "pick a familiar" CTAs is just noise.
+      if (suppressEmpty) return null;
       return (
         <aside className="companion-rail companion-rail--empty">
           <div className="companion-rail__empty-body">

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1119,6 +1119,9 @@ export function Workspace() {
               onTabChange={setRailTab}
               daemonRunning={daemonRunning}
               onCreateFamiliar={openOnboarding}
+              // Chat surface already shows a "Choose a familiar" CTA in the
+              // detail panel — suppress the rail's duplicate prompt there.
+              suppressEmpty={mode === "chat"}
               chatSlot={
                 <AgentPanel
                   familiar={active}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -497,6 +497,14 @@
   color: var(--accent-presence);
 }
 
+/* The "{modKey}↵ to send" hint is keyboard-only; on touch devices the user
+ * sends via the composer button, not a shortcut. */
+@media (pointer: coarse) {
+  .cave-chat-empty-hint {
+    display: none;
+  }
+}
+
 /* User turn — compact operator input, right-aligned */
 .cave-turn-user,
 .cave-turn-system {


### PR DESCRIPTION
## Summary

Polishes the chat surface across four small gaps:

- **Mobile-aware empty state** — `chat-router` now uses `useIsMobile` to swap copy: "Choose a familiar to start chatting / Open the menu to pick a familiar, or set one up below." on mobile, the existing "from the sidebar selector / left panel" on desktop. The previous copy was confusing on mobile where there is no visible sidebar.
- **Dedupe the agent-rail "No familiar yet" CTA** — `CompanionRail` accepts a new `suppressEmpty` prop; `Workspace` wires `suppressEmpty={mode === "chat"}` so the rail short-circuits when chat-router is already rendering its own "pick a familiar" empty state. Two side-by-side CTAs were just noise.
- **Chats / Memory tab strip** — promoted from plain buttons to a proper WAI-ARIA tablist (`role="tablist"` / `role="tab"` / `aria-selected`). Adds a 2px rounded underline with focus-ring affordance and hover preview.
- **Composer hint on touch** — the "{modKey}↵ to send" hint in the chat-view empty state is keyboard-only. New `.cave-chat-empty-hint` class + `@media (pointer: coarse)` rule hides it on touch devices, where users send via the composer button.

## Test plan

- [x] `node --experimental-strip-types --test src/components/chat-surface-polish.test.ts` — new source-text regression test, 6/6 pass
- [x] Re-ran 9 adjacent suites (chat-surface, chat-router-switching, chat-view, chat-view-polish, companion-rail, companion-rail-persistence, workspace-chat-handoff, workspace-inspector-mount, workspace-agents-landing) — 15/15 pass
- [x] Playwright capture at 375px (iPhone SE), 390px (iPhone 13), 1024px (tablet), 1440px (desktop) — empty-state copy switches correctly at the 1023px breakpoint; agent rail "No familiar yet" pane suppressed on chat mode at all desktop widths; tab underline renders
- [ ] Smoke on a real touch device — confirm the kb hint is gone (caught by `(pointer: coarse)`, not viewport size)

🤖 Generated with [Claude Code](https://claude.com/claude-code)