### PR TITLE
feat(library): replace native filter selects with a compact app-styled dropdown

### DIFF
--- a/src/components/library-timeline.tsx
+++ b/src/components/library-timeline.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Icon } from "@/lib/icon";
 import { ViewHeader } from "@/components/ui/view-header";
 import { SearchInput } from "@/components/ui/search-input";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -11,6 +12,84 @@ import type { Familiar } from "@/lib/types";
 
 type GroupBy = "date" | "source";
 type ListFilter = "all" | "bookmarks" | "reading" | "github";
+
+/**
+ * Compact, app-styled replacement for a native `<select>` in the timeline
+ * controls. The trigger keeps the `.library-timeline-select` look (and its
+ * mobile touch-target sizing); only the open menu is custom — a dense
+ * `role="menu"` with a check on the active option — instead of the OS dropdown.
+ */
+function TimelineSelect<T extends string>({
+  value,
+  options,
+  onChange,
+  ariaLabel,
+}: {
+  value: T;
+  options: { value: T; label: string }[];
+  onChange: (next: T) => void;
+  ariaLabel: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const current = options.find((o) => o.value === value);
+
+  return (
+    <div
+      ref={wrapRef}
+      className="library-timeline-dropdown"
+      onBlur={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setOpen(false);
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Escape" && open) {
+          e.stopPropagation();
+          setOpen(false);
+        }
+      }}
+    >
+      <button
+        type="button"
+        className="library-timeline-select library-timeline-select--trigger focus-ring"
+        aria-label={ariaLabel}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        {current?.label ?? ""}
+      </button>
+      {open ? (
+        <ul className="library-timeline-menu" role="menu" aria-label={ariaLabel}>
+          {options.map((o) => {
+            const active = o.value === value;
+            return (
+              <li key={o.value} role="none">
+                <button
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={active}
+                  className="library-timeline-menu-item focus-ring"
+                  onClick={() => {
+                    onChange(o.value);
+                    setOpen(false);
+                  }}
+                >
+                  <Icon
+                    name="ph:check-bold"
+                    width={12}
+                    className="library-timeline-menu-item__check"
+                    aria-hidden
+                  />
+                  <span className="library-timeline-menu-item__label">{o.label}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
 
 function timelineEntryKey(entry: TimelineEntry, index: number): string {
   const item = entry.item as TimelineEntry["item"] & { id?: string; url?: string };
@@ -110,17 +189,15 @@ export function LibraryTimeline({
         }
         filters={
           <div className="library-timeline-filters">
-            <select
-              className="library-timeline-select focus-ring"
+            <TimelineSelect
+              ariaLabel="Filter by familiar"
               value={familiarFilter}
-              onChange={(e) => setFamiliarFilter(e.target.value)}
-              aria-label="Filter by familiar"
-            >
-              <option value="all">Familiar: all</option>
-              {familiars.map((f) => (
-                <option key={f.id} value={f.id}>{f.display_name}</option>
-              ))}
-            </select>
+              onChange={setFamiliarFilter}
+              options={[
+                { value: "all", label: "Familiar: all" },
+                ...familiars.map((f) => ({ value: f.id, label: f.display_name })),
+              ]}
+            />
             <div className="library-timeline-group-toggle" role="group" aria-label="Group by">
               {(["date", "source"] as const).map((g) => (
                 <button
@@ -134,17 +211,17 @@ export function LibraryTimeline({
                 </button>
               ))}
             </div>
-            <select
-              className="library-timeline-select focus-ring"
+            <TimelineSelect<ListFilter>
+              ariaLabel="Filter by list"
               value={listFilter}
-              onChange={(e) => setListFilter(e.target.value as ListFilter)}
-              aria-label="Filter by list"
-            >
-              <option value="all">All lists</option>
-              <option value="bookmarks">Bookmarks</option>
-              <option value="reading">Reading</option>
-              <option value="github">GitHub</option>
-            </select>
+              onChange={setListFilter}
+              options={[
+                { value: "all", label: "All lists" },
+                { value: "bookmarks", label: "Bookmarks" },
+                { value: "reading", label: "Reading" },
+                { value: "github", label: "GitHub" },
+              ]}
+            />
           </div>
         }
       />

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -391,6 +391,98 @@
   box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--accent-presence) 38%, transparent);
 }
 
+/* ── Custom filter dropdown ──
+   The trigger keeps the .library-timeline-select look (border, gradient,
+   chevron, mobile touch sizing); only the menu is ours — a dense, app-styled
+   list instead of the OS <select> popup. */
+.library-timeline-dropdown {
+  position: relative;
+  min-width: 0;
+}
+
+.library-timeline-select--trigger {
+  display: block;
+  text-align: left;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+
+.library-timeline-menu {
+  position: absolute;
+  z-index: 60;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 100%;
+  max-width: min(240px, 70vw);
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  border: 1px solid var(--border-strong);
+  border-radius: 9px;
+  background: var(--bg-elevated);
+  box-shadow:
+    0 1px 0 color-mix(in oklch, var(--text-primary) 6%, transparent) inset,
+    0 14px 36px color-mix(in oklch, black 46%, transparent);
+  animation: library-timeline-menu-in var(--duration-fast) var(--ease-standard);
+}
+
+@keyframes library-timeline-menu-in {
+  from { opacity: 0; transform: translateY(-2px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.library-timeline-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  height: 30px;
+  padding: 0 10px 0 7px;
+  border-radius: 6px;
+  font-size: 12px;
+  line-height: 1;
+  color: var(--text-secondary);
+  text-align: left;
+  transition:
+    background-color var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard);
+}
+
+.library-timeline-menu-item__label {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.library-timeline-menu-item:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.library-timeline-menu-item__check {
+  flex-shrink: 0;
+  opacity: 0;
+  color: var(--accent-presence);
+}
+
+.library-timeline-menu-item[aria-checked="true"] {
+  color: var(--text-primary);
+}
+
+.library-timeline-menu-item[aria-checked="true"] .library-timeline-menu-item__check {
+  opacity: 1;
+}
+
+/* Phones: keep menu rows at the 44px touch target. */
+@media (max-width: 767px) {
+  .library-timeline-menu-item {
+    height: var(--touch-target);
+  }
+}
+
 /* Wide enough header → all filter options share one row. */
 @container view-header (min-width: 440px) {
   .library-timeline-filters {


### PR DESCRIPTION
## What

The library timeline's **familiar** and **list** filters were native `<select>`s, so opening one showed the bulky OS dropdown (spacious rows, OS chrome) — inconsistent with the rest of the Cave. This swaps them for a small `TimelineSelect` that renders a compact, app-styled menu.

| before | after |
|---|---|
| OS native `<select>` popup — large rows, OS styling | dense `role="menu"`: 30px rows, app surface + border, accent checkmark on the active option |

## How

- New `TimelineSelect` component in `library-timeline.tsx` (button trigger + custom `role="menu"` / `role="menuitemradio"` items with a check on the selected value). Closes on pick, blur, and Escape.
- The trigger **keeps the `.library-timeline-select` class**, so the closed control looks identical and the existing mobile touch-target sizing still applies. Only the open menu is ours.
- `library.css`: `.library-timeline-dropdown` / `.library-timeline-menu` / `.library-timeline-menu-item` (with a 44px mobile row floor and a subtle entrance animation).

## Verification

Drove the running app (library via ⌘6): both filters open a compact menu, picking an option updates the trigger label and moves the check, and the menu closes correctly. `tsc` clean; `library-timeline`, `library-polish`, `library-mobile-command-center`, `library-quick-open` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)