### PR TITLE
chore(release): v0.0.100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.100] - 2026-06-17
+
+Patch release: Salem perch proximity polish, companion rail alignment fixes, next-path chat suggestions, and mobile handoff quality-of-life updates after 0.0.99.
+
+### Added
+- **Chat** — assistant responses can surface model-generated next-path suggestion chips to keep follow-up work moving (#898).
+- **Mobile** — handoff now auto-copies invite details and includes small UI refinements for the mobile bridge.
+
+### Fixed
+- **Shell** — companion rail tab strip aligns cleanly with the corner side-panel trigger (#899).
+
+### Polished
+- **Salem** — the perch starts smaller and translucent, grows on cursor approach, and uses a brighter approach glow (#896, #897).
+
 ## [0.0.99] - 2026-06-16
 
 Patch release: Windows first-run daemon startup fix and a Salem typecheck guard after 0.0.98.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.99",
+  "version": "0.0.100",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.99"
+version = "0.0.100"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.99"
+version = "0.0.100"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.99</string>
+	<string>0.0.100</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.99</string>
+	<string>0.0.100</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.99</string>
+	<string>0.0.100</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.99</string>
+	<string>0.0.100</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.99",
+  "version": "0.0.100",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary

- Bump CovenCave desktop/iOS metadata to 0.0.100.
- Add changelog entry for the five commits after v0.0.99.

## Verification

- `node --experimental-strip-types src/lib/app-version.test.ts`
- `node --experimental-strip-types src/lib/app-update.test.ts`
- `node scripts/mobile-tailscale-native.test.mjs`
- `node scripts/release-notes.test.mjs`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm exec tsc --noEmit`
- `git diff --check`
