### PR TITLE
feat(typography): Text size control (reframed from Screen magnification)

### DIFF
--- a/src/components/settings-appearance.test.ts
+++ b/src/components/settings-appearance.test.ts
@@ -18,6 +18,10 @@ const globals = await readFile(
   new URL("../app/globals.css", import.meta.url),
   "utf8",
 );
+const fontSettings = await readFile(
+  new URL("./settings-fonts.tsx", import.meta.url),
+  "utf8",
+);
 
 assert.match(
   settings,
@@ -97,22 +101,30 @@ assert.doesNotMatch(
   "About settings must not hardcode an app version literal",
 );
 
-assert.match(
+// The screen-scale control was reframed as "Text size" and moved into the
+// Typography block (<FontSettings />); it no longer lives in settings-shell.
+assert.doesNotMatch(
   settings,
   /Screen magnification/,
-  "Appearance settings should expose a screen magnification control",
+  "settings-shell should no longer render the old Screen magnification control",
 );
 
 assert.match(
-  settings,
+  fontSettings,
+  /Text size/,
+  "Typography (FontSettings) should expose a Text size control",
+);
+
+assert.match(
+  fontSettings,
   /SCREEN_SCALE_OPTIONS\.map/,
-  "Screen magnification should render the shared scale options",
+  "Text size should render the shared scale options",
 );
 
 assert.match(
-  settings,
-  /aria-pressed=\{screenScale === option\}/,
-  "Screen magnification buttons should expose the selected scale to assistive tech",
+  fontSettings,
+  /aria-pressed=\{scale === option\}/,
+  "Text size buttons should expose the selected scale to assistive tech",
 );
 
 assert.match(

--- a/src/components/settings-fonts.test.ts
+++ b/src/components/settings-fonts.test.ts
@@ -27,4 +27,16 @@ assert.match(
   "mount effect applies both saved fonts",
 );
 
+// Text size control (reframed Screen magnification) lives in Typography.
+assert.match(src, /Text size/, "renders a Text size control");
+assert.match(src, /SCREEN_SCALE_OPTIONS/, "uses the shared scale ladder");
+assert.match(src, /applyScreenScale/, "applies the scale via the shared helper");
+assert.match(src, /aria-pressed=\{scale === option\}/, "scale buttons expose selected state");
+// Reset restores text size to the default too, not just the fonts.
+assert.match(
+  src,
+  /const reset = \(\) => \{[\s\S]*?DEFAULT_SCREEN_SCALE[\s\S]*?\}/,
+  "reset restores the default text size",
+);
+
 console.log("settings-fonts.test.ts OK");

--- a/src/components/settings-fonts.tsx
+++ b/src/components/settings-fonts.tsx
@@ -10,6 +10,14 @@ import {
   type FontOption,
 } from "@/lib/font-catalog";
 import { applyFont, readFontPref, writeFontPref } from "@/lib/font-storage";
+import {
+  DEFAULT_SCREEN_SCALE,
+  SCREEN_SCALE_EVENT,
+  SCREEN_SCALE_OPTIONS,
+  applyScreenScale,
+  readScreenScale,
+  type ScreenScale,
+} from "@/lib/screen-magnification";
 
 const SANS_OPTIONS = FONT_OPTIONS.filter((o) => o.slot === "sans");
 const MONO_OPTIONS = FONT_OPTIONS.filter((o) => o.slot === "mono");
@@ -62,6 +70,7 @@ function FontField({
 export function FontSettings() {
   const [sansId, setSansId] = useState<string>(DEFAULT_FONT_ID.sans);
   const [monoId, setMonoId] = useState<string>(DEFAULT_FONT_ID.mono);
+  const [scale, setScale] = useState<ScreenScale>(DEFAULT_SCREEN_SCALE);
 
   useEffect(() => {
     const sans = readFontPref("sans");
@@ -70,6 +79,20 @@ export function FontSettings() {
     setMonoId(mono);
     applyFont("sans", sans);
     applyFont("mono", mono);
+    // The mounted ScreenMagnificationController already applies the saved
+    // scale before this runs; we only mirror it into local UI state.
+    setScale(readScreenScale());
+  }, []);
+
+  // Keep the segmented control in sync with the ⌘+/⌘−/⌘0 keyboard shortcuts,
+  // which dispatch SCREEN_SCALE_EVENT from the controller.
+  useEffect(() => {
+    const onScaleChange = (event: Event) => {
+      const next = (event as CustomEvent<{ scale?: ScreenScale }>).detail?.scale;
+      if (next) setScale(next);
+    };
+    window.addEventListener(SCREEN_SCALE_EVENT, onScaleChange);
+    return () => window.removeEventListener(SCREEN_SCALE_EVENT, onScaleChange);
   }, []);
 
   const select = (slot: FontSlot, id: string) => {
@@ -79,25 +102,55 @@ export function FontSettings() {
     applyFont(slot, id);
   };
 
+  const setTextSize = (next: ScreenScale) => {
+    setScale(next);
+    applyScreenScale(next);
+  };
+
   const reset = () => {
     select("sans", DEFAULT_FONT_ID.sans);
     select("mono", DEFAULT_FONT_ID.mono);
+    setTextSize(DEFAULT_SCREEN_SCALE);
   };
 
   const isDefault =
-    sansId === DEFAULT_FONT_ID.sans && monoId === DEFAULT_FONT_ID.mono;
+    sansId === DEFAULT_FONT_ID.sans &&
+    monoId === DEFAULT_FONT_ID.mono &&
+    scale === DEFAULT_SCREEN_SCALE;
 
   return (
     <section className="flex flex-col gap-4">
       <div>
         <h3 className="text-[13px] font-semibold text-[var(--text-primary)]">Typography</h3>
         <p className="text-[11px] text-[var(--text-muted)]">
-          Choose the interface and code fonts. Changes apply immediately.
+          Choose the interface and code fonts and the overall text size. Changes apply immediately.
         </p>
       </div>
       <div className="flex flex-col gap-4">
         <FontField slot="sans" label="Interface" options={SANS_OPTIONS} value={sansId} onChange={(id) => select("sans", id)} />
         <FontField slot="mono" label="Code &amp; terminal" options={MONO_OPTIONS} value={monoId} onChange={(id) => select("mono", id)} />
+        <div className="flex flex-col gap-1.5">
+          <label className="text-[12px] font-medium text-[var(--text-secondary)]">Text size</label>
+          <p className="text-[11px] text-[var(--text-muted)] -mt-0.5">Scale all text and UI.</p>
+          <div className="flex w-fit shrink-0 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-base)] p-0.5">
+            {SCREEN_SCALE_OPTIONS.map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => setTextSize(option)}
+                aria-pressed={scale === option}
+                aria-label={`Text size ${option}%`}
+                className={`focus-ring min-w-12 rounded-md px-2.5 py-1.5 text-[11px] font-medium transition-colors ${
+                  scale === option
+                    ? "bg-[var(--accent-presence)] text-white"
+                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+                }`}
+              >
+                {option}%
+              </button>
+            ))}
+          </div>
+        </div>
       </div>
       <div>
         <button

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -10,13 +10,6 @@ import { ModeToggle } from "@/components/mode-toggle";
 import { FamiliarStudioProvider } from "@/lib/familiar-studio-context";
 import { APP_VERSION } from "@/lib/app-version";
 import { useIsMobile } from "@/lib/use-viewport";
-import {
-  SCREEN_SCALE_EVENT,
-  SCREEN_SCALE_OPTIONS,
-  applyScreenScale,
-  readScreenScale,
-  type ScreenScale,
-} from "@/lib/screen-magnification";
 import { ThemeColorEditor } from "@/components/theme-color-editor";
 import { FontSettings } from "./settings-fonts";
 import {
@@ -651,7 +644,6 @@ function ThemePresetCard({
 function AppearanceSection() {
   const [activeTheme, setActiveTheme] = useState<ActiveTheme>("coven");
   const [mode, setMode] = useState<Mode>("dark");
-  const [screenScale, setScreenScale] = useState<ScreenScale>(100);
   const [customData, setCustomData] = useState<CustomThemeData | null>(null);
   const [importUrl, setImportUrl] = useState("");
   const [importing, setImporting] = useState(false);
@@ -663,7 +655,6 @@ function AppearanceSection() {
   useEffect(() => {
     setActiveTheme(readPersistedTheme());
     setMode(readPersistedMode());
-    setScreenScale(readScreenScale());
     const saved = localStorage.getItem(COVEN_THEME_KEY);
     if (saved === "custom") {
       const raw = localStorage.getItem(COVEN_CUSTOM_THEME_KEY);
@@ -675,15 +666,6 @@ function AppearanceSection() {
         }
       }
     }
-  }, []);
-
-  useEffect(() => {
-    const onScaleChange = (event: Event) => {
-      const scale = (event as CustomEvent<{ scale?: ScreenScale }>).detail?.scale;
-      if (scale) setScreenScale(scale);
-    };
-    window.addEventListener(SCREEN_SCALE_EVENT, onScaleChange);
-    return () => window.removeEventListener(SCREEN_SCALE_EVENT, onScaleChange);
   }, []);
 
   const handleSelectPreset = (id: PresetTheme) => {
@@ -701,11 +683,6 @@ function AppearanceSection() {
     if (activeTheme === "custom" && customData) {
       applyCustomVars(customData.cssVars, next);
     }
-  };
-
-  const handleSetScreenScale = (next: ScreenScale) => {
-    setScreenScale(next);
-    applyScreenScale(next);
   };
 
   const handleResetCustom = () => {
@@ -794,30 +771,7 @@ function AppearanceSection() {
         </div>
       </SettingsGroup>
 
-      <SettingsGroup label="Accessibility">
-        <SettingsRow
-          label="Screen magnification"
-          description="Scale the whole Cave UI."
-        >
-          <div className="flex shrink-0 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-base)] p-0.5">
-            {SCREEN_SCALE_OPTIONS.map((option) => (
-              <button
-                key={option}
-                type="button"
-                onClick={() => handleSetScreenScale(option)}
-                aria-pressed={screenScale === option}
-                className={`focus-ring min-w-12 rounded-md px-2.5 py-1.5 text-[11px] font-medium transition-colors ${
-                  screenScale === option
-                    ? "bg-[var(--accent-presence)] text-white"
-                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
-                }`}
-              >
-                {option}%
-              </button>
-            ))}
-          </div>
-        </SettingsRow>
-      </SettingsGroup>
+      {/* Text size lives in the Typography block (<FontSettings />) below. */}
 
       {/* ── Preset themes ── */}
       <SettingsGroup label="Theme">


### PR DESCRIPTION
## What

Adds a **Text size** control to the Typography block in Settings → Appearance.

## Why this shape

You asked for a font-size control. On inspection, **Screen magnification already scaled all text + UI** (`zoom: var(--cave-screen-scale)` on `<body>`), and the app's text is ~384 hard-coded `px` values with no shared scale knob — so a *separate* font-size control would be either redundant with the existing zoom or unworkable without a large px→rem refactor. The honest, working version is to **reframe the existing control as "Text size" and put it where users look for it** (Typography).

## Changes

- **Move** the 100/110/125/150% segmented control into `<FontSettings>` (Typography), relabeled **"Text size"** ("Scale all text and UI."). It reads/writes the same `cave:screen-scale` store via `applyScreenScale`, syncs to `SCREEN_SCALE_EVENT` so the ⌘+ / ⌘− / ⌘0 shortcuts keep it in sync, and **Reset to default now also restores 100%**.
- **Remove** the now-empty "Accessibility" group (and its state/handler/imports) from `AppearanceSection`.
- The `screen-magnification` lib, the mount controller, and the keyboard shortcuts are **unchanged** — this is a UI relocation + relabel.

## Verification

- `pnpm test:app` (252 files) ✅ · `pnpm typecheck` clean ✅ · `next build` exit 0 ✅
- Updated `settings-appearance.test.ts` (assert the control moved to Typography as "Text size", and `settings-shell` no longer renders "Screen magnification") + `settings-fonts.test.ts` (Text size row, scale ladder, reset-restores-100%).
- **e2e (Playwright on a prod build):** "Screen magnification" gone from settings; clicking **125%** sets `data-screen-scale=125` live; reload → persists (button `aria-pressed=true`); **Reset** → back to 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)