### PR TITLE
fix(chat): clear find highlight timer on reset

### DIFF
--- a/src/components/chat-router-switching.test.ts
+++ b/src/components/chat-router-switching.test.ts
@@ -252,7 +252,7 @@ assert.doesNotMatch(
 //    so the next SSE chunk doesn't yank the reader back to the bottom, and
 //    the jump itself is instant (behavior: "auto" — reduced-motion-safe).
 const jumpFn =
-  chatViewSource.match(/const jumpToFindMatch = useCallback\([\s\S]*?\[updateFollowing\],\s*\);/)?.[0] ?? "";
+  chatViewSource.match(/const jumpToFindMatch = useCallback\([\s\S]*?\[[^\]]*updateFollowing[^\]]*\],\s*\);/)?.[0] ?? "";
 
 assert.ok(jumpFn.length > 0, "ChatView should define jumpToFindMatch");
 

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -284,6 +284,26 @@ assert.match(
   "Assistant turn meta row appends the muted usage/cost readout after the timestamp (CHAT-D12-02)",
 );
 
+// ── CHAT-D9-04: find highlight timer cleanup ──
+
+assert.match(
+  source,
+  /const clearFoundHighlightTimer = useCallback\(\(\) => \{[\s\S]*?window\.clearTimeout\(foundClearTimerRef\.current\);[\s\S]*?foundClearTimerRef\.current = null;/,
+  "Find highlight timer cleanup should clear and null the pending timeout",
+);
+
+assert.match(
+  source,
+  /const closeFind = useCallback\(\(\) => \{[\s\S]*?clearFoundHighlightTimer\(\);[\s\S]*?setFoundTurnId\(null\);/,
+  "Closing find should clear the pending highlight timer before resetting foundTurnId",
+);
+
+assert.match(
+  source,
+  /useEffect\(\(\) => \{[\s\S]*?setFindOpen\(false\);[\s\S]*?clearFoundHighlightTimer\(\);[\s\S]*?setFoundTurnId\(null\);[\s\S]*?\}, \[clearFoundHighlightTimer, sessionId\]\);/,
+  "Switching sessions should clear the pending find highlight timer",
+);
+
 // MetaLine complete state extends the existing one-liner format:
 // "… · 7s · 12.4k tok · $0.08" — and stays silent when there is no usage.
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1165,6 +1165,13 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const foundClearTimerRef = useRef<number | null>(null);
   const lastJumpedQueryRef = useRef("");
 
+  const clearFoundHighlightTimer = useCallback(() => {
+    if (foundClearTimerRef.current !== null) {
+      window.clearTimeout(foundClearTimerRef.current);
+      foundClearTimerRef.current = null;
+    }
+  }, []);
+
   // Debounce the query ~150ms so matching doesn't churn per keystroke.
   useEffect(() => {
     if (!findOpen) return;
@@ -1209,17 +1216,18 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       el?.scrollIntoView({ block: "center", behavior: "auto" });
       // Restart the 1.5s highlight fade even when re-landing on the same
       // turn: clear, then re-set on the next frame so the class re-applies.
-      if (foundClearTimerRef.current !== null) window.clearTimeout(foundClearTimerRef.current);
+      clearFoundHighlightTimer();
       setFoundTurnId(null);
       requestAnimationFrame(() => setFoundTurnId(id));
-      foundClearTimerRef.current = window.setTimeout(() => setFoundTurnId(null), 1500);
+      foundClearTimerRef.current = window.setTimeout(() => {
+        setFoundTurnId(null);
+        foundClearTimerRef.current = null;
+      }, 1500);
     },
-    [updateFollowing],
+    [clearFoundHighlightTimer, updateFollowing],
   );
 
-  useEffect(() => () => {
-    if (foundClearTimerRef.current !== null) window.clearTimeout(foundClearTimerRef.current);
-  }, []);
+  useEffect(() => () => clearFoundHighlightTimer(), [clearFoundHighlightTimer]);
 
   // A fresh (debounced) query jumps to its first matching turn. Guarded by
   // ref so turns-driven recomputes (e.g. streaming) never re-trigger a jump.
@@ -1252,10 +1260,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     setFindDebouncedQuery("");
     lastJumpedQueryRef.current = "";
     setFindActiveIdx(0);
+    clearFoundHighlightTimer();
     setFoundTurnId(null);
     // Esc hands focus back to the composer.
     inputRef.current?.focus();
-  }, []);
+  }, [clearFoundHighlightTimer]);
 
   // Reset find when switching sessions — match indices are per-transcript.
   useEffect(() => {
@@ -1264,8 +1273,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     setFindDebouncedQuery("");
     lastJumpedQueryRef.current = "";
     setFindActiveIdx(0);
+    clearFoundHighlightTimer();
     setFoundTurnId(null);
-  }, [sessionId]);
+  }, [clearFoundHighlightTimer, sessionId]);
 
   // ⌘F/Ctrl+F is scoped to the chat section via this React keydown handler
   // on the section root — NOT a window-level listener — so ChatList's ⌘F


### PR DESCRIPTION
## Summary
- clear and null the pending find highlight timer when closing find or switching sessions
- null the timer after the highlight timeout fires
- update source regressions for the cleanup path and callback dependency

## Verification
- node --experimental-strip-types src/components/chat-view-lifecycle.test.ts
- node --experimental-strip-types src/components/chat-router-switching.test.ts
- pnpm test:app
- pnpm typecheck