### PR TITLE
feat(workflows): flatten Inspect and Manifest tabs (drop collapse framing)

### DIFF
--- a/src/components/workflows/workflow-inspector.tsx
+++ b/src/components/workflows/workflow-inspector.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { Icon } from "@/lib/icon";
 import type { WorkflowGraphNode } from "@/lib/workflow-graph";
 import {
@@ -86,7 +85,6 @@ export function WorkflowInspector({
   onRemoveStep,
 }: WorkflowInspectorProps) {
   const issues = issuesForAction(action);
-  const [open, setOpen] = useState(false);
   const step = selectedNode
     ? workflow?.steps?.find((entry) => entry.id === selectedNode.id) ?? null
     : null;
@@ -95,15 +93,6 @@ export function WorkflowInspector({
     <section className="workflow-panel workflow-inspector" aria-label="Workflow inspector">
       <div className="workflow-panel-heading">
         <div className="workflow-heading-lead">
-          <button
-            type="button"
-            className="workflow-section-caret-btn"
-            aria-expanded={open}
-            aria-label={`${open ? "Collapse" : "Expand"} inspector`}
-            onClick={() => setOpen((value) => !value)}
-          >
-            <Icon name={open ? "ph:caret-down" : "ph:caret-right"} width={12} aria-hidden />
-          </button>
           <div>
             <p className="workflow-eyebrow">{step ? "Selected node" : "Workflow"}</p>
             <h2>{step ? (step.name ?? step.id) : (workflow?.name ?? workflow?.id ?? "No workflow")}</h2>
@@ -122,7 +111,6 @@ export function WorkflowInspector({
         )}
       </div>
 
-      {open && (
       <>
       {step ? (
         <div className="workflow-editor">
@@ -265,7 +253,6 @@ export function WorkflowInspector({
         </ul>
       )}
       </>
-      )}
     </section>
   );
 }

--- a/src/components/workflows/workflow-manifest-preview.tsx
+++ b/src/components/workflows/workflow-manifest-preview.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { Icon } from "@/lib/icon";
+import { useMemo } from "react";
 import { workflowToYaml } from "@/lib/workflow-edit";
 import type { WorkflowSummary } from "@/lib/workflows";
 
@@ -12,22 +11,12 @@ type WorkflowManifestPreviewProps = {
 
 /** Live canonical YAML for the current draft — what Save writes to disk. */
 export function WorkflowManifestPreview({ workflow, dirty }: WorkflowManifestPreviewProps) {
-  const [open, setOpen] = useState(false);
   const yaml = useMemo(() => (workflow ? workflowToYaml(workflow) : null), [workflow]);
 
   return (
     <section className="workflow-panel workflow-manifest-preview" aria-label="Workflow manifest preview">
       <div className="workflow-panel-heading">
         <div className="workflow-heading-lead">
-          <button
-            type="button"
-            className="workflow-section-caret-btn"
-            aria-expanded={open}
-            aria-label={`${open ? "Collapse" : "Expand"} Manifest`}
-            onClick={() => setOpen((value) => !value)}
-          >
-            <Icon name={open ? "ph:caret-down" : "ph:caret-right"} width={12} aria-hidden />
-          </button>
           <div>
             <p className="workflow-eyebrow">WORKFLOW.md / .workflow.yaml</p>
             <h2>
@@ -37,18 +26,14 @@ export function WorkflowManifestPreview({ workflow, dirty }: WorkflowManifestPre
           </div>
         </div>
       </div>
-      {open && (
-        <>
-          {yaml ? (
-            <pre className="workflow-manifest-yaml">
-              <code>{`# schema_version: CWF-01\n${yaml}`}</code>
-            </pre>
-          ) : (
-            <p className="workflow-muted">Select a workflow to preview its canonical manifest.</p>
-          )}
-          <p className="workflow-muted">Cave-only layout stays in WORKFLOW.cave.json.</p>
-        </>
+      {yaml ? (
+        <pre className="workflow-manifest-yaml">
+          <code>{`# schema_version: CWF-01\n${yaml}`}</code>
+        </pre>
+      ) : (
+        <p className="workflow-muted">Select a workflow to preview its canonical manifest.</p>
       )}
+      <p className="workflow-muted">Cave-only layout stays in WORKFLOW.cave.json.</p>
     </section>
   );
 }

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -237,6 +237,15 @@ assert.doesNotMatch(attachments, /workflow-section-caret-btn/, "Bind tab content
 assert.match(attachments, /workflow-attachment-title/, "Attachment section headers are plain titles");
 assert.doesNotMatch(css, /\.workflow-attachment-row \{[^}]*border/, "Flat attachment sections drop the bordered framing");
 assert.match(css, /\.workflow-attachment-body > \* \{\n  width: 100%;/, "Attachment bodies span the full row width");
+
+// Inspect and Manifest tabs are flat too — content shows directly on tab-select,
+// not behind an outer disclosure caret (the tabs already gate visibility).
+assert.doesNotMatch(inspector, /workflow-section-caret-btn/, "Inspect tab content is not behind an outer collapse caret");
+assert.doesNotMatch(inspector, /aria-expanded=\{open\}/, "Inspect tab does not gate content behind a disclosure");
+assert.doesNotMatch(manifestPreview, /workflow-section-caret-btn/, "Manifest tab content is not behind an outer collapse caret");
+assert.doesNotMatch(manifestPreview, /aria-expanded=\{open\}/, "Manifest tab does not gate content behind a disclosure");
+// The caret control is fully retired across the workflow panels.
+assert.doesNotMatch(css, /\.workflow-section-caret-btn/, "Dead caret-button CSS is removed");
 assert.match(attachments, /workflow-role-emoji/, "Role rows reserve a fixed emoji slot so names align");
 assert.match(css, /grid-template-columns: auto 20px minmax\(0, 1fr\) auto/, "Role rows align as checkbox/emoji/name/familiar columns");
 assert.match(css, /scrollbar-width: thin/, "Studio scroll regions use thin themed scrollbars");

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -263,11 +263,6 @@
   margin-bottom: 12px;
 }
 
-/* Collapsed sections trim the heading's bottom gap so headers stack tightly. */
-.workflow-panel:has(.workflow-section-caret-btn[aria-expanded="false"]) .workflow-panel-heading {
-  margin-bottom: 0;
-}
-
 /* Library actions toolbar — the panel header owns the title, so this is just
    a right-aligned row of create/refresh buttons. */
 .workflow-library-toolbar {
@@ -276,38 +271,12 @@
   margin-bottom: 8px;
 }
 
-/* Caret toggle + title group on the left of a collapsible section heading. */
+/* Title group on the left of a section heading. */
 .workflow-heading-lead {
   display: flex;
   align-items: center;
   gap: 8px;
   min-width: 0;
-}
-
-.workflow-section-caret-btn {
-  display: grid;
-  place-items: center;
-  flex-shrink: 0;
-  width: 20px;
-  height: 20px;
-  margin-top: 1px;
-  padding: 0;
-  border: 0;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
-  transition: background 120ms ease, color 120ms ease;
-}
-
-.workflow-section-caret-btn:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
-
-.workflow-section-caret-btn:focus-visible {
-  outline: var(--ring-width) solid var(--ring-focus);
-  outline-offset: 1px;
 }
 
 .workflow-panel-heading h2,
@@ -1681,16 +1650,14 @@
   .workflow-library-footer button,
   .workflow-field input,
   .workflow-field select,
-  .workflow-search,
-  .workflow-section-caret-btn {
+  .workflow-search {
     min-height: var(--touch-target);
     -webkit-tap-highlight-color: transparent;
   }
 
   .workflow-icon-button,
   .workflow-canvas-tool,
-  .workflow-canvas .react-flow__controls-button,
-  .workflow-section-caret-btn {
+  .workflow-canvas .react-flow__controls-button {
     width: var(--touch-target);
     height: var(--touch-target);
     min-width: var(--touch-target);


### PR DESCRIPTION
## What

Follow-up to #681 (Bind tab). The **Inspect** and **Manifest** tabs carried the same redundant outer disclosure caret (`workflow-section-caret-btn`) that hid their content behind an extra click — even though selecting the tab already gates visibility.

Both tabs now render flat: content shows directly on tab-select. Removed the caret button + `open` state from each, and retired the now-dead caret CSS (the rule block, hover/focus, the mobile touch-target entries, and the collapsed-heading `:has()` rule). The `Icon` import drops from the manifest preview since the caret was its only use.

This makes all three Workflow Studio side-panel tabs consistent (Bind was done in #681).

## Changes
- `workflow-inspector.tsx` — remove caret/`open`; render content directly; drop unused `useState` import.
- `workflow-manifest-preview.tsx` — same; drop unused `Icon` import.
- `styles/workflows.css` — remove all `.workflow-section-caret-btn` rules (now dead).
- `workflow-studio.test.ts` — assert Inspect/Manifest have no caret/disclosure and the caret CSS is gone.

## Verification
- tsc clean; `workflow-studio` test passes; no remaining `workflow-section-caret-btn` references in `src/` (outside the negative test assertion).
- Visual pattern is identical to #681's Bind flatten, which was screenshot-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)