### PR TITLE
fix(ui): popover stays within the viewport (auto-flip + clamp)

### DIFF
--- a/src/components/ui/popover.test.ts
+++ b/src/components/ui/popover.test.ts
@@ -13,4 +13,12 @@ assert.match(src, /e\.stopPropagation\(\)/, "popover stops Escape from propagati
 assert.match(src, /addEventListener\("keydown", onKey, true\)/, "popover keydown listens in the capture phase");
 assert.match(src, /removeEventListener\("keydown", onKey, true\)/, "popover keydown cleanup matches the capture phase");
 
+// Viewport-aware positioning: auto-flip to the opposite side when the preferred
+// side can't fit the popover, clamp horizontally, and cap height so it never
+// overflows the viewport (the color picker overflowed at laptop height before).
+assert.match(src, /scrollHeight/, "measures the popover's natural content height for fit checks");
+assert.match(src, /spaceBelow|spaceAbove/, "compares room below vs above the anchor to decide flip");
+assert.match(src, /Math\.min\(r\.left/, "clamps the left edge within the viewport");
+assert.match(src, /maxHeight/, "caps height (with overflowY:auto) so neither side overflows");
+
 console.log("popover.test.ts: ok");

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -49,21 +49,40 @@ export function Popover({
     const a = anchorRef.current;
     if (!a) return;
     const r = a.getBoundingClientRect();
-    const isTop = placement.startsWith("top");
+    const pop = popoverRef.current;
+    // scrollHeight = natural content height, stable regardless of the maxHeight we
+    // apply below (so the flip decision doesn't oscillate on reflow).
+    const popH = pop?.scrollHeight ?? 0;
+    const popW = pop?.offsetWidth ?? minWidth ?? r.width;
+    const MARGIN = 8;
+
+    // Vertical auto-flip: honor the requested side, but flip to the opposite side
+    // when the popover can't fit there and the other side has more room. Keeps it
+    // on-screen when the anchor sits low (or high) in the viewport.
+    const spaceBelow = window.innerHeight - r.bottom - offset;
+    const spaceAbove = r.top - offset;
+    const isTop = placement.startsWith("top")
+      ? !(popH > spaceAbove && spaceBelow > spaceAbove)
+      : popH > spaceBelow && spaceAbove > spaceBelow;
     const isEnd = placement.endsWith("end");
+
     const next: CSSProperties = {
       position: "absolute",
       minWidth: minWidth ?? r.width,
+      // Never exceed the chosen side's available space; scroll inside if it must.
+      maxHeight: `${Math.round(Math.max(isTop ? spaceAbove : spaceBelow, 160))}px`,
+      overflowY: "auto",
     };
     if (isTop) {
       next.bottom = window.innerHeight - r.top + offset;
     } else {
       next.top = r.bottom + offset;
     }
+    // Horizontal clamp: keep both edges within the viewport.
     if (isEnd) {
-      next.right = window.innerWidth - r.right;
+      next.right = Math.max(MARGIN, window.innerWidth - r.right);
     } else {
-      next.left = r.left;
+      next.left = Math.max(MARGIN, Math.min(r.left, window.innerWidth - popW - MARGIN));
     }
     setStyle(next);
   }, [anchorRef, placement, offset, minWidth]);


### PR DESCRIPTION
## Summary
A `Popover` near the bottom of the viewport overflowed below the fold (the #603 color-picker hex field + swatch strip were cut off at laptop height). The component positioned purely from the requested `placement` with no fit-checking.

**Fix (`ui/popover.tsx` `compute()`):**
- **Auto-flip** to the opposite side when the preferred side can't fit the popover and the other side has more room (uses the popover's `scrollHeight`).
- **Clamp** the horizontal edge so it never runs off the left/right.
- **Cap `maxHeight`** (with `overflowY:auto`) to the chosen side's available space, so it never overflows even in a short viewport.

Viewport-relative math is correct because `.ui-popover-portal` is `position:fixed; inset:0`. Benefits every `Popover` consumer (color picker, menus, etc.).

## Test Plan
- [x] `popover.test.ts` extended (scrollHeight fit-check, flip, horizontal clamp, maxHeight) — passes, wired
- [x] `tsc --noEmit` clean
- [ ] Live: laptop-height viewport, open the Background color swatch (low in the Settings scroll) → popover stays fully on-screen (flips up / scrolls), nothing cut off

🤖 Generated with [Claude Code](https://claude.com/claude-code)