### PR TITLE
feat(projects): cap nested chat lists with a Show all toggle

### DIFF
--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -24,6 +24,10 @@ assert.match(projectsView, /applyProjectOverrides\(sessions, projectOverrides\)/
 assert.match(projectsView, /setProjectOverride\(activeId, targetRoot\)/, "cross-project drop moves the chat via an override");
 assert.match(projectsView, /mergeVisibleOrder[\s\S]{0,120}writeSessionOrder/, "same-project drop reorders via the shared manual order");
 assert.match(projectsView, /cave:agents-open-session/, "clicking a chat opens it via the agents-open-session event");
+// Long chat lists are capped with a Show all / Show less toggle.
+assert.match(projectsView, /const CHAT_CAP =/, "nested chat lists are capped");
+assert.match(projectsView, /chats\.slice\(0, CHAT_CAP\)/, "only the first CHAT_CAP chats render until expanded");
+assert.match(projectsView, /Show all \$\{chats\.length\} chats/, "a toggle reveals the rest");
 assert.match(projectsView, /import \{ EmptyState \} from "@\/components\/ui\/empty-state"/, "uses EmptyState primitive");
 assert.match(projectsView, /import \{ ErrorState \} from "@\/components\/ui\/error-state"/, "uses ErrorState primitive");
 assert.match(projectsView, /import \{ SkeletonRows \} from "@\/components\/ui\/skeleton"/, "uses SkeletonRows for first load");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -38,6 +38,10 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
+// Cap nested chats per project card so a busy project doesn't bury the others;
+// a "Show all" toggle expands the rest.
+const CHAT_CAP = 8;
+
 function chatDotClass(status: string): string {
   if (status === "running") return "bg-[var(--accent-presence)]";
   if (status === "failed" || status === "error") return "bg-[var(--color-danger)]";
@@ -112,6 +116,8 @@ function ProjectRow({
   onOpenSession,
 }: ProjectRowProps) {
   const chatCount = chats.length;
+  const [showAllChats, setShowAllChats] = useState(false);
+  const visibleChats = showAllChats ? chats : chats.slice(0, CHAT_CAP);
   const { setNodeRef: setDropRef, isOver } = useDroppable({
     id: `pcard:${normalizeProjectRoot(project.root)}`,
   });
@@ -298,13 +304,25 @@ function ProjectRow({
       </div>
 
       {chats.length > 0 ? (
-        <SortableContext items={chats.map((s) => s.id)} strategy={verticalListSortingStrategy}>
-          <ul className="mt-2 flex flex-col gap-0.5 border-t border-[var(--border-hairline)] pt-2">
-            {chats.map((session) => (
-              <ProjectChatRow key={session.id} session={session} onOpen={() => onOpenSession?.(session.id)} />
-            ))}
-          </ul>
-        </SortableContext>
+        <>
+          <SortableContext items={visibleChats.map((s) => s.id)} strategy={verticalListSortingStrategy}>
+            <ul className="mt-2 flex flex-col gap-0.5 border-t border-[var(--border-hairline)] pt-2">
+              {visibleChats.map((session) => (
+                <ProjectChatRow key={session.id} session={session} onOpen={() => onOpenSession?.(session.id)} />
+              ))}
+            </ul>
+          </SortableContext>
+          {chats.length > CHAT_CAP ? (
+            <button
+              type="button"
+              onClick={() => setShowAllChats((value) => !value)}
+              aria-expanded={showAllChats}
+              className="focus-ring mt-1 rounded-md px-2 py-1 text-[11px] font-medium text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-secondary)]"
+            >
+              {showAllChats ? "Show less" : `Show all ${chats.length} chats`}
+            </button>
+          ) : null}
+        </>
       ) : (
         <p className="mt-2 border-t border-[var(--border-hairline)] pt-2 text-[11px] text-[var(--text-muted)]">
           No chats yet — drag one here or start a new chat.


### PR DESCRIPTION
Follow-up polish to #617. A busy project (194 chats in my screenshot) buried every other project card. Each card now caps its nested chats at **8** with a **"Show all N chats" / "Show less"** toggle.

DnD still works on the visible subset (reorder via the shared manual order); the card stays a drop target for cross-project moves regardless of cap.

`tsc` clean · `projects-view.test.ts` updated + passing · production build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)