### PR TITLE
polish(workflows): minimal inspector + full-height collapse tabs

### DIFF
--- a/src/components/workflows/workflow-inspector.tsx
+++ b/src/components/workflows/workflow-inspector.tsx
@@ -143,7 +143,7 @@ export function WorkflowInspector({
             onCommit={(next) => onUpdateStep(step.id, { summary: next || undefined })}
           />
           <Field
-            label="Permissions (comma-separated)"
+            label="Permissions"
             value={(step.permissions ?? []).join(", ")}
             placeholder="repo.read, web.fetch"
             onCommit={(next) => onUpdateStep(step.id, { permissions: parseCsv(next) })}
@@ -185,12 +185,13 @@ export function WorkflowInspector({
             onCommit={(next) => onUpdateMeta({ summary: next || undefined })}
           />
           <Field
-            label="Tags (comma-separated)"
+            label="Tags"
             value={(workflow.tags ?? []).join(", ")}
+            placeholder="library, annotation"
             onCommit={(next) => onUpdateMeta({ tags: parseCsv(next) })}
           />
           <Field
-            label="Permissions (comma-separated)"
+            label="Permissions"
             value={(workflow.permissions ?? []).join(", ")}
             placeholder="repo.read, web.fetch"
             onCommit={(next) => onUpdateMeta({ permissions: parseCsv(next) })}

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -59,7 +59,6 @@
 
 .workflow-studio-shell.is-right-collapsed > .workflow-studio-side {
   border-left: 1px solid var(--border-hairline);
-  background: color-mix(in oklch, var(--bg-raised) 40%, transparent);
 }
 
 .workflow-studio-shell.is-left-collapsed .workflow-studio-library-content,
@@ -114,6 +113,18 @@
 
 .workflow-panel-tab-right {
   justify-content: flex-start;
+}
+
+/* Collapsed: the whole narrow strip is the toggle, icon pinned to the top line.
+   padding-top reproduces the icon's expanded vertical position (8px margin +
+   half the 34px control's slack), so it doesn't jump when (de)collapsing. */
+.workflow-studio-shell.is-left-collapsed .workflow-panel-tab-left,
+.workflow-studio-shell.is-right-collapsed .workflow-panel-tab-right {
+  flex: 1 1 auto;
+  height: auto;
+  align-items: flex-start;
+  padding-top: 10px;
+  margin-bottom: 0;
 }
 
 .workflow-studio-side,
@@ -729,17 +740,17 @@
 
 .workflow-editor {
   display: grid;
-  gap: 8px;
+  gap: 6px;
 }
 
 .workflow-field {
   display: grid;
-  gap: 3px;
+  gap: 2px;
   font-size: 12px;
 }
 
 .workflow-field > span {
-  font-size: 11px;
+  font-size: 10.5px;
   color: var(--muted-foreground);
 }
 
@@ -747,10 +758,10 @@
 .workflow-field select {
   width: 100%;
   font-size: 12px;
-  padding: 5px 8px;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--card);
+  padding: 4px 8px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--muted) 55%, transparent);
   color: var(--text-primary, inherit);
 }
 


### PR DESCRIPTION
## What

Workflow-studio inspector and panel polish.

- **Concise inspector** — tighter editor/field spacing, lighter labels, and flat inputs (subtle `--muted` fill, border only on focus).
- **Trimmed labels** — drop "(comma-separated)" from Tags/Permissions; the hint moves to placeholder text.
- **Collapsed panels** — the whole narrow strip is the reopen toggle (full-height, icon pinned to the top line), and the collapsed-state background tint is removed so the strip blends with the canvas.

CSS-only + label text; no behavior or API changes. `workflow-studio.test.ts` (asserts `.workflow-field` + `Permissions`) still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)