### PR TITLE
feat(code): theme the CodeMirror editor to the app's tokens

### DIFF
--- a/src/components/code-editor.test.ts
+++ b/src/components/code-editor.test.ts
@@ -27,6 +27,12 @@ assert.match(
 );
 assert.match(editor, /key: "Escape", run: \(\) => \{ onCancel\(\); return true; \}/, "Escape cancels from inside the editor");
 
+// Editor chrome is themed to the app's CSS tokens (not the generic dark theme).
+assert.match(editor, /const appTheme = EditorView\.theme\(/, "a CodeMirror theme is defined from app tokens");
+assert.match(editor, /backgroundColor: "var\(--bg-base\)"/, "editor background uses the app surface token");
+assert.match(editor, /caretColor: "var\(--accent-presence\)"/, "caret uses the app accent token");
+assert.match(editor, /theme=\{appTheme\}/, "the editor uses the app theme");
+
 // comux uses CodeEditor in edit mode — the plain textarea is gone.
 assert.match(comux, /import \{ CodeEditor \} from "@\/components\/code-editor"/, "comux imports CodeEditor");
 assert.match(

--- a/src/components/code-editor.tsx
+++ b/src/components/code-editor.tsx
@@ -4,6 +4,42 @@ import { useMemo } from "react";
 import CodeMirror, { EditorView, keymap, type Extension } from "@uiw/react-codemirror";
 import { loadLanguage, type LanguageName } from "@uiw/codemirror-extensions-langs";
 
+// Editor chrome themed to the app's tokens so it reads as part of the Cave
+// rather than a generic dark box. Only the frame is themed here (background,
+// gutter, cursor, selection, active line); the default dark syntax palette
+// still colors the code. `dark: true` keeps CodeMirror's dark-mode defaults
+// for anything not overridden.
+const appTheme = EditorView.theme(
+  {
+    "&": {
+      backgroundColor: "var(--bg-base)",
+      color: "var(--text-primary)",
+      height: "100%",
+      fontSize: "12px",
+    },
+    ".cm-content": {
+      fontFamily: 'ui-monospace, "SF Mono", Menlo, Consolas, monospace',
+      caretColor: "var(--accent-presence)",
+    },
+    ".cm-gutters": {
+      backgroundColor: "var(--bg-base)",
+      color: "var(--text-muted)",
+      border: "none",
+    },
+    ".cm-activeLine": { backgroundColor: "color-mix(in oklch, var(--foreground) 4%, transparent)" },
+    ".cm-activeLineGutter": {
+      backgroundColor: "color-mix(in oklch, var(--foreground) 4%, transparent)",
+      color: "var(--text-secondary)",
+    },
+    "&.cm-focused .cm-cursor": { borderLeftColor: "var(--accent-presence)" },
+    "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": {
+      backgroundColor: "color-mix(in oklch, var(--accent-presence) 28%, transparent)",
+    },
+    ".cm-scroller": { fontFamily: 'ui-monospace, "SF Mono", Menlo, Consolas, monospace' },
+  },
+  { dark: true },
+);
+
 // File extension → CodeMirror language. Mirrors the extensions the Projects
 // file preview already accepts; anything unmapped just edits as plain text.
 const EXT_TO_LANG: Record<string, LanguageName> = {
@@ -87,7 +123,7 @@ export function CodeEditor({ value, filename, onChange, onSave, onCancel }: Prop
     <CodeMirror
       value={value}
       onChange={onChange}
-      theme="dark"
+      theme={appTheme}
       height="100%"
       className="cave-code-editor h-full"
       extensions={extensions}


### PR DESCRIPTION
## What

Polish follow-up to #942. The editor used CodeMirror's generic dark theme, which clashed with the Cave palette. This themes the editor **chrome** (background, gutter, cursor, selection, active line) to the app's CSS tokens (`--bg-base`, `--text-*`, `--accent-presence`) via `EditorView.theme`, so the editor reads as part of the surface rather than a foreign box.

Default dark syntax colors still color the code — **no new dependencies**, no syntax-palette churn.

## Verification

- `code-editor.test.ts` asserts the themed tokens (`appTheme`, `--bg-base` background, `--accent-presence` caret, `theme={appTheme}`).
- `pnpm typecheck`, `check:tests-wired` (369), and `next build` all green.

## Follow-up
Match the syntax-token palette to the Shiki `mood-c-dark` theme used in read mode (needs `@codemirror/language` + `@lezer/highlight` for a `HighlightStyle`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)