### PR TITLE
fix(proxy): honor Tailscale Serve forwarded port

### DIFF
--- a/src/proxy-behavior.test.ts
+++ b/src/proxy-behavior.test.ts
@@ -153,6 +153,26 @@ assert.equal(
 );
 assert.equal(
   isAllowedRequestSource(
+    "https://cave.tailnet.example.ts.net:8443",
+    "http://127.0.0.1:3000",
+    false,
+    "cave.tailnet.example.ts.net:8443",
+  ),
+  true,
+  "Tailscale Serve origins should allow the same non-default HTTPS port as the forwarded Host",
+);
+assert.equal(
+  isAllowedRequestSource(
+    "https://cave.tailnet.example.ts.net:8444",
+    "http://127.0.0.1:3000",
+    false,
+    "cave.tailnet.example.ts.net:8443",
+  ),
+  false,
+  "Tailscale Serve origins must not borrow a different HTTPS port from the same host",
+);
+assert.equal(
+  isAllowedRequestSource(
     "https://other.tailnet.example.ts.net",
     "http://127.0.0.1:3000",
     false,

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -33,6 +33,17 @@ function hostnameFromHost(host: string | null) {
     : host.split(":")[0];
 }
 
+function portFromHost(host: string | null) {
+  if (!host) return "";
+  if (host.startsWith("[")) {
+    const close = host.indexOf("]");
+    const rest = close >= 0 ? host.slice(close + 1) : "";
+    return rest.startsWith(":") ? rest.slice(1) : "";
+  }
+  const parts = host.split(":");
+  return parts.length > 1 ? parts[parts.length - 1] : "";
+}
+
 function isTailscaleServeHost(host: string | null) {
   const hostname = hostnameFromHost(host);
   return Boolean(hostname?.endsWith(".ts.net"));
@@ -76,7 +87,7 @@ function sameTailscaleServeSource(value: string | null, host: string | null | un
     return (
       url.protocol === "https:" &&
       url.hostname === hostnameFromHost(host) &&
-      url.port === ""
+      url.port === portFromHost(host)
     );
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- parse forwarded Host ports for Tailscale Serve requests
- allow matching non-default HTTPS ports from the same forwarded Tailscale host
- reject same-host origins that use a different forwarded port

## Verification
- node --experimental-strip-types src/proxy-behavior.test.ts
- pnpm typecheck
- pnpm build
