### PR TITLE
feat(sidebar): notifications row + unread count in the left footer

### DIFF
--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -168,6 +168,34 @@ assert.match(
   "Footer rows should align labels from matching icon cells",
 );
 
+// Notifications footer row: a dedicated bell + unread count that opens the
+// inbox, sitting above Settings.
+assert.match(
+  source,
+  /onClick=\{onOpenInbox\}[\s\S]{0,700}sidebar-foot-label">Notifications/,
+  "footer renders a Notifications row wired to onOpenInbox",
+);
+assert.match(
+  source,
+  /unreadCount > 0 \? "ph:bell-fill" : "ph:bell"/,
+  "the notifications icon fills when there are unread items",
+);
+assert.match(
+  source,
+  /sidebar-foot-badge[\s\S]{0,80}unreadCount > 99 \? "99\+" : unreadCount/,
+  "the notifications row shows the unread count badge (capped at 99+)",
+);
+assert.match(
+  source,
+  /aria-label=\{unreadCount > 0 \? `Notifications, \$\{unreadCount\} unread` : "Notifications"\}/,
+  "the notifications row exposes the unread count to assistive tech",
+);
+assert.match(
+  styles,
+  /\.sidebar-foot-badge \{[^}]*background: var\(--color-danger\)/,
+  "the unread count badge uses the danger treatment",
+);
+
 // Tools-group entries include browser, terminal, roles, workflows, and capabilities.
 assert.match(
   source,

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -190,7 +190,11 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
     activeFamiliarId,
     onFamiliarScopeChange,
     responseNeeded,
+    notificationBadgeCount,
+    onOpenInbox,
   } = props;
+
+  const unreadCount = notificationBadgeCount ?? 0;
 
   // Projects lives only inside the Familiars surface's Projects tab now (and ⌘9 /
   // the /projects deep-link in workspace.tsx open it there) — no sidebar entry.
@@ -287,8 +291,31 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
         </SidebarSection>
       </div>
 
-      {/* Bottom: Settings */}
+      {/* Bottom: Notifications + Settings */}
       <div className="sidebar-foot">
+        {onOpenInbox ? (
+          <button
+            type="button"
+            className="sidebar-foot-btn"
+            onClick={onOpenInbox}
+            aria-label={unreadCount > 0 ? `Notifications, ${unreadCount} unread` : "Notifications"}
+            title={unreadCount > 0 ? `${unreadCount} unread notifications` : "Notifications"}
+          >
+            <span className="sidebar-foot-icon-cell" aria-hidden="true">
+              <Icon
+                name={unreadCount > 0 ? "ph:bell-fill" : "ph:bell"}
+                width={14}
+                className="sidebar-foot-icon"
+              />
+            </span>
+            <span className="sidebar-foot-label">Notifications</span>
+            {unreadCount > 0 ? (
+              <span className="sidebar-foot-badge" aria-hidden="true">
+                {unreadCount > 99 ? "99+" : unreadCount}
+              </span>
+            ) : null}
+          </button>
+        ) : null}
         <button
           type="button"
           className="sidebar-foot-btn"

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -319,6 +319,24 @@
   color: inherit;
 }
 
+/* Unread notification count pill, right-aligned in the Notifications footer
+   row (mirrors the bell badge's danger treatment). */
+.sidebar-foot-badge {
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  margin-left: auto;
+  border-radius: 999px;
+  background: var(--color-danger);
+  color: var(--text-primary);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+}
+
 /* NotificationBell renders an absolutely-positioned popover anchored at the
  * top-right of its trigger. In the sidebar foot that pushes the popover off
  * the bottom of the viewport, so flip it to open upward to the right. */


### PR DESCRIPTION
## What
Adds a dedicated **Notifications** row to the left sidebar footer (above Settings) with an unread count badge.

The sidebar already *received* `notificationBadgeCount` / `onOpenInbox` / `inboxItems` from the workspace, but rendered nothing — only Settings was in the footer. This wires up that data.

- **Icon**: `ph:bell` → `ph:bell-fill` when there are unread items.
- **Label**: "Notifications", matching the Settings row treatment (`sidebar-foot-btn` / `sidebar-foot-icon-cell`).
- **Counter**: right-aligned danger pill (`.sidebar-foot-badge`), shown only when count > 0, capped at `99+`.
- **Click**: opens the inbox (`onOpenInbox` → Schedules). `aria-label` announces the unread count.
- **Source**: unread = `notificationBadgeCount` (unresolved escalations), already computed in the workspace.

## Verification
Live (prod build + Playwright): the Notifications row renders above Settings; the count pill shows when unread > 0 (verified by injecting a count). New assertions in `sidebar-minimal.test.ts`; full `pnpm test:app` + `pnpm test:api` + `pnpm build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)