### PR TITLE
fix(roles): widen capability label column so "Workflows" isn't clipped

### DIFF
--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -419,7 +419,7 @@ function CapabilityRow({
   openHint?: string;
 }) {
   return (
-    <div className="plugins-role-capability grid grid-cols-[64px_minmax(0,1fr)] items-start gap-2">
+    <div className="plugins-role-capability grid grid-cols-[78px_minmax(0,1fr)] items-start gap-2">
       <dt className="pt-1 text-[10px] font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]">
         {label}
       </dt>


### PR DESCRIPTION
Follow-up to #906. The `CapabilityRow` label column on the role cards was 64px — a hair too narrow for the longest label, so **WORKFLOWS** rendered with its final letter clipped (`SKILLS`/`TOOLS` fit fine). Widen the column to 78px.

One-line CSS-only change. `#906` auto-merged on green checks before this fix could fold into it, hence the separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)