### PR TITLE
feat(chat): flatten Memory and Projects tab cards (drop box framing)

### DIFF
--- a/src/components/familiars-memory-view-full-tab.test.ts
+++ b/src/components/familiars-memory-view-full-tab.test.ts
@@ -50,4 +50,23 @@ assert.match(
   "Empty-state card must use py-6 padding instead of min-h",
 );
 
+// The memory list/cards render flat — the master-detail list drops its bordered
+// box wrapper (rows keep their divide-y hairlines) and the compact cards become
+// borderless divided rows instead of bordered card boxes.
+assert.doesNotMatch(
+  source,
+  /overflow-y-auto rounded-lg border border-\[var\(--border-hairline\)\] bg-\[var\(--bg-raised\)\]\/25/,
+  "Master-detail memory list should not be wrapped in a bordered rounded box",
+);
+assert.doesNotMatch(
+  source,
+  /rounded-lg border border-\[var\(--border-hairline\)\] bg-\[var\(--bg-raised\)\]\/35 p-3/,
+  "Compact memory cards should not be bordered rounded card boxes",
+);
+assert.match(
+  source,
+  /flex flex-col divide-y divide-\[var\(--border-hairline\)\] border-t border-\[var\(--border-hairline\)\]/,
+  "Compact memories render as a flat divided list",
+);
+
 console.log("familiars-memory-view-full-tab.test.ts: ok");

--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -484,7 +484,7 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
                   </span>
                 </div>
               </div>
-              <div className="min-h-0 flex-1 overflow-y-auto rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/25">
+              <div className="min-h-0 flex-1 overflow-y-auto border-t border-[var(--border-hairline)]">
                 {unifiedRows.length === 0 ? (
                   <div className="px-3 py-8 text-center text-[12px] text-[var(--text-muted)]">
                     {loaded ? (error ? "Couldn't load memories. See the error above and try again." : "No memories match this view.") : "Loading memories…"}
@@ -546,13 +546,13 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
               {loaded ? (error ? "Couldn’t load familiar memories. See the error above and try again." : "No familiar memories match this view.") : "Loading memories..."}
             </div>
           ) : (
-            <div className="grid gap-2 md:grid-cols-2">
+            <div className="flex flex-col divide-y divide-[var(--border-hairline)] border-t border-[var(--border-hairline)]">
               {visibleCoven.slice(0, effectiveLimit).map((entry) => {
                 const familiar = familiarById.get(entry.familiar_id);
                 return (
                   <article
                     key={entry.id}
-                    className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 p-3 transition-colors"
+                    className="px-1 py-3 transition-colors hover:bg-[var(--bg-raised)]/30"
                   >
                     <div className="flex items-start justify-between gap-2">
                       <div className="min-w-0">

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -74,4 +74,17 @@ assert.match(
   "new-project form closes on Escape",
 );
 
+// Project rows render flat — a bottom hairline divider instead of a bordered
+// rounded card box, so the Projects tab reads as a flat list.
+assert.doesNotMatch(
+  projectsView,
+  /group rounded-lg border bg-\[var\(--bg-raised\)\]/,
+  "Project rows should not be bordered rounded card boxes",
+);
+assert.match(
+  projectsView,
+  /group border-b border-\[var\(--border-hairline\)\] px-2 py-3/,
+  "Project rows should be flat rows separated by a hairline divider",
+);
+
 console.log("projects-view.test.ts: ok");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -169,8 +169,10 @@ function ProjectRow({
       ref={setDropRef}
       data-drop-over={isOver ? "true" : undefined}
       className={[
-        "group rounded-lg border bg-[var(--bg-raised)] px-4 py-3 transition-colors",
-        isOver ? "border-[var(--accent-presence)]" : "border-[var(--border-hairline)] hover:border-[var(--border-strong)]",
+        "group border-b border-[var(--border-hairline)] px-2 py-3 transition-colors",
+        isOver
+          ? "bg-[color-mix(in_oklch,var(--accent-presence)_10%,transparent)]"
+          : "hover:bg-[var(--bg-raised)]/40",
       ].join(" ")}
     >
       <div className="flex min-w-0 items-center gap-2">
@@ -534,7 +536,7 @@ export function ProjectsView({ sessions = [], onNewChat }: ProjectsViewProps) {
             }
           />
         ) : (
-          <div className="mx-auto flex w-full max-w-[1100px] flex-col gap-2">
+          <div className="mx-auto flex w-full max-w-[1100px] flex-col">
             {error ? (
               <div
                 role="alert"


### PR DESCRIPTION
## What

The chat surface tabs (Chats / Memory / Projects) are already flat underline tabs, but their panels framed content in bordered rounded card boxes. This flattens them to borderless rows separated by hairlines — consistent with the Workflow Studio flatten (#681/#682).

- **Projects** — each project is now a flat row with a bottom hairline divider + hover tint instead of a rounded bordered card; the list drops its inter-card gap so dividers sit flush.
- **Memory (master-detail)** — the list drops its bordered rounded box wrapper; rows keep their `divide-y` hairlines.
- **Memory (compact)** — the 2-column grid of bordered cards becomes a single flat divided list of borderless rows.

Functional controls (search, filter, rename inputs, drag-and-drop, show-more) and intentional dashed empty-state placeholders are untouched.

## Verification
- tsc clean; `projects-view`, `familiars-memory-view-*`, `chat-surface*` tests pass; added assertions locking the flat classes (no rounded/bordered card boxes; flat divided rows).
- Built current main + this branch, ran the production server, drove the chat surface with mocked projects/memory/familiars data, and screenshotted both tabs: **0 legacy bordered article cards**. Projects renders as a clean borderless list; Memory's master-detail list shows flat rows with no box wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)