### PR TITLE
fix(test): make reminder-draft expectations timezone-independent

### DIFF
--- a/src/lib/reminder-draft.test.ts
+++ b/src/lib/reminder-draft.test.ts
@@ -4,13 +4,28 @@ import { draftReminderFromText } from "./reminder-draft.ts";
 
 const now = new Date("2026-06-11T14:00:00.000Z");
 
+// parseWhen resolves wall-clock phrases ("10am", "5pm") in the process
+// timezone, so expected instants must be derived the same way — hard-coded
+// UTC strings only hold in the timezone they were written in (this one
+// failed on UTC CI runners after passing in UTC-5).
+const localISO = (dayOffset, hour) =>
+  new Date(now.getFullYear(), now.getMonth(), now.getDate() + dayOffset, hour, 0).toISOString();
+
+// Bare times roll to the next day once passed (parse-when.ts), so the
+// expectation has to apply the same rule.
+const nextLocalISO = (hour) => {
+  const d = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hour, 0);
+  if (d.getTime() <= now.getTime()) d.setDate(d.getDate() + 1);
+  return d.toISOString();
+};
+
 {
   const draft = draftReminderFromText("review PRs @ tomorrow 10am", now);
 
   assert.equal(draft.ok, true);
   assert.equal(draft.title, "review PRs");
   assert.equal(draft.whenText, "tomorrow 10am");
-  assert.equal(draft.fireAt, "2026-06-12T15:00:00.000Z");
+  assert.equal(draft.fireAt, localISO(1, 10));
   assert.deepEqual(draft.recurrence, { type: "none" });
 }
 
@@ -20,7 +35,7 @@ const now = new Date("2026-06-11T14:00:00.000Z");
   assert.equal(draft.ok, true);
   assert.equal(draft.title, "check deploy");
   assert.equal(draft.whenText, "5pm");
-  assert.equal(draft.fireAt, "2026-06-11T22:00:00.000Z");
+  assert.equal(draft.fireAt, nextLocalISO(17));
 }
 
 {


### PR DESCRIPTION
## What

Main is currently red: `0d19640` (committed directly to main, so CI never gated it) hard-codes UTC instants for wall-clock phrases that `parseWhen` resolves in the process timezone. The author's UTC-5 produced `15:00Z` for "tomorrow 10am"; UTC CI runners produce `10:00Z`. Every open PR is blocked on this.

Test-only fix: expected values are derived via local-time `Date` constructors, and the bare-time "5pm" case applies parse-when's roll-to-next-day rule (`parse-when.ts:122`) so the expectation also holds in timezones where 5 PM has already passed at the fixed `now`.

Verified under `America/Chicago`, `UTC`, `Asia/Tokyo`, and `Pacific/Kiritimati` (UTC+14). No change to `reminder-draft.ts` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)