### PR TITLE
fix(mobile): polish shell chrome

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4317,6 +4317,7 @@ button:active > .edge-rail-chip {
     position: fixed !important;
     top: 0;
     bottom: 0;
+    height: 100dvh;
     z-index: 200;
     width: min(86vw, 320px) !important;
     min-width: 0 !important;
@@ -4327,6 +4328,8 @@ button:active > .edge-rail-chip {
     overflow-y: auto;
     overscroll-behavior: contain;
     -webkit-overflow-scrolling: touch;
+    padding-top: var(--sai-top);
+    padding-bottom: var(--sai-bottom);
     transition: transform var(--duration-base) var(--ease-emphasized);
     will-change: transform;
   }
@@ -4387,8 +4390,8 @@ button:active > .edge-rail-chip {
     grid-template-columns: auto minmax(0, 1fr) auto;
     padding: 0 calc(8px + var(--sai-right)) 0 calc(8px + var(--sai-left));
     padding-top: var(--sai-top);
-    height: calc(40px + var(--sai-top));
-    gap: 6px;
+    height: calc(52px + var(--sai-top));
+    gap: 8px;
   }
   .top-bar__mobile-toggle {
     display: inline-flex;
@@ -4405,7 +4408,9 @@ button:active > .edge-rail-chip {
                 color var(--duration-fast) var(--ease-standard);
   }
   .top-bar__mobile-toggle:hover,
-  .top-bar__mobile-toggle:focus-visible {
+  .top-bar__mobile-toggle:focus-visible,
+  .top-bar__mobile-toggle[aria-expanded="true"],
+  .top-bar__mobile-toggle[aria-pressed="true"] {
     background: var(--bg-hover);
     color: var(--text-primary);
   }
@@ -4416,6 +4421,8 @@ button:active > .edge-rail-chip {
   .top-bar__search {
     min-width: 0;
     width: 100%;
+    min-height: var(--touch-target);
+    padding-block: 0;
   }
   .top-bar__search span {
     min-width: 0;
@@ -4479,29 +4486,41 @@ button:active > .edge-rail-chip {
   align-items: stretch;
   justify-content: space-around;
   gap: 0;
-  min-height: 56px;
+  min-height: 60px;
   padding: 0 calc(4px + var(--sai-left, 0px)) 0 calc(4px + var(--sai-right, 0px));
   padding-bottom: max(8px, env(safe-area-inset-bottom));
-  background: color-mix(in oklch, var(--bg-raised) 92%, transparent);
-  backdrop-filter: blur(14px) saturate(140%);
-  -webkit-backdrop-filter: blur(14px) saturate(140%);
-  border-top: 1px solid var(--border-hairline);
+  background:
+    linear-gradient(to top, color-mix(in oklch, var(--bg-base) 92%, transparent), color-mix(in oklch, var(--bg-raised) 88%, transparent)),
+    color-mix(in oklch, var(--bg-raised) 92%, transparent);
+  backdrop-filter: blur(18px) saturate(145%);
+  -webkit-backdrop-filter: blur(18px) saturate(145%);
+  border-top: 1px solid color-mix(in oklch, var(--border-hairline) 88%, transparent);
+  box-shadow: 0 -14px 32px color-mix(in oklch, black 18%, transparent);
 }
 .mobile-bottom-tab {
+  position: relative;
   display: flex;
   flex: 1 1 0;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 2px;
-  padding: 6px 10px;
+  gap: 3px;
+  min-width: 0;
+  min-height: var(--touch-target);
+  padding: 7px 6px 8px;
   background: transparent;
   border: 0;
   color: var(--text-muted);
   font: inherit;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
-  transition: color var(--duration-fast) var(--ease-standard);
+  border-radius: 10px;
+  transition: color var(--duration-fast) var(--ease-standard),
+              background var(--duration-fast) var(--ease-standard);
+}
+.mobile-bottom-tab:hover,
+.mobile-bottom-tab:focus-visible {
+  background: color-mix(in oklch, var(--bg-hover) 70%, transparent);
 }
 .mobile-bottom-tab:focus-visible {
   outline: var(--ring-width) solid var(--ring-focus);
@@ -4521,13 +4540,34 @@ button:active > .edge-rail-chip {
   font-size: 11px;
   line-height: 1.1;
   font-weight: 500;
-  letter-spacing: 0.01em;
+  letter-spacing: 0;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .mobile-bottom-tab--active {
   color: var(--accent-presence);
 }
 .mobile-bottom-tab--active .mobile-bottom-tab__label {
   font-weight: 600;
+}
+.mobile-bottom-tab__indicator {
+  position: absolute;
+  left: 22%;
+  right: 22%;
+  bottom: calc(4px + max(0px, var(--sai-bottom)));
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+  transform: scaleX(0);
+  opacity: 0;
+  transition: transform var(--duration-fast) var(--ease-emphasized),
+              opacity var(--duration-fast) var(--ease-standard);
+}
+.mobile-bottom-tab--active .mobile-bottom-tab__indicator {
+  transform: scaleX(1);
+  opacity: 1;
 }
 .mobile-bottom-tab__badge {
   position: absolute;

--- a/src/components/mobile-bottom-tabs.tsx
+++ b/src/components/mobile-bottom-tabs.tsx
@@ -3,7 +3,7 @@
 /**
  * MobileBottomTabs — fixed/sticky bottom navigation strip for mobile/tablet
  * viewports. Surfaces the five most-used destinations (Home, Chat, Board,
- * Automations, Library) as a tablist with icon + label and an active highlight.
+ * Inbox, Library) as a tablist with icon + label and an active highlight.
  *
  * Renders only when the parent shell is in mobile mode (≤1023px); Shell is
  * responsible for that conditional render — this component itself doesn't
@@ -17,15 +17,16 @@ type TabId = "home" | "chat" | "board" | "inbox" | "library";
 type TabDef = {
   id: TabId;
   label: string;
+  ariaLabel: string;
   iconName: IconName;
 };
 
 const TABS: TabDef[] = [
-  { id: "home", label: "Home", iconName: "ph:house-bold" },
-  { id: "chat", label: "Chat", iconName: "ph:chats" },
-  { id: "board", label: "Board", iconName: "ph:kanban" },
-  { id: "inbox", label: "Automations", iconName: "ph:tray" },
-  { id: "library", label: "Library", iconName: "ph:books" },
+  { id: "home", label: "Home", ariaLabel: "Home", iconName: "ph:house-bold" },
+  { id: "chat", label: "Chat", ariaLabel: "Chat", iconName: "ph:chats" },
+  { id: "board", label: "Board", ariaLabel: "Board", iconName: "ph:kanban" },
+  { id: "inbox", label: "Inbox", ariaLabel: "Inbox and automations", iconName: "ph:tray" },
+  { id: "library", label: "Library", ariaLabel: "Library", iconName: "ph:books" },
 ];
 
 export type MobileBottomTabsProps = {
@@ -55,6 +56,7 @@ export function MobileBottomTabs({
             role="tab"
             aria-selected={active}
             aria-current={active ? "page" : undefined}
+            aria-label={showBadge ? `${tab.ariaLabel}, ${inboxBadgeCount} unread` : tab.ariaLabel}
             className={
               "mobile-bottom-tab" +
               (active ? " mobile-bottom-tab--active" : "")
@@ -70,6 +72,7 @@ export function MobileBottomTabs({
               ) : null}
             </span>
             <span className="mobile-bottom-tab__label">{tab.label}</span>
+            <span className="mobile-bottom-tab__indicator" aria-hidden />
             {showBadge ? (
               <span className="sr-only">
                 {inboxBadgeCount} unread

--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
+const mobileTabs = await readFile(new URL("./mobile-bottom-tabs.tsx", import.meta.url), "utf8");
+const topBar = await readFile(new URL("./top-bar.tsx", import.meta.url), "utf8");
 const bottomTerminal = await readFile(new URL("./bottom-terminal.tsx", import.meta.url), "utf8");
 const browserPane = await readFile(new URL("./browser-pane.tsx", import.meta.url), "utf8");
 const globals = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
@@ -23,6 +25,72 @@ assert.match(
   globals,
   /Those tabs live in normal shell flow[\s\S]{0,220}\.shell-detail\s*\{[\s\S]{0,80}padding-bottom:\s*0;/,
   "Mobile shell detail should not reserve extra space above bottom tabs",
+);
+
+assert.match(
+  mobileTabs,
+  /{ id: "inbox", label: "Inbox", ariaLabel: "Inbox and automations", iconName: "ph:tray" }/,
+  "Mobile bottom tabs should keep labels short while preserving the full Inbox/Automations accessible name",
+);
+
+assert.match(
+  mobileTabs,
+  /aria-label=\{showBadge \? `\$\{tab\.ariaLabel\}, \$\{inboxBadgeCount\} unread` : tab\.ariaLabel\}/,
+  "Mobile bottom tabs should expose per-tab accessible labels instead of relying on cramped visual text",
+);
+
+assert.match(
+  mobileTabs,
+  /<span className="mobile-bottom-tab__indicator" aria-hidden \/>/,
+  "Mobile bottom tabs should include an explicit active indicator hook",
+);
+
+assert.match(
+  topBar,
+  /navDrawerOpen\?: boolean;[\s\S]*listDrawerOpen\?: boolean;[\s\S]*familiarDrawerOpen\?: boolean;/,
+  "TopBar should receive mobile drawer state so controls can announce open/closed state",
+);
+
+assert.match(
+  topBar,
+  /aria-expanded=\{Boolean\(navDrawerOpen\)\}/,
+  "Mobile nav toggle should announce whether the navigation drawer is open",
+);
+
+assert.match(
+  topBar,
+  /aria-pressed=\{Boolean\(listDrawerOpen\)\}/,
+  "Mobile list toggle should expose pressed state while the list drawer is open",
+);
+
+assert.match(
+  topBar,
+  /aria-pressed=\{Boolean\(familiarDrawerOpen\)\}/,
+  "Mobile familiar toggle should expose pressed state while the familiar drawer is open",
+);
+
+assert.match(
+  globals,
+  /@media \(max-width: 1023px\) \{[\s\S]*\.top-bar\s*\{[\s\S]*height:\s*calc\(52px \+ var\(--sai-top\)\)/,
+  "Mobile top bar should provide enough vertical room for 44px controls",
+);
+
+assert.match(
+  globals,
+  /@media \(max-width: 1023px\) \{[\s\S]*\.top-bar__search\s*\{[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "Mobile search button should meet the 44px touch target",
+);
+
+assert.match(
+  globals,
+  /\.shell-nav-panel,[\s\S]{0,120}\.shell-list-panel,[\s\S]{0,120}\.shell-familiar-panel\s*\{[\s\S]{0,260}height:\s*100dvh/,
+  "Mobile drawers should use dynamic viewport height so iOS browser chrome does not create hidden overflow",
+);
+
+assert.match(
+  globals,
+  /\.mobile-bottom-tab__indicator\s*\{[\s\S]{0,200}transform:\s*scaleX\(0\)/,
+  "Mobile bottom tabs should render an active indicator that can animate without shifting layout",
 );
 
 assert.match(

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -96,6 +96,14 @@ export type ShellHandle = {
   toggleList: () => void;
 };
 
+type ShellMobileChromeState = {
+  navDrawerOpen: boolean;
+  listDrawerOpen: boolean;
+  familiarDrawerOpen: boolean;
+};
+
+type ShellTopBar = ReactNode | ((state: ShellMobileChromeState) => ReactNode);
+
 function ShellInner({
   familiarRail,
   familiarPanelRail,
@@ -118,7 +126,7 @@ function ShellInner({
   detail: ReactNode;
   agent?: ReactNode;
   bottom?: ReactNode;
-  topBar?: ReactNode;
+  topBar?: ShellTopBar;
   /** Mobile/tablet-only bottom tab bar. Rendered after `.shell-body`
    *  inside `.shell-frame`, but only when the viewport matches the
    *  mobile breakpoint (≤1023px). */
@@ -149,6 +157,12 @@ function ShellInner({
   useEffect(() => {
     if (!isMobile) setMobileDrawer(null);
   }, [isMobile]);
+  const mobileChromeState: ShellMobileChromeState = {
+    navDrawerOpen: isMobile && mobileDrawer === "nav",
+    listDrawerOpen: isMobile && mobileDrawer === "list",
+    familiarDrawerOpen: isMobile && mobileDrawer === "agent",
+  };
+  const renderedTopBar = typeof topBar === "function" ? topBar(mobileChromeState) : topBar;
 
   useImperativeHandle(ref, () => {
     const toggleDrawer = (slot: NonNullable<MobileDrawerSlot>) => {
@@ -354,7 +368,7 @@ function ShellInner({
   if (!mounted) {
     return (
       <div className="shell-frame flex h-full w-full flex-col">
-        {topBar}
+        {renderedTopBar}
         <div className="shell-body flex flex-1 min-h-0">
           {familiarRail}
           <div className="shell-root flex-1 min-h-0" />
@@ -454,7 +468,6 @@ function ShellInner({
     "--shell-right-gap-px": `${detailGaps.right}px`,
     "--shell-home-center-shift-px": `${homeCenterShift}px`,
   };
-
   // Floating reopen affordance — once the sidebar is collapsed (via its own
   // top toggle, ⌘B, or a drag), this left-edge rail is how it comes back. It
   // stays hidden while the nav is open so the in-panel toggle owns collapsing.
@@ -490,7 +503,7 @@ function ShellInner({
       style={shellFrameStyle}
       data-settled={settled ? "" : undefined}
     >
-      {topBar}
+      {renderedTopBar}
       <div className="shell-body flex flex-1 min-h-0">
         {familiarRail}
         {navRail}

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -24,6 +24,9 @@ type Props = {
   onToggleNav?: () => void;
   onToggleList?: () => void;
   onToggleFamiliar?: () => void;
+  navDrawerOpen?: boolean;
+  listDrawerOpen?: boolean;
+  familiarDrawerOpen?: boolean;
 };
 
 export function TopBar(props: Props) {
@@ -41,6 +44,9 @@ export function TopBar(props: Props) {
     onToggleNav,
     onToggleList,
     onToggleFamiliar,
+    navDrawerOpen,
+    listDrawerOpen,
+    familiarDrawerOpen,
   } = props;
 
   return (
@@ -53,8 +59,10 @@ export function TopBar(props: Props) {
             type="button"
             className="top-bar__mobile-toggle"
             onClick={onToggleNav}
-            aria-label="Open navigation (⌘B)"
-            title="Open navigation"
+            aria-label={navDrawerOpen ? "Close navigation" : "Open navigation (⌘B)"}
+            aria-expanded={Boolean(navDrawerOpen)}
+            aria-controls="nav"
+            title={navDrawerOpen ? "Close navigation" : "Open navigation"}
           >
             <Icon name="ph:sidebar-simple" width={18} />
           </button>
@@ -64,8 +72,11 @@ export function TopBar(props: Props) {
             type="button"
             className="top-bar__mobile-toggle"
             onClick={onToggleList}
-            aria-label="Open list (⌘\\)"
-            title="Open list"
+            aria-label={listDrawerOpen ? "Close list" : "Open list (⌘\\)"}
+            aria-expanded={Boolean(listDrawerOpen)}
+            aria-pressed={Boolean(listDrawerOpen)}
+            aria-controls="list"
+            title={listDrawerOpen ? "Close list" : "Open list"}
           >
             <Icon name="ph:list-checks-bold" width={18} />
           </button>
@@ -116,8 +127,11 @@ export function TopBar(props: Props) {
             type="button"
             className="top-bar__mobile-toggle"
             onClick={onToggleFamiliar}
-            aria-label="Open familiar panel (⌘J)"
-            title="Open familiar panel"
+            aria-label={familiarDrawerOpen ? "Close familiar panel" : "Open familiar panel (⌘J)"}
+            aria-expanded={Boolean(familiarDrawerOpen)}
+            aria-pressed={Boolean(familiarDrawerOpen)}
+            aria-controls="agent"
+            title={familiarDrawerOpen ? "Close familiar panel" : "Open familiar panel"}
           >
             <Icon name="ph:cat" width={18} />
           </button>

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1393,7 +1393,7 @@ export function Workspace() {
           setFamiliarPanelOpen(open);
           if (activeId) setRailOpen(activeId, open);
         }}
-        topBar={
+        topBar={({ navDrawerOpen, listDrawerOpen, familiarDrawerOpen }) => (
           <TopBar
             onOpenPalette={() => setPaletteOpen(true)}
             onOpenInbox={() => setMode("inbox")}
@@ -1410,6 +1410,9 @@ export function Workspace() {
             onNotificationPrefsChanged={refreshPrefs}
             onToggleNav={() => shellRef.current?.toggleNav()}
             onToggleList={list ? () => shellRef.current?.toggleList() : undefined}
+            navDrawerOpen={navDrawerOpen}
+            listDrawerOpen={listDrawerOpen}
+            familiarDrawerOpen={familiarDrawerOpen}
             onToggleFamiliar={
               showCompanionRail
                 ? () => {
@@ -1418,7 +1421,7 @@ export function Workspace() {
                 : undefined
             }
           />
-        }
+        )}
         familiarPanelRail={showCompanionRail ? (
           <aside className="familiar-trigger-rail familiar-trigger-rail--stacked" aria-label="Right panel tabs">
             <button


### PR DESCRIPTION
## Summary
- tighten mobile bottom tabs with short visual labels, stable active indicators, and full accessible labels
- expose mobile drawer open state through the top bar toggles
- improve mobile top bar/search tap targets and drawer viewport sizing

## Test Plan
- `node --experimental-strip-types src/components/mobile-shell-smoke.test.ts`
- `pnpm typecheck`
- `pnpm test:mobile`
- Playwright mobile rendered check at 390x844 against `http://127.0.0.1:3010/`
- `pnpm build`
