### PR TITLE
fix(mobile): scope composer dock styles to chat

### DIFF
--- a/src/components/chat-view-mobile-command-center.test.ts
+++ b/src/components/chat-view-mobile-command-center.test.ts
@@ -49,8 +49,8 @@ assert.match(
 
 assert.match(
   styles,
-  /@media \(max-width: 767px\) \{[\s\S]*\.cave-composer-dock\s*\{[\s\S]*bottom\s*:\s*0/,
-  "Mobile composer should dock to the chat surface; the shell already reserves bottom-tab space",
+  /@media \(max-width: 767px\) \{[\s\S]*\.cave-chat-linear \.cave-composer-dock\s*\{[\s\S]*bottom\s*:\s*0/,
+  "Mobile composer should dock only inside the chat surface; the shell already reserves bottom-tab space",
 );
 
 assert.match(

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2041,7 +2041,7 @@ details[open] > .cave-tool-summary::before {
     max-width: 100%;
   }
 
-  .cave-composer-dock {
+  .cave-chat-linear .cave-composer-dock {
     padding: 8px 12px 12px;
   }
 }


### PR DESCRIPTION
## Summary
- Scope mobile composer dock padding to the chat surface instead of all composer docks
- Tighten the mobile command-center assertion so the chat selector is required

## Verification
- pnpm test:mobile
- pnpm typecheck
- git diff --check