### PR TITLE
fix(onboarding): retry harness fetch while empty so the runtime step can't strand

### DIFF
--- a/src/components/onboarding-guided-steps.test.ts
+++ b/src/components/onboarding-guided-steps.test.ts
@@ -184,4 +184,10 @@ assert.match(
   "Hermes shows the PowerShell installer on Windows",
 );
 
+assert.match(
+  source,
+  /if \(!open \|\| harnesses\.length > 0\) return;[\s\S]{0,120}setInterval\(\(\) => void loadHarnesses\(\), 2000\)/,
+  "harness list retries while empty so a slow first fetch cannot strand the runtime step",
+);
+
 console.log("onboarding-guided-steps.test.ts: ok");

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -401,6 +401,17 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
     };
   }, [open, refresh, loadHarnesses, loadOpenClawAgents, loadFamiliars]);
 
+  // The harness probe races first paint: it loads once at open, so a slow or
+  // failed first fetch left the runtime step's grid empty until a manual
+  // Refresh. Retry on the status cadence while the list is empty — a
+  // successful response always carries the bundled adapters, so the loop
+  // stops after the first real load and never spins on a healthy state.
+  useEffect(() => {
+    if (!open || harnesses.length > 0) return;
+    const retry = setInterval(() => void loadHarnesses(), 2000);
+    return () => clearInterval(retry);
+  }, [open, harnesses.length, loadHarnesses]);
+
   // Refresh the familiar list when the familiars step flips healthy so the
   // final step can list them for editing.
   const familiarsOk = !!status?.steps.familiars.ok;


### PR DESCRIPTION
## What

Follow-up to #474, fixing a race found during post-merge verification: the harness list loaded **once** at overlay open, so a slow or failed first `/api/harnesses` fetch left the "Install a runtime" step rendering an **empty grid** — no cards, no install buttons — until the user discovered the manual Refresh button.

The fix retries on the status cadence (2s) **only while the list is empty**. A successful response always carries the bundled adapters, so the loop stops after the first real load and adds zero traffic in the healthy case.

## Verification (live, deterministic repro)

Playwright route-intercepted `/api/harnesses` to fail the first two requests with 500s, then pass through:

- Grid empty after the failed first fetch ✓ (the pre-fix stranding)
- Grid **self-healed without clicking Refresh** — Hermes install button + all 4 cards appeared ✓
- **0 further fetches** in the 6s after the list landed — the retry loop stops cleanly ✓

`onboarding-guided-steps.test.ts` pins the retry effect; full `test:app` passes; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)