### PR TITLE
chore(release): cut 0.0.71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.71] - 2026-06-11
+
+### Added
+- **Chat attachments** — paste or drag-drop files straight into the composer (#412); image attachments reach the harness via temp files instead of being dropped (#407).
+- **Edit and resend** — edit-and-resend user turns and regenerate assistant turns (#409).
+- **Workflow manifest surface** — Cave workflows gain a manifest view.
+
+### Changed
+- **Kanban board** — kanban always uses status columns; the group toggle is hidden there (#393).
+- **Shell chrome** — left-edge reopen tab for collapsed nav, pressable edge-rail chips (#392), and side-panel edge-trigger polish.
+- **Salem panel** — the Docs/Tools/Skills/Context count pills under the header are gone; the panel opens straight into the chat (#408).
+
+### Fixed
+- **Terminal works in the packaged desktop app** — the sidecar now ships the custom PTY-bridge server, so terminal websockets (browser localhost access against the installed app, mobile handoff) reach a real shell instead of hanging on the upgrade; `pnpm dev:app` boots against the live dev server without requiring a prebuilt sidecar bundle; Tauri-mobile rides the same WebSocket bridge instead of rendering a "not available" placeholder. (#401)
+- **Terminal shell environment** — spawned shells no longer inherit pnpm's `npm_config_*` leakage. (#403)
+- **Dev server hardening** — dev binds loopback by default and the PTY websocket rejects cross-site browser origins. (#391)
+- **Chat streaming stability** — markdown renders progressively while streaming (#405), scroll pins instantly with intent-based release and respects reduced motion (#404), composer input typed while streaming survives (#397), code-block copy buttons work (#398), message actions are keyboard- and touch-reachable (#400), and the highlighted slash-menu command runs on Enter.
+- **Home reminders** — reminders can be scheduled from the composer, with timezone-independent draft expectations in tests (#396).
+- **Memory rail** — the inspector failure browser collapses when no entries exist (#394).
+
 ## [0.0.70] - 2026-06-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "private": true,
   "scripts": {
     "dev": "node --experimental-strip-types server.ts",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.70"
+version = "0.0.71"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.70"
+version = "0.0.71"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Version bump + changelog for v0.0.71. Headline: **the terminal fix (#401) reaches the packaged desktop app** — the sidecar now ships the PTY-bridge server, so terminal websockets work against the installed app, `pnpm dev:app` boots without a prebuilt bundle, and Tauri-mobile rides the WS bridge.

Also in this cut: PTY env sanitization (#403), dev-server loopback bind + origin-gated PTY websocket (#391), chat streaming/attachment fixes (#397 #398 #400 #404 #405 #407 #409 #412), kanban status columns (#393), shell chrome polish (#392), Salem header pill removal (#408), reminder + memory-rail fixes (#394 #396).

Bumps: package.json, tauri.conf.json, Cargo.toml, Cargo.lock → 0.0.71. `cargo check` clean; app-version, release-notes, and macos-signing tests pass; `scripts/release-notes.sh v0.0.71` renders the entry correctly.

After merge: tag the squash commit `v0.0.71` and push — release.yml builds and uploads both macOS DMGs, the AppImage, and the MSI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)