### PR TITLE
fix(top-bar): always show the familiar switcher box

### DIFF
--- a/src/components/top-bar.test.ts
+++ b/src/components/top-bar.test.ts
@@ -65,7 +65,7 @@ assert.match(
 );
 
 // Active-familiar switcher box: a button showing the current familiar that opens
-// a Popover picker (desktop + mobile). Gated on onSelectFamiliar + activeFamiliar.
+// a Popover picker (desktop + mobile). Gated on a display familiar (active, or first option as fallback).
 assert.match(
   source,
   /className="top-bar__familiar"[\s\S]*aria-haspopup="listbox"/,
@@ -73,7 +73,7 @@ assert.match(
 );
 assert.match(
   source,
-  /<FamiliarAvatar familiar=\{activeFamiliar\}/,
+  /<FamiliarAvatar familiar=\{displayFamiliar\}/,
   "Switcher box shows the active familiar's avatar",
 );
 assert.match(
@@ -88,7 +88,7 @@ assert.match(
 );
 assert.match(
   source,
-  /const showFamiliarSwitcher = Boolean\(onSelectFamiliar && activeFamiliar\)/,
+  /const showFamiliarSwitcher = Boolean\(onSelectFamiliar && displayFamiliar\)/,
   "Switcher only renders when wired with a selection handler + active familiar",
 );
 

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -64,7 +64,12 @@ export function TopBar(props: Props) {
 
   const [familiarPickerOpen, setFamiliarPickerOpen] = useState(false);
   const familiarBoxRef = useRef<HTMLButtonElement | null>(null);
-  const showFamiliarSwitcher = Boolean(onSelectFamiliar && activeFamiliar);
+  // Show the switcher whenever there are familiars to pick — even before one is
+  // the global "active" familiar (e.g. the Home surface, where activeId is null).
+  // The box previews the active familiar, falling back to the first option, so
+  // it's always reachable to make a first selection.
+  const displayFamiliar = activeFamiliar ?? familiarOptions?.[0] ?? null;
+  const showFamiliarSwitcher = Boolean(onSelectFamiliar && displayFamiliar);
 
   return (
     <header className="top-bar">
@@ -112,7 +117,7 @@ export function TopBar(props: Props) {
       </button>
 
       <div className="top-bar__actions">
-        {showFamiliarSwitcher && activeFamiliar ? (
+        {showFamiliarSwitcher && displayFamiliar ? (
           <>
             <button
               ref={familiarBoxRef}
@@ -121,11 +126,11 @@ export function TopBar(props: Props) {
               onClick={() => setFamiliarPickerOpen((open) => !open)}
               aria-haspopup="listbox"
               aria-expanded={familiarPickerOpen}
-              aria-label={`Switch familiar — current: ${activeFamiliar.display_name}`}
+              aria-label={`Switch familiar — current: ${displayFamiliar.display_name}`}
               title="Switch familiar"
             >
-              <FamiliarAvatar familiar={activeFamiliar} size="sm" />
-              <span className="top-bar__familiar-name">{activeFamiliar.display_name}</span>
+              <FamiliarAvatar familiar={displayFamiliar} size="sm" />
+              <span className="top-bar__familiar-name">{displayFamiliar.display_name}</span>
               <Icon name="ph:caret-down" width={10} />
             </button>
             <Popover
@@ -138,7 +143,7 @@ export function TopBar(props: Props) {
             >
               <ul className="top-bar__familiar-list" role="listbox" aria-label="Switch familiar">
                 {(familiarOptions ?? []).map((option) => {
-                  const isActive = option.id === activeFamiliar.id;
+                  const isActive = option.id === activeFamiliar?.id;
                   return (
                     <li key={option.id}>
                       <button


### PR DESCRIPTION
Follow-up to #679. The switcher box was gated on an **active** familiar, so on the Home surface — where the global `activeId` is null until you pick one — the box never rendered. That's the one place you'd most want it (to choose a familiar).

Fix: preview the active familiar, **falling back to the first option** (`displayFamiliar = activeFamiliar ?? familiarOptions[0]`), so the box is always available when familiars exist. The picker still marks only the genuinely-active familiar as selected (`option.id === activeFamiliar?.id`).

**Verified live in the iOS simulator** (Tailscale HTTPS dev flow): the box now renders in the top bar on Home (avatar + caret; name hidden on mobile per the existing CSS). Screenshot before/after confirmed.

typecheck + `top-bar.test.ts` pass (assertions updated to `displayFamiliar`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)