### PR TITLE
fix(library): style timeline group headers as clear headers

### DIFF
--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -422,15 +422,19 @@
   min-height: 31px;
   padding: 6px 16px;
   border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 76%, transparent);
-  background: color-mix(in oklch, var(--bg-base) 94%, transparent);
+  /* Shared mode-aware header band (matches the chat rail / board / GitHub /
+     calendar / schedules / workflows group headers): darker than the page in
+     light mode, lighter in dark — the mix toward --foreground inverts per mode.
+     Opaque, so content scrolls cleanly under this sticky header. */
+  background: color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%);
   backdrop-filter: blur(14px);
 }
 
 .library-timeline-group-label {
   min-width: 0;
   overflow: hidden;
-  color: var(--text-muted);
-  font-size: 10px;
+  color: var(--text-primary);
+  font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.16em;
   line-height: 1;


### PR DESCRIPTION
Extends the shared header treatment (#803 / #805 / #806 / #813 / #816 / #819 / #824) to the Library.

The timeline group headers (**Today** / **This week** / **This month**, or by source) used a near-transparent 94%-base glass fill with a `--text-muted` label — so they barely read as headers.

Now aligned: the same mode-aware band `color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%)` (darker than the page in light mode, lighter in dark). The mix is opaque, so content scrolls cleanly under the sticky header (blur kept). Label bumped to bold `--text-primary` one step larger. The left-rail collapse toggles are secondary nav chrome and left as-is.

### Verification
Driven live via Playwright (mocked `/api/library/all` with bookmark entries across Today / This week / This month, sidebar → Library). Captured both modes — the timeline group headers read as clear darker bands in light mode and lighter bands in dark.

`pnpm test:app` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)