### PR TITLE
fix(workflows): left-align Boards/Projects attachment toggles

### DIFF
--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -183,7 +183,11 @@
 
 .workflow-icon-button,
 .workflow-run-actions button,
-.workflow-attachment-row button {
+/* Action buttons only (e.g. Save) — NOT the disclosure toggle, which is a
+   flat, left-aligned, full-width control styled by .workflow-attachment-toggle.
+   Without the :not(), this chrome centered the toggle label on rows that have
+   no count to mask it (Boards/Projects). */
+.workflow-attachment-row button:not(.workflow-attachment-toggle) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -571,7 +575,7 @@
   color: var(--muted-foreground);
 }
 
-.workflow-attachment-row button {
+.workflow-attachment-row button:not(.workflow-attachment-toggle) {
   padding: 0 9px;
 }
 


### PR DESCRIPTION
## What

In the Workflow Studio **Cave bindings** panel, the **Boards** and **Projects** rows rendered their caret + icon + label *centered*, while **Familiars** and **Roles** were left-aligned.

| Before | After |
|---|---|
| Boards/Projects labels centered | All four rows left-aligned |

## Cause

The disclosure toggle is a `<button>`, so the generic `.workflow-attachment-row button` rule — intended for the **Save** action buttons — applied its `justify-content: center` (plus border/min-height chrome) to the toggle. At specificity `(0,1,1)` it beat `.workflow-attachment-toggle` `(0,1,0)`.

Familiars/Roles masked the effect because their `.workflow-attachment-count` carries `margin-left: auto`, distributing the label left. Boards/Projects have no count, so the label centered.

## Fix

Scope the action-button chrome with `:not(.workflow-attachment-toggle)` so only the Save buttons get it; the toggle keeps its flat, left-aligned, full-width styling. One-line CSS change (both `.workflow-attachment-row button` rules).

## Verification

Driven live (worktree dev server, Playwright): all four rows now report `caretLeftOffset: 10`, `labelLeftOffset: 46`, `justify: normal`, no toggle border — Save buttons keep their chrome. `workflow-studio` test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)