### PR TITLE
fix(terminal): harden pty websocket access

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -6,11 +6,17 @@ import { parse } from "node:url";
 import next from "next";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
 
+import {
+  ACCESS_TOKEN_COOKIE,
+  isAllowedRequestSource,
+  isLoopbackHost,
+} from "./src/proxy-helpers.ts";
+
 const require = createRequire(import.meta.url);
 const pty: typeof import("node-pty") = require("node-pty");
 
 const ACCESS_TOKEN = process.env.COVEN_CAVE_ACCESS_TOKEN ?? "";
-const ACCESS_COOKIE = "coven_access_token";
+const ACCESS_COOKIE = ACCESS_TOKEN_COOKIE;
 
 type PtySession = {
   pty: import("node-pty").IPty;
@@ -30,14 +36,54 @@ function getTokenFromCookie(header: string | undefined): string {
   return "";
 }
 
-function isAuthorized(req: IncomingMessage): boolean {
-  if (!ACCESS_TOKEN) return true;
+function hasAccessToken(req: IncomingMessage): boolean {
+  if (!ACCESS_TOKEN) return false;
 
   const cookie = getTokenFromCookie(req.headers.cookie);
   if (cookie === ACCESS_TOKEN) return true;
 
   const auth = req.headers.authorization ?? "";
   return auth.startsWith("Bearer ") && auth.slice("Bearer ".length) === ACCESS_TOKEN;
+}
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function isLoopbackAddress(value: string | undefined): boolean {
+  if (!value) return false;
+  if (value === "::1" || value === "127.0.0.1") return true;
+  if (value.startsWith("::ffff:")) return value.slice("::ffff:".length) === "127.0.0.1";
+  return false;
+}
+
+function isLocalUpgrade(req: IncomingMessage): boolean {
+  return (
+    isLoopbackHost(headerValue(req.headers.host) ?? null) &&
+    isLoopbackAddress(req.socket.remoteAddress)
+  );
+}
+
+function requestOrigin(req: IncomingMessage): string | null {
+  const host = headerValue(req.headers.host);
+  if (!host) return null;
+  const encrypted = Boolean((req.socket as typeof req.socket & { encrypted?: boolean }).encrypted);
+  const proto = headerValue(req.headers["x-forwarded-proto"]) ?? (encrypted ? "https" : "http");
+  const firstProto = proto.split(",", 1)[0];
+  return `${firstProto.trim() || "http"}://${host}`;
+}
+
+function isAllowedBrowserSource(req: IncomingMessage): boolean {
+  const expectedOrigin = requestOrigin(req);
+  if (!expectedOrigin) return false;
+  return (
+    isAllowedRequestSource(headerValue(req.headers.origin) ?? null, expectedOrigin) &&
+    isAllowedRequestSource(headerValue(req.headers.referer) ?? null, expectedOrigin)
+  );
+}
+
+function isAuthorized(req: IncomingMessage): boolean {
+  return (hasAccessToken(req) || isLocalUpgrade(req)) && isAllowedBrowserSource(req);
 }
 
 function defaultShell(): string {
@@ -193,7 +239,7 @@ function handlePtyConnection(
   ws.on("message", (data) => onWsMessage(threadId, data));
   ws.on("close", () => {
     const session = sessions.get(threadId);
-    if (session?.ws !== ws) return;
+    if (!session || session.ws !== ws) return;
     sessions.delete(threadId);
     try {
       session.pty.kill();
@@ -204,7 +250,7 @@ function handlePtyConnection(
 }
 
 const dev = process.env.NODE_ENV !== "production";
-const hostname = process.env.HOSTNAME ?? "0.0.0.0";
+const hostname = process.env.HOST ?? "127.0.0.1";
 const port = Number.parseInt(process.env.PORT ?? "3000", 10);
 
 const app = next({ dev, hostname, port });

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -8,8 +8,14 @@ const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.me
 assert.match(src, /new WebSocketServer\(\{ noServer: true \}\)/, "server owns a noServer WebSocket upgrade handler");
 assert.match(src, /pathname !== "\/api\/pty-ws"/, "server only handles /api/pty-ws upgrades");
 assert.match(src, /COVEN_CAVE_ACCESS_TOKEN/, "server checks sidecar access token");
-assert.match(src, /coven_access_token/, "server accepts the same access cookie as REST middleware");
+assert.doesNotMatch(src, /if \(!ACCESS_TOKEN\) return true/, "missing access token must not authorize every WebSocket upgrade");
+assert.match(src, /isLocalUpgrade\(req\)/, "unauthenticated PTY upgrades are restricted to local loopback callers");
+assert.match(src, /isAllowedBrowserSource\(req\)/, "PTY upgrades enforce browser Origin/Referer checks");
+assert.match(src, /isLoopbackAddress\(req\.socket\.remoteAddress\)/, "local PTY upgrades verify the peer address, not only the Host header");
+assert.match(src, /ACCESS_TOKEN_COOKIE/, "server accepts the same access cookie as REST middleware");
 assert.match(src, /Bearer /, "server accepts bearer auth for non-cookie clients");
+assert.match(src, /isAllowedRequestSource/, "server reuses the proxy source-origin guard for WebSocket upgrades");
+assert.match(src, /const hostname = process\.env\.HOST \?\? "127\.0\.0\.1"/, "server binds loopback by default");
 assert.match(src, /pty\.spawn\(defaultShell\(\),\s*defaultShellArgs\(\)/, "server hardcodes shell and args");
 assert.doesNotMatch(src, /query\.command|query\.args|query\.env/, "renderer must not supply process authority through query params");
 assert.match(src, /statSync\(raw\)/, "projectRoot is stat-validated before use as cwd");


### PR DESCRIPTION
### Motivation
- Close a critical unauthenticated remote command execution path exposed by the custom `/api/pty-ws` WebSocket upgrade handler which previously allowed any upgrade when `COVEN_CAVE_ACCESS_TOKEN` was unset.
- Preserve PTY functionality for legitimate local development and sidecar-authenticated clients while preventing network- or cross-origin attackers from reaching a spawned shell.

### Description
- Replace permissive token logic with a conservative gate that requires either a valid sidecar access token or a local loopback upgrade, and also enforces browser `Origin`/`Referer` checks by reusing the existing proxy source-origin helpers (`isAllowedRequestSource`/`isLoopbackHost`).
- Use the shared access cookie constant (`ACCESS_TOKEN_COOKIE`) instead of a hardcoded cookie name and keep bearer-token support for non-cookie clients.
- Restrict unauthenticated upgrades to genuine loopback connections by validating both the Host header and the peer address, and compute an expected origin for `Origin`/`Referer` checks.
- Default the server bind host to loopback via `HOST ?? "127.0.0.1"` (instead of `HOSTNAME`/`0.0.0.0`) to avoid exposing the PTY on the LAN by default.
- Small robustness fix: tighten session close / null checks in the WS close handler.
- Update `src/server-pty-ws.test.ts` assertions to pin the hardened behavior and to ensure the server code reuses the proxy origin guards.

### Testing
- Ran `node --experimental-strip-types src/server-pty-ws.test.ts` and `node --experimental-strip-types src/proxy-behavior.test.ts`, both completed successfully.
- Ran `git diff --check` with no issues reported.
- Attempted `pnpm exec tsc --noEmit`, which could not complete in the environment due to missing module/type resolutions for `ws` and `node-pty` (local dev dependency availability); this is an environment/install issue rather than a code semantics failure.
- `pnpm install --frozen-lockfile` was attempted but blocked by the environment registry (403 fetching `ws@8.21.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a666c66548327b789909ffff9dbed)