### PR TITLE
polish(onboarding): drop the OpenClaw clause from the create-familiar confirm

### DIFF
--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -424,7 +424,6 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   const chatHarnesses = harnesses.filter((adapter) => adapter.chatSupported);
   const selectedHarness =
     chatHarnesses.find((adapter) => adapter.id === selectedHarnessId) ?? null;
-  const hasExistingOpenClawAgents = openclawAgents.length > 0;
 
   const copyText = async (text: string): Promise<boolean> => {
     try {
@@ -1083,7 +1082,6 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                             selectedAgentId={selectedAgentId}
                             agentsLoading={agentsLoading}
                             agentsError={agentsError}
-                            hasExistingOpenClawAgents={hasExistingOpenClawAgents}
                             familiarName={familiarName}
                             familiarRole={familiarRole}
                             familiarGlyph={familiarGlyph}
@@ -1527,7 +1525,6 @@ function StepFamiliar(props: {
   selectedAgentId: string | null;
   agentsLoading: boolean;
   agentsError: string | null;
-  hasExistingOpenClawAgents: boolean;
   familiarName: string;
   familiarRole: string;
   familiarGlyph: string;
@@ -1564,7 +1561,6 @@ function StepFamiliar(props: {
     selectedAgentId,
     agentsLoading,
     agentsError,
-    hasExistingOpenClawAgents,
     familiarName,
     familiarRole,
     familiarGlyph,
@@ -1862,9 +1858,6 @@ function StepFamiliar(props: {
               </span>{" "}harness
             </>
           ) : null}
-          {hasExistingOpenClawAgents
-            ? ", not a connection to one of the existing OpenClaw agents listed alongside"
-            : ""}
           .
         </span>
       </label>


### PR DESCRIPTION
## What

Re-applies the edit parked during today's pull-main switchover (`park/onboarding-overlay-edit-2026-06-12` → `41f80ac`) onto current `main`, as a clean 7-line deletion instead of restoring the stale-base copy (which would have reverted ~97 lines of #477/#479).

Removes `hasExistingOpenClawAgents` (derived flag, prop, type, destructure) and the conditional confirm-checkbox tail — the create-familiar confirmation now reads simply *"I understand this creates a new Coven familiar bound to the X harness."* The familiar step's Option A / Option B layout already makes the new-vs-connect distinction visually.

No other references to the symbol exist; `tsc --noEmit` clean; onboarding-guided-steps + onboarding-polish tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)