### PR TITLE
fix(workflows): drop duplicate left-panel title now that the tab is the header

### DIFF
--- a/src/components/workflows/workflow-library.tsx
+++ b/src/components/workflows/workflow-library.tsx
@@ -106,11 +106,9 @@ export function WorkflowLibrary({
 
   return (
     <aside className="workflow-library" aria-label="Workflow library">
-      <div className="workflow-panel-heading">
-        <div>
-          <p className="workflow-eyebrow">Library</p>
-          <h2>Workflows</h2>
-        </div>
+      {/* The panel header ("Workflows" + collapse) supplies the title; this
+          row just carries the create/refresh actions, right-aligned. */}
+      <div className="workflow-library-toolbar">
         <div className="workflow-library-actions">
           <button
             type="button"

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -190,6 +190,14 @@
   margin-bottom: 0;
 }
 
+/* Library actions toolbar — the panel header owns the title, so this is just
+   a right-aligned row of create/refresh buttons. */
+.workflow-library-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 8px;
+}
+
 /* Caret toggle + title group on the left of a collapsible section heading. */
 .workflow-heading-lead {
   display: flex;


### PR DESCRIPTION
Follow-up to #612. The screenshot pass showed the library panel rendered **"Workflows" twice** — the new panel header bar *and* the library's own "Library / Workflows" heading.

Fix: remove the library's eyebrow+title; keep the create/refresh buttons in a right-aligned toolbar. The panel header bar is now the single title (header + actions-row idiom, matching the main sidebar). The right panel ("Details" + 3 collapsed sections) was already correct and is unchanged.

**Verified live** — launched the studio, screenshotted the left panel before/after; the duplicate is gone, actions preserved.

`tsc` clean · `test:app` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)