### PR TITLE
polish(capabilities): shrink the Detail/Warning value text

### DIFF
--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -949,7 +949,7 @@ function ClampedValue({ value, tone }: { value: string; tone?: "warning" }) {
     <div className="min-w-0">
       <span
         ref={ref}
-        className={`break-words text-[11px] leading-5 ${expanded ? "block" : "line-clamp-3"} ${
+        className={`break-words text-[10px] leading-[17px] ${expanded ? "block" : "line-clamp-3"} ${
           tone === "warning" ? "text-[var(--color-warning)]" : "text-[var(--text-secondary)]"
         }`}
       >


### PR DESCRIPTION
Shrinks the capability inspector's clamped prose value (Detail / Warning) from `text-[11px]` to `text-[10px]` with a tighter `17px` line-height, so the description reads as compact secondary detail. One-line className change. `tsc` ✓ · polish test ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)