### PR TITLE
feat(salem): brighten the perch glow on cursor approach

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5632,9 +5632,14 @@ button:active > .edge-rail-chip {
   cursor: pointer;
   user-select: none;
   isolation: isolate;
+  /* Accent glow also tracks proximity: dim + tight at rest, brighter + wider as
+     the cursor nears (same --salem-proximity 0→1). */
   filter:
     drop-shadow(0 7px 18px rgba(0, 0, 0, 0.38))
-    drop-shadow(0 0 16px color-mix(in oklch, var(--accent-presence) 45%, transparent));
+    drop-shadow(
+      0 0 calc(10px + 22px * var(--salem-proximity))
+      color-mix(in oklch, var(--accent-presence) calc(26% + 46% * var(--salem-proximity)), transparent)
+    );
   transform: translate3d(0, 0, 0);
   transform-origin: 50% 80%;
   /* Cursor-proximity presence: the perch rests small + translucent and grows to

--- a/src/components/salem/salem.test.ts
+++ b/src/components/salem/salem.test.ts
@@ -111,5 +111,9 @@ assert.match(
   /@media \(hover: none\)[\s\S]*?--salem-proximity:\s*1/,
   "touch/no-hover must pin the perch to full presence (proximity 1)",
 );
+// Glow also brightens/widens on approach: both the blur radius and the
+// color-mix accent percentage interpolate on --salem-proximity.
+assert.match(css, /calc\(10px \+ 22px \* var\(--salem-proximity\)\)/, "perch glow blur radius must grow with --salem-proximity");
+assert.match(css, /calc\(26% \+ 46% \* var\(--salem-proximity\)\)/, "perch glow accent strength must brighten with --salem-proximity");
 
 console.log("✅  Salem guard tests passed");


### PR DESCRIPTION
## What

Extends the Salem perch's cursor-proximity effect (#896) to its **accent glow**: dim + tight at rest, brighter + wider as the cursor nears — driven by the same `--salem-proximity` var.

The accent drop-shadow interpolates both its blur radius (`10px → 32px`) and its `color-mix` accent strength (`alpha .26 → .72`) on `--salem-proximity`. The dark base shadow is untouched.

## Verification (live, on the webview)

Computed `filter` of `.salem-perch`:
- **Far:** `…drop-shadow(oklch(… / 0.26) 0 0 10px)`
- **Near:** `…drop-shadow(oklch(… / 0.65) 0 0 28.7px)`

So the `calc()`-in-`color-mix` resolves correctly and the glow visibly brightens + widens. `tsc` ✓ · salem guard test (+ glow assertions) ✓ · globals.css test ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)