### PR TITLE
fix(library): resolve docs from trusted allowlist + anchor path guard

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -164,7 +164,7 @@ for (const contract of contracts) {
     assert.match(source, /path not allowed|collection path not allowed/, `${contract.route} must preserve path-deny errors`);
     assert.match(source, /status:\s*403/, `${contract.route} path guard must preserve 403 response`);
   }
-  if (contract.route === "/library" || contract.route === "/library/doc") {
+  if (contract.route === "/library") {
     assert.match(
       source,
       /function realpathOrResolve\(value: string\)[\s\S]*fs\.realpathSync\(resolved\)/,
@@ -174,6 +174,23 @@ for (const contract of contracts) {
       source,
       /const root = realpathOrResolve\((?:researchRoot|RESEARCH_ROOT)\);[\s\S]*const resolved = realpathOrResolve\(p\);[\s\S]*resolved\.startsWith\(root \+ path\.sep\)/,
       `${contract.route} should allow symlinked familiar research paths only within the real research root`,
+    );
+    assert.doesNotMatch(
+      source,
+      /resolveAllowedProjectPath/,
+      `${contract.route} should not reject symlinked familiar research dirs via the global project-root allowlist`,
+    );
+  }
+  if (contract.route === "/library/doc") {
+    assert.match(
+      source,
+      /function realpathOrResolveFromBase\(base: string, value: string\)[\s\S]*path\.resolve\(base, value\)[\s\S]*fs\.realpathSync\(resolved\)/,
+      `${contract.route} should canonicalize candidate document paths from a trusted base`,
+    );
+    assert.match(
+      source,
+      /const root = realpathOrResolveFromBase\("\/", RESEARCH_ROOT\);[\s\S]*if \(isAbsolute\)[\s\S]*path\.isAbsolute\(input\)[\s\S]*realpathOrResolveFromBase\("\/", input\)[\s\S]*realpathOrResolveFromBase\(SAGE_ROOT, input\)[\s\S]*candidate\.startsWith\(root \+ path\.sep\)/,
+      `${contract.route} should validate legacy absolute paths and relative ids under the real research root`,
     );
     assert.doesNotMatch(
       source,

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -189,8 +189,13 @@ for (const contract of contracts) {
     );
     assert.match(
       source,
-      /const root = realpathOrResolveFromBase\("\/", RESEARCH_ROOT\);[\s\S]*if \(isAbsolute\)[\s\S]*path\.isAbsolute\(input\)[\s\S]*realpathOrResolveFromBase\("\/", input\)[\s\S]*realpathOrResolveFromBase\(SAGE_ROOT, input\)[\s\S]*candidate\.startsWith\(root \+ path\.sep\)/,
-      `${contract.route} should validate legacy absolute paths and relative ids under the real research root`,
+      /function listResearchEntries\(root: string\)[\s\S]*fs\.readdirSync\(dir, \{ withFileTypes: true \}\)[\s\S]*isWithinRoot\(realPath, root\)[\s\S]*relativeToSage/,
+      `${contract.route} should build an allowlist from trusted research-root entries`,
+    );
+    assert.match(
+      source,
+      /const requestedAbsolute = isAbsolute \? normalizeAbsolutePath\(input, root\) : null;[\s\S]*const requestedRelative = isAbsolute \? null : normalizeRelativeId\(input\);[\s\S]*listResearchEntries\(root\)\.find/,
+      `${contract.route} should use user input only to select from the trusted research allowlist`,
     );
     assert.doesNotMatch(
       source,

--- a/src/app/api/library/doc/route.ts
+++ b/src/app/api/library/doc/route.ts
@@ -9,8 +9,8 @@ const RESEARCH_ROOT = path.join(SAGE_ROOT, "research");
 const MAX_SIZE = 512 * 1024; // 512KB
 
 // Security: must be within sage research dir
-function realpathOrResolve(value: string): string {
-  const resolved = path.resolve(value);
+function realpathOrResolveFromBase(base: string, value: string): string {
+  const resolved = path.resolve(base, value);
   try {
     return fs.realpathSync(resolved);
   } catch {
@@ -18,11 +18,19 @@ function realpathOrResolve(value: string): string {
   }
 }
 
-function resolveResearchPath(p: string): string | null {
-  const root = realpathOrResolve(RESEARCH_ROOT);
-  const resolved = realpathOrResolve(p);
-  if (resolved !== root && !resolved.startsWith(root + path.sep)) return null;
-  return resolved;
+function resolveResearchPath(input: string, isAbsolute: boolean): string | null {
+  const root = realpathOrResolveFromBase("/", RESEARCH_ROOT);
+
+  let candidate: string;
+  if (isAbsolute) {
+    if (!path.isAbsolute(input)) return null;
+    candidate = realpathOrResolveFromBase("/", input);
+  } else {
+    candidate = realpathOrResolveFromBase(SAGE_ROOT, input);
+  }
+
+  if (candidate !== root && !candidate.startsWith(root + path.sep)) return null;
+  return candidate;
 }
 
 function parseFrontmatter(content: string): { frontmatter: Record<string, string>; body: string } {
@@ -73,19 +81,19 @@ function stripMarkdown(text: string): string {
 
 export async function GET(req: NextRequest) {
   // Accept either ?path= (absolute, legacy) or ?id= (relative to sage root)
-  let filePath = req.nextUrl.searchParams.get("path");
-  const docId   = req.nextUrl.searchParams.get("id");
+  const filePath = req.nextUrl.searchParams.get("path");
+  const docId = req.nextUrl.searchParams.get("id");
 
-  if (!filePath && docId) {
+  let resolved: string | null = null;
+  if (filePath) {
+    resolved = resolveResearchPath(filePath, true);
+  } else if (docId) {
     // id is relative to the sage workspace root (e.g. "research/synthesis/foo.md")
-    filePath = path.join(SAGE_ROOT, docId);
-  }
-
-  if (!filePath) {
+    resolved = resolveResearchPath(docId, false);
+  } else {
     return NextResponse.json({ ok: false, error: "missing path or id param" }, { status: 400 });
   }
 
-  const resolved = resolveResearchPath(filePath);
   if (!resolved) {
     return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
   }
@@ -125,7 +133,7 @@ export async function GET(req: NextRequest) {
   const tags = extractTags(frontmatter);
   const excerpt = stripMarkdown(body).slice(0, 200);
 
-  const id = path.relative(realpathOrResolve(SAGE_ROOT), resolved);
+  const id = path.relative(realpathOrResolveFromBase("/", SAGE_ROOT), resolved);
 
   const doc: LibraryDocBody = {
     id,

--- a/src/app/api/library/doc/route.ts
+++ b/src/app/api/library/doc/route.ts
@@ -8,6 +8,10 @@ const SAGE_ROOT = path.join(homedir(), ".openclaw", "workspace", "sage");
 const RESEARCH_ROOT = path.join(SAGE_ROOT, "research");
 const MAX_SIZE = 512 * 1024; // 512KB
 
+type ResearchPathResolution =
+  | { ok: true; path: string }
+  | { ok: false; reason: "forbidden" | "not_found" | "not_file" };
+
 // Security: must be within sage research dir
 function realpathOrResolveFromBase(base: string, value: string): string {
   const resolved = path.resolve(base, value);
@@ -18,19 +22,78 @@ function realpathOrResolveFromBase(base: string, value: string): string {
   }
 }
 
-function resolveResearchPath(input: string, isAbsolute: boolean): string | null {
-  const root = realpathOrResolveFromBase("/", RESEARCH_ROOT);
+function isWithinRoot(value: string, root: string): boolean {
+  return value === root || value.startsWith(root + path.sep);
+}
 
-  let candidate: string;
-  if (isAbsolute) {
-    if (!path.isAbsolute(input)) return null;
-    candidate = realpathOrResolveFromBase("/", input);
-  } else {
-    candidate = realpathOrResolveFromBase(SAGE_ROOT, input);
+function normalizeRelativeId(value: string): string | null {
+  if (!value || value.includes("\0") || path.isAbsolute(value)) return null;
+  const normalized = path.normalize(value);
+  if (normalized === "." || normalized === ".." || normalized.startsWith(`..${path.sep}`)) return null;
+  return normalized;
+}
+
+function normalizeAbsolutePath(value: string, root: string): string | null {
+  if (!value || value.includes("\0") || !path.isAbsolute(value)) return null;
+  const normalized = path.normalize(value);
+  if (!isWithinRoot(normalized, root)) return null;
+  return normalized;
+}
+
+function listResearchEntries(root: string): Array<{ path: string; relativeToSage: string; isFile: boolean }> {
+  const entries: Array<{ path: string; relativeToSage: string; isFile: boolean }> = [];
+  const sageRoot = realpathOrResolveFromBase("/", SAGE_ROOT);
+
+  function walk(dir: string) {
+    let dirents: fs.Dirent[];
+    try {
+      dirents = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const dirent of dirents) {
+      const fullPath = path.join(dir, dirent.name);
+      const realPath = realpathOrResolveFromBase("/", fullPath);
+      if (!isWithinRoot(realPath, root)) continue;
+      if (dirent.isDirectory()) {
+        entries.push({ path: realPath, relativeToSage: path.relative(sageRoot, realPath), isFile: false });
+        walk(realPath);
+        continue;
+      }
+      if (dirent.isFile()) {
+        entries.push({ path: realPath, relativeToSage: path.relative(sageRoot, realPath), isFile: true });
+      }
+    }
   }
 
-  if (candidate !== root && !candidate.startsWith(root + path.sep)) return null;
-  return candidate;
+  walk(root);
+  return entries;
+}
+
+function resolveResearchPath(input: string, isAbsolute: boolean): ResearchPathResolution {
+  const root = realpathOrResolveFromBase("/", RESEARCH_ROOT);
+  const requestedAbsolute = isAbsolute ? normalizeAbsolutePath(input, root) : null;
+  const requestedRelative = isAbsolute ? null : normalizeRelativeId(input);
+  if (isAbsolute ? !requestedAbsolute : !requestedRelative) {
+    return { ok: false, reason: "forbidden" };
+  }
+
+  const match = listResearchEntries(root).find((entry) =>
+    isAbsolute
+      ? entry.path === requestedAbsolute
+      : entry.relativeToSage === requestedRelative,
+  );
+
+  if (!match) {
+    return { ok: false, reason: "not_found" };
+  }
+
+  if (!match.isFile) {
+    return { ok: false, reason: "not_file" };
+  }
+
+  return { ok: true, path: match.path };
 }
 
 function parseFrontmatter(content: string): { frontmatter: Record<string, string>; body: string } {
@@ -84,19 +147,27 @@ export async function GET(req: NextRequest) {
   const filePath = req.nextUrl.searchParams.get("path");
   const docId = req.nextUrl.searchParams.get("id");
 
-  let resolved: string | null = null;
+  let resolution: ResearchPathResolution;
   if (filePath) {
-    resolved = resolveResearchPath(filePath, true);
+    resolution = resolveResearchPath(filePath, true);
   } else if (docId) {
     // id is relative to the sage workspace root (e.g. "research/synthesis/foo.md")
-    resolved = resolveResearchPath(docId, false);
+    resolution = resolveResearchPath(docId, false);
   } else {
     return NextResponse.json({ ok: false, error: "missing path or id param" }, { status: 400 });
   }
 
-  if (!resolved) {
+  if (!resolution.ok && resolution.reason === "forbidden") {
     return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
   }
+  if (!resolution.ok && resolution.reason === "not_file") {
+    return NextResponse.json({ ok: false, error: "not a file" }, { status: 400 });
+  }
+  if (!resolution.ok) {
+    return NextResponse.json({ ok: false, error: "file not found" }, { status: 404 });
+  }
+
+  const resolved = resolution.path;
 
   let stat: fs.Stats;
   try {


### PR DESCRIPTION
Two-commit fix for library doc path traversal guard:\n- Anchors path resolution to prevent escape\n- Resolves library docs through a trusted allowlist\n\nAddresses code scanning alert #15/#16 more robustly.