### PR TITLE
fix(chat): don't destroy composer input typed while streaming

### DIFF
--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -126,6 +126,18 @@ assert.match(
 );
 
 assert.match(
+  source,
+  /const send = async \(\) => \{[\s\S]*?intentFromSlash\(text\)[\s\S]*?if \(busy\) return;[\s\S]*?setInput\(""\);[\s\S]*?setAttachments\(\[\]\);[\s\S]*?await sendRaw\(/,
+  "send() must run slash intents first, then bail on busy BEFORE clearing the composer — a mid-stream Enter must not destroy the draft (CHAT-D5-01)",
+);
+
+assert.match(
+  source,
+  /const sendRaw = async [\s\S]*?\|\| busy\) return;/,
+  "sendRaw should keep its own busy guard as the backstop behind send()'s",
+);
+
+assert.match(
   styles,
   /\.cave-chat-meta-line\s*\{[\s\S]*min-height:/,
   "Lifecycle header meta line should have stable dimensions",

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1414,6 +1414,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     const text = input.trim();
     if (!text && attachments.length === 0) return;
     if (attachments.length === 0 && intentFromSlash(text)) return;
+    // CHAT-D5-01: sendRaw early-returns while a response is streaming, so
+    // clearing the composer first would silently destroy the typed message
+    // (and staged attachments). Bail before touching state — slash intents
+    // above still run mid-stream; plain sends keep the draft intact.
+    if (busy) return;
     const outgoingAttachments = attachments.map(({ id: _id, ...attachment }) => attachment);
     setInput("");
     setAttachments([]);


### PR DESCRIPTION
## Summary

Fixes audit finding **CHAT-D5-01** (P1) from the chat UX audit (#395) — live-confirmed data loss: pressing Enter while a response is streaming cleared the composer and the typed message (plus any staged attachments) was silently destroyed. `send()` ran `setInput(""); setAttachments([]);` before `sendRaw`, whose first line early-returns on `busy` — so the send-call count stayed at 1 and the text appeared nowhere.

## Fix (minimum scope)

- `send()` now bails on `busy` **after** the slash-intent branch and **before** clearing the composer:
  - Slash commands (`/clear`, `/help`, …) keep their existing behavior and still execute mid-stream.
  - A plain mid-stream Enter is now a no-op that leaves the draft (text + attachments) intact — the preserved input is the fix; no toast or queue pill added.
- `sendRaw`'s own busy guard is kept as the backstop.
- Queue-while-streaming is deliberately deferred to a separate later work item per the audit's recommendation.

## Tests

- Extended `src/components/chat-view-lifecycle.test.ts` with source-inspection pins: the busy guard sits between the slash-intent branch and the composer-clearing lines, and `sendRaw` retains its backstop guard.

## Verification

- `node --experimental-strip-types src/components/chat-view-lifecycle.test.ts` — ok
- `node --experimental-strip-types src/components/chat-view-polish.test.ts` — ok
- `pnpm test:app` — exit 0, no failures
- `pnpm typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)