### PR TITLE
feat(chat): make the conversation thread full-width

### DIFF
--- a/src/components/message-bubble-code-header.test.ts
+++ b/src/components/message-bubble-code-header.test.ts
@@ -86,33 +86,32 @@ assert.match(
 );
 
 // ---------------------------------------------------------------------------
-// Centered reading column (2026-06-13) — supersedes the 2026-06-12 full-width
-// decision (#533): the thread fills narrow panes (width: 100%) but caps its
-// measure (max-width: 1180px) and centers (margin-inline: auto) on wide/full-
-// screen so the transcript sits in the middle rather than sprawling left. The
-// old CHAT-D10-04 920px measure stays gone.
+// Full-width chat (2026-06-18) — supersedes the 2026-06-13 centered-column
+// decision: the thread spans the whole pane (width: 100%, max-width: 100%, no
+// auto centering) so the transcript lines up with the full-width header and
+// composer. The old 920px and 1180px reading-measure caps stay gone.
 // ---------------------------------------------------------------------------
 
 const linearThread = /\.cave-chat-linear \.cave-chat-thread \{[^}]*\}/.exec(css)?.[0] ?? "";
 assert.match(
   linearThread,
   /width:\s*100%/,
-  "Linear thread must fill narrow panes (width: 100%)",
+  "Linear thread must fill the pane (width: 100%)",
 );
 assert.match(
   linearThread,
-  /max-width:\s*1180px/,
-  "Linear thread must cap its reading measure at 1180px (centered reading column)",
-);
-assert.match(
-  linearThread,
-  /margin-inline:\s*auto/,
-  "Linear thread must center its capped measure (margin-inline: auto)",
+  /max-width:\s*100%/,
+  "Linear thread must span full width (max-width: 100%)",
 );
 assert.doesNotMatch(
   linearThread,
-  /max-width:\s*(?:min\(100%,\s*)?920px/,
-  "The old 920px reading-measure cap must stay gone",
+  /margin-inline:\s*auto/,
+  "Linear thread must not center (no margin-inline: auto)",
+);
+assert.doesNotMatch(
+  linearThread,
+  /max-width:\s*(?:min\(100%,\s*)?(?:920|1180)px/,
+  "The old reading-measure caps (920px / 1180px) must stay gone",
 );
 
 const linearComposerShell = /\.cave-chat-linear \.cave-composer-shell \{[^}]*\}/.exec(css)?.[0] ?? "";

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -680,12 +680,12 @@
   display: flex;
   flex-direction: column;
   gap: 18px;
-  /* Centered reading column (2026-06-13): the thread fills narrow panes but
-     caps its measure and centers on wide/full-screen so responses sit in the
-     middle instead of sprawling left across the pane. */
+  /* Full-width chat (2026-06-18): the thread spans the whole pane so the
+     transcript lines up with the full-width header and composer instead of
+     sitting in a centered reading column. */
   width: 100%;
-  max-width: 1180px;
-  margin-inline: auto;
+  max-width: 100%;
+  margin-inline: 0;
 }
 
 .cave-chat-empty {
@@ -2172,13 +2172,13 @@ details[open] > .cave-tool-summary::before {
 
 .cave-chat-linear .cave-chat-thread {
   gap: 0;
-  /* Centered reading column (2026-06-13): fill narrow panes, but cap the
-     measure and center on wide/full-screen so the transcript sits in the
-     middle rather than sprawling left. */
+  /* Full-width chat (2026-06-18): span the whole pane so the transcript lines
+     up with the full-width header and composer instead of sitting in a
+     centered reading column. */
   width: 100%;
-  max-width: 1180px;
+  max-width: 100%;
   margin-block: 0;
-  margin-inline: auto;
+  margin-inline: 0;
 }
 
 /* ── Turn rows ──────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## What

The Sessions chat thread capped its measure at `max-width: 1180px` and centered with `margin-inline: auto`, so on wide screens the transcript sat in a narrow centered column while the header and composer ran full width (see the empty margins in the report). This makes the thread span the full pane width so the conversation lines up with the header and composer.

Changed both `.cave-chat-thread` and `.cave-chat-linear .cave-chat-thread` in `src/styles/cave-chat.css` to `max-width: 100%` / `margin-inline: 0`.

## Verification

`pnpm typecheck` clean; `message-bubble-code-header.test.ts` updated to assert the full-width measure and passes; `labels-and-live-regions.test.ts` (also references the thread) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)