### PR TITLE
fix(terms): use "Familiar" for user-facing AI-assistant labels (was "Agent")

### DIFF
--- a/src/app/mockup/page.tsx
+++ b/src/app/mockup/page.tsx
@@ -54,7 +54,7 @@ const WORKSPACE_NAV: Array<{ id: string; label: string; icon: string; view?: Vie
   { id: "issues-ws", label: "Issues", icon: "ph:kanban" },
   { id: "projects", label: "Projects", icon: "ph:folder" },
   { id: "autopilot", label: "Autopilot", icon: "ph:lightning", view: "autopilot" },
-  { id: "agents", label: "Agents", icon: "ph:robot" },
+  { id: "agents", label: "Familiars", icon: "ph:robot" },
   { id: "squads", label: "Squads", icon: "ph:users-three" },
   { id: "usage", label: "Usage", icon: "ph:chart-bar" },
 ];
@@ -153,7 +153,7 @@ function ViewSwitcher({ view, onView }: { view: View; onView: (v: View) => void 
   const opts: Array<{ id: View; label: string }> = [
     { id: "autopilot", label: "Autopilot" },
     { id: "settings", label: "Settings" },
-    { id: "agent", label: "Create Agent" },
+    { id: "agent", label: "Create Familiar" },
   ];
   return (
     <div className="multica-view-switcher">
@@ -280,8 +280,8 @@ function CreateAgentModal({ onClose }: { onClose: () => void }) {
         <div className="multica-modal-header">
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16 }}>
             <div>
-              <div className="multica-modal-title">Create Agent</div>
-              <div className="multica-modal-description">Create a new AI agent for your workspace.</div>
+              <div className="multica-modal-title">Create Familiar</div>
+              <div className="multica-modal-description">Create a new AI familiar for your workspace.</div>
             </div>
             <button className="multica-btn multica-btn--ghost" onClick={onClose} aria-label="Close">
               <Icon name="ph:x" width={14} />
@@ -308,11 +308,11 @@ function CreateAgentModal({ onClose }: { onClose: () => void }) {
             <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 16 }}>
               <div className="multica-field">
                 <label className="multica-field-label">Name</label>
-                <input className="multica-field-input" placeholder="e.g. Deep Research Agent" />
+                <input className="multica-field-input" placeholder="e.g. Deep Research Familiar" />
               </div>
               <div className="multica-field">
                 <label className="multica-field-label">Description</label>
-                <input className="multica-field-input" placeholder="What does this agent do?" />
+                <input className="multica-field-input" placeholder="What does this familiar do?" />
                 <div style={{ alignSelf: "flex-end", fontSize: 11, color: "var(--muted-foreground)" }}>0 / 255</div>
               </div>
             </div>

--- a/src/components/agents-memory-reader.tsx
+++ b/src/components/agents-memory-reader.tsx
@@ -114,7 +114,7 @@ export function MemoryReaderPane({
         </div>
         <div className="mt-2 flex flex-wrap items-center gap-1.5 text-[10px] text-[var(--text-muted)]">
           <span className="rounded bg-[var(--bg-elevated)] px-1.5 py-0.5 text-[var(--text-secondary)]">
-            {row.kind === "agent" ? "Agent memory" : "File"}
+            {row.kind === "agent" ? "Familiar memory" : "File"}
           </span>
           <span className="rounded bg-[var(--bg-elevated)] px-1.5 py-0.5">{row.sourceLabel}</span>
           {sizeLabel ? (

--- a/src/components/agents-memory-view-full-tab.test.ts
+++ b/src/components/agents-memory-view-full-tab.test.ts
@@ -18,7 +18,7 @@ assert.doesNotMatch(
   "Old four-card stats grid must be removed",
 );
 
-for (const label of ["Agent memories", "Coven origin", "External harnesses", "Runtime memory"]) {
+for (const label of ["Familiar memories", "Coven origin", "External harnesses", "Runtime memory"]) {
   assert.ok(source.includes(label), `Inline stats row must keep label: ${label}`);
 }
 

--- a/src/components/agents-memory-view.tsx
+++ b/src/components/agents-memory-view.tsx
@@ -334,10 +334,10 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
             <div>
               <div className="flex items-center gap-2">
                 <Icon name="ph:brain-bold" width={15} className="text-[var(--accent-presence)]" />
-                <h2 className="text-[14px] font-semibold text-[var(--text-primary)]">Agent Memory</h2>
+                <h2 className="text-[14px] font-semibold text-[var(--text-primary)]">Familiar Memory</h2>
               </div>
               <p className="mt-1 text-[11px] text-[var(--text-muted)]">
-                Focused recall for one agent at a time, with local memory files kept in the list surface.
+                Focused recall for one familiar at a time, with local memory files kept in the list surface.
               </p>
             </div>
             <div className="flex items-center gap-2.5">
@@ -359,7 +359,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
             data-testid="memory-stats-inline"
             className="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1.5 text-[11px] text-[var(--text-secondary)]"
           >
-            <span className="inline-flex items-baseline gap-1 px-1"><span className="text-[var(--text-muted)]">Agent memories</span> <span className="font-semibold text-[var(--text-primary)]">{visibleCoven.length}</span></span>
+            <span className="inline-flex items-baseline gap-1 px-1"><span className="text-[var(--text-muted)]">Familiar memories</span> <span className="font-semibold text-[var(--text-primary)]">{visibleCoven.length}</span></span>
             <span aria-hidden className="text-[var(--border-strong)]">·</span>
             <span className="mr-0.5 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Files</span>
             <SourceFilterChip label="Coven origin" count={fileSourceCounts.covenOrigin} active={sourceFilter === "coven-origin"} onClick={() => setSourceFilter((s) => (s === "coven-origin" ? "all" : "coven-origin"))} />
@@ -458,7 +458,7 @@ export function AgentsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, 
               No memories yet for {selectedFamiliar?.display_name ?? "this familiar"}
             </div>
             <p className="mt-1 max-w-[280px] text-[11px] leading-5 text-[var(--text-muted)]">
-              Familiar memories are saved during chats. Memory files appear when the agent's harness writes to disk.
+              Familiar memories are saved during chats. Memory files appear when the familiar's harness writes to disk.
             </p>
           </div>
         ) : (

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -873,7 +873,7 @@ function openTargetLabel(item: InboxItem): string | null {
 
 const KIND_LABEL: Record<InboxItem["kind"], string> = {
   reminder: "Reminder",
-  agent: "Agent",
+  agent: "Familiar",
   "response-needed": "Response needed",
 };
 

--- a/src/components/calls-view.tsx
+++ b/src/components/calls-view.tsx
@@ -253,7 +253,7 @@ export function CallsView({ familiars, sessions, onOpenSession, initialTab = "fl
               <input
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
-                placeholder="Search agent, request, status..."
+                placeholder="Search familiar, request, status..."
                 className="h-8 w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 pl-8 pr-3 text-[12px] text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)] focus:border-[var(--accent-presence)]"
               />
             </div>
@@ -288,7 +288,7 @@ export function CallsView({ familiars, sessions, onOpenSession, initialTab = "fl
             <Metric label="Inferred" value={metrics.inferred} tone="text-[var(--color-warning)]" />
             <Metric label="Running" value={metrics.running} tone="text-[var(--color-success)]" />
             <Metric label="Failed" value={metrics.failed} tone="text-[var(--color-danger)]" />
-            <Metric label="Agents" value={metrics.agents} tone="text-[var(--text-primary)]" />
+            <Metric label="Familiars" value={metrics.agents} tone="text-[var(--text-primary)]" />
           </div>
 
           <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-hidden px-5 py-4 xl:grid-cols-[minmax(0,1fr)_360px]">
@@ -427,7 +427,7 @@ function TraceInspector({
   if (selectedNode) {
     return (
       <aside className="min-h-0 overflow-y-auto rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-raised)]/20 p-4">
-        <InspectorTitle eyebrow="Selected agent" title={familiarName(familiars, selectedNode.id)} />
+        <InspectorTitle eyebrow="Selected familiar" title={familiarName(familiars, selectedNode.id)} />
         <div className="mt-4 grid grid-cols-2 gap-2">
           <Metric label="Sent" value={selectedNode.sentCount} tone="text-[var(--text-primary)]" />
           <Metric label="Received" value={selectedNode.receivedCount} tone="text-[var(--text-primary)]" />

--- a/src/components/chat-list-panel.test.ts
+++ b/src/components/chat-list-panel.test.ts
@@ -12,7 +12,7 @@ assert.match(
 
 assert.match(
   source,
-  /Agent runtime/,
+  /Familiar runtime/,
   "ChatList should label the familiar harness/model metadata as agent runtime",
 );
 
@@ -24,7 +24,7 @@ assert.match(
 
 assert.match(
   source,
-  /panelRole[\s\S]*Agent runtime/,
+  /panelRole[\s\S]*Familiar runtime/,
   "ChatList dossier header should keep the familiar role and runtime subtitle together",
 );
 

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -565,7 +565,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                     {" · "}
                   </>
                 ) : null}
-                Agent runtime{" "}
+                Familiar runtime{" "}
                 <span className="font-mono">{panelRuntime}</span>
               </p>
             </div>

--- a/src/components/chat-project-sidebar.tsx
+++ b/src/components/chat-project-sidebar.tsx
@@ -45,7 +45,7 @@ type ChatFilter = "all" | "active" | "tasks" | "pinned";
 // chat plane's git mode for agentic coding.
 const ADVANCED_OPS: Array<{ event: string; label: string; title: string; icon: IconName }> = [
   { event: "cave:changes-open", label: "Git", title: "Git changes for this session", icon: "ph:git-diff" },
-  { event: "cave:inspector-open", label: "Inspect", title: "Open the agent inspector", icon: "ph:brain-bold" },
+  { event: "cave:inspector-open", label: "Inspect", title: "Open the familiar inspector", icon: "ph:brain-bold" },
   { event: "cave:debug-open", label: "Debug", title: "Open the session debug panel", icon: "ph:bug-bold" },
 ];
 

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -128,7 +128,7 @@ assert.match(
 
 assert.match(
   agentsMemoryView,
-  /Agent memories[\s\S]*Coven origin[\s\S]*External harnesses[\s\S]*Runtime memory/,
+  /Familiar memories[\s\S]*Coven origin[\s\S]*External harnesses[\s\S]*Runtime memory/,
   "Agents memory view should summarize native Coven, external harness, and runtime memory sources",
 );
 

--- a/src/components/library-github-list.tsx
+++ b/src/components/library-github-list.tsx
@@ -316,7 +316,7 @@ function AttachTaskModal({
   );
 }
 
-// ── Handoff to Agent modal ─────────────────────────────────────────────────
+// ── Handoff to Familiar modal ─────────────────────────────────────────────────
 
 // Scripted launch templates keyed by GitHub item kind
 const LAUNCH_TEMPLATES: Record<GitHubItemKind, string> = {
@@ -443,12 +443,12 @@ function HandoffModal({
         className="gh-modal gh-modal--wide"
         role="dialog"
         aria-modal="true"
-        aria-label="Handoff to Agent"
+        aria-label="Handoff to Familiar"
         tabIndex={-1}
       >
         <div className="gh-modal-header">
           <Icon name="ph:share-network" width={14} />
-          <span>Handoff to Agent</span>
+          <span>Handoff to Familiar</span>
           <button type="button" className="gh-modal-close" onClick={onClose}>
             <Icon name="ph:x" width={13} />
           </button>
@@ -476,7 +476,7 @@ function HandoffModal({
             </div>
 
             {/* Agent picker */}
-            <label className="gh-modal-label">Agent
+            <label className="gh-modal-label">Familiar
               <div className="gh-modal-agent-row">
                 <select
                   className="gh-modal-select"
@@ -820,8 +820,8 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
                                 type="button"
                                 className="gh-row-action-btn"
                                 onClick={() => setHandoffItem(item)}
-                                aria-label={`Handoff ${item.title} to agent`}
-                                title="Handoff to agent"
+                                aria-label={`Handoff ${item.title} to familiar`}
+                                title="Handoff to familiar"
                               >
                                 <Icon name="ph:share-network" width={12} />
                               </button>

--- a/src/components/sidebar-familiar-filter.test.ts
+++ b/src/components/sidebar-familiar-filter.test.ts
@@ -32,7 +32,7 @@ assert.match(
 
 assert.match(
   sidebar,
-  /<span className="sidebar-familiar-filter__label">Agent<\/span>[\s\S]*aria-label="Filter workspace by agent"[\s\S]*<option value="">Familiars<\/option>/,
+  /<span className="sidebar-familiar-filter__label">Familiar<\/span>[\s\S]*aria-label="Filter workspace by familiar"[\s\S]*<option value="">Familiars<\/option>/,
   "Familiar selector should expose Familiars as the generic no-filter agent option",
 );
 

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -125,11 +125,11 @@ function FamiliarScopeSelect({
 }) {
   return (
     <label className="sidebar-familiar-filter">
-      <span className="sidebar-familiar-filter__label">Agent</span>
+      <span className="sidebar-familiar-filter__label">Familiar</span>
       <span className="sidebar-familiar-filter__control">
         <Icon name="ph:sparkle" width={14} className="sidebar-familiar-filter__icon" aria-hidden />
         <select
-          aria-label="Filter workspace by agent"
+          aria-label="Filter workspace by familiar"
           value={activeFamiliarId ?? ""}
           onChange={(e) => onFamiliarScopeChange(e.currentTarget.value || null)}
           className="sidebar-familiar-filter__select"

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -116,8 +116,8 @@ export function TopBar(props: Props) {
             type="button"
             className="top-bar__mobile-toggle"
             onClick={onToggleAgent}
-            aria-label="Open agent panel (⌘J)"
-            title="Open agent panel"
+            aria-label="Open familiar panel (⌘J)"
+            title="Open familiar panel"
           >
             <Icon name="ph:cat" width={18} />
           </button>

--- a/src/components/trace-graph-3d.tsx
+++ b/src/components/trace-graph-3d.tsx
@@ -523,8 +523,8 @@ export function TraceGraph3D({ graph, familiars, selection, onSelect, memoryCoun
   ], [sceneModel.edges, sceneModel.nodes]);
 
   const selectedSummary = useMemo(() => {
-    if (!selection) return `${graph.nodes.length} agents, ${graph.edges.length} routes, ${graph.traces.length} traces.`;
-    if (selection.kind === "node") return `Selected agent ${familiarName(familiars, selection.id)}.`;
+    if (!selection) return `${graph.nodes.length} familiars, ${graph.edges.length} routes, ${graph.traces.length} traces.`;
+    if (selection.kind === "node") return `Selected familiar ${familiarName(familiars, selection.id)}.`;
     if (selection.kind === "edge") {
       const edge = graph.edges.find((candidate) => edgeKey(candidate) === selection.key);
       return edge ? `Selected route ${familiarName(familiars, edge.caller)} to ${familiarName(familiars, edge.callee)}, ${edge.count} traces.` : "Selected route.";
@@ -576,7 +576,7 @@ export function TraceGraph3D({ graph, familiars, selection, onSelect, memoryCoun
         <div className="rounded-lg border border-white/10 bg-black/45 px-3 py-2 shadow-2xl backdrop-blur">
           <div className="text-[10px] font-semibold uppercase tracking-widest text-white/55">3D trace graph</div>
           <div className="mt-1 flex flex-wrap gap-2 text-[10px] text-white/70">
-            <span>{graph.nodes.length} agents</span>
+            <span>{graph.nodes.length} familiars</span>
             <span>{graph.edges.length} routes</span>
             <span>{graph.traces.length} traces</span>
           </div>

--- a/src/lib/memory-rows.test.ts
+++ b/src/lib/memory-rows.test.ts
@@ -122,7 +122,7 @@ const grows = [
 // type → Agent memories first, then Files; counts correct
 {
   const g = groupMemoryRows(grows, "type");
-  assert.deepEqual(g.map((x) => x.label), ["Agent memories", "Files"]);
+  assert.deepEqual(g.map((x) => x.label), ["Familiar memories", "Files"]);
   assert.equal(g[0].rows.length, 1);
   assert.equal(g[1].rows.length, 2);
 }

--- a/src/lib/memory-rows.ts
+++ b/src/lib/memory-rows.ts
@@ -104,7 +104,7 @@ export function buildMemoryRows(args: BuildArgs): MemoryRow[] {
 
 export type MemoryRowGroup = { key: string; label: string; rows: MemoryRow[] };
 
-const TYPE_LABEL: Record<MemoryRowKind, string> = { agent: "Agent memories", file: "Files" };
+const TYPE_LABEL: Record<MemoryRowKind, string> = { agent: "Familiar memories", file: "Files" };
 
 function rowDateBucket(iso: string, now: number): { key: string; label: string } {
   const t = Date.parse(iso);


### PR DESCRIPTION
## What
"Familiar" is the canonical product term (~1270 uses in `src/`), but ~24 user-facing strings still said "Agent" — most tellingly the **Handoff modal**, which already types everything as `Familiar` internally (`/api/familiars`, `familiarId`, `onLaunched(familiarId,...)`) yet labeled its button **"Handoff to Agent"**.

This converts **user-facing text only** to "Familiar":
- **Handoff to Agent → Handoff to Familiar** (label, aria-label, title, modal select label)
- Agent Memory / Agent memories / Agent memory → Familiar … (memory tab heading, reader, row labels)
- Open agent panel → Open familiar panel (top-bar aria + tooltip)
- "Agent" filter + "Filter workspace by agent" → Familiar … (sidebar)
- Selected agent / Search agent / "N agents" → familiar(s) (calls view, trace graph)
- Open the agent inspector → … familiar inspector (chat rail)
- Agent runtime → Familiar runtime (chat-list panel footer)
- inbox `KIND_LABEL` agent → "Familiar" (calendar)
- mockup demo labels (Create Agent → Create Familiar, placeholders)

## Deliberately left unchanged
Not user-facing or legitimately "agent": internal identifiers/components/routes/CSS (`AgentsView`, `agentPanel`, `/api/openclaw-agents`, `.agent-panel-dossier`), data enums (`MemoryRowKind "agent"`, `InboxItem` kind `"agent"`), OpenClaw/Hermes product names, `User-Agent` HTTP headers, the workflow **agent** step taxonomy, and the ai-toggle `manual|agent` mode.

## Verification
- Audited all ~303 "Agent"/"agent" occurrences; classified user-facing vs identifier vs legitimate.
- Updated the **6 source-text tests** that pinned the old strings.
- `tsc --noEmit` clean (0 errors); affected suites pass; pure string swaps (+37/−37).

## Follow-up (not in this PR)
A deeper **identifier-level** rename (`AgentsView`→`FamiliarsView`, `agentPanel`→`familiarPanel`, `/api/openclaw-agents`, storage keys, CSS classes) is a larger, riskier refactor — happy to do it separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)