### PR TITLE
fix(workflows): reattach canvas edge arrows under screen magnification

### DIFF
--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -68,6 +68,11 @@ assert.match(
 );
 assert.match(css, /\.workflow-studio-shell/, "workflow CSS should style the studio shell");
 assert.match(css, /@media \(max-width: 860px\)/, "workflow CSS should include mobile studio layout");
+assert.match(
+  css,
+  /\.workflow-canvas \.react-flow \{[\s\S]{0,300}zoom:\s*calc\(1 \/ var\(--cave-screen-scale\)\)[\s\S]{0,160}width:\s*calc\(100% \* var\(--cave-screen-scale\)\)[\s\S]{0,80}height:\s*calc\(100% \* var\(--cave-screen-scale\)\)/,
+  "Workflow canvas must cancel the app-wide screen-scale zoom inside React Flow — its handle measurement ignores ancestor CSS zoom, so at 110/125/150% edge arrows detach from their handles",
+);
 
 // --- Studio v2: visual builder, runs, assignments ---
 

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -965,6 +965,18 @@
 
 /* ---- Studio final touch: legible edges + dark React Flow chrome ---- */
 
+/* React Flow anchors edges by dividing getBoundingClientRect() deltas by its
+   own viewport transform only — the app-wide screen-scale `zoom` (globals.css
+   body rule) is not in that divisor, so at 110/125/150% every edge anchor
+   lands past its handle and arrows float mid-gap. Cancel the zoom inside the
+   flow so it measures at 1:1, and re-grow the box so it still fills the
+   canvas after its own zoom shrinks it. */
+.workflow-canvas .react-flow {
+  zoom: calc(1 / var(--cave-screen-scale));
+  width: calc(100% * var(--cave-screen-scale));
+  height: calc(100% * var(--cave-screen-scale));
+}
+
 .workflow-canvas .react-flow__edge-path {
   stroke: color-mix(in oklch, var(--accent-presence) 65%, transparent);
   stroke-width: 1.6;


### PR DESCRIPTION
## Problem

At 110/125/150% screen scale (Settings → Appearance), workflow canvas edges render as floating arrow stubs mid-gap instead of lines connecting the step handles:

| Broken (125%) | Fixed (125%) |
|---|---|
| arrow stub floats ~40px past the source handle, slightly below center | line spans handle to handle |

## Root cause

React Flow computes edge anchors from handle `getBoundingClientRect()` deltas divided by **its own viewport transform only** (`@xyflow/system` `getHandleBounds` → `updateNodeInternals` derives the divisor from the viewport's computed `transform` matrix). The app-wide `zoom: var(--cave-screen-scale)` on `body` (globals.css) inflates every rect by the scale factor, so each stored handle offset — and therefore each edge anchor — lands `scale ×` past its handle: at 125%, the source anchor sits at `node.x + 172×1.25` instead of `node.x + 172`, and `node.y + 37×1.25` instead of vertical center. Latest `@xyflow/react` 12.11.0 has no CSS-zoom compensation.

## Fix

Cancel the zoom inside the flow and re-grow the box so it still fills the canvas:

```css
.workflow-canvas .react-flow {
  zoom: calc(1 / var(--cave-screen-scale));
  width: calc(100% * var(--cave-screen-scale));
  height: calc(100% * var(--cave-screen-scale));
}
```

Effective zoom inside the canvas is 1 at every scale, so all of React Flow's rect-based math (edges, drags, connects) is self-consistent. No-op at 100%.

## Verification

Playwright against the dev app with `cave:screen-scale` persisted before load, Chromium **and** WebKit, at 100/125/150%: edge paths start exactly at the source handle (`M255.5 117.25`) in all six combinations; before the fix at 125% they started at `M297.625 125.4375`. Flow box fills the canvas at every scale (flow width = canvas width − border). `pnpm run test:app` passes; added a regression assertion to `workflow-studio.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)