### PR TITLE
fix(memory): render agent-memory excerpt in reader pane

### DIFF
--- a/src/components/agents-memory-reader.test.ts
+++ b/src/components/agents-memory-reader.test.ts
@@ -17,6 +17,12 @@ assert.match(source, /<pre/, "Raw mode must render a <pre> of the source");
 assert.ok(!/Showing first/.test(source), "inline reader must NOT clip long files");
 assert.ok(!/MAX_LINES/.test(source), "inline reader must NOT use a line cap");
 
+// Agent (coven) rows render their excerpt and skip the file fetch (their relative
+// path is rejected by /api/memory/file). File rows still fetch.
+assert.match(source, /const isAgent = row\?\.kind === "agent"/, "reader must distinguish agent rows");
+assert.match(source, /useMemoryFile\(isAgent \? null :/, "agent rows must NOT fetch the file endpoint");
+assert.match(source, /isAgent \? row\.excerpt/, "agent body must come from the excerpt");
+
 // Copy-path + empty state + open-file + expand.
 assert.match(source, /navigator\.clipboard\.writeText/, "copy-path button must copy the path");
 assert.match(source, /Select a memory to read/, "empty state when no row selected");

--- a/src/components/agents-memory-reader.tsx
+++ b/src/components/agents-memory-reader.tsx
@@ -31,7 +31,11 @@ export function MemoryReaderPane({
 }) {
   const [mode, setMode] = useState<"rendered" | "raw">("rendered");
   const [copied, setCopied] = useState(false);
-  const { text, error, loading } = useMemoryFile(row?.path ?? null);
+  // Agent (coven) memories carry a relative path the file endpoint rejects, and the
+  // entry already ships its full body as `excerpt` — render that directly. Only file
+  // entries (absolute path) are fetched from /api/memory/file.
+  const isAgent = row?.kind === "agent";
+  const { text, error, loading } = useMemoryFile(isAgent ? null : row?.path ?? null);
 
   if (!row) {
     return (
@@ -51,6 +55,11 @@ export function MemoryReaderPane({
       window.setTimeout(() => setCopied(false), 1500);
     });
   };
+
+  // For agent rows the body is the excerpt; for file rows it's the fetched text.
+  const content = isAgent ? row.excerpt ?? "" : text ?? "";
+  const isFileLoading = !isAgent && (loading || text === null);
+  const emptyMsg = isAgent ? "No excerpt available." : "Empty file.";
 
   return (
     <div className="flex h-full min-h-0 flex-col rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/30">
@@ -143,17 +152,17 @@ export function MemoryReaderPane({
         </div>
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto p-4">
-        {error ? (
+        {!isAgent && error ? (
           <p className="text-[12px] text-[var(--color-warning)]">{error}</p>
-        ) : loading || text === null ? (
+        ) : isFileLoading ? (
           <p className="text-[12px] text-[var(--text-muted)]">Loading memory…</p>
-        ) : text.trim() === "" ? (
-          <p className="text-[12px] text-[var(--text-muted)]">Empty file.</p>
+        ) : content.trim() === "" ? (
+          <p className="text-[12px] text-[var(--text-muted)]">{emptyMsg}</p>
         ) : mode === "rendered" ? (
-          <MarkdownBlock text={text} />
+          <MarkdownBlock text={content} />
         ) : (
           <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-5 text-[var(--text-secondary)]">
-            {text}
+            {content}
           </pre>
         )}
       </div>


### PR DESCRIPTION
Follow-up to #592. Live verification surfaced that selecting an **agent (coven) memory** in the new reader showed **"path not allowed"** (HTTP 403): coven entries carry a *relative* `path` (e.g. `sage/2026-05-24.md`), which `/api/memory/file` rejects — it only serves absolute, allow-listed paths. File entries (absolute `fullPath`) were unaffected.

## Fix
`MemoryReaderPane` now branches on row kind:
- **agent rows** — skip the file fetch and render `row.excerpt` (the entry already ships its body), via the same Rendered/Raw + MarkdownBlock path. Empty → "No excerpt available."
- **file rows** — unchanged (fetch `/api/memory/file`).

This restores the pre-redesign behavior (the old drawer showed coven excerpts inline) while keeping the unified reader.

## Verification
- Live-drove the dev app against real data: the agent memory now renders its excerpt (no 403); file memories still render full markdown.
- `agents-memory-reader.test.ts` extended (agent-skips-fetch + excerpt-body); `pnpm typecheck` clean.

Full content for agent memories (option 2 — absolute coven paths) is a deferred follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)