### PR TITLE
fix(board): one malformed card no longer zeroes the whole board

### DIFF
--- a/src/lib/cave-board-atomic.test.ts
+++ b/src/lib/cave-board-atomic.test.ts
@@ -60,7 +60,70 @@ await Promise.all([
 ]);
 assert.equal(tornReads, 0, "no torn reads (empty board) during concurrent writes");
 
+// 5. A single malformed card must NOT zero the whole board. Regression: a card
+//    whose `links` were stored as `{label,url}` objects (instead of string[])
+//    made backfillCard().normalizeList() throw `value.trim is not a function`;
+//    because loadBoard() mapped every card inside one try, that one poison card
+//    collapsed the entire board to empty — every task, including all
+//    familiar-scoped ones, silently vanished. loadBoard() must now salvage the
+//    object-form links (pull out `url`) and isolate per-card failures.
+const poisonId = "poison-links-card";
+const goodId = "good-sibling-card";
+await board.saveBoard({
+  version: 1,
+  cards: [
+    {
+      id: poisonId,
+      title: "card with object links",
+      // Deliberately the wrong shape (objects, not strings) — the real bug.
+      links: [
+        { label: "PR", url: "https://github.com/OpenCoven/coven-cave/pull/647" },
+        { label: "worktree", url: "/tmp/wt" },
+      ],
+      status: "queued",
+      priority: "medium",
+      familiarId: "nova",
+      createdAt: "2026-06-15T00:00:00.000Z",
+      updatedAt: "2026-06-15T00:00:00.000Z",
+    },
+    {
+      id: goodId,
+      title: "well-formed sibling",
+      links: ["https://example.com"],
+      status: "queued",
+      priority: "medium",
+      familiarId: "sage",
+      createdAt: "2026-06-15T00:00:00.000Z",
+      updatedAt: "2026-06-15T00:00:00.000Z",
+    },
+  ] as unknown as Parameters<typeof board.saveBoard>[0]["cards"],
+});
+
+const recovered = await board.loadBoard();
+assert.equal(
+  recovered.cards.length,
+  2,
+  "malformed card does not collapse the board — both cards survive",
+);
+const poison = recovered.cards.find((c) => c.id === poisonId);
+assert.ok(poison, "the poison card itself is salvaged, not dropped");
+assert.deepEqual(
+  poison!.links,
+  ["https://github.com/OpenCoven/coven-cave/pull/647", "/tmp/wt"],
+  "object-form links are coerced to their url strings",
+);
+assert.equal(
+  poison!.github.length,
+  1,
+  "github links are still derived from the salvaged urls",
+);
+assert.ok(
+  recovered.cards.some((c) => c.id === goodId),
+  "the well-formed sibling still loads",
+);
+
 // cleanup
 await rm(tmpHome, { recursive: true, force: true });
 
 console.log("ok - cave-board atomic write + write lock: no lost updates, no torn reads");
+console.log("ok - cave-board: malformed card links salvaged, board not zeroed");

--- a/src/lib/cave-board-atomic.test.ts
+++ b/src/lib/cave-board-atomic.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -26,7 +26,19 @@ assert.ok(
   `refusing to run: BOARD_PATH (${board.BOARD_PATH}) is not under the temp home`,
 );
 
-// 1. Concurrent creates — no lost updates (the write lock). Without
+// 1. Valid JSON with the wrong top-level shape is corrupted data too. It should
+//    behave like a missing/invalid file, not throw outside loadBoard().
+await mkdir(path.dirname(board.BOARD_PATH), { recursive: true });
+for (const value of ["null", "[]", "0"]) {
+  await writeFile(board.BOARD_PATH, value, "utf8");
+  assert.deepEqual(
+    await board.loadBoard(),
+    { version: 1, cards: [] },
+    `valid non-object board JSON (${value}) loads as an empty board`,
+  );
+}
+
+// 2. Concurrent creates — no lost updates (the write lock). Without
 //    serialization every create reads the same snapshot and the last save wins,
 //    leaving a single card.
 const N = 25;
@@ -35,18 +47,18 @@ const afterCreate = await board.loadBoard();
 assert.equal(afterCreate.cards.length, N, "all concurrent creates persisted (no lost updates)");
 assert.equal(new Set(afterCreate.cards.map((c) => c.id)).size, N, "every card id is distinct");
 
-// 2. The on-disk file is always complete, valid JSON — never torn.
+// 3. The on-disk file is always complete, valid JSON — never torn.
 const raw = await readFile(board.BOARD_PATH, "utf8");
 assert.equal(JSON.parse(raw).cards.length, N, "persisted file parses with all cards");
 
-// 3. No leftover temp files after atomic writes.
+// 4. No leftover temp files after atomic writes.
 const dir = path.dirname(board.BOARD_PATH);
 assert.ok(
   !(await readdir(dir)).some((name) => name.endsWith(".tmp")),
   "no leftover .tmp files after atomic writes",
 );
 
-// 4. Reads interleaved with a burst of writes never observe an empty board
+// 5. Reads interleaved with a burst of writes never observe an empty board
 //    (the torn-read 404). With atomic rename a reader always sees a complete
 //    old-or-new file.
 const targetId = afterCreate.cards[0].id;
@@ -60,7 +72,7 @@ await Promise.all([
 ]);
 assert.equal(tornReads, 0, "no torn reads (empty board) during concurrent writes");
 
-// 5. A single malformed card must NOT zero the whole board. Regression: a card
+// 6. A single malformed card must NOT zero the whole board. Regression: a card
 //    whose `links` were stored as `{label,url}` objects (instead of string[])
 //    made backfillCard().normalizeList() throw `value.trim is not a function`;
 //    because loadBoard() mapped every card inside one try, that one poison card

--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -55,7 +55,26 @@ function statusForLifecycle(lifecycle: CardLifecycle, currentStatus: CardStatus)
 }
 
 function normalizeList(values: string[] | undefined): string[] {
-  return [...new Set((values ?? []).map((value) => value.trim()).filter(Boolean))];
+  return [...new Set(toStringList(values).map((value) => value.trim()).filter(Boolean))];
+}
+
+// Defensive coercion for `links`. The Card type declares `links: string[]`, but
+// older/hand-edited boards (and agent writes) have stored entries as
+// `{ label, url }` objects — the same shape as the GitHub link list. A raw
+// `.trim()` on such an object throws, and because loadBoard() maps every card
+// inside one try, a single malformed entry zeroed the ENTIRE board. Pull the
+// `url` out of object entries so legacy data is salvaged instead of fatal.
+function toStringList(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+  return values
+    .map((value) => {
+      if (typeof value === "string") return value;
+      if (value && typeof value === "object" && typeof (value as { url?: unknown }).url === "string") {
+        return (value as { url: string }).url;
+      }
+      return "";
+    })
+    .filter((value): value is string => value.length > 0);
 }
 
 function normalizeLinks(values: string[] | undefined): string[] {
@@ -67,7 +86,7 @@ function normalizeGitHubLinks(values: CardGitHubLink[] | undefined): CardGitHubL
 }
 
 function gitHubLinksFromLinks(values: string[] | undefined): CardGitHubLink[] {
-  return (values ?? [])
+  return toStringList(values)
     .map((url) => taskGitHubLinkFromUrl(url))
     .filter((item): item is CardGitHubLink => item !== null);
 }
@@ -126,18 +145,33 @@ async function ensureDir() {
 }
 
 export async function loadBoard(): Promise<BoardFile> {
+  let parsed: Partial<BoardFile>;
   try {
     const raw = await readFile(BOARD_PATH, "utf8");
-    const parsed = JSON.parse(raw) as Partial<BoardFile>;
-    const rawCards = Array.isArray(parsed.cards) ? parsed.cards : [];
-    const projects = await loadProjects();
-    return {
-      version: parsed.version ?? 1,
-      cards: rawCards.map((c) => migrateProjectId(backfillCard(c as Card), projects)),
-    };
+    parsed = JSON.parse(raw) as Partial<BoardFile>;
   } catch {
+    // Missing file or torn/invalid JSON — nothing recoverable.
     return EMPTY;
   }
+
+  const rawCards = Array.isArray(parsed.cards) ? parsed.cards : [];
+  const projects = await loadProjects();
+  // Normalize each card in isolation. A single malformed card (e.g. `links`
+  // stored as objects instead of strings) must never throw out of the whole
+  // map and collapse the board to empty — that made every task, including all
+  // familiar-scoped ones, silently vanish. Drop only the unrecoverable card.
+  const cards: Card[] = [];
+  for (const raw of rawCards) {
+    try {
+      cards.push(migrateProjectId(backfillCard(raw as Card), projects));
+    } catch (err) {
+      console.error(
+        `cave-board: skipping unreadable card ${(raw as { id?: unknown })?.id ?? "<unknown>"}:`,
+        err,
+      );
+    }
+  }
+  return { version: parsed.version ?? 1, cards };
 }
 
 // Serialize board mutations. Each mutator does load → modify → save; without

--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -60,9 +60,7 @@ function normalizeList(values: string[] | undefined): string[] {
 
 // Defensive coercion for `links`. The Card type declares `links: string[]`, but
 // older/hand-edited boards (and agent writes) have stored entries as
-// `{ label, url }` objects — the same shape as the GitHub link list. A raw
-// `.trim()` on such an object throws, and because loadBoard() maps every card
-// inside one try, a single malformed entry zeroed the ENTIRE board. Pull the
+// `{ label, url }` objects — the same shape as the GitHub link list. Pull the
 // `url` out of object entries so legacy data is salvaged instead of fatal.
 function toStringList(values: unknown): string[] {
   if (!Array.isArray(values)) return [];
@@ -145,16 +143,20 @@ async function ensureDir() {
 }
 
 export async function loadBoard(): Promise<BoardFile> {
-  let parsed: Partial<BoardFile>;
+  let parsed: unknown;
   try {
     const raw = await readFile(BOARD_PATH, "utf8");
-    parsed = JSON.parse(raw) as Partial<BoardFile>;
+    parsed = JSON.parse(raw);
   } catch {
     // Missing file or torn/invalid JSON — nothing recoverable.
     return EMPTY;
   }
 
-  const rawCards = Array.isArray(parsed.cards) ? parsed.cards : [];
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return EMPTY;
+  }
+  const board = parsed as Partial<BoardFile>;
+  const rawCards = Array.isArray(board.cards) ? board.cards : [];
   const projects = await loadProjects();
   // Normalize each card in isolation. A single malformed card (e.g. `links`
   // stored as objects instead of strings) must never throw out of the whole
@@ -171,7 +173,7 @@ export async function loadBoard(): Promise<BoardFile> {
       );
     }
   }
-  return { version: parsed.version ?? 1, cards };
+  return { version: board.version ?? 1, cards };
 }
 
 // Serialize board mutations. Each mutator does load → modify → save; without


### PR DESCRIPTION
## What

The Board API was returning **0 cards** even though `~/.coven/cave-board.json` held 127 — so every task tied to a familiar disappeared from the Board surface.

## Root cause

`loadBoard()` mapped every card through `backfillCard()` inside a **single `try`**. A card (created during #647 work, "Build Cast Codes-style terminal pane architecture") had its `links` stored as `{label,url}` objects instead of the declared `string[]`. `normalizeList()` calls `.trim()` on each entry, and `.trim()` on an object throws `TypeError: value.trim is not a function`. That throw aborted the whole `.map`, the `catch` returned an EMPTY board, and **all** tasks vanished — including every familiar-scoped one.

## Fix

- **Salvage, don't crash:** `toStringList()` coerces object-form link entries (`{url}`) to their url string in both `normalizeLinks()` and `gitHubLinksFromLinks()`, so legacy/hand-edited data loads cleanly and still derives GitHub links.
- **Isolate per-card failures:** `loadBoard()` now normalizes each card in its own `try` — an unrecoverable card is skipped (and logged) instead of collapsing the whole board to empty.

## Test

Added a regression case to `cave-board-atomic.test.ts`: a board with one object-links card now loads both cards, salvages the poison card's urls, and still derives its GitHub link. Verified it fails (0 cards) against the old loader.

`tsc --noEmit` clean; board test suite green.

> Note: the affected user's live `cave-board.json` was also repaired in place (object links → url strings), so the Board is already back to 127 cards. This PR prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)