### PR TITLE
fix(sidebar): style nav group labels as clear header bands

### DIFF
--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -382,13 +382,22 @@
   padding-top: 4px;
 }
 
+/* Shared mode-aware header band (matches the chat rail / board / GitHub /
+   calendar / schedules / library / roles / capabilities group headers): darker
+   than the page in light mode, lighter in dark — the mix toward --foreground
+   inverts per mode. Applied to every eyebrow section label in this sidebar so
+   they read as headers and stay consistent with each other. */
 .sidebar-section-label {
-  padding: 0 10px 6px;
+  margin: 0 6px 6px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%);
+  border: 1px solid color-mix(in oklch, var(--border-hairline) 75%, transparent);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 700;
   letter-spacing: 0.07em;
   text-transform: uppercase;
-  color: var(--text-muted);
+  color: var(--text-primary);
   user-select: none;
 }
 
@@ -455,12 +464,16 @@
 
 /* ── Recents header ──────────────────────────────────────────────────────── */
 .sidebar-recents-header {
-  padding: 8px 14px 3px;
+  margin: 4px 6px 3px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%);
+  border: 1px solid color-mix(in oklch, var(--border-hairline) 75%, transparent);
   font-size: 10px;
-  font-weight: 600;
+  font-weight: 700;
   letter-spacing: 0.07em;
   text-transform: uppercase;
-  color: var(--text-muted);
+  color: var(--text-primary);
   flex-shrink: 0;
   user-select: none;
 }
@@ -642,12 +655,16 @@
 
 /* ── Familiars section (left nav) ────────────────────────────────────────── */
 .sidebar-familiar-section-label {
-  padding: 5px 8px 2px;
+  margin: 5px 6px 2px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%);
+  border: 1px solid color-mix(in oklch, var(--border-hairline) 75%, transparent);
   font-size: 10px;
-  font-weight: 600;
+  font-weight: 700;
   letter-spacing: 0.07em;
   text-transform: uppercase;
-  color: var(--text-muted);
+  color: var(--text-primary);
   user-select: none;
 }
 
@@ -885,8 +902,9 @@
    Superconductor activity sidebar: stacked cards with title · project · model ·
    +N -N diff · relative time, the active session marked by a left accent bar. */
 .recent-activity { display: flex; flex-direction: column; gap: 6px; padding: 0 2px; }
-.recent-activity__head { display: flex; align-items: center; justify-content: space-between; gap: 8px; width: 100%; padding: 2px 6px; border: 0; background: transparent; cursor: pointer; color: var(--text-muted); }
-.recent-activity__label { font-size: 10px; font-weight: 650; letter-spacing: 0.08em; text-transform: uppercase; }
+.recent-activity__head { display: flex; align-items: center; justify-content: space-between; gap: 8px; width: 100%; padding: 4px 8px; border: 0; border-radius: 6px; background: color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%);
+  border: 1px solid color-mix(in oklch, var(--border-hairline) 75%, transparent); cursor: pointer; color: var(--text-primary); }
+.recent-activity__label { font-size: 10px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
 .recent-activity__chevron { transition: transform 140ms ease; }
 .recent-activity__chevron--collapsed { transform: rotate(-90deg); }
 .recent-activity__list { display: flex; flex-direction: column; gap: 6px; margin: 0; padding: 0; list-style: none; }


### PR DESCRIPTION
Completes the header-consistency pass (#803 / #805 / #806 / #813 / #816 / #819 / #824 / #825 / #832 / #835) on the **left sidebar**, as requested after the Home check (Home's content has no group headers — its only header-like elements are these shared sidebar labels).

The eyebrow section labels — **WORK / KNOWLEDGE / TOOLS**, the familiars + recents section labels, and the **Recent Activity** header — were quiet muted text with no fill, out of step with the group headers on every content surface.

Now aligned: the same mode-aware band `color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%)` (darker than the page in light mode, lighter in dark), a bold `--text-primary` label, rounded with a small side inset. Added a hairline border so each reads as a header even over the sidebar's top gradient. Applied to **every** eyebrow label in the sidebar so they stay consistent with each other (banding one alone would have looked broken).

### Verification
Driven live via Playwright (full-page screenshots), both modes — WORK / KNOWLEDGE / TOOLS render as clear darker bands in light mode and lighter bands in dark, all consistent.

> Note: an earlier element-clipped screenshot made the first label (WORK) look missing — that was a test-harness artifact (expanding the Recent Activity panel scrolled the nav and clipped the top label). A clean full-page capture confirms all labels band correctly in normal use.

`pnpm test:app` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)