### PR TITLE
fix(release): scope updater signing key to signing steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,11 +82,11 @@ jobs:
             arch_suffix: aarch64
           - platform: ubuntu-22.04
             label: Linux (AppImage)
-            args: "--bundles appimage"
+            args: '--bundles appimage --config ''{"bundle":{"createUpdaterArtifacts":false}}'''
             arch_suffix: ""
           - platform: windows-latest
             label: Windows (MSI)
-            args: "--bundles msi"
+            args: '--bundles msi --config ''{"bundle":{"createUpdaterArtifacts":false}}'''
             arch_suffix: ""
 
     runs-on: ${{ matrix.platform }}
@@ -221,11 +221,6 @@ jobs:
         uses: tauri-apps/tauri-action@1ddc7b49b13c3038297360482fcb3e058764d7c9 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Sign the updater artifacts (createUpdaterArtifacts in tauri.conf.json).
-          # Linux/Windows .sig files are uploaded next to the AppImage/MSI; the
-          # latest.json aggregation job composes the manifest from them.
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: ${{ env.RELEASE_TAG }}
           releaseName: "CovenCave ${{ env.RELEASE_TAG }}"
@@ -236,6 +231,34 @@ jobs:
           # here would clobber the manifest with a single platform.
           includeUpdaterJson: false
           args: ${{ matrix.args }}
+
+      - name: Sign Linux/Windows updater artifact
+        if: >-
+          (
+            matrix.platform == 'ubuntu-22.04' &&
+            (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'linux')
+          ) ||
+          (
+            matrix.platform == 'windows-latest' &&
+            (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'windows')
+          )
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          mapfile -t artifacts < <(find src-tauri/target/release/bundle -type f \( -name '*.AppImage' -o -name '*.msi' -o -name '*.msi.zip' -o -name '*.nsis.zip' -o -name '*-setup.exe' \) | sort)
+          if [ "${#artifacts[@]}" -eq 0 ]; then
+            echo "::error::No Linux/Windows updater artifact found to sign"
+            exit 1
+          fi
+          for artifact in "${artifacts[@]}"; do
+            echo "Signing updater artifact: $artifact"
+            pnpm exec tauri signer sign "$artifact"
+            gh release upload "$RELEASE_TAG" "${artifact}.sig" --clobber
+          done
 
       - name: Build macOS DMG with custom release script
         if: >-

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -208,8 +208,10 @@ env \
   -u NOTARY_APPLE_ID \
   -u NOTARY_APPLE_PASSWORD \
   -u NOTARY_TEAM_ID \
+  -u TAURI_SIGNING_PRIVATE_KEY \
+  -u TAURI_SIGNING_PRIVATE_KEY_PASSWORD \
   APPLE_SIGNING_IDENTITY="$SIGNING_IDENTITY" \
-  pnpm tauri build --bundles app
+  pnpm tauri build --bundles app --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
 APP_PATH=$(find "$BUILD_DIR/macos" -name "${APP_NAME}.app" -type d -maxdepth 2 | head -n1)
 if [ -z "$APP_PATH" ] || [ ! -d "$APP_PATH" ]; then


### PR DESCRIPTION
### Motivation
- The Tauri updater private key was injected into broad release build steps, exposing it to `beforeBuildCommand` scripts and build-time dependencies that can read environment variables.
- A compromised build-time dependency or malicious build script could exfiltrate the long-lived signing key, breaking the updater trust boundary.
- The signing key is only needed for a narrow post-build signing step, so it should not be present during general application build work.

### Description
- Removed `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` from the broad `tauri-action` environment in `.github/workflows/release.yml` so the main Linux/Windows build runs without the updater secret.
- Disabled generation of updater artifacts during main builds by adding `--config '{"bundle":{"createUpdaterArtifacts":false}}'` to the Linux/Windows `tauri` build `args` and to the macOS `pnpm tauri build` invocation.
- Added a new, narrow `Sign Linux/Windows updater artifact` workflow step that receives the updater secrets, locates built artifacts under `src-tauri/target/release/bundle`, runs `pnpm exec tauri signer sign` on each artifact, and uploads the `.sig` files to the release.
- Updated `scripts/release.sh` to strip `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` from the `pnpm tauri build` subprocess environment and to run the build with `--config` to avoid producing updater artifacts; the existing later signing of the final notarized `.app.tar.gz` remains unchanged.

### Testing
- Ran a syntax check on the release script with `bash -n scripts/release.sh`, which succeeded.
- Validated the workflow YAML loads with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`, which succeeded.
- Ran `git diff --check` to ensure no accidental whitespace/errors, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e4d7557108327aa904c535ccf5177)