### PR TITLE
fix(chat): address late review feedback

### DIFF
--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -210,6 +210,11 @@ assert.equal(
   ["+++ b/new.ts", "+alpha", "+beta"].join("\n"),
   "Write content renders as all-plus lines without a phantom trailing row",
 );
+assert.equal(
+  toolInputAsDiff("Write", JSON.stringify({ file_path: "empty.ts", content: "" })),
+  "+++ b/empty.ts",
+  "Empty Write content renders only the file header, not a phantom + row",
+);
 
 // MultiEdit → one @@-labelled hunk per edit, concatenated.
 const multi = toolInputAsDiff(

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -161,6 +161,16 @@ assert.match(
   /if \(q\.length < 2\) \{\s*\n\s*setContentHits\(\[\]\);\s*\n\s*setContentLoading\(false\);/,
   "Queries under 2 chars must clear content hits instead of fetching",
 );
+assert.match(
+  source,
+  /const controller = new AbortController\(\);\s*\n\s*setContentHits\(\[\]\);\s*\n\s*setContentLoading\(true\);/,
+  "Starting a new content-search request must clear prior hits during debounce",
+);
+assert.match(
+  source,
+  /if \(!controller\.signal\.aborted\) \{\s*\n\s*setContentHits\(\[\]\);\s*\n\s*setContentLoading\(false\);\s*\n\s*\}/,
+  "Non-abort content-search failures must clear stale hits",
+);
 
 // Title-filtered rows stay primary: sessions already visible by title match
 // are deduped out of the content section, and hits resolve against the

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -231,6 +231,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
       return;
     }
     const controller = new AbortController();
+    setContentHits([]);
     setContentLoading(true);
     const timer = window.setTimeout(async () => {
       try {
@@ -244,7 +245,10 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
         setContentLoading(false);
       } catch {
         // aborted retype or network hiccup — a newer effect owns the state
-        if (!controller.signal.aborted) setContentLoading(false);
+        if (!controller.signal.aborted) {
+          setContentHits([]);
+          setContentLoading(false);
+        }
       }
     }, 300);
     return () => {

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -93,10 +93,12 @@ for (const [name, src] of [
     /role="option"[\s\S]{0,200}?<button\s+type="button"\s+tabIndex=\{-1\}/,
     `${name} option buttons must be out of the tab order — focus stays in the textarea, aria-activedescendant conveys selection`,
   );
+  assert.match(src, /aria-autocomplete="list"/, `${name} composer textarea should expose list autocomplete`);
+  assert.match(src, /aria-haspopup="listbox"/, `${name} composer textarea should advertise the listbox popup`);
   assert.match(
     src,
-    /aria-autocomplete="list"\s+aria-haspopup="listbox"\s+aria-expanded=\{slashSuggestions\.length > 0\}/,
-    `${name} composer textarea should expose listbox popup semantics with aria-expanded tracking the open menu`,
+    /aria-expanded=\{slashSuggestions\.length > 0\}/,
+    `${name} composer textarea should track whether the slash menu is open`,
   );
   assert.doesNotMatch(
     src,

--- a/src/lib/cave-conversations.test.ts
+++ b/src/lib/cave-conversations.test.ts
@@ -116,6 +116,16 @@ assert.equal(await deleteConversation("cancelled-turn"), true);
     fixture("search-miss", "2026-06-11T02:00:00.000Z", ["nothing relevant here"]),
     "utf8",
   );
+  await writeFile(
+    path.join(CONV_DIR, "same-date-a.json"),
+    fixture("same-date-a", "2026-06-11T03:00:00.000Z", ["same timestamp match"]),
+    "utf8",
+  );
+  await writeFile(
+    path.join(CONV_DIR, "same-date-b.json"),
+    fixture("same-date-b", "2026-06-11T03:00:00.000Z", ["same timestamp match"]),
+    "utf8",
+  );
   await writeFile(path.join(CONV_DIR, "search-corrupt.json"), "{ not json", "utf8");
 
   // Body match → one hit per conversation, with snippet + match count;
@@ -130,6 +140,13 @@ assert.equal(await deleteConversation("cancelled-turn"), true);
 
   // No match → empty; never an error.
   assert.deepEqual(await searchConversations("zanzibar"), []);
+
+  const sameDateHits = await searchConversations("same timestamp", { limit: 2 });
+  assert.deepEqual(
+    sameDateHits.map((h) => h.sessionId),
+    ["same-date-a", "same-date-b"],
+    "equal updatedAt values keep deterministic filename order",
+  );
 
   // Min query length 2 (whitespace doesn't count).
   assert.deepEqual(await searchConversations("k"), []);

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -235,7 +235,11 @@ export async function searchConversations(
     }
   }
 
-  hits.sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1));
+  hits.sort((a, b) => {
+    if (a.updatedAt < b.updatedAt) return 1;
+    if (a.updatedAt > b.updatedAt) return -1;
+    return a.sessionId.localeCompare(b.sessionId);
+  });
   return hits.slice(0, limit).map(({ updatedAt: _updatedAt, ...hit }) => hit);
 }
 

--- a/src/lib/tool-input-diff.ts
+++ b/src/lib/tool-input-diff.ts
@@ -32,6 +32,7 @@ function filePathOf(record: Rec): string {
 function prefixLines(text: string, prefix: "+" | "-"): string[] {
   // A trailing newline would otherwise render a spurious empty +/- row.
   const body = text.endsWith("\n") ? text.slice(0, -1) : text;
+  if (!body) return [];
   return body.split("\n").map((line) => `${prefix}${line}`);
 }
 


### PR DESCRIPTION
## Summary
- clear stale content-search hits when a new query starts or a non-abort failure occurs
- make conversation search ordering deterministic when timestamps match
- avoid phantom diff rows for empty mutation tool content
- make slash textarea ARIA source assertions order-independent

## Verification
- node --experimental-strip-types src/components/chat-list-delete.test.ts
- node --experimental-strip-types src/lib/cave-conversations.test.ts
- node --experimental-strip-types src/components/chat-header-row.test.ts
- node --experimental-strip-types src/components/home-composer.test.ts
- pnpm test:app
- pnpm typecheck