### PR TITLE
fix(board): portal task drawer so it's viewport-fixed, not trapped in the mode-fade transform

### DIFF
--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { Card, CardLifecycle, CardPriority, CardStatus } from "@/lib/cave-board-types";
 import { STATUSES, PRIORITIES } from "@/lib/cave-board-types";
@@ -870,7 +871,16 @@ export function BoardInspector({ card, familiars, sessions, onClose, onPatch, on
     } finally { setLifecycleBusy(null); }
   };
 
-  return (
+  if (typeof document === "undefined") return null;
+
+  // Portal to <body> so the drawer's `position: fixed` resolves against the
+  // viewport, NOT the `.cave-mode-fade` mode wrapper. That wrapper retains a
+  // transform from its `cave-mode-in … both` animation, which silently makes
+  // it the containing block for fixed descendants — so an inline drawer
+  // anchored its `right:0`/`width:480px` to the (narrower, inset) detail panel
+  // instead of the window. Symptoms: a right-edge gap on desktop and left-
+  // clipped content on narrow viewports. Mirrors the ui/Modal portal pattern.
+  return createPortal(
     <>
       <div className="board-drawer-backdrop" onClick={close} />
       <div ref={dialogRef} className={`board-drawer${closing ? " board-drawer--closing" : ""}`} role="dialog" aria-modal aria-label="Card inspector" tabIndex={-1}>
@@ -1123,7 +1133,8 @@ export function BoardInspector({ card, familiars, sessions, onClose, onPatch, on
           <button type="button" className="board-toolbar-btn" onClick={close}>Close</button>
         </div>
       </div>
-    </>
+    </>,
+    document.body,
   );
 }
 function safeHref(value: string): string | null {


### PR DESCRIPTION
## Problem

The board task-detail drawer (`board-inspector.tsx`) is `position: fixed; right:0; width:480px; max-width:100vw`, but it was rendered **inline** inside `.cave-mode-fade`. That mode-transition wrapper has `animation: cave-mode-in … both` — the `both` fill-mode permanently retains the animation's end-state `transform`, and **any** `transform ≠ none` makes an element the containing block for `position: fixed` descendants.

So the drawer anchored its `right:0`/`width` to `.cave-mode-fade` (the inset detail panel) instead of the viewport:

- **Desktop:** a ~26px gap between the drawer and the window's right edge.
- **Narrow viewports:** when `.cave-mode-fade` is narrower than 480px, the drawer's left edge computes **negative** → the title and fields get clipped off the left side (reported via screenshot).

## Fix

Portal the drawer to `document.body` (the same pattern `ui/Modal` already uses), so its fixed positioning resolves against the viewport rather than the transformed wrapper. Two-line change: add `createPortal` import, wrap the return.

## Verification (Playwright, demo board)

- **Desktop 1440px:** drawer right edge `1414 → 1440` — now hugs the window edge; `parentIsBody: true`; no transformed ancestor.
- **Mobile 516px:** zero left-clipped elements; content fully readable.
- `tsc --noEmit` clean.
- Board + focus-trap suites pass (`board-link-browser`, `board-chat-link`, `board-view-familiar-scope`, `task-chat-cwd`, `board-kanban-keyboard`, `board-enrich-steps`, `modal-trap-adoption`, `use-focus-trap`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)