### PR TITLE
fix(capabilities): limit previews to markdown files

### DIFF
--- a/src/components/capabilities-normalize.test.ts
+++ b/src/components/capabilities-normalize.test.ts
@@ -20,7 +20,7 @@ const manifests = [
         name: "Review",
         source: "local",
         harness_id: "codex",
-        path: "/Users/buns/.codex/skills/review/SKILL.md",
+        path: "/Users/buns/.codex/skills/review",
         description: "Review code",
         tags: ["quality"],
       },
@@ -105,6 +105,9 @@ assert.deepEqual(ids, [
 const disabledMcp = view.items.find((item) => item.id === "codex:mcp:filesystem");
 assert.equal(disabledMcp?.status, "disabled");
 assert.equal(disabledMcp?.command, "fs-mcp");
+
+const reviewSkill = view.items.find((item) => item.id === "codex:skill:review");
+assert.equal(reviewSkill?.sourcePath, "/Users/buns/.codex/skills/review/SKILL.md");
 
 assert.deepEqual(
   filterCapabilityItems(view.items, { query: "config", types: new Set(["warning"]) }).map((item) => item.id),

--- a/src/components/capabilities-normalize.ts
+++ b/src/components/capabilities-normalize.ts
@@ -74,6 +74,15 @@ export function harnessLabel(id: string): string {
   return HARNESS_LABEL[id] ?? id;
 }
 
+function skillSourcePath(skillPath?: string): string | undefined {
+  if (!skillPath) return undefined;
+  const cleanPath = skillPath.replace(/\/+$/, "");
+  const lowerPath = cleanPath.toLowerCase();
+  if (lowerPath.endsWith(".md") || lowerPath.endsWith(".toml")) return cleanPath;
+  if (lowerPath.includes("/.codex/automations/")) return cleanPath;
+  return `${cleanPath}/SKILL.md`;
+}
+
 export function normalizeCapabilities({
   manifests,
   covenSkills,
@@ -119,7 +128,7 @@ export function normalizeCapabilities({
         label: skill.name,
         status: "available",
         description: skill.description,
-        sourcePath: skill.path,
+        sourcePath: skillSourcePath(skill.path),
         tags: skillMeta.tags,
         version: skillMeta.version,
         kind: skillMeta.source,

--- a/src/components/capabilities-view.test.ts
+++ b/src/components/capabilities-view.test.ts
@@ -37,5 +37,8 @@ assert.match(source, /const applyTypeFilter = \(value: CapabilityType \| "all"\)
 assert.match(source, /const applyStatusFilter = \(value: CapabilityStatus \| "all"\) => \{[\s\S]*setStatusFilter\(value\);[\s\S]*setSelectionId\(null\);[\s\S]*\};/, "status changes should clear stale inspector selection");
 assert.match(source, /const readinessStatus = operatorView\.summary\.warnings > 0 \? "warning" : operatorView\.summary\.disabled > 0 \? "disabled" : "all";/, "readiness tile should route to disabled when disabled is the only issue type");
 assert.match(source, /type="search"[\s\S]*aria-label="Search capabilities"/, "search input should expose a stable accessible name");
+assert.match(source, /function isMarkdownPreviewable\(/, "previewability should be based on markdown-capable files");
+assert.match(source, /json\.path \?\? previewPath/, "preview state should preserve the server-resolved markdown file path");
+assert.match(source, /Markdown preview/, "capability file previews should be explicitly labelled as markdown previews");
 
 console.log("capabilities-view.test.ts: ok");

--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -47,6 +47,7 @@ const STATUS_LABEL: Record<CapabilityStatus, string> = {
 
 const CAPABILITY_TYPES = new Set<CapabilityType>(["instructions", "skill", "plugin", "mcp", "warning"]);
 const CAPABILITY_STATUSES = new Set<CapabilityStatus>(["available", "enabled", "disabled", "warning"]);
+const MARKDOWN_PREVIEW_FILE_NAMES = new Set(["skill.md", "claude.md", "agents.md"]);
 
 function readUrlParam(name: string): string | null {
   if (typeof window === "undefined") return null;
@@ -77,6 +78,14 @@ function initialTypeFilter(): CapabilityType | "all" {
 
 function initialStatusFilter(): CapabilityStatus | "all" {
   return readCapabilityStatusParam("status");
+}
+
+function isMarkdownPreviewable(path?: string): boolean {
+  if (!path) return false;
+  const normalized = path.toLowerCase();
+  if (!normalized.endsWith(".md")) return false;
+  const filename = normalized.split("/").pop() ?? "";
+  return MARKDOWN_PREVIEW_FILE_NAMES.has(filename);
 }
 
 export function CapabilitiesViewSurface({
@@ -207,14 +216,12 @@ export function CapabilitiesViewSurface({
     [operatorView.items, selectionId],
   );
 
-  // Load the selected capability's markdown so the inspector can render a
-  // styled preview. Skills report their FOLDER as the path (the daemon doesn't
-  // point at the SKILL.md inside) so any skill is previewable and the route
-  // resolves the folder → SKILL.md; instructions report a CLAUDE.md/AGENTS.md
-  // file directly. Out-of-tree paths (403) fall back to the description.
+  // Load the selected capability markdown so the inspector can render a styled
+  // Markdown preview. Skills are normalized to SKILL.md; instructions report a
+  // CLAUDE.md/AGENTS.md file directly. Out-of-tree paths (403) fall back to the
+  // description.
   const previewPath = selectedItem?.sourcePath ?? null;
-  const isPreviewable =
-    !!previewPath && (selectedItem?.type === "skill" || previewPath.toLowerCase().endsWith(".md"));
+  const isPreviewable = isMarkdownPreviewable(previewPath ?? undefined);
   useEffect(() => {
     if (!previewPath || !isPreviewable) {
       setPreview({ path: null, status: "idle", text: null, error: null });
@@ -227,12 +234,12 @@ export function CapabilitiesViewSurface({
         const res = await fetch(`/api/skills/file?path=${encodeURIComponent(previewPath)}`, {
           cache: "no-store",
         });
-        const json = (await res.json()) as { ok: boolean; text?: string; error?: string };
+        const json = (await res.json()) as { ok: boolean; path?: string; text?: string; error?: string };
         if (cancelled) return;
         if (!json.ok) {
           setPreview({ path: previewPath, status: "error", text: null, error: json.error ?? `http ${res.status}` });
         } else {
-          setPreview({ path: previewPath, status: "loaded", text: json.text ?? "", error: null });
+          setPreview({ path: json.path ?? previewPath, status: "loaded", text: json.text ?? "", error: null });
         }
       } catch (err) {
         if (cancelled) return;
@@ -568,11 +575,9 @@ function CapabilityMapRow({
   onOpenPath: (path?: string) => void;
   onSelectHarness: (id: string | null) => void;
 }) {
-  // Every row expands inline to reveal its inspector details. Skills report
-  // their folder as the path and any .md instruction is previewable too — those
-  // additionally render the file as styled markdown beneath the details.
-  const isPreviewable =
-    !!item.sourcePath && (item.type === "skill" || item.sourcePath.toLowerCase().endsWith(".md"));
+  // Every row expands inline to reveal its inspector details. Known markdown
+  // capability files render beneath the details as styled markdown.
+  const isPreviewable = isMarkdownPreviewable(item.sourcePath);
   const previewMatches = preview.path === item.sourcePath;
   return (
     <div>
@@ -803,7 +808,7 @@ function SkillPreviewBlock({
       <InspectorBlock label="Detail" value={fallbackDescription} />
     ) : (
       <div>
-        <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">Preview</p>
+        <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">Markdown preview</p>
         <p className="rounded-md bg-muted px-2 py-1.5 text-[11px] leading-5 text-muted-foreground">
           Preview unavailable for this file.
         </p>
@@ -814,7 +819,7 @@ function SkillPreviewBlock({
   return (
     <div>
       <div className="mb-1 flex items-center justify-between gap-2">
-        <p className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">Preview</p>
+        <p className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">Markdown preview</p>
         {canExpand ? (
           <button
             type="button"


### PR DESCRIPTION
## Summary
- normalize skill folder paths to SKILL.md for preview/open-path consistency
- restrict inline previews to known Markdown capability files
- preserve server-resolved preview paths and label the section as Markdown preview

## Note
This overlaps the capabilities preview area touched by #737 and should be reviewed/ordered with that PR before release.

## Verification
- node --experimental-strip-types src/components/capabilities-normalize.test.ts
- node --experimental-strip-types src/components/capabilities-view.test.ts
- pnpm check:tests-wired
- git diff --check
- pnpm typecheck