### PR TITLE
fix(projects): close the New project form on Escape

### DIFF
--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -55,4 +55,11 @@ assert.match(projectsView, /aria-label=\{`Rename \$\{project\.name\}`\}/, "renam
 assert.match(projectsView, /aria-label=\{`Delete \$\{project\.name\}`\}/, "delete action labeled per project");
 assert.match(projectsView, /motion-reduce:transition-none/, "reveal respects reduced motion");
 
+// The "New project" inline form closes on Escape (parity with its Cancel button + the row inline-edits).
+assert.match(
+  projectsView,
+  /onSubmit=\{handleCreate\}[\s\S]{0,200}?onKeyDown[\s\S]{0,120}?"Escape"[\s\S]{0,80}?setShowForm\(false\)/,
+  "new-project form closes on Escape",
+);
+
 console.log("projects-view.test.ts: ok");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -282,6 +282,9 @@ export function ProjectsView({ sessions = [], onNewChat }: ProjectsViewProps) {
       {showForm ? (
         <form
           onSubmit={handleCreate}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") setShowForm(false);
+          }}
           className="shrink-0 border-b border-[var(--border-hairline)] bg-[var(--bg-sunken)] px-4 py-3 sm:px-6"
         >
           <div className="grid gap-2 lg:grid-cols-[minmax(160px,0.7fr)_minmax(260px,1.3fr)_auto]">


### PR DESCRIPTION
## Summary
The inline **New project** create form in the Projects chat tab had no Escape handler — only the Cancel button dismissed it. The row inline-edits already close on Escape; this brings the create form to parity.

One-line fix: an `onKeyDown` on the `<form>` that calls `setShowForm(false)` on Escape.

## Test Plan
- [x] `projects-view.test.ts` extended (asserts the create form wires Escape → `setShowForm(false)`) — passes
- [x] `tsc --noEmit` clean
- [ ] Reviewer: open Projects tab → New project → press Escape → form closes

Follow-up to the live verification of #586, which surfaced this gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)