### PR TITLE
polish(chat): make the chat full width

### DIFF
--- a/src/components/chat-view.test.ts
+++ b/src/components/chat-view.test.ts
@@ -25,8 +25,13 @@ assert.doesNotMatch(
 
 assert.match(
   assistantContentRule,
-  /width\s*:\s*min\(100%,\s*920px\)/,
-  "Assistant responses should use a wide readable content column",
+  /width\s*:\s*100%/,
+  "Assistant responses should span the full pane (full-width chat, 2026-06-12)",
+);
+assert.doesNotMatch(
+  assistantContentRule,
+  /(?:width|max-width):\s*(?:min\(100%,\s*)?920px/,
+  "The old 920px content cap must stay gone — chat is full width",
 );
 
 assert.match(

--- a/src/components/message-bubble-code-header.test.ts
+++ b/src/components/message-bubble-code-header.test.ts
@@ -86,30 +86,29 @@ assert.match(
 );
 
 // ---------------------------------------------------------------------------
-// CHAT-D10-04 — the shipped linear layout must cap its reading measure.
-// Without a cap, assistant prose runs 150+ chars/line on wide panes
-// (benchmarks: Claude.ai ~48rem, ChatGPT ~768px; we match the workbench's
-// 920px content cap). The composer shell shares the same measure so the
-// input lines up with the conversation column.
+// Full-width chat (2026-06-12) — supersedes CHAT-D10-04's 920px reading
+// measure by product decision: the thread and composer span the pane on
+// every width. The composer still shares the thread's measure so the input
+// lines up with the conversation column.
 // ---------------------------------------------------------------------------
 
 const linearThread = /\.cave-chat-linear \.cave-chat-thread \{[^}]*\}/.exec(css)?.[0] ?? "";
 assert.match(
   linearThread,
-  /max-width:\s*min\(100%,\s*920px\)/,
-  "Linear thread must cap its measure at 920px on wide panes",
+  /max-width:\s*100%/,
+  "Linear thread must span the full pane (full-width chat)",
 );
-assert.match(
+assert.doesNotMatch(
   linearThread,
-  /margin-inline:\s*auto/,
-  "Linear thread column must center inside wide panes",
+  /max-width:\s*(?:min\(100%,\s*)?920px/,
+  "The old 920px reading-measure cap must stay gone — chat is full width",
 );
 
 const linearComposerShell = /\.cave-chat-linear \.cave-composer-shell \{[^}]*\}/.exec(css)?.[0] ?? "";
 assert.match(
   linearComposerShell,
-  /max-width:\s*920px/,
-  "Linear composer shell must share the thread's 920px measure so the input aligns with the column",
+  /max-width:\s*100%/,
+  "Linear composer shell must share the thread's full-width measure so the input aligns with the column",
 );
 
 // ---------------------------------------------------------------------------

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -240,7 +240,7 @@
   /* CHAT-D7-03: the wrap is the block's vertical scroll container — huge
      blocks clamp instead of dominating the transcript (cf. the system
      bubble's 320px cap; benchmark: Claude Code truncates long blocks).
-     520px reads as ~24 code lines against the 920px thread measure.
+     520px reads as ~24 code lines.
      overflow-x stays hidden: the inner <pre> owns horizontal scrolling,
      and the wrap must keep clipping its rounded corners. */
   max-height: min(60vh, 520px);
@@ -594,8 +594,9 @@
   display: flex;
   flex-direction: column;
   gap: 18px;
-  width: min(100%, 1180px);
-  margin: 0 auto;
+  /* Full-width chat (2026-06-12): the thread spans the pane; the old
+     1180px centered column is gone. */
+  width: 100%;
 }
 
 .cave-chat-empty {
@@ -983,8 +984,8 @@
 
 .cave-turn-content {
   min-width: 0;
-  width: min(100%, 920px);
-  max-width: 920px;
+  /* Full-width chat (2026-06-12): responses span the pane (was 920px). */
+  width: 100%;
 }
 
 .cave-turn-card {
@@ -1573,12 +1574,10 @@ details[open] > .cave-tool-summary::before {
 
 .cave-chat-linear .cave-chat-thread {
   gap: 0;
+  /* Full-width chat (2026-06-12): supersedes CHAT-D10-04's 920px reading
+     measure — the thread now spans the pane on every width. */
   width: 100%;
-  /* CHAT-D10-04 — cap the reading measure on wide panes (Claude.ai ~48rem,
-     ChatGPT ~768px; we match the workbench's 920px .cave-turn-content cap)
-     and center the column. Collapses to 100% on narrow panes, so the
-     ≤767px mobile rules are unaffected. */
-  max-width: min(100%, 920px);
+  max-width: 100%;
   margin-block: 0;
   margin-inline: auto;
 }
@@ -1710,15 +1709,17 @@ details[open] > .cave-tool-summary::before {
 
 .cave-composer-shell {
   position: relative;
+  /* Full-width chat (2026-06-12): the composer shares the thread's
+     full-pane measure so the input lines up with the conversation. */
   width: 100%;
-  max-width: 1180px;
+  max-width: 100%;
   margin: 0 auto;
 }
 
 .cave-chat-linear .cave-composer-shell {
-  /* Share the thread's 920px measure (CHAT-D10-04) so the composer lines up
-     with the capped conversation column; base rule centers via margin auto. */
-  max-width: 920px;
+  /* Shares the thread's full-width measure so the input lines up with the
+     conversation column; base rule centers via margin auto. */
+  max-width: 100%;
 }
 
 .cave-chat-linear .cave-composer-panel {


### PR DESCRIPTION
## What

The chat thread, per-turn content, and composer now span the full chat pane instead of centering inside capped columns:

| Rule | Before | After |
|---|---|---|
| `.cave-chat-thread` | `min(100%, 1180px)` centered | `100%` |
| `.cave-turn-content` | `920px` cap | `100%` |
| `.cave-chat-linear .cave-chat-thread` | `min(100%, 920px)` (CHAT-D10-04) | `100%` |
| `.cave-composer-shell` (base + linear) | `1180px` / `920px` | `100%` |

This supersedes CHAT-D10-04's 920px reading measure by product decision (2026-06-12). The composer keeps sharing the thread's measure so the input stays aligned with the conversation column. Pin tests updated to the new contract.

## Verification

- `pnpm test:app` green.
- Live (worktree dev server + Playwright, 1728px viewport): thread and composer both measure 1118px — the full transcript pane (1186px minus 34px padding each side) — where the old linear cap held them at 920px. Screenshot eyeballed: assistant turns and composer span the pane, user bubbles stay right-aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)