### PR TITLE
fix(security): bind dev server to loopback; origin-gate the PTY websocket

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -40,6 +40,29 @@ function isAuthorized(req: IncomingMessage): boolean {
   return auth.startsWith("Bearer ") && auth.slice("Bearer ".length) === ACCESS_TOKEN;
 }
 
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1";
+}
+
+// WebSocket upgrades are not subject to the browser same-origin policy, so a
+// page on any site could open ws://localhost:3000/api/pty-ws (and the browser
+// would attach the access cookie). Reject upgrades whose Origin is neither
+// loopback nor the host this socket was opened on; requests without an Origin
+// header come from non-browser clients, which the bind address and access
+// token already govern.
+function isAllowedUpgradeOrigin(req: IncomingMessage): boolean {
+  const origin = req.headers.origin;
+  if (!origin) return true;
+  let url: URL;
+  try {
+    url = new URL(origin);
+  } catch {
+    return false;
+  }
+  if (isLoopbackHostname(url.hostname)) return true;
+  return url.host === (req.headers.host ?? "");
+}
+
 function defaultShell(): string {
   if (process.platform === "darwin") return "/bin/zsh";
   if (process.platform === "win32") {
@@ -204,7 +227,7 @@ function handlePtyConnection(
 }
 
 const dev = process.env.NODE_ENV !== "production";
-const hostname = process.env.HOSTNAME ?? "0.0.0.0";
+const hostname = process.env.HOSTNAME ?? (dev ? "127.0.0.1" : "0.0.0.0");
 const port = Number.parseInt(process.env.PORT ?? "3000", 10);
 
 const app = next({ dev, hostname, port });
@@ -226,6 +249,12 @@ server.on("upgrade", (req, socket, head) => {
       console.error(`Failed to handle websocket upgrade for ${req.url ?? "unknown url"}`, err);
       socket.destroy();
     });
+    return;
+  }
+
+  if (!isAllowedUpgradeOrigin(req)) {
+    socket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
+    socket.destroy();
     return;
   }
 

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -23,6 +23,26 @@ assert.match(src, /frame\[0\]\s*=\s*0x01/, "server sends output tag 0x01");
 assert.match(src, /frame\[0\]\s*=\s*0x02/, "server sends exit tag 0x02");
 assert.match(src, /tag === 0x03/, "server receives input tag 0x03");
 assert.match(src, /tag === 0x04/, "server receives resize tag 0x04");
+assert.match(
+  src,
+  /HOSTNAME \?\? \(dev \? "127\.0\.0\.1" : "0\.0\.0\.0"\)/,
+  "dev server binds loopback by default; LAN exposure is opt-in via HOSTNAME",
+);
+assert.match(
+  src,
+  /if \(!isAllowedUpgradeOrigin\(req\)\)[\s\S]*?403 Forbidden/,
+  "PTY upgrade rejects cross-site browser origins before spawning a shell",
+);
+assert.match(
+  src,
+  /isAllowedUpgradeOrigin[\s\S]*?if \(!origin\) return true;/,
+  "origin gate permits non-browser clients that send no Origin header",
+);
+assert.match(
+  src,
+  /pathname !== "\/api\/pty-ws"[\s\S]*isAllowedUpgradeOrigin\(req\)[\s\S]*wss\.handleUpgrade/,
+  "origin gate runs on the PTY upgrade path before the websocket is accepted",
+);
 assert.match(packageJson.scripts.postinstall ?? "", /fix-node-pty-spawn-helper\.mjs/, "postinstall repairs node-pty spawn-helper mode");
 assert.equal(
   existsSync(new URL("../scripts/fix-node-pty-spawn-helper.mjs", import.meta.url)),


### PR DESCRIPTION
## What

Two structural hardenings for the dev/sidecar server, which exposes `/api/pty-ws` — a websocket that spawns a real login shell (`/bin/zsh -l`) with caller-chosen cwd:

1. **Loopback bind by default in dev.** `server.ts` bound `0.0.0.0` unconditionally, so a tokenless `pnpm dev` was reachable from the entire LAN — and direct (non-browser) callers sail past the proxy's Host/origin CSRF guards by forging `Host: localhost`. Dev now defaults to `127.0.0.1`; production keeps `0.0.0.0` (mobile handoff needs it and is always token-gated). `HOSTNAME` still overrides either default.

2. **Origin gate on the PTY upgrade.** WebSocket upgrades bypass the browser same-origin policy, so any webpage could open `ws://localhost:3000/api/pty-ws` — and the browser would attach the access cookie, defeating even token-gated setups. The upgrade handler now rejects origins that are neither loopback nor same-host with `403`, before auth runs. Origin-less (non-browser) clients are unaffected; the bundled Tauri app loads `http://127.0.0.1:<port>` (loopback) and mobile-over-Tailscale pages are same-host, so both still pass.

## Verification

- `src/server-pty-ws.test.ts` extended first (TDD), watched fail, then implementation; `pnpm test:api` green, `pnpm typecheck` clean.
- Live on a scratch port: `lsof` shows a `127.0.0.1`-only listener (was `*`); upgrade probes — `Origin: https://evil.example` → `403`, `Origin: http://localhost:3210` → `101`, no Origin → `101`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)