### PR TITLE
fix(memory): don't reject memory reads under a symlinked root

### DIFF
--- a/src/lib/server/memory-file-sources.test.ts
+++ b/src/lib/server/memory-file-sources.test.ts
@@ -108,6 +108,25 @@ try {
     null,
     "familiar memory files reached through symlinked directories must stay blocked",
   );
+
+  // Regression (OS-independent): when the allowed root itself is reached through
+  // a symlinked ancestor (macOS /var→/private/var, a symlinked ~/.coven, network
+  // mounts), a legitimate in-root read must still resolve. A guard that compares
+  // the realpath'd target against a lexically-resolved root wrongly returns null
+  // here — but only on platforms where tmpdir is symlinked, so assert it via an
+  // explicit symlinked root that fails on every platform.
+  const realBase = path.join(tempRoot, "real-base");
+  const linkedRoot = path.join(tempRoot, "linked-root");
+  const linkedRootMemory = path.join(linkedRoot, ".openclaw", "workspace", "echo", "memory");
+  const linkedRootSafe = path.join(linkedRootMemory, "safe.md");
+  await mkdir(path.join(realBase, ".openclaw", "workspace", "echo", "memory"), { recursive: true });
+  await writeFile(path.join(realBase, ".openclaw", "workspace", "echo", "memory", "safe.md"), "safe via symlinked root");
+  await symlink(realBase, linkedRoot);
+  assert.equal(
+    await resolveAllowedMemoryFileReadPath(linkedRootSafe, linkedRoot),
+    await realpath(linkedRootSafe),
+    "in-root reads must resolve even when the allowed root is reached through a symlinked ancestor",
+  );
 } finally {
   await rm(tempRoot, { recursive: true, force: true });
 }

--- a/src/lib/server/memory-file-sources.ts
+++ b/src/lib/server/memory-file-sources.ts
@@ -48,7 +48,14 @@ async function isRealPathWithinAllowedRoot(targetPath: string, allowedRoot: stri
     realpathIfPresent(allowedRoot),
   ]);
   if (realTarget === null || realRoot === null) return false;
-  return isWithinRoot(realTarget, realRoot) && isWithinRoot(realTarget, path.resolve(allowedRoot));
+  // Containment is realpath-vs-realpath: both operands are canonicalized above,
+  // which correctly blocks symlink escapes. A previous extra clause also compared
+  // the realpath'd target against a LEXICALLY-resolved root
+  // (path.resolve(allowedRoot)); when any ancestor of the allowed root is a
+  // symlink (macOS /var→/private/var, a symlinked ~/.coven, network mounts), the
+  // canonical prefix never matched the lexical one, so legitimate memory reads
+  // were wrongly rejected. realRoot already carries the canonical prefix.
+  return isWithinRoot(realTarget, realRoot);
 }
 
 function familiarAllowedRootPath(fullPath: string, classification: MemoryFileClassification): string | null {


### PR DESCRIPTION
Post-merge review finding on the codex security batch (#717 "block symlink escapes when reading memory files").

`isRealPathWithinAllowedRoot` (`src/lib/server/memory-file-sources.ts`) required containment against **two** roots:
```
return isWithinRoot(realTarget, realRoot) && isWithinRoot(realTarget, path.resolve(allowedRoot));
```
Clause 1 (realpath target vs realpath root) is the correct, sufficient symlink-escape guard. Clause 2 compares the realpath'd target against a **lexically**-resolved root, so whenever any ancestor of the allowed root is a symlink — macOS `/var`→`/private/var`, a symlinked `~/.coven`, network mounts — the canonical target prefix never matches the lexical root and a **legitimate familiar-memory read returns null → 403**.

Not an escape (clause 1 still blocks out-of-root symlinks) — an over-restrictive availability bug. The fix drops clause 2.

**It was shipping CI-masked:** the existing test seeds its root under `tmpdir()`, which is symlinked on macOS (`/var`→`/private/var`) but not on Linux CI — so `memory-file-sources.test.ts` failed locally on macOS yet passed in CI. This PR adds an **OS-independent** regression case (an explicit symlinked root) that fails on the bug everywhere.

### Verification
- `memory-file-sources.test.ts` (incl. new symlinked-root case) + `memory-file-paths` / `memory-mutation-routes` / `memory-file-sources-coven-familiar` all pass; `typecheck` clean.
- Symlink-escape guards (the actual #717 security intent) are unchanged and still pass: `leak.md` → outside file blocked, `nested-leak.md` via symlinked dir blocked.