### PR TITLE
Potential fix for code scanning alert no. 30: Uncontrolled data used in path expression

### DIFF
--- a/src/app/api/roles/workflows/route.ts
+++ b/src/app/api/roles/workflows/route.ts
@@ -11,11 +11,16 @@ function safeSegment(value: string): boolean {
 }
 
 async function resolveRoleMd(roleId: string, familiar: string): Promise<string | null> {
-  const candidates = [
-    path.join(await familiarWorkspace(familiar), "roles", roleId, "ROLE.md"),
-    path.join(covenHome(), "roles", roleId, "ROLE.md"),
+  const roots = [
+    path.resolve(await familiarWorkspace(familiar), "roles"),
+    path.resolve(covenHome(), "roles"),
   ];
-  for (const candidate of candidates) {
+  for (const root of roots) {
+    const candidate = path.resolve(root, roleId, "ROLE.md");
+    const rel = path.relative(root, candidate);
+    if (rel.startsWith("..") || path.isAbsolute(rel)) {
+      continue;
+    }
     try {
       await stat(candidate);
       return candidate;
@@ -44,8 +49,8 @@ export async function POST(req: Request) {
       { status: 400 },
     );
   }
-  if (!safeSegment(roleId) || !safeSegment(workflowId)) {
-    return NextResponse.json({ ok: false, error: "unsafe roleId or workflowId" }, { status: 400 });
+  if (!safeSegment(roleId) || !safeSegment(familiar) || !safeSegment(workflowId)) {
+    return NextResponse.json({ ok: false, error: "unsafe roleId, familiar, or workflowId" }, { status: 400 });
   }
 
   const roleMdPath = await resolveRoleMd(roleId, familiar);


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/30](https://github.com/OpenCoven/coven-cave/security/code-scanning/30)

General fix: canonicalize candidate paths and enforce they remain under approved root directories before any file IO. Also validate all user-controlled path segments, not just some.

Best fix in this file:
1. Validate `familiar` with `safeSegment` alongside `roleId`/`workflowId`.
2. In `resolveRoleMd`, compute trusted roots (`familiarWorkspace(familiar)/roles` and `covenHome()/roles`) using `path.resolve`.
3. For each candidate, build with `path.resolve(root, roleId, "ROLE.md")`, then verify containment via `path.relative(root, candidate)` (must not be absolute and must not start with `..`).
4. Only `stat` and return candidates that pass containment.

This keeps behavior (find first existing ROLE.md in familiar workspace, else coven home) while ensuring no uncontrolled path can escape intended roots.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
