### PR TITLE
fix(chat): slash menu runs highlighted command; Esc dismisses; unknown commands surface feedback

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -238,3 +238,51 @@ assert.match(
   /ph:pencil-simple/,
   "Rename affordance uses the pencil icon",
 );
+
+// — CHAT-D2-01: slash menu keyboard contract ("↵ run · Tab complete · esc cancel") —
+const composerKey = source.match(/const onComposerKey = [\s\S]*?\n  \};/)?.[0] ?? "";
+const slashBranch = composerKey.match(/if \(slashSuggestions\.length > 0\) \{[\s\S]*?\n    \}/)?.[0] ?? "";
+
+assert.match(
+  slashBranch,
+  /if \(e\.key === "Enter" && !e\.shiftKey\) \{[\s\S]*slashSuggestions\[slashIdx\][\s\S]*intentFromSlash\(cmd\.name\)/,
+  "Slash-menu Enter must run the highlighted suggestion, not send the partially typed text",
+);
+assert.match(
+  slashBranch,
+  /cmd\.argPlaceholder && canonicalize\(input\.trim\(\)\) !== cmd\.name[\s\S]*setInput\(cmd\.name \+ " "\)/,
+  "Slash-menu Enter autocompletes argument-taking commands (like Tab) instead of running them bare",
+);
+assert.match(
+  slashBranch,
+  /if \(e\.key === "Escape"\) \{[\s\S]*setSlashDismissed\(true\)/,
+  "Esc with the slash menu open must dismiss the menu",
+);
+assert.ok(
+  composerKey.includes("setSlashDismissed(true)") &&
+    composerKey.indexOf("setSlashDismissed(true)") < composerKey.indexOf("cancelSend()"),
+  "Esc precedence: dismiss the slash menu before the busy-cancel branch can kill the stream",
+);
+assert.match(
+  source,
+  /setSlashIdx\(0\);\s*\n\s*setSlashDismissed\(false\);/,
+  "Editing the input must re-arm dismissed slash suggestions",
+);
+assert.match(
+  source,
+  /\{keys\.up\}\{keys\.down\} navigate · \{keys\.enter\} run · Tab complete · esc cancel/,
+  "Slash menu footer promises run/complete/cancel — keep it in sync with onComposerKey",
+);
+
+const workspaceSource = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+const slashHelper = workspaceSource.match(/const handleSlashIntent = [\s\S]*?\n  \};/)?.[0] ?? "";
+assert.match(
+  slashHelper,
+  /\n    return false;\n  \};$/,
+  "Workspace slash helper must return false for unknown commands so chat-view's Unknown-command feedback is reachable",
+);
+assert.equal(
+  (workspaceSource.match(/onSlashFromChat=\{handleSlashIntent\}/g) ?? []).length,
+  2,
+  "Both onSlashFromChat sites must report unhandled slash commands honestly (no unconditional return-true wrappers)",
+);

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -981,12 +981,15 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       : 0;
 
   // Slash suggestions
-  const slashSuggestions: SlashCommand[] = useMemo(() => {
+  const slashMatches: SlashCommand[] = useMemo(() => {
     const firstWord = input.trimStart().split(/\s/)[0] ?? "";
     if (!firstWord.startsWith("/") || input.trimStart().includes(" ")) return [];
     return matchSlash(firstWord);
   }, [input]);
   const [slashIdx, setSlashIdx] = useState(0);
+  // Esc hides the menu for the current input; any edit brings it back.
+  const [slashDismissed, setSlashDismissed] = useState(false);
+  const slashSuggestions: SlashCommand[] = slashDismissed ? [] : slashMatches;
   const activeLifecycle = useMemo(() => {
     const activeTurn = [...turns].reverse().find((turn) => turn.role === "assistant" && turn.pending);
     return activeTurn?.lifecycle ?? (busy ? "connecting" : null);
@@ -994,6 +997,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
 
   useEffect(() => {
     setSlashIdx(0);
+    setSlashDismissed(false);
   }, [input]);
 
   useEffect(() => {
@@ -1625,6 +1629,27 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         e.preventDefault();
         const cmd = slashSuggestions[slashIdx];
         if (cmd) setInput(cmd.name + (cmd.argPlaceholder ? " " : ""));
+        return;
+      }
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        const cmd = slashSuggestions[slashIdx];
+        // If the highlighted command takes an argument and the input isn't
+        // the exact command yet, autocomplete first (like Tab) so the user
+        // can fill in args; otherwise run the highlighted suggestion — not
+        // the partially typed text. Mirrors home-composer.
+        if (cmd && cmd.argPlaceholder && canonicalize(input.trim()) !== cmd.name) {
+          setInput(cmd.name + " ");
+        } else if (cmd) {
+          intentFromSlash(cmd.name);
+        }
+        return;
+      }
+      // Esc precedence: an open slash menu consumes Esc (dismiss) before
+      // the busy branch below gets a chance to cancel the stream.
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setSlashDismissed(true);
         return;
       }
     }

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -746,103 +746,110 @@ export function Workspace() {
       return;
     }
     if (intent.kind === "slash") {
-      // Map slash commands directly to local actions
-      switch (intent.command) {
-        case "/new":
-          startAgentChat(activeId);
-          return;
-        case "/board":
-          setMode("board");
-          return;
-        case "/chats":
-        case "/agents":
-        case "/chat":
-          showAgentChatList();
-          return;
-        case "/inbox":
-          setMode("inbox");
-          return;
-        case "/remind": {
-          const args = (intent.args ?? "").trim();
-          const { title, whenText } = args
-            ? draftFromSlashArgs(args)
-            : { title: "", whenText: "" };
-          openReminderModal(title, whenText);
-          return;
-        }
-        case "/palette":
-          setPaletteOpen(true);
-          return;
-        case "/terminal":
-          setMode("terminal");
-          return;
-        case "/projects":
-          setMode("library");
-          window.location.hash = "library:projects";
-          return;
-        case "/library":
-          setMode("library");
-          return;
-        case "/toggle-agent":
-          toggleAgentPanel();
-          return;
-        case "/quit":
-          showAgentChatList();
-          return;
-        case "/sessions":
-          setMode("chat");
-          showAgentChatList();
-          return;
-        case "/familiar": {
-          const name = (intent.args ?? "").trim().toLowerCase();
-          if (name) {
-            const match = familiars.find(
-              (f) => f.id === name || f.display_name.toLowerCase() === name,
-            );
-            if (match) {
-              setActiveId(match.id);
-              showAgentChatList();
-              return;
-            }
-          }
-          setPaletteOpen(true);
-          return;
-        }
-        case "/attach": {
-          const sid = (intent.args ?? "").trim();
-          if (!sid) {
-            setPaletteOpen(true);
-            return;
-          }
-          // Find which familiar this session belongs to so we surface the right rail row
-          const target = sessions.find((s) => s.id === sid);
-          openAgentSession(sid, target?.familiarId);
-          return;
-        }
-        case "/tui": {
-          const sid = routerRef.current?.currentSessionId();
-          if (sid) {
-            void fetch("/api/launch", {
-              method: "POST",
-              headers: { "content-type": "application/json" },
-              body: JSON.stringify({ mode: "attach", sessionId: sid }),
-            });
-          }
-          return;
-        }
-        case "/clear":
-          routerRef.current?.clearTranscript();
-          return;
-        case "/help":
-        case "/familiar":
-        case "/run":
-        case "/codex":
-        case "/claude":
-          // These need composer context; route to the chat view's slash handler.
-          routerRef.current?.runSlash(intent.command);
-          return;
-      }
+      handleSlashIntent(intent.command, intent.args);
+      return;
     }
+  };
+
+  // Map slash commands directly to local actions. Returns false for commands
+  // this surface doesn't know so the chat composer can show its
+  // "Unknown command" feedback instead of silently swallowing the input.
+  const handleSlashIntent = (command: string, args = ""): boolean => {
+    switch (command) {
+      case "/new":
+        startAgentChat(activeId);
+        return true;
+      case "/board":
+        setMode("board");
+        return true;
+      case "/chats":
+      case "/agents":
+      case "/chat":
+        showAgentChatList();
+        return true;
+      case "/inbox":
+        setMode("inbox");
+        return true;
+      case "/remind": {
+        const trimmedArgs = args.trim();
+        const { title, whenText } = trimmedArgs
+          ? draftFromSlashArgs(trimmedArgs)
+          : { title: "", whenText: "" };
+        openReminderModal(title, whenText);
+        return true;
+      }
+      case "/palette":
+        setPaletteOpen(true);
+        return true;
+      case "/terminal":
+        setMode("terminal");
+        return true;
+      case "/projects":
+        setMode("library");
+        window.location.hash = "library:projects";
+        return true;
+      case "/library":
+        setMode("library");
+        return true;
+      case "/toggle-agent":
+        toggleAgentPanel();
+        return true;
+      case "/quit":
+        showAgentChatList();
+        return true;
+      case "/sessions":
+        setMode("chat");
+        showAgentChatList();
+        return true;
+      case "/familiar": {
+        const name = args.trim().toLowerCase();
+        if (name) {
+          const match = familiars.find(
+            (f) => f.id === name || f.display_name.toLowerCase() === name,
+          );
+          if (match) {
+            setActiveId(match.id);
+            showAgentChatList();
+            return true;
+          }
+        }
+        setPaletteOpen(true);
+        return true;
+      }
+      case "/attach": {
+        const sid = args.trim();
+        if (!sid) {
+          setPaletteOpen(true);
+          return true;
+        }
+        // Find which familiar this session belongs to so we surface the right rail row
+        const target = sessions.find((s) => s.id === sid);
+        openAgentSession(sid, target?.familiarId);
+        return true;
+      }
+      case "/tui": {
+        const sid = routerRef.current?.currentSessionId();
+        if (sid) {
+          void fetch("/api/launch", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ mode: "attach", sessionId: sid }),
+          });
+        }
+        return true;
+      }
+      case "/clear":
+        routerRef.current?.clearTranscript();
+        return true;
+      case "/help":
+      case "/run":
+      case "/codex":
+      case "/claude":
+        // These need composer context; route to the chat view's slash handler.
+        routerRef.current?.runSlash(command);
+        return true;
+    }
+    return false;
   };
 
   const active = familiars.find((f) => f.id === activeId) ?? null;
@@ -977,10 +984,7 @@ export function Workspace() {
         onClearPendingProjectRoot={() => setPendingProjectChatRoot(null)}
         onPendingChatActionHandled={() => setPendingChatAction(null)}
         onSessionStarted={loadSessions}
-        onSlashFromChat={(command, args) => {
-          onPaletteIntent({ kind: "slash", command, args });
-          return true;
-        }}
+        onSlashFromChat={handleSlashIntent}
         onOpenOnboarding={openOnboarding}
         onOpenInbox={() => setMode("inbox")}
         onCreateReminder={openReminderForFamiliar}
@@ -1171,10 +1175,7 @@ export function Workspace() {
                   sessions={sessions}
                   daemonRunning={daemonRunning}
                   onSessionStarted={loadSessions}
-                  onSlashFromChat={(command, args) => {
-                    onPaletteIntent({ kind: "slash", command, args });
-                    return true;
-                  }}
+                  onSlashFromChat={handleSlashIntent}
                   onOpenOnboarding={openOnboarding}
                 />
               }


### PR DESCRIPTION
Fixes audit finding **CHAT-D2-01 (P0)** from the chat UX audit (#395): the chat composer's slash-menu footer promises "↵ run · Tab complete · esc cancel", but none of it was true — and unknown commands silently destroyed the input.

## The three sub-bugs

1. **Enter ignored the highlight.** The slash branch of `onComposerKey` handled only ArrowDown/ArrowUp/Tab; Enter fell through to `send()` with the *typed* text, never consulting `slashIdx`. Arrow-keying to `/help` and pressing Enter ran whatever was typed, not the highlighted command.
2. **Esc couldn't dismiss the menu.** Escape only fired `cancelSend()` when `busy` — there was no way to close the slash menu from the keyboard.
3. **Unknown commands vanished silently.** `intentFromSlash`'s "Unknown command" feedback was dead code: both `onSlashFromChat` wrappers in `workspace.tsx` returned `true` unconditionally, while the slash switch inside `onPaletteIntent` silently dropped commands it didn't know. Net effect: `/he` + Enter cleared the input with zero feedback.

## The fix

- **chat-view.tsx** — Enter in the slash branch now runs the highlighted suggestion, porting home-composer's semantics: argument-taking commands (`argPlaceholder`) autocomplete into the input like Tab; bare commands dispatch through `intentFromSlash`. Esc sets a new `slashDismissed` state that hides the menu (re-armed on any input change); precedence is slash-menu-dismiss first, busy-`cancelSend()` second.
- **workspace.tsx** — the slash-intent switch is extracted into `handleSlashIntent(command, args): boolean`, which returns `false` for unknown commands. `onPaletteIntent` (still void) delegates to it, and both `onSlashFromChat` call sites pass it directly — so chat-view's `Unknown command: … Try /help.` feedback is reachable again. All known-command behavior (including the recent `/remind` reminder-modal drafting) is preserved verbatim; one dead duplicate `case "/familiar"` label was dropped.
- **chat-view-polish.test.ts** — extended with source-level pins for all three behaviors: Enter-runs-highlighted (with argPlaceholder autocomplete), Esc-dismiss-before-busy-cancel ordering, dismissal re-arm on input change, the footer promise staying in sync, and workspace's helper returning `false` for unknown commands at both call sites.

The footer text itself is unchanged — it is simply truthful now.

## Verification

- `node --experimental-strip-types src/components/chat-view-polish.test.ts` ✓
- `node --experimental-strip-types src/components/home-composer.test.ts` ✓
- `node --experimental-strip-types src/components/chat-view-lifecycle.test.ts` ✓
- `pnpm test:app` ✓ (full suite, 0 failures)
- `pnpm typecheck` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)