### PR TITLE
fix(typography): apply reading leading + width controls to library preview

### DIFF
--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -1553,7 +1553,11 @@ tr:hover .library-row-delete,
  * ---------------------------------------------------------------- */
 .library-preview-md.cave-md {
   font-size: 15px;
-  line-height: 1.8;
+  /* Honor the reading line-spacing control (Settings → Appearance →
+     Typography); fall back to the library default when the var is unset.
+     Without the var this 2-class rule shadows .cave-md's var-based
+     line-height, so the leading control had no effect in the preview. */
+  line-height: var(--cave-reading-leading, 1.8);
 }
 
 /* More vertical breathing between block-level elements */
@@ -1699,9 +1703,12 @@ html[data-reading-dropcap="on"] .library-preview-md.cave-md p:first-of-type::fir
   color: var(--text-primary);
 }
 
-/* Max readable width with comfortable padding */
+/* Max readable width with comfortable padding. Honors the reading
+   max-width control (Settings → Appearance → Typography); falls back to
+   the library default (740px) when the var is unset, so the width control
+   takes effect in the preview instead of being shadowed by this rule. */
 .library-preview-md {
-  max-width: 740px;
+  max-width: var(--cave-reading-width, 740px);
   padding-bottom: 48px;
 }
 


### PR DESCRIPTION
## Problem
Of the 7 reading-typography controls shipped in v0.0.77, two had **no effect in the library preview pane**:

- `library.css` `.library-preview-md.cave-md { line-height: 1.8 }` (2-class specificity) shadowed `.cave-md`'s `line-height: var(--cave-reading-leading)`.
- `library.css` `.library-preview-md { max-width: 740px }` shadowed `.cave-md`'s `max-width: var(--cave-reading-width)`.

The other controls (tracking, weight, align, hyphens) flowed through fine, and drop cap is library-only by design — so the partial gap was an inconsistency, surfaced by a comprehensive harness over the real CSS.

## Fix
Route both library rules through the reading vars with the current values as fallbacks:
- `line-height: var(--cave-reading-leading, 1.8)`
- `max-width: var(--cave-reading-width, 740px)`

Default rendering is unchanged; the leading and width controls now take effect in the preview. The full library reader (`.library-reader-body`) keeps its own opinionated serif typography + A−/A+ size control and is intentionally left independent.

## Verification
Playwright harness over the real `cave-chat.css` + `library.css`, all 7 controls × both surfaces:
- **Before:** library leading stuck at 27px, width stuck at 740px.
- **After:** library leading 21.75→25.5→30px, width none→680→560px; every other control still works; drop cap still library-only.
- `reading-*` and `library-*` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)