### PR TITLE
fix(ui): show only the starter's name in the session initiator badge

### DIFF
--- a/src/components/ui/session-initiator-chip.tsx
+++ b/src/components/ui/session-initiator-chip.tsx
@@ -33,7 +33,7 @@ export function SessionInitiatorChip({ initiator, iconOnly, className }: Props) 
       {iconOnly ? (
         <span className="sr-only">{tooltip}</span>
       ) : (
-        <span className="ui-initiator-chip-label">Started by {label}</span>
+        <span className="ui-initiator-chip-label">{label}</span>
       )}
     </span>
   );


### PR DESCRIPTION
## What

The session initiator chip rendered **"Started by {name}"**. Trim the visible label to just the starter's name (e.g. `Val`, `Lyra`) so the badge reads cleaner in the chat list and on the coven floor.

## Accessibility preserved

The `title` tooltip and `aria-label` still read **"Started by {name}"**, so hover context and screen-reader output are unchanged — only the on-screen chip text is shortened. The `sessionInitiatorLabel` logic (human-via-channel resolution, etc.) is untouched.

## Verification

- `src/lib/session-initiator.test.ts` (wired): pass
- `src/components/coven-floor-table.test.ts`, `src/components/chat-list-delete.test.ts` (chip-usage source-text): pass

Single-line change in `src/components/ui/session-initiator-chip.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)