### PR TITLE
feat(chat): one-line arg summaries on collapsed tool rows

### DIFF
--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { toolArgSummary } from "../lib/tool-arg-summary.ts";
 
 const source = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
 const styles = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
@@ -113,6 +114,68 @@ assert.match(
   source,
   /onSessionsChanged\?\.\(\);\s*\n\s*onBack\?\.\(\);/,
   "Successful delete refreshes sessions and navigates back to the list",
+);
+
+// ── Collapsed tool rows show a one-line arg summary (CHAT-D4-02) ─────────────
+// The summary is derived by the pure helper in src/lib/tool-arg-summary.ts so
+// a run can be audited (`Read(src/foo.ts)`-style) without expanding blocks.
+
+// JSON input with a well-known key picks that key's value.
+assert.equal(
+  toolArgSummary("Read", JSON.stringify({ file_path: "src/foo.ts" }, null, 2)),
+  "src/foo.ts",
+  "JSON input with file_path summarizes to the path",
+);
+
+// Bash commands arrive as plain (non-JSON) strings — used directly.
+assert.equal(
+  toolArgSummary("Bash", "pnpm test"),
+  "pnpm test",
+  "plain-string Bash input is used as the summary",
+);
+
+// Bash JSON payloads prefer the command key.
+assert.equal(
+  toolArgSummary("Bash", JSON.stringify({ description: "Run tests", command: "pnpm test" })),
+  "pnpm test",
+  "Bash JSON input prefers command over other keys",
+);
+
+// Unknown JSON falls back to the first string value.
+assert.equal(
+  toolArgSummary("Mystery", JSON.stringify({ widget: "left-panel", count: 3 })),
+  "left-panel",
+  "unknown JSON keys fall back to the first string value",
+);
+
+// Oversize values are flattened to one line and ellipsized (~48 chars).
+const oversize = toolArgSummary("Bash", `pnpm run a-very-long-command ${"x".repeat(80)}\nsecond line`);
+assert.ok(oversize.length <= 48, "summary is capped at 48 chars");
+assert.ok(oversize.endsWith("…"), "oversize summary ends with an ellipsis");
+assert.ok(!oversize.includes("\n"), "summary is never multi-line");
+
+// Absent input yields an empty string.
+assert.equal(toolArgSummary("Read", undefined), "", "absent input gives empty summary");
+assert.equal(toolArgSummary("Read", "   "), "", "whitespace-only input gives empty summary");
+
+// Truncated object-ish blobs surface the first path-looking token.
+assert.equal(
+  toolArgSummary("Edit", "{ file_path: src/components/chat-view.tsx, old_string: ... }"),
+  "src/components/chat-view.tsx",
+  "non-JSON object blobs surface the first path-looking token",
+);
+
+// ToolBlock renders the helper output in its collapsed summary row, and the
+// progress detail uses the Claude Code `Name(arg)` shape.
+assert.match(
+  source,
+  /function ToolBlock[\s\S]*?const argSummary = toolArgSummary\(tool\.name, tool\.input\)[\s\S]*?<summary[\s\S]*?\{tool\.name\}[\s\S]*?\{argSummary \?[\s\S]*?truncate[\s\S]*?\{argSummary\}/,
+  "ToolBlock collapsed summary renders the one-line arg summary next to the name",
+);
+assert.match(
+  source,
+  /detail: argSummary \? `\$\{incoming\.name\}\(\$\{argSummary\}\)` : incoming\.name/,
+  "Tool progress detail carries Name(arg) instead of the bare tool name",
 );
 
 console.log("chat-header-row.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -26,6 +26,7 @@ import { VoiceCallButton } from "./voice-call-button";
 import { VoiceCallOverlay } from "./voice-call-overlay";
 import { CsvImportModal } from "./csv-import-modal";
 import { looksLikeCsv } from "@/lib/csv-import";
+import { toolArgSummary } from "@/lib/tool-arg-summary";
 
 type ToolEvent = {
   id: string;
@@ -1663,6 +1664,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                       : x,
                   )
                 : [...tools, incoming];
+            // Post-tool events carry no input, so summarize from the merged
+            // record (which preserves the input captured at pre-tool time).
+            const argSummary = toolArgSummary(
+              incoming.name,
+              existingIdx >= 0 ? nextTools[existingIdx]?.input : incoming.input,
+            );
             return {
               ...t,
               tools: nextTools,
@@ -1670,7 +1677,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               progress: upsertProgressEvent(t.progress, {
                 id: "tools",
                 label: incoming.status === "running" ? "Tool call running" : "Tool call finished",
-                detail: incoming.name,
+                detail: argSummary ? `${incoming.name}(${argSummary})` : incoming.name,
                 status: incoming.status === "error" ? "error" : incoming.status === "ok" ? "done" : "running",
                 durationMs: incoming.durationMs,
               }),
@@ -2586,11 +2593,15 @@ function ToolGroup({ tools }: { tools: ToolEvent[] }) {
 }
 
 function ToolBlock({ tool }: { tool: ToolEvent }) {
+  const argSummary = toolArgSummary(tool.name, tool.input);
   return (
     <details className="cave-tool-block" data-default-collapsed="true">
       <summary className="flex min-w-0 cursor-pointer select-none flex-wrap items-center gap-2 text-[11px]">
         <Icon name="ph:terminal-window" width={12} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
         <span className="min-w-0 truncate font-mono text-[var(--text-secondary)]">{tool.name}</span>
+        {argSummary ? (
+          <span className="min-w-0 max-w-[18rem] truncate font-mono text-[var(--text-muted)]">· {argSummary}</span>
+        ) : null}
         <span className={[
           "rounded px-1.5 py-0.5 font-mono text-[10px]",
           tool.status === "error"

--- a/src/lib/tool-arg-summary.ts
+++ b/src/lib/tool-arg-summary.ts
@@ -1,0 +1,95 @@
+// One-line argument summaries for collapsed tool rows.
+//
+// Tool inputs arrive as strings (see src/app/api/chat/send/route.ts): either
+// pretty-printed JSON (when the hook payload parsed) or the raw payload text
+// (e.g. a bare Bash command line, or a truncated `{...}` blob). The chat UI
+// shows `Read(src/foo.ts)`-style summaries so a run can be audited without
+// expanding each tool block.
+
+const MAX_SUMMARY_CHARS = 48;
+
+// Well-known argument keys, most identifying first.
+const PREFERRED_KEYS = [
+  "file_path",
+  "path",
+  "command",
+  "pattern",
+  "url",
+  "query",
+  "prompt",
+  "description",
+  "skill",
+  "notebook_path",
+] as const;
+
+// Shell-ish tools whose `command` key is the headline argument.
+const COMMAND_FIRST_TOOLS = /^(bash|shell|terminal|exec)/i;
+
+// A quoted token, or something that looks like a file path.
+const QUOTED_TOKEN_RE = /"([^"\n]{2,})"|'([^'\n]{2,})'/;
+const PATH_TOKEN_RE = /(?:~|\.{1,2})?\/?[\w.@-]+(?:\/[\w.@-]+)+/;
+
+/** Collapse to a single line and cap at `max` characters with an ellipsis. */
+function ellipsize(value: string, max = MAX_SUMMARY_CHARS): string {
+  const flat = value.replace(/\s+/g, " ").trim();
+  if (flat.length <= max) return flat;
+  return `${flat.slice(0, max - 1)}…`;
+}
+
+function tryParseJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function summarizeRecord(name: string, record: Record<string, unknown>): string {
+  const keys: readonly string[] = COMMAND_FIRST_TOOLS.test(name)
+    ? ["command", ...PREFERRED_KEYS.filter((k) => k !== "command")]
+    : PREFERRED_KEYS;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) return ellipsize(value);
+    if (typeof value === "number" || typeof value === "boolean") return ellipsize(String(value));
+  }
+  // No well-known key — fall back to the first non-empty string value, then
+  // to the flattened JSON itself.
+  for (const value of Object.values(record)) {
+    if (typeof value === "string" && value.trim()) return ellipsize(value);
+  }
+  return ellipsize(JSON.stringify(record));
+}
+
+/**
+ * Derive a one-line argument summary from a tool's input payload.
+ * Always single-line, at most ~48 chars, empty string when input is absent.
+ */
+export function toolArgSummary(name: string, input?: string | null): string {
+  const raw = (input ?? "").trim();
+  if (!raw) return "";
+
+  const parsed = tryParseJson(raw);
+  if (parsed !== undefined && parsed !== null) {
+    if (typeof parsed === "string") return ellipsize(parsed);
+    if (Array.isArray(parsed)) return ellipsize(parsed.map((v) => String(v)).join(" "));
+    if (typeof parsed === "object") return summarizeRecord(name, parsed as Record<string, unknown>);
+    return ellipsize(String(parsed));
+  }
+
+  // Non-JSON object-ish blob (e.g. truncated `{ file_path: src/foo.ts … }`):
+  // pull the first path-looking or quoted token out of it.
+  if (raw.startsWith("{")) {
+    const quoted = raw.match(QUOTED_TOKEN_RE);
+    const quotedToken = quoted?.[1] ?? quoted?.[2];
+    const pathToken = raw.match(PATH_TOKEN_RE)?.[0];
+    const token =
+      pathToken && (!quotedToken || raw.indexOf(pathToken) < raw.indexOf(quotedToken))
+        ? pathToken
+        : quotedToken ?? pathToken;
+    if (token) return ellipsize(token);
+  }
+
+  // Plain string payload (e.g. a Bash command line) — use it directly.
+  return ellipsize(raw);
+}


### PR DESCRIPTION
Implements **CHAT-D4-02 (P2)** from the chat UX audit (PR #395).

## Gap

Collapsed `ToolBlock` rows showed only the tool name plus a status chip; the tool's input sat two `<details>` levels deep. Claude Code's collapsed lines read `Read(src/foo.ts)` / `Bash(pnpm test)` so a run can be audited without expanding anything. The tool progress row likewise carried only the bare tool name as `detail`.

## Fix

- **New pure helper `src/lib/tool-arg-summary.ts`** — `toolArgSummary(name, input)` derives a one-line arg from the tool input string (route.ts emits either pretty-printed JSON or the raw hook payload):
  1. JSON object → first well-known key (`file_path`, `path`, `command`, `pattern`, `url`, `query`, `prompt`, …; shell-ish tools prefer `command` first) → else first non-empty string value → else flattened JSON.
  2. Non-JSON `{...}`-ish blob → first path-looking or quoted token.
  3. Plain string (bare Bash command lines) → used directly.
  Output is always single-line, ellipsized at ~48 chars, `""` when input is absent.
- **ToolBlock collapsed summary** renders the summary muted/mono/truncating next to the name: `Read · src/foo.ts` (matches the progress-row detail idiom: `min-w-0 max-w-[18rem] truncate text-[var(--text-muted)]`).
- **Progress row detail** now reads `Read(src/foo.ts)` instead of the bare name. Post-tool events carry no input, so the summary is derived from the merged tool record, which preserves the input captured at pre-tool time.

## Test-file choice

Extended `src/components/chat-header-row.test.ts`. Decision rule: least-bad existing `test:app` file (no `package.json` edits allowed) that already reads chat-view source and is not in the contended list. `task-chat-cwd.test.ts` is CWD-routing themed and `comux-view-terminal.test.ts` reads comux-view, both unrelated; `chat-header-row.test.ts` is chat-view UI source pins — the closest home. Added behavioral tests for the helper (JSON `file_path`, plain Bash string, Bash JSON `command` preference, unknown-key fallback, oversize ellipsis/single-line, absent input, non-JSON blob token extraction) plus source pins that ToolBlock renders the helper and the progress detail uses the `Name(arg)` shape.

## Verification

- `node --experimental-strip-types src/components/chat-header-row.test.ts` — ok
- Pinned `chat-view-polish.test.ts` / `chat-view-lifecycle.test.ts` (untouched) — pass
- Full `pnpm test:app` — green
- `pnpm typecheck` — clean

Scope kept strictly to ToolBlock/ToolGroup + the one progress-detail line in chat-view.tsx (three other agents are editing other regions of the file this wave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)