### PR TITLE
polish(workflows): enlarge the manifest preview

### DIFF
--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -1062,14 +1062,17 @@
 
 .workflow-manifest-yaml {
   margin: 0;
-  padding: 9px 10px;
+  padding: 11px 12px;
   border: 1px solid var(--border);
   border-radius: 8px;
   background: color-mix(in oklch, var(--background) 80%, transparent);
-  font-size: 11px;
-  line-height: 1.5;
+  font-size: 12px;
+  line-height: 1.55;
   overflow: auto;
-  max-height: 240px;
+  /* Larger preview: the manifest is the canonical "what Save writes", so give
+     it room to show most workflows without its own scrollbar. Scales with the
+     viewport; the side panel still scrolls past it on short screens. */
+  max-height: min(620px, 58vh);
   white-space: pre;
 }
 


### PR DESCRIPTION
## What

The Workflow Studio's **Manifest** preview (the canonical YAML that Save writes) was a cramped little box — `max-height: 240px`, `font-size: 11px` — with its own scrollbar inside the already-scrolling side panel, cutting most workflows off around `limits:`.

## Change

- `max-height: 240px → min(620px, 58vh)` — scales with the viewport; the side panel still scrolls past it on short screens.
- `font-size: 11px → 12px` (and a touch more padding/line-height) for legibility.

One CSS rule (`.workflow-manifest-yaml`).

## Verification

Driven live (worktree dev server, Playwright): the manifest renders at **551px** (was 240px) at **12px**, now showing through `steps:` instead of stopping at `limits:`. `workflow-studio` test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)