### PR TITLE
Polish mobile shell touch targets

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1788,6 +1788,21 @@ select {
   .ui-search-input-field {
     min-height: var(--touch-target);
   }
+
+  .command-palette-row,
+  .notification-bell__action,
+  .mode-toggle__option {
+    min-height: var(--touch-target);
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .notification-bell__mute {
+    width: var(--touch-target);
+    height: var(--touch-target);
+    min-width: var(--touch-target);
+    opacity: 1;
+    -webkit-tap-highlight-color: transparent;
+  }
 }
 
 .ui-search-input-clear {
@@ -4063,6 +4078,15 @@ button:active > .edge-rail-chip {
   outline-offset: 1px;
 }
 
+@media (max-width: 767px) {
+  .settings-back-button {
+    min-height: var(--touch-target);
+    border-radius: 10px;
+    padding-inline: 12px;
+    -webkit-tap-highlight-color: transparent;
+  }
+}
+
 /* ────────────────────────────────────────────────
    Calendar item detail panel
    Sits over the right edge of the calendar surface
@@ -4836,6 +4860,34 @@ button:active > .edge-rail-chip {
 
   .browser-toolbar-close {
     display: none;
+  }
+
+  .plugins-view button,
+  .plugins-view [role="button"],
+  .capabilities-view button,
+  .capabilities-view select,
+  .capabilities-view label:has(input) {
+    min-height: var(--touch-target);
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .plugins-view input,
+  .capabilities-view input {
+    min-height: var(--touch-target);
+    font-size: 16px;
+  }
+
+  .plugins-role-card {
+    align-items: flex-start;
+  }
+
+  .plugins-role-toggle {
+    width: var(--touch-target);
+    min-width: var(--touch-target);
+  }
+
+  .capabilities-view button.rounded-full {
+    padding-inline: 14px;
   }
 
   .chat-list-surface {

--- a/src/components/capabilities-view-polish.test.ts
+++ b/src/components/capabilities-view-polish.test.ts
@@ -6,6 +6,10 @@ const source = readFileSync(
   new URL("./capabilities-view.tsx", import.meta.url),
   "utf8",
 );
+const globals = readFileSync(
+  new URL("../app/globals.css", import.meta.url),
+  "utf8",
+);
 
 // Inner "Capabilities · read-only" header bar removed — duplicated the workspace breadcrumb.
 assert.doesNotMatch(
@@ -65,6 +69,13 @@ assert.match(
   source,
   /tag === "INPUT" \|\| tag === "TEXTAREA"/,
   "keydown handler skips when an input/textarea is focused",
+);
+
+assert.match(source, /capabilities-view/, "Capabilities surface should expose a mobile hit-area root hook");
+assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.capabilities-view button,[\s\S]*\.capabilities-view select,[\s\S]*\.capabilities-view label:has\(input\)[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "Capabilities mobile controls should meet the shared touch target",
 );
 
 console.log("capabilities-view-polish.test.ts OK");

--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -306,7 +306,7 @@ export function CapabilitiesViewSurface({
   const readinessStatus = operatorView.summary.warnings > 0 ? "warning" : operatorView.summary.disabled > 0 ? "disabled" : "all";
 
   return (
-    <div className="flex h-full min-w-0 flex-col bg-background text-foreground">
+    <div className="capabilities-view flex h-full min-w-0 flex-col bg-background text-foreground">
       <div className="flex-1 overflow-y-auto">
         <div className="mx-auto w-full max-w-[1280px] px-4 pb-12 sm:px-8">
           <div className="pb-4 pt-5">

--- a/src/components/command-palette.test.ts
+++ b/src/components/command-palette.test.ts
@@ -6,6 +6,10 @@ const source = readFileSync(
   new URL("./command-palette.tsx", import.meta.url),
   "utf8",
 );
+const globals = readFileSync(
+  new URL("../app/globals.css", import.meta.url),
+  "utf8",
+);
 
 // Input is labelled.
 assert.match(
@@ -19,6 +23,12 @@ assert.match(source, /role="listbox"/, "results container has role=listbox");
 
 // Items have role=option.
 assert.match(source, /role="option"/, "each result item has role=option");
+assert.match(source, /command-palette-row/, "command palette rows expose a mobile hit-area hook");
+assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.command-palette-row,[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "command palette mobile rows should meet the shared touch target",
+);
 
 // Input is linked to listbox via aria-controls.
 assert.match(source, /aria-controls=/, "input is linked to results via aria-controls");

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -485,7 +485,7 @@ export function CommandPalette({
                   tabIndex={-1}
                   onMouseEnter={() => setActiveIdx(i)}
                   onClick={() => fire(row)}
-                  className={`focus-ring-inset flex w-full items-center gap-3 border-l-2 px-4 py-2 text-left text-sm transition-colors ${
+                  className={`command-palette-row focus-ring-inset flex w-full items-center gap-3 border-l-2 px-4 py-2 text-left text-sm transition-colors ${
                     active
                       ? "border-l-[var(--accent-presence)] bg-[var(--bg-hover)]"
                       : "border-l-transparent hover:bg-[var(--bg-hover)]"

--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -62,6 +62,17 @@ assert.match(
 );
 
 assert.match(
+  workspace,
+  /onModeChange=\{\(m\) => \{[\s\S]*shellRef\.current\?\.closeNav\(\);[\s\S]*setMode\(m as WorkspaceMode\);[\s\S]*shellRef\.current\?\.closeNav\(\);[\s\S]*\}\}/,
+  "Mobile sidebar destination taps should close the nav drawer after changing surfaces",
+);
+assert.match(
+  workspace,
+  /onOpenSession=\{\(id\) => \{[\s\S]*openFamiliarSession\(id\);[\s\S]*shellRef\.current\?\.closeList\(\);[\s\S]*\}\}/,
+  "Mobile list drawer session taps should close the list drawer after opening a session",
+);
+
+assert.match(
   topBar,
   /aria-pressed=\{Boolean\(listDrawerOpen\)\}/,
   "Mobile list toggle should expose pressed state while the list drawer is open",
@@ -102,6 +113,11 @@ assert.match(
   /notification-bell__popover[\s\S]*notification-bell__settings-btn[\s\S]*notification-bell__open-inbox[\s\S]*notification-bell__list/,
   "Notification bell should expose stable hooks for mobile popover layout and actions",
 );
+assert.match(
+  notificationBell,
+  /notification-bell__mute[\s\S]*notification-bell__action/,
+  "Notification bell item controls should expose stable mobile hit-area hooks",
+);
 
 assert.match(
   globals,
@@ -131,6 +147,11 @@ assert.match(
   globals,
   /@media \(max-width: 1023px\) \{[\s\S]*\.notification-bell__settings-btn,[\s\S]*\.notification-bell__open-inbox\s*\{[\s\S]*min-height:\s*var\(--touch-target\)/,
   "Mobile notification popover header actions should meet the 44px touch target",
+);
+assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.notification-bell__action,[\s\S]*min-height:\s*var\(--touch-target\)[\s\S]*\.notification-bell__mute\s*\{[\s\S]*width:\s*var\(--touch-target\)[\s\S]*height:\s*var\(--touch-target\)/,
+  "Mobile notification item actions and mute controls should meet the shared touch target",
 );
 
 assert.match(

--- a/src/components/mode-toggle.test.ts
+++ b/src/components/mode-toggle.test.ts
@@ -17,5 +17,6 @@ assert.match(source, /"dark"/, "dark option");
 
 // 4. Uses aria-pressed for accessibility (segmented control).
 assert.match(source, /aria-pressed/, "aria-pressed for active state");
+assert.match(source, /mode-toggle__option/, "mode toggle options expose a mobile hit-area hook");
 
 console.log("mode-toggle.test.ts OK");

--- a/src/components/mode-toggle.tsx
+++ b/src/components/mode-toggle.tsx
@@ -35,7 +35,7 @@ export function ModeToggle({ value, onChange }: ModeToggleProps) {
             type="button"
             aria-pressed={active}
             onClick={() => onChange(opt.id)}
-            className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[12px] font-medium transition-colors ${
+            className={`mode-toggle__option inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[12px] font-medium transition-colors ${
               active
                 ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
                 : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -276,7 +276,7 @@ export function NotificationBell({
                         onClick={() => void toggleMute(it.familiarId!)}
                         title={muted ? `Unmute ${fname}` : `Mute ${fname}`}
                         aria-label={muted ? `Unmute ${fname}` : `Mute ${fname}`}
-                        className="touch-always-visible focus-ring grid h-5 w-5 shrink-0 place-items-center rounded text-[var(--text-muted)] opacity-0 transition-opacity hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] group-hover/popover:opacity-100"
+                        className="notification-bell__mute touch-always-visible focus-ring grid h-5 w-5 shrink-0 place-items-center rounded text-[var(--text-muted)] opacity-0 transition-opacity hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] group-hover/popover:opacity-100"
                       >
                         <Icon
                           name={muted ? "ph:bell-slash-fill" : "ph:bell-slash"}
@@ -333,7 +333,7 @@ function BellBtn({
     <button
       onClick={onClick}
       title={title}
-      className={`focus-ring rounded border px-2 py-0.5 text-[10px] transition-colors ${
+      className={`notification-bell__action focus-ring rounded border px-2 py-0.5 text-[10px] transition-colors ${
         primary
           ? "border-[var(--border-strong)] bg-[var(--bg-raised)] text-[var(--text-primary)] hover:bg-[var(--bg-hover)]"
           : "border-[var(--border-hairline)] bg-transparent text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"

--- a/src/components/plugins-view-polish.test.ts
+++ b/src/components/plugins-view-polish.test.ts
@@ -6,6 +6,10 @@ const source = readFileSync(
   new URL("./plugins-view.tsx", import.meta.url),
   "utf8",
 );
+const globals = readFileSync(
+  new URL("../app/globals.css", import.meta.url),
+  "utf8",
+);
 
 // Keyboard hint footer (matches the terminal/inbox/calendar/library/home/browser pattern).
 assert.match(
@@ -70,6 +74,20 @@ assert.match(
   source,
   /ref=\{searchRef\}[\s\S]{0,160}type="search"/,
   "search input wires ref={searchRef}",
+);
+
+assert.match(source, /plugins-view/, "Plugins/Roles surface should expose a mobile hit-area root hook");
+assert.match(source, /plugins-role-card/, "Role cards should expose a mobile hit-area hook");
+assert.match(source, /plugins-role-toggle/, "Role activation toggles should expose a mobile hit-area hook");
+assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.plugins-view button,[\s\S]*\.plugins-view \[role="button"\][\s\S]*min-height:\s*var\(--touch-target\)/,
+  "Plugins/Roles mobile controls should meet the shared touch target",
+);
+assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.plugins-role-toggle\s*\{[\s\S]*width:\s*var\(--touch-target\)[\s\S]*min-width:\s*var\(--touch-target\)/,
+  "Role activation toggles should be square-enough touch targets on mobile",
 );
 
 console.log("plugins-view-polish.test.ts OK");

--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -501,7 +501,7 @@ export function PluginsView({
           : "Loading roles";
 
   return (
-    <div className="flex h-full min-w-0 flex-col bg-background text-foreground">
+    <div className="plugins-view flex h-full min-w-0 flex-col bg-background text-foreground">
       {/* ── Top bar: tabs left, controls right ─────────────────────────── */}
       <header className="shrink-0 border-b border-border px-4 sm:px-8">
         <div className="flex h-12 items-center justify-between gap-4">
@@ -1007,7 +1007,7 @@ function RoleCard({
         }
       }}
       className={[
-        "focus-ring group flex min-w-0 cursor-pointer items-center gap-3 rounded-lg border px-3 py-2.5 transition-colors",
+        "plugins-role-card focus-ring group flex min-w-0 cursor-pointer items-center gap-3 rounded-lg border px-3 py-2.5 transition-colors",
         selected
           ? "border-[var(--accent-presence)] bg-[var(--accent-presence)]/10"
           : role.active
@@ -1069,7 +1069,7 @@ function RoleCard({
         disabled={toggling}
         onClick={handleToggle}
         className={[
-          "focus-ring ml-auto shrink-0 rounded-md p-1.5 transition-colors disabled:opacity-40",
+          "plugins-role-toggle focus-ring ml-auto shrink-0 rounded-md p-1.5 transition-colors disabled:opacity-40",
           role.active
             ? "text-[var(--color-success)] hover:bg-[color-mix(in_oklch,var(--color-success)_15%,transparent)]"
             : "text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]",

--- a/src/components/settings-shell-polish.test.ts
+++ b/src/components/settings-shell-polish.test.ts
@@ -6,6 +6,10 @@ const source = readFileSync(
   new URL("./settings-shell.tsx", import.meta.url),
   "utf8",
 );
+const globals = readFileSync(
+  new URL("../app/globals.css", import.meta.url),
+  "utf8",
+);
 
 assert.match(
   source,
@@ -30,6 +34,17 @@ assert.match(
   source,
   /Esc back · ↑↓ navigate sections/,
   "renders the keyboard hint footer below the content area",
+);
+
+assert.match(
+  source,
+  /settings-back-button/,
+  "Settings back control should expose a mobile hit-area hook",
+);
+assert.match(
+  globals,
+  /@media \(max-width: 767px\) \{[\s\S]*\.settings-back-button\s*\{[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "Settings mobile back control should meet the shared touch target",
 );
 
 // Esc keydown handler routes back.

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -121,7 +121,7 @@ export function SettingsShell() {
             if (isMobile && !pickerView) backToPicker();
             else router.back();
           }}
-          className="focus-ring flex items-center gap-1.5 rounded-md px-2 py-1 text-[12px] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+          className="settings-back-button focus-ring flex items-center gap-1.5 rounded-md px-2 py-1 text-[12px] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
         >
           <Icon name="ph:arrow-left" width={13} />
           {isMobile && !pickerView ? "Settings" : "Back"}

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -204,5 +204,10 @@ assert.match(
   /\.sidebar-toggle \{/,
   "the sidebar toggle button has dedicated styling",
 );
+assert.match(
+  styles,
+  /@media \(max-width: 1023px\) \{[\s\S]*\.sidebar-header,[\s\S]*\.sidebar-action-row,[\s\S]*\.sidebar-folder-row,[\s\S]*\.sidebar-foot-btn,[\s\S]*\.sidebar-familiar-filter__select[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "Mobile sidebar drawer rows and familiar select should meet the shared touch target",
+);
 
 console.log("sidebar-minimal.test.ts (shell-ia-lastmile) OK");

--- a/src/components/workflows/workflow-run-strip.tsx
+++ b/src/components/workflows/workflow-run-strip.tsx
@@ -122,11 +122,11 @@ export function WorkflowRunStrip({
           <Icon name={forking ? "ph:git-fork-bold" : "ph:floppy-disk-bold"} width={14} />
           {saveLabel}
         </button>
-        <button type="button" disabled={!workflow || anyBusy} onClick={() => workflow && onValidate(workflow)}>
+        <button type="button" className="workflow-run-action-button" disabled={!workflow || anyBusy} onClick={() => workflow && onValidate(workflow)}>
           <Icon name="ph:check-circle-bold" width={14} />
           {validateBusy ? "Validating" : "Validate"}
         </button>
-        <button type="button" disabled={!workflow || anyBusy} onClick={() => workflow && onDryRun(workflow)}>
+        <button type="button" className="workflow-run-action-button" disabled={!workflow || anyBusy} onClick={() => workflow && onDryRun(workflow)}>
           <Icon name="ph:rocket-bold" width={14} />
           {dryRunBusy ? "Planning" : "Dry-run"}
         </button>

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -137,6 +137,12 @@ assert.match(canvas, /layoutDirection === "vertical" \? Position\.Top : Position
 assert.match(canvas, /layoutDirection === "vertical" \? Position\.Bottom : Position\.Right/, "Vertical layout should move source handles to the bottom edge");
 assert.match(canvas, /key=\{flowKey\}/, "Canvas should remount React Flow when the view is reset so fitView reruns");
 assert.match(css, /\.workflow-canvas-toolbar/, "Workflow CSS should style the canvas action toolbar");
+assert.match(runStrip, /workflow-run-action-button/, "Workflow run strip text actions should expose a mobile hit-area hook");
+assert.match(
+  css,
+  /@media \(max-width: 767px\) \{[\s\S]*\.workflow-studio-shell\s*\{[\s\S]*--workflow-top-control-height:\s*var\(--touch-target\)[\s\S]*\.workflow-panel-tab,[\s\S]*\.workflow-palette-item,[\s\S]*\.workflow-run-row,[\s\S]*\.workflow-run-action-button,[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "Workflow mobile controls should meet the shared touch target",
+);
 
 // Draggable nodes: local node state + drag-stop persistence to the sidecar.
 assert.match(canvas, /nodesDraggable/, "Canvas nodes must be draggable");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1171,18 +1171,25 @@ export function Workspace() {
       addons={addons}
       onNewChat={() => {
         startFamiliarChat(activeId);
+        shellRef.current?.closeNav();
       }}
       onToggleSidebar={() => shellRef.current?.toggleNav()}
-      onOpenSettings={() => nextRouter.push("/settings")}
+      onOpenSettings={() => {
+        shellRef.current?.closeNav();
+        nextRouter.push("/settings");
+      }}
       onModeChange={(m) => {
         if (m === "browser") {
           setMode("browser");
+          shellRef.current?.closeNav();
           return;
         }
         setMode(m as WorkspaceMode);
+        shellRef.current?.closeNav();
       }}
       onOpenSession={(id) => {
         openFamiliarSession(id);
+        shellRef.current?.closeList();
       }}
       inboxItems={inboxItemsWithEphemeral}
       inboxPrefs={inboxPrefs}

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -526,6 +526,19 @@
   color: var(--text-secondary);
 }
 
+@media (max-width: 1023px) {
+  .sidebar-header,
+  .sidebar-action-row,
+  .sidebar-folder-row,
+  .sidebar-foot-bell,
+  .sidebar-foot-btn,
+  .sidebar-familiar-filter__control,
+  .sidebar-familiar-filter__select {
+    min-height: var(--touch-target);
+    -webkit-tap-highlight-color: transparent;
+  }
+}
+
 /* ── FamiliarStrip (FamiliarPanel top) ──────────────────────────────────────── */
 .familiar-strip {
   display: flex;
@@ -789,5 +802,18 @@
   .sidebar-foot-bell,
   .sidebar-foot-btn {
     min-height: 31px;
+  }
+}
+
+@media (max-width: 1023px) {
+  .sidebar-minimal .sidebar-header,
+  .sidebar-minimal .sidebar-action-row,
+  .sidebar-minimal .sidebar-folder-row,
+  .sidebar-minimal .sidebar-foot-bell,
+  .sidebar-minimal .sidebar-foot-btn,
+  .sidebar-minimal .sidebar-familiar-filter__control,
+  .sidebar-minimal .sidebar-familiar-filter__select {
+    min-height: var(--touch-target);
+    -webkit-tap-highlight-color: transparent;
   }
 }

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -1328,6 +1328,50 @@
   to { transform: rotate(360deg); }
 }
 
+@media (max-width: 767px) {
+  .workflow-studio-shell {
+    --workflow-top-control-height: var(--touch-target);
+  }
+
+  .workflow-panel-tab,
+  .workflow-palette-item,
+  .workflow-run-row,
+  .workflow-history-button,
+  .workflow-primary-button,
+  .workflow-play-button,
+  .workflow-run-action-button,
+  .workflow-library-footer button,
+  .workflow-field input,
+  .workflow-field select,
+  .workflow-search,
+  .workflow-section-caret-btn {
+    min-height: var(--touch-target);
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .workflow-icon-button,
+  .workflow-canvas-tool,
+  .workflow-canvas .react-flow__controls-button,
+  .workflow-section-caret-btn {
+    width: var(--touch-target);
+    height: var(--touch-target);
+    min-width: var(--touch-target);
+  }
+
+  .workflow-canvas .react-flow__node {
+    min-height: var(--touch-target) !important;
+  }
+
+  .workflow-search input {
+    min-height: var(--touch-target);
+    font-size: 16px;
+  }
+
+  .workflow-palette-item {
+    padding-inline: 12px;
+  }
+}
+
 /* Active dependency edge: brighten the path + arrowhead feeding the live step. */
 .workflow-canvas .react-flow__edge.workflow-edge-active .react-flow__edge-path {
   stroke: #d8c98f;
@@ -1562,4 +1606,22 @@
 .workflow-run-no-steps {
   font-size: 11px;
   margin: 0;
+}
+
+@media (max-width: 767px) {
+  .workflow-run-actions .workflow-history-button,
+  .workflow-run-actions .workflow-primary-button,
+  .workflow-run-actions .workflow-run-action-button,
+  .workflow-run-actions .workflow-play-button {
+    min-height: var(--touch-target);
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .workflow-run-actions .workflow-history-button {
+    min-width: var(--touch-target);
+  }
+
+  .workflow-canvas .react-flow__node {
+    min-height: calc(var(--touch-target) * 2) !important;
+  }
 }


### PR DESCRIPTION
## Summary
- close mobile drawers after navigation actions and widen advanced mobile controls to shared touch targets
- add mobile touch-target hooks for plugins, capabilities, settings, workflows, command palette, notifications, and sidebar rows
- extend focused smoke tests around the mobile CSS and component hooks

## Verification
- node --experimental-strip-types src/components/command-palette.test.ts && node --experimental-strip-types src/components/mobile-shell-smoke.test.ts && node --experimental-strip-types src/components/sidebar-minimal.test.ts && node --experimental-strip-types src/components/mode-toggle.test.ts && node --experimental-strip-types src/components/plugins-view-polish.test.ts && node --experimental-strip-types src/components/capabilities-view-polish.test.ts && node --experimental-strip-types src/components/workflows/workflow-studio.test.ts && node --experimental-strip-types src/components/settings-shell-polish.test.ts
- pnpm test:mobile
- pnpm typecheck
- pnpm build
- git diff --check
- Playwright mobile drawer audit at 390x844: tinyCount=0, overflowX=0