### PR TITLE
fix(chat): scroll-to-bottom FAB renders correctly on mobile

### DIFF
--- a/src/components/chat-view-mobile-command-center.test.ts
+++ b/src/components/chat-view-mobile-command-center.test.ts
@@ -125,4 +125,13 @@ assert.match(
   "Mobile scroll-to-bottom FAB should sit above the taller composer",
 );
 
+// The FAB must NOT use `float` — float removes it from flow and breaks
+// `position: sticky` (it then renders at the wrong spot / not at all in the
+// iOS WKWebView). Right-align via `ml-auto` instead so sticky keeps working.
+const fabClass = source.match(/className="cave-scroll-bottom-button[^"]*"/)?.[0] ?? "";
+assert.ok(fabClass, "scroll-to-bottom FAB className should be present");
+assert.ok(!/\bfloat-right\b/.test(fabClass), "scroll-to-bottom FAB must not use float-right (breaks position: sticky)");
+assert.match(fabClass, /\bml-auto\b/, "scroll-to-bottom FAB should right-align with ml-auto so sticky still applies");
+assert.match(fabClass, /\bsticky\b/, "scroll-to-bottom FAB stays position: sticky");
+
 console.log("chat-view-mobile-command-center.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2856,7 +2856,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               el.scrollTo({ top: el.scrollHeight, behavior: reduceMotion ? "auto" : "smooth" });
             }}
             aria-label={`Scroll to bottom${newTurnsCount ? ` (${newTurnsCount} new message${newTurnsCount !== 1 ? "s" : ""})` : ""}`}
-            className="cave-scroll-bottom-button sticky bottom-4 float-right z-20 flex h-7 w-7 items-center justify-center rounded-md border border-[var(--accent-presence)]/40 bg-[var(--bg-raised)] text-[var(--accent-presence)] shadow-[0_2px_12px_var(--accent-presence)/20] transition-all hover:border-[var(--accent-presence)]/70 hover:bg-[color-mix(in_oklch,var(--accent-presence)_10%,var(--bg-raised))] hover:shadow-[0_2px_18px_var(--accent-presence)/35]"
+            className="cave-scroll-bottom-button sticky bottom-4 ml-auto z-[60] flex h-7 w-7 items-center justify-center rounded-md border border-[var(--accent-presence)]/40 bg-[var(--bg-raised)] text-[var(--accent-presence)] shadow-[0_2px_12px_var(--accent-presence)/20] transition-all hover:border-[var(--accent-presence)]/70 hover:bg-[color-mix(in_oklch,var(--accent-presence)_10%,var(--bg-raised))] hover:shadow-[0_2px_18px_var(--accent-presence)/35]"
             title={newTurnsCount ? `${newTurnsCount} new message${newTurnsCount !== 1 ? "s" : ""}` : undefined}
           >
             <Icon name="ph:caret-down-bold" width={12} />


### PR DESCRIPTION
## Why

On mobile chat (reported in the iOS simulator), the scroll-to-bottom FAB **appeared too high up and often failed to render**. The button already had mobile styling, so the gap was a positioning bug, not a missing feature.

Root cause: the FAB used `float: right` **together with** `position: sticky`. `float` takes the element out of normal flow, which breaks `position: sticky` — desktop Chromium limped along, but the iOS WKWebView rendered it at the wrong spot or not at all. The mobile `bottom: calc(244px + safe-area)` (chosen to clear the overlaying composer) never took effect because the sticky positioning was broken.

## Fix

`src/components/chat-view.tsx` — the FAB className:
- `float-right` → `ml-auto` (right-aligns without removing the element from flow, so `position: sticky` + `bottom` work)
- `z-20` → `z-[60]` (above the composer dock's `z-50`, so it can't be occluded when they overlap)

Confirmed in a layout harness with the real CSS: `float` left the button stuck near the top of the scrollport (erratic); `ml-auto` restores a proper sticky position, still right-aligned.

## Test

Extended `chat-view-mobile-command-center.test.ts` to assert the FAB stays `sticky` + `ml-auto` and never reintroduces `float-right`.

typecheck + the mobile test pass.

> Note: verified by code + layout harness; please confirm the exact landing in the iOS sim — if `bottom: 244px` still reads slightly high for your composer height, it's a one-line tweak in `cave-chat.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)