### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Frontend build


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/2](https://github.com/OpenCoven/coven-cave/security/code-scanning/2)

Add an explicit workflow-level `permissions` block with the minimum required scope.

Best fix (without changing functionality): in `.github/workflows/ci.yml`, insert at the top level (after `concurrency` and before `jobs`) the following:

```yml
permissions:
  contents: read
```

This applies to all jobs unless overridden and satisfies CodeQL’s requirement while preserving current behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
