### PR TITLE
fix(terminal): stop losing input — shell-owned chords, PTY survival, reconnect

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -32,10 +32,35 @@ const ACCESS_COOKIE = "coven_access_token";
 
 type PtySession = {
   pty: import("node-pty").IPty;
-  ws: WebSocket;
+  /** Currently-attached socket; null while detached (client dropped). */
+  ws: WebSocket | null;
+  /** Bounded ring of recent output, replayed on (re)attach so a returning
+   *  client repaints the screen instead of staring at a blank pane. */
+  scrollback: Buffer[];
+  scrollbackBytes: number;
+  /** Pending kill while detached — cleared when a client reattaches. */
+  detachTimer: NodeJS.Timeout | null;
 };
 
 const sessions = new Map<string, PtySession>();
+
+/** Cap on replayed output per session (~enough to repaint a busy screen). */
+const SCROLLBACK_LIMIT_BYTES = 256 * 1024;
+/** How long a PTY survives with no client before it is killed. Covers tab
+ *  switches, page reloads, and brief network drops (laptop sleep is longer —
+ *  the client reconnects as soon as it wakes, which lands well inside this
+ *  window after resume). Killing on the FIRST close was the old behavior,
+ *  and it destroyed the shell on every remount. */
+const DETACH_GRACE_MS = 60_000;
+
+function appendScrollback(session: PtySession, data: Buffer): void {
+  session.scrollback.push(data);
+  session.scrollbackBytes += data.length;
+  while (session.scrollbackBytes > SCROLLBACK_LIMIT_BYTES && session.scrollback.length > 1) {
+    const dropped = session.scrollback.shift();
+    if (dropped) session.scrollbackBytes -= dropped.length;
+  }
+}
 
 function getTokenFromCookie(header: string | undefined): string {
   if (!header) return "";
@@ -205,16 +230,31 @@ function spawnPty(threadId: string, ws: WebSocket, cols: number, rows: number, c
     },
   });
 
-  sessions.set(threadId, { pty: shell, ws });
+  const session: PtySession = {
+    pty: shell,
+    ws,
+    scrollback: [],
+    scrollbackBytes: 0,
+    detachTimer: null,
+  };
+  sessions.set(threadId, session);
 
-  shell.onData((data) => sendPtyData(ws, data));
+  shell.onData((data) => {
+    appendScrollback(session, Buffer.from(data, "utf8"));
+    // Output keeps flowing into the ring while detached, so the client that
+    // reattaches sees what happened while it was away.
+    if (session.ws) sendPtyData(session.ws, data);
+  });
   shell.onExit(({ exitCode }) => {
     const current = sessions.get(threadId);
     if (current?.pty === shell) {
+      if (current.detachTimer) clearTimeout(current.detachTimer);
       sessions.delete(threadId);
     }
-    sendPtyExit(ws, exitCode ?? 0);
-    ws.close(1000, "pty exit");
+    if (session.ws) {
+      sendPtyExit(session.ws, exitCode ?? 0);
+      session.ws.close(1000, "pty exit");
+    }
   });
 }
 
@@ -241,19 +281,37 @@ function onWsMessage(threadId: string, data: RawData): void {
   }
 }
 
-function closeExistingSession(threadId: string): void {
-  const existing = sessions.get(threadId);
-  if (!existing) return;
-  sessions.delete(threadId);
-  try {
-    existing.pty.kill();
-  } catch {
-    // Already gone.
+/** Attach a (re)connecting client to an already-running PTY: the previous
+ *  socket (if any) is told it was replaced, the pending detach-kill is
+ *  cancelled, and the scrollback ring is replayed so the client repaints. */
+function adoptSession(
+  session: PtySession,
+  ws: WebSocket,
+  cols: number,
+  rows: number,
+): void {
+  if (session.detachTimer) {
+    clearTimeout(session.detachTimer);
+    session.detachTimer = null;
   }
-  try {
-    existing.ws.close(1000, "replaced");
-  } catch {
-    // Already closed.
+  const previous = session.ws;
+  session.ws = ws;
+  if (previous && previous !== ws) {
+    try {
+      previous.close(1000, "replaced");
+    } catch {
+      // Already closed.
+    }
+  }
+  if (cols > 0 && rows > 0) {
+    try {
+      session.pty.resize(cols, rows);
+    } catch {
+      // Exited between adopt and resize; onExit handles the rest.
+    }
+  }
+  if (session.scrollbackBytes > 0) {
+    sendPtyData(ws, Buffer.concat(session.scrollback).toString("utf8"));
   }
 }
 
@@ -264,19 +322,36 @@ function handlePtyConnection(
   rows: number,
   cwd?: string,
 ): void {
-  closeExistingSession(threadId);
-  spawnPty(threadId, ws, cols, rows, cwd);
+  // Same threadId while the shell is alive (tab switch, page reload, network
+  // blip, second window) → adopt the running PTY instead of killing it.
+  // Killing here was the old behavior, and it cost the user their shell on
+  // every reconnect.
+  const existing = sessions.get(threadId);
+  if (existing) {
+    adoptSession(existing, ws, cols, rows);
+  } else {
+    spawnPty(threadId, ws, cols, rows, cwd);
+  }
 
   ws.on("message", (data) => onWsMessage(threadId, data));
   ws.on("close", () => {
     const session = sessions.get(threadId);
     if (session?.ws !== ws) return;
-    sessions.delete(threadId);
-    try {
-      session.pty.kill();
-    } catch {
-      // Already gone.
-    }
+    // Detach, don't kill: give the client a grace window to come back
+    // (remounts, reloads, sleep/wake). The ring keeps collecting output;
+    // the timer reaps truly-abandoned shells.
+    session.ws = null;
+    if (session.detachTimer) clearTimeout(session.detachTimer);
+    session.detachTimer = setTimeout(() => {
+      const current = sessions.get(threadId);
+      if (current !== session || current.ws) return;
+      sessions.delete(threadId);
+      try {
+        session.pty.kill();
+      } catch {
+        // Already gone.
+      }
+    }, DETACH_GRACE_MS);
   });
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -838,6 +838,7 @@ pub fn run() {
             pty::pty_resize,
             pty::pty_stop,
             pty::pty_list,
+            pty::pty_snapshot,
             pty::pty_diagnose,
             webview_probe_report,
             browser::browser_navigate,

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -33,7 +33,14 @@ struct PtySession {
     #[allow(dead_code)]
     master: Box<dyn MasterPty + Send>,
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
+    /// Bounded ring of recent output. Terminal views remount on tab switches
+    /// (the PTY deliberately outlives them); replaying this on reattach
+    /// restores the screen instead of presenting a blank-but-alive shell.
+    scrollback: Arc<Mutex<Vec<u8>>>,
 }
+
+/// Cap on replayed output per session (~enough to repaint a busy screen).
+const SCROLLBACK_LIMIT_BYTES: usize = 256 * 1024;
 
 static SESSIONS: Lazy<Mutex<HashMap<String, PtySession>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
@@ -186,6 +193,7 @@ pub fn pty_start(app: AppHandle, webview: Webview, options: StartOptions) -> Res
     let mut reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
     let writer = pair.master.take_writer().map_err(|e| e.to_string())?;
 
+    let scrollback = Arc::new(Mutex::new(Vec::new()));
     {
         let mut guard = SESSIONS.lock();
         guard.insert(
@@ -193,6 +201,7 @@ pub fn pty_start(app: AppHandle, webview: Webview, options: StartOptions) -> Res
             PtySession {
                 master: pair.master,
                 writer: Arc::new(Mutex::new(writer)),
+                scrollback: scrollback.clone(),
             },
         );
     }
@@ -202,6 +211,7 @@ pub fn pty_start(app: AppHandle, webview: Webview, options: StartOptions) -> Res
     // Reader thread — forwards bytes to the webview as pty:data events.
     let tid_read = thread_id.clone();
     let app_read = app.clone();
+    let ring = scrollback;
     thread::spawn(move || {
         info!("pty_start[{}]: reader thread started", tid_read);
         let mut buf = [0u8; 8192];
@@ -218,6 +228,14 @@ pub fn pty_start(app: AppHandle, webview: Webview, options: StartOptions) -> Res
                 }
                 Ok(n) => {
                     total = total.saturating_add(n);
+                    {
+                        let mut buffer = ring.lock();
+                        buffer.extend_from_slice(&buf[..n]);
+                        let len = buffer.len();
+                        if len > SCROLLBACK_LIMIT_BYTES {
+                            buffer.drain(0..len - SCROLLBACK_LIMIT_BYTES);
+                        }
+                    }
                     debug!("pty_start[{}]: emit pty:data {} bytes (total {})", tid_read, n, total);
                     let _ = app_read.emit(
                         "pty:data",
@@ -298,6 +316,18 @@ pub fn pty_stop(webview: Webview, thread_id: String) -> Result<(), String> {
 pub fn pty_list(webview: Webview) -> Result<Vec<String>, String> {
     ensure_trusted_pty_caller(&webview)?;
     Ok(SESSIONS.lock().keys().cloned().collect())
+}
+
+/// Recent output for a running session, replayed by a terminal view that
+/// reattaches after a remount. Empty when the session is unknown.
+#[tauri::command]
+pub fn pty_snapshot(webview: Webview, thread_id: String) -> Result<Vec<u8>, String> {
+    ensure_trusted_pty_caller(&webview)?;
+    let sessions = SESSIONS.lock();
+    Ok(sessions
+        .get(&thread_id)
+        .map(|session| session.scrollback.lock().clone())
+        .unwrap_or_default())
 }
 
 /// Diagnostic: spawn a one-shot known-good PTY (`/bin/echo hello && exit`),

--- a/src/components/bottom-terminal-ws-bridge.test.ts
+++ b/src/components/bottom-terminal-ws-bridge.test.ts
@@ -15,3 +15,35 @@ assert.match(src, /bridge\.resize\(term\.cols,\s*term\.rows\)/, "terminal resize
 assert.match(src, /bridge\.dispose\(\)/, "WS bridge is disposed on cleanup");
 
 console.log("bottom-terminal-ws-bridge.test.ts OK");
+
+// ── Disconnect recovery (the "terminal stopped accepting input" class) ───────
+assert.match(src, /bridge\.onClose\(/, "terminal reacts to a dropped socket instead of freezing");
+assert.match(src, /terminal disconnected — reconnecting/, "drop is announced in the pane");
+assert.match(src, /const RECONNECT_DELAYS_MS = \[0, 1000, 3000\]/, "reconnect retries with capped backoff");
+assert.match(
+  src,
+  /if \(!bridge\.isOpen\) \{[\s\S]{0,260}attemptReconnect\(\);[\s\S]{0,80}return;[\s\S]{0,120}bridge\.write\(new TextEncoder\(\)\.encode\(data\)\)/,
+  "typing on a dead socket revives the terminal instead of vanishing into a no-op write",
+);
+assert.match(src, /term\.reset\(\);[\s\S]{0,120}await bridge\.reconnect\(\)/, "screen resets before reattach so the server replay paints clean");
+assert.match(src, /reason === "replaced"/, "a take-over by another window is announced, not fought with reconnects");
+
+// ── PTY lifetime is decoupled from view lifetime ──────────────────────────────
+// Unmount is usually a keepalive tab-switch remount; killing the PTY there
+// raced the next mount's pty_list and left a dead pane that ate keystrokes.
+assert.doesNotMatch(
+  src,
+  /invoke\("pty_stop"/,
+  "desktop cleanup must NOT stop the PTY — only closing the tab (ComuxView.removeSession) kills the shell",
+);
+assert.match(
+  src,
+  /pty_snapshot/,
+  "attaching to a running PTY replays the Rust scrollback ring",
+);
+assert.match(
+  src,
+  /const attachToRunning = running\.includes\(threadId\);[\s\S]{0,900}unlistenData/,
+  "snapshot replay happens before the live data listener registers",
+);
+console.log("bottom-terminal disconnect-recovery assertions: ok");

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -195,6 +195,29 @@ export function BottomTerminal({
       log("xterm opened", { cols: term.cols, rows: term.rows });
 
       let stopped = false;
+      // Attach-to-running comes first: tab switches remount this component
+      // (the keepalive container is a different React parent), and the PTY
+      // deliberately survives unmounts. Replaying the Rust-side scrollback
+      // ring BEFORE registering the live listener restores the screen instead
+      // of presenting a blank-but-alive shell. A byte that lands in the gap
+      // between snapshot and listen is lost from the view (not the shell) —
+      // acceptable for an idle tab switch.
+      const running = await bridge.invoke<string[]>("pty_list").catch((err) => {
+        log("pty_list FAILED", err);
+        return [] as string[];
+      });
+      log("pty_list →", running);
+      const attachToRunning = running.includes(threadId);
+      if (attachToRunning) {
+        const snapshot = await bridge
+          .invoke<number[]>("pty_snapshot", { threadId: threadId })
+          .catch(() => [] as number[]);
+        if (snapshot.length > 0) {
+          const bytes = new Uint8Array(snapshot);
+          term.write(bytes);
+          pushToMirror(bytes);
+        }
+      }
       const unlistenData = await bridge.listen<{
         thread_id: string;
         bytes: number[];
@@ -229,12 +252,7 @@ export function BottomTerminal({
         }).catch((err) => log("pty_write FAILED", err));
       });
 
-      const running = await bridge.invoke<string[]>("pty_list").catch((err) => {
-        log("pty_list FAILED", err);
-        return [] as string[];
-      });
-      log("pty_list →", running);
-      if (!running.includes(threadId)) {
+      if (!attachToRunning) {
         log("pty_start: invoking with projectRoot=", projectRootRef.current);
         try {
           await bridge.invoke("pty_start", {
@@ -295,7 +313,12 @@ export function BottomTerminal({
         pendingMirrorRef.current = "";
         termRef.current = null;
         term.dispose();
-        void bridge.invoke("pty_stop", { threadId: threadId });
+        // Deliberately NO pty_stop here. Unmount is usually a tab switch
+        // (keepalive reparenting), and the fire-and-forget stop raced the
+        // next mount's pty_list — losing the race attached the new terminal
+        // to a shell that was about to be SIGHUPed, a dead pane that ate
+        // keystrokes. The shell is killed exactly once, when the user closes
+        // the tab (ComuxView.removeSession).
       };
 
       if (disposed) cleanup();
@@ -351,14 +374,72 @@ export function BottomTerminal({
       const bridge = new PtyWsBridge();
       wsBridgeRef.current = bridge;
 
+      const announce = (msg: string) => {
+        term.write(msg);
+        pushToMirror(new TextEncoder().encode(msg));
+      };
+
       bridge.onData((bytes) => {
         term.write(bytes);
         pushToMirror(bytes);
       });
       bridge.onExit((code) => {
-        const exitMsg = `\r\n\x1b[2m[exit ${code}]\x1b[0m\r\n`;
-        term.write(exitMsg);
-        pushToMirror(new TextEncoder().encode(exitMsg));
+        announce(
+          `\r\n\x1b[2m[exit ${code} — press any key to start a new shell]\x1b[0m\r\n`,
+        );
+      });
+
+      // Reconnection: a dropped socket (laptop sleep, server restart, network
+      // change) used to leave a frozen pane that silently swallowed
+      // keystrokes — write() no-ops on a dead socket. Now the pane says so,
+      // retries with a short backoff, and any keypress retries again. The
+      // server keeps the PTY alive for a detach grace window and replays
+      // recent output on reattach, so a quick drop loses nothing.
+      const RECONNECT_DELAYS_MS = [0, 1000, 3000];
+      let reconnecting = false;
+      const attemptReconnect = async () => {
+        if (reconnecting || disposed) return;
+        reconnecting = true;
+        try {
+          for (const delay of RECONNECT_DELAYS_MS) {
+            if (delay > 0) {
+              await new Promise((r) => setTimeout(r, delay));
+            }
+            if (disposed) return;
+            try {
+              // The server replays its scrollback ring on reattach; reset
+              // first so the replay paints a clean screen instead of
+              // appending a duplicate of what's already visible.
+              term.reset();
+              await bridge.reconnect();
+              bridge.resize(term.cols, term.rows);
+              return;
+            } catch {
+              /* next delay */
+            }
+          }
+          announce(
+            "\r\n\x1b[2m[terminal reconnect failed — press any key to retry]\x1b[0m\r\n",
+          );
+        } finally {
+          reconnecting = false;
+        }
+      };
+
+      bridge.onClose((_code, reason) => {
+        if (disposed) return;
+        if (reason === "replaced") {
+          announce(
+            "\r\n\x1b[2m[this terminal was opened in another window — view detached]\x1b[0m\r\n",
+          );
+          return;
+        }
+        if (reason === "pty exit") {
+          // onExit already announced; a keypress starts a fresh shell.
+          return;
+        }
+        announce("\r\n\x1b[2m[terminal disconnected — reconnecting…]\x1b[0m\r\n");
+        void attemptReconnect();
       });
 
       try {
@@ -377,6 +458,12 @@ export function BottomTerminal({
       }
 
       const onDataDispose = term.onData((data) => {
+        if (!bridge.isOpen) {
+          // Dead socket (or exited shell): typing revives the terminal
+          // instead of vanishing into a no-op write.
+          void attemptReconnect();
+          return;
+        }
         bridge.write(new TextEncoder().encode(data));
       });
 

--- a/src/components/comux-view-terminal.test.ts
+++ b/src/components/comux-view-terminal.test.ts
@@ -190,3 +190,18 @@ assert.match(
 );
 
 console.log("comux-view-terminal.test.ts OK");
+
+// ── Shell-owned chords + explicit close semantics ─────────────────────────────
+// Ctrl+W is readline delete-word and Ctrl+N is next-history; hijacking them
+// for tab management closed/spawned terminals mid-keystroke.
+assert.match(
+  source,
+  /if \(e\.ctrlKey && !e\.metaKey && target\?\.closest\?\.\("\.xterm"\)\) return;/,
+  "ctrl-chords typed inside the terminal go to the shell, not tab management",
+);
+assert.match(
+  source,
+  /removeSession[\s\S]{0,900}pty_stop/,
+  "closing a tab is the one place the desktop PTY is killed",
+);
+console.log("comux terminal chord/close assertions: ok");

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -269,6 +269,20 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
         const next = prev.filter((_, i) => i !== idx);
         if (removedId) {
           setPaneSessionIds((panes) => panes.filter((id) => id !== removedId));
+          // Closing a tab is the ONLY place a desktop PTY is killed. The
+          // terminal component deliberately does not stop the shell on
+          // unmount — tab switches remount terminals through the keepalive
+          // container, and killing there raced the next mount's liveness
+          // check, leaving a dead pane that ate keystrokes.
+          const internals = (window as unknown as Record<string, unknown>)
+            .__TAURI_INTERNALS__;
+          if (internals) {
+            void import("@tauri-apps/api/core")
+              .then(({ invoke }) =>
+                invoke("pty_stop", { threadId: `cave.comux.${removedId}` }),
+              )
+              .catch(() => {});
+          }
         }
         setCurrentIdx((ci) => {
           if (next.length === 0) return 0;
@@ -360,6 +374,12 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
       if (!mod) return;
       const target = e.target as HTMLElement | null;
       if (target?.isContentEditable) return;
+      // Ctrl-chords typed inside the terminal belong to the SHELL, not to
+      // tab management: Ctrl+W is readline delete-word and Ctrl+N is
+      // next-history. Hijacking them closed/spawned tabs mid-keystroke,
+      // which read as the terminal randomly "losing the ability to type".
+      // ⌘-chords still manage tabs (macOS terminals reserve ⌘, never Ctrl).
+      if (e.ctrlKey && !e.metaKey && target?.closest?.(".xterm")) return;
       if (e.key === "n" || e.key === "N") {
         e.preventDefault();
         addSession();

--- a/src/lib/pty-ws-bridge.test.ts
+++ b/src/lib/pty-ws-bridge.test.ts
@@ -16,3 +16,19 @@ assert.match(src, /setUint16\(3,\s*rows,\s*true\)/, "resize encodes rows little-
 assert.match(src, /dispose\(\)/, "bridge exposes dispose");
 
 console.log("pty-ws-bridge.test.ts OK");
+
+// ── Disconnect resilience ─────────────────────────────────────────────────────
+// A dropped socket used to be silent: write() no-ops when not OPEN and the
+// close handler only nulled the field, so the terminal froze and ate
+// keystrokes. The bridge now surfaces established-socket closes and can
+// re-dial with its remembered parameters.
+assert.match(src, /onClose\(cb: CloseHandler\)/, "bridge surfaces post-open closes");
+assert.match(src, /reconnect\(\): Promise<void>/, "bridge can re-dial the same session");
+assert.match(src, /private lastConnect/, "reconnect reuses the original connect parameters");
+assert.match(src, /get isOpen\(\)/, "callers can check liveness before writing");
+assert.match(
+  src,
+  /const wasCurrent = this\.ws === ws;[\s\S]{0,700}if \(wasCurrent\) \{\s*\n\s*for \(const cb of this\.closeHandlers\) cb\(event\.code, event\.reason \?\? ""\);/,
+  "close handlers fire only for the bridge's current socket — dispose() nulls ws first so intentional teardown stays silent",
+);
+console.log("pty-ws-bridge reconnect assertions: ok");

--- a/src/lib/pty-ws-bridge.ts
+++ b/src/lib/pty-ws-bridge.ts
@@ -1,10 +1,18 @@
 type DataHandler = (bytes: Uint8Array) => void;
 type ExitHandler = (code: number) => void;
+type CloseHandler = (code: number, reason: string) => void;
 
 export class PtyWsBridge {
   private ws: WebSocket | null = null;
   private dataHandlers: DataHandler[] = [];
   private exitHandlers: ExitHandler[] = [];
+  private closeHandlers: CloseHandler[] = [];
+  private lastConnect: {
+    threadId: string;
+    cols: number;
+    rows: number;
+    projectRoot?: string;
+  } | null = null;
 
   onData(cb: DataHandler): void {
     this.dataHandlers.push(cb);
@@ -14,16 +22,46 @@ export class PtyWsBridge {
     this.exitHandlers.push(cb);
   }
 
+  /** Fires when an ESTABLISHED socket closes (never for connect failures —
+   *  those reject connect() — and never for our own dispose()). The terminal
+   *  uses this to tell the user and to drive reconnection; without it a
+   *  dropped socket (sleep/wake, server restart) left a frozen pane that
+   *  silently swallowed keystrokes. */
+  onClose(cb: CloseHandler): void {
+    this.closeHandlers.push(cb);
+  }
+
+  get isOpen(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
   connect(threadId: string, cols: number, rows: number, projectRoot?: string): Promise<void> {
+    this.lastConnect = { threadId, cols, rows, projectRoot };
+    return this.open();
+  }
+
+  /** Re-dial with the parameters from the last connect(). The server adopts
+   *  a still-running PTY for the same threadId (replaying recent output) or
+   *  spawns a fresh shell if it was lost — either way typing works again. */
+  reconnect(): Promise<void> {
+    if (!this.lastConnect) {
+      return Promise.reject(new Error("reconnect before connect"));
+    }
+    return this.open();
+  }
+
+  private open(): Promise<void> {
+    const target = this.lastConnect;
+    if (!target) return Promise.reject(new Error("no connect parameters"));
     return new Promise((resolve, reject) => {
       const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
       const params = new URLSearchParams({
-        threadId,
-        cols: String(cols),
-        rows: String(rows),
+        threadId: target.threadId,
+        cols: String(target.cols),
+        rows: String(target.rows),
       });
-      if (projectRoot) {
-        params.set("projectRoot", projectRoot);
+      if (target.projectRoot) {
+        params.set("projectRoot", target.projectRoot);
       }
 
       const url = `${proto}//${window.location.host}/api/pty-ws?${params}`;
@@ -57,7 +95,8 @@ export class PtyWsBridge {
         }
       });
       ws.addEventListener("close", (event) => {
-        if (this.ws === ws) {
+        const wasCurrent = this.ws === ws;
+        if (wasCurrent) {
           this.ws = null;
         }
         if (!settled) {
@@ -69,6 +108,12 @@ export class PtyWsBridge {
                 "Restart the app; if this is a remote/mobile session, re-open it from a fresh handoff link.",
             ),
           );
+          return;
+        }
+        // dispose() nulls this.ws before closing, so an intentional teardown
+        // never reaches the handlers.
+        if (wasCurrent) {
+          for (const cb of this.closeHandlers) cb(event.code, event.reason ?? "");
         }
       });
     });
@@ -95,6 +140,7 @@ export class PtyWsBridge {
   dispose(): void {
     this.dataHandlers = [];
     this.exitHandlers = [];
+    this.closeHandlers = [];
     const ws = this.ws;
     this.ws = null;
     if (ws && ws.readyState !== WebSocket.CLOSED) {

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -126,3 +126,19 @@ assert.match(
 );
 
 console.log("server-pty-ws.test.ts OK");
+
+// ── Detach grace + adopt (PTY survives reconnects) ────────────────────────────
+// Killing the shell on every socket close/replace destroyed terminal state on
+// remounts, reloads, and sleep/wake — and a frozen client then ate keystrokes.
+assert.match(src, /const DETACH_GRACE_MS = 60_000/, "detached PTYs survive for a grace window");
+assert.match(src, /function adoptSession\(/, "a reconnect with the same threadId adopts the running PTY");
+assert.match(src, /previous\.close\(1000, "replaced"\)/, "the replaced socket is told why it closed");
+assert.match(src, /const SCROLLBACK_LIMIT_BYTES = 256 \* 1024/, "replay ring is bounded");
+assert.match(src, /session\.ws = null;[\s\S]{0,500}DETACH_GRACE_MS/, "socket close detaches instead of killing");
+assert.doesNotMatch(
+  src,
+  /ws\.on\("close", \(\) => \{[\s\S]{0,200}session\.pty\.kill\(\)/,
+  "close handler must not kill the PTY inline — the grace timer reaps abandoned shells",
+);
+assert.match(src, /if \(session\.ws\) sendPtyData\(session\.ws, data\)/, "output keeps flowing into the ring while detached");
+console.log("server pty detach/adopt assertions: ok");


### PR DESCRIPTION
## The bug

"The terminal keeps losing the ability to type and is just being finicky." Three root causes, found by tracing the input path end-to-end:

1. **Readline chords were hijacked.** The tab-management hotkeys accepted `metaKey || ctrlKey`, and the guard only excluded `contentEditable` — xterm's input is a *textarea*. So **Ctrl+W (delete-word) closed the terminal tab** and **Ctrl+N (next-history) spawned a new one**, mid-keystroke.
2. **The PTY died on every remount.** Tab switches reparent terminals through the keepalive container (React unmount/remount); unmount fired a fire-and-forget `pty_stop` that raced the next mount's `pty_list`. Lose the race → the new view attaches to a shell that's about to be SIGHUPed → dead pane that eats keystrokes. Win the race → your shell restarts from scratch on every tab switch.
3. **A dropped websocket froze the pane silently.** `write()` no-ops on a dead socket; the close handler only nulled the field. Laptop sleep or a server restart = frozen terminal, no notice, no reconnect — and clicking (refocus) can't fix it.

## The fix

- **Chords:** Ctrl-chords originating inside `.xterm` go to the shell; ⌘-chords still manage tabs (macOS convention — terminals reserve ⌘, never Ctrl).
- **PTY lifetime ≠ view lifetime:**
  - Desktop: unmount no longer stops the PTY; **closing the tab** (`removeSession`) is the one kill site. Reattach replays a bounded (256 KiB) Rust-side scrollback ring via new `pty_snapshot` command.
  - WS server: socket close **detaches** (60s grace, output keeps ringing) instead of killing; a reconnect for the same `threadId` **adopts** the running PTY, tells the replaced socket why, resizes, and replays the ring.
- **Bridge resilience:** `PtyWsBridge` gains `onClose` (established-socket closes only — dispose stays silent), `reconnect()` (re-dials with remembered params), `isOpen`. The terminal announces drops, retries with capped backoff (0/1s/3s), and **any keypress revives a dead pane** — including after shell `exit`, where the notice now says so.

## Verified live (Playwright, WS path, real shell)

- `Ctrl+W` deletes a word and the pane **survives**; `Ctrl+N` spawns nothing from inside the terminal; `Ctrl+C` still interrupts (`sleep 30` → SIGINT → usable prompt)
- `export CAVE_MARKER=… → page reload → echo $CAVE_MARKER` → **marker survives** and pre-reload scrollback repaints (server adopt + replay)
- Server killed mid-session → `[terminal disconnected — reconnecting…]` then `[reconnect failed — press any key to retry]` render in-pane; after restart the terminal is fully interactive
- Full `test:app` + `test:api` green; new source assertions lock every behavior above; `cargo check` clean

**Honest scope note:** the desktop Tauri IPC path carries the same lifecycle change (no kill on unmount + snapshot replay) and compiles, but was not exercised end-to-end here — needs an eyeball in the packaged app. One dev-only artifact observed during verification: a dev-server restart triggers Next HMR's full-page reload, which remounts the terminal with a fresh shell (server memory was lost anyway); production/packaged builds have no HMR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)