### PR TITLE
Fix workflow layout path storage race

### DIFF
--- a/src/lib/workflow-source.ts
+++ b/src/lib/workflow-source.ts
@@ -567,14 +567,18 @@ async function storageForWorkflowId(id: string): Promise<WorkflowStorageScope> {
 }
 
 /** Absolute path for a layout sidecar, constrained to its workflow storage dir. */
-async function layoutFilePath(id: string): Promise<string | null> {
-  const file = layoutFileName(id);
-  if (!file) return null;
-  const root = path.resolve(workflowDirForStorage(await storageForWorkflowId(id)));
+function resolveLayoutFilePath(rootDir: string, file: string): string | null {
+  const root = path.resolve(rootDir);
   const target = path.resolve(root, file);
   const rel = path.relative(root, target);
   if (rel.startsWith("..") || path.isAbsolute(rel)) return null;
   return target;
+}
+
+async function layoutFilePath(id: string): Promise<string | null> {
+  const file = layoutFileName(id);
+  if (!file) return null;
+  return resolveLayoutFilePath(workflowDirForStorage(await storageForWorkflowId(id)), file);
 }
 
 /** Saved node positions for a workflow, or null when none exist. */
@@ -610,10 +614,8 @@ export async function saveWorkflowLayout(
     await withWorkflowWriteLock(async () => {
       const storage = await storageForWorkflowId(id);
       const dir = await ensureWorkflowDir(storage);
-      const root = path.resolve(dir);
-      const filePath = path.resolve(root, file);
-      const rel = path.relative(root, filePath);
-      if (rel.startsWith("..") || path.isAbsolute(rel)) {
+      const filePath = resolveLayoutFilePath(dir, file);
+      if (!filePath) {
         throw new Error("resolved layout path escapes workflow storage directory");
       }
       await writeFile(


### PR DESCRIPTION
Supersedes #566, which GitHub/Copilot closed after the autofix branch update instead of allowing it to reopen.\n\nThis keeps the CodeQL path hardening for layout sidecars and addresses the Copilot review thread from #566 by deriving the layout file path inside withWorkflowWriteLock from the storage directory that was just resolved and ensured.\n\nVerification:\n- pnpm test:app\n- node --experimental-strip-types src/lib/workflow-source.test.ts\n- pnpm typecheck\n- git diff --check origin/main...HEAD