### PR TITLE
feat(familiars): scrim + click-away on Studio drawer; honest dock create

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4140,6 +4140,24 @@ button:active > .edge-rail-chip {
    Familiar Studio drawer
    ──────────────────────────────────────────────── */
 
+.familiar-studio__scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 44;
+  background: var(--backdrop-scrim);
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: default;
+  animation: familiar-studio-fade 160ms var(--ease-decelerate, ease-out);
+}
+@keyframes familiar-studio-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .familiar-studio__scrim { animation: none; }
+}
 .familiar-studio__drawer {
   position: fixed;
   top: 0;

--- a/src/components/familiar-dock.tsx
+++ b/src/components/familiar-dock.tsx
@@ -39,6 +39,14 @@ export function FamiliarDock({
   onFamiliarScopeChange,
 }: Props) {
   const { openFamiliarStudio, openFamiliarStudioListView } = useFamiliarStudio();
+  // Familiars are daemon-owned — there is no cave-side create. "New familiar"
+  // routes to onboarding (the app's canonical create flow) via the same
+  // window-event bus the Workspace listens on (see `cave:onboarding-open`).
+  const fireCreateFamiliar = () => {
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent("cave:onboarding-open"));
+    }
+  };
   const rowRef = useRef<HTMLDivElement | null>(null);
   const overflowBtnRef = useRef<HTMLButtonElement | null>(null);
   const [popoverOpen, setPopoverOpen] = useState(false);
@@ -178,9 +186,9 @@ export function FamiliarDock({
         <button
           type="button"
           className="familiar-dock__add"
-          aria-label="Add familiar"
-          title="Add familiar"
-          onClick={() => openFamiliarStudioListView()}
+          aria-label="New familiar"
+          title="New familiar"
+          onClick={fireCreateFamiliar}
         >
           <Icon name="ph:plus-bold" width={12} aria-hidden />
         </button>
@@ -235,8 +243,8 @@ export function FamiliarDock({
             <PopoverSeparator />
             <div className="familiar-dock__pop-foot">
               <button type="button" className="familiar-dock__pop-btn familiar-dock__pop-btn--pri"
-                onClick={() => { openFamiliarStudioListView(); setPopoverOpen(false); }}>
-                <Icon name="ph:plus-bold" width={11} aria-hidden /> New
+                onClick={() => { fireCreateFamiliar(); setPopoverOpen(false); }}>
+                <Icon name="ph:plus-bold" width={11} aria-hidden /> New familiar
               </button>
               <button type="button" className="familiar-dock__pop-btn"
                 onClick={() => { openFamiliarStudioListView(); setPopoverOpen(false); }}>

--- a/src/components/familiar-studio.tsx
+++ b/src/components/familiar-studio.tsx
@@ -97,6 +97,8 @@ export function FamiliarStudio({ familiars }: Props) {
   // Open-for-id-that-no-longer-exists empty state.
   if (activeFamiliarId && !familiar) {
     return (
+      <>
+        <StudioScrim onClose={closeFamiliarStudio} />
       <aside
         role="dialog"
         aria-label="Familiar Studio"
@@ -112,10 +114,13 @@ export function FamiliarStudio({ familiars }: Props) {
           This familiar is no longer available.
         </div>
       </aside>
+      </>
     );
   }
 
   return (
+    <>
+      <StudioScrim onClose={closeFamiliarStudio} />
     <aside
       role="dialog"
       aria-label={`Familiar Studio${familiar ? ` — ${familiar.display_name}` : ""}`}
@@ -219,6 +224,26 @@ export function FamiliarStudio({ familiars }: Props) {
         </footer>
       </div>
     </aside>
+    </>
+  );
+}
+
+/**
+ * Dimming scrim behind the drawer. Adopts the app-wide `--backdrop-scrim`
+ * convention (see `.ui-modal-backdrop` / `.mobile-drawer-backdrop`) so the
+ * Studio reads as a modal surface and closes on outside click — matching every
+ * other drawer/modal in the app. Click-away + the existing Esc handler are the
+ * two dismiss paths; the X button is the third.
+ */
+function StudioScrim({ onClose }: { onClose: () => void }) {
+  return (
+    <button
+      type="button"
+      aria-label="Close Familiar Studio"
+      tabIndex={-1}
+      className="familiar-studio__scrim"
+      onClick={onClose}
+    />
   );
 }
 

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -255,6 +255,16 @@ export function Workspace() {
     return () => window.removeEventListener("cave:salem-open", openSalem);
   }, []);
 
+  // Cross-surface "create a familiar" bridge. The dock (and any deep surface
+  // that can't reach openOnboarding directly) announces intent and the
+  // Workspace opens onboarding — the app's canonical create-a-familiar flow,
+  // since familiars are daemon-owned and have no cave-side create path.
+  useEffect(() => {
+    const openCreate = () => setOnboardingOpen(true);
+    window.addEventListener("cave:onboarding-open", openCreate);
+    return () => window.removeEventListener("cave:onboarding-open", openCreate);
+  }, []);
+
   // Cross-surface navigation bridge: surfaces that don't own setMode (e.g. the
   // chat rail's nav block) announce a target mode and the Workspace switches to
   // it. Keeps those surfaces decoupled from the mode state owner.


### PR DESCRIPTION
## Why

Comprehensive review of **switching between** and **editing** familiars, toward the sleek/minimalist feel of Codex / ChatGPT / Claude Code. The surfaces are already mature, so this is targeted polish on the two genuine gaps I verified (not assumed) against the live code:

1. **The Familiar Studio drawer was the only drawer in the app with no backdrop** — no dimming, no click-outside-to-close. The app already has a `--backdrop-scrim` convention (`.ui-modal-backdrop`, `.mobile-drawer-backdrop`).
2. **The dock's create affordances were dishonest and redundant** — the `+` ("Add familiar") and the overflow popover's "New" both called `openFamiliarStudioListView()`, identical to "Manage", and created nothing. Familiars are daemon-owned (GET-only API); the app's real create path is onboarding (already used elsewhere via `onCreateFamiliar={openOnboarding}`).

## What changed

**Editing — Studio drawer (`familiar-studio.tsx`, `globals.css`)**
- Added a dimming scrim sibling that closes the drawer on outside click, using the house `--backdrop-scrim` token. Fade-in with a `prefers-reduced-motion` guard. Esc + X still work. Scrim `z-index: 44` sits just under the drawer's `45`.

**Switching — dock (`familiar-dock.tsx`, `workspace.tsx`)**
- New `cave:onboarding-open` window event (mirrors `cave:salem-open`); Workspace listens and opens onboarding.
- The dock `+` is relabeled **"New familiar"** and the popover footer's **"New familiar"** both fire it → the real create flow. Footer actions are now distinct and honest: **New familiar / Manage / Reorder** (Manage still opens the Studio list view).

## Deferred (out of scope — larger features)
Stubbed Settings→Familiars tab, orphaned "agents" nav mode, OpenClaw integration, permanent delete.

## Verification
- `pnpm test:app` green; `pnpm typecheck` + `pnpm build` clean.
- Playwright pass against a prod build: scrim dims the background and click-away closes the drawer; `+` ("New familiar") opens onboarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)