### PR TITLE
feat(familiars): avatar fallback chain (route + glyph) behind the direct asset link

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -40,6 +40,7 @@ const contracts: RouteContract[] = [
   { route: "/daemon/status", methods: ["GET"], kind: "json" },
   { route: "/escalations/[id]", methods: ["PATCH"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/escalations", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/familiars/[id]/avatar", methods: ["GET"], kind: "stream", pathGuard: true },
   { route: "/familiars/[id]/contract", methods: ["GET"], kind: "json", pathGuard: true },
   { route: "/familiars/[id]/icon", methods: ["PUT"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
   { route: "/familiars", methods: ["GET"], kind: "json" },

--- a/src/app/api/familiars/[id]/avatar/route.ts
+++ b/src/app/api/familiars/[id]/avatar/route.ts
@@ -1,0 +1,125 @@
+import { NextResponse } from "next/server";
+import { constants } from "node:fs";
+import { open } from "node:fs/promises";
+import sharp from "sharp";
+import { isValidFamiliarId } from "@/lib/server/familiar-id";
+import { resolveFamiliarAvatar } from "@/lib/server/familiar-avatar";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+// Generous read cap: the seeded workspace avatars are full-resolution PNGs
+// (~30MB / 4096px). We bound it so a pathological file can't be slurped whole
+// into memory before downscaling.
+const MAX_AVATAR_BYTES = 48 * 1024 * 1024;
+
+// Avatars render at 16–36px (sm/md/lg); 256px on the longest edge stays crisp
+// at 3–4× DPR while turning a ~30MB source into a few KB of WebP.
+const AVATAR_MAX_DIM = 256;
+
+type RenderedAvatar = { body: Uint8Array<ArrayBuffer>; contentType: string };
+
+// Process-lifetime cache keyed by file path + mtime, so the expensive resize
+// runs once per (avatar file version) instead of on every cold request. The
+// familiar set is tiny, so a small bound is plenty.
+const MAX_CACHE_ENTRIES = 64;
+const renderCache = new Map<string, RenderedAvatar>();
+
+function cacheGet(key: string): RenderedAvatar | undefined {
+  const hit = renderCache.get(key);
+  if (hit) {
+    // Refresh LRU recency.
+    renderCache.delete(key);
+    renderCache.set(key, hit);
+  }
+  return hit;
+}
+
+function cacheSet(key: string, value: RenderedAvatar): void {
+  renderCache.set(key, value);
+  while (renderCache.size > MAX_CACHE_ENTRIES) {
+    const oldest = renderCache.keys().next().value;
+    if (oldest === undefined) break;
+    renderCache.delete(oldest);
+  }
+}
+
+/**
+ * Serve a familiar's avatar image from its workspace:
+ *   ~/.coven/workspaces/familiars/<id>/avatars/<image>.<ext>
+ *
+ * Raster avatars are downscaled to <=256px and re-encoded as WebP so a 30MB
+ * source doesn't ship for a 36px glyph; SVGs are served as-is (already small,
+ * and vector). The `id` segment (the only user input) is slug-guarded, and the
+ * served filename is chosen from the directory listing — never from the request
+ * — so this can't read outside the avatars dir. 404 when the familiar has no
+ * avatar; the UI then falls back to the glyph.
+ */
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  if (!id || !isValidFamiliarId(id)) {
+    return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
+  }
+
+  const avatar = await resolveFamiliarAvatar(id);
+  if (!avatar) {
+    return NextResponse.json({ ok: false, error: "no avatar" }, { status: 404 });
+  }
+
+  const cacheKey = `${avatar.absPath}\0${avatar.mtimeMs}`;
+  const cached = cacheGet(cacheKey);
+  if (cached) {
+    return imageResponse(cached);
+  }
+
+  let bytes: Buffer;
+  try {
+    // O_NOFOLLOW: refuse to follow a symlink at the final path component, so a
+    // symlinked avatar file can't redirect the read outside the avatars dir.
+    const file = await open(avatar.absPath, constants.O_RDONLY | constants.O_NOFOLLOW);
+    try {
+      const st = await file.stat();
+      if (!st.isFile() || st.size > MAX_AVATAR_BYTES) {
+        return NextResponse.json({ ok: false, error: "no avatar" }, { status: 404 });
+      }
+      bytes = await file.readFile();
+    } finally {
+      await file.close();
+    }
+  } catch {
+    return NextResponse.json({ ok: false, error: "no avatar" }, { status: 404 });
+  }
+
+  let rendered: RenderedAvatar;
+  if (avatar.contentType === "image/svg+xml") {
+    // Vector source — already tiny; serve verbatim rather than rasterizing.
+    rendered = { body: new Uint8Array(bytes), contentType: "image/svg+xml" };
+  } else {
+    try {
+      const webp = await sharp(bytes)
+        .rotate() // honor EXIF orientation before resizing
+        .resize(AVATAR_MAX_DIM, AVATAR_MAX_DIM, { fit: "inside", withoutEnlargement: true })
+        .webp({ quality: 82 })
+        .toBuffer();
+      rendered = { body: new Uint8Array(webp), contentType: "image/webp" };
+    } catch {
+      // Not a decodable raster image — treat as missing rather than 500.
+      return NextResponse.json({ ok: false, error: "no avatar" }, { status: 404 });
+    }
+  }
+
+  cacheSet(cacheKey, rendered);
+  return imageResponse(rendered);
+}
+
+function imageResponse({ body, contentType }: RenderedAvatar): NextResponse {
+  return new NextResponse(body, {
+    status: 200,
+    headers: {
+      "content-type": contentType,
+      // Content is keyed by the `?v=<mtime>` the familiars list appends, so it
+      // can be cached hard and busted whenever the file changes on disk.
+      "cache-control": "private, max-age=31536000, immutable",
+    },
+  });
+}

--- a/src/components/familiar-avatar.test.ts
+++ b/src/components/familiar-avatar.test.ts
@@ -11,6 +11,8 @@ assert.match(source, /avatarImage/, "Must consume the avatarImage field");
 assert.match(source, /avatarPath/, "Must consume the workspace avatarPath field");
 assert.match(source, /convertFileSrc/, "Must link to the workspace file via Tauri's asset protocol");
 assert.match(source, /__TAURI_INTERNALS__/, "Must guard convertFileSrc behind a Tauri-runtime check");
+assert.match(source, /\/api\/familiars\/\$\{encodeURIComponent\(familiar\.id\)\}\/avatar/, "Must keep the avatar route as a universal fallback candidate");
+assert.match(source, /onError=/, "Must advance to the next candidate when an avatar src fails to load");
 assert.match(source, /FamiliarGlyph/, "Must fall back to FamiliarGlyph when no image");
 assert.match(source, /<img/, "Must render an <img> for image avatars");
 assert.match(source, /alt=/, "img must have alt text for a11y");

--- a/src/components/familiar-avatar.tsx
+++ b/src/components/familiar-avatar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { FamiliarGlyph } from "./familiar-glyph";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 
@@ -16,54 +16,68 @@ type Props = {
 };
 
 /**
- * Resolve the `<img src>` for a familiar avatar.
- *
- * A workspace avatar is an absolute `.coven` path (`avatarPath`); we link to the
- * file directly through Tauri's asset protocol (`convertFileSrc`) instead of
- * proxying bytes through an API route. That only works inside the Tauri webview,
- * so it's computed after mount — server render and any non-Tauri context fall
- * back to the Cave-local upload (`avatarImage`) if present, else the glyph.
+ * The `/api/familiars/<id>/avatar` route reads the same workspace file and
+ * downscales it. It works in any context (browser or the Tauri webview, both
+ * served by the local server), so it's the reliable fallback when the direct
+ * asset link isn't usable.
  */
-function useAvatarSrc(familiar: ResolvedFamiliar): string | undefined {
-  // `avatarImage` (a data URL) is SSR-safe and usable as the initial value; a
-  // workspace `avatarPath` resolves only client-side, so start without it.
-  const [src, setSrc] = useState<string | undefined>(
-    familiar.avatarPath ? undefined : familiar.avatarImage,
-  );
+function avatarRouteUrl(familiar: ResolvedFamiliar): string | undefined {
+  if (!familiar.avatarPath) return undefined;
+  const v = familiar.avatarVersion ? `?v=${familiar.avatarVersion}` : "";
+  return `/api/familiars/${encodeURIComponent(familiar.id)}/avatar${v}`;
+}
+
+/**
+ * Ordered `<img src>` candidates for a familiar avatar, best first. The avatar
+ * component renders the first that hasn't errored and advances on load failure:
+ *
+ *   1. Direct `.coven` file via Tauri's asset protocol (`convertFileSrc`) — the
+ *      "link straight to the path" case. Only resolvable inside the Tauri webview
+ *      and only for paths inside the asset-protocol scope, so it's computed after
+ *      mount and may be absent.
+ *   2. The `/api/familiars/<id>/avatar` route — downscales and works everywhere
+ *      (browser, or a workspace path outside the asset scope). Reliable baseline.
+ *   3. A Cave-local uploaded data URL.
+ *
+ * When all are exhausted (or none exist) the glyph renders instead.
+ */
+function useAvatarCandidates(familiar: ResolvedFamiliar): string[] {
+  const [assetUrl, setAssetUrl] = useState<string | undefined>(undefined);
 
   useEffect(() => {
-    if (!familiar.avatarPath) {
-      setSrc(familiar.avatarImage);
-      return;
-    }
+    setAssetUrl(undefined);
+    if (!familiar.avatarPath) return;
+    // convertFileSrc needs the Tauri webview runtime; skip it elsewhere (browser,
+    // SSR) and rely on the route candidate below.
+    if (typeof window === "undefined" || !("__TAURI_INTERNALS__" in window)) return;
     let cancelled = false;
     void (async () => {
       try {
-        // convertFileSrc needs the Tauri webview runtime; outside it (browser,
-        // SSR) the file isn't loadable, so degrade to the upload / glyph.
-        if (typeof window === "undefined" || !("__TAURI_INTERNALS__" in window)) {
-          if (!cancelled) setSrc(familiar.avatarImage);
-          return;
-        }
         const { convertFileSrc } = await import("@tauri-apps/api/core");
         const base = convertFileSrc(familiar.avatarPath!);
-        const url = familiar.avatarVersion ? `${base}?v=${familiar.avatarVersion}` : base;
-        if (!cancelled) setSrc(url);
+        if (!cancelled) setAssetUrl(familiar.avatarVersion ? `${base}?v=${familiar.avatarVersion}` : base);
       } catch {
-        if (!cancelled) setSrc(familiar.avatarImage);
+        // Leave assetUrl unset — the route candidate covers it.
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [familiar.avatarPath, familiar.avatarVersion, familiar.avatarImage]);
+  }, [familiar.avatarPath, familiar.avatarVersion]);
 
-  return src;
+  return useMemo(
+    () => [assetUrl, avatarRouteUrl(familiar), familiar.avatarImage].filter((s): s is string => !!s),
+    [assetUrl, familiar],
+  );
 }
 
 export function FamiliarAvatar({ familiar, size = "md", className, title }: Props) {
   const px = PX[size];
-  const src = useAvatarSrc(familiar);
+  const candidates = useAvatarCandidates(familiar);
+  // Track srcs that failed to load so an onError advances to the next candidate.
+  const [failed, setFailed] = useState<Set<string>>(() => new Set());
+  const src = candidates.find((c) => !failed.has(c));
+
   if (src) {
     return (
       <img
@@ -73,6 +87,13 @@ export function FamiliarAvatar({ familiar, size = "md", className, title }: Prop
         height={px}
         className={className ?? "inline-block rounded-sm object-cover"}
         title={title}
+        onError={() =>
+          setFailed((prev) => {
+            const next = new Set(prev);
+            next.add(src);
+            return next;
+          })
+        }
       />
     );
   }

--- a/src/lib/familiar-resolve.ts
+++ b/src/lib/familiar-resolve.ts
@@ -17,7 +17,8 @@ export type ResolvedFamiliar = Omit<Familiar, "display_name" | "role"> & {
   /**
    * Absolute path to the familiar's workspace avatar
    * (`~/.coven/workspaces/familiars/<id>/avatars/<img>`) when present. The avatar
-   * component links to it through Tauri's asset protocol. Wins over `avatarImage`.
+   * component links to it through Tauri's asset protocol, falling back to the
+   * `/api/familiars/<id>/avatar` route. Wins over `avatarImage`.
    */
   avatarPath?: string;
   /** Avatar file mtime (ms) used to cache-bust the asset URL; pairs with `avatarPath`. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,8 +23,9 @@ export type Familiar = {
    * Absolute filesystem path to the familiar's workspace avatar image
    * (`~/.coven/workspaces/familiars/<id>/avatars/<img>`). Set by `/api/familiars`
    * only when an avatar exists on disk; absent otherwise. The client links
-   * straight to this file through Tauri's asset protocol (`convertFileSrc`)
-   * rather than proxying the bytes through an API route.
+   * straight to this file through Tauri's asset protocol (`convertFileSrc`),
+   * falling back to the `GET /api/familiars/<id>/avatar` route when the asset
+   * link isn't usable (browser, or a workspace path outside the asset scope).
    */
   avatarPath?: string;
   /**


### PR DESCRIPTION
Follow-up to #837. That PR merged the direct `.coven` asset link but, due to a merge/push race, **without** the fallback commit — so `main` currently renders the glyph for any avatar the Tauri asset protocol can't load (browser context, or a workspace path outside the asset scope). This restores the fallback.

## What
Avatars render through an ordered candidate chain, advancing on `<img>` load error:
1. `convertFileSrc(avatarPath)` — direct `.coven` file link (Tauri, in-scope paths)
2. `/api/familiars/<id>/avatar` — **restored** route (downscales, path-guarded, universal)
3. Cave-local uploaded data URL
4. glyph

SSR-safe route URL paints first (no glyph flash); the webview then upgrades to the direct link, falling back automatically if it errors.

## Verification
- ✅ `tsc --noEmit`, `familiar-resolve` / `familiar-avatar` / `api-contracts` (95) / server `familiar-avatar` tests
- ✅ `next build` (verified on the prior branch; CI re-runs it here)

Cherry-picked clean onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)