### PR TITLE
fix(chat): promote rounded usage tokens

### DIFF
--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -568,6 +568,7 @@ assert.match(
   assert.equal(formatTokens(1000), "1k", "trailing .0 is trimmed");
   assert.equal(formatTokens(1234), "1.2k");
   assert.equal(formatTokens(12350), "12.4k", "12350 tokens read as 12.4k");
+  assert.equal(formatTokens(999_950), "1M", "rounded token counts should promote across suffix boundaries");
   assert.equal(formatTokens(2_500_000), "2.5M");
   assert.equal(formatTokens(0), "0");
   assert.equal(formatTokens(-5), null);

--- a/src/lib/usage-format.ts
+++ b/src/lib/usage-format.ts
@@ -67,11 +67,17 @@ export function normalizeTurnUsage(raw: unknown): TurnUsage | undefined {
 export function formatTokens(n: number): string | null {
   if (typeof n !== "number" || !Number.isFinite(n) || n < 0) return null;
   if (n < 1000) return String(Math.round(n));
-  const scaled = n < 1_000_000 ? n / 1000 : n / 1_000_000;
-  const suffix = n < 1_000_000 ? "k" : "M";
+  let scaled = n < 1_000_000 ? n / 1000 : n / 1_000_000;
+  let suffix = n < 1_000_000 ? "k" : "M";
   // Half-up to one decimal without toFixed's float drift (12350 → "12.4k");
   // integral results render bare ("1k", not "1.0k").
-  return `${Math.round(scaled * 10) / 10}${suffix}`;
+  let rounded = Math.round(scaled * 10) / 10;
+  if (suffix === "k" && rounded >= 1000) {
+    scaled = n / 1_000_000;
+    suffix = "M";
+    rounded = Math.round(scaled * 10) / 10;
+  }
+  return `${rounded}${suffix}`;
 }
 
 /** "$0.08"; "<$0.01" under a cent; null when zero, undefined, or invalid —
@@ -100,8 +106,8 @@ export function usageSummary(
   return parts.length ? parts.join(" · ") : null;
 }
 
-/** Full breakdown for tooltips: every captured counter plus a higher-precision
- *  cost. Null when there is nothing to break down. */
+/** Full breakdown for tooltips: every captured counter plus a cost, preserving
+ *  four decimals only for sub-cent values. Null when there is nothing to break down. */
 export function usageBreakdown(
   usage?: TurnUsage,
   costUsd?: number,


### PR DESCRIPTION
## Summary
- promote compact token counts across suffix boundaries after rounding
- add a regression for 999,950 tokens rendering as 1M
- align the usage breakdown docstring with current cost precision behavior

## Verification
- node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts
- pnpm test:api
- pnpm typecheck