### PR TITLE
fix(proxy): sidecar-header-token requests pass the origin gate over Tailscale Serve

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -18,9 +18,31 @@ assert.match(source, /req\.headers\.get\("origin"\)/, "middleware should reject 
 assert.match(source, /req\.headers\.get\("host"\)/, "middleware should reject unsafe hosts");
 assert.match(source, /const requestHost = req\.headers\.get\("host"\)/, "proxy should capture the forwarded request host once");
 assert.match(source, /isAllowedApiHost\(requestHost, mobileAccessAuthenticated\)/, "valid mobile access should satisfy the API host gate");
-assert.match(source, /isAllowedRequestSource\(req\.headers\.get\("origin"\), expectedOrigin\)/, "API origin gate should always require same-origin sources");
-assert.match(source, /isAllowedRequestSource\(req\.headers\.get\("referer"\), expectedOrigin\)/, "API referer gate should always require same-origin sources");
+assert.match(source, /isAllowedRequestSource\(req\.headers\.get\("origin"\), expectedOrigin\)/, "API origin gate should require same-origin sources unless header-CSRF-trusted");
+assert.match(source, /isAllowedRequestSource\(req\.headers\.get\("referer"\), expectedOrigin\)/, "API referer gate should require same-origin sources unless header-CSRF-trusted");
 assert.match(source, /unsupported content-type/, "middleware should reject unsafe content types before body parsing");
+
+// Tailscale Serve fix (re-applies #618; #716 reverted it): a request bearing the
+// sidecar token in the CSRF-immune CUSTOM HEADER bypasses the origin/referer gate
+// — Serve forwards `Host: 127.0.0.1`, so the real ts.net identity survives only in
+// the Origin header and otherwise 403s every mutating request. The bypass is keyed
+// to the header ONLY; the access cookie / mobile-access path must NOT grant it
+// (cookies auto-send cross-origin → CSRF).
+assert.match(
+  source,
+  /const headerCsrfTrusted =\s*Boolean\(sidecarToken\) && req\.headers\.get\(TOKEN_HEADER\) === sidecarToken/,
+  "origin/referer gate bypass must be keyed to the custom sidecar header token",
+);
+assert.match(
+  source,
+  /if \(!headerCsrfTrusted\) \{[\s\S]*?isAllowedRequestSource\(req\.headers\.get\("origin"\)/,
+  "origin gate must run unless the request is header-CSRF-trusted",
+);
+assert.doesNotMatch(
+  source,
+  /csrfTrusted\s*=\s*mobileAccessAuthenticated/,
+  "cookie-backed mobile-access must NOT bypass the CSRF origin gate",
+);
 
 // Ordering guard: dev-mode token-bypass (NextResponse.next() when no token is set)
 // must sit AFTER the host / origin / referer / content-type checks. Pre-fix,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -140,17 +140,35 @@ export async function proxy(req: NextRequest) {
   if (!isAllowedApiHost(requestHost, mobileAccessAuthenticated)) {
     return jsonError(403, "forbidden host");
   }
-  if (!isAllowedRequestSource(req.headers.get("origin"), expectedOrigin)) {
-    return jsonError(403, "forbidden origin");
-  }
-  if (!isAllowedRequestSource(req.headers.get("referer"), expectedOrigin)) {
-    return jsonError(403, "forbidden referer");
+
+  const sidecarToken = process.env.COVEN_CAVE_AUTH_TOKEN;
+  // A request bearing the sidecar token in the CUSTOM HEADER (x-coven-cave-token)
+  // is provably first-party: a browser cannot set a custom header on a
+  // cross-origin request (it forces a CORS preflight the server never approves),
+  // so such a request cannot be CSRF regardless of its Origin. Tailscale Serve
+  // terminates TLS and proxies to loopback, forwarding `Host: 127.0.0.1`, so a
+  // legitimately-authenticated WKWebView request keeps its real
+  // https://<machine>.ts.net identity only in the Origin header — which otherwise
+  // fails the same-origin gate and 403s every mutating request as "forbidden
+  // origin" (fixed in #618; #716 reverted it and re-broke mobile-over-Serve).
+  // Scope is deliberately the header ONLY: NOT the access cookie (auto-sent
+  // cross-origin → CSRF) and NOT the query/referer token paths. The token value
+  // is still validated below; this only relaxes the CSRF source gate.
+  const headerCsrfTrusted =
+    Boolean(sidecarToken) && req.headers.get(TOKEN_HEADER) === sidecarToken;
+
+  if (!headerCsrfTrusted) {
+    if (!isAllowedRequestSource(req.headers.get("origin"), expectedOrigin)) {
+      return jsonError(403, "forbidden origin");
+    }
+    if (!isAllowedRequestSource(req.headers.get("referer"), expectedOrigin)) {
+      return jsonError(403, "forbidden referer");
+    }
   }
   if (!hasSafeContentType(req)) {
     return jsonError(415, "unsupported content-type");
   }
 
-  const sidecarToken = process.env.COVEN_CAVE_AUTH_TOKEN;
   const suppliedToken =
     req.headers.get(TOKEN_HEADER) ??
     req.nextUrl.searchParams.get(TOKEN_PARAM) ??


### PR DESCRIPTION
Fixes the regression confirmed in the post-merge review of #716. **#716 reverted #618** and re-broke the mobile/native app over Tailscale Serve.

### The bug
Tailscale Serve terminates TLS and proxies to loopback, forwarding `Host: 127.0.0.1`. So Next's `expectedOrigin` is `http://127.0.0.1:PORT`, while the WKWebView sends `Origin: https://<machine>.ts.net`. In `proxy.ts` the origin gate (`isAllowedRequestSource` → `sameOrigin`) runs **before** the sidecar-token check, so every mutating request 403s "forbidden origin" while GETs (no Origin header) slip through — "sessions visible but new tasks won't start." Verified with the real helpers: `isAllowedRequestSource("https://x.ts.net","http://127.0.0.1:3000")` → false; `(null, …)` → true.

### The fix
A request bearing the sidecar token in the **custom header** `x-coven-cave-token` is provably first-party — a browser cannot set a custom header on a cross-origin request (it forces a CORS preflight the server never approves), so it can't be CSRF regardless of Origin. Such requests now bypass the origin/referer gate. The app's `SidecarAuthBridge` already attaches this header to every `/api/` fetch.

### Why this is CSRF-safe (and tighter than #618)
Scope is the **header only**. Unlike #618, this does **not** trust:
- the cookie-backed mobile-access path — `mobileAccessSuppliedTokens` reads the access **cookie**, which browsers auto-send cross-origin → genuine CSRF (this is what #716 was right to drop), nor
- the `covenCaveToken` query/referer token paths.

The helper stays pure `sameOrigin`; the token value is still validated after the gate (unchanged 401 on mismatch). `content-type` and host gates still apply unconditionally.

### Verification
- `middleware.test.ts` (new assertions: bypass keyed to the custom header; origin gate runs unless header-trusted; **guards against re-introducing the cookie bypass**) + `proxy-behavior.test.ts` pass; `typecheck` + `build` clean.
- `proxy()` itself isn't node-importable under the strip-types runner (next/server) — the suite tests the helpers + middleware source structure, per the file's existing convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)