### PR TITLE
release: 0.0.63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.63] — 2026-06-10
+
+### Changed
+- **Chat surface streamline** — the chat header collapses into a single MetaLine (editable title + `harness · model · repo · duration` meta); streaming/failed/daemon-offline states recolor the line instead of emitting separate pills; task/GitHub chips move to a conditional linked-context row. (#350)
+- **Quiet top bar** — brand mark, Home button, breadcrumb, and gear icon removed; ⌘K search is centered with bell + account button on the right. Sidebar carries identity and nav. (#350)
+- **Thread declutter** — turn numbers, "You" labels, per-turn duration, and tool-count meta removed; the Tool activity disclosure summary and header meta carry those signals. Composer drops its model pill and gains a `↵ to send` placeholder hint. (#350, #351)
+- **Cross-surface error/empty consistency** — Board, Inbox, Chat list, and Library load failures share one banner idiom (icon + message + Retry/dismiss); Library's empty doc list gains icon + title + hint. (#351)
+
+### Fixed
+- **Transcript debug-log leak** — upstream harness lines like `[model-fallback/decision] …` are stripped from assistant messages without touching line-leading markdown links. (#350)
+- **Empty-state send hint** — the chat empty state advertised `⌘↵ to send` while plain Enter sends; it now reads `↵ to send · shift↵ for newline`. (#351)
+- **Onboarding offline attribution** — with the daemon stopped, the binding step now says familiars load once the daemon starts instead of blaming the user's bindings. (#351)
+
 ## [0.0.62] — 2026-06-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.62",
+  "version": "0.0.63",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.62"
+version = "0.0.63"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.62",
+  "version": "0.0.63",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary

Cuts **0.0.63** — the streamline + consistency polish release (#350, #351).

- Bumps `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `Cargo.lock` to 0.0.63
- CHANGELOG entry covering the chat-surface streamline, quiet top bar, thread declutter, cross-surface error/empty consistency, transcript debug-log filter, and onboarding offline attribution

After merge: signed tag `v0.0.63` on the merge commit triggers the release workflow (macOS DMG signed + notarized, Linux AppImage, Windows MSI).

## Test plan

- `pnpm typecheck` / `test:app` (includes app-version consistency check) / `test:api` / `test:mobile` / `pnpm build` all pass
- `src-tauri/release-runtime.test.mjs` passes
- Release commit SSH-signed