### PR TITLE
fix(e2e): un-nest screen-magnification test from library-rail test body

### DIFF
--- a/tests/mobile/foundations.spec.ts
+++ b/tests/mobile/foundations.spec.ts
@@ -158,6 +158,7 @@ test.describe("mobile foundations", () => {
     expect(metrics.doclistHeight, "Document list should stay bounded by the right panel").toBeLessThanOrEqual(metrics.panelHeight + 1);
     expect(metrics.itemsOverflowY, "Document rows should be the inner scroll container").toBe("auto");
     expect(metrics.itemsScrollHeight, "Document rows should have more content than visible space").toBeGreaterThan(metrics.itemsHeight + 1);
+  });
 
   test("persisted screen magnification scales the app without window scroll", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
@@ -186,8 +187,6 @@ test.describe("mobile foundations", () => {
     expect(metrics.documentOverflow, "document should not be vertically scrollable at 125%").toBeLessThanOrEqual(1);
     expect(metrics.bodyOverflow, "body should not be vertically scrollable at 125%").toBeLessThanOrEqual(1);
     expect(metrics.frameBottom, "magnified app frame should still fit the viewport").toBeLessThanOrEqual(metrics.viewportHeight + 1);
-  });
-
   });
 
   test("mobile drawer toggles render on phone viewport", async ({ page }) => {


### PR DESCRIPTION
## Summary

Owning a bug from my own #363 conflict resolution: the union-merge script placed the `persisted screen magnification` test **inside** the `library document rail` test body. Syntactically valid JS — `node --check` passed and the suite isn't in CI — but Playwright rejects nested `test()`, which failed `library-rail` on all three device projects and silently never ran the magnification test at all.

Found by closing the verification gap #363's PR body admitted ("Playwright spec changes are e2e — not run here"): ran the suite from a throwaway worktree against the config's self-started server on :3100.

**Before**: 15 passed, 3 failed (library-rail × desktop/pixel-5/iphone-13).
**After**: **21 passed** — library-rail green everywhere, magnification now actually executing on all three projects.

Two-line structural fix: close the library test before the magnification test opens; remove the stray dangling `});`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)