### PR TITLE
fix(chat): drop native select chevron from the project chip

### DIFF
--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1469,6 +1469,14 @@ details[open] > .cave-tool-summary::before {
   background: color-mix(in oklch, var(--bg-hover) 64%, transparent);
 }
 
+/* The folder icon is the project picker's only affordance — hide the native
+   select chevron, which otherwise overlaps the truncated project name in the
+   narrow chip (WebKit webview needs the -webkit- prefix). */
+.cave-chat-cwd-inline select {
+  appearance: none;
+  -webkit-appearance: none;
+}
+
 .cave-chat-session-actions {
   display: inline-flex;
   min-width: 0;


### PR DESCRIPTION
## What

In the chat header, the project picker pairs a folder icon with a `<select>`. The select kept its **native dropdown chevron**, which in the WebKit (Tauri) webview rendered *on top of* the truncated project name — e.g. `Nova Cl…` — reading as a glyph collision.

## Fix

Hide the chevron on `.cave-chat-cwd-inline select` via `appearance: none` + `-webkit-appearance: none` (the webview needs the prefix). The folder icon becomes the picker's only affordance, as requested.

## Verification

Driven live (worktree dev server, Playwright): the select computes `appearance: none` / `webkitAppearance: none`, the folder icon is retained, and the chip shows **"Nova Claw"** cleanly with no overlap. `chat-header-row` test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)