### PR TITLE
fix(chat): clarify changes panel empty repo state

### DIFF
--- a/src/components/debug-pane.test.ts
+++ b/src/components/debug-pane.test.ts
@@ -60,6 +60,16 @@ assert.match(
   /All uncommitted changes in/,
   "Panel caption must be honest that git shows repo-wide changes, not per-session ones",
 );
+assert.match(
+  changesPanel,
+  /notARepo\s*\?\s*<>\s*No git working tree at[\s\S]*?:\s*<>\s*All uncommitted changes in/,
+  "Panel caption should switch copy when the project is not a git repository",
+);
+assert.match(
+  changesPanel,
+  /title=\{untracked \? `Delete \$\{file\.path\}` : `Revert \$\{file\.path\}`\}[\s\S]*?<Icon name=\{untracked \? "ph:trash" : "ph:arrow-counter-clockwise"\}/,
+  "Untracked file delete action should use a trash icon before confirm, matching its label",
+);
 
 const changesRoute = await readFile(
   new URL("../app/api/changes/route.ts", import.meta.url),

--- a/src/components/session-changes-panel.tsx
+++ b/src/components/session-changes-panel.tsx
@@ -151,7 +151,7 @@ function FileRow({
             aria-label={untracked ? `Delete untracked file ${file.path}` : `Revert ${file.path}`}
             className="focus-ring shrink-0 rounded border border-[var(--border-hairline)] px-1.5 py-0.5 text-[var(--text-muted)] transition-all hover:border-[color-mix(in_oklch,var(--color-danger)_45%,transparent)] hover:bg-[color-mix(in_oklch,var(--color-danger)_14%,transparent)] hover:text-[var(--color-danger)] disabled:opacity-40"
           >
-            <Icon name="ph:arrow-counter-clockwise" width={11} aria-hidden />
+            <Icon name={untracked ? "ph:trash" : "ph:arrow-counter-clockwise"} width={11} aria-hidden />
           </button>
         )}
       </div>
@@ -334,7 +334,9 @@ function SessionChangesInner({ projectRoot, running }: { projectRoot: string; ru
           </button>
         </div>
         <p className="mt-0.5 truncate text-[10px] text-[var(--text-muted)]" title={repoRoot ?? projectRoot}>
-          All uncommitted changes in {repoRoot ?? projectRoot} — not only this session&rsquo;s edits.
+          {notARepo
+            ? <>No git working tree at {repoRoot ?? projectRoot}.</>
+            : <>All uncommitted changes in {repoRoot ?? projectRoot} — not only this session&rsquo;s edits.</>}
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
- show not-a-repo copy in the changes panel caption instead of claiming uncommitted changes
- use a trash icon for the unarmed untracked-file delete action
- add source regressions for both review comments

## Verification
- node --experimental-strip-types src/components/debug-pane.test.ts
- pnpm test:app
- pnpm typecheck