### PR TITLE
fix(chat): combobox/listbox ARIA for both slash menus

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
+import { forwardRef, useCallback, useEffect, useId, useImperativeHandle, useMemo, useRef, useState } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { RichText } from "@/components/rich-text";
 import { MessageBubble, SyntaxBlock } from "@/components/message-bubble";
@@ -1017,6 +1017,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // Esc hides the menu for the current input; any edit brings it back.
   const [slashDismissed, setSlashDismissed] = useState(false);
   const slashSuggestions: SlashCommand[] = slashDismissed ? [] : slashMatches;
+  // Stable per-mount listbox id — the home composer mounts its own slash menu,
+  // so ids must be unique across simultaneously mounted composers.
+  const slashListboxId = useId();
   const activeLifecycle = useMemo(() => {
     const activeTurn = [...turns].reverse().find((turn) => turn.role === "assistant" && turn.pending);
     return activeTurn?.lifecycle ?? (busy ? "connecting" : null);
@@ -2154,13 +2157,19 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         <div className="cave-composer-shell">
           {slashSuggestions.length > 0 ? (
             <div className="absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-xl">
-              <ul className="max-h-64 overflow-y-auto py-1">
+              <ul className="max-h-64 overflow-y-auto py-1" id={slashListboxId} role="listbox" aria-label="Slash commands">
                 {slashSuggestions.map((cmd, i) => {
                   const active = i === slashIdx;
                   return (
-                    <li key={cmd.name}>
+                    <li
+                      key={cmd.name}
+                      role="option"
+                      id={`${slashListboxId}-opt-${i}`}
+                      aria-selected={active}
+                    >
                       <button
                         type="button"
+                        tabIndex={-1}
                         ref={active ? activeSlashOptionRef : null}
                         onMouseEnter={() => setSlashIdx(i)}
                         onClick={() => {
@@ -2275,6 +2284,13 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               enterKeyHint="send"
               className="cave-composer-input w-full resize-none bg-transparent px-4 pt-3 pb-2 leading-6 text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)] md:text-sm"
               aria-label="Message"
+              role="combobox"
+              aria-autocomplete="list"
+              aria-expanded={slashSuggestions.length > 0}
+              aria-controls={slashSuggestions.length > 0 ? slashListboxId : undefined}
+              aria-activedescendant={
+                slashSuggestions.length > 0 ? `${slashListboxId}-opt-${slashIdx}` : undefined
+              }
             />
             <div className="flex items-center justify-between px-3 pb-2.5">
               <div className="flex items-center gap-1 text-[var(--text-muted)]">

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -64,3 +64,48 @@ assert.doesNotMatch(
   /native Cave chat only supports Codex, Claude Code, and Hermes right now/,
   "HomeComposer should allow OpenClaw familiars through native chat send",
 );
+
+// ─── CHAT-D2-04: combobox/listbox ARIA on both slash menus ───────────────────
+// The slash menus were plain ul/li/button with a visual-only active class —
+// screen readers announced nothing about the menu or the highlighted command.
+// Both composers must carry the WAI-ARIA combobox pattern: textarea =
+// combobox, menu = listbox, rows = options, aria-activedescendant conveys the
+// highlight while DOM focus stays in the textarea.
+
+const chatSource = await readFile(new URL("./chat-view.tsx", import.meta.url), "utf8");
+
+for (const [name, src] of [
+  ["HomeComposer", source],
+  ["ChatView", chatSource],
+]) {
+  assert.match(
+    src,
+    /id=\{slashListboxId\} role="listbox" aria-label="Slash commands"/,
+    `${name} slash menu should be a labelled listbox with a stable id`,
+  );
+  assert.match(
+    src,
+    /role="option"\s+id=\{`\$\{slashListboxId\}-opt-\$\{i\}`\}\s+aria-selected=\{active\}/,
+    `${name} slash rows should be options with stable ids and aria-selected on the highlighted row`,
+  );
+  assert.match(
+    src,
+    /role="option"[\s\S]{0,200}?<button\s+type="button"\s+tabIndex=\{-1\}/,
+    `${name} option buttons must be out of the tab order — focus stays in the textarea, aria-activedescendant conveys selection`,
+  );
+  assert.match(
+    src,
+    /role="combobox"\s+aria-autocomplete="list"\s+aria-expanded=\{slashSuggestions\.length > 0\}/,
+    `${name} composer textarea should expose combobox semantics with aria-expanded tracking the open menu`,
+  );
+  assert.match(
+    src,
+    /aria-controls=\{slashSuggestions\.length > 0 \? slashListboxId : undefined\}/,
+    `${name} aria-controls should reference the listbox only while the menu is open`,
+  );
+  assert.match(
+    src,
+    /aria-activedescendant=\{\s*slashSuggestions\.length > 0 \? `\$\{slashListboxId\}-opt-\$\{slashIdx\}` : undefined\s*\}/,
+    `${name} aria-activedescendant should track the highlighted index and be absent when the menu is closed`,
+  );
+}

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -11,6 +11,7 @@ import {
   type KeyboardEvent,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -81,6 +82,9 @@ export function HomeComposer({
   const [history, setHistory] = useState<string[]>([]);
   const [historyIdx, setHistoryIdx] = useState<number>(-1);
   const [slashIdx, setSlashIdx] = useState(0);
+  // Stable per-mount listbox id — the chat composer mounts its own slash menu,
+  // so ids must be unique across simultaneously mounted composers.
+  const slashListboxId = useId();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const selectedFamiliarId = activeFamiliarId ?? familiars[0]?.id ?? "";
 
@@ -296,13 +300,19 @@ export function HomeComposer({
             push the rest of the layout when it opens. */}
         {slashSuggestions.length > 0 ? (
           <div className="hc-slash-menu">
-            <ul className="hc-slash-list">
+            <ul className="hc-slash-list" id={slashListboxId} role="listbox" aria-label="Slash commands">
               {slashSuggestions.map((cmd, i) => {
                 const active = i === slashIdx;
                 return (
-                  <li key={cmd.name}>
+                  <li
+                    key={cmd.name}
+                    role="option"
+                    id={`${slashListboxId}-opt-${i}`}
+                    aria-selected={active}
+                  >
                     <button
                       type="button"
+                      tabIndex={-1}
                       onMouseEnter={() => setSlashIdx(i)}
                       onClick={() => {
                         setText(cmd.name + (cmd.argPlaceholder ? " " : ""));
@@ -339,6 +349,13 @@ export function HomeComposer({
           onKeyDown={handleKeyDown}
           disabled={sending}
           aria-label="Ask anything"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded={slashSuggestions.length > 0}
+          aria-controls={slashSuggestions.length > 0 ? slashListboxId : undefined}
+          aria-activedescendant={
+            slashSuggestions.length > 0 ? `${slashListboxId}-opt-${slashIdx}` : undefined
+          }
           inputMode="text"
           enterKeyHint="send"
         />


### PR DESCRIPTION
Implements **CHAT-D2-04 (P2)** from the chat UX audit (#395).

## The gap

Verified live during the audit: 22 slash-menu items, zero listbox semantics. Both slash menus (chat composer and home composer) were plain `ul`/`li`/`button` with a visual-only active class, and neither composer textarea carried combobox wiring — screen readers announced nothing about the menu or the highlighted command.

## The fix

Standard WAI-ARIA combobox/listbox pattern, applied identically in `src/components/chat-view.tsx` and `src/components/home-composer.tsx`:

- **Menu container** (`ul`): `role="listbox"`, stable `useId`-derived id (unique even with both composers mounted), `aria-label="Slash commands"`.
- **Option rows** (`li`): `role="option"`, stable id `` `${listboxId}-opt-${i}` ``, `aria-selected` on the highlighted row — matches the existing `browser-quick-open.tsx` house pattern.
- **Row buttons**: `tabIndex={-1}` so options stay out of the tab order; DOM focus stays in the textarea and `aria-activedescendant` conveys the highlight.
- **Textareas**: `role="combobox"`, `aria-autocomplete="list"`, `aria-expanded` tracking the open menu; `aria-controls` and `aria-activedescendant` are present only while the menu is open (collapse to absent when closed).

Semantics only — no behavioral changes to matching/Enter/Esc/Tab (#402) or the paste handlers (#412). The chat-view hunks are confined to the slash-menu JSX and the composer textarea attributes.

## Tests

- Extended `src/components/home-composer.test.ts` with pins for **both** composers (reads `chat-view.tsx` too, per house pattern): listbox/option/`aria-selected` wiring, combobox attrs on both textareas, `aria-activedescendant` tracking the highlighted index, attributes collapsing when the menu closes, options out of tab order.
- `home-composer.test.ts`, `home-composer-centering.test.ts`, `chat-view-polish.test.ts` (read-only, kept green) all pass.
- Full `pnpm test:app` exit 0; `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)