### PR TITLE
fix(board): inspector close/path buttons actually hit 44px on mobile

### DIFF
--- a/src/components/board-ux-polish.test.ts
+++ b/src/components/board-ux-polish.test.ts
@@ -72,8 +72,8 @@ assert.match(
 // touch targets — the desktop-dense 24-28px close/action sizes must scale up.
 assert.match(
   styles,
-  /@media \(max-width: 767px\) \{[\s\S]*\.board-drawer-close,\s*\n\s*\.board-drawer-path-open\s*\{[\s\S]*width:\s*var\(--touch-target\)[\s\S]*height:\s*var\(--touch-target\)/,
-  "Mobile inspector close/open-path controls should meet the shared touch target",
+  /@media \(max-width: 767px\) \{[\s\S]*\.board-drawer-close,\s*\n\s*\.board-drawer-path-open\s*\{[\s\S]*min-width:\s*var\(--touch-target\)[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "Mobile inspector close/open-path controls should meet the shared touch target via min-* (so the 44px hit area wins the cascade over the earlier-in-file base width/height)",
 );
 assert.match(
   styles,

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -118,11 +118,16 @@
   /* The task inspector goes full-screen on phones (.board-drawer is
      max-width:100vw), so its interactive controls are primary touch targets
      and must meet --touch-target — the desktop-dense 24-28px sizes are too
-     small to hit reliably with a thumb. */
+     small to hit reliably with a thumb.
+     Use min-* (not width/height): this mobile block sits earlier in the file
+     than the base .board-drawer-close/.board-drawer-path-open rules, so an
+     equal-specificity width/height would LOSE the cascade to them (verified:
+     the close button measured 28px). min-* clamps the base size up regardless
+     of source order. */
   .board-drawer-close,
   .board-drawer-path-open {
-    width: var(--touch-target);
-    height: var(--touch-target);
+    min-width: var(--touch-target);
+    min-height: var(--touch-target);
   }
 
   .board-drawer-lifecycle-action,


### PR DESCRIPTION
Follow-up to #670, **caught by live mobile-viewport verification** (the whole reason to verify visually, not just by source-text test).

## The bug
On a 390px viewport, the board task-inspector **close button still measured 28×28**, not 44px. #670's mobile touch-target block sits *earlier* in `board.css` than the base `.board-drawer-close` / `.board-drawer-path-open` rules (line ~124 vs ~308/391), so the equal-specificity `width`/`height` override **lost the cascade** to the later base `width:28px; height:28px`. The sibling lifecycle/chat/delete controls were unaffected — they use `min-height`, which clamps up regardless of source order.

## The fix
Switch close/path-open to `min-width`/`min-height` too.

## Verification (live, not just unit)
Built and re-measured at iPhone-13 viewport via Playwright: close button now reports **44×44** (was 28×28). `board-ux-polish.test.ts` updated to assert `min-*` + documents the cascade reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)