### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -103,9 +103,25 @@ export type BrowserTab = {
 function normalizeUrl(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) return HOME_URL;
-  if (/^https?:\/\//i.test(trimmed)) return trimmed;
-  if (/^localhost(:\d+)?(\/.*)?$/.test(trimmed)) return `http://${trimmed}`;
-  if (/^[a-z0-9-]+\.[a-z]{2,}/i.test(trimmed)) return `https://${trimmed}`;
+
+  // Preserve existing convenience behavior first.
+  let candidate = trimmed;
+  if (/^localhost(:\d+)?(\/.*)?$/i.test(trimmed)) {
+    candidate = `http://${trimmed}`;
+  } else if (/^[a-z0-9-]+\.[a-z]{2,}/i.test(trimmed) && !/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) {
+    candidate = `https://${trimmed}`;
+  }
+
+  // Only allow http(s) URLs to reach the iframe src.
+  try {
+    const parsed = new URL(candidate);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.toString();
+    }
+  } catch {
+    // fall through to safe search
+  }
+
   return `https://www.google.com/search?q=${encodeURIComponent(trimmed)}`;
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/5](https://github.com/OpenCoven/coven-cave/security/code-scanning/5)

To fix this safely without changing intended functionality, enforce a strict URL policy in `normalizeUrl` so only `http:` and `https:` are ever returned for direct navigation targets. Any other input (including explicit non-http(s) schemes or malformed values) should be converted to a safe search URL. This preserves UX (“search or enter address”) while preventing unsafe schemes from reaching the iframe `src`.

Best single fix in this file:
- Update `normalizeUrl(raw: string)` in `src/components/browser-pane.tsx` to:
  - trim input,
  - preserve existing localhost/domain convenience handling,
  - parse candidate URLs with `new URL(...)`,
  - allow only `http:` / `https:`,
  - otherwise fall back to `https://www.google.com/search?q=...`.
- No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
