### PR TITLE
feat(code): transcript-only chat pane + de-dup nav in Code mode

### DIFF
--- a/src/components/chat-surface-projects-tab.test.ts
+++ b/src/components/chat-surface-projects-tab.test.ts
@@ -16,9 +16,17 @@ assert.match(
   "shared Tabs items list all three scopes ending with the projects tab",
 );
 assert.match(surface, /\{\s*id:\s*"projects",\s*label:\s*"Projects"\s*\}/, "projects tab is labeled");
-assert.match(surface, /scope === "projects" \? \(/, "projects scope renders its own panel");
+assert.match(surface, /scope === "projects" && !isCodeSurface \? \(/, "projects scope renders its own panel (standalone chat only)");
 assert.match(surface, /<ProjectsView[\s\S]*?sessions=\{sessions\}/, "projects panel renders ProjectsView with sessions");
 assert.match(surface, /onNewChat=\{startProjectChat\}/, "projects panel wires onNewChat to startProjectChat");
 assert.match(surface, /addEventListener\(CHAT_OPEN_PROJECTS_EVENT/, "listens for the reroute event");
+
+// Code surface drops the duplicate Projects tab (the comux pane owns project /
+// file navigation there) — the tab list is Sessions + Memory only when isCodeSurface.
+assert.match(
+  surface,
+  /isCodeSurface\s*\?\s*\[\s*\{\s*id:\s*"conversation",\s*label:\s*"Sessions"\s*\},\s*\{\s*id:\s*"memory",\s*label:\s*"Memory"\s*\},?\s*\]\s*:\s*\[/,
+  "Code surface tab list omits the Projects tab",
+);
 
 console.log("chat-surface-projects-tab.test.ts: ok");

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -156,6 +156,31 @@ assert.match(
   "ChatSurface should keep live chat available inside the Chat tab",
 );
 
+// Code surface ("code" mode): the chat pane is transcript-only — the comux pane
+// owns project/file navigation. ChatSurface takes a `surface` prop, derives
+// isCodeSurface, drops the in-chat project sidebar by passing compact, and tags
+// the transcript wrapper so the reading-width cap applies.
+assert.match(
+  chatSurface,
+  /surface\s*=\s*"chat"/,
+  "ChatSurface should accept a surface prop defaulting to standalone chat",
+);
+assert.match(
+  chatSurface,
+  /const isCodeSurface = surface === "code"/,
+  "ChatSurface should derive isCodeSurface from the surface prop",
+);
+assert.match(
+  chatSurface,
+  /<ChatRouter[\s\S]*?compact=\{isCodeSurface\}/,
+  "ChatSurface should suppress the in-chat project sidebar in Code mode via compact",
+);
+assert.match(
+  chatSurface,
+  /data-surface=\{surface\}/,
+  "ChatSurface should tag the transcript wrapper with the surface for the reading-width cap",
+);
+
 assert.match(
   chatSurface,
   /onOpenUrl\?: \(url: string\) => void/,

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -80,6 +80,12 @@ type Props = {
    *  routes back to the board with the linked card focused. */
   onOpenTask?: (cardId: string) => void;
   onOpenUrl?: (url: string) => void;
+  /** Which surface embeds this ChatSurface. In "code" mode the chat pane is
+   *  transcript-only (the comux pane owns project/file/session navigation), so
+   *  the in-chat project sidebar and the duplicate Projects tab are dropped and
+   *  the transcript gets a readable measure. Defaults to the standalone
+   *  "chat" surface, which keeps the sidebar + all three scope tabs. */
+  surface?: "chat" | "code";
 };
 
 // ── Right panel (inspector / chat) ────────────────────────────────────────────
@@ -277,7 +283,9 @@ export function ChatSurface({
   onSessionsChanged,
   onOpenTask,
   onOpenUrl,
+  surface = "chat",
 }: Props) {
+  const isCodeSurface = surface === "code";
   const [scope, setScope] = useState<FamiliarsScope>("conversation");
   const [rightExpanded, setRightExpanded] = useState(false);
   // Below the desktop shell breakpoint the inline 230px right sidebar is hidden
@@ -537,11 +545,20 @@ export function ChatSurface({
                   window.setTimeout(() => routerRef.current?.goToList(), 0);
                 }
               }}
-              items={[
-                { id: "conversation", label: "Sessions" },
-                { id: "memory", label: "Memory" },
-                { id: "projects", label: "Projects" },
-              ]}
+              // In Code mode the comux pane owns project/file navigation, so the
+              // duplicate Projects tab is dropped — only Sessions + Memory here.
+              items={
+                isCodeSurface
+                  ? [
+                      { id: "conversation", label: "Sessions" },
+                      { id: "memory", label: "Memory" },
+                    ]
+                  : [
+                      { id: "conversation", label: "Sessions" },
+                      { id: "memory", label: "Memory" },
+                      { id: "projects", label: "Projects" },
+                    ]
+              }
             />
           </div>
         </div>
@@ -556,7 +573,7 @@ export function ChatSurface({
               window.location.hash = `memory:${encodeURIComponent(path)}`;
             }}
           />
-        ) : scope === "projects" ? (
+        ) : scope === "projects" && !isCodeSurface ? (
           <ProjectsView sessions={sessions} onNewChat={startProjectChat} onSessionsChanged={onSessionsChanged} />
         ) : (
           <Group
@@ -566,7 +583,7 @@ export function ChatSurface({
             onLayoutChanged={onLayoutChanged}
           >
             <Panel id="chat-main" className="flex min-h-0 min-w-0" minSize="45%">
-              <div className="min-h-0 min-w-0 flex-1">
+              <div className="min-h-0 min-w-0 flex-1" data-surface={surface}>
                 <ChatRouter
                   ref={routerRef}
                   familiar={activeFamiliar}
@@ -574,6 +591,7 @@ export function ChatSurface({
                   sessions={sessions}
                   daemonRunning={daemonRunning}
                   sessionsLoaded={sessionsLoaded}
+                  compact={isCodeSurface}
                   onSetActiveFamiliar={onSetActiveFamiliar}
                   onSessionStarted={onSessionStarted}
                   onSessionsChanged={onSessionsChanged}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1420,6 +1420,7 @@ export function Workspace() {
       <CodeView
         chat={
           <ChatSurface
+            surface="code"
             familiars={familiars}
             sessions={sessions}
             activeFamiliar={active}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -46,6 +46,14 @@
   -webkit-font-smoothing: antialiased;
 }
 
+/* Code surface (mode === "code"): the chat pane is transcript-only, so it can
+   get wide. Cap the measure at a readable ~90ch by default so agent prose
+   doesn't stretch to 200-char lines. An explicit Settings reading-width still
+   wins (the var), and standalone chat (no data-surface="code") keeps `none`. */
+[data-surface="code"] .cave-md {
+  max-width: var(--cave-reading-width, 90ch);
+}
+
 /* Chat message prose reads in Inter — a neutral grotesque for the ChatGPT/Codex
    look — instead of the rounder geometric UI sans (Geist). Scoped to chat bubbles
    so library-doc and memory prose (which also use .cave-md) keep the app font.


### PR DESCRIPTION
First PR (Phase 0+1) of the approved Code-surface redesign — plan: reclaim transcript width and remove redundant navigation in **Code mode** (`workspace mode "code"`), where the layout nested three levels of resizable panels and the agent transcript collapsed to ~250px (wrapping after ~3 words), with project/session lists shown in three places at once.

## Changes

- **`ChatSurface` gains `surface: "chat" | "code"`** (default `"chat"`). In Code mode it derives `isCodeSurface` and passes `compact` to `ChatRouter`, which suppresses the in-chat `ChatProjectSidebar` — the comux pane already owns project/file/session navigation there. The chat pane becomes **transcript-only and wide**.
- **Drops the duplicate Projects tab** (and its `ProjectsView` render) in Code mode; only **Sessions + Memory** remain. Standalone `mode "chat"` keeps the sidebar and all three tabs unchanged.
- **Transcript reading cap**: the transcript wrapper is tagged `data-surface="code"`, and a scoped `.cave-md` rule caps the measure at ~90ch by default (an explicit Settings reading-width still wins; standalone chat keeps `none`).
- `workspace.tsx` passes `surface="code"` only to the CodeView's `ChatSurface`.

Scoped entirely to Code mode — the standalone chat surface is unchanged.

## Verify

- `tsc --noEmit` clean.
- Source-text suites pass: `chat-surface`, `chat-surface-projects-tab` (asserts the Projects tab is omitted + `compact`/`data-surface` wiring), `chat-thread-rail` (sidebar still under `!compact`), `code-view`, `projects-view`.

Follow-ups (approved plan, separate PRs): layout presets, diff-first review, persistent agent-activity view, denser composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)