### PR TITLE
fix(ci): de-flake DMG notarization check (spctl tee/grep SIGPIPE race)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,7 +289,13 @@ jobs:
             exit 1
           fi
           echo "Verifying $DMG"
-          if ! spctl -a -t open --context context:primary-signature -vv "$DMG" 2>&1 | tee /tmp/spctl.out | grep -q "accepted"; then
+          # Capture first, grep the file after. The previous form piped
+          # spctl through `tee | grep -q`; grep -q exits on first match,
+          # tee dies of SIGPIPE, and pipefail turns a PASSING check into
+          # a failure (raced on the v0.0.63 aarch64 job — the DMG was
+          # accepted + notarized but the step failed).
+          spctl -a -t open --context context:primary-signature -vv "$DMG" > /tmp/spctl.out 2>&1 || true
+          if ! grep -q "accepted" /tmp/spctl.out; then
             echo "::error::DMG is not accepted by Gatekeeper. Output:"
             cat /tmp/spctl.out
             exit 1


### PR DESCRIPTION
## Summary

The v0.0.63 release run (27302274447) failed on the **macOS Apple Silicon** leg even though the DMG was `accepted` with `source=Notarized Developer ID`. The verify step's pipeline raced:

```
spctl … 2>&1 | tee /tmp/spctl.out | grep -q "accepted"
```

`grep -q` exits on first match → `tee` gets SIGPIPE (`tee: stdout: Broken pipe` is visible in the failed log) → `set -o pipefail` fails the pipeline despite a passing Gatekeeper check. The Intel leg passed the identical step — timing luck.

Fix: write spctl output to the file first (`|| true` so the failure branch still reads the captured output), then `grep -q` the file. Deterministic, no pipeline.

The failed leg was rerun as-is (the artifact itself is valid) — this PR prevents future flakes.

## Test plan

- `yaml-lint` passes on the workflow
- Failure semantics preserved: non-accepted output still hits the `::error::` + `exit 1` branch with the full spctl output printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)