### PR TITLE
feat(top-bar): familiar switcher box with picker

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3834,6 +3834,113 @@ button:active > .edge-rail-chip {
   gap: 4px;
 }
 
+/* Active-familiar switcher box — shows the current familiar and opens a picker. */
+.top-bar__familiar {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 26px;
+  max-width: 180px;
+  padding: 0 7px 0 5px;
+  border-radius: 999px;
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-raised);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--ease-standard),
+              background var(--duration-fast) var(--ease-standard);
+}
+
+.top-bar__familiar:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.top-bar__familiar:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 2px;
+}
+
+.top-bar__familiar-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+/* Narrow viewports: keep just the avatar + caret to save room. */
+@media (max-width: 767px) {
+  .top-bar__familiar-name {
+    display: none;
+  }
+}
+
+.top-bar__familiar-popover {
+  padding: 4px;
+  border-radius: 10px;
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-base);
+  box-shadow: var(--shadow-popover, 0 8px 28px rgb(0 0 0 / 0.28));
+}
+
+.top-bar__familiar-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  max-height: min(60vh, 420px);
+  overflow-y: auto;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.top-bar__familiar-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  text-align: left;
+}
+
+.top-bar__familiar-option:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.top-bar__familiar-option.is-active {
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+  color: var(--text-primary);
+}
+
+.top-bar__familiar-option:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: -2px;
+}
+
+.top-bar__familiar-option-name {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.top-bar__familiar-option-meta {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
 .top-bar__account {
   display: grid;
   place-items: center;

--- a/src/components/top-bar.test.ts
+++ b/src/components/top-bar.test.ts
@@ -64,4 +64,32 @@ assert.match(
   "Mobile handoff (open on phone) button is preserved",
 );
 
+// Active-familiar switcher box: a button showing the current familiar that opens
+// a Popover picker (desktop + mobile). Gated on onSelectFamiliar + activeFamiliar.
+assert.match(
+  source,
+  /className="top-bar__familiar"[\s\S]*aria-haspopup="listbox"/,
+  "Top bar renders a familiar switcher box that opens a listbox picker",
+);
+assert.match(
+  source,
+  /<FamiliarAvatar familiar=\{activeFamiliar\}/,
+  "Switcher box shows the active familiar's avatar",
+);
+assert.match(
+  source,
+  /<Popover[\s\S]*anchorRef=\{familiarBoxRef\}/,
+  "Picker uses the shared Popover anchored to the switcher box",
+);
+assert.match(
+  source,
+  /role="option"[\s\S]*onSelectFamiliar\?\.\(option\.id\)/,
+  "Picking a familiar option calls onSelectFamiliar with its id",
+);
+assert.match(
+  source,
+  /const showFamiliarSwitcher = Boolean\(onSelectFamiliar && activeFamiliar\)/,
+  "Switcher only renders when wired with a selection handler + active familiar",
+);
+
 console.log("top-bar.test.ts: ok");

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -1,8 +1,12 @@
 "use client";
 
+import { useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { NotificationBell } from "@/components/notification-bell";
+import { Popover } from "@/components/ui/popover";
+import { FamiliarAvatar } from "@/components/familiar-avatar";
 import type { Familiar } from "@/lib/types";
+import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 
@@ -17,6 +21,12 @@ type Props = {
   inboxBadgeCount: number;
   onOpenInboxItem?: (item: InboxItem) => void;
   onNotificationPrefsChanged: () => void;
+  /** Active-familiar switcher box. When `onSelectFamiliar` + `activeFamiliar`
+   *  are provided, the top bar renders a box showing the current familiar that
+   *  opens a picker (desktop + mobile). Resolved familiars carry avatar glyphs. */
+  activeFamiliar?: ResolvedFamiliar | null;
+  familiarOptions?: ResolvedFamiliar[];
+  onSelectFamiliar?: (id: string) => void;
   /** Mobile-only drawer toggles. Visibility is gated by CSS at <768px
    *  (.top-bar__mobile-toggle is `display: none` on desktop). Omit any
    *  that aren't applicable to the current surface — e.g. two-pane modes
@@ -47,7 +57,14 @@ export function TopBar(props: Props) {
     navDrawerOpen,
     listDrawerOpen,
     familiarDrawerOpen,
+    activeFamiliar,
+    familiarOptions,
+    onSelectFamiliar,
   } = props;
+
+  const [familiarPickerOpen, setFamiliarPickerOpen] = useState(false);
+  const familiarBoxRef = useRef<HTMLButtonElement | null>(null);
+  const showFamiliarSwitcher = Boolean(onSelectFamiliar && activeFamiliar);
 
   return (
     <header className="top-bar">
@@ -95,6 +112,59 @@ export function TopBar(props: Props) {
       </button>
 
       <div className="top-bar__actions">
+        {showFamiliarSwitcher && activeFamiliar ? (
+          <>
+            <button
+              ref={familiarBoxRef}
+              type="button"
+              className="top-bar__familiar"
+              onClick={() => setFamiliarPickerOpen((open) => !open)}
+              aria-haspopup="listbox"
+              aria-expanded={familiarPickerOpen}
+              aria-label={`Switch familiar — current: ${activeFamiliar.display_name}`}
+              title="Switch familiar"
+            >
+              <FamiliarAvatar familiar={activeFamiliar} size="sm" />
+              <span className="top-bar__familiar-name">{activeFamiliar.display_name}</span>
+              <Icon name="ph:caret-down" width={10} />
+            </button>
+            <Popover
+              open={familiarPickerOpen}
+              onOpenChange={setFamiliarPickerOpen}
+              anchorRef={familiarBoxRef}
+              placement="bottom-end"
+              minWidth={208}
+              className="top-bar__familiar-popover"
+            >
+              <ul className="top-bar__familiar-list" role="listbox" aria-label="Switch familiar">
+                {(familiarOptions ?? []).map((option) => {
+                  const isActive = option.id === activeFamiliar.id;
+                  return (
+                    <li key={option.id}>
+                      <button
+                        type="button"
+                        role="option"
+                        aria-selected={isActive}
+                        className={`top-bar__familiar-option${isActive ? " is-active" : ""}`}
+                        onClick={() => {
+                          onSelectFamiliar?.(option.id);
+                          setFamiliarPickerOpen(false);
+                        }}
+                      >
+                        <FamiliarAvatar familiar={option} size="sm" />
+                        <span className="top-bar__familiar-option-name">{option.display_name}</span>
+                        {option.harness ? (
+                          <span className="top-bar__familiar-option-meta">{option.harness}</span>
+                        ) : null}
+                        {isActive ? <Icon name="ph:check" width={12} /> : null}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </Popover>
+          </>
+        ) : null}
         <button
           type="button"
           className="top-bar__icon-btn top-bar__mobile-handoff"

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1420,6 +1420,9 @@ export function Workspace() {
             onOpenMobileHandoff={() => setMobileHandoffOpen(true)}
             inboxItems={inboxItemsWithEphemeral}
             familiars={familiars}
+            activeFamiliar={resolvedFamiliars.find((f) => f.id === activeId) ?? null}
+            familiarOptions={resolvedFamiliars}
+            onSelectFamiliar={setActiveId}
             inboxPrefs={inboxPrefs}
             inboxBadgeCount={inboxBadgeCount}
             onOpenInboxItem={(item) => {


### PR DESCRIPTION
## What

Adds a **familiar switcher box** to the top bar (desktop + mobile): a box showing the active familiar (avatar + name) that opens a Popover picker to switch familiars.

- **`top-bar.tsx`** — new props `activeFamiliar` / `familiarOptions` / `onSelectFamiliar`; renders the box + a `role=listbox` Popover of `role=option` familiar entries. Selecting one calls `onSelectFamiliar(id)` and closes. Only renders when wired (handler + active familiar present).
- **`workspace.tsx`** — wires the existing global active-familiar state: `activeFamiliar={resolvedFamiliars.find(id)}`, `familiarOptions={resolvedFamiliars}`, `onSelectFamiliar={setActiveId}`.
- **`globals.css`** — `.top-bar__familiar` box + picker list styling; on `max-width:767px` the name collapses to just avatar + caret to save room.
- Reuses the shared `ui/popover` (closes on Escape/outside/scroll/resize) and `FamiliarAvatar`.

## Test

Extended `top-bar.test.ts`: asserts the switcher box (`aria-haspopup=listbox`), the active-familiar avatar, the anchored Popover, the `role=option` → `onSelectFamiliar` wiring, and the render gate.

typecheck + top-bar test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)