### PR TITLE
fix(sidebar): honor shared control radius

### DIFF
--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -224,6 +224,16 @@ assert.match(
 );
 assert.match(
   styles,
+  /\.sidebar-action-stack \.sidebar-action-row\s*\{[^}]*border-radius:\s*var\(--radius-control\);/,
+  "Sidebar action rows should follow the shared control radius setting",
+);
+assert.match(
+  styles,
+  /\.sidebar-folder-row,\n\.sidebar-actions--footer \.sidebar-action-row\s*\{[^}]*border-radius:\s*var\(--radius-control\);/,
+  "Sidebar folder/footer rows should follow the shared control radius setting",
+);
+assert.match(
+  styles,
   /@media \(max-width: 1023px\) \{[\s\S]*\.sidebar-header,[\s\S]*\.sidebar-action-row,[\s\S]*\.sidebar-folder-row,[\s\S]*\.sidebar-foot-btn,[\s\S]*\.sidebar-familiar-filter__select[\s\S]*min-height:\s*var\(--touch-target\)/,
   "Mobile sidebar drawer rows and familiar select should meet the shared touch target",
 );

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -721,7 +721,7 @@
 .sidebar-action-stack .sidebar-action-row {
   min-height: 38px;
   border: 1px solid var(--border-hairline);
-  border-radius: 10px;
+  border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--bg-raised) 78%, transparent);
   padding: 0 11px;
   font-size: 13px;
@@ -745,7 +745,7 @@
 .sidebar-actions--footer .sidebar-action-row {
   gap: 7px;
   min-height: 34px;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   padding: 0 8px;
   color: var(--text-secondary);
 }


### PR DESCRIPTION
## Summary
- Routes sidebar action, folder, and footer rows through the shared `--radius-control` token instead of hardcoded pixel radii.
- Adds a regression assertion in `sidebar-minimal.test.ts` so these rows keep following the Appearance corner-radius setting.

## Validation
- `node --experimental-strip-types src/components/sidebar-minimal.test.ts`
- `git diff --check`
- `pnpm typecheck`

## Red check
- Temporarily restored the old hardcoded row radii and confirmed the new sidebar assertion failed before restoring the implementation.