### PR TITLE
feat(code): Files / Changes toggle in the comux pane

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -117,6 +117,7 @@ export const SUITES = {
     "src/components/library-link-viewer.test.ts",
     "src/components/comux-view-terminal.test.ts",
     "src/components/comux-view-edit.test.ts",
+    "src/components/comux-view-changes.test.ts",
     "src/components/code-view.test.ts",
     "src/components/bottom-terminal-sr-mirror.test.ts",
     "src/components/terminal-key-bar.test.ts",

--- a/src/components/comux-view-changes.test.ts
+++ b/src/components/comux-view-changes.test.ts
@@ -1,0 +1,44 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Files / Changes toggle in the comux pane: review the selected project's
+// working-tree diffs (revert + checkpoints) without leaving the coding surface.
+
+const comux = await readFile(new URL("./comux-view.tsx", import.meta.url), "utf8");
+const changes = await readFile(new URL("./session-changes-panel.tsx", import.meta.url), "utf8");
+
+// The reusable inner panel is exported for embedding.
+assert.match(
+  changes,
+  /export function SessionChangesInner\(\{ projectRoot, running \}/,
+  "SessionChangesInner must be exported so other surfaces can embed the diff review",
+);
+
+// comux imports it and renders it for the SELECTED project (not the active
+// chat session), keyed by root so state resets when the project changes.
+assert.match(comux, /import \{ SessionChangesInner \} from "@\/components\/session-changes-panel"/, "comux imports SessionChangesInner");
+assert.match(
+  comux,
+  /<SessionChangesInner[\s\S]*?key=\{selectedProject\.root\}[\s\S]*?projectRoot=\{selectedProject\.root\}[\s\S]*?running=\{projectHasRunningSession\}/,
+  "comux renders SessionChangesInner for the selected project, polling while a session runs",
+);
+
+// A right-pane view toggle drives it.
+assert.match(comux, /useState<"files" \| "changes">\("files"\)/, "right pane defaults to the Files view");
+assert.match(comux, /onClick=\{\(\) => setRightView\("changes"\)\}/, "a Changes toggle switches the right pane");
+assert.match(comux, /onClick=\{\(\) => setRightView\("files"\)\}/, "a Files toggle switches back");
+assert.match(
+  comux,
+  /rightView === "changes" \? \([\s\S]*?<SessionChangesInner/,
+  "the Changes view replaces the file preview when selected",
+);
+
+// Polling flag is derived from a running session in the selected project.
+assert.match(
+  comux,
+  /projectHasRunningSession = recentProjectSessions\.some\(\(s\) => s\.status === "running"\)/,
+  "live diff polling keys off a running session in the selected project",
+);
+
+console.log("comux-view-changes.test.ts: ok");

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -7,6 +7,7 @@ import { Icon } from "@/lib/icon";
 import { copyText } from "@/lib/clipboard";
 import { ProjectTree, type ProjectTreeHandle } from "@/components/project-tree";
 import { MarkdownBlock, SyntaxBlock } from "@/components/message-bubble";
+import { SessionChangesInner } from "@/components/session-changes-panel";
 import { resolveLangLabel } from "@/lib/code-lang";
 import type { SearchResult } from "@/lib/project-search";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
@@ -281,6 +282,8 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [sessionsCollapsed, setSessionsCollapsed] = useState(false);
+  // Right pane view: the file preview, or the project's git changes/diff review.
+  const [rightView, setRightView] = useState<"files" | "changes">("files");
   // Project-wide code search (CODE-SEARCH-01).
   const [searchInput, setSearchInput] = useState("");
   const [searchRegex, setSearchRegex] = useState(false);
@@ -660,6 +663,9 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
       .slice(0, 6);
   }, [daemonSessions, selectedProject]);
 
+  // Poll the diff while a familiar is actively working this project so the
+  // Changes view reflects edits as they land.
+  const projectHasRunningSession = recentProjectSessions.some((s) => s.status === "running");
   const previewIsMarkdown = preview?.kind === "text" && isMarkdownPath(previewPath);
   const previewLineCount = preview?.kind === "text" ? preview.content.split("\n").length : 0;
   const renderAsMarkdown = previewIsMarkdown && !previewRaw;
@@ -1177,7 +1183,37 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                 </div>
 
                 <div className="min-w-0 min-h-0 flex flex-1 flex-col overflow-hidden">
-                  {previewPath ? (
+                  {/* Files / Changes toggle — review the familiar's working-tree
+                      diffs (revert + checkpoints) without leaving the surface. */}
+                  <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-hairline)] px-2 py-1.5">
+                    <div className="flex items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 p-0.5 text-[10px]">
+                      <button
+                        type="button"
+                        onClick={() => setRightView("files")}
+                        className={`flex items-center gap-1 rounded-[4px] px-2 py-0.5 transition-colors ${rightView === "files" ? "bg-[var(--bg-raised)] text-[var(--text-primary)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"}`}
+                      >
+                        <Icon name="ph:file-code" width={11} />
+                        Files
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setRightView("changes")}
+                        className={`flex items-center gap-1 rounded-[4px] px-2 py-0.5 transition-colors ${rightView === "changes" ? "bg-[var(--bg-raised)] text-[var(--text-primary)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"}`}
+                      >
+                        <Icon name="ph:git-diff" width={11} />
+                        Changes
+                      </button>
+                    </div>
+                  </div>
+                  {rightView === "changes" ? (
+                    <div className="min-h-0 flex-1 overflow-hidden">
+                      <SessionChangesInner
+                        key={selectedProject.root}
+                        projectRoot={selectedProject.root}
+                        running={projectHasRunningSession}
+                      />
+                    </div>
+                  ) : previewPath ? (
                     <>
                       {/* Preview header */}
                       <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-hairline)] px-3 py-2">

--- a/src/components/session-changes-panel.tsx
+++ b/src/components/session-changes-panel.tsx
@@ -332,7 +332,7 @@ function CheckpointSection({
 
 // ── Panel body (mounted per project root) ─────────────────────────────────────
 
-function SessionChangesInner({ projectRoot, running }: { projectRoot: string; running: boolean }) {
+export function SessionChangesInner({ projectRoot, running }: { projectRoot: string; running: boolean }) {
   const [files, setFiles] = useState<ChangedFile[]>([]);
   const [repoRoot, setRepoRoot] = useState<string | null>(null);
   const [notARepo, setNotARepo] = useState(false);


### PR DESCRIPTION
## What

Continues the coding-experience roadmap. Surfaces the git **Changes review** (diff + per-file revert + checkpoints) right inside the comux coding surface via a **Files / Changes** toggle — so the *familiar edits → review → revert* loop lives beside the files and terminal, not just in a cramped chat sidebar. Available in both the **Code workspace** (#939) and the standalone **Terminal** surface.

## How

- Exported `SessionChangesInner` so the diff panel can be embedded with an **explicit project root**. The outer `SessionChangesPanel` (which derives its root from the active chat session) is unchanged.
- The comux right pane gains a Files / Changes segmented toggle. **Changes** renders `SessionChangesInner` for the **selected** project (keyed by root so state resets per project), with `running` derived from whether a session is active in that project — so diffs refresh live while the familiar works.

No new dependency; reuses the existing `/api/changes` panel wholesale.

## Verification

- New `comux-view-changes.test.ts` (export + wiring + toggle + live-poll flag).
- `pnpm typecheck`, `check:tests-wired` (367), full **app + api suites (351)**, and **`next build`** all green locally.

## Follow-ups
Optionally scope the Changes view to the active chat session's root when it differs from the browsed project; a count badge on the Changes toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)