### PR TITLE
fix(chat): stop session-row meta overlapping in the narrow Companion Rail

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5199,6 +5199,30 @@ button:active > .edge-rail-chip {
   justify-content: center;
 }
 
+/* The chat list renders both full-width (the chat surface rail) and narrow
+   (the per-familiar Companion Rail, ~440-480px). In the narrow case the row
+   meta's tags (familiar name + origin/initiator chips) and the right-aligned
+   date/time can't share one line — the chips overflow their shrunk box and
+   collide with the date. Make the surface a query container and stack the meta
+   (date below the tags) when the container is narrow, regardless of viewport. */
+.chat-list-surface {
+  container-type: inline-size;
+  container-name: chatlist;
+}
+@container chatlist (max-width: 520px) {
+  .chat-list-row-meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+  }
+  .chat-list-row-tags {
+    max-width: 100%;
+  }
+  .chat-list-row-time {
+    width: auto;
+  }
+}
+
 /* Touch / coarse-pointer surface. On devices with no hover capability,
    controls that the desktop hides behind `opacity-0 group-hover:opacity-100`
    become permanently visible — opt in with `.touch-always-visible`. */


### PR DESCRIPTION
In the per-familiar **Companion Rail** (the narrow ~440–480px side panel with the chat/brain/globe/book tabs), session-row metadata overlaps: the familiar/origin/initiator chips collide with the right-aligned date — e.g. the "You"/"Nova" chip rendering on top of "Jun 16, 2026".

## Cause
The session-row meta is a one-line `flex justify-between` (tags left, date/time right). The chips inside the tags don't shrink, so when the rail is narrow they overflow their (min-w-0) box and visually collide with the date. The list's existing stacked layout is gated on **viewport** width (`@media max-width: 767px`), so it never triggers for a narrow rail on a desktop viewport (same viewport-vs-container trap as #840).

## Fix
Make `.chat-list-surface` a **query container** and stack the meta (date below the tags) at `@container (max-width: 520px)` — independent of viewport. Full-width rails (chat surface) keep the single-row layout.

## Verification (running app, mocked sessions)
- Container ≤520px → meta `flex-direction: column`, tags on line 1, date on line 2 — **no overlap** (screenshot confirms "coven-cave · chat · You" then "Jun 16, 2026 · 9h ago").
- Container >520px (640px tested) → single row, `space-between`, as before.
- `globals.css` test passes; braces balanced; `pnpm build` green. CSS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)