### PR TITLE
chore(release): v0.0.83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.83] - 2026-06-15
+
+Patch release carrying the latest `main` polish on top of the refreshed
+OpenCoven app icon (shipped in 0.0.82).
+
+### Changed
+- **Navigation** — Projects moved out of the left sidebar; it now lives solely as the Chat Projects tab.
+- **Capabilities** — skill markdown renders as a styled preview in the inspector.
+
+### Fixed
+- **Mobile** — composer/library rendering polish, notification popover fit, and larger touch targets.
+- **iOS** — capability scoping fix.
+
 ## [0.0.82] - 2026-06-14
 
 This patch release ships the Tailscale/proxy fixes needed for the new Cave release, plus the latest Projects and mobile handoff polish from `main`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.82",
+  "version": "0.0.83",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.82"
+version = "0.0.83"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.82"
+version = "0.0.83"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.82</string>
+	<string>0.0.83</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.82</string>
+	<string>0.0.83</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.82</string>
+	<string>0.0.83</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.82</string>
+	<string>0.0.83</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.82",
+  "version": "0.0.83",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Cuts **v0.0.83**. The refreshed OpenCoven app icon already shipped in 0.0.82; this release carries the unreleased `main` polish on top: Projects sidebar→tab nav change (#624), capabilities skill-markdown preview (#626), mobile rendering/popover/touch-target fixes, and the iOS capability-scoping fix.

Version bumped consistently across package.json, Cargo.toml, Cargo.lock (`app`), tauri.conf.json, `Info.ios.plist`, `gen/apple/app_iOS/Info.plist`, + CHANGELOG. `app-version.test.ts` green; release notes render.

After merge: a signed annotated `v0.0.83` tag triggers `release.yml` (notarized DMG/AppImage/MSI + signed updater artifacts + latest.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)