### PR TITLE
fix(home-composer): ring the whole familiar-selector pill on focus

### DIFF
--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -423,8 +423,13 @@
 }
 .hc-dest-pill:focus-visible,
 .hc-send-btn:focus-visible,
-.hc-suggestion:focus-visible,
-.hc-familiar-select:focus-visible {
+.hc-suggestion:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: var(--ring-offset);
+}
+/* The familiar selector is a pill (glyph + borderless native <select>). Ring the
+   whole pill when the select is focused, not just the inner rectangular control. */
+.hc-familiar-selector:focus-within {
   outline: var(--ring-width) solid var(--ring-focus);
   outline-offset: var(--ring-offset);
 }


### PR DESCRIPTION
## What

The home composer's familiar/model selector is a pill — a sparkle glyph plus a borderless native `<select>`. The focus ring was attached to the inner `<select>` (`.hc-familiar-select:focus-visible`), so focusing it outlined only the inner rectangle, leaving the glyph and pill border outside the ring.

This moves the ring to the wrapper `.hc-familiar-selector` via `:focus-within`, so the **whole pill** is outlined on focus. The inner `<select>` keeps `outline: none`.

CSS-only; no markup or test changes (no test asserted the old rule).

## Verification

Drove the running app (Playwright): focused the selector and confirmed the `2px solid` ring now sits on `.hc-familiar-selector` (border-radius 8px) while `.hc-familiar-select` computes `outline-style: none`. Screenshot shows the ring wrapping the full "✦ Nova ⌄" pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)