### PR TITLE
refactor(workflows): drop the redundant "Add step" palette caption

### DIFF
--- a/src/components/workflows/workflow-palette.tsx
+++ b/src/components/workflows/workflow-palette.tsx
@@ -19,8 +19,7 @@ const PALETTE: Array<{ kind: WorkflowStepKind; label: string; icon: IconName; to
 /** Node palette: one click appends a step of the given CWF-01 kind. */
 export function WorkflowPalette({ workflow, onAddStep }: WorkflowPaletteProps) {
   return (
-    <div className="workflow-palette" role="toolbar" aria-label="Step palette">
-      <span className="workflow-palette-label">Add step</span>
+    <div className="workflow-palette" role="toolbar" aria-label="Add step">
       {PALETTE.map((entry) => (
         <button
           key={entry.kind}

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -956,16 +956,6 @@
   overflow-x: auto;
 }
 
-.workflow-palette-label {
-  flex-shrink: 0;
-  white-space: nowrap;
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--muted-foreground);
-  margin-right: 4px;
-}
-
 .workflow-palette-item {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## What

Removes the standalone uppercase **"ADD STEP"** caption from the workflow step palette (and its now-unused `.workflow-palette-label` CSS rule).

The palette is a toolbar of self-describing kind buttons — Agent / Skill / Tool / Human gate / Workflow — each with an "Add … step" tooltip. The extra caption was redundant visual clutter. Accessibility is preserved by moving the intent into the toolbar's `aria-label` ("Add step", was "Step palette").

CSS-only + one JSX line; no test asserted the label text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)