### PR TITLE
feat(board): add touch drag support

### DIFF
--- a/src/components/board-kanban-keyboard.test.ts
+++ b/src/components/board-kanban-keyboard.test.ts
@@ -55,4 +55,27 @@ assert.match(
   "card rows expose data-card-id",
 );
 
+// Touch / pen drag keeps mouse HTML5 drag intact while giving touch users a
+// long-press path with a visible ghost and the same move callback.
+assert.match(
+  source,
+  /pointerType === "mouse"/,
+  "touch drag handler must leave mouse/native HTML5 drag alone",
+);
+assert.match(
+  source,
+  /setTimeout\([\s\S]*?350\)/,
+  "touch drag should wait for a long-press before activating",
+);
+assert.match(
+  source,
+  /board-kanban-touch-ghost/,
+  "touch drag should render a floating ghost while active",
+);
+assert.match(
+  source,
+  /onMoveStatus\(card\.id, target\)/,
+  "touch drop should reuse the board status move callback",
+);
+
 console.log("board-kanban-keyboard.test.ts OK");

--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -255,6 +255,88 @@ export function BoardKanban({ cards, familiars, sessions, groupBy, selectedCardI
     [],
   );
 
+  // ── Touch / pen finger-drag (Pointer Events) ───────────────────────────────
+  // HTML5 drag is mouse-only, so touch/pen get a long-press → drag → drop path.
+  // A 350ms long-press disambiguates a drag from a list scroll; we don't capture
+  // the pointer or preventDefault until it fires, so normal scrolling is intact.
+  const [touchDragId, setTouchDragId] = useState<string | null>(null);
+  const [ghost, setGhost] = useState<{ x: number; y: number; title: string } | null>(null);
+  const dropTargetRef = useRef<CardStatus | null>(null);
+  const setDrop = useCallback((s: CardStatus | null) => { dropTargetRef.current = s; setDropTarget(s); }, []);
+
+  const handleCardPointerDown = useCallback((e: React.PointerEvent, card: Card) => {
+    if (e.pointerType === "mouse") return;                       // mouse keeps native HTML5 DnD
+    if ((e.target as HTMLElement).closest("button")) return;     // never on the card's action buttons
+    const pointerId = e.pointerId;
+    const node = e.currentTarget as HTMLElement;
+    const startX = e.clientX;
+    const startY = e.clientY;
+    let active = false;
+    let raf = 0;
+
+    const cleanup = () => {
+      clearTimeout(longPress);
+      if (raf) cancelAnimationFrame(raf);
+      try { node.releasePointerCapture(pointerId); } catch { /* harmless */ }
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+    };
+
+    const onMove = (ev: PointerEvent) => {
+      if (!active) {
+        // Movement before the long-press fires means the user is scrolling/tapping.
+        if (Math.hypot(ev.clientX - startX, ev.clientY - startY) > 8) cleanup();
+        return;
+      }
+      ev.preventDefault();
+      const x = ev.clientX, y = ev.clientY;
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        setGhost((g) => (g ? { ...g, x, y } : g));
+        const el = document.elementFromPoint(x, y) as HTMLElement | null;
+        const col = (el?.closest("[data-kanban-column]") as HTMLElement | null)?.dataset?.kanbanColumn as CardStatus | undefined;
+        setDrop(col ?? null);
+        const rail = node.closest(".board-kanban-rail-wrap, .board-swimlane-rail") as HTMLElement | null;
+        if (rail) {
+          const r = rail.getBoundingClientRect();
+          if (x > r.right - 48) rail.scrollLeft += 14;
+          else if (x < r.left + 48) rail.scrollLeft -= 14;
+        }
+      });
+    };
+
+    const onUp = () => {
+      const wasActive = active;
+      const target = dropTargetRef.current;
+      cleanup();
+      if (!wasActive) return;
+      setTouchDragId(null);
+      setGhost(null);
+      if (target && card.status !== target) {
+        const col = COLUMNS.find((c) => c.id === target);
+        onMoveStatus(card.id, target);
+        announce(`Moved '${card.title}' to ${col?.label ?? target}.`);
+      } else {
+        announce("Drop cancelled.");
+      }
+      setDrop(null);
+    };
+
+    const longPress = window.setTimeout(() => {
+      active = true;
+      try { node.setPointerCapture(pointerId); } catch { /* harmless */ }
+      setTouchDragId(card.id);
+      setGhost({ x: startX, y: startY, title: card.title });
+      announce(`Picked up '${card.title}'. Drag over a column and release to drop.`);
+    }, 350);
+
+    window.addEventListener("pointermove", onMove, { passive: false });
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onUp);
+  }, [announce, onMoveStatus, setDrop]);
+
   const toggleGroup = (key: string) =>
     setCollapsedGroups((prev) => { const n = new Set(prev); if (n.has(key)) n.delete(key); else n.add(key); return n; });
 
@@ -342,11 +424,13 @@ export function BoardKanban({ cards, familiars, sessions, groupBy, selectedCardI
                           )}
                           {rows.map((card) => (
                             <KanbanCard key={card.id} card={card} familiars={familiars} sessions={sessions}
-                              isDragging={draggingId === card.id} isSelected={selectedCardId === card.id}
-                              isGrabbed={grabbedCardId === card.id}
+                              isDragging={draggingId === card.id || touchDragId === card.id}
+                              isSelected={selectedCardId === card.id}
+                              isGrabbed={grabbedCardId === card.id || touchDragId === card.id}
                               onSelect={() => onSelect(card.id)}
                               onDragStart={(e) => handleDragStart(e, card.id)}
                               onDragEnd={handleDragEnd}
+                              onPointerDownTouch={(e) => handleCardPointerDown(e, card)}
                               onJumpToSession={onJumpToSession}
                               onOpenTaskChat={onOpenTaskChat}
                               chatLinking={chatLinkingId === card.id} />
@@ -361,14 +445,24 @@ export function BoardKanban({ cards, familiars, sessions, groupBy, selectedCardI
           </div>
         );
       })}
+      {ghost && (
+        <div
+          className="board-kanban-touch-ghost"
+          style={{ left: ghost.x, top: ghost.y }}
+          aria-hidden
+        >
+          {ghost.title}
+        </div>
+      )}
     </div>
   );
 }
 
-function KanbanCard({ card, familiars, sessions, isDragging, isSelected, isGrabbed, onSelect, onDragStart, onDragEnd, onJumpToSession, onOpenTaskChat, chatLinking = false }: {
+function KanbanCard({ card, familiars, sessions, isDragging, isSelected, isGrabbed, onSelect, onDragStart, onDragEnd, onPointerDownTouch, onJumpToSession, onOpenTaskChat, chatLinking = false }: {
   card: Card; familiars: Familiar[]; sessions: SessionRow[];
   isDragging: boolean; isSelected: boolean; isGrabbed: boolean;
   onSelect: () => void; onDragStart: (e: React.DragEvent) => void; onDragEnd: () => void;
+  onPointerDownTouch?: (e: React.PointerEvent) => void;
   onJumpToSession?: (sessionId: string, familiarId: string | null) => void;
   onOpenTaskChat?: (id: string) => Promise<void>;
   chatLinking?: boolean;
@@ -392,6 +486,7 @@ function KanbanCard({ card, familiars, sessions, isDragging, isSelected, isGrabb
       aria-keyshortcuts="Enter Space"
       onDragStart={(e) => { draggedRef.current = true; onDragStart(e); }}
       onDragEnd={() => { setTimeout(() => { draggedRef.current = false; }, 0); onDragEnd(); }}
+      onPointerDown={onPointerDownTouch}
       onClick={() => { if (draggedRef.current) return; onSelect(); }}
       onKeyDown={(e) => { if (e.key !== "Enter") return; e.preventDefault(); onSelect(); }}
       tabIndex={0}

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -171,6 +171,26 @@
 .board-kanban-card--selected { background:color-mix(in oklch,var(--accent-presence) 13%,var(--bg-base)); border-color:color-mix(in oklch,var(--accent-presence) 55%,var(--border-strong)); box-shadow:inset 0 0 0 1px color-mix(in oklch,var(--accent-presence) 35%,transparent); }
 .board-kanban-card--dragging { opacity:.35; cursor:grabbing; }
 .board-kanban-card--grabbed { border-color:color-mix(in oklch,var(--accent-presence) 72%,var(--border-strong)); box-shadow:0 0 0 2px color-mix(in oklch,var(--accent-presence) 28%,transparent),inset 0 0 0 1px color-mix(in oklch,var(--accent-presence) 44%,transparent); }
+/* Floating clone that follows the finger during a touch/pen drag. */
+.board-kanban-touch-ghost {
+  position: fixed;
+  z-index: 1000;
+  transform: translate(-50%, -120%);
+  max-width: 220px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 55%, var(--border-strong));
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  box-shadow: 0 8px 24px oklch(0 0 0 / 38%);
+  pointer-events: none;
+}
 
 .board-kanban-card::before { content:""; position:absolute; left:0; top:8px; bottom:8px; width:3px; border-radius:0 2px 2px 0; }
 .board-kanban-card--priority-urgent::before { background:var(--color-danger); box-shadow:0 0 5px color-mix(in oklch,var(--color-danger) 50%,transparent); }

--- a/tests/board-touch.spec.ts
+++ b/tests/board-touch.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect, type Page } from "@playwright/test";
+test.use({ hasTouch: true, viewport: { width: 1280, height: 900 } });
+const mk = (id: string, title: string, status: string) => ({ id, title, notes: "", status, priority: "medium", familiarId: null, sessionId: null, cwd: null, projectId: null, links: [], github: [], labels: [], createdAt: "2026-06-13T12:00:00Z", updatedAt: "2026-06-13T12:00:00Z", lifecycle: "queued", lifecycleAt: "2026-06-13T12:00:00Z", retryCount: 0, maxRetries: 3, steps: [] });
+test("touch long-press drag moves a card between columns", async ({ page }) => {
+  const patches: any[] = [];
+  await page.route("**/api/familiars**", (r) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, familiars: [] }) }));
+  await page.route("**/api/sessions/list**", (r) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, sessions: [] }) }));
+  await page.route("**/api/escalations**", (r) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, count: 0 }) }));
+  await page.route("**/api/board/*", async (r) => { patches.push(JSON.parse(r.request().postData() || "{}")); r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, card: mk("c1","Drag me","inbox") }) }); });
+  await page.route("**/api/board", (r) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, cards: [mk("c1", "Drag me", "backlog")] }) }));
+  await page.goto("/"); await page.waitForSelector(".shell-frame", { timeout: 60000 });
+  await page.locator(".sidebar-nav-scroll").getByRole("button", { name: /^Board\b/ }).click();
+  await page.waitForSelector(".board-kanban-card", { timeout: 60000 });
+
+  const card = page.locator(".board-kanban-card").first();
+  const inbox = page.locator('[data-kanban-column="inbox"]');
+  const cb = await card.boundingBox(); const tb = await inbox.boundingBox();
+  const from = { x: cb!.x + cb!.width / 2, y: cb!.y + 20 };
+  const to = { x: tb!.x + tb!.width / 2, y: tb!.y + 120 };
+
+  await page.evaluate(({ from }) => {
+    const el = document.elementFromPoint(from.x, from.y)!.closest("[data-card-id]")!;
+    el.dispatchEvent(new PointerEvent("pointerdown", { pointerType: "touch", pointerId: 1, isPrimary: true, clientX: from.x, clientY: from.y, bubbles: true, cancelable: true }));
+  }, { from });
+  await page.waitForTimeout(420); // let the 350ms long-press fire
+  await expect(page.locator(".board-kanban-touch-ghost")).toBeVisible();
+  for (const pt of [ { x: (from.x+to.x)/2, y: (from.y+to.y)/2 }, to, to ]) {
+    await page.evaluate((pt) => window.dispatchEvent(new PointerEvent("pointermove", { pointerType: "touch", pointerId: 1, isPrimary: true, clientX: pt.x, clientY: pt.y, bubbles: true, cancelable: true })), pt);
+    await page.waitForTimeout(40);
+  }
+  await page.screenshot({ path: "/tmp/board-touch-drag.png" });
+  await page.evaluate((pt) => window.dispatchEvent(new PointerEvent("pointerup", { pointerType: "touch", pointerId: 1, isPrimary: true, clientX: pt.x, clientY: pt.y, bubbles: true, cancelable: true })), to);
+  await page.waitForTimeout(100);
+  console.log("PATCHES:", JSON.stringify(patches));
+  expect(patches.some((p) => p.status === "inbox"), "card should be moved to inbox via touch drag").toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- add long-press touch/pen drag handling for board cards while preserving mouse HTML5 drag
- render a floating touch-drag ghost and auto-scroll the board rail near edges
- add static and Playwright coverage for touch drag moving a card

## Test Plan
- node --experimental-strip-types src/components/board-kanban-keyboard.test.ts
- node --experimental-strip-types src/components/board-ux-polish.test.ts
- pnpm typecheck
- pnpm exec playwright test tests/board-touch.spec.ts --project=desktop