### PR TITLE
chore(release): v0.0.76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.76] - 2026-06-12
+
+Cave gets a security-hardening sweep, safer dependency intake, production workflow starters, and more durable chat tool history.
+
+### Added
+- **Production workflow starter manifests** — default workflow manifests now ship with repository coverage so the Workflow view has real starting points to build from.
+- **Supply-chain policy test** — dependencies must stay exact-pinned, the pnpm manager version is pinned, and pnpm's 3-day `minimumReleaseAge` gate is enforced in CI.
+
+### Changed
+- **Dependency intake hardening** — package ranges are pinned exactly, future saves default to exact versions, and too-fresh package releases are delayed for three days before install eligibility.
+- **Chat layout polish** — the chat surface uses the available width more fully and settled tool activity can collapse behind a compact meta row.
+- **Role/workflow internals** — role-file scanning is shared through one source library, reducing drift between workflow and role surfaces.
+
+### Fixed
+- **Persisted tool-use rows** — assistant tool rows now survive refreshes and chat switches instead of existing only in live client state.
+- **CSV import stability** — CSV mapping no longer falls into a render loop.
+- **Security hardening** — CodeQL-driven fixes tightened browser-pane URL handling, GitHub enrichment URL validation, graph/project/chat path constraints, chat mention paths, CI workflow permissions, regex tag stripping, slug generation, and GitHub library host checks.
+
 ## [0.0.75] - 2026-06-12
 
 Cave gets safer library/workflow file handling, live onboarding jobs, and clearer session provenance.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A familiar is not just a chat window. It has a name, role, runtime, memory, tool
 
 ## Status
 
-- Current app version: `0.0.72`
+- Current app version: `0.0.76`
 - Native shell: Tauri 2
 - Frontend: Next.js 16, React 19, Tailwind v4
 - Runtime dependency: a healthy local `coven` CLI/daemon plus at least one runtime source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.75",
+  "version": "0.0.76",
   "private": true,
   "scripts": {
     "dev": "node --experimental-strip-types server.ts",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.75"
+version = "0.0.76"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.75"
+version = "0.0.76"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.75",
+  "version": "0.0.76",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- bump CovenCave app metadata to `0.0.76`
- add the `0.0.76` CHANGELOG entry for security, dependency, workflow, and chat persistence changes
- refresh README's current app version

## Test Plan
- `corepack pnpm test:supply-chain`
- `node --experimental-strip-types src/lib/app-version.test.ts`
- `node scripts/release-notes.test.mjs`
- `corepack pnpm typecheck`
- `(cd src-tauri && cargo check)`
- `git diff --check`
