### PR TITLE
feat(capabilities): add operator map inspector

### DIFF
--- a/src/components/capabilities-normalize.test.ts
+++ b/src/components/capabilities-normalize.test.ts
@@ -1,0 +1,122 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  filterCapabilityItems,
+  normalizeCapabilities,
+} from "./capabilities-normalize.ts";
+
+const manifests = [
+  {
+    harness_id: "codex",
+    scanned_at: "2026-06-11T12:00:00.000Z",
+    global_instructions: {
+      present: true,
+      path: "/Users/buns/.codex/AGENTS.md",
+      byte_count: 2048,
+    },
+    skills: [
+      {
+        id: "review",
+        name: "Review",
+        source: "local",
+        harness_id: "codex",
+        path: "/Users/buns/.codex/skills/review/SKILL.md",
+        description: "Review code",
+        tags: ["quality"],
+      },
+    ],
+    plugins: [
+      {
+        id: "browser",
+        name: "Browser",
+        source: "plugin",
+        harness_id: "codex",
+        kind: "plugin",
+        enabled: true,
+        command: "browser-mcp",
+        args: ["--stdio"],
+      },
+      {
+        id: "filesystem",
+        name: "Filesystem",
+        source: "plugin",
+        harness_id: "codex",
+        kind: "mcp",
+        enabled: false,
+        command: "fs-mcp",
+      },
+    ],
+    warnings: [
+      {
+        kind: "parse",
+        path: "/Users/buns/.codex/config.toml",
+        message: "Could not parse plugin config",
+      },
+    ],
+  },
+  {
+    harness_id: "claude",
+    scanned_at: "2026-06-11T12:03:00.000Z",
+    global_instructions: { present: false },
+    skills: [],
+    plugins: [],
+    warnings: [],
+  },
+];
+
+const covenSkills = [
+  {
+    id: "daily-brief",
+    name: "Daily Brief",
+    description: "Summarize project state",
+    version: "1.0.0",
+    tags: ["planning"],
+  },
+];
+
+const view = normalizeCapabilities({ manifests, covenSkills });
+
+assert.equal(view.summary.harnesses, 2);
+assert.equal(view.summary.instructions, 1);
+assert.equal(view.summary.skills, 2);
+assert.equal(view.summary.plugins, 1);
+assert.equal(view.summary.mcpServers, 1);
+assert.equal(view.summary.disabled, 1);
+assert.equal(view.summary.warnings, 1);
+
+assert.deepEqual(
+  view.harnesses.map((h) => [h.id, h.label, h.itemCount, h.warningCount]),
+  [
+    ["codex", "Codex", 4, 1],
+    ["claude", "Claude Code", 0, 0],
+  ],
+);
+
+const ids = view.items.map((item) => item.id);
+assert.deepEqual(ids, [
+  "codex:instructions:global",
+  "codex:skill:review",
+  "codex:plugin:browser",
+  "codex:mcp:filesystem",
+  "codex:warning:0",
+  "coven:skill:daily-brief",
+]);
+
+const disabledMcp = view.items.find((item) => item.id === "codex:mcp:filesystem");
+assert.equal(disabledMcp?.status, "disabled");
+assert.equal(disabledMcp?.command, "fs-mcp");
+
+assert.deepEqual(
+  filterCapabilityItems(view.items, { query: "config", types: new Set(["warning"]) }).map((item) => item.id),
+  ["codex:warning:0"],
+);
+assert.deepEqual(
+  filterCapabilityItems(view.items, { query: "browser --stdio" }).map((item) => item.id),
+  ["codex:plugin:browser"],
+);
+assert.deepEqual(
+  filterCapabilityItems(view.items, { harnessId: "codex", status: "disabled" }).map((item) => item.id),
+  ["codex:mcp:filesystem"],
+);
+
+console.log("capabilities-normalize.test.ts: ok");

--- a/src/components/capabilities-normalize.ts
+++ b/src/components/capabilities-normalize.ts
@@ -1,0 +1,232 @@
+import type { HarnessCapabilityManifest } from "@/components/capability-card";
+
+export type CovenSkill = {
+  id: string;
+  name: string;
+  description?: string;
+  version?: string;
+  tags?: string[];
+};
+
+export type CapabilityType = "instructions" | "skill" | "plugin" | "mcp" | "warning";
+export type CapabilityStatus = "available" | "enabled" | "disabled" | "warning";
+
+export type CapabilityMapItem = {
+  id: string;
+  type: CapabilityType;
+  harnessId: string;
+  harnessLabel: string;
+  label: string;
+  status: CapabilityStatus;
+  description?: string;
+  sourcePath?: string;
+  command?: string;
+  tags?: string[];
+  version?: string;
+  kind?: string;
+  warningMessage?: string;
+  scannedAt?: string;
+};
+
+export type CapabilityHarnessSummary = {
+  id: string;
+  label: string;
+  itemCount: number;
+  warningCount: number;
+  disabledCount: number;
+  scannedAt: string;
+};
+
+export type CapabilitySummary = {
+  harnesses: number;
+  instructions: number;
+  skills: number;
+  plugins: number;
+  mcpServers: number;
+  disabled: number;
+  warnings: number;
+};
+
+export type CapabilitiesOperatorView = {
+  items: CapabilityMapItem[];
+  harnesses: CapabilityHarnessSummary[];
+  summary: CapabilitySummary;
+};
+
+export type CapabilityFilters = {
+  query?: string;
+  harnessId?: string | null;
+  types?: Set<CapabilityType>;
+  status?: CapabilityStatus | "all" | null;
+};
+
+const HARNESS_LABEL: Record<string, string> = {
+  codex: "Codex",
+  claude: "Claude Code",
+  cursor: "Cursor",
+  gemini: "Gemini CLI",
+  opencode: "OpenCode",
+  "coven-code": "Coven Code",
+  copilot: "GitHub Copilot",
+};
+
+export function harnessLabel(id: string): string {
+  return HARNESS_LABEL[id] ?? id;
+}
+
+export function normalizeCapabilities({
+  manifests,
+  covenSkills,
+}: {
+  manifests: HarnessCapabilityManifest[];
+  covenSkills: CovenSkill[];
+}): CapabilitiesOperatorView {
+  const items: CapabilityMapItem[] = [];
+  const harnesses: CapabilityHarnessSummary[] = [];
+
+  for (const manifest of manifests) {
+    const label = harnessLabel(manifest.harness_id);
+    const manifestItems: CapabilityMapItem[] = [];
+
+    if (manifest.global_instructions.present) {
+      manifestItems.push({
+        id: `${manifest.harness_id}:instructions:global`,
+        type: "instructions",
+        harnessId: manifest.harness_id,
+        harnessLabel: label,
+        label: "Global instructions",
+        status: "available",
+        sourcePath: manifest.global_instructions.path,
+        description:
+          manifest.global_instructions.byte_count !== undefined
+            ? `${(manifest.global_instructions.byte_count / 1024).toFixed(1)} KB`
+            : undefined,
+        scannedAt: manifest.scanned_at,
+      });
+    }
+
+    for (const skill of manifest.skills) {
+      const skillMeta = skill as typeof skill & {
+        source?: string;
+        tags?: string[];
+        version?: string;
+      };
+      manifestItems.push({
+        id: `${manifest.harness_id}:skill:${skill.id}`,
+        type: "skill",
+        harnessId: manifest.harness_id,
+        harnessLabel: label,
+        label: skill.name,
+        status: "available",
+        description: skill.description,
+        sourcePath: skill.path,
+        tags: skillMeta.tags,
+        version: skillMeta.version,
+        kind: skillMeta.source,
+        scannedAt: manifest.scanned_at,
+      });
+    }
+
+    for (const plugin of manifest.plugins) {
+      const type = plugin.kind?.toLowerCase() === "mcp" ? "mcp" : "plugin";
+      manifestItems.push({
+        id: `${manifest.harness_id}:${type}:${plugin.id}`,
+        type,
+        harnessId: manifest.harness_id,
+        harnessLabel: label,
+        label: plugin.name,
+        status: plugin.enabled ? "enabled" : "disabled",
+        description: plugin.kind,
+        command: [plugin.command, ...(plugin.args ?? [])].filter(Boolean).join(" ") || undefined,
+        kind: plugin.kind,
+        scannedAt: manifest.scanned_at,
+      });
+    }
+
+    for (const [index, warning] of manifest.warnings.entries()) {
+      manifestItems.push({
+        id: `${manifest.harness_id}:warning:${index}`,
+        type: "warning",
+        harnessId: manifest.harness_id,
+        harnessLabel: label,
+        label: warning.kind,
+        status: "warning",
+        description: warning.message,
+        sourcePath: warning.path,
+        warningMessage: warning.message,
+        scannedAt: manifest.scanned_at,
+      });
+    }
+
+    harnesses.push({
+      id: manifest.harness_id,
+      label,
+      itemCount:
+        (manifest.global_instructions.present ? 1 : 0) +
+        manifest.skills.length +
+        manifest.plugins.length,
+      warningCount: manifest.warnings.length,
+      disabledCount: manifest.plugins.filter((plugin) => !plugin.enabled).length,
+      scannedAt: manifest.scanned_at,
+    });
+    items.push(...manifestItems);
+  }
+
+  for (const skill of covenSkills) {
+    items.push({
+      id: `coven:skill:${skill.id}`,
+      type: "skill",
+      harnessId: "coven",
+      harnessLabel: "Coven",
+      label: skill.name,
+      status: "available",
+      description: skill.description,
+      tags: skill.tags,
+      version: skill.version,
+    });
+  }
+
+  const summary: CapabilitySummary = {
+    harnesses: manifests.length,
+    instructions: items.filter((item) => item.type === "instructions").length,
+    skills: items.filter((item) => item.type === "skill").length,
+    plugins: items.filter((item) => item.type === "plugin").length,
+    mcpServers: items.filter((item) => item.type === "mcp").length,
+    disabled: items.filter((item) => item.status === "disabled").length,
+    warnings: items.filter((item) => item.status === "warning").length,
+  };
+
+  return { items, harnesses, summary };
+}
+
+export function filterCapabilityItems(
+  items: CapabilityMapItem[],
+  filters: CapabilityFilters,
+): CapabilityMapItem[] {
+  const query = filters.query?.trim().toLowerCase() ?? "";
+  return items.filter((item) => {
+    if (filters.harnessId && item.harnessId !== filters.harnessId) return false;
+    if (filters.types && filters.types.size > 0 && !filters.types.has(item.type)) return false;
+    if (filters.status && filters.status !== "all" && item.status !== filters.status) return false;
+    if (!query) return true;
+
+    const searchable = [
+      item.id,
+      item.type,
+      item.harnessId,
+      item.harnessLabel,
+      item.label,
+      item.status,
+      item.description,
+      item.sourcePath,
+      item.command,
+      item.kind,
+      item.version,
+      ...(item.tags ?? []),
+    ]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase();
+    return query.split(/\s+/).every((term) => searchable.includes(term));
+  });
+}

--- a/src/components/capabilities-view-polish.test.ts
+++ b/src/components/capabilities-view-polish.test.ts
@@ -41,7 +41,7 @@ assert.match(
 // Keyboard hint footer.
 assert.match(
   source,
-  /⌘R refresh · click a harness to expand · read-only/,
+  /⌘R refresh · search narrows the operator map · read-only/,
   "renders the keyboard hint footer below the scrolling content",
 );
 

--- a/src/components/capabilities-view.test.ts
+++ b/src/components/capabilities-view.test.ts
@@ -10,9 +10,14 @@ const source = readFileSync(
 assert.match(source, /export function CapabilitiesViewSurface/);
 assert.match(source, /\/api\/capabilities/, "should fetch from the Cave capabilities proxy");
 assert.match(source, /refresh=1/, "should support a refresh that bypasses the daemon cache");
-assert.match(source, /CapabilitiesGrid/, "should render the shared CapabilitiesView card grid");
+assert.doesNotMatch(source, /CapabilitiesGrid/, "operator map replaces the old shared card grid");
 assert.match(source, /harness_capabilities/, "should consume daemon harness manifests");
 assert.match(source, /coven_skills/, "should surface daemon-owned coven skills");
 assert.match(source, /read-only/i, "should label itself as read-only — daemon is read-only by design");
+assert.match(source, /normalizeCapabilities/, "should derive an operator map view model from daemon manifests");
+assert.match(source, /CapabilityMap/, "should render the hybrid capability map");
+assert.match(source, /CapabilityInspector/, "should render a right-side inspector for selected harness or capability");
+assert.match(source, /placeholder="Search skills, plugins, paths, commands"/, "should expose operator-grade search");
+assert.match(source, /copyCapabilityDetail/, "inspector should expose read-only copy actions");
 
 console.log("capabilities-view.test.ts: ok");

--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -1,19 +1,19 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
 import { Icon } from "@/lib/icon";
+import type { HarnessCapabilityManifest } from "@/components/capability-card";
 import {
-  CapabilitiesView as CapabilitiesGrid,
-  type HarnessCapabilityManifest,
-} from "@/components/capability-card";
-
-type CovenSkill = {
-  id: string;
-  name: string;
-  description?: string;
-  version?: string;
-  tags?: string[];
-};
+  filterCapabilityItems,
+  harnessLabel,
+  normalizeCapabilities,
+  type CapabilityHarnessSummary,
+  type CapabilityMapItem,
+  type CapabilityStatus,
+  type CapabilityType,
+  type CovenSkill,
+} from "@/components/capabilities-normalize";
 
 type CapabilitiesResponse = {
   ok: boolean;
@@ -23,18 +23,42 @@ type CapabilitiesResponse = {
   error?: string;
 };
 
-const HARNESS_LABEL: Record<string, string> = {
-  codex: "Codex",
-  claude: "Claude Code",
-  cursor: "Cursor",
-  gemini: "Gemini CLI",
-  opencode: "OpenCode",
-  "coven-code": "Coven Code",
-  copilot: "GitHub Copilot",
+const TYPE_FILTERS: Array<{ id: CapabilityType | "all"; label: string; icon: Parameters<typeof Icon>[0]["name"] }> = [
+  { id: "all", label: "All", icon: "ph:lightning-bold" },
+  { id: "instructions", label: "Instructions", icon: "ph:note-pencil" },
+  { id: "skill", label: "Skills", icon: "ph:sparkle" },
+  { id: "plugin", label: "Plugins", icon: "ph:plug" },
+  { id: "mcp", label: "MCP", icon: "ph:plug-bold" },
+  { id: "warning", label: "Warnings", icon: "ph:warning-fill" },
+];
+
+const TYPE_LABEL: Record<CapabilityType, string> = {
+  instructions: "Instructions",
+  skill: "Skills",
+  plugin: "Plugins",
+  mcp: "MCP Servers",
+  warning: "Warnings",
 };
 
-function harnessLabel(id: string): string {
-  return HARNESS_LABEL[id] ?? id;
+const TYPE_ICON: Record<CapabilityType, Parameters<typeof Icon>[0]["name"]> = {
+  instructions: "ph:note-pencil",
+  skill: "ph:sparkle",
+  plugin: "ph:plug",
+  mcp: "ph:plug-bold",
+  warning: "ph:warning-fill",
+};
+
+const STATUS_LABEL: Record<CapabilityStatus, string> = {
+  available: "available",
+  enabled: "enabled",
+  disabled: "disabled",
+  warning: "warning",
+};
+
+function initialHarness(activeHarness?: string | null): string | null {
+  if (activeHarness !== undefined) return activeHarness ?? null;
+  if (typeof window === "undefined") return null;
+  return new URLSearchParams(window.location.search).get("harness");
 }
 
 export function CapabilitiesViewSurface({
@@ -48,7 +72,12 @@ export function CapabilitiesViewSurface({
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
-  const [filter, setFilter] = useState<string | null>(activeHarness ?? null);
+  const [harnessFilter, setHarnessFilter] = useState<string | null>(() => initialHarness(activeHarness));
+  const [typeFilter, setTypeFilter] = useState<CapabilityType | "all">("all");
+  const [statusFilter, setStatusFilter] = useState<CapabilityStatus | "all">("all");
+  const [query, setQuery] = useState("");
+  const [selectionId, setSelectionId] = useState<string | null>(null);
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
 
   const load = useCallback(async (refresh = false) => {
     setRefreshing(refresh);
@@ -84,8 +113,21 @@ export function CapabilitiesViewSurface({
   }, [load]);
 
   useEffect(() => {
-    if (activeHarness !== undefined) setFilter(activeHarness ?? null);
+    if (activeHarness !== undefined) setHarnessFilter(activeHarness ?? null);
   }, [activeHarness]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    if (harnessFilter) params.set("harness", harnessFilter);
+    else params.delete("harness");
+    if (query.trim()) params.set("q", query.trim());
+    else params.delete("q");
+    if (typeFilter !== "all") params.set("type", typeFilter);
+    else params.delete("type");
+    const next = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ""}`;
+    window.history.replaceState(null, "", next);
+  }, [harnessFilter, query, typeFilter]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -103,28 +145,69 @@ export function CapabilitiesViewSurface({
     return () => window.removeEventListener("keydown", onKey);
   }, [load]);
 
-  const visible = filter
-    ? items.filter((m) => m.harness_id === filter)
-    : items;
+  const operatorView = useMemo(
+    () => normalizeCapabilities({ manifests: items, covenSkills }),
+    [items, covenSkills],
+  );
 
-  const totalSkills = items.reduce((sum, m) => sum + m.skills.length, 0);
-  const totalPlugins = items.reduce((sum, m) => sum + m.plugins.length, 0);
-  const totalAgentsMd = items.filter((m) => m.global_instructions.present).length;
-  const totalWarnings = items.reduce((sum, m) => sum + m.warnings.length, 0);
+  const filteredItems = useMemo(
+    () =>
+      filterCapabilityItems(operatorView.items, {
+        query,
+        harnessId: harnessFilter,
+        types: typeFilter === "all" ? undefined : new Set([typeFilter]),
+        status: statusFilter,
+      }),
+    [operatorView.items, query, harnessFilter, typeFilter, statusFilter],
+  );
+
+  const selectedItem = useMemo(
+    () => operatorView.items.find((item) => item.id === selectionId) ?? null,
+    [operatorView.items, selectionId],
+  );
+  const selectedHarness =
+    operatorView.harnesses.find((h) => h.id === (selectedItem?.harnessId ?? harnessFilter)) ?? null;
+
+  const copyCapabilityDetail = useCallback(async (key: string, value?: string) => {
+    if (!value) return;
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopiedKey(key);
+      window.setTimeout(() => setCopiedKey(null), 1200);
+    } catch {
+      setCopiedKey(null);
+    }
+  }, []);
+
+  const openLocalPath = useCallback((path?: string) => {
+    if (!path || !path.startsWith("/")) return;
+    window.open(`file://${path}`, "_blank", "noopener");
+  }, []);
+
+  const applyHarnessFilter = (id: string | null) => {
+    setHarnessFilter(id);
+    setSelectionId(null);
+  };
+
+  const applySummaryFilter = (type: CapabilityType | "all", status: CapabilityStatus | "all" = "all") => {
+    setTypeFilter(type);
+    setStatusFilter(status);
+    setSelectionId(null);
+  };
 
   return (
     <div className="flex h-full min-w-0 flex-col bg-background text-foreground">
       <div className="flex-1 overflow-y-auto">
-        <div className="mx-auto w-full max-w-[1200px] px-4 pb-12 sm:px-8">
+        <div className="mx-auto w-full max-w-[1280px] px-4 pb-12 sm:px-8">
           <div className="pb-4 pt-5">
-            <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="mb-3 flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
               <div className="min-w-0">
                 <h2 className="text-[18px] font-semibold text-[var(--text-primary)]">
                   Harness capabilities
                 </h2>
-                <p className="mt-1 text-[12px] text-muted-foreground">
-                  Per-harness manifest of skills, plugins, global instructions, and version detected
-                  by the Coven daemon. Read-only — edits happen in the harness&apos;s own config files.
+                <p className="mt-1 max-w-3xl text-[12px] text-muted-foreground">
+                  Read-only operator map of skills, plugins, MCP servers, global instructions,
+                  warnings, and Coven daemon skills discovered across connected harnesses.
                 </p>
               </div>
               <div className="flex shrink-0 items-center gap-2 text-[11px] text-muted-foreground">
@@ -154,111 +237,391 @@ export function CapabilitiesViewSurface({
             </div>
           </div>
 
-          {loaded && !error && items.length > 0 && (
-            <div className="mb-4 grid grid-cols-2 gap-2 sm:grid-cols-4">
-              <SummaryTile
-                icon="ph:cube-bold"
-                label="Harnesses"
-                value={items.length.toString()}
-              />
-              <SummaryTile
-                icon="ph:note-pencil"
-                label="With AGENTS.md"
-                value={`${totalAgentsMd}/${items.length}`}
-              />
-              <SummaryTile icon="ph:sparkle" label="Skills" value={totalSkills.toString()} />
-              <SummaryTile icon="ph:plug" label="Plugins" value={totalPlugins.toString()} />
-            </div>
-          )}
-
-          {loaded && !error && items.length > 1 && (
-            <div className="mb-4 flex flex-wrap items-center gap-1.5">
-              <FilterPill
-                label="All"
-                count={items.length}
-                active={filter === null}
-                onClick={() => setFilter(null)}
-              />
-              {items.map((m) => (
-                <FilterPill
-                  key={m.harness_id}
-                  label={harnessLabel(m.harness_id)}
-                  count={
-                    (m.global_instructions.present ? 1 : 0) +
-                    m.skills.length +
-                    m.plugins.length
-                  }
-                  active={filter === m.harness_id}
-                  onClick={() =>
-                    setFilter(filter === m.harness_id ? null : m.harness_id)
-                  }
+          {!loaded ? (
+            <CapabilitiesSkeleton />
+          ) : error ? (
+            <CapabilitiesError error={error} onRefresh={() => void load(true)} />
+          ) : operatorView.items.length === 0 ? (
+            <CapabilitiesEmpty onRefresh={() => void load(true)} />
+          ) : (
+            <>
+              <div className="mb-4 grid grid-cols-2 gap-2 lg:grid-cols-6">
+                <SummaryTile
+                  icon="ph:heartbeat"
+                  label="Readiness"
+                  value={operatorView.summary.warnings + operatorView.summary.disabled === 0 ? "Clear" : `${operatorView.summary.warnings + operatorView.summary.disabled} issue${operatorView.summary.warnings + operatorView.summary.disabled === 1 ? "" : "s"}`}
+                  active={typeFilter === "warning" || statusFilter === "disabled"}
+                  onClick={() => applySummaryFilter("warning")}
                 />
-              ))}
-            </div>
-          )}
+                <SummaryTile
+                  icon="ph:cube-bold"
+                  label="Harnesses"
+                  value={operatorView.summary.harnesses.toString()}
+                  active={harnessFilter === null && typeFilter === "all" && statusFilter === "all"}
+                  onClick={() => {
+                    applyHarnessFilter(null);
+                    applySummaryFilter("all");
+                  }}
+                />
+                <SummaryTile
+                  icon="ph:sparkle"
+                  label="Skills"
+                  value={operatorView.summary.skills.toString()}
+                  active={typeFilter === "skill"}
+                  onClick={() => applySummaryFilter("skill")}
+                />
+                <SummaryTile
+                  icon="ph:plug"
+                  label="Plugins"
+                  value={operatorView.summary.plugins.toString()}
+                  active={typeFilter === "plugin"}
+                  onClick={() => applySummaryFilter("plugin")}
+                />
+                <SummaryTile
+                  icon="ph:plug-bold"
+                  label="MCP"
+                  value={operatorView.summary.mcpServers.toString()}
+                  active={typeFilter === "mcp"}
+                  onClick={() => applySummaryFilter("mcp")}
+                />
+                <SummaryTile
+                  icon="ph:warning-fill"
+                  label="Disabled"
+                  value={operatorView.summary.disabled.toString()}
+                  active={statusFilter === "disabled"}
+                  onClick={() => applySummaryFilter("all", "disabled")}
+                />
+              </div>
 
-          {loaded && !error && totalWarnings > 0 && filter === null && (
-            <div className="mb-4 flex items-start gap-2 rounded-md border border-border bg-card px-3 py-2 text-[11px] text-muted-foreground">
-              <Icon name="ph:warning-fill" width={12} className="mt-0.5 shrink-0" />
-              <span>
-                {totalWarnings} parse warning{totalWarnings === 1 ? "" : "s"} across
-                harness configs — expand a harness below to see details.
-              </span>
-            </div>
-          )}
+              <CapabilityToolbar
+                query={query}
+                onQueryChange={setQuery}
+                typeFilter={typeFilter}
+                onTypeFilter={setTypeFilter}
+                statusFilter={statusFilter}
+                onStatusFilter={setStatusFilter}
+                harnesses={operatorView.harnesses}
+                harnessFilter={harnessFilter}
+                onHarnessFilter={applyHarnessFilter}
+              />
 
-          <CapabilitiesGrid
-            items={visible}
-            loaded={loaded}
-            error={error}
-            onRefresh={() => void load(true)}
-          />
-
-          {loaded && !error && covenSkills.length > 0 && filter === null && (
-            <section className="mt-8">
-              <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">
-                Coven skills · {covenSkills.length}
-              </h3>
-              <p className="mb-3 text-[12px] text-muted-foreground">
-                Skills shipped with the Coven daemon and available to every familiar.
-              </p>
-              <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                {covenSkills.map((s) => (
-                  <li
-                    key={s.id}
-                    className="rounded-lg border border-border bg-card px-3 py-2"
-                  >
-                    <div className="flex min-w-0 items-center gap-2">
-                      <Icon
-                        name="ph:sparkle"
-                        width={11}
-                        className="shrink-0 text-muted-foreground"
-                      />
-                      <p className="min-w-0 truncate text-[12px] font-medium text-foreground">
-                        {s.name}
-                      </p>
-                      {s.version && (
-                        <span className="rounded-full bg-muted px-1.5 py-px text-[9px] text-muted-foreground">
-                          v{s.version}
-                        </span>
-                      )}
-                    </div>
-                    {s.description && (
-                      <p className="mt-1 text-[11px] text-muted-foreground">
-                        {s.description}
-                      </p>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </section>
+              <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
+                <CapabilityMap
+                  items={filteredItems}
+                  selectedId={selectedItem?.id ?? null}
+                  onSelect={(item) => setSelectionId(item.id)}
+                  onTypeFilter={(type) => applySummaryFilter(type)}
+                />
+                <CapabilityInspector
+                  item={selectedItem}
+                  harness={selectedHarness}
+                  copiedKey={copiedKey}
+                  onCopy={copyCapabilityDetail}
+                  onOpenPath={openLocalPath}
+                  onSelectHarness={applyHarnessFilter}
+                />
+              </div>
+            </>
           )}
         </div>
       </div>
       <footer className="shrink-0 border-t border-border px-3 py-1.5 text-center text-[10px] text-muted-foreground">
-        ⌘R refresh · click a harness to expand · read-only
+        ⌘R refresh · search narrows the operator map · read-only
       </footer>
     </div>
+  );
+}
+
+function CapabilityToolbar({
+  query,
+  onQueryChange,
+  typeFilter,
+  onTypeFilter,
+  statusFilter,
+  onStatusFilter,
+  harnesses,
+  harnessFilter,
+  onHarnessFilter,
+}: {
+  query: string;
+  onQueryChange: (value: string) => void;
+  typeFilter: CapabilityType | "all";
+  onTypeFilter: (value: CapabilityType | "all") => void;
+  statusFilter: CapabilityStatus | "all";
+  onStatusFilter: (value: CapabilityStatus | "all") => void;
+  harnesses: CapabilityHarnessSummary[];
+  harnessFilter: string | null;
+  onHarnessFilter: (id: string | null) => void;
+}) {
+  return (
+    <div className="mb-4 rounded-lg border border-border bg-card p-3">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+        <label className="focus-within:ring-ring flex min-w-0 flex-1 items-center gap-2 rounded-md border border-border bg-background px-2.5 py-1.5 text-[12px] focus-within:ring-1">
+          <Icon name="ph:magnifying-glass" width={13} className="shrink-0 text-muted-foreground" />
+          <input
+            value={query}
+            onChange={(e) => onQueryChange(e.target.value)}
+            placeholder="Search skills, plugins, paths, commands"
+            className="min-w-0 flex-1 bg-transparent text-foreground outline-none placeholder:text-muted-foreground"
+          />
+        </label>
+        <select
+          value={statusFilter}
+          onChange={(e) => onStatusFilter(e.target.value as CapabilityStatus | "all")}
+          className="focus-ring h-8 rounded-md border border-border bg-background px-2 text-[12px] text-foreground"
+          aria-label="Filter by status"
+        >
+          <option value="all">All statuses</option>
+          <option value="enabled">Enabled</option>
+          <option value="available">Available</option>
+          <option value="disabled">Disabled</option>
+          <option value="warning">Warnings</option>
+        </select>
+      </div>
+      <div className="mt-3 flex flex-wrap items-center gap-1.5">
+        {TYPE_FILTERS.map((filter) => (
+          <FilterPill
+            key={filter.id}
+            icon={filter.icon}
+            label={filter.label}
+            active={typeFilter === filter.id}
+            onClick={() => onTypeFilter(filter.id)}
+          />
+        ))}
+      </div>
+      {harnesses.length > 1 ? (
+        <div className="mt-2 flex flex-wrap items-center gap-1.5">
+          <FilterPill
+            label="All harnesses"
+            count={harnesses.length}
+            active={harnessFilter === null}
+            onClick={() => onHarnessFilter(null)}
+          />
+          {harnesses.map((harness) => (
+            <FilterPill
+              key={harness.id}
+              label={harness.label}
+              count={harness.itemCount + harness.warningCount}
+              active={harnessFilter === harness.id}
+              warning={harness.warningCount > 0 || harness.disabledCount > 0}
+              onClick={() => onHarnessFilter(harnessFilter === harness.id ? null : harness.id)}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function CapabilityMap({
+  items,
+  selectedId,
+  onSelect,
+  onTypeFilter,
+}: {
+  items: CapabilityMapItem[];
+  selectedId: string | null;
+  onSelect: (item: CapabilityMapItem) => void;
+  onTypeFilter: (type: CapabilityType) => void;
+}) {
+  const grouped = useMemo(() => {
+    const map = new Map<CapabilityType, CapabilityMapItem[]>();
+    for (const item of items) {
+      const list = map.get(item.type);
+      if (list) list.push(item);
+      else map.set(item.type, [item]);
+    }
+    return map;
+  }, [items]);
+
+  if (items.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border px-4 py-10 text-center text-[13px] text-muted-foreground">
+        No capabilities match the current filters.
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-w-0 space-y-3">
+      {(Object.keys(TYPE_LABEL) as CapabilityType[]).map((type) => {
+        const group = grouped.get(type);
+        if (!group?.length) return null;
+        return (
+          <section key={type} className="rounded-lg border border-border bg-card">
+            <button
+              type="button"
+              onClick={() => onTypeFilter(type)}
+              className="focus-ring flex w-full items-center gap-2 border-b border-border px-3 py-2 text-left"
+            >
+              <Icon name={TYPE_ICON[type]} width={13} className="text-muted-foreground" />
+              <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">
+                {TYPE_LABEL[type]}
+              </h3>
+              <span className="ml-auto rounded bg-muted px-1.5 py-px text-[10px] tabular-nums text-muted-foreground">
+                {group.length}
+              </span>
+            </button>
+            <div className="divide-y divide-border">
+              {group.map((item) => (
+                <CapabilityMapRow
+                  key={item.id}
+                  item={item}
+                  active={selectedId === item.id}
+                  onSelect={() => onSelect(item)}
+                />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+function CapabilityMapRow({
+  item,
+  active,
+  onSelect,
+}: {
+  item: CapabilityMapItem;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`focus-ring flex min-w-0 w-full items-start gap-2 px-3 py-2 text-left transition-colors ${
+        active ? "bg-muted" : "hover:bg-muted/60"
+      }`}
+    >
+      <span className={`mt-1 h-2 w-2 shrink-0 rounded-full ${statusDotClass(item.status)}`} />
+      <span className="min-w-0 flex-1">
+        <span className="flex min-w-0 flex-wrap items-center gap-1.5">
+          <span className="min-w-0 truncate text-[12px] font-medium text-foreground">{item.label}</span>
+          <span className="rounded bg-background px-1.5 py-px text-[9px] uppercase tracking-wide text-muted-foreground">
+            {item.harnessLabel}
+          </span>
+          {item.version ? (
+            <span className="rounded bg-muted px-1.5 py-px text-[9px] text-muted-foreground">v{item.version}</span>
+          ) : null}
+        </span>
+        <span className="mt-0.5 block truncate text-[11px] text-muted-foreground">
+          {item.warningMessage ?? item.description ?? item.sourcePath ?? item.command ?? item.id}
+        </span>
+      </span>
+      <span className="shrink-0 rounded-full bg-background px-1.5 py-px text-[9px] text-muted-foreground">
+        {STATUS_LABEL[item.status]}
+      </span>
+    </button>
+  );
+}
+
+function CapabilityInspector({
+  item,
+  harness,
+  copiedKey,
+  onCopy,
+  onOpenPath,
+  onSelectHarness,
+}: {
+  item: CapabilityMapItem | null;
+  harness: CapabilityHarnessSummary | null;
+  copiedKey: string | null;
+  onCopy: (key: string, value?: string) => void;
+  onOpenPath: (path?: string) => void;
+  onSelectHarness: (id: string | null) => void;
+}) {
+  return (
+    <aside className="min-w-0 rounded-lg border border-border bg-card xl:sticky xl:top-4 xl:self-start">
+      <div className="border-b border-border px-3 py-2">
+        <p className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">
+          Inspector
+        </p>
+        <h3 className="mt-1 truncate text-[14px] font-semibold text-foreground">
+          {item?.label ?? harness?.label ?? "Select a capability"}
+        </h3>
+      </div>
+
+      {item ? (
+        <div className="space-y-3 p-3">
+          <div className="flex flex-wrap gap-1.5">
+            <Badge>{TYPE_LABEL[item.type]}</Badge>
+            <Badge tone={item.status}>{STATUS_LABEL[item.status]}</Badge>
+            <button
+              type="button"
+              onClick={() => onSelectHarness(item.harnessId === "coven" ? null : item.harnessId)}
+              className="focus-ring rounded-full border border-border px-2 py-px text-[10px] text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              {item.harnessLabel}
+            </button>
+          </div>
+
+          {item.description ? <InspectorBlock label="Detail" value={item.description} /> : null}
+          {item.warningMessage ? <InspectorBlock label="Warning" value={item.warningMessage} tone="warning" /> : null}
+          {item.sourcePath ? <InspectorBlock label="Path" value={item.sourcePath} mono /> : null}
+          {item.command ? <InspectorBlock label="Command" value={item.command} mono /> : null}
+          {item.tags?.length ? <InspectorBlock label="Tags" value={item.tags.join(", ")} /> : null}
+          {item.scannedAt ? <InspectorBlock label="Scanned" value={new Date(item.scannedAt).toLocaleString()} /> : null}
+
+          <div className="flex flex-wrap gap-1.5 border-t border-border pt-3">
+            <InspectorAction
+              icon={copiedKey === "id" ? "ph:check" : "ph:copy"}
+              label={copiedKey === "id" ? "Copied id" : "Copy id"}
+              onClick={() => void onCopy("id", item.id)}
+            />
+            {item.sourcePath ? (
+              <>
+                <InspectorAction
+                  icon={copiedKey === "path" ? "ph:check" : "ph:copy"}
+                  label={copiedKey === "path" ? "Copied path" : "Copy path"}
+                  onClick={() => void onCopy("path", item.sourcePath)}
+                />
+                <InspectorAction
+                  icon="ph:file-text"
+                  label="Open file"
+                  onClick={() => onOpenPath(item.sourcePath)}
+                />
+              </>
+            ) : null}
+            {item.command ? (
+              <InspectorAction
+                icon={copiedKey === "command" ? "ph:check" : "ph:copy"}
+                label={copiedKey === "command" ? "Copied command" : "Copy command"}
+                onClick={() => void onCopy("command", item.command)}
+              />
+            ) : null}
+          </div>
+        </div>
+      ) : harness ? (
+        <div className="space-y-3 p-3">
+          <div className="grid grid-cols-3 gap-2">
+            <MiniMetric label="Items" value={harness.itemCount} />
+            <MiniMetric label="Issues" value={harness.warningCount + harness.disabledCount} />
+            <MiniMetric label="Warnings" value={harness.warningCount} />
+          </div>
+          <InspectorBlock label="Harness" value={harness.id} />
+          <InspectorBlock label="Last scan" value={new Date(harness.scannedAt).toLocaleString()} />
+          <div className="flex flex-wrap gap-1.5 border-t border-border pt-3">
+            <InspectorAction
+              icon={copiedKey === "harness" ? "ph:check" : "ph:copy"}
+              label={copiedKey === "harness" ? "Copied harness" : "Copy harness id"}
+              onClick={() => void onCopy("harness", harness.id)}
+            />
+            <InspectorAction
+              icon="ph:funnel"
+              label="Focus harness"
+              onClick={() => onSelectHarness(harness.id)}
+            />
+          </div>
+        </div>
+      ) : (
+        <p className="p-3 text-[12px] leading-5 text-muted-foreground">
+          Select a capability or harness to inspect provenance, status, paths, commands, and read-only actions.
+        </p>
+      )}
+    </aside>
   );
 }
 
@@ -266,33 +629,45 @@ function SummaryTile({
   icon,
   label,
   value,
+  active,
+  onClick,
 }: {
   icon: Parameters<typeof Icon>[0]["name"];
   label: string;
   value: string;
+  active?: boolean;
+  onClick: () => void;
 }) {
   return (
-    <div className="rounded-lg border border-border bg-card px-3 py-2">
-      <div className="flex items-center gap-1.5 text-[var(--text-secondary)]">
+    <button
+      type="button"
+      onClick={onClick}
+      className={`focus-ring rounded-lg border px-3 py-2 text-left transition-colors ${
+        active ? "border-foreground bg-foreground text-background" : "border-border bg-card hover:bg-muted"
+      }`}
+    >
+      <div className={`flex items-center gap-1.5 ${active ? "text-background/75" : "text-[var(--text-secondary)]"}`}>
         <Icon name={icon} width={11} />
         <span className="text-[10px] uppercase tracking-widest">{label}</span>
       </div>
-      <p className="mt-1 text-[18px] font-semibold tabular-nums text-foreground">
-        {value}
-      </p>
-    </div>
+      <p className="mt-1 truncate text-[18px] font-semibold tabular-nums">{value}</p>
+    </button>
   );
 }
 
 function FilterPill({
+  icon,
   label,
   count,
   active,
+  warning,
   onClick,
 }: {
+  icon?: Parameters<typeof Icon>[0]["name"];
   label: string;
-  count: number;
+  count?: number;
   active: boolean;
+  warning?: boolean;
   onClick: () => void;
 }) {
   return (
@@ -302,18 +677,154 @@ function FilterPill({
       className={`focus-ring flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] transition-colors ${
         active
           ? "border-foreground bg-foreground text-background"
-          : "border-border bg-card text-muted-foreground hover:bg-muted hover:text-foreground"
+          : warning
+            ? "border-[color-mix(in_oklch,var(--color-warning)_45%,var(--border))] bg-card text-muted-foreground hover:bg-muted hover:text-foreground"
+            : "border-border bg-card text-muted-foreground hover:bg-muted hover:text-foreground"
       }`}
       aria-pressed={active}
     >
+      {icon ? <Icon name={icon} width={11} /> : null}
       <span>{label}</span>
-      <span
-        className={`rounded-full px-1.5 py-px text-[9px] ${
-          active ? "bg-background/20 text-background" : "bg-muted text-muted-foreground"
-        }`}
-      >
-        {count}
-      </span>
+      {count !== undefined ? (
+        <span className={`rounded-full px-1.5 py-px text-[9px] ${active ? "bg-background/20 text-background" : "bg-muted text-muted-foreground"}`}>
+          {count}
+        </span>
+      ) : null}
     </button>
   );
+}
+
+function InspectorBlock({
+  label,
+  value,
+  mono,
+  tone,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  tone?: "warning";
+}) {
+  return (
+    <div>
+      <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">{label}</p>
+      <p className={`break-words rounded-md bg-muted px-2 py-1.5 text-[11px] leading-5 ${mono ? "font-mono" : ""} ${tone === "warning" ? "text-[var(--color-warning)]" : "text-muted-foreground"}`}>
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function InspectorAction({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: Parameters<typeof Icon>[0]["name"];
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="focus-ring inline-flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+    >
+      <Icon name={icon} width={12} />
+      <span>{label}</span>
+    </button>
+  );
+}
+
+function Badge({
+  children,
+  tone,
+}: {
+  children: ReactNode;
+  tone?: CapabilityStatus;
+}) {
+  return (
+    <span className={`rounded-full px-2 py-px text-[10px] ${badgeClass(tone)}`}>
+      {children}
+    </span>
+  );
+}
+
+function MiniMetric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md border border-border bg-background px-2 py-1.5">
+      <p className="text-[15px] font-semibold tabular-nums text-foreground">{value}</p>
+      <p className="text-[9px] uppercase tracking-widest text-muted-foreground">{label}</p>
+    </div>
+  );
+}
+
+function CapabilitiesSkeleton() {
+  return (
+    <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
+      <div className="space-y-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-lg border border-border bg-card p-3">
+            <span className="block h-3 w-32 animate-pulse rounded bg-muted" />
+            <span className="mt-3 block h-12 animate-pulse rounded bg-muted" />
+          </div>
+        ))}
+      </div>
+      <div className="rounded-lg border border-border bg-card p-3">
+        <span className="block h-3 w-20 animate-pulse rounded bg-muted" />
+        <span className="mt-3 block h-28 animate-pulse rounded bg-muted" />
+      </div>
+    </div>
+  );
+}
+
+function CapabilitiesError({ error, onRefresh }: { error: string; onRefresh: () => void }) {
+  return (
+    <div className="rounded-lg border border-border bg-card px-4 py-6 sm:px-5">
+      <p className="mb-3 text-[13px] text-muted-foreground">
+        {error === "daemon offline"
+          ? "Coven daemon is offline — harness capabilities require a running daemon."
+          : `Could not load capabilities: ${error}`}
+      </p>
+      <button
+        onClick={onRefresh}
+        className="focus-ring rounded-md border border-border bg-card px-3 py-1.5 text-[12px] text-foreground hover:bg-muted"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+function CapabilitiesEmpty({ onRefresh }: { onRefresh: () => void }) {
+  return (
+    <div className="rounded-lg border border-dashed border-border px-4 py-8 text-center">
+      <p className="text-[13px] text-muted-foreground">
+        No harness capabilities found. Start the daemon or add a local harness to see its instructions, skills, and plugins.
+      </p>
+      <button
+        type="button"
+        onClick={onRefresh}
+        className="focus-ring mt-3 rounded-md border border-border px-3 py-1.5 text-[12px] text-foreground hover:bg-muted"
+      >
+        Refresh
+      </button>
+    </div>
+  );
+}
+
+function statusDotClass(status: CapabilityStatus): string {
+  if (status === "enabled" || status === "available") return "bg-[var(--color-success)]";
+  if (status === "disabled") return "bg-[var(--color-warning)]";
+  return "bg-[var(--color-danger,var(--color-warning))]";
+}
+
+function badgeClass(status?: CapabilityStatus): string {
+  if (status === "enabled" || status === "available") {
+    return "bg-[color-mix(in_oklch,var(--color-success)_15%,transparent)] text-[var(--color-success)]";
+  }
+  if (status === "disabled" || status === "warning") {
+    return "bg-[color-mix(in_oklch,var(--color-warning)_15%,transparent)] text-[var(--color-warning)]";
+  }
+  return "bg-muted text-muted-foreground";
 }


### PR DESCRIPTION
## Summary
- Refactor Capabilities into a hybrid operator map with searchable grouped capability rows and a persistent inspector.
- Add client-side normalization for harness manifests, summary metrics, statuses, and filters.
- Keep capability actions read-only: refresh, copy ids/paths/commands, and open local file paths.

## Verification
- node --experimental-strip-types src/components/capabilities-normalize.test.ts
- node --experimental-strip-types src/components/capabilities-view.test.ts
- node --experimental-strip-types src/components/capabilities-view-polish.test.ts
- node --experimental-strip-types src/app/api/capabilities/route.test.ts
- pnpm typecheck
- git diff --check
- Browser smoke: desktop render, row selection/inspector, mobile layout, search URL update