### PR TITLE
fix(chat): adopt shared focus trap in expand modal and attachment lightbox

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -20,6 +20,7 @@ import {
   type ChatAttachment,
 } from "@/lib/chat-attachments";
 import { Modal } from "@/components/ui/modal";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 import { DebugPane } from "@/components/debug-pane";
 import { clearChatDebugState, publishChatDebugState } from "@/lib/chat-debug-store";
 import { VoiceCallButton } from "./voice-call-button";
@@ -2621,18 +2622,21 @@ function ToolBlock({ tool }: { tool: ToolEvent }) {
 
 function AttachmentLightbox({ attachment, onClose }: { attachment: ChatAttachment; onClose: () => void }) {
   const isImage = (attachment.mimeType ?? attachment.type)?.startsWith("image/");
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  // CHAT-D11-02: shared focus trap — focuses the first control on open,
+  // cycles Tab/Shift+Tab inside the dialog, closes on Escape, and restores
+  // focus to the attachment-chip trigger on close. Always active: this
+  // component only mounts while the lightbox is open.
+  useFocusTrap(true, dialogRef, { onEscape: onClose });
   return (
     <div
+      ref={dialogRef}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
       onClick={onClose}
       role="dialog"
       aria-modal="true"
       aria-label={`Preview ${attachment.name}`}
+      tabIndex={-1}
     >
       <div
         className="relative max-h-[90vh] w-[90vw] max-w-screen-2xl overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-2xl"

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -34,6 +34,7 @@ import type { Highlighter } from "shiki";
 import moodCTheme from "@/styles/shiki/mood-c-dark.json";
 import { Icon } from "@/lib/icon";
 import { sanitizeHtml } from "@/lib/html-sanitize";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -827,12 +828,13 @@ function MarkdownExpandModal({
 }) {
   const [copied, setCopied] = useState(false);
   const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  // CHAT-D11-02: shared focus trap — focuses the first control on open,
+  // cycles Tab/Shift+Tab inside the dialog, closes on Escape, and restores
+  // focus to the Expand trigger on close. Always active: this component only
+  // mounts while the modal is open.
+  useFocusTrap(true, dialogRef, { onEscape: onClose });
 
   useEffect(() => () => { if (copyTimer.current) clearTimeout(copyTimer.current); }, []);
 
@@ -845,11 +847,13 @@ function MarkdownExpandModal({
 
   return (
     <div
+      ref={dialogRef}
       className="fixed inset-0 z-[60] flex items-center justify-center bg-black/75 backdrop-blur-sm"
       onClick={onClose}
       role="dialog"
       aria-modal="true"
       aria-label={`Expanded ${label}`}
+      tabIndex={-1}
     >
       <div
         className="relative flex h-[90vh] w-[92vw] max-w-[1100px] flex-col overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-panel)] shadow-2xl"

--- a/src/components/voice-call-button.test.ts
+++ b/src/components/voice-call-button.test.ts
@@ -36,3 +36,113 @@ test("button uses a phone icon", () => {
     "voice-call-button should use a phone iconify glyph",
   );
 });
+
+// ---------------------------------------------------------------------------
+// CHAT-D11-02 — ad-hoc chat overlays must adopt the shared focus trap
+// (src/lib/use-focus-trap.ts, same infra as ui/modal.tsx) instead of bare
+// window-level Escape listeners. Pins: trap adoption, ad-hoc listener removal,
+// and the focus-restore path in the shared hook.
+// ---------------------------------------------------------------------------
+
+const messageBubbleSource = readFileSync(
+  new URL("./message-bubble.tsx", import.meta.url),
+  "utf8",
+);
+const chatViewSource = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const focusTrapSource = readFileSync(
+  new URL("../lib/use-focus-trap.ts", import.meta.url),
+  "utf8",
+);
+
+/** Slice a top-level `function <name>` body out of a source file (to the next
+ *  top-level `function` declaration, or EOF). Keeps the no-ad-hoc-listener
+ *  assertions scoped to the overlay, not the whole file. */
+function sliceFunction(src, name) {
+  const start = src.indexOf(`function ${name}`);
+  assert.notEqual(start, -1, `expected to find function ${name}`);
+  const next = src.indexOf("\nfunction ", start + 1);
+  return next === -1 ? src.slice(start) : src.slice(start, next);
+}
+
+const expandModal = sliceFunction(messageBubbleSource, "MarkdownExpandModal");
+const lightbox = sliceFunction(chatViewSource, "AttachmentLightbox");
+
+test("CHAT-D11-02: MarkdownExpandModal uses the shared focus trap", () => {
+  assert.match(
+    messageBubbleSource,
+    /import \{ useFocusTrap \} from "@\/lib\/use-focus-trap"/,
+    "message-bubble should import the shared useFocusTrap hook",
+  );
+  assert.match(
+    expandModal,
+    /useFocusTrap\(true, dialogRef, \{ onEscape: onClose \}\)/,
+    "MarkdownExpandModal should activate useFocusTrap with Escape wired to onClose",
+  );
+  assert.match(
+    expandModal,
+    /ref=\{dialogRef\}/,
+    "MarkdownExpandModal should attach the trap container ref to the dialog",
+  );
+  assert.match(
+    expandModal,
+    /tabIndex=\{-1\}/,
+    "MarkdownExpandModal dialog needs tabIndex={-1} for the trap's container-focus fallback",
+  );
+});
+
+test("CHAT-D11-02: AttachmentLightbox uses the shared focus trap", () => {
+  assert.match(
+    chatViewSource,
+    /import \{ useFocusTrap \} from "@\/lib\/use-focus-trap"/,
+    "chat-view should import the shared useFocusTrap hook",
+  );
+  assert.match(
+    lightbox,
+    /useFocusTrap\(true, dialogRef, \{ onEscape: onClose \}\)/,
+    "AttachmentLightbox should activate useFocusTrap with Escape wired to onClose",
+  );
+  assert.match(
+    lightbox,
+    /ref=\{dialogRef\}/,
+    "AttachmentLightbox should attach the trap container ref to the dialog",
+  );
+  assert.match(
+    lightbox,
+    /tabIndex=\{-1\}/,
+    "AttachmentLightbox dialog needs tabIndex={-1} for the trap's container-focus fallback",
+  );
+});
+
+test("CHAT-D11-02: ad-hoc window keydown listeners are gone from both overlays", () => {
+  assert.doesNotMatch(
+    expandModal,
+    /window\.addEventListener\(\s*["']keydown["']/,
+    "MarkdownExpandModal must not register its own window keydown listener — the trap owns Escape",
+  );
+  assert.doesNotMatch(
+    lightbox,
+    /window\.addEventListener\(\s*["']keydown["']/,
+    "AttachmentLightbox must not register its own window keydown listener — the trap owns Escape",
+  );
+});
+
+test("CHAT-D11-02: overlays keep dialog semantics", () => {
+  for (const [name, body] of [["MarkdownExpandModal", expandModal], ["AttachmentLightbox", lightbox]]) {
+    assert.match(body, /role="dialog"/, `${name} should keep role="dialog"`);
+    assert.match(body, /aria-modal="true"/, `${name} should keep aria-modal="true"`);
+    assert.match(body, /aria-label=\{/, `${name} should keep an aria-label`);
+  }
+});
+
+test("CHAT-D11-02: shared trap provides the focus-restore path the overlays rely on", () => {
+  assert.match(
+    focusTrapSource,
+    /returnFocusRef\.current = \(document\.activeElement as HTMLElement\) \?\? null/,
+    "useFocusTrap should capture the previously-focused element (the trigger) on activate",
+  );
+  assert.match(
+    focusTrapSource,
+    /returnFocusRef\.current\?\.focus\(\)/,
+    "useFocusTrap should restore focus to the trigger on deactivate/unmount",
+  );
+});


### PR DESCRIPTION
## Summary

Implements **CHAT-D11-02 (P2)** from the chat UX audit (#395) — the remaining half of D11-01/02 (composer Esc precedence was fixed in #402).

Two ad-hoc chat overlays bypassed the app's existing focus-trap infrastructure (`src/lib/use-focus-trap.ts`, used correctly by `ui/modal.tsx`), each rolling a bare window-level Escape keydown listener with no initial focus, no Tab trap, and no focus restore:

- **MarkdownExpandModal** (`src/components/message-bubble.tsx`) — and with #400's CSS-revealed action rows, focus restore matters here: closing should return focus to the Expand button.
- **AttachmentLightbox** (`src/components/chat-view.tsx`)

## Fix: direct `useFocusTrap`, not `Modal` wrapping

For **both** overlays I applied `useFocusTrap(true, dialogRef, { onEscape: onClose })` directly — the same hook + options `Modal` uses — rather than wrapping in `Modal`. Justification: both overlays are full-bleed custom layouts (expand modal: `h-[90vh] w-[92vw] max-w-[1100px]` with its own header bar + Copy control; lightbox: `max-h-[90vh] w-[90vw] max-w-screen-2xl` with name/size/truncated chrome and edge-to-edge image/pre body). `Modal`'s `ui-modal` chrome (its own backdrop, max-width, padding, breadcrumb header, close button) would materially change their appearance, and this finding is a behavior/a11y adoption, not a redesign.

Per overlay:
- Initial focus lands inside (first focusable: the Copy button / the Close button)
- Tab and Shift+Tab cycle within the dialog
- Escape closes via the trap; the ad-hoc `window.addEventListener("keydown", ...)` listeners are **removed**
- Focus restores to the trigger (Expand button / attachment chip) on close
- `role="dialog"`, `aria-modal="true"`, and aria-labels preserved; dialog gets `tabIndex={-1}` for the trap's container-focus fallback
- No visual change

## Tests

**Choice: extended `src/components/voice-call-button.test.ts`.** Decision rule applied: among the non-contended candidates, `voice-call-overlay-state.test.ts` is a pure reducer test (no overlay/modal source-pin idioms — fs pins would be a poor fit there), while `voice-call-button.test.ts` already uses exactly the `readFileSync` + `assert.match` source-pin idiom this needs and is in `test:app`. Added pins: both overlays adopt `useFocusTrap` (ref + `tabIndex={-1}` + `onEscape: onClose`), ad-hoc window keydown listeners are gone (scoped to each component's sliced function body), dialog semantics kept, and the shared hook's focus-restore path exists.

- `node --experimental-strip-types src/components/voice-call-button.test.ts` — 9/9 pass
- `pnpm test:app` — exit 0, no failures
- `pnpm typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)