### PR TITLE
fix: sanitize legacy canon-binding session title variant

### DIFF
--- a/src/lib/cave-chat-titles.ts
+++ b/src/lib/cave-chat-titles.ts
@@ -32,13 +32,22 @@ export function chatTitleFromPrompt(prompt: string | null | undefined): string |
   return `${normalized.slice(0, MAX_PROMPT_TITLE_LENGTH - 1).trimEnd()}\u2026`;
 }
 
+// Matches the current header ("Coven identity canon:") and legacy variants
+// with a parenthetical before the colon ("Coven identity canon (binding):"),
+// which ~17 historical sessions still carry. A colon-less title like
+// "Coven identity canon (binding)" is a legitimate human-chosen name and
+// passes through.
+const CANON_TITLE_LEAK_RE = new RegExp(
+  `^${COVEN_IDENTITY_CANON_HEADER.replace(/:$/, "")}\\s*(\\([^)]*\\))?\\s*:`,
+);
+
 /** Reject harness-derived titles that leaked the identity-canon preamble the
  *  chat route prepends to every harness prompt. Returns the normalized title,
  *  or null when the caller should fall back to a default. */
 export function sanitizeSessionTitle(title: string | null | undefined): string | null {
   const normalized = normalizeChatTitle(title);
   if (!normalized) return null;
-  if (normalized.startsWith(COVEN_IDENTITY_CANON_HEADER)) return null;
+  if (CANON_TITLE_LEAK_RE.test(normalized)) return null;
   return normalized;
 }
 

--- a/src/lib/session-title-canon.test.ts
+++ b/src/lib/session-title-canon.test.ts
@@ -45,6 +45,16 @@ assert.equal(
   "Fix the parser bug",
   "ordinary titles pass through",
 );
+assert.equal(
+  sanitizeSessionTitle("Coven identity canon (binding): - Valentina is the arbiter"),
+  null,
+  "legacy '(binding):' preamble variants are rejected too",
+);
+assert.equal(
+  sanitizeSessionTitle("Coven identity canon (binding)"),
+  "Coven identity canon (binding)",
+  "a colon-less canon-themed name is a legitimate human title and passes through",
+);
 
 // ── merge layer falls back when the daemon title is canon-leaked ──
 const daemonRow = {


### PR DESCRIPTION
Follow-up to #371, found by runtime-verifying it against the live session list: the sanitizer matched only the current `Coven identity canon:` header, but 17 historical sessions carry the older `Coven identity canon (binding): - Valentina is t…` preamble variant and still leaked into the session list.

Broadens the match to any canon header with an optional parenthetical before the colon. A colon-less title like `Coven identity canon (binding)` is a legitimate human-chosen session name (one exists, stored as an explicit override) and still passes through.

Tests: `session-title-canon.test.ts` gains both cases (variant rejected / colon-less name kept); existing title and merge tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)