### PR TITLE
fix(roles): surface a hint when a role activate/deactivate fails

### DIFF
--- a/src/components/plugins-view-polish.test.ts
+++ b/src/components/plugins-view-polish.test.ts
@@ -90,4 +90,23 @@ assert.match(
   "Role activation toggles should be square-enough touch targets on mobile",
 );
 
+// A failed activate/deactivate must surface to the user, not silently revert.
+// The optimistic handler re-raises after rollback, and the toggle control
+// catches it to show a transient failure hint.
+assert.match(
+  source,
+  /catch \(err\)[\s\S]{0,600}throw err;/,
+  "handleRoleToggle re-raises after rolling back so the failure can surface",
+);
+assert.match(
+  source,
+  /catch \{\s*setFailed\(true\);/,
+  "the role toggle control catches a failed save and flags it",
+);
+assert.match(
+  source,
+  /failed && \([\s\S]{0,400}role="status"[\s\S]{0,400}ph:warning-circle/,
+  "a failure hint (status icon) renders when the role toggle save fails",
+);
+
 console.log("plugins-view-polish.test.ts OK");

--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -207,10 +207,12 @@ export function PluginsView({
         body: JSON.stringify({ id: role.id, familiar: role.familiar, active: next }),
       });
       if (!res.ok) throw new Error('save failed');
-    } catch {
-      // Rollback on error
+    } catch (err) {
+      // Rollback on error, then re-raise so the toggle control can surface the
+      // failure instead of silently bouncing the switch back with no explanation.
       setRoles(prev => prev.map(r => r.id === role.id && r.familiar === role.familiar ? { ...r, active: role.active } : r));
       setSelectedRole(prev => prev && prev.id === role.id && prev.familiar === role.familiar ? role : prev);
+      throw err;
     }
   };
   const [capabilities, setCapabilities] = useState<HarnessCapabilityManifest[]>([]);
@@ -979,6 +981,13 @@ function RoleCard({
   onToggle: (role: RoleEntry) => Promise<void>;
 }) {
   const [toggling, setToggling] = React.useState(false);
+  const [failed, setFailed] = React.useState(false);
+  // Auto-clear the failure hint so it doesn't linger after the user moves on.
+  React.useEffect(() => {
+    if (!failed) return;
+    const timer = setTimeout(() => setFailed(false), 4000);
+    return () => clearTimeout(timer);
+  }, [failed]);
 
   type ChipEntry = { key: string; icon: Parameters<typeof Icon>[0]["name"]; label: string };
   const chips: ChipEntry[] = ([
@@ -991,8 +1000,15 @@ function RoleCard({
   const handleToggle = async (e: React.MouseEvent) => {
     e.stopPropagation();
     if (toggling) return;
+    setFailed(false);
     setToggling(true);
-    try { await onToggle(role); } finally { setToggling(false); }
+    try {
+      await onToggle(role);
+    } catch {
+      setFailed(true);
+    } finally {
+      setToggling(false);
+    }
   };
 
   return (
@@ -1061,6 +1077,19 @@ function RoleCard({
             </span>
           ))}
         </div>
+      )}
+
+      {/* Failure hint — shown when the activate/deactivate save fails so the
+          switch doesn't just bounce back silently. */}
+      {failed && (
+        <span
+          role="status"
+          aria-label="Couldn't update role — try again"
+          title="Couldn't update — check the daemon and try again"
+          className="shrink-0 text-[var(--color-danger)]"
+        >
+          <Icon name="ph:warning-circle" width={14} aria-hidden />
+        </span>
       )}
 
       {/* Toggle */}


### PR DESCRIPTION
## The bug

Toggling a role's active state did an optimistic update, then **silently** rolled it back when the `/api/roles` save failed (`plugins-view.tsx` `handleRoleToggle`). The switch just bounced back with no explanation — the user can't tell whether the toggle did nothing, is loading, or failed. This is the "surface mutation failures" papercut the repo has fixed on the board (#567) and calendar (#553) surfaces.

## The fix

- `handleRoleToggle` re-raises after rolling back (instead of swallowing the error).
- The `RoleCard` toggle control catches it and shows a transient (4s, auto-clearing) `role="status"` warning-circle hint next to the switch.
- The rollback behavior is unchanged; this only adds the missing user-facing feedback.

## Verification (real running app)

Drove the live Roles surface with `/api/roles` GET mocked to one active role and the **POST mocked to 500**:
- ✅ clicking the toggle **reverts** the role to its prior (active) state
- ✅ a **failure hint** (red warning-circle, `role="status"`) appears next to the switch
- ✅ the hint is **absent** before the click (happy-path baseline)

Screenshot: the Reviewer role stays `ACTIVE` with the red hint beside the green toggle after the failed save.

Typecheck clean; added regression assertions to `plugins-view-polish.test.ts` (re-raise after rollback, catch sets the failed flag, status hint renders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)