### PR TITLE
style(chat): remove orphaned .chat-scope-tabs__new CSS

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5300,14 +5300,9 @@ button:active > .edge-rail-chip {
     -webkit-backdrop-filter: blur(14px) saturate(140%);
   }
 
-  .chat-scope-tabs [role="tab"],
-  .chat-scope-tabs__new {
+  .chat-scope-tabs [role="tab"] {
     min-height: var(--touch-target);
     -webkit-tap-highlight-color: transparent;
-  }
-
-  .chat-scope-tabs__new {
-    padding-inline: 12px;
   }
 
   .calendar-toolbar {
@@ -5587,16 +5582,6 @@ button:active > .edge-rail-chip {
 
 .chat-scope-tabs--minimal [role="tab"] {
   padding-block: 8px;
-}
-
-.chat-scope-tabs__new {
-  border: 1px solid transparent;
-  border-radius: 6px;
-  padding-inline: 6px;
-}
-
-.chat-scope-tabs__new:hover {
-  background: color-mix(in oklch, var(--bg-hover) 64%, transparent);
 }
 
 /* Dynamic viewport units for layout shell + modals — `100vh` on iOS

--- a/src/components/chat-surface-mobile-command-center.test.ts
+++ b/src/components/chat-surface-mobile-command-center.test.ts
@@ -37,8 +37,8 @@ assert.match(
 
 assert.match(
   styles,
-  /@media \(max-width: 767px\) \{[\s\S]*\.chat-scope-tabs \[role="tab"\],[\s\S]*\.chat-scope-tabs__new\s*\{[\s\S]*min-height\s*:\s*var\(--touch-target\)/,
-  "Mobile chat scope tabs and New action should meet the shared touch target",
+  /@media \(max-width: 767px\) \{[\s\S]*\.chat-scope-tabs \[role="tab"\]\s*\{[\s\S]*min-height\s*:\s*var\(--touch-target\)/,
+  "Mobile chat scope tabs should meet the shared touch target",
 );
 
 assert.match(


### PR DESCRIPTION
Cleanup follow-up to #856, which removed the redundant top-right "+ New" button from the chat scope-tab strip but left its CSS behind.

## Change
- Remove the four dead `.chat-scope-tabs__new` rules from `globals.css` (the mobile touch-target grouping, mobile padding, base border/radius/padding, and `:hover`).
- Drop the now-removed selector from the `chat-surface-mobile-command-center` touch-target assertion.

No live element references `.chat-scope-tabs__new` anymore (confirmed 0 in `chat-surface.tsx`).

## Verification
- 0 `chat-scope-tabs__new` occurrences left in `globals.css`; braces balanced.
- `chat-surface`, `chat-surface-mobile-command-center`, and `globals.css` tests pass; `pnpm build` green. Net −15 lines.