### PR TITLE
Fix composer sizing and reading previews

### DIFF
--- a/src/components/chat-view-first-class.test.ts
+++ b/src/components/chat-view-first-class.test.ts
@@ -7,8 +7,26 @@ const styles = readFileSync(new URL("../styles/cave-chat.css", import.meta.url),
 
 assert.match(
   source,
-  /function resizeComposer\(\)[\s\S]*?Math\.min\(el\.scrollHeight,\s*220\)/,
+  /function resizeComposer\(\)[\s\S]*?Math\.min\(el\.scrollHeight,\s*maxHeight\)/,
   "Chat composer should auto-grow up to a bounded height",
+);
+
+assert.match(
+  source,
+  /const COMPOSER_MAX_HEIGHT = 220;/,
+  "Chat composer should keep its scroll threshold aligned with the 6-8 row desktop height",
+);
+
+assert.match(
+  source,
+  /const computedMaxHeight = Number\.parseFloat\(window\.getComputedStyle\(el\)\.maxHeight\);[\s\S]*const maxHeight = Number\.isFinite\(computedMaxHeight\) \? computedMaxHeight : COMPOSER_MAX_HEIGHT;/,
+  "Chat composer should honor the responsive CSS max-height while resizing",
+);
+
+assert.match(
+  source,
+  /const isOverflowing = el\.scrollHeight > maxHeight;[\s\S]*el\.style\.overflowY = isOverflowing \? "auto" : "hidden";/,
+  "Chat composer should only enable internal scrolling after it reaches the height cap",
 );
 
 assert.match(
@@ -61,8 +79,8 @@ assert.match(
 
 assert.match(
   styles,
-  /\.cave-composer-input\s*\{[\s\S]*max-height:\s*220px[\s\S]*overflow-y:\s*auto/,
-  "Composer textarea should have bounded scrolling styles",
+  /\.cave-composer-input\s*\{[\s\S]*min-height:\s*96px[\s\S]*max-height:\s*220px[\s\S]*overflow-x:\s*hidden[\s\S]*overflow-y:\s*hidden/,
+  "Composer textarea should start taller without showing scroll overflow",
 );
 
 console.log("chat-view-first-class.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -147,6 +147,8 @@ type FailedSend = {
   mentionedFiles?: string[];
 };
 
+const COMPOSER_MAX_HEIGHT = 220;
+
 function shouldKeepLiveNewChatState({
   sessionId,
   currentSessionId,
@@ -1845,8 +1847,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   function resizeComposer() {
     const el = inputRef.current;
     if (!el) return;
+    const computedMaxHeight = Number.parseFloat(window.getComputedStyle(el).maxHeight);
+    const maxHeight = Number.isFinite(computedMaxHeight) ? computedMaxHeight : COMPOSER_MAX_HEIGHT;
     el.style.height = "auto";
-    el.style.height = `${Math.min(el.scrollHeight, 220)}px`;
+    el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
+    const isOverflowing = el.scrollHeight > maxHeight;
+    el.style.overflowY = isOverflowing ? "auto" : "hidden";
   }
 
   useEffect(() => {

--- a/src/components/library-doc-preview.tsx
+++ b/src/components/library-doc-preview.tsx
@@ -49,6 +49,17 @@ function fmtDate(iso?: string): string {
 }
 
 type UrlOpenKind = "web" | "github" | "vscode-file";
+const SIDECAR_TOKEN_PARAM = "covenCaveToken";
+const SIDECAR_STORAGE_KEY = "coven-cave:sidecar-auth-token";
+
+function readSidecarAuthToken(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.sessionStorage.getItem(SIDECAR_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
 
 function canOpenUrl(url: string, kind: UrlOpenKind): boolean {
   if (kind === "github") return isSafeGitHubUrl(url);
@@ -1068,9 +1079,12 @@ function DocDetail({ doc, docNav }: { doc: LibraryDocBody; docNav?: DocNav }) {
 // Falls back to a "Open in system viewer" button if the path is unavailable.
 function PdfViewer({ localPath, title }: { localPath: string; title: string }) {
   const [error, setError] = useState(false);
+  const [sidecarAuthToken] = useState(() => readSidecarAuthToken());
   // Use the Next.js API route to serve the PDF (safe, no file:// CSP issues)
   const filename = localPath.split("/").pop() ?? "";
-  const iframeUrl = `/api/library/pdf?file=${encodeURIComponent(filename)}`;
+  const iframeUrl = sidecarAuthToken
+    ? `/api/library/pdf?file=${encodeURIComponent(filename)}&${SIDECAR_TOKEN_PARAM}=${encodeURIComponent(sidecarAuthToken)}`
+    : `/api/library/pdf?file=${encodeURIComponent(filename)}`;
   // file:// fallback for Tauri desktop mode
   const fileUrl = `file://${localPath}`;
 

--- a/src/components/library-link-viewer.test.ts
+++ b/src/components/library-link-viewer.test.ts
@@ -74,6 +74,18 @@ assert.match(
 
 assert.match(
   preview,
+  /const SIDECAR_TOKEN_PARAM = "covenCaveToken";[\s\S]*const SIDECAR_STORAGE_KEY = "coven-cave:sidecar-auth-token";[\s\S]*function readSidecarAuthToken\(\)[\s\S]*window\.sessionStorage\.getItem\(SIDECAR_STORAGE_KEY\)/,
+  "PDF previews should read the sidecar token saved by SidecarAuthBridge",
+);
+
+assert.match(
+  preview,
+  /const iframeUrl = sidecarAuthToken[\s\S]*`\/api\/library\/pdf\?file=\$\{encodeURIComponent\(filename\)\}&\$\{SIDECAR_TOKEN_PARAM\}=\$\{encodeURIComponent\(sidecarAuthToken\)\}`[\s\S]*`\/api\/library\/pdf\?file=\$\{encodeURIComponent\(filename\)\}`/,
+  "PDF preview iframes should authenticate same-origin API navigation with covenCaveToken",
+);
+
+assert.match(
+  preview,
   /function GitHubDetail[\s\S]*<LibraryLinkViewer/,
   "GitHub selections should render the embedded Library link viewer",
 );

--- a/src/components/onboarding-guided-steps.test.ts
+++ b/src/components/onboarding-guided-steps.test.ts
@@ -132,6 +132,12 @@ assert.match(
   "SSH copy is explicit that Cave holds no secrets",
 );
 
+assert.match(
+  source,
+  /selectedHarnessId \? \([\s\S]*Create new Coven familiar[\s\S]*\) : selectedAgentId \? \([\s\S]*Connect selected existing agent[\s\S]*\) : null/,
+  "the familiar binding step shows only the CTA for the selected setup path",
+);
+
 // ── Editable familiars ──────────────────────────────────────────────────────
 
 assert.match(

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -2093,34 +2093,35 @@ function StepFamiliar(props: {
       </label>
 
       <div className="flex flex-wrap items-center gap-3">
-        <button
-          onClick={props.onCreateLocal}
-          disabled={
-            picking !== null ||
-            !selectedHarnessId ||
-            !confirmCreateNewFamiliar ||
-            (familiarGlyph.trim() !== "" && !familiarGlyph.trim().startsWith("ph:"))
-          }
-          className="focus-ring inline-flex items-center gap-2 rounded-md bg-[var(--accent-presence)] px-4 py-2 text-[13px] font-medium text-white hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-50"
-        >
-          <Icon name="ph:terminal-window" />
-          {picking === "local" ? "Creating..." : "Create new Coven familiar"}
-        </button>
-        <button
-          onClick={props.onConnectAgent}
-          disabled={
-            picking !== null ||
-            !selectedAgentId ||
-            familiarName.trim().length === 0 ||
-            (familiarGlyph.trim() !== "" && !familiarGlyph.trim().startsWith("ph:"))
-          }
-          className="focus-ring inline-flex items-center gap-2 rounded-md border border-[var(--border-strong)] bg-[var(--bg-raised)] px-4 py-2 text-[13px] text-[var(--text-primary)] hover:border-[var(--accent-presence)] disabled:opacity-50"
-        >
-          <Icon name="ph:sparkle" />
-          {picking === "familiar"
-            ? "Connecting..."
-            : "Connect selected existing agent"}
-        </button>
+        {selectedHarnessId ? (
+          <button
+            onClick={props.onCreateLocal}
+            disabled={
+              picking !== null ||
+              !confirmCreateNewFamiliar ||
+              (familiarGlyph.trim() !== "" && !familiarGlyph.trim().startsWith("ph:"))
+            }
+            className="focus-ring inline-flex items-center gap-2 rounded-md bg-[var(--accent-presence)] px-4 py-2 text-[13px] font-medium text-white hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-50"
+          >
+            <Icon name="ph:terminal-window" />
+            {picking === "local" ? "Creating..." : "Create new Coven familiar"}
+          </button>
+        ) : selectedAgentId ? (
+          <button
+            onClick={props.onConnectAgent}
+            disabled={
+              picking !== null ||
+              familiarName.trim().length === 0 ||
+              (familiarGlyph.trim() !== "" && !familiarGlyph.trim().startsWith("ph:"))
+            }
+            className="focus-ring inline-flex items-center gap-2 rounded-md border border-[var(--border-strong)] bg-[var(--bg-raised)] px-4 py-2 text-[13px] text-[var(--text-primary)] hover:border-[var(--accent-presence)] disabled:opacity-50"
+          >
+            <Icon name="ph:sparkle" />
+            {picking === "familiar"
+              ? "Connecting..."
+              : "Connect selected existing agent"}
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1304,8 +1304,10 @@ details[open] > .cave-tool-summary::before {
 }
 
 .cave-composer-input {
+  min-height: 96px;
   max-height: 220px;
-  overflow-y: auto;
+  overflow-x: hidden;
+  overflow-y: hidden;
   scrollbar-width: thin;
   scrollbar-color: color-mix(in oklch, var(--accent-presence) 22%, transparent) transparent;
 }


### PR DESCRIPTION
## Summary
- Make the chat composer start taller and only show internal scrolling after it reaches its responsive height cap.
- Show only the setup CTA that matches the selected onboarding path.
- Pass the sidecar auth token through Library PDF preview iframe URLs so reading-list PDFs do not render raw unauthorized JSON.

## Test Plan
- node --experimental-strip-types src/components/chat-view-first-class.test.ts
- node --experimental-strip-types src/components/chat-view-mobile-command-center.test.ts
- node --experimental-strip-types src/app/composer-zoom-smoke.test.ts
- node --experimental-strip-types src/components/onboarding-guided-steps.test.ts
- node --experimental-strip-types src/components/library-link-viewer.test.ts
- node --experimental-strip-types src/components/library-reader-polish.test.ts
- node --experimental-strip-types src/components/library-polish.test.ts
- node --experimental-strip-types src/proxy-behavior.test.ts
- pnpm typecheck
