### PR TITLE
fix(chat): deliver image attachments to the harness via temp files

### DIFF
--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -1,6 +1,12 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
+import {
+  buildPromptWithAttachments,
+  IMAGE_ATTACHMENTS_UNSUPPORTED_NOTE,
+  MAX_ATTACHMENT_IMAGE_BYTES,
+  normalizeChatAttachments,
+} from "../../../../lib/chat-attachments.ts";
 
 const chatRoute = await readFile(
   new URL("./route.ts", import.meta.url),
@@ -130,3 +136,125 @@ assert.match(
   /isTrustedChatHarness\(binding\.harness\)/,
   "Board step enrichment should enforce the same trusted Coven harness gate",
 );
+
+// ── Image attachment delivery (CHAT-D1-01) ────────────────────────────────
+// Source pins: the route must write validated image payloads to private temp
+// files for file-reading harnesses, and never offer file paths to the
+// OpenClaw bridge or SSH runtimes (they cannot read this machine's disk).
+
+assert.match(
+  chatRoute,
+  /const imagesSupported = !sshRuntime && binding\.harness !== "openclaw";/,
+  "Image temp-file delivery should be limited to local coven-run harnesses with a Read tool",
+);
+
+assert.match(
+  chatRoute,
+  /imagesSupported\s*\?\s*await writeImageAttachmentsToTemp\(attachments\)/,
+  "Image payloads should be written to temp files before the harness prompt is built",
+);
+
+assert.match(
+  chatRoute,
+  /buildPromptWithAttachments\(promptText, attachments, \{\s*imagesSupported,\s*imageFilePaths,\s*\}\)/,
+  "The harness prompt should carry the saved image paths or the unsupported notice",
+);
+
+assert.match(
+  chatRoute,
+  /await writeFile\(filePath, payload, \{ mode: 0o600 \}\)/,
+  "Saved image payloads should be private temp files (mode 0600)",
+);
+
+assert.match(
+  chatRoute,
+  /crypto\.randomUUID\(\)\}\.\$\{imageExtension\(attachment\.mimeType\)/,
+  "Temp image filenames should be random with an extension derived from the validated mime type, never user input",
+);
+
+assert.match(
+  chatRoute,
+  /cleanupImageTempFiles\(imageFilePaths\);/,
+  "Image temp files should be best-effort deleted after the harness child has exited",
+);
+
+assert.match(
+  chatRoute,
+  /const persistedAttachments = stripPreviewOnlyAttachmentFields\(attachments\);/,
+  "Persisted transcripts should keep attachment metadata only, not base64 image payloads",
+);
+
+// Behavioral coverage: normalization keeps bounded image payloads and rejects
+// anything malformed or oversized; prompt building renders the file-path line
+// for capable harnesses and an explicit notice otherwise.
+
+const smallPng = `data:image/png;base64,${Buffer.from("png-payload-bytes").toString("base64")}`;
+
+{
+  const [image] = normalizeChatAttachments([
+    { name: "shot.png", type: "image/png", mimeType: "image/png", size: 17, dataUrl: smallPng },
+  ]);
+  assert.equal(image.dataUrl, smallPng, "normalize should preserve a bounded image dataUrl");
+  assert.equal(image.mimeType, "image/png", "normalize should preserve the image mime type");
+}
+
+{
+  const oversizedBase64 = "A".repeat((Math.ceil(MAX_ATTACHMENT_IMAGE_BYTES / 3) + 4) * 4);
+  const cases = [
+    { label: "oversized payload", dataUrl: `data:image/png;base64,${oversizedBase64}` },
+    { label: "non-image data URL", dataUrl: "data:application/pdf;base64,aGVsbG8=" },
+    { label: "non-base64 payload", dataUrl: "data:image/png;base64,not!!valid~~" },
+    { label: "non-data URL", dataUrl: "https://example.com/x.png" },
+    { label: "empty payload", dataUrl: "data:image/png;base64," },
+  ];
+  for (const { label, dataUrl } of cases) {
+    const [image] = normalizeChatAttachments([
+      { name: "shot.png", mimeType: "image/png", size: 1, dataUrl },
+    ]);
+    assert.equal(image.dataUrl, undefined, `normalize should reject ${label}`);
+  }
+}
+
+{
+  const attachments = normalizeChatAttachments([
+    { name: "shot.png", type: "image/png", mimeType: "image/png", size: 17, dataUrl: smallPng },
+  ]);
+  const savedPath = "/tmp/coven-cave-attachments/00000000-0000-0000-0000-000000000000.png";
+  const withPath = buildPromptWithAttachments("Look at this.", attachments, {
+    imagesSupported: true,
+    imageFilePaths: new Map([[0, savedPath]]),
+  });
+  assert.match(
+    withPath,
+    new RegExp(`Image saved to ${savedPath} — open it with the Read tool to view\\.`),
+    "Capable harnesses should be pointed at the saved image file",
+  );
+  assert.doesNotMatch(
+    withPath,
+    /\(content unavailable\)/,
+    "Delivered images should never render the misleading (content unavailable)",
+  );
+
+  const unsupported = buildPromptWithAttachments("Look at this.", attachments, {
+    imagesSupported: false,
+  });
+  assert.ok(
+    unsupported.includes(IMAGE_ATTACHMENTS_UNSUPPORTED_NOTE),
+    "Harnesses without file access should see an explicit unsupported notice",
+  );
+  assert.doesNotMatch(
+    unsupported,
+    /\(content unavailable\)/,
+    "Unsupported-harness images should never render (content unavailable)",
+  );
+
+  const undelivered = buildPromptWithAttachments("Look at this.", [
+    { name: "shot.png", mimeType: "image/png", size: 17 },
+  ]);
+  assert.match(
+    undelivered,
+    /\(image attachment was not delivered — payload missing or over the size limit\)/,
+    "Images whose payload never arrived should explain why instead of (content unavailable)",
+  );
+  assert.doesNotMatch(undelivered, /\(content unavailable\)/);
+}

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
-import { readFile, stat } from "node:fs/promises";
-import { homedir } from "node:os";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { stripAnsi } from "@/lib/ansi";
 import {
@@ -16,7 +16,9 @@ import {
 } from "@/lib/cave-chat-titles";
 import {
   buildPromptWithAttachments,
+  MAX_ATTACHMENT_IMAGE_BYTES,
   normalizeChatAttachments,
+  stripPreviewOnlyAttachmentFields,
   type ChatAttachment,
 } from "@/lib/chat-attachments";
 import { AssistantFilter } from "@/lib/chat-assistant-filter";
@@ -124,6 +126,58 @@ async function resolveFamiliarWorkspace(
     /* not found */
   }
   return undefined;
+}
+
+// ── Image attachment delivery ────────────────────────────────────────────
+// Local coven-run harnesses are agentic CLIs with a Read tool that can open
+// image files, so image payloads are written to private temp files and the
+// prompt points the harness at them. Bridges/remotes that cannot read this
+// machine's filesystem get an explicit unsupported notice instead.
+
+const ATTACHMENT_TMP_DIR = path.join(tmpdir(), "coven-cave-attachments");
+const IMAGE_EXT_BY_SUBTYPE: Record<string, string> = {
+  jpeg: "jpg",
+  "svg+xml": "svg",
+};
+
+function imageExtension(mimeType?: string): string {
+  const subtype = mimeType?.split("/")[1]?.toLowerCase() ?? "";
+  const mapped = IMAGE_EXT_BY_SUBTYPE[subtype] ?? subtype;
+  // Extension derives from the validated mime subtype only — never from a
+  // user-controlled filename — and falls back to a fixed token.
+  return /^[a-z0-9]{1,8}$/.test(mapped) ? mapped : "img";
+}
+
+async function writeImageAttachmentsToTemp(
+  attachments: ChatAttachment[],
+): Promise<Map<number, string>> {
+  const filePaths = new Map<number, string>();
+  for (const [index, attachment] of attachments.entries()) {
+    if (!attachment.dataUrl || !attachment.mimeType?.startsWith("image/")) continue;
+    const base64 = attachment.dataUrl.slice(attachment.dataUrl.indexOf(",") + 1);
+    const payload = Buffer.from(base64, "base64");
+    // Defense in depth: normalizeChatAttachments already enforces the cap,
+    // but never write more than the cap regardless.
+    if (payload.byteLength === 0 || payload.byteLength > MAX_ATTACHMENT_IMAGE_BYTES) continue;
+    try {
+      await mkdir(ATTACHMENT_TMP_DIR, { recursive: true, mode: 0o700 });
+      const filePath = path.join(
+        ATTACHMENT_TMP_DIR,
+        `${crypto.randomUUID()}.${imageExtension(attachment.mimeType)}`,
+      );
+      await writeFile(filePath, payload, { mode: 0o600 });
+      filePaths.set(index, filePath);
+    } catch {
+      /* best effort — the prompt falls back to the not-delivered notice */
+    }
+  }
+  return filePaths;
+}
+
+function cleanupImageTempFiles(filePaths: ReadonlyMap<number, string>) {
+  for (const filePath of filePaths.values()) {
+    void rm(filePath, { force: true }).catch(() => undefined);
+  }
 }
 
 function scheduleLinkRoute(args: {
@@ -534,14 +588,9 @@ export async function POST(req: Request) {
       { status: 400, headers: { "content-type": "application/json" } },
     );
   }
-  const taskContext = await taskContextForSession(body.sessionId);
-  const harnessPrompt = buildPromptWithCovenIdentityCanon(
-    buildTaskAwarePrompt(
-      buildPromptWithAttachments(promptText, attachments),
-      taskContext,
-    ),
-    body.familiarId,
-  );
+  // Persisted transcripts keep attachment metadata only — base64 image
+  // payloads stay out of the conversation store.
+  const persistedAttachments = stripPreviewOnlyAttachmentFields(attachments);
 
   const config = await loadConfig();
   const binding = bindingFor(config, body.familiarId);
@@ -580,13 +629,33 @@ export async function POST(req: Request) {
       { status: 501, headers: { "content-type": "application/json" } },
     );
   }
+  // Image delivery channel: only local coven-run harnesses can Read files on
+  // this machine. The OpenClaw bridge and SSH runtimes cannot, so their
+  // prompts carry an explicit unsupported notice instead of a dead path.
+  const imagesSupported = !sshRuntime && binding.harness !== "openclaw";
+  const imageFilePaths = imagesSupported
+    ? await writeImageAttachmentsToTemp(attachments)
+    : new Map<number, string>();
+
+  const taskContext = await taskContextForSession(body.sessionId);
+  const harnessPrompt = buildPromptWithCovenIdentityCanon(
+    buildTaskAwarePrompt(
+      buildPromptWithAttachments(promptText, attachments, {
+        imagesSupported,
+        imageFilePaths,
+      }),
+      taskContext,
+    ),
+    body.familiarId,
+  );
+
   if (binding.harness === "openclaw" && !sshRuntime) {
     return openClawChatResponse({
       req,
       body,
       promptText,
       harnessPrompt,
-      attachments,
+      attachments: persistedAttachments,
     });
   }
 
@@ -961,7 +1030,7 @@ export async function POST(req: Request) {
           id: userTurnId,
           role: "user",
           text: promptText,
-          ...(attachments.length ? { attachments } : {}),
+          ...(persistedAttachments.length ? { attachments: persistedAttachments } : {}),
           createdAt: now,
         };
         const assistantTurn: ChatTurn = {
@@ -1010,6 +1079,10 @@ export async function POST(req: Request) {
         isError: result.is_error,
         sessionId: finalSessionId ?? undefined,
       });
+      // Best-effort temp cleanup: the harness child process has already
+      // exited (including any resume retry), so nothing can still be reading
+      // the saved images. Failures just leave files in tmpdir.
+      cleanupImageTempFiles(imageFilePaths);
       await sleep(20);
       close();
     },

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -8,8 +8,14 @@ const splitReasoning = source.match(/function splitReasoning[\s\S]*?\n}\n\n\/\/ 
 
 assert.match(
   source,
-  /fetch\("\/api\/chat\/send"[\s\S]*body: JSON\.stringify\(\{[\s\S]*attachments: stripPreviewOnlyAttachmentFields\(outgoingAttachments\)/,
-  "Chat send should strip preview-only attachment fields before POSTing",
+  /fetch\("\/api\/chat\/send"[\s\S]*body: JSON\.stringify\(\{[\s\S]*attachments: stripPreviewOnlyAttachmentFieldsKeepingImages\(outgoingAttachments\)/,
+  "Chat send should strip preview-only attachment fields before POSTing, keeping image payloads so the harness can see them",
+);
+
+assert.match(
+  source,
+  /if \(file\.size > MAX_ATTACHMENT_IMAGE_BYTES\) \{[\s\S]*?attachment\.truncated = true;/,
+  "Oversized image attachments should be capped at capture time and marked like truncated text",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -14,8 +14,9 @@ import { useGlyphOverrides } from "@/lib/cave-glyph-overrides";
 import { resolveFamiliarGlyph } from "@/lib/familiar-glyph";
 import type { ChatLinkedContext } from "@/lib/chat-linked-context";
 import {
+  MAX_ATTACHMENT_IMAGE_BYTES,
   MAX_ATTACHMENT_TEXT_CHARS,
-  stripPreviewOnlyAttachmentFields,
+  stripPreviewOnlyAttachmentFieldsKeepingImages,
   type ChatAttachment,
 } from "@/lib/chat-attachments";
 import { Modal } from "@/components/ui/modal";
@@ -266,6 +267,12 @@ async function fileToAttachment(file: File): Promise<ComposerAttachment> {
     attachment.text = text;
     if (file.size > new Blob([text]).size) attachment.truncated = true;
   } else if (file.type.startsWith("image/")) {
+    if (file.size > MAX_ATTACHMENT_IMAGE_BYTES) {
+      // Mirror the text-truncation idiom: keep the attachment listed but
+      // skip capturing an oversized payload, surfacing the same chip.
+      attachment.truncated = true;
+      return attachment;
+    }
     await new Promise<void>((resolve) => {
       const reader = new FileReader();
       reader.onload = () => {
@@ -1323,7 +1330,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         body: JSON.stringify({
           familiarId: familiar.id,
           prompt: trimmed,
-          ...(outgoingAttachments.length ? { attachments: stripPreviewOnlyAttachmentFields(outgoingAttachments) } : {}),
+          ...(outgoingAttachments.length ? { attachments: stripPreviewOnlyAttachmentFieldsKeepingImages(outgoingAttachments) } : {}),
           sessionId: currentSessionRef.current,
           ...((cwdDraft.trim() || projectRoot) && !currentSessionRef.current
             ? { projectRoot: cwdDraft.trim() || projectRoot }

--- a/src/lib/chat-attachments.test.ts
+++ b/src/lib/chat-attachments.test.ts
@@ -4,6 +4,7 @@ import {
   buildPromptWithAttachments,
   normalizeChatAttachments,
   stripPreviewOnlyAttachmentFields,
+  stripPreviewOnlyAttachmentFieldsKeepingImages,
 } from "./chat-attachments.ts";
 
 const attachments = normalizeChatAttachments([
@@ -37,7 +38,10 @@ assert.match(prompt, /^Please review these\./);
 assert.match(prompt, /Attached files:/);
 assert.match(prompt, /1\. notes\.md \(text\/markdown, 42 B\)/);
 assert.match(prompt, /```text\nFirst line\nSecond line\n```/);
-assert.match(prompt, /2\. diagram\.png \(image\/png, 128 B\)\n\(content unavailable\)/);
+// Image attachments never render the misleading "(content unavailable)" —
+// without a delivered payload they get an explicit not-delivered notice.
+assert.match(prompt, /2\. diagram\.png \(image\/png, 128 B\)\n\(image attachment was not delivered — payload missing or over the size limit\)/);
+assert.doesNotMatch(prompt, /2\. diagram\.png[^\n]*\n\(content unavailable\)/);
 assert.match(prompt, /3\. secret\.txt \(text\/plain, 12 B\)/);
 
 const attachmentOnly = buildPromptWithAttachments("", [attachments[0]]);
@@ -70,6 +74,41 @@ assert.deepEqual(
       name: "diagram.png",
       type: "image/png",
       size: 128,
+    },
+  ],
+);
+
+// The send-body variant keeps valid image payloads (so the server can deliver
+// them to the harness) but still strips preview fields from non-images.
+assert.deepEqual(
+  stripPreviewOnlyAttachmentFieldsKeepingImages([
+    {
+      name: "diagram.png",
+      type: "image/png",
+      mimeType: "image/png",
+      size: 128,
+      dataUrl: "data:image/png;base64,aGVsbG8=",
+    },
+    {
+      name: "doc.pdf",
+      type: "application/pdf",
+      mimeType: "application/pdf",
+      size: 64,
+      dataUrl: "data:application/pdf;base64,aGVsbG8=",
+    },
+  ]),
+  [
+    {
+      name: "diagram.png",
+      type: "image/png",
+      size: 128,
+      mimeType: "image/png",
+      dataUrl: "data:image/png;base64,aGVsbG8=",
+    },
+    {
+      name: "doc.pdf",
+      type: "application/pdf",
+      size: 64,
     },
   ],
 );

--- a/src/lib/chat-attachments.ts
+++ b/src/lib/chat-attachments.ts
@@ -1,4 +1,11 @@
 export const MAX_ATTACHMENT_TEXT_CHARS = 64_000;
+/** Hard cap on a decoded image payload, enforced on capture (client) and on
+ * normalize (server) — the server never trusts the client-side check. */
+export const MAX_ATTACHMENT_IMAGE_BYTES = 5 * 1024 * 1024;
+export const IMAGE_ATTACHMENTS_UNSUPPORTED_NOTE =
+  "(image attachments are not supported by this harness)";
+const IMAGE_NOT_DELIVERED_NOTE =
+  "(image attachment was not delivered — payload missing or over the size limit)";
 
 export type ChatAttachment = {
   name: string;
@@ -29,6 +36,36 @@ function cleanSize(size: unknown): number | undefined {
   return Math.round(size);
 }
 
+const IMAGE_DATA_URL_RE =
+  /^data:(image\/[a-z0-9.+-]{1,60});base64,([A-Za-z0-9+/]+={0,2})$/i;
+// Generous string-length gate so multi-megabyte non-payloads are rejected
+// before the regex ever scans them: base64 inflates bytes 4/3 plus prefix.
+const MAX_IMAGE_DATA_URL_CHARS =
+  Math.ceil(MAX_ATTACHMENT_IMAGE_BYTES / 3) * 4 + 128;
+
+function base64DecodedBytes(base64: string): number {
+  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+  return Math.floor((base64.length * 3) / 4) - padding;
+}
+
+/** Validate a base64 image data URL and enforce the decoded-size cap.
+ * Returns the canonical mime type from the data URL itself, or null when the
+ * payload is malformed, non-image, or oversized. */
+export function cleanImageDataUrl(
+  dataUrl: unknown,
+): { dataUrl: string; mimeType: string } | null {
+  if (typeof dataUrl !== "string" || dataUrl.length > MAX_IMAGE_DATA_URL_CHARS) return null;
+  const match = dataUrl.match(IMAGE_DATA_URL_RE);
+  if (!match) return null;
+  const decodedBytes = base64DecodedBytes(match[2]);
+  if (decodedBytes === 0 || decodedBytes > MAX_ATTACHMENT_IMAGE_BYTES) return null;
+  return { dataUrl, mimeType: match[1].toLowerCase() };
+}
+
+function isImageAttachment(attachment: ChatAttachment): boolean {
+  return Boolean((attachment.mimeType ?? attachment.type)?.startsWith("image/"));
+}
+
 export function normalizeChatAttachments(input: unknown): ChatAttachment[] {
   if (!Array.isArray(input)) return [];
   return input
@@ -37,18 +74,37 @@ export function normalizeChatAttachments(input: unknown): ChatAttachment[] {
       const raw = (item && typeof item === "object") ? item as Record<string, unknown> : {};
       const rawText = typeof raw.text === "string" ? raw.text.replace(/\r\n/g, "\n") : undefined;
       const text = rawText != null ? rawText.slice(0, MAX_ATTACHMENT_TEXT_CHARS) : undefined;
+      // Image payloads ride through normalization (bounded + validated) so the
+      // server can hand them to the harness. Everything else stays metadata-only.
+      const image = cleanImageDataUrl(raw.dataUrl);
+      const mimeType = cleanType(raw.mimeType);
       return {
         name: cleanName(raw.name),
         type: cleanType(raw.type),
         size: cleanSize(raw.size),
+        ...(mimeType ? { mimeType } : {}),
         ...(text != null ? { text } : {}),
         ...(rawText != null && rawText.length > MAX_ATTACHMENT_TEXT_CHARS ? { truncated: true } : {}),
+        ...(image ? { mimeType: image.mimeType, dataUrl: image.dataUrl } : {}),
       };
     });
 }
 
 export function stripPreviewOnlyAttachmentFields(attachments: ChatAttachment[]): ChatAttachment[] {
   return attachments.map(({ dataUrl: _dataUrl, mimeType: _mimeType, ...attachment }) => attachment);
+}
+
+/** Send-body variant of stripPreviewOnlyAttachmentFields: image attachments
+ * keep their bounded `dataUrl`/`mimeType` (the only channel that gets the
+ * pixels to the harness); everything else is stripped to metadata. */
+export function stripPreviewOnlyAttachmentFieldsKeepingImages(
+  attachments: ChatAttachment[],
+): ChatAttachment[] {
+  return attachments.map((attachment) => {
+    const { dataUrl, mimeType, ...rest } = attachment;
+    const image = mimeType?.startsWith("image/") ? cleanImageDataUrl(dataUrl) : null;
+    return image ? { ...rest, mimeType: image.mimeType, dataUrl: image.dataUrl } : rest;
+  });
 }
 
 function formatBytes(size?: number): string {
@@ -67,21 +123,46 @@ function metadataFor(attachment: ChatAttachment): string {
   return [attachment.type || "unknown type", formatBytes(attachment.size)].join(", ");
 }
 
-export function buildPromptWithAttachments(prompt: string, attachments: ChatAttachment[]): string {
+export type AttachmentPromptOptions = {
+  /** Absolute path per attachment index where the server saved the image
+   * payload so a file-reading harness can open it. */
+  imageFilePaths?: ReadonlyMap<number, string>;
+  /** When false, image entries render an explicit unsupported notice (e.g. a
+   * bridge harness with no access to this machine's filesystem). */
+  imagesSupported?: boolean;
+};
+
+export function buildPromptWithAttachments(
+  prompt: string,
+  attachments: ChatAttachment[],
+  options: AttachmentPromptOptions = {},
+): string {
   const text = prompt.trim();
   const normalized = normalizeChatAttachments(attachments);
   if (normalized.length === 0) return text;
 
   const header = text || `Review the attached file${normalized.length === 1 ? "" : "s"}.`;
   const parts = normalized.map((attachment, index) => {
-    const body = attachment.text
-      ? [
-          "```text",
-          attachment.text,
-          "```",
-          attachment.truncated ? "(content truncated)" : "",
-        ].filter(Boolean).join("\n")
-      : "(content unavailable)";
+    let body: string;
+    if (attachment.text) {
+      body = [
+        "```text",
+        attachment.text,
+        "```",
+        attachment.truncated ? "(content truncated)" : "",
+      ].filter(Boolean).join("\n");
+    } else if (isImageAttachment(attachment)) {
+      const savedPath = options.imageFilePaths?.get(index);
+      if (options.imagesSupported === false) {
+        body = IMAGE_ATTACHMENTS_UNSUPPORTED_NOTE;
+      } else if (savedPath) {
+        body = `Image saved to ${savedPath} — open it with the Read tool to view.`;
+      } else {
+        body = IMAGE_NOT_DELIVERED_NOTE;
+      }
+    } else {
+      body = "(content unavailable)";
+    }
     return `${index + 1}. ${attachment.name} (${metadataFor(attachment)})\n${body}`;
   });
 


### PR DESCRIPTION
## Summary

Implements audit finding **CHAT-D1-01 (P0)** from the chat UX audit (#395): the chat UI accepts image attachments and previews them in the lightbox, but the model never sees them — the client strips `dataUrl`/`mimeType` from the POST body, `normalizeChatAttachments` never preserves them, and `buildPromptWithAttachments` renders the literal `"(content unavailable)"` for every non-text attachment. The user reasonably believes the familiar saw the screenshot; it saw a shrug.

## Channel design

The local coven-run harnesses are agentic CLIs with a Read tool that can view image files, so images are delivered via the filesystem:

1. **Client** (`chat-view.tsx`): the send body now uses `stripPreviewOnlyAttachmentFieldsKeepingImages` — image attachments keep their bounded base64 `dataUrl` + `mimeType`; everything else is stripped to metadata as before.
2. **Server normalize** (`chat-attachments.ts`): `normalizeChatAttachments` preserves the payload only when it is a well-formed `data:image/...;base64,` URL within the size cap (validated server-side; the client is not trusted). Malformed, non-image, empty, or oversized payloads are dropped to metadata.
3. **Route** (`route.ts`): each surviving image payload is written to `$TMPDIR/coven-cave-attachments/<uuid>.<ext>` (file mode `0600`, dir `0700`; extension derived from the validated mime subtype, never from user input). The prompt then renders:
   > `Image saved to <absolute path> — open it with the Read tool to view.`
4. **Per-harness behavior**: the OpenClaw bridge and SSH runtimes cannot read this machine's filesystem, so no temp files are written for them and their prompts render an explicit `(image attachments are not supported by this harness)`. An image whose payload never arrived (oversized/legacy client) renders `(image attachment was not delivered — payload missing or over the size limit)`. Images never render the misleading `(content unavailable)` anymore.

## Size caps

`MAX_ATTACHMENT_IMAGE_BYTES = 5 MB` decoded, enforced at three points: capture (`fileToAttachment` skips reading the payload and marks the attachment `truncated`, mirroring the text-truncation idiom/chip), normalization (data-URL validation + decoded-size check, with a string-length gate before the regex), and the temp-file writer (defense in depth, also rejects empty payloads).

## Cleanup choice

Temp files are best-effort deleted **after the final `done` SSE event**, i.e. after the harness child process (including any transparent resume retry, which reuses the same prompt and therefore the same files) has exited — so cleanup cannot race the harness reading them. If the request aborts mid-stream, files may remain in tmpdir; that's the accepted trade-off per the finding.

Transcripts persist attachment **metadata only** (`stripPreviewOnlyAttachmentFields`) so base64 payloads never bloat the conversation store.

## Pinned-test adjustments

- `chat-view-polish.test.ts`: the strip-before-POST pin now expects `stripPreviewOnlyAttachmentFieldsKeepingImages` (the fix's whole point is that image payloads survive the POST); added a pin for the capture-time image cap.
- `chat-attachments.test.ts`: the `diagram.png → (content unavailable)` pin now expects the explicit not-delivered notice, plus coverage for the keeping-images strip variant.
- `harness-routing.test.ts`: extended with behavioral tests (normalize preserves bounded image dataUrl; rejects oversized/malformed/non-image/empty payloads; prompt renders the saved-path line, the unsupported-harness line, and never `(content unavailable)` for images) and source pins for the temp-file channel (0600 mode, uuid+mime-derived names, openclaw/ssh exclusion, post-exit cleanup, metadata-only persistence).

## Verification

- `node --experimental-strip-types` on `harness-routing.test.ts`, `chat-attachments.test.ts`, `chat-view-polish.test.ts`, `api-contracts.test.ts` — pass
- `pnpm test:api` — pass
- `pnpm test:app` — pass
- `pnpm typecheck` — pass
- Note: `board-chat-link.test.ts` fails identically on `main` (stale pin on the board chat route, not in any CI script) — untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)