### PR TITLE
fix(ui): tighten cave sidepanel spacing

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5071,17 +5071,6 @@ button:active > .edge-rail-chip {
     -webkit-overflow-scrolling: touch;
   }
 
-  /* Familiar switcher strip — horizontal momentum scroll, no visible bar. */
-  .chat-list-familiar-strip {
-    overscroll-behavior-x: contain;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none;
-  }
-
-  .chat-list-familiar-strip::-webkit-scrollbar {
-    display: none;
-  }
-
   .chat-list-search-control,
   .chat-list-filter-button,
   .chat-list-new-button {

--- a/src/components/chat-list-mobile-rail-port.test.ts
+++ b/src/components/chat-list-mobile-rail-port.test.ts
@@ -5,28 +5,11 @@ import { readFileSync } from "node:fs";
 const source = readFileSync(new URL("./chat-list.tsx", import.meta.url), "utf8");
 const styles = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 
-// ── Familiar switcher strip (mobile analog of the desktop rail footer) ───────
-assert.match(source, /function ChatListFamiliarStrip/, "ChatList gains a familiar-switcher strip");
-assert.match(source, /useResolvedFamiliars\(familiars\)/, "The strip resolves familiars for display");
-assert.match(source, /<FamiliarAvatar familiar=\{f\} size="md"/, "Each chip reuses FamiliarAvatar");
-assert.match(
-  source,
-  /className="chat-list-familiar-strip /,
-  "The strip exposes a mobile-targetable class for horizontal scroll styling",
-);
-// Tapping a familiar starts a chat with them; wired where the strip is rendered.
-assert.match(
-  source,
-  /<ChatListFamiliarStrip[\s\S]{0,160}onSelect=\{\(id\) => onNewChat\(undefined, id\)\}/,
-  "Tapping a familiar chip starts a new chat scoped to that familiar",
-);
-// The trailing chip jumps to the Familiars surface via the shared nav event.
-assert.match(
-  source,
-  /new CustomEvent\("cave:navigate-mode", \{ detail: \{ mode \} \}\)/,
-  "The strip's + chip uses the decoupled cave:navigate-mode bridge",
-);
-assert.match(source, /navigateToMode\("agents"\)/, "The + chip opens the Familiars surface");
+// ── Familiar switching lives in the sidepanel selector ──────────────────────
+assert.doesNotMatch(source, /function ChatListFamiliarStrip/, "ChatList should not render a redundant circular familiar strip");
+assert.doesNotMatch(source, /chat-list-familiar-strip/, "ChatList should not keep the removed strip styling hook");
+assert.doesNotMatch(source, /<FamiliarAvatar familiar=\{f\} size="md"/, "ChatList should not map familiars into circular selector chips");
+assert.doesNotMatch(styles, /\.chat-list-familiar-strip/, "Removed familiar strip should not leave dead mobile CSS behind");
 
 // ── Counted PINNED / SESSIONS section headers ────────────────────────────────
 assert.match(source, /function ChatListSection/, "ChatList gains a counted section-header primitive");
@@ -53,13 +36,6 @@ assert.match(
   source,
   /projectRoot === null && idx === firstPinnedIdx/,
   "Sections only apply to the flat all-chats list",
-);
-
-// ── Strip CSS: horizontal momentum scroll without a visible bar ──────────────
-assert.match(
-  styles,
-  /@media \(max-width: 767px\) \{[\s\S]*\.chat-list-familiar-strip\s*\{[\s\S]*scrollbar-width\s*:\s*none/,
-  "Mobile familiar strip scrolls horizontally without a visible scrollbar",
 );
 
 // ── Preserved: existing rows still sortable by session id ────────────────────

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -2,7 +2,6 @@
 
 import { Fragment, useMemo, useState, useEffect, useRef, type CSSProperties, type ReactNode } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
-import type { WorkspaceMode } from "@/lib/workspace-mode";
 import { stripLeadingTrailingEmoji } from "@/lib/cave-chat-titles";
 import { Icon } from "@/lib/icon";
 import { useKeySymbols } from "@/lib/platform-keys";
@@ -178,12 +177,6 @@ function SortableChatListItem({
   );
 }
 
-// Decoupled cross-surface navigation (matches the desktop rail): announce a
-// target mode; the Workspace owns setMode and switches surfaces.
-function navigateToMode(mode: WorkspaceMode) {
-  window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode } }));
-}
-
 // Uppercase counted section header — mirrors the desktop rail's RailSection so
 // the phone list reads with the same grouping language (PINNED / SESSIONS).
 function ChatListSection({ label, count }: { label: string; count?: number }) {
@@ -196,57 +189,6 @@ function ChatListSection({ label, count }: { label: string; count?: number }) {
         <span className="font-mono text-[11px] text-[var(--text-muted)] opacity-70">{count}</span>
       ) : null}
     </li>
-  );
-}
-
-// Horizontal familiar-switcher strip for the phone chat list — the mobile analog
-// of the desktop rail's footer avatars. Tap starts a chat with that familiar;
-// the trailing chip jumps to the Familiars surface to add or manage one.
-function ChatListFamiliarStrip({
-  familiars,
-  activeFamiliarId,
-  onSelect,
-}: {
-  familiars: Familiar[];
-  activeFamiliarId?: string | null;
-  onSelect: (id: string) => void;
-}) {
-  const resolved = useResolvedFamiliars(familiars);
-  if (resolved.length === 0) return null;
-  return (
-    <div className="chat-list-familiar-strip flex items-center gap-2 overflow-x-auto px-4 pb-1 pt-2.5">
-      {resolved.map((f) => {
-        const active = f.id === activeFamiliarId;
-        return (
-          <button
-            key={f.id}
-            type="button"
-            onClick={() => onSelect(f.id)}
-            title={`New chat with ${f.display_name}`}
-            aria-label={`New chat with ${f.display_name}`}
-            aria-pressed={active}
-            style={{ ["--familiar-accent" as string]: f.color }}
-            className={[
-              "grid h-10 w-10 shrink-0 place-items-center rounded-full border bg-[var(--bg-raised)] transition-all active:scale-95",
-              active
-                ? "border-[var(--familiar-accent,var(--accent-presence))] ring-1 ring-[var(--familiar-accent,var(--accent-presence))]"
-                : "border-transparent",
-            ].join(" ")}
-          >
-            <FamiliarAvatar familiar={f} size="md" />
-          </button>
-        );
-      })}
-      <button
-        type="button"
-        onClick={() => navigateToMode("agents")}
-        title="Open familiars"
-        aria-label="Open familiars"
-        className="focus-ring grid h-10 w-10 shrink-0 place-items-center rounded-full border border-dashed border-[var(--border-hairline)] text-[var(--text-muted)] transition-colors active:scale-95"
-      >
-        <Icon name="ph:plus" width={14} aria-hidden />
-      </button>
-    </div>
   );
 }
 
@@ -662,14 +604,6 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
           </div>
         </div>
         )}
-
-        {/* Familiar switcher — horizontal strip mirroring the desktop rail's
-            footer avatars; tap starts a chat with that familiar. */}
-        <ChatListFamiliarStrip
-          familiars={familiars}
-          activeFamiliarId={familiar?.id ?? null}
-          onSelect={(id) => onNewChat(undefined, id)}
-        />
 
         {/* Stats removed for sidepanel optimization */}
 

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -104,6 +104,8 @@ assert.match(studio, /rightPanelOpen,\s*setRightPanelOpen[\s\S]{0,80}useState\(t
 assert.match(studio, /type WorkflowSidePanelSection/, "Workflow right panel should model distinct selectable sections");
 assert.match(studio, /sidePanelSection,\s*setSidePanelSection[\s\S]{0,100}useState<WorkflowSidePanelSection>\("inspector"\)/, "Workflow right panel should default to the inspector section");
 assert.match(studio, /<Tabs<WorkflowSidePanelSection>[\s\S]{0,160}ariaLabel="Workflow detail sections"/, "Workflow right panel should expose section tabs (shared Vercel-style Tabs) instead of using selection as a close action");
+assert.match(studio, /<Tabs<WorkflowSidePanelSection>[\s\S]{0,180}size="sm"/, "Workflow right panel tabs should use compact density so Manifest fits in the sidepanel");
+assert.doesNotMatch(studio, /<Tabs<WorkflowSidePanelSection>[\s\S]{0,220}\n\s*fill\n/, "Workflow right panel tabs should not use equal-width fill tabs in the narrow sidepanel");
 assert.match(studio, /setSidePanelSection\(id\);[\s\S]{0,80}if \(!rightPanelOpen\) setRightPanelOpen\(true\);/, "Selecting a workflow side-panel tab should open or keep the panel open");
 assert.match(studio, /sidePanelSection === "inspector"[\s\S]{0,400}<WorkflowInspector/, "Workflow inspector should render only in the inspector tab panel");
 assert.match(studio, /sidePanelSection === "attachments"[\s\S]{0,500}<WorkflowAttachments/, "Workflow attachments should render only in the attachments tab panel");
@@ -126,6 +128,9 @@ assert.match(css, /\.workflow-side-panel-header/, "Workflow right side panel sho
 // `.workflow-side-panel-tab[aria-selected]` box rule no longer exists. The
 // tablist container class is still styled here for layout.
 assert.match(css, /\.workflow-side-panel-tabs\s*\{/, "Workflow right side panel tablist should keep its layout styles");
+assert.match(css, /\.workflow-side-panel-tabs\s*\{[\s\S]{0,120}flex:\s*0 1 auto/, "Workflow right side panel tabs should size to their labels, not spread into wide gutters");
+assert.match(css, /\.workflow-side-panel-tabs\s*\{[\s\S]{0,180}max-width:\s*calc\(100% - var\(--workflow-top-control-height\) - 4px\)/, "Workflow tabs reserve room for the collapse button without clipping Manifest");
+assert.match(css, /\.workflow-side-panel-header\s*\{[\s\S]{0,140}gap:\s*4px[\s\S]{0,120}margin:\s*0 0 4px/, "Workflow sidepanel header should keep tight spacing between tabs, toggle, and content");
 assert.match(css, /\.workflow-studio-library-panel,[\s\S]{0,140}flex-direction:\s*column/, "Workflow panel content should sit below the full-width trigger row");
 assert.match(css, /\.workflow-palette-item[\s\S]{0,160}min-height:\s*var\(--workflow-top-control-height\)/, "Workflow palette buttons should use the same height as the side-panel triggers");
 assert.match(css, /is-left-collapsed[\s\S]{0,120}grid-template-columns:\s*36px/, "Collapsed left workflow panel should keep a visible toggle rail");

--- a/src/components/workflows/workflow-studio.tsx
+++ b/src/components/workflows/workflow-studio.tsx
@@ -300,7 +300,7 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
             className="workflow-side-panel-tabs"
             ariaLabel="Workflow detail sections"
             idPrefix="workflow-side-panel"
-            fill
+            size="sm"
             value={sidePanelSection}
             onChange={(id) => {
               setSidePanelSection(id);

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -158,18 +158,23 @@
 .workflow-side-panel-header {
   display: flex;
   align-items: flex-end;
-  gap: 6px;
+  gap: 4px;
   flex-shrink: 0;
   width: 100%;
   min-height: var(--workflow-top-control-height);
-  margin: 0 0 6px;
+  margin: 0 0 4px;
 }
 
-/* Workflow detail tabs — Vercel-style underline tabs (components/ui/tabs.tsx).
-   The tablist fills the header row; the collapse toggle keeps its own box. */
+/* Workflow detail tabs — compact underline tabs (components/ui/tabs.tsx).
+   Natural-width tabs keep "Manifest" readable beside the collapse button. */
 .workflow-side-panel-tabs {
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   min-width: 0;
+  max-width: calc(100% - var(--workflow-top-control-height) - 4px);
+}
+
+.workflow-studio-side-content .workflow-panel {
+  padding-top: 10px;
 }
 
 .workflow-panel-collapse-button {


### PR DESCRIPTION
## Summary
- remove the duplicate circular familiar selector from the chat list now that familiar switching lives in the sidepanel
- tighten the Workflow sidepanel Inspect / Bind / Manifest tabs so Manifest is not clipped and the collapse button spacing is cleaner
- update guard tests for both UI decisions

## Test Plan
- node src/components/chat-list-mobile-rail-port.test.ts
- node src/components/workflows/workflow-studio.test.ts
- pnpm exec tsc --noEmit
- git diff --check
- pnpm run test:app