### PR TITLE
Potential fix for code scanning alert no. 17: Uncontrolled data used in path expression

### DIFF
--- a/src/app/api/library/graph/route.ts
+++ b/src/app/api/library/graph/route.ts
@@ -104,13 +104,21 @@ async function readGraphById(id: string): Promise<GraphifyResult | null> {
   }
 
   const graphsRoot = path.resolve(GRAPHS_DIR);
-  const candidatePath = path.resolve(graphsRoot, `${id}.json`);
-  if (!(candidatePath === graphsRoot || candidatePath.startsWith(`${graphsRoot}${path.sep}`))) {
-    return null;
-  }
+  const expectedFile = `${id}.json`;
 
   try {
-    const raw = await fs.readFile(candidatePath, "utf-8");
+    const files = await fs.readdir(graphsRoot);
+    const matchedFile = files.find((file) => file === expectedFile);
+    if (!matchedFile) {
+      return null;
+    }
+
+    const safePath = path.resolve(graphsRoot, matchedFile);
+    if (!(safePath === graphsRoot || safePath.startsWith(`${graphsRoot}${path.sep}`))) {
+      return null;
+    }
+
+    const raw = await fs.readFile(safePath, "utf-8");
     return withGraphRunSnapshots(JSON.parse(raw) as GraphifyResult);
   } catch {
     return null;

--- a/src/app/api/library/graph/route.ts
+++ b/src/app/api/library/graph/route.ts
@@ -94,9 +94,23 @@ async function readAllGraphMeta(): Promise<Omit<GraphifyResult, "graphJson" | "r
   return metas.sort((a, b) => (a.generatedAt < b.generatedAt ? 1 : -1));
 }
 
+function isSafeGraphId(id: string): boolean {
+  return /^[A-Za-z0-9_-]+$/.test(id);
+}
+
 async function readGraphById(id: string): Promise<GraphifyResult | null> {
+  if (!isSafeGraphId(id)) {
+    return null;
+  }
+
+  const graphsRoot = path.resolve(GRAPHS_DIR);
+  const candidatePath = path.resolve(graphsRoot, `${id}.json`);
+  if (!(candidatePath === graphsRoot || candidatePath.startsWith(`${graphsRoot}${path.sep}`))) {
+    return null;
+  }
+
   try {
-    const raw = await fs.readFile(path.join(GRAPHS_DIR, `${id}.json`), "utf-8");
+    const raw = await fs.readFile(candidatePath, "utf-8");
     return withGraphRunSnapshots(JSON.parse(raw) as GraphifyResult);
   } catch {
     return null;


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/17](https://github.com/OpenCoven/coven-cave/security/code-scanning/17)

The best fix is to enforce a strict allowlist for `id` (since this endpoint expects a simple graph identifier, not a multi-segment path), and reject any `id` not matching safe filename characters. Then safely construct and verify the resolved path remains under `GRAPHS_DIR` before reading.

In `src/app/api/library/graph/route.ts`:
1. Add a small validator for graph IDs (e.g., `^[A-Za-z0-9_-]+$`).
2. In `readGraphById`, return `null` for invalid IDs.
3. Resolve the candidate file path with `path.resolve` and ensure it starts with `path.resolve(GRAPHS_DIR) + path.sep` (or equals base dir edge-case-safe logic), then read only if valid.

This preserves existing behavior (`null` => 404 in caller) while eliminating traversal.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
