### PR TITLE
chore(release): v0.0.86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.86] - 2026-06-15
+
+Patch release: finishes repairing the auto-updater (the GitHub PAT no longer writes inside the signed bundle) and fixes the mobile scroll-to-bottom button.
+
+### Fixed
+- **Updater** — the in-app GitHub PAT form no longer writes `.env.local` inside the read-only, code-signed `.app` bundle (it resolves to a writable per-user path, read back via the vault resolver). This was the last of the runtime writes that broke the bundle's signature seal and the in-place auto-updater (#657).
+- **Chat** — the mobile scroll-to-bottom button now renders correctly. It used `float: right` with `position: sticky`, which broke sticky positioning in the iOS WKWebView so the button landed too high or not at all; it now right-aligns with `ml-auto` and sits above the composer (#662).
+
 ## [0.0.85] - 2026-06-15
 
 Patch release: a recoverable update flow, a mobile task-page fix, and the chat rail redesign on top of 0.0.84.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A familiar is not just a chat window. It has a name, role, runtime, memory, tool
 
 ## Status
 
-- Current app version: `0.0.85`
+- Current app version: `0.0.86`
 - Native shell: Tauri 2
 - Frontend: Next.js 16, React 19, Tailwind v4
 - Runtime dependency: a healthy local `coven` CLI/daemon plus at least one runtime source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.85",
+  "version": "0.0.86",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.85"
+version = "0.0.86"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.85"
+version = "0.0.86"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.85</string>
+	<string>0.0.86</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.85</string>
+	<string>0.0.86</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.85</string>
+	<string>0.0.86</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.85</string>
+	<string>0.0.86</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.85",
+  "version": "0.0.86",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Patch release on top of v0.0.85, shipping the last two fixes after that tag:

- **Updater** — the in-app GitHub PAT form no longer writes `.env.local` inside the read-only, code-signed `.app` bundle (writable per-user path, read back via the vault resolver). Last of the runtime writes that broke the bundle's signature seal and the in-place auto-updater (#657).
- **Chat** — the mobile scroll-to-bottom button renders correctly again: it used `float: right` + `position: sticky` (broken in the iOS WKWebView), now right-aligns with `ml-auto` above the composer (#662).

Bumped: `package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock` (app), both iOS plists, README, CHANGELOG. `app-version.test.ts` passes.

Tag `v0.0.86` to be pushed after merge → release.yml publishes the notarized DMG / AppImage / MSI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)