### PR TITLE
feat(mobile): 8h handoff invites + hide Salem bubble on mobile

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5780,6 +5780,14 @@ a.mobile-handoff__link:hover {
   }
 }
 
+/* Mobile (≤1023px) navigates via the bottom tab bar, so the floating Salem
+   chat bubble is hidden there — it overlaps the tabs and the composer. */
+@media (max-width: 1023px) {
+  .salem-perch {
+    display: none;
+  }
+}
+
 .salem-panel {
   position: fixed;
   bottom: 20px;

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -3,7 +3,7 @@ import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 import { signMobileAccessToken } from "./mobile-access-token.ts";
 
-export const MOBILE_INVITE_TTL_MS = 10 * 60 * 1000;
+export const MOBILE_INVITE_TTL_MS = 8 * 60 * 60 * 1000;
 
 type TailscaleServeStatus = {
   Web?: Record<


### PR DESCRIPTION
## What

**1. Longer mobile handoff invites** (`src/lib/mobile-handoff.ts`)
- `MOBILE_INVITE_TTL_MS`: **10 min → 8 hours**. An "Open on phone" / `pnpm mobile:tailscale` invite (and the resulting phone session cookie) now stays valid for a full working session instead of expiring every few minutes. Token remains tailnet-only (Tailscale Serve, not public Funnel).

**2. Hide the Salem chat bubble on mobile** (`src/app/globals.css`)
- The floating `.salem-perch` bubble is hidden at `≤1023px`, where it overlapped the bottom tab bar and the composer. Desktop behavior is unchanged.

## Verification
- `mobile-handoff.test.ts` passes (its invite test passes an explicit `ttlMs`, so the default-constant change doesn't affect it).
- `globals.css.test.ts`, `misc-aria-fixes.test.ts`, `salem.test.ts` all pass.
- Mobile breakpoint `1023px` matches the repo convention used by `.mobile-bottom-tabs` and the avatar rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)