### PR TITLE
feat(chat): surface token usage and cost per turn

### DIFF
--- a/src/app/api/chat/conversation/[id]/route.ts
+++ b/src/app/api/chat/conversation/[id]/route.ts
@@ -11,6 +11,7 @@ import { linkedContextForSession } from "@/lib/chat-linked-context";
 import { loadConversationFromJsonl } from "@/lib/openclaw-conversation";
 import { loadState, recordSessionFamiliar, sacrificeSessionLocal } from "@/lib/cave-config";
 import { defaultChatTitleForSession } from "@/lib/cave-chat-titles";
+import { normalizeTurnUsage, parseCostUsd } from "@/lib/usage-format";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -46,6 +47,8 @@ function normalizeTurn(input: unknown): ChatTurn | null {
   }
   if (typeof value.text !== "string") return null;
   const now = new Date().toISOString();
+  const usage = normalizeTurnUsage(value.usage);
+  const costUsd = parseCostUsd(value.costUsd);
   return {
     id: typeof value.id === "string" && value.id.trim() ? value.id : crypto.randomUUID(),
     role: value.role,
@@ -60,6 +63,8 @@ function normalizeTurn(input: unknown): ChatTurn | null {
     ...(typeof value.durationMs === "number" ? { durationMs: value.durationMs } : {}),
     ...(typeof value.isError === "boolean" ? { isError: value.isError } : {}),
     ...(typeof value.cancelled === "boolean" ? { cancelled: value.cancelled } : {}),
+    ...(usage ? { usage } : {}),
+    ...(costUsd !== undefined ? { costUsd } : {}),
   };
 }
 

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -463,4 +463,151 @@ assert.match(
   assert.equal(flattenToolResultContent(null), undefined);
 }
 
+// ── Token usage + cost capture (CHAT-D12-02) ───────────────────────────────
+// Source pins: the stream-json `result` parse must capture `total_cost_usd`
+// and `usage` through the shared defensive validators, forward both on the
+// `done` SSE event, and persist them on the saved assistant turn.
+
+import {
+  formatCost,
+  formatTokens,
+  normalizeTurnUsage,
+  parseCostUsd,
+  parseStreamJsonUsage,
+  usageBreakdown,
+  usageSummary,
+} from "../../../../lib/usage-format.ts";
+
+assert.match(
+  chatRoute,
+  /if \(ev\.type === "result"\) \{[\s\S]*?usage: parseStreamJsonUsage\(ev\.usage\),[\s\S]*?costUsd: parseCostUsd\(ev\.total_cost_usd\),/,
+  "The result-event parse must capture usage and total_cost_usd through the defensive validators (CHAT-D12-02)",
+);
+
+assert.match(
+  chatRoute,
+  /kind: "done";[\s\S]*?usage\?: TurnUsage;[\s\S]*?costUsd\?: number;/,
+  "The done StreamEvent must carry optional usage and costUsd fields (CHAT-D12-02)",
+);
+
+assert.match(
+  chatRoute,
+  /kind: "done",\s*\n\s*durationMs: result\.duration_ms,\s*\n\s*isError: result\.is_error,\s*\n\s*sessionId: finalSessionId \?\? undefined,\s*\n\s*\.\.\.\(result\.usage \? \{ usage: result\.usage \} : \{\}\),\s*\n\s*\.\.\.\(result\.costUsd !== undefined \? \{ costUsd: result\.costUsd \} : \{\}\),/,
+  "The final done event must forward captured usage and cost, omitting them when the harness emitted none (CHAT-D12-02)",
+);
+
+assert.match(
+  chatRoute,
+  /durationMs: result\.duration_ms,\s*\n\s*isError: result\.is_error,\s*\n\s*\.\.\.\(cancelledByUser \? \{ cancelled: true \} : \{\}\),\s*\n\s*\.\.\.\(result\.usage \? \{ usage: result\.usage \} : \{\}\),\s*\n\s*\.\.\.\(result\.costUsd !== undefined \? \{ costUsd: result\.costUsd \} : \{\}\),/,
+  "The persisted assistant turn must carry usage and cost alongside durationMs (CHAT-D12-02)",
+);
+
+// Behavioral: stream-json usage parse is defensive — optional fields,
+// validated numbers, undefined when nothing usable was emitted.
+{
+  assert.deepEqual(
+    parseStreamJsonUsage({
+      input_tokens: 10200,
+      output_tokens: 2150,
+      cache_read_input_tokens: 5000,
+      cache_creation_input_tokens: 1200,
+    }),
+    {
+      inputTokens: 10200,
+      outputTokens: 2150,
+      cacheReadTokens: 5000,
+      cacheCreationTokens: 1200,
+    },
+    "a full usage block maps snake_case counters onto the turn shape",
+  );
+  assert.deepEqual(
+    parseStreamJsonUsage({ input_tokens: 12, output_tokens: 34 }),
+    { inputTokens: 12, outputTokens: 34 },
+    "cache counters are optional and omitted when absent",
+  );
+  assert.equal(parseStreamJsonUsage(undefined), undefined, "missing usage stays absent");
+  assert.equal(parseStreamJsonUsage(null), undefined);
+  assert.equal(parseStreamJsonUsage("12k"), undefined, "non-object usage is rejected");
+  assert.equal(parseStreamJsonUsage({}), undefined, "empty usage objects stay absent");
+  assert.equal(
+    parseStreamJsonUsage({ input_tokens: "12", output_tokens: NaN }),
+    undefined,
+    "non-numeric and NaN counters are rejected",
+  );
+  assert.deepEqual(
+    parseStreamJsonUsage({ input_tokens: 7, output_tokens: -3, cache_read_input_tokens: -1 }),
+    { inputTokens: 7, outputTokens: 0 },
+    "negative counters drop; partial blocks keep the valid fields",
+  );
+}
+
+// Behavioral: cost validation.
+{
+  assert.equal(parseCostUsd(0.0812), 0.0812);
+  assert.equal(parseCostUsd(0), 0, "zero cost is captured (display layer hides it)");
+  assert.equal(parseCostUsd(-1), undefined);
+  assert.equal(parseCostUsd(NaN), undefined);
+  assert.equal(parseCostUsd("0.08"), undefined);
+  assert.equal(parseCostUsd(undefined), undefined);
+}
+
+// Behavioral: persisted camelCase round-trip validator (conversation POST/PUT).
+{
+  assert.deepEqual(
+    normalizeTurnUsage({ inputTokens: 10, outputTokens: 5, cacheReadTokens: 2 }),
+    { inputTokens: 10, outputTokens: 5, cacheReadTokens: 2 },
+  );
+  assert.equal(normalizeTurnUsage({}), undefined);
+  assert.equal(normalizeTurnUsage({ inputTokens: "10" }), undefined);
+}
+
+// Behavioral: formatting thresholds, sub-cent floor, absent states.
+{
+  assert.equal(formatTokens(980), "980");
+  assert.equal(formatTokens(999), "999");
+  assert.equal(formatTokens(1000), "1k", "trailing .0 is trimmed");
+  assert.equal(formatTokens(1234), "1.2k");
+  assert.equal(formatTokens(12350), "12.4k", "12350 tokens read as 12.4k");
+  assert.equal(formatTokens(2_500_000), "2.5M");
+  assert.equal(formatTokens(0), "0");
+  assert.equal(formatTokens(-5), null);
+  assert.equal(formatTokens(NaN), null);
+
+  assert.equal(formatCost(0.08), "$0.08");
+  assert.equal(formatCost(1.5), "$1.50");
+  assert.equal(formatCost(0.004), "<$0.01", "sub-cent costs floor at <$0.01");
+  assert.equal(formatCost(0), null, "zero cost renders nothing");
+  assert.equal(formatCost(undefined), null);
+  assert.equal(formatCost(-0.5), null);
+
+  assert.equal(
+    usageSummary({ inputTokens: 10200, outputTokens: 2150 }, 0.0812),
+    "12.4k tok · $0.08",
+    "the compact form sums input+output and appends the cost",
+  );
+  assert.equal(
+    usageSummary({ inputTokens: 500, outputTokens: 480 }, undefined),
+    "980 tok",
+    "cost-less usage shows tokens alone",
+  );
+  assert.equal(usageSummary(undefined, 0.05), "$0.05", "cost without usage still shows");
+  assert.equal(usageSummary(undefined, undefined), null, "no usage, no cost → nothing renders");
+  assert.equal(usageSummary({ inputTokens: 0, outputTokens: 0 }, 0), null, "all-zero usage renders nothing");
+
+  assert.equal(
+    usageBreakdown(
+      { inputTokens: 10200, outputTokens: 2150, cacheReadTokens: 5000, cacheCreationTokens: 1200 },
+      0.0812,
+    ),
+    "input 10200 · output 2150 · cache read 5000 · cache write 1200 · $0.08",
+    "the tooltip breakdown lists every captured counter",
+  );
+  assert.equal(
+    usageBreakdown({ inputTokens: 1, outputTokens: 2 }, 0.004),
+    "input 1 · output 2 · $0.0040",
+    "sub-cent tooltip costs keep precision instead of flooring",
+  );
+  assert.equal(usageBreakdown(undefined, undefined), null);
+}
+
 console.log("harness-routing tests passed");

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -48,6 +48,11 @@ import {
   buildSshSpawnArgs,
   isSshRuntime,
 } from "@/lib/familiar-runtime";
+import {
+  parseCostUsd,
+  parseStreamJsonUsage,
+  type TurnUsage,
+} from "@/lib/usage-format";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -74,7 +79,14 @@ type StreamEvent =
       status?: "running" | "ok" | "error";
       durationMs?: number;
     }
-  | { kind: "done"; durationMs?: number; isError?: boolean; sessionId?: string }
+  | {
+      kind: "done";
+      durationMs?: number;
+      isError?: boolean;
+      sessionId?: string;
+      usage?: TurnUsage;
+      costUsd?: number;
+    }
   | { kind: "error"; message: string; code?: string };
 
 // Hook-line shapes emitted by codex/claude harnesses while a tool runs.
@@ -760,7 +772,12 @@ export async function POST(req: Request) {
       let assistantFilter = new AssistantFilter();
       let assistantText = "";
       let jsonBuf = "";
-      let result: { duration_ms?: number; is_error?: boolean } = {};
+      let result: {
+        duration_ms?: number;
+        is_error?: boolean;
+        usage?: TurnUsage;
+        costUsd?: number;
+      } = {};
       // Tracks open tool calls from both hook lines and stream-json
       // envelopes: per-name FIFO queues give concurrent same-name calls
       // distinct ids, and hook/envelope events describing the same call are
@@ -794,6 +811,8 @@ export async function POST(req: Request) {
               session_id?: string;
               duration_ms?: number;
               is_error?: boolean;
+              total_cost_usd?: number;
+              usage?: unknown;
               message?: {
                 content?: Array<{
                   type?: string;
@@ -822,7 +841,15 @@ export async function POST(req: Request) {
               ).catch(() => undefined);
             }
             if (ev.type === "result") {
-              result = { duration_ms: ev.duration_ms, is_error: ev.is_error };
+              // The result event also carries token usage and total cost
+              // (CHAT-D12-02). Both are optional and defensively validated —
+              // harnesses without billing metadata simply omit them.
+              result = {
+                duration_ms: ev.duration_ms,
+                is_error: ev.is_error,
+                usage: parseStreamJsonUsage(ev.usage),
+                costUsd: parseCostUsd(ev.total_cost_usd),
+              };
             } else if (
               ev.type === "assistant" &&
               Array.isArray(ev.message?.content)
@@ -1080,6 +1107,8 @@ export async function POST(req: Request) {
           durationMs: result.duration_ms,
           isError: result.is_error,
           ...(cancelledByUser ? { cancelled: true } : {}),
+          ...(result.usage ? { usage: result.usage } : {}),
+          ...(result.costUsd !== undefined ? { costUsd: result.costUsd } : {}),
         };
         const conv = existing ?? {
           sessionId: finalSessionId,
@@ -1118,6 +1147,8 @@ export async function POST(req: Request) {
         durationMs: result.duration_ms,
         isError: result.is_error,
         sessionId: finalSessionId ?? undefined,
+        ...(result.usage ? { usage: result.usage } : {}),
+        ...(result.costUsd !== undefined ? { costUsd: result.costUsd } : {}),
       });
       // Best-effort temp cleanup: the harness child process has already
       // exited (including any resume retry), so nothing can still be reading

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -248,4 +248,60 @@ assert.match(
   "Retry pill has always-visible styling — no hover-reveal gating (CHAT-D12-03)",
 );
 
+// ── CHAT-D12-02: per-turn token usage + cost ──
+
+assert.match(
+  source,
+  /kind: "done"; durationMs\?: number; isError\?: boolean; sessionId\?: string; usage\?: TurnUsage; costUsd\?: number/,
+  "The done StreamEvent must carry optional usage and cost fields (CHAT-D12-02)",
+);
+
+assert.match(
+  source,
+  /case "done":[\s\S]*?durationMs: ev\.durationMs,\s*\n\s*usage: ev\.usage,\s*\n\s*costUsd: ev\.costUsd,/,
+  "The done handler must store usage and cost on the settled turn alongside duration (CHAT-D12-02)",
+);
+
+assert.match(
+  source,
+  /durationMs: t\.durationMs,\s*\n\s*usage: t\.usage,\s*\n\s*costUsd: t\.costUsd,/,
+  "History load must map persisted usage and cost back onto turns (CHAT-D12-02)",
+);
+
+assert.match(
+  source,
+  /function UsageText\(\{ usage, costUsd \}[\s\S]*?const summary = usageSummary\(usage, costUsd\);[\s\S]*?if \(!summary\) return null;[\s\S]*?title=\{usageBreakdown\(usage, costUsd\) \?\? undefined\}/,
+  "UsageText renders the compact summary with the full breakdown as tooltip, and nothing when the harness emitted no usage (CHAT-D12-02)",
+);
+
+// The readout lives in the assistant turn's meta row, after the timestamp.
+const usageTurnRow =
+  source.match(/function TurnRow[\s\S]*?\n}\n\nfunction AttachmentLightbox/)?.[0] ?? "";
+assert.ok(usageTurnRow, "TurnRow body should be extractable (CHAT-D12-02)");
+assert.match(
+  usageTurnRow,
+  /fmtTime\(turn\.createdAt\)[\s\S]{0,120}?<UsageText usage=\{turn\.usage\} costUsd=\{turn\.costUsd\} \/>/,
+  "Assistant turn meta row appends the muted usage/cost readout after the timestamp (CHAT-D12-02)",
+);
+
+// MetaLine complete state extends the existing one-liner format:
+// "… · 7s · 12.4k tok · $0.08" — and stays silent when there is no usage.
+assert.match(
+  source,
+  /const dur = fmtDuration\(args\.durationMs\);\s*\n\s*if \(dur\) parts\.push\(dur\);[\s\S]{0,300}?const usage = usageSummary\(args\.usage, args\.costUsd\);\s*\n\s*if \(usage\) parts\.push\(usage\);/,
+  "MetaLine's complete state appends the usage summary after the duration in the same dot-separated format (CHAT-D12-02)",
+);
+
+assert.match(
+  source,
+  /const lastSettledAssistantTurn = useMemo\([\s\S]*?t\.role === "assistant" &&\s*\n\s*!t\.pending/,
+  "The MetaLine readout derives from the latest settled assistant turn (CHAT-D12-02)",
+);
+
+assert.match(
+  source,
+  /durationMs=\{lastSettledAssistantTurn\?\.durationMs\}\s*\n\s*usage=\{lastSettledAssistantTurn\?\.usage\}\s*\n\s*costUsd=\{lastSettledAssistantTurn\?\.costUsd\}/,
+  "ChatView passes the settled turn's duration, usage, and cost into MetaLine together (CHAT-D12-02)",
+);
+
 console.log("chat-view-lifecycle.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -27,6 +27,7 @@ import { VoiceCallButton } from "./voice-call-button";
 import { VoiceCallOverlay } from "./voice-call-overlay";
 import { CsvImportModal } from "./csv-import-modal";
 import { looksLikeCsv } from "@/lib/csv-import";
+import { usageBreakdown, usageSummary, type TurnUsage } from "@/lib/usage-format";
 
 type ToolEvent = {
   id: string;
@@ -68,6 +69,10 @@ type Turn = {
   error?: boolean;
   lifecycle?: ChatTurnLifecycle;
   durationMs?: number;
+  /** Token usage / cost from the harness result event (CHAT-D12-02).
+   *  Absent when the harness emitted none (e.g. the OpenClaw bridge). */
+  usage?: TurnUsage;
+  costUsd?: number;
   origin?: "chat" | "voice";
   voiceCallId?: string;
 };
@@ -103,7 +108,7 @@ type StreamEvent =
   | { kind: "assistant_chunk"; text: string }
   | { kind: "progress"; id?: string; label: string; detail?: string; status?: "running" | "done" | "error"; durationMs?: number }
   | { kind: "tool_use"; id?: string; name: string; input?: string; output?: string; status?: "running" | "ok" | "error"; durationMs?: number }
-  | { kind: "done"; durationMs?: number; isError?: boolean; sessionId?: string }
+  | { kind: "done"; durationMs?: number; isError?: boolean; sessionId?: string; usage?: TurnUsage; costUsd?: number }
   | { kind: "error"; message: string; code?: string };
 
 type ComposerAttachment = ChatAttachment & { id: string };
@@ -184,6 +189,22 @@ function fmtDuration(ms?: number): string | null {
 function DurationText({ durationMs }: { durationMs?: number }) {
   const duration = fmtDuration(durationMs);
   return duration ? <span className="font-mono text-[10px] text-[var(--text-muted)]">{duration}</span> : null;
+}
+
+/** CHAT-D12-02: compact per-turn token/cost readout ("12.4k tok · $0.08")
+ *  with the full breakdown in the tooltip. Renders nothing when the harness
+ *  emitted no usage (e.g. the OpenClaw bridge). */
+function UsageText({ usage, costUsd }: { usage?: TurnUsage; costUsd?: number }) {
+  const summary = usageSummary(usage, costUsd);
+  if (!summary) return null;
+  return (
+    <span
+      className="font-mono text-[10px] text-[var(--text-muted)]"
+      title={usageBreakdown(usage, costUsd) ?? undefined}
+    >
+      {summary}
+    </span>
+  );
 }
 
 function lifecycleLabel(lifecycle: ChatTurnLifecycle): string {
@@ -625,6 +646,8 @@ function metaLineString(args: {
   model?: string;
   projectRoot?: string | null;
   durationMs?: number;
+  usage?: TurnUsage;
+  costUsd?: number;
 }): string {
   const parts: string[] = [];
   if (args.state === "offline") {
@@ -643,6 +666,10 @@ function metaLineString(args: {
     if (repo) parts.push(repo);
     const dur = fmtDuration(args.durationMs);
     if (dur) parts.push(dur);
+    // CHAT-D12-02: "… · 7s · 12.4k tok · $0.08" — absent when the harness
+    // emitted no usage (e.g. the OpenClaw bridge).
+    const usage = usageSummary(args.usage, args.costUsd);
+    if (usage) parts.push(usage);
   }
   return parts.join(" · ");
 }
@@ -671,6 +698,8 @@ function MetaLine({
   error,
   daemonRunning,
   durationMs,
+  usage,
+  costUsd,
   familiar,
   projectRoot,
   onSessionsChanged,
@@ -684,6 +713,8 @@ function MetaLine({
   error: boolean;
   daemonRunning: boolean | undefined;
   durationMs: number | undefined;
+  usage?: TurnUsage;
+  costUsd?: number;
   familiar: Familiar;
   projectRoot?: string;
   onSessionsChanged?: () => void;
@@ -698,6 +729,8 @@ function MetaLine({
     model: familiar.model ?? undefined,
     projectRoot: session?.project_root ?? projectRoot,
     durationMs,
+    usage,
+    costUsd,
   });
   const task = linkedContext?.task ?? null;
   // Same defense-in-depth override as the old headline row: hide a raw
@@ -1029,6 +1062,20 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     const activeTurn = [...turns].reverse().find((turn) => turn.role === "assistant" && turn.pending);
     return activeTurn?.lifecycle ?? (busy ? "connecting" : null);
   }, [busy, turns]);
+  // Latest settled assistant turn feeds the MetaLine's complete-state
+  // one-liner: duration plus token usage / cost (CHAT-D12-02).
+  const lastSettledAssistantTurn = useMemo(
+    () =>
+      [...turns]
+        .reverse()
+        .find(
+          (t) =>
+            t.role === "assistant" &&
+            !t.pending &&
+            (typeof t.durationMs === "number" || t.usage !== undefined || typeof t.costUsd === "number"),
+        ),
+    [turns],
+  );
 
   useEffect(() => {
     setSlashIdx(0);
@@ -1100,6 +1147,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               tools?: ToolEvent[];
               durationMs?: number;
               isError?: boolean;
+              usage?: TurnUsage;
+              costUsd?: number;
               createdAt?: string;
               origin?: "chat" | "voice";
               voiceCallId?: string;
@@ -1121,6 +1170,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   tools?: ToolEvent[];
                   durationMs?: number;
                   isError?: boolean;
+                  usage?: TurnUsage;
+                  costUsd?: number;
                   cancelled?: boolean;
                   createdAt?: string;
                   origin?: "chat" | "voice";
@@ -1135,6 +1186,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   reasoning: t.reasoning,
                   tools: t.tools,
                   durationMs: t.durationMs,
+                  usage: t.usage,
+                  costUsd: t.costUsd,
                   error: t.isError,
                   lifecycle: t.cancelled ? ("cancelled" as const) : undefined,
                   createdAt: t.createdAt ?? new Date().toISOString(),
@@ -1699,6 +1752,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   error: ev.isError ?? false,
                   lifecycle: ev.isError ? "failed" : "complete",
                   durationMs: ev.durationMs,
+                  usage: ev.usage,
+                  costUsd: ev.costUsd,
                   progress: settleRunningProgress(t.progress, ev.isError ? "error" : "done"),
                 }
               : t,
@@ -1931,10 +1986,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           lifecycle={activeLifecycle}
           error={!!error}
           daemonRunning={daemonRunning}
-          durationMs={(() => {
-            const last = [...turns].reverse().find((t) => t.role === "assistant" && !t.pending && typeof t.durationMs === "number");
-            return last?.durationMs;
-          })()}
+          durationMs={lastSettledAssistantTurn?.durationMs}
+          usage={lastSettledAssistantTurn?.usage}
+          costUsd={lastSettledAssistantTurn?.costUsd}
           familiar={familiar}
           projectRoot={projectRoot}
           onSessionsChanged={onSessionsChanged}
@@ -2500,6 +2554,7 @@ function TurnRow({
               </button>
             ) : null}
             {showTimestamp && turn.createdAt ? <span className="opacity-60">{fmtTime(turn.createdAt)}</span> : null}
+            <UsageText usage={turn.usage} costUsd={turn.costUsd} />
           </div>
 
           <div className="cave-linear-turn-body">

--- a/src/lib/cave-conversations.test.ts
+++ b/src/lib/cave-conversations.test.ts
@@ -79,6 +79,59 @@ assert.equal(cancelledTurn?.isError, false, "a user cancel is not an error");
 assert.equal(cancelledTurn?.text, "Roses are red, violets", "partial streamed text must survive the save");
 assert.equal(await deleteConversation("cancelled-turn"), true);
 
+// CHAT-D12-02: per-turn token usage and cost round-trip through the store —
+// optional fields that mirror how durationMs flows, absent when the harness
+// emitted none (e.g. the OpenClaw bridge).
+await saveConversation({
+  sessionId: "usage-turn",
+  familiarId: "charm",
+  harness: "claude",
+  title: "Usage and cost",
+  createdAt: "2026-06-11T00:00:00.000Z",
+  updatedAt: "2026-06-11T00:00:00.000Z",
+  turns: [
+    {
+      id: "turn-user",
+      role: "user",
+      text: "how big was that?",
+      createdAt: "2026-06-11T00:00:00.000Z",
+    },
+    {
+      id: "turn-assistant",
+      role: "assistant",
+      text: "Pretty big.",
+      createdAt: "2026-06-11T00:00:01.000Z",
+      durationMs: 7000,
+      isError: false,
+      usage: {
+        inputTokens: 10200,
+        outputTokens: 2150,
+        cacheReadTokens: 5000,
+        cacheCreationTokens: 1200,
+      },
+      costUsd: 0.0812,
+    },
+    {
+      id: "turn-assistant-no-usage",
+      role: "assistant",
+      text: "No billing metadata here.",
+      createdAt: "2026-06-11T00:00:02.000Z",
+    },
+  ],
+});
+const usageConv = await loadConversation("usage-turn");
+const usageTurn = usageConv?.turns.find((turn) => turn.id === "turn-assistant");
+assert.deepEqual(
+  usageTurn?.usage,
+  { inputTokens: 10200, outputTokens: 2150, cacheReadTokens: 5000, cacheCreationTokens: 1200 },
+  "token usage must round-trip through the store",
+);
+assert.equal(usageTurn?.costUsd, 0.0812, "cost must round-trip through the store");
+const noUsageTurn = usageConv?.turns.find((turn) => turn.id === "turn-assistant-no-usage");
+assert.equal(noUsageTurn?.usage, undefined, "turns without usage stay absent — never fabricated");
+assert.equal(noUsageTurn?.costUsd, undefined, "turns without cost stay absent — never fabricated");
+assert.equal(await deleteConversation("usage-turn"), true);
+
 if (previousHome === undefined) {
   delete process.env.HOME;
 } else {

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -23,6 +23,11 @@ export type ChatTurn = {
   isError?: boolean;
   /** True when the user stopped this response mid-stream (Esc/Stop). */
   cancelled?: boolean;
+  /** Token usage from the harness result event (CHAT-D12-02). Absent when
+   *  the harness emitted none (e.g. the OpenClaw bridge). */
+  usage?: import("./usage-format").TurnUsage;
+  /** Total cost in USD from the harness result event (CHAT-D12-02). */
+  costUsd?: number;
   origin?: "chat" | "voice";
   voiceCallId?: string;
 };

--- a/src/lib/usage-format.ts
+++ b/src/lib/usage-format.ts
@@ -1,0 +1,123 @@
+/**
+ * Token-usage and cost formatting for chat turns (CHAT-D12-02).
+ *
+ * Pure module — shared by the chat/send route (parsing the harness
+ * stream-json `result` event), the conversation store round-trip, and the
+ * chat UI's meta rows. No React, no Node APIs.
+ */
+
+export type TurnUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+};
+
+function finiteNonNegative(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+/** Validated cost from an untrusted number-ish value. Zero is preserved
+ *  (formatCost hides it at render time); negatives/NaN/non-numbers drop. */
+export function parseCostUsd(raw: unknown): number | undefined {
+  return finiteNonNegative(raw);
+}
+
+/** Parse the `usage` object from a Claude Code stream-json `result` event.
+ *  Fields are optional and defensively validated — a malformed or empty
+ *  usage block yields undefined so callers omit it entirely. */
+export function parseStreamJsonUsage(raw: unknown): TurnUsage | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const u = raw as Record<string, unknown>;
+  const inputTokens = finiteNonNegative(u.input_tokens);
+  const outputTokens = finiteNonNegative(u.output_tokens);
+  if (inputTokens === undefined && outputTokens === undefined) return undefined;
+  const cacheReadTokens = finiteNonNegative(u.cache_read_input_tokens);
+  const cacheCreationTokens = finiteNonNegative(u.cache_creation_input_tokens);
+  return {
+    inputTokens: inputTokens ?? 0,
+    outputTokens: outputTokens ?? 0,
+    ...(cacheReadTokens !== undefined ? { cacheReadTokens } : {}),
+    ...(cacheCreationTokens !== undefined ? { cacheCreationTokens } : {}),
+  };
+}
+
+/** Validate a persisted camelCase usage shape (conversation POST/PUT
+ *  round-trip — same defensive posture as the `cancelled` flag). */
+export function normalizeTurnUsage(raw: unknown): TurnUsage | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const u = raw as Record<string, unknown>;
+  const inputTokens = finiteNonNegative(u.inputTokens);
+  const outputTokens = finiteNonNegative(u.outputTokens);
+  if (inputTokens === undefined && outputTokens === undefined) return undefined;
+  const cacheReadTokens = finiteNonNegative(u.cacheReadTokens);
+  const cacheCreationTokens = finiteNonNegative(u.cacheCreationTokens);
+  return {
+    inputTokens: inputTokens ?? 0,
+    outputTokens: outputTokens ?? 0,
+    ...(cacheReadTokens !== undefined ? { cacheReadTokens } : {}),
+    ...(cacheCreationTokens !== undefined ? { cacheCreationTokens } : {}),
+  };
+}
+
+/** Compact token count: 980 → "980", 1234 → "1.2k", 2_500_000 → "2.5M".
+ *  Trailing ".0" is trimmed (1000 → "1k"). Invalid input → null. */
+export function formatTokens(n: number): string | null {
+  if (typeof n !== "number" || !Number.isFinite(n) || n < 0) return null;
+  if (n < 1000) return String(Math.round(n));
+  const scaled = n < 1_000_000 ? n / 1000 : n / 1_000_000;
+  const suffix = n < 1_000_000 ? "k" : "M";
+  // Half-up to one decimal without toFixed's float drift (12350 → "12.4k");
+  // integral results render bare ("1k", not "1.0k").
+  return `${Math.round(scaled * 10) / 10}${suffix}`;
+}
+
+/** "$0.08"; "<$0.01" under a cent; null when zero, undefined, or invalid —
+ *  a turn that cost nothing (or reported nothing) shows nothing. */
+export function formatCost(usd?: number): string | null {
+  if (usd == null || !Number.isFinite(usd) || usd <= 0) return null;
+  if (usd < 0.01) return "<$0.01";
+  return `$${usd.toFixed(2)}`;
+}
+
+/** One-line summary for meta rows: "12.4k tok · $0.08". Tokens are
+ *  input+output summed for the compact form. Null when the harness emitted
+ *  nothing (e.g. the OpenClaw bridge has no usage). */
+export function usageSummary(
+  usage?: TurnUsage,
+  costUsd?: number,
+): string | null {
+  const parts: string[] = [];
+  const total = usage ? usage.inputTokens + usage.outputTokens : 0;
+  if (usage && total > 0) {
+    const tokens = formatTokens(total);
+    if (tokens) parts.push(`${tokens} tok`);
+  }
+  const cost = formatCost(costUsd);
+  if (cost) parts.push(cost);
+  return parts.length ? parts.join(" · ") : null;
+}
+
+/** Full breakdown for tooltips: every captured counter plus a higher-precision
+ *  cost. Null when there is nothing to break down. */
+export function usageBreakdown(
+  usage?: TurnUsage,
+  costUsd?: number,
+): string | null {
+  const parts: string[] = [];
+  if (usage) {
+    parts.push(`input ${usage.inputTokens}`, `output ${usage.outputTokens}`);
+    if (usage.cacheReadTokens !== undefined) {
+      parts.push(`cache read ${usage.cacheReadTokens}`);
+    }
+    if (usage.cacheCreationTokens !== undefined) {
+      parts.push(`cache write ${usage.cacheCreationTokens}`);
+    }
+  }
+  if (costUsd != null && Number.isFinite(costUsd) && costUsd > 0) {
+    parts.push(`$${costUsd.toFixed(costUsd < 0.01 ? 4 : 2)}`);
+  }
+  return parts.length ? parts.join(" · ") : null;
+}


### PR DESCRIPTION
Implements **CHAT-D12-02 (P2)** from the chat UX audit (#395).

## The gap

The chat surface showed no token/cost information anywhere. The send route's stream-json `result` parse kept only `duration_ms`/`is_error` — Claude Code's `result` event also carries `total_cost_usd` and `usage` (input/output/cache tokens), all discarded. The `done` SSE event forwarded duration alone; the MetaLine showed duration alone. Benchmark: Claude Code shows tokens + cost (`/cost`).

## The fix

**Route (`src/app/api/chat/send/route.ts`)**
- The `result` parse now captures `total_cost_usd` and `usage` through defensive validators (`parseStreamJsonUsage` / `parseCostUsd` — fields optional, numbers must be finite and non-negative).
- The `done` StreamEvent gains optional `usage?: TurnUsage` and `costUsd?: number`, omitted entirely when the harness emitted none.
- Both persist on the saved assistant `ChatTurn`, mirroring how `durationMs` flows. The OpenClaw bridge path is untouched — it has no usage, so nothing renders for it.

**Store + round-trip**
- `src/lib/cave-conversations.ts`: optional `usage` / `costUsd` turn fields.
- `src/app/api/chat/conversation/[id]/route.ts`: POST/PUT `normalizeTurn` round-trips the new fields (same posture as the #416 `cancelled` flag); GET returns stored JSON so it flows automatically.

**UI (`src/components/chat-view.tsx`)**
- The `done` handler stores usage/cost on the settled turn; history load maps them back.
- Assistant turn meta row appends a muted, compact readout after the timestamp — `12.4k tok · $0.08` (tokens = input+output summed), with the full breakdown (input/output/cache read/cache write, higher-precision cost) in the tooltip.
- MetaLine complete state extends the existing one-liner: `claude · sonnet · repo · 7s · 12.4k tok · $0.08`, derived from the latest settled assistant turn.
- Hidden entirely when there is no usage and no cost.

**New pure lib (`src/lib/usage-format.ts`)**
- `formatTokens(n)`: `980` → `"980"`, `1234` → `"1.2k"`, `2_500_000` → `"2.5M"`, half-up rounding without float drift.
- `formatCost(usd)`: `"$0.08"`; `"<$0.01"` under a cent; absent when 0/undefined/invalid.
- `usageSummary` / `usageBreakdown` builders plus the snake_case (stream-json) and camelCase (persisted) validators shared by both routes.

**Debug pane**: no edits needed — its bundle export serializes ChatView turns directly, so the new fields appear in exported debug bundles for free.

## Tests

- `harness-routing.test.ts`: source pins for the result-parse capture, done-event fields, and turn persistence; behavioral coverage for thresholds, sub-cent floor, zero/absent states, and defensive parsing.
- `cave-conversations.test.ts`: usage/cost store round-trip; absent fields stay absent.
- `chat-view-lifecycle.test.ts`: done-handler storage, history mapping, turn meta-row render, MetaLine one-liner pins.
- Full `pnpm test:api`, `pnpm test:app`, and `pnpm typecheck` pass. Existing pins (#416 abort guards, #418 tracker wiring, #420 retry, chat-view-polish's no-per-turn-duration pin) all kept green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)