### PR TITLE
fix(capabilities): render skill markdown preview for real (folder-path) skills

### DIFF
--- a/src/app/api/skills/file/route.ts
+++ b/src/app/api/skills/file/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { readFile } from "node:fs/promises";
+import path from "node:path";
 import { isAllowedSkillFilePath } from "@/lib/server/skill-file-paths";
 
 export const dynamic = "force-dynamic";
@@ -8,6 +9,11 @@ export const dynamic = "force-dynamic";
  * Read a skill / harness-instructions markdown file for the Capabilities
  * inspector preview. The `path` param is constrained to the well-known harness
  * roots under $HOME by isAllowedSkillFilePath — out-of-tree paths get 403.
+ *
+ * The daemon reports a skill's `path` as its directory (e.g.
+ * `~/.claude/skills/brainstorming`), not the SKILL.md inside it, so a
+ * non-markdown path is treated as a skill folder and resolved to its SKILL.md
+ * before the allow-list check.
  */
 export async function GET(req: Request) {
   const url = new URL(req.url);
@@ -15,17 +21,20 @@ export async function GET(req: Request) {
   if (!target) {
     return NextResponse.json({ ok: false, error: "path required" }, { status: 400 });
   }
-  if (!isAllowedSkillFilePath(target)) {
+  const candidate = target.toLowerCase().endsWith(".md")
+    ? target
+    : path.join(target, "SKILL.md");
+  if (!isAllowedSkillFilePath(candidate)) {
     return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
   }
   let text: string;
   try {
-    text = await readFile(target, "utf8");
+    text = await readFile(candidate, "utf8");
   } catch (err) {
     return NextResponse.json(
       { ok: false, error: err instanceof Error ? err.message : "read failed" },
       { status: 404 },
     );
   }
-  return NextResponse.json({ ok: true, path: target, text });
+  return NextResponse.json({ ok: true, path: candidate, text });
 }

--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -220,10 +220,13 @@ export function CapabilitiesViewSurface({
     operatorView.harnesses.find((h) => h.id === (selectedItem?.harnessId ?? harnessFilter)) ?? null;
 
   // Load the selected capability's markdown so the inspector can render a
-  // styled preview (skills are SKILL.md; instructions are CLAUDE.md/AGENTS.md).
-  // Non-markdown items and out-of-tree paths (403) fall back to the description.
+  // styled preview. Skills report their FOLDER as the path (the daemon doesn't
+  // point at the SKILL.md inside) so any skill is previewable and the route
+  // resolves the folder → SKILL.md; instructions report a CLAUDE.md/AGENTS.md
+  // file directly. Out-of-tree paths (403) fall back to the description.
   const previewPath = selectedItem?.sourcePath ?? null;
-  const isPreviewable = !!previewPath && previewPath.toLowerCase().endsWith(".md");
+  const isPreviewable =
+    !!previewPath && (selectedItem?.type === "skill" || previewPath.toLowerCase().endsWith(".md"));
   useEffect(() => {
     if (!previewPath || !isPreviewable) {
       setPreview({ path: null, status: "idle", text: null, error: null });
@@ -645,7 +648,8 @@ function CapabilityInspector({
   onOpenPath: (path?: string) => void;
   onSelectHarness: (id: string | null) => void;
 }) {
-  const isMarkdown = !!item?.sourcePath && item.sourcePath.toLowerCase().endsWith(".md");
+  const isMarkdown =
+    !!item?.sourcePath && (item.type === "skill" || item.sourcePath.toLowerCase().endsWith(".md"));
   const previewMatches = preview.path === item?.sourcePath;
   return (
     <aside className="min-w-0 rounded-lg border border-border bg-card xl:sticky xl:top-4 xl:self-start">
@@ -822,6 +826,13 @@ type SkillPreviewState = {
   error: string | null;
 };
 
+// Skill/instructions markdown opens with a YAML frontmatter block (name,
+// description, tags) which the inspector already surfaces as the title/badges.
+// Strip it so the preview shows the prose body, not raw `key: value` lines.
+function stripFrontmatter(text: string): string {
+  return text.replace(/^﻿?---\r?\n[\s\S]*?\r?\n---[ \t]*\r?\n?/, "").trimStart();
+}
+
 function SkillPreviewBlock({
   preview,
   fallbackDescription,
@@ -829,6 +840,7 @@ function SkillPreviewBlock({
   preview: SkillPreviewState;
   fallbackDescription?: string;
 }) {
+  const body = preview.text ? stripFrontmatter(preview.text) : "";
   // Rendered the file content as styled markdown. On error (e.g. the path is
   // outside the previewable roots) fall back to the scanned description so the
   // inspector never goes blank.
@@ -849,8 +861,8 @@ function SkillPreviewBlock({
     <div>
       <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">Preview</p>
       <div className="max-h-[440px] overflow-y-auto rounded-md border border-border bg-background px-3 py-2">
-        {preview.status === "loaded" && preview.text ? (
-          <MarkdownBlock text={preview.text} className="text-[12px]" />
+        {preview.status === "loaded" && body ? (
+          <MarkdownBlock text={body} className="text-[12px]" />
         ) : preview.status === "loaded" ? (
           <p className="text-[11px] italic text-muted-foreground">This file is empty.</p>
         ) : (


### PR DESCRIPTION
Follow-up to #626. Verification in the running app found the preview **never rendered** for real daemon-reported skills.

## Root cause

#626 only triggered the preview when the capability's `path` ended in `.md`. But the daemon reports each skill's `path` as its **folder** (e.g. `~/.claude/skills/brainstorming`), not the `SKILL.md` inside — so the gate was always false and the inspector kept showing the plain frontmatter description. (My #626 curl check passed because I hand-built a `.md` path; it didn't reflect real data.)

## Fix

- **Client**: a `skill` item is previewable regardless of path extension (it's a folder); instructions keep the `.md`-file rule.
- **Server** (`/api/skills/file`): a non-`.md` path is treated as a skill folder and resolved to `<dir>/SKILL.md` before the allow-list check. Missing `SKILL.md` → 404 → UI falls back to the description.
- Strip the leading YAML frontmatter before rendering (the `name`/`description` are already the inspector title/badges).

## Verified in the running app (prod build, real daemon, Playwright)

- ✅ Select **brainstorming** → inspector renders `SKILL.md` as styled markdown — `Preview` heading, `.cave-md`, 8 rendered headings, bold/prose, scrollable; frontmatter stripped.
- 🔍 **codex automation** folder (no `SKILL.md`, no description) → 404 → honest "Preview unavailable" fallback (no crash).
- 🔍 `../../../etc` traversal → **403 path not allowed**.
- `tsc` clean, `next build` green, api-contracts / capabilities-view / skill-file-paths suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)