### PR TITLE
fix(calendar): style agenda date headers as clear headers

### DIFF
--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -265,18 +265,17 @@ function AgendaView({
       ) : null}
       {groups.map(({ date, items: groupItems }) => (
         <div key={date.toISOString()}>
-          <div className="mb-2 flex items-center gap-3">
+          <div className="mb-2 flex items-center gap-2 rounded-md border-b border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)] px-3 py-1.5">
             <span
-              className={`text-[11px] font-semibold uppercase tracking-wider ${
+              className={`text-[12px] font-bold uppercase tracking-wider ${
                 isSameDay(date, new Date())
                   ? "text-[var(--accent-presence)]"
-                  : "text-[var(--text-muted)]"
+                  : "text-[var(--text-primary)]"
               }`}
             >
               {isSameDay(date, new Date()) ? "Today" : fmtDateHeading(date)}
             </span>
-            <div className="flex-1 h-px bg-[var(--border-hairline)]" />
-            <span className="text-[10px] text-[var(--text-muted)]">
+            <span className="ml-auto font-mono text-[11px] text-[var(--text-secondary)] opacity-80">
               {groupItems.length} item{groupItems.length !== 1 ? "s" : ""}
             </span>
           </div>


### PR DESCRIPTION
Final surface in the header-consistency pass (#803 / #805 / #806 / #813).

The calendar agenda view's date-group headers (TODAY / WEDNESDAY, JUNE 17 / …) were a minimal "label + hairline rule + count" with no fill — unlike the section/group headers now used across the chat rail, board, and GitHub view.

Converted to the same mode-aware header band:
- `color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%)` — darker than the page in light mode, lighter in dark.
- Bold `--text-primary` label one step larger; count right-aligned in mono. **Today** keeps its accent color.

The day/week/month grid axis headers (weekday/date labels) are a different idiom — column labels, not section dividers — so they're intentionally left unchanged.

### Verification
Driven live via Playwright (inbox items seeded through the `/api/inbox/stream` SSE snapshot, agenda view). Captured both modes — the date headers (TODAY / WED JUN 17 / THU JUN 18) read as clear darker bands in light mode and lighter bands in dark.

`pnpm test:app` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)