### PR TITLE
chore(release): cut 0.0.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.75] - 2026-06-12
+
+Cave gets safer library/workflow file handling, live onboarding jobs, and clearer session provenance.
+
+### Added
+- **Background onboarding install jobs** — setup actions now run as resumable jobs with live progress, reducing stuck setup states and making install status visible (#484, #486).
+- **Session initiator provenance** — chat sessions and Coven Floor traces now show who started a session, such as `Started by Valentina / Telegram`, `Started by Kitty`, or automation like cron/heartbeat, without exposing raw IDs or paths (#478).
+- **Palette link saves** — `/save <url>` now offers a destination choice for saved links (#480).
+- **Security policy** — the repository now includes `SECURITY.md`.
+
+### Changed
+- **Workflow Studio polish** — compact engine-consistent selects and tighter panel trigger alignment make workflow editing denser and steadier (#476, #485).
+- **Onboarding copy** — familiar creation confirmation drops the extra OpenClaw wording and setup buttons provide clearer live feedback (#479, #483).
+
+### Fixed
+- **Terminal stability** — shell-owned keyboard chords, PTY survival, and reconnect handling stop terminal input from being lost (#481).
+- **Workflow canvas arrows** — edge arrows render correctly under screen magnification (#482).
+- **Onboarding retry behavior** — harness fetch retries while empty so runtime setup does not strand (#477).
+- **Library and workflow path hardening** — CodeQL path alerts are fixed by constraining saved graph IDs and role/workflow path segments before file reads/writes (#487, #488).
+
 ## [0.0.74] - 2026-06-12
 
 The terminal works again in the packaged app.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "private": true,
   "scripts": {
     "dev": "node --experimental-strip-types server.ts",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.74"
+version = "0.0.75"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.74"
+version = "0.0.75"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- bump package, Tauri, and Cargo versions to 0.0.75
- add the 0.0.75 changelog entry covering post-0.0.74 onboarding, provenance, terminal, workflow, and security fixes
- verify release notes render for v0.0.75

## Verification
- pnpm typecheck
- pnpm test:api
- pnpm test:app
- pnpm build
- node --experimental-strip-types src/lib/app-version.test.ts
- node scripts/release-notes.test.mjs
- bash scripts/release-notes.sh v0.0.75 v0.0.74
- git diff --check