### PR TITLE
chore(release): v0.0.88

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.88] - 2026-06-15
+
+Patch release: a familiar switcher in the top bar.
+
+### Added
+- **Top bar** — a familiar switcher box showing the active familiar; click it to open a picker and switch familiars, on desktop and mobile (#679).
+
 ## [0.0.87] - 2026-06-15
 
 Patch release: positions the mobile scroll-to-bottom button correctly.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A familiar is not just a chat window. It has a name, role, runtime, memory, tool
 
 ## Status
 
-- Current app version: `0.0.87`
+- Current app version: `0.0.88`
 - Native shell: Tauri 2
 - Frontend: Next.js 16, React 19, Tailwind v4
 - Runtime dependency: a healthy local `coven` CLI/daemon plus at least one runtime source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.87",
+  "version": "0.0.88",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.87"
+version = "0.0.88"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.87"
+version = "0.0.88"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.87</string>
+	<string>0.0.88</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.87</string>
+	<string>0.0.88</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.87</string>
+	<string>0.0.88</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.87</string>
+	<string>0.0.88</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.87",
+  "version": "0.0.88",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Patch release on top of v0.0.87:

- **Top bar** — familiar switcher box showing the active familiar; click to open a picker and switch familiars, desktop + mobile (#679).

Bumped: `package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock` (app), both iOS plists, README, CHANGELOG. `app-version.test.ts` passes.

Tag `v0.0.88` to be pushed after merge → release.yml publishes the notarized DMG / AppImage / MSI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)