### PR TITLE
chore(models): replace Claude Fable 5 with Claude Opus 4.8 in the catalog

### DIFF
--- a/src/lib/runtime-models.test.ts
+++ b/src/lib/runtime-models.test.ts
@@ -22,8 +22,12 @@ assert.equal(catalogForRuntime("claude").provider, "anthropic");
 assert.equal(catalogForRuntime("hermes").provider, "nous");
 assert.ok(catalogForRuntime("claude").models.length > 0, "claude should seed a menu");
 assert.ok(
-  catalogForRuntime("claude").models.some((m) => m.id === "anthropic/claude-fable-5"),
-  "claude catalog should seed Claude Fable 5",
+  catalogForRuntime("claude").models.some((m) => m.id === "anthropic/claude-opus-4-8"),
+  "claude catalog should seed Claude Opus 4.8",
+);
+assert.ok(
+  !catalogForRuntime("claude").models.some((m) => m.id === "anthropic/claude-fable-5"),
+  "claude catalog should no longer offer the retired Claude Fable 5",
 );
 
 // Namespaced model id convention (`provider/model`) holds across the seed.

--- a/src/lib/runtime-models.ts
+++ b/src/lib/runtime-models.ts
@@ -36,7 +36,7 @@ export const RUNTIME_MODEL_CATALOG: Record<string, RuntimeModelCatalog> = {
     runtime: "claude",
     provider: "anthropic",
     models: [
-      { id: "anthropic/claude-fable-5", label: "Claude Fable 5" },
+      { id: "anthropic/claude-opus-4-8", label: "Claude Opus 4.8" },
       { id: "anthropic/claude-opus-4-7", label: "Claude Opus 4.7" },
       { id: "anthropic/claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
       { id: "anthropic/claude-haiku-4-5", label: "Claude Haiku 4.5" },


### PR DESCRIPTION
## What

Fable 5 is no longer a valid option for the Claude runtime. The model catalog's only reference was the selectable option in `runtime-models.ts`, so swap it:

- `anthropic/claude-fable-5` ("Claude Fable 5") → `anthropic/claude-opus-4-8` ("Claude Opus 4.8"), kept as the top Claude model above Opus 4.7.

A repo-wide search (`grep -ri fable`) confirmed these were the only references (everything else was the unrelated word "spoofable"). The model-selection UI (familiar + home pickers) reads this catalog, so the dropdown now offers Opus 4.8 instead of Fable 5.

## Tests

Updated `runtime-models.test.ts` to assert Opus 4.8 is seeded **and** Fable 5 is no longer offered (regression guard). `tsc` ✓ · `runtime-models` test ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)