### PR TITLE
fix(mobile): fit notification popover

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4429,6 +4429,43 @@ button:active > .edge-rail-chip {
     border-radius: var(--radius-control);
     background: transparent;
   }
+  .top-bar__actions .notification-bell {
+    position: static;
+  }
+  .notification-bell__popover {
+    position: fixed;
+    left: calc(8px + var(--sai-left));
+    right: calc(8px + var(--sai-right));
+    top: calc(52px + var(--sai-top));
+    width: auto;
+    max-height: calc(100dvh - 64px - var(--sai-top) - var(--sai-bottom));
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .notification-bell__header {
+    min-height: var(--touch-target);
+    padding: 0 8px 0 12px;
+  }
+  .notification-bell__settings-btn,
+  .notification-bell__open-inbox {
+    min-width: var(--touch-target);
+    min-height: var(--touch-target);
+  }
+  .notification-bell__settings-btn {
+    width: var(--touch-target);
+    height: var(--touch-target);
+    opacity: 1;
+  }
+  .notification-bell__open-inbox {
+    display: inline-flex;
+    align-items: center;
+    padding: 0 10px;
+  }
+  .notification-bell__list {
+    max-height: none;
+    flex: 1 1 auto;
+  }
   .top-bar__search {
     min-width: 0;
     width: 100%;

--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -89,9 +89,27 @@ assert.match(
 );
 
 assert.match(
+  notificationBell,
+  /notification-bell__popover[\s\S]*notification-bell__settings-btn[\s\S]*notification-bell__open-inbox[\s\S]*notification-bell__list/,
+  "Notification bell should expose stable hooks for mobile popover layout and actions",
+);
+
+assert.match(
   globals,
   /@media \(max-width: 1023px\) \{[\s\S]*\.top-bar__actions \.notification-bell__trigger,[\s\S]*\.top-bar__account\s*\{[\s\S]*width:\s*var\(--touch-target\)[\s\S]*height:\s*var\(--touch-target\)/,
   "Mobile top-bar notification and account buttons should meet the 44px touch target",
+);
+
+assert.match(
+  globals,
+  /@media \(max-width: 1023px\) \{[\s\S]*\.notification-bell__popover\s*\{[\s\S]*position:\s*fixed;[\s\S]*left:\s*calc\(8px \+ var\(--sai-left\)\);[\s\S]*right:\s*calc\(8px \+ var\(--sai-right\)\);[\s\S]*width:\s*auto;/,
+  "Mobile notification popover should be fixed to the safe viewport instead of overflowing from the trigger",
+);
+
+assert.match(
+  globals,
+  /@media \(max-width: 1023px\) \{[\s\S]*\.notification-bell__settings-btn,[\s\S]*\.notification-bell__open-inbox\s*\{[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "Mobile notification popover header actions should meet the 44px touch target",
 );
 
 assert.match(

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -116,7 +116,7 @@ export function NotificationBell({
   }, []);
 
   return (
-    <div ref={wrapRef} className="relative">
+    <div ref={wrapRef} className="notification-bell relative">
       <button
         onClick={() => setOpen((v) => !v)}
         className={`notification-bell__trigger focus-ring relative grid h-7 w-7 place-items-center rounded-md border transition-colors ${
@@ -140,15 +140,15 @@ export function NotificationBell({
       </button>
 
       {open ? (
-        <div className="group/popover absolute right-0 top-full z-50 mt-1 w-[400px] rounded-xl border border-[var(--border-strong)] bg-[var(--bg-elevated)] shadow-2xl">
-          <div className="flex items-center justify-between border-b border-[var(--border-hairline)] px-3 py-2">
+        <div className="notification-bell__popover group/popover absolute right-0 top-full z-50 mt-1 w-[400px] rounded-xl border border-[var(--border-strong)] bg-[var(--bg-elevated)] shadow-2xl">
+          <div className="notification-bell__header flex items-center justify-between border-b border-[var(--border-hairline)] px-3 py-2">
             <span className="text-[11px] font-medium text-[var(--text-primary)]">
               Notifications
             </span>
-            <div className="flex items-center gap-1.5">
+            <div className="notification-bell__header-actions flex items-center gap-1.5">
               <button
                 onClick={() => setSettingsOpen((v) => !v)}
-                className="touch-always-visible focus-ring grid h-5 w-5 place-items-center rounded text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-primary)] group-hover/popover:opacity-100"
+                className="notification-bell__settings-btn touch-always-visible focus-ring grid h-5 w-5 place-items-center rounded text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-primary)] group-hover/popover:opacity-100"
                 title="Notification settings"
                 aria-label="Notification settings"
               >
@@ -159,7 +159,7 @@ export function NotificationBell({
                   setOpen(false);
                   onOpenInbox();
                 }}
-                className="focus-ring rounded text-[11px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
+                className="notification-bell__open-inbox focus-ring rounded text-[11px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
               >
                 Open Automations →
               </button>
@@ -231,7 +231,7 @@ export function NotificationBell({
               </ul>
             </div>
           ) : null}
-          <ul className="max-h-[420px] overflow-y-auto p-2 text-xs">
+          <ul className="notification-bell__list max-h-[420px] overflow-y-auto p-2 text-xs">
             {recent.length === 0 ? (
               <li className="px-2 py-6 text-center text-[11px] text-[var(--text-muted)]">
                 No notifications.


### PR DESCRIPTION
## Summary
- make the notification popover mobile-aware instead of anchoring a 400px desktop panel off the bell trigger
- keep the mobile panel inside safe viewport margins below the top bar
- make notification popover header actions visible and 44px-tappable on phones

## Test Plan
- `node --experimental-strip-types src/components/mobile-shell-smoke.test.ts`
- `pnpm test:mobile`
- `pnpm typecheck`
- `pnpm build`
- Playwright rendered check at 390x844 against `http://127.0.0.1:3012/`

## Rendered QA
- Before: popover x=-114, width=400 on a 390px viewport
- After: popover x=8, width=374, overflow=false
- Settings and Open Automations actions measured 44px high
