### PR TITLE
feat(code): layout presets (Chat / Split / Review)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -262,6 +262,7 @@ export const SUITES = {
     "src/lib/reading-hyphens.test.ts",
     "src/lib/reading-dropcap.test.ts",
     "src/lib/appearance-corner-radius.test.ts",
+    "src/lib/code-layout-preset.test.ts",
     "src/components/chat-surface-projects-tab.test.ts",
     "src/lib/memory-rows.test.ts",
     "src/components/familiars-memory-row.test.ts",

--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -30,6 +30,21 @@ assert.match(
 // Desktop keeps the two-pane resizable split under its own key.
 assert.match(codeView, /panelIds: \["code-chat", "code-comux"\]/, "desktop mounts both panels in the split");
 
+// ── Layout presets (Chat / Split / Review) re-weight the desktop split ───────
+// A preset toolbar resizes the chat panel imperatively (usePanelRef) — no
+// remount, so the comux terminals/preview keep their state. The chip selection
+// persists under its own key; pane sizes persist under CODE_GROUP_ID.
+assert.match(codeView, /usePanelRef/, "desktop uses a panel ref to drive presets");
+assert.match(codeView, /panelRef=\{chatPanelRef\}/, "the chat panel takes the preset handle via panelRef");
+assert.match(codeView, /chatPanelRef\.current\?\.resize\(CODE_PRESET_CHAT_SIZE\[/, "presets resize the chat panel (comux fills the rest)");
+assert.match(codeView, /writeCodePreset\(next\)/, "selecting a preset persists the chip");
+assert.match(
+  codeView,
+  /codeStorage\.getItem\(CODE_GROUP_ID\) == null/,
+  "the stored preset is applied only when no dragged layout exists (no clobbering manual drags)",
+);
+assert.match(codeView, /CODE_PRESETS\.map\(/, "the toolbar renders a chip per preset");
+
 // ── ComuxView accepts a storage namespace so Code-mode terminals are isolated ─
 assert.match(comux, /storageNamespace\?: string/, "ComuxView accepts a storageNamespace prop");
 assert.match(

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -1,10 +1,20 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
-import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { Group, Panel, Separator, useDefaultLayout, usePanelRef } from "react-resizable-panels";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
 import { Icon } from "@/lib/icon";
 import { useIsMobile } from "@/lib/use-viewport";
+import {
+  CODE_PRESET_CHAT_SIZE,
+  CODE_PRESET_ICONS,
+  CODE_PRESET_LABELS,
+  CODE_PRESETS,
+  DEFAULT_CODE_PRESET,
+  readCodePreset,
+  writeCodePreset,
+  type CodePreset,
+} from "@/lib/code-layout-preset";
 
 const CODE_GROUP_ID = "cave.code.widths.v1";
 
@@ -91,23 +101,79 @@ function DesktopCodeView({ chat, comux }: Props) {
     panelIds: ["code-chat", "code-comux"],
     storage: codeStorage,
   });
+  const chatPanelRef = usePanelRef();
+  // Tracks the highlighted chip. The actual sizes live in the panels' own
+  // persisted layout (CODE_GROUP_ID); this only records the last preset chosen.
+  const [preset, setPreset] = useState<CodePreset>(DEFAULT_CODE_PRESET);
+
+  useEffect(() => {
+    setPreset(readCodePreset());
+    // Apply the stored preset's width ONLY on a first-ever load (no dragged
+    // layout persisted yet), so we never clobber a manual drag on reload — the
+    // "default only when unstored" idiom. After this, useDefaultLayout restores
+    // the persisted sizes and the chip is purely cosmetic until the next click.
+    if (codeStorage.getItem(CODE_GROUP_ID) == null) {
+      chatPanelRef.current?.resize(CODE_PRESET_CHAT_SIZE[readCodePreset()]);
+    }
+    // run once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const applyPreset = (next: CodePreset) => {
+    setPreset(next);
+    writeCodePreset(next);
+    // Resize the chat panel; the comux pane fills the remainder (clamped to its
+    // own minSize). This goes through onLayoutChanged, so it persists — no
+    // remount, so the comux terminals/file preview keep their state.
+    chatPanelRef.current?.resize(CODE_PRESET_CHAT_SIZE[next]);
+  };
 
   return (
-    <Group
-      className="flex min-h-0 min-w-0 flex-1"
-      orientation="horizontal"
-      defaultLayout={defaultLayout}
-      onLayoutChanged={onLayoutChanged}
-    >
-      <Panel id="code-chat" className="flex min-h-0 min-w-0" defaultSize="38%" minSize="28%" maxSize="60%">
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col">{chat}</div>
-      </Panel>
-      <Separator className="shell-separator hidden lg:flex">
-        <SeparatorHandle orientation="col" />
-      </Separator>
-      <Panel id="code-comux" className="hidden min-h-0 min-w-0 lg:flex" minSize="35%">
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col">{comux}</div>
-      </Panel>
-    </Group>
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center justify-end gap-1 border-b border-[var(--border-hairline)] px-2 py-1">
+        <div className="flex items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 p-0.5 text-[11px]">
+          {CODE_PRESETS.map((p) => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => applyPreset(p)}
+              aria-pressed={preset === p}
+              title={`${CODE_PRESET_LABELS[p]} layout`}
+              className={`flex items-center gap-1.5 rounded-[5px] px-2.5 py-1 transition-colors ${
+                preset === p
+                  ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
+                  : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+              }`}
+            >
+              <Icon name={CODE_PRESET_ICONS[p]} width={13} />
+              {CODE_PRESET_LABELS[p]}
+            </button>
+          ))}
+        </div>
+      </div>
+      <Group
+        className="flex min-h-0 min-w-0 flex-1"
+        orientation="horizontal"
+        defaultLayout={defaultLayout}
+        onLayoutChanged={onLayoutChanged}
+      >
+        <Panel
+          panelRef={chatPanelRef}
+          id="code-chat"
+          className="flex min-h-0 min-w-0"
+          defaultSize="38%"
+          minSize="28%"
+          maxSize="75%"
+        >
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col">{chat}</div>
+        </Panel>
+        <Separator className="shell-separator hidden lg:flex">
+          <SeparatorHandle orientation="col" />
+        </Separator>
+        <Panel id="code-comux" className="hidden min-h-0 min-w-0 lg:flex" minSize="35%">
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col">{comux}</div>
+        </Panel>
+      </Group>
+    </div>
   );
 }

--- a/src/lib/code-layout-preset.test.ts
+++ b/src/lib/code-layout-preset.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import {
+  CODE_PRESET_CHAT_SIZE,
+  CODE_PRESET_ICONS,
+  CODE_PRESET_LABELS,
+  CODE_PRESET_KEY,
+  CODE_PRESETS,
+  DEFAULT_CODE_PRESET,
+  normalizeCodePreset,
+  readCodePreset,
+} from "./code-layout-preset.ts";
+
+assert.deepEqual([...CODE_PRESETS], ["chat", "split", "review"], "three presets, ordered");
+assert.equal(DEFAULT_CODE_PRESET, "split", "default is the balanced split");
+assert.equal(CODE_PRESET_KEY, "cave.code.preset.v1", "stable storage key");
+
+// normalizeCodePreset: pass through known, fall back to default otherwise.
+for (const p of CODE_PRESETS) {
+  assert.equal(normalizeCodePreset(p), p, `${p} passes through`);
+}
+assert.equal(normalizeCodePreset("bogus"), DEFAULT_CODE_PRESET, "unknown → default");
+assert.equal(normalizeCodePreset(undefined), DEFAULT_CODE_PRESET, "undefined → default");
+assert.equal(normalizeCodePreset(null), DEFAULT_CODE_PRESET, "null → default");
+
+// Every preset has a chat-pane width within the code-chat panel's 28%–75% band,
+// a label, and a whitelisted icon name.
+for (const p of CODE_PRESETS) {
+  const size = CODE_PRESET_CHAT_SIZE[p];
+  assert.match(size, /^\d+%$/, `${p} chat size is a percent string`);
+  const pct = Number.parseInt(size, 10);
+  assert.ok(pct >= 28 && pct <= 75, `${p} chat size ${size} is within the panel min/max band`);
+  assert.ok(CODE_PRESET_LABELS[p].length > 0, `${p} has a label`);
+  assert.match(CODE_PRESET_ICONS[p], /^ph:/, `${p} has a phosphor icon`);
+}
+
+// review gives comux the most room; chat the least; split sits between.
+const chatPct = (p: (typeof CODE_PRESETS)[number]) => Number.parseInt(CODE_PRESET_CHAT_SIZE[p], 10);
+assert.ok(chatPct("chat") > chatPct("split"), "chat preset is wider than split");
+assert.ok(chatPct("split") > chatPct("review"), "split is wider than review");
+
+// SSR / no-window: readCodePreset must not throw and returns the default.
+assert.equal(readCodePreset(), DEFAULT_CODE_PRESET, "readCodePreset is SSR-safe");
+
+console.log("code-layout-preset.test.ts: ok");

--- a/src/lib/code-layout-preset.ts
+++ b/src/lib/code-layout-preset.ts
@@ -1,0 +1,64 @@
+/**
+ * Layout presets for the Code workspace (mode "code"): quick re-weightings of
+ * the chat | comux split so the user can jump between conversation-heavy,
+ * balanced, and review-heavy layouts without dragging the separator.
+ *
+ * Mirrors src/lib/reading-width.ts: a small enum persisted in localStorage. The
+ * preset only records *which chip is selected*; the actual pane sizes live in
+ * react-resizable-panels' own persisted layout ("cave.code.widths.v1"), applied
+ * by resizing the chat panel to CODE_PRESET_CHAT_SIZE. Values stay inside the
+ * code-chat panel's min/max band (the comux pane fills the remainder, clamped to
+ * its own minSize), so a preset never produces an impossible layout.
+ */
+import type { IconName } from "@/lib/icon";
+
+export const CODE_PRESET_KEY = "cave.code.preset.v1";
+
+export const CODE_PRESETS = ["chat", "split", "review"] as const;
+
+export type CodePreset = (typeof CODE_PRESETS)[number];
+
+export const DEFAULT_CODE_PRESET: CodePreset = "split";
+
+/** Chat-pane width per preset; the comux pane fills what's left. */
+export const CODE_PRESET_CHAT_SIZE: Record<CodePreset, string> = {
+  chat: "65%", // conversation-forward (comux at its 35% min)
+  split: "45%", // balanced
+  review: "30%", // comux-forward for diff review
+};
+
+export const CODE_PRESET_LABELS: Record<CodePreset, string> = {
+  chat: "Chat",
+  split: "Split",
+  review: "Review",
+};
+
+export const CODE_PRESET_ICONS: Record<CodePreset, IconName> = {
+  chat: "ph:chats",
+  split: "ph:columns",
+  review: "ph:git-diff",
+};
+
+export function normalizeCodePreset(value: unknown): CodePreset {
+  return CODE_PRESETS.includes(value as CodePreset)
+    ? (value as CodePreset)
+    : DEFAULT_CODE_PRESET;
+}
+
+export function readCodePreset(): CodePreset {
+  if (typeof window === "undefined") return DEFAULT_CODE_PRESET;
+  try {
+    return normalizeCodePreset(window.localStorage.getItem(CODE_PRESET_KEY));
+  } catch {
+    return DEFAULT_CODE_PRESET;
+  }
+}
+
+export function writeCodePreset(preset: CodePreset): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(CODE_PRESET_KEY, normalizeCodePreset(preset));
+  } catch {
+    /* ignore unavailable storage */
+  }
+}


### PR DESCRIPTION
Phase 2 of the approved Code-surface redesign. Adds a preset toolbar to the desktop Code workspace so the chat | comux split can be re-weighted with one click instead of dragging the separator.

## Changes

- **New `src/lib/code-layout-preset.ts`** (mirrors `reading-width.ts`): a persisted enum — `chat` / `split` / `review` (default `split`) — mapping each preset to a chat-pane width inside the panel's min/max band. The comux pane fills the remainder (clamped to its own 35% min).
- **`code-view.tsx`** `DesktopCodeView` gains a segmented toolbar that resizes the chat panel imperatively via `usePanelRef().resize()` — **no remount**, so the comux terminals/file preview keep their state. Selecting a preset persists the chip; the stored preset is applied on mount **only when no dragged layout exists**, so manual drags aren't clobbered on reload. Chat panel `maxSize` raised 60%→75% so the "Chat" preset can give the transcript real width.
- Presets are **desktop-only**; the mobile Chat/Code switcher is untouched.

## Verify

- `tsc --noEmit` clean; `check:tests-wired` green (375 wired).
- New `code-layout-preset.test.ts` (enum/normalize/size-band/ordering, SSR-safe) registered in `run-tests.mjs`.
- `code-view.test.ts` asserts the toolbar, `usePanelRef`/`panelRef` wiring, `resize(CODE_PRESET_CHAT_SIZE[...])`, and the default-only-when-unstored guard.

Builds on the Code-surface redesign plan; independent of PR #951 (no file overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)