### PR TITLE
chore(tauri): update app metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "coven-cave",
   "version": "0.0.79",
   "private": true,
+  "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
+  "author": "OpenCoven contributors",
+  "license": "MIT OR AGPL-3.0-only",
+  "homepage": "https://github.com/OpenCoven/coven-cave",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/OpenCoven/coven-cave.git"
+  },
   "scripts": {
     "dev": "node --experimental-strip-types server.ts",
     "dev:app": "bash scripts/dev-app.sh",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "app"
 version = "0.0.79"
-description = "A Tauri App"
-authors = ["you"]
-license = ""
-repository = ""
+description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
+authors = ["OpenCoven contributors"]
+license = "MIT OR AGPL-3.0-only"
+repository = "https://github.com/OpenCoven/coven-cave"
+homepage = "https://github.com/OpenCoven/coven-cave"
 edition = "2021"
 rust-version = "1.77.2"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,6 +23,14 @@
       "app",
       "msi"
     ],
+    "publisher": "OpenCoven",
+    "homepage": "https://github.com/OpenCoven/coven-cave",
+    "copyright": "Copyright (c) 2026 OpenCoven contributors",
+    "license": "MIT OR AGPL-3.0-only",
+    "licenseFile": "../LICENSE",
+    "category": "DeveloperTool",
+    "shortDescription": "Desktop control room for OpenCoven familiars.",
+    "longDescription": "CovenCave is the OpenCoven desktop control room for managing familiars, local agent sessions, workflows, memory, tools, and release-ready automation from one native Tauri app.",
     "resources": [
       "resources/server/**/*",
       "resources/node/**/*"

--- a/src/lib/app-version.test.ts
+++ b/src/lib/app-version.test.ts
@@ -8,9 +8,32 @@ const cargoToml = await readFile(new URL("../../src-tauri/Cargo.toml", import.me
 const appVersionSource = await readFile(new URL("./app-version.ts", import.meta.url), "utf8");
 
 const cargoVersion = cargoToml.match(/^version\s*=\s*"([^"]+)"/m)?.[1];
+const cargoDescription = cargoToml.match(/^description\s*=\s*"([^"]+)"/m)?.[1];
+const cargoAuthors = cargoToml.match(/^authors\s*=\s*\[([^\]]+)\]/m)?.[1] ?? "";
+const cargoLicense = cargoToml.match(/^license\s*=\s*"([^"]+)"/m)?.[1];
+const cargoRepository = cargoToml.match(/^repository\s*=\s*"([^"]+)"/m)?.[1];
 
 assert.equal(tauriConfig.version, packageJson.version, "Tauri bundle version must match package.json");
 assert.equal(cargoVersion, packageJson.version, "Tauri Cargo package version must match package.json");
+assert.equal(
+  cargoDescription,
+  "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
+  "Cargo package description must describe CovenCave, not the Tauri template",
+);
+assert.match(cargoAuthors, /OpenCoven contributors/, "Cargo package authors must name OpenCoven contributors");
+assert.equal(cargoLicense, "MIT OR AGPL-3.0-only", "Cargo package license must match the repository dual-license offer");
+assert.equal(cargoRepository, "https://github.com/OpenCoven/coven-cave", "Cargo package repository must point at Coven Cave");
+assert.equal(packageJson.description, cargoDescription, "package.json and Cargo descriptions must match");
+assert.equal(packageJson.license, cargoLicense, "package.json and Cargo licenses must match");
+assert.equal(tauriConfig.bundle.publisher, "OpenCoven", "Tauri bundle publisher must be OpenCoven");
+assert.equal(tauriConfig.bundle.license, cargoLicense, "Tauri bundle license must match Cargo license");
+assert.equal(tauriConfig.bundle.licenseFile, "../LICENSE", "Tauri bundle must include the repository license notice");
+assert.equal(tauriConfig.bundle.category, "DeveloperTool", "Tauri bundle category must identify CovenCave as a developer tool");
+assert.match(
+  tauriConfig.bundle.longDescription,
+  /OpenCoven desktop control room/,
+  "Tauri bundle long description must explain the app's purpose",
+);
 assert.match(
   appVersionSource,
   /from "\.\.\/\.\.\/package\.json"/,


### PR DESCRIPTION
## Summary
- replace default Tauri/Cargo package metadata with OpenCoven app description, authors, dual license, homepage, and repository
- add installer-facing Tauri bundle metadata: publisher, homepage, copyright, license file, category, and short/long descriptions
- extend the version metadata regression test to catch placeholder metadata regressions

## Verification
- pnpm install --frozen-lockfile
- node --experimental-strip-types src/lib/app-version.test.ts
- cargo metadata --manifest-path src-tauri/Cargo.toml --format-version 1 --no-deps
- pnpm exec tauri info
- pnpm typecheck
- pnpm test:app
- git diff --check