### PR TITLE
feat(salem): cursor-proximity perch — small + translucent, grows on approach

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5637,10 +5637,25 @@ button:active > .edge-rail-chip {
     drop-shadow(0 0 16px color-mix(in oklch, var(--accent-presence) 45%, transparent));
   transform: translate3d(0, 0, 0);
   transform-origin: 50% 80%;
+  /* Cursor-proximity presence: the perch rests small + translucent and grows to
+     full size/opacity as the pointer nears. JS writes --salem-proximity (0 far →
+     1 near); scale uses the standalone `scale` property so it composes with the
+     retreat/hover `transform`. */
+  --salem-proximity: 0;
+  scale: calc(0.62 + 0.38 * var(--salem-proximity));
+  opacity: calc(0.38 + 0.62 * var(--salem-proximity));
   transition:
     transform 0.52s cubic-bezier(0.22, 1, 0.36, 1),
-    opacity 0.28s ease,
+    scale 0.2s ease,
+    opacity 0.2s ease,
     filter 0.18s ease;
+}
+/* Touch / no-hover: there's no cursor to approach, so keep the perch fully
+   present instead of stuck small + translucent. */
+@media (hover: none), (pointer: coarse) {
+  .salem-perch {
+    --salem-proximity: 1;
+  }
 }
 .salem-perch::before {
   content: "";
@@ -5663,7 +5678,8 @@ button:active > .edge-rail-chip {
   transform: translateX(-50%);
 }
 .salem-perch:hover {
-  transform: translateY(-4px) scale(1.06);
+  transform: translateY(-4px);
+  scale: 1.06;
   filter:
     drop-shadow(0 10px 22px rgba(0, 0, 0, 0.42))
     drop-shadow(0 0 24px color-mix(in oklch, var(--accent-presence) 62%, transparent));
@@ -5672,7 +5688,8 @@ button:active > .edge-rail-chip {
 .salem-perch--retreating:hover {
   pointer-events: none;
   opacity: 0;
-  transform: translate3d(calc(100% + 36px), 10px, 0) rotate(5deg) scale(0.96);
+  transform: translate3d(calc(100% + 36px), 10px, 0) rotate(5deg);
+  scale: 0.96;
   filter:
     drop-shadow(0 5px 12px rgba(0, 0, 0, 0.24))
     drop-shadow(0 0 10px color-mix(in oklch, var(--accent-presence) 28%, transparent));
@@ -5691,6 +5708,8 @@ button:active > .edge-rail-chip {
 
 @media (prefers-reduced-motion: reduce) {
   .salem-perch {
+    /* No cursor-driven growth — keep the perch at full presence. */
+    --salem-proximity: 1;
     transition: opacity 0.12s ease, filter 0.12s ease;
   }
   .salem-perch--retreating,

--- a/src/components/salem/salem-widget.tsx
+++ b/src/components/salem/salem-widget.tsx
@@ -5,6 +5,7 @@ import { Icon } from "@/lib/icon";
 import type { SalemPreloadContext } from "./salem-context";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { useIsCoarsePointer } from "@/lib/use-viewport";
+import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
 import { SalemPathfinderCard } from "./salem-pathfinder-card";
 import type { SalemPathfinderCard as SalemPathfinderCardData } from "@/lib/salem/pathfinder-types";
 // Salem's 2D cat avatar (floating perch 88px + chat panel 40px). Replaced the
@@ -29,6 +30,9 @@ export function SalemWidget({ retreat = false }: SalemWidgetProps) {
   const [mood, setMood] = useState<SalemMood>("idle");
   const [docked, setDocked] = useState(false);
   const [edgeRetreating, setEdgeRetreating] = useState(false);
+  const perchRef = useRef<HTMLButtonElement>(null);
+  const coarse = useIsCoarsePointer();
+  const reducedMotion = usePrefersReducedMotion();
 
   useEffect(() => {
     const dock = () => setDocked(true);
@@ -50,6 +54,37 @@ export function SalemWidget({ retreat = false }: SalemWidgetProps) {
     return () => window.removeEventListener("pointermove", onPointerMove);
   }, []);
 
+  // Proximity: the perch rests small + translucent and grows toward full size /
+  // opacity as the cursor approaches it. Drives a `--salem-proximity` CSS var
+  // (0 far → 1 near), written straight to the node in a rAF tick to avoid a
+  // re-render per pointer move. Skipped on touch / reduced-motion (CSS pins the
+  // var to 1 there so the perch is always fully visible).
+  useEffect(() => {
+    if (coarse || reducedMotion || docked) return;
+    const el = perchRef.current;
+    if (!el) return;
+    const RADIUS = 280;
+    let raf = 0;
+    let target = 0;
+    const apply = () => {
+      raf = 0;
+      el.style.setProperty("--salem-proximity", target.toFixed(3));
+    };
+    const onMove = (event: PointerEvent) => {
+      const rect = el.getBoundingClientRect();
+      const dx = event.clientX - (rect.left + rect.width / 2);
+      const dy = event.clientY - (rect.top + rect.height / 2);
+      const distance = Math.hypot(dx, dy);
+      target = Math.max(0, Math.min(1, 1 - distance / RADIUS));
+      if (!raf) raf = requestAnimationFrame(apply);
+    };
+    window.addEventListener("pointermove", onMove, { passive: true });
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [coarse, reducedMotion, docked]);
+
   const open = () => {
     setDocked(true);
     openSalemPanel();
@@ -61,6 +96,7 @@ export function SalemWidget({ retreat = false }: SalemWidgetProps) {
 
   return (
     <button
+      ref={perchRef}
       type="button"
       className={`salem-perch${retreat || edgeRetreating ? " salem-perch--retreating" : ""}`}
       onClick={open}

--- a/src/components/salem/salem.test.ts
+++ b/src/components/salem/salem.test.ts
@@ -100,4 +100,16 @@ assert.match(css, /prefers-reduced-motion: reduce[\s\S]*\.salem-perch--retreatin
 assert.doesNotMatch(css, /\.salem-msg__glyph/, "open Salem chat must not keep unused emoji glyph CSS");
 assert.match(css, /position:\s*fixed/, "salem perch must be position fixed");
 
+// 8. Cursor-proximity presence: perch rests small + translucent and grows near.
+assert.match(widget, /--salem-proximity/, "widget must drive the --salem-proximity var");
+assert.match(widget, /setProperty\("--salem-proximity"/, "widget writes proximity straight to the node (no per-move re-render)");
+assert.match(widget, /requestAnimationFrame/, "proximity updates should be rAF-throttled");
+assert.match(css, /scale:\s*calc\([^)]*var\(--salem-proximity\)/, "perch scale must be driven by --salem-proximity");
+assert.match(css, /opacity:\s*calc\([^)]*var\(--salem-proximity\)/, "perch opacity must be driven by --salem-proximity");
+assert.match(
+  css,
+  /@media \(hover: none\)[\s\S]*?--salem-proximity:\s*1/,
+  "touch/no-hover must pin the perch to full presence (proximity 1)",
+);
+
 console.log("✅  Salem guard tests passed");


### PR DESCRIPTION
## What

The floating Salem perch (the corner cat orb) now rests **small + translucent** and **grows to full size/opacity as the cursor approaches** it.

- Driven by a `--salem-proximity` CSS var (0 = far → 1 = near). A `pointermove` handler computes the cursor's distance to the perch center within a 280px radius and writes the var straight to the node in a `requestAnimationFrame` tick — no React re-render per move.
- Scale uses the standalone `scale` property so it composes cleanly with the existing retreat/hover `transform` (no clobbering).
- At rest: `scale 0.62`, `opacity 0.38`. Over/near: ramps to full.
- **Touch / no-hover** and **reduced-motion** pin the var to `1` (CSS media queries) so the perch is always fully present where there's no cursor to approach.

## Verification (live)

| cursor | proximity | scale | opacity |
|---|---|---|---|
| far (corner) | 0.000 | 0.62 | 0.38 |
| ~150px away | 0.444 | 0.79 | 0.66 |
| ~57px away | 0.811 | 0.93 | 0.88 |

`tsc` ✓ · salem guard test (+ new proximity assertions) ✓ · globals.css test ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)