### PR TITLE
fix(terminal): restore credential-less loopback for the PTY websocket

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -369,7 +369,13 @@ server.on("upgrade", (req, socket, head) => {
     return;
   }
 
-  if (!isAuthorized(req, query)) {
+  // Only enforce token auth when a token is actually configured (remote/mobile
+  // access mode). With no token set — the local desktop app and dev server —
+  // the loopback host+origin gate above is the protection, and credential-less
+  // connections are the local app itself. #714 dropped this and 401'd every
+  // local terminal (reintroducing the v0.0.72 "Terminal connection failed"
+  // regression that server-pty-ws.test.ts warns about).
+  if (ACCESS_TOKEN && !isAuthorized(req, query)) {
     socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
     socket.destroy();
     return;

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -12,6 +12,11 @@ assert.match(src, /COVEN_CAVE_ACCESS_TOKEN/, "server checks sidecar access token
 assert.match(src, /ACCESS_COOKIE = "coven_cave_access"/, "server accepts the same access cookie as REST middleware");
 assert.match(src, /ACCESS_QUERY_PARAM = "coven_access_token"/, "server accepts the mobile access token query param for WebSocket auth");
 assert.match(src, /if \(!ACCESS_TOKEN\) return false/, "PTY WebSocket auth fails closed when no access token is configured");
+// The 401 only applies when a token is actually configured (remote/mobile). With
+// no token (the local desktop app / dev server) the loopback host+origin gate is
+// the protection — guarding the 401 on ACCESS_TOKEN keeps credential-less local
+// connections working. #714 dropped this guard and 401'd every local terminal.
+assert.match(src, /if \(ACCESS_TOKEN && !isAuthorized\(req, query\)\)/, "PTY upgrade only 401s on missing credentials when a token is configured (credential-less loopback is the local app)");
 assert.match(src, /Bearer /, "server accepts bearer auth for non-cookie clients");
 assert.match(src, /isAllowedUpgradeSource/, "server validates WebSocket upgrade host and origin");
 assert.match(src, /isLoopbackHost\(host\)/, "server only accepts loopback WebSocket hosts by default");


### PR DESCRIPTION
## Problem

Every local terminal websocket was being refused with **401 Unauthorized**. Observed as the repeating console error:

```
WebSocket connection to 'ws://localhost:3000/api/pty-ws?…&projectRoot=…/familiars/sage' failed
```

This is not sage-specific — it breaks **all** local terminals.

## Root cause

PR #714 (`c07003c`, "lock down pty websocket auth") flipped `isAuthorized` to fail closed:

```diff
-  if (!ACCESS_TOKEN) return true;   // credential-less loopback = the local app
+  if (!ACCESS_TOKEN) return false;
```

But the upgrade handler unconditionally 401s on `!isAuthorized`. With no `COVEN_CAVE_ACCESS_TOKEN` configured — the normal local desktop app and dev server, where the loopback host+origin gate is the real protection — every terminal upgrade now 401s. This is exactly the v0.0.72 regression that `server-pty-ws.test.ts:74-77` warns about, reintroduced.

## Fix

Gate the 401 on `ACCESS_TOKEN &&` — only enforce token auth when a token is actually configured:

```js
if (ACCESS_TOKEN && !isAuthorized(req, query)) { /* 401 */ }
```

`isAuthorized` keeps failing closed (assertion stays green), so a configured-but-unsupplied token still 401s. With no token, the existing `isAllowedUpgradeSource` loopback+origin gate is the protection.

## Verification (live, 4 cases on patched server)

| Mode | Request | Result |
|---|---|---|
| No token (local app) | loopback, valid root | **101** ✅ (was 401) |
| No token | cross-origin | 403 ✅ |
| Token set (remote) | no credential | 401 ✅ |
| Token set | correct credential | 101 ✅ |

Added a regression assertion to `server-pty-ws.test.ts` pinning the `ACCESS_TOKEN &&` guard. `server-pty-ws.test.ts` and `pty-ws-bridge.test.ts` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)