### PR TITLE
chore(release): v0.0.92

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.92] - 2026-06-15
+
+Patch release: ships the post-0.0.91 hardening and Cave polish sweep.
+
+### Added
+- **Salem Pathfinder** — adds the Home entry point, deterministic pathfinder cards, Save-to-Board flow, local feedback capture, and eval fixtures (#703, #724, #727, #730).
+- **Familiars** — replaces the scope dropdown with the horizontal dock, adds the sleeker Studio/dock surfaces, moves the switcher into the top bar, and gives the sidebar switcher a legible labeled trigger (#701, #722, #723, #729, #741, #744).
+- **Capabilities** — expands rows with inline inspector details and previews supported Markdown/Codex automation descriptors safely (#732, #737, #742).
+- **Calls** — surfaces delegation attention summaries in the calls graph (#740).
+
+### Fixed
+- **Security** — hardens daemon session APIs, launch cwd handling, local PDF serving, memory and skill file reads, checkpoint diff hooks, and sidecar dependency integrity (#705, #711, #715, #718, #719, #720, #721).
+- **Terminal** — locks down PTY websocket auth while restoring credential-less loopback and verifying peer address for the local desktop path (#708, #714, #735, #738).
+- **Mobile/Tailscale** — requires signed native access, avoids leaking handoff tokens, keeps proxy source checks same-origin, and fixes sidecar-token requests through Tailscale Serve (#706, #709, #710, #712, #713, #716, #739).
+- **Library** — dedupes table-of-contents heading IDs so duplicate React keys do not break the reader (#731).
+- **Memory** — blocks symlink escapes while preserving valid reads under a symlinked root (#717, #736).
+- **Workflows** — pins the collapsed right-panel toggle to the top (#734).
+
 ## [0.0.91] - 2026-06-15
 
 Patch release: tidies the GitHub PAT button.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A familiar is not just a chat window. It has a name, role, runtime, memory, tool
 
 ## Status
 
-- Current app version: `0.0.91`
+- Current app version: `0.0.92`
 - Native shell: Tauri 2
 - Frontend: Next.js 16, React 19, Tailwind v4
 - Runtime dependency: a healthy local `coven` CLI/daemon plus at least one runtime source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/server.mjs
+++ b/server.mjs
@@ -18,56 +18,71 @@ if (process.env.COVEN_CAVE_BUNDLE === "1" && !process.env.__NEXT_PRIVATE_STANDAL
   }
 }
 const ACCESS_TOKEN = process.env.COVEN_CAVE_ACCESS_TOKEN ?? "";
-const ACCESS_COOKIE = "coven_access_token";
+const ACCESS_COOKIE = "coven_cave_access";
+const LEGACY_ACCESS_COOKIE = "coven_access_token";
+const ACCESS_QUERY_PARAM = "coven_access_token";
 const sessions = /* @__PURE__ */ new Map();
-const SCROLLBACK_LIMIT_BYTES = 256 * 1024;
-const DETACH_GRACE_MS = 6e4;
-function appendScrollback(session, data) {
-  session.scrollback.push(data);
-  session.scrollbackBytes += data.length;
-  while (session.scrollbackBytes > SCROLLBACK_LIMIT_BYTES && session.scrollback.length > 1) {
-    const dropped = session.scrollback.shift();
-    if (dropped) session.scrollbackBytes -= dropped.length;
-  }
-}
-function getTokenFromCookie(header) {
-  if (!header) return "";
+function getTokensFromCookie(header) {
+  if (!header) return [];
+  const tokens = [];
   for (const part of header.split(";")) {
     const [key, ...rest] = part.trim().split("=");
-    if (key === ACCESS_COOKIE) {
-      return decodeURIComponent(rest.join("=") ?? "");
+    if (key === ACCESS_COOKIE || key === LEGACY_ACCESS_COOKIE) {
+      tokens.push(decodeURIComponent(rest.join("=") ?? ""));
     }
   }
-  return "";
+  return tokens;
 }
-function isLoopbackHostHeader(host) {
+function timingSafeEqualString(a, b) {
+  const aBytes = Buffer.from(a);
+  const bBytes = Buffer.from(b);
+  if (aBytes.length !== bBytes.length) return false;
+  let diff = 0;
+  for (let i = 0; i < aBytes.length; i += 1) {
+    diff |= aBytes[i] ^ bBytes[i];
+  }
+  return diff === 0;
+}
+function isExpectedToken(value) {
+  return Boolean(ACCESS_TOKEN && value && timingSafeEqualString(value, ACCESS_TOKEN));
+}
+function bearerToken(req) {
+  const auth = req.headers.authorization ?? "";
+  return auth.startsWith("Bearer ") ? auth.slice("Bearer ".length).trim() : null;
+}
+function isLoopbackHost(host) {
   if (!host) return false;
   const hostname2 = host.startsWith("[") ? host.slice(1, host.indexOf("]")) : host.split(":")[0];
   return hostname2 === "127.0.0.1" || hostname2 === "localhost" || hostname2 === "::1";
 }
-function isAuthorized(req) {
-  if (!ACCESS_TOKEN) return true;
-  const cookie = getTokenFromCookie(req.headers.cookie);
-  const auth = req.headers.authorization ?? "";
-  const bearer = auth.startsWith("Bearer ") ? auth.slice("Bearer ".length) : "";
-  const supplied = cookie || bearer;
-  if (supplied) return supplied === ACCESS_TOKEN;
-  return isLoopbackHostHeader(req.headers.host);
+function isLoopbackAddress(value) {
+  if (!value) return false;
+  if (value === "::1" || value === "127.0.0.1") return true;
+  if (value.startsWith("::ffff:")) return value.slice("::ffff:".length) === "127.0.0.1";
+  return false;
 }
-function isLoopbackHostname(hostname2) {
-  return hostname2 === "127.0.0.1" || hostname2 === "localhost" || hostname2 === "::1";
-}
-function isAllowedUpgradeOrigin(req) {
-  const origin = req.headers.origin;
-  if (!origin) return true;
-  let url;
+function sameOrigin(value, expectedOrigin) {
+  if (!value) return true;
   try {
-    url = new URL(origin);
+    const url = new URL(value);
+    if (url.origin === expectedOrigin) return true;
+    const expected = new URL(expectedOrigin);
+    return url.protocol === expected.protocol && url.port === expected.port && isLoopbackHost(url.host) && isLoopbackHost(expected.host);
   } catch {
     return false;
   }
-  if (isLoopbackHostname(url.hostname)) return true;
-  return url.host === (req.headers.host ?? "");
+}
+function isAllowedUpgradeSource(req) {
+  const host = req.headers.host;
+  if (!isLoopbackHost(host)) return false;
+  if (!isLoopbackAddress(req.socket.remoteAddress)) return false;
+  return sameOrigin(req.headers.origin, `http://${host}`);
+}
+function isAuthorized(req, query) {
+  if (!ACCESS_TOKEN) return false;
+  const queryToken = Array.isArray(query[ACCESS_QUERY_PARAM]) ? query[ACCESS_QUERY_PARAM][0] : query[ACCESS_QUERY_PARAM];
+  const candidates = [bearerToken(req), queryToken, ...getTokensFromCookie(req.headers.cookie)];
+  return candidates.some(isExpectedToken);
 }
 function defaultShell() {
   if (process.platform === "darwin") return "/bin/zsh";
@@ -165,10 +180,7 @@ function spawnPty(threadId, ws, cols, rows, cwd) {
     detachTimer: null
   };
   sessions.set(threadId, session);
-  shell.onData((data) => {
-    appendScrollback(session, Buffer.from(data, "utf8"));
-    if (session.ws) sendPtyData(session.ws, data);
-  });
+  shell.onData((data) => sendPtyData(ws, data));
   shell.onExit(({ exitCode }) => {
     const current = sessions.get(threadId);
     if (current?.pty === shell) {
@@ -234,22 +246,16 @@ function handlePtyConnection(ws, threadId, cols, rows, cwd) {
   ws.on("message", (data) => onWsMessage(threadId, data));
   ws.on("close", () => {
     const session = sessions.get(threadId);
-    if (session?.ws !== ws) return;
-    session.ws = null;
-    if (session.detachTimer) clearTimeout(session.detachTimer);
-    session.detachTimer = setTimeout(() => {
-      const current = sessions.get(threadId);
-      if (current !== session || current.ws) return;
-      sessions.delete(threadId);
-      try {
-        session.pty.kill();
-      } catch {
-      }
-    }, DETACH_GRACE_MS);
+    if (!session || session.ws !== ws) return;
+    sessions.delete(threadId);
+    try {
+      session.pty.kill();
+    } catch {
+    }
   });
 }
 const dev = process.env.NODE_ENV !== "production";
-const hostname = process.env.HOSTNAME ?? (dev ? "127.0.0.1" : "0.0.0.0");
+const hostname = process.env.HOSTNAME ?? "127.0.0.1";
 const port = Number.parseInt(process.env.PORT ?? "3000", 10);
 const app = next({ dev, hostname, port });
 const handle = app.getRequestHandler();
@@ -269,12 +275,12 @@ server.on("upgrade", (req, socket, head) => {
     });
     return;
   }
-  if (!isAllowedUpgradeOrigin(req)) {
+  if (!isAllowedUpgradeSource(req)) {
     socket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
     socket.destroy();
     return;
   }
-  if (!isAuthorized(req)) {
+  if (ACCESS_TOKEN && !isAuthorized(req, query)) {
     socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
     socket.destroy();
     return;

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.91"
+version = "0.0.92"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.91"
+version = "0.0.92"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.91</string>
+	<string>0.0.92</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.91</string>
+	<string>0.0.92</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.91</string>
+	<string>0.0.92</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.91</string>
+	<string>0.0.92</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- stamp CovenCave v0.0.92 across package/Tauri/Cargo/iOS metadata
- add the 0.0.92 changelog for the post-0.0.91 hardening and polish sweep
- refresh generated `server.mjs` from the current `server.ts` build output

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm run check:tests-wired`
- `node --experimental-strip-types src/lib/app-version.test.ts`
- `node --test scripts/release-notes.test.mjs`
- `bash scripts/release-notes.sh v0.0.92`
- `pnpm run typecheck`
- `pnpm run test:app`
- `pnpm run test:api`
- `pnpm run test:mobile`
- `for attempt in 1 2 3; do if pnpm build; then exit 0; fi; rm -rf .next; done; exit 1`
- `cargo check --locked` in `src-tauri`
- `git diff --check`
