### PR TITLE
fix(mobile): avoid leaking Tailscale access token

### DIFF
--- a/scripts/mobile-tailscale.sh
+++ b/scripts/mobile-tailscale.sh
@@ -58,6 +58,28 @@ backend_url() {
   fi
 }
 
+recorded_server_is_running() {
+  if [ ! -s "$PID_FILE" ]; then
+    return 1
+  fi
+
+  pid="$(cat "$PID_FILE")"
+  case "$pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+
+  kill -0 "$pid" >/dev/null 2>&1
+}
+
+require_recorded_server() {
+  if recorded_server_is_running; then
+    return 0
+  fi
+
+  echo "Refusing to contact an untracked server on ${HOST}:${PORT}. Run: pnpm mobile:tailscale:stop && pnpm mobile:tailscale" >&2
+  exit 1
+}
+
 tailscale_cmd() {
   node - "$TAILSCALE_TIMEOUT_MS" "$@" <<'NODE'
 const { spawnSync } = require("node:child_process");
@@ -210,13 +232,10 @@ start_next_server() {
       echo "CovenCave native mobile server is already listening on ${HOST}:${PORT}."
       return 0
     fi
-    if [ -n "${COVEN_CAVE_ACCESS_TOKEN:-}" ] || [ -s "$TOKEN_FILE" ]; then
-      load_or_create_token
-      echo "CovenCave mobile server is already listening on ${HOST}:${PORT}."
-      return 0
-    fi
-    echo "Refusing to publish an already-running server on ${HOST}:${PORT} without a stored mobile token." >&2
-    exit 1
+    require_recorded_server
+    load_or_create_token
+    echo "CovenCave mobile server is already listening on ${HOST}:${PORT}."
+    return 0
   fi
 
   if [ "${CAVE_MOBILE_NATIVE:-0}" != "1" ]; then
@@ -340,9 +359,25 @@ create_invite() {
     echo "CovenCave mobile server is not listening on ${HOST}:${PORT}. Run: pnpm mobile:tailscale" >&2
     exit 1
   fi
+  require_recorded_server
 
   node - "$HOST" "$PORT" "$ACCESS_TOKEN" "$INVITE_FILE" "$EXPIRES_FILE" <<'NODE'
+const crypto = require("node:crypto");
 const fs = require("node:fs");
+
+const CONTROL_TOKEN_TTL_MS = 2 * 60 * 1000;
+
+function base64Url(buffer) {
+  return Buffer.from(buffer).toString("base64url");
+}
+
+function createMobileAccessToken(secret) {
+  const expiresAt = Date.now() + CONTROL_TOKEN_TTL_MS;
+  const nonce = crypto.randomUUID();
+  const payload = `v1.${expiresAt}.${nonce}`;
+  const signature = crypto.createHmac("sha256", secret).update(payload).digest();
+  return `${payload}.${base64Url(signature)}`;
+}
 
 (async () => {
   const [host, port, accessToken, invitePath, expiresPath] = process.argv.slice(2);
@@ -353,7 +388,7 @@ const fs = require("node:fs");
   const res = await fetch(`${base}/api/mobile-handoff`, {
     method: "POST",
     headers: {
-      "authorization": `Bearer ${accessToken}`,
+      "authorization": `Bearer ${createMobileAccessToken(accessToken)}`,
       "content-type": "application/json",
     },
     body: JSON.stringify({ action: "start" }),

--- a/scripts/mobile-tailscale.test.mjs
+++ b/scripts/mobile-tailscale.test.mjs
@@ -31,6 +31,19 @@ test("mobile tailscale runner persists state for remote invite regeneration", ()
   assert.match(script, /chmod 600 "\$TOKEN_FILE"/);
 });
 
+test("mobile tailscale runner refuses untracked localhost listeners", () => {
+  assert.match(script, /recorded_server_is_running\(\)/);
+  assert.match(script, /require_recorded_server\(\)/);
+  assert.match(script, /Refusing to contact an untracked server/);
+  assert.match(script, /kill -0 "\$pid"/);
+});
+
+test("mobile tailscale invite flow does not send the raw persisted token", () => {
+  assert.match(script, /CONTROL_TOKEN_TTL_MS/);
+  assert.match(script, /createMobileAccessToken\(accessToken\)/);
+  assert.doesNotMatch(script, /Bearer \$\{accessToken\}/);
+});
+
 test("mobile tailscale runner keeps dev server alive after the wrapper exits", () => {
   assert.match(script, /tmux new-session -d/);
   assert.match(script, /nohup env COVEN_CAVE_ACCESS_TOKEN=/);

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -63,7 +63,7 @@ assert.match(sidecarBridgeSource, /window\.history\.replaceState/, "sidecar toke
 assert.match(sidecarMonitorSource, /useIsTauriDesktop/, "sidecar auth warning should only run for desktop Tauri");
 assert.doesNotMatch(sidecarMonitorSource, /Boolean\(window\.__TAURI_INTERNALS__\)/, "mobile Tauri should not be treated as a sidecar host");
 assert.match(mobileScriptSource, /tailscale_cmd serve --bg "\$TAILSCALE_BACKEND"/, "mobile script should publish the exact loopback backend it started");
-assert.match(mobileScriptSource, /"authorization": `Bearer \$\{accessToken\}`/, "mobile script should authenticate its local invite API request");
+assert.match(mobileScriptSource, /"authorization": `Bearer \$\{createMobileAccessToken\(accessToken\)\}`/, "mobile script should authenticate its local invite API request with a derived token");
 assert.match(nextConfigSource, /allowedDevOrigins:\s*\[[\s\S]*"\*\*\.ts\.net"/, "Next dev should allow Tailscale Serve origins for mobile browser access");
 assert.match(nextConfigSource, /devIndicators:\s*false/, "Next dev tools launcher should not intercept mobile bottom-tab taps");
 assert.match(mobileDocsSource, /signed (?:expiring )?invites?/, "mobile docs should describe the signed access token invite");


### PR DESCRIPTION
### Motivation
- Prevent disclosure of the persisted `COVEN_CAVE_ACCESS_TOKEN` to arbitrary local listeners when using the mobile Tailscale helper, which allowed a local attacker to capture a reusable legacy credential.
- Restore the prior safety model where the helper will not contact or publish to an already-bound localhost port unless that server was started and tracked by the helper.
- Preserve the mobile handoff UX (invite/start) while eliminating the high-risk behavior of posting the raw access secret to an unverified listener.

### Description
- Added `recorded_server_is_running()` and `require_recorded_server()` in `scripts/mobile-tailscale.sh` to ensure only the helper-tracked server PID is considered a valid listener; untracked listeners are refused with an explanatory error.
- Reworked the already-listening branch in `start_next_server()` to call `require_recorded_server()` before trusting a listener and to continue to load the token only for tracked servers.
- Modified the invite flow to send a short-lived signed control credential instead of the raw persisted token by adding an inline `createMobileAccessToken(secret)` implementation (TTL 2 minutes) and using `Bearer <signed-token>` when POSTing to `/api/mobile-handoff`.
- Added regression tests in `scripts/mobile-tailscale.test.mjs` to assert the presence of the recorded-server checks and to assert that the invite flow no longer sends `Bearer ${accessToken}` directly.

### Testing
- Ran the script unit checks with `node scripts/mobile-tailscale.test.mjs`, which passed (all tests OK).
- Performed a shell syntax check with `bash -n scripts/mobile-tailscale.sh`, which succeeded.
- Ran token verification tests with `node --experimental-strip-types src/lib/mobile-access-token.test.ts`, which passed.
- Executed the full mobile test suite via `pnpm test:mobile`, which completed with all mobile-related tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b1b4d5ee48327a1d96c9e4c14f34d)