### PR TITLE
feat(shell): Codex-style floating panel toggles in the top corners

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3223,6 +3223,69 @@ button:active > .edge-rail-chip {
 }
 
 /* ────────────────────────────────────────────────
+   Floating panel toggles (Codex-style)
+   Always-visible rounded buttons pinned to the shell's top corners that
+   show/hide the side panels — left toggles the nav sidebar, right toggles
+   the active companion/side panel. They float above the panels (z-index)
+   so a single persistent control owns each panel in any open/closed state.
+   ──────────────────────────────────────────────── */
+.shell-body--floats {
+  position: relative;
+}
+
+.shell-panel-float {
+  position: absolute;
+  top: 8px;
+  z-index: 40;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in oklch, var(--text-muted) 34%, transparent);
+  background: color-mix(in oklch, var(--bg-raised) 86%, var(--bg-elevated));
+  color: color-mix(in oklch, var(--text-secondary) 86%, var(--text-primary));
+  box-shadow:
+    inset 0 1px 0 color-mix(in oklch, var(--text-primary) 10%, transparent),
+    0 6px 16px color-mix(in oklch, black 22%, transparent);
+  cursor: pointer;
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease, box-shadow 120ms ease, transform 80ms ease;
+}
+
+.shell-panel-float--left {
+  left: 8px;
+}
+
+.shell-panel-float--right {
+  right: 8px;
+}
+
+/* The Phosphor sidebar glyph points at a left panel; mirror it on the right
+   toggle so it reads as a right-edge panel. */
+.shell-panel-float--right svg {
+  transform: scaleX(-1);
+}
+
+.shell-panel-float:hover {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  border-color: color-mix(in oklch, var(--text-muted) 48%, transparent);
+}
+
+.shell-panel-float:active {
+  transform: scale(0.94);
+}
+
+/* Open state: accent-tinted, matching the edge-rail "expanded" treatment. */
+.shell-panel-float--active {
+  color: var(--text-primary);
+  border-color: color-mix(in oklch, var(--accent-presence) 58%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 18%, var(--bg-raised));
+}
+
+/* ────────────────────────────────────────────────
    Companion rail — right-side per-familiar pane
    (Phase 2, shell-ia-redesign)
    ──────────────────────────────────────────────── */

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -14,35 +14,60 @@ const projectSidebar = readFileSync(new URL("./chat-project-sidebar.tsx", import
 const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 const shortcuts = readFileSync(new URL("../lib/keyboard-shortcuts.ts", import.meta.url), "utf8");
 
+// Codex-style floating panel toggles: two always-visible rounded buttons
+// pinned to the shell's top corners (left = nav sidebar, right = active side
+// panel) replace the old collapsed-only left edge rail.
 assert.match(
   shell,
-  /familiar-trigger-rail familiar-trigger-rail--left/,
-  "shell renders a left edge rail mirroring the right agent rail",
+  /const panelFloats = !isMobile/,
+  "shell builds the floating panel toggles on desktop only",
 );
 assert.match(
   shell,
-  /!isMobile && !navOpen \? \([\s\S]*?familiar-trigger-rail--left/,
-  "left edge rail appears on desktop once the nav is collapsed",
+  /shell-panel-float shell-panel-float--left/,
+  "shell renders a floating left toggle for the nav sidebar",
 );
 assert.match(
   shell,
-  /familiar-trigger-rail--left[\s\S]*?aria-label=\{navOpen \? "Hide navigation" : "Show navigation"\}/,
-  "left edge rail toggle label reflects nav state",
+  /shell-panel-float--right/,
+  "shell renders a floating right toggle for the active side panel",
 );
 assert.match(
   shell,
-  /familiar-trigger-rail--left[\s\S]*?aria-expanded=\{navOpen\}/,
-  "left edge rail exposes nav expanded state",
+  /shell-panel-float--left[\s\S]*?aria-label=\{navOpen \? "Hide navigation" : "Show navigation"\}/,
+  "left float label reflects nav state",
 );
 assert.match(
   shell,
-  /familiar-trigger-rail--left[\s\S]*?navRef\.current\?\.collapse\(\)[\s\S]*?navRef\.current\?\.expand\(\)/,
-  "left edge rail toggle collapses and expands the nav panel",
+  /shell-panel-float--left[\s\S]*?aria-expanded=\{navOpen\}/,
+  "left float exposes nav expanded state",
 );
 assert.match(
   shell,
-  /familiar-trigger-rail--left[\s\S]*?navOpen \? "ph:sidebar-simple-fill" : "ph:sidebar-simple"/,
-  "left edge rail icon reflects nav state",
+  /shell-panel-float--left[\s\S]*?navOpen \? "ph:sidebar-simple-fill" : "ph:sidebar-simple"/,
+  "left float icon reflects nav state",
+);
+assert.match(
+  shell,
+  /const toggleNavPanel = \(\) => \{[\s\S]*?panel\.expand\(\); setNavOpen\(true\)[\s\S]*?panel\.collapse\(\); setNavOpen\(false\)/,
+  "left float collapses and expands the nav panel",
+);
+assert.match(
+  shell,
+  /shell-panel-float--right[\s\S]*?aria-expanded=\{familiarOpen\}/,
+  "right float exposes the active side-panel state",
+);
+assert.match(
+  shell,
+  /const toggleRightPanel = \(\) => \{[\s\S]*?familiarRef\.current[\s\S]*?setFamiliarOpen/,
+  "right float toggles the active right panel via familiarRef",
+);
+// Floats are always visible (open or closed) — the old collapsed-only left
+// edge rail is gone.
+assert.doesNotMatch(
+  shell,
+  /familiar-trigger-rail--left/,
+  "the old collapsed-only left edge rail is removed from the shell",
 );
 
 assert.match(

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -116,8 +116,6 @@ type ShellMobileChromeState = {
 type ShellTopBar = ReactNode | ((state: ShellMobileChromeState) => ReactNode);
 
 function ShellInner({
-  familiarRail,
-  familiarPanelRail,
   nav,
   list,
   detail,
@@ -129,9 +127,10 @@ function ShellInner({
   onFamiliarOpenChange,
   panelShortcutOverrides,
 }: {
+  /** @deprecated Side-panel toggles are now the floating corner controls
+   *  rendered by the shell itself; these edge-rail slots are no longer used.
+   *  Kept optional so existing call sites type-check during migration. */
   familiarRail?: ReactNode;
-  /** Mirror of familiarRail on the right edge — typically a thin column with
-   *  a toggle for the agent panel. Rendered after the panel group. */
   familiarPanelRail?: ReactNode;
   nav: ReactNode;
   list?: ReactNode;
@@ -404,7 +403,6 @@ function ShellInner({
       <div className="shell-frame flex h-full w-full flex-col">
         {renderedTopBar}
         <div className="shell-body flex flex-1 min-h-0">
-          {familiarRail}
           <div className="shell-root flex-1 min-h-0" />
         </div>
       </div>
@@ -502,34 +500,51 @@ function ShellInner({
     "--shell-right-gap-px": `${detailGaps.right}px`,
     "--shell-home-center-shift-px": `${homeCenterShift}px`,
   };
-  // Floating reopen affordance — once the sidebar is collapsed (via its own
-  // top toggle, ⌘B, or a drag), this left-edge rail is how it comes back. It
-  // stays hidden while the nav is open so the in-panel toggle owns collapsing.
-  const navRail =
-    !isMobile && !navOpen ? (
-      <aside className="familiar-trigger-rail familiar-trigger-rail--left" aria-label="Navigation toggle">
+  // Codex-style floating panel toggles. Two always-visible rounded buttons
+  // pinned to the shell's top corners that show/hide the side panels: the
+  // left one toggles the navigation sidebar, the right one toggles whichever
+  // right panel is active (the companion/inspector/browser slot). They replace
+  // the old collapsed-only edge rails and the in-panel collapse toggles, so a
+  // single persistent control owns each panel regardless of its open state.
+  const rightPanelShortcutLabel = labelPanelShortcut(panelShortcuts.toggleRightPanel);
+  const toggleNavPanel = () => {
+    const panel = navRef.current;
+    if (!panel) return;
+    if (panel.isCollapsed()) { panel.expand(); setNavOpen(true); }
+    else { panel.collapse(); setNavOpen(false); }
+  };
+  const toggleRightPanel = () => {
+    const panel = familiarRef.current;
+    if (!panel) return;
+    if (panel.isCollapsed()) { panel.expand(); setFamiliarOpen(true); }
+    else { panel.collapse(); setFamiliarOpen(false); }
+  };
+  const panelFloats = !isMobile ? (
+    <>
+      <button
+        type="button"
+        className={`shell-panel-float shell-panel-float--left focus-ring${navOpen ? " shell-panel-float--active" : ""}`}
+        aria-label={navOpen ? "Hide navigation" : "Show navigation"}
+        aria-expanded={navOpen}
+        title={navOpen ? `Hide navigation (${leftPanelShortcutLabel})` : `Show navigation (${leftPanelShortcutLabel})`}
+        onClick={toggleNavPanel}
+      >
+        <Icon name={navOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={15} />
+      </button>
+      {hasFamiliar ? (
         <button
           type="button"
-          className="familiar-trigger-rail__toggle"
-          aria-label={navOpen ? "Hide navigation" : "Show navigation"}
-          aria-expanded={navOpen}
-          title={navOpen ? `Hide navigation (${leftPanelShortcutLabel})` : `Show navigation (${leftPanelShortcutLabel})`}
-          onClick={() => {
-            if (navOpen) {
-              navRef.current?.collapse();
-              setNavOpen(false);
-            } else {
-              navRef.current?.expand();
-              setNavOpen(true);
-            }
-          }}
+          className={`shell-panel-float shell-panel-float--right focus-ring${familiarOpen ? " shell-panel-float--active" : ""}`}
+          aria-label={familiarOpen ? "Hide side panel" : "Show side panel"}
+          aria-expanded={familiarOpen}
+          title={familiarOpen ? `Hide side panel (${rightPanelShortcutLabel})` : `Show side panel (${rightPanelShortcutLabel})`}
+          onClick={toggleRightPanel}
         >
-          <span className="edge-rail-chip">
-            <Icon name={navOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={14} />
-          </span>
+          <Icon name={familiarOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={15} />
         </button>
-      </aside>
-    ) : null;
+      ) : null}
+    </>
+  ) : null;
 
   return (
     <div
@@ -538,9 +553,8 @@ function ShellInner({
       data-settled={settled ? "" : undefined}
     >
       {renderedTopBar}
-      <div className="shell-body flex flex-1 min-h-0">
-        {familiarRail}
-        {navRail}
+      <div className="shell-body shell-body--floats flex flex-1 min-h-0">
+        {panelFloats}
         {hasBottom ? (
           <Group
             className="flex-1 min-h-0"
@@ -567,7 +581,6 @@ function ShellInner({
         ) : (
           horizontalGroup
         )}
-        {familiarPanelRail}
       </div>
       {isMobile && mobileTabs ? mobileTabs : null}
       <MobileDrawer


### PR DESCRIPTION
## What
Replaces the collapsed-only left edge rail with **two always-visible rounded floating toggles** pinned to the shell's top corners, emulating Codex:
- **Left** → show/hide the navigation sidebar (`navRef` + ⌘B)
- **Right** → show/hide whichever right panel is active — the companion / inspector / browser slot (`familiarRef` + ⌘⇧B), shown when a companion panel is present

Both float above the panels (z-index + backdrop blur), flip to a filled accent-tinted state when their panel is open, mirror the sidebar glyph on the right edge, and expose `aria-expanded` + the shortcut hint. Desktop-only.

## Scope (per discussion)
Lands the floating toggles as the **new primary control** and removes the old left edge rail + the shell's right edge-rail render. Confined to **`shell.tsx` + `globals.css`** (+ test).

The legacy **in-panel** collapse affordances (CompanionRail hide button + `cave:familiar-panel-toggle`, the sidebar "Coven Cave" header toggle, the chat-rail reopen tab) are intentionally **left for a follow-up** — removing them touches `workspace.tsx` / `sidebar-minimal.tsx` / `companion-rail.tsx`, which are under active concurrent edits (the Delegations-removal work). This keeps the change self-contained and avoids racing that work. So for now there's a redundant sidebar header toggle; it'll be cleaned up once that lands.

> Note: the top-left "pill + back/forward" cluster in the original screenshot is **browser/OS chrome, not the app** (desktop renders no top bar), so it's untouched.

## Verification
- Live (prod build + Playwright, 1440px): both floats render at the top corners — left `8,8` accent-active (nav open), right pinned to the right edge and always visible (side panel closed). "Coven Cave" clears the left float.
- `shell-edge-rails.test.ts` updated to assert the floating toggles; full `pnpm test:app` + `pnpm build` + `tsc` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)