### PR TITLE
chore: regenerate stale server.mjs to match server.ts

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -22,6 +22,16 @@ const ACCESS_COOKIE = "coven_cave_access";
 const LEGACY_ACCESS_COOKIE = "coven_access_token";
 const ACCESS_QUERY_PARAM = "coven_access_token";
 const sessions = /* @__PURE__ */ new Map();
+const SCROLLBACK_LIMIT_BYTES = 256 * 1024;
+const DETACH_GRACE_MS = 6e4;
+function appendScrollback(session, data) {
+  session.scrollback.push(data);
+  session.scrollbackBytes += data.length;
+  while (session.scrollbackBytes > SCROLLBACK_LIMIT_BYTES && session.scrollback.length > 1) {
+    const dropped = session.scrollback.shift();
+    if (dropped) session.scrollbackBytes -= dropped.length;
+  }
+}
 function getTokensFromCookie(header) {
   if (!header) return [];
   const tokens = [];
@@ -180,7 +190,10 @@ function spawnPty(threadId, ws, cols, rows, cwd) {
     detachTimer: null
   };
   sessions.set(threadId, session);
-  shell.onData((data) => sendPtyData(ws, data));
+  shell.onData((data) => {
+    appendScrollback(session, Buffer.from(data, "utf8"));
+    if (session.ws) sendPtyData(session.ws, data);
+  });
   shell.onExit(({ exitCode }) => {
     const current = sessions.get(threadId);
     if (current?.pty === shell) {
@@ -247,11 +260,17 @@ function handlePtyConnection(ws, threadId, cols, rows, cwd) {
   ws.on("close", () => {
     const session = sessions.get(threadId);
     if (!session || session.ws !== ws) return;
-    sessions.delete(threadId);
-    try {
-      session.pty.kill();
-    } catch {
-    }
+    session.ws = null;
+    if (session.detachTimer) clearTimeout(session.detachTimer);
+    session.detachTimer = setTimeout(() => {
+      const current = sessions.get(threadId);
+      if (current !== session || current.ws) return;
+      sessions.delete(threadId);
+      try {
+        session.pty.kill();
+      } catch {
+      }
+    }, DETACH_GRACE_MS);
   });
 }
 const dev = process.env.NODE_ENV !== "production";


### PR DESCRIPTION
## What

The tracked `server.mjs` (esbuild bundle of `server.ts`) drifted from source: #925's PTY scrollback ring + detach-grace changes to `server.ts` weren't re-bundled into the committed `server.mjs`. This regenerates it via `pnpm build:server`.

## Why it's safe / low-stakes

`pnpm build` runs `build:server` and overwrites `server.mjs` during every build, so packaged releases and CI already use the up-to-date bundle. This only corrects the **tracked artifact** so it matches `server.ts` — surfaced while trimming an accidental `server.mjs` rebuild from #928.

## Verification

- Diff is exactly the #925 PTY logic (`SCROLLBACK_LIMIT_BYTES`, `DETACH_GRACE_MS`, `appendScrollback`, `detachTimer`, `session.ws` routing).
- `node --check server.mjs` passes (valid ESM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)