### PR TITLE
fix(release): prune foreign native sidecar packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
             arch_suffix: aarch64
           - platform: ubuntu-22.04
             label: Linux (AppImage)
-            args: '--bundles appimage --config ''{"bundle":{"createUpdaterArtifacts":false}}'''
+            args: '-vv --bundles appimage --config ''{"bundle":{"createUpdaterArtifacts":false}}'''
             arch_suffix: ""
           - platform: windows-latest
             label: Windows (MSI)

--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -57,4 +57,24 @@ test("DMG packaging retries transient hdiutil resource-busy failures", () => {
 test("Linux release job forces AppImage extract-and-run mode", () => {
   assert.match(releaseWorkflow, /APPIMAGE_EXTRACT_AND_RUN:/);
   assert.match(releaseWorkflow, /matrix\.platform == 'ubuntu-22\.04'/);
+  assert.match(
+    releaseWorkflow,
+    /label: Linux \(AppImage\)[\s\S]*args: '-vv --bundles appimage/,
+    "Linux AppImage packaging should keep verbose linuxdeploy logs available",
+  );
+});
+
+test("sidecar bundle prunes foreign native packages before release bundling", () => {
+  assert.match(sidecarScript, /prune_foreign_native_packages\(\)/);
+  assert.match(sidecarScript, /process\.platform/);
+  assert.match(sidecarScript, /process\.arch/);
+  assert.match(sidecarScript, /@next\/swc-\$target-\$libc/);
+  assert.match(sidecarScript, /@img\/sharp-libvips-\$target/);
+  assert.match(sidecarScript, /node-pty\/prebuilds/);
+  assert.match(sidecarScript, /rm -rf "\$base\/fsevents"/);
+  assert(
+    sidecarScript.indexOf('prune_foreign_native_packages "$PNPM_STAGE/node_modules"') <
+      sidecarScript.indexOf('fix_node_pty_spawn_helpers "$PNPM_STAGE/node_modules"'),
+    "native package pruning should run before node-pty permission repair",
+  );
 });

--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -47,6 +47,96 @@ fix_node_pty_spawn_helpers() {
   fi
 }
 
+prune_foreign_native_packages() {
+  local base="$1"
+  if [ ! -d "$base" ]; then
+    return 0
+  fi
+
+  local platform arch libc target next_pkg sharp_pkg sharp_vips_pkg node_pty_prebuild
+  platform="$(node -p "process.platform")"
+  arch="$(node -p "process.arch")"
+  libc=""
+  if [ "$platform" = "linux" ]; then
+    libc="$(node -p "process.report?.getReport?.().header?.glibcVersionRuntime ? 'gnu' : 'musl'")"
+  fi
+
+  case "$platform" in
+    darwin)
+      target="darwin-$arch"
+      next_pkg="@next/swc-$target"
+      sharp_pkg="@img/sharp-$target"
+      sharp_vips_pkg="@img/sharp-libvips-$target"
+      node_pty_prebuild="$target"
+      ;;
+    linux)
+      target="linux-$arch"
+      next_pkg="@next/swc-$target-$libc"
+      sharp_pkg="@img/sharp-$target"
+      sharp_vips_pkg="@img/sharp-libvips-$target"
+      if [ "$libc" = "musl" ]; then
+        sharp_pkg="@img/sharp-linuxmusl-$arch"
+        sharp_vips_pkg="@img/sharp-libvips-linuxmusl-$arch"
+      fi
+      node_pty_prebuild="$target"
+      ;;
+    win32)
+      target="win32-$arch"
+      next_pkg="@next/swc-$target-msvc"
+      sharp_pkg="@img/sharp-$target"
+      sharp_vips_pkg=""
+      node_pty_prebuild="$target"
+      ;;
+    *)
+      echo "==> sidecar native prune: unsupported platform $platform/$arch; leaving native packages intact"
+      return 0
+      ;;
+  esac
+
+  echo "==> pruning sidecar native packages for $platform/$arch${libc:+/$libc}"
+
+  local dir pkg
+  for dir in "$base"/@next/swc-*; do
+    [ -e "$dir" ] || continue
+    pkg="@next/$(basename "$dir")"
+    if [ "$pkg" != "$next_pkg" ]; then
+      rm -rf "$dir"
+    fi
+  done
+
+  for dir in "$base"/@img/sharp-*; do
+    [ -e "$dir" ] || continue
+    pkg="@img/$(basename "$dir")"
+    if [ "$pkg" != "$sharp_pkg" ] && [ "$pkg" != "$sharp_vips_pkg" ]; then
+      rm -rf "$dir"
+    fi
+  done
+
+  if [ "$platform" != "darwin" ]; then
+    rm -rf "$base/fsevents"
+  fi
+
+  if [ -d "$base/node-pty/prebuilds" ]; then
+    for dir in "$base"/node-pty/prebuilds/*; do
+      [ -e "$dir" ] || continue
+      if [ "$(basename "$dir")" != "$node_pty_prebuild" ]; then
+        rm -rf "$dir"
+      fi
+    done
+  fi
+
+  if [ "$platform" != "win32" ]; then
+    rm -rf "$base/node-pty/third_party/conpty"
+  elif [ -d "$base/node-pty/third_party/conpty" ]; then
+    for dir in "$base"/node-pty/third_party/conpty/*/win10-*; do
+      [ -e "$dir" ] || continue
+      if [ "$(basename "$dir")" != "win10-$arch" ]; then
+        rm -rf "$dir"
+      fi
+    done
+  fi
+}
+
 echo "==> next build"
 (cd "$ROOT" && pnpm build) >&2
 
@@ -88,6 +178,7 @@ fi
   cd "$PNPM_STAGE" && pnpm install --prod --frozen-lockfile \
     --config.node-linker=hoisted --ignore-scripts
 ) >&2
+prune_foreign_native_packages "$PNPM_STAGE/node_modules"
 fix_node_pty_spawn_helpers "$PNPM_STAGE/node_modules"
 
 echo "==> copying standalone tree → $DEST"


### PR DESCRIPTION
## Summary
- prune cross-platform native packages from the packaged Next sidecar before Tauri AppImage bundling
- keep Linux AppImage bundling verbose so linuxdeploy failures expose the concrete file/plugin cause
- add release regression coverage for the pruning and verbose AppImage invariants

## Verification
- bash -n scripts/sidecar-bundle.sh
- node scripts/release-macos-signing.test.mjs
- synthetic Linux x64 GNU prune smoke
- pnpm check:tests-wired
- pnpm run test:api
- pnpm typecheck
- git diff --check

## Release context
This is aimed at unblocking the v0.0.93 Linux AppImage release failure where linuxdeploy dies inside Tauri after the 1.5G sidecar is staged. The prior FUSE/extract-and-run patch was present in the rerun but did not fix the failure; this removes the foreign native binaries that linuxdeploy scans and tries to patch.