### PR TITLE
chore(release): v0.0.80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.80] - 2026-06-13
+
+This patch release ships the next macOS desktop build and a fresh iOS/TestFlight build after the App Store Connect bootstrap work, carrying the latest mobile, chat, workflow, and memory polish from `main`.
+
+### Added
+- **Native iOS release path** — CovenCave now declares exempt encryption usage, skips desktop sidecar resources for iOS, and shows a mobile release bootstrap screen in the native shell.
+- **Projects in chat** — chat gains a first-class Projects tab and project selection improvements for routing work into the right local repo.
+- **Memory master-detail view** — the Agent Memory tab now uses a denser master-detail reader with reusable row/read hooks and better source handling.
+
+### Changed
+- **Workflow Studio** — workflow canvases gained a vertical layout mode and tighter canvas controls.
+- **Chat and reading polish** — chat lists, mobile command-center spacing, and Library reading styles were tightened for daily use.
+- **Library scope** — the old knowledge graph section was removed to keep the current Library surface focused.
+
+### Fixed
+- **iOS/TestFlight metadata** — bundle and generated iOS plist versions now advance with the app release, and export-compliance metadata is included for App Store Connect processing.
+- **Mobile shell bootstrap** — the iOS shell falls back to a clearer release bootstrap experience when the desktop daemon is not available.
+
 ## [0.0.79] - 2026-06-13
 
 This patch release follows v0.0.78 with mobile shell hardening: native browser IPC now stays desktop-only, and the mobile chat command center gets tighter composer geometry.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A familiar is not just a chat window. It has a name, role, runtime, memory, tool
 
 ## Status
 
-- Current app version: `0.0.79`
+- Current app version: `0.0.80`
 - Native shell: Tauri 2
 - Frontend: Next.js 16, React 19, Tailwind v4
 - Runtime dependency: a healthy local `coven` CLI/daemon plus at least one runtime source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.79",
+  "version": "0.0.80",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.79"
+version = "0.0.80"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.79"
+version = "0.0.80"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.79</string>
+	<string>0.0.80</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.79</string>
+	<string>0.0.80</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.79</string>
+	<string>0.0.80</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.79</string>
+	<string>0.0.80</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.79",
+  "version": "0.0.80",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- Bump CovenCave version metadata to v0.0.80 across package, Tauri, Cargo, and iOS plist files
- Add the v0.0.80 changelog entry covering the fresh iOS/TestFlight patch and next macOS desktop release
- Update README current app version

## Verification
- pnpm install --frozen-lockfile
- node --experimental-strip-types src/lib/app-version.test.ts
- node scripts/release-notes.test.mjs
- bash scripts/release-notes.sh v0.0.80
- git diff --check
- pnpm test:mobile
- pnpm typecheck
- pnpm test:api
- pnpm test:app
- pnpm check:tests-wired
- pnpm build
- cargo check --locked

Co-authored-by: Nova <nova@openclaw.local>