### PR TITLE
feat(rail): in-panel collapse trigger on the Companion panel (mirror the left)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3321,6 +3321,23 @@ button:active > .edge-rail-chip {
   background: var(--text-muted);
 }
 
+/* In-panel collapse trigger — mirror of the left sessions-rail Hide button. */
+.companion-rail__collapse {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  border-radius: 6px;
+  color: var(--text-muted);
+  transition: background-color 0.12s ease, color 0.12s ease;
+}
+
+.companion-rail__collapse:hover {
+  background: color-mix(in oklch, var(--bg-raised) 40%, transparent);
+  color: var(--text-primary);
+}
+
 .companion-rail__tabs {
   display: flex;
   gap: 2px;

--- a/src/components/companion-rail.test.ts
+++ b/src/components/companion-rail.test.ts
@@ -36,3 +36,18 @@ assert.match(
   /hideChatTab && requestedTab === "chat"[\s\S]*\? browserSlot \? "browser" : fallbackTab/,
   "When the main chat surface hides the duplicate Chat tab, the companion rail should fall back to Browser before Salem",
 );
+
+// In-panel collapse trigger — mirrors the left sessions-rail Hide button so the
+// right panel can be hidden from its own header (not only via ⌘⇧B).
+assert.match(source, /companion-rail__collapse/, "Header includes an in-panel collapse button (BEM class)");
+assert.match(source, /aria-label="Hide companion panel"/, "Collapse button is labelled for assistive tech");
+assert.match(
+  source,
+  /ph:sidebar-simple-fill/,
+  "Collapse button uses the same sidebar-simple glyph as the left rail's Hide button",
+);
+assert.match(
+  source,
+  /new CustomEvent\("cave:familiar-panel-toggle"\)/,
+  "Collapse button dispatches cave:familiar-panel-toggle so the Shell reuses its ⌘⇧B collapse path",
+);

--- a/src/components/companion-rail.tsx
+++ b/src/components/companion-rail.tsx
@@ -124,6 +124,15 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
               <span>Browser</span>
             </span>
           )}
+          <button
+            type="button"
+            className="companion-rail__collapse focus-ring"
+            aria-label="Hide companion panel"
+            title="Hide companion panel (⌘⇧B)"
+            onClick={() => window.dispatchEvent(new CustomEvent("cave:familiar-panel-toggle"))}
+          >
+            <Icon name="ph:sidebar-simple-fill" width={14} aria-hidden />
+          </button>
         </header>
         <nav className="companion-rail__tabs" aria-label="Companion sections">
           {!familiar || hideChatTab ? null : (

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -138,4 +138,18 @@ assert.doesNotMatch(
 assert.match(shortcuts, /keys: "⌘B"[\s\S]*Toggle the left sidebar/, "shortcut sheet documents the default left panel toggle");
 assert.match(shortcuts, /keys: "⌘⇧B"[\s\S]*Toggle the right side panel/, "shortcut sheet documents the default right panel toggle");
 
+// The CompanionRail's in-panel Hide button (mirror of the left rail) dispatches
+// cave:familiar-panel-toggle; the Shell listens for it and reuses the ⌘⇧B path.
+assert.match(
+  shell,
+  /addEventListener\("cave:familiar-panel-toggle", familiarPanelToggle\)/,
+  "Shell listens for the CompanionRail in-panel collapse event",
+);
+assert.match(
+  shell,
+  /removeEventListener\("cave:familiar-panel-toggle", familiarPanelToggle\)/,
+  "Shell cleans up the familiar-panel-toggle listener",
+);
+assert.match(css, /\.companion-rail__collapse/, "globals.css styles the in-panel collapse button");
+
 console.log("shell-edge-rails.test.ts OK");

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -385,11 +385,17 @@ function ShellInner({
         togglePanel(bottomRef.current);
       }
     };
+    // In-panel collapse trigger inside CompanionRail dispatches this so the
+    // right panel can be hidden from its own header (mirror of the left rail),
+    // reusing the same collapse path as the ⌘⇧B shortcut.
+    const familiarPanelToggle = () => toggleFamiliarPanel();
     window.addEventListener("keydown", handler);
     window.addEventListener("keydown", bottomToggle);
+    window.addEventListener("cave:familiar-panel-toggle", familiarPanelToggle);
     return () => {
       window.removeEventListener("keydown", handler);
       window.removeEventListener("keydown", bottomToggle);
+      window.removeEventListener("cave:familiar-panel-toggle", familiarPanelToggle);
     };
   }, [twoPane, hasFamiliar, hasBottom, isMobile, panelShortcuts]);
 


### PR DESCRIPTION
The right **Companion panel** (familiar brain/memory) had no in-panel collapse affordance — it could only be hidden with ⌘⇧B — while the **left sessions rail** has long had a Hide button in its header. This mirrors that.

## What
- Adds a Hide button to the `companion-rail` header (far right, by the familiar name/status), using the **same `ph:sidebar-simple-fill` glyph and button treatment** as the left rail's Hide button.
- The button dispatches a `cave:familiar-panel-toggle` `CustomEvent`. The **Shell** listens for it and runs the **same collapse path as ⌘⇧B** (`familiarRef.collapse()` + `setFamiliarOpen(false)`), so behavior is identical and reopen still works via the existing floating right-edge rail.
- New `.companion-rail__collapse` CSS mirrors the left Hide button's 24px hit area + hover.

## Tests
- `companion-rail.test.ts` — asserts the button, its label, the shared glyph, and the event dispatch.
- `shell-edge-rails.test.ts` — asserts the Shell add/removeEventListener wiring + the CSS class.
- Full `pnpm test:app` green; `tsc --noEmit` clean.