### PR TITLE
fix(chat): size header metadata to match the chat title

### DIFF
--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -90,6 +90,12 @@ assert.match(
 
 assert.match(
   styles,
+  /\.cave-chat-meta-line__meta\s*\{[\s\S]*?font-size:\s*12\.5px/,
+  "Header meta should read at the chat title size (12.5px), not fine print",
+);
+
+assert.match(
+  styles,
   /\.cave-chat-cwd-pair\s*\{[\s\S]*?display:\s*inline-flex[\s\S]*?gap:\s*4px/,
   "Header ROOT/CWD editor pair should stay compact inside the meta row",
 );

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1429,7 +1429,9 @@ details[open] > .cave-tool-summary::before {
   white-space: nowrap;
   color: var(--text-muted);
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  /* Match the chat title (.cave-chat-title-input, 12.5px) so the runtime/cwd
+     metadata reads at the same size as the title rather than as fine print. */
+  font-size: 12.5px;
 }
 
 /* CHAT-D3-06: ticking elapsed inside the streaming meta line. Tabular digits


### PR DESCRIPTION
## What

The chat header's runtime/cwd metadata line (`claude · openclaw-local · ~/…/coven-cave · 27s`) rendered at **10.5px** — smaller than the **12.5px** chat title next to it, so it read as fine print. This bumps `.cave-chat-meta-line__meta` to **12.5px** to match `.cave-chat-title-input`.

## Files
- `src/styles/cave-chat.css` — `.cave-chat-meta-line__meta` font-size 10.5px → 12.5px.
- `src/components/chat-header-row.test.ts` — assertion pinning the meta to 12.5px (title size).

## Verified in the running app
Opened a chat and read computed styles: `.cave-chat-meta-line__meta` font-size → `12.5px`, matching the title. Header crop confirms the metadata now reads at the same size as the "What…" title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)