### PR TITLE
fix(chat): track the live side-panel header so floating toggles don't flash misaligned

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3167,8 +3167,11 @@ button:active > .edge-rail-chip {
   /* Vertically centered on the side-panel header row — the 38px Inspector/Debug/
      Changes tab strip that sits directly below the ~45px chat scope-tabs header.
      The trigger + expand toggle read as part of that header rather than floating
-     above it; the left nav toggle is moved to the same row to stay level. */
-  top: 50px;
+     above it; the left nav toggle is moved to the same row to stay level.
+     ChatSurface measures the live header and publishes --shell-float-top so the
+     floats track it through the post-load settle (no fixed-offset flash); the
+     50px fallback matches the settled position when no panel is open. */
+  top: var(--shell-float-top, 50px);
   z-index: 40;
   display: grid;
   place-items: center;

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -446,6 +446,55 @@ export function ChatSurface({
     return () => root.removeAttribute("data-right-panel-open");
   }, [rightPanel, isMobile, scope]);
 
+  // Keep the shell's floating toggles (left nav, expand, side-panel trigger)
+  // vertically centered on the LIVE side-panel header. Its top can shift while
+  // the layout settles after load (e.g. transient chrome above the panel), so a
+  // fixed CSS offset flashes out of alignment. Publish the header's centered top
+  // as a root CSS var the floats consume (--shell-float-top), and track it via a
+  // short rAF loop that runs only until the value holds steady, plus a resize
+  // re-arm. Falls back to the CSS default when there's no panel to align to.
+  useEffect(() => {
+    if (isMobile || scope !== "conversation" || rightPanel === null || rightExpanded) return;
+    const root = document.documentElement;
+    const FLOAT_H = 28;
+    let raf = 0;
+    let steady = 0;
+    let last = Number.NaN;
+    const measure = () => {
+      const header = document.querySelector(".right-panel-tabs");
+      if (header) {
+        const r = header.getBoundingClientRect();
+        const top = Math.round(r.top + (r.height - FLOAT_H) / 2);
+        if (top !== last) {
+          root.style.setProperty("--shell-float-top", `${top}px`);
+          last = top;
+          steady = 0;
+        } else {
+          steady += 1;
+        }
+      }
+    };
+    const loop = () => {
+      measure();
+      // Stop once the measurement holds for ~6 frames — covers the post-load
+      // settle without polling forever.
+      if (steady < 6) raf = requestAnimationFrame(loop);
+    };
+    loop();
+    const rearm = () => {
+      steady = 0;
+      last = Number.NaN;
+      cancelAnimationFrame(raf);
+      loop();
+    };
+    window.addEventListener("resize", rearm);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("resize", rearm);
+      root.style.removeProperty("--shell-float-top");
+    };
+  }, [isMobile, scope, rightPanel, rightExpanded]);
+
   // While the right panel is expanded it covers the chat surface, but the
   // shell's right edge-rail float (.shell-panel-float--right, z-40) sits above
   // the overlay's trapped z-index and intercepts clicks on the panel's

--- a/src/components/right-panel-expand.test.ts
+++ b/src/components/right-panel-expand.test.ts
@@ -59,4 +59,22 @@ assert.match(
   "expand float is hidden again while the panel is expanded",
 );
 
+// The floats track the live side-panel header position via a measured CSS var so
+// they stay aligned through the post-load layout settle (no fixed-offset flash).
+assert.match(
+  css,
+  /\.shell-panel-float\s*\{[\s\S]*?top:\s*var\(--shell-float-top,\s*50px\)/,
+  "floats consume the measured --shell-float-top (with a 50px fallback)",
+);
+assert.match(
+  src,
+  /setProperty\("--shell-float-top"/,
+  "ChatSurface publishes the live header center to --shell-float-top",
+);
+assert.match(
+  src,
+  /querySelector\("\.right-panel-tabs"\)[\s\S]*getBoundingClientRect/,
+  "the float position is derived from the measured side-panel header rect",
+);
+
 console.log("right-panel-expand.test.ts: ok");


### PR DESCRIPTION
## Problem

Follow-up to #845. The shell's floating toggles (left nav, expand, side-panel trigger) were pinned to a fixed `top:50px` to center on the side-panel header. That header's top can shift while the layout settles right after load (transient chrome briefly sits above it, ~+43px), so the floats **flashed out of alignment** before snapping into place. Verified earlier: header center read 107 during the transient vs 64 settled.

## Fix

`ChatSurface` measures the live `.right-panel-tabs` header and publishes its centered top as a `--shell-float-top` root CSS var that `.shell-panel-float` consumes (`top: var(--shell-float-top, 50px)`). A short `requestAnimationFrame` loop tracks it **only until the value holds steady** (~6 frames), with a `resize` re-arm and full cleanup. The floats now move *with* the header through the settle, so they stay aligned at every frame instead of sitting at a fixed offset. The 50px fallback preserves the settled position for when no panel is open.

## Verification (in-app, 1440×900)

Measured float-vs-header center at three settle points; the CSS var tracks the header the whole way:

| settle | header center | expand Δ | left Δ | trigger Δ | `--shell-float-top` |
|---|---|---|---|---|---|
| 120ms (transient) | 107 | 0 | 0 | 0 | `93px` |
| 400ms | 64 | 0 | 0 | 0 | `50px` |
| 1800ms (settled) | 64 | 0 | 0 | 0 | `50px` |

**Δ=0px at every point** — the flash is gone. `tsc` clean; `right-panel-expand`, `chat-surface`, `chat-surface-polish`, `shell-edge-rails` pass; added source-text coverage for the var + measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)