### PR TITLE
feat(code): jump from a transcript edit tool to its diff

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3921,11 +3921,19 @@ function ToolBlock({ tool }: { tool: ToolEvent }) {
   // Dispatched as an event; the comux pane (Code/Terminal) handles it, and the
   // workspace switches to Code mode first when neither is showing.
   const targetFile = toolTargetFile(tool.name, tool.input);
+  // An edit tool (Edit/Write/MultiEdit/NotebookEdit — the ones with a structured
+  // input diff) jumps to its file's DIFF in the Changes review; other file tools
+  // open the file preview. The comux pane handles both events.
+  const isEditTool = inputDiff != null;
   const openTargetFile = (e: ReactMouseEvent) => {
     if (!targetFile) return;
     e.preventDefault();
     e.stopPropagation();
-    window.dispatchEvent(new CustomEvent("cave:open-project-file", { detail: { path: targetFile } }));
+    window.dispatchEvent(
+      new CustomEvent(isEditTool ? "cave:open-file-diff" : "cave:open-project-file", {
+        detail: { path: targetFile },
+      }),
+    );
   };
   return (
     <details className="cave-tool-block" data-default-collapsed="true">
@@ -3937,11 +3945,11 @@ function ToolBlock({ tool }: { tool: ToolEvent }) {
             <button
               type="button"
               onClick={openTargetFile}
-              title={`Open ${targetFile} in the Code workspace`}
+              title={isEditTool ? `View diff for ${targetFile}` : `Open ${targetFile} in the Code workspace`}
               className="group/openfile inline-flex min-w-0 max-w-[18rem] items-center gap-1 truncate font-mono text-[var(--text-muted)] hover:text-[var(--accent-presence,var(--text-secondary))] hover:underline"
             >
               <span className="truncate">· {argSummary}</span>
-              <Icon name="ph:arrow-square-out" width={10} className="shrink-0 opacity-0 transition-opacity group-hover/openfile:opacity-100" aria-hidden />
+              <Icon name={isEditTool ? "ph:git-diff" : "ph:arrow-square-out"} width={10} className="shrink-0 opacity-0 transition-opacity group-hover/openfile:opacity-100" aria-hidden />
             </button>
           ) : (
             <span className="min-w-0 max-w-[18rem] truncate font-mono text-[var(--text-muted)]">· {argSummary}</span>

--- a/src/components/comux-view-changes.test.ts
+++ b/src/components/comux-view-changes.test.ts
@@ -11,8 +11,18 @@ const changes = await readFile(new URL("./session-changes-panel.tsx", import.met
 // The reusable inner panel is exported for embedding.
 assert.match(
   changes,
-  /export function SessionChangesInner\(\{ projectRoot, running \}/,
+  /export function SessionChangesInner\(\{\s*projectRoot,\s*running/,
   "SessionChangesInner must be exported so other surfaces can embed the diff review",
+);
+
+// Jump-to-diff: SessionChangesInner accepts focusPath/focusNonce and expands the
+// matching file's diff (repo-relative or suffix match) when a transcript edit
+// tool is clicked.
+assert.match(changes, /focusPath\?: string \| null;/, "SessionChangesInner takes a focusPath prop");
+assert.match(
+  changes,
+  /focusPath\.endsWith\(f\.path\) \|\| f\.path\.endsWith\(focusPath\)/,
+  "focusPath matches repo-relative or absolute paths by suffix",
 );
 
 // comux imports it and renders it for the SELECTED project (not the active
@@ -47,6 +57,24 @@ assert.match(
   comux,
   /!pinnedRightViewRef\.current &&[\s\S]*?rightView === "files" &&[\s\S]*?prev === 0 &&[\s\S]*?changesSummary\.count > 0[\s\S]*?setRightView\("changes"\)/,
   "auto-switch to Changes on the first edit transition when the user hasn't pinned a view",
+);
+
+// Transcript edit tool → diff jump: comux listens for cave:open-file-diff,
+// pins + switches to Changes, and focuses the file via a nonce.
+assert.match(comux, /window\.addEventListener\("cave:open-file-diff"/, "comux listens for the open-file-diff jump");
+assert.match(
+  comux,
+  /setRightView\("changes"\);\s*setFocusDiff\(\(prev\) => \(\{ path: detail\.path!, nonce: \(prev\?\.nonce \?\? 0\) \+ 1 \}\)\)/,
+  "open-file-diff pins Changes and bumps the focus nonce",
+);
+assert.match(comux, /focusPath=\{focusDiff\?\.path \?\? null\}[\s\S]*?focusNonce=\{focusDiff\?\.nonce\}/, "focus is forwarded to SessionChangesInner");
+
+const chatView = await readFile(new URL("./chat-view.tsx", import.meta.url), "utf8");
+assert.match(chatView, /const isEditTool = inputDiff != null/, "ToolBlock detects edit tools by their input diff");
+assert.match(
+  chatView,
+  /isEditTool \? "cave:open-file-diff" : "cave:open-project-file"/,
+  "edit tools jump to the diff; other file tools open the preview",
 );
 
 console.log("comux-view-changes.test.ts (diff-first) checks passed");

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -291,6 +291,9 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   // flips once the user clicks a toggle or opens a file; prevChangeCount tracks
   // the 0→>0 edit transition so we surface the diff exactly once per project.
   const pinnedRightViewRef = useRef(false);
+  // Jump-to-diff target from a transcript edit tool (cave:open-file-diff). The
+  // nonce re-triggers the focus even when the same path is clicked again.
+  const [focusDiff, setFocusDiff] = useState<{ path: string; nonce: number } | null>(null);
   const prevChangeCountRef = useRef(0);
   // Project-wide code search (CODE-SEARCH-01).
   const [searchInput, setSearchInput] = useState("");
@@ -570,8 +573,22 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
       setRightView("files");
       void openFilePreview(path, typeof detail.line === "number" ? detail.line : undefined);
     };
+    // Edit tools jump to their file's diff in the Changes review instead of the
+    // file preview. Pin Changes and focus that file (matched repo-relative or
+    // by suffix inside SessionChangesInner).
+    const onOpenDiff = (event: Event) => {
+      const detail = (event as CustomEvent<{ path?: string }>).detail;
+      if (!detail?.path) return;
+      pinnedRightViewRef.current = true;
+      setRightView("changes");
+      setFocusDiff((prev) => ({ path: detail.path!, nonce: (prev?.nonce ?? 0) + 1 }));
+    };
     window.addEventListener("cave:open-project-file", onOpenFile as EventListener);
-    return () => window.removeEventListener("cave:open-project-file", onOpenFile as EventListener);
+    window.addEventListener("cave:open-file-diff", onOpenDiff as EventListener);
+    return () => {
+      window.removeEventListener("cave:open-project-file", onOpenFile as EventListener);
+      window.removeEventListener("cave:open-file-diff", onOpenDiff as EventListener);
+    };
   }, [active, openFilePreview, selectedRoot]);
 
   const copyPreview = useCallback(() => {
@@ -1272,6 +1289,8 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                         key={selectedProject.root}
                         projectRoot={selectedProject.root}
                         running={projectHasRunningSession}
+                        focusPath={focusDiff?.path ?? null}
+                        focusNonce={focusDiff?.nonce}
                       />
                     </div>
                   ) : previewPath ? (

--- a/src/components/session-changes-panel.tsx
+++ b/src/components/session-changes-panel.tsx
@@ -332,7 +332,19 @@ function CheckpointSection({
 
 // ── Panel body (mounted per project root) ─────────────────────────────────────
 
-export function SessionChangesInner({ projectRoot, running }: { projectRoot: string; running: boolean }) {
+export function SessionChangesInner({
+  projectRoot,
+  running,
+  focusPath,
+  focusNonce,
+}: {
+  projectRoot: string;
+  running: boolean;
+  /** Expand a specific file's diff (e.g. jumped to from a transcript edit
+   *  tool). `focusNonce` re-triggers the jump even when the same path repeats. */
+  focusPath?: string | null;
+  focusNonce?: number;
+}) {
   const [files, setFiles] = useState<ChangedFile[]>([]);
   const [repoRoot, setRepoRoot] = useState<string | null>(null);
   const [notARepo, setNotARepo] = useState(false);
@@ -458,6 +470,21 @@ export function SessionChangesInner({ projectRoot, running }: { projectRoot: str
     },
     [diffs, expandedPath, fetchDiff],
   );
+
+  // Jump-to-diff: when a transcript edit tool is clicked, expand that file's
+  // diff. The changes list is repo-relative while focusPath may be absolute (or
+  // vice versa), so match on exact path or suffix. Keyed on focusNonce + the
+  // file list so it retries once the just-edited file appears in the diff list.
+  useEffect(() => {
+    if (!focusPath) return;
+    const match = files.find(
+      (f) => f.path === focusPath || focusPath.endsWith(f.path) || f.path.endsWith(focusPath),
+    );
+    if (!match) return;
+    setExpandedPath(match.path);
+    if (!diffs[match.path]) void fetchDiff(match.path);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [focusNonce, focusPath, filesSig]);
 
   const saveCheckpoint = useCallback(async () => {
     setCheckpointing(true);

--- a/src/lib/tool-target-file.test.ts
+++ b/src/lib/tool-target-file.test.ts
@@ -45,8 +45,8 @@ assert.match(
 );
 assert.match(
   chatView,
-  /dispatchEvent\(new CustomEvent\("cave:open-project-file", \{ detail: \{ path: targetFile \} \}\)\)/,
-  "clicking a tool's file dispatches cave:open-project-file",
+  /dispatchEvent\(\s*new CustomEvent\(isEditTool \? "cave:open-file-diff" : "cave:open-project-file", \{\s*detail: \{ path: targetFile \},/,
+  "clicking a tool's file dispatches the diff jump for edit tools, else the file preview",
 );
 // Click must not also toggle the <details> open/closed.
 assert.match(chatView, /openTargetFile = \(e: ReactMouseEvent\) => \{[\s\S]*?stopPropagation\(\)/, "open handler stops propagation");


### PR DESCRIPTION
Phase 3b of the Code-surface redesign — the deferred diff polish. Clicking an edit tool's target in the transcript opened the file *preview*; for an edit you almost always want the *diff*.

## Changes

- **`ToolBlock`**: for edit tools (Edit/Write/MultiEdit/NotebookEdit — those with a structured input diff) the target now dispatches **`cave:open-file-diff`** with a "View diff" affordance (git-diff icon); other file tools keep `cave:open-project-file` (preview).
- **`comux-view`** listens for `cave:open-file-diff`: pins + switches to the **Changes** review and focuses the file via a bumped nonce.
- **`SessionChangesInner`** gains `focusPath`/`focusNonce`: expands + fetches that file's diff, matching repo-relative or absolute paths by suffix, retrying once the just-edited file appears in the list.

## Verify

- `comux-view-changes.test.ts` asserts the `open-file-diff` wiring, the `focusPath` prop + suffix match, and the `ToolBlock` edit-vs-open branch.
- `message-bubble-file-links` / `chat-view` / `chat-view-polish` still pass; `tsc` + `check:tests-wired` green.

Final piece of the approved redesign. Builds on #951/#954/#955 (merged) and #956 (Phase 4)/#957 (Phase 5) — disjoint regions, merges in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)