### PR TITLE
feat(chat): widen the user message bubble

### DIFF
--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -978,7 +978,10 @@
   border: 1px solid var(--border-hairline);
   border-radius: 8px;
   padding: 10px 13px;
-  max-width: min(78%, 640px);
+  /* Wider bubble (2026-06-18): pairs with the full-width thread — the user
+     message uses most of the pane instead of a narrow 640px cap, while still
+     right-aligning so it reads as the user's turn. */
+  max-width: min(85%, 1100px);
   word-break: break-word;
   overflow-wrap: anywhere;
   box-shadow:


### PR DESCRIPTION
## What

Follow-up to the full-width thread (#917): the user message bubble was still capped at `min(78%, 640px)`, so it looked narrow against the now full-width transcript. Raise the desktop cap to `min(85%, 1100px)` so the bubble uses most of the pane while still right-aligning as the user's turn.

The mobile rule (`min(92%, 520px)` under 767px) is unchanged.

## Verification

`message-bubble-code-header`, `chat-view-mobile-command-center`, `chat-surface-polish`, and `font-css-vars` tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)