### PR TITLE
fix(rail): style project-folder headers as clear task-section headers

### DIFF
--- a/src/components/chat-project-sidebar.tsx
+++ b/src/components/chat-project-sidebar.tsx
@@ -556,8 +556,15 @@ export function ChatProjectSidebar({
                   <FolderDroppable key={key} id={`folder:${key}`}>
                     <div
                       className={[
-                        "group relative flex w-full items-center transition-colors",
-                        isSelected ? "bg-[var(--bg-raised)]" : "hover:bg-[var(--bg-raised)]/50",
+                        // Project folders are task-section headers: a mode-aware
+                        // fill (darker than the page in light mode, lighter in
+                        // dark — the ramp inverts per mode) + a hairline divider
+                        // so each group reads clearly as a header, matching the
+                        // RailSection treatment. Selected keeps an accent tint.
+                        "group relative flex w-full items-center border-b border-[var(--border-hairline)] transition-colors",
+                        isSelected
+                          ? "bg-[color-mix(in_oklch,var(--bg-base)_80%,var(--accent-presence)_20%)]"
+                          : "bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)] hover:bg-[color-mix(in_oklch,var(--bg-base)_80%,var(--foreground)_20%)]",
                       ].join(" ")}
                     >
                     {isSelected ? <AccentBar tall /> : null}
@@ -586,13 +593,13 @@ export function ChatProjectSidebar({
                       />
                       <span
                         className={[
-                          "min-w-0 flex-1 truncate",
-                          isSelected ? "font-semibold text-[var(--accent-presence)]" : "",
+                          "min-w-0 flex-1 truncate font-bold",
+                          isSelected ? "text-[var(--accent-presence)]" : "text-[var(--text-primary)]",
                         ].join(" ")}
                       >
                         {label}
                       </span>
-                      <span className="shrink-0 font-mono text-[10px] text-[var(--text-muted)]">
+                      <span className="shrink-0 font-mono text-[11px] text-[var(--text-secondary)] opacity-80">
                         {group.sessions.length}
                       </span>
                     </button>

--- a/src/components/chat-thread-rail.test.ts
+++ b/src/components/chat-thread-rail.test.ts
@@ -65,8 +65,13 @@ assert.match(
 );
 assert.match(
   source,
-  /isSelected \? "font-semibold text-\[var\(--accent-presence\)\]" : ""/,
+  /isSelected \? "text-\[var\(--accent-presence\)\]" : "text-\[var\(--text-primary\)\]"/,
   "The selected project name should use the primary accent color so it stands out in the rail",
+);
+assert.match(
+  source,
+  /min-w-0 flex-1 truncate font-bold/,
+  "Project folder headers read as headers: the label is bold",
 );
 
 // ── Pin toggle is Cave-local (shared localStorage key with the chat list) ────
@@ -157,7 +162,7 @@ assert.match(
 );
 assert.match(
   source,
-  /className=\{\[\s*"group relative flex w-full items-center transition-colors"/,
+  /className=\{\[\s*\/\/[\s\S]*?"group relative flex w-full items-center border-b border-\[var\(--border-hairline\)\] transition-colors"/,
   "Project folder rows should span the rail's full width instead of reserving side gutters",
 );
 assert.match(


### PR DESCRIPTION
Follow-up to #803.

Live verification of #803 (screenshots, both modes) showed the `RailSection` master label ("PROJECTS") got the new mode-aware header fill — but in the **default project-grouped rail layout**, the headers a user actually reads as section dividers are the **per-project folder rows** (`FolderDroppable`), which #803 didn't touch. So the master label popped while the actual group dividers stayed flat → the rail read inconsistently.

This extends the same treatment to the folder headers:
- **Mode-aware fill** via `color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%)` — darker than the page in light mode, lighter in dark (ramp inverts per mode).
- **Hairline bottom divider**, **bold** label in contrasting `--text-primary`, one-step-larger count.
- **Selected** keeps an accent tint + accent-colored label so selection stays distinct.

### Verification
Driven live via Playwright (demo mode, mocked sessions across two projects, chat surface). Both modes captured — folder headers now read clearly as headers and stand out from the page in light *and* dark.

`pnpm test:app` exit 0. Updated the two `chat-thread-rail.test.ts` source-text assertions that pinned the old folder-header classes (intent preserved: selected → accent; added a bold-label assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)