### PR TITLE
fix(chat): distinct ids for concurrent same-name tool calls; surface envelope tool events

### DIFF
--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -7,6 +7,12 @@ import {
   MAX_ATTACHMENT_IMAGE_BYTES,
   normalizeChatAttachments,
 } from "../../../../lib/chat-attachments.ts";
+import {
+  flattenToolResultContent,
+  formatToolInputValue,
+  formatToolPayload,
+  ToolCallTracker,
+} from "../../../../lib/chat-tool-events.ts";
 
 const chatRoute = await readFile(
   new URL("./route.ts", import.meta.url),
@@ -270,3 +276,191 @@ const smallPng = `data:image/png;base64,${Buffer.from("png-payload-bytes").toStr
   );
   assert.doesNotMatch(undelivered, /\(content unavailable\)/);
 }
+
+// ── Tool-event fidelity (CHAT-D4-03 + CHAT-D4-04) ──────────────────────────
+// Source pins: the route must route BOTH tool-event sources through the
+// shared ToolCallTracker — hook lines and stream-json envelope blocks — and
+// must no longer key open calls by bare tool name.
+
+assert.match(
+  chatRoute,
+  /let toolTracker = new ToolCallTracker\(\);/,
+  "Native chat should track open tool calls with the shared ToolCallTracker",
+);
+
+assert.doesNotMatch(
+  chatRoute,
+  /toolStartTimes/,
+  "The name-keyed toolStartTimes map merged concurrent same-name calls (CHAT-D4-03) and must stay gone",
+);
+
+assert.match(
+  chatRoute,
+  /toolTracker\.hookEnd\([\s\S]*?toolTracker\.hookStart\(/,
+  "Hook lines should feed the tracker so posts pair FIFO with the oldest open pre",
+);
+
+assert.match(
+  chatRoute,
+  /block\.type === "tool_use" && block\.id && block\.name[\s\S]*?toolTracker\.envelopeToolUse\(/,
+  "Assistant envelope tool_use blocks should surface as running tool events (CHAT-D4-04)",
+);
+
+assert.match(
+  chatRoute,
+  /ev\.type === "user" && Array\.isArray\(ev\.message\?\.content\)[\s\S]*?block\.type === "tool_result" && block\.tool_use_id[\s\S]*?toolTracker\.envelopeToolResult\(/,
+  "User envelope tool_result blocks should settle the matching tool event (CHAT-D4-04)",
+);
+
+assert.match(
+  chatRoute,
+  /toolTracker = new ToolCallTracker\(\);/,
+  "The resume retry should reset the tool tracker alongside the other per-attempt state",
+);
+
+// Behavioral: per-name FIFO queue gives overlapping same-name calls distinct
+// ids and pairs each post with the oldest open pre (correct durations).
+{
+  let t = 0;
+  const tracker = new ToolCallTracker(() => t);
+
+  const first = tracker.hookStart("Bash", '{"command":"sleep 5"}');
+  t = 100;
+  const second = tracker.hookStart("Bash", '{"command":"ls"}');
+  assert.notEqual(
+    first.id,
+    second.id,
+    "two overlapping Bash calls must get distinct ids",
+  );
+  assert.equal(first.status, "running");
+  assert.equal(second.status, "running");
+
+  t = 250;
+  const firstDone = tracker.hookEnd("Bash", '{"exitCode":0}', false);
+  assert.equal(firstDone.id, first.id, "first post pairs with the FIRST open pre (FIFO)");
+  assert.equal(firstDone.status, "ok");
+  assert.equal(firstDone.durationMs, 250, "duration measured from the first call's own start");
+
+  t = 400;
+  const secondDone = tracker.hookEnd("Bash", '{"exitCode":1}', true);
+  assert.equal(secondDone.id, second.id, "second post pairs with the remaining open call");
+  assert.equal(secondDone.status, "error");
+  assert.equal(secondDone.durationMs, 300, "duration measured from the second call's own start");
+}
+
+// Behavioral: a post with no open call still surfaces, under a fresh id.
+{
+  const tracker = new ToolCallTracker(() => 0);
+  const orphan = tracker.hookEnd("Edit", "done", false);
+  assert.ok(orphan.id, "orphan post still gets an id");
+  assert.equal(orphan.status, "ok");
+  assert.equal(orphan.durationMs, undefined, "no start time means no fabricated duration");
+}
+
+// Behavioral: envelope-only harnesses (no pre/post_tool_use hooks) get a full
+// running → settled lifecycle from the stream-json blocks alone.
+{
+  let t = 0;
+  const tracker = new ToolCallTracker(() => t);
+  const running = tracker.envelopeToolUse(
+    "toolu_01",
+    "Bash",
+    formatToolInputValue({ command: "ls" }),
+  );
+  assert.ok(running, "envelope tool_use must surface as a tool event");
+  assert.equal(running.id, "toolu_01", "envelope events keep the native tool_use id");
+  assert.equal(running.status, "running");
+  assert.match(running.input ?? "", /"command": "ls"/, "envelope input is pretty-printed");
+
+  assert.equal(
+    tracker.envelopeToolUse("toolu_01", "Bash"),
+    null,
+    "a repeated tool_use block for the same native id is deduped",
+  );
+
+  t = 1200;
+  const settled = tracker.envelopeToolResult(
+    "toolu_01",
+    flattenToolResultContent([{ type: "text", text: "file-a\nfile-b" }]),
+    false,
+  );
+  assert.ok(settled, "envelope tool_result must settle the call");
+  assert.equal(settled.id, "toolu_01");
+  assert.equal(settled.status, "ok");
+  assert.equal(settled.output, "file-a\nfile-b");
+  assert.equal(settled.durationMs, 1200);
+
+  const errored = tracker.envelopeToolUse("toolu_02", "Bash");
+  assert.ok(errored);
+  const erroredDone = tracker.envelopeToolResult("toolu_02", "boom", true);
+  assert.equal(erroredDone?.status, "error", "is_error tool_result blocks settle as errors");
+}
+
+// Behavioral: hook events win when hooks AND envelopes describe the same
+// call — envelope blocks are linked onto the hook's id (UI merges on id) or
+// suppressed once the hook has settled the call.
+{
+  // Envelope first (assistant message flushes before the tool executes).
+  let t = 0;
+  const tracker = new ToolCallTracker(() => t);
+  const announced = tracker.envelopeToolUse("toolu_a", "Bash", '{"command":"pwd"}');
+  assert.ok(announced);
+
+  t = 50;
+  const hookRunning = tracker.hookStart("Bash", '{"command":"pwd"}');
+  assert.equal(
+    hookRunning.id,
+    "toolu_a",
+    "the hook pre claims the envelope-announced call's id so the UI merges them",
+  );
+
+  t = 350;
+  const hookDone = tracker.hookEnd("Bash", '{"exitCode":0}', false);
+  assert.equal(hookDone.id, "toolu_a");
+  assert.equal(hookDone.durationMs, 300, "duration baselined at the hook pre, not envelope parse");
+
+  assert.equal(
+    tracker.envelopeToolResult("toolu_a", "pwd output", false),
+    null,
+    "the envelope tool_result is suppressed once the post hook settled the call",
+  );
+}
+
+{
+  // Hook first (interleaving can deliver the hook line before the envelope).
+  const tracker = new ToolCallTracker(() => 0);
+  const hookRunning = tracker.hookStart("Read", '{"file_path":"/tmp/x"}');
+  assert.equal(
+    tracker.envelopeToolUse("toolu_b", "Read", '{"file_path":"/tmp/x"}'),
+    null,
+    "the envelope tool_use links to the already-announced hook call instead of duplicating",
+  );
+  const hookDone = tracker.hookEnd("Read", "contents", false);
+  assert.equal(hookDone.id, hookRunning.id);
+  assert.equal(
+    tracker.envelopeToolResult("toolu_b", "contents", false),
+    null,
+    "the linked native id dedups the tool_result after the hook settled the call",
+  );
+}
+
+// Behavioral: payload formatters used by both event sources.
+{
+  assert.equal(formatToolPayload(""), undefined);
+  assert.equal(formatToolPayload("not json"), "not json");
+  assert.equal(formatToolPayload('{"a":1}'), '{\n  "a": 1\n}');
+  assert.equal(formatToolInputValue(undefined), undefined);
+  assert.equal(formatToolInputValue({}), undefined, "empty input objects stay blank");
+  assert.equal(formatToolInputValue({ a: 1 }), '{\n  "a": 1\n}');
+  assert.equal(flattenToolResultContent("plain"), "plain");
+  assert.equal(
+    flattenToolResultContent([
+      { type: "text", text: "one" },
+      { type: "text", text: "two" },
+    ]),
+    "one\ntwo",
+  );
+  assert.equal(flattenToolResultContent(null), undefined);
+}
+
+console.log("harness-routing tests passed");

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -22,6 +22,12 @@ import {
   type ChatAttachment,
 } from "@/lib/chat-attachments";
 import { AssistantFilter } from "@/lib/chat-assistant-filter";
+import {
+  flattenToolResultContent,
+  formatToolInputValue,
+  formatToolPayload,
+  ToolCallTracker,
+} from "@/lib/chat-tool-events";
 import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
 import { buildPromptWithCovenIdentityCanon } from "@/lib/coven-identity-canon";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
@@ -755,18 +761,11 @@ export async function POST(req: Request) {
       let assistantText = "";
       let jsonBuf = "";
       let result: { duration_ms?: number; is_error?: boolean } = {};
-      // Per-tool start times so post_tool_use can compute durationMs and
-      // associate output with the matching pre_tool_use event.
-      let toolStartTimes = new Map<string, { startedAt: number; id: string }>();
-      let toolSeq = 0;
-      const toolIdFor = (name: string): string => {
-        const existing = toolStartTimes.get(name);
-        if (existing) return existing.id;
-        toolSeq += 1;
-        const id = `tool-${toolSeq}-${name}`;
-        toolStartTimes.set(name, { startedAt: Date.now(), id });
-        return id;
-      };
+      // Tracks open tool calls from both hook lines and stream-json
+      // envelopes: per-name FIFO queues give concurrent same-name calls
+      // distinct ids, and hook/envelope events describing the same call are
+      // deduped onto one id (hook events win — they carry real durations).
+      let toolTracker = new ToolCallTracker();
       // Keep stderr off the assistant stream — surface it only on failure
       // or empty-success so users don't see raw 401 traces mid-bubble.
       const stderrTail: string[] = [];
@@ -796,7 +795,18 @@ export async function POST(req: Request) {
               duration_ms?: number;
               is_error?: boolean;
               message?: {
-                content?: Array<{ type?: string; text?: string }>;
+                content?: Array<{
+                  type?: string;
+                  text?: string;
+                  // tool_use blocks
+                  id?: string;
+                  name?: string;
+                  input?: unknown;
+                  // tool_result blocks
+                  tool_use_id?: string;
+                  content?: unknown;
+                  is_error?: boolean;
+                }>;
               };
             };
             if (ev.session_id && !sessionId) {
@@ -813,14 +823,41 @@ export async function POST(req: Request) {
             }
             if (ev.type === "result") {
               result = { duration_ms: ev.duration_ms, is_error: ev.is_error };
-            } else if (ev.type === "assistant" && ev.message?.content) {
+            } else if (
+              ev.type === "assistant" &&
+              Array.isArray(ev.message?.content)
+            ) {
               // Claude stream-json wraps assistant text inside a message envelope.
               // Extract every text chunk and surface it as an assistant_chunk so
-              // the chat bubble renders.
+              // the chat bubble renders. tool_use blocks become structured
+              // tool events so harnesses WITHOUT pre/post_tool_use hooks still
+              // show tool activity; the tracker dedups against hook-derived
+              // events when both sources describe the same call.
               for (const block of ev.message.content) {
                 if (block.type === "text" && block.text) {
                   assistantText += block.text;
                   push({ kind: "assistant_chunk", text: block.text });
+                } else if (block.type === "tool_use" && block.id && block.name) {
+                  const toolEv = toolTracker.envelopeToolUse(
+                    block.id,
+                    block.name,
+                    formatToolInputValue(block.input),
+                  );
+                  if (toolEv) push({ kind: "tool_use", ...toolEv });
+                }
+              }
+            } else if (ev.type === "user" && Array.isArray(ev.message?.content)) {
+              // Tool outputs come back as tool_result blocks on the follow-up
+              // user envelope. Settle the matching tool event unless a post
+              // hook already did (hook output + duration win).
+              for (const block of ev.message.content) {
+                if (block.type === "tool_result" && block.tool_use_id) {
+                  const toolEv = toolTracker.envelopeToolResult(
+                    block.tool_use_id,
+                    flattenToolResultContent(block.content),
+                    block.is_error === true,
+                  );
+                  if (toolEv) push({ kind: "tool_use", ...toolEv });
                 }
               }
             }
@@ -844,38 +881,14 @@ export async function POST(req: Request) {
           const isPost = trimmed.startsWith("hook: post_tool_use");
           const name = toolMatch[1];
           const rest = (toolMatch[2] ?? "").trim();
-          const id = toolIdFor(name);
-          // Try to pretty-print JSON payloads; fall back to raw string.
-          const fmtPayload = (raw: string): string | undefined => {
-            if (!raw) return undefined;
-            try {
-              return JSON.stringify(JSON.parse(raw), null, 2);
-            } catch {
-              return raw;
-            }
-          };
-          if (isPost) {
-            const meta = toolStartTimes.get(name);
-            const durationMs = meta ? Date.now() - meta.startedAt : undefined;
-            const isError = /error|fail|denied|exit\s*[1-9]/i.test(rest);
-            push({
-              kind: "tool_use",
-              id,
-              name,
-              output: fmtPayload(rest),
-              status: isError ? "error" : "ok",
-              durationMs,
-            });
-            toolStartTimes.delete(name);
-          } else {
-            push({
-              kind: "tool_use",
-              id,
-              name,
-              input: fmtPayload(rest),
-              status: "running",
-            });
-          }
+          const toolEv = isPost
+            ? toolTracker.hookEnd(
+                name,
+                formatToolPayload(rest),
+                /error|fail|denied|exit\s*[1-9]/i.test(rest),
+              )
+            : toolTracker.hookStart(name, formatToolPayload(rest));
+          push({ kind: "tool_use", ...toolEv });
         }
         const filtered = assistantFilter.push(cleaned + "\n");
         if (filtered) {
@@ -1001,8 +1014,7 @@ export async function POST(req: Request) {
         assistantText = "";
         jsonBuf = "";
         result = {};
-        toolStartTimes = new Map();
-        toolSeq = 0;
+        toolTracker = new ToolCallTracker();
         stderrTail.length = 0;
         stdoutErrTail.length = 0;
         resumeFailed = false;

--- a/src/lib/chat-tool-events.ts
+++ b/src/lib/chat-tool-events.ts
@@ -1,0 +1,223 @@
+// Tool-call event tracking for the native chat SSE stream.
+//
+// Two independent sources describe the same tool calls:
+//   1. Hook lines on stdout ("hook: pre_tool_use Bash {...}" /
+//      "hook: post_tool_use Bash {...}") — only present when the harness has
+//      those hooks configured. They carry real start/end timing.
+//   2. stream-json envelopes — assistant messages carry `tool_use` content
+//      blocks (native id, name, input) and the follow-up user message carries
+//      the matching `tool_result` block (tool_use_id, content).
+//
+// The tracker turns both into UI-ready events with a stable `id` per call —
+// the chat UI upserts tool blocks keyed on `id`, so two events with the same
+// id merge into one block. Invariants:
+//   - Concurrent same-name calls get DISTINCT ids (per-name FIFO queue of
+//     open calls; CHAT-D4-03 was a name-keyed map that merged them).
+//   - When hooks and envelopes describe the same call, hook events win for
+//     timing/output; envelope events are linked to the same id (so they merge
+//     in the UI) or suppressed once the hook has settled the call
+//     (CHAT-D4-04 dedup).
+//   - When hooks are absent, envelope blocks alone produce a full
+//     running → settled lifecycle.
+
+export type ToolStreamEvent = {
+  id: string;
+  name: string;
+  input?: string;
+  output?: string;
+  status: "running" | "ok" | "error";
+  durationMs?: number;
+};
+
+/** Pretty-print a raw JSON payload string; fall back to the raw text. */
+export function formatToolPayload(raw: string): string | undefined {
+  if (!raw) return undefined;
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}
+
+/** Pretty-print an envelope tool_use input value (already-parsed JSON). */
+export function formatToolInputValue(value: unknown): string | undefined {
+  if (value == null) return undefined;
+  if (typeof value === "string") return formatToolPayload(value);
+  try {
+    const text = JSON.stringify(value, null, 2);
+    // "{}" carries no information; keep the block input empty instead.
+    return text === "{}" ? undefined : text;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Flatten a stream-json tool_result content value into display text. */
+export function flattenToolResultContent(content: unknown): string | undefined {
+  if (content == null) return undefined;
+  if (typeof content === "string") return content || undefined;
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const block of content) {
+      if (
+        block &&
+        typeof block === "object" &&
+        (block as { type?: unknown }).type === "text" &&
+        typeof (block as { text?: unknown }).text === "string"
+      ) {
+        parts.push((block as { text: string }).text);
+      }
+    }
+    if (parts.length) return parts.join("\n");
+  }
+  try {
+    return JSON.stringify(content, null, 2);
+  } catch {
+    return undefined;
+  }
+}
+
+type OpenCall = {
+  /** Stream id used on SSE events — the UI's merge key. */
+  id: string;
+  name: string;
+  startedAt: number;
+  /** Native stream-json tool_use id, when known. */
+  envelopeId?: string;
+  origin: "hook" | "envelope";
+  /** A pre_tool_use hook has been paired with this call. */
+  hookStarted: boolean;
+};
+
+export class ToolCallTracker {
+  private seq = 0;
+  /** FIFO queues of OPEN calls per tool name. */
+  private open = new Map<string, OpenCall[]>();
+  /** Open calls addressable by native envelope tool_use id. */
+  private byEnvelopeId = new Map<string, OpenCall>();
+  /** Envelope ids whose calls were already settled (dedup tool_result). */
+  private settledEnvelopeIds = new Set<string>();
+  private readonly now: () => number;
+
+  constructor(now: () => number = Date.now) {
+    this.now = now;
+  }
+
+  private queueFor(name: string): OpenCall[] {
+    let q = this.open.get(name);
+    if (!q) {
+      q = [];
+      this.open.set(name, q);
+    }
+    return q;
+  }
+
+  private settle(call: OpenCall): void {
+    const q = this.open.get(call.name);
+    if (q) {
+      const idx = q.indexOf(call);
+      if (idx >= 0) q.splice(idx, 1);
+    }
+    if (call.envelopeId) {
+      this.byEnvelopeId.delete(call.envelopeId);
+      this.settledEnvelopeIds.add(call.envelopeId);
+    }
+  }
+
+  /** pre_tool_use (or bare tool_use) hook line: a call is starting. */
+  hookStart(name: string, input?: string): ToolStreamEvent {
+    const queue = this.queueFor(name);
+    // The envelope may have announced this call first (assistant message
+    // flushes before the tool executes). Claim the oldest unclaimed
+    // envelope-announced call of this name so both sources share one id.
+    const claim = queue.find((c) => c.origin === "envelope" && !c.hookStarted);
+    if (claim) {
+      claim.hookStarted = true;
+      // The hook marks actual execution start — a tighter duration baseline
+      // than when the envelope was parsed.
+      claim.startedAt = this.now();
+      return { id: claim.id, name, input, status: "running" };
+    }
+    this.seq += 1;
+    const call: OpenCall = {
+      id: `tool-${this.seq}-${name}`,
+      name,
+      startedAt: this.now(),
+      origin: "hook",
+      hookStarted: true,
+    };
+    queue.push(call);
+    return { id: call.id, name, input, status: "running" };
+  }
+
+  /** post_tool_use hook line: the OLDEST open hook-started call completed. */
+  hookEnd(name: string, output: string | undefined, isError: boolean): ToolStreamEvent {
+    const queue = this.queueFor(name);
+    // FIFO pairing: a post matches the oldest open pre of the same name.
+    // Fall back to the oldest envelope-only call (post-hook-only harnesses).
+    const call = queue.find((c) => c.hookStarted) ?? queue[0];
+    const status = isError ? "error" : "ok";
+    if (!call) {
+      // Post without any open call: surface it anyway under a fresh id.
+      this.seq += 1;
+      return { id: `tool-${this.seq}-${name}`, name, output, status };
+    }
+    const durationMs = this.now() - call.startedAt;
+    this.settle(call);
+    return { id: call.id, name, output, status, durationMs };
+  }
+
+  /**
+   * stream-json assistant `tool_use` block. Returns an event when the call is
+   * new; returns null when a hook already announced it (the native id is
+   * linked to the hook's id instead, so later tool_result blocks dedup).
+   */
+  envelopeToolUse(id: string, name: string, input?: string): ToolStreamEvent | null {
+    if (this.byEnvelopeId.has(id) || this.settledEnvelopeIds.has(id)) return null;
+    const queue = this.queueFor(name);
+    // A hook pre may have surfaced this call already under a minted id. Link
+    // the native id to the oldest unlinked hook call rather than emitting a
+    // duplicate block — hook events win when both sources exist.
+    const hookCall = queue.find((c) => c.origin === "hook" && !c.envelopeId);
+    if (hookCall) {
+      hookCall.envelopeId = id;
+      this.byEnvelopeId.set(id, hookCall);
+      return null;
+    }
+    const call: OpenCall = {
+      id,
+      name,
+      startedAt: this.now(),
+      envelopeId: id,
+      origin: "envelope",
+      hookStarted: false,
+    };
+    queue.push(call);
+    this.byEnvelopeId.set(id, call);
+    return { id, name, input, status: "running" };
+  }
+
+  /**
+   * stream-json `tool_result` block (from the follow-up user message).
+   * Returns null when the matching call was already settled by a post hook
+   * (hook output + duration win) or was never announced.
+   */
+  envelopeToolResult(
+    toolUseId: string,
+    output: string | undefined,
+    isError: boolean,
+  ): ToolStreamEvent | null {
+    if (this.settledEnvelopeIds.has(toolUseId)) return null;
+    const call = this.byEnvelopeId.get(toolUseId);
+    if (!call) return null;
+    const durationMs = this.now() - call.startedAt;
+    this.settle(call);
+    return {
+      id: call.id,
+      name: call.name,
+      output,
+      status: isError ? "error" : "ok",
+      durationMs,
+    };
+  }
+}


### PR DESCRIPTION
Implements **CHAT-D4-03** and **CHAT-D4-04** (both P2) from the chat UX audit (#395).

## CHAT-D4-03 — tool ids keyed by name merged concurrent same-name calls

`toolIdFor` in `src/app/api/chat/send/route.ts` kept one open entry per tool *name*: a second `Bash` starting before the first's `post_tool_use` hook reused the first call's id, so the UI upsert overwrote the first call's input/output and the duration was computed against the wrong start time.

**Fix:** open calls now live in a per-name **FIFO queue** — `pre_tool_use` pushes a fresh id, `post_tool_use` settles the oldest open one — so overlapping same-name invocations get distinct ids and per-call durations.

## CHAT-D4-04 — stream-json tool_use/tool_result content blocks were dropped

The assistant envelope parser extracted only `text` blocks. A harness without pre/post_tool_use hooks configured surfaced zero tool blocks: the turn sat in a silent "Using tools".

**Fix:** assistant-envelope `tool_use` blocks (id, name, input) now map to `kind:"tool_use"` SSE events with status `running`, and user-envelope `tool_result` blocks (tool_use_id, content, is_error) settle them with output, ok/error status, and duration. Inputs/outputs are pretty-printed consistently with the hook path.

## Dedup design (hooks + envelope describing the same call)

The chat UI upserts tool blocks keyed on `id`, so dedup works by id-unification, preferring hook events (they carry real timings):

- **Envelope first** (assistant message flushes before the tool runs): the next `pre_tool_use` of that name *claims* the envelope-announced call — it reuses the native `toolu_*` id (UI merges) and re-baselines `startedAt` at actual execution start.
- **Hook first** (interleaving): the envelope `tool_use` is *linked* to the oldest unlinked hook call of that name instead of emitting a duplicate block.
- A call settled by a `post_tool_use` hook records its native id, so the late envelope `tool_result` is suppressed (hook output + duration win).
- With no hooks at all, envelope blocks alone produce the full running → settled lifecycle.

The queue + dedup are a pure module — `src/lib/chat-tool-events.ts` (`ToolCallTracker`, `formatToolPayload`, `formatToolInputValue`, `flattenToolResultContent`) — wired into `route.ts` for both the hook-line path and the envelope path, and reset on the transparent resume retry.

## Tests

`harness-routing.test.ts` extended with:
- source pins: tracker wiring, envelope `tool_use`/`tool_result` mapping, `toolStartTimes` must stay gone, retry reset
- behavioral: two overlapping same-name calls get distinct ids + FIFO pairing + correct per-call durations; orphan post still surfaces (no fabricated duration); envelope-only lifecycle (native id, pretty input, ok/error settle, duration); both dedup orders (envelope-first claim, hook-first link); payload formatters

## Verification

- `node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts` — pass
- `pnpm typecheck` — pass
- `pnpm test:api` — pass (full suite)
- `pnpm test:app` — pass (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)