### PR TITLE
polish(chat): center the transcript column on full screen

### DIFF
--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -594,9 +594,12 @@
   display: flex;
   flex-direction: column;
   gap: 18px;
-  /* Full-width chat (2026-06-12): the thread spans the pane; the old
-     1180px centered column is gone. */
+  /* Centered reading column (2026-06-13): the thread fills narrow panes but
+     caps its measure and centers on wide/full-screen so responses sit in the
+     middle instead of sprawling left across the pane. */
   width: 100%;
+  max-width: 1180px;
+  margin-inline: auto;
 }
 
 .cave-chat-empty {
@@ -1648,10 +1651,11 @@ details[open] > .cave-tool-summary::before {
 
 .cave-chat-linear .cave-chat-thread {
   gap: 0;
-  /* Full-width chat (2026-06-12): supersedes CHAT-D10-04's 920px reading
-     measure — the thread now spans the pane on every width. */
+  /* Centered reading column (2026-06-13): fill narrow panes, but cap the
+     measure and center on wide/full-screen so the transcript sits in the
+     middle rather than sprawling left. */
   width: 100%;
-  max-width: 100%;
+  max-width: 1180px;
   margin-block: 0;
   margin-inline: auto;
 }


### PR DESCRIPTION
## What

On a maximized window the chat transcript sprawled left across the entire pane instead of sitting centered. This caps the measure and centers it.

## Why

The thread was made full-width on 2026-06-12 — both `.cave-chat-thread` and the more-specific `.cave-chat-linear .cave-chat-thread` (the linear chat mode shown in the report) forced `max-width: 100%`. With no cap, responses ran the full pane width and read off-center on wide screens.

## Change

Cap both rules at `max-width: 1180px` with `margin-inline: auto`. Narrow panes still fill 100%; only wide/full-screen gets the centered column. (1180px is the width that existed before the full-width change.)

Touches only `src/styles/cave-chat.css`.

## Verification

Driven live (Playwright, 1920px viewport, real transcript): the thread measures **1180px wide with equal 72px gaps** on both sides, and the response visibly sits in a centered column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)