### PR TITLE
Polish mobile composer and library rendering

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // The Next.js dev tools launcher renders in a portal at bottom-left by
+  // default, which intercepts taps on Cave's mobile bottom tabs in local dev.
+  devIndicators: false,
   // Mobile dev access goes through Tailscale Serve while Next stays bound to
   // loopback. Next 16 blocks cross-origin dev internals unless the browser
   // origin is explicitly allowlisted, so permit tailnet HTTPS hostnames here.

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -163,6 +163,23 @@ for (const contract of contracts) {
     assert.match(source, /path not allowed|collection path not allowed/, `${contract.route} must preserve path-deny errors`);
     assert.match(source, /status:\s*403/, `${contract.route} path guard must preserve 403 response`);
   }
+  if (contract.route === "/library" || contract.route === "/library/doc") {
+    assert.match(
+      source,
+      /function realpathOrResolve\(value: string\)[\s\S]*fs\.realpathSync\(resolved\)/,
+      `${contract.route} should canonicalize familiar research roots through realpath`,
+    );
+    assert.match(
+      source,
+      /const root = realpathOrResolve\((?:researchRoot|RESEARCH_ROOT)\);[\s\S]*const resolved = realpathOrResolve\(p\);[\s\S]*resolved\.startsWith\(root \+ path\.sep\)/,
+      `${contract.route} should allow symlinked familiar research paths only within the real research root`,
+    );
+    assert.doesNotMatch(
+      source,
+      /resolveAllowedProjectPath/,
+      `${contract.route} should not reject symlinked familiar research dirs via the global project-root allowlist`,
+    );
+  }
   if (contract.localOriginGuard) {
     assert.match(source, /isLocalOrigin/, `${contract.route} must preserve local-origin guard`);
     assert.match(source, /status:\s*403/, `${contract.route} local-origin guard must preserve 403 response`);

--- a/src/app/api/library/doc/route.ts
+++ b/src/app/api/library/doc/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from "next/server";
 import fs from "node:fs";
 import path from "node:path";
 import { homedir } from "node:os";
-import { resolveAllowedProjectPath } from "@/lib/server/project-paths";
 import type { LibraryDocBody } from "@/lib/library-types";
 
 const SAGE_ROOT = path.join(homedir(), ".openclaw", "workspace", "sage");
@@ -10,10 +9,19 @@ const RESEARCH_ROOT = path.join(SAGE_ROOT, "research");
 const MAX_SIZE = 512 * 1024; // 512KB
 
 // Security: must be within sage research dir
+function realpathOrResolve(value: string): string {
+  const resolved = path.resolve(value);
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
 function resolveResearchPath(p: string): string | null {
-  const resolved = resolveAllowedProjectPath(p);
-  if (!resolved) return null;
-  if (resolved !== RESEARCH_ROOT && !resolved.startsWith(RESEARCH_ROOT + path.sep)) return null;
+  const root = realpathOrResolve(RESEARCH_ROOT);
+  const resolved = realpathOrResolve(p);
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) return null;
   return resolved;
 }
 
@@ -117,7 +125,7 @@ export async function GET(req: NextRequest) {
   const tags = extractTags(frontmatter);
   const excerpt = stripMarkdown(body).slice(0, 200);
 
-  const id = path.relative(SAGE_ROOT, resolved);
+  const id = path.relative(realpathOrResolve(SAGE_ROOT), resolved);
 
   const doc: LibraryDocBody = {
     id,

--- a/src/app/api/library/route.ts
+++ b/src/app/api/library/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from "next/server";
 import fs from "node:fs";
 import path from "node:path";
 import { homedir } from "node:os";
-import { resolveAllowedProjectPath } from "@/lib/server/project-paths";
 import type { LibraryDoc, LibraryCollection } from "@/lib/library-types";
 
 // ── Familiar registry ─────────────────────────────────────────────────────────
@@ -146,10 +145,19 @@ function buildCollections(familiar: typeof FAMILIAR_WORKSPACES[number]): Library
 }
 
 // ── Security helper ──────────────────────────────────────────────────────────
+function realpathOrResolve(value: string): string {
+  const resolved = path.resolve(value);
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
 function resolveResearchPath(p: string, researchRoot: string): string | null {
-  const resolved = resolveAllowedProjectPath(p);
-  if (!resolved) return null;
-  if (resolved !== researchRoot && !resolved.startsWith(researchRoot + path.sep)) return null;
+  const root = realpathOrResolve(researchRoot);
+  const resolved = realpathOrResolve(p);
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) return null;
   return resolved;
 }
 
@@ -203,6 +211,7 @@ export async function GET(req: NextRequest) {
 
   const familiar = FAMILIAR_WORKSPACES.find((f) => f.id === familiarId) ?? FAMILIAR_WORKSPACES[0];
   const researchRoot = path.join(familiar.root, "research");
+  const familiarRoot = realpathOrResolve(familiar.root);
   const collections = buildCollections(familiar);
 
   const col = collections.find((c) => c.id === collectionId) ?? collections[0];
@@ -225,7 +234,7 @@ export async function GET(req: NextRequest) {
       const content = fs.readFileSync(/* turbopackIgnore: true */ resolvedFile, "utf-8");
       const { frontmatter, body } = parseFrontmatter(content);
       docs.push({
-        id: path.relative(familiar.root, resolvedFile),
+        id: path.relative(familiarRoot, resolvedFile),
         title: frontmatter.title ?? extractTitle(body, file),
         familiar: familiar.id,
         collection: collectionId,

--- a/src/components/chat-view-mobile-command-center.test.ts
+++ b/src/components/chat-view-mobile-command-center.test.ts
@@ -43,14 +43,20 @@ assert.doesNotMatch(
 
 assert.match(
   styles,
-  /@media \(max-width: 767px\) \{[\s\S]*\.cave-chat-linear \.cave-chat-transcript\s*\{[\s\S]*padding-bottom\s*:\s*calc\(156px \+ var\(--sai-bottom\)\)[\s\S]*overscroll-behavior\s*:\s*contain/,
-  "Mobile transcript should reserve bottom safe-area breathing room above the composer",
+  /@media \(max-width: 767px\) \{[\s\S]*\.cave-chat-linear \.cave-chat-transcript\s*\{[\s\S]*padding-bottom\s*:\s*calc\(320px \+ var\(--sai-bottom\)\)[\s\S]*scroll-padding-bottom\s*:\s*calc\(336px \+ var\(--sai-bottom\)\)[\s\S]*overscroll-behavior\s*:\s*contain/,
+  "Mobile transcript should reserve bottom safe-area breathing room above the taller composer",
 );
 
 assert.match(
   styles,
   /@media \(max-width: 767px\) \{[\s\S]*\.cave-chat-linear \.cave-composer-dock\s*\{[\s\S]*bottom\s*:\s*0/,
   "Mobile composer should dock only inside the chat surface; the shell already reserves bottom-tab space",
+);
+
+assert.match(
+  styles,
+  /@media \(max-width: 767px\) \{[\s\S]*\.cave-chat-linear \.cave-composer-dock\s*\{[\s\S]*linear-gradient\(to top, var\(--bg-base\) 0%, var\(--bg-base\) 74%, color-mix\(in oklch, var\(--bg-base\) 96%, var\(--bg-raised\)\) 100%\)[\s\S]*box-shadow:\s*0 -18px 32px var\(--bg-base\)[\s\S]*backdrop-filter:\s*blur\(18px\)/,
+  "Mobile composer dock should be opaque enough that transcript content does not ghost through behind controls",
 );
 
 assert.match(
@@ -74,13 +80,13 @@ assert.match(
 assert.match(
   source,
   /className="cave-composer-controls flex items-center justify-between/,
-  "Composer controls should expose a mobile overlay hook",
+  "Composer controls should expose a mobile layout hook",
 );
 
 assert.match(
   styles,
-  /@media \(max-width: 767px\) \{[\s\S]*\.cave-composer-panel\s*\{[\s\S]*position\s*:\s*relative[\s\S]*\.cave-composer-controls\s*\{[\s\S]*position\s*:\s*absolute/,
-  "Mobile composer controls should overlay the composer panel instead of adding a second full row",
+  /@media \(max-width: 767px\) \{[\s\S]*\.cave-composer-panel\s*\{[\s\S]*display\s*:\s*flex[\s\S]*flex-direction\s*:\s*column[\s\S]*\.cave-composer-controls\s*\{[\s\S]*position\s*:\s*static[\s\S]*min-height\s*:\s*54px/,
+  "Mobile composer controls should sit in a footer row so they never cover multiline text",
 );
 
 assert.match(
@@ -105,6 +111,18 @@ assert.match(
   styles,
   /@media \(max-width: 767px\) \{[\s\S]*\.cave-composer-icon-button\s*\{[\s\S]*width\s*:\s*var\(--touch-target\)[\s\S]*height\s*:\s*var\(--touch-target\)/,
   "Mobile composer icon buttons should meet the 44px touch target",
+);
+
+assert.match(
+  styles,
+  /@media \(max-width: 767px\) \{[\s\S]*\.cave-composer-input\s*\{[\s\S]*min-height\s*:\s*116px[\s\S]*max-height\s*:\s*min\(34dvh, 188px\)/,
+  "Mobile composer input should start tall and only scroll after roughly 6-8 rows",
+);
+
+assert.match(
+  styles,
+  /@media \(max-width: 767px\) \{[\s\S]*\.cave-scroll-bottom-button\s*\{[\s\S]*bottom\s*:\s*calc\(244px \+ var\(--sai-bottom\)\)/,
+  "Mobile scroll-to-bottom FAB should sit above the taller composer",
 );
 
 console.log("chat-view-mobile-command-center.test.ts: ok");

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -65,6 +65,7 @@ assert.doesNotMatch(sidecarMonitorSource, /Boolean\(window\.__TAURI_INTERNALS__\
 assert.match(mobileScriptSource, /tailscale_cmd serve --bg "\$TAILSCALE_BACKEND"/, "mobile script should publish the exact loopback backend it started");
 assert.match(mobileScriptSource, /"authorization": `Bearer \$\{accessToken\}`/, "mobile script should authenticate its local invite API request");
 assert.match(nextConfigSource, /allowedDevOrigins:\s*\[[\s\S]*"\*\*\.ts\.net"/, "Next dev should allow Tailscale Serve origins for mobile browser access");
+assert.match(nextConfigSource, /devIndicators:\s*false/, "Next dev tools launcher should not intercept mobile bottom-tab taps");
 assert.match(mobileDocsSource, /signed (?:expiring )?invites?/, "mobile docs should describe the signed access token invite");
 assert.match(tauriSource, /sidecar_auth_token\(\)/, "Tauri sidecar should generate a per-launch token");
 assert.match(tauriSource, /\.env\("COVEN_CAVE_AUTH_TOKEN", &auth_token\)/, "Tauri sidecar should pass the token to Next.js");

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2143,10 +2143,10 @@ details[open] > .cave-tool-summary::before {
 
   .cave-chat-linear .cave-chat-transcript {
     padding: 16px 12px 96px;
-    padding-bottom: calc(156px + var(--sai-bottom));
+    padding-bottom: calc(320px + var(--sai-bottom));
     overscroll-behavior: contain;
     scroll-padding-top: calc(var(--sai-top) + 64px);
-    scroll-padding-bottom: calc(172px + var(--sai-bottom));
+    scroll-padding-bottom: calc(336px + var(--sai-bottom));
     -webkit-overflow-scrolling: touch;
   }
 
@@ -2196,7 +2196,7 @@ details[open] > .cave-tool-summary::before {
   }
 
   .cave-scroll-bottom-button {
-    bottom: calc(92px + var(--sai-bottom));
+    bottom: calc(244px + var(--sai-bottom));
     width: var(--touch-target);
     height: var(--touch-target);
     border-radius: 999px;
@@ -2211,8 +2211,10 @@ details[open] > .cave-tool-summary::before {
             8px
             clamp(12px, 3vw, 18px);
     background:
-      linear-gradient(to top, var(--bg-base) 68%, color-mix(in oklch, var(--bg-base) 86%, transparent));
+      linear-gradient(to top, var(--bg-base) 0%, var(--bg-base) 74%, color-mix(in oklch, var(--bg-base) 96%, var(--bg-raised)) 100%);
     border-top-color: color-mix(in oklch, var(--foreground) 10%, transparent);
+    box-shadow: 0 -18px 32px var(--bg-base);
+    backdrop-filter: blur(18px);
     contain: layout paint style;
     transform: translateY(calc(-1 * var(--composer-kb-offset, 0px)));
     transition: transform var(--duration-fast) var(--ease-decelerate);
@@ -2229,6 +2231,8 @@ details[open] > .cave-tool-summary::before {
 
   .cave-composer-panel {
     position: relative;
+    display: flex;
+    flex-direction: column;
     border-radius: 9px;
   }
 
@@ -2244,22 +2248,16 @@ details[open] > .cave-tool-summary::before {
   }
 
   .cave-composer-input {
-    min-height: 76px;
-    max-height: min(28vh, 140px);
-    padding: 11px 62px 12px 52px !important;
+    min-height: 116px;
+    max-height: min(34dvh, 188px);
+    padding: 12px 14px 8px !important;
     line-height: 1.45;
   }
 
   .cave-composer-controls {
-    pointer-events: none;
-    position: absolute;
-    inset-inline: 10px;
-    bottom: 10px;
-    padding: 0 !important;
-  }
-
-  .cave-composer-controls button {
-    pointer-events: auto;
+    position: static;
+    min-height: 54px;
+    padding: 0 10px 10px !important;
   }
 
   .cave-composer-icon-button {


### PR DESCRIPTION
## Summary
- make the mobile chat composer taller by default and move controls into a footer row so multiline text is not covered
- disable the Next dev tools launcher that intercepted mobile bottom-tab taps in local dev
- resolve symlinked familiar research library paths through realpaths so reading list/doc views return clean `research/...` IDs instead of unauthorized/path-deny errors

## Test Plan
- `node --experimental-strip-types src/app/api/api-contracts.test.ts && node --experimental-strip-types src/middleware.test.ts && node --experimental-strip-types src/components/chat-view-mobile-command-center.test.ts`
- `pnpm test:mobile`
- `pnpm typecheck`
- `pnpm build`
- Playwright mobile smoke at 390x844: bottom tabs clickable, no horizontal overflow, composer scroll starts after roughly 6-8 rows, `/api/library?collection=all` and `/api/library/doc` return 200 with clean `research/...` IDs
