### PR TITLE
Fix Linux AppImage release on GitHub runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,6 +222,11 @@ jobs:
         uses: tauri-apps/tauri-action@1ddc7b49b13c3038297360482fcb3e058764d7c9 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GitHub-hosted Linux runners do not reliably expose FUSE to nested
+          # AppImages. linuxdeploy is itself an AppImage, so force its
+          # extract-and-run fallback instead of letting AppImage startup fail
+          # with Tauri's opaque "failed to run linuxdeploy" wrapper error.
+          APPIMAGE_EXTRACT_AND_RUN: ${{ matrix.platform == 'ubuntu-22.04' && '1' || '' }}
         with:
           tagName: ${{ env.RELEASE_TAG }}
           releaseName: "CovenCave ${{ env.RELEASE_TAG }}"

--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -7,6 +7,10 @@ const releaseScript = readFileSync(
   fileURLToPath(new URL("./release.sh", import.meta.url)),
   "utf8",
 );
+const releaseWorkflow = readFileSync(
+  fileURLToPath(new URL("../.github/workflows/release.yml", import.meta.url)),
+  "utf8",
+);
 const sidecarScript = readFileSync(
   fileURLToPath(new URL("./sidecar-bundle.sh", import.meta.url)),
   "utf8",
@@ -48,4 +52,9 @@ test("DMG packaging retries transient hdiutil resource-busy failures", () => {
     releaseScript.indexOf("create_dmg_with_retry") <
       releaseScript.indexOf('echo "==> Signing DMG container"'),
   );
+});
+
+test("Linux release job forces AppImage extract-and-run mode", () => {
+  assert.match(releaseWorkflow, /APPIMAGE_EXTRACT_AND_RUN:/);
+  assert.match(releaseWorkflow, /matrix\.platform == 'ubuntu-22\.04'/);
 });


### PR DESCRIPTION
## Summary
- force AppImage extract-and-run mode for the Linux release job so linuxdeploy does not depend on runner FUSE support
- add a regression assertion to keep the release workflow wired for Linux AppImage CI

## Verification
- node scripts/release-macos-signing.test.mjs
- pnpm check:tests-wired
- git diff --check

Follow-up for v0.0.93: after this merges, rerun the release workflow with tag v0.0.93 and platform=linux.