### PR TITLE
feat(chat): pin and archive sessions in the chat list

### DIFF
--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -1,6 +1,12 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import {
+  PINNED_SESSIONS_KEY,
+  readPinnedSessions,
+  togglePinnedSession,
+  sortPinnedFirst,
+} from "../lib/chat-session-prefs.ts";
 
 const source = readFileSync(new URL("./chat-list.tsx", import.meta.url), "utf8");
 
@@ -32,6 +38,103 @@ assert.match(
   source,
   /<Icon name="ph:trash"/,
   "ChatList delete action should use the trash icon",
+);
+
+// ── Pin & archive (CHAT-D9-03) ───────────────────────────────────────────────
+
+// Pin store: Cave-local localStorage set with SSR-safe reads.
+assert.equal(
+  PINNED_SESSIONS_KEY,
+  "cave:chat:pinned-sessions",
+  "pinned sessions persist under a cave-scoped localStorage key",
+);
+assert.deepEqual(
+  readPinnedSessions(),
+  [],
+  "readPinnedSessions degrades to empty without a window (SSR)",
+);
+assert.deepEqual(togglePinnedSession([], "s1"), ["s1"], "toggle adds a missing id");
+assert.deepEqual(togglePinnedSession(["s1", "s2"], "s1"), ["s2"], "toggle removes a present id");
+
+// Pinned rows sort first within their project group; recency order is
+// preserved inside both partitions and pin-free groups keep their reference.
+const row = (id) => ({ id });
+const groups = [
+  {
+    projectRoot: "/repo",
+    sessions: [row("a"), row("b"), row("c"), row("d")],
+    defaultFamiliarId: null,
+    updatedAt: null,
+  },
+  {
+    projectRoot: null,
+    sessions: [row("e")],
+    defaultFamiliarId: null,
+    updatedAt: null,
+  },
+];
+const sorted = sortPinnedFirst(groups, ["d", "b"]);
+assert.deepEqual(
+  sorted[0].sessions.map((s) => s.id),
+  ["b", "d", "a", "c"],
+  "pinned rows float to the top of their group, keeping recency order within partitions",
+);
+assert.equal(sorted[1], groups[1], "groups without pins keep their reference");
+assert.equal(sortPinnedFirst(groups, []), groups, "no pins → groups returned untouched");
+
+// ChatList wiring: persisted pin state drives a pinned-first ordering.
+assert.match(
+  source,
+  /setPinnedIds\(readPinnedSessions\(\)\)/,
+  "ChatList should hydrate pinned ids from the localStorage store after mount",
+);
+assert.match(
+  source,
+  /window\.localStorage\.setItem\(PINNED_SESSIONS_KEY, JSON\.stringify\(pinnedIds\)\)/,
+  "ChatList should persist pin toggles back to the localStorage store",
+);
+assert.match(
+  source,
+  /sortPinnedFirst\(scopedGroups, pinnedIds\)/,
+  "ChatList should float pinned rows to the top of their project group",
+);
+assert.match(
+  source,
+  /togglePinnedSession\(prev, sessionId\)/,
+  "ChatList pin action should toggle through the shared store helper",
+);
+assert.match(
+  source,
+  /aria-label=\{`\$\{pinned \? "Unpin" : "Pin"\} chat \$\{rowName\}`\}/,
+  "Pin toggle should be a real button with a state-aware aria-label",
+);
+
+// Archive rides the existing sessions PATCH endpoint (Cave-local archived_at)
+// and archived rows stay hidden until the Show archived filter opts in.
+assert.match(
+  source,
+  /fetch\(`\/api\/sessions\/\$\{encodeURIComponent\(sessionId\)\}`, \{\s*method: "PATCH",[\s\S]*?JSON\.stringify\(\{ archived \}\)/,
+  "Archive action should persist through the sessions PATCH endpoint",
+);
+assert.match(
+  source,
+  /aria-label=\{`\$\{s\.archived_at \? "Unarchive" : "Archive"\} chat \$\{rowName\}`\}/,
+  "Archive toggle should be a real button with a state-aware aria-label",
+);
+assert.match(
+  source,
+  /if \(!showArchived\) \{\s*setArchivedRows\(\[\]\);/,
+  "Archived rows should be dropped whenever the Show archived toggle is off",
+);
+assert.match(
+  source,
+  /\/api\/sessions\/list\?includeArchived=1/,
+  "Archived rows should load only via the opt-in includeArchived list query",
+);
+assert.match(
+  source,
+  /aria-pressed=\{showArchived\}[\s\S]*?aria-label=\{showArchived \? "Hide archived chats" : "Show archived chats"\}/,
+  "Show archived filter should be an aria-labeled toggle alongside the existing filters",
 );
 
 console.log("chat-list-delete.test.ts: ok");

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -21,6 +21,13 @@ import {
   PROJECT_SIDEBAR_KEYS,
   type ProjectSelection,
 } from "@/lib/chat-project-selection";
+import {
+  PINNED_SESSIONS_KEY,
+  isSessionPinned,
+  readPinnedSessions,
+  sortPinnedFirst,
+  togglePinnedSession,
+} from "@/lib/chat-session-prefs";
 
 type Props = {
   familiar: Familiar | null;
@@ -92,6 +99,16 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [unreadsOnly, setUnreadsOnly] = useState(false);
+  // Pins are Cave-local UI state (localStorage), same idiom as the project
+  // sidebar persistence below — the daemon never learns about them.
+  const [pinnedIds, setPinnedIds] = useState<string[]>([]);
+  // Archived rows are excluded server-side by /api/sessions/list; the toggle
+  // opts into them with its own includeArchived fetch (the workspace's list
+  // poll stays archive-free).
+  const [showArchived, setShowArchived] = useState(false);
+  const [archivedRows, setArchivedRows] = useState<SessionRow[]>([]);
+  const [archivingId, setArchivingId] = useState<string | null>(null);
+  const [archiveNonce, setArchiveNonce] = useState(0);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [expandedKeys, setExpandedKeys] = useState<string[]>([]);
@@ -136,6 +153,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     );
     const storedSelection = readPersisted<unknown>(PROJECT_SIDEBAR_KEYS.selected, "all");
     setSelection(typeof storedSelection === "string" ? storedSelection : "all");
+    setPinnedIds(readPinnedSessions());
     setSidebarHydrated(true);
   }, []);
   useEffect(() => {
@@ -147,12 +165,41 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   useEffect(() => {
     if (sidebarHydrated) window.localStorage.setItem(PROJECT_SIDEBAR_KEYS.selected, JSON.stringify(selection));
   }, [sidebarHydrated, selection]);
+  useEffect(() => {
+    if (sidebarHydrated) window.localStorage.setItem(PINNED_SESSIONS_KEY, JSON.stringify(pinnedIds));
+  }, [sidebarHydrated, pinnedIds]);
+
+  // Archived sessions only load while the toggle is on; archive/unarchive
+  // bumps archiveNonce so the opt-in list refetches after each change.
+  useEffect(() => {
+    if (!showArchived) {
+      setArchivedRows([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/sessions/list?includeArchived=1", { cache: "no-store" });
+        const json = await res.json().catch(() => ({ ok: false }));
+        if (cancelled || !json.ok || !Array.isArray(json.sessions)) return;
+        setArchivedRows((json.sessions as SessionRow[]).filter((s) => s.archived_at));
+      } catch {
+        // keep whatever archived rows we already have
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [showArchived, archiveNonce]);
 
   // ── Data: filter ──────────────────────────────────────────────────────────
 
   const mine = useMemo(() => {
-    return filterVisibleChatSessions(sessions, familiar?.id ?? null);
-  }, [sessions, familiar?.id]);
+    let rows = sessions;
+    if (showArchived && archivedRows.length > 0) {
+      const seen = new Set(sessions.map((s) => s.id));
+      rows = [...sessions, ...archivedRows.filter((s) => !seen.has(s.id))];
+    }
+    return filterVisibleChatSessions(rows, familiar?.id ?? null);
+  }, [sessions, showArchived, archivedRows, familiar?.id]);
 
   const filtered = useMemo(() => {
     let rows = mine;
@@ -192,6 +239,12 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     () => applyProjectScope(grouped, effectiveSelection),
     [grouped, effectiveSelection],
   );
+  // Pinned rows float to the top of their project group; recency order is
+  // preserved inside both partitions.
+  const displayGroups = useMemo(
+    () => sortPinnedFirst(scopedGroups, pinnedIds),
+    [scopedGroups, pinnedIds],
+  );
   const visibleRows = useMemo(
     () => scopedGroups.reduce((n, g) => n + g.sessions.length, 0),
     [scopedGroups],
@@ -216,6 +269,37 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
       setError(err instanceof Error ? err.message : "delete failed");
     } finally {
       setDeletingId(null);
+    }
+  };
+
+  // ── Pin (Cave-local) + archive (sessions PATCH) ──────────────────────────
+
+  const togglePin = (e: React.MouseEvent, sessionId: string) => {
+    e.stopPropagation();
+    setPinnedIds((prev) => togglePinnedSession(prev, sessionId));
+  };
+
+  const setSessionArchived = async (e: React.MouseEvent, sessionId: string, archived: boolean) => {
+    e.stopPropagation();
+    setArchivingId(sessionId);
+    setError(null);
+    try {
+      const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ archived }),
+      });
+      const json = await res.json().catch(() => ({ ok: false }));
+      if (!res.ok || !json.ok) {
+        setError(json.error ?? (archived ? "archive failed" : "unarchive failed"));
+        return;
+      }
+      setArchiveNonce((n) => n + 1);
+      onSessionsChanged?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "archive failed");
+    } finally {
+      setArchivingId(null);
     }
   };
 
@@ -372,6 +456,23 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
             Unreads
           </button>
 
+          <button
+            type="button"
+            onClick={() => setShowArchived((v) => !v)}
+            aria-pressed={showArchived}
+            aria-label={showArchived ? "Hide archived chats" : "Show archived chats"}
+            title={showArchived ? "Hide archived chats" : "Show archived chats"}
+            className={[
+              "focus-ring flex h-8 shrink-0 items-center gap-1.5 rounded-lg border px-2.5 text-[11px] font-medium transition-colors",
+              showArchived
+                ? "border-[color-mix(in_oklch,var(--accent-presence)_40%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_15%,transparent)] text-[var(--accent-presence)]"
+                : "border-[var(--border-hairline)] text-[var(--text-muted)] hover:border-[var(--border-strong)] hover:text-[var(--text-secondary)]",
+            ].join(" ")}
+          >
+            <Icon name="ph:archive" width={12} aria-hidden />
+            Archived
+          </button>
+
           {/* With the identity row hidden, the + Chat CTA lives here */}
           {familiar && (
             <button
@@ -479,7 +580,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
           </div>
         ) : (
           <ul className="divide-y divide-[var(--border-hairline)]">
-            {scopedGroups.map(({ projectRoot, sessions: rows, defaultFamiliarId }) => (
+            {displayGroups.map(({ projectRoot, sessions: rows, defaultFamiliarId }) => (
               <li key={projectRoot ?? "__none__"}>
                 {/* Project group header */}
                 {projectRoot !== null && effectiveSelection === "all" && (
@@ -508,6 +609,8 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                     const isActive = activeId === s.id;
                     const rowFamiliar = s.familiarId ? familiarsById.get(s.familiarId) : null;
                     const rowFamiliarName = rowFamiliar?.display_name ?? familiar?.display_name ?? "Familiar";
+                    const pinned = isSessionPinned(pinnedIds, s.id);
+                    const rowName = s.title || s.id;
 
                     return (
                       <li key={s.id}>
@@ -558,17 +661,28 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                             {/* Row 2: session title (bold subject line)
                            Running sessions get full white; others are slightly muted
                            — mirrors the unread/read convention in email clients. */}
-                            <span className={[
-                              "truncate text-[13px] font-semibold",
-                              s.status === "running"
-                                ? "text-white"
-                                : "text-[var(--text-primary)]",
-                            ].join(" ")}>
-                              {stripLeadingTrailingEmoji(s.title || "(untitled chat)")}
+                            <span className="flex min-w-0 items-center gap-1.5">
+                              {pinned && (
+                                <Icon
+                                  name="ph:bookmark-simple-fill"
+                                  width={11}
+                                  className="shrink-0 text-[var(--accent-presence)]"
+                                  aria-hidden
+                                />
+                              )}
+                              <span className={[
+                                "truncate text-[13px] font-semibold",
+                                s.status === "running"
+                                  ? "text-white"
+                                  : "text-[var(--text-primary)]",
+                              ].join(" ")}>
+                                {stripLeadingTrailingEmoji(s.title || "(untitled chat)")}
+                              </span>
                             </span>
 
                             {/* Row 3: status preview */}
                             <span className={`truncate text-[12px] ${st.preview}`}>
+                              {s.archived_at ? <span className="text-[var(--text-muted)]">Archived · </span> : null}
                               {st.label === "running"
                                 ? "Active now…"
                                 : st.label === "failed"
@@ -612,15 +726,48 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                               </button>
                             </span>
                           ) : (
-                            <button
-                              type="button"
-                              onClick={(e) => { e.stopPropagation(); setConfirmDeleteId(s.id); }}
-                              title="Delete chat"
-                              aria-label={`Delete chat ${s.title || s.id}`}
-                              className="touch-always-visible self-center shrink-0 rounded border border-[var(--border-hairline)] px-1.5 py-0.5 text-[var(--text-muted)] opacity-0 transition-all hover:border-[color-mix(in_oklch,var(--color-danger)_45%,transparent)] hover:bg-[color-mix(in_oklch,var(--color-danger)_14%,transparent)] hover:text-[var(--color-danger)] group-hover:opacity-100"
+                            /* Row actions — pin (Cave-local), archive (PATCH), delete.
+                               Keyboard Enter on a button must not bubble into the
+                               row's open handler. */
+                            <span
+                              className="flex shrink-0 items-center gap-1 self-center"
+                              onKeyDown={(e) => e.stopPropagation()}
                             >
-                              <Icon name="ph:trash" width={12} aria-hidden />
-                            </button>
+                              <button
+                                type="button"
+                                onClick={(e) => togglePin(e, s.id)}
+                                title={pinned ? "Unpin chat" : "Pin chat"}
+                                aria-label={`${pinned ? "Unpin" : "Pin"} chat ${rowName}`}
+                                aria-pressed={pinned}
+                                className={[
+                                  "touch-always-visible shrink-0 rounded border border-[var(--border-hairline)] px-1.5 py-0.5 transition-all hover:border-[color-mix(in_oklch,var(--accent-presence)_45%,transparent)] hover:bg-[color-mix(in_oklch,var(--accent-presence)_14%,transparent)] hover:text-[var(--accent-presence)] focus-visible:opacity-100 group-hover:opacity-100",
+                                  pinned
+                                    ? "text-[var(--accent-presence)] opacity-100"
+                                    : "text-[var(--text-muted)] opacity-0",
+                                ].join(" ")}
+                              >
+                                <Icon name={pinned ? "ph:bookmark-simple-fill" : "ph:bookmark-simple"} width={12} aria-hidden />
+                              </button>
+                              <button
+                                type="button"
+                                onClick={(e) => void setSessionArchived(e, s.id, !s.archived_at)}
+                                disabled={archivingId === s.id}
+                                title={s.archived_at ? "Unarchive chat" : "Archive chat"}
+                                aria-label={`${s.archived_at ? "Unarchive" : "Archive"} chat ${rowName}`}
+                                className="touch-always-visible shrink-0 rounded border border-[var(--border-hairline)] px-1.5 py-0.5 text-[var(--text-muted)] opacity-0 transition-all hover:border-[var(--border-strong)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover:opacity-100 disabled:opacity-40"
+                              >
+                                <Icon name={s.archived_at ? "ph:arrow-counter-clockwise" : "ph:archive"} width={12} aria-hidden />
+                              </button>
+                              <button
+                                type="button"
+                                onClick={(e) => { e.stopPropagation(); setConfirmDeleteId(s.id); }}
+                                title="Delete chat"
+                                aria-label={`Delete chat ${s.title || s.id}`}
+                                className="touch-always-visible shrink-0 rounded border border-[var(--border-hairline)] px-1.5 py-0.5 text-[var(--text-muted)] opacity-0 transition-all hover:border-[color-mix(in_oklch,var(--color-danger)_45%,transparent)] hover:bg-[color-mix(in_oklch,var(--color-danger)_14%,transparent)] hover:text-[var(--color-danger)] focus-visible:opacity-100 group-hover:opacity-100"
+                              >
+                                <Icon name="ph:trash" width={12} aria-hidden />
+                              </button>
+                            </span>
                           )}
                         </div>
                       </li>

--- a/src/lib/chat-session-prefs.ts
+++ b/src/lib/chat-session-prefs.ts
@@ -1,0 +1,52 @@
+import type { ChatProjectGroup } from "./chat-projects.ts";
+
+/** localStorage key for the Cave-local pinned-session set. Pins are a pure
+ *  UI preference — the daemon never learns about them — so they persist the
+ *  same way as the chat project sidebar state (see chat-project-selection). */
+export const PINNED_SESSIONS_KEY = "cave:chat:pinned-sessions";
+
+/** Read the pinned session ids; survives SSR (no window) and corrupt values. */
+export function readPinnedSessions(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(PINNED_SESSIONS_KEY);
+    if (raw === null) return [];
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((v): v is string => typeof v === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function isSessionPinned(pinned: readonly string[], sessionId: string): boolean {
+  return pinned.includes(sessionId);
+}
+
+/** Toggle membership; always returns a new array (state-setter friendly). */
+export function togglePinnedSession(pinned: readonly string[], sessionId: string): string[] {
+  return pinned.includes(sessionId)
+    ? pinned.filter((id) => id !== sessionId)
+    : [...pinned, sessionId];
+}
+
+/** Pinned rows float to the top of their project group; relative recency
+ *  order is preserved within both partitions. Group order is untouched, and
+ *  untouched groups keep their reference so memoized consumers can bail. */
+export function sortPinnedFirst(
+  groups: ChatProjectGroup[],
+  pinned: readonly string[],
+): ChatProjectGroup[] {
+  if (pinned.length === 0) return groups;
+  const set = new Set(pinned);
+  let changed = false;
+  const next = groups.map((group) => {
+    const pinnedRows = group.sessions.filter((s) => set.has(s.id));
+    if (pinnedRows.length === 0) return group;
+    changed = true;
+    const rest = group.sessions.filter((s) => !set.has(s.id));
+    return { ...group, sessions: [...pinnedRows, ...rest] };
+  });
+  return changed ? next : groups;
+}


### PR DESCRIPTION
## Summary

Implements **CHAT-D9-03 (P2)** from the chat UX audit (#395): the only per-row session action in `chat-list.tsx` was the two-step delete, so long-lived agent sessions accumulated with no way to pin important threads or demote stale ones short of deleting. Benchmarks: ChatGPT pin + archive; Claude.ai star + archive.

## Storage decisions

- **Pin — Cave-local (localStorage).** Pins are a pure UI preference; the daemon never needs to know. New `src/lib/chat-session-prefs.ts` persists a pinned-id set under `cave:chat:pinned-sessions`, following the exact persistence idiom of the existing project-sidebar state (`chat-project-selection.ts`: hydrate after mount, persist gated on the hydration flag).
- **Archive — real backend wiring, no daemon changes.** Investigation found archive is *already* supported end-to-end on the Cave side: `PATCH /api/sessions/[id]` accepts `{ archived: boolean }` (writes `archived_at` to Cave-local state via `cave-config`'s `archiveSessionLocal`/`summonSessionLocal`), and `/api/sessions/list` already filters archived rows unless `?includeArchived=1`. The row action uses that PATCH as-is; **zero route or daemon edits were needed.**

## Behavior

- Pinned rows float to the top of their project group (recency order preserved within the pinned/unpinned partitions; group order untouched) with a bookmark indicator next to the title. Smaller change than a separate "Pinned" cluster and reads naturally with the existing grouping.
- Archived rows stay hidden by default. A "Show archived" toggle next to the existing Unreads filter opts in — the list does its own `?includeArchived=1` fetch so the workspace's poll stays archive-free — and archived rows get an "Archived ·" preview cue plus an inline unarchive action.
- Pin / archive / delete are real buttons with state-aware `aria-label`s and `stopPropagation` (clicks *and* Enter keydown no longer bubble into the row's open handler). Running-session emphasis, unread conventions, and the two-step delete are untouched.

## Verification

- `src/components/chat-list-delete.test.ts` extended: pin store behavior (toggle, SSR-safe read, pinned-first sort incl. reference-stability), pinned-first wiring, archive-via-PATCH, archived-hidden-behind-toggle, aria-labels — passes.
- `sidebar-familiar-filter.test.ts` and `chat-all-familiars-project-list.test.ts` (pin chat-list/sidebar sources) — pass.
- Full `pnpm test:app` — pass.
- `pnpm typecheck` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)