### PR TITLE
fix(chat): remove the left whitespace from the session list

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5529,6 +5529,7 @@ a.mobile-handoff__link:hover {
   }
 
   .chat-list-drag-handle {
+    position: static;
     grid-area: handle;
     width: var(--touch-target);
     height: var(--touch-target);

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -530,7 +530,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
 
   return (
     <div className="flex h-full min-w-0">
-      {!compact && (
+      {!compact && sidebarOpen && (
       <ChatProjectSidebar
         groups={sidebarGroups}
         selection={effectiveSelection}
@@ -621,6 +621,18 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
 
         {/* Search + filter row */}
         <div className="mt-3 flex items-center gap-2 px-4 pb-3">
+          {!compact && !sidebarOpen && (
+            <button
+              type="button"
+              onClick={() => setSidebarOpen(true)}
+              title="Show sessions"
+              aria-label="Show sessions"
+              aria-expanded={false}
+              className="chat-list-reopen-rail focus-ring hidden h-8 w-8 shrink-0 place-items-center rounded-lg border border-[var(--border-hairline)] text-[var(--text-muted)] transition-colors hover:border-[var(--border-strong)] hover:text-[var(--text-secondary)] lg:grid"
+            >
+              <Icon name="ph:sidebar-simple" width={14} aria-hidden />
+            </button>
+          )}
           <label className="chat-list-search-control flex h-8 min-w-0 flex-1 items-center gap-2 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/60 px-2.5 transition-colors focus-within:border-[var(--accent-presence)]/50 focus-within:bg-[var(--bg-raised)]">
             <Icon name="ph:magnifying-glass" width={13} className="shrink-0 text-[var(--text-muted)]" />
             <input
@@ -870,7 +882,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                             onClick={(e) => e.stopPropagation()}
                             title="Drag to reorder"
                             aria-label={`Reorder chat ${rowName}`}
-                            className="chat-list-drag-handle touch-always-visible -ml-1 mt-0.5 grid h-6 w-4 shrink-0 cursor-grab touch-none place-items-center rounded text-[var(--text-muted)] opacity-0 transition-all hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover:opacity-100"
+                            className="chat-list-drag-handle touch-always-visible absolute left-0 top-1/2 grid h-6 w-4 -translate-y-1/2 cursor-grab touch-none place-items-center rounded text-[var(--text-muted)] opacity-0 transition-all hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover:opacity-100"
                           >
                             <Icon name="ph:dots-six-vertical" width={12} aria-hidden />
                           </button>


### PR DESCRIPTION
## What

Closes two empty gutters on the left edge of the session list view.

- **Collapsed rail column** — the Projects/sessions rail no longer leaves an empty bordered column when collapsed. It mounts only when open; when collapsed, a compact **Show sessions** toggle now lives inline at the start of the search row (desktop only), so the search bar and rows sit flush left.
- **Per-row indent** — the (invisible until hover) drag handle was reserving ~28px of flow width before every status dot. It's now absolutely positioned inside the row's existing left-padding lane, so content starts at the normal 16px edge while the handle still appears on hover.

Mobile is unaffected: `.chat-list-drag-handle` gets a `position: static` reset in the `max-width: 767px` block so the existing `grid-area` layout keeps working.

## Verify

- `tsc --noEmit` clean
- chat-list / rail test suites pass (`chat-thread-rail`, `chat-rail-modern-redesign`, `chat-list-delete`, `chat-list-mobile-rail-port`, `chat-list-mobile-command-center`, `chat-all-familiars-project-list`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)