### PR TITLE
fix(chat): sticky code headers, height clamp, copy without data-code duplication

### DIFF
--- a/src/components/message-bubble-code-header.test.ts
+++ b/src/components/message-bubble-code-header.test.ts
@@ -36,12 +36,14 @@ assert.match(
 
 // ---------------------------------------------------------------------------
 // Copy buttons must be WIRED, not just rendered. renderCodeBlock emits the
-// <button class="cave-copy-btn" data-code> markup, but the click handler only
-// attaches via wireCopyButtons after the HTML lands in the DOM. Every
-// component that injects this HTML (MarkdownContent, SyntaxBlock,
+// <button class="cave-copy-btn cave-copy-btn-mounted"> markup, but the click
+// handler only attaches via wireCopyButtons after the HTML lands in the DOM.
+// Every component that injects this HTML (MarkdownContent, SyntaxBlock,
 // MarkdownBlock) must run the post-render wiring — otherwise Copy silently
 // does nothing in tool blocks, the inspector pane, comux previews, and the
 // markdown expand modal (audit finding CHAT-D7-01).
+// (Stale #398-era note removed: the buttons no longer carry a data-code
+// attribute — see the CHAT-D7-04 pins below.)
 // ---------------------------------------------------------------------------
 
 const source = await readFile(new URL("./message-bubble.tsx", import.meta.url), "utf8");
@@ -206,3 +208,111 @@ for (const selector of [".cave-code-wrap", ".cave-bubble-system"]) {
     `${selector} surface must not mix with theme backgrounds`,
   );
 }
+
+// ---------------------------------------------------------------------------
+// CHAT-D7-02 — the code-block header must be sticky inside the block's own
+// scroll container, so the language label and Copy button stay reachable on
+// long blocks (benchmarks: ChatGPT/Cursor). Sticking against page scroll
+// would be a no-op: the wrap clips overflow, so the wrap itself must be the
+// scroll container (see CHAT-D7-03 below) and the header sticks to its top.
+// ---------------------------------------------------------------------------
+
+const headerBlock = ruleBlock(".cave-code-header");
+assert.match(headerBlock, /position:\s*sticky/, "Code-block header must be sticky");
+assert.match(headerBlock, /top:\s*0/, "Sticky header must pin to the top of the wrap's scroll viewport");
+assert.match(headerBlock, /z-index:\s*1/, "Sticky header must layer above the code lines it scrolls over");
+
+// ---------------------------------------------------------------------------
+// CHAT-D7-03 — huge blocks must not dominate the transcript. The wrap clamps
+// to min(60vh, 520px) with inner vertical scroll (the system bubble's 320px
+// cap is the in-repo precedent); blocks shorter than the cap are unaffected.
+// A "Show more" footer (emitted only on blocks tall enough to clamp) lifts
+// the cap via the --expanded class, toggled by the same delegated wiring as
+// the copy buttons.
+// ---------------------------------------------------------------------------
+
+const wrapBlock = ruleBlock(".cave-code-wrap");
+assert.match(
+  wrapBlock,
+  /max-height:\s*min\(60vh,\s*520px\)/,
+  "Code-block wrap must clamp its height so huge blocks don't dominate the transcript",
+);
+assert.match(wrapBlock, /overflow-y:\s*auto/, "Clamped wrap must scroll vertically (it is the sticky header's container)");
+assert.match(wrapBlock, /overflow-x:\s*hidden/, "Wrap must keep clipping horizontally — the inner <pre> owns x-scroll");
+assert.match(
+  ruleBlock(".cave-code-wrap--expanded"),
+  /max-height:\s*none/,
+  "The expanded state must lift the height clamp",
+);
+
+const renderCodeBlockFn = /async function renderCodeBlock\([\s\S]*?\n\}/.exec(source)?.[0] ?? "";
+assert.match(
+  renderCodeBlockFn,
+  /cave-code-expand-btn/,
+  "renderCodeBlock must emit the Show more footer button for clamp-height blocks",
+);
+assert.match(
+  source,
+  /CODE_EXPAND_MIN_LINES/,
+  "The expand footer must only be emitted for blocks tall enough to actually clamp",
+);
+
+const wireFn = /function wireCopyButtons\([\s\S]*?\n\}/.exec(source)?.[0] ?? "";
+assert.match(
+  wireFn,
+  /cave-code-expand-btn/,
+  "wireCopyButtons must wire the expand toggle alongside the copy buttons",
+);
+assert.match(
+  wireFn,
+  /cave-code-wrap--expanded/,
+  "The expand toggle must flip the --expanded class on the wrap",
+);
+
+// ---------------------------------------------------------------------------
+// CHAT-D7-04 — no data-code duplication. renderCodeBlock used to copy every
+// block's full source into a data-code attribute (via SyntaxBlock that meant
+// whole tool outputs and file previews twice in memory, as giant DOM
+// attributes). The Copy buttons now read the code text out of the rendered
+// DOM at click time: .cave-line rows joined with "\n", with the aria-hidden
+// .cave-ln line-number spans stripped first (textContent WOULD include
+// them). Byte-parity with the old data-code path was verified for plain,
+// line-numbered, diff, entity-heavy and trailing-newline blocks.
+// (Updated #398-era pins: wireCopyButtons used to select
+// ".cave-copy-btn[data-code]" — it now selects ".cave-copy-btn-mounted".)
+// ---------------------------------------------------------------------------
+
+assert.doesNotMatch(
+  source,
+  /data-code=/,
+  "renderCodeBlock must not duplicate block source into a data-code attribute",
+);
+assert.doesNotMatch(
+  source,
+  /dataset\.code/,
+  "Copy wiring must not read from the removed data-code attribute",
+);
+assert.match(
+  wireFn,
+  /cave-copy-btn-mounted/,
+  "wireCopyButtons must select the injected header buttons by their mounted class (React bubble buttons wire their own onClick)",
+);
+assert.match(wireFn, /codeTextFromWrap/, "Copy clicks must read the code text from the DOM at click time");
+
+const codeTextFn = /function codeTextFromWrap\([\s\S]*?\n\}/.exec(source)?.[0] ?? "";
+assert.match(
+  codeTextFn,
+  /closest\("\.cave-code-wrap"\)/,
+  "Click-time extraction must scope to the button's own code block",
+);
+assert.match(codeTextFn, /cloneNode/, "Extraction must clone line rows before stripping line numbers");
+assert.match(
+  codeTextFn,
+  /\.cave-ln/,
+  "Extraction must strip .cave-ln line-number spans (aria-hidden, but included by textContent)",
+);
+assert.match(
+  codeTextFn,
+  /join\("\\n"\)/,
+  'Line rows carry no newline text nodes — extraction must rejoin them with "\\n"',
+);

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -101,6 +101,16 @@ function parseFenceInfo(info: string): { lang: string; filename?: string } {
 // Render a single code block with Shiki + chrome
 // ---------------------------------------------------------------------------
 
+/**
+ * Blocks at/above this many lines get a "Show more" footer (CHAT-D7-03).
+ * Tuned to the CSS clamp on .cave-code-wrap (max-height: min(60vh, 520px)):
+ * at 12px mono / 1.6em rows plus header + footer + pre padding, 24 lines is
+ * the first count guaranteed to overflow the 520px cap, so the toggle never
+ * appears on a block that has nothing to expand. Shorter blocks on short
+ * viewports (60vh < 520px) may still clip — inner scroll covers those.
+ */
+const CODE_EXPAND_MIN_LINES = 24;
+
 async function renderCodeBlock(
   code: string,
   info: string,
@@ -158,9 +168,15 @@ async function renderCodeBlock(
   const filenameHtml = filename
     ? `<span class="cave-code-filename">${escHtml(filename)}</span>`
     : "";
-  const headerHtml = `<div class="cave-code-header">${labelHtml}${filenameHtml}<button type="button" class="cave-copy-btn cave-copy-btn-mounted" data-code="${escAttr(code)}">Copy</button></div>`;
+  // No data-code attribute (CHAT-D7-04): wireCopyButtons reads the code text
+  // back out of the rendered DOM at click time instead of carrying a second
+  // copy of every block's source in an attribute.
+  const headerHtml = `<div class="cave-code-header">${labelHtml}${filenameHtml}<button type="button" class="cave-copy-btn cave-copy-btn-mounted">Copy</button></div>`;
+  const expandHtml = lines.length >= CODE_EXPAND_MIN_LINES
+    ? `<div class="cave-code-expand"><button type="button" class="cave-code-expand-btn">Show more</button></div>`
+    : "";
 
-  return `<div class="cave-code-wrap">${headerHtml}${lineWrapped}</div>`;
+  return `<div class="cave-code-wrap">${headerHtml}${lineWrapped}${expandHtml}</div>`;
 }
 
 // ---------------------------------------------------------------------------
@@ -276,10 +292,6 @@ function escHtml(s: string): string {
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#039;");
 }
-function escAttr(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
-}
-
 // ---------------------------------------------------------------------------
 // Render markdown to HTML (async, Shiki per code block)
 // ---------------------------------------------------------------------------
@@ -494,17 +506,48 @@ async function mdToHtml(markdown: string, opts?: { transient?: boolean }): Promi
 }
 
 // ---------------------------------------------------------------------------
-// Post-render: wire copy buttons in DOM
+// Post-render: wire copy + expand buttons in DOM
 // ---------------------------------------------------------------------------
 
+/**
+ * Click-time code extraction (CHAT-D7-04). The block's full source used to be
+ * duplicated into a `data-code` attribute on every Copy button — double the
+ * memory and a giant DOM attribute for big tool outputs / file previews (the
+ * SyntaxBlock path). Instead, read the text back out of the rendered block:
+ * line rows are `.cave-line` spans with no newline text nodes between them,
+ * so reconstruct with join("\n"); `.cave-ln` line-number spans are
+ * presentation-only (aria-hidden, user-select: none) and must be excluded —
+ * textContent WOULD include them, hence the clone-and-strip. Diff +/- line
+ * prefixes are real token text and copy as-is, matching the old behavior of
+ * copying the raw fence content. Byte-parity with the old data-code path was
+ * verified for plain, line-numbered, diff, entity-heavy, empty-interior-line
+ * and trailing-newline blocks.
+ */
+function codeTextFromWrap(btn: HTMLElement): string {
+  const codeEl = btn.closest(".cave-code-wrap")?.querySelector("pre code");
+  if (!codeEl) return "";
+  const lineEls = Array.from(codeEl.querySelectorAll(".cave-line"));
+  // Shiki-failure fallback renders a plain <pre><code> without line rows.
+  if (lineEls.length === 0) return codeEl.textContent ?? "";
+  return lineEls
+    .map((line) => {
+      const clone = line.cloneNode(true) as HTMLElement;
+      for (const ln of Array.from(clone.querySelectorAll(".cave-ln"))) ln.remove();
+      return clone.textContent ?? "";
+    })
+    .join("\n");
+}
+
 function wireCopyButtons(container: HTMLElement) {
-  for (const btn of Array.from(container.querySelectorAll<HTMLButtonElement>(".cave-copy-btn[data-code]"))) {
+  // Only the injected-HTML header buttons (.cave-copy-btn-mounted) need
+  // wiring — the React-rendered bubble copy/expand buttons carry their own
+  // onClick handlers and props.
+  for (const btn of Array.from(container.querySelectorAll<HTMLButtonElement>(".cave-copy-btn-mounted"))) {
     if ((btn as HTMLButtonElement & { _wired?: boolean })._wired) continue;
     (btn as HTMLButtonElement & { _wired?: boolean })._wired = true;
-    const code = btn.dataset.code ?? "";
     let timer: ReturnType<typeof setTimeout> | null = null;
     btn.addEventListener("click", () => {
-      navigator.clipboard.writeText(code).catch(() => undefined);
+      navigator.clipboard.writeText(codeTextFromWrap(btn)).catch(() => undefined);
       btn.textContent = "Copied";
       btn.classList.add("cave-copy-btn--confirmed");
       if (timer) clearTimeout(timer);
@@ -512,6 +555,20 @@ function wireCopyButtons(container: HTMLElement) {
         btn.textContent = "Copy";
         btn.classList.remove("cave-copy-btn--confirmed");
       }, 2000);
+    });
+  }
+  // Show more / Show less footer on height-clamped blocks (CHAT-D7-03).
+  for (const btn of Array.from(container.querySelectorAll<HTMLButtonElement>(".cave-code-expand-btn"))) {
+    if ((btn as HTMLButtonElement & { _wired?: boolean })._wired) continue;
+    (btn as HTMLButtonElement & { _wired?: boolean })._wired = true;
+    btn.addEventListener("click", () => {
+      const wrap = btn.closest(".cave-code-wrap");
+      if (!wrap) return;
+      const expanded = wrap.classList.toggle("cave-code-wrap--expanded");
+      btn.textContent = expanded ? "Show less" : "Show more";
+      // Collapsing from deep in a long block would otherwise leave the
+      // clamped viewport scrolled to an arbitrary middle.
+      if (!expanded) wrap.scrollTop = 0;
     });
   }
 }

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -216,15 +216,43 @@
   box-shadow:
     0 1px 3px oklch(0 0 0 / 30%),
     inset 0 1px 0 oklch(0.985 0 0 / 4%);
-  overflow: hidden;
+  /* CHAT-D7-03: the wrap is the block's vertical scroll container — huge
+     blocks clamp instead of dominating the transcript (cf. the system
+     bubble's 320px cap; benchmark: Claude Code truncates long blocks).
+     520px reads as ~24 code lines against the 920px thread measure.
+     overflow-x stays hidden: the inner <pre> owns horizontal scrolling,
+     and the wrap must keep clipping its rounded corners. */
+  max-height: min(60vh, 520px);
+  overflow-x: hidden;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in oklch, var(--accent-presence) 20%, transparent) transparent;
   font-size: 12px;
   margin: 0.6em 0;
+}
+
+/* "Show more" lifts the clamp (toggled by wireCopyButtons' expand wiring). */
+.cave-code-wrap--expanded {
+  max-height: none;
+}
+
+.cave-code-wrap::-webkit-scrollbar { width: 4px; }
+.cave-code-wrap::-webkit-scrollbar-track { background: transparent; }
+.cave-code-wrap::-webkit-scrollbar-thumb {
+  background: color-mix(in oklch, var(--accent-presence) 22%, transparent);
+  border-radius: 2px;
 }
 
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    CODE BLOCK HEADER
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
 .cave-code-header {
+  /* CHAT-D7-02: stick to the top of the wrap's scroll viewport so the lang
+     label + Copy stay reachable on long blocks (benchmark: ChatGPT/Cursor).
+     Legible while stuck thanks to the near-opaque surface (CHAT-D13-01). */
+  position: sticky;
+  top: 0;
+  z-index: 1;
   display: flex;
   align-items: center;
   gap: 0.5em;
@@ -430,6 +458,42 @@
   align-items: center;
   justify-content: center;
   padding: 3px 5px;
+}
+
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   EXPAND FOOTER (CHAT-D7-03) — emitted only on blocks tall enough to clamp;
+   sticks to the bottom of the wrap's scroll viewport like the header sticks
+   to its top. Fixed dark chrome inks (CHAT-D13-01), no theme ink.
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+.cave-code-expand {
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+  display: flex;
+  justify-content: center;
+  padding: 0.25em 0.75em;
+  background: oklch(0.16 0.015 280 / 92%);
+  border-top: 1px solid var(--border-hairline);
+  backdrop-filter: blur(4px);
+}
+
+.cave-code-expand-btn {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  padding: 0.2em 0.8em;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--code-chrome-ink-faint);
+  cursor: pointer;
+  transition: color 0.1s;
+  line-height: 1.4;
+}
+
+.cave-code-expand-btn:hover,
+.cave-code-expand-btn:focus-visible {
+  color: var(--code-chrome-ink);
 }
 
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### PR DESCRIPTION
Implements chat UX audit findings **CHAT-D7-02**, **CHAT-D7-03**, **CHAT-D7-04** (all P2) from the chat UX audit (#395).

## CHAT-D7-02 — sticky code-block header
`.cave-code-header` is now `position: sticky; top: 0; z-index: 1` inside the block's own scroll container, so the language label and Copy button stay reachable while scrolling a long block (benchmarks: ChatGPT/Cursor). Sticking against page scroll was a no-op (`.cave-code-wrap` clips overflow), so the wrap itself becomes the scroll container — see D7-03. The near-opaque chrome surface from #425 keeps the stuck header legible.

## CHAT-D7-03 — height clamp + Show more
`.cave-code-wrap` clamps to `max-height: min(60vh, 520px)` (~24 code lines against the 920px thread measure; in-repo precedent: the system bubble's 320px cap) with inner vertical scroll. Blocks shorter than the cap are unaffected. Blocks of ≥ 24 lines — the first line count guaranteed to overflow the cap, so the toggle never appears on a block with nothing to expand — get a sticky-bottom **Show more / Show less** footer that toggles a `--expanded` class via the same delegated `wireCopyButtons` wiring (per-button `_wired` idempotence) used for copy. Collapsing resets the inner scroll to the top.

## CHAT-D7-04 — drop `data-code` source duplication
`renderCodeBlock` no longer emits `data-code="<entire source>"` on every Copy button — via `SyntaxBlock` that meant whole tool outputs and file previews held twice (DOM attribute + rendered text). Copy now reads the code back from the DOM at click time (`codeTextFromWrap`): `.cave-line` rows joined with `"\n"` (the rows carry no newline text nodes), with the aria-hidden `.cave-ln` line-number spans clone-and-stripped first — `textContent` *would* include them. One change covers all injectors (MarkdownContent / SyntaxBlock / MarkdownBlock share `useWireCopyButtons`).

**Copy byte-parity verification:** the old path copied the raw fence content from the attribute. The new DOM read was verified byte-identical against real Shiki output (scratch harness replicating the exact line-wrap transform + a faithful `textContent` simulation) for: plain short blocks (no line numbers), line-numbered blocks (>5 lines), diff blocks (+/- prefixes are real token text and copy as-is), entity-heavy code (`&`, `<`, quotes, literal `&amp;`), empty interior lines, trailing newline (Shiki emits an empty final line span, so the join restores it), 500-line blocks, and tabs/unicode — 8/8 byte-identical. The Shiki-failure fallback (`<pre><code>` without line rows) falls back to plain `textContent`. React-rendered bubble Copy/Expand buttons take props and wire their own `onClick` — untouched.

## Tests
- Extended `message-bubble-code-header.test.ts`: sticky header pins, clamp + overflow pins, `--expanded` lift, expand-footer emission + wiring pins, `data-code=`/`dataset.code` absence, click-time DOM extraction with `.cave-ln` exclusion. Updated the stale #398-era comment that described the `data-code` markup; all pre-existing #425 pins (traffic lights, copy-btn order/margin, `--code-chrome-*` inks, near-opaque surfaces) stay green.
- `message-bubble-markdown.test.ts` untouched and green.
- Full `pnpm test:app` green; `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)