### PR TITLE
fix(chat): harden chat hash navigation

### DIFF
--- a/src/components/chat-router-switching.test.ts
+++ b/src/components/chat-router-switching.test.ts
@@ -125,10 +125,30 @@ assert.match(
   "Unknown/stale deep-link ids must fall back to the chat list with the hash cleared — no crash",
 );
 
+const readChatHashHelper =
+  workspaceSource.match(/function readChatHash\(\): string \| null \{[\s\S]*?\n\}/)?.[0] ?? "";
+
 assert.match(
-  workspaceSource,
+  readChatHashHelper,
+  /try \{[\s\S]*decodeURIComponent\(hash\.slice\(CHAT_HASH_PREFIX\.length\)\)[\s\S]*\} catch/,
+  "readChatHash should treat malformed percent-encoding as null instead of throwing during render/popstate",
+);
+
+const popstateEffect =
+  workspaceSource.match(
+    /useEffect\(\(\) => \{\s*const onPopState = \(\) => \{[\s\S]*?\};\s*window\.addEventListener\("popstate", onPopState\);[\s\S]*?\}, \[openAgentSession, showAgentChatList\]\);/,
+  )?.[0] ?? "";
+
+assert.match(
+  popstateEffect,
   /addEventListener\("popstate"/,
   "Workspace must listen for popstate so browser Back/Forward navigates between list and chat",
+);
+
+assert.match(
+  popstateEffect,
+  /if \(target\) \{\s*openAgentSession\(sid, target\.familiarId\);\s*return;\s*\}[\s\S]*clearChatHash\(\);\s*showAgentChatList\(\);/,
+  "Popstate should clear stale chat hashes and return to the list when the target session is missing",
 );
 
 console.log("chat-router-switching.test.ts: ok");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -70,9 +70,12 @@ const CHAT_HASH_PREFIX = "#chat-";
 function readChatHash(): string | null {
   if (typeof window === "undefined") return null;
   const hash = window.location.hash;
-  return hash.startsWith(CHAT_HASH_PREFIX)
-    ? decodeURIComponent(hash.slice(CHAT_HASH_PREFIX.length))
-    : null;
+  if (!hash.startsWith(CHAT_HASH_PREFIX)) return null;
+  try {
+    return decodeURIComponent(hash.slice(CHAT_HASH_PREFIX.length));
+  } catch {
+    return null;
+  }
 }
 
 function clearChatHash() {
@@ -137,6 +140,8 @@ export function Workspace() {
   // often; the listener should not resubscribe on either.
   const sessionsRef = useRef(sessions);
   sessionsRef.current = sessions;
+  const sessionsLoadedRef = useRef(sessionsLoaded);
+  sessionsLoadedRef.current = sessionsLoaded;
   const modeRef = useRef(mode);
   modeRef.current = mode;
 
@@ -730,7 +735,16 @@ export function Workspace() {
       const sid = readChatHash();
       if (sid) {
         const target = sessionsRef.current.find((s) => s.id === sid);
-        openAgentSession(sid, target?.familiarId);
+        if (target) {
+          openAgentSession(sid, target.familiarId);
+          return;
+        }
+        if (!sessionsLoadedRef.current) {
+          pendingChatDeepLinkRef.current = sid;
+          return;
+        }
+        clearChatHash();
+        showAgentChatList();
         return;
       }
       // Popped back out of a chat entry → show the list, but only while the


### PR DESCRIPTION
## Summary
- treat malformed `#chat-...` hashes as null instead of throwing during Workspace render/popstate
- avoid opening missing chat sessions from Back/Forward; clear stale chat hashes and return to the chat list once sessions are loaded
- add source regression coverage for both hash paths

Follows up on Copilot review feedback from #414.

## Verification
- `node --experimental-strip-types src/components/chat-router-switching.test.ts`
- `pnpm test:app`
- `pnpm typecheck`