### PR TITLE
Potential fix for code scanning alert no. 12: Uncontrolled data used in path expression

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -813,13 +813,16 @@ export async function POST(req: Request) {
   const imageFilePaths = imagesSupported
     ? await writeImageAttachmentsToTemp(attachments)
     : new Map<number, string>();
+  const resolvedFamiliarWorkspace = !sshRuntime
+    ? await resolveFamiliarWorkspace(body.familiarId)
+    : undefined;
   // @-mentioned files share the image-delivery constraint: only local
   // coven-run harnesses can Read this machine's filesystem, so bridges and
   // SSH runtimes never get a block of unreachable absolute paths.
   const mentionedFiles = imagesSupported
     ? await resolveMentionedFiles(
         body.mentionedFiles,
-        familiarWorkspace(body.familiarId),
+        resolvedFamiliarWorkspace,
       )
     : [];
 
@@ -873,8 +876,8 @@ export async function POST(req: Request) {
   // generic CLI identity. A resumed conversation keeps its recorded cwd over
   // the workspace for the same reason. SSH runtimes own their remote cwd, so
   // never stat the local filesystem for a remote familiar.
-  const familiarWorkspace = !sshRuntime && !body.projectRoot && !resumeCwd
-    ? await resolveFamiliarWorkspace(body.familiarId)
+  const familiarCwd = !sshRuntime && !body.projectRoot && !resumeCwd
+    ? resolvedFamiliarWorkspace
     : undefined;
   const responseMetadata: ChatResponseMetadata = {
     familiarId: body.familiarId,
@@ -882,7 +885,7 @@ export async function POST(req: Request) {
     model: binding.model,
     runtime: sshRuntime
       ? `ssh:${sshRuntime.host}:${sshRuntime.cwd}`
-      : `local:${familiarWorkspace ?? cwd}`,
+      : `local:${familiarCwd ?? cwd}`,
   };
 
   // Build coven run argv.
@@ -1129,7 +1132,7 @@ export async function POST(req: Request) {
             "running",
             sshRuntime
               ? `${sshRuntime.host}:${sshRuntime.cwd}`
-              : familiarWorkspace ?? cwd,
+              : familiarCwd ?? cwd,
           );
           const child = sshRuntime
             ? (() => {
@@ -1145,7 +1148,7 @@ export async function POST(req: Request) {
                 // root and Codex/Claude pick up AGENTS.md / SOUL.md / IDENTITY.md
                 // from the familiar's home. When a project root IS supplied,
                 // honor that instead.
-                cwd: familiarWorkspace ?? cwd,
+                cwd: familiarCwd ?? cwd,
                 stdio: ["ignore", "pipe", "pipe"],
                 env: covenSpawnEnv(),
               });

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -31,7 +31,7 @@ import {
 import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
 import { buildPromptWithCovenIdentityCanon } from "@/lib/coven-identity-canon";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
-import { covenHome, familiarWorkspace } from "@/lib/coven-paths";
+import { covenHome, readFamiliarWorkspaces } from "@/lib/coven-paths";
 import { isTrustedChatHarness } from "@/lib/harness-adapters";
 import {
   type ChatTurn,
@@ -187,10 +187,35 @@ async function resolveFamiliarWorkspace(
 ): Promise<string | undefined> {
   // Guard against path traversal: familiar IDs should be simple slugs.
   if (!/^[a-z0-9_-]+$/i.test(familiarId)) return undefined;
-  const candidate = await familiarWorkspace(familiarId);
+  const declared = await readFamiliarWorkspaces();
+  const declaredWorkspace = declared.get(familiarId);
+  if (declaredWorkspace) {
+    try {
+      const resolvedDeclared = await realpath(declaredWorkspace);
+      const s = await stat(resolvedDeclared);
+      if (s.isDirectory()) return resolvedDeclared;
+    } catch {
+      /* fall through to default familiar workspace */
+    }
+  }
+  const familiarsRoot = path.join(covenHome(), "familiars");
+  const candidate = path.resolve(familiarsRoot, familiarId);
+  const relative = path.relative(familiarsRoot, candidate);
+  if (
+    relative.startsWith("..") ||
+    path.isAbsolute(relative) ||
+    relative.split(path.sep).includes("..")
+  ) {
+    return undefined;
+  }
   try {
-    const s = await stat(candidate);
-    if (s.isDirectory()) return candidate;
+    const root = await realpath(familiarsRoot);
+    const resolvedCandidate = await realpath(candidate);
+    if (resolvedCandidate !== root && !resolvedCandidate.startsWith(root + path.sep)) {
+      return undefined;
+    }
+    const s = await stat(resolvedCandidate);
+    if (s.isDirectory()) return resolvedCandidate;
   } catch {
     /* not found */
   }

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -819,7 +819,7 @@ export async function POST(req: Request) {
   const mentionedFiles = imagesSupported
     ? await resolveMentionedFiles(
         body.mentionedFiles,
-        body.mentionedFilesRoot ?? body.projectRoot,
+        familiarWorkspace(body.familiarId),
       )
     : [];
 

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -747,6 +747,11 @@ assert.match(
 );
 assert.match(
   mentionSendSource,
-  /const mentionedFiles = imagesSupported\s*\n\s*\? await resolveMentionedFiles\(\s*\n\s*body\.mentionedFiles,\s*\n\s*body\.mentionedFilesRoot \?\? body\.projectRoot,/,
-  "Mentions are only delivered to harnesses that can Read this machine's filesystem, against the client-supplied root",
+  /const resolvedFamiliarWorkspace = !sshRuntime\s*\n\s*\? await resolveFamiliarWorkspace\(body\.familiarId\)\s*\n\s*: undefined;/,
+  "Mention roots must come from the validated familiar workspace, not a client-supplied path",
+);
+assert.match(
+  mentionSendSource,
+  /const mentionedFiles = imagesSupported\s*\n\s*\? await resolveMentionedFiles\(\s*\n\s*body\.mentionedFiles,\s*\n\s*resolvedFamiliarWorkspace,/,
+  "Mentions are only delivered to harnesses that can Read this machine's filesystem, against the validated familiar workspace",
 );

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -732,6 +732,11 @@ assert.match(
 );
 assert.match(
   mentionSendSource,
+  /async function resolveFamiliarWorkspace\([\s\S]*?readFamiliarWorkspaces\(\)[\s\S]*?path\.resolve\(familiarsRoot, familiarId\)[\s\S]*?path\.relative\(familiarsRoot, candidate\)[\s\S]*?relative\.startsWith\("\.\."\)/,
+  "/chat/send must validate default familiar workspace paths under the familiar root while preserving configured workspaces",
+);
+assert.match(
+  mentionSendSource,
   /const real = await realpath\(candidate\);[\s\S]*?real\.startsWith\(realRoot \+ path\.sep\)/,
   "/chat/send must re-check containment on the realpathed file so in-repo symlinks cannot smuggle outside paths",
 );


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/12](https://github.com/OpenCoven/coven-cave/security/code-scanning/12)

General fix: do not allow request data to define the filesystem root used for path resolution. Anchor resolution to a trusted server-side base path, and treat user-provided paths only as relative components validated against that base.

Best minimal fix in this file: in `POST`, replace the untrusted root argument passed to `resolveMentionedFiles` with a trusted server-side root (`familiarWorkspace(body.familiarId)`), which is already imported and used for coven paths. This preserves existing behavior of resolving user-mentioned relative paths while removing attacker control over the root path expression that CodeQL flagged.

Change region: `src/app/api/chat/send/route.ts`, lines around `mentionedFiles` creation (around 800–804).  
No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
