### PR TITLE
feat(chat): persist tool-use rows across refresh and chat switches

### DIFF
--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -371,6 +371,30 @@ assert.match(
   "The resume retry should reset the tool tracker alongside the other per-attempt state",
 );
 
+assert.match(
+  chatRoute,
+  /toolTracker\.hookStart\(name, formatToolPayload\(rest\), assistantText\.length\)/,
+  "hook tool starts are stamped with the current assistant-text offset",
+);
+
+assert.match(
+  chatRoute,
+  /formatToolInputValue\(block\.input\),\s*assistantText\.length,/,
+  "envelope tool starts are stamped with the current assistant-text offset",
+);
+
+assert.match(
+  chatRoute,
+  /toPersistedTools\(toolTracker\.snapshot\(\)/,
+  "the saved assistant turn captures the tracker's final tool state",
+);
+
+assert.match(
+  chatRoute,
+  /\.\.\.\(persistedTools \? \{ tools: persistedTools \} : \{\}\)/,
+  "tools persist on the assistant turn alongside usage and cost",
+);
+
 // Behavioral: per-name FIFO queue gives overlapping same-name calls distinct
 // ids and pairs each post with the oldest open pre (correct durations).
 {
@@ -728,10 +752,13 @@ assert.match(
 
   const longOut = new ToolCallTracker(() => 0);
   longOut.hookStart("Bash", undefined, 0);
-  longOut.hookEnd("Bash", "y".repeat(9000), false);
+  longOut.hookEnd("Bash", "HEAD" + "y".repeat(9000), false);
   const capped = toPersistedTools(longOut.snapshot(), 0);
   assert.equal(capped?.[0].output?.length, 4000, "output tail-capped at 4000");
-  assert.equal(capped?.[0].output?.[0], "y");
+  assert.ok(
+    !capped?.[0].output?.includes("HEAD"),
+    "output keeps the tail, not the head",
+  );
 
   assert.equal(
     toPersistedTools(new ToolCallTracker().snapshot(), 0),

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -12,6 +12,7 @@ import {
   formatToolInputValue,
   formatToolPayload,
   ToolCallTracker,
+  toPersistedTools,
 } from "../../../../lib/chat-tool-events.ts";
 
 const chatRoute = await readFile(
@@ -662,5 +663,82 @@ assert.match(
   );
   assert.equal(usageBreakdown(undefined, undefined), null);
 }
+
+// ── Tool persistence: tracker recording + snapshot (spec 2026-06-12) ────────
+{
+  let t = 0;
+  const tracker = new ToolCallTracker(() => t);
+  tracker.hookStart("Bash", '{"command":"ls"}', 12);
+  t = 1500;
+  tracker.hookEnd("Bash", "file-list", false);
+  const snap = tracker.snapshot();
+  assert.equal(snap.length, 1, "snapshot keeps the settled hook call");
+  assert.equal(snap[0].name, "Bash");
+  assert.equal(snap[0].status, "ok");
+  assert.equal(snap[0].durationMs, 1500);
+  assert.equal(snap[0].textOffset, 12, "offset stamped at start survives the end merge");
+  assert.equal(snap[0].input, '{"command":"ls"}', "input stored verbatim — the route formats before calling");
+  assert.equal(snap[0].output, "file-list");
+}
+
+{
+  let t = 0;
+  const tracker = new ToolCallTracker(() => t);
+  tracker.envelopeToolUse("toolu_x", "Read", '{"file":"a.ts"}', 40);
+  t = 250;
+  tracker.envelopeToolResult("toolu_x", "contents", false);
+  const snap = tracker.snapshot();
+  assert.equal(snap.length, 1, "envelope lifecycle recorded once");
+  assert.equal(snap[0].id, "toolu_x");
+  assert.equal(snap[0].textOffset, 40);
+  assert.equal(snap[0].status, "ok");
+  assert.equal(snap[0].durationMs, 250);
+}
+
+{
+  // Hook + envelope describing the same call must record ONE entry.
+  const tracker = new ToolCallTracker(() => 0);
+  tracker.hookStart("Bash", undefined, 5);
+  tracker.envelopeToolUse("toolu_dup", "Bash", '{"command":"pwd"}', 9);
+  tracker.hookEnd("Bash", "done", false);
+  const snap = tracker.snapshot();
+  assert.equal(snap.length, 1, "linked hook+envelope call records a single entry");
+  assert.equal(snap[0].textOffset, 5, "first stamp (hook start) wins");
+  assert.equal(
+    snap[0].input,
+    '{"command":"pwd"}',
+    "envelope input backfills a hook call that had none (stored verbatim)",
+  );
+}
+
+{
+  // toPersistedTools: caps, running coercion, offset shift, empty → undefined.
+  const tracker = new ToolCallTracker(() => 0);
+  tracker.hookStart("Bash", "x".repeat(3000), 10);
+  // never ended — still running at save time
+  const persisted = toPersistedTools(tracker.snapshot(), 4);
+  assert.ok(persisted && persisted.length === 1);
+  assert.equal(persisted[0].status, "error", "running coerces to error at save");
+  assert.ok(
+    (persisted[0].output ?? "").includes("[tool did not settle before the turn ended]"),
+    "coercion is explained in the output",
+  );
+  assert.equal(persisted[0].input?.length, 2000, "input head-capped at 2000");
+  assert.equal(persisted[0].textOffset, 6, "offset shifted by the leading trim (10 - 4)");
+
+  const longOut = new ToolCallTracker(() => 0);
+  longOut.hookStart("Bash", undefined, 0);
+  longOut.hookEnd("Bash", "y".repeat(9000), false);
+  const capped = toPersistedTools(longOut.snapshot(), 0);
+  assert.equal(capped?.[0].output?.length, 4000, "output tail-capped at 4000");
+  assert.equal(capped?.[0].output?.[0], "y");
+
+  assert.equal(
+    toPersistedTools(new ToolCallTracker().snapshot(), 0),
+    undefined,
+    "no tools → undefined, not an empty array",
+  );
+}
+console.log("tool persistence tracker tests passed");
 
 console.log("harness-routing tests passed");

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -26,6 +26,7 @@ import {
   flattenToolResultContent,
   formatToolInputValue,
   formatToolPayload,
+  toPersistedTools,
   ToolCallTracker,
 } from "@/lib/chat-tool-events";
 import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
@@ -1046,6 +1047,7 @@ export async function POST(req: Request) {
                     block.id,
                     block.name,
                     formatToolInputValue(block.input),
+                    assistantText.length,
                   );
                   if (toolEv) push({ kind: "tool_use", ...toolEv });
                 }
@@ -1091,7 +1093,7 @@ export async function POST(req: Request) {
                 formatToolPayload(rest),
                 /error|fail|denied|exit\s*[1-9]/i.test(rest),
               )
-            : toolTracker.hookStart(name, formatToolPayload(rest));
+            : toolTracker.hookStart(name, formatToolPayload(rest), assistantText.length);
           push({ kind: "tool_use", ...toolEv });
         }
         const filtered = assistantFilter.push(cleaned + "\n");
@@ -1281,6 +1283,13 @@ export async function POST(req: Request) {
           ...(persistedAttachments.length ? { attachments: persistedAttachments } : {}),
           createdAt: now,
         };
+        // Persist the turn's tool rows: the live chips exist only in client
+        // state fed by SSE; without this, refresh/chat-switch loses them.
+        // Offsets were stamped against the untrimmed stream — shift by the
+        // leading trim so interleaving matches the saved text.
+        const persistedTools = toPersistedTools(toolTracker.snapshot(),
+          assistantText.length - assistantText.trimStart().length,
+        );
         const assistantTurn: ChatTurn = {
           id: assistantTurnId,
           role: "assistant",
@@ -1291,6 +1300,7 @@ export async function POST(req: Request) {
           ...(cancelledByUser ? { cancelled: true } : {}),
           ...(result.usage ? { usage: result.usage } : {}),
           ...(result.costUsd !== undefined ? { costUsd: result.costUsd } : {}),
+          ...(persistedTools ? { tools: persistedTools } : {}),
           responseMetadata,
         };
         const conv = existing ?? {

--- a/src/lib/chat-tool-events.ts
+++ b/src/lib/chat-tool-events.ts
@@ -29,6 +29,11 @@ export type ToolStreamEvent = {
   durationMs?: number;
 };
 
+/** A tool event as recorded for persistence — ToolStreamEvent plus the
+ *  position in the accumulated assistant text where the call started
+ *  (mirrors the chat UI's textOffset for chronological interleaving). */
+export type RecordedToolEvent = ToolStreamEvent & { textOffset?: number };
+
 /** Pretty-print a raw JSON payload string; fall back to the raw text. */
 export function formatToolPayload(raw: string): string | undefined {
   if (!raw) return undefined;
@@ -97,6 +102,9 @@ export class ToolCallTracker {
   private byEnvelopeId = new Map<string, OpenCall>();
   /** Envelope ids whose calls were already settled (dedup tool_result). */
   private settledEnvelopeIds = new Set<string>();
+  /** Final state of every call this tracker has emitted, by stream id —
+   *  insertion-ordered, so snapshot() preserves call order for persistence. */
+  private recorded = new Map<string, RecordedToolEvent>();
   private readonly now: () => number;
 
   constructor(now: () => number = Date.now) {
@@ -124,8 +132,36 @@ export class ToolCallTracker {
     }
   }
 
+  private record(ev: ToolStreamEvent, textOffset?: number): void {
+    const prev = this.recorded.get(ev.id);
+    if (!prev) {
+      this.recorded.set(ev.id, {
+        ...ev,
+        ...(textOffset !== undefined ? { textOffset } : {}),
+      });
+      return;
+    }
+    // End events merge into the start record; the first textOffset and the
+    // original input win (mirrors the chat UI's upsert-by-id semantics).
+    this.recorded.set(ev.id, {
+      ...prev,
+      ...ev,
+      input: prev.input ?? ev.input,
+      ...(prev.textOffset !== undefined
+        ? { textOffset: prev.textOffset }
+        : textOffset !== undefined
+          ? { textOffset }
+          : {}),
+    });
+  }
+
+  /** Final ordered tool list for persistence into the saved turn. */
+  snapshot(): RecordedToolEvent[] {
+    return Array.from(this.recorded.values());
+  }
+
   /** pre_tool_use (or bare tool_use) hook line: a call is starting. */
-  hookStart(name: string, input?: string): ToolStreamEvent {
+  hookStart(name: string, input?: string, textOffset?: number): ToolStreamEvent {
     const queue = this.queueFor(name);
     // The envelope may have announced this call first (assistant message
     // flushes before the tool executes). Claim the oldest unclaimed
@@ -136,7 +172,9 @@ export class ToolCallTracker {
       // The hook marks actual execution start — a tighter duration baseline
       // than when the envelope was parsed.
       claim.startedAt = this.now();
-      return { id: claim.id, name, input, status: "running" };
+      const ev: ToolStreamEvent = { id: claim.id, name, input, status: "running" };
+      this.record(ev, textOffset);
+      return ev;
     }
     this.seq += 1;
     const call: OpenCall = {
@@ -147,7 +185,9 @@ export class ToolCallTracker {
       hookStarted: true,
     };
     queue.push(call);
-    return { id: call.id, name, input, status: "running" };
+    const ev: ToolStreamEvent = { id: call.id, name, input, status: "running" };
+    this.record(ev, textOffset);
+    return ev;
   }
 
   /** post_tool_use hook line: the OLDEST open hook-started call completed. */
@@ -160,11 +200,15 @@ export class ToolCallTracker {
     if (!call) {
       // Post without any open call: surface it anyway under a fresh id.
       this.seq += 1;
-      return { id: `tool-${this.seq}-${name}`, name, output, status };
+      const ev: ToolStreamEvent = { id: `tool-${this.seq}-${name}`, name, output, status };
+      this.record(ev);
+      return ev;
     }
     const durationMs = this.now() - call.startedAt;
     this.settle(call);
-    return { id: call.id, name, output, status, durationMs };
+    const ev: ToolStreamEvent = { id: call.id, name, output, status, durationMs };
+    this.record(ev);
+    return ev;
   }
 
   /**
@@ -172,7 +216,7 @@ export class ToolCallTracker {
    * new; returns null when a hook already announced it (the native id is
    * linked to the hook's id instead, so later tool_result blocks dedup).
    */
-  envelopeToolUse(id: string, name: string, input?: string): ToolStreamEvent | null {
+  envelopeToolUse(id: string, name: string, input?: string, textOffset?: number): ToolStreamEvent | null {
     if (this.byEnvelopeId.has(id) || this.settledEnvelopeIds.has(id)) return null;
     const queue = this.queueFor(name);
     // A hook pre may have surfaced this call already under a minted id. Link
@@ -182,6 +226,10 @@ export class ToolCallTracker {
     if (hookCall) {
       hookCall.envelopeId = id;
       this.byEnvelopeId.set(id, hookCall);
+      const prev = this.recorded.get(hookCall.id);
+      if (prev && prev.input === undefined && input !== undefined) {
+        this.recorded.set(hookCall.id, { ...prev, input });
+      }
       return null;
     }
     const call: OpenCall = {
@@ -194,7 +242,9 @@ export class ToolCallTracker {
     };
     queue.push(call);
     this.byEnvelopeId.set(id, call);
-    return { id, name, input, status: "running" };
+    const ev: ToolStreamEvent = { id, name, input, status: "running" };
+    this.record(ev, textOffset);
+    return ev;
   }
 
   /**
@@ -212,12 +262,54 @@ export class ToolCallTracker {
     if (!call) return null;
     const durationMs = this.now() - call.startedAt;
     this.settle(call);
-    return {
+    const ev: ToolStreamEvent = {
       id: call.id,
       name: call.name,
       output,
       status: isError ? "error" : "ok",
       durationMs,
     };
+    this.record(ev);
+    return ev;
   }
+}
+
+/** Caps for persisted tool payloads — chips are tiny; expandable payloads are
+ *  what can grow a conversation file. Output keeps the tail (the end of a log
+ *  is where errors live); input keeps the head (commands lead with intent). */
+export const PERSIST_INPUT_CAP = 2_000;
+export const PERSIST_OUTPUT_CAP = 4_000;
+
+/**
+ * Shape a tracker snapshot for the saved ChatTurn.
+ *
+ * - `leadingTrim`: the saved turn text is `assistantText.trim()`, so offsets
+ *   stamped against the untrimmed stream shift left by the leading-whitespace
+ *   length (clamped at 0).
+ * - Still-running calls coerce to error — a persisted "running" badge would
+ *   spin forever after reload.
+ * - Returns undefined when there is nothing to persist (no `tools: []` noise).
+ */
+export function toPersistedTools(
+  events: RecordedToolEvent[],
+  leadingTrim: number,
+): RecordedToolEvent[] | undefined {
+  if (events.length === 0) return undefined;
+  return events.map((ev) => {
+    const stillRunning = ev.status === "running";
+    const output = stillRunning
+      ? `${ev.output ? `${ev.output}\n` : ""}[tool did not settle before the turn ended]`
+      : ev.output;
+    return {
+      id: ev.id,
+      name: ev.name,
+      status: stillRunning ? "error" : ev.status,
+      ...(ev.input !== undefined ? { input: ev.input.slice(0, PERSIST_INPUT_CAP) } : {}),
+      ...(output !== undefined ? { output: output.slice(-PERSIST_OUTPUT_CAP) } : {}),
+      ...(ev.durationMs !== undefined ? { durationMs: ev.durationMs } : {}),
+      ...(ev.textOffset !== undefined
+        ? { textOffset: Math.max(0, ev.textOffset - leadingTrim) }
+        : {}),
+    };
+  });
 }


### PR DESCRIPTION
## Summary

Tool-use chips in assistant turns ("Bash · grep …" with ok/error badges and durations) lived only in client React state fed by SSE — refreshing or switching chats reloaded the conversation file, whose turns carried usage/cost but no tools, so the rows vanished.

- **ToolCallTracker** (`src/lib/chat-tool-events.ts`) now records the final state of every call it emits (insertion-ordered, upsert-by-id mirroring the chat UI's merge; first textOffset wins, original input wins, envelope input backfills hook calls), stamps assistant-text offsets at the two start entry points, and exposes `snapshot()`.
- **`toPersistedTools()`** shapes a snapshot for the saved turn: input head-capped at 2k, output tail-capped at 4k, still-running calls coerced to `error` with an explanatory note, offsets shifted by the save-time leading trim, `undefined` when empty (no `tools: []` noise).
- **`/api/chat/send`** stamps offsets at both tool-start call sites and saves the capped snapshot on the assistant turn next to usage/cost.
- **Zero client changes:** `ChatTurn.tools` already round-trips through the conversation GET and renders interleaved via `textOffset` (`segmentTurn`), so reloaded chats show exactly the chips the live stream showed — review traced that server-stamped offsets equal the client's live offsets, so placement is identical.

## Test plan

- [x] `node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts` (4 new behavioral tracker blocks + 4 route source assertions; output-cap test strengthened to distinguish tail from head)
- [x] `pnpm test:app` + `tsc --noEmit` + api-contracts (86 routes, unchanged)
- [x] Live round-trip on :3100 with a synthetic conversation fixture: chips render from disk — interleaved at their offsets, no-offset tools in the trailing rollup, error badges, expandable persisted output, stable across reload (15/15 checks)

## Notes

- Cancelled turns persist their (error-coerced) tools — you can see what ran before hitting stop.
- Board-chat (`/api/board/[id]/chat`) is a separate surface and out of scope per the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)