### PR TITLE
fix(library): surface failures when saving a bookmark to the board

### DIFF
--- a/src/components/library-error-retry.test.ts
+++ b/src/components/library-error-retry.test.ts
@@ -54,4 +54,12 @@ assert.match(
   "LibraryView should pass a retry handler that re-fires loadDocs",
 );
 
+// Saving a bookmark to the board must throw on a failed response so NewCardModal
+// surfaces the error and keeps the dialog open — never silently close on a lost save.
+assert.match(
+  view,
+  /const res = await fetch\("\/api\/board"[\s\S]{0,700}if \(!res\.ok \|\| !json\?\.ok\) \{[\s\S]{0,120}throw new Error/,
+  "Save-to-board should throw on a failed/!ok response instead of closing silently",
+);
+
 console.log("library-error-retry.test.ts: ok");

--- a/src/components/library-view.tsx
+++ b/src/components/library-view.tsx
@@ -343,7 +343,9 @@ export function LibraryView({ sessions, onOpenSession, onNewProjectChat }: Libra
           defaultNotes={[boardDraft.url, boardDraft.notes].filter(Boolean).join("\n")}
           defaultLabels={boardDraft.tags}
           onCreate={async (draft: NewCardDraft) => {
-            await fetch("/api/board", {
+            // Throw on failure so NewCardModal surfaces the error and keeps the
+            // dialog open, instead of silently closing on a lost save.
+            const res = await fetch("/api/board", {
               method: "POST",
               headers: { "content-type": "application/json" },
               body: JSON.stringify({
@@ -356,6 +358,10 @@ export function LibraryView({ sessions, onOpenSession, onNewProjectChat }: Libra
                 labels: draft.labels,
               }),
             });
+            const json = await res.json().catch(() => null);
+            if (!res.ok || !json?.ok) {
+              throw new Error(json?.error ?? "Couldn't save to the board. Please try again.");
+            }
             setBoardDraft(null);
           }}
         />


### PR DESCRIPTION
## The bug

The Library "Add to Board" flow fired the `/api/board` POST **without checking the response** and called `setBoardDraft(null)` unconditionally:

```ts
await fetch("/api/board", { method: "POST", ... });
setBoardDraft(null);   // closes the dialog even if the save failed
```

So a failed save silently closed the dialog and the bookmark was lost with no indication it hadn't been saved — the "review the failure path" papercut already fixed on the board (#567), calendar (#553), and roles (#771) surfaces.

## The fix

Parse the response and `throw` on a failed / `!ok` result — matching the canonical `board-view.tsx` `create()` pattern. `NewCardModal` **already** catches a thrown `onCreate`, renders the error, and keeps the dialog open (it's the same modal board-view uses), so this reuses the existing error UI with **no modal changes** — the fix is entirely in `library-view.tsx`.

## Verification (real running app)

Drove the live Library → Bookmarks surface (bookmarks GET mocked to one item), clicked **Add to Board**, submitted the modal:
- ✅ with `/api/board` POST mocked to **500**: the dialog **stays open** and shows the error ("Server error — could not save")
- ✅ with a **200**: the dialog **closes** as before

Typecheck clean; added a regression assertion to `library-error-retry.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)