### PR TITLE
fix(chat): make the expanded right-panel Close button clickable

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3297,6 +3297,13 @@ button:active > .edge-rail-chip {
   background: color-mix(in oklch, var(--accent-presence) 18%, var(--bg-raised));
 }
 
+/* When the chat right panel is expanded it covers the whole chat surface; the
+   right edge-rail float would otherwise float above it (z-40) and intercept the
+   panel's top-right Close button. Hide it while expanded. */
+:root[data-right-panel-expanded] .shell-panel-float--right {
+  display: none;
+}
+
 /* ────────────────────────────────────────────────
    Companion rail — right-side per-familiar pane
    (Phase 2, shell-ia-redesign)

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -424,6 +424,19 @@ export function ChatSurface({
     return () => window.removeEventListener("keydown", onKey);
   }, [rightExpanded]);
 
+  // While the right panel is expanded it covers the chat surface, but the
+  // shell's right edge-rail float (.shell-panel-float--right, z-40) sits above
+  // the overlay's trapped z-index and intercepts clicks on the panel's
+  // top-right Close button. Flag the expanded state on the document root so CSS
+  // can hide that float while expanded (it's redundant under a full-surface
+  // panel anyway). Restore/Esc clear it; the cleanup guards against unmount.
+  useEffect(() => {
+    const root = document.documentElement;
+    if (rightExpanded) root.setAttribute("data-right-panel-expanded", "");
+    else root.removeAttribute("data-right-panel-expanded");
+    return () => root.removeAttribute("data-right-panel-expanded");
+  }, [rightExpanded]);
+
   // ── Render ──────────────────────────────────────────────────────────────────
 
   return (

--- a/src/components/right-panel-expand.test.ts
+++ b/src/components/right-panel-expand.test.ts
@@ -16,4 +16,8 @@ assert.match(src, /onSetPanel\("changes"\)/, "Changes is selectable as a tab whe
 assert.match(src, /rightExpanded/, "ChatSurface tracks rightExpanded");
 assert.match(src, /chat-right-expanded/, "expanded overlay container");
 
+// While expanded, the shell's right edge-rail float is hidden (via a root data
+// attribute + CSS) so it can't intercept clicks on the top-right Close button.
+assert.match(src, /data-right-panel-expanded/, "flags expanded state on the document root");
+
 console.log("right-panel-expand.test.ts: ok");


### PR DESCRIPTION
Follow-up to #829. When the right panel is **expanded**, its top-right **Close (X)** button was unclickable — the shell's right edge-rail float (`.shell-panel-float--right`, `z-40`) sits at the same corner, and the expanded overlay's `z-[60]` is trapped in a nested stacking context, so the float rendered on top and intercepted the click.

## Fix
While expanded, flag `data-right-panel-expanded` on the document root (effect in `ChatSurface`, cleared on restore/Esc/unmount) and hide `.shell-panel-float--right` via CSS. The float is redundant anyway while a full-surface panel is open.

## Verified in the running app (prod build, Playwright)
- Expanded → `.shell-panel-float--right` computed `display: none`; `elementFromPoint` at the Close button center returns the button itself ("self, clickable").
- Clicking **Close (X)** now fully closes the panel (overlay→0, tabs→0); reopen returns to the docked split.
- Restore button + Esc still work; root attribute is cleared on close.

`pnpm test:app` / `test:api` / `tsc --noEmit` (0 errors) all pass; `right-panel-expand.test.ts` updated to assert the new behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)