### PR TITLE
polish(capabilities): shrink the Detail Show more/less toggle text

### DIFF
--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -960,7 +960,7 @@ function ClampedValue({ value, tone }: { value: string; tone?: "warning" }) {
           type="button"
           onClick={() => setExpanded((v) => !v)}
           aria-expanded={expanded}
-          className="focus-ring mt-0.5 text-[10px] font-medium text-[var(--accent-presence)] transition-colors hover:underline"
+          className="focus-ring mt-0.5 text-[9px] font-medium text-[var(--accent-presence)] transition-colors hover:underline"
         >
           {expanded ? "Show less" : "Show more"}
         </button>


### PR DESCRIPTION
Shrinks the capability inspector's **Show more / Show less** clamp toggle from `text-[10px]` to `text-[9px]`, so it reads as a quieter secondary control under the description. One-line className change. `tsc` ✓ · polish test ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)