### PR TITLE
fix(github): align group-row headers to the shared header treatment

### DIFF
--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -558,9 +558,9 @@
 
 /* Group header rows in the GitHub table */
 .gh-table tbody tr.gh-group-row,
-.gh-table tbody tr.gh-group-row:hover { background:color-mix(in oklab,var(--bg-raised) 60%,var(--bg-base)); }
+.gh-table tbody tr.gh-group-row:hover { background:color-mix(in oklch,var(--bg-base) 82%,var(--foreground) 18%); }
 .gh-group-row td { padding:5px 12px; border-top:1px solid var(--border-hairline); }
-.gh-group-label { display:inline-flex; align-items:center; gap:7px; font-family:var(--font-mono,ui-monospace,SFMono-Regular,Menlo,monospace); font-size:11px; font-weight:600; color:var(--text-secondary); }
+.gh-group-label { display:inline-flex; align-items:center; gap:7px; font-family:var(--font-mono,ui-monospace,SFMono-Regular,Menlo,monospace); font-size:12px; font-weight:700; color:var(--text-primary); }
 .gh-group-count { display:inline-flex; align-items:center; min-width:16px; height:15px; padding:0 5px; border-radius:9999px; background:var(--bg-base); color:var(--text-muted); font-size:9.5px; font-weight:600; }
 
 .gh-actions { display:inline-flex; align-items:center; gap:4px; justify-content:flex-end; }


### PR DESCRIPTION
Final surface in the header-consistency pass (#803 / #805 / #806).

The GitHub view's group rows (`.gh-group-row`, when grouped by org/repo) used a one-off fill (`color-mix` of `--bg-raised`/`--bg-base`) and a muted 11px/600 `--text-secondary` label — so they didn't match the header language now used by the chat rail and board.

Now aligned: the same mode-aware fill `color-mix(in oklch, var(--bg-base) 82%, var(--foreground) 18%)` (darker than the page in light mode, lighter in dark) and a bold `--text-primary` label one step larger. Keeps the GitHub table's monospace label font.

### Verification
Driven live via Playwright (github addon enabled, mocked `/api/github/{pat,activity}` with items across two orgs, grouped by org). Captured both modes — the `acme` / `globex` group rows now read as clear darker bands in light mode and lighter bands in dark, matching the rest of the app.

`pnpm test:app` exit 0. No source-text tests pinned these values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)