### PR TITLE
fix(appearance): map imported tweakcn themes onto the Cave's semantic tokens

### DIFF
--- a/src/components/settings-appearance.test.ts
+++ b/src/components/settings-appearance.test.ts
@@ -83,6 +83,41 @@ assert.match(
   "applyCustomVars should accept tweakcn's bare-name keys by prefixing -- when missing",
 );
 
+// tweakcn ships only shadcn base tokens; the Cave UI is driven by --accent-presence,
+// --bg-panel, --bg-elevated and --bg-hover, which are hardcoded per theme and do NOT
+// alias from the base. The import must translate the base tokens into those so an
+// imported theme recolors the accent/sidebar/popovers, not just the canvas.
+assert.match(
+  settings,
+  /function tweakcnSemanticVars\(/,
+  "Imports must translate tweakcn base tokens into the Cave's semantic vocabulary",
+);
+assert.match(
+  settings,
+  /tweakcnSemanticVars[\s\S]*"--accent-presence"\] = accent/,
+  "tweakcn import should drive --accent-presence from the theme's primary/ring/accent",
+);
+assert.match(
+  settings,
+  /pick\("primary"\) \|\| pick\("ring"\) \|\| pick\("accent"\)/,
+  "Accent should resolve from primary, then ring, then accent",
+);
+assert.match(
+  settings,
+  /"--bg-panel"\][\s\S]*"--bg-hover"\][\s\S]*"--bg-elevated"\]/,
+  "tweakcn import should derive the surface ramp (panel/hover/elevated) the app uses",
+);
+assert.match(
+  settings,
+  /const data = enrichTweakcnTheme\(raw\)/,
+  "handleImport should enrich the raw tweakcn theme before applying and persisting it",
+);
+assert.match(
+  settings,
+  /enrichTweakcnTheme[\s\S]*\{ \.\.\.tweakcnSemanticVars\(group, modeName\), \.\.\.group \}/,
+  "Enrichment must preserve raw tweakcn keys (spread last) while adding derived Cave tokens",
+);
+
 assert.match(
   settings,
   /import \{ APP_VERSION \} from "@\/lib\/app-version"/,

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -626,6 +626,85 @@ function applyCustomVars(cssVars: CustomThemeData["cssVars"], mode: Mode) {
   apply(modeGroup);
 }
 
+/**
+ * Translate a tweakcn (shadcn) mode group into the Cave's richer semantic
+ * vocabulary.
+ *
+ * tweakcn ships only shadcn's base tokens — `background`, `foreground`,
+ * `primary`, `card`, `popover`, `border`, … The Cave UI, however, is driven
+ * mostly by Issue #14 surface/accent tokens. Some of those alias from the base
+ * in globals.css and so update for free (`--bg-base: var(--background)`,
+ * `--bg-raised: var(--card)`, `--border-hairline: var(--border)`,
+ * `--text-primary: var(--foreground)`, `--text-secondary: var(--muted-foreground)`).
+ * But the most visible ones are HARDCODED per theme and do NOT alias from the
+ * base, so a raw tweakcn import never touches them:
+ *   --accent-presence  → every button, focus ring, active state, scrollbar,
+ *                        --brand, --ring-focus and --color-info derive from it
+ *   --bg-panel         → app shell / sidebar floor
+ *   --bg-elevated      → dropdowns / popovers
+ *   --bg-hover         → hover state
+ *   --border-strong    → emphasised borders
+ * Derive those here so an imported theme recolors the whole app, not just the
+ * canvas and body text. Mix direction is mode-aware: in dark mode the panel
+ * floor sits darker than the canvas and hovers lift lighter; light mode is the
+ * inverse.
+ */
+function tweakcnSemanticVars(
+  group: Record<string, string>,
+  modeName: Mode,
+): Record<string, string> {
+  const pick = (key: string) => group[key] ?? group[`--${key}`];
+  const accent = pick("primary") || pick("ring") || pick("accent");
+  const bg = pick("background");
+  const card = pick("card");
+  const popover = pick("popover");
+  const border = pick("border");
+  // Panel = deepest floor (darker in dark mode, lighter in light mode).
+  // Hover = lifted surface (lighter in dark mode, darker in light mode).
+  const deepen = modeName === "light" ? "white" : "black";
+  const lift = modeName === "light" ? "black" : "white";
+
+  const out: Record<string, string> = {};
+  if (accent) {
+    out["--accent-presence"] = accent;
+    out["--accent-presence-soft"] = `color-mix(in oklch, ${accent} 78%, transparent)`;
+    out["--accent-faint"] = `color-mix(in oklch, ${accent} 14%, transparent)`;
+  }
+  if (bg) {
+    out["--bg-panel"] = `color-mix(in oklch, ${bg} 92%, ${deepen})`;
+    out["--bg-hover"] = `color-mix(in oklch, ${bg} 84%, ${lift})`;
+  }
+  const elevated = popover || card;
+  if (elevated) out["--bg-elevated"] = elevated;
+  if (border) {
+    out["--border-strong"] = accent
+      ? `color-mix(in oklch, ${border} 62%, ${accent} 38%)`
+      : border;
+  }
+  return out;
+}
+
+/**
+ * Enrich an imported tweakcn theme with the derived Cave semantic tokens
+ * (see tweakcnSemanticVars). The extra tokens are baked into each mode group so
+ * BOTH the live apply path (applyCustomVars) and the flash-free boot script
+ * (theme-script.tsx) replay identical data with no further logic. Raw tweakcn
+ * keys are preserved (and win on the unlikely collision) by spreading last.
+ */
+function enrichTweakcnTheme(data: CustomThemeData): CustomThemeData {
+  const enrich = (group: Record<string, string> | undefined, modeName: Mode) =>
+    group ? { ...tweakcnSemanticVars(group, modeName), ...group } : group;
+  const { theme, light, dark } = data.cssVars;
+  return {
+    name: data.name,
+    cssVars: {
+      ...(theme ? { theme } : {}),
+      ...(light ? { light: enrich(light, "light") } : {}),
+      ...(dark ? { dark: enrich(dark, "dark") } : {}),
+    },
+  };
+}
+
 function clearCustomTheme() {
   document.documentElement.setAttribute("data-theme", "coven");
   document.documentElement.removeAttribute("style");
@@ -828,10 +907,14 @@ function AppearanceSection() {
         throw new Error("Response missing cssVars — not a valid tweakcn theme JSON.");
       }
 
-      const data: CustomThemeData = {
+      const raw: CustomThemeData = {
         name: (json.name as string) || canonical.split("/").pop() || "custom",
         cssVars: cssVars as CustomThemeData["cssVars"],
       };
+      // Translate shadcn base tokens into the Cave's semantic vocabulary so the
+      // import recolors the accent, sidebar, popovers and hover states — not
+      // just the canvas (see enrichTweakcnTheme / tweakcnSemanticVars).
+      const data = enrichTweakcnTheme(raw);
 
       applyCustomVars(data.cssVars, mode);
       localStorage.setItem(COVEN_CUSTOM_THEME_KEY, JSON.stringify(data));


### PR DESCRIPTION
## Problem

Importing a tweakcn theme (Settings → Appearance → Import from tweakcn) only **partially** recolored the app. tweakcn ships shadcn's base vocabulary — `background`, `foreground`, `primary`, `card`, `popover`, `border`… — but the Cave UI is driven mostly by a richer semantic set:

- `--accent-presence` — every button, focus ring, active state, scrollbar, plus `--brand` / `--ring-focus` / `--color-info` derive from it
- `--bg-panel` — app shell / sidebar floor
- `--bg-elevated` — dropdowns / popovers
- `--bg-hover` — hover state
- `--border-strong` — emphasised borders

Some Cave tokens alias from the shadcn base in `globals.css` and updated for free (`--bg-base ← --background`, `--bg-raised ← --card`, `--border-hairline ← --border`, `--text-primary ← --foreground`). But the most *visible* ones above are **hardcoded per theme and don't alias from the base**, so a raw import left the accent (and several surfaces) stuck on the previously-active theme. The result looked broken — the canvas changed, the buttons didn't.

## Fix

- `tweakcnSemanticVars(group, mode)` — translate an imported mode group into the missing Cave tokens. Accent resolves from `primary` → `ring` → `accent`; the surface ramp derives from `background` / `card` / `popover` / `border` with **mode-aware** mix direction (panel deeper / hovers lighter in dark mode, inverse in light).
- `enrichTweakcnTheme(data)` — bake the derived tokens into each stored mode group, preserving the raw tweakcn keys. Because it's baked into the *persisted* theme, both the live apply path (`applyCustomVars`) and the flash-free boot script (`theme-script.tsx`) replay identical data — no change to the fragile inline boot string.
- `handleImport` enriches the fetched theme before applying/persisting.

## Verification

Drove a real browser against the running app and imported `https://tweakcn.com/themes/cmpn5il0b000204l2gknihy2w` (the Coffef theme):

| token | before (Coven) | after (Coffef import) |
|---|---|---|
| `--accent-presence` | `#9a8ecd` | `oklch(0.9247 0.0524 66.1732)` (theme primary) |
| `--brand` | `#9a8ecd` | follows accent ✅ |
| `--ring-focus` | lavender mix | recomputed to new accent ✅ |
| `--scrollbar-thumb` | lavender mix | recomputed to new accent ✅ |
| `--bg-panel` / `--bg-elevated` / `--bg-hover` | unchanged | derived from import ✅ |
| `--background` (→`--bg-base`) | — | tracks imported canvas ✅ |

`data-theme` flips to `custom`, the "Custom: Coffef" chip renders, and the persisted theme carries the derived tokens so the boot script replays them on reload. 12/12 live checks pass. Live fetch (tweakcn sends `access-control-allow-origin: *`, no mock).

Added source-text coverage in `settings-appearance.test.ts` for the translation, accent precedence, surface ramp, and enrich-before-persist wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)