### PR TITLE
fix(familiars): fall back to glyph when an avatar image fails to load

### DIFF
--- a/src/components/familiar-avatar.test.ts
+++ b/src/components/familiar-avatar.test.ts
@@ -12,4 +12,12 @@ assert.match(source, /FamiliarGlyph/, "Must fall back to FamiliarGlyph when no i
 assert.match(source, /<img/, "Must render an <img> for image avatars");
 assert.match(source, /alt=/, "img must have alt text for a11y");
 
+// On a failed image load, fall back to the glyph instead of leaving the
+// browser's broken-image placeholder (the avatar route's 404 contract relies
+// on this). The <img> must carry an onError that flips to the fallback, and
+// the render must be gated on that error state.
+assert.match(source, /onError=\{\(\) => setErrored\(true\)\}/, "img must fall back on load error");
+assert.match(source, /familiar\.avatarImage && !errored/, "render must gate the img on the not-errored state");
+assert.match(source, /useEffect\(\s*\(\) => \{\s*setErrored\(false\);\s*\}, \[familiar\.avatarImage\]\)/, "error state must reset when the avatar src changes");
+
 console.log("familiar-avatar.test.ts: ok");

--- a/src/components/familiar-avatar.tsx
+++ b/src/components/familiar-avatar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { FamiliarGlyph } from "./familiar-glyph";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 
@@ -16,7 +17,17 @@ type Props = {
 
 export function FamiliarAvatar({ familiar, size = "md", className, title }: Props) {
   const px = PX[size];
-  if (familiar.avatarImage) {
+  // Fall back to the glyph when the avatar image fails to load (e.g. a
+  // transient 404 while the avatar route compiles on a cold start, a timeout,
+  // or a decode failure) instead of leaving the browser's broken-image
+  // placeholder. The avatar route's 404 contract assumes this fallback. Reset
+  // on src change so a new familiar/version re-attempts the image.
+  const [errored, setErrored] = useState(false);
+  useEffect(() => {
+    setErrored(false);
+  }, [familiar.avatarImage]);
+
+  if (familiar.avatarImage && !errored) {
     return (
       <img
         src={familiar.avatarImage}
@@ -25,6 +36,7 @@ export function FamiliarAvatar({ familiar, size = "md", className, title }: Prop
         height={px}
         className={className ?? "inline-block rounded-sm object-cover"}
         title={title}
+        onError={() => setErrored(true)}
       />
     );
   }


### PR DESCRIPTION
## Problem

A familiar's chat-header avatar showed the browser's **broken-image placeholder** (a "?" box) instead of the avatar. `FamiliarAvatar` rendered a bare `<img src={avatarImage}>` with no error handling, so any failed load — a transient 404 while `/api/familiars/[id]/avatar` compiles on a cold start, a timeout, or a decode failure — left the broken placeholder permanently. The avatar route's own 404 contract already says "the UI then falls back to the glyph," but that fallback was never implemented for a *failed* load (only for an absent `avatarImage`).

## Fix

On `<img>` error, swap to `FamiliarGlyph` (the familiar's deterministic glyph). Reset the error state when the avatar `src` changes so a new familiar/version re-attempts the image. Success path unchanged — when the route serves the avatar (verified: 200, image/png), the real image still renders.

## Verification

- Root cause confirmed: the route serves Nova's avatar fine (200, 113KB) — the "?" was a transient load failure with no graceful fallback.
- Fallback wiring covered by `familiar-avatar.test.ts`; typecheck clean.
- Note: couldn't live-trigger the error path end-to-end — avatar `<img>`s only render on chat/roster surfaces that need a running daemon/sessions, and forcing the failure would mean corrupting the shared avatar files the live app uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)