### PR TITLE
fix(home): model pill is a native select so its menu opens visibly

### DIFF
--- a/src/components/chat-model-control.test.ts
+++ b/src/components/chat-model-control.test.ts
@@ -36,12 +36,15 @@ assert.match(
   "Selection writes session scope when a chat exists, else familiar-default",
 );
 
-// Pill variant — model selection mirrors the familiar selector pill (used on
-// the home composer): caret-up-down trigger + dedicated pill styling.
+// Pill variant — model selection mirrors the familiar selector: a native
+// <select> (so the option list opens in the OS layer and can't be clipped by
+// the composer card's overflow) with a caret-up-down, in a matching pill.
 assert.match(source, /variant\??:\s*"default"\s*\|\s*"pill"/, "ChatModelControl exposes a pill variant");
-assert.match(source, /cave-chat-model-control--pill/, "pill variant adds its modifier class");
-assert.match(source, /caret-up-down/, "pill trigger shows a caret-up-down like the familiar selector");
-assert.match(css, /\.cave-chat-model-control--pill/, "pill variant has matching CSS");
+assert.match(source, /if \(variant === "pill"\)/, "pill variant has a dedicated render branch");
+assert.match(source, /<select\b[\s\S]{0,200}cave-chat-model-pill__select|cave-chat-model-pill__select[\s\S]{0,200}<select/, "pill uses a native <select> (opens in a visible OS layer, like the familiar picker)");
+assert.match(source, /caret-up-down/, "pill shows a caret-up-down like the familiar selector");
+assert.match(css, /\.cave-chat-model-pill\b/, "pill variant has matching CSS");
+assert.match(css, /\.cave-chat-model-pill__select/, "pill select has matching CSS");
 
 const homeComposer = await readFile(new URL("./home-composer.tsx", import.meta.url), "utf8");
 assert.match(homeComposer, /<ChatModelControl[\s\S]{0,160}variant="pill"/, "home composer uses the pill model selector");

--- a/src/components/chat-model-control.tsx
+++ b/src/components/chat-model-control.tsx
@@ -64,6 +64,40 @@ export function ChatModelControl({ state, onSelectModel, busy, variant = "defaul
     setOpen(false);
   };
 
+  // Pill variant: a native <select> that mirrors the familiar selector. The OS
+  // renders the option list in its own layer, so it can't be clipped by the
+  // composer card's `overflow: hidden` the way a custom popover is — and it's
+  // the same control type used to pick a familiar. The current model is always
+  // an option even if it isn't in the runtime catalog.
+  if (variant === "pill") {
+    const inCatalog = options.some((option) => option.id === state.effectiveModel);
+    const pillOptions = inCatalog
+      ? options
+      : [{ id: state.effectiveModel, label: state.effectiveModel }, ...options];
+    return (
+      <label
+        className="cave-chat-model-pill"
+        title={`${state.effectiveModel} · ${sourceLabel} · ${stateLabel}`}
+      >
+        <Icon name="ph:brain-bold" width={12} aria-hidden />
+        <select
+          className="cave-chat-model-pill__select"
+          aria-label="Chat model"
+          value={state.effectiveModel}
+          disabled={!canPick || busy}
+          onChange={(event) => choose(event.currentTarget.value)}
+        >
+          {pillOptions.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <Icon name="ph:caret-up-down-bold" width={10} className="cave-chat-model-pill__caret" aria-hidden />
+      </label>
+    );
+  }
+
   return (
     <div
       className="cave-chat-model-wrap"
@@ -73,7 +107,7 @@ export function ChatModelControl({ state, onSelectModel, busy, variant = "defaul
     >
       <button
         type="button"
-        className={`cave-chat-model-control focus-ring${variant === "pill" ? " cave-chat-model-control--pill" : ""}`}
+        className="cave-chat-model-control focus-ring"
         aria-label="Chat model"
         aria-expanded={open}
         aria-haspopup={canPick ? "menu" : undefined}
@@ -82,11 +116,7 @@ export function ChatModelControl({ state, onSelectModel, busy, variant = "defaul
       >
         <Icon name="ph:brain-bold" width={12} aria-hidden />
         <span className="cave-chat-model-control__model">{state.effectiveModel}</span>
-        {variant === "pill" ? (
-          <Icon name="ph:caret-up-down-bold" width={10} className="cave-chat-model-control__caret" aria-hidden />
-        ) : (
-          <span className="cave-chat-model-control__state">{stateLabel}</span>
-        )}
+        <span className="cave-chat-model-control__state">{stateLabel}</span>
       </button>
       {open ? (
         <div

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1780,31 +1780,58 @@ details[open] > .cave-tool-summary::before {
   color: var(--text-muted);
 }
 
-/* Pill variant — mirrors .hc-familiar-selector so model selection reads as the
-   same dropdown-pill control as the familiar picker on the home composer. */
-.cave-chat-model-control--pill {
-  height: auto;
+/* Pill variant — a native <select> mirroring .hc-familiar-selector, so model
+   selection is the same control type as the familiar picker and (being native)
+   opens in the OS layer instead of a custom popover that the composer card's
+   `overflow: hidden` would clip. */
+.cave-chat-model-pill {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
   gap: 5px;
+  flex-shrink: 0;
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 25%, transparent);
   border-radius: 8px;
-  padding: 3px 7px 3px 6px;
   background: color-mix(in oklch, var(--accent-presence) 10%, var(--bg-base));
-  border-color: color-mix(in oklch, var(--accent-presence) 25%, transparent);
+  padding: 3px 7px 3px 6px;
   color: var(--text-primary);
-  font-size: 12px;
 }
 
-.cave-chat-model-control--pill:hover,
-.cave-chat-model-control--pill[aria-expanded="true"] {
+.cave-chat-model-pill:hover,
+.cave-chat-model-pill:focus-within {
   background: color-mix(in oklch, var(--accent-presence) 16%, var(--bg-base));
   border-color: color-mix(in oklch, var(--accent-presence) 40%, transparent);
 }
 
-.cave-chat-model-control--pill .cave-chat-model-control__model {
-  max-width: 140px;
-  font-weight: 500;
+.cave-chat-model-pill > svg {
+  flex-shrink: 0;
+  color: var(--accent-presence);
 }
 
-.cave-chat-model-control--pill .cave-chat-model-control__caret {
+.cave-chat-model-pill__select {
+  appearance: none;
+  -webkit-appearance: none;
+  border: none;
+  outline: none;
+  background: transparent;
+  cursor: pointer;
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: var(--font-mono);
+  max-width: 150px;
+  padding-right: 14px;
+  text-overflow: ellipsis;
+}
+
+.cave-chat-model-pill__select:disabled {
+  cursor: default;
+}
+
+.cave-chat-model-pill__caret {
+  position: absolute;
+  right: 5px;
+  pointer-events: none;
   flex-shrink: 0;
   color: var(--text-muted);
 }


### PR DESCRIPTION
## What

Follow-up to #903. The pill model picker's custom popover opened *inside* the home composer card's `overflow: hidden` (and `.home-composer-root` overflow), so the menu was clipped out of view — "doesn't open in a visible space."

Fix: render the pill variant as a **native `<select>`** instead of a custom popover. The OS draws the option list in its own layer, so it can't be clipped — and it's literally the same control type as the familiar picker (also a native select).

- Shows catalog labels (e.g. "Claude Opus 4.7"), keeps the current model as an option even if it isn't in the runtime catalog, and persists through the same `onSelectModel` channel.
- The default in-chat variant (button + rich catalog/custom popover) is untouched.

## Verification (live)

Diagnosed the clip: the popover sat inside an `overflow: hidden` composer card. After the fix the pill is a real `<select>` (4 runtime models), selecting an option fires the model-state PATCH, and the pill matches the familiar pill (`Claude Opus 4.7 ⇅` beside `Nova ⇅`). `tsc` ✓ · chat-model-control / home-composer / home-composer-polish tests ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)