### PR TITLE
feat(canvas): Sketch layer — spin up live UI examples ad hoc (ChatGPT/Codex-style)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -105,6 +105,8 @@ export const SUITES = {
     "src/components/calendar-view-polish.test.ts",
     "src/lib/calendar-layout.test.ts",
     "src/lib/canvas-layout.test.ts",
+    "src/lib/canvas-artifacts.test.ts",
+    "src/lib/canvas-generate.test.ts",
     "src/lib/cave-canvas.test.ts",
     "src/components/canvas-view.test.ts",
     "src/components/calendar-actions.test.ts",
@@ -409,6 +411,8 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/lib/canvas-generate.test.ts",
+  "src/lib/cave-canvas.test.ts",
   "src/lib/task-archive-nudge.test.ts",
   "src/lib/cave-config.test.ts",
   "src/lib/cave-config-state-race.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -23,7 +23,7 @@ const contracts: RouteContract[] = [
   { route: "/board/[id]", methods: ["PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/board/enrich-steps", methods: ["POST"], kind: "json", readsJson: true },
   { route: "/board", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
-  { route: "/canvas", methods: ["GET", "PUT"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/canvas", methods: ["GET", "PUT", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/capabilities", methods: ["GET"], kind: "json" },
   { route: "/changes", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", pathGuard: true },
   { route: "/chat/conversation/[id]", methods: ["GET", "POST", "PUT", "PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },

--- a/src/app/api/canvas/route.ts
+++ b/src/app/api/canvas/route.ts
@@ -1,13 +1,19 @@
 import { NextResponse } from "next/server";
 
-import { loadCanvas, mergeCanvasPositions } from "@/lib/cave-canvas";
+import {
+  deleteCanvasArtifact,
+  loadCanvas,
+  mergeCanvasPositions,
+  upsertCanvasArtifact,
+} from "@/lib/cave-canvas";
+import type { CanvasArtifact } from "@/lib/canvas-artifacts";
 import type { CanvasPositions } from "@/lib/canvas-layout";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
   const file = await loadCanvas();
-  return NextResponse.json({ ok: true, positions: file.positions });
+  return NextResponse.json({ ok: true, positions: file.positions, artifacts: file.artifacts });
 }
 
 export async function PUT(req: Request) {
@@ -22,4 +28,32 @@ export async function PUT(req: Request) {
   }
   const file = await mergeCanvasPositions(body.positions);
   return NextResponse.json({ ok: true, positions: file.positions });
+}
+
+export async function POST(req: Request) {
+  let body: { artifact?: CanvasArtifact };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 });
+  }
+  if (!body.artifact || typeof body.artifact !== "object") {
+    return NextResponse.json({ ok: false, error: "artifact required" }, { status: 400 });
+  }
+  const file = await upsertCanvasArtifact(body.artifact);
+  return NextResponse.json({ ok: true, artifacts: file.artifacts });
+}
+
+export async function DELETE(req: Request) {
+  let body: { id?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 });
+  }
+  if (!body.id || typeof body.id !== "string") {
+    return NextResponse.json({ ok: false, error: "id required" }, { status: 400 });
+  }
+  const file = await deleteCanvasArtifact(body.id);
+  return NextResponse.json({ ok: true, artifacts: file.artifacts });
 }

--- a/src/components/canvas-artifact-node.tsx
+++ b/src/components/canvas-artifact-node.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { NodeResizer, type NodeProps, type Node } from "@xyflow/react";
+import { Icon } from "@/lib/icon";
+import { buildPreviewSrcDoc, type CanvasArtifact } from "@/lib/canvas-artifacts";
+
+export type ArtifactNodeData = {
+  artifact: CanvasArtifact;
+  view: "preview" | "code";
+  generating: boolean;
+  onToggleView: (id: string) => void;
+  onRefine: (id: string) => void;
+  onDuplicate: (id: string) => void;
+  onDelete: (id: string) => void;
+  onEditCode: (id: string, code: string) => void;
+  onOpenInBrowser: (id: string) => void;
+};
+
+export type ArtifactFlowNode = Node<ArtifactNodeData & Record<string, unknown>, "artifact">;
+
+export function ArtifactNode({ data, selected }: NodeProps<ArtifactFlowNode>) {
+  const { artifact, view, generating } = data;
+  return (
+    <div className={`canvas-artifact${selected ? " is-selected" : ""}`}>
+      <NodeResizer minWidth={260} minHeight={200} isVisible={selected} />
+      {/* Drag handle — the iframe swallows pointer events, so the node is only
+          draggable by this header (see dragHandle wiring in canvas-view). */}
+      <div className="canvas-artifact__grip">
+        <span className="canvas-artifact__title" title={artifact.prompt || artifact.title}>
+          {generating ? <span className="canvas-artifact__spinner" aria-hidden /> : <Icon name="ph:bounding-box" />}
+          {artifact.title || "Untitled"}
+        </span>
+        <div className="canvas-artifact__actions nodrag">
+          <button
+            type="button"
+            className={`canvas-artifact__btn${view === "preview" ? " is-active" : ""}`}
+            title="Preview"
+            aria-label="Preview"
+            onClick={() => data.onToggleView(artifact.id)}
+          >
+            <Icon name={view === "preview" ? "ph:code" : "ph:squares-four"} />
+          </button>
+          <button
+            type="button"
+            className="canvas-artifact__btn"
+            title="Refine with the familiar"
+            aria-label="Refine"
+            disabled={generating}
+            onClick={() => data.onRefine(artifact.id)}
+          >
+            <Icon name="ph:sparkle" />
+          </button>
+          <button
+            type="button"
+            className="canvas-artifact__btn"
+            title="Open in browser"
+            aria-label="Open in browser"
+            onClick={() => data.onOpenInBrowser(artifact.id)}
+          >
+            <Icon name="ph:arrow-square-out" />
+          </button>
+          <button
+            type="button"
+            className="canvas-artifact__btn"
+            title="Duplicate"
+            aria-label="Duplicate"
+            onClick={() => data.onDuplicate(artifact.id)}
+          >
+            <Icon name="ph:copy" />
+          </button>
+          <button
+            type="button"
+            className="canvas-artifact__btn canvas-artifact__btn--danger"
+            title="Delete"
+            aria-label="Delete"
+            onClick={() => data.onDelete(artifact.id)}
+          >
+            <Icon name="ph:trash" />
+          </button>
+        </div>
+      </div>
+
+      <div className="canvas-artifact__body nodrag">
+        {view === "code" ? (
+          <textarea
+            className="canvas-artifact__code"
+            spellCheck={false}
+            value={artifact.code}
+            placeholder="<!doctype html> …"
+            onChange={(e) => data.onEditCode(artifact.id, e.target.value)}
+          />
+        ) : artifact.code ? (
+          // Untrusted generated markup runs ONLY inside this sandbox:
+          // allow-scripts WITHOUT allow-same-origin means scripts execute but
+          // can't reach Cave's origin, cookies, or storage.
+          <iframe
+            className="canvas-artifact__frame"
+            title={artifact.title || "preview"}
+            sandbox="allow-scripts allow-popups allow-modals"
+            srcDoc={buildPreviewSrcDoc(artifact.code)}
+          />
+        ) : (
+          <div className="canvas-artifact__placeholder">
+            {generating ? "Generating…" : "No preview yet"}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/canvas-view.test.ts
+++ b/src/components/canvas-view.test.ts
@@ -44,4 +44,35 @@ assert.match(
   "canvas must scope cards to the active familiar the same way the board does",
 );
 
+// ── Sketch layer: generate UIs ad hoc, render in a sandboxed iframe ────────
+
+const artifactNode = await readFile(new URL("./canvas-artifact-node.tsx", import.meta.url), "utf8");
+
+// Layer toggle is persisted and gates the bands (triage-only).
+assert.match(view, /cave:canvas:layer/, "the Triage/Sketch layer choice must persist");
+assert.match(view, /isSketch \? null : <BandGuides/, "status bands must only render in the triage layer");
+
+// Generation routes through the chat bridge (Cave has no server LLM).
+assert.match(view, /generateArtifactCode/, "Sketch must generate via the chat-bridge helper");
+assert.match(
+  artifactNode + view,
+  /buildSketchPrompt|buildRefinePrompt/,
+  "generation must wrap the user's ask in the one-document sketch/refine prompt",
+);
+
+// The preview MUST be a sandboxed iframe WITHOUT allow-same-origin, so
+// generated (untrusted) code can't reach Cave's origin.
+assert.match(artifactNode, /<iframe/, "artifacts render in an iframe");
+assert.match(artifactNode, /srcDoc=\{buildPreviewSrcDoc/, "the iframe is fed a framed srcDoc");
+assert.match(artifactNode, /sandbox="allow-scripts/, "the preview iframe must be sandboxed (scripts allowed)");
+assert.doesNotMatch(
+  artifactNode,
+  /sandbox="[^"]*allow-same-origin/,
+  "the preview must NOT grant allow-same-origin — that would break isolation",
+);
+
+// Artifacts persist to the canvas store via POST and delete via DELETE.
+assert.match(view, /method:\s*"POST"[\s\S]{0,120}artifact/, "artifacts upsert to /api/canvas via POST");
+assert.match(view, /method:\s*"DELETE"/, "deleting an artifact calls DELETE /api/canvas");
+
 console.log("canvas-view.test.ts ✓");

--- a/src/components/canvas-view.tsx
+++ b/src/components/canvas-view.tsx
@@ -36,6 +36,19 @@ import {
   type CanvasPosition,
   type CanvasPositions,
 } from "@/lib/canvas-layout";
+import {
+  buildPreviewSrcDoc,
+  buildRefinePrompt,
+  buildSketchPrompt,
+  clampArtifactCode,
+  STARTER_ARTIFACT_HTML,
+  titleFromPrompt,
+  type CanvasArtifact,
+} from "@/lib/canvas-artifacts";
+import { generateArtifactCode } from "@/lib/canvas-generate";
+import { ArtifactNode, type ArtifactFlowNode } from "@/components/canvas-artifact-node";
+
+type CanvasLayer = "triage" | "sketch";
 
 type Props = {
   familiars: Familiar[];
@@ -53,7 +66,16 @@ type IssueNodeData = {
 
 type IssueFlowNode = Node<IssueNodeData & Record<string, unknown>, "issue">;
 
-// ── Node ────────────────────────────────────────────────────────────────────
+const ARTIFACT_W = 420;
+const ARTIFACT_H = 320;
+
+function loadLayer(): CanvasLayer {
+  if (typeof window === "undefined") return "triage";
+  const v = localStorage.getItem("cave:canvas:layer");
+  return v === "sketch" ? "sketch" : "triage";
+}
+
+// ── Issue node (triage) ─────────────────────────────────────────────────────
 
 function IssueNode({ data }: NodeProps<IssueFlowNode>) {
   const { card, familiarName, onOpenCard, onOpenUrl } = data;
@@ -97,17 +119,16 @@ function IssueNode({ data }: NodeProps<IssueFlowNode>) {
   );
 }
 
-const nodeTypes: NodeTypes = { issue: IssueNode };
+const nodeTypes: NodeTypes = { issue: IssueNode, artifact: ArtifactNode };
 
-// ── Band guides ───────────────────────────────────────────────────────────--
+// ── Band guides (triage only) ───────────────────────────────────────────────
 //
 // The triage bands live in world space but are drawn as a screen overlay that
 // re-projects on every pan/zoom (React Flow keeps node DOM in a transformed
-// layer we can't inject into, so we mirror the transform ourselves). Each
-// band gets a left divider and a header label pinned to the top of the pane.
+// layer we can't inject into, so we mirror the transform ourselves).
 
 function BandGuides() {
-  const { x, y: _y, zoom } = useViewport();
+  const { x, zoom } = useViewport();
   return (
     <div className="canvas-bands" aria-hidden>
       {CANVAS_BANDS.map((status, i) => {
@@ -126,11 +147,22 @@ function BandGuides() {
 // ── Surface ───────────────────────────────────────────────────────────────--
 
 function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: Props) {
+  const [layer, setLayer] = useState<CanvasLayer>(loadLayer);
   const [cards, setCards] = useState<Card[]>([]);
   const [positions, setPositions] = useState<CanvasPositions>({});
-  const [nodes, setNodes] = useState<IssueFlowNode[]>([]);
+  const [artifacts, setArtifacts] = useState<CanvasArtifact[]>([]);
+  const [nodes, setNodes] = useState<Node[]>([]);
   const [hasLoaded, setHasLoaded] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [artifactView, setArtifactView] = useState<Record<string, "preview" | "code">>({});
+  const [generating, setGenerating] = useState<Set<string>>(new Set());
+  const [composer, setComposer] = useState("");
+
+  const artifactsRef = useRef<CanvasArtifact[]>([]);
+  useEffect(() => {
+    artifactsRef.current = artifacts;
+  }, [artifacts]);
+  const editTimers = useRef<Record<string, number>>({});
 
   const familiarsById = useMemo(() => new Map(familiars.map((f) => [f.id, f])), [familiars]);
 
@@ -138,6 +170,12 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
     () => cards.filter((c) => activeFamiliarId === null || c.familiarId === activeFamiliarId),
     [cards, activeFamiliarId],
   );
+
+  const setLayerPersisted = useCallback((next: CanvasLayer) => {
+    setLayer(next);
+    setActionError(null);
+    if (typeof window !== "undefined") localStorage.setItem("cave:canvas:layer", next);
+  }, []);
 
   const load = useCallback(async () => {
     if (isDemoModeEnabled()) {
@@ -155,6 +193,7 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
       const canvasJson = await canvasRes.json().catch(() => ({}));
       if (boardJson?.ok) setCards(boardJson.cards as Card[]);
       setPositions((canvasJson?.positions as CanvasPositions) ?? {});
+      setArtifacts((canvasJson?.artifacts as CanvasArtifact[]) ?? []);
     } catch {
       // Leave whatever we had; the empty state covers a cold failure.
     } finally {
@@ -166,7 +205,6 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
     load();
   }, [load]);
 
-  // The Board emits this after any mutation; keep the canvas in sync.
   useEffect(() => {
     const onReload = () => load();
     window.addEventListener("cave:board:reload", onReload);
@@ -177,27 +215,14 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
     };
   }, [load]);
 
-  // Rebuild nodes whenever the card set, positions, or familiar lookup change.
-  // resolvePositions keeps saved coordinates and auto-places newcomers.
-  useEffect(() => {
-    const resolved = resolvePositions(filtered, positions);
-    setNodes(
-      filtered.map((card) => ({
-        id: card.id,
-        type: "issue" as const,
-        position: resolved[card.id] ?? { x: 0, y: 0 },
-        data: {
-          card,
-          familiarName: card.familiarId ? familiarsById.get(card.familiarId)?.name ?? null : null,
-          onOpenCard,
-          onOpenUrl,
-        },
-      })),
-    );
-  }, [filtered, positions, familiarsById, onOpenCard, onOpenUrl]);
+  // ── Artifact persistence ──────────────────────────────────────────────────
 
-  const onNodesChange = useCallback((changes: NodeChange[]) => {
-    setNodes((prev) => applyNodeChanges(changes, prev) as IssueFlowNode[]);
+  const persistArtifact = useCallback((art: CanvasArtifact) => {
+    void fetch("/api/canvas", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ artifact: art }),
+    }).catch(() => undefined);
   }, []);
 
   const savePosition = useCallback((id: string, pos: CanvasPosition) => {
@@ -206,15 +231,198 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
       method: "PUT",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ positions: { [id]: pos } }),
-    }).catch(() => {
-      /* position persistence is best-effort; layout rebuilds from status */
+    }).catch(() => undefined);
+  }, []);
+
+  // ── Generation ────────────────────────────────────────────────────────────
+
+  const runGeneration = useCallback(
+    async (id: string, ask: string, refineOf?: CanvasArtifact) => {
+      const familiarId = activeFamiliarId ?? familiars[0]?.id ?? null;
+      if (!familiarId) {
+        setActionError("Pick a familiar first — generation runs through it.");
+        return;
+      }
+      setActionError(null);
+      setGenerating((prev) => new Set(prev).add(id));
+      const sendPrompt = refineOf ? buildRefinePrompt(refineOf.code, ask) : buildSketchPrompt(ask);
+      const result = await generateArtifactCode({ prompt: sendPrompt, familiarId });
+      setGenerating((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+      if (result.code) {
+        const code = clampArtifactCode(result.code);
+        const updatedAt = new Date().toISOString();
+        const current = artifactsRef.current.find((a) => a.id === id);
+        const updated: CanvasArtifact | null = current ? { ...current, code, updatedAt } : null;
+        if (updated) {
+          setArtifacts((prev) => prev.map((a) => (a.id === id ? updated : a)));
+          setArtifactView((prev) => ({ ...prev, [id]: "preview" }));
+          persistArtifact(updated);
+        }
+      } else {
+        setActionError(result.error ?? "Generation failed.");
+      }
+    },
+    [activeFamiliarId, familiars, persistArtifact],
+  );
+
+  const placementFor = useCallback((index: number): CanvasPosition => {
+    const col = index % 3;
+    const row = Math.floor(index / 3);
+    return { x: 40 + col * (ARTIFACT_W + 40), y: 40 + row * (ARTIFACT_H + 48) };
+  }, []);
+
+  const createArtifact = useCallback(
+    (ask: string, opts?: { blank?: boolean }) => {
+      const prompt = ask.trim();
+      if (!opts?.blank && !prompt) return;
+      const id = `art-${crypto.randomUUID()}`;
+      const now = new Date().toISOString();
+      const art: CanvasArtifact = {
+        id,
+        title: opts?.blank ? "Blank sketch" : titleFromPrompt(prompt),
+        prompt,
+        code: opts?.blank ? STARTER_ARTIFACT_HTML : "",
+        createdAt: now,
+        updatedAt: now,
+      };
+      setArtifacts((prev) => [...prev, art]);
+      const pos = placementFor(artifactsRef.current.length);
+      savePosition(id, pos);
+      setArtifactView((prev) => ({ ...prev, [id]: opts?.blank ? "code" : "preview" }));
+      persistArtifact(art);
+      if (!opts?.blank) void runGeneration(id, prompt);
+    },
+    [placementFor, savePosition, persistArtifact, runGeneration],
+  );
+
+  // ── Per-artifact node handlers ─────────────────────────────────────────────
+
+  const onToggleView = useCallback((id: string) => {
+    setArtifactView((prev) => ({ ...prev, [id]: prev[id] === "code" ? "preview" : "code" }));
+  }, []);
+
+  const onRefine = useCallback(
+    (id: string) => {
+      const art = artifactsRef.current.find((a) => a.id === id);
+      if (!art) return;
+      const ask = window.prompt("How should this change?", "");
+      if (ask === null || !ask.trim()) return;
+      void runGeneration(id, ask.trim(), art);
+    },
+    [runGeneration],
+  );
+
+  const onDuplicate = useCallback(
+    (id: string) => {
+      const art = artifactsRef.current.find((a) => a.id === id);
+      if (!art) return;
+      const copyId = `art-${crypto.randomUUID()}`;
+      const now = new Date().toISOString();
+      const copy: CanvasArtifact = { ...art, id: copyId, title: `${art.title} copy`, createdAt: now, updatedAt: now };
+      setArtifacts((prev) => [...prev, copy]);
+      const base = positions[id] ?? placementFor(artifactsRef.current.length);
+      savePosition(copyId, { x: base.x + 32, y: base.y + 32 });
+      setArtifactView((prev) => ({ ...prev, [copyId]: prev[id] ?? "preview" }));
+      persistArtifact(copy);
+    },
+    [positions, placementFor, savePosition, persistArtifact],
+  );
+
+  const onDeleteArtifact = useCallback((id: string) => {
+    setArtifacts((prev) => prev.filter((a) => a.id !== id));
+    setPositions((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
     });
+    void fetch("/api/canvas", {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id }),
+    }).catch(() => undefined);
+  }, []);
+
+  const onEditCode = useCallback(
+    (id: string, code: string) => {
+      const clamped = clampArtifactCode(code);
+      const updatedAt = new Date().toISOString();
+      setArtifacts((prev) => prev.map((a) => (a.id === id ? { ...a, code: clamped, updatedAt } : a)));
+      window.clearTimeout(editTimers.current[id]);
+      editTimers.current[id] = window.setTimeout(() => {
+        const a = artifactsRef.current.find((x) => x.id === id);
+        if (a) persistArtifact(a);
+      }, 700);
+    },
+    [persistArtifact],
+  );
+
+  const onOpenInBrowser = useCallback((id: string) => {
+    const art = artifactsRef.current.find((a) => a.id === id);
+    if (!art) return;
+    try {
+      const blob = new Blob([buildPreviewSrcDoc(art.code)], { type: "text/html" });
+      window.open(URL.createObjectURL(blob), "_blank", "noopener");
+    } catch {
+      /* popup blocked or unsupported — preview node still works */
+    }
+  }, []);
+
+  // ── Node assembly (per layer) ──────────────────────────────────────────────
+
+  useEffect(() => {
+    if (layer === "triage") {
+      const resolved = resolvePositions(filtered, positions);
+      setNodes(
+        filtered.map((card) => ({
+          id: card.id,
+          type: "issue" as const,
+          position: resolved[card.id] ?? { x: 0, y: 0 },
+          data: {
+            card,
+            familiarName: card.familiarId ? familiarsById.get(card.familiarId)?.name ?? null : null,
+            onOpenCard,
+            onOpenUrl,
+          },
+        })),
+      );
+      return;
+    }
+    setNodes(
+      artifacts.map((art, i) => ({
+        id: art.id,
+        type: "artifact" as const,
+        position: positions[art.id] ?? placementFor(i),
+        dragHandle: ".canvas-artifact__grip",
+        style: { width: ARTIFACT_W, height: ARTIFACT_H },
+        data: {
+          artifact: art,
+          view: artifactView[art.id] ?? "preview",
+          generating: generating.has(art.id),
+          onToggleView,
+          onRefine,
+          onDuplicate,
+          onDelete: onDeleteArtifact,
+          onEditCode,
+          onOpenInBrowser,
+        },
+      })) as ArtifactFlowNode[],
+    );
+  }, [
+    layer, filtered, positions, familiarsById, onOpenCard, onOpenUrl, artifacts, artifactView,
+    generating, placementFor, onToggleView, onRefine, onDuplicate, onDeleteArtifact, onEditCode, onOpenInBrowser,
+  ]);
+
+  const onNodesChange = useCallback((changes: NodeChange[]) => {
+    setNodes((prev) => applyNodeChanges(changes, prev));
   }, []);
 
   const patchStatus = useCallback(async (id: string, status: CardStatus) => {
     const prevStatus = cards.find((c) => c.id === id)?.status;
     if (!prevStatus || prevStatus === status) return;
-    // Optimistic: reflect the new band immediately, revert on failure.
     setCards((prev) => prev.map((c) => (c.id === id ? { ...c, status } : c)));
     setActionError(null);
     try {
@@ -231,21 +439,21 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
   }, [cards]);
 
   const onNodeDragStop = useCallback(
-    (_e: unknown, node: IssueFlowNode) => {
+    (_e: unknown, node: Node) => {
       savePosition(node.id, { x: node.position.x, y: node.position.y });
-      const centerX = node.position.x + CANVAS_NODE_WIDTH / 2;
-      void patchStatus(node.id, bandForX(centerX));
+      // Triage cards retriage by which band they land in; artifacts are free.
+      if (node.type === "issue") {
+        const centerX = node.position.x + CANVAS_NODE_WIDTH / 2;
+        void patchStatus(node.id, bandForX(centerX));
+      }
     },
     [savePosition, patchStatus],
   );
 
   const arrange = useCallback(() => {
-    if (isDemoModeEnabled()) {
-      setPositions(autoArrange(filtered));
-      return;
-    }
     const next = autoArrange(filtered);
-    setPositions(next);
+    setPositions((prev) => ({ ...prev, ...next }));
+    if (isDemoModeEnabled()) return;
     void fetch("/api/canvas", {
       method: "PUT",
       headers: { "content-type": "application/json" },
@@ -253,10 +461,18 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
     }).catch(() => undefined);
   }, [filtered]);
 
-  const isEmpty = hasLoaded && filtered.length === 0;
+  const submitComposer = useCallback(() => {
+    if (!composer.trim()) return;
+    createArtifact(composer);
+    setComposer("");
+  }, [composer, createArtifact]);
+
+  const isSketch = layer === "sketch";
+  const triageEmpty = hasLoaded && !isSketch && filtered.length === 0;
+  const sketchEmpty = hasLoaded && isSketch && artifacts.length === 0;
 
   return (
-    <div className="canvas-view" data-mode="canvas">
+    <div className="canvas-view" data-mode="canvas" data-layer={layer}>
       <ReactFlow
         nodes={nodes}
         edges={[]}
@@ -266,35 +482,114 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
         nodesConnectable={false}
         fitView
         fitViewOptions={{ padding: 0.25, maxZoom: 1 }}
-        minZoom={0.25}
+        minZoom={0.2}
         maxZoom={1.5}
         proOptions={{ hideAttribution: true }}
       >
-        <BandGuides />
+        {isSketch ? null : <BandGuides />}
         <Background gap={24} size={1} />
         <Controls showInteractive={false} />
         <MiniMap pannable zoomable nodeStrokeWidth={2} />
+
         <Panel position="top-left" className="canvas-toolbar">
           <span className="canvas-toolbar__title">
-            <Icon name="ph:bounding-box" /> Triage Canvas
+            <Icon name="ph:bounding-box" /> Canvas
           </span>
-          <span className="canvas-toolbar__count">{filtered.length} issues</span>
-          <button type="button" className="canvas-toolbar__btn" onClick={arrange} title="Tidy cards into their status bands">
-            <Icon name="ph:arrows-clockwise" /> Auto-arrange
-          </button>
+          <div className="canvas-segmented" role="tablist" aria-label="Canvas mode">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={!isSketch}
+              className={`canvas-segmented__btn${!isSketch ? " is-active" : ""}`}
+              onClick={() => setLayerPersisted("triage")}
+            >
+              Triage
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={isSketch}
+              className={`canvas-segmented__btn${isSketch ? " is-active" : ""}`}
+              onClick={() => setLayerPersisted("sketch")}
+            >
+              Sketch
+            </button>
+          </div>
+          {isSketch ? (
+            <span className="canvas-toolbar__count">{artifacts.length} examples</span>
+          ) : (
+            <>
+              <span className="canvas-toolbar__count">{filtered.length} issues</span>
+              <button
+                type="button"
+                className="canvas-toolbar__btn"
+                onClick={arrange}
+                title="Tidy cards into their status bands"
+              >
+                <Icon name="ph:arrows-clockwise" /> Auto-arrange
+              </button>
+            </>
+          )}
         </Panel>
+
         {actionError ? (
           <Panel position="top-center" className="canvas-error" role="alert">
             {actionError}
           </Panel>
         ) : null}
+
+        {isSketch ? (
+          <Panel position="bottom-center" className="canvas-composer">
+            <textarea
+              className="canvas-composer__input"
+              placeholder="Describe a UI to spin up — e.g. “a pricing page with three tiers and a toggle”"
+              value={composer}
+              rows={2}
+              onChange={(e) => setComposer(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                  e.preventDefault();
+                  submitComposer();
+                }
+              }}
+            />
+            <div className="canvas-composer__actions">
+              <button
+                type="button"
+                className="canvas-composer__blank"
+                title="Add a blank artifact to hand-write or paste HTML"
+                onClick={() => createArtifact("", { blank: true })}
+              >
+                <Icon name="ph:plus" /> Blank
+              </button>
+              <button
+                type="button"
+                className="canvas-composer__send"
+                disabled={!composer.trim()}
+                onClick={submitComposer}
+              >
+                <Icon name="ph:sparkle" /> Generate
+              </button>
+            </div>
+          </Panel>
+        ) : null}
       </ReactFlow>
-      {isEmpty ? (
+
+      {triageEmpty ? (
         <div className="canvas-empty">
           <Icon name="ph:bounding-box" />
           <p className="canvas-empty__title">No issues to triage</p>
           <p className="canvas-empty__hint">
-            Cards from the Board appear here as you create them. Drag a card across a band to retriage it.
+            Cards from the Board appear here. Drag a card across a band to retriage it, or switch to Sketch to build UIs.
+          </p>
+        </div>
+      ) : null}
+      {sketchEmpty ? (
+        <div className="canvas-empty">
+          <Icon name="ph:sparkle" />
+          <p className="canvas-empty__title">Spin up a UI</p>
+          <p className="canvas-empty__hint">
+            Describe a component or page below and a familiar will generate it as a live, editable preview. Add several to compare side by side.
           </p>
         </div>
       ) : null}

--- a/src/lib/canvas-artifacts.test.ts
+++ b/src/lib/canvas-artifacts.test.ts
@@ -1,0 +1,94 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+
+import {
+  buildPreviewSrcDoc,
+  buildRefinePrompt,
+  buildSketchPrompt,
+  clampArtifactCode,
+  extractHtmlArtifact,
+  isFullDocument,
+  MAX_ARTIFACT_CODE_CHARS,
+  sanitizeArtifacts,
+  STARTER_ARTIFACT_HTML,
+  titleFromPrompt,
+} from "./canvas-artifacts.ts";
+
+// ── extractHtmlArtifact: pull the document out of a chat response ──────────
+
+const fenced = 'Sure!\n```html\n<!doctype html><html><body>hi</body></html>\n```\nDone.';
+assert.equal(
+  extractHtmlArtifact(fenced),
+  "<!doctype html><html><body>hi</body></html>",
+  "prefers the html-tagged fenced block, stripped of prose",
+);
+
+// Picks the html fence even when another fenced block comes first.
+const multi = "```js\nconsole.log(1)\n```\n```html\n<div>x</div>\n```";
+assert.equal(extractHtmlArtifact(multi), "<div>x</div>", "html fence wins over an earlier js fence");
+
+// Falls back to the first fence when none is tagged html.
+assert.equal(extractHtmlArtifact("```\n<p>plain</p>\n```"), "<p>plain</p>", "untagged fence is accepted");
+
+// Bare document with no fence at all.
+assert.equal(
+  extractHtmlArtifact("here you go <!doctype html><html><body>z</body></html> bye"),
+  "<!doctype html><html><body>z</body></html>",
+  "a bare document is sliced out when the model ignores the fence format",
+);
+
+assert.equal(extractHtmlArtifact("no code here, sorry"), null, "prose-only response yields null");
+assert.equal(extractHtmlArtifact(""), null, "empty string yields null");
+
+// ── buildPreviewSrcDoc: full docs pass through, fragments get wrapped ──────
+
+assert.ok(isFullDocument("<!doctype html><html></html>"), "doctype counts as a full document");
+assert.ok(isFullDocument("<HTML lang=en>"), "an <html> tag counts (case-insensitive)");
+assert.ok(!isFullDocument("<div>fragment</div>"), "a bare fragment is not a full document");
+
+const fullDoc = "<!doctype html><html><body>x</body></html>";
+assert.equal(buildPreviewSrcDoc(fullDoc), fullDoc, "a full document is returned untouched");
+
+const wrapped = buildPreviewSrcDoc("<button>Click</button>");
+assert.match(wrapped, /^<!doctype html>/i, "a fragment is wrapped into a full document");
+assert.match(wrapped, /<button>Click<\/button>/, "the fragment is placed in the wrapped body");
+
+// ── titles, clamping, prompts ──────────────────────────────────────────────
+
+assert.equal(titleFromPrompt("  Make a   pricing page  "), "Make a pricing page", "title collapses whitespace");
+assert.equal(titleFromPrompt(""), "Untitled", "empty prompt falls back to Untitled");
+assert.ok(titleFromPrompt("x".repeat(200)).length <= 60, "long titles are clamped");
+
+const huge = "y".repeat(MAX_ARTIFACT_CODE_CHARS + 500);
+assert.equal(clampArtifactCode(huge).length, MAX_ARTIFACT_CODE_CHARS, "code is clamped to the storage cap");
+
+const prompt = buildSketchPrompt("a login form");
+assert.match(prompt, /ONE fenced ```html code block/, "sketch prompt constrains output to one html block");
+assert.match(prompt, /a login form/, "sketch prompt carries the user's ask");
+assert.match(buildSketchPrompt("  "), /a simple example UI/, "blank ask gets a sensible default");
+
+const refine = buildRefinePrompt("<!doctype html><html></html>", "make it dark mode");
+assert.match(refine, /make it dark mode/, "refine prompt carries the change request");
+assert.match(refine, /<!doctype html><html><\/html>/, "refine prompt embeds the current document");
+assert.match(refine, /FULL updated document/, "refine asks for the full document, not a diff");
+
+assert.match(STARTER_ARTIFACT_HTML, /^<!doctype html>/i, "starter template is a full document");
+
+// ── sanitizeArtifacts: trust boundary for disk + request bodies ────────────
+
+const clean = sanitizeArtifacts([
+  { id: "a", title: "A", prompt: "p", code: "<i>x</i>", createdAt: "t", updatedAt: "t" },
+  { id: "", title: "no id", prompt: "", code: "", createdAt: "", updatedAt: "" }, // dropped: empty id
+  { nope: true }, // dropped: not an artifact
+  { id: "a", title: "dupe", prompt: "", code: "", createdAt: "", updatedAt: "" }, // dropped: duplicate id
+]);
+assert.equal(clean.length, 1, "only the one valid, unique artifact survives");
+assert.equal(clean[0].id, "a");
+assert.deepEqual(sanitizeArtifacts("nope"), [], "non-array input yields an empty list");
+assert.equal(
+  sanitizeArtifacts([{ id: "x", prompt: "build a thing" }])[0].title,
+  "build a thing",
+  "a missing title is derived from the prompt",
+);
+
+console.log("canvas-artifacts.test.ts ✓");

--- a/src/lib/canvas-artifacts.ts
+++ b/src/lib/canvas-artifacts.ts
@@ -1,0 +1,181 @@
+// Pure helpers for the Sketch layer of the Canvas — ad-hoc "spin up a UI"
+// artifacts. A familiar is asked to emit one self-contained HTML document; we
+// extract it from the chat response, frame it for a sandboxed <iframe srcdoc>
+// preview, and persist it. Everything here is framework-/fs-free so it can be
+// unit-tested without a DOM, a daemon, or React Flow.
+
+export type CanvasArtifact = {
+  id: string;
+  /** Short human label, derived from the prompt (editable later). */
+  title: string;
+  /** The natural-language description the user asked for. */
+  prompt: string;
+  /** The self-contained HTML document rendered in the preview. */
+  code: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+// Storage guard: a single artifact's code is capped so a runaway generation
+// can't bloat the canvas store. Generous enough for a real standalone page.
+export const MAX_ARTIFACT_CODE_CHARS = 200_000;
+const MAX_TITLE_CHARS = 60;
+
+/**
+ * Pull the HTML document out of a familiar's chat response.
+ *
+ * Models reliably wrap code in a fenced block; we prefer an html/markup-tagged
+ * fence, fall back to the first fence of any language, and finally — if the
+ * model ignored the format and emitted a bare document — slice from the first
+ * `<!doctype` / `<html` tag. Returns null when there's nothing renderable.
+ */
+export function extractHtmlArtifact(text: string): string | null {
+  if (typeof text !== "string" || !text.trim()) return null;
+
+  const fences = [...text.matchAll(/```([\w-]*)\n([\s\S]*?)```/g)];
+  if (fences.length > 0) {
+    const htmlFence = fences.find((m) => /^(html?|markup|xml)$/i.test(m[1] ?? ""));
+    const chosen = (htmlFence ?? fences[0])[2] ?? "";
+    const trimmed = chosen.trim();
+    if (trimmed) return trimmed;
+  }
+
+  // No usable fence — accept a bare document if one is present.
+  const docMatch = text.match(/<!doctype html[\s\S]*<\/html>/i) ?? text.match(/<html[\s\S]*<\/html>/i);
+  if (docMatch) return docMatch[0].trim();
+
+  return null;
+}
+
+/** True when `code` already looks like a full HTML document (vs a fragment). */
+export function isFullDocument(code: string): boolean {
+  return /<html[\s>]/i.test(code) || /<!doctype html/i.test(code);
+}
+
+/**
+ * Frame artifact code for the preview iframe. Full documents pass through; a
+ * bare fragment is wrapped in a minimal document with neutral base styling so
+ * it renders sensibly on its own. The result is fed to `<iframe srcdoc>` and
+ * runs under `sandbox="allow-scripts"` (no same-origin) — isolation comes from
+ * the sandbox, so we intentionally do NOT strip scripts here.
+ */
+export function buildPreviewSrcDoc(code: string): string {
+  const src = typeof code === "string" ? code : "";
+  if (isFullDocument(src)) return src;
+  return [
+    "<!doctype html>",
+    '<html lang="en">',
+    "<head>",
+    '<meta charset="utf-8" />',
+    '<meta name="viewport" content="width=device-width, initial-scale=1" />',
+    "<style>",
+    "  :root { color-scheme: light dark; }",
+    "  body { margin: 0; padding: 16px; font-family: system-ui, -apple-system, sans-serif; }",
+    "</style>",
+    "</head>",
+    `<body>${src}</body>`,
+    "</html>",
+  ].join("\n");
+}
+
+/** A compact title from a prompt: first line, collapsed, clamped. */
+export function titleFromPrompt(prompt: string): string {
+  const firstLine = (prompt ?? "").split("\n").map((l) => l.trim()).find(Boolean) ?? "Untitled";
+  const collapsed = firstLine.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= MAX_TITLE_CHARS) return collapsed || "Untitled";
+  return collapsed.slice(0, MAX_TITLE_CHARS - 1).trimEnd() + "…";
+}
+
+/** Clamp code to the storage cap, preserving the head of the document. */
+export function clampArtifactCode(code: string): string {
+  const src = typeof code === "string" ? code : "";
+  return src.length > MAX_ARTIFACT_CODE_CHARS ? src.slice(0, MAX_ARTIFACT_CODE_CHARS) : src;
+}
+
+/**
+ * The instruction wrapped around the user's description before it goes to the
+ * familiar. Constrains output to one self-contained document so extraction is
+ * deterministic — no build step, no external files, no prose.
+ */
+export function buildSketchPrompt(userPrompt: string): string {
+  const ask = (userPrompt ?? "").trim() || "a simple example UI";
+  return [
+    "You are generating a UI for a live preview sandbox inside a design canvas.",
+    "",
+    "Rules:",
+    "- Output EXACTLY ONE fenced ```html code block and nothing else — no prose, no explanation before or after.",
+    "- The block must be a COMPLETE, self-contained document starting with `<!doctype html>`.",
+    "- Inline all CSS in a <style> tag and all JS in a <script> tag. Do not reference local files or build tooling.",
+    "- It must render on its own with no network access. If you need a library (e.g. React), load it from a CDN such as https://esm.sh, but prefer plain HTML/CSS/JS when it suffices.",
+    "- Make it visually polished and responsive; fill the viewport sensibly.",
+    "",
+    `Build this: ${ask}`,
+  ].join("\n");
+}
+
+/**
+ * Prompt for iterating on an existing artifact: hand the familiar the current
+ * document plus the change request, keeping the same one-document output
+ * contract so the result drops straight back onto the canvas.
+ */
+export function buildRefinePrompt(currentCode: string, changeRequest: string): string {
+  const ask = (changeRequest ?? "").trim() || "improve it";
+  return [
+    buildSketchPrompt(`Apply this change: ${ask}`),
+    "",
+    "Modify the document below. Return the FULL updated document, not a diff:",
+    "",
+    "```html",
+    (currentCode ?? "").trim(),
+    "```",
+  ].join("\n");
+}
+
+/** A minimal starter document for hand-written / pasted artifacts. */
+export const STARTER_ARTIFACT_HTML = [
+  "<!doctype html>",
+  '<html lang="en">',
+  "<head>",
+  '<meta charset="utf-8" />',
+  '<meta name="viewport" content="width=device-width, initial-scale=1" />',
+  "<style>",
+  "  body { margin: 0; display: grid; place-items: center; min-height: 100vh;",
+  "    font-family: system-ui, sans-serif; background: #0f1115; color: #e7e9ee; }",
+  "  .card { padding: 24px 28px; border-radius: 14px; background: #1a1d24;",
+  "    box-shadow: 0 8px 30px rgba(0,0,0,.4); }",
+  "</style>",
+  "</head>",
+  "<body>",
+  '  <div class="card"><h1>Hello, canvas</h1><p>Edit this HTML to sketch a UI.</p></div>',
+  "</body>",
+  "</html>",
+].join("\n");
+
+/** Validate/normalize a raw artifact record from disk or a request body. */
+export function sanitizeArtifact(value: unknown): CanvasArtifact | null {
+  if (!value || typeof value !== "object") return null;
+  const v = value as Record<string, unknown>;
+  const id = typeof v.id === "string" ? v.id.trim() : "";
+  if (!id) return null;
+  const prompt = typeof v.prompt === "string" ? v.prompt : "";
+  const code = clampArtifactCode(typeof v.code === "string" ? v.code : "");
+  const title = typeof v.title === "string" && v.title.trim() ? v.title.trim().slice(0, MAX_TITLE_CHARS) : titleFromPrompt(prompt);
+  const createdAt = typeof v.createdAt === "string" ? v.createdAt : "";
+  const updatedAt = typeof v.updatedAt === "string" ? v.updatedAt : createdAt;
+  return { id, title, prompt, code, createdAt, updatedAt };
+}
+
+/** Sanitize an array of artifact records, dropping any that are unusable. */
+export function sanitizeArtifacts(raw: unknown): CanvasArtifact[] {
+  if (!Array.isArray(raw)) return [];
+  const out: CanvasArtifact[] = [];
+  const seen = new Set<string>();
+  for (const entry of raw) {
+    const art = sanitizeArtifact(entry);
+    if (art && !seen.has(art.id)) {
+      seen.add(art.id);
+      out.push(art);
+    }
+  }
+  return out;
+}

--- a/src/lib/canvas-generate.test.ts
+++ b/src/lib/canvas-generate.test.ts
@@ -1,0 +1,27 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+
+import { parseSseFrame } from "./canvas-generate.ts";
+
+// parseSseFrame is the pure half of the streaming generator — it must tolerate
+// the exact frame shape /api/chat/send emits ("data: {json}") and shrug off
+// anything malformed without throwing.
+
+assert.deepEqual(
+  parseSseFrame('data: {"kind":"assistant_chunk","text":"hi"}'),
+  { kind: "assistant_chunk", text: "hi" },
+  "a well-formed data frame parses to its event",
+);
+
+assert.deepEqual(
+  parseSseFrame('data:{"kind":"done","sessionId":"s1"}'),
+  { kind: "done", sessionId: "s1" },
+  "no space after the colon is fine",
+);
+
+assert.equal(parseSseFrame(": keep-alive comment"), null, "SSE comments are ignored");
+assert.equal(parseSseFrame("event: ping"), null, "non-data lines are ignored");
+assert.equal(parseSseFrame("data: "), null, "empty data payload yields null");
+assert.equal(parseSseFrame("data: {not json"), null, "malformed JSON yields null, not a throw");
+
+console.log("canvas-generate.test.ts ✓");

--- a/src/lib/canvas-generate.ts
+++ b/src/lib/canvas-generate.ts
@@ -1,0 +1,108 @@
+// Client helper: ask a familiar to generate a self-contained UI document by
+// streaming /api/chat/send (the same chat bridge the Familiars surface uses —
+// Cave has no server-side LLM, so generation routes through the daemon agent).
+// The SSE frame parser is exported pure so it can be unit-tested.
+
+import { extractHtmlArtifact } from "@/lib/canvas-artifacts";
+
+export type SketchStreamEvent = {
+  kind?: string;
+  text?: string;
+  sessionId?: string;
+  isError?: boolean;
+  message?: string;
+};
+
+/** Parse one SSE frame ("data: {...}") into its event object, or null. */
+export function parseSseFrame(frame: string): SketchStreamEvent | null {
+  if (!frame.startsWith("data:")) return null;
+  const payload = frame.slice(5).trim();
+  if (!payload) return null;
+  try {
+    return JSON.parse(payload) as SketchStreamEvent;
+  } catch {
+    return null;
+  }
+}
+
+export type GenerateResult = {
+  code: string | null;
+  text: string;
+  sessionId: string | null;
+  error: string | null;
+};
+
+/**
+ * Send `prompt` to `familiarId` and collect the assistant's full text, then
+ * extract the HTML document from it. `onText` fires with the running text so
+ * the UI can show progress. The prompt is sent verbatim — callers wrap it with
+ * buildSketchPrompt / buildRefinePrompt before calling.
+ */
+export async function generateArtifactCode(opts: {
+  prompt: string;
+  familiarId: string;
+  projectRoot?: string | null;
+  signal?: AbortSignal;
+  onText?: (fullText: string) => void;
+}): Promise<GenerateResult> {
+  let res: Response;
+  try {
+    res = await fetch("/api/chat/send", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        familiarId: opts.familiarId,
+        prompt: opts.prompt,
+        projectRoot: opts.projectRoot ?? undefined,
+      }),
+      signal: opts.signal,
+    });
+  } catch (err) {
+    return { code: null, text: "", sessionId: null, error: (err as Error)?.message ?? "request failed" };
+  }
+  if (!res.ok || !res.body) {
+    return { code: null, text: "", sessionId: null, error: `chat bridge ${res.status}` };
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let text = "";
+  let sessionId: string | null = null;
+  let error: string | null = null;
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let idx;
+    while ((idx = buffer.indexOf("\n\n")) >= 0) {
+      const frame = buffer.slice(0, idx);
+      buffer = buffer.slice(idx + 2);
+      const ev = parseSseFrame(frame);
+      if (!ev) continue;
+      switch (ev.kind) {
+        case "assistant_chunk":
+          text += ev.text ?? "";
+          opts.onText?.(text);
+          break;
+        case "session":
+          sessionId = ev.sessionId ?? sessionId;
+          break;
+        case "done":
+          if (ev.sessionId) sessionId = ev.sessionId;
+          if (ev.isError) error = error ?? "the familiar reported an error";
+          break;
+        case "error":
+          error = ev.message ?? "generation error";
+          break;
+      }
+    }
+  }
+
+  const code = extractHtmlArtifact(text);
+  if (!code && !error) {
+    error = "The familiar didn't return an HTML document. Try rephrasing.";
+  }
+  return { code, text, sessionId, error };
+}

--- a/src/lib/cave-canvas.ts
+++ b/src/lib/cave-canvas.ts
@@ -11,12 +11,19 @@ import path from "node:path";
 import { homedir } from "node:os";
 
 import type { CanvasPosition, CanvasPositions } from "@/lib/canvas-layout";
+import { sanitizeArtifacts, type CanvasArtifact } from "@/lib/canvas-artifacts";
 
 const CANVAS_PATH = path.join(homedir(), ".coven", "cave-canvas.json");
 
-export type CanvasFile = { version: number; positions: CanvasPositions };
+export type CanvasFile = {
+  version: number;
+  positions: CanvasPositions;
+  // Sketch-layer artifacts: ad-hoc generated UI examples. Their positions live
+  // in the shared `positions` map (keyed by artifact id) like every other node.
+  artifacts: CanvasArtifact[];
+};
 
-const EMPTY: CanvasFile = { version: 1, positions: {} };
+const EMPTY: CanvasFile = { version: 1, positions: {}, artifacts: [] };
 
 /** Coerce an unknown value into a finite {x,y}, or null if unusable. */
 function asPosition(value: unknown): CanvasPosition | null {
@@ -56,7 +63,11 @@ export async function loadCanvas(): Promise<CanvasFile> {
     return { ...EMPTY };
   }
   const file = parsed as Partial<CanvasFile>;
-  return { version: file.version ?? 1, positions: sanitizePositions(file.positions) };
+  return {
+    version: file.version ?? 1,
+    positions: sanitizePositions(file.positions),
+    artifacts: sanitizeArtifacts(file.artifacts),
+  };
 }
 
 // Serialize writes: each mutation does load → merge → save, so without a lock
@@ -92,10 +103,48 @@ export async function mergeCanvasPositions(
   return withLock(async () => {
     const current = await loadCanvas();
     const merged: CanvasFile = {
-      version: current.version,
+      ...current,
       positions: { ...current.positions, ...clean },
     };
     await saveCanvas(merged);
     return merged;
   });
 }
+
+/**
+ * Insert or replace an artifact by id, returning the updated file. The caller's
+ * record is normalized through sanitizeArtifacts so a bad body can't corrupt
+ * the store. `updatedAt` is the caller's responsibility (it has the clock).
+ */
+export async function upsertCanvasArtifact(artifact: CanvasArtifact): Promise<CanvasFile> {
+  const [clean] = sanitizeArtifacts([artifact]);
+  if (!clean) {
+    // Nothing usable in the payload — return the current file unchanged.
+    return withLock(loadCanvas);
+  }
+  return withLock(async () => {
+    const current = await loadCanvas();
+    const without = current.artifacts.filter((a) => a.id !== clean.id);
+    const next: CanvasFile = { ...current, artifacts: [...without, clean] };
+    await saveCanvas(next);
+    return next;
+  });
+}
+
+/** Remove an artifact (and its saved position) by id. */
+export async function deleteCanvasArtifact(id: string): Promise<CanvasFile> {
+  return withLock(async () => {
+    const current = await loadCanvas();
+    const positions = { ...current.positions };
+    delete positions[id];
+    const next: CanvasFile = {
+      ...current,
+      positions,
+      artifacts: current.artifacts.filter((a) => a.id !== id),
+    };
+    await saveCanvas(next);
+    return next;
+  });
+}
+
+export type { CanvasArtifact } from "@/lib/canvas-artifacts";

--- a/src/styles/canvas.css
+++ b/src/styles/canvas.css
@@ -275,3 +275,234 @@
   font-size: var(--text-sm);
   max-width: 340px;
 }
+
+/* ── Sketch layer: segmented toggle ──────────────────────────────────────── */
+
+.canvas-segmented {
+  display: inline-flex;
+  padding: 2px;
+  gap: 2px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border-hairline);
+  border-radius: 8px;
+}
+
+.canvas-segmented__btn {
+  padding: 3px 12px;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-muted);
+  background: none;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.canvas-segmented__btn.is-active {
+  color: var(--text-primary);
+  background: var(--bg-panel);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+
+/* ── Sketch layer: prompt composer ───────────────────────────────────────── */
+
+.canvas-composer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: min(640px, 80vw);
+  margin-bottom: 16px;
+  padding: 10px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hairline);
+  border-radius: 12px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.22);
+}
+
+.canvas-composer__input {
+  width: 100%;
+  resize: none;
+  border: none;
+  background: none;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: var(--text-sm);
+  line-height: 1.45;
+  outline: none;
+}
+
+.canvas-composer__input::placeholder {
+  color: var(--text-muted);
+}
+
+.canvas-composer__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.canvas-composer__blank,
+.canvas-composer__send {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.canvas-composer__blank {
+  color: var(--text-secondary);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-hairline);
+}
+
+.canvas-composer__blank:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.canvas-composer__send {
+  color: var(--accent-foreground, #fff);
+  background: var(--accent, #6b8fbf);
+  border: 1px solid transparent;
+}
+
+.canvas-composer__send:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Artifact node ───────────────────────────────────────────────────────── */
+
+.canvas-artifact {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hairline);
+  border-radius: 12px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.16);
+}
+
+.canvas-artifact.is-selected {
+  border-color: var(--accent, #6b8fbf);
+}
+
+.canvas-artifact__grip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px 6px 10px;
+  background: var(--bg-raised);
+  border-bottom: 1px solid var(--border-hairline);
+  cursor: grab;
+}
+
+.canvas-artifact__grip:active {
+  cursor: grabbing;
+}
+
+.canvas-artifact__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  flex: 1;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.canvas-artifact__actions {
+  display: inline-flex;
+  gap: 2px;
+}
+
+.canvas-artifact__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  color: var(--text-muted);
+  background: none;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.canvas-artifact__btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.canvas-artifact__btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.canvas-artifact__btn--danger:hover {
+  color: #d2533e;
+}
+
+.canvas-artifact__body {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  background: #fff;
+}
+
+.canvas-artifact__frame {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+}
+
+.canvas-artifact__code {
+  width: 100%;
+  height: 100%;
+  resize: none;
+  border: 0;
+  padding: 10px;
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  outline: none;
+  white-space: pre;
+}
+
+.canvas-artifact__placeholder {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  background: var(--bg-panel);
+}
+
+.canvas-artifact__spinner {
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--border-strong);
+  border-top-color: var(--accent, #6b8fbf);
+  border-radius: 50%;
+  animation: canvas-spin 0.7s linear infinite;
+  flex: none;
+}
+
+@keyframes canvas-spin {
+  to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## What

Evolves the **Canvas** into a generative surface. A toolbar toggle switches between:

- **Triage** — the issue board from #948 (status bands, drag-to-retriage), unchanged.
- **Sketch** — describe a UI in the composer and a **familiar generates it** as a self-contained HTML document that renders live in a **sandboxed iframe** node. This is the ChatGPT/Codex Canvas pattern: generate → live preview → iterate, with multiple examples as tiles you can compare side by side.

Each artifact node supports: **code/preview toggle**, **Refine** (re-prompt the familiar to change it), **Duplicate** (make variations), **Open in browser**, **Delete**, and **resize**. A **Blank** button drops a starter document you can hand-write or paste into.

## How it works (and why this shape)

- **Generation** streams `/api/chat/send` to the active familiar with a strict "emit exactly one `<!doctype html>` document" instruction, then extracts the fenced doc. Cave has **no server-side LLM** — all generation routes through the daemon agent, so this reuses the same bridge the Familiars chat uses rather than inventing a new path.
- **Preview isolation**: `<iframe srcdoc sandbox="allow-scripts">` **without** `allow-same-origin` — generated/untrusted markup runs but can't touch Cave's origin, cookies, or storage. No bundler/transpiler dependency added; works offline. React/Tailwind can come via the familiar's own CDN `<script>`, or a follow-up can add a local transpiler.
- **Persistence**: artifacts live in the existing `~/.coven/cave-canvas.json` store via new `POST`/`DELETE` on `/api/canvas`; positions reuse the shared positions map (merge-on-write, atomic temp+rename).

## Touch points

- `src/lib/canvas-artifacts.ts` — pure: extract doc from a chat response, frame srcDoc, build sketch/refine prompts, sanitize, clamp.
- `src/lib/canvas-generate.ts` — stream `/api/chat/send`, accumulate assistant text, extract code (pure `parseSseFrame`).
- `src/lib/cave-canvas.ts` + `src/app/api/canvas/route.ts` — artifact persistence (GET returns artifacts; POST upsert; DELETE).
- `src/components/canvas-artifact-node.tsx` — the iframe/code node.
- `src/components/canvas-view.tsx` + `src/styles/canvas.css` — layer toggle, composer, generation, node assembly.

## Tests / verification

- New: `canvas-artifacts.test.ts` (extract/frame/prompt/sanitize), `canvas-generate.test.ts` (SSE frame parse); `canvas-view.test.ts` extended to **guard the iframe-sandbox isolation invariant** (asserts `allow-scripts` present and `allow-same-origin` absent) and the generation/persist wiring. `/canvas` contract updated to `GET/PUT/POST/DELETE`.
- Full `pnpm test:app` (287 files) + `test:api` (73) green; `tsc` clean; `pnpm build` succeeds.
- Live-smoke against the built server: `POST` persists an artifact, `DELETE` removes it, invalid-JSON and missing-id return guarded 400s, `GET` returns `{positions, artifacts}`.
- **Not** exercised end-to-end in a browser: the live familiar-generation round-trip (needs a running daemon + active familiar). The streaming wiring mirrors the existing chat consumer exactly and the parsing/extraction is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)