### PR TITLE
polish(capabilities): shrink the mono Path/Command value text

### DIFF
--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -989,7 +989,7 @@ function InspectorBlock({
         <ClampedValue value={value} tone={tone} />
       ) : (
         <span
-          className={`min-w-0 break-words text-[11px] leading-5 ${mono ? "font-mono text-[10.5px]" : ""} ${
+          className={`min-w-0 break-words text-[11px] leading-5 ${mono ? "font-mono text-[9.5px]" : ""} ${
             tone === "warning" ? "text-[var(--color-warning)]" : "text-[var(--text-secondary)]"
           }`}
         >


### PR DESCRIPTION
Shrinks the capability inspector's monospace value (PATH / Command) from `text-[10.5px]` to `text-[9.5px]`, so paths read as compact reference detail. One-line className change. `tsc` ✓ · polish test ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)