### PR TITLE
fix(chat): reach Inspector/Debug/Changes panels on mobile via a sheet

### DIFF
--- a/src/components/chat-surface-mobile-command-center.test.ts
+++ b/src/components/chat-surface-mobile-command-center.test.ts
@@ -47,4 +47,34 @@ assert.match(
   "Mobile chat should prevent the shell detail from becoming a second scroll owner",
 );
 
+// The Inspector/Debug/Changes panels live in a 230px right sidebar that is
+// hidden below the desktop shell breakpoint (no room beside the chat thread).
+// On mobile they must remain reachable — rendered in a right-edge sheet over a
+// dismissible scrim — instead of silently vanishing.
+assert.match(
+  source,
+  /scope === "conversation" && rightPanel !== null && isMobile && \(/,
+  "ChatSurface should render the session panels as a mobile sheet when the inline sidebar is hidden",
+);
+
+assert.match(
+  source,
+  /className="chat-right-sheet fixed inset-0 z-\[200\] flex justify-end lg:hidden"/,
+  "Mobile session-panel sheet should be a fixed right-edge overlay, hidden once the desktop sidebar fits (lg)",
+);
+
+assert.match(
+  source,
+  /aria-label="Close session panels"[\s\S]*?onClick=\{\(\) => setRightPanel\(null\)\}/,
+  "Mobile session-panel sheet should close on scrim tap",
+);
+
+// Gate the inline desktop sidebar on !isMobile so only one RightPanel mounts per
+// breakpoint — otherwise InspectorPane double-fetches and duplicates DOM ids.
+assert.match(
+  source,
+  /rightPanel !== null && !isMobile && \(/,
+  "Inline desktop right sidebar should not also mount on mobile (avoids duplicate RightPanel)",
+);
+
 console.log("chat-surface-mobile-command-center.test.ts: ok");

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -10,6 +10,7 @@ import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
 import { DebugPane } from "@/components/debug-pane";
 import { SessionChangesPanel } from "@/components/session-changes-panel";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
+import { useIsMobile } from "@/lib/use-viewport";
 import { Icon } from "@/lib/icon";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { Familiar, SessionRow } from "@/lib/types";
@@ -167,6 +168,10 @@ export function ChatSurface({
   onOpenTask,
 }: Props) {
   const [scope, setScope] = useState<FamiliarsScope>("conversation");
+  // Below the desktop shell breakpoint the inline 230px right sidebar is hidden
+  // (no room beside the chat thread), so the Inspector/Debug/Changes panels would
+  // be unreachable. On mobile we render them in a right-edge sheet overlay instead.
+  const isMobile = useIsMobile();
   const consumedPendingActionNonce = useRef<number | null>(null);
 
   // Right panel — prefer new prop, fall back to legacy bool
@@ -369,7 +374,7 @@ export function ChatSurface({
                 />
               </div>
             </Panel>
-            {rightPanel !== null && (
+            {rightPanel !== null && !isMobile && (
               <>
                 {/* Fixed-width mirror of the internal left rail (chat-thread-rail
                     is w-[230px]). No resize handle — the panel's own border-l is
@@ -397,6 +402,39 @@ export function ChatSurface({
           </Group>
         )}
       </div>
+      {/* Mobile: the inline 230px right sidebar can't fit beside the chat thread,
+          so the Inspector/Debug/Changes panels open in a right-edge sheet over a
+          dismissible scrim. Gated on isMobile so only one RightPanel mounts per
+          breakpoint — the InspectorPane won't double-fetch or duplicate DOM ids.
+          Scoped to the conversation tab to mirror the desktop placement. */}
+      {scope === "conversation" && rightPanel !== null && isMobile && (
+        <div
+          className="chat-right-sheet fixed inset-0 z-[200] flex justify-end lg:hidden"
+          role="presentation"
+          onKeyDown={(e) => {
+            if (e.key === "Escape") setRightPanel(null);
+          }}
+        >
+          <button
+            type="button"
+            aria-label="Close session panels"
+            className="absolute inset-0 bg-[var(--backdrop-scrim)]"
+            onClick={() => setRightPanel(null)}
+          />
+          <div className="relative flex h-full w-[min(92vw,420px)] flex-col bg-[var(--bg-raised)] shadow-[-8px_0_32px_rgba(0,0,0,0.2)] [padding-bottom:var(--sai-bottom)] [padding-top:var(--sai-top)]">
+            <RightPanel
+              panel={rightPanel}
+              activeFamiliar={activeFamiliar}
+              inboxItems={inboxItems}
+              onSetPanel={setRightPanel}
+              onOpenInbox={onOpenInbox}
+              onCreateReminder={onCreateReminder}
+              onOpenInboxItem={onOpenInboxItem}
+              onInboxItemChanged={onInboxItemChanged}
+            />
+          </div>
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
**Phase 1 (mobile parity)** — first confirmed-gap fix. Follows #658 (foundation).

## The gap (verified, not speculative)
While re-checking the audit's mobile claims against the actual code, most were already handled — all 12 surfaces are reachable via the shell **nav drawer**, the calendar **force-routes to Agenda** on mobile, and the board inspector is already a `max-width:100vw` full-screen sheet. The one real exception: the chat **right sidebar** (Inspector / Debug / Changes) is a 230px inline `Panel` marked `hidden lg:flex` with **no other entry point**, so on phones/narrow windows those panels were silently unreachable.

## Fix
- Render the panels in a **right-edge sheet** over a dismissible scrim when `useIsMobile()` is true (safe-area aware, closes on scrim tap or Escape).
- Gate the inline desktop `Panel` on `!isMobile` so exactly **one `RightPanel` mounts per breakpoint** — otherwise `InspectorPane` would double-fetch and duplicate DOM ids (`right-sidebar`, `right-panel-primary`).
- `useIsMobile` (≤1023px) aligns with the existing `lg` breakpoint, so desktop behavior is unchanged; narrow desktop windows now also get the sheet instead of a hidden, unreachable panel.

## Verification
- `pnpm typecheck` ✅ · `pnpm build` ✅ · `pnpm test:mobile` ✅
- Extended `chat-surface-mobile-command-center.test.ts` to lock in the sheet + the single-mount gate; `right-sidebar-fit` / `chat-surface` structural tests still green.
- On-device smoke via `mobile:tailscale:native` recommended before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)