### PR TITLE
feat(capabilities): full-size preview for skill/instruction markdown

### DIFF
--- a/src/components/capabilities-view-polish.test.ts
+++ b/src/components/capabilities-view-polish.test.ts
@@ -71,6 +71,39 @@ assert.match(
   "keydown handler skips when an input/textarea is focused",
 );
 
+// Full-size skill/instructions preview: inspector exposes an Expand control that
+// opens a reader-scale modal rendering the same markdown body.
+assert.match(
+  source,
+  /function CapabilityPreviewModal\(/,
+  "inspector should ship a full-size preview modal",
+);
+assert.match(
+  source,
+  /aria-label="Open full-size preview"/,
+  "skill preview should expose an Expand control with an accessible name",
+);
+assert.match(
+  source,
+  /ph:arrows-out-simple/,
+  "Expand control should use the expand affordance icon",
+);
+assert.match(
+  source,
+  /role="dialog"[\s\S]{0,120}aria-modal="true"/,
+  "full-size preview should be a modal dialog",
+);
+assert.match(
+  source,
+  /e\.key === "Escape"[\s\S]{0,40}onClose\(\)/,
+  "full-size preview should close on Escape",
+);
+assert.match(
+  source,
+  /<MarkdownBlock text=\{body\} className="cave-md--expanded"/,
+  "full-size preview should render markdown at reader scale",
+);
+
 assert.match(source, /capabilities-view/, "Capabilities surface should expose a mobile hit-area root hook");
 assert.match(
   globals,

--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -680,6 +680,7 @@ function CapabilityInspector({
             <SkillPreviewBlock
               preview={previewMatches ? preview : { path: item.sourcePath ?? null, status: "loading", text: null, error: null }}
               fallbackDescription={item.description}
+              title={item.label}
             />
           ) : item.description ? (
             <InspectorBlock label="Detail" value={item.description} />
@@ -836,11 +837,15 @@ function stripFrontmatter(text: string): string {
 function SkillPreviewBlock({
   preview,
   fallbackDescription,
+  title,
 }: {
   preview: SkillPreviewState;
   fallbackDescription?: string;
+  title?: string;
 }) {
+  const [expanded, setExpanded] = useState(false);
   const body = preview.text ? stripFrontmatter(preview.text) : "";
+  const canExpand = preview.status === "loaded" && !!body;
   // Rendered the file content as styled markdown. On error (e.g. the path is
   // outside the previewable roots) fall back to the scanned description so the
   // inspector never goes blank.
@@ -859,7 +864,21 @@ function SkillPreviewBlock({
 
   return (
     <div>
-      <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">Preview</p>
+      <div className="mb-1 flex items-center justify-between gap-2">
+        <p className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">Preview</p>
+        {canExpand ? (
+          <button
+            type="button"
+            onClick={() => setExpanded(true)}
+            aria-label="Open full-size preview"
+            title="Open full-size preview"
+            className="focus-ring inline-flex h-6 items-center gap-1 rounded-md border border-border px-1.5 text-[10px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <Icon name="ph:arrows-out-simple" width={11} />
+            <span>Expand</span>
+          </button>
+        ) : null}
+      </div>
       <div className="max-h-[440px] overflow-y-auto rounded-md border border-border bg-background px-3 py-2">
         {preview.status === "loaded" && body ? (
           <MarkdownBlock text={body} className="text-[12px]" />
@@ -872,6 +891,75 @@ function SkillPreviewBlock({
             ))}
           </div>
         )}
+      </div>
+      {expanded ? (
+        <CapabilityPreviewModal
+          title={title}
+          path={preview.path}
+          body={body}
+          onClose={() => setExpanded(false)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+// Full-size reader for a capability's markdown. Mirrors the familiars memory
+// reader modal: a centered overlay with a wide, scrollable column rendering the
+// same MarkdownBlock at reader scale. The body is already loaded by the
+// inspector, so this is purely presentational — no extra fetch.
+function CapabilityPreviewModal({
+  title,
+  path,
+  body,
+  onClose,
+}: {
+  title?: string;
+  path: string | null;
+  body: string;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const heading = title ?? path?.split("/").pop() ?? "Preview";
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/75 p-4 backdrop-blur-sm"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Preview: ${heading}`}
+    >
+      <div
+        className="relative flex h-[92vh] w-[94vw] max-w-[1100px] flex-col overflow-hidden rounded-xl border border-border bg-card shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-2.5">
+          <Icon name="ph:book-open" width={13} className="shrink-0 text-muted-foreground" aria-hidden />
+          <span className="flex-1 truncate text-[12px] text-[var(--text-secondary)]" title={path ?? undefined}>
+            {heading}
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            className="focus-ring ml-1 flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            aria-label="Close preview"
+          >
+            <Icon name="ph:x-bold" width={11} aria-hidden />
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto px-8 py-6">
+          <div className="mx-auto w-full max-w-[820px]">
+            <MarkdownBlock text={body} className="cave-md--expanded" />
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## What

The Capabilities view inspector renders a skill / global-instructions `.md` preview, but it's confined to a 440px-tall scroll pane — long skills get clipped and there was no way to read the whole thing in place.

This adds an **Expand** control in the preview header that opens a full-size reader modal:

- Centered overlay, wide scrollable column (`92vh × 94vw`, max 1100px), rendering the same `MarkdownBlock` at reader scale (`cave-md--expanded`).
- Closes on **Escape**, backdrop click, or the **✕** button.
- Mirrors the established familiars memory reader (`MemoryReaderModal`) for a consistent feel.
- The body is already loaded by the inspector, so the modal is purely presentational — **no extra fetch**.
- Expand only appears once the preview has loaded non-empty markdown.

## Test

- `capabilities-view-polish.test.ts` — added source assertions for the modal, the accessible Expand control, the dialog role, Escape-to-close, and reader-scale markdown.
- `tsc --noEmit` clean; existing capabilities tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)