### PR TITLE
Potential fix for code scanning alert no. 44: Uncontrolled data used in path expression

### DIFF
--- a/src/lib/workflow-source.ts
+++ b/src/lib/workflow-source.ts
@@ -605,7 +605,12 @@ export async function saveWorkflowLayout(
     await withWorkflowWriteLock(async () => {
       const storage = await storageForWorkflowId(id);
       const dir = await ensureWorkflowDir(storage);
-      const filePath = path.join(dir, file);
+      const root = path.resolve(dir);
+      const filePath = path.resolve(root, file);
+      const rel = path.relative(root, filePath);
+      if (rel.startsWith("..") || path.isAbsolute(rel)) {
+        throw new Error("resolved layout path escapes workflow storage directory");
+      }
       await writeFile(
         filePath,
         JSON.stringify({ version: 1, positions }, null, 2),


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/44](https://github.com/OpenCoven/coven-cave/security/code-scanning/44)

To fix this class of issue, ensure that any path derived from potentially untrusted input is canonicalized and verified to remain under an expected root before file operations. The strongest pattern is:

1. Resolve the trusted root directory.
2. Resolve the candidate path from root + user-derived filename.
3. Use `path.relative(root, candidate)` (or prefix checks on normalized paths) to verify containment.
4. Reject if candidate escapes root.

Best targeted fix (without changing functionality): in `src/lib/workflow-source.ts`, update `saveWorkflowLayout()` to construct `filePath` using `path.resolve(root, file)` and verify it is still under `root` before `writeFile`/`chmod`. This mirrors the existing safe logic in `layoutFilePath()` and keeps current slug validation and behavior intact.

No route-layer behavior change is required; the backend path handling becomes robust even if upstream validation changes later.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
