### PR TITLE
fix(chat): visible retry at failed turns on desktop

### DIFF
--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -207,4 +207,45 @@ assert.match(
   "Regenerate renders in the assistant bubble's CSS-revealed action row with the shared button styling (CHAT-D6-02)",
 );
 
+// ── CHAT-D12-03: visible retry at failed turns on desktop ──
+
+// regenerateFor's gate is busy/role/pending only — a failed turn (pending:
+// false, error: true) must keep passing it, or the pill below never renders.
+const regenerateForBody =
+  source.match(
+    /function regenerateFor\(turn: Turn\)[\s\S]*?return \(\) => void sendRaw\(text, prevAttachments \?\? \[\]\);/,
+  )?.[0] ?? "";
+assert.ok(regenerateForBody, "regenerateFor body should be extractable (CHAT-D12-03)");
+assert.doesNotMatch(
+  regenerateForBody,
+  /turn\.error/,
+  "regenerateFor must serve failed turns — its gate must not exclude turn.error (CHAT-D12-03)",
+);
+
+assert.match(
+  source,
+  /\{turn\.error && onRegenerate \? \([\s\S]{0,400}?aria-label="Retry failed turn"[\s\S]{0,300}?onClick=\{onRegenerate\}/,
+  "Failed assistant turns render an explicit Retry button wired to the regenerate callback (CHAT-D12-03)",
+);
+
+assert.match(
+  source,
+  /cave-turn-status--\$\{turnStatus\}[\s\S]{0,900}?cave-turn-retry/,
+  "The Retry affordance lives in the turn meta row beside the status chip — discoverable without hover (CHAT-D12-03)",
+);
+
+// The transport-failure path is untouched: failed dones still arm the
+// lastFailedSend banner state alongside the per-turn affordance.
+assert.match(
+  source,
+  /case "done":[\s\S]*?if \(ev\.isError\) setLastFailedSend\(request\);/,
+  "Failed dones must still arm lastFailedSend for the transport retry path (CHAT-D12-03)",
+);
+
+assert.match(
+  styles,
+  /\.cave-turn-retry\s*\{[\s\S]*?display: inline-flex/,
+  "Retry pill has always-visible styling — no hover-reveal gating (CHAT-D12-03)",
+);
+
 console.log("chat-view-lifecycle.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2460,6 +2460,22 @@ function TurnRow({
                 {lifecycleLabel(turnStatus)}
               </span>
             )}
+            {/* CHAT-D12-03: a failed turn must offer retry WITHOUT hover — the
+                bubble action row is hover-revealed (and absent entirely when
+                the turn died with no text), and the lastFailedSend banner only
+                covers transport errors. Same gated callback as Regenerate. */}
+            {turn.error && onRegenerate ? (
+              <button
+                type="button"
+                aria-label="Retry failed turn"
+                title="Retry"
+                onClick={onRegenerate}
+                className="cave-turn-retry"
+              >
+                <Icon name="ph:arrow-clockwise" width={11} aria-hidden />
+                Retry
+              </button>
+            ) : null}
             {showTimestamp && turn.createdAt ? <span className="opacity-60">{fmtTime(turn.createdAt)}</span> : null}
           </div>
 

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -720,6 +720,29 @@
   color: var(--color-danger);
 }
 
+/* CHAT-D12-03: always-visible retry pill beside a failed turn's status chip.
+   Deliberately NOT hover-revealed — a stuck user must see it immediately. */
+.cave-turn-retry {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 5px;
+  border: 1px solid color-mix(in oklch, var(--color-danger) 35%, transparent);
+  background: transparent;
+  padding: 1px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--color-danger);
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.cave-turn-retry:hover {
+  background: color-mix(in oklch, var(--color-danger) 12%, transparent);
+  border-color: color-mix(in oklch, var(--color-danger) 55%, transparent);
+}
+
 .cave-reasoning-block,
 .cave-progress-group,
 .cave-tool-group {


### PR DESCRIPTION
Implements **CHAT-D12-03 (P2)** from the chat UX audit (#395).

## Problem

When a harness turn completes failed (`done` event with `isError: true`), the done handler arms `lastFailedSend` but never calls `setError(...)` — and the retry banner is gated on `error`. The only other Retry lives in the mobile action strip (`display: none` on desktop). The bubble's hover-revealed Regenerate doesn't rescue this: it's invisible without hover, and absent entirely when the turn failed with no text (the action row is gated on `content`). Net: a desktop user whose turn fails has **no discoverable retry affordance**. Benchmark: ChatGPT always shows Regenerate at a failed turn.

## Fix (option a — per-turn affordance, not banner)

- **`chat-view.tsx`** — TurnRow renders an always-visible **Retry** pill in the failed turn's meta row, beside the "Failed" status chip, wired to the same gated `regenerateFor` callback from #409. Verified: `regenerateFor` already serves failed turns — its gate is `busy || role !== "assistant" || pending`, and a failed turn is settled (`pending: false`, `error: true`). Per-turn state survives re-render, unlike the transient banner.
- **`cave-chat.css`** — `.cave-turn-retry` pill styling (danger-tinted, `inline-flex`, deliberately no hover-reveal gating).
- **`lastFailedSend` untouched** for transport failures — the banner path still works exactly as before.

## Tests

Extended `chat-view-lifecycle.test.ts` (#409's pins kept intact):
- `regenerateFor`'s gate must not exclude `turn.error` (extracted function body, `doesNotMatch`)
- failed turns render the Retry button wired to `onRegenerate`
- the pill sits in the meta row beside the status chip — discoverable without hover
- failed dones still arm `lastFailedSend`
- `.cave-turn-retry` styling exists with no hover gating

`pnpm test:app` exit 0, `pnpm typecheck` clean. (Pre-existing non-CI `board-chat-link.test.ts` failure not triggered in `test:app`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)