### PR TITLE
polish(shell): Coven Cave sidebar title; trim right rail to Salem

### DIFF
--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -86,10 +86,12 @@ assert.match(
   /edge-rail-chip[\s\S]{0,80}ph:cat/,
   "right agent rail toggle renders its icon inside the pressable chip",
 );
-assert.match(
+// The right rail is Salem-only — the browser globe tab was retired; the
+// Browser surface is still reachable via the nav (⌘7).
+assert.doesNotMatch(
   workspace,
-  /edge-rail-chip[\s\S]{0,80}ph:globe/,
-  "right agent rail exposes a browser tab inside the pressable chip",
+  /agent-trigger-rail__toggle[\s\S]{0,160}ph:globe/,
+  "right agent rail no longer exposes the browser globe tab",
 );
 assert.match(
   css,

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -228,6 +228,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
           hands off to the left-edge rail, which reopens the panel. */}
       {onToggleSidebar ? (
         <div className="sidebar-header">
+          <span className="sidebar-title">Coven Cave</span>
           <button
             type="button"
             className="sidebar-toggle"

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1362,17 +1362,6 @@ export function Workspace() {
             <button
               type="button"
               className="agent-trigger-rail__toggle"
-              aria-label="Open browser panel"
-              title="Browser"
-              onClick={() => openCompanionTab("browser")}
-            >
-              <span className="edge-rail-chip">
-                <Icon name="ph:globe" width={14} />
-              </span>
-            </button>
-            <button
-              type="button"
-              className="agent-trigger-rail__toggle"
               aria-label="Toggle Salem"
               title="Toggle Salem (⌘J)"
               onClick={() => openCompanionTab("salem")}

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -25,16 +25,29 @@
 .sidebar-header {
   display: flex;
   align-items: center;
-  padding: 0;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 7px;
   flex-shrink: 0;
+}
+
+.sidebar-title {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .sidebar-toggle {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  width: 100%;
-  padding: 0 7px;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 28px;
+  padding: 0;
   height: 28px;
   border-radius: 8px;
   border: 1px solid transparent;


### PR DESCRIPTION
## What

- **Sidebar title** — add a "Coven Cave" title to the minimal sidebar header; the panel toggle moves to the right of it (was a full-width right-aligned toggle).
- **Right edge rail** — remove the browser globe tab, leaving only the Salem cat. With one toggle the stacked rail centers it vertically. The Browser surface is still reachable from the nav (⌘7).
- **Test** — `shell-edge-rails.test.ts` now asserts the globe tab is gone and keeps the cat assertion.

## Verification

Driven live (Playwright against the dev app):
- Right rail: `globeButtons: 0`, `catButtons: 1`, chip vertically centered (deltaPx 0).
- Collapsed nav reopen chip: vertically centered (deltaPx 0); clicking it reopens the sidebar.
- Header reads "Coven Cave" with the toggle to its right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)