### PR TITLE
fix: keep Cave shell within viewport

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4152,13 +4152,19 @@ select {
 }
 
 /* Dynamic viewport units for layout shell + modals — `100vh` on iOS
-   includes the address bar height, so a `min-height: 100vh` element
-   would push content under the chrome. `100dvh` tracks the visible
-   area, including the on-screen keyboard. */
+   includes the address bar height, so a `100vh` element would push
+   content under the chrome. `100dvh` tracks the visible area, including
+   the on-screen keyboard.
+
+   Anchor the dynamic-viewport height on the OUTER `.shell-frame` so the
+   whole app is exactly the visible viewport tall. The inner `.shell-body`
+   / `.shell-root` must NOT also be 100dvh — they sit below the top bar
+   inside the frame, so a full-viewport height on them would overflow the
+   frame and force the window to scroll. They fill the remaining space via
+   their existing `flex-1 min-h-0`. */
 @supports (height: 100dvh) {
-  .shell-root,
-  .shell-body {
-    min-height: 100dvh;
+  .shell-frame {
+    height: 100dvh;
   }
   .ui-modal-shell {
     max-height: calc(100dvh - 2 * var(--space-4));

--- a/tests/mobile/foundations.spec.ts
+++ b/tests/mobile/foundations.spec.ts
@@ -36,7 +36,29 @@ test.describe("mobile foundations", () => {
     expect(overflow, "no horizontal overflow at 360px viewport").toBeLessThanOrEqual(0);
   });
 
+  test("home route does not create window-level vertical scroll", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+    await page.waitForSelector(".shell-frame");
+
+    const metrics = await page.evaluate(() => {
+      const frame = document.querySelector(".shell-frame");
+      const frameRect = frame?.getBoundingClientRect();
+      return {
+        documentOverflow: document.documentElement.scrollHeight - document.documentElement.clientHeight,
+        bodyOverflow: document.body.scrollHeight - document.body.clientHeight,
+        frameBottom: frameRect?.bottom ?? 0,
+        viewportHeight: window.innerHeight,
+      };
+    });
+
+    expect(metrics.documentOverflow, "document should not be vertically scrollable").toBeLessThanOrEqual(1);
+    expect(metrics.bodyOverflow, "body should not be vertically scrollable").toBeLessThanOrEqual(1);
+    expect(metrics.frameBottom, "app frame should fit the viewport").toBeLessThanOrEqual(metrics.viewportHeight + 1);
+  });
+
   test("mobile drawer toggles render on phone viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 360, height: 720 });
     await page.goto("/");
     // The .top-bar__mobile-toggle class is `display: none` on desktop
     // and `display: inline-flex` under @media (max-width: 767px). At


### PR DESCRIPTION
## Problem

The app shell could still create window-level vertical scroll on desktop. A 1280x720 viewport rendered the document 31px taller than the viewport because `.shell-body` and `.shell-root` were given `min-height: 100dvh` even though they sit below the top bar.

## Fix

- Move the dynamic viewport height anchor to the outer `.shell-frame`
- Let `.shell-body` / `.shell-root` fill remaining space through their existing `flex-1 min-h-0`
- Add a Playwright regression that asserts the document/body are not vertically scrollable and the shell frame fits the viewport
- Make the existing mobile drawer visibility assertion explicitly use a phone viewport so the desktop project can run the foundations file too

## Verification

- Red test before fix: `pnpm exec playwright test tests/mobile/foundations.spec.ts --project=desktop -g "window-level vertical"` failed with document overflow 31px
- Green: `pnpm exec playwright test tests/mobile/foundations.spec.ts --project=desktop -g "window-level vertical"`
- `pnpm exec playwright test tests/mobile/foundations.spec.ts` (12/12 desktop + Pixel 5 + iPhone 13)
- `pnpm typecheck`
- `pnpm test:mobile`
- `pnpm test:app`
- `git diff --check`
- `pnpm build`

Co-authored-by: Nova <nova@openclaw.local>