### PR TITLE
fix(sidebar): make Recent Activity items navigate to the session

### DIFF
--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -223,6 +223,20 @@ assert.match(
   "capabilities stays in Tools",
 );
 
+// Recent Activity items must navigate: RecentActivityRollup's onClick calls
+// onOpenSession, so the sidebar must forward the prop (and activeSessionId for
+// the active-row accent) or clicking a recent session silently does nothing.
+assert.match(
+  source,
+  /<RecentActivityRollup\b[^/]*\bonOpenSession=\{onOpenSession\}/,
+  "Recent Activity must receive onOpenSession so selecting an item navigates to it",
+);
+assert.match(
+  source,
+  /<RecentActivityRollup\b[^/]*\bactiveSessionId=\{activeSessionId\}/,
+  "Recent Activity must receive activeSessionId to highlight the open session",
+);
+
 // PR #322 wrapped the New Chat ActionRow in .sidebar-new-chat-row so desktop
 // CSS could hide it (the FamiliarSwitcher had its own + button to dedupe
 // against). PR #304 replaced the switcher with a plain dropdown that has no

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -188,6 +188,8 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
     onOpenSettings,
     onOpenMobileHandoff,
     onModeChange,
+    onOpenSession,
+    activeSessionId,
     addons,
     familiars,
     activeFamiliarId,
@@ -293,7 +295,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
           ))}
         </SidebarSection>
 
-        <RecentActivityRollup />
+        <RecentActivityRollup activeSessionId={activeSessionId} onOpenSession={onOpenSession} />
       </div>
 
       {/* Bottom: Notifications + Settings */}


### PR DESCRIPTION
## What

Clicking an item in the sidebar's **Recent activity** roll-up did nothing. This wires it up so selecting a recent session navigates to it.

## Why

`RecentActivityRollup`'s row button calls `onOpenSession?.(s.id)`, but `SidebarMinimal` rendered `<RecentActivityRollup />` with no props — so `onOpenSession` (and `activeSessionId`) were never passed. Clicks were silently dropped, and the currently-open session never got the active-row accent.

## How

Forward the two props, which `SidebarMinimal` already receives from `workspace.tsx`:

```tsx
<RecentActivityRollup activeSessionId={activeSessionId} onOpenSession={onOpenSession} />
```

In the parent, `onOpenSession` is wired to `openFamiliarSession(id)` (selects the familiar, sets the pending chat action, switches to chat mode), so selecting a recent item now opens that session.

## Tests

- `pnpm typecheck` clean.
- `sidebar-minimal.test.ts` passes, with two added source-text regression guards asserting `RecentActivityRollup` receives `onOpenSession` and `activeSessionId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)