### PR TITLE
feat(rail): fold the magnifier Inspector tab into the brain Memory tab

### DIFF
--- a/src/components/companion-rail.test.ts
+++ b/src/components/companion-rail.test.ts
@@ -9,11 +9,11 @@ assert.match(source, /companion-rail__header/, "Header element with BEM class");
 assert.match(source, /companion-rail__tabs/, "Tab strip element with BEM class");
 assert.match(
   source,
-  /type CompanionTab = "chat" \| "inspector" \| "memory" \| "browser" \| "salem"/,
-  "Companion tab union must include Browser and Salem",
+  /type CompanionTab = "chat" \| "memory" \| "browser" \| "salem"/,
+  "Companion tab union must include Browser and Salem (Inspector folded into Memory)",
 );
 assert.match(source, /Chat/, "Chat label rendered");
-assert.match(source, /Inspector/, "Inspector label rendered");
+assert.doesNotMatch(source, /title="Inspector"/, "standalone Inspector tab removed — folded into the Memory (brain) tab");
 assert.match(source, /Memory/, "Memory label rendered");
 assert.match(source, /Browser/, "Browser label rendered");
 assert.match(source, /Salem/, "Salem label rendered");

--- a/src/components/companion-rail.tsx
+++ b/src/components/companion-rail.tsx
@@ -7,14 +7,13 @@ import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import type { ChatRouterHandle } from "@/components/chat-router";
 import type { Familiar } from "@/lib/types";
 
-export type CompanionTab = "chat" | "inspector" | "memory" | "browser" | "salem";
+export type CompanionTab = "chat" | "memory" | "browser" | "salem";
 
 type Props = {
   familiar: Familiar | null;
   defaultTab?: CompanionTab;
   activeTab?: CompanionTab;
   chatSlot: ReactNode;
-  inspectorSlot: ReactNode;
   memorySlot: ReactNode;
   browserSlot?: ReactNode;
   salemSlot?: ReactNode;
@@ -37,7 +36,6 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
       defaultTab = "chat",
       activeTab,
       chatSlot,
-      inspectorSlot,
       memorySlot,
       browserSlot,
       salemSlot,
@@ -52,7 +50,7 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
     const resolvedFamiliar = resolvedFamiliars[0];
     const [tab, setTab] = useState<CompanionTab>(defaultTab);
     const requestedTab = activeTab ?? tab;
-    const fallbackTab: CompanionTab = browserSlot ? "browser" : salemSlot ? "salem" : "inspector";
+    const fallbackTab: CompanionTab = browserSlot ? "browser" : salemSlot ? "salem" : "memory";
     const selectedTab =
       hideChatTab && requestedTab === "chat"
         ? browserSlot ? "browser" : fallbackTab
@@ -140,26 +138,15 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
             </button>
           )}
           {familiar ? (
-            <>
-              <button
-                type="button"
-                className={`companion-rail__tab${selectedTab === "inspector" ? " companion-rail__tab--active" : ""}`}
-                onClick={() => switchTab("inspector")}
-                aria-current={selectedTab === "inspector"}
-                title="Inspector"
-              >
-                <Icon name="ph:magnifying-glass" width={14} />
-              </button>
-              <button
-                type="button"
-                className={`companion-rail__tab${selectedTab === "memory" ? " companion-rail__tab--active" : ""}`}
-                onClick={() => switchTab("memory")}
-                aria-current={selectedTab === "memory"}
-                title="Memory"
-              >
-                <Icon name="ph:brain" width={14} />
-              </button>
-            </>
+            <button
+              type="button"
+              className={`companion-rail__tab${selectedTab === "memory" ? " companion-rail__tab--active" : ""}`}
+              onClick={() => switchTab("memory")}
+              aria-current={selectedTab === "memory"}
+              title="Memory"
+            >
+              <Icon name="ph:brain" width={14} />
+            </button>
           ) : null}
           {browserSlot ? (
             <button
@@ -191,14 +178,9 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
             </div>
           )}
           {familiar ? (
-            <>
-              <div hidden={selectedTab !== "inspector"} className="companion-rail__pane">
-                {inspectorSlot}
-              </div>
-              <div hidden={selectedTab !== "memory"} className="companion-rail__pane">
-                {memorySlot}
-              </div>
-            </>
+            <div hidden={selectedTab !== "memory"} className="companion-rail__pane">
+              {memorySlot}
+            </div>
           ) : null}
           {browserSlot ? (
             <div hidden={selectedTab !== "browser"} className="companion-rail__pane companion-rail__pane--browser">

--- a/src/components/inspector-pane-polish.test.ts
+++ b/src/components/inspector-pane-polish.test.ts
@@ -40,7 +40,7 @@ test("InspectorEmpty helper is defined and used for the three no-familiar/error 
 test("memory inner mode toggle uses the shared Vercel-style Tabs (2px underline)", () => {
   // The memory mode strip now delegates to the shared <Tabs> component, which
   // owns the tablist role + 2px underline idiom.
-  assert.match(src, /<Tabs<"inspector" \| "coven" \| "files">/, "memory mode renders shared Tabs");
+  assert.match(src, /<Tabs<"coven" \| "files">/, "memory mode renders shared Tabs");
   assert.match(src, /ariaLabel="Memory mode"/, "memory mode tablist labelled");
   // Should no longer use the old pill background for active mode
   assert.doesNotMatch(

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -6,7 +6,6 @@ import type { Familiar } from "@/lib/types";
 import type { InboxItem } from "@/lib/cave-inbox";
 import { SyntaxBlock, MarkdownBlock } from "@/components/message-bubble";
 import { EvalLoopPanel } from "@/components/eval-loop-panel";
-import { MemoryInspectorPanel } from "@/components/memory-inspector-panel";
 import { VaultPanel } from "@/components/vault-panel";
 import { SnoozeMenu } from "@/components/snooze-menu";
 import { Icon, type IconName } from "@/lib/icon";
@@ -585,7 +584,7 @@ type CovenMemoryEntry = {
 };
 
 function MemoryTab({ familiar }: { familiar: Familiar | null }) {
-  const [mode, setMode] = useState<"inspector" | "coven" | "files">("inspector");
+  const [mode, setMode] = useState<"coven" | "files">("coven");
   const [entries, setEntries] = useState<MemoryEntry[]>([]);
   const [covenEntries, setCovenEntries] = useState<CovenMemoryEntry[]>([]);
   const [covenLoaded, setCovenLoaded] = useState(false);
@@ -708,7 +707,7 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
   return (
     <div className="inspector-memory-tab-surface flex h-full min-h-0 flex-col bg-[var(--bg-base)]">
       <div className="flex items-end gap-0.5 border-b border-[var(--border-hairline)] px-2">
-        <Tabs<"inspector" | "coven" | "files">
+        <Tabs<"coven" | "files">
           bordered={false}
           size="sm"
           ariaLabel="Memory mode"
@@ -718,16 +717,14 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
             setMode(m);
           }}
           items={[
-            { id: "inspector", label: "Inspect" },
             { id: "coven", label: "Coven" },
             { id: "files", label: "Files" },
           ]}
         />
         <span className="ml-auto pb-1.5 text-[10px] text-[var(--text-muted)]">
-          {mode === "inspector" ? "read-only" : mode === "coven" ? covenFiltered.length : filtered.length}
+          {mode === "coven" ? covenFiltered.length : filtered.length}
         </span>
       </div>
-      {mode !== "inspector" ? (
       <div className="border-b border-[var(--border-hairline)] p-2">
         <input
           value={query}
@@ -736,13 +733,6 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
           className="w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1 text-xs text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)] focus:border-[var(--accent-presence)]"
         />
       </div>
-      ) : null}
-
-      {mode === "inspector" ? (
-        <div className="min-h-0 flex-1 overflow-hidden">
-          <MemoryInspectorPanel familiar={familiar} />
-        </div>
-      ) : null}
 
       {mode === "coven" ? (
         <ul className="min-h-0 flex-1 overflow-y-auto p-2 text-xs">

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -23,7 +23,6 @@ import { CompanionRail, type CompanionTab } from "@/components/companion-rail";
 import { RailInspector } from "@/components/inspector-pane";
 import { FamiliarsView } from "@/components/familiars-view";
 import { CallsView } from "@/components/calls-view";
-import { RailMemoryList } from "@/components/familiars-memory-view";
 import {
   getActiveFamiliar,
   setActiveFamiliar,
@@ -134,7 +133,11 @@ export function Workspace() {
   const [rightPanel, setRightPanel] = useState<RightPanelKind | null>(null);
   const [railTab, setRailTab] = useState<CompanionTab>(() => {
     if (typeof window === "undefined") return "chat";
-    return (window.localStorage.getItem("cave:rail.tab") as CompanionTab) ?? "chat";
+    const stored = window.localStorage.getItem("cave:rail.tab");
+    // The standalone "inspector" (magnifier) tab folded into "memory" (brain);
+    // remap any persisted value so a stale key doesn't select a removed tab.
+    if (stored === "inspector") return "memory";
+    return (stored as CompanionTab) ?? "chat";
   });
   const [familiarPanelOpen, setFamiliarPanelOpen] = useState(false);
   const [pendingProjectChatRoot, setPendingProjectChatRoot] = useState<string | null>(null);
@@ -1520,15 +1523,8 @@ export function Workspace() {
                   onOpenOnboarding={openOnboarding}
                 />
               }
-              inspectorSlot={
-                <RailInspector familiar={active} />
-              }
               memorySlot={
-                <RailMemoryList
-                  familiar={active}
-                  familiars={familiars}
-                  onOpenFullView={() => setMode("agents")}
-                />
+                <RailInspector familiar={active} />
               }
               browserSlot={
                 <BrowserPane ref={companionBrowserPaneRef} label="companion" activeFamiliarId={active?.id ?? null} />


### PR DESCRIPTION
## What

The companion rail (per-familiar right panel) had **two overlapping memory surfaces**:
- a magnifier **Inspector** tab → the `MemoryTab` with **Inspect / Coven / Files** sub-tabs
- a brain **Memory** tab → a separate memory list

This consolidates them into the brain tab, per request:

- **Remove the `Inspect` sub-tab** (`MemoryInspectorPanel`) — the memory mode strip is now just **Coven | Files**, defaulting to Coven. Search now shows for both modes.
- **Remove the standalone magnifier `Inspector` tab** from the rail (and its `inspectorSlot`).
- **Point the brain `Memory` tab at the `MemoryTab`** (`RailInspector`), so Coven memory + Files live under the brain icon.
- Drop `"inspector"` from `CompanionTab`; remap any persisted `cave:rail.tab === "inspector"` → `"memory"` so a stale localStorage key doesn't select a removed tab.

### Rail tabs, after

`[chat] [brain → Coven | Files] [globe] [book]`

## Test

- `tsc --noEmit` clean on all touched files.
- Updated + passing: `companion-rail.test.ts`, `inspector-pane-polish.test.ts`; unaffected `companion-rail-persistence`, `inspector-pane-surface`, `familiars-memory-view-rail` still green.

Note: `MemoryInspectorPanel` and `RailMemoryList` are no longer wired into the rail but remain defined (their own tests stay green); the brain tab loses the old "Open full memory →" affordance from the list view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)