### PR TITLE
fix(chat): clear pending find highlight frame

### DIFF
--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -215,6 +215,11 @@ assert.equal(
   "+++ b/empty.ts",
   "Empty Write content renders only the file header, not a phantom + row",
 );
+assert.equal(
+  toolInputAsDiff("Write", JSON.stringify({ file_path: "blank.ts", content: "\n" })),
+  ["+++ b/blank.ts", "+"].join("\n"),
+  "Write content containing one blank line renders a meaningful blank + row",
+);
 
 // MultiEdit → one @@-labelled hunk per edit, concatenated.
 const multi = toolInputAsDiff(

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -291,6 +291,16 @@ assert.match(
   /const clearFoundHighlightTimer = useCallback\(\(\) => \{[\s\S]*?window\.clearTimeout\(foundClearTimerRef\.current\);[\s\S]*?foundClearTimerRef\.current = null;/,
   "Find highlight timer cleanup should clear and null the pending timeout",
 );
+assert.match(
+  source,
+  /const foundFrameRef = useRef<number \| null>\(null\);[\s\S]*?window\.cancelAnimationFrame\(foundFrameRef\.current\);[\s\S]*?foundFrameRef\.current = null;/,
+  "Find highlight cleanup should cancel and null a pending requestAnimationFrame",
+);
+assert.match(
+  source,
+  /foundFrameRef\.current = requestAnimationFrame\(\(\) => \{[\s\S]*?setFoundTurnId\(id\);[\s\S]*?foundFrameRef\.current = null;/,
+  "Find jumps should track the highlight requestAnimationFrame until it fires",
+);
 
 assert.match(
   source,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1182,9 +1182,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // Turn id flashed with the cave-turn-found highlight after a jump.
   const [foundTurnId, setFoundTurnId] = useState<string | null>(null);
   const foundClearTimerRef = useRef<number | null>(null);
+  const foundFrameRef = useRef<number | null>(null);
   const lastJumpedQueryRef = useRef("");
 
   const clearFoundHighlightTimer = useCallback(() => {
+    if (foundFrameRef.current !== null) {
+      window.cancelAnimationFrame(foundFrameRef.current);
+      foundFrameRef.current = null;
+    }
     if (foundClearTimerRef.current !== null) {
       window.clearTimeout(foundClearTimerRef.current);
       foundClearTimerRef.current = null;
@@ -1237,7 +1242,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       // turn: clear, then re-set on the next frame so the class re-applies.
       clearFoundHighlightTimer();
       setFoundTurnId(null);
-      requestAnimationFrame(() => setFoundTurnId(id));
+      foundFrameRef.current = requestAnimationFrame(() => {
+        setFoundTurnId(id);
+        foundFrameRef.current = null;
+      });
       foundClearTimerRef.current = window.setTimeout(() => {
         setFoundTurnId(null);
         foundClearTimerRef.current = null;

--- a/src/lib/tool-input-diff.ts
+++ b/src/lib/tool-input-diff.ts
@@ -31,8 +31,9 @@ function filePathOf(record: Rec): string {
 
 function prefixLines(text: string, prefix: "+" | "-"): string[] {
   // A trailing newline would otherwise render a spurious empty +/- row.
+  if (text === "") return [];
   const body = text.endsWith("\n") ? text.slice(0, -1) : text;
-  if (!body) return [];
+  if (!body) return [`${prefix}`];
   return body.split("\n").map((line) => `${prefix}${line}`);
 }
 


### PR DESCRIPTION
## Summary
- cancel pending find highlight requestAnimationFrame callbacks during cleanup
- preserve single blank-line mutation diffs while still suppressing empty content phantom rows
- add regressions for both late review comments

## Verification
- node --experimental-strip-types src/components/chat-header-row.test.ts
- node --experimental-strip-types src/components/chat-view-lifecycle.test.ts
- pnpm test:app
- pnpm typecheck