### PR TITLE
chore(shell): remove legacy panel toggles, leaving the floating ones

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3245,9 +3245,17 @@ button:active > .edge-rail-chip {
   position: relative;
 }
 
+/* Clear the floating top-left toggle so it doesn't sit on top of the sidebar
+   wordmark. Scoped to the desktop shell — the floats are desktop-only. */
+.shell-body--floats .sidebar-header--static {
+  padding-left: 40px;
+}
+
 .shell-panel-float {
   position: absolute;
-  top: 8px;
+  /* Vertically centered on the sidebar header row so the toggle reads as part
+     of that row rather than floating above it. */
+  top: 18px;
   z-index: 40;
   display: grid;
   place-items: center;

--- a/src/components/companion-rail.test.ts
+++ b/src/components/companion-rail.test.ts
@@ -37,17 +37,12 @@ assert.match(
   "When the main chat surface hides the duplicate Chat tab, the companion rail should fall back to Browser before Salem",
 );
 
-// In-panel collapse trigger — mirrors the left sessions-rail Hide button so the
-// right panel can be hidden from its own header (not only via ⌘⇧B).
-assert.match(source, /companion-rail__collapse/, "Header includes an in-panel collapse button (BEM class)");
-assert.match(source, /aria-label="Hide companion panel"/, "Collapse button is labelled for assistive tech");
-assert.match(
-  source,
-  /ph:sidebar-simple-fill/,
-  "Collapse button uses the same sidebar-simple glyph as the left rail's Hide button",
-);
-assert.match(
+// The in-panel collapse trigger was removed — hiding the right panel is now
+// owned by the shell's floating top-right toggle (and ⌘⇧B), so the rail no
+// longer carries its own Hide button.
+assert.doesNotMatch(source, /companion-rail__collapse/, "in-panel collapse button is removed");
+assert.doesNotMatch(
   source,
   /new CustomEvent\("cave:familiar-panel-toggle"\)/,
-  "Collapse button dispatches cave:familiar-panel-toggle so the Shell reuses its ⌘⇧B collapse path",
+  "rail no longer dispatches the cave:familiar-panel-toggle collapse event",
 );

--- a/src/components/companion-rail.tsx
+++ b/src/components/companion-rail.tsx
@@ -124,15 +124,6 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
               <span>Browser</span>
             </span>
           )}
-          <button
-            type="button"
-            className="companion-rail__collapse focus-ring"
-            aria-label="Hide companion panel"
-            title="Hide companion panel (⌘⇧B)"
-            onClick={() => window.dispatchEvent(new CustomEvent("cave:familiar-panel-toggle"))}
-          >
-            <Icon name="ph:sidebar-simple-fill" width={14} aria-hidden />
-          </button>
         </header>
         <nav className="companion-rail__tabs" aria-label="Companion sections">
           {!familiar || hideChatTab ? null : (

--- a/src/components/misc-aria-fixes.test.ts
+++ b/src/components/misc-aria-fixes.test.ts
@@ -21,12 +21,14 @@ function read(file: string) {
   );
 }
 
-// 2. Sidebar collapse toggle has aria-expanded.
+// 2. Sidebar collapse moved to the shell's floating top-left toggle, which
+// exposes aria-expanded (covered by shell-edge-rails.test.ts). The sidebar
+// header itself is now a static wordmark with no collapse button.
 {
-  const a = read("sidebar-minimal.tsx");
+  const shell = read("shell.tsx");
   assert.ok(
-    /aria-expanded/.test(a),
-    "sidebar collapse toggle exposes aria-expanded (in sidebar-minimal.tsx)",
+    /shell-panel-float--left[\s\S]*?aria-expanded=\{navOpen\}/.test(shell),
+    "the floating left toggle exposes aria-expanded (in shell.tsx)",
   );
 }
 

--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -211,11 +211,6 @@ assert.match(
 );
 assert.match(
   workspace,
-  /familiarPanelRail=\{showCompanionRail \? \(/,
-  "Browser and Agents modes should suppress the desktop companion trigger rail unless a floating rail tab is selected",
-);
-assert.match(
-  workspace,
   /const openUrlInCompanionBrowser = useCallback\(\(url: string\) => \{/,
   "Workspace should provide a dedicated side-panel browser opener for chat links",
 );

--- a/src/components/salem/salem.test.ts
+++ b/src/components/salem/salem.test.ts
@@ -58,17 +58,13 @@ assert.doesNotMatch(route, /🐱|😅/, "Salem API replies must stay emoji-free 
 assert.match(widget, /preload/, "widget must load Salem preload metadata");
 assert.doesNotMatch(widget, /salem-panel__preload/, "preload count pills stay removed from the Salem header");
 
-// 6. Workspace exposes Salem via a right-edge familiarPanelRail toggle that mirrors
-//    the left-edge sidebar-trigger-rail. The standalone perch in layout.tsx
-//    has been retired in favour of the rail-based affordance.
+// 6. Workspace exposes Salem via the shared companion tab opener, which expands
+//    the right panel. The right edge-rail toggle was retired in favour of the
+//    shell's floating top-right panel toggle.
 const workspace = await readFile(path.join(root, "src/components/workspace.tsx"), "utf8");
-const shell = await readFile(path.join(root, "src/components/shell.tsx"), "utf8");
 const companionRail = await readFile(path.join(root, "src/components/companion-rail.tsx"), "utf8");
-assert.match(shell, /familiarPanelRail\?:\s*ReactNode/, "Shell must declare an familiarPanelRail slot mirroring familiarRail");
-assert.match(workspace, /familiarPanelRail=\{/, "workspace must pass an familiarPanelRail to Shell");
-assert.match(workspace, /familiar-trigger-rail--stacked/, "familiarPanelRail must use the stacked right tab opener");
-assert.match(workspace, /const openCompanionTab = useCallback/, "familiarPanelRail tabs must use the shared companion tab opener");
-assert.match(workspace, /shellRef\.current\?\.openFamiliar\(\)/, "familiarPanelRail tab opener must expand the right panel");
+assert.match(workspace, /const openCompanionTab = useCallback/, "Salem opens through the shared companion tab opener");
+assert.match(workspace, /shellRef\.current\?\.openFamiliar\(\)/, "the companion tab opener expands the right panel");
 assert.match(workspace, /cave:salem-open/, "workspace must listen for Salem launcher events");
 assert.match(workspace, /shellRef\.current\?\.openFamiliar\(\)/, "Salem launcher must expand the right panel");
 assert.match(workspace, /setRailTab\("salem"\)/, "Salem launcher must select the Salem rail tab");

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -107,17 +107,12 @@ assert.match(
   "edge-rail chip has a pressed state",
 );
 
-assert.match(
-  workspace,
-  /edge-rail-chip[\s\S]{0,80}ph:cat/,
-  "right agent rail toggle renders its icon inside the pressable chip",
-);
-// The right rail is Salem-only — the browser globe tab was retired; the
-// Browser surface is still reachable via the nav (⌘7).
+// The right edge-rail tab toggle was retired — the shell's floating top-right
+// toggle now owns showing/hiding the companion panel.
 assert.doesNotMatch(
   workspace,
-  /familiar-trigger-rail__toggle[\s\S]{0,160}ph:globe/,
-  "right agent rail no longer exposes the browser globe tab",
+  /familiarPanelRail=/,
+  "workspace no longer passes a right edge-rail tab toggle to the shell",
 );
 assert.match(
   css,
@@ -163,18 +158,13 @@ assert.doesNotMatch(
 assert.match(shortcuts, /keys: "⌘B"[\s\S]*Toggle the left sidebar/, "shortcut sheet documents the default left panel toggle");
 assert.match(shortcuts, /keys: "⌘⇧B"[\s\S]*Toggle the right side panel/, "shortcut sheet documents the default right panel toggle");
 
-// The CompanionRail's in-panel Hide button (mirror of the left rail) dispatches
-// cave:familiar-panel-toggle; the Shell listens for it and reuses the ⌘⇧B path.
-assert.match(
+// The CompanionRail's in-panel Hide button was removed along with its
+// cave:familiar-panel-toggle bridge — the floating top-right toggle (and ⌘⇧B)
+// own hiding the right panel now.
+assert.doesNotMatch(
   shell,
-  /addEventListener\("cave:familiar-panel-toggle", familiarPanelToggle\)/,
-  "Shell listens for the CompanionRail in-panel collapse event",
+  /cave:familiar-panel-toggle/,
+  "Shell no longer wires the retired in-panel collapse event",
 );
-assert.match(
-  shell,
-  /removeEventListener\("cave:familiar-panel-toggle", familiarPanelToggle\)/,
-  "Shell cleans up the familiar-panel-toggle listener",
-);
-assert.match(css, /\.companion-rail__collapse/, "globals.css styles the in-panel collapse button");
 
 console.log("shell-edge-rails.test.ts OK");

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -127,11 +127,6 @@ function ShellInner({
   onFamiliarOpenChange,
   panelShortcutOverrides,
 }: {
-  /** @deprecated Side-panel toggles are now the floating corner controls
-   *  rendered by the shell itself; these edge-rail slots are no longer used.
-   *  Kept optional so existing call sites type-check during migration. */
-  familiarRail?: ReactNode;
-  familiarPanelRail?: ReactNode;
   nav: ReactNode;
   list?: ReactNode;
   detail: ReactNode;
@@ -384,17 +379,11 @@ function ShellInner({
         togglePanel(bottomRef.current);
       }
     };
-    // In-panel collapse trigger inside CompanionRail dispatches this so the
-    // right panel can be hidden from its own header (mirror of the left rail),
-    // reusing the same collapse path as the ⌘⇧B shortcut.
-    const familiarPanelToggle = () => toggleFamiliarPanel();
     window.addEventListener("keydown", handler);
     window.addEventListener("keydown", bottomToggle);
-    window.addEventListener("cave:familiar-panel-toggle", familiarPanelToggle);
     return () => {
       window.removeEventListener("keydown", handler);
       window.removeEventListener("keydown", bottomToggle);
-      window.removeEventListener("cave:familiar-panel-toggle", familiarPanelToggle);
     };
   }, [twoPane, hasFamiliar, hasBottom, isMobile, panelShortcuts]);
 

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -201,27 +201,23 @@ assert.match(
 // + button, so the New Chat ActionRow is the sole new-chat affordance now —
 // no wrapper, no responsive hide.
 
-// Dia-style panel toggle: when onToggleSidebar is provided, the whole header
-// row is the collapse button (the left-edge rail handles reopening).
+// The sidebar header is a static wordmark — collapsing the panel is owned by
+// the shell's floating top-left toggle (and ⌘B), so the header is no longer a
+// button and the in-panel collapse toggle is gone.
 assert.match(
   source,
-  /onToggleSidebar\?: \(\) => void;/,
-  "SidebarMinimal accepts an onToggleSidebar collapse handler",
+  /className="sidebar-header sidebar-header--static"/,
+  "the sidebar header is a static wordmark, not a collapse button",
 );
 assert.match(
   source,
-  /className="sidebar-header"[\s\S]{0,160}onClick=\{onToggleSidebar\}/,
-  "the full header row is wired to onToggleSidebar",
+  /<span className="sidebar-title">Coven Cave<\/span>/,
+  "the static header keeps the Coven Cave wordmark",
 );
-assert.match(
+assert.doesNotMatch(
   source,
-  /className="sidebar-toggle"[\s\S]{0,200}ph:sidebar-simple/,
-  "the sidebar toggle uses the panel (sidebar-simple) icon",
-);
-assert.match(
-  styles,
-  /\.sidebar-toggle \{/,
-  "the sidebar toggle button has dedicated styling",
+  /onToggleSidebar/,
+  "the in-panel sidebar collapse toggle is removed",
 );
 assert.match(
   styles,

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -47,9 +47,6 @@ export type SidebarMinimalProps = {
   onNewChat: () => void;
   onOpenSettings: () => void;
   onModeChange: (mode: string) => void;
-  /* Collapse the sidebar. When provided, a Dia-style toggle button renders at
-   * the top of the panel; the left-edge rail reopens it once collapsed. */
-  onToggleSidebar?: () => void;
   onOpenSession: (id: string) => void;
   addons?: AddonsConfig;
   /* Notifications — when omitted, the bell is hidden. */
@@ -188,7 +185,6 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
     onNewChat,
     onOpenSettings,
     onModeChange,
-    onToggleSidebar,
     addons,
     familiars,
     activeFamiliarId,
@@ -214,23 +210,12 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
 
   return (
     <nav className="sidebar-minimal">
-      {/* Dia-style panel toggle pinned to the top of the sidebar. Collapsing
-          hands off to the left-edge rail, which reopens the panel. */}
-      {onToggleSidebar ? (
-        <button
-          type="button"
-          className="sidebar-header"
-          onClick={onToggleSidebar}
-          aria-label="Hide sidebar (⌘B)"
-          title="Hide sidebar (⌘B)"
-          aria-expanded
-        >
-          <span className="sidebar-title">Coven Cave</span>
-          <span className="sidebar-toggle" aria-hidden>
-            <Icon name="ph:sidebar-simple-fill" width={16} />
-          </span>
-        </button>
-      ) : null}
+      {/* Static wordmark. Collapsing the sidebar is now owned by the shell's
+          floating top-left toggle (and ⌘B), so the header is no longer a
+          button — it just leaves room for the float. */}
+      <div className="sidebar-header sidebar-header--static">
+        <span className="sidebar-title">Coven Cave</span>
+      </div>
 
       {/* Header actions: familiar profile switcher + New session. The same switcher
           also renders in the mobile top bar; on desktop this is its home. */}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1254,7 +1254,6 @@ export function Workspace() {
         startFamiliarChat(activeId);
         shellRef.current?.dismissNavMobile();
       }}
-      onToggleSidebar={() => shellRef.current?.toggleNav()}
       onOpenSettings={() => {
         shellRef.current?.dismissNavMobile();
         nextRouter.push("/settings");
@@ -1523,21 +1522,6 @@ export function Workspace() {
             }
           />
         )}
-        familiarPanelRail={showCompanionRail ? (
-          <aside className="familiar-trigger-rail familiar-trigger-rail--stacked" aria-label="Right panel tabs">
-            <button
-              type="button"
-              className="familiar-trigger-rail__toggle"
-              aria-label={railTab === "browser" ? "Toggle Browser" : "Toggle Salem"}
-              title={railTab === "browser" ? "Toggle Browser (⌘⇧B)" : "Toggle Salem (⌘⇧B)"}
-              onClick={() => openCompanionTab(railTab === "browser" ? "browser" : "salem")}
-            >
-              <span className="edge-rail-chip">
-                <Icon name="ph:cat" width={14} />
-              </span>
-            </button>
-          </aside>
-        ) : undefined}
         nav={sidebar}
         list={list}
         detail={detail}

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -50,6 +50,19 @@
   outline-offset: 1px;
 }
 
+/* Static wordmark variant — the header is no longer a collapse button (the
+   shell's floating top-left toggle owns that now), so drop the pressable
+   affordances. Left clearance for the float lives in globals.css, scoped to
+   the desktop shell (.shell-body--floats). */
+.sidebar-header--static {
+  cursor: default;
+}
+
+.sidebar-header--static:hover {
+  background: transparent;
+  border-color: transparent;
+}
+
 .sidebar-title {
   font-size: 13px;
   font-weight: 600;


### PR DESCRIPTION
Follow-up to the Codex-style floating panel toggles (#828). Now that the floating top-corner toggles own showing/hiding both side panels, this removes the redundant legacy affordances so each panel has a single control.

## Removed
- **CompanionRail** — the in-panel "Hide companion panel" button and its `cave:familiar-panel-toggle` dispatch (the shell's right float + ⌘⇧B own hiding now).
- **shell.tsx** — the now-unused `cave:familiar-panel-toggle` listener and the dead `familiarRail`/`familiarPanelRail` props.
- **workspace.tsx** — the right edge-rail tab toggle (`familiarPanelRail`) and the `onToggleSidebar` collapse handler.
- **sidebar-minimal** — the "Coven Cave" header is now a **static wordmark** (`sidebar-header--static`), not a collapse button; the floating left toggle (and ⌘B) own collapsing. `globals.css` pads the header so the float clears the wordmark on desktop.

## Kept
- The **chat-list reopen tab** — it serves the *list* panel, which the floating toggles don't cover.
- The now-unused `.familiar-trigger-rail*` CSS is left in place for a separate prune (several tests still assert it; pruning it + those assertions is follow-up cleanup).

## Tests
Updated across `shell-edge-rails`, `sidebar-minimal`, `companion-rail`, `misc-aria-fixes`, `salem`, `mobile-shell-smoke` to match the new single-control model.

## Verification
Live (prod build + Playwright, 1440px): the sidebar header is a static "Coven Cave" wordmark sitting clear of the left float, both floats are present, and there are **zero** companion collapse buttons. Full `pnpm test:app` + `pnpm test:api` + `pnpm build` + `tsc` green.

> Branched off current `main` (has #828/#833). The concurrent Delegations-removal work on `workspace.tsx`/`sidebar-minimal.tsx` is still in flight on another branch, so a routine merge-resolve may be needed if that lands first — the regions are disjoint (calls/FolderMode vs panel toggles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)