### PR TITLE
fix(github): make the Connect GitHub modal an accessible dialog

### DIFF
--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -2,6 +2,7 @@
 
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 import type { Familiar } from "@/lib/types";
 import type { Card, CardStatus } from "@/lib/cave-board-types";
 import type { GitHubItem } from "@/lib/github-tasks";
@@ -156,8 +157,12 @@ function PatSetupModal({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => { inputRef.current?.focus(); }, []);
+  // Trap Tab/Shift+Tab inside the modal and close on Escape. focusFirst is off
+  // so the username input's focus effect above keeps the initial focus.
+  useFocusTrap(true, dialogRef, { onEscape: onClose, focusFirst: false });
 
   async function save() {
     const trimmedPat = pat.trim();
@@ -194,16 +199,29 @@ function PatSetupModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
-      <div className="w-full max-w-md rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] p-6 shadow-2xl">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+      role="presentation"
+      onClick={onClose}
+    >
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="github-pat-modal-title"
+        onClick={(event) => event.stopPropagation()}
+        className="w-full max-w-md rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] p-6 shadow-2xl"
+      >
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-2">
             <Icon name="ph:github-logo" width={18} className="text-[var(--text-secondary)]" />
-            <h3 className="text-[15px] font-semibold">Connect GitHub</h3>
+            <h3 id="github-pat-modal-title" className="text-[15px] font-semibold">Connect GitHub</h3>
           </div>
           <button
             type="button"
             onClick={onClose}
+            aria-label="Close"
             className="rounded-md p-1 text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)]"
           >
             <Icon name="ph:x" width={14} />

--- a/src/components/modal-trap-adoption.test.ts
+++ b/src/components/modal-trap-adoption.test.ts
@@ -9,6 +9,7 @@ const FILES = [
   "library-github-list.tsx",
   "onboarding-overlay.tsx",
   "workflows/workflow-create-dialog.tsx",
+  "github-view.tsx",
 ];
 
 for (const file of FILES) {


### PR DESCRIPTION
## The bug

`PatSetupModal` (the "Connect GitHub" modal) rendered as a bare overlay `<div>`:
- no `role="dialog"` / `aria-modal` and no accessible name
- **no focus trap** — Tab walked out of the modal into the page behind it
- **no Escape-to-close** and no backdrop dismiss
- an **unlabeled** icon-only Close button (screen readers announced "button")

## The fix

- Adopt the shared `useFocusTrap` hook: Tab/Shift+Tab cycle within, `Escape` closes, focus restores on unmount.
- Mark the container `role="dialog"` `aria-modal="true"` `aria-labelledby` the heading, with `tabIndex={-1}`.
- Add backdrop click-to-close (matches the other Cave dialogs).
- Give the Close button `aria-label="Close"`.

`focusFirst` is off so the existing username-input focus effect keeps the initial focus. Added `github-view.tsx` to `modal-trap-adoption.test.ts` to enforce the standard.

## Verification (real running app)

Drove the live GitHub surface (PAT status mocked to not-connected), opened the Connect modal:
- ✅ dialog opens with the **username field focused**
- ✅ exposes an **accessible name** (aria-labelledby → "Connect GitHub")
- ✅ Close button is **labeled**
- ✅ focus **stayed trapped** across 12 Tab presses
- ✅ **Escape**, the **Close button**, and a **backdrop click** each dismiss it

Typecheck clean; `modal-trap-adoption.test.ts` passes.

> Note: the overlay sits within the workspace content's stacking context (the sidebar renders above its far-left edge) — a pre-existing, systemic layering trait shared by the other in-content dialogs, out of scope for this a11y fix. Escape / Close / content-area backdrop all dismiss correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)