### PR TITLE
fix(chat): disable archive controls while pending

### DIFF
--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -123,6 +123,11 @@ assert.match(
 );
 assert.match(
   source,
+  /disabled=\{archivingId !== null\}/,
+  "All archive controls should stay disabled while any archive request is in flight",
+);
+assert.match(
+  source,
   /if \(!showArchived\) \{\s*setArchivedRows\(\[\]\);/,
   "Archived rows should be dropped whenever the Show archived toggle is off",
 );

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -838,7 +838,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                               <button
                                 type="button"
                                 onClick={(e) => void setSessionArchived(e, s.id, !s.archived_at)}
-                                disabled={archivingId === s.id}
+                                disabled={archivingId !== null}
                                 title={s.archived_at ? "Unarchive chat" : "Archive chat"}
                                 aria-label={`${s.archived_at ? "Unarchive" : "Archive"} chat ${rowName}`}
                                 className="touch-always-visible shrink-0 rounded border border-[var(--border-hairline)] px-1.5 py-0.5 text-[var(--text-muted)] opacity-0 transition-all hover:border-[var(--border-strong)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover:opacity-100 disabled:opacity-40"


### PR DESCRIPTION
Follow-up for an unresolved review thread on #415.

Disables every archive/unarchive row action while any archive PATCH is in flight, preventing a second row from being re-enabled and double-submitted before the first request settles.

Verification:
- node --experimental-strip-types src/components/chat-list-delete.test.ts
- pnpm typecheck
- git diff --check