### PR TITLE
chore(workflows): add saved node positions for prepare-social-post

### DIFF
--- a/workflows/prepare-social-post.cave.json
+++ b/workflows/prepare-social-post.cave.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "positions": {
+    "brief": {
+      "x": 80,
+      "y": 80
+    },
+    "draft-posts": {
+      "x": 80,
+      "y": 220
+    },
+    "check-claims": {
+      "x": 80,
+      "y": 360
+    },
+    "approval-gate": {
+      "x": 80,
+      "y": 500
+    },
+    "store-state": {
+      "x": 80,
+      "y": 640
+    }
+  }
+}


### PR DESCRIPTION
Persists the Workflow Studio graph layout (node x/y positions) for the existing **prepare-social-post** workflow — a 325-byte `*.cave.json` companion, matching the already-tracked position files for the other workflows (`annotate-document.cave.json`, `coordination-router.cave.json`, `curate-reading-list.cave.json`, …).

The paired `workflows/prepare-social-post.yaml` is already on `main`, so this isn't orphaned. Data-only (positions JSON); no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)