### PR TITLE
fix(chat): consolidate streaming status signals; persistent elapsed in meta line

### DIFF
--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -304,4 +304,82 @@ assert.match(
   "ChatView passes the settled turn's duration, usage, and cost into MetaLine together (CHAT-D12-02)",
 );
 
+// ── CHAT-D12-01: consolidate simultaneous streaming status signals ──
+
+// (a) While the turn's own live indicator shows (pending, no visible text),
+// the Queued/Connecting/Writing chip in the same meta row is redundant —
+// suppressed until text flows or the turn settles. One shared flag gates both
+// so the chip and the indicator can never double up.
+assert.match(
+  source,
+  /const indicatorVisible = Boolean\(turn\.pending\) && !visible;/,
+  "TurnRow derives a single indicator-visibility flag from pending + visible text (CHAT-D12-01)",
+);
+assert.match(
+  source,
+  /\{turnStatus !== "complete" && !indicatorVisible && \(/,
+  "Lifecycle chip is suppressed while the turn's own ThinkingIndicator is visible (CHAT-D12-01)",
+);
+assert.match(
+  source,
+  /\{indicatorVisible \? \(\s*\n\s*<ThinkingIndicator since=\{turn\.createdAt\} \/>/,
+  "ThinkingIndicator renders off the same flag that suppresses the chip (CHAT-D12-01)",
+);
+// Settled chips stay load-bearing: the suppression must key off pending, so a
+// failed turn (pending: false) always shows the Failed chip that anchors the
+// Retry pill (#416/#420).
+assert.doesNotMatch(
+  source,
+  /const indicatorVisible =[^\n]*turn\.error/,
+  "Indicator-visibility flag must not involve turn.error — settled Failed chips always render (CHAT-D12-01)",
+);
+
+// (b) The synthetic "Receiving response" progress row settles at the first
+// assistant chunk instead of staying "running" for the whole stream — the
+// streamed text itself is the live signal, and the auto-open ProgressGroup
+// quiets down to real connect/tool events.
+assert.match(
+  source,
+  /case "assistant_chunk":[\s\S]*?id: "stream",\s*\n\s*label: "Receiving response",\s*\n\s*status: "done",/,
+  "The synthetic Receiving-response row settles (done) at first chunk (CHAT-D12-01)",
+);
+
+// (c) CHAT-D3-06: the MetaLine streaming state carries a compact ticking
+// elapsed ("writing… · 14s · esc to cancel") so the wall-clock counter
+// survives past the first token. SR-quiet: the ticker lives in an aria-hidden
+// span INSIDE the role="status" live region, so the per-second rewrite is
+// excluded from the accessibility tree (the CHAT-D12-04 rewrites-per-second
+// problem); the announced meta string only changes on state transitions.
+assert.match(
+  source,
+  /function MetaLineElapsed\(\{ since \}: \{ since: string \}\)[\s\S]*?setInterval\(tick, 1000\)[\s\S]*?aria-hidden="true"/,
+  "MetaLineElapsed ticks on a 1s interval and renders aria-hidden (CHAT-D3-06)",
+);
+assert.match(
+  source,
+  /\{state === "streaming" && pendingSince \? <MetaLineElapsed since=\{pendingSince\} \/> : null\}\s*\n\s*\{state === "streaming" \? " · esc to cancel" : null\}/,
+  "Streaming meta line renders elapsed between the phase wording and the esc hint (CHAT-D3-06)",
+);
+// The esc hint moved out of metaLineString into MetaLine's JSX so the ticker
+// could slot in before it — the string builder must not duplicate it.
+const metaLineStringBody =
+  source.match(/function metaLineString\([\s\S]*?\n}\n/)?.[0] ?? "";
+assert.ok(metaLineStringBody, "metaLineString body should be extractable (CHAT-D3-06)");
+assert.doesNotMatch(
+  metaLineStringBody,
+  /esc to cancel/,
+  "metaLineString no longer carries the esc hint — MetaLine renders it after the ticker (CHAT-D3-06)",
+);
+// The ticker anchors to the in-flight assistant turn's createdAt.
+assert.match(
+  source,
+  /pendingSince=\{activePendingTurn\?\.createdAt \?\? null\}/,
+  "ChatView anchors the MetaLine ticker to the pending assistant turn (CHAT-D3-06)",
+);
+assert.match(
+  styles,
+  /\.cave-chat-meta-line__elapsed\s*\{[\s\S]*?font-variant-numeric:\s*tabular-nums/,
+  "Elapsed ticker uses tabular digits so the meta line doesn't jitter (CHAT-D3-06)",
+);
+
 console.log("chat-view-lifecycle.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -661,7 +661,9 @@ function metaLineString(args: {
   } else if (args.state === "streaming") {
     if (args.model) parts.push(args.model);
     parts.push(args.lifecycle === "tooling" ? "using tools…" : args.lifecycle === "connecting" || args.lifecycle === "queued" ? "connecting…" : "writing…");
-    parts.push("esc to cancel");
+    // CHAT-D3-06: the "· 14s" ticker + esc hint tail is rendered by MetaLine
+    // itself so the ticking elapsed can live in an aria-hidden span — keeping
+    // the per-second rewrite out of the role="status" live region.
   } else {
     if (args.harness) parts.push(args.harness);
     if (args.model) parts.push(args.model);
@@ -805,6 +807,27 @@ function ChatBackButton({ onBack }: { onBack: () => void }) {
   );
 }
 
+/** CHAT-D3-06: compact ticking elapsed for the streaming/tooling meta line,
+ *  so the wall-clock counter survives past the first token (ThinkingIndicator
+ *  swaps to text and takes its counter with it). Same 1s interval pattern as
+ *  ThinkingIndicator. SR-quiet by construction: the span is aria-hidden INSIDE
+ *  the role="status" live region, so the per-second rewrite is excluded from
+ *  the accessibility tree and never announced (the rewrites-per-second
+ *  problem from CHAT-D12-04). */
+function MetaLineElapsed({ since }: { since: string }) {
+  const [elapsed, setElapsed] = useState(0);
+  useEffect(() => {
+    const start = new Date(since).getTime();
+    const tick = () => setElapsed(Math.max(0, Math.floor((Date.now() - start) / 1000)));
+    tick();
+    const t = setInterval(tick, 1000);
+    return () => clearInterval(t);
+  }, [since]);
+  return (
+    <span aria-hidden="true" className="cave-chat-meta-line__elapsed">{` · ${elapsed}s`}</span>
+  );
+}
+
 /** Single header row: editable title left, harness/model/status meta right.
  *  Ephemeral state (streaming, failed, daemon offline) recolors the line and
  *  rewrites the meta string instead of emitting separate pills/bars. */
@@ -813,6 +836,7 @@ function MetaLine({
   linkedContext,
   busy,
   lifecycle,
+  pendingSince,
   error,
   daemonRunning,
   durationMs,
@@ -828,6 +852,8 @@ function MetaLine({
   linkedContext: ChatLinkedContext | null;
   busy: boolean;
   lifecycle: ChatTurnLifecycle | null;
+  /** createdAt of the in-flight assistant turn — start of the elapsed ticker. */
+  pendingSince?: string | null;
   error: boolean;
   daemonRunning: boolean | undefined;
   durationMs: number | undefined;
@@ -868,7 +894,11 @@ function MetaLine({
           onSessionsChanged={onSessionsChanged}
         />
       ) : null}
-      <span className="cave-chat-meta-line__meta">{meta}</span>
+      <span className="cave-chat-meta-line__meta">
+        {meta}
+        {state === "streaming" && pendingSince ? <MetaLineElapsed since={pendingSince} /> : null}
+        {state === "streaming" ? " · esc to cancel" : null}
+      </span>
       {children}
     </div>
   );
@@ -1309,10 +1339,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // Stable per-mount listbox id — the home composer mounts its own slash menu,
   // so ids must be unique across simultaneously mounted composers.
   const slashListboxId = useId();
-  const activeLifecycle = useMemo(() => {
-    const activeTurn = [...turns].reverse().find((turn) => turn.role === "assistant" && turn.pending);
-    return activeTurn?.lifecycle ?? (busy ? "connecting" : null);
-  }, [busy, turns]);
+  // In-flight assistant turn drives the MetaLine's live state: its lifecycle
+  // picks the phase wording and its createdAt anchors the elapsed ticker
+  // (CHAT-D3-06).
+  const activePendingTurn = useMemo(
+    () => [...turns].reverse().find((turn) => turn.role === "assistant" && turn.pending),
+    [turns],
+  );
+  const activeLifecycle = activePendingTurn?.lifecycle ?? (busy ? "connecting" : null);
   // Latest settled assistant turn feeds the MetaLine's complete-state
   // one-liner: duration plus token usage / cost (CHAT-D12-02).
   const lastSettledAssistantTurn = useMemo(
@@ -1932,10 +1966,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   text: (t.text + ev.text).replace(/\n{3,}/g, "\n\n"),
                   pending: true,
                   lifecycle: "streaming",
+                  // CHAT-D12-01: settle the synthetic row the moment text is
+                  // flowing — the streamed text IS the live signal from here
+                  // on. Leaving it "running" kept the auto-open ProgressGroup
+                  // pulsing for the entire stream.
                   progress: upsertProgressEvent(t.progress, {
                     id: "stream",
                     label: "Receiving response",
-                    status: "running",
+                    status: "done",
                   }),
                 }
               : t,
@@ -2242,6 +2280,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           linkedContext={linkedContext}
           busy={busy}
           lifecycle={activeLifecycle}
+          pendingSince={activePendingTurn?.createdAt ?? null}
           error={!!error}
           daemonRunning={daemonRunning}
           durationMs={lastSettledAssistantTurn?.durationMs}
@@ -2802,6 +2841,12 @@ function TurnRow({
   const { visible, reasoning: inlineReasoning } = splitReasoning(turn.text);
   const reasoning = turn.reasoning?.trim() || inlineReasoning;
   const turnStatus = turn.lifecycle ?? (turn.error ? "failed" : turn.pending ? "streaming" : "complete");
+  // CHAT-D12-01: while this turn's own live indicator is showing (pending, no
+  // visible text yet), a Queued/Connecting/Writing chip in the same meta row
+  // duplicates it — suppress the chip until text flows or the turn settles.
+  // Settled chips never hit this (pending is false by then), so the Failed
+  // chip that anchors the Retry pill (#416/#420) always renders.
+  const indicatorVisible = Boolean(turn.pending) && !visible;
 
   return (
     <div
@@ -2816,7 +2861,7 @@ function TurnRow({
         <div className="cave-linear-turn-right">
           <div className="cave-linear-turn-meta">
             <span className="cave-linear-turn-name">{familiar.display_name}</span>
-            {turnStatus !== "complete" && (
+            {turnStatus !== "complete" && !indicatorVisible && (
               <span className={`cave-turn-status cave-turn-status--${turnStatus}`}>
                 {lifecycleLabel(turnStatus)}
               </span>
@@ -2842,7 +2887,7 @@ function TurnRow({
           </div>
 
           <div className="cave-linear-turn-body">
-            {turn.pending && !visible ? (
+            {indicatorVisible ? (
               <ThinkingIndicator since={turn.createdAt} />
             ) : (
               <MessageBubble

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1081,6 +1081,12 @@ details[open] > .cave-tool-summary::before {
   font-size: 11px;
 }
 
+/* CHAT-D3-06: ticking elapsed inside the streaming meta line. Tabular digits
+   keep the line from jittering as the counter advances each second. */
+.cave-chat-meta-line__elapsed {
+  font-variant-numeric: tabular-nums;
+}
+
 .cave-chat-meta-line__dot {
   width: 7px;
   height: 7px;


### PR DESCRIPTION
Implements **CHAT-D12-01 (P2)** and **CHAT-D3-06 (P3)** from the chat UX audit (#395).

## Problem

Up to **five simultaneous status signals** during a single stream in `chat-view.tsx`:

1. MetaLine `writing… · esc to cancel` + blinking dot
2. Per-turn "Writing" lifecycle chip
3. ThinkingIndicator animated dots + elapsed counter
4. Auto-open ProgressGroup with a synthetic "Receiving response" row pinned at `running` for the entire stream
5. Composer placeholder `Streaming… (esc to cancel)`

Benchmark: Claude Code carries phase + elapsed + esc hint in **one** status line; ChatGPT shows exactly one stop affordance. Meanwhile the elapsed counter here *vanished* once text started flowing (the indicator swaps to the streamed text and takes its counter with it) — CHAT-D3-06.

## Signal inventory: before → after

| # | Signal | Before | After |
|---|--------|--------|-------|
| 1 | MetaLine (ambient channel) | `model · writing… · esc to cancel` | `model · writing… · 14s · esc to cancel` — now also carries a ticking elapsed (CHAT-D3-06) |
| 2 | Per-turn lifecycle chip | Queued/Connecting/Writing shown alongside the indicator | **Suppressed while the turn's own ThinkingIndicator is visible** (pending, no text); returns once text flows; settled chips (Cancelled/**Failed**) untouched |
| 3 | ThinkingIndicator | dots + elapsed, pre-first-token | unchanged (primary live channel; shared dedupe is CHAT-D3-05, deferred to the last bundle) |
| 4 | "Receiving response" progress row | `running` for the whole stream → group pulses throughout | **Settles (`done`) at first chunk** — ProgressGroup quiets down to real connect/tool events; with no running rows the pulse stops. Row kept: pre-first-token is when it's useful |
| 5 | Composer placeholder | `Streaming… (esc to cancel)` | **Left intact** — exact string is pinned by `chat-view-polish.test.ts` (contended this wave, not editable) |

Net during a healthy stream: **one primary live channel** (the per-turn area: indicator pre-token, then the streamed text) + **one ambient channel** (MetaLine, now carrying phase + elapsed + esc hint, Claude Code-style).

## Failure stack (verified, no behavior change)

- The transient error banner is gated on the `error` state, which `done` events with `isError` never set (they only arm `lastFailedSend`) — confirmed CHAT-D12-03's transport-only gating has not regressed.
- Chip suppression keys off `turn.pending`, which is false on settled turns — the **Failed chip always renders** and keeps anchoring the #420 Retry pill. A regression pin asserts the suppression flag never involves `turn.error`.

## SR-quiet ticker (the CHAT-D12-04 hazard)

MetaLine is a `role="status"` / `aria-live="polite"` region; a per-second text rewrite inside it would spam screen readers. Chosen option: **the ticking elapsed lives in an `aria-hidden="true"` span inside the live region** — aria-hidden subtrees are excluded from the accessibility tree, so the 1s rewrites are never announced, while state transitions (writing → complete/failed) still announce normally. The esc-hint tail moved out of `metaLineString` into MetaLine's JSX so the ticker slots between phase wording and hint; the live region itself stays fully intact (no demotion needed).

## Implementation notes

- `MetaLineElapsed` reuses ThinkingIndicator's 1s-interval pattern, anchored to the in-flight assistant turn's `createdAt`; `cave-chat-meta-line__elapsed` uses `tabular-nums` so the line doesn't jitter.
- `activeLifecycle` derivation refactored to expose the pending turn (`activePendingTurn`) — same lookup, now also feeding the ticker anchor.
- `chat-view-lifecycle.test.ts` extended with pins for: chip suppressed while indicator shows (and never via `turn.error`), "Receiving response" settles at first chunk, MetaLineElapsed present + aria-hidden + 1s interval, esc hint out of `metaLineString`, ticker anchored to the pending turn, tabular-nums rule.

## Tests

- `chat-view-lifecycle.test.ts`: ok (all existing #397/#409/#416/#420 pins + new ones)
- `pnpm test:app`: exit 0
- `pnpm typecheck`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)