### PR TITLE
fix(mobile): expand touch targets

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4418,6 +4418,17 @@ button:active > .edge-rail-chip {
     outline: var(--ring-width) solid var(--ring-focus);
     outline-offset: -2px;
   }
+  .top-bar__actions .notification-bell__trigger,
+  .top-bar__account {
+    width: var(--touch-target);
+    height: var(--touch-target);
+    min-width: var(--touch-target);
+    min-height: var(--touch-target);
+  }
+  .top-bar__account {
+    border-radius: var(--radius-control);
+    background: transparent;
+  }
   .top-bar__search {
     min-width: 0;
     width: 100%;

--- a/src/components/library-mobile-command-center.test.ts
+++ b/src/components/library-mobile-command-center.test.ts
@@ -46,4 +46,16 @@ assert.match(
   "Library lists should reserve space above the mobile bottom tabs",
 );
 
+assert.match(
+  styles,
+  /@media \(max-width: 767px\) \{[\s\S]*\.library-rail-item\s*\{[\s\S]*min-height\s*:\s*var\(--touch-target\)/,
+  "Library rail filter chips should meet the 44px mobile touch target",
+);
+
+assert.match(
+  styles,
+  /@media \(max-width: 767px\) \{[\s\S]*\.library-timeline-header \.ui-search-input,[\s\S]*\.library-timeline-select,[\s\S]*\.library-timeline-filter-button,[\s\S]*\.library-timeline-group-toggle\s*\{[\s\S]*min-height\s*:\s*var\(--touch-target\)/,
+  "Library timeline search, filters, and segmented controls should meet the 44px mobile touch target",
+);
+
 console.log("library-mobile-command-center.test.ts: ok");

--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -5,6 +5,7 @@ import { readFile } from "node:fs/promises";
 const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
 const mobileTabs = await readFile(new URL("./mobile-bottom-tabs.tsx", import.meta.url), "utf8");
 const topBar = await readFile(new URL("./top-bar.tsx", import.meta.url), "utf8");
+const notificationBell = await readFile(new URL("./notification-bell.tsx", import.meta.url), "utf8");
 const bottomTerminal = await readFile(new URL("./bottom-terminal.tsx", import.meta.url), "utf8");
 const browserPane = await readFile(new URL("./browser-pane.tsx", import.meta.url), "utf8");
 const globals = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
@@ -79,6 +80,18 @@ assert.match(
   globals,
   /@media \(max-width: 1023px\) \{[\s\S]*\.top-bar__search\s*\{[\s\S]*min-height:\s*var\(--touch-target\)/,
   "Mobile search button should meet the 44px touch target",
+);
+
+assert.match(
+  notificationBell,
+  /notification-bell__trigger/,
+  "Notification bell should expose a stable hook for mobile hit-area sizing",
+);
+
+assert.match(
+  globals,
+  /@media \(max-width: 1023px\) \{[\s\S]*\.top-bar__actions \.notification-bell__trigger,[\s\S]*\.top-bar__account\s*\{[\s\S]*width:\s*var\(--touch-target\)[\s\S]*height:\s*var\(--touch-target\)/,
+  "Mobile top-bar notification and account buttons should meet the 44px touch target",
 );
 
 assert.match(

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -119,7 +119,7 @@ export function NotificationBell({
     <div ref={wrapRef} className="relative">
       <button
         onClick={() => setOpen((v) => !v)}
-        className={`focus-ring relative grid h-7 w-7 place-items-center rounded-md border transition-colors ${
+        className={`notification-bell__trigger focus-ring relative grid h-7 w-7 place-items-center rounded-md border transition-colors ${
           displayBadgeCount > 0
             ? "border-[color-mix(in_oklch,var(--color-warning)_45%,var(--border-strong))] bg-[color-mix(in_oklch,var(--color-warning)_14%,transparent)] text-[var(--color-warning)] hover:bg-[color-mix(in_oklch,var(--color-warning)_22%,transparent)]"
             : "border-[var(--border-hairline)] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -2555,7 +2555,7 @@ h3:hover .library-heading-anchor,
   }
 
   .library-rail-item {
-    min-height: 34px;
+    min-height: var(--touch-target);
     width: auto;
     flex: 0 0 auto;
     border: 1px solid var(--border-hairline);
@@ -2621,6 +2621,44 @@ h3:hover .library-heading-anchor,
   .library-list-content--hidden {
     opacity: 1;
     pointer-events: auto;
+  }
+
+  .library-timeline-header.ui-view-header {
+    padding: 18px 16px 16px;
+    gap: 12px;
+  }
+
+  .library-timeline-header .ui-search-input,
+  .library-timeline-select,
+  .library-timeline-filter-button,
+  .library-timeline-group-toggle {
+    min-height: var(--touch-target);
+  }
+
+  .library-timeline-header .ui-search-input {
+    height: var(--touch-target);
+  }
+
+  .library-timeline-header .ui-search-input-leading {
+    width: var(--touch-target);
+  }
+
+  .library-timeline-select,
+  .library-timeline-filter-button {
+    height: var(--touch-target);
+    border-radius: 10px;
+    font-size: 13px;
+  }
+
+  .library-timeline-group-toggle {
+    height: var(--touch-target);
+    border-radius: 10px;
+    padding: 3px;
+  }
+
+  .library-timeline-group-toggle-option {
+    border-radius: 7px;
+    font-size: 13px;
   }
 
   .library-doclist-search {


### PR DESCRIPTION
## Summary
- expand mobile top-bar notification and account/settings controls to the shared 44px touch target
- expand Library mobile rail chips, timeline search, selects, and segmented filters to mobile-safe hit areas
- add smoke coverage for the mobile top-bar and Library command-center regressions

## Test Plan
- `pnpm test:mobile`
- `pnpm typecheck`
- `pnpm build`
- Playwright rendered check at 390x844 against `http://127.0.0.1:3011/`

## Rendered QA
- Top bar: search, notification, account/settings, and familiar controls measured at 44px hit height after clearing stale `.next` dev cache
- Library: rail chips, timeline search, selects, and group toggle measured at 44px hit height
- No visible framework error overlay in the rendered screenshots
