### PR TITLE
Potential fix for code scanning alert no. 10: Uncontrolled data used in path expression

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -123,9 +123,16 @@ function normalizePath(p: string): string {
 async function resolveCwd(requested?: string): Promise<string> {
   if (requested) {
     try {
+      const safeRoot = await realpath(homedir());
       const normalized = normalizePath(requested);
-      const s = await stat(normalized);
-      if (s.isDirectory()) return normalized;
+      const candidateResolved = path.resolve(normalized);
+      const candidateReal = await realpath(candidateResolved);
+      const withinSafeRoot =
+        candidateReal === safeRoot ||
+        candidateReal.startsWith(safeRoot.endsWith(path.sep) ? safeRoot : safeRoot + path.sep);
+      if (!withinSafeRoot) return homedir();
+      const s = await stat(candidateReal);
+      if (s.isDirectory()) return candidateReal;
     } catch {
       /* fall through to homedir */
     }

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -125,7 +125,13 @@ async function resolveCwd(requested?: string): Promise<string> {
     try {
       const safeRoot = await realpath(homedir());
       const normalized = normalizePath(requested);
-      const candidateResolved = path.resolve(normalized);
+      const candidateResolved = path.resolve(safeRoot, normalized);
+      const withinSafeRootResolved =
+        candidateResolved === safeRoot ||
+        candidateResolved.startsWith(
+          safeRoot.endsWith(path.sep) ? safeRoot : safeRoot + path.sep,
+        );
+      if (!withinSafeRootResolved) return homedir();
       const candidateReal = await realpath(candidateResolved);
       const withinSafeRoot =
         candidateReal === safeRoot ||

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -54,6 +54,7 @@ import {
   type TurnUsage,
 } from "@/lib/usage-format";
 import type { ChatResponseMetadata } from "@/lib/chat-response-metadata";
+import { resolveAllowedProjectPath } from "@/lib/server/project-paths";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -123,22 +124,12 @@ function normalizePath(p: string): string {
 async function resolveCwd(requested?: string): Promise<string> {
   if (requested) {
     try {
-      const safeRoot = await realpath(homedir());
       const normalized = normalizePath(requested);
-      const candidateResolved = path.resolve(safeRoot, normalized);
-      const withinSafeRootResolved =
-        candidateResolved === safeRoot ||
-        candidateResolved.startsWith(
-          safeRoot.endsWith(path.sep) ? safeRoot : safeRoot + path.sep,
-        );
-      if (!withinSafeRootResolved) return homedir();
-      const candidateReal = await realpath(candidateResolved);
-      const withinSafeRoot =
-        candidateReal === safeRoot ||
-        candidateReal.startsWith(safeRoot.endsWith(path.sep) ? safeRoot : safeRoot + path.sep);
-      if (!withinSafeRoot) return homedir();
-      const s = await stat(candidateReal);
-      if (s.isDirectory()) return candidateReal;
+      const allowed = resolveAllowedProjectPath(normalized);
+      if (allowed !== null) {
+        const s = await stat(allowed);
+        if (s.isDirectory()) return allowed;
+      }
     } catch {
       /* fall through to homedir */
     }


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/10](https://github.com/OpenCoven/coven-cave/security/code-scanning/10)

General fix: validate and constrain user-provided paths before using them in filesystem APIs. For this case, canonicalize the candidate path and enforce it is under an allowlisted root.

Best fix in this file: harden `resolveCwd` so `requested` is resolved with `path.resolve`, canonicalized via `realpath`, and checked to be within a safe root (use `homedir()` as the root, since fallback already uses it and this avoids changing behavior outside shown code). Then call `stat()` only after validation passes. Also ensure prefix checking is path-segment safe.

Edits needed in `src/app/api/chat/send/route.ts`:
- In `resolveCwd`, replace direct `stat(normalized)` flow with:
  - `safeRoot = await realpath(homedir())`
  - `candidateResolved = path.resolve(normalizePath(requested))`
  - `candidateReal = await realpath(candidateResolved)`
  - verify `candidateReal === safeRoot || candidateReal.startsWith(safeRoot + path.sep)`
  - only then `stat(candidateReal)` and return it if directory
  - otherwise fall through to `homedir()` fallback
- No new imports required (`realpath` and `path` are already imported).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
