### PR TITLE
feat(library): add Back + Refresh controls to the Library nav

### DIFF
--- a/src/components/library-collection-rail.tsx
+++ b/src/components/library-collection-rail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import type { LibraryCollection, LibrarySectionKind } from "@/lib/library-types";
 
@@ -42,6 +42,10 @@ type Props = {
   onSelectSection: (section: LibrarySectionKind) => void;
   onSelectSkill?: (skill: Skill) => void;
   activeSkillId?: string | null;
+  canGoBack?: boolean;
+  onBack?: () => void;
+  onRefresh?: () => void;
+  refreshing?: boolean;
 };
 
 // ── Rail ─────────────────────────────────────────────────────────────────────
@@ -55,26 +59,60 @@ export function LibraryCollectionRail({
   onSelectSection,
   onSelectSkill,
   activeSkillId,
+  canGoBack = false,
+  onBack,
+  onRefresh,
+  refreshing = false,
 }: Props) {
   const [skills, setSkills] = useState<Skill[]>([]);
   const [skillsOpen, setSkillsOpen] = useState(false);
 
-  // Fetch skills from daemon via Cave proxy
-  useEffect(() => {
-    void (async () => {
-      try {
-        const res = await fetch("/api/skills", { cache: "no-store" });
-        const json = await res.json().catch(() => null) as { ok?: boolean; skills?: Skill[] } | null;
-        if (json?.ok && Array.isArray(json.skills)) setSkills(json.skills);
-      } catch { /* daemon unavailable — section stays hidden */ }
-    })();
+  // Fetch skills from daemon via Cave proxy. Exposed as a callback so the
+  // header Refresh button can re-pull them alongside the parent's reload.
+  const loadSkills = useCallback(async () => {
+    try {
+      const res = await fetch("/api/skills", { cache: "no-store" });
+      const json = await res.json().catch(() => null) as { ok?: boolean; skills?: Skill[] } | null;
+      if (json?.ok && Array.isArray(json.skills)) setSkills(json.skills);
+    } catch { /* daemon unavailable — section stays hidden */ }
   }, []);
+
+  useEffect(() => { void loadSkills(); }, [loadSkills]);
+
+  const handleRefresh = useCallback(() => {
+    onRefresh?.();
+    void loadSkills();
+  }, [onRefresh, loadSkills]);
 
   return (
     <div className="library-rail">
 
       {/* ── Research collections ─────────────────────────────── */}
-      <div className="library-rail-header">Library</div>
+      <div className="library-rail-header library-rail-header--actions">
+        <span className="library-rail-header-title">Library</span>
+        <div className="library-rail-header-actions">
+          <button
+            type="button"
+            className="library-rail-action"
+            onClick={() => onBack?.()}
+            disabled={!canGoBack}
+            title="Back"
+            aria-label="Back to previous library view"
+          >
+            <Icon name="ph:arrow-left" width={13} />
+          </button>
+          <button
+            type="button"
+            className={`library-rail-action${refreshing ? " library-rail-action--spinning" : ""}`}
+            onClick={handleRefresh}
+            disabled={refreshing}
+            title="Refresh"
+            aria-label="Refresh library"
+          >
+            <Icon name="ph:arrow-clockwise" width={13} />
+          </button>
+        </div>
+      </div>
       <div className="library-rail-list">
         {collections.map((col) => {
           const count = docCounts[col.id] ?? 0;

--- a/src/components/library-view.tsx
+++ b/src/components/library-view.tsx
@@ -50,6 +50,28 @@ export function LibraryView({ sessions, onOpenSession, onNewProjectChat }: Libra
   const [timelineSelectedId, setTimelineSelectedId] = useState<string | null>(null);
   const [boardDraft, setBoardDraft] = useState<LibraryBookmark | null>(null);
 
+  // ── Nav history (powers the rail's Back control) ─────────────────────────
+  // A "location" is the section + collection + skill triple. We record the
+  // location we just left whenever it changes, so Back can restore it. The
+  // effect coalesces multi-setState navigations (e.g. selecting a collection
+  // sets both collection and section) into one transition via React batching.
+  type NavLoc = { section: LibrarySectionKind; collection: string; skillId: string | null };
+  const [navHistory, setNavHistory] = useState<NavLoc[]>([]);
+  const prevLocRef = useRef<NavLoc>({ section: "all", collection: "all", skillId: null });
+  const goingBackRef = useRef(false);
+  useEffect(() => {
+    const cur: NavLoc = { section: activeSection, collection: activeCollection, skillId: activeSkillId };
+    const prev = prevLocRef.current;
+    const same = prev.section === cur.section && prev.collection === cur.collection && prev.skillId === cur.skillId;
+    if (same) return;
+    if (goingBackRef.current) {
+      goingBackRef.current = false;
+    } else {
+      setNavHistory((h) => [...h, prev]);
+    }
+    prevLocRef.current = cur;
+  }, [activeSection, activeCollection, activeSkillId]);
+
   useEffect(() => {
     void fetch("/api/familiars", { cache: "no-store" })
       .then((r) => r.json())
@@ -117,6 +139,27 @@ export function LibraryView({ sessions, onOpenSession, onNewProjectChat }: Libra
     setSelectedItem(null);
     setSearchQuery("");
   }
+
+  function goBack() {
+    setNavHistory((h) => {
+      if (h.length === 0) return h;
+      const target = h[h.length - 1];
+      goingBackRef.current = true;
+      setActiveSection(target.section);
+      setActiveCollection(target.collection);
+      setActiveSkillId(target.skillId);
+      setSelectedItem(null);
+      setSearchQuery("");
+      return h.slice(0, -1);
+    });
+  }
+
+  // Reload everything the nav surfaces: collections + docs for the active
+  // collection (loadDocs refreshes both). Skills are owned by the rail, which
+  // re-fetches them from its own Refresh handler alongside this.
+  const reloadLibrary = useCallback(() => {
+    void loadDocs(activeCollection);
+  }, [loadDocs, activeCollection]);
 
   const docCounts: Record<string, number> = { [activeCollection]: docs.length };
   const selectedDocId =  selectedItem?.kind === "doc"      ? selectedItem.doc.id  : null;
@@ -220,6 +263,10 @@ export function LibraryView({ sessions, onOpenSession, onNewProjectChat }: Libra
           setActiveSkillId(skill.id);
           setSelectedItem({ kind: "skill", skill });
         }}
+        canGoBack={navHistory.length > 0}
+        onBack={goBack}
+        onRefresh={reloadLibrary}
+        refreshing={loading}
       />
       <div className="library-divider" />
       {/* Preview pane — dominant left content area; graph and projects own the full canvas */}

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -46,6 +46,59 @@
   padding: 0 14px 8px;
 }
 
+/* Top header carries Back + Refresh actions beside the title. */
+.library-rail-header--actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding-right: 8px;
+}
+.library-rail-header-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.library-rail-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+.library-rail-action {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 5px;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.12s, background 0.12s;
+}
+.library-rail-action:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+.library-rail-action:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
+}
+.library-rail-action:disabled {
+  opacity: 0.35;
+  cursor: default;
+  background: none;
+  color: var(--text-muted);
+}
+.library-rail-action--spinning > svg {
+  animation: library-rail-spin 0.7s linear infinite;
+}
+@keyframes library-rail-spin {
+  to { transform: rotate(360deg); }
+}
+
 .library-rail-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What

The Library rail's top header was a bare **"Library"** label with no actions — no way to reload its data or step back through where you'd been without using the app sidebar. This adds a **Back + Refresh** cluster to the rail header.

## Behavior

- **Refresh** — re-fetches collections + docs (parent `reloadLibrary`) and the skills list (rail `loadSkills`); spins while the reload is in flight.
- **Back** — walks a section/collection/skill history stack. An effect records the location you leave (coalescing multi-`setState` navigations via React batching), and Back restores it. Disabled when there's no history.

Touches `library-view.tsx`, `library-collection-rail.tsx`, `library.css`.

## Verification

Driven live (worktree dev server, Playwright):
- Back **disabled** at root → **enables** after navigating → returns through `Bookmarks → Timeline` → **disables** again when history is exhausted.
- Refresh fires without error (spin shows on slower reloads).
- Header action row renders cleanly aligned with the "LIBRARY" title.

`tsc --noEmit` clean; `library-polish` test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)