### PR TITLE
fix(appearance): cap Pill-level card radius at 20px

### DIFF
--- a/src/components/theme-script.tsx
+++ b/src/components/theme-script.tsx
@@ -87,7 +87,7 @@ const THEME_SCRIPT = `
     // roundedness. Inlined from src/lib/appearance-corner-radius.ts (key +
     // level → [base, control, card] values) — keep in sync. "default" is absent
     // so it falls back to the :root token values.
-    var RADII = { sharp: ["0.125rem","2px","4px"], round: ["0.875rem","12px","16px"], pill: ["999px","999px","999px"] };
+    var RADII = { sharp: ["0.125rem","2px","4px"], round: ["0.875rem","12px","16px"], pill: ["999px","999px","20px"] };
     var radiusLevel = localStorage.getItem("cave:corner-radius");
     if (radiusLevel && RADII[radiusLevel]) {
       try {

--- a/src/lib/appearance-corner-radius.test.ts
+++ b/src/lib/appearance-corner-radius.test.ts
@@ -47,10 +47,11 @@ test("apply(non-default) overrides all three radius tokens and persists", () => 
   assert.equal(readCornerRadius(), "round");
 });
 
-test("apply(pill) drives the tokens fully round", () => {
+test("apply(pill) makes controls fully round but caps card radius at 20px", () => {
   const { props } = setupDom();
   applyCornerRadius("pill");
   assert.equal(props.get("--radius-control"), "999px");
+  assert.equal(props.get("--radius-card"), "20px");
 });
 
 test("apply(default) removes the overrides so :root token values apply", () => {

--- a/src/lib/appearance-corner-radius.ts
+++ b/src/lib/appearance-corner-radius.ts
@@ -45,7 +45,9 @@ type RadiusVars = { base: string; control: string; card: string };
 export const CORNER_RADIUS_VALUES: Record<Exclude<CornerRadius, "default">, RadiusVars> = {
   sharp: { base: "0.125rem", control: "2px", card: "4px" },
   round: { base: "0.875rem", control: "12px", card: "16px" },
-  pill: { base: "999px", control: "999px", card: "999px" },
+  // control is fully round, but cap card at 20px so large panels stay legible
+  // (a 999px card radius reads as an oversized blob, not a stadium).
+  pill: { base: "999px", control: "999px", card: "20px" },
 };
 
 export function normalizeCornerRadius(value: unknown): CornerRadius {


### PR DESCRIPTION
Follow-up to #791. At the **Pill** corner-radius level, controls stay fully round (`999px`) but cards were also `999px`, which reads as an oversized blob on large panels. Cap `--radius-card` at `20px` for Pill (control stays `999px`).

- `appearance-corner-radius.ts` + the flash-free `ThemeScript` block updated in lockstep.
- Unit test now asserts the pill card cap.

Verified: `pnpm typecheck` ✅, lib test (5 cases) ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)