### PR TITLE
fix(chat): gutter the header so its actions clear the floating panel toggle

### DIFF
--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -105,6 +105,16 @@ assert.doesNotMatch(
   "The inline project-chip picker is folded into the session overflow menu",
 );
 
+// The right floating panel toggle (.shell-panel-float--right) overlays the
+// top-right corner; with no right panel open the header runs full-width and its
+// actions (find + ⋮ menu) would land under the toggle. A guarded gutter clears
+// them — without it the session overflow menu is unclickable.
+assert.match(
+  styles,
+  /:root:not\(\[data-right-panel-open\]\)\s*\.cave-chat-linear-header\s*\{[^}]*padding-right:\s*44px/,
+  "Chat header reserves a right gutter (panel-closed) so its actions clear the floating panel toggle",
+);
+
 assert.doesNotMatch(
   styles,
   /\.cave-chat-lifecycle-status/,

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1597,6 +1597,17 @@ details[open] > .cave-tool-summary::before {
   padding: 4px 10px 5px;
 }
 
+/* The right floating panel toggle (.shell-panel-float--right — right:8px, 28px
+   wide) overlays the top-right corner. With no right panel open the chat header
+   runs full-width to the viewport edge, so its right-edge actions (in-transcript
+   find + the ⋮ session menu) land under the toggle and become unclickable.
+   Reserve a gutter (8px edge + 28px button + 8px gap = 44px) so they clear it.
+   A panel open stops the header at the panel edge with the toggle over the
+   panel, so the base padding is correct there — hence the :not() guard. */
+:root:not([data-right-panel-open]) .cave-chat-linear-header {
+  padding-right: 44px;
+}
+
 .cave-mobile-header-identity,
 .cave-mobile-header-task,
 .cave-mobile-action-strip,


### PR DESCRIPTION
## Problem

After the float-align work (#854), the right floating panel toggle (`.shell-panel-float--right`, `right:8px`, 28px) rides in the open-chat header row. With **no right panel open** the header runs full-width to the viewport edge, so its right-edge actions — the in-transcript find and the `⋮` session overflow menu (#844/#847) — land **under** the toggle. `document.elementFromPoint` at the kebab's centre returns the toggle's SVG, so the whole session menu (Rename / Project / Voice / Debug / Delete) is **unclickable**.

(Reported on #854; this is the agreed header-side fix — it does **not** touch `.shell-panel-float`.)

## Fix

Reserve a **44px right gutter** (8px edge + 28px button + 8px gap) on `.cave-chat-linear-header`, guarded by `:root:not([data-right-panel-open])`. With a panel open the header stops at the panel edge and the toggle sits over the panel, so the base padding stays correct there — hence the `:not()` guard.

## Verification

- Driven live: kebab right edge **1236** vs toggle left **1244** (8px gap); hit-test at the kebab centre returns the kebab; clicking it opens the menu.
- Added a regression test asserting the guarded gutter rule.
- `pnpm test:app` green (full suite), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)