### PR TITLE
feat(chat-mobile): surface linked task in the open-chat header

### DIFF
--- a/src/components/chat-view-mobile-command-center.test.ts
+++ b/src/components/chat-view-mobile-command-center.test.ts
@@ -134,4 +134,43 @@ assert.ok(!/\bfloat-right\b/.test(fabClass), "scroll-to-bottom FAB must not use 
 assert.match(fabClass, /\bml-auto\b/, "scroll-to-bottom FAB should right-align with ml-auto so sticky still applies");
 assert.match(fabClass, /\bsticky\b/, "scroll-to-bottom FAB stays position: sticky");
 
+// The chat's linked task is surfaced directly in the mobile header (not just
+// buried in the kebab drawer), so its affiliation is visible at a glance.
+assert.match(
+  source,
+  /function MobileHeaderTask\(/,
+  "Mobile header should have a dedicated linked-task chip component",
+);
+
+assert.match(
+  source,
+  /\{linkedContext\?\.task \? \(\s*<MobileHeaderTask task=\{linkedContext\.task\} onOpenTask=\{onOpenTask\} \/>/,
+  "Mobile chat header should render the linked task chip when the chat is tied to a task",
+);
+
+assert.match(
+  source,
+  /aria-label=\{`Open linked task: \$\{task\.title\}`\}/,
+  "Linked-task header chip should be a labelled control that opens the task",
+);
+
+// The task lives in the header now, so it must not be duplicated in the kebab.
+assert.doesNotMatch(
+  source,
+  /cave-mobile-context-link[\s\S]{0,80}Task: \$\{task\.title\}/,
+  "Linked task should not be duplicated inside the mobile context drawer",
+);
+
+assert.match(
+  styles,
+  /@media \(max-width: 767px\) \{[\s\S]*\.cave-mobile-header-task\s*\{[\s\S]*width\s*:\s*100%[\s\S]*min-height\s*:\s*34px/,
+  "Mobile linked-task chip should be a full-width, comfortably tappable header row",
+);
+
+assert.match(
+  styles,
+  /\.cave-mobile-header-identity,\s*\.cave-mobile-header-task,/,
+  "Linked-task chip should be hidden on desktop alongside the other mobile-only header elements",
+);
+
 console.log("chat-view-mobile-command-center.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1076,6 +1076,43 @@ function LinkedContextRow({
   );
 }
 
+// Compact, always-visible linked-task chip for the mobile chat header. The
+// task tied to this chat used to live only inside the kebab context menu; on
+// mobile it now rides directly in the info header so the affiliation is
+// visible without opening a menu. Tapping opens the task on the board.
+function MobileHeaderTask({
+  task,
+  onOpenTask,
+}: {
+  task: NonNullable<ChatLinkedContext["task"]>;
+  onOpenTask?: (cardId: string) => void;
+}) {
+  const inner = (
+    <>
+      <Icon name="ph:kanban" width={12} className="cave-mobile-header-task__icon" aria-hidden />
+      <span className="cave-mobile-header-task__title">{task.title}</span>
+      <span className="cave-mobile-header-task__status">{task.status}</span>
+      {onOpenTask ? (
+        <Icon name="ph:arrow-square-out" width={11} className="cave-mobile-header-task__open" aria-hidden />
+      ) : null}
+    </>
+  );
+  return onOpenTask ? (
+    <button
+      type="button"
+      className="cave-mobile-header-task"
+      onClick={() => onOpenTask(task.id)}
+      aria-label={`Open linked task: ${task.title}`}
+    >
+      {inner}
+    </button>
+  ) : (
+    <div className="cave-mobile-header-task" role="note" aria-label={`Linked task: ${task.title}`}>
+      {inner}
+    </div>
+  );
+}
+
 function MobileChatContextMenu({
   familiar,
   session,
@@ -1095,7 +1132,6 @@ function MobileChatContextMenu({
   onOpenTask?: (cardId: string) => void;
   onOpenDebug?: () => void;
 }) {
-  const task = linkedContext?.task ?? null;
   const github = linkedContext?.github ?? [];
   const repo = repoName(session?.project_root ?? projectRoot);
   const runtime = [
@@ -1131,24 +1167,8 @@ function MobileChatContextMenu({
             <span className="min-w-0 flex-1 truncate">Debug session</span>
           </button>
         ) : null}
-        {task ? (
-          onOpenTask ? (
-            <button
-              type="button"
-              className="cave-mobile-context-link"
-              onClick={() => onOpenTask(task.id)}
-            >
-              <Icon name="ph:kanban" width={13} aria-hidden />
-              <span className="min-w-0 flex-1 truncate">Task: {task.title}</span>
-              <Icon name="ph:arrow-square-out" width={12} aria-hidden />
-            </button>
-          ) : (
-            <span className="cave-mobile-context-link">
-              <Icon name="ph:kanban" width={13} aria-hidden />
-              <span className="min-w-0 flex-1 truncate">Task: {task.title}</span>
-            </span>
-          )
-        ) : null}
+        {/* The linked task now rides in the mobile header (MobileHeaderTask),
+            so it's intentionally not duplicated here. */}
         {github.length ? (
           <div className="cave-mobile-context-links">
             {github.slice(0, 3).map((item) => (
@@ -2622,6 +2642,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             onOpenDebug={sessionId ? () => setDebugModalOpen(true) : undefined}
           />
         </div>
+        {linkedContext?.task ? (
+          <MobileHeaderTask task={linkedContext.task} onOpenTask={onOpenTask} />
+        ) : null}
         <MetaLine
           session={session ?? null}
           linkedContext={linkedContext}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1383,6 +1383,7 @@ details[open] > .cave-tool-summary::before {
 }
 
 .cave-mobile-header-identity,
+.cave-mobile-header-task,
 .cave-mobile-action-strip,
 .cave-mobile-context {
   display: none;
@@ -2130,6 +2131,51 @@ details[open] > .cave-tool-summary::before {
   .cave-mobile-daemon-pill--offline {
     background: color-mix(in oklch, var(--color-danger) 16%, transparent);
     color: var(--color-danger);
+  }
+
+  /* Linked-task chip — full-width row directly under the identity line, so the
+     chat's task affiliation is visible without opening the kebab menu. */
+  .cave-mobile-header-task {
+    display: flex;
+    width: 100%;
+    min-height: 34px;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 10px;
+    border-radius: 9px;
+    border: 1px solid color-mix(in oklch, var(--accent-presence) 30%, transparent);
+    background: color-mix(in oklch, var(--accent-presence) 11%, transparent);
+    color: var(--text-secondary);
+    font-size: 11px;
+    text-align: left;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .cave-mobile-header-task__icon {
+    flex: 0 0 auto;
+    color: var(--accent-presence);
+  }
+
+  .cave-mobile-header-task__title {
+    min-width: 0;
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .cave-mobile-header-task__status {
+    flex: 0 0 auto;
+    text-transform: capitalize;
+    color: var(--text-muted);
+    font-size: 10px;
+  }
+
+  .cave-mobile-header-task__open {
+    flex: 0 0 auto;
+    color: var(--text-muted);
   }
 
   .cave-mobile-context {


### PR DESCRIPTION
## What

On mobile, the task tied to a chat was only reachable by opening the kebab (⋮) context drawer. This surfaces it directly in the open-chat **info header** as a compact, full-width tappable chip — kanban icon + task title + status + open affordance — that opens the task on the board.

- New `MobileHeaderTask` chip renders in the chat header whenever the chat is linked to a board task (`linkedContext.task`), right under the familiar identity row.
- Removed the now-duplicate "Task: …" entry from the mobile kebab drawer (de-duplication — the kebab keeps GitHub links + debug).
- Mobile-only: the chip is `display:none` on desktop, which keeps its existing `LinkedContextRow` chip. No desktop change.
- Styled to match the app: accent-tinted, 34px row, title truncates with ellipsis, capitalized status.

## Why

Comprehensive mobile optimization of the open chat view: make the chat↔task affiliation visible at a glance without a menu, and stop duplicating it across the header and the drawer.

## Test

- Added source + CSS assertions to `chat-view-mobile-command-center.test.ts` (chip component exists, renders on linked task, is a labelled control, is not duplicated in the drawer, is full-width/hidden-on-desktop). Passes.
- `tsc --noEmit` clean.
- Visual: rendered the real header markup with the real `globals.css` + `cave-chat.css` at a 393px iPhone viewport — chip is full-width (393px), 34px tall, accent-tinted, title ellipsizes. Screenshot captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)