### PR TITLE
feat(salem): icon perch label; always hide the perch when the side panel is open

### DIFF
--- a/src/components/salem/salem-widget.tsx
+++ b/src/components/salem/salem-widget.tsx
@@ -91,7 +91,9 @@ export function SalemWidget({ retreat = false }: SalemWidgetProps) {
       tabIndex={retreating ? -1 : undefined}
     >
       <SalemCat3D mood={mood} size={88} />
-      <span className="salem-perch__label">Salem</span>
+      <span className="salem-perch__label" aria-hidden>
+        <Icon name="ph:chat-circle-dots-fill" width={13} />
+      </span>
     </button>
   );
 }

--- a/src/components/salem/salem.test.ts
+++ b/src/components/salem/salem.test.ts
@@ -30,6 +30,11 @@ assert.match(widget, /size=\{88\}/, "perch cat must be large enough to read on d
 assert.match(widget, /clientX >= window\.innerWidth - 2/, "floating Salem must retreat when the pointer leaves through the right edge");
 assert.match(widget, /clientX < window\.innerWidth - 96/, "floating Salem must return when the pointer moves back from the right edge");
 assert.match(widget, /salem-perch--retreating/, "floating Salem must expose a retreating class");
+assert.match(
+  widget,
+  /salem-perch__label[\s\S]*?<Icon name="ph:chat-circle-dots-fill"/,
+  "the perch label is an icon (chat-with-Salem), not a text label",
+);
 assert.doesNotMatch(widget, /salem-msg__glyph|🐱|😅/, "open Salem chat must not render emoji glyphs");
 
 // 3. Salem preload context exists
@@ -73,7 +78,8 @@ assert.match(workspace, /cave:salem-open/, "workspace must listen for Salem laun
 assert.match(workspace, /shellRef\.current\?\.openFamiliar\(\)/, "Salem launcher must expand the right panel");
 assert.match(workspace, /setRailTab\("salem"\)/, "Salem launcher must select the Salem rail tab");
 assert.match(workspace, /import \{ SalemChatPanel, SalemWidget \}/, "workspace must import both Salem surfaces");
-assert.match(workspace, /const salemRetreating = mode === "chat" \|\| mode === "workflows" \|\| mode === "browser" \|\| mode === "terminal"/, "workspace must retreat floating Salem on crowded surfaces");
+assert.match(workspace, /const salemRetreating =[\s\S]*?mode === "chat"[\s\S]*?mode === "workflows"[\s\S]*?mode === "browser"[\s\S]*?mode === "terminal"/, "workspace must retreat floating Salem on crowded surfaces");
+assert.match(workspace, /const salemRetreating =\s*\n?\s*familiarPanelOpen \|\|/, "floating Salem must always retreat while the right side panel is open");
 assert.match(workspace, /<SalemWidget retreat=\{salemRetreating\} \/>/, "workspace must render floating Salem with screen-driven retreat state");
 assert.match(workspace, /salemSlot=\{<SalemChatPanel \/>\}/, "workspace must render Salem in the companion rail");
 assert.match(companionRail, /"salem"/, "companion rail must expose a Salem tab");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1494,7 +1494,14 @@ export function Workspace() {
       inboxBadgeCount={inboxBadgeCount}
     />
   );
-  const salemRetreating = mode === "chat" || mode === "workflows" || mode === "browser" || mode === "terminal";
+  // The Salem perch retreats on dense work surfaces, and ALWAYS while the right
+  // side panel (companion) is open — so it never overlaps that panel.
+  const salemRetreating =
+    familiarPanelOpen ||
+    mode === "chat" ||
+    mode === "workflows" ||
+    mode === "browser" ||
+    mode === "terminal";
 
   return (
     <FamiliarStudioProvider>


### PR DESCRIPTION
Two Salem-perch tweaks.

- **Icon label** — the perch's "SALEM" text label is replaced with a chat icon (`ph:chat-circle-dots-fill`) under the cat, a cleaner "chat with Salem" affordance than the wordmark.
- **Always hide when the side panel is open** — the floating perch now retreats (slides off, opacity 0) whenever the right side panel (companion) is open, on any surface. Added `familiarPanelOpen` to `salemRetreating` so it never overlaps that panel.

## Verification
Live (demo + Playwright): home shows the perch with the icon label and no text; opening the side panel drops the perch to `opacity: 0` (retreating). `salem.test.ts` updated (icon-label assertion + `salemRetreating` gated on `familiarPanelOpen`). Full `pnpm test:app` + `pnpm test:api` + `pnpm build` + `tsc` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)