### PR TITLE
Reduce packaged sidecar size

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -17,6 +17,9 @@ const nextConfig: NextConfig = {
   // Standalone output produces a self-contained Node server at
   // .next/standalone/ that we can bundle as a Tauri sidecar.
   output: "standalone",
+  // Cave does not use Next's server-side image optimizer in the packaged app;
+  // icon generation happens before build via scripts/generate-pwa-icons.mjs.
+  images: { unoptimized: true },
   serverExternalPackages: ["node-pty"],
   // Next.js file tracing otherwise sucks the entire src-tauri/target/
   // (multi-GB) into the standalone bundle. Exclude noisy siblings.

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -23,4 +23,12 @@ assert.match(src, /PNPM_STAGE.*node_modules/, "final node_modules must come from
 // Security: must not blindly copy symlinks from STANDALONE into bundle
 assert.match(src, /cp -aL/, "all node_modules copies must dereference symlinks");
 
+// App-size: runtime bundles must drop test/dev packages and metadata that are
+// useful only while developing or debugging the build machine.
+assert.match(src, /prune_sidecar_nonruntime_files\(\)/, "sidecar must prune non-runtime files before release bundling");
+assert.match(src, /node_modules\/playwright-core/, "sidecar must remove Playwright test runtime from the packaged app");
+assert.match(src, /node_modules\/@types/, "sidecar must remove TypeScript declaration packages from the packaged app");
+assert.match(src, /-name '\*\.map'/, "sidecar must remove source maps from the packaged app");
+assert.match(src, /node_modules\/sharp/, "sidecar must remove optional Sharp image optimizer from the packaged app");
+
 console.log("sidecar-bundle-deps.test: ok");

--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -137,6 +137,29 @@ prune_foreign_native_packages() {
   fi
 }
 
+prune_sidecar_nonruntime_files() {
+  local dest="$1"
+  if [ ! -d "$dest" ]; then
+    return 0
+  fi
+
+  echo "==> pruning sidecar non-runtime files"
+
+  rm -rf \
+    "$dest/node_modules/@playwright" \
+    "$dest/node_modules/@types" \
+    "$dest/node_modules/playwright" \
+    "$dest/node_modules/playwright-core" \
+    "$dest/node_modules/sharp" \
+    "$dest/node_modules/@img"
+
+  find "$dest" -type f \( \
+    -name '*.map' -o \
+    -name '*.d.ts' -o \
+    -name '*.d.ts.map' \
+  \) -delete
+}
+
 echo "==> next build"
 (cd "$ROOT" && pnpm build) >&2
 
@@ -263,6 +286,8 @@ if [ -d "$PUBLIC" ]; then
   echo "==> copying public/ → $DEST/public"
   cp -a "$PUBLIC/." "$DEST/public/"
 fi
+
+prune_sidecar_nonruntime_files "$DEST"
 
 # Sanity check
 for must in node_modules/@next/env node_modules/@swc/helpers/_; do


### PR DESCRIPTION
## Summary
- prune non-runtime sidecar payload after resource assembly
- disable packaged Next image optimizer because Cave does not use server image optimization
- add sidecar dependency regression assertions for the app-size pruning

## Size
- clean current main baseline: `sidecar bundle ready (651M)`
- patched bundle: `sidecar bundle ready (450M)`
- savings: about `201M` from `src-tauri/resources/server`

## Test plan
- `node scripts/sidecar-bundle-deps.test.mjs`
- `node scripts/sidecar-bundle.test.mjs`
- `bash -n scripts/sidecar-bundle.sh`
- `node --experimental-strip-types scripts/release-macos-signing.test.mjs`
- `node --experimental-strip-types src-tauri/release-runtime.test.mjs`
- `pnpm typecheck`
- `bash scripts/sidecar-bundle.sh`

## Notes
- Turbopack still emits the existing broad file-tracing warning for dynamic file APIs; build succeeds.