### PR TITLE
fix(chat): remove the redundant top-right '+ New' button

### DIFF
--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -20,20 +20,16 @@ assert.doesNotMatch(
 
 assert.match(
   chatSurface,
-  /New/,
-  "ChatSurface should expose the primary chat launch action without a separate composer block",
-);
-
-assert.match(
-  chatSurface,
   /className="chat-scope-tabs chat-scope-tabs--minimal/,
   "ChatSurface should use the compact tab strip treatment on open chat sessions",
 );
 
-assert.match(
+// The redundant "+ New" action was removed from the scope-tab strip — the
+// chat list rail's "New Session" button is the single new-chat launch point.
+assert.doesNotMatch(
   chatSurface,
   /className="chat-scope-tabs__new/,
-  "ChatSurface new-chat action should use the minimal tab-strip action styling",
+  "ChatSurface should not render a redundant New action in the scope-tab strip",
 );
 
 assert.doesNotMatch(

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -394,12 +394,6 @@ export function ChatSurface({
     onPendingChatActionHandled();
   }, [onPendingChatActionHandled, onSetActiveFamiliar, pendingChatAction, routerRef]);
 
-  function startConversation(familiarId?: string | null) {
-    if (familiarId) onSetActiveFamiliar(familiarId);
-    setScope("conversation");
-    window.setTimeout(() => routerRef.current?.newChat(undefined, undefined, familiarId), 0);
-  }
-
   function startProjectChat(projectRoot: string) {
     setScope("conversation");
     window.setTimeout(() => routerRef.current?.newChat(projectRoot), 0);
@@ -500,19 +494,6 @@ export function ChatSurface({
                 { id: "projects", label: "Projects" },
               ]}
             />
-          </div>
-
-          {/* Actions flush right — chromeless */}
-          <div className="flex items-center gap-2 py-1.5">
-            <button
-              type="button"
-              onClick={() => startConversation(activeFamiliarId)}
-              title="New session"
-              className="chat-scope-tabs__new inline-flex h-7 items-center gap-1 text-[11px] text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)]"
-            >
-              <Icon name="ph:plus-bold" width={11} />
-              New
-            </button>
           </div>
         </div>
 


### PR DESCRIPTION
The chat scope-tab header (shown when the **Familiars** nav opens the sessions surface) carried a top-right **"+ New"** action that duplicated the chat-list rail's **"+ New Session"** button sitting right below it — two new-session launchers, inches apart.

## Change
Removed the redundant `.chat-scope-tabs__new` button from the scope-tab strip (and its now-unused `startConversation` helper). The chat-list rail's "+ New Session" remains the single new-chat launch point.

## Verification (running app)
- Before: top-right showed both "+ New" (`chat-scope-tabs__new`) and "+ Session" (`chat-list-new-button`).
- After: `chat-scope-tabs__new` count = **0**; `chat-list-new-button` count = **1** (kept). Screenshot confirms only the "+ Session" button + panel toggle remain.
- `tsc --noEmit` clean; `chat-surface*` tests pass (updated the assertion that required the removed button); `pnpm build` green. 2 files, net -23 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)