### PR TITLE
release: 0.0.67

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,25 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
-## [0.0.66] — 2026-06-10
+## [0.0.67] — 2026-06-11
+
+### Added
+- **Chat deletion** — chats can be deleted from the Chats page behind an inline Cancel/Delete confirmation; deletion goes through `DELETE /api/chat/conversation/[id]`, removing the transcript file and sacrificing the session. (#373, follow-up unification)
+- **Session debug panel** — bug button, right-panel Debug tab, and a live event tail for diagnosing a session in place. (#370)
+- **Project-context chat grouping** — the chat list groups conversations by project, with local Coven Cave branch collapsing. (#368, #377)
+- **Memory graph source hubs** — graph mode now renders source-level memories (Coven native, OpenClaw workspace/index, Codex runtime) as standalone hubs instead of silently dropping them; `includeSources: false` preserves the agent-only view. (#369)
+- **Library workflows** — search, URL field, inline status, and error states for the list sections, plus an undo-delete toast. (MF-1/2/3/6, DF-4)
+
+### Changed
+- **First-fetch loading skeletons** — Chat list, Inbox, and Settings Add-ons show row-shaped skeletons until their first fetch settles instead of flashing empty states. (#375)
+- **Send on Enter** — home and dock-chat composers send on plain Enter, matching the chat composer.
+- **Quieter row actions** — Board/GitHub/Agents/Plugins row CTAs shortened to `Start` / `Open`; library timeline sidebar polished; right-panel content scrolls properly.
+
+### Fixed
+- **Inspector tab flicker** — selecting any non-Memory tab oscillated between tabs every frame (bidirectional roving-tabindex sync); the pane is now stable with selection-follows-focus keyboard navigation. (#374)
+- **Identity canon leaking into session titles** — canon-binding text no longer appears as chat titles, legacy variants are sanitized, and prompt-derived titles are dropped from the send route. (#371, #372)
+- **Home-screen chat handoff** — no longer kills the harness and 404s; auto-send deferred past React strict-mode effect replay.
+- **e2e suite repair** — un-nested a Playwright test that silently never ran (15→21 passing across the three device projects). (#376)
 
 ### Added
 - **Runtime demo mode** — demo data for screenshots and simple testing can now be activated with `?demo=1`, from onboarding, or from Settings → General → Startup without editing environment files.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.66",
+  "version": "0.0.67",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.66"
+version = "0.0.67"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.66"
+version = "0.0.67"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.66",
+  "version": "0.0.67",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary

Cuts **0.0.67** — 30 commits since v0.0.66 across chat deletion (+ confirmation UI), the session debug panel, project-context chat grouping, memory-graph source hubs, library workflows, first-fetch loading skeletons, the inspector flicker fix, canon-title sanitization, home-handoff fixes, and the e2e suite repair.

- Bumps `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `Cargo.lock` to 0.0.67
- CHANGELOG entry grouped per Keep-a-Changelog

After merge: signed tag `v0.0.67` on the merge commit triggers the release workflow — first release to run with the #353 spctl de-flake in the tagged tree.

## Test plan

- `pnpm typecheck` / `test:app` (version-consistency check included) / `test:api` / `test:mobile` / `release-runtime.test.mjs` / `pnpm build` all pass
- Release commit SSH-signed

🤖 Generated with [Claude Code](https://claude.com/claude-code)