### PR TITLE
feat(code): clickable file references in chat prose

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -72,6 +72,7 @@ export const SUITES = {
     "src/components/mermaid-viewer.test.ts",
     "src/components/message-bubble-code-header.test.ts",
     "src/components/message-bubble-jump-to-line.test.ts",
+    "src/components/message-bubble-file-links.test.ts",
     "src/components/library-reader-polish.test.ts",
     "src/components/chat-view-polish.test.ts",
     "src/components/chat-view-lifecycle.test.ts",

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -541,20 +541,28 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
     }
   }, []);
 
-  // Click-to-open from chat: a file tool's target (or any surface) dispatches
-  // `cave:open-project-file` with an absolute path; the active comux opens it
-  // in the Files preview. Gated on `active` so only the visible instance reacts.
+  // Click-to-open from chat: a file tool's target (absolute path) or a prose
+  // reference (relative, e.g. `src/foo.ts:42`) dispatches `cave:open-project-file`;
+  // the active comux opens it in the Files preview. Relative paths resolve
+  // against the selected project root. Gated on `active` so only the visible
+  // instance reacts.
+  const selectedRoot = selectedProject?.root;
   useEffect(() => {
     if (!active) return;
     const onOpenFile = (event: Event) => {
       const detail = (event as CustomEvent<{ path?: string; line?: number }>).detail;
       if (!detail?.path) return;
+      const path = detail.path.startsWith("/")
+        ? detail.path
+        : selectedRoot
+          ? `${selectedRoot.replace(/\/$/, "")}/${detail.path.replace(/^\.?\//, "")}`
+          : detail.path;
       setRightView("files");
-      void openFilePreview(detail.path, typeof detail.line === "number" ? detail.line : undefined);
+      void openFilePreview(path, typeof detail.line === "number" ? detail.line : undefined);
     };
     window.addEventListener("cave:open-project-file", onOpenFile as EventListener);
     return () => window.removeEventListener("cave:open-project-file", onOpenFile as EventListener);
-  }, [active, openFilePreview]);
+  }, [active, openFilePreview, selectedRoot]);
 
   const copyPreview = useCallback(() => {
     if (!preview || preview.kind !== "text") return;

--- a/src/components/message-bubble-file-links.test.ts
+++ b/src/components/message-bubble-file-links.test.ts
@@ -1,0 +1,59 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const { FILE_REF_RE } = await import("../lib/file-ref.ts");
+
+// ── FILE_REF_RE: matches real file refs, ignores ordinary prose/code ─────────
+const matches = (s) => FILE_REF_RE.exec(s);
+{
+  // Relative + absolute paths, with/without :line[:col].
+  assert.ok(matches("src/foo.ts"), "relative path");
+  assert.equal(matches("lib/bar.py:42")[1], "lib/bar.py", "path captured without the :line");
+  assert.equal(matches("lib/bar.py:42")[2], "42", "line captured");
+  assert.ok(matches("a/b/c.tsx:10:5"), "path:line:col");
+  assert.ok(matches("package.json"), "bare config file");
+  assert.ok(matches("README.md"), "bare doc file");
+  assert.ok(matches("/Users/x/app/index.html"), "absolute path");
+
+  // NOT file refs — must never linkify ordinary prose / shell / numbers.
+  assert.equal(matches("npm install"), null, "command with space");
+  assert.equal(matches("e.g."), null, "abbreviation");
+  assert.equal(matches("foo()"), null, "function call");
+  assert.equal(matches("3.14"), null, "number");
+  assert.equal(matches("foo.bar"), null, "unknown extension");
+  assert.equal(matches("https://example.com"), null, "url");
+  assert.equal(matches("just some text"), null, "prose");
+}
+
+// ── wiring ───────────────────────────────────────────────────────────────────
+const bubble = await readFile(new URL("./message-bubble.tsx", import.meta.url), "utf8");
+const comux = await readFile(new URL("./comux-view.tsx", import.meta.url), "utf8");
+const css = await readFile(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
+
+// Linkify only inline code, never fenced-block lines.
+assert.match(
+  bubble,
+  /code\.closest\("pre"\) \|\| code\.closest\("\.cave-code-wrap"\)\) continue/,
+  "only inline code is linkified (fenced blocks skipped)",
+);
+assert.match(
+  bubble,
+  /dispatchEvent\(new CustomEvent\("cave:open-project-file", \{ detail: \{ path, line \} \}\)\)/,
+  "clicking a file ref opens it in the Code workspace",
+);
+// Chat prose enables linkify; the shared MarkdownBlock must NOT.
+assert.match(bubble, /useWireCopyButtons\(html, onOpenUrl, true\)/, "MarkdownContent (chat) enables linkifyPaths");
+assert.match(bubble, /const containerRef = useWireCopyButtons\(html\);/, "MarkdownBlock keeps linkify off (default)");
+
+// comux resolves relative refs against the selected project root.
+assert.match(
+  comux,
+  /detail\.path\.startsWith\("\/"\)[\s\S]*?selectedRoot[\s\S]*?\$\{detail\.path\.replace\(\/\^\\\.\?\\\/\/, ""\)\}/,
+  "relative prose paths resolve against the selected project root",
+);
+
+// Affordance styling exists.
+assert.match(css, /code\.cave-file-link \{[\s\S]*?cursor: pointer/, "file-link affordance is styled");
+
+console.log("message-bubble-file-links.test.ts: ok");

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -33,6 +33,7 @@ import { copyText } from "@/lib/clipboard";
 import { sanitizeHtml } from "@/lib/html-sanitize";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { SHIKI_LANGS, resolveShikiLang } from "@/lib/code-lang";
+import { parseFileRef } from "@/lib/file-ref";
 import { wireMermaidDiagrams } from "./mermaid-viewer";
 
 // ---------------------------------------------------------------------------
@@ -650,22 +651,55 @@ function wireMarkdownLinks(container: HTMLElement, onOpenUrl?: (url: string) => 
   }
 }
 
+// Inline file references in prose (e.g. `src/foo.ts` or `lib/bar.py:42`) become
+// clickable, opening the file in the Code workspace. Match logic lives in
+// @/lib/file-ref (pure + unit-tested); only inline code is considered.
+function wireFilePathLinks(container: HTMLElement) {
+  for (const code of Array.from(container.querySelectorAll<HTMLElement>("code"))) {
+    // Inline code only — never the highlighted lines inside a fenced block.
+    if (code.closest("pre") || code.closest(".cave-code-wrap")) continue;
+    const flagged = code as HTMLElement & { _caveFileLink?: boolean };
+    if (flagged._caveFileLink) continue;
+    const ref = parseFileRef(code.textContent ?? "");
+    if (!ref) continue;
+    flagged._caveFileLink = true;
+    const { path, line } = ref;
+    code.classList.add("cave-file-link");
+    code.setAttribute("role", "button");
+    code.setAttribute("tabindex", "0");
+    code.title = `Open ${path}${line ? `:${line}` : ""} in the Code workspace`;
+    const open = () =>
+      window.dispatchEvent(new CustomEvent("cave:open-project-file", { detail: { path, line } }));
+    code.addEventListener("click", open);
+    code.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        open();
+      }
+    });
+  }
+}
+
 /**
  * Shared post-render hook: wires `.cave-copy-btn` clicks inside the container
  * whenever the injected HTML changes. Every component that injects
  * renderCodeBlock/mdToHtml output via dangerouslySetInnerHTML must attach the
  * returned ref, otherwise its Copy buttons render but silently do nothing
  * (wireCopyButtons is idempotent per button via the `_wired` flag).
+ *
+ * `linkifyPaths` opts inline file references in prose into clickable
+ * Code-workspace links; only the chat prose path enables it.
  */
-function useWireCopyButtons(html: string | null, onOpenUrl?: (url: string) => void) {
+function useWireCopyButtons(html: string | null, onOpenUrl?: (url: string) => void, linkifyPaths = false) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
     if (html && containerRef.current) {
       wireCopyButtons(containerRef.current);
       wireMarkdownLinks(containerRef.current, onOpenUrl);
       wireMermaidDiagrams(containerRef.current);
+      if (linkifyPaths) wireFilePathLinks(containerRef.current);
     }
-  }, [html, onOpenUrl]);
+  }, [html, onOpenUrl, linkifyPaths]);
   return containerRef;
 }
 
@@ -676,7 +710,8 @@ function useWireCopyButtons(html: string | null, onOpenUrl?: (url: string) => vo
 
 function MarkdownContent({ text, pending, onOpenUrl }: { text: string; pending?: boolean; onOpenUrl?: (url: string) => void }) {
   const [html, setHtml] = useState<string | null>(null);
-  const containerRef = useWireCopyButtons(html, onOpenUrl);
+  // linkifyPaths=true: chat prose file references (`src/foo.ts:42`) open in Code.
+  const containerRef = useWireCopyButtons(html, onOpenUrl, true);
   // Out-of-order guard: mdToHtml is async and during streaming several
   // renders can be in flight at once. Every render takes a monotonically
   // increasing stamp, and a result only commits if it is newer than the

--- a/src/lib/file-ref.ts
+++ b/src/lib/file-ref.ts
@@ -1,0 +1,21 @@
+// Detecting inline file references in chat prose (e.g. `src/foo.ts` or
+// `lib/bar.py:42`) so they can be linkified to open in the Code workspace.
+// Pure + JSX-free so it's unit-testable without a DOM or the bubble renderer.
+
+/**
+ * A file path ending in a known code/config extension, with an optional
+ * `:line` or `:line:col` suffix. Anchored so it only matches when the whole
+ * (inline-code) token is a reference — prose like `npm install`, `e.g.`, or
+ * `foo()` never matches.
+ */
+export const FILE_REF_RE =
+  /^([/\w@][\w./@+-]*\.(?:ts|tsx|js|jsx|mjs|cjs|json|md|mdx|css|scss|sass|html|py|rs|go|rb|java|c|h|cpp|hpp|cc|sh|bash|zsh|yaml|yml|toml|sql|swift|kt|lua|php|xml|svg|nix|txt|lock|cfg|ini|conf))(?::(\d+))?(?::\d+)?$/;
+
+export type FileRef = { path: string; line?: number };
+
+/** Parse a trimmed token into a file reference, or null if it isn't one. */
+export function parseFileRef(text: string): FileRef | null {
+  const match = FILE_REF_RE.exec(text.trim());
+  if (!match) return null;
+  return { path: match[1], line: match[2] ? Number(match[2]) : undefined };
+}

--- a/src/lib/tool-target-file.test.ts
+++ b/src/lib/tool-target-file.test.ts
@@ -58,8 +58,8 @@ assert.match(
 );
 assert.match(
   comux,
-  /if \(!active\) return;[\s\S]*?setRightView\("files"\);[\s\S]*?openFilePreview\(detail\.path/,
-  "the active comux opens the file in the Files preview",
+  /if \(!active\) return;[\s\S]*?setRightView\("files"\);[\s\S]*?openFilePreview\(path/,
+  "the active comux opens the file in the Files preview (path resolved from the event detail)",
 );
 
 assert.match(

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -122,6 +122,22 @@
   white-space: nowrap;
 }
 
+/* Inline file references linkified by wireFilePathLinks — clickable, with an
+   underline-on-hover affordance so they read as actionable. */
+.cave-md code.cave-file-link {
+  cursor: pointer;
+  border-color: color-mix(in oklch, var(--accent-presence) 38%, transparent);
+}
+.cave-md code.cave-file-link:hover {
+  background: color-mix(in oklch, var(--accent-presence) 24%, transparent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.cave-md code.cave-file-link:focus-visible {
+  outline: 2px solid var(--accent-presence);
+  outline-offset: 1px;
+}
+
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    BLOCKQUOTE
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */


### PR DESCRIPTION
## What

Extends #941 (clickable tool-file chips) to **plain-text file references** the familiar writes in prose. Inline code like `src/foo.ts` or `lib/bar.py:42` becomes clickable and opens that file in the Code workspace — landing on the line when one is given (reusing jump-to-line).

## How

- **`@/lib/file-ref`** (pure, unit-tested): `FILE_REF_RE` + `parseFileRef`. **Tight match** — a known code/config extension with optional `:line[:col]` — so prose like `npm install`, `e.g.`, `foo()`, or `3.14` is never linkified.
- **`wireFilePathLinks`** (message-bubble) linkifies **inline code only** (never fenced-block lines), dispatching `cave:open-project-file`. Enabled via a new `linkifyPaths` flag on `useWireCopyButtons` that **only the chat prose path** (`MarkdownContent`) turns on — the shared `MarkdownBlock` (library, comux preview) is unaffected.
- comux's `cave:open-project-file` handler now resolves **relative** refs against the selected project root (tool chips send absolute paths; prose is usually relative).
- `.cave-file-link` affordance styling (cursor, hover underline, focus ring).

## Verification

- `message-bubble-file-links.test.ts` unit-tests the matcher (real refs match; commands/abbreviations/numbers/URLs don't) and asserts the wiring (inline-only, dispatch, chat-only enablement, relative-path resolution, CSS). Updated `tool-target-file.test.ts` for the resolved-path handler.
- `pnpm typecheck`, `check:tests-wired` (370), full **app + api (354)**, and **`next build`** all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)