### PR TITLE
fix(chat): message actions always rendered, CSS-revealed — keyboard and touch reachable

### DIFF
--- a/src/components/message-bubble-markdown.test.ts
+++ b/src/components/message-bubble-markdown.test.ts
@@ -39,4 +39,42 @@ assert.match(
   "Rendered tables substitute positionally for the renderer's own <table> output",
 );
 
+// ── CHAT-D6-04: per-message actions must be keyboard/touch reachable ──────
+// The Copy/Expand bubble actions must be mounted unconditionally (when not
+// pending) and revealed by CSS — never mount-gated on a JS `hovered` state,
+// which keeps them out of the DOM (and the accessibility tree) until
+// onMouseEnter fires.
+assert.doesNotMatch(
+  source,
+  /\bhovered\b/,
+  "Bubble actions must not be gated on a JS hovered state — render always, reveal with CSS",
+);
+assert.match(
+  source,
+  /\{!pending && <CopyBubble/,
+  "User-bubble Copy action renders whenever the message is not pending",
+);
+assert.match(
+  source,
+  /\{!pending && content \? \(\s*<div className="cave-bubble-actions">/,
+  "Assistant bubble actions render whenever there is settled content",
+);
+
+const css = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
+assert.match(
+  css,
+  /\.cave-copy-btn:focus-visible \{ opacity: 1; \}/,
+  "Focused action buttons must be visible (focus-visible reveal)",
+);
+assert.match(
+  css,
+  /\.group:focus-within \.cave-copy-btn \{ opacity: 1; \}/,
+  "Tabbing into a bubble's actions must reveal them (focus-within reveal)",
+);
+assert.match(
+  css,
+  /@media \(pointer: coarse\) \{\s*\.cave-copy-btn-bubble \{\s*opacity: 1;/,
+  "Coarse pointers have no hover — bubble actions must be always visible there",
+);
+
 console.log("message-bubble-markdown.test.ts: ok");

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -561,18 +561,15 @@ export type MessageBubbleProps = {
 };
 
 export function MessageBubble({ role, content, timestamp, showTimestamp = true, pending, isError, label }: MessageBubbleProps) {
-  const [hovered, setHovered] = useState(false);
   const [tsVisible, setTsVisible] = useState(false);
   const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleMouseEnter = () => {
-    setHovered(true);
     if (!showTimestamp) {
       hoverTimer.current = setTimeout(() => setTsVisible(true), 600);
     }
   };
   const handleMouseLeave = () => {
-    setHovered(false);
     setTsVisible(false);
     if (hoverTimer.current) clearTimeout(hoverTimer.current);
   };
@@ -610,7 +607,9 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
       >
         <div className="relative cave-bubble-user">
           <MarkdownContent text={content} pending={pending} />
-          {hovered && !pending && <CopyBubble text={content} />}
+          {/* Always in the DOM (CHAT-D6-04) — visibility is CSS-gated so the
+              button is reachable by keyboard (Tab), screen readers, and touch. */}
+          {!pending && <CopyBubble text={content} />}
         </div>
         <div className={`cave-bubble-timestamp cave-bubble-timestamp--right${shouldShowTs ? " cave-bubble-timestamp--visible" : ""}`}>
           {fmtBubbleTime(timestamp)}
@@ -629,7 +628,9 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
       <div className={isError ? "text-[var(--color-warning)]" : ""}>
         <MarkdownContent text={content} pending={pending} />
       </div>
-      {hovered && !pending && content ? (
+      {/* Always in the DOM (CHAT-D6-04) — visibility is CSS-gated so the
+          actions are reachable by keyboard (Tab), screen readers, and touch. */}
+      {!pending && content ? (
         <div className="cave-bubble-actions">
           <ExpandBubble text={content} label={label ?? "Familiar response"} />
           <CopyBubble text={content} />

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -353,6 +353,11 @@
 .cave-code-wrap:hover .cave-copy-btn,
 .group:hover .cave-copy-btn { opacity: 1; }
 
+/* Keyboard reach (CHAT-D6-04): the buttons are always in the DOM; tabbing
+ * into them must reveal them even without a pointer. */
+.cave-code-wrap:focus-within .cave-copy-btn,
+.group:focus-within .cave-copy-btn { opacity: 1; }
+
 .cave-copy-btn--confirmed {
   opacity: 1 !important;
   color: oklch(0.65 0.15 170);
@@ -392,6 +397,14 @@
   position: static;
   top: auto;
   right: auto;
+}
+
+/* Touch devices have no hover (CHAT-D6-04) — keep per-message actions
+ * always visible on coarse pointers. */
+@media (pointer: coarse) {
+  .cave-copy-btn-bubble {
+    opacity: 1;
+  }
 }
 
 /* Icon-only copy/expand button variant — tighter padding */


### PR DESCRIPTION
Fixes audit finding **CHAT-D6-04 (P1)** from the chat UX audit (#395).

## Problem

The per-message action buttons (user-bubble Copy; assistant Expand + Copy) in `src/components/message-bubble.tsx` were mount-gated on a JS `hovered` state — they did not exist in the DOM until `onMouseEnter` fired. That made them unreachable by keyboard (Tab), invisible to screen readers/AT, and unreliable on touch, where hover doesn't exist.

## Fix

Render the actions unconditionally whenever the message is settled (`!pending`, and for assistant bubbles, has content), and gate **visibility** with CSS — mirroring the in-repo code-block copy button idiom (`.cave-copy-btn` at `opacity: 0`).

Reveal rules (`src/styles/cave-chat.css`):
- **Hover:** existing `.group:hover .cave-copy-btn { opacity: 1; }` (unchanged)
- **Keyboard:** new `.group:focus-within .cave-copy-btn` / `.cave-code-wrap:focus-within .cave-copy-btn`, alongside the existing per-button `:focus-visible` reveal
- **Touch:** new `@media (pointer: coarse) { .cave-copy-btn-bubble { opacity: 1; } }` — actions always visible on coarse pointers

The `hovered` state and its sets are removed; the mouse handlers remain because they still drive the timestamp hover-delay (`tsVisible`). CopyBubble/ExpandBubble behavior (what they copy, the expand modal) is untouched — only mounting/visibility changed.

Note on the audit screenshot's right-edge clipping of the user-bubble Copy chip: the chip is absolutely positioned *inside* the bubble (`right: 0.45em` relative to `.cave-bubble-user`), so no positioning change was needed or made here.

## Tests

Extended `src/components/message-bubble-markdown.test.ts` with source-level pins: no JS `hovered` gate, unconditional render expressions, and the CSS `focus-visible` / `focus-within` / coarse-pointer reveal rules.

## Verification

- `node --experimental-strip-types` on `message-bubble-markdown.test.ts`, `message-bubble-code-header.test.ts`, `chat-view-polish.test.ts` — all pass
- `pnpm test:app` — 0 failures
- `pnpm typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)