### PR TITLE
Potential fix for code scanning alert no. 19: Uncontrolled data used in path expression

### DIFF
--- a/src/app/api/library/graph/route.ts
+++ b/src/app/api/library/graph/route.ts
@@ -9,6 +9,17 @@ import { resolveSecret } from "@/lib/vault";
 
 const execFileAsync = promisify(execFile);
 
+const GRAPH_ROOT_DIR = homedir();
+
+function resolveAndValidateTargetPath(inputPath: string): string | null {
+  const resolved = path.resolve(GRAPH_ROOT_DIR, inputPath);
+  const rel = path.relative(GRAPH_ROOT_DIR, resolved);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    return null;
+  }
+  return resolved;
+}
+
 const GRAPHIFY_LLM_ENV_KEYS = [
   "GEMINI_API_KEY",
   "GOOGLE_API_KEY",
@@ -268,7 +279,10 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ok: false, error: "targetPath required" }, { status: 400 });
   }
 
-  const targetPath = body.targetPath;
+  const targetPath = resolveAndValidateTargetPath(body.targetPath);
+  if (!targetPath) {
+    return NextResponse.json({ ok: false, error: "targetPath is outside allowed root" }, { status: 400 });
+  }
 
   // Verify path exists
   try {


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/19](https://github.com/OpenCoven/coven-cave/security/code-scanning/19)

General fix: canonicalize and validate user-provided paths against an approved root directory before any filesystem use. Use `path.resolve` to normalize, then enforce containment with `path.relative` (or prefix check with separator-safe handling).

Best fix here without changing core behavior too much: in `POST` handler (`src/app/api/library/graph/route.ts` around lines 266–281), resolve `body.targetPath` against a safe base (for example `homedir()`), reject absolute/escaping paths, then use only the validated absolute path for `fs.stat` and subsequent logic. This preserves functionality for expected local-project directories under the chosen root while blocking traversal/out-of-scope access.

Concretely:
- Add a small helper in this file (near constants) to validate/normalize target paths.
- In `POST`, replace direct assignment `const targetPath = body.targetPath;` with validated path result.
- Return 400 if validation fails.
- Keep existing directory existence/type checks, but run them on the sanitized path.

No new dependencies are required; existing `path` and `homedir` imports are already present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
