### PR TITLE
fix(workflows): mirror right panel header — collapse toggle leftmost

### DIFF
--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -113,7 +113,7 @@ assert.match(studio, /sidePanelSection === "manifest"[\s\S]{0,300}<WorkflowManif
 assert.match(studio, /aria-label=\{leftPanelOpen \? "Hide workflow library" : "Show workflow library"\}/, "Studio should expose an accessible left-panel toggle");
 assert.match(studio, /aria-label=\{rightPanelOpen \? "Hide workflow details" : "Show workflow details"\}/, "Studio should expose an accessible right-panel toggle");
 assert.match(studio, /workflow-studio-library-panel[\s\S]{0,500}workflow-panel-tab workflow-panel-tab-left[\s\S]{0,700}<WorkflowLibrary/, "Left workflow panel toggle should live at the panel top edge");
-assert.match(studio, /workflow-studio-side[\s\S]{0,700}workflow-side-panel-tabs/, "Right workflow panel should render section tabs at the panel top edge");
+assert.match(studio, /workflow-side-panel-header[\s\S]{0,400}workflow-panel-collapse-button workflow-panel-tab-right[\s\S]{0,720}workflow-side-panel-tabs/, "Right workflow panel header should put the collapse toggle leftmost (mirroring the left panel), then the section tabs");
 assert.match(studio, /workflow-panel-collapse-button workflow-panel-tab-right/, "Right workflow panel collapse should stay separate from section selection");
 assert.match(studio, /leftPanelOpen \? "ph:sidebar-simple-fill" : "ph:sidebar-simple"/, "Left workflow panel toggle should use the sidebar tab icon");
 assert.match(studio, /rightPanelOpen \? "ph:sidebar-simple-fill" : "ph:sidebar-simple"/, "Right workflow panel toggle should use the sidebar tab icon");

--- a/src/components/workflows/workflow-studio.tsx
+++ b/src/components/workflows/workflow-studio.tsx
@@ -296,6 +296,17 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
       </main>
       <aside className="workflow-studio-side" aria-label="Workflow details">
         <div className="workflow-side-panel-header">
+          {/* Toggle leftmost (inner edge) — mirrors the left library panel. */}
+          <button
+            type="button"
+            className="workflow-panel-collapse-button workflow-panel-tab-right"
+            aria-label={rightPanelOpen ? "Hide workflow details" : "Show workflow details"}
+            aria-expanded={rightPanelOpen}
+            title={rightPanelOpen ? "Hide workflow details" : "Show workflow details"}
+            onClick={() => setRightPanelOpen((open) => !open)}
+          >
+            <Icon name={rightPanelOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={14} className="workflow-panel-tab__icon" />
+          </button>
           <Tabs<WorkflowSidePanelSection>
             className="workflow-side-panel-tabs"
             ariaLabel="Workflow detail sections"
@@ -313,16 +324,6 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
               title: s.label,
             }))}
           />
-          <button
-            type="button"
-            className="workflow-panel-collapse-button workflow-panel-tab-right"
-            aria-label={rightPanelOpen ? "Hide workflow details" : "Show workflow details"}
-            aria-expanded={rightPanelOpen}
-            title={rightPanelOpen ? "Hide workflow details" : "Show workflow details"}
-            onClick={() => setRightPanelOpen((open) => !open)}
-          >
-            <Icon name={rightPanelOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={14} className="workflow-panel-tab__icon" />
-          </button>
         </div>
         <div className="workflow-studio-side-content">
           <div

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -155,9 +155,12 @@
   outline-offset: 1px;
 }
 
+/* Toggle (first child) pins to the inner/left edge; tabs push to the outer/right
+   edge — a horizontal mirror of the left library panel's title+toggle header. */
 .workflow-side-panel-header {
   display: flex;
   align-items: flex-end;
+  justify-content: space-between;
   gap: 4px;
   flex-shrink: 0;
   width: 100%;


### PR DESCRIPTION
## What

On the **Workflows** page, the right detail panel's collapse toggle sat at the far right, *after* the Inspect / Bind / Manifest tabs. That didn't mirror the left library panel, whose toggle lives on its own inner (canvas-facing) edge.

This moves the toggle to be **leftmost** in the header (the panel's inner edge) and pushes the section tabs to the outer (right) edge via `justify-content: space-between` — a clean horizontal reflection of the left panel's `[title …… toggle]` row.

## Changes
- `workflow-studio.tsx` — reorder the side-panel header so the collapse `<button>` precedes the `<Tabs>`.
- `workflows.css` — `.workflow-side-panel-header` gets `justify-content: space-between` (toggle pins left, tabs push right).
- `workflow-studio.test.ts` — assertion updated to encode the new toggle-then-tabs order.

## Verified in the running app
Drove the Workflows page and selected a workflow:
- Right header first child **is** the toggle, x=1218 (inner/left edge); tabs pushed right, x=1329 → panel edge.
- Mirror check vs left panel: title x=35 (outer-left), toggle-icon x=283 (inner-right). Both toggles now face the canvas.

![header](toggle leftmost, then Inspect / Bind / Manifest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)