### PR TITLE
feat(memory): isolate familiar memory — own vs shared, with a clear divider

### DIFF
--- a/src/components/familiars-memory-master-detail.test.ts
+++ b/src/components/familiars-memory-master-detail.test.ts
@@ -29,4 +29,17 @@ assert.match(source, /value=\{groupMode\}/, "Group control is bound to groupMode
 assert.match(source, /groupMemoryRows\(pagedRows, groupMode\)/, "grouped mode wraps the paged rows");
 assert.match(source, /groupMode === "none" \?/, "flat list renders only when group mode is none");
 
+// Shared (global-pool) memory is separated from the familiar's own memory by a
+// labelled divider, so a selected familiar's view is clearly isolated.
+assert.match(
+  source,
+  /Coven-wide memory/,
+  "Memory list separates shared/global pools under a 'Coven-wide memory' divider",
+);
+assert.match(
+  source,
+  /ownership === "shared"/,
+  "Flat list detects the owned->shared boundary to place the divider",
+);
+
 console.log("familiars-memory-master-detail: all assertions passed");

--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import type { Familiar } from "@/lib/types";
 import type { CovenMemoryEntry } from "@/components/familiars-view-stats";
@@ -514,7 +514,20 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
                   </div>
                 ) : groupMode === "none" ? (
                   <ul className="divide-y divide-[var(--border-hairline)]">
-                    {pagedRows.map(renderRow)}
+                    {pagedRows.map((row, i) => {
+                      const prev = pagedRows[i - 1];
+                      const startsShared = row.ownership === "shared" && (!prev || prev.ownership === "owned");
+                      return (
+                        <Fragment key={row.rowId}>
+                          {startsShared ? (
+                            <li className="memory-shared-divider sticky top-0 z-[1] border-b border-[var(--border-hairline)] bg-[var(--bg-raised)]/95 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] backdrop-blur">
+                              Coven-wide memory · shared across all familiars
+                            </li>
+                          ) : null}
+                          {renderRow(row)}
+                        </Fragment>
+                      );
+                    })}
                   </ul>
                 ) : (
                   <div>

--- a/src/lib/memory-rows.test.ts
+++ b/src/lib/memory-rows.test.ts
@@ -18,14 +18,14 @@ const files = [
     modified: "2026-06-13T11:30:00Z" },
 ];
 
-// Merges both sources, defaults to recency-desc.
+// Merges both sources, defaults to recency-desc. Owned (coven) rows come before shared (file) rows.
 {
   const rows = buildMemoryRows({ coven, files, familiarFilter: "echo", query: "",
     sourceFilter: "all", sortMode: "recent", staleOnly: false, now: NOW });
   assert.equal(rows.length, 3, "all three entries present");
-  assert.deepEqual(rows.map((r) => r.kind), ["file", "agent", "file"], "newest file, then coven, then old file");
-  assert.equal(rows[0].rowId, "file:/Users/x/.coven/echo/memory/new.md");
-  assert.equal(rows[1].rowId, "coven:c1");
+  assert.deepEqual(rows.map((r) => r.kind), ["agent", "file", "file"], "coven (owned) first, then files (shared) by recency");
+  assert.equal(rows[0].rowId, "coven:c1");
+  assert.equal(rows[1].rowId, "file:/Users/x/.coven/echo/memory/new.md");
   assert.ok(rows.every((r) => typeof r.title === "string" && r.title.length > 0));
 }
 
@@ -45,11 +45,11 @@ const files = [
   assert.equal(rows.filter((r) => r.kind === "file").length, 2, "files unaffected by familiar filter");
 }
 
-// sourceFilter narrows files only (coven is not a file source, so it survives).
+// sourceFilter narrows files only (coven is not a file source, so it survives). Owned (coven) before shared (file).
 {
   const rows = buildMemoryRows({ coven, files, familiarFilter: "echo", query: "",
     sourceFilter: "runtime", sortMode: "recent", staleOnly: false, now: NOW });
-  assert.deepEqual(rows.map((r) => r.rowId), ["file:/Users/x/.coven/echo/memory/new.md", "coven:c1"]);
+  assert.deepEqual(rows.map((r) => r.rowId), ["coven:c1", "file:/Users/x/.coven/echo/memory/new.md"]);
 }
 
 // query matches title across both kinds.
@@ -144,3 +144,28 @@ const grows = [
 }
 
 console.log("memory-rows: all assertions passed");
+
+// ── Familiar isolation: file rows partition into owned / shared ──────────────
+{
+  const coven = [
+    { id: "c1", familiar_id: "salem", title: "Salem note", updated_at: "2026-06-10T00:00:00.000Z", excerpt: "x", path: "p", protection: "none" },
+  ];
+  const files = [
+    { fullPath: "/g/coven.md", relPath: "coven.md", modified: "2026-06-12T00:00:00.000Z", size: 1, sourceKind: "coven-origin", sourceKindLabel: "Coven origin" },
+    { fullPath: "/w/salem/a.md", relPath: "memory/a.md", modified: "2026-06-13T00:00:00.000Z", size: 1, sourceKind: "external-harness", sourceKindLabel: "External runtime", familiarId: "salem" },
+    { fullPath: "/w/echo/b.md", relPath: "memory/b.md", modified: "2026-06-14T00:00:00.000Z", size: 1, sourceKind: "external-harness", sourceKindLabel: "External runtime", familiarId: "echo" },
+  ];
+  const rows = buildMemoryRows({ coven, files, familiarFilter: "salem", query: "", sourceFilter: "all", sortMode: "recent", staleOnly: false });
+  const ids = rows.map((r) => r.rowId);
+  assert.ok(!ids.includes("file:/w/echo/b.md"), "other-familiar file is dropped");
+  assert.ok(ids.includes("file:/w/salem/a.md"), "owned file is kept");
+  assert.ok(ids.includes("file:/g/coven.md"), "shared (no-familiarId) file is kept");
+  const owned = rows.filter((r) => r.ownership === "owned").map((r) => r.rowId);
+  const shared = rows.filter((r) => r.ownership === "shared").map((r) => r.rowId);
+  assert.deepEqual(shared, ["file:/g/coven.md"], "no-familiarId file is shared");
+  assert.ok(owned.includes("coven:c1") && owned.includes("file:/w/salem/a.md"), "coven + matching-familiar file are owned");
+  const firstSharedIdx = rows.findIndex((r) => r.ownership === "shared");
+  const lastOwnedIdx = rows.map((r) => r.ownership).lastIndexOf("owned");
+  assert.ok(lastOwnedIdx < firstSharedIdx, "owned rows ordered before shared rows");
+  console.log("memory-rows familiar-isolation: ok");
+}

--- a/src/lib/memory-rows.ts
+++ b/src/lib/memory-rows.ts
@@ -24,6 +24,9 @@ export type MemoryRow = {
   stale: boolean;
   protection: ProtectionTier;
   excerpt?: string;         // agent rows only
+  /** Whether this row belongs to the selected familiar ("owned") or is a
+   *  shared/global pool with no familiar owner ("shared"). */
+  ownership: "owned" | "shared";
 };
 
 type BuildArgs = {
@@ -67,11 +70,15 @@ export function buildMemoryRows(args: BuildArgs): MemoryRow[] {
         stale: detectStale(managed).stale,
         protection: classifyProtection(e.path),
         excerpt: e.excerpt,
+        ownership: "owned" as const,
       };
     });
 
   const fileRows: MemoryRow[] = args.files
     .filter((e) => args.sourceFilter === "all" || e.sourceKind === args.sourceFilter)
+    // Drop files owned by a *different* familiar; keep this familiar's files
+    // and ownerless (global/shared) files.
+    .filter((e) => e.familiarId == null || e.familiarId === args.familiarFilter)
     .map((e) => {
       const managed = normalizeFileEntry(e);
       return {
@@ -85,6 +92,7 @@ export function buildMemoryRows(args: BuildArgs): MemoryRow[] {
         sourceLabel: e.sourceKindLabel,
         stale: detectStale(managed).stale,
         protection: classifyProtection(e.fullPath),
+        ownership: e.familiarId === args.familiarFilter ? ("owned" as const) : ("shared" as const),
       };
     });
 
@@ -99,7 +107,12 @@ export function buildMemoryRows(args: BuildArgs): MemoryRow[] {
     size: (a, b) => (b.size ?? 0) - (a.size ?? 0),
     staleFirst: (a, b) => Number(b.stale) - Number(a.stale),
   };
-  return rows.sort(cmp[args.sortMode]);
+  const sorted = rows.sort(cmp[args.sortMode]);
+  // Owned (this familiar's) rows first, shared (global) rows after.
+  return [
+    ...sorted.filter((r) => r.ownership === "owned"),
+    ...sorted.filter((r) => r.ownership === "shared"),
+  ];
 }
 
 export type MemoryRowGroup = { key: string; label: string; rows: MemoryRow[] };


### PR DESCRIPTION
Selecting a familiar in the memory surface (Studio Memory tab / chat Memory scope) didn't actually isolate memory to that familiar: the agent "Familiar memories" count was per-familiar, but the file pools (**Coven origin / External runtimes / Runtime memory**) are global and rendered in full for *every* familiar. Salem showed "Familiar memories 0" yet 1527 rows, none his.

## Fix
**Principle: a selected familiar shows their own memory; memory that isn't theirs is excluded (other familiars') or clearly separated as shared (global pools).**

1. **`buildMemoryRows` (`src/lib/memory-rows.ts`)** — the core fix. File rows are now partitioned by `familiarId`:
   - owned = the familiar's agent memory + workspace files (`familiarId === filter`)
   - shared = global-pool files with no `familiarId`
   - files owned by a *different* familiar are **dropped**
   - rows are ordered **owned-first, then shared**. `MemoryRow` gains an additive `ownership: "owned" | "shared"`.
2. **`familiars-memory-view.tsx`** — the flat list renders owned rows first, then a labelled **"Coven-wide memory · shared across all familiars"** divider before the shared pools, so the familiar's own memory is unmistakable.

## Verification
- **Unit test** (`memory-rows.test.ts`): partition correctness — owned vs shared tagging, other-familiar files dropped, owned-before-shared ordering. Pre-existing ordering assertions updated to match.
- **Source-text test** (`familiars-memory-master-detail.test.ts`): the divider renders, gated on the owned→shared boundary.
- `pnpm test:app` / `test:api` / `tsc --noEmit` (0 errors) / `check:tests-wired` (350) / `pnpm build` all pass; app renders with **0 page errors**. (Visual divider-with-data not shown in the demo build — it serves no memory data — but is covered deterministically by the tests above.)

Deferred (noted, not scope-crept): re-scoping the source-count chips to owned-only — they remain accurate as shared-pool filters; the divider delivers the isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)