### PR TITLE
feat(code): persistent run-activity strip above the transcript

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -75,6 +75,7 @@ export const SUITES = {
     "src/components/message-bubble-file-links.test.ts",
     "src/components/library-reader-polish.test.ts",
     "src/components/chat-view-polish.test.ts",
+    "src/components/run-activity-strip.test.ts",
     "src/components/chat-view-lifecycle.test.ts",
     "src/components/chat-view-render-optimization.test.ts",
     "src/components/csv-import-modal.test.ts",

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3046,6 +3046,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         </MetaLine>
         <LinkedContextRow linkedContext={linkedContext} onOpenTask={onOpenTask} />
       </header>
+      <RunActivityStrip activeTurn={activePendingTurn} lastTurn={lastSettledAssistantTurn} />
       <div ref={scrollRef} tabIndex={0} className="cave-chat-transcript relative min-h-0 flex-1 overflow-y-auto">
         <div
           className="cave-chat-thread"
@@ -3830,6 +3831,15 @@ function ReasoningBlock({ reasoning }: { reasoning: string }) {
   );
 }
 
+/** The step to surface as "what's happening now": the most recent running
+ *  event, else the last event. Shared by ProgressGroup and RunActivityStrip. */
+function currentProgress(progress: ProgressEvent[]): ProgressEvent | undefined {
+  return (
+    [...progress].reverse().find((event) => event.status === "running") ??
+    progress[progress.length - 1]
+  );
+}
+
 function ProgressGroup({
   progress,
   pending,
@@ -3840,9 +3850,7 @@ function ProgressGroup({
   const running = progress.filter((event) => event.status === "running").length;
   const errors = progress.filter((event) => event.status === "error").length;
   const completed = progress.length - running - errors;
-  const current =
-    [...progress].reverse().find((event) => event.status === "running") ??
-    progress[progress.length - 1];
+  const current = currentProgress(progress);
 
   return (
     <details className="cave-progress-group mt-3" data-default-collapsed="true" open={pending || undefined}>
@@ -4036,6 +4044,100 @@ function AttachmentLightbox({ attachment, onClose }: { attachment: ChatAttachmen
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+/**
+ * Persistent run-activity strip (pinned above the transcript). Surfaces what the
+ * agent is doing *now* — the running tool (with its arg summary) or current
+ * plan/todo step, plus running/done/issue counts — and, unlike the inline
+ * per-turn ProgressGroup (hidden after settle, CHAT-D13-01), keeps a compact,
+ * dismissible "last run" summary after the turn settles. Click to expand the
+ * full ProgressGroup + tool list. Reads live turn data directly, so it works for
+ * both segmented and legacy turns.
+ */
+function RunActivityStrip({
+  activeTurn,
+  lastTurn,
+}: {
+  activeTurn: Turn | undefined;
+  lastTurn: Turn | undefined;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [dismissedId, setDismissedId] = useState<string | null>(null);
+  const live = !!activeTurn;
+  const turn = activeTurn ?? lastTurn;
+  if (!turn) return null;
+  if (!live && dismissedId === turn.id) return null;
+
+  const tools = turn.tools ?? [];
+  const progress = turn.progress ?? [];
+  if (tools.length === 0 && progress.length === 0) return null;
+
+  const runningTool = [...tools].reverse().find((t) => t.status === "running");
+  const step = currentProgress(progress);
+  const running =
+    tools.filter((t) => t.status === "running").length +
+    progress.filter((p) => p.status === "running").length;
+  const issues =
+    tools.filter((t) => t.status === "error").length +
+    progress.filter((p) => p.status === "error").length;
+  const done =
+    tools.filter((t) => t.status === "ok").length +
+    progress.filter((p) => p.status === "done").length;
+
+  let headline: string;
+  if (live && runningTool) {
+    const arg = toolArgSummary(runningTool.name, runningTool.input);
+    headline = arg ? `${runningTool.name} · ${arg}` : runningTool.name;
+  } else if (live) {
+    headline = step?.label ?? "Working…";
+  } else {
+    headline = step?.label ?? "Last run";
+  }
+
+  return (
+    <div className="cave-run-activity shrink-0 border-b border-[var(--border-hairline)] bg-[var(--bg-base)]/60 px-3 py-1.5 text-[11px]">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => setExpanded((e) => !e)}
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+          aria-expanded={expanded}
+          aria-label={live ? "Agent activity (running)" : "Last run summary"}
+        >
+          <Icon
+            name={live ? "ph:circle-dashed" : issues ? "ph:warning-circle" : "ph:check-circle"}
+            width={13}
+            className={`shrink-0 ${live ? "animate-spin text-[var(--accent-presence)]" : issues ? "text-[var(--color-warning)]" : "text-[var(--color-success)]"}`}
+            aria-hidden
+          />
+          <span className="min-w-0 flex-1 truncate text-[var(--text-secondary)]">{headline}</span>
+          <span className="flex shrink-0 items-center gap-1.5 font-mono text-[10px] text-[var(--text-muted)]">
+            {running ? <span className="cave-tool-count cave-tool-count--running">{running} running</span> : null}
+            {issues ? <span className="cave-tool-count cave-tool-count--error">{issues} {issues === 1 ? "issue" : "issues"}</span> : null}
+            {done ? <span className="cave-tool-count">{done} done</span> : null}
+          </span>
+          <Icon name={expanded ? "ph:caret-up" : "ph:caret-down"} width={11} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
+        </button>
+        {!live ? (
+          <button
+            type="button"
+            onClick={() => setDismissedId(turn.id)}
+            className="shrink-0 rounded p-0.5 text-[var(--text-muted)] transition-colors hover:text-[var(--text-secondary)]"
+            aria-label="Dismiss last run summary"
+          >
+            <Icon name="ph:x" width={11} aria-hidden />
+          </button>
+        ) : null}
+      </div>
+      {expanded ? (
+        <div className="mt-1.5">
+          {progress.length ? <ProgressGroup progress={progress} pending={live} /> : null}
+          {tools.length ? <ToolGroup tools={tools} /> : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/components/run-activity-strip.test.ts
+++ b/src/components/run-activity-strip.test.ts
@@ -1,0 +1,31 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// RunActivityStrip: a persistent, compact "what's the agent doing now" strip
+// pinned above the transcript, with a dismissible last-run summary after settle.
+const src = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+
+// currentProgress is extracted from ProgressGroup and shared with the strip.
+assert.match(src, /function currentProgress\(progress: ProgressEvent\[\]\)/, "currentProgress helper is extracted");
+assert.match(src, /const current = currentProgress\(progress\)/, "ProgressGroup reuses currentProgress");
+
+assert.match(src, /function RunActivityStrip\(/, "RunActivityStrip component exists");
+assert.match(src, /const live = !!activeTurn/, "strip is live while a turn is pending");
+assert.match(src, /const turn = activeTurn \?\? lastTurn/, "falls back to the last settled turn after settle");
+assert.match(src, /dismissedId === turn\.id/, "the settled last-run summary is dismissible");
+assert.match(src, /toolArgSummary\(runningTool\.name, runningTool\.input\)/, "headline shows the running tool's arg summary");
+
+// Reads live turn data directly (not via segmentTurn) so it works for legacy
+// non-segmented turns too.
+assert.match(src, /const tools = turn\.tools \?\? \[\]/, "reads turn.tools directly");
+assert.match(src, /const progress = turn\.progress \?\? \[\]/, "reads turn.progress directly");
+
+// Mounted above the transcript, fed by the active + last-settled turns.
+assert.match(
+  src,
+  /<RunActivityStrip activeTurn=\{activePendingTurn\} lastTurn=\{lastSettledAssistantTurn\} \/>/,
+  "RunActivityStrip is mounted above the transcript",
+);
+
+console.log("run-activity-strip.test.ts: ok");


### PR DESCRIPTION
Phase 4 of the approved Code-surface redesign. Tool calls and plan/todo progress were buried inside the streaming turn and hidden after settle (CHAT-D13-01), so "what is the agent doing now" wasn't visible at a glance.

## Changes

- Extracts `ProgressGroup`'s current-step logic into a shared **`currentProgress()`** helper.
- **New `RunActivityStrip`** pinned above the transcript: shows the running tool (with its `toolArgSummary`) or the current plan/todo step, plus running/done/issue counts; click to expand the full `ProgressGroup` + tool list. Unlike the inline per-turn rendering, it keeps a compact, **dismissible "last run" summary after the turn settles**. Reads `turn.tools`/`turn.progress` directly so it works for both segmented and legacy turns; driven by the active pending turn, falling back to the last settled assistant turn.

Additive — the inline `ProgressGroup`/`ToolBlock`/"N tools" chip are untouched. Placed after `AttachmentLightbox` so the `chat-view-polish` `TurnRow…AttachmentLightbox` anchor regex is unaffected.

## Verify

- `tsc --noEmit` clean; `check:tests-wired` green (379 wired).
- New `run-activity-strip.test.ts`; `chat-view` + `chat-view-polish` suites pass.

Builds on #951 / #954 / #955 (all merged). Next: Phase 5 (denser composer) and the deferred Phase 3b (change badge + transcript→diff jump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)