### PR TITLE
chore(gitignore): ignore extra macOS metadata + scratch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,11 +23,16 @@ release/
 # Local Playwright verification outputs (e.g. scripts/verify-trace-graph-3d.mjs)
 artifacts/
 
-# Logs
+# Logs / scratch
 *.log
+*.tmp
+*.bak
 
 # OS junk
 .DS_Store
+.AppleDouble
+.Spotlight-V100
+.Trashes
 Thumbs.db
 desktop.ini
 ehthumbs.db


### PR DESCRIPTION
Adds the few ignore patterns the repo's `.gitignore` was missing, matching the memory store's set:

- macOS metadata: `.AppleDouble`, `.Spotlight-V100`, `.Trashes`
- scratch: `*.tmp`, `*.bak`

Everything else (`.DS_Store`, `*.swp/swo`, `*~`, `.vscode`, `.idea`, `*.log`, …) was already covered. `.gitignore`-only change — no build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)