### PR TITLE
chore(release): v0.0.95

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.95] - 2026-06-16
+
+Patch release: reminders gain links and editing, the Companion panel gets an in-panel collapse trigger, a new Familiar Studio Contract tab, workspace-sourced avatars, and more header/polish fixes after 0.0.94.
+
+### Added
+- **Reminders** — a `link` parameter (URL / board card / chat session) on reminders, shown as a routing chip in the detail panel, plus full **edit** of an existing reminder (title / when / recurrence / link) via the reused reminder modal (#826).
+- **Companion panel** — an in-panel collapse trigger in the panel header, mirroring the left sessions rail's Hide button (#822).
+- **Familiar Studio** — a Contract tab that tests a familiar's adherence to the Familiar Contract.
+- **Familiars** — source avatars from the workspace `avatars/` dir, with the workspace avatar taking precedence (#821).
+
+### Fixed
+- **Changes** — allow the git Changes panel for daemon-known session roots (#d9a67288).
+- **Headers** — consistent "clear header" treatment for library timeline groups, schedules sections, and workflow library group headings.
+
 ## [0.0.94] - 2026-06-16
 
 Patch release: a chat composer and projects/sessions overhaul, configurable panel shortcuts, inline Familiar Studio in Settings, new research workflow templates, a markdown-rendering refactor, and a broad sweep of header/theme polish and accessibility fixes after 0.0.93.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A familiar is not just a chat window. It has a name, role, runtime, memory, tool
 
 ## Status
 
-- Current app version: `0.0.94`
+- Current app version: `0.0.95`
 - Native shell: Tauri 2
 - Frontend: Next.js 16, React 19, Tailwind v4
 - Runtime dependency: a healthy local `coven` CLI/daemon plus at least one runtime source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.94",
+  "version": "0.0.95",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.94"
+version = "0.0.95"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.94"
+version = "0.0.95"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.94</string>
+	<string>0.0.95</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.94</string>
+	<string>0.0.95</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.94</string>
+	<string>0.0.95</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.94</string>
+	<string>0.0.95</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.94",
+  "version": "0.0.95",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Cuts **v0.0.95**, bundling 9 commits since `v0.0.94`. Version bumped across the 8 release files (package.json, tauri.conf.json, Cargo.toml, Cargo.lock `app`, README, both iOS plists) + a `[0.0.95]` CHANGELOG section.

Highlights:
- **Reminders** — link parameter (URL / board card / chat session) + edit existing reminders (#826).
- **Companion panel** — in-panel collapse trigger mirroring the left rail (#822).
- **Familiar Studio** — Contract tab (adherence testing).
- **Familiars** — workspace-sourced avatars (#821).
- Changes-panel + header polish fixes.

`app-version.test.ts` (version/iOS-plist gate) passes locally. Tag `v0.0.95` pushed after merge → notarized DMG / AppImage / MSI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)