### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete URL substring sanitization

### DIFF
--- a/src/components/library-github-list.tsx
+++ b/src/components/library-github-list.tsx
@@ -92,7 +92,8 @@ function stateStyle(state?: LibraryGitHubItem["state"]): React.CSSProperties & {
 function parseGitHubUrl(url: string): { repo: string; kind: GitHubItemKind; number?: number } | null {
   try {
     const u = new URL(url);
-    if (!u.hostname.includes("github.com")) return null;
+    const hostname = u.hostname.toLowerCase();
+    if (hostname !== "github.com" && hostname !== "www.github.com") return null;
     const parts = u.pathname.replace(/^\//, "").split("/");
     if (parts.length < 2) return null;
     const repo = `${parts[0]}/${parts[1]}`;


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/6](https://github.com/OpenCoven/coven-cave/security/code-scanning/6)

Use parsed URL host validation with exact hostname allowlisting instead of substring matching.

Best fix here (without changing intended functionality) is to only accept:
- `github.com`
- `www.github.com` (optional compatibility)

In `src/components/library-github-list.tsx`, inside `parseGitHubUrl`, replace:
- `if (!u.hostname.includes("github.com")) return null;`
with strict normalized hostname checks:
- lowercase hostname
- compare against an explicit set of allowed hosts

No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
