### PR TITLE
revert(familiars): always serve avatars via the downscaled route

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,13 +13,7 @@
     "windows": [],
     "withGlobalTauri": true,
     "security": {
-      "csp": null,
-      "assetProtocol": {
-        "enable": true,
-        "scope": [
-          "$HOME/.coven/workspaces/familiars/*/avatars/*"
-        ]
-      }
+      "csp": null
     }
   },
   "plugins": {

--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -34,11 +34,10 @@ export async function GET() {
   // glyph picker uses as the starting value. The Cave-local override store
   // (`cave-glyph-overrides.ts`) wins on render when the user picks something.
   //
-  // `avatarPath` is the absolute path to the workspace avatar
-  // (.../familiars/<id>/avatars/<img>) when one exists; the client links to it
-  // directly via Tauri's asset protocol. `avatarVersion` (file mtime) cache-busts
-  // the asset URL so an updated image shows without a restart. Familiars with no
-  // on-disk avatar omit both and render the glyph instead.
+  // `avatarUrl` points at the workspace avatar (.../familiars/<id>/avatars/<img>)
+  // when one exists, cache-busted by the file mtime so an updated image shows
+  // without a hard refresh. Familiars with no on-disk avatar omit it and render
+  // the glyph instead.
   const familiars = await Promise.all(
     (res.data ?? []).map(async (f) => {
       const binding = bindingFor(config, f.id);
@@ -51,8 +50,9 @@ export async function GET() {
         voiceProvider: binding.voiceProvider,
         voiceModel: binding.voiceModel,
         voiceName: binding.voiceName,
-        avatarPath: avatar?.absPath,
-        avatarVersion: avatar ? Math.round(avatar.mtimeMs) : undefined,
+        avatarUrl: avatar
+          ? `/api/familiars/${encodeURIComponent(f.id)}/avatar?v=${Math.round(avatar.mtimeMs)}`
+          : undefined,
       };
     }),
   );

--- a/src/components/familiar-avatar.test.ts
+++ b/src/components/familiar-avatar.test.ts
@@ -8,11 +8,6 @@ assert.match(source, /export function FamiliarAvatar/, "Must export FamiliarAvat
 assert.match(source, /familiar/, "Must accept a familiar prop");
 assert.match(source, /size/, "Must accept a size prop");
 assert.match(source, /avatarImage/, "Must consume the avatarImage field");
-assert.match(source, /avatarPath/, "Must consume the workspace avatarPath field");
-assert.match(source, /convertFileSrc/, "Must link to the workspace file via Tauri's asset protocol");
-assert.match(source, /__TAURI_INTERNALS__/, "Must guard convertFileSrc behind a Tauri-runtime check");
-assert.match(source, /\/api\/familiars\/\$\{encodeURIComponent\(familiar\.id\)\}\/avatar/, "Must keep the avatar route as a universal fallback candidate");
-assert.match(source, /onError=/, "Must advance to the next candidate when an avatar src fails to load");
 assert.match(source, /FamiliarGlyph/, "Must fall back to FamiliarGlyph when no image");
 assert.match(source, /<img/, "Must render an <img> for image avatars");
 assert.match(source, /alt=/, "img must have alt text for a11y");

--- a/src/components/familiar-avatar.tsx
+++ b/src/components/familiar-avatar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
 import { FamiliarGlyph } from "./familiar-glyph";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 
@@ -15,85 +14,17 @@ type Props = {
   title?: string;
 };
 
-/**
- * The `/api/familiars/<id>/avatar` route reads the same workspace file and
- * downscales it. It works in any context (browser or the Tauri webview, both
- * served by the local server), so it's the reliable fallback when the direct
- * asset link isn't usable.
- */
-function avatarRouteUrl(familiar: ResolvedFamiliar): string | undefined {
-  if (!familiar.avatarPath) return undefined;
-  const v = familiar.avatarVersion ? `?v=${familiar.avatarVersion}` : "";
-  return `/api/familiars/${encodeURIComponent(familiar.id)}/avatar${v}`;
-}
-
-/**
- * Ordered `<img src>` candidates for a familiar avatar, best first. The avatar
- * component renders the first that hasn't errored and advances on load failure:
- *
- *   1. Direct `.coven` file via Tauri's asset protocol (`convertFileSrc`) — the
- *      "link straight to the path" case. Only resolvable inside the Tauri webview
- *      and only for paths inside the asset-protocol scope, so it's computed after
- *      mount and may be absent.
- *   2. The `/api/familiars/<id>/avatar` route — downscales and works everywhere
- *      (browser, or a workspace path outside the asset scope). Reliable baseline.
- *   3. A Cave-local uploaded data URL.
- *
- * When all are exhausted (or none exist) the glyph renders instead.
- */
-function useAvatarCandidates(familiar: ResolvedFamiliar): string[] {
-  const [assetUrl, setAssetUrl] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    setAssetUrl(undefined);
-    if (!familiar.avatarPath) return;
-    // convertFileSrc needs the Tauri webview runtime; skip it elsewhere (browser,
-    // SSR) and rely on the route candidate below.
-    if (typeof window === "undefined" || !("__TAURI_INTERNALS__" in window)) return;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const { convertFileSrc } = await import("@tauri-apps/api/core");
-        const base = convertFileSrc(familiar.avatarPath!);
-        if (!cancelled) setAssetUrl(familiar.avatarVersion ? `${base}?v=${familiar.avatarVersion}` : base);
-      } catch {
-        // Leave assetUrl unset — the route candidate covers it.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [familiar.avatarPath, familiar.avatarVersion]);
-
-  return useMemo(
-    () => [assetUrl, avatarRouteUrl(familiar), familiar.avatarImage].filter((s): s is string => !!s),
-    [assetUrl, familiar],
-  );
-}
-
 export function FamiliarAvatar({ familiar, size = "md", className, title }: Props) {
   const px = PX[size];
-  const candidates = useAvatarCandidates(familiar);
-  // Track srcs that failed to load so an onError advances to the next candidate.
-  const [failed, setFailed] = useState<Set<string>>(() => new Set());
-  const src = candidates.find((c) => !failed.has(c));
-
-  if (src) {
+  if (familiar.avatarImage) {
     return (
       <img
-        src={src}
+        src={familiar.avatarImage}
         alt={familiar.display_name}
         width={px}
         height={px}
         className={className ?? "inline-block rounded-sm object-cover"}
         title={title}
-        onError={() =>
-          setFailed((prev) => {
-            const next = new Set(prev);
-            next.add(src);
-            return next;
-          })
-        }
       />
     );
   }

--- a/src/lib/familiar-resolve.test.ts
+++ b/src/lib/familiar-resolve.test.ts
@@ -47,35 +47,6 @@ const base = {
   assert.equal(r.glyph.name, "ph:wand-fill");
 }
 
-// Workspace avatar path + version flow through to the resolved familiar
-{
-  const r = resolveFamiliar(
-    { ...base, avatarPath: "/Users/x/.coven/workspaces/familiars/cody/avatars/cody.png", avatarVersion: 1234 },
-    { archived: false },
-  );
-  assert.equal(r.avatarPath, "/Users/x/.coven/workspaces/familiars/cody/avatars/cody.png");
-  assert.equal(r.avatarVersion, 1234);
-}
-
-// Workspace avatar and a Cave-local upload coexist: both are exposed (the avatar
-// component prefers the workspace path), and a missing workspace avatar leaves
-// only the upload.
-{
-  const both = resolveFamiliar(
-    { ...base, avatarPath: "/ws/cody/avatars/cody.png", avatarVersion: 1 },
-    { image: { dataUrl: "data:image/png;base64,AAA", mime: "image/png", updatedAt: "2026-06-08T00:00:00Z" }, archived: false },
-  );
-  assert.equal(both.avatarPath, "/ws/cody/avatars/cody.png");
-  assert.equal(both.avatarImage, "data:image/png;base64,AAA");
-
-  const uploadOnly = resolveFamiliar(base, {
-    image: { dataUrl: "data:image/png;base64,BBB", mime: "image/png", updatedAt: "2026-06-08T00:00:00Z" },
-    archived: false,
-  });
-  assert.equal(uploadOnly.avatarPath, undefined);
-  assert.equal(uploadOnly.avatarImage, "data:image/png;base64,BBB");
-}
-
 // Glyph override wins
 {
   const r = resolveFamiliar(base, { glyphOverride: "ph:cat-fill", archived: false });

--- a/src/lib/familiar-resolve.ts
+++ b/src/lib/familiar-resolve.ts
@@ -15,18 +15,10 @@ export type ResolvedFamiliar = Omit<Familiar, "display_name" | "role"> & {
   /** Always non-empty; falls back to var(--accent-presence). */
   color: string;
   /**
-   * Absolute path to the familiar's workspace avatar
-   * (`~/.coven/workspaces/familiars/<id>/avatars/<img>`) when present. The avatar
-   * component links to it through Tauri's asset protocol, falling back to the
-   * `/api/familiars/<id>/avatar` route. Wins over `avatarImage`.
-   */
-  avatarPath?: string;
-  /** Avatar file mtime (ms) used to cache-bust the asset URL; pairs with `avatarPath`. */
-  avatarVersion?: number;
-  /**
-   * Cave-local uploaded data URL — the fallback avatar source when the familiar
-   * has no workspace avatar on disk. Undefined when neither exists, in which case
-   * the glyph renders instead.
+   * Avatar image source: the familiar's workspace avatar URL (`base.avatarUrl`,
+   * served from `~/.coven/workspaces/familiars/<id>/avatars/`) when present,
+   * else a Cave-local uploaded data URL as fallback. Undefined when neither
+   * exists — the glyph renders instead.
    */
   avatarImage?: string;
   /** Resolved glyph for fallback rendering when no image is set. */
@@ -52,11 +44,9 @@ export function resolveFamiliar(base: Familiar, ctx: ResolveContext): ResolvedFa
     description: ov.description ?? base.description,
     color: ov.color ?? "var(--accent-presence)",
     // The familiar's workspace avatar (.../familiars/<id>/avatars/<img>) is the
-    // source of truth and always wins; a Cave-local upload (`avatarImage`) is
-    // only the fallback when the familiar has no workspace avatar on disk.
-    avatarPath: base.avatarPath,
-    avatarVersion: base.avatarVersion,
-    avatarImage: ctx.image?.dataUrl,
+    // source of truth and always wins; a Cave-local upload is only the fallback
+    // when the familiar has no workspace avatar on disk.
+    avatarImage: base.avatarUrl ?? ctx.image?.dataUrl,
     glyph: resolveFamiliarGlyph(
       { id: base.id, icon: base.icon, emoji: base.emoji, role: ov.role ?? base.role },
       glyphOverrides,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,19 +20,12 @@ export type Familiar = {
    */
   icon?: string;
   /**
-   * Absolute filesystem path to the familiar's workspace avatar image
-   * (`~/.coven/workspaces/familiars/<id>/avatars/<img>`). Set by `/api/familiars`
-   * only when an avatar exists on disk; absent otherwise. The client links
-   * straight to this file through Tauri's asset protocol (`convertFileSrc`),
-   * falling back to the `GET /api/familiars/<id>/avatar` route when the asset
-   * link isn't usable (browser, or a workspace path outside the asset scope).
+   * URL of the familiar's workspace avatar image
+   * (`~/.coven/workspaces/familiars/<id>/avatars/<img>`), served by
+   * `GET /api/familiars/{id}/avatar` and cache-busted by file mtime. Set by
+   * `/api/familiars` only when an avatar exists on disk; absent otherwise.
    */
-  avatarPath?: string;
-  /**
-   * Avatar file mtime in ms — appended to the asset URL as `?v=` so an updated
-   * image busts the webview cache without a restart.
-   */
-  avatarVersion?: number;
+  avatarUrl?: string;
   // CovenCave-side enrichment from cave-config.json
   harness?: string;
   model?: string;


### PR DESCRIPTION
Reverses the direct Tauri asset-protocol avatar link (#837/#841) in favor of **always serving avatars through the downscaled `/api/familiars/<id>/avatar` route**.

## Why
Runtime testing (`tauri dev`) confirmed the route + data path work, but also showed the direct asset link loads the **full-resolution source** — e.g. cody's avatar is a **28.9 MB / 4096px PNG** — into the webview for a ≤36px glyph. The route serves a **14 KB / 256px WebP** instead. Not worth the asset-protocol surface or its per-location scope limits.

## Changes
- Contract reverted to `avatarUrl` (the route URL); `avatarPath`/`avatarVersion` removed.
- `FamiliarAvatar` back to the simple `<img src={avatarImage}>` — no `convertFileSrc`, no candidate chain.
- Removed the `assetProtocol` config (webview no longer needs filesystem access).
- Kept: the downscaling route + its api-contract entry + the version bump.

Restored the 6 avatar files to their exact pre-#837 original; one surgical edit to `tauri.conf.json`. `+22 / −148`.

## Verified
`tsc` · `familiar-resolve` / `familiar-avatar` / `api-contracts` (95) / server tests · `check:tests-wired` (348) · `next build` (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)