### PR TITLE
style(chat): polish new-chat empty/start screen layout

### DIFF
--- a/src/components/chat-surface-polish.test.ts
+++ b/src/components/chat-surface-polish.test.ts
@@ -63,7 +63,7 @@ test("cave-chat.css modernizes the new-chat launch surface responsively", () => 
   const src = read("../styles/cave-chat.css");
   assert.match(
     src,
-    /\.cave-chat-empty-shell\s*\{[\s\S]*?width:\s*min\(760px,\s*100%\);[\s\S]*?display:\s*grid;/,
+    /\.cave-chat-empty-shell\s*\{[\s\S]*?width:\s*min\(680px,\s*100%\);[\s\S]*?display:\s*grid;/,
     "launch shell is constrained and grid-based",
   );
   assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -543,20 +543,22 @@ function ChatEmptyState({
 
         {onProjectChange && project && (
           <label className="cave-chat-empty-project">
-            <Icon name="ph:folder-open" width={14} aria-hidden />
-            <span className="cave-chat-empty-project-label">Project</span>
-            <select
-              value={project.id}
-              onChange={(e) => onProjectChange(e.target.value)}
-              aria-label="Project for this chat"
-              className="cave-chat-empty-project-select"
-            >
-              {projects.map((project) => (
-                <option key={project.id} value={project.id}>
-                  {project.name}
-                </option>
-              ))}
-            </select>
+            <span className="cave-chat-empty-project-head">
+              <Icon name="ph:folder-open" width={14} aria-hidden />
+              <span className="cave-chat-empty-project-label">Project</span>
+              <select
+                value={project.id}
+                onChange={(e) => onProjectChange(e.target.value)}
+                aria-label="Project for this chat"
+                className="cave-chat-empty-project-select"
+              >
+                {projects.map((project) => (
+                  <option key={project.id} value={project.id}>
+                    {project.name}
+                  </option>
+                ))}
+              </select>
+            </span>
             <span className="cave-chat-empty-project-root">
               {project.root}
             </span>

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -697,9 +697,9 @@
 }
 
 .cave-chat-empty-shell {
-  width: min(760px, 100%);
+  width: min(680px, 100%);
   display: grid;
-  gap: 18px;
+  gap: 16px;
 }
 
 .cave-chat-empty-familiar {
@@ -740,6 +740,7 @@
 .cave-chat-empty-meta {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 6px;
   margin: 5px 0 0;
   color: var(--text-muted);
@@ -755,20 +756,32 @@
   white-space: nowrap;
 }
 
+.cave-chat-empty-meta span + span::before {
+  content: "·";
+  margin-right: 6px;
+  color: color-mix(in oklch, var(--text-muted) 70%, transparent);
+}
+
 .cave-chat-empty-project {
-  display: grid;
-  grid-template-columns: auto auto minmax(96px, 0.45fr) minmax(0, 1fr);
-  align-items: center;
-  gap: 8px;
-  min-height: 34px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
   border: 1px solid var(--border-panel);
   border-radius: 7px;
   background: color-mix(in oklch, var(--bg-elevated) 78%, transparent);
-  padding: 0 10px;
+  padding: 8px 11px;
   color: var(--text-muted);
   box-shadow:
     0 4px 16px oklch(0 0 0 / 14%),
     inset 0 1px 0 oklch(1 0 0 / 5%);
+}
+
+.cave-chat-empty-project-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
 }
 
 .cave-chat-empty-project-label {
@@ -782,13 +795,15 @@
 
 .cave-chat-empty-project-select {
   min-width: 0;
-  width: 100%;
+  max-width: 100%;
+  width: auto;
   border: 0;
   background: transparent;
   color: var(--text-primary);
   font: inherit;
   font-size: 14px;
   font-weight: 520;
+  cursor: pointer;
   outline: none;
 }
 
@@ -799,6 +814,8 @@
 
 .cave-chat-empty-project-root {
   min-width: 0;
+  max-width: 100%;
+  padding-left: 22px;
   overflow: hidden;
   color: var(--text-muted);
   font-family: "SF Mono", "JetBrains Mono", "Roboto Mono", monospace;
@@ -896,20 +913,11 @@
   }
 
   .cave-chat-empty-project {
-    grid-template-columns: auto minmax(0, 1fr);
-    align-items: start;
-    gap: 5px 10px;
-    min-height: 0;
     padding: 9px 12px;
   }
 
   .cave-chat-empty-project-label {
     display: none;
-  }
-
-  .cave-chat-empty-project-select,
-  .cave-chat-empty-project-root {
-    grid-column: 2;
   }
 
   .cave-chat-empty-project-select {


### PR DESCRIPTION
## Summary

Tightens the `ChatEmptyState` launch screen (the new-chat empty state).

- **Project chip → two lines.** The selector + chevron sit on the top row; the repo path is muted/indented below. This removes the dead horizontal gap that previously pushed the path to the far edge, so the project name and path read as one unit. The path truncates with an ellipsis when space is tight (`min-width: 0` guard lets the chip shrink).
- **Meta separator.** The identity line now reads `claude · project files ready` via a CSS `span + span::before` divider (stays correct when "project files ready" is absent).
- **Tighter composition.** Shell width `760px → 680px` and section gap `18px → 16px` so the rows feel less stretched.

The pinned launch-shell width assertion in `chat-surface-polish.test.ts` is updated to match (`760px → 680px`); its "constrained + grid-based" intent is preserved.

## Verification

- `chat-view-polish`, `chat-surface-polish`, `chat-view`, `chat-view-first-class` tests pass
- `tsc --noEmit` clean
- Rendered against the real `cave-chat.css` in a headless browser at desktop and narrow (300px) widths — two-line row + separator render correctly, and the path ellipsizes without overflow on narrow screens

## Files

- `src/components/chat-view.tsx` — wrap project icon/label/select in a `cave-chat-empty-project-head` row
- `src/styles/cave-chat.css` — flex two-line project chip, meta separator, width/gap trim
- `src/components/chat-surface-polish.test.ts` — update pinned shell width

🤖 Generated with [Claude Code](https://claude.com/claude-code)