### PR TITLE
chore(models): remove Claude Fable 5 from the catalog

### DIFF
--- a/src/lib/runtime-models.test.ts
+++ b/src/lib/runtime-models.test.ts
@@ -26,8 +26,8 @@ assert.ok(
   "claude catalog should seed Claude Opus 4.8",
 );
 assert.ok(
-  catalogForRuntime("claude").models.some((m) => m.id === "anthropic/claude-fable-5"),
-  "claude catalog should still offer Claude Fable 5 (both Fable 5 and Opus 4.8 are current)",
+  !catalogForRuntime("claude").models.some((m) => m.id === "anthropic/claude-fable-5"),
+  "claude catalog should not offer Claude Fable 5",
 );
 
 // Namespaced model id convention (`provider/model`) holds across the seed.

--- a/src/lib/runtime-models.ts
+++ b/src/lib/runtime-models.ts
@@ -36,7 +36,6 @@ export const RUNTIME_MODEL_CATALOG: Record<string, RuntimeModelCatalog> = {
     runtime: "claude",
     provider: "anthropic",
     models: [
-      { id: "anthropic/claude-fable-5", label: "Claude Fable 5" },
       { id: "anthropic/claude-opus-4-8", label: "Claude Opus 4.8" },
       { id: "anthropic/claude-opus-4-7", label: "Claude Opus 4.7" },
       { id: "anthropic/claude-sonnet-4-6", label: "Claude Sonnet 4.6" },


### PR DESCRIPTION
Per product decision, drop Claude Fable 5 from the `claude` runtime catalog. Claude Opus 4.8 leads. Catalog is now: Opus 4.8, Opus 4.7, Sonnet 4.6, Haiku 4.5. Test asserts Fable 5 is not offered.

(Reverses #913's "offer both" at the user's request.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)