### PR TITLE
fix(familiars): legible labeled trigger for the sidebar familiar switcher

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3653,6 +3653,36 @@ button:active > .edge-rail-chip {
   color: var(--text-muted);
 }
 
+/* Labeled variant — the sidebar's familiar-scope control. Full-width row
+   (avatar/glyph + name + caret) that lines up with the New chat / Ask Salem
+   action rows beneath it, so the control reads as the scope selector instead of
+   a bare floating icon. The mobile top bar keeps the compact icon (no label). */
+.familiar-switcher__trigger[data-labeled="true"] {
+  width: 100%;
+  height: 32px;
+  gap: 8px;
+  padding: 0 8px 0 6px;
+  justify-content: flex-start;
+}
+.familiar-switcher__trigger-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+  font-size: 12.5px;
+  color: var(--text-secondary);
+}
+.familiar-switcher__trigger[data-labeled="true"]:hover .familiar-switcher__trigger-label {
+  color: var(--text-primary);
+}
+.familiar-switcher__trigger[data-labeled="true"] .familiar-switcher__caret {
+  margin-left: auto;
+}
+.sidebar-familiar-slot { flex: 1; }
+.sidebar-familiar-slot > * { flex: 1; }
+
 /* Reply-needed dot on the collapsed trigger. */
 .familiar-switcher__unread {
   position: absolute;

--- a/src/components/familiar-switcher.tsx
+++ b/src/components/familiar-switcher.tsx
@@ -32,6 +32,11 @@ type Props = {
    *  left-edge sidebar home); the mobile top bar passes "bottom-end" since its
    *  trigger sits at the right edge. */
   placement?: "bottom-start" | "bottom-end" | "top-start" | "top-end";
+  /** Render the trigger as a full-width labeled row (avatar/glyph + name +
+   *  caret) instead of the compact icon pill. The sidebar uses this so the
+   *  control reads as the familiar scope and aligns with the action rows below
+   *  it; the mobile top bar keeps the compact icon. */
+  labeled?: boolean;
 };
 
 /**
@@ -48,6 +53,7 @@ export function FamiliarSwitcher({
   responseNeeded,
   onSelectFamiliar,
   placement = "bottom-start",
+  labeled = false,
 }: Props) {
   const { openFamiliarStudio, openFamiliarStudioListView } = useFamiliarStudio();
   const triggerRef = useRef<HTMLButtonElement | null>(null);
@@ -111,6 +117,7 @@ export function FamiliarSwitcher({
         ref={triggerRef}
         type="button"
         className="familiar-switcher__trigger focus-ring"
+        data-labeled={labeled ? "true" : undefined}
         onClick={() => setOpen((o) => !o)}
         aria-haspopup="dialog"
         aria-expanded={open}
@@ -123,6 +130,11 @@ export function FamiliarSwitcher({
         ) : (
           <Icon name="ph:sparkle" width={14} aria-hidden />
         )}
+        {labeled ? (
+          <span className="familiar-switcher__trigger-label">
+            {active ? active.display_name : "All familiars"}
+          </span>
+        ) : null}
         <Icon name="ph:caret-down" width={9} className="familiar-switcher__caret" aria-hidden />
         {anyNeedsReply ? <span className="familiar-switcher__unread" aria-hidden /> : null}
       </button>

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -244,6 +244,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
             sessions={sessions}
             responseNeeded={responseNeeded}
             onSelectFamiliar={onFamiliarScopeChange}
+            labeled
           />
         </div>
         <ActionRow


### PR DESCRIPTION
Follow-up to the familiar top-bar switcher (#741). The switcher has two mounts: the desktop **top bar** (which is `display:none` on desktop, #360 — so that copy is invisible) and the **sidebar slot**, which is the real desktop home. In the sidebar it rendered as a bare **icon-only pill** (avatar/sparkle + caret, no label) floating under the title — a discoverability regression from the old dock, and it doesn't read as the familiar-scope control.

### Fix
Adds a `labeled` trigger variant: a full-width row showing the active familiar's name (or "All familiars") beside the avatar/glyph, caret pinned right, aligned with the New chat / Ask Salem action rows beneath it. The sidebar passes `labeled`; the mobile top bar keeps the compact icon. Purely additive — a `data-labeled` CSS hook (the `className` literal is unchanged, so existing source tests hold) + a label span + scoped CSS.

### Verification
- `pnpm typecheck` clean; `familiar-switcher`, `sidebar-minimal`, `sidebar-familiar-filter`, `globals.css` tests pass; `pnpm build` clean — all run before the work was committed.
- Diagnosed against the running app first: confirmed the sidebar trigger was a 39×26 icon-only pill (boundingBox/screenshot) and the popover menu itself is well-styled; the top-bar copy computes 0×0 (hidden top bar).
- Note: the final in-app screenshot of the *fixed* trigger was blocked by concurrent worktree-cleanup automation tearing down my worktrees/servers mid-run on this hot surface — CI rebuilds and the change is small + test-covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)