### PR TITLE
feat(typography): bundled font catalog + runtime wiring

### DIFF
--- a/src/app/fonts.ts
+++ b/src/app/fonts.ts
@@ -1,0 +1,113 @@
+/**
+ * Bundled font declarations — the runtime half of the typography feature.
+ *
+ * Every `--font-*` cssVar referenced by FONT_OPTIONS in
+ * `src/lib/font-catalog.ts` is declared here as a `next/font/google`
+ * instance, and all of their `.variable` classes are concatenated into
+ * `fontVariables` which the root layout spreads onto <html>. That makes
+ * each cssVar resolve anywhere in the app, so the catalog's `fontStack()`
+ * output actually renders the chosen family rather than silently falling
+ * back.
+ *
+ * Cost: only the two defaults (Geist / Geist Mono) preload. Everything
+ * else is `preload: false`, so @font-face files download lazily and only
+ * for the family whose cssVar is actually applied to rendered text — an
+ * unselected font in the catalog costs nothing at runtime.
+ *
+ * NOTE: `next/font/google` validates `weight` at build time (static
+ * families require an explicit weight; variable families accept the full
+ * axis). If you add a family here, confirm with a real `next build` /
+ * dev compile — tsc does not catch font-config errors.
+ */
+import {
+  DM_Sans,
+  Figtree,
+  Fira_Code,
+  Fredoka,
+  Geist,
+  Geist_Mono,
+  IBM_Plex_Mono,
+  IBM_Plex_Sans,
+  Inconsolata,
+  Inter,
+  JetBrains_Mono,
+  Lato,
+  Manrope,
+  Noto_Sans,
+  Open_Sans,
+  Public_Sans,
+  Roboto,
+  Roboto_Mono,
+  Source_Code_Pro,
+  Source_Sans_3,
+  Space_Mono,
+  Work_Sans,
+} from "next/font/google";
+
+// next/font/google statically parses these calls at build time, so every
+// argument must be an inline literal — no shared consts, spreads, or vars.
+
+// ── Defaults: preload (a fresh profile renders Geist immediately) ──
+export const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
+export const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
+
+// Brand/display font — not in the selectable catalog, but used by the app
+// chrome, so it must stay applied to <html>.
+export const fredoka = Fredoka({
+  variable: "--font-fredoka",
+  subsets: ["latin"],
+  weight: ["300", "400", "500", "600", "700"],
+});
+
+// ── Sans catalog (preload: false) ──
+const inter = Inter({ variable: "--font-inter", subsets: ["latin"], preload: false });
+const roboto = Roboto({ variable: "--font-roboto", subsets: ["latin"], preload: false });
+const openSans = Open_Sans({ variable: "--font-open-sans", subsets: ["latin"], preload: false });
+const lato = Lato({ variable: "--font-lato", subsets: ["latin"], weight: ["400", "700"], preload: false });
+const sourceSans3 = Source_Sans_3({ variable: "--font-source-sans-3", subsets: ["latin"], preload: false });
+const notoSans = Noto_Sans({ variable: "--font-noto-sans", subsets: ["latin"], preload: false });
+const ibmPlexSans = IBM_Plex_Sans({ variable: "--font-ibm-plex-sans", subsets: ["latin"], weight: ["400", "500", "600", "700"], preload: false });
+const workSans = Work_Sans({ variable: "--font-work-sans", subsets: ["latin"], preload: false });
+const dmSans = DM_Sans({ variable: "--font-dm-sans", subsets: ["latin"], preload: false });
+const manrope = Manrope({ variable: "--font-manrope", subsets: ["latin"], preload: false });
+const figtree = Figtree({ variable: "--font-figtree", subsets: ["latin"], preload: false });
+const publicSans = Public_Sans({ variable: "--font-public-sans", subsets: ["latin"], preload: false });
+
+// ── Mono catalog (preload: false) ──
+const jetbrainsMono = JetBrains_Mono({ variable: "--font-jetbrains-mono", subsets: ["latin"], preload: false });
+const firaCode = Fira_Code({ variable: "--font-fira-code", subsets: ["latin"], preload: false });
+const sourceCodePro = Source_Code_Pro({ variable: "--font-source-code-pro", subsets: ["latin"], preload: false });
+const ibmPlexMono = IBM_Plex_Mono({ variable: "--font-ibm-plex-mono", subsets: ["latin"], weight: ["400", "500", "600", "700"], preload: false });
+const robotoMono = Roboto_Mono({ variable: "--font-roboto-mono", subsets: ["latin"], preload: false });
+const spaceMono = Space_Mono({ variable: "--font-space-mono", subsets: ["latin"], weight: ["400", "700"], preload: false });
+const inconsolata = Inconsolata({ variable: "--font-inconsolata", subsets: ["latin"], preload: false });
+
+/** Every declared font instance — order is irrelevant; the layout just
+ *  needs all `.variable` classes on the same element. */
+const ALL_FONTS = [
+  geistSans,
+  geistMono,
+  fredoka,
+  inter,
+  roboto,
+  openSans,
+  lato,
+  sourceSans3,
+  notoSans,
+  ibmPlexSans,
+  workSans,
+  dmSans,
+  manrope,
+  figtree,
+  publicSans,
+  jetbrainsMono,
+  firaCode,
+  sourceCodePro,
+  ibmPlexMono,
+  robotoMono,
+  spaceMono,
+  inconsolata,
+];
+
+/** Space-joined `.variable` classes for the root <html> element. */
+export const fontVariables = ALL_FONTS.map((f) => f.variable).join(" ");

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Fredoka, Geist, Geist_Mono } from "next/font/google";
+import { fontVariables } from "./fonts";
 import "./globals.css";
 import { SidecarAuthBridge } from "@/components/security/sidecar-auth-bridge";
 import { SidecarAuthMonitor } from "@/components/security/sidecar-auth-monitor";
@@ -8,22 +8,6 @@ import { ShellBannersProvider } from "@/lib/shell-banners";
 import { LiveRegionProvider } from "@/components/ui/live-region";
 import { PwaRegister } from "@/components/pwa-register";
 import { DevCacheResetScript } from "@/components/dev-cache-reset-script";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
-
-const fredoka = Fredoka({
-  variable: "--font-fredoka",
-  subsets: ["latin"],
-  weight: ["300", "400", "500", "600", "700"],
-});
 
 export const metadata: Metadata = {
   title: "CovenCave",
@@ -64,7 +48,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} ${fredoka.variable} h-full antialiased`}
+      className={`${fontVariables} h-full antialiased`}
     >
       <body className="h-full flex flex-col">
         <DevCacheResetScript />

--- a/src/lib/font-catalog.ts
+++ b/src/lib/font-catalog.ts
@@ -1,0 +1,64 @@
+/**
+ * Bundled font registry. Every entry corresponds to a `next/font/google`
+ * instance declared in src/app/fonts.ts whose `.variable` class is spread
+ * onto <html> by the root layout — so each cssVar resolves anywhere in the
+ * app. Unselected fonts cost nothing at runtime: they're declared with
+ * `preload: false` and @font-face only downloads files for families that
+ * rendered text actually uses.
+ */
+export type FontSlot = "sans" | "mono";
+
+export type FontOption = {
+  id: string;
+  label: string;
+  slot: FontSlot;
+  cssVar: string;
+};
+
+export const SANS_FALLBACK =
+  'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif';
+export const MONO_FALLBACK =
+  'ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace';
+
+export const FONT_OPTIONS: FontOption[] = [
+  // ── Sans (UI) ──
+  { id: "geist", label: "Geist", slot: "sans", cssVar: "--font-geist-sans" },
+  { id: "inter", label: "Inter", slot: "sans", cssVar: "--font-inter" },
+  { id: "roboto", label: "Roboto", slot: "sans", cssVar: "--font-roboto" },
+  { id: "open-sans", label: "Open Sans", slot: "sans", cssVar: "--font-open-sans" },
+  { id: "lato", label: "Lato", slot: "sans", cssVar: "--font-lato" },
+  { id: "source-sans-3", label: "Source Sans 3", slot: "sans", cssVar: "--font-source-sans-3" },
+  { id: "noto-sans", label: "Noto Sans", slot: "sans", cssVar: "--font-noto-sans" },
+  { id: "ibm-plex-sans", label: "IBM Plex Sans", slot: "sans", cssVar: "--font-ibm-plex-sans" },
+  { id: "work-sans", label: "Work Sans", slot: "sans", cssVar: "--font-work-sans" },
+  { id: "dm-sans", label: "DM Sans", slot: "sans", cssVar: "--font-dm-sans" },
+  { id: "manrope", label: "Manrope", slot: "sans", cssVar: "--font-manrope" },
+  { id: "figtree", label: "Figtree", slot: "sans", cssVar: "--font-figtree" },
+  { id: "public-sans", label: "Public Sans", slot: "sans", cssVar: "--font-public-sans" },
+  // ── Mono (code / terminal) ──
+  { id: "geist-mono", label: "Geist Mono", slot: "mono", cssVar: "--font-geist-mono" },
+  { id: "jetbrains-mono", label: "JetBrains Mono", slot: "mono", cssVar: "--font-jetbrains-mono" },
+  { id: "fira-code", label: "Fira Code", slot: "mono", cssVar: "--font-fira-code" },
+  { id: "source-code-pro", label: "Source Code Pro", slot: "mono", cssVar: "--font-source-code-pro" },
+  { id: "ibm-plex-mono", label: "IBM Plex Mono", slot: "mono", cssVar: "--font-ibm-plex-mono" },
+  { id: "roboto-mono", label: "Roboto Mono", slot: "mono", cssVar: "--font-roboto-mono" },
+  { id: "space-mono", label: "Space Mono", slot: "mono", cssVar: "--font-space-mono" },
+  { id: "inconsolata", label: "Inconsolata", slot: "mono", cssVar: "--font-inconsolata" },
+];
+
+export const DEFAULT_FONT_ID: Record<FontSlot, string> = {
+  sans: "geist",
+  mono: "geist-mono",
+};
+
+export function fontOptionById(id: string): FontOption | undefined {
+  return FONT_OPTIONS.find((o) => o.id === id);
+}
+
+export function slotFallback(slot: FontSlot): string {
+  return slot === "sans" ? SANS_FALLBACK : MONO_FALLBACK;
+}
+
+export function fontStack(option: FontOption): string {
+  return `var(${option.cssVar}), ${slotFallback(option.slot)}`;
+}

--- a/src/lib/font-settings.test.ts
+++ b/src/lib/font-settings.test.ts
@@ -1,0 +1,48 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  FONT_OPTIONS,
+  DEFAULT_FONT_ID,
+  SANS_FALLBACK,
+  MONO_FALLBACK,
+  fontOptionById,
+  fontStack,
+} from "./font-catalog.ts";
+
+// Spec: 15–25 bundled options spanning both slots.
+assert.ok(
+  FONT_OPTIONS.length >= 15 && FONT_OPTIONS.length <= 25,
+  `catalog must bundle 15-25 fonts (got ${FONT_OPTIONS.length})`,
+);
+const sans = FONT_OPTIONS.filter((o) => o.slot === "sans");
+const mono = FONT_OPTIONS.filter((o) => o.slot === "mono");
+assert.ok(sans.length >= 8, "catalog needs a real sans selection");
+assert.ok(mono.length >= 5, "catalog needs a real mono selection");
+
+// Ids are unique and kebab-case; every entry carries a CSS var.
+const ids = new Set(FONT_OPTIONS.map((o) => o.id));
+assert.equal(ids.size, FONT_OPTIONS.length, "font ids must be unique");
+for (const o of FONT_OPTIONS) {
+  assert.match(o.id, /^[a-z0-9-]+$/, `id ${o.id} must be kebab-case`);
+  assert.match(o.cssVar, /^--font-[a-z0-9-]+$/, `cssVar for ${o.id}`);
+  assert.ok(o.label.length > 0, `label for ${o.id}`);
+}
+
+// Defaults are the existing Geist pair, so a fresh profile changes nothing.
+assert.equal(DEFAULT_FONT_ID.sans, "geist");
+assert.equal(DEFAULT_FONT_ID.mono, "geist-mono");
+assert.equal(fontOptionById("geist")?.cssVar, "--font-geist-sans");
+assert.equal(fontOptionById("geist-mono")?.cssVar, "--font-geist-mono");
+assert.equal(fontOptionById("nope"), undefined);
+
+// Stacks chain the font var onto the slot fallback.
+assert.equal(
+  fontStack(fontOptionById("geist")),
+  `var(--font-geist-sans), ${SANS_FALLBACK}`,
+);
+assert.equal(
+  fontStack(fontOptionById("geist-mono")),
+  `var(--font-geist-mono), ${MONO_FALLBACK}`,
+);
+
+console.log("font-catalog tests passed");

--- a/src/lib/font-wiring.test.ts
+++ b/src/lib/font-wiring.test.ts
@@ -1,0 +1,53 @@
+// @ts-nocheck
+// Cross-check: the catalog (data) vs the runtime declarations (src/app/fonts.ts)
+// + the root layout wiring. font-catalog.ts on its own can list cssVars that
+// nothing declares — this test fails if a catalog entry has no matching
+// `next/font/google` instance, or if the layout stops applying them to <html>.
+// Source is read as text (not imported): next/font only resolves under the
+// Next build, so importing fonts.ts in the node test runner would throw.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { FONT_OPTIONS } from "./font-catalog.ts";
+
+const fontsSrc = readFileSync(new URL("../app/fonts.ts", import.meta.url), "utf8");
+const layoutSrc = readFileSync(new URL("../app/layout.tsx", import.meta.url), "utf8");
+
+// 1. Every catalog cssVar is declared as a next/font variable in fonts.ts.
+for (const o of FONT_OPTIONS) {
+  assert.ok(
+    fontsSrc.includes(`variable: "${o.cssVar}"`),
+    `fonts.ts must declare a next/font instance with variable: "${o.cssVar}" for "${o.id}"`,
+  );
+}
+
+// 2. fonts.ts exports the joined class string the layout consumes.
+assert.match(
+  fontsSrc,
+  /export const fontVariables\s*=/,
+  "fonts.ts must export `fontVariables`",
+);
+
+// 3. The root layout imports fontVariables and spreads it onto <html>, so the
+//    declared `.variable` classes actually reach the DOM.
+assert.match(
+  layoutSrc,
+  /import\s*\{\s*fontVariables\s*\}\s*from\s*["']\.\/fonts["']/,
+  "layout.tsx must import { fontVariables } from ./fonts",
+);
+const htmlTag = layoutSrc.match(/<html[\s\S]*?>/);
+assert.ok(htmlTag, "layout.tsx must render an <html> element");
+assert.match(
+  htmlTag[0],
+  /\$\{fontVariables\}/,
+  "layout.tsx must apply ${fontVariables} to the <html> className",
+);
+
+// 4. Guard against the regression we just fixed: no per-font next/font import
+//    should linger in layout.tsx — fonts.ts is the single source of truth.
+assert.doesNotMatch(
+  layoutSrc,
+  /from\s+["']next\/font\/google["']/,
+  "layout.tsx must not declare fonts directly; they live in src/app/fonts.ts",
+);
+
+console.log("font-wiring.test.ts OK");


### PR DESCRIPTION
## What

A selectable typography system: a font **catalog** (data) plus the **runtime declarations** that make every option actually render.

**Commit 1 — catalog** (`src/lib/font-catalog.ts`, `font-settings.test.ts`)
- 21 bundled families (13 sans + 8 mono), each with id / label / slot / cssVar, Geist defaults, and `fontStack()`/`fontOptionById()` helpers.

**Commit 2 — wiring + cross-check** (`src/app/fonts.ts`, `layout.tsx`, `font-wiring.test.ts`)
- `fonts.ts` declares every catalog `cssVar` as a `next/font/google` instance (Geist pair preloads; the other 19 are `preload: false`), and exports `fontVariables`.
- `layout.tsx` spreads `fontVariables` onto `<html>` instead of declaring three fonts inline — single source of truth.
- `font-wiring.test.ts` fails if any catalog `cssVar` lacks a declaration, if `fontVariables` isn't exported, or if the layout stops applying it — the gap that previously left 19/21 options inert.

## Why

The catalog originally referenced 19 `--font-*` vars that nothing declared — only Geist/Geist Mono resolved, so a picker built on it would offer 21 choices with 2 working. This PR closes that and guards it with a test.

## Verification
- `next build` → **exit 0**; all 22 families compile (next/font requires inline-literal args — shared consts/spreads break the build loader).
- `tsc --noEmit` clean for `fonts.ts`/`layout.tsx`.
- `font-settings.test.ts` + `font-wiring.test.ts` → pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)