### PR TITLE
chore(release): v0.0.96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.96] - 2026-06-16
+
+Patch release: GitHub org/repo filtering improvements, Codex-style floating panel toggles, an expanding chat right-panel, Agent Completion Reports, and theme/header fixes after 0.0.95.
+
+### Added
+- **GitHub** — selecting a repo now locks the Org filter to that repo's org, and grouping is a `None · Org · Repo` segmented toggle (#831).
+- **Shell** — Codex-style floating panel toggles in the top corners.
+- **Chat** — the right side panel can expand to cover the chat surface (#829).
+- **Reports** — an Agent Completion Report schema + markdown generator.
+
+### Fixed
+- **Appearance** — imported tweakcn themes map onto Cave's semantic tokens.
+- **Headers** — per-familiar role group headers use the shared clear-header treatment.
+
 ## [0.0.95] - 2026-06-16
 
 Patch release: reminders gain links and editing, the Companion panel gets an in-panel collapse trigger, a new Familiar Studio Contract tab, workspace-sourced avatars, and more header/polish fixes after 0.0.94.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A familiar is not just a chat window. It has a name, role, runtime, memory, tool
 
 ## Status
 
-- Current app version: `0.0.95`
+- Current app version: `0.0.96`
 - Native shell: Tauri 2
 - Frontend: Next.js 16, React 19, Tailwind v4
 - Runtime dependency: a healthy local `coven` CLI/daemon plus at least one runtime source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.95",
+  "version": "0.0.96",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.95"
+version = "0.0.96"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.95"
+version = "0.0.96"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.95</string>
+	<string>0.0.96</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.95</string>
+	<string>0.0.96</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.95</string>
+	<string>0.0.96</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.95</string>
+	<string>0.0.96</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.95",
+  "version": "0.0.96",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Cuts **v0.0.96**, bundling 6 commits since `v0.0.95`. Version bumped across the 8 release files + `[0.0.96]` CHANGELOG section.

Highlights:
- **GitHub** — repo selection locks the Org filter + `None · Org · Repo` grouping toggle (#831).
- **Shell** — Codex-style floating panel toggles in the top corners.
- **Chat** — expanding right side panel (#829).
- **Reports** — Agent Completion Report schema + markdown generator.
- Appearance (tweakcn theme mapping) + header polish fixes.

`app-version.test.ts` gate passes locally. Tag `v0.0.96` pushed after merge → notarized DMG / AppImage / MSI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)