### PR TITLE
fix(chat): normalize drag file type detection

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -402,12 +402,22 @@ assert.match(
 // — CHAT-D1-03: drag-and-drop attach on the chat surface —
 assert.match(
   source,
-  /onDragEnter=\{\(e\) => \{\s*\n\s*if \(!e\.dataTransfer\.types\.includes\("Files"\)\) return;[\s\S]*?dragDepthRef\.current \+= 1;\s*\n\s*setDropActive\(true\);/,
+  /function hasDraggedFiles\(types: DataTransfer\["types"\]\): boolean \{[\s\S]*Array\.from\(types\)\.includes\("Files"\)/,
+  "Drag file detection must normalize DataTransfer.types before calling includes for WebKit/WebView DOMStringList compatibility",
+);
+assert.doesNotMatch(
+  source,
+  /dataTransfer\.types\.includes\("Files"\)/,
+  "Drag handlers must not call DataTransfer.types.includes directly; WebKit DOMStringList may not implement includes",
+);
+assert.match(
+  source,
+  /onDragEnter=\{\(e\) => \{\s*\n\s*if \(!hasDraggedFiles\(e\.dataTransfer\.types\)\) return;[\s\S]*?dragDepthRef\.current \+= 1;\s*\n\s*setDropActive\(true\);/,
   "dragenter must guard on a Files-type drag (text selections must not hijack) and use counter-based depth tracking",
 );
 assert.match(
   source,
-  /onDragOver=\{\(e\) => \{\s*\n\s*if \(!e\.dataTransfer\.types\.includes\("Files"\)\) return;\s*\n\s*e\.preventDefault\(\);/,
+  /onDragOver=\{\(e\) => \{\s*\n\s*if \(!hasDraggedFiles\(e\.dataTransfer\.types\)\) return;\s*\n\s*e\.preventDefault\(\);/,
   "dragover must preventDefault (only for file drags) so the browser allows the drop",
 );
 assert.match(
@@ -417,7 +427,7 @@ assert.match(
 );
 assert.match(
   source,
-  /onDrop=\{\(e\) => \{\s*\n\s*dragDepthRef\.current = 0;\s*\n\s*setDropActive\(false\);[\s\S]*?void attachFiles\(e\.dataTransfer\.files\);/,
+  /onDrop=\{\(e\) => \{\s*\n\s*dragDepthRef\.current = 0;\s*\n\s*setDropActive\(false\);[\s\S]*?if \(!hasDraggedFiles\(e\.dataTransfer\.types\)\) return;[\s\S]*?void attachFiles\(e\.dataTransfer\.files\);/,
   "drop must reset the overlay state and route dataTransfer.files through the existing attach pipeline",
 );
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -254,6 +254,10 @@ function isTextLike(file: File): boolean {
   return /\.(txt|md|markdown|json|yaml|yml|toml|csv|ts|tsx|js|jsx|css|scss|html|xml|rs|go|py|rb|swift|java|kt|sh|zsh|fish|sql|log)$/i.test(file.name);
 }
 
+function hasDraggedFiles(types: DataTransfer["types"]): boolean {
+  return Array.from(types).includes("Files");
+}
+
 async function fileToAttachment(file: File): Promise<ComposerAttachment> {
   const attachment: ComposerAttachment = {
     id: crypto.randomUUID(),
@@ -1855,24 +1859,24 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     <section
       className="cave-chat-linear flex h-full flex-col bg-[var(--bg-base)] text-[var(--text-primary)]"
       onDragEnter={(e) => {
-        if (!e.dataTransfer.types.includes("Files")) return;
+        if (!hasDraggedFiles(e.dataTransfer.types)) return;
         e.preventDefault();
         dragDepthRef.current += 1;
         setDropActive(true);
       }}
       onDragOver={(e) => {
-        if (!e.dataTransfer.types.includes("Files")) return;
+        if (!hasDraggedFiles(e.dataTransfer.types)) return;
         e.preventDefault();
       }}
       onDragLeave={(e) => {
-        if (!e.dataTransfer.types.includes("Files")) return;
+        if (!hasDraggedFiles(e.dataTransfer.types)) return;
         dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
         if (dragDepthRef.current === 0) setDropActive(false);
       }}
       onDrop={(e) => {
         dragDepthRef.current = 0;
         setDropActive(false);
-        if (!e.dataTransfer.types.includes("Files")) return;
+        if (!hasDraggedFiles(e.dataTransfer.types)) return;
         e.preventDefault();
         void attachFiles(e.dataTransfer.files);
       }}


### PR DESCRIPTION
## Summary
- normalize `DataTransfer.types` with `Array.from(...)` before checking for `Files`
- use the normalized helper in all chat drag/drop handlers
- update the drag/drop source assertions to prevent direct `.types.includes(...)` regressions

Follow-up for late Copilot feedback on merged PR #412.

## Verification
- node --experimental-strip-types src/components/chat-view-polish.test.ts
- pnpm test:app
- pnpm typecheck