### PR TITLE
feat(theme): retheme Ember into Vintage Paper (tweakcn port)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2872,41 +2872,54 @@ select {
   --ring-focus: color-mix(in oklch, #2A8050 55%, transparent);
 }
 
-/* ---- Ember (brazier 40) — slow burn for long workings ---- */
+/* ---- Vintage Paper (id: ember) — warm tan ink steeped into aged folio.
+   Ported from tweakcn's "vintage-paper" theme; mapped onto Cave's semantic
+   token ladder. Dark mode is a warm sepia, not the usual near-black. ---- */
 [data-theme="ember"] {
-  --background: oklch(0.11 0.045 40);
-  --card: oklch(0.15 0.048 40);
-  --popover: oklch(0.15 0.048 40);
-  --muted: oklch(0.19 0.050 40);
-  --accent: oklch(0.19 0.050 40);
-  --secondary: oklch(0.19 0.050 40);
-  --muted-foreground: oklch(0.72 0.038 40);
-  --accent-presence: #F4B264;
-  --ring: oklch(0.74 0.16 40);
+  --background: oklch(0.2747 0.0139 57.6523);
+  --foreground: oklch(0.9239 0.0190 83.0636);
+  --card: oklch(0.3237 0.0155 59.0603);
+  --card-foreground: oklch(0.9239 0.0190 83.0636);
+  --popover: oklch(0.3237 0.0155 59.0603);
+  --popover-foreground: oklch(0.9239 0.0190 83.0636);
+  --muted: oklch(0.2939 0.0125 62.1298);
+  --accent: oklch(0.4186 0.0281 56.3404);
+  --secondary: oklch(0.3795 0.0181 57.1280);
+  --muted-foreground: oklch(0.7982 0.0243 82.1078);
+  --accent-presence: oklch(0.7264 0.0581 66.6967);
+  --accent-presence-soft: oklch(0.80 0.050 75);
+  --ring: oklch(0.7264 0.0581 66.6967);
+  --border: oklch(0.3795 0.0181 57.1280);
+  --input: oklch(0.3795 0.0181 57.1280);
   --bg-base: var(--background);
-  --bg-panel: oklch(0.085 0.042 40);
+  --bg-panel: oklch(0.2450 0.0130 57.6523);
   --bg-raised: var(--card);
-  --bg-elevated: oklch(0.19 0.050 40);
-  --bg-hover: oklch(0.23 0.052 40);
-  --ring-focus: color-mix(in oklch, #F4B264 55%, transparent);
+  --bg-elevated: oklch(0.3795 0.0181 57.1280);
+  --bg-hover: oklch(0.4186 0.0281 56.3404);
+  --ring-focus: color-mix(in oklch, var(--accent-presence) 55%, transparent);
 }
 [data-theme="ember"][data-mode="light"] {
-  --background: oklch(0.975 0.014 65);
-  --foreground: oklch(0.18 0.024 35);
-  --card: oklch(0.95 0.018 65);
-  --popover: oklch(0.97 0.018 65);
-  --muted: oklch(0.92 0.022 60);
-  --accent: oklch(0.92 0.022 60);
-  --secondary: oklch(0.92 0.022 60);
-  --muted-foreground: oklch(0.40 0.028 35);
-  --accent-presence: #8E5614;
-  --ring: oklch(0.50 0.14 40);
+  --background: oklch(0.9582 0.0152 90.2357);
+  --foreground: oklch(0.3760 0.0225 64.3434);
+  --card: oklch(0.9914 0.0098 87.4695);
+  --card-foreground: oklch(0.3760 0.0225 64.3434);
+  --popover: oklch(0.9914 0.0098 87.4695);
+  --popover-foreground: oklch(0.3760 0.0225 64.3434);
+  --muted: oklch(0.9239 0.0190 83.0636);
+  --accent: oklch(0.8348 0.0426 88.8064);
+  --secondary: oklch(0.8846 0.0302 85.5655);
+  --muted-foreground: oklch(0.5391 0.0387 71.1655);
+  --accent-presence: oklch(0.6180 0.0778 65.5444);
+  --accent-presence-soft: oklch(0.6180 0.060 65);
+  --ring: oklch(0.6180 0.0778 65.5444);
+  --border: oklch(0.8606 0.0321 84.5881);
+  --input: oklch(0.8606 0.0321 84.5881);
   --bg-base: var(--background);
-  --bg-panel: oklch(0.99 0.012 65);
+  --bg-panel: oklch(0.9914 0.0098 87.4695);
   --bg-raised: var(--card);
-  --bg-elevated: oklch(0.93 0.020 60);
-  --bg-hover: oklch(0.89 0.024 55);
-  --ring-focus: color-mix(in oklch, #8E5614 55%, transparent);
+  --bg-elevated: oklch(0.9239 0.0190 83.0636);
+  --bg-hover: oklch(0.8846 0.0302 85.5655);
+  --ring-focus: color-mix(in oklch, var(--accent-presence) 55%, transparent);
 }
 
 /* ---- Bloom (bewitching-blood 20) — saccharine looks; thorned hands ---- */

--- a/src/lib/theme-palettes.ts
+++ b/src/lib/theme-palettes.ts
@@ -53,10 +53,10 @@ export const THEME_META: Record<ThemeId, ThemeMeta> = {
     bgDark: "oklch(0.10 0.040 150)", bgLight: "oklch(0.97 0.018 145)",
   },
   ember: {
-    name: "Ember",
-    description: "Brazier-warmed parchment. A slow burn for long workings.",
-    hue: 40, accentDark: "#F4B264", accentLight: "#8E5614",
-    bgDark: "oklch(0.11 0.045 40)", bgLight: "oklch(0.975 0.014 65)",
+    name: "Vintage Paper",
+    description: "Sun-faded folio. Warm tan ink steeped into aged paper; unhurried.",
+    hue: 66, accentDark: "#c0a080", accentLight: "#a67c52",
+    bgDark: "oklch(0.2747 0.0139 57.6523)", bgLight: "oklch(0.9582 0.0152 90.2357)",
   },
   bloom: {
     name: "Bloom",


### PR DESCRIPTION
## What

Reskins the **Ember** theme to emulate [tweakcn's Vintage Paper theme](https://tweakcn.com/editor/theme?theme=vintage-paper) and renames its display name to **Vintage Paper**.

- Every surface/accent token from tweakcn's `vintage-paper` was mapped onto Cave's semantic ladder (`--background`, `--card`, `--popover`, `--muted`, `--accent`, `--secondary`, `--ring`, `--border`/`--input`, plus the `--bg-base` → `--bg-hover` ladder).
- **Dark mode is now a warm sepia** rather than near-black — added `--foreground`, `--card-foreground`, `--popover-foreground` (warm cream) and a warm `--border` so the parchment reads on every surface.
- `--ring-focus` derives from `var(--accent-presence)` in both modes (no hardcoded hex).
- `THEME_META` updated: name → "Vintage Paper", new description, `hue: 66`, swatch backgrounds, and accent swatches converted to hex (`#c0a080` dark / `#a67c52` light, since `getSwatches` appends an alpha suffix).

## Scope note

The internal theme **id stays `ember`** — so existing saved user preferences, the `[data-theme="ember"]` CSS selectors, and the `THEME_IDS` contract are untouched. Only the user-facing name and the colors change. (Renaming the slug would reset every existing user's saved theme; not worth it for a rename.)

## Verify

- `theme-palettes.test.ts`, `globals.css.test.ts`, `theme-color-editor.test.ts` all pass
- oklch→hex swatch conversions computed and checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)