### PR TITLE
polish(chat): honest header metadata + fix task-chip navigation to board

### DIFF
--- a/src/components/chat-linked-context.test.ts
+++ b/src/components/chat-linked-context.test.ts
@@ -94,6 +94,17 @@ assert.match(
   "Workspace should open the board view and focus the linked task card",
 );
 
+// Regression guard: the popstate back-to-list fallback must be gated on an
+// EMPTY hash. Writing `#card-<id>` (the task chip's navigation) synchronously
+// fires this handler while mode is still "chat"; an unconditional
+// showAgentChatList() there clobbered the same-batch setMode("board") and
+// stranded the user on the chat list instead of the task's board inspector.
+assert.match(
+  workspace,
+  /modeRef\.current === "chat" && !window\.location\.hash\) showAgentChatList\(\)/,
+  "Workspace popstate must only show the chat list on an empty hash, so the task chip's #card- navigation isn't hijacked back to the list",
+);
+
 assert.match(
   chatView,
   /historyState === "loading"[\s\S]*Loading chat history/,

--- a/src/components/chat-response-metadata.test.ts
+++ b/src/components/chat-response-metadata.test.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
+import { formatRuntime } from "../lib/chat-response-metadata.ts";
 
 const chatRoute = await readFile(new URL("../app/api/chat/send/route.ts", import.meta.url), "utf8");
 const chatView = await readFile(new URL("./chat-view.tsx", import.meta.url), "utf8");
@@ -70,8 +71,13 @@ assert.match(
 
 assert.match(
   chatView,
-  /modelLabel\(args\.model\)[\s\S]*runtimeLabel\(args\.runtime\)/,
-  "Chat session metadata should label model and runtime clearly in the header",
+  /formatRuntime\(args\.runtime\)/,
+  "Chat header should render the runtime honestly as a working directory (no dishonest 'model:'/'runtime:' labels)",
+);
+assert.doesNotMatch(
+  chatView,
+  /modelLabel|runtimeLabel/,
+  "The misleading 'model:'/'runtime:' label helpers should be gone — openclaw-local is not a model and the runtime is a cwd",
 );
 
 assert.match(
@@ -103,5 +109,27 @@ assert.match(
   /model\?: string \| null;[\s\S]*runtime\?: string \| null;/,
   "Session rows should carry optional model/runtime metadata",
 );
+
+// formatRuntime turns the opaque `runtime` value into an honest working
+// directory: scheme stripped, home collapsed to ~, long paths left-truncated
+// so the repo folder survives. The full path stays in the tooltip title.
+{
+  const local = formatRuntime("local:/Users/buns/Documents/GitHub/OpenCoven/coven-cave");
+  assert.equal(local?.label, "~/…/coven-cave", "local cwd shows home-relative, repo-name-preserving");
+  assert.equal(local?.title, "~/Documents/GitHub/OpenCoven/coven-cave", "tooltip keeps the full cwd");
+
+  assert.equal(formatRuntime("local:/home/val/proj")?.label, "~/proj", "linux home collapses too");
+  assert.equal(formatRuntime("local:/Users/buns")?.label, "~", "bare home is ~");
+  assert.equal(formatRuntime("local:/opt/work/repo")?.label, "/opt/…/repo", "non-home absolute path keeps its root slash");
+
+  const ssh = formatRuntime("ssh:beacon:/home/val/srv");
+  assert.equal(ssh?.label, "beacon:~/srv", "ssh shows host:cwd");
+  assert.match(ssh?.title ?? "", /ssh/, "ssh tooltip notes the transport");
+
+  assert.equal(formatRuntime(""), null, "empty runtime renders nothing");
+  assert.equal(formatRuntime(null), null, "missing runtime renders nothing");
+  // No dishonest "model:" / "runtime:" prefixes anywhere in the label.
+  assert.doesNotMatch(local?.label ?? "", /model:|runtime:/, "label carries no dishonest prefix");
+}
 
 console.log("chat-response-metadata.test.ts: ok");

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -318,7 +318,7 @@ assert.match(
 // "… · 7s · 12.4k tok · $0.08" — and stays silent when there is no usage.
 assert.match(
   source,
-  /const dur = fmtDuration\(args\.durationMs\);\s*\n\s*if \(dur\) parts\.push\(dur\);[\s\S]{0,300}?const usage = usageSummary\(args\.usage, args\.costUsd\);\s*\n\s*if \(usage\) parts\.push\(usage\);/,
+  /const dur = fmtDuration\(args\.durationMs\);\s*\n\s*if \(dur\) segs\.push\(dur\);[\s\S]{0,300}?const usage = usageSummary\(args\.usage, args\.costUsd\);\s*\n\s*if \(usage\) segs\.push\(usage\);/,
   "MetaLine's complete state appends the usage summary after the duration in the same dot-separated format (CHAT-D12-02)",
 );
 
@@ -390,15 +390,15 @@ assert.match(
   /\{state === "streaming" && pendingSince \? <MetaLineElapsed since=\{pendingSince\} \/> : null\}\s*\n\s*\{state === "streaming" \? " · esc to cancel" : null\}/,
   "Streaming meta line renders elapsed between the phase wording and the esc hint (CHAT-D3-06)",
 );
-// The esc hint moved out of metaLineString into MetaLine's JSX so the ticker
-// could slot in before it — the string builder must not duplicate it.
-const metaLineStringBody =
-  source.match(/function metaLineString\([\s\S]*?\n}\n/)?.[0] ?? "";
-assert.ok(metaLineStringBody, "metaLineString body should be extractable (CHAT-D3-06)");
+// The esc hint moved out of the meta builder into MetaLine's JSX so the ticker
+// could slot in before it — the segment builder must not duplicate it.
+const metaLineSegmentsBody =
+  source.match(/function metaLineSegments\([\s\S]*?\n}\n/)?.[0] ?? "";
+assert.ok(metaLineSegmentsBody, "metaLineSegments body should be extractable (CHAT-D3-06)");
 assert.doesNotMatch(
-  metaLineStringBody,
+  metaLineSegmentsBody,
   /esc to cancel/,
-  "metaLineString no longer carries the esc hint — MetaLine renders it after the ticker (CHAT-D3-06)",
+  "metaLineSegments no longer carries the esc hint — MetaLine renders it after the ticker (CHAT-D3-06)",
 );
 // The ticker anchors to the in-flight assistant turn's createdAt.
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, useCallback, useEffect, useId, useImperativeHandle, useMemo, useRef, useState } from "react";
+import { forwardRef, Fragment, useCallback, useEffect, useId, useImperativeHandle, useMemo, useRef, useState } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { RichText } from "@/components/rich-text";
 import { MessageBubble, SyntaxBlock, type MessageBubbleSegment } from "@/components/message-bubble";
@@ -37,8 +37,7 @@ import { CsvImportModal } from "./csv-import-modal";
 import { looksLikeCsv } from "@/lib/csv-import";
 import { usageBreakdown, usageSummary, type TurnUsage } from "@/lib/usage-format";
 import {
-  modelLabel,
-  runtimeLabel,
+  formatRuntime,
   type ChatResponseMetadata,
 } from "@/lib/chat-response-metadata";
 import {
@@ -696,15 +695,22 @@ function ChatTitleEditable({
 }
 
 function ResponseMetadataText({ metadata }: { metadata?: ChatResponseMetadata }) {
-  const model = modelLabel(metadata?.model);
-  const runtime = runtimeLabel(metadata?.runtime);
-  if (!model && !runtime) return null;
+  const model = metadata?.model?.trim() || null;
+  const dir = formatRuntime(metadata?.runtime);
+  if (!model && !dir) return null;
   return (
     <span
-      className="font-mono text-[10px] text-[var(--text-muted)]"
-      title={[metadata?.harness, model, runtime].filter(Boolean).join(" · ") || undefined}
+      className="font-mono text-[10px] text-[var(--text-muted)] inline-flex items-center gap-1"
+      title={[metadata?.harness, model, dir?.title].filter(Boolean).join(" · ") || undefined}
     >
-      {[model, runtime].filter(Boolean).join(" · ")}
+      {model}
+      {model && dir ? " · " : null}
+      {dir ? (
+        <span className="inline-flex items-center gap-1">
+          <Icon name="ph:folder" width={10} aria-hidden />
+          {dir.label}
+        </span>
+      ) : null}
     </span>
   );
 }
@@ -723,7 +729,11 @@ function metaLineState(args: {
   return "complete";
 }
 
-function metaLineString(args: {
+/** A directory segment renders with a folder icon (the runtime IS the working
+ *  directory — see formatRuntime); plain strings render as text. */
+type MetaSegment = string | { dir: { label: string; title: string } };
+
+function metaLineSegments(args: {
   state: MetaLineState;
   lifecycle: ChatTurnLifecycle | null;
   harness?: string;
@@ -733,41 +743,38 @@ function metaLineString(args: {
   durationMs?: number;
   usage?: TurnUsage;
   costUsd?: number;
-}): string {
-  const parts: string[] = [];
+}): MetaSegment[] {
+  const segs: MetaSegment[] = [];
+  // The runtime is the cwd; fall back to the project root so a directory shows
+  // even before the first turn records runtime metadata. No dishonest "model:"
+  // / "runtime:" labels — the harness and agent profile read bare, the cwd
+  // reads as a folder.
+  const runtime = formatRuntime(args.runtime) ?? formatRuntime(args.projectRoot ? `local:${args.projectRoot}` : null);
   if (args.state === "offline") {
-    parts.push("daemon offline · check Coven");
+    segs.push("daemon offline · check Coven");
   } else if (args.state === "failed") {
-    const model = modelLabel(args.model);
-    if (model) parts.push(model);
-    const runtime = runtimeLabel(args.runtime);
-    if (runtime) parts.push(runtime);
-    parts.push("failed");
+    if (args.model) segs.push(args.model);
+    if (runtime) segs.push({ dir: runtime });
+    segs.push("failed");
   } else if (args.state === "streaming") {
-    const model = modelLabel(args.model);
-    if (model) parts.push(model);
-    const runtime = runtimeLabel(args.runtime);
-    if (runtime) parts.push(runtime);
-    parts.push(args.lifecycle === "tooling" ? "using tools…" : args.lifecycle === "connecting" || args.lifecycle === "queued" ? "connecting…" : "writing…");
+    if (args.model) segs.push(args.model);
+    if (runtime) segs.push({ dir: runtime });
+    segs.push(args.lifecycle === "tooling" ? "using tools…" : args.lifecycle === "connecting" || args.lifecycle === "queued" ? "connecting…" : "writing…");
     // CHAT-D3-06: the "· 14s" ticker + esc hint tail is rendered by MetaLine
     // itself so the ticking elapsed can live in an aria-hidden span — keeping
     // the per-second rewrite out of the role="status" live region.
   } else {
-    if (args.harness) parts.push(args.harness);
-    const model = modelLabel(args.model);
-    if (model) parts.push(model);
-    const runtime = runtimeLabel(args.runtime);
-    if (runtime) parts.push(runtime);
-    const repo = repoName(args.projectRoot);
-    if (repo) parts.push(repo);
+    if (args.harness) segs.push(args.harness);
+    if (args.model) segs.push(args.model);
+    if (runtime) segs.push({ dir: runtime });
     const dur = fmtDuration(args.durationMs);
-    if (dur) parts.push(dur);
+    if (dur) segs.push(dur);
     // CHAT-D12-02: "… · 7s · 12.4k tok · $0.08" — absent when the harness
     // emitted no usage (e.g. the OpenClaw bridge).
     const usage = usageSummary(args.usage, args.costUsd);
-    if (usage) parts.push(usage);
+    if (usage) segs.push(usage);
   }
-  return parts.join(" · ");
+  return segs;
 }
 
 /** In-transcript find bar (CHAT-D9-04). Collapsed: a search icon button in
@@ -959,7 +966,7 @@ function MetaLine({
   children?: React.ReactNode;
 }) {
   const state = metaLineState({ busy, lifecycle, error, daemonRunning });
-  const meta = metaLineString({
+  const segments = metaLineSegments({
     state,
     lifecycle,
     harness: familiar.harness ?? undefined,
@@ -989,7 +996,19 @@ function MetaLine({
         />
       ) : null}
       <span className="cave-chat-meta-line__meta">
-        {meta}
+        {segments.map((seg, i) => (
+          <Fragment key={i}>
+            {i > 0 ? " · " : null}
+            {typeof seg === "string" ? (
+              seg
+            ) : (
+              <span className="cave-chat-meta-line__dir" title={seg.dir.title}>
+                <Icon name="ph:folder" width={11} aria-hidden />
+                {seg.dir.label}
+              </span>
+            )}
+          </Fragment>
+        ))}
         {state === "streaming" && pendingSince ? <MetaLineElapsed since={pendingSince} /> : null}
         {state === "streaming" ? " · esc to cancel" : null}
       </span>

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -790,9 +790,17 @@ export function Workspace() {
         showAgentChatList();
         return;
       }
-      // Popped back out of a chat entry → show the list, but only while the
-      // chat surface is active; other surfaces own their own hash traffic.
-      if (modeRef.current === "chat") showAgentChatList();
+      // Popped back out of a chat entry to the root (empty hash) → show the
+      // list. A *non-empty* hash belongs to another surface's deep link — the
+      // `#card-<id>` the task chip writes, or `#memory:` / `#library:` — and
+      // that surface owns its own mode switch. Bouncing to the chat list here
+      // would hijack such navigation: writing `#card-<id>` synchronously fires
+      // this handler while `mode` is still "chat" (the intent's setMode("board")
+      // hasn't committed yet), so an unconditional showAgentChatList() clobbers
+      // the board switch in the same render batch and strands the user on the
+      // chat list. Gating on the empty hash leaves cross-surface deep links to
+      // their owners while preserving genuine Back-to-list.
+      if (modeRef.current === "chat" && !window.location.hash) showAgentChatList();
     };
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);

--- a/src/lib/chat-response-metadata.ts
+++ b/src/lib/chat-response-metadata.ts
@@ -5,12 +5,42 @@ export type ChatResponseMetadata = {
   runtime: string;
 };
 
-export function modelLabel(model?: string | null): string | null {
-  const trimmed = model?.trim();
-  return trimmed ? `model: ${trimmed}` : null;
+/** Collapse a user home prefix to "~" so the directory reads as a location the
+ *  user can place, not a machine-specific absolute path. Matches the macOS
+ *  /Users/<name> and Linux /home/<name> conventions the daemon emits. */
+function homeRelative(p: string): string {
+  return p.replace(/^\/(?:Users|home)\/[^/]+(?=\/|$)/, "~");
 }
 
-export function runtimeLabel(runtime?: string | null): string | null {
+/** Keep the path legible at header widths by left-truncating: first segment +
+ *  last segment with an ellipsis between, so the meaningful repo folder
+ *  survives instead of being clipped off the end. Short paths (≤2 segments)
+ *  pass through whole. */
+function shortenPath(p: string): string {
+  const isAbs = p.startsWith("/");
+  const parts = p.split("/").filter(Boolean);
+  if (parts.length <= 2) return p;
+  return `${isAbs ? "/" : ""}${parts[0]}/…/${parts[parts.length - 1]}`;
+}
+
+/** The conversation's `runtime` is not a "runtime" the user thinks about — it's
+ *  the working directory the harness runs in. Render it as a directory:
+ *  `local:<cwd>` → the cwd (home-relative, shortened); `ssh:<host>:<cwd>` →
+ *  `host:<cwd>`. `label` is what shows next to the folder icon; `title` carries
+ *  the full, unshortened location for the hover tooltip. */
+export function formatRuntime(
+  runtime?: string | null,
+): { label: string; title: string } | null {
   const trimmed = runtime?.trim();
-  return trimmed ? `runtime: ${trimmed}` : null;
+  if (!trimmed) return null;
+  if (trimmed.startsWith("ssh:")) {
+    const rest = trimmed.slice(4);
+    const sep = rest.indexOf(":");
+    const host = sep >= 0 ? rest.slice(0, sep) : rest;
+    const cwd = sep >= 0 ? homeRelative(rest.slice(sep + 1)) : "";
+    if (!cwd) return { label: host, title: `${host} (ssh)` };
+    return { label: `${host}:${shortenPath(cwd)}`, title: `${host}:${cwd} (ssh)` };
+  }
+  const cwd = homeRelative(trimmed.startsWith("local:") ? trimmed.slice(6) : trimmed);
+  return { label: shortenPath(cwd), title: cwd };
 }

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1386,6 +1386,20 @@ details[open] > .cave-tool-summary::before {
   font-variant-numeric: tabular-nums;
 }
 
+/* The runtime renders as a working directory: a folder glyph + the cwd
+   (home-relative, left-truncated in JS so the repo name survives). The glyph
+   sits flush with its baseline so the segment reads as one token. */
+.cave-chat-meta-line__dir {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  vertical-align: bottom;
+}
+.cave-chat-meta-line__dir svg {
+  flex-shrink: 0;
+  opacity: 0.75;
+}
+
 .cave-chat-meta-line__dot {
   width: 6px;
   height: 6px;

--- a/tests/chat-task-chip-nav.spec.ts
+++ b/tests/chat-task-chip-nav.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Repro for: clicking the linked-task chip in the chat header should navigate
+// to the board and open that card's inspector (expanded details). User reports
+// it lands on the Chat List instead. We mock a board-originated session whose
+// conversation carries linked task context, open it, then click the chip.
+
+const ISO = "2026-06-12T10:00:00.000Z";
+const CARD_ID = "card-vcs-review";
+
+const SESSION = {
+  id: "s-task",
+  title: "Task: Review Version Control in Cave",
+  status: "running",
+  origin: "board",
+  project_root: "/Users/buns/Documents/GitHub/OpenCoven/coven-cave",
+  harness: "claude",
+  familiarId: "nova",
+  model: "openclaw-local",
+  runtime: "local:/Users/buns/Documents/GitHub/OpenCoven/coven-cave",
+  exit_code: null,
+  archived_at: null,
+  created_at: ISO,
+  updated_at: ISO,
+};
+
+const CARD = {
+  id: CARD_ID,
+  title: "Review Version Control in Cave",
+  notes: "Audit the changes panel.",
+  status: "backlog",
+  priority: "medium",
+  familiarId: "nova",
+  sessionId: "s-task",
+  cwd: "/Users/buns/Documents/GitHub/OpenCoven/coven-cave",
+  links: [],
+  github: [],
+  labels: [],
+  createdAt: ISO,
+  updatedAt: ISO,
+  lifecycle: "queued",
+  lifecycleAt: ISO,
+  retryCount: 0,
+  maxRetries: 2,
+  steps: [],
+};
+
+const CONTEXT = {
+  task: {
+    id: CARD_ID,
+    title: CARD.title,
+    status: CARD.status,
+    priority: CARD.priority,
+    lifecycle: CARD.lifecycle,
+    labels: [],
+    cwd: CARD.cwd,
+    notes: CARD.notes,
+  },
+  github: [],
+};
+
+async function setup(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:demo-mode", "1");
+    window.localStorage.setItem("cave:active-familiar", "nova");
+    window.localStorage.setItem("cave:familiar:nova:last-surface", "chat");
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+  });
+  await page.route("**/api/sessions/list**", (route) =>
+    route.fulfill({ json: { ok: true, sessions: [SESSION] } }),
+  );
+  await page.route("**/api/chat/conversation/**", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        conversation: { turns: [{ id: "t1", role: "assistant", text: "On it.", createdAt: ISO }] },
+        context: CONTEXT,
+      },
+    }),
+  );
+  await page.route("**/api/board**", (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({ json: { ok: true, cards: [CARD] } });
+    }
+    return route.continue();
+  });
+  await page.goto("/?demo=1");
+  await page.waitForTimeout(500);
+  await page.keyboard.press("Meta+2");
+  await page.waitForSelector(".chat-surface", { timeout: 30_000 });
+}
+
+test("task chip navigates to the board card inspector, not the chat list", async ({ page }) => {
+  await setup(page);
+
+  // Open the task chat from the rail.
+  const rail = page.locator(".chat-thread-rail");
+  await rail.getByText("Review Version Control in Cave", { exact: false }).first().click();
+
+  // The linked-task chip appears in the chat header. Its accessible name is
+  // the chip's own text content ("Task … backlog medium"), which the status/
+  // priority suffix distinguishes from the rail's session button.
+  const chip = page.getByRole("button", { name: /Review Version Control in Cave backlog medium/ });
+  await expect(chip).toBeVisible({ timeout: 30_000 });
+
+  // Click it → leaves the chat surface and opens the board card inspector.
+  // Regression guard: writing `#card-<id>` used to synchronously fire the
+  // workspace popstate handler, which bounced back to the chat list (mode was
+  // still "chat" before the intent's setMode("board") committed) — stranding
+  // the user on the list instead of the task.
+  await chip.click();
+
+  await expect(page.getByRole("dialog", { name: "Card inspector" })).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator(".chat-surface")).toHaveCount(0);
+});


### PR DESCRIPTION
Two fixes from a pass over the chat details header.

## 1. Honest, minimal header metadata

The header read `claude · model: openclaw-local · runtime: local:/Users/buns/Documents/GitHub/Open…`. Two dishonest labels and a truncation that hid the useful part:

- **`openclaw-local` is not a model** — it's the agent-profile id (`${harness}-local`). The `model:` prefix misrepresents it.
- **`runtime:` is just the working directory** — the value is `local:<cwd>` (a scheme + path). Users think of it as the directory (cwd).
- **End-truncation clipped the repo name** (`Open…`), the one segment that identifies the directory.

Now: `claude · openclaw-local · 📁 ~/…/coven-cave` (full path in the hover tooltip)

- Drop the `model:` / `runtime:` label helpers. Harness + agent profile read bare; the cwd renders as a directory with a folder glyph (the `ph:folder` = cwd convention already used in the board inspector).
- New `formatRuntime()`: strips the `local:` scheme, collapses home to `~`, **left-truncates** so the repo folder survives (`~/…/coven-cave`). `ssh:<host>:<cwd>` → `host:<cwd>`. Full location in the tooltip.
- Same treatment for the per-turn `ResponseMetadataText` row.
- Meta line renders as `MetaSegment[]` so the directory segment can carry an icon.

## 2. Task chip now lands on the board card (not the chat list)

Clicking the linked-task chip stranded the user on the **chat list** instead of opening the task's board inspector.

Root cause: the `focus-card` intent does `setMode("board")` then `window.location.hash = "card-<id>"`. Writing the hash synchronously fires the workspace popstate handler, whose back-to-list fallback was gated only on `mode === "chat"`. At that instant `mode` is still `chat` (the `setMode("board")` hasn't committed) and the new hash isn't a `#chat-` hash, so the fallback called `showAgentChatList()` → `setMode("chat")`, clobbering the board switch in the same render batch.

Fix: gate the fallback on an **empty** hash. A non-empty hash belongs to another surface's deep link (`#card-`, `#memory:`, `#library:`) that owns its own mode switch — popstate must not hijack it. Genuine Back-to-list (hash-less root entry) is preserved.

## Verification

- `formatRuntime` behavioral tests + updated source-grep guards (`chat-response-metadata.test.ts`, `chat-view-lifecycle.test.ts`).
- New Playwright regression spec `tests/chat-task-chip-nav.spec.ts` — **live-verified**: chip click leaves the chat surface and opens the "Card inspector" dialog (confirmed the bug first, then the fix). The honest header line (`claude · openclaw-local · ~/…/coven-cave`) was also confirmed in the same live run's ARIA snapshot.
- CI source-grep guard added in `chat-linked-context.test.ts` for the popstate gate.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)