### PR TITLE
fix(workflows): focus the fork after save, not the template

### DIFF
--- a/src/components/workflows-view.test.ts
+++ b/src/components/workflows-view.test.ts
@@ -61,5 +61,6 @@ assert.match(source, /const forking = isPublicTemplate\(workflow\)/, "Save shoul
 assert.match(source, /uniqueId\(`\$\{slugifyWorkflowId\(workflow\.id\)\}-personal`\)/, "Forking a template should mint a new personal id (public-wins dedup hides same-id copies)");
 assert.match(source, /public: false/, "Forking should clear the public flag so the runtime routes the copy to ~/.coven");
 assert.match(source, /forking \? `Forked to a personal copy/, "Saving a template edit should report a personal fork");
+assert.match(source, /await load\(true\);\s*\n\s*setSelectedWorkflowId\(saved\.id\)/, "Save must refresh the list before re-selecting so a fork's new id exists when selected (else the selection effect falls back to the template)");
 
 console.log("workflows-view.test.ts: ok");

--- a/src/components/workflows-view.tsx
+++ b/src/components/workflows-view.tsx
@@ -326,10 +326,15 @@ export function WorkflowsView() {
       if (result.validation) {
         setAction({ id: saved.id, kind: "validate", result: result.validation });
       }
-      setDraftState(initialWorkflowDraft(saved));
+      // Refresh the list BEFORE re-selecting: a fork lands under a new id, and
+      // the selection effect would otherwise run against the stale list, fail to
+      // find the new id, and fall back to workflows[0] (the template). Awaiting
+      // load first means the fork exists when we select it. (handleDuplicate
+      // uses the same ordering.)
+      await load(true);
       setSelectedWorkflowId(saved.id);
+      setDraftState(initialWorkflowDraft(saved));
       showNotice(forking ? `Forked to a personal copy: ${saved.id} — the template stays untouched.` : "Workflow saved.");
-      void load(true);
       if (forking) void loadRuns(saved.id);
     } finally {
       setBusyId(null);


### PR DESCRIPTION
## What

Forking a template (Fork & Save) created the personal copy correctly but left the studio **focused on the template** instead of the new fork.

`runSave` set `selectedWorkflowId` to the saved id, then called `load(true)` **without awaiting**. The selection effect (`workflows-view.tsx`) ran against the stale list, couldn't find the fork's new `<id>-personal`, and fell back to `workflows[0]` — the template.

**Fix:** await `load(true)` *before* re-selecting, so the fork exists in the list when it's selected (the same ordering `handleDuplicate` already uses).

## Verification

Found during an end-to-end dev-app verification of the fork flow (the feature merged in #515). Re-ran the same flow after the fix:

- **Before:** after Fork & Save, active row = `Annotate Document` (Template).
- **After:** active row = `Annotate Document (forked)` under **Personal**, inspector title matches, notice unchanged. No console errors.

Drove the real UI (Playwright) against `next dev` with `COVEN_HOME` pointed at a temp dir (real `~/.coven` untouched). `pnpm typecheck` clean; `workflows-view` / `workflow-studio` / `workflows` tests pass; ordering locked with a source assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)