### PR TITLE
feat(ui): full-width role rows + tighter chat session rail

### DIFF
--- a/src/components/chat-project-sidebar.tsx
+++ b/src/components/chat-project-sidebar.tsx
@@ -162,30 +162,32 @@ function ThreadRow({
         }}
         aria-current={active ? "true" : undefined}
         className={[
-          "focus-ring-inset relative flex min-h-[36px] w-full items-center gap-2 py-2 pl-3 pr-1.5 text-left text-[12px] transition-colors",
+          "focus-ring-inset relative flex min-h-[36px] w-full items-center gap-1.5 py-2 pl-2 pr-1.5 text-left text-[12px] transition-colors",
           active
             ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
             : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]/50 hover:text-[var(--text-primary)]",
         ].join(" ")}
       >
         {active ? <AccentBar /> : null}
-        {/* Drag handle — appears on hover; carries the sortable listeners so the
-            row's own click stays an "open". */}
-        <button
-          type="button"
-          {...attributes}
-          {...listeners}
-          onClick={(e) => e.stopPropagation()}
-          title="Drag to reorder"
-          aria-label={`Reorder ${title}`}
-          className="chat-thread-handle -ml-1 grid h-4 w-3 shrink-0 cursor-grab touch-none place-items-center text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover/row:opacity-100"
-        >
-          <Icon name="ph:dots-six-vertical" width={11} aria-hidden />
-        </button>
-        <span
-          aria-hidden
-          className={`h-1.5 w-1.5 shrink-0 rounded-full ${statusDotClass(session.status)}`}
-        />
+        {/* Status dot and drag handle share one slot — dot by default, handle on
+            hover — so the row reserves no extra left gutter for the handle. */}
+        <span className="relative grid h-4 w-3 shrink-0 place-items-center">
+          <span
+            aria-hidden
+            className={`h-1.5 w-1.5 rounded-full transition-opacity group-hover/row:opacity-0 ${statusDotClass(session.status)}`}
+          />
+          <button
+            type="button"
+            {...attributes}
+            {...listeners}
+            onClick={(e) => e.stopPropagation()}
+            title="Drag to reorder"
+            aria-label={`Reorder ${title}`}
+            className="chat-thread-handle absolute inset-0 grid cursor-grab touch-none place-items-center text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover/row:opacity-100"
+          >
+            <Icon name="ph:dots-six-vertical" width={11} aria-hidden />
+          </button>
+        </span>
         <span className="min-w-0 flex-1 truncate">{title}</span>
         <span className="chat-thread-age shrink-0 font-mono text-[10px] text-[var(--text-muted)] group-hover/row:hidden">
           {shortAge(session.updated_at)}
@@ -260,25 +262,32 @@ function FolderChatRow({
         }}
         aria-current={active ? "true" : undefined}
         className={[
-          "relative flex min-h-[34px] w-full items-center gap-2 py-2 pl-3 pr-2 text-left text-[12px] transition-colors",
+          "relative flex min-h-[34px] w-full items-center gap-1.5 py-2 pl-2 pr-2 text-left text-[12px] transition-colors",
           active
             ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
             : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]/50 hover:text-[var(--text-primary)]",
         ].join(" ")}
       >
         {active ? <AccentBar /> : null}
-        <button
-          type="button"
-          {...attributes}
-          {...listeners}
-          onClick={(e) => e.stopPropagation()}
-          title="Drag to reorder or move to another project"
-          aria-label={`Move ${title}`}
-          className="grid h-4 w-3 shrink-0 cursor-grab touch-none place-items-center text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover/row:opacity-100"
-        >
-          <Icon name="ph:dots-six-vertical" width={10} aria-hidden />
-        </button>
-        <span aria-hidden className={`h-1.5 w-1.5 shrink-0 rounded-full ${statusDotClass(session.status)}`} />
+        {/* Status dot and drag handle share one slot — dot by default, handle on
+            hover — so the row reserves no extra left gutter for the handle. */}
+        <span className="relative grid h-4 w-3 shrink-0 place-items-center">
+          <span
+            aria-hidden
+            className={`h-1.5 w-1.5 rounded-full transition-opacity group-hover/row:opacity-0 ${statusDotClass(session.status)}`}
+          />
+          <button
+            type="button"
+            {...attributes}
+            {...listeners}
+            onClick={(e) => e.stopPropagation()}
+            title="Drag to reorder or move to another project"
+            aria-label={`Move ${title}`}
+            className="absolute inset-0 grid cursor-grab touch-none place-items-center text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover/row:opacity-100"
+          >
+            <Icon name="ph:dots-six-vertical" width={10} aria-hidden />
+          </button>
+        </span>
         <span className="min-w-0 flex-1 truncate">{title}</span>
       </div>
     </li>

--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Icon } from "@/lib/icon";
 import { SkillCard } from "@/components/skill-card";
 import {
   SkillDetailDrawer,
@@ -9,6 +8,7 @@ import {
   type SkillEntry as SkillDetailEntry,
 } from "@/components/skill-detail-drawer";
 import { listWorkflows, type WorkflowSummary } from "@/lib/workflows";
+import { Icon } from "@/lib/icon";
 
 type Tab = "roles" | "workflows" | "skills";
 
@@ -54,10 +54,23 @@ const TAB_LABEL: Record<Tab, string> = {
   skills: "Skills",
 };
 
-const TAB_ICON: Record<Tab, Parameters<typeof Icon>[0]["name"]> = {
-  roles: "ph:mask-happy",
-  workflows: "ph:graph",
-  skills: "ph:sparkle",
+type IconName = Parameters<typeof Icon>[0]["name"];
+
+// Single source of truth for every icon in this view — edit a name here to swap it everywhere.
+const ICONS = {
+  search: "ph:magnifying-glass",
+  tabRoles: "ph:mask-happy",
+  tabWorkflows: "ph:graph",
+  tabSkills: "ph:sparkle",
+  workflowChip: "ph:lightning-bold",
+  workflowItem: "ph:graph",
+  workflowOpen: "ph:arrow-right-bold",
+} satisfies Record<string, IconName>;
+
+const TAB_ICON: Record<Tab, IconName> = {
+  roles: ICONS.tabRoles,
+  workflows: ICONS.tabWorkflows,
+  skills: ICONS.tabSkills,
 };
 
 function includesQuery(values: Array<string | undefined>, query: string): boolean {
@@ -244,7 +257,7 @@ export function PluginsView({
             </h2>
           </div>
           <label className="flex min-w-0 items-center gap-2 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-panel)] px-3 py-2 lg:w-80">
-            <Icon name="ph:magnifying-glass" width={15} className="shrink-0 text-[var(--text-muted)]" />
+            <Icon name={ICONS.search} width={15} className="shrink-0 text-[var(--text-muted)]" />
             <input
               ref={searchRef}
               value={query}
@@ -342,16 +355,16 @@ function RolesTab({
   if (roles.length === 0) return <EmptyPanel title="No roles found" body="Add ROLE.md files to a familiar workspace to populate this view." />;
 
   return (
-    <div className="grid gap-3 xl:grid-cols-2">
+    <div className="flex flex-col gap-2">
       {roles.map((role) => {
         const key = `${role.familiar}:${role.id}`;
         return (
           <article
             key={key}
-            className="plugins-role-card rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-panel)] p-4"
+            className="plugins-role-card rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-panel)] px-4 py-3"
           >
             <div className="flex items-start gap-3">
-              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-raised)] text-[16px] font-semibold text-[var(--text-primary)]">
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-raised)] text-[15px] font-semibold text-[var(--text-primary)]">
                 {role.emoji || role.name.slice(0, 1).toUpperCase()}
               </span>
               <div className="min-w-0 flex-1">
@@ -367,20 +380,29 @@ function RolesTab({
                   ) : null}
                 </div>
                 {role.description ? (
-                  <p className="mt-1 text-[12px] leading-relaxed text-[var(--text-secondary)]">{role.description}</p>
+                  <p className="mt-0.5 text-[12px] leading-relaxed text-[var(--text-secondary)]">{role.description}</p>
                 ) : null}
               </div>
-              <button
-                type="button"
-                disabled={busyRoleKey === key}
-                onClick={() => onToggleRole(role)}
-                className="plugins-role-toggle focus-ring rounded-md border border-[var(--border-hairline)] px-3 py-1.5 text-[12px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)] disabled:opacity-50"
-              >
-                {role.active ? "Disable" : "Enable"}
-              </button>
+              <div className="flex shrink-0 items-center gap-2">
+                <button
+                  type="button"
+                  disabled={busyRoleKey === key}
+                  onClick={() => onToggleRole(role)}
+                  className="plugins-role-toggle focus-ring rounded-md border border-[var(--border-hairline)] px-3 py-1.5 text-[12px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)] disabled:opacity-50"
+                >
+                  {role.active ? "Disable" : "Enable"}
+                </button>
+                <button
+                  type="button"
+                  onClick={onOpenChat}
+                  className="focus-ring rounded-md bg-[var(--text-primary)] px-3 py-1.5 text-[12px] text-[var(--bg-base)]"
+                >
+                  Open chat
+                </button>
+              </div>
             </div>
 
-            <dl className="mt-4 space-y-2.5">
+            <dl className="mt-3 space-y-2">
               <CapabilityRow label="Skills" items={role.skills} />
               <CapabilityRow label="Tools" items={role.tools} />
               <CapabilityRow
@@ -390,16 +412,6 @@ function RolesTab({
                 openHint="Open workflow"
               />
             </dl>
-
-            <div className="mt-4">
-              <button
-                type="button"
-                onClick={onOpenChat}
-                className="focus-ring rounded-md bg-[var(--text-primary)] px-3 py-1.5 text-[12px] text-[var(--bg-base)]"
-              >
-                Open chat
-              </button>
-            </div>
           </article>
         );
       })}
@@ -437,7 +449,7 @@ function CapabilityRow({
                   title={openHint ? `${openHint}: ${item}` : item}
                   className="plugins-role-chip plugins-role-chip--action focus-ring inline-flex items-center gap-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2 py-1 text-[11px] text-[var(--text-primary)] hover:border-[var(--border-strong)] hover:text-[var(--accent-text)]"
                 >
-                  <Icon name="ph:lightning-bold" width={10} aria-hidden />
+                  <Icon name={ICONS.workflowChip} width={10} aria-hidden />
                   {item}
                 </button>
               ) : (
@@ -478,7 +490,7 @@ function WorkflowsTab({
           className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-[var(--bg-raised)]"
         >
           <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-raised)]">
-            <Icon name="ph:graph" width={16} className="text-[var(--text-muted)]" />
+            <Icon name={ICONS.workflowItem} width={16} className="text-[var(--text-muted)]" />
           </span>
           <span className="min-w-0 flex-1">
             <span className="block truncate text-[13px] font-medium text-[var(--text-primary)]">
@@ -488,7 +500,7 @@ function WorkflowsTab({
               {[workflow.pattern, workflow.familiar, workflow.summary].filter(Boolean).join(" · ") || workflow.id}
             </span>
           </span>
-          <Icon name="ph:arrow-right-bold" width={13} className="text-[var(--text-muted)]" />
+          <Icon name={ICONS.workflowOpen} width={13} className="text-[var(--text-muted)]" />
         </button>
       ))}
     </div>


### PR DESCRIPTION
## What

Two UI-density passes requested in-session:

**Role and capability map** (`plugins-view.tsx`)
- Roles now render as full-width **rows** (single column) instead of the 2-column card grid.
- **Enable** + **Open chat** actions grouped top-right of each row.
- Every icon name in this view is centralized into one `ICONS` map (`satisfies Record<string, IconName>`) so icons are trivial to swap and type-checked at compile time.

**Chat session rail** (`chat-project-sidebar.tsx`)
- Drag handle and status dot now share **one slot** — status dot by default, drag handle on hover — instead of the handle reserving its own ~20px gutter while invisible.
- Trimmed left padding (`pl-3` → `pl-2`) and gap (`gap-2` → `gap-1.5`).
- Net: titles start further left and show more text; drag-to-reorder preserved. Applied to both `FolderChatRow` and `ThreadRow`.

## Verification
- `pnpm tsc --noEmit` clean for both files.
- Source-text suites pass: `chat-thread-rail`, `chat-rail-modern-redesign`, `chat-project-sidebar-dnd`, `right-sidebar-fit`, `shell-edge-rails`, `chat-all-familiars-project-list`.
- Driven live in demo mode: roles render as full-width rows with icons intact; rail rows show the dot→title with the handle appearing in-slot on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)