### PR TITLE
chore(release): v0.0.84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.84] - 2026-06-15
+
+Patch release with capabilities, library, and iOS fixes on top of 0.0.83.
+
+### Fixed
+- **Capabilities** — the skill markdown preview now renders for real skills. The daemon reports a skill's folder path, so the preview resolves `<folder>/SKILL.md`, strips YAML frontmatter, and falls back to the description when no `SKILL.md` exists.
+- **Library** — reading list sections now order Want to Read → Reading → Done.
+- **iOS** — fixed the terminal reconnect hang and capability scoping (TestFlight).
+
 ## [0.0.83] - 2026-06-15
 
 Patch release carrying the latest `main` polish on top of the refreshed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A familiar is not just a chat window. It has a name, role, runtime, memory, tool
 
 ## Status
 
-- Current app version: `0.0.81`
+- Current app version: `0.0.84`
 - Native shell: Tauri 2
 - Frontend: Next.js 16, React 19, Tailwind v4
 - Runtime dependency: a healthy local `coven` CLI/daemon plus at least one runtime source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.83",
+  "version": "0.0.84",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.83"
+version = "0.0.84"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.83</string>
+	<string>0.0.84</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.83</string>
+	<string>0.0.84</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.83</string>
+	<string>0.0.84</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.83</string>
+	<string>0.0.84</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.83",
+  "version": "0.0.84",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Patch release on top of v0.0.83, shipping three fixes that landed after that tag:

- **Capabilities** — skill markdown preview now renders for real (folder-path) skills, with frontmatter stripped and a description fallback (#635).
- **Library** — reading list section ordering Want to Read → Reading → Done (#634).
- **iOS** — terminal reconnect hang + capability scoping (#633).

Bumped: `package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock` (app), both iOS plists, README app-version (corrected stale 0.0.81), and CHANGELOG. `app-version.test.ts` passes locally.

Tag `v0.0.84` to be pushed after merge → release.yml publishes the notarized DMG / AppImage / MSI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)