### PR TITLE
fix(workflows): keep side panel selection separate

### DIFF
--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -101,10 +101,18 @@ assert.match(studio, /aria-label="Drag to resize run preview"/, "Run preview res
 assert.match(studio, /onUndo[\s\S]*onRedo/, "Studio should thread undo/redo");
 assert.match(studio, /leftPanelOpen,\s*setLeftPanelOpen[\s\S]{0,80}useState\(true\)/, "Studio should keep the workflow library panel open by default");
 assert.match(studio, /rightPanelOpen,\s*setRightPanelOpen[\s\S]{0,80}useState\(true\)/, "Studio should keep the workflow details panel open by default");
+assert.match(studio, /type WorkflowSidePanelSection/, "Workflow right panel should model distinct selectable sections");
+assert.match(studio, /sidePanelSection,\s*setSidePanelSection[\s\S]{0,100}useState<WorkflowSidePanelSection>\("inspector"\)/, "Workflow right panel should default to the inspector section");
+assert.match(studio, /role="tablist"[\s\S]{0,120}aria-label="Workflow detail sections"/, "Workflow right panel should expose section tabs instead of using selection as a close action");
+assert.match(studio, /setSidePanelSection\(section\.id\);[\s\S]{0,80}if \(!rightPanelOpen\) setRightPanelOpen\(true\);/, "Selecting a workflow side-panel tab should open or keep the panel open");
+assert.match(studio, /sidePanelSection === "inspector"[\s\S]{0,400}<WorkflowInspector/, "Workflow inspector should render only in the inspector tab panel");
+assert.match(studio, /sidePanelSection === "attachments"[\s\S]{0,500}<WorkflowAttachments/, "Workflow attachments should render only in the attachments tab panel");
+assert.match(studio, /sidePanelSection === "manifest"[\s\S]{0,300}<WorkflowManifestPreview/, "Workflow manifest should render only in the manifest tab panel");
 assert.match(studio, /aria-label=\{leftPanelOpen \? "Hide workflow library" : "Show workflow library"\}/, "Studio should expose an accessible left-panel toggle");
 assert.match(studio, /aria-label=\{rightPanelOpen \? "Hide workflow details" : "Show workflow details"\}/, "Studio should expose an accessible right-panel toggle");
 assert.match(studio, /workflow-studio-library-panel[\s\S]{0,500}workflow-panel-tab workflow-panel-tab-left[\s\S]{0,700}<WorkflowLibrary/, "Left workflow panel toggle should live at the panel top edge");
-assert.match(studio, /workflow-studio-side[\s\S]{0,500}workflow-panel-tab workflow-panel-tab-right[\s\S]{0,700}<WorkflowInspector/, "Right workflow panel toggle should live at the panel top edge");
+assert.match(studio, /workflow-studio-side[\s\S]{0,700}workflow-side-panel-tabs/, "Right workflow panel should render section tabs at the panel top edge");
+assert.match(studio, /workflow-panel-collapse-button workflow-panel-tab-right/, "Right workflow panel collapse should stay separate from section selection");
 assert.match(studio, /leftPanelOpen \? "ph:sidebar-simple-fill" : "ph:sidebar-simple"/, "Left workflow panel toggle should use the sidebar tab icon");
 assert.match(studio, /rightPanelOpen \? "ph:sidebar-simple-fill" : "ph:sidebar-simple"/, "Right workflow panel toggle should use the sidebar tab icon");
 assert.match(studio, /is-left-collapsed[\s\S]{0,160}is-right-collapsed/, "Studio should put collapsed panel state on the shell");
@@ -112,6 +120,8 @@ assert.match(css, /\.workflow-panel-tab/, "Workflow CSS should style sidebar-lik
 assert.match(css, /--workflow-top-control-height:\s*34px/, "Workflow top controls should share a standardized height");
 assert.match(css, /--workflow-top-control-offset:\s*8px/, "Workflow top controls should share a standardized y offset (8px matches the palette's vertical padding)");
 assert.match(css, /\.workflow-panel-tab[\s\S]{0,320}width:\s*100%[\s\S]{0,160}height:\s*var\(--workflow-top-control-height\)[\s\S]{0,120}margin-top:\s*0[\s\S]{0,80}margin-bottom:\s*6px/, "Workflow panel tabs should span the full panel width, share the control height, and sit flush at the top (no offset) so the panel header pulls content up");
+assert.match(css, /\.workflow-side-panel-header/, "Workflow right side panel should style its tab row separately from the collapse control");
+assert.match(css, /\.workflow-side-panel-tab\[aria-selected="true"\]/, "Workflow right side panel should show the selected section tab");
 assert.match(css, /\.workflow-studio-library-panel,[\s\S]{0,140}flex-direction:\s*column/, "Workflow panel content should sit below the full-width trigger row");
 assert.match(css, /\.workflow-palette-item[\s\S]{0,160}min-height:\s*var\(--workflow-top-control-height\)/, "Workflow palette buttons should use the same height as the side-panel triggers");
 assert.match(css, /is-left-collapsed[\s\S]{0,120}grid-template-columns:\s*36px/, "Collapsed left workflow panel should keep a visible toggle rail");

--- a/src/components/workflows/workflow-studio.tsx
+++ b/src/components/workflows/workflow-studio.tsx
@@ -29,6 +29,7 @@ import { WorkflowRunStrip } from "./workflow-run-strip";
 import { WorkflowRunsPanel } from "./workflow-runs-panel";
 
 type WorkflowRunPreviewMode = "compact" | "custom" | "half" | "full" | "split";
+type WorkflowSidePanelSection = "inspector" | "attachments" | "manifest";
 
 type WorkflowRunPreviewPreset = {
   id: Exclude<WorkflowRunPreviewMode, "custom">;
@@ -42,6 +43,16 @@ const WORKFLOW_RUN_PREVIEW_PRESETS: WorkflowRunPreviewPreset[] = [
   { id: "half", label: "50%", icon: "ph:caret-up-down", title: "Use half-height run preview" },
   { id: "full", label: "Full", icon: "ph:arrows-out-simple", title: "Expand run preview to full height" },
   { id: "split", label: "Side by side", icon: "ph:columns", title: "Show runs beside the workflow view" },
+];
+
+const WORKFLOW_SIDE_PANEL_SECTIONS: Array<{
+  id: WorkflowSidePanelSection;
+  label: string;
+  icon: IconName;
+}> = [
+  { id: "inspector", label: "Inspect", icon: "ph:sliders-horizontal" },
+  { id: "attachments", label: "Bind", icon: "ph:paperclip" },
+  { id: "manifest", label: "Manifest", icon: "ph:code" },
 ];
 
 export type WorkflowStudioActionState = {
@@ -115,6 +126,7 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
   const [scheduleOpen, setScheduleOpen] = useState(false);
   const [leftPanelOpen, setLeftPanelOpen] = useState(true);
   const [rightPanelOpen, setRightPanelOpen] = useState(true);
+  const [sidePanelSection, setSidePanelSection] = useState<WorkflowSidePanelSection>("inspector");
   const [runPreviewMode, setRunPreviewMode] = useState<WorkflowRunPreviewMode>("compact");
   const [runPreviewHeight, setRunPreviewHeight] = useState(280);
   const [runPreviewSideWidth, setRunPreviewSideWidth] = useState(420);
@@ -265,35 +277,72 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
         </section>
       </main>
       <aside className="workflow-studio-side" aria-label="Workflow details">
-        <button
-          type="button"
-          className="workflow-panel-tab workflow-panel-tab-right"
-          aria-label={rightPanelOpen ? "Hide workflow details" : "Show workflow details"}
-          aria-expanded={rightPanelOpen}
-          title={rightPanelOpen ? "Hide workflow details" : "Show workflow details"}
-          onClick={() => setRightPanelOpen((open) => !open)}
-        >
-          <span className="workflow-panel-tab__title">Details</span>
-          <Icon name={rightPanelOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={14} className="workflow-panel-tab__icon" />
-        </button>
+        <div className="workflow-side-panel-header">
+          <div className="workflow-side-panel-tabs" role="tablist" aria-label="Workflow detail sections">
+            {WORKFLOW_SIDE_PANEL_SECTIONS.map((section) => {
+              const active = sidePanelSection === section.id;
+              return (
+                <button
+                  key={section.id}
+                  type="button"
+                  role="tab"
+                  id={`workflow-side-panel-tab-${section.id}`}
+                  aria-selected={active}
+                  aria-controls={`workflow-side-panel-${section.id}`}
+                  className="workflow-side-panel-tab"
+                  title={section.label}
+                  onClick={() => {
+                    setSidePanelSection(section.id);
+                    if (!rightPanelOpen) setRightPanelOpen(true);
+                  }}
+                >
+                  <Icon name={section.icon} width={13} aria-hidden />
+                  <span>{section.label}</span>
+                </button>
+              );
+            })}
+          </div>
+          <button
+            type="button"
+            className="workflow-panel-collapse-button workflow-panel-tab-right"
+            aria-label={rightPanelOpen ? "Hide workflow details" : "Show workflow details"}
+            aria-expanded={rightPanelOpen}
+            title={rightPanelOpen ? "Hide workflow details" : "Show workflow details"}
+            onClick={() => setRightPanelOpen((open) => !open)}
+          >
+            <Icon name={rightPanelOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={14} className="workflow-panel-tab__icon" />
+          </button>
+        </div>
         <div className="workflow-studio-side-content">
-          <WorkflowInspector
-            workflow={selectedWorkflow}
-            selectedNode={selectedNode}
-            action={action}
-            onUpdateStep={props.onUpdateStep}
-            onUpdateMeta={props.onUpdateMeta}
-            onRemoveStep={props.onRemoveStep}
-          />
-          <WorkflowAttachments
-            workflow={selectedWorkflow}
-            familiarOptions={props.familiarOptions}
-            roles={props.roles}
-            onAttachRole={props.onAttachRole}
-            onUpdateMeta={props.onUpdateMeta}
-            onScheduleRequest={() => setScheduleOpen(true)}
-          />
-          <WorkflowManifestPreview workflow={selectedWorkflow} dirty={props.dirty} />
+          <div
+            id={`workflow-side-panel-${sidePanelSection}`}
+            role="tabpanel"
+            aria-labelledby={`workflow-side-panel-tab-${sidePanelSection}`}
+          >
+            {sidePanelSection === "inspector" && (
+              <WorkflowInspector
+                workflow={selectedWorkflow}
+                selectedNode={selectedNode}
+                action={action}
+                onUpdateStep={props.onUpdateStep}
+                onUpdateMeta={props.onUpdateMeta}
+                onRemoveStep={props.onRemoveStep}
+              />
+            )}
+            {sidePanelSection === "attachments" && (
+              <WorkflowAttachments
+                workflow={selectedWorkflow}
+                familiarOptions={props.familiarOptions}
+                roles={props.roles}
+                onAttachRole={props.onAttachRole}
+                onUpdateMeta={props.onUpdateMeta}
+                onScheduleRequest={() => setScheduleOpen(true)}
+              />
+            )}
+            {sidePanelSection === "manifest" && (
+              <WorkflowManifestPreview workflow={selectedWorkflow} dirty={props.dirty} />
+            )}
+          </div>
         </div>
       </aside>
       {createOpen && (

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -101,9 +101,8 @@
   grid-template-rows: auto minmax(0, 1fr) auto;
 }
 
-/* The panel tab doubles as the panel HEADER: a full-width row with the panel
-   title and the collapse toggle, flush to the top so the sections sit right
-   under it (same idiom as the main sidebar header). */
+/* The left panel tab doubles as the panel header: a full-width row with the
+   title and collapse toggle, flush to the top so sections sit right under it. */
 .workflow-panel-tab {
   display: flex;
   align-items: center;
@@ -156,6 +155,77 @@
   outline-offset: 1px;
 }
 
+.workflow-side-panel-header {
+  display: flex;
+  align-items: stretch;
+  gap: 6px;
+  flex-shrink: 0;
+  width: 100%;
+  height: var(--workflow-top-control-height);
+  margin: 0 0 6px;
+}
+
+.workflow-side-panel-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 4px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.workflow-side-panel-tab,
+.workflow-panel-collapse-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  height: var(--workflow-top-control-height);
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.workflow-side-panel-tab {
+  gap: 5px;
+  padding: 0 6px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.workflow-side-panel-tab span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-panel-collapse-button {
+  flex: 0 0 var(--workflow-top-control-height);
+  width: var(--workflow-top-control-height);
+}
+
+.workflow-side-panel-tab:hover,
+.workflow-panel-collapse-button:hover {
+  border-color: var(--border-hairline);
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.workflow-side-panel-tab:focus-visible,
+.workflow-panel-collapse-button:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
+}
+
+.workflow-side-panel-tab[aria-selected="true"] {
+  border-color: var(--border);
+  background: var(--surface-raised);
+  color: var(--text-primary);
+}
+
 /* Collapsed: hide the title so only the toggle icon shows in the narrow strip. */
 .workflow-studio-shell.is-left-collapsed .workflow-panel-tab-left .workflow-panel-tab__title,
 .workflow-studio-shell.is-right-collapsed .workflow-panel-tab-right .workflow-panel-tab__title {
@@ -172,6 +242,20 @@
   align-items: flex-start;
   padding-top: 10px;
   margin-bottom: 0;
+}
+
+.workflow-studio-shell.is-right-collapsed .workflow-side-panel-header {
+  flex: 1 1 auto;
+  height: auto;
+  margin-bottom: 0;
+}
+
+.workflow-studio-shell.is-right-collapsed .workflow-side-panel-tabs {
+  display: none;
+}
+
+.workflow-studio-shell.is-right-collapsed .workflow-panel-collapse-button.workflow-panel-tab-right {
+  width: 100%;
 }
 
 .workflow-studio-side,
@@ -1488,6 +1572,8 @@
   }
 
   .workflow-panel-tab,
+  .workflow-side-panel-tab,
+  .workflow-panel-collapse-button,
   .workflow-palette-item,
   .workflow-run-row,
   .workflow-history-button,


### PR DESCRIPTION
## Summary
- split workflow side-panel section selection from the collapse control
- keep Inspect, Bind, and Manifest as proper tabs so selecting a section does not close the panel
- add regression coverage and styling for the side-panel tab row

## Verification
- node --experimental-strip-types src/components/workflows/workflow-studio.test.ts
- pnpm typecheck
- git diff --check