### PR TITLE
feat(github): filter by org → repo and group the activity table

### DIFF
--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import type { Familiar } from "@/lib/types";
 import type { Card, CardStatus } from "@/lib/cave-board-types";
@@ -28,6 +28,14 @@ type Filter = "all" | "pr" | "review_request" | "issue";
 
 type SortKey = "kind" | "repo" | "title" | "tasks" | "updatedAt";
 type SortDir = "asc" | "desc";
+
+type GroupBy = "none" | "org" | "repo";
+
+/** `item.repo` is "owner/name" — the organization is the slash prefix. */
+function orgOf(repo: string): string {
+  const i = repo.indexOf("/");
+  return i === -1 ? repo : repo.slice(0, i);
+}
 
 type Props = {
   onJumpToSession?: (sessionId: string, familiarId?: string | null) => void;
@@ -537,6 +545,9 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<Filter>("all");
+  const [orgFilter, setOrgFilter] = useState<string>("all");
+  const [repoFilter, setRepoFilter] = useState<string>("all");
+  const [groupBy, setGroupBy] = useState<GroupBy>("none");
   const [showPatModal, setShowPatModal] = useState(false);
   const [sortKey, setSortKey] = useState<SortKey>("updatedAt");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
@@ -616,16 +627,46 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
   const items = activity?.items ?? [];
   const filtered = filter === "all" ? items : items.filter((i) => i.kind === filter);
 
+  // Organization options come from the kind-filtered set; repository options
+  // narrow to the chosen org so the two selects cascade (org → repo).
+  const orgOptions = useMemo(
+    () => Array.from(new Set(filtered.map((i) => orgOf(i.repo)))).sort((a, b) => a.localeCompare(b)),
+    [filtered],
+  );
+  const repoOptions = useMemo(() => {
+    const base = orgFilter === "all" ? filtered : filtered.filter((i) => orgOf(i.repo) === orgFilter);
+    return Array.from(new Set(base.map((i) => i.repo))).sort((a, b) => a.localeCompare(b));
+  }, [filtered, orgFilter]);
+
+  // Drop a stale org/repo selection when the underlying options change (e.g.
+  // the kind filter or org filter removed the previously-selected value).
+  useEffect(() => {
+    if (orgFilter !== "all" && !orgOptions.includes(orgFilter)) setOrgFilter("all");
+  }, [orgOptions, orgFilter]);
+  useEffect(() => {
+    if (repoFilter !== "all" && !repoOptions.includes(repoFilter)) setRepoFilter("all");
+  }, [repoOptions, repoFilter]);
+
+  const scoped = useMemo(
+    () =>
+      filtered.filter(
+        (i) =>
+          (orgFilter === "all" || orgOf(i.repo) === orgFilter) &&
+          (repoFilter === "all" || i.repo === repoFilter),
+      ),
+    [filtered, orgFilter, repoFilter],
+  );
+
   const linkedMap = useMemo(() => {
     const m = new Map<string, Card[]>();
-    for (const item of filtered) {
+    for (const item of scoped) {
       m.set(item.id, linkedCardsForItem(cards, item));
     }
     return m;
-  }, [filtered, cards]);
+  }, [scoped, cards]);
 
   const sorted = useMemo(() => {
-    const arr = [...filtered];
+    const arr = [...scoped];
     arr.sort((a, b) => {
       let cmp = 0;
       switch (sortKey) {
@@ -654,7 +695,21 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
       return sortDir === "asc" ? cmp : -cmp;
     });
     return arr;
-  }, [filtered, sortKey, sortDir, linkedMap]);
+  }, [scoped, sortKey, sortDir, linkedMap]);
+
+  // When grouping is on, bucket the already-sorted rows by org or full repo.
+  // Map insertion order follows the sort, so groups appear in sorted order too.
+  const grouped = useMemo(() => {
+    if (groupBy === "none") return null;
+    const m = new Map<string, GitHubItem[]>();
+    for (const item of sorted) {
+      const key = groupBy === "org" ? orgOf(item.repo) : item.repo;
+      const bucket = m.get(key);
+      if (bucket) bucket.push(item);
+      else m.set(key, [item]);
+    }
+    return Array.from(m.entries());
+  }, [sorted, groupBy]);
 
   const counts: Record<Filter, number> = {
     all: items.length,
@@ -763,6 +818,47 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
             </button>
           );
         })}
+
+        <div className="ml-auto flex items-center gap-2">
+          <select
+            className="gh-select"
+            value={orgFilter}
+            onChange={(e) => setOrgFilter(e.target.value)}
+            title="Filter by organization"
+            aria-label="Filter by organization"
+            disabled={orgOptions.length === 0}
+          >
+            <option value="all">All orgs</option>
+            {orgOptions.map((o) => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+          <select
+            className="gh-select"
+            value={repoFilter}
+            onChange={(e) => setRepoFilter(e.target.value)}
+            title="Filter by repository"
+            aria-label="Filter by repository"
+            disabled={repoOptions.length === 0}
+          >
+            <option value="all">All repos</option>
+            {repoOptions.map((r) => (
+              <option key={r} value={r}>{orgFilter === "all" ? r : (r.split("/")[1] ?? r)}</option>
+            ))}
+          </select>
+          <span className="gh-select-sep" aria-hidden />
+          <select
+            className="gh-select"
+            value={groupBy}
+            onChange={(e) => setGroupBy(e.target.value as GroupBy)}
+            title="Group rows"
+            aria-label="Group rows"
+          >
+            <option value="none">No grouping</option>
+            <option value="org">Group by org</option>
+            <option value="repo">Group by repo</option>
+          </select>
+        </div>
       </div>
 
       {/* ── Body ── */}
@@ -842,7 +938,8 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
                 </tr>
               </thead>
               <tbody>
-                {sorted.map((item) => {
+                {(() => {
+                  const renderRow = (item: GitHubItem) => {
                   const linked = linkedMap.get(item.id) ?? [];
                   const familiarsForRow = Array.from(
                     new Set(
@@ -966,7 +1063,25 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
                       </td>
                     </tr>
                   );
-                })}
+                  };
+                  return grouped
+                    ? grouped.flatMap(([key, rows]) => [
+                        <tr key={`grp:${key}`} className="gh-group-row">
+                          <td colSpan={COLS.length}>
+                            <span className="gh-group-label">
+                              <Icon
+                                name={groupBy === "org" ? "ph:folders-bold" : "ph:git-branch-bold"}
+                                width={11}
+                              />
+                              <span className="gh-group-name">{key}</span>
+                              <span className="gh-group-count">{rows.length}</span>
+                            </span>
+                          </td>
+                        </tr>,
+                        ...rows.map(renderRow),
+                      ])
+                    : sorted.map(renderRow);
+                })()}
               </tbody>
             </table>
           </div>

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -382,6 +382,20 @@
 .gh-familiar-stack-item:first-child { margin-left:0; }
 .gh-familiar-stack-more { margin-left:5px; color:var(--text-muted); font-size:10.5px; }
 
+/* Org/repo filter + group-by controls (right of the kind tabs) */
+.gh-select { appearance:none; -webkit-appearance:none; max-width:170px; padding:3px 22px 3px 8px; border:1px solid var(--border-hairline); border-radius:6px; background-color:var(--bg-base); color:var(--text-secondary); font-size:11px; cursor:pointer; background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='5' viewBox='0 0 8 5'%3E%3Cpath d='M0 0l4 5 4-5z' fill='%238a8a96'/%3E%3C/svg%3E"); background-repeat:no-repeat; background-position:right 8px center; transition:background-color .12s,border-color .12s,color .12s; }
+.gh-select:hover:not(:disabled) { border-color:var(--border-strong); color:var(--text-primary); background-color:var(--bg-hover); }
+.gh-select:focus-visible { outline:none; border-color:var(--accent-presence); }
+.gh-select:disabled { opacity:.45; cursor:not-allowed; }
+.gh-select-sep { width:1px; height:18px; background:var(--border-hairline); }
+
+/* Group header rows in the GitHub table */
+.gh-table tbody tr.gh-group-row,
+.gh-table tbody tr.gh-group-row:hover { background:color-mix(in oklab,var(--bg-raised) 60%,var(--bg-base)); }
+.gh-group-row td { padding:5px 12px; border-top:1px solid var(--border-hairline); }
+.gh-group-label { display:inline-flex; align-items:center; gap:7px; font-family:var(--font-mono,ui-monospace,SFMono-Regular,Menlo,monospace); font-size:11px; font-weight:600; color:var(--text-secondary); }
+.gh-group-count { display:inline-flex; align-items:center; min-width:16px; height:15px; padding:0 5px; border-radius:9999px; background:var(--bg-base); color:var(--text-muted); font-size:9.5px; font-weight:600; }
+
 .gh-actions { display:inline-flex; align-items:center; gap:4px; justify-content:flex-end; }
 .gh-action-wrap { position:relative; display:inline-flex; }
 .gh-action-btn { display:inline-flex; align-items:center; gap:4px; padding:3px 7px; border:1px solid var(--border-hairline); border-radius:6px; background:var(--bg-base); color:var(--text-secondary); font-size:10.5px; cursor:pointer; transition:background .1s,color .1s,border-color .1s; }


### PR DESCRIPTION
## What

Adds **filtering** and **grouping** to the GitHub activity table.

- **Filter by Organization → Repository** — two cascading selects in the filter bar. The Repository select narrows to the chosen org's repos and shows short names once an org is picked. A stale repo/org selection is auto-cleared when the kind filter or org filter removes it.
- **Group by** — a select (None / Organization / Repository) that buckets the sorted rows under header rows with a count pill. Groups follow the active column sort.

Org/repo are derived from the existing `owner/name` repo string — no API or type changes.

## Verification

Driven live (Playwright against the dev app, activity API mocked to a 2-org / 4-repo dataset):
- Org filter `OpenCoven` → 5 rows narrow to 3; repo options cascade to `coven-cave`/`coven-cli`; repo `coven-cli` → 1 row.
- Group by org → 2 headers (`acme` ×2, `OpenCoven` ×3); group by repo → 4 headers.
- Stale repo selection auto-clears when the org changes.

Existing `github-view-polish.test.ts` still passes; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)