### PR TITLE
polish(chat-header): rename into overflow menu + model-only metadata

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -308,13 +308,18 @@ assert.match(
 
 assert.match(
   source,
-  /aria-label="Rename chat"[\s\S]{0,200}setEditing\(true\)/,
-  "Chat title has an explicit, labeled rename button — click-to-rename alone is not discoverable",
+  /icon="ph:pencil-simple"[\s\S]{0,200}dispatchEvent\(new Event\("cave:chat-rename"\)\)[\s\S]{0,160}Rename chat/,
+  "Rename lives in the session overflow menu (Codex/ChatGPT idiom), firing cave:chat-rename",
 );
 assert.match(
   source,
-  /ph:pencil-simple/,
-  "Rename affordance uses the pencil icon",
+  /addEventListener\("cave:chat-rename", onRename\)[\s\S]{0,80}setEditing\(true\)|onRename = \(\) => setEditing\(true\)/,
+  "ChatTitleEditable enters edit mode when the overflow menu fires cave:chat-rename",
+);
+assert.doesNotMatch(
+  source,
+  /aria-label="Rename chat"/,
+  "The persistent pencil button is removed — the title is clean, rename is one click away in the menu",
 );
 
 // — CHAT-D2-01: slash menu keyboard contract ("↵ run · Tab complete · esc cancel") —

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -653,6 +653,16 @@ function SessionOverflowMenu({
         minWidth={216}
       >
         <PopoverBody>
+          <PopoverItem
+            icon="ph:pencil-simple"
+            onSelect={() => {
+              window.dispatchEvent(new Event("cave:chat-rename"));
+              close();
+            }}
+          >
+            Rename chat
+          </PopoverItem>
+          <PopoverSeparator />
           {projects.length > 1 ? (
             <>
               <PopoverLabel>Project</PopoverLabel>
@@ -788,6 +798,15 @@ function ChatTitleEditable({
     inputRef.current?.select();
   }, [editing]);
 
+  // The rename affordance now lives in the session overflow menu (Codex/ChatGPT
+  // idiom — a clean title, secondary actions one click away). The menu fires
+  // this event; clicking the title itself still enters edit mode directly.
+  useEffect(() => {
+    const onRename = () => setEditing(true);
+    window.addEventListener("cave:chat-rename", onRename);
+    return () => window.removeEventListener("cave:chat-rename", onRename);
+  }, []);
+
   const display = baseTitle || session.id;
 
   const submit = async () => {
@@ -850,33 +869,17 @@ function ChatTitleEditable({
   }
 
   return (
-    <span className={headline ? "flex w-full min-w-0 items-center gap-1.5" : "flex min-w-0 flex-1 items-center gap-1"}>
-      <button
-        type="button"
-        className={buttonClassName}
-        title={`${display} — click to rename`}
-        onClick={(e) => {
-          e.stopPropagation();
-          setEditing(true);
-        }}
-      >
-        {display}
-      </button>
-      {/* Explicit rename affordance — the click-to-rename title alone is
-          invisible; the pencil makes renaming discoverable. */}
-      <button
-        type="button"
-        title="Rename chat"
-        aria-label="Rename chat"
-        onClick={(e) => {
-          e.stopPropagation();
-          setEditing(true);
-        }}
-        className="focus-ring grid h-5 w-5 shrink-0 place-items-center rounded text-[var(--text-muted)] opacity-60 transition-all hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] hover:opacity-100"
-      >
-        <Icon name="ph:pencil-simple" width={11} aria-hidden />
-      </button>
-    </span>
+    <button
+      type="button"
+      className={buttonClassName}
+      title={`${display} — click to rename`}
+      onClick={(e) => {
+        e.stopPropagation();
+        setEditing(true);
+      }}
+    >
+      {display}
+    </button>
   );
 }
 
@@ -965,8 +968,10 @@ function metaLineSegments(args: {
     // itself so the ticking elapsed can live in an aria-hidden span — keeping
     // the per-second rewrite out of the role="status" live region.
   } else {
-    if (args.harness) segs.push(args.harness);
+    // Lead with the model (ChatGPT idiom) — the harness name is redundant with
+    // it, so it only appears as a fallback when no model id is resolved.
     if (args.model) segs.push(args.model);
+    else if (args.harness) segs.push(args.harness);
     if (runtime) segs.push({ dir: runtime });
     const dur = fmtDuration(args.durationMs);
     if (dur) segs.push(dur);


### PR DESCRIPTION
Two follow-ups to #844, completing the Codex/ChatGPT header idiom.

## Changes

1. **Rename folded into the overflow menu.** Removed the persistent hover-pencil beside the title — the title now reads perfectly clean. Added **Rename chat** to the top of `SessionOverflowMenu`; it fires a `cave:chat-rename` window event that `ChatTitleEditable` listens for and enters edit mode (auto-focused). Clicking the title itself still renames directly.
2. **Metadata trimmed to the model.** Dropped the redundant harness name from the meta line — it now leads with the model (`openclaw-local · ~/…/coven-cave · 5s` instead of `claude · openclaw-local · …`). Harness only appears as a fallback when no model id resolves.

## Verification

- Driven live in a real browser: menu leads with **Rename chat**; clicking it opens and focuses the title input (`rename input present: 1 focused: true`); metadata renders model-first.
- `pnpm test:app` green (full suite), `tsc --noEmit` clean. Updated the source-text test that pinned the old pencil affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)