### PR TITLE
style(chat): compact empty-state project selector and prompt buttons

### DIFF
--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -667,24 +667,24 @@
 
 .cave-chat-empty-project {
   display: grid;
-  grid-template-columns: auto auto minmax(120px, 0.45fr) minmax(0, 1fr);
+  grid-template-columns: auto auto minmax(96px, 0.45fr) minmax(0, 1fr);
   align-items: center;
-  gap: 10px;
-  min-height: 48px;
+  gap: 8px;
+  min-height: 34px;
   border: 1px solid var(--border-panel);
-  border-radius: 8px;
+  border-radius: 7px;
   background: color-mix(in oklch, var(--bg-elevated) 78%, transparent);
-  padding: 0 13px;
+  padding: 0 10px;
   color: var(--text-muted);
   box-shadow:
-    0 10px 34px oklch(0 0 0 / 18%),
+    0 4px 16px oklch(0 0 0 / 14%),
     inset 0 1px 0 oklch(1 0 0 / 5%);
 }
 
 .cave-chat-empty-project-label {
   color: var(--text-muted);
   font-family: "SF Mono", "JetBrains Mono", "Roboto Mono", monospace;
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 650;
   letter-spacing: 0;
   text-transform: uppercase;
@@ -697,7 +697,7 @@
   background: transparent;
   color: var(--text-primary);
   font: inherit;
-  font-size: 18px;
+  font-size: 14px;
   font-weight: 520;
   outline: none;
 }
@@ -712,7 +712,7 @@
   overflow: hidden;
   color: var(--text-muted);
   font-family: "SF Mono", "JetBrains Mono", "Roboto Mono", monospace;
-  font-size: 12px;
+  font-size: 11px;
   line-height: 1.3;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -721,21 +721,21 @@
 .cave-chat-empty-prompts {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
+  gap: 8px;
 }
 
 .cave-chat-empty-prompt {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  min-height: 46px;
+  gap: 10px;
+  min-height: 34px;
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: 7px;
   background: color-mix(in oklch, var(--bg-raised) 78%, transparent);
-  padding: 0 14px;
+  padding: 0 11px;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 500;
   text-align: left;
   transition:


### PR DESCRIPTION
## What

Shrinks the chat empty-state ("launch screen") so it reads tighter in narrow side-panel widths:

- **PROJECT selector** (`.cave-chat-empty-project`): row 48 → 34px, project name 18 → 14px, label 11 → 10px, root path 12 → 11px, lighter drop-shadow (`0 10px 34px` → `0 4px 16px`), radius/padding/gap tightened.
- **Starter-prompt buttons** (`.cave-chat-empty-prompt`, ×4): 46 → 34px tall, font 13 → 12px, radius 8 → 7px, padding/gap tightened.

CSS-only; the mobile `@media (max-width: 640px)` layout is unchanged.

## Verification

Driven in-app via Playwright against the dev server (chat empty state reached through **New chat**). Rendered computed styles matched the change exactly — project row 34px / 14px name, prompt buttons 34px / 12px. Existing `chat-surface-polish.test.ts` still passes (it asserts the className, not pixel values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)