### PR TITLE
fix(terminal): verify PTY websocket loopback by peer address

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,6 +1,7 @@
 import { readFileSync, statSync } from "node:fs";
 import { createServer, type IncomingMessage } from "node:http";
 import { createRequire } from "node:module";
+import { isIP } from "node:net";
 import { parse } from "node:url";
 
 import next from "next";
@@ -73,13 +74,12 @@ function getTokenFromCookie(header: string | undefined): string {
   return "";
 }
 
-// Mirrors isLoopbackHost in src/proxy-helpers.ts (host header, port stripped).
-function isLoopbackHostHeader(host: string | undefined): boolean {
-  if (!host) return false;
-  const hostname = host.startsWith("[")
-    ? host.slice(1, host.indexOf("]"))
-    : host.split(":")[0];
-  return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1";
+function isLoopbackRemoteAddress(address: string | undefined): boolean {
+  if (!address) return false;
+  if (address === "::1") return true;
+
+  const ipv4 = address.startsWith("::ffff:") ? address.slice("::ffff:".length) : address;
+  return isIP(ipv4) === 4 && ipv4.startsWith("127.");
 }
 
 function isAuthorized(req: IncomingMessage): boolean {
@@ -91,13 +91,10 @@ function isAuthorized(req: IncomingMessage): boolean {
   const supplied = cookie || bearer;
   // A supplied credential is always verified, even on loopback.
   if (supplied) return supplied === ACCESS_TOKEN;
-  // No credential: loopback connections are the local app itself — the
-  // mobile-access token gates remote (Tailscale) entry, which arrives with a
-  // tailnet Host header even though the socket is proxied via loopback.
-  // Mirrors shouldRequireMobileAccessCredential (src/proxy-helpers.ts,
-  // 9d0001c); without this, every desktop-webview terminal upgrade 401'd the
-  // moment the Tauri shell exported COVEN_CAVE_ACCESS_TOKEN.
-  return isLoopbackHostHeader(req.headers.host);
+  // No credential: only a real loopback TCP peer is the local app itself.
+  // The Host header is client-controlled and must not grant the loopback
+  // exemption for remote clients that can reach an exposed server.
+  return isLoopbackRemoteAddress(req.socket.remoteAddress);
 }
 
 function isLoopbackHostname(hostname: string): boolean {

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -103,8 +103,13 @@ assert.match(
 );
 assert.match(
   src,
-  /return isLoopbackHostHeader\(req\.headers\.host\);/,
-  "credential-less loopback upgrades stay authorized",
+  /return isLoopbackRemoteAddress\(req\.socket\.remoteAddress\);/,
+  "credential-less upgrades require a real loopback TCP peer",
+);
+assert.doesNotMatch(
+  src,
+  /isLoopbackHostHeader\(req\.headers\.host\)|return isLoopbackHostHeader/,
+  "PTY websocket auth must not trust the client-controlled Host header for loopback",
 );
 
 const bridge = readFileSync(new URL("./lib/pty-ws-bridge.ts", import.meta.url), "utf8");


### PR DESCRIPTION
### Motivation
- The PTY websocket upgrade allowed credential-less access when the `Host` header looked loopback, but the `Host` header is client-controlled and can be spoofed, enabling remote unauthenticated shells. 
- Production servers may bind `0.0.0.0`, so trusting the `Host` header grants attackers remote PTY access when an access token is present.

### Description
- Replace the `Host`-header loopback check with a TCP peer check by adding `isLoopbackRemoteAddress(req.socket.remoteAddress)` and importing `isIP` from `node:net` to safely detect IPv4, IPv6, and IPv4-mapped loopback peers. 
- Keep existing credential semantics: supplied credentials (`cookie` or `Bearer`) are still always verified before applying the loopback exemption. 
- Remove reliance on `isLoopbackHostHeader(req.headers.host)` for PTY websocket authorization and update the regression guard in `src/server-pty-ws.test.ts` to assert the new `req.socket.remoteAddress` check and ensure the host-header-based helper is not present. 

### Testing
- Ran the server unit/regression check with `node --experimental-strip-types src/server-pty-ws.test.ts` and it passed. 
- Ran type checking with `pnpm typecheck` (`tsc --noEmit`) and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c56a290cc8327bd30b7dd51d6d911)