### PR TITLE
feat(chat): search conversation content from the chat list

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -25,6 +25,7 @@ const contracts: RouteContract[] = [
   { route: "/capabilities", methods: ["GET"], kind: "json" },
   { route: "/changes", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", pathGuard: true },
   { route: "/chat/conversation/[id]", methods: ["GET", "POST", "PUT", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/chat/search", methods: ["GET"], kind: "json" },
   { route: "/chat/send", methods: ["POST"], kind: "stream", readsJson: true },
   { route: "/codex-automations/[id]", methods: ["GET", "PATCH"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/codex-automations", methods: ["GET"], kind: "json" },

--- a/src/app/api/chat/search/route.ts
+++ b/src/app/api/chat/search/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { searchConversations } from "@/lib/cave-conversations";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/** CHAT-D9-02: content search over stored conversation transcripts.
+ *  GET /api/chat/search?q=… → { ok, hits: [{ sessionId, snippet, matchCount }] }
+ *  Queries under 2 chars return an empty hit list rather than an error so the
+ *  client can fire-and-render without special-casing. */
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const q = (url.searchParams.get("q") ?? "").trim();
+  if (q.length < 2) {
+    return NextResponse.json({ ok: true, hits: [] });
+  }
+  const hits = await searchConversations(q);
+  return NextResponse.json({ ok: true, hits });
+}

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -137,4 +137,71 @@ assert.match(
   "Show archived filter should be an aria-labeled toggle alongside the existing filters",
 );
 
+// ── Content search (CHAT-D9-02) ──────────────────────────────────────────────
+
+// The search box also fires a content search against /api/chat/search for
+// queries of length ≥2 — debounced ~300ms with an abortable fetch.
+assert.match(
+  source,
+  /fetch\(`\/api\/chat\/search\?q=\$\{encodeURIComponent\(q\)\}`,\s*\{\s*cache: "no-store",\s*signal: controller\.signal,/,
+  "ChatList should query the content-search endpoint with an abortable fetch",
+);
+assert.match(
+  source,
+  /const timer = window\.setTimeout\([\s\S]{0,900}?\}, 300\);/,
+  "Content search should debounce ~300ms behind the keystroke",
+);
+assert.match(
+  source,
+  /window\.clearTimeout\(timer\);\s*\n\s*controller\.abort\(\);/,
+  "A retype must clear the pending debounce and abort the in-flight fetch",
+);
+assert.match(
+  source,
+  /if \(q\.length < 2\) \{\s*\n\s*setContentHits\(\[\]\);\s*\n\s*setContentLoading\(false\);/,
+  "Queries under 2 chars must clear content hits instead of fetching",
+);
+
+// Title-filtered rows stay primary: sessions already visible by title match
+// are deduped out of the content section, and hits resolve against the
+// familiar-scoped rows so other familiars' chats never leak in.
+assert.match(
+  source,
+  /if \(shown\.has\(hit\.sessionId\)\) continue;/,
+  "Content hits already shown by the title filter must be deduped",
+);
+assert.match(
+  source,
+  /const byId = new Map\(mine\.map\(\(s\) => \[s\.id, s\]\)\);/,
+  "Content hits must resolve against the familiar-scoped session rows",
+);
+
+// Render: secondary "In conversations" section with highlighted snippet,
+// loading shimmer, and the existing onOpen path for clicks.
+assert.match(
+  source,
+  /In conversations/,
+  "Content matches render under an 'In conversations' section header",
+);
+assert.match(
+  source,
+  /contentLoading && contentMatches\.length === 0 \?[\s\S]{0,200}?animate-pulse/,
+  "Content search shows the shimmer idiom while the first fetch is in flight",
+);
+assert.match(
+  source,
+  /<mark className=/,
+  "The matched substring inside the snippet is highlighted with <mark>",
+);
+assert.match(
+  source,
+  /HighlightedSnippet snippet=\{hit\.snippet\} query=\{search\.trim\(\)\}/,
+  "Snippets render through the highlight helper with the live query",
+);
+assert.match(
+  source,
+  /onClick=\{\(\) => \{ setActiveId\(hit\.sessionId\); onOpen\(hit\.sessionId, row\.familiarId\); \}\}/,
+  "Clicking a content hit opens the session via the existing onOpen path",
+);
+
 console.log("chat-list-delete.test.ts: ok");

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -89,6 +89,33 @@ function statusStyle(s: string) {
   return STATUS_STYLES[s] ?? STATUS_STYLES.completed;
 }
 
+// ── Content search (CHAT-D9-02) ───────────────────────────────────────────────
+// Title filtering stays instant/local; conversation bodies are searched
+// server-side (debounced) and surface as a secondary "In conversations"
+// section beneath the title-filtered rows.
+
+type ContentSearchHit = {
+  sessionId: string;
+  title?: string;
+  snippet: string;
+  matchCount: number;
+};
+
+/** Wrap the first case-insensitive occurrence of `query` in a <mark>. */
+function HighlightedSnippet({ snippet, query }: { snippet: string; query: string }) {
+  const idx = query ? snippet.toLowerCase().indexOf(query.toLowerCase()) : -1;
+  if (idx < 0) return <>{snippet}</>;
+  return (
+    <>
+      {snippet.slice(0, idx)}
+      <mark className="rounded-[2px] bg-[color-mix(in_oklch,var(--accent-presence)_28%,transparent)] px-0.5 text-[var(--text-primary)]">
+        {snippet.slice(idx, idx + query.length)}
+      </mark>
+      {snippet.slice(idx + query.length)}
+    </>
+  );
+}
+
 // ── Main component ────────────────────────────────────────────────────────────
 
 export function ChatList({ familiar, familiars = [], sessions, daemonRunning, onOpen, onNewChat, onSessionsChanged, sessionsLoaded = true }: Props) {
@@ -109,6 +136,10 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   const [archivedRows, setArchivedRows] = useState<SessionRow[]>([]);
   const [archivingId, setArchivingId] = useState<string | null>(null);
   const [archiveNonce, setArchiveNonce] = useState(0);
+  // Content search (CHAT-D9-02) — hits from /api/chat/search for the current
+  // query; cleared the moment the query drops below the 2-char threshold.
+  const [contentHits, setContentHits] = useState<ContentSearchHit[]>([]);
+  const [contentLoading, setContentLoading] = useState(false);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [expandedKeys, setExpandedKeys] = useState<string[]>([]);
@@ -190,6 +221,38 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     return () => { cancelled = true; };
   }, [showArchived, archiveNonce]);
 
+  // Content search fires only for queries of length ≥2, debounced ~300ms so
+  // each keystroke doesn't hit disk; a retype aborts the in-flight fetch.
+  useEffect(() => {
+    const q = search.trim();
+    if (q.length < 2) {
+      setContentHits([]);
+      setContentLoading(false);
+      return;
+    }
+    const controller = new AbortController();
+    setContentLoading(true);
+    const timer = window.setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/chat/search?q=${encodeURIComponent(q)}`, {
+          cache: "no-store",
+          signal: controller.signal,
+        });
+        const json = await res.json().catch(() => ({ ok: false }));
+        if (controller.signal.aborted) return;
+        setContentHits(json.ok && Array.isArray(json.hits) ? json.hits : []);
+        setContentLoading(false);
+      } catch {
+        // aborted retype or network hiccup — a newer effect owns the state
+        if (!controller.signal.aborted) setContentLoading(false);
+      }
+    }, 300);
+    return () => {
+      window.clearTimeout(timer);
+      controller.abort();
+    };
+  }, [search]);
+
   // ── Data: filter ──────────────────────────────────────────────────────────
 
   const mine = useMemo(() => {
@@ -249,6 +312,24 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     () => scopedGroups.reduce((n, g) => n + g.sessions.length, 0),
     [scopedGroups],
   );
+  // Content hits resolve against the familiar-scoped rows and drop any
+  // session the title filter already shows — title matches stay primary.
+  const contentMatches = useMemo(() => {
+    if (search.trim().length < 2 || contentHits.length === 0) return [];
+    const shown = new Set<string>();
+    for (const group of scopedGroups) for (const s of group.sessions) shown.add(s.id);
+    const byId = new Map(mine.map((s) => [s.id, s]));
+    const out: Array<{ hit: ContentSearchHit; row: SessionRow }> = [];
+    for (const hit of contentHits) {
+      if (shown.has(hit.sessionId)) continue;
+      const row = byId.get(hit.sessionId);
+      if (!row) continue;
+      out.push({ hit, row });
+    }
+    return out;
+  }, [contentHits, scopedGroups, mine, search]);
+  const showContentSection =
+    search.trim().length >= 2 && (contentLoading || contentMatches.length > 0);
   // ── Delete (two-step confirm) ────────────────────────────────────────────
 
   const deleteSession = async (e: React.MouseEvent, sessionId: string) => {
@@ -564,7 +645,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               to jump back to chat search after this list has history.
             </div>
           </div>
-        ) : visibleRows === 0 ? (
+        ) : visibleRows === 0 && !showContentSection ? (
           <div className="flex flex-col items-center justify-center gap-2 py-16 text-center">
             <Icon name="ph:magnifying-glass" width={20} className="text-[var(--text-muted)]" />
             <p className="text-sm text-[var(--text-muted)]">
@@ -579,6 +660,8 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
             </button>
           </div>
         ) : (
+          <>
+          {visibleRows > 0 && (
           <ul className="divide-y divide-[var(--border-hairline)]">
             {displayGroups.map(({ projectRoot, sessions: rows, defaultFamiliarId }) => (
               <li key={projectRoot ?? "__none__"}>
@@ -777,6 +860,60 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               </li>
             ))}
           </ul>
+          )}
+
+          {/* ── In conversations (CHAT-D9-02) — body matches for the query.
+                 Title-filtered rows above stay primary; sessions already
+                 visible there are deduped out of this section. ── */}
+          {showContentSection && (
+            <section aria-label="Matches in conversation content">
+              <div className="flex items-center gap-1.5 border-y border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 px-4 py-1.5">
+                <Icon name="ph:chats" width={12} className="shrink-0 text-[var(--text-muted)]" />
+                <span className="truncate text-[11px] font-medium uppercase tracking-wide text-[var(--text-muted)]">
+                  In conversations
+                </span>
+              </div>
+              {contentLoading && contentMatches.length === 0 ? (
+                <div aria-hidden className="space-y-px px-4 py-2">
+                  {[0, 1].map((i) => (
+                    <div key={i} className="animate-pulse flex flex-col gap-1.5 py-2.5">
+                      <span className="h-3 w-1/2 rounded bg-[var(--bg-hover)]" />
+                      <span className="h-2.5 w-3/4 rounded bg-[var(--bg-hover)] opacity-60" />
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <ul className="divide-y divide-[var(--border-hairline)]">
+                  {contentMatches.map(({ hit, row }) => (
+                    <li key={hit.sessionId}>
+                      <div
+                        role="button"
+                        tabIndex={0}
+                        onClick={() => { setActiveId(hit.sessionId); onOpen(hit.sessionId, row.familiarId); }}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") { setActiveId(hit.sessionId); onOpen(hit.sessionId, row.familiarId); }
+                        }}
+                        className="focus-ring-inset group flex cursor-pointer flex-col gap-0.5 px-4 py-2.5 transition-colors hover:bg-[var(--bg-raised)]/50"
+                      >
+                        <span className="flex items-baseline justify-between gap-2">
+                          <span className="min-w-0 truncate text-[13px] font-semibold text-[var(--text-primary)]">
+                            {stripLeadingTrailingEmoji(row.title || hit.title || "(untitled chat)")}
+                          </span>
+                          <span className="shrink-0 text-[11px] text-[var(--text-muted)]">
+                            {hit.matchCount === 1 ? "1 match" : `${hit.matchCount} matches`}
+                          </span>
+                        </span>
+                        <span className="truncate text-[12px] text-[var(--text-muted)]">
+                          <HighlightedSnippet snippet={hit.snippet} query={search.trim()} />
+                        </span>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          )}
+          </>
         )}
       </div>
 

--- a/src/lib/cave-conversations.test.ts
+++ b/src/lib/cave-conversations.test.ts
@@ -79,6 +79,87 @@ assert.equal(cancelledTurn?.isError, false, "a user cancel is not an error");
 assert.equal(cancelledTurn?.text, "Roses are red, violets", "partial streamed text must survive the save");
 assert.equal(await deleteConversation("cancelled-turn"), true);
 
+// ── CHAT-D9-02: conversation content search ──────────────────────────────────
+// Appended section — searchConversations over fixture transcripts written
+// directly into CONV_DIR (still pointing at the temp HOME from above).
+{
+  const { searchConversations, CONV_DIR } = await import("./cave-conversations.ts");
+  const { writeFile, mkdir } = await import("node:fs/promises");
+  await mkdir(CONV_DIR, { recursive: true });
+
+  const fixture = (sessionId, updatedAt, texts) =>
+    JSON.stringify({
+      sessionId,
+      familiarId: "charm",
+      harness: "codex",
+      title: `Title ${sessionId}`,
+      createdAt: updatedAt,
+      updatedAt,
+      turns: texts.map((text, i) => ({
+        id: `t${i}`,
+        role: i % 2 ? "assistant" : "user",
+        text,
+        createdAt: updatedAt,
+      })),
+    });
+
+  await writeFile(
+    path.join(CONV_DIR, "search-hit.json"),
+    fixture("search-hit", "2026-06-11T01:00:00.000Z", [
+      "let's plan the trip",
+      "We should book the Kyoto ryokan in autumn.\nKyoto is busy then.",
+    ]),
+    "utf8",
+  );
+  await writeFile(
+    path.join(CONV_DIR, "search-miss.json"),
+    fixture("search-miss", "2026-06-11T02:00:00.000Z", ["nothing relevant here"]),
+    "utf8",
+  );
+  await writeFile(path.join(CONV_DIR, "search-corrupt.json"), "{ not json", "utf8");
+
+  // Body match → one hit per conversation, with snippet + match count;
+  // the corrupt file alongside must be skipped, not thrown on.
+  const hits = await searchConversations("kyoto");
+  assert.equal(hits.length, 1, "one conversation matches 'kyoto'");
+  assert.equal(hits[0].sessionId, "search-hit");
+  assert.equal(hits[0].matchCount, 2, "matchCount counts every occurrence across turns");
+  assert.match(hits[0].snippet, /Kyoto ryokan/, "snippet centers on the first match");
+  assert.doesNotMatch(hits[0].snippet, /\n/, "snippet is single-line");
+  assert.ok(hits[0].snippet.length <= 100, "snippet stays excerpt-sized");
+
+  // No match → empty; never an error.
+  assert.deepEqual(await searchConversations("zanzibar"), []);
+
+  // Min query length 2 (whitespace doesn't count).
+  assert.deepEqual(await searchConversations("k"), []);
+  assert.deepEqual(await searchConversations("  k  "), []);
+  assert.deepEqual(await searchConversations(""), []);
+
+  // Result cap — most recently updated conversations win.
+  for (let i = 0; i < 5; i++) {
+    await writeFile(
+      path.join(CONV_DIR, `cap-${i}.json`),
+      fixture(`cap-${i}`, `2026-06-12T0${i}:00:00.000Z`, ["the otters convene at dawn"]),
+      "utf8",
+    );
+  }
+  const capped = await searchConversations("otters", { limit: 3 });
+  assert.equal(capped.length, 3, "limit caps the hit list");
+  assert.deepEqual(
+    capped.map((h) => h.sessionId),
+    ["cap-4", "cap-3", "cap-2"],
+    "most recently updated conversations rank first",
+  );
+
+  // Oversized transcripts are skipped gracefully, not scanned.
+  assert.deepEqual(
+    await searchConversations("kyoto", { maxFileBytes: 10 }),
+    [],
+    "files above the byte cap are skipped",
+  );
+}
+
 if (previousHome === undefined) {
   delete process.env.HOME;
 } else {

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -148,4 +148,95 @@ export async function listConversations(): Promise<
   return results;
 }
 
+// ── Content search (CHAT-D9-02) ──────────────────────────────────────────────
+// "Where did we discuss X" — scan stored transcripts for a case-insensitive
+// substring and return one hit per conversation with a snippet around the
+// first match. Pure-ish + bounded: cheap text pre-filter before JSON.parse,
+// oversized files skipped, corrupt files skipped, result count capped.
+
+export type ConversationSearchHit = {
+  sessionId: string;
+  title?: string;
+  /** Single-line excerpt (~80 chars) around the first match. */
+  snippet: string;
+  /** Total occurrences across the conversation's turn texts. */
+  matchCount: number;
+};
+
+const SEARCH_DEFAULT_LIMIT = 30;
+const SEARCH_MAX_FILE_BYTES = 2 * 1024 * 1024;
+const SEARCH_SNIPPET_RADIUS = 40;
+
+function searchSnippet(text: string, index: number, matchLength: number): string {
+  const start = Math.max(0, index - SEARCH_SNIPPET_RADIUS);
+  const end = Math.min(text.length, index + matchLength + SEARCH_SNIPPET_RADIUS);
+  let excerpt = text.slice(start, end).replace(/\s+/g, " ").trim();
+  if (start > 0) excerpt = `…${excerpt}`;
+  if (end < text.length) excerpt = `${excerpt}…`;
+  return excerpt;
+}
+
+export async function searchConversations(
+  query: string,
+  opts: { limit?: number; maxFileBytes?: number } = {},
+): Promise<ConversationSearchHit[]> {
+  const q = query.trim();
+  if (q.length < 2) return [];
+  const qLower = q.toLowerCase();
+  const limit = Math.max(1, opts.limit ?? SEARCH_DEFAULT_LIMIT);
+  const maxFileBytes = opts.maxFileBytes ?? SEARCH_MAX_FILE_BYTES;
+
+  let entries: string[];
+  try {
+    entries = await readdir(CONV_DIR);
+  } catch {
+    return [];
+  }
+
+  const hits: Array<ConversationSearchHit & { updatedAt: string }> = [];
+  for (const name of entries) {
+    if (!name.endsWith(".json")) continue;
+    try {
+      const file = path.join(CONV_DIR, name);
+      const info = await stat(file);
+      if (info.size > maxFileBytes) continue; // huge body — skip gracefully
+      const raw = await readFile(file, "utf8");
+      // Cheap substring pre-filter on the raw text before paying for parse.
+      if (!raw.toLowerCase().includes(qLower)) continue;
+      const conv = JSON.parse(raw) as ConversationFile;
+      if (!Array.isArray(conv?.turns)) continue;
+      let matchCount = 0;
+      let snippet = "";
+      for (const turn of conv.turns) {
+        const text = typeof turn?.text === "string" ? turn.text : "";
+        if (!text) continue;
+        const textLower = text.toLowerCase();
+        let idx = textLower.indexOf(qLower);
+        if (idx < 0) continue;
+        if (!snippet) snippet = searchSnippet(text, idx, q.length);
+        while (idx >= 0) {
+          matchCount += 1;
+          idx = textLower.indexOf(qLower, idx + qLower.length);
+        }
+      }
+      if (matchCount === 0) continue;
+      hits.push({
+        sessionId:
+          typeof conv.sessionId === "string" && conv.sessionId
+            ? conv.sessionId
+            : name.replace(/\.json$/, ""),
+        ...(typeof conv.title === "string" && conv.title ? { title: conv.title } : {}),
+        snippet,
+        matchCount,
+        updatedAt: typeof conv.updatedAt === "string" ? conv.updatedAt : "",
+      });
+    } catch {
+      /* corrupt or unreadable file — skip */
+    }
+  }
+
+  hits.sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1));
+  return hits.slice(0, limit).map(({ updatedAt: _updatedAt, ...hit }) => hit);
+}
+
 export { CONV_DIR, appendFile };


### PR DESCRIPTION
Implements **CHAT-D9-02 (P2)** from the chat UX audit (#395).

## The gap

The chat-list search filtered on `title` + `project_root` only, so "where did we discuss X" — the dominant recall query — found nothing unless the title happened to contain X. ChatGPT and Claude.ai both index message bodies and surface snippets.

## The fix

**Server**
- `searchConversations(q, { limit, maxFileBytes })` in `src/lib/cave-conversations.ts`: scans stored transcripts for a case-insensitive substring, returns one hit per conversation as `{ sessionId, title?, snippet, matchCount }`.
  - snippet: single-line, ~80 chars (40-char radius) around the first match, whitespace collapsed, `…` ellipses when truncated
  - bounded: min query length 2; cheap raw-text `includes` pre-filter before paying for `JSON.parse`; files over 2MB skipped; corrupt files skipped, never thrown on; hits sorted by `updatedAt` desc and capped at 30
- New `GET /api/chat/search?q=…` route; one contract line added to `api-contracts.test.ts` (per the #422 precedent).

**UI (`chat-list.tsx`)**
- Queries of length ≥2 also fire the content search: debounced 300ms, abortable fetch (retype clears the timer and aborts in-flight), shimmer per the existing loading idiom.
- Hits render in an "In conversations" section under the title-filtered rows: session title + muted snippet with the match highlighted via `<mark>`; clicking opens through the existing `onOpen` path.
- Title matches stay primary; sessions already visible there are deduped out; hits resolve against the familiar-scoped rows so other familiars' chats never leak in.
- ⌘F focus, Unreads/Archived filters, and pin/archive (#415) untouched.

## Tests

- `cave-conversations.test.ts` (appended section): body match → hit with snippet + matchCount; no match → empty; corrupt file skipped; result cap + recency ordering; min query length; oversized-file skip.
- `chat-list-delete.test.ts`: pins for the endpoint fetch + abort, 300ms debounce, <2-char guard, dedupe, "In conversations" section, `<mark>` highlight, onOpen path, shimmer.
- Full `pnpm test:api`, `pnpm test:app`, and `pnpm typecheck` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)