### PR TITLE
feat(workflows): Workflow Studio v2 — visual builder, runs, role assignments

### DIFF
--- a/src/components/workflows-view.test.ts
+++ b/src/components/workflows-view.test.ts
@@ -22,7 +22,26 @@ assert.match(client, /\/api\/workflows/, "Workflows view should stay behind Cave
 assert.match(source, /validateWorkflow/, "Workflows view should wire validation through the workflow client");
 assert.match(source, /dryRunWorkflow/, "Workflows view should wire dry-run through the workflow client");
 assert.match(source, /workflowToGraph/, "Workflows view should derive selected graph data with workflowToGraph");
-assert.match(source, /action\?\.id\s*===\s*selectedWorkflow\?\.id/, "Workflows view should scope action state to the selected workflow");
+assert.match(source, /action\.id\s*===\s*draft\?\.id/, "Workflows view should scope action state to the selected draft");
 assert.match(source, /onSelectNode=\{\(node\)\s*=>\s*setSelectedNodeId\(node\.id\)\}/, "Workflows view should store selected node IDs from Studio");
+
+// --- Studio v2: builder orchestration ---
+assert.match(source, /workflowDraftReducer/, "Workflows view should edit through the draft reducer");
+assert.match(source, /initialWorkflowDraft/, "Workflows view should seed drafts on selection");
+assert.match(source, /workflowToManifest/, "Workflows view should serialize drafts back to manifests");
+assert.match(source, /saveWorkflow/, "Workflows view should persist manifests through the save client");
+assert.match(source, /deleteWorkflow/, "Workflows view should wire manifest deletion");
+assert.match(source, /createWorkflowFromTemplate/, "Workflows view should create workflows from pattern templates");
+assert.match(source, /duplicateWorkflow/, "Workflows view should duplicate workflows");
+assert.match(source, /runWorkflow/, "Workflows view should probe the daemon run proxy");
+assert.match(source, /listWorkflowRuns/, "Workflows view should load run history");
+assert.match(source, /recordWorkflowRun/, "Workflows view should snapshot dry-run plans into history");
+assert.match(source, /attachWorkflowToRole/, "Workflows view should persist role assignments");
+assert.match(source, /scheduleWorkflow/, "Workflows view should schedule reminders");
+assert.match(source, /confirmDiscard|Discard unsaved/, "Workflows view should guard unsaved drafts");
+assert.match(client, /\/api\/workflows\/save/, "Workflow client should call the save route");
+assert.match(client, /\/api\/workflows\/runs/, "Workflow client should call the runs route");
+assert.match(client, /\/api\/roles\/workflows/, "Workflow client should call the role-attach route");
+assert.match(client, /cave:\/\/workflows\//, "Scheduled reminders should deep-link back to the workflow");
 
 console.log("workflows-view.test.ts: ok");

--- a/src/components/workflows-view.tsx
+++ b/src/components/workflows-view.tsx
@@ -1,12 +1,36 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { workflowToGraph } from "@/lib/workflow-graph";
 import {
+  createWorkflowFromTemplate,
+  duplicateWorkflow,
+  slugifyWorkflowId,
+  workflowToManifest,
+} from "@/lib/workflow-edit";
+import {
+  initialWorkflowDraft,
+  workflowDraftReducer,
+  type WorkflowDraftAction,
+  type WorkflowDraftState,
+} from "@/lib/workflow-draft";
+import {
+  attachWorkflowToRole,
+  deleteWorkflow,
   dryRunWorkflow,
+  listWorkflowRoles,
+  listWorkflowRuns,
   listWorkflows,
+  recordWorkflowRun,
+  runWorkflow,
+  saveWorkflow,
+  scheduleWorkflow,
   validateWorkflow,
   type WorkflowDryRunPlan,
+  type WorkflowPattern,
+  type WorkflowRoleSummary,
+  type WorkflowRunRecord,
+  type WorkflowScheduleRecurrence,
   type WorkflowSummary,
 } from "@/lib/workflows";
 import {
@@ -23,6 +47,26 @@ export function WorkflowsView() {
   const [action, setAction] = useState<WorkflowStudioActionState | null>(null);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [draftState, setDraftState] = useState<WorkflowDraftState | null>(null);
+  const [runs, setRuns] = useState<WorkflowRunRecord[]>([]);
+  const [runsLoading, setRunsLoading] = useState(false);
+  const [roles, setRoles] = useState<WorkflowRoleSummary[]>([]);
+  const [engineUnavailable, setEngineUnavailable] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  // The draft is the single editing surface; selection changes re-seed it.
+  const draft = draftState?.draft ?? null;
+  const dirty = draftState?.dirty ?? false;
+
+  const dispatchDraft = useCallback((actionInput: WorkflowDraftAction) => {
+    setDraftState((current) => {
+      if (actionInput.type === "reset") {
+        return initialWorkflowDraft(actionInput.workflow);
+      }
+      if (!current) return current;
+      return workflowDraftReducer(current, actionInput);
+    });
+  }, []);
 
   const load = useCallback(async (refresh = false) => {
     setRefreshing(refresh);
@@ -45,39 +89,58 @@ export function WorkflowsView() {
     }
   }, []);
 
+  const loadRuns = useCallback(async (workflowId: string) => {
+    setRunsLoading(true);
+    try {
+      const result = await listWorkflowRuns(workflowId);
+      setRuns(result.ok ? result.runs : []);
+    } catch {
+      setRuns([]);
+    } finally {
+      setRunsLoading(false);
+    }
+  }, []);
+
+  const loadRoles = useCallback(async () => {
+    try {
+      const result = await listWorkflowRoles();
+      if (result.ok) setRoles(result.roles);
+    } catch {
+      // roles are an enhancement; the studio works without them
+    }
+  }, []);
+
   useEffect(() => {
     void load(false);
-  }, [load]);
+    void loadRoles();
+  }, [load, loadRoles]);
 
+  // Keep a valid selection as the library changes; seed the draft for it.
   useEffect(() => {
     if (workflows.length === 0) {
       setSelectedWorkflowId(null);
       setSelectedNodeId(null);
+      setDraftState(null);
       return;
     }
-    if (selectedWorkflowId && workflows.some((workflow) => workflow.id === selectedWorkflowId)) {
-      return;
-    }
-    setSelectedWorkflowId(workflows[0]?.id ?? null);
+    const current = workflows.find((workflow) => workflow.id === selectedWorkflowId);
+    if (current) return;
+    const next = workflows[0];
+    setSelectedWorkflowId(next.id);
     setSelectedNodeId(null);
-  }, [selectedWorkflowId, workflows]);
-
-  const selectedWorkflow = useMemo(
-    () => workflows.find((workflow) => workflow.id === selectedWorkflowId) ?? null,
-    [selectedWorkflowId, workflows],
-  );
-
-  const selectedAction = action?.id === selectedWorkflow?.id ? action : null;
+    setDraftState(initialWorkflowDraft(next));
+    void loadRuns(next.id);
+  }, [loadRuns, selectedWorkflowId, workflows]);
 
   const selectedDryRun = useMemo<WorkflowDryRunPlan | undefined>(() => {
-    if (selectedAction?.kind !== "dry-run") return undefined;
-    return selectedAction.result as WorkflowDryRunPlan;
-  }, [selectedAction]);
+    if (action?.kind !== "dry-run" || action.id !== draft?.id) return undefined;
+    return action.result as WorkflowDryRunPlan;
+  }, [action, draft?.id]);
 
   const selectedGraph = useMemo(() => {
-    if (!selectedWorkflow) return null;
-    return workflowToGraph(selectedWorkflow, selectedDryRun);
-  }, [selectedDryRun, selectedWorkflow]);
+    if (!draft) return null;
+    return workflowToGraph(draft, selectedDryRun);
+  }, [draft, selectedDryRun]);
 
   const selectedNode = useMemo(
     () => selectedGraph?.nodes.find((node) => node.id === selectedNodeId) ?? null,
@@ -91,10 +154,42 @@ export function WorkflowsView() {
     }
   }, [selectedGraph, selectedNodeId]);
 
+  // Transient notices (schedule confirmations, run feedback) self-expire.
+  const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const showNotice = useCallback((message: string) => {
+    setNotice(message);
+    if (noticeTimer.current) clearTimeout(noticeTimer.current);
+    noticeTimer.current = setTimeout(() => setNotice(null), 6000);
+  }, []);
+  useEffect(() => () => {
+    if (noticeTimer.current) clearTimeout(noticeTimer.current);
+  }, []);
+
+  const confirmDiscard = useCallback((): boolean => {
+    if (!dirty) return true;
+    return window.confirm("Discard unsaved workflow changes?");
+  }, [dirty]);
+
+  const selectWorkflow = (workflow: WorkflowSummary) => {
+    if (workflow.id === selectedWorkflowId) return;
+    if (!confirmDiscard()) return;
+    setSelectedWorkflowId(workflow.id);
+    setSelectedNodeId(null);
+    setDraftState(initialWorkflowDraft(workflow));
+    setEngineUnavailable(false);
+    void loadRuns(workflow.id);
+  };
+
   const runValidate = async (workflow: WorkflowSummary) => {
     setBusyId(`${workflow.id}:validate`);
     try {
-      const result = await validateWorkflow(workflow.path ? { path: workflow.path } : { id: workflow.id });
+      const result = await validateWorkflow(
+        dirty
+          ? { manifest: workflowToManifest(workflow) }
+          : workflow.path
+            ? { path: workflow.path }
+            : { id: workflow.id },
+      );
       setAction({ id: workflow.id, kind: "validate", result });
     } finally {
       setBusyId(null);
@@ -104,34 +199,211 @@ export function WorkflowsView() {
   const runDryRun = async (workflow: WorkflowSummary) => {
     setBusyId(`${workflow.id}:dry-run`);
     try {
-      const result = await dryRunWorkflow({ id: workflow.id, inputs: {} });
+      const result = await dryRunWorkflow(
+        dirty ? { manifest: workflowToManifest(workflow) } : { id: workflow.id, inputs: {} },
+      );
       setAction({ id: workflow.id, kind: "dry-run", result });
+      // Snapshot the plan into run history so the runs panel reflects it.
+      await recordWorkflowRun({
+        workflowId: workflow.id,
+        version: workflow.version,
+        kind: "dry-run",
+        status: result.ok ? "plan" : "blocked",
+        startedAt: new Date().toISOString(),
+        steps: (result.steps ?? []).map((step) => ({
+          id: step.id,
+          kind: step.kind,
+          status: step.status,
+        })),
+        summary: dirty ? "plan snapshot (unsaved draft)" : "plan snapshot",
+        source: "cave",
+      });
+      void loadRuns(workflow.id);
     } finally {
       setBusyId(null);
     }
   };
 
-  const selectWorkflow = (workflow: WorkflowSummary) => {
-    setSelectedWorkflowId(workflow.id);
+  const runPlay = async (workflow: WorkflowSummary) => {
+    setBusyId(`${workflow.id}:play`);
+    try {
+      const result = await runWorkflow({ id: workflow.id });
+      if (result.unavailable) {
+        setEngineUnavailable(true);
+        showNotice("Daemon workflow engine unavailable — Play stays guarded.");
+        return;
+      }
+      if (!result.ok) {
+        showNotice(result.error ?? "workflow run failed");
+        return;
+      }
+      showNotice("Execution accepted by daemon.");
+      void loadRuns(workflow.id);
+    } catch (err) {
+      showNotice(err instanceof Error ? err.message : "workflow run failed");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const runSave = async (workflow: WorkflowSummary) => {
+    setBusyId(`${workflow.id}:save`);
+    try {
+      const result = await saveWorkflow(workflowToManifest(workflow));
+      if (!result.ok) {
+        showNotice(result.error ?? "save failed");
+        return;
+      }
+      if (result.validation) {
+        setAction({ id: workflow.id, kind: "validate", result: result.validation });
+      }
+      if (result.workflow) {
+        setDraftState(initialWorkflowDraft(result.workflow));
+        setSelectedWorkflowId(result.workflow.id);
+      }
+      showNotice("Workflow saved.");
+      void load(true);
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const uniqueId = useCallback(
+    (base: string): string => {
+      const taken = new Set(workflows.map((workflow) => workflow.id));
+      if (!taken.has(base)) return base;
+      let n = 2;
+      while (taken.has(`${base}-${n}`)) n += 1;
+      return `${base}-${n}`;
+    },
+    [workflows],
+  );
+
+  const handleCreate = async (input: { name: string; pattern: WorkflowPattern; familiar?: string }) => {
+    if (!confirmDiscard()) return;
+    const id = uniqueId(slugifyWorkflowId(input.name));
+    const workflow = createWorkflowFromTemplate({
+      id,
+      name: input.name.trim() || id,
+      pattern: input.pattern,
+      familiar: input.familiar?.trim() || undefined,
+    });
+    const result = await saveWorkflow(workflowToManifest(workflow));
+    if (!result.ok) {
+      showNotice(result.error ?? "workflow create failed");
+      return;
+    }
+    await load(true);
+    const saved = result.workflow ?? workflow;
+    setSelectedWorkflowId(saved.id);
     setSelectedNodeId(null);
+    setDraftState(initialWorkflowDraft(saved));
+    void loadRuns(saved.id);
+    showNotice(`Created ${saved.id} from the ${input.pattern} pattern.`);
+  };
+
+  const handleDuplicate = async (workflow: WorkflowSummary) => {
+    const id = uniqueId(`${slugifyWorkflowId(workflow.id)}-copy`);
+    const copy = duplicateWorkflow(workflow, id);
+    const result = await saveWorkflow(workflowToManifest(copy));
+    if (!result.ok) {
+      showNotice(result.error ?? "duplicate failed");
+      return;
+    }
+    await load(true);
+    setSelectedWorkflowId(id);
+    setSelectedNodeId(null);
+    setDraftState(initialWorkflowDraft(result.workflow ?? copy));
+    void loadRuns(id);
+    showNotice(`Duplicated as ${id}.`);
+  };
+
+  const handleDelete = async (workflow: WorkflowSummary) => {
+    if (!window.confirm(`Delete workflow \`${workflow.id}\`? The manifest file is removed.`)) return;
+    const result = await deleteWorkflow(
+      workflow.path ? { path: workflow.path } : { id: workflow.id },
+    );
+    if (!result.ok) {
+      showNotice(result.error ?? "delete failed");
+      return;
+    }
+    setSelectedWorkflowId(null);
+    setDraftState(null);
+    await load(true);
+    showNotice(`Deleted ${workflow.id}.`);
+  };
+
+  const handleAttachRole = async (role: WorkflowRoleSummary, attach: boolean) => {
+    if (!draft) return;
+    const result = await attachWorkflowToRole({
+      roleId: role.id,
+      familiar: role.familiar,
+      workflowId: draft.id,
+      attach,
+    });
+    if (!result.ok) {
+      showNotice(result.error ?? "role update failed");
+      return;
+    }
+    setRoles((current) =>
+      current.map((entry) =>
+        entry.id === role.id && entry.familiar === role.familiar
+          ? { ...entry, workflows: result.workflows ?? entry.workflows }
+          : entry,
+      ),
+    );
+    showNotice(attach ? `Attached to role ${role.name}.` : `Detached from role ${role.name}.`);
+  };
+
+  const handleSchedule = async (fireAt: string, recurrence: WorkflowScheduleRecurrence) => {
+    if (!draft) return;
+    const result = await scheduleWorkflow({ workflow: draft, fireAt, recurrence });
+    showNotice(
+      result.ok
+        ? "Scheduled — the reminder lives on the Automations surface."
+        : result.error ?? "schedule failed",
+    );
   };
 
   return (
     <WorkflowStudio
       workflows={workflows}
-      selectedWorkflow={selectedWorkflow}
+      selectedWorkflow={draft}
       selectedNode={selectedNode}
-      action={selectedAction}
+      action={action && action.id === draft?.id ? action : null}
       busyId={busyId}
       loaded={loaded}
       refreshing={refreshing}
       error={error}
+      dirty={dirty}
+      canUndo={(draftState?.past.length ?? 0) > 0}
+      canRedo={(draftState?.future.length ?? 0) > 0}
+      runs={runs}
+      runsLoading={runsLoading}
+      roles={roles}
+      engineUnavailable={engineUnavailable}
+      notice={notice}
       onRefresh={() => void load(true)}
       onSelectWorkflow={selectWorkflow}
       onSelectNode={(node) => setSelectedNodeId(node.id)}
       onClearNode={() => setSelectedNodeId(null)}
       onValidate={(workflow) => void runValidate(workflow)}
       onDryRun={(workflow) => void runDryRun(workflow)}
+      onPlay={(workflow) => void runPlay(workflow)}
+      onSave={(workflow) => void runSave(workflow)}
+      onUndo={() => dispatchDraft({ type: "undo" })}
+      onRedo={() => dispatchDraft({ type: "redo" })}
+      onAddStep={(kind) => dispatchDraft({ type: "add-step", kind })}
+      onUpdateStep={(id, patch) => dispatchDraft({ type: "update-step", id, patch })}
+      onUpdateMeta={(patch) => dispatchDraft({ type: "update-meta", patch })}
+      onRemoveStep={(id) => dispatchDraft({ type: "remove-step", id })}
+      onConnect={(source, target) => dispatchDraft({ type: "connect", source, target })}
+      onDisconnect={(source, target) => dispatchDraft({ type: "disconnect", source, target })}
+      onCreate={(input) => void handleCreate(input)}
+      onDuplicate={(workflow) => void handleDuplicate(workflow)}
+      onDelete={(workflow) => void handleDelete(workflow)}
+      onAttachRole={(role, attach) => void handleAttachRole(role, attach)}
+      onSchedule={(fireAt, recurrence) => void handleSchedule(fireAt, recurrence)}
     />
   );
 }

--- a/src/components/workflows/workflow-attachments.tsx
+++ b/src/components/workflows/workflow-attachments.tsx
@@ -1,20 +1,28 @@
 "use client";
 
 import { Icon } from "@/lib/icon";
-import type { WorkflowSummary } from "@/lib/workflows";
+import type { WorkflowRoleSummary, WorkflowSummary } from "@/lib/workflows";
 
 type WorkflowAttachmentsProps = {
   workflow: WorkflowSummary | null;
+  roles: WorkflowRoleSummary[];
+  onAttachRole: (role: WorkflowRoleSummary, attach: boolean) => void;
+  onUpdateMeta: (patch: Partial<WorkflowSummary>) => void;
+  onScheduleRequest: () => void;
 };
 
-const attachmentSections = [
-  { title: "Familiars", icon: "ph:mask-happy-bold", value: (workflow: WorkflowSummary) => workflow.familiar ?? "Unassigned" },
-  { title: "Roles", icon: "ph:users-three-bold", value: (workflow: WorkflowSummary) => workflow.permissions?.join(", ") || "No role bindings" },
-  { title: "Boards", icon: "ph:kanban-bold", value: () => "No board attachment" },
-  { title: "Projects", icon: "ph:folder-open", value: () => "No project attachment" },
-] as const;
-
-export function WorkflowAttachments({ workflow }: WorkflowAttachmentsProps) {
+/**
+ * Cave bindings for the selected workflow. Familiars persist into the
+ * manifest (`familiar:` field), roles persist into ROLE.md `workflows:`
+ * lists; boards/projects remain visibly pending until an API owns them.
+ */
+export function WorkflowAttachments({
+  workflow,
+  roles,
+  onAttachRole,
+  onUpdateMeta,
+  onScheduleRequest,
+}: WorkflowAttachmentsProps) {
   return (
     <section className="workflow-panel workflow-attachments" aria-label="Workflow attachments">
       <div className="workflow-panel-heading">
@@ -22,24 +30,113 @@ export function WorkflowAttachments({ workflow }: WorkflowAttachmentsProps) {
           <p className="workflow-eyebrow">Attachments</p>
           <h2>Cave bindings</h2>
         </div>
+        <button
+          type="button"
+          className="workflow-icon-button"
+          disabled={!workflow}
+          onClick={onScheduleRequest}
+          title="Schedule as automation"
+          aria-label="Schedule as automation"
+        >
+          <Icon name="ph:clock-countdown" width={14} />
+        </button>
       </div>
+
       <div className="workflow-attachment-list">
-        {attachmentSections.map((section) => (
-          <article key={section.title} className="workflow-attachment-row">
-            <div>
-              <h3>
-                <Icon name={section.icon} width={13} />
-                {section.title}
-              </h3>
-              <p>{workflow ? section.value(workflow) : "Select a workflow"}</p>
-            </div>
-            <button type="button" disabled title="Persistence pending daemon API">
-              Save
-            </button>
-          </article>
-        ))}
+        <article className="workflow-attachment-row">
+          <div>
+            <h3>
+              <Icon name="ph:mask-happy" width={13} />
+              Familiars
+            </h3>
+            {workflow ? (
+              <label className="workflow-field workflow-field-inline">
+                <span className="sr-only">Familiar binding</span>
+                <input
+                  type="text"
+                  key={workflow.familiar ?? ""}
+                  defaultValue={workflow.familiar ?? ""}
+                  placeholder="Unassigned — saved into the manifest"
+                  onBlur={(event) => {
+                    const next = event.target.value.trim();
+                    if (next !== (workflow.familiar ?? "")) {
+                      onUpdateMeta({ familiar: next || undefined });
+                    }
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") (event.target as HTMLInputElement).blur();
+                  }}
+                />
+              </label>
+            ) : (
+              <p>Select a workflow</p>
+            )}
+          </div>
+        </article>
+
+        <article className="workflow-attachment-row">
+          <div>
+            <h3>
+              <Icon name="ph:users-three" width={13} />
+              Roles
+            </h3>
+            {!workflow ? (
+              <p>Select a workflow</p>
+            ) : roles.length === 0 ? (
+              <p>No roles discovered — create one under a familiar workspace.</p>
+            ) : (
+              <ul className="workflow-role-list">
+                {roles.map((role) => {
+                  const attached = role.workflows.includes(workflow.id);
+                  return (
+                    <li key={`${role.familiar}:${role.id}`}>
+                      <label className="workflow-role-toggle">
+                        <input
+                          type="checkbox"
+                          checked={attached}
+                          onChange={() => onAttachRole(role, !attached)}
+                        />
+                        <span className="workflow-role-name">
+                          {role.emoji ? `${role.emoji} ` : ""}
+                          {role.name}
+                        </span>
+                        <span className="workflow-role-familiar">{role.familiar}</span>
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </article>
+
+        <article className="workflow-attachment-row">
+          <div>
+            <h3>
+              <Icon name="ph:kanban" width={13} />
+              Boards
+            </h3>
+            <p>No board attachment</p>
+          </div>
+          <button type="button" disabled title="Persistence pending daemon API">
+            Save
+          </button>
+        </article>
+
+        <article className="workflow-attachment-row">
+          <div>
+            <h3>
+              <Icon name="ph:folder-open" width={13} />
+              Projects
+            </h3>
+            <p>No project attachment</p>
+          </div>
+          <button type="button" disabled title="Persistence pending daemon API">
+            Save
+          </button>
+        </article>
       </div>
-      <p className="workflow-muted">Persistence pending daemon API</p>
+      <p className="workflow-muted">Boards/Projects: persistence pending daemon API</p>
     </section>
   );
 }

--- a/src/components/workflows/workflow-canvas.tsx
+++ b/src/components/workflows/workflow-canvas.tsx
@@ -7,6 +7,7 @@ import {
   Controls,
   MiniMap,
   ReactFlow,
+  type Connection,
   type Edge,
   type Node,
   type NodeMouseHandler,
@@ -26,6 +27,9 @@ type WorkflowCanvasProps = {
   selectedNode: WorkflowGraphNode | null;
   onSelectNode: (node: WorkflowGraphNode) => void;
   onClearNode: () => void;
+  onConnect: (source: string, target: string) => void;
+  onDisconnect: (source: string, target: string) => void;
+  onRemoveStep: (id: string) => void;
 };
 
 export function WorkflowStepNode({ data, selected }: NodeProps<WorkflowFlowNode>) {
@@ -60,6 +64,9 @@ export function WorkflowCanvas({
   selectedNode,
   onSelectNode,
   onClearNode,
+  onConnect,
+  onDisconnect,
+  onRemoveStep,
 }: WorkflowCanvasProps) {
   const graph = useMemo(() => {
     if (!workflow) return { nodes: [] as WorkflowGraphNode[], edges: [] as Edge[] };
@@ -76,6 +83,25 @@ export function WorkflowCanvas({
       position: node.position,
       data: node.data,
     });
+  };
+
+  // Drawing source→target on the canvas means "target requires source".
+  const handleConnect = (connection: Connection) => {
+    if (connection.source && connection.target) {
+      onConnect(connection.source, connection.target);
+    }
+  };
+
+  const handleEdgesDelete = (deleted: Edge[]) => {
+    for (const edge of deleted) {
+      onDisconnect(edge.source, edge.target);
+    }
+  };
+
+  const handleNodesDelete = (deleted: WorkflowFlowNode[]) => {
+    for (const node of deleted) {
+      onRemoveStep(node.id);
+    }
   };
 
   if (!workflow) {
@@ -95,6 +121,10 @@ export function WorkflowCanvas({
         fitView
         onNodeClick={handleNodeClick}
         onPaneClick={onClearNode}
+        onConnect={handleConnect}
+        onEdgesDelete={handleEdgesDelete}
+        onNodesDelete={handleNodesDelete}
+        deleteKeyCode={["Backspace", "Delete"]}
         proOptions={{ hideAttribution: true }}
       >
         <Background />

--- a/src/components/workflows/workflow-create-dialog.tsx
+++ b/src/components/workflows/workflow-create-dialog.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useState } from "react";
+import { Icon } from "@/lib/icon";
+import { slugifyWorkflowId } from "@/lib/workflow-edit";
+import type {
+  WorkflowPattern,
+  WorkflowScheduleRecurrence,
+  WorkflowSummary,
+} from "@/lib/workflows";
+
+const PATTERNS: Array<{ id: WorkflowPattern; hint: string }> = [
+  { id: "sequential", hint: "plan → execute → review" },
+  { id: "fan-out-and-synthesize", hint: "parallel workers → merge" },
+  { id: "classify-and-act", hint: "label → route-specific action" },
+  { id: "adversarial-verification", hint: "propose → refute → verdict" },
+  { id: "generate-and-filter", hint: "wide pool → keep the best" },
+  { id: "tournament", hint: "seed → rounds → champion" },
+  { id: "loop-until-done", hint: "attempt → check → repeat" },
+  { id: "custom", hint: "start from a blank pair" },
+];
+
+type WorkflowCreateDialogProps = {
+  onClose: () => void;
+  onCreate: (input: { name: string; pattern: WorkflowPattern; familiar?: string }) => void;
+};
+
+/** New-workflow dialog: name + CWF-01 pattern template + optional familiar. */
+export function WorkflowCreateDialog({ onClose, onCreate }: WorkflowCreateDialogProps) {
+  const [name, setName] = useState("");
+  const [pattern, setPattern] = useState<WorkflowPattern>("sequential");
+  const [familiar, setFamiliar] = useState("");
+  const id = slugifyWorkflowId(name);
+
+  return (
+    <div className="workflow-dialog-backdrop" role="presentation" onClick={onClose}>
+      <div
+        className="workflow-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label="New workflow"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="workflow-panel-heading">
+          <div>
+            <p className="workflow-eyebrow">New workflow</p>
+            <h2>Create from pattern</h2>
+          </div>
+          <button type="button" className="workflow-icon-button" onClick={onClose} aria-label="Close">
+            <Icon name="ph:x" width={14} />
+          </button>
+        </div>
+        <label className="workflow-field">
+          <span>Name</span>
+          <input
+            type="text"
+            value={name}
+            autoFocus
+            placeholder="Nightly release review"
+            onChange={(event) => setName(event.target.value)}
+          />
+        </label>
+        <p className="workflow-muted">Saved as workflows/{id}.yaml</p>
+        <div className="workflow-pattern-grid" role="radiogroup" aria-label="Pattern">
+          {PATTERNS.map((entry) => (
+            <button
+              key={entry.id}
+              type="button"
+              role="radio"
+              aria-checked={pattern === entry.id}
+              className={`workflow-pattern-option${pattern === entry.id ? " is-active" : ""}`}
+              onClick={() => setPattern(entry.id)}
+            >
+              <span className="workflow-pattern-name">{entry.id}</span>
+              <span className="workflow-pattern-hint">{entry.hint}</span>
+            </button>
+          ))}
+        </div>
+        <label className="workflow-field">
+          <span>Familiar (optional)</span>
+          <input
+            type="text"
+            value={familiar}
+            placeholder="nova"
+            onChange={(event) => setFamiliar(event.target.value)}
+          />
+        </label>
+        <div className="workflow-dialog-actions">
+          <button type="button" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="workflow-primary-button"
+            disabled={name.trim().length === 0}
+            onClick={() => onCreate({ name, pattern, familiar: familiar || undefined })}
+          >
+            <Icon name="ph:plus-bold" width={13} />
+            Create workflow
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type WorkflowScheduleDialogProps = {
+  workflow: WorkflowSummary;
+  onClose: () => void;
+  onSchedule: (fireAt: string, recurrence: WorkflowScheduleRecurrence) => void;
+};
+
+type Cadence = "once" | "daily" | "weekly" | "interval";
+
+const WEEKDAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+
+function defaultFireAt(): string {
+  // datetime-local value for one hour from now, minute precision.
+  const next = new Date(Date.now() + 60 * 60 * 1000);
+  next.setSeconds(0, 0);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${next.getFullYear()}-${pad(next.getMonth() + 1)}-${pad(next.getDate())}T${pad(next.getHours())}:${pad(next.getMinutes())}`;
+}
+
+/**
+ * Schedule-as-automation: creates a real inbox reminder linking back to the
+ * workflow. Deliberately not an execution schedule — the daemon has no
+ * workflow engine yet.
+ */
+export function WorkflowScheduleDialog({ workflow, onClose, onSchedule }: WorkflowScheduleDialogProps) {
+  const [fireAtLocal, setFireAtLocal] = useState(defaultFireAt);
+  const [cadence, setCadence] = useState<Cadence>("once");
+  const [days, setDays] = useState<number[]>([1, 2, 3, 4, 5]);
+  const [intervalHours, setIntervalHours] = useState(24);
+
+  const submit = () => {
+    const fireDate = new Date(fireAtLocal);
+    if (Number.isNaN(fireDate.getTime())) return;
+    const fireAt = fireDate.toISOString();
+    const hour = fireDate.getHours();
+    const minute = fireDate.getMinutes();
+    const recurrence: WorkflowScheduleRecurrence =
+      cadence === "daily"
+        ? { type: "daily", hour, minute }
+        : cadence === "weekly"
+          ? { type: "weekly", days, hour, minute }
+          : cadence === "interval"
+            ? { type: "interval", everyMs: Math.max(1, intervalHours) * 60 * 60 * 1000 }
+            : { type: "none" };
+    onSchedule(fireAt, recurrence);
+  };
+
+  return (
+    <div className="workflow-dialog-backdrop" role="presentation" onClick={onClose}>
+      <div
+        className="workflow-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Schedule workflow"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="workflow-panel-heading">
+          <div>
+            <p className="workflow-eyebrow">Schedule</p>
+            <h2>{workflow.name ?? workflow.id}</h2>
+          </div>
+          <button type="button" className="workflow-icon-button" onClick={onClose} aria-label="Close">
+            <Icon name="ph:x" width={14} />
+          </button>
+        </div>
+        <label className="workflow-field">
+          <span>First reminder</span>
+          <input
+            type="datetime-local"
+            value={fireAtLocal}
+            onChange={(event) => setFireAtLocal(event.target.value)}
+          />
+        </label>
+        <label className="workflow-field">
+          <span>Repeat</span>
+          <select value={cadence} onChange={(event) => setCadence(event.target.value as Cadence)}>
+            <option value="once">Once</option>
+            <option value="daily">Daily</option>
+            <option value="weekly">Weekly</option>
+            <option value="interval">Every N hours</option>
+          </select>
+        </label>
+        {cadence === "weekly" && (
+          <div className="workflow-weekday-row" role="group" aria-label="Weekdays">
+            {WEEKDAYS.map((label, index) => (
+              <button
+                key={label}
+                type="button"
+                className={`workflow-weekday${days.includes(index) ? " is-active" : ""}`}
+                aria-pressed={days.includes(index)}
+                onClick={() =>
+                  setDays((current) =>
+                    current.includes(index)
+                      ? current.filter((day) => day !== index)
+                      : [...current, index].sort(),
+                  )
+                }
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        )}
+        {cadence === "interval" && (
+          <label className="workflow-field">
+            <span>Hours between reminders</span>
+            <input
+              type="number"
+              min={1}
+              max={720}
+              value={intervalHours}
+              onChange={(event) => setIntervalHours(Number(event.target.value) || 1)}
+            />
+          </label>
+        )}
+        <p className="workflow-muted">
+          Creates a reminder on the Automations surface that links back to this workflow. Execution
+          scheduling arrives with the daemon engine.
+        </p>
+        <div className="workflow-dialog-actions">
+          <button type="button" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="workflow-primary-button"
+            disabled={cadence === "weekly" && days.length === 0}
+            onClick={submit}
+          >
+            <Icon name="ph:clock-countdown" width={13} />
+            Schedule
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/workflows/workflow-inspector.tsx
+++ b/src/components/workflows/workflow-inspector.tsx
@@ -1,70 +1,253 @@
 "use client";
 
+import { Icon } from "@/lib/icon";
 import type { WorkflowGraphNode } from "@/lib/workflow-graph";
-import { workflowIssueSummary, type WorkflowValidationIssue, type WorkflowSummary } from "@/lib/workflows";
+import {
+  workflowIssueSummary,
+  type WorkflowStepSummary,
+  type WorkflowSummary,
+  type WorkflowValidationIssue,
+} from "@/lib/workflows";
 import type { WorkflowStudioActionState } from "./workflow-studio";
 
 type WorkflowInspectorProps = {
   workflow: WorkflowSummary | null;
   selectedNode: WorkflowGraphNode | null;
   action: WorkflowStudioActionState | null;
+  onUpdateStep: (id: string, patch: Partial<WorkflowStepSummary>) => void;
+  onUpdateMeta: (patch: Partial<WorkflowSummary>) => void;
+  onRemoveStep: (id: string) => void;
 };
+
+const STEP_KINDS = ["agent", "skill", "tool", "human-gate", "workflow"];
+
+const PATTERNS = [
+  "sequential",
+  "fan-out-and-synthesize",
+  "classify-and-act",
+  "adversarial-verification",
+  "generate-and-filter",
+  "tournament",
+  "loop-until-done",
+  "custom",
+];
 
 function issuesForAction(action: WorkflowStudioActionState | null): WorkflowValidationIssue[] {
   if (!action?.result || !("issues" in action.result)) return [];
   return action.result.issues ?? [];
 }
 
-export function WorkflowInspector({ workflow, selectedNode, action }: WorkflowInspectorProps) {
+function parseCsv(value: string): string[] | undefined {
+  const entries = value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  return entries.length > 0 ? entries : undefined;
+}
+
+function Field({
+  label,
+  value,
+  placeholder,
+  onCommit,
+}: {
+  label: string;
+  value: string;
+  placeholder?: string;
+  onCommit: (next: string) => void;
+}) {
+  return (
+    <label className="workflow-field">
+      <span>{label}</span>
+      <input
+        type="text"
+        defaultValue={value}
+        placeholder={placeholder}
+        key={`${label}:${value}`}
+        onBlur={(event) => {
+          if (event.target.value !== value) onCommit(event.target.value);
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") (event.target as HTMLInputElement).blur();
+        }}
+      />
+    </label>
+  );
+}
+
+/** Step editor when a node is selected; workflow meta editor otherwise. */
+export function WorkflowInspector({
+  workflow,
+  selectedNode,
+  action,
+  onUpdateStep,
+  onUpdateMeta,
+  onRemoveStep,
+}: WorkflowInspectorProps) {
   const issues = issuesForAction(action);
+  const step = selectedNode
+    ? workflow?.steps?.find((entry) => entry.id === selectedNode.id) ?? null
+    : null;
 
   return (
     <section className="workflow-panel workflow-inspector" aria-label="Workflow inspector">
       <div className="workflow-panel-heading">
         <div>
-          <p className="workflow-eyebrow">Selected node</p>
-          <h2>{selectedNode?.data.label ?? "Workflow"}</h2>
+          <p className="workflow-eyebrow">{step ? "Selected node" : "Workflow"}</p>
+          <h2>{step ? (step.name ?? step.id) : (workflow?.name ?? workflow?.id ?? "No workflow")}</h2>
         </div>
+        {step && (
+          <button
+            type="button"
+            className="workflow-icon-button workflow-icon-button-danger"
+            onClick={() => onRemoveStep(step.id)}
+            title="Remove step"
+            aria-label={`Remove step ${step.id}`}
+          >
+            <Icon name="ph:trash" width={13} />
+          </button>
+        )}
       </div>
 
-      {selectedNode ? (
-        <dl className="workflow-detail-list">
-          <div>
-            <dt>Kind</dt>
-            <dd>{selectedNode.data.kind}</dd>
+      {step ? (
+        <div className="workflow-editor">
+          <Field label="Name" value={step.name ?? ""} onCommit={(next) => onUpdateStep(step.id, { name: next || undefined })} />
+          <Field
+            label="ID"
+            value={step.id}
+            onCommit={(next) => {
+              const id = next.trim();
+              if (id) onUpdateStep(step.id, { id });
+            }}
+          />
+          <label className="workflow-field">
+            <span>Kind</span>
+            <select value={step.kind} onChange={(event) => onUpdateStep(step.id, { kind: event.target.value })}>
+              {STEP_KINDS.map((kind) => (
+                <option key={kind} value={kind}>
+                  {kind}
+                </option>
+              ))}
+              {!STEP_KINDS.includes(step.kind) && <option value={step.kind}>{step.kind}</option>}
+            </select>
+          </label>
+          <Field
+            label="Uses"
+            value={step.uses ?? ""}
+            placeholder="nova · cwf-validator@^1.0.0 · cave.output"
+            onCommit={(next) => onUpdateStep(step.id, { uses: next || undefined })}
+          />
+          <Field
+            label="Summary"
+            value={step.summary ?? ""}
+            onCommit={(next) => onUpdateStep(step.id, { summary: next || undefined })}
+          />
+          <Field
+            label="Permissions (comma-separated)"
+            value={(step.permissions ?? []).join(", ")}
+            placeholder="repo.read, web.fetch"
+            onCommit={(next) => onUpdateStep(step.id, { permissions: parseCsv(next) })}
+          />
+          <Field
+            label="On error"
+            value={step.on_error ?? ""}
+            placeholder="retry · halt · escalate"
+            onCommit={(next) => onUpdateStep(step.id, { on_error: next || undefined })}
+          />
+          <p className="workflow-muted">
+            Requires: {step.requires?.length ? step.requires.join(", ") : "none"} — draw edges on the
+            canvas to change dependencies.
+          </p>
+        </div>
+      ) : workflow ? (
+        <div className="workflow-editor">
+          <Field label="Name" value={workflow.name ?? ""} onCommit={(next) => onUpdateMeta({ name: next || undefined })} />
+          <Field label="Version" value={workflow.version} onCommit={(next) => onUpdateMeta({ version: next || workflow.version })} />
+          <label className="workflow-field">
+            <span>Pattern</span>
+            <select
+              value={workflow.pattern ?? "custom"}
+              onChange={(event) => onUpdateMeta({ pattern: event.target.value })}
+            >
+              {PATTERNS.map((pattern) => (
+                <option key={pattern} value={pattern}>
+                  {pattern}
+                </option>
+              ))}
+              {workflow.pattern && !PATTERNS.includes(workflow.pattern) && (
+                <option value={workflow.pattern}>{workflow.pattern}</option>
+              )}
+            </select>
+          </label>
+          <Field
+            label="Summary"
+            value={workflow.summary ?? ""}
+            onCommit={(next) => onUpdateMeta({ summary: next || undefined })}
+          />
+          <Field
+            label="Tags (comma-separated)"
+            value={(workflow.tags ?? []).join(", ")}
+            onCommit={(next) => onUpdateMeta({ tags: parseCsv(next) })}
+          />
+          <Field
+            label="Permissions (comma-separated)"
+            value={(workflow.permissions ?? []).join(", ")}
+            placeholder="repo.read, web.fetch"
+            onCommit={(next) => onUpdateMeta({ permissions: parseCsv(next) })}
+          />
+          <div className="workflow-limits-row">
+            <Field
+              label="Max agents"
+              value={workflow.limits?.max_agents?.toString() ?? ""}
+              onCommit={(next) =>
+                onUpdateMeta({
+                  limits: { ...workflow.limits, max_agents: next ? Number(next) || undefined : undefined },
+                })
+              }
+            />
+            <Field
+              label="Timeout (s)"
+              value={workflow.limits?.timeout_s?.toString() ?? ""}
+              onCommit={(next) =>
+                onUpdateMeta({
+                  limits: { ...workflow.limits, timeout_s: next ? Number(next) || undefined : undefined },
+                })
+              }
+            />
+            <Field
+              label="Cost ceiling ($)"
+              value={workflow.limits?.cost_ceiling_usd?.toString() ?? ""}
+              onCommit={(next) =>
+                onUpdateMeta({
+                  limits: { ...workflow.limits, cost_ceiling_usd: next ? Number(next) || undefined : undefined },
+                })
+              }
+            />
           </div>
-          <div>
-            <dt>Uses</dt>
-            <dd>{selectedNode.data.uses ?? "No binding"}</dd>
-          </div>
-          <div>
-            <dt>Summary</dt>
-            <dd>{selectedNode.data.summary ?? "No node summary"}</dd>
-          </div>
-        </dl>
+        </div>
       ) : (
-        <p className="workflow-muted">Select a graph node to inspect step bindings and dry-run status.</p>
+        <p className="workflow-muted">Select a workflow to edit its manifest.</p>
       )}
-
-      <h3>Workflow</h3>
-      <dl className="workflow-detail-list">
-        <div>
-          <dt>ID</dt>
-          <dd>{workflow?.id ?? "No workflow selected"}</dd>
-        </div>
-        <div>
-          <dt>Pattern</dt>
-          <dd>{workflow?.pattern ?? "Unspecified"}</dd>
-        </div>
-      </dl>
-
-      <h3>Permissions</h3>
-      <p className="workflow-muted">{workflow?.permissions?.join(", ") || "No explicit permissions declared"}</p>
 
       <h3>Validation</h3>
       <p className="workflow-muted">
-        {action ? `${action.kind}: ${action.result.ok ? "ready" : "blocked"} · ${workflowIssueSummary(issues)}` : workflow?.validation_state ?? "unknown"}
+        {action
+          ? `${action.kind}: ${action.result.ok ? "ready" : "blocked"} · ${workflowIssueSummary(issues)}`
+          : workflow?.validation_state ?? "unknown"}
       </p>
+      {issues.length > 0 && (
+        <ul className="workflow-issue-list">
+          {issues.slice(0, 6).map((issue, index) => (
+            <li key={`${issue.code}:${issue.path ?? index}`}>
+              <span className={`workflow-issue-tier workflow-issue-${issue.tier}`}>{issue.tier}</span>
+              <span>
+                {issue.message ?? issue.code}
+                {issue.suggestion ? ` — ${issue.suggestion}` : ""}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
     </section>
   );
 }

--- a/src/components/workflows/workflow-library.tsx
+++ b/src/components/workflows/workflow-library.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
 import type { WorkflowSummary } from "@/lib/workflows";
 
@@ -9,8 +10,12 @@ type WorkflowLibraryProps = {
   loaded: boolean;
   refreshing: boolean;
   error: string | null;
+  dirty: boolean;
   onRefresh: () => void;
   onSelectWorkflow: (workflow: WorkflowSummary) => void;
+  onCreateRequest: () => void;
+  onDuplicate: (workflow: WorkflowSummary) => void;
+  onDelete: (workflow: WorkflowSummary) => void;
 };
 
 const validationLabels: Record<NonNullable<WorkflowSummary["validation_state"]>, string> = {
@@ -20,15 +25,42 @@ const validationLabels: Record<NonNullable<WorkflowSummary["validation_state"]>,
   unknown: "Unknown",
 };
 
+function matchesQuery(workflow: WorkflowSummary, query: string): boolean {
+  const haystack = [
+    workflow.id,
+    workflow.name,
+    workflow.summary,
+    workflow.familiar,
+    workflow.pattern,
+    ...(workflow.tags ?? []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(query);
+}
+
 export function WorkflowLibrary({
   workflows,
   selectedWorkflow,
   loaded,
   refreshing,
   error,
+  dirty,
   onRefresh,
   onSelectWorkflow,
+  onCreateRequest,
+  onDuplicate,
+  onDelete,
 }: WorkflowLibraryProps) {
+  const [query, setQuery] = useState("");
+
+  const visible = useMemo(() => {
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) return workflows;
+    return workflows.filter((workflow) => matchesQuery(workflow, trimmed));
+  }, [query, workflows]);
+
   return (
     <aside className="workflow-library" aria-label="Workflow library">
       <div className="workflow-panel-heading">
@@ -36,27 +68,58 @@ export function WorkflowLibrary({
           <p className="workflow-eyebrow">Library</p>
           <h2>Workflows</h2>
         </div>
-        <button
-          type="button"
-          className="workflow-icon-button"
-          onClick={onRefresh}
-          disabled={refreshing}
-          title={refreshing ? "Refreshing workflows" : "Refresh workflows"}
-          aria-label={refreshing ? "Refreshing workflows" : "Refresh workflows"}
-        >
-          <Icon name="ph:arrows-clockwise-bold" width={14} className={refreshing ? "animate-spin" : undefined} />
-        </button>
+        <div className="workflow-library-actions">
+          <button
+            type="button"
+            className="workflow-icon-button"
+            onClick={onCreateRequest}
+            title="New workflow"
+            aria-label="New workflow"
+          >
+            <Icon name="ph:plus-bold" width={14} />
+          </button>
+          <button
+            type="button"
+            className="workflow-icon-button"
+            onClick={onRefresh}
+            disabled={refreshing}
+            title={refreshing ? "Refreshing workflows" : "Refresh workflows"}
+            aria-label={refreshing ? "Refreshing workflows" : "Refresh workflows"}
+          >
+            <Icon name="ph:arrows-clockwise-bold" width={14} className={refreshing ? "animate-spin" : undefined} />
+          </button>
+        </div>
       </div>
+
+      <label className="workflow-search">
+        <Icon name="ph:magnifying-glass" width={13} />
+        <input
+          type="search"
+          value={query}
+          placeholder="Search id, tag, familiar…"
+          aria-label="Search workflows"
+          onChange={(event) => setQuery(event.target.value)}
+        />
+      </label>
 
       {!loaded ? (
         <div className="workflow-library-state">Loading workflow manifests...</div>
       ) : error ? (
         <div className="workflow-library-state workflow-library-state-error">Workflows unavailable: {error}</div>
       ) : workflows.length === 0 ? (
-        <div className="workflow-library-state">No WORKFLOW.md or .workflow.yaml manifests found.</div>
+        <div className="workflow-library-state">
+          No WORKFLOW.md or .workflow.yaml manifests found.
+          <button type="button" className="workflow-primary-button" onClick={onCreateRequest}>
+            <Icon name="ph:plus-bold" width={13} />
+            New workflow
+          </button>
+        </div>
       ) : (
         <div className="workflow-library-list">
-          {workflows.map((workflow) => {
+          {visible.length === 0 && (
+            <div className="workflow-library-state">No workflows match “{query.trim()}”.</div>
+          )}
+          {visible.map((workflow) => {
             const active = selectedWorkflow?.id === workflow.id;
             const validationState = workflow.validation_state ?? "unknown";
             return (
@@ -66,15 +129,37 @@ export function WorkflowLibrary({
                 className={`workflow-library-item${active ? " is-active" : ""}`}
                 onClick={() => onSelectWorkflow(workflow)}
               >
-                <span className="workflow-library-item-title">{workflow.name ?? workflow.id}</span>
+                <span className="workflow-library-item-title">
+                  {workflow.name ?? workflow.id}
+                  {active && dirty && <span className="workflow-dirty-dot" title="Unsaved changes" />}
+                </span>
                 <span className="workflow-library-item-meta">
                   <span className={`workflow-health workflow-health-${validationState}`} />
                   {validationLabels[validationState]} · v{workflow.version}
+                  {workflow.pattern ? ` · ${workflow.pattern}` : ""}
                 </span>
                 {workflow.summary && <span className="workflow-library-item-summary">{workflow.summary}</span>}
               </button>
             );
           })}
+        </div>
+      )}
+
+      {selectedWorkflow && (
+        <div className="workflow-library-footer">
+          <button type="button" onClick={() => onDuplicate(selectedWorkflow)} title="Duplicate selected workflow">
+            <Icon name="ph:copy" width={13} />
+            Duplicate
+          </button>
+          <button
+            type="button"
+            className="workflow-danger-button"
+            onClick={() => onDelete(selectedWorkflow)}
+            title="Delete selected workflow"
+          >
+            <Icon name="ph:trash" width={13} />
+            Delete
+          </button>
         </div>
       )}
     </aside>

--- a/src/components/workflows/workflow-manifest-preview.tsx
+++ b/src/components/workflows/workflow-manifest-preview.tsx
@@ -1,55 +1,36 @@
 "use client";
 
+import { useMemo } from "react";
+import { workflowToYaml } from "@/lib/workflow-edit";
 import type { WorkflowSummary } from "@/lib/workflows";
 
 type WorkflowManifestPreviewProps = {
   workflow: WorkflowSummary | null;
+  dirty: boolean;
 };
 
-export function WorkflowManifestPreview({ workflow }: WorkflowManifestPreviewProps) {
-  const limits = workflow?.limits;
+/** Live canonical YAML for the current draft — what Save writes to disk. */
+export function WorkflowManifestPreview({ workflow, dirty }: WorkflowManifestPreviewProps) {
+  const yaml = useMemo(() => (workflow ? workflowToYaml(workflow) : null), [workflow]);
 
   return (
     <section className="workflow-panel workflow-manifest-preview" aria-label="Workflow manifest preview">
       <div className="workflow-panel-heading">
         <div>
           <p className="workflow-eyebrow">WORKFLOW.md / .workflow.yaml</p>
-          <h2>Manifest</h2>
+          <h2>
+            Manifest
+            {dirty && <span className="workflow-dirty-dot" title="Unsaved changes" />}
+          </h2>
         </div>
       </div>
-      <dl className="workflow-detail-list">
-        <div>
-          <dt>schema_version</dt>
-          <dd>CWF-01</dd>
-        </div>
-        <div>
-          <dt>id</dt>
-          <dd>{workflow?.id ?? "Select a workflow"}</dd>
-        </div>
-        <div>
-          <dt>version</dt>
-          <dd>{workflow?.version ?? "n/a"}</dd>
-        </div>
-        <div>
-          <dt>pattern</dt>
-          <dd>{workflow?.pattern ?? "custom"}</dd>
-        </div>
-        <div>
-          <dt>familiar</dt>
-          <dd>{workflow?.familiar ?? "Unassigned"}</dd>
-        </div>
-        <div>
-          <dt>limits</dt>
-          <dd>
-            agents {limits?.max_agents ?? "n/a"} · timeout {limits?.timeout_s ?? "n/a"}s · cost $
-            {limits?.cost_ceiling_usd ?? "n/a"}
-          </dd>
-        </div>
-        <div>
-          <dt>step count</dt>
-          <dd>{workflow?.steps?.length ?? 0}</dd>
-        </div>
-      </dl>
+      {yaml ? (
+        <pre className="workflow-manifest-yaml">
+          <code>{`# schema_version: CWF-01\n${yaml}`}</code>
+        </pre>
+      ) : (
+        <p className="workflow-muted">Select a workflow to preview its canonical manifest.</p>
+      )}
       <p className="workflow-muted">Cave-only layout stays in WORKFLOW.cave.json.</p>
     </section>
   );

--- a/src/components/workflows/workflow-palette.tsx
+++ b/src/components/workflows/workflow-palette.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Icon, type IconName } from "@/lib/icon";
+import type { WorkflowStepKind, WorkflowSummary } from "@/lib/workflows";
+
+type WorkflowPaletteProps = {
+  workflow: WorkflowSummary | null;
+  onAddStep: (kind: WorkflowStepKind) => void;
+};
+
+const PALETTE: Array<{ kind: WorkflowStepKind; label: string; icon: IconName; tone: string }> = [
+  { kind: "agent", label: "Agent", icon: "ph:brain", tone: "agent" },
+  { kind: "skill", label: "Skill", icon: "ph:sparkle", tone: "tool" },
+  { kind: "tool", label: "Tool", icon: "ph:wrench", tone: "tool" },
+  { kind: "human-gate", label: "Human gate", icon: "ph:hand", tone: "gate" },
+  { kind: "workflow", label: "Workflow", icon: "ph:graph", tone: "workflow" },
+];
+
+/** Node palette: one click appends a step of the given CWF-01 kind. */
+export function WorkflowPalette({ workflow, onAddStep }: WorkflowPaletteProps) {
+  return (
+    <div className="workflow-palette" role="toolbar" aria-label="Step palette">
+      <span className="workflow-palette-label">Add step</span>
+      {PALETTE.map((entry) => (
+        <button
+          key={entry.kind}
+          type="button"
+          className={`workflow-palette-item workflow-palette-${entry.tone}`}
+          disabled={!workflow}
+          onClick={() => onAddStep(entry.kind)}
+          title={workflow ? `Add ${entry.label.toLowerCase()} step` : "Select a workflow first"}
+        >
+          <Icon name={entry.icon} width={13} />
+          {entry.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/workflows/workflow-run-strip.tsx
+++ b/src/components/workflows/workflow-run-strip.tsx
@@ -8,8 +8,17 @@ type WorkflowRunStripProps = {
   workflow: WorkflowSummary | null;
   action: WorkflowStudioActionState | null;
   busyId: string | null;
+  dirty: boolean;
+  canUndo: boolean;
+  canRedo: boolean;
+  engineUnavailable: boolean;
+  notice: string | null;
   onValidate: (workflow: WorkflowSummary) => void;
   onDryRun: (workflow: WorkflowSummary) => void;
+  onPlay: (workflow: WorkflowSummary) => void;
+  onSave: (workflow: WorkflowSummary) => void;
+  onUndo: () => void;
+  onRedo: () => void;
 };
 
 function issuesForAction(action: WorkflowStudioActionState | null): WorkflowValidationIssue[] {
@@ -17,34 +26,96 @@ function issuesForAction(action: WorkflowStudioActionState | null): WorkflowVali
   return action.result.issues ?? [];
 }
 
-export function WorkflowRunStrip({ workflow, action, busyId, onValidate, onDryRun }: WorkflowRunStripProps) {
+export function WorkflowRunStrip({
+  workflow,
+  action,
+  busyId,
+  dirty,
+  canUndo,
+  canRedo,
+  engineUnavailable,
+  notice,
+  onValidate,
+  onDryRun,
+  onPlay,
+  onSave,
+  onUndo,
+  onRedo,
+}: WorkflowRunStripProps) {
   const issues = issuesForAction(action);
   const validateBusy = workflow ? busyId === `${workflow.id}:validate` : false;
   const dryRunBusy = workflow ? busyId === `${workflow.id}:dry-run` : false;
+  const playBusy = workflow ? busyId === `${workflow.id}:play` : false;
+  const saveBusy = workflow ? busyId === `${workflow.id}:save` : false;
+  const anyBusy = busyId !== null;
 
   return (
     <section className="workflow-run-strip" aria-label="Workflow actions">
       <div className="workflow-run-actions">
-        <button type="button" disabled={!workflow || busyId !== null} onClick={() => workflow && onValidate(workflow)}>
+        <button
+          type="button"
+          className="workflow-history-button"
+          disabled={!canUndo}
+          onClick={onUndo}
+          title="Undo"
+          aria-label="Undo edit"
+        >
+          <Icon name="ph:arrow-counter-clockwise" width={14} />
+        </button>
+        <button
+          type="button"
+          className="workflow-history-button"
+          disabled={!canRedo}
+          onClick={onRedo}
+          title="Redo"
+          aria-label="Redo edit"
+        >
+          <Icon name="ph:arrow-clockwise" width={14} />
+        </button>
+        <button
+          type="button"
+          className="workflow-primary-button"
+          disabled={!workflow || anyBusy || !dirty}
+          onClick={() => workflow && onSave(workflow)}
+          title={dirty ? "Save manifest to disk" : "No unsaved changes"}
+        >
+          <Icon name="ph:floppy-disk-bold" width={14} />
+          {saveBusy ? "Saving" : "Save"}
+        </button>
+        <button type="button" disabled={!workflow || anyBusy} onClick={() => workflow && onValidate(workflow)}>
           <Icon name="ph:check-circle-bold" width={14} />
           {validateBusy ? "Validating" : "Validate"}
         </button>
-        <button type="button" disabled={!workflow || busyId !== null} onClick={() => workflow && onDryRun(workflow)}>
+        <button type="button" disabled={!workflow || anyBusy} onClick={() => workflow && onDryRun(workflow)}>
           <Icon name="ph:rocket-bold" width={14} />
           {dryRunBusy ? "Planning" : "Dry-run"}
         </button>
-        <button type="button" disabled title="Run endpoint pending">
+        <button
+          type="button"
+          className="workflow-play-button"
+          disabled={!workflow || anyBusy || dirty || engineUnavailable}
+          onClick={() => workflow && onPlay(workflow)}
+          title={
+            engineUnavailable
+              ? "Run endpoint pending — daemon workflow engine unavailable"
+              : dirty
+                ? "Save before running"
+                : "Execute through the daemon engine"
+          }
+        >
           <Icon name="ph:lightning-bold" width={14} />
-          Play
+          {playBusy ? "Running" : "Play"}
         </button>
       </div>
-      <p className="workflow-run-hint">Run endpoint pending</p>
+      {engineUnavailable && <p className="workflow-run-hint">Run endpoint pending</p>}
       <p className="workflow-run-feedback">
-        {action
-          ? `${action.kind === "validate" ? "Validation" : "Dry-run"} ${action.result.ok ? "ready" : "blocked"} · ${
-              action.result.error ?? workflowIssueSummary(issues)
-            }`
-          : "Validate or dry-run a workflow to preview action feedback."}
+        {notice
+          ? notice
+          : action
+            ? `${action.kind === "validate" ? "Validation" : "Dry-run"} ${action.result.ok ? "ready" : "blocked"} · ${
+                action.result.error ?? workflowIssueSummary(issues)
+              }`
+            : "Validate or dry-run a workflow to preview action feedback."}
       </p>
     </section>
   );

--- a/src/components/workflows/workflow-runs-panel.tsx
+++ b/src/components/workflows/workflow-runs-panel.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Icon } from "@/lib/icon";
+import type { WorkflowRunRecord, WorkflowSummary } from "@/lib/workflows";
+
+type WorkflowRunsPanelProps = {
+  runs: WorkflowRunRecord[];
+  loading: boolean;
+  workflow: WorkflowSummary | null;
+};
+
+function relativeTime(iso: string): string {
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return iso;
+  const seconds = Math.round((Date.now() - then) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+function stepRollup(run: WorkflowRunRecord): string {
+  if (run.steps.length === 0) return run.summary ?? "no step detail";
+  const counts = new Map<string, number>();
+  for (const step of run.steps) {
+    counts.set(step.status, (counts.get(step.status) ?? 0) + 1);
+  }
+  return [...counts.entries()].map(([status, count]) => `${count} ${status}`).join(" · ");
+}
+
+/** Run history for the selected workflow: plan snapshots and executions. */
+export function WorkflowRunsPanel({ runs, loading, workflow }: WorkflowRunsPanelProps) {
+  return (
+    <section className="workflow-runs-panel" aria-label="Workflow run history">
+      <div className="workflow-runs-heading">
+        <Icon name="ph:clock-countdown" width={13} />
+        <span>Runs</span>
+        <span className="workflow-runs-count">
+          {loading ? "loading" : `${runs.length} recorded`}
+        </span>
+      </div>
+      {!workflow ? (
+        <p className="workflow-muted">Select a workflow to see its run history.</p>
+      ) : runs.length === 0 && !loading ? (
+        <p className="workflow-muted">
+          No runs yet — dry-run snapshots and daemon executions land here.
+        </p>
+      ) : (
+        <ol className="workflow-runs-list">
+          {runs.map((run) => (
+            <li key={run.id} className="workflow-run-row">
+              <span className={`workflow-run-chip workflow-run-chip-${run.status}`}>{run.status}</span>
+              <span className="workflow-run-kind">{run.kind}</span>
+              <span className="workflow-run-detail">{stepRollup(run)}</span>
+              <span className="workflow-run-time" title={run.startedAt}>
+                {relativeTime(run.startedAt)}
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -9,6 +9,9 @@ const inspector = readFileSync(new URL("./workflow-inspector.tsx", import.meta.u
 const attachments = readFileSync(new URL("./workflow-attachments.tsx", import.meta.url), "utf8");
 const runStrip = readFileSync(new URL("./workflow-run-strip.tsx", import.meta.url), "utf8");
 const manifestPreview = readFileSync(new URL("./workflow-manifest-preview.tsx", import.meta.url), "utf8");
+const palette = readFileSync(new URL("./workflow-palette.tsx", import.meta.url), "utf8");
+const runsPanel = readFileSync(new URL("./workflow-runs-panel.tsx", import.meta.url), "utf8");
+const dialogs = readFileSync(new URL("./workflow-create-dialog.tsx", import.meta.url), "utf8");
 const css = readFileSync(new URL("../../styles/workflows.css", import.meta.url), "utf8");
 
 assert.match(studio, /export (type )?WorkflowStudioActionState/, "WorkflowStudio action state should be exported");
@@ -65,5 +68,59 @@ assert.match(
 );
 assert.match(css, /\.workflow-studio-shell/, "workflow CSS should style the studio shell");
 assert.match(css, /@media \(max-width: 860px\)/, "workflow CSS should include mobile studio layout");
+
+// --- Studio v2: visual builder, runs, assignments ---
+
+assert.match(studio, /WorkflowPalette/, "Studio should include the step palette");
+assert.match(studio, /WorkflowRunsPanel/, "Studio should include the runs panel");
+assert.match(studio, /WorkflowCreateDialog/, "Studio should wire the create dialog");
+assert.match(studio, /WorkflowScheduleDialog/, "Studio should wire the schedule dialog");
+assert.match(studio, /onUndo[\s\S]*onRedo/, "Studio should thread undo/redo");
+
+for (const kind of ["agent", "skill", "tool", "human-gate", "workflow"]) {
+  assert.match(palette, new RegExp(`"${kind}"`), `Palette should offer the ${kind} step kind`);
+}
+
+assert.match(canvas, /onConnect/, "Canvas should support drawing dependency edges");
+assert.match(canvas, /onEdgesDelete/, "Canvas should support deleting dependency edges");
+assert.match(canvas, /onNodesDelete/, "Canvas should support deleting step nodes");
+assert.match(canvas, /deleteKeyCode/, "Canvas should map delete keys for edit operations");
+
+assert.match(inspector, /onUpdateStep/, "Inspector should edit step fields");
+assert.match(inspector, /onUpdateMeta/, "Inspector should edit workflow metadata");
+assert.match(inspector, /workflow-field/, "Inspector should render editable fields");
+assert.match(inspector, /on_error/, "Inspector should expose on-error behavior");
+
+assert.match(runStrip, /Save/, "Run strip should expose Save");
+assert.match(runStrip, /floppy-disk/, "Save should use the floppy icon");
+assert.match(runStrip, /Undo/, "Run strip should expose Undo");
+assert.match(runStrip, /Redo/, "Run strip should expose Redo");
+assert.match(runStrip, /onPlay/, "Run strip should probe the daemon run proxy");
+assert.match(runStrip, /engineUnavailable/, "Play should stay guarded when the engine is unavailable");
+
+assert.match(runsPanel, /WorkflowRunRecord/, "Runs panel should render run records");
+assert.match(runsPanel, /dry-run snapshots and daemon executions/i, "Runs panel should explain its data sources");
+
+assert.match(attachments, /onAttachRole/, "Attachments should persist role bindings");
+assert.match(attachments, /onUpdateMeta/, "Attachments should bind familiars into the manifest");
+assert.match(attachments, /onScheduleRequest/, "Attachments should open scheduling");
+
+assert.match(dialogs, /WorkflowCreateDialog/, "Create dialog exists");
+assert.match(dialogs, /WorkflowScheduleDialog/, "Schedule dialog exists");
+assert.match(dialogs, /slugifyWorkflowId/, "Create dialog previews the manifest slug");
+assert.match(dialogs, /not an execution schedule|Execution\s+scheduling arrives/i, "Schedule dialog stays honest about reminders vs execution");
+
+assert.match(library, /type="search"/, "Library should include search");
+assert.match(library, /Duplicate/, "Library should offer duplicate");
+assert.match(library, /Delete/, "Library should offer delete");
+assert.match(library, /onCreateRequest/, "Library should offer new-workflow creation");
+assert.match(library, /workflow-dirty-dot/, "Library should mark unsaved drafts");
+
+assert.match(manifestPreview, /workflowToYaml/, "Manifest preview should render live canonical YAML");
+
+assert.match(css, /\.workflow-palette/, "CSS should style the palette");
+assert.match(css, /\.workflow-runs-panel/, "CSS should style the runs panel");
+assert.match(css, /\.workflow-dialog/, "CSS should style dialogs");
+assert.match(css, /\.workflow-field/, "CSS should style editor fields");
 
 console.log("workflow-studio.test.ts: ok");

--- a/src/components/workflows/workflow-studio.tsx
+++ b/src/components/workflows/workflow-studio.tsx
@@ -2,18 +2,28 @@
 
 import "@/styles/workflows.css";
 
+import { useState } from "react";
 import type { WorkflowGraphNode } from "@/lib/workflow-graph";
 import type {
   WorkflowDryRunPlan,
+  WorkflowPattern,
+  WorkflowRoleSummary,
+  WorkflowRunRecord,
+  WorkflowScheduleRecurrence,
+  WorkflowStepKind,
+  WorkflowStepSummary,
   WorkflowSummary,
   WorkflowValidationResult,
 } from "@/lib/workflows";
 import { WorkflowAttachments } from "./workflow-attachments";
 import { WorkflowCanvas } from "./workflow-canvas";
+import { WorkflowCreateDialog, WorkflowScheduleDialog } from "./workflow-create-dialog";
 import { WorkflowInspector } from "./workflow-inspector";
 import { WorkflowLibrary } from "./workflow-library";
 import { WorkflowManifestPreview } from "./workflow-manifest-preview";
+import { WorkflowPalette } from "./workflow-palette";
 import { WorkflowRunStrip } from "./workflow-run-strip";
+import { WorkflowRunsPanel } from "./workflow-runs-panel";
 
 export type WorkflowStudioActionState = {
   id: string;
@@ -30,31 +40,50 @@ export type WorkflowStudioProps = {
   loaded: boolean;
   refreshing: boolean;
   error: string | null;
+  dirty: boolean;
+  canUndo: boolean;
+  canRedo: boolean;
+  runs: WorkflowRunRecord[];
+  runsLoading: boolean;
+  roles: WorkflowRoleSummary[];
+  engineUnavailable: boolean;
+  notice: string | null;
   onRefresh: () => void;
   onSelectWorkflow: (workflow: WorkflowSummary) => void;
   onSelectNode: (node: WorkflowGraphNode) => void;
   onClearNode: () => void;
   onValidate: (workflow: WorkflowSummary) => void;
   onDryRun: (workflow: WorkflowSummary) => void;
+  onPlay: (workflow: WorkflowSummary) => void;
+  onSave: (workflow: WorkflowSummary) => void;
+  onUndo: () => void;
+  onRedo: () => void;
+  onAddStep: (kind: WorkflowStepKind) => void;
+  onUpdateStep: (id: string, patch: Partial<WorkflowStepSummary>) => void;
+  onUpdateMeta: (patch: Partial<WorkflowSummary>) => void;
+  onRemoveStep: (id: string) => void;
+  onConnect: (source: string, target: string) => void;
+  onDisconnect: (source: string, target: string) => void;
+  onCreate: (input: { name: string; pattern: WorkflowPattern; familiar?: string }) => void;
+  onDuplicate: (workflow: WorkflowSummary) => void;
+  onDelete: (workflow: WorkflowSummary) => void;
+  onAttachRole: (role: WorkflowRoleSummary, attach: boolean) => void;
+  onSchedule: (fireAt: string, recurrence: WorkflowScheduleRecurrence) => void;
 };
 
-export function WorkflowStudio({
-  workflows,
-  selectedWorkflow,
-  selectedNode,
-  action,
-  busyId,
-  loaded,
-  refreshing,
-  error,
-  onRefresh,
-  onSelectWorkflow,
-  onSelectNode,
-  onClearNode,
-  onValidate,
-  onDryRun,
-}: WorkflowStudioProps) {
-  const selectedAction = action && selectedWorkflow?.id === action.id ? action : null;
+export function WorkflowStudio(props: WorkflowStudioProps) {
+  const {
+    workflows,
+    selectedWorkflow,
+    selectedNode,
+    action,
+    busyId,
+    loaded,
+    refreshing,
+    error,
+  } = props;
+  const [createOpen, setCreateOpen] = useState(false);
+  const [scheduleOpen, setScheduleOpen] = useState(false);
 
   return (
     <section className="workflow-studio-shell" aria-label="Workflow Studio">
@@ -64,30 +93,80 @@ export function WorkflowStudio({
         loaded={loaded}
         refreshing={refreshing}
         error={error}
-        onRefresh={onRefresh}
-        onSelectWorkflow={onSelectWorkflow}
+        dirty={props.dirty}
+        onRefresh={props.onRefresh}
+        onSelectWorkflow={props.onSelectWorkflow}
+        onCreateRequest={() => setCreateOpen(true)}
+        onDuplicate={props.onDuplicate}
+        onDelete={props.onDelete}
       />
       <main className="workflow-studio-main">
+        <WorkflowPalette workflow={selectedWorkflow} onAddStep={props.onAddStep} />
         <WorkflowCanvas
           workflow={selectedWorkflow}
-          action={selectedAction}
+          action={action}
           selectedNode={selectedNode}
-          onSelectNode={onSelectNode}
-          onClearNode={onClearNode}
+          onSelectNode={props.onSelectNode}
+          onClearNode={props.onClearNode}
+          onConnect={props.onConnect}
+          onDisconnect={props.onDisconnect}
+          onRemoveStep={props.onRemoveStep}
         />
         <WorkflowRunStrip
           workflow={selectedWorkflow}
-          action={selectedAction}
+          action={action}
           busyId={busyId}
-          onValidate={onValidate}
-          onDryRun={onDryRun}
+          dirty={props.dirty}
+          canUndo={props.canUndo}
+          canRedo={props.canRedo}
+          engineUnavailable={props.engineUnavailable}
+          notice={props.notice}
+          onValidate={props.onValidate}
+          onDryRun={props.onDryRun}
+          onPlay={props.onPlay}
+          onSave={props.onSave}
+          onUndo={props.onUndo}
+          onRedo={props.onRedo}
         />
+        <WorkflowRunsPanel runs={props.runs} loading={props.runsLoading} workflow={selectedWorkflow} />
       </main>
       <aside className="workflow-studio-side" aria-label="Workflow details">
-        <WorkflowInspector workflow={selectedWorkflow} selectedNode={selectedNode} action={selectedAction} />
-        <WorkflowAttachments workflow={selectedWorkflow} />
-        <WorkflowManifestPreview workflow={selectedWorkflow} />
+        <WorkflowInspector
+          workflow={selectedWorkflow}
+          selectedNode={selectedNode}
+          action={action}
+          onUpdateStep={props.onUpdateStep}
+          onUpdateMeta={props.onUpdateMeta}
+          onRemoveStep={props.onRemoveStep}
+        />
+        <WorkflowAttachments
+          workflow={selectedWorkflow}
+          roles={props.roles}
+          onAttachRole={props.onAttachRole}
+          onUpdateMeta={props.onUpdateMeta}
+          onScheduleRequest={() => setScheduleOpen(true)}
+        />
+        <WorkflowManifestPreview workflow={selectedWorkflow} dirty={props.dirty} />
       </aside>
+      {createOpen && (
+        <WorkflowCreateDialog
+          onClose={() => setCreateOpen(false)}
+          onCreate={(input) => {
+            setCreateOpen(false);
+            props.onCreate(input);
+          }}
+        />
+      )}
+      {scheduleOpen && selectedWorkflow && (
+        <WorkflowScheduleDialog
+          workflow={selectedWorkflow}
+          onClose={() => setScheduleOpen(false)}
+          onSchedule={(fireAt, recurrence) => {
+            setScheduleOpen(false);
+            props.onSchedule(fireAt, recurrence);
+          }}
+        />
+      )}
     </section>
   );
 }

--- a/src/lib/icon.tsx
+++ b/src/lib/icon.tsx
@@ -247,6 +247,7 @@ export const ICON_NAMES = [
   "ph:terminal-window-bold",
   "ph:git-branch-bold",
   "ph:lightning-bold",
+  "ph:floppy-disk-bold",
   "ph:lightning-fill",
   "ph:paw-print-bold",
   "ph:code-bold",

--- a/src/lib/workflow-runs.ts
+++ b/src/lib/workflow-runs.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
 import path from "node:path";
-import { covenHome } from "./coven-paths.ts";
 
 /**
  * Local run-history store for the Workflow Studio. The daemon has no workflow
@@ -20,10 +20,12 @@ import type { WorkflowRunRecord } from "./workflows.ts";
 
 type RunsFile = { version: 1; runs: WorkflowRunRecord[] };
 
+// Same shape as cave-inbox's INBOX_PATH: a statically-scoped home path keeps
+// Next's file tracing from sweeping the whole project into the bundle.
 function runsPath(): string {
   const override = process.env.COVEN_WORKFLOW_RUNS_PATH?.trim();
   if (override) return override;
-  return path.join(covenHome(), "workflow-runs.json");
+  return path.join(homedir(), ".coven", "workflow-runs.json");
 }
 
 async function loadRunsFile(): Promise<RunsFile> {

--- a/src/lib/workflow-runs.ts
+++ b/src/lib/workflow-runs.ts
@@ -15,26 +15,8 @@ import { covenHome } from "./coven-paths.ts";
 
 export const RUNS_HISTORY_CAP = 200;
 
-export type WorkflowRunStatus = "plan" | "queued" | "running" | "succeeded" | "failed" | "blocked";
-
-export type WorkflowRunStepRecord = {
-  id: string;
-  kind: string;
-  status: "ready" | "blocked" | "succeeded" | "failed" | "skipped";
-};
-
-export type WorkflowRunRecord = {
-  id: string;
-  workflowId: string;
-  version?: string;
-  kind: "dry-run" | "execution";
-  status: WorkflowRunStatus;
-  startedAt: string;
-  finishedAt?: string;
-  steps: WorkflowRunStepRecord[];
-  summary?: string;
-  source: "cave" | "daemon";
-};
+export type { WorkflowRunRecord, WorkflowRunStatus, WorkflowRunStepRecord } from "./workflows.ts";
+import type { WorkflowRunRecord } from "./workflows.ts";
 
 type RunsFile = { version: 1; runs: WorkflowRunRecord[] };
 

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -92,6 +92,52 @@ export type WorkflowListResponse = {
   error?: string;
 };
 
+// Run-history types live here (client-safe) so components never import the
+// fs-backed store module; src/lib/workflow-runs.ts type-imports these.
+export type WorkflowRunStatus = "plan" | "queued" | "running" | "succeeded" | "failed" | "blocked";
+
+export type WorkflowRunStepRecord = {
+  id: string;
+  kind: string;
+  status: "ready" | "blocked" | "succeeded" | "failed" | "skipped";
+};
+
+export type WorkflowRunRecord = {
+  id: string;
+  workflowId: string;
+  version?: string;
+  kind: "dry-run" | "execution";
+  status: WorkflowRunStatus;
+  startedAt: string;
+  finishedAt?: string;
+  steps: WorkflowRunStepRecord[];
+  summary?: string;
+  source: "cave" | "daemon";
+};
+
+export type SaveWorkflowResponse = {
+  ok: boolean;
+  workflow?: WorkflowSummary;
+  validation?: WorkflowValidationResult;
+  error?: string;
+};
+
+export type RunWorkflowResponse = {
+  ok: boolean;
+  unavailable?: boolean;
+  error?: string;
+  run?: WorkflowRunRecord;
+};
+
+/** Minimal role shape the studio needs for attach toggles. */
+export type WorkflowRoleSummary = {
+  id: string;
+  name: string;
+  familiar: string;
+  emoji?: string;
+  workflows: string[];
+};
+
 type FetchLike = (input: string, init?: RequestInit) => Promise<{ json: () => Promise<unknown> }>;
 
 export function workflowDetailPath(id: string): string {
@@ -121,10 +167,126 @@ export async function validateWorkflow(
 }
 
 export async function dryRunWorkflow(
-  body: { id?: string; path?: string; inputs?: Record<string, unknown> },
+  body: { id?: string; path?: string; manifest?: unknown; inputs?: Record<string, unknown> },
   fetchImpl: FetchLike = fetch,
 ): Promise<WorkflowDryRunPlan> {
   return postJson<WorkflowDryRunPlan>("/api/workflows/dry-run", body, fetchImpl);
+}
+
+/** Persist a manifest through the Cave save route. */
+export async function saveWorkflow(
+  manifest: Record<string, unknown>,
+  fetchImpl: FetchLike = fetch,
+): Promise<SaveWorkflowResponse> {
+  return postJson<SaveWorkflowResponse>("/api/workflows/save", { manifest }, fetchImpl);
+}
+
+/** Delete a locally-authored manifest by id or source path. */
+export async function deleteWorkflow(
+  body: { id?: string; path?: string },
+  fetchImpl: FetchLike = fetch,
+): Promise<{ ok: boolean; error?: string }> {
+  return postJson<{ ok: boolean; error?: string }>("/api/workflows/delete", body, fetchImpl);
+}
+
+/** Execute through the daemon engine; `unavailable: true` keeps Play guarded. */
+export async function runWorkflow(
+  body: { id?: string; path?: string; inputs?: Record<string, unknown> },
+  fetchImpl: FetchLike = fetch,
+): Promise<RunWorkflowResponse> {
+  return postJson<RunWorkflowResponse>("/api/workflows/run", body, fetchImpl);
+}
+
+/** Newest-first run history, optionally scoped to one workflow. */
+export async function listWorkflowRuns(
+  workflowId?: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<{ ok: boolean; runs: WorkflowRunRecord[]; error?: string }> {
+  const query = workflowId ? `?workflowId=${encodeURIComponent(workflowId)}` : "";
+  const res = await fetchImpl(`/api/workflows/runs${query}`, { cache: "no-store" });
+  return res.json() as Promise<{ ok: boolean; runs: WorkflowRunRecord[]; error?: string }>;
+}
+
+/** Record a run (the studio snapshots dry-run plans into history). */
+export async function recordWorkflowRun(
+  input: Omit<WorkflowRunRecord, "id">,
+  fetchImpl: FetchLike = fetch,
+): Promise<{ ok: boolean; run?: WorkflowRunRecord; error?: string }> {
+  return postJson<{ ok: boolean; run?: WorkflowRunRecord; error?: string }>(
+    "/api/workflows/runs",
+    input,
+    fetchImpl,
+  );
+}
+
+/** Roles flattened to what the attachments panel needs. */
+export async function listWorkflowRoles(
+  fetchImpl: FetchLike = fetch,
+): Promise<{ ok: boolean; roles: WorkflowRoleSummary[]; error?: string }> {
+  const res = await fetchImpl("/api/roles", { cache: "no-store" });
+  const data = (await res.json()) as {
+    ok: boolean;
+    roles?: Array<WorkflowRoleSummary & Record<string, unknown>>;
+    error?: string;
+  };
+  return {
+    ok: data.ok,
+    error: data.error,
+    roles: (data.roles ?? []).map((role) => ({
+      id: role.id,
+      name: role.name,
+      familiar: role.familiar,
+      emoji: role.emoji,
+      workflows: Array.isArray(role.workflows) ? role.workflows : [],
+    })),
+  };
+}
+
+/** Attach or detach a workflow on a role (rewrites ROLE.md). */
+export async function attachWorkflowToRole(
+  body: { roleId: string; familiar: string; workflowId: string; attach: boolean },
+  fetchImpl: FetchLike = fetch,
+): Promise<{ ok: boolean; workflows?: string[]; error?: string }> {
+  return postJson<{ ok: boolean; workflows?: string[]; error?: string }>(
+    "/api/roles/workflows",
+    body,
+    fetchImpl,
+  );
+}
+
+export type WorkflowScheduleRecurrence =
+  | { type: "none" }
+  | { type: "interval"; everyMs: number }
+  | { type: "daily"; hour: number; minute: number }
+  | { type: "weekly"; days: number[]; hour: number; minute: number };
+
+/**
+ * Schedule a workflow as a real inbox reminder (shows up on the Automations
+ * surface). This intentionally creates a reminder, not an execution: the
+ * daemon has no workflow engine yet, and Cave never pretends one ran.
+ */
+export async function scheduleWorkflow(
+  body: {
+    workflow: WorkflowSummary;
+    fireAt: string;
+    recurrence?: WorkflowScheduleRecurrence;
+  },
+  fetchImpl: FetchLike = fetch,
+): Promise<{ ok: boolean; error?: string }> {
+  return postJson<{ ok: boolean; error?: string }>(
+    "/api/inbox",
+    {
+      kind: "reminder",
+      title: `Run workflow: ${body.workflow.name ?? body.workflow.id}`,
+      body: body.workflow.summary,
+      fireAt: body.fireAt,
+      recurrence: body.recurrence,
+      source: "user",
+      familiarId: body.workflow.familiar ?? null,
+      link: { kind: "url", ref: `cave://workflows/${encodeURIComponent(body.workflow.id)}` },
+    },
+    fetchImpl,
+  );
 }
 
 export function workflowIssueSummary(issues: WorkflowValidationIssue[]): string {

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -11,8 +11,8 @@
 .workflow-studio-main {
   display: grid;
   min-width: 0;
-  grid-template-rows: minmax(420px, 1fr) auto;
-  gap: 12px;
+  grid-template-rows: auto minmax(320px, 1fr) auto auto;
+  gap: 0;
 }
 
 .workflow-studio-side,
@@ -348,7 +348,7 @@
   }
 
   .workflow-studio-main {
-    grid-template-rows: minmax(360px, 60vh) auto;
+    grid-template-rows: auto minmax(300px, 50vh) auto auto;
   }
 
   .workflow-run-strip {
@@ -359,4 +359,402 @@
   .workflow-run-feedback {
     text-align: left;
   }
+}
+
+/* ---- Studio v2: builder, palette, runs, dialogs ---- */
+
+.workflow-palette {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in oklch, var(--card) 72%, transparent);
+}
+
+.workflow-palette-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-foreground);
+  margin-right: 4px;
+}
+
+.workflow-palette-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  padding: 4px 9px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--card);
+  color: var(--text-primary, inherit);
+}
+
+.workflow-palette-item:hover:not(:disabled) {
+  border-color: var(--border-strong);
+}
+
+.workflow-palette-item:disabled {
+  opacity: 0.45;
+}
+
+.workflow-palette-agent { border-left: 3px solid color-mix(in oklch, var(--color-info, #6aa6ff) 70%, transparent); }
+.workflow-palette-tool { border-left: 3px solid color-mix(in oklch, var(--color-success, #57c878) 70%, transparent); }
+.workflow-palette-gate { border-left: 3px solid color-mix(in oklch, var(--color-warning, #d9a13c) 70%, transparent); }
+.workflow-palette-workflow { border-left: 3px solid color-mix(in oklch, var(--accent-presence) 70%, transparent); }
+
+.workflow-library-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.workflow-search {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 12px 8px;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  color: var(--muted-foreground);
+}
+
+.workflow-search input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-size: 12px;
+  color: var(--text-primary, inherit);
+}
+
+.workflow-dirty-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  margin-left: 6px;
+  border-radius: 50%;
+  background: var(--color-warning, #d9a13c);
+  vertical-align: middle;
+}
+
+.workflow-library-footer {
+  display: flex;
+  gap: 8px;
+  padding: 10px 12px;
+  border-top: 1px solid var(--border);
+}
+
+.workflow-library-footer button {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  padding: 4px 9px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--card);
+}
+
+.workflow-danger-button,
+.workflow-icon-button-danger {
+  color: var(--color-danger, #e5484d);
+}
+
+.workflow-danger-button:hover,
+.workflow-icon-button-danger:hover {
+  border-color: color-mix(in oklch, var(--color-danger, #e5484d) 60%, transparent);
+}
+
+.workflow-editor {
+  display: grid;
+  gap: 8px;
+}
+
+.workflow-field {
+  display: grid;
+  gap: 3px;
+  font-size: 12px;
+}
+
+.workflow-field > span {
+  font-size: 11px;
+  color: var(--muted-foreground);
+}
+
+.workflow-field input,
+.workflow-field select {
+  width: 100%;
+  font-size: 12px;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--card);
+  color: var(--text-primary, inherit);
+}
+
+.workflow-field input:focus,
+.workflow-field select:focus {
+  outline: none;
+  border-color: color-mix(in oklch, var(--accent-presence) 65%, transparent);
+}
+
+.workflow-field-inline {
+  margin-top: 4px;
+}
+
+.workflow-limits-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.workflow-issue-list {
+  margin: 6px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 4px;
+  font-size: 11.5px;
+}
+
+.workflow-issue-list li {
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+}
+
+.workflow-issue-tier {
+  flex: none;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 1px 5px;
+  border-radius: 5px;
+  border: 1px solid var(--border);
+}
+
+.workflow-issue-schema { color: var(--color-danger, #e5484d); }
+.workflow-issue-semantic { color: var(--color-warning, #d9a13c); }
+.workflow-issue-preflight { color: var(--color-info, #6aa6ff); }
+
+.workflow-role-list {
+  margin: 4px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 4px;
+}
+
+.workflow-role-toggle {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.workflow-role-familiar {
+  font-size: 11px;
+  color: var(--muted-foreground);
+}
+
+.workflow-runs-panel {
+  border-top: 1px solid var(--border);
+  padding: 8px 12px 10px;
+  max-height: 180px;
+  overflow-y: auto;
+  background: color-mix(in oklch, var(--card) 60%, transparent);
+}
+
+.workflow-runs-heading {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.workflow-runs-count {
+  font-weight: 400;
+  font-size: 11px;
+  color: var(--muted-foreground);
+}
+
+.workflow-runs-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 4px;
+}
+
+.workflow-run-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  padding: 4px 6px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+}
+
+.workflow-run-chip {
+  flex: none;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+}
+
+.workflow-run-chip-plan { color: var(--color-info, #6aa6ff); }
+.workflow-run-chip-queued,
+.workflow-run-chip-running { color: var(--color-warning, #d9a13c); }
+.workflow-run-chip-succeeded { color: var(--color-success, #57c878); }
+.workflow-run-chip-failed,
+.workflow-run-chip-blocked { color: var(--color-danger, #e5484d); }
+
+.workflow-run-kind {
+  flex: none;
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+
+.workflow-run-detail {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-run-time {
+  flex: none;
+  font-size: 11px;
+  color: var(--muted-foreground);
+}
+
+.workflow-history-button {
+  padding: 4px 7px;
+}
+
+.workflow-primary-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 60%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 18%, transparent);
+}
+
+.workflow-play-button:not(:disabled) {
+  border-color: color-mix(in oklch, var(--color-danger, #e5484d) 55%, transparent);
+  background: color-mix(in oklch, var(--color-danger, #e5484d) 14%, transparent);
+}
+
+.workflow-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: grid;
+  place-items: center;
+  background: rgb(0 0 0 / 45%);
+}
+
+.workflow-dialog {
+  width: min(440px, calc(100vw - 32px));
+  max-height: min(80vh, 640px);
+  overflow-y: auto;
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  background: var(--card);
+  box-shadow: 0 24px 60px rgb(0 0 0 / 40%);
+}
+
+.workflow-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.workflow-dialog-actions button {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  padding: 5px 11px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--card);
+}
+
+.workflow-pattern-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+.workflow-pattern-option {
+  display: grid;
+  gap: 2px;
+  text-align: left;
+  font-size: 12px;
+  padding: 7px 9px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--card);
+}
+
+.workflow-pattern-option.is-active {
+  border-color: color-mix(in oklch, var(--accent-presence) 70%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+}
+
+.workflow-pattern-name {
+  font-weight: 600;
+}
+
+.workflow-pattern-hint {
+  font-size: 11px;
+  color: var(--muted-foreground);
+}
+
+.workflow-weekday-row {
+  display: flex;
+  gap: 5px;
+}
+
+.workflow-weekday {
+  font-size: 11px;
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--card);
+}
+
+.workflow-weekday.is-active {
+  border-color: color-mix(in oklch, var(--accent-presence) 70%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 16%, transparent);
+}
+
+.workflow-manifest-yaml {
+  margin: 0;
+  padding: 9px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in oklch, var(--background) 80%, transparent);
+  font-size: 11px;
+  line-height: 1.5;
+  overflow: auto;
+  max-height: 240px;
+  white-space: pre;
 }


### PR DESCRIPTION
## Summary

Completes the Workflow Studio arc (PR 2 + PR 3 slices of the approved design) on top of #458/#466/#470: the studio becomes a full creation/management surface instead of a read-only viewer.

**Builder (PR 2 slice)**
- Draft reducer (`workflow-draft.ts`, pure, tested): add/update/remove steps, requires-edge connect/disconnect with self/duplicate/**cycle** rejection, id renames rewriting dependents, capped undo/redo, dirty tracking.
- Palette appends `agent / skill / tool / human-gate / workflow` steps; canvas edges are drawn/deleted via React Flow; inspector edits step fields and workflow metadata (version, pattern, tags, limits, permissions).
- Save serializes the draft through `workflow-edit.ts` (key-ordered YAML, cave-only fields stripped) to `POST /api/workflows/save`, which returns the validation verdict alongside the write. Manifest preview shows the live canonical YAML that Save will write.
- Create-from-pattern dialog (8 CWF-01 pattern templates, all validate clean), duplicate, delete (confirmed), library search, dirty marker.

**Runs (PR 3 slice, honest about the missing engine)**
- `~/.coven/workflow-runs.json` store (locked writes, capped 200, corrupt-store recovery) + `GET/POST /api/workflows/runs`.
- Dry-runs (including **unsaved drafts** via inline-manifest planning) snapshot into the runs panel.
- `POST /api/workflows/run` proxies the daemon engine and returns `unavailable: true` on 404/offline — Play stays guarded; Cave never pretends an execution happened.

**Assignments & roles**
- Familiar binding persists into the manifest (`familiar:`); role attachment rewrites the `workflows:` list block in ROLE.md via pure `role-manifest.ts` helpers (format verified readable by the existing roles GET).
- Schedule-as-automation creates a real inbox reminder (Automations surface) deep-linking `cave://workflows/<id>` — deliberately a reminder, not an execution schedule.
- Boards/projects stay visibly pending (no owning API yet).

## Verification

- `tsc --noEmit`, `pnpm run test:app` (5 new lib test files + extended studio/view source tests), `pnpm run test:api` (route contracts for the 5 new routes landed via #472), `pnpm build` all green.
- Live e2e against `next dev` with isolated `COVEN_WORKFLOWS_DIR`/`COVEN_WORKFLOW_RUNS_PATH`/`COVEN_HOME`: save → list → inline-draft dry-run → run-snapshot record → guarded run proxy → role attach (ROLE.md rewritten, roles GET reflects it) → delete. All passed.
- Not yet eyeballed pixel-by-pixel in the Tauri webview — interaction layer is exercised via API + source tests; visual pass welcome.

## Notes

- Spec: `docs/superpowers/specs/2026-06-11-cave-workflow-studio-design.md` (approved direction; PR 2 + PR 3 slices). Plan: `docs/superpowers/plans/2026-06-11-workflow-studio-v2.md` (local, gitignored).
- Deferred per spec open-decisions: sidecar `WORKFLOW.cave.json` node-position writes, boards/projects persistence, live run streaming (needs daemon engine).
- Supersedes the now-merged branch `feat/workflow-studio-v2` (its pre-UI commits landed in #470; its duplicate contracts commit was dropped in favor of #472).
- Pre-existing Turbopack NFT trace warning on main is unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)