### PR TITLE
style(chat-list): normalize tab-indented lines to spaces

### DIFF
--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -473,7 +473,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               type="button"
               onClick={() => onNewChat(undefined, fallbackFamiliarId)}
               disabled={!fallbackFamiliarId}
-	              className="chat-list-new-button mt-0.5 flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-[var(--accent-presence)] px-3 text-[12px] font-semibold text-white shadow-[0_1px_8px_color-mix(in_oklch,var(--accent-presence)_35%,transparent)] transition-all hover:opacity-90 hover:shadow-[0_2px_12px_color-mix(in_oklch,var(--accent-presence)_50%,transparent)] active:scale-95"
+              className="chat-list-new-button mt-0.5 flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-[var(--accent-presence)] px-3 text-[12px] font-semibold text-white shadow-[0_1px_8px_color-mix(in_oklch,var(--accent-presence)_35%,transparent)] transition-all hover:opacity-90 hover:shadow-[0_2px_12px_color-mix(in_oklch,var(--accent-presence)_50%,transparent)] active:scale-95"
             >
               <Icon name="ph:plus-bold" width={11} />
               Chat
@@ -660,7 +660,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                       {repoName(projectRoot)}
                     </span>
                     <button
-	                      className="chat-list-group-new touch-always-visible absolute right-2 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center w-5 h-5 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
+                      className="chat-list-group-new touch-always-visible absolute right-2 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center w-5 h-5 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
                       onClick={(e) => {
                         e.stopPropagation();
                         onNewChat(projectRoot, defaultFamiliarId ?? fallbackFamiliarId);
@@ -691,8 +691,8 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                           onKeyDown={(e) => {
                             if (e.key === "Enter") { setActiveId(s.id); onOpen(s.id, s.familiarId); }
                           }}
-	                          className={[
-	                            "chat-list-row focus-ring-inset group relative flex cursor-pointer gap-3 px-4 py-3.5 transition-colors",
+                          className={[
+                            "chat-list-row focus-ring-inset group relative flex cursor-pointer gap-3 px-4 py-3.5 transition-colors",
                             isActive
                               ? "bg-[var(--bg-raised)]"
                               : "hover:bg-[var(--bg-raised)]/50",
@@ -704,7 +704,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                           )}
 
                           {/* Status dot (top-aligned) */}
-	                          <span className="chat-list-status-dot mt-[5px] shrink-0">
+                          <span className="chat-list-status-dot mt-[5px] shrink-0">
                             <span
                               className={`block h-2 w-2 rounded-full ${st.dot}`}
                               title={st.label}
@@ -712,17 +712,17 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                           </span>
 
                           {/* Content */}
-	                          <span className="chat-list-row-content flex min-w-0 flex-1 flex-col gap-0.5">
+                          <span className="chat-list-row-content flex min-w-0 flex-1 flex-col gap-0.5">
                             {/* Row 1: familiar/project name + timestamp */}
-	                            <span className="chat-list-row-meta flex items-baseline justify-between gap-2">
-	                              <span className="chat-list-row-tags flex items-center gap-1.5 min-w-0">
+                            <span className="chat-list-row-meta flex items-baseline justify-between gap-2">
+                              <span className="chat-list-row-tags flex items-center gap-1.5 min-w-0">
                                 <span className="truncate text-[12px] font-medium text-[var(--text-secondary)]">
                                   {project || rowFamiliarName}
                                 </span>
                                 {s.origin ? <OriginChip origin={s.origin} /> : null}
                                 <SessionInitiatorChip initiator={s.initiator} />
                               </span>
-	                              <span className="chat-list-row-time flex shrink-0 items-baseline gap-1 text-[11px] text-[var(--text-muted)]">
+                              <span className="chat-list-row-time flex shrink-0 items-baseline gap-1 text-[11px] text-[var(--text-muted)]">
                                 <span>{chatDate(s.updated_at)}</span>
                                 <span aria-hidden>·</span>
                                 <span>{age(s.updated_at)}</span>
@@ -732,7 +732,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                             {/* Row 2: session title (bold subject line)
                            Running sessions get full white; others are slightly muted
                            — mirrors the unread/read convention in email clients. */}
-	                            <span className="chat-list-row-title flex min-w-0 items-center gap-1.5">
+                            <span className="chat-list-row-title flex min-w-0 items-center gap-1.5">
                               {pinned && (
                                 <Icon
                                   name="ph:bookmark-simple-fill"
@@ -771,7 +771,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                           {confirmDeleteId === s.id ? (
                             /* Inline delete confirmation — replaces row actions until resolved */
                             <span
-	                              className="chat-list-row-confirm flex shrink-0 items-center gap-1.5 self-center"
+                              className="chat-list-row-confirm flex shrink-0 items-center gap-1.5 self-center"
                               onClick={(e) => e.stopPropagation()}
                               onKeyDown={(e) => e.stopPropagation()}
                               role="group"
@@ -801,7 +801,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                                Keyboard Enter on a button must not bubble into the
                                row's open handler. */
                             <span
-	                              className="chat-list-row-actions flex shrink-0 items-center gap-1 self-center"
+                              className="chat-list-row-actions flex shrink-0 items-center gap-1 self-center"
                               onKeyDown={(e) => e.stopPropagation()}
                             >
                               <button


### PR DESCRIPTION
\`d6c6b5b\` ("Improve mobile touch targets and iOS script") landed on \`main\` with a stray leading **tab** on 12 \`className\` lines in \`src/components/chat-list.tsx\`, inconsistent with the file's space indentation.

This normalizes those 12 lines back to spaces. Whitespace-only — no behavior or markup change. The repo has no prettier/lint gate, so this was cosmetic-only, but it's worth not leaving tab/space mixing on a touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)