### PR TITLE
fix(chat): clarify turn segment review notes

### DIFF
--- a/src/lib/session-debug.test.ts
+++ b/src/lib/session-debug.test.ts
@@ -80,7 +80,7 @@ assert.equal(
 assert.equal(debugFileName("s1"), "debug-s1.json");
 assert.equal(debugFileName(null), "debug-session.json");
 
-console.log("session-debug tests passed");
+console.log("session-debug core assertions passed");
 
 // ═══════════════════════════════════════════════════════════════════════════
 // CHAT-D4-01 — interleaved tool segments (src/lib/turn-segments.ts).
@@ -189,6 +189,7 @@ assert.equal(
 // ── Source pins ─────────────────────────────────────────────────────────────
 const chatViewSource = readFileSync(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
 const bubbleSource = readFileSync(new URL("../components/message-bubble.tsx", import.meta.url), "utf8");
+const turnSegmentsSource = readFileSync(new URL("./turn-segments.ts", import.meta.url), "utf8");
 const convRouteSource = readFileSync(
   new URL("../app/api/chat/conversation/[id]/route.ts", import.meta.url),
   "utf8",
@@ -205,6 +206,16 @@ assert.match(
   chatViewSource,
   /textOffset: x\.textOffset,/,
   "CHAT-D4-01: settle/update events keep the offset captured at first arrival",
+);
+assert.doesNotMatch(
+  turnSegmentsSource,
+  /always lands in the span FOLLOWING that tool/,
+  "CHAT-D4-01: turn-segments comments must not overstate mid-paragraph snap behavior",
+);
+assert.match(
+  turnSegmentsSource,
+  /later text in that same paragraph[\s\S]*?can remain before the tool/,
+  "CHAT-D4-01: turn-segments comments should document mid-paragraph streaming behavior",
 );
 
 // TurnRow renders the segmented path from the reasoning-stripped visible

--- a/src/lib/turn-segments.ts
+++ b/src/lib/turn-segments.ts
@@ -18,11 +18,11 @@
 // consecutive group, preserving arrival order.
 //
 // Streaming stability falls out of the offset model: offsets are captured
-// against a text that only ever grows, so text appended after a tool arrived
-// always lands in the span FOLLOWING that tool. A tool that arrives
-// mid-paragraph floats at the end of the current text until the paragraph
-// boundary streams in, then anchors there permanently — settled spans never
-// change retroactively.
+// against text that only ever grows. A tool that arrives at a safe boundary can
+// render before later prose immediately; a tool that arrives mid-paragraph
+// floats at the end of the current text, so later text in that same paragraph
+// can remain before the tool until the paragraph boundary streams in. Once a
+// safe boundary exists, the tool anchors there permanently.
 //
 // Legacy compatibility (graceful degradation, NO transcript migration):
 // stored transcripts predate `textOffset`. When there are no tools, or ANY


### PR DESCRIPTION
## Summary
- rename the early session-debug pass log so it only claims the core assertions passed
- correct the turn-segments streaming-stability comment for mid-paragraph tool snapping
- pin the corrected wording in the CHAT-D4-01 source assertions

## Verification
- node --experimental-strip-types src/lib/session-debug.test.ts
- pnpm typecheck
- pnpm test:app