### PR TITLE
feat(chat): URL deep-links to chat sessions (#chat-<id>) with back/forward

### DIFF
--- a/src/components/chat-router-switching.test.ts
+++ b/src/components/chat-router-switching.test.ts
@@ -42,4 +42,93 @@ assert.match(
   "ChatRouter should render the projects sidebar next to ChatView while a chat is open",
 );
 
+// ── CHAT-D9-01: URL deep links (#chat-<sessionId>) ───────────────────────────
+
+const workspaceSource = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+const chatSurfaceSource = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "utf8");
+
+const hashSyncEffect =
+  source.match(/useEffect\(\(\) => \{[\s\S]*?\}, \[syncUrlHash, view\]\);/)?.[0] ?? "";
+
+assert.ok(
+  hashSyncEffect.length > 0,
+  "ChatRouter should sync the URL hash from an effect keyed on [syncUrlHash, view] — session promotion flows through setView, so the same effect picks up the promoted id",
+);
+
+assert.match(
+  hashSyncEffect,
+  /`#chat-\$\{encodeURIComponent\(view\.sessionId\)\}`/,
+  "Opening a chat should write #chat-<sessionId> to the URL hash",
+);
+
+assert.match(
+  hashSyncEffect,
+  /history\.pushState/,
+  "Opening a chat must push a history entry so browser Back returns to the list",
+);
+
+assert.match(
+  hashSyncEffect,
+  /hash\.startsWith\("#chat-"\)[\s\S]*?history\.replaceState/,
+  "Returning to the list should clear the chat hash via replaceState (no extra history entry)",
+);
+
+assert.match(
+  hashSyncEffect,
+  /if \(!syncUrlHash/,
+  "Hash sync must be opt-in — the companion-rail ChatRouter must not fight the main surface for the URL hash",
+);
+
+assert.match(
+  hashSyncEffect,
+  /isFirstRun/,
+  "The first effect run (mount lands on the list view) must not clear a deep-link hash before workspace restores it",
+);
+
+assert.match(
+  source,
+  /prev\.kind === "chat" && prev\.sessionId === null\s*\? \{ kind: "chat", sessionId: sid/,
+  "Session promotion must update the view's sessionId via setView so the hash-sync effect writes the promoted id",
+);
+
+assert.match(
+  chatSurfaceSource,
+  /<ChatRouter[\s\S]*?syncUrlHash[\s\S]*?\/>/,
+  "The main chat surface's ChatRouter must opt into URL hash sync",
+);
+
+const restoreEffect =
+  workspaceSource.match(
+    /useEffect\(\(\) => \{\s*if \(!sessionsLoaded\) return;[\s\S]*?\}, \[sessionsLoaded, sessions, openAgentSession, showAgentChatList\]\);/,
+  )?.[0] ?? "";
+
+assert.ok(
+  restoreEffect.length > 0,
+  "Workspace's mount-time deep-link restore must wait for the async sessions fetch (sessionsLoaded) before resolving #chat-<sessionId>",
+);
+
+assert.match(
+  restoreEffect,
+  /pendingChatDeepLinkRef/,
+  "Mount-time restore should consume the deep-link target captured at mount",
+);
+
+assert.match(
+  restoreEffect,
+  /openAgentSession\(sid, target\.familiarId\)/,
+  "A resolved deep link should open the session via openAgentSession (same lookup as /attach)",
+);
+
+assert.match(
+  restoreEffect,
+  /clearChatHash\(\);\s*showAgentChatList\(\)/,
+  "Unknown/stale deep-link ids must fall back to the chat list with the hash cleared — no crash",
+);
+
+assert.match(
+  workspaceSource,
+  /addEventListener\("popstate"/,
+  "Workspace must listen for popstate so browser Back/Forward navigates between list and chat",
+);
+
 console.log("chat-router-switching.test.ts: ok");

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -35,6 +35,11 @@ type Props = {
   pendingProjectRoot?: string | null;
   /** Route back to the linked board task from the chat header. */
   onOpenTask?: (cardId: string) => void;
+  /** Mirror the open chat into the URL hash (`#chat-<sessionId>`) so chats are
+   *  deep-linkable and browser Back/Forward navigates list ↔ chat. Only the
+   *  main chat surface opts in — the companion-rail ChatRouter must not fight
+   *  it for the hash. Workspace owns mount-time restore + popstate handling. */
+  syncUrlHash?: boolean;
 };
 
 export type ChatRouterHandle = {
@@ -66,6 +71,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     onOpenOnboarding,
     pendingProjectRoot,
     onOpenTask,
+    syncUrlHash,
   },
   ref,
 ) {
@@ -121,6 +127,34 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
   useEffect(() => {
     if (sidebarHydrated) window.localStorage.setItem(PROJECT_SIDEBAR_KEYS.selected, JSON.stringify(selection));
   }, [sidebarHydrated, selection]);
+
+  // ── URL hash sync (CHAT-D9-01) ────────────────────────────────────────────
+  // Follows the existing in-app hash idiom (`#card-<id>`, `library:projects`):
+  // an open chat is reflected as `#chat-<sessionId>`, so reloads and shared
+  // links can re-enter the thread (workspace.tsx owns mount-time restore and
+  // the popstate listener). History semantics: opening a chat *pushes* an
+  // entry — browser Back returns to the list; switching chats and session
+  // promotion are view changes through this same effect. Returning to the
+  // list *replaces* — the hash is cleared without growing the stack, so a
+  // direct deep-link entry isn't trapped behind a synthetic entry.
+  const hashSyncedOnceRef = useRef(false);
+  useEffect(() => {
+    if (!syncUrlHash || typeof window === "undefined") return;
+    const isFirstRun = !hashSyncedOnceRef.current;
+    hashSyncedOnceRef.current = true;
+    const hash = window.location.hash;
+    if (view.kind === "chat" && view.sessionId) {
+      const next = `#chat-${encodeURIComponent(view.sessionId)}`;
+      if (hash !== next) window.history.pushState(null, "", next);
+      return;
+    }
+    // Mount always lands on the list view; never clear a deep-link hash here
+    // before workspace's restore effect has had a chance to open the session.
+    if (isFirstRun) return;
+    if (hash.startsWith("#chat-")) {
+      window.history.replaceState(null, "", window.location.pathname + window.location.search);
+    }
+  }, [syncUrlHash, view]);
 
   function selectFamiliarForChat(familiarId?: string | null): Familiar | null {
     const next = familiarId

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -314,6 +314,7 @@ export function ChatSurface({
                   onOpenOnboarding={onOpenOnboarding}
                   pendingProjectRoot={pendingProjectRoot}
                   onOpenTask={onOpenTask}
+                  syncUrlHash
                 />
               </div>
             </Panel>

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -61,6 +61,25 @@ import type { PendingChatAction } from "@/lib/pending-chat-action";
 
 type WorkspaceMode = WorkspaceModeFromDaemon;
 
+// Chat deep links (CHAT-D9-01): `#chat-<sessionId>` re-enters a specific
+// thread, same in-app hash idiom as `#card-<id>` and `library:projects`.
+// ChatRouter writes the hash (syncUrlHash); Workspace owns restore + popstate.
+const CHAT_HASH_PREFIX = "#chat-";
+
+function readChatHash(): string | null {
+  if (typeof window === "undefined") return null;
+  const hash = window.location.hash;
+  return hash.startsWith(CHAT_HASH_PREFIX)
+    ? decodeURIComponent(hash.slice(CHAT_HASH_PREFIX.length))
+    : null;
+}
+
+function clearChatHash() {
+  if (typeof window === "undefined") return;
+  if (!window.location.hash.startsWith(CHAT_HASH_PREFIX)) return;
+  window.history.replaceState(null, "", window.location.pathname + window.location.search);
+}
+
 export function Workspace() {
   const nextRouter = useRouter();
   const routerRef = useRef<ChatRouterHandle | null>(null);
@@ -109,6 +128,15 @@ export function Workspace() {
   const [addons, setAddons] = useState<{ github?: boolean; library?: boolean }>({});
   const responseNeededRef = useRef(responseNeeded);
   responseNeededRef.current = responseNeeded;
+  // Deep-link target captured at mount, held until the async sessions fetch
+  // settles (loadSessions → sessionsLoaded) so the restore can resolve it.
+  const pendingChatDeepLinkRef = useRef<string | null>(readChatHash());
+  // Refs for the popstate listener — sessions repoll every 4s and mode flips
+  // often; the listener should not resubscribe on either.
+  const sessionsRef = useRef(sessions);
+  sessionsRef.current = sessions;
+  const modeRef = useRef(mode);
+  modeRef.current = mode;
 
   // One-shot legacy localStorage key sweep: runs once per browser profile,
   // then marks itself done so it never re-runs.
@@ -655,6 +683,50 @@ export function Workspace() {
     setPendingChatAction({ kind: "list", nonce: Date.now() });
     setMode("chat");
   }, []);
+
+  // Mount-time deep-link restore: sessions load async (/api/sessions/list),
+  // so hold the `#chat-<sessionId>` target until the first fetch settles,
+  // then open the session — same lookup as the `/attach` slash command.
+  // Unknown/stale ids fall back to the chat list with the hash cleared.
+  useEffect(() => {
+    if (!sessionsLoaded) return;
+    const sid = pendingChatDeepLinkRef.current;
+    if (!sid) return;
+    pendingChatDeepLinkRef.current = null;
+    const target = sessions.find((s) => s.id === sid);
+    if (target) {
+      openAgentSession(sid, target.familiarId);
+    } else {
+      clearChatHash();
+      showAgentChatList();
+    }
+  }, [sessionsLoaded, sessions, openAgentSession, showAgentChatList]);
+
+  // Browser Back/Forward between list ↔ chat (and chat ↔ chat). Only acts on
+  // chat hashes — board `#card-` and library hashes keep their own listeners.
+  useEffect(() => {
+    const onPopState = () => {
+      const sid = readChatHash();
+      if (sid) {
+        const target = sessionsRef.current.find((s) => s.id === sid);
+        openAgentSession(sid, target?.familiarId);
+        return;
+      }
+      // Popped back out of a chat entry → show the list, but only while the
+      // chat surface is active; other surfaces own their own hash traffic.
+      if (modeRef.current === "chat") showAgentChatList();
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [openAgentSession, showAgentChatList]);
+
+  // Leaving the chat surface invalidates a chat hash — clear it in place
+  // (replace, not push) so a reload restores the surface the user actually
+  // sees. Skip while the mount-time deep link is still awaiting sessions.
+  useEffect(() => {
+    if (mode === "chat" || pendingChatDeepLinkRef.current) return;
+    clearChatHash();
+  }, [mode]);
 
   const openToastTarget = useCallback((toast: Toast) => {
     setToasts((prev) => prev.filter((t) => t.id !== toast.id));


### PR DESCRIPTION
Implements **CHAT-D9-01 (P1)** from the chat UX audit (#395).

## The gap

Chats were unreachable by URL — all chat navigation was component state (`chat-router.tsx` `useState<View>({ kind: "list" })`; session promotion likewise). A reload always landed on the list, and browser Back/Forward did nothing between chats. Every benchmark (ChatGPT/Claude.ai `/c/<id>`, Claude Code `--resume`) can re-enter a specific thread.

## The fix — hash deep links, the repo's existing idiom

The codebase already deep-links in-app via the URL hash (`#card-<id>` for board cards, `library:projects`, `memory:<path>`). This extends that idiom with `#chat-<sessionId>` rather than restructuring the app into Next routes — no general router is introduced.

- **ChatRouter** gains an opt-in `syncUrlHash` prop. ChatRouter is mounted twice (main chat surface + companion-rail `AgentPanel`); only the main surface opts in so the rail never fights for the hash. A `[view]`-keyed effect mirrors the open chat into the hash.
- **Workspace** owns mount-time restore, the `popstate` listener, and clearing the chat hash when leaving the chat surface.

## History-entry decisions (push vs replace)

- **Opening a chat (list → chat, chat → chat): `pushState`** — Back returns to the list / previous chat, Forward re-enters. Chat open/close is the only push-worthy transition; surface switches deliberately get no history entries.
- **Session promotion (new chat gets its id): same effect, ends up as a push** — promotion flows through `setView`, the hash effect picks up the promoted id, and Back from the promoted chat returns to wherever the user started.
- **Returning to the list (in-app back, familiar switch): `replaceState`-clear** — clearing without a synthetic entry means a *direct* deep-link entry isn't trapped (Back exits the app, as it should when there's no in-app history), and the stack doesn't accumulate junk.
- **Leaving the chat surface (e.g. → board): `replaceState`-clear** — a reload restores the surface the user actually sees, not a stale chat.
- The effect's **first run never clears** a deep-link hash — mount always lands on the list view, and clearing there would race the restore.

## Async sessions race + stale ids

Sessions load via `/api/sessions/list`; the `#chat-<id>` target is captured at mount in a ref and held until `sessionsLoaded`, then opened through `openAgentSession` using the same familiar lookup as the `/attach` slash command. **Unknown/stale ids fall back to the chat list with the hash cleared — no crash**; deleted-but-listed sessions are covered by the chat view's own missing-history notice.

## Coexistence

Board `#card-<id>` and library/memory hashes are untouched: the popstate handler only acts on `#chat-` hashes (and only returns to the list when the chat surface is active), and all clears are prefix-guarded.

## Verification

- `node --experimental-strip-types src/components/chat-router-switching.test.ts` — extended with source-inspection pins: hash written on open + cleared on back-to-list, opt-in gate, first-run guard, sessions-race restore, stale-id fallback, popstate listener, promotion-through-setView. Passes.
- `pnpm test:app` — full suite passes.
- `pnpm typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)