### PR TITLE
Potential fix for code scanning alert no. 42: Uncontrolled data used in path expression

### DIFF
--- a/src/lib/workflow-source.ts
+++ b/src/lib/workflow-source.ts
@@ -501,9 +501,10 @@ export async function saveLocalWorkflow(body: {
   try {
     await withWorkflowWriteLock(async () => {
       const dir = await ensureWorkflowDir(storage);
-      const resolvedDir = path.resolve(dir);
-      const filePath = path.resolve(resolvedDir, file);
-      if (!filePath.startsWith(`${resolvedDir}${path.sep}`)) {
+      const root = path.resolve(dir);
+      const filePath = path.resolve(root, file);
+      const rel = path.relative(root, filePath);
+      if (rel.startsWith("..") || path.isAbsolute(rel)) {
         throw new Error("resolved workflow path escapes workflow directory");
       }
       await writeFile(filePath, text, { encoding: "utf8", mode: storage === "personal" ? 0o600 : undefined });

--- a/src/lib/workflow-source.ts
+++ b/src/lib/workflow-source.ts
@@ -501,7 +501,11 @@ export async function saveLocalWorkflow(body: {
   try {
     await withWorkflowWriteLock(async () => {
       const dir = await ensureWorkflowDir(storage);
-      const filePath = path.join(dir, file);
+      const resolvedDir = path.resolve(dir);
+      const filePath = path.resolve(resolvedDir, file);
+      if (!filePath.startsWith(`${resolvedDir}${path.sep}`)) {
+        throw new Error("resolved workflow path escapes workflow directory");
+      }
       await writeFile(filePath, text, { encoding: "utf8", mode: storage === "personal" ? 0o600 : undefined });
       if (storage === "personal") {
         await chmod(filePath, 0o600);


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/42](https://github.com/OpenCoven/coven-cave/security/code-scanning/42)

General fix: keep input validation on filename, and additionally enforce that the final resolved path is contained within the intended workflow directory before writing.

Best fix here (without changing behavior): in `saveLocalWorkflow` (around lines 503–505 in `src/lib/workflow-source.ts`), resolve both the target directory and the computed file path, then verify the file path starts with the normalized directory prefix. If not, throw an error and abort write. This preserves current logic while adding an explicit path-containment guard CodeQL recognizes.

Changes needed:
- File: `src/lib/workflow-source.ts`
- Region: inside `withWorkflowWriteLock` callback in `saveLocalWorkflow`, where `filePath` is built and used.
- No new imports required (`path` is already imported).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
