### PR TITLE
fix(chat): cap linear line length; fix dark code chrome ink in light mode

### DIFF
--- a/src/components/message-bubble-code-header.test.ts
+++ b/src/components/message-bubble-code-header.test.ts
@@ -82,3 +82,127 @@ assert.match(
   /useWireCopyButtons\(/,
   "MarkdownContent must keep wiring its copy buttons (chat message bubbles)",
 );
+
+// ---------------------------------------------------------------------------
+// CHAT-D10-04 — the shipped linear layout must cap its reading measure.
+// Without a cap, assistant prose runs 150+ chars/line on wide panes
+// (benchmarks: Claude.ai ~48rem, ChatGPT ~768px; we match the workbench's
+// 920px content cap). The composer shell shares the same measure so the
+// input lines up with the conversation column.
+// ---------------------------------------------------------------------------
+
+const linearThread = /\.cave-chat-linear \.cave-chat-thread \{[^}]*\}/.exec(css)?.[0] ?? "";
+assert.match(
+  linearThread,
+  /max-width:\s*min\(100%,\s*920px\)/,
+  "Linear thread must cap its measure at 920px on wide panes",
+);
+assert.match(
+  linearThread,
+  /margin-inline:\s*auto/,
+  "Linear thread column must center inside wide panes",
+);
+
+const linearComposerShell = /\.cave-chat-linear \.cave-composer-shell \{[^}]*\}/.exec(css)?.[0] ?? "";
+assert.match(
+  linearComposerShell,
+  /max-width:\s*920px/,
+  "Linear composer shell must share the thread's 920px measure so the input aligns with the column",
+);
+
+// ---------------------------------------------------------------------------
+// CHAT-D13-01 — dark-terminal chrome must pin its inks, not follow the theme.
+// Code blocks and system turns keep fixed dark surfaces in BOTH modes; any
+// var(--text-*) inside them flips to dark ink under [data-mode="light"] and
+// becomes unreadable. The fixed --code-chrome-* properties mirror the
+// dark-mode palette instead.
+// ---------------------------------------------------------------------------
+
+assert.match(css, /--code-chrome-ink:\s*oklch\(/, "Fixed dark-chrome primary ink must exist");
+assert.match(css, /--code-chrome-ink-muted:\s*oklch\(/, "Fixed dark-chrome muted ink must exist");
+assert.match(css, /--code-chrome-ink-faint:\s*oklch\(/, "Fixed dark-chrome faint ink must exist");
+assert.match(css, /--code-chrome-accent:/, "Fixed dark-chrome accent must exist");
+
+function ruleBlock(selector) {
+  const start = css.indexOf(`${selector} {`);
+  assert.notEqual(start, -1, `Expected a rule for "${selector}"`);
+  return css.slice(start, css.indexOf("}", start) + 1);
+}
+
+// Every dark-chrome block that previously leaked theme ink must now use the
+// fixed properties — and none may still reference var(--text-*).
+const darkChromeSelectors = [
+  ".cave-code-wrap",
+  ".cave-code-header",
+  ".cave-code-lang",
+  ".cave-code-filename",
+  ".cave-ln",
+  ".cave-copy-btn",
+  ".cave-copy-btn:hover",
+  ".cave-bubble-system",
+  ".cave-bubble-system-header",
+  ".cave-bubble-system-sigil",
+  ".cave-bubble-system-label",
+  ".cave-bubble-system-label--dim",
+  ".cave-bubble-system-body",
+];
+for (const selector of darkChromeSelectors) {
+  assert.doesNotMatch(
+    ruleBlock(selector),
+    /var\(--text-/,
+    `${selector} is fixed dark chrome — it must not take theme ink (var(--text-*) flips dark in light mode)`,
+  );
+}
+
+assert.match(
+  ruleBlock(".cave-copy-btn"),
+  /color:\s*var\(--code-chrome-ink-faint\)/,
+  "Copy button resting ink must be the fixed faint chrome ink",
+);
+assert.match(
+  ruleBlock(".cave-copy-btn:hover"),
+  /color:\s*var\(--code-chrome-ink\)/,
+  "Copy button hover ink must be the fixed primary chrome ink",
+);
+assert.match(
+  ruleBlock(".cave-code-lang"),
+  /var\(--code-chrome-accent\)/,
+  "Code-header language tag must mix from the fixed chrome accent",
+);
+assert.match(
+  ruleBlock(".cave-code-filename"),
+  /color:\s*var\(--code-chrome-ink-faint\)/,
+  "Code-header filename ink must be the fixed faint chrome ink",
+);
+assert.match(
+  ruleBlock(".cave-ln"),
+  /var\(--code-chrome-accent\)/,
+  "Line numbers must mix from the fixed chrome accent",
+);
+assert.match(
+  ruleBlock(".cave-bubble-system-label"),
+  /color:\s*var\(--code-chrome-ink-muted\)/,
+  "System-turn header label ink must be the fixed muted chrome ink",
+);
+assert.match(
+  ruleBlock(".cave-bubble-system-body"),
+  /color:\s*var\(--code-chrome-ink-muted\)/,
+  "System-turn body ink must be the fixed muted chrome ink",
+);
+
+// The fixed dark surfaces must be near-opaque so they stay self-consistent
+// over a light --bg-base (a 60%-alpha wash goes muddy), and must not mix
+// with theme surfaces.
+for (const selector of [".cave-code-wrap", ".cave-bubble-system"]) {
+  const block = ruleBlock(selector);
+  assert.match(
+    block,
+    /background:\s*oklch\([^)]*\/\s*9\d%\)/,
+    `${selector} surface must be a near-opaque fixed dark oklch`,
+  );
+  assert.doesNotMatch(
+    block,
+    /var\(--bg-/,
+    `${selector} surface must not mix with theme backgrounds`,
+  );
+}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -4,6 +4,21 @@
  */
 
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   DARK-CHROME FIXED INKS (CHAT-D13-01)
+   Code blocks and system turns keep a deliberate dark-terminal surface in
+   BOTH theme modes (the Shiki theme is mood-c-dark either way). Their
+   foregrounds therefore must NOT follow --text-* — in light mode those
+   tokens flip to dark ink, which is unreadable on the still-dark chrome.
+   Values mirror the globals.css DARK palette so dark mode is unchanged.
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+:root {
+  --code-chrome-ink: oklch(0.985 0 0);                /* dark-mode --text-primary */
+  --code-chrome-ink-muted: oklch(0.66 0.018 293);     /* dark-mode --text-secondary */
+  --code-chrome-ink-faint: oklch(0.985 0 0 / 40%);    /* dark-mode --text-muted */
+  --code-chrome-accent: #9a8ecd;                      /* dark-mode --accent-presence */
+}
+
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    BASE PROSE
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
 .cave-md {
@@ -195,10 +210,12 @@
   position: relative;
   border-radius: 9px;
   border: 1px solid var(--border-hairline);
-  background: oklch(0.1 0.01 280 / 60%);
+  /* Near-opaque fixed dark: a 60%-alpha wash went muddy over a light
+     --bg-base (CHAT-D13-01). */
+  background: oklch(0.12 0.012 280 / 92%);
   box-shadow:
     0 1px 3px oklch(0 0 0 / 30%),
-    inset 0 1px 0 color-mix(in oklch, var(--foreground) 4%, transparent);
+    inset 0 1px 0 oklch(0.985 0 0 / 4%);
   overflow: hidden;
   font-size: 12px;
   margin: 0.6em 0;
@@ -212,7 +229,7 @@
   align-items: center;
   gap: 0.5em;
   padding: 0.35em 0.75em;
-  background: oklch(0.14 0.015 280 / 70%);
+  background: oklch(0.16 0.015 280 / 92%);
   border-bottom: 1px solid var(--border-hairline);
   min-height: 28px;
   backdrop-filter: blur(4px);
@@ -227,7 +244,7 @@
   height: 8px;
   border-radius: 50%;
   flex-shrink: 0;
-  background: color-mix(in oklch, var(--accent-presence) 40%, oklch(0.4 0 0));
+  background: color-mix(in oklch, var(--code-chrome-accent) 40%, oklch(0.4 0 0));
   box-shadow:
     16px 0 0 color-mix(in oklch, oklch(0.75 0.18 60) 40%, oklch(0.4 0 0)),
     32px 0 0 color-mix(in oklch, oklch(0.65 0.18 170) 40%, oklch(0.4 0 0));
@@ -242,7 +259,7 @@
   font-size: 10px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: color-mix(in oklch, var(--accent-presence) 80%, var(--text-muted));
+  color: color-mix(in oklch, var(--code-chrome-accent) 80%, var(--code-chrome-ink-faint));
   flex-shrink: 0;
   opacity: 0.85;
 }
@@ -251,7 +268,7 @@
   order: 2;
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   font-size: 10px;
-  color: var(--text-muted);
+  color: var(--code-chrome-ink-faint);
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -308,7 +325,7 @@
   flex-shrink: 0;
   width: 2.6em;
   padding-right: 0.8em;
-  color: color-mix(in oklch, var(--accent-presence) 28%, oklch(0.5 0 0 / 50%));
+  color: color-mix(in oklch, var(--code-chrome-accent) 28%, oklch(0.5 0 0 / 50%));
   font-size: 10px;
   text-align: right;
   user-select: none;
@@ -340,8 +357,8 @@
   padding: 0.2em 0.6em;
   border-radius: 5px;
   border: 1px solid var(--border-strong);
-  background: oklch(0.18 0.01 280 / 60%);
-  color: var(--text-muted);
+  background: oklch(0.2 0.012 280 / 92%);
+  color: var(--code-chrome-ink-faint);
   cursor: pointer;
   opacity: 0;
   transition: opacity 0.15s, color 0.1s, background 0.1s;
@@ -364,8 +381,8 @@
 }
 
 .cave-copy-btn:hover {
-  color: var(--text-primary);
-  background: oklch(0.22 0.015 280 / 70%);
+  color: var(--code-chrome-ink);
+  background: oklch(0.25 0.015 280 / 92%);
 }
 .cave-copy-btn:focus-visible { opacity: 1; }
 
@@ -1043,8 +1060,13 @@ details[open] > .cave-tool-summary::before {
 .cave-chat-linear .cave-chat-thread {
   gap: 0;
   width: 100%;
-  max-width: 100%;
-  margin: 0;
+  /* CHAT-D10-04 — cap the reading measure on wide panes (Claude.ai ~48rem,
+     ChatGPT ~768px; we match the workbench's 920px .cave-turn-content cap)
+     and center the column. Collapses to 100% on narrow panes, so the
+     ≤767px mobile rules are unaffected. */
+  max-width: min(100%, 920px);
+  margin-block: 0;
+  margin-inline: auto;
 }
 
 /* ── Turn rows ──────────────────────────────────────────────────────────── */
@@ -1180,7 +1202,9 @@ details[open] > .cave-tool-summary::before {
 }
 
 .cave-chat-linear .cave-composer-shell {
-  max-width: none;
+  /* Share the thread's 920px measure (CHAT-D10-04) so the composer lines up
+     with the capped conversation column; base rule centers via margin auto. */
+  max-width: 920px;
 }
 
 .cave-chat-linear .cave-composer-panel {
@@ -1513,10 +1537,11 @@ details[open] > .cave-tool-summary::before {
 .cave-bubble-system {
   border-radius: 9px;
   border: 1px solid var(--border-hairline);
-  background: oklch(0.1 0.01 280 / 60%);
+  /* Fixed near-opaque dark terminal surface — see DARK-CHROME FIXED INKS. */
+  background: oklch(0.12 0.012 280 / 92%);
   box-shadow:
     0 1px 3px oklch(0 0 0 / 30%),
-    inset 0 1px 0 color-mix(in oklch, var(--foreground) 4%, transparent);
+    inset 0 1px 0 oklch(0.985 0 0 / 4%);
   overflow: hidden;
 }
 
@@ -1525,7 +1550,7 @@ details[open] > .cave-tool-summary::before {
   align-items: center;
   gap: 0.5em;
   padding: 0.3em 0.75em;
-  background: oklch(0.14 0.015 280 / 70%);
+  background: oklch(0.16 0.015 280 / 92%);
   border-bottom: 1px solid var(--border-hairline);
   min-height: 26px;
   backdrop-filter: blur(4px);
@@ -1534,7 +1559,7 @@ details[open] > .cave-tool-summary::before {
 .cave-bubble-system-sigil {
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   font-size: 11px;
-  color: color-mix(in oklch, var(--accent-presence) 70%, var(--text-muted));
+  color: color-mix(in oklch, var(--code-chrome-accent) 70%, var(--code-chrome-ink-faint));
   flex-shrink: 0;
 }
 
@@ -1542,14 +1567,14 @@ details[open] > .cave-tool-summary::before {
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   font-size: 10px;
   letter-spacing: 0.04em;
-  color: var(--text-secondary);
+  color: var(--code-chrome-ink-muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .cave-bubble-system-label--dim {
-  color: var(--text-muted);
+  color: var(--code-chrome-ink-faint);
   opacity: 0.6;
 }
 
@@ -1559,7 +1584,7 @@ details[open] > .cave-tool-summary::before {
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   font-size: 12px;
   line-height: 1.6;
-  color: var(--text-secondary);
+  color: var(--code-chrome-ink-muted);
   white-space: pre-wrap;
   word-break: break-word;
   overflow-wrap: anywhere;


### PR DESCRIPTION
Implements two P2 CSS-only findings from the chat UX audit (#395).

## CHAT-D10-04 — unbounded line length in the linear layout

The shipped linear chat layout (`.cave-chat-linear`, the variant ChatView renders) let `.cave-chat-thread` span the full pane width, so assistant prose ran 150+ chars/line on wide panes. The workbench variant already caps content at 920px (`.cave-turn-content`); benchmarks: Claude.ai ~48rem, ChatGPT ~768px.

- `.cave-chat-linear .cave-chat-thread`: `max-width: min(100%, 920px); margin-inline: auto;` — caps and centers the whole conversation column, so right-aligned user bubbles, meta rows, and the empty state all stay aligned within the same measure.
- `.cave-chat-linear .cave-composer-shell`: `max-width: none` → `920px` — the composer shares the thread's measure (the base rule already centers it), mirroring how the workbench keys its composer shell to its thread width.
- The cap collapses to 100% on narrow panes; the ≤767px mobile rules are unaffected.

## CHAT-D13-01 — dark code/system chrome took theme ink (broken in light mode)

Code blocks and system turns deliberately keep a dark-terminal surface in both modes (Shiki theme is mood-c-dark either way), but their foregrounds used `var(--text-*)`, which `[data-mode="light"]` flips to dark ink — near-unreadable on the still-dark chrome — and the 60%-alpha dark washes went muddy over a light `--bg-base`.

- New fixed properties at the top of `cave-chat.css`, mirroring the dark-mode palette so dark mode is visually unchanged:
  - `--code-chrome-ink: oklch(0.985 0 0)` (dark-mode `--text-primary`)
  - `--code-chrome-ink-muted: oklch(0.66 0.018 293)` (dark-mode `--text-secondary`)
  - `--code-chrome-ink-faint: oklch(0.985 0 0 / 40%)` (dark-mode `--text-muted`)
  - `--code-chrome-accent: #9a8ecd` (dark-mode `--accent-presence`)
- Applied to: `.cave-code-lang`, `.cave-code-filename`, `.cave-ln`, `.cave-copy-btn` (rest + hover), `.cave-code-header::after` dots, `.cave-bubble-system-sigil/-label/-label--dim/-body`. No `var(--text-*)` remains in the dark-chrome blocks.
- Fixed dark surfaces raised from 60–70% alpha to 92% (`.cave-code-wrap`, `.cave-code-header`, `.cave-copy-btn`, `.cave-bubble-system`, `.cave-bubble-system-header`) so they stay self-consistent over light backgrounds; inset highlights pinned to fixed white-alpha instead of `--foreground`.
- `.cave-md` prose colors untouched — they should follow the theme.

## Tests

Extended `message-bubble-code-header.test.ts` with pins for the 920px linear measure + composer alignment, the fixed-ink properties and their application, no remaining `var(--text-*)` in the fixed dark-chrome blocks, and near-opaque fixed surfaces.

- `message-bubble-code-header.test.ts`: pass
- `message-bubble-markdown.test.ts` (read-only): pass
- `pnpm test:app`: pass (exit 0)
- `pnpm typecheck`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)