### PR TITLE
feat(chat): right session panel mirrors the 230px left rail width

### DIFF
--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -355,15 +355,15 @@ export function ChatSurface({
             </Panel>
             {rightPanel !== null && (
               <>
-                <Separator className="shell-separator hidden lg:block" />
+                {/* Fixed-width mirror of the internal left rail (chat-thread-rail
+                    is w-[230px]). No resize handle — the panel's own border-l is
+                    the divider, matching the left rail's border-r. */}
                 <Panel
                   id="right-sidebar"
                   className="hidden min-h-0 min-w-0 lg:flex"
-                  defaultSize="33%"
-                  minSize="33%"
-                  maxSize="46%"
-                  collapsible
-                  collapsedSize={0}
+                  defaultSize="230px"
+                  minSize="230px"
+                  maxSize="230px"
                 >
                   <RightPanel
                     panel={rightPanel}

--- a/src/components/right-sidebar-fit.test.ts
+++ b/src/components/right-sidebar-fit.test.ts
@@ -4,23 +4,27 @@ import { readFile } from "node:fs/promises";
 
 const chatSurface = await readFile(new URL("./chat-surface.tsx", import.meta.url), "utf8");
 const globals = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
+const projectSidebar = await readFile(new URL("./chat-project-sidebar.tsx", import.meta.url), "utf8");
 
 assert.match(
   chatSurface,
-  /Panel[\s\S]*id="right-sidebar"[\s\S]*defaultSize="33%"[\s\S]*minSize="33%"[\s\S]*maxSize="46%"/,
-  "ChatSurface right sidebar should open at the requested 33% width",
+  /Panel[\s\S]*id="right-sidebar"[\s\S]*defaultSize="230px"[\s\S]*minSize="230px"[\s\S]*maxSize="230px"/,
+  "ChatSurface right sidebar should be a fixed 230px mirror of the internal left rail (min===max===default)",
 );
 
-assert.match(
-  chatSurface,
-  /Separator\s+className="[^"]*shell-separator[^"]*"/,
-  "ChatSurface right sidebar should render a resize separator before the panel",
-);
-
+// Fixed-width mirror: the outer resize separator is gone — the panel's own
+// border-l is the divider, matching the left rail's border-r. The INNER
+// vertical-split separator (shell-separator-h) is unaffected (asserted below).
 assert.doesNotMatch(
   chatSurface,
-  /w-\[320px\]\s+shrink-0/,
-  "ChatSurface right sidebar should not be a fixed 320px non-resizable aside",
+  /Separator className="shell-separator hidden lg:block"/,
+  "The right sidebar is fixed-width now — no outer drag-to-resize separator before it",
+);
+
+assert.match(
+  projectSidebar,
+  /chat-thread-rail[\s\S]*w-\[230px\]/,
+  "The internal left rail is 230px — the width the right sidebar mirrors",
 );
 
 assert.match(


### PR DESCRIPTION
## What

Makes the **right inner sidepanel** (Inspector/Debug + Changes) a fixed **230px**, matching the internal **left thread rail** (`chat-thread-rail`, `w-[230px]`). The two internal sidepanels are now symmetric.

Before: the right panel was a resizable `react-resizable-panels` panel at `defaultSize 33% / min 33% / max 46%` — much wider than the 230px left rail.

## Changes

- Right `#right-sidebar` panel → `defaultSize="230px" minSize="230px" maxSize="230px"` (v4 supports px units; min===max locks it).
- Dropped the outer drag-to-resize `Separator` — the panel's own `border-l` is the divider, mirroring the left rail's `border-r` (the left rail has no resize handle either).
- The inner 50/50 vertical split (Inspector/Debug over Changes) is untouched.
- Updated `right-sidebar-fit.test.ts` to the fixed-mirror contract + a cross-check that the left rail is 230px. `chat-surface.test.ts` (outer horizontal Group) stays green.

## Verification

- `tsc --noEmit` clean; full `pnpm test:app` green; `pnpm build` succeeds.
- **Live** (Playwright, prod build): with both panels open, measured `LEFT_W=230 RIGHT_W=230` — exact match. Screenshot confirms symmetric layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)