### PR TITLE
feat: polish chat and reading lists

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4638,12 +4638,20 @@ button:active > .edge-rail-chip {
 
   .chat-list-row {
     display: grid;
-    grid-template-columns: 14px minmax(0, 1fr);
+    grid-template-columns: 24px 14px minmax(0, 1fr);
     grid-template-areas:
-      "dot content"
-      ". actions";
+      "handle dot content"
+      ". . actions";
     gap: 6px 10px;
     padding: 14px 12px;
+  }
+
+  .chat-list-drag-handle {
+    grid-area: handle;
+    width: var(--touch-target);
+    height: var(--touch-target);
+    margin: -10px 0 0 -10px;
+    opacity: 1;
   }
 
   .chat-list-status-dot {

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -109,6 +109,24 @@ assert.match(
   "Pin toggle should be a real button with a state-aware aria-label",
 );
 
+// Full ChatList drag reorder mirrors the thread rail: @dnd-kit handles the
+// gesture, the shared Cave-local order store persists the result, and stale ids
+// are pruned against live familiar-scoped sessions.
+assert.match(source, /from "@dnd-kit\/core"/, "ChatList should use @dnd-kit for drag reorder");
+assert.match(source, /const displayIds = useMemo\([\s\S]*displayGroups\.flatMap\(\(group\) => group\.sessions\.map\(\(session\) => session\.id\)\)/, "ChatList should derive one flat list of visible sortable ids");
+assert.match(source, /<DndContext[\s\S]*onDragEnd=\{\(event\) => handleDragEnd\(event, displayIds\)\}/, "The visible chat list should wire drag end with all displayed ids");
+assert.match(source, /<SortableContext items=\{displayIds\} strategy=\{verticalListSortingStrategy\}/, "All visible chat rows should share one SortableContext");
+assert.match(source, /useSortable\(\{ id \}\)/, "ChatList rows should be individually sortable by session id");
+assert.match(source, /setSessionOrder\(readSessionOrder\(\)\)/, "ChatList should hydrate the persisted manual order after mount");
+assert.match(source, /if \(effectiveSelection === "all"\) \{[\s\S]*scopedGroups\.flatMap\(\(group\) => group\.sessions\)/, "All chats should flatten groups so cross-project drag order can stick");
+assert.match(source, /partitionPinnedFirst\(rows, pinnedIds\)/, "Pinned rows should still float in the flat All chats view until manual drag order exists");
+assert.match(source, /applyManualOrder\(group\.sessions, sessionOrder\)/, "ChatList should apply the manual order inside visible project groups");
+assert.match(source, /mergeVisibleOrder\(prev\.length > 0 \? prev : fallbackOrderIds, nextVisible\)/, "ChatList should merge dragged visible rows back into the full saved order");
+assert.match(source, /const pruned = merged\.filter\(\(id\) => liveSessionIds\.has\(id\)\)/, "ChatList should prune stale session ids before persisting drag order");
+assert.match(source, /writeSessionOrder\(pruned\)/, "ChatList should persist drag order to the shared session-order store");
+assert.match(source, /activationConstraint: \{ distance: 5 \}/, "Pointer drag should require movement so normal clicks still open chats");
+assert.match(source, /aria-label=\{`Reorder chat \$\{rowName\}`\}/, "Drag handle should be accessible and scoped to the row");
+
 // Archive rides the existing sessions PATCH endpoint (Cave-local archived_at)
 // and archived rows stay hidden until the Show archived filter opts in.
 assert.match(

--- a/src/components/chat-list-mobile-command-center.test.ts
+++ b/src/components/chat-list-mobile-command-center.test.ts
@@ -61,8 +61,8 @@ assert.match(
 
 assert.match(
   styles,
-  /@media \(max-width: 767px\) \{[\s\S]*\.chat-list-row\s*\{[\s\S]*grid-template-areas\s*:[\s\S]*"dot content"[\s\S]*"\. actions"/,
-  "Mobile chat list rows should move actions below content instead of squeezing metadata",
+  /@media \(max-width: 767px\) \{[\s\S]*\.chat-list-row\s*\{[\s\S]*grid-template-areas\s*:[\s\S]*"handle dot content"[\s\S]*"\. \. actions"/,
+  "Mobile chat list rows should reserve a drag handle column and move actions below content",
 );
 
 assert.match(

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, useEffect, useRef } from "react";
+import { useMemo, useState, useEffect, useRef, type CSSProperties, type ReactNode } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { stripLeadingTrailingEmoji } from "@/lib/cave-chat-titles";
 import { Icon } from "@/lib/icon";
@@ -30,6 +30,30 @@ import {
   sortPinnedFirst,
   togglePinnedSession,
 } from "@/lib/chat-session-prefs";
+import {
+  applyManualOrder,
+  mergeVisibleOrder,
+  partitionPinnedFirst,
+  readSessionOrder,
+  writeSessionOrder,
+} from "@/lib/chat-session-order";
+import {
+  DndContext,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 
 type Props = {
   familiar: Familiar | null;
@@ -121,6 +145,36 @@ function HighlightedSnippet({ snippet, query }: { snippet: string; query: string
   );
 }
 
+type SortableHandleProps = {
+  attributes: ReturnType<typeof useSortable>["attributes"];
+  listeners: ReturnType<typeof useSortable>["listeners"];
+  isDragging: boolean;
+};
+
+function SortableChatListItem({
+  id,
+  children,
+}: {
+  id: string;
+  children: (handleProps: SortableHandleProps) => ReactNode;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+  const style: CSSProperties = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+  };
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      data-dragging={isDragging ? "true" : undefined}
+      className="chat-list-sortable-row"
+    >
+      {children({ attributes, listeners, isDragging })}
+    </li>
+  );
+}
+
 // ── Main component ────────────────────────────────────────────────────────────
 
 export function ChatList({ familiar, familiars = [], sessions, daemonRunning, onOpen, onNewChat, onSessionsChanged, sessionsLoaded = true, compact = false }: Props) {
@@ -135,6 +189,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   // Pins are Cave-local UI state (localStorage), same idiom as the project
   // sidebar persistence below — the daemon never learns about them.
   const [pinnedIds, setPinnedIds] = useState<string[]>([]);
+  const [sessionOrder, setSessionOrder] = useState<string[]>([]);
   // Archived rows are excluded server-side by /api/sessions/list; the toggle
   // opts into them with its own includeArchived fetch (the workspace's list
   // poll stays archive-free).
@@ -165,6 +220,10 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   const panelTitle = familiar?.display_name ?? "Familiars";
   const panelRole = familiar?.role ?? "All project conversations";
   const panelRuntime = familiar ? (familiar.harness ?? "codex") : "mixed";
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
 
   // Focus search on Cmd+F / Ctrl+F
   useEffect(() => {
@@ -191,6 +250,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     const storedSelection = readPersisted<unknown>(PROJECT_SIDEBAR_KEYS.selected, "all");
     setSelection(typeof storedSelection === "string" ? storedSelection : "all");
     setPinnedIds(readPinnedSessions());
+    setSessionOrder(readSessionOrder());
     setSidebarHydrated(true);
   }, []);
   useEffect(() => {
@@ -310,11 +370,35 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     () => applyProjectScope(grouped, effectiveSelection),
     [grouped, effectiveSelection],
   );
-  // Pinned rows float to the top of their project group; recency order is
-  // preserved inside both partitions.
-  const displayGroups = useMemo(
-    () => sortPinnedFirst(scopedGroups, pinnedIds),
-    [scopedGroups, pinnedIds],
+  const displayGroups = useMemo(() => {
+    if (effectiveSelection === "all") {
+      let rows = scopedGroups.flatMap((group) => group.sessions);
+      rows = sessionOrder.length === 0
+        ? partitionPinnedFirst(rows, pinnedIds)
+        : applyManualOrder(rows, sessionOrder);
+      const latest = rows[0] ?? null;
+      return [{
+        projectId: null,
+        projectRoot: null,
+        projectName: null,
+        sessions: rows,
+        defaultFamiliarId: latest?.familiarId ?? fallbackFamiliarId,
+        updatedAt: latest ? (latest.updated_at || latest.created_at) : null,
+      }];
+    }
+    if (sessionOrder.length === 0) return sortPinnedFirst(scopedGroups, pinnedIds);
+    let changed = false;
+    const next = scopedGroups.map((group) => {
+      const ordered = applyManualOrder(group.sessions, sessionOrder);
+      if (ordered === group.sessions) return group;
+      changed = true;
+      return { ...group, sessions: ordered };
+    });
+    return changed ? next : scopedGroups;
+  }, [effectiveSelection, scopedGroups, sessionOrder, pinnedIds, fallbackFamiliarId]);
+  const displayIds = useMemo(
+    () => displayGroups.flatMap((group) => group.sessions.map((session) => session.id)),
+    [displayGroups],
   );
   const visibleRows = useMemo(
     () => scopedGroups.reduce((n, g) => n + g.sessions.length, 0),
@@ -338,6 +422,24 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   }, [contentHits, scopedGroups, mine, search]);
   const showContentSection =
     search.trim().length >= 2 && (contentLoading || contentMatches.length > 0);
+
+  const fallbackOrderIds = useMemo(() => mine.map((s) => s.id), [mine]);
+  const liveSessionIds = useMemo(() => new Set(mine.map((s) => s.id)), [mine]);
+
+  function handleDragEnd(event: DragEndEvent, displayIds: string[]) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = displayIds.indexOf(String(active.id));
+    const newIndex = displayIds.indexOf(String(over.id));
+    if (oldIndex < 0 || newIndex < 0) return;
+    const nextVisible = arrayMove(displayIds, oldIndex, newIndex);
+    setSessionOrder((prev) => {
+      const merged = mergeVisibleOrder(prev.length > 0 ? prev : fallbackOrderIds, nextVisible);
+      const pruned = merged.filter((id) => liveSessionIds.has(id));
+      writeSessionOrder(pruned);
+      return pruned;
+    });
+  }
   // ── Delete (two-step confirm) ────────────────────────────────────────────
 
   const deleteSession = async (e: React.MouseEvent, sessionId: string) => {
@@ -649,6 +751,12 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
         ) : (
           <>
           {visibleRows > 0 && (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={(event) => handleDragEnd(event, displayIds)}
+          >
+            <SortableContext items={displayIds} strategy={verticalListSortingStrategy}>
           <ul className="divide-y divide-[var(--border-hairline)]">
             {displayGroups.map(({ projectRoot, sessions: rows, defaultFamiliarId }) => (
               <li key={projectRoot ?? "__none__"}>
@@ -683,7 +791,8 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                     const rowName = s.title || s.id;
 
                     return (
-                      <li key={s.id}>
+                      <SortableChatListItem key={s.id} id={s.id}>
+                        {({ attributes, listeners }) => (
                         <div
                           role="button"
                           tabIndex={0}
@@ -702,6 +811,18 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                           {isActive && (
                             <span className="absolute left-0 top-1/2 -translate-y-1/2 w-[2px] h-8 rounded-r-full bg-[var(--accent-presence)]" />
                           )}
+
+                          <button
+                            type="button"
+                            {...attributes}
+                            {...listeners}
+                            onClick={(e) => e.stopPropagation()}
+                            title="Drag to reorder"
+                            aria-label={`Reorder chat ${rowName}`}
+                            className="chat-list-drag-handle touch-always-visible -ml-1 mt-0.5 grid h-6 w-4 shrink-0 cursor-grab touch-none place-items-center rounded text-[var(--text-muted)] opacity-0 transition-all hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover:opacity-100"
+                          >
+                            <Icon name="ph:dots-six-vertical" width={12} aria-hidden />
+                          </button>
 
                           {/* Status dot (top-aligned) */}
                           <span className="chat-list-status-dot mt-[5px] shrink-0">
@@ -841,13 +962,16 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                             </span>
                           )}
                         </div>
-                      </li>
+                        )}
+                      </SortableChatListItem>
                     );
                   })}
                 </ul>
               </li>
             ))}
           </ul>
+            </SortableContext>
+          </DndContext>
           )}
 
           {/* ── In conversations (CHAT-D9-02) — body matches for the query.

--- a/src/components/library-polish.test.ts
+++ b/src/components/library-polish.test.ts
@@ -122,8 +122,18 @@ assert.match(
 );
 assert.match(
   libraryCss,
-  /@container \(max-width: 560px\) \{[\s\S]*?\.library-reading-row\s*\{[\s\S]*?display:\s*grid;[\s\S]*?grid-template-columns:\s*minmax\(0,\s*1fr\)\s*minmax\(126px,\s*142px\)\s*44px;/,
-  "Narrow reading panels should render rows as a compact grid that gives Title flexible space",
+  /@container \(max-width: 560px\) \{[\s\S]*?\.library-reading-row\s*\{[\s\S]*?display:\s*grid;[\s\S]*?grid-template-columns:\s*minmax\(0,\s*1fr\)\s*minmax\(132px,\s*176px\)\s*42px;/,
+  "Narrow reading panels should render rows as a compact grid with a readable status control",
+);
+assert.match(
+  libraryCss,
+  /\.library-list-shell \.library-doclist-search\s*\{[\s\S]*?position:\s*sticky;[\s\S]*?height:\s*48px;[\s\S]*?backdrop-filter:\s*blur\(12px\);/,
+  "Reading search should stay compact and sticky at the top of the side-panel list",
+);
+assert.match(
+  libraryCss,
+  /\.library-reading-row\.selected\s*\{[\s\S]*?linear-gradient\(90deg,[\s\S]*?box-shadow:\s*inset 3px 0 0 var\(--accent-presence\);/,
+  "Selected reading rows should use a left accent and soft fill instead of a heavy block",
 );
 assert.match(
   reading,

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2482,3 +2482,22 @@ details[open] > .cave-tool-summary::before {
 .chat-thread-row[data-dragging="true"] .chat-thread-handle {
   cursor: grabbing;
 }
+
+/* Full chat list rows use the same persisted drag intent as the thread rail,
+   but keep their larger row surface as the open target. */
+.chat-list-sortable-row[data-dragging="true"] {
+  position: relative;
+  z-index: 2;
+  opacity: 0.94;
+}
+.chat-list-sortable-row[data-dragging="true"] > .chat-list-row {
+  background: var(--bg-raised);
+  box-shadow: 0 8px 22px color-mix(in oklch, var(--shadow-color, #000) 26%, transparent);
+}
+.chat-list-drag-handle {
+  cursor: grab;
+}
+.chat-list-sortable-row[data-dragging="true"] .chat-list-drag-handle {
+  cursor: grabbing;
+  opacity: 1;
+}

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -1089,7 +1089,7 @@
 .library-reading-title {
   display: -webkit-box;
   max-width: 100%;
-  line-height: 1.35;
+  line-height: 1.32;
   overflow: hidden;
   /* break-word, not anywhere: only split words that genuinely can't fit,
      instead of shattering "Confirmation" into "Confirmati on". */
@@ -1100,7 +1100,9 @@
   white-space: normal;
 }
 .library-reading-author {
-  margin-top: 2px;
+  margin-top: 3px;
+  color: var(--text-muted);
+  line-height: 1.25;
 }
 .library-reading-col-added {
   text-align: right;
@@ -1168,8 +1170,8 @@ tr:focus-within .library-row-delete {
 .library-status-badge {
   display: inline-flex;
   align-items: center;
-  padding: 2px 7px;
-  border-radius: 4px;
+  padding: 2px 8px;
+  border-radius: 6px;
   font-size: 11px;
   font-weight: 500;
   text-transform: capitalize;
@@ -1182,6 +1184,8 @@ tr:focus-within .library-row-delete {
   color: var(--text-primary);
   cursor: pointer;
   outline: none;
+  min-height: 28px;
+  background-color: color-mix(in oklch, var(--bg-raised) 76%, transparent);
 }
 .library-status-select:focus-visible {
   outline: var(--ring-width) solid var(--ring-focus);
@@ -1238,16 +1242,18 @@ tr:focus-within .library-row-delete {
   min-height: 0;
   min-width: 0;
   overflow: hidden;
+  background: color-mix(in oklch, var(--bg-base) 97%, var(--bg-raised));
 }
 .library-list-header {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 6px;
-  padding: 8px 12px;
+  padding: 8px 14px;
   border-bottom: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-base) 94%, var(--bg-raised));
   flex-shrink: 0;
-  min-height: 40px;
+  min-height: 44px;
 }
 .library-list-header-title {
   font-size: 13px;
@@ -1273,7 +1279,7 @@ tr:focus-within .library-row-delete {
 }
 .library-list-header-controls .board-toolbar-btn {
   font-size: 11px;
-  padding: 3px 8px;
+  padding: 4px 9px;
   white-space: nowrap;
 }
 
@@ -2863,9 +2869,69 @@ h3:hover .library-heading-anchor,
   overflow: auto;
   scrollbar-width: thin;
   scrollbar-color: color-mix(in oklch, var(--accent-presence) 22%, transparent) transparent;
+  background: var(--bg-base);
 }
 .library-list-shell .board-table {
   table-layout: fixed;
+}
+.library-list-shell .library-doclist-search {
+  position: sticky;
+  top: 0;
+  z-index: 15;
+  flex-shrink: 0;
+  height: 48px;
+  padding-inline: 14px;
+  border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 78%, transparent);
+  background: color-mix(in oklch, var(--bg-base) 96%, transparent);
+  backdrop-filter: blur(12px);
+}
+.library-list-shell .library-doclist-search-input {
+  font-size: 13px;
+}
+.library-reading-table .board-table-group-row {
+  position: sticky;
+  top: 0;
+  z-index: 9;
+  background: color-mix(in oklch, var(--bg-base) 94%, transparent);
+  backdrop-filter: blur(10px);
+}
+.library-reading-table .board-table-group-row td {
+  height: 36px;
+  border-top: 1px solid color-mix(in oklch, var(--border-hairline) 72%, transparent);
+  border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 88%, transparent);
+  color: var(--text-muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+}
+.library-reading-row {
+  min-height: 64px;
+  transition:
+    background-color var(--duration-fast) var(--ease-standard),
+    box-shadow var(--duration-fast) var(--ease-standard);
+}
+.library-reading-row:hover {
+  background: color-mix(in oklch, var(--bg-raised) 52%, transparent);
+}
+.library-reading-row.selected {
+  background:
+    linear-gradient(90deg, color-mix(in oklch, var(--accent-presence) 13%, transparent), transparent 42%),
+    color-mix(in oklch, var(--bg-raised) 72%, transparent);
+  box-shadow: inset 3px 0 0 var(--accent-presence);
+}
+.library-reading-row > td {
+  vertical-align: middle;
+}
+.library-reading-table .library-reading-col-status {
+  padding-left: 8px;
+  padding-right: 8px;
+}
+.library-reading-table .library-reading-col-added {
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.library-reading-table .library-status-select {
+  width: 100%;
+  text-transform: capitalize;
 }
 /* Bookmarks: Title is the row's identity and must stay the priority column.
    Use auto layout + a fluid first column (max-width:0 + width:100%) so the
@@ -2943,23 +3009,23 @@ h3:hover .library-heading-anchor,
   .library-reading-row {
     box-sizing: border-box;
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(126px, 142px) 44px;
+    grid-template-columns: minmax(0, 1fr) minmax(132px, 176px) 42px;
     align-items: center;
-    column-gap: 10px;
-    min-height: 72px;
+    column-gap: 12px;
+    min-height: 74px;
     width: 100%;
   }
   .library-reading-row > td {
     box-sizing: border-box;
     display: block;
     min-width: 0;
-    padding: 12px 0;
+    padding: 13px 0;
   }
   .library-reading-row > .library-reading-col-title {
-    padding-left: 12px;
+    padding-left: 14px;
   }
   .library-reading-row > .library-reading-col-added {
-    padding-right: 12px;
+    padding-right: 14px;
   }
   .library-reading-table .library-reading-col-source,
   .library-reading-table .library-reading-col-progress,


### PR DESCRIPTION
## Summary
- make the full Chat list drag-sortable across all visible chats with persisted local ordering
- polish the Reading list side panel density, sticky search, selected state, and status controls
- add source assertions for the chat drag and Reading layout contracts

## Verification
- git diff --check HEAD~1..HEAD
- pnpm typecheck
- pnpm test:app