### PR TITLE
Potential fix for code scanning alert no. 18: Uncontrolled data used in path expression

### DIFF
--- a/src/app/api/library/graph/route.ts
+++ b/src/app/api/library/graph/route.ts
@@ -241,21 +241,25 @@ export async function GET(req: NextRequest) {
   // ?path= loads an existing UA knowledge-graph.json directly (no pipeline run)
   const rawPath = req.nextUrl.searchParams.get("path");
   if (rawPath) {
+    const validatedPath = resolveAndValidateTargetPath(rawPath);
+    if (!validatedPath) {
+      return NextResponse.json({ ok: false, error: "invalid path" }, { status: 400 });
+    }
     try {
-      const uaPath = path.join(rawPath, ".understand-anything", "knowledge-graph.json");
+      const uaPath = path.join(validatedPath, ".understand-anything", "knowledge-graph.json");
       const raw = await fs.readFile(uaPath, "utf-8");
       const graphJson = normalizeUAGraph(JSON.parse(raw));
-      const label = path.basename(rawPath);
-      const id = `ua_${Buffer.from(rawPath).toString("base64url").slice(0, 16)}`;
+      const label = path.basename(validatedPath);
+      const id = `ua_${Buffer.from(validatedPath).toString("base64url").slice(0, 16)}`;
       const result: GraphifyResult = {
         id,
         label,
-        targetPath: rawPath,
+        targetPath: validatedPath,
         generatedAt: new Date().toISOString(),
         snapshots: [
           makeGraphRunSnapshot({
             id: `${id}_loaded`,
-            targetPath: rawPath,
+            targetPath: validatedPath,
             label,
             status: "completed",
             graphJson,


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/18](https://github.com/OpenCoven/coven-cave/security/code-scanning/18)

General fix: validate and normalize user-supplied paths before filesystem access, and enforce they remain inside a safe root directory.

Best fix in this file: in `GET`, inside the `rawPath` branch (around lines 242–270), run `rawPath` through `resolveAndValidateTargetPath`. Reject invalid/out-of-root paths with HTTP 400. Build `uaPath` from the validated absolute path, not from raw input. Use the validated path consistently for `label`, `id`, and `targetPath` so downstream metadata reflects the canonical safe path.

No new imports or dependencies are needed because `resolveAndValidateTargetPath` already exists in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
