### PR TITLE
fix(schedules): style section headers as clear headers

### DIFF
--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -420,9 +420,9 @@ function ReminderTaskSection({
   if (items.length === 0) return null;
   return (
     <div className="mb-6">
-      <div className="flex items-center gap-3 mb-1 pb-2"
-        style={{ borderBottom: "1px solid var(--border-hairline)" }}>
-        <span className="text-[12px] font-semibold" style={{ color: "var(--text-secondary)" }}>
+      <div className="flex items-center gap-3 mb-1 rounded-md px-3 py-1.5"
+        style={{ background: "color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%)", borderBottom: "1px solid var(--border-hairline)" }}>
+        <span className="text-[12px] font-bold" style={{ color: "var(--text-primary)" }}>
           {title}
         </span>
       </div>
@@ -840,9 +840,9 @@ function AutomationScheduleSection({
   if (items.length === 0) return null;
   return (
     <div className="mb-6">
-      <div className="flex items-center gap-3 mb-1 pb-2"
-        style={{ borderBottom: "1px solid var(--border-hairline)" }}>
-        <span className="text-[12px] font-semibold" style={{ color: "var(--text-secondary)" }}>
+      <div className="flex items-center gap-3 mb-1 rounded-md px-3 py-1.5"
+        style={{ background: "color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%)", borderBottom: "1px solid var(--border-hairline)" }}>
+        <span className="text-[12px] font-bold" style={{ color: "var(--text-primary)" }}>
           {title}
         </span>
         <span className="text-[10px] px-1.5 py-0.5 rounded"


### PR DESCRIPTION
Extends the shared header treatment (#803 / #805 / #806 / #813 / #816 / #819) to the Schedules view (AutomationsView).

The reminder section headers (**Repeating** / **Paused** / **One-time** / **History**) and automation section headers (**Active** / **Paused**) were a flat 12px/600 `--text-secondary` label + hairline rule with no fill — unlike the section/group headers now used across the chat rail, board, GitHub, calendar, and workflows.

Now aligned: the same mode-aware band `color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%)` (darker than the page in light mode, lighter in dark), a bold `--text-primary` label, rounded. Keeps the hairline divider and the Codex badge.

### Verification
Driven live via Playwright (mocked `/api/inbox` with reminders across Repeating / Paused / One-time, sidebar → Schedules). Captured both modes — the section headers read as clear darker bands in light mode and lighter bands in dark.

`pnpm test:app` exit 0 (including `schedules-tabs.test.ts` source-text checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)