### PR TITLE
feat(nav): wire the Delegations (Coven Calls) surface back into navigation

### DIFF
--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -4,6 +4,21 @@ import { readFileSync } from "node:fs";
 
 const styles = readFileSync(new URL("../styles/sidebar-minimal.css", import.meta.url), "utf8");
 const source = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+
+// The Delegations (calls) surface is wired back into navigation: a Tools entry
+// in the sidebar + a render branch + a mode title in the workspace.
+assert.match(
+  source,
+  /\{ id: "calls", label: "Delegations", iconName: "ph:graph", group: "tools", description:/,
+  "Delegations should appear as a Tools surface (CallsView wired back into nav)",
+);
+assert.match(
+  workspace,
+  /mode === "calls" \?\s*\(\s*<CallsView/,
+  "workspace should render CallsView for the calls mode",
+);
+assert.match(workspace, /calls: "Delegations"/, "calls mode has a Delegations title");
 
 assert.match(
   source,

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -32,7 +32,8 @@ export type FolderMode =
   | "roles"
   | "workflows"
   | "library"
-  | "capabilities";
+  | "capabilities"
+  | "calls";
 
 export type AddonsConfig = {
   github?: boolean;
@@ -89,6 +90,7 @@ const FOLDER_MODES: Array<{
   { id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools", description: "Reusable agent personas you can attach to a familiar" },
   { id: "workflows", label: "Workflows", iconName: "ph:git-branch-bold", group: "tools", description: "Multi-step pipelines that orchestrate familiars" },
   { id: "capabilities", label: "Capabilities", iconName: "ph:lightning-bold", group: "tools", description: "Skills and tools your familiars can use" },
+  { id: "calls", label: "Delegations", iconName: "ph:graph", group: "tools", description: "Delegation call graph and live floor activity" },
   // Add-ons (gated)
   { id: "github", label: "GitHub", iconName: "ph:github-logo", group: "addons", description: "Issues and PRs assigned to you" },
 ];

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -22,6 +22,7 @@ import { FamiliarStudio } from "@/components/familiar-studio";
 import { CompanionRail, type CompanionTab } from "@/components/companion-rail";
 import { RailInspector } from "@/components/inspector-pane";
 import { FamiliarsView } from "@/components/familiars-view";
+import { CallsView } from "@/components/calls-view";
 import { RailMemoryList } from "@/components/familiars-memory-view";
 import {
   getActiveFamiliar,
@@ -81,6 +82,7 @@ const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = {
   roles: "Roles",
   workflows: "Workflows",
   capabilities: "Capabilities",
+  calls: "Delegations",
 };
 
 // Chat deep links (CHAT-D9-01): `#chat-<sessionId>` re-enters a specific
@@ -966,6 +968,10 @@ export function Workspace() {
       case "/board":
         setMode("board");
         return true;
+      case "/calls":
+      case "/delegations":
+        setMode("calls");
+        return true;
       case "/chats":
       case "/agents":
       case "/chat":
@@ -1356,6 +1362,13 @@ export function Workspace() {
       />
     ) : mode === "capabilities" ? (
       <CapabilitiesViewSurface activeHarness={active?.harness ?? null} />
+    ) : mode === "calls" ? (
+      <CallsView
+        familiars={familiars}
+        sessions={sessions}
+        onOpenSession={(sessionId, familiarId) => openFamiliarSession(sessionId, familiarId)}
+        initialTab="delegations"
+      />
     ) : mode === "calendar" ? (
       <CalendarView
         items={inboxItems}

--- a/src/lib/workspace-mode.ts
+++ b/src/lib/workspace-mode.ts
@@ -11,4 +11,5 @@ export type WorkspaceMode =
   | "github"
   | "roles"
   | "workflows"
-  | "capabilities";
+  | "capabilities"
+  | "calls";


### PR DESCRIPTION
Follow-up to the verification pass — during it I found `CallsView` (the floor + delegation-graph surface) was no longer reachable: when the `agents` mode was switched to `FamiliarsView` (the roster), the delegation call graph lost its home (only its file + tests referenced it). This wires it back.

## Changes
- New **`calls` `WorkspaceMode`** + `FolderMode`, titled **"Delegations"**
- Sidebar entry in **Tools**: `{ label: "Delegations", icon: ph:graph, description: "Delegation call graph and live floor activity" }` — labelled "Delegations" rather than "Calls" to avoid clashing with the voice-call feature
- Workspace renders `<CallsView initialTab="delegations">`, so it opens on the call graph — **3D on desktop, the #669 2D fallback on mobile**
- `/calls` and `/delegations` slash deep-links

## Verification (live, Playwright)
- **Desktop**: sidebar "Delegations" entry renders (active), surface mounts with the 3D graph + empty state
- **Mobile** (iPhone-13): `CallsView` mounts and the **2D fallback path renders** (`callsViewMounted:1, fallback:1`) — so #669's fallback is now actually reachable
- `pnpm typecheck` ✅ · `pnpm build` ✅ · `sidebar-minimal` (extended: asserts the entry + workspace render branch + title) / `roles-tools-navigation` / `calls-view-graph` / `calls-graph-fallback` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)