### PR TITLE
polish(capabilities): minimal metadata layout in the inspector

### DIFF
--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -679,12 +679,14 @@ function CapabilityDetails({
         </button>
       </div>
 
-      {item.description ? <InspectorBlock label="Detail" value={item.description} /> : null}
-      {item.warningMessage ? <InspectorBlock label="Warning" value={item.warningMessage} tone="warning" /> : null}
-      {item.sourcePath ? <InspectorBlock label="Path" value={item.sourcePath} mono /> : null}
-      {item.command ? <InspectorBlock label="Command" value={item.command} mono /> : null}
-      {item.tags?.length ? <InspectorBlock label="Tags" value={item.tags.join(", ")} /> : null}
-      {item.scannedAt ? <InspectorBlock label="Scanned" value={new Date(item.scannedAt).toLocaleString()} /> : null}
+      <div className="divide-y divide-[var(--border-hairline)] border-t border-[var(--border-hairline)]">
+        {item.description ? <InspectorBlock label="Detail" value={item.description} /> : null}
+        {item.warningMessage ? <InspectorBlock label="Warning" value={item.warningMessage} tone="warning" /> : null}
+        {item.sourcePath ? <InspectorBlock label="Path" value={item.sourcePath} mono /> : null}
+        {item.command ? <InspectorBlock label="Command" value={item.command} mono /> : null}
+        {item.tags?.length ? <InspectorBlock label="Tags" value={item.tags.join(", ")} /> : null}
+        {item.scannedAt ? <InspectorBlock label="Scanned" value={new Date(item.scannedAt).toLocaleString()} /> : null}
+      </div>
 
       <div className="flex flex-wrap gap-1.5 border-t border-border pt-3">
         <InspectorAction
@@ -944,11 +946,15 @@ function InspectorBlock({
   tone?: "warning";
 }) {
   return (
-    <div>
-      <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-secondary)]">{label}</p>
-      <p className={`break-words rounded-md bg-muted px-2 py-1.5 text-[11px] leading-5 ${mono ? "font-mono" : ""} ${tone === "warning" ? "text-[var(--color-warning)]" : "text-muted-foreground"}`}>
+    <div className="grid grid-cols-[4.25rem_1fr] items-baseline gap-x-3 py-[7px]">
+      <span className="text-[9.5px] font-medium uppercase tracking-wider text-[var(--text-muted)]">{label}</span>
+      <span
+        className={`min-w-0 break-words text-[11px] leading-5 ${mono ? "font-mono text-[10.5px]" : ""} ${
+          tone === "warning" ? "text-[var(--color-warning)]" : "text-[var(--text-secondary)]"
+        }`}
+      >
         {value}
-      </p>
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
## What

Makes the capability inspector's metadata block more minimal/modern/sleek.

**Before:** each field (Detail / Warning / Path / Command / Tags / Scanned) was an uppercase bold header stacked over a full-width `bg-muted` filled box — visually heavy, lots of stacked boxes.

**After:** a borderless two-column definition list — small muted label on the left (`4.25rem` column), value on the right — with rows separated by subtle hairline dividers. No filled backgrounds, tighter rhythm. Path/Command stay monospace, just lighter.

Only `InspectorBlock` (the per-field renderer) and the grouping wrapper in `CapabilityDetails` change; the chips row, action buttons, and markdown preview are untouched.

## Verification

`tsc` typecheck ✓ · `capabilities-view` / `capabilities-view-polish` / `capabilities-normalize` tests ✓.

I couldn't grab a live screenshot — the inspector's Path/Tags/Scanned only populate from the real daemon scan, which a fresh demo-mode dev server doesn't expose. Please eyeball in-app; happy to tweak label-column width / divider weight / spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)