### PR TITLE
fix(memory): block symlink escapes when reading memory files

### DIFF
--- a/src/app/api/memory/file/route.ts
+++ b/src/app/api/memory/file/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { readFile } from "node:fs/promises";
 import { redact } from "@/lib/redact";
-import { isAllowedMemoryFilePath } from "@/lib/server/memory-file-paths";
+import { resolveAllowedMemoryFilePath } from "@/lib/server/memory-file-paths";
 
 export const dynamic = "force-dynamic";
 
@@ -12,12 +12,13 @@ export async function GET(req: Request) {
   if (!target) {
     return NextResponse.json({ ok: false, error: "path required" }, { status: 400 });
   }
-  if (!isAllowedMemoryFilePath(target)) {
+  const allowedPath = await resolveAllowedMemoryFilePath(target);
+  if (!allowedPath) {
     return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
   }
   let raw: string;
   try {
-    raw = await readFile(target, "utf8");
+    raw = await readFile(/* turbopackIgnore: true */ allowedPath, "utf8");
   } catch (err) {
     return NextResponse.json(
       { ok: false, error: err instanceof Error ? err.message : "read failed" },

--- a/src/lib/server/memory-file-paths.ts
+++ b/src/lib/server/memory-file-paths.ts
@@ -1,5 +1,9 @@
-import { isMemoryFilePathAllowed } from "./memory-file-sources.ts";
+import { isMemoryFilePathAllowed, resolveAllowedMemoryFileReadPath } from "./memory-file-sources.ts";
 
 export function isAllowedMemoryFilePath(fullPath: string): boolean {
   return isMemoryFilePathAllowed(fullPath);
+}
+
+export async function resolveAllowedMemoryFilePath(fullPath: string): Promise<string | null> {
+  return resolveAllowedMemoryFileReadPath(fullPath);
 }

--- a/src/lib/server/memory-file-sources.test.ts
+++ b/src/lib/server/memory-file-sources.test.ts
@@ -1,9 +1,12 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   classifyMemoryFilePath,
   memoryFileSourcesForHome,
+  resolveAllowedMemoryFileReadPath,
 } from "./memory-file-sources.ts";
 
 const home = "/Users/val";
@@ -72,5 +75,41 @@ assert.equal(
   null,
   "unrelated local files should not be treated as memory API sources",
 );
+
+const tempRoot = await mkdtemp(path.join(tmpdir(), "coven-memory-paths-"));
+try {
+  const familiarMemory = path.join(tempRoot, ".openclaw", "workspace", "echo", "memory");
+  const secretOutside = path.join(tempRoot, "secret-outside.md");
+  const outsideDir = path.join(tempRoot, "outside-dir");
+  const safeMemory = path.join(familiarMemory, "safe.md");
+  const leak = path.join(familiarMemory, "leak.md");
+  const linkedDir = path.join(familiarMemory, "linked-dir");
+  const nestedLeak = path.join(linkedDir, "nested-leak.md");
+  await mkdir(familiarMemory, { recursive: true });
+  await mkdir(outsideDir, { recursive: true });
+  await writeFile(safeMemory, "safe memory");
+  await writeFile(secretOutside, "outside secret");
+  await writeFile(path.join(outsideDir, "nested-leak.md"), "nested outside secret");
+  await symlink(secretOutside, leak);
+  await symlink(outsideDir, linkedDir);
+
+  assert.equal(
+    await resolveAllowedMemoryFileReadPath(safeMemory, tempRoot),
+    await realpath(safeMemory),
+    "regular familiar memory files should resolve to readable real paths",
+  );
+  assert.equal(
+    await resolveAllowedMemoryFileReadPath(leak, tempRoot),
+    null,
+    "familiar memory symlinks must not resolve to files outside the memory root",
+  );
+  assert.equal(
+    await resolveAllowedMemoryFileReadPath(nestedLeak, tempRoot),
+    null,
+    "familiar memory files reached through symlinked directories must stay blocked",
+  );
+} finally {
+  await rm(tempRoot, { recursive: true, force: true });
+}
 
 console.log("memory-file-sources.test.ts: ok");

--- a/src/lib/server/memory-file-sources.ts
+++ b/src/lib/server/memory-file-sources.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { lstat, realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 
 export type MemorySourceKind = "coven-origin" | "external-harness" | "runtime";
@@ -31,6 +32,33 @@ export type MemoryFileClassification = {
 
 function isWithinRoot(resolved: string, root: string): boolean {
   return resolved === root || resolved.startsWith(root + path.sep);
+}
+
+async function realpathIfPresent(targetPath: string): Promise<string | null> {
+  try {
+    return await realpath(/* turbopackIgnore: true */ targetPath);
+  } catch {
+    return null;
+  }
+}
+
+async function isRealPathWithinAllowedRoot(targetPath: string, allowedRoot: string): Promise<boolean> {
+  const [realTarget, realRoot] = await Promise.all([
+    realpathIfPresent(targetPath),
+    realpathIfPresent(allowedRoot),
+  ]);
+  if (realTarget === null || realRoot === null) return false;
+  return isWithinRoot(realTarget, realRoot) && isWithinRoot(realTarget, path.resolve(allowedRoot));
+}
+
+function familiarAllowedRootPath(fullPath: string, classification: MemoryFileClassification): string | null {
+  if (!classification.familiarId) return null;
+  const familiarRoot = classification.rootPath;
+  const rel = path.relative(familiarRoot, path.resolve(/* turbopackIgnore: true */ fullPath));
+  const parts = rel.split(path.sep);
+  if (parts.length === 1 && parts[0] === "MEMORY.md") return path.join(familiarRoot, "MEMORY.md");
+  if (parts.length >= 2 && parts[0] === "memory") return path.join(familiarRoot, "memory");
+  return null;
 }
 
 function displayId(id: string): string {
@@ -161,4 +189,25 @@ export function classifyMemoryFilePath(fullPath: string, home = homedir()): Memo
 
 export function isMemoryFilePathAllowed(fullPath: string, home = homedir()): boolean {
   return classifyMemoryFilePath(fullPath, home) !== null;
+}
+
+export async function resolveAllowedMemoryFileReadPath(fullPath: string, home = homedir()): Promise<string | null> {
+  const classification = classifyMemoryFilePath(fullPath, home);
+  if (!classification) return null;
+
+  let fileStat;
+  try {
+    fileStat = await lstat(/* turbopackIgnore: true */ fullPath);
+  } catch {
+    return null;
+  }
+  if (!fileStat.isFile()) return null;
+
+  const allowedRoot = classification.familiarId
+    ? familiarAllowedRootPath(fullPath, classification)
+    : classification.rootPath;
+  if (!allowedRoot) return null;
+
+  if (!(await isRealPathWithinAllowedRoot(fullPath, allowedRoot))) return null;
+  return await realpath(/* turbopackIgnore: true */ fullPath);
 }


### PR DESCRIPTION
### Motivation
- A lexical allowlist for per-familiar memory paths could be bypassed by symlink escapes because `path.resolve()` does not resolve symlinks while `readFile` follows them. 
- The intent is to ensure any file we read for the memory API is actually located under the real (symlink-resolved) memory root before returning contents.

### Description
- Add a realpath-aware resolver `resolveAllowedMemoryFileReadPath` in `src/lib/server/memory-file-sources.ts` that uses `lstat`/`realpath` and `isRealPathWithinAllowedRoot` to validate reads against the real allowed root. 
- Constrain familiar reads to the familiar `MEMORY.md` or `memory/` root via `familiarAllowedRootPath` so only those sub-roots are permitted for familiar workspaces. 
- Expose an async wrapper `resolveAllowedMemoryFilePath` in `src/lib/server/memory-file-paths.ts` and change the memory file route `src/app/api/memory/file/route.ts` to call the resolver and read the resolved path instead of the original user-supplied path. 
- Add regression coverage to `src/lib/server/memory-file-sources.test.ts` for direct symlink escapes and symlinked-directory escapes while preserving regular familiar memory reads, and keep the existing synchronous lexical allowlist API for compatibility. 

### Testing
- Ran `pnpm test:api`, which executed the updated `memory-file-sources` tests and all API tests and they passed. 
- Ran `pnpm typecheck` (`tsc --noEmit`) and it completed successfully. 
- Added targeted assertions in `src/lib/server/memory-file-sources.test.ts` that verify symlink and symlinked-directory escapes are rejected and that regular familiar memory files still resolve to readable real paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27594c29948327831a029fbf7541bc)