### PR TITLE
Fix iOS capability scoping

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,6 +3,11 @@
   "identifier": "default",
   "description": "enables the default permissions",
   "local": true,
+  "platforms": [
+    "linux",
+    "macOS",
+    "windows"
+  ],
   "windows": [
     "main"
   ],

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -63,6 +63,11 @@ function assertCapabilityDoesNotGrant(capability, deniedPermissions) {
 
 test("packaged desktop app can use native browser and terminal commands", () => {
   assert.equal(defaultCapability.local, true, "packaged local app origin must receive the default capability");
+  assert.deepEqual(
+    defaultCapability.platforms,
+    ["linux", "macOS", "windows"],
+    "desktop-only permissions must not leak into mobile Tauri builds",
+  );
   assert.ok(defaultCapability.permissions.includes("default"), "default capability should include custom app permissions");
 
   for (const permissionId of requiredPermissionIds) {
@@ -243,8 +248,8 @@ test("terminal commands use Tauri camelCase command arguments", () => {
   );
   assert.match(
     bottomTerminal,
-    /invoke\("pty_stop", \{ threadId: threadId \}/,
-    "pty_stop must pass threadId so desktop cleanup reaches Rust",
+    /Deliberately NO pty_stop here/,
+    "terminal unmount must not race the next pane mount by stopping the PTY",
   );
   assert.doesNotMatch(
     bottomTerminal,


### PR DESCRIPTION
## Summary
- scope the desktop Tauri capability to desktop platforms only so updater/process permissions do not leak into iOS builds
- refresh the desktop permissions guard for the current terminal lifecycle behavior

## Verification
- node src-tauri/permissions/desktop-permissions.test.mjs
- node scripts/mobile-tailscale-native.test.mjs
- PATH="/Users/buns/.cargo/bin:/Users/buns/.local/share/solana/install/active_release/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/usr/local/go/bin:/Users/buns/.rover/bin:/Users/buns/.cargo/bin:/Users/buns/.openclaw/agents/cody/agent/codex-home/tmp/arg0/codex-arg0DHJ3Bl:/Users/buns/.openclaw/npm/projects/openclaw-codex-8902d781d4/node_modules/@openclaw/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex-path:/opt/homebrew/Cellar/node/26.0.0/bin:/opt/homebrew/opt/node/bin:/Users/buns/Library/pnpm:/Users/buns/.local/bin:/Users/buns/.bun/bin:/Users/buns/.yarn/bin:/Users/buns/.foundry/bin:/Users/buns/.local/bin" cargo build --package app --manifest-path src-tauri/Cargo.toml --target aarch64-apple-ios --features "tauri/custom-protocol" --lib --release
- pnpm test:app
- git diff --check