### PR TITLE
fix(about): align Links row + add X, Discord, Grimoire & Podcast

### DIFF
--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -1043,10 +1043,14 @@ function AboutSection() {
         <OpenCovenToolsUpdate />
       </SettingsGroup>
       <SettingsGroup label="Links">
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-2 px-4 py-3">
           {[
-            { label: "GitHub", href: "https://github.com/OpenCoven/coven-cave" },
-            { label: "Docs",   href: "https://docs.openclaw.ai" },
+            { label: "GitHub",   href: "https://github.com/OpenCoven/coven-cave", icon: "ph:github-logo" as const },
+            { label: "Docs",     href: "https://docs.openclaw.ai",                icon: "ph:file-text" as const },
+            { label: "X",        href: "https://x.com/OpenCvn",                   icon: "ph:x-logo-bold" as const },
+            { label: "Discord",  href: "https://discord.gg/opencoven",            icon: "ph:discord-logo" as const },
+            { label: "Grimoire", href: "https://mind.opencoven.ai",               icon: "ph:book-open" as const },
+            { label: "Podcast",  href: "https://pod.opencoven.ai",                icon: "ph:waveform-bold" as const },
           ].map((l) => (
             <a
               key={l.href}
@@ -1055,7 +1059,7 @@ function AboutSection() {
               rel="noopener noreferrer"
               className="flex items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-3 py-1.5 text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
             >
-              <Icon name="ph:arrow-square-out" width={12} />
+              <Icon name={l.icon} width={12} />
               {l.label}
             </a>
           ))}


### PR DESCRIPTION
## What

Settings → About → **Links** row.

- **Alignment fix:** the link-button wrapper had no padding, so the buttons sat flush against the card's left edge while every other settings row insets its content by `px-4 py-3`. Added matching inset so the row lines up with the cards above it.
- **New socials** alongside GitHub/Docs, each with a branded icon:
  - X — https://x.com/OpenCvn
  - Discord — https://discord.gg/opencoven
  - Grimoire (blog) — https://mind.opencoven.ai
  - Podcast — https://pod.opencoven.ai

All icons are existing entries in the `ICON_NAMES` whitelist. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)