### PR TITLE
PROBE: verify CI guard fails on unwired test (DO NOT MERGE)

### DIFF
--- a/src/lib/__ci_guard_probe.test.ts
+++ b/src/lib/__ci_guard_probe.test.ts
@@ -1,0 +1,3 @@
+import assert from "node:assert/strict";
+assert.equal(1, 1);
+console.log("ci-guard-probe: ok");


### PR DESCRIPTION
Throwaway probe: adds an unwired `src/lib/__ci_guard_probe.test.ts` to confirm `check:tests-wired` fails the Frontend build in real CI. **Do not merge — will be closed.**