### PR TITLE
feat(nav): differentiate sidebar surfaces with hover/long-press descriptions

### DIFF
--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -25,7 +25,7 @@ assert.match(
 
 assert.match(
   sidebar,
-  /\{ id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools" \}/,
+  /\{ id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools", description:/,
   "Sidebar navigation should expose Roles as a tools surface",
 );
 

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -67,13 +67,13 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /\{ id: "chat", label: "Chat", iconName: "ph:chats", group: "work", kbd: "⌘2" \}/,
+  /\{ id: "chat", label: "Chat", iconName: "ph:chats", group: "work", kbd: "⌘2", description:/,
   "Chat should move to the ⌘2 Work shortcut after removing Familiars",
 );
 
 assert.match(
   source,
-  /\{ id: "board", label: "Board", iconName: "ph:kanban", group: "work", kbd: "⌘3" \}/,
+  /\{ id: "board", label: "Board", iconName: "ph:kanban", group: "work", kbd: "⌘3", description:/,
   "Board should move to the ⌘3 Work shortcut after removing Familiars",
 );
 
@@ -85,31 +85,31 @@ assert.match(
 
 assert.match(
   source,
-  /\{ id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘7" \}/,
+  /\{ id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘7", description:/,
   "Browser remains a Tools surface and moves to ⌘7",
 );
 
 assert.match(
   source,
-  /\{ id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools", kbd: "⌘8" \}/,
+  /\{ id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools", kbd: "⌘8", description:/,
   "Terminal remains a Tools surface and takes ⌘8",
 );
 
 assert.match(
   source,
-  /\{ id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools" \}/,
+  /\{ id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools", description:/,
   "Roles should appear as a Tools surface",
 );
 
 assert.match(
   source,
-  /\{ id: "workflows", label: "Workflows", iconName: "ph:git-branch-bold", group: "tools" \}/,
+  /\{ id: "workflows", label: "Workflows", iconName: "ph:git-branch-bold", group: "tools", description:/,
   "Workflows should appear as a Tools surface",
 );
 
 assert.match(
   source,
-  /\{ id: "capabilities", label: "Capabilities", iconName: "ph:lightning-bold", group: "tools" \}/,
+  /\{ id: "capabilities", label: "Capabilities", iconName: "ph:lightning-bold", group: "tools", description:/,
   "Capabilities should appear as a Tools surface",
 );
 
@@ -208,6 +208,35 @@ assert.match(
   styles,
   /@media \(max-width: 1023px\) \{[\s\S]*\.sidebar-header,[\s\S]*\.sidebar-action-row,[\s\S]*\.sidebar-folder-row,[\s\S]*\.sidebar-foot-btn,[\s\S]*\.sidebar-familiar-filter__select[\s\S]*min-height:\s*var\(--touch-target\)/,
   "Mobile sidebar drawer rows and familiar select should meet the shared touch target",
+);
+
+// Every surface carries a one-line description, and FolderRow surfaces it as a
+// title (hover tooltip / touch long-press hint / AT description) — so the
+// look-alike surfaces (Roles vs Workflows vs Capabilities) are differentiated.
+assert.match(
+  source,
+  /id: "roles"[\s\S]*?description: "Reusable agent personas/,
+  "Roles is described as personas, distinct from Workflows/Capabilities",
+);
+assert.match(
+  source,
+  /id: "workflows"[\s\S]*?description: "Multi-step pipelines/,
+  "Workflows is described as pipelines, distinct from Roles/Capabilities",
+);
+assert.match(
+  source,
+  /id: "capabilities"[\s\S]*?description: "Skills and tools/,
+  "Capabilities is described as skills/tools, distinct from Roles/Workflows",
+);
+assert.match(
+  source,
+  /title=\{title\}/,
+  "FolderRow renders the description as a native title (hover/long-press/AT)",
+);
+assert.match(
+  source,
+  /`\$\{label\} — \$\{description\}( \(\$\{kbd\}\))?`/,
+  "title combines label + description (+ shortcut when present)",
 );
 
 console.log("sidebar-minimal.test.ts (shell-ia-lastmile) OK");

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -70,23 +70,27 @@ const FOLDER_MODES: Array<{
   badge?: (props: SidebarMinimalProps) => string | undefined;
   group: "work" | "knowledge" | "tools" | "addons";
   kbd?: string;
+  // One-line hover/long-press help. Differentiates the surfaces that read
+  // alike at a glance — especially Roles (who) vs Workflows (steps) vs
+  // Capabilities (what tools).
+  description: string;
 }> = [
   // Work
-  { id: "home", label: "Home", iconName: "ph:house-bold", group: "work", kbd: "⌘1" },
-  { id: "chat", label: "Chat", iconName: "ph:chats", group: "work", kbd: "⌘2" },
-  { id: "board", label: "Board", iconName: "ph:kanban", group: "work", kbd: "⌘3" },
-  { id: "calendar", label: "Calendar", iconName: "ph:calendar-blank", group: "work", kbd: "⌘4" },
-  { id: "inbox", label: "Automations", iconName: "ph:tray", group: "work", kbd: "⌘5" },
+  { id: "home", label: "Home", iconName: "ph:house-bold", group: "work", kbd: "⌘1", description: "Overview and quick actions" },
+  { id: "chat", label: "Chat", iconName: "ph:chats", group: "work", kbd: "⌘2", description: "Talk with your familiars" },
+  { id: "board", label: "Board", iconName: "ph:kanban", group: "work", kbd: "⌘3", description: "Track tasks across projects" },
+  { id: "calendar", label: "Calendar", iconName: "ph:calendar-blank", group: "work", kbd: "⌘4", description: "Schedule and timeline of work" },
+  { id: "inbox", label: "Automations", iconName: "ph:tray", group: "work", kbd: "⌘5", description: "Scheduled runs and items needing attention" },
   // Knowledge
-  { id: "library", label: "Library", iconName: "ph:books", group: "knowledge", kbd: "⌘6" },
+  { id: "library", label: "Library", iconName: "ph:books", group: "knowledge", kbd: "⌘6", description: "Saved docs, links, and reading" },
   // Tools
-  { id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘7" },
-  { id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools", kbd: "⌘8" },
-  { id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools" },
-  { id: "workflows", label: "Workflows", iconName: "ph:git-branch-bold", group: "tools" },
-  { id: "capabilities", label: "Capabilities", iconName: "ph:lightning-bold", group: "tools" },
+  { id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘7", description: "Built-in web browser" },
+  { id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools", kbd: "⌘8", description: "Shell session in your project" },
+  { id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools", description: "Reusable agent personas you can attach to a familiar" },
+  { id: "workflows", label: "Workflows", iconName: "ph:git-branch-bold", group: "tools", description: "Multi-step pipelines that orchestrate familiars" },
+  { id: "capabilities", label: "Capabilities", iconName: "ph:lightning-bold", group: "tools", description: "Skills and tools your familiars can use" },
   // Add-ons (gated)
-  { id: "github", label: "GitHub", iconName: "ph:github-logo", group: "addons" },
+  { id: "github", label: "GitHub", iconName: "ph:github-logo", group: "addons", description: "Issues and PRs assigned to you" },
 ];
 
 export { FOLDER_MODES };
@@ -172,6 +176,7 @@ function FolderRow({
   active,
   badge,
   kbd,
+  description,
   onClick,
 }: {
   id: string;
@@ -180,13 +185,22 @@ function FolderRow({
   active: boolean;
   badge?: string;
   kbd?: string;
+  description?: string;
   onClick: () => void;
 }) {
+  // Native title doubles as a desktop hover tooltip and a touch long-press
+  // hint, and is exposed to AT as the button's accessible description.
+  const title = description
+    ? kbd
+      ? `${label} — ${description} (${kbd})`
+      : `${label} — ${description}`
+    : undefined;
   return (
     <button
       type="button"
       className={`sidebar-folder-row${active ? " sidebar-folder-row--active" : ""}`}
       aria-current={active ? "page" : undefined}
+      title={title}
       onClick={onClick}
     >
       <Icon name={iconName} width={15} className="sidebar-folder-icon" />
@@ -271,6 +285,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
               active={mode === fm.id}
               badge={fm.badge?.(props)}
               kbd={fm.kbd}
+              description={fm.description}
               onClick={() => handleModeSelect(fm.id)}
             />
           ))}
@@ -286,6 +301,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
               active={mode === fm.id}
               badge={fm.badge?.(props)}
               kbd={fm.kbd}
+              description={fm.description}
               onClick={() => handleModeSelect(fm.id)}
             />
           ))}
@@ -301,6 +317,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
               active={mode === fm.id}
               badge={fm.badge?.(props)}
               kbd={fm.kbd}
+              description={fm.description}
               onClick={() => handleModeSelect(fm.id)}
             />
           ))}

--- a/src/components/workspace-familiars-landing.test.ts
+++ b/src/components/workspace-familiars-landing.test.ts
@@ -104,19 +104,19 @@ assert.doesNotMatch(
 
 assert.match(
   sidebar,
-  /\{ id: "home", label: "Home", iconName: "ph:house-bold", group: "work", kbd: "⌘1" \}/,
+  /\{ id: "home", label: "Home", iconName: "ph:house-bold", group: "work", kbd: "⌘1", description:/,
   "Sidebar Home keeps its shortcut hint",
 );
 
 assert.match(
   sidebar,
-  /\{ id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘7" \}/,
+  /\{ id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘7", description:/,
   "Sidebar Browser shifts to ⌘7 after removing Familiars from Work",
 );
 
 assert.match(
   sidebar,
-  /\{ id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools", kbd: "⌘8" \}/,
+  /\{ id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools", kbd: "⌘8", description:/,
   "Sidebar Terminal takes the final ⌘8 shortcut",
 );
 


### PR DESCRIPTION
**Phase 3 (IA differentiation).** Follows the Phase 0–2 PRs (#658, #661, #663, #668, #669, #670, #671).

## What & why
The 12 sidebar surfaces had **no help text**, so look-alike entries — **Roles vs Workflows vs Capabilities** especially — were easy to confuse. Each `FOLDER_MODES` entry now carries a one-line `description`, surfaced via `FolderRow`'s native **`title`** (desktop hover tooltip, touch long-press hint, and the button's accessible description for assistive tech). Copy is written to disambiguate:
- **Roles** = "Reusable agent personas you can attach to a familiar"
- **Workflows** = "Multi-step pipelines that orchestrate familiars"
- **Capabilities** = "Skills and tools your familiars can use"

## Scope note
Verifying the rest of Phase 3 against the code, most was **already shipped**: `ui/empty-state`, `ui/skeleton`, `ui/error-state` exist with `surface-loading-states`/`surface-error-states` guards, and onboarding re-entry is wired (`openOnboarding`). So this PR targets the one genuine remaining gap.

## Verification
`pnpm typecheck` ✅ · `pnpm build` ✅ · `sidebar-minimal` / `roles-tools-navigation` / `workspace-familiars-landing` tests ✅ (relaxed their pinned-entry regexes to allow the new field + added description-differentiation assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)