### PR TITLE
feat(updates): native in-app auto-updater (download, install, relaunch)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,11 +221,19 @@ jobs:
         uses: tauri-apps/tauri-action@1ddc7b49b13c3038297360482fcb3e058764d7c9 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Sign the updater artifacts (createUpdaterArtifacts in tauri.conf.json).
+          # Linux/Windows .sig files are uploaded next to the AppImage/MSI; the
+          # latest.json aggregation job composes the manifest from them.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: ${{ env.RELEASE_TAG }}
           releaseName: "CovenCave ${{ env.RELEASE_TAG }}"
           releaseDraft: false
           prerelease: false
+          # latest.json is built by the dedicated `updater-manifest` job after
+          # all platforms upload their signed artifacts — per-job generation
+          # here would clobber the manifest with a single platform.
           includeUpdaterJson: false
           args: ${{ matrix.args }}
 
@@ -245,6 +253,10 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # Updater signing key — release.sh regenerates the .app.tar.gz from the
+          # FINAL notarized .app and signs it, so the updated app stays notarized.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
           set -euo pipefail
           bash scripts/release.sh "$RELEASE_VERSION"
@@ -269,6 +281,17 @@ jobs:
           fi
           mv "$SRC" "$DST"
           echo "Renamed to $DST"
+          # Per-arch updater artifact (if release.sh produced it). The macOS
+          # updater bundle is the signed .app.tar.gz; name it per-arch so the
+          # Intel and Apple Silicon legs upload distinct assets.
+          TARBALL="release/CovenCave.app.tar.gz"
+          if [ -f "$TARBALL" ]; then
+            mv "$TARBALL" "release/CovenCave-v${RELEASE_VERSION}-${{ matrix.arch_suffix }}.app.tar.gz"
+            mv "${TARBALL}.sig" "release/CovenCave-v${RELEASE_VERSION}-${{ matrix.arch_suffix }}.app.tar.gz.sig"
+            echo "Renamed updater artifact for ${{ matrix.arch_suffix }}"
+          else
+            echo "::warning::No updater .app.tar.gz from release.sh (auto-update unavailable for this arch)"
+          fi
 
       # Hard gate: fail the macOS leg if the produced DMG is not accepted
       # by Gatekeeper as a notarized Developer ID app. This is what makes
@@ -314,7 +337,10 @@ jobs:
         uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.3.3
         with:
           tag_name: ${{ env.RELEASE_TAG }}
-          files: release/CovenCave-v${{ env.RELEASE_VERSION }}-${{ matrix.arch_suffix }}.dmg
+          files: |
+            release/CovenCave-v${{ env.RELEASE_VERSION }}-${{ matrix.arch_suffix }}.dmg
+            release/CovenCave-v${{ env.RELEASE_VERSION }}-${{ matrix.arch_suffix }}.app.tar.gz
+            release/CovenCave-v${{ env.RELEASE_VERSION }}-${{ matrix.arch_suffix }}.app.tar.gz.sig
 
   checksums:
     name: Publish SHA256SUMS
@@ -400,3 +426,45 @@ jobs:
           cat /tmp/release-body.md
           echo "--- end body ---"
           gh release edit "$RELEASE_TAG" --notes-file /tmp/release-body.md
+
+  # Compose the Tauri auto-update manifest (latest.json) from the signed
+  # updater artifacts each platform uploaded, then attach it to the release.
+  # The desktop app's updater endpoint points at
+  # releases/latest/download/latest.json. Runs after every build leg so the
+  # manifest reflects all platforms that produced a signed artifact.
+  updater-manifest:
+    name: Publish updater manifest (latest.json)
+    needs: build
+    runs-on: ubuntu-22.04
+    if: success()
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Resolve release tag
+        shell: bash
+        env:
+          RAW_RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          TAG="$RAW_RELEASE_TAG"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid release tag. Expected format: vMAJOR.MINOR.PATCH[-PRERELEASE]"
+            exit 1
+          fi
+          echo "RELEASE_TAG=$TAG" >> "$GITHUB_ENV"
+
+      - name: Generate latest.json
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          node scripts/generate-latest-json.mjs "$RELEASE_TAG" "${RELEASE_TAG#v}" > latest.json
+          echo "--- latest.json ---"
+          cat latest.json
+
+      - name: Upload latest.json to GitHub Release
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.3.3
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          files: latest.json

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "@tauri-apps/api": "2.11.0",
     "@tauri-apps/plugin-notification": "2.3.3",
     "@tauri-apps/plugin-os": "2.3.2",
+    "@tauri-apps/plugin-process": "2.3.1",
+    "@tauri-apps/plugin-updater": "2.10.1",
     "@types/qrcode": "1.5.6",
     "@xterm/addon-fit": "0.11.0",
     "@xterm/addon-web-links": "0.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,12 @@ importers:
       '@tauri-apps/plugin-os':
         specifier: 2.3.2
         version: 2.3.2
+      '@tauri-apps/plugin-process':
+        specifier: 2.3.1
+        version: 2.3.1
+      '@tauri-apps/plugin-updater':
+        specifier: 2.10.1
+        version: 2.10.1
       '@types/qrcode':
         specifier: 1.5.6
         version: 1.5.6
@@ -787,6 +793,12 @@ packages:
 
   '@tauri-apps/plugin-os@2.3.2':
     resolution: {integrity: sha512-n+nXWeuSeF9wcEsSPmRnBEGrRgOy6jjkSU+UVCOV8YUGKb2erhDOxis7IqRXiRVHhY8XMKks00BJ0OAdkpf6+A==}
+
+  '@tauri-apps/plugin-process@2.3.1':
+    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
 
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
@@ -1849,6 +1861,14 @@ snapshots:
       '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-os@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-process@2.3.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-updater@2.10.1':
     dependencies:
       '@tauri-apps/api': 2.11.0
 

--- a/scripts/generate-latest-json.mjs
+++ b/scripts/generate-latest-json.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// Build the Tauri updater manifest (latest.json) from a published GitHub
+// release by discovering the signed updater artifacts already uploaded by the
+// build matrix. We DISCOVER `<artifact>` + `<artifact>.sig` pairs rather than
+// hardcoding installer names, so it's robust to per-platform naming (esp. the
+// Windows .msi vs .msi.zip variance across Tauri versions).
+//
+//   node scripts/generate-latest-json.mjs <tag> [version] > latest.json
+//
+// Platforms are included only when a signed artifact exists; missing platforms
+// are logged and skipped (the app falls back to manual download for those).
+import { execFileSync } from "node:child_process";
+import { readFileSync, mkdtempSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const [tag, versionArg] = process.argv.slice(2);
+if (!tag) {
+  console.error("usage: generate-latest-json.mjs <tag> [version]");
+  process.exit(1);
+}
+const repo = process.env.RELEASE_REPO || "OpenCoven/coven-cave";
+const version = (versionArg || tag).replace(/^v/, "");
+
+const gh = (args) => execFileSync("gh", args, { encoding: "utf8" });
+
+const assets = JSON.parse(
+  gh(["release", "view", tag, "--repo", repo, "--json", "assets"]),
+).assets.map((a) => a.name);
+
+// Pull every signature file so we can read its contents locally.
+const dir = mkdtempSync(join(tmpdir(), "latestjson-"));
+try {
+  gh(["release", "download", tag, "--repo", repo, "--dir", dir, "--pattern", "*.sig", "--clobber"]);
+} catch (e) {
+  console.error("warning: failed to download .sig assets:", e.message);
+}
+
+const sigFor = (name) => {
+  const p = join(dir, `${name}.sig`);
+  return existsSync(p) ? readFileSync(p, "utf8").trim() : null;
+};
+const urlFor = (name) =>
+  `https://github.com/${repo}/releases/download/${tag}/${encodeURIComponent(name)}`;
+
+const platforms = {};
+const add = (key, predicate) => {
+  const artifact = assets.find((n) => !n.endsWith(".sig") && predicate(n) && sigFor(n));
+  if (!artifact) {
+    console.error(`skip ${key}: no signed artifact found`);
+    return;
+  }
+  platforms[key] = { signature: sigFor(artifact), url: urlFor(artifact) };
+  console.error(`include ${key}: ${artifact}`);
+};
+
+add("darwin-aarch64", (n) => n.endsWith("-aarch64.app.tar.gz"));
+add("darwin-x86_64", (n) => n.endsWith("-x86_64.app.tar.gz"));
+add("linux-x86_64", (n) => n.endsWith(".AppImage"));
+add(
+  "windows-x86_64",
+  (n) => n.endsWith(".msi.zip") || n.endsWith(".nsis.zip") || n.endsWith(".msi") || n.endsWith("-setup.exe"),
+);
+
+if (Object.keys(platforms).length === 0) {
+  console.error("ERROR: no signed updater artifacts found on the release; refusing to write an empty manifest");
+  process.exit(2);
+}
+
+const manifest = { version, pub_date: new Date().toISOString(), platforms };
+process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`);

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -311,6 +311,32 @@ else
   echo "$SHA  $DMG_BASENAME" > "$SUMS_PATH"
 fi
 echo "Wrote checksum entry to $SUMS_PATH"
+
+# ── Updater artifact (desktop auto-update) ───────────────────────────────
+# Tauri's build-time .app.tar.gz predates this script's manual re-sign +
+# notarization, so regenerate it from the FINAL stapled .app and sign it with
+# the updater key. The Tauri updater verifies the minisign signature; the
+# installed app must still pass Gatekeeper, which only the notarized bundle
+# does. Non-fatal by design: a failure here must never sink a release — the
+# DMG is the source of truth and the app falls back to manual download.
+if [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+  echo ""
+  echo "==> Building signed updater artifact (.app.tar.gz)"
+  UPDATER_TARBALL="$DMG_DIR/CovenCave.app.tar.gz"
+  if tar -czf "$UPDATER_TARBALL" -C "$(dirname "$APP_PATH")" "$(basename "$APP_PATH")"; then
+    if pnpm exec tauri signer sign "$UPDATER_TARBALL"; then
+      echo "    wrote $UPDATER_TARBALL (+ .sig)"
+    else
+      echo "    ! updater signing failed; skipping updater artifact" >&2
+      rm -f "$UPDATER_TARBALL"
+    fi
+  else
+    echo "    ! updater tarball creation failed; skipping" >&2
+  fi
+else
+  echo "==> TAURI_SIGNING_PRIVATE_KEY unset; skipping updater artifact"
+fi
+
 echo ""
 echo "Signature:"
 codesign -d --verbose=2 "$APP_PATH" 2>&1 | grep -E "Authority|TeamIdentifier|Identifier|Timestamp"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -91,6 +91,17 @@ dependencies = [
  "tauri-plugin-log",
  "tauri-plugin-notification",
  "tauri-plugin-os",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
 ]
 
 [[package]]
@@ -800,6 +811,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1139,16 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1700,6 +1732,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1964,6 +2011,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,6 +2265,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2487,6 +2570,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2550,6 +2645,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,6 +2680,20 @@ dependencies = [
  "objc2-ui-kit",
  "serde",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3121,15 +3236,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3139,6 +3259,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3216,6 +3350,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3228,6 +3435,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3292,6 +3508,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3572,6 +3811,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3690,6 +3939,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3782,7 +4037,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -3822,6 +4077,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3844,7 +4110,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -4016,6 +4282,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4025,7 +4334,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -4048,7 +4357,7 @@ checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -4269,6 +4578,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4591,6 +4910,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4895,6 +5220,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5095,11 +5429,29 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -5135,11 +5487,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5173,6 +5542,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5183,6 +5558,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5197,10 +5578,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5215,6 +5608,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5225,6 +5624,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5239,6 +5644,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5249,6 +5660,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -5411,7 +5828,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -5465,6 +5882,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -5593,6 +6020,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5623,6 +6056,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,3 +49,8 @@ tauri-plugin-os = "2"
 [target.'cfg(not(any(target_os = "ios", target_os = "android")))'.dependencies]
 tauri = { version = "2.11.2", features = ["tray-icon"] }
 portable-pty = "0.8"
+# Desktop auto-update: the updater plugin checks/downloads/installs signed
+# release artifacts; process gives us relaunch() after an install. Both are
+# desktop-only (mobile updates via the App Store / TestFlight).
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,8 @@
     "notification:default",
     "notification:allow-notify",
     "notification:allow-request-permission",
-    "notification:allow-is-permission-granted"
+    "notification:allow-is-permission-granted",
+    "updater:default",
+    "process:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -874,6 +874,11 @@ pub fn run() {
 
             app.handle().plugin(tauri_plugin_notification::init())?;
 
+            // Desktop auto-update: updater checks/downloads/installs signed
+            // release artifacts; process provides relaunch() after install.
+            app.handle().plugin(tauri_plugin_updater::Builder::new().build())?;
+            app.handle().plugin(tauri_plugin_process::init())?;
+
             check_app_translocation();
 
             // Dev builds: when the configured dev server (tauri.conf.json

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,8 +16,17 @@
       "csp": null
     }
   },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/OpenCoven/coven-cave/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEVBREJCNjNFRjBCMDk3QUIKUldTcmw3RHdQcmJiNmxiaEpuV1NDRlVHNzNkYWlMVzlRNnVGZXNRTHZEM1luV251OVRUbk0zdXUK"
+    }
+  },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": [
       "dmg",
       "app",

--- a/src/components/update-available.test.ts
+++ b/src/components/update-available.test.ts
@@ -7,20 +7,29 @@ const src = await readFile(new URL("./update-available.tsx", import.meta.url), "
 // Desktop-only: both surfaces gate on the Tauri desktop hook.
 assert.match(src, /useIsTauriDesktop/, "gates the update UI to the Tauri desktop build");
 
-// Pulls status from the server route (avoids client CORS / rate limits).
-assert.match(src, /\/api\/app\/latest-release/, "fetches update status from the API route");
+// Native updater path: check() → downloadAndInstall() → relaunch().
+assert.match(src, /@tauri-apps\/plugin-updater/, "uses the native Tauri updater plugin");
+assert.match(src, /downloadAndInstall/, "installs via the native updater");
+assert.match(src, /@tauri-apps\/plugin-process/, "relaunches via the process plugin");
+assert.match(src, /relaunch\(\)/, "relaunches the app after install");
 
-// Banner trigger pushes a dismissible shell banner with a Download CTA.
+// Graceful fallback when no updater-enabled release exists yet.
+assert.match(src, /\/api\/app\/latest-release/, "falls back to the server release check");
+assert.match(src, /openExternalUrl/, "fallback opens the release page in the system browser");
+
+// Both surfaces are exported and resolve native-first.
 assert.match(src, /export function UpdateBannerTrigger/, "exports the banner trigger");
-assert.match(src, /pushBanner\(/, "pushes a shell banner when an update is available");
-assert.match(src, /label: "Download"[\s\S]*openExternalUrl/, "banner Download CTA opens the release URL");
+assert.match(src, /export function UpdateSettingsRow/, "exports the settings row");
+assert.match(src, /async function resolveUpdate/, "resolves native-first, then fallback");
 
-// Per-version dismissal persists across launches.
+// Banner: dismissible CTA, persisted per version.
+assert.match(src, /pushBanner\(/, "pushes a shell banner when an update is available");
 assert.match(src, /cave:update:dismissed:/, "persists dismissal keyed by version");
 assert.match(src, /onDismiss:\s*\(\)\s*=>\s*markDismissed/, "dismissing the banner records it for that version");
 
-// Settings row exposes Download (when newer) and a manual Check action.
-assert.match(src, /export function UpdateSettingsRow/, "exports the settings row");
+// Settings row exposes install / download / progress / manual recheck.
+assert.match(src, /Install &amp; restart/, "native path offers install + restart");
+assert.match(src, /Downloading…/, "shows download progress");
 assert.match(src, /Check for updates/, "settings row offers a manual re-check");
 
 console.log("update-available.test.ts: ok");

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { Icon } from "@/lib/icon";
-import { useIsTauriDesktop } from "@/lib/tauri-platform";
+import { isTauri, useIsTauriDesktop } from "@/lib/tauri-platform";
 import { useShellBanners } from "@/lib/shell-banners";
 import { openExternalUrl } from "@/lib/open-external";
 import type { UpdateStatus } from "@/lib/app-update";
 
 const BANNER_ID = "update-available";
+const RELEASES_PAGE = "https://github.com/OpenCoven/coven-cave/releases/latest";
 const DISMISS_KEY = (version: string) => `cave:update:dismissed:${version}`;
 
 function isDismissed(version: string): boolean {
@@ -28,7 +29,59 @@ function markDismissed(version: string): void {
   }
 }
 
-async function fetchUpdateStatus(): Promise<UpdateStatus | null> {
+// Minimal shape of the plugin-updater Update we depend on.
+type TauriUpdate = {
+  version: string;
+  available?: boolean;
+  downloadAndInstall: (onEvent?: (e: DownloadEvent) => void) => Promise<void>;
+};
+type DownloadEvent =
+  | { event: "Started"; data?: { contentLength?: number } }
+  | { event: "Progress"; data?: { chunkLength?: number } }
+  | { event: "Finished" };
+
+/**
+ * Try the native Tauri updater. Returns the Update handle when a newer signed
+ * release is available, or null when up to date / unavailable (no endpoint yet,
+ * not a desktop build, plugin error). Never throws.
+ */
+async function checkNativeUpdate(): Promise<TauriUpdate | null> {
+  if (!isTauri()) return null;
+  try {
+    const { check } = await import("@tauri-apps/plugin-updater");
+    const update = (await check()) as TauriUpdate | null;
+    if (!update) return null;
+    // Older plugin versions expose `.available`; newer return null when none.
+    if (update.available === false) return null;
+    return update;
+  } catch {
+    return null; // endpoint missing / not signed yet → caller falls back
+  }
+}
+
+/** Download + install a native update, reporting 0–100 progress, then relaunch. */
+async function installNativeUpdate(
+  update: TauriUpdate,
+  onProgress: (pct: number) => void,
+): Promise<void> {
+  let total = 0;
+  let received = 0;
+  await update.downloadAndInstall((e) => {
+    if (e.event === "Started") {
+      total = e.data?.contentLength ?? 0;
+    } else if (e.event === "Progress") {
+      received += e.data?.chunkLength ?? 0;
+      if (total > 0) onProgress(Math.min(99, Math.round((received / total) * 100)));
+    } else if (e.event === "Finished") {
+      onProgress(100);
+    }
+  });
+  const { relaunch } = await import("@tauri-apps/plugin-process");
+  await relaunch();
+}
+
+/** Lightweight fallback: ask the server route what the latest release is. */
+async function fetchFallbackStatus(): Promise<UpdateStatus | null> {
   try {
     const res = await fetch("/api/app/latest-release", { cache: "no-store" });
     if (!res.ok) return null;
@@ -38,10 +91,23 @@ async function fetchUpdateStatus(): Promise<UpdateStatus | null> {
   }
 }
 
+type Resolved =
+  | { kind: "current" }
+  | { kind: "native"; version: string; update: TauriUpdate }
+  | { kind: "fallback"; version: string; url: string };
+
+/** Native-first, then fallback. Used by both the banner and the settings row. */
+async function resolveUpdate(): Promise<Resolved> {
+  const native = await checkNativeUpdate();
+  if (native) return { kind: "native", version: native.version, update: native };
+  const fb = await fetchFallbackStatus();
+  if (fb?.available && fb.latest) return { kind: "fallback", version: fb.latest, url: fb.url };
+  return { kind: "current" };
+}
+
 /**
- * Desktop-only. Checks for a newer release on mount and, if one is available and
- * hasn't been dismissed for that version, pushes a dismissible shell banner.
- * Renders nothing. Mount once inside <ShellBannersProvider>.
+ * Desktop-only. On mount, checks for an update and (if available and not
+ * dismissed for that version) shows a dismissible shell banner. Renders nothing.
  */
 export function UpdateBannerTrigger() {
   const isDesktop = useIsTauriDesktop();
@@ -50,21 +116,38 @@ export function UpdateBannerTrigger() {
   useEffect(() => {
     if (!isDesktop) return;
     let cancelled = false;
-    void fetchUpdateStatus().then((status) => {
-      if (cancelled || !status?.available || !status.latest) return;
-      if (isDismissed(status.latest)) return;
-      const latest = status.latest;
+    void resolveUpdate().then((r) => {
+      if (cancelled || r.kind === "current") return;
+      if (isDismissed(r.version)) return;
+
       pushBanner({
         id: BANNER_ID,
         severity: "info",
-        title: `Update available — v${latest}`,
-        cta: { label: "Download", onClick: () => void openExternalUrl(status.url) },
-        onDismiss: () => markDismissed(latest),
+        title: `Update available — v${r.version}`,
+        cta: {
+          label: r.kind === "native" ? "Install & restart" : "Download",
+          onClick: () => {
+            if (r.kind === "native") {
+              pushBanner({ id: BANNER_ID, severity: "info", title: `Downloading update v${r.version}…` });
+              void installNativeUpdate(r.update, () => {}).catch(() => {
+                pushBanner({
+                  id: BANNER_ID,
+                  severity: "warning",
+                  title: "Update failed — open the release page",
+                  cta: { label: "Open", onClick: () => void openExternalUrl(RELEASES_PAGE) },
+                  onDismiss: () => markDismissed(r.version),
+                });
+              });
+            } else {
+              void openExternalUrl(r.url);
+            }
+          },
+        },
+        onDismiss: () => markDismissed(r.version),
       });
     });
     return () => {
       cancelled = true;
-      // Drop the banner if this trigger unmounts (e.g. shell teardown).
       dismissBanner(BANNER_ID);
     };
   }, [isDesktop, pushBanner, dismissBanner]);
@@ -72,63 +155,103 @@ export function UpdateBannerTrigger() {
   return null;
 }
 
+type RowState =
+  | { phase: "checking" }
+  | { phase: "current"; error?: boolean }
+  | { phase: "available"; r: Extract<Resolved, { kind: "native" | "fallback" }> }
+  | { phase: "downloading"; version: string; pct: number }
+  | { phase: "ready"; version: string };
+
 /**
- * Desktop-only row for Settings ▸ About. Shows the current update state and a
- * Download (when newer) or Check (when current) action. Renders nothing on web.
+ * Desktop-only row for Settings ▸ About. Native updater when available
+ * (Install & restart with progress), else a Download link to the release page.
  */
 export function UpdateSettingsRow() {
   const isDesktop = useIsTauriDesktop();
-  const [status, setStatus] = useState<UpdateStatus | null>(null);
-  const [checking, setChecking] = useState(false);
+  const [state, setState] = useState<RowState>({ phase: "checking" });
+  const mounted = useRef(true);
 
   const check = useCallback(() => {
-    setChecking(true);
-    void fetchUpdateStatus()
-      .then((s) => setStatus(s))
-      .finally(() => setChecking(false));
+    setState({ phase: "checking" });
+    void resolveUpdate().then((r) => {
+      if (!mounted.current) return;
+      if (r.kind === "current") setState({ phase: "current" });
+      else setState({ phase: "available", r });
+    });
   }, []);
 
   useEffect(() => {
+    mounted.current = true;
     if (isDesktop) check();
+    return () => {
+      mounted.current = false;
+    };
   }, [isDesktop, check]);
 
   if (!isDesktop) return null;
 
+  const install = (update: TauriUpdate, version: string) => {
+    setState({ phase: "downloading", version, pct: 0 });
+    void installNativeUpdate(update, (pct) => {
+      if (mounted.current) setState({ phase: "downloading", version, pct });
+    })
+      .then(() => {
+        if (mounted.current) setState({ phase: "ready", version });
+      })
+      .catch(() => {
+        if (mounted.current) setState({ phase: "current", error: true });
+      });
+  };
+
+  const accentBtn =
+    "flex items-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-3 py-1 text-[11px] font-semibold text-white transition-opacity hover:opacity-90";
+
+  let control: ReactNode;
+  if (state.phase === "checking") {
+    control = <span className="text-[12px] text-[var(--text-muted)]">Checking…</span>;
+  } else if (state.phase === "downloading") {
+    control = <span className="text-[12px] text-[var(--text-muted)]">Downloading… {state.pct}%</span>;
+  } else if (state.phase === "ready") {
+    control = <span className="text-[12px] font-medium text-[var(--text-primary)]">Restarting…</span>;
+  } else if (state.phase === "available") {
+    const r = state.r; // narrowed to native | fallback
+    control = (
+      <>
+        <span className="text-[12px] font-medium text-[var(--text-primary)]">v{r.version} available</span>
+        {r.kind === "native" ? (
+          <button type="button" onClick={() => install(r.update, r.version)} className={accentBtn}>
+            <Icon name="ph:arrow-down-bold" width={12} />
+            Install &amp; restart
+          </button>
+        ) : (
+          <button type="button" onClick={() => void openExternalUrl(r.url)} className={accentBtn}>
+            <Icon name="ph:arrow-square-out" width={12} />
+            Download
+          </button>
+        )}
+      </>
+    );
+  } else {
+    control = (
+      <>
+        <span className="text-[12px] text-[var(--text-muted)]">
+          {state.error ? "Update failed" : "Up to date"}
+        </span>
+        <button
+          type="button"
+          onClick={check}
+          className="rounded-md border border-[var(--border-hairline)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+        >
+          Check for updates
+        </button>
+      </>
+    );
+  }
+
   return (
     <div className="flex items-center justify-between gap-4 px-4 py-3">
       <span className="text-[12px] text-[var(--text-secondary)]">Updates</span>
-      <div className="flex items-center gap-2">
-        {checking ? (
-          <span className="text-[12px] text-[var(--text-muted)]">Checking…</span>
-        ) : status?.available && status.latest ? (
-          <>
-            <span className="text-[12px] font-medium text-[var(--text-primary)]">
-              v{status.latest} available
-            </span>
-            <button
-              type="button"
-              onClick={() => void openExternalUrl(status.url)}
-              className="flex items-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-3 py-1 text-[11px] font-semibold text-white transition-opacity hover:opacity-90"
-            >
-              <Icon name="ph:arrow-square-out" width={12} />
-              Download
-            </button>
-          </>
-        ) : (
-          <>
-            <span className="text-[12px] text-[var(--text-muted)]">
-              {status?.error ? "Check failed" : "Up to date"}
-            </span>
-            <button
-              type="button"
-              onClick={check}
-              className="rounded-md border border-[var(--border-hairline)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
-            >
-              Check for updates
-            </button>
-          </>
-        )}
-      </div>
+      <div className="flex items-center gap-2">{control}</div>
     </div>
   );
 }


### PR DESCRIPTION
## What

Upgrades #599's "open the release page" affordance to the **full Tauri v2 auto-updater**: the desktop app checks a signed `latest.json`, **downloads + installs in place, and relaunches** — with a graceful fallback to the GitHub release page when no updater-enabled release exists yet.

## App / config (verified by PR CI)

- `@tauri-apps/plugin-updater` + `@tauri-apps/plugin-process` (JS) and `tauri-plugin-updater` + `tauri-plugin-process` (Rust, **desktop-only** target — mobile untouched)
- plugins registered in the desktop `setup()`
- `tauri.conf.json`: `createUpdaterArtifacts: true` + `plugins.updater` (GitHub `latest.json` endpoint + embedded minisign **pubkey**)
- `capabilities/default.json`: `updater:default`, `process:default`
- `update-available.tsx`: native `check() → downloadAndInstall(progress) → relaunch()` in **Settings ▸ About** and the **dismissible banner**; falls back to `/api/app/latest-release` + open-release-page when native is unavailable/errors

## Release pipeline ⚠️ validated only on the next tagged release

- `release.yml`: `TAURI_SIGNING_PRIVATE_KEY` (+ password) passed to all build legs; new **`updater-manifest`** job composes `latest.json` from the signed artifacts (`scripts/generate-latest-json.mjs`, which *discovers* signed artifacts so it's robust to per-platform naming) and attaches it
- `release.sh`: regenerates the macOS `.app.tar.gz` from the **final notarized** `.app` and signs it — **non-fatal**, so it can never sink the proven DMG/notarization path

## Signing key

Keypair generated; `TAURI_SIGNING_PRIVATE_KEY` (+ `_PASSWORD`) set as repo secrets. **Private key backed up at `~/.tauri/coven-cave-updater.key` — must be saved off-machine (GitHub secrets can't be read back; losing it breaks updates for installed apps).**

## Verification

- `tsc` clean · `cargo check` clean (plugins compile) · full `test:app`/`test:api` exit 0 · `check:tests-wired` (278) · `release.yml` YAML valid · `release.sh`/`generate-latest-json.mjs` syntax-checked · **production `pnpm build` exit 0**, `/api/app/latest-release` registered.
- The PR's required checks (Frontend build, Rust check, CodeQL) exercise the app/Rust/config side. The `release.yml`/`release.sh` paths only run on a tag, so **cut a `v0.0.x` after merge and watch the release** to validate signed-artifact generation + `latest.json` before relying on auto-update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)