### PR TITLE
chore(release): v0.0.79

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.79] - 2026-06-13
+
+This patch release follows v0.0.78 with mobile shell hardening: native browser IPC now stays desktop-only, and the mobile chat command center gets tighter composer geometry.
+
+### Fixed
+- **Mobile browser fallback** — BrowserPane and embedded Library link previews now call native `browser_*` IPC only on Tauri desktop, so mobile/iOS shells fall back cleanly instead of touching desktop-only commands.
+- **Mobile chat composer geometry** — the mobile composer controls now expose a dedicated overlay hook and tighter spacing so the command center stays usable on phone viewports.
+- **Mobile tab spacing** — shell detail panes no longer double-reserve bottom-tab height after the tabs moved into normal shell flow.
+
+### Tests
+- Added mobile coverage for the native-browser fallback path and the chat command-center composer overlay.
+
 ## [0.0.78] - 2026-06-13
 
 This patch release carries the latest tailnet/mobile dev auth hardening after v0.0.77, including Tailscale Serve host support and native iOS webview sidecar authentication.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A familiar is not just a chat window. It has a name, role, runtime, memory, tool
 
 ## Status
 
-- Current app version: `0.0.78`
+- Current app version: `0.0.79`
 - Native shell: Tauri 2
 - Frontend: Next.js 16, React 19, Tailwind v4
 - Runtime dependency: a healthy local `coven` CLI/daemon plus at least one runtime source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.78",
+  "version": "0.0.79",
   "private": true,
   "scripts": {
     "dev": "node --experimental-strip-types server.ts",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.78"
+version = "0.0.79"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.78",
+  "version": "0.0.79",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- bump CovenCave metadata to 0.0.79
- add release notes for mobile browser fallback hardening and mobile chat command-center geometry

## Verification
- pnpm install --frozen-lockfile
- git diff --check
- bash scripts/release-notes.sh v0.0.79 v0.0.78
- pnpm test:mobile
- pnpm typecheck
- pnpm test:app
- pnpm test:api
- pnpm build