### PR TITLE
fix(mobile): clear iOS safe area on task drawer header so close button is reachable

### DIFF
--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -298,7 +298,10 @@
 @keyframes board-drawer-in { from{transform:translateX(100%)} to{transform:translateX(0)} }
 .board-drawer--closing { animation:board-drawer-out .18s ease-in forwards; }
 @keyframes board-drawer-out { from{transform:translateX(0)} to{transform:translateX(100%)} }
-.board-drawer-header { display:flex; align-items:center; justify-content:space-between; gap:8px; padding:14px 16px; border-bottom:1px solid var(--border-hairline); flex-shrink:0; }
+/* padding-top/right clear the iOS status bar + Dynamic Island and the
+   landscape rounded corner so the title and close button are never occluded;
+   --sai-* fall back to 0px off-device so desktop is unaffected. */
+.board-drawer-header { display:flex; align-items:center; justify-content:space-between; gap:8px; padding:14px 16px; padding-top:calc(14px + var(--sai-top)); padding-right:calc(16px + var(--sai-right)); border-bottom:1px solid var(--border-hairline); flex-shrink:0; }
 .board-drawer-title { font-size:13px; font-weight:600; color:var(--text-primary); flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .board-drawer-title-input { flex:1; min-width:0; background:transparent; border:1px solid transparent; border-radius:7px; padding:4px 8px; margin-left:-8px; font:600 15px/1.3 var(--font-sans,inherit); color:var(--text-primary); outline:none; text-overflow:ellipsis; transition:background .12s,border-color .12s,box-shadow .12s; }
 .board-drawer-title-input:hover { border-color:var(--border-hairline); background:color-mix(in oklch,var(--bg-hover) 50%,transparent); }


### PR DESCRIPTION
## Problem

The board card **task page** (the `BoardInspector` drawer, opened via the chat "Open task" / `#card-<id>` deep link) is portalled to `<body>` at `position:fixed; top:0; right:0` with no safe-area inset. On iPhone, the drawer header — card title + the close (**X**) button — renders **under the status bar / Dynamic Island**, so the close affordance is occluded and effectively unreachable.

Reproduced live on the iPhone 16 Pro simulator: the title is sliced by the Dynamic Island and the X is jammed into the top-right corner behind the status bar.

## Fix

Give `.board-drawer-header` a top (and right, for landscape) safe-area inset using the app's existing `--sai-top` / `--sai-right` variables (`env(safe-area-inset-*)`, defined once in `globals.css` and already used by `top-bar`, `settings-shell`, and the chat mobile command center). They fall back to `0px` off-device, so desktop is unaffected.

```
.board-drawer-header { … padding-top:calc(14px + var(--sai-top)); padding-right:calc(16px + var(--sai-right)); … }
```

## Verification

- Bug reproduced on-device (iPhone 16 Pro simulator) — header occluded by the Dynamic Island.
- Mechanism matches the codebase's established safe-area pattern; no tests pin the rule.
- CSS-only; desktop layout unchanged (insets resolve to 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)