### PR TITLE
Potential fix for code scanning alert no. 25: Uncontrolled data used in path expression

### DIFF
--- a/src/lib/server/project-paths.ts
+++ b/src/lib/server/project-paths.ts
@@ -33,8 +33,12 @@ function isWithinRoot(candidate: string, root: string): boolean {
 }
 
 export function resolveAllowedProjectPath(value: string): string | null {
-  const candidate = realpathOrResolve(value);
-  return ALLOWED_ROOTS.some((root) => isWithinRoot(candidate, root))
-    ? candidate
-    : null;
+  for (const root of ALLOWED_ROOTS) {
+    const canonicalRoot = realpathOrResolve(root);
+    const candidate = realpathOrResolve(path.resolve(canonicalRoot, value));
+    if (isWithinRoot(candidate, canonicalRoot)) {
+      return candidate;
+    }
+  }
+  return null;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/25](https://github.com/OpenCoven/coven-cave/security/code-scanning/25)

General fix: resolve untrusted input **relative to each allowed root**, canonicalize it (`path.resolve` + `fs.realpathSync` when possible), and only accept it if the canonicalized candidate remains within that same root. This prevents traversal outside roots and strengthens symlink handling.

Best targeted fix here (without changing intended functionality): update `resolveAllowedProjectPath` in `src/lib/server/project-paths.ts` so it no longer canonicalizes the raw user value independently. Instead, iterate through `ALLOWED_ROOTS`, build `path.resolve(root, value)`, canonicalize candidate and root, then check `isWithinRoot(candidate, canonicalRoot)`. Return the first allowed candidate, else `null`. This keeps existing API usage unchanged in `route.ts` and preserves current behavior of allowing files under configured roots.

Needed changes:
- File: `src/lib/server/project-paths.ts`
- Modify only `resolveAllowedProjectPath` implementation.
- No new dependencies required.
- No import changes required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
