### PR TITLE
fix(shell): keep the left panel open when an option is selected

### DIFF
--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -67,15 +67,33 @@ assert.match(
   "Mobile nav toggle should announce whether the navigation drawer is open",
 );
 
+// Selecting a destination dismisses the mobile OVERLAY drawer, but must use
+// the mobile-only `dismissNavMobile`/`dismissListMobile` — NOT `closeNav`/
+// `closeList`, which also collapse the persistent DESKTOP side panel. On
+// desktop the left panel must stay open when an option is selected.
 assert.match(
   workspace,
-  /onModeChange=\{\(m\) => \{[\s\S]*shellRef\.current\?\.closeNav\(\);[\s\S]*setMode\(m as WorkspaceMode\);[\s\S]*shellRef\.current\?\.closeNav\(\);[\s\S]*\}\}/,
-  "Mobile sidebar destination taps should close the nav drawer after changing surfaces",
+  /onModeChange=\{\(m\) => \{[\s\S]*shellRef\.current\?\.dismissNavMobile\(\);[\s\S]*setMode\(m as WorkspaceMode\);[\s\S]*shellRef\.current\?\.dismissNavMobile\(\);[\s\S]*\}\}/,
+  "Mobile sidebar destination taps should dismiss the nav drawer (mobile-only) without collapsing the desktop nav",
 );
 assert.match(
   workspace,
-  /onOpenSession=\{\(id\) => \{[\s\S]*openFamiliarSession\(id\);[\s\S]*shellRef\.current\?\.closeList\(\);[\s\S]*\}\}/,
-  "Mobile list drawer session taps should close the list drawer after opening a session",
+  /onOpenSession=\{\(id\) => \{[\s\S]*openFamiliarSession\(id\);[\s\S]*shellRef\.current\?\.dismissListMobile\(\);[\s\S]*\}\}/,
+  "Mobile list drawer session taps should dismiss the list drawer (mobile-only) without collapsing the desktop list",
+);
+
+// The mobile-only dismissers must be gated on isMobile and must NOT call the
+// panel collapse() that closeNav/closeList use — that's what keeps the desktop
+// side panel open when an option is selected. (`shell` is read above.)
+assert.match(
+  shell,
+  /dismissNavMobile:\s*\(\)\s*=>\s*\{\s*if \(isMobile\) setMobileDrawer\(\(c\) => \(c === "nav" \? null : c\)\);\s*\}/,
+  "dismissNavMobile must only dismiss the mobile drawer (no desktop collapse)",
+);
+assert.match(
+  shell,
+  /dismissListMobile:\s*\(\)\s*=>\s*\{\s*if \(isMobile\) setMobileDrawer\(\(c\) => \(c === "list" \? null : c\)\);\s*\}/,
+  "dismissListMobile must only dismiss the mobile drawer (no desktop collapse)",
 );
 
 assert.match(

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -94,6 +94,11 @@ export type ShellHandle = {
   openList: () => void;
   closeList: () => void;
   toggleList: () => void;
+  /** Dismiss the nav/list ONLY on mobile (where it's an overlay drawer over the
+   *  content). On desktop these are persistent side panels, so selecting an
+   *  option inside them must NOT collapse them — these are no-ops there. */
+  dismissNavMobile: () => void;
+  dismissListMobile: () => void;
 };
 
 type ShellMobileChromeState = {
@@ -196,6 +201,9 @@ function ShellInner({
         navRef.current?.collapse();
         setNavOpen(false);
       },
+      dismissNavMobile: () => {
+        if (isMobile) setMobileDrawer((c) => (c === "nav" ? null : c));
+      },
       toggleNav: () => {
         if (isMobile) { toggleDrawer("nav"); return; }
         const panel = navRef.current;
@@ -210,6 +218,9 @@ function ShellInner({
       closeList: () => {
         if (isMobile) { setMobileDrawer((c) => (c === "list" ? null : c)); return; }
         listRef.current?.collapse();
+      },
+      dismissListMobile: () => {
+        if (isMobile) setMobileDrawer((c) => (c === "list" ? null : c));
       },
       toggleList: () => {
         if (isMobile) { toggleDrawer("list"); return; }

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1206,25 +1206,25 @@ export function Workspace() {
       addons={addons}
       onNewChat={() => {
         startFamiliarChat(activeId);
-        shellRef.current?.closeNav();
+        shellRef.current?.dismissNavMobile();
       }}
       onToggleSidebar={() => shellRef.current?.toggleNav()}
       onOpenSettings={() => {
-        shellRef.current?.closeNav();
+        shellRef.current?.dismissNavMobile();
         nextRouter.push("/settings");
       }}
       onModeChange={(m) => {
         if (m === "browser") {
           setMode("browser");
-          shellRef.current?.closeNav();
+          shellRef.current?.dismissNavMobile();
           return;
         }
         setMode(m as WorkspaceMode);
-        shellRef.current?.closeNav();
+        shellRef.current?.dismissNavMobile();
       }}
       onOpenSession={(id) => {
         openFamiliarSession(id);
-        shellRef.current?.closeList();
+        shellRef.current?.dismissListMobile();
       }}
       inboxItems={inboxItemsWithEphemeral}
       inboxPrefs={inboxPrefs}


### PR DESCRIPTION
## Problem

On **desktop**, selecting any option in the left sidebar collapsed the whole left nav. The sidebar handlers in `workspace.tsx` called the shell's imperative `closeNav()` (on mode change / new chat / open settings) and `closeList()` (on opening a session). Those methods are mobile-aware: on mobile they dismiss the overlay drawer, but **on desktop they collapse the persistent side panel** (`navRef.collapse()` / `listRef.collapse()`).

Result: every nav-item tap nuked the sidebar. Measured live — the nav panel went **265px → ~0** on a single mode click — forcing you to reopen it to pick another option.

## Fix

Mobile genuinely wants the drawer to close on selection (it overlays the content), so the close can't just be removed. Added mobile-only dismissers to the shell handle:

```ts
dismissNavMobile:  () => { if (isMobile) setMobileDrawer(c => c === "nav"  ? null : c); },
dismissListMobile: () => { if (isMobile) setMobileDrawer(c => c === "list" ? null : c); },
```

They dismiss the overlay drawer on mobile and are **no-ops on desktop**. The selection handlers (`onModeChange`, `onNewChat`, `onOpenSettings`, `onOpenSession`) now call these instead of `closeNav`/`closeList`.

- **Desktop:** left panel stays open when you select an option ✅
- **Mobile:** drawer still auto-dismisses after a selection (unchanged) ✅

## Verification

Drove the running app and measured the nav panel width across selections:

| Action | Before | After |
|---|---|---|
| initial | 265px | 265px |
| click **Board** | **1px** (collapsed) | **265px** |
| click **Familiars** | 1px | 265px |
| click a session row | 1px | 265px |

Plus: updated `mobile-shell-smoke.test.ts` to assert the new mobile-only dismiss (preserving the mobile-drawer-closes contract) and that the dismissers don't collapse on desktop. `tsc --noEmit` clean; `mobile-shell-smoke` + `shell-drawer-smoke` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)