### PR TITLE
fix(github): connected PAT button is icon-only

### DIFF
--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -60,4 +60,22 @@ assert.match(
   "keydown handler skips when an input/textarea is focused",
 );
 
+// When a PAT is connected the button is icon-only (no text label); it keeps an
+// aria-label for accessibility and only shows "Add PAT" text when not connected.
+assert.doesNotMatch(
+  source,
+  /PAT connected</,
+  "Connected PAT button drops its text label (icon only)",
+);
+assert.match(
+  source,
+  /aria-label=\{patStatus\?\.hasPat \? "GitHub PAT connected/,
+  "Icon-only connected PAT button keeps an aria-label",
+);
+assert.match(
+  source,
+  /\{patStatus\?\.hasPat \? null : "Add PAT"\}/,
+  "Disconnected state still shows the 'Add PAT' call to action",
+);
+
 console.log("github-view-polish.test.ts OK");

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -769,10 +769,11 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
             type="button"
             onClick={() => setShowPatModal(true)}
             title={patStatus?.hasPat ? "Manage GitHub PAT" : "Connect GitHub PAT"}
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2 py-1 text-[11px] text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] transition-colors"
+            aria-label={patStatus?.hasPat ? "GitHub PAT connected — manage" : "Connect GitHub PAT"}
+            className={`flex items-center gap-1.5 rounded-md border border-[var(--border-hairline)] py-1 text-[11px] text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] transition-colors ${patStatus?.hasPat ? "px-1.5" : "px-2"}`}
           >
             <Icon name="ph:key" width={11} />
-            {patStatus?.hasPat ? "PAT connected" : "Add PAT"}
+            {patStatus?.hasPat ? null : "Add PAT"}
           </button>
           <button
             type="button"


### PR DESCRIPTION
The GitHub toolbar's PAT button showed a key icon **+ "PAT connected"** text when a token was set. Per request, the **connected** state is now **icon-only** (just the key), with:
- an `aria-label` ("GitHub PAT connected — manage") so it stays accessible without visible text,
- slightly tighter padding for the icon-only shape.

The **disconnected** state is unchanged — it keeps the "Add PAT" text as a call to action.

Guarded in `github-view-polish.test.ts` (no "PAT connected" text, aria-label present, "Add PAT" CTA retained). typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)