### PR TITLE
fix(magnification): rem-based screen scaling instead of app-wide zoom

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -361,16 +361,22 @@ html {
   background: transparent;
 }
 
+/* Magnification is rem-based: scaling the root font-size enlarges text and
+   em-sized icons and lets the layout reflow, rather than a generic full-window
+   `zoom` (which ballooned everything — including the embedded browser/canvas —
+   and broke getBoundingClientRect math). Anything sized in rem/em scales;
+   fixed-px sizes stay put. */
+html {
+  font-size: calc(16px * var(--cave-screen-scale));
+}
+
 body {
   font-family:
     var(--font-sans), ui-sans-serif, system-ui, -apple-system,
     "Segoe UI", Roboto, sans-serif;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: var(--leading-normal);
   -webkit-font-smoothing: antialiased;
-  width: calc(100dvw / var(--cave-screen-scale));
-  height: calc(100dvh / var(--cave-screen-scale));
-  zoom: var(--cave-screen-scale);
 }
 
 /* Mobile foundations — kill iOS focus-zoom on text entry. Any input/
@@ -5208,7 +5214,7 @@ button:active > .edge-rail-chip {
    their existing `flex-1 min-h-0`. */
 @supports (height: 100dvh) {
   .shell-frame {
-    height: calc(100dvh / var(--cave-screen-scale));
+    height: 100dvh;
   }
   .ui-modal-shell {
     max-height: calc(100dvh - 2 * var(--space-4));

--- a/src/components/settings-appearance.test.ts
+++ b/src/components/settings-appearance.test.ts
@@ -249,8 +249,8 @@ assert.match(
 
 assert.match(
   globals,
-  /zoom: var\(--cave-screen-scale\)/,
-  "Global CSS should magnify the entire app surface via the screen scale token",
+  /font-size: calc\(16px \* var\(--cave-screen-scale\)\)/,
+  "Global CSS should magnify the app via rem-based root font scaling (not an app-wide zoom, which broke getBoundingClientRect math)",
 );
 
 assert.match(

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -77,10 +77,10 @@ assert.match(css, /\.workflow-studio-shell \{[\s\S]{0,700}padding:\s*16px 16px 1
   assert.ok(!/background/.test(collapsedLeft[0]), "Collapsed left rail should have no background fill");
 }
 assert.match(css, /@media \(max-width: 860px\)/, "workflow CSS should include mobile studio layout");
-assert.match(
+assert.doesNotMatch(
   css,
-  /\.workflow-canvas \.react-flow \{[\s\S]{0,300}zoom:\s*calc\(1 \/ var\(--cave-screen-scale\)\)[\s\S]{0,160}width:\s*calc\(100% \* var\(--cave-screen-scale\)\)[\s\S]{0,80}height:\s*calc\(100% \* var\(--cave-screen-scale\)\)/,
-  "Workflow canvas must cancel the app-wide screen-scale zoom inside React Flow — its handle measurement ignores ancestor CSS zoom, so at 110/125/150% edge arrows detach from their handles",
+  /\.workflow-canvas \.react-flow \{[\s\S]{0,300}zoom:\s*calc\(1 \/ var\(--cave-screen-scale\)\)/,
+  "Workflow canvas must NOT counter-zoom — screen magnification is rem-based (no app-wide CSS zoom), so a 1/scale counter-zoom here would shrink the canvas and re-detach edge arrows (the #482 bug)",
 );
 
 // --- Studio v2: visual builder, runs, assignments ---

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -1465,17 +1465,11 @@
 
 /* ---- Studio final touch: legible edges + dark React Flow chrome ---- */
 
-/* React Flow anchors edges by dividing getBoundingClientRect() deltas by its
-   own viewport transform only — the app-wide screen-scale `zoom` (globals.css
-   body rule) is not in that divisor, so at 110/125/150% every edge anchor
-   lands past its handle and arrows float mid-gap. Cancel the zoom inside the
-   flow so it measures at 1:1, and re-grow the box so it still fills the
-   canvas after its own zoom shrinks it. */
-.workflow-canvas .react-flow {
-  zoom: calc(1 / var(--cave-screen-scale));
-  width: calc(100% * var(--cave-screen-scale));
-  height: calc(100% * var(--cave-screen-scale));
-}
+/* Screen magnification is now rem-based (globals.css scales the root
+   font-size, not an app-wide `zoom`), so React Flow no longer sits inside a
+   CSS zoom its handle measurement can't see. The canvas measures at 1:1 at
+   every scale, so the old counter-zoom workaround is gone — adding one back
+   would reintroduce the detached-edge bug it was meant to fix. */
 
 .workflow-canvas .react-flow__edge-path {
   stroke: color-mix(in oklch, var(--accent-presence) 65%, transparent);


### PR DESCRIPTION
Salvages orphaned work (session e13bc48e) that never made it into a PR.

### Problem
Screen magnification scaled the entire app with `body { zoom: var(--cave-screen-scale) }`. CSS `zoom` inflates `getBoundingClientRect()` deltas, which React Flow divides by its own viewport transform only — so at 110/125/150% every edge arrow detached from its handle (**#482**). It also ballooned the embedded browser/canvas indiscriminately rather than enlarging text.

### Fix
Scale the root font-size instead: `html { font-size: calc(16px * var(--cave-screen-scale)) }`. Text and `em`-sized icons grow and the layout reflows; fixed-`px` chrome and the canvas stay at 1:1. `body` font drops to `0.875rem` so it tracks the root.

With no ancestor CSS zoom, the `.workflow-canvas .react-flow` **counter-zoom** workaround (which only existed to cancel the global zoom) is removed — re-adding one would re-introduce the detached-edge bug.

### Tests
- `settings-appearance.test.ts`: asserts the rem-based root rule (was asserting `zoom:`).
- `workflow-studio.test.ts`: now asserts the canvas does **not** counter-zoom.
- `tsc --noEmit` clean; both suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)