### PR TITLE
Potential fix for code scanning alert no. 45: Uncontrolled data used in path expression

### DIFF
--- a/src/lib/workflow-source.ts
+++ b/src/lib/workflow-source.ts
@@ -562,14 +562,19 @@ async function storageForWorkflowId(id: string): Promise<WorkflowStorageScope> {
 }
 
 /** Absolute path for a layout sidecar, constrained to its workflow storage dir. */
-async function layoutFilePath(id: string): Promise<string | null> {
+function layoutFilePathForStorage(id: string, storage: WorkflowStorageScope): string | null {
   const file = layoutFileName(id);
   if (!file) return null;
-  const root = path.resolve(workflowDirForStorage(await storageForWorkflowId(id)));
+  const root = path.resolve(workflowDirForStorage(storage));
   const target = path.resolve(root, file);
   const rel = path.relative(root, target);
   if (rel.startsWith("..") || path.isAbsolute(rel)) return null;
   return target;
+}
+
+/** Absolute path for a layout sidecar, constrained to its workflow storage dir. */
+async function layoutFilePath(id: string): Promise<string | null> {
+  return layoutFilePathForStorage(id, await storageForWorkflowId(id));
 }
 
 /** Saved node positions for a workflow, or null when none exist. */
@@ -597,13 +602,16 @@ export async function saveWorkflowLayout(
   id: string,
   positions: WorkflowLayout,
 ): Promise<{ ok: boolean; error?: string }> {
-  const filePath = await layoutFilePath(id);
-  if (!filePath) {
+  if (!layoutFileName(id)) {
     return { ok: false, error: `Workflow id \`${id}\` is not a safe filename slug.` };
   }
   try {
     await withWorkflowWriteLock(async () => {
       const storage = await storageForWorkflowId(id);
+      const filePath = layoutFilePathForStorage(id, storage);
+      if (!filePath) {
+        throw new Error(`Workflow id \`${id}\` is not a safe filename slug.`);
+      }
       await ensureWorkflowDir(storage);
       await writeFile(
         filePath,

--- a/src/lib/workflow-source.ts
+++ b/src/lib/workflow-source.ts
@@ -597,15 +597,14 @@ export async function saveWorkflowLayout(
   id: string,
   positions: WorkflowLayout,
 ): Promise<{ ok: boolean; error?: string }> {
-  const file = layoutFileName(id);
-  if (!file) {
+  const filePath = await layoutFilePath(id);
+  if (!filePath) {
     return { ok: false, error: `Workflow id \`${id}\` is not a safe filename slug.` };
   }
   try {
     await withWorkflowWriteLock(async () => {
       const storage = await storageForWorkflowId(id);
-      const dir = await ensureWorkflowDir(storage);
-      const filePath = path.join(dir, file);
+      await ensureWorkflowDir(storage);
       await writeFile(
         filePath,
         JSON.stringify({ version: 1, positions }, null, 2),


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/45](https://github.com/OpenCoven/coven-cave/security/code-scanning/45)

Use a canonical, root-contained path calculation in `saveWorkflowLayout` instead of `path.join(dir, file)`.

Best fix (without changing behavior): in `src/lib/workflow-source.ts`, inside `saveWorkflowLayout`, replace manual path joining with `layoutFilePath(id)` and reject if it returns `null`. This reuses the existing safe resolver that:
- resolves against an absolute root,
- normalizes the resulting path,
- verifies the target remains inside the root via `path.relative`.

This keeps current slug validation and storage resolution behavior while making the write/chmod sink use a defensively validated absolute path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
