### PR TITLE
fix(proxy): require mobile credential despite loopback Host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,7 +238,7 @@ Chats that persist and a workflow canvas you can rearrange by hand.
 - **Chat conversations no longer fork on resumed turns** — continued turns now resume in the conversation's original working directory (harness session stores are cwd-scoped) and keep a stable cave-owned conversation id while the harness's per-resume session id is tracked internally. Previously each continued turn could lose project context and spawn a new sidebar session.
 - **Workflow canvas edges render** — step nodes gained explicit connection handles (React Flow error #008), with a toggleable themed minimap.
 - **Machines without Node or Git are covered** — Node ships inside the app bundle (the release now refuses to build without it); Git became an advisory setup check with platform-aware install hints, missing-git API errors are actionable, and the README gains a dependency table.
-- **Friendly error when the coven CLI is missing**, and loopback requests skip the mobile-access gate.
+- **Friendly error when the coven CLI is missing**, and mobile-access token checks no longer trust spoofable `Host` headers.
 
 ### Changed
 - **Workflow studio polish** — role attach rows align as fixed columns with right-pinned familiar tags; all studio scroll regions use thin dark scrollbars.

--- a/docs/mobile-tailscale.md
+++ b/docs/mobile-tailscale.md
@@ -56,7 +56,7 @@ pnpm mobile:tailscale:invite
 
 The agent should verify that the invite redirects, stores the cookie, and loads the app shell before reporting success. It should not paste the raw invite into chat by default. If a fresh invite expires while you are away from the laptop, ask the agent to run `pnpm mobile:tailscale:invite`; the command refreshes the invite without restarting the dev server.
 
-Do not open the Serve URL without the invite query. When `COVEN_CAVE_ACCESS_TOKEN` is set, CovenCave rejects non-loopback requests until a valid invite is supplied by query, cookie, bearer header, or the equivalent internal request path. Loopback browser requests still load so a local/new-install shell that inherits the token does not lock out the desktop app.
+Do not open the Serve URL without the invite query. When `COVEN_CAVE_ACCESS_TOKEN` is set, CovenCave rejects requests until a valid signed `coven_access_token` invite is supplied by query, cookie, bearer header, or the equivalent internal request path. A loopback-looking `Host` header is not treated as proof of a local connection because remote clients can spoof it.
 
 Independent of the mobile token, every `/api/*` request also has to satisfy loopback/same-origin/referer/content-type checks — those guards apply in plain browser dev too, not just in bundled mode. A valid mobile token lets Tailscale Serve satisfy the host/origin/referer gates while it proxies to the loopback dev server; anything else (LAN scanners, accidental `-H 0.0.0.0`, mismatched origins without the token) hits a 403 before any handler runs.
 

--- a/src/proxy-behavior.test.ts
+++ b/src/proxy-behavior.test.ts
@@ -211,13 +211,13 @@ assert.equal(
 // ─── shouldRequireMobileAccessCredential ──────────────────────────────────
 assert.equal(
   shouldRequireMobileAccessCredential("localhost:3000", false),
-  false,
-  "loopback startup should not require a mobile invite just because a token exists",
+  true,
+  "Host headers are spoofable and must not exempt requests from the mobile gate",
 );
 assert.equal(
   shouldRequireMobileAccessCredential("127.0.0.1:3000", false),
-  false,
-  "new local installs inheriting COVEN_CAVE_ACCESS_TOKEN must still load",
+  true,
+  "loopback-looking Host headers still require a valid invite",
 );
 assert.equal(
   shouldRequireMobileAccessCredential("cave.tailnet.example.ts.net", false),

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -104,10 +104,14 @@ export function isAllowedRequestSource(
 }
 
 export function shouldRequireMobileAccessCredential(
-  host: string | null,
-  hasSuppliedCredential: boolean,
+  _host: string | null,
+  _hasSuppliedCredential: boolean,
 ) {
-  return hasSuppliedCredential || !isLoopbackHost(host);
+  // The Host header is client-controlled, so it cannot prove that the actual
+  // TCP peer is loopback. When COVEN_CAVE_ACCESS_TOKEN is configured, require
+  // a valid mobile credential for every request unless a future caller can pass
+  // a non-spoofable remote socket address into this decision.
+  return true;
 }
 
 export function bearerFromReferer(value: string | null, expectedOrigin: string) {


### PR DESCRIPTION
### Motivation
- The mobile access gate previously treated a `Host` header that looked like `localhost`/`127.0.0.1` as proof of a loopback peer, which is client-controlled and allows an attacker to spoof `Host` to bypass `COVEN_CAVE_ACCESS_TOKEN` protections.
- The intent of the change is to close this authentication bypass by requiring a valid mobile credential whenever `COVEN_CAVE_ACCESS_TOKEN` is configured, unless a future non-spoofable signal (e.g., verified remote socket address) is available.

### Description
- Change `shouldRequireMobileAccessCredential` to stop trusting the `Host` header and always require a mobile credential when `COVEN_CAVE_ACCESS_TOKEN` is configured by returning `true` in `src/proxy-helpers.ts`.
- Update behavior tests in `src/proxy-behavior.test.ts` to assert that `localhost`/`127.0.0.1` Host headers no longer exempt requests from the mobile gate.
- Update documentation in `docs/mobile-tailscale.md` and `CHANGELOG.md` to describe the stricter requirement for a signed `coven_access_token` invite and note that a loopback-looking `Host` header is not proof of a local connection.
- The change preserves existing credential verification and redirect/cookie behavior handled by `mobileAccessVerification` and `mobileAccessGate` in `src/proxy.ts`.

### Testing
- Ran `node --experimental-strip-types src/middleware.test.ts`, which passed and validated middleware assertions about host/origin/referer and mobile token behavior.
- Ran `node --experimental-strip-types src/proxy-behavior.test.ts`, which printed `proxy-behavior.test.ts: ok` and passed after updating assertions.
- Ran `pnpm typecheck` (`tsc --noEmit`), which completed successfully with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c4f2395288327bad86e5195b6550c)