### PR TITLE
fix(ui): keyboard-aware popover positioning + tokenize focus-ring offsets

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -176,6 +176,10 @@
   --ring-focus-soft: color-mix(in oklch, var(--accent-presence) 30%, transparent);
   --ring-width: 2px;
   --ring-offset: 2px;
+  /* Inset offset for rings on items inside dense/clipping containers (list rows,
+     popover items, nav tabs) where an outset ring would be clipped by the parent.
+     Single source so these don't drift between -1px/-2px ad hoc. */
+  --ring-offset-inset: calc(-1 * var(--ring-width));
 
   /* ---- Surface alphas ---- */
   --backdrop-scrim: oklch(0 0 0 / 60%);
@@ -1825,7 +1829,7 @@ select {
 }
 .ui-search-input-clear:focus-visible {
   outline: var(--ring-width) solid var(--ring-focus);
-  outline-offset: 1px;
+  outline-offset: var(--ring-offset);
 }
 .ui-search-input-hint {
   display: flex;
@@ -1894,7 +1898,7 @@ select {
 }
 .ui-popover-item:focus-visible {
   outline: var(--ring-width) solid var(--ring-focus);
-  outline-offset: -2px;
+  outline-offset: var(--ring-offset-inset);
 }
 .ui-popover-item--danger {
   color: var(--color-danger-soft);
@@ -1961,7 +1965,7 @@ select {
 }
 .ui-row-card:focus-visible {
   outline: var(--ring-width) solid var(--ring-focus);
-  outline-offset: -1px;
+  outline-offset: var(--ring-offset-inset);
 }
 .ui-row-card--selected {
   background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
@@ -2373,7 +2377,7 @@ select {
 .shell-nav-tab:focus-visible,
 .shell-familiar-strip-btn:focus-visible {
   outline: var(--ring-width) solid var(--ring-focus);
-  outline-offset: -2px;
+  outline-offset: var(--ring-offset-inset);
 }
 .shell-nav-tab--open {
   background: var(--bg-raised);

--- a/src/components/ui/popover.test.ts
+++ b/src/components/ui/popover.test.ts
@@ -21,4 +21,16 @@ assert.match(src, /spaceBelow|spaceAbove/, "compares room below vs above the anc
 assert.match(src, /Math\.min\(r\.left/, "clamps the left edge within the viewport");
 assert.match(src, /maxHeight/, "caps height (with overflowY:auto) so neither side overflows");
 
+// Visual-viewport awareness: the on-screen keyboard (iOS) shrinks the visible band
+// without changing window.innerHeight. The popover must measure against
+// window.visualViewport so it clamps inside the visible area instead of hiding
+// under the keyboard, and must recompute when the keyboard opens/closes.
+assert.match(src, /window\.visualViewport/, "measures against the visual viewport (keyboard-aware)");
+assert.match(src, /vv\?\.height|visualViewport\b[\s\S]*?\.height/, "uses the visual viewport height for fit checks");
+assert.match(
+  src,
+  /vv\?\.addEventListener\("resize"|visualViewport[\s\S]*?addEventListener\("resize"/,
+  "recomputes when the visual viewport resizes (keyboard show/hide)",
+);
+
 console.log("popover.test.ts: ok");

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -56,11 +56,24 @@ export function Popover({
     const popW = pop?.offsetWidth ?? minWidth ?? r.width;
     const MARGIN = 8;
 
+    // Measure against the VISUAL viewport, not the layout viewport, so the
+    // on-screen keyboard (iOS) is treated as unavailable space. getBoundingClientRect
+    // is in layout-viewport coords, so the visible region's bounds in those same
+    // coords are [offsetTop, offsetTop + height]. Falls back to innerHeight/Width
+    // where visualViewport is unavailable (older webviews, SSR is guarded by callers).
+    const vv = window.visualViewport;
+    const viewTop = vv?.offsetTop ?? 0;
+    const viewLeft = vv?.offsetLeft ?? 0;
+    const viewH = vv?.height ?? window.innerHeight;
+    const viewW = vv?.width ?? window.innerWidth;
+    const visibleBottom = viewTop + viewH;
+
     // Vertical auto-flip: honor the requested side, but flip to the opposite side
     // when the popover can't fit there and the other side has more room. Keeps it
-    // on-screen when the anchor sits low (or high) in the viewport.
-    const spaceBelow = window.innerHeight - r.bottom - offset;
-    const spaceAbove = r.top - offset;
+    // on-screen when the anchor sits low (or high) in the viewport — or when the
+    // keyboard has eaten the space below.
+    const spaceBelow = visibleBottom - r.bottom - offset;
+    const spaceAbove = r.top - viewTop - offset;
     const isTop = placement.startsWith("top")
       ? !(popH > spaceAbove && spaceBelow > spaceAbove)
       : popH > spaceBelow && spaceAbove > spaceBelow;
@@ -69,8 +82,10 @@ export function Popover({
     const next: CSSProperties = {
       position: "absolute",
       minWidth: minWidth ?? r.width,
-      // Never exceed the chosen side's available space; scroll inside if it must.
-      maxHeight: `${Math.round(Math.max(isTop ? spaceAbove : spaceBelow, 160))}px`,
+      // Never exceed the chosen side's visible space; scroll inside if it must. Floor
+      // low (120px) rather than 160 so a keyboard-shrunk viewport still clamps inside
+      // the visible band instead of disappearing under the keyboard.
+      maxHeight: `${Math.round(Math.max(Math.min(isTop ? spaceAbove : spaceBelow, viewH - 2 * MARGIN), 120))}px`,
       overflowY: "auto",
     };
     if (isTop) {
@@ -78,11 +93,11 @@ export function Popover({
     } else {
       next.top = r.bottom + offset;
     }
-    // Horizontal clamp: keep both edges within the viewport.
+    // Horizontal clamp: keep both edges within the visible viewport.
     if (isEnd) {
       next.right = Math.max(MARGIN, window.innerWidth - r.right);
     } else {
-      next.left = Math.max(MARGIN, Math.min(r.left, window.innerWidth - popW - MARGIN));
+      next.left = Math.max(MARGIN, Math.min(r.left, viewLeft + viewW - popW - MARGIN));
     }
     setStyle(next);
   }, [anchorRef, placement, offset, minWidth]);
@@ -115,11 +130,18 @@ export function Popover({
     document.addEventListener("mousedown", onDocClick);
     window.addEventListener("resize", onReflow);
     window.addEventListener("scroll", onReflow, true);
+    // Recompute when the on-screen keyboard opens/closes or the page pinch-zooms,
+    // so the popover re-clamps to the shrunken visible band instead of hiding under it.
+    const vv = window.visualViewport;
+    vv?.addEventListener("resize", onReflow);
+    vv?.addEventListener("scroll", onReflow);
     return () => {
       window.removeEventListener("keydown", onKey, true);
       document.removeEventListener("mousedown", onDocClick);
       window.removeEventListener("resize", onReflow);
       window.removeEventListener("scroll", onReflow, true);
+      vv?.removeEventListener("resize", onReflow);
+      vv?.removeEventListener("scroll", onReflow);
     };
   }, [open, onOpenChange, anchorRef, compute]);
 


### PR DESCRIPTION
**Phase 0 (foundation)** of the desktop + mobile UX refactor. The audit's scariest finding — "the design system is immature" — turned out to be **enforcement debt, not missing infrastructure**: the token ladders, `--ring-*`, `--touch-target`, `--opacity-disabled`, safe-area insets, and the `useVisualViewport` hook all already exist. So this phase *enforces what's there* and fixes the one real bug that blocks every mobile phase.

## Changes
- **Keyboard-aware popovers (the real fix).** `Popover` now measures available space against `window.visualViewport` instead of the layout viewport, so the iOS on-screen keyboard counts as unavailable space. The popover clamps inside the visible band (floor 120px + internal scroll) and recomputes on `visualViewport` resize/scroll — instead of being trapped under the keyboard. Every dropdown/menu/selector rides this primitive, so this unblocks the mobile phases.
- **Tokenize focus-ring offsets.** Added one `--ring-offset-inset: calc(-1 * var(--ring-width))` token and pointed the ad-hoc inset/outset focus offsets (`ui-popover-item`, `ui-row-card`, shell nav tabs/familiar strip, `ui-search-input-clear`) at the ring tokens, so keyboard-focus offset stops drifting between `-1px`/`-2px`/`1px`.

## Deferred (intentionally, to keep this PR's conflict surface small with concurrent sessions)
Breakpoint custom-media centralization, the disabled-opacity literal sweep, and the inline-style CI guard — high churn across every CSS file, low user value. `--text-muted` already meets AA (55%/62%, per the `CHAT-D13-02` rationale) — no change.

## Verification
- `pnpm typecheck` ✅
- `pnpm build` ✅
- `popover.test.ts` extended to lock in visual-viewport behavior; `globals.css.test.ts` ✅; `check:tests-wired` ✅ (292 files wired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)