### PR TITLE
feat(chat): hide tool activity on settled turns behind a meta-row toggle

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -88,6 +88,32 @@ assert.doesNotMatch(
   "Thinking and tool-use disclosures must not default open",
 );
 
+// --- CHAT-D13-01: tool activity hidden by default on settled turns ---
+
+assert.match(
+  turnRow,
+  /const showTools = turn\.pending \? true : \(showToolsOverride \?\? false\)/,
+  "Tool activity should stay visible while streaming and default hidden once the response has fully generated",
+);
+
+assert.match(
+  turnRow,
+  /cave-turn-tools-toggle[\s\S]{0,300}aria-pressed=\{showTools\}/,
+  "Settled turns with tools should expose an always-visible toggle chip with pressed state",
+);
+
+assert.match(
+  turnRow,
+  /segments=\{showTools \? bubbleSegments : undefined\}/,
+  "Hiding tools should fall back to plain prose rendering instead of segment interleaving",
+);
+
+assert.match(
+  turnRow,
+  /showTools && !segments && turn\.tools\?\.length \? <ToolGroup/,
+  "The legacy trailing ToolGroup should honor the same hidden-by-default contract",
+);
+
 assert.match(
   turnRow,
   /const \{ visible, reasoning: inlineReasoning \} = splitReasoning\(turn\.text\)/,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3151,6 +3151,14 @@ function TurnRow({
   /** CHAT-D6-02: present only on settled assistant turns with a preceding user turn. */
   onRegenerate?: () => void;
 }) {
+  // CHAT-D13-01: tool activity stays visible while a turn streams (watching
+  // tools run IS the live feedback), then hides once the response has fully
+  // generated and sent — a "N tools" chip in the meta row toggles it back.
+  // Only an explicit click records an override; the pending→settled flip
+  // collapses tools on its own because the settled default is hidden.
+  const [showToolsOverride, setShowToolsOverride] = useState<boolean | null>(null);
+  const showTools = turn.pending ? true : (showToolsOverride ?? false);
+
   if (turn.role === "system" || turn.role === "user") {
     return (
       <div
@@ -3253,6 +3261,22 @@ function TurnRow({
             {showTimestamp && turn.createdAt ? <span className="opacity-60">{fmtTime(turn.createdAt)}</span> : null}
             <ResponseMetadataText metadata={turn.responseMetadata} />
             <UsageText usage={turn.usage} costUsd={turn.costUsd} />
+            {/* CHAT-D13-01: settled turns hide tool activity by default —
+                this chip is the only way back to it, so it must not be
+                hover-gated. Hidden while streaming (tools are inline then). */}
+            {!turn.pending && (turn.tools?.length ?? 0) > 0 ? (
+              <button
+                type="button"
+                className={`cave-turn-tools-toggle${showTools ? " is-active" : ""}`}
+                aria-pressed={showTools}
+                aria-label={showTools ? "Hide tool activity" : "Show tool activity"}
+                title={showTools ? "Hide tool activity" : "Show tool activity"}
+                onClick={() => setShowToolsOverride(!showTools)}
+              >
+                <Icon name="ph:wrench" width={11} aria-hidden />
+                {turn.tools!.length} tool{turn.tools!.length === 1 ? "" : "s"}
+              </button>
+            ) : null}
           </div>
 
           <div className="cave-linear-turn-body">
@@ -3268,7 +3292,10 @@ function TurnRow({
                 isError={turn.error}
                 label={familiar.display_name}
                 onRegenerate={onRegenerate}
-                segments={bubbleSegments}
+                // CHAT-D13-01: with tools hidden, fall back to plain content —
+                // the text segments concatenate to `visible` anyway, so prose
+                // renders identically with the tool blocks omitted.
+                segments={showTools ? bubbleSegments : undefined}
               />
             )}
             {/* CHAT-D4-01: tools often run BEFORE the first prose chunk
@@ -3286,8 +3313,9 @@ function TurnRow({
             {turn.progress?.length ? <ProgressGroup progress={turn.progress} pending={!!turn.pending} /> : null}
             {reasoning ? <ReasoningBlock reasoning={reasoning} /> : null}
             {/* Legacy trailing rollup — ONLY for turns whose tools predate
-                textOffset; segmented turns render their tools inline. */}
-            {!segments && turn.tools?.length ? <ToolGroup tools={turn.tools} /> : null}
+                textOffset; segmented turns render their tools inline.
+                CHAT-D13-01: same default-hidden contract as inline tools. */}
+            {showTools && !segments && turn.tools?.length ? <ToolGroup tools={turn.tools} /> : null}
           </div>
         </div>
       </div>

--- a/src/lib/session-debug.test.ts
+++ b/src/lib/session-debug.test.ts
@@ -227,7 +227,7 @@ assert.match(
 );
 assert.match(
   chatViewSource,
-  /\{!segments && turn\.tools\?\.length \? <ToolGroup tools=\{turn\.tools\} \/> : null\}/,
+  /\{showTools && !segments && turn\.tools\?\.length \? <ToolGroup tools=\{turn\.tools\} \/> : null\}/,
   "CHAT-D4-01: trailing ToolGroup rollup survives ONLY for legacy turns without offsets",
 );
 assert.match(

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1073,6 +1073,36 @@
   border-color: color-mix(in oklch, var(--color-danger) 55%, transparent);
 }
 
+/* CHAT-D13-01: "N tools" chip on settled assistant turns — tool activity is
+   hidden by default once a response has fully generated, and this chip is the
+   only way back to it, so like the retry pill it is NOT hover-revealed. */
+.cave-turn-tools-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 5px;
+  border: 1px solid var(--border-hairline);
+  background: transparent;
+  padding: 1px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.cave-turn-tools-toggle:hover {
+  color: var(--text-secondary);
+  border-color: var(--border-strong);
+}
+
+.cave-turn-tools-toggle.is-active {
+  color: var(--text-secondary);
+  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
+  border-color: color-mix(in oklch, var(--accent-presence) 35%, transparent);
+}
+
 .cave-reasoning-block,
 .cave-progress-group,
 .cave-tool-group {


### PR DESCRIPTION
## What (CHAT-D13-01)

Per Val's request: chat tool usage gets a show/hide toggle, **defaulting to hidden once a response has fully generated and sent**.

- **While streaming**: tool blocks render inline at their chronological positions exactly as today — watching tools run is the live feedback.
- **On settle** (`pending` → false): tool blocks collapse automatically. Prose falls back to plain content rendering (the text segments concatenate to the visible text, so nothing reflows oddly).
- **Toggle**: a compact `N tools` chip in the turn meta row (wrench icon, `aria-pressed`, always visible — not hover-gated, since it's the only way back to the activity). Clicking shows/hides; active state tints with the presence accent.
- The legacy trailing `ToolGroup` (transcripts predating text offsets) honors the same contract. Reasoning and Progress disclosures are unchanged.

## Verification

- Drove the real chat surface against a mocked `/api/chat/send` SSE stream (text + 2 tool_use events + done): after settle the chip reads "2 tools" with zero tool blocks visible; click → `aria-pressed=true`, Bash/Read blocks appear inline; click again → hidden. Screenshots in both states.
- `test:app` passes; added 4 regression assertions to `chat-view-polish.test.ts` and updated the pinned legacy-rollup expression in `session-debug.test.ts` to the new gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)