### PR TITLE
fix(release): let manual retries use updated source ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,10 @@ on:
         description: "Tag to attach builds to (e.g. v0.0.16). Must already exist on origin."
         required: true
         type: string
+      source_ref:
+        description: "Git ref to build from for manual release-infra retries. Defaults to tag."
+        required: false
+        type: string
       platform:
         description: "Platform to build when manually re-running a release."
         required: false
@@ -94,7 +98,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          # Manual retries may need newer release infrastructure while still
+          # attaching artifacts to an existing tag.
+          ref: ${{ github.event.inputs.source_ref || github.event.inputs.tag || github.ref }}
 
       - name: Set release metadata
         shell: bash
@@ -379,7 +385,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          # Manual retries may need newer release infrastructure while still
+          # attaching artifacts to an existing tag.
+          ref: ${{ github.event.inputs.source_ref || github.event.inputs.tag || github.ref }}
           # release-notes.sh resolves the previous tag for the compare link
           # via `git tag --sort=-version:refname`, so the checksums job needs
           # the full tag history (shallow defaults would only have HEAD).

--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -64,6 +64,23 @@ test("Linux release job forces AppImage extract-and-run mode", () => {
   );
 });
 
+test("manual release retries can build from a source ref while attaching to the tag", () => {
+  assert.match(releaseWorkflow, /source_ref:/);
+  assert.match(
+    releaseWorkflow,
+    /description: "Git ref to build from for manual release-infra retries\. Defaults to tag\."/,
+  );
+  assert.match(
+    releaseWorkflow,
+    /ref: \$\{\{ github\.event\.inputs\.source_ref \|\| github\.event\.inputs\.tag \|\| github\.ref \}\}/,
+  );
+  assert.match(
+    releaseWorkflow,
+    /RAW_RELEASE_TAG: \$\{\{ github\.event\.inputs\.tag \|\| github\.ref_name \}\}/,
+    "release attachment metadata must continue to come from the tag input",
+  );
+});
+
 test("sidecar bundle prunes foreign native packages before release bundling", () => {
   assert.match(sidecarScript, /prune_foreign_native_packages\(\)/);
   assert.match(sidecarScript, /process\.platform/);


### PR DESCRIPTION
## Summary
- add a manual release workflow source_ref input for release-infra retries
- checkout source_ref while keeping tag as the release attachment target
- add regression coverage for the retry checkout/tag split

## Verification
- node scripts/release-macos-signing.test.mjs
- pnpm check:tests-wired
- git diff --check -- .github/workflows/release.yml scripts/release-macos-signing.test.mjs