### PR TITLE
ui(chat): explicit rename button on the chat title

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -227,3 +227,14 @@ assert.match(
   /↵ to send · shift↵ for newline/,
   "Empty-state hint matches actual composer key behavior",
 );
+
+assert.match(
+  source,
+  /aria-label="Rename chat"[\s\S]{0,200}setEditing\(true\)/,
+  "Chat title has an explicit, labeled rename button — click-to-rename alone is not discoverable",
+);
+assert.match(
+  source,
+  /ph:pencil-simple/,
+  "Rename affordance uses the pencil icon",
+);

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -539,17 +539,33 @@ function ChatTitleEditable({
   }
 
   return (
-    <button
-      type="button"
-      className={buttonClassName}
-      title={`${display} — click to rename`}
-      onClick={(e) => {
-        e.stopPropagation();
-        setEditing(true);
-      }}
-    >
-      {display}
-    </button>
+    <span className={headline ? "flex w-full min-w-0 items-center gap-1.5" : "flex min-w-0 flex-1 items-center gap-1"}>
+      <button
+        type="button"
+        className={buttonClassName}
+        title={`${display} — click to rename`}
+        onClick={(e) => {
+          e.stopPropagation();
+          setEditing(true);
+        }}
+      >
+        {display}
+      </button>
+      {/* Explicit rename affordance — the click-to-rename title alone is
+          invisible; the pencil makes renaming discoverable. */}
+      <button
+        type="button"
+        title="Rename chat"
+        aria-label="Rename chat"
+        onClick={(e) => {
+          e.stopPropagation();
+          setEditing(true);
+        }}
+        className="focus-ring grid h-5 w-5 shrink-0 place-items-center rounded text-[var(--text-muted)] opacity-60 transition-all hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] hover:opacity-100"
+      >
+        <Icon name="ph:pencil-simple" width={11} aria-hidden />
+      </button>
+    </span>
   );
 }
 


### PR DESCRIPTION
## Summary

Renaming a chat existed only as click-to-rename on the title text — an invisible affordance. The MetaLine title now carries a small pencil button (`aria-label="Rename chat"`) that opens the same inline edit (Enter saves via `PATCH /api/sessions/:id`, Esc cancels — unchanged plumbing). Title text stays clickable too.

## Test plan

- `chat-view-polish.test.ts` pins the labeled button wired to the edit state + the pencil icon; `test:app` / typecheck / build pass
- **Live-verified**: in an active chat the button renders (1 instance) and clicking it swaps in the `Chat title` input
- Commit SSH-signed

🤖 Generated with [Claude Code](https://claude.com/claude-code)