### PR TITLE
test: tighten mobile inspector chip assertion

### DIFF
--- a/src/components/capabilities-view-polish.test.ts
+++ b/src/components/capabilities-view-polish.test.ts
@@ -134,7 +134,7 @@ assert.match(
 // stays a compact pill instead of a rounded-full circle.
 assert.match(
   globals,
-  /\.capabilities-view \.capability-chips button \{[\s\S]*min-height:\s*0/,
+  /@media \(max-width: 767px\) \{[\s\S]*\.capabilities-view \.capability-chips button \{[\s\S]*min-height:\s*0/,
   "mobile chip-row buttons should reset the blanket min-height to stay compact pills",
 );
 


### PR DESCRIPTION
Follow-up to #659 after Copilot review: tighten the capabilities polish test so the compact chip button min-height reset is proven to live inside the mobile media query.\n\nVerification run locally:\n- node --experimental-strip-types src/components/capabilities-view-polish.test.ts\n- corepack pnpm typecheck\n- git diff --check