### PR TITLE
fix(chat): folder icon follows expand state, not selection

### DIFF
--- a/src/components/chat-project-sidebar.tsx
+++ b/src/components/chat-project-sidebar.tsx
@@ -483,7 +483,7 @@ export function ChatProjectSidebar({
                     >
                       <Icon name={expanded ? "ph:caret-down" : "ph:caret-right"} width={10} aria-hidden className="shrink-0 text-[var(--text-muted)]" />
                       <Icon
-                        name={isSelected ? "ph:folder-open" : "ph:folder"}
+                        name={expanded ? "ph:folder-open" : "ph:folder"}
                         width={13}
                         aria-hidden
                         className="shrink-0 text-[var(--text-muted)]"


### PR DESCRIPTION
## What

In the Chats panel's project tree, an **expanded** project that wasn't the currently-selected one showed a **closed** folder icon — its caret pointed down and its sessions were visible, but the folder looked shut. Caret and folder disagreed.

## Cause

The folder icon was bound to selection:

```tsx
name={isSelected ? "ph:folder-open" : "ph:folder"}
```

So only the selected project ever showed an open folder, regardless of expansion.

## Fix

Bind it to `expanded` (an expanded folder is an open folder):

```tsx
name={expanded ? "ph:folder-open" : "ph:folder"}
```

Selection is already conveyed by the accent bar, row highlight, and text colour — the folder icon is free to track expansion.

## Verification

Driven live (worktree dev server, Playwright). Compared the rendered folder SVG path across rows: an expanded **unselected** project ("Coven Cave") now renders the open-folder path (`ph:folder-open`, `M245 110.64…`), distinct from collapsed rows (`ph:folder`, `M216 72h…`). `tsc` clean; `chat-list-panel` test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)