### PR TITLE
fix(daemon): make "start daemon" idempotent — skip when already running

### DIFF
--- a/src/app/api/daemon/start/route.ts
+++ b/src/app/api/daemon/start/route.ts
@@ -1,11 +1,22 @@
 import { NextResponse } from "next/server";
 import { spawn } from "node:child_process";
+import { callDaemon } from "@/lib/coven-daemon";
 import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
 import { covenCliMissingError, isMissingExecutableError } from "@/lib/coven-spawn-error";
 
 export const dynamic = "force-dynamic";
 
 export async function POST() {
+  // Idempotent start: if a daemon is already serving, don't spawn `coven daemon
+  // start`. That subcommand *restarts* the daemon, which fights a supervisor
+  // (e.g. a launchd KeepAlive agent) for the socket — the supervisor relaunches
+  // its copy while the restart spawns another, churning the socket. A healthy
+  // daemon means "start" has nothing to do, so report it as already running.
+  const health = await callDaemon({ path: "/api/v1/health", timeoutMs: 1500 });
+  if (health.ok) {
+    return NextResponse.json({ ok: true, alreadyRunning: true });
+  }
+
   return new Promise<Response>((resolve) => {
     const child = spawn(covenBin(), ["daemon", "start"], {
       stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
## What

`/api/daemon/start` always spawned `coven daemon start`, which **restarts** the daemon. When a supervisor keeps the daemon alive (e.g. the launchd `KeepAlive` agent we just added), that restart fights it for the socket — the supervisor relaunches its copy while the restart spawns another, churning the socket.

Now the route probes `/api/v1/health` first; if a daemon is already serving, it returns `{ ok: true, alreadyRunning: true }` without spawning anything. "Start" becomes a no-op when the daemon is up — correct regardless of how it's supervised, and it removes the contention.

## Verify

- `daemon start route.test.ts` passes (ENOENT handling + win32 shell flag preserved).
- `api-contracts.test.ts` passes (96 route contracts; daemon/start contract unchanged — still POST/json).

Pairs with OpenCoven/coven#243 (daemon-side flock single-instance + per-connection threading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)