### PR TITLE
chore(release): v0.0.78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.78] - 2026-06-13
+
+This patch release carries the latest tailnet/mobile dev auth hardening after v0.0.77, including Tailscale Serve host support and native iOS webview sidecar authentication.
+
+### Added
+- **Tailscale Serve host support** — mobile/dev access now recognizes Tailscale Serve hostnames alongside localhost-style development hosts.
+- **Tauri desktop check coverage** — proxy behavior coverage now verifies the desktop/webview host path stays wired while remote tailnet access remains gated.
+
+### Fixed
+- **Native iOS dev webview auth** — the Tailscale native launch path now writes and passes the sidecar mobile token so the iOS Tauri shell can authenticate against the local dev server.
+- **Host-gate test drift** — middleware ordering assertions now match the shared `requestHost` path used by the proxy host gate.
+
 ## [0.0.77] - 2026-06-13
 
 A large reading-experience release: a full suite of long-form typography controls, board touch dragging and reliability fixes, real calendar actions, memory management, and continued CodeQL security hardening.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A familiar is not just a chat window. It has a name, role, runtime, memory, tool
 
 ## Status
 
-- Current app version: `0.0.77`
+- Current app version: `0.0.78`
 - Native shell: Tauri 2
 - Frontend: Next.js 16, React 19, Tailwind v4
 - Runtime dependency: a healthy local `coven` CLI/daemon plus at least one runtime source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "private": true,
   "scripts": {
     "dev": "node --experimental-strip-types server.ts",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.77"
+version = "0.0.78"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.77"
+version = "0.0.78"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary\n- bump CovenCave metadata to 0.0.78\n- add release notes for Tailscale Serve host support and native iOS webview sidecar auth\n- update README current app version\n\n## Verification\n- pnpm install --frozen-lockfile\n- git diff --check\n- bash scripts/release-notes.sh v0.0.78 v0.0.77\n- pnpm test:mobile\n- pnpm typecheck\n- pnpm test:app\n- pnpm test:api\n- pnpm build