### PR TITLE
fix(calls): honest trace count instead of silently capping at 30

### DIFF
--- a/src/components/calls-view-graph.test.ts
+++ b/src/components/calls-view-graph.test.ts
@@ -161,3 +161,23 @@ assert.match(
   /"three":/,
   "Cave should declare Three.js as a dependency for the 3D trace graph",
 );
+
+// ── Trace timeline: honest count + no silent truncation ──────────────────────
+// The list caps rendered rows for perf; the header badge and a footer note must
+// stay honest about traces beyond the cap rather than claiming "N visible" while
+// silently dropping the rest.
+assert.match(source, /const MAX_VISIBLE_TRACES = \d+/, "trace list cap is a named constant");
+assert.match(source, /const shown = traces\.slice\(0, MAX_VISIBLE_TRACES\)/, "renders the capped slice via `shown`");
+// The list must render `shown`, never the full set, so the badge/footer counts
+// can't drift from what's actually on screen.
+assert.doesNotMatch(source, /traces\.slice\(0, 30\)/, "no inline magic-number slice (use MAX_VISIBLE_TRACES)");
+assert.match(
+  source,
+  /hiddenCount > 0 \? `\$\{shown\.length\} of \$\{traces\.length\}`/,
+  'header badge shows "<shown> of <total>" when traces are hidden',
+);
+assert.match(
+  source,
+  /hiddenCount > 0 &&[\s\S]{0,200}Showing the newest \{shown\.length\} of \{traces\.length\}/,
+  "a footer note discloses how many older traces are hidden",
+);

--- a/src/components/calls-view.tsx
+++ b/src/components/calls-view.tsx
@@ -532,6 +532,11 @@ function Metric({ label, value, tone }: { label: string; value: number; tone: st
   );
 }
 
+// Cap rendered rows for perf; the scroll container handles overflow within the
+// cap. The header count + footer note stay honest about anything beyond it
+// instead of silently dropping older traces under a wrong "N visible" badge.
+const MAX_VISIBLE_TRACES = 30;
+
 function TraceTimeline({
   traces,
   familiars,
@@ -543,6 +548,8 @@ function TraceTimeline({
   selectedTraceId: string | null;
   onSelect: (trace: DelegationTrace) => void;
 }) {
+  const shown = traces.slice(0, MAX_VISIBLE_TRACES);
+  const hiddenCount = traces.length - shown.length;
   return (
     <div className="min-h-[190px] overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-raised)]/20">
       <div className="flex items-center justify-between gap-3 border-b border-[var(--border-hairline)] px-3 py-2">
@@ -550,7 +557,9 @@ function TraceTimeline({
           <h2 className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">Trace timeline</h2>
           <p className="mt-0.5 truncate text-[10px] text-[var(--text-muted)]">Newest delegation events first</p>
         </div>
-        <span className="shrink-0 rounded-full bg-[var(--bg-raised)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">{traces.length} visible</span>
+        <span className="shrink-0 rounded-full bg-[var(--bg-raised)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">
+          {hiddenCount > 0 ? `${shown.length} of ${traces.length}` : `${traces.length} visible`}
+        </span>
       </div>
       {traces.length === 0 ? (
         <div className="grid min-h-[130px] place-items-center px-4 text-center text-sm text-[var(--text-muted)]">
@@ -558,7 +567,7 @@ function TraceTimeline({
         </div>
       ) : (
         <div className="max-h-[240px] overflow-y-auto">
-          {traces.slice(0, 30).map((trace) => (
+          {shown.map((trace) => (
             <button
               key={trace.id}
               type="button"
@@ -584,6 +593,11 @@ function TraceTimeline({
               </span>
             </button>
           ))}
+          {hiddenCount > 0 && (
+            <p className="border-t border-[var(--border-hairline)] px-3 py-2 text-center text-[10px] text-[var(--text-muted)]">
+              Showing the newest {shown.length} of {traces.length} — narrow the time window or filters to see older traces.
+            </p>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## The bug

The delegation **Trace timeline** (`calls-view.tsx`) rendered `traces.slice(0, 30)` but its header badge read `{traces.length} visible`. So with more than 30 traces the badge was **wrong** (e.g. "50 visible" while only 30 rows existed) and the older 20 were dropped with no indication they existed — the repo's documented "no silent caps / honest counts" anti-pattern.

## The fix

- Cap via a named `MAX_VISIBLE_TRACES` and render the `shown` slice.
- Header badge is honest: `"30 of N"` when truncated, `"N visible"` otherwise.
- A footer note discloses the rest: *"Showing the newest 30 of N — narrow the time window or filters to see older traces."*

Purely presentational; the cap (for render perf) stays, but the UI no longer lies about it.

## Verification (real running app)

Drove the live Calls/Delegations surface with 35 mocked traces:
- ✅ badge reads **"30 of 35"** (screenshot)
- ✅ footer note renders ("Showing the newest 30 of 35…")
- ✅ exactly **30 rows** displayed
- ✅ no stray "35 visible", no console errors

Typecheck clean; regression assertions added to `calls-view-graph.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)