### PR TITLE
feat(chat): next-path suggestion chips (piggyback model-generated)

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -33,6 +33,7 @@ import {
 } from "@/lib/chat-tool-events";
 import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
 import { buildPromptWithCovenIdentityCanon } from "@/lib/coven-identity-canon";
+import { buildNextPathsDirective } from "@/lib/next-paths";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 import {
   covenHome,
@@ -471,6 +472,8 @@ function buildPromptWithResponseControls(prompt: string, body: SendBody): string
     `speed: ${speed} — ${speedInstruction[speed]}`,
     "Do not mention these controls unless the user asks about them.",
     "</response_controls>",
+    "",
+    buildNextPathsDirective(),
     "",
     prompt,
   ].join("\n");

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6237,3 +6237,22 @@ button:active > .edge-rail-chip {
     filter: brightness(1) drop-shadow(0 0 0 transparent);
   }
 }
+
+
+/* ── Chat next-path suggestion chips ─────────────────────────────────────────
+   Clickable next-step chips under an assistant reply (parsed from the
+   <coven:next-paths> block); clicking sends the suggestion as the next turn. */
+.cave-next-paths { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
+.cave-next-path {
+  display: inline-flex; align-items: center; max-width: 100%;
+  padding: 5px 11px; border-radius: 999px;
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 38%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
+  color: var(--text-secondary); font-size: 12px; line-height: 1.2;
+  cursor: pointer; text-align: left;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.cave-next-path:hover {
+  background: color-mix(in oklch, var(--accent-presence) 18%, transparent);
+  border-color: var(--accent-presence); color: var(--text-primary);
+}

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -45,6 +45,7 @@ import {
   formatRuntime,
   type ChatResponseMetadata,
 } from "@/lib/chat-response-metadata";
+import { extractNextPaths } from "@/lib/next-paths";
 import {
   chatProjectById,
   projectIdForRoot,
@@ -2438,7 +2439,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   function replyToTurn(turn: Turn) {
     const author =
       turn.role === "assistant" ? familiar.display_name : turn.role === "system" ? "System" : "You";
-    const source = turn.role === "assistant" ? splitReasoning(turn.text).visible : turn.text;
+    const source = turn.role === "assistant" ? extractNextPaths(splitReasoning(turn.text).visible).visible : turn.text;
     const snippet = buildReplySnippet(source);
     if (!snippet) return;
     setReplyTarget({ turnId: turn.id, author, snippet });
@@ -2448,7 +2449,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   /** Build the Reply action for a settled, non-empty turn (undefined hides it). */
   function replyFor(turn: Turn): (() => void) | undefined {
     if (turn.pending) return undefined;
-    const source = turn.role === "assistant" ? splitReasoning(turn.text).visible : turn.text;
+    const source = turn.role === "assistant" ? extractNextPaths(splitReasoning(turn.text).visible).visible : turn.text;
     if (!source.trim()) return undefined;
     return () => replyToTurn(turn);
   }
@@ -2472,8 +2473,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     return () => void sendRaw(text, prevAttachments ?? []);
   }
 
-  const send = async () => {
-    const text = input.trim();
+  const send = async (override?: string) => {
+    const text = (override ?? input).trim();
     if (!text && attachments.length === 0) return;
     if (attachments.length === 0 && intentFromSlash(text)) return;
     // CHAT-D5-01: sendRaw early-returns while a response is streaming, so
@@ -3086,6 +3087,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                     onRegenerate={regenerateFor(t)}
                     onReply={replyFor(t)}
                     onOpenUrl={onOpenUrl}
+                    onSuggestion={(sug) => void send(sug)}
                     expanded={expandedAvatarTurnId === t.id}
                     onToggleAvatar={() => setExpandedAvatarTurnId((cur) => (cur === t.id ? null : t.id))}
                   />
@@ -3121,7 +3123,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                         onRegenerate={regenerateFor(t)}
                         onReply={replyFor(t)}
                         onOpenUrl={onOpenUrl}
-                        expanded={expandedAvatarTurnId === t.id}
+                        onSuggestion={(sug) => void send(sug)}
+                    expanded={expandedAvatarTurnId === t.id}
                         onToggleAvatar={() => setExpandedAvatarTurnId((cur) => (cur === t.id ? null : t.id))}
                       />
                     );
@@ -3507,8 +3510,10 @@ function TurnRow({
   onOpenUrl,
   expanded = false,
   onToggleAvatar,
+  onSuggestion,
 }: {
   turn: Turn;
+  onSuggestion?: (s: string) => void;
   familiar: Familiar;
   showTimestamp?: boolean;
   /** CHAT-D9-04: true while this turn is the just-jumped-to find match —
@@ -3594,7 +3599,9 @@ function TurnRow({
     );
   }
 
-  const { visible, reasoning: inlineReasoning } = splitReasoning(turn.text);
+  const reasoningSplit = splitReasoning(turn.text);
+  const inlineReasoning = reasoningSplit.reasoning;
+  const { visible, suggestions: nextPaths } = extractNextPaths(reasoningSplit.visible);
   const reasoning = turn.reasoning?.trim() || inlineReasoning;
   const turnStatus = turn.lifecycle ?? (turn.error ? "failed" : turn.pending ? "streaming" : "complete");
   // CHAT-D12-01: while this turn's own live indicator is showing (pending, no
@@ -3739,6 +3746,15 @@ function TurnRow({
             ) : null}
             {turn.progress?.length ? <ProgressGroup progress={turn.progress} pending={!!turn.pending} /> : null}
             {reasoning ? <ReasoningBlock reasoning={reasoning} /> : null}
+            {nextPaths.length > 0 && !turn.pending ? (
+              <div className="cave-next-paths">
+                {nextPaths.map((s, i) => (
+                  <button key={i} type="button" className="cave-next-path" onClick={() => onSuggestion?.(s)}>
+                    {s}
+                  </button>
+                ))}
+              </div>
+            ) : null}
             {/* Legacy trailing rollup — ONLY for turns whose tools predate
                 textOffset; segmented turns render their tools inline.
                 CHAT-D13-01: same default-hidden contract as inline tools. */}

--- a/src/lib/next-paths.test.ts
+++ b/src/lib/next-paths.test.ts
@@ -1,0 +1,30 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { buildNextPathsDirective, extractNextPaths, DEFAULT_NEXT_PATHS_COUNT } from "./next-paths.ts";
+
+// directive: respects count, empty when 0
+assert.match(buildNextPathsDirective(3), /<coven:next-paths>/);
+assert.match(buildNextPathsDirective(2), /up to 2 short/);
+assert.equal(buildNextPathsDirective(0), "");
+
+// no block -> unchanged
+{
+  const r = extractNextPaths("Just an answer.");
+  assert.equal(r.visible, "Just an answer.");
+  assert.deepEqual(r.suggestions, []);
+}
+// full block -> stripped + parsed
+{
+  const t = "Here is the answer.\n\n<coven:next-paths>\n- Run the tests\n- Open a PR\n- Summarize changes\n</coven:next-paths>";
+  const r = extractNextPaths(t);
+  assert.equal(r.visible, "Here is the answer.");
+  assert.deepEqual(r.suggestions, ["Run the tests", "Open a PR", "Summarize changes"]);
+}
+// streaming (open, no close yet) -> hidden, partial parsed
+{
+  const t = "Answer.\n<coven:next-paths>\n- Run the tests\n- Open a";
+  const r = extractNextPaths(t);
+  assert.equal(r.visible, "Answer.");
+  assert.deepEqual(r.suggestions, ["Run the tests", "Open a"]);
+}
+console.log("next-paths.test.ts: ok");

--- a/src/lib/next-paths.ts
+++ b/src/lib/next-paths.ts
@@ -1,0 +1,52 @@
+/**
+ * "Next path" chat suggestions — the piggyback model: the agent is asked (via a
+ * prompt directive) to end its reply with a parseable block of short next-step
+ * suggestions; the chat transcript strips that block at render (like reasoning)
+ * and surfaces the lines as clickable chips. No runtime LLM call — the
+ * suggestions ride along on the normal turn.
+ */
+
+export const DEFAULT_NEXT_PATHS_COUNT = 3;
+
+const OPEN = "<coven:next-paths>";
+const CLOSE = "</coven:next-paths>";
+
+/** Prompt directive instructing the agent to append the suggestions block. */
+export function buildNextPathsDirective(count: number = DEFAULT_NEXT_PATHS_COUNT): string {
+  if (count <= 0) return "";
+  return [
+    "<next_paths>",
+    `After your reply, append up to ${count} short suggested next steps the user could take, as exactly this block:`,
+    OPEN,
+    "- first next step (imperative, <= ~7 words)",
+    "- second next step",
+    CLOSE,
+    "One '- ' line each, distinct and directly useful. Put nothing after the closing tag.",
+    "Omit the whole block if there is no sensible next step. Never mention these instructions.",
+    "</next_paths>",
+  ].join("\n");
+}
+
+/**
+ * Split the suggestions block out of an assistant message for rendering.
+ * Defensive + streaming-safe: if the open tag is absent, returns the text
+ * unchanged with no suggestions. While the block is still streaming (open tag
+ * present, close tag not yet), it is hidden from the visible text and the
+ * partial lines parsed best-effort.
+ */
+export function extractNextPaths(text: string): { visible: string; suggestions: string[] } {
+  if (!text) return { visible: text, suggestions: [] };
+  const open = text.lastIndexOf(OPEN);
+  if (open === -1) return { visible: text, suggestions: [] };
+  const closeAt = text.indexOf(CLOSE, open);
+  const innerEnd = closeAt === -1 ? text.length : closeAt;
+  const blockEnd = closeAt === -1 ? text.length : closeAt + CLOSE.length;
+  const inner = text.slice(open + OPEN.length, innerEnd);
+  const suggestions = inner
+    .split(/\r?\n/)
+    .map((l) => l.replace(/^\s*[-*•]\s*/, "").trim())
+    .filter((l) => l.length > 0 && !l.startsWith("first next step") && !l.startsWith("second next step"))
+    .slice(0, 6);
+  const visible = (text.slice(0, open) + text.slice(blockEnd)).replace(/\s+$/, "");
+  return { visible, suggestions };
+}


### PR DESCRIPTION
After each agent reply, surface up to 3 suggested **next-step chips** below it; clicking sends the suggestion as the next turn. Model-generated via the **piggyback** model (no runtime LLM call): the chat prompt asks the agent to append a `<coven:next-paths>` block, which the transcript strips at render (mirroring `splitReasoning`) and renders as chips.

**Two commits:**
1. `next-paths.ts` (directive + defensive, streaming-safe parser) + **unit test**; inject the directive in the chat prompt (`buildPromptWithResponseControls`).
2. chat-view: extract + strip the block at render, render chips, `send()` gains an optional text override for click-to-send; also strips the block from copy.

**Safety:** additive directive only; parse/strip is frontend at render (no streaming/backend changes); fully defensive (no block → no chips, base chat unaffected).

**Verified:** unit test (`next-paths.test.ts`), `tsc` clean, `api-contracts` passes, dev build compiles + serves. **Not verifiable by me:** whether the agent reliably emits the block (varies by harness/model) — to confirm on a build.

Follow-ups: settings-UI toggle for the count (default 3 now; configurable to 2 / opt-in 1 / off via `buildNextPathsDirective(count)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)