### PR TITLE
fix(memory): label the shared file pools 'Coven-wide' in the memory header

### DIFF
--- a/src/components/familiars-memory-view-full-tab.test.ts
+++ b/src/components/familiars-memory-view-full-tab.test.ts
@@ -22,6 +22,16 @@ for (const label of ["Familiar memories", "Coven origin", "External runtimes", "
   assert.ok(source.includes(label), `Inline stats row must keep label: ${label}`);
 }
 
+// The file-source pools are shared/global — the header groups them under a
+// "Coven-wide" label (not "Files"), and the counts only include ownerless
+// (shared) entries, so the header stays isolated to the selected familiar.
+assert.ok(source.includes(">Coven-wide<"), "File-source chips are grouped under a 'Coven-wide' label");
+assert.match(
+  source,
+  /entry\.familiarId == null && entry\.sourceKind === "coven-origin"/,
+  "Source counts must only include ownerless (shared/coven-wide) entries",
+);
+
 // ───────── Graph-absence guards ─────────
 
 assert.doesNotMatch(

--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -307,10 +307,14 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
     return familiars.filter((familiar) => ids.has(familiar.id));
   }, [covenEntries, familiars]);
 
+  // These pools are coven-wide / shared (no familiar owner). Count only the
+  // ownerless entries so the header reflects the shared pool, not other
+  // familiars' workspace files — keeping the header isolated to the selected
+  // familiar's own memory + the shared coven pools.
   const fileSourceCounts = useMemo(() => ({
-    covenOrigin: fileEntries.filter((entry) => entry.sourceKind === "coven-origin").length,
-    externalHarnesses: fileEntries.filter((entry) => entry.sourceKind === "external-harness").length,
-    runtimeMemory: fileEntries.filter((entry) => entry.sourceKind === "runtime").length,
+    covenOrigin: fileEntries.filter((entry) => entry.familiarId == null && entry.sourceKind === "coven-origin").length,
+    externalHarnesses: fileEntries.filter((entry) => entry.familiarId == null && entry.sourceKind === "external-harness").length,
+    runtimeMemory: fileEntries.filter((entry) => entry.familiarId == null && entry.sourceKind === "runtime").length,
   }), [fileEntries]);
 
   useEffect(() => {
@@ -383,7 +387,7 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
             >
               <span className="inline-flex items-baseline gap-1 px-1"><span className="text-[var(--text-muted)]">Familiar memories</span> <span className="font-semibold text-[var(--text-primary)]">{visibleCoven.length}</span></span>
               <span aria-hidden className="text-[var(--border-strong)]">·</span>
-              <span className="mr-0.5 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Files</span>
+              <span className="mr-0.5 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Coven-wide</span>
               <SourceFilterChip label="Coven origin" count={fileSourceCounts.covenOrigin} active={sourceFilter === "coven-origin"} onClick={() => setSourceFilter((s) => (s === "coven-origin" ? "all" : "coven-origin"))} />
               <SourceFilterChip label="External runtimes" count={fileSourceCounts.externalHarnesses} active={sourceFilter === "external-harness"} onClick={() => setSourceFilter((s) => (s === "external-harness" ? "all" : "external-harness"))} />
               <SourceFilterChip label="Runtime memory" count={fileSourceCounts.runtimeMemory} active={sourceFilter === "runtime"} onClick={() => setSourceFilter((s) => (s === "runtime" ? "all" : "runtime"))} />


### PR DESCRIPTION
Polish follow-up to #862 (familiar memory isolation). The memory header still showed the global file pools under a **"Files"** label with **global totals** sitting next to "Familiar memories" — implying they were the selected familiar's.

## Change
- Relabel the file-source group **"Files" → "Coven-wide"**, matching the list's "Coven-wide memory · shared across all familiars" divider.
- Count the chips **shared-only** (`familiarId == null`), so the numbers reflect the coven-wide shared pool — not other familiars' workspace files.

The header now reads honestly: the familiar's own memory ("Familiar memories N") distinct from the shared pools ("Coven-wide · Coven origin … External runtimes … Runtime memory …").

## Verification (running app, mocked memory)
For Nova with 1 owned agent memory + 1 owned external file + 2 shared global files, the header renders:
`Familiar memories 1 · COVEN-WIDE · Coven origin 1 · External runtimes 0 · Runtime memory 1`
— the owned external file is correctly **excluded** from the shared count (0, not 1). 0 page errors.

`familiars-memory-view-*` tests pass (added assertions for the "Coven-wide" label + shared-only count); `tsc --noEmit` clean; `pnpm build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)