### PR TITLE
Polish mobile touch targets

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1783,6 +1783,13 @@ select {
 .ui-search-input-field::placeholder {
   color: var(--text-muted);
 }
+
+@media (max-width: 767px) {
+  .ui-search-input-field {
+    min-height: var(--touch-target);
+  }
+}
+
 .ui-search-input-clear {
   display: inline-flex;
   align-items: center;
@@ -2208,6 +2215,52 @@ select {
 
 .comux-terminal-resize:hover::after {
   opacity: 1;
+}
+
+@media (max-width: 767px) {
+  .comux-terminal-tab-strip {
+    min-height: calc(var(--touch-target) + 8px);
+    gap: 8px;
+    padding: 4px 8px;
+  }
+
+  .comux-terminal-toolbar-actions {
+    gap: 8px;
+  }
+
+  .comux-terminal-split-controls {
+    gap: 4px;
+    border-radius: 10px;
+    padding: 4px;
+  }
+
+  .comux-terminal-toolbar-button,
+  .comux-terminal-empty-add {
+    min-height: var(--touch-target);
+    border-radius: 8px;
+    padding-inline: 12px;
+    font-size: 12px;
+  }
+
+  .comux-terminal-add-button,
+  .comux-terminal-tab-close,
+  .comux-terminal-pane-action {
+    width: var(--touch-target);
+    height: var(--touch-target);
+    border-radius: 8px;
+  }
+
+  .comux-terminal-tab-close {
+    display: inline-flex;
+    justify-content: center;
+  }
+
+  .comux-terminal-pane-bar {
+    min-height: var(--touch-target);
+    gap: 8px;
+    padding-inline: 10px;
+    font-size: 12px;
+  }
 }
 
 /* ---- Projects viewer: file preview + project list ----------- */
@@ -3664,6 +3717,30 @@ button:active > .edge-rail-chip {
   opacity: 1;
 }
 
+@media (max-width: 767px) {
+  .shell-banner {
+    gap: 8px;
+    padding: 8px 8px 8px 16px;
+  }
+
+  .shell-banner__cta {
+    min-height: var(--touch-target);
+    border-radius: 10px;
+    padding-inline: 14px;
+    font-size: 13px;
+    white-space: nowrap;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .shell-banner__dismiss {
+    width: var(--touch-target);
+    height: var(--touch-target);
+    min-width: var(--touch-target);
+    border-radius: 10px;
+    -webkit-tap-highlight-color: transparent;
+  }
+}
+
 /* ────────────────────────────────────────────────
    Mobile top bar — drawer controls plus compact search/account actions.
    Desktop keeps the app chrome headerless; sidebar carries navigation and
@@ -4667,10 +4744,98 @@ button:active > .edge-rail-chip {
     position: sticky;
     top: 0;
     z-index: 55;
-    min-height: 42px;
+    min-height: calc(var(--touch-target) + 4px);
     background: color-mix(in oklch, var(--bg-raised) 92%, transparent);
     backdrop-filter: blur(14px) saturate(140%);
     -webkit-backdrop-filter: blur(14px) saturate(140%);
+  }
+
+  .chat-scope-tabs [role="tab"],
+  .chat-scope-tabs__new {
+    min-height: var(--touch-target);
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .chat-scope-tabs__new {
+    padding-inline: 12px;
+  }
+
+  .calendar-toolbar {
+    gap: 8px;
+    padding: 8px 12px;
+  }
+
+  .calendar-toolbar-icon,
+  .calendar-toolbar-button,
+  .calendar-heading-button,
+  .calendar-empty-action {
+    min-height: var(--touch-target);
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .calendar-toolbar-icon {
+    width: var(--touch-target);
+    height: var(--touch-target);
+    min-width: var(--touch-target);
+  }
+
+  .calendar-toolbar-button,
+  .calendar-empty-action {
+    border-radius: 10px;
+    padding-inline: 14px;
+    font-size: 13px;
+  }
+
+  .calendar-heading-button {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 10px;
+    padding-inline: 8px;
+  }
+
+  .browser-pane {
+    flex-direction: column;
+  }
+
+  .browser-tab-rail {
+    display: none;
+  }
+
+  .browser-toolbar {
+    position: relative;
+    min-height: calc(var(--touch-target) + 12px);
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 6px;
+    transform: none !important;
+    pointer-events: auto !important;
+  }
+
+  .browser-toolbar-button,
+  .browser-toolbar-save {
+    width: var(--touch-target);
+    height: var(--touch-target);
+    min-width: var(--touch-target);
+    border-radius: 10px;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .browser-address-form {
+    min-height: var(--touch-target);
+    min-width: 0;
+    order: 10;
+    flex-basis: 100%;
+    border-radius: 10px;
+    padding-inline: 12px;
+  }
+
+  .browser-address-input {
+    min-height: var(--touch-target);
+    font-size: 16px;
+  }
+
+  .browser-toolbar-close {
+    display: none;
   }
 
   .chat-list-surface {
@@ -4702,6 +4867,10 @@ button:active > .edge-rail-chip {
   .chat-list-new-button {
     min-height: var(--touch-target);
     -webkit-tap-highlight-color: transparent;
+  }
+
+  .chat-list-search-control input {
+    min-height: var(--touch-target);
   }
 
   .chat-list-filter-button {

--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -204,16 +204,16 @@ function SaveToLibraryButton({
 
   if (state === "saved") {
     return (
-      <IconButton icon="ph:check-bold" aria-label="Save to library" title="Saved" onClick={handleSave} />
+      <IconButton className="browser-toolbar-save" icon="ph:check-bold" aria-label="Save to library" title="Saved" onClick={handleSave} />
     );
   }
   if (state === "dedup") {
     return (
-      <IconButton icon="ph:bookmark-simple-fill" aria-label="Save to library" title="Already in library" onClick={handleSave} />
+      <IconButton className="browser-toolbar-save" icon="ph:bookmark-simple-fill" aria-label="Save to library" title="Already in library" onClick={handleSave} />
     );
   }
   return (
-    <IconButton icon="ph:bookmark-simple" aria-label="Save to library" title="Save to library" onClick={handleSave} />
+    <IconButton className="browser-toolbar-save" icon="ph:bookmark-simple" aria-label="Save to library" title="Save to library" onClick={handleSave} />
   );
 }
 
@@ -752,14 +752,14 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
 
       {/* ── Main area (toolbar + viewport) ──────────────────────── */}
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-      {/* ── Viewport (full-pane webview target) + collapsible toolbar ── */}
-      <div className="relative min-h-0 flex-1 overflow-hidden" style={{ background: "var(--bg-base)" }}>
-        {/* Toolbar — absolute overlay that slides down when open. The page
-            webview is hidden while it's open (see the bounds sync), so the
-            DOM toolbar and the native overlay never fight for the same space. */}
-        <header
+        {/* ── Viewport (full-pane webview target) + collapsible toolbar ── */}
+        <div className="relative min-h-0 flex-1 overflow-hidden" style={{ background: "var(--bg-base)" }}>
+          {/* Toolbar — absolute overlay that slides down when open. The page
+              webview is hidden while it's open (see the bounds sync), so the
+              DOM toolbar and the native overlay never fight for the same space. */}
+          <header
           className={[
-            "absolute inset-x-0 top-0 z-30 flex min-h-10 items-center gap-1",
+            "browser-toolbar absolute inset-x-0 top-0 z-30 flex min-h-10 items-center gap-1",
             "border-b border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2 py-1.5",
             "transition-transform duration-150 ease-out",
             toolbarOpen ? "translate-y-0" : "pointer-events-none -translate-y-full",
@@ -768,13 +768,13 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
         >
           {/* Back */}
           <button type="button" onClick={goBack} disabled={!canBack}
-            className="focus-ring grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)] disabled:opacity-30 disabled:cursor-default"
+            className="browser-toolbar-button focus-ring grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)] disabled:opacity-30 disabled:cursor-default"
             title="Back" aria-label="Back">
             <Icon name="ph:arrow-left-bold" width={13} />
           </button>
           {/* Forward */}
           <button type="button" onClick={goForward} disabled={!canForward}
-            className="focus-ring grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)] disabled:opacity-30 disabled:cursor-default"
+            className="browser-toolbar-button focus-ring grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)] disabled:opacity-30 disabled:cursor-default"
             title="Forward" aria-label="Forward">
             <Icon name="ph:arrow-right-bold" width={13} />
           </button>
@@ -784,7 +784,7 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
               if (bridge) void bridge.invoke("browser_reload", { label: tabLabel(activeTabId) });
               else navigateTo(activeUrl);
             }}
-            className="focus-ring grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)]"
+            className="browser-toolbar-button focus-ring grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)]"
             title={loading ? "Stop" : "Reload"} aria-label={loading ? "Stop" : "Reload"}>
             {loading
               ? <Icon name="ph:x-bold" width={12} />
@@ -793,7 +793,7 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
           {/* Address bar */}
           <form
             onSubmit={(e) => { e.preventDefault(); navigateTo(addressBar); }}
-            className="flex flex-1 items-center gap-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 py-1 focus-within:border-[var(--accent-presence)]"
+            className="browser-address-form flex flex-1 items-center gap-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 py-1 focus-within:border-[var(--accent-presence)]"
           >
             {activeUrl.startsWith("https://") && (
               <Icon name="ph:lock-simple-bold" width={11} className="shrink-0 text-[var(--fg-muted)]" />
@@ -805,12 +805,12 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
               onChange={(e) => setAddressBar(e.target.value)}
               onFocus={(e) => e.currentTarget.select()}
               placeholder="Search or enter address"
-              className="focus-ring-inset flex-1 rounded bg-transparent text-[12px] text-[var(--fg-base)]"
+              className="browser-address-input focus-ring-inset flex-1 rounded bg-transparent text-[12px] text-[var(--fg-base)]"
             />
           </form>
           {/* Home */}
           <button type="button" onClick={() => navigateTo(HOME_URL)}
-            className="focus-ring grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)]"
+            className="browser-toolbar-button focus-ring grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)]"
             title="Home" aria-label="Home">
             <Icon name="ph:house-bold" width={13} />
           </button>
@@ -831,13 +831,13 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
                 window.open(activeUrl, "_blank", "noopener");
               }
             }}
-            className="focus-ring grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)]"
+            className="browser-toolbar-button focus-ring grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)]"
             title="Open in system browser" aria-label="Open in system browser">
             <Icon name="ph:arrow-square-out" width={13} />
           </button>
           {/* Close toolbar — restores the full-pane page */}
           <button type="button" onClick={() => setToolbarOpen(false)}
-            className="focus-ring grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)]"
+            className="browser-toolbar-button browser-toolbar-close focus-ring grid h-7 w-7 place-items-center rounded text-[var(--fg-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--fg-base)]"
             title="Close (Esc)" aria-label="Close address bar">
             <Icon name="ph:x-bold" width={12} />
           </button>

--- a/src/components/browser-polish.test.ts
+++ b/src/components/browser-polish.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const pane = await readFile(new URL("./browser-pane.tsx", import.meta.url), "utf8");
+const globals = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
 
 // ───────── Task 1: Keyboard hint footer + [ shortcut ─────────
 assert.match(
@@ -51,6 +52,33 @@ assert.doesNotMatch(
   pane,
   /w-\[2px\] rounded-r-full bg-\[var\(--fg-base\)\]\/20/,
   "Old 2px accent dot must be removed",
+);
+
+// ───────── Mobile browser chrome ─────────
+assert.match(pane, /browser-toolbar/, "Browser toolbar should expose a stable mobile chrome hook");
+assert.match(pane, /browser-toolbar-button/, "Browser toolbar buttons should expose a mobile hook");
+assert.match(pane, /browser-address-form/, "Browser address form should expose a mobile hook");
+assert.match(pane, /browser-address-input/, "Browser address input should expose a mobile hook");
+assert.match(pane, /browser-toolbar-save/, "Browser save button should expose a mobile hook");
+assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.browser-tab-rail\s*\{[\s\S]*display:\s*none/,
+  "Mobile browser should hide the hover rail instead of exposing tiny offscreen controls",
+);
+assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.browser-toolbar\s*\{[\s\S]*transform:\s*none !important[\s\S]*pointer-events:\s*auto !important/,
+  "Mobile browser toolbar should stay visible without relying on hover or keyboard shortcuts",
+);
+assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.browser-toolbar-button,[\s\S]*\.browser-toolbar-save\s*\{[\s\S]*width:\s*var\(--touch-target\)[\s\S]*height:\s*var\(--touch-target\)/,
+  "Mobile browser toolbar buttons should meet the shared touch target",
+);
+assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.browser-address-input\s*\{[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "Mobile browser address input should meet the shared touch target",
 );
 
 // ───────── Task 4: Quick-open backdrop ─────────

--- a/src/components/calendar-view-polish.test.ts
+++ b/src/components/calendar-view-polish.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const source = await readFile(new URL("./calendar-view.tsx", import.meta.url), "utf8");
+const globals = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
 
 // ───────── Task 1: AM/PM hour labels ─────────
 assert.match(
@@ -145,4 +146,21 @@ assert.match(
   source,
   /aria-label="Add event"/,
   "Toolbar Add event button is labeled",
+);
+
+// ───────── Mobile toolbar hit areas ─────────
+assert.match(source, /calendar-toolbar/, "Calendar toolbar should expose a stable mobile hook");
+assert.match(source, /calendar-toolbar-icon/, "Calendar icon buttons should expose a mobile hook");
+assert.match(source, /calendar-toolbar-button/, "Calendar toolbar buttons should expose a mobile hook");
+assert.match(source, /calendar-heading-button/, "Calendar heading button should expose a mobile hook");
+assert.match(source, /calendar-empty-action/, "Calendar empty-state actions should expose a mobile hook");
+assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.calendar-toolbar-icon,[\s\S]*\.calendar-toolbar-button,[\s\S]*\.calendar-heading-button,[\s\S]*\.calendar-empty-action\s*\{[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "Mobile calendar toolbar and empty-state controls should meet the shared touch target",
+);
+assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.calendar-toolbar-icon\s*\{[\s\S]*width:\s*var\(--touch-target\)[\s\S]*height:\s*var\(--touch-target\)/,
+  "Mobile calendar icon buttons should be square touch targets",
 );

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -172,7 +172,7 @@ function EmptyScheduleState({
         <button
           type="button"
           onClick={onAddEntry}
-          className="inline-flex h-8 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 text-[11px] font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--bg-elevated)]"
+          className="calendar-empty-action inline-flex h-8 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 text-[11px] font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--bg-elevated)]"
         >
           <Icon name="ph:plus" width={12} />
           Add task or event
@@ -231,7 +231,7 @@ function AgendaView({
           <button
             type="button"
             onClick={() => setShowPast(true)}
-            className="focus-ring rounded-md border border-[var(--border-hairline)] px-3 py-1 text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+            className="calendar-empty-action focus-ring rounded-md border border-[var(--border-hairline)] px-3 py-1 text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
           >
             Show {pastCount} past item{pastCount !== 1 ? "s" : ""}
           </button>
@@ -240,7 +240,7 @@ function AgendaView({
           <button
             type="button"
             onClick={() => onAddEntry({ fireAt: defaultEntryFireAt(anchor) })}
-            className="focus-ring inline-flex items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-3 py-1 text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+            className="calendar-empty-action focus-ring inline-flex items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-3 py-1 text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
           >
             <Icon name="ph:plus" width={11} />
             Add task or event
@@ -257,7 +257,7 @@ function AgendaView({
           <button
             type="button"
             onClick={() => setShowPast(false)}
-            className="focus-ring rounded-md px-2 py-0.5 text-[10px] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+            className="calendar-empty-action focus-ring rounded-md px-2 py-0.5 text-[10px] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
           >
             Hide past
           </button>
@@ -1100,26 +1100,26 @@ export function CalendarView({ items, familiars, activeFamiliarId, onAddEntry, o
   return (
     <div ref={containerRef} className="relative flex h-full min-w-0 flex-col bg-[var(--bg-base)]">
       {/* Header */}
-      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-[var(--border-hairline)] px-3 py-3 sm:gap-3 sm:px-6">
+      <div className="calendar-toolbar flex shrink-0 flex-wrap items-center gap-2 border-b border-[var(--border-hairline)] px-3 py-3 sm:gap-3 sm:px-6">
         <div className="flex shrink-0 items-center gap-1">
           {/* Nav arrows */}
           <button
             onClick={() => navigate(-1)}
             aria-label="Previous"
-            className="focus-ring grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+            className="calendar-toolbar-icon focus-ring grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
           >
             <Icon name="ph:arrow-left-bold" width={12} />
           </button>
           <button
             onClick={() => setAnchor(new Date())}
-            className="focus-ring inline-flex h-7 items-center rounded-md border border-[var(--border-hairline)] px-2.5 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)]"
+            className="calendar-toolbar-button focus-ring inline-flex h-7 items-center rounded-md border border-[var(--border-hairline)] px-2.5 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)]"
           >
             Today
           </button>
           <button
             onClick={() => navigate(1)}
             aria-label="Next"
-            className="focus-ring grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+            className="calendar-toolbar-icon focus-ring grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
           >
             <Icon name="ph:arrow-right-bold" width={12} />
           </button>
@@ -1132,7 +1132,7 @@ export function CalendarView({ items, familiars, activeFamiliarId, onAddEntry, o
             onClick={() => setPickerOpen((v) => !v)}
             aria-expanded={pickerOpen}
             aria-haspopup="dialog"
-            className="focus-ring truncate text-sm font-semibold text-[var(--text-primary)] transition-colors hover:text-[var(--accent-presence)]"
+            className="calendar-heading-button focus-ring truncate text-sm font-semibold text-[var(--text-primary)] transition-colors hover:text-[var(--accent-presence)]"
           >
             {headingLabel()}
           </button>
@@ -1173,7 +1173,7 @@ export function CalendarView({ items, familiars, activeFamiliarId, onAddEntry, o
             type="button"
             onClick={() => onAddEntry({ fireAt: defaultEntryFireAt(anchor) })}
             aria-label="Add event"
-            className="focus-ring inline-flex h-7 shrink-0 items-center gap-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+            className="calendar-toolbar-button focus-ring inline-flex h-7 shrink-0 items-center gap-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
           >
             <Icon name="ph:plus-bold" width={10} />
             Add event

--- a/src/components/chat-list-mobile-command-center.test.ts
+++ b/src/components/chat-list-mobile-command-center.test.ts
@@ -43,6 +43,12 @@ assert.match(
 
 assert.match(
   styles,
+  /@media \(max-width: 767px\) \{[\s\S]*\.chat-list-search-control input\s*\{[\s\S]*min-height\s*:\s*var\(--touch-target\)/,
+  "Mobile chat list search input should fill its touch-sized search control",
+);
+
+assert.match(
+  styles,
   /@media \(max-width: 767px\) \{[\s\S]*\.chat-list-footer\s*\{[\s\S]*display\s*:\s*none/,
   "Mobile chat list should drop the desktop keyboard-shortcut footer",
 );

--- a/src/components/chat-surface-mobile-command-center.test.ts
+++ b/src/components/chat-surface-mobile-command-center.test.ts
@@ -31,6 +31,18 @@ assert.match(
 
 assert.match(
   styles,
+  /@media \(max-width: 767px\) \{[\s\S]*\.chat-scope-tabs\s*\{[\s\S]*min-height\s*:\s*calc\(var\(--touch-target\) \+ 4px\)/,
+  "Mobile chat tab strip should leave room for touch-sized tabs",
+);
+
+assert.match(
+  styles,
+  /@media \(max-width: 767px\) \{[\s\S]*\.chat-scope-tabs \[role="tab"\],[\s\S]*\.chat-scope-tabs__new\s*\{[\s\S]*min-height\s*:\s*var\(--touch-target\)/,
+  "Mobile chat scope tabs and New action should meet the shared touch target",
+);
+
+assert.match(
+  styles,
   /@media \(max-width: 767px\) \{[\s\S]*\.shell-detail:has\(> \.cave-mode-fade > \.chat-surface\)\s*\{[\s\S]*overflow\s*:\s*hidden/,
   "Mobile chat should prevent the shell detail from becoming a second scroll owner",
 );

--- a/src/components/comux-view-terminal.test.ts
+++ b/src/components/comux-view-terminal.test.ts
@@ -10,6 +10,10 @@ const workspace = readFileSync(
   new URL("./workspace.tsx", import.meta.url),
   "utf8",
 );
+const globals = readFileSync(
+  new URL("../app/globals.css", import.meta.url),
+  "utf8",
+);
 
 // Keyboard hint footer (matches the inbox/calendar/library/home/browser pattern).
 assert.match(
@@ -29,6 +33,16 @@ assert.match(
   /title="New terminal \(⌘N\)"/,
   "tab-strip add button has tooltip with shortcut",
 );
+assert.match(
+  source,
+  /comux-terminal-tab-strip/,
+  "terminal tab strip exposes a stable mobile layout hook",
+);
+assert.match(
+  source,
+  /comux-terminal-toolbar-button[\s\S]*Split right[\s\S]*comux-terminal-toolbar-button[\s\S]*Split down[\s\S]*comux-terminal-add-button/,
+  "terminal toolbar actions expose stable mobile hit-area hooks",
+);
 
 // Empty-state copy + ⌘N kbd hint.
 assert.match(
@@ -45,6 +59,11 @@ assert.match(
   source,
   /<kbd[\s\S]{0,200}⌘N[\s\S]{0,20}<\/kbd>/,
   "empty state shows the ⌘N kbd hint",
+);
+assert.match(
+  source,
+  /comux-terminal-empty-add/,
+  "terminal empty-state add button exposes a stable mobile hit-area hook",
 );
 
 // ⌘N / ⌘W keydown handler is wired and respects modifier + contentEditable gate.
@@ -81,6 +100,11 @@ assert.match(
   workspace,
   /\{terminalDetail\}[\s\S]{0,80}\{mode === "terminal" \? null :/,
   "Workspace should always render the terminal subtree and hide other detail surfaces while Terminal is active",
+);
+assert.match(
+  workspace,
+  /: "pointer-events-none invisible absolute inset-0 opacity-0"/,
+  "Hidden terminal subtree should be invisible instead of only transparent",
 );
 assert.doesNotMatch(
   workspace,
@@ -145,6 +169,21 @@ assert.match(
   source,
   /onSplitTerminal\("vertical"\)[\s\S]*?Split down/,
   "toolbar exposes a split-down command",
+);
+assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.comux-terminal-tab-strip\s*\{[\s\S]*min-height:\s*calc\(var\(--touch-target\) \+ 8px\)/,
+  "mobile terminal tab strip should leave room for touch-sized actions",
+);
+assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.comux-terminal-toolbar-button,[\s\S]*\.comux-terminal-empty-add\s*\{[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "mobile terminal toolbar buttons should meet the shared touch target",
+);
+assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.comux-terminal-add-button,[\s\S]*\.comux-terminal-tab-close,[\s\S]*\.comux-terminal-pane-action\s*\{[\s\S]*width:\s*var\(--touch-target\)[\s\S]*height:\s*var\(--touch-target\)/,
+  "mobile terminal icon and close buttons should meet the shared touch target",
 );
 
 // Projects view: the file/navigation side and preview side should share the

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -474,7 +474,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
       {view === "terminal" ? (
         <div className="flex flex-1 flex-col min-h-0">
           {/* Session tab strip */}
-          <div className="flex items-center gap-2 border-b border-[var(--border-hairline)] bg-[var(--bg-raised)]/20 px-2 py-1 text-[11px]">
+          <div className="comux-terminal-tab-strip flex items-center gap-2 border-b border-[var(--border-hairline)] bg-[var(--bg-raised)]/20 px-2 py-1 text-[11px]">
             <div className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto">
               {sessions.map((s, i) => (
                 <div
@@ -514,7 +514,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                       e.stopPropagation();
                       removeSession(i);
                     }}
-                    className="hidden items-center text-[var(--text-muted)] hover:text-[var(--text-primary)] group-hover:inline-flex"
+                    className="comux-terminal-tab-close hidden items-center text-[var(--text-muted)] hover:text-[var(--text-primary)] group-hover:inline-flex"
                     aria-label={`Close ${s.label}`}
                   >
                     <Icon name="ph:x-bold" width={10} />
@@ -522,13 +522,13 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                 </div>
               ))}
             </div>
-            <div className="flex shrink-0 items-center gap-1.5">
-              <div className="flex items-center gap-0.5 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 p-0.5">
+            <div className="comux-terminal-toolbar-actions flex shrink-0 items-center gap-1.5">
+              <div className="comux-terminal-split-controls flex items-center gap-0.5 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 p-0.5">
                 <button
                   type="button"
                   onClick={() => onSplitTerminal("horizontal")}
                   disabled={sessions.length === 0}
-                  className="inline-flex items-center gap-1 rounded-[5px] px-1.5 py-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] disabled:pointer-events-none disabled:opacity-40"
+                  className="comux-terminal-toolbar-button inline-flex items-center gap-1 rounded-[5px] px-1.5 py-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] disabled:pointer-events-none disabled:opacity-40"
                   title="Split right"
                 >
                   <Icon name="ph:columns" width={12} aria-hidden />
@@ -538,7 +538,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                   type="button"
                   onClick={() => onSplitTerminal("vertical")}
                   disabled={sessions.length === 0}
-                  className="inline-flex items-center gap-1 rounded-[5px] px-1.5 py-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] disabled:pointer-events-none disabled:opacity-40"
+                  className="comux-terminal-toolbar-button inline-flex items-center gap-1 rounded-[5px] px-1.5 py-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] disabled:pointer-events-none disabled:opacity-40"
                   title="Split down"
                 >
                   <Icon name="ph:rows" width={12} aria-hidden />
@@ -550,7 +550,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                 onClick={() => addSession()}
                 aria-label="New terminal"
                 title="New terminal (⌘N)"
-                className="inline-grid h-[22px] w-[22px] place-items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)]"
+                className="comux-terminal-add-button inline-grid h-[22px] w-[22px] place-items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)]"
               >
                 <Icon name="ph:plus" width={12} aria-hidden />
               </button>
@@ -571,7 +571,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                   <button
                     type="button"
                     onClick={() => addSession()}
-                    className="rounded border border-[var(--border-hairline)] px-3 py-1 text-xs text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+                    className="comux-terminal-empty-add rounded border border-[var(--border-hairline)] px-3 py-1 text-xs text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
                   >
                     + New terminal
                   </button>

--- a/src/components/home-composer-mobile-gaps.test.ts
+++ b/src/components/home-composer-mobile-gaps.test.ts
@@ -36,7 +36,7 @@ assert.match(
 // ───── Phone composer controls are thumb-sized ─────
 assert.match(
   css,
-  /@media \(max-width: 520px\)\s*\{[\s\S]*?\.hc-action-bar\s*\{[\s\S]*?flex-wrap:\s*wrap;[\s\S]*?\.hc-familiar-selector\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-send-btn\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-dest-pills\s*\{[\s\S]*?grid-template-columns:\s*repeat\(3,\s*minmax\(0,\s*1fr\)\);[\s\S]*?\.hc-dest-pill\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);/,
+  /@media \(max-width: 520px\)\s*\{[\s\S]*?\.hc-action-bar\s*\{[\s\S]*?flex-wrap:\s*wrap;[\s\S]*?\.hc-familiar-selector\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-familiar-select\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-send-btn\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-dest-pills\s*\{[\s\S]*?grid-template-columns:\s*repeat\(3,\s*minmax\(0,\s*1fr\)\);[\s\S]*?\.hc-dest-pill\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);/,
   "phone composer action bar wraps into thumb-sized familiar/send/destination controls",
 );
 

--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -3,11 +3,13 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
+const shell = await readFile(new URL("./shell.tsx", import.meta.url), "utf8");
 const mobileTabs = await readFile(new URL("./mobile-bottom-tabs.tsx", import.meta.url), "utf8");
 const topBar = await readFile(new URL("./top-bar.tsx", import.meta.url), "utf8");
 const notificationBell = await readFile(new URL("./notification-bell.tsx", import.meta.url), "utf8");
 const bottomTerminal = await readFile(new URL("./bottom-terminal.tsx", import.meta.url), "utf8");
 const browserPane = await readFile(new URL("./browser-pane.tsx", import.meta.url), "utf8");
+const comuxView = await readFile(new URL("./comux-view.tsx", import.meta.url), "utf8");
 const automationsView = await readFile(new URL("./automations-view.tsx", import.meta.url), "utf8");
 const globals = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
 
@@ -84,6 +86,12 @@ assert.match(
 );
 
 assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.ui-search-input-field\s*\{[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "Shared mobile search input fields should fill their touch-sized wrappers",
+);
+
+assert.match(
   notificationBell,
   /notification-bell__trigger/,
   "Notification bell should expose a stable hook for mobile hit-area sizing",
@@ -99,6 +107,18 @@ assert.match(
   globals,
   /@media \(max-width: 1023px\) \{[\s\S]*\.top-bar__actions \.notification-bell__trigger,[\s\S]*\.top-bar__account\s*\{[\s\S]*width:\s*var\(--touch-target\)[\s\S]*height:\s*var\(--touch-target\)/,
   "Mobile top-bar notification and account buttons should meet the 44px touch target",
+);
+
+assert.match(
+  shell,
+  /shell-banner__cta[\s\S]*shell-banner__dismiss/,
+  "Shell banners should expose stable CTA and dismiss hooks",
+);
+
+assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.shell-banner__cta\s*\{[\s\S]*min-height:\s*var\(--touch-target\)[\s\S]*\.shell-banner__dismiss\s*\{[\s\S]*width:\s*var\(--touch-target\)[\s\S]*height:\s*var\(--touch-target\)/,
+  "Mobile shell banner CTA and dismiss controls should meet the shared touch target",
 );
 
 assert.match(
@@ -152,4 +172,22 @@ assert.match(
   globals,
   /@media \(max-width: 767px\) \{[\s\S]*\.automation-create-chat-btn\s*\{[\s\S]*min-height:\s*var\(--touch-target\)[\s\S]*\.automation-list-row\s*\{[\s\S]*min-height:\s*var\(--touch-target\)/,
   "Automations mobile CTA and list rows should meet the shared touch target",
+);
+
+assert.match(
+  workspace,
+  /mode === "terminal"[\s\S]*\? "relative"[\s\S]*: "pointer-events-none invisible absolute inset-0 opacity-0"/,
+  "Inactive persistent terminal detail should be invisible, not just transparent, on mobile surfaces",
+);
+
+assert.match(
+  comuxView,
+  /comux-terminal-toolbar-button[\s\S]*Split right[\s\S]*comux-terminal-toolbar-button[\s\S]*Split down[\s\S]*comux-terminal-add-button/,
+  "Terminal toolbar actions should expose stable mobile hit-area hooks",
+);
+
+assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.comux-terminal-toolbar-button,[\s\S]*\.comux-terminal-empty-add\s*\{[\s\S]*min-height:\s*var\(--touch-target\)[\s\S]*\.comux-terminal-add-button,[\s\S]*\.comux-terminal-tab-close,[\s\S]*\.comux-terminal-pane-action\s*\{[\s\S]*width:\s*var\(--touch-target\)[\s\S]*height:\s*var\(--touch-target\)/,
+  "Terminal mobile toolbar and close controls should meet the shared touch target",
 );

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1210,7 +1210,7 @@ export function Workspace() {
         "h-full min-h-0 flex flex-col",
         mode === "terminal"
           ? "relative"
-          : "pointer-events-none absolute inset-0 opacity-0",
+          : "pointer-events-none invisible absolute inset-0 opacity-0",
       ].join(" ")}
       aria-hidden={mode !== "terminal"}
     >

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -248,7 +248,7 @@
   .hc-familiar-select {
     width: 100%;
     max-width: none;
-    min-height: 36px;
+    min-height: var(--touch-target);
     font-size: 15px;
   }
 


### PR DESCRIPTION
## Summary
- expands mobile touch targets across terminal chrome, chat tabs, shell banners, search inputs, calendar controls, and browser toolbar controls
- hides the browser hover rail on mobile and makes the browser toolbar/address bar usable without hover shortcuts
- adds stable hook coverage for the mobile control contracts

## Test Plan
- node --experimental-strip-types src/components/browser-polish.test.ts && node --experimental-strip-types src/components/calendar-view-polish.test.ts && node --experimental-strip-types src/components/comux-view-terminal.test.ts && node --experimental-strip-types src/components/home-composer-mobile-gaps.test.ts && node --experimental-strip-types src/components/chat-list-mobile-command-center.test.ts && node --experimental-strip-types src/components/chat-surface-mobile-command-center.test.ts && node --experimental-strip-types src/components/mobile-shell-smoke.test.ts
- pnpm test:mobile
- pnpm typecheck
- Playwright mobile audit at 390x844: Calendar tinyCount=0 overflowX=0; Browser tinyCount=0 overflowX=0
- pnpm build