### PR TITLE
fix(memory): Familiar Studio Memory tab layout — gate master-detail on container width

### DIFF
--- a/src/components/familiars-memory-master-detail.test.ts
+++ b/src/components/familiars-memory-master-detail.test.ts
@@ -13,14 +13,16 @@ assert.match(source, /Delete \{bulkDeletable\.length\} cleanable/, "bulk-delete 
 assert.ok(!/memory-list-drawer/.test(source), "old grid drawer removed");
 assert.match(source, /MemoryReaderModal path=\{expandRow\.contentPath \?\? expandRow\.path\}/, "fullscreen expand uses the resolved content path");
 
-// Responsive: panes gate on selection below xl; reader has a Back button.
-assert.match(source, /selectedRowId \? "hidden xl:flex" : "flex"/, "list pane hides below xl when a row is selected");
-assert.match(source, /selectedRowId \? "flex" : "hidden xl:flex"/, "reader wrapper hides below xl when nothing is selected");
+// Responsive: panes gate on selection below the container breakpoint; reader has a Back button.
+// Layout keys off the view's own container width (@container/memview), not the viewport,
+// so the master-detail collapses to one pane inside narrow surfaces like the Studio drawer.
+assert.match(source, /selectedRowId \? "hidden @min-\[1024px\]\/memview:flex" : "flex"/, "list pane hides below the container breakpoint when a row is selected");
+assert.match(source, /selectedRowId \? "flex" : "hidden @min-\[1024px\]\/memview:flex"/, "reader wrapper hides below the container breakpoint when nothing is selected");
 assert.match(source, /onBack=\{\(\) => setSelectedRowId\(null\)\}/, "reader receives a back-to-list handler");
 
 const reader = await readFile(new URL("./familiars-memory-reader.tsx", import.meta.url), "utf8");
 assert.match(reader, /aria-label="Back to list"/, "reader renders a Back button");
-assert.match(reader, /xl:hidden/, "Back button is hidden at xl and above");
+assert.match(reader, /@min-\[1024px\]\/memview:hidden/, "Back button is hidden at/above the container breakpoint");
 
 // Grouping: a Group control drives groupMemoryRows over the paged rows.
 assert.match(source, /value=\{groupMode\}/, "Group control is bound to groupMode");

--- a/src/components/familiars-memory-reader.tsx
+++ b/src/components/familiars-memory-reader.tsx
@@ -73,7 +73,7 @@ export function MemoryReaderPane({
               type="button"
               onClick={onBack}
               aria-label="Back to list"
-              className="focus-ring mr-1 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)] xl:hidden"
+              className="focus-ring mr-1 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)] @min-[1024px]/memview:hidden"
             >
               <Icon name="ph:arrow-left" width={13} aria-hidden />
             </button>

--- a/src/components/familiars-memory-view-rail.test.ts
+++ b/src/components/familiars-memory-view-rail.test.ts
@@ -57,8 +57,8 @@ assert.match(
 
 assert.match(
   source,
-  /xl:grid-cols-\[minmax\(0,1fr\)_minmax\(420px,560px\)\]/,
-  "List-mode container (non-compact) must use an asymmetric list/reader grid",
+  /@min-\[1024px\]\/memview:grid-cols-\[minmax\(0,1fr\)_minmax\(420px,560px\)\]/,
+  "List-mode container (non-compact) must use an asymmetric list/reader grid, gated on the view's own container width",
 );
 
 assert.doesNotMatch(

--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -342,10 +342,10 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
 
   const contentClass = compact
     ? "flex flex-col gap-4 overflow-y-auto p-4"
-    : "grid min-h-0 gap-4 p-4 xl:grid-cols-[minmax(0,1fr)_minmax(420px,560px)]";
+    : "grid min-h-0 gap-4 p-4 @min-[1024px]/memview:grid-cols-[minmax(0,1fr)_minmax(420px,560px)]";
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col bg-[var(--bg-base)]">
+    <div className="@container/memview flex min-h-0 flex-1 flex-col bg-[var(--bg-base)]">
       <div className={`shrink-0 border-b border-[var(--border-hairline)] ${compact ? "px-3 py-2" : "px-4 py-3"}`}>
         {compact ? null : (
           <div
@@ -488,7 +488,7 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
           !compact ? (
           <>
             {/* LIST PANE */}
-            <section className={`min-h-0 flex-col ${selectedRowId ? "hidden xl:flex" : "flex"}`}>
+            <section className={`min-h-0 flex-col ${selectedRowId ? "hidden @min-[1024px]/memview:flex" : "flex"}`}>
               <div className="mb-2 flex items-center justify-between gap-2">
                 <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">Memories</h3>
                 <div className="flex items-center gap-2">
@@ -545,7 +545,7 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
             </section>
 
             {/* READER PANE */}
-            <div className={`min-h-0 flex-col ${selectedRowId ? "flex" : "hidden xl:flex"}`}>
+            <div className={`min-h-0 flex-col ${selectedRowId ? "flex" : "hidden @min-[1024px]/memview:flex"}`}>
               <MemoryReaderPane
                 row={selectedRow}
                 age={selectedRow ? age(selectedRow.sortTime) : ""}


### PR DESCRIPTION
## Problem
In the **Familiar Studio → Memory** tab, the memory list/reader was badly cramped: the "N of N" count wrapped vertically, the memory rows were pushed out of view, and a horizontal scrollbar appeared.

## Root cause
`FamiliarsMemoryView`'s 2-column master-detail (and the list/reader pane + Back-button visibility) keyed off the **viewport** `xl:` breakpoint. The Studio renders the view inside a fixed ~840px drawer, but `xl:` triggers on the full browser viewport (≥1280px). So on a desktop viewport the 2-column grid activated *inside* the narrow drawer — the 420–560px reader column crushed the list column, hence the wrapping/overflow.

## Fix
Switch the responsive trigger from the viewport `xl:` breakpoint to a **CSS container query** on the view's own width: the outer wrapper becomes `@container/memview`, and the grid + panes + Back button gate on `@min-[1024px]/memview:`. Now the layout keys off the container:
- **Studio drawer (~840px) → single column** (list fills the width — bug fixed).
- **Full Memory page (~1200px) → two columns** (master-detail preserved).

## Verification
- Against the **compiled CSS** in the running app: a 840px `@container/memview` wrapper yields `grid-template-columns: 808px` (1 track); a 1200px wrapper yields `592px 560px` (2 tracks). `CSS.supports('container-type','inline-size')` = true.
- `pnpm test:app` / `test:api` / `tsc --noEmit` (0 errors) pass. Updated `familiars-memory-master-detail` + `-rail` tests to assert the container-query classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)