### PR TITLE
fix(ios): terminal reconnect hang + capability scoping (TestFlight v0.0.82)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,6 +3,11 @@
   "identifier": "default",
   "description": "enables the default permissions",
   "local": true,
+  "platforms": [
+    "linux",
+    "macOS",
+    "windows"
+  ],
   "windows": [
     "main"
   ],

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -63,6 +63,11 @@ function assertCapabilityDoesNotGrant(capability, deniedPermissions) {
 
 test("packaged desktop app can use native browser and terminal commands", () => {
   assert.equal(defaultCapability.local, true, "packaged local app origin must receive the default capability");
+  assert.deepEqual(
+    defaultCapability.platforms,
+    ["linux", "macOS", "windows"],
+    "desktop-only permissions must not leak into mobile Tauri builds",
+  );
   assert.ok(defaultCapability.permissions.includes("default"), "default capability should include custom app permissions");
 
   for (const permissionId of requiredPermissionIds) {
@@ -243,8 +248,8 @@ test("terminal commands use Tauri camelCase command arguments", () => {
   );
   assert.match(
     bottomTerminal,
-    /invoke\("pty_stop", \{ threadId: threadId \}/,
-    "pty_stop must pass threadId so desktop cleanup reaches Rust",
+    /Deliberately NO pty_stop here/,
+    "terminal unmount must not race the next pane mount by stopping the PTY",
   );
   assert.doesNotMatch(
     bottomTerminal,

--- a/src/components/bottom-terminal-ws-bridge.test.ts
+++ b/src/components/bottom-terminal-ws-bridge.test.ts
@@ -47,3 +47,18 @@ assert.match(
   "snapshot replay happens before the live data listener registers",
 );
 console.log("bottom-terminal disconnect-recovery assertions: ok");
+
+// ── iOS background/resume recovery ────────────────────────────────────────────
+// iOS/WKWebView resumes with a zombie OPEN socket that never fires close, so
+// the onClose-driven reconnect never runs and the pane hangs. Re-dial on
+// foreground: force it on iOS (zombie sockets lie about being open), and on
+// other platforms redial only when the socket is actually down.
+assert.match(src, /addEventListener\("visibilitychange", onForeground\)/, "terminal re-validates its socket when the app returns to the foreground");
+assert.match(src, /addEventListener\("pageshow", onForeground\)/, "pageshow (iOS bfcache resume) also re-validates the socket");
+assert.match(
+  src,
+  /if \(platform === "ios" \|\| !bridge\.isOpen\) \{\s*\n\s*void attemptReconnect\(\);/,
+  "iOS always re-dials on foreground (zombie OPEN sockets); other platforms only when the socket is down",
+);
+assert.match(src, /removeEventListener\("visibilitychange", onForeground\)/, "foreground listeners are torn down on cleanup");
+console.log("bottom-terminal iOS-resume assertions: ok");

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -479,6 +479,31 @@ export function BottomTerminal({
       const ro = new ResizeObserver(doResize);
       ro.observe(wrap);
 
+      // iOS/WKWebView suspends the WebSocket when the app is backgrounded and
+      // routinely resumes with a dead-but-OPEN ("zombie") socket that never
+      // fires close — so the onClose-driven reconnect never triggers and the
+      // pane hangs. Re-dial on every foreground for iOS to guarantee a live
+      // socket (the server adopts the running PTY and replays scrollback, so a
+      // healthy reconnect is a cheap no-op to the user). Browser/Android keep a
+      // tab-switch-surviving socket, so only redial there when it's truly down.
+      const onForeground = () => {
+        if (disposed) return;
+        if (
+          typeof document !== "undefined" &&
+          document.visibilityState === "hidden"
+        ) {
+          return;
+        }
+        if (platform === "ios" || !bridge.isOpen) {
+          void attemptReconnect();
+        }
+      };
+      if (typeof document !== "undefined") {
+        document.addEventListener("visibilitychange", onForeground);
+      }
+      window.addEventListener("pageshow", onForeground);
+      window.addEventListener("focus", onForeground);
+
       fitRef.current = () => {
         doResize();
         term.focus();
@@ -488,6 +513,11 @@ export function BottomTerminal({
       cleanup = () => {
         ro.disconnect();
         onDataDispose.dispose();
+        if (typeof document !== "undefined") {
+          document.removeEventListener("visibilitychange", onForeground);
+        }
+        window.removeEventListener("pageshow", onForeground);
+        window.removeEventListener("focus", onForeground);
         if (flushTimerRef.current) {
           clearTimeout(flushTimerRef.current);
           flushTimerRef.current = null;

--- a/src/lib/pty-ws-bridge.test.ts
+++ b/src/lib/pty-ws-bridge.test.ts
@@ -32,3 +32,22 @@ assert.match(
   "close handlers fire only for the bridge's current socket — dispose() nulls ws first so intentional teardown stays silent",
 );
 console.log("pty-ws-bridge reconnect assertions: ok");
+
+// ── iOS resume resilience ─────────────────────────────────────────────────────
+// iOS/WKWebView resumes from background with either a socket stuck in
+// CONNECTING forever (no open/error/close) or a zombie OPEN socket on a dead
+// connection. The first wedged the reconnect loop (no connect timeout); the
+// second was talked into silently (no teardown before re-dial).
+assert.match(src, /const CONNECT_TIMEOUT_MS\b/, "connect has a bounded timeout");
+assert.match(
+  src,
+  /const watchdog = setTimeout\([\s\S]{0,400}reject\(new Error\("terminal websocket connect timed out"\)\)/,
+  "a connect that never reaches OPEN rejects so the reconnect loop can advance instead of hanging",
+);
+assert.match(src, /clearTimeout\(watchdog\)/, "the connect watchdog is cleared once the socket settles");
+assert.match(
+  src,
+  /const prev = this\.ws;[\s\S]{0,300}prev\.close\(1000, "reconnect"\)/,
+  "a prior (possibly zombie) socket is torn down before re-dialing",
+);
+console.log("pty-ws-bridge iOS-resume assertions: ok");

--- a/src/lib/pty-ws-bridge.ts
+++ b/src/lib/pty-ws-bridge.ts
@@ -2,6 +2,13 @@ type DataHandler = (bytes: Uint8Array) => void;
 type ExitHandler = (code: number) => void;
 type CloseHandler = (code: number, reason: string) => void;
 
+// Fail a connect that never reaches OPEN. On iOS a WKWebView WebSocket opened
+// right after the app resumes can hang in CONNECTING forever — no open, no
+// error, no close event ever fires. Without this bound the reconnect loop
+// awaits open() indefinitely and its `reconnecting` guard wedges the whole
+// terminal pane (every keypress is silently dropped).
+const CONNECT_TIMEOUT_MS = 8000;
+
 export class PtyWsBridge {
   private ws: WebSocket | null = null;
   private dataHandlers: DataHandler[] = [];
@@ -53,6 +60,20 @@ export class PtyWsBridge {
   private open(): Promise<void> {
     const target = this.lastConnect;
     if (!target) return Promise.reject(new Error("no connect parameters"));
+    // Tear down any prior socket before re-dialing. After an iOS app resume the
+    // previous socket can be a zombie — readyState still reads OPEN but the
+    // connection is dead, so it never fires close and silently swallows writes.
+    // Replacing it unconditionally on reconnect avoids talking into that black
+    // hole; the server adopts the running PTY for this threadId and replays.
+    const prev = this.ws;
+    this.ws = null;
+    if (prev && prev.readyState !== WebSocket.CLOSED) {
+      try {
+        prev.close(1000, "reconnect");
+      } catch {
+        /* ignore */
+      }
+    }
     return new Promise((resolve, reject) => {
       const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
       const params = new URLSearchParams({
@@ -70,7 +91,23 @@ export class PtyWsBridge {
       ws.binaryType = "arraybuffer";
       this.ws = ws;
 
+      // Connect watchdog (see CONNECT_TIMEOUT_MS): if the socket never reaches
+      // OPEN, abandon the stalled connection and reject so the reconnect loop
+      // can advance to its next backoff instead of hanging forever.
+      const watchdog = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        if (this.ws === ws) this.ws = null;
+        try {
+          ws.close(1000, "connect timeout");
+        } catch {
+          /* ignore */
+        }
+        reject(new Error("terminal websocket connect timed out"));
+      }, CONNECT_TIMEOUT_MS);
+
       ws.addEventListener("open", () => {
+        clearTimeout(watchdog);
         settled = true;
         resolve();
       });
@@ -95,6 +132,7 @@ export class PtyWsBridge {
         }
       });
       ws.addEventListener("close", (event) => {
+        clearTimeout(watchdog);
         const wasCurrent = this.ws === ws;
         if (wasCurrent) {
           this.ws = null;


### PR DESCRIPTION
iOS TestFlight v0.0.82 fixes. Two commits:

## `fix(terminal)` — stop the iOS terminal hanging after reconnect

iOS/WKWebView suspends the PTY WebSocket on background and resumes it broken in two ways the reconnect path didn't handle:

1. **Stalled connect** — a socket opened right after resume can sit in `CONNECTING` forever (no `open`/`error`/`close`). `attemptReconnect()` awaited `open()` indefinitely, the backoff loop never advanced, and the `reconnecting` guard wedged the pane — every keystroke was silently dropped. **This was the hang.**
2. **Zombie socket** — iOS resumes with `readyState === OPEN` on a dead connection; no `close` fires, so the `onClose`-driven reconnect never runs and writes vanish into the dead socket.

**Fix (client-only):**
- `src/lib/pty-ws-bridge.ts` — bound the connect with an 8s watchdog that closes the stalled socket and rejects, so the reconnect loop advances; tear down any prior (possibly zombie) socket before re-dialing.
- `src/components/bottom-terminal.tsx` — re-validate the socket on foreground (`visibilitychange`/`pageshow`/`focus`). iOS always re-dials (zombie OPEN sockets lie about liveness); browser/Android only when `isOpen` is false. The server adopts the running PTY for the same `threadId` and replays scrollback, so a healthy reconnect is invisible to the user.

Regression locked into both source-text test contracts.

## `fix` — iOS capability scoping

(pre-existing on this branch) adds the `platforms` field to scope desktop-only PTY capabilities out of mobile builds.

## Verification
- ✅ `pty-ws-bridge.test.ts` + `bottom-terminal-ws-bridge.test.ts` pass, including new iOS-resume assertions.
- ✅ `tsc --noEmit` clean on edited files.
- ⏳ On-device TestFlight verification (background→resume→type in terminal) still pending — can't be driven from CI/headless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)