### PR TITLE
fix(board): touch-size the full-screen task inspector controls on mobile

### DIFF
--- a/src/components/board-ux-polish.test.ts
+++ b/src/components/board-ux-polish.test.ts
@@ -63,4 +63,17 @@ assert.match(
   "Mobile BoardCardStack section add button should meet the shared touch target",
 );
 
+// The task inspector goes full-screen on phones, so its controls are primary
+// touch targets — the desktop-dense 24-28px close/action sizes must scale up.
+assert.match(
+  styles,
+  /@media \(max-width: 767px\) \{[\s\S]*\.board-drawer-close,\s*\n\s*\.board-drawer-path-open\s*\{[\s\S]*width:\s*var\(--touch-target\)[\s\S]*height:\s*var\(--touch-target\)/,
+  "Mobile inspector close/open-path controls should meet the shared touch target",
+);
+assert.match(
+  styles,
+  /@media \(max-width: 767px\) \{[\s\S]*\.board-drawer-lifecycle-action,[\s\S]*\.board-drawer-chat-cta,[\s\S]*\.board-drawer-delete-btn,[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "Mobile inspector lifecycle/chat/delete actions should meet the shared touch target",
+);
+
 console.log("board-ux-polish.test.ts: ok");

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -114,6 +114,24 @@
   .board-new-card-btn {
     flex: 0 0 auto;
   }
+
+  /* The task inspector goes full-screen on phones (.board-drawer is
+     max-width:100vw), so its interactive controls are primary touch targets
+     and must meet --touch-target — the desktop-dense 24-28px sizes are too
+     small to hit reliably with a thumb. */
+  .board-drawer-close,
+  .board-drawer-path-open {
+    width: var(--touch-target);
+    height: var(--touch-target);
+  }
+
+  .board-drawer-lifecycle-action,
+  .board-drawer-chat-cta,
+  .board-drawer-delete-btn,
+  .board-drawer-field-select,
+  .board-drawer-field-input {
+    min-height: var(--touch-target);
+  }
 }
 
 .board-filter-chips { display:flex; flex-wrap:wrap; align-items:center; gap:5px; padding:6px 16px; border-bottom:1px solid var(--border-hairline); flex-shrink:0; }


### PR DESCRIPTION
**Phase 2 (hard-surface mobile redesigns)** — board. Follows #658, #661, #663, #668, #669.

## What & why
`BoardCardStack` (the mobile board) is already thoroughly touch-optimized — 44px chips/menus, tap-to-open, and a deliberate `⋯` status menu *instead of* drag. But the **task inspector** it opens (`.board-drawer`, which goes `max-width:100vw` / full-screen on phones) kept desktop-dense control sizes: a **28px** close button, **24px** lifecycle actions, **28px** chat CTA. When the drawer fills the screen those are primary touch targets.

Under the `767px` breakpoint, bump close/open-path to a 44px box and the lifecycle/chat/delete actions + form fields to a 44px `min-height`. CSS-only; desktop sizing unchanged.

## Verification
`pnpm build` ✅ · extended `board-ux-polish.test.ts` (reads `board.css`, asserts the new mobile touch sizing) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)