### PR TITLE
fix(pty): sanitize shell environment — drop pnpm's npm_config_* leakage

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -135,6 +135,25 @@ function validateCwd(raw: string | undefined): string | undefined {
   return raw;
 }
 
+// The server is usually launched by pnpm (dev) or as a bundled sidecar, and
+// pnpm exports its whole config to children as npm_config_* env vars. A
+// shell that inherits them gets "npm warn Unknown env config …" on every
+// npm command, and npm/pnpm/yarn invoked there read pnpm's settings as if
+// the user had set them. Strip the package-manager lifecycle namespace —
+// and the server's own NODE_ENV — before handing the env to a user shell.
+const PTY_ENV_DROPPED = new Set(["NODE_ENV", "INIT_CWD", "PNPM_SCRIPT_SRC_DIR"]);
+
+function sanitizedEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined) continue;
+    if (/^npm_/i.test(key)) continue;
+    if (PTY_ENV_DROPPED.has(key)) continue;
+    env[key] = value;
+  }
+  return env;
+}
+
 function sendPtyData(ws: WebSocket, data: string): void {
   if (ws.readyState !== WebSocket.OPEN) return;
   const encoded = Buffer.from(data, "utf8");
@@ -159,7 +178,7 @@ function spawnPty(threadId: string, ws: WebSocket, cols: number, rows: number, c
     rows: rows > 0 ? rows : 40,
     cwd: cwd ?? process.env.HOME ?? process.cwd(),
     env: {
-      ...process.env,
+      ...sanitizedEnv(),
       PATH: augmentedPath(),
       TERM: "xterm-256color",
       COLORTERM: "truecolor",

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -19,6 +19,21 @@ assert.match(src, /Bearer /, "server accepts bearer auth for non-cookie clients"
 assert.match(src, /pty\.spawn\(defaultShell\(\),\s*defaultShellArgs\(\)/, "server hardcodes shell and args");
 assert.doesNotMatch(src, /query\.command|query\.args|query\.env/, "renderer must not supply process authority through query params");
 assert.match(src, /statSync\(raw\)/, "projectRoot is stat-validated before use as cwd");
+assert.match(
+  src,
+  /\.\.\.sanitizedEnv\(\)/,
+  "PTY shells receive a sanitized environment, not raw process.env",
+);
+assert.doesNotMatch(
+  src,
+  /env: \{\s*\.\.\.process\.env/,
+  "spawnPty must not spread raw process.env — pnpm leaks npm_config_* into it",
+);
+assert.match(
+  src,
+  /\^npm_/,
+  "sanitizer strips the npm_* lifecycle/config namespace",
+);
 assert.match(src, /frame\[0\]\s*=\s*0x01/, "server sends output tag 0x01");
 assert.match(src, /frame\[0\]\s*=\s*0x02/, "server sends exit tag 0x02");
 assert.match(src, /tag === 0x03/, "server receives input tag 0x03");


### PR DESCRIPTION
## What

Val's Cave terminal printed six `npm warn Unknown env config …` lines on every npm command. Root cause: pnpm exports its config to child processes as `npm_config_*` env vars (`only-allow`, `verify-deps-before-run`, `manage-package-manager-versions`, `_jsr-registry`, …); the dev server inherits them from `pnpm dev`, and `spawnPty` spread raw `process.env` into every shell. Beyond the warning noise, npm/yarn run in those shells silently treat pnpm's settings as user config.

`spawnPty` now spreads a sanitized env: anything matching `^npm_` is dropped, plus `NODE_ENV`, `INIT_CWD`, and `PNPM_SCRIPT_SRC_DIR` (server lifecycle context that doesn't belong in a user shell). PATH augmentation is unchanged.

## Verification

- `src/server-pty-ws.test.ts` extended first (asserts the sanitized spread, forbids raw `...process.env`, pins the `^npm_` filter); `pnpm test:api` exit 0; `pnpm typecheck` clean.
- Live probe over `pty-ws`: spawned shell reports `env | grep -c '^npm_config_'` → **0** (the launching server carries 11) and empty `NODE_ENV`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)