### PR TITLE
fix: unblock main CI — restore @xyflow/react + projects client/server boundary

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
+    "@xyflow/react": "12.11.0",
     "next": "16.2.6",
     "node-pty": "^1.1.0",
     "qrcode": "^1.5.4",

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -3,8 +3,8 @@
 import { useMemo, useState, type FormEvent } from "react";
 
 import { Icon } from "@/lib/icon";
-import type { CaveProject } from "@/lib/cave-projects";
-import { normalizeProjectRoot } from "@/lib/cave-projects";
+import type { CaveProject } from "@/lib/cave-projects-types";
+import { normalizeProjectRoot } from "@/lib/cave-projects-types";
 import { useProjects } from "@/lib/use-projects";
 
 type ProjectsViewProps = {

--- a/src/lib/cave-projects-types.ts
+++ b/src/lib/cave-projects-types.ts
@@ -1,0 +1,21 @@
+/**
+ * cave-projects-types.ts
+ *
+ * Client-safe type definitions and pure helpers extracted from cave-projects.ts.
+ * Import these in "use client" components instead of cave-projects.ts directly
+ * to avoid pulling node:fs/promises into the browser bundle.
+ */
+
+export type CaveProject = {
+  id: string;
+  name: string;
+  root: string;
+  color?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/** Normalise a project root path to a canonical forward-slash, no-trailing-slash form. */
+export function normalizeProjectRoot(root: string | null | undefined): string {
+  return root?.trim().replace(/\\/g, "/").replace(/\/+$/, "") || "/";
+}

--- a/src/lib/cave-projects.ts
+++ b/src/lib/cave-projects.ts
@@ -3,14 +3,12 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 
-export type CaveProject = {
-  id: string;
-  name: string;
-  root: string;
-  color?: string;
-  createdAt: string;
-  updatedAt: string;
-};
+// CaveProject and normalizeProjectRoot live in the client-safe types module so
+// "use client" components can import them without dragging node:fs/promises
+// into the browser bundle. Re-exported here for existing server-side importers.
+import type { CaveProject } from "./cave-projects-types";
+export type { CaveProject };
+export { normalizeProjectRoot } from "./cave-projects-types";
 
 type ProjectsFile = {
   version: 1;
@@ -26,10 +24,6 @@ function projectsFilePath(): string {
 
 function normalizeRoot(root: string): string {
   return root.trim().replace(/\\/g, "/").replace(/\/+$/, "") || "/";
-}
-
-export function normalizeProjectRoot(root: string | null | undefined): string {
-  return root?.trim().replace(/\\/g, "/").replace(/\/+$/, "") || "/";
 }
 
 function nanoid(len = 10): string {


### PR DESCRIPTION
`main` CI has been red. Two independent breakages from the recent Projects/Workflows churn, both fixed here:

### 1. Missing dependency (was PR #464, folded in)
`@xyflow/react@12.11.0` was dropped from `package.json` (commit f811f20) while `workflow-canvas.tsx` still imports it. → `ERR_PNPM_OUTDATED_LOCKFILE` + `TS2307`. **Fix:** restore the one dep line.

### 2. node:fs in the client bundle
`f811f20` intended a client/server split (`cave-projects-types.ts`) so `"use client"` components import types + pure helpers, but the split file was **lost in a merge** and `projects-view.tsx` imported the *value* `normalizeProjectRoot` straight from `cave-projects.ts` (which imports `node:fs/promises`). → Turbopack: *"chunk item errored … does not support external modules (request: node:fs/promises)"* on `workspace.tsx`. **Fix:** recreate `cave-projects-types.ts`, re-export from `cave-projects.ts` for server importers, point `projects-view.tsx` at the safe module.

### Verification
`pnpm build` compiles clean and generates all 18 static pages locally; `pnpm typecheck` passes.

Supersedes #464 (its one-line fix is included here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)