### PR TITLE
fix(mobile-handoff): actionable dev error when access token is missing

### DIFF
--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -100,10 +100,15 @@ function backendUrl(req: Request) {
 async function mobileHandoff(req: Request) {
   const accessSecret = process.env.COVEN_CAVE_ACCESS_TOKEN?.trim();
   if (!accessSecret) {
-    return NextResponse.json(
-      { ok: false, error: "mobile access token unavailable" },
-      { status: 503 },
-    );
+    // Plain `next dev` never sets COVEN_CAVE_ACCESS_TOKEN, so the handoff
+    // can't mint a signed invite. Give devs the exact next step instead of
+    // an opaque string; keep the terse message in packaged builds, where a
+    // missing token is a real misconfiguration rather than the dev default.
+    const error =
+      process.env.NODE_ENV !== "production"
+        ? "Mobile handoff isn't available in plain `pnpm dev` — it needs the signed access token that the packaged app and `pnpm mobile:tailscale` set up. Run `pnpm mobile:tailscale` (or open the packaged app), then use Open on phone from that session."
+        : "mobile access token unavailable";
+    return NextResponse.json({ ok: false, error }, { status: 503 });
   }
 
   const self = await runTailscale(["status", "--self"]);

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -33,6 +33,7 @@ assert.match(css, /\.mobile-handoff__link/, "Invite link should have stable styl
 assert.match(modal, /action: "reset"/, "Modal should expose explicit Tailscale Serve reset");
 assert.match(handoffRoute, /inviteUrl: invite\.url/, "API should expose inviteUrl as the canonical invite field");
 assert.match(handoffRoute, /appUrl: invite\.url/, "API should keep appUrl as an inviteUrl alias for compatibility");
+assert.match(handoffRoute, /NODE_ENV !== "production"[\s\S]*pnpm mobile:tailscale/, "API should give an actionable dev hint when the access token is missing");
 assert.match(css, /\.mobile-handoff-qr/, "QR block should have stable layout CSS");
 assert.match(css, /@media \(max-width: 1023px\)[\s\S]*\.top-bar__mobile-handoff[\s\S]*display: none/, "Phone handoff button should hide on mobile/tablet chrome");
 assert.match(mobileStub, /Invite link or Tailscale URL/, "Mobile connection screen should label the real accepted input");


### PR DESCRIPTION
## What

In plain `pnpm dev`, `/api/mobile-handoff` 503s with the opaque `mobile access token unavailable` (the dev server never sets `COVEN_CAVE_ACCESS_TOKEN`). This returns an actionable message **in development** — pointing at `pnpm mobile:tailscale` / the packaged app — while keeping the terse string in packaged builds, where a missing token is a real misconfiguration rather than the dev default.

## Context

The handoff already works **one-click in the packaged app**: the Tauri shell mints and injects the access token at sidecar launch (`src-tauri/src/lib.rs`), and the route runs `tailscale serve` on click. This change only improves the dev-harness error; it does not touch the access gate.

## Verification

`pnpm typecheck` clean; `mobile-handoff.test.ts` green (added an assertion for the dev hint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)