### PR TITLE
feat(chat): working-tree changes panel with per-file diff and revert

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -23,6 +23,7 @@ const contracts: RouteContract[] = [
   { route: "/board/enrich-steps", methods: ["POST"], kind: "json", readsJson: true },
   { route: "/board", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/capabilities", methods: ["GET"], kind: "json" },
+  { route: "/changes", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", pathGuard: true },
   { route: "/chat/conversation/[id]", methods: ["GET", "POST", "PUT", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/chat/send", methods: ["POST"], kind: "stream", readsJson: true },
   { route: "/codex-automations/[id]", methods: ["GET", "PATCH"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },

--- a/src/app/api/changes/route.ts
+++ b/src/app/api/changes/route.ts
@@ -1,0 +1,285 @@
+import { NextRequest, NextResponse } from "next/server";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import fs from "node:fs";
+import path from "node:path";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Working-tree changes for a chat session's project root (CHAT-D8-01).
+ *
+ * GET  ?projectRoot=<abs>             → list uncommitted changes (git status)
+ * GET  ?projectRoot=<abs>&path=<rel>  → unified diff for one file (capped)
+ * POST { projectRoot, path, confirmUntracked? } → revert ONE file
+ *
+ * Security posture: every git invocation goes through execFile with an
+ * argument array — no shell, so paths are never string-interpolated into a
+ * command. File paths from the client are repo-relative and must pass a
+ * resolve + prefix containment check (absolute paths and `..` segments are
+ * rejected). Reverting an untracked file deletes it, so that path is gated
+ * behind an explicit confirmUntracked flag; the blast radius of POST is one
+ * file per call.
+ */
+
+const execFileAsync = promisify(execFile);
+
+const GIT_TIMEOUT_MS = 10_000;
+const MAX_GIT_BUFFER = 8 * 1024 * 1024;
+/** Diff payload cap (~200KB) so one giant lockfile diff can't flood the panel. */
+const DIFF_CAP_CHARS = 200 * 1024;
+
+type FileStatus = "modified" | "added" | "deleted" | "renamed" | "untracked";
+
+type ChangedFile = {
+  path: string;
+  status: FileStatus;
+  renamedFrom?: string;
+  insertions?: number;
+  deletions?: number;
+};
+
+// ── git helpers ───────────────────────────────────────────────────────────────
+
+/** Run git via execFile (argument array, no shell interpolation). */
+function git(cwd: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  return execFileAsync("git", args, {
+    cwd,
+    timeout: GIT_TIMEOUT_MS,
+    maxBuffer: MAX_GIT_BUFFER,
+  });
+}
+
+type RootResolution =
+  | { ok: true; repoRoot: string }
+  | { ok: false; status: number; error: string; notARepo?: boolean };
+
+/** Validate projectRoot: absolute, exists, is a directory, is a git work tree.
+ *  Resolves to the repo toplevel so status paths line up with diff/revert. */
+async function resolveRepoRoot(projectRoot: string): Promise<RootResolution> {
+  if (!path.isAbsolute(projectRoot)) {
+    return { ok: false, status: 400, error: "projectRoot must be an absolute path" };
+  }
+  let real: string;
+  try {
+    real = fs.realpathSync(path.resolve(projectRoot));
+  } catch {
+    return { ok: false, status: 404, error: "projectRoot does not exist" };
+  }
+  if (!fs.statSync(real).isDirectory()) {
+    return { ok: false, status: 400, error: "projectRoot is not a directory" };
+  }
+  try {
+    const { stdout } = await git(real, ["rev-parse", "--show-toplevel"]);
+    const top = stdout.trim();
+    if (!top) return { ok: false, status: 422, error: "not a git repository", notARepo: true };
+    return { ok: true, repoRoot: fs.realpathSync(top) };
+  } catch {
+    return { ok: false, status: 422, error: "not a git repository", notARepo: true };
+  }
+}
+
+/** Containment check: repo-relative path only — reject absolute paths, NUL,
+ *  `..` traversal, and anything that resolves outside repoRoot. */
+function resolveContainedFile(repoRoot: string, relPath: string): string | null {
+  if (!relPath || relPath.includes("\0") || path.isAbsolute(relPath)) return null;
+  if (relPath.split(/[\\/]+/).includes("..")) return null;
+  const resolved = path.resolve(repoRoot, relPath);
+  if (resolved === repoRoot) return null;
+  if (!resolved.startsWith(repoRoot + path.sep)) return null;
+  return resolved;
+}
+
+function pathNotAllowed(): NextResponse {
+  return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
+}
+
+// ── status parsing ────────────────────────────────────────────────────────────
+
+function statusOf(x: string, y: string): FileStatus {
+  if (x === "?") return "untracked";
+  if (x === "R" || y === "R" || x === "C") return "renamed";
+  if (x === "A" || y === "A") return "added";
+  if (x === "D" || y === "D") return "deleted";
+  return "modified";
+}
+
+/** Parse `git status --porcelain=v1 -z`. Entries are NUL-separated
+ *  `XY <path>`; renames/copies carry the original path as the next token. */
+function parsePorcelainZ(out: string): ChangedFile[] {
+  const tokens = out.split("\0");
+  const files: ChangedFile[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const entry = tokens[i];
+    if (entry.length < 4 || entry[2] !== " ") continue;
+    const x = entry[0];
+    const y = entry[1];
+    const file: ChangedFile = { path: entry.slice(3), status: statusOf(x, y) };
+    if (x === "R" || x === "C") {
+      file.renamedFrom = tokens[i + 1];
+      i++;
+    }
+    files.push(file);
+  }
+  return files;
+}
+
+/** Parse `git diff --numstat -z`: `ins\tdel\tpath` tokens; renames leave the
+ *  path slot empty and append old/new as the following two tokens. Binary
+ *  files report `-` and are skipped — counts are best-effort decoration. */
+function parseNumstatZ(out: string): Map<string, { insertions: number; deletions: number }> {
+  const map = new Map<string, { insertions: number; deletions: number }>();
+  const tokens = out.split("\0");
+  for (let i = 0; i < tokens.length; i++) {
+    const m = /^(\d+|-)\t(\d+|-)\t([\s\S]*)$/.exec(tokens[i]);
+    if (!m) continue;
+    let file = m[3];
+    if (file === "") {
+      file = tokens[i + 2] ?? "";
+      i += 2;
+    }
+    if (!file || m[1] === "-" || m[2] === "-") continue;
+    map.set(file, { insertions: Number(m[1]), deletions: Number(m[2]) });
+  }
+  return map;
+}
+
+async function isTracked(repoRoot: string, relPath: string): Promise<boolean> {
+  try {
+    await git(repoRoot, ["ls-files", "--error-unmatch", "--", relPath]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── GET: change list / single-file diff ───────────────────────────────────────
+
+async function listChanges(repoRoot: string): Promise<NextResponse> {
+  const { stdout } = await git(repoRoot, ["status", "--porcelain=v1", "-z", "--untracked-files=all"]);
+  const files = parsePorcelainZ(stdout);
+
+  // Best-effort ins/del counts vs HEAD (covers staged + unstaged). Repos
+  // without a first commit have no HEAD — skip counts rather than fail.
+  try {
+    const { stdout: numstat } = await git(repoRoot, ["diff", "--numstat", "-z", "HEAD", "--"]);
+    const counts = parseNumstatZ(numstat);
+    for (const file of files) {
+      const c = counts.get(file.path);
+      if (c) {
+        file.insertions = c.insertions;
+        file.deletions = c.deletions;
+      }
+    }
+  } catch {
+    /* no HEAD yet — list without counts */
+  }
+
+  return NextResponse.json({ ok: true, repo: true, repoRoot, files });
+}
+
+async function diffFile(repoRoot: string, relPath: string, absPath: string): Promise<NextResponse> {
+  let diff = "";
+  if (await isTracked(repoRoot, relPath)) {
+    try {
+      // Diff vs HEAD so staged edits show up too (status lists them).
+      ({ stdout: diff } = await git(repoRoot, ["diff", "HEAD", "--", relPath]));
+    } catch {
+      // No HEAD yet (unborn branch) — fall back to worktree-vs-index.
+      ({ stdout: diff } = await git(repoRoot, ["diff", "--", relPath]));
+    }
+  } else {
+    // Untracked: synthesize an all-additions diff. --no-index exits 1 when
+    // the files differ, which execFile reports as an error — recover stdout.
+    try {
+      ({ stdout: diff } = await git(repoRoot, ["diff", "--no-index", "--", "/dev/null", absPath]));
+    } catch (err) {
+      const e = err as { code?: number; stdout?: string };
+      if (e.code === 1 && typeof e.stdout === "string") diff = e.stdout;
+      else throw err;
+    }
+  }
+
+  const truncated = diff.length > DIFF_CAP_CHARS;
+  return NextResponse.json({
+    ok: true,
+    diff: truncated ? diff.slice(0, DIFF_CAP_CHARS) : diff,
+    truncated,
+  });
+}
+
+export async function GET(req: NextRequest) {
+  const projectRoot = req.nextUrl.searchParams.get("projectRoot");
+  const filePath = req.nextUrl.searchParams.get("path");
+  if (!projectRoot) {
+    return NextResponse.json({ ok: false, error: "missing projectRoot param" }, { status: 400 });
+  }
+
+  const root = await resolveRepoRoot(projectRoot);
+  if (!root.ok) {
+    if (root.notARepo) {
+      // Clear, non-error state the panel can render distinctly.
+      return NextResponse.json({ ok: true, repo: false, error: root.error });
+    }
+    return NextResponse.json({ ok: false, error: root.error }, { status: root.status });
+  }
+
+  try {
+    if (filePath === null) return await listChanges(root.repoRoot);
+    const abs = resolveContainedFile(root.repoRoot, filePath);
+    if (!abs) return pathNotAllowed();
+    return await diffFile(root.repoRoot, filePath, abs);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+
+// ── POST: revert one file ─────────────────────────────────────────────────────
+
+export async function POST(req: NextRequest) {
+  let body: { projectRoot?: string; path?: string; confirmUntracked?: boolean };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 });
+  }
+  if (typeof body.projectRoot !== "string" || typeof body.path !== "string") {
+    return NextResponse.json(
+      { ok: false, error: "projectRoot and path are required" },
+      { status: 400 },
+    );
+  }
+
+  const root = await resolveRepoRoot(body.projectRoot);
+  if (!root.ok) {
+    return NextResponse.json({ ok: false, error: root.error }, { status: root.status });
+  }
+  const abs = resolveContainedFile(root.repoRoot, body.path);
+  if (!abs) return pathNotAllowed();
+
+  try {
+    if (await isTracked(root.repoRoot, body.path)) {
+      // Restore the worktree copy (also resurrects a deleted tracked file).
+      await git(root.repoRoot, ["checkout", "--", body.path]);
+      return NextResponse.json({ ok: true, reverted: "checkout", path: body.path });
+    }
+    // Untracked: reverting means deleting the file — destructive, so it is
+    // gated behind an explicit confirmUntracked flag from the client.
+    if (body.confirmUntracked !== true) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "untracked file — deleting it requires confirmUntracked",
+          requiresConfirmUntracked: true,
+        },
+        { status: 400 },
+      );
+    }
+    await git(root.repoRoot, ["clean", "-f", "--", body.path]);
+    return NextResponse.json({ ok: true, reverted: "clean", path: body.path });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -6,6 +6,7 @@ import { ChatRouter, type ChatRouterHandle } from "@/components/chat-router";
 import { AgentsMemoryView } from "@/components/agents-memory-view";
 import { InspectorPane } from "@/components/inspector-pane";
 import { DebugPane } from "@/components/debug-pane";
+import { SessionChangesPanel } from "@/components/session-changes-panel";
 import { Icon } from "@/lib/icon";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { Familiar, SessionRow } from "@/lib/types";
@@ -15,7 +16,7 @@ import type { PendingChatAction } from "@/lib/pending-chat-action";
 
 type AgentsScope = "conversation" | "memory";
 
-export type RightPanelKind = "inspector" | "debug";
+export type RightPanelKind = "inspector" | "changes" | "debug";
 
 type Props = {
   familiars: Familiar[];
@@ -82,6 +83,14 @@ function RightPanel({
         </button>
         <button
           type="button"
+          className={`right-panel-tab${panel === "changes" ? " right-panel-tab--active" : ""}`}
+          onClick={() => onSetPanel("changes")}
+        >
+          <Icon name="ph:git-diff" width={13} />
+          Changes
+        </button>
+        <button
+          type="button"
           className={`right-panel-tab${panel === "debug" ? " right-panel-tab--active" : ""}`}
           onClick={() => onSetPanel("debug")}
         >
@@ -103,6 +112,7 @@ function RightPanel({
             onInboxItemChanged={onInboxItemChanged}
           />
         )}
+        {panel === "changes" && <SessionChangesPanel />}
         {panel === "debug" && <DebugPane />}
       </div>
     </aside>

--- a/src/components/debug-pane.test.ts
+++ b/src/components/debug-pane.test.ts
@@ -20,4 +20,86 @@ assert.doesNotMatch(
   "Debug payload blocks should not force unreadable break-all wrapping",
 );
 
+// ── Changes tab (CHAT-D8-01): working-tree review panel in the right panel ────
+
+const surface = await readFile(new URL("./chat-surface.tsx", import.meta.url), "utf8");
+
+assert.match(
+  surface,
+  /onSetPanel\("changes"\)[\s\S]*?Changes/,
+  "Chat right panel should expose a Changes tab alongside Inspector/Debug",
+);
+assert.match(
+  surface,
+  /\{panel === "changes" && <SessionChangesPanel \/>\}/,
+  "Changes tab should render SessionChangesPanel",
+);
+
+const changesPanel = await readFile(
+  new URL("./session-changes-panel.tsx", import.meta.url),
+  "utf8",
+);
+
+assert.match(
+  changesPanel,
+  /<SyntaxBlock text=\{diffState\.diff\} lang="diff"/,
+  "File diffs should render through SyntaxBlock with diff highlighting",
+);
+assert.match(
+  changesPanel,
+  /Two-step revert[\s\S]*?setConfirmRevert\(true\)/,
+  "Revert must be two-step: first click arms an inline confirm",
+);
+assert.match(
+  changesPanel,
+  /confirmRevert \?[\s\S]*?Cancel[\s\S]*?onRevert\(\)/,
+  "Armed revert row offers Cancel and only the explicit confirm commits",
+);
+assert.match(
+  changesPanel,
+  /All uncommitted changes in/,
+  "Panel caption must be honest that git shows repo-wide changes, not per-session ones",
+);
+
+const changesRoute = await readFile(
+  new URL("../app/api/changes/route.ts", import.meta.url),
+  "utf8",
+);
+
+assert.match(
+  changesRoute,
+  /execFileAsync\("git", args/,
+  "Changes API must shell out via execFile with an argument array",
+);
+assert.doesNotMatch(
+  changesRoute,
+  /\bspawn\(|shell:\s*true|(?<!\.)\bexec\(/,
+  "Changes API must never run git through a shell",
+);
+assert.match(
+  changesRoute,
+  /function resolveContainedFile[\s\S]*?path\.isAbsolute\(relPath\)[\s\S]*?includes\("\.\."\)[\s\S]*?startsWith\(repoRoot \+ path\.sep\)/,
+  "File paths must pass a resolve + prefix containment check (no absolute paths, no ..)",
+);
+assert.match(
+  changesRoute,
+  /"path not allowed"[\s\S]*?status: 403/,
+  "Containment failures return the repo-standard 403 path-deny error",
+);
+assert.match(
+  changesRoute,
+  /confirmUntracked !== true[\s\S]*?requiresConfirmUntracked/,
+  "Deleting an untracked file must be gated behind an explicit confirmUntracked flag",
+);
+assert.match(
+  changesRoute,
+  /\["clean", "-f", "--", body\.path\]/,
+  "Untracked revert is scoped to git clean -f -- <one file>",
+);
+assert.match(
+  changesRoute,
+  /\["checkout", "--", body\.path\]/,
+  "Tracked revert is scoped to git checkout -- <one file>",
+);
+
 console.log("debug-pane.test.ts: ok");

--- a/src/components/session-changes-panel.tsx
+++ b/src/components/session-changes-panel.tsx
@@ -1,0 +1,444 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Icon } from "@/lib/icon";
+import { SyntaxBlock } from "@/components/message-bubble";
+import { useChatDebugSnapshot } from "@/lib/chat-debug-store";
+
+/**
+ * "Changes" right-panel tab (CHAT-D8-01): a per-session review surface for the
+ * working tree the agent is mutating. Lists uncommitted changes under the
+ * session's project root with per-file diff preview and per-file revert.
+ *
+ * Honest scoping: git can't attribute a change to this session specifically,
+ * so the panel shows ALL uncommitted changes in the repo and says so.
+ */
+
+const POLL_MS = 5000;
+
+type FileStatus = "modified" | "added" | "deleted" | "renamed" | "untracked";
+
+type ChangedFile = {
+  path: string;
+  status: FileStatus;
+  renamedFrom?: string;
+  insertions?: number;
+  deletions?: number;
+};
+
+type ChangesResponse = {
+  ok?: boolean;
+  repo?: boolean;
+  repoRoot?: string;
+  files?: ChangedFile[];
+  error?: string;
+};
+
+type DiffState = {
+  loading: boolean;
+  diff?: string;
+  truncated?: boolean;
+  error?: string;
+};
+
+const STATUS_META: Record<FileStatus, { letter: string; label: string; color: string }> = {
+  modified: { letter: "M", label: "modified", color: "var(--color-warning)" },
+  added: { letter: "A", label: "added", color: "var(--accent-presence)" },
+  deleted: { letter: "D", label: "deleted", color: "var(--color-danger)" },
+  renamed: { letter: "R", label: "renamed", color: "var(--text-secondary)" },
+  untracked: { letter: "U", label: "untracked", color: "var(--text-muted)" },
+};
+
+function StatusChip({ status }: { status: FileStatus }) {
+  const meta = STATUS_META[status];
+  return (
+    <span
+      title={meta.label}
+      aria-label={meta.label}
+      className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded font-mono text-[9px] font-semibold"
+      style={{
+        color: meta.color,
+        background: `color-mix(in oklch, ${meta.color} 14%, transparent)`,
+      }}
+    >
+      {meta.letter}
+    </span>
+  );
+}
+
+// ── File row ──────────────────────────────────────────────────────────────────
+
+function FileRow({
+  file,
+  expanded,
+  diffState,
+  reverting,
+  onToggle,
+  onRevert,
+}: {
+  file: ChangedFile;
+  expanded: boolean;
+  diffState: DiffState | undefined;
+  reverting: boolean;
+  onToggle: () => void;
+  onRevert: () => void;
+}) {
+  // Two-step revert: first click arms an inline Cancel/Revert confirm that
+  // replaces the row action; only the explicit confirm commits. Untracked
+  // files get delete copy because reverting one deletes it.
+  const [confirmRevert, setConfirmRevert] = useState(false);
+  const untracked = file.status === "untracked";
+
+  return (
+    <div className="rounded-md border border-[var(--border-hairline)]">
+      <div className="flex items-center gap-2 px-2 py-1.5">
+        <button
+          type="button"
+          className="focus-ring flex min-w-0 flex-1 items-center gap-2 rounded text-left text-[11px]"
+          onClick={onToggle}
+          aria-expanded={expanded}
+          title={file.renamedFrom ? `${file.renamedFrom} → ${file.path}` : file.path}
+        >
+          <Icon name={expanded ? "ph:caret-down" : "ph:caret-right"} width={10} aria-hidden />
+          <StatusChip status={file.status} />
+          <span className="min-w-0 flex-1 truncate font-mono text-[var(--text-secondary)]">
+            {file.path}
+          </span>
+          {typeof file.insertions === "number" || typeof file.deletions === "number" ? (
+            <span className="shrink-0 font-mono text-[10px]">
+              <span className="text-[var(--accent-presence)]">+{file.insertions ?? 0}</span>{" "}
+              <span className="text-[var(--color-danger)]">−{file.deletions ?? 0}</span>
+            </span>
+          ) : null}
+        </button>
+
+        {confirmRevert ? (
+          <span
+            className="flex shrink-0 items-center gap-1.5"
+            role="group"
+            aria-label={untracked ? "Confirm untracked file deletion" : "Confirm file revert"}
+          >
+            <span className="text-[10px] font-medium text-[var(--color-danger)]">
+              {untracked ? "Delete file?" : "Revert file?"}
+            </span>
+            <button
+              type="button"
+              onClick={() => setConfirmRevert(false)}
+              className="focus-ring rounded border border-[var(--border-hairline)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)]"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setConfirmRevert(false);
+                onRevert();
+              }}
+              disabled={reverting}
+              aria-label={untracked ? `Confirm delete ${file.path}` : `Confirm revert ${file.path}`}
+              className="focus-ring inline-flex items-center gap-1 rounded border border-[color-mix(in_oklch,var(--color-danger)_45%,transparent)] bg-[color-mix(in_oklch,var(--color-danger)_18%,transparent)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--color-danger)] transition-colors hover:bg-[color-mix(in_oklch,var(--color-danger)_30%,transparent)] disabled:opacity-40"
+            >
+              <Icon name={untracked ? "ph:trash" : "ph:arrow-counter-clockwise"} width={10} aria-hidden />
+              {reverting ? "…" : untracked ? "Delete" : "Revert"}
+            </button>
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setConfirmRevert(true)}
+            disabled={reverting}
+            title={untracked ? `Delete ${file.path}` : `Revert ${file.path}`}
+            aria-label={untracked ? `Delete untracked file ${file.path}` : `Revert ${file.path}`}
+            className="focus-ring shrink-0 rounded border border-[var(--border-hairline)] px-1.5 py-0.5 text-[var(--text-muted)] transition-all hover:border-[color-mix(in_oklch,var(--color-danger)_45%,transparent)] hover:bg-[color-mix(in_oklch,var(--color-danger)_14%,transparent)] hover:text-[var(--color-danger)] disabled:opacity-40"
+          >
+            <Icon name="ph:arrow-counter-clockwise" width={11} aria-hidden />
+          </button>
+        )}
+      </div>
+
+      {expanded ? (
+        <div className="border-t border-[var(--border-hairline)] p-2">
+          {!diffState || diffState.loading ? (
+            <div className="py-1 text-[10px] text-[var(--text-muted)]">Loading diff…</div>
+          ) : diffState.error ? (
+            <div className="py-1 text-[10px] text-[var(--color-danger)]">diff: {diffState.error}</div>
+          ) : !diffState.diff ? (
+            <div className="py-1 text-[10px] text-[var(--text-muted)]">
+              No textual diff (binary file or staged-only state).
+            </div>
+          ) : (
+            <>
+              <div className="max-h-80 overflow-auto">
+                <SyntaxBlock text={diffState.diff} lang="diff" className="text-[11px]" />
+              </div>
+              {diffState.truncated ? (
+                <div className="pt-1 text-[10px] text-[var(--text-muted)]">
+                  Diff truncated at 200KB.
+                </div>
+              ) : null}
+            </>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// ── Panel body (mounted per project root) ─────────────────────────────────────
+
+function SessionChangesInner({ projectRoot, running }: { projectRoot: string; running: boolean }) {
+  const [files, setFiles] = useState<ChangedFile[]>([]);
+  const [repoRoot, setRepoRoot] = useState<string | null>(null);
+  const [notARepo, setNotARepo] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [expandedPath, setExpandedPath] = useState<string | null>(null);
+  const [diffs, setDiffs] = useState<Record<string, DiffState>>({});
+  const [revertingPath, setRevertingPath] = useState<string | null>(null);
+  const inFlightRef = useRef(false);
+
+  const load = useCallback(async () => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    setRefreshing(true);
+    try {
+      const res = await fetch(`/api/changes?projectRoot=${encodeURIComponent(projectRoot)}`, {
+        cache: "no-store",
+      });
+      const json = (await res.json()) as ChangesResponse;
+      if (!res.ok || !json.ok) throw new Error(json.error ?? `http ${res.status}`);
+      setNotARepo(json.repo === false);
+      setRepoRoot(json.repoRoot ?? null);
+      setFiles(json.files ?? []);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      inFlightRef.current = false;
+      setRefreshing(false);
+      setLoaded(true);
+    }
+  }, [projectRoot]);
+
+  // Load when the panel becomes visible: on mount (the tab mounts the panel)
+  // and when the document regains visibility. No polling while hidden — the
+  // interval below only ticks for visible documents on a running session.
+  useEffect(() => {
+    void load();
+    const onVisible = () => {
+      if (document.visibilityState === "visible") void load();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [load]);
+
+  useEffect(() => {
+    if (!running) return;
+    const id = window.setInterval(() => {
+      if (document.visibilityState === "visible") void load();
+    }, POLL_MS);
+    return () => window.clearInterval(id);
+  }, [load, running]);
+
+  const fetchDiff = useCallback(
+    async (filePath: string) => {
+      setDiffs((prev) => ({ ...prev, [filePath]: { loading: true } }));
+      try {
+        const res = await fetch(
+          `/api/changes?projectRoot=${encodeURIComponent(projectRoot)}&path=${encodeURIComponent(filePath)}`,
+          { cache: "no-store" },
+        );
+        const json = (await res.json()) as { ok?: boolean; diff?: string; truncated?: boolean; error?: string };
+        if (!res.ok || !json.ok) throw new Error(json.error ?? `http ${res.status}`);
+        setDiffs((prev) => ({
+          ...prev,
+          [filePath]: { loading: false, diff: json.diff ?? "", truncated: json.truncated },
+        }));
+      } catch (err) {
+        setDiffs((prev) => ({
+          ...prev,
+          [filePath]: { loading: false, error: err instanceof Error ? err.message : String(err) },
+        }));
+      }
+    },
+    [projectRoot],
+  );
+
+  const toggleFile = useCallback(
+    (file: ChangedFile) => {
+      setExpandedPath((prev) => (prev === file.path ? null : file.path));
+      if (expandedPath !== file.path && !diffs[file.path]) void fetchDiff(file.path);
+    },
+    [diffs, expandedPath, fetchDiff],
+  );
+
+  const revertFile = useCallback(
+    async (file: ChangedFile) => {
+      setRevertingPath(file.path);
+      setActionError(null);
+      try {
+        const res = await fetch("/api/changes", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            projectRoot,
+            path: file.path,
+            // The untracked branch deletes the file; the confirm step the
+            // user just clicked through is the explicit consent for that.
+            confirmUntracked: file.status === "untracked",
+          }),
+        });
+        const json = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+        if (!res.ok || !json.ok) throw new Error(json.error ?? `http ${res.status}`);
+        setDiffs((prev) => {
+          const next = { ...prev };
+          delete next[file.path];
+          return next;
+        });
+        setExpandedPath((prev) => (prev === file.path ? null : prev));
+        await load();
+      } catch (err) {
+        setActionError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setRevertingPath(null);
+      }
+    },
+    [load, projectRoot],
+  );
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Header: honest scope copy + refresh */}
+      <div className="shrink-0 border-b border-[var(--border-hairline)] px-3 py-2">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+            Working tree changes
+            {loaded && !notARepo && !error ? (
+              <span className="ml-1.5 font-mono font-normal normal-case text-[var(--text-muted)]">
+                {files.length}
+              </span>
+            ) : null}
+          </span>
+          <button
+            type="button"
+            onClick={() => void load()}
+            disabled={refreshing}
+            title="Refresh"
+            aria-label="Refresh working tree changes"
+            className="focus-ring inline-flex shrink-0 items-center gap-1 rounded px-1 py-0.5 text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)] disabled:opacity-40"
+          >
+            <Icon name="ph:arrows-clockwise" width={11} aria-hidden className={refreshing ? "animate-spin" : undefined} />
+            Refresh
+          </button>
+        </div>
+        <p className="mt-0.5 truncate text-[10px] text-[var(--text-muted)]" title={repoRoot ?? projectRoot}>
+          All uncommitted changes in {repoRoot ?? projectRoot} — not only this session&rsquo;s edits.
+        </p>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {/* Load failure: icon + truncating message + Retry, per the shared idiom */}
+        {error && (
+          <div
+            role="alert"
+            className="mb-2 flex items-center justify-between gap-2 rounded-md border border-[color-mix(in_oklch,var(--color-danger)_45%,transparent)] bg-[color-mix(in_oklch,var(--color-danger)_10%,transparent)] px-2 py-1.5 text-[11px] text-[var(--color-danger)]"
+          >
+            <span className="flex min-w-0 items-center gap-1.5">
+              <Icon name="ph:warning-circle" width={12} aria-hidden className="shrink-0" />
+              <span className="min-w-0 truncate" title={error}>
+                {error}
+              </span>
+            </span>
+            <button
+              type="button"
+              className="focus-ring shrink-0 underline"
+              onClick={() => void load()}
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
+        {/* Transient action failures are dismissable */}
+        {actionError && (
+          <div
+            role="alert"
+            className="mb-2 flex items-center justify-between gap-2 rounded-md border border-[color-mix(in_oklch,var(--color-danger)_45%,transparent)] bg-[color-mix(in_oklch,var(--color-danger)_10%,transparent)] px-2 py-1.5 text-[11px] text-[var(--color-danger)]"
+          >
+            <span className="flex min-w-0 items-center gap-1.5">
+              <Icon name="ph:warning-circle" width={12} aria-hidden className="shrink-0" />
+              <span className="min-w-0 truncate" title={actionError}>
+                revert: {actionError}
+              </span>
+            </span>
+            <button
+              type="button"
+              className="focus-ring shrink-0"
+              aria-label="Dismiss revert error"
+              onClick={() => setActionError(null)}
+            >
+              <Icon name="ph:x-bold" width={10} aria-hidden />
+            </button>
+          </div>
+        )}
+
+        {!loaded && !error ? (
+          <div className="py-6 text-center text-[11px] text-[var(--text-muted)]">Loading changes…</div>
+        ) : notARepo ? (
+          <div className="px-2 py-6 text-center text-[11px] text-[var(--text-muted)]">
+            <p className="font-medium text-[var(--text-secondary)]">Not a git repository.</p>
+            <p className="mt-1">
+              This session&rsquo;s project root isn&rsquo;t under git, so there&rsquo;s no working
+              tree to review.
+            </p>
+          </div>
+        ) : loaded && !error && files.length === 0 ? (
+          <div className="px-2 py-6 text-center text-[11px] text-[var(--text-muted)]">
+            <p className="font-medium text-[var(--text-secondary)]">No uncommitted changes.</p>
+            <p className="mt-1">Edits the agent makes to this project will show up here.</p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-1">
+            {files.map((file) => (
+              <FileRow
+                key={file.path}
+                file={file}
+                expanded={expandedPath === file.path}
+                diffState={diffs[file.path]}
+                reverting={revertingPath === file.path}
+                onToggle={() => toggleFile(file)}
+                onRevert={() => void revertFile(file)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Public component ──────────────────────────────────────────────────────────
+
+/** Resolves the active session's project root the same way DebugPane resolves
+ *  its session context: via the chat debug store bridge from ChatView. */
+export function SessionChangesPanel() {
+  const snapshot = useChatDebugSnapshot();
+  const projectRoot = snapshot.session?.project_root ?? null;
+  if (!projectRoot) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-center text-[11px] text-[var(--text-muted)]">
+        Open a chat session to review its working tree changes.
+      </div>
+    );
+  }
+  // Keyed by root so list/diff/confirm state resets when the session moves.
+  return (
+    <SessionChangesInner
+      key={projectRoot}
+      projectRoot={projectRoot}
+      running={snapshot.session?.status === "running"}
+    />
+  );
+}


### PR DESCRIPTION
## What

Implements **CHAT-D8-01 (P1)** from the chat UX audit (#395) — the audit's minimum-viable change-review milestone. Today the agent mutates the user's working tree (Edit/Write/Bash through the harness) with **zero in-app review or undo**: no accept/reject, no revert, no checkpoint anywhere. Benchmarks (Cursor/Windsurf per-file review, Claude Code permission gates) all give the user some control loop. Full accept/reject **gating is deliberately deferred** to a later milestone per the audit's scoping; this PR ships the review surface: a per-session "Changes" tab with per-file diff preview and per-file revert.

## API — `/api/changes`

One consolidated route (`src/app/api/changes/route.ts`):

- `GET ?projectRoot=<abs>` → `git status --porcelain=v1 -z` (+ best-effort `git diff --numstat -z HEAD` for ins/del counts; skipped on unborn HEAD) in the session's project root, resolved to the repo toplevel. Distinct `{ ok: true, repo: false }` state when the root isn't a git repo.
- `GET ?projectRoot=<abs>&path=<rel>` → single-file unified diff (`git diff HEAD -- <file>` so staged edits show too, fallback for unborn HEAD; untracked files synthesize an all-additions diff via `git diff --no-index -- /dev/null <file>`). Capped at 200KB with a `truncated` flag.
- `POST { projectRoot, path, confirmUntracked? }` → revert **exactly one file** per call. Tracked → `git checkout -- <file>` (also resurrects deleted files). Untracked → reverting means deleting, so it returns `requiresConfirmUntracked` unless the body carries an explicit `confirmUntracked: true`, then `git clean -f -- <file>`.

**Security posture:** every git call goes through `execFile` with an argument array — no shell, paths are never string-interpolated. `projectRoot` must be absolute, existing, a directory, and a git work tree. File paths must be repo-relative and pass a resolve + prefix containment check (absolute paths, NUL, and `..` segments rejected → repo-standard `403 "path not allowed"`). Mutation blast radius is one explicit file per call.

## UI — "Changes" right-panel tab

New `SessionChangesPanel` (`src/components/session-changes-panel.tsx`), wired as a third tab between Inspector and Debug in `chat-surface.tsx`. Session context resolves the same way DebugPane's does — via the chat debug store bridge.

- File rows: status chip (M/A/D/R/U) + path + `+ins −del` counts; click expands an inline diff rendered with the existing `SyntaxBlock` (`lang="diff"`, diff gutter rendering).
- Per-file revert uses the repo's two-step inline confirm idiom (chat-list delete pattern), with honest "Delete file?" copy for untracked files.
- Refresh button; loads on mount/visibility; polls (5s) only while the session is running **and** the document is visible — no polling while hidden.
- Load failures use the shared `role="alert"` + `ph:warning-circle` + Retry idiom; revert failures are dismissable; empty and not-a-repo states match existing surface states.
- **Honest copy:** header reads "Working tree changes" with a caption that it shows *all* uncommitted changes in the repo — git can't attribute changes to this session specifically.

## Note on `api-contracts.test.ts`

That test enforces a closed-world route registry (`deepEqual(actualRoutes, contractRoutes)`), so **any** new API route requires a contract entry there. I kept the touch to a single appended line (`/changes`, GET+POST, json, invalid-JSON guarded, pathGuard) and consolidated what could have been three routes into one to minimize it.

## Verification

- `src/components/debug-pane.test.ts` extended with pins: Changes tab exists in chat-surface, panel renders diffs through `SyntaxBlock lang="diff"`, revert is two-step confirmed, route uses `execFile` arg arrays with no shell, containment check + 403, `confirmUntracked` gate, and one-file-scoped `checkout`/`clean` invocations.
- Functional smoke against a scratch repo exercised: list (modified/deleted/untracked with counts), tracked + untracked diffs, `../` and absolute path → 403, not-a-repo and missing-root states, untracked revert blocked without the flag, tracked revert, deleted-file resurrection, confirmed untracked delete, invalid JSON → 400.
- `pnpm typecheck`, full `pnpm test:app`, `pnpm test:api`, `pnpm test:mobile` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)