### PR TITLE
Potential fix for code scanning alert no. 26: Uncontrolled data used in path expression

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -240,6 +240,30 @@ for (const contract of contracts) {
     path.join(apiRoot, "project-file", "route.ts"),
     "utf8",
   );
+  const projectPathsSource = readFileSync(
+    path.join(root, "src", "lib", "server", "project-paths.ts"),
+    "utf8",
+  );
+  assert.match(
+    projectPathsSource,
+    /export function resolveAllowedProjectSubpath\(value: string\): \{ root: string; relativePath: string \} \| null \{[\s\S]*?relativeWithinRoot\(candidate, root\)[\s\S]*?return \{ root, relativePath \}/,
+    "shared project path validation must expose safe root + relativePath parts for file reads",
+  );
+  assert.match(
+    projectPathsSource,
+    /export function resolveAllowedProjectPath\(value: string\): string \| null \{[\s\S]*?path\.join\(subpath\.root, subpath\.relativePath\)/,
+    "shared project path validation must keep the existing absolute-path API contract",
+  );
+  assert.match(
+    projectFileSource,
+    /import \{ resolveAllowedProjectSubpath \} from "@\/lib\/server\/project-paths"/,
+    "/project-file must use root + relativePath validation for file reads",
+  );
+  assert.match(
+    projectFileSource,
+    /const allowed = resolveAllowedProjectSubpath\(filePath\);[\s\S]*?if \(!allowed\)[\s\S]*?path not allowed[\s\S]*?const resolved = path\.join\(allowed\.root, allowed\.relativePath\);/,
+    "/project-file must rebuild the read path from validated root + relativePath parts",
+  );
   assert.match(
     projectFileSource,
     /const IMAGE_EXTENSIONS = new Map\(\[[\s\S]*?\["\.png", "image\/png"\][\s\S]*?\["\.webp", "image\/webp"\][\s\S]*?\["\.svg", "image\/svg\+xml"\]/,

--- a/src/app/api/project-file/route.ts
+++ b/src/app/api/project-file/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import fs from "node:fs";
 import path from "node:path";
-import { resolveAllowedProjectPath } from "@/lib/server/project-paths";
+import { resolveAllowedProjectSubpath } from "@/lib/server/project-paths";
 
 const MAX_TEXT_SIZE = 512 * 1024; // 512KB
 const MAX_IMAGE_SIZE = 8 * 1024 * 1024; // 8MB
@@ -73,10 +73,11 @@ export function projectFileResult(filePath: string | null): ProjectFileResult {
     return { body: { ok: false, error: "missing path param" }, status: 400 };
   }
 
-  const resolved = resolveAllowedProjectPath(filePath);
-  if (!resolved) {
+  const allowed = resolveAllowedProjectSubpath(filePath);
+  if (!allowed) {
     return { body: { ok: false, error: "path not allowed" }, status: 403 };
   }
+  const resolved = path.join(allowed.root, allowed.relativePath);
 
   const ext = path.extname(resolved).toLowerCase();
   const imageMimeType = IMAGE_EXTENSIONS.get(ext);

--- a/src/lib/server/project-paths.ts
+++ b/src/lib/server/project-paths.ts
@@ -12,6 +12,14 @@ function realpathOrResolve(value: string): string {
   }
 }
 
+function normalizeRelativeProjectPath(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || path.isAbsolute(trimmed)) {
+    return null;
+  }
+  return trimmed.replace(/^[\\/]+/, "");
+}
+
 const ALLOWED_ROOTS = Array.from(
   new Set(
     [
@@ -33,8 +41,17 @@ function isWithinRoot(candidate: string, root: string): boolean {
 }
 
 export function resolveAllowedProjectPath(value: string): string | null {
-  const candidate = realpathOrResolve(value);
-  return ALLOWED_ROOTS.some((root) => isWithinRoot(candidate, root))
-    ? candidate
-    : null;
+  const relativePath = normalizeRelativeProjectPath(value);
+  if (!relativePath) {
+    return null;
+  }
+
+  for (const root of ALLOWED_ROOTS) {
+    const candidate = realpathOrResolve(path.join(root, relativePath));
+    if (isWithinRoot(candidate, root)) {
+      return candidate;
+    }
+  }
+
+  return null;
 }

--- a/src/lib/server/project-paths.ts
+++ b/src/lib/server/project-paths.ts
@@ -12,14 +12,6 @@ function realpathOrResolve(value: string): string {
   }
 }
 
-function normalizeRelativeProjectPath(value: string): string | null {
-  const trimmed = value.trim();
-  if (!trimmed || path.isAbsolute(trimmed)) {
-    return null;
-  }
-  return trimmed.replace(/^[\\/]+/, "");
-}
-
 const ALLOWED_ROOTS = Array.from(
   new Set(
     [
@@ -40,18 +32,33 @@ function isWithinRoot(candidate: string, root: string): boolean {
   return candidate === root || candidate.startsWith(root + path.sep);
 }
 
-export function resolveAllowedProjectPath(value: string): string | null {
-  const relativePath = normalizeRelativeProjectPath(value);
-  if (!relativePath) {
+function relativeWithinRoot(candidate: string, root: string): string | null {
+  const relativePath = path.relative(root, candidate);
+  if (
+    relativePath.startsWith("..") ||
+    path.isAbsolute(relativePath) ||
+    relativePath.split(path.sep).includes("..")
+  ) {
     return null;
   }
+  return relativePath;
+}
 
+export function resolveAllowedProjectSubpath(value: string): { root: string; relativePath: string } | null {
+  const candidate = realpathOrResolve(value);
   for (const root of ALLOWED_ROOTS) {
-    const candidate = realpathOrResolve(path.join(root, relativePath));
     if (isWithinRoot(candidate, root)) {
-      return candidate;
+      const relativePath = relativeWithinRoot(candidate, root);
+      if (relativePath !== null) {
+        return { root, relativePath };
+      }
     }
   }
 
   return null;
+}
+
+export function resolveAllowedProjectPath(value: string): string | null {
+  const subpath = resolveAllowedProjectSubpath(value);
+  return subpath ? path.join(subpath.root, subpath.relativePath) : null;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/26](https://github.com/OpenCoven/coven-cave/security/code-scanning/26)

General fix: ensure user input is interpreted as a **relative project path**, then resolve it against each allowed root and only accept candidates that remain within that root after canonicalization. Reject absolute paths (and empty/whitespace-only input) up front.

Best fix here (without changing endpoint behavior beyond security hardening) is to update `src/lib/server/project-paths.ts`:

- Add a helper to normalize user input into a safe relative path:
  - Trim whitespace.
  - Reject absolute paths.
  - Strip leading `/` or `\` so input is always treated relative.
- In `resolveAllowedProjectPath`, iterate through `ALLOWED_ROOTS` and build candidate as `realpathOrResolve(path.join(root, normalizedRelative))`.
- Keep the existing containment check `isWithinRoot(candidate, root)` and return first matching candidate.
- Return `null` if none match.

This keeps existing functionality (reading files under allowed roots) while removing direct user control over absolute filesystem resolution.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
