### PR TITLE
fix(workflows): pin collapsed right-panel toggle to the top

### DIFF
--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -220,6 +220,11 @@
   flex: 1 1 auto;
   height: auto;
   margin-bottom: 0;
+  /* Expanded, the header aligns its underline tabs to the bottom (flex-end).
+     Collapsed, the header stretches full-height with only the toggle left, so
+     flip to flex-start to pin that toggle to the TOP — mirroring the left
+     library panel's collapsed tab instead of stranding it at the bottom. */
+  align-items: flex-start;
 }
 
 .workflow-studio-shell.is-right-collapsed .workflow-side-panel-tabs {


### PR DESCRIPTION
## What
On the Workflows page, when the right **details** panel is collapsed its re-open toggle was stranded at the **bottom** of the rail, while the left **library** panel's collapsed toggle sits at the **top**. This pins the right toggle to the top so the two mirror each other.

## Cause
`.workflow-side-panel-header` uses `align-items: flex-end` so the underline tabs align to the bottom of the header row when expanded. When collapsed, the header stretches to full height (`flex: 1`) but kept `flex-end`, dropping the lone toggle to the bottom. The left panel's collapsed tab already uses `flex-start`.

## Fix
Add `align-items: flex-start` to the `is-right-collapsed .workflow-side-panel-header` rule. One-line CSS, no behavior change.

## Verification
Live Playwright (prod build): with the panel collapsed, the right toggle now renders at **y=16**, identical to the left tab at **y=16** (was y=778). Screenshot confirms both toggles at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)