### PR TITLE
feat(code): support .mjs/.cjs in the file preview + editor

### DIFF
--- a/src/app/api/project-file/route.test.ts
+++ b/src/app/api/project-file/route.test.ts
@@ -62,4 +62,8 @@ assert.match(
   "writes must reject non-string content",
 );
 
+// ES/CommonJS module files (.mjs/.cjs — e.g. scripts/run-tests.mjs, *.test.mjs)
+// are JavaScript text and must be previewable + editable, not rejected.
+assert.match(source, /"\.mjs",[\s\S]*?"\.cjs",/, ".mjs and .cjs are previewable/editable text extensions");
+
 console.log("project-file route.test.ts: ok");

--- a/src/app/api/project-file/route.ts
+++ b/src/app/api/project-file/route.ts
@@ -11,6 +11,8 @@ const TEXT_EXTENSIONS = new Set([
   ".tsx",
   ".js",
   ".jsx",
+  ".mjs",
+  ".cjs",
   ".json",
   ".md",
   ".mdx",


### PR DESCRIPTION
## What

`.mjs` / `.cjs` files (e.g. `scripts/run-tests.mjs`, the `*.test.mjs` suite) were **rejected** by the project-file route as "extension not supported" — so they couldn't be previewed or edited in the Code workspace, despite being plain JavaScript. `code-lang` already maps `mjs`/`cjs` → JavaScript, so once allowed they highlight correctly in both the Shiki read preview and the CodeMirror editor.

## How

Add `".mjs"` and `".cjs"` to `TEXT_EXTENSIONS` in `src/app/api/project-file/route.ts` — covers both the GET preview and the POST save (both gate on that set).

## Verification (live)

Standalone prod build: `GET /api/project-file?path=…/postcss.config.mjs` now returns `ok:true, kind:text` (94 bytes) — it returned `400 "extension .mjs not supported"` before. `route.test.ts` pins the extensions; `pnpm typecheck`, api-contracts, full **app+api (358)**, and **`next build`** all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)