### PR TITLE
fix(shell): tighten panel-toggle proximity-glow range (250→160px)

### DIFF
--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -330,7 +330,7 @@ function ShellInner({
   // cursor's distance to the chip; the CSS uses it for opacity + the pulse.
   useEffect(() => {
     if (!mounted || isMobile) return;
-    const RANGE = 250; // px — how far out the glow starts responding
+    const RANGE = 160; // px — how far out the glow starts responding (tighter: kicks in closer to the toggle)
     let raf = 0;
     const onMove = (e: MouseEvent) => {
       if (raf) return;


### PR DESCRIPTION
The floating panel toggles' proximity glow started responding from 250px away — too early. Shortens the activation distance to **160px** so the glow/pulse kicks in closer to the toggle. One-line change to the `RANGE` constant in `shell.tsx`; `tsc` + `shell-edge-rails` test + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)