### PR TITLE
fix(onboarding): use runtime wording consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Cave also needs a local runtime source: Codex, Claude Code, Hermes, an existing 
 | Git | Recommended | The working-tree changes panel, project file tree, and patch checkpoints shell out to `git`. Everything else (chat, boards, workflows, library) works without it. Setup flags it but never blocks on it. |
 | `coven` CLI | **Yes** | Powers native familiar chat, the daemon, and doctor checks. Setup walks you through `npm i -g @opencoven/cli@latest`. |
 | A runtime source | **Yes** (any one) | Codex, Claude Code, Hermes, or an OpenClaw agent — see below. |
-| OpenSSH / Tailscale / graphify | Optional | Only for SSH-runtime familiars, mobile handoff, and Library knowledge graphs respectively; each surfaces a clear message if missing. |
+| OpenSSH / Tailscale / graphify | Optional | Only for SSH-transport familiars, mobile handoff, and Library knowledge graphs respectively; each surfaces a clear message if missing. |
 
 ### First Familiar Without OpenClaw
 

--- a/src/components/chat-list-panel.test.ts
+++ b/src/components/chat-list-panel.test.ts
@@ -12,8 +12,8 @@ assert.match(
 
 assert.match(
   source,
-  /Familiar runtime/,
-  "ChatList should label the familiar harness/model metadata as agent runtime",
+  /Runtime/,
+  "ChatList should label the familiar agent source as a runtime",
 );
 
 assert.match(
@@ -24,7 +24,7 @@ assert.match(
 
 assert.match(
   source,
-  /panelRole[\s\S]*Familiar runtime/,
+  /panelRole[\s\S]*Runtime/,
   "ChatList dossier header should keep the familiar role and runtime subtitle together",
 );
 

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -644,7 +644,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                     {" · "}
                   </>
                 ) : null}
-                Familiar runtime{" "}
+                Runtime{" "}
                 <span className="font-mono">{panelRuntime}</span>
               </p>
             </div>
@@ -799,7 +799,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               </div>
               <div className="mt-4 divide-y divide-[var(--border-hairline)] border-y border-[var(--border-hairline)] text-left">
                 <div className="flex items-center justify-between gap-3 py-2">
-                  <p className="text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">Harness</p>
+                  <p className="text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">Runtime</p>
                   <p className="min-w-0 truncate font-mono text-[11px] text-[var(--text-secondary)]">{panelRuntime}</p>
                 </div>
                 <div className="flex items-center justify-between gap-3 py-2">

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -1657,7 +1657,7 @@ function StepRuntimes({
     <div className="flex flex-col gap-3">
       <div className="flex items-start justify-between gap-3">
         <p className="text-[12px] leading-5 text-[var(--text-secondary)]">
-          A runtime (harness) is the agent CLI your familiar speaks through.
+          A runtime is the agent CLI your familiar speaks through.
           You only need{" "}
           <span className="font-medium text-[var(--text-primary)]">one</span> —
           pick whichever you already use, or one-click install any of them
@@ -2021,7 +2021,7 @@ function StepFamiliar(props: {
             <span className="font-medium text-[var(--text-primary)]">
               Runs on a remote machine (SSH)
             </span>{" "}
-            — the familiar&rsquo;s harness runs over SSH on another box (a
+            — the familiar&rsquo;s runtime uses SSH transport on another box (a
             build server, a homelab, a VM). Cave connects non-interactively
             with your SSH keys and never stores passwords or key material.
           </span>
@@ -2111,7 +2111,7 @@ function StepFamiliar(props: {
               {" "}bound to the{" "}
               <span className="font-medium text-[var(--text-primary)]">
                 {selectedHarness.label}
-              </span>{" "}harness
+              </span>{" "}runtime
             </>
           ) : null}
           .
@@ -2170,7 +2170,7 @@ function StepMeetFamiliars({
     <div className="flex flex-col gap-3">
       <p className="text-[12px] leading-5 text-[var(--text-secondary)]">
         {statusOk
-          ? "Your familiars are loaded. Everything about them stays editable — name, look, brain, harness — in the Familiar Studio, any time."
+          ? "Your familiars are loaded. Everything about them stays editable — name, look, brain, runtime, transport — in the Familiar Studio, any time."
           : "Once the daemon is running and a familiar exists, they appear here."}
       </p>
       {familiars.length > 0 ? (

--- a/src/lib/server/skill-file-paths.test.ts
+++ b/src/lib/server/skill-file-paths.test.ts
@@ -15,6 +15,9 @@ async function touch(relativePath: string, contents = "# preview\n") {
 
 const claudeSkill = await touch(path.join(".claude", "skills", "deep-research", "SKILL.md"));
 const covenSkill = await touch(path.join(".coven", "skills", "foo", "SKILL.md"));
+const agentsSkill = await touch(path.join(".agents", "skills", "brainstorming", "SKILL.md"));
+const claudeSkillSymlink = path.join(home, ".claude", "skills", "brainstorming");
+await symlink(path.join(home, ".agents", "skills", "brainstorming"), claudeSkillSymlink);
 const claudeInstructions = await touch(path.join(".claude", "CLAUDE.md"));
 const codexInstructions = await touch(path.join(".codex", "AGENTS.md"));
 const nonMarkdown = await touch(path.join(".claude", "skills", "x", "run.sh"));
@@ -36,6 +39,11 @@ assert.equal(
   await isAllowedSkillFilePath(covenSkill, home),
   true,
   "a SKILL.md under ~/.coven/skills is allowed",
+);
+assert.equal(
+  await isAllowedSkillFilePath(path.join(claudeSkillSymlink, "SKILL.md"), home),
+  true,
+  "a SKILL.md reached through a symlinked skill directory is allowed when the target is ~/.agents/skills",
 );
 
 // Harness instructions files (CLAUDE.md / AGENTS.md) are allowed under roots.

--- a/src/lib/server/skill-file-paths.ts
+++ b/src/lib/server/skill-file-paths.ts
@@ -16,7 +16,7 @@ import { lstat, realpath } from "node:fs/promises";
  * the preview endpoint from exposing arbitrary markdown or symlink targets from
  * broad harness directories.
  */
-const SKILL_ROOT_SUBPATHS = [".claude", ".coven", ".codex", ".cursor", ".gemini"];
+const SKILL_ROOT_SUBPATHS = [".claude", ".coven", ".codex", ".cursor", ".gemini", path.join(".agents", "skills")];
 const ALLOWED_SKILL_FILE_NAMES = new Set(["SKILL.md", "CLAUDE.md", "AGENTS.md"]);
 
 export const MAX_SKILL_FILE_PREVIEW_BYTES = 512 * 1024;


### PR DESCRIPTION
## Summary
- use runtime/transport language consistently in onboarding and chat surfaces
- clarify SSH familiars as SSH transport instead of harness wording
- allow skill previews for symlinked ~/.agents/skills entries reached from harness skill folders

## Verification
- node --experimental-strip-types src/components/chat-list-panel.test.ts
- node --experimental-strip-types src/components/onboarding-guided-steps.test.ts
- node --experimental-strip-types src/lib/server/skill-file-paths.test.ts
- git diff --check
- pnpm check:tests-wired
- pnpm typecheck