### PR TITLE
feat(chat): split right panel vertically

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2462,6 +2462,48 @@ select {
 }
 .right-panel-close:hover { color: var(--text-primary); background: var(--bg-hover); }
 
+.right-panel-split {
+  height: 100%;
+  min-height: 0;
+  min-width: 0;
+  width: 100%;
+}
+
+.right-panel-pane {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+}
+
+.right-panel-splitter {
+  flex-shrink: 0;
+}
+
+.right-panel-changes-header {
+  display: flex;
+  align-items: center;
+  height: 38px;
+  flex-shrink: 0;
+  min-width: 0;
+  border-bottom: 1px solid var(--border-hairline);
+  background: var(--bg-raised);
+  padding: 0 10px;
+}
+
+.right-panel-changes-title {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+  font-size: 11px;
+  font-weight: 500;
+}
+
 /* ============================================================
    Theme palettes — 7 non-default themes (Coven default lives in :root).
    Each theme ships a DARK and a LIGHT palette. Hue is held constant

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -7,6 +7,7 @@ import { AgentsMemoryView } from "@/components/agents-memory-view";
 import { InspectorPane } from "@/components/inspector-pane";
 import { DebugPane } from "@/components/debug-pane";
 import { SessionChangesPanel } from "@/components/session-changes-panel";
+import { SeparatorHandle } from "@/components/ui/separator-handle";
 import { Icon } from "@/lib/icon";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { Familiar, SessionRow } from "@/lib/types";
@@ -70,54 +71,65 @@ function RightPanel({
   onOpenInboxItem: (item: InboxItem) => void;
   onInboxItemChanged: () => void | Promise<void>;
 }) {
+  const primaryPanel: Exclude<RightPanelKind, "changes"> = panel === "debug" ? "debug" : "inspector";
+
   return (
     // CHAT-D13-05: this panel renders inside the shell's <main>, where a
     // complementary landmark is invalid (axe landmark-complementary-is-top-level)
     // — expose it as a named region instead.
     <aside role="region" aria-label="Session panels" className="relative flex h-full min-h-0 min-w-0 flex-1 flex-col border-l border-[var(--border-hairline)]">
-      <div className="right-panel-tabs">
-        <button
-          type="button"
-          className={`right-panel-tab${panel === "inspector" ? " right-panel-tab--active" : ""}`}
-          onClick={() => onSetPanel("inspector")}
-        >
-          <Icon name="ph:brain-bold" width={13} />
-          Inspector
-        </button>
-        <button
-          type="button"
-          className={`right-panel-tab${panel === "changes" ? " right-panel-tab--active" : ""}`}
-          onClick={() => onSetPanel("changes")}
-        >
-          <Icon name="ph:git-diff" width={13} />
-          Changes
-        </button>
-        <button
-          type="button"
-          className={`right-panel-tab${panel === "debug" ? " right-panel-tab--active" : ""}`}
-          onClick={() => onSetPanel("debug")}
-        >
-          <Icon name="ph:bug-bold" width={13} />
-          Debug
-        </button>
-        <button type="button" className="right-panel-close" onClick={() => onSetPanel(null)}>
-          <Icon name="ph:x-bold" width={11} />
-        </button>
-      </div>
-      <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
-        {panel === "inspector" && (
-          <InspectorPane
-            familiar={activeFamiliar}
-            inboxItems={inboxItems}
-            onOpenInbox={onOpenInbox}
-            onCreateReminder={onCreateReminder}
-            onOpenInboxItem={onOpenInboxItem}
-            onInboxItemChanged={onInboxItemChanged}
-          />
-        )}
-        {panel === "changes" && <SessionChangesPanel />}
-        {panel === "debug" && <DebugPane />}
-      </div>
+      <Group className="right-panel-split" orientation="vertical">
+        <Panel id="right-panel-primary" className="right-panel-pane min-h-0" defaultSize="50%" minSize="25%">
+          <div className="right-panel-tabs">
+            <button
+              type="button"
+              className={`right-panel-tab${primaryPanel === "inspector" ? " right-panel-tab--active" : ""}`}
+              onClick={() => onSetPanel("inspector")}
+            >
+              <Icon name="ph:brain-bold" width={13} />
+              Inspector
+            </button>
+            <button
+              type="button"
+              className={`right-panel-tab${primaryPanel === "debug" ? " right-panel-tab--active" : ""}`}
+              onClick={() => onSetPanel("debug")}
+            >
+              <Icon name="ph:bug-bold" width={13} />
+              Debug
+            </button>
+            <button type="button" className="right-panel-close" onClick={() => onSetPanel(null)}>
+              <Icon name="ph:x-bold" width={11} />
+            </button>
+          </div>
+          <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
+            {primaryPanel === "inspector" && (
+              <InspectorPane
+                familiar={activeFamiliar}
+                inboxItems={inboxItems}
+                onOpenInbox={onOpenInbox}
+                onCreateReminder={onCreateReminder}
+                onOpenInboxItem={onOpenInboxItem}
+                onInboxItemChanged={onInboxItemChanged}
+              />
+            )}
+            {primaryPanel === "debug" && <DebugPane />}
+          </div>
+        </Panel>
+        <Separator className="shell-separator-h right-panel-splitter">
+          <SeparatorHandle orientation="row" />
+        </Separator>
+        <Panel id="right-panel-changes" className="right-panel-pane min-h-0" defaultSize="50%" minSize="25%">
+          <div className="right-panel-changes-header">
+            <span className="right-panel-changes-title">
+              <Icon name="ph:git-diff" width={13} />
+              Changes
+            </span>
+          </div>
+          <div className="min-h-0 flex-1 overflow-hidden">
+            <SessionChangesPanel />
+          </div>
+        </Panel>
+      </Group>
     </aside>
   );
 }

--- a/src/components/debug-pane.test.ts
+++ b/src/components/debug-pane.test.ts
@@ -26,13 +26,13 @@ const surface = await readFile(new URL("./chat-surface.tsx", import.meta.url), "
 
 assert.match(
   surface,
-  /onSetPanel\("changes"\)[\s\S]*?Changes/,
-  "Chat right panel should expose a Changes tab alongside Inspector/Debug",
+  /right-panel-changes-header[\s\S]*?Changes/,
+  "Chat right panel should expose a persistent Changes half beneath Inspector/Debug",
 );
 assert.match(
   surface,
-  /\{panel === "changes" && <SessionChangesPanel \/>\}/,
-  "Changes tab should render SessionChangesPanel",
+  /<Panel[\s\S]*id="right-panel-changes"[\s\S]*<SessionChangesPanel \/>/,
+  "Changes half should render SessionChangesPanel persistently",
 );
 
 const changesPanel = await readFile(

--- a/src/components/right-sidebar-fit.test.ts
+++ b/src/components/right-sidebar-fit.test.ts
@@ -38,7 +38,19 @@ assert.match(
 assert.match(
   chatSurface,
   /right-panel-close[\s\S]*?className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto"/,
-  "Right panel content wrapper must scroll vertically so pane content without an internal scroller is reachable",
+  "Right panel top content wrapper must scroll vertically so pane content without an internal scroller is reachable",
+);
+
+assert.match(
+  chatSurface,
+  /<Group[\s\S]*className="right-panel-split"[\s\S]*orientation="vertical"/,
+  "ChatSurface right sidebar should use a vertical split inside the right panel",
+);
+
+assert.match(
+  chatSurface,
+  /<Panel[\s\S]*id="right-panel-primary"[\s\S]*defaultSize="50%"[\s\S]*<Separator[\s\S]*className="shell-separator-h right-panel-splitter"[\s\S]*<Panel[\s\S]*id="right-panel-changes"[\s\S]*defaultSize="50%"/,
+  "ChatSurface right sidebar should default to a 50/50 vertical split",
 );
 
 console.log("right-sidebar-fit.test.ts OK");


### PR DESCRIPTION
## Summary
- Make the Chat right sidebar a real vertical resizable 50/50 split
- Keep Inspector/Debug selectable in the top half
- Keep Changes persistently visible in the bottom half
- Add a visible resize handle and update source guards for the split contract

## Verification
- node --experimental-strip-types src/components/right-sidebar-fit.test.ts
- node --experimental-strip-types src/components/debug-pane.test.ts
- pnpm test:app
- pnpm typecheck
- pnpm build
- git diff --check
- Browser smoke on 127.0.0.1:3102 measured the split at 429px / 429px with a visible divider
