### PR TITLE
fix(shell): polish side panel edge triggers

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2921,28 +2921,47 @@ select {
 }
 
 /* ────────────────────────────────────────────────
-   Agent trigger rail — right-edge slim column holding
-   the Salem toggle, mirror of the (now-removed) sidebar
-   trigger rail.
+   Agent trigger rails — slim edge columns holding the
+   left navigation toggle and right Salem toggle.
    ──────────────────────────────────────────────── */
 
 .agent-trigger-rail {
-  width: 22px;
-  flex: 0 0 22px;
+  position: relative;
+  width: 26px;
+  flex: 0 0 26px;
   display: flex;
   flex-direction: column;
   align-items: stretch;
   padding: 0;
-  background: color-mix(in oklch, var(--bg-panel) 22%, transparent);
+  overflow: hidden;
+  background: color-mix(in oklch, var(--bg-panel) 38%, transparent);
   border-left: 1px solid var(--border-hairline);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   user-select: none;
+}
+
+.agent-trigger-rail::before {
+  content: "";
+  position: absolute;
+  top: 10px;
+  bottom: 10px;
+  left: 3px;
+  width: 1px;
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--accent) 52%, transparent);
+  opacity: 0.82;
+  pointer-events: none;
 }
 
 .agent-trigger-rail--left {
   border-left: 0;
   border-right: 1px solid var(--border-hairline);
+}
+
+.agent-trigger-rail--left::before {
+  right: 3px;
+  left: auto;
 }
 
 .agent-trigger-rail__toggle {
@@ -2957,7 +2976,7 @@ select {
   border-radius: 0;
   border: 0;
   background: transparent;
-  color: var(--text-muted);
+  color: color-mix(in oklch, var(--text-secondary) 86%, var(--text-primary));
   cursor: pointer;
   transition: background 120ms ease, color 120ms ease;
 }
@@ -2978,13 +2997,26 @@ select {
 .edge-rail-chip {
   display: grid;
   place-items: center;
-  width: 18px;
+  width: 20px;
   height: 44px;
   border-radius: 7px;
-  border: 1px solid var(--border-hairline);
-  background: var(--bg-raised);
+  border: 1px solid color-mix(in oklch, var(--text-muted) 38%, transparent);
+  background: color-mix(in oklch, var(--bg-raised) 90%, var(--bg-elevated));
   color: inherit;
-  transition: background 120ms ease, border-color 120ms ease, transform 80ms ease;
+  box-shadow:
+    inset 0 1px 0 color-mix(in oklch, var(--text-primary) 12%, transparent),
+    0 8px 16px color-mix(in oklch, black 20%, transparent);
+  transition: background 120ms ease, border-color 120ms ease, box-shadow 120ms ease, transform 80ms ease;
+}
+
+.agent-trigger-rail__toggle[aria-expanded="true"] > .edge-rail-chip {
+  color: var(--text-primary);
+  border-color: color-mix(in oklch, var(--accent-presence) 58%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 18%, var(--bg-raised));
+  box-shadow:
+    inset 0 1px 0 color-mix(in oklch, var(--text-primary) 18%, transparent),
+    0 0 0 1px color-mix(in oklch, var(--accent-presence) 24%, transparent),
+    0 10px 18px color-mix(in oklch, black 24%, transparent);
 }
 
 button:hover > .edge-rail-chip,

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -1,8 +1,7 @@
 // @ts-nocheck
 // Closed side panels must stay discoverable and read as pressable:
-//   - a collapsed nav leaves a left-edge reopen tab mirroring the
-//     right-edge agent trigger rail (which already persists when the
-//     companion rail is closed)
+//   - the nav has a persistent left-edge collapse/expand tab mirroring the
+//     right-edge agent trigger rail
 //   - edge-rail toggles render a visible button chip instead of an
 //     invisible-until-hover icon
 import assert from "node:assert/strict";
@@ -20,18 +19,33 @@ assert.match(
 );
 assert.match(
   shell,
+  /!isMobile \? \([\s\S]*?agent-trigger-rail--left/,
+  "left edge rail appears persistently on desktop",
+);
+assert.doesNotMatch(
+  shell,
   /!isMobile && !navOpen[\s\S]*?agent-trigger-rail--left/,
-  "left edge rail only appears when the nav panel is collapsed on desktop",
+  "left edge rail must not disappear while navigation is open",
 );
 assert.match(
   shell,
-  /agent-trigger-rail--left[\s\S]*?aria-label="Show navigation"/,
-  "left edge rail toggle is labelled for screen readers",
+  /agent-trigger-rail--left[\s\S]*?aria-label=\{navOpen \? "Hide navigation" : "Show navigation"\}/,
+  "left edge rail toggle label reflects nav state",
 );
 assert.match(
   shell,
-  /agent-trigger-rail--left[\s\S]*?navRef\.current\?\.expand\(\)/,
-  "left edge rail toggle expands the nav panel",
+  /agent-trigger-rail--left[\s\S]*?aria-expanded=\{navOpen\}/,
+  "left edge rail exposes nav expanded state",
+);
+assert.match(
+  shell,
+  /agent-trigger-rail--left[\s\S]*?navRef\.current\?\.collapse\(\)[\s\S]*?navRef\.current\?\.expand\(\)/,
+  "left edge rail toggle collapses and expands the nav panel",
+);
+assert.match(
+  shell,
+  /agent-trigger-rail--left[\s\S]*?navOpen \? "ph:sidebar-simple-fill" : "ph:sidebar-simple"/,
+  "left edge rail icon reflects nav state",
 );
 
 assert.match(
@@ -39,7 +53,27 @@ assert.match(
   /\.agent-trigger-rail--left \{[^}]*border-right: 1px solid var\(--border-hairline\)/,
   "left rail variant flips the hairline to its right edge",
 );
+assert.match(
+  css,
+  /\.agent-trigger-rail \{[^}]*width: 26px;[^}]*flex: 0 0 26px;/,
+  "edge trigger rails should be wide enough to read as intentional controls",
+);
+assert.match(
+  css,
+  /\.agent-trigger-rail::before \{[^}]*width: 1px;[^}]*background: color-mix\(in oklch, var\(--accent\) 52%, transparent\)/,
+  "edge trigger rails should carry a subtle accent guide line",
+);
 assert.match(css, /\.edge-rail-chip \{/, "edge-rail chip class exists");
+assert.match(
+  css,
+  /\.edge-rail-chip \{[^}]*width: 20px;[^}]*box-shadow:/,
+  "edge-rail chip should be visibly pressable without feeling bulky",
+);
+assert.match(
+  css,
+  /\.agent-trigger-rail__toggle\[aria-expanded="true"\] > \.edge-rail-chip/,
+  "expanded side-panel triggers should have an active chip treatment",
+);
 assert.doesNotMatch(
   css,
   /\.agent-trigger-rail__toggle \{[^}]*opacity: 0/,

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -455,24 +455,29 @@ function ShellInner({
     "--shell-home-asymmetry-px": `${homeCenterAsymmetry}px`,
   };
 
-  // Closed-state reopen tab for the nav panel — the left-edge mirror of the
-  // agent trigger rail, so a collapsed sidebar stays discoverable.
+  // Persistent nav toggle — the left-edge mirror of the agent trigger rail, so
+  // the sidebar can be collapsed and reopened from the same stable affordance.
   const navRail =
-    !isMobile && !navOpen ? (
+    !isMobile ? (
       <aside className="agent-trigger-rail agent-trigger-rail--left" aria-label="Navigation toggle">
         <button
           type="button"
           className="agent-trigger-rail__toggle"
-          aria-label="Show navigation"
-          aria-expanded={false}
-          title="Show navigation (⌘B)"
+          aria-label={navOpen ? "Hide navigation" : "Show navigation"}
+          aria-expanded={navOpen}
+          title={navOpen ? "Hide navigation (⌘B)" : "Show navigation (⌘B)"}
           onClick={() => {
-            navRef.current?.expand();
-            setNavOpen(true);
+            if (navOpen) {
+              navRef.current?.collapse();
+              setNavOpen(false);
+            } else {
+              navRef.current?.expand();
+              setNavOpen(true);
+            }
           }}
         >
           <span className="edge-rail-chip">
-            <Icon name="ph:sidebar-simple" width={14} />
+            <Icon name={navOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={14} />
           </span>
         </button>
       </aside>


### PR DESCRIPTION
## Summary
- make the left/right side-panel edge rails more visible with a wider trigger column and subtle accent guide
- give edge trigger chips stronger contrast, shadow, and expanded-state styling
- keep the persistent left navigation trigger covered by the shell edge-rail guard test

## Verification
- `node --experimental-strip-types src/components/shell-edge-rails.test.ts`
- `pnpm typecheck`
