### PR TITLE
feat(nav): remove Projects from the left sidebar — Chat Projects tab only

### DIFF
--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -41,8 +41,8 @@ assert.doesNotMatch(workspace, /mode === "projects" \?/, "workspace has no proje
 assert.match(chatTabEvents, /CHAT_OPEN_PROJECTS_EVENT/, "reroute event exists");
 assert.match(workspace, /case "\/projects":[\s\S]*?setMode\("chat"\)[\s\S]*?CHAT_OPEN_PROJECTS_EVENT/, "/projects reroutes: setMode(chat) + chat-open-projects event");
 
-assert.match(sidebar, /\{ id: "projects", label: "Projects", iconName: "ph:folders-bold", group: "tools"/, "Sidebar keeps the Projects Tools entry");
-assert.match(sidebar, /CHAT_OPEN_PROJECTS_EVENT/, "Sidebar Projects entry reroutes into the chat tab");
+assert.doesNotMatch(sidebar, /id: "projects"/, "Sidebar no longer shows a Projects entry — Projects lives only in the Chat tab");
+assert.doesNotMatch(sidebar, /CHAT_OPEN_PROJECTS_EVENT/, "Sidebar no longer imports the chat-tab reroute event (entry removed)");
 
 for (const icon of [
   "ph:folders-bold",

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -14,7 +14,6 @@
 
 import React from "react";
 import { Icon } from "@/lib/icon";
-import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { SessionRow } from "@/lib/types";
 import type { InboxItem } from "@/lib/cave-inbox";
@@ -34,10 +33,6 @@ export type FolderMode =
   | "workflows"
   | "library"
   | "capabilities";
-
-// "projects" is a pseudo-mode rerouted by handleModeSelect (→ chat + event).
-// It is never passed to onModeChange; only FolderMode values are real modes.
-type FolderEntryId = FolderMode | "projects";
 
 export type AddonsConfig = {
   github?: boolean;
@@ -69,7 +64,7 @@ export type SidebarMinimalProps = {
 };
 
 const FOLDER_MODES: Array<{
-  id: FolderEntryId;
+  id: FolderMode;
   label: string;
   iconName: Parameters<typeof Icon>[0]["name"];
   badge?: (props: SidebarMinimalProps) => string | undefined;
@@ -89,7 +84,6 @@ const FOLDER_MODES: Array<{
   { id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools", kbd: "⌘8" },
   { id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools" },
   { id: "workflows", label: "Workflows", iconName: "ph:git-branch-bold", group: "tools" },
-  { id: "projects", label: "Projects", iconName: "ph:folders-bold", group: "tools", kbd: "⌘9" },
   { id: "capabilities", label: "Capabilities", iconName: "ph:lightning-bold", group: "tools" },
   // Add-ons (gated)
   { id: "github", label: "GitHub", iconName: "ph:github-logo", group: "addons" },
@@ -216,14 +210,9 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
     onFamiliarScopeChange,
   } = props;
 
-  // Projects is no longer a top-level WorkspaceMode — reroute via the chat tab event.
-  // The "projects" guard narrows id to FolderMode below, so onModeChange stays type-safe.
-  const handleModeSelect = (id: FolderEntryId) => {
-    if (id === "projects") {
-      onModeChange("chat");
-      window.setTimeout(() => window.dispatchEvent(new CustomEvent(CHAT_OPEN_PROJECTS_EVENT)), 0);
-      return;
-    }
+  // Projects lives only inside the Chat surface's Projects tab now (and ⌘9 /
+  // the /projects deep-link in workspace.tsx open it there) — no sidebar entry.
+  const handleModeSelect = (id: FolderMode) => {
     onModeChange(id);
   };
 


### PR DESCRIPTION
Per product direction: **Projects no longer appears in the main left sidebar** — it lives only inside the Chat surface's Projects tab.

## What changed
The sidebar "Projects" item was already a *pseudo-entry* that just rerouted into the Chat Projects tab. Removed it entirely from `sidebar-minimal.tsx`:
- dropped the `{ id: "projects", … }` Tools nav item (and its ⌘9 label)
- removed the now-dead `FolderEntryId` pseudo-mode type and the `handleModeSelect` "projects" reroute branch (now a straight `onModeChange` passthrough)
- removed the unused `CHAT_OPEN_PROJECTS_EVENT` import

## Access to Projects is unchanged elsewhere
All still open the **Chat** Projects tab (handled in `workspace.tsx`, untouched):
- the Chat surface's **Projects tab**
- the **⌘9** keyboard shortcut
- the **`/projects`** deep-link

## Verified
`tsc` clean; full `test:app` green. Updated `projects-view.test.ts` to assert the sidebar no longer carries the entry/import. No conflict with the active `feat/projects-chat-cap` (#622) — it doesn't touch the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)