### PR TITLE
Potential fix for code scanning alert no. 20: Uncontrolled data used in path expression

### DIFF
--- a/src/app/api/library/graph/route.ts
+++ b/src/app/api/library/graph/route.ts
@@ -268,9 +268,24 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ok: false, error: "targetPath required" }, { status: 400 });
   }
 
-  const targetPath = body.targetPath;
+  // Constrain user-provided paths to a safe root directory.
+  // Use HOME as the allowed workspace root for graph operations.
+  const safeRoot = await fs.realpath(homedir());
+  const resolvedTargetPath = path.resolve(safeRoot, body.targetPath);
 
-  // Verify path exists
+  let targetPath: string;
+  try {
+    targetPath = await fs.realpath(resolvedTargetPath);
+  } catch {
+    return NextResponse.json({ ok: false, error: "targetPath does not exist" }, { status: 400 });
+  }
+
+  const safeRootWithSep = safeRoot.endsWith(path.sep) ? safeRoot : `${safeRoot}${path.sep}`;
+  if (targetPath !== safeRoot && !targetPath.startsWith(safeRootWithSep)) {
+    return NextResponse.json({ ok: false, error: "targetPath is outside allowed root" }, { status: 403 });
+  }
+
+  // Verify path exists and is a directory
   try {
     const stat = await fs.stat(targetPath);
     if (!stat.isDirectory()) {


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/20](https://github.com/OpenCoven/coven-cave/security/code-scanning/20)

To fix this without changing intended behavior more than necessary, normalize and constrain user-supplied `targetPath` to a safe root directory, then use only the validated canonical path afterwards.

Best approach in this file:
1. Define a safe root (for example, user home directory) and canonicalize it.
2. Resolve user input against that root (`path.resolve`), then canonicalize with `fs.realpath`.
3. Ensure the canonical path is inside the canonical root (prefix check with trailing separator safety).
4. Reuse the validated canonical path (`targetPath`) for all later uses (`stat`, `cwd`, `path.join`, etc.).

Edits are in `src/app/api/library/graph/route.ts`, within `POST` where `targetPath` is read and validated (around lines 266–281). No new dependency is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
