### PR TITLE
fix(workflows): make run-preview frame opaque so shell bg stops bleeding

### DIFF
--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -1191,7 +1191,7 @@
   min-width: 0;
   min-height: 0;
   border-top: 1px solid var(--border);
-  background: color-mix(in oklch, var(--card) 60%, transparent);
+  background: var(--card);
 }
 
 .workflow-run-preview-resizer {


### PR DESCRIPTION
## What

The Workflow Studio Runs preview panel painted itself with `color-mix(in oklch, var(--card) 60%, transparent)`, letting the studio shell's `--background` bleed through the 40% transparency as a muddy tint. Against a warm/custom background it read as a peach wash that clashed with the solid `--card` library, inspector, and run-strip panels around it.

## Fix

Use solid `var(--card)` for `.workflow-run-preview-frame` so the run area reads as a clean panel like its siblings.

One-line CSS change. `workflow-studio.test.ts` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)