### PR TITLE
fix(ios): register opencoven URL scheme

### DIFF
--- a/scripts/mobile-tailscale-native.test.mjs
+++ b/scripts/mobile-tailscale-native.test.mjs
@@ -12,6 +12,11 @@ assert.match(infoPlist, /<string>_tailscale\._tcp<\/string>/);
 assert.match(infoPlist, /<string>_tailscale\._udp<\/string>/);
 assert.match(infoPlist, /<key>NSAllowsArbitraryLoads<\/key>\s*<false\/>/);
 assert.match(infoPlist, /<key>ITSAppUsesNonExemptEncryption<\/key>\s*<false\/>/);
+assert.match(
+  infoPlist,
+  /<key>CFBundleURLTypes<\/key>\s*<array>[\s\S]*<key>CFBundleURLSchemes<\/key>\s*<array>[\s\S]*<string>opencoven<\/string>[\s\S]*<\/array>[\s\S]*<\/array>/,
+  "iOS Info.plist should register the opencoven URL scheme",
+);
 
 const sourceInfoPlist = read("src-tauri/Info.ios.plist");
 assert.equal(sourceInfoPlist.trimEnd(), infoPlist.trimEnd());

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -64,5 +64,16 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>opencoven</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>opencoven</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -64,5 +64,16 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>opencoven</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>opencoven</string>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- register the opencoven URL scheme in the iOS source and generated Info.plist
- add a mobile native regression asserting CFBundleURLTypes includes opencoven
- leave generated entitlements formatting churn out of the PR

## Verification
- node scripts/mobile-tailscale-native.test.mjs (red check first with intentionally wrong scheme)
- pnpm test:mobile
- git diff --check
- git diff --check origin/main..HEAD