### PR TITLE
feat(sidebar): remove the Ask Salem button from the left side panel

### DIFF
--- a/src/components/salem/salem-home-entry.test.ts
+++ b/src/components/salem/salem-home-entry.test.ts
@@ -23,9 +23,8 @@ assert.match(widget, /labels: \["salem", "happy-path", card\.recommendedPathId\]
 assert.match(widget, /steps: card\.steps\.map/, "copies path steps into the checklist");
 assert.match(widget, /Salem path: \$\{card\.title\}/, "titles the board card by the path");
 
-// Sidebar: Ask Salem entry opens the Salem rail.
-assert.match(sidebar, /label="Ask Salem"/, "sidebar exposes an Ask Salem entry");
-assert.match(sidebar, /cave:salem-open/, "Ask Salem opens the Salem rail");
+// Sidebar: the Ask Salem entry was removed from the left side panel.
+assert.doesNotMatch(sidebar, /label="Ask Salem"/, "sidebar no longer exposes an Ask Salem entry");
 
 // Projects empty state offers Ask Salem.
 assert.match(projects, /Ask Salem/, "projects empty state offers Ask Salem");

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -252,15 +252,6 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
           label="New session"
           onClick={onNewChat}
         />
-        <ActionRow
-          icon={<Icon name="ph:sparkle" width={14} />}
-          label="Ask Salem"
-          onClick={() => {
-            if (typeof window !== "undefined") {
-              window.dispatchEvent(new CustomEvent("cave:salem-open"));
-            }
-          }}
-        />
       </div>
 
       <div className="sidebar-nav-scroll">


### PR DESCRIPTION
## What

Removes the **Ask Salem** action row from the left sidebar (`sidebar-minimal.tsx`). The sidebar header now shows just the familiar switcher + **New session**.

Salem is **not orphaned** — it stays reachable via the Projects empty-state "Ask Salem" entry and the companion-rail Salem widget, both of which still dispatch `cave:salem-open` (workspace still listens).

## Files
- `src/components/sidebar-minimal.tsx` — drop the Ask Salem `ActionRow`.
- `src/components/salem/salem-home-entry.test.ts` — assert the sidebar no longer exposes the entry; Projects empty-state coverage kept.

## Verified in the running app
Sidebar now renders only "All familiars" + "New session" (Ask Salem button count = 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)