### PR TITLE
fix(chat): clamp mention picker index

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -72,7 +72,7 @@ const contracts: RouteContract[] = [
   { route: "/openclaw-agents", methods: ["GET"], kind: "json" },
   { route: "/project-file", methods: ["GET"], kind: "json", pathGuard: true },
   { route: "/project-tree", methods: ["GET"], kind: "json", pathGuard: true },
-  { route: "/project/files", methods: ["GET"], kind: "json" },
+  { route: "/project/files", methods: ["GET"], kind: "json", pathGuard: true },
   { route: "/roles", methods: ["GET", "POST"], kind: "json", readsJson: true },
   { route: "/salem", methods: ["GET", "POST"], kind: "json", readsJson: true },
   { route: "/sessions/[id]/events", methods: ["GET"], kind: "json" },

--- a/src/app/api/project/files/route.ts
+++ b/src/app/api/project/files/route.ts
@@ -3,6 +3,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import fs from "node:fs";
 import path from "node:path";
+import { resolveAllowedProjectPath } from "@/lib/server/project-paths";
 
 export const dynamic = "force-dynamic";
 
@@ -68,13 +69,19 @@ async function resolveIndexRoot(root: string): Promise<RootResolution> {
   if (!path.isAbsolute(root)) {
     return { ok: false, status: 400, error: "root must be an absolute path" };
   }
+  const allowedRoot = resolveAllowedProjectPath(root);
+  if (!allowedRoot) {
+    return { ok: false, error: "path not allowed", status: 403 };
+  }
   let real: string;
+  let stat: fs.Stats;
   try {
-    real = fs.realpathSync(path.resolve(root));
+    real = fs.realpathSync(allowedRoot);
+    stat = fs.statSync(real);
   } catch {
     return { ok: false, status: 404, error: "root does not exist" };
   }
-  if (!fs.statSync(real).isDirectory()) {
+  if (!stat.isDirectory()) {
     return { ok: false, status: 400, error: "root is not a directory" };
   }
   try {

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -545,8 +545,18 @@ assert.match(
 );
 assert.match(
   filesRouteSource,
-  /fs\.realpathSync\(path\.resolve\(root\)\)/,
-  "/api/project/files must realpath the root before use (mirror /api/changes)",
+  /import \{ resolveAllowedProjectPath \} from "@\/lib\/server\/project-paths"/,
+  "/api/project/files must reuse the standard allowed-root guard",
+);
+assert.match(
+  filesRouteSource,
+  /const allowedRoot = resolveAllowedProjectPath\(root\);[\s\S]*?if \(!allowedRoot\)[\s\S]*?path not allowed[\s\S]*?status: 403/,
+  "/api/project/files must reject roots outside allowed workspaces",
+);
+assert.match(
+  filesRouteSource,
+  /try \{[\s\S]*?fs\.realpathSync\(allowedRoot\);[\s\S]*?fs\.statSync\(real\);[\s\S]*?\} catch/,
+  "/api/project/files must realpath and stat the allowed root inside a guarded block",
 );
 assert.match(
   filesRouteSource,
@@ -598,13 +608,28 @@ assert.match(
 );
 assert.match(
   mentionSource,
-  /const mentionAriaOverrides: React\.AriaAttributes = mentionOpen\s*\n\s*\? \{\s*\n\s*"aria-expanded": true,\s*\n\s*"aria-controls": mentionListboxId,\s*\n\s*"aria-activedescendant": `\$\{mentionListboxId\}-opt-\$\{mentionIdx\}`,/,
-  "While the mention picker is open it must override the combobox ARIA (expanded/controls/activedescendant) — the menus are disjoint, so the closed slash wiring yields",
+  /const mentionActiveIdx = mentionOpen \? Math\.min\(mentionIdx, mentionMatches\.length - 1\) : 0;/,
+  "Mention active index must clamp to the current match count",
+);
+assert.match(
+  mentionSource,
+  /setMentionIdx\(\(i\) => \(mentionMatches\.length === 0 \? 0 : Math\.min\(i, mentionMatches\.length - 1\)\)\);/,
+  "Mention index should be brought back in range when the match list shrinks",
+);
+assert.match(
+  mentionSource,
+  /const mentionAriaOverrides: React\.AriaAttributes = mentionOpen\s*\n\s*\? \{\s*\n\s*"aria-expanded": true,\s*\n\s*"aria-controls": mentionListboxId,\s*\n\s*"aria-activedescendant": `\$\{mentionListboxId\}-opt-\$\{mentionActiveIdx\}`,/,
+  "While the mention picker is open it must override the combobox ARIA with the clamped active option",
 );
 assert.match(
   mentionSource,
   /\{\.\.\.mentionAriaOverrides\}/,
   "The composer textarea must apply the mention ARIA overrides after the slash wiring (later JSX attributes win)",
+);
+assert.match(
+  mentionSource,
+  /const active = i === mentionActiveIdx;/,
+  "Mention row highlight should use the same clamped active index as aria-activedescendant",
 );
 
 // Esc precedence (#402): mention dismiss → slash dismiss → busy cancel.

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1382,6 +1382,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     return filterFileMentions(mentionIndex.files, mentionToken.query, FILE_MENTION_RESULT_LIMIT);
   }, [mentionToken, mentionDismissed, mentionIndex, mentionRoot]);
   const mentionOpen = mentionMatches.length > 0;
+  const mentionActiveIdx = mentionOpen ? Math.min(mentionIdx, mentionMatches.length - 1) : 0;
   // The mention picker shares the composer combobox with the slash menu but
   // the two can never open together (`@` is mid-token, `/` first-token-only),
   // so while the picker IS open these override the closed slash menu's ARIA
@@ -1391,7 +1392,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     ? {
         "aria-expanded": true,
         "aria-controls": mentionListboxId,
-        "aria-activedescendant": `${mentionListboxId}-opt-${mentionIdx}`,
+        "aria-activedescendant": `${mentionListboxId}-opt-${mentionActiveIdx}`,
       }
     : {};
 
@@ -1476,8 +1477,13 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
 
   useEffect(() => {
     if (mentionMatches.length === 0) return;
+    setMentionIdx((i) => (mentionMatches.length === 0 ? 0 : Math.min(i, mentionMatches.length - 1)));
+  }, [mentionMatches.length]);
+
+  useEffect(() => {
+    if (mentionMatches.length === 0) return;
     activeMentionOptionRef.current?.scrollIntoView({ block: "nearest" });
-  }, [mentionIdx, mentionMatches.length]);
+  }, [mentionActiveIdx, mentionMatches.length]);
 
   useEffect(() => {
     turnsRef.current = turns;
@@ -2246,7 +2252,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       }
       if (e.key === "Tab" || (e.key === "Enter" && !e.shiftKey)) {
         e.preventDefault();
-        const file = mentionMatches[Math.min(mentionIdx, mentionMatches.length - 1)];
+        const file = mentionMatches[mentionActiveIdx];
         if (file) selectMention(file);
         return;
       }
@@ -2688,7 +2694,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             <div className="absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-xl">
               <ul className="max-h-64 overflow-y-auto py-1" id={mentionListboxId} role="listbox" aria-label="Workspace files">
                 {mentionMatches.map((file, i) => {
-                  const active = i === mentionIdx;
+                  const active = i === mentionActiveIdx;
                   const base = file.split("/").pop() ?? file;
                   return (
                     <li


### PR DESCRIPTION
## Summary
- clamp the @-mention active option before wiring aria-activedescendant and row highlight
- guard /api/project/files roots with resolveAllowedProjectPath and guarded stat/realpath handling
- mark /project/files as pathGuard-covered in API contracts

## Verification
- node --experimental-strip-types src/components/chat-view-polish.test.ts
- node --experimental-strip-types src/app/api/api-contracts.test.ts
- pnpm test:app
- pnpm test:api
- pnpm typecheck