### PR TITLE
chore(release): v0.0.81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.81] - 2026-06-14
+
+This patch release completes the Agent Memory redesign, adds local-change checkpoints and an in-app update button, and tidies the bookmarks table.
+
+### Added
+- **Update available button** — the app now surfaces a button when a newer release has been published.
+- **Agent memory grouping & full content** — the unified memory list can group by type, source, or date, and agent (familiar) memories now open their full file in the reader instead of just an excerpt.
+- **Change checkpoints** — the Changes view gained checkpoints with recoverable reverts.
+
+### Changed
+- **Bookmarks** — removed the Tags column from bookmark rows for a cleaner, more legible table.
+
+### Fixed
+- **Agent memory reader** — agent memories no longer fail with "path not allowed"; their content renders correctly.
+- **Changes** — fixed stale diffs and `.env` file mangling.
+
 ## [0.0.80] - 2026-06-13
 
 This patch release ships the next macOS desktop build and a fresh iOS/TestFlight build after the App Store Connect bootstrap work, carrying the latest mobile, chat, workflow, and memory polish from `main`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A familiar is not just a chat window. It has a name, role, runtime, memory, tool
 
 ## Status
 
-- Current app version: `0.0.80`
+- Current app version: `0.0.81`
 - Native shell: Tauri 2
 - Frontend: Next.js 16, React 19, Tailwind v4
 - Runtime dependency: a healthy local `coven` CLI/daemon plus at least one runtime source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.80",
+  "version": "0.0.81",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.80"
+version = "0.0.81"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.80"
+version = "0.0.81"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.80</string>
+	<string>0.0.81</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.80</string>
+	<string>0.0.81</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.80</string>
+	<string>0.0.81</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.80</string>
+	<string>0.0.81</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.80",
+  "version": "0.0.81",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Patch release **v0.0.81**. Bumps `package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`, README, and adds the CHANGELOG entry.

Carries everything merged since v0.0.80 (#595–#600):
- **Added** — update-available button (#599); agent-memory grouping + full-content reader (#597, #600); change checkpoints with recoverable reverts (#596).
- **Changed** — removed the Tags column from bookmark rows (#598).
- **Fixed** — agent-memory reader "path not allowed" (#595); stale diffs & `.env` mangling in Changes (#596).

Once merged, a signed `v0.0.81` tag triggers `release.yml` (notarized DMG/AppImage/MSI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)