### PR TITLE
fix(workflows): standardize the run-strip toolbar + runs list layout

### DIFF
--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -741,28 +741,46 @@
   color: white;
 }
 
+/* Stack the action row over the hint/feedback line. The old side-by-side
+   layout let the hint text claim half the width and squeezed the buttons
+   into 2–3 cramped wrapped rows; giving the actions the full width keeps
+   them on one tidy row (wrapping only when genuinely narrow). */
 .workflow-run-strip {
   grid-area: strip;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
   padding: 10px;
 }
 
 .workflow-run-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  align-items: center;
+  gap: 6px;
 }
 
+/* Every action button shares one height + radius so the row reads as a
+   single, even control strip regardless of label length. */
 .workflow-run-actions button {
-  padding: 0 10px;
+  height: 32px;
+  min-height: 32px;
+  padding: 0 12px;
+  border-radius: 7px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+/* Play is the terminal/execute action — pin it to the right edge of the row
+   so it's visually separated from Validate/Dry-run. */
+.workflow-play-button {
+  margin-left: auto;
 }
 
 .workflow-run-feedback {
   margin: 0;
-  text-align: right;
+  text-align: left;
 }
 
 .workflow-detail-list {
@@ -1320,10 +1338,16 @@
 
 .workflow-run-chip {
   flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  /* Uniform width so every run's status pill is the same size and the kind /
+     detail / time columns line up vertically down the list. */
+  min-width: 68px;
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  padding: 1px 6px;
+  padding: 2px 6px;
   border-radius: 999px;
   border: 1px solid var(--border);
 }
@@ -1337,6 +1361,7 @@
 
 .workflow-run-kind {
   flex: none;
+  min-width: 50px;
   color: var(--muted-foreground);
   font-size: 11px;
 }
@@ -1356,7 +1381,8 @@
 }
 
 .workflow-history-button {
-  padding: 4px 7px;
+  width: 32px;
+  padding: 0;
 }
 
 .workflow-primary-button {


### PR DESCRIPTION
## What

Optimizes the Workflow Studio **action toolbar** and standardizes the **runs list** — both flagged as inconsistent/cramped.

### Toolbar (`workflow-run-strip`)
Before, the action row used `justify-content: space-between` next to the hint text, so the hint claimed ~half the width and forced the buttons to wrap into 2–3 cramped rows at uneven sizes (the undo/redo icon buttons used different padding than the rest).

- The strip now **stacks**: one full-width action row over the hint line, so the buttons get the whole width and sit on a single tidy row (wrapping only when genuinely narrow).
- Every action button shares one **32px height + radius**; undo/redo are uniform **32×32 squares**.
- **Play** pins to the right edge as the terminal execute action.
- The hint/feedback moves **below**, left-aligned and muted.

### Runs (`workflow-runs-panel`)
Status pills were variable-width, so the kind / detail / time columns zig-zagged down the list. The chip now has a uniform **68px** min-width (centered) and the kind column a **50px** min-width, so every run lines up in clean columns.

## Verification

Production build + Playwright:
- All 6 toolbar buttons measure **32px** tall; strip `flex-direction: column`; hint left-aligned.
- All run status chips measure **68px** wide.

`tsc --noEmit` clean; `workflows-view`, `workflow-studio`, `workflow-step-list`, `workflow-playback` tests pass. CSS-only change (no TSX touched).

> Made in an isolated worktree off `origin/main` (a parallel session holds the primary checkout on another branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)