### PR TITLE
feat(chat): in-transcript find with turn-level jump

### DIFF
--- a/src/components/chat-router-switching.test.ts
+++ b/src/components/chat-router-switching.test.ts
@@ -151,4 +151,181 @@ assert.match(
   "Popstate should clear stale chat hashes and return to the list when the target session is missing",
 );
 
+// ── CHAT-D9-04: in-transcript find (turn-level jump + count) ─────────────────
+// The find bar lives in ChatView's header meta line; matching is turn-level
+// (case-insensitive substring over visible text) via the pure helper in
+// src/lib/transcript-find.ts. Intra-turn highlighting is deferred.
+
+const chatViewSource = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const chatCssSource = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
+
+// 1. Behavioral: the pure turn-level match helper.
+const { findMatchingTurnIds } = await import("../lib/transcript-find.ts");
+
+assert.deepEqual(
+  findMatchingTurnIds(
+    [
+      { id: "a", text: "Deploy the staging build" },
+      { id: "b", text: "nothing relevant here" },
+      { id: "c", text: "redeploy after the fix" },
+    ],
+    "DEPLOY",
+  ),
+  ["a", "c"],
+  "findMatchingTurnIds must be a case-insensitive substring match over turn text, in transcript order",
+);
+
+assert.deepEqual(
+  findMatchingTurnIds([{ id: "a", text: "anything" }], "   "),
+  [],
+  "A blank/whitespace query must match zero turns — not every turn via the empty substring",
+);
+
+assert.deepEqual(
+  findMatchingTurnIds([], "query"),
+  [],
+  "An empty transcript has no matches",
+);
+
+// 2. The find bar renders in the header meta line with n/m count and
+//    prev/next navigation carrying aria-labels.
+assert.match(
+  chatViewSource,
+  /<MetaLine[\s\S]*?<ChatFindBar[\s\S]*?<\/MetaLine>/,
+  "ChatFindBar must render inside the header MetaLine row so rename/voice/debug/delete actions stay put",
+);
+
+assert.match(
+  chatViewSource,
+  /\$\{activeIndex \+ 1\} \/ \$\{matchCount\}/,
+  "The find bar must show a 1-based `n / m` matching-turn count",
+);
+
+assert.match(
+  chatViewSource,
+  /aria-label="Previous match"/,
+  "Prev navigation needs an aria-label",
+);
+
+assert.match(
+  chatViewSource,
+  /aria-label="Next match"/,
+  "Next navigation needs an aria-label",
+);
+
+assert.match(
+  chatViewSource,
+  /aria-label="Find in conversation"/,
+  "The collapsed search toggle needs an aria-label",
+);
+
+// 3. ⌘F is scoped to the chat section root — a React keydown handler with
+//    preventDefault, NOT a window-level listener (ChatList's ⌘F session
+//    search and browser-native find elsewhere must keep working).
+const sectionKeyHandler =
+  chatViewSource.match(/const onChatSectionKeyDown = useCallback\([\s\S]*?\[openFind\],\s*\);/)?.[0] ?? "";
+
+assert.ok(
+  sectionKeyHandler.length > 0,
+  "ChatView should define onChatSectionKeyDown for section-scoped find activation",
+);
+
+assert.match(
+  sectionKeyHandler,
+  /\(e\.metaKey \|\| e\.ctrlKey\)[\s\S]*?e\.key\.toLowerCase\(\) === "f"[\s\S]*?e\.preventDefault\(\)/,
+  "⌘F/Ctrl+F inside the chat section must preventDefault (suppress browser find) and open the find bar",
+);
+
+assert.match(
+  chatViewSource,
+  /<section[\s\S]{0,200}onKeyDown=\{onChatSectionKeyDown\}/,
+  "The keydown handler must sit on the chat section root so it only fires while focus is inside the chat",
+);
+
+assert.doesNotMatch(
+  chatViewSource,
+  /window\.addEventListener\(["']keydown["']/,
+  "Find must NOT register a window-level keydown listener — that would shadow ChatList's ⌘F and browser find elsewhere",
+);
+
+// 4. Navigating to a match releases the streaming follow-pin (CHAT-D10-01)
+//    so the next SSE chunk doesn't yank the reader back to the bottom, and
+//    the jump itself is instant (behavior: "auto" — reduced-motion-safe).
+const jumpFn =
+  chatViewSource.match(/const jumpToFindMatch = useCallback\([\s\S]*?\[updateFollowing\],\s*\);/)?.[0] ?? "";
+
+assert.ok(jumpFn.length > 0, "ChatView should define jumpToFindMatch");
+
+assert.match(
+  jumpFn,
+  /if \(followingRef\.current\) updateFollowing\(false\);/,
+  "A find jump must release the follow-pin before scrolling",
+);
+
+assert.match(
+  jumpFn,
+  /scrollIntoView\(\{ block: "center", behavior: "auto" \}\)/,
+  "Find jumps must scroll instantly (behavior: \"auto\") and center the matching turn",
+);
+
+assert.match(
+  jumpFn,
+  /data-turn-id/,
+  "Jump targeting should resolve the turn row via its data-turn-id attribute",
+);
+
+// 5. Turn rows expose stable DOM ids for scroll targeting in BOTH branches
+//    (user/system and assistant).
+assert.equal(
+  (chatViewSource.match(/data-turn-id=\{turn\.id\}/g) ?? []).length,
+  2,
+  "Both TurnRow render branches must stamp data-turn-id",
+);
+
+// 6. The Esc layering is self-contained: the find input stops propagation so
+//    closing find never reaches the composer's Esc handling, and Enter /
+//    Shift+Enter cycle next/prev.
+const findBarComponent =
+  chatViewSource.match(/function ChatFindBar\(\{[\s\S]*?\nfunction ChatBackButton/)?.[0] ?? "";
+
+assert.match(
+  findBarComponent,
+  /e\.key === "Escape"[\s\S]*?e\.stopPropagation\(\);[\s\S]*?onClose\(\)/,
+  "Esc in the find input must close the bar without bubbling into composer Esc layering",
+);
+
+assert.match(
+  findBarComponent,
+  /e\.key === "Enter"[\s\S]*?if \(e\.shiftKey\) onPrev\(\);\s*else onNext\(\);/,
+  "Enter = next match, Shift+Enter = prev match in the find input",
+);
+
+// 7. Matching is debounced and turn-level over VISIBLE text only (reasoning
+//    is excluded; assistant inline <thinking> blocks are split out first).
+assert.match(
+  chatViewSource,
+  /setTimeout\(\(\) => setFindDebouncedQuery\(findQuery\), 150\)/,
+  "Query matching should be debounced ~150ms",
+);
+
+assert.match(
+  chatViewSource,
+  /t\.role === "assistant" \? splitReasoning\(t\.text\)\.visible : t\.text/,
+  "Find must match the VISIBLE transcript text — never turn.reasoning or unsplit thinking blocks",
+);
+
+// 8. Highlight CSS: temporary cave-turn-found flash with reduced-motion
+//    safety (explicit static fallback on top of the global kill switch).
+assert.match(
+  chatCssSource,
+  /\.cave-turn-found \{\s*animation: cave-turn-found-fade 1\.5s/,
+  "The landing turn gets a one-shot 1.5s cave-turn-found fade",
+);
+
+assert.match(
+  chatCssSource,
+  /@media \(prefers-reduced-motion: reduce\) \{\s*\.cave-turn-found \{\s*animation: none;/,
+  "cave-turn-found must disable its animation under prefers-reduced-motion (static tint instead)",
+);
+
 console.log("chat-router-switching.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -30,6 +30,7 @@ import { looksLikeCsv } from "@/lib/csv-import";
 import { usageBreakdown, usageSummary, type TurnUsage } from "@/lib/usage-format";
 import { toolArgSummary } from "@/lib/tool-arg-summary";
 import { toolInputAsDiff } from "@/lib/tool-input-diff";
+import { findMatchingTurnIds } from "@/lib/transcript-find";
 
 type ToolEvent = {
   id: string;
@@ -676,6 +677,121 @@ function metaLineString(args: {
   return parts.join(" · ");
 }
 
+/** In-transcript find bar (CHAT-D9-04). Collapsed: a search icon button in
+ *  the meta line. Expanded: query input + `n / m` matching-TURN count +
+ *  prev/next/close, styled to extend the meta line without displacing the
+ *  rename/voice/debug/delete actions. Esc layering is self-contained: the
+ *  input's own onKeyDown stops propagation so closing find never reaches the
+ *  composer's Esc handling (slash dismiss / stream cancel). */
+function ChatFindBar({
+  open,
+  query,
+  activeIndex,
+  matchCount,
+  focusNonce,
+  onOpen,
+  onClose,
+  onQueryChange,
+  onNext,
+  onPrev,
+}: {
+  open: boolean;
+  query: string;
+  /** 0-based index of the active match; rendered 1-based. */
+  activeIndex: number;
+  matchCount: number;
+  /** Bumped on every section-level ⌘F so an already-open bar refocuses. */
+  focusNonce: number;
+  onOpen: () => void;
+  onClose: () => void;
+  onQueryChange: (value: string) => void;
+  onNext: () => void;
+  onPrev: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, [open, focusNonce]);
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        className="focus-ring inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]"
+        title="Find in conversation (⌘F)"
+        aria-label="Find in conversation"
+        onClick={onOpen}
+      >
+        <Icon name="ph:magnifying-glass" width={12} aria-hidden />
+      </button>
+    );
+  }
+
+  return (
+    <span className="cave-chat-find" role="search" aria-label="Find in conversation">
+      <Icon name="ph:magnifying-glass" width={11} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            e.stopPropagation();
+            if (e.shiftKey) onPrev();
+            else onNext();
+            return;
+          }
+          if (e.key === "Escape") {
+            e.preventDefault();
+            e.stopPropagation();
+            onClose();
+          }
+        }}
+        placeholder="Find in chat…"
+        aria-label="Find in conversation"
+        className="cave-chat-find__input"
+      />
+      <span className="cave-chat-find__count" aria-live="polite">
+        {matchCount > 0 ? `${activeIndex + 1} / ${matchCount}` : "0 / 0"}
+      </span>
+      <button
+        type="button"
+        className="cave-chat-find__nav focus-ring"
+        aria-label="Previous match"
+        title="Previous match (shift+enter)"
+        disabled={matchCount === 0}
+        onClick={onPrev}
+      >
+        <Icon name="ph:caret-up" width={10} aria-hidden />
+      </button>
+      <button
+        type="button"
+        className="cave-chat-find__nav focus-ring"
+        aria-label="Next match"
+        title="Next match (enter)"
+        disabled={matchCount === 0}
+        onClick={onNext}
+      >
+        <Icon name="ph:caret-down" width={10} aria-hidden />
+      </button>
+      <button
+        type="button"
+        className="cave-chat-find__nav focus-ring"
+        aria-label="Close find"
+        title="Close find (esc)"
+        onClick={onClose}
+      >
+        <Icon name="ph:x-bold" width={9} aria-hidden />
+      </button>
+    </span>
+  );
+}
+
 function ChatBackButton({ onBack }: { onBack: () => void }) {
   return (
     <button
@@ -1034,6 +1150,139 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const abortRef = useRef<AbortController | null>(null);
   const initialPromptSentRef = useRef(false);
   const keys = useKeySymbols();
+
+  // ── In-transcript find (CHAT-D9-04) ────────────────────────────────────
+  // Turn-level find: case-insensitive substring over each turn's VISIBLE
+  // text. `m` counts matching TURNS (honest scope — intra-turn highlighting
+  // inside sanitized rendered HTML is deferred render-pipeline surgery).
+  const [findOpen, setFindOpen] = useState(false);
+  const [findQuery, setFindQuery] = useState("");
+  const [findDebouncedQuery, setFindDebouncedQuery] = useState("");
+  const [findActiveIdx, setFindActiveIdx] = useState(0);
+  const [findFocusNonce, setFindFocusNonce] = useState(0);
+  // Turn id flashed with the cave-turn-found highlight after a jump.
+  const [foundTurnId, setFoundTurnId] = useState<string | null>(null);
+  const foundClearTimerRef = useRef<number | null>(null);
+  const lastJumpedQueryRef = useRef("");
+
+  // Debounce the query ~150ms so matching doesn't churn per keystroke.
+  useEffect(() => {
+    if (!findOpen) return;
+    const timer = window.setTimeout(() => setFindDebouncedQuery(findQuery), 150);
+    return () => window.clearTimeout(timer);
+  }, [findOpen, findQuery]);
+
+  // Recompute on (debounced) query change AND on turns change while open —
+  // a streaming chunk can create or grow a matching turn.
+  const findMatches = useMemo(() => {
+    if (!findOpen) return [];
+    return findMatchingTurnIds(
+      turns.map((t) => ({
+        id: t.id,
+        // Visible text only: assistant turns may carry inline <thinking>
+        // blocks in `text`; match what the transcript actually renders.
+        text: t.role === "assistant" ? splitReasoning(t.text).visible : t.text,
+      })),
+      findDebouncedQuery,
+    );
+  }, [findOpen, findDebouncedQuery, turns]);
+
+  // Keep the active pointer in bounds when the match set shrinks.
+  useEffect(() => {
+    setFindActiveIdx((i) => (findMatches.length === 0 ? 0 : Math.min(i, findMatches.length - 1)));
+  }, [findMatches]);
+
+  const jumpToFindMatch = useCallback(
+    (idx: number, matches: string[]) => {
+      const id = matches[idx];
+      if (!id) return;
+      setFindActiveIdx(idx);
+      // A find jump is explicit navigation away from the tail — release the
+      // stream follow-pin (CHAT-D10-01) so the next SSE chunk doesn't yank
+      // the reader back to the bottom.
+      if (followingRef.current) updateFollowing(false);
+      const el = scrollRef.current?.querySelector<HTMLElement>(
+        `[data-turn-id="${CSS.escape(id)}"]`,
+      );
+      // Always instant: the pin/release machinery owns smooth behavior, and
+      // "auto" is reduced-motion-safe without a matchMedia branch.
+      el?.scrollIntoView({ block: "center", behavior: "auto" });
+      // Restart the 1.5s highlight fade even when re-landing on the same
+      // turn: clear, then re-set on the next frame so the class re-applies.
+      if (foundClearTimerRef.current !== null) window.clearTimeout(foundClearTimerRef.current);
+      setFoundTurnId(null);
+      requestAnimationFrame(() => setFoundTurnId(id));
+      foundClearTimerRef.current = window.setTimeout(() => setFoundTurnId(null), 1500);
+    },
+    [updateFollowing],
+  );
+
+  useEffect(() => () => {
+    if (foundClearTimerRef.current !== null) window.clearTimeout(foundClearTimerRef.current);
+  }, []);
+
+  // A fresh (debounced) query jumps to its first matching turn. Guarded by
+  // ref so turns-driven recomputes (e.g. streaming) never re-trigger a jump.
+  useEffect(() => {
+    if (!findOpen) return;
+    if (findDebouncedQuery === lastJumpedQueryRef.current) return;
+    lastJumpedQueryRef.current = findDebouncedQuery;
+    if (findMatches.length > 0) jumpToFindMatch(0, findMatches);
+    else setFindActiveIdx(0);
+  }, [findOpen, findDebouncedQuery, findMatches, jumpToFindMatch]);
+
+  const findNext = useCallback(() => {
+    if (findMatches.length === 0) return;
+    jumpToFindMatch((findActiveIdx + 1) % findMatches.length, findMatches);
+  }, [findActiveIdx, findMatches, jumpToFindMatch]);
+
+  const findPrev = useCallback(() => {
+    if (findMatches.length === 0) return;
+    jumpToFindMatch((findActiveIdx - 1 + findMatches.length) % findMatches.length, findMatches);
+  }, [findActiveIdx, findMatches, jumpToFindMatch]);
+
+  const openFind = useCallback(() => {
+    setFindOpen(true);
+    setFindFocusNonce((n) => n + 1);
+  }, []);
+
+  const closeFind = useCallback(() => {
+    setFindOpen(false);
+    setFindQuery("");
+    setFindDebouncedQuery("");
+    lastJumpedQueryRef.current = "";
+    setFindActiveIdx(0);
+    setFoundTurnId(null);
+    // Esc hands focus back to the composer.
+    inputRef.current?.focus();
+  }, []);
+
+  // Reset find when switching sessions — match indices are per-transcript.
+  useEffect(() => {
+    setFindOpen(false);
+    setFindQuery("");
+    setFindDebouncedQuery("");
+    lastJumpedQueryRef.current = "";
+    setFindActiveIdx(0);
+    setFoundTurnId(null);
+  }, [sessionId]);
+
+  // ⌘F/Ctrl+F is scoped to the chat section via this React keydown handler
+  // on the section root — NOT a window-level listener — so ChatList's ⌘F
+  // (session search) and browser-native find elsewhere keep working.
+  const onChatSectionKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLElement>) => {
+      if ((e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.key.toLowerCase() === "f") {
+        e.preventDefault();
+        // Stop the event short of window so a co-mounted ChatList (its ⌘F
+        // session-search listener lives on window) can't steal focus while
+        // the user is finding inside this chat.
+        e.stopPropagation();
+        openFind();
+      }
+    },
+    [openFind],
+  );
 
   // Track the iOS visual viewport so the composer dock can translate up
   // by the on-screen keyboard height. `100dvh` shrinks the layout for
@@ -1925,6 +2174,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   return (
     <section
       className="cave-chat-linear flex h-full flex-col bg-[var(--bg-base)] text-[var(--text-primary)]"
+      onKeyDown={onChatSectionKeyDown}
       onDragEnter={(e) => {
         if (!hasDraggedFiles(e.dataTransfer.types)) return;
         e.preventDefault();
@@ -2002,6 +2252,20 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           onSessionsChanged={onSessionsChanged}
           onBack={onBack}
         >
+          {turns.length > 0 ? (
+            <ChatFindBar
+              open={findOpen}
+              query={findQuery}
+              activeIndex={findActiveIdx}
+              matchCount={findMatches.length}
+              focusNonce={findFocusNonce}
+              onOpen={openFind}
+              onClose={closeFind}
+              onQueryChange={setFindQuery}
+              onNext={findNext}
+              onPrev={findPrev}
+            />
+          ) : null}
           {sessionId && (
             <>
               <VoiceCallButton
@@ -2133,6 +2397,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                     turn={t}
                     familiar={familiar}
                     showTimestamp={showTimestamp}
+                    found={foundTurnId === t.id}
                     onEdit={t.role === "user" && t.text.trim() ? () => editTurnInComposer(t) : undefined}
                     onRegenerate={regenerateFor(t)}
                   />
@@ -2163,6 +2428,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                         turn={t}
                         familiar={familiar}
                         showTimestamp={showTimestamp}
+                        found={foundTurnId === t.id}
                         onEdit={t.role === "user" && t.text.trim() ? () => editTurnInComposer(t) : undefined}
                         onRegenerate={regenerateFor(t)}
                       />
@@ -2490,12 +2756,16 @@ function TurnRow({
   turn,
   familiar,
   showTimestamp = true,
+  found = false,
   onEdit,
   onRegenerate,
 }: {
   turn: Turn;
   familiar: Familiar;
   showTimestamp?: boolean;
+  /** CHAT-D9-04: true while this turn is the just-jumped-to find match —
+   *  applies the temporary cave-turn-found highlight flash. */
+  found?: boolean;
   /** CHAT-D6-01: present only on user turns — loads the turn into the composer. */
   onEdit?: () => void;
   /** CHAT-D6-02: present only on settled assistant turns with a preceding user turn. */
@@ -2503,7 +2773,10 @@ function TurnRow({
 }) {
   if (turn.role === "system" || turn.role === "user") {
     return (
-      <div className={`cave-linear-turn cave-linear-turn--${turn.role}`}>
+      <div
+        data-turn-id={turn.id}
+        className={`cave-linear-turn cave-linear-turn--${turn.role}${found ? " cave-turn-found" : ""}`}
+      >
         <div className="cave-linear-turn-content">
           <div className="cave-linear-turn-meta">
             {turn.role === "system" ? (
@@ -2531,7 +2804,10 @@ function TurnRow({
   const turnStatus = turn.lifecycle ?? (turn.error ? "failed" : turn.pending ? "streaming" : "complete");
 
   return (
-    <div className="cave-linear-turn cave-linear-turn--assistant">
+    <div
+      data-turn-id={turn.id}
+      className={`cave-linear-turn cave-linear-turn--assistant${found ? " cave-turn-found" : ""}`}
+    >
       <div className="cave-linear-turn-content text-[14px] leading-relaxed text-[var(--text-primary)] group/turn">
         {/* Avatar + right column */}
         <div className="cave-linear-turn-avatar" aria-hidden>

--- a/src/lib/transcript-find.ts
+++ b/src/lib/transcript-find.ts
@@ -1,0 +1,35 @@
+/**
+ * In-transcript find (CHAT-D9-04).
+ *
+ * Turn-level matching: a case-insensitive substring scan over each turn's
+ * VISIBLE text (callers pass the already-rendered visible body — reasoning
+ * blocks and tool payloads are deliberately excluded). Honest scope: the
+ * find bar reports and jumps between matching TURNS; intra-turn `<mark>`
+ * highlighting inside sanitized rendered HTML is deferred render-pipeline
+ * surgery.
+ */
+
+export type FindableTurn = {
+  id: string;
+  /** Visible transcript text for the turn (post reasoning-split). */
+  text: string;
+};
+
+/**
+ * Returns the ids of turns whose visible text contains `query`
+ * (case-insensitive substring), in transcript order. A blank or
+ * whitespace-only query matches nothing — an empty find bar should
+ * report 0 / 0, not "every turn matches the empty string".
+ */
+export function findMatchingTurnIds(
+  turns: readonly FindableTurn[],
+  query: string,
+): string[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return [];
+  const out: string[] = [];
+  for (const turn of turns) {
+    if (turn.text.toLowerCase().includes(needle)) out.push(turn.id);
+  }
+  return out;
+}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1114,6 +1114,89 @@ details[open] > .cave-tool-summary::before {
   50%      { opacity: 1; }
 }
 
+/* ── In-transcript find bar (CHAT-D9-04) ────────────────────────────────── */
+/* Expanded state extends the meta line: a hairline pill housing the query
+   input, the `n / m` matching-turn count, and prev/next/close controls. */
+.cave-chat-find {
+  display: inline-flex;
+  min-width: 0;
+  flex: 0 1 auto;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 6px;
+  background: color-mix(in oklch, var(--bg-base) 60%, transparent);
+  padding: 1px 6px;
+}
+
+.cave-chat-find:focus-within {
+  border-color: color-mix(in oklch, var(--accent-presence) 48%, var(--border-strong));
+}
+
+.cave-chat-find__input {
+  width: 10rem;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  outline: none;
+  color: var(--text-primary);
+  font-size: 11px;
+  line-height: 20px;
+}
+
+.cave-chat-find__input::placeholder {
+  color: var(--text-muted);
+}
+
+.cave-chat-find__count {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-family: var(--font-geist-mono);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.cave-chat-find__nav {
+  display: grid;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  place-items: center;
+  border-radius: 4px;
+  color: var(--text-muted);
+  transition: background var(--duration-fast) var(--ease-standard), color var(--duration-fast) var(--ease-standard);
+}
+
+.cave-chat-find__nav:hover:not(:disabled) {
+  background: var(--bg-raised);
+  color: var(--text-primary);
+}
+
+.cave-chat-find__nav:disabled {
+  opacity: 0.4;
+}
+
+/* Temporary flash on the turn a find jump landed on. One-shot 1.5s fade —
+   the global reduced-motion kill switch (globals.css) clamps the keyframe's
+   duration, and the explicit block below swaps the flash for a static tint
+   so the landing turn stays findable without motion. */
+.cave-turn-found {
+  animation: cave-turn-found-fade 1.5s ease-out 1;
+}
+
+@keyframes cave-turn-found-fade {
+  0%   { background: color-mix(in oklch, var(--accent-presence) 18%, transparent); }
+  100% { background: transparent; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cave-turn-found {
+    animation: none;
+    background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+  }
+}
+
 /* Linked context row (chips for task / GitHub items) */
 .cave-chat-linked-context {
   display: flex;


### PR DESCRIPTION
## Summary

Implements **CHAT-D9-04 (P2)** from the chat UX audit (#395): there was no in-transcript search or jump-to-message — the only ⌘F was ChatList's SESSION search, and browser-native find only worked by accident of nothing being virtualized. Benchmarks (Claude Code desktop, Cursor) offer in-conversation find; ChatGPT has per-turn anchors.

### What this adds

- **Find bar in the chat header meta line** — a search icon button (left of voice/debug/delete, which stay put) toggles a compact input extending the meta line: query field, `n / m` matching-turn count, prev/next buttons (aria-labelled), close. Enter = next, Shift+Enter = prev, Esc closes and hands focus back to the composer. The find input's own onKeyDown stops propagation, so its Esc never touches the composer's Esc layering (slash dismiss / stream cancel).
- **Turn-level matching** — case-insensitive substring over each turn's *visible* text (assistant inline `<thinking>` blocks split out first; `turn.reasoning` deliberately excluded), debounced ~150ms, recomputed on turns change while the bar is open. Pure helper: `src/lib/transcript-find.ts` → `findMatchingTurnIds(turns, query)`.
- **Jump** — next/prev cycles matching turns; the active turn scrolls to center **instantly** (`behavior: "auto"` always — reduced-motion-safe, and #404's pin/release machinery owns smooth behavior). A jump **releases the follow-pin** (`updateFollowing(false)`) so a streaming SSE chunk can't yank the reader back to the tail. The landing turn flashes a 1.5s `cave-turn-found` fade; under `prefers-reduced-motion` the animation is disabled in favor of a static tint (on top of the global kill switch).
- **Section-scoped ⌘F** — a React keydown handler on the chat section root (NO window-level listener), so ⌘F opens find only when focus is inside the chat. ChatList's ⌘F session search and browser-native find elsewhere keep working; the handler stops propagation so a co-mounted ChatList can't steal focus mid-find.
- **Stable scroll targets** — both TurnRow render branches stamp `data-turn-id`.

### Honest scope note (deferred)

`m` counts **matching turns**, not occurrences — intra-turn text highlighting (`<mark>` injection) inside the sanitized rendered HTML is render-pipeline surgery and is deliberately **deferred**. Turn-level jump + count meets the finding.

## Test plan

- `chat-router-switching.test.ts` — appended a commented CHAT-D9-04 section: behavioral tests for `findMatchingTurnIds` (case-insensitivity, blank-query = 0 matches, ordering) plus source pins for the header find bar, n/m count, prev/next aria-labels, section-scoped ⌘F with no window keydown listener, pin release + instant centered scroll in the jump fn, `data-turn-id` in both TurnRow branches, find-input Esc/Enter layering, 150ms debounce, visible-text-only matching, and the reduced-motion-safe highlight CSS.
- `pnpm test:app` — full suite green.
- `pnpm typecheck` — clean.
- (Pre-existing non-CI failure in `board-chat-link.test.ts` untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)