### PR TITLE
Potential fix for code scanning alert no. 16: Uncontrolled data used in path expression

### DIFF
--- a/src/app/api/library/doc/route.ts
+++ b/src/app/api/library/doc/route.ts
@@ -20,7 +20,12 @@ function realpathOrResolve(value: string): string {
 
 function resolveResearchPath(p: string): string | null {
   const root = realpathOrResolve(RESEARCH_ROOT);
-  const resolved = realpathOrResolve(p);
+
+  // Always anchor incoming input to the trusted SAGE_ROOT first, then canonicalize.
+  // This prevents arbitrary absolute/cwd-based interpretation of user-controlled paths.
+  const candidate = path.resolve(SAGE_ROOT, p);
+  const resolved = realpathOrResolve(candidate);
+
   if (resolved !== root && !resolved.startsWith(root + path.sep)) return null;
   return resolved;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven-cave/security/code-scanning/16](https://github.com/OpenCoven/coven-cave/security/code-scanning/16)

General fix: normalize and validate user-provided paths relative to a trusted base directory, then enforce strict containment under the allowed root before any filesystem operation.

Best concrete fix here (single best, minimal behavior change): in `src/app/api/library/doc/route.ts`, update `resolveResearchPath` so it **always resolves input relative to `SAGE_ROOT`** (not process cwd / arbitrary absolute resolution), canonicalizes that candidate, and then verifies the canonical candidate is within canonical `RESEARCH_ROOT`. This keeps existing feature intent (`id` relative to sage root; `path` legacy) while preventing arbitrary absolute path interpretation. No new dependency is required.

Changes needed:
- Edit only `resolveResearchPath` body (around lines 21–26).
- Keep existing imports; no new methods/imports required.
- Use existing `realpathOrResolve`, `SAGE_ROOT`, `RESEARCH_ROOT`, and `path.resolve`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
