### PR TITLE
feat(chat): make the Inspector/Debug right sidebar resizable + persist width

### DIFF
--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -192,7 +192,7 @@ assert.match(
 
 assert.match(
   chatSurface,
-  /scope === "memory" \? \([\s\S]*?\) : \(\s*<Group className="flex min-h-0 min-w-0 flex-1" orientation="horizontal">/,
+  /scope === "memory" \? \([\s\S]*?\) : \(\s*<Group\s+className="flex min-h-0 min-w-0 flex-1"\s+orientation="horizontal"/,
   "ChatSurface non-memory branch (conversation) should use remaining height below the tab bar instead of h-full",
 );
 

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
-import { Group, Panel, Separator } from "react-resizable-panels";
+import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
 import { ChatRouter, type ChatRouterHandle } from "@/components/chat-router";
 import { FamiliarsMemoryView } from "@/components/familiars-memory-view";
 import { ProjectsView } from "@/components/projects-view";
@@ -18,6 +18,31 @@ import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { PendingChatAction } from "@/lib/pending-chat-action";
+
+// ── Layout persistence ─────────────────────────────────────────────────────────
+
+// Persists the chat thread / right-sidebar split width across reloads. Keyed by
+// the set of mounted panel ids, so the no-sidebar layout doesn't clobber the
+// with-sidebar one. localStorage-backed, fails soft under strict privacy modes.
+const CHAT_GROUP_ID = "cave.chat.widths.v1";
+const chatStorage = {
+  getItem(key: string): string | null {
+    if (typeof window === "undefined") return null;
+    try {
+      return window.localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  },
+  setItem(key: string, value: string): void {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(key, value);
+    } catch {
+      /* ignore — strict privacy mode or storage quota */
+    }
+  },
+};
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -185,6 +210,15 @@ export function ChatSurface({
     if (onSetRightPanel) { onSetRightPanel(next); return; }
     onSetInspectorOpen(next === "inspector");
   }
+
+  // Persist the chat / right-sidebar split. panelIds tracks which panels are
+  // actually mounted so the with-sidebar and no-sidebar layouts persist separately.
+  const showRightSidebar = rightPanel !== null && !isMobile;
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+    id: CHAT_GROUP_ID,
+    panelIds: showRightSidebar ? ["chat-main", "right-sidebar"] : ["chat-main"],
+    storage: chatStorage,
+  });
 
   const scopedFamiliars = useMemo(() => activeFamiliar ? [activeFamiliar] : familiars, [activeFamiliar, familiars]);
   const resolvedFamiliars = useResolvedFamiliars(familiars, { includeArchived: true });
@@ -354,7 +388,12 @@ export function ChatSurface({
         ) : scope === "projects" ? (
           <ProjectsView sessions={sessions} onNewChat={startProjectChat} onSessionsChanged={onSessionsChanged} />
         ) : (
-          <Group className="flex min-h-0 min-w-0 flex-1" orientation="horizontal">
+          <Group
+            className="flex min-h-0 min-w-0 flex-1"
+            orientation="horizontal"
+            defaultLayout={defaultLayout}
+            onLayoutChanged={onLayoutChanged}
+          >
             <Panel id="chat-main" className="flex min-h-0 min-w-0" minSize="45%">
               <div className="min-h-0 min-w-0 flex-1">
                 <ChatRouter
@@ -377,15 +416,18 @@ export function ChatSurface({
             </Panel>
             {rightPanel !== null && !isMobile && (
               <>
-                {/* Fixed-width mirror of the internal left rail (chat-thread-rail
-                    is w-[230px]). No resize handle — the panel's own border-l is
-                    the divider, matching the left rail's border-r. */}
+                {/* Defaults to 230px (mirrors the internal left rail, chat-thread-rail
+                    is w-[230px]) but is drag-resizable via the handle below, clamped
+                    to a sane band so the chat thread keeps its 45% minSize. */}
+                <Separator className="shell-separator hidden lg:flex">
+                  <SeparatorHandle orientation="col" />
+                </Separator>
                 <Panel
                   id="right-sidebar"
                   className="hidden min-h-0 min-w-0 lg:flex"
                   defaultSize="230px"
-                  minSize="230px"
-                  maxSize="230px"
+                  minSize="200px"
+                  maxSize="480px"
                 >
                   <RightPanel
                     panel={rightPanel}

--- a/src/components/right-sidebar-fit.test.ts
+++ b/src/components/right-sidebar-fit.test.ts
@@ -8,17 +8,30 @@ const projectSidebar = await readFile(new URL("./chat-project-sidebar.tsx", impo
 
 assert.match(
   chatSurface,
-  /Panel[\s\S]*id="right-sidebar"[\s\S]*defaultSize="230px"[\s\S]*minSize="230px"[\s\S]*maxSize="230px"/,
-  "ChatSurface right sidebar should be a fixed 230px mirror of the internal left rail (min===max===default)",
+  /Panel[\s\S]*id="right-sidebar"[\s\S]*defaultSize="230px"[\s\S]*minSize="200px"[\s\S]*maxSize="480px"/,
+  "ChatSurface right sidebar should default to 230px but be drag-resizable within a 200–480px band",
 );
 
-// Fixed-width mirror: the outer resize separator is gone — the panel's own
-// border-l is the divider, matching the left rail's border-r. The INNER
-// vertical-split separator (shell-separator-h) is unaffected (asserted below).
-assert.doesNotMatch(
+// Drag-to-resize: an outer separator with a col handle sits before the right
+// sidebar so its width can be changed. The INNER vertical-split separator
+// (shell-separator-h) is unaffected (asserted below).
+assert.match(
   chatSurface,
-  /Separator className="shell-separator hidden lg:block"/,
-  "The right sidebar is fixed-width now — no outer drag-to-resize separator before it",
+  /<Separator className="shell-separator hidden lg:flex">[\s\S]*<SeparatorHandle orientation="col" \/>/,
+  "The right sidebar should have an outer drag-to-resize separator before it",
+);
+
+// The split width must persist across reloads via useDefaultLayout.
+assert.match(
+  chatSurface,
+  /useDefaultLayout\(\{[\s\S]*id: CHAT_GROUP_ID[\s\S]*storage: chatStorage/,
+  "ChatSurface should persist the chat/right-sidebar split width across reloads",
+);
+
+assert.match(
+  chatSurface,
+  /<Group[\s\S]*orientation="horizontal"[\s\S]*defaultLayout=\{defaultLayout\}[\s\S]*onLayoutChanged=\{onLayoutChanged\}/,
+  "The horizontal chat Group should apply the persisted layout",
 );
 
 assert.match(


### PR DESCRIPTION
## What

The chat right sidebar — the one holding **Inspector** and **Debug** (and the Changes split) — was locked to a fixed **230px** (`minSize === maxSize === defaultSize === 230px`, with no resize handle). This makes it **drag-resizable** and **persists the width across reloads**.

## Changes

- **Resizable** — added an outer `Separator` + `SeparatorHandle` (`orientation="col"`) between the chat thread and the sidebar, and unlocked the panel to a **200–480px** band (still defaults to 230px). The chat thread keeps its existing `minSize="45%"` so it can't be crushed.
- **Persistent** — wired the conversation `Group` to `useDefaultLayout` (the same hook `shell.tsx` uses), backed by a small `localStorage` helper keyed `cave.chat.widths.v1`. `panelIds` switches between the with-sidebar and no-sidebar sets so the two layouts persist independently and don't clobber each other.
- Both gated to the `lg:` desktop breakpoint — mobile (right-edge sheet overlay) is unaffected.

## Note

This intentionally reverses the prior "fixed-width mirror of the left rail, no resize handle" design decision. `right-sidebar-fit.test.ts` is updated to encode the new resizable + persistent behavior; one regex in `chat-surface.test.ts` was loosened for the now multi-line `Group`.

## Verify

- `tsc --noEmit` clean
- `right-sidebar-fit.test.ts`, `chat-surface.test.ts`, `chat-surface-polish.test.ts` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)