### PR TITLE
fix(home): center home content on viewport at startup

### DIFF
--- a/src/components/home-composer-centering.test.ts
+++ b/src/components/home-composer-centering.test.ts
@@ -2,43 +2,85 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-// ───── Shell exposes panel pixel widths as CSS variables ─────
+// ───── Shell measures the detail panel's real viewport gaps ─────
+//
+// The Home composer centers on the VIEWPORT, not on the asymmetric
+// .shell-detail panel. Two requirements drove the current design (both were
+// real bugs, caught with a Playwright probe at 1512×945):
+//
+//   1. "Centered at start" — the old implementation fed the CSS vars from
+//      react-resizable-panels' onResize callbacks, which land AFTER first
+//      paint. The home content painted ~nav/2 (≈123px) off-center, then slid
+//      into place ~1s later. The Shell must therefore measure synchronously
+//      before paint (useLayoutEffect) so the first painted frame is centered.
+//
+//   2. "Centered, period" — the old vars only carried the nav/agent PANEL
+//      widths, ignoring separators and the right-edge agent-trigger rail
+//      (≈22px), leaving a permanent ~11px bias. The Shell must therefore
+//      expose the detail panel's actual left/right gaps (everything between
+//      the detail box and the viewport edges), not a partial reconstruction.
 const shell = await readFile(new URL("./shell.tsx", import.meta.url), "utf8");
 
 assert.match(
   shell,
-  /const \[navWidthPx, setNavWidthPx\] = useState\(0\);/,
-  "Shell tracks navWidthPx state",
+  /useLayoutEffect/,
+  "Shell measures with useLayoutEffect (before paint, not after)",
 );
 assert.match(
   shell,
-  /const \[agentWidthPx, setAgentWidthPx\] = useState\(0\);/,
-  "Shell tracks agentWidthPx state",
+  /const \[detailGaps, setDetailGaps\] = useState/,
+  "Shell tracks detailGaps state ({ left, right })",
 );
 assert.match(
   shell,
-  /setNavWidthPx\(size\.inPixels \?\? 0\)/,
-  "Nav panel onResize updates navWidthPx via size.inPixels",
+  /getBoundingClientRect\(\)/,
+  "Shell reads the detail element's bounding rect",
 );
 assert.match(
   shell,
-  /setAgentWidthPx\(size\.inPixels \?\? 0\)/,
-  "Agent panel onResize updates agentWidthPx via size.inPixels",
+  /window\.innerWidth - rect\.right/,
+  "right gap derived from viewport width minus detail right edge",
 );
 assert.match(
   shell,
-  /"--shell-nav-px": `\$\{Math\.round\(navWidthPx\)\}px`/,
-  "Shell exposes --shell-nav-px on .shell-frame",
+  /new ResizeObserver\(measure\)/,
+  "Shell keeps gaps fresh with its own ResizeObserver",
 );
 assert.match(
   shell,
-  /"--shell-agent-px": `\$\{Math\.round\(agentWidthPx\)\}px`/,
-  "Shell exposes --shell-agent-px on .shell-frame",
+  /"--shell-left-gap-px": `\$\{detailGaps\.left\}px`/,
+  "Shell exposes --shell-left-gap-px on .shell-frame",
+);
+assert.match(
+  shell,
+  /"--shell-right-gap-px": `\$\{detailGaps\.right\}px`/,
+  "Shell exposes --shell-right-gap-px on .shell-frame",
 );
 assert.match(
   shell,
   /style=\{shellFrameStyle\}/,
   ".shell-frame receives the custom-property style object",
+);
+
+// The old panel-width plumbing must be gone — it was both late (post-paint)
+// and incomplete (panels only, no rails/separators).
+assert.doesNotMatch(shell, /navWidthPx|agentWidthPx/, "old panel-width state removed");
+assert.doesNotMatch(shell, /--shell-nav-px|--shell-agent-px/, "old panel-width vars removed");
+
+// Startup settle gate: the panel library applies its persisted layout one
+// frame after first paint, so the gap correction lands a frame late. The
+// Shell marks the frame [data-settled] only after startup, and the CSS keys
+// the centering transition off that — the startup correction snaps
+// invisibly instead of gliding across the screen on every launch.
+assert.match(
+  shell,
+  /const \[settled, setSettled\] = useState\(false\)/,
+  "Shell tracks startup settled state",
+);
+assert.match(
+  shell,
+  /data-settled=\{settled \? "" : undefined\}/,
+  ".shell-frame exposes [data-settled] after startup",
 );
 
 // ───── Home composer reads the variables and centers on viewport ─────
@@ -47,13 +89,13 @@ const css = await readFile(
   "utf8",
 );
 
-// --hc-asymmetry: abs(nav - agent) — the cards are narrowed by this so the
+// --hc-asymmetry: abs(left - right) — the cards are narrowed by this so the
 // composer can translate all the way to viewport center without overflowing
 // under a side panel.
 assert.match(
   css,
-  /--hc-asymmetry:\s*max\(\s*calc\(var\(--shell-nav-px, 0px\) - var\(--shell-agent-px, 0px\)\),\s*calc\(var\(--shell-agent-px, 0px\) - var\(--shell-nav-px, 0px\)\)\s*\)/,
-  "--hc-asymmetry computed as abs(nav - agent)",
+  /--hc-asymmetry:\s*max\(\s*calc\(var\(--shell-left-gap-px, 0px\) - var\(--shell-right-gap-px, 0px\)\),\s*calc\(var\(--shell-right-gap-px, 0px\) - var\(--shell-left-gap-px, 0px\)\)\s*\)/,
+  "--hc-asymmetry computed as abs(left - right)",
 );
 
 // --hc-max-shift includes the asymmetry/2 term so the clamp upper bound
@@ -64,11 +106,11 @@ assert.match(
   "--hc-max-shift includes asymmetry/2",
 );
 
-// --hc-ideal-shift = (agent - nav) / 2
+// --hc-ideal-shift = (right - left) / 2
 assert.match(
   css,
-  /--hc-ideal-shift:\s*calc\(\s*\(var\(--shell-agent-px, 0px\) - var\(--shell-nav-px, 0px\)\) \/ 2\s*\)/,
-  "--hc-ideal-shift = (agent - nav) / 2",
+  /--hc-ideal-shift:\s*calc\(\s*\(var\(--shell-right-gap-px, 0px\) - var\(--shell-left-gap-px, 0px\)\) \/ 2\s*\)/,
+  "--hc-ideal-shift = (right - left) / 2",
 );
 
 // transform uses clamp(-max, ideal, max) so the shift is bounded.
@@ -76,6 +118,20 @@ assert.match(
   css,
   /transform:\s*translateX\(\s*clamp\(\s*calc\(-1 \* var\(--hc-max-shift\)\),\s*var\(--hc-ideal-shift\),\s*var\(--hc-max-shift\)\s*\)\s*\)/,
   "transform: translateX(clamp(-max, ideal, max))",
+);
+
+// Centering transition only runs after startup has settled.
+const rootRuleMatch = css.match(/\.home-composer-root\s*\{[\s\S]*?\n\}/);
+assert.ok(rootRuleMatch, ".home-composer-root rule must exist");
+assert.match(
+  rootRuleMatch[0],
+  /transition:\s*none/,
+  ".home-composer-root has no transition at startup",
+);
+assert.match(
+  css,
+  /\.shell-frame\[data-settled\] \.home-composer-root\s*\{\s*transition:\s*transform 120ms ease-out;\s*\}/,
+  "centering transition enabled only under .shell-frame[data-settled]",
 );
 
 // Composer card wrap + suggestions use the widened 1200px max-width minus

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useImperativeHandle, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useImperativeHandle, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import type { ForwardedRef } from "react";
 import { forwardRef } from "react";
 import {
@@ -237,11 +237,60 @@ function ShellInner({
     return typeof pct !== "number" || pct > 0;
   });
 
-  // Track rendered pixel widths of the side panels so child surfaces (e.g. the
-  // Home composer) can visually center on the viewport rather than on the
-  // asymmetric .shell-detail panel.
-  const [navWidthPx, setNavWidthPx] = useState(0);
-  const [agentWidthPx, setAgentWidthPx] = useState(0);
+  // Track the detail panel's REAL left/right viewport gaps (side panels +
+  // separators + edge rails — everything between the detail box and the
+  // viewport edges) so child surfaces (e.g. the Home composer) can visually
+  // center on the viewport rather than on the asymmetric .shell-detail panel.
+  //
+  // Measured from the detail element's own rect instead of the panel
+  // onResize callbacks, for two reasons (both were shipped bugs):
+  //   1. onResize lands AFTER first paint, so the home content painted
+  //      ~nav/2 off-center at startup and then slid into place. The
+  //      useLayoutEffect below runs in the same commit that mounts the
+  //      panels, so the first painted frame already has correct gaps.
+  //   2. Panel widths miss the separators and the agent-trigger rail,
+  //      leaving a permanent ~11px centering bias.
+  const detailElRef = useRef<HTMLElement | null>(null);
+  const [detailGaps, setDetailGaps] = useState({ left: 0, right: 0 });
+
+  useLayoutEffect(() => {
+    if (!mounted) return;
+    const el = detailElRef.current;
+    if (!el) return;
+    const measure = () => {
+      const rect = el.getBoundingClientRect();
+      const left = Math.max(0, Math.round(rect.left));
+      const right = Math.max(0, Math.round(window.innerWidth - rect.right));
+      setDetailGaps((prev) =>
+        prev.left === left && prev.right === right ? prev : { left, right },
+      );
+    };
+    measure();
+    // Separator drags and panel collapse/expand resize the detail element;
+    // window resizes that somehow don't (e.g. only chrome around the group
+    // changes) are caught by the window listener.
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    window.addEventListener("resize", measure);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, [mounted, hasBottom, hasAgent, twoPane, isMobile]);
+
+  // The first painted frames can still shift: react-resizable-panels applies
+  // its persisted layout (and Workspace collapses an empty companion rail)
+  // one frame AFTER first paint, so the gap correction above lands a frame
+  // late. Keep centering transitions OFF during that startup window so the
+  // correction snaps invisibly instead of gliding 120ms across the screen;
+  // flip them on once startup has settled (user-initiated toggles still
+  // animate). 250ms is several frames past the observed 1–2 frame settle.
+  const [settled, setSettled] = useState(false);
+  useEffect(() => {
+    if (!mounted) return;
+    const t = window.setTimeout(() => setSettled(true), 250);
+    return () => window.clearTimeout(t);
+  }, [mounted]);
 
   useEffect(() => {
     onNavOpenChange?.(navOpen);
@@ -332,7 +381,6 @@ function ShellInner({
         panelRef={navRef}
         onResize={(size) => {
           setNavOpen((size.asPercentage ?? 0) > 0);
-          setNavWidthPx(size.inPixels ?? 0);
         }}
       >
         <aside className="shell-nav">{nav}</aside>
@@ -356,7 +404,7 @@ function ShellInner({
         </>
       )}
       <Panel id="detail" className="shell-detail-panel">
-        <main className="shell-detail">
+        <main className="shell-detail" ref={detailElRef}>
           <ShellBannerStrip />
           {detail}
         </main>
@@ -375,7 +423,6 @@ function ShellInner({
             panelRef={agentRef}
             onResize={(size) => {
               setAgentOpen((size.asPercentage ?? 0) > 0);
-              setAgentWidthPx(size.inPixels ?? 0);
             }}
           >
             <aside className="shell-agent">{agentOpen ? agent : null}</aside>
@@ -386,19 +433,21 @@ function ShellInner({
   );
 
   const shellFrameStyle: CSSProperties & {
-    "--shell-nav-px": string;
-    "--shell-agent-px": string;
+    "--shell-left-gap-px": string;
+    "--shell-right-gap-px": string;
   } = {
     // Surfaces that need to visually center on the viewport (e.g. Home)
-    // use these to compensate for the asymmetric side-panel widths.
-    "--shell-nav-px": `${Math.round(navWidthPx)}px`,
-    "--shell-agent-px": `${Math.round(agentWidthPx)}px`,
+    // use these to compensate for the asymmetric chrome around the detail
+    // panel (side panels, separators, edge rails).
+    "--shell-left-gap-px": `${detailGaps.left}px`,
+    "--shell-right-gap-px": `${detailGaps.right}px`,
   };
 
   return (
     <div
       className="shell-frame flex h-full w-full flex-col"
       style={shellFrameStyle}
+      data-settled={settled ? "" : undefined}
     >
       {topBar}
       <div className="shell-body flex flex-1 min-h-0">

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -22,13 +22,15 @@
   gap: 16px;
   overflow-y: auto;
   box-sizing: border-box;
-  /* Visually center on the viewport, compensating for the side-panel widths
-   * exposed by the Shell as --shell-nav-px / --shell-agent-px. The asymmetry
-   * (nav present, agent collapsed in home mode) would otherwise push the
-   * composer off to the right.
+  /* Visually center on the viewport, compensating for the chrome around the
+   * detail panel. The Shell measures the detail panel's real left/right
+   * viewport gaps (side panels + separators + edge rails) before first paint
+   * and exposes them as --shell-left-gap-px / --shell-right-gap-px. The
+   * asymmetry (nav present, agent collapsed in home mode) would otherwise
+   * push the composer off to the right.
    *
    * Two coordinated pieces:
-   *   1. --hc-asymmetry — abs(nav - agent), used to narrow the composer
+   *   1. --hc-asymmetry — abs(left - right), used to narrow the composer
    *      cards so there is room to translate them all the way to the
    *      viewport's center without overflowing under a side panel.
    *   2. transform: translateX(clamp(...)) — the actual viewport shift,
@@ -36,8 +38,8 @@
    *      so the card never overflows even if the variables get out of sync.
    */
   --hc-asymmetry: max(
-    calc(var(--shell-nav-px, 0px) - var(--shell-agent-px, 0px)),
-    calc(var(--shell-agent-px, 0px) - var(--shell-nav-px, 0px))
+    calc(var(--shell-left-gap-px, 0px) - var(--shell-right-gap-px, 0px)),
+    calc(var(--shell-right-gap-px, 0px) - var(--shell-left-gap-px, 0px))
   );
   --hc-max-shift: max(
     0px,
@@ -45,7 +47,7 @@
     calc(var(--hc-asymmetry) / 2)
   );
   --hc-ideal-shift: calc(
-    (var(--shell-agent-px, 0px) - var(--shell-nav-px, 0px)) / 2
+    (var(--shell-right-gap-px, 0px) - var(--shell-left-gap-px, 0px)) / 2
   );
   transform: translateX(
     clamp(
@@ -54,6 +56,15 @@
       var(--hc-max-shift)
     )
   );
+  /* No transition during startup — the Shell's gap measurement can be
+   * corrected a frame after first paint (panel library applies persisted
+   * layout late), and animating that correction reads as the whole home
+   * surface sliding into place on every launch. The Shell sets
+   * [data-settled] once startup is done; from then on panel toggles animate. */
+  transition: none;
+}
+
+.shell-frame[data-settled] .home-composer-root {
   transition: transform 120ms ease-out;
 }
 


### PR DESCRIPTION
## Summary

Salvaged orphan from the worktree sweep — committed work with no PR, rebased cleanly onto `main` (post-v0.0.65).

Home content centered on the asymmetric `.shell-detail` panel rather than the viewport at startup. The shell now tracks the detail panel's REAL left/right viewport gaps (side panels + separators + edge rails) and exposes them as custom properties, so child surfaces like the Home composer can visually center on the viewport. Extends the previously-landed `shellFrameStyle` work (`--shell-nav-px`/`--shell-agent-px`) with actual gap measurement.

- `src/components/shell.tsx` — measure and publish viewport gaps (+`useLayoutEffect` wiring)
- `src/styles/home-composer.css` — consume the gap variables for centering
- `src/components/home-composer-centering.test.ts` — assertions extended for the gap-tracking contract

## Test plan

- `home-composer-centering.test.ts` ✅
- `pnpm typecheck` ✅ · `pnpm test:app` ✅ · `pnpm build` ✅ (shell + CSS touched)
- Rebase was conflict-free; commit re-signed

🤖 Generated with [Claude Code](https://claude.com/claude-code)