### PR TITLE
fix(library): stop bookmark titles collapsing to "DeepWi…"

### DIFF
--- a/src/components/library-bookmarks-list.tsx
+++ b/src/components/library-bookmarks-list.tsx
@@ -182,7 +182,7 @@ type Props = {
 
 const COLS: { key: SortKey; label: string; width?: string }[] = [
   { key: "title",   label: "Title" },
-  { key: "domain",  label: "Domain",  width: "150px" },
+  { key: "domain",  label: "Domain",  width: "112px" },
   { key: "savedAt", label: "Saved",   width: "64px" },
 ];
 
@@ -349,7 +349,7 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
                     </span>
                   </th>
                 ))}
-                <th style={{ width: "128px" }}>Tags</th>
+                <th style={{ width: "96px" }}>Tags</th>
                 <th style={{ width: "56px" }} />
               </tr>
             </thead>

--- a/src/components/library-polish.test.ts
+++ b/src/components/library-polish.test.ts
@@ -257,6 +257,27 @@ assert.match(
   /\.library-title-cell\s*\{[\s\S]*?min-width:\s*0;/,
   "Bookmark title cells should be allowed to shrink inside the side panel",
 );
+// Title must stay the priority column: the bookmarks table uses auto layout
+// with a fluid (max-width:0 + width:100%) first column so the Title absorbs
+// leftover space and truncates LAST — even when Saved/Tags columns are hidden.
+// (Fixed-layout left the Title unable to re-claim hidden columns' width, so it
+// collapsed to an indistinguishable "DeepWi…".)
+assert.match(
+  libraryCss,
+  /\.library-list-shell \.library-bookmarks-table\s*\{[\s\S]*?table-layout:\s*auto;/,
+  "Bookmarks table should use auto layout so the Title can claim freed column width",
+);
+assert.match(
+  libraryCss,
+  /\.library-list-shell \.library-bookmarks-table[\s\S]*?td:first-child\s*\{[\s\S]*?width:\s*100%;[\s\S]*?max-width:\s*0;/,
+  "Bookmarks Title cell should be the fluid clipping column (width:100%; max-width:0)",
+);
+// The repetitive Domain must be able to truncate rather than hold fixed width.
+assert.match(
+  libraryCss,
+  /\.library-domain-cell\s*\{[\s\S]*?text-overflow:\s*ellipsis;/,
+  "Bookmark domain cell should ellipsize so it yields width to the Title",
+);
 assert.doesNotMatch(
   github,
   /gh-row-action-strip-row/,

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -1167,6 +1167,10 @@ tr:focus-within .library-row-delete {
   display: flex;
   align-items: center;
   gap: 5px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-size: 12px;
   color: var(--text-secondary);
 }
@@ -2713,9 +2717,20 @@ h3:hover .library-heading-anchor,
 .library-list-shell .board-table {
   table-layout: fixed;
 }
-/* Bookmarks: Title is the sole fluid column, so let it claim the full
-   width of its cell. The shared .board-table-title cap (300px) otherwise
-   strands the leftover space as a dead band once the panel is wide. */
+/* Bookmarks: Title is the row's identity and must stay the priority column.
+   Use auto layout + a fluid first column (max-width:0 + width:100%) so the
+   Title absorbs all leftover space and *clips* — instead of fixed-layout,
+   where hidden Saved/Tags columns stop the Title from re-claiming their
+   width and it collapses to an indistinguishable "DeepWi…". Domain/Saved/
+   Tags keep their fixed widths and the repetitive domain truncates first. */
+.library-list-shell .library-bookmarks-table {
+  table-layout: auto;
+}
+.library-list-shell .library-bookmarks-table thead th:first-child,
+.library-list-shell .library-bookmarks-table tbody td:first-child {
+  width: 100%;
+  max-width: 0;
+}
 .library-list-shell .library-bookmarks-table .board-table-title {
   display: flex;
   max-width: none;


### PR DESCRIPTION
## Problem
In a narrow bookmarks panel, distinct rows all rendered as an identical truncated **`DeepWi…`** + `deepwiki.com` — you couldn't tell four entries apart (see report screenshot).

## Root cause
The bookmarks table used `table-layout: fixed` with the **Title as the only width-less (leftover) column**. The Title is the row's identity but had the *lowest* width priority, so as the panel narrowed it was sacrificed first. And once the responsive rules hid Saved/Tags (≤520px), fixed-layout wouldn't let the Title re-claim that freed width — it collapsed to ~content-min while a repetitive **150px Domain** column held its space.

## Fix
- `.library-bookmarks-table` → **`table-layout: auto`** with the Title as a fluid `max-width:0; width:100%` clipping column, so it absorbs all leftover space and truncates *last* — at every width, including when columns are hidden.
- Domain cell now **ellipsizes** (`min-width:0` + overflow) and its column trimmed **150→112px** (only ever holds a short host); Tags **128→96px**.
- Base `table-layout: fixed` for other library tables and the responsive ladder are untouched.

## Validation (standalone CSS harness, real board.css+library.css, across shell widths)
| shell | Title width | cols | title collapses? |
|------:|------------:|-----:|:----------------:|
| 820 | 615px | 5 | no |
| 520 | 402px | 3 (domain shown, saved/tags hidden) | no |
| 440 | 414px | 2 (domain hidden) | no |
| 280 | 254px | 2 | no |

Title now gets **254–615px** and never collapses (was ~70–150px in the narrow band). Also measured in the live app: at shell 827 Title 429→**533px**.

`pnpm typecheck`, the library `*.test.ts` suite, and `pnpm build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)