### PR TITLE
Potential fix for code scanning alert no. 24: Uncontrolled data used in path expression

### DIFF
--- a/src/app/api/project-tree/route.ts
+++ b/src/app/api/project-tree/route.ts
@@ -56,7 +56,14 @@ export async function GET(req: NextRequest) {
       { status: 400 },
     );
   }
-  const allowedRoot = resolveAllowedProjectPath(root);
+  if (path.isAbsolute(root)) {
+    return NextResponse.json(
+      { ok: false, error: "absolute paths are not allowed" },
+      { status: 400 },
+    );
+  }
+  const requestedRoot = path.resolve(process.cwd(), root);
+  const allowedRoot = resolveAllowedProjectPath(requestedRoot);
   if (!allowedRoot) {
     return NextResponse.json(
       { ok: false, error: "path not allowed" },


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/24](https://github.com/OpenCoven/coven-cave/security/code-scanning/24)

To fix this without changing intended functionality, add explicit path normalization + containment enforcement in `GET` before calling `readTree`, using the already-computed `ALLOWED_ROOTS` policy indirectly via `resolveAllowedProjectPath`.

Best concrete approach in `src/app/api/project-tree/route.ts`:
1. Reject absolute `root` input from the request (`path.isAbsolute(root)`), so callers cannot directly request arbitrary absolute paths.
2. Resolve request input as a relative segment under the server working directory (`path.resolve(process.cwd(), root)`), then pass that resolved value into `resolveAllowedProjectPath`.
3. Keep existing `resolveAllowedProjectPath` check and 403 behavior.
4. Use the validated resolved path (`allowedRoot`) for `readTree` as before.

This preserves behavior for legitimate project-relative paths while preventing direct absolute-path probing and making the sanitization step obvious to CodeQL and reviewers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
