### PR TITLE
style(theme): dark scrollbars in dark mode, comprehensively

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -183,6 +183,11 @@
   /* Foundations PR — disabled state */
   --opacity-disabled: 0.4;
 
+  /* Dark is the base mode. color-scheme makes native scrollbars and form
+     controls render in their dark variant everywhere (overridden to `light`
+     under [data-mode="light"] below). */
+  color-scheme: dark;
+
   /* Foundations PR — scrollbar tokens (consumed by all themed scrollbars) */
   --scrollbar-thumb: color-mix(in oklch, var(--accent-presence) 30%, transparent);
   --scrollbar-track: transparent;
@@ -219,6 +224,7 @@
    structural tokens (radii, spacing, motion) are inherited.
    ============================================================ */
 :root[data-mode="light"] {
+  color-scheme: light;
   --background: oklch(0.975 0.012 293);
   --foreground: oklch(0.18 0.020 293);
   --card: oklch(0.95 0.014 293);
@@ -308,6 +314,47 @@ body {
      overflow. */
   height: 100%;
   overflow: hidden;
+}
+
+/* ── Global scrollbars ───────────────────────────────────────────────────────
+ * Dark, thin scrollbars on every scroll surface in dark mode (and a matching
+ * light treatment under [data-mode="light"], via color-scheme + the tokens).
+ *
+ * Three layers of coverage so nothing slips through:
+ *   1. color-scheme (set on :root) — native scrollbars + form controls.
+ *   2. scrollbar-color/-width — Firefox and the standards path. These are
+ *      INHERITED, so declaring them on html cascades to every element; a
+ *      surface with its own scrollbar-color (cave-chat, library, sidebar, …)
+ *      still overrides via the normal cascade.
+ *   3. ::-webkit-scrollbar — Chromium/WebKit (the Tauri desktop webview). A
+ *      bare pseudo-element matches every scrollbar; per-component
+ *      `.foo::-webkit-scrollbar` rules are more specific and still win. */
+html {
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+}
+
+::-webkit-scrollbar {
+  width: 11px;
+  height: 11px;
+}
+::-webkit-scrollbar-track {
+  background: var(--scrollbar-track);
+}
+::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb);
+  border-radius: 8px;
+  /* Transparent border + padding-box clip insets the thumb so it reads as a
+     slim pill with breathing room rather than a full-width bar. */
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in oklch, var(--accent-presence) 50%, transparent);
+  background-clip: padding-box;
+}
+::-webkit-scrollbar-corner {
+  background: transparent;
 }
 
 body {


### PR DESCRIPTION
Set `color-scheme` (dark base, light under `[data-mode="light"]`) so native scrollbars and form controls render in the right variant everywhere, plus global `scrollbar-color` (inherited) and `::webkit-scrollbar` rules using the existing `--scrollbar-thumb/track` tokens. Per-component scrollbar styles stay more specific and are unaffected.