### PR TITLE
fix(chat): align assistant-turn avatar grid track with enlarged avatar

### DIFF
--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1880,7 +1880,7 @@ details[open] > .cave-tool-summary::before {
 
 .cave-linear-turn--assistant .cave-linear-turn-content {
   display: grid;
-  grid-template-columns: 34px minmax(0, 1fr);
+  grid-template-columns: 44px minmax(0, 1fr);
   gap: 10px;
   align-items: start;
 }
@@ -2315,7 +2315,7 @@ details[open] > .cave-tool-summary::before {
   }
 
   .cave-linear-turn--assistant .cave-linear-turn-content {
-    grid-template-columns: 30px minmax(0, 1fr);
+    grid-template-columns: 38px minmax(0, 1fr);
     gap: 9px;
   }
 


### PR DESCRIPTION
## What

PR #752 enlarged the familiar avatar in assistant chat turns (34→44px desktop, 30→38px mobile) but left the CSS grid **avatar column** at its old width (34px desktop `cave-chat.css:1883`, 30px mobile `:2318`). The 44px avatar overflowed its 34px track and ate the column gap, so the header/body text was crowded right up against the avatar.

## Fix

Widen the grid avatar track to match the avatar size (44px / 38px) so the intended 10px/9px gap between avatar and text is restored. Two CSS values; no JS, no behavior change.

Reported via screenshot of a Nova assistant turn with crowded spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)