### PR TITLE
fix(library): order reading list sections Want to Read → Reading → Done

### DIFF
--- a/src/components/library-reading-list.tsx
+++ b/src/components/library-reading-list.tsx
@@ -15,8 +15,8 @@ type GroupBy = "status" | "sourceType" | "none";
 const INLINE_STATUS_OPTIONS: ReadingStatus[] = ["want-to-read", "reading", "done"];
 
 const STATUS_ORDER: Record<ReadingStatus, number> = {
-  reading: 0,
-  "want-to-read": 1,
+  "want-to-read": 0,
+  reading: 1,
   done: 2,
   abandoned: 3,
 };


### PR DESCRIPTION
## What

Reorder the reading list status sections on the Library right panel to: **Want to Read → Reading → Done** (Abandoned stays last).

Single-line change to `STATUS_ORDER` in `src/components/library-reading-list.tsx` — swaps the weights of `want-to-read` and `reading`. This constant drives both the section grouping order (`groupItems`) and the Status-column sort (`sortItems`).

## Verification

Ran the real app under Playwright (demo mode, mocked `/api/library/reading` with one item per status) and drove to Library → Reading. Sections rendered top-to-bottom as **Want To Read → Reading → Done → Abandoned** — confirmed via the group-row labels and a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)