### PR TITLE
fix(capabilities): style type group headers as clear headers

### DIFF
--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -533,10 +533,10 @@ function CapabilityMap({
             <button
               type="button"
               onClick={() => onTypeFilter(type)}
-              className="focus-ring flex w-full items-center gap-2 border-b border-border px-3 py-2 text-left"
+              className="focus-ring flex w-full items-center gap-2 rounded-t-lg border-b border-border bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)] px-3 py-2 text-left"
             >
               <Icon name={TYPE_ICON[type]} width={13} className="text-muted-foreground" />
-              <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">
+              <h3 className="text-[12px] font-bold uppercase tracking-widest text-[var(--text-primary)]">
                 {TYPE_LABEL[type]}
               </h3>
               <span className="ml-auto rounded bg-muted px-1.5 py-px text-[10px] tabular-nums text-muted-foreground">


### PR DESCRIPTION
Extends the shared header treatment (#803 / #805 / #806 / #813 / #816 / #819 / #824 / #825 / #832) to the Capabilities view.

Each type section (**Instructions** / **Skills** / **Plugins** / **MCP Servers** / **Warnings**) had a flat uppercase-eyebrow header on its card with no fill — unlike the section/group headers now used across the chat rail, board, GitHub, calendar, workflows, schedules, library, and roles.

Now aligned: the section header gets the same mode-aware band `color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%)` (darker than the page in light mode, lighter in dark), a bold `--text-primary` label one step larger, rounded-top to match the card. Keeps the type icon + count badge.

### Verification
Driven live via Playwright (mocked `/api/capabilities` with a manifest of instructions/skills/MCP/warnings, sidebar → Capabilities). Captured both modes — the INSTRUCTIONS / SKILLS / MCP SERVERS group headers read as clear darker bands in light mode and lighter bands in dark.

`pnpm test:app` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)