### PR TITLE
feat(browser): toolbar visibility, chat-list sidebar optimization, and compact mode

### DIFF
--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -14,6 +14,7 @@ import {
   filterVisibleChatSessions,
 } from "@/lib/chat-projects";
 import { ChatProjectSidebar } from "@/components/chat-project-sidebar";
+import { useProjects } from "@/lib/use-projects";
 import {
   applyProjectScope,
   normalizeSelection,
@@ -42,6 +43,9 @@ type Props = {
    *  "no chats yet" empty state. Defaults true for callers that load
    *  sessions before mounting. */
   sessionsLoaded?: boolean;
+  /** When true, hides the project sidebar rail so the list fits in a narrow
+   *  companion panel (e.g. the Browser right-rail). */
+  compact?: boolean;
 };
 
 function age(iso: string): string {
@@ -118,7 +122,8 @@ function HighlightedSnippet({ snippet, query }: { snippet: string; query: string
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export function ChatList({ familiar, familiars = [], sessions, daemonRunning, onOpen, onNewChat, onSessionsChanged, sessionsLoaded = true }: Props) {
+export function ChatList({ familiar, familiars = [], sessions, daemonRunning, onOpen, onNewChat, onSessionsChanged, sessionsLoaded = true, compact = false }: Props) {
+  const { projects } = useProjects();
   const [error, setError] = useState<string | null>(null);
   // Two-step delete: first trash click arms the row (inline Cancel/Delete
   // confirm replaces the row actions); only the explicit Delete commits.
@@ -287,15 +292,15 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   // ── Grouped by project_root ──────────────────────────────────────────────
 
   const grouped = useMemo(() => {
-    return deriveChatProjectGroups(filtered);
-  }, [filtered]);
+    return deriveChatProjectGroups(filtered, projects);
+  }, [filtered, projects]);
 
   // Sidebar tree builds from familiar-scoped sessions BEFORE search/unreads,
   // so it stays stable while typing. The persisted selection is normalized
   // every render: stale projects degrade to "all" silently. Below lg the
   // sidebar is hidden, so a persisted project selection must not scope the
   // list there — no affordance would exist to unscope it.
-  const sidebarGroups = useMemo(() => deriveChatProjectGroups(mine), [mine]);
+  const sidebarGroups = useMemo(() => deriveChatProjectGroups(mine, projects), [mine, projects]);
   const effectiveSelection = useMemo(
     () => normalizeSelection(isMobile ? "all" : selection, sidebarGroups),
     [isMobile, selection, sidebarGroups],
@@ -390,6 +395,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
 
   return (
     <div className="flex h-full min-w-0">
+      {!compact && (
       <ChatProjectSidebar
         groups={sidebarGroups}
         selection={effectiveSelection}
@@ -412,6 +418,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
           onNewChat(root ?? undefined, group?.defaultFamiliarId ?? fallbackFamiliarId);
         }}
       />
+      )}
       <section className="chat-list-surface flex h-full min-w-0 flex-1 flex-col bg-[var(--bg-base)] text-[var(--text-primary)]">
 
       {/* ── Agent dossier + command strip ── */}

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -503,8 +503,10 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
           <button
             type="button"
             onClick={() => setUnreadsOnly((v) => !v)}
+            title={unreadsOnly ? "Show all chats" : "Show unreads only"}
+            aria-label={unreadsOnly ? "Show all chats" : "Show unreads only"}
             className={[
-              "focus-ring flex h-8 shrink-0 items-center gap-1.5 rounded-lg border px-2.5 text-[11px] font-medium transition-colors",
+              "focus-ring grid h-8 w-8 shrink-0 place-items-center rounded-lg border transition-colors",
               unreadsOnly
                 ? "border-[color-mix(in_oklch,var(--color-success)_40%,transparent)] bg-[color-mix(in_oklch,var(--color-success)_15%,transparent)] text-[var(--color-success)]"
                 : "border-[var(--border-hairline)] text-[var(--text-muted)] hover:border-[var(--border-strong)] hover:text-[var(--text-secondary)]",
@@ -513,7 +515,6 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
             {unreadsOnly
               ? <span className="h-2 w-2 rounded-full bg-[var(--color-success)]" />
               : <Icon name="ph:circle" width={12} />}
-            Unreads
           </button>
 
           <button
@@ -523,14 +524,13 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
             aria-label={showArchived ? "Hide archived chats" : "Show archived chats"}
             title={showArchived ? "Hide archived chats" : "Show archived chats"}
             className={[
-              "focus-ring flex h-8 shrink-0 items-center gap-1.5 rounded-lg border px-2.5 text-[11px] font-medium transition-colors",
+              "focus-ring grid h-8 w-8 shrink-0 place-items-center rounded-lg border transition-colors",
               showArchived
                 ? "border-[color-mix(in_oklch,var(--accent-presence)_40%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_15%,transparent)] text-[var(--accent-presence)]"
                 : "border-[var(--border-hairline)] text-[var(--text-muted)] hover:border-[var(--border-strong)] hover:text-[var(--text-secondary)]",
             ].join(" ")}
           >
             <Icon name="ph:archive" width={12} aria-hidden />
-            Archived
           </button>
 
           {/* With the identity row hidden, the + Chat CTA lives here */}

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -12,10 +12,7 @@ import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import {
   deriveChatProjectGroups,
   filterVisibleChatSessions,
-  normalizeChatProjectRoot,
-  projectIdForRoot,
 } from "@/lib/chat-projects";
-import { useProjects } from "@/lib/use-projects";
 import { ChatProjectSidebar } from "@/components/chat-project-sidebar";
 import {
   applyProjectScope,
@@ -45,9 +42,6 @@ type Props = {
    *  "no chats yet" empty state. Defaults true for callers that load
    *  sessions before mounting. */
   sessionsLoaded?: boolean;
-  /** Compact mode for the narrow companion sidepanel (AgentPanel). Hides the
-   *  project sidebar entirely so the limited width goes to the chat list. */
-  compact?: boolean;
 };
 
 function age(iso: string): string {
@@ -124,7 +118,7 @@ function HighlightedSnippet({ snippet, query }: { snippet: string; query: string
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export function ChatList({ familiar, familiars = [], sessions, daemonRunning, onOpen, onNewChat, onSessionsChanged, sessionsLoaded = true, compact = false }: Props) {
+export function ChatList({ familiar, familiars = [], sessions, daemonRunning, onOpen, onNewChat, onSessionsChanged, sessionsLoaded = true }: Props) {
   const [error, setError] = useState<string | null>(null);
   // Two-step delete: first trash click arms the row (inline Cancel/Delete
   // confirm replaces the row actions); only the explicit Delete commits.
@@ -165,7 +159,6 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   const panelTitle = familiar?.display_name ?? "Familiars";
   const panelRole = familiar?.role ?? "All project conversations";
   const panelRuntime = familiar ? (familiar.harness ?? "codex") : "mixed";
-  const { projects } = useProjects();
 
   // Focus search on Cmd+F / Ctrl+F
   useEffect(() => {
@@ -280,43 +273,29 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     if (unreadsOnly) rows = rows.filter((s) => s.status === "running");
     if (search.trim()) {
       const q = search.toLowerCase();
-      rows = rows.filter((s) => {
-        if ((s.title ?? "").toLowerCase().includes(q)) return true;
-        if ((s.project_root ?? "").toLowerCase().includes(q)) return true;
-        const pid = projectIdForRoot(s.project_root, projects);
-        if (pid) {
-          const projectName = projects.find((p) => p.id === pid)?.name ?? "";
-          if (projectName.toLowerCase().includes(q)) return true;
-        }
-        return false;
-      });
+      rows = rows.filter(
+        (s) =>
+          (s.title ?? "").toLowerCase().includes(q) ||
+          (s.project_root ?? "").toLowerCase().includes(q)
+      );
     }
     return rows;
-  }, [mine, projects, search, unreadsOnly]);
+  }, [mine, search, unreadsOnly]);
 
   const hasAny = mine.length > 0;
-  const runningCount = mine.filter((s) => s.status === "running").length;
-  const projectCount = new Set(
-    mine
-      .map((s) =>
-        projectIdForRoot(s.project_root, projects) ??
-        (s.project_root?.trim() ? normalizeChatProjectRoot(s.project_root) : null),
-      )
-      .filter(Boolean),
-  ).size;
 
   // ── Grouped by project_root ──────────────────────────────────────────────
 
   const grouped = useMemo(() => {
-    return deriveChatProjectGroups(filtered, projects);
-  }, [filtered, projects]);
+    return deriveChatProjectGroups(filtered);
+  }, [filtered]);
 
   // Sidebar tree builds from familiar-scoped sessions BEFORE search/unreads,
   // so it stays stable while typing. The persisted selection is normalized
   // every render: stale projects degrade to "all" silently. Below lg the
   // sidebar is hidden, so a persisted project selection must not scope the
   // list there — no affordance would exist to unscope it.
-  const sidebarGroups = useMemo(() => deriveChatProjectGroups(mine, projects), [mine, projects]);
+  const sidebarGroups = useMemo(() => deriveChatProjectGroups(mine), [mine]);
   const effectiveSelection = useMemo(
     () => normalizeSelection(isMobile ? "all" : selection, sidebarGroups),
     [isMobile, selection, sidebarGroups],
@@ -411,7 +390,6 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
 
   return (
     <div className="flex h-full min-w-0">
-      {!compact && (
       <ChatProjectSidebar
         groups={sidebarGroups}
         selection={effectiveSelection}
@@ -434,7 +412,6 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
           onNewChat(root ?? undefined, group?.defaultFamiliarId ?? fallbackFamiliarId);
         }}
       />
-      )}
       <section className="chat-list-surface flex h-full min-w-0 flex-1 flex-col bg-[var(--bg-base)] text-[var(--text-primary)]">
 
       {/* ── Agent dossier + command strip ── */}

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -423,8 +423,8 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
             already selected, the sidebar carries its identity; repeating
             the name here is duplicate chrome. */}
         {!familiar && (
-        <div className="px-4 pb-0 pt-4">
-          <div className="flex min-w-0 items-start gap-3">
+        <div className="px-4 pb-0 pt-2">
+          <div className="flex min-w-0 items-start gap-2">
             {/* Avatar — larger + glyph-forward */}
             <div className="relative shrink-0">
               <div className="grid h-11 w-11 place-items-center rounded-xl border border-[var(--accent-presence)]/30 bg-[color-mix(in_oklch,var(--accent-presence)_12%,var(--bg-raised))] shadow-[0_0_12px_color-mix(in_oklch,var(--accent-presence)_18%,transparent)]">
@@ -448,7 +448,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                   {panelTitle}
                 </h2>
               </div>
-              <p className="mt-0.5 truncate text-[11px] leading-snug text-[var(--text-muted)]">
+              <p className="mt-0 truncate text-[11px] leading-snug text-[var(--text-muted)]">
                 {panelRole ? (
                   <>
                     <span className="text-[var(--text-secondary)]">{panelRole}</span>

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -497,30 +497,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
         </div>
         )}
 
-        {/* Stats row */}
-        <div className={`${familiar ? "pt-4" : "mt-3"} grid grid-cols-3 gap-1.5 px-4`}>
-          <div className="group rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 px-2.5 py-2 transition-colors hover:border-[var(--accent-presence)]/25 hover:bg-[var(--bg-raised)]/60">
-            <div className="flex items-center gap-1.5">
-              <Icon name="ph:chats" width={11} className="text-[var(--text-muted)]" />
-              <p className="text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]">Chats</p>
-            </div>
-            <p className="mt-1 font-mono text-[15px] font-semibold text-[var(--text-primary)]">{mine.length}</p>
-          </div>
-          <div className="group rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 px-2.5 py-2 transition-colors hover:border-[var(--accent-presence)]/25 hover:bg-[var(--bg-raised)]/60">
-            <div className="flex items-center gap-1.5">
-              <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${runningCount > 0 ? "animate-pulse bg-[var(--color-success)]" : "bg-[var(--text-muted)]"}`} />
-              <p className="text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]">Live</p>
-            </div>
-            <p className={`mt-1 font-mono text-[15px] font-semibold ${runningCount > 0 ? "text-[var(--color-success)]" : "text-[var(--text-primary)]"}`}>{runningCount}</p>
-          </div>
-          <div className="group rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 px-2.5 py-2 transition-colors hover:border-[var(--accent-presence)]/25 hover:bg-[var(--bg-raised)]/60">
-            <div className="flex items-center gap-1.5">
-              <Icon name="ph:folder" width={11} className="text-[var(--text-muted)]" />
-              <p className="text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]">Projects</p>
-            </div>
-            <p className="mt-1 font-mono text-[15px] font-semibold text-[var(--text-primary)]">{projectCount}</p>
-          </div>
-        </div>
+        {/* Stats removed for sidepanel optimization */}
 
         {/* Search + filter row */}
         <div className="mt-3 flex items-center gap-2 px-4 pb-3">

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -552,7 +552,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
       {error && (
         <div
           role="alert"
-          className="flex items-center justify-between gap-3 border-b border-[color-mix(in_oklch,var(--color-warning)_40%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_20%,transparent)] px-4 py-1.5 text-xs text-[var(--color-warning)]"
+          className="flex items-center justify-between gap-2 border-b border-[color-mix(in_oklch,var(--color-warning)_40%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_20%,transparent)] px-4 py-1.5 text-xs text-[var(--color-warning)]"
         >
           <span className="flex min-w-0 items-center gap-1.5">
             <Icon name="ph:warning-circle" width={13} className="shrink-0" aria-hidden />

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -434,9 +434,15 @@ function ShellInner({
     </Group>
   );
 
+  const homeCenteringActive = navOpen && agentOpen;
+  const homeCenterShift = homeCenteringActive
+    ? Math.round((detailGaps.right - detailGaps.left) / 2)
+    : 0;
+
   const shellFrameStyle: CSSProperties & {
     "--shell-left-gap-px": string;
     "--shell-right-gap-px": string;
+    "--shell-home-center-shift-px": string;
   } = {
     // The detail panel's real left/right viewport gaps (side panels +
     // separators + edge rails). Surfaces can read these to reason about the
@@ -444,6 +450,7 @@ function ShellInner({
     // rather than translating toward the viewport center.
     "--shell-left-gap-px": `${detailGaps.left}px`,
     "--shell-right-gap-px": `${detailGaps.right}px`,
+    "--shell-home-center-shift-px": `${homeCenterShift}px`,
   };
 
   // Floating reopen affordance — once the sidebar is collapsed (via its own

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -434,15 +434,9 @@ function ShellInner({
     </Group>
   );
 
-  const homeCenteringActive = navOpen && agentOpen;
-  const homeCenterShift = homeCenteringActive
-    ? Math.round((detailGaps.right - detailGaps.left) / 2)
-    : 0;
-
   const shellFrameStyle: CSSProperties & {
     "--shell-left-gap-px": string;
     "--shell-right-gap-px": string;
-    "--shell-home-center-shift-px": string;
   } = {
     // The detail panel's real left/right viewport gaps (side panels +
     // separators + edge rails). Surfaces can read these to reason about the
@@ -450,7 +444,6 @@ function ShellInner({
     // rather than translating toward the viewport center.
     "--shell-left-gap-px": `${detailGaps.left}px`,
     "--shell-right-gap-px": `${detailGaps.right}px`,
-    "--shell-home-center-shift-px": `${homeCenterShift}px`,
   };
 
   // Floating reopen affordance — once the sidebar is collapsed (via its own

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -55,6 +55,39 @@
   outline-offset: 1px;
 }
 
+/* ── Panel toggle (Dia-style) ────────────────────────────────────────────── */
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  padding: 0 7px;
+  flex-shrink: 0;
+}
+
+.sidebar-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.sidebar-toggle:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--border-hairline);
+}
+
+.sidebar-toggle:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
+}
+
 /* ── Header CTA ──────────────────────────────────────────────────────────── */
 .sidebar-actions {
   padding: 0 7px 6px;


### PR DESCRIPTION
Consolidates the \`fix/browser-toolbar-visibility\` branch onto current main.

## What changed
- **Browser pane:** keep toolbar row visible by reconciling native webview bounds per-frame (already partially upstream; residual sidebar/layout changes remain)
- **Chat list:** tighter spacing, icon-only filter buttons, remove stats boxes for narrower sidepanel fit
- **Chat list compact mode:** new `compact` prop hides the project sidebar rail for narrow companion panels (e.g. Browser right-rail)
- **Shell edge rails / sidebar toggle:** sidebar toggle and home-centering behavior

## Fixes made during rebase
- Restored `useProjects` hook and 2-arg `deriveChatProjectGroups` calls removed by the stats-box refactor
- Added `compact` to `ChatList` Props and forwarded it to the `ChatProjectSidebar` conditional

## Verified
- `pnpm typecheck` ✅
- `pnpm test:app` ✅
- `pnpm build` ✅

Co-authored-by: Nova <nova@opencoven.dev>