### PR TITLE
feat(memory): group the unified memory list by type/source/date

### DIFF
--- a/src/components/agents-memory-master-detail.test.ts
+++ b/src/components/agents-memory-master-detail.test.ts
@@ -22,4 +22,9 @@ const reader = await readFile(new URL("./agents-memory-reader.tsx", import.meta.
 assert.match(reader, /aria-label="Back to list"/, "reader renders a Back button");
 assert.match(reader, /xl:hidden/, "Back button is hidden at xl and above");
 
+// Grouping: a Group control drives groupMemoryRows over the paged rows.
+assert.match(source, /value=\{groupMode\}/, "Group control is bound to groupMode");
+assert.match(source, /groupMemoryRows\(pagedRows, groupMode\)/, "grouped mode wraps the paged rows");
+assert.match(source, /groupMode === "none" \?/, "flat list renders only when group mode is none");
+
 console.log("agents-memory-master-detail: all assertions passed");

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -17,7 +17,7 @@ import {
   type RawCovenEntry,
   type RawFileEntry,
 } from "@/lib/memory-management";
-import { buildMemoryRows, type MemoryRow } from "@/lib/memory-rows";
+import { buildMemoryRows, groupMemoryRows, type MemoryRow } from "@/lib/memory-rows";
 import { MemoryRowItem } from "@/components/agents-memory-row";
 import { MemoryReaderPane } from "@/components/agents-memory-reader";
 import "@/styles/library.css";
@@ -252,6 +252,23 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
     () => unifiedRows.find((r) => r.rowId === selectedRowId) ?? null,
     [unifiedRows, selectedRowId],
   );
+  // The visible page of rows (shared by flat + grouped rendering).
+  const pagedRows = useMemo(() => unifiedRows.slice(0, fileLimit), [unifiedRows, fileLimit]);
+  const renderRow = (row: MemoryRow) => (
+    <MemoryRowItem
+      key={row.rowId}
+      row={row}
+      age={age(row.sortTime)}
+      selected={selectedRowId === row.rowId}
+      onSelect={() => setSelectedRowId(row.rowId)}
+      onExpand={() => setExpandRow(row)}
+      onDelete={
+        row.protection !== "structural"
+          ? () => handleDelete(row.path, row.rowId, row.kind === "agent" ? "coven" : "file")
+          : undefined
+      }
+    />
+  );
 
   // Stale entries across BOTH sources, powering the Stale pill + bulk delete.
   const suggestions = useMemo(() => {
@@ -399,9 +416,15 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
         </div>
         {compact ? null : (
           <div className="memory-controls mt-3">
-            {/* Group control is intentionally omitted in the unified master-detail
-                view — grouping over MemoryRow is a deferred follow-up. groupMode
-                state is retained for that work; it does not affect the flat list. */}
+            <label className="memory-control">
+              Group
+              <select value={groupMode} onChange={(e) => setGroupMode(e.target.value as GroupBy)}>
+                <option value="none">None</option>
+                <option value="type">Type</option>
+                <option value="source">Source</option>
+                <option value="date">Date</option>
+              </select>
+            </label>
             <label className="memory-control">
               Sort
               <select value={sortMode} onChange={(e) => setSortMode(e.target.value as typeof sortMode)}>
@@ -466,20 +489,24 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
                   <div className="px-3 py-8 text-center text-[12px] text-[var(--text-muted)]">
                     {loaded ? (error ? "Couldn't load memories. See the error above and try again." : "No memories match this view.") : "Loading memories…"}
                   </div>
-                ) : (
+                ) : groupMode === "none" ? (
                   <ul className="divide-y divide-[var(--border-hairline)]">
-                    {unifiedRows.slice(0, fileLimit).map((row) => (
-                      <MemoryRowItem
-                        key={row.rowId}
-                        row={row}
-                        age={age(row.sortTime)}
-                        selected={selectedRowId === row.rowId}
-                        onSelect={() => setSelectedRowId(row.rowId)}
-                        onExpand={() => setExpandRow(row)}
-                        onDelete={row.protection !== "structural" ? () => handleDelete(row.path, row.rowId, row.kind === "agent" ? "coven" : "file") : undefined}
-                      />
-                    ))}
+                    {pagedRows.map(renderRow)}
                   </ul>
+                ) : (
+                  <div>
+                    {groupMemoryRows(pagedRows, groupMode).map((group) => (
+                      <div key={group.key}>
+                        <h4 className="sticky top-0 z-[1] flex items-center gap-1.5 border-b border-[var(--border-hairline)] bg-[var(--bg-raised)]/95 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-secondary)] backdrop-blur">
+                          {group.label}
+                          <span className="font-normal text-[var(--text-muted)]">({group.rows.length})</span>
+                        </h4>
+                        <ul className="divide-y divide-[var(--border-hairline)]">
+                          {group.rows.map(renderRow)}
+                        </ul>
+                      </div>
+                    ))}
+                  </div>
                 )}
                 {unifiedRows.length > fileLimit ? (
                   <button

--- a/src/lib/memory-rows.test.ts
+++ b/src/lib/memory-rows.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { buildMemoryRows } from "./memory-rows.ts";
+import { buildMemoryRows, groupMemoryRows } from "./memory-rows.ts";
 
 const NOW = Date.parse("2026-06-13T12:00:00Z");
 
@@ -80,6 +80,46 @@ const files = [
   const rows = buildMemoryRows({ coven, files, familiarFilter: "echo", query: "",
     sourceFilter: "all", sortMode: "recent", staleOnly: false, now: NOW });
   assert.ok(rows.every((r) => ["structural", "bulk-protected", "normal"].includes(r.protection)));
+}
+
+// ── groupMemoryRows ──
+const GNOW = Date.parse("2026-06-13T12:00:00Z");
+const grows = [
+  { rowId: "coven:c1", kind: "agent", title: "Note", path: "sage/x.md", sortTime: "2026-06-13T11:00:00Z", sourceLabel: "Sage", stale: false, protection: "normal" },
+  { rowId: "file:f1", kind: "file", title: "new.md", path: "/x/new.md", size: 10, sortTime: "2026-06-13T10:00:00Z", sourceLabel: "Runtime memory", stale: false, protection: "normal" },
+  { rowId: "file:f2", kind: "file", title: "old.md", path: "/x/old.md", size: 20, sortTime: "2026-01-01T00:00:00Z", sourceLabel: "Coven origin", stale: false, protection: "normal" },
+];
+
+// none → single "All" group preserving order
+{
+  const g = groupMemoryRows(grows, "none");
+  assert.equal(g.length, 1);
+  assert.equal(g[0].key, "all");
+  assert.equal(g[0].rows.length, 3);
+}
+
+// type → Agent memories first, then Files; counts correct
+{
+  const g = groupMemoryRows(grows, "type");
+  assert.deepEqual(g.map((x) => x.label), ["Agent memories", "Files"]);
+  assert.equal(g[0].rows.length, 1);
+  assert.equal(g[1].rows.length, 2);
+}
+
+// source → one group per sourceLabel
+{
+  const g = groupMemoryRows(grows, "source");
+  assert.deepEqual(g.map((x) => x.label).sort(), ["Coven origin", "Runtime memory", "Sage"]);
+}
+
+// date → time buckets; Today before Older
+{
+  const g = groupMemoryRows(grows, "date", GNOW);
+  const today = g.find((x) => x.label === "Today");
+  const older = g.find((x) => x.label === "Older");
+  assert.equal(today.rows.length, 2, "the two June-13 rows bucket into Today");
+  assert.equal(older.rows.length, 1, "the Jan row buckets into Older");
+  assert.ok(g[0].key < g[g.length - 1].key, "buckets are key-ordered (Today→Older)");
 }
 
 console.log("memory-rows: all assertions passed");

--- a/src/lib/memory-rows.ts
+++ b/src/lib/memory-rows.ts
@@ -3,6 +3,7 @@ import {
   detectStale,
   normalizeCovenEntry,
   normalizeFileEntry,
+  type GroupBy,
   type ProtectionTier,
   type RawCovenEntry,
   type RawFileEntry,
@@ -96,4 +97,56 @@ export function buildMemoryRows(args: BuildArgs): MemoryRow[] {
     staleFirst: (a, b) => Number(b.stale) - Number(a.stale),
   };
   return rows.sort(cmp[args.sortMode]);
+}
+
+export type MemoryRowGroup = { key: string; label: string; rows: MemoryRow[] };
+
+const TYPE_LABEL: Record<MemoryRowKind, string> = { agent: "Agent memories", file: "Files" };
+
+function rowDateBucket(iso: string, now: number): { key: string; label: string } {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t) || !t) return { key: "z-unknown", label: "Unknown" };
+  const ageDays = (now - t) / 86_400_000;
+  if (ageDays < 1) return { key: "a-today", label: "Today" };
+  if (ageDays < 7) return { key: "b-week", label: "This week" };
+  if (ageDays < 31) return { key: "c-month", label: "This month" };
+  return { key: "d-older", label: "Older" };
+}
+
+/**
+ * Partition already-sorted rows into labelled groups for the list pane. Within-group
+ * order is preserved from the input (i.e. the active sort still applies inside a group).
+ * Groups are ordered by a sort key: date uses time buckets (Today→Older), others sort
+ * alphabetically. `none` returns a single "All" group.
+ */
+export function groupMemoryRows(rows: MemoryRow[], by: GroupBy, now = Date.now()): MemoryRowGroup[] {
+  if (by === "none") return [{ key: "all", label: "All", rows: [...rows] }];
+  const map = new Map<string, MemoryRowGroup>();
+  for (const r of rows) {
+    let key: string;
+    let label: string;
+    if (by === "type") {
+      key = r.kind;
+      label = TYPE_LABEL[r.kind] ?? r.kind;
+    } else if (by === "source") {
+      key = r.sourceLabel;
+      label = r.sourceLabel;
+    } else if (by === "date") {
+      const b = rowDateBucket(r.sortTime, now);
+      key = b.key;
+      label = b.label;
+    } else {
+      // "familiar": agent rows group under their familiar label; files bucket together.
+      if (r.kind === "agent") {
+        key = `a:${r.sourceLabel}`;
+        label = r.sourceLabel;
+      } else {
+        key = "z:files";
+        label = "Files";
+      }
+    }
+    if (!map.has(key)) map.set(key, { key, label, rows: [] });
+    map.get(key)!.rows.push(r);
+  }
+  return [...map.values()].sort((x, y) => x.key.localeCompare(y.key));
 }


### PR DESCRIPTION
Completes the grouping follow-up deferred from #592. The unified memory list can now be grouped, with sticky section headers.

## What changed
- **`groupMemoryRows(rows, by)`** (`src/lib/memory-rows.ts`) — pure, unit-tested partitioner. `none` → single "All"; `type` → Agent memories / Files; `source` → by source label (Coven origin / External harness / Runtime / familiar); `date` → Today / This week / This month / Older / Unknown. Within-group order preserves the active sort; groups are key-ordered (date buckets Today→Older, others alphabetical).
- **Group control restored** in the full view (`None / Type / Source / Date`). "Familiar" is intentionally dropped — this view is familiar-locked and rows carry no familiarId.
- **Grouped rendering** in the list pane: when a group mode is active, rows render under sticky `LABEL (n)` headers; `none` keeps the flat list. Grouping is applied to the **paged** rows, so "Show more" pagination still works and selection/hover-actions are unchanged (shared `renderRow`).

## Verification
- Live-drove the dev app (real data, 1474 entries): Type → `AGENT MEMORIES (1)` / `FILES (79)`; Source → `COVEN ORIGIN (2)` / `EXTERNAL HARNESS (2)` / `RUNTIME (75)` / `SAGE (1)`; Date → `TODAY (79)` / `UNKNOWN (1)`; None → flat. Selecting a row in grouped mode still loads the reader.
- `memory-rows.test.ts` extended (none/type/source/date); `agents-memory-master-detail.test.ts` extended (Group control + grouped render); `pnpm typecheck` clean; `pnpm build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)