### PR TITLE
release: 0.0.68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.68] — 2026-06-11
+
+### Added
+- **Project-aware new chats** — new chat launches can carry an explicit working directory from the home composer, task chat actions, terminal/Comux project lists, and project-scoped chat navigation.
+- **Library reader controls** — document reading gains a deduped title treatment, document navigation affordances, themed scroll styling, and reader width controls. (#380, #383)
+
+### Changed
+- **Chat and project surfaces** — the selected-familiar chat list drops redundant dossier chrome, project rows toggle/select as a full row, the project sidebar stays visible, and chat titles use an explicit rename button. (#379, #382)
+- **Library Projects view** — Projects now owns the full Library canvas, with deduped/disambiguated project rail entries instead of cramped nested content. (#381)
+- **Toolbar consistency** — Calendar uses one Add-event entry point with a uniform compact toolbar row. (#384)
+
+### Fixed
+- **Dev-server HMR and stale PWA state** — the custom dev server forwards non-PTY websocket upgrades to Next.js again, while development unregisters stale service workers and clears old CovenCave PWA caches. (#385)
+- **Terminal bridge recovery** — browser PTY bridge support is restored on main after the release polish wave.
+- **Capabilities and skills restoration** — harness manifests and user Claude skills are visible again in Roles → Skills.
+
 ## [0.0.67] — 2026-06-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.67",
+  "version": "0.0.68",
   "private": true,
   "scripts": {
     "dev": "node --experimental-strip-types server.ts",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.67"
+version = "0.0.68"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.67"
+version = "0.0.68"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.67",
+  "version": "0.0.68",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- bump CovenCave to 0.0.68 across package, Tauri, and Cargo metadata
- add the v0.0.68 CHANGELOG entry for dev HMR/PWA reset, project-aware chat launches, library/reader polish, terminal bridge recovery, and UI fixes

## Verification
- pnpm typecheck
- pnpm test:app
- pnpm test:api
- pnpm build
- bash scripts/release-notes.sh v0.0.68
- git diff --check