### PR TITLE
fix(mobile): tokenize bottom-tab focus offset + guard primary tab touch target

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4677,7 +4677,7 @@ button:active > .edge-rail-chip {
 }
 .mobile-bottom-tab:focus-visible {
   outline: var(--ring-width) solid var(--ring-focus);
-  outline-offset: -2px;
+  outline-offset: var(--ring-offset-inset);
   border-radius: var(--radius-control);
 }
 .mobile-bottom-tab__icon-wrap {

--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -166,6 +166,20 @@ assert.match(
   "Mobile bottom tabs should render an active indicator that can animate without shifting layout",
 );
 
+// The bottom tabs are the primary mobile destination switcher — each tap target
+// must meet the shared 44px hit-area, and its keyboard focus ring must use the
+// shared inset offset token (not an ad-hoc value) so it doesn't clip or drift.
+assert.match(
+  globals,
+  /\.mobile-bottom-tab\s*\{[\s\S]*?min-height:\s*var\(--touch-target\)/,
+  "Primary mobile bottom tabs should meet the shared touch target",
+);
+assert.match(
+  globals,
+  /\.mobile-bottom-tab:focus-visible\s*\{[\s\S]*?outline-offset:\s*var\(--ring-offset-inset\)/,
+  "Mobile bottom tab focus ring should use the shared inset offset token",
+);
+
 assert.match(
   workspace,
   /railTab === "browser" \|\| railTab === "salem" \|\| \(mode !== "browser" && mode !== "agents"\)/,


### PR DESCRIPTION
**Phase 1 (mobile parity)** — touch-target enforcement. Follows #658, #661.

## Finding: the audit's "touch targets unevenly applied" was a false positive
Reading the actual CSS, **every primary mobile tap control already declares `min-height: var(--touch-target)`** under its mobile media block — sidebar nav rows (`.sidebar-action-row`/`.sidebar-folder-row`), library rail items, board controls, chat scope tabs, bottom tabs, top-bar search, notification bell, automations rows — and ~11 existing tests guard them (`mobile-shell-smoke`, the `*-polish` and `*-mobile-command-center` suites). The audit had read desktop padding values and missed the mobile overrides. **No sweep was warranted**, so this PR doesn't churn one.

## The two genuine gaps it closes
- `.mobile-bottom-tab:focus-visible` used an ad-hoc `-2px` offset → now points at the `--ring-offset-inset` token from #658, so it stops drifting.
- The primary `.mobile-bottom-tab` 44px hit-area + its tokenized focus offset weren't *explicitly* asserted → added guards to `mobile-shell-smoke.test.ts` so they can't regress.

## Verification
`pnpm typecheck` ✅ · `pnpm build` ✅ · `mobile-shell-smoke.test.ts` + `globals.css.test.ts` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)