### PR TITLE
fix(release): install platform runner dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,7 @@ jobs:
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
             libappindicator3-dev \
+            libfuse2 \
             librsvg2-dev \
             patchelf \
             libgtk-3-dev \

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "supportedArchitectures": {
       "os": [
         "linux",
-        "darwin"
+        "darwin",
+        "win32"
       ],
       "cpu": [
         "x64",


### PR DESCRIPTION
## Summary
- install `libfuse2` on Ubuntu release runners before AppImage bundling
- include `win32` in pnpm supported architectures so Tauri's Windows native CLI binding is installed

## Root Cause
The v0.0.92 release failed after the app build succeeded:
- Linux compiled the Tauri app, then AppImage bundling failed while running `linuxdeploy`; Ubuntu AppImage tooling needs FUSE support available on the runner.
- Windows failed immediately in `pnpm tauri build` because `@tauri-apps/cli-win32-x64-msvc` was not installed. `package.json` only allowed pnpm to materialize Linux and Darwin optional architecture packages.
- macOS Intel failed during Apple notarization polling with `NSURLErrorDomain Code=-1009`, which looks transient rather than a repo config issue.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm run test:supply-chain`
- `git diff --check`
- `test -d node_modules/.pnpm/@tauri-apps+cli-win32-x64-msvc@2.11.2`
- `pnpm exec tauri --version`
