### PR TITLE
fix: constrain skill preview file reads

### DIFF
--- a/src/app/api/skills/file/route.ts
+++ b/src/app/api/skills/file/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
-import { readFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { open } from "node:fs/promises";
 import path from "node:path";
-import { isAllowedSkillFilePath } from "@/lib/server/skill-file-paths";
+import { isAllowedSkillFilePath, MAX_SKILL_FILE_PREVIEW_BYTES } from "@/lib/server/skill-file-paths";
 
 export const dynamic = "force-dynamic";
 
@@ -24,12 +25,21 @@ export async function GET(req: Request) {
   const candidate = target.toLowerCase().endsWith(".md")
     ? target
     : path.join(target, "SKILL.md");
-  if (!isAllowedSkillFilePath(candidate)) {
+  if (!(await isAllowedSkillFilePath(candidate))) {
     return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
   }
   let text: string;
   try {
-    text = await readFile(candidate, "utf8");
+    const file = await open(candidate, constants.O_RDONLY | constants.O_NOFOLLOW);
+    try {
+      const targetStat = await file.stat();
+      if (targetStat.size > MAX_SKILL_FILE_PREVIEW_BYTES) {
+        return NextResponse.json({ ok: false, error: "file too large" }, { status: 413 });
+      }
+      text = await file.readFile("utf8");
+    } finally {
+      await file.close();
+    }
   } catch (err) {
     return NextResponse.json(
       { ok: false, error: err instanceof Error ? err.message : "read failed" },

--- a/src/lib/server/skill-file-paths.test.ts
+++ b/src/lib/server/skill-file-paths.test.ts
@@ -1,69 +1,101 @@
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
-import { isAllowedSkillFilePath } from "./skill-file-paths.ts";
+import { isAllowedSkillFilePath, MAX_SKILL_FILE_PREVIEW_BYTES } from "./skill-file-paths.ts";
 
-const home = "/home/witch";
+const home = await mkdtemp(path.join(tmpdir(), "coven-skill-paths-"));
+
+async function touch(relativePath: string, contents = "# preview\n") {
+  const fullPath = path.join(home, relativePath);
+  await mkdir(path.dirname(fullPath), { recursive: true });
+  await writeFile(fullPath, contents);
+  return fullPath;
+}
+
+const claudeSkill = await touch(path.join(".claude", "skills", "deep-research", "SKILL.md"));
+const covenSkill = await touch(path.join(".coven", "skills", "foo", "SKILL.md"));
+const claudeInstructions = await touch(path.join(".claude", "CLAUDE.md"));
+const codexInstructions = await touch(path.join(".codex", "AGENTS.md"));
+const nonMarkdown = await touch(path.join(".claude", "skills", "x", "run.sh"));
+const privateMarkdown = await touch(path.join(".claude", "private-not-a-skill.md"));
+const outsideMarkdown = await touch(path.join("secrets", "notes.md"));
+const prefixSibling = await touch(path.join(".claude-evil", "SKILL.md"));
+const symlinkTarget = await touch(path.join("secrets", "outside-secret.md"), "secret\n");
+const symlinkPath = path.join(home, ".claude", "skills", "leaky", "SKILL.md");
+await mkdir(path.dirname(symlinkPath), { recursive: true });
+await symlink(symlinkTarget, symlinkPath);
 
 // Skills live under the harness roots as SKILL.md files.
 assert.equal(
-  isAllowedSkillFilePath(path.join(home, ".claude", "skills", "deep-research", "SKILL.md"), home),
+  await isAllowedSkillFilePath(claudeSkill, home),
   true,
   "a SKILL.md under ~/.claude/skills is allowed",
 );
 assert.equal(
-  isAllowedSkillFilePath(path.join(home, ".coven", "skills", "foo", "SKILL.md"), home),
+  await isAllowedSkillFilePath(covenSkill, home),
   true,
   "a SKILL.md under ~/.coven/skills is allowed",
 );
 
-// Harness instructions files (CLAUDE.md / AGENTS.md) are markdown under a root.
+// Harness instructions files (CLAUDE.md / AGENTS.md) are allowed under roots.
 assert.equal(
-  isAllowedSkillFilePath(path.join(home, ".claude", "CLAUDE.md"), home),
+  await isAllowedSkillFilePath(claudeInstructions, home),
   true,
   "harness instructions markdown under a root is allowed",
 );
 assert.equal(
-  isAllowedSkillFilePath(path.join(home, ".codex", "AGENTS.md"), home),
+  await isAllowedSkillFilePath(codexInstructions, home),
   true,
   "codex instructions markdown is allowed",
 );
 
-// Non-markdown is rejected — only skill docs are previewable.
+// Non-markdown and arbitrary markdown are rejected — only skill docs are previewable.
 assert.equal(
-  isAllowedSkillFilePath(path.join(home, ".claude", "skills", "x", "run.sh"), home),
+  await isAllowedSkillFilePath(nonMarkdown, home),
   false,
   "non-markdown files are rejected",
+);
+assert.equal(
+  await isAllowedSkillFilePath(privateMarkdown, home),
+  false,
+  "arbitrary markdown under a harness root is rejected",
 );
 
 // Out-of-tree paths are rejected even when markdown.
 assert.equal(
-  isAllowedSkillFilePath(path.join(home, "secrets", "notes.md"), home),
+  await isAllowedSkillFilePath(outsideMarkdown, home),
   false,
   "markdown outside the allow-listed roots is rejected",
 );
 assert.equal(
-  isAllowedSkillFilePath("/etc/passwd", home),
+  await isAllowedSkillFilePath("/etc/passwd", home),
   false,
   "absolute system paths are rejected",
 );
 
 // Traversal cannot escape an allowed root.
 assert.equal(
-  isAllowedSkillFilePath(path.join(home, ".claude", "skills", "..", "..", ".ssh", "id_rsa.md"), home),
+  await isAllowedSkillFilePath(path.join(home, ".claude", "skills", "..", "..", ".ssh", "id_rsa.md"), home),
   false,
   "`..` traversal that escapes the home roots is rejected",
 );
-assert.equal(
-  isAllowedSkillFilePath("", home),
-  false,
-  "empty path is rejected",
-);
+assert.equal(await isAllowedSkillFilePath("", home), false, "empty path is rejected");
 
 // A sibling directory that merely shares a prefix must not pass containment.
 assert.equal(
-  isAllowedSkillFilePath(path.join(home, ".claude-evil", "SKILL.md"), home),
+  await isAllowedSkillFilePath(prefixSibling, home),
   false,
   "a prefix-sharing sibling root (.claude-evil) must not pass containment",
 );
+
+// Symlinks are rejected before readFile can follow them out of an allowed root.
+assert.equal(
+  await isAllowedSkillFilePath(symlinkPath, home),
+  false,
+  "symlinked skill files are rejected",
+);
+
+assert.equal(MAX_SKILL_FILE_PREVIEW_BYTES, 512 * 1024, "skill previews have a bounded size");
 
 console.log("skill-file-paths.test.ts: ok");

--- a/src/lib/server/skill-file-paths.ts
+++ b/src/lib/server/skill-file-paths.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { homedir } from "node:os";
+import { lstat, realpath } from "node:fs/promises";
 
 /**
  * Allow-list for the Capabilities skill-preview reader (/api/skills/file).
@@ -10,25 +11,45 @@ import { homedir } from "node:os";
  * path MUST be constrained to the well-known harness/skill roots under $HOME —
  * otherwise the route is an arbitrary-file-read primitive.
  *
- * The barrier is the inline `path.resolve` + containment check below: the
- * resolved candidate must live within one of the allow-listed roots and carry a
- * `.md` extension. A traversal-laden or out-of-tree path fails containment and
- * yields `false`, so the caller returns 403 and the UI falls back to the
- * scanned description/excerpt.
+ * The guard rejects symlinks, resolves both the candidate and root through the
+ * filesystem, and only allows expected instruction/skill filenames. This keeps
+ * the preview endpoint from exposing arbitrary markdown or symlink targets from
+ * broad harness directories.
  */
 const SKILL_ROOT_SUBPATHS = [".claude", ".coven", ".codex", ".cursor", ".gemini"];
+const ALLOWED_SKILL_FILE_NAMES = new Set(["SKILL.md", "CLAUDE.md", "AGENTS.md"]);
+
+export const MAX_SKILL_FILE_PREVIEW_BYTES = 512 * 1024;
 
 function isWithinRoot(resolved: string, root: string): boolean {
   return resolved === root || resolved.startsWith(root + path.sep);
 }
 
-export function isAllowedSkillFilePath(fullPath: string, home = homedir()): boolean {
-  if (!fullPath) return false;
-  const resolved = path.resolve(/* turbopackIgnore: true */ fullPath);
-  // Only markdown files are previewable — skills and harness instructions are
-  // markdown; anything else (plugin binaries, configs) is not a skill doc.
-  if (path.extname(resolved).toLowerCase() !== ".md") return false;
-  return SKILL_ROOT_SUBPATHS.some((sub) =>
-    isWithinRoot(resolved, path.resolve(/* turbopackIgnore: true */ path.join(home, sub))),
-  );
+export function isAllowedSkillFileName(fullPath: string): boolean {
+  return ALLOWED_SKILL_FILE_NAMES.has(path.basename(fullPath));
+}
+
+export async function isAllowedSkillFilePath(fullPath: string, home = homedir()): Promise<boolean> {
+  if (!fullPath || !isAllowedSkillFileName(fullPath)) return false;
+
+  let candidateStat;
+  let candidateRealPath: string;
+  try {
+    candidateStat = await lstat(fullPath);
+    if (candidateStat.isSymbolicLink() || !candidateStat.isFile()) return false;
+    candidateRealPath = await realpath(fullPath);
+  } catch {
+    return false;
+  }
+
+  for (const sub of SKILL_ROOT_SUBPATHS) {
+    try {
+      const rootRealPath = await realpath(path.join(home, sub));
+      if (isWithinRoot(candidateRealPath, rootRealPath)) return true;
+    } catch {
+      // Missing harness roots are not previewable roots.
+    }
+  }
+
+  return false;
 }


### PR DESCRIPTION
### Motivation
- The skill-preview endpoint allowed reading any `.md` under broad dot-directories and followed symlinks, exposing non-skill markdown and symlinked secrets. This needed tightening to avoid arbitrary file disclosure.

### Description
- Restrict previewable filenames to the expected instruction/skill files by allowing only `SKILL.md`, `CLAUDE.md`, and `AGENTS.md` via `isAllowedSkillFileName` in `src/lib/server/skill-file-paths.ts`.
- Harden path checks by rejecting symlinks with `lstat`, resolving filesystem real paths with `realpath`, and verifying containment against real harness roots under `$HOME` in `isAllowedSkillFilePath`.
- Add a preview size bound `MAX_SKILL_FILE_PREVIEW_BYTES = 512 * 1024` and enforce it in the API before reading.
- Update the API handler `GET /api/skills/file` to `await` the hardened guard, open files with `O_NOFOLLOW` via `open()` (to avoid following symlinks), check `stat().size` and return `413` if too large, read with the opened handle, and close the handle safely.
- Add/extend unit tests in `src/lib/server/skill-file-paths.test.ts` to exercise allowed filenames, rejection of arbitrary markdown under harness roots, prefix-sibling containment, symlink rejection, and the size-constant presence.

### Testing
- Ran typecheck with `pnpm exec tsc --noEmit` and it completed successfully.
- Ran the new unit test with `node --experimental-strip-types src/lib/server/skill-file-paths.test.ts` and it passed (`skill-file-paths.test.ts: ok`).
- Ran API route contracts with `node --experimental-strip-types src/app/api/api-contracts.test.ts` and route contracts passed (`api-contracts.test.ts: 90 route contracts passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f77c50a0c8327bbb94d3ea333488e)