### PR TITLE
fix(terminal): verify PTY websocket peer address

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -85,6 +85,13 @@ function isLoopbackHost(host: string | null | undefined): boolean {
   return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1";
 }
 
+function isLoopbackAddress(value: string | undefined): boolean {
+  if (!value) return false;
+  if (value === "::1" || value === "127.0.0.1") return true;
+  if (value.startsWith("::ffff:")) return value.slice("::ffff:".length) === "127.0.0.1";
+  return false;
+}
+
 function sameOrigin(value: string | undefined, expectedOrigin: string): boolean {
   if (!value) return true;
   try {
@@ -106,6 +113,7 @@ function sameOrigin(value: string | undefined, expectedOrigin: string): boolean 
 function isAllowedUpgradeSource(req: IncomingMessage): boolean {
   const host = req.headers.host;
   if (!isLoopbackHost(host)) return false;
+  if (!isLoopbackAddress(req.socket.remoteAddress)) return false;
   return sameOrigin(req.headers.origin, `http://${host}`);
 }
 

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -20,6 +20,7 @@ assert.match(src, /if \(ACCESS_TOKEN && !isAuthorized\(req, query\)\)/, "PTY upg
 assert.match(src, /Bearer /, "server accepts bearer auth for non-cookie clients");
 assert.match(src, /isAllowedUpgradeSource/, "server validates WebSocket upgrade host and origin");
 assert.match(src, /isLoopbackHost\(host\)/, "server only accepts loopback WebSocket hosts by default");
+assert.match(src, /isLoopbackAddress\(req\.socket\.remoteAddress\)/, "server verifies the WebSocket peer address, not only the Host header");
 assert.match(src, /sameOrigin\(req\.headers\.origin/, "server rejects cross-origin WebSocket upgrades");
 assert.match(src, /process\.env\.HOSTNAME \?\? "127\.0\.0\.1"/, "server binds to loopback by default");
 assert.match(src, /pty\.spawn\(defaultShell\(\),\s*defaultShellArgs\(\)/, "server hardcodes shell and args");


### PR DESCRIPTION
## Summary
- require PTY websocket upgrades to come from a loopback socket peer, not only a loopback Host header
- keep the existing loopback host and origin compatibility behavior
- add a regression assertion for the peer-address guard

## Verification
- node --experimental-strip-types src/server-pty-ws.test.ts
- git diff --check
- pnpm check:tests-wired
- pnpm typecheck