### PR TITLE
feat(rail): restore "Open full memory →" button in the brain Memory tab

### DIFF
--- a/src/components/inspector-pane-polish.test.ts
+++ b/src/components/inspector-pane-polish.test.ts
@@ -50,6 +50,14 @@ test("memory inner mode toggle uses the shared Vercel-style Tabs (2px underline)
   );
 });
 
+test("Memory tab renders an 'Open full memory' footer when onOpenFullView is provided", () => {
+  // The rail's brain (Memory) tab threads onOpenFullView so it can jump to the
+  // full Agent Memory view, reusing the pinned .rail-memory__open-full button.
+  assert.match(src, /onOpenFullView\?: \(\) => void/, "MemoryTab/InspectorPane accept onOpenFullView");
+  assert.match(src, /onOpenFullView \? \(/, "footer button is conditional on the callback");
+  assert.match(src, /rail-memory__open-full[\s\S]*?Open full memory/, "renders the Open full memory button");
+});
+
 test("inbox card gets fired-state visual emphasis + hover affordance", () => {
   // Fired cards: warning-tinted border + bg
   assert.match(

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -49,6 +49,8 @@ type Props = {
   onInboxItemChanged?: () => void | Promise<void>;
   /** When true, drop the tab nav and outer border so the pane fits in 296px rail. */
   compact?: boolean;
+  /** When set, the Memory tab shows an "Open full memory →" footer button. */
+  onOpenFullView?: () => void;
 };
 
 const TAB_LABEL: Record<Tab, string> = {
@@ -114,6 +116,7 @@ export function InspectorPane({
   onOpenInboxItem,
   onInboxItemChanged,
   compact = false,
+  onOpenFullView,
 }: Props) {
   const [tab, setTab] = useState<Tab>("memory");
   const tablistRef = useRef<HTMLElement | null>(null);
@@ -209,7 +212,7 @@ export function InspectorPane({
           tab === "memory" ? "overflow-hidden" : "overflow-y-auto"
         }`}
       >
-        {tab === "memory" ? <MemoryTab familiar={familiar} /> : null}
+        {tab === "memory" ? <MemoryTab familiar={familiar} onOpenFullView={onOpenFullView} /> : null}
         {tab === "familiar" ? <FamiliarCapabilityPanel familiar={familiar} /> : null}
         {tab === "inbox" ? (
           <InboxTab
@@ -583,7 +586,13 @@ type CovenMemoryEntry = {
   excerpt?: string;
 };
 
-function MemoryTab({ familiar }: { familiar: Familiar | null }) {
+function MemoryTab({
+  familiar,
+  onOpenFullView,
+}: {
+  familiar: Familiar | null;
+  onOpenFullView?: () => void;
+}) {
   const [mode, setMode] = useState<"coven" | "files">("coven");
   const [entries, setEntries] = useState<MemoryEntry[]>([]);
   const [covenEntries, setCovenEntries] = useState<CovenMemoryEntry[]>([]);
@@ -821,6 +830,16 @@ function MemoryTab({ familiar }: { familiar: Familiar | null }) {
           </li>
         ) : null}
       </ul>
+      ) : null}
+
+      {onOpenFullView ? (
+        <button
+          type="button"
+          className="focus-ring rail-memory__open-full"
+          onClick={onOpenFullView}
+        >
+          Open full memory →
+        </button>
       ) : null}
     </div>
   );
@@ -1380,8 +1399,10 @@ function FamiliarCapabilityPanel({ familiar }: { familiar: Familiar | null }) {
 
 export function RailInspector({
   familiar,
+  onOpenFullView,
 }: {
   familiar: Familiar | null;
+  onOpenFullView?: () => void;
 }) {
   if (!familiar) {
     return (
@@ -1392,7 +1413,7 @@ export function RailInspector({
   }
   return (
     <div className="rail-inspector">
-      <InspectorPane familiar={familiar} compact={true} />
+      <InspectorPane familiar={familiar} compact={true} onOpenFullView={onOpenFullView} />
     </div>
   );
 }

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1524,7 +1524,7 @@ export function Workspace() {
                 />
               }
               memorySlot={
-                <RailInspector familiar={active} />
+                <RailInspector familiar={active} onOpenFullView={() => setMode("agents")} />
               }
               browserSlot={
                 <BrowserPane ref={companionBrowserPaneRef} label="companion" activeFamiliarId={active?.id ?? null} />


### PR DESCRIPTION
## What

Follow-up to #785. Folding the magnifier tab into the brain (Memory) tab routed it through `RailInspector` → `InspectorPane` → `MemoryTab`, which dropped the old `RailMemoryList` footer that jumped to the full Agent Memory view.

This threads an optional `onOpenFullView` callback through `InspectorPane` → `MemoryTab`, rendering the pinned **`Open full memory →`** footer button (reusing the existing `.rail-memory__open-full` style) below the Coven/Files list. `workspace` wires it to `setMode("agents")`.

The prop is optional, so the chat-surface `InspectorPane` (which doesn't pass it) shows no button — the footer only appears in the companion rail's brain tab, as before.

## Test

- `tsc --noEmit` clean on touched files.
- Added a regression assertion in `inspector-pane-polish.test.ts` (7 pass / 0 fail); `companion-rail`, `inspector-pane-surface`, `familiars-memory-view-rail` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)