### PR TITLE
feat(familiars): redesign familiar sessions surface

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3620,6 +3620,14 @@ button:active > .edge-rail-chip {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  min-width: 0;
+}
+
+.top-bar__actions .familiar-switcher__trigger[data-labeled="true"] {
+  width: min(174px, 34vw);
+  height: 34px;
+  border-radius: var(--radius-control);
+  background: var(--bg-base);
 }
 
 /* ── Familiar profile switcher ──────────────────────────────────────────────
@@ -3653,10 +3661,11 @@ button:active > .edge-rail-chip {
   color: var(--text-muted);
 }
 
-/* Labeled variant — the sidebar's familiar-scope control. Full-width row
+/* Labeled variant — the familiar-scope control. Full-width row
    (avatar/glyph + name + caret) that lines up with the New chat / Ask Salem
    action rows beneath it, so the control reads as the scope selector instead of
-   a bare floating icon. The mobile top bar keeps the compact icon (no label). */
+   a bare floating icon. Surface-specific wrappers constrain this width where
+   needed, such as the Familiars header and mobile top bar. */
 .familiar-switcher__trigger[data-labeled="true"] {
   width: 100%;
   height: 32px;

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -156,7 +156,7 @@ assert.match(
 );
 assert.match(
   source,
-  /aria-pressed=\{showArchived\}[\s\S]*?aria-label=\{showArchived \? "Hide archived chats" : "Show archived chats"\}/,
+  /aria-pressed=\{showArchived\}[\s\S]*?aria-label=\{showArchived \? "Hide archived sessions" : "Show archived sessions"\}/,
   "Show archived filter should be an aria-labeled toggle alongside the existing filters",
 );
 

--- a/src/components/chat-list-mobile-rail-port.test.ts
+++ b/src/components/chat-list-mobile-rail-port.test.ts
@@ -4,12 +4,16 @@ import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./chat-list.tsx", import.meta.url), "utf8");
 const styles = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const topBar = readFileSync(new URL("./top-bar.tsx", import.meta.url), "utf8");
+const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 
-// ── Familiar switching lives in the sidepanel selector ──────────────────────
-assert.doesNotMatch(source, /function ChatListFamiliarStrip/, "ChatList should not render a redundant circular familiar strip");
-assert.doesNotMatch(source, /chat-list-familiar-strip/, "ChatList should not keep the removed strip styling hook");
+// ── Familiar switcher lives in the header, not the mobile chat list ──────────
+assert.doesNotMatch(source, /function ChatListFamiliarStrip/, "ChatList should not duplicate the header familiar selector");
+assert.doesNotMatch(source, /chat-list-familiar-strip/, "Mobile list should not keep the removed familiar-strip hook");
 assert.doesNotMatch(source, /<FamiliarAvatar familiar=\{f\} size="md"/, "ChatList should not map familiars into circular selector chips");
 assert.doesNotMatch(styles, /\.chat-list-familiar-strip/, "Removed familiar strip should not leave dead mobile CSS behind");
+assert.match(topBar, /labeled=\{familiarSwitcherLabeled\}/, "TopBar can render the labeled familiar selector");
+assert.match(workspace, /familiarSwitcherLabeled=\{mode === "chat"\}/, "Workspace labels the top-bar selector on the Familiars page");
 
 // ── Counted PINNED / SESSIONS section headers ────────────────────────────────
 assert.match(source, /function ChatListSection/, "ChatList gains a counted section-header primitive");

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -523,9 +523,6 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
         expandedKeys={expandedKeys}
         open={sidebarOpen}
         activeSessionId={activeId}
-        familiars={familiars}
-        activeFamiliarId={familiar?.id ?? null}
-        onSelectFamiliar={(id) => onNewChat(undefined, id)}
         onSetOpen={setSidebarOpen}
         onSelect={setSelection}
         onToggleExpanded={(key) =>
@@ -591,7 +588,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               </p>
             </div>
 
-            {/* + Chat CTA */}
+            {/* + Session CTA */}
             <button
               type="button"
               onClick={() => onNewChat(undefined, fallbackFamiliarId)}
@@ -599,7 +596,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               className="chat-list-new-button mt-0.5 flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-[var(--accent-presence)] px-3 text-[12px] font-semibold text-white shadow-[0_1px_8px_color-mix(in_oklch,var(--accent-presence)_35%,transparent)] transition-all hover:opacity-90 hover:shadow-[0_2px_12px_color-mix(in_oklch,var(--accent-presence)_50%,transparent)] active:scale-95"
             >
               <Icon name="ph:plus-bold" width={11} />
-              Chat
+              Session
             </button>
           </div>
         </div>
@@ -616,7 +613,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               type="text"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search chats…"
+              placeholder="Search sessions…"
               className="min-w-0 flex-1 bg-transparent text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none"
             />
             {search && (
@@ -634,8 +631,8 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
           <button
             type="button"
             onClick={() => setUnreadsOnly((v) => !v)}
-            title={unreadsOnly ? "Show all chats" : "Show unreads only"}
-            aria-label={unreadsOnly ? "Show all chats" : "Show unreads only"}
+            title={unreadsOnly ? "Show all sessions" : "Show active only"}
+            aria-label={unreadsOnly ? "Show all sessions" : "Show active only"}
             className={[
               "chat-list-filter-button focus-ring grid h-8 w-8 shrink-0 place-items-center rounded-lg border transition-colors",
               unreadsOnly
@@ -652,8 +649,8 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
             type="button"
             onClick={() => setShowArchived((v) => !v)}
             aria-pressed={showArchived}
-            aria-label={showArchived ? "Hide archived chats" : "Show archived chats"}
-            title={showArchived ? "Hide archived chats" : "Show archived chats"}
+            aria-label={showArchived ? "Hide archived sessions" : "Show archived sessions"}
+            title={showArchived ? "Hide archived sessions" : "Show archived sessions"}
             className={[
               "chat-list-filter-button focus-ring grid h-8 w-8 shrink-0 place-items-center rounded-lg border transition-colors",
               showArchived
@@ -664,7 +661,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
             <Icon name="ph:archive" width={12} aria-hidden />
           </button>
 
-          {/* With the identity row hidden, the + Chat CTA lives here */}
+          {/* With the identity row hidden, the + Session CTA lives here */}
           {familiar && (
             <button
               type="button"
@@ -673,7 +670,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               className="chat-list-new-button flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-[var(--accent-presence)] px-3 text-[12px] font-semibold text-white shadow-[0_1px_8px_color-mix(in_oklch,var(--accent-presence)_35%,transparent)] transition-all hover:opacity-90 hover:shadow-[0_2px_12px_color-mix(in_oklch,var(--accent-presence)_50%,transparent)] active:scale-95"
             >
               <Icon name="ph:plus-bold" width={11} />
-              Chat
+              Session
             </button>
           )}
         </div>
@@ -759,7 +756,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
           <div className="flex flex-col items-center justify-center gap-2 py-16 text-center">
             <Icon name="ph:magnifying-glass" width={20} className="text-[var(--text-muted)]" />
             <p className="text-sm text-[var(--text-muted)]">
-              {search.trim() ? `No results for "${search}"` : "No chats match the current filters"}
+              {search.trim() ? `No results for "${search}"` : "No sessions match the current filters"}
             </p>
             <button
               type="button"
@@ -780,7 +777,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
             <SortableContext items={displayIds} strategy={verticalListSortingStrategy}>
           <ul className="divide-y divide-[var(--border-hairline)]">
             {displayGroups.map(({ projectRoot, sessions: rows, defaultFamiliarId }) => {
-              // Flat "All chats" view (the phone surface): split the list into a
+              // Flat "All sessions" view (the phone surface): split the list into a
               // counted PINNED section and a counted SESSIONS section, mirroring
               // the desktop rail. firstPinnedIdx/firstRestIdx place each header
               // before its first member, so it reads right regardless of order.
@@ -805,8 +802,8 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                         e.stopPropagation();
                         onNewChat(projectRoot, defaultFamiliarId ?? fallbackFamiliarId);
                       }}
-                      title={`New chat in ${repoName(projectRoot)}`}
-                      aria-label={`New chat in ${repoName(projectRoot)}`}
+                      title={`New session in ${repoName(projectRoot)}`}
+                      aria-label={`New session in ${repoName(projectRoot)}`}
                     >
                       <Icon name="ph:plus" width="0.7rem" height="0.7rem" />
                     </button>

--- a/src/components/chat-project-sidebar.tsx
+++ b/src/components/chat-project-sidebar.tsx
@@ -1,13 +1,11 @@
 "use client";
 
 import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from "react";
-import type { Familiar, SessionRow } from "@/lib/types";
+import type { SessionRow } from "@/lib/types";
 import { type ChatProjectGroup } from "@/lib/chat-projects";
 import { selectionKey, type ProjectSelection } from "@/lib/chat-project-selection";
 import { setProjectOverride } from "@/lib/chat-project-overrides";
 import { stripLeadingTrailingEmoji } from "@/lib/cave-chat-titles";
-import { useResolvedFamiliars } from "@/lib/familiar-resolve";
-import { FamiliarAvatar } from "@/components/familiar-avatar";
 import type { WorkspaceMode } from "@/lib/workspace-mode";
 import {
   PINNED_SESSIONS_KEY,
@@ -75,10 +73,6 @@ type Props = {
   expandedKeys: string[];
   open: boolean;
   activeSessionId?: string | null;
-  /** Familiars for the footer avatar strip (optional — omitted in compact embeds). */
-  familiars?: Familiar[];
-  activeFamiliarId?: string | null;
-  onSelectFamiliar?: (id: string) => void;
   onSetOpen: (open: boolean) => void;
   onSelect: (selection: ProjectSelection) => void;
   onToggleExpanded: (key: string) => void;
@@ -361,71 +355,12 @@ function FolderChatRow({
   );
 }
 
-// Footer avatar strip — the rail's familiar switcher. Clicking starts a fresh
-// chat scoped to that familiar; the trailing chip jumps to the Familiars surface
-// to add or manage one. Mirrors the look of the standalone familiar-avatar-rail.
-function RailFamiliarStrip({
-  familiars,
-  activeFamiliarId,
-  onSelectFamiliar,
-}: {
-  familiars: Familiar[];
-  activeFamiliarId?: string | null;
-  onSelectFamiliar: (id: string) => void;
-}) {
-  const resolved = useResolvedFamiliars(familiars);
-  const MAX = 6;
-  const shown = resolved.slice(0, MAX);
-  const overflow = resolved.length - shown.length;
-  return (
-    <div className="flex shrink-0 items-center gap-1 border-t border-[var(--border-hairline)] px-2 py-1.5">
-      {shown.map((f) => {
-        const active = f.id === activeFamiliarId;
-        return (
-          <button
-            key={f.id}
-            type="button"
-            onClick={() => onSelectFamiliar(f.id)}
-            title={`New chat with ${f.display_name}`}
-            aria-label={`New chat with ${f.display_name}`}
-            aria-pressed={active}
-            style={{ ["--familiar-accent" as string]: f.color }}
-            className={[
-              "grid h-6 w-6 shrink-0 place-items-center rounded-full border bg-[var(--bg-raised)] transition-all hover:scale-105",
-              active
-                ? "border-[var(--familiar-accent,var(--accent-presence))] ring-1 ring-[var(--familiar-accent,var(--accent-presence))]"
-                : "border-transparent",
-            ].join(" ")}
-          >
-            <FamiliarAvatar familiar={f} size="sm" />
-          </button>
-        );
-      })}
-      {overflow > 0 ? (
-        <span className="shrink-0 font-mono text-[10px] text-[var(--text-muted)]">+{overflow}</span>
-      ) : null}
-      <button
-        type="button"
-        onClick={() => navigateToMode("agents")}
-        title="Open familiars"
-        aria-label="Open familiars"
-        className="focus-ring ml-auto grid h-6 w-6 shrink-0 place-items-center rounded-full border border-dashed border-[var(--border-hairline)] text-[var(--text-muted)] transition-colors hover:border-[color-mix(in_oklch,var(--accent-presence)_60%,transparent)] hover:text-[var(--text-secondary)]"
-      >
-        <Icon name="ph:plus" width={11} aria-hidden />
-      </button>
-    </div>
-  );
-}
-
 export function ChatProjectSidebar({
   groups,
   selection,
   expandedKeys,
   open,
   activeSessionId,
-  familiars = [],
-  activeFamiliarId,
-  onSelectFamiliar,
   onSetOpen,
   onSelect,
   onToggleExpanded,
@@ -597,8 +532,8 @@ export function ChatProjectSidebar({
         <button
           type="button"
           onClick={() => onSetOpen(true)}
-          title="Show chats"
-          aria-label="Show chats"
+          title="Show sessions"
+          aria-label="Show sessions"
           aria-expanded={false}
           className="focus-ring flex w-7 flex-col items-center pt-3 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)]/50 hover:text-[var(--text-primary)]"
         >
@@ -617,8 +552,8 @@ export function ChatProjectSidebar({
         <button
           type="button"
           onClick={() => onSetOpen(false)}
-          title="Hide chats"
-          aria-label="Hide chats"
+          title="Hide sessions"
+          aria-label="Hide sessions"
           aria-expanded
           className="focus-ring grid h-6 w-6 place-items-center rounded text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)]/40 hover:text-[var(--text-primary)]"
         >
@@ -632,8 +567,8 @@ export function ChatProjectSidebar({
           icon="ph:plus-bold"
           prominent
           kbd="⌘N"
-          title="New chat"
-          ariaLabel="New chat"
+          title="New session"
+          ariaLabel="New session"
           onClick={() => onNewChat(null)}
           label="New session"
         />
@@ -655,8 +590,8 @@ export function ChatProjectSidebar({
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search chats…"
-            aria-label="Search chats"
+            placeholder="Search sessions…"
+            aria-label="Search sessions"
             className="min-w-0 flex-1 bg-transparent text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none"
           />
           {search && (
@@ -673,7 +608,7 @@ export function ChatProjectSidebar({
       </div>
 
       {/* Filter chips — All · Active · Tasks · Pinned */}
-      <div className="chat-thread-filters flex shrink-0 items-center gap-1 px-2 pb-2" role="tablist" aria-label="Chat filters">
+      <div className="chat-thread-filters flex shrink-0 items-center gap-1 px-2 pb-2" role="tablist" aria-label="Session filters">
         {FILTERS.map((f) => {
           const isActive = filter === f.key;
           return (
@@ -698,15 +633,15 @@ export function ChatProjectSidebar({
         })}
       </div>
 
-      <nav aria-label="Chats" className="min-h-0 flex-1 overflow-y-auto pb-2">
-        {/* ── Flat, always-visible all-chats list, grouped into sections ── */}
+      <nav aria-label="Familiar sessions" className="min-h-0 flex-1 overflow-y-auto pb-2">
+        {/* ── Flat, always-visible all-sessions list, grouped into sections ── */}
         {display.length === 0 ? (
           <p className="px-3 py-6 text-center text-[11px] text-[var(--text-muted)]">
             {search.trim()
-              ? "No chats match your search"
+              ? "No sessions match your search"
               : filter === "all"
-                ? "No chats yet"
-                : `No ${filter} chats`}
+                ? "No sessions yet"
+                : `No ${filter} sessions`}
           </p>
         ) : (
           <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
@@ -718,7 +653,7 @@ export function ChatProjectSidebar({
                   </li>
                   {pinnedRows.length === 0 ? (
                     <li className="px-3 pb-1 text-[11px] text-[var(--text-muted)]">
-                      Pin a chat to keep it here
+                      Pin a session to keep it here
                     </li>
                   ) : (
                     pinnedRows.map((session) => (
@@ -785,7 +720,7 @@ export function ChatProjectSidebar({
                         : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]",
                     ].join(" ")}
                   >
-                    All chats
+                    All sessions
                   </button>
                 }
               />
@@ -839,8 +774,8 @@ export function ChatProjectSidebar({
                     <button
                       type="button"
                       onClick={() => onNewChat(group.projectRoot)}
-                      title={`New chat in ${label}`}
-                      aria-label={`New chat in ${label}`}
+                      title={`New session in ${label}`}
+                      aria-label={`New session in ${label}`}
                       className="touch-always-visible focus-ring grid h-5 w-5 shrink-0 place-items-center rounded text-[var(--text-muted)] opacity-0 transition-opacity hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] focus-visible:opacity-100 group-hover:opacity-100"
                     >
                       <Icon name="ph:plus" width={11} aria-hidden />
@@ -887,17 +822,6 @@ export function ChatProjectSidebar({
           </button>
         ))}
       </div>
-
-      {/* ── Familiar switcher strip ── start a chat with any familiar, or jump
-            to the Familiars surface to add one. Only shown when wired with
-            familiars + a select handler (omitted in compact embeds). */}
-      {onSelectFamiliar && familiars.length > 0 ? (
-        <RailFamiliarStrip
-          familiars={familiars}
-          activeFamiliarId={activeFamiliarId}
-          onSelectFamiliar={onSelectFamiliar}
-        />
-      ) : null}
     </aside>
   );
 }

--- a/src/components/chat-rail-modern-redesign.test.ts
+++ b/src/components/chat-rail-modern-redesign.test.ts
@@ -61,37 +61,28 @@ assert.match(
 assert.match(source, /label="Projects"/, "Projects keep a section header");
 assert.match(
   source,
-  /Pin a chat to keep it here/,
+  /Pin a session to keep it here/,
   "Empty PINNED section shows a hint, like the mockup",
 );
 
-// ── Familiar-avatar footer strip ─────────────────────────────────────────────
-assert.match(source, /function RailFamiliarStrip/, "Rail footer carries a familiar-avatar strip");
-assert.match(source, /useResolvedFamiliars\(familiars\)/, "The strip resolves familiars for display");
-assert.match(source, /<FamiliarAvatar familiar=\{f\} size="sm"/, "Each chip reuses the FamiliarAvatar");
-assert.match(
-  source,
-  /onClick=\{\(\) => navigateToMode\("agents"\)\}/,
-  "The trailing + chip jumps to the Familiars surface",
-);
-assert.match(
-  source,
-  /\{onSelectFamiliar && familiars\.length > 0 \?/,
-  "The strip only renders when wired (optional in compact embeds)",
-);
+// ── Familiar selection lives in the page header, not this rail ───────────────
+assert.doesNotMatch(source, /function RailFamiliarStrip/, "Rail no longer carries a duplicate familiar-avatar strip");
+assert.doesNotMatch(source, /<FamiliarAvatar familiar=\{f\} size="sm"/, "Familiar chips moved out of the session rail");
+assert.match(source, /placeholder="Search sessions…"/, "Rail search uses session language");
+assert.match(source, /aria-label="Familiar sessions"/, "Rail names the region as familiar sessions");
 
-// ── Ops footer (Git / Inspect / Debug) is kept alongside the avatars ─────────
+// ── Ops footer (Git / Inspect / Debug) is preserved ─────────────────────────
 assert.match(
   source,
   /event: "cave:changes-open", label: "Git"/,
   "Git/Inspect/Debug ops row is preserved",
 );
 
-// ── Router forwards the familiar wiring into the rail ─────────────────────────
-assert.match(
+// ── Router no longer forwards familiar selection into the rail ───────────────
+assert.doesNotMatch(
   router,
-  /familiars=\{familiars\}[\s\S]{0,120}activeFamiliarId=\{familiar\?\.id \?\? null\}[\s\S]{0,160}onSelectFamiliar=\{/,
-  "ChatRouter forwards familiars + active id + select handler into the sidebar",
+  /onSelectFamiliar=\{/,
+  "ChatRouter keeps familiar selection out of the session rail",
 );
 
 console.log("chat-rail-modern-redesign.test.ts: ok");

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -312,12 +312,6 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
         expandedKeys={expandedKeys}
         open={sidebarOpen}
         activeSessionId={view.kind === "chat" ? view.sessionId : null}
-        familiars={familiars}
-        activeFamiliarId={familiar?.id ?? null}
-        onSelectFamiliar={(id) => {
-          const next = selectFamiliarForChat(id);
-          setView({ kind: "chat", sessionId: null, familiarId: next?.id ?? id });
-        }}
         onSetOpen={setSidebarOpen}
         onSelect={setSelection}
         onToggleExpanded={(key) =>

--- a/src/components/chat-surface-projects-tab.test.ts
+++ b/src/components/chat-surface-projects-tab.test.ts
@@ -12,7 +12,7 @@ assert.match(surface, /CHAT_OPEN_PROJECTS_EVENT/, "chat-surface references the r
 assert.match(surface, /type FamiliarsScope = "conversation" \| "memory" \| "projects"/, "scope union includes projects");
 assert.match(
   surface,
-  /\{\s*id:\s*"conversation",\s*label:\s*"Chats"\s*\}[\s\S]*?\{\s*id:\s*"memory",\s*label:\s*"Memory"\s*\}[\s\S]*?\{\s*id:\s*"projects",\s*label:\s*"Projects"\s*\}/,
+  /\{\s*id:\s*"conversation",\s*label:\s*"Sessions"\s*\}[\s\S]*?\{\s*id:\s*"memory",\s*label:\s*"Memory"\s*\}[\s\S]*?\{\s*id:\s*"projects",\s*label:\s*"Projects"\s*\}/,
   "shared Tabs items list all three scopes ending with the projects tab",
 );
 assert.match(surface, /\{\s*id:\s*"projects",\s*label:\s*"Projects"\s*\}/, "projects tab is labeled");

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -89,6 +89,16 @@ assert.match(
   /\{\s*id:\s*"memory",\s*label:\s*"Memory"\s*\}/,
   "ChatSurface should label the secondary primary tab Memory instead of Traces",
 );
+assert.match(
+  chatSurface,
+  /<FamiliarSwitcher[\s\S]*activeFamiliarId=\{activeFamiliarId\}[\s\S]*onSelectFamiliar=\{\(id\) => \{/,
+  "ChatSurface should move familiar selection into the page header",
+);
+assert.match(
+  chatSurface,
+  /\{\s*id:\s*"conversation",\s*label:\s*"Sessions"\s*\}/,
+  "ChatSurface should name the primary history tab Sessions inside the Familiars page",
+);
 
 assert.match(
   chatSurface,
@@ -189,7 +199,7 @@ assert.match(
 assert.match(
   workspace,
   /mode === "chat"[\s\S]*<ChatSurface/,
-  "Workspace should mount ChatSurface for chat mode",
+  "Workspace should mount ChatSurface for the internal chat mode",
 );
 
 assert.match(

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -13,6 +13,8 @@ import { SeparatorHandle } from "@/components/ui/separator-handle";
 import { useIsMobile } from "@/lib/use-viewport";
 import { Tabs } from "@/components/ui/tabs";
 import { Icon } from "@/lib/icon";
+import { FamiliarSwitcher } from "@/components/familiar-switcher";
+import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { PendingChatAction } from "@/lib/pending-chat-action";
@@ -38,7 +40,7 @@ type Props = {
   pendingChatAction?: PendingChatAction;
   onSetInspectorOpen: (open: boolean) => void;
   onSetRightPanel?: (panel: RightPanelKind | null) => void;
-  onSetActiveFamiliar: (id: string) => void;
+  onSetActiveFamiliar: (id: string | null) => void;
   onClearPendingProjectRoot: () => void;
   onPendingChatActionHandled: () => void;
   onSessionStarted: () => void;
@@ -185,6 +187,7 @@ export function ChatSurface({
   }
 
   const scopedFamiliars = useMemo(() => activeFamiliar ? [activeFamiliar] : familiars, [activeFamiliar, familiars]);
+  const resolvedFamiliars = useResolvedFamiliars(familiars, { includeArchived: true });
 
   // Window events
   useEffect(() => {
@@ -288,31 +291,48 @@ export function ChatSurface({
       {/* Main content */}
       <div className="flex min-w-0 flex-1 flex-col">
         {/* ── Ultra-minimalist header ────────────────────────────────────── */}
-        <div className="chat-scope-tabs chat-scope-tabs--minimal flex shrink-0 items-center justify-between border-b border-[var(--border-hairline)] px-4">
-          {/* Tabs flush left — Vercel-style underline tabs. The header row
-              already draws the divider, so the tablist itself is borderless. */}
-          <Tabs<FamiliarsScope>
-            bordered={false}
-            value={scope}
-            onChange={(s) => {
-              setScope(s);
-              if (s === "conversation") {
-                window.setTimeout(() => routerRef.current?.goToList(), 0);
-              }
-            }}
-            items={[
-              { id: "conversation", label: "Chats" },
-              { id: "memory", label: "Memory" },
-              { id: "projects", label: "Projects" },
-            ]}
-          />
+        <div className="chat-scope-tabs chat-scope-tabs--minimal flex shrink-0 items-center justify-between gap-3 border-b border-[var(--border-hairline)] px-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="chat-surface__familiar-scope flex w-[min(220px,34vw)] min-w-0 shrink-0 py-1.5 max-sm:w-[min(168px,42vw)]">
+              <FamiliarSwitcher
+                familiars={resolvedFamiliars}
+                activeFamiliarId={activeFamiliarId}
+                sessions={sessions}
+                onSelectFamiliar={(id) => {
+                  onSetActiveFamiliar(id);
+                  setScope("conversation");
+                  window.setTimeout(() => routerRef.current?.goToList(), 0);
+                }}
+                placement="bottom-start"
+                labeled
+              />
+            </div>
+            <span aria-hidden className="h-5 w-px shrink-0 bg-[var(--border-hairline)]" />
+            {/* Tabs flush left — Vercel-style underline tabs. The header row
+                already draws the divider, so the tablist itself is borderless. */}
+            <Tabs<FamiliarsScope>
+              bordered={false}
+              value={scope}
+              onChange={(s) => {
+                setScope(s);
+                if (s === "conversation") {
+                  window.setTimeout(() => routerRef.current?.goToList(), 0);
+                }
+              }}
+              items={[
+                { id: "conversation", label: "Sessions" },
+                { id: "memory", label: "Memory" },
+                { id: "projects", label: "Projects" },
+              ]}
+            />
+          </div>
 
           {/* Actions flush right — chromeless */}
           <div className="flex items-center gap-2 py-1.5">
             <button
               type="button"
               onClick={() => startConversation(activeFamiliarId)}
-              title="New chat"
+              title="New session"
               className="chat-scope-tabs__new inline-flex h-7 items-center gap-1 text-[11px] text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)]"
             >
               <Icon name="ph:plus-bold" width={11} />

--- a/src/components/chat-thread-rail.test.ts
+++ b/src/components/chat-thread-rail.test.ts
@@ -4,11 +4,11 @@ import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./chat-project-sidebar.tsx", import.meta.url), "utf8");
 
-// ── Always-visible flat all-chats list (Codex-style visibility) ───────────────
+// ── Always-visible flat all-sessions list (Codex-style visibility) ───────────
 assert.match(
   source,
   /const allSessions = useMemo\(\(\) => \{[\s\S]*groups\.flatMap\(\(g\) => g\.sessions\)/,
-  "Rail should flatten every project group into one always-visible all-chats list",
+  "Rail should flatten every project group into one always-visible all-sessions list",
 );
 assert.match(
   source,
@@ -36,15 +36,15 @@ assert.match(
   "Persisted order must be pruned against live sessions so it can't grow unbounded across deletes",
 );
 
-// ── Launch new chats from the rail ───────────────────────────────────────────
+// ── Launch new sessions from the rail ────────────────────────────────────────
 assert.match(
   source,
   /onClick=\{\(\) => onNewChat\(null\)\}[\s\S]*New/,
-  "Rail header should carry a prominent New chat launcher (global new chat)",
+  "Rail header should carry a prominent New session launcher",
 );
 
 // ── Search + mode filters (All / Active / Tasks / Pinned) ────────────────────
-assert.match(source, /placeholder="Search chats…"/, "Rail offers inline chat search");
+assert.match(source, /placeholder="Search sessions…"/, "Rail offers inline session search");
 assert.match(
   source,
   /type ChatFilter = "all" \| "active" \| "tasks" \| "pinned"/,

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -7,8 +7,8 @@ const destinations = source.match(/const DESTINATIONS:[\s\S]*?\n\];/)?.[0] ?? ""
 
 assert.match(
   destinations,
-  /id: "chat"[\s\S]*label: "Chat"/,
-  "HomeComposer should keep Chat as a launch destination",
+  /id: "chat"[\s\S]*label: "Familiar"/,
+  "HomeComposer should frame chat launch as a Familiar destination",
 );
 
 assert.match(

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -27,13 +27,13 @@ import { canonicalize, matchSlash, type SlashCommand } from "@/lib/slash-command
 export type Destination = "chat" | "board" | "reminder";
 
 const DESTINATIONS: { id: Destination; label: string; icon: IconName }[] = [
-  { id: "chat",     label: "Chat",     icon: "ph:chat-circle-dots" },
+  { id: "chat",     label: "Familiar", icon: "ph:chat-circle-dots" },
   { id: "board",    label: "Tasks",    icon: "ph:kanban" },
   { id: "reminder", label: "Reminder", icon: "ph:alarm-fill" },
 ];
 
 const PLACEHOLDERS: Record<Destination, string> = {
-  chat: "Ask anything in Chat…",
+  chat: "Ask a familiar anything…",
   board: "Describe a new task…",
   reminder: "Remind me about…",
 };

--- a/src/components/mobile-bottom-tabs.tsx
+++ b/src/components/mobile-bottom-tabs.tsx
@@ -2,7 +2,7 @@
 
 /**
  * MobileBottomTabs — fixed/sticky bottom navigation strip for mobile/tablet
- * viewports. Surfaces the most-used destinations (Home, Chat, Board, Inbox,
+ * viewports. Surfaces the most-used destinations (Home, Familiars, Board, Inbox,
  * Library, Delegations) as a tablist with icon + label and an active highlight.
  *
  * Renders only when the parent shell is in mobile mode (≤1023px); Shell is
@@ -23,7 +23,7 @@ type TabDef = {
 
 const TABS: TabDef[] = [
   { id: "home", label: "Home", ariaLabel: "Home", iconName: "ph:house-bold" },
-  { id: "chat", label: "Chat", ariaLabel: "Chat", iconName: "ph:chats" },
+  { id: "chat", label: "Familiars", ariaLabel: "Familiars", iconName: "ph:chats" },
   { id: "board", label: "Board", ariaLabel: "Board", iconName: "ph:kanban" },
   { id: "inbox", label: "Inbox", ariaLabel: "Inbox and automations", iconName: "ph:tray" },
   { id: "library", label: "Library", ariaLabel: "Library", iconName: "ph:books" },

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -27,7 +27,7 @@ assert.match(projectsView, /cave:agents-open-session/, "clicking a chat opens it
 // Long chat lists are capped with a Show all / Show less toggle.
 assert.match(projectsView, /const CHAT_CAP =/, "nested chat lists are capped");
 assert.match(projectsView, /chats\.slice\(0, CHAT_CAP\)/, "only the first CHAT_CAP chats render until expanded");
-assert.match(projectsView, /Show all \$\{chats\.length\} chats/, "a toggle reveals the rest");
+assert.match(projectsView, /Show all \$\{chats\.length\} sessions/, "a toggle reveals the rest");
 assert.match(projectsView, /import \{ EmptyState \} from "@\/components\/ui\/empty-state"/, "uses EmptyState primitive");
 assert.match(projectsView, /import \{ ErrorState \} from "@\/components\/ui\/error-state"/, "uses ErrorState primitive");
 assert.match(projectsView, /import \{ SkeletonRows \} from "@\/components\/ui\/skeleton"/, "uses SkeletonRows for first load");
@@ -62,7 +62,7 @@ for (const icon of [
 // Row actions must stay keyboard-reachable (focus-within), never display:none.
 assert.match(projectsView, /group-hover:opacity-100/, "row actions reveal on hover");
 assert.match(projectsView, /group-focus-within:opacity-100/, "row actions also reveal on keyboard focus");
-assert.match(projectsView, /aria-label=\{`New chat in /, "new-chat action is labeled per project");
+assert.match(projectsView, /aria-label=\{`New session in /, "new-session action is labeled per project");
 assert.match(projectsView, /aria-label=\{`Rename \$\{project\.name\}`\}/, "rename action labeled per project");
 assert.match(projectsView, /aria-label=\{`Delete \$\{project\.name\}`\}/, "delete action labeled per project");
 assert.match(projectsView, /motion-reduce:transition-none/, "reveal respects reduced motion");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -268,7 +268,7 @@ function ProjectRow({
         )}
 
         <span className="shrink-0 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">
-          {chatCount} {chatCount === 1 ? "chat" : "chats"}
+          {chatCount} {chatCount === 1 ? "session" : "sessions"}
         </span>
 
         <div className="flex shrink-0 items-center gap-1 opacity-100 transition-opacity motion-reduce:transition-none sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100">
@@ -276,8 +276,8 @@ function ProjectRow({
             type="button"
             onClick={() => onNewChat?.(project.root)}
             className="focus-ring flex h-7 w-7 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
-            title="New chat"
-            aria-label={`New chat in ${project.name}`}
+            title="New session"
+            aria-label={`New session in ${project.name}`}
           >
             <Icon name="ph:chat-circle-dots-bold" width={14} aria-hidden />
           </button>
@@ -381,13 +381,13 @@ function ProjectRow({
               aria-expanded={showAllChats}
               className="focus-ring mt-1 rounded-md px-2 py-1 text-[11px] font-medium text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-secondary)]"
             >
-              {showAllChats ? "Show less" : `Show all ${chats.length} chats`}
+              {showAllChats ? "Show less" : `Show all ${chats.length} sessions`}
             </button>
           ) : null}
         </>
       ) : (
         <p className="mt-2 border-t border-[var(--border-hairline)] pt-2 text-[11px] text-[var(--text-muted)]">
-          No chats yet — drag one here or start a new chat.
+          No sessions yet — drag one here or start a new session.
         </p>
       )}
     </article>

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -79,8 +79,8 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /\{ id: "chat", label: "Chat", iconName: "ph:chats", group: "work", kbd: "⌘2", description:/,
-  "Chat should move to the ⌘2 Work shortcut after removing Familiars",
+  /\{ id: "chat", label: "Familiars", iconName: "ph:chats", group: "work", kbd: "⌘2", description:/,
+  "Familiars should live at the ⌘2 Work shortcut",
 );
 
 assert.match(

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -6,7 +6,7 @@
  * Layout (top to bottom):
  *   1. Familiar scope selector + New chat CTA
  *   2. App destinations grouped by purpose:
- *      Work  (Home / Chat / Board / Calendar / Automations)
+ *      Work  (Home / Familiars / Board / Calendar / Automations)
  *      Knowledge (Library)
  *      Tools (Browser / Terminal / Roles / Workflows / Capabilities / GitHub)
  *   3. Footer: Settings
@@ -80,7 +80,7 @@ const FOLDER_MODES: Array<{
 }> = [
   // Work
   { id: "home", label: "Home", iconName: "ph:house-bold", group: "work", kbd: "⌘1", description: "Overview and quick actions" },
-  { id: "chat", label: "Chat", iconName: "ph:chats", group: "work", kbd: "⌘2", description: "Talk with your familiars" },
+  { id: "chat", label: "Familiars", iconName: "ph:chats", group: "work", kbd: "⌘2", description: "Talk with your familiars" },
   { id: "board", label: "Board", iconName: "ph:kanban", group: "work", kbd: "⌘3", description: "Track tasks across projects" },
   { id: "calendar", label: "Calendar", iconName: "ph:calendar-blank", group: "work", kbd: "⌘4", description: "Schedule and timeline of work" },
   { id: "inbox", label: "Automations", iconName: "ph:tray", group: "work", kbd: "⌘5", description: "Scheduled runs and items needing attention" },
@@ -198,7 +198,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
     responseNeeded,
   } = props;
 
-  // Projects lives only inside the Chat surface's Projects tab now (and ⌘9 /
+  // Projects lives only inside the Familiars surface's Projects tab now (and ⌘9 /
   // the /projects deep-link in workspace.tsx open it there) — no sidebar entry.
   const handleModeSelect = (id: FolderMode) => {
     onModeChange(id);
@@ -234,7 +234,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
         </button>
       ) : null}
 
-      {/* Header actions: familiar profile switcher + New chat. The same switcher
+      {/* Header actions: familiar profile switcher + New session. The same switcher
           also renders in the mobile top bar; on desktop this is its home. */}
       <div className="sidebar-actions sidebar-action-stack">
         <div className="sidebar-familiar-slot">
@@ -249,7 +249,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
         </div>
         <ActionRow
           icon={<Icon name="ph:note-pencil" width={14} />}
-          label="New chat"
+          label="New session"
           onClick={onNewChat}
         />
         <ActionRow

--- a/src/components/top-bar.test.ts
+++ b/src/components/top-bar.test.ts
@@ -84,6 +84,16 @@ assert.match(
 );
 assert.match(
   source,
+  /familiarSwitcherLabeled\?: boolean/,
+  "Top bar accepts a labeled familiar switcher mode for the Familiars page",
+);
+assert.match(
+  source,
+  /labeled=\{familiarSwitcherLabeled\}/,
+  "Top bar forwards the page-specific labeled mode into FamiliarSwitcher",
+);
+assert.match(
+  source,
   /const showFamiliarSwitcher = Boolean\(onSelectFamiliar && \(familiarOptions\?\.length \?\? 0\) > 0\)/,
   "Switcher renders when wired with a selection handler and at least one familiar",
 );

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -31,6 +31,7 @@ type Props = {
    *  reply badges (and the unread dot on the collapsed profile button). */
   sessions?: SessionRow[];
   responseNeeded?: Set<string>;
+  familiarSwitcherLabeled?: boolean;
   /** Mobile-only drawer toggles. Visibility is gated by CSS at <768px
    *  (.top-bar__mobile-toggle is `display: none` on desktop). Omit any
    *  that aren't applicable to the current surface — e.g. two-pane modes
@@ -66,6 +67,7 @@ export function TopBar(props: Props) {
     onSelectFamiliar,
     sessions,
     responseNeeded,
+    familiarSwitcherLabeled,
   } = props;
 
   // Show the switcher whenever there are familiars to pick and a selection
@@ -127,6 +129,7 @@ export function TopBar(props: Props) {
             responseNeeded={responseNeeded}
             onSelectFamiliar={onSelectFamiliar}
             placement="bottom-end"
+            labeled={familiarSwitcherLabeled}
           />
         ) : null}
         <button

--- a/src/components/workspace-familiars-landing.test.ts
+++ b/src/components/workspace-familiars-landing.test.ts
@@ -49,7 +49,7 @@ assert.match(
 assert.match(
   workspace,
   /hideChatTab=\{mode === "chat"\}/,
-  "Workspace should hide the companion rail Chat tab while the main surface is already Chats",
+  "Workspace should hide the companion rail Chat tab while the main surface is already Familiars",
 );
 
 assert.match(

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -71,7 +71,7 @@ type WorkspaceMode = WorkspaceModeFromDaemon;
 const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = {
   agents: "Familiars",
   home: "Home",
-  chat: "Chat",
+  chat: "Familiars",
   board: "Board",
   calendar: "Calendar",
   inbox: "Automations",
@@ -1449,6 +1449,7 @@ export function Workspace() {
             onSelectFamiliar={selectFamiliarScope}
             sessions={sessions}
             responseNeeded={responseNeeded}
+            familiarSwitcherLabeled={mode === "chat"}
             inboxPrefs={inboxPrefs}
             inboxBadgeCount={inboxBadgeCount}
             onOpenInboxItem={(item) => {


### PR DESCRIPTION
## Summary
- rename the main chat surface/navigation toward Familiars and session language
- move familiar selection into the Familiars header and remove duplicate rail/avatar strips
- update related UI copy and guard tests

## Test Plan
- node src/components/chat-list-mobile-rail-port.test.ts && node src/components/chat-list-delete.test.ts && node src/components/chat-rail-modern-redesign.test.ts && node src/components/chat-surface.test.ts && node src/components/projects-view.test.ts && node src/components/top-bar.test.ts
- pnpm exec tsc --noEmit
- git diff --check
- pnpm run test:app