### PR TITLE
feat(mobile-handoff): show the invite link in the modal

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4285,6 +4285,18 @@ button:active > .edge-rail-chip {
   overflow-wrap: anywhere;
 }
 
+a.mobile-handoff__link {
+  display: block;
+  text-decoration: none;
+  user-select: all;
+  transition: border-color 120ms ease;
+}
+
+a.mobile-handoff__link:hover {
+  border-color: var(--border-strong, var(--text-secondary));
+  text-decoration: underline;
+}
+
 .mobile-handoff__error {
   margin: 0;
   padding: 8px 10px;

--- a/src/components/mobile-handoff-modal.tsx
+++ b/src/components/mobile-handoff-modal.tsx
@@ -159,7 +159,14 @@ export function MobileHandoffModal({ open, onClose, autoCopyRequest = 0 }: Props
               <p className="mobile-handoff__meta">
                 Expires at {expiryLabel(handoff.expiresAtIso)}
               </p>
-              <p className="mobile-handoff__url">{handoff.serveUrl}</p>
+              <a
+                className="mobile-handoff__url mobile-handoff__link"
+                href={handoff.inviteUrl || handoff.url}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {handoff.inviteUrl || handoff.url}
+              </a>
               <p className="mobile-handoff__hint">
                 Scan the short-lived Tailscale invite link, or copy it and paste it into the mobile app.
               </p>

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -28,6 +28,8 @@ assert.match(modal, /autoCopyRequest/, "Modal should accept an auto-copy request
 assert.match(modal, /lastAutoCopyRequestRef/, "Modal should copy the invite only once per sidebar request");
 assert.match(modal, /Copy invite/, "Modal should make the invite link copyable");
 assert.match(modal, /handoff\?\.inviteUrl \|\| handoff\?\.url/, "Modal should prefer inviteUrl while supporting url fallback");
+assert.match(modal, /mobile-handoff__link[\s\S]*href=\{handoff\.inviteUrl \|\| handoff\.url\}/, "Modal should display the invite link as a clickable link");
+assert.match(css, /\.mobile-handoff__link/, "Invite link should have stable styling");
 assert.match(modal, /action: "reset"/, "Modal should expose explicit Tailscale Serve reset");
 assert.match(handoffRoute, /inviteUrl: invite\.url/, "API should expose inviteUrl as the canonical invite field");
 assert.match(handoffRoute, /appUrl: invite\.url/, "API should keep appUrl as an inviteUrl alias for compatibility");


### PR DESCRIPTION
## What

The **Open on phone** modal previously displayed only the bare serve URL (tailnet host, no token). This adds the full short-lived **invite link** as a selectable, clickable link directly under the expiry line, so it can be opened or copied without relying solely on the QR code or the "Copy invite" button.

- Renders `inviteUrl` (falling back to `url`) as an `<a>` element (`target=_blank`, `rel=noreferrer`).
- `user-select: all` so a single click selects the whole link for easy copy; hover affordance via border + underline.

## Verification

`pnpm typecheck` clean; `mobile-handoff.test.ts` green (added assertions for the link element and its styling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)