### PR TITLE
feat(chat): interleave tool calls at their chronological position in the turn

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3,7 +3,8 @@
 import { forwardRef, useCallback, useEffect, useId, useImperativeHandle, useMemo, useRef, useState } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { RichText } from "@/components/rich-text";
-import { MessageBubble, SyntaxBlock } from "@/components/message-bubble";
+import { MessageBubble, SyntaxBlock, type MessageBubbleSegment } from "@/components/message-bubble";
+import { segmentTurn } from "@/lib/turn-segments";
 import { canonicalize, formatHelp, matchSlash, type SlashCommand } from "@/lib/slash-commands";
 import { slashSaveParse } from "@/lib/slash-save-parser";
 import { Icon, type IconName } from "@/lib/icon";
@@ -37,6 +38,12 @@ type ToolEvent = {
   output?: string;
   status: "running" | "ok" | "error";
   durationMs?: number;
+  /** CHAT-D4-01: length of the turn's accumulated text when this tool's
+   *  FIRST event arrived — lets TurnRow interleave the tool block at its
+   *  chronological position between prose spans. Absent on tool events from
+   *  stored transcripts that predate the field (legacy turns keep the
+   *  trailing rollup). */
+  textOffset?: number;
 };
 
 type ProgressEvent = {
@@ -1671,10 +1678,17 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                           // update doesn't supply them.
                           input: incoming.input ?? x.input,
                           output: incoming.output ?? x.output,
+                          // CHAT-D4-01: keep the offset captured when the
+                          // call first arrived — settle events must not move
+                          // the block.
+                          textOffset: x.textOffset,
                         }
                       : x,
                   )
-                : [...tools, incoming];
+                : // CHAT-D4-01: first event for this call — record how much
+                  // text had streamed so far, so the tool block renders at
+                  // its chronological position between prose spans.
+                  [...tools, { ...incoming, textOffset: t.text.length }];
             // Post-tool events carry no input, so summarize from the merged
             // record (which preserves the input captured at pre-tool time).
             const argSummary = toolArgSummary(
@@ -2476,6 +2490,33 @@ function TurnRow({
   const reasoning = turn.reasoning?.trim() || inlineReasoning;
   const turnStatus = turn.lifecycle ?? (turn.error ? "failed" : turn.pending ? "streaming" : "complete");
 
+  // CHAT-D4-01: when every tool event carries a textOffset (live turns from
+  // this session), render the turn as ordered segments — prose spans with
+  // each tool call inline at its chronological position — instead of the
+  // legacy "all text, then a trailing Tool activity rollup" stack that
+  // inverted causality. Offsets were captured against the raw streamed text;
+  // segmentTurn snaps them forward to fence-safe paragraph boundaries (and
+  // clamps past-end offsets, e.g. when splitReasoning stripped thinking
+  // markup), so a drifted offset degrades toward trailing — never a split
+  // inside a code fence. Stored transcripts without offsets return null and
+  // keep today's trailing ToolGroup.
+  const segments = segmentTurn(visible, turn.tools);
+  const bubbleSegments: MessageBubbleSegment[] | undefined = segments?.map((seg, i) =>
+    seg.kind === "text"
+      ? { kind: "text" as const, text: seg.text }
+      : {
+          kind: "block" as const,
+          key: `tools-${seg.tools[0]?.id ?? i}`,
+          // Reuse the EXISTING collapsed ToolBlock (arg summary + diff
+          // inputs); same-offset tools render consecutively in one group.
+          node: (
+            <div className="space-y-2">
+              {seg.tools.map((tool) => <ToolBlock key={tool.id} tool={tool} />)}
+            </div>
+          ),
+        },
+  );
+
   return (
     <div className="cave-linear-turn cave-linear-turn--assistant">
       <div className="cave-linear-turn-content text-[14px] leading-relaxed text-[var(--text-primary)] group/turn">
@@ -2512,7 +2553,21 @@ function TurnRow({
 
           <div className="cave-linear-turn-body">
             {turn.pending && !visible ? (
-              <ThinkingIndicator since={turn.createdAt} />
+              <>
+                <ThinkingIndicator since={turn.createdAt} />
+                {/* CHAT-D4-01: tools often run BEFORE the first prose chunk
+                    (research-style turns) — show them inline immediately so
+                    they don't teleport out of a rollup once text arrives. */}
+                {segments?.length ? (
+                  <div className="mt-3 space-y-2">
+                    {segments.flatMap((seg) =>
+                      seg.kind === "tools"
+                        ? seg.tools.map((tool) => <ToolBlock key={tool.id} tool={tool} />)
+                        : [],
+                    )}
+                  </div>
+                ) : null}
+              </>
             ) : (
               <MessageBubble
                 role="assistant"
@@ -2523,11 +2578,14 @@ function TurnRow({
                 isError={turn.error}
                 label={familiar.display_name}
                 onRegenerate={onRegenerate}
+                segments={bubbleSegments}
               />
             )}
             {turn.progress?.length ? <ProgressGroup progress={turn.progress} pending={!!turn.pending} /> : null}
             {reasoning ? <ReasoningBlock reasoning={reasoning} /> : null}
-            {turn.tools?.length ? <ToolGroup tools={turn.tools} /> : null}
+            {/* Legacy trailing rollup — ONLY for turns whose tools predate
+                textOffset; segmented turns render their tools inline. */}
+            {!segments && turn.tools?.length ? <ToolGroup tools={turn.tools} /> : null}
           </div>
         </div>
       </div>

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -27,6 +27,7 @@ import {
   useEffect,
   useRef,
   useState,
+  type ReactNode,
 } from "react";
 import { parse } from "@create-markdown/core";
 import type { Block } from "@create-markdown/core";
@@ -680,6 +681,15 @@ function CopyBubble({ text }: { text: string }) {
 // Public: MessageBubble
 // ---------------------------------------------------------------------------
 
+/**
+ * CHAT-D4-01: one ordered display segment of an assistant turn — either a
+ * prose span or an opaque block (a tool call rendered by the caller) at its
+ * chronological position between spans.
+ */
+export type MessageBubbleSegment =
+  | { kind: "text"; text: string }
+  | { kind: "block"; key: string; node: ReactNode };
+
 export type MessageBubbleProps = {
   role: "user" | "assistant" | "system";
   content: string;
@@ -694,9 +704,16 @@ export type MessageBubbleProps = {
   /** CHAT-D6-02: regenerate — renders a Regenerate action in the assistant
    *  bubble's revealed action row. Caller gates it on !busy/!pending. */
   onRegenerate?: () => void;
+  /** CHAT-D4-01: ordered segments — prose spans interleaved with tool blocks
+   *  at their chronological position. Assistant role only; when present they
+   *  replace the single MarkdownContent render. `content` must still carry
+   *  the FULL text so the Copy/Expand actions are unchanged. Only the LAST
+   *  text span streams (progressive markdown + ▌ cursor); earlier spans
+   *  render settled. */
+  segments?: MessageBubbleSegment[];
 };
 
-export function MessageBubble({ role, content, timestamp, showTimestamp = true, pending, isError, label, onEdit, onRegenerate }: MessageBubbleProps) {
+export function MessageBubble({ role, content, timestamp, showTimestamp = true, pending, isError, label, onEdit, onRegenerate, segments }: MessageBubbleProps) {
   const [tsVisible, setTsVisible] = useState(false);
   const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -768,6 +785,13 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
   }
 
   // Assistant
+  // CHAT-D4-01: with segments, only the LAST text span is the live streaming
+  // edge — earlier spans are settled slices that never change retroactively,
+  // so they take MarkdownContent's settled path (cached render, no throttle,
+  // no cursor) and the ▌ cursor shows on at most one span.
+  const lastTextIdx = segments
+    ? segments.reduce((acc, seg, i) => (seg.kind === "text" ? i : acc), -1)
+    : -1;
   return (
     <div
       className="group relative cave-bubble-assistant"
@@ -775,7 +799,17 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
       onMouseLeave={handleMouseLeave}
     >
       <div className={isError ? "text-[var(--color-warning)]" : ""}>
-        <MarkdownContent text={content} pending={pending} />
+        {segments?.length ? (
+          segments.map((seg, i) =>
+            seg.kind === "text" ? (
+              <MarkdownContent key={`span-${i}`} text={seg.text} pending={pending && i === lastTextIdx} />
+            ) : (
+              <div key={seg.key} className="my-2">{seg.node}</div>
+            ),
+          )
+        ) : (
+          <MarkdownContent text={content} pending={pending} />
+        )}
       </div>
       {/* Always in the DOM (CHAT-D6-04) — visibility is CSS-gated so the
           actions are reachable by keyboard (Tab), screen readers, and touch. */}

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -17,6 +17,12 @@ export type ChatTurn = {
     output?: string;
     status: "running" | "ok" | "error";
     durationMs?: number;
+    /** CHAT-D4-01: length of the turn text when the tool's first event
+     *  arrived — drives inline (chronological) tool placement in the chat
+     *  view. Optional: turns persisted before the field render with the
+     *  legacy trailing rollup. The conversation route passes tool arrays
+     *  through whole, so the field round-trips for free. */
+    textOffset?: number;
   }>;
   createdAt: string;
   durationMs?: number;

--- a/src/lib/session-debug.test.ts
+++ b/src/lib/session-debug.test.ts
@@ -81,3 +81,169 @@ assert.equal(debugFileName("s1"), "debug-s1.json");
 assert.equal(debugFileName(null), "debug-session.json");
 
 console.log("session-debug tests passed");
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CHAT-D4-01 — interleaved tool segments (src/lib/turn-segments.ts).
+// Lives here because test:app is an explicit script list (no package.json
+// edits) and this is the non-contended lib test file in it.
+// ═══════════════════════════════════════════════════════════════════════════
+
+import { readFileSync } from "node:fs";
+import { segmentTurn } from "./turn-segments.ts";
+
+// ── Legacy passthrough: turns without offsets render exactly as today ──────
+assert.equal(segmentTurn("some text", undefined), null, "no tools → null (legacy)");
+assert.equal(segmentTurn("some text", []), null, "empty tools → null (legacy)");
+assert.equal(
+  segmentTurn("some text", [{ id: "a" }]),
+  null,
+  "tools without textOffset (stored transcripts) → null (legacy trailing rollup)",
+);
+assert.equal(
+  segmentTurn("some text", [{ id: "a", textOffset: 0 }, { id: "b" }]),
+  null,
+  "ANY tool missing an offset disables segmentation — never a half-interleaved turn",
+);
+
+// ── Basic interleave: tool between paragraphs, in chronological order ──────
+{
+  const text = "Intro para.\n\nSecond para.\n\nThird para.";
+  // Tool arrived mid-first-paragraph (offset 4): snaps FORWARD to the start
+  // of the next paragraph, never splitting a paragraph in half.
+  const segs = segmentTurn(text, [{ id: "t1", textOffset: 4 }]);
+  assert.deepEqual(
+    segs.map((s) => s.kind),
+    ["text", "tools", "text"],
+    "tool renders between prose spans",
+  );
+  assert.equal(segs[0].text, "Intro para.\n\n", "first span is a verbatim slice");
+  assert.equal(segs[2].text, "Second para.\n\nThird para.");
+  assert.equal(
+    segs.filter((s) => s.kind === "text").map((s) => s.text).join(""),
+    text,
+    "text spans reassemble the full text verbatim",
+  );
+}
+
+// ── Offset 0: tool that ran before any prose renders FIRST ─────────────────
+{
+  const segs = segmentTurn("Answer prose.", [{ id: "t1", textOffset: 0 }]);
+  assert.deepEqual(segs.map((s) => s.kind), ["tools", "text"], "pre-prose tool leads the turn");
+}
+
+// ── Past-end offsets clamp to a trailing group (graceful degradation) ──────
+{
+  const segs = segmentTurn("Short.", [{ id: "t1", textOffset: 9999 }]);
+  assert.deepEqual(segs.map((s) => s.kind), ["text", "tools"]);
+}
+
+// ── Fence safety: blank lines INSIDE a code fence are not boundaries ───────
+{
+  const text = "Before.\n\n```ts\nconst a = 1;\n\nconst b = 2;\n```\n\nAfter.";
+  // Offset lands inside the fence (after "const a = 1;") — must snap past
+  // the fence to the paragraph after it, never splitting the fence open.
+  const inFence = text.indexOf("const b") - 1;
+  const segs = segmentTurn(text, [{ id: "t1", textOffset: inFence }]);
+  assert.deepEqual(segs.map((s) => s.kind), ["text", "tools", "text"]);
+  assert.ok(segs[0].text.includes("```\n"), "the whole fence stays in the span before the tool");
+  assert.equal(segs[2].text, "After.");
+  const fenceCount = (segs[0].text.match(/```/g) ?? []).length;
+  assert.equal(fenceCount % 2, 0, "no span ends inside an unterminated fence");
+}
+
+// ── Same-offset tools group consecutively, preserving arrival order ────────
+{
+  const text = "Para one.\n\nPara two.";
+  const segs = segmentTurn(text, [
+    { id: "first", textOffset: 3 },
+    { id: "second", textOffset: 3 },
+  ]);
+  assert.deepEqual(segs.map((s) => s.kind), ["text", "tools", "text"]);
+  assert.deepEqual(
+    segs[1].tools.map((t) => t.id),
+    ["first", "second"],
+    "same-offset tools render as one consecutive group in arrival order",
+  );
+}
+
+// ── Streaming stability: appended text lands AFTER the tool ────────────────
+{
+  // Tool arrived when the text was exactly "First para." (offset = length).
+  const tools = [{ id: "t1", textOffset: "First para.".length }];
+  const before = segmentTurn("First para.", tools);
+  assert.deepEqual(before.map((s) => s.kind), ["text", "tools"], "mid-stream: tool trails current text");
+  // More text streams in: it belongs to the NEXT span; the prose before the
+  // tool is unchanged — settled spans never move retroactively.
+  const after = segmentTurn("First para.\n\nSecond para.", tools);
+  assert.deepEqual(after.map((s) => s.kind), ["text", "tools", "text"]);
+  assert.equal(after[0].text.trim(), before[0].text.trim(), "span before the tool is stable across appends");
+  assert.equal(after[2].text, "Second para.", "appended text falls into the following span");
+}
+
+// ── Tool-only turn (no prose yet): pure tool segments ──────────────────────
+{
+  const segs = segmentTurn("", [{ id: "t1", textOffset: 0 }]);
+  assert.deepEqual(segs.map((s) => s.kind), ["tools"]);
+}
+
+// ── Source pins ─────────────────────────────────────────────────────────────
+const chatViewSource = readFileSync(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
+const bubbleSource = readFileSync(new URL("../components/message-bubble.tsx", import.meta.url), "utf8");
+const convRouteSource = readFileSync(
+  new URL("../app/api/chat/conversation/[id]/route.ts", import.meta.url),
+  "utf8",
+);
+
+// The tool_use SSE handler captures the offset at the tool's FIRST event —
+// the length of the text accumulated so far — and settle events preserve it.
+assert.match(
+  chatViewSource,
+  /\[\.\.\.tools, \{ \.\.\.incoming, textOffset: t\.text\.length \}\]/,
+  "CHAT-D4-01: new tool events record the accumulated text length as textOffset",
+);
+assert.match(
+  chatViewSource,
+  /textOffset: x\.textOffset,/,
+  "CHAT-D4-01: settle/update events keep the offset captured at first arrival",
+);
+
+// TurnRow renders the segmented path from the reasoning-stripped visible
+// text, and keeps the trailing ToolGroup ONLY as the legacy (no-offset) path.
+assert.match(
+  chatViewSource,
+  /const segments = segmentTurn\(visible, turn\.tools\)/,
+  "CHAT-D4-01: assistant turns segment the visible text by tool offsets",
+);
+assert.match(
+  chatViewSource,
+  /\{!segments && turn\.tools\?\.length \? <ToolGroup tools=\{turn\.tools\} \/> : null\}/,
+  "CHAT-D4-01: trailing ToolGroup rollup survives ONLY for legacy turns without offsets",
+);
+assert.match(
+  chatViewSource,
+  /seg\.tools\.map\(\(tool\) => <ToolBlock key=\{tool\.id\} tool=\{tool\} \/>\)/,
+  "CHAT-D4-01: interleaved tools reuse the existing collapsed ToolBlock",
+);
+
+// MessageBubble: only the LAST text span streams (progressive markdown +
+// cursor); settled spans render with pending=false.
+assert.match(
+  bubbleSource,
+  /pending=\{pending && i === lastTextIdx\}/,
+  "CHAT-D4-01: the ▌ cursor / progressive render applies only to the last text span",
+);
+assert.match(
+  bubbleSource,
+  /<MarkdownContent text=\{content\} pending=\{pending\} \/>/,
+  "CHAT-D4-01: segment-less bubbles keep the single MarkdownContent render",
+);
+
+// Round-trip: the conversation write route passes tool arrays through whole,
+// so textOffset on persisted tools survives serialization without migration.
+assert.match(
+  convRouteSource,
+  /\.\.\.\(Array\.isArray\(value\.tools\) \? \{ tools: value\.tools \} : \{\}\)/,
+  "CHAT-D4-01: conversation route round-trips whole tool objects (textOffset survives)",
+);
+
+console.log("turn-segments (CHAT-D4-01) tests passed");

--- a/src/lib/turn-segments.ts
+++ b/src/lib/turn-segments.ts
@@ -1,0 +1,128 @@
+// CHAT-D4-01 — interleave tool calls at their chronological position.
+//
+// An assistant turn streams as text chunks interleaved with tool_use events,
+// but the legacy display flattened that into "all text, then a trailing tool
+// rollup" — tools that ran BEFORE a paragraph rendered AFTER it, inverting
+// causality. The chat SSE handler now records, per tool, the length of the
+// accumulated turn text at the moment the tool's FIRST event arrived
+// (`textOffset`), and this module turns (text, tools-with-offsets) into an
+// ordered list of display segments: prose spans and tool groups in arrival
+// order.
+//
+// Splitting markdown at an arbitrary character offset is hazardous — a split
+// inside a code fence breaks the fence and re-typesets everything after it.
+// Offsets are therefore snapped FORWARD to the next paragraph boundary that
+// sits OUTSIDE any code fence (the start of the line following a blank line,
+// with ```/~~~ fence tracking), or to the end of the text when no such
+// boundary follows yet. Tools that snap to the same boundary render as one
+// consecutive group, preserving arrival order.
+//
+// Streaming stability falls out of the offset model: offsets are captured
+// against a text that only ever grows, so text appended after a tool arrived
+// always lands in the span FOLLOWING that tool. A tool that arrives
+// mid-paragraph floats at the end of the current text until the paragraph
+// boundary streams in, then anchors there permanently — settled spans never
+// change retroactively.
+//
+// Legacy compatibility (graceful degradation, NO transcript migration):
+// stored transcripts predate `textOffset`. When there are no tools, or ANY
+// tool lacks a finite offset, segmentTurn returns null and the caller keeps
+// today's trailing-rollup rendering.
+
+export type SegmentedTool = {
+  /** Length of the turn text when this tool's first event arrived. */
+  textOffset?: number;
+};
+
+export type TurnSegment<T extends SegmentedTool> =
+  | { kind: "text"; text: string }
+  | { kind: "tools"; tools: T[] };
+
+/**
+ * Offsets (into `text`) where the document can be split without landing
+ * inside a code fence: the start of each line that follows a blank line,
+ * computed with fence tracking (a blank line INSIDE a ```/~~~ fence is not a
+ * paragraph boundary). A fence only closes on its own marker style, so a
+ * ``` line inside a ~~~ block does not toggle state.
+ */
+function paragraphBreakpoints(text: string): number[] {
+  const points: number[] = [];
+  let pos = 0;
+  let fence: "```" | "~~~" | null = null;
+  let prevBlank = false;
+  for (const line of text.split("\n")) {
+    const lead = line.trimStart();
+    const blank = lead.length === 0;
+    // Boundary check uses the fence state BEFORE this line: splitting right
+    // before a fence opener is safe.
+    if (!fence && prevBlank && !blank) points.push(pos);
+    const marker = lead.startsWith("```") ? "```" : lead.startsWith("~~~") ? "~~~" : null;
+    if (marker && (fence === null || fence === marker)) {
+      fence = fence === null ? marker : null;
+    }
+    prevBlank = fence === null && blank;
+    pos += line.length + 1;
+  }
+  return points;
+}
+
+/** Snap an offset forward to the next safe paragraph boundary, or text end. */
+function snapOffset(offset: number, textLength: number, breakpoints: number[]): number {
+  if (offset <= 0) return 0;
+  if (offset >= textLength) return textLength;
+  for (const bp of breakpoints) {
+    if (bp >= offset) return bp;
+  }
+  return textLength;
+}
+
+/**
+ * Assemble the ordered segment list for an assistant turn.
+ *
+ * Returns null when the turn cannot be segmented (no tools, or any tool
+ * without a finite `textOffset`) — the caller renders the legacy layout.
+ * Otherwise returns text spans and tool groups in chronological order;
+ * whitespace-only spans are dropped, and the concatenation of the emitted
+ * text spans plus dropped whitespace equals the input text (spans are
+ * verbatim slices — markdown is never rewritten).
+ */
+export function segmentTurn<T extends SegmentedTool>(
+  text: string,
+  tools: readonly T[] | undefined,
+): Array<TurnSegment<T>> | null {
+  if (!tools || tools.length === 0) return null;
+  if (!tools.every((t) => typeof t.textOffset === "number" && Number.isFinite(t.textOffset))) {
+    return null;
+  }
+  const breakpoints = paragraphBreakpoints(text);
+  // Stable sort: tools captured at the same boundary keep arrival order.
+  const placed = tools
+    .map((tool) => ({
+      tool,
+      at: snapOffset(tool.textOffset as number, text.length, breakpoints),
+    }))
+    .sort((a, b) => a.at - b.at);
+
+  const segments: Array<TurnSegment<T>> = [];
+  let cursor = 0;
+  let i = 0;
+  while (i < placed.length) {
+    const at = placed[i].at;
+    const group: T[] = [];
+    while (i < placed.length && placed[i].at === at) {
+      group.push(placed[i].tool);
+      i += 1;
+    }
+    if (at > cursor) {
+      const span = text.slice(cursor, at);
+      if (span.trim()) segments.push({ kind: "text", text: span });
+      cursor = at;
+    }
+    segments.push({ kind: "tools", tools: group });
+  }
+  if (cursor < text.length) {
+    const tail = text.slice(cursor);
+    if (tail.trim()) segments.push({ kind: "text", text: tail });
+  }
+  return segments;
+}


### PR DESCRIPTION
Implements **CHAT-D4-01 (P1, L)** from the chat UX audit (#395) — the largest remaining presentation gap.

## The gap

An assistant turn rendered as a fixed stack: MessageBubble (all text) → ProgressGroup → ReasoningBlock → trailing ToolGroup. Every tool trailed the ENTIRE answer as an appendix, so tools that ran BEFORE the prose appeared AFTER it — inverting causality. Claude Code and Cursor both render each tool call collapsed inline at its chronological position between prose segments.

## Design: ordered segments via additive textOffset

- **Offset capture (chat-view SSE handler):** when a tool's FIRST event arrives, the `tool_use` upsert records `textOffset = turn.text.length` — how much text had streamed so far. Settle/update events preserve the captured offset, so blocks never move when a tool finishes.
- **Segment assembly (`src/lib/turn-segments.ts`, new pure helper):** `segmentTurn(text, tools)` splits the turn into ordered text spans + tool groups. Splitting markdown at an arbitrary offset is hazardous, so each offset is **snapped forward to the next paragraph boundary outside any code fence** (blank-line tracking with ``` / ~~~ fence state — blank lines *inside* fences are not boundaries), or to text end. Same-offset tools render as one consecutive group in arrival order.
- **Render (TurnRow assistant branch):** when every tool carries an offset, the bubble renders MarkdownContent(span₀) → ToolBlock(s) → MarkdownContent(span₁) → … reusing the EXISTING collapsed ToolBlock (#424 arg summaries + #429 diff inputs — no fork). ProgressGroup/ReasoningBlock placement unchanged. Tools that run before the first prose chunk render inline under the ThinkingIndicator instead of teleporting out of a rollup once text arrives.
- **Legacy fallback, no migration:** stored transcripts whose tools lack offsets (and the jsonl fallback loader's synthesized tools) return `null` from `segmentTurn` and keep today's trailing ToolGroup rollup exactly. Mixed turns (any tool missing an offset) also fall back — never a half-interleaved turn.
- **Streaming correctness:** offsets are captured against a text that only grows, so text appended after a tool arrives lands in the following span; settled spans are verbatim slices that never change retroactively (cached settled markdown renders). Only the **last** text span streams through the progressive #405 path (throttle + stamps) and shows the ▌ cursor.
- **MessageBubble additive `segments` prop:** per-span progressive rendering + "copy copies the whole turn text" both require composing inside the bubble, and `MarkdownContent` is private — so MessageBubble gained one optional additive prop instead of forking the bubble chrome. `content` still carries the full thinking-stripped text; Copy/Expand/Regenerate actions are byte-for-byte unchanged (the contended message-bubble pins pass untouched).
- **Persistence:** the conversation write route already passes tool arrays through whole, so `textOffset` round-trips for free; `ChatTurn.tools` in `cave-conversations.ts` documents the optional field (one-field addition mirroring `durationMs`). The send route never persisted tools at all (pre-existing), so nothing there changes.

## Test placement choice

`test:app` is an explicit script chain (and package.json edits were out of scope), so a new test file couldn't self-register; per the audit dispatch, the behavioral tests + source pins live as a clearly-commented **CHAT-D4-01 section appended to `src/lib/session-debug.test.ts`** (in test:app, non-contended, next to the other lib tests).

Behavioral coverage: legacy/no-offset passthrough, basic interleave + verbatim reassembly, offset-0 (tool before prose), past-end clamp, fence-interior snapping, same-offset grouping, streaming append stability, tool-only turns. Source pins: offset capture + preservation in the tool_use handler, segmented render path, legacy-only ToolGroup fallback, ToolBlock reuse, last-span-only cursor, conversation-route round-trip.

## Tests

- `node --experimental-strip-types src/lib/session-debug.test.ts` — pass (incl. new CHAT-D4-01 section)
- chat-header-row, message-bubble-markdown, chat-view-lifecycle, chat-view-polish pins — all pass unedited
- `pnpm test:app` — pass
- `pnpm test:api` — pass
- `pnpm typecheck` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)