### PR TITLE
polish(library): let Bookmarks Title fill the available width

### DIFF
--- a/src/components/library-bookmarks-list.tsx
+++ b/src/components/library-bookmarks-list.tsx
@@ -182,8 +182,8 @@ type Props = {
 
 const COLS: { key: SortKey; label: string; width?: string }[] = [
   { key: "title",   label: "Title" },
-  { key: "domain",  label: "Domain",  width: "140px" },
-  { key: "savedAt", label: "Saved",   width: "80px" },
+  { key: "domain",  label: "Domain",  width: "150px" },
+  { key: "savedAt", label: "Saved",   width: "64px" },
 ];
 
 export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBoard }: Props) {
@@ -349,8 +349,8 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
                     </span>
                   </th>
                 ))}
-                <th style={{ width: "160px" }}>Tags</th>
-                <th style={{ width: "64px" }} />
+                <th style={{ width: "128px" }}>Tags</th>
+                <th style={{ width: "56px" }} />
               </tr>
             </thead>
             <tbody>

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -2713,6 +2713,14 @@ h3:hover .library-heading-anchor,
 .library-list-shell .board-table {
   table-layout: fixed;
 }
+/* Bookmarks: Title is the sole fluid column, so let it claim the full
+   width of its cell. The shared .board-table-title cap (300px) otherwise
+   strands the leftover space as a dead band once the panel is wide. */
+.library-list-shell .library-bookmarks-table .board-table-title {
+  display: flex;
+  max-width: none;
+  width: 100%;
+}
 .library-reading-table .library-reading-col-source {
   width: 92px;
   max-width: 92px;


### PR DESCRIPTION
## What

The Bookmarks list was stranding horizontal space — long titles clipped at ~300px while a wide empty band sat to the right of the rows.

## Why

The table is `table-layout: fixed; width: 100%`, so **Title** is the only fluid column and absorbs the leftover width. Two things wasted it:

1. The shared `.board-table-title` **`max-width: 300px`** cap clipped the title mid-column once the column grew past 300px.
2. The **Saved (80px) + Tags (160px) + actions (64px)** columns reserved ~300px of mostly-empty width (sparse timestamps, untagged rows, hover-only actions).

## Changes

- `src/styles/library.css` — uncap the bookmarks Title cell (`max-width: none; width: 100%`) so it fills its column.
- `src/components/library-bookmarks-list.tsx` — trim the sparse fixed columns (Saved 80→64, Tags 160→128, actions 64→56) so Title claims the freed width.

## Verification

Driven live in the running dev server (Playwright). Measured: Title column **560px**, with the title cell now filling **540px** of it (vs. clipping at 300px before). Long titles like "Assigning and Completing Issues with Coding Agent in GitHub Copilot" now render in full; Saved/Tags still display. Narrow side-panel mode is unaffected — existing container queries still collapse columns at small widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)