### PR TITLE
feat(chat): float the right-panel expand toggle beside the side-panel trigger

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3253,9 +3253,11 @@ button:active > .edge-rail-chip {
 
 .shell-panel-float {
   position: absolute;
-  /* Vertically centered on the sidebar header row so the toggle reads as part
-     of that row rather than floating above it. */
-  top: 18px;
+  /* Vertically centered on the side-panel header row — the 38px Inspector/Debug/
+     Changes tab strip that sits directly below the ~45px chat scope-tabs header.
+     The trigger + expand toggle read as part of that header rather than floating
+     above it; the left nav toggle is moved to the same row to stay level. */
+  top: 50px;
   z-index: 40;
   display: grid;
   place-items: center;
@@ -3280,6 +3282,20 @@ button:active > .edge-rail-chip {
 
 .shell-panel-float--right {
   right: 8px;
+}
+
+/* Expand-to-cover toggle: pinned one button-width + gap to the left of the
+   side-panel trigger (8 + 28 + 8). Hidden until a chat right panel is actually
+   open, and re-hidden while expanded (the in-panel Restore button takes over). */
+.shell-panel-float--expand {
+  right: 44px;
+  display: none;
+}
+:root[data-right-panel-open] .shell-panel-float--expand {
+  display: grid;
+}
+:root[data-right-panel-expanded] .shell-panel-float--expand {
+  display: none;
 }
 
 /* The Phosphor sidebar glyph points at a left panel; mirror it on the right

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -424,6 +424,28 @@ export function ChatSurface({
     return () => window.removeEventListener("keydown", onKey);
   }, [rightExpanded]);
 
+  // The expand affordance lives in the shell's floating toggle cluster
+  // (.shell-panel-float--expand), a different subtree, so it reaches the expand
+  // state through a window event — the same bridge pattern as cave:inspector-open.
+  // The reset effect above clears rightExpanded if the panel closes, so this is
+  // safe to fire unconditionally.
+  useEffect(() => {
+    const onExpand = () => setRightExpanded(true);
+    window.addEventListener("cave:right-panel-expand", onExpand);
+    return () => window.removeEventListener("cave:right-panel-expand", onExpand);
+  }, []);
+
+  // Flag right-panel-open on the document root so the shell's floating expand
+  // toggle (in shell.tsx, outside this subtree) shows only when there's actually
+  // a panel to expand. Mirrors the desktop placement: conversation scope only.
+  useEffect(() => {
+    const root = document.documentElement;
+    const open = rightPanel !== null && !isMobile && scope === "conversation";
+    if (open) root.setAttribute("data-right-panel-open", "");
+    else root.removeAttribute("data-right-panel-open");
+    return () => root.removeAttribute("data-right-panel-open");
+  }, [rightPanel, isMobile, scope]);
+
   // While the right panel is expanded it covers the chat surface, but the
   // shell's right edge-rail float (.shell-panel-float--right, z-40) sits above
   // the overlay's trapped z-index and intercepts clicks on the panel's
@@ -559,9 +581,7 @@ export function ChatSurface({
                       onCreateReminder={onCreateReminder}
                       onOpenInboxItem={onOpenInboxItem}
                       onInboxItemChanged={onInboxItemChanged}
-                      allowExpand
                       expanded={false}
-                      onToggleExpand={() => setRightExpanded(true)}
                     />
                   )}
                 </Panel>

--- a/src/components/right-panel-expand.test.ts
+++ b/src/components/right-panel-expand.test.ts
@@ -20,4 +20,43 @@ assert.match(src, /chat-right-expanded/, "expanded overlay container");
 // attribute + CSS) so it can't intercept clicks on the top-right Close button.
 assert.match(src, /data-right-panel-expanded/, "flags expanded state on the document root");
 
+// The expand affordance is a floating toggle pinned just left of the side-panel
+// trigger in the shell, not an in-header button. ChatSurface bridges it via a
+// window event and flags right-panel-open on the root so the float can show only
+// when there is a panel to expand.
+assert.match(
+  src,
+  /addEventListener\("cave:right-panel-expand"/,
+  "ChatSurface listens for the shell float's expand event",
+);
+assert.match(
+  src,
+  /data-right-panel-open/,
+  "ChatSurface flags right-panel-open on the root for the shell float's visibility",
+);
+
+const shell = readFileSync(new URL("./shell.tsx", import.meta.url), "utf8");
+assert.match(
+  shell,
+  /shell-panel-float--expand/,
+  "shell renders the floating expand toggle",
+);
+assert.match(
+  shell,
+  /dispatchEvent\(new CustomEvent\("cave:right-panel-expand"\)\)/,
+  "the expand float dispatches the bridge event",
+);
+
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+assert.match(
+  css,
+  /\[data-right-panel-open\]\s*\.shell-panel-float--expand/,
+  "expand float is shown only when a right panel is open",
+);
+assert.match(
+  css,
+  /\[data-right-panel-expanded\]\s*\.shell-panel-float--expand[\s\S]*?display:\s*none/,
+  "expand float is hidden again while the panel is expanded",
+);
+
 console.log("right-panel-expand.test.ts: ok");

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -521,16 +521,31 @@ function ShellInner({
         <Icon name={navOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={15} />
       </button>
       {hasFamiliar ? (
-        <button
-          type="button"
-          className={`shell-panel-float shell-panel-float--right focus-ring${familiarOpen ? " shell-panel-float--active" : ""}`}
-          aria-label={familiarOpen ? "Hide side panel" : "Show side panel"}
-          aria-expanded={familiarOpen}
-          title={familiarOpen ? `Hide side panel (${rightPanelShortcutLabel})` : `Show side panel (${rightPanelShortcutLabel})`}
-          onClick={toggleRightPanel}
-        >
-          <Icon name={familiarOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={15} />
-        </button>
+        <>
+          {/* Expand-to-cover toggle, pinned just left of the side-panel trigger.
+              CSS keeps it hidden until a chat right panel is actually open
+              (:root[data-right-panel-open]) and re-hides it while expanded. It
+              reaches the chat surface's expand state via a window event. */}
+          <button
+            type="button"
+            className="shell-panel-float shell-panel-float--expand focus-ring"
+            aria-label="Expand side panel"
+            title="Expand side panel"
+            onClick={() => window.dispatchEvent(new CustomEvent("cave:right-panel-expand"))}
+          >
+            <Icon name="ph:arrows-out-simple" width={14} />
+          </button>
+          <button
+            type="button"
+            className={`shell-panel-float shell-panel-float--right focus-ring${familiarOpen ? " shell-panel-float--active" : ""}`}
+            aria-label={familiarOpen ? "Hide side panel" : "Show side panel"}
+            aria-expanded={familiarOpen}
+            title={familiarOpen ? `Hide side panel (${rightPanelShortcutLabel})` : `Show side panel (${rightPanelShortcutLabel})`}
+            onClick={toggleRightPanel}
+          >
+            <Icon name={familiarOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={15} />
+          </button>
+        </>
       ) : null}
     </>
   ) : null;


### PR DESCRIPTION
## What

Moves the right-panel **expand-to-cover** affordance (#829) out of the cramped Inspector/Debug header and into the shell's floating toggle cluster — pinned just **left of the side-panel trigger** — and aligns the floating toggles with the side-panel header row.

## How

- **New `.shell-panel-float--expand`** button in `shell.tsx`, one button-width + gap left of the side-panel trigger. It dispatches a `cave:right-panel-expand` window event.
- **`chat-surface.tsx`** listens for that event and expands; it also flags `data-right-panel-open` on the document root so the float shows only when a chat right panel is actually open, and re-hides while expanded (the in-panel **Restore** button takes over there — same bridge pattern as the existing `data-right-panel-expanded`). The in-header expand button is no longer rendered on the inline panel.
- **`globals.css`**: positions the expand float at `right:44px`, gates its visibility on `[data-right-panel-open]`, hides it under `[data-right-panel-expanded]`, and moves `.shell-panel-float` from `top:18px` → `top:50px` so the left nav toggle, the expand toggle, and the side-panel trigger all sit level with the 38px side-panel header.

## Verification (in-app, 1440×900)

Drove the running app, opened the right panel, and measured bounding boxes across two runs (stable):

- expand float **36px left** of the trigger, same top ✅
- expand / left / trigger centerY **= side-panel header centerY (Δ 0px)** ✅
- click expand → panel covers the surface, `data-right-panel-expanded` set, expand+trigger floats hidden, **Restore** button present ✅

Added source-text coverage in `right-panel-expand.test.ts` for the float, the event bridge, the open-flag, and the show/hide CSS. `tsc` clean; `shell-edge-rails`, `chat-surface`, `right-sidebar-fit`, `misc-aria-fixes`, `right-panel-expand` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)