### PR TITLE
fix(familiar-dock): address review accessibility polish

### DIFF
--- a/src/components/familiar-dock.test.ts
+++ b/src/components/familiar-dock.test.ts
@@ -25,10 +25,12 @@ assert.match(src, /computeDockInlineCount/, "uses the overflow helper");
 assert.match(src, /ResizeObserver/, "measures the row width responsively");
 assert.match(src, /familiar-dock__overflow/, "renders the overflow button");
 assert.match(src, /overflowCount > 0/, "overflow button is conditional on hidden count");
+assert.match(src, /aria-haspopup="dialog"/, "overflow trigger matches the shared Popover dialog role");
 
 // Task 5: overflow + operations popover
 assert.match(src, /from "@\/components\/ui\/popover"/, "uses the shared popover");
 assert.match(src, /placeholder="Filter familiars…"/, "popover has a search field");
+assert.match(src, /className="familiar-dock__pop-search focus-ring-inset"/, "popover search keeps visible focus styling");
 assert.match(src, /Not shown in dock/, "popover groups overflow familiars");
 assert.match(src, /openFamiliarStudioListView\(\)/, "Manage opens the studio list");
 assert.match(src, /Reorder/, "footer exposes Reorder");
@@ -39,5 +41,10 @@ assert.match(src, /horizontalListSortingStrategy/, "horizontal sorting strategy"
 assert.match(src, /setFamiliarOrder\(arrayMove/, "persists reorder via setFamiliarOrder");
 assert.match(src, /useRovingTabIndex/, "roving tabindex for keyboard nav");
 assert.match(src, /orientation: "horizontal"/, "roving nav is horizontal");
+
+// Review polish: keyboard focus rings remain visible and accessible labels match actions.
+assert.match(src, /className=\{`familiar-dock__all focus-ring/, "All chip uses the shared focus ring");
+assert.match(src, /className=\{`familiar-dock__avatar focus-ring/, "dock avatars use the shared focus ring");
+assert.doesNotMatch(src, /aria-label=\{`Reorder \$\{familiar\.display_name\}`\}/, "sortable avatar label should not claim click-only reorder");
 
 console.log("familiar-dock.test.ts OK");

--- a/src/components/familiar-dock.tsx
+++ b/src/components/familiar-dock.tsx
@@ -106,7 +106,7 @@ export function FamiliarDock({
       <div className="familiar-dock__row" ref={rowRef} role="toolbar" aria-label="Familiar scope">
         <button
           type="button"
-          className={`familiar-dock__all${activeFamiliarId == null ? " familiar-dock__all--active" : ""}`}
+          className={`familiar-dock__all focus-ring${activeFamiliarId == null ? " familiar-dock__all--active" : ""}`}
           aria-pressed={activeFamiliarId == null}
           onClick={() => onFamiliarScopeChange(null)}
           title="All familiars"
@@ -145,7 +145,7 @@ export function FamiliarDock({
                 type="button"
                 data-id={f.id}
                 style={{ ["--familiar-accent" as string]: f.color } as CSSProperties}
-                className={`familiar-dock__avatar${active ? " familiar-dock__avatar--active" : ""}`}
+                className={`familiar-dock__avatar focus-ring${active ? " familiar-dock__avatar--active" : ""}`}
                 aria-pressed={active}
                 aria-label={`Filter by ${f.display_name}${needsReply ? " — reply needed" : ""}`}
                 title={`${f.display_name} · ${presence.label}`}
@@ -166,7 +166,7 @@ export function FamiliarDock({
             ref={overflowBtnRef}
             className="familiar-dock__overflow"
             aria-label={`Show ${overflowCount} more familiars`}
-            aria-haspopup="menu"
+            aria-haspopup="dialog"
             aria-expanded={popoverOpen}
             onClick={() => setPopoverOpen((o) => !o)}
           >
@@ -198,7 +198,7 @@ export function FamiliarDock({
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Filter familiars…"
             aria-label="Filter familiars"
-            className="familiar-dock__pop-search"
+            className="familiar-dock__pop-search focus-ring-inset"
             autoFocus
           />
           <PopoverBody>
@@ -280,14 +280,14 @@ function SortableDockAvatar({
       <button
         type="button"
         data-id={familiar.id}
-        className={`familiar-dock__avatar${active ? " familiar-dock__avatar--active" : ""}`}
+        className={`familiar-dock__avatar focus-ring${active ? " familiar-dock__avatar--active" : ""}`}
         title={`${familiar.display_name} · ${presence.label}`}
         onClick={onSelect}
         onContextMenu={(e) => { e.preventDefault(); onOpenStudio(); }}
         {...attributes}
         {...listeners}
         aria-pressed={active}
-        aria-label={`Reorder ${familiar.display_name}`}
+        aria-label={`Filter by ${familiar.display_name}${needsReply ? " — reply needed" : ""}`}
       >
         <FamiliarAvatar familiar={familiar} size="sm" />
         <span className={`familiar-dock__presence ${presence.dot}`} aria-hidden />

--- a/src/lib/familiar-dock-overflow.test.ts
+++ b/src/lib/familiar-dock-overflow.test.ts
@@ -1,6 +1,15 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { computeDockInlineCount } from "./familiar-dock-overflow.ts";
+
+const src = readFileSync(new URL("./familiar-dock-overflow.ts", import.meta.url), "utf8");
+
+assert.match(
+  src,
+  /overflow control only needs to be reserved when callers\s+\* choose to show it/,
+  "reservedWidth docs clarify conditional overflow-trigger space",
+);
 
 // Wide container: everything fits inline, no overflow.
 assert.equal(

--- a/src/lib/familiar-dock-overflow.ts
+++ b/src/lib/familiar-dock-overflow.ts
@@ -3,8 +3,9 @@
  * the overflow popover. Pure + UI-agnostic so it can be unit-tested without a
  * DOM; the component feeds it a measured container width (ResizeObserver).
  *
- * `reservedWidth` accounts for the fixed controls that always render (the All
- * chip, the overflow ··· button, the + add button, and inter-item gaps).
+ * `reservedWidth` accounts for non-avatar controls and gaps outside the inline
+ * avatar row. The overflow control only needs to be reserved when callers
+ * choose to show it for hidden familiars.
  */
 export function computeDockInlineCount(opts: {
   containerWidth: number;


### PR DESCRIPTION
## Summary
- Fixes the post-merge Familiar Dock review comments around ARIA/focus behavior.
- Aligns the overflow trigger with the shared Popover dialog role.
- Adds source tests covering focus-ring classes, the sortable avatar label, and reserved-width documentation.

## Verification
- node --experimental-strip-types src/components/familiar-dock.test.ts
- node --experimental-strip-types src/lib/familiar-dock-overflow.test.ts
- pnpm run test:app
- pnpm run check:tests-wired
- pnpm build
- git diff --check