### PR TITLE
fix(familiars): downsize large avatar uploads

### DIFF
--- a/src/components/familiar-studio-look-tab.test.ts
+++ b/src/components/familiar-studio-look-tab.test.ts
@@ -18,6 +18,36 @@ assert.match(source, /input.*type="file"/);
 assert.match(source, /onDrop|onDragOver/, "Drag-drop wired for image upload");
 assert.match(
   source,
+  /MAX_FAMILIAR_IMAGE_DATAURL_BYTES/,
+  "Look tab should read the familiar image storage cap before saving",
+);
+assert.match(
+  source,
+  /prepareFamiliarImage/,
+  "Look tab should prepare uploaded images before setFamiliarImage",
+);
+assert.match(
+  source,
+  /downsizeFamiliarImage/,
+  "Oversized raster uploads should be automatically downsized",
+);
+assert.match(
+  source,
+  /DOWNSIZABLE_MIMES = new Set\(\["image\/png", "image\/jpeg", "image\/webp"\]\)/,
+  "Only raster formats should be canvas-downsized; SVG remains guarded by the store cap",
+);
+assert.match(
+  source,
+  /Image was downsized for Cave\./,
+  "User should get feedback when a large image is compressed successfully",
+);
+assert.match(
+  source,
+  /Large raster images are downsized automatically/,
+  "Upload hint should explain automatic downsizing",
+);
+assert.match(
+  source,
   /color-mix\(in oklch, var\(--accent-presence\)/,
   "Color presets should include theme-derived pastel colors",
 );

--- a/src/components/familiar-studio-look-tab.tsx
+++ b/src/components/familiar-studio-look-tab.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Icon } from "@/lib/icon";
 import { FamiliarGlyphPickerPanel } from "./familiar-glyph-picker-panel";
 import {
+  MAX_FAMILIAR_IMAGE_DATAURL_BYTES,
   setFamiliarImage,
   clearFamiliarImage,
   useFamiliarImages,
@@ -120,9 +121,17 @@ export function FamiliarStudioLookTab({ familiar, allFamiliars }: Props) {
 
   async function onFile(file: File) {
     setToast(null);
-    const dataUrl = await fileToDataUrl(file);
-    const res = setFamiliarImage(familiar.id, { dataUrl, mime: file.type });
-    if (!res.ok) setToast(res.reason);
+    try {
+      const prepared = await prepareFamiliarImage(file);
+      const res = setFamiliarImage(familiar.id, prepared);
+      if (!res.ok) {
+        setToast(res.reason);
+        return;
+      }
+      if (prepared.downsized) setToast("Image was downsized for Cave.");
+    } catch (err) {
+      setToast(err instanceof Error ? err.message : "Could not read image.");
+    }
   }
 
   return (
@@ -227,7 +236,7 @@ export function FamiliarStudioLookTab({ familiar, allFamiliars }: Props) {
             </>
           ) : (
             <span className="familiar-studio-look__hint">
-              Drop a PNG, JPEG, WebP, or SVG (max 2MB), or
+              Drop a PNG, JPEG, WebP, or SVG. Large raster images are downsized automatically, or
             </span>
           )}
           <label className="familiar-studio-look__upload">
@@ -253,7 +262,81 @@ export function FamiliarStudioLookTab({ familiar, allFamiliars }: Props) {
 // (it does its own resolve). The shape overlap means we can pass it through;
 // TypeScript will widen as needed.
 
-function fileToDataUrl(file: File): Promise<string> {
+type PreparedFamiliarImage = {
+  dataUrl: string;
+  mime: string;
+  downsized?: boolean;
+};
+
+const DOWNSIZABLE_MIMES = new Set(["image/png", "image/jpeg", "image/webp"]);
+const DOWNSIZE_DIMENSIONS = [1024, 768, 512, 384, 256];
+const DOWNSIZE_QUALITIES = [0.86, 0.76, 0.66];
+
+async function prepareFamiliarImage(file: File): Promise<PreparedFamiliarImage> {
+  const dataUrl = await fileToDataUrl(file);
+  if (dataUrl.length <= MAX_FAMILIAR_IMAGE_DATAURL_BYTES || !DOWNSIZABLE_MIMES.has(file.type)) {
+    return { dataUrl, mime: file.type };
+  }
+
+  const downsized = await downsizeFamiliarImage(file);
+  return { ...downsized, downsized: true };
+}
+
+async function downsizeFamiliarImage(file: File): Promise<{ dataUrl: string; mime: string }> {
+  const image = await loadImage(file);
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Could not resize image in this browser.");
+
+  let smallest: { dataUrl: string; mime: string } | null = null;
+  const outputMimes = file.type === "image/jpeg"
+    ? ["image/jpeg", "image/webp"]
+    : ["image/webp", "image/jpeg"];
+
+  for (const maxSide of DOWNSIZE_DIMENSIONS) {
+    const scale = Math.min(1, maxSide / Math.max(image.naturalWidth, image.naturalHeight));
+    canvas.width = Math.max(1, Math.round(image.naturalWidth * scale));
+    canvas.height = Math.max(1, Math.round(image.naturalHeight * scale));
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+    for (const mime of outputMimes) {
+      for (const quality of DOWNSIZE_QUALITIES) {
+        const blob = await canvasToBlob(canvas, mime, quality);
+        if (!blob) continue;
+        const dataUrl = await blobToDataUrl(blob);
+        const candidate = { dataUrl, mime: blob.type || mime };
+        if (!smallest || dataUrl.length < smallest.dataUrl.length) smallest = candidate;
+        if (dataUrl.length <= MAX_FAMILIAR_IMAGE_DATAURL_BYTES) return candidate;
+      }
+    }
+  }
+
+  if (!smallest) throw new Error("Could not resize image in this browser.");
+  return smallest;
+}
+
+function loadImage(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const image = new Image();
+    image.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(image);
+    };
+    image.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error("Could not load image."));
+    };
+    image.src = url;
+  });
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement, mime: string, quality: number): Promise<Blob | null> {
+  return new Promise((resolve) => canvas.toBlob(resolve, mime, quality));
+}
+
+function fileToDataUrl(file: File | Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = () => resolve(reader.result as string);
@@ -261,6 +344,8 @@ function fileToDataUrl(file: File): Promise<string> {
     reader.readAsDataURL(file);
   });
 }
+
+const blobToDataUrl = fileToDataUrl;
 
 function colorInputValue(color: string | null): string {
   return color && /^#[0-9a-f]{6}$/i.test(color)

--- a/src/lib/cave-familiar-images.test.ts
+++ b/src/lib/cave-familiar-images.test.ts
@@ -14,6 +14,12 @@ globalThis.window = {
 
 const mod = await import("./cave-familiar-images.ts");
 
+assert.equal(
+  typeof mod.MAX_FAMILIAR_IMAGE_DATAURL_BYTES,
+  "number",
+  "store should expose the cap so upload UI can downsize before saving",
+);
+
 // Set + read
 {
   const dataUrl = "data:image/png;base64," + "A".repeat(1000);

--- a/src/lib/cave-familiar-images.ts
+++ b/src/lib/cave-familiar-images.ts
@@ -12,7 +12,7 @@
 import { useSyncExternalStore } from "react";
 
 const IMAGES_KEY = "cave:familiar-images:v1";
-const MAX_DATAURL_BYTES = Math.floor(2 * 1024 * 1024 * 4 / 3) + 100; // ~2.8MB
+export const MAX_FAMILIAR_IMAGE_DATAURL_BYTES = Math.floor(2 * 1024 * 1024 * 4 / 3) + 100; // ~2.8MB
 const MAX_TOTAL_BYTES = 20 * 1024 * 1024;
 const ALLOWED_MIMES = new Set([
   "image/png",
@@ -71,7 +71,7 @@ export function setFamiliarImage(id: string, image: { dataUrl: string; mime: str
   if (!ALLOWED_MIMES.has(image.mime)) {
     return { ok: false, reason: "Unsupported format. Use PNG, JPEG, WebP, or SVG." };
   }
-  if (image.dataUrl.length > MAX_DATAURL_BYTES) {
+  if (image.dataUrl.length > MAX_FAMILIAR_IMAGE_DATAURL_BYTES) {
     return { ok: false, reason: "Image too large (max 2MB)." };
   }
   const curr = getMap();


### PR DESCRIPTION
## Summary
- Downsize oversized PNG/JPEG/WebP familiar image uploads in-browser before saving
- Keep the image store cap as a final guard and expose it to the upload UI
- Update Familiar Studio copy and source-contract tests for the downsizing path

## Verification
- node --experimental-strip-types src/components/familiar-studio-look-tab.test.ts
- node --experimental-strip-types src/lib/cave-familiar-images.test.ts
- pnpm run typecheck
- pnpm run check:tests-wired
- pnpm run test:app
- pnpm run build