### PR TITLE
fix(ios): declare exempt encryption usage

### DIFF
--- a/scripts/mobile-tailscale-native.test.mjs
+++ b/scripts/mobile-tailscale-native.test.mjs
@@ -11,6 +11,7 @@ assert.match(infoPlist, /<key>NSBonjourServices<\/key>/);
 assert.match(infoPlist, /<string>_tailscale\._tcp<\/string>/);
 assert.match(infoPlist, /<string>_tailscale\._udp<\/string>/);
 assert.match(infoPlist, /<key>NSAllowsArbitraryLoads<\/key>\s*<false\/>/);
+assert.match(infoPlist, /<key>ITSAppUsesNonExemptEncryption<\/key>\s*<false\/>/);
 
 const sourceInfoPlist = read("src-tauri/Info.ios.plist");
 assert.equal(sourceInfoPlist.trimEnd(), infoPlist.trimEnd());

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -18,6 +18,8 @@
 	<string>0.0.79</string>
 	<key>CFBundleVersion</key>
 	<string>0.0.79</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -18,6 +18,8 @@
 	<string>0.0.79</string>
 	<key>CFBundleVersion</key>
 	<string>0.0.79</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
**Opened via branch triage** — this surfaces an existing, signed, complete-looking local commit (`5d95107`) that hadn't been pushed. Left as **draft**: promote to ready (or close) when the owning work is confirmed done.

Declares `ITSAppUsesNonExemptEncryption` in the iOS Info.plist (both `src-tauri/Info.ios.plist` and the generated `src-tauri/gen/apple/app_iOS/Info.plist`) so TestFlight/App Store builds skip the export-compliance prompt, plus a matching assertion in `scripts/mobile-tailscale-native.test.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)