### PR TITLE
fix(mobile-handoff): produce a working invite link/QR when Tailscale Serve start fails

### DIFF
--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -5,6 +5,7 @@ import { stripAnsi } from "@/lib/ansi";
 import {
   createMobileInvite,
   findServeUrl,
+  magicDnsServeUrl,
   MOBILE_INVITE_TTL_MS,
   tailscaleBin,
   tailscaleSpawnEnv,
@@ -111,48 +112,53 @@ async function mobileHandoff(req: Request) {
     return NextResponse.json({ ok: false, error }, { status: 503 });
   }
 
-  const self = await runTailscale(["status", "--self"]);
+  // `--json` doubles as the connectivity check (exit 0 == connected) and the
+  // source for the MagicDNS fallback host below.
+  const self = await runTailscale(["status", "--self", "--json"]);
   if (!self.ok) {
     return NextResponse.json(
       { ok: false, error: "tailscale is not connected", stderr: self.stderr },
       { status: 503 },
     );
   }
+  // Best-effort: an unparseable self status just disables the MagicDNS
+  // fallback; an existing serve config can still yield a URL. Reuse the
+  // tolerant parser so prepended health/warning lines don't break it.
+  const parsedSelf = parseServeStatus(self.stdout);
+  const selfStatus: unknown = "error" in parsedSelf ? null : parsedSelf.value;
 
   const backend = backendUrl(req);
+
+  // Best-effort (re)start of Tailscale Serve. Don't hard-fail when this errors
+  // — on macOS the CLI can return "GUI failed to start (CLIError 3)" even
+  // though the serve config (and tunnel) is already live in the daemon. Capture
+  // the error as a non-fatal warning and try to produce a working link anyway.
   const serve = await runTailscale(["serve", "--bg", backend]);
-  if (!serve.ok) {
-    return NextResponse.json(
-      { ok: false, error: "failed to start tailscale serve", stderr: serve.stderr },
-      { status: 500 },
-    );
-  }
+  const serveWarning = serve.ok
+    ? null
+    : serve.stderr || "Tailscale Serve could not be (re)started.";
 
+  // Prefer the real serve config when it's readable.
+  let serveUrl: string | null = null;
   const status = await runTailscale(["serve", "status", "--json"]);
-  if (!status.ok) {
-    return NextResponse.json(
-      { ok: false, error: "failed to read tailscale serve status", stderr: status.stderr },
-      { status: 500 },
-    );
+  if (status.ok) {
+    const parsed = parseServeStatus(status.stdout);
+    if (!("error" in parsed)) serveUrl = findServeUrl(parsed.value, backend);
   }
 
-  const parsed = parseServeStatus(status.stdout);
-  if ("error" in parsed) {
+  // Fallback to the device's MagicDNS host so the invite link + QR still work
+  // when the serve config can't be read (the case the user hit).
+  if (!serveUrl) serveUrl = magicDnsServeUrl(selfStatus);
+
+  if (!serveUrl) {
+    // Nothing usable — surface the most actionable error we have.
     return NextResponse.json(
       {
         ok: false,
-        error: "invalid tailscale serve status output",
-        stderr: status.stderr || parsed.error,
+        error: serveWarning ?? "tailscale serve URL not found",
+        stderr: serveWarning ?? status.stderr,
+        backendUrl: backend,
       },
-      { status: 500 },
-    );
-  }
-  const parsedStatus = parsed.value;
-
-  const serveUrl = findServeUrl(parsedStatus, backend);
-  if (!serveUrl) {
-    return NextResponse.json(
-      { ok: false, error: "tailscale serve URL not found", backendUrl: backend },
       { status: 500 },
     );
   }
@@ -180,6 +186,9 @@ async function mobileHandoff(req: Request) {
     expiresAt: invite.expiresAt,
     expiresAtIso: invite.expiresAtIso,
     qrSvg,
+    // Non-fatal: the link/QR are usable, but Serve couldn't be (re)started, so
+    // the tunnel may need attention if the link doesn't resolve on the phone.
+    warning: serveWarning ?? undefined,
   });
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4323,6 +4323,19 @@ a.mobile-handoff__link:hover {
   line-height: 1.45;
 }
 
+/* Non-fatal note: the link/QR are usable but Tailscale Serve couldn't be
+   (re)started. Caution treatment so it reads as advisory, not a hard failure. */
+.mobile-handoff__warning {
+  margin: 0;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--warning, #d9a441) 45%, var(--border-hairline));
+  border-radius: var(--radius-control);
+  background: color-mix(in srgb, var(--warning, #d9a441) 12%, transparent);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.45;
+}
+
 /* ────────────────────────────────────────────────
    Settings · Familiars panel
    (Phase 5, shell-ia-redesign)

--- a/src/components/mobile-handoff-modal.tsx
+++ b/src/components/mobile-handoff-modal.tsx
@@ -14,6 +14,7 @@ type HandoffReady = {
   expiresAt: number;
   expiresAtIso: string;
   qrSvg: string;
+  warning?: string;
 };
 
 type HandoffError = {
@@ -170,6 +171,9 @@ export function MobileHandoffModal({ open, onClose, autoCopyRequest = 0 }: Props
               <p className="mobile-handoff__hint">
                 Scan the short-lived Tailscale invite link, or copy it and paste it into the mobile app.
               </p>
+              {handoff.warning ? (
+                <p className="mobile-handoff__warning">{handoff.warning}</p>
+              ) : null}
             </>
           ) : error ? (
             <p className="mobile-handoff__error">{error}</p>

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -44,4 +44,35 @@ assert.match(mobileStub, /id="clear-url"[\s\S]*hidden/, "Mobile connection scree
 assert.doesNotMatch(tauriConfig, /"deep-link"[\s\S]*"scheme": \["opencoven"\]/, "iOS app should not register a custom app connect URL scheme");
 assert.doesNotMatch(tauriLib, /tauri_plugin_deep_link::init/, "iOS shell should not install the deep-link plugin");
 
+// Resilient handoff: when `tailscale serve --bg` fails (e.g. macOS "GUI failed
+// to start, CLIError 3"), the route must NOT hard-fail. It should fall back to
+// the MagicDNS host so the invite link + QR still generate, returning the serve
+// error as a non-fatal warning instead.
+assert.doesNotMatch(
+  handoffRoute,
+  /error: "failed to start tailscale serve"/,
+  "serve --bg failure must not short-circuit the whole handoff",
+);
+assert.match(
+  handoffRoute,
+  /magicDnsServeUrl\(selfStatus\)/,
+  "route falls back to the MagicDNS host when the serve config can't be read",
+);
+assert.match(
+  handoffRoute,
+  /status", "--self", "--json"/,
+  "route reads self status as JSON to source the MagicDNS fallback host",
+);
+assert.match(
+  handoffRoute,
+  /warning: serveWarning/,
+  "route returns the serve-start failure as a non-fatal warning alongside the link",
+);
+assert.match(
+  modal,
+  /handoff\.warning \?\s*\(\s*<p className="mobile-handoff__warning">\{handoff\.warning\}/,
+  "modal shows the non-fatal warning while still rendering the link and QR",
+);
+assert.match(css, /\.mobile-handoff__warning/, "the non-fatal warning has stable styling");
+
 console.log("mobile-handoff.test.ts OK");

--- a/src/lib/mobile-handoff.test.ts
+++ b/src/lib/mobile-handoff.test.ts
@@ -4,6 +4,8 @@ import {
   buildInviteUrl,
   createMobileInvite,
   findServeUrl,
+  magicDnsHost,
+  magicDnsServeUrl,
   resolveTailscaleBin,
 } from "./mobile-handoff.ts";
 import { verifyMobileAccessToken } from "./mobile-access-token.ts";
@@ -113,6 +115,27 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
   assert.ok(token);
   const verification = await verifyMobileAccessToken(token, signingKey, now);
   assert.equal(verification.ok, true);
+}
+
+{
+  // MagicDNS fallback: derive the serve URL from `status --self --json` when
+  // the serve config can't be read (the GUI-failed-to-start case). The root
+  // dot Tailscale appends to DNSName is stripped.
+  const self = { Self: { DNSName: "cave.tailnet.example.ts.net." } };
+  assert.equal(magicDnsHost(self), "cave.tailnet.example.ts.net");
+  assert.equal(magicDnsServeUrl(self), serveUrl);
+
+  // The fallback host matches what findServeUrl would have produced, so the
+  // invite link is well-formed either way.
+  assert.equal(magicDnsServeUrl(self), findServeUrl(status, "http://127.0.0.1:3000"));
+}
+
+{
+  // No DNSName → no fallback (caller then surfaces the serve error).
+  assert.equal(magicDnsServeUrl(null), null);
+  assert.equal(magicDnsServeUrl({}), null);
+  assert.equal(magicDnsServeUrl({ Self: {} }), null);
+  assert.equal(magicDnsHost({ Self: { DNSName: "  " } }), null);
 }
 
 console.log("mobile-handoff.test.ts OK");

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -134,6 +134,30 @@ export function tailscaleSpawnEnv(): NodeJS.ProcessEnv {
   return { ...process.env, PATH: cachedTailscalePath };
 }
 
+type TailscaleSelfStatus = {
+  Self?: { DNSName?: string };
+};
+
+// The device's MagicDNS name from `tailscale status --self --json`, with the
+// trailing root dot the daemon appends to DNSName stripped so it can prefix a
+// `https://` URL.
+export function magicDnsHost(selfStatus: unknown): string | null {
+  const dns = (selfStatus as TailscaleSelfStatus | null)?.Self?.DNSName;
+  if (typeof dns !== "string") return null;
+  const host = dns.trim().replace(/\.+$/, "");
+  return host || null;
+}
+
+// Fallback serve URL when `tailscale serve status` can't be read (e.g. the GUI
+// failed to start): the MagicDNS host is the same host key `findServeUrl`
+// returns, so the invite link/QR are still well-formed. The link resolves once
+// a serve config is live — which it often already is, since serve config
+// persists in the daemon independently of the GUI helper that errored.
+export function magicDnsServeUrl(selfStatus: unknown): string | null {
+  const host = magicDnsHost(selfStatus);
+  return host ? `https://${host}/` : null;
+}
+
 export function findServeUrl(status: unknown, backendUrl: string) {
   const web = (status as TailscaleServeStatus | null)?.Web;
   if (!web || typeof web !== "object") return null;


### PR DESCRIPTION
## Problem

In the **Open on phone** modal, when `tailscale serve --bg` returns the macOS *"The Tailscale GUI failed to start (CLIError 3)"* error, the API hard-failed the whole request. Result: **No QR**, no link, and a disabled **Copy invite** — even though the device is connected and the Serve tunnel is usually already live. (See screenshot in the issue/thread.)

## Fix

`src/app/api/mobile-handoff/route.ts` is now resilient:

- `tailscale serve --bg` is **best-effort** — its failure is captured as a non-fatal `warning` instead of aborting.
- It reads any existing serve config; if that can't be read, it falls back to the device's **MagicDNS host** from `tailscale status --self --json` (the same host an active serve config yields), so the signed invite link + QR still generate and **Copy invite** works.
- Returns `ok: true` with the serve error as `warning`; it only truly fails when there is *neither* a serve config *nor* a MagicDNS name.

The modal (`mobile-handoff-modal.tsx`) renders the link/QR plus a caution-styled, non-blocking note (`.mobile-handoff__warning`).

New lib helpers: `magicDnsHost` / `magicDnsServeUrl`.

## Honest caveat

The derived link is well-formed and Copy invite/QR always work now, but it only *resolves on the phone* if a Serve tunnel is live in the daemon. That's usually the case (serve config persists independently of the GUI helper that errored); the warning flags the case where it isn't. This matches the ask: at minimum the link/QR always generate.

## Tests

- `pnpm typecheck` clean.
- `src/lib/mobile-handoff.test.ts`: added unit tests for the MagicDNS fallback (trailing-dot strip, parity with `findServeUrl`, null cases).
- `src/components/mobile-handoff.test.ts`: source-text guards that the route no longer short-circuits on serve failure, uses the MagicDNS fallback + `--self --json`, returns `warning`, and the modal/CSS render it.
- api-contracts pass.

Not run against live Tailscale (the GUI error is environment-specific and not reproducible here); logic is covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)