### PR TITLE
chore(css): prune dead familiar-trigger-rail styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3115,90 +3115,11 @@ select {
 }
 
 /* ────────────────────────────────────────────────
-   Familiar trigger rails — slim edge columns holding the
-   left navigation toggle and right Salem toggle.
+   Edge-rail chip — the pressable chip the collapsed chat-projects
+   strip uses for its reopen tab. (The familiar trigger rails that
+   used to share it were replaced by the shell's floating panel
+   toggles.)
    ──────────────────────────────────────────────── */
-
-.familiar-trigger-rail {
-  position: relative;
-  width: 26px;
-  flex: 0 0 26px;
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  padding: 0;
-  overflow: hidden;
-  background: color-mix(in oklch, var(--bg-panel) 38%, transparent);
-  border-left: 1px solid var(--border-hairline);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  user-select: none;
-}
-
-.familiar-trigger-rail--stacked {
-  justify-content: stretch;
-  gap: 0;
-  padding-top: 0;
-}
-
-.familiar-trigger-rail::before {
-  content: "";
-  position: absolute;
-  top: 10px;
-  bottom: 10px;
-  left: 3px;
-  width: 1px;
-  border-radius: 999px;
-  background: color-mix(in oklch, var(--accent) 52%, transparent);
-  opacity: 0.82;
-  pointer-events: none;
-}
-
-.familiar-trigger-rail--left {
-  border-left: 0;
-  border-right: 1px solid var(--border-hairline);
-}
-
-.familiar-trigger-rail--left::before {
-  right: 3px;
-  left: auto;
-}
-
-.familiar-trigger-rail__toggle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex: 1 1 auto;
-  align-self: stretch;
-  width: 100%;
-  min-height: 0;
-  padding: 12px 0;
-  border-radius: 0;
-  border: 0;
-  background: transparent;
-  color: color-mix(in oklch, var(--text-secondary) 86%, var(--text-primary));
-  cursor: pointer;
-  transition: background 120ms ease, color 120ms ease;
-}
-
-.familiar-trigger-rail--stacked .familiar-trigger-rail__toggle {
-  flex: 1 1 0;
-  min-height: 0;
-}
-
-.familiar-trigger-rail__toggle:hover {
-  color: var(--text-primary);
-  background: var(--bg-hover);
-}
-
-.familiar-trigger-rail__toggle:focus-visible {
-  outline: var(--ring-width) solid var(--ring-focus);
-  outline-offset: -2px;
-}
-
-/* Chip that makes edge-rail toggles read as pressable buttons rather than
-   bare hover-revealed icons. Shared by the nav/agent trigger rails and the
-   collapsed chat-projects strip. */
 .edge-rail-chip {
   display: grid;
   place-items: center;
@@ -3212,16 +3133,6 @@ select {
     inset 0 1px 0 color-mix(in oklch, var(--text-primary) 12%, transparent),
     0 8px 16px color-mix(in oklch, black 20%, transparent);
   transition: background 120ms ease, border-color 120ms ease, box-shadow 120ms ease, transform 80ms ease;
-}
-
-.familiar-trigger-rail__toggle[aria-expanded="true"] > .edge-rail-chip {
-  color: var(--text-primary);
-  border-color: color-mix(in oklch, var(--accent-presence) 58%, var(--border-hairline));
-  background: color-mix(in oklch, var(--accent-presence) 18%, var(--bg-raised));
-  box-shadow:
-    inset 0 1px 0 color-mix(in oklch, var(--text-primary) 18%, transparent),
-    0 0 0 1px color-mix(in oklch, var(--accent-presence) 24%, transparent),
-    0 10px 18px color-mix(in oklch, black 24%, transparent);
 }
 
 button:hover > .edge-rail-chip,
@@ -5034,11 +4945,6 @@ button:active > .edge-rail-chip {
   }
   .top-bar__mobile-handoff {
     display: none;
-  }
-  /* Hide the familiar-trigger rail — its single button is now in the top
-     bar's mobile toggles, so showing both is redundant. */
-  .familiar-trigger-rail {
-    display: none !important;
   }
 }
 

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -70,21 +70,9 @@ assert.doesNotMatch(
   "the old collapsed-only left edge rail is removed from the shell",
 );
 
-assert.match(
-  css,
-  /\.familiar-trigger-rail--left \{[^}]*border-right: 1px solid var\(--border-hairline\)/,
-  "left rail variant flips the hairline to its right edge",
-);
-assert.match(
-  css,
-  /\.familiar-trigger-rail \{[^}]*width: 26px;[^}]*flex: 0 0 26px;/,
-  "edge trigger rails should be wide enough to read as intentional controls",
-);
-assert.match(
-  css,
-  /\.familiar-trigger-rail::before \{[^}]*width: 1px;[^}]*background: color-mix\(in oklch, var\(--accent\) 52%, transparent\)/,
-  "edge trigger rails should carry a subtle accent guide line",
-);
+// The edge-rail chip survives — the collapsed chat-projects strip still uses it
+// for its reopen tab. The familiar trigger-rail CSS that used to share it was
+// pruned along with the rails themselves.
 assert.match(css, /\.edge-rail-chip \{/, "edge-rail chip class exists");
 assert.match(
   css,
@@ -93,18 +81,13 @@ assert.match(
 );
 assert.match(
   css,
-  /\.familiar-trigger-rail__toggle\[aria-expanded="true"\] > \.edge-rail-chip/,
-  "expanded side-panel triggers should have an active chip treatment",
+  /button:active > \.edge-rail-chip/,
+  "edge-rail chip has a pressed state",
 );
 assert.doesNotMatch(
   css,
-  /\.familiar-trigger-rail__toggle \{[^}]*opacity: 0/,
-  "edge-rail toggles must be visible without hovering",
-);
-assert.match(
-  css,
-  /button:active > \.edge-rail-chip/,
-  "edge-rail chip has a pressed state",
+  /familiar-trigger-rail/,
+  "the dead familiar trigger-rail CSS is pruned",
 );
 
 // The right edge-rail tab toggle was retired — the shell's floating top-right
@@ -113,16 +96,6 @@ assert.doesNotMatch(
   workspace,
   /familiarPanelRail=/,
   "workspace no longer passes a right edge-rail tab toggle to the shell",
-);
-assert.match(
-  css,
-  /\.familiar-trigger-rail--stacked \{[^}]*justify-content: stretch;/,
-  "right edge stacked tabs stretch to fill the rail height",
-);
-assert.match(
-  css,
-  /\.familiar-trigger-rail--stacked \.familiar-trigger-rail__toggle \{[^}]*flex: 1 1 0;/,
-  "stacked rail toggles each fill half the rail (50/50 split)",
 );
 assert.match(
   projectSidebar,


### PR DESCRIPTION
Final follow-up to the floating panel toggles. The familiar trigger rails were replaced by the shell's floating toggles (#828) and their last JSX users removed (#838), leaving only dead CSS.

## Removed
All `.familiar-trigger-rail*` rules from `globals.css` — base, `--stacked`, `--left`, the `::before` accent guides, `__toggle` (+ hover/focus), the `[aria-expanded] > .edge-rail-chip` variant, and the mobile `display:none`. **−132 / +11 lines.**

## Kept
`.edge-rail-chip` and its `button:hover/active` states — the collapsed chat-projects strip still uses the chip for its reopen tab.

## Tests
`shell-edge-rails.test.ts`: dropped the obsolete trigger-rail CSS-existence assertions, kept the `edge-rail-chip` ones, and added a `doesNotMatch(css, /familiar-trigger-rail/)` guard so the dead CSS can't creep back.

## Verification
Zero `familiar-trigger-rail` references remain in source/CSS (only the test's absence guard mentions the string). Full `pnpm test:app` + `pnpm test:api` + `pnpm build` green. Pure dead-code removal — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)