### PR TITLE
fix(proxy): token-bearing requests bypass origin gate (fixes Tailscale "forbidden origin")

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -18,8 +18,13 @@ assert.match(source, /req\.headers\.get\("origin"\)/, "middleware should reject 
 assert.match(source, /req\.headers\.get\("host"\)/, "middleware should reject unsafe hosts");
 assert.match(source, /const requestHost = req\.headers\.get\("host"\)/, "proxy should capture the forwarded request host once");
 assert.match(source, /isAllowedApiHost\(requestHost, mobileAccessAuthenticated\)/, "valid mobile access should satisfy the API host gate");
-assert.match(source, /isAllowedRequestSource\(req\.headers\.get\("origin"\), expectedOrigin, mobileAccessAuthenticated, requestHost\)/, "valid mobile access should satisfy the API origin gate");
-assert.match(source, /isAllowedRequestSource\(req\.headers\.get\("referer"\), expectedOrigin, mobileAccessAuthenticated, requestHost\)/, "valid mobile access should satisfy the API referer gate");
+assert.match(source, /isAllowedRequestSource\(req\.headers\.get\("origin"\), expectedOrigin, csrfTrusted, requestHost\)/, "origin gate should trust mobile-access- or sidecar-token-authenticated requests");
+assert.match(source, /isAllowedRequestSource\(req\.headers\.get\("referer"\), expectedOrigin, csrfTrusted, requestHost\)/, "referer gate should trust mobile-access- or sidecar-token-authenticated requests");
+// Tailscale Serve fix: a request bearing the sidecar token (CSRF-immune custom
+// header) is trusted for the origin/referer gate, so Serve's cross-origin
+// (https://<machine>.ts.net → loopback) requests aren't 403'd as "forbidden origin".
+assert.match(source, /const sidecarAuthenticated = Boolean\(sidecarToken\) && suppliedToken === sidecarToken/, "proxy should derive sidecar-token authentication");
+assert.match(source, /const csrfTrusted = mobileAccessAuthenticated \|\| sidecarAuthenticated/, "csrf gate should trust either mobile-access or sidecar-token auth");
 assert.match(source, /unsupported content-type/, "middleware should reject unsafe content types before body parsing");
 
 // Ordering guard: dev-mode token-bypass (NextResponse.next() when no token is set)

--- a/src/proxy-behavior.test.ts
+++ b/src/proxy-behavior.test.ts
@@ -171,6 +171,22 @@ assert.equal(
   true,
   "normal same-origin browser dev mode remains allowed",
 );
+// Tailscale Serve over loopback: Serve terminates TLS and proxies to
+// 127.0.0.1, forwarding `Host: 127.0.0.1`, so the https://<machine>.ts.net
+// identity survives only in the Origin header (which fails the same-origin
+// gate). proxy() sets the trusted flag for sidecar-token-bearing requests
+// (CSRF-immune custom header), which must then pass; an untrusted cross-origin
+// request with the same loopback Host must still be rejected.
+assert.equal(
+  isAllowedRequestSource("https://mac.example.ts.net", "http://127.0.0.1:3000", true, "127.0.0.1:3000"),
+  true,
+  "token-authenticated Tailscale Serve POST (loopback-forwarded Host) must pass the origin gate",
+);
+assert.equal(
+  isAllowedRequestSource("https://mac.example.ts.net", "http://127.0.0.1:3000", false, "127.0.0.1:3000"),
+  false,
+  "untrusted cross-origin Tailscale Serve request (loopback-forwarded Host) must still be blocked",
+);
 
 // ─── shouldRequireMobileAccessCredential ──────────────────────────────────
 assert.equal(

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -140,29 +140,42 @@ export async function proxy(req: NextRequest) {
   if (!isAllowedApiHost(requestHost, mobileAccessAuthenticated)) {
     return jsonError(403, "forbidden host");
   }
-  if (!isAllowedRequestSource(req.headers.get("origin"), expectedOrigin, mobileAccessAuthenticated, requestHost)) {
+
+  // A request that carries the sidecar auth token (custom x-coven-cave-token
+  // header / covenCaveToken param) is provably first-party: a browser cannot
+  // attach that header on a cross-origin request, so such a request can't be a
+  // CSRF / cross-site forgery regardless of its Origin. This is what makes
+  // Tailscale Serve work: Serve terminates TLS and proxies to loopback,
+  // forwarding `Host: 127.0.0.1`, so the real `https://<machine>.ts.net`
+  // identity survives only in the Origin header — which otherwise fails the
+  // same-origin gate and 403s every mutating request ("forbidden origin").
+  // Token-bearing requests are trusted for the CSRF gate just like
+  // mobile-access-authenticated ones; the token itself is still validated below.
+  const sidecarToken = process.env.COVEN_CAVE_AUTH_TOKEN;
+  const suppliedToken =
+    req.headers.get(TOKEN_HEADER) ??
+    req.nextUrl.searchParams.get(TOKEN_PARAM) ??
+    bearerFromReferer(req.headers.get("referer"), expectedOrigin);
+  const sidecarAuthenticated = Boolean(sidecarToken) && suppliedToken === sidecarToken;
+  const csrfTrusted = mobileAccessAuthenticated || sidecarAuthenticated;
+
+  if (!isAllowedRequestSource(req.headers.get("origin"), expectedOrigin, csrfTrusted, requestHost)) {
     return jsonError(403, "forbidden origin");
   }
-  if (!isAllowedRequestSource(req.headers.get("referer"), expectedOrigin, mobileAccessAuthenticated, requestHost)) {
+  if (!isAllowedRequestSource(req.headers.get("referer"), expectedOrigin, csrfTrusted, requestHost)) {
     return jsonError(403, "forbidden referer");
   }
   if (!hasSafeContentType(req)) {
     return jsonError(415, "unsupported content-type");
   }
 
-  const token = process.env.COVEN_CAVE_AUTH_TOKEN;
-  if (!token) {
+  if (!sidecarToken) {
     return process.env.COVEN_CAVE_BUNDLE === "1"
       ? jsonError(500, "missing sidecar auth token")
       : NextResponse.next();
   }
 
-  const supplied =
-    req.headers.get(TOKEN_HEADER) ??
-    req.nextUrl.searchParams.get(TOKEN_PARAM) ??
-    bearerFromReferer(req.headers.get("referer"), expectedOrigin);
-
-  if (supplied !== token) {
+  if (!sidecarAuthenticated) {
     return jsonError(401, "unauthorized");
   }
 


### PR DESCRIPTION
## Symptom
Mobile/native app over Tailscale shows **"Daemon start failed — forbidden origin"** and "Daemon offline — existing sessions visible but new tasks may not start." Reads work; every mutating POST 403s.

## Root cause
`src/proxy.ts` rejects with `403 "forbidden origin"` when the request `Origin` fails the same-origin gate. Tailscale Serve terminates TLS and **proxies to the loopback Next server, forwarding `Host: 127.0.0.1`** (`mobile-tailscale.sh` even keeps Next bound to loopback). So:
- `Origin: https://<machine>.ts.net` (browser) vs `expected: http://127.0.0.1:PORT` → cross-origin → **blocked**.
- The `.ts.net` identity is **not in the Host** (it's loopback), so the `sameTailscaleServeSource` allowance (which keys off the forwarded Host being `.ts.net`) never fires.
- GETs carry no `Origin` header → slip through → "sessions visible but new tasks won't start."

Confirmed by exercising the real helpers: `isAllowedRequestSource("https://x.ts.net", "http://127.0.0.1:PORT", /*trusted*/false, "127.0.0.1:PORT")` → **BLOCK**.

## Fix
A request bearing the sidecar auth token (`x-coven-cave-token` header / `covenCaveToken` param — both attached by `SidecarAuthBridge`) is **provably first-party**: a browser cannot set that custom header on a cross-origin request, so it can't be CSRF *regardless of Origin*. Compute `sidecarAuthenticated` **before** the origin/referer gate and treat it as CSRF-trusted — mirroring the existing `mobileAccessAuthenticated` bypass. The token is still validated afterward (unchanged `401` on mismatch).

- **No `mobile-tailscale.sh` change** — the token is already sent via header.
- **No security regression**: token-bearing requests are already fully authenticated by the token (the real auth); the origin check is redundant CSRF defense-in-depth that custom-header auth doesn't need. No-token browser-dev and bundle paths are untouched.

## Verified
`proxy-behavior.test.ts` + `daemon-start route.test.ts` pass; `tsc` clean. Added helper assertions for the exact loopback-forwarded-Host Tailscale scenario (trusted → allow, untrusted → still blocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)