### PR TITLE
Potential fix for code scanning alert no. 8: Server-side request forgery

### DIFF
--- a/src/lib/title-enricher.ts
+++ b/src/lib/title-enricher.ts
@@ -38,17 +38,34 @@ function titleFromPath(url: URL): string {
   return last ? slugToTitle(last) : domainFrom(url);
 }
 
+function isValidGitHubOwnerOrRepoSegment(value: string): boolean {
+  if (!value) return false;
+  if (value === "." || value === "..") return false;
+  // Conservative allowlist for a single path segment.
+  return /^[A-Za-z0-9._-]+$/.test(value);
+}
+
+function isValidGitHubIssueOrPullNumber(value: string | undefined): value is string {
+  return typeof value === "string" && /^\d+$/.test(value);
+}
+
 // ── GitHub API ───────────────────────────────────────────────────────────────
 
 async function enrichGitHub(url: URL): Promise<EnrichedMeta | null> {
   const parts = url.pathname.replace(/^\//, "").split("/");
   if (parts.length < 2) return null;
   const [owner, repo, section, num] = parts;
+  if (!isValidGitHubOwnerOrRepoSegment(owner) || !isValidGitHubOwnerOrRepoSegment(repo)) return null;
+
+  const safeOwner = encodeURIComponent(owner);
+  const safeRepo = encodeURIComponent(repo);
 
   try {
     if (section === "issues" || section === "pull") {
+      if (!isValidGitHubIssueOrPullNumber(num)) return null;
       const kind = section === "issues" ? "issues" : "pulls";
-      const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/${kind}/${num}`, {
+      const safeNum = encodeURIComponent(num);
+      const res = await fetch(`https://api.github.com/repos/${safeOwner}/${safeRepo}/${kind}/${safeNum}`, {
         headers: { Accept: "application/vnd.github+json", "User-Agent": "coven-cave/1.0" },
         signal: AbortSignal.timeout(4000),
       });
@@ -60,7 +77,7 @@ async function enrichGitHub(url: URL): Promise<EnrichedMeta | null> {
         };
       }
     } else {
-      const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`, {
+      const res = await fetch(`https://api.github.com/repos/${safeOwner}/${safeRepo}`, {
         headers: { Accept: "application/vnd.github+json", "User-Agent": "coven-cave/1.0" },
         signal: AbortSignal.timeout(4000),
       });


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/8](https://github.com/OpenCoven/coven-cave/security/code-scanning/8)

General fix: ensure any user-derived URL components used in outbound requests are validated against a strict allowlist format and URL-encoded per path segment before interpolation.

Best fix here (single-file, minimal behavior change): in `src/lib/title-enricher.ts` inside `enrichGitHub`, validate `owner`, `repo`, and optional numeric item id before constructing GitHub API URLs. If invalid, return `null` (best-effort behavior already used). Build URLs with `encodeURIComponent` on each segment (`safeOwner`, `safeRepo`, `safeNum`) so user input cannot alter path structure.

Changes needed:
- Add helper validators near existing helpers:
  - `isValidGitHubOwnerOrRepoSegment(value: string): boolean`
  - `isValidGitHubIssueOrPullNumber(value: string | undefined): value is string`
- Update `enrichGitHub` request construction to use validated+encoded segments.
- Keep existing functionality: still enriches valid GitHub repos/issues/PRs and falls back silently on invalid inputs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
