### PR TITLE
fix(board): reveal inspector row actions on hover and keyboard focus

### DIFF
--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -540,7 +540,7 @@ function LinksSection({
                     {link}
                   </span>
                 )}
-                <span style={{ opacity: 0, display: "flex", alignItems: "center", gap: 2 }} className="step-actions">
+                <span style={{ display: "flex", alignItems: "center", gap: 2 }} className="step-actions">
                   {saveState === "error" ? (
                     <span style={{ fontSize: 10, color: "var(--color-danger)" }} title="Save failed">
                       err
@@ -605,7 +605,7 @@ function LinksSection({
       </div>
 
       {/* CSS for hover reveal on link actions */}
-      <style>{".link-item-anchor:hover { text-decoration: underline; } li:hover .step-actions { opacity: 1; }"}</style>
+      <style>{".link-item-anchor:hover { text-decoration: underline; } .step-actions { opacity: 0; transition: opacity 0.1s; } li:hover .step-actions, li:focus-within .step-actions { opacity: 1; }"}</style>
     </div>
   );
 }
@@ -762,7 +762,7 @@ function StepsSection({
               </span>
 
               {/* Actions */}
-              <span style={{ display: "flex", gap: 2, flexShrink: 0, opacity: 0 }} className="step-actions">
+              <span style={{ display: "flex", gap: 2, flexShrink: 0 }} className="step-actions">
                 {i > 0 && (
                   <button type="button" className="board-toolbar-btn" style={{ padding: "1px 4px" }}
                     onClick={() => reorderStep(step.id, -1)} title="Move up">
@@ -817,7 +817,7 @@ function StepsSection({
       </div>
 
       {/* CSS for hover reveal on step actions */}
-      <style>{".step-actions { opacity: 0; transition: opacity 0.1s; } li:hover .step-actions { opacity: 1; }"}</style>
+      <style>{".step-actions { opacity: 0; transition: opacity 0.1s; } li:hover .step-actions, li:focus-within .step-actions { opacity: 1; }"}</style>
     </div>
   );
 }

--- a/src/components/board-link-browser.test.ts
+++ b/src/components/board-link-browser.test.ts
@@ -54,4 +54,27 @@ assert.doesNotMatch(
   "Task link clicks should not bypass the app with a new external tab",
 );
 
+// ── Row-action visibility: keyboard-reachable, not hover-only ────────────────
+// The inspector's link/step action buttons (Save to Library, Remove link,
+// Delete step) reveal on hover AND keyboard focus. They must NOT carry an inline
+// `opacity: 0` — inline styles outrank the CSS reveal rules, so an inline
+// opacity:0 leaves the buttons permanently invisible (unreachable for keyboard
+// and mouse users alike).
+assert.doesNotMatch(
+  boardInspector,
+  /style=\{\{[^}]*opacity:\s*0[^}]*\}\}\s*className="step-actions"/,
+  "step-actions span must not set inline opacity:0 (it overrides the CSS reveal)",
+);
+assert.doesNotMatch(
+  boardInspector,
+  /className="step-actions"\s*style=\{\{[^}]*opacity:\s*0/,
+  "step-actions span must not set inline opacity:0 (it overrides the CSS reveal)",
+);
+// Both inspector sections reveal their actions on keyboard focus, not just hover.
+const focusReveals = boardInspector.match(/li:focus-within \.step-actions/g) ?? [];
+assert.ok(
+  focusReveals.length >= 2,
+  "both the links and steps sections reveal row actions on :focus-within (keyboard reachable)",
+);
+
 console.log("board-link-browser.test.ts: ok");


### PR DESCRIPTION
## The bug

The board inspector's **link** and **step** rows hide their action buttons (Save to Library, Remove link, Delete step) behind an inline `opacity: 0` on the `.step-actions` span, then attempt to reveal them with a CSS `li:hover .step-actions { opacity: 1 }` rule.

Inline styles outrank selector rules without `!important`, so **the reveal never applied** — the buttons were effectively invisible for *both* mouse and keyboard users, while still being focusable (Tab lands on an unseen control = a keyboard trap).

Verified empirically in a browser: with the inline `opacity: 0`, computed opacity stayed `0` on hover and on focus.

## The fix

Drop the inline `opacity: 0` and let the `.step-actions` class own the hidden state, then reveal on `li:hover` **and** `li:focus-within` — so the actions appear when a keyboard user tabs into the row. This matches the focus-reveal standard already used by the projects list ("row actions also reveal on keyboard focus").

Two files, four small edits (remove inline opacity on the two spans; add the base class rule + `:focus-within` to the two `<style>` blocks).

## Verification

Browser harness with the fixed markup (both `<style>` blocks, no inline opacity):

| state | links section | steps section |
|---|---|---|
| default | `0` | `0` |
| hover | `1` | — |
| after un-hover | `0` | — |
| keyboard focus | `1` | `1` |

Added regression assertions to `board-link-browser.test.ts`: no inline `opacity:0` on `.step-actions`, and both sections carry `li:focus-within .step-actions`. Typecheck clean; test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)