### PR TITLE
feat(workflows): group library by personal vs public origin

### DIFF
--- a/src/components/workflows-view.test.ts
+++ b/src/components/workflows-view.test.ts
@@ -58,6 +58,8 @@ assert.match(client, /export function isPersonalWorkflow/, "Workflow client shou
 assert.match(client, /export function isPublicTemplate/, "Workflow client should expose the public-template predicate");
 assert.match(source, /if \(isPublicTemplate\(workflow\)\)[\s\S]{0,160}read-only/i, "Deleting a template should be blocked as read-only");
 assert.match(source, /const forking = isPublicTemplate\(workflow\)/, "Save should detect whether it is forking a template");
-assert.match(source, /forking \? "Forked to a personal copy/, "Saving a template edit should report a personal fork");
+assert.match(source, /uniqueId\(`\$\{slugifyWorkflowId\(workflow\.id\)\}-personal`\)/, "Forking a template should mint a new personal id (public-wins dedup hides same-id copies)");
+assert.match(source, /public: false/, "Forking should clear the public flag so the runtime routes the copy to ~/.coven");
+assert.match(source, /forking \? `Forked to a personal copy/, "Saving a template edit should report a personal fork");
 
 console.log("workflows-view.test.ts: ok");

--- a/src/components/workflows-view.test.ts
+++ b/src/components/workflows-view.test.ts
@@ -53,4 +53,11 @@ assert.match(client, /\/api\/workflows\/layout/, "Workflow client should call th
 assert.match(client, /\/api\/roles\/workflows/, "Workflow client should call the role-attach route");
 assert.match(client, /cave:\/\/workflows\//, "Scheduled reminders should deep-link back to the workflow");
 
+// Read-only templates + fork-on-save.
+assert.match(client, /export function isPersonalWorkflow/, "Workflow client should expose the personal-origin predicate");
+assert.match(client, /export function isPublicTemplate/, "Workflow client should expose the public-template predicate");
+assert.match(source, /if \(isPublicTemplate\(workflow\)\)[\s\S]{0,160}read-only/i, "Deleting a template should be blocked as read-only");
+assert.match(source, /const forking = isPublicTemplate\(workflow\)/, "Save should detect whether it is forking a template");
+assert.match(source, /forking \? "Forked to a personal copy/, "Saving a template edit should report a personal fork");
+
 console.log("workflows-view.test.ts: ok");

--- a/src/components/workflows-view.tsx
+++ b/src/components/workflows-view.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/lib/workflow-draft";
 import {
   attachWorkflowToRole,
+  isPublicTemplate,
   loadWorkflowLayout,
   saveWorkflowLayout,
   deleteWorkflow,
@@ -295,6 +296,10 @@ export function WorkflowsView() {
   };
 
   const runSave = async (workflow: WorkflowSummary) => {
+    // Templates are read-only: saving an edit forks a personal copy under
+    // ~/.coven (the runtime routes any non-public manifest there) and leaves the
+    // repo template untouched.
+    const forking = isPublicTemplate(workflow);
     setBusyId(`${workflow.id}:save`);
     try {
       const result = await saveWorkflow(workflowToManifest(workflow));
@@ -309,7 +314,7 @@ export function WorkflowsView() {
         setDraftState(initialWorkflowDraft(result.workflow));
         setSelectedWorkflowId(result.workflow.id);
       }
-      showNotice("Workflow saved.");
+      showNotice(forking ? "Forked to a personal copy — the template stays untouched." : "Workflow saved.");
       void load(true);
     } finally {
       setBusyId(null);
@@ -367,6 +372,10 @@ export function WorkflowsView() {
   };
 
   const handleDelete = async (workflow: WorkflowSummary) => {
+    if (isPublicTemplate(workflow)) {
+      showNotice("Templates are read-only — duplicate to make an editable copy.");
+      return;
+    }
     if (!window.confirm(`Delete workflow \`${workflow.id}\`? The manifest file is removed.`)) return;
     const result = await deleteWorkflow(
       workflow.path ? { path: workflow.path } : { id: workflow.id },

--- a/src/components/workflows-view.tsx
+++ b/src/components/workflows-view.tsx
@@ -296,26 +296,41 @@ export function WorkflowsView() {
   };
 
   const runSave = async (workflow: WorkflowSummary) => {
-    // Templates are read-only: saving an edit forks a personal copy under
-    // ~/.coven (the runtime routes any non-public manifest there) and leaves the
-    // repo template untouched.
+    // Templates are read-only. Saving an edit forks a *new* personal workflow
+    // under ~/.coven and leaves the repo template untouched. The fork takes a
+    // distinct id (`<id>-personal`): the runtime's library is public-wins on id
+    // collisions, so a same-id personal copy would be shadowed and invisible.
+    // A manifest is routed to ~/.coven unless `visibility.public === true`, so
+    // the fork clears that flag.
     const forking = isPublicTemplate(workflow);
     setBusyId(`${workflow.id}:save`);
     try {
-      const result = await saveWorkflow(workflowToManifest(workflow));
+      let manifest = workflowToManifest(workflow);
+      if (forking) {
+        const forkId = uniqueId(`${slugifyWorkflowId(workflow.id)}-personal`);
+        const visibility = {
+          ...(manifest.visibility && typeof manifest.visibility === "object"
+            ? (manifest.visibility as Record<string, unknown>)
+            : {}),
+          public: false,
+          personal: true,
+        };
+        manifest = { ...manifest, id: forkId, visibility };
+      }
+      const result = await saveWorkflow(manifest);
       if (!result.ok) {
         showNotice(result.error ?? "save failed");
         return;
       }
+      const saved = result.workflow ?? workflow;
       if (result.validation) {
-        setAction({ id: workflow.id, kind: "validate", result: result.validation });
+        setAction({ id: saved.id, kind: "validate", result: result.validation });
       }
-      if (result.workflow) {
-        setDraftState(initialWorkflowDraft(result.workflow));
-        setSelectedWorkflowId(result.workflow.id);
-      }
-      showNotice(forking ? "Forked to a personal copy — the template stays untouched." : "Workflow saved.");
+      setDraftState(initialWorkflowDraft(saved));
+      setSelectedWorkflowId(saved.id);
+      showNotice(forking ? `Forked to a personal copy: ${saved.id} — the template stays untouched.` : "Workflow saved.");
       void load(true);
+      if (forking) void loadRuns(saved.id);
     } finally {
       setBusyId(null);
     }

--- a/src/components/workflows/workflow-library.tsx
+++ b/src/components/workflows/workflow-library.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
-import type { WorkflowSummary } from "@/lib/workflows";
+import { isPersonalWorkflow, isPublicTemplate, type WorkflowSummary } from "@/lib/workflows";
 
 type WorkflowLibraryProps = {
   workflows: WorkflowSummary[];
@@ -24,16 +24,6 @@ const validationLabels: Record<NonNullable<WorkflowSummary["validation_state"]>,
   invalid: "Blocked",
   unknown: "Unknown",
 };
-
-/**
- * A workflow is "personal" when its manifest lives under the user's private
- * Coven home (`storage: "personal"`, i.e. `~/.coven/workflows`). Everything
- * else — repo templates and role-declared placeholders — reads as a shared
- * public template. The library groups by this so the two never blur together.
- */
-function isPersonal(workflow: WorkflowSummary): boolean {
-  return workflow.storage === "personal";
-}
 
 function matchesQuery(workflow: WorkflowSummary, query: string): boolean {
   const haystack = [
@@ -75,7 +65,7 @@ export function WorkflowLibrary({
     const personal: WorkflowSummary[] = [];
     const templates: WorkflowSummary[] = [];
     for (const workflow of visible) {
-      (isPersonal(workflow) ? personal : templates).push(workflow);
+      (isPersonalWorkflow(workflow) ? personal : templates).push(workflow);
     }
     return { personal, templates };
   }, [visible]);
@@ -83,7 +73,7 @@ export function WorkflowLibrary({
   const renderItem = (workflow: WorkflowSummary) => {
     const active = selectedWorkflow?.id === workflow.id;
     const validationState = workflow.validation_state ?? "unknown";
-    const personal = isPersonal(workflow);
+    const personal = isPersonalWorkflow(workflow);
     return (
       <button
         key={`${workflow.id}:${workflow.path ?? ""}`}
@@ -197,19 +187,32 @@ export function WorkflowLibrary({
 
       {selectedWorkflow && (
         <div className="workflow-library-footer">
-          <button type="button" onClick={() => onDuplicate(selectedWorkflow)} title="Duplicate selected workflow">
-            <Icon name="ph:copy" width={13} />
-            Duplicate
-          </button>
-          <button
-            type="button"
-            className="workflow-danger-button"
-            onClick={() => onDelete(selectedWorkflow)}
-            title="Delete selected workflow"
-          >
-            <Icon name="ph:trash" width={13} />
-            Delete
-          </button>
+          {isPublicTemplate(selectedWorkflow) && (
+            <p className="workflow-library-footer-note" title="Templates live in the repo (workflows/). Editing and saving forks a personal copy to ~/.coven; the template itself stays untouched.">
+              <Icon name="ph:lock-simple" width={12} />
+              Read-only template — edits fork a personal copy
+            </p>
+          )}
+          <div className="workflow-library-footer-actions">
+            <button type="button" onClick={() => onDuplicate(selectedWorkflow)} title="Duplicate selected workflow">
+              <Icon name="ph:copy" width={13} />
+              Duplicate
+            </button>
+            <button
+              type="button"
+              className="workflow-danger-button"
+              disabled={isPublicTemplate(selectedWorkflow)}
+              onClick={() => onDelete(selectedWorkflow)}
+              title={
+                isPublicTemplate(selectedWorkflow)
+                  ? "Templates are read-only — duplicate to make an editable copy"
+                  : "Delete selected workflow"
+              }
+            >
+              <Icon name="ph:trash" width={13} />
+              Delete
+            </button>
+          </div>
         </div>
       )}
     </aside>

--- a/src/components/workflows/workflow-library.tsx
+++ b/src/components/workflows/workflow-library.tsx
@@ -25,6 +25,16 @@ const validationLabels: Record<NonNullable<WorkflowSummary["validation_state"]>,
   unknown: "Unknown",
 };
 
+/**
+ * A workflow is "personal" when its manifest lives under the user's private
+ * Coven home (`storage: "personal"`, i.e. `~/.coven/workflows`). Everything
+ * else — repo templates and role-declared placeholders — reads as a shared
+ * public template. The library groups by this so the two never blur together.
+ */
+function isPersonal(workflow: WorkflowSummary): boolean {
+  return workflow.storage === "personal";
+}
+
 function matchesQuery(workflow: WorkflowSummary, query: string): boolean {
   const haystack = [
     workflow.id,
@@ -60,6 +70,49 @@ export function WorkflowLibrary({
     if (!trimmed) return workflows;
     return workflows.filter((workflow) => matchesQuery(workflow, trimmed));
   }, [query, workflows]);
+
+  const groups = useMemo(() => {
+    const personal: WorkflowSummary[] = [];
+    const templates: WorkflowSummary[] = [];
+    for (const workflow of visible) {
+      (isPersonal(workflow) ? personal : templates).push(workflow);
+    }
+    return { personal, templates };
+  }, [visible]);
+
+  const renderItem = (workflow: WorkflowSummary) => {
+    const active = selectedWorkflow?.id === workflow.id;
+    const validationState = workflow.validation_state ?? "unknown";
+    const personal = isPersonal(workflow);
+    return (
+      <button
+        key={`${workflow.id}:${workflow.path ?? ""}`}
+        type="button"
+        className={`workflow-library-item${active ? " is-active" : ""}`}
+        onClick={() => onSelectWorkflow(workflow)}
+      >
+        <span className="workflow-library-item-title">
+          <span className="workflow-library-item-name">{workflow.name ?? workflow.id}</span>
+          {active && dirty && <span className="workflow-dirty-dot" title="Unsaved changes" />}
+          <span
+            className={`workflow-origin-dot workflow-origin-dot-${personal ? "personal" : "public"}`}
+            title={
+              personal
+                ? "Personal — private to you (~/.coven/workflows)"
+                : "Template — shared in the repo (workflows/)"
+            }
+            aria-label={personal ? "Personal workflow" : "Public template"}
+          />
+        </span>
+        <span className="workflow-library-item-meta">
+          <span className={`workflow-health workflow-health-${validationState}`} />
+          {validationLabels[validationState]} · v{workflow.version}
+          {workflow.pattern ? ` · ${workflow.pattern}` : ""}
+        </span>
+        {workflow.summary && <span className="workflow-library-item-summary">{workflow.summary}</span>}
+      </button>
+    );
+  };
 
   return (
     <aside className="workflow-library" aria-label="Workflow library">
@@ -119,29 +172,26 @@ export function WorkflowLibrary({
           {visible.length === 0 && (
             <div className="workflow-library-state">No workflows match “{query.trim()}”.</div>
           )}
-          {visible.map((workflow) => {
-            const active = selectedWorkflow?.id === workflow.id;
-            const validationState = workflow.validation_state ?? "unknown";
-            return (
-              <button
-                key={`${workflow.id}:${workflow.path ?? ""}`}
-                type="button"
-                className={`workflow-library-item${active ? " is-active" : ""}`}
-                onClick={() => onSelectWorkflow(workflow)}
-              >
-                <span className="workflow-library-item-title">
-                  {workflow.name ?? workflow.id}
-                  {active && dirty && <span className="workflow-dirty-dot" title="Unsaved changes" />}
-                </span>
-                <span className="workflow-library-item-meta">
-                  <span className={`workflow-health workflow-health-${validationState}`} />
-                  {validationLabels[validationState]} · v{workflow.version}
-                  {workflow.pattern ? ` · ${workflow.pattern}` : ""}
-                </span>
-                {workflow.summary && <span className="workflow-library-item-summary">{workflow.summary}</span>}
-              </button>
-            );
-          })}
+          {groups.personal.length > 0 && (
+            <section className="workflow-library-group" aria-label="Personal workflows">
+              <p className="workflow-library-group-heading">
+                <span className="workflow-origin-dot workflow-origin-dot-personal" aria-hidden />
+                Personal
+                <span className="workflow-library-group-count">{groups.personal.length}</span>
+              </p>
+              {groups.personal.map(renderItem)}
+            </section>
+          )}
+          {groups.templates.length > 0 && (
+            <section className="workflow-library-group" aria-label="Public templates">
+              <p className="workflow-library-group-heading">
+                <span className="workflow-origin-dot workflow-origin-dot-public" aria-hidden />
+                Templates
+                <span className="workflow-library-group-count">{groups.templates.length}</span>
+              </p>
+              {groups.templates.map(renderItem)}
+            </section>
+          )}
         </div>
       )}
 

--- a/src/components/workflows/workflow-run-strip.tsx
+++ b/src/components/workflows/workflow-run-strip.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Icon } from "@/lib/icon";
-import { workflowIssueSummary, type WorkflowValidationIssue, type WorkflowSummary } from "@/lib/workflows";
+import { isPublicTemplate, workflowIssueSummary, type WorkflowValidationIssue, type WorkflowSummary } from "@/lib/workflows";
 import type { WorkflowStudioActionState } from "./workflow-studio";
 
 type WorkflowRunStripProps = {
@@ -48,6 +48,9 @@ export function WorkflowRunStrip({
   const playBusy = workflow ? busyId === `${workflow.id}:play` : false;
   const saveBusy = workflow ? busyId === `${workflow.id}:save` : false;
   const anyBusy = busyId !== null;
+  // Templates are read-only; saving an edit forks a personal copy to ~/.coven.
+  const forking = workflow ? isPublicTemplate(workflow) : false;
+  const saveLabel = saveBusy ? (forking ? "Forking" : "Saving") : forking ? "Fork & Save" : "Save";
 
   return (
     <section className="workflow-run-strip" aria-label="Workflow actions">
@@ -77,10 +80,16 @@ export function WorkflowRunStrip({
           className="workflow-primary-button"
           disabled={!workflow || anyBusy || !dirty}
           onClick={() => workflow && onSave(workflow)}
-          title={dirty ? "Save manifest to disk" : "No unsaved changes"}
+          title={
+            !dirty
+              ? "No unsaved changes"
+              : forking
+                ? "Read-only template — saves a personal copy to ~/.coven"
+                : "Save manifest to disk"
+          }
         >
-          <Icon name="ph:floppy-disk-bold" width={14} />
-          {saveBusy ? "Saving" : "Save"}
+          <Icon name={forking ? "ph:git-fork-bold" : "ph:floppy-disk-bold"} width={14} />
+          {saveLabel}
         </button>
         <button type="button" disabled={!workflow || anyBusy} onClick={() => workflow && onValidate(workflow)}>
           <Icon name="ph:check-circle-bold" width={14} />

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -67,6 +67,7 @@ assert.match(
   "WorkflowManifestPreview should keep the sidecar boundary visible",
 );
 assert.match(css, /\.workflow-studio-shell/, "workflow CSS should style the studio shell");
+assert.match(css, /\.workflow-studio-shell \{[\s\S]{0,700}padding:\s*16px 16px 16px 0/, "Studio shell drops left padding so the library hugs the app nav (no blank band)");
 assert.match(css, /@media \(max-width: 860px\)/, "workflow CSS should include mobile studio layout");
 assert.match(
   css,

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -68,6 +68,14 @@ assert.match(
 );
 assert.match(css, /\.workflow-studio-shell/, "workflow CSS should style the studio shell");
 assert.match(css, /\.workflow-studio-shell \{[\s\S]{0,700}padding:\s*16px 16px 16px 0/, "Studio shell drops left padding so the library hugs the app nav (no blank band)");
+{
+  // The collapsed left library rail keeps its hairline divider but drops the
+  // background fill so the toggle blends with the canvas.
+  const collapsedLeft = css.match(/\.workflow-studio-shell\.is-left-collapsed > \.workflow-studio-library-panel \{[\s\S]*?\}/);
+  assert.ok(collapsedLeft, "Collapsed left library rail rule should exist");
+  assert.ok(/border-right/.test(collapsedLeft[0]), "Collapsed left rail keeps its hairline divider");
+  assert.ok(!/background/.test(collapsedLeft[0]), "Collapsed left rail should have no background fill");
+}
 assert.match(css, /@media \(max-width: 860px\)/, "workflow CSS should include mobile studio layout");
 assert.match(
   css,

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -169,13 +169,21 @@ assert.match(library, /workflow-dirty-dot/, "Library should mark unsaved drafts"
 
 // Personal vs public split: the library groups by manifest origin so private
 // (~/.coven) workflows never blur into shared repo templates.
-assert.match(library, /storage === "personal"/, "Library should classify workflows by storage origin");
+assert.match(library, /isPersonalWorkflow\(workflow\)/, "Library should classify workflows by storage origin");
 assert.match(library, /groups\.personal[\s\S]{0,400}Personal[\s\S]{0,400}groups\.templates[\s\S]{0,400}Templates/, "Library should render Personal then Templates groups");
 assert.match(library, /workflow-origin-dot-personal/, "Personal rows should carry a personal origin badge");
 assert.match(library, /workflow-origin-dot-public/, "Template rows should carry a public origin badge");
 assert.match(css, /\.workflow-library-group-heading/, "CSS should style the origin group headings");
 assert.match(css, /\.workflow-origin-dot-personal/, "CSS should style the personal origin badge");
 assert.match(css, /\.workflow-origin-dot-public/, "CSS should style the public origin badge");
+
+// Read-only templates: delete is blocked and saving forks a personal copy.
+assert.match(library, /disabled=\{isPublicTemplate\(selectedWorkflow\)\}/, "Delete should be disabled for read-only templates");
+assert.match(library, /Read-only template/, "Library footer should flag read-only templates");
+assert.match(css, /\.workflow-library-footer-note/, "CSS should style the read-only template note");
+assert.match(css, /\.workflow-library-footer button:disabled/, "CSS should dim disabled footer buttons");
+assert.match(runStrip, /isPublicTemplate\(workflow\)/, "Run strip should detect read-only templates");
+assert.match(runStrip, /Fork & Save/, "Save button should read 'Fork & Save' for templates");
 
 assert.match(manifestPreview, /workflowToYaml/, "Manifest preview should render live canonical YAML");
 

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -167,6 +167,16 @@ assert.match(library, /Delete/, "Library should offer delete");
 assert.match(library, /onCreateRequest/, "Library should offer new-workflow creation");
 assert.match(library, /workflow-dirty-dot/, "Library should mark unsaved drafts");
 
+// Personal vs public split: the library groups by manifest origin so private
+// (~/.coven) workflows never blur into shared repo templates.
+assert.match(library, /storage === "personal"/, "Library should classify workflows by storage origin");
+assert.match(library, /groups\.personal[\s\S]{0,400}Personal[\s\S]{0,400}groups\.templates[\s\S]{0,400}Templates/, "Library should render Personal then Templates groups");
+assert.match(library, /workflow-origin-dot-personal/, "Personal rows should carry a personal origin badge");
+assert.match(library, /workflow-origin-dot-public/, "Template rows should carry a public origin badge");
+assert.match(css, /\.workflow-library-group-heading/, "CSS should style the origin group headings");
+assert.match(css, /\.workflow-origin-dot-personal/, "CSS should style the personal origin badge");
+assert.match(css, /\.workflow-origin-dot-public/, "CSS should style the public origin badge");
+
 assert.match(manifestPreview, /workflowToYaml/, "Manifest preview should render live canonical YAML");
 
 assert.match(css, /\.workflow-palette/, "CSS should style the palette");

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -53,6 +53,22 @@ export type WorkflowSummary = {
   storage?: "public" | "personal";
 };
 
+/** A workflow whose manifest lives in the user's private Coven home (`~/.coven`). */
+export function isPersonalWorkflow(workflow: WorkflowSummary): boolean {
+  return workflow.storage === "personal";
+}
+
+/**
+ * A shared repo template (lives under `workflows/`). Templates are read-only in
+ * the Cave: deleting is blocked, and saving an edit *forks* a personal copy
+ * under `~/.coven` rather than mutating the repo file. `storage` is only set
+ * once the runtime has resolved the manifest's origin; an unknown origin is
+ * treated as editable so behavior is unchanged until the runtime lands.
+ */
+export function isPublicTemplate(workflow: WorkflowSummary): boolean {
+  return workflow.storage === "public";
+}
+
 export type WorkflowValidationTier = "schema" | "semantic" | "preflight";
 
 export type WorkflowValidationIssue = {

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -39,9 +39,18 @@ export type WorkflowSummary = {
   path?: string;
   validation_state?: "valid" | "warning" | "invalid" | "unknown";
   visibility?: {
+    public?: boolean;
+    personal?: boolean;
     coven_code?: boolean;
     coven_cave?: boolean;
   };
+  /**
+   * Where the manifest lives, derived from its on-disk location — not stored in
+   * the YAML. `public` manifests are repo templates under `workflows/`;
+   * `personal` manifests are private to the user under `~/.coven/workflows/`.
+   * The Workflow Studio groups the library by this so the two never blur.
+   */
+  storage?: "public" | "personal";
 };
 
 export type WorkflowValidationTier = "schema" | "semantic" | "preflight";

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -55,7 +55,6 @@
 
 .workflow-studio-shell.is-left-collapsed > .workflow-studio-library-panel {
   border-right: 1px solid var(--border-hairline);
-  background: color-mix(in oklch, var(--bg-raised) 40%, transparent);
 }
 
 .workflow-studio-shell.is-right-collapsed > .workflow-studio-side {

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -8,7 +8,9 @@
   height: 100%;
   min-height: 0;
   overflow: hidden;
-  padding: 16px;
+  /* No left padding: the library panel sits flush against the app nav so there
+     is no blank band between the two. Top/right/bottom keep their breathing room. */
+  padding: 16px 16px 16px 0;
   color: var(--text-primary);
   background: var(--background);
 }

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -205,7 +205,39 @@
 .workflow-library-list {
   display: flex;
   flex-direction: column;
+  gap: 14px;
+}
+
+.workflow-library-group {
+  display: flex;
+  flex-direction: column;
   gap: 8px;
+}
+
+.workflow-library-group-heading {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  padding: 0 2px;
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+}
+
+.workflow-library-group-count {
+  margin-left: auto;
+  min-width: 16px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--muted);
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0;
+  text-align: center;
 }
 
 .workflow-library-item {
@@ -220,15 +252,43 @@
   text-align: left;
 }
 
+.workflow-library-item-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Origin marker: a diamond for personal (private to ~/.coven), a dot for shared
+   repo templates. Mirrors the section badges so a row reads on its own too. */
+.workflow-origin-dot {
+  flex: 0 0 auto;
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+}
+
+.workflow-origin-dot-public {
+  background: var(--muted-foreground);
+}
+
+.workflow-origin-dot-personal {
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--foreground) 72%, var(--primary, #6d5ae0));
+  transform: rotate(45deg);
+}
+
 .workflow-library-item.is-active {
   border-color: color-mix(in srgb, var(--foreground) 36%, var(--border));
   background: var(--muted);
 }
 
 .workflow-library-item-title {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 6px;
   font-size: 13px;
   font-weight: 650;
 }

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -679,9 +679,25 @@
 
 .workflow-library-footer {
   display: flex;
+  flex-direction: column;
   gap: 8px;
   padding: 10px 12px;
   border-top: 1px solid var(--border);
+}
+
+.workflow-library-footer-note {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.3;
+  color: var(--muted-foreground);
+}
+
+.workflow-library-footer-actions {
+  display: flex;
+  gap: 8px;
 }
 
 .workflow-library-footer button {
@@ -693,6 +709,11 @@
   border: 1px solid var(--border);
   border-radius: 7px;
   background: var(--card);
+}
+
+.workflow-library-footer button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .workflow-danger-button,


### PR DESCRIPTION
## What

Makes the personal-vs-public split first-class in the Workflow Studio.

**Library display**
- **Grouped sections** — `Personal` first, then `Templates`, each with a count badge.
- **Per-row origin marker** — a diamond for personal (private `~/.coven/workflows`), a dot for shared repo templates, with hover tooltips spelling out the location.

**Read-only templates + fork-on-save**
- Delete is **disabled** on template rows (library footer + a controller-side guard), with a "duplicate to make an editable copy" affordance.
- Saving an edit to a template **forks a personal copy** to `~/.coven` instead of mutating the repo file — the Save button reads **"Fork & Save"**, and the controller reports *"Forked to a personal copy — the template stays untouched."*

**Plumbing**
- Adds `storage: "public" | "personal"` to `WorkflowSummary` — derived from the manifest's on-disk location, **never** written into the YAML.
- Centralizes origin predicates as `isPersonalWorkflow` / `isPublicTemplate` in the client-safe `workflows.ts`.

## Scope — UI / controller only

This is the **presentation + interaction half**. The runtime that resolves the two manifest directories (`workflows/` repo templates vs `~/.coven/workflows/` personal) and populates `storage` is landing **separately**.

Everything is gated strictly on `storage === "public"`, so until the runtime sets it, an unknown origin keeps **current editable behavior** and all workflows render under **Templates** (accurate — they're all repo manifests today). The runtime's save routing already writes a non-public manifest to `~/.coven`, so fork-on-save composes cleanly once it lands.

## Verification

- `pnpm typecheck` — clean
- Full workflow test suite (`workflows`, `workflow-graph`, `workflow-source`, `workflow-edit`, `workflow-draft`, `workflow-runs`, `workflows-view`, `workflow-studio`) — all pass
- Behavior assertions added in the repo's source-string idiom

## Merge ordering

Recommend this merges **after** the runtime branch — the Personal group, read-only state, and fork notice all activate once `storage` is exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)