### PR TITLE
chore(release): cut 0.0.65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.65] — 2026-06-10
+
+### Added
+- **Library PDF papers** — Library reading items can point at local PDF files, with an inline PDF viewer and a guarded `/api/library/pdf` route for files in `~/.coven/library/papers`.
+- **Understand-Anything graph loading** — Library graph now prefers `.understand-anything/knowledge-graph.json` output, preserving typed node/edge metadata while falling back to the older Graphify output path when needed.
+
+### Changed
+- **Library storage root** — Library data now lives under `~/.coven/library` alongside other Cave state, with `CAVE_LIBRARY_DIR` still available as an override.
+- **Desktop chrome** — desktop Cave runs without the global top header while keeping the mobile/tablet top bar available for drawer controls. (#360)
+
+### Fixed
+- **Browser toolbar visibility** — the desktop browser pane now keeps its back/forward/address toolbar in flow and aligns the native Tauri child webview bounds with the visible pane.
+- **First-message chat continuity** — new chats keep their optimistic in-flight transcript visible while the daemon session id is promoted, instead of briefly replacing it with an unavailable-history state. (#361)
+- **Desktop window scroll** — the desktop shell regression now asserts the hidden top bar does not reintroduce window-level vertical scrolling. (#360)
+
 ## [0.0.64] — 2026-06-10
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.64"
+version = "0.0.65"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.64"
+version = "0.0.65"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- bump CovenCave version metadata to 0.0.65
- add CHANGELOG notes for library PDFs/UA graph loading, library root move, browser/top-bar/chat fixes

## Test Plan
- git diff --check
- pnpm run test:app
- pnpm run test:api
- pnpm run typecheck
- pnpm run build
- cargo check --locked
- bash scripts/release-notes.sh v0.0.65 v0.0.64
