### PR TITLE
fix(terminal): stop splits killing the shell (dead/blank pane) + drag panes to reorganize

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -46,6 +46,30 @@ type PtySession = {
 
 const sessions = new Map<string, PtySession>();
 
+// Recent-output ring replayed to a (re)attaching client so it repaints the
+// screen instead of staring at a blank pane. Matches the Rust desktop PTY's
+// 256KB ring (src-tauri/src/pty.rs).
+const SCROLLBACK_LIMIT_BYTES = 256 * 1024;
+// How long a shell survives after its socket drops before being reaped. A
+// terminal pane remounts whenever the Comux layout restructures (split,
+// drag-reorganize, tab switch) or the page reloads; killing the shell the
+// instant the old socket closes turned every one of those into a dead/blank
+// pane with a brand-new shell. Detach instead of kill, and let the timer reap
+// only genuinely-abandoned shells.
+const DETACH_GRACE_MS = 60_000;
+
+function appendScrollback(session: PtySession, data: Buffer): void {
+  session.scrollback.push(data);
+  session.scrollbackBytes += data.length;
+  while (
+    session.scrollbackBytes > SCROLLBACK_LIMIT_BYTES &&
+    session.scrollback.length > 1
+  ) {
+    const dropped = session.scrollback.shift();
+    if (dropped) session.scrollbackBytes -= dropped.length;
+  }
+}
+
 function getTokensFromCookie(header: string | undefined): string[] {
   if (!header) return [];
   const tokens: string[] = [];
@@ -243,7 +267,14 @@ function spawnPty(threadId: string, ws: WebSocket, cols: number, rows: number, c
   };
   sessions.set(threadId, session);
 
-  shell.onData((data: string) => sendPtyData(ws, data));
+  shell.onData((data: string) => {
+    // Keep the ring filling even while detached so a client that reattaches
+    // (split/reorg remount, reload, sleep/wake) sees what happened while it
+    // was away. Route live output to the CURRENTLY-attached socket, not the
+    // spawn-time one — adoptSession swaps session.ws on reattach.
+    appendScrollback(session, Buffer.from(data, "utf8"));
+    if (session.ws) sendPtyData(session.ws, data);
+  });
   shell.onExit(({ exitCode }: { exitCode?: number | null }) => {
     const current = sessions.get(threadId);
     if (current?.pty === shell) {
@@ -335,13 +366,24 @@ function handlePtyConnection(
   ws.on("message", (data: RawData) => onWsMessage(threadId, data));
   ws.on("close", () => {
     const session = sessions.get(threadId);
+    // A newer socket already adopted this shell (adoptSession swapped ws and
+    // closed us as "replaced") — nothing to reap.
     if (!session || session.ws !== ws) return;
-    sessions.delete(threadId);
-    try {
-      session.pty.kill();
-    } catch {
-      // Already gone.
-    }
+    // Detach, don't kill: give the client a grace window to come back
+    // (layout restructure remount, reload, sleep/wake). The ring keeps
+    // collecting output; the timer reaps only truly-abandoned shells.
+    session.ws = null;
+    if (session.detachTimer) clearTimeout(session.detachTimer);
+    session.detachTimer = setTimeout(() => {
+      const current = sessions.get(threadId);
+      if (current !== session || current.ws) return;
+      sessions.delete(threadId);
+      try {
+        session.pty.kill();
+      } catch {
+        // Already gone.
+      }
+    }, DETACH_GRACE_MS);
   });
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2116,6 +2116,21 @@ select {
     opacity var(--duration-fast) var(--ease-standard);
 }
 
+/* The bar is a drag handle: grab a pane by its header and drop it onto
+   another pane's edge to relocate it (mirrors the tab-drag gesture). */
+.comux-terminal-pane-bar {
+  cursor: grab;
+}
+
+.comux-terminal-pane-bar:active {
+  cursor: grabbing;
+}
+
+/* Source pane recedes while it's being dragged so the drop target reads. */
+.comux-terminal-pane[data-dragging="true"] {
+  opacity: 0.5;
+}
+
 /* Inactive pane headers dim back; the active one lifts with an accent wash. */
 .comux-terminal-pane:not([data-active="true"]) .comux-terminal-pane-bar {
   opacity: 0.66;

--- a/src/components/comux-view-terminal.test.ts
+++ b/src/components/comux-view-terminal.test.ts
@@ -18,7 +18,7 @@ const globals = readFileSync(
 // Keyboard hint footer (matches the inbox/calendar/library/home/browser pattern).
 assert.match(
   source,
-  /⌘N new · ⌘W close · drag tabs onto pane edges to split · drag dividers to resize/,
+  /⌘N new · ⌘W close · drag tabs or pane bars onto pane edges to split &amp; reorganize · drag dividers to resize/,
   "renders the keyboard hint footer below the terminal area",
 );
 
@@ -168,6 +168,18 @@ assert.match(
   source,
   /function TerminalDropZone\([\s\S]*?onDrop=\{\(e\) => \{[\s\S]*?onSplit\(dragged,\s*side\);/,
   "terminal panes expose edge drop zones that split with the dragged session",
+);
+// Drag a pane by its title bar onto another pane's edge to relocate it — the
+// same gesture as dragging a tab, reusing the move/drop-zone machinery.
+assert.match(
+  source,
+  /comux-terminal-pane-bar"\s*\n\s*draggable\s*\n\s*data-terminal-pane-handle=\{s\.id\}/,
+  "the pane title bar is a drag handle carrying its session id",
+);
+assert.match(
+  source,
+  /comux-terminal-pane-bar[\s\S]*?onDragStart=\{[\s\S]*?dataTransfer\.setData\(TERMINAL_SESSION_DRAG_TYPE,\s*s\.id\)/,
+  "dragging a pane bar stores the session id so a drop relocates that pane",
 );
 assert.match(
   source,

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -562,12 +562,30 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
             data-active={isActive ? "true" : undefined}
             onClick={() => focusSessionById(s.id)}
           >
-            <div className="comux-terminal-pane-bar">
+            <div
+              className="comux-terminal-pane-bar"
+              draggable
+              data-terminal-pane-handle={s.id}
+              title="Drag onto another pane's edge to move this terminal"
+              onDragStart={(e) => {
+                e.dataTransfer.effectAllowed = "move";
+                e.dataTransfer.setData(TERMINAL_SESSION_DRAG_TYPE, s.id);
+                e.currentTarget
+                  .closest(".comux-terminal-pane")
+                  ?.setAttribute("data-dragging", "true");
+              }}
+              onDragEnd={(e) => {
+                e.currentTarget
+                  .closest(".comux-terminal-pane")
+                  ?.removeAttribute("data-dragging");
+              }}
+            >
               <Icon name="ph:terminal-window" width={12} aria-hidden />
               <span className="min-w-0 flex-1 truncate">{s.label}</span>
               {visiblePaneCount > 1 ? (
                 <button
                   type="button"
+                  draggable={false}
                   className="comux-terminal-pane-action"
                   onClick={(e) => {
                     e.stopPropagation();
@@ -768,7 +786,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
             )}
           </div>
           <footer className="shrink-0 border-t border-[var(--border-hairline)] px-3 py-1.5 text-center text-[10px] text-[var(--text-muted)]">
-            ⌘N new · ⌘W close · drag tabs onto pane edges to split · drag dividers to resize
+            ⌘N new · ⌘W close · drag tabs or pane bars onto pane edges to split &amp; reorganize · drag dividers to resize
           </footer>
         </div>
       ) : (

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -102,6 +102,55 @@ assert.match(
   "terminal renders the error message, not [object Event]",
 );
 
-console.log("server-pty-ws.test.ts OK");
+// PTY survival across pane remounts (#481 behavior; regressed by the #714 auth
+// rewrite, restored here). A Comux pane remounts whenever the terminal layout
+// restructures — split, drag-reorganize, tab switch — which closes its
+// websocket. If the shell is killed the instant that socket drops, the split
+// leaves a dead/blank pane backed by a brand-new shell. Three pieces keep the
+// shell alive and repaintable across the remount:
+//
+// 1. A bounded scrollback ring, populated as output streams and replayed on
+//    reattach so the returning client repaints instead of showing a blank pane.
+assert.match(
+  src,
+  /function appendScrollback\(session: PtySession, data: Buffer\): void/,
+  "server keeps a scrollback ring helper so reattaching clients can repaint",
+);
+assert.match(
+  src,
+  /shell\.onData\(\(data: string\) => \{[\s\S]*?appendScrollback\(session,/,
+  "live PTY output is appended to the scrollback ring",
+);
+// 2. Live output is routed to the CURRENTLY-attached socket. Capturing the
+//    spawn-time socket (the #714 regression) sent output into the closed
+//    socket after adoptSession swapped session.ws — one replay then silence.
+assert.match(
+  src,
+  /shell\.onData\(\(data: string\) => \{[\s\S]*?if \(session\.ws\) sendPtyData\(session\.ws, data\)/,
+  "live PTY output routes to the current session.ws, not the spawn-time socket",
+);
+assert.match(
+  src,
+  /session\.scrollbackBytes > 0[\s\S]{0,80}sendPtyData\(ws, Buffer\.concat\(session\.scrollback\)/,
+  "adoptSession replays the scrollback ring to a reattaching client",
+);
+// 3. A detach grace window: on socket close the shell is detached (session.ws
+//    nulled) and a timer reaps it later, instead of an immediate kill. A quick
+//    remount reattaches within the window and the shell survives losslessly.
+assert.match(
+  src,
+  /const DETACH_GRACE_MS = /,
+  "server defines a detach grace window before reaping an abandoned shell",
+);
+assert.match(
+  src,
+  /ws\.on\("close", \(\) => \{[\s\S]*?session\.ws = null;[\s\S]*?setTimeout\([\s\S]*?DETACH_GRACE_MS\)/,
+  "closing the socket detaches and arms a reap timer rather than killing the shell immediately",
+);
+assert.match(
+  src,
+  /if \(session\.detachTimer\) \{\s*clearTimeout\(session\.detachTimer\)/,
+  "adoptSession cancels the pending reap when a client reattaches in time",
+);
 
-// Detach grace removed in #714 — PTY is killed immediately on close
+console.log("server-pty-ws.test.ts OK");


### PR DESCRIPTION
## The dead/blank pane on split

Splitting a terminal left a **dead/blank pane** on the browser/iOS WebSocket path.

A Comux pane **remounts whenever the layout restructures** — a split turns `root = leaf A` (rendered as a bare pane div) into a `<Group>` of nested `<Panel>`s, which changes pane A's React parent chain and forces React to unmount/remount its `BottomTerminal`. That remount closes A's pty websocket.

The #714 auth-lockdown PR **accidentally gutted the #481 PTY-survival machinery**, so a socket close killed the shell *immediately* and the remount connected to a brand-new blank shell. (Confirmed via `git show c07003c6` — the auth PR deleted `appendScrollback`, the `session.ws` output routing, and the detach-grace window.)

### Fix (server.ts) — restore the three regressed pieces
- **Scrollback ring** repopulated (256KB, matching the Rust PTY) so a reattaching client repaints instead of showing a blank pane.
- **Live output routes to the current `session.ws`** (`adoptSession` swaps it on reattach) instead of the captured spawn-time socket — the old code sent output into the closed socket after adoption (one replay, then silence).
- **Detach-with-grace on close**: null `session.ws` + arm a 60s reap timer instead of an immediate `pty.kill()`. A split's remount reattaches within the window and the shell survives losslessly; `adoptSession` cancels the pending reap.

Desktop (Rust `pty.rs`) already survived splits via global `app.emit` + `pty_snapshot` replay, so it's unaffected.

## Drag panes to reorganize
The move machinery (`moveTerminalPane`) and edge drop-zones already existed; only *tabs* were draggable. The **pane title bar is now a drag handle** carrying its session id — drop it onto another pane's edge to relocate it, reusing the same drop-zones. Tab-edge dragging still works. Adds a grab cursor and a dim-while-dragging affordance.

## Verification
- `pnpm typecheck` clean.
- Affected tests green: `server-pty-ws`, `comux-view-terminal`, `terminal-layout`, `pty-ws-bridge`, `globals.css`, `globals-background`.
- New assertions cover the restored scrollback/routing/grace behavior and the draggable pane handle.
- Not run live in-app: a two-socket reconnect-across-split / on-device check (PTY needs the running app). Happy to drive a live verify if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)