### PR TITLE
fix(familiars): preserve model id casing

### DIFF
--- a/src/components/familiar-studio-brain-tab.test.ts
+++ b/src/components/familiar-studio-brain-tab.test.ts
@@ -25,6 +25,11 @@ assert.match(
   /allowCustomModel/,
   "Brain tab should keep a free-text fallback for ids not in the curated catalog",
 );
+assert.match(
+  source,
+  /type="text"[\s\S]{0,320}autoCapitalize="none"[\s\S]{0,80}autoCorrect="off"[\s\S]{0,80}spellCheck=\{false\}/,
+  "Brain tab custom model input should not auto-capitalize, autocorrect, or spellcheck model ids",
+);
 assert.match(source, /note/);
 assert.match(source, /\/api\/harnesses/);
 assert.match(source, /\/api\/config/);

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -193,6 +193,9 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
               onChange={(e) => setDraftModel(e.target.value)}
               onBlur={() => save({ model: draftModel.trim() || undefined })}
               placeholder="provider/model"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
               className="familiar-studio-brain__input"
             />
           ) : null}


### PR DESCRIPTION
## Summary

- disables mobile autocapitalize/autocorrect/spellcheck on the Familiar Studio Brain custom model input
- keeps the newer runtime-catalog model picker behavior from main intact
- adds a regression assertion for the custom model input keyboard attributes

## Verification

- `node --experimental-strip-types src/components/familiar-studio-brain-tab.test.ts`
- `pnpm typecheck`
