### PR TITLE
fix(chat): wire copy buttons in SyntaxBlock and MarkdownBlock

### DIFF
--- a/src/components/message-bubble-code-header.test.ts
+++ b/src/components/message-bubble-code-header.test.ts
@@ -33,3 +33,52 @@ assert.match(
   /\.cave-code-header \.cave-copy-btn[\s\S]*order:\s*3[\s\S]*margin-left:\s*auto/,
   "The copy button should stay at the far edge after the label and traffic lights",
 );
+
+// ---------------------------------------------------------------------------
+// Copy buttons must be WIRED, not just rendered. renderCodeBlock emits the
+// <button class="cave-copy-btn" data-code> markup, but the click handler only
+// attaches via wireCopyButtons after the HTML lands in the DOM. Every
+// component that injects this HTML (MarkdownContent, SyntaxBlock,
+// MarkdownBlock) must run the post-render wiring — otherwise Copy silently
+// does nothing in tool blocks, the inspector pane, comux previews, and the
+// markdown expand modal (audit finding CHAT-D7-01).
+// ---------------------------------------------------------------------------
+
+const source = await readFile(new URL("./message-bubble.tsx", import.meta.url), "utf8");
+
+assert.match(
+  source,
+  /function useWireCopyButtons\([\s\S]*?wireCopyButtons\(containerRef\.current\)/,
+  "A shared post-render hook should wire copy buttons once the injected HTML lands",
+);
+
+const syntaxBlock = /export function SyntaxBlock\([\s\S]*?\n\}/.exec(source)?.[0] ?? "";
+assert.match(
+  syntaxBlock,
+  /useWireCopyButtons\(/,
+  "SyntaxBlock must wire its copy buttons (tool I/O, inspector pane, comux preview)",
+);
+assert.match(
+  syntaxBlock,
+  /ref=\{containerRef\}/,
+  "SyntaxBlock must attach the wiring ref to its dangerouslySetInnerHTML container",
+);
+
+const markdownBlock = /export function MarkdownBlock\([\s\S]*?\n\}/.exec(source)?.[0] ?? "";
+assert.match(
+  markdownBlock,
+  /useWireCopyButtons\(/,
+  "MarkdownBlock must wire its copy buttons (inspector pane, markdown expand modal)",
+);
+assert.match(
+  markdownBlock,
+  /ref=\{containerRef\}/,
+  "MarkdownBlock must attach the wiring ref to its dangerouslySetInnerHTML container",
+);
+
+const markdownContent = /function MarkdownContent\([\s\S]*?\n\}/.exec(source)?.[0] ?? "";
+assert.match(
+  markdownContent,
+  /useWireCopyButtons\(/,
+  "MarkdownContent must keep wiring its copy buttons (chat message bubbles)",
+);

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -199,6 +199,7 @@ type SyntaxBlockProps = {
  */
 export function SyntaxBlock({ text, lang, className }: SyntaxBlockProps) {
   const [html, setHtml] = useState<string | null>(null);
+  const containerRef = useWireCopyButtons(html);
   const resolvedLang = lang ?? autoDetectLang(text);
 
   useEffect(() => {
@@ -220,6 +221,7 @@ export function SyntaxBlock({ text, lang, className }: SyntaxBlockProps) {
 
   return (
     <div
+      ref={containerRef}
       className={`cave-syntax-block text-[12px] ${className ?? ""}`}
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{ __html: html }}
@@ -234,6 +236,7 @@ export function SyntaxBlock({ text, lang, className }: SyntaxBlockProps) {
 
 export function MarkdownBlock({ text, className }: { text: string; className?: string }) {
   const [html, setHtml] = useState<string | null>(null);
+  const containerRef = useWireCopyButtons(html);
 
   useEffect(() => {
     if (!text) return;
@@ -254,6 +257,7 @@ export function MarkdownBlock({ text, className }: { text: string; className?: s
 
   return (
     <div
+      ref={containerRef}
       className={`cave-md ${className ?? ""}`}
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{ __html: html }}
@@ -464,13 +468,28 @@ function wireCopyButtons(container: HTMLElement) {
   }
 }
 
+/**
+ * Shared post-render hook: wires `.cave-copy-btn` clicks inside the container
+ * whenever the injected HTML changes. Every component that injects
+ * renderCodeBlock/mdToHtml output via dangerouslySetInnerHTML must attach the
+ * returned ref, otherwise its Copy buttons render but silently do nothing
+ * (wireCopyButtons is idempotent per button via the `_wired` flag).
+ */
+function useWireCopyButtons(html: string | null) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (html && containerRef.current) wireCopyButtons(containerRef.current);
+  }, [html]);
+  return containerRef;
+}
+
 // ---------------------------------------------------------------------------
 // MarkdownContent — async render; plain fallback while streaming
 // ---------------------------------------------------------------------------
 
 function MarkdownContent({ text, pending }: { text: string; pending?: boolean }) {
   const [html, setHtml] = useState<string | null>(null);
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const containerRef = useWireCopyButtons(html);
 
   useEffect(() => {
     if (pending) {
@@ -490,10 +509,6 @@ function MarkdownContent({ text, pending }: { text: string; pending?: boolean })
       .catch((err) => { console.error("[MarkdownContent] mdToHtml failed", err); });
     return () => { cancelled = true; };
   }, [text, pending]);
-
-  useEffect(() => {
-    if (html && containerRef.current) wireCopyButtons(containerRef.current);
-  }, [html]);
 
   if (!html) {
     return (


### PR DESCRIPTION
## Summary

Fixes audit finding **CHAT-D7-01 (P0)** from the chat UX audit (#395).

`renderCodeBlock` always emits `<button class="cave-copy-btn" data-code>Copy</button>` into its generated HTML, but the click wiring (`wireCopyButtons`) only ran from `MarkdownContent`'s post-render effect. The exported `SyntaxBlock` and `MarkdownBlock` components inject the same HTML and never wired it, so the Copy button rendered but silently did nothing on four surfaces:

- **Tool blocks** — ToolBlock input/output in `chat-view.tsx`
- **Inspector pane** — `inspector-pane.tsx`
- **Comux file preview** — `comux-view.tsx`
- **Markdown expand modal** — `MarkdownExpandModal` rendering via `MarkdownBlock`

## Fix

Extracted the existing containerRef + post-render effect into a shared `useWireCopyButtons(html)` hook in `message-bubble.tsx`, now used by all three injecting components (`MarkdownContent`, `SyntaxBlock`, `MarkdownBlock`). `wireCopyButtons` itself is unchanged (already idempotent via the `_wired` flag); rendered HTML and CSS are untouched. Grep confirms no other component injects `cave-copy-btn` HTML.

## Tests

- Extended `src/components/message-bubble-code-header.test.ts` with source-level assertions pinning that `SyntaxBlock`, `MarkdownBlock`, and `MarkdownContent` all wire copy buttons via the shared hook and attach the ref to their `dangerouslySetInnerHTML` containers.

## Verification

- `node --experimental-strip-types src/components/message-bubble-code-header.test.ts` — pass
- `node --experimental-strip-types src/components/message-bubble-markdown.test.ts` — pass
- `pnpm test:app` — pass (exit 0)
- `pnpm typecheck` — pass (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)