### PR TITLE
feat(home): model selector matches the familiar dropdown pill

### DIFF
--- a/src/components/chat-model-control.test.ts
+++ b/src/components/chat-model-control.test.ts
@@ -36,4 +36,14 @@ assert.match(
   "Selection writes session scope when a chat exists, else familiar-default",
 );
 
+// Pill variant — model selection mirrors the familiar selector pill (used on
+// the home composer): caret-up-down trigger + dedicated pill styling.
+assert.match(source, /variant\??:\s*"default"\s*\|\s*"pill"/, "ChatModelControl exposes a pill variant");
+assert.match(source, /cave-chat-model-control--pill/, "pill variant adds its modifier class");
+assert.match(source, /caret-up-down/, "pill trigger shows a caret-up-down like the familiar selector");
+assert.match(css, /\.cave-chat-model-control--pill/, "pill variant has matching CSS");
+
+const homeComposer = await readFile(new URL("./home-composer.tsx", import.meta.url), "utf8");
+assert.match(homeComposer, /<ChatModelControl[\s\S]{0,160}variant="pill"/, "home composer uses the pill model selector");
+
 console.log("chat-model-control.test.ts: ok");

--- a/src/components/chat-model-control.tsx
+++ b/src/components/chat-model-control.tsx
@@ -13,6 +13,13 @@ type Props = {
    */
   onSelectModel?: (modelId: string) => void;
   busy?: boolean;
+  /**
+   * "pill" renders the trigger as a dropdown pill matching the familiar
+   * selector (glyph + model + caret-up-down) so model selection reads as the
+   * same control type as picking a familiar. Default keeps the compact in-chat
+   * chip with its inline application-state label.
+   */
+  variant?: "default" | "pill";
 };
 
 const SOURCE_LABELS: Record<ModelScope, string> = {
@@ -31,7 +38,7 @@ const STATE_LABELS: Record<ModelApplicationState, string> = {
   failed: "Runtime failed",
 };
 
-export function ChatModelControl({ state, onSelectModel, busy }: Props) {
+export function ChatModelControl({ state, onSelectModel, busy, variant = "default" }: Props) {
   const [open, setOpen] = useState(false);
   const [custom, setCustom] = useState("");
 
@@ -66,7 +73,7 @@ export function ChatModelControl({ state, onSelectModel, busy }: Props) {
     >
       <button
         type="button"
-        className="cave-chat-model-control focus-ring"
+        className={`cave-chat-model-control focus-ring${variant === "pill" ? " cave-chat-model-control--pill" : ""}`}
         aria-label="Chat model"
         aria-expanded={open}
         aria-haspopup={canPick ? "menu" : undefined}
@@ -75,7 +82,11 @@ export function ChatModelControl({ state, onSelectModel, busy }: Props) {
       >
         <Icon name="ph:brain-bold" width={12} aria-hidden />
         <span className="cave-chat-model-control__model">{state.effectiveModel}</span>
-        <span className="cave-chat-model-control__state">{stateLabel}</span>
+        {variant === "pill" ? (
+          <Icon name="ph:caret-up-down-bold" width={10} className="cave-chat-model-control__caret" aria-hidden />
+        ) : (
+          <span className="cave-chat-model-control__state">{stateLabel}</span>
+        )}
       </button>
       {open ? (
         <div

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -447,6 +447,7 @@ export function HomeComposer({
               state={modelState}
               onSelectModel={handleSelectModel}
               busy={sending}
+              variant="pill"
             />
           ) : null}
 

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1780,6 +1780,35 @@ details[open] > .cave-tool-summary::before {
   color: var(--text-muted);
 }
 
+/* Pill variant — mirrors .hc-familiar-selector so model selection reads as the
+   same dropdown-pill control as the familiar picker on the home composer. */
+.cave-chat-model-control--pill {
+  height: auto;
+  gap: 5px;
+  border-radius: 8px;
+  padding: 3px 7px 3px 6px;
+  background: color-mix(in oklch, var(--accent-presence) 10%, var(--bg-base));
+  border-color: color-mix(in oklch, var(--accent-presence) 25%, transparent);
+  color: var(--text-primary);
+  font-size: 12px;
+}
+
+.cave-chat-model-control--pill:hover,
+.cave-chat-model-control--pill[aria-expanded="true"] {
+  background: color-mix(in oklch, var(--accent-presence) 16%, var(--bg-base));
+  border-color: color-mix(in oklch, var(--accent-presence) 40%, transparent);
+}
+
+.cave-chat-model-control--pill .cave-chat-model-control__model {
+  max-width: 140px;
+  font-weight: 500;
+}
+
+.cave-chat-model-control--pill .cave-chat-model-control__caret {
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
 .cave-chat-model-popover {
   position: absolute;
   right: 0;


### PR DESCRIPTION
## What

On the home composer, the model picker now reads as the **same selection type as the familiar picker** — a dropdown pill with a caret-up-down — instead of the compact chip with inline "Saved in Cave" state text.

Added a `variant="pill"` to the shared `ChatModelControl`: the pill trigger mirrors `.hc-familiar-selector` (accent-tinted pill, glyph + model + `caret-up-down`). The home composer passes `variant="pill"`. The dropdown itself (catalog models + custom-model input + runtime info) is unchanged, and the default in-chat chip variant is untouched.

## Verification (live, real model-state)

`Nova ⇅` (familiar) and `openai/gpt-5.5 ⇅` (model) now share identical pill chrome + caret; the model dropdown still opens and selects. `tsc` ✓ · `chat-model-control` (+ pill assertions) / `home-composer` / `home-composer-polish` tests ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)