### PR TITLE
fix(library): dedupe TOC heading ids to avoid duplicate React keys

### DIFF
--- a/src/components/library-doc-preview.tsx
+++ b/src/components/library-doc-preview.tsx
@@ -716,9 +716,16 @@ function DocDetail({ doc, docNav }: { doc: LibraryDocBody; docNav?: DocNav }) {
   useEffect(() => {
     if (!mdRef.current) return;
     const headings = Array.from(mdRef.current.querySelectorAll<HTMLElement>("h1,h2,h3")) as HTMLElement[];
+    // Two headings with the same text would slug to the same id, producing
+    // duplicate React keys and colliding DOM anchors (scroll/observer/copy-link
+    // would all resolve to the first). Suffix repeats (-2, -3, …) to keep ids unique.
+    const seen = new Map<string, number>();
     const items = headings.map((el) => {
       const text = el.textContent ?? "";
-      const id = "toc-" + text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+      const base = "toc-" + text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+      const n = (seen.get(base) ?? 0) + 1;
+      seen.set(base, n);
+      const id = n === 1 ? base : `${base}-${n}`;
       el.id = id;
       return { id, text, level: parseInt(el.tagName[1]) };
     });
@@ -756,9 +763,14 @@ function DocDetail({ doc, docNav }: { doc: LibraryDocBody; docNav?: DocNav }) {
   useEffect(() => {
     if (!readerOpen || !readerMdRef.current) return;
     const headings = Array.from(readerMdRef.current.querySelectorAll<HTMLElement>("h1,h2,h3")) as HTMLElement[];
+    // Suffix duplicate-text headings (see main-preview note) so ids/anchors stay unique.
+    const seen = new Map<string, number>();
     const items = headings.map((el) => {
       const text = el.textContent ?? "";
-      const id = "reader-toc-" + text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+      const base = "reader-toc-" + text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+      const n = (seen.get(base) ?? 0) + 1;
+      seen.set(base, n);
+      const id = n === 1 ? base : `${base}-${n}`;
       el.id = id;
       // Hover copy-link anchor: copies <path>#<slug>. DOM-appended (same
       // idiom as the id/aria-current mutations above) so RenderedMarkdown


### PR DESCRIPTION
## Bug
Opening a Library doc with two same-text headings (e.g. two "Usage" sections) throws a React console error: *"Encountered two children with the same key, `toc-usage`."* The TOC builders in `library-doc-preview.tsx` slug ids purely from heading text, so duplicate headings collide. Beyond the key warning, the colliding DOM ids break **scroll-to-section**, the **IntersectionObserver** active-heading highlight, and the reader-mode **copy-link** slug — all resolve to the first matching heading only.

## Fix
Track seen slugs in both the main-preview and reader-mode TOC builders and suffix repeats (`-2`, `-3`, …) so every heading gets a unique id (and therefore unique React key + anchor). Single-occurrence headings are unchanged.

## Verification
- `pnpm typecheck` + `pnpm test:app` green (no test relied on the old id format).

Found while running the app to verify the familiar UX work; unrelated pre-existing bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)