### PR TITLE
fix: add pnpm supportedArchitectures for linux-x64 CI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,5 +81,12 @@
     "tailwindcss": "4.3.0",
     "typescript": "5.9.3"
   },
-  "packageManager": "pnpm@10.34.0"
+  "packageManager": "pnpm@10.34.0",
+  "pnpm": {
+    "supportedArchitectures": {
+      "os": ["linux", "darwin"],
+      "cpu": ["x64", "arm64"],
+      "libc": ["glibc", "musl"]
+    }
+  }
 }


### PR DESCRIPTION
All open PRs are failing CI with:
```
Error: Could not load the "sharp" module using the linux-x64 runtime
```

Root cause: the lockfile was generated on macOS arm64 and pnpm's `--frozen-lockfile` on the linux-x64 CI runner doesn't install optional platform binaries that weren't resolved during lock generation.

Fix: add `pnpm.supportedArchitectures` to `package.json` covering linux/darwin × x64/arm64 × glibc/musl. This ensures the lockfile and installs include platform binaries for all target environments.

Unblocks: #705–#725 (all failing Frontend build due to same root cause).