### PR TITLE
fix(library): reading-list fit + reader width toggle

### DIFF
--- a/src/components/library-doc-preview.tsx
+++ b/src/components/library-doc-preview.tsx
@@ -470,12 +470,19 @@ function stripLeadingTitleHeading(body: string, title: string): string {
 }
 
 const READER_FONT_KEY = "cave:library:reader-font";
+const READER_WIDE_KEY = "cave:library:reader-wide";
 const READER_FONT_SIZES = [15, 17, 19, 21];
 
 function DocDetail({ doc, docNav }: { doc: LibraryDocBody; docNav?: DocNav }) {
   const [readerOpen, setReaderOpen] = useState(false);
 
   const renderBody = stripLeadingTitleHeading(doc.body, doc.title);
+
+  // Reader width — narrow (~68ch measure) or wide (fills the modal).
+  const [readerWide, setReaderWide] = useState(false);
+  useEffect(() => {
+    try { setReaderWide(window.localStorage.getItem(READER_WIDE_KEY) === "true"); } catch { /* private mode */ }
+  }, []);
 
   // Reader font size — persisted, stepped through READER_FONT_SIZES.
   const [readerFont, setReaderFont] = useState(17);
@@ -776,7 +783,7 @@ function DocDetail({ doc, docNav }: { doc: LibraryDocBody; docNav?: DocNav }) {
           aria-label={`Reader: ${doc.title}`}
           tabIndex={-1}
         >
-          <div className="library-reader-modal" style={{ "--reader-font-size": `${readerFont}px` } as CSSProperties}>
+          <div className={readerWide ? "library-reader-modal library-reader-modal--wide" : "library-reader-modal"} style={{ "--reader-font-size": `${readerFont}px` } as CSSProperties}>
             {/* Reader scroll progress bar */}
             <div className="library-scroll-progress">
               <div className="library-scroll-progress-fill" style={{ width: `${readerScrollPct}%` }} />
@@ -849,11 +856,12 @@ function DocDetail({ doc, docNav }: { doc: LibraryDocBody; docNav?: DocNav }) {
                 <button
                   type="button"
                   className="library-reader-iconbtn"
-                  onClick={() => { if (doc.absolutePath) void openUrl(`vscode://file${doc.absolutePath}`, "vscode-file"); }}
-                  title="Open in editor"
-                  aria-label="Open in editor"
+                  onClick={() => setReaderWide((v) => { const next = !v; try { window.localStorage.setItem(READER_WIDE_KEY, String(next)); } catch { /* ignore */ } return next; })}
+                  title={readerWide ? "Narrow reading width" : "Widen reading width"}
+                  aria-label={readerWide ? "Narrow reading width" : "Widen reading width"}
+                  aria-pressed={readerWide}
                 >
-                  <Icon name="ph:code" width={13} />
+                  <Icon name={readerWide ? "ph:arrows-in-simple" : "ph:arrows-out-simple"} width={13} />
                 </button>
                 <button
                   type="button"

--- a/src/components/library-polish.test.ts
+++ b/src/components/library-polish.test.ts
@@ -25,8 +25,8 @@ assert.match(
 );
 assert.match(
   libraryCss,
-  /\.library-reading-title\s*\{[\s\S]*?-webkit-line-clamp:\s*3[\s\S]*?white-space:\s*normal/,
-  "reading titles should wrap and clamp at three visible lines",
+  /\.library-reading-title\s*\{[\s\S]*?-webkit-line-clamp:\s*2[\s\S]*?white-space:\s*normal/,
+  "reading titles should wrap and clamp at two visible lines",
 );
 
 // github — title, repo, savedAt
@@ -61,5 +61,29 @@ const view2 = await readFile(new URL("./library-view.tsx", import.meta.url), "ut
 assert.match(view2, /if \(e\.key !== "\["\) return;/, "library-view must filter keydown events for '['");
 assert.match(view2, /setListPinned\(\(v\) => !v\)/, "library-view must call setListPinned((v) => !v)");
 assert.match(view2, /\["input", "textarea", "select"\]\.includes\(tag\)/, "library-view must skip when focus is in an input");
+
+console.log("library-polish.test.ts: ok");
+
+// ── Reading list fit (narrow panel) ──
+assert.match(
+  reading,
+  /className="board-table library-reading-table"/,
+  "Reading table carries its own class so narrow-container rules can scope to it",
+);
+assert.match(
+  libraryCss,
+  /overflow-wrap: break-word;/,
+  "Reading titles wrap at word boundaries instead of shattering mid-word",
+);
+assert.match(
+  libraryCss,
+  /\.library-list-shell \{\s*container-type: inline-size;/,
+  "List shell is a size container so the table adapts to the panel, not the viewport",
+);
+assert.match(
+  libraryCss,
+  /@container \(max-width: 560px\) \{[\s\S]*?\.library-reading-table th:nth-child\(4\)/,
+  "Narrow panels drop the Type/Progress columns so Title keeps the space",
+);
 
 console.log("library-polish.test.ts: ok");

--- a/src/components/library-reader-polish.test.ts
+++ b/src/components/library-reader-polish.test.ts
@@ -69,6 +69,26 @@ assert.match(
 assert.doesNotMatch(src, /library-reader-footer/, "Reader footer bar is removed");
 assert.doesNotMatch(src, /Exit reader/, "Duplicate Exit-reader affordance is gone (X + Esc + backdrop remain)");
 assert.match(src, /className="library-reader-actions"/, "Header hosts the consolidated action cluster");
+assert.doesNotMatch(
+  src,
+  /library-reader-iconbtn"[\s\S]{0,300}Open in editor/,
+  "Reader cluster has no open-in-editor button (it stays in the inline preview header)",
+);
+assert.match(
+  src,
+  /READER_WIDE_KEY = "cave:library:reader-wide"/,
+  "Reader width preference persists",
+);
+assert.match(
+  src,
+  /aria-pressed=\{readerWide\}[\s\S]{0,200}ph:arrows-(in|out)-simple/,
+  "Width toggle is a labeled pressed-state button",
+);
+assert.match(
+  css,
+  /\.library-reader-modal--wide \{[\s\S]*?max-width: min\(1240px/,
+  "Wide mode grows the modal and unlocks the measure",
+);
 
 // ── P2: prev/next document nav ──
 assert.match(src, /export type DocNav = \{ index: number; total: number; onPrev/, "DocNav contract exported");

--- a/src/components/library-reading-list.tsx
+++ b/src/components/library-reading-list.tsx
@@ -175,8 +175,8 @@ type Props = {
 
 const COLS: { key: SortKey; label: string; width?: string }[] = [
   { key: "title",   label: "Title" },
-  { key: "status",  label: "Status",   width: "110px" },
-  { key: "addedAt", label: "Added",    width: "80px" },
+  { key: "status",  label: "Status",   width: "104px" },
+  { key: "addedAt", label: "Added",    width: "64px" },
 ];
 
 export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
@@ -334,7 +334,7 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
         <div className="library-list-empty">No results for &quot;{query}&quot;.</div>
       ) : (
         <div className="board-table-wrap">
-          <table aria-label="Reading list" className="board-table">
+          <table aria-label="Reading list" className="board-table library-reading-table">
             <thead>
               <tr>
                 {COLS.map((col) => (

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -916,10 +916,12 @@
   max-width: 100%;
   line-height: 1.35;
   overflow: hidden;
-  overflow-wrap: anywhere;
+  /* break-word, not anywhere: only split words that genuinely can't fit,
+     instead of shattering "Confirmation" into "Confirmati on". */
+  overflow-wrap: break-word;
   text-overflow: clip;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 2;
   white-space: normal;
 }
 
@@ -993,7 +995,8 @@ tr:focus-within .library-row-delete {
   white-space: nowrap;
 }
 .library-status-select {
-  min-width: 92px;
+  min-width: 0;
+  max-width: 100%;
   border: 1px solid var(--border-strong);
   color: var(--text-primary);
   cursor: pointer;
@@ -1043,6 +1046,7 @@ tr:focus-within .library-row-delete {
 
 /* ── list shell & header ────────────────────────────────────────── */
 .library-list-shell {
+  container-type: inline-size;
   display: flex;
   flex-direction: column;
   flex: 1;
@@ -2321,5 +2325,59 @@ h3:hover .library-heading-anchor,
   }
   .library-heading--active {
     transition: none;
+  }
+}
+
+
+/* ── Reading table fit ──────────────────────────────────────────────
+   The list panel can be a narrow column; six fixed-width columns were
+   crushing Title into a sliver and overflowing horizontally. In narrow
+   containers the low-value Type and Progress columns drop out, padding
+   tightens, and Title keeps the remaining space. */
+.library-list-shell .board-table-wrap {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in oklch, var(--accent-presence) 22%, transparent) transparent;
+}
+.library-list-shell .board-table-wrap::-webkit-scrollbar { height: 6px; width: 6px; }
+.library-list-shell .board-table-wrap::-webkit-scrollbar-thumb {
+  background: color-mix(in oklch, var(--accent-presence) 22%, transparent);
+  border-radius: 999px;
+}
+
+@container (max-width: 560px) {
+  .library-reading-table th:nth-child(4),
+  .library-reading-table td:nth-child(4),
+  .library-reading-table th:nth-child(5),
+  .library-reading-table td:nth-child(5) {
+    display: none;
+  }
+  .library-reading-table thead th,
+  .library-reading-table tbody td {
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+  .library-reading-table .library-status-select {
+    padding-left: 6px;
+    padding-right: 18px;
+  }
+}
+
+
+/* ── Reader wide mode ───────────────────────────────────────────────
+   Toggled from the header cluster: the modal grows and the prose
+   measure unlocks from 68ch to fill it. */
+.library-reader-modal--wide {
+  max-width: min(1240px, calc(100vw - 64px));
+}
+.library-reader-modal--wide .library-reader-body .cave-md.library-preview-md {
+  max-width: 100%;
+}
+
+/* Ultra-narrow panels: the Added timestamp goes too (Title + Status +
+   delete remain) so the table never scrolls horizontally. */
+@container (max-width: 400px) {
+  .library-reading-table th:nth-child(3),
+  .library-reading-table td:nth-child(3) {
+    display: none;
   }
 }


### PR DESCRIPTION
## Summary

Two library follow-ups, both screenshot-driven:

**Reading list fit** — titles were shattering mid-word ("Confirmati on") and the 6-column table overflowed the narrow list panel into an unstyled horizontal scrollbar.
- `overflow-wrap: anywhere` → `break-word`, clamp 3 → 2 lines: whole-word wrapping.
- The list shell becomes a size container: **≤560px** drops the Type + Progress columns, **≤400px** drops the Added timestamp too — Title keeps the space and the table never scrolls sideways (verified `scrollWidth ≤ clientWidth` at a 271px panel).
- Status select can shrink (`min-width: 0`); Added column trimmed 80→64px; themed thin scrollbar on the table wrap for legitimate overflow.

**Reader view** —
- The **open-in-editor button leaves the reader cluster** (still available in the inline preview header): reading mode is for reading.
- New **width toggle** in its place (persisted in `cave:library:reader-wide`, `aria-pressed`): narrow keeps the 68ch measure; wide grows the modal to `min(1240px, viewport)` and unlocks the prose width. Live: 880px → 1216px, button flips to "Narrow reading width".

## Test plan

- `library-polish.test.ts` pins the table class, word wrapping, container rules (one stale 3-line-clamp assertion updated to the new 2-line contract); `library-reader-polish.test.ts` pins the removed editor button, persisted width key, pressed-state toggle, and wide-mode CSS
- `test:app` / typecheck / build pass; both behaviors live-verified against the real daemon library
- Commits SSH-signed

🤖 Generated with [Claude Code](https://claude.com/claude-code)