### PR TITLE
feat(code): click a tool's file in chat to open it in the Code workspace

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -110,6 +110,7 @@ export const SUITES = {
     "src/lib/comux-projects.test.ts",
     "src/lib/code-lang.test.ts",
     "src/lib/project-search.test.ts",
+    "src/lib/tool-target-file.test.ts",
     "src/lib/terminal-layout.test.ts",
     "src/components/library-polish.test.ts",
     "src/components/eval-loop-panel.test.ts",

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, Fragment, useCallback, useEffect, useId, useImperativeHandle, useMemo, useRef, useState } from "react";
+import { forwardRef, Fragment, useCallback, useEffect, useId, useImperativeHandle, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { RichText } from "@/components/rich-text";
 import { MessageBubble, SyntaxBlock, type MessageBubbleSegment } from "@/components/message-bubble";
@@ -54,7 +54,7 @@ import {
 import type { CaveProject } from "@/lib/cave-projects";
 import { useProjects } from "@/lib/use-projects";
 import { toolArgSummary } from "@/lib/tool-arg-summary";
-import { toolInputAsDiff } from "@/lib/tool-input-diff";
+import { toolInputAsDiff, toolTargetFile } from "@/lib/tool-input-diff";
 import { findMatchingTurnIds } from "@/lib/transcript-find";
 import { isSyntheticLocalModel, type ChatModelState } from "@/lib/chat-model-state";
 
@@ -3917,13 +3917,35 @@ function ToolBlock({ tool }: { tool: ToolEvent }) {
   // structured before/after diff instead of the raw JSON payload; null for
   // every other tool (or unparseable input) falls back to the plain block.
   const inputDiff = toolInputAsDiff(tool.name, tool.input);
+  // Click-to-open: a file tool's target opens in the Code workspace preview.
+  // Dispatched as an event; the comux pane (Code/Terminal) handles it, and the
+  // workspace switches to Code mode first when neither is showing.
+  const targetFile = toolTargetFile(tool.name, tool.input);
+  const openTargetFile = (e: ReactMouseEvent) => {
+    if (!targetFile) return;
+    e.preventDefault();
+    e.stopPropagation();
+    window.dispatchEvent(new CustomEvent("cave:open-project-file", { detail: { path: targetFile } }));
+  };
   return (
     <details className="cave-tool-block" data-default-collapsed="true">
       <summary className="flex min-w-0 cursor-pointer select-none flex-wrap items-center gap-2 text-[11px]">
         <Icon name="ph:terminal-window" width={12} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
         <span className="min-w-0 truncate font-mono text-[var(--text-secondary)]">{tool.name}</span>
         {argSummary ? (
-          <span className="min-w-0 max-w-[18rem] truncate font-mono text-[var(--text-muted)]">· {argSummary}</span>
+          targetFile ? (
+            <button
+              type="button"
+              onClick={openTargetFile}
+              title={`Open ${targetFile} in the Code workspace`}
+              className="group/openfile inline-flex min-w-0 max-w-[18rem] items-center gap-1 truncate font-mono text-[var(--text-muted)] hover:text-[var(--accent-presence,var(--text-secondary))] hover:underline"
+            >
+              <span className="truncate">· {argSummary}</span>
+              <Icon name="ph:arrow-square-out" width={10} className="shrink-0 opacity-0 transition-opacity group-hover/openfile:opacity-100" aria-hidden />
+            </button>
+          ) : (
+            <span className="min-w-0 max-w-[18rem] truncate font-mono text-[var(--text-muted)]">· {argSummary}</span>
+          )
         ) : null}
         <span className={[
           "rounded px-1.5 py-0.5 font-mono text-[10px]",

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -540,6 +540,21 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
     }
   }, []);
 
+  // Click-to-open from chat: a file tool's target (or any surface) dispatches
+  // `cave:open-project-file` with an absolute path; the active comux opens it
+  // in the Files preview. Gated on `active` so only the visible instance reacts.
+  useEffect(() => {
+    if (!active) return;
+    const onOpenFile = (event: Event) => {
+      const detail = (event as CustomEvent<{ path?: string; line?: number }>).detail;
+      if (!detail?.path) return;
+      setRightView("files");
+      void openFilePreview(detail.path, typeof detail.line === "number" ? detail.line : undefined);
+    };
+    window.addEventListener("cave:open-project-file", onOpenFile as EventListener);
+    return () => window.removeEventListener("cave:open-project-file", onOpenFile as EventListener);
+  }, [active, openFilePreview]);
+
   const copyPreview = useCallback(() => {
     if (!preview || preview.kind !== "text") return;
     void copyText(preview.content).then(() => {

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -316,6 +316,24 @@ export function Workspace() {
     return () => window.removeEventListener("cave:navigate-mode", onNavigate as EventListener);
   }, []);
 
+  // Click-to-open a file from chat: the comux pane (Code/Terminal) handles
+  // `cave:open-project-file` directly when it's showing. When neither is, switch
+  // to the Code workspace and re-emit so the freshly-mounted comux catches it.
+  useEffect(() => {
+    const onOpenFile = (e: Event) => {
+      const m = modeRef.current;
+      if (m === "code" || m === "terminal") return;
+      const detail = (e as CustomEvent).detail;
+      setMode("code");
+      window.setTimeout(
+        () => window.dispatchEvent(new CustomEvent("cave:open-project-file", { detail })),
+        0,
+      );
+    };
+    window.addEventListener("cave:open-project-file", onOpenFile as EventListener);
+    return () => window.removeEventListener("cave:open-project-file", onOpenFile as EventListener);
+  }, []);
+
   useEffect(() => {
     if (railTab !== "salem") {
       window.dispatchEvent(new CustomEvent("cave:salem-undock"));

--- a/src/lib/tool-input-diff.ts
+++ b/src/lib/tool-input-diff.ts
@@ -108,3 +108,30 @@ export function toolInputAsDiff(name: string, input?: string | null): string | n
 
   return null;
 }
+
+/** Tool names that operate on a single addressable file we can open in the
+ *  editor preview (mutations plus the read tool). */
+const FILE_TOOLS = new Set([...MUTATION_TOOLS, "read"]);
+
+/**
+ * Best-effort absolute file path a tool call targets, for click-to-open in the
+ * Code workspace. Returns null for non-file tools, unparseable input, or when
+ * no concrete path is present (so the caller renders a plain, non-clickable
+ * label rather than a dead link).
+ */
+export function toolTargetFile(name: string, input?: string | null): string | null {
+  if (!FILE_TOOLS.has(name.toLowerCase())) return null;
+  const raw = (input ?? "").trim();
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const path = filePathOf(parsed as Rec);
+  // filePathOf falls back to the literal "file" when no key matched; treat that
+  // sentinel (and any non-absolute path) as "no openable target".
+  return path !== "file" && path.startsWith("/") ? path : null;
+}

--- a/src/lib/tool-target-file.test.ts
+++ b/src/lib/tool-target-file.test.ts
@@ -1,0 +1,71 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const { toolTargetFile } = await import("./tool-input-diff.ts");
+
+// ── toolTargetFile: openable absolute path for file tools, else null ─────────
+{
+  // Edit / Write / MultiEdit / NotebookEdit + Read are file tools.
+  assert.equal(
+    toolTargetFile("Edit", JSON.stringify({ file_path: "/repo/src/a.ts", old_string: "x", new_string: "y" })),
+    "/repo/src/a.ts",
+  );
+  assert.equal(toolTargetFile("Write", JSON.stringify({ file_path: "/repo/b.ts", content: "z" })), "/repo/b.ts");
+  assert.equal(toolTargetFile("Read", JSON.stringify({ file_path: "/repo/c.ts" })), "/repo/c.ts");
+  assert.equal(
+    toolTargetFile("NotebookEdit", JSON.stringify({ notebook_path: "/repo/n.ipynb", new_source: "q" })),
+    "/repo/n.ipynb",
+  );
+  // Case-insensitive tool name.
+  assert.equal(toolTargetFile("edit", JSON.stringify({ path: "/repo/d.ts" })), "/repo/d.ts");
+
+  // Non-file tools → null.
+  assert.equal(toolTargetFile("Bash", JSON.stringify({ command: "ls" })), null);
+  assert.equal(toolTargetFile("Grep", JSON.stringify({ pattern: "x", path: "/repo" })), null);
+
+  // Relative paths are NOT openable (the preview needs an absolute path) → null.
+  assert.equal(toolTargetFile("Edit", JSON.stringify({ file_path: "src/rel.ts" })), null);
+  // Missing path / unparseable / empty → null.
+  assert.equal(toolTargetFile("Edit", JSON.stringify({ old_string: "x", new_string: "y" })), null);
+  assert.equal(toolTargetFile("Edit", "not json"), null);
+  assert.equal(toolTargetFile("Edit", ""), null);
+  assert.equal(toolTargetFile("Edit", null), null);
+}
+
+// ── wiring: chat dispatches, comux handles, workspace falls back ─────────────
+const chatView = await readFile(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
+const comux = await readFile(new URL("../components/comux-view.tsx", import.meta.url), "utf8");
+const workspace = await readFile(new URL("../components/workspace.tsx", import.meta.url), "utf8");
+
+assert.match(
+  chatView,
+  /toolTargetFile\(tool\.name, tool\.input\)/,
+  "ToolBlock derives the openable target file from the tool input",
+);
+assert.match(
+  chatView,
+  /dispatchEvent\(new CustomEvent\("cave:open-project-file", \{ detail: \{ path: targetFile \} \}\)\)/,
+  "clicking a tool's file dispatches cave:open-project-file",
+);
+// Click must not also toggle the <details> open/closed.
+assert.match(chatView, /openTargetFile = \(e: ReactMouseEvent\) => \{[\s\S]*?stopPropagation\(\)/, "open handler stops propagation");
+
+assert.match(
+  comux,
+  /addEventListener\("cave:open-project-file"/,
+  "comux listens for cave:open-project-file",
+);
+assert.match(
+  comux,
+  /if \(!active\) return;[\s\S]*?setRightView\("files"\);[\s\S]*?openFilePreview\(detail\.path/,
+  "the active comux opens the file in the Files preview",
+);
+
+assert.match(
+  workspace,
+  /if \(m === "code" \|\| m === "terminal"\) return;[\s\S]*?setMode\("code"\)[\s\S]*?dispatchEvent\(new CustomEvent\("cave:open-project-file"/,
+  "workspace switches to Code mode and re-emits when no comux is showing",
+);
+
+console.log("tool-target-file.test.ts: ok");


### PR DESCRIPTION
## What

Ties the chat and editor panes together — a signature Codex/Cursor behavior. When a familiar runs a file tool (Edit / Write / MultiEdit / NotebookEdit / Read), its file path in the tool chip is now **clickable** and opens that file in the comux **Files preview**. In the Code workspace (#939) the file opens in the right pane beside the chat; from plain chat mode it switches to Code mode first.

## How

- **`toolTargetFile(name, input)`** (`tool-input-diff.ts`): returns the openable **absolute** path for a file tool, else `null` (non-file tools, relative paths, or missing path render as plain text — no dead links).
- **`ToolBlock`** renders the path as a button that dispatches `cave:open-project-file` (with `stopPropagation` so it doesn't toggle the `<details>`).
- **`ComuxView`** handles the event (gated on `active`) → switches to Files and opens the path.
- **`workspace`** fallback: if neither Code nor Terminal is showing, it switches to Code mode and re-emits so the freshly-mounted comux catches it (the same setTimeout-redispatch idiom as the Projects tab).

## Verification

- `tool-target-file.test.ts` unit-tests the extractor (file tools, case-insensitivity, relative/missing/unparseable → null) and source-asserts the dispatch/handle/fallback wiring.
- `pnpm typecheck`, `check:tests-wired` (368), full **app + api (352)**, and **`next build`** all green.

## Follow-ups
Carry a line number for Read/Edit targets (open at the exact line, reusing jump-to-line); make plain `path:line` references in assistant prose clickable too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)