### PR TITLE
feat(familiars): downscale workspace avatars; workspace avatar always wins

### DIFF
--- a/src/app/api/familiars/[id]/avatar/route.ts
+++ b/src/app/api/familiars/[id]/avatar/route.ts
@@ -1,24 +1,59 @@
 import { NextResponse } from "next/server";
 import { constants } from "node:fs";
 import { open } from "node:fs/promises";
+import sharp from "sharp";
 import { isValidFamiliarId } from "@/lib/server/familiar-id";
 import { resolveFamiliarAvatar } from "@/lib/server/familiar-avatar";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-// Generous cap: the seeded workspace avatars are full-resolution PNGs (~30MB).
-// We still bound it so a pathological file can't be slurped whole into memory.
+// Generous read cap: the seeded workspace avatars are full-resolution PNGs
+// (~30MB / 4096px). We bound it so a pathological file can't be slurped whole
+// into memory before downscaling.
 const MAX_AVATAR_BYTES = 48 * 1024 * 1024;
+
+// Avatars render at 16–36px (sm/md/lg); 256px on the longest edge stays crisp
+// at 3–4× DPR while turning a ~30MB source into a few KB of WebP.
+const AVATAR_MAX_DIM = 256;
+
+type RenderedAvatar = { body: Uint8Array<ArrayBuffer>; contentType: string };
+
+// Process-lifetime cache keyed by file path + mtime, so the expensive resize
+// runs once per (avatar file version) instead of on every cold request. The
+// familiar set is tiny, so a small bound is plenty.
+const MAX_CACHE_ENTRIES = 64;
+const renderCache = new Map<string, RenderedAvatar>();
+
+function cacheGet(key: string): RenderedAvatar | undefined {
+  const hit = renderCache.get(key);
+  if (hit) {
+    // Refresh LRU recency.
+    renderCache.delete(key);
+    renderCache.set(key, hit);
+  }
+  return hit;
+}
+
+function cacheSet(key: string, value: RenderedAvatar): void {
+  renderCache.set(key, value);
+  while (renderCache.size > MAX_CACHE_ENTRIES) {
+    const oldest = renderCache.keys().next().value;
+    if (oldest === undefined) break;
+    renderCache.delete(oldest);
+  }
+}
 
 /**
  * Serve a familiar's avatar image from its workspace:
  *   ~/.coven/workspaces/familiars/<id>/avatars/<image>.<ext>
  *
- * The `id` segment (the only user input) is slug-guarded, and the served
- * filename is chosen from the directory listing — never from the request — so
- * this can't read outside the avatars dir. 404 when the familiar has no avatar;
- * the UI then falls back to the glyph.
+ * Raster avatars are downscaled to <=256px and re-encoded as WebP so a 30MB
+ * source doesn't ship for a 36px glyph; SVGs are served as-is (already small,
+ * and vector). The `id` segment (the only user input) is slug-guarded, and the
+ * served filename is chosen from the directory listing — never from the request
+ * — so this can't read outside the avatars dir. 404 when the familiar has no
+ * avatar; the UI then falls back to the glyph.
  */
 export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
   const { id } = await ctx.params;
@@ -29,6 +64,12 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
   const avatar = await resolveFamiliarAvatar(id);
   if (!avatar) {
     return NextResponse.json({ ok: false, error: "no avatar" }, { status: 404 });
+  }
+
+  const cacheKey = `${avatar.absPath}\0${avatar.mtimeMs}`;
+  const cached = cacheGet(cacheKey);
+  if (cached) {
+    return imageResponse(cached);
   }
 
   let bytes: Buffer;
@@ -49,10 +90,33 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     return NextResponse.json({ ok: false, error: "no avatar" }, { status: 404 });
   }
 
-  return new NextResponse(new Uint8Array(bytes), {
+  let rendered: RenderedAvatar;
+  if (avatar.contentType === "image/svg+xml") {
+    // Vector source — already tiny; serve verbatim rather than rasterizing.
+    rendered = { body: new Uint8Array(bytes), contentType: "image/svg+xml" };
+  } else {
+    try {
+      const webp = await sharp(bytes)
+        .rotate() // honor EXIF orientation before resizing
+        .resize(AVATAR_MAX_DIM, AVATAR_MAX_DIM, { fit: "inside", withoutEnlargement: true })
+        .webp({ quality: 82 })
+        .toBuffer();
+      rendered = { body: new Uint8Array(webp), contentType: "image/webp" };
+    } catch {
+      // Not a decodable raster image — treat as missing rather than 500.
+      return NextResponse.json({ ok: false, error: "no avatar" }, { status: 404 });
+    }
+  }
+
+  cacheSet(cacheKey, rendered);
+  return imageResponse(rendered);
+}
+
+function imageResponse({ body, contentType }: RenderedAvatar): NextResponse {
+  return new NextResponse(body, {
     status: 200,
     headers: {
-      "content-type": avatar.contentType,
+      "content-type": contentType,
       // Content is keyed by the `?v=<mtime>` the familiars list appends, so it
       // can be cached hard and busted whenever the file changes on disk.
       "cache-control": "private, max-age=31536000, immutable",

--- a/src/lib/familiar-resolve.ts
+++ b/src/lib/familiar-resolve.ts
@@ -15,9 +15,9 @@ export type ResolvedFamiliar = Omit<Familiar, "display_name" | "role"> & {
   /** Always non-empty; falls back to var(--accent-presence). */
   color: string;
   /**
-   * Avatar image source: a Cave-local uploaded data URL when the user set one,
-   * otherwise the familiar's workspace avatar URL (`base.avatarUrl`, served from
-   * `~/.coven/workspaces/familiars/<id>/avatars/`). Undefined when neither
+   * Avatar image source: the familiar's workspace avatar URL (`base.avatarUrl`,
+   * served from `~/.coven/workspaces/familiars/<id>/avatars/`) when present,
+   * else a Cave-local uploaded data URL as fallback. Undefined when neither
    * exists — the glyph renders instead.
    */
   avatarImage?: string;
@@ -43,9 +43,10 @@ export function resolveFamiliar(base: Familiar, ctx: ResolveContext): ResolvedFa
     pronouns: ov.pronouns ?? base.pronouns,
     description: ov.description ?? base.description,
     color: ov.color ?? "var(--accent-presence)",
-    // A Cave-local upload is an explicit user choice, so it wins; otherwise use
-    // the familiar's workspace avatar (.../familiars/<id>/avatars/<img>).
-    avatarImage: ctx.image?.dataUrl ?? base.avatarUrl,
+    // The familiar's workspace avatar (.../familiars/<id>/avatars/<img>) is the
+    // source of truth and always wins; a Cave-local upload is only the fallback
+    // when the familiar has no workspace avatar on disk.
+    avatarImage: base.avatarUrl ?? ctx.image?.dataUrl,
     glyph: resolveFamiliarGlyph(
       { id: base.id, icon: base.icon, emoji: base.emoji, role: ov.role ?? base.role },
       glyphOverrides,


### PR DESCRIPTION
Two follow-ups to #821, per request.

## 1. Downscale on serve
The seeded workspace avatars are full-res **4096×4096 PNGs (~28–34 MB each)** — far too heavy for a 16–36px glyph. The avatar route now uses **sharp** to resize raster avatars to ≤256px and re-encode as **WebP** (quality 82); SVGs pass through untouched (already small + vector).

- **~30 MB → ~14 KB per avatar** (256×256).
- A process-lifetime LRU cache keyed by `path + mtime` runs the resize once per avatar version, not per request.
- The read still uses `O_NOFOLLOW` + the 48 MB cap *before* decode; an undecodable file 404s (→ glyph fallback) rather than 500.
- `sharp` is already a dependency (Next image optimization) — no new package, dependency-policy guard unaffected.

## 2. Workspace avatar always wins
`familiar-resolve` now resolves `avatarImage = base.avatarUrl ?? uploaded data URL` (previously the reverse). The on-disk workspace avatar is the source of truth; a Cave-local upload is only the fallback when there's no workspace avatar.

## Verification
Live against the daemon + real files: all 7 familiars serve `200` as `image/webp` at `256×256`, **13–18 KB each** (down from 28–34 MB); a repeat request hits the in-process cache. Full `pnpm test:app` + `pnpm test:api` + `pnpm build` + `tsc` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)