### PR TITLE
fix(deps): restore @xyflow/react to package.json (unblocks CI)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
+    "@xyflow/react": "12.11.0",
     "next": "16.2.6",
     "node-pty": "^1.1.0",
     "qrcode": "^1.5.4",


### PR DESCRIPTION
## Problem

`main` CI has been red on every branch. Two layered failures:
1. `pnpm install --frozen-lockfile` → `ERR_PNPM_OUTDATED_LOCKFILE` (Frontend-build dies at install, ~11s).
2. Past that, `pnpm typecheck` → `TS2307: Cannot find module '@xyflow/react'` in `src/components/workflows/workflow-canvas.tsx`.

## Root cause

`@xyflow/react@12.11.0` was **accidentally dropped from `package.json` in f811f20** (a "first-class Projects page" commit) — while `workflow-canvas.tsx` still imports it for the Workflow Studio ReactFlow canvas, and the lockfile still pinned it. So package.json was the odd one out.

## Fix

Restore the one dep line. **Net change: +1 line in package.json**; the lockfile already had the correct entry. Verified locally: `pnpm install --frozen-lockfile` passes and `pnpm typecheck` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)