### PR TITLE
fix(familiars): render uploaded avatar images across cave

### DIFF
--- a/src/components/chat-view.test.ts
+++ b/src/components/chat-view.test.ts
@@ -40,6 +40,18 @@ assert.match(
   "ChatView should send the active familiar id to /api/chat/send",
 );
 
+assert.match(
+  source,
+  /useFamiliarImages/,
+  "ChatView turn avatars should subscribe to uploaded familiar images",
+);
+
+assert.match(
+  source,
+  /<FamiliarAvatar familiar=\{resolved\} size=\{size\} \/>/,
+  "ChatView turn avatars should render uploaded images through FamiliarAvatar before glyph fallback",
+);
+
 assert.doesNotMatch(
   source,
   /native Cave chat only supports Codex, Claude Code, and Hermes right now/,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -10,9 +10,11 @@ import { slashSaveParse } from "@/lib/slash-save-parser";
 import { Icon, type IconName } from "@/lib/icon";
 import { useKeySymbols } from "@/lib/platform-keys";
 import { useVisualViewport } from "@/lib/use-viewport";
-import { FamiliarGlyph } from "@/components/familiar-glyph";
 import { useGlyphOverrides } from "@/lib/cave-glyph-overrides";
-import { resolveFamiliarGlyph } from "@/lib/familiar-glyph";
+import { useFamiliarImages } from "@/lib/cave-familiar-images";
+import { useFamiliarOverrides } from "@/lib/cave-familiar-overrides";
+import { resolveFamiliar } from "@/lib/familiar-resolve";
+import { FamiliarAvatar } from "@/components/familiar-avatar";
 import type { ChatLinkedContext } from "@/lib/chat-linked-context";
 import {
   MAX_ATTACHMENT_IMAGE_BYTES,
@@ -3200,8 +3202,15 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
 
 function FamiliarIcon({ familiar, size = "sm" }: { familiar: Familiar; size?: "sm" | "md" | "lg" }) {
   const overrides = useGlyphOverrides();
-  const glyph = resolveFamiliarGlyph(familiar, overrides);
-  return <FamiliarGlyph glyph={glyph} size={size} />;
+  const images = useFamiliarImages();
+  const familiarOverrides = useFamiliarOverrides();
+  const resolved = resolveFamiliar(familiar, {
+    override: familiarOverrides[familiar.id],
+    image: images[familiar.id],
+    glyphOverride: overrides[familiar.id],
+    archived: false,
+  });
+  return <FamiliarAvatar familiar={resolved} size={size} />;
 }
 
 function TurnRow({

--- a/src/components/familiar-roster-card.test.ts
+++ b/src/components/familiar-roster-card.test.ts
@@ -11,8 +11,8 @@ assert.match(card, /aria-label=\{`Open \$\{familiar\.display_name\}`\}/, "Card h
 
 assert.match(
   card,
-  /Icon name=\{glyph\}/,
-  "Card renders the familiar glyph (familiar.icon, with circle-half-tilt fallback)",
+  /<FamiliarAvatar familiar=\{familiar\} size="sm" \/>/,
+  "Card renders the shared FamiliarAvatar so uploaded images win over glyph fallback",
 );
 
 assert.match(card, /familiar\.display_name/, "Card shows display name");

--- a/src/components/familiars-view.test.ts
+++ b/src/components/familiars-view.test.ts
@@ -8,6 +8,24 @@ assert.match(source, /export function FamiliarsView/, "FamiliarsView must be exp
 
 assert.match(
   source,
+  /useResolvedFamiliars\(familiars, \{ includeArchived: true \}\)/,
+  "FamiliarsView should resolve local avatar images before rendering roster/detail surfaces",
+);
+
+assert.match(
+  source,
+  /<FamiliarAvatar familiar=\{familiar\} size="sm" \/>/,
+  "FamiliarsView detail header/card should render FamiliarAvatar instead of raw daemon icons",
+);
+
+assert.match(
+  source,
+  /<FamiliarAvatar familiar=\{f\} size="sm" \/>/,
+  "FamiliarsView rail should render uploaded avatar images via FamiliarAvatar",
+);
+
+assert.match(
+  source,
   /const LAST_SELECTED_KEY = "cave:agents\.lastSelected"/,
   "Selection persistence uses cave:agents.lastSelected localStorage key",
 );
@@ -56,8 +74,8 @@ assert.match(
 
 assert.match(
   source,
-  /const memoryFamiliar = selectedFamiliar \?\? activeFamiliar \?\? null/,
-  "Familiar memory scope falls back to the workspace-selected familiar",
+  /const memoryFamiliar = selectedFamiliar \?\? resolvedActiveFamiliar \?\? null/,
+  "Familiar memory scope falls back to the resolved workspace-selected familiar",
 );
 
 assert.match(

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Icon, type IconName } from "@/lib/icon";
+import { Icon } from "@/lib/icon";
 import type { Familiar, SessionRow } from "@/lib/types";
+import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { FamiliarsMemoryView, MemoryFilesList } from "@/components/familiars-memory-view";
 import type { FileMemoryEntry } from "@/components/familiars-memory-view";
 import {
@@ -10,6 +11,7 @@ import {
   type FamiliarCardStats,
   type CovenMemoryEntry,
 } from "@/components/familiars-view-stats";
+import { useResolvedFamiliars, type ResolvedFamiliar } from "@/lib/familiar-resolve";
 
 type CovenMemoryResponse =
   | { ok: true; entries: CovenMemoryEntry[] }
@@ -121,17 +123,22 @@ export function FamiliarsView({
     () => buildFamiliarCardStats({ familiars, sessions, covenEntries }),
     [familiars, sessions, covenEntries],
   );
+  const resolvedFamiliars = useResolvedFamiliars(familiars, { includeArchived: true });
 
   const visibleFamiliars = useMemo(
-    () => familiars.filter((f) => familiarMatches(f, query)),
-    [familiars, query],
+    () => resolvedFamiliars.filter((f) => familiarMatches(f, query)),
+    [resolvedFamiliars, query],
   );
 
   const selectedFamiliar = useMemo(
-    () => familiars.find((f) => f.id === selectedFamiliarId) ?? null,
-    [familiars, selectedFamiliarId],
+    () => resolvedFamiliars.find((f) => f.id === selectedFamiliarId) ?? null,
+    [resolvedFamiliars, selectedFamiliarId],
   );
-  const memoryFamiliar = selectedFamiliar ?? activeFamiliar ?? null;
+  const resolvedActiveFamiliar = useMemo(
+    () => (activeFamiliar ? resolvedFamiliars.find((f) => f.id === activeFamiliar.id) ?? null : null),
+    [activeFamiliar, resolvedFamiliars],
+  );
+  const memoryFamiliar = selectedFamiliar ?? resolvedActiveFamiliar ?? null;
 
   useEffect(() => {
     if (selectedFamiliarId && !selectedFamiliar) {
@@ -222,14 +229,14 @@ export function FamiliarsView({
         ) : viewMode === "detail" && selectedFamiliar ? (
           <div className="familiars-view__detail flex h-full min-h-0">
             <FamiliarDetailRail
-              familiars={familiars}
+              familiars={resolvedFamiliars}
               selectedId={selectedFamiliar.id}
               onSelect={enterDetail}
               onBack={backToRoster}
             />
             <FamiliarDetailPanel
               familiar={selectedFamiliar}
-              familiars={familiars}
+              familiars={resolvedFamiliars}
               sessions={sessions}
               fileEntries={fileEntries}
               memoryError={memoryError}
@@ -260,7 +267,7 @@ export function FamiliarsView({
       </div>
       {viewMode === "agent-memory" && memoryFamiliar ? (
         <FamiliarMemoryOverlay
-          familiars={familiars}
+          familiars={resolvedFamiliars}
           familiar={memoryFamiliar}
           onClose={() => setViewMode(selectedFamiliarId ? "detail" : "roster")}
           onOpenMemoryFile={onOpenMemoryFile}
@@ -303,7 +310,7 @@ function FamiliarsEmptyState({ onOpenOnboarding }: { onOpenOnboarding: () => voi
 type MemoryStatus = "loading" | "error" | "ready";
 
 type AgentRosterCardProps = {
-  familiar: Familiar;
+  familiar: ResolvedFamiliar;
   stats: FamiliarCardStats;
   daemonRunning: boolean;
   responseNeeded: boolean;
@@ -319,7 +326,6 @@ function FamiliarRosterCard({
   memoryStatus,
   onSelect,
 }: AgentRosterCardProps) {
-  const glyph = (familiar.icon ?? "ph:circle-half-tilt") as IconName;
   const lastSessionLabel = stats.lastSessionAt
     ? `Last session ${age(stats.lastSessionAt)}`
     : "No sessions yet";
@@ -333,7 +339,7 @@ function FamiliarRosterCard({
       aria-label={`Open ${familiar.display_name}`}
     >
       <div className="flex items-center gap-2">
-        <Icon name={glyph} width={18} className="text-[var(--accent-presence)]" />
+        <FamiliarAvatar familiar={familiar} size="sm" />
         <span className="min-w-0 flex-1">
           <span className="block truncate text-[13px] font-semibold text-[var(--text-primary)]">
             {familiar.display_name}
@@ -396,8 +402,8 @@ function FamiliarRosterCard({
 // ────────────────────────────────────────────────────────────────────────────
 
 type AgentMemoryOverlayProps = {
-  familiars: Familiar[];
-  familiar: Familiar;
+  familiars: ResolvedFamiliar[];
+  familiar: ResolvedFamiliar;
   onClose: () => void;
   onOpenMemoryFile: (path: string) => void;
 };
@@ -451,7 +457,7 @@ function FamiliarMemoryOverlay({ familiars, familiar, onClose, onOpenMemoryFile 
 // ────────────────────────────────────────────────────────────────────────────
 
 type AgentDetailRailProps = {
-  familiars: Familiar[];
+  familiars: ResolvedFamiliar[];
   selectedId: string;
   onSelect: (id: string) => void;
   onBack: () => void;
@@ -487,7 +493,7 @@ function FamiliarDetailRail({ familiars, selectedId, onSelect, onBack }: AgentDe
                 aria-label={f.display_name}
                 aria-current={active ? "true" : undefined}
               >
-                <Icon name={(f.icon ?? "ph:circle-half-tilt") as IconName} width={14} />
+                <FamiliarAvatar familiar={f} size="sm" />
               </button>
             </li>
           );
@@ -504,8 +510,8 @@ function FamiliarDetailRail({ familiars, selectedId, onSelect, onBack }: AgentDe
 type DetailTab = "memory" | "files" | "sessions";
 
 type AgentDetailPanelProps = {
-  familiar: Familiar;
-  familiars: Familiar[];
+  familiar: ResolvedFamiliar;
+  familiars: ResolvedFamiliar[];
   sessions: SessionRow[];
   fileEntries: FileMemoryEntry[];
   memoryError: string | null;
@@ -548,7 +554,7 @@ function FamiliarDetailPanel({
     <section className="familiars-view__panel flex min-h-0 flex-1 flex-col bg-[var(--bg-base)]">
       <header className="flex items-center justify-between gap-2 border-b border-[var(--border-hairline)] px-4 py-3">
         <div className="flex items-center gap-2">
-          <Icon name={(familiar.icon ?? "ph:circle-half-tilt") as IconName} width={18} className="text-[var(--accent-presence)]" />
+          <FamiliarAvatar familiar={familiar} size="sm" />
           <div className="min-w-0">
             <h2 className="truncate text-[14px] font-semibold text-[var(--text-primary)]">
               {familiar.display_name}


### PR DESCRIPTION
## Summary
- route familiar roster/detail/chat avatar surfaces through `FamiliarAvatar`
- resolve local uploaded familiar images before rendering those surfaces
- keep existing glyph/icons as the fallback when no image is uploaded

## Root Cause
Familiar image upload/storage already existed in Studio, but a few Cave surfaces still rendered raw daemon icons/glyphs directly. That meant uploaded images did not replace icons everywhere.

## Verification
- `node --experimental-strip-types src/lib/cave-familiar-images.test.ts && node --experimental-strip-types src/lib/familiar-resolve.test.ts && node --experimental-strip-types src/components/familiar-avatar.test.ts && node --experimental-strip-types src/components/familiar-studio-look-tab.test.ts`
- `node --experimental-strip-types src/components/familiar-roster-card.test.ts && node --experimental-strip-types src/components/familiars-view.test.ts && node --experimental-strip-types src/components/chat-view.test.ts`
- `pnpm run typecheck`
- `pnpm run check:tests-wired && pnpm run test:app`
- `pnpm run build && git diff --check`
