### PR TITLE
fix(chat): readability polish — muted ink contrast, table overflow, tool clamp, landmarks

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -71,7 +71,11 @@
   --fg-muted: var(--text-secondary);
   --text-primary: var(--foreground);
   --text-secondary: var(--muted-foreground);
-  --text-muted: color-mix(in oklch, var(--foreground) 40%, transparent);
+  /* CHAT-D13-02: 40% alpha composited ~3:1 on the dark panel ladder — under
+     AA for the 9-11px labels that consume this token. 55% lands ~6:1 over
+     --card/--bg-elevated while still reading as muted next to
+     --text-secondary. Light mode needs its own ratio (override below). */
+  --text-muted: color-mix(in oklch, var(--foreground) 55%, transparent);
 
   /* ---- Radii ---- */
   --radius: 0.625rem;
@@ -240,8 +244,12 @@
 
   --text-primary: var(--foreground);
   --text-secondary: var(--muted-foreground);
-  /* --border, --border-strong, --input, --text-muted are derived from --foreground;
+  /* --border, --border-strong, --input are derived from --foreground;
      they auto-invert. No override needed. */
+  /* CHAT-D13-02: dark ink over near-white needs a higher mix than light ink
+     over near-black for the same contrast — 55% composites ~4.1:1 here; 62%
+     lands ~5:1 against --background/--card. */
+  --text-muted: color-mix(in oklch, var(--foreground) 62%, transparent);
 
   --ring-focus: color-mix(in oklch, var(--accent-presence) 55%, transparent);
   --ring-focus-soft: color-mix(in oklch, var(--accent-presence) 30%, transparent);

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -214,4 +214,36 @@ assert.match(
   "Clicking a content hit opens the session via the existing onOpen path",
 );
 
+// ── CHAT-D13-02: micro-type legibility ─────────────────────────────────────
+// 9px uppercase stat/meta labels sat under AA contrast at the old 40%-alpha
+// muted ink. Labels are lifted to 10px (hierarchy preserved via uppercase +
+// tracking) and the token itself is raised: 55% mix in dark, 62% in light.
+assert.doesNotMatch(
+  source,
+  /text-\[9px\]/,
+  "ChatList must not render 9px micro-type (CHAT-D13-02 — lifted to 10px)",
+);
+assert.match(
+  source,
+  /text-\[10px\] font-medium uppercase tracking-\[0\.1em\] text-\[var\(--text-muted\)\]/,
+  "Stat labels keep the uppercase/tracking hierarchy at the lifted 10px size",
+);
+
+const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+assert.match(
+  globals,
+  /--text-muted: color-mix\(in oklch, var\(--foreground\) 55%, transparent\);/,
+  "Dark-mode --text-muted mixes at 55% (≥4.5:1 over the panel ladder, CHAT-D13-02)",
+);
+assert.match(
+  globals,
+  /--text-muted: color-mix\(in oklch, var\(--foreground\) 62%, transparent\);/,
+  "Light-mode --text-muted overrides to 62% (dark ink needs a higher mix for the same contrast)",
+);
+assert.doesNotMatch(
+  globals,
+  /--text-muted: color-mix\(in oklch, var\(--foreground\) 40%, transparent\);/,
+  "The old 40% muted-ink mix (~3:1 on dark, ~2.5:1 on light) must not return",
+);
+
 console.log("chat-list-delete.test.ts: ok");

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -481,21 +481,21 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
           <div className="group rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 px-2.5 py-2 transition-colors hover:border-[var(--accent-presence)]/25 hover:bg-[var(--bg-raised)]/60">
             <div className="flex items-center gap-1.5">
               <Icon name="ph:chats" width={11} className="text-[var(--text-muted)]" />
-              <p className="text-[9px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]">Chats</p>
+              <p className="text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]">Chats</p>
             </div>
             <p className="mt-1 font-mono text-[15px] font-semibold text-[var(--text-primary)]">{mine.length}</p>
           </div>
           <div className="group rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 px-2.5 py-2 transition-colors hover:border-[var(--accent-presence)]/25 hover:bg-[var(--bg-raised)]/60">
             <div className="flex items-center gap-1.5">
               <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${runningCount > 0 ? "animate-pulse bg-[var(--color-success)]" : "bg-[var(--text-muted)]"}`} />
-              <p className="text-[9px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]">Live</p>
+              <p className="text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]">Live</p>
             </div>
             <p className={`mt-1 font-mono text-[15px] font-semibold ${runningCount > 0 ? "text-[var(--color-success)]" : "text-[var(--text-primary)]"}`}>{runningCount}</p>
           </div>
           <div className="group rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 px-2.5 py-2 transition-colors hover:border-[var(--accent-presence)]/25 hover:bg-[var(--bg-raised)]/60">
             <div className="flex items-center gap-1.5">
               <Icon name="ph:folder" width={11} className="text-[var(--text-muted)]" />
-              <p className="text-[9px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]">Projects</p>
+              <p className="text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]">Projects</p>
             </div>
             <p className="mt-1 font-mono text-[15px] font-semibold text-[var(--text-primary)]">{projectCount}</p>
           </div>
@@ -627,11 +627,11 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               </div>
               <div className="mt-4 divide-y divide-[var(--border-hairline)] border-y border-[var(--border-hairline)] text-left">
                 <div className="flex items-center justify-between gap-3 py-2">
-                  <p className="text-[9px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">Harness</p>
+                  <p className="text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">Harness</p>
                   <p className="min-w-0 truncate font-mono text-[11px] text-[var(--text-secondary)]">{panelRuntime}</p>
                 </div>
                 <div className="flex items-center justify-between gap-3 py-2">
-                  <p className="text-[9px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">Model</p>
+                  <p className="text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">Model</p>
                   <p className="min-w-0 truncate font-mono text-[11px] text-[var(--text-secondary)]">{familiar?.model ?? "default"}</p>
                 </div>
               </div>

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -158,8 +158,8 @@ assert.match(
 
 assert.match(
   chatSurface,
-  /<aside className="relative flex h-full min-h-0 min-w-0 flex-1 flex-col border-l border-\[var\(--border-hairline\)\]">/,
-  "ChatSurface right side panel should be height-bounded so its body can scroll vertically",
+  /<aside role="region" aria-label="Session panels" className="relative flex h-full min-h-0 min-w-0 flex-1 flex-col border-l border-\[var\(--border-hairline\)\]">/,
+  "ChatSurface right side panel should be height-bounded so its body can scroll vertically (and read as a named region, not a nested complementary landmark — CHAT-D13-05)",
 );
 
 assert.match(

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -71,7 +71,10 @@ function RightPanel({
   onInboxItemChanged: () => void | Promise<void>;
 }) {
   return (
-    <aside className="relative flex h-full min-h-0 min-w-0 flex-1 flex-col border-l border-[var(--border-hairline)]">
+    // CHAT-D13-05: this panel renders inside the shell's <main>, where a
+    // complementary landmark is invalid (axe landmark-complementary-is-top-level)
+    // — expose it as a named region instead.
+    <aside role="region" aria-label="Session panels" className="relative flex h-full min-h-0 min-w-0 flex-1 flex-col border-l border-[var(--border-hairline)]">
       <div className="right-panel-tabs">
         <button
           type="button"

--- a/src/components/message-bubble-code-header.test.ts
+++ b/src/components/message-bubble-code-header.test.ts
@@ -245,6 +245,22 @@ assert.match(
   "The expanded state must lift the height clamp",
 );
 
+// CHAT-D4-07 — tool I/O is secondary context: inside .cave-tool-block the
+// wrap clamps tighter (min(48vh, 360px) vs prose's 520px). The :not() guard
+// keeps the Show-more toggle able to lift the clamp, and the rule reuses the
+// wrap's own overflow-y: auto — no second scroll container.
+const toolWrapBlock = ruleBlock(".cave-tool-block .cave-code-wrap:not(.cave-code-wrap--expanded)");
+assert.match(
+  toolWrapBlock,
+  /max-height:\s*min\(48vh,\s*360px\)/,
+  "Tool-block code wraps must clamp tighter than prose code blocks (CHAT-D4-07)",
+);
+assert.doesNotMatch(
+  toolWrapBlock,
+  /overflow/,
+  "The tool clamp must not introduce a second scroll container — the wrap already scrolls",
+);
+
 const renderCodeBlockFn = /async function renderCodeBlock\([\s\S]*?\n\}/.exec(source)?.[0] ?? "";
 assert.match(
   renderCodeBlockFn,

--- a/src/components/message-bubble-markdown.test.ts
+++ b/src/components/message-bubble-markdown.test.ts
@@ -39,6 +39,17 @@ assert.match(
   "Rendered tables substitute positionally for the renderer's own <table> output",
 );
 
+// ── CHAT-D7-08: wide tables scroll, they don't word-shatter ───────────────
+// Every substituted table is wrapped in a horizontal scroll container; cells
+// undo .cave-md's overflow-wrap: anywhere so unbreakable tokens grow the
+// table past 100% (auto table layout) into the wrapper's scrollbar instead
+// of shattering mid-word.
+assert.match(
+  source,
+  /<div class="cave-table-scroll">\$\{tableReplacements\[tableIdx\] \?\? tableMatch\[0\]\}<\/div>/,
+  "mdToHtml wraps each rendered table (including the positional fallback) in .cave-table-scroll",
+);
+
 // ── CHAT-D6-04: per-message actions must be keyboard/touch reachable ──────
 // The Copy/Expand bubble actions must be mounted unconditionally (when not
 // pending) and revealed by CSS — never mount-gated on a JS `hovered` state,
@@ -160,6 +171,19 @@ assert.match(
   css,
   /@media \(pointer: coarse\) \{\s*\.cave-copy-btn-bubble \{\s*opacity: 1;/,
   "Coarse pointers have no hover — bubble actions must be always visible there",
+);
+
+// CHAT-D7-08 CSS half: the wrapper owns horizontal overflow; cells restore
+// normal word wrapping so the table can exceed its container when needed.
+assert.match(
+  css,
+  /\.cave-md \.cave-table-scroll \{\s*max-width: 100%;\s*overflow-x: auto;/,
+  ".cave-table-scroll is the horizontal scroll container for rendered tables",
+);
+assert.match(
+  css,
+  /\.cave-md th,\s*\.cave-md td \{[\s\S]*?word-break: normal;\s*overflow-wrap: normal;/,
+  "Table cells undo .cave-md's break-anywhere so wide content scrolls instead of word-shattering",
 );
 
 console.log("message-bubble-markdown.test.ts: ok");

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -497,7 +497,9 @@ async function mdToHtml(markdown: string, opts?: { transient?: boolean }): Promi
     let tableMatch: RegExpExecArray | null;
     while ((tableMatch = tableRe.exec(html)) !== null) {
       tableHtml += html.slice(tableLastIdx, tableMatch.index);
-      tableHtml += tableReplacements[tableIdx] ?? tableMatch[0];
+      // CHAT-D7-08: wide tables scroll horizontally inside this wrapper
+      // instead of word-shattering under .cave-md's overflow-wrap: anywhere.
+      tableHtml += `<div class="cave-table-scroll">${tableReplacements[tableIdx] ?? tableMatch[0]}</div>`;
       tableLastIdx = tableRe.lastIndex;
       tableIdx += 1;
     }

--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -120,3 +120,37 @@ assert.match(
   /keyboard shortcuts sheet/,
   "/help footer should mention the shortcuts sheet so it stays discoverable",
 );
+
+// ── CHAT-D13-05: landmark hygiene (live axe findings) ───────────────────────
+// page-has-heading-one: the shell renders no visible page title, so the
+// workspace detail pane carries a visually-hidden h1 naming the active
+// surface. landmark-unique: the shell's complementary panels need distinct
+// accessible names.
+const shell = await readFile(new URL("./shell.tsx", import.meta.url), "utf8");
+
+assert.match(
+  workspace,
+  /<h1 className="sr-only">\{WORKSPACE_MODE_TITLES\[mode\] \?\? "Coven Cave"\}<\/h1>/,
+  "Workspace detail must render a visually-hidden h1 naming the active surface (axe page-has-heading-one)",
+);
+assert.match(
+  workspace,
+  /const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = \{/,
+  "The h1 title map must cover every WorkspaceMode (Record enforces exhaustiveness)",
+);
+
+assert.match(
+  shell,
+  /<aside className="shell-nav" aria-label="Sidebar">/,
+  "Shell nav panel must carry a distinct accessible name (axe landmark-unique)",
+);
+assert.match(
+  shell,
+  /<aside className="shell-list" aria-label="List pane">/,
+  "Shell list panel must carry a distinct accessible name (axe landmark-unique)",
+);
+assert.match(
+  shell,
+  /<aside className="shell-agent" aria-label="Companion">/,
+  "Shell agent panel must carry a distinct accessible name (axe landmark-unique)",
+);

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -383,7 +383,9 @@ function ShellInner({
           setNavOpen((size.asPercentage ?? 0) > 0);
         }}
       >
-        <aside className="shell-nav">{nav}</aside>
+        {/* CHAT-D13-05: every complementary landmark carries a distinct
+            accessible name (axe landmark-unique). */}
+        <aside className="shell-nav" aria-label="Sidebar">{nav}</aside>
       </Panel>
       <Separator className="shell-separator" />
       {!twoPane && (
@@ -398,7 +400,7 @@ function ShellInner({
             collapsedSize={0}
             panelRef={listRef}
           >
-            <aside className="shell-list">{list}</aside>
+            <aside className="shell-list" aria-label="List pane">{list}</aside>
           </Panel>
           <Separator className="shell-separator" />
         </>
@@ -425,7 +427,7 @@ function ShellInner({
               setAgentOpen((size.asPercentage ?? 0) > 0);
             }}
           >
-            <aside className="shell-agent">{agentOpen ? agent : null}</aside>
+            <aside className="shell-agent" aria-label="Companion">{agentOpen ? agent : null}</aside>
           </Panel>
         </>
       )}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -62,6 +62,25 @@ import type { PendingChatAction } from "@/lib/pending-chat-action";
 
 type WorkspaceMode = WorkspaceModeFromDaemon;
 
+// CHAT-D13-05 (axe page-has-heading-one): the shell renders no visible page
+// title, so the detail pane carries a visually-hidden h1 naming the active
+// surface. Labels mirror the sidebar's vocabulary.
+const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = {
+  agents: "Familiars",
+  home: "Home",
+  chat: "Chat",
+  board: "Board",
+  calendar: "Calendar",
+  inbox: "Inbox",
+  library: "Library",
+  browser: "Browser",
+  terminal: "Terminal",
+  github: "GitHub",
+  roles: "Roles",
+  workflows: "Workflows",
+  capabilities: "Capabilities",
+};
+
 // Chat deep links (CHAT-D9-01): `#chat-<sessionId>` re-enters a specific
 // thread, same in-app hash idiom as `#card-<id>` and `library:projects`.
 // ChatRouter writes the hash (syncUrlHash); Workspace owns restore + popstate.
@@ -1061,6 +1080,7 @@ export function Workspace() {
 
   const detail = (
     <div key={mode} className="cave-mode-fade h-full flex flex-col">
+      <h1 className="sr-only">{WORKSPACE_MODE_TITLES[mode] ?? "Coven Cave"}</h1>
       {mode === "agents" ? (
       <AgentsView
         familiars={familiars}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -153,6 +153,21 @@
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    TABLES
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+/* CHAT-D7-08: mdToHtml wraps every rendered table in .cave-table-scroll so
+   wide tables get a horizontal scrollbar instead of dominating layout. */
+.cave-md .cave-table-scroll {
+  max-width: 100%;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in oklch, var(--accent-presence) 20%, transparent) transparent;
+}
+.cave-md .cave-table-scroll::-webkit-scrollbar { height: 4px; }
+.cave-md .cave-table-scroll::-webkit-scrollbar-track { background: transparent; }
+.cave-md .cave-table-scroll::-webkit-scrollbar-thumb {
+  background: color-mix(in oklch, var(--accent-presence) 22%, transparent);
+  border-radius: 2px;
+}
+
 .cave-md table {
   width: 100%;
   border-collapse: collapse;
@@ -168,6 +183,11 @@
   border-right: 1px solid var(--border-hairline);
   text-align: left;
   vertical-align: top;
+  /* CHAT-D7-08: undo .cave-md's break-anywhere inside cells — auto table
+     layout then grows the table past 100% when a token can't wrap, and the
+     .cave-table-scroll wrapper scrolls it instead of shattering words. */
+  word-break: normal;
+  overflow-wrap: normal;
 }
 .cave-md th:last-child,
 .cave-md td:last-child { border-right: none; }
@@ -951,6 +971,15 @@ details[open] > .cave-tool-summary::before {
   border-radius: 7px;
   background: color-mix(in oklch, var(--bg-base) 58%, transparent);
   padding: 9px;
+}
+
+/* CHAT-D4-07: expanded tool I/O is secondary context — clamp it tighter than
+   prose code blocks (which cap at min(60vh, 520px), CHAT-D7-03). 360px sits
+   between that and the system bubble's 320px. SyntaxBlock renders through
+   .cave-code-wrap, which already owns overflow-y: auto; only the cap changes.
+   :not() leaves the "Show more" toggle able to lift the clamp. */
+.cave-tool-block .cave-code-wrap:not(.cave-code-wrap--expanded) {
+  max-height: min(48vh, 360px);
 }
 
 .cave-composer-dock {


### PR DESCRIPTION
Implements four P2/P3 findings from the chat UX audit (#395) as one polish bundle.

## CHAT-D13-02 — micro-type on 40%-alpha muted ink

- `--text-muted` raised from a 40% to a **55%** foreground mix in the dark base (`src/app/globals.css`). Rough composite math over the dark panel ladder (`--card` oklch 0.165): ~3.7:1 → ~6:1.
- Light mode previously inherited the same derivation (~2.6:1 over near-white); it now gets its own **62%** override (~5:1) — dark ink needs a higher mix than light ink for the same contrast.
- **Intentionally global:** `--text-muted` has ~580 consumers across the app. Every one of them was below AA; this is a readability floor-raise, not a chat-only tweak. Code-block chrome is unaffected — it uses the fixed `--code-chrome-ink-*` tokens since #425.
- ChatList's five 9px uppercase stat/meta labels (`Chats`/`Live`/`Projects`/`Harness`/`Model`) lifted to 10px, keeping the uppercase + tracking hierarchy.

## CHAT-D7-08 — tables had no horizontal-overflow handling

- `mdToHtml` now wraps every substituted table (including the positional fallback) in `<div class="cave-table-scroll">` with `overflow-x: auto`.
- `th/td` reset `word-break`/`overflow-wrap` to `normal`: with auto table layout, an unbreakable token grows the table past 100% into the wrapper's scrollbar instead of shattering mid-word under `.cave-md`'s `overflow-wrap: anywhere`. Normal tables still wrap at word boundaries and render full-width — no `nowrap`, no `max-content` blowup.

## CHAT-D4-07 — expanded tool output unbounded height

- Verified first: `SyntaxBlock` renders through `.cave-code-wrap`, so #433's `min(60vh, 520px)` clamp **already bounds** tool output — the literal "unbounded" finding is stale.
- Still applied the audit's tool-specific intent: inside `.cave-tool-block`, the wrap clamps tighter at `min(48vh, 360px)` (between the 320px system-bubble precedent and prose's 520px). The rule targets the same node that already owns `overflow-y: auto` (no double scrollbars) and uses `:not(.cave-code-wrap--expanded)` so "Show more" still lifts the clamp.

## CHAT-D13-05 — landmark hygiene (live axe findings)

- `landmark-unique`: shell's three unlabeled `<aside>` panels get distinct names — `Sidebar`, `List pane`, `Companion` (the trigger rails already had `Navigation toggle` / `Salem toggle`).
- `landmark-complementary-is-top-level`: ChatSurface's right panel `<aside>` renders inside the shell's `<main>` — demoted to `role="region"` + `aria-label="Session panels"`.
- `page-has-heading-one`: the workspace detail pane now renders `<h1 class="sr-only">` naming the active surface, via an exhaustive `Record<WorkspaceMode, string>` mirroring the sidebar vocabulary.
- Residual (out of scope, noted for follow-up): `inspector-pane.tsx:160` renders its own `<aside>` inside this region when the Inspector tab is open — axe may still flag that one nested complementary landmark.

## Tests

Pins added in free files per the audit-sweep conventions:
- `chat-list-delete.test.ts` — no 9px micro-type remains in ChatList; 10px labels keep hierarchy; 55%/62% mix values pinned, 40% banned.
- `message-bubble-markdown.test.ts` — `.cave-table-scroll` wrapper in `mdToHtml` + CSS (scroll container, cell wrap reset).
- `message-bubble-code-header.test.ts` — tool-context clamp value + no second scroll container.
- `roles-tools-navigation.test.ts` — sr-only h1 + exhaustive title map + shell aside labels.
- `chat-surface.test.ts` — existing right-panel pin updated to include the region role/label.

`pnpm test:app` exit 0, `pnpm typecheck` clean.

Audit findings: CHAT-D13-02, CHAT-D7-08, CHAT-D4-07, CHAT-D13-05 (from #395).

🤖 Generated with [Claude Code](https://claude.com/claude-code)