### PR TITLE
chore(release): v0.0.97

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.97] - 2026-06-16
+
+Patch release: per-session branch-diff in the new recent-activity roll-up, magic corner sidepanel triggers, and a sweep of capability-inspector polish after 0.0.96.
+
+### Added
+- **Activity** — recent-activity roll-up in the left panel + a top-right inbox toast (#880).
+- **Activity** — per-session branch diff in the roll-up: each session's own branch vs the repo's default base, cached per `(root, branch)` (#883).
+- **Shell** — corner sidepanel triggers cast from a distance (proximity-glow magic triggers) (#881).
+- **Workflows** — saved node positions for the `prepare-social-post` workflow (#886).
+
+### Fixed
+- **Chat** — session-row meta no longer overlaps in the narrow Companion Rail (#874).
+- **Capabilities** — skill description now renders in the inspector Detail row (#875).
+- **Shell** — tightened panel-toggle proximity-glow range (250→160px) (#884).
+- **CSS** — dropped orphaned `.chat-scope-tabs__new` styles (#877).
+
+### Polished
+- **Capabilities** — Detail/Warning clamps to 3 lines with Show more/less (#876).
+- **Capabilities** — Show more/less toggle uses accent-color (#879) and tighter type (#882).
+- **Capabilities** — Detail/Warning value text and mono Path/Command text use compact reference sizing (#885, #887).
+
 ## [0.0.96] - 2026-06-16
 
 Patch release: GitHub org/repo filtering improvements, Codex-style floating panel toggles, an expanding chat right-panel, Agent Completion Reports, and theme/header fixes after 0.0.95.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A familiar is not just a chat window. It has a name, role, runtime, memory, tool
 
 ## Status
 
-- Current app version: `0.0.96`
+- Current app version: `0.0.97`
 - Native shell: Tauri 2
 - Frontend: Next.js 16, React 19, Tailwind v4
 - Runtime dependency: a healthy local `coven` CLI/daemon plus at least one runtime source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.96",
+  "version": "0.0.97",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.96"
+version = "0.0.97"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.96"
+version = "0.0.97"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.96</string>
+	<string>0.0.97</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.96</string>
+	<string>0.0.97</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.96</string>
+	<string>0.0.97</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.96</string>
+	<string>0.0.97</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.96",
+  "version": "0.0.97",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Cuts **v0.0.97**, bundling 13 commits since `v0.0.96`. Version bumped across the 8 release files + `[0.0.97]` CHANGELOG section.

Highlights:
- **Activity** — recent-activity roll-up in the left panel + top-right inbox toast (#880).
- **Activity** — per-session branch diff in the roll-up: each session's branch vs the repo's default base, cached per `(root, branch)` (#883).
- **Shell** — corner sidepanel triggers cast from a distance (proximity-glow magic triggers) (#881), with proximity-glow range tightened to 250→160px (#884).
- **Capabilities** — clamp Detail/Warning to 3 lines with Show more/less (#876), accent-color the toggle (#879), tighter type on the toggle (#882), Detail/Warning value text (#885), and mono Path/Command text (#887).
- **Capabilities** — show the skill description in the inspector Detail row (#875).
- **Chat** — stop session-row meta overlapping in the narrow Companion Rail (#874).
- **Workflows** — saved node positions for `prepare-social-post` (#886).
- **CSS** — drop orphaned `.chat-scope-tabs__new` styles (#877).

Verification:
- `app-version.test.ts` ✅
- `pnpm typecheck` ✅
- `cargo check` ✅ (`Compiling app v0.0.97` → `Finished dev profile in 14.91s`)

Tag `v0.0.97` will be pushed after merge → notarized DMG / AppImage / MSI / iOS build.

Co-authored-by: Nova <nova@opencoven.ai>
