### PR TITLE
feat(projects): per-project Terminal button that launches in the project cwd

### DIFF
--- a/src/components/comux-view-terminal.test.ts
+++ b/src/components/comux-view-terminal.test.ts
@@ -71,6 +71,20 @@ assert.match(
   "opening the active Terminal surface should auto-start one terminal session without respawning after in-surface closes",
 );
 
+// Cross-surface launch: the Projects page (and others) open a terminal in a
+// project's cwd by dispatching cave:terminal-open; the canonical terminal
+// instance handles it and spawns the shell in that project root.
+assert.match(
+  source,
+  /addSession\(detail\?\.projectRoot\)[\s\S]{0,200}?addEventListener\("cave:terminal-open"/,
+  "the terminal instance launches a session in the requested project root on cave:terminal-open",
+);
+assert.match(
+  source,
+  /if \(view !== "terminal"\) return;[\s\S]{0,260}?addEventListener\("cave:terminal-open"/,
+  "only the canonical terminal instance handles cave:terminal-open (single session, no duplicates)",
+);
+
 // ⌘N / ⌘W keydown handler is wired and respects modifier + contentEditable gate.
 assert.match(
   source,

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -338,6 +338,20 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
     return id;
   }, [daemonProjectRoot, selectedProjectRoot, sessions.length, terminalLayout]);
 
+  // Cross-surface launch: other surfaces (e.g. the Projects page) open a
+  // terminal in a specific project by dispatching `cave:terminal-open` with the
+  // project root. Only the canonical terminal instance handles it so a single
+  // session is created, and it spawns in that project's cwd via addSession.
+  useEffect(() => {
+    if (view !== "terminal") return;
+    const onTerminalOpen = (event: Event) => {
+      const detail = (event as CustomEvent<{ projectRoot?: string }>).detail;
+      addSession(detail?.projectRoot);
+    };
+    window.addEventListener("cave:terminal-open", onTerminalOpen as EventListener);
+    return () => window.removeEventListener("cave:terminal-open", onTerminalOpen as EventListener);
+  }, [view, addSession]);
+
   useEffect(() => {
     const activeTerminal = view === "terminal" && active;
     if (!activeTerminal) {

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -53,6 +53,7 @@ for (const icon of [
   "ph:folder-open-bold",
   "ph:folder-simple-dashed",
   "ph:chat-circle-dots-bold",
+  "ph:terminal-window-bold",
   "ph:trash-bold",
   "ph:pencil-simple-bold",
 ]) {
@@ -63,6 +64,18 @@ for (const icon of [
 assert.match(projectsView, /group-hover:opacity-100/, "row actions reveal on hover");
 assert.match(projectsView, /group-focus-within:opacity-100/, "row actions also reveal on keyboard focus");
 assert.match(projectsView, /aria-label=\{`New session in /, "new-session action is labeled per project");
+// Terminal action launches a terminal in the project's cwd, then jumps to the surface.
+assert.match(projectsView, /aria-label=\{`Open terminal in \$\{project\.name\}`\}/, "terminal action labeled per project");
+assert.match(
+  projectsView,
+  /new CustomEvent\("cave:terminal-open", \{ detail: \{ projectRoot: project\.root \} \}\)/,
+  "terminal action launches a terminal scoped to the project's cwd",
+);
+assert.match(
+  projectsView,
+  /new CustomEvent\("cave:navigate-mode", \{ detail: \{ mode: "terminal" \} \}\)/,
+  "terminal action brings the Terminal surface to the foreground",
+);
 assert.match(projectsView, /aria-label=\{`Rename \$\{project\.name\}`\}/, "rename action labeled per project");
 assert.match(projectsView, /aria-label=\{`Delete \$\{project\.name\}`\}/, "delete action labeled per project");
 assert.match(projectsView, /motion-reduce:transition-none/, "reveal respects reduced motion");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -283,6 +283,26 @@ function ProjectRow({
           </button>
           <button
             type="button"
+            onClick={() => {
+              // Launch a terminal in this project's cwd, then jump to the
+              // Terminal surface. The always-mounted terminal instance creates
+              // the session (spawning the shell in project.root); cave:navigate-mode
+              // brings the Terminal surface to the foreground.
+              window.dispatchEvent(
+                new CustomEvent("cave:terminal-open", { detail: { projectRoot: project.root } }),
+              );
+              window.dispatchEvent(
+                new CustomEvent("cave:navigate-mode", { detail: { mode: "terminal" } }),
+              );
+            }}
+            className="focus-ring flex h-7 w-7 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+            title="Open terminal"
+            aria-label={`Open terminal in ${project.name}`}
+          >
+            <Icon name="ph:terminal-window-bold" width={14} aria-hidden />
+          </button>
+          <button
+            type="button"
             onClick={() => { setNameDraft(project.name); setEditingName(true); }}
             aria-label={`Rename ${project.name}`}
             title="Rename"


### PR DESCRIPTION
## What

The Projects page (`projects-view`) let you start a chat, rename, or delete a project, but there was **no way to open a terminal in a project**. This adds a Terminal button to each project card that launches a terminal **in that project's working directory**.

## How

- **`projects-view.tsx`** — new per-card Terminal button (`ph:terminal-window-bold`, `aria-label="Open terminal in <name>"`). On click it dispatches `cave:terminal-open` with `{ projectRoot: project.root }`, then `cave:navigate-mode` → `terminal` to bring the Terminal surface forward.
- **`comux-view.tsx`** — the always-mounted terminal instance now listens for `cave:terminal-open` and calls `addSession(projectRoot)`. Gated on `view === "terminal"` so exactly one session is created (no duplicates).

The cwd plumbing already existed end-to-end; this just wires the missing UI entry point into it:

`addSession(root)` → session `projectRoot` → `BottomTerminal projectRoot` →
- **Desktop:** `pty_start { project_root }` → Rust `validated_cwd` → `cmd.cwd(root)`
- **Browser/mobile:** `?projectRoot=` → server `validateCwd` → `spawnPty({ cwd })`

## Tests

- `projects-view.test.ts` — asserts the Terminal button, its per-project aria-label, both dispatched events, and the icon allowlist entry.
- `comux-view-terminal.test.ts` — asserts the `cave:terminal-open` listener calls `addSession(detail?.projectRoot)` and is gated to the canonical terminal instance.

Typecheck clean; both suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)