### PR TITLE
fix(workflows): trap focus + Escape-to-close in create/schedule dialogs

### DIFF
--- a/src/components/modal-trap-adoption.test.ts
+++ b/src/components/modal-trap-adoption.test.ts
@@ -8,6 +8,7 @@ const FILES = [
   "library-doc-preview.tsx",
   "library-github-list.tsx",
   "onboarding-overlay.tsx",
+  "workflows/workflow-create-dialog.tsx",
 ];
 
 for (const file of FILES) {

--- a/src/components/workflows/workflow-create-dialog.tsx
+++ b/src/components/workflows/workflow-create-dialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 import { slugifyWorkflowId } from "@/lib/workflow-edit";
 import type {
   WorkflowPattern,
@@ -31,10 +32,16 @@ export function WorkflowCreateDialog({ onClose, onCreate }: WorkflowCreateDialog
   const [pattern, setPattern] = useState<WorkflowPattern>("sequential");
   const [familiar, setFamiliar] = useState("");
   const id = slugifyWorkflowId(name);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  // Trap Tab/Shift+Tab inside the modal and close on Escape. focusFirst is off
+  // so the Name input's autoFocus keeps the initial focus.
+  useFocusTrap(true, dialogRef, { onEscape: onClose, focusFirst: false });
 
   return (
     <div className="workflow-dialog-backdrop" role="presentation" onClick={onClose}>
       <div
+        ref={dialogRef}
+        tabIndex={-1}
         className="workflow-dialog"
         role="dialog"
         aria-modal="true"
@@ -132,6 +139,10 @@ export function WorkflowScheduleDialog({ workflow, onClose, onSchedule }: Workfl
   const [cadence, setCadence] = useState<Cadence>("once");
   const [days, setDays] = useState<number[]>([1, 2, 3, 4, 5]);
   const [intervalHours, setIntervalHours] = useState(24);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  // Trap Tab/Shift+Tab inside the modal and close on Escape. focusFirst is off
+  // so the "First reminder" input's autoFocus keeps the initial focus.
+  useFocusTrap(true, dialogRef, { onEscape: onClose, focusFirst: false });
 
   const submit = () => {
     const fireDate = new Date(fireAtLocal);
@@ -153,6 +164,8 @@ export function WorkflowScheduleDialog({ workflow, onClose, onSchedule }: Workfl
   return (
     <div className="workflow-dialog-backdrop" role="presentation" onClick={onClose}>
       <div
+        ref={dialogRef}
+        tabIndex={-1}
         className="workflow-dialog"
         role="dialog"
         aria-modal="true"
@@ -173,6 +186,7 @@ export function WorkflowScheduleDialog({ workflow, onClose, onSchedule }: Workfl
           <input
             type="datetime-local"
             value={fireAtLocal}
+            autoFocus
             onChange={(event) => setFireAtLocal(event.target.value)}
           />
         </label>


### PR DESCRIPTION
## The bug

`WorkflowCreateDialog` and `WorkflowScheduleDialog` are both `aria-modal="true"` dialogs, but neither trapped focus or closed on Escape:
- **Tab walked straight out of the modal** into the page behind it (a focusable element behind a modal is a classic a11y trap — focus disappears under the overlay).
- The only way to dismiss was a mouse click on the backdrop or the Close button — **no keyboard dismiss**.

These were the only `role="dialog"` modals in the workflows surface not yet on the repo's focus-trap standard (`modal-trap-adoption.test.ts`).

## The fix

Adopt the shared `useFocusTrap` hook on both dialogs:
- Tab / Shift+Tab cycle within the dialog
- `Escape` calls `onClose`
- focus restores to the trigger on unmount
- `tabIndex={-1}` added to each dialog container

`focusFirst` is disabled so each dialog's autoFocused input keeps the initial focus (the create dialog already autoFocused its Name input; added `autoFocus` to the schedule dialog's first field to match).

Added `workflows/workflow-create-dialog.tsx` to `modal-trap-adoption.test.ts` so the standard is enforced going forward.

## Verification (real running app)

Drove the live Workflows surface, opened the New-workflow dialog:
- ✅ dialog opens with the **Name input focused**
- ✅ focus **stayed trapped** across 12 Tab presses
- ✅ focus **stayed trapped** across 6 Shift+Tab presses
- ✅ **Escape closed** the dialog

Typecheck clean; `modal-trap-adoption.test.ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)