### PR TITLE
Fix terminal auto-start and workflow run preview resizing

### DIFF
--- a/src/components/comux-view-terminal.test.ts
+++ b/src/components/comux-view-terminal.test.ts
@@ -65,6 +65,11 @@ assert.match(
   /comux-terminal-empty-add/,
   "terminal empty-state add button exposes a stable mobile hit-area hook",
 );
+assert.match(
+  source,
+  /const wasActiveTerminalRef = useRef\(false\);[\s\S]*?const activeTerminal = view === "terminal" && active;[\s\S]*?wasActiveTerminalRef\.current = true;[\s\S]*?if \(sessions\.length > 0\) return;[\s\S]*?addSession\(\);/,
+  "opening the active Terminal surface should auto-start one terminal session without respawning after in-surface closes",
+);
 
 // ⌘N / ⌘W keydown handler is wired and respects modifier + contentEditable gate.
 assert.match(

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -190,6 +190,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   const [previewRaw, setPreviewRaw] = useState(false);
   const [sessionsCollapsed, setSessionsCollapsed] = useState(false);
   const treeRef = useRef<ProjectTreeHandle | null>(null);
+  const wasActiveTerminalRef = useRef(false);
 
   // Daemon project root — forwarded to BottomTerminal so terminals open in
   // the right CWD instead of the app bundle dir.
@@ -276,6 +277,18 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
     });
     return id;
   }, [currentIdx, daemonProjectRoot, selectedProjectRoot, sessions]);
+
+  useEffect(() => {
+    const activeTerminal = view === "terminal" && active;
+    if (!activeTerminal) {
+      wasActiveTerminalRef.current = false;
+      return;
+    }
+    if (wasActiveTerminalRef.current) return;
+    wasActiveTerminalRef.current = true;
+    if (sessions.length > 0) return;
+    addSession();
+  }, [active, addSession, sessions.length, view]);
 
   const removeSession = useCallback(
     (idx: number) => {

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -89,6 +89,15 @@ assert.match(studio, /WorkflowPalette/, "Studio should include the step palette"
 assert.match(studio, /WorkflowRunsPanel/, "Studio should include the runs panel");
 assert.match(studio, /WorkflowCreateDialog/, "Studio should wire the create dialog");
 assert.match(studio, /WorkflowScheduleDialog/, "Studio should wire the schedule dialog");
+assert.match(studio, /type WorkflowRunPreviewMode/, "Run preview layout modes should be typed");
+assert.match(studio, /runPreviewMode,\s*setRunPreviewMode[\s\S]{0,80}useState<WorkflowRunPreviewMode>\("compact"\)/, "Run preview should default to compact bottom mode");
+assert.match(studio, /--workflow-runs-height/, "Run preview should expose a CSS height variable for drag resizing");
+assert.match(studio, /--workflow-runs-side-width/, "Run preview should expose a CSS side width variable for split resizing");
+assert.match(studio, /startRunPreviewResize/, "Run preview should expose a drag resize handler");
+assert.match(studio, /setRunPreviewMode\("custom"\)/, "Dragging the bottom run preview should switch to a custom height");
+assert.match(studio, /WORKFLOW_RUN_PREVIEW_PRESETS[\s\S]{0,500}50%[\s\S]{0,500}Full[\s\S]{0,500}Side by side/, "Run preview presets should offer half, full, and side-by-side modes");
+assert.match(studio, /workflow-run-preview-toolbar/, "Run preview should render a mode toolbar");
+assert.match(studio, /aria-label="Drag to resize run preview"/, "Run preview resize handle should be accessible");
 assert.match(studio, /onUndo[\s\S]*onRedo/, "Studio should thread undo/redo");
 assert.match(studio, /leftPanelOpen,\s*setLeftPanelOpen[\s\S]{0,80}useState\(true\)/, "Studio should keep the workflow library panel open by default");
 assert.match(studio, /rightPanelOpen,\s*setRightPanelOpen[\s\S]{0,80}useState\(true\)/, "Studio should keep the workflow details panel open by default");
@@ -245,6 +254,13 @@ assert.match(manifestPreview, /workflowToYaml/, "Manifest preview should render 
 
 assert.match(css, /\.workflow-palette/, "CSS should style the palette");
 assert.match(css, /\.workflow-runs-panel/, "CSS should style the runs panel");
+assert.match(css, /grid-template-areas:[\s\S]*"palette"[\s\S]*"canvas"[\s\S]*"strip"[\s\S]*"runs"/, "Workflow main grid should name the bottom run preview area");
+assert.match(css, /\.workflow-run-preview-frame/, "CSS should style the run preview frame");
+assert.match(css, /\.workflow-run-preview-resizer/, "CSS should style the draggable run preview handle");
+assert.match(css, /\.workflow-studio-main\.is-run-preview-half/, "CSS should support a 50% bottom run preview");
+assert.match(css, /\.workflow-studio-main\.is-run-preview-full/, "CSS should support a full-height bottom run preview");
+assert.match(css, /\.workflow-studio-main\.is-run-preview-split/, "CSS should support a side-by-side run preview");
+assert.match(css, /\.workflow-studio-main\.is-run-preview-split\s*\{[\s\S]*grid-template-areas:[\s\S]*"palette palette"[\s\S]*"canvas runs"[\s\S]*"strip runs"/, "Side-by-side mode should place runs next to the workflow view");
 assert.match(css, /\.workflow-dialog/, "CSS should style dialogs");
 assert.match(css, /\.workflow-field/, "CSS should style editor fields");
 

--- a/src/components/workflows/workflow-studio.tsx
+++ b/src/components/workflows/workflow-studio.tsx
@@ -2,8 +2,8 @@
 
 import "@/styles/workflows.css";
 
-import { useState } from "react";
-import { Icon } from "@/lib/icon";
+import { useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react";
+import { Icon, type IconName } from "@/lib/icon";
 import type { WorkflowGraphNode, WorkflowLayoutDirection, WorkflowNodePositions } from "@/lib/workflow-graph";
 import type { WorkflowPlaybackState } from "@/lib/workflow-playback";
 import type {
@@ -27,6 +27,22 @@ import { WorkflowManifestPreview } from "./workflow-manifest-preview";
 import { WorkflowPalette } from "./workflow-palette";
 import { WorkflowRunStrip } from "./workflow-run-strip";
 import { WorkflowRunsPanel } from "./workflow-runs-panel";
+
+type WorkflowRunPreviewMode = "compact" | "custom" | "half" | "full" | "split";
+
+type WorkflowRunPreviewPreset = {
+  id: Exclude<WorkflowRunPreviewMode, "custom">;
+  label: string;
+  icon: IconName;
+  title: string;
+};
+
+const WORKFLOW_RUN_PREVIEW_PRESETS: WorkflowRunPreviewPreset[] = [
+  { id: "compact", label: "Compact", icon: "ph:rows", title: "Keep runs compact at the bottom" },
+  { id: "half", label: "50%", icon: "ph:caret-up-down", title: "Use half-height run preview" },
+  { id: "full", label: "Full", icon: "ph:arrows-out-simple", title: "Expand run preview to full height" },
+  { id: "split", label: "Side by side", icon: "ph:columns", title: "Show runs beside the workflow view" },
+];
 
 export type WorkflowStudioActionState = {
   id: string;
@@ -99,11 +115,50 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
   const [scheduleOpen, setScheduleOpen] = useState(false);
   const [leftPanelOpen, setLeftPanelOpen] = useState(true);
   const [rightPanelOpen, setRightPanelOpen] = useState(true);
+  const [runPreviewMode, setRunPreviewMode] = useState<WorkflowRunPreviewMode>("compact");
+  const [runPreviewHeight, setRunPreviewHeight] = useState(280);
+  const [runPreviewSideWidth, setRunPreviewSideWidth] = useState(420);
   const shellClassName = [
     "workflow-studio-shell",
     leftPanelOpen ? "" : "is-left-collapsed",
     rightPanelOpen ? "" : "is-right-collapsed",
   ].filter(Boolean).join(" ");
+  const mainClassName = [
+    "workflow-studio-main",
+    `is-run-preview-${runPreviewMode}`,
+  ].join(" ");
+  const mainStyle = {
+    "--workflow-runs-height": `${runPreviewHeight}px`,
+    "--workflow-runs-side-width": `${runPreviewSideWidth}px`,
+  } as CSSProperties;
+
+  function startRunPreviewResize(event: ReactPointerEvent<HTMLButtonElement>) {
+    event.preventDefault();
+    const split = runPreviewMode === "split";
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const startHeight = runPreviewHeight;
+    const startWidth = runPreviewSideWidth;
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      if (split) {
+        const nextWidth = Math.min(760, Math.max(320, startWidth + startX - moveEvent.clientX));
+        setRunPreviewSideWidth(nextWidth);
+        return;
+      }
+      const nextHeight = Math.min(720, Math.max(160, startHeight + startY - moveEvent.clientY));
+      setRunPreviewMode("custom");
+      setRunPreviewHeight(nextHeight);
+    };
+
+    const handlePointerUp = () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+    };
+
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp, { once: true });
+  }
 
   return (
     <section className={shellClassName} aria-label="Workflow Studio">
@@ -135,7 +190,7 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
           />
         </div>
       </aside>
-      <main className="workflow-studio-main">
+      <main className={mainClassName} style={mainStyle}>
         <WorkflowPalette workflow={selectedWorkflow} onAddStep={props.onAddStep} />
         <WorkflowCanvas
           workflow={selectedWorkflow}
@@ -172,13 +227,42 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
           onRedo={props.onRedo}
           onStopPlayback={props.onStopPlayback}
         />
-        <WorkflowRunsPanel
-          runs={props.runs}
-          loading={props.runsLoading}
-          workflow={selectedWorkflow}
-          playback={props.playback}
-          onReplayRun={props.onReplayRun}
-        />
+        <section className="workflow-run-preview-frame" aria-label="Run preview details">
+          <button
+            type="button"
+            className="workflow-run-preview-resizer"
+            aria-label="Drag to resize run preview"
+            title={runPreviewMode === "split" ? "Drag horizontally to resize run preview" : "Drag vertically to resize run preview"}
+            onPointerDown={startRunPreviewResize}
+          >
+            <Icon name="ph:dots-six-vertical" width={15} aria-hidden />
+          </button>
+          <div className="workflow-run-preview-toolbar" role="toolbar" aria-label="Run preview layout">
+            {WORKFLOW_RUN_PREVIEW_PRESETS.map((preset) => {
+              const active = runPreviewMode === preset.id;
+              return (
+                <button
+                  key={preset.id}
+                  type="button"
+                  className={`workflow-run-preview-mode${active ? " is-active" : ""}`}
+                  aria-pressed={active}
+                  title={preset.title}
+                  onClick={() => setRunPreviewMode(preset.id)}
+                >
+                  <Icon name={preset.icon} width={12} aria-hidden />
+                  <span>{preset.label}</span>
+                </button>
+              );
+            })}
+          </div>
+          <WorkflowRunsPanel
+            runs={props.runs}
+            loading={props.runsLoading}
+            workflow={selectedWorkflow}
+            playback={props.playback}
+            onReplayRun={props.onReplayRun}
+          />
+        </section>
       </main>
       <aside className="workflow-studio-side" aria-label="Workflow details">
         <button

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -75,8 +75,30 @@
   display: grid;
   position: relative;
   min-width: 0;
-  grid-template-rows: auto minmax(320px, 1fr) auto auto;
+  grid-template-areas:
+    "palette"
+    "canvas"
+    "strip"
+    "runs";
+  grid-template-rows: auto minmax(240px, 1fr) auto minmax(160px, var(--workflow-runs-height, 280px));
   gap: 0;
+}
+
+.workflow-studio-main.is-run-preview-half {
+  grid-template-rows: auto minmax(180px, 1fr) auto minmax(260px, 50%);
+}
+
+.workflow-studio-main.is-run-preview-full {
+  grid-template-rows: auto minmax(120px, 0.32fr) auto minmax(360px, 1fr);
+}
+
+.workflow-studio-main.is-run-preview-split {
+  grid-template-areas:
+    "palette palette"
+    "canvas runs"
+    "strip runs";
+  grid-template-columns: minmax(0, 1fr) minmax(320px, var(--workflow-runs-side-width, 420px));
+  grid-template-rows: auto minmax(0, 1fr) auto;
 }
 
 /* The panel tab doubles as the panel HEADER: a full-width row with the panel
@@ -429,6 +451,7 @@
 }
 
 .workflow-canvas {
+  grid-area: canvas;
   position: relative;
   min-height: 420px;
   overflow: hidden;
@@ -545,6 +568,7 @@
 }
 
 .workflow-run-strip {
+  grid-area: strip;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -675,7 +699,45 @@
   }
 
   .workflow-studio-main {
-    grid-template-rows: auto minmax(300px, 50vh) auto auto;
+    grid-template-areas:
+      "palette"
+      "canvas"
+      "strip"
+      "runs";
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(300px, 50vh) auto minmax(180px, var(--workflow-runs-height, 280px));
+  }
+
+  .workflow-studio-main.is-run-preview-half {
+    grid-template-rows: auto minmax(240px, 44vh) auto minmax(240px, 42vh);
+  }
+
+  .workflow-studio-main.is-run-preview-full {
+    grid-template-rows: auto minmax(160px, 30vh) auto minmax(320px, 1fr);
+  }
+
+  .workflow-studio-main.is-run-preview-split {
+    grid-template-areas:
+      "palette"
+      "canvas"
+      "strip"
+      "runs";
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(260px, 44vh) auto minmax(240px, 42vh);
+  }
+
+  .workflow-studio-main.is-run-preview-split .workflow-run-preview-frame {
+    border-top: 1px solid var(--border);
+    border-left: 0;
+  }
+
+  .workflow-studio-main.is-run-preview-split .workflow-run-preview-resizer {
+    top: -8px;
+    left: 50%;
+    width: 58px;
+    height: 14px;
+    transform: translateX(-50%);
+    cursor: ns-resize;
   }
 
   .workflow-run-strip {
@@ -691,6 +753,7 @@
 /* ---- Studio v2: builder, palette, runs, dialogs ---- */
 
 .workflow-palette {
+  grid-area: palette;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -959,12 +1022,103 @@
   text-align: right;
 }
 
-.workflow-runs-panel {
+.workflow-run-preview-frame {
+  grid-area: runs;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
   border-top: 1px solid var(--border);
-  padding: 8px 12px 10px;
-  max-height: 180px;
-  overflow-y: auto;
   background: color-mix(in oklch, var(--card) 60%, transparent);
+}
+
+.workflow-run-preview-resizer {
+  position: absolute;
+  top: -8px;
+  left: 50%;
+  z-index: 8;
+  display: grid;
+  place-items: center;
+  width: 58px;
+  height: 14px;
+  transform: translateX(-50%);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--card) 92%, transparent);
+  color: var(--muted-foreground);
+  cursor: ns-resize;
+}
+
+.workflow-run-preview-resizer:hover {
+  border-color: color-mix(in oklch, var(--accent-presence) 54%, var(--border));
+  color: var(--text-primary);
+}
+
+.workflow-run-preview-resizer:focus-visible,
+.workflow-run-preview-mode:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
+}
+
+.workflow-run-preview-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  padding: 8px 12px 0;
+}
+
+.workflow-run-preview-mode {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 26px;
+  padding: 0 8px;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.workflow-run-preview-mode:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.workflow-run-preview-mode.is-active {
+  border-color: color-mix(in oklch, var(--accent-presence) 45%, var(--border));
+  background: var(--background);
+  color: var(--text-primary);
+}
+
+.workflow-runs-panel {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 8px 12px 10px;
+  overflow-y: auto;
+}
+
+.workflow-studio-main.is-run-preview-split .workflow-run-preview-frame {
+  border-top: 0;
+  border-left: 1px solid var(--border);
+}
+
+.workflow-studio-main.is-run-preview-split .workflow-run-preview-resizer {
+  top: 50%;
+  left: -8px;
+  width: 14px;
+  height: 58px;
+  transform: translateY(-50%);
+  cursor: ew-resize;
+}
+
+.workflow-studio-main.is-run-preview-split .workflow-runs-panel {
+  height: 100%;
 }
 
 .workflow-runs-heading {
@@ -1451,10 +1605,6 @@
 }
 
 /* ── Runs panel: expandable rows, summary, replay ────────────────────────── */
-.workflow-runs-panel {
-  max-height: 280px;
-}
-
 .workflow-run-item {
   border: 1px solid var(--border);
   border-radius: 7px;


### PR DESCRIPTION
## Summary
- Auto-start the first Cave terminal session when the Terminal surface is opened with no saved sessions.
- Add workflow run-preview layout presets and drag resizing.
- Cover the terminal launch regression and workflow preview behavior in source tests.

## Test Plan
- pnpm exec node --experimental-strip-types src/components/comux-view-terminal.test.ts
- pnpm exec node --experimental-strip-types src/components/bottom-terminal-ws-bridge.test.ts && pnpm exec node --experimental-strip-types src/lib/pty-ws-bridge.test.ts && pnpm exec node --experimental-strip-types src/server-pty-ws.test.ts
- pnpm exec node --experimental-strip-types src/components/workflows/workflow-studio.test.ts
- pnpm typecheck
- Live browser check: clear cave:comux:sessions, click Terminal, confirm xterm mounts and /api/pty-ws opens automatically
