### PR TITLE
fix(updater): make a failed update install recoverable (download fallback + reason)

### DIFF
--- a/src/components/update-available.test.ts
+++ b/src/components/update-available.test.ts
@@ -32,4 +32,12 @@ assert.match(src, /Install &amp; restart/, "native path offers install + restart
 assert.match(src, /Downloading…/, "shows download progress");
 assert.match(src, /Check for updates/, "settings row offers a manual re-check");
 
+// A failed native install must not dead-end: it captures the reason and offers
+// a working manual download (the release page) plus a retry, so the update is
+// always reachable even when downloadAndInstall/relaunch throws.
+assert.match(src, /phase: "failed"/, "tracks a dedicated failed state for a thrown install");
+assert.match(src, /message: err instanceof Error \? err\.message/, "captures the real failure reason instead of swallowing it");
+assert.match(src, /onClick=\{\(\) => void openExternalUrl\(RELEASES_PAGE\)\}/, "failed state offers a manual download to the release page");
+assert.match(src, />\s*Retry\s*</, "failed state offers a retry");
+
 console.log("update-available.test.ts: ok");

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -129,12 +129,15 @@ export function UpdateBannerTrigger() {
           onClick: () => {
             if (r.kind === "native") {
               pushBanner({ id: BANNER_ID, severity: "info", title: `Downloading update v${r.version}…` });
-              void installNativeUpdate(r.update, () => {}).catch(() => {
+              void installNativeUpdate(r.update, () => {}).catch((err) => {
+                const reason = err instanceof Error ? err.message : "";
                 pushBanner({
                   id: BANNER_ID,
                   severity: "warning",
-                  title: "Update failed — open the release page",
-                  cta: { label: "Open", onClick: () => void openExternalUrl(RELEASES_PAGE) },
+                  title: reason
+                    ? `Update failed (${reason}) — download manually`
+                    : "Update failed — download manually",
+                  cta: { label: "Download", onClick: () => void openExternalUrl(RELEASES_PAGE) },
                   onDismiss: () => markDismissed(r.version),
                 });
               });
@@ -157,9 +160,10 @@ export function UpdateBannerTrigger() {
 
 type RowState =
   | { phase: "checking" }
-  | { phase: "current"; error?: boolean }
+  | { phase: "current" }
   | { phase: "available"; r: Extract<Resolved, { kind: "native" | "fallback" }> }
   | { phase: "downloading"; version: string; pct: number }
+  | { phase: "failed"; version: string; message: string }
   | { phase: "ready"; version: string };
 
 /**
@@ -198,8 +202,13 @@ export function UpdateSettingsRow() {
       .then(() => {
         if (mounted.current) setState({ phase: "ready", version });
       })
-      .catch(() => {
-        if (mounted.current) setState({ phase: "current", error: true });
+      .catch((err) => {
+        if (mounted.current)
+          setState({
+            phase: "failed",
+            version,
+            message: err instanceof Error ? err.message : "Update failed",
+          });
       });
   };
 
@@ -231,12 +240,35 @@ export function UpdateSettingsRow() {
         )}
       </>
     );
+  } else if (state.phase === "failed") {
+    // The native install threw (e.g. unsigned/dev build, app translocation, or
+    // a network/verification error). Don't dead-end: surface the reason and a
+    // working manual download so the update is always reachable.
+    control = (
+      <>
+        <span
+          className="text-[12px] font-medium text-[var(--color-danger)]"
+          title={state.message}
+        >
+          Update failed
+        </span>
+        <button type="button" onClick={() => void openExternalUrl(RELEASES_PAGE)} className={accentBtn}>
+          <Icon name="ph:arrow-square-out" width={12} />
+          Download
+        </button>
+        <button
+          type="button"
+          onClick={check}
+          className="rounded-md border border-[var(--border-hairline)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+        >
+          Retry
+        </button>
+      </>
+    );
   } else {
     control = (
       <>
-        <span className="text-[12px] text-[var(--text-muted)]">
-          {state.error ? "Update failed" : "Up to date"}
-        </span>
+        <span className="text-[12px] text-[var(--text-muted)]">Up to date</span>
         <button
           type="button"
           onClick={check}


### PR DESCRIPTION
## Problem

The app-update "download/install" button **flashes "Update failed" and dead-ends** when pressed. Pressing **Install & restart** runs the native updater's `downloadAndInstall()` → `relaunch()`; when that throws (unsigned/dev build, macOS app *translocation*, or a network/verification error), the Settings row showed a silent "Update failed" with only a "Check for updates" button, and the banner offered just "Open". There was no working path to actually get the update — so to the user the download button "does nothing".

Permissions are **not** the cause: `updater:default` already grants `allow-download-and-install` and `process:default` grants `allow-restart`. The throw is environmental — so the fix is to make the failure **actionable** rather than silent.

## Fix (`src/components/update-available.tsx`)

- Capture the real failure reason instead of swallowing it (`.catch(() => …)` → `.catch((err) => …)`).
- Add a dedicated `failed` row state that shows the reason (on `title`) plus a **working Download button** (opens the releases page) and a **Retry**.
- Banner failure now offers a **Download** CTA and includes the reason in its title.

Desktop-only behaviour; up-to-date / available / downloading paths unchanged.

## Verification

- `update-available.test.ts` extended to assert the failed state captures the reason and offers the manual download + retry — passes.
- `tsc --noEmit` clean.

Note: the *underlying* native-install failure is environment-specific (commonly a dev/unsigned build or an app run from the DMG/quarantine — see `check_app_translocation`). This PR guarantees the update is always reachable when that happens; it doesn't change the signed-release auto-update happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)