### PR TITLE
feat(shell): proximity glow on panel floats; drop the in-chat back chevron

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3189,6 +3189,7 @@ button:active > .edge-rail-chip {
 .shell-panel-float::before {
   content: "";
   position: absolute;
+  z-index: 1;
   /* Vertically centered on the side-panel header row — the 38px Inspector/Debug/
      Changes tab strip that sits directly below the ~45px chat scope-tabs header.
      The trigger + expand toggle read as part of that header rather than floating
@@ -3207,19 +3208,58 @@ button:active > .edge-rail-chip {
   box-shadow:
     inset 0 1px 0 color-mix(in oklch, var(--text-primary) 10%, transparent),
     0 6px 16px color-mix(in oklch, black 22%, transparent);
-  opacity: 0;
+  /* Fades in by cursor proximity (--float-prox, set per-float in shell.tsx);
+     :hover/:focus-visible below force it fully visible for direct interaction. */
+  opacity: var(--float-prox, 0);
   transform: translateX(-50%);
   -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
   transition: background 120ms ease, border-color 120ms ease, box-shadow 120ms ease, opacity 120ms ease, transform 80ms ease;
 }
 
+/* Pulsing accent halo behind the chip — gated by --float-prox so it only shows
+   (and pulses) as the cursor approaches the toggle. */
+.shell-panel-float::after {
+  content: "";
+  position: absolute;
+  top: var(--shell-float-top, 50px);
+  left: 50%;
+  width: 28px;
+  height: 28px;
+  border-radius: 10px;
+  z-index: 0;
+  pointer-events: none;
+  background: radial-gradient(circle, color-mix(in oklch, var(--accent-presence) 60%, transparent), transparent 70%);
+  opacity: 0;
+  transform: translateX(-50%) scale(1);
+  animation: shell-float-pulse 1800ms ease-in-out infinite;
+}
+
+@keyframes shell-float-pulse {
+  0%,
+  100% {
+    opacity: calc(var(--float-prox, 0) * 0.35);
+    transform: translateX(-50%) scale(1);
+  }
+  50% {
+    opacity: calc(var(--float-prox, 0) * 0.75);
+    transform: translateX(-50%) scale(1.55);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shell-panel-float::after {
+    animation: none;
+    opacity: calc(var(--float-prox, 0) * 0.4);
+  }
+}
+
 .shell-panel-float > svg {
   position: absolute;
   top: calc(var(--shell-float-top, 50px) + 6.5px);
   left: 50%;
-  z-index: 1;
-  opacity: 0;
+  z-index: 2;
+  opacity: var(--float-prox, 0);
   pointer-events: none;
   transform: translateX(-50%);
   transition: opacity 120ms ease, color 120ms ease, transform 80ms ease;

--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -28,34 +28,18 @@ assert.match(
   "ChatView renders MetaLine for the title + status banner",
 );
 
-assert.match(
-  source,
-  /onBack &&[\s\S]*aria-label="Back to chats"[\s\S]*onClick=\{onBack\}/,
-  "ChatView should expose a normal back button in the chat header",
-);
-
-assert.match(
-  source,
-  /function ChatBackButton\(\{ onBack \}[\s\S]*aria-label="Back to chats"[\s\S]*onClick=\{onBack\}[\s\S]*<Icon name="ph:arrow-left-bold"[\s\S]*<\/button>/,
-  "ChatView back button should be a reusable icon-only control",
-);
-
-assert.match(
-  source,
-  /<div className=\{`cave-chat-meta-line[\s\S]*\{onBack \? <ChatBackButton onBack=\{onBack\} \/> : null\}[\s\S]*<ChatTitleEditable/,
-  "ChatView back button should sit inline before the desktop chat title",
-);
-
-assert.match(
-  source,
-  /<div className="cave-mobile-header-familiar">\s*\{onBack \? <ChatBackButton onBack=\{onBack\} \/> : null\}\s*<FamiliarIcon/,
-  "ChatView mobile header should reuse the icon-only back control next to the chat name",
-);
-
+// The in-chat "back to chats" chevron was removed — the chat header stays
+// minimal and navigation back to the list is via the sidebar/list. (onBack is
+// still used to navigate away after a delete.)
 assert.doesNotMatch(
   source,
-  /aria-label="Back to chats"[\s\S]*>\s*<Icon name="ph:arrow-left-bold"[\s\S]*>\s*Back\s*<\/button>/,
-  "ChatView back button should not render a separate text label",
+  /ChatBackButton/,
+  "the ChatBackButton component and its renders are removed",
+);
+assert.doesNotMatch(
+  source,
+  /aria-label="Back to chats"/,
+  "the back-to-chats control is gone from the chat header",
 );
 
 assert.match(

--- a/src/components/chat-router-switching.test.ts
+++ b/src/components/chat-router-switching.test.ts
@@ -286,7 +286,7 @@ assert.equal(
 //    closing find never reaches the composer's Esc handling, and Enter /
 //    Shift+Enter cycle next/prev.
 const findBarComponent =
-  chatViewSource.match(/function ChatFindBar\(\{[\s\S]*?\nfunction ChatBackButton/)?.[0] ?? "";
+  chatViewSource.match(/function ChatFindBar\(\{[\s\S]*?\nfunction MetaLineElapsed/)?.[0] ?? "";
 
 assert.match(
   findBarComponent,

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -220,10 +220,10 @@ assert.doesNotMatch(
   "ChatLifecycleStatus bar should be folded into the header meta line",
 );
 
-assert.match(
+assert.doesNotMatch(
   source,
-  /className="cave-chat-icon-button cave-chat-back-button/,
-  "Open chat back control should use the shared minimal icon-button treatment",
+  /cave-chat-back-button/,
+  "the in-chat back-to-chats control is removed",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1098,19 +1098,6 @@ function ChatFindBar({
   );
 }
 
-function ChatBackButton({ onBack }: { onBack: () => void }) {
-  return (
-    <button
-      type="button"
-      className="cave-chat-icon-button cave-chat-back-button focus-ring"
-      aria-label="Back to chats"
-      onClick={onBack}
-    >
-      <Icon name="ph:arrow-left-bold" width={12} aria-hidden />
-    </button>
-  );
-}
-
 /** CHAT-D3-06: compact ticking elapsed for the streaming/tooling meta line,
  *  so the wall-clock counter survives past the first token (ThinkingIndicator
  *  swaps to text and takes its counter with it). Same 1s interval pattern as
@@ -1197,7 +1184,6 @@ function MetaLine({
   return (
     <div className={`cave-chat-meta-line cave-chat-meta-line--${state}`} role="status" aria-live="polite" data-lifecycle={state}>
       {state !== "complete" ? <span className="cave-chat-meta-line__dot" aria-hidden /> : null}
-      {onBack ? <ChatBackButton onBack={onBack} /> : null}
       {session ? (
         <ChatTitleEditable
           session={session}
@@ -2928,8 +2914,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       <header className="cave-chat-linear-header">
         <div className="cave-mobile-header-identity">
           <div className="cave-mobile-header-familiar">
-            {onBack ? <ChatBackButton onBack={onBack} /> : null}
-            <FamiliarIcon familiar={familiar} size="sm" />
+                  <FamiliarIcon familiar={familiar} size="sm" />
             <div className="min-w-0">
               <div className="truncate text-[13px] font-semibold leading-tight text-[var(--text-primary)]">{familiar.display_name}</div>
               <div className="truncate font-mono text-[10px] leading-tight text-[var(--text-muted)]">

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -161,4 +161,24 @@ assert.doesNotMatch(
   "Shell no longer wires the retired in-panel collapse event",
 );
 
+// Proximity glow: floats fade in (and pulse) as the cursor approaches. shell.tsx
+// tracks mousemove distance and sets --float-prox per float; the CSS drives the
+// chip opacity + the pulse halo from it.
+assert.match(shell, /addEventListener\("mousemove"/, "shell listens for mousemove to track cursor proximity");
+assert.match(
+  shell,
+  /setProperty\("--float-prox"/,
+  "shell sets a per-float --float-prox from cursor distance",
+);
+assert.match(
+  css,
+  /\.shell-panel-float::before \{[\s\S]*?opacity: var\(--float-prox, 0\)/,
+  "the float chip fades in by cursor proximity",
+);
+assert.match(
+  css,
+  /@keyframes shell-float-pulse \{[\s\S]*?var\(--float-prox, 0\)/,
+  "the proximity halo pulses with intensity gated by --float-prox",
+);
+
 console.log("shell-edge-rails.test.ts OK");

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -325,6 +325,40 @@ function ShellInner({
     return () => window.clearTimeout(t);
   }, [mounted]);
 
+  // Proximity glow: as the cursor moves toward a floating panel toggle, fade in
+  // (and pulse) its chip. Each float gets a `--float-prox` (0→1) driven by the
+  // cursor's distance to the chip; the CSS uses it for opacity + the pulse.
+  useEffect(() => {
+    if (!mounted || isMobile) return;
+    const RANGE = 200; // px — how far out the glow starts responding
+    let raf = 0;
+    const onMove = (e: MouseEvent) => {
+      if (raf) return;
+      raf = window.requestAnimationFrame(() => {
+        raf = 0;
+        const floatTop =
+          parseFloat(
+            getComputedStyle(document.documentElement).getPropertyValue("--shell-float-top"),
+          ) || 50;
+        for (const el of document.querySelectorAll<HTMLElement>(".shell-panel-float")) {
+          const r = el.getBoundingClientRect();
+          // Chip center: horizontally centered in the 44px column, vertically at
+          // the float band (top + ~14px to the 28px chip's center).
+          const cx = r.left + r.width / 2;
+          const cy = r.top + floatTop + 14;
+          const dist = Math.hypot(e.clientX - cx, e.clientY - cy);
+          const prox = Math.max(0, Math.min(1, 1 - dist / RANGE));
+          el.style.setProperty("--float-prox", prox.toFixed(3));
+        }
+      });
+    };
+    window.addEventListener("mousemove", onMove, { passive: true });
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      if (raf) window.cancelAnimationFrame(raf);
+    };
+  }, [mounted, isMobile]);
+
   useEffect(() => {
     onNavOpenChange?.(navOpen);
   }, [navOpen, onNavOpenChange]);


### PR DESCRIPTION
Two tweaks to the floating panel toggles and the chat header.

## Proximity glow on the floating toggles
The toggles now fade in (and pulse) as the cursor moves toward them:
- `shell.tsx` tracks `mousemove` distance to each float's chip (within 200px) and sets a per-float `--float-prox` (0→1, rAF-throttled, desktop-only).
- `globals.css` drives the chip (`::before`) + icon opacity from `--float-prox`, and adds a pulsing accent halo (`::after`) whose intensity is gated by `--float-prox` — a soft background pulse appears as you approach. `prefers-reduced-motion` → static glow, no pulse. `:hover`/`:focus-visible` still force full visibility for direct/keyboard use.

## Drop the in-chat back chevron
Removed the "back to chats" `<` (`ChatBackButton`) from the desktop meta line **and** the mobile header, plus the component itself. Back-to-list nav stays available via the sidebar/list; `onBack` is still used to navigate away after a delete.

## Tests
`chat-header-row` / `chat-view-polish` / `chat-router-switching` updated for the back-button removal; `shell-edge-rails` gains proximity-glow assertions.

## Verification
Live (demo + Playwright): cursor near a float → `--float-prox ≈ 0.99`, chip visible + halo pulsing; cursor away → `0.0`, faded out; chat header renders no back chevron. Full `pnpm test:app` + `pnpm test:api` + `pnpm build` + `tsc` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)