### PR TITLE
feat(chat): edit-and-resend user turns; regenerate assistant turns

### DIFF
--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -161,4 +161,50 @@ assert.match(
   "Tooling lifecycle should have its own status style",
 );
 
+// ── CHAT-D6-01 / CHAT-D6-02: edit-and-resend + regenerate (append semantics) ──
+
+const bubbleSource = readFileSync(new URL("./message-bubble.tsx", import.meta.url), "utf8");
+
+assert.match(
+  source,
+  /function editTurnInComposer\(turn: Turn\)[\s\S]*?setInput\(\(current\) => \(current\.trim\(\) \? current : turn\.text\)\);[\s\S]*?inputRef\.current\?\.focus\(\);/,
+  "Edit on a user turn loads its text into the composer only when the draft is empty, then focuses it (CHAT-D6-01)",
+);
+
+assert.match(
+  source,
+  /onEdit=\{t\.role === "user" && t\.text\.trim\(\) \? \(\) => editTurnInComposer\(t\) : undefined\}/,
+  "Only user turns with text get the Edit affordance (CHAT-D6-01)",
+);
+
+assert.match(
+  source,
+  /function regenerateFor\(turn: Turn\)[\s\S]*?if \(busy \|\| turn\.role !== "assistant" \|\| turn\.pending\) return undefined;/,
+  "Regenerate is hidden while busy and on pending turns (CHAT-D6-02)",
+);
+
+assert.match(
+  source,
+  /function regenerateFor\(turn: Turn\)[\s\S]*?role === "user"[\s\S]*?if \(!prevUser\) return undefined;[\s\S]*?return \(\) => void sendRaw\(text, prevAttachments \?\? \[\]\);/,
+  "Regenerate re-sends the preceding user turn (text + attachments) through the guarded sendRaw path, and hides when no user turn precedes (CHAT-D6-02)",
+);
+
+assert.match(
+  source,
+  /onRegenerate=\{regenerateFor\(t\)\}/,
+  "Assistant turns get the Regenerate affordance via the gated helper (CHAT-D6-02)",
+);
+
+assert.match(
+  bubbleSource,
+  /aria-label="Edit message"[\s\S]{0,200}className="cave-copy-btn cave-copy-btn-bubble cave-copy-btn--icon"/,
+  "Edit renders in the user bubble's CSS-revealed action row with the shared button styling (CHAT-D6-01)",
+);
+
+assert.match(
+  bubbleSource,
+  /aria-label="Regenerate response"[\s\S]{0,200}className="cave-copy-btn cave-copy-btn-bubble cave-copy-btn--icon"/,
+  "Regenerate renders in the assistant bubble's CSS-revealed action row with the shared button styling (CHAT-D6-02)",
+);
+
 console.log("chat-view-lifecycle.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1414,6 +1414,36 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     void sendRaw(lastFailedSend.text, lastFailedSend.attachments);
   }
 
+  // CHAT-D6-01: edit-and-resend. Loads a user turn's text into the composer so
+  // the user can revise and send it as a NEW message — append semantics, no
+  // truncation/forking (that's D6-03: the harness session keeps its own
+  // server-side context, so locally rewriting the transcript would lie on
+  // reload). A non-empty draft is never silently destroyed: we only prefill
+  // when the composer is empty, and always hand focus back to it.
+  function editTurnInComposer(turn: Turn) {
+    setInput((current) => (current.trim() ? current : turn.text));
+    inputRef.current?.focus();
+  }
+
+  // CHAT-D6-02: regenerate. Re-sends the PRECEDING user turn (text +
+  // attachments) through the normal guarded sendRaw path as a new turn pair.
+  // Returns undefined (action hidden) while busy, on pending turns, and on
+  // assistant turns with no preceding user turn (e.g. system-injected).
+  function regenerateFor(turn: Turn): (() => void) | undefined {
+    if (busy || turn.role !== "assistant" || turn.pending) return undefined;
+    const idx = turns.findIndex((t) => t.id === turn.id);
+    if (idx < 0) return undefined;
+    let prevUser: Turn | undefined;
+    for (let j = idx - 1; j >= 0; j -= 1) {
+      const candidate = turns[j];
+      if (candidate && candidate.role === "user") { prevUser = candidate; break; }
+    }
+    if (!prevUser) return undefined;
+    const { text, attachments: prevAttachments } = prevUser;
+    if (!text.trim() && !prevAttachments?.length) return undefined;
+    return () => void sendRaw(text, prevAttachments ?? []);
+  }
+
   const send = async () => {
     const text = input.trim();
     if (!text && attachments.length === 0) return;
@@ -1898,7 +1928,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   return prev.role !== t.role;
                 })();
                 return (
-                  <TurnRow key={t.id} turn={t} familiar={familiar} showTimestamp={showTimestamp} />
+                  <TurnRow
+                    key={t.id}
+                    turn={t}
+                    familiar={familiar}
+                    showTimestamp={showTimestamp}
+                    onEdit={t.role === "user" && t.text.trim() ? () => editTurnInComposer(t) : undefined}
+                    onRegenerate={regenerateFor(t)}
+                  />
                 );
               }
               const mm = String(Math.floor(g.durationSec / 60)).padStart(2, "0");
@@ -1921,7 +1958,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                       return prev.role !== t.role;
                     })();
                     return (
-                      <TurnRow key={t.id} turn={t} familiar={familiar} showTimestamp={showTimestamp} />
+                      <TurnRow
+                        key={t.id}
+                        turn={t}
+                        familiar={familiar}
+                        showTimestamp={showTimestamp}
+                        onEdit={t.role === "user" && t.text.trim() ? () => editTurnInComposer(t) : undefined}
+                        onRegenerate={regenerateFor(t)}
+                      />
                     );
                   })}
                 </div>
@@ -2210,10 +2254,16 @@ function TurnRow({
   turn,
   familiar,
   showTimestamp = true,
+  onEdit,
+  onRegenerate,
 }: {
   turn: Turn;
   familiar: Familiar;
   showTimestamp?: boolean;
+  /** CHAT-D6-01: present only on user turns — loads the turn into the composer. */
+  onEdit?: () => void;
+  /** CHAT-D6-02: present only on settled assistant turns with a preceding user turn. */
+  onRegenerate?: () => void;
 }) {
   if (turn.role === "system" || turn.role === "user") {
     return (
@@ -2232,6 +2282,7 @@ function TurnRow({
             timestamp={turn.createdAt}
             showTimestamp={false}
             pending={turn.pending}
+            onEdit={onEdit}
           />
           {turn.attachments?.length ? <AttachmentList attachments={turn.attachments} /> : null}
         </div>
@@ -2273,6 +2324,7 @@ function TurnRow({
                 pending={turn.pending}
                 isError={turn.error}
                 label={familiar.display_name}
+                onRegenerate={onRegenerate}
               />
             )}
             {turn.progress?.length ? <ProgressGroup progress={turn.progress} pending={!!turn.pending} /> : null}

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -573,9 +573,15 @@ export type MessageBubbleProps = {
   pending?: boolean;
   isError?: boolean;
   label?: string;
+  /** CHAT-D6-01: edit-and-resend — renders an Edit action in the user bubble's
+   *  revealed action row. Caller decides availability (user turns with text). */
+  onEdit?: () => void;
+  /** CHAT-D6-02: regenerate — renders a Regenerate action in the assistant
+   *  bubble's revealed action row. Caller gates it on !busy/!pending. */
+  onRegenerate?: () => void;
 };
 
-export function MessageBubble({ role, content, timestamp, showTimestamp = true, pending, isError, label }: MessageBubbleProps) {
+export function MessageBubble({ role, content, timestamp, showTimestamp = true, pending, isError, label, onEdit, onRegenerate }: MessageBubbleProps) {
   const [tsVisible, setTsVisible] = useState(false);
   const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -623,8 +629,21 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
         <div className="relative cave-bubble-user">
           <MarkdownContent text={content} pending={pending} />
           {/* Always in the DOM (CHAT-D6-04) — visibility is CSS-gated so the
-              button is reachable by keyboard (Tab), screen readers, and touch. */}
-          {!pending && <CopyBubble text={content} />}
+              buttons are reachable by keyboard (Tab), screen readers, and touch. */}
+          <div className="cave-bubble-actions">
+            {!pending && onEdit ? (
+              <button
+                type="button"
+                aria-label="Edit message"
+                title="Edit and resend"
+                onClick={onEdit}
+                className="cave-copy-btn cave-copy-btn-bubble cave-copy-btn--icon"
+              >
+                <Icon name="ph:pencil-simple" width={11} aria-hidden />
+              </button>
+            ) : null}
+            {!pending && <CopyBubble text={content} />}
+          </div>
         </div>
         <div className={`cave-bubble-timestamp cave-bubble-timestamp--right${shouldShowTs ? " cave-bubble-timestamp--visible" : ""}`}>
           {fmtBubbleTime(timestamp)}
@@ -647,6 +666,17 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
           actions are reachable by keyboard (Tab), screen readers, and touch. */}
       {!pending && content ? (
         <div className="cave-bubble-actions">
+          {onRegenerate ? (
+            <button
+              type="button"
+              aria-label="Regenerate response"
+              title="Regenerate"
+              onClick={onRegenerate}
+              className="cave-copy-btn cave-copy-btn-bubble cave-copy-btn--icon"
+            >
+              <Icon name="ph:arrow-clockwise" width={11} aria-hidden />
+            </button>
+          ) : null}
           <ExpandBubble text={content} label={label ?? "Familiar response"} />
           <CopyBubble text={content} />
         </div>


### PR DESCRIPTION
## Summary

Implements **CHAT-D6-01** (no edit affordance on user turns) and **CHAT-D6-02** (no regenerate on assistant turns) — both P1 findings from the chat UX audit (#395). Until now the only retry in the chat surface was for *failed* sends (`retryLastSend`); benchmarks (ChatGPT, Claude.ai, Cursor) put pencil-edit and Regenerate on every message.

## Scope decision: append semantics (deliberate)

True forking/truncation is **deferred to D6-03** (turn-store redesign with `parentId`/siblings). The harness session retains its own context server-side, so locally truncating turns would make the visible transcript lie on reload. This PR ships the honest MVP:

- **Edit (user turns):** loads the turn's text into the composer and focuses it. The edited send is a normal new message in the session — no truncation. **Draft rule:** a non-empty composer draft is never silently destroyed; Edit only prefill when the draft is empty, and always hands focus back to the composer (same idiom as the mobile Summarize chip).
- **Regenerate (assistant turns):** re-sends the *preceding* user turn's text **and attachments** (the `Turn` type carries them) through the existing guarded `sendRaw` path, as a new turn pair. Hidden while `busy`, on pending turns, and on assistant turns with no preceding user turn (system-injected).

Explicitly out of scope (D6-03): version navigation, branching, model switching, transcript truncation.

## Placement & a11y (follows #400's pattern)

- Buttons are **always rendered when not pending** and revealed by the existing `.cave-copy-btn` CSS family: container hover, `:focus-within`, `:focus-visible`, and always-on for coarse pointers (`@media (pointer: coarse) .cave-copy-btn-bubble { opacity: 1 }` — the new buttons carry `cave-copy-btn-bubble`, so touch is covered).
- They sit in the **same `cave-bubble-actions` row** as Copy/Expand — one consistent affordance group. The user bubble's lone Copy button moved into a `cave-bubble-actions` wrapper (same absolute top-right placement; the existing `.cave-bubble-actions .cave-copy-btn-bubble { position: static }` rule handles layout). **No CSS changes needed.**
- `aria-label="Edit message"` / `aria-label="Regenerate response"`, icon-only (`ph:pencil-simple` / `ph:arrow-clockwise`, both already in the Icon whitelist), keyboard reachable via Tab.
- Gating logic lives in chat-view (`regenerateFor` helper + per-turn `onEdit`); `MessageBubble` only grew optional `onEdit`/`onRegenerate` props rendering into its existing action rows.

All existing source pins kept matching: `{!pending && <CopyBubble`, the assistant `{!pending && content ? (<div className="cave-bubble-actions">` row, the no-`hovered` rule, and #397's send()-ordering pins (the new paths go through `sendRaw`'s busy guard; nothing bypasses it).

## Tests

Extended `src/components/chat-view-lifecycle.test.ts` (already in `test:app`) with pins:
- Edit routes to the composer (empty-draft-only prefill + focus) and only user turns with text get it
- Regenerate re-sends the preceding user turn (text + attachments) via `sendRaw`, gated on `!busy` / `!pending`, hidden with no preceding user turn
- Both buttons render in the CSS-revealed action rows with the shared `cave-copy-btn` styling family

## Verification

- `node --experimental-strip-types` on chat-view-lifecycle, chat-view-polish, message-bubble-markdown — all pass
- Full `pnpm test:app` — exit 0
- `pnpm typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)