### PR TITLE
fix(settings): demo-mode toggle hydrates SSR-safe (no aria-pressed mismatch)

### DIFF
--- a/src/components/settings-appearance.test.ts
+++ b/src/components/settings-appearance.test.ts
@@ -264,3 +264,17 @@ assert.match(
   /clearDemoModeData/,
   "Settings should offer an easy demo-mode reset path",
 );
+
+// Demo-mode toggle must hydrate SSR-safe: reading localStorage during render makes
+// the first client render's aria-pressed disagree with the server's → hydration
+// mismatch. Start from the default and read the real value after mount.
+assert.doesNotMatch(
+  settings,
+  /useState\(\(\) => isDemoModeEnabled\(\)\)/,
+  "Demo-mode state must not read localStorage during render (SSR hydration mismatch)",
+);
+assert.match(
+  settings,
+  /const sync = \(\) => setDemoMode\(isDemoModeEnabled\(\)\);\s*sync\(\);/,
+  "Demo-mode reads its real value after mount via sync() in the effect",
+);

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -200,10 +200,14 @@ export function SettingsShell() {
 // ─── Section: General ─────────────────────────────────────────────────────────
 
 function GeneralSection() {
-  const [demoMode, setDemoMode] = useState(() => isDemoModeEnabled());
+  // Start from the SSR-safe default (false) so the first client render matches the
+  // server's; read the real localStorage value after mount to avoid an aria-pressed
+  // hydration mismatch on the Demo mode toggle.
+  const [demoMode, setDemoMode] = useState(false);
 
   useEffect(() => {
     const sync = () => setDemoMode(isDemoModeEnabled());
+    sync();
     window.addEventListener(DEMO_MODE_EVENT, sync);
     return () => window.removeEventListener(DEMO_MODE_EVENT, sync);
   }, []);


### PR DESCRIPTION
## Summary
`GeneralSection` (Settings) seeded state with `useState(() => isDemoModeEnabled())` — the lazy initializer reads `localStorage` on the client's first render too, so when demo mode is persisted **on**, the server rendered `aria-pressed=false` but the first client render produced `aria-pressed=true` → a **React hydration mismatch** (the recurring console warning seen while verifying the color picker).

**Fix:** start from the SSR-safe default (`false`, matching the server) and read the real value after mount via the existing `sync()` effect. Server and first client render now agree; the toggle settles to its true state post-hydration.

## Test Plan
- [x] `settings-appearance.test.ts` extended (no localStorage read during render; `sync()` called in the effect) — passes
- [x] `tsc --noEmit` clean
- [ ] Live: persist `cave:demo-mode=1`, load Settings → General → no hydration / `aria-pressed` mismatch warning in console; toggle still shows "On"

🤖 Generated with [Claude Code](https://claude.com/claude-code)