### PR TITLE
fix(models): restore Claude Fable 5 to the catalog alongside Opus 4.8

### DIFF
--- a/src/lib/runtime-models.test.ts
+++ b/src/lib/runtime-models.test.ts
@@ -26,8 +26,8 @@ assert.ok(
   "claude catalog should seed Claude Opus 4.8",
 );
 assert.ok(
-  !catalogForRuntime("claude").models.some((m) => m.id === "anthropic/claude-fable-5"),
-  "claude catalog should no longer offer the retired Claude Fable 5",
+  catalogForRuntime("claude").models.some((m) => m.id === "anthropic/claude-fable-5"),
+  "claude catalog should still offer Claude Fable 5 (both Fable 5 and Opus 4.8 are current)",
 );
 
 // Namespaced model id convention (`provider/model`) holds across the seed.

--- a/src/lib/runtime-models.ts
+++ b/src/lib/runtime-models.ts
@@ -36,6 +36,7 @@ export const RUNTIME_MODEL_CATALOG: Record<string, RuntimeModelCatalog> = {
     runtime: "claude",
     provider: "anthropic",
     models: [
+      { id: "anthropic/claude-fable-5", label: "Claude Fable 5" },
       { id: "anthropic/claude-opus-4-8", label: "Claude Opus 4.8" },
       { id: "anthropic/claude-opus-4-7", label: "Claude Opus 4.7" },
       { id: "anthropic/claude-sonnet-4-6", label: "Claude Sonnet 4.6" },


### PR DESCRIPTION
#908 replaced Claude Fable 5 with Claude Opus 4.8 in the `claude` runtime catalog, dropping Fable 5 — a **current** model — entirely.

Both Fable 5 and Opus 4.8 are current Claude models, so this restores Fable 5 (as the lead entry) **and keeps** Opus 4.8 rather than doing a strict revert (which would have removed the newest model). Catalog is now: Fable 5, Opus 4.8, Opus 4.7, Sonnet 4.6, Haiku 4.5. Test asserts both Fable 5 and Opus 4.8 are offered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)