### PR TITLE
fix(capabilities): hydrate URL filters after mount

### DIFF
--- a/src/components/capabilities-view.test.ts
+++ b/src/components/capabilities-view.test.ts
@@ -24,8 +24,13 @@ assert.match(source, /initialHarness\(activeHarness\?: string \| null\)[\s\S]*ac
 assert.match(source, /initialQuery\(\)[\s\S]*readUrlParam\("q"\)/, "query filter should initialize from the URL");
 assert.match(source, /initialTypeFilter\(\)[\s\S]*readCapabilityTypeParam\("type"\)/, "type filter should initialize from the URL");
 assert.match(source, /initialStatusFilter\(\)[\s\S]*readCapabilityStatusParam\("status"\)/, "status filter should initialize from the URL");
+assert.match(source, /const \[urlFiltersHydrated, setUrlFiltersHydrated\] = useState\(false\);/, "URL filters should hydrate after mount, not during SSR initial render");
+assert.doesNotMatch(source, /useState<[^>]+>\(\(\) => initial(?:Harness|TypeFilter|StatusFilter)\(/, "URL-backed typed filters should not read window in useState initializers");
+assert.doesNotMatch(source, /useState\(\(\) => initialQuery\(\)\)/, "query filter should not read window in a useState initializer");
+assert.match(source, /setHarnessFilter\(initialHarness\(activeHarness\)\);[\s\S]*setQuery\(initialQuery\(\)\);[\s\S]*setTypeFilter\(initialTypeFilter\(\)\);[\s\S]*setStatusFilter\(initialStatusFilter\(\)\);[\s\S]*setUrlFiltersHydrated\(true\);/, "URL filters should hydrate together in a mount effect");
+assert.match(source, /if \(!urlFiltersHydrated\) return;[\s\S]*window\.history\.replaceState/, "URL sync should wait until URL filters hydrate");
 assert.match(source, /if \(statusFilter !== "all"\) params\.set\("status", statusFilter\);[\s\S]*else params\.delete\("status"\);/, "status filter should sync into shareable URLs");
-assert.match(source, /\}, \[harnessFilter, query, typeFilter, statusFilter\]\);/, "URL sync should rerun when status changes");
+assert.match(source, /\}, \[harnessFilter, query, typeFilter, statusFilter, urlFiltersHydrated\]\);/, "URL sync should rerun when status changes after hydration");
 assert.match(source, /const applyQueryFilter = \(value: string\) => \{[\s\S]*setQuery\(value\);[\s\S]*setSelectionId\(null\);[\s\S]*\};/, "query changes should clear stale inspector selection");
 assert.match(source, /const applyTypeFilter = \(value: CapabilityType \| "all"\) => \{[\s\S]*setTypeFilter\(value\);[\s\S]*setSelectionId\(null\);[\s\S]*\};/, "type changes should clear stale inspector selection");
 assert.match(source, /const applyStatusFilter = \(value: CapabilityStatus \| "all"\) => \{[\s\S]*setStatusFilter\(value\);[\s\S]*setSelectionId\(null\);[\s\S]*\};/, "status changes should clear stale inspector selection");

--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -99,10 +99,11 @@ export function CapabilitiesViewSurface({
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
-  const [harnessFilter, setHarnessFilter] = useState<string | null>(() => initialHarness(activeHarness));
-  const [typeFilter, setTypeFilter] = useState<CapabilityType | "all">(() => initialTypeFilter());
-  const [statusFilter, setStatusFilter] = useState<CapabilityStatus | "all">(() => initialStatusFilter());
-  const [query, setQuery] = useState(() => initialQuery());
+  const [harnessFilter, setHarnessFilter] = useState<string | null>(activeHarness ?? null);
+  const [typeFilter, setTypeFilter] = useState<CapabilityType | "all">("all");
+  const [statusFilter, setStatusFilter] = useState<CapabilityStatus | "all">("all");
+  const [query, setQuery] = useState("");
+  const [urlFiltersHydrated, setUrlFiltersHydrated] = useState(false);
   const [selectionId, setSelectionId] = useState<string | null>(null);
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
 
@@ -140,13 +141,24 @@ export function CapabilitiesViewSurface({
   }, [load]);
 
   useEffect(() => {
+    if (urlFiltersHydrated) return;
+    setHarnessFilter(initialHarness(activeHarness));
+    setQuery(initialQuery());
+    setTypeFilter(initialTypeFilter());
+    setStatusFilter(initialStatusFilter());
+    setUrlFiltersHydrated(true);
+  }, [activeHarness, urlFiltersHydrated]);
+
+  useEffect(() => {
+    if (!urlFiltersHydrated) return;
     if (activeHarness) {
       setHarnessFilter(activeHarness);
       setSelectionId(null);
     }
-  }, [activeHarness]);
+  }, [activeHarness, urlFiltersHydrated]);
 
   useEffect(() => {
+    if (!urlFiltersHydrated) return;
     if (typeof window === "undefined") return;
     const params = new URLSearchParams(window.location.search);
     if (harnessFilter) params.set("harness", harnessFilter);
@@ -159,7 +171,7 @@ export function CapabilitiesViewSurface({
     else params.delete("status");
     const next = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ""}`;
     window.history.replaceState(null, "", next);
-  }, [harnessFilter, query, typeFilter, statusFilter]);
+  }, [harnessFilter, query, typeFilter, statusFilter, urlFiltersHydrated]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {


### PR DESCRIPTION
Follow-up for a late review thread on #452.

Keeps capability filter state SSR-stable on the initial render, hydrates URL-backed filters after mount, and gates URL writes until that hydration completes.

Verification:
- node --experimental-strip-types src/components/capabilities-normalize.test.ts
- node --experimental-strip-types src/components/capabilities-view.test.ts
- node --experimental-strip-types src/components/capabilities-view-polish.test.ts
- node --experimental-strip-types src/app/api/capabilities/route.test.ts
- pnpm typecheck
- git diff --check