### PR TITLE
feat(code): unified Code workspace (chat + files + terminal)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -117,6 +117,7 @@ export const SUITES = {
     "src/components/library-link-viewer.test.ts",
     "src/components/comux-view-terminal.test.ts",
     "src/components/comux-view-edit.test.ts",
+    "src/components/code-view.test.ts",
     "src/components/bottom-terminal-sr-mirror.test.ts",
     "src/components/terminal-key-bar.test.ts",
     "src/components/voice-call-button.test.ts",

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -439,8 +439,8 @@ assert.match(
 );
 assert.equal(
   (workspaceSource.match(/onSlashFromChat=\{handleSlashIntent\}/g) ?? []).length,
-  2,
-  "Both onSlashFromChat sites must report unhandled slash commands honestly (no unconditional return-true wrappers)",
+  3,
+  "All onSlashFromChat sites (chat mode, code workspace, …) must report unhandled slash commands honestly (no unconditional return-true wrappers)",
 );
 
 // — CHAT-D1-02: paste-to-attach (clipboard files route through attachFiles) —

--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -1,0 +1,59 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Unified Code workspace (mode "code"): a familiar chat beside the comux coding
+// surface (tree + editable preview + terminal + search) in one resizable split.
+
+const codeView = await readFile(new URL("./code-view.tsx", import.meta.url), "utf8");
+const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
+const sidebar = await readFile(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const comux = await readFile(new URL("./comux-view.tsx", import.meta.url), "utf8");
+const modeType = await readFile(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
+
+// ── CodeView is a two-pane resizable shell, chat | comux ─────────────────────
+assert.match(codeView, /orientation="horizontal"/, "CodeView lays the panes out horizontally");
+assert.match(codeView, /id="code-chat"[\s\S]*?\{chat\}/, "the left pane renders the chat slot");
+assert.match(codeView, /id="code-comux"[\s\S]*?\{comux\}/, "the right pane renders the comux slot");
+// Its own persisted layout key, independent of chat/shell.
+assert.match(codeView, /CODE_GROUP_ID = "cave\.code\.widths\.v1"/, "CodeView persists under its own storage key");
+// Mobile collapses to chat-only (a horizontal split is unusable on a phone).
+assert.match(
+  codeView,
+  /isMobile \? \["code-chat"\] : \["code-chat", "code-comux"\]/,
+  "on mobile only the chat pane mounts (panelIds reflect it)",
+);
+
+// ── ComuxView accepts a storage namespace so Code-mode terminals are isolated ─
+assert.match(comux, /storageNamespace\?: string/, "ComuxView accepts a storageNamespace prop");
+assert.match(
+  comux,
+  /const layoutKey = STORAGE_LAYOUT \+ storageNamespace;[\s\S]*?const sessionsKey = STORAGE_SESSIONS \+ storageNamespace;/,
+  "ComuxView namespaces its persisted layout/session keys",
+);
+// The cave:terminal-open listener is active-gated so two mounted instances
+// don't both spawn a session.
+assert.match(comux, /if \(view !== "terminal" \|\| !active\) return;/, "terminal-open handler is gated on active");
+
+// ── workspace wires the "code" mode ──────────────────────────────────────────
+assert.match(modeType, /\|\s*"code"/, "WorkspaceMode includes 'code'");
+assert.match(workspace, /code: "Code",/, "mode title registered");
+assert.match(
+  workspace,
+  /mode === "code" \? \([\s\S]*?<CodeView[\s\S]*?storageNamespace=":code"/,
+  "mode 'code' renders CodeView with a namespaced ComuxView",
+);
+assert.match(
+  workspace,
+  /e\.key === "0"\) \{[\s\S]*?setMode\("code"\)/,
+  "Cmd/Ctrl+0 switches to the Code workspace",
+);
+
+// ── sidebar exposes a Code entry (⌘0) ────────────────────────────────────────
+assert.match(
+  sidebar,
+  /id: "code", label: "Code"[\s\S]*?kbd: "⌘0"/,
+  "sidebar has a Code nav entry bound to ⌘0",
+);
+
+console.log("code-view.test.ts: ok");

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
+import { SeparatorHandle } from "@/components/ui/separator-handle";
+import { useIsMobile } from "@/lib/use-viewport";
+
+const CODE_GROUP_ID = "cave.code.widths.v1";
+
+const codeStorage = {
+  getItem(key: string): string | null {
+    if (typeof window === "undefined") return null;
+    try {
+      return window.localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  },
+  setItem(key: string, value: string): void {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(key, value);
+    } catch {
+      /* ignore — strict privacy mode or storage quota */
+    }
+  },
+};
+
+type Props = {
+  /** Familiar conversation pane (left). */
+  chat: ReactNode;
+  /** Code pane (right): the comux surface — file tree + editable preview +
+   *  terminal + project search. */
+  comux: ReactNode;
+};
+
+/**
+ * Unified Code workspace (mode "code"): a familiar chat on the left beside the
+ * full comux coding surface on the right, in one resizable two-pane split. A
+ * thin layout shell — both panes are existing components (ChatSurface,
+ * ComuxView) composed here, not rewritten. The split width persists under its
+ * own storage key, independent of the chat surface's and shell's layouts.
+ */
+export function CodeView({ chat, comux }: Props) {
+  const isMobile = useIsMobile();
+  // On mobile a side-by-side split is unusable, so the comux pane drops out and
+  // the chat fills the surface. panelIds tracks the mounted panels so the
+  // two-pane and chat-only layouts persist independently (no clobbering).
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+    id: CODE_GROUP_ID,
+    panelIds: isMobile ? ["code-chat"] : ["code-chat", "code-comux"],
+    storage: codeStorage,
+  });
+
+  return (
+    <Group
+      className="flex min-h-0 min-w-0 flex-1"
+      orientation="horizontal"
+      defaultLayout={defaultLayout}
+      onLayoutChanged={onLayoutChanged}
+    >
+      <Panel id="code-chat" className="flex min-h-0 min-w-0" defaultSize="38%" minSize="28%" maxSize={isMobile ? undefined : "60%"}>
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">{chat}</div>
+      </Panel>
+      {!isMobile && (
+        <>
+          <Separator className="shell-separator hidden lg:flex">
+            <SeparatorHandle orientation="col" />
+          </Separator>
+          <Panel id="code-comux" className="hidden min-h-0 min-w-0 lg:flex" minSize="35%">
+            <div className="flex min-h-0 min-w-0 flex-1 flex-col">{comux}</div>
+          </Panel>
+        </>
+      )}
+    </Group>
+  );
+}

--- a/src/components/comux-view-terminal.test.ts
+++ b/src/components/comux-view-terminal.test.ts
@@ -81,8 +81,8 @@ assert.match(
 );
 assert.match(
   source,
-  /if \(view !== "terminal"\) return;[\s\S]{0,260}?addEventListener\("cave:terminal-open"/,
-  "only the canonical terminal instance handles cave:terminal-open (single session, no duplicates)",
+  /if \(view !== "terminal" \|\| !active\) return;[\s\S]{0,360}?addEventListener\("cave:terminal-open"/,
+  "only the ACTIVE terminal instance handles cave:terminal-open — when several ComuxViews are mounted (e.g. Terminal surface + Code workspace) just one spawns a session",
 );
 
 // ⌘N / ⌘W keydown handler is wired and respects modifier + contentEditable gate.

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -43,6 +43,10 @@ type Props = {
   onOpenSession: (sessionId: string, familiarId?: string | null) => void;
   onNewChat: (projectRoot: string) => void;
   active?: boolean;
+  /** Suffix that isolates this instance's persisted terminal layout/sessions
+   *  from other ComuxView instances (e.g. the Code workspace keeps its own
+   *  terminals separate from the standalone Terminal surface). */
+  storageNamespace?: string;
 };
 
 type ProjectFilePreview =
@@ -94,10 +98,10 @@ function TerminalDropZone({
   );
 }
 
-function readLegacySessions(): TerminalSession[] {
+function readLegacySessions(storageKey: string): TerminalSession[] {
   if (typeof window === "undefined") return [];
   try {
-    const raw = window.localStorage.getItem(STORAGE_SESSIONS);
+    const raw = window.localStorage.getItem(storageKey);
     if (!raw) return [];
     const parsed = JSON.parse(raw) as unknown;
     if (!Array.isArray(parsed)) return [];
@@ -132,10 +136,10 @@ function isLayoutNode(value: unknown): value is TerminalLayoutNode {
   });
 }
 
-function readTerminalLayout(): TerminalLayoutState {
+function readTerminalLayout(layoutKey: string, sessionsKey: string): TerminalLayoutState {
   if (typeof window === "undefined") return createTerminalLayout();
   try {
-    const raw = window.localStorage.getItem(STORAGE_LAYOUT);
+    const raw = window.localStorage.getItem(layoutKey);
     if (raw) {
       const parsed = JSON.parse(raw) as Partial<TerminalLayoutState>;
       if (
@@ -171,7 +175,7 @@ function readTerminalLayout(): TerminalLayoutState {
   } catch {
     // Fall back to the legacy flat session list below.
   }
-  const legacy = readLegacySessions();
+  const legacy = readLegacySessions(sessionsKey);
   return createTerminalLayout(legacy, legacy[0]?.id ?? null);
 }
 
@@ -246,11 +250,13 @@ function shortProjectTime(iso: string | null): string {
   }
 }
 
-export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNewChat, active = true }: Props) {
+export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNewChat, active = true, storageNamespace = "" }: Props) {
+  const layoutKey = STORAGE_LAYOUT + storageNamespace;
+  const sessionsKey = STORAGE_SESSIONS + storageNamespace;
   const [terminalLayout, dispatchTerminalLayout] = useReducer(
     terminalLayoutReducer,
     undefined,
-    readTerminalLayout,
+    () => readTerminalLayout(layoutKey, sessionsKey),
   );
   const sessions = terminalLayout.sessions;
   const activeSessionId = terminalLayout.activeSessionId;
@@ -309,9 +315,9 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   // Persist the full pane tree. Keep the legacy flat key in sync so older
   // versions can still recover terminal tabs if a user rolls back.
   useEffect(() => {
-    window.localStorage.setItem(STORAGE_LAYOUT, JSON.stringify(terminalLayout));
-    window.localStorage.setItem(STORAGE_SESSIONS, JSON.stringify(sessions));
-  }, [terminalLayout, sessions]);
+    window.localStorage.setItem(layoutKey, JSON.stringify(terminalLayout));
+    window.localStorage.setItem(sessionsKey, JSON.stringify(sessions));
+  }, [terminalLayout, sessions, layoutKey, sessionsKey]);
 
   const projects = useMemo(
     () => deriveComuxProjects(daemonSessions, daemonProjectRoot),
@@ -361,14 +367,17 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   // project root. Only the canonical terminal instance handles it so a single
   // session is created, and it spawns in that project's cwd via addSession.
   useEffect(() => {
-    if (view !== "terminal") return;
+    // Gate on `active` so that when several ComuxView instances are mounted
+    // (e.g. the hidden Terminal surface plus the visible Code workspace), only
+    // the active one opens a session — otherwise a single event spawns two.
+    if (view !== "terminal" || !active) return;
     const onTerminalOpen = (event: Event) => {
       const detail = (event as CustomEvent<{ projectRoot?: string }>).detail;
       addSession(detail?.projectRoot);
     };
     window.addEventListener("cave:terminal-open", onTerminalOpen as EventListener);
     return () => window.removeEventListener("cave:terminal-open", onTerminalOpen as EventListener);
-  }, [view, addSession]);
+  }, [view, active, addSession]);
 
   useEffect(() => {
     const activeTerminal = view === "terminal" && active;

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -29,6 +29,7 @@ export type FolderMode =
   | "calendar"
   | "inbox"
   | "terminal"
+  | "code"
   | "browser"
   | "github"
   | "roles"
@@ -87,6 +88,7 @@ const FOLDER_MODES: Array<{
   // Tools
   { id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘7", description: "Built-in web browser" },
   { id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools", kbd: "⌘8", description: "Shell session in your project" },
+  { id: "code", label: "Code", iconName: "ph:code", group: "tools", kbd: "⌘0", description: "Chat with a familiar beside your files and terminal" },
   { id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools", description: "Reusable agent personas you can attach to a familiar" },
   { id: "workflows", label: "Workflows", iconName: "ph:git-branch-bold", group: "tools", description: "Multi-step pipelines that orchestrate familiars" },
   { id: "capabilities", label: "Capabilities", iconName: "ph:lightning-bold", group: "tools", description: "Skills and tools your familiars can use" },

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -35,6 +35,7 @@ import { ChooserModal, type ChooserOption } from "@/components/ui/chooser-modal"
 import { FamiliarPanel } from "@/components/familiar-panel";
 import { BrowserPane, type BrowserPaneHandle } from "@/components/browser-pane";
 import { ComuxView } from "@/components/comux-view";
+import { CodeView } from "@/components/code-view";
 import { GitHubView } from "@/components/github-view";
 import { LibraryView } from "@/components/library-view";
 import { CapabilitiesViewSurface } from "@/components/capabilities-view";
@@ -78,6 +79,7 @@ const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = {
   library: "Library",
   browser: "Browser",
   terminal: "Terminal",
+  code: "Code",
   github: "GitHub",
   roles: "Roles",
   workflows: "Workflows",
@@ -848,6 +850,13 @@ export function Workspace() {
         return;
       }
 
+      // ⌘0 -> Code workspace (chat beside files + terminal)
+      if (meta && !alt && e.key === "0") {
+        e.preventDefault();
+        setMode("code");
+        return;
+      }
+
       // ⌥1..⌥9 → Nth familiar
       if (alt && !meta && /^[1-9]$/.test(e.key)) {
         const idx = parseInt(e.key, 10) - 1;
@@ -1387,6 +1396,52 @@ export function Workspace() {
         onOpenTask={(cardId) => onPaletteIntent({ kind: "focus-card", cardId })}
         onOpenUrl={openUrlInCompanionBrowser}
       />
+    ) : mode === "code" ? (
+      <CodeView
+        chat={
+          <ChatSurface
+            familiars={familiars}
+            sessions={sessions}
+            activeFamiliar={active}
+            activeFamiliarId={activeId}
+            daemonRunning={daemonRunning}
+            routerRef={routerRef}
+            sessionsLoaded={sessionsLoaded}
+            inboxItems={inboxItemsWithEphemeral}
+            inspectorOpen={inspectorOpen}
+            rightPanel={rightPanel}
+            pendingProjectRoot={pendingProjectChatRoot}
+            pendingChatAction={pendingChatAction}
+            onSetInspectorOpen={setInspectorOpen}
+            onSetRightPanel={setRightPanel}
+            onSetActiveFamiliar={setActiveId}
+            onClearPendingProjectRoot={() => setPendingProjectChatRoot(null)}
+            onPendingChatActionHandled={() => setPendingChatAction(null)}
+            onSessionStarted={loadSessions}
+            onSlashFromChat={handleSlashIntent}
+            onOpenOnboarding={openOnboarding}
+            onOpenInbox={() => setMode("inbox")}
+            onCreateReminder={openReminderForFamiliar}
+            onOpenInboxItem={openInspectorInboxItem}
+            onInboxItemChanged={refreshInbox}
+            onSessionsChanged={loadSessions}
+            onOpenTask={(cardId) => onPaletteIntent({ kind: "focus-card", cardId })}
+            onOpenUrl={openUrlInCompanionBrowser}
+          />
+        }
+        comux={
+          <ComuxView
+            view="terminal"
+            active={mode === "code"}
+            storageNamespace=":code"
+            sessions={sessions}
+            onOpenSession={(sessionId, familiarId) => {
+              openFamiliarSession(sessionId, familiarId);
+            }}
+            onNewChat={openProjectChat}
+          />
+        }
+      />
     ) : mode === "library" ? (
       <LibraryView
         onOpenUrl={(url) => {
@@ -1506,6 +1561,7 @@ export function Workspace() {
   const salemRetreating =
     familiarPanelOpen ||
     mode === "chat" ||
+    mode === "code" ||
     mode === "workflows" ||
     mode === "browser" ||
     mode === "terminal";

--- a/src/lib/workspace-mode.ts
+++ b/src/lib/workspace-mode.ts
@@ -8,6 +8,7 @@ export type WorkspaceMode =
   | "library"
   | "browser"
   | "terminal"
+  | "code"
   | "github"
   | "roles"
   | "workflows"


### PR DESCRIPTION
## What

Caps the coding-experience arc (after #932 search, #934 jump-to-line, #937 editable preview) with a top-level **Code workspace** (⌘0): a familiar conversation beside the full coding surface in one resizable two-pane split — **chat left, the comux pane (file tree + editable preview + terminal + project search) right**.

This composes the previously separate surfaces into a single IDE-like workspace, the Codex/Cursor-style "talk to the agent while you watch the files and terminal" layout, chosen via the 2-pane option.

## How (lowest-footprint composition — no rewrites)

- **`CodeView`** (`code-view.tsx`): a thin layout shell that composes the **existing** `ChatSurface` and `ComuxView`. Own persisted split key (`cave.code.widths.v1`); collapses to chat-only on mobile (a horizontal split is unusable on a phone).
- **`ComuxView` gains `storageNamespace`** so the Code workspace keeps its own terminal layout/sessions separate from the standalone Terminal surface; its `cave:terminal-open` handler is now **`active`-gated** so two mounted instances don't both spawn a session.
- Wired the `"code"` `WorkspaceMode`: title, a render branch (reusing the chat prop bundle + a `":code"`-namespaced `ComuxView`), the ⌘0 shortcut, a sidebar nav entry, and Salem-perch retreat on this dense surface.

Respects the terminal-survival constraint (#925): the mounted `ComuxView`'s wrapper structure is never reshaped.

## Verification

- New `code-view.test.ts` (shell + full wiring); updated `comux-view-terminal` (active-gated handler) and `chat-view-polish` (third honest `onSlashFromChat` site).
- `pnpm typecheck`, `check:tests-wired` (366 files), full **app + api suites (350 files)**, and **`next build`** all green locally.

## Follow-ups
Keeping Code-mode terminals alive across mode switches (today they re-init on re-entry — desktop is daemon-lossless); a mobile layout beyond chat-only; surfacing the inspector/Changes within the Code surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)