### PR TITLE
fix(studio): match inline tab-strip height to a familiar-list row

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4632,8 +4632,11 @@ button:active > .edge-rail-chip {
 }
 .familiar-studio-inline__tabs {
   display: flex;
+  align-items: stretch;
   gap: 2px;
-  padding: var(--space-2) var(--space-3) 0;
+  /* Match a left familiar-list row (~50px) so the two columns' top bands line up. */
+  min-height: 50px;
+  padding: 0 var(--space-3);
   border-bottom: 1px solid var(--border-hairline);
   overflow-x: auto;
 }
@@ -4641,7 +4644,7 @@ button:active > .edge-rail-chip {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 8px 12px;
+  padding: 0 12px;
   border: none;
   border-bottom: 2px solid transparent;
   margin-bottom: -1px;


### PR DESCRIPTION
The Familiar Studio tab strip (~40px) read shorter than the left familiar-list rows (~50px), so the columns' top bands didn't line up. Gives the tab strip a 50px min-height with stretched, vertically-centered tabs and the active underline flush to the bottom border — matching one list row. `globals.css.test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)