### PR TITLE
fix(chat): no message hover tint; copy action row below the message

### DIFF
--- a/src/components/message-bubble-markdown.test.ts
+++ b/src/components/message-bubble-markdown.test.ts
@@ -62,8 +62,8 @@ assert.doesNotMatch(
 );
 assert.match(
   source,
-  /\{!pending && <CopyBubble/,
-  "User-bubble Copy action renders whenever the message is not pending",
+  /\{!pending \? \(\s*<div className="cave-bubble-actions">/,
+  "User-bubble action row renders (below the bubble) whenever the message is not pending",
 );
 assert.match(
   source,
@@ -169,8 +169,8 @@ assert.match(
 );
 assert.match(
   css,
-  /@media \(pointer: coarse\) \{\s*\.cave-copy-btn-bubble \{\s*opacity: 1;/,
-  "Coarse pointers have no hover — bubble actions must be always visible there",
+  /@media \(pointer: coarse\) \{\s*\.cave-bubble-actions,\s*\.cave-copy-btn-bubble \{\s*opacity: 1;/,
+  "Coarse pointers have no hover — bubble action rows must be always visible there",
 );
 
 // CHAT-D7-08 CSS half: the wrapper owns horizontal overflow; cells restore

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -822,12 +822,16 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
       >
-        <div className="relative cave-bubble-user">
+        <div className="cave-bubble-user">
           <MarkdownContent text={content} pending={pending} />
-          {/* Always in the DOM (CHAT-D6-04) — visibility is CSS-gated so the
-              buttons are reachable by keyboard (Tab), screen readers, and touch. */}
+        </div>
+        {/* Action row sits BELOW the bubble (right-aligned via the items-end
+            column) so it never overlays the message. Always in the DOM
+            (CHAT-D6-04) — visibility is CSS-gated so the buttons are reachable
+            by keyboard (Tab), screen readers, and touch. */}
+        {!pending ? (
           <div className="cave-bubble-actions">
-            {!pending && onEdit ? (
+            {onEdit ? (
               <button
                 type="button"
                 aria-label="Edit message"
@@ -838,9 +842,9 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
                 <Icon name="ph:pencil-simple" width={11} aria-hidden />
               </button>
             ) : null}
-            {!pending && <CopyBubble text={content} />}
+            <CopyBubble text={content} />
           </div>
-        </div>
+        ) : null}
         <div className={`cave-bubble-timestamp cave-bubble-timestamp--right${shouldShowTs ? " cave-bubble-timestamp--visible" : ""}`}>
           {fmtBubbleTime(timestamp)}
         </div>

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -471,26 +471,35 @@
   right: 0.45em;
 }
 
-/* When grouped inside .cave-bubble-actions, drop the absolute positioning so
- * the buttons can sit side-by-side in flex layout. The wrapper handles
- * placement. */
+/* Per-message action row — sits in normal flow BELOW the message rather than
+ * floating over its top-right corner, so it never obscures the prose. The
+ * assistant row reads left-aligned; the user row right-aligns via the bubble's
+ * items-end column. Hidden until the turn is hovered/focused, and it reserves
+ * its own height so revealing it never reflows the transcript. */
 .cave-bubble-actions {
-  position: absolute;
-  top: 0.35em;
-  right: 0.45em;
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  margin-top: 5px;
+  opacity: 0;
+  transition: opacity var(--duration-fast, 120ms) var(--ease-standard, ease);
 }
+.group:hover .cave-bubble-actions,
+.group:focus-within .cave-bubble-actions {
+  opacity: 1;
+}
+/* The row owns the reveal; its buttons stay in flow and fully opaque. */
 .cave-bubble-actions .cave-copy-btn-bubble {
   position: static;
   top: auto;
   right: auto;
+  opacity: 1;
 }
 
 /* Touch devices have no hover (CHAT-D6-04) — keep per-message actions
  * always visible on coarse pointers. */
 @media (pointer: coarse) {
+  .cave-bubble-actions,
   .cave-copy-btn-bubble {
     opacity: 1;
   }
@@ -1690,16 +1699,14 @@ details[open] > .cave-tool-summary::before {
   flex-direction: column;
   padding: 14px 0 12px;
   border-bottom: 1px solid color-mix(in oklch, var(--foreground) 5%, transparent);
-  transition: background 0.1s;
 }
 
 .cave-linear-turn:last-child {
   border-bottom: 0;
 }
 
-.cave-linear-turn:hover {
-  background: color-mix(in oklch, var(--foreground) 1.5%, transparent);
-}
+/* No hover tint on chat turns — hovering a message must not shift its
+   background; the per-message action row is the only hover affordance. */
 
 /* User turn — right-aligned bubble */
 .cave-linear-turn--user {


### PR DESCRIPTION
Two chat-transcript changes:

1. **No hover background on messages** — hovering a `.cave-linear-turn` no longer tints its background (rule + unused transition removed). The per-message action row is now the only hover affordance.
2. **Copy/Edit/Expand/Regenerate move below the message** — out of the absolute top-right overlay (which could cover prose) into a hover/focus-revealed **flow row** beneath each turn: assistant left-aligned, user right-aligned (via the bubble's `items-end` column). The row reserves its own height so revealing it never reflows the transcript, and stays always-visible on coarse pointers.

Keyboard / screen-reader reachability (CHAT-D6-04) preserved — actions stay mounted, visibility is CSS-gated. typecheck + chat-view/message-bubble tests pass (source-text assertions updated for the new structure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)