### PR TITLE
feat(chat): render Edit/Write tool calls as structured diffs

### DIFF
--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -2,9 +2,11 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { toolArgSummary } from "../lib/tool-arg-summary.ts";
+import { toolInputAsDiff } from "../lib/tool-input-diff.ts";
 
 const source = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
 const styles = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
+const bubbleSource = readFileSync(new URL("./message-bubble.tsx", import.meta.url), "utf8");
 
 // After the streamline refactor the header is MetaLine (title + status meta)
 // plus an optional LinkedContextRow — no ChatContextStrip, no headline row.
@@ -176,6 +178,98 @@ assert.match(
   source,
   /detail: argSummary \? `\$\{incoming\.name\}\(\$\{argSummary\}\)` : incoming\.name/,
   "Tool progress detail carries Name(arg) instead of the bare tool name",
+);
+
+// ── Edit/Write tool inputs render as structured diffs (CHAT-D8-02) ──────────
+// toolInputAsDiff converts file-mutation tool JSON payloads into unified-diff
+// text; ToolBlock routes the Input section through it with lang="diff".
+
+// Edit pair → a/b headers + -old/+new lines.
+assert.equal(
+  toolInputAsDiff(
+    "Edit",
+    JSON.stringify({ file_path: "src/foo.ts", old_string: "const a = 1;", new_string: "const a = 2;" }, null, 2),
+  ),
+  ["--- a/src/foo.ts", "+++ b/src/foo.ts", "-const a = 1;", "+const a = 2;"].join("\n"),
+  "Edit input becomes a -/+ diff with a/b file headers",
+);
+
+// Multiline strings keep one gutter prefix per line.
+assert.equal(
+  toolInputAsDiff(
+    "edit",
+    JSON.stringify({ file_path: "x.txt", old_string: "one\ntwo", new_string: "one\nTWO\nthree" }),
+  ),
+  ["--- a/x.txt", "+++ b/x.txt", "-one", "-two", "+one", "+TWO", "+three"].join("\n"),
+  "multiline edit strings get per-line -/+ prefixes (name match is case-insensitive)",
+);
+
+// Write → all-plus body under a +++ header.
+assert.equal(
+  toolInputAsDiff("Write", JSON.stringify({ file_path: "new.ts", content: "alpha\nbeta\n" })),
+  ["+++ b/new.ts", "+alpha", "+beta"].join("\n"),
+  "Write content renders as all-plus lines without a phantom trailing row",
+);
+
+// MultiEdit → one @@-labelled hunk per edit, concatenated.
+const multi = toolInputAsDiff(
+  "MultiEdit",
+  JSON.stringify({
+    file_path: "m.ts",
+    edits: [
+      { old_string: "a", new_string: "b" },
+      { old_string: "c", new_string: "d" },
+    ],
+  }),
+);
+assert.equal(
+  multi,
+  ["--- a/m.ts", "+++ b/m.ts", "@@ edit 1/2 @@", "-a", "+b", "@@ edit 2/2 @@", "-c", "+d"].join("\n"),
+  "MultiEdit concatenates per-edit hunks under @@ headers",
+);
+
+// NotebookEdit's new_source is Write-like.
+assert.equal(
+  toolInputAsDiff("NotebookEdit", JSON.stringify({ notebook_path: "nb.ipynb", new_source: "print(1)" })),
+  ["+++ b/nb.ipynb", "+print(1)"].join("\n"),
+  "NotebookEdit new_source renders as an all-plus block keyed on notebook_path",
+);
+
+// Non-mutation tools and unparseable input fall back to null (raw rendering).
+assert.equal(toolInputAsDiff("Bash", JSON.stringify({ command: "rm -rf" })), null, "non-mutation tools return null");
+assert.equal(toolInputAsDiff("Read", JSON.stringify({ file_path: "f" })), null, "Read is not a mutation tool");
+assert.equal(toolInputAsDiff("Edit", "{ truncated payload …"), null, "unparseable input returns null");
+assert.equal(toolInputAsDiff("Edit", JSON.stringify({ file_path: "f" })), null, "unrecognised shapes return null");
+assert.equal(toolInputAsDiff("Edit", undefined), null, "absent input returns null");
+
+// Oversize diffs are capped with a truncation marker (~400 lines).
+const bigDiff = toolInputAsDiff(
+  "Write",
+  JSON.stringify({ file_path: "big.txt", content: Array.from({ length: 900 }, (_, i) => `line ${i}`).join("\n") }),
+);
+const bigLines = bigDiff.split("\n");
+assert.ok(bigLines.length <= 401, "diff output is capped near 400 lines");
+assert.match(bigLines[bigLines.length - 1], /more lines truncated/, "capped diff ends with a truncation marker");
+
+// ToolBlock routes the Input section through toolInputAsDiff with diff chrome.
+assert.match(
+  source,
+  /function ToolBlock[\s\S]*?const inputDiff = toolInputAsDiff\(tool\.name, tool\.input\)[\s\S]*?\{inputDiff \? <SyntaxBlock text=\{inputDiff\} lang="diff" \/> : <SyntaxBlock text=\{tool\.input\} \/>\}/,
+  "ToolBlock Input renders the structured diff when available, raw payload otherwise",
+);
+
+// ── Diff gutter excludes file headers; @@ rows are muted meta (CHAT-D8-03) ──
+// `+++ b/file` must not classify as an addition nor `--- a/file` as a
+// deletion; `@@` hunk headers carry the cave-diff-meta chrome class.
+assert.match(
+  bubbleSource,
+  /\/\^@@\/\.test\(plainLine\)\s*\?\s*" cave-diff-meta"\s*:\s*\/\^\(\\\+\\\+\\\+ \|--- \)\/\.test\(plainLine\)\s*\?\s*""/,
+  "diff gutter mutes @@ headers and exempts +++/--- file headers before +/- classification",
+);
+assert.match(
+  styles,
+  /\.cave-diff-meta\s*\{/,
+  "cave-diff-meta CSS rule is defined for hunk-header chrome",
 );
 
 console.log("chat-header-row.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -28,6 +28,7 @@ import { VoiceCallOverlay } from "./voice-call-overlay";
 import { CsvImportModal } from "./csv-import-modal";
 import { looksLikeCsv } from "@/lib/csv-import";
 import { toolArgSummary } from "@/lib/tool-arg-summary";
+import { toolInputAsDiff } from "@/lib/tool-input-diff";
 
 type ToolEvent = {
   id: string;
@@ -2633,6 +2634,10 @@ function ToolGroup({ tools }: { tools: ToolEvent[] }) {
 
 function ToolBlock({ tool }: { tool: ToolEvent }) {
   const argSummary = toolArgSummary(tool.name, tool.input);
+  // CHAT-D8-02: Edit/Write/MultiEdit/NotebookEdit inputs render as a
+  // structured before/after diff instead of the raw JSON payload; null for
+  // every other tool (or unparseable input) falls back to the plain block.
+  const inputDiff = toolInputAsDiff(tool.name, tool.input);
   return (
     <details className="cave-tool-block" data-default-collapsed="true">
       <summary className="flex min-w-0 cursor-pointer select-none flex-wrap items-center gap-2 text-[11px]">
@@ -2656,7 +2661,7 @@ function ToolBlock({ tool }: { tool: ToolEvent }) {
       {tool.input ? (
         <div className="mt-2">
           <div className="mb-1 text-[10px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Input</div>
-          <SyntaxBlock text={tool.input} />
+          {inputDiff ? <SyntaxBlock text={inputDiff} lang="diff" /> : <SyntaxBlock text={tool.input} />}
         </div>
       ) : null}
       {tool.output ? (

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -136,10 +136,18 @@ async function renderCodeBlock(
         // Remove trailing empty line Shiki adds
         if (rawLines[rawLines.length - 1] === "") rawLines.pop();
         const wrappedLines = rawLines.map((line: string, i: number) => {
+          // CHAT-D8-03: `+++ b/file` / `--- a/file` headers are metadata, not
+          // additions/deletions — exclude them from the +/- gutter strips and
+          // mute `@@` hunk headers instead of leaving them content-colored.
+          const plainLine = line.replace(/<[^>]+>/g, "");
           const gutterClass = isDiff
-            ? line.includes('<span class="shiki-diff add"') || /^\+/.test(line.replace(/<[^>]+>/g, ""))
+            ? /^@@/.test(plainLine)
+              ? " cave-diff-meta"
+              : /^(\+\+\+ |--- )/.test(plainLine)
+              ? ""
+              : line.includes('<span class="shiki-diff add"') || /^\+/.test(plainLine)
               ? " cave-diff-add"
-              : /^-/.test(line.replace(/<[^>]+>/g, ""))
+              : /^-/.test(plainLine)
               ? " cave-diff-del"
               : ""
             : "";

--- a/src/lib/tool-input-diff.ts
+++ b/src/lib/tool-input-diff.ts
@@ -1,0 +1,108 @@
+// Structured diff rendering for file-mutation tool calls (CHAT-D8-02).
+//
+// Edit/Write tool inputs arrive as pretty-printed JSON strings (see
+// formatToolPayload/formatToolInputValue in chat-tool-events.ts): an Edit is
+// `{"file_path": …, "old_string": …, "new_string": …}`. Rendering that JSON
+// blob through SyntaxBlock buries the actual change. This module converts the
+// payload into unified-diff-style text so the chat can render it with diff
+// gutter chrome — the same way Claude Code shows every Edit as a before/after
+// block.
+//
+// Deliberately NOT an LCS line differ: Edit old_string/new_string pairs are
+// already minimal context by construction (the harness requires a unique
+// match), so a full-block -/+ diff is faithful.
+
+/** Tool names whose input mutates a file (case-insensitive exact match). */
+const MUTATION_TOOLS = new Set(["edit", "write", "multiedit", "notebookedit"]);
+
+/** Cap rendered diff output; beyond this we truncate with a marker. */
+const MAX_DIFF_LINES = 400;
+
+type Rec = Record<string, unknown>;
+
+function str(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/** Best-effort file path from the well-known keys mutation tools use. */
+function filePathOf(record: Rec): string {
+  return str(record.file_path) ?? str(record.path) ?? str(record.notebook_path) ?? "file";
+}
+
+function prefixLines(text: string, prefix: "+" | "-"): string[] {
+  // A trailing newline would otherwise render a spurious empty +/- row.
+  const body = text.endsWith("\n") ? text.slice(0, -1) : text;
+  return body.split("\n").map((line) => `${prefix}${line}`);
+}
+
+/** -old/+new hunk body for one edit pair. Empty old_string (file-creation
+ *  style edits) yields an all-plus hunk. */
+function editHunk(oldString: string, newString: string): string[] {
+  return [
+    ...(oldString ? prefixLines(oldString, "-") : []),
+    ...(newString ? prefixLines(newString, "+") : []),
+  ];
+}
+
+function isEditLike(record: Rec): record is Rec & { old_string: string; new_string: string } {
+  return typeof record.old_string === "string" && typeof record.new_string === "string";
+}
+
+function capLines(lines: string[]): string {
+  if (lines.length <= MAX_DIFF_LINES) return lines.join("\n");
+  const hidden = lines.length - MAX_DIFF_LINES;
+  return [...lines.slice(0, MAX_DIFF_LINES), `… (${hidden} more lines truncated)`].join("\n");
+}
+
+/**
+ * Convert a file-mutation tool input payload into unified-diff-style text.
+ *
+ * Returns null for non-mutation tools, non-JSON input, or payload shapes we
+ * don't recognise — callers fall back to their current raw rendering.
+ */
+export function toolInputAsDiff(name: string, input?: string | null): string | null {
+  if (!MUTATION_TOOLS.has(name.toLowerCase())) return null;
+  const raw = (input ?? "").trim();
+  if (!raw) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const record = parsed as Rec;
+  const file = filePathOf(record);
+
+  // Edit-like: { old_string, new_string } → -old/+new with a/b headers.
+  if (isEditLike(record)) {
+    return capLines([
+      `--- a/${file}`,
+      `+++ b/${file}`,
+      ...editHunk(record.old_string, record.new_string),
+    ]);
+  }
+
+  // MultiEdit: { edits: [{ old_string, new_string }, …] } → one hunk per edit.
+  if (Array.isArray(record.edits)) {
+    const edits = record.edits.filter((e): e is Rec & { old_string: string; new_string: string } =>
+      Boolean(e) && typeof e === "object" && isEditLike(e as Rec),
+    );
+    if (!edits.length) return null;
+    const lines = [`--- a/${file}`, `+++ b/${file}`];
+    edits.forEach((edit, i) => {
+      lines.push(`@@ edit ${i + 1}/${edits.length} @@`);
+      lines.push(...editHunk(edit.old_string, edit.new_string));
+    });
+    return capLines(lines);
+  }
+
+  // Write-like: { content } (or NotebookEdit's { new_source }) → all-plus.
+  const content = str(record.content) ?? str(record.new_source);
+  if (content !== undefined) {
+    return capLines([`+++ b/${file}`, ...prefixLines(content, "+")]);
+  }
+
+  return null;
+}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -345,6 +345,14 @@
   border-left: 2px solid oklch(0.55 0.2 15 / 55%);
   padding-left: calc(1em - 2px);
 }
+/* CHAT-D8-03: @@ hunk headers read as muted metadata, not content. Shiki
+   tokens carry inline colors, so the ink override needs !important. */
+.cave-diff-meta {
+  opacity: 0.65;
+}
+.cave-diff-meta span {
+  color: var(--text-muted) !important;
+}
 
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    COPY BUTTON


### PR DESCRIPTION
Implements **CHAT-D8-02 (P2)** and **CHAT-D8-03 (P3)** from the chat UX audit (#395).

## CHAT-D8-02 — Edit/Write tool calls as structured diffs

Edit/Write/MultiEdit/NotebookEdit tool calls rendered their raw JSON input through `SyntaxBlock` — an Edit showed up as a `{"file_path": …, "old_string": …, "new_string": …}` blob, and `autoDetectLang` only applies diff chrome when text already looks like a unified diff. Benchmark: Claude Code renders every Edit as a structured before/after diff block.

- **New pure module `src/lib/tool-input-diff.ts`** — `toolInputAsDiff(name, input)`:
  - Edit-like `{old_string, new_string}` → `--- a/<file>` / `+++ b/<file>` headers, then `-`old / `+`new lines (full-block diff; the strings are already minimal context by construction, so no LCS differ).
  - Write-like `{content}` (and NotebookEdit `{new_source}`) → all-plus body under `+++ b/<file>`.
  - MultiEdit `{edits: […]}` → concatenated hunks under `@@ edit N/M @@` headers.
  - Returns `null` for non-mutation tools, non-JSON, or unrecognised shapes — caller keeps the current raw rendering. Output capped at 400 lines with a truncation marker.
- **`chat-view.tsx` ToolBlock** — Input section renders `<SyntaxBlock text={diffText} lang="diff" />` when the converter produces text; output section and the #424 arg-summary span untouched.

## CHAT-D8-03 — diff gutter header misclassification

`message-bubble.tsx`'s diff gutter classified `+++ b/file` as an addition and `--- a/file` as a deletion via the per-line `/^\+/` / `/^-/` regexes. Now `^+++ ` / `^--- ` file headers are exempt from the +/- strips, and `^@@` hunk headers get a muted `.cave-diff-meta` class (new rule at the end of the diff-styles section in `cave-chat.css`).

## Tests

- Behavioral coverage for `toolInputAsDiff` (Edit pair, multiline, Write all-plus, MultiEdit hunks, NotebookEdit, non-mutation → null, unparseable → null, 400-line cap) plus source pins for the ToolBlock routing and the gutter header exclusion — all in `chat-header-row.test.ts` (this wave's owned test file; contended message-bubble tests untouched).
- `pnpm test:app` green (exit 0), `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)