### PR TITLE
feat(workflows): collapse studio side-panel sections by default + header-style panel tabs

### DIFF
--- a/src/components/workflows/workflow-attachments.tsx
+++ b/src/components/workflows/workflow-attachments.tsx
@@ -31,7 +31,7 @@ function AttachmentSection({
   action?: ReactNode;
   children: ReactNode;
 }) {
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(false);
   return (
     <article className="workflow-attachment-row">
       <div className="workflow-attachment-head">
@@ -71,6 +71,7 @@ export function WorkflowAttachments({
   onUpdateMeta,
   onScheduleRequest,
 }: WorkflowAttachmentsProps) {
+  const [open, setOpen] = useState(false);
   const attachedRoles = workflow
     ? roles.filter((role) => role.workflows.includes(workflow.id)).length
     : 0;
@@ -78,9 +79,20 @@ export function WorkflowAttachments({
   return (
     <section className="workflow-panel workflow-attachments" aria-label="Workflow attachments">
       <div className="workflow-panel-heading">
-        <div>
-          <p className="workflow-eyebrow">Attachments</p>
-          <h2>Cave bindings</h2>
+        <div className="workflow-heading-lead">
+          <button
+            type="button"
+            className="workflow-section-caret-btn"
+            aria-expanded={open}
+            aria-label={`${open ? "Collapse" : "Expand"} Cave bindings`}
+            onClick={() => setOpen((value) => !value)}
+          >
+            <Icon name={open ? "ph:caret-down" : "ph:caret-right"} width={12} aria-hidden />
+          </button>
+          <div>
+            <p className="workflow-eyebrow">Attachments</p>
+            <h2>Cave bindings</h2>
+          </div>
         </div>
         <button
           type="button"
@@ -94,6 +106,7 @@ export function WorkflowAttachments({
         </button>
       </div>
 
+      {open && (
       <div className="workflow-attachment-list">
         <AttachmentSection icon="ph:mask-happy" title="Familiars" count={workflow?.familiar ?? undefined}>
           {workflow ? (
@@ -178,7 +191,8 @@ export function WorkflowAttachments({
           <p>No project attachment</p>
         </AttachmentSection>
       </div>
-      <p className="workflow-muted">Boards/Projects: persistence pending daemon API</p>
+      )}
+      {open && <p className="workflow-muted">Boards/Projects: persistence pending daemon API</p>}
     </section>
   );
 }

--- a/src/components/workflows/workflow-inspector.tsx
+++ b/src/components/workflows/workflow-inspector.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Icon } from "@/lib/icon";
 import type { WorkflowGraphNode } from "@/lib/workflow-graph";
 import {
@@ -85,6 +86,7 @@ export function WorkflowInspector({
   onRemoveStep,
 }: WorkflowInspectorProps) {
   const issues = issuesForAction(action);
+  const [open, setOpen] = useState(false);
   const step = selectedNode
     ? workflow?.steps?.find((entry) => entry.id === selectedNode.id) ?? null
     : null;
@@ -92,9 +94,20 @@ export function WorkflowInspector({
   return (
     <section className="workflow-panel workflow-inspector" aria-label="Workflow inspector">
       <div className="workflow-panel-heading">
-        <div>
-          <p className="workflow-eyebrow">{step ? "Selected node" : "Workflow"}</p>
-          <h2>{step ? (step.name ?? step.id) : (workflow?.name ?? workflow?.id ?? "No workflow")}</h2>
+        <div className="workflow-heading-lead">
+          <button
+            type="button"
+            className="workflow-section-caret-btn"
+            aria-expanded={open}
+            aria-label={`${open ? "Collapse" : "Expand"} inspector`}
+            onClick={() => setOpen((value) => !value)}
+          >
+            <Icon name={open ? "ph:caret-down" : "ph:caret-right"} width={12} aria-hidden />
+          </button>
+          <div>
+            <p className="workflow-eyebrow">{step ? "Selected node" : "Workflow"}</p>
+            <h2>{step ? (step.name ?? step.id) : (workflow?.name ?? workflow?.id ?? "No workflow")}</h2>
+          </div>
         </div>
         {step && (
           <button
@@ -109,6 +122,8 @@ export function WorkflowInspector({
         )}
       </div>
 
+      {open && (
+      <>
       {step ? (
         <div className="workflow-editor">
           <Field label="Name" value={step.name ?? ""} onCommit={(next) => onUpdateStep(step.id, { name: next || undefined })} />
@@ -248,6 +263,8 @@ export function WorkflowInspector({
             </li>
           ))}
         </ul>
+      )}
+      </>
       )}
     </section>
   );

--- a/src/components/workflows/workflow-manifest-preview.tsx
+++ b/src/components/workflows/workflow-manifest-preview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import { Icon } from "@/lib/icon";
 import { workflowToYaml } from "@/lib/workflow-edit";
 import type { WorkflowSummary } from "@/lib/workflows";
 
@@ -11,27 +12,43 @@ type WorkflowManifestPreviewProps = {
 
 /** Live canonical YAML for the current draft — what Save writes to disk. */
 export function WorkflowManifestPreview({ workflow, dirty }: WorkflowManifestPreviewProps) {
+  const [open, setOpen] = useState(false);
   const yaml = useMemo(() => (workflow ? workflowToYaml(workflow) : null), [workflow]);
 
   return (
     <section className="workflow-panel workflow-manifest-preview" aria-label="Workflow manifest preview">
       <div className="workflow-panel-heading">
-        <div>
-          <p className="workflow-eyebrow">WORKFLOW.md / .workflow.yaml</p>
-          <h2>
-            Manifest
-            {dirty && <span className="workflow-dirty-dot" title="Unsaved changes" />}
-          </h2>
+        <div className="workflow-heading-lead">
+          <button
+            type="button"
+            className="workflow-section-caret-btn"
+            aria-expanded={open}
+            aria-label={`${open ? "Collapse" : "Expand"} Manifest`}
+            onClick={() => setOpen((value) => !value)}
+          >
+            <Icon name={open ? "ph:caret-down" : "ph:caret-right"} width={12} aria-hidden />
+          </button>
+          <div>
+            <p className="workflow-eyebrow">WORKFLOW.md / .workflow.yaml</p>
+            <h2>
+              Manifest
+              {dirty && <span className="workflow-dirty-dot" title="Unsaved changes" />}
+            </h2>
+          </div>
         </div>
       </div>
-      {yaml ? (
-        <pre className="workflow-manifest-yaml">
-          <code>{`# schema_version: CWF-01\n${yaml}`}</code>
-        </pre>
-      ) : (
-        <p className="workflow-muted">Select a workflow to preview its canonical manifest.</p>
+      {open && (
+        <>
+          {yaml ? (
+            <pre className="workflow-manifest-yaml">
+              <code>{`# schema_version: CWF-01\n${yaml}`}</code>
+            </pre>
+          ) : (
+            <p className="workflow-muted">Select a workflow to preview its canonical manifest.</p>
+          )}
+          <p className="workflow-muted">Cave-only layout stays in WORKFLOW.cave.json.</p>
+        </>
       )}
-      <p className="workflow-muted">Cave-only layout stays in WORKFLOW.cave.json.</p>
     </section>
   );
 }

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -102,13 +102,14 @@ assert.match(studio, /is-left-collapsed[\s\S]{0,160}is-right-collapsed/, "Studio
 assert.match(css, /\.workflow-panel-tab/, "Workflow CSS should style sidebar-like side-panel tab toggles");
 assert.match(css, /--workflow-top-control-height:\s*34px/, "Workflow top controls should share a standardized height");
 assert.match(css, /--workflow-top-control-offset:\s*8px/, "Workflow top controls should share a standardized y offset (8px matches the palette's vertical padding)");
-assert.match(css, /\.workflow-panel-tab[\s\S]{0,260}width:\s*100%[\s\S]{0,120}height:\s*var\(--workflow-top-control-height\)[\s\S]{0,120}margin-top:\s*var\(--workflow-top-control-offset\)[\s\S]{0,80}margin-bottom:\s*6px/, "Workflow panel tabs should span the full panel width, use the shared height/y offset, and leave padding below");
+assert.match(css, /\.workflow-panel-tab[\s\S]{0,320}width:\s*100%[\s\S]{0,160}height:\s*var\(--workflow-top-control-height\)[\s\S]{0,120}margin-top:\s*0[\s\S]{0,80}margin-bottom:\s*6px/, "Workflow panel tabs should span the full panel width, share the control height, and sit flush at the top (no offset) so the panel header pulls content up");
 assert.match(css, /\.workflow-studio-library-panel,[\s\S]{0,140}flex-direction:\s*column/, "Workflow panel content should sit below the full-width trigger row");
 assert.match(css, /\.workflow-palette-item[\s\S]{0,160}min-height:\s*var\(--workflow-top-control-height\)/, "Workflow palette buttons should use the same height as the side-panel triggers");
 assert.match(css, /is-left-collapsed[\s\S]{0,120}grid-template-columns:\s*36px/, "Collapsed left workflow panel should keep a visible toggle rail");
 assert.match(css, /is-right-collapsed[\s\S]{0,160}36px;/, "Collapsed right workflow panel should keep a visible toggle rail");
-assert.match(css, /\.workflow-panel-tab-left[\s\S]{0,120}justify-content:\s*flex-end/, "Left workflow panel tab should sit at the top right");
-assert.match(css, /\.workflow-panel-tab-right[\s\S]{0,120}justify-content:\s*flex-start/, "Right workflow panel tab should sit at the top left");
+assert.match(studio, /<span className="workflow-panel-tab__title">/, "Panel tabs render a header title");
+assert.match(css, /\.workflow-panel-tab\b[\s\S]{0,200}justify-content:\s*space-between/, "Panel tab header lays title and toggle across the row");
+assert.match(css, /is-left-collapsed \.workflow-panel-tab-left \.workflow-panel-tab__title,[\s\S]{0,140}display:\s*none/, "Collapsed panel hides the header title, leaving only the toggle icon");
 assert.match(css, /\.workflow-studio-shell\.is-left-collapsed/, "Workflow CSS should collapse the left workflow panel");
 assert.match(css, /\.workflow-studio-shell\.is-right-collapsed/, "Workflow CSS should collapse the right workflow panel");
 

--- a/src/components/workflows/workflow-studio.tsx
+++ b/src/components/workflows/workflow-studio.tsx
@@ -116,7 +116,8 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
           title={leftPanelOpen ? "Hide workflow library" : "Show workflow library"}
           onClick={() => setLeftPanelOpen((open) => !open)}
         >
-          <Icon name={leftPanelOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={14} />
+          <span className="workflow-panel-tab__title">Workflows</span>
+          <Icon name={leftPanelOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={14} className="workflow-panel-tab__icon" />
         </button>
         <div className="workflow-studio-library-content">
           <WorkflowLibrary
@@ -188,7 +189,8 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
           title={rightPanelOpen ? "Hide workflow details" : "Show workflow details"}
           onClick={() => setRightPanelOpen((open) => !open)}
         >
-          <Icon name={rightPanelOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={14} />
+          <span className="workflow-panel-tab__title">Details</span>
+          <Icon name={rightPanelOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={14} className="workflow-panel-tab__icon" />
         </button>
         <div className="workflow-studio-side-content">
           <WorkflowInspector

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -79,21 +79,48 @@
   gap: 0;
 }
 
+/* The panel tab doubles as the panel HEADER: a full-width row with the panel
+   title and the collapse toggle, flush to the top so the sections sit right
+   under it (same idiom as the main sidebar header). */
 .workflow-panel-tab {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 8px;
   flex-shrink: 0;
   width: 100%;
   height: var(--workflow-top-control-height);
-  margin-top: var(--workflow-top-control-offset);
+  margin-top: 0;
   margin-bottom: 6px;
-  padding: 0 7px;
+  padding: 0 8px;
   border: 1px solid transparent;
   border-radius: 8px;
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
   transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.workflow-panel-tab__title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+}
+
+.workflow-panel-tab__icon {
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+.workflow-panel-tab:hover .workflow-panel-tab__icon {
+  color: var(--text-primary);
 }
 
 .workflow-panel-tab:hover {
@@ -107,12 +134,10 @@
   outline-offset: 1px;
 }
 
-.workflow-panel-tab-left {
-  justify-content: flex-end;
-}
-
-.workflow-panel-tab-right {
-  justify-content: flex-start;
+/* Collapsed: hide the title so only the toggle icon shows in the narrow strip. */
+.workflow-studio-shell.is-left-collapsed .workflow-panel-tab-left .workflow-panel-tab__title,
+.workflow-studio-shell.is-right-collapsed .workflow-panel-tab-right .workflow-panel-tab__title {
+  display: none;
 }
 
 /* Collapsed: the whole narrow strip is the toggle, icon pinned to the top line.
@@ -158,6 +183,45 @@
   justify-content: space-between;
   gap: 10px;
   margin-bottom: 12px;
+}
+
+/* Collapsed sections trim the heading's bottom gap so headers stack tightly. */
+.workflow-panel:has(.workflow-section-caret-btn[aria-expanded="false"]) .workflow-panel-heading {
+  margin-bottom: 0;
+}
+
+/* Caret toggle + title group on the left of a collapsible section heading. */
+.workflow-heading-lead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.workflow-section-caret-btn {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  margin-top: 1px;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.workflow-section-caret-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.workflow-section-caret-btn:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
 }
 
 .workflow-panel-heading h2,


### PR DESCRIPTION
## What

In the Workflow Studio's inner side panels:

1. **All right-panel sections collapsed by default** — Inspector, Attachments (Cave bindings), and Manifest each get a caret toggle in their heading and start collapsed. Inspector & Manifest were previously always-open.
2. **The first section ("Synthesize sources" / selected-node editor = the Inspector) is now collapsible + collapsed by default.** Attachments' sub-sections (Familiars/Roles/Boards/Projects) also default collapsed.
3. **Panel tabs are now headers** — the left/right collapse-trigger row became a full-width header bar (`Workflows` / `Details` title + toggle icon), flush to the top with the offset gap removed so content pulls up into that space, matching the main sidebar-header idiom.

## Notes

- Panel open/closed state (whole-panel collapse) is unchanged; this is about the *sections within*.
- Valid markup: the caret is a small `<button>` beside the heading (the `<h2>` stays outside the button).

## Verification

`tsc` clean · full `test:app` exit 0 · `check:tests-wired` (283) · production `pnpm build` exit 0. Updated `workflow-studio.test.ts` assertions for the new header (margin-top:0, `space-between`, `workflow-panel-tab__title`, collapsed-title hidden).

⚠️ This is a visual/layout change I haven't eyeballed live — happy to screenshot the studio and adjust (e.g. the left "Workflows" header vs the Library's own heading) on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)