### PR TITLE
chore(release): v0.0.77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.77] - 2026-06-13
+
+A large reading-experience release: a full suite of long-form typography controls, board touch dragging and reliability fixes, real calendar actions, memory management, and continued CodeQL security hardening.
+
+### Added
+- **Reading typography suite** — new long-form reading controls: drop cap (library reader), hyphenation, font weight, text alignment, letter spacing, line spacing, maximum reading width, and a reframed Text size control.
+- **JetBrains Mono** is now the default monospace/code font.
+- **Board touch dragging** — cards can be dragged on touch devices, with a long-press ghost and reliable drop handling.
+- **Calendar item actions** — real Done/Dismiss/Snooze actions, an overlap-aware day grid, and an accessible, keyboard-navigable dialog.
+- **Memory management** — delete with undo, stale-memory suggestions, and grouping/sorting/filtering of memories.
+- **Library navigation** — Back and Refresh controls in the Library nav.
+- **Roles** — role workflows resolve against Workflow Studio manifests, with scaffold/open support.
+- **Projects** — richer project list with readable file previews.
+
+### Changed
+- **Chat surface polish** — honest header metadata, task chips navigate to the board, the transcript column centers on wide screens, the right session panel mirrors the left rail width, and message hover tint was dropped (copy moved to its own row).
+- **Chat list** — unified row pill chrome and uniform action buttons.
+- **Workflows** — enlarged manifest preview, left-aligned Boards/Projects attachment toggles, and saved builder node positions.
+- **iOS / mobile** — larger touch targets and Info.plist newline syncing.
+
+### Fixed
+- **Board reliability** — honest loading-vs-empty state, surfaced (and dismissible) move failures, a card crash guard, accessibility fixes, and a portaled task drawer so fixed positioning escapes the mode-fade transform.
+- **Library** — bookmark titles no longer collapse to "DeepWi…".
+- **Chat** — folder icon follows expand state rather than selection, and the native select chevron was removed from the project chip.
+- **Changes panel** — reverts against HEAD and handles staged files correctly.
+- **Security hardening** — additional CodeQL-driven path-injection fixes across workflow source file handling (alerts 42–45).
+
 ## [0.0.76] - 2026-06-12
 
 Cave gets a security-hardening sweep, safer dependency intake, production workflow starters, and more durable chat tool history.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A familiar is not just a chat window. It has a name, role, runtime, memory, tool
 
 ## Status
 
-- Current app version: `0.0.76`
+- Current app version: `0.0.77`
 - Native shell: Tauri 2
 - Frontend: Next.js 16, React 19, Tailwind v4
 - Runtime dependency: a healthy local `coven` CLI/daemon plus at least one runtime source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.76",
+  "version": "0.0.77",
   "private": true,
   "scripts": {
     "dev": "node --experimental-strip-types server.ts",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.76"
+version = "0.0.77"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.76"
+version = "0.0.77"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.76",
+  "version": "0.0.77",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Release bump for **v0.0.77** — captures the 63 commits merged to `main` since v0.0.76.

Bumps version metadata (`package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`, `README.md`) to `0.0.77` and adds the CHANGELOG entry.

### Highlights
- **Reading typography suite** — drop cap, hyphenation, font weight, text alignment, letter/line spacing, max reading width, reframed Text size.
- **Board** — touch dragging + loading/failure/crash/a11y reliability fixes.
- **Calendar** — real item actions, overlap-aware grid, accessible dialog.
- **Memory management**, **Library nav**, **role↔Studio manifests**, **richer projects**.
- **Security** — continued CodeQL path-injection hardening (alerts 42–45).

After squash-merge, `v0.0.77` will be tagged (signed) and pushed to trigger `release.yml` (notarized macOS DMG + Linux AppImage + Windows MSI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)