### PR TITLE
fix(chat): filter sessions without valid cwd

### DIFF
--- a/src/app/api/sessions/list/route.ts
+++ b/src/app/api/sessions/list/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import fs from "node:fs";
 import { callDaemon } from "@/lib/coven-daemon";
 import { loadState } from "@/lib/cave-config";
 import { listConversations } from "@/lib/cave-conversations";
@@ -20,6 +21,16 @@ type DaemonSession = {
   created_at: string;
   updated_at: string;
 };
+
+function isTrueProjectCwd(projectRoot: string): boolean {
+  const trimmed = projectRoot.trim();
+  if (!trimmed) return false;
+  try {
+    return fs.statSync(trimmed).isDirectory();
+  } catch {
+    return false;
+  }
+}
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
@@ -51,6 +62,7 @@ export async function GET(req: Request) {
     localConversations,
     state,
     includeArchived,
+    isValidDaemonProjectRoot: isTrueProjectCwd,
   });
 
   return NextResponse.json({ ok: true, sessions });

--- a/src/lib/session-list-merge.test.ts
+++ b/src/lib/session-list-merge.test.ts
@@ -67,6 +67,43 @@ assert.deepEqual(
   "session list should include local-only saved chats alongside daemon sessions",
 );
 
+const cwdFiltered = mergeSessionRows({
+  daemonSessions: [
+    {
+      id: "daemon-valid",
+      project_root: "/repo",
+      harness: "codex",
+      title: "Valid daemon chat",
+      status: "completed",
+      exit_code: 0,
+      archived_at: null,
+      created_at: "2026-06-08T18:00:00.000Z",
+      updated_at: "2026-06-08T18:05:00.000Z",
+    },
+    {
+      id: "daemon-missing-cwd",
+      project_root: "/deleted/worktree",
+      harness: "codex",
+      title: "Stale daemon chat",
+      status: "orphaned",
+      exit_code: null,
+      archived_at: null,
+      created_at: "2026-06-08T18:10:00.000Z",
+      updated_at: "2026-06-08T18:15:00.000Z",
+    },
+  ],
+  localConversations: [localConversation],
+  state,
+  includeArchived: false,
+  isValidDaemonProjectRoot: (root) => root === "/repo",
+});
+
+assert.deepEqual(
+  cwdFiltered.map((s) => s.id),
+  ["local-1", "daemon-valid"],
+  "daemon sessions without a true project cwd should be filtered while local Cave chats remain visible",
+);
+
 assert.equal(
   mergeSessionRows({
     daemonSessions: [],

--- a/src/lib/session-list-merge.ts
+++ b/src/lib/session-list-merge.ts
@@ -24,6 +24,7 @@ type MergeOptions = {
   localConversations: LocalConversationSummary[];
   state: CaveState;
   includeArchived: boolean;
+  isValidDaemonProjectRoot?: (projectRoot: string) => boolean;
 };
 
 function localConversationToSession(
@@ -71,11 +72,15 @@ export function mergeSessionRows({
   localConversations,
   state,
   includeArchived,
+  isValidDaemonProjectRoot,
 }: MergeOptions): SessionRow[] {
   const seen = new Set<string>();
   const rows: SessionRow[] = [];
 
   for (const session of daemonSessions) {
+    if (isValidDaemonProjectRoot && !isValidDaemonProjectRoot(session.project_root)) {
+      continue;
+    }
     seen.add(session.id);
     const titleOverride = state.sessionTitles[session.id];
     const archivedLocal = state.sessionArchived[session.id] ?? null;


### PR DESCRIPTION
## Summary
- filter daemon-backed sessions out of `/api/sessions/list` when their `project_root` is missing or not a directory
- keep local Cave conversations visible, so saved chats without daemon cwd are not lost
- add regression coverage for valid daemon sessions, invalid daemon sessions, and local-only Cave chats

## Operational cleanup
- removed 22 stale daemon session rows whose project cwd no longer existed or was synthetic
- verified the live daemon session list after cleanup: 317 sessions, `badCount: 0`
- kept local backup files before touching state/DB:
  - `/Users/buns/.coven/cave-state.json.bak-invalid-cwd-2026-06-11T20-09-10-228Z`
  - `/Users/buns/.coven/coven.sqlite3.bak-invalid-cwd-2026-06-11T20-09-44-089Z`
- preserved the invalid-row inventory at `/Users/buns/.coven/invalid-cwd-sessions-2026-06-11T20-09-10-228Z.json`

## Verification
- `pnpm build`
- `pnpm test:app`
- `pnpm test:api`
- `git diff --check`

Commit: 988b107
