### PR TITLE
fix(shell): make side panel toggles full-height strips

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3148,11 +3148,10 @@ button:active > .edge-rail-chip {
 }
 
 /* ────────────────────────────────────────────────
-   Floating panel toggles (Codex-style)
-   Always-visible rounded buttons pinned to the shell's top corners that
-   show/hide the side panels — left toggles the nav sidebar, right toggles
-   the active companion/side panel. They float above the panels (z-index)
-   so a single persistent control owns each panel in any open/closed state.
+   Edge panel toggles (Codex-style)
+   Full-height invisible strips pinned to the shell's left/right edges. Hover
+   or keyboard focus reveals the small aligned chip; clicking anywhere along
+   the strip toggles the corresponding side panel.
    ──────────────────────────────────────────────── */
 .shell-body--floats {
   position: relative;
@@ -3170,17 +3169,35 @@ button:active > .edge-rail-chip {
 
 .shell-panel-float {
   position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 40;
+  display: block;
+  width: 44px;
+  height: 100%;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: color-mix(in oklch, var(--text-secondary) 86%, var(--text-primary));
+  box-shadow: none;
+  cursor: pointer;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  transition: color 120ms ease;
+}
+
+.shell-panel-float::before {
+  content: "";
+  position: absolute;
   /* Vertically centered on the side-panel header row — the 38px Inspector/Debug/
      Changes tab strip that sits directly below the ~45px chat scope-tabs header.
      The trigger + expand toggle read as part of that header rather than floating
-     above it; the left nav toggle is moved to the same row to stay level.
+     above it; both side strips use this same value so the chips stay level.
      ChatSurface measures the live header and publishes --shell-float-top so the
      floats track it through the post-load settle (no fixed-offset flash); the
      50px fallback matches the settled position when no panel is open. */
   top: var(--shell-float-top, 50px);
-  z-index: 40;
-  display: grid;
-  place-items: center;
+  left: 50%;
   width: 28px;
   height: 28px;
   border-radius: 8px;
@@ -3190,30 +3207,63 @@ button:active > .edge-rail-chip {
   box-shadow:
     inset 0 1px 0 color-mix(in oklch, var(--text-primary) 10%, transparent),
     0 6px 16px color-mix(in oklch, black 22%, transparent);
-  cursor: pointer;
+  opacity: 0;
+  transform: translateX(-50%);
   -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
-  transition: background 120ms ease, border-color 120ms ease, color 120ms ease, box-shadow 120ms ease, transform 80ms ease;
+  transition: background 120ms ease, border-color 120ms ease, box-shadow 120ms ease, opacity 120ms ease, transform 80ms ease;
+}
+
+.shell-panel-float > svg {
+  position: absolute;
+  top: calc(var(--shell-float-top, 50px) + 6.5px);
+  left: 50%;
+  z-index: 1;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-50%);
+  transition: opacity 120ms ease, color 120ms ease, transform 80ms ease;
 }
 
 .shell-panel-float--left {
-  left: 8px;
-  /* The left nav toggle belongs beside the "Coven Cave" wordmark row at the top
-     of the sidebar, not level with the right panel's lower tab strip. Override
-     the shared `top` so it rides up next to the wordmark. */
-  top: 20px;
+  left: 0;
 }
 
 .shell-panel-float--right {
-  right: 8px;
+  right: 0;
 }
 
 /* Expand-to-cover toggle: pinned one button-width + gap to the left of the
    side-panel trigger (8 + 28 + 8). Hidden until a chat right panel is actually
    open, and re-hidden while expanded (the in-panel Restore button takes over). */
 .shell-panel-float--expand {
+  top: var(--shell-float-top, 50px);
   right: 44px;
+  bottom: auto;
+  z-index: 40;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in oklch, var(--text-muted) 34%, transparent);
+  background: color-mix(in oklch, var(--bg-raised) 86%, var(--bg-elevated));
+  box-shadow:
+    inset 0 1px 0 color-mix(in oklch, var(--text-primary) 10%, transparent),
+    0 6px 16px color-mix(in oklch, black 22%, transparent);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
   display: none;
+}
+.shell-panel-float--expand::before {
+  content: none;
+}
+.shell-panel-float--expand > svg {
+  position: static;
+  opacity: 1;
+  transform: none;
+}
+.shell-panel-float--expand:active {
+  transform: scale(0.94);
 }
 :root[data-right-panel-open] .shell-panel-float--expand {
   display: grid;
@@ -3224,23 +3274,38 @@ button:active > .edge-rail-chip {
 
 /* The Phosphor sidebar glyph points at a left panel; mirror it on the right
    toggle so it reads as a right-edge panel. */
-.shell-panel-float--right svg {
-  transform: scaleX(-1);
+.shell-panel-float--right > svg {
+  transform: translateX(-50%) scaleX(-1);
 }
 
-.shell-panel-float:hover {
-  background: var(--bg-elevated);
+.shell-panel-float:hover,
+.shell-panel-float:focus-visible {
   color: var(--text-primary);
+}
+
+.shell-panel-float:hover::before,
+.shell-panel-float:focus-visible::before,
+.shell-panel-float:hover > svg,
+.shell-panel-float:focus-visible > svg {
+  opacity: 1;
+}
+
+.shell-panel-float:hover::before,
+.shell-panel-float:focus-visible::before {
+  background: var(--bg-elevated);
   border-color: color-mix(in oklch, var(--text-muted) 48%, transparent);
 }
 
-.shell-panel-float:active {
-  transform: scale(0.94);
+.shell-panel-float:active::before {
+  transform: translateX(-50%) scale(0.94);
 }
 
 /* Open state: accent-tinted, matching the edge-rail "expanded" treatment. */
 .shell-panel-float--active {
   color: var(--text-primary);
+}
+
+.shell-panel-float--active::before {
   border-color: color-mix(in oklch, var(--accent-presence) 58%, var(--border-hairline));
   background: color-mix(in oklch, var(--accent-presence) 18%, var(--bg-raised));
 }

--- a/src/components/right-panel-expand.test.ts
+++ b/src/components/right-panel-expand.test.ts
@@ -63,8 +63,8 @@ assert.match(
 // they stay aligned through the post-load layout settle (no fixed-offset flash).
 assert.match(
   css,
-  /\.shell-panel-float\s*\{[\s\S]*?top:\s*var\(--shell-float-top,\s*50px\)/,
-  "floats consume the measured --shell-float-top (with a 50px fallback)",
+  /\.shell-panel-float::before\s*\{[\s\S]*?top:\s*var\(--shell-float-top,\s*50px\)[\s\S]*?\.shell-panel-float--expand\s*\{[\s\S]*?top:\s*var\(--shell-float-top,\s*50px\)/,
+  "side-panel chips and the expand float consume the measured --shell-float-top (with a 50px fallback)",
 );
 assert.match(
   src,

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -1,10 +1,8 @@
 // @ts-nocheck
-// Closed side panels must stay discoverable and read as pressable:
-//   - when the nav is collapsed, a left-edge rail (mirroring the right-edge
-//     agent trigger rail) is the floating reopen affordance; while the nav is
-//     open the in-panel top toggle owns collapsing, so the rail stays hidden
-//   - edge-rail toggles render a visible button chip instead of an
-//     invisible-until-hover icon
+// Side panels must stay discoverable without visual chrome noise:
+//   - desktop shell owns a left and right full-height edge strip
+//   - the strips are clickable across their full height
+//   - the aligned chip/icon stays invisible until hover or keyboard focus
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
@@ -14,9 +12,9 @@ const projectSidebar = readFileSync(new URL("./chat-project-sidebar.tsx", import
 const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 const shortcuts = readFileSync(new URL("../lib/keyboard-shortcuts.ts", import.meta.url), "utf8");
 
-// Codex-style floating panel toggles: two always-visible rounded buttons
-// pinned to the shell's top corners (left = nav sidebar, right = active side
-// panel) replace the old collapsed-only left edge rail.
+// Codex-style side panel toggles: two full-height invisible edge strips
+// (left = nav sidebar, right = active side panel) replace the old
+// collapsed-only left edge rail.
 assert.match(
   shell,
   /const panelFloats = !isMobile/,
@@ -69,6 +67,29 @@ assert.doesNotMatch(
   /familiar-trigger-rail--left/,
   "the old collapsed-only left edge rail is removed from the shell",
 );
+
+assert.match(
+  css,
+  /\.shell-panel-float\s*\{[\s\S]*?top:\s*0;[\s\S]*?bottom:\s*0;[\s\S]*?width:\s*44px;[\s\S]*?height:\s*100%;[\s\S]*?background:\s*transparent;/,
+  "left/right panel toggles should be full-height invisible edge strips",
+);
+assert.match(
+  css,
+  /\.shell-panel-float::before\s*\{[\s\S]*?top:\s*var\(--shell-float-top,\s*50px\);[\s\S]*?opacity:\s*0;/,
+  "panel toggle chip should share the measured top and stay hidden by default",
+);
+assert.match(
+  css,
+  /\.shell-panel-float > svg\s*\{[\s\S]*?top:\s*calc\(var\(--shell-float-top,\s*50px\) \+ 6\.5px\);[\s\S]*?opacity:\s*0;/,
+  "panel toggle icon should share the same measured top and stay hidden by default",
+);
+assert.match(
+  css,
+  /\.shell-panel-float:hover::before,[\s\S]*?\.shell-panel-float:focus-visible::before,[\s\S]*?\.shell-panel-float:hover > svg,[\s\S]*?\.shell-panel-float:focus-visible > svg\s*\{[\s\S]*?opacity:\s*1;/,
+  "panel toggle chip and icon should reveal on hover or keyboard focus",
+);
+assert.match(css, /\.shell-panel-float--left\s*\{[\s\S]*?left:\s*0;/, "left strip is pinned to the left edge");
+assert.match(css, /\.shell-panel-float--right\s*\{[\s\S]*?right:\s*0;/, "right strip is pinned to the right edge");
 
 // The edge-rail chip survives — the collapsed chat-projects strip still uses it
 // for its reopen tab. The familiar trigger-rail CSS that used to share it was


### PR DESCRIPTION
## Summary
- turn the left and right side-panel toggles into full-height invisible edge strips
- reveal the aligned chip/icon only on hover or keyboard focus
- keep the expand-to-cover button aligned to the same measured side-panel top

## Test Plan
- node --experimental-strip-types src/components/shell-edge-rails.test.ts
- node --experimental-strip-types src/components/right-panel-expand.test.ts
- pnpm typecheck
- git diff --check -- src/app/globals.css src/components/shell-edge-rails.test.ts src/components/right-panel-expand.test.ts
- Playwright rendered check on http://127.0.0.1:3000/ for strip dimensions, hover reveal, and click toggles