### PR TITLE
Potential fix for code scanning alert no. 11: Uncontrolled data used in path expression

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -170,10 +170,17 @@ async function resolveFamiliarWorkspace(
   if (!/^[a-z0-9_-]+$/i.test(familiarId)) return undefined;
   const candidate = await familiarWorkspace(familiarId);
   try {
-    const s = await stat(candidate);
-    if (s.isDirectory()) return candidate;
+    const safeRoot = await realpath(path.join(covenHome(), "familiars"));
+    const resolvedCandidate = await realpath(candidate);
+    const rootPrefix = safeRoot.endsWith(path.sep) ? safeRoot : `${safeRoot}${path.sep}`;
+    if (resolvedCandidate !== safeRoot && !resolvedCandidate.startsWith(rootPrefix)) {
+      return undefined;
+    }
+
+    const s = await stat(resolvedCandidate);
+    if (s.isDirectory()) return resolvedCandidate;
   } catch {
-    /* not found */
+    /* not found or outside allowed root */
   }
   return undefined;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/11](https://github.com/OpenCoven/coven-cave/security/code-scanning/11)

Use root-containment validation after resolving the candidate path:

1. Keep the existing `familiarId` slug validation.
2. Resolve both the trusted root (`covenHome()/familiars`) and the candidate via `realpath(...)`.
3. Ensure the resolved candidate is inside the resolved root using a path-prefix check with separator safety.
4. Only then call `stat` and return the path when it is a directory.

Best place: `resolveFamiliarWorkspace` in `src/app/api/chat/send/route.ts` (lines around 166–179).  
No functional behavior change for valid in-root familiar workspaces; out-of-root configured paths are rejected, which is the intended security hardening.

No new methods/imports are needed (both `realpath` and `path` are already imported).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
