### PR TITLE
ui(salem): drop the Docs/Tools/Skills/Context count pills from the panel header

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4413,30 +4413,6 @@ button:active > .edge-rail-chip {
   background: color-mix(in oklch, var(--accent-presence) 15%, transparent);
 }
 
-.salem-panel__preload {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 6px;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--border-hairline);
-  background: color-mix(in oklch, var(--bg-panel) 82%, var(--bg-base));
-  flex-shrink: 0;
-}
-
-.salem-panel__preload span {
-  min-width: 0;
-  border: 1px solid color-mix(in oklch, var(--accent-presence) 16%, var(--border-hairline));
-  border-radius: var(--radius-control);
-  padding: 5px 6px;
-  color: var(--text-secondary);
-  background: color-mix(in oklch, var(--bg-raised) 72%, transparent);
-  font-size: var(--text-2xs);
-  font-weight: 650;
-  line-height: 1.1;
-  text-align: center;
-  white-space: nowrap;
-}
-
 .salem-panel__messages {
   flex: 1;
   overflow-y: auto;

--- a/src/components/salem/salem-widget.tsx
+++ b/src/components/salem/salem-widget.tsx
@@ -23,7 +23,6 @@ const SalemCat3D = dynamic(
 type Message = { role: "user" | "salem"; text: string };
 
 type SalemMood = "idle" | "thinking" | "happy" | "listening";
-type PreloadSummary = { docs: number; tools: number; skills: number; context: number };
 
 const GREETING = "I'm Salem, your Coven docs familiar. Yes, the black-cat-in-the-corner thing is intentional. I'm preloaded with Coven docs, tool context, guide skills, and Cave route awareness. Ask me about familiars, plugins, roles, the marketplace, or how Cave works.";
 
@@ -70,10 +69,7 @@ export function SalemChatPanel() {
   ]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
-  const [preload, setPreload] = useState<{
-    summary: PreloadSummary;
-    preload: SalemPreloadContext;
-  } | null>(null);
+  const [preload, setPreload] = useState<SalemPreloadContext | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const coarse = useIsCoarsePointer();
 
@@ -85,9 +81,9 @@ export function SalemChatPanel() {
     let alive = true;
     fetch("/api/salem")
       .then((res) => res.json())
-      .then((data: { summary?: PreloadSummary; preload?: SalemPreloadContext }) => {
-        if (alive && data.summary && data.preload) {
-          setPreload({ summary: data.summary, preload: data.preload });
+      .then((data: { preload?: SalemPreloadContext }) => {
+        if (alive && data.preload) {
+          setPreload(data.preload);
         }
       })
       .catch(() => { if (alive) setPreload(null); });
@@ -131,7 +127,7 @@ export function SalemChatPanel() {
           <div>
             <div className="salem-panel__name">Salem</div>
             <div className="salem-panel__subtitle">
-              {preload?.preload.persona.archetype ?? "Male docs familiar"}
+              {preload?.persona.archetype ?? "Male docs familiar"}
             </div>
           </div>
         </div>
@@ -139,23 +135,6 @@ export function SalemChatPanel() {
           <Icon name="ph:book-open" width={14} />
         </div>
       </div>
-
-      {preload ? (
-        <div className="salem-panel__preload" aria-label="Salem loaded context">
-          <span title={preload.preload.docsCorpus.map((item) => item.label).join(", ")}>
-            Docs {preload.summary.docs}
-          </span>
-          <span title={preload.preload.toolLoadout.map((item) => item.label).join(", ")}>
-            Tools {preload.summary.tools}
-          </span>
-          <span title={preload.preload.skillLoadout.map((item) => item.label).join(", ")}>
-            Skills {preload.summary.skills}
-          </span>
-          <span title={preload.preload.routeContext.map((item) => item.label).join(", ")}>
-            Context {preload.summary.context}
-          </span>
-        </div>
-      ) : null}
 
       {/* Messages */}
       <div className="salem-panel__messages">

--- a/src/components/salem/salem.test.ts
+++ b/src/components/salem/salem.test.ts
@@ -51,10 +51,12 @@ assert.match(route, /plugin|Plugin/, "must know about plugins");
 assert.match(route, /Male black cat/, "must answer with Salem's persona");
 assert.doesNotMatch(route, /🐱|😅/, "Salem API replies must stay emoji-free inside chat");
 
-// 5. SalemWidget surfaces preload status
+// 5. SalemWidget loads preload metadata for the persona subtitle, but the
+//    Docs/Tools/Skills/Context count pills were removed on purpose
+//    (2026-06-11, Val: "no one cares about the docs count") — they must
+//    not come back.
 assert.match(widget, /preload/, "widget must load Salem preload metadata");
-assert.match(widget, /salem-panel__preload/, "widget must render preload metadata");
-assert.match(widget, /Docs|Tools|Skills|Context/, "widget must label loaded docs/tools/skills/context");
+assert.doesNotMatch(widget, /salem-panel__preload/, "preload count pills stay removed from the Salem header");
 
 // 6. Workspace exposes Salem via a right-edge agentRail toggle that mirrors
 //    the left-edge sidebar-trigger-rail. The standalone perch in layout.tsx
@@ -78,7 +80,7 @@ assert.match(css, /\.salem-perch/, "must have .salem-perch CSS");
 assert.match(css, /\.salem-panel/, "must have .salem-panel CSS");
 assert.match(css, /\.salem-panel--rail/, "must support Salem inside the right rail");
 assert.match(css, /\.salem-msg/, "must have .salem-msg CSS");
-assert.match(css, /\.salem-panel__preload/, "must style Salem preload metadata");
+assert.doesNotMatch(css, /\.salem-panel__preload/, "preload pill CSS removed with the pills — no dead rules");
 assert.match(css, /--background:\s*oklch\([^)]+\);/, "default dark app background must be lifted for black-cat contrast");
 assert.match(css, /\.salem-perch::before/, "Salem perch must include a visibility halo");
 assert.doesNotMatch(css, /\.salem-msg__glyph/, "open Salem chat must not keep unused emoji glyph CSS");


### PR DESCRIPTION
Removes the pill row under the Salem header ("Docs 6 / Tools 5 / Skills 4 / Context 5") — inventory counts nobody acts on. 

- `salem-widget.tsx`: pill JSX gone; the `/api/salem` preload fetch stays because the persona subtitle ("Male black cat docs familiar") comes from it. `PreloadSummary` plumbing removed.
- `globals.css`: both `.salem-panel__preload` rules deleted — no dead CSS.
- `salem.test.ts`: guard flipped — the widget and CSS must NOT reference `salem-panel__preload` anymore.

Verified in Chromium against a worktree dev server: panel renders header → greeting, no pill row. Salem guard tests pass (7 sections, 37 assertions); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)