### PR TITLE
feat(code): denser composer controls in the narrow Code column

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -267,6 +267,7 @@ export const SUITES = {
     "src/lib/code-layout-preset.test.ts",
     "src/lib/use-changes-summary.test.ts",
     "src/components/chat-surface-projects-tab.test.ts",
+    "src/components/composer-density.test.ts",
     "src/lib/memory-rows.test.ts",
     "src/components/familiars-memory-row.test.ts",
     "src/components/familiars-memory-reader.test.ts",

--- a/src/components/composer-density.test.ts
+++ b/src/components/composer-density.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// Composer density: in the narrow Code-mode chat column the model + Thinking +
+// Speed pills wrapped to 2–3 lines. A container query on the composer collapses
+// the control labels and shrinks the model pill so they stay on one row, while
+// the wide standalone-chat composer keeps the full labels.
+const css = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
+
+assert.match(
+  css,
+  /\.cave-composer-controls \{[\s\S]*?container-type: inline-size;[\s\S]*?container-name: composer;/,
+  "the composer controls is a named inline-size query container",
+);
+assert.match(
+  css,
+  /@container composer \(max-width: 480px\) \{[\s\S]*?\.cave-composer-select__label \{\s*display: none;/,
+  "a narrow composer collapses the Thinking/Speed labels (value still shows)",
+);
+assert.match(
+  css,
+  /@container composer \(max-width: 480px\) \{[\s\S]*?cave-chat-model-wrap \{\s*flex: 1 1 120px/,
+  "the model pill shrinks when the composer is narrow",
+);
+
+console.log("composer-density.test.ts: ok");

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1546,6 +1546,10 @@ details[open] > .cave-tool-summary::before {
   flex-direction: column;
   gap: 0;
   padding: 0 12px 12px;
+  /* Container for the settings-row density query below: in the narrow Code-mode
+     column the model + Thinking + Speed pills used to wrap to 2–3 lines. */
+  container-type: inline-size;
+  container-name: composer;
 }
 
 .cave-composer-action-row {
@@ -1655,6 +1659,23 @@ details[open] > .cave-tool-summary::before {
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Density: when the composer column is narrow (notably the Code-mode chat pane),
+   drop the "Thinking"/"Speed" control labels — the icon + value still show — and
+   let the model pill shrink, so model + Thinking + Speed stay on one row instead
+   of wrapping to two or three. The wide standalone-chat composer is unaffected. */
+@container composer (max-width: 480px) {
+  .cave-composer-settings-row {
+    gap: 6px;
+  }
+  .cave-composer-select__label {
+    display: none;
+  }
+  .cave-composer-settings-row .cave-chat-model-wrap {
+    flex: 1 1 120px;
+    min-width: 92px;
+  }
 }
 
 .cave-composer-select select {


### PR DESCRIPTION
Phase 5 of the approved Code-surface redesign. The composer's model + Thinking + Speed pills are a `flex-wrap` row, so in the narrow Code-mode chat column they wrapped to two or three lines, eating vertical space.

## Changes (CSS-only)

- Make `.cave-composer-controls` a named **inline-size container**.
- `@container composer (max-width: 480px)`: collapse the **Thinking/Speed labels** (icon + value still show) and let the model pill shrink, so the controls stay on **one row** when the column is narrow. The wide standalone-chat composer keeps the full labels.

No JSX, send/attach, or mobile-layout changes — the mobile `@media` 3-col grid is untouched.

## Verify

- New `composer-density.test.ts` asserts the container + collapse rules.
- `chat-view-mobile-command-center` suite still passes; `check:tests-wired` green (379).

Independent of the other phase PRs (CSS file only). Builds on the merged #951/#954/#955; pairs with #956 (Phase 4, in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)