### PR TITLE
fix: stop identity canon leaking into session titles

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -10,7 +10,10 @@ import {
   recordSessionFamiliar,
   setSessionTitle,
 } from "@/lib/cave-config";
-import { defaultChatTitleForSession } from "@/lib/cave-chat-titles";
+import {
+  chatTitleFromPrompt,
+  defaultChatTitleForSession,
+} from "@/lib/cave-chat-titles";
 import {
   buildPromptWithAttachments,
   normalizeChatAttachments,
@@ -440,7 +443,10 @@ function openClawChatResponse(args: {
           const now = new Date().toISOString();
           const userTurnId = crypto.randomUUID();
           const assistantTurnId = crypto.randomUUID();
-          const chatTitle = existing?.title ?? defaultChatTitleForSession(sessionId);
+          const chatTitle =
+            existing?.title ??
+            chatTitleFromPrompt(args.promptText) ??
+            defaultChatTitleForSession(sessionId);
           if (!existing) await setDefaultSessionTitleIfMissing(sessionId, chatTitle);
           const conv = existing ?? {
             sessionId,
@@ -718,6 +724,14 @@ export async function POST(req: Request) {
             if (ev.session_id && !sessionId) {
               sessionId = ev.session_id;
               push({ kind: "session", sessionId });
+              // Title the session from the user's prompt as soon as the id
+              // exists. The daemon's own title derives from the harness
+              // prompt \u2014 i.e. the identity-canon preamble \u2014 and is what the
+              // UI would otherwise show until the transcript save runs.
+              void setDefaultSessionTitleIfMissing(
+                sessionId,
+                chatTitleFromPrompt(promptText) ?? defaultChatTitleForSession(sessionId),
+              ).catch(() => undefined);
             }
             if (ev.type === "result") {
               result = { duration_ms: ev.duration_ms, is_error: ev.is_error };
@@ -944,7 +958,10 @@ export async function POST(req: Request) {
         const now = new Date().toISOString();
         const userTurnId = crypto.randomUUID();
         const assistantTurnId = crypto.randomUUID();
-        const chatTitle = existing?.title ?? defaultChatTitleForSession(finalSessionId);
+        const chatTitle =
+          existing?.title ??
+          chatTitleFromPrompt(promptText) ??
+          defaultChatTitleForSession(finalSessionId);
         if (!existing) await setDefaultSessionTitleIfMissing(finalSessionId, chatTitle);
         const userTurn: ChatTurn = {
           id: userTurnId,

--- a/src/lib/cave-chat-titles.ts
+++ b/src/lib/cave-chat-titles.ts
@@ -1,3 +1,5 @@
+import { COVEN_IDENTITY_CANON_HEADER } from "./coven-identity-canon.ts";
+
 type SessionLike = {
   id: string;
   title: string;
@@ -17,6 +19,27 @@ export function normalizeChatTitle(input: unknown): string | null {
   const title = input.trim().replace(/\s+/g, " ");
   if (!title) return null;
   return title.slice(0, MAX_CHAT_TITLE_LENGTH);
+}
+
+const MAX_PROMPT_TITLE_LENGTH = 64;
+
+/** Default title for a chat session started from a user prompt: the prompt
+ *  itself, whitespace-collapsed and truncated to a title-sized string. */
+export function chatTitleFromPrompt(prompt: string | null | undefined): string | null {
+  const normalized = normalizeChatTitle(prompt);
+  if (!normalized) return null;
+  if (normalized.length <= MAX_PROMPT_TITLE_LENGTH) return normalized;
+  return `${normalized.slice(0, MAX_PROMPT_TITLE_LENGTH - 1).trimEnd()}\u2026`;
+}
+
+/** Reject harness-derived titles that leaked the identity-canon preamble the
+ *  chat route prepends to every harness prompt. Returns the normalized title,
+ *  or null when the caller should fall back to a default. */
+export function sanitizeSessionTitle(title: string | null | undefined): string | null {
+  const normalized = normalizeChatTitle(title);
+  if (!normalized) return null;
+  if (normalized.startsWith(COVEN_IDENTITY_CANON_HEADER)) return null;
+  return normalized;
 }
 
 export function defaultChatTitleForSession(sessionId: string | null | undefined): string {

--- a/src/lib/coven-identity-canon.ts
+++ b/src/lib/coven-identity-canon.ts
@@ -1,3 +1,7 @@
+/** First line of the canon block. Exposed so title-handling code can detect
+ *  harness-derived session titles that leaked the canon preamble. */
+export const COVEN_IDENTITY_CANON_HEADER = "Coven identity canon:";
+
 export const COVEN_IDENTITY_CANON = [
   "Each familiar has a defined lane, name, and role scoped to the Coven instance it belongs to.",
   "A familiar's identity is set by its own IDENTITY.md, SOUL.md, and role/skill configuration.",
@@ -9,7 +13,7 @@ export function buildCovenIdentityCanonBlock(familiarId?: string): string {
     ? [`Current familiar: ${familiarId.trim()}.`]
     : [];
   return [
-    "Coven identity canon:",
+    COVEN_IDENTITY_CANON_HEADER,
     ...COVEN_IDENTITY_CANON.map((line) => `- ${line}`),
     ...familiarLine,
   ].join("\n");

--- a/src/lib/session-list-merge.ts
+++ b/src/lib/session-list-merge.ts
@@ -1,4 +1,8 @@
 import type { CaveState } from "./cave-config.ts";
+import {
+  defaultChatTitleForSession,
+  sanitizeSessionTitle,
+} from "./cave-chat-titles.ts";
 import { inferOrigin } from "./session-origin.ts";
 import type { SessionRow } from "./types.ts";
 
@@ -24,7 +28,8 @@ function localConversationToSession(
   conv: LocalConversationSummary,
   state: CaveState,
 ): SessionRow {
-  const title = state.sessionTitles[conv.sessionId] ?? conv.title ?? "Chat";
+  const title =
+    state.sessionTitles[conv.sessionId] ?? sanitizeSessionTitle(conv.title) ?? "Chat";
   const familiarId = state.sessionFamiliar[conv.sessionId] ?? conv.familiarId ?? null;
   return {
     id: conv.sessionId,
@@ -73,7 +78,13 @@ export function mergeSessionRows({
     const archived_at = archivedLocal ?? session.archived_at;
     const row: SessionRow = {
       ...session,
-      title: titleOverride ?? session.title,
+      // Daemon titles derive from the harness prompt, which the chat route
+      // prefixes with the identity canon \u2014 sanitize so the preamble never
+      // surfaces as a session title.
+      title:
+        titleOverride ??
+        sanitizeSessionTitle(session.title) ??
+        defaultChatTitleForSession(session.id),
       archived_at,
       familiarId: state.sessionFamiliar[session.id] ?? null,
       origin: inferOrigin(session),

--- a/src/lib/session-title-canon.test.ts
+++ b/src/lib/session-title-canon.test.ts
@@ -1,0 +1,114 @@
+// @ts-nocheck
+// The coven daemon derives session titles from the harness prompt, which the
+// cave chat route prefixes with the identity canon — so untitled sessions
+// showed "Coven identity canon: - Each familiar has a defi…". Two-sided fix:
+// titles default to the user's raw prompt at the source, and canon-prefixed
+// titles are rejected at the display boundary for historical/streaming rows.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import {
+  chatTitleFromPrompt,
+  sanitizeSessionTitle,
+  defaultChatTitleForSession,
+} from "./cave-chat-titles.ts";
+import { mergeSessionRows } from "./session-list-merge.ts";
+import { buildPromptWithCovenIdentityCanon } from "./coven-identity-canon.ts";
+
+// ── chatTitleFromPrompt ──
+assert.equal(
+  chatTitleFromPrompt("Reply with exactly the single word: covenant"),
+  "Reply with exactly the single word: covenant",
+  "short prompts become the title verbatim",
+);
+assert.equal(
+  chatTitleFromPrompt("  line one\nline two  "),
+  "line one line two",
+  "whitespace and newlines collapse",
+);
+const long = "x".repeat(200);
+assert.ok(
+  (chatTitleFromPrompt(long) ?? "").length <= 64,
+  "long prompts truncate to a title-sized string",
+);
+assert.equal(chatTitleFromPrompt("   "), null, "blank prompts yield no title");
+
+// ── sanitizeSessionTitle ──
+const canonPrompt = buildPromptWithCovenIdentityCanon("hello", "nova");
+const leakedTitle = canonPrompt.split("\n").slice(0, 2).join(" ").slice(0, 60);
+assert.equal(
+  sanitizeSessionTitle(leakedTitle),
+  null,
+  "titles that start with the canon header are rejected",
+);
+assert.equal(
+  sanitizeSessionTitle("Fix the parser bug"),
+  "Fix the parser bug",
+  "ordinary titles pass through",
+);
+
+// ── merge layer falls back when the daemon title is canon-leaked ──
+const daemonRow = {
+  id: "abc12345-dead-beef-0000-000000000000",
+  project_root: "",
+  harness: "claude",
+  title: "Coven identity canon: - Each familiar has a defi",
+  status: "completed",
+  exit_code: 0,
+  archived_at: null,
+  created_at: "2026-06-11T00:00:00Z",
+  updated_at: "2026-06-11T00:00:00Z",
+};
+const emptyState = {
+  sessionTitles: {},
+  sessionFamiliar: {},
+  sessionArchived: {},
+  sessionSacrificed: {},
+};
+const rows = mergeSessionRows({
+  daemonSessions: [daemonRow],
+  localConversations: [],
+  state: emptyState,
+  includeArchived: false,
+});
+assert.equal(rows.length, 1);
+assert.ok(
+  !rows[0].title.startsWith("Coven identity canon"),
+  "merged rows must not surface canon-leaked daemon titles",
+);
+assert.equal(
+  rows[0].title,
+  defaultChatTitleForSession(daemonRow.id),
+  "canon-leaked titles fall back to the default session title",
+);
+
+// explicit title overrides still win over sanitization
+const rows2 = mergeSessionRows({
+  daemonSessions: [daemonRow],
+  localConversations: [],
+  state: { ...emptyState, sessionTitles: { [daemonRow.id]: "My chat" } },
+  includeArchived: false,
+});
+assert.equal(rows2[0].title, "My chat", "explicit title overrides still win");
+
+// ── chat/send route titles sessions from the user prompt, early ──
+const route = await readFile(
+  new URL("../app/api/chat/send/route.ts", import.meta.url),
+  "utf8",
+);
+assert.match(
+  route,
+  /chatTitleFromPrompt\(promptText\)/,
+  "chat/send should derive default session titles from the user's raw prompt",
+);
+assert.match(
+  route,
+  /push\(\{ kind: "session", sessionId \}\);[\s\S]{0,500}?setDefaultSessionTitleIfMissing\(/,
+  "the stream path should set the default title when the session id first arrives, not only at save time",
+);
+assert.match(
+  route,
+  /chatTitleFromPrompt\(args\.promptText\)/,
+  "the openclaw path should also title sessions from the user's raw prompt",
+);
+
+console.log("session-title-canon: ok");


### PR DESCRIPTION
## Problem

Chat sessions started from the Cave showed up titled `Coven identity canon: - Each familiar has a defi…`.

The coven daemon derives a session's title from the harness prompt — and `/api/chat/send` prefixes every harness prompt with the identity-canon block (`buildPromptWithCovenIdentityCanon`). The UI surfaces the daemon title whenever no local override exists: for the whole streaming window (the override was only written at transcript-save time), and permanently for sessions whose save never ran. Even on the happy path the override was the generic `New Session <id>`.

## Fix — both boundaries (the daemon's titling itself lives outside this repo)

**Source** — `chatTitleFromPrompt()`: default session titles come from the user's raw prompt (whitespace-collapsed, 64-char cap). Set as soon as the `session` event arrives on the stream — closing the leak window — and again idempotently at transcript save. OpenClaw path included.

**Display** — `sanitizeSessionTitle()`: the session-list merge rejects canon-prefixed titles, so historical leaked sessions fall back to `New Session <id>` instead of the preamble. Explicit user titles still win over sanitization.

## Tests

New `session-title-canon.test.ts` exercises the title helpers and `mergeSessionRows` with real calls (canon-leaked daemon title → fallback; override → wins), plus route contracts (`node --experimental-strip-types src/lib/session-title-canon.test.ts`). Existing `coven-identity-canon`, `session-list-merge`, `cave-chat-titles`, `cave-conversations`, and `api-contracts` tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)