### PR TITLE
fix(chat): honest model-application state from run outcome, not echo alone

### DIFF
--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -895,10 +895,19 @@ assert.match(
   "A harness-echoed model should be recorded as the confirmed model",
 );
 
+// coven echoes the model in system.init BEFORE the harness runs, so the applied
+// state must be contingent on the run outcome — not the echo alone. The route
+// resolves it through modelApplicationFromRun (echo + is_error + error tail) so
+// an errored run reports failed/pending instead of a dishonest applied.
 assert.match(
   chatRoute,
+  /modelApplicationFromRun\(\{[\s\S]*?confirmedModel,[\s\S]*?isError: result\.is_error === true,[\s\S]*?errorText:[\s\S]*?\}\)/,
+  "Model application must be resolved from both the echo and the run outcome",
+);
+assert.doesNotMatch(
+  chatRoute,
   /modelApplicationForHarness\(\{ supported: true, confirmed: true \}\)/,
-  "Confirming an echoed model should promote the application state to applied",
+  "Applied must no longer be promoted unconditionally on an echo (errored runs must not read as applied)",
 );
 
 console.log("model parity routing tests passed");

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -49,6 +49,7 @@ import {
 import {
   cleanModelId,
   modelApplicationForHarness,
+  modelApplicationFromRun,
   resolveChatModelState,
   type ChatModelState,
 } from "@/lib/chat-model-state";
@@ -1461,12 +1462,19 @@ export async function POST(req: Request) {
       // conversation's identity — keying off it created a new conversation
       // file (and sidebar entry) for every resumed turn.
       const harnessSessionId = sessionId;
-      // Model parity: if the harness echoed its resolved model, promote the
-      // application state from `pending` to `applied` and record what actually
-      // ran. No echo ⇒ leave the honest `pending`/`unsupported` state untouched.
-      if (confirmedModel) {
-        const application = modelApplicationForHarness({ supported: true, confirmed: true });
-        responseMetadata.confirmedModel = confirmedModel;
+      // Model parity: coven echoes the requested model in `system.init` BEFORE
+      // the harness runs, so an echo confirms forwarding — not a successful run.
+      // Resolve the honest state from BOTH the echo and the run outcome:
+      // succeeded ⇒ applied, errored on the model ⇒ failed, errored otherwise ⇒
+      // pending. No echo ⇒ leave the pre-run `pending`/`unsupported` untouched.
+      if (confirmedModel) responseMetadata.confirmedModel = confirmedModel;
+      const modelSignal = modelApplicationFromRun({
+        confirmedModel,
+        isError: result.is_error === true,
+        errorText: (stderrTail.length ? stderrTail : stdoutErrTail).join("\n"),
+      });
+      if (modelSignal) {
+        const application = modelApplicationForHarness(modelSignal);
         responseMetadata.modelApplicationState = application.state;
         responseMetadata.modelApplicationReason = application.reason;
         modelState.applicationState = application.state;

--- a/src/lib/chat-model-state.test.ts
+++ b/src/lib/chat-model-state.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import {
   cleanModelId,
   modelApplicationForHarness,
+  modelApplicationFromRun,
+  modelRejectionInError,
   resolveChatModelState,
 } from "./chat-model-state.ts";
 
@@ -64,5 +66,85 @@ assert.deepEqual(modelApplicationForHarness({ supported: false, confirmed: false
   state: "unsupported",
   reason: "Saved in Cave. Runtime model application is not confirmed by this harness path yet.",
 });
+
+// modelRejectionInError: only model-specific failures count, not generic errors.
+assert.equal(
+  modelRejectionInError("error: model claude-bogus-9 not found"),
+  true,
+  "a 'model … not found' tail names the model",
+);
+assert.equal(
+  modelRejectionInError("invalid value 'gpt-nope' for '--model <MODEL>'"),
+  true,
+  "an 'invalid … model' tail names the model (flag-rejection form)",
+);
+assert.equal(
+  modelRejectionInError("unknown model: nous/hermes-99"),
+  true,
+  "an 'unknown model' tail names the model",
+);
+assert.equal(
+  modelRejectionInError("401 Unauthorized: missing API key"),
+  false,
+  "an auth failure must NOT be mistaken for a model rejection",
+);
+assert.equal(
+  modelRejectionInError("network error: connection refused"),
+  false,
+  "a transport failure must NOT be mistaken for a model rejection",
+);
+assert.equal(modelRejectionInError(""), false, "empty tail is not a rejection");
+assert.equal(modelRejectionInError(undefined), false, "non-string tail is not a rejection");
+
+// modelApplicationFromRun: coven echoes the requested model in system.init BEFORE
+// the harness runs, so an echo confirms forwarding — not a successful run.
+assert.equal(
+  modelApplicationFromRun({ confirmedModel: null, isError: false, errorText: "" }),
+  null,
+  "no echo ⇒ leave the pre-run application state untouched (null)",
+);
+assert.deepEqual(
+  modelApplicationFromRun({
+    confirmedModel: "anthropic/claude-opus-4-7",
+    isError: false,
+    errorText: "",
+  }),
+  { supported: true, confirmed: true },
+  "echo + successful run ⇒ applied",
+);
+assert.deepEqual(
+  modelApplicationFromRun({
+    confirmedModel: "anthropic/claude-bogus-9",
+    isError: true,
+    errorText: "error: model claude-bogus-9 not found",
+  }),
+  { failed: true },
+  "echo + run errored ON the model ⇒ failed",
+);
+assert.deepEqual(
+  modelApplicationFromRun({
+    confirmedModel: "anthropic/claude-opus-4-7",
+    isError: true,
+    errorText: "401 Unauthorized: missing API key",
+  }),
+  { supported: true },
+  "echo + run errored for a NON-model reason ⇒ pending (model was forwarded, not confirmed)",
+);
+
+// Round-trip guard: coven echoes the namespaced id verbatim, so the application
+// pipeline confirms an exact match against the id Cave sent. If anyone later
+// normalizes one side (strips provider/), this applied-state path breaks.
+{
+  const requested = "anthropic/claude-opus-4-7";
+  const echoedByInit = cleanModelId(requested); // what route.ts derives confirmedModel from
+  assert.equal(echoedByInit, requested, "namespaced id must survive cleanModelId unchanged");
+  assert.deepEqual(
+    modelApplicationForHarness(
+      modelApplicationFromRun({ confirmedModel: echoedByInit, isError: false, errorText: "" }),
+    ),
+    { state: "applied", reason: "Runtime confirmed the selected model." },
+    "a verbatim namespaced echo round-trips to applied",
+  );
+}
 
 console.log("chat-model-state.test.ts: ok");

--- a/src/lib/chat-model-state.ts
+++ b/src/lib/chat-model-state.ts
@@ -85,6 +85,38 @@ export function modelApplicationForHarness(input?: ModelApplicationInput): Model
   };
 }
 
+// A run's error tail names the selected model. `coven run --model` warns (never
+// errors) for adapters with no model mechanism, so the only way a forwarded
+// model produces a hard error is the underlying CLI rejecting the id. coven
+// emits no structured model-error event, so we match the error tail
+// conservatively: a rejection word adjacent to the word "model", in either
+// order ("model … not found" or "invalid … model"). Auth/network failures that
+// merely contain "invalid"/"missing" without "model" are deliberately excluded.
+const MODEL_REJECTION_RE =
+  /\bmodel\b[^.\n]*\b(?:not found|not supported|unsupported|invalid|unknown|unrecognized|does not exist|no such|unavailable)\b|\b(?:invalid|unknown|unrecognized|unsupported)\b[^.\n]*\bmodel\b/i;
+
+export function modelRejectionInError(errorText: unknown): boolean {
+  return typeof errorText === "string" && MODEL_REJECTION_RE.test(errorText);
+}
+
+// Decide how a finished run reflects on the selected model. coven echoes the
+// requested model id in `system.init` BEFORE spawning the harness, so an echo
+// confirms forwarding — not a successful run. We therefore only report
+// `applied` when the run also succeeded; `failed` when the run errored AND the
+// error names the model; and `pending` when the run errored for some other
+// reason (the model was forwarded but never confirmed). No echo ⇒ null, so the
+// caller leaves the honest pre-run state (`pending`/`unsupported`) untouched.
+export function modelApplicationFromRun(input: {
+  confirmedModel: string | null;
+  isError: boolean;
+  errorText: string;
+}): ModelApplicationInput | null {
+  if (!input.confirmedModel) return null;
+  if (!input.isError) return { supported: true, confirmed: true };
+  if (modelRejectionInError(input.errorText)) return { failed: true };
+  return { supported: true };
+}
+
 export function resolveChatModelState(input: ResolveChatModelStateInput): ChatModelState {
   const nextMessageModel = cleanModelId(input.nextMessageModel);
   if (nextMessageModel) {


### PR DESCRIPTION
## Why

Verifying the model-parity spec (`docs/superpowers/specs/2026-06-15-model-parity-design.md`) surfaced a latent honesty bug in §3.3, now reachable because the companion `coven run --model` passthrough is implemented.

coven emits the `system.init` model echo **before** spawning the harness, so the echo confirms that `--model` was *forwarded* — not that the run *succeeded*. The old logic promoted application state to `applied` on **any** echo, so a run that errored on a bad model still rendered as `applied`.

## What

Resolve the state from both the echo and the run outcome via a new pure, unit-tested helper `modelApplicationFromRun` in `chat-model-state.ts`:

| echo | run outcome | state |
|---|---|---|
| present | succeeded | `applied` |
| present | errored, error names the model | `failed` |
| present | errored, other reason | `pending` (forwarded, not confirmed) |
| absent | — | untouched (honest pre-run state) |

- The `failed` path is gated by `modelRejectionInError` — a **conservative** tail match (a rejection word adjacent to `model`) so auth/network failures (`401`, `connection refused`) are never mislabeled as model failures. coven emits no structured model-error event, so a heuristic on the error tail is the available signal.
- coven echoes the **namespaced id verbatim** (prefix-strip happens only on the harness arg, init field name is `model`). A round-trip test pins the exact-match confirmation so a future "normalize the id" change on either side can't silently break `applied`.

## Tests

- `chat-model-state.test.ts`: `modelRejectionInError` (model vs. auth/network/empty), `modelApplicationFromRun` (all four branches), namespaced round-trip → `applied`.
- `harness-routing.test.ts`: route resolves via `modelApplicationFromRun`; asserts `applied` is **no longer** promoted unconditionally on an echo.
- Full `test:api` + `test:app` green; `tsc --noEmit` clean; `check:tests-wired` passes.

## Scope

Cave-side only. The `coven run --model` passthrough itself lives in `OpenCoven/coven` (already implemented there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)