### PR TITLE
feat(shell): keyboard shortcuts sheet (⌘/ or ?) and /help keyboard section

### DIFF
--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -7,6 +7,9 @@ const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "u
 const settings = await readFile(new URL("./settings-shell.tsx", import.meta.url), "utf8");
 const pluginsView = await readFile(new URL("./plugins-view.tsx", import.meta.url), "utf8");
 const workspaceMode = await readFile(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
+const shortcutsCatalog = await readFile(new URL("../lib/keyboard-shortcuts.ts", import.meta.url), "utf8");
+const shortcutsSheet = await readFile(new URL("./shortcuts-sheet.tsx", import.meta.url), "utf8");
+const slashCommands = await readFile(new URL("../lib/slash-commands.ts", import.meta.url), "utf8");
 
 assert.match(
   workspaceMode,
@@ -48,4 +51,72 @@ assert.match(
   pluginsView,
   /tabs\?: Tab\[\]/,
   "PluginsView should support caller-selected tab sets",
+);
+
+// --- Keyboard shortcuts sheet (CHAT-D11-03) ---
+
+assert.match(
+  shortcutsCatalog,
+  /export const SHORTCUT_GROUPS/,
+  "Keyboard shortcut catalog should live in src/lib/keyboard-shortcuts.ts",
+);
+
+assert.match(
+  shortcutsCatalog,
+  /Panels & navigation[\s\S]*Composer[\s\S]*Slash menu[\s\S]*Other/,
+  "Catalog should group shortcuts: Panels & navigation / Composer / Slash menu / Other",
+);
+
+assert.match(
+  shortcutsSheet,
+  /from "@\/components\/ui\/modal"/,
+  "Shortcuts sheet should use the shared a11y Modal (focus trap + Esc come free)",
+);
+
+assert.match(
+  shortcutsSheet,
+  /useKeySymbols[\s\S]*SHORTCUT_GROUPS\.map[\s\S]*platformizeHint/,
+  "Sheet should render the catalog with platform-aware key glyphs, never hardcoded ⌘/Ctrl",
+);
+
+assert.match(
+  workspace,
+  /e\.key === "\/"[\s\S]{0,200}setShortcutsOpen/,
+  "⌘/ (Ctrl+/ off-Mac) should toggle the shortcuts sheet from anywhere",
+);
+
+assert.match(
+  workspace,
+  /e\.key === "\?" && !isEditableTarget\(e\.target\)/,
+  "Bare ? should open the sheet only when focus is outside an editable control",
+);
+
+assert.match(
+  workspace,
+  /case "\/shortcuts":[\s\S]{0,80}setShortcutsOpen\(true\)/,
+  "/shortcuts slash command should open the sheet via handleSlashIntent",
+);
+
+assert.match(
+  workspace,
+  /<ShortcutsSheet open=\{shortcutsOpen\}/,
+  "Workspace should mount the ShortcutsSheet alongside the command palette",
+);
+
+assert.match(
+  slashCommands,
+  /name: "\/shortcuts", aliases: \["\/keys"\]/,
+  "/shortcuts (alias /keys) should be a first-class slash command",
+);
+
+assert.match(
+  slashCommands,
+  /lines\.push\("Keyboard"\)[\s\S]*SHORTCUT_GROUPS[\s\S]*neutralizeKeys/,
+  "formatHelp should append a Keyboard section sourced from the shared catalog",
+);
+
+assert.match(
+  slashCommands,
+  /keyboard shortcuts sheet/,
+  "/help footer should mention the shortcuts sheet so it stays discoverable",
 );

--- a/src/components/shortcuts-sheet.tsx
+++ b/src/components/shortcuts-sheet.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Modal } from "@/components/ui/modal";
+import { platformizeHint, useKeySymbols } from "@/lib/platform-keys";
+import { SHORTCUT_GROUPS } from "@/lib/keyboard-shortcuts";
+
+/**
+ * Keyboard shortcuts sheet — opened with ⌘/ (Ctrl+/ off-Mac) or `?` outside
+ * an input (wired in workspace.tsx, next to the ⌘K palette listener), or via
+ * the /shortcuts slash command. Renders the static catalog from
+ * src/lib/keyboard-shortcuts.ts through the shared a11y Modal, so Esc-close
+ * and focus restore come from useFocusTrap for free.
+ */
+export function ShortcutsSheet({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const keys = useKeySymbols();
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      breadcrumb={["CovenCave", "Keyboard shortcuts"]}
+      wide
+      ariaLabel="Keyboard shortcuts"
+    >
+      <div className="grid grid-cols-1 gap-x-8 gap-y-5 sm:grid-cols-2">
+        {SHORTCUT_GROUPS.map((group) => (
+          <section key={group.id} aria-label={group.label}>
+            <h3 className="mb-2 text-[11px] font-medium uppercase tracking-wide text-[var(--text-muted)]">
+              {group.label}
+            </h3>
+            <ul className="flex flex-col gap-1.5">
+              {group.entries.map((entry) => (
+                <li
+                  key={`${entry.keys} ${entry.description}`}
+                  className="flex items-center justify-between gap-3 text-[13px]"
+                >
+                  <span className="text-[var(--text-secondary)]">{entry.description}</span>
+                  <kbd className="shell-kbd whitespace-nowrap">
+                    {platformizeHint(entry.keys, keys)}
+                  </kbd>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -43,6 +43,7 @@ import { HomeComposer } from "@/components/home-composer";
 import { ChatSurface, type RightPanelKind } from "@/components/chat-surface";
 import { SalemChatPanel } from "@/components/salem/salem-widget";
 import { MobileHandoffModal } from "@/components/mobile-handoff-modal";
+import { ShortcutsSheet } from "@/components/shortcuts-sheet";
 import { nativeNotify } from "@/lib/native-notify";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
@@ -78,6 +79,7 @@ export function Workspace() {
   const { pushBanner, dismissBanner } = useShellBanners();
   const [responseNeeded, setResponseNeeded] = useState<Set<string>>(new Set());
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [mode, setMode] = useState<WorkspaceMode>("home");
   const browserPaneRef = useRef<BrowserPaneHandle>(null);
   const [inspectorOpen, setInspectorOpen] = useState(false);
@@ -457,14 +459,33 @@ export function Workspace() {
   }, []);
 
   useEffect(() => {
+    const isEditableTarget = (target: EventTarget | null): boolean => {
+      if (!(target instanceof HTMLElement)) return false;
+      if (target.isContentEditable) return true;
+      const tag = target.tagName;
+      return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+    };
     const onKey = (e: KeyboardEvent) => {
       const meta = e.metaKey || e.ctrlKey;
-      if (!meta) return;
-      const k = e.key.toLowerCase();
-      if (k === "k") {
-        e.preventDefault();
-        setPaletteOpen(true);
+      if (meta) {
+        const k = e.key.toLowerCase();
+        if (k === "k") {
+          e.preventDefault();
+          setPaletteOpen(true);
+          return;
+        }
+        // ⌘/ (Ctrl+/ off-Mac) → keyboard shortcuts sheet, from anywhere.
+        if (e.key === "/") {
+          e.preventDefault();
+          setShortcutsOpen((open) => !open);
+        }
         return;
+      }
+      // Bare `?` also opens the sheet, but only when focus is not in an
+      // input/textarea/contentEditable — typing "?" must stay typing.
+      if (e.key === "?" && !isEditableTarget(e.target)) {
+        e.preventDefault();
+        setShortcutsOpen(true);
       }
     };
     window.addEventListener("keydown", onKey);
@@ -781,6 +802,9 @@ export function Workspace() {
       }
       case "/palette":
         setPaletteOpen(true);
+        return true;
+      case "/shortcuts":
+        setShortcutsOpen(true);
         return true;
       case "/terminal":
         setMode("terminal");
@@ -1206,6 +1230,8 @@ export function Workspace() {
         activeFamiliarId={activeId}
         onIntent={onPaletteIntent}
       />
+
+      <ShortcutsSheet open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
 
       <OnboardingOverlay open={onboardingOpen} onDismiss={closeOnboarding} />
 

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -1,0 +1,89 @@
+/**
+ * Keyboard shortcut catalog — the single source of truth for the Shortcuts
+ * sheet (⌘/ or `?`) and the Keyboard section of `/help`.
+ *
+ * Entries are authored with Mac-canonical glyphs (⌘ ⌥ ⌃ ⇧ ↵) just like the
+ * slash command hints; UI surfaces retarget them per platform with
+ * `platformizeHint` (src/lib/platform-keys.ts), and plain-text surfaces
+ * (`/help`) use [`neutralizeKeys`] below for platform-neutral labels.
+ *
+ * Keep this list truthful: every entry must correspond to a binding that
+ * actually exists in code —
+ *   - panels/terminal: src/components/shell.tsx keydown handlers
+ *   - palette, surfaces, familiars, new chat, this sheet: src/components/workspace.tsx
+ *   - composer + slash menu: src/components/chat-view.tsx onComposerKey and
+ *     src/components/home-composer.tsx handleKeyDown
+ */
+
+export type ShortcutEntry = {
+  /** Key combo, Mac-canonical glyphs (run through platformizeHint to render). */
+  keys: string;
+  description: string;
+};
+
+export type ShortcutGroup = {
+  id: "panels" | "composer" | "slash-menu" | "other";
+  label: string;
+  entries: ShortcutEntry[];
+};
+
+export const SHORTCUT_GROUPS: ShortcutGroup[] = [
+  {
+    id: "panels",
+    label: "Panels & navigation",
+    entries: [
+      { keys: "⌘K", description: "Open the command palette" },
+      { keys: "⌘B", description: "Toggle the navigation sidebar" },
+      { keys: "⌘\\", description: "Toggle the list panel" },
+      { keys: "⌘J", description: "Toggle the Familiar Chat side panel" },
+      { keys: "⌃`", description: "Toggle the integrated terminal (desktop app)" },
+      { keys: "⌘1–⌘8", description: "Jump to a sidebar surface (Home … Terminal)" },
+      { keys: "⌥1–⌥9", description: "Select the Nth familiar" },
+      { keys: "⌘↑ / ⌘↓", description: "Cycle through familiars" },
+      { keys: "⌘N", description: "New chat (on the Chat surface)" },
+    ],
+  },
+  {
+    id: "composer",
+    label: "Composer",
+    entries: [
+      { keys: "↵", description: "Send the message" },
+      { keys: "⇧↵", description: "Insert a newline" },
+      { keys: "Esc", description: "Dismiss the slash menu, then cancel a streaming reply" },
+      { keys: "↑ / ↓", description: "Recall prompt history (home composer, empty input)" },
+    ],
+  },
+  {
+    id: "slash-menu",
+    label: "Slash menu",
+    entries: [
+      { keys: "↑ / ↓", description: "Move the highlight" },
+      { keys: "Tab", description: "Complete the highlighted command" },
+      { keys: "↵", description: "Run the highlighted command (completes first if it takes arguments)" },
+      { keys: "Esc", description: "Dismiss the menu" },
+    ],
+  },
+  {
+    id: "other",
+    label: "Other",
+    entries: [
+      { keys: "⌘/", description: "Open this shortcuts sheet" },
+      { keys: "?", description: "Open the shortcuts sheet (when not typing in a field)" },
+      { keys: "Esc", description: "Close dialogs and modals" },
+    ],
+  },
+];
+
+/**
+ * Platform-neutral plain-text rendering of a key combo, for surfaces that
+ * can't (or shouldn't) detect the platform — e.g. the `/help` transcript
+ * block. "⌘B" → "Cmd/Ctrl+B", "⇧↵" → "Shift+Enter".
+ */
+export function neutralizeKeys(keys: string): string {
+  return keys
+    .replaceAll("⌘", "Cmd/Ctrl+")
+    .replaceAll("⌥", "Alt+")
+    .replaceAll("⌃", "Ctrl+")
+    .replaceAll("⇧", "Shift+")
+    .replaceAll("↵", "Enter");
+}

--- a/src/lib/slash-commands.ts
+++ b/src/lib/slash-commands.ts
@@ -5,6 +5,8 @@
  * /h, /cls, /q, etc. and get the same behavior as the canonical command.
  */
 
+import { SHORTCUT_GROUPS, neutralizeKeys } from "./keyboard-shortcuts";
+
 export type SlashCommand = {
   name: string;
   aliases?: string[];
@@ -21,6 +23,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: "/clear", aliases: ["/cls"], hint: "clear transcript", description: "Clear the local view (daemon session is untouched).", section: "chat" },
   { name: "/quit", aliases: ["/exit", "/q"], hint: "back to chats", description: "Close this chat and return to the chat list.", section: "chat" },
   { name: "/palette", hint: "open ⌘K", description: "Open the command palette.", section: "chat" },
+  { name: "/shortcuts", aliases: ["/keys"], hint: "open ⌘/ sheet", description: "Open the keyboard shortcuts sheet.", section: "chat" },
   { name: "/new", hint: "new chat", description: "Start a fresh chat with the active familiar.", section: "chat" },
 
   // Familiar
@@ -103,5 +106,17 @@ export function formatHelp(): string {
     }
     lines.push("");
   }
+  // Keyboard shortcuts — sourced from the same catalog as the ⌘/ sheet
+  // (src/lib/keyboard-shortcuts.ts). /help is rendered as plain transcript
+  // text with no platform detection, so use neutral Cmd/Ctrl labels.
+  lines.push("Keyboard");
+  for (const group of SHORTCUT_GROUPS) {
+    lines.push(`  ${group.label}`);
+    for (const entry of group.entries) {
+      lines.push(`    ${neutralizeKeys(entry.keys)} — ${entry.description}`);
+    }
+  }
+  lines.push("");
+  lines.push("Press Cmd/Ctrl+/ (or ? outside an input) to open the keyboard shortcuts sheet.");
   return lines.join("\n").trim();
 }


### PR DESCRIPTION
Implements **CHAT-D11-03 (P2)** from the chat UX audit (#395): the app has rich chrome shortcuts but no help surface listing them — they were discoverable only via scattered hints. Benchmarks: ChatGPT ⌘/, Linear-style `?` sheet.

## What's new

### Shortcut catalog — `src/lib/keyboard-shortcuts.ts`
Single source of truth, every entry verified against the actual handlers (shell.tsx, workspace.tsx, chat-view.tsx `onComposerKey`, home-composer.tsx). Groups:

- **Panels & navigation** — ⌘K palette, ⌘B nav, ⌘\ list, ⌘J agent panel, ⌃` terminal, ⌘1–⌘8 surfaces, ⌥1–⌥9 familiars, ⌘↑/⌘↓ cycle familiars, ⌘N new chat
- **Composer** — ↵ send, ⇧↵ newline, Esc precedence (dismiss slash menu → cancel stream, per #402), ↑/↓ history (home composer)
- **Slash menu** — ↑↓ navigate, Tab complete, ↵ run, Esc dismiss
- **Other** — ⌘/ sheet, `?` sheet (outside inputs), Esc closes dialogs

Entries are authored with Mac-canonical glyphs (same pattern as slash hints); `neutralizeKeys()` produces platform-neutral labels ("Cmd/Ctrl+B") for plain-text surfaces.

### Shortcuts sheet — `src/components/shortcuts-sheet.tsx`
Built on the shared a11y `Modal` (useFocusTrap → Esc close + focus restore for free). Key glyphs rendered via `useKeySymbols` + `platformizeHint` — nothing hardcoded ⌘ vs Ctrl.

### Wiring — `workspace.tsx`
- **⌘/ (Ctrl+/ off-Mac)** toggles the sheet from anywhere; **`?`** opens it only when focus is NOT in an input/textarea/contentEditable. The listener lives in the same effect as the existing ⌘K handler so layering matches.
- **`/shortcuts` (alias `/keys`) included** — wiring was clean: one `case` in `handleSlashIntent` (which already returns true/false per #402), one catalog entry in `SLASH_COMMANDS`. Both composers canonicalize aliases before dispatch, so `/keys` works everywhere.

### `/help` — `src/lib/slash-commands.ts`
`formatHelp()` gains a **Keyboard** section sourced from the same catalog (neutral Cmd/Ctrl labels — /help is platform-agnostic transcript text), plus a footer line advertising the sheet. No new chrome buttons.

## Tests
Extended `roles-tools-navigation.test.ts` (it already source-inspects workspace.tsx + lib modules) with pins: catalog exists with the four groups; sheet renders from it via shared Modal + useKeySymbols/platformizeHint; ⌘/ and guarded-`?` listeners; `/shortcuts` case; formatHelp Keyboard section + footer mention.

- `node --experimental-strip-types src/components/roles-tools-navigation.test.ts` — pass
- `node --experimental-strip-types src/components/chat-view-polish.test.ts` — pass (pins handleSlashIntent shape; not edited)
- `pnpm test:app` — full suite pass
- `pnpm typecheck` — pass

Out of scope per audit constraints: chat-view.tsx, message-bubble.tsx, contended test files, package.json — all untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)