### PR TITLE
docs: fix stale "6 checks" comment in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ git worktree add -b <branch> .worktrees/<branch> origin/main
 # … commit (signed, per the global -S rule) …
 git push -u origin <branch>
 gh pr create --base main --head <branch> --title "…" --body "…"
-# wait for the 6 checks to go green, then:
+# wait for the 3 required checks to go green, then:
 gh pr merge <#> --squash --delete-branch
 ```
 


### PR DESCRIPTION
Trivial follow-up to #588. The workflow-example comment still said `wait for the 6 checks`; required checks are now 3 (`Frontend build`, `Rust check`, `CodeQL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)