### PR TITLE
fix(shell): align companion rail tab strip with corner side-panel trigger

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3488,11 +3488,11 @@ button:active > .edge-rail-chip {
 .companion-rail__tabs {
   display: flex;
   gap: 2px;
-  /* Align the tab strip's top with the left sidebar's floating toggle, which
-     sits at --shell-float-top (published by the chat surface; 50px fallback).
-     The familiar header used to fill this band; now the tab strip is the
-     panel's top row and lines up with the left panel's toggle trigger. */
-  margin-top: var(--shell-float-top, 50px);
+  /* The side-panel trigger is now pinned flush into the top-right window corner
+     (.shell-panel-float--right::before — a 35px notch at top:0), not centered on
+     --shell-float-top. Sit the tab strip flush at the panel's top so its icon row
+     lines up with that corner trigger instead of dropping ~50px below it. */
+  margin-top: 0;
   padding: 5px 8px;
   border-bottom: 1px solid var(--border-hairline);
   background: var(--bg-panel);


### PR DESCRIPTION
## What

The side-panel trigger was recently pinned flush into the top-right window corner (`.shell-panel-float--right::before` — a 35px notch at `top:0`). The companion rail's icon strip still used `margin-top: var(--shell-float-top, 50px)`, an offset meant to center it on the *old* non-corner toggle, so the strip dropped ~50px below the trigger.

Set `.companion-rail__tabs` `margin-top: 0` so the icon row sits flush at the panel top, level with the corner trigger. The value is now independent of `--shell-float-top`, so the alignment holds across all scopes.

## Verification

Ran the app (dev server, demo mode, 1440×900) and measured live bounding rects:
- Side-panel trigger notch center Y = **17.5px**
- Companion rail icon strip center Y = **19px** (delta 1.5px → aligned)
- Confirmed computed `margin-top: 0px`

🤖 Generated with [Claude Code](https://claude.com/claude-code)