### PR TITLE
fix(capabilities): preview Codex automation descriptors again (#742 regressed #737)

### DIFF
--- a/src/components/capabilities-view.test.ts
+++ b/src/components/capabilities-view.test.ts
@@ -38,6 +38,10 @@ assert.match(source, /const applyStatusFilter = \(value: CapabilityStatus \| "al
 assert.match(source, /const readinessStatus = operatorView\.summary\.warnings > 0 \? "warning" : operatorView\.summary\.disabled > 0 \? "disabled" : "all";/, "readiness tile should route to disabled when disabled is the only issue type");
 assert.match(source, /type="search"[\s\S]*aria-label="Search capabilities"/, "search input should expose a stable accessible name");
 assert.match(source, /function isMarkdownPreviewable\(/, "previewability should be based on markdown-capable files");
+// #742 limited previews to markdown; #737 added Codex automation descriptors
+// (automation.toml). The gate must accept that filename or automation previews
+// silently never render (regression caught in review).
+assert.match(source, /filename === AUTOMATION_PREVIEW_FILE_NAME/, "preview gate accepts Codex automation descriptors (automation.toml)");
 assert.match(source, /json\.path \?\? previewPath/, "preview state should preserve the server-resolved markdown file path");
 assert.match(source, /Markdown preview/, "capability file previews should be explicitly labelled as markdown previews");
 

--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -48,6 +48,10 @@ const STATUS_LABEL: Record<CapabilityStatus, string> = {
 const CAPABILITY_TYPES = new Set<CapabilityType>(["instructions", "skill", "plugin", "mcp", "warning"]);
 const CAPABILITY_STATUSES = new Set<CapabilityStatus>(["available", "enabled", "disabled", "warning"]);
 const MARKDOWN_PREVIEW_FILE_NAMES = new Set(["skill.md", "claude.md", "agents.md"]);
+// Codex automation descriptors preview as their `automation.toml` (#737); the
+// server skill-file reader allow-lists this exact name. It isn't markdown, but
+// it renders through the same styled preview, so the gate accepts it too.
+const AUTOMATION_PREVIEW_FILE_NAME = "automation.toml";
 
 function readUrlParam(name: string): string | null {
   if (typeof window === "undefined") return null;
@@ -83,8 +87,12 @@ function initialStatusFilter(): CapabilityStatus | "all" {
 function isMarkdownPreviewable(path?: string): boolean {
   if (!path) return false;
   const normalized = path.toLowerCase();
-  if (!normalized.endsWith(".md")) return false;
   const filename = normalized.split("/").pop() ?? "";
+  // #742 limited previews to known markdown files; #737 added Codex automation
+  // descriptors whose path ends in automation.toml. Without this the automation
+  // preview never renders client-side even though the server serves it.
+  if (filename === AUTOMATION_PREVIEW_FILE_NAME) return true;
+  if (!normalized.endsWith(".md")) return false;
   return MARKDOWN_PREVIEW_FILE_NAMES.has(filename);
 }
 


### PR DESCRIPTION
Review finding from the post-merge pass on today's PRs (two reviewers flagged it independently, verified on main).

**#742** ("limit previews to markdown files") gated the client preview on `isMarkdownPreviewable`: path must end in `.md` and be one of `{skill,claude,agents}.md`. **#737** ("preview Codex automation descriptors"), merged ~12 min later, normalizes automation paths to `…/automation.toml` (`capabilities-normalize.ts`) and the server skill-file reader allow-lists + serves that exact name (`skill-file-paths.ts`). The markdown-only client gate rejected the `.toml` path, so automation rows expanded with **no preview** and #737's server support was dead client-side. CI missed it (the view test only asserted the function exists).

### Fix
`isMarkdownPreviewable` now also accepts `automation.toml`, mirroring the server allow-list and the normalize output. Adds a source-text guard (`filename === AUTOMATION_PREVIEW_FILE_NAME`) so it can't re-regress.

### Verification
- `pnpm typecheck` clean; `capabilities-view` + `capabilities-normalize` tests pass.
- Confirmed the chain on main: gate at `capabilities-view.tsx:83`, normalize emits `automation.toml` at `capabilities-normalize.ts:82`, server allows it at `skill-file-paths.ts:21,49`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)