### PR TITLE
chore(release): v0.0.85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.85] - 2026-06-15
+
+Patch release: a recoverable update flow, a mobile task-page fix, and the chat rail redesign on top of 0.0.84.
+
+### Fixed
+- **Updater** — a failed native install no longer dead-ends. The settings row and banner now surface the real failure reason and offer a working manual Download (release page) plus Retry, so the update is always reachable (#642).
+- **Mobile** — the board card "task page" drawer header now clears the iOS status bar / Dynamic Island, so the title and close button are no longer occluded (#640).
+
+### Changed
+- **Chat rail** — modern redesign with a nav block, counted sections, and a familiar strip (#644).
+- **OpenCoven tools** — added tool update controls.
+
 ## [0.0.84] - 2026-06-15
 
 Patch release with capabilities, library, and iOS fixes on top of 0.0.83.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A familiar is not just a chat window. It has a name, role, runtime, memory, tool
 
 ## Status
 
-- Current app version: `0.0.84`
+- Current app version: `0.0.85`
 - Native shell: Tauri 2
 - Frontend: Next.js 16, React 19, Tailwind v4
 - Runtime dependency: a healthy local `coven` CLI/daemon plus at least one runtime source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.84",
+  "version": "0.0.85",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.84"
+version = "0.0.85"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.84"
+version = "0.0.85"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.84</string>
+	<string>0.0.85</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.84</string>
+	<string>0.0.85</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.84</string>
+	<string>0.0.85</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.84</string>
+	<string>0.0.85</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.84",
+  "version": "0.0.85",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Version bump **0.0.84 → 0.0.85** across the 6 release files (package.json, tauri.conf.json, Cargo.toml, Cargo.lock, README, CHANGELOG).

Once merged, push the signed `v0.0.85` tag to trigger `release.yml` (notarized DMG/AppImage/MSI + signed `latest.json`). This is the first release to include the recoverable-updater fix (#642), so installed apps will pick it up via the working auto-updater.

### Included since 0.0.84
- **Updater** — failed native installs are recoverable: real reason surfaced + manual Download + Retry (#642).
- **Mobile** — task-page drawer header clears the iOS status bar / Dynamic Island (#640).
- **Chat rail** — modern redesign (#644).
- **OpenCoven tools** — tool update controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)