### PR TITLE
fix(chat): put overlay dialog semantics on panels

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3354,17 +3354,18 @@ function AttachmentLightbox({ attachment, onClose }: { attachment: ChatAttachmen
   useFocusTrap(true, dialogRef, { onEscape: onClose });
   return (
     <div
-      ref={dialogRef}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
       onClick={onClose}
-      role="dialog"
-      aria-modal="true"
-      aria-label={`Preview ${attachment.name}`}
-      tabIndex={-1}
+      role="presentation"
     >
       <div
+        ref={dialogRef}
         className="relative max-h-[90vh] w-[90vw] max-w-screen-2xl overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-2xl"
         onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Preview ${attachment.name}`}
+        tabIndex={-1}
       >
         {/* Header */}
         <div className="flex items-center gap-2 border-b border-[var(--border-hairline)]/60 px-4 py-2.5">

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -948,17 +948,18 @@ function MarkdownExpandModal({
 
   return (
     <div
-      ref={dialogRef}
       className="fixed inset-0 z-[60] flex items-center justify-center bg-black/75 backdrop-blur-sm"
       onClick={onClose}
-      role="dialog"
-      aria-modal="true"
-      aria-label={`Expanded ${label}`}
-      tabIndex={-1}
+      role="presentation"
     >
       <div
+        ref={dialogRef}
         className="relative flex h-[90vh] w-[92vw] max-w-[1100px] flex-col overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-panel)] shadow-2xl"
         onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Expanded ${label}`}
+        tabIndex={-1}
       >
         <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-hairline)] px-4 py-2.5">
           <Icon name="ph:arrows-out-simple" width={13} className="shrink-0 text-[var(--text-muted)]" aria-hidden />

--- a/src/components/voice-call-button.test.ts
+++ b/src/components/voice-call-button.test.ts
@@ -134,6 +134,21 @@ test("CHAT-D11-02: overlays keep dialog semantics", () => {
   }
 });
 
+test("CHAT-D11-02: overlay backdrops are presentation-only and panels own dialog semantics", () => {
+  for (const [name, body] of [["MarkdownExpandModal", expandModal], ["AttachmentLightbox", lightbox]]) {
+    assert.match(
+      body,
+      /<div\s+(?=[^>]*className="fixed inset-0)(?=[^>]*onClick=\{onClose\})(?=[^>]*role="presentation")[^>]*>/,
+      `${name} backdrop should be presentation-only`,
+    );
+    assert.match(
+      body,
+      /<div\s+[\s\S]{0,80}ref=\{dialogRef\}[\s\S]{0,300}className="relative[\s\S]{0,300}onClick=\{\(e\) => e\.stopPropagation\(\)\}[\s\S]{0,160}role="dialog"[\s\S]{0,80}aria-modal="true"[\s\S]{0,120}aria-label=\{[\s\S]{0,120}tabIndex=\{-1\}/,
+      `${name} panel should own the focus trap ref and dialog semantics`,
+    );
+  }
+});
+
 test("CHAT-D11-02: shared trap provides the focus-restore path the overlays rely on", () => {
   assert.match(
     focusTrapSource,


### PR DESCRIPTION
Follow-up for unresolved review threads on #421.

Changes:
- make the Markdown expand modal backdrop presentation-only
- make the attachment lightbox backdrop presentation-only
- move `role="dialog"`, `aria-modal`, `aria-label`, `tabIndex`, and the focus-trap ref onto each inner panel
- pin that structure in the existing CHAT-D11-02 source regression

Verification:
- node --experimental-strip-types src/components/voice-call-button.test.ts
- pnpm test:app
- pnpm typecheck