### PR TITLE
fix(workflows): style library group headings as clear headers

### DIFF
--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -370,12 +370,17 @@
   align-items: center;
   gap: 6px;
   margin: 0;
-  padding: 0 2px;
-  font-size: 10px;
-  font-weight: 650;
+  /* Shared mode-aware header band (matches the chat rail / board / GitHub /
+     calendar group headers): darker than the page in light mode, lighter in
+     dark — the mix toward --foreground inverts per mode. */
+  padding: 5px 8px;
+  border-radius: 6px;
+  background: color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%);
+  font-size: 11px;
+  font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--muted-foreground);
+  color: var(--text-primary);
 }
 
 .workflow-library-group-count {


### PR DESCRIPTION
Extends the shared header treatment (#803 / #805 / #806 / #813 / #816) to the Workflow Studio library panel.

The library's **Personal** / **Templates** group headings were a flat 10px/650 `--muted-foreground` label with no fill — unlike the section/group headers now used across the chat rail, board, GitHub, and calendar.

Now aligned: the same mode-aware band `color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%)` (darker than the page in light mode, lighter in dark), a bold `--text-primary` label one step larger, rounded. Keeps the origin dot + count badge.

### Verification
Driven live via Playwright (mocked `/api/workflows` with personal + public workflows so both groups render, sidebar → Workflows). Captured both modes — the `PERSONAL` / `TEMPLATES` headings read as clear darker bands in light mode and lighter bands in dark.

`pnpm test:app` exit 0. No source-text tests pinned these values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)