### PR TITLE
fix(theme): uniform bg across all themes (incl. custom) + clearer task-section headers

### DIFF
--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -181,12 +181,12 @@ function SortableChatListItem({
 // the phone list reads with the same grouping language (PINNED / SESSIONS).
 function ChatListSection({ label, count }: { label: string; count?: number }) {
   return (
-    <li className="flex items-center gap-1.5 border-b border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 px-4 py-1.5">
-      <span className="truncate text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
+    <li className="flex items-center gap-1.5 border-b border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)] px-4 py-2">
+      <span className="truncate text-[12px] font-bold uppercase tracking-[0.12em] text-[var(--text-primary)]">
         {label}
       </span>
       {typeof count === "number" ? (
-        <span className="font-mono text-[11px] text-[var(--text-muted)] opacity-70">{count}</span>
+        <span className="font-mono text-[12px] text-[var(--text-secondary)] opacity-80">{count}</span>
       ) : null}
     </li>
   );
@@ -790,12 +790,12 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               <li key={projectRoot ?? "__none__"}>
                 {/* Project group header */}
                 {projectRoot !== null && effectiveSelection === "all" && (
-                  <div className="group relative flex items-center gap-1.5 px-4 py-1.5 bg-[var(--bg-raised)]/30 border-b border-[var(--border-hairline)]">
-                    <Icon name="ph:folder" width={12} className="shrink-0 text-[var(--text-muted)]" />
-                    <span className="truncate text-[11px] font-medium text-[var(--text-muted)] uppercase tracking-wide">
+                  <div className="group relative flex items-center gap-1.5 px-4 py-2 bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)] border-b border-[var(--border-hairline)]">
+                    <Icon name="ph:folder" width={12} className="shrink-0 text-[var(--text-secondary)]" />
+                    <span className="truncate text-[12px] font-bold text-[var(--text-primary)] uppercase tracking-wide">
                       {repoName(projectRoot)}
                     </span>
-                    <span className="font-mono text-[11px] text-[var(--text-muted)] opacity-70">{rows.length}</span>
+                    <span className="font-mono text-[12px] text-[var(--text-secondary)] opacity-80">{rows.length}</span>
                     <button
                       className="chat-list-group-new touch-always-visible absolute right-2 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center w-5 h-5 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
                       onClick={(e) => {
@@ -1017,9 +1017,9 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                  visible there are deduped out of this section. ── */}
           {showContentSection && (
             <section aria-label="Matches in conversation content">
-              <div className="flex items-center gap-1.5 border-y border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 px-4 py-1.5">
-                <Icon name="ph:chats" width={12} className="shrink-0 text-[var(--text-muted)]" />
-                <span className="truncate text-[11px] font-medium uppercase tracking-wide text-[var(--text-muted)]">
+              <div className="flex items-center gap-1.5 border-y border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)] px-4 py-2">
+                <Icon name="ph:chats" width={12} className="shrink-0 text-[var(--text-secondary)]" />
+                <span className="truncate text-[12px] font-bold uppercase tracking-wide text-[var(--text-primary)]">
                   In conversations
                 </span>
               </div>

--- a/src/components/chat-project-sidebar.tsx
+++ b/src/components/chat-project-sidebar.tsx
@@ -123,13 +123,13 @@ function AccentBar({ tall }: { tall?: boolean }) {
 // Reused for PINNED / SESSIONS / PROJECTS so every group reads the same way.
 function RailSection({ label, count, action }: { label: string; count?: number; action?: ReactNode }) {
   return (
-    <div className="flex items-center justify-between px-3 pb-1 pt-2">
+    <div className="flex items-center justify-between border-b border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)] px-3 py-1.5">
       <span className="flex min-w-0 items-center gap-1.5">
-        <span className="truncate text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
+        <span className="truncate text-[11px] font-bold uppercase tracking-[0.12em] text-[var(--text-primary)]">
           {label}
         </span>
         {typeof count === "number" ? (
-          <span className="font-mono text-[10px] text-[var(--text-muted)] opacity-70">{count}</span>
+          <span className="font-mono text-[11px] text-[var(--text-secondary)] opacity-80">{count}</span>
         ) : null}
       </span>
       {action}

--- a/src/components/theme-color-editor.tsx
+++ b/src/components/theme-color-editor.tsx
@@ -67,41 +67,64 @@ function resolveToHex(color: string): string {
 }
 
 /**
- * Write three colors to CSS vars on <html>. We map them to the Cave
- * custom-theme var set: --bg-base (background), --accent-presence (accent),
- * and --border-hairline (border). We also write --bg-card / --bg-raised as
- * lightened/darkened bg variants so the rest of the UI stays coherent.
+ * Build the full, coherent custom-theme variable group from the three picked
+ * colors. This is the single source of truth replayed by both the live editor
+ * (applyColorsToDOM) and the persisted theme (theme-script boot + settings-shell).
+ *
+ * Uniformity matters here: the preset themes define BOTH the Issue #14 surface
+ * ramp (--bg-base / --bg-raised / --bg-elevated / …) AND the legacy base tokens
+ * it aliases from (--background, --card, --muted, --border — see globals.css
+ * `--bg-base: var(--background)` etc.). Surfaces are split across the two
+ * vocabularies (calendar/board/roles use --bg-base; capabilities, inbox
+ * escalations, card modals, board-inspector chips still use bg-background /
+ * bg-card / bg-muted / border-border). A custom theme must therefore set BOTH
+ * groups — otherwise the legacy-vocab surfaces keep the previously-active
+ * theme's background and the app looks non-uniform under a custom theme.
+ */
+function deriveThemeVars(colors: ThreeColors): Record<string, string> {
+  const { bg, accent, border } = colors;
+  // Surface ramp lightened from the chosen background; color-mix is broadly
+  // supported in our target Chromium/WebKit.
+  const raised = `color-mix(in oklch, ${bg} 90%, white 10%)`;
+  const card = `color-mix(in oklch, ${bg} 93%, white 7%)`;
+  const elevated = `color-mix(in oklch, ${bg} 85%, white 15%)`;
+  return {
+    "--accent-presence": accent,
+    "--accent-faint": `${accent}22`,
+    // Issue #14 surface ramp.
+    "--bg-base": bg,
+    "--bg-panel": `color-mix(in oklch, ${bg} 92%, black 8%)`,
+    "--bg-raised": raised,
+    "--bg-card": card,
+    "--bg-elevated": elevated,
+    "--bg-hover": `color-mix(in oklch, ${bg} 80%, white 20%)`,
+    "--border-hairline": border,
+    "--border-strong": `color-mix(in oklch, ${border} 60%, ${accent} 40%)`,
+    // Legacy base tokens the ramp aliases from in preset themes. Mirror the
+    // preset aliasing so legacy-vocab surfaces track the custom background:
+    //   --bg-base: var(--background); --bg-raised: var(--card);
+    //   --bg-elevated≈--muted; --border-hairline: var(--border).
+    "--background": bg,
+    "--card": raised,
+    "--muted": elevated,
+    "--border": border,
+  };
+}
+
+/**
+ * Write the custom-theme colors to CSS vars on <html> for live preview.
  */
 function applyColorsToDOM(colors: ThreeColors, _mode: Mode) {
   const html = document.documentElement;
   html.setAttribute("data-theme", "custom");
-
-  const set = (prop: string, val: string) =>
+  const vars = deriveThemeVars(colors);
+  for (const [prop, val] of Object.entries(vars)) {
     html.style.setProperty(prop, val);
-
-  set("--accent-presence", colors.accent);
-  set("--accent-faint", `${colors.accent}22`);
-  set("--bg-base", colors.bg);
-  // bg-raised / bg-card are slightly lighter than bg-base; for now we use
-  // color-mix which is broadly supported in our target Chromium/WebKit.
-  set("--bg-raised", `color-mix(in oklch, ${colors.bg} 90%, white 10%)`);
-  set("--bg-card", `color-mix(in oklch, ${colors.bg} 93%, white 7%)`);
-  set("--bg-elevated", `color-mix(in oklch, ${colors.bg} 85%, white 15%)`);
-  set("--border-hairline", colors.border);
-  set("--border-strong", `color-mix(in oklch, ${colors.border} 60%, ${colors.accent} 40%)`);
+  }
 }
 
 function persistCustomTheme(presetBase: ThemeId, colors: ThreeColors, mode: Mode) {
-  const modeGroup = {
-    "--bg-base": colors.bg,
-    "--bg-raised": `color-mix(in oklch, ${colors.bg} 90%, white 10%)`,
-    "--bg-card": `color-mix(in oklch, ${colors.bg} 93%, white 7%)`,
-    "--bg-elevated": `color-mix(in oklch, ${colors.bg} 85%, white 15%)`,
-    "--accent-presence": colors.accent,
-    "--accent-faint": `${colors.accent}22`,
-    "--border-hairline": colors.border,
-    "--border-strong": `color-mix(in oklch, ${colors.border} 60%, ${colors.accent} 40%)`,
-  };
+  const modeGroup = deriveThemeVars(colors);
   const data = {
     name: `${THEME_META[presetBase].name} (custom)`,
     cssVars: {


### PR DESCRIPTION
## Background uniformity across all modes & themes (incl. custom)

Preset themes define **both** token vocabularies — the Issue #14 surface ramp (`--bg-base`, `--bg-raised`, `--bg-elevated`, …) **and** the legacy base tokens it aliases from (`--background`, `--card`, `--muted`, `--border`) — so every surface is uniform in every preset, in both light and dark.

**Custom themes were the gap.** The 3-color custom editor only injected the `--bg-*` ramp. Surfaces still on the legacy vocab (`bg-background` / `bg-card` / `bg-muted` / `border-border` — capabilities view, inbox escalations, card modals, board-inspector chips) read `--background`/`--card`/`--muted`/`--border`, which a custom theme never set. Result: under a custom theme those surfaces kept the **previously-active** theme's background → a visibly non-uniform app.

Fix: centralize derivation in `deriveThemeVars()` (one source of truth, used by both live-apply and persistence) and emit **both** vocabularies plus the previously-missing `--bg-panel`/`--bg-hover`, mirroring the preset aliasing. Calendar, Workflows and Roles already used `--bg-base` and were uniform — they stay so; the named surfaces now match under custom themes too.

> Note: already-saved custom themes pick up the legacy aliases on their next save; newly created/edited custom themes are fully uniform immediately.

## Clearer task-section headers

The chat-rail section headers (`RailSection` desktop → Pinned/Sessions/Projects; `ChatListSection`, the project-group header, and "In conversations" on mobile) now read clearly as headers:
- **Mode-aware fill** via `color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%)` — darker than the page in light mode, lighter in dark mode (the elevation inverts per mode automatically from one expression).
- **Contrasting text** (`--text-primary`).
- **Heavier weight** (`font-bold`) and **one step larger** font size.

## Verification
- `pnpm test:app` — exit 0, 0 failures.
- Existing source-text guards (`chat-rail-modern-redesign`, `chat-list-mobile-rail-port`, `chat-list-delete`, `theme-color-editor`, `settings-appearance`, `theme-script`) all pass; the `uppercase tracking-[0.12em]` contract is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)