### PR TITLE
[codex] Hide desktop top bar

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -56,6 +56,7 @@ const contracts: RouteContract[] = [
   { route: "/library/doc", methods: ["GET"], kind: "json", pathGuard: true },
   { route: "/library/github", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true },
   { route: "/library/graph", methods: ["GET", "POST"], kind: "json", readsJson: true },
+  { route: "/library/pdf", methods: ["GET"], kind: "json" },
   { route: "/library/reading", methods: ["GET", "POST", "PATCH", "DELETE"], kind: "json", readsJson: true },
   { route: "/library/route-link", methods: ["POST"], kind: "json", readsJson: true },
   { route: "/library", methods: ["GET"], kind: "json" },

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -56,7 +56,7 @@ const contracts: RouteContract[] = [
   { route: "/library/doc", methods: ["GET"], kind: "json", pathGuard: true },
   { route: "/library/github", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true },
   { route: "/library/graph", methods: ["GET", "POST"], kind: "json", readsJson: true },
-  { route: "/library/pdf", methods: ["GET"], kind: "json" },
+  { route: "/library/pdf", methods: ["GET"], kind: "stream" },
   { route: "/library/reading", methods: ["GET", "POST", "PATCH", "DELETE"], kind: "json", readsJson: true },
   { route: "/library/route-link", methods: ["POST"], kind: "json", readsJson: true },
   { route: "/library", methods: ["GET"], kind: "json" },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3234,13 +3234,13 @@ select {
 }
 
 /* ────────────────────────────────────────────────
-   Top bar — quiet command-first frame: centered ⌘K search,
-   right cluster for handoff · bell · account. Sidebar carries
-   brand/identity/nav (no breadcrumb, no Home button).
+   Mobile top bar — drawer controls plus compact search/account actions.
+   Desktop keeps the app chrome headerless; sidebar carries navigation and
+   keyboard shortcuts keep search available.
    ──────────────────────────────────────────────── */
 
 .top-bar {
-  display: grid;
+  display: none;
   grid-template-columns: 1fr minmax(auto, 560px) 1fr;
   align-items: center;
   gap: 12px;
@@ -3950,6 +3950,7 @@ select {
    top edge. */
 @media (max-width: 1023px) {
   .top-bar {
+    display: grid;
     grid-template-columns: 1fr auto 1fr;
     padding: 0 calc(8px + var(--sai-right)) 0 calc(8px + var(--sai-left));
     padding-top: var(--sai-top);

--- a/tests/mobile/foundations.spec.ts
+++ b/tests/mobile/foundations.spec.ts
@@ -6,8 +6,9 @@ import { expect, test } from "@playwright/test";
 //   - viewport meta is set to viewport-fit=cover so env() returns
 //     non-zero on iOS
 //   - the layout doesn't trigger horizontal scrolling at 360px
-//   - the top-bar mobile-toggle is visible (since these viewports
-//     are below the 768px breakpoint, the toggles must render)
+//   - the desktop shell does not render the global top header
+//   - the top-bar mobile-toggle is visible (since mobile viewports
+//     still need drawer controls)
 //
 // Surface-specific specs (chat composer, board card-stack, calendar
 // agenda, hover-tap) belong in their own files; this one is the
@@ -57,12 +58,28 @@ test.describe("mobile foundations", () => {
     expect(metrics.frameBottom, "app frame should fit the viewport").toBeLessThanOrEqual(metrics.viewportHeight + 1);
   });
 
+  test("desktop home route hides the global top header without window scroll", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+
+    await expect(page.locator(".top-bar")).toBeHidden();
+
+    const metrics = await page.evaluate(() => {
+      return {
+        documentOverflow: document.documentElement.scrollHeight - document.documentElement.clientHeight,
+        bodyOverflow: document.body.scrollHeight - document.body.clientHeight,
+      };
+    });
+    expect(metrics.documentOverflow, "document should not be vertically scrollable").toBeLessThanOrEqual(1);
+    expect(metrics.bodyOverflow, "body should not be vertically scrollable").toBeLessThanOrEqual(1);
+  });
+
   test("mobile drawer toggles render on phone viewport", async ({ page }) => {
     await page.setViewportSize({ width: 360, height: 720 });
     await page.goto("/");
-    // The .top-bar__mobile-toggle class is `display: none` on desktop
-    // and `display: inline-flex` under @media (max-width: 767px). At
-    // least one (the nav hamburger) is always wired by workspace.tsx.
+    // The .top-bar__mobile-toggle class is hidden by default and revealed
+    // under the mobile/tablet breakpoint. At least one (the nav hamburger)
+    // is always wired by workspace.tsx.
     const toggles = page.locator(".top-bar__mobile-toggle");
     await expect(toggles.first()).toBeVisible();
   });

--- a/tests/mobile/foundations.spec.ts
+++ b/tests/mobile/foundations.spec.ts
@@ -61,8 +61,11 @@ test.describe("mobile foundations", () => {
   test("desktop home route hides the global top header without window scroll", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
+    await page.waitForSelector(".shell-frame");
 
-    await expect(page.locator(".top-bar")).toBeHidden();
+    const topBar = page.locator(".top-bar");
+    await expect(topBar).toHaveCount(1);
+    await expect(topBar).toBeHidden();
 
     const metrics = await page.evaluate(() => {
       return {


### PR DESCRIPTION
## Summary
- Hide the global `.top-bar` by default so desktop app chrome is headerless.
- Re-enable the top bar only under the existing mobile/tablet breakpoint for drawer controls.
- Add a Playwright regression that checks desktop hides the header and keeps document/body vertical overflow at zero.
- Add the missing `/api/library/pdf` API contract entry from current `main` so CI's API contract suite stays green.

## Why
The desktop shell already gets navigation and search from the sidebar/keyboard shortcuts, and the extra top header consumes vertical room. Removing it prevents the app frame from presenting app-level overflow at the far right while preserving mobile drawer access.

The API contract update is a small follow-up for the latest `main`: CI failed because `/api/library/pdf` existed without a contract entry. The route itself was already present; this PR records its existing GET contract.

## Validation
- `git diff --check`
- `pnpm test:api`
- `pnpm exec playwright test tests/mobile/foundations.spec.ts` — 15/15 passed
- `pnpm run test:app`
- `pnpm run typecheck`
- `pnpm run build`
