### PR TITLE
fix(chat): persist cancelled turns as cancelled, not fabricated errors

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -151,6 +151,59 @@ for (const contract of contracts) {
   }
 }
 
+// CHAT-D5-02: cancelling a streaming response (Esc/Stop) must persist an
+// honest cancelled record — the partial text streamed so far, or a minimal
+// "(cancelled)" marker — never the fabricated empty-response error
+// diagnostic. Both adapter paths (coven stream-json and the OpenClaw bridge)
+// carry the guard, so a reload shows the cancel, not a harness error.
+{
+  const sendSource = readFileSync(
+    path.join(apiRoot, "chat", "send", "route.ts"),
+    "utf8",
+  );
+  const abortReads = [
+    ...sendSource.matchAll(/const cancelledByUser = (?:args\.)?req\.signal\.aborted;/g),
+  ];
+  assert.equal(
+    abortReads.length,
+    2,
+    "/chat/send: both adapter paths must detect a user abort before synthesizing diagnostics",
+  );
+  const guardedDiagnostics = [
+    ...sendSource.matchAll(
+      /if \(cancelledByUser\) \{[\s\S]{0,200}?\} else if \(!assistantText\.trim\(\)\) \{/g,
+    ),
+  ];
+  assert.equal(
+    guardedDiagnostics.length,
+    2,
+    "/chat/send: the empty-response error diagnostic must be skipped when the user cancelled",
+  );
+  assert.match(
+    sendSource,
+    /assistantText = "\(cancelled\)"/,
+    "/chat/send: an abort with no partial text must persist the minimal cancelled marker",
+  );
+  const cancelledFlags = [
+    ...sendSource.matchAll(/\.\.\.\(cancelledByUser \? \{ cancelled: true \} : \{\}\)/g),
+  ];
+  assert.equal(
+    cancelledFlags.length,
+    2,
+    "/chat/send: both adapter paths must persist cancelled: true on the assistant turn",
+  );
+  assert.match(
+    sendSource,
+    /if \(cancelledByUser\) \{\s*\n\s*if \(!assistantText\.trim\(\)\) assistantText = "\(cancelled\)";\s*\n\s*result\.is_error = false;/,
+    "/chat/send: a user cancel must never be recorded as a harness error (stream-json path)",
+  );
+  assert.match(
+    sendSource,
+    /if \(cancelledByUser\) \{\s*\n\s*if \(!assistantText\.trim\(\)\) assistantText = "\(cancelled\)";\s*\n\s*isError = false;/,
+    "/chat/send: a user cancel must never be recorded as a harness error (openclaw path)",
+  );
+}
+
 const packageJson = JSON.parse(readFileSync(path.join(root, "package.json"), "utf8"));
 assert.match(packageJson.scripts?.["test:api"] ?? "", /api-contracts\.test\.ts/, "package.json must expose this API contract suite");
 

--- a/src/app/api/chat/conversation/[id]/route.ts
+++ b/src/app/api/chat/conversation/[id]/route.ts
@@ -59,6 +59,7 @@ function normalizeTurn(input: unknown): ChatTurn | null {
         : now,
     ...(typeof value.durationMs === "number" ? { durationMs: value.durationMs } : {}),
     ...(typeof value.isError === "boolean" ? { isError: value.isError } : {}),
+    ...(typeof value.cancelled === "boolean" ? { cancelled: value.cancelled } : {}),
   };
 }
 

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -463,6 +463,12 @@ function openClawChatResponse(args: {
           durationMs,
         );
 
+        // User cancel (CHAT-D5-02): a stopped response SIGTERMs the bridge,
+        // so stdout is usually empty or truncated JSON. Persist an honest
+        // cancelled marker — never raw truncated output or the fabricated
+        // "returned no text" error diagnostic.
+        const cancelledByUser = args.req.signal.aborted;
+
         if (stdout.trim()) {
           try {
             const parsed = JSON.parse(stdout.trim()) as OpenClawAgentJson;
@@ -470,11 +476,14 @@ function openClawChatResponse(args: {
             assistantText = extractOpenClawText(parsed);
             isError = isError || parsed.status === "error";
           } catch {
-            assistantText = stdout.trim();
+            if (!cancelledByUser) assistantText = stdout.trim();
           }
         }
 
-        if (!assistantText.trim()) {
+        if (cancelledByUser) {
+          if (!assistantText.trim()) assistantText = "(cancelled)";
+          isError = false;
+        } else if (!assistantText.trim()) {
           const tail = stderr
             .split(/\r?\n/)
             .map((line) => line.trim())
@@ -523,6 +532,7 @@ function openClawChatResponse(args: {
               createdAt: new Date().toISOString(),
               durationMs,
               isError,
+              ...(cancelledByUser ? { cancelled: true } : {}),
             },
           );
           await saveConversation(conv);
@@ -996,10 +1006,23 @@ export async function POST(req: Request) {
         pushProgress("resume-retry", "Fresh chat started", "done");
       }
 
-      // Empty-response diagnostic: when the harness reports done but never
-      // produced assistant text, the user otherwise sees a silent empty
-      // bubble. Synthesize a short explanation so they know what to do.
-      if (!assistantText.trim()) {
+      // User cancel (CHAT-D5-02): when the client stops the response
+      // (Esc/Stop), req.signal aborts and the harness child gets SIGTERM —
+      // usually before any "result" event. Without this guard the
+      // empty-response diagnostic below fabricates an auth-hint error and
+      // saves it, so reloading the chat rewrote the user's cancel into a
+      // harness error. Persist the honest record instead: the partial text
+      // streamed so far (or a minimal "(cancelled)" marker), never an error,
+      // and skip the diagnostic SSE chunk — the client already rendered its
+      // own cancelled state and is gone.
+      const cancelledByUser = req.signal.aborted;
+      if (cancelledByUser) {
+        if (!assistantText.trim()) assistantText = "(cancelled)";
+        result.is_error = false;
+      } else if (!assistantText.trim()) {
+        // Empty-response diagnostic: when the harness reports done but never
+        // produced assistant text, the user otherwise sees a silent empty
+        // bubble. Synthesize a short explanation so they know what to do.
         const harness = binding.harness;
         const durMs = result.duration_ms;
         const durSuffix = durMs != null ? ` in ${durMs}ms` : "";
@@ -1040,6 +1063,7 @@ export async function POST(req: Request) {
           createdAt: new Date().toISOString(),
           durationMs: result.duration_ms,
           isError: result.is_error,
+          ...(cancelledByUser ? { cancelled: true } : {}),
         };
         const conv = existing ?? {
           sessionId: finalSessionId,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1101,6 +1101,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   tools?: ToolEvent[];
                   durationMs?: number;
                   isError?: boolean;
+                  cancelled?: boolean;
                   createdAt?: string;
                   origin?: "chat" | "voice";
                   voiceCallId?: string;
@@ -1115,6 +1116,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   tools: t.tools,
                   durationMs: t.durationMs,
                   error: t.isError,
+                  lifecycle: t.cancelled ? ("cancelled" as const) : undefined,
                   createdAt: t.createdAt ?? new Date().toISOString(),
                   origin: t.origin,
                   voiceCallId: t.voiceCallId,

--- a/src/lib/cave-conversations.test.ts
+++ b/src/lib/cave-conversations.test.ts
@@ -46,6 +46,39 @@ assert.equal(await deleteConversation("delete-me"), true);
 assert.equal(await loadConversation("delete-me"), null);
 assert.equal(await deleteConversation("delete-me"), false);
 
+// CHAT-D5-02: a user-cancelled turn persists as an honest cancelled record —
+// partial text kept, cancelled flag set, never re-flagged as an error.
+await saveConversation({
+  sessionId: "cancelled-turn",
+  familiarId: "charm",
+  harness: "claude",
+  title: "Cancelled mid-stream",
+  createdAt: "2026-06-11T00:00:00.000Z",
+  updatedAt: "2026-06-11T00:00:00.000Z",
+  turns: [
+    {
+      id: "turn-user",
+      role: "user",
+      text: "write me a long poem",
+      createdAt: "2026-06-11T00:00:00.000Z",
+    },
+    {
+      id: "turn-assistant",
+      role: "assistant",
+      text: "Roses are red, violets",
+      createdAt: "2026-06-11T00:00:01.000Z",
+      isError: false,
+      cancelled: true,
+    },
+  ],
+});
+const cancelledConv = await loadConversation("cancelled-turn");
+const cancelledTurn = cancelledConv?.turns.find((turn) => turn.id === "turn-assistant");
+assert.equal(cancelledTurn?.cancelled, true, "cancelled flag must round-trip through the store");
+assert.equal(cancelledTurn?.isError, false, "a user cancel is not an error");
+assert.equal(cancelledTurn?.text, "Roses are red, violets", "partial streamed text must survive the save");
+assert.equal(await deleteConversation("cancelled-turn"), true);
+
 if (previousHome === undefined) {
   delete process.env.HOME;
 } else {

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -21,6 +21,8 @@ export type ChatTurn = {
   createdAt: string;
   durationMs?: number;
   isError?: boolean;
+  /** True when the user stopped this response mid-stream (Esc/Stop). */
+  cancelled?: boolean;
   origin?: "chat" | "voice";
   voiceCallId?: string;
 };


### PR DESCRIPTION
## Summary

Implements **CHAT-D5-02 (P2)** from the chat UX audit (#395): reloading a chat rewrote a user cancel into a harness error.

When the user stopped a streaming response (Esc/Stop), the client kept the partial text and marked the turn `lifecycle: "cancelled"` — but the server's abort listener SIGTERMed the harness child and execution fell through to the empty-response diagnostic, which fabricated an auth-hint/`/doctor` error bubble, set `is_error = true`, and **saved that fabricated error to the transcript**. Benchmark: ChatGPT — a stopped response persists identically across reloads (partial text + stopped marker).

## What gets persisted now (per adapter)

Both adapter paths check `req.signal.aborted` at the diagnostic-decision point:

- **coven stream-json path** (claude/codex): persists the **partial `assistantText` streamed so far**; if nothing arrived before the kill, a minimal `"(cancelled)"` marker (same string the live client renders). `is_error` forced false; the fabricated diagnostic chunk is never synthesized or emitted on aborts.
- **OpenClaw bridge path**: stdout is usually empty or truncated JSON after SIGTERM, so truncated raw output is discarded on cancel and the `"(cancelled)"` marker is persisted; `isError` forced false (SIGTERM's non-zero exit no longer flags an error).

Both assistant turns carry a new optional `cancelled: true` field on `ChatTurn`. The conversation GET passes it through unchanged; `normalizeTurn` in the conversation write API round-trips it; chat-view's history load maps `t.cancelled` → `lifecycle: "cancelled"` (one-line hunk in the history mapping only), so a reload renders the exact same Cancelled badge + partial text the user saw live.

The #407 image temp-file cleanup after `done` is untouched and still runs on the abort path.

## Tests

- `src/app/api/api-contracts.test.ts`: source contracts pin the abort guard in **both** adapter paths — diagnostic skipped on cancel, `"(cancelled)"` marker, `cancelled: true` persisted, never recorded as an error.
- `src/lib/cave-conversations.test.ts`: round-trip pin — partial text + `cancelled: true` + `isError: false` survive the store.

## Verification

- `node --experimental-strip-types src/app/api/api-contracts.test.ts` — pass (72 contracts)
- `node --experimental-strip-types src/lib/cave-conversations.test.ts` — pass
- `pnpm test:api` — exit 0
- `pnpm test:app` — exit 0
- `pnpm typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)