### PR TITLE
fix: resolve Tailscale CLI for mobile handoff QR

### DIFF
--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -6,6 +6,8 @@ import {
   createMobileInvite,
   findServeUrl,
   MOBILE_INVITE_TTL_MS,
+  tailscaleBin,
+  tailscaleSpawnEnv,
 } from "@/lib/mobile-handoff";
 
 export const dynamic = "force-dynamic";
@@ -19,8 +21,10 @@ type TailscaleResult = {
 
 function runTailscale(args: string[], timeoutMs = 8000): Promise<TailscaleResult> {
   return new Promise((resolve) => {
-    const child = spawn("tailscale", args, {
+    const bin = tailscaleBin();
+    const child = spawn(bin, args, {
       stdio: ["ignore", "pipe", "pipe"],
+      env: tailscaleSpawnEnv(),
     });
     let stdout = "";
     let stderr = "";
@@ -42,11 +46,14 @@ function runTailscale(args: string[], timeoutMs = 8000): Promise<TailscaleResult
     });
     child.on("error", (error) => {
       clearTimeout(timer);
+      const missing = (error as NodeJS.ErrnoException).code === "ENOENT";
       resolve({
         ok: false,
         status: null,
         stdout: stripAnsi(stdout),
-        stderr: error.message,
+        stderr: missing
+          ? "Tailscale CLI not found. Install Tailscale or set TAILSCALE_BIN to the tailscale executable."
+          : error.message,
       });
     });
     child.on("close", (status) => {

--- a/src/lib/mobile-handoff.test.ts
+++ b/src/lib/mobile-handoff.test.ts
@@ -4,6 +4,7 @@ import {
   buildInviteUrl,
   createMobileInvite,
   findServeUrl,
+  resolveTailscaleBin,
 } from "./mobile-handoff.ts";
 import { verifyMobileAccessToken } from "./mobile-access-token.ts";
 
@@ -31,6 +32,35 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
 {
   const url = findServeUrl(status, "http://127.0.0.1:4242");
   assert.equal(url, null);
+}
+
+{
+  const bin = resolveTailscaleBin({
+    envBin: "/custom/tailscale",
+    pathEnv: "",
+    exists: (candidate) => candidate === "/custom/tailscale",
+    candidatePaths: ["/Applications/Tailscale.app/Contents/MacOS/Tailscale"],
+  });
+  assert.equal(bin, "/custom/tailscale");
+}
+
+{
+  const appBin = "/Applications/Tailscale.app/Contents/MacOS/Tailscale";
+  const bin = resolveTailscaleBin({
+    pathEnv: "/usr/bin:/bin",
+    exists: (candidate) => candidate === appBin,
+    candidatePaths: [appBin, "/usr/local/bin/tailscale"],
+  });
+  assert.equal(bin, appBin);
+}
+
+{
+  const bin = resolveTailscaleBin({
+    pathEnv: "/usr/bin:/bin",
+    exists: () => false,
+    candidatePaths: ["/Applications/Tailscale.app/Contents/MacOS/Tailscale"],
+  });
+  assert.equal(bin, "tailscale");
 }
 
 {

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -96,13 +96,14 @@ export function tailscaleBin() {
 
 export function tailscaleSpawnEnv(): NodeJS.ProcessEnv {
   if (cachedTailscalePath === null) {
+    const delimiter = path.delimiter;
     const fromShell = loginShellPath();
     const parts = [
       TAILSCALE_APP_DIR,
       "/opt/homebrew/bin",
       "/usr/local/bin",
-      ...(fromShell ? fromShell.split(":") : []),
-      ...(process.env.PATH ? process.env.PATH.split(":") : []),
+      ...(fromShell ? fromShell.split(delimiter) : []),
+      ...(process.env.PATH ? process.env.PATH.split(delimiter) : []),
     ];
     const seen = new Set<string>();
     const dedup: string[] = [];
@@ -111,7 +112,8 @@ export function tailscaleSpawnEnv(): NodeJS.ProcessEnv {
       seen.add(p);
       dedup.push(p);
     }
-    cachedTailscalePath = dedup.join(":");
+    const joined = dedup.join(delimiter);
+    cachedTailscalePath = joined || process.env.PATH || "";
   }
 
   return { ...process.env, PATH: cachedTailscalePath };

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -1,3 +1,6 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import path from "node:path";
 import { signMobileAccessToken } from "./mobile-access-token.ts";
 
 export const MOBILE_INVITE_TTL_MS = 10 * 60 * 1000;
@@ -18,6 +21,100 @@ type TailscaleServeStatus = {
 
 function normalizeServeHost(host: string) {
   return host.endsWith(":443") ? host.slice(0, -4) : host;
+}
+
+type ResolveTailscaleBinOptions = {
+  envBin?: string | null;
+  pathEnv?: string | null;
+  exists?: (candidate: string) => boolean;
+  candidatePaths?: string[];
+};
+
+const TAILSCALE_APP_DIR = "/Applications/Tailscale.app/Contents/MacOS";
+const DEFAULT_TAILSCALE_PATHS = [
+  path.join(TAILSCALE_APP_DIR, "tailscale"),
+  path.join(TAILSCALE_APP_DIR, "Tailscale"),
+  "/opt/homebrew/bin/tailscale",
+  "/usr/local/bin/tailscale",
+  "/usr/bin/tailscale",
+  "/bin/tailscale",
+];
+
+let cachedTailscaleBin: string | null = null;
+let cachedTailscalePath: string | null = null;
+
+function executableExists(candidate: string) {
+  try {
+    const st = statSync(candidate);
+    return st.isFile() || st.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+function loginShellPath(): string | null {
+  const env = process.env as Record<string, string | undefined>;
+  const shell = env["SHELL"] ?? ["/bin", "zsh"].join("/");
+  try {
+    const out = execFileSync(shell, ["-ilc", "echo $PATH"], {
+      encoding: "utf-8",
+      timeout: 4000,
+    }).trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+function pathCandidates(pathEnv: string | null | undefined) {
+  if (!pathEnv) return [];
+  return pathEnv
+    .split(":")
+    .filter(Boolean)
+    .map((dir) => path.join(dir, "tailscale"));
+}
+
+export function resolveTailscaleBin({
+  envBin = process.env.TAILSCALE_BIN,
+  pathEnv = process.env.PATH,
+  exists = executableExists,
+  candidatePaths = DEFAULT_TAILSCALE_PATHS,
+}: ResolveTailscaleBinOptions = {}) {
+  if (envBin && exists(envBin)) return envBin;
+
+  for (const candidate of [...candidatePaths, ...pathCandidates(pathEnv)]) {
+    if (exists(candidate)) return candidate;
+  }
+
+  return "tailscale";
+}
+
+export function tailscaleBin() {
+  if (!cachedTailscaleBin) cachedTailscaleBin = resolveTailscaleBin();
+  return cachedTailscaleBin;
+}
+
+export function tailscaleSpawnEnv(): NodeJS.ProcessEnv {
+  if (cachedTailscalePath === null) {
+    const fromShell = loginShellPath();
+    const parts = [
+      TAILSCALE_APP_DIR,
+      "/opt/homebrew/bin",
+      "/usr/local/bin",
+      ...(fromShell ? fromShell.split(":") : []),
+      ...(process.env.PATH ? process.env.PATH.split(":") : []),
+    ];
+    const seen = new Set<string>();
+    const dedup: string[] = [];
+    for (const p of parts) {
+      if (!p || seen.has(p) || !existsSync(p)) continue;
+      seen.add(p);
+      dedup.push(p);
+    }
+    cachedTailscalePath = dedup.join(":");
+  }
+
+  return { ...process.env, PATH: cachedTailscalePath };
 }
 
 export function findServeUrl(status: unknown, backendUrl: string) {

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -69,7 +69,7 @@ function loginShellPath(): string | null {
 function pathCandidates(pathEnv: string | null | undefined) {
   if (!pathEnv) return [];
   return pathEnv
-    .split(":")
+    .split(path.delimiter)
     .filter(Boolean)
     .map((dir) => path.join(dir, "tailscale"));
 }

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -59,8 +59,13 @@ function loginShellPath(): string | null {
     const out = execFileSync(shell, ["-ilc", "echo $PATH"], {
       encoding: "utf-8",
       timeout: 4000,
-    }).trim();
-    return out || null;
+    });
+    const lastLine = out
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .at(-1);
+    return lastLine || null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Problem

The mobile handoff modal showed `spawn tailscale ENOENT` and rendered `No QR` because the packaged/Finder-launched Cave app starts with a minimal macOS PATH that doesn't include Tailscale.

## Fix

Added `resolveTailscaleBin` and `tailscaleSpawnEnv` to `src/lib/mobile-handoff.ts`:

- Checks `TAILSCALE_BIN` env override first
- Then probes known macOS install locations: Tailscale.app bundle, Homebrew arm64/x86, `/usr/local/bin`, `/usr/bin`
- Builds a safe augmented PATH for the spawn environment (login-shell PATH + known dirs)
- Falls back to `"tailscale"` so it still works on Linux or CI where it's on PATH

`src/app/api/mobile-handoff/route.ts` now uses `tailscaleBin()` + `tailscaleSpawnEnv()` instead of hard-coding `"tailscale"`.

Added a clearer missing-CLI error message so the modal no longer shows the raw `ENOENT` exception.

## Verification

- `pnpm test:mobile` ✅ (all 12 tests pass, including new `resolveTailscaleBin` coverage)
- `pnpm typecheck` ✅
- `pnpm test:api` ✅

Co-authored-by: Nova <nova@openclaw.local>