### PR TITLE
feat(workflows): add research-brief and synthesize-sources templates

### DIFF
--- a/workflows/curate-reading-list.cave.json
+++ b/workflows/curate-reading-list.cave.json
@@ -6,8 +6,8 @@
       "y": 80
     },
     "classify-items": {
-      "x": 320,
-      "y": 80
+      "x": 333,
+      "y": 47
     },
     "prioritize-queue": {
       "x": 560,

--- a/workflows/research-brief.cave.json
+++ b/workflows/research-brief.cave.json
@@ -1,23 +1,27 @@
 {
   "version": 1,
   "positions": {
-    "intake": {
+    "scope-question": {
       "x": 80,
       "y": 80
     },
-    "read-pass": {
+    "gather-primary": {
       "x": 80,
       "y": 220
     },
-    "annotate-claims": {
+    "gather-local": {
+      "x": 320,
+      "y": 220
+    },
+    "map-claims": {
       "x": 80,
       "y": 360
     },
-    "verify-citations": {
+    "synthesize": {
       "x": 80,
       "y": 500
     },
-    "save-notes": {
+    "deliver": {
       "x": 80,
       "y": 640
     }

--- a/workflows/synthesize-sources.cave.json
+++ b/workflows/synthesize-sources.cave.json
@@ -1,23 +1,23 @@
 {
   "version": 1,
   "positions": {
-    "intake": {
+    "select-cluster": {
       "x": 80,
       "y": 80
     },
-    "read-pass": {
+    "extract-source-notes": {
       "x": 80,
       "y": 220
     },
-    "annotate-claims": {
+    "compare-claims": {
       "x": 80,
       "y": 360
     },
-    "verify-citations": {
+    "write-synthesis": {
       "x": 80,
       "y": 500
     },
-    "save-notes": {
+    "save-synthesis": {
       "x": 80,
       "y": 640
     }


### PR DESCRIPTION
Salvaged from accumulated local WIP (preserved on `salvage/wip-snapshot`).

Adds two new workflow templates and tweaks two existing ones:
- `workflows/research-brief.cave.json` (new)
- `workflows/synthesize-sources.cave.json` (new)
- `workflows/annotate-document.cave.json`, `workflows/curate-reading-list.cave.json` (minor updates)

Data-only change. `workflow-source`, `workflows`, and `workflow-graph` tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)