### PR TITLE
feat(chat): @-mention repo files in the composer

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -71,6 +71,7 @@ const contracts: RouteContract[] = [
   { route: "/openclaw-agents", methods: ["GET"], kind: "json" },
   { route: "/project-file", methods: ["GET"], kind: "json", pathGuard: true },
   { route: "/project-tree", methods: ["GET"], kind: "json", pathGuard: true },
+  { route: "/project/files", methods: ["GET"], kind: "json" },
   { route: "/roles", methods: ["GET", "POST"], kind: "json", readsJson: true },
   { route: "/salem", methods: ["GET", "POST"], kind: "json", readsJson: true },
   { route: "/sessions/[id]/events", methods: ["GET"], kind: "json" },

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { stripAnsi } from "@/lib/ansi";
@@ -58,6 +58,11 @@ type SendBody = {
   sessionId?: string;
   projectRoot?: string;
   attachments?: ChatAttachment[];
+  /** Repo-relative paths the user @-mentioned in the composer (CHAT-D1-04). */
+  mentionedFiles?: string[];
+  /** Project root the mentions are relative to — resumed sessions don't carry
+   * projectRoot in the body, so the composer sends the root it knows. */
+  mentionedFilesRoot?: string;
 };
 
 type StreamEvent =
@@ -184,6 +189,58 @@ function cleanupImageTempFiles(filePaths: ReadonlyMap<number, string>) {
   for (const filePath of filePaths.values()) {
     void rm(filePath, { force: true }).catch(() => undefined);
   }
+}
+
+// ── @-mentioned file delivery (CHAT-D1-04) ───────────────────────────────
+// The composer's `@` picker records repo-relative paths; the prompt gets a
+// compact "Referenced files" block of absolute paths the harness can open
+// with its Read tool. Validation mirrors /api/changes: repo-relative paths
+// only, resolved against the realpathed root with a prefix containment
+// check — absolute paths, NUL bytes, `..` segments, and symlinks that
+// escape the root are silently skipped, never errors.
+
+const MAX_MENTIONED_FILES = 10;
+
+async function resolveMentionedFiles(
+  relPaths: unknown,
+  root: unknown,
+): Promise<string[]> {
+  if (!Array.isArray(relPaths) || relPaths.length === 0) return [];
+  if (typeof root !== "string" || !path.isAbsolute(root)) return [];
+  let realRoot: string;
+  try {
+    realRoot = await realpath(path.resolve(root));
+    if (!(await stat(realRoot)).isDirectory()) return [];
+  } catch {
+    return [];
+  }
+  const resolved: string[] = [];
+  for (const rel of relPaths.slice(0, MAX_MENTIONED_FILES)) {
+    if (typeof rel !== "string" || !rel || rel.includes("\0") || path.isAbsolute(rel)) continue;
+    if (rel.split(/[\\/]+/).includes("..")) continue;
+    const candidate = path.resolve(realRoot, rel);
+    if (candidate === realRoot || !candidate.startsWith(realRoot + path.sep)) continue;
+    try {
+      // Containment must hold for the real file too, or a symlink inside the
+      // root could point the prompt at an arbitrary path outside it.
+      const real = await realpath(candidate);
+      if (real !== candidate && !real.startsWith(realRoot + path.sep)) continue;
+      if (!(await stat(real)).isFile()) continue;
+      if (!resolved.includes(candidate)) resolved.push(candidate);
+    } catch {
+      /* missing or unreadable — skip */
+    }
+  }
+  return resolved;
+}
+
+function appendMentionedFilesBlock(prompt: string, absPaths: string[]): string {
+  if (absPaths.length === 0) return prompt;
+  const block = [
+    "Referenced files (open with the Read tool):",
+    ...absPaths.map((p) => `- ${p}`),
+  ].join("\n");
+  return prompt ? `${prompt}\n\n${block}` : block;
 }
 
 function scheduleLinkRoute(args: {
@@ -652,14 +709,26 @@ export async function POST(req: Request) {
   const imageFilePaths = imagesSupported
     ? await writeImageAttachmentsToTemp(attachments)
     : new Map<number, string>();
+  // @-mentioned files share the image-delivery constraint: only local
+  // coven-run harnesses can Read this machine's filesystem, so bridges and
+  // SSH runtimes never get a block of unreachable absolute paths.
+  const mentionedFiles = imagesSupported
+    ? await resolveMentionedFiles(
+        body.mentionedFiles,
+        body.mentionedFilesRoot ?? body.projectRoot,
+      )
+    : [];
 
   const taskContext = await taskContextForSession(body.sessionId);
   const harnessPrompt = buildPromptWithCovenIdentityCanon(
     buildTaskAwarePrompt(
-      buildPromptWithAttachments(promptText, attachments, {
-        imagesSupported,
-        imageFilePaths,
-      }),
+      appendMentionedFilesBlock(
+        buildPromptWithAttachments(promptText, attachments, {
+          imagesSupported,
+          imageFilePaths,
+        }),
+        mentionedFiles,
+      ),
       taskContext,
     ),
     body.familiarId,

--- a/src/app/api/project/files/route.ts
+++ b/src/app/api/project/files/route.ts
@@ -1,0 +1,138 @@
+import { NextRequest, NextResponse } from "next/server";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import fs from "node:fs";
+import path from "node:path";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Workspace file index for the chat composer's `@`-mention picker
+ * (CHAT-D1-04).
+ *
+ * GET ?root=<abs> → { ok, repo, root, files, truncated }
+ *
+ * Lists git-visible files under the requested root: tracked plus
+ * untracked-but-not-ignored (`git ls-files --cached --others
+ * --exclude-standard`), capped at MAX_FILES with a `truncated` flag. Paths
+ * are relative to the requested root (the chat's project root — the same
+ * directory the harness boots in), so the composer can insert them verbatim.
+ *
+ * Security posture mirrors /api/changes: every git invocation goes through
+ * execFile with an argument array — no shell, so the root is never
+ * string-interpolated into a command. The root must be an absolute path,
+ * is realpath-resolved before use, and must be a directory inside a git
+ * work tree. A non-repo root is a distinct non-error state
+ * (`{ ok: true, repo: false }`) the composer can render or skip.
+ */
+
+const execFileAsync = promisify(execFile);
+
+const GIT_TIMEOUT_MS = 10_000;
+const MAX_GIT_BUFFER = 16 * 1024 * 1024;
+/** Cap the index so a monorepo can't flood the client; the picker only ever
+ * shows a dozen fuzzy matches, so the tail matters less than the bound. */
+const MAX_FILES = 5000;
+/** Module-level response cache: repeated keystrokes re-open the picker, but
+ * the index only needs refreshing every few seconds. Keyed by realpathed
+ * root. */
+const CACHE_TTL_MS = 10_000;
+
+type FilesPayload = {
+  ok: true;
+  repo: true;
+  root: string;
+  files: string[];
+  truncated: boolean;
+};
+
+const cache = new Map<string, { at: number; payload: FilesPayload }>();
+
+/** Run git via execFile (argument array, no shell interpolation). */
+function git(cwd: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  return execFileAsync("git", args, {
+    cwd,
+    timeout: GIT_TIMEOUT_MS,
+    maxBuffer: MAX_GIT_BUFFER,
+  });
+}
+
+type RootResolution =
+  | { ok: true; root: string }
+  | { ok: false; status: number; error: string; notARepo?: boolean };
+
+/** Validate root: absolute, exists (realpath), is a directory, and sits
+ * inside a git work tree. Unlike /api/changes we keep the REQUESTED dir
+ * (not the repo toplevel) so listed paths stay relative to the chat root. */
+async function resolveIndexRoot(root: string): Promise<RootResolution> {
+  if (!path.isAbsolute(root)) {
+    return { ok: false, status: 400, error: "root must be an absolute path" };
+  }
+  let real: string;
+  try {
+    real = fs.realpathSync(path.resolve(root));
+  } catch {
+    return { ok: false, status: 404, error: "root does not exist" };
+  }
+  if (!fs.statSync(real).isDirectory()) {
+    return { ok: false, status: 400, error: "root is not a directory" };
+  }
+  try {
+    const { stdout } = await git(real, ["rev-parse", "--is-inside-work-tree"]);
+    if (stdout.trim() !== "true") {
+      return { ok: false, status: 422, error: "not a git repository", notARepo: true };
+    }
+    return { ok: true, root: real };
+  } catch {
+    return { ok: false, status: 422, error: "not a git repository", notARepo: true };
+  }
+}
+
+async function listFiles(root: string): Promise<FilesPayload> {
+  const cached = cache.get(root);
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) return cached.payload;
+
+  // Tracked + untracked-but-not-ignored, NUL-separated so filenames with
+  // newlines can't split entries.
+  const { stdout } = await git(root, [
+    "ls-files",
+    "-z",
+    "--cached",
+    "--others",
+    "--exclude-standard",
+  ]);
+  const all = stdout.split("\0").filter(Boolean);
+  const truncated = all.length > MAX_FILES;
+  const payload: FilesPayload = {
+    ok: true,
+    repo: true,
+    root,
+    files: truncated ? all.slice(0, MAX_FILES) : all,
+    truncated,
+  };
+  cache.set(root, { at: Date.now(), payload });
+  return payload;
+}
+
+export async function GET(req: NextRequest) {
+  const root = req.nextUrl.searchParams.get("root");
+  if (!root) {
+    return NextResponse.json({ ok: false, error: "missing root param" }, { status: 400 });
+  }
+
+  const resolved = await resolveIndexRoot(root);
+  if (!resolved.ok) {
+    if (resolved.notARepo) {
+      // Distinct, non-error state — the composer hides the picker.
+      return NextResponse.json({ ok: true, repo: false, error: resolved.error });
+    }
+    return NextResponse.json({ ok: false, error: resolved.error }, { status: resolved.status });
+  }
+
+  try {
+    return NextResponse.json(await listFiles(resolved.root));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -446,3 +446,246 @@ assert.match(
   /\.cave-chat-linear \{\s*\n\s*position: relative;/,
   "The chat section must anchor the absolutely-positioned drop overlay",
 );
+
+// — CHAT-D1-04: @-mention repo files in the composer —
+
+// Behavioral: mention token parsing + fuzzy ranking (src/lib/file-mention.ts)
+const { fileMentionToken, filterFileMentions, MAX_FILE_MENTIONS, FILE_MENTION_RESULT_LIMIT } =
+  await import("../lib/file-mention.ts");
+
+assert.deepEqual(
+  fileMentionToken("@", 1),
+  { start: 0, query: "" },
+  "A bare `@` at the start of the composer opens an empty-query mention token",
+);
+assert.deepEqual(
+  fileMentionToken("look at @src/ch", 15),
+  { start: 8, query: "src/ch" },
+  "`@` after whitespace yields the text between the @ and the caret (slashes allowed)",
+);
+assert.equal(
+  fileMentionToken("mail me a@b.com", 15),
+  null,
+  "Mid-word `@` (emails) must not open the picker — the @ must start the text or follow whitespace",
+);
+assert.equal(
+  fileMentionToken("@src foo", 8),
+  null,
+  "Whitespace between the @ and the caret closes the token",
+);
+assert.equal(
+  fileMentionToken("@a@b", 4),
+  null,
+  "A second `@` inside the query invalidates the token",
+);
+assert.deepEqual(
+  fileMentionToken("@src/ch trailing", 7),
+  { start: 0, query: "src/ch" },
+  "Only text up to the caret counts as the query",
+);
+assert.equal(
+  fileMentionToken("/help", 5),
+  null,
+  "A `/` first token is never a mention — slash menu and mention menu stay disjoint",
+);
+
+const mentionIndexFixture = [
+  "src/components/chat-view.tsx",
+  "src/lib/chat-attachments.ts",
+  "src/lib/file-mention.ts",
+  "docs/changelog.md",
+  "chat.ts",
+];
+assert.deepEqual(
+  filterFileMentions(mentionIndexFixture, "chat")[0],
+  "chat.ts",
+  "Basename-prefix matches rank above basename/path substring matches",
+);
+assert.ok(
+  filterFileMentions(mentionIndexFixture, "chat").includes("src/components/chat-view.tsx"),
+  "Basename substring matches are included after prefix matches",
+);
+assert.deepEqual(
+  filterFileMentions(mentionIndexFixture, "scmvt"),
+  ["src/components/chat-view.tsx"],
+  "Subsequence matching catches scattered-character queries",
+);
+assert.deepEqual(
+  filterFileMentions(mentionIndexFixture, "zzz"),
+  [],
+  "Non-matching queries return no rows",
+);
+assert.equal(
+  filterFileMentions(mentionIndexFixture, "", 2).length,
+  2,
+  "The result limit caps the list (empty query returns the head of the index)",
+);
+assert.equal(MAX_FILE_MENTIONS, 10, "Mentions are capped at 10 per send");
+assert.ok(FILE_MENTION_RESULT_LIMIT <= 15, "The picker shows a short list (~12), not the whole index");
+
+// Pins: file-index route mirrors the /api/changes security posture
+const filesRouteSource = readFileSync(
+  new URL("../app/api/project/files/route.ts", import.meta.url),
+  "utf8",
+);
+assert.match(
+  filesRouteSource,
+  /execFileAsync\("git", args, \{/,
+  "/api/project/files must run git through execFile with an argument array (no shell)",
+);
+assert.doesNotMatch(
+  filesRouteSource,
+  /\bexec\(|shell:\s*true|spawnSync\(/,
+  "/api/project/files must never interpolate the root into a shell command",
+);
+assert.match(
+  filesRouteSource,
+  /if \(!path\.isAbsolute\(root\)\)/,
+  "/api/project/files must reject relative roots",
+);
+assert.match(
+  filesRouteSource,
+  /fs\.realpathSync\(path\.resolve\(root\)\)/,
+  "/api/project/files must realpath the root before use (mirror /api/changes)",
+);
+assert.match(
+  filesRouteSource,
+  /\{ ok: true, repo: false, error: resolved\.error \}/,
+  "Not-a-repo must be a distinct non-error state, not a 4xx/5xx",
+);
+assert.match(
+  filesRouteSource,
+  /"ls-files",\s*\n\s*"-z",\s*\n\s*"--cached",\s*\n\s*"--others",\s*\n\s*"--exclude-standard",/,
+  "The index must list tracked plus untracked-but-not-ignored files, NUL-separated",
+);
+assert.match(
+  filesRouteSource,
+  /const MAX_FILES = 5000;/,
+  "The index must cap at ~5000 paths",
+);
+assert.match(
+  filesRouteSource,
+  /truncated = all\.length > MAX_FILES/,
+  "An over-cap index must set the truncated flag",
+);
+assert.match(
+  filesRouteSource,
+  /const CACHE_TTL_MS = 10_000;[\s\S]*Date\.now\(\) - cached\.at < CACHE_TTL_MS/,
+  "The route must keep a ~10s module-level cache keyed by root",
+);
+
+// Pins: composer mention picker (chat-view.tsx)
+const mentionSource = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+assert.match(
+  mentionSource,
+  /const mentionRoot = \(session\?\.project_root\?\.trim\(\) \|\| cwdDraft\.trim\(\) \|\| projectRoot \|\| ""\)\.trim\(\);/,
+  "The mention root must come from the same sources the send body uses: session root, CWD draft, projectRoot prop",
+);
+assert.match(
+  mentionSource,
+  /\/api\/project\/files\?root=\$\{encodeURIComponent\(mentionRoot\)\}/,
+  "The picker must fetch the file index for the chat's project root",
+);
+assert.match(
+  mentionSource,
+  /id=\{mentionListboxId\} role="listbox" aria-label="Workspace files"/,
+  "The mention popover must be a listbox (ARIA parity with the slash menu, #423)",
+);
+assert.match(
+  mentionSource,
+  /role="option"\s*\n\s*id=\{`\$\{mentionListboxId\}-opt-\$\{i\}`\}\s*\n\s*aria-selected=\{active\}/,
+  "Mention rows must be aria-selected options with stable ids for aria-activedescendant",
+);
+assert.match(
+  mentionSource,
+  /const mentionAriaOverrides: React\.AriaAttributes = mentionOpen\s*\n\s*\? \{\s*\n\s*"aria-expanded": true,\s*\n\s*"aria-controls": mentionListboxId,\s*\n\s*"aria-activedescendant": `\$\{mentionListboxId\}-opt-\$\{mentionIdx\}`,/,
+  "While the mention picker is open it must override the combobox ARIA (expanded/controls/activedescendant) — the menus are disjoint, so the closed slash wiring yields",
+);
+assert.match(
+  mentionSource,
+  /\{\.\.\.mentionAriaOverrides\}/,
+  "The composer textarea must apply the mention ARIA overrides after the slash wiring (later JSX attributes win)",
+);
+
+// Esc precedence (#402): mention dismiss → slash dismiss → busy cancel.
+const mentionComposerKey = mentionSource.match(/const onComposerKey = [\s\S]*?\n  \};/)?.[0] ?? "";
+assert.match(
+  mentionComposerKey,
+  /if \(mentionOpen\) \{[\s\S]*?setMentionDismissed\(true\)/,
+  "Esc with the mention picker open must dismiss the picker",
+);
+assert.ok(
+  mentionComposerKey.indexOf("if (mentionOpen) {") <
+    mentionComposerKey.indexOf("if (slashSuggestions.length > 0) {"),
+  "The mention branch must run before the slash branch in onComposerKey",
+);
+assert.ok(
+  mentionComposerKey.indexOf("setMentionDismissed(true)") <
+    mentionComposerKey.indexOf("setSlashDismissed(true)") &&
+    mentionComposerKey.indexOf("setSlashDismissed(true)") <
+      mentionComposerKey.indexOf("cancelSend()"),
+  "Esc precedence: mention dismiss before slash dismiss before busy-cancel",
+);
+assert.match(
+  mentionComposerKey,
+  /if \(e\.key === "Tab" \|\| \(e\.key === "Enter" && !e\.shiftKey\)\) \{[\s\S]*?selectMention\(file\)/,
+  "Enter/Tab must insert the highlighted file, never send the draft, while the picker is open",
+);
+assert.match(
+  mentionSource,
+  /setMentionIdx\(0\);\s*\n\s*setMentionDismissed\(false\);/,
+  "Editing the input must re-arm a dismissed mention picker",
+);
+
+// Selection semantics: inline `@path` token + mentionedFiles in the send body.
+assert.match(
+  mentionSource,
+  /const insert = `@\$\{relPath\} `;[\s\S]*?input\.slice\(0, mentionToken\.start\) \+ insert \+ input\.slice\(composerCaret\)/,
+  "Selecting a file must replace the `@query` token with the relative path inline (Claude Code convention)",
+);
+assert.match(
+  mentionSource,
+  /\.\.\.\(outgoingMentions\.length && mentionRoot\s*\n\s*\? \{\s*\n\s*mentionedFiles: outgoingMentions\.slice\(0, MAX_FILE_MENTIONS\),\s*\n\s*mentionedFilesRoot: mentionRoot,/,
+  "The send body must carry mentionedFiles plus the root they are relative to",
+);
+assert.match(
+  mentionSource,
+  /mentionedFiles\s*\n?\s*\.filter\(\(p\) => text\.includes\(`@\$\{p\}`\)\)/,
+  "Only mentions whose @path token survived editing may ride the send",
+);
+assert.match(
+  mentionSource,
+  /setInput\(""\);\s*\n\s*setAttachments\(\[\]\);\s*\n\s*setMentionedFiles\(\[\]\);/,
+  "Sending must clear staged mentions with the composer",
+);
+
+// Pins: send route validates mentions and appends the prompt block.
+const mentionSendSource = readFileSync(
+  new URL("../app/api/chat/send/route.ts", import.meta.url),
+  "utf8",
+);
+assert.match(
+  mentionSendSource,
+  /async function resolveMentionedFiles\([\s\S]*?relPaths\.slice\(0, MAX_MENTIONED_FILES\)[\s\S]*?\.includes\("\.\."\)[\s\S]*?candidate\.startsWith\(realRoot \+ path\.sep\)/,
+  "/chat/send must validate each mention: cap, repo-relative only, no `..`, prefix containment under the realpathed root",
+);
+assert.match(
+  mentionSendSource,
+  /const real = await realpath\(candidate\);[\s\S]*?real\.startsWith\(realRoot \+ path\.sep\)/,
+  "/chat/send must re-check containment on the realpathed file so in-repo symlinks cannot smuggle outside paths",
+);
+assert.match(
+  mentionSendSource,
+  /"Referenced files \(open with the Read tool\):",\s*\n\s*\.\.\.absPaths\.map\(\(p\) => `- \$\{p\}`\)/,
+  "Validated mentions must render as the compact Referenced-files prompt block of absolute paths",
+);
+assert.match(
+  mentionSendSource,
+  /appendMentionedFilesBlock\(\s*\n\s*buildPromptWithAttachments\(/,
+  "The mention block must join the prompt at the attachment prompt-build site",
+);
+assert.match(
+  mentionSendSource,
+  /const mentionedFiles = imagesSupported\s*\n\s*\? await resolveMentionedFiles\(\s*\n\s*body\.mentionedFiles,\s*\n\s*body\.mentionedFilesRoot \?\? body\.projectRoot,/,
+  "Mentions are only delivered to harnesses that can Read this machine's filesystem, against the client-supplied root",
+);

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -19,6 +19,12 @@ import {
   stripPreviewOnlyAttachmentFieldsKeepingImages,
   type ChatAttachment,
 } from "@/lib/chat-attachments";
+import {
+  FILE_MENTION_RESULT_LIMIT,
+  fileMentionToken,
+  filterFileMentions,
+  MAX_FILE_MENTIONS,
+} from "@/lib/file-mention";
 import { Modal } from "@/components/ui/modal";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { DebugPane } from "@/components/debug-pane";
@@ -112,6 +118,7 @@ type ChatHistoryState = "idle" | "loading" | "loaded" | "missing" | "error";
 type FailedSend = {
   text: string;
   attachments: ChatAttachment[];
+  mentionedFiles?: string[];
 };
 
 function shouldKeepLiveNewChatState({
@@ -367,6 +374,7 @@ function ChatEmptyState({
   cwd,
   defaultCwd,
   onCwdChange,
+  fileMentions = false,
 }: {
   familiar: Familiar;
   onPrompt?: (text: string) => void;
@@ -376,6 +384,8 @@ function ChatEmptyState({
   defaultCwd?: string;
   /** Present only while the chat has no session — the CWD is fixed after the first send. */
   onCwdChange?: (value: string) => void;
+  /** True when the chat knows a project root, so `@` opens the file picker (CHAT-D1-04). */
+  fileMentions?: boolean;
 }) {
 
   return (
@@ -396,6 +406,15 @@ function ChatEmptyState({
           /
         </kbd>
         {" "}for commands
+        {fileMentions ? (
+          <>
+            {" "}·{" "}
+            <kbd className="rounded px-1 py-0.5 font-mono text-[11px] bg-[var(--bg-raised)] text-[var(--text-secondary)]">
+              @
+            </kbd>
+            {" "}to reference files
+          </>
+        ) : null}
       </p>
 
       {onCwdChange && (
@@ -1026,6 +1045,96 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // Stable per-mount listbox id — the home composer mounts its own slash menu,
   // so ids must be unique across simultaneously mounted composers.
   const slashListboxId = useId();
+
+  // @-file mentions (CHAT-D1-04). Typing `@` opens a workspace-file picker
+  // when the chat knows its project root — the session's project_root, the
+  // CWD draft, or the pre-wired projectRoot prop, i.e. the same sources the
+  // send body uses. The file index is fetched once per root from
+  // /api/project/files and fuzzy-filtered client-side. Mentions stay
+  // disjoint from the slash menu: `@` is mid-token, `/` is first-token only.
+  const mentionRoot = (session?.project_root?.trim() || cwdDraft.trim() || projectRoot || "").trim();
+  const [composerCaret, setComposerCaret] = useState(0);
+  const [mentionIdx, setMentionIdx] = useState(0);
+  // Esc hides the picker for the current input; any edit brings it back.
+  const [mentionDismissed, setMentionDismissed] = useState(false);
+  // Paths the user picked this draft — sent alongside the prompt so the
+  // server can hand the harness resolvable absolute paths.
+  const [mentionedFiles, setMentionedFiles] = useState<string[]>([]);
+  const [mentionIndex, setMentionIndex] = useState<{ root: string; repo: boolean; files: string[] } | null>(null);
+  const mentionListboxId = useId();
+  const activeMentionOptionRef = useRef<HTMLButtonElement | null>(null);
+
+  const mentionToken = useMemo(
+    () => (mentionRoot ? fileMentionToken(input, composerCaret) : null),
+    [input, composerCaret, mentionRoot],
+  );
+  const mentionMatches: string[] = useMemo(() => {
+    if (!mentionToken || mentionDismissed) return [];
+    if (!mentionIndex || mentionIndex.root !== mentionRoot || !mentionIndex.repo) return [];
+    return filterFileMentions(mentionIndex.files, mentionToken.query, FILE_MENTION_RESULT_LIMIT);
+  }, [mentionToken, mentionDismissed, mentionIndex, mentionRoot]);
+  const mentionOpen = mentionMatches.length > 0;
+  // The mention picker shares the composer combobox with the slash menu but
+  // the two can never open together (`@` is mid-token, `/` first-token-only),
+  // so while the picker IS open these override the closed slash menu's ARIA
+  // wiring (later JSX attributes win; AriaAttributes keys are optional so the
+  // override spread typechecks).
+  const mentionAriaOverrides: React.AriaAttributes = mentionOpen
+    ? {
+        "aria-expanded": true,
+        "aria-controls": mentionListboxId,
+        "aria-activedescendant": `${mentionListboxId}-opt-${mentionIdx}`,
+      }
+    : {};
+
+  // Lazy index fetch: first `@` for a given root loads it; the API's own
+  // short-lived cache absorbs re-opens across composer instances.
+  useEffect(() => {
+    if (!mentionToken || !mentionRoot) return;
+    if (mentionIndex?.root === mentionRoot) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(`/api/project/files?root=${encodeURIComponent(mentionRoot)}`, { cache: "no-store" });
+        const json = await res.json() as { ok?: boolean; repo?: boolean; files?: string[] };
+        if (cancelled) return;
+        setMentionIndex({
+          root: mentionRoot,
+          repo: json.ok === true && json.repo === true,
+          files: Array.isArray(json.files) ? json.files : [],
+        });
+      } catch {
+        if (!cancelled) setMentionIndex({ root: mentionRoot, repo: false, files: [] });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [mentionToken, mentionRoot, mentionIndex]);
+
+  // Insert the picked path inline, replacing the `@query` token (Claude Code
+  // convention: `@src/foo.ts`), and record it for the send body.
+  const selectMention = (relPath: string) => {
+    if (!mentionToken) return;
+    const insert = `@${relPath} `;
+    const next = input.slice(0, mentionToken.start) + insert + input.slice(composerCaret);
+    const nextCaret = mentionToken.start + insert.length;
+    setInput(next);
+    setComposerCaret(nextCaret);
+    setMentionedFiles((prev) =>
+      (prev.includes(relPath) ? prev : [...prev, relPath]).slice(0, MAX_FILE_MENTIONS),
+    );
+    requestAnimationFrame(() => {
+      const el = inputRef.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(nextCaret, nextCaret);
+    });
+  };
+
+  const syncComposerCaret = (e: React.SyntheticEvent<HTMLTextAreaElement>) => {
+    setComposerCaret(e.currentTarget.selectionStart ?? e.currentTarget.value.length);
+  };
   const activeLifecycle = useMemo(() => {
     const activeTurn = [...turns].reverse().find((turn) => turn.role === "assistant" && turn.pending);
     return activeTurn?.lifecycle ?? (busy ? "connecting" : null);
@@ -1034,12 +1143,19 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   useEffect(() => {
     setSlashIdx(0);
     setSlashDismissed(false);
+    setMentionIdx(0);
+    setMentionDismissed(false);
   }, [input]);
 
   useEffect(() => {
     if (slashSuggestions.length === 0) return;
     activeSlashOptionRef.current?.scrollIntoView({ block: "nearest" });
   }, [slashIdx, slashSuggestions.length]);
+
+  useEffect(() => {
+    if (mentionMatches.length === 0) return;
+    activeMentionOptionRef.current?.scrollIntoView({ block: "nearest" });
+  }, [mentionIdx, mentionMatches.length]);
 
   useEffect(() => {
     turnsRef.current = turns;
@@ -1386,10 +1502,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     return true;
   };
 
-  const sendRaw = async (text: string, outgoingAttachments: ChatAttachment[] = []) => {
+  const sendRaw = async (text: string, outgoingAttachments: ChatAttachment[] = [], outgoingMentions: string[] = []) => {
     const trimmed = text.trim();
     if ((!trimmed && outgoingAttachments.length === 0) || busy) return;
-    const request: FailedSend = { text: trimmed, attachments: outgoingAttachments };
+    const request: FailedSend = {
+      text: trimmed,
+      attachments: outgoingAttachments,
+      ...(outgoingMentions.length ? { mentionedFiles: outgoingMentions } : {}),
+    };
     setBusy(true);
     setError(null);
     setLastFailedSend(null);
@@ -1434,6 +1554,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           sessionId: currentSessionRef.current,
           ...((cwdDraft.trim() || projectRoot) && !currentSessionRef.current
             ? { projectRoot: cwdDraft.trim() || projectRoot }
+            : {}),
+          // CHAT-D1-04: @-mentioned repo files ride with the root they are
+          // relative to — resumed sessions don't resend projectRoot above.
+          ...(outgoingMentions.length && mentionRoot
+            ? {
+                mentionedFiles: outgoingMentions.slice(0, MAX_FILE_MENTIONS),
+                mentionedFilesRoot: mentionRoot,
+              }
             : {}),
         }),
         signal: controller.signal,
@@ -1518,7 +1646,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     if (!lastFailedSend || busy) return;
     setError(null);
     setLastFailedSend(null);
-    void sendRaw(lastFailedSend.text, lastFailedSend.attachments);
+    void sendRaw(lastFailedSend.text, lastFailedSend.attachments, lastFailedSend.mentionedFiles ?? []);
   }
 
   // CHAT-D6-01: edit-and-resend. Loads a user turn's text into the composer so
@@ -1561,9 +1689,15 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     // above still run mid-stream; plain sends keep the draft intact.
     if (busy) return;
     const outgoingAttachments = attachments.map(({ id: _id, ...attachment }) => attachment);
+    // Only mentions whose `@path` token survived editing ride along — a
+    // deleted reference must not silently re-enter the prompt.
+    const outgoingMentions = mentionedFiles
+      .filter((p) => text.includes(`@${p}`))
+      .slice(0, MAX_FILE_MENTIONS);
     setInput("");
     setAttachments([]);
-    await sendRaw(text, outgoingAttachments);
+    setMentionedFiles([]);
+    await sendRaw(text, outgoingAttachments, outgoingMentions);
   };
 
   // Auto-send a prompt handed off from the home composer. Deferred one
@@ -1762,6 +1896,32 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   }
 
   const onComposerKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (mentionOpen) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setMentionIdx((i) => Math.min(i + 1, mentionMatches.length - 1));
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setMentionIdx((i) => Math.max(i - 1, 0));
+        return;
+      }
+      if (e.key === "Tab" || (e.key === "Enter" && !e.shiftKey)) {
+        e.preventDefault();
+        const file = mentionMatches[Math.min(mentionIdx, mentionMatches.length - 1)];
+        if (file) selectMention(file);
+        return;
+      }
+      // Esc precedence: an open mention menu consumes Esc (dismiss) before
+      // the slash-menu and busy-cancel branches below (#402 ordering). The
+      // two menus never open together — `@` is mid-token, `/` first-token.
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setMentionDismissed(true);
+        return;
+      }
+    }
     if (slashSuggestions.length > 0) {
       if (e.key === "ArrowDown") {
         e.preventDefault();
@@ -1812,11 +1972,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     }
   };
 
-  // Disarm a pending delete confirmation (and drop any CWD draft) when
-  // switching sessions.
+  // Disarm a pending delete confirmation (and drop any CWD draft and staged
+  // file mentions) when switching sessions.
   useEffect(() => {
     setConfirmDelete(false);
     setCwdDraft("");
+    setMentionedFiles([]);
   }, [sessionId]);
 
   const deleteChat = async () => {
@@ -2033,6 +2194,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 cwd={cwdDraft}
                 defaultCwd={projectRoot}
                 onCwdChange={!sessionId ? setCwdDraft : undefined}
+                fileMentions={Boolean(mentionRoot)}
               />
             )
           ) : null}
@@ -2169,6 +2331,42 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         style={{ "--composer-kb-offset": `${keyboardOffset}px` } as React.CSSProperties}
       >
         <div className="cave-composer-shell">
+          {mentionOpen ? (
+            <div className="absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-xl">
+              <ul className="max-h-64 overflow-y-auto py-1" id={mentionListboxId} role="listbox" aria-label="Workspace files">
+                {mentionMatches.map((file, i) => {
+                  const active = i === mentionIdx;
+                  const base = file.split("/").pop() ?? file;
+                  return (
+                    <li
+                      key={file}
+                      role="option"
+                      id={`${mentionListboxId}-opt-${i}`}
+                      aria-selected={active}
+                    >
+                      <button
+                        type="button"
+                        tabIndex={-1}
+                        ref={active ? activeMentionOptionRef : null}
+                        onMouseEnter={() => setMentionIdx(i)}
+                        onClick={() => selectMention(file)}
+                        className={`flex w-full items-center gap-3 px-3 py-2 text-left text-sm transition-colors ${
+                          active ? "bg-[var(--bg-raised)]/60" : "hover:bg-[var(--bg-raised)]/50"
+                        }`}
+                      >
+                        <Icon name="ph:file-code" width={13} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
+                        <span className="font-mono text-[var(--text-primary)]">{base}</span>
+                        <span className="flex-1 truncate text-xs text-[var(--text-muted)]">{file}</span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+              <div className="border-t border-[var(--border-hairline)] px-3 py-1.5 text-[10px] text-[var(--text-muted)]">
+                {keys.up}{keys.down} navigate · {keys.enter} insert · Tab insert · esc cancel
+              </div>
+            </div>
+          ) : null}
           {slashSuggestions.length > 0 ? (
             <div className="absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-xl">
               <ul className="max-h-64 overflow-y-auto py-1" id={slashListboxId} role="listbox" aria-label="Slash commands">
@@ -2273,8 +2471,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             <textarea
               ref={inputRef}
               value={input}
-              onChange={(e) => setInput(e.target.value)}
+              onChange={(e) => {
+                setInput(e.target.value);
+                syncComposerCaret(e);
+              }}
               onKeyDown={onComposerKey}
+              onKeyUp={syncComposerCaret}
+              onClick={syncComposerCaret}
+              onSelect={syncComposerCaret}
               onPaste={(e) => {
                 // Paste-to-attach (CHAT-D1-02): clipboard files (screenshots,
                 // copied images/files) win over any text payload riding along.
@@ -2305,6 +2509,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               aria-activedescendant={
                 slashSuggestions.length > 0 ? `${slashListboxId}-opt-${slashIdx}` : undefined
               }
+              {...mentionAriaOverrides}
             />
             <div className="flex items-center justify-between px-3 pb-2.5">
               <div className="flex items-center gap-1 text-[var(--text-muted)]">

--- a/src/lib/file-mention.ts
+++ b/src/lib/file-mention.ts
@@ -1,0 +1,91 @@
+/**
+ * `@`-file mention helpers for the chat composer (CHAT-D1-04).
+ *
+ * Pure functions so the token parsing and fuzzy ranking are behaviorally
+ * testable without a DOM: `fileMentionToken` finds the active `@query`
+ * token at the caret, `filterFileMentions` ranks the workspace file index
+ * against the query.
+ */
+
+/** Hard cap on mentions per send — mirrors the attachment cap. */
+export const MAX_FILE_MENTIONS = 10;
+/** How many fuzzy matches the picker shows. */
+export const FILE_MENTION_RESULT_LIMIT = 12;
+
+export type FileMentionToken = {
+  /** Index of the `@` in the composer text. */
+  start: number;
+  /** Text between the `@` and the caret. */
+  query: string;
+};
+
+/**
+ * Find the active `@` mention token at the caret. The `@` must start the
+ * text or follow whitespace — so emails and mid-word `@` never trigger the
+ * picker, and a `/slash` first token can never also be a mention (the two
+ * menus stay disjoint). The query must contain no whitespace and no second
+ * `@`; it may contain `/` so nested paths keep filtering.
+ */
+export function fileMentionToken(text: string, caret: number): FileMentionToken | null {
+  const bounded = Math.max(0, Math.min(caret, text.length));
+  const upTo = text.slice(0, bounded);
+  const start = upTo.lastIndexOf("@");
+  if (start < 0) return null;
+  if (start > 0 && !/\s/.test(upTo[start - 1] ?? "")) return null;
+  const query = upTo.slice(start + 1);
+  if (/[\s@]/.test(query)) return null;
+  return { start, query };
+}
+
+/** True when every char of `query` appears in `target` in order. */
+function isSubsequence(query: string, target: string): boolean {
+  let qi = 0;
+  for (let ti = 0; ti < target.length && qi < query.length; ti += 1) {
+    if (target[ti] === query[qi]) qi += 1;
+  }
+  return qi === query.length;
+}
+
+function basenameOf(p: string): string {
+  const idx = p.lastIndexOf("/");
+  return idx < 0 ? p : p.slice(idx + 1);
+}
+
+/**
+ * Case-insensitive fuzzy filter over repo-relative paths. Rank order:
+ *   0 — basename starts with the query (best: `@cha` → chat-view.tsx)
+ *   1 — basename contains the query
+ *   2 — full path contains the query
+ *   3 — query is a subsequence of the full path (weakest)
+ * Ties break to the shorter path, then lexicographically. An empty query
+ * returns the head of the index unranked.
+ */
+export function filterFileMentions(
+  files: readonly string[],
+  query: string,
+  limit: number = FILE_MENTION_RESULT_LIMIT,
+): string[] {
+  if (limit <= 0) return [];
+  const q = query.trim().toLowerCase();
+  if (!q) return files.slice(0, limit);
+
+  const scored: Array<{ file: string; rank: number }> = [];
+  for (const file of files) {
+    const p = file.toLowerCase();
+    const base = basenameOf(p);
+    let rank: number;
+    if (base.startsWith(q)) rank = 0;
+    else if (base.includes(q)) rank = 1;
+    else if (p.includes(q)) rank = 2;
+    else if (isSubsequence(q, p)) rank = 3;
+    else continue;
+    scored.push({ file, rank });
+  }
+  scored.sort(
+    (a, b) =>
+      a.rank - b.rank ||
+      a.file.length - b.file.length ||
+      (a.file < b.file ? -1 : a.file > b.file ? 1 : 0),
+  );
+  return scored.slice(0, limit).map((entry) => entry.file);
+}


### PR DESCRIPTION
Implements **CHAT-D1-04 (P1, L)** from the chat UX audit (#395) — the audit calls @-file references "the defining composer feature of the category" (Cursor/Windsurf `@file` pickers, Claude Code `@path` completion). The chat already knew its `projectRoot`; the composer just couldn't reach files.

## What's here

**File-index API — `GET /api/project/files?root=<abs>`**
- `git ls-files -z --cached --others --exclude-standard` (tracked + untracked-but-not-ignored), capped at 5000 paths with a `truncated` flag, ~10s module-level cache keyed by the realpathed root.
- Not-a-repo is a distinct non-error state (`{ ok: true, repo: false }`).

**Composer trigger (chat composer only — the home composer has no projectRoot)**
- Typing `@` opens a file-picker popover when the chat knows its root: `session.project_root`, the CWD draft, or the pre-wired `projectRoot` prop — the same sources the send body uses.
- Client-side fuzzy filter (`src/lib/file-mention.ts`, pure + behaviorally tested): basename-prefix > basename-substring > path-substring > subsequence; shows 12.
- ↑↓ navigate, Enter/Tab insert, Esc dismisses with precedence ahead of the slash and busy-cancel branches (#402 ordering). The two menus are structurally disjoint (`@` mid-token vs `/` first-token).
- Combobox/listbox ARIA mirrors the slash menu (#423). The contended `home-composer.test.ts` pins the slash ARIA verbatim, so the picker overrides it via a later `{...mentionAriaOverrides}` spread only while open — pinned wiring stays byte-identical.

## Selection semantics (choice: inline `@path` + prompt block, not pills)

Selecting a file replaces the `@query` token with the relative path inline (`@src/foo.ts`, Claude Code convention) and records it in `mentionedFiles` state. On send the body carries `mentionedFiles` + `mentionedFilesRoot` (resumed sessions don't resend `projectRoot`); mentions whose `@path` token was edited out of the draft are dropped; cap 10. I chose the recommended inline path over pill-based attachment-row references — smaller diff, no `chat-attachments.ts` changes, and the reference survives in the visible turn text.

Server-side, `/api/chat/send` appends a compact block at the prompt-build site:

```
Referenced files (open with the Read tool):
- /abs/path/to/src/foo.ts
```

## Security posture

Mirrors `/api/changes` (#422): every git invocation is `execFile` with an argument array — no shell; the root must be absolute, is realpath-resolved, and must be inside a git work tree. Mention validation on the send route: repo-relative only, NUL/absolute/`..` rejected, prefix containment under the realpathed root, plus a realpath re-check on each file so an in-repo symlink can't smuggle an outside path into the prompt; invalid entries are silently skipped. Mentions only ship to local filesystem-readable harnesses (same gate as image delivery — bridges/SSH never get unreachable paths).

## Tests

- Behavioral fuzzy-helper tests + source pins (route posture, ARIA parity, Esc precedence order, send-body shape, prompt-block render) in `chat-view-polish.test.ts` (mine this wave).
- Exactly one `/project/files` contract line in `api-contracts.test.ts` (74 contracts pass).
- `pnpm typecheck`, `pnpm test:api`, `pnpm test:app` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)