### PR TITLE
docs(chat): clarify fixed code chrome tokens

### DIFF
--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1,6 +1,7 @@
 /* cave-chat.css — Markdown + Shiki styles for Cave chat bubbles.
  * Scoped to .cave-md so styles don't bleed into app chrome.
- * Tokens reference globals.css custom properties only.
+ * Tokens reference globals.css custom properties except the fixed code-chrome
+ * inks below, which intentionally mirror the dark palette in both themes.
  */
 
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### PR DESCRIPTION
Follow-up for an unresolved review thread on #425.

Updates the `cave-chat.css` header to document the fixed code-chrome ink exception that intentionally mirrors the dark palette in both themes.

Verification:
- git diff --check