### PR TITLE
chore(release): cut 0.0.64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.64] — 2026-06-10
+
+### Changed
+- **Chat history recovery states** — missing/error transcript notices now offer Retry and Back to sessions actions, with retry reloading history without a page refresh. (#356)
+- **Knowledge graph readability** — dense graphs now use a faster large-graph layout, suppress noisy labels until hover/selection, and render the graph on the full Library canvas. (#356)
+- **Empty companion rail behavior** — when no familiar is selected, Cave collapses the right companion panel instead of reserving space for an empty rail. (#357)
+
+### Fixed
+- **Packaged mobile handoff QR** — the mobile handoff API now resolves the Tailscale CLI from macOS app/Homebrew/common install paths or `TAILSCALE_BIN`, preventing packaged app `spawn tailscale ENOENT` failures. (#354)
+- **Window-level shell scroll** — the app shell now anchors `100dvh` on the outer frame so the document/body do not become globally scrollable. (#358)
+
 ## [0.0.63] — 2026-06-10
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.63"
+version = "0.0.64"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary

- Bump CovenCave package, Tauri config, Cargo package, and Cargo lock versions to 0.0.64
- Add the 0.0.64 changelog entry covering the mobile handoff QR fix, graph/chat UX polish, empty companion rail collapse, and no-global-scroll shell fix

## Verification

- `node --experimental-strip-types src/lib/app-version.test.ts`
- `node --test scripts/release-notes.test.mjs`
- `scripts/release-notes.sh v0.0.64 v0.0.63`
- `pnpm typecheck`
- `git diff --check`

Co-authored-by: Nova <nova@openclaw.local>