### PR TITLE
fix(code): Code workspace shows the coding surfaces (projects view), not just a terminal

### DIFF
--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -49,6 +49,14 @@ assert.match(
   /mode === "code" \? \([\s\S]*?<CodeView[\s\S]*?storageNamespace=":code"/,
   "mode 'code' renders CodeView with a namespaced ComuxView",
 );
+// The Code workspace must mount the comux PROJECTS view (file tree + editable
+// preview + project search + Files/Changes), not the terminal-only view — that
+// is where the coding surfaces live.
+assert.match(
+  workspace,
+  /mode === "code" \? \([\s\S]*?<ComuxView\s+view="projects"[\s\S]*?storageNamespace=":code"/,
+  "the Code workspace comux uses the projects view (coding surfaces), not terminal-only",
+);
 assert.match(
   workspace,
   /e\.key === "0"\) \{[\s\S]*?setMode\("code"\)/,

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1451,7 +1451,7 @@ export function Workspace() {
         }
         comux={
           <ComuxView
-            view="terminal"
+            view="projects"
             active={mode === "code"}
             storageNamespace=":code"
             sessions={sessions}


### PR DESCRIPTION
## What

**Found by live verification** of the Code workspace (⌘0). It mounted the comux **`terminal`** view, which renders only the terminal + session list — so the **file tree, editable preview, project search, and Files/Changes toggle** (all in the comux **`projects`** view) never appeared. The unified Code workspace was effectively *chat + terminal*, missing the very coding surfaces the arc (#932/#937/#940/#942) shipped.

## Fix

Mount the comux **`projects`** view in the Code workspace. That view has the file tree + preview/editor + project search + Files/Changes toggle **and** a `BottomTerminal` — so it delivers the full "tree + editor + terminal + search" unit the 2-pane design intended.

One-line change in `workspace.tsx` (`view="terminal"` → `view="projects"` on the `:code` ComuxView), plus a `code-view.test` assertion pinning the projects view so this can't regress.

## Verification (live)

Standalone prod build, driven headless against a running daemon:
- **Before:** Code mode exposed only `Search sessions…` + `New session` (terminal). No project search, no file tree, no Files/Changes.
- **After:** Code mode exposes the **`Search in project`** box, the **Files/Changes** toggle, the **file-tree refresh** control, and the **file tree** (screenshot confirmed — chat left, tree + search + preview + toggle right).

`pnpm typecheck`, full **app + api (358)**, and **`next build`** all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)