### PR TITLE
fix(chat): lower mobile scroll-to-bottom FAB to hug the composer

### DIFF
--- a/src/components/chat-view-mobile-command-center.test.ts
+++ b/src/components/chat-view-mobile-command-center.test.ts
@@ -121,8 +121,8 @@ assert.match(
 
 assert.match(
   styles,
-  /@media \(max-width: 767px\) \{[\s\S]*\.cave-scroll-bottom-button\s*\{[\s\S]*bottom\s*:\s*calc\(244px \+ var\(--sai-bottom\)\)/,
-  "Mobile scroll-to-bottom FAB should sit above the taller composer",
+  /@media \(max-width: 767px\) \{[\s\S]*\.cave-scroll-bottom-button\s*\{[\s\S]*bottom\s*:\s*calc\(208px \+ var\(--sai-bottom\)\)/,
+  "Mobile scroll-to-bottom FAB should hug just above the composer dock",
 );
 
 // The FAB must NOT use `float` — float removes it from flow and breaks

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2337,7 +2337,10 @@ details[open] > .cave-tool-summary::before {
   }
 
   .cave-scroll-bottom-button {
-    bottom: calc(244px + var(--sai-bottom));
+    /* Sit just above the composer dock. The mobile composer (action strip +
+       ~116px input + ~54px controls + padding) is ~210px tall; hug ~just above
+       it rather than floating high in the transcript. */
+    bottom: calc(208px + var(--sai-bottom));
     width: var(--touch-target);
     height: var(--touch-target);
     border-radius: 999px;


### PR DESCRIPTION
Follow-up to #662. The mobile scroll-to-bottom FAB's `bottom` was `244px`, which floated it noticeably high above the composer dock. The mobile composer (action strip + ~116px input + ~54px controls + padding) is ~210px tall, so lower the offset to `208px` so the button hugs just above the dock.

- `cave-chat.css`: `.cave-scroll-bottom-button` mobile `bottom: calc(244px → 208px + var(--sai-bottom))`
- Updated the `chat-view-mobile-command-center.test.ts` assertion to match.

Eyeball-tunable: if it still reads slightly high/low in the sim, it's a one-line nudge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)