### PR TITLE
chore(release): v0.0.94

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.94] - 2026-06-16
+
+Patch release: a chat composer and projects/sessions overhaul, configurable panel shortcuts, inline Familiar Studio in Settings, new research workflow templates, a markdown-rendering refactor, and a broad sweep of header/theme polish and accessibility fixes after 0.0.93.
+
+### Added
+- **Chat** — composer **thinking-effort** and **response-speed** controls (persisted), **quote replies**, and chat-project inference that groups the session rail by project (#798-equivalent composer/projects work in #801, #808).
+- **Chat** — render assistant prose in Inter, and render ` ```mermaid ` diagrams via `@create-markdown/preview-mermaid` (#778, #786).
+- **Sessions** — session git/PR context (branch / worktree / linked PR) surfaced in the rail (#801).
+- **Shortcuts** — configurable panel-toggle keyboard shortcuts (#798).
+- **Settings** — full Familiar Studio inline in Settings → Familiars (#802); per-runtime model picker with gated `--model` passthrough (model parity) (#791-era, #0399a089).
+- **Board** — task-chat project selector / project-assignment picker in the card inspector and new-card flow (#801, #40ad738e).
+- **Workflows** — new `research-brief` and `synthesize-sources` templates (#799).
+- **Tasks** — nudge completed chats toward archive (#810).
+- **Library** — a `/` quick-open palette across library content (#790).
+- **Appearance** — a 4-level UI corner-radius control (#791).
+- **Rail** — restored the "Open full memory →" button and folded the magnifier Inspector into the brain Memory tab (#785, #788).
+
+### Changed
+- **Markdown** — message-bubble now renders via `renderAsync` custom renderers instead of positional regex substitution (#800).
+- **Performance** — ship only the Phosphor icons the app actually uses (~3.5 MB lighter) and reduce packaged sidecar size (#793).
+- **UI polish** — uniform background across all themes (incl. custom), standardized "clear header" treatment across board / calendar / GitHub / rail section headers, sidebar spacing/rhythm, and new-chat start screen layout (#791, #803, #805–#807, #812, #813, #816).
+- **Schedules** — split into Reminders and Automations.
+
+### Fixed
+- **Rail** — suppress the bare default-branch (`main`/`master`) suffix in session titles when it carries no signal (#809).
+- **Honesty** — calls show the real trace count instead of capping at 30; chat reports model-application state from the run outcome, not echo alone (#795, #796).
+- **Clipboard** — copy buttons work off-localhost (Tauri webview / Tailscale) (#772).
+- **Accessibility** — focus-trap/Escape in workflow dialogs, accessible Connect-GitHub modal, board inspector row actions reachable by hover and keyboard (#58d80641, #6ab94b8b, #f97bba0a).
+- **Misc** — keep the desktop left panel open on selection, surface bookmark-save failures, preserve familiar model-id casing, cap Pill-level card radius at 20px, and release-pipeline fixes (FUSE-less AppImage, foreign-sidecar pruning) (#776, #777, #784, #794, and others).
+
 ## [0.0.93] - 2026-06-15
 
 Patch release: ships the familiar sessions polish, board project grouping, Delegations trace recovery, and chat runtime-scope hardening work after 0.0.92.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A familiar is not just a chat window. It has a name, role, runtime, memory, tool
 
 ## Status
 
-- Current app version: `0.0.93`
+- Current app version: `0.0.94`
 - Native shell: Tauri 2
 - Frontend: Next.js 16, React 19, Tailwind v4
 - Runtime dependency: a healthy local `coven` CLI/daemon plus at least one runtime source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.93",
+  "version": "0.0.94",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.93"
+version = "0.0.94"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.93"
+version = "0.0.94"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.93</string>
+	<string>0.0.94</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.93</string>
+	<string>0.0.94</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.93</string>
+	<string>0.0.94</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.93</string>
+	<string>0.0.94</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.93",
+  "version": "0.0.94",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Cuts **v0.0.94**, bundling all unreleased work since `v0.0.93` (52 commits). Version bumped across the 8 release files (package.json, tauri.conf.json, Cargo.toml, Cargo.lock `app`, README, both iOS plists) and a `[0.0.94]` CHANGELOG section added.

Highlights:
- **Chat/board** — composer thinking-effort & response-speed controls, chat-project inference, session git/PR context, board task-chat project selector (#801); quote replies (#808).
- **Shortcuts** — configurable panel-toggle keybindings (#798).
- **Settings** — inline Familiar Studio (#802); model parity per-runtime picker.
- **Workflows** — research-brief / synthesize-sources templates (#799).
- **Markdown** — message-bubble `renderAsync` refactor (#800); mermaid diagrams.
- **Rail** — suppress redundant `- main` branch suffix (#809).
- Broad header/theme polish, accessibility fixes, and ~3.5 MB icon trim.

`app-version.test.ts` (the iOS-plist/version-consistency gate) passes locally. Tag `v0.0.94` will be pushed after merge to trigger the notarized DMG / AppImage / MSI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)