### PR TITLE
fix(terminal): ship the PTY-bridge server in the sidecar; boot dev:app against the live dev server

### DIFF
--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -100,6 +100,18 @@ echo "==> grafting fresh node_modules → $DEST/node_modules"
 cp -a "$NPM_STAGE/node_modules" "$DEST/node_modules"
 fix_node_pty_spawn_helpers "$DEST/node_modules"
 
+# The standalone tree's server.js is Next's generated entrypoint — it serves
+# the app but has no /api/pty-ws websocket bridge, so the terminal cannot
+# reach a shell through the sidecar. Ship the custom server (server.ts →
+# server.mjs, produced by `pnpm build:server` inside `pnpm build` above);
+# the Tauri launcher prefers server.mjs when present.
+echo "==> shipping custom PTY-bridge server → $DEST/server.mjs"
+if [ ! -f "$ROOT/server.mjs" ]; then
+  echo "ERROR: $ROOT/server.mjs missing after build — build:server should have produced it" >&2
+  exit 1
+fi
+cp "$ROOT/server.mjs" "$DEST/server.mjs"
+
 # But Next.js's compiled server.js requires the standalone's own internal
 # next package layout. Merge any package the standalone shipped that npm
 # didn't reinstall (rare, but cheap to do).

--- a/server.ts
+++ b/server.ts
@@ -1,4 +1,4 @@
-import { statSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { createServer, type IncomingMessage } from "node:http";
 import { createRequire } from "node:module";
 import { parse } from "node:url";
@@ -8,6 +8,24 @@ import { WebSocket, WebSocketServer, type RawData } from "ws";
 
 const require = createRequire(import.meta.url);
 const pty: typeof import("node-pty") = require("node-pty");
+
+// Packaged desktop builds (the Tauri sidecar) run this server from inside the
+// .app bundle, where next.config.ts is not shipped. The standalone build
+// serializes the resolved config into .next/required-server-files.json — hand
+// it to Next the same way the generated standalone server.js does, before
+// next() resolves config.
+if (process.env.COVEN_CAVE_BUNDLE === "1" && !process.env.__NEXT_PRIVATE_STANDALONE_CONFIG) {
+  try {
+    const requiredServerFiles = JSON.parse(
+      readFileSync(new URL(".next/required-server-files.json", import.meta.url), "utf8"),
+    ) as { config?: unknown };
+    if (requiredServerFiles.config) {
+      process.env.__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(requiredServerFiles.config);
+    }
+  } catch {
+    // Not fatal — fall through to Next's normal config resolution.
+  }
+}
 
 const ACCESS_TOKEN = process.env.COVEN_CAVE_ACCESS_TOKEN ?? "";
 const ACCESS_COOKIE = "coven_access_token";

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -381,6 +381,41 @@ fn find_free_port() -> Option<u16> {
         .map(|a| a.port())
 }
 
+/// Dev builds only: the dev-server URL from tauri.conf.json `build.devUrl`,
+/// returned only when something is actually listening on it. Release builds
+/// always get `None` so they can never be pointed away from the bundled
+/// sidecar.
+#[cfg(desktop)]
+fn live_dev_server_url(app: &tauri::App) -> Option<tauri::Url> {
+    if !cfg!(debug_assertions) {
+        return None;
+    }
+    let url = app.config().build.dev_url.clone()?;
+    let host = url.host_str()?.to_string();
+    let port = url.port_or_known_default()?;
+    let reachable = std::net::ToSocketAddrs::to_socket_addrs(&(host.as_str(), port))
+        .ok()
+        .map(|addrs| {
+            addrs.into_iter().any(|addr| {
+                std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(1500)).is_ok()
+            })
+        })
+        .unwrap_or(false);
+    if reachable {
+        log::info!(
+            "[cave] dev server live at {} — using it for the main webview (bundled sidecar skipped)",
+            url
+        );
+        Some(url)
+    } else {
+        log::warn!(
+            "[cave] dev build but {} is not serving — falling back to the bundled sidecar",
+            url
+        );
+        None
+    }
+}
+
 #[cfg(desktop)]
 fn wait_for_port(port: u16, timeout: Duration) -> bool {
     use std::net::TcpStream;
@@ -790,21 +825,41 @@ pub fn run() {
 
             check_app_translocation();
 
+            // Dev builds: when the configured dev server (tauri.conf.json
+            // `build.devUrl` — `pnpm dev`) is live, point the main webview
+            // straight at it and skip the bundled sidecar entirely. The
+            // sidecar bundle only exists after a release build
+            // (scripts/sidecar-bundle.sh), so requiring it here meant a clean
+            // checkout could not boot `pnpm dev:app` at all — and when a
+            // stale bundle did exist, the dev app silently rendered an old
+            // production build instead of live code.
+            let main_url: tauri::Url = if let Some(dev_url) = live_dev_server_url(app) {
+                dev_url
+            } else {
             let resource_dir = match app.path().resource_dir() {
                 Ok(d) => d,
                 Err(e) => fatal_exit(&format!("could not resolve resource dir: {}", e)),
             };
-            let server_js = resource_dir
-                .join("resources")
-                .join("server")
-                .join("server.js");
-
-            if !server_js.exists() {
+            // Prefer the custom server (server.ts → server.mjs): it carries
+            // the /api/pty-ws terminal websocket bridge. server.js is Next's
+            // generated standalone entrypoint, kept as a fallback for old
+            // bundles — it serves the app but has no terminal bridge.
+            let server_dir_root = resource_dir.join("resources").join("server");
+            let server_mjs = server_dir_root.join("server.mjs");
+            let server_js = server_dir_root.join("server.js");
+            let server_entry = if server_mjs.exists() {
+                server_mjs
+            } else if server_js.exists() {
+                log::warn!(
+                    "[cave] bundle has no server.mjs — terminal websocket bridge unavailable in this build"
+                );
+                server_js
+            } else {
                 fatal_exit(&format!(
                     "standalone server not found at {}",
                     server_js.display()
                 ));
-            }
+            };
 
             let port = match find_free_port() {
                 Some(p) => p,
@@ -860,12 +915,12 @@ pub fn run() {
                 .as_ref()
                 .and_then(|f| f.try_clone().ok());
 
-            // Crucially, run from the directory that contains server.js so
-            // Next.js standalone can locate its sibling .next/ and public/.
-            let server_dir = server_js
+            // Crucially, run from the directory that contains the server
+            // entrypoint so Next.js can locate its sibling .next/ and public/.
+            let server_dir = server_entry
                 .parent()
-                .ok_or("server_js has no parent dir")?;
-            let server_js_arg = node_arg_path(&server_js);
+                .ok_or("server entry has no parent dir")?;
+            let server_js_arg = node_arg_path(&server_entry);
             let server_dir_arg = node_arg_path(server_dir);
 
             // GUI launches often inherit a stripped PATH. Prepend the
@@ -956,13 +1011,16 @@ pub fn run() {
                 ));
             }
 
-            let url = format!(
+            format!(
                 "http://127.0.0.1:{}/?covenCaveToken={}&coven_access_token={}",
                 port, auth_token, mobile_access_token
-            );
-            let main_url = url.parse().expect("valid url");
+            )
+            .parse()
+            .expect("valid url")
+            };
+
             pty::trust_main_origin(&main_url);
-            if let Err(e) = WebviewWindowBuilder::new(
+            let mut main_window = WebviewWindowBuilder::new(
                 app,
                 "main",
                 WebviewUrl::External(main_url),
@@ -975,9 +1033,23 @@ pub fn run() {
             // work in the webview — otherwise Tauri's OS-level file-drop
             // handler intercepts dragenter/dragover/drop before the DOM sees
             // them.
-            .disable_drag_drop_handler()
-            .build()
-            {
+            .disable_drag_drop_handler();
+            // Dev-only automation hook: WKWebView has no external driver
+            // protocol, so dev tooling (terminal e2e checks, screenshots)
+            // can inject a script that runs before the page loads. No-op in
+            // release builds.
+            if cfg!(debug_assertions) {
+                if let Ok(script) = std::env::var("COVEN_CAVE_DEV_INIT_SCRIPT") {
+                    if !script.is_empty() {
+                        log::info!(
+                            "[cave] injecting COVEN_CAVE_DEV_INIT_SCRIPT ({} bytes)",
+                            script.len()
+                        );
+                        main_window = main_window.initialization_script(&script);
+                    }
+                }
+            }
+            if let Err(e) = main_window.build() {
                 fatal_exit(&format!("failed to build main window: {}", e));
             }
 

--- a/src/components/bottom-terminal-ws-bridge.test.ts
+++ b/src/components/bottom-terminal-ws-bridge.test.ts
@@ -6,9 +6,9 @@ const src = readFileSync(new URL("./bottom-terminal.tsx", import.meta.url), "utf
 
 assert.match(src, /import \{ PtyWsBridge \} from "@\/lib\/pty-ws-bridge";/, "BottomTerminal imports browser WS bridge");
 assert.doesNotMatch(src, /platform === "browser"[\s\S]{0,120}setUnavailable\(true\)/, "browser mode must not render unavailable placeholder");
-assert.match(src, /platform === "ios" \|\| platform === "android"[\s\S]{0,120}setUnavailable\(true\)/, "mobile native still renders unavailable placeholder");
+assert.doesNotMatch(src, /platform === "ios" \|\| platform === "android"[\s\S]{0,120}setUnavailable\(true\)/, "mobile native must not hard-render the unavailable placeholder — it rides the WS bridge");
 assert.match(src, /if \(platform !== "desktop"\) return;/, "Tauri IPC path remains desktop-only");
-assert.match(src, /if \(platform !== "browser"\) return;/, "WS bridge path is browser-only");
+assert.match(src, /if \(platform !== "browser" && platform !== "ios" && platform !== "android"\) return;/, "WS bridge path covers browser and Tauri-mobile");
 assert.match(src, /bridge\.connect\(threadId,\s*term\.cols,\s*term\.rows,\s*projectRootRef\.current\)/, "WS bridge connects with terminal dimensions and cwd");
 assert.match(src, /bridge\.write\(new TextEncoder\(\)\.encode\(data\)\)/, "terminal input flows to WS bridge");
 assert.match(src, /bridge\.resize\(term\.cols,\s*term\.rows\)/, "terminal resize flows to WS bridge");

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -8,8 +8,9 @@ import { PtyWsBridge } from "@/lib/pty-ws-bridge";
 // portable-pty session on the Rust side (see src-tauri/src/pty.rs).
 //
 // Desktop Tauri uses native pty.* commands. Browser dev/prod uses the
-// WebSocket PTY bridge. Tauri-mobile (iOS, Android) renders a placeholder
-// because the native sandbox cannot spawn a shell.
+// WebSocket PTY bridge (server.ts /api/pty-ws). Tauri-mobile (iOS, Android)
+// cannot spawn a local shell, but its webview points at a remote Cave
+// server — so it rides the same WebSocket bridge and gets a shell there.
 
 // Screen-reader mirror: xterm renders to a <canvas>, which is opaque to AT.
 // We keep an offscreen text mirror of recent PTY output (ANSI stripped) and
@@ -66,14 +67,10 @@ export function BottomTerminal({
   useEffect(() => { projectRootRef.current = projectRoot; }, [projectRoot]);
   const [unavailable, setUnavailable] = useState(false);
   // useTauriPlatform() resolves async and starts at "unknown". Desktop uses
-  // Tauri IPC, browser dev/prod uses the WebSocket PTY bridge, and native
-  // mobile remains unavailable because the sandbox cannot spawn a shell.
+  // Tauri IPC; browser dev/prod AND Tauri-mobile use the WebSocket PTY
+  // bridge — the mobile webview is served by a remote Cave server, and the
+  // bridge opens the shell on that machine.
   const platform = useTauriPlatform();
-  useEffect(() => {
-    if (platform === "ios" || platform === "android") {
-      setUnavailable(true);
-    }
-  }, [platform]);
   // Screen-reader mirror state: see comment block near top of file.
   const [mirrorLines, setMirrorLines] = useState<string[]>([]);
   const pendingMirrorRef = useRef<string>("");
@@ -145,10 +142,8 @@ export function BottomTerminal({
   useEffect(() => {
     const wrap = wrapRef.current;
     if (!wrap) return;
-    // The pty.* Tauri commands are only registered on desktop. Don't
-    // even attempt xterm setup on Tauri-mobile or in the browser —
-    // the dedicated useEffect above sets `unavailable` and the JSX
-    // renders the placeholder instead.
+    // The pty.* Tauri commands are only registered on desktop. Browser and
+    // Tauri-mobile use the WebSocket-bridge effect below instead.
     if (platform !== "desktop") return;
 
     let disposed = false;
@@ -315,7 +310,9 @@ export function BottomTerminal({
   useEffect(() => {
     const wrap = wrapRef.current;
     if (!wrap) return;
-    if (platform !== "browser") return;
+    // Browser and Tauri-mobile both reach the shell through the WebSocket
+    // bridge served by the Cave server the page was loaded from.
+    if (platform !== "browser" && platform !== "ios" && platform !== "android") return;
 
     let disposed = false;
     let cleanup: (() => void) | null = null;

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -50,4 +50,30 @@ assert.equal(
   "node-pty spawn-helper repair script exists",
 );
 
+// Packaged desktop app: the sidecar must run THIS server (built to
+// server.mjs), not Next's generated standalone server.js — the generated
+// entrypoint has no /api/pty-ws bridge, so the terminal websocket hangs.
+assert.match(
+  src,
+  /COVEN_CAVE_BUNDLE[\s\S]*?__NEXT_PRIVATE_STANDALONE_CONFIG[\s\S]*?required-server-files\.json/,
+  "bundle mode hands Next the standalone config (next.config.ts is not shipped in the .app)",
+);
+const sidecarBundle = readFileSync(new URL("../scripts/sidecar-bundle.sh", import.meta.url), "utf8");
+assert.match(
+  sidecarBundle,
+  /cp "\$ROOT\/server\.mjs" "\$DEST\/server\.mjs"/,
+  "sidecar bundle ships the custom PTY-bridge server next to the standalone tree",
+);
+const tauriLib = readFileSync(new URL("../src-tauri/src/lib.rs", import.meta.url), "utf8");
+assert.match(
+  tauriLib,
+  /server_mjs\.exists\(\)[\s\S]{0,400}server_js\.exists\(\)/,
+  "Tauri sidecar launcher prefers server.mjs over the bridge-less standalone server.js",
+);
+assert.match(
+  tauriLib,
+  /live_dev_server_url/,
+  "dev builds boot against the live dev server instead of requiring a sidecar bundle",
+);
+
 console.log("server-pty-ws.test.ts OK");


### PR DESCRIPTION
## What was broken

The terminal had three independent failures, found by probing each layer live:

1. **Packaged app shipped the wrong server.** `sidecar-bundle.sh` shipped Next's auto-generated standalone `server.js`, which has **no `/api/pty-ws` websocket bridge** — the custom `server.ts` (built to `server.mjs` by `pnpm build:server`) was never copied into the bundle, and the Tauri launcher ran `server.js`. Any terminal connection through the sidecar (browser localhost against the installed app, mobile handoff) hung forever on the websocket upgrade. Reproduced against the installed `/Applications/CovenCave.app` bundle: the upgrade never completes.

2. **`pnpm dev:app` could not boot on a clean checkout.** `lib.rs` unconditionally required the gitignored sidecar bundle even in dev (`devUrl` was never used), fatal-exiting with `standalone server not found` before opening a window. When a stale bundle did exist, the dev app silently rendered an old production build instead of live code.

3. **Tauri-mobile hard-rendered the "not available" placeholder**, even though its webview is served by a remote Cave server that can host the shell.

## The fix

- `scripts/sidecar-bundle.sh` ships `server.mjs` next to the standalone tree; the Tauri launcher prefers it (falls back to `server.js` for old bundles, with a warning).
- `server.ts` hands Next the standalone config from `.next/required-server-files.json` when running inside the bundle (`COVEN_CAVE_BUNDLE=1`) — `next.config.ts` is not shipped in the .app; this is the same mechanism the generated standalone server uses (`__NEXT_PRIVATE_STANDALONE_CONFIG`).
- `lib.rs` dev builds: if the configured `devUrl` (`pnpm dev`) is live, the main webview points straight at it and the sidecar is skipped — `pnpm dev:app` now boots from a clean checkout with live HMR code. Release builds are unchanged (`live_dev_server_url` is hard-`None` outside `debug_assertions`). A dev-only `COVEN_CAVE_DEV_INIT_SCRIPT` hook enables webview automation (WKWebView has no driver protocol); no-op in release.
- `bottom-terminal.tsx`: iOS/Android ride the same WebSocket bridge as the browser (shell opens on the machine serving the webview). PTY IPC origin trust and the #391 origin gate hold for all paths (loopback webview origin, same-host ts.net origin).

The big `lib.rs` sidecar block is intentionally left at its original indentation inside the new `else` — keeps the diff reviewable instead of a 150-line re-indent.

## Verification (all live, not just smoke tests)

- **Bundle**: rebuilt with the new script, booted via the bundled node exactly as the launcher does (`HOSTNAME=127.0.0.1 NODE_ENV=production COVEN_CAVE_BUNDLE=1` + tokens): app page serves (200), auth gate intact (401 unauthenticated), and a raw websocket probe round-trips `PTY_OK_42` through `/api/pty-ws`.
- **Dev desktop**: `pnpm dev:app` boots sidecar-less against the worktree dev server; a seeded terminal session drove `pty_start` over webview IPC → `/bin/zsh -l` spawned as a live child of the app with `pty:data` streaming back.
- **Browser UI**: Playwright drove the Terminal surface end-to-end — typed `echo BROWSER_OK_$((40+2))` into xterm, `BROWSER_OK_42` rendered back in the UI.
- `pnpm test:app`, `test:api`, `test:mobile` all pass; `cargo check` clean; `tsc --noEmit` clean.

Smoke tests now pin all of this: bundle ships `server.mjs`, launcher prefers it, bundle-mode config bootstrap exists, dev builds use the live dev server, and mobile is not hard-gated off the WS bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)