### PR TITLE
polish(workflows): compact engine-consistent studio selects

### DIFF
--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -672,6 +672,19 @@
   color: var(--text-primary, inherit);
 }
 
+/* Compact, engine-consistent selects: native appearance ignores the field
+   padding in WebKit and inflates it in Chromium, so the closed control reads
+   taller than the rows around it. Flatten to a styled control with our own
+   chevron; height lands at ~24px to match the attachment list rows. */
+.workflow-field select {
+  appearance: none;
+  padding: 3px 26px 3px 8px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='5' viewBox='0 0 8 5'%3E%3Cpath d='M0 0l4 5 4-5z' fill='%238a8a96'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  cursor: pointer;
+}
+
 .workflow-field input:focus,
 .workflow-field select:focus {
   outline: none;


### PR DESCRIPTION
## Problem

The familiar-binding dropdown in the Workflow Studio attachments panel (Val's report: "dropdown selection is too tall") — and every `.workflow-field select` — rendered as a native control with engine-divergent metrics:

- **Chromium**: padding applied → 30px tall, chunkier than the 26px attachment rows beside it
- **WebKit** (Tauri webview): field padding ignored on `appearance: auto` selects → OS-styled 21px control that doesn't match the dark theme

## Fix

Flatten the studio selects (`appearance: none`), tighten padding to `3px 26px 3px 8px`, and draw our own chevron via data-URI SVG. Closed control is now a uniform **26px in both engines**, matching the attachment list rows. Covers the attachments familiar binding, inspector step-kind, and schedule cadence selects via the shared rule.

Verified by Playwright measurement in Chromium and WebKit (26px, padding honored, both) plus panel screenshots. `pnpm run test:app` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)