### PR TITLE
fix(chat): render markdown progressively while streaming

### DIFF
--- a/src/components/message-bubble-markdown.test.ts
+++ b/src/components/message-bubble-markdown.test.ts
@@ -60,6 +60,91 @@ assert.match(
   "Assistant bubble actions render whenever there is settled content",
 );
 
+// ── CHAT-D3-01: markdown must render progressively while streaming ────────
+// The pending branch used to bail (`setHtml(null); return;`), leaving the
+// user staring at raw ``` fences and **markers** until `done`, then
+// re-typesetting the whole bubble at once (live-measured CLS 0.53).
+const markdownContent = /function MarkdownContent\([\s\S]*?\n\}/.exec(source)?.[0] ?? "";
+assert.ok(markdownContent, "MarkdownContent component exists");
+assert.doesNotMatch(
+  markdownContent,
+  /setHtml\(null\)/,
+  "The pending branch must schedule a streaming render, not bail to the plain-text fallback",
+);
+assert.match(
+  markdownContent,
+  /if \(pending\) \{[\s\S]*?mdToHtml\(/,
+  "While pending, the accumulated text re-renders through mdToHtml",
+);
+assert.match(
+  source,
+  /const STREAM_RENDER_INTERVAL_MS = \d+/,
+  "Streaming renders are throttled by a named interval constant",
+);
+assert.match(
+  markdownContent,
+  /STREAM_RENDER_INTERVAL_MS - \(Date\.now\(\) - lastStreamRenderRef\.current\)/,
+  "The throttle is trailing-edge and persists across per-chunk effect re-runs (ref, not per-effect timer state)",
+);
+assert.match(
+  markdownContent,
+  /setTimeout\(run, wait\)/,
+  "Renders inside the throttle window are deferred to a trailing timer",
+);
+
+// Out-of-order protection: mdToHtml is async; a slower earlier render must
+// never overwrite a newer one. Each render takes a monotonic stamp and only
+// commits if newer than the last applied stamp.
+assert.match(
+  markdownContent,
+  /\+\+renderStampRef\.current/,
+  "Each render takes a monotonically increasing stamp",
+);
+assert.match(
+  markdownContent,
+  /if \(stamp <= appliedStampRef\.current\) return;/,
+  "A render result only commits if its stamp is newer than the last applied one",
+);
+
+// Streaming cursor: with rendered HTML during pending, the ▌ affordance must
+// render as a SIBLING after the markdown container — never injected into the
+// sanitized HTML string.
+assert.match(
+  markdownContent,
+  /dangerouslySetInnerHTML=\{\{ __html: html \}\}\s*\/>\s*\{\/\*[\s\S]*?\*\/\}\s*\{pending \? \(\s*<span[^>]*>▌<\/span>/,
+  "While pending, the streaming cursor renders as a sibling element after the markdown container",
+);
+assert.match(
+  markdownContent,
+  /\{pending && text \? \(\s*<span[^>]*>▌<\/span>/,
+  "The plain-text fallback keeps its cursor for the window before the first render lands",
+);
+
+// ── CHAT-D3-03: renderCache must not grow unboundedly ─────────────────────
+// The cache is keyed by the FULL markdown string; mid-stream snapshots would
+// add an entry per throttle tick. Guards: (1) transient streaming renders
+// skip cache writes entirely, (2) the cache is a small LRU with a hard cap.
+assert.match(
+  source,
+  /const RENDER_CACHE_MAX = \d+/,
+  "renderCache has a named size cap",
+);
+assert.match(
+  source,
+  /if \(renderCache\.size > RENDER_CACHE_MAX\) \{\s*const oldest = renderCache\.keys\(\)\.next\(\)\.value;/,
+  "On overflow the least-recently-used entry is evicted",
+);
+assert.match(
+  source,
+  /if \(!opts\?\.transient\) renderCacheSet\(markdown, sanitizedHtml\);/,
+  "Transient mid-stream renders never write to the cache",
+);
+assert.match(
+  markdownContent,
+  /mdToHtml\(closeTrailingFence\(text\), \{ transient: true \}\)/,
+  "Streaming renders are marked transient (and auto-close a trailing unterminated fence)",
+);
+
 const css = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
 assert.match(
   css,

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -283,7 +283,50 @@ function escAttr(s: string): string {
 // Render markdown to HTML (async, Shiki per code block)
 // ---------------------------------------------------------------------------
 
+/**
+ * renderCache LRU — keyed by the FULL markdown string. Capped (CHAT-D3-03):
+ * an unbounded Map keyed by entire messages grows for the whole session.
+ * Map iteration order is insertion order, so refreshing recency on get and
+ * evicting the first key on overflow gives a small LRU for free.
+ */
+const RENDER_CACHE_MAX = 200;
 const renderCache = new Map<string, string>();
+
+function renderCacheGet(key: string): string | undefined {
+  const value = renderCache.get(key);
+  if (value !== undefined) {
+    renderCache.delete(key);
+    renderCache.set(key, value);
+  }
+  return value;
+}
+
+function renderCacheSet(key: string, value: string) {
+  if (renderCache.has(key)) renderCache.delete(key);
+  renderCache.set(key, value);
+  if (renderCache.size > RENDER_CACHE_MAX) {
+    const oldest = renderCache.keys().next().value;
+    if (oldest !== undefined) renderCache.delete(oldest);
+  }
+}
+
+/** Streaming markdown re-renders at most once per this many ms (trailing). */
+const STREAM_RENDER_INTERVAL_MS = 200;
+
+/**
+ * Mid-stream nicety: if the accumulated text ends inside an unterminated
+ * code fence, close it before rendering so the partial block highlights as
+ * code instead of pulling the rest of the snapshot into a runaway open
+ * block. Only applied to transient streaming snapshots — the final settled
+ * render gets the text verbatim.
+ */
+function closeTrailingFence(markdown: string): string {
+  let inFence = false;
+  for (const line of markdown.split("\n")) {
+    if (/^\s*```/.test(line)) inFence = !inFence;
+  }
+  return inFence ? `${markdown}\n\`\`\`` : markdown;
+}
 
 /**
  * Scan markdown for fence openers in order, returning the filename suffix for
@@ -357,8 +400,9 @@ async function renderTableBlock(block: TableBlock, renderAsync: RenderAsyncFn): 
   return `<table class="cm-table"><thead><tr>${ths.join("")}</tr></thead><tbody>${trs.join("")}</tbody></table>`;
 }
 
-async function mdToHtml(markdown: string): Promise<string> {
-  if (renderCache.has(markdown)) return renderCache.get(markdown)!;
+async function mdToHtml(markdown: string, opts?: { transient?: boolean }): Promise<string> {
+  const cached = renderCacheGet(markdown);
+  if (cached !== undefined) return cached;
 
   // We render ourselves: use @create-markdown/core to parse, then manually
   // serialize to HTML so we can inject our custom Shiki code blocks.
@@ -441,7 +485,10 @@ async function mdToHtml(markdown: string): Promise<string> {
   }
 
   const sanitizedHtml = sanitizeHtml(html);
-  renderCache.set(markdown, sanitizedHtml);
+  // Transient (mid-stream) snapshots are never requested again once the
+  // stream advances past them — caching one per throttle tick would churn
+  // settled entries out of the LRU for no hit-rate gain.
+  if (!opts?.transient) renderCacheSet(markdown, sanitizedHtml);
   return sanitizedHtml;
 }
 
@@ -484,28 +531,80 @@ function useWireCopyButtons(html: string | null) {
 }
 
 // ---------------------------------------------------------------------------
-// MarkdownContent — async render; plain fallback while streaming
+// MarkdownContent — progressive async render while streaming (CHAT-D3-01);
+// plain fallback only until the first render lands
 // ---------------------------------------------------------------------------
 
 function MarkdownContent({ text, pending }: { text: string; pending?: boolean }) {
   const [html, setHtml] = useState<string | null>(null);
   const containerRef = useWireCopyButtons(html);
+  // Out-of-order guard: mdToHtml is async and during streaming several
+  // renders can be in flight at once. Every render takes a monotonically
+  // increasing stamp, and a result only commits if it is newer than the
+  // last committed one — a slower earlier render never overwrites a newer
+  // one (including the final settled render).
+  const renderStampRef = useRef(0);
+  const appliedStampRef = useRef(0);
+  // Throttle bookkeeping for streaming renders. Lives in a ref because the
+  // effect re-fires on every streamed chunk: a per-effect trailing debounce
+  // would be reset by each chunk and never fire under a steady stream.
+  const lastStreamRenderRef = useRef(0);
 
   useEffect(() => {
-    if (pending) {
-      // Don't block on async render while streaming
-      setHtml(null);
-      return;
-    }
     // No "same text" guard here: the effect only re-fires when text/pending
     // change, and a ref-based guard poisons itself under StrictMode's
     // double-invoke (run 1 marks the text seen, then gets cancelled; run 2
     // early-returns and the bubble is stuck on the plain-text fallback).
     // mdToHtml memoizes per-text, so re-entry is cheap.
     if (!text) return;
+
+    if (pending) {
+      // CHAT-D3-01: render markdown progressively during the stream instead
+      // of showing literal ``` fences and **markers** until `done` (which
+      // then re-typesets the whole bubble at once — live-measured CLS 0.53).
+      // Renders are throttled to one per STREAM_RENDER_INTERVAL_MS, trailing
+      // edge; the first chunk renders immediately (lastStreamRenderRef starts
+      // at 0, so the first elapsed check always passes).
+      //
+      // Deliberately NOT gated on a `cancelled` flag: every chunk re-runs
+      // this effect, so any stream whose chunk interval is shorter than
+      // mdToHtml's latency would cancel every in-flight render before it
+      // commits and nothing would paint until the turn settles (starvation).
+      // The stamp guard above provides ordering safety instead; a commit
+      // after unmount is a no-op state update that React drops.
+      const run = () => {
+        lastStreamRenderRef.current = Date.now();
+        const stamp = ++renderStampRef.current;
+        mdToHtml(closeTrailingFence(text), { transient: true })
+          .then((h) => {
+            if (stamp <= appliedStampRef.current) return; // stale out-of-order render
+            appliedStampRef.current = stamp;
+            setHtml(h);
+          })
+          .catch((err) => { console.error("[MarkdownContent] mdToHtml failed", err); });
+      };
+      const wait = STREAM_RENDER_INTERVAL_MS - (Date.now() - lastStreamRenderRef.current);
+      if (wait <= 0) {
+        run();
+        return;
+      }
+      const timer = setTimeout(run, wait);
+      return () => { clearTimeout(timer); };
+    }
+
+    // Settled (`pending` → false): final immediate render on the verbatim
+    // text, keeping the original async-cancellation discipline — once the
+    // turn is done there is no starvation risk, and cancellation keeps a
+    // stale effect run from committing.
     let cancelled = false;
+    const stamp = ++renderStampRef.current;
     mdToHtml(text)
-      .then((h) => { if (!cancelled) setHtml(h); })
+      .then((h) => {
+        if (cancelled) return;
+        if (stamp <= appliedStampRef.current) return; // stale out-of-order render
+        appliedStampRef.current = stamp;
+        setHtml(h);
+      })
       .catch((err) => { console.error("[MarkdownContent] mdToHtml failed", err); });
     return () => { cancelled = true; };
   }, [text, pending]);
@@ -522,13 +621,20 @@ function MarkdownContent({ text, pending }: { text: string; pending?: boolean })
   }
 
   return (
-    <div
-      ref={containerRef}
-      className="cave-md"
-      // Markdown output is sanitized in mdToHtml before DOM insertion.
-      // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
+    <>
+      <div
+        ref={containerRef}
+        className="cave-md"
+        // Markdown output is sanitized in mdToHtml before DOM insertion.
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+      {/* Streaming cursor as a SIBLING of the markdown container — never
+          injected into the sanitized HTML string. */}
+      {pending ? (
+        <span aria-hidden="true" className="ml-1 inline-block animate-pulse text-[var(--text-secondary)]">▌</span>
+      ) : null}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary

Implements **CHAT-D3-01 (P1)** from the chat UX audit (#395): during streaming, `MarkdownContent` bailed out of rendering (`setHtml(null); return;`), so users watched literal ``` ``` ``` fences and `**bold**` markers in a plain-text span until the turn completed — then the entire bubble re-typeset at once (**live-measured CLS 0.53**; Core Web Vitals "poor" threshold is 0.25). ChatGPT and Claude.ai both render markdown progressively during the stream.

## Design

**Trailing throttle, 200 ms (`STREAM_RENDER_INTERVAL_MS`).** While `pending`, the accumulated text re-renders through `mdToHtml` at most once per 200 ms, trailing edge, with the first chunk rendering immediately. The throttle timestamp lives in a ref rather than per-effect state: the effect re-fires on every streamed chunk, so a per-effect trailing debounce would be reset by each chunk and never fire under a steady stream. On `pending → false` the settled path does a final immediate render on the verbatim text, keeping the original `cancelled`-flag discipline and the StrictMode no-same-text-guard behavior.

**Out-of-order protection (stamp).** `mdToHtml` is async and multiple renders can be in flight; each render takes a monotonic stamp and a result only commits if newer than the last applied stamp — a slower earlier render never overwrites a newer one, including the final settled render. Pending commits are deliberately gated on the stamp *instead of* the per-effect `cancelled` flag: any stream whose chunk interval is shorter than `mdToHtml` latency would otherwise cancel every in-flight render before it commits, and nothing would paint until `done` (starvation). A post-unmount commit is a state update React silently drops.

**renderCache guard — both options (also closes CHAT-D3-03).**
1. Transient mid-stream snapshots **skip cache writes** — a stream snapshot is never requested again once the stream advances, so caching one per throttle tick is pure churn against entries that can actually be re-hit (expand modal, re-mounts).
2. The cache is now a small **LRU capped at 200 entries** (Map insertion-order recency refresh + evict-oldest on overflow), closing the unbounded-growth finding (CHAT-D3-03) for settled entries too.

**Trailing unterminated fence.** Transient renders auto-close a trailing open code fence (`closeTrailingFence`) so a partial code block highlights as code instead of rendering as a runaway open block. The final settled render gets the text verbatim.

**Streaming cursor.** With HTML now rendered during `pending`, the ▌ cursor renders as a **sibling element after** the markdown container (never injected into the sanitized HTML string). The plain-text fallback keeps its cursor for the window before the first render lands.

`useWireCopyButtons` re-runs on every html commit, so copy buttons stay wired across progressive updates (#398 pin holds); `{!pending && <CopyBubble` / bubble-actions gating (#400 pins) untouched.

## Tests

Extended `src/components/message-bubble-markdown.test.ts` (already in `test:app`) to pin:
- the pending branch schedules a throttled `mdToHtml` render (no `setHtml(null)` bail)
- the trailing throttle persists across per-chunk effect re-runs (ref-based)
- the monotonic render stamp + `stamp <= appliedStampRef` commit guard
- the cursor renders as a sibling while pending, fallback cursor retained
- `RENDER_CACHE_MAX` LRU eviction + transient renders skipping cache writes

`node --experimental-strip-types` targeted tests, full `pnpm test:app` (exit 0), and `pnpm typecheck` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)