### PR TITLE
fix(capabilities): actually shrink the mono Path/Command text

### DIFF
--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -989,7 +989,7 @@ function InspectorBlock({
         <ClampedValue value={value} tone={tone} />
       ) : (
         <span
-          className={`min-w-0 break-words text-[11px] leading-5 ${mono ? "font-mono text-[9.5px]" : ""} ${
+          className={`min-w-0 break-words leading-5 ${mono ? "font-mono text-[9.5px]" : "text-[11px]"} ${
             tone === "warning" ? "text-[var(--color-warning)]" : "text-[var(--text-secondary)]"
           }`}
         >


### PR DESCRIPTION
## What

#887 tried to shrink the PATH/Command mono text but was a **no-op**: it added `text-[9.5px]` alongside the existing `text-[11px]` on the same span, and `text-[11px]` won the cascade — so the path stayed 11px.

Fix: make the size **conditional** (`mono ? text-[9.5px] : text-[11px]`) so only one size class applies. Verified live — the path span now computes **9.5px** (was 11px).

`tsc` ✓ · capabilities-view-polish test ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)