### PR TITLE
feat(library): remove Tags column from bookmark rows

### DIFF
--- a/src/components/library-bookmarks-list.tsx
+++ b/src/components/library-bookmarks-list.tsx
@@ -349,7 +349,6 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
                     </span>
                   </th>
                 ))}
-                <th style={{ width: "96px" }}>Tags</th>
                 <th style={{ width: "56px" }} />
               </tr>
             </thead>
@@ -358,7 +357,7 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
                 <React.Fragment key={key}>
                   {groupBy !== "none" && (
                     <tr className="board-table-group-row" onClick={() => toggleGroup(key)}>
-                      <td colSpan={5}>
+                      <td colSpan={4}>
                         <span className="board-table-group-caret">
                           <Icon name={collapsed.has(key) ? "ph:caret-right" : "ph:caret-down"} width={10} />
                         </span>
@@ -392,16 +391,6 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
                       </td>
                       <td style={{ textAlign: "right" }}>
                         <span className="board-table-muted">{relTime(item.savedAt)}</span>
-                      </td>
-                      <td>
-                        <div className="library-tag-chips">
-                          {item.tags.slice(0, 3).map((t: string) => (
-                            <span key={t} className="library-doclist-tag">{t}</span>
-                          ))}
-                          {item.tags.length > 3 && (
-                            <span className="board-table-muted">+{item.tags.length - 3}</span>
-                          )}
-                        </div>
                       </td>
                       <td onClick={(e) => e.stopPropagation()}>
                         <span style={{ display: "flex", alignItems: "center", gap: 4 }}>


### PR DESCRIPTION
Removes the per-row **Tags** chip column from the bookmarks list table.

- Drops the `Tags` header `<th>` and the tag-chips `<td>` in each row
- Adjusts the group-row `colSpan` 5 → 4 to match the new column count

Tags are still stored, editable via the add-bookmark form, and used for search/grouping — only the per-row column display is removed.

Verified with `pnpm build` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)