### PR TITLE
release: 0.0.69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.69] - 2026-06-11
+
+### Fixed
+- **macOS notarized DMGs** - restores the macOS release lane after the packaged `node-pty` sidecar added unsigned `spawn-helper` Mach-O files. The sidecar bundle now restores executable mode for those helpers, the release signing sweep signs them explicitly, and invalid Apple notarization responses print the notary log instead of falling through to a vague stapler Error 65.
+
+### Notes
+- This is the replacement desktop release for `v0.0.68`; it includes the `v0.0.68` project-aware chat, library reader, dev-server, and terminal bridge changes with the macOS packaging fix applied.
+
 ## [0.0.68] — 2026-06-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "private": true,
   "scripts": {
     "dev": "node --experimental-strip-types server.ts",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.68"
+version = "0.0.69"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.68"
+version = "0.0.69"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- bump CovenCave desktop release metadata to 0.0.69
- add changelog notes marking this as the replacement desktop release for failed macOS v0.0.68 artifacts

## Verification
- pnpm typecheck
- pnpm test:api
- pnpm build
- bash -n scripts/release.sh && bash -n scripts/sidecar-bundle.sh
- bash scripts/release-notes.sh v0.0.69 v0.0.68
- git diff --check