### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete multi-character sanitization

### DIFF
--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -150,7 +150,7 @@ async function renderCodeBlock(
           // CHAT-D8-03: `+++ b/file` / `--- a/file` headers are metadata, not
           // additions/deletions — exclude them from the +/- gutter strips and
           // mute `@@` hunk headers instead of leaving them content-colored.
-          const plainLine = line.replace(/<[^>]+>/g, "");
+          const plainLine = sanitizeHtml(line, { allowedTags: [], allowedAttributes: {} });
           const gutterClass = isDiff
             ? /^@@/.test(plainLine)
               ? " cave-diff-meta"

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -112,6 +112,11 @@ function parseFenceInfo(info: string): { lang: string; filename?: string } {
  */
 const CODE_EXPAND_MIN_LINES = 24;
 
+function plainTextFromHtmlLine(line: string): string {
+  const doc = new DOMParser().parseFromString(line, "text/html");
+  return doc.body.textContent ?? "";
+}
+
 async function renderCodeBlock(
   code: string,
   info: string,
@@ -150,7 +155,7 @@ async function renderCodeBlock(
           // CHAT-D8-03: `+++ b/file` / `--- a/file` headers are metadata, not
           // additions/deletions — exclude them from the +/- gutter strips and
           // mute `@@` hunk headers instead of leaving them content-colored.
-          const plainLine = sanitizeHtml(line, { allowedTags: [], allowedAttributes: {} });
+          const plainLine = plainTextFromHtmlLine(line);
           const gutterClass = isDiff
             ? /^@@/.test(plainLine)
               ? " cave-diff-meta"


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/4](https://github.com/OpenCoven/coven-cave/security/code-scanning/4)

Use a proper HTML sanitizer/parser routine instead of regex tag stripping for `plainLine`.

Best fix in this file: replace
- `const plainLine = line.replace(/<[^>]+>/g, "");`
with
- `const plainLine = sanitizeHtml(line, { allowedTags: [], allowedAttributes: {} });`

Why this is best:
- It avoids multi-character regex removal pitfalls.
- It keeps behavior (derive plain-text-ish line for prefix checks) without changing rendering output.
- It uses an already imported utility (`sanitizeHtml` from `@/lib/html-sanitize`), so no new dependency/import changes are needed.

Change scope:
- File: `src/components/message-bubble.tsx`
- Region: line-wrapping map callback around current line 153.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
