### PR TITLE
redesign(chat-header): collapse session actions into a Codex/ChatGPT-style overflow menu

### DIFF
--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -90,19 +90,19 @@ assert.match(
 
 assert.match(
   styles,
-  /\.cave-chat-meta-line__meta\s*\{[\s\S]*?font-size:\s*12\.5px/,
-  "Header meta should read at the chat title size (12.5px), not fine print",
+  /\.cave-chat-meta-line__meta\s*\{[\s\S]*?font-size:\s*11\.5px/,
+  "Header meta is the demoted context line — a notch under the title, not fine print",
+);
+assert.doesNotMatch(
+  styles,
+  /\.cave-chat-meta-line__meta\s*\{[^}]*font-family/,
+  "Header meta reads in the chrome font (Codex/ChatGPT vocabulary), not monospace",
 );
 
-assert.match(
+assert.doesNotMatch(
   styles,
-  /\.cave-chat-cwd-pair\s*\{[\s\S]*?display:\s*inline-flex[\s\S]*?gap:\s*4px/,
-  "Header ROOT/CWD editor pair should stay compact inside the meta row",
-);
-assert.match(
-  styles,
-  /\.cave-chat-cwd-inline\s*\{[\s\S]*?width:\s*clamp\(100px,\s*12vw,\s*168px\)/,
-  "Each header ROOT/CWD editor should stay narrow inside the meta row",
+  /\.cave-chat-cwd-inline\b/,
+  "The inline project-chip picker is folded into the session overflow menu",
 );
 
 assert.doesNotMatch(
@@ -116,12 +116,12 @@ assert.doesNotMatch(
 // success refreshes the session list and navigates back.
 assert.match(
   source,
-  /aria-label="Delete chat"[\s\S]*?onClick=\{\(\) => setConfirmDelete\(true\)\}/,
-  "Header trash button only arms the confirmation — it must not delete",
+  /danger onSelect=\{\(\) => onConfirmDeleteChange\(true\)\}>\s*Delete chat/,
+  "Overflow-menu Delete only arms the confirmation — it must not delete",
 );
 assert.match(
   source,
-  /confirmDelete \?[\s\S]*?Cancel[\s\S]*?Confirm delete chat/,
+  /confirmDelete \?[\s\S]*?Cancel[\s\S]*?Confirm delete/,
   "Armed state offers explicit Cancel and Delete actions",
 );
 assert.match(

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -228,8 +228,13 @@ assert.match(
 
 assert.match(
   source,
-  /<div className="cave-chat-session-actions">[\s\S]*<ChatFindBar[\s\S]*<InlineProjectField[\s\S]*<VoiceCallButton[\s\S]*Debug session[\s\S]*Delete chat/,
-  "Open chat header actions should sit in one compact session action cluster",
+  /<div className="cave-chat-session-actions">[\s\S]*<ChatFindBar[\s\S]*<SessionOverflowMenu/,
+  "Open chat header actions collapse to a find bar plus a single overflow menu",
+);
+assert.match(
+  source,
+  /function SessionOverflowMenu[\s\S]*Debug session[\s\S]*Delete chat/,
+  "Secondary session actions (project, voice, debug, delete) live in the overflow menu",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -36,7 +36,7 @@ import { useFocusTrap } from "@/lib/use-focus-trap";
 import { DebugPane } from "@/components/debug-pane";
 import { ChatModelControl } from "@/components/chat-model-control";
 import { clearChatDebugState, publishChatDebugState } from "@/lib/chat-debug-store";
-import { VoiceCallButton } from "./voice-call-button";
+import { Popover, PopoverBody, PopoverItem, PopoverLabel, PopoverSeparator } from "@/components/ui/popover";
 import { VoiceCallOverlay } from "./voice-call-overlay";
 import { CsvImportModal } from "./csv-import-modal";
 import { looksLikeCsv } from "@/lib/csv-import";
@@ -591,35 +591,124 @@ function ChatEmptyState({
   );
 }
 
-function InlineProjectField({
+/** Codex/ChatGPT-style overflow menu. Collapses the session's secondary
+ *  controls — project switch, voice call, debug, delete — into a single kebab
+ *  so the header reads as title + quiet metadata instead of a row of competing
+ *  icons. Find stays inline (one-click, frequently used); everything else lives
+ *  one click away here. */
+function SessionOverflowMenu({
+  projects,
   projectId,
   onProjectChange,
-  projects,
+  familiar,
+  voiceActive,
+  onOpenVoice,
+  onOpenDebug,
+  onDelete,
+  deleting,
+  confirmDelete,
+  onConfirmDeleteChange,
 }: {
+  projects: CaveProject[];
   projectId: string | null;
   onProjectChange: (value: string) => void;
-  projects: CaveProject[];
+  familiar: Familiar;
+  voiceActive: boolean;
+  onOpenVoice: () => void;
+  onOpenDebug: () => void;
+  onDelete: () => void;
+  deleting: boolean;
+  confirmDelete: boolean;
+  onConfirmDeleteChange: (next: boolean) => void;
 }) {
-  const project = (projectId ? chatProjectById(projectId, projects) ?? projects[0] : projects[0]) ?? null;
-  if (!project) return null;
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const activeProject = (projectId ? chatProjectById(projectId, projects) ?? projects[0] : projects[0]) ?? null;
+  const voiceConfigured = Boolean(familiar.voiceProvider);
+
+  const close = () => {
+    setOpen(false);
+    onConfirmDeleteChange(false);
+  };
+
   return (
-    <div className="cave-chat-cwd-pair" title={project.root}>
-      <label className="cave-chat-cwd-inline focus-within:border-[var(--border-strong)]">
-        <Icon name="ph:folder-open" width={11} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
-        <select
-          value={project.id}
-          onChange={(e) => onProjectChange(e.target.value)}
-          aria-label="Project for this chat"
-          className="min-w-0 flex-1 bg-transparent outline-none"
-        >
-          {projects.map((entry) => (
-            <option key={entry.id} value={entry.id}>
-              {entry.name}
-            </option>
-          ))}
-        </select>
-      </label>
-    </div>
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="focus-ring"
+        aria-label="Session options"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title="Session options"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <Icon name="ph:dots-three-vertical" width={15} aria-hidden />
+      </button>
+      <Popover
+        open={open}
+        onOpenChange={(next) => (next ? setOpen(true) : close())}
+        anchorRef={triggerRef}
+        placement="bottom-end"
+        minWidth={216}
+      >
+        <PopoverBody>
+          {projects.length > 1 ? (
+            <>
+              <PopoverLabel>Project</PopoverLabel>
+              {projects.map((entry) => (
+                <PopoverItem
+                  key={entry.id}
+                  icon={entry.id === activeProject?.id ? "ph:check" : "ph:folder"}
+                  active={entry.id === activeProject?.id}
+                  onSelect={() => {
+                    onProjectChange(entry.id);
+                    close();
+                  }}
+                >
+                  {entry.name}
+                </PopoverItem>
+              ))}
+              <PopoverSeparator />
+            </>
+          ) : null}
+          <PopoverItem
+            icon="ph:phone"
+            disabled={!voiceConfigured || voiceActive}
+            onSelect={() => {
+              onOpenVoice();
+              close();
+            }}
+          >
+            {voiceConfigured ? `Call ${familiar.display_name}` : "Voice — set up in Studio"}
+          </PopoverItem>
+          <PopoverItem
+            icon="ph:bug-bold"
+            onSelect={() => {
+              onOpenDebug();
+              close();
+            }}
+          >
+            Debug session
+          </PopoverItem>
+          <PopoverSeparator />
+          {confirmDelete ? (
+            <>
+              <PopoverItem icon="ph:x" onSelect={() => onConfirmDeleteChange(false)}>
+                Cancel
+              </PopoverItem>
+              <PopoverItem icon="ph:trash" danger disabled={deleting} onSelect={() => onDelete()}>
+                {deleting ? "Deleting…" : "Confirm delete"}
+              </PopoverItem>
+            </>
+          ) : (
+            <PopoverItem icon="ph:trash" danger onSelect={() => onConfirmDeleteChange(true)}>
+              Delete chat
+            </PopoverItem>
+          )}
+        </PopoverBody>
+      </Popover>
+    </>
   );
 }
 
@@ -2900,57 +2989,19 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               />
             ) : null}
             {sessionId && (
-              <>
-                <InlineProjectField
-                  projectId={projectIdDraft}
-                  onProjectChange={setProjectIdDraft}
-                  projects={projects}
-                />
-                <VoiceCallButton
-                  familiar={familiar}
-                  callActive={voiceCallOpen}
-                  onOpen={() => setVoiceCallOpen(true)}
-                />
-                <button
-                  type="button"
-                  className="focus-ring inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]"
-                  title="Debug session"
-                  aria-label="Debug session"
-                  onClick={openDebug}
-                >
-                  <Icon name="ph:bug-bold" width={12} aria-hidden />
-                </button>
-                {confirmDelete ? (
-                  <span className="inline-flex shrink-0 items-center gap-1 text-[10px]">
-                    <button
-                      type="button"
-                      className="focus-ring rounded border border-[var(--border-hairline)] px-1.5 py-0.5 text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)]"
-                      onClick={() => setConfirmDelete(false)}
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      type="button"
-                      aria-label="Confirm delete chat"
-                      className="focus-ring rounded border border-[color-mix(in_oklch,var(--color-danger)_45%,transparent)] bg-[color-mix(in_oklch,var(--color-danger)_14%,transparent)] px-1.5 py-0.5 text-[var(--color-danger)] transition-colors disabled:opacity-40"
-                      onClick={() => void deleteChat()}
-                      disabled={deleting}
-                    >
-                      {deleting ? "Deleting…" : "Delete"}
-                    </button>
-                  </span>
-                ) : (
-                  <button
-                    type="button"
-                    className="focus-ring inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-[var(--text-muted)] transition-colors hover:text-[var(--color-danger)]"
-                    title="Delete chat"
-                    aria-label="Delete chat"
-                    onClick={() => setConfirmDelete(true)}
-                  >
-                    <Icon name="ph:trash" width={12} aria-hidden />
-                  </button>
-                )}
-              </>
+              <SessionOverflowMenu
+                projects={projects}
+                projectId={projectIdDraft}
+                onProjectChange={setProjectIdDraft}
+                familiar={familiar}
+                voiceActive={voiceCallOpen}
+                onOpenVoice={() => setVoiceCallOpen(true)}
+                onOpenDebug={openDebug}
+                onDelete={() => void deleteChat()}
+                deleting={deleting}
+                confirmDelete={confirmDelete}
+                onConfirmDeleteChange={setConfirmDelete}
+              />
             )}
           </div>
         </MetaLine>

--- a/src/components/task-chat-cwd.test.ts
+++ b/src/components/task-chat-cwd.test.ts
@@ -46,12 +46,12 @@ assert.match(
 );
 assert.match(
   chatView,
-  /function InlineProjectField[\s\S]*aria-label="Project for this chat"/,
-  "Active chats expose a compact project selector in the header",
+  /function SessionOverflowMenu[\s\S]*projects\.map\(\(entry\) => \([\s\S]*onSelect=\{\(\) => \{\s*onProjectChange\(entry\.id\)/,
+  "Active chats expose project switching through the session overflow menu",
 );
 assert.match(
   chatView,
-  /sessionId && \(\s*<>\s*<InlineProjectField[\s\S]*projectId=\{projectIdDraft\}[\s\S]*onProjectChange=\{setProjectIdDraft\}/,
+  /sessionId && \(\s*<SessionOverflowMenu[\s\S]*projectId=\{projectIdDraft\}[\s\S]*onProjectChange=\{setProjectIdDraft\}/,
   "The active-chat project selector shares the same draft used by send",
 );
 assert.match(

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1631,10 +1631,11 @@ details[open] > .cave-tool-summary::before {
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--text-muted);
-  font-family: var(--font-mono);
-  /* Match the chat title (.cave-chat-title-input, 12.5px) so the runtime/cwd
-     metadata reads at the same size as the title rather than as fine print. */
-  font-size: 12.5px;
+  /* Quiet UI-sans secondary text (Codex/ChatGPT vocabulary) rather than a
+     monospace "code" string — the title is the hero, this is the demoted
+     context line, so it reads a notch smaller and in the chrome font. */
+  font-size: 11.5px;
+  letter-spacing: 0.01em;
 }
 
 /* CHAT-D3-06: ticking elapsed inside the streaming meta line. Tabular digits
@@ -1921,54 +1922,6 @@ details[open] > .cave-tool-summary::before {
   line-height: 1.35;
 }
 
-.cave-chat-cwd-pair {
-  display: inline-flex;
-  min-width: 0;
-  flex: 0 1 auto;
-  align-items: center;
-  gap: 4px;
-}
-
-.cave-chat-cwd-inline {
-  display: inline-flex;
-  width: clamp(100px, 12vw, 168px);
-  min-width: 0;
-  flex: 0 1 auto;
-  align-items: center;
-  gap: 4px;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  background: transparent;
-  padding: 1px 6px;
-  color: var(--text-secondary);
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  font-weight: 400;
-  line-height: 1;
-  letter-spacing: 0;
-}
-
-.cave-chat-cwd-inline:hover,
-.cave-chat-cwd-inline:focus-within {
-  border-color: color-mix(in oklch, var(--border-strong) 74%, transparent);
-  background: color-mix(in oklch, var(--bg-hover) 64%, transparent);
-}
-
-/* The folder icon is the project picker's only affordance — hide the native
-   select chevron, which otherwise overlaps the truncated project name in the
-   narrow chip (WebKit webview needs the -webkit- prefix). */
-.cave-chat-cwd-inline select {
-  appearance: none;
-  -webkit-appearance: none;
-  color: inherit;
-  font: inherit;
-  letter-spacing: inherit;
-}
-
-.cave-chat-cwd-inline option {
-  font: inherit;
-}
-
 .cave-chat-session-actions {
   display: inline-flex;
   min-width: 0;
@@ -1982,8 +1935,7 @@ details[open] > .cave-tool-summary::before {
   display: none;
 }
 
-.cave-chat-session-actions > .focus-ring:not(.cave-chat-find):not(.cave-chat-cwd-pair),
-.cave-chat-session-actions .voice-call-button {
+.cave-chat-session-actions > .focus-ring:not(.cave-chat-find) {
   display: inline-grid;
   width: 24px;
   height: 24px;
@@ -2000,8 +1952,7 @@ details[open] > .cave-tool-summary::before {
     color var(--duration-fast) var(--ease-standard);
 }
 
-.cave-chat-session-actions > .focus-ring:not(.cave-chat-find):not(.cave-chat-cwd-pair):hover:not(:disabled),
-.cave-chat-session-actions .voice-call-button:hover:not(:disabled) {
+.cave-chat-session-actions > .focus-ring:not(.cave-chat-find):hover:not(:disabled) {
   border-color: color-mix(in oklch, var(--border-strong) 74%, transparent);
   background: color-mix(in oklch, var(--bg-hover) 64%, transparent);
   color: var(--text-primary);


### PR DESCRIPTION
## What

Full redesign of the open-session chat header for a world-class, minimalist hierarchy in the Codex / ChatGPT idiom.

The meta row had no hierarchy: a bold title competed with a monospace metadata string and a **seven-control action cluster** (find · project chip · voice · debug · delete), all at equal visual weight.

**Before:** `← Title …  claude · openclaw-local · ~/…/coven-cave · 5s  ⌕  📁 Coven Cave  ☎  ⚙  🗑`
**After:** `← Title …  ✎  claude · openclaw-local · 📁~/…/coven-cave · 5s  ⌕  ⋮`

## Changes

- **Title is the hero** — metadata demoted to quiet UI-sans secondary text (11.5px, dropped monospace) so it reads as the context line, not a second headline.
- **New `SessionOverflowMenu`** (built on the existing `Popover` primitives) collapses project switch / voice / debug / delete into a single `⋮` kebab. Find stays inline (one-click, frequently used).
  - Project switcher lists projects with the active one checked.
  - Voice item disabled + explained when no provider is configured.
  - Two-step delete confirm preserved (Cancel / Confirm inside the menu).
- Removed the now-dead `InlineProjectField` + `.cave-chat-cwd-*` CSS and simplified the redundant action-button selectors.
- Updated the four source-text tests that pinned the old layout.

## Verification

- Driven live in a real browser — header, overflow menu, and full-context render correctly (project list checks the active project; voice correctly disabled).
- `pnpm test:app` green (full suite), `tsc --noEmit` clean.
- `test:api` untouched (no server/route changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)