### PR TITLE
fix(familiars): persist studio settings

### DIFF
--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -44,6 +44,11 @@ export async function GET() {
       const avatar = await resolveFamiliarAvatar(f.id);
       return {
         ...f,
+        display_name: binding.display_name ?? f.display_name,
+        role: binding.role ?? f.role,
+        pronouns: binding.pronouns ?? f.pronouns,
+        description: binding.description ?? f.description,
+        color: binding.color,
         harness: binding.harness,
         model: binding.model,
         note: binding.note,

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -144,7 +144,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
             value={draftHarness}
             onChange={(e) => {
               setDraftHarness(e.target.value);
-              void save({ harness: e.target.value || undefined });
+              void save({ harness: e.target.value || null });
             }}
             className="familiar-studio-brain__input"
           >
@@ -172,7 +172,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
                   return;
                 }
                 setDraftModel(value);
-                void save({ model: value || undefined });
+                void save({ model: value || null });
               }}
               className="familiar-studio-brain__input"
             >
@@ -190,7 +190,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
               type="text"
               value={draftModel}
               onChange={(e) => setDraftModel(e.target.value)}
-              onBlur={() => save({ model: draftModel.trim() || undefined })}
+              onBlur={() => save({ model: draftModel.trim() || null })}
               placeholder="provider/model"
               autoCapitalize="none"
               autoCorrect="off"
@@ -208,7 +208,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
             rows={5}
             value={draftNote}
             onChange={(e) => setDraftNote(e.target.value)}
-            onBlur={() => save({ note: draftNote.trim() || undefined })}
+            onBlur={() => save({ note: draftNote.trim() || null })}
             placeholder="Plain text instructions to seed this familiar's behavior."
             className="familiar-studio-brain__input"
           />
@@ -222,7 +222,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
             value={draftVoiceProvider}
             onChange={(e) => {
               setDraftVoiceProvider(e.target.value);
-              void save({ voiceProvider: e.target.value || undefined });
+              void save({ voiceProvider: e.target.value || null });
             }}
             className="familiar-studio-brain__input"
           >
@@ -242,7 +242,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
                 type="text"
                 value={draftVoiceModel}
                 onChange={(e) => setDraftVoiceModel(e.target.value)}
-                onBlur={() => void save({ voiceModel: draftVoiceModel.trim() || undefined })}
+                onBlur={() => void save({ voiceModel: draftVoiceModel.trim() || null })}
                 placeholder="gpt-4o-realtime-preview"
                 className="familiar-studio-brain__input"
               />
@@ -256,7 +256,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
                 value={draftVoiceName}
                 onChange={(e) => {
                   setDraftVoiceName(e.target.value);
-                  void save({ voiceName: e.target.value || undefined });
+                  void save({ voiceName: e.target.value || null });
                 }}
                 className="familiar-studio-brain__input"
               >

--- a/src/components/familiar-studio-lifecycle-tab.tsx
+++ b/src/components/familiar-studio-lifecycle-tab.tsx
@@ -99,7 +99,7 @@ export function FamiliarStudioLifecycleTab({ familiar, allResolved }: Props) {
     void fetch("/api/config", {
       method: "PATCH",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ familiars: { [familiar!.id]: {} } }),
+      body: JSON.stringify({ familiars: { [familiar!.id]: null } }),
     });
     setConfirmReset(false);
   }

--- a/src/lib/cave-config.test.ts
+++ b/src/lib/cave-config.test.ts
@@ -62,6 +62,55 @@ try {
   await config.uninstallMarketplacePlugin("github");
   cfg = await config.loadConfig();
   assert.deepEqual(cfg.marketplace.installed, {});
+
+  await config.saveConfig({
+    familiars: {
+      nova: {
+        harness: "claude",
+        model: "anthropic/claude-sonnet-4-6",
+        voiceProvider: "openai",
+      },
+    },
+  });
+  await config.saveConfig({
+    familiars: {
+      nova: {
+        display_name: "Nova Prime",
+        role: "review familiar",
+      },
+    },
+  });
+  cfg = await config.loadConfig();
+  assert.deepEqual(cfg.familiars.nova, {
+    harness: "claude",
+    model: "anthropic/claude-sonnet-4-6",
+    voiceProvider: "openai",
+    display_name: "Nova Prime",
+    role: "review familiar",
+  });
+
+  const novaBinding = config.bindingFor(cfg, "nova");
+  assert.equal(novaBinding.display_name, "Nova Prime");
+  assert.equal(novaBinding.role, "review familiar");
+
+  await config.saveConfig({
+    familiars: {
+      nova: {
+        voiceProvider: null,
+      },
+    },
+  });
+  cfg = await config.loadConfig();
+  assert.deepEqual(cfg.familiars.nova, {
+    harness: "claude",
+    model: "anthropic/claude-sonnet-4-6",
+    display_name: "Nova Prime",
+    role: "review familiar",
+  });
+
+  await config.saveConfig({ familiars: { nova: null } });
+  cfg = await config.loadConfig();
+  assert.equal(cfg.familiars.nova, undefined);
 } finally {
   if (previousHome === undefined) delete process.env.HOME;
   else process.env.HOME = previousHome;

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -50,11 +50,25 @@ function defaultState(): CaveState {
 export type FamiliarBinding = {
   harness: string;
   model: string;
+  display_name?: string;
+  role?: string;
+  pronouns?: string;
+  description?: string;
+  color?: string;
   note?: string;
   voiceProvider?: string;
   voiceModel?: string;
   voiceName?: string;
   runtime?: FamiliarRuntime;
+};
+
+type FamiliarBindingPatch = {
+  [K in keyof FamiliarBinding]?: FamiliarBinding[K] | null;
+};
+
+type CaveConfigPatch = Omit<Partial<CaveConfig>, "defaults" | "familiars"> & {
+  defaults?: Partial<FamiliarBinding>;
+  familiars?: Record<string, FamiliarBindingPatch | null>;
 };
 
 export type RoleConfigEntry = {
@@ -119,7 +133,36 @@ export async function loadConfig(): Promise<CaveConfig> {
   }
 }
 
-export async function saveConfig(patch: Partial<CaveConfig>): Promise<CaveConfig> {
+function mergeFamiliarConfigs(
+  current: CaveConfig["familiars"],
+  patch: CaveConfigPatch["familiars"],
+): CaveConfig["familiars"] {
+  if (patch === undefined) return current;
+  const updated: CaveConfig["familiars"] = { ...current };
+  for (const [id, entry] of Object.entries(patch)) {
+    if (entry === null) {
+      delete updated[id];
+      continue;
+    }
+    const next: Partial<FamiliarBinding> = { ...(updated[id] ?? {}) };
+    for (const [key, value] of Object.entries(entry)) {
+      if (
+        value === null ||
+        value === undefined ||
+        (typeof value === "string" && value.trim() === "")
+      ) {
+        delete next[key as keyof FamiliarBinding];
+      } else {
+        (next as Record<string, unknown>)[key] = value;
+      }
+    }
+    if (Object.keys(next).length === 0) delete updated[id];
+    else updated[id] = next;
+  }
+  return updated;
+}
+
+export async function saveConfig(patch: CaveConfigPatch): Promise<CaveConfig> {
   const current = await loadConfig();
   const updated: CaveConfig = {
     ...current,
@@ -140,10 +183,7 @@ export async function saveConfig(patch: Partial<CaveConfig>): Promise<CaveConfig
       ...current.defaults,
       ...(patch.defaults ?? {}),
     },
-    // Shallow-merge familiars
-    familiars: patch.familiars !== undefined
-      ? { ...current.familiars, ...patch.familiars }
-      : current.familiars,
+    familiars: mergeFamiliarConfigs(current.familiars, patch.familiars),
     // Replace roles if provided
     roles: patch.roles !== undefined ? patch.roles : current.roles,
   };
@@ -190,6 +230,11 @@ export function bindingFor(config: CaveConfig, familiarId: string): FamiliarBind
   return {
     harness: f.harness ?? config.defaults.harness,
     model: f.model ?? config.defaults.model,
+    display_name: f.display_name,
+    role: f.role,
+    pronouns: f.pronouns,
+    description: f.description,
+    color: f.color,
     note: f.note,
     voiceProvider: f.voiceProvider,
     voiceModel: f.voiceModel,

--- a/src/lib/cave-familiar-overrides.test.ts
+++ b/src/lib/cave-familiar-overrides.test.ts
@@ -14,6 +14,7 @@ globalThis.window = {
 };
 
 const mod = await import("./cave-familiar-overrides.ts");
+const flushAsync = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 // setFamiliarOverride writes a partial patch
 {
@@ -59,6 +60,39 @@ const mod = await import("./cave-familiar-overrides.ts");
   mod.setFamiliarOverride("ember", { display_name: "" });
   const snap = mod.readFamiliarOverridesSnapshot();
   assert.deepEqual(snap, {});
+}
+
+// Browser-side overrides also sync into Cave config so server-side familiar
+// settings (voice calls, chat identity hydration, /api/familiars reloads) see them.
+{
+  const calls: Array<{ input: string; init: { method?: string; body?: string } }> = [];
+  globalThis.fetch = async (input, init = {}) => {
+    calls.push({ input: String(input), init });
+    return { ok: true, status: 200 };
+  };
+
+  mod.setFamiliarOverride("milo", { display_name: "Milo Prime", color: "#123456" });
+  await flushAsync();
+  assert.equal(calls.at(-1)?.input, "/api/config");
+  assert.equal(calls.at(-1)?.init.method, "PATCH");
+  assert.deepEqual(JSON.parse(calls.at(-1)?.init.body ?? "{}"), {
+    familiars: {
+      milo: {
+        display_name: "Milo Prime",
+        color: "#123456",
+      },
+    },
+  });
+
+  mod.clearFamiliarOverrideField("milo", "display_name");
+  await flushAsync();
+  assert.deepEqual(JSON.parse(calls.at(-1)?.init.body ?? "{}"), {
+    familiars: {
+      milo: {
+        display_name: null,
+      },
+    },
+  });
 }
 
 console.log("cave-familiar-overrides.test.ts: ok");

--- a/src/lib/cave-familiar-overrides.ts
+++ b/src/lib/cave-familiar-overrides.ts
@@ -27,6 +27,7 @@ export type FamiliarOverride = {
 };
 
 type OverrideMap = Record<string, FamiliarOverride>;
+type ConfigPatch = Partial<Record<keyof FamiliarOverride, string | null>>;
 
 let cached: OverrideMap | null = null;
 const listeners = new Set<() => void>();
@@ -63,6 +64,36 @@ function writeMap(next: OverrideMap) {
   notify();
 }
 
+async function syncToConfig(id: string, patch: ConfigPatch | null): Promise<void> {
+  if (typeof window === "undefined") return;
+  const { reportDaemonSyncFailure, reportDaemonSyncSuccess } = await import(
+    "./daemon-sync-status.ts"
+  );
+  try {
+    const res = await fetch("/api/config", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ familiars: { [id]: patch } }),
+    });
+    if (res.ok) reportDaemonSyncSuccess();
+    else reportDaemonSyncFailure(`cave-config write: HTTP ${res.status}`);
+  } catch (err) {
+    reportDaemonSyncFailure(`cave-config write: ${(err as Error).message}`);
+  }
+}
+
+function configPatchForOverridePatch(patch: Partial<FamiliarOverride>): ConfigPatch {
+  const configPatch: ConfigPatch = {};
+  for (const [key, value] of Object.entries(patch)) {
+    if (typeof value === "string" && value.trim() === "") {
+      configPatch[key as keyof FamiliarOverride] = null;
+    } else if (value !== undefined) {
+      configPatch[key as keyof FamiliarOverride] = value;
+    }
+  }
+  return configPatch;
+}
+
 /** Merge a partial override patch for one familiar. Empty-string values are dropped. */
 export function setFamiliarOverride(
   id: string,
@@ -84,6 +115,8 @@ export function setFamiliarOverride(
   if (isEmpty) delete updated[id];
   else updated[id] = next;
   writeMap(updated);
+  const configPatch = configPatchForOverridePatch(patch);
+  if (Object.keys(configPatch).length > 0) void syncToConfig(id, configPatch);
 }
 
 /** Clear a single override field; drops the id entry entirely if it becomes empty. */
@@ -99,6 +132,7 @@ export function clearFamiliarOverrideField(
   if (Object.keys(nextEntry).length === 0) delete updated[id];
   else updated[id] = nextEntry;
   writeMap(updated);
+  void syncToConfig(id, { [field]: null });
 }
 
 /** Drop every override field for a familiar. */
@@ -108,6 +142,7 @@ export function clearAllFamiliarOverrides(id: string): void {
   const updated = { ...curr };
   delete updated[id];
   writeMap(updated);
+  void syncToConfig(id, null);
 }
 
 if (typeof window !== "undefined") {

--- a/src/lib/familiar-resolve.test.ts
+++ b/src/lib/familiar-resolve.test.ts
@@ -36,6 +36,12 @@ const base = {
   assert.equal(r.color, "#ff6600");
 }
 
+// Saved Cave config color wins over the default when no local override is present
+{
+  const r = resolveFamiliar({ ...base, color: "#123456" }, { archived: false });
+  assert.equal(r.color, "#123456");
+}
+
 // Image present
 {
   const r = resolveFamiliar(base, {

--- a/src/lib/familiar-resolve.ts
+++ b/src/lib/familiar-resolve.ts
@@ -42,7 +42,7 @@ export function resolveFamiliar(base: Familiar, ctx: ResolveContext): ResolvedFa
     role: ov.role ?? base.role,
     pronouns: ov.pronouns ?? base.pronouns,
     description: ov.description ?? base.description,
-    color: ov.color ?? "var(--accent-presence)",
+    color: ov.color ?? base.color ?? "var(--accent-presence)",
     // The familiar's workspace avatar (.../familiars/<id>/avatars/<img>) is the
     // source of truth and always wins; a Cave-local upload is only the fallback
     // when the familiar has no workspace avatar on disk.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,6 +5,7 @@ export type Familiar = {
   role: string;
   description?: string;
   pronouns?: string;
+  color?: string;
   status?: string;
   last_seen?: string;
   active_sessions?: number;


### PR DESCRIPTION
## Summary
- Persist Familiar Studio identity/look settings into Cave config while preserving local optimistic overrides
- Deep-merge per-familiar config patches so saving one field does not drop runtime/model/voice settings
- Use explicit null clears for default/reset flows and return saved identity/color through /api/familiars

## Test Plan
- node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/cave-config.test.ts
- node --experimental-strip-types src/lib/cave-familiar-overrides.test.ts
- node --experimental-strip-types src/lib/familiar-resolve.test.ts
- node --experimental-strip-types src/components/familiar-studio-brain-tab.test.ts
- node --experimental-strip-types src/components/familiar-studio-lifecycle-tab.test.ts
- node --experimental-strip-types src/components/familiar-studio-look-tab.test.ts
- node --experimental-strip-types src/components/familiar-studio-identity-tab.test.ts
- pnpm typecheck