### PR TITLE
feat(workflows): flatten Bind tab attachment sections (drop collapse framing)

### DIFF
--- a/src/components/workflows/workflow-attachments.tsx
+++ b/src/components/workflows/workflow-attachments.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import type { WorkflowRoleSummary, WorkflowSummary } from "@/lib/workflows";
 
@@ -31,28 +31,17 @@ function AttachmentSection({
   action?: ReactNode;
   children: ReactNode;
 }) {
-  const [open, setOpen] = useState(false);
   return (
     <article className="workflow-attachment-row">
       <div className="workflow-attachment-head">
-        <button
-          type="button"
-          className="workflow-attachment-toggle"
-          aria-expanded={open}
-          onClick={() => setOpen((value) => !value)}
-        >
-          <Icon
-            name={open ? "ph:caret-down" : "ph:caret-right"}
-            width={11}
-            className="workflow-attachment-caret"
-          />
+        <span className="workflow-attachment-title">
           <Icon name={icon} width={13} />
           <span>{title}</span>
           {count && <span className="workflow-attachment-count">{count}</span>}
-        </button>
+        </span>
         {action}
       </div>
-      {open && <div className="workflow-attachment-body">{children}</div>}
+      <div className="workflow-attachment-body">{children}</div>
     </article>
   );
 }
@@ -61,7 +50,8 @@ function AttachmentSection({
  * Cave bindings for the selected workflow. Familiars persist into the
  * manifest (`familiar:` field), roles persist into ROLE.md `workflows:`
  * lists; boards/projects remain visibly pending until an API owns them.
- * Every section collapses independently; bodies span the panel's full width.
+ * Sections render flat inside the Bind tab — no per-section collapse framing;
+ * bodies span the panel's full width.
  */
 export function WorkflowAttachments({
   workflow,
@@ -71,7 +61,6 @@ export function WorkflowAttachments({
   onUpdateMeta,
   onScheduleRequest,
 }: WorkflowAttachmentsProps) {
-  const [open, setOpen] = useState(false);
   const attachedRoles = workflow
     ? roles.filter((role) => role.workflows.includes(workflow.id)).length
     : 0;
@@ -80,15 +69,6 @@ export function WorkflowAttachments({
     <section className="workflow-panel workflow-attachments" aria-label="Workflow attachments">
       <div className="workflow-panel-heading">
         <div className="workflow-heading-lead">
-          <button
-            type="button"
-            className="workflow-section-caret-btn"
-            aria-expanded={open}
-            aria-label={`${open ? "Collapse" : "Expand"} Cave bindings`}
-            onClick={() => setOpen((value) => !value)}
-          >
-            <Icon name={open ? "ph:caret-down" : "ph:caret-right"} width={12} aria-hidden />
-          </button>
           <div>
             <p className="workflow-eyebrow">Attachments</p>
             <h2>Cave bindings</h2>
@@ -106,7 +86,6 @@ export function WorkflowAttachments({
         </button>
       </div>
 
-      {open && (
       <div className="workflow-attachment-list">
         <AttachmentSection icon="ph:mask-happy" title="Familiars" count={workflow?.familiar ?? undefined}>
           {workflow ? (
@@ -191,8 +170,7 @@ export function WorkflowAttachments({
           <p>No project attachment</p>
         </AttachmentSection>
       </div>
-      )}
-      {open && <p className="workflow-muted">Boards/Projects: persistence pending daemon API</p>}
+      <p className="workflow-muted">Boards/Projects: persistence pending daemon API</p>
     </section>
   );
 }

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -228,8 +228,14 @@ assert.match(attachments, /<select[\s\S]{0,220}aria-label="Familiar binding"/, "
 assert.doesNotMatch(attachments, /placeholder="Unassigned — saved into the manifest"[\s\S]{0,120}<input/, "Familiar attachment binding should no longer be free-text input");
 assert.match(attachments, /<option value="">Unassigned — saved into the manifest<\/option>/, "Familiar dropdown should keep an unassigned choice");
 assert.match(attachments, /familiarOptions\.map/, "Familiar dropdown should render discovered familiar options");
-assert.match(attachments, /aria-expanded=\{open\}/, "Attachment sections are collapsible");
-assert.match(attachments, /AttachmentSection/, "Attachments compose collapsible sections");
+assert.match(attachments, /AttachmentSection/, "Attachments compose sections");
+// Bind tab sections render flat — no per-section collapse framing, and the Bind
+// content is not gated behind an outer disclosure caret (the tab already gates it).
+assert.doesNotMatch(attachments, /aria-expanded=\{open\}/, "Attachment sections no longer collapse behind a caret");
+assert.doesNotMatch(attachments, /workflow-attachment-toggle/, "Attachment section headers are not disclosure toggles");
+assert.doesNotMatch(attachments, /workflow-section-caret-btn/, "Bind tab content is not behind an outer collapse caret");
+assert.match(attachments, /workflow-attachment-title/, "Attachment section headers are plain titles");
+assert.doesNotMatch(css, /\.workflow-attachment-row \{[^}]*border/, "Flat attachment sections drop the bordered framing");
 assert.match(css, /\.workflow-attachment-body > \* \{\n  width: 100%;/, "Attachment bodies span the full row width");
 assert.match(attachments, /workflow-role-emoji/, "Role rows reserve a fixed emoji slot so names align");
 assert.match(css, /grid-template-columns: auto 20px minmax\(0, 1fr\) auto/, "Role rows align as checkbox/emoji/name/familiar columns");

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -333,11 +333,8 @@
 
 .workflow-icon-button,
 .workflow-run-actions button,
-/* Action buttons only (e.g. Save) — NOT the disclosure toggle, which is a
-   flat, left-aligned, full-width control styled by .workflow-attachment-toggle.
-   Without the :not(), this chrome centered the toggle label on rows that have
-   no count to mask it (Boards/Projects). */
-.workflow-attachment-row button:not(.workflow-attachment-toggle) {
+/* Action buttons (e.g. Save) inside a flat attachment section. */
+.workflow-attachment-row button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -815,11 +812,10 @@
   gap: 8px;
 }
 
+/* Flat section — no bordered/collapsible framing; content shows inline. */
 .workflow-attachment-row {
   display: block;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 8px 9px;
+  padding: 0;
 }
 
 .workflow-attachment-head {
@@ -829,25 +825,16 @@
   gap: 10px;
 }
 
-.workflow-attachment-toggle {
+.workflow-attachment-title {
   display: flex;
   flex: 1;
   min-width: 0;
   align-items: center;
   gap: 6px;
-  padding: 0;
-  border: none;
-  background: none;
   font-size: 12.5px;
   font-weight: 600;
   color: var(--text-primary, inherit);
-  cursor: pointer;
   text-align: left;
-}
-
-.workflow-attachment-caret {
-  flex: none;
-  color: var(--muted-foreground);
 }
 
 .workflow-attachment-count {
@@ -876,7 +863,7 @@
   color: var(--muted-foreground);
 }
 
-.workflow-attachment-row button:not(.workflow-attachment-toggle) {
+.workflow-attachment-row button {
   padding: 0 9px;
 }
 


### PR DESCRIPTION
## What

In the Workflow Studio's **Bind** tab, each binding (Familiars / Roles / Boards / Projects) was wrapped in a collapsible, bordered box, and the whole list was gated behind an outer disclosure caret. Opening the tab showed a collapsed "Cave bindings ▸" that needed extra clicks to reach anything.

Now that these are real tabs, that framing is redundant. The sections render **flat**: each is a plain title + its content shown directly — the Familiar `<select>`, the Roles checklist, the Boards/Projects placeholders — with no per-section border, no caret, and no outer collapse. The tab itself gates visibility.

## Changes
- `workflow-attachments.tsx` — `AttachmentSection` is now a flat title + always-visible body (no `open` state, caret, or button); removed the outer collapse caret/state so the list shows on tab-select.
- `styles/workflows.css` — dropped the bordered box on `.workflow-attachment-row`, replaced the toggle styles with a plain `.workflow-attachment-title`, cleaned up the now-dead `.workflow-attachment-toggle` selectors.
- `workflow-studio.test.ts` — updated assertions: sections are flat (no `aria-expanded`, no toggle/caret), titles are plain, and the row rule has no border; kept the full-width-body check.

## Verification
- tsc clean; `workflow-studio` and `workflows-view` tests pass.
- Visual: rendered the new Bind-tab markup against the real `globals.css` + `workflows.css` — all four sections show flat with content inline, zero row borders (measured 0px). Screenshot captured.

## Note / possible follow-up
The Inspect and Manifest tabs carry the *same* redundant outer collapse caret (`workflow-section-caret-btn`). I scoped this to the Bind tab per your selection; happy to flatten those two as well for consistency if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)