### PR TITLE
feat(chat): enlarge the familiar avatar in assistant turns

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3313,7 +3313,7 @@ function TurnRow({
       <div className="cave-linear-turn-content text-[14px] leading-relaxed text-[var(--text-primary)] group/turn">
         {/* Avatar + right column */}
         <div className="cave-linear-turn-avatar" aria-hidden>
-          <FamiliarIcon familiar={familiar} size="sm" />
+          <FamiliarIcon familiar={familiar} size="lg" />
         </div>
         <div className="cave-linear-turn-right">
           <div className="cave-linear-turn-meta">

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1888,15 +1888,24 @@ details[open] > .cave-tool-summary::before {
 .cave-linear-turn-avatar {
   display: grid;
   place-items: center;
-  width: 34px;
-  height: 34px;
+  width: 44px;
+  height: 44px;
   border: 1px solid color-mix(in oklch, var(--accent-presence) 22%, transparent);
-  border-radius: 9px;
+  border-radius: 11px;
   background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-raised));
   color: var(--accent-presence);
   overflow: hidden;
   flex-shrink: 0;
   margin-top: 1px;
+}
+
+/* Photo avatars fill the enlarged box edge-to-edge; glyph avatars keep their
+   intrinsic (size="lg") sizing centered within it. */
+.cave-linear-turn-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: inherit;
 }
 
 .cave-linear-turn-right {
@@ -2311,9 +2320,9 @@ details[open] > .cave-tool-summary::before {
   }
 
   .cave-linear-turn-avatar {
-    width: 30px;
-    height: 30px;
-    border-radius: 8px;
+    width: 38px;
+    height: 38px;
+    border-radius: 10px;
   }
 
   .cave-chat-linear .cave-bubble-user {


### PR DESCRIPTION
Enlarges the familiar avatar shown next to the name in a chat assistant turn (the small rounded box by "Sage 4:37 PM …").

- Avatar box: **34px → 44px** (30→38 on narrow viewports), border-radius bumped to match.
- Inner avatar rendered at `size="lg"` (was `sm`); photo avatars now fill the box edge-to-edge via a scoped `img` rule.
- Scope: only `.cave-linear-turn-avatar`. The mobile-header `FamiliarIcon` (test-pinned `size="sm"`) is untouched.

**Verified:** `typecheck` ✓, `build` ✓, chat-view/polish/header tests ✓; live (Playwright on a real Sage thread) the avatar measures 44×44 and renders cleanly next to the name/meta row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)