### PR TITLE
feat(fonts): default code font to JetBrains Mono

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -301,7 +301,7 @@
   --color-border-strong: var(--border-strong);
   --color-accent-presence: var(--accent-presence);
   --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-mono: var(--font-jetbrains-mono);
 }
 
 html,

--- a/src/components/font-boot.test.ts
+++ b/src/components/font-boot.test.ts
@@ -8,7 +8,7 @@ const src = readFileSync(new URL("./theme-script.tsx", import.meta.url), "utf8")
 assert.match(src, /cave:font:sans/, "boot reads cave:font:sans");
 assert.match(src, /cave:font:mono/, "boot reads cave:font:mono");
 assert.match(src, /"geist"/, "boot skips the sans default");
-assert.match(src, /"geist-mono"/, "boot skips the mono default");
+assert.match(src, /"jetbrains-mono"/, "boot skips the mono default");
 assert.match(src, /setProperty\(\s*["']--font-sans["']/, "boot sets --font-sans");
 assert.match(src, /setProperty\(\s*["']--font-mono["']/, "boot sets --font-mono");
 assert.match(src, /\^\[a-z0-9-\]\+\$/, "boot validates id is kebab-case");

--- a/src/components/theme-script.tsx
+++ b/src/components/theme-script.tsx
@@ -22,7 +22,7 @@
  * renames.
  *
  * NOTE: The font keys ("cave:font:sans", "cave:font:mono"), default ids
- * ("geist", "geist-mono"), and the SANS_FALLBACK / MONO_FALLBACK strings
+ * ("geist", "jetbrains-mono"), and the SANS_FALLBACK / MONO_FALLBACK strings
  * are duplicated from src/lib/font-catalog.ts and src/lib/font-storage.ts.
  * Keep in sync when adding new fonts or changing fallback chains.
  */
@@ -79,7 +79,7 @@ const THEME_SCRIPT = `
       try { html.style.setProperty("--font-sans", "var(--font-" + fontSansId + "), " + SANS_FB); } catch (e) {}
     }
     var fontMonoId = localStorage.getItem("cave:font:mono");
-    if (fontMonoId && fontMonoId !== "geist-mono" && /^[a-z0-9-]+$/.test(fontMonoId)) {
+    if (fontMonoId && fontMonoId !== "jetbrains-mono" && /^[a-z0-9-]+$/.test(fontMonoId)) {
       try { html.style.setProperty("--font-mono", "var(--font-" + fontMonoId + "), " + MONO_FB); } catch (e) {}
     }
   } catch (e) {}

--- a/src/lib/font-catalog.ts
+++ b/src/lib/font-catalog.ts
@@ -48,7 +48,7 @@ export const FONT_OPTIONS: FontOption[] = [
 
 export const DEFAULT_FONT_ID: Record<FontSlot, string> = {
   sans: "geist",
-  mono: "geist-mono",
+  mono: "jetbrains-mono",
 };
 
 export function fontOptionById(id: string): FontOption | undefined {

--- a/src/lib/font-css-vars.test.ts
+++ b/src/lib/font-css-vars.test.ts
@@ -30,7 +30,7 @@ for (const rel of FILES) {
 
 const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 assert.match(globals, /--font-sans:\s*var\(--font-geist-sans\)/, ":root --font-sans default must remain");
-assert.match(globals, /--font-mono:\s*var\(--font-geist-mono\)/, ":root --font-mono default must remain");
+assert.match(globals, /--font-mono:\s*var\(--font-jetbrains-mono\)/, ":root --font-mono default is JetBrains Mono");
 
 // The reading line-spacing control drives the shared .cave-md prose surface via
 // --cave-reading-leading, with a 1.7 fallback so the default is unchanged.

--- a/src/lib/font-settings.test.ts
+++ b/src/lib/font-settings.test.ts
@@ -28,9 +28,9 @@ for (const o of FONT_OPTIONS) {
   assert.ok(o.label.length > 0, `label for ${o.id}`);
 }
 
-// Defaults are the existing Geist pair, so a fresh profile changes nothing.
+// Defaults are the Coven-branded pair: Geist Sans for UI, JetBrains Mono for code.
 assert.equal(DEFAULT_FONT_ID.sans, "geist");
-assert.equal(DEFAULT_FONT_ID.mono, "geist-mono");
+assert.equal(DEFAULT_FONT_ID.mono, "jetbrains-mono");
 assert.equal(fontOptionById("geist")?.cssVar, "--font-geist-sans");
 assert.equal(fontOptionById("geist-mono")?.cssVar, "--font-geist-mono");
 assert.equal(fontOptionById("nope"), undefined);

--- a/src/lib/font-storage.test.ts
+++ b/src/lib/font-storage.test.ts
@@ -65,8 +65,10 @@ test("applyFont(default) removes the override", () => {
 
 test("mono slot uses the mono key and --font-mono var", () => {
   const { props } = setupDom();
-  writeFontPref("mono", "jetbrains-mono");
-  applyFont("mono", "jetbrains-mono");
-  assert.equal(readFontPref("mono"), "jetbrains-mono");
-  assert.equal(props.get("--font-mono"), fontStack(fontOptionById("jetbrains-mono")));
+  // geist-mono is a non-default mono now (default is jetbrains-mono), so it
+  // sets the override rather than clearing it.
+  writeFontPref("mono", "geist-mono");
+  applyFont("mono", "geist-mono");
+  assert.equal(readFontPref("mono"), "geist-mono");
+  assert.equal(props.get("--font-mono"), fontStack(fontOptionById("geist-mono")));
 });


### PR DESCRIPTION
Makes the Coven-branded code font the default: **JetBrains Mono** for the mono slot. Geist Sans stays the UI default (unchanged).

Keeps the three sources of the mono default in sync:
- `DEFAULT_FONT_ID.mono` → `jetbrains-mono` (`font-catalog.ts`)
- `:root --font-mono` alias → `var(--font-jetbrains-mono)` (`globals.css`)
- no-FOUC boot script default-skip id (`theme-script.tsx`)

Geist Mono remains selectable in the picker. Tests updated for the new default (catalog, css-vars, boot, storage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)