### PR TITLE
Polish mobile command surfaces

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4805,6 +4805,22 @@ button:active > .edge-rail-chip {
     min-height: 36px;
     padding-inline: 12px;
   }
+
+  .automation-create-chat-btn {
+    min-height: var(--touch-target);
+    padding-inline: 14px;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .automation-list-row {
+    min-height: var(--touch-target);
+    padding-block: 12px;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .automation-list-row > span {
+    min-width: 0;
+  }
 }
 
 .chat-scope-tabs--minimal {

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -387,7 +387,7 @@ function Section({
               <button
                 type="button"
                 onClick={() => onSelect(item)}
-                className="group flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors"
+                className="automation-list-row group flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors"
                 style={{
                   background: selected ? "rgba(255,255,255,0.05)" : "transparent",
                 }}
@@ -743,7 +743,7 @@ function CodexRow({
       <button
         type="button"
         onClick={() => onSelect(auto)}
-        className="group flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors"
+        className="automation-list-row group flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors"
         style={{ background: selected ? "rgba(255,255,255,0.05)" : "transparent" }}
         onMouseEnter={(e) => { if (!selected) (e.currentTarget as HTMLButtonElement).style.background = "rgba(255,255,255,0.03)"; }}
         onMouseLeave={(e) => { if (!selected) (e.currentTarget as HTMLButtonElement).style.background = "transparent"; }}
@@ -1013,7 +1013,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder }: Pro
             <button
               type="button"
               onClick={onNewReminder}
-              className="inline-flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-1.5 text-[12px] font-medium whitespace-nowrap transition-colors hover:bg-white/5"
+              className="automation-create-chat-btn inline-flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-1.5 text-[12px] font-medium whitespace-nowrap transition-colors hover:bg-white/5"
               style={{
                 background: "var(--bg-raised)",
                 border: "1px solid var(--border-hairline)",

--- a/src/components/board-ux-polish.test.ts
+++ b/src/components/board-ux-polish.test.ts
@@ -4,6 +4,7 @@ import { readFile } from "node:fs/promises";
 
 const view = await readFile(new URL("./board-view.tsx", import.meta.url), "utf8");
 const kanban = await readFile(new URL("./board-kanban.tsx", import.meta.url), "utf8");
+const styles = await readFile(new URL("../styles/board.css", import.meta.url), "utf8");
 
 // ───────── Loading state (no empty-CTA flash on open) ─────────
 assert.match(view, /const \[hasLoaded, setHasLoaded\] = useState\(false\)/, "BoardView must track a hasLoaded flag");
@@ -36,5 +37,30 @@ assert.doesNotMatch(kanban, /aria-grabbed=\{isGrabbed\}/, "Deprecated aria-grabb
 // Keyboard DnD contract preserved.
 assert.match(kanban, /data-card-id=\{card\.id\}/, "Cards keep data-card-id for keyboard grab");
 assert.match(kanban, /board-kanban-card--grabbed/, "Grabbed visual affordance preserved");
+
+// ───────── Mobile board chrome ─────────
+assert.match(
+  styles,
+  /@media \(max-width: 767px\) \{[\s\S]*\.board-search-input\s*\{[\s\S]*height:\s*44px[\s\S]*\.board-view-toggle\s*\{[\s\S]*display:\s*none[\s\S]*\.board-toolbar-btn,\s*\n\s*\.board-new-card-btn\s*\{[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "Mobile board search and toolbar controls should meet thumb-sized touch targets",
+);
+
+assert.match(
+  styles,
+  /\.board-card-stack__filters\s*\{[\s\S]*flex:\s*0 0 54px[\s\S]*min-height:\s*54px[\s\S]*overflow-y:\s*hidden/,
+  "Mobile BoardCardStack filters should reserve full touch-sized chip height instead of clipping to a scrollbar sliver",
+);
+
+assert.match(
+  styles,
+  /\.board-card-stack__chip\s*\{[\s\S]*height:\s*var\(--touch-target\)/,
+  "Mobile BoardCardStack filter chips should meet the shared touch target",
+);
+
+assert.match(
+  styles,
+  /\.board-card-stack__section-add\s*\{[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "Mobile BoardCardStack section add button should meet the shared touch target",
+);
 
 console.log("board-ux-polish.test.ts: ok");

--- a/src/components/home-composer-mobile-gaps.test.ts
+++ b/src/components/home-composer-mobile-gaps.test.ts
@@ -33,6 +33,19 @@ assert.match(
   ".hc-suggestion > span ellipsis chain (min-width: 0 + overflow + text-overflow + nowrap)",
 );
 
+// ───── Phone composer controls are thumb-sized ─────
+assert.match(
+  css,
+  /@media \(max-width: 520px\)\s*\{[\s\S]*?\.hc-action-bar\s*\{[\s\S]*?flex-wrap:\s*wrap;[\s\S]*?\.hc-familiar-selector\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-send-btn\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-dest-pills\s*\{[\s\S]*?grid-template-columns:\s*repeat\(3,\s*minmax\(0,\s*1fr\)\);[\s\S]*?\.hc-dest-pill\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);/,
+  "phone composer action bar wraps into thumb-sized familiar/send/destination controls",
+);
+
+assert.match(
+  css,
+  /@media \(max-width: 520px\)\s*\{[\s\S]*?\.hc-suggestion\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);/,
+  "phone suggestion chips should meet the shared touch target",
+);
+
 // ───── Keyboard hint hides on touch ─────
 // Touch devices have no physical keyboard — hide the desktop-only legend.
 assert.match(

--- a/src/components/library-mobile-command-center.test.ts
+++ b/src/components/library-mobile-command-center.test.ts
@@ -58,4 +58,16 @@ assert.match(
   "Library timeline search, filters, and segmented controls should meet the 44px mobile touch target",
 );
 
+assert.match(
+  styles,
+  /@media \(max-width: 767px\) \{[\s\S]*\.library-timeline-group-toggle\s*\{[\s\S]*height\s*:\s*calc\(var\(--touch-target\) \+ 8px\)/,
+  "Library timeline segmented control should leave enough room for 44px inner options on phones",
+);
+
+assert.match(
+  styles,
+  /@media \(max-width: 767px\) \{[\s\S]*\.library-timeline-group-toggle-option\s*\{[\s\S]*min-height\s*:\s*var\(--touch-target\)/,
+  "Library timeline segmented control options should each meet the 44px mobile touch target",
+);
+
 console.log("library-mobile-command-center.test.ts: ok");

--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -8,6 +8,7 @@ const topBar = await readFile(new URL("./top-bar.tsx", import.meta.url), "utf8")
 const notificationBell = await readFile(new URL("./notification-bell.tsx", import.meta.url), "utf8");
 const bottomTerminal = await readFile(new URL("./bottom-terminal.tsx", import.meta.url), "utf8");
 const browserPane = await readFile(new URL("./browser-pane.tsx", import.meta.url), "utf8");
+const automationsView = await readFile(new URL("./automations-view.tsx", import.meta.url), "utf8");
 const globals = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
 
 assert.match(
@@ -133,4 +134,22 @@ assert.match(
   workspace,
   /familiarPanelRail=\{showCompanionRail \? \(/,
   "Browser and Agents modes should suppress the desktop companion trigger rail unless a floating rail tab is selected",
+);
+
+assert.match(
+  automationsView,
+  /automation-create-chat-btn/,
+  "Automations create-via-chat CTA should expose a stable mobile hit-area hook",
+);
+
+assert.match(
+  automationsView,
+  /automation-list-row/g,
+  "Automation rows should expose stable mobile row hooks",
+);
+
+assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.automation-create-chat-btn\s*\{[\s\S]*min-height:\s*var\(--touch-target\)[\s\S]*\.automation-list-row\s*\{[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "Automations mobile CTA and list rows should meet the shared touch target",
 );

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -50,6 +50,72 @@
 .board-new-card-btn:hover { background:color-mix(in oklch, var(--accent-presence) 85%, #000); transform:scale(1.02); }
 .board-new-card-btn:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:2px; }
 
+@media (max-width: 767px) {
+  .board-header {
+    align-items: stretch;
+    gap: 10px;
+    padding: 18px 16px 16px;
+  }
+
+  .board-header-title {
+    flex: 1 0 100%;
+    font-size: 22px;
+    line-height: 1.15;
+  }
+
+  .board-search-wrap {
+    flex: 1 0 100%;
+    min-width: 0;
+    max-width: none;
+    margin-left: 0;
+  }
+
+  .board-search-icon {
+    left: 14px;
+  }
+
+  .board-search-input {
+    height: 44px;
+    padding-inline: 44px 36px;
+    border-radius: 8px;
+    font-size: 16px;
+  }
+
+  .board-search-clear {
+    right: 8px;
+    width: 32px;
+    height: 32px;
+  }
+
+  .board-header-controls {
+    width: 100%;
+    margin-left: 0;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  .board-view-toggle {
+    display: none;
+  }
+
+  .board-toolbar-btn,
+  .board-new-card-btn {
+    min-height: var(--touch-target);
+    border-radius: 8px;
+    padding-inline: 14px;
+    font-size: 13px;
+  }
+
+  .board-toolbar-btn {
+    flex: 1 1 auto;
+    justify-content: center;
+  }
+
+  .board-new-card-btn {
+    flex: 0 0 auto;
+  }
+}
+
 .board-filter-chips { display:flex; flex-wrap:wrap; align-items:center; gap:5px; padding:6px 16px; border-bottom:1px solid var(--border-hairline); flex-shrink:0; }
 .board-filter-chip { display:inline-flex; align-items:center; gap:4px; padding:2px 8px; border-radius:20px; border:1px solid var(--border-strong); background:var(--bg-raised); color:var(--text-secondary); font-size:11px; cursor:default; }
 .board-filter-chip-remove { display:flex; align-items:center; justify-content:center; width:14px; height:14px; border-radius:4px; border:none; background:transparent; color:var(--text-muted); cursor:pointer; padding:0; margin-left:1px; transition:background .1s,color .1s; }
@@ -452,11 +518,15 @@
 }
 .board-card-stack__filters {
   display: flex;
+  align-items: center;
+  flex: 0 0 54px;
   gap: 6px;
+  min-height: 54px;
   overflow-x: auto;
+  overflow-y: hidden;
   scrollbar-width: none;
   margin: 0 calc(-1 * clamp(12px, 4vw, 18px)) 4px;
-  padding: 2px clamp(12px, 4vw, 18px);
+  padding: 5px clamp(12px, 4vw, 18px);
   position: sticky;
   top: 0;
   background: var(--bg-base);
@@ -467,8 +537,8 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  height: 32px;
-  padding: 0 12px;
+  height: var(--touch-target);
+  padding: 0 14px;
   border-radius: 999px;
   border: 1px solid var(--border-strong);
   background: var(--bg-raised);
@@ -529,7 +599,7 @@
   align-items: center;
   justify-content: center;
   min-width: var(--touch-target);
-  min-height: 32px;
+  min-height: var(--touch-target);
   padding: 0 10px;
   border-radius: 7px;
   border: 1px solid var(--border-hairline);

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -225,10 +225,64 @@
   font-weight: 500;
 }
 
-/* Hide text on very narrow viewports, keep icons */
 @media (max-width: 520px) {
-  .hc-dest-label { display: none; }
-  .hc-dest-pill { padding: 4px 6px; }
+  .hc-action-bar {
+    align-items: stretch;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 10px;
+  }
+
+  .hc-familiar-selector {
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: var(--touch-target);
+    padding: 0 34px 0 12px;
+  }
+
+  .hc-familiar-glyph {
+    width: 20px;
+    height: 20px;
+  }
+
+  .hc-familiar-select {
+    width: 100%;
+    max-width: none;
+    min-height: 36px;
+    font-size: 15px;
+  }
+
+  .hc-select-caret {
+    right: 12px;
+  }
+
+  .hc-send-btn {
+    min-height: var(--touch-target);
+    border-radius: 8px;
+    padding-inline: 16px;
+  }
+
+  .hc-dest-pills {
+    order: 3;
+    flex: 1 0 100%;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .hc-dest-pill {
+    min-height: var(--touch-target);
+    justify-content: center;
+    gap: 6px;
+    padding: 0 8px;
+    border-color: var(--border-hairline);
+    background: color-mix(in oklch, var(--bg-base) 72%, transparent);
+    font-size: 12px;
+  }
+
+  .hc-dest-label {
+    display: inline;
+  }
 }
 
 /* ── Send button ─────────────────────────────────────────────────────────── */
@@ -271,6 +325,14 @@
   opacity: 0.75;
   cursor: wait;
   transform: none;
+}
+
+@media (max-width: 520px) {
+  .hc-send-btn {
+    min-height: var(--touch-target);
+    border-radius: 8px;
+    padding-inline: 16px;
+  }
 }
 
 /* Spinner */
@@ -319,6 +381,16 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+@media (max-width: 520px) {
+  .hc-suggestion {
+    min-height: var(--touch-target);
+    justify-content: flex-start;
+    padding: 10px 14px;
+    border-radius: 999px;
+    font-size: 13px;
+  }
 }
 
 /* The label inside each chip needs its own overflow context with min-width: 0

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -2651,14 +2651,15 @@ h3:hover .library-heading-anchor,
   }
 
   .library-timeline-group-toggle {
-    height: var(--touch-target);
+    height: calc(var(--touch-target) + 8px);
     border-radius: 10px;
-    padding: 3px;
+    padding: 4px;
   }
 
   .library-timeline-group-toggle-option {
     border-radius: 7px;
     font-size: 13px;
+    min-height: var(--touch-target);
   }
 
   .library-doclist-search {


### PR DESCRIPTION
## Summary
- tighten mobile Board chrome, filter chips, and add controls around shared touch targets
- make Home composer controls, destination pills, and suggestions thumb-sized on phones
- improve mobile Automations and Library controls with stable hit-area hooks and test coverage

## Test Plan
- node --experimental-strip-types src/components/library-mobile-command-center.test.ts
- node --experimental-strip-types src/components/mobile-shell-smoke.test.ts
- node --experimental-strip-types src/components/board-ux-polish.test.ts
- node --experimental-strip-types src/components/home-composer-mobile-gaps.test.ts
- node --experimental-strip-types src/components/home-composer-polish.test.ts
- pnpm test:mobile
- pnpm typecheck
- pnpm build
- Playwright mobile render at 390x844 for Library: /tmp/coven-mobile-library-final.png