### PR TITLE
fix(roles): style per-familiar group headers as clear headers

### DIFF
--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -854,14 +854,14 @@ function RoleGrid({
             <button
               type="button"
               onClick={() => toggleCollapse(fam)}
-              className="focus-ring mb-2 flex w-full items-center gap-2 rounded text-left"
+              className="focus-ring mb-2 flex w-full items-center gap-2 rounded-md border-b border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)] px-3 py-1.5 text-left"
             >
               <Icon
                 name="ph:caret-right-bold"
                 width={11}
                 className={`shrink-0 text-[var(--text-muted)] transition-transform duration-150 ${isOpen ? "rotate-90" : ""}`}
               />
-              <span className="text-[11px] font-semibold capitalize tracking-wide text-[var(--text-secondary)]">
+              <span className="text-[12px] font-bold capitalize tracking-wide text-[var(--text-primary)]">
                 {fam}
               </span>
               <span className="rounded-full bg-[var(--bg-raised)] px-1.5 py-px text-[10px] text-[var(--text-muted)]">


### PR DESCRIPTION
Extends the shared header treatment (#803 / #805 / #806 / #813 / #816 / #819 / #824 / #825) to the Roles view.

The Roles tab groups roles per familiar (**Nova** / **Sage** / …) under a collapsible header that was flat text (caret + name + count + active pill) with no fill — unlike the section/group headers now used across the chat rail, board, GitHub, calendar, workflows, schedules, and library.

Now aligned: the same mode-aware band `color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%)` (darker than the page in light mode, lighter in dark), a bold `--text-primary` label one step larger, full-width with a hairline divider. Keeps the caret + count + active pills.

> The plugin/skill *category* labels are eyebrow-style (uppercase tracking, not group-row dividers) and are left as-is, like the page-title eyebrows elsewhere.

### Verification
Driven live via Playwright (mocked `/api/roles` with roles across two familiars, sidebar → Roles). Captured both modes — the `Nova` / `Sage` group headers read as clear darker bands in light mode and lighter bands in dark.

`pnpm test:app` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)