### PR TITLE
polish(capabilities): accent-color the Detail Show more/less toggle

### DIFF
--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -960,7 +960,7 @@ function ClampedValue({ value, tone }: { value: string; tone?: "warning" }) {
           type="button"
           onClick={() => setExpanded((v) => !v)}
           aria-expanded={expanded}
-          className="focus-ring mt-0.5 text-[10px] font-medium text-[var(--text-muted)] transition-colors hover:text-[var(--text-secondary)]"
+          className="focus-ring mt-0.5 text-[10px] font-medium text-[var(--accent-presence)] transition-colors hover:underline"
         >
           {expanded ? "Show less" : "Show more"}
         </button>


### PR DESCRIPTION
## What

Recolors the capability inspector's **Show more / Show less** clamp toggle from muted grey to the lavender accent (`text-[var(--accent-presence)] hover:underline`), so it reads as the interactive control — matching the app's accent-link convention.

One-line className change. Verified live: computed color is `rgb(154, 142, 205)` = `--accent-presence`.

`tsc` ✓ · capabilities-view-polish test ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)