### PR TITLE
Potential fix for code scanning alert no. 14: Uncontrolled data used in path expression

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -125,9 +125,19 @@ async function resolveCwd(requested?: string): Promise<string> {
   if (requested) {
     try {
       const normalized = normalizePath(requested);
-      const s = await stat(normalized);
+      const candidate = path.resolve(normalized);
+      const relToHome = path.relative(homeRoot, candidate);
+      if (
+        relToHome === ".." ||
+        relToHome.startsWith(".." + path.sep) ||
+        path.isAbsolute(relToHome) ||
+        relToHome.split(path.sep).includes("..")
+      ) {
+        return homeRoot;
+      }
+      const s = await stat(candidate);
       if (s.isDirectory()) {
-        const resolved = await realpath(normalized);
+        const resolved = await realpath(candidate);
         if (
           resolved === homeRoot ||
           resolved.startsWith(homeRoot + path.sep)

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -121,16 +121,25 @@ function normalizePath(p: string): string {
 }
 
 async function resolveCwd(requested?: string): Promise<string> {
+  const homeRoot = await realpath(homedir());
   if (requested) {
     try {
       const normalized = normalizePath(requested);
       const s = await stat(normalized);
-      if (s.isDirectory()) return normalized;
+      if (s.isDirectory()) {
+        const resolved = await realpath(normalized);
+        if (
+          resolved === homeRoot ||
+          resolved.startsWith(homeRoot + path.sep)
+        ) {
+          return resolved;
+        }
+      }
     } catch {
       /* fall through to homedir */
     }
   }
-  return homedir();
+  return homeRoot;
 }
 
 /**


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/14](https://github.com/OpenCoven/coven-cave/security/code-scanning/14)

General fix: canonicalize and validate user-provided paths against a trusted root before using them as filesystem/process paths. For `cwd`, resolve symlinks (`realpath`) and ensure the resulting absolute path is inside an allowed base directory.

Best fix in this file: strengthen `resolveCwd` so when `requested` is provided it:
1. normalizes input (`normalizePath`),
2. verifies it is a directory,
3. resolves to canonical path with `realpath`,
4. resolves canonical `homedir()` as safe root,
5. allows only paths equal to home root or under it (`startsWith(homeRoot + path.sep)`),
6. otherwise falls back to `homedir()`.

This preserves existing behavior (valid dirs still work) but limits user-controlled `projectRoot` to a safe root and removes traversal/symlink bypass risk.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
