### PR TITLE
feat(chat): render message prose in Inter (ChatGPT/Codex feel)

### DIFF
--- a/src/lib/font-css-vars.test.ts
+++ b/src/lib/font-css-vars.test.ts
@@ -71,4 +71,12 @@ assert.match(
   ".cave-md must also set -webkit-hyphens for the WebKit webview",
 );
 
+// Chat message prose uses Inter (ChatGPT/Codex vibe), scoped to chat bubbles so
+// library + memory prose keep the app font.
+assert.match(
+  caveChat,
+  /\.cave-bubble-user\s+\.cave-md,\s*\.cave-bubble-assistant\s+\.cave-md,\s*\.cave-md--expanded\s*\{[\s\S]*?font-family:\s*var\(--font-inter\)/,
+  "chat bubble prose must set font-family to var(--font-inter)",
+);
+
 console.log("font-css-vars.test.ts OK");

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -46,6 +46,18 @@
   -webkit-font-smoothing: antialiased;
 }
 
+/* Chat message prose reads in Inter — a neutral grotesque for the ChatGPT/Codex
+   look — instead of the rounder geometric UI sans (Geist). Scoped to chat bubbles
+   so library-doc and memory prose (which also use .cave-md) keep the app font.
+   --font-inter is declared on <html> by next/font (src/app/fonts.ts) and loads
+   on demand the first time chat prose renders. */
+.cave-bubble-user .cave-md,
+.cave-bubble-assistant .cave-md,
+.cave-md--expanded {
+  font-family: var(--font-inter), ui-sans-serif, system-ui, -apple-system,
+    "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
 .cave-md > * + * { margin-top: 0.7em; }
 .cave-md > *:first-child { margin-top: 0; }
 


### PR DESCRIPTION
## What

Chat message prose inherited the app's rounder geometric UI sans (Geist). This switches **chat-bubble prose** to **Inter** — a neutral grotesque that gives the ChatGPT/Codex reading feel.

## Scope

Applied only to chat prose via `.cave-bubble-user .cave-md, .cave-bubble-assistant .cave-md, .cave-md--expanded`. Library-doc previews and memory (which also use `.cave-md`) and the rest of the UI **keep Geist**. `--font-inter` is already declared on `<html>` by `next/font` (`src/app/fonts.ts`) and loads on demand the first time chat prose renders.

## Files
- `src/styles/cave-chat.css` — scoped `font-family: var(--font-inter), …` rule after the `.cave-md` block.
- `src/lib/font-css-vars.test.ts` — assertion that chat-bubble prose sets `var(--font-inter)`.

## Verified in the running app
Opened a chat with messages and read computed styles:
- chat prose `font-family` → `Inter, "Inter Fallback", ui-sans-serif, …`
- `body` → still `Geist, …` (UI unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)