### PR TITLE
chore(release): v0.0.98

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.98] - 2026-06-16
+
+Patch release: capability inspector text-size polish, a more dramatic shell sparkle, and saved workflow node-position updates after 0.0.97.
+
+### Fixed
+- **Capabilities** — mono Path/Command text now applies only the compact `9.5px` class instead of losing to the base `11px` class in the cascade (#892).
+
+### Polished
+- **Shell** — corner-trigger sparkle now casts with a brighter, more dramatic pass (#893).
+- **Workflows** — refreshed saved node positions for `curate-reading-list` and `research-brief`.
+
 ## [0.0.97] - 2026-06-16
 
 Patch release: per-session branch-diff in the new recent-activity roll-up, magic corner sidepanel triggers (now click-to-open), Salem perch polish, and a sweep of capability-inspector polish after 0.0.96.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A familiar is not just a chat window. It has a name, role, runtime, memory, tool
 
 ## Status
 
-- Current app version: `0.0.97`
+- Current app version: `0.0.98`
 - Native shell: Tauri 2
 - Frontend: Next.js 16, React 19, Tailwind v4
 - Runtime dependency: a healthy local `coven` CLI/daemon plus at least one runtime source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.97",
+  "version": "0.0.98",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.97"
+version = "0.0.98"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.97"
+version = "0.0.98"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.97</string>
+	<string>0.0.98</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.97</string>
+	<string>0.0.98</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.97</string>
+	<string>0.0.98</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.97</string>
+	<string>0.0.98</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.97",
+  "version": "0.0.98",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- Bump CovenCave release metadata to 0.0.98 across package, Tauri, Cargo, and iOS plist files.
- Add the 0.0.98 changelog entry for capability text-size polish, shell sparkle polish, and workflow node-position updates.
- Update the README current app version.

## Verification
- `pnpm typecheck`
- `pnpm check:tests-wired`
- `node scripts/release-notes.test.mjs && node --experimental-strip-types scripts/release-macos-signing.test.mjs`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm test:mobile`
- `cargo check --locked` in `src-tauri`
- `pnpm build` was attempted with the CI retry loop and failed locally because DNS resolution to Google Fonts timed out (`fonts.googleapis.com` / `fonts.gstatic.com`). This should be rechecked by GitHub CI before tagging.