### PR TITLE
chore(release): v0.0.91

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
-## [0.0.90] - 2026-06-15
+## [0.0.91] - 2026-06-15
 
 Patch release: tidies the GitHub PAT button.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A familiar is not just a chat window. It has a name, role, runtime, memory, tool
 
 ## Status
 
-- Current app version: `0.0.90`
+- Current app version: `0.0.91`
 - Native shell: Tauri 2
 - Frontend: Next.js 16, React 19, Tailwind v4
 - Runtime dependency: a healthy local `coven` CLI/daemon plus at least one runtime source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.90",
+  "version": "0.0.91",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.90"
+version = "0.0.91"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.90"
+version = "0.0.91"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.90</string>
+	<string>0.0.91</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.90</string>
+	<string>0.0.91</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.90</string>
+	<string>0.0.91</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.90</string>
+	<string>0.0.91</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.90",
+  "version": "0.0.91",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Bumps version to v0.0.91.

**Included since v0.0.90:**
- #698 feat(capabilities): inline dropdown preview for skills in the list
- #697 feat(terminal): on-screen key bar (Esc/Tab/Ctrl/arrows) for mobile
- #692 feat(mobile): mobile UX phase 0–3 + touch fixes
- #695 fix(board,env): atomic board writes + PAT .env.local outside bundle
- #694 feat(capabilities): full-preview + library doc path guard + autofix
- #696 docs: chat UX model routing design spec
- #690 feat(memory): collapse Familiar Memory masthead on list scroll-down
- #693 feat(nav): navigation, Coven Calls surface, and familiar switcher