### PR TITLE
fix(chat): make transcript keyboard scroll release reachable

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -319,6 +319,11 @@ assert.match(
 );
 assert.match(
   source,
+  /<div\b(?=[^>]*\bref=\{scrollRef\})(?=[^>]*\btabIndex=\{0\})(?=[^>]*\bclassName="cave-chat-transcript)[^>]*>/,
+  "Transcript scroller must be focusable so PageUp/Home/ArrowUp keydown releases following",
+);
+assert.match(
+  source,
   /y > lastTouchY && followingRef\.current\) updateFollowing\(false\)/,
   "Touch drag toward earlier content (finger moving down) detaches following",
 );

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1907,7 +1907,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         </MetaLine>
         <LinkedContextRow linkedContext={linkedContext} onOpenTask={onOpenTask} />
       </header>
-      <div ref={scrollRef} className="cave-chat-transcript relative min-h-0 flex-1 overflow-y-auto">
+      <div ref={scrollRef} tabIndex={0} className="cave-chat-transcript relative min-h-0 flex-1 overflow-y-auto">
         <div
           className="cave-chat-thread"
           role="log"


### PR DESCRIPTION
## Summary
- make the transcript scroller focusable so its PageUp/Home/ArrowUp keydown release handler can actually fire
- add a source-level regression assertion for the focusable scroll container

Follow-up for Copilot feedback on merged PR #404.

## Verification
- node --experimental-strip-types src/components/chat-view-polish.test.ts
- pnpm test:app