### PR TITLE
fix(shell): raise the left nav toggle to the Coven Cave wordmark row

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3189,6 +3189,10 @@ button:active > .edge-rail-chip {
 
 .shell-panel-float--left {
   left: 8px;
+  /* The left nav toggle belongs beside the "Coven Cave" wordmark row at the top
+     of the sidebar, not level with the right panel's lower tab strip. Override
+     the shared `top` so it rides up next to the wordmark. */
+  top: 20px;
 }
 
 .shell-panel-float--right {


### PR DESCRIPTION
The left sidebar's floating nav toggle had drifted down to sit beside the familiar switcher instead of beside the **"Coven Cave"** wordmark.

## Cause
A prior change set `.shell-panel-float { top: 50px }` to align the **right** panel toggle with its inspector tab strip (~45px header + 38px tabs). But the shared base rule also pushed the **left** nav toggle to `top: 50px` — while the "Coven Cave" wordmark sits at ~25px — so the toggle detached from the wordmark and landed next to "All familiars".

## Fix
Give `.shell-panel-float--left` its own `top: 20px` so it rides back up beside the wordmark; `--right` keeps `top: 50px`.

## Verification (running app)
- Before: left float at y=50 (beside the switcher), wordmark at y=25 — misaligned.
- After: left float at y=20, aligned with the "Coven Cave" wordmark row; right float unchanged at y=50.
- `shell-edge-rails` + `globals.css` tests pass; `pnpm build` succeeds; one-file CSS change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)