### PR TITLE
feat(nav): add Delegations to the mobile bottom tabs

### DIFF
--- a/src/components/mobile-bottom-tabs.tsx
+++ b/src/components/mobile-bottom-tabs.tsx
@@ -2,8 +2,8 @@
 
 /**
  * MobileBottomTabs — fixed/sticky bottom navigation strip for mobile/tablet
- * viewports. Surfaces the five most-used destinations (Home, Chat, Board,
- * Inbox, Library) as a tablist with icon + label and an active highlight.
+ * viewports. Surfaces the most-used destinations (Home, Chat, Board, Inbox,
+ * Library, Delegations) as a tablist with icon + label and an active highlight.
  *
  * Renders only when the parent shell is in mobile mode (≤1023px); Shell is
  * responsible for that conditional render — this component itself doesn't
@@ -12,7 +12,7 @@
 
 import { Icon, type IconName } from "@/lib/icon";
 
-type TabId = "home" | "chat" | "board" | "inbox" | "library";
+type TabId = "home" | "chat" | "board" | "inbox" | "library" | "calls";
 
 type TabDef = {
   id: TabId;
@@ -27,6 +27,11 @@ const TABS: TabDef[] = [
   { id: "board", label: "Board", ariaLabel: "Board", iconName: "ph:kanban" },
   { id: "inbox", label: "Inbox", ariaLabel: "Inbox and automations", iconName: "ph:tray" },
   { id: "library", label: "Library", ariaLabel: "Library", iconName: "ph:books" },
+  // Short visible label ("keep labels short" — see the Inbox/Automations split):
+  // "Delegations" truncates to "Delegati…" in a 6-tab bar, so use the surface's
+  // own header name ("Coven Calls"); the accessible name stays "Delegations" to
+  // match the sidebar Tools entry (mode "calls").
+  { id: "calls", label: "Calls", ariaLabel: "Delegations", iconName: "ph:graph" },
 ];
 
 export type MobileBottomTabsProps = {

--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -39,6 +39,12 @@ assert.match(
 
 assert.match(
   mobileTabs,
+  /{ id: "calls", label: "Calls", ariaLabel: "Delegations", iconName: "ph:graph" }/,
+  "Mobile bottom tabs should include the Delegations surface (short 'Calls' label, full 'Delegations' accessible name)",
+);
+
+assert.match(
+  mobileTabs,
   /aria-label=\{showBadge \? `\$\{tab\.ariaLabel\}, \$\{inboxBadgeCount\} unread` : tab\.ariaLabel\}/,
   "Mobile bottom tabs should expose per-tab accessible labels instead of relying on cramped visual text",
 );


### PR DESCRIPTION
Adds the **Delegations** (Coven Calls) destination — wired into nav in #683 — as a 6th **mobile bottom tab**, so it's reachable directly without opening the nav drawer.

## Detail
- New `calls` tab: visible label **"Calls"**, accessible name **"Delegations"**, icon `ph:graph`.
- Why "Calls" visible: "Delegations" truncates to "Delegati…" in a 6-tab bar (measured `scrollWidth 61 > clientWidth 52` at 390px). "Calls" is the surface's own on-screen header ("Coven Calls") and fits cleanly like "Board"/"Inbox"; the full "Delegations" name is preserved as the accessible label to match the sidebar Tools entry + mode.
- `onSelect` already casts the id to `WorkspaceMode` and `setMode`s it, and `calls` is a valid mode (#683), so no extra wiring needed.

## Verification (live, Playwright iPhone-13)
- All six labels render **untruncated** at 390px and 360px (screenshot: Home · Chat · Board · Inbox · Library · Calls)
- Tapping the tab **activates it** (`activeTab: "Calls"`) and **mounts CallsView** (the #669 2D fallback) — confirmed end-to-end
- `pnpm typecheck` ✅ · `pnpm build` ✅ · `mobile-shell-smoke.test.ts` extended to assert the new tab entry ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)