### PR TITLE
fix(chat): instant scroll pin with intent-based release; respect reduced motion

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -274,6 +274,69 @@ assert.match(
   "Slash menu footer promises run/complete/cancel — keep it in sync with onComposerKey",
 );
 
+// — CHAT-D10-01 + CHAT-D13-03: instant scroll pin, intent-based release —
+const pinEffect = source.match(/\/\/ Pin: while following[\s\S]*?\}, \[turns\]\);/)?.[0] ?? "";
+assert.match(
+  pinEffect,
+  /requestAnimationFrame\(\(\) => \{[\s\S]*el\.scrollTop = el\.scrollHeight/,
+  "Streaming pin must set scrollTop instantly inside a rAF (coalesced per frame)",
+);
+assert.doesNotMatch(
+  pinEffect,
+  /scrollIntoView|behavior:/,
+  "The turns-change pin path must never queue a smooth scrollIntoView per SSE chunk",
+);
+assert.match(
+  pinEffect,
+  /if \(pinFrameRef\.current !== null\) return/,
+  "Pin must coalesce multiple turns updates into one frame, not stack rAF callbacks",
+);
+assert.doesNotMatch(
+  source,
+  /scrollIntoView\(\{ behavior: "smooth"/,
+  "No explicit smooth scrollIntoView anywhere — the reduced-motion CSS kill switch cannot override explicit options",
+);
+assert.match(
+  source,
+  /addEventListener\("wheel", onWheel, \{ passive: true \}\)/,
+  "Release must hook wheel input (passive) for intent detection",
+);
+assert.match(
+  source,
+  /if \(e\.deltaY < 0 && followingRef\.current\) updateFollowing\(false\)/,
+  "Wheel-up (negative deltaY) is the user intent that detaches following",
+);
+assert.match(
+  source,
+  /addEventListener\("touchmove", onTouchMove, \{ passive: true \}\)/,
+  "Release must hook touchmove (passive) for touch intent detection",
+);
+assert.match(
+  source,
+  /y > lastTouchY && followingRef\.current\) updateFollowing\(false\)/,
+  "Touch drag toward earlier content (finger moving down) detaches following",
+);
+assert.match(
+  source,
+  /if \(followingRef\.current\) return;[\s\S]{0,200}gap <= 4\) updateFollowing\(true\)/,
+  "Re-pin only on user scrolls reaching the true bottom (small epsilon); pin's own scroll events are no-ops while following",
+);
+assert.match(
+  source,
+  /updateFollowing\(true\);[\s\S]{0,600}prefers-reduced-motion: reduce[\s\S]{0,200}behavior: reduceMotion \? "auto" : "smooth"[\s\S]{0,400}aria-label="Scroll to bottom"/,
+  "Scroll FAB must re-engage following and gate its smooth scroll on prefers-reduced-motion",
+);
+assert.match(
+  source,
+  /\{!following && \(/,
+  "Scroll FAB visibility is driven by the following state",
+);
+assert.match(
+  source,
+  /useEffect\(\(\) => \{\s*updateFollowing\(true\);\s*\}, \[sessionId, updateFollowing\]\)/,
+  "A freshly opened chat / session switch must re-engage following by default",
+);
+
 const workspaceSource = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const slashHelper = workspaceSource.match(/const handleSlashIntent = [\s\S]*?\n  \};/)?.[0] ?? "";
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -961,7 +961,20 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const turnsRef = useRef<Turn[]>([]);
   const tailRef = useRef<HTMLDivElement | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
-  const [atBottom, setAtBottom] = useState(true);
+  // Scroll-pin state (CHAT-D10-01). `following` means "keep the transcript
+  // pinned to the newest content". It releases on user INTENT (wheel up /
+  // touch drag toward earlier content), never on mere scroll position — the
+  // old position-threshold release meant the stream's own smooth-scroll
+  // animation kept re-arming the pin and yanked readers back per SSE chunk.
+  // The ref mirrors the state so passive DOM listeners and rAF callbacks
+  // read the live value without re-subscribing.
+  const [following, setFollowing] = useState(true);
+  const followingRef = useRef(true);
+  const updateFollowing = useCallback((next: boolean) => {
+    followingRef.current = next;
+    setFollowing(next);
+  }, []);
+  const pinFrameRef = useRef<number | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -1133,20 +1146,84 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     };
   }, [sessionId, historyRetryKey]);
 
+  // Pin: while following, every turns mutation snaps the scroller to the
+  // bottom INSTANTLY (scrollTop assignment inside a rAF, coalescing multiple
+  // SSE chunks per frame). Never a queued smooth animation per chunk — that
+  // is the CHAT-D10-01 bug, and instant pinning also satisfies
+  // prefers-reduced-motion during streaming (CHAT-D13-03).
   useEffect(() => {
-    if (atBottom) tailRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
-  }, [turns, atBottom]);
+    if (!followingRef.current) return;
+    if (pinFrameRef.current !== null) return;
+    pinFrameRef.current = requestAnimationFrame(() => {
+      pinFrameRef.current = null;
+      const el = scrollRef.current;
+      if (!el || !followingRef.current) return;
+      el.scrollTop = el.scrollHeight;
+    });
+  }, [turns]);
 
+  useEffect(() => () => {
+    if (pinFrameRef.current !== null) cancelAnimationFrame(pinFrameRef.current);
+  }, []);
+
+  // A freshly opened chat (or session switch) follows by default; the pin
+  // effect above then handles the initial scroll-to-bottom once history lands.
+  useEffect(() => {
+    updateFollowing(true);
+  }, [sessionId, updateFollowing]);
+
+  // Release on intent: only USER input events detach following. Programmatic
+  // pins (scrollTop assignment, FAB scrollTo) emit scroll events but never
+  // wheel/touch/key events, so they are structurally excluded from intent
+  // detection here.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    let lastTouchY: number | null = null;
+    const onWheel = (e: WheelEvent) => {
+      if (e.deltaY < 0 && followingRef.current) updateFollowing(false);
+    };
+    const onTouchStart = (e: TouchEvent) => {
+      lastTouchY = e.touches[0]?.clientY ?? null;
+    };
+    const onTouchMove = (e: TouchEvent) => {
+      const y = e.touches[0]?.clientY;
+      if (y === undefined) return;
+      // Finger moving down the screen drags content down = scrolling up.
+      if (lastTouchY !== null && y > lastTouchY && followingRef.current) updateFollowing(false);
+      lastTouchY = y;
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.key === "PageUp" || e.key === "Home" || e.key === "ArrowUp") && followingRef.current) {
+        updateFollowing(false);
+      }
+    };
+    el.addEventListener("wheel", onWheel, { passive: true });
+    el.addEventListener("touchstart", onTouchStart, { passive: true });
+    el.addEventListener("touchmove", onTouchMove, { passive: true });
+    el.addEventListener("keydown", onKeyDown);
+    return () => {
+      el.removeEventListener("wheel", onWheel);
+      el.removeEventListener("touchstart", onTouchStart);
+      el.removeEventListener("touchmove", onTouchMove);
+      el.removeEventListener("keydown", onKeyDown);
+    };
+  }, [updateFollowing]);
+
+  // Re-pin: only when the user actually returns to the true bottom (small
+  // epsilon). While following this is a no-op, so the pin's own scroll events
+  // can never count as user intent.
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
     const onScroll = () => {
-      const threshold = 80;
-      setAtBottom(el.scrollHeight - el.scrollTop - el.clientHeight < threshold);
+      if (followingRef.current) return;
+      const gap = el.scrollHeight - el.scrollTop - el.clientHeight;
+      if (gap <= 4) updateFollowing(true);
     };
     el.addEventListener("scroll", onScroll, { passive: true });
     return () => el.removeEventListener("scroll", onScroll);
-  }, []);
+  }, [updateFollowing]);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -1932,12 +2009,20 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         </div>
 
         {/* Scroll-to-bottom FAB */}
-        {!atBottom && (
+        {!following && (
           <button
             type="button"
             onClick={() => {
-              setAtBottom(true);
-              tailRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+              updateFollowing(true);
+              const el = scrollRef.current;
+              if (!el) return;
+              // CHAT-D13-03: the global `scroll-behavior: auto !important`
+              // kill switch does NOT override explicit scrollTo options, so
+              // gate the smooth animation on prefers-reduced-motion here.
+              const reduceMotion =
+                typeof window !== "undefined" &&
+                window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+              el.scrollTo({ top: el.scrollHeight, behavior: reduceMotion ? "auto" : "smooth" });
             }}
             aria-label="Scroll to bottom"
             className="sticky bottom-4 float-right z-20 flex h-7 w-7 items-center justify-center rounded-md border border-[var(--accent-presence)]/40 bg-[var(--bg-raised)] text-[var(--accent-presence)] shadow-[0_2px_12px_var(--accent-presence)/20] transition-all hover:border-[var(--accent-presence)]/70 hover:bg-[color-mix(in_oklch,var(--accent-presence)_10%,var(--bg-raised))] hover:shadow-[0_2px_18px_var(--accent-presence)/35]"


### PR DESCRIPTION
Implements **CHAT-D10-01 (P1)** and **CHAT-D13-03 (P3)** from the chat UX audit (#395).

## The bug

- **CHAT-D10-01:** the pin effect fired `scrollIntoView({ behavior: "smooth", block: "end" })` on **every** `turns` mutation while `atBottom` — i.e. per SSE chunk. Each chunk queued a fresh smooth animation, and the animation's own scroll events kept `atBottom` true under the 80px position threshold, so near the bottom the stream repeatedly yanked the reader back down. Release was position-based, not intent-based.
- **CHAT-D13-03:** the explicit `behavior: "smooth"` (pin effect + scroll FAB) is **not** overridden by the global `scroll-behavior: auto !important` reduced-motion kill switch in globals.css — explicit `scrollIntoView`/`scrollTo` options win per the CSSOM View spec. Vestibular-sensitive users got continuous animated scrolling during streaming.

## The fix (the ChatGPT model: instant pin, intent-based release)

- **Pin:** while `following`, turns changes set `scroller.scrollTop = scroller.scrollHeight` inside a `requestAnimationFrame`, coalescing multiple chunks per frame. Instant — never a queued smooth animation per chunk. (This also satisfies reduced motion during streaming by construction.)
- **Release on intent:** following detaches only on user input — wheel with negative `deltaY`, touchmove dragging content downward (= scrolling up), or PageUp/Home/ArrowUp on the scroller. All listeners passive where applicable. Programmatic pins emit only `scroll` events, never wheel/touch/key events, so they are structurally excluded from intent detection — the old bug class (the pin re-arming itself) can't recur.
- **Re-pin:** only when the user returns to the true bottom (≤4px epsilon, checked on scroll events while detached — a no-op while following, so the pin's own scroll events never count) or clicks the scroll FAB.
- **Reduced motion:** the FAB click gates its smooth scroll on `matchMedia("(prefers-reduced-motion: reduce)")` → `behavior: "auto"`.
- **Preserved:** initial scroll-to-bottom on history load and session switch (`following` re-engages on `sessionId` change; the rAF pin handles the landing scroll), FAB behavior and `aria-label="Scroll to bottom"` (visibility now driven by `following`).

## Verification

- Extended `src/components/chat-view-polish.test.ts` with source-inspection pins: rAF instant pin path (no `scrollIntoView`/`behavior:` in the turns-change path, no smooth `scrollIntoView` anywhere), passive wheel/touchmove intent listeners and their release conditions, epsilon re-pin guard, FAB reduced-motion gate + `following`-driven visibility, session-switch re-engage.
- `node --experimental-strip-types` on chat-view-polish + chat-view-lifecycle: pass (including today's slash-menu and send()-ordering pins).
- Full `pnpm test:app`: pass. `pnpm typecheck`: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)