### PR TITLE
fix(release): retry Apple Silicon DMG packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.70] - 2026-06-11
+
+### Fixed
+- **Apple Silicon DMG release packaging** - retries transient `hdiutil create` `Resource busy` failures and detaches stale CovenCave DMG mounts before rebuilding the container, restoring the missing Apple Silicon macOS artifact after `v0.0.69` partially uploaded only the Intel DMG.
+
 ## [0.0.69] - 2026-06-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "private": true,
   "scripts": {
     "dev": "node --experimental-strip-types server.ts",

--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -37,3 +37,15 @@ test("notary rejection stops before stapling and prints the Apple log", () => {
       releaseScript.indexOf('echo "==> Stapling notarization ticket"'),
   );
 });
+
+test("DMG packaging retries transient hdiutil resource-busy failures", () => {
+  assert.match(releaseScript, /create_dmg_with_retry\(\)/);
+  assert.match(releaseScript, /hdiutil detach "\$mount" -force/);
+  assert.match(releaseScript, /Resource busy/);
+  assert.match(releaseScript, /hdiutil create[\s\S]*"\$DMG_PATH"/);
+  assert.match(releaseScript, /create_dmg_with_retry\n\n/);
+  assert(
+    releaseScript.indexOf("create_dmg_with_retry") <
+      releaseScript.indexOf('echo "==> Signing DMG container"'),
+  );
+});

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -104,6 +104,57 @@ run_notary_submit() {
   fi
   rm -f "$output"
 }
+cleanup_dmg_artifacts() {
+  local mount
+
+  rm -f "$DMG_PATH"
+
+  while IFS= read -r mount; do
+    [ -n "$mount" ] || continue
+    echo "    detaching stale DMG mount: $mount"
+    hdiutil detach "$mount" -force >/dev/null 2>&1 || true
+  done < <(
+    hdiutil info 2>/dev/null |
+      awk -v app="$APP_NAME" '$1 == "/dev/disk" { next } $0 ~ "^/Volumes/" app { print $0 }'
+  )
+}
+create_dmg_with_retry() {
+  local attempt
+  local max_attempts=4
+  local output
+  local status
+
+  for attempt in $(seq 1 "$max_attempts"); do
+    output=$(mktemp)
+    cleanup_dmg_artifacts
+    set +e
+    hdiutil create \
+      -volname "${APP_NAME}" \
+      -srcfolder "$DMG_STAGE" \
+      -ov \
+      -format UDZO \
+      "$DMG_PATH" >"$output" 2>&1
+    status=$?
+    set -e
+
+    if [ "$status" -eq 0 ]; then
+      rm -f "$output"
+      return 0
+    fi
+
+    echo "    hdiutil create failed on attempt ${attempt}/${max_attempts}:"
+    cat "$output"
+    if ! grep -qi "Resource busy" "$output" || [ "$attempt" -eq "$max_attempts" ]; then
+      rm -f "$output"
+      return "$status"
+    fi
+
+    rm -f "$output"
+    sleep "$((attempt * 3))"
+  done
+
+  return 1
+}
 
 require_tool pnpm
 require_tool codesign
@@ -211,7 +262,7 @@ DMG_STAGE=$(mktemp -d -t covencave-dmg)
 trap 'rm -rf "$DMG_STAGE"' EXIT
 cp -R "$APP_PATH" "$DMG_STAGE/"
 ln -s /Applications "$DMG_STAGE/Applications"
-hdiutil create -volname "${APP_NAME}" -srcfolder "$DMG_STAGE" -ov -format UDZO "$DMG_PATH" >/dev/null
+create_dmg_with_retry
 
 echo "==> Signing DMG container"
 codesign --force --timestamp \

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.69"
+version = "0.0.70"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.69"
+version = "0.0.70"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- retry macOS DMG creation when `hdiutil create` hits transient `Resource busy`
- detach stale CovenCave DMG mounts before each retry and remove partial DMG output
- cut `v0.0.70` so the release tag includes the patched script and can publish the missing Apple Silicon DMG

## Root Cause
`v0.0.69` Apple Silicon built and signed the app successfully, but failed during DMG packaging with:

```text
hdiutil: create failed - Resource busy
```

The failed runner cleanup also terminated a lingering `diskimages-help` process, so the packaging path needs retry/cleanup around `hdiutil create` instead of a single attempt.

## Verification
- `node --experimental-strip-types scripts/release-macos-signing.test.mjs`
- `node scripts/release-notes.test.mjs`
- `node --experimental-strip-types src/lib/app-version.test.ts`
- `pnpm typecheck`
- `bash -n scripts/release.sh`
- `bash -n scripts/sidecar-bundle.sh`
- `git diff --check`
