### PR TITLE
feat(companion-rail): drop familiar header; align tab strip to the toggle band

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3436,6 +3436,11 @@ button:active > .edge-rail-chip {
 .companion-rail__tabs {
   display: flex;
   gap: 2px;
+  /* Align the tab strip's top with the left sidebar's floating toggle, which
+     sits at --shell-float-top (published by the chat surface; 50px fallback).
+     The familiar header used to fill this band; now the tab strip is the
+     panel's top row and lines up with the left panel's toggle trigger. */
+  margin-top: var(--shell-float-top, 50px);
   padding: 5px 8px;
   border-bottom: 1px solid var(--border-hairline);
   background: var(--bg-panel);

--- a/src/components/companion-rail.test.ts
+++ b/src/components/companion-rail.test.ts
@@ -5,7 +5,7 @@ import { readFileSync } from "node:fs";
 const source = readFileSync(new URL("./companion-rail.tsx", import.meta.url), "utf8");
 
 assert.match(source, /export function CompanionRail/, "Component must be named CompanionRail");
-assert.match(source, /companion-rail__header/, "Header element with BEM class");
+assert.doesNotMatch(source, /companion-rail__header/, "familiar header removed — tab strip is the panel's top row");
 assert.match(source, /companion-rail__tabs/, "Tab strip element with BEM class");
 assert.match(
   source,

--- a/src/components/companion-rail.tsx
+++ b/src/components/companion-rail.tsx
@@ -2,8 +2,6 @@
 
 import { forwardRef, useEffect, useState, type ReactNode } from "react";
 import { Icon } from "@/lib/icon";
-import { FamiliarAvatar } from "@/components/familiar-avatar";
-import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import type { ChatRouterHandle } from "@/components/chat-router";
 import type { Familiar } from "@/lib/types";
 
@@ -39,15 +37,11 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
       memorySlot,
       browserSlot,
       salemSlot,
-      onOpenSwitcher,
       onCreateFamiliar,
-      daemonRunning,
       onTabChange,
       suppressEmpty = false,
       hideChatTab = false,
     } = props;
-    const resolvedFamiliars = useResolvedFamiliars(familiar ? [familiar] : [], { includeArchived: true });
-    const resolvedFamiliar = resolvedFamiliars[0];
     const [tab, setTab] = useState<CompanionTab>(defaultTab);
     const requestedTab = activeTab ?? tab;
     const fallbackTab: CompanionTab = browserSlot ? "browser" : salemSlot ? "salem" : "memory";
@@ -95,36 +89,8 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
 
     return (
       <aside className="companion-rail">
-        <header className="companion-rail__header">
-          <span className="companion-rail__glyph">
-            {resolvedFamiliar ? (
-              <FamiliarAvatar familiar={resolvedFamiliar} size="sm" />
-            ) : (
-              <Icon name="ph:globe" width={16} />
-            )}
-          </span>
-          {familiar ? (
-            <>
-              <button
-                type="button"
-                className="companion-rail__name"
-                onClick={onOpenSwitcher}
-                aria-label="Switch familiar"
-              >
-                <span>{familiar.display_name}</span>
-              </button>
-              <span
-                className={`companion-rail__status${daemonRunning ? "" : " companion-rail__status--off"}`}
-                title={daemonRunning ? "Live" : "Daemon offline"}
-                aria-hidden
-              />
-            </>
-          ) : (
-            <span className="companion-rail__name companion-rail__name--static">
-              <span>Browser</span>
-            </span>
-          )}
-        </header>
+        {/* Familiar header removed — the tab strip is the panel's top row and
+            its trigger band aligns with the left sidebar's floating toggle. */}
         <nav className="companion-rail__tabs" aria-label="Companion sections">
           {!familiar || hideChatTab ? null : (
             <button


### PR DESCRIPTION
Removes the right side panel's familiar header and lines its tab strip up with the left sidebar's floating toggle.

- **Removed** the companion-rail header (avatar + name + presence dot, and the "Browser" static variant) — it duplicated the sidebar's familiar switcher and pushed the tabs out of line. The tab strip (Chat / Memory / Browser / Salem) is now the panel's top row. Dropped the now-unused `FamiliarAvatar` / `useResolvedFamiliars` imports and the `resolvedFamiliar` lookup; `onOpenSwitcher`/`daemonRunning` stay in the prop type (workspace still passes them) but are no longer consumed.
- **Aligned** the tab strip's top to `--shell-float-top` (the band the left sidebar's floating toggle sits at; 50px fallback), so the right panel's trigger row is level with the left panel's toggle trigger.

## Verification
Live (demo mode + Playwright): the familiar header is gone and the tab strip top renders at `50px`, matching the float band the left toggle uses. Full `pnpm test:app` + `pnpm test:api` + `pnpm build` + `tsc` green (`companion-rail.test.ts` updated to assert the header's removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)