### PR TITLE
fix(inspector): kill aggressive tab flicker on non-Memory tabs

### DIFF
--- a/src/components/inspector-pane-polish.test.ts
+++ b/src/components/inspector-pane-polish.test.ts
@@ -64,3 +64,21 @@ test("inspector empty helper imports IconName for type-safe icon prop", () => {
   assert.match(src, /import \{ Icon, type IconName \} from "@\/lib\/icon"/, "IconName imported");
   assert.match(src, /icon: IconName;/, "InspectorEmpty.icon typed as IconName");
 });
+
+// ── Tab flicker regression ────────────────────────────────────────────────
+// The roving-tabindex sync must be ONE-WAY (tab → activeIndex). The old
+// bidirectional pair oscillated forever on any non-memory tab: activeIndex
+// dragged tab back to memory while tab pushed activeIndex forward, every
+// commit, flickering the pane.
+assert.doesNotMatch(  src,
+  /INSPECTOR_TABS\[activeIndex\][\s\S]{0,120}setTab/,
+  "activeIndex must never drive setTab — that effect pair oscillates on non-memory tabs",
+);
+assert.match(  src,
+  /const tabIndex = INSPECTOR_TABS\.indexOf\(tab\);\s*if \(tabIndex >= 0 && tabIndex !== activeIndex\) setActiveIndex\(tabIndex\)/,
+  "roving tab stop follows the selected tab one-way",
+);
+assert.match(  src,
+  /onFocus=\{\(\) => setTab\(t\)\}/,
+  "selection follows focus so arrow-key roving still switches tabs (ARIA APG)",
+);

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -123,11 +123,13 @@ export function InspectorPane({
     orientation: "horizontal",
   });
 
-  useEffect(() => {
-    const next = INSPECTOR_TABS[activeIndex];
-    if (next && next !== tab) setTab(next);
-  }, [activeIndex, tab]);
-
+  // `tab` is the single source of truth. The roving tab stop follows it
+  // one-way; selection follows focus (onFocus on each tab button, per the
+  // ARIA APG tabs pattern) so arrow-key roving still switches tabs. The
+  // previous BIDIRECTIONAL effect pair (activeIndex → setTab as well)
+  // oscillated forever whenever tab !== memory: each effect saw the other's
+  // stale half and flipped it back every commit, flickering the pane
+  // between Memory and the selected tab.
   useEffect(() => {
     const tabIndex = INSPECTOR_TABS.indexOf(tab);
     if (tabIndex >= 0 && tabIndex !== activeIndex) setActiveIndex(tabIndex);
@@ -174,6 +176,7 @@ export function InspectorPane({
                 aria-selected={isActive}
                 aria-controls={`inspector-panel-${t}`}
                 onClick={() => setTab(t)}
+                onFocus={() => setTab(t)}
                 className={[
                   "relative flex-1 px-3 py-2.5 font-medium tracking-normal transition-colors outline-none",
                   "after:absolute after:bottom-0 after:left-3 after:right-3 after:h-[2px] after:rounded-full after:transition-colors",


### PR DESCRIPTION
## Summary

Selecting any Inspector tab other than Memory made the pane flicker aggressively (screenshot in report: Memory underlined active while Familiar content renders, both underlines lit mid-flap).

**Root cause — a genuine infinite oscillation**: `inspector-pane.tsx` had a *bidirectional* effect pair syncing `useRovingTabIndex`'s `activeIndex` with the `tab` state. Click Familiar → `tab=familiar, activeIndex=0` → effect A forces `tab` back to memory while effect B pushes `activeIndex` to 1 → now crossed the other way → effect A flips `tab` to familiar while effect B resets `activeIndex` to 0 → repeat every commit, forever. Memory (index 0) is the only stable fixed point, which is exactly why only non-Memory tabs flickered.

**Fix**: `tab` is the single source of truth.
- The `activeIndex → setTab` effect is deleted; the roving tab stop follows `tab` one-way (converges in one pass).
- Arrow-key roving still switches tabs via `onFocus={() => setTab(t)}` on each tab button — the ARIA APG selection-follows-focus pattern for tablists (the hook focuses the next tab on ArrowLeft/Right; focus now selects).

## Test plan

- `inspector-pane-polish.test.ts` gains regression asserts: `activeIndex` must never drive `setTab`, one-way sync present, selection-follows-focus present (file already runs under node:test; wired style preserved)
- `inspector-inbox`, `inspector-pane-surface`, `pnpm test:app`, `typecheck`, `build` all pass
- Commit SSH-signed

🤖 Generated with [Claude Code](https://claude.com/claude-code)