### PR TITLE
feat(code): diff-first review — auto-open Changes when the agent edits

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -263,6 +263,7 @@ export const SUITES = {
     "src/lib/reading-dropcap.test.ts",
     "src/lib/appearance-corner-radius.test.ts",
     "src/lib/code-layout-preset.test.ts",
+    "src/lib/use-changes-summary.test.ts",
     "src/components/chat-surface-projects-tab.test.ts",
     "src/lib/memory-rows.test.ts",
     "src/components/familiars-memory-row.test.ts",

--- a/src/components/comux-view-changes.test.ts
+++ b/src/components/comux-view-changes.test.ts
@@ -24,15 +24,32 @@ assert.match(
   "comux renders SessionChangesInner for the selected project, polling while a session runs",
 );
 
-// A right-pane view toggle drives it.
+// A right-pane view toggle drives it. Clicking a toggle pins the choice so the
+// diff-first auto-switch won't override an explicit selection.
 assert.match(comux, /useState<"files" \| "changes">\("files"\)/, "right pane defaults to the Files view");
-assert.match(comux, /onClick=\{\(\) => setRightView\("changes"\)\}/, "a Changes toggle switches the right pane");
-assert.match(comux, /onClick=\{\(\) => setRightView\("files"\)\}/, "a Files toggle switches back");
+assert.match(comux, /pinnedRightViewRef\.current = true; setRightView\("changes"\)/, "Changes toggle switches + pins the view");
+assert.match(comux, /pinnedRightViewRef\.current = true; setRightView\("files"\)/, "Files toggle switches + pins the view");
 assert.match(
   comux,
   /rightView === "changes" \? \([\s\S]*?<SessionChangesInner/,
   "the Changes view replaces the file preview when selected",
 );
+
+// Diff-first review: the comux pane polls a lightweight changes summary and
+// auto-switches to Changes the first time edits appear (0 → >0), unless pinned.
+assert.match(comux, /import \{ useChangesSummary \} from "@\/lib\/use-changes-summary"/, "comux uses the changes-summary hook");
+assert.match(
+  comux,
+  /useChangesSummary\(\s*selectedProject\?\.root,\s*rightView !== "changes" && projectHasRunningSession,/,
+  "the summary poll is gated to Files view + a running session (pauses when Changes is shown)",
+);
+assert.match(
+  comux,
+  /!pinnedRightViewRef\.current &&[\s\S]*?rightView === "files" &&[\s\S]*?prev === 0 &&[\s\S]*?changesSummary\.count > 0[\s\S]*?setRightView\("changes"\)/,
+  "auto-switch to Changes on the first edit transition when the user hasn't pinned a view",
+);
+
+console.log("comux-view-changes.test.ts (diff-first) checks passed");
 
 // Polling flag is derived from a running session in the selected project.
 assert.match(

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -8,6 +8,7 @@ import { copyText } from "@/lib/clipboard";
 import { ProjectTree, type ProjectTreeHandle } from "@/components/project-tree";
 import { MarkdownBlock, SyntaxBlock } from "@/components/message-bubble";
 import { SessionChangesInner } from "@/components/session-changes-panel";
+import { useChangesSummary } from "@/lib/use-changes-summary";
 import { CodeEditor } from "@/components/code-editor";
 import { resolveLangLabel } from "@/lib/code-lang";
 import type { SearchResult } from "@/lib/project-search";
@@ -285,6 +286,12 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   const [sessionsCollapsed, setSessionsCollapsed] = useState(false);
   // Right pane view: the file preview, or the project's git changes/diff review.
   const [rightView, setRightView] = useState<"files" | "changes">("files");
+  // Diff-first review: auto-switch to Changes the first time an agent run
+  // produces edits — but never fight an explicit user choice. pinnedRightView
+  // flips once the user clicks a toggle or opens a file; prevChangeCount tracks
+  // the 0→>0 edit transition so we surface the diff exactly once per project.
+  const pinnedRightViewRef = useRef(false);
+  const prevChangeCountRef = useRef(0);
   // Project-wide code search (CODE-SEARCH-01).
   const [searchInput, setSearchInput] = useState("");
   const [searchRegex, setSearchRegex] = useState(false);
@@ -557,6 +564,9 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
         : selectedRoot
           ? `${selectedRoot.replace(/\/$/, "")}/${detail.path.replace(/^\.?\//, "")}`
           : detail.path;
+      // A user-initiated file open is an explicit view choice — pin it so the
+      // diff-first auto-switch doesn't yank them back to Changes.
+      pinnedRightViewRef.current = true;
       setRightView("files");
       void openFilePreview(path, typeof detail.line === "number" ? detail.line : undefined);
     };
@@ -690,6 +700,33 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   // Poll the diff while a familiar is actively working this project so the
   // Changes view reflects edits as they land.
   const projectHasRunningSession = recentProjectSessions.some((s) => s.status === "running");
+
+  // Diff-first review: poll a lightweight changes summary while Files is showing
+  // and a familiar is working this project, and flip to the Changes/diff view
+  // the first time edits appear — unless the user pinned a view. The poll pauses
+  // once Changes is shown (SessionChangesInner takes over its own polling).
+  const changesSummary = useChangesSummary(
+    selectedProject?.root,
+    rightView !== "changes" && projectHasRunningSession,
+  );
+  useEffect(() => {
+    // Reset the diff-first decision when switching projects.
+    pinnedRightViewRef.current = false;
+    prevChangeCountRef.current = 0;
+  }, [selectedProject?.root]);
+  useEffect(() => {
+    const prev = prevChangeCountRef.current;
+    prevChangeCountRef.current = changesSummary.count;
+    if (
+      !pinnedRightViewRef.current &&
+      rightView === "files" &&
+      prev === 0 &&
+      changesSummary.count > 0
+    ) {
+      setRightView("changes");
+    }
+  }, [changesSummary.count, rightView]);
+
   const previewIsMarkdown = preview?.kind === "text" && isMarkdownPath(previewPath);
   const previewLineCount = preview?.kind === "text" ? preview.content.split("\n").length : 0;
   const renderAsMarkdown = previewIsMarkdown && !previewRaw;
@@ -1213,7 +1250,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                     <div className="flex items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 p-0.5 text-[10px]">
                       <button
                         type="button"
-                        onClick={() => setRightView("files")}
+                        onClick={() => { pinnedRightViewRef.current = true; setRightView("files"); }}
                         className={`flex items-center gap-1 rounded-[4px] px-2 py-0.5 transition-colors ${rightView === "files" ? "bg-[var(--bg-raised)] text-[var(--text-primary)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"}`}
                       >
                         <Icon name="ph:file-code" width={11} />
@@ -1221,7 +1258,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                       </button>
                       <button
                         type="button"
-                        onClick={() => setRightView("changes")}
+                        onClick={() => { pinnedRightViewRef.current = true; setRightView("changes"); }}
                         className={`flex items-center gap-1 rounded-[4px] px-2 py-0.5 transition-colors ${rightView === "changes" ? "bg-[var(--bg-raised)] text-[var(--text-primary)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"}`}
                       >
                         <Icon name="ph:git-diff" width={11} />

--- a/src/lib/use-changes-summary.test.ts
+++ b/src/lib/use-changes-summary.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// useChangesSummary is the lightweight "are there uncommitted edits?" signal
+// that drives the Code surface's diff-first auto-switch. It must mirror
+// SessionChangesInner's poll discipline and never double-poll.
+const src = readFileSync(new URL("./use-changes-summary.ts", import.meta.url), "utf8");
+
+assert.match(src, /POLL_MS = 5000/, "5s interval matches SessionChangesInner");
+assert.match(
+  src,
+  /if \(!active \|\| !projectRoot\) return/,
+  "gated on active + projectRoot so it pauses once the full panel takes over polling",
+);
+assert.match(src, /document\.visibilityState !== "visible"/, "skips work while the document is hidden");
+assert.match(src, /inFlight\.current/, "single-flight guard prevents overlapping requests");
+assert.match(src, /`\/api\/changes\?projectRoot=\$\{encodeURIComponent\(projectRoot\)\}`/, "hits /api/changes for the root");
+assert.doesNotMatch(src, /&path=/, "summary request omits a file path — it only needs the count");
+assert.match(src, /window\.setInterval\(load, POLL_MS\)/, "polls on the interval");
+assert.match(src, /window\.clearInterval\(id\)/, "clears the interval on cleanup");
+assert.match(src, /document\.removeEventListener\("visibilitychange"/, "removes the visibility listener on cleanup");
+assert.match(src, /Array\.isArray\(json\.files\) \? json\.files\.length : 0/, "count is the changed-file list length");
+
+console.log("use-changes-summary.test.ts: ok");

--- a/src/lib/use-changes-summary.ts
+++ b/src/lib/use-changes-summary.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Lightweight "are there uncommitted edits?" signal for a project root, without
+ * mounting the full SessionChangesPanel. Drives the Code surface's diff-first
+ * default: the comux pane auto-switches to the Changes/diff view the moment an
+ * agent run produces edits.
+ *
+ * Mirrors the poll discipline of SessionChangesInner.load
+ * (src/components/session-changes-panel.tsx): same /api/changes endpoint, the
+ * same 5s interval, document-visibility gating, and a single-flight guard. It is
+ * `active`-gated so it pauses (no redundant polling) once the full panel is
+ * shown and takes over polling itself.
+ */
+const POLL_MS = 5000;
+
+type ChangesSummary = {
+  /** Number of changed files (0 when clean, when not a repo, or before load). */
+  count: number;
+  /** True once the first fetch has settled. */
+  loaded: boolean;
+  /** The root is not a git repo (no diffs to show). */
+  notARepo: boolean;
+};
+
+type ChangesResponse = {
+  ok?: boolean;
+  repo?: boolean;
+  files?: unknown[];
+};
+
+export function useChangesSummary(
+  projectRoot: string | undefined,
+  active: boolean,
+): ChangesSummary {
+  const [count, setCount] = useState(0);
+  const [loaded, setLoaded] = useState(false);
+  const [notARepo, setNotARepo] = useState(false);
+  const inFlight = useRef(false);
+
+  useEffect(() => {
+    if (!active || !projectRoot) return;
+
+    let cancelled = false;
+    const load = async () => {
+      if (inFlight.current) return;
+      if (document.visibilityState !== "visible") return;
+      inFlight.current = true;
+      try {
+        const res = await fetch(
+          `/api/changes?projectRoot=${encodeURIComponent(projectRoot)}`,
+          { cache: "no-store" },
+        );
+        const json = (await res.json()) as ChangesResponse;
+        if (cancelled) return;
+        if (res.ok && json.ok) {
+          setNotARepo(json.repo === false);
+          setCount(Array.isArray(json.files) ? json.files.length : 0);
+        }
+      } catch {
+        /* transient — keep the last known summary */
+      } finally {
+        inFlight.current = false;
+        if (!cancelled) setLoaded(true);
+      }
+    };
+
+    void load();
+    const onVisible = () => {
+      if (document.visibilityState === "visible") void load();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    const id = window.setInterval(load, POLL_MS);
+    return () => {
+      cancelled = true;
+      document.removeEventListener("visibilitychange", onVisible);
+      window.clearInterval(id);
+    };
+  }, [projectRoot, active]);
+
+  return { count, loaded, notARepo };
+}


### PR DESCRIPTION
Phase 3 of the approved Code-surface redesign. In agentic coding, reviewing the agent's edits is the primary act — but the comux right pane defaulted to an empty "Select a file to preview" while the diff sat behind the Files/Changes toggle.

## Changes

- **New `src/lib/use-changes-summary.ts`** — a lightweight "are there uncommitted edits?" hook for a project root, without mounting the full `SessionChangesPanel`. Mirrors `SessionChangesInner`'s poll discipline (same `/api/changes` endpoint, 5s interval, document-visibility gating, single-flight) and is **`active`-gated so it pauses once the full Changes panel is shown** and takes over its own polling — no double-polling.
- **`comux-view.tsx`** auto-switches the right pane to **Changes** the first time edits appear (count 0 → >0) while Files is showing and a session is running. A **pin** (set when the user clicks the Files/Changes toggle or opens a file from the transcript) ensures the auto-switch never overrides an explicit choice; the decision resets per project.

## Scope

Scoped to the headline diff-first behavior so it stays reviewable. Two follow-ups (Phase 3b) from the plan: the chat-surface change-count badge, and the transcript-tool → diff jump (`cave:open-file-diff` + `focusPath`).

## Verify

- `tsc --noEmit` clean; `check:tests-wired` green (376 wired).
- New `use-changes-summary.test.ts` (poll discipline, no `&path=`, cleanup).
- `comux-view-changes.test.ts` asserts the hook wiring, the gated poll, and the pinned auto-switch (existing `SessionChangesInner` assertions preserved).

Builds on #951 (Phase 0+1) and #954 (Phase 2), both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)