### PR TITLE
feat(canvas): offline React sandbox runtime for Sketch (phase 1 of JSX preview)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ package-lock.json
 /graphify-out
 /artifacts
 /docs/superpowers
+
+# Generated Canvas Sketch sandbox runtime (built in prebuild)
+/public/sandbox/

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "mobile:tailscale:stop": "bash scripts/mobile-tailscale.sh stop",
     "pwa:icons": "node scripts/generate-pwa-icons.mjs",
     "icons:subset": "node scripts/generate-icon-subset.mjs",
-    "prebuild": "node scripts/generate-icon-subset.mjs && node scripts/generate-pwa-icons.mjs",
+    "prebuild": "node scripts/generate-icon-subset.mjs && node scripts/generate-pwa-icons.mjs && node scripts/build-sandbox-runtime.mjs",
     "build": "next build && pnpm build:server",
     "typecheck": "tsc --noEmit",
     "check:tests-wired": "node scripts/check-tests-wired.mjs",
@@ -67,6 +67,7 @@
     "react-dom": "19.2.4",
     "react-resizable-panels": "4.11.2",
     "shiki": "4.2.0",
+    "sucrase": "3.35.1",
     "ws": "8.21.0",
     "yaml": "2.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       shiki:
         specifier: 4.2.0
         version: 4.2.0
+      sucrase:
+        specifier: 3.35.1
+        version: 3.35.1
       ws:
         specifier: 8.21.0
         version: 8.21.0
@@ -1198,6 +1201,9 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   baseline-browser-mapping@2.10.36:
     resolution: {integrity: sha512-lVq/Df7LXlO79MVaaUHztSwWiG9oXoWHlgvNS51v8Dpd4+G4/VIy6qYePTw31nAVls33nUtnfezYeLkYAak9dg==}
     engines: {node: '>=6.0.0'}
@@ -1243,6 +1249,10 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
 
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
@@ -1462,6 +1472,15 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -1599,6 +1618,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -1635,6 +1657,9 @@ packages:
   micromark-util-types@2.0.2:
     resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1667,6 +1692,10 @@ packages:
   node-pty@1.1.0:
     resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   oniguruma-parser@0.12.2:
     resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
 
@@ -1697,6 +1726,14 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
 
   playwright-core@1.60.0:
     resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
@@ -1839,6 +1876,11 @@ packages:
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
 
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   tailwindcss@4.3.0:
     resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
 
@@ -1846,9 +1888,20 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -1856,6 +1909,9 @@ packages:
   ts-dedent@2.3.0:
     resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
     engines: {node: '>=6.10'}
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -3046,6 +3102,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  any-promise@1.3.0: {}
+
   baseline-browser-mapping@2.10.36: {}
 
   camelcase@5.3.1: {}
@@ -3091,6 +3149,8 @@ snapshots:
   color-name@1.1.4: {}
 
   comma-separated-tokens@2.0.3: {}
+
+  commander@4.1.1: {}
 
   commander@7.2.0: {}
 
@@ -3352,6 +3412,10 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -3459,6 +3523,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lines-and-columns@1.2.4: {}
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -3524,6 +3590,12 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
   nanoid@3.3.12: {}
 
   next@16.2.6(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -3557,6 +3629,8 @@ snapshots:
     dependencies:
       node-addon-api: 7.1.1
 
+  object-assign@4.1.1: {}
+
   oniguruma-parser@0.12.2: {}
 
   oniguruma-to-es@4.3.6:
@@ -3582,6 +3656,10 @@ snapshots:
   path-exists@4.0.0: {}
 
   picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  pirates@4.0.7: {}
 
   playwright-core@1.60.0: {}
 
@@ -3740,15 +3818,40 @@ snapshots:
 
   stylis@4.4.0: {}
 
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.17
+      ts-interface-checker: 0.1.13
+
   tailwindcss@4.3.0: {}
 
   tapable@2.3.3: {}
 
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
   tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   trim-lines@3.0.1: {}
 
   ts-dedent@2.3.0: {}
+
+  ts-interface-checker@0.1.13: {}
 
   tslib@2.8.1: {}
 

--- a/scripts/build-sandbox-runtime.mjs
+++ b/scripts/build-sandbox-runtime.mjs
@@ -1,0 +1,42 @@
+// Bundles the Canvas Sketch React sandbox runtime (src/sandbox/runtime-entry.ts)
+// into public/sandbox/react-runtime.js — a self-contained browser IIFE with
+// React 19 + sucrase inlined, so JSX/TSX artifacts render live and offline.
+//
+// Run directly (`node scripts/build-sandbox-runtime.mjs`) or via `prebuild`.
+// Exports buildSandboxRuntime() so tests can invoke it without a subprocess.
+
+import { build } from "esbuild";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const ENTRY = path.join(root, "src", "sandbox", "runtime-entry.ts");
+export const OUTFILE = path.join(root, "public", "sandbox", "react-runtime.js");
+
+export async function buildSandboxRuntime() {
+  await build({
+    entryPoints: [ENTRY],
+    outfile: OUTFILE,
+    bundle: true,
+    format: "iife",
+    platform: "browser",
+    target: ["es2020"],
+    minify: true,
+    sourcemap: false,
+    legalComments: "none",
+    // React's dev/prod branch keys off this; production trims warnings + checks.
+    define: { "process.env.NODE_ENV": '"production"' },
+    banner: { js: "/* Coven Cave Sketch sandbox runtime — generated; do not edit. */" },
+  });
+  return OUTFILE;
+}
+
+// Run when invoked directly (not when imported by the test).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  buildSandboxRuntime()
+    .then((out) => console.log(`sandbox runtime → ${path.relative(root, out)}`))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/scripts/build-sandbox-runtime.test.mjs
+++ b/scripts/build-sandbox-runtime.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFile, stat } from "node:fs/promises";
+
+import { buildSandboxRuntime, OUTFILE } from "./build-sandbox-runtime.mjs";
+
+// Build the sandbox runtime and assert it produced a self-contained browser
+// bundle with React + sucrase inlined and the runtime's public surface intact.
+// (Functional render is covered by a Playwright check run outside CI.)
+
+await buildSandboxRuntime();
+
+const info = await stat(OUTFILE);
+assert.ok(info.isFile(), "react-runtime.js must be emitted");
+// React 19 + ReactDOM + sucrase bundled and minified lands well over 100KB;
+// a tiny file means the bundle silently dropped a dependency.
+assert.ok(info.size > 100_000, `bundle looks too small (${info.size} bytes) — a dependency may be missing`);
+
+const src = await readFile(OUTFILE, "utf8");
+
+assert.match(src, /generated; do not edit/, "keeps the generated banner");
+// Runtime public surface — these are the contract the iframe harness relies on.
+for (const sym of ["__transpile", "__mount", "createRoot", "sandbox-error"]) {
+  assert.ok(src.includes(sym), `bundle must expose/reference \`${sym}\``);
+}
+// Offline guarantee: nothing should be fetched from a CDN at runtime.
+assert.doesNotMatch(src, /https?:\/\/(unpkg|esm\.sh|cdn\.|jsdelivr)/i, "runtime must not reference a CDN (offline)");
+// Production React (no dev-only invariant message machinery bloating the sandbox).
+assert.doesNotMatch(src, /react-dom\.development/i, "must bundle the production React build");
+
+console.log("build-sandbox-runtime.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -313,6 +313,7 @@ export const SUITES = {
   ],
   api: [
     "scripts/dependency-policy.test.mjs",
+    "scripts/build-sandbox-runtime.test.mjs",
     "scripts/git-hooks-pre-commit.test.mjs",
     "src/lib/coven-paths.test.ts",
     "src/app/api/api-contracts.test.ts",

--- a/src/sandbox/runtime-entry.ts
+++ b/src/sandbox/runtime-entry.ts
@@ -1,0 +1,112 @@
+// Sandbox runtime for the Canvas "Sketch" layer's React artifacts.
+//
+// This file is NOT part of the app bundle. `scripts/build-sandbox-runtime.mjs`
+// esbuilds it into `public/sandbox/react-runtime.js`, a self-contained browser
+// IIFE that the preview <iframe> loads. It bundles the app's own React 19
+// (which ships no UMD build) plus the sucrase transpiler, so JSX/TSX artifacts
+// render live and fully offline — no CDN.
+//
+// It runs inside `<iframe sandbox="allow-scripts">` WITHOUT allow-same-origin:
+// the iframe is an opaque origin that can load this script from our server but
+// cannot touch Cave's DOM, cookies, or storage. Errors are reported to the
+// parent via postMessage (the only channel across the sandbox boundary).
+
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+import { transform } from "sucrase";
+
+// Local view of the globals we set on the sandbox window. We deliberately do
+// NOT augment the global `Window` interface — the app already declares
+// `window.ReactDOM` as the full react-dom namespace, and this isolated runtime
+// only needs `createRoot`.
+const sandboxWindow = window as unknown as {
+  React: typeof React;
+  ReactDOM: { createRoot: typeof createRoot };
+  __transpile: (src: string) => string;
+  __mount: (src: string, root: HTMLElement) => void;
+};
+
+// Expose React so transpiled JSX (classic runtime → React.createElement) and
+// hand-written code can reference it as a global.
+sandboxWindow.React = React;
+sandboxWindow.ReactDOM = { createRoot };
+
+/** JSX + TypeScript → plain JS. Module syntax is stripped before this runs. */
+function transpile(src: string): string {
+  return transform(src, {
+    transforms: ["jsx", "typescript"],
+    jsxRuntime: "classic",
+    production: true,
+  }).code;
+}
+sandboxWindow.__transpile = transpile;
+
+/**
+ * Strip ESM module syntax so the source can run inside `new Function`. React is
+ * already a global, so imports are dropped; the default export is rewritten to
+ * a known binding (`__default`) and named exports lose their keyword.
+ */
+function stripModuleSyntax(src: string): string {
+  return src
+    .replace(/^[ \t]*import[^\n;]*;?[ \t]*$/gm, "")
+    .replace(/^[ \t]*export[ \t]+default[ \t]+function[ \t]+/m, "function ")
+    .replace(/^[ \t]*export[ \t]+default[ \t]+class[ \t]+/m, "class ")
+    .replace(/^[ \t]*export[ \t]+default[ \t]+/m, "const __default = ")
+    .replace(/^[ \t]*export[ \t]+/gm, "");
+}
+
+function reportError(message: string, stack?: string) {
+  try {
+    window.parent?.postMessage({ type: "sandbox-error", message, stack }, "*");
+  } catch {
+    /* parent may be gone */
+  }
+}
+
+/** Transpile, evaluate, and render the component into `root`. */
+function mount(src: string, root: HTMLElement) {
+  let component: unknown;
+  try {
+    const code = transpile(stripModuleSyntax(src));
+    // The component is resolved by convention: a default export becomes
+    // `__default`; otherwise a top-level `App` is used.
+    const factory = new Function(
+      "React",
+      "ReactDOM",
+      `${code}\n;return typeof __default !== "undefined" ? __default : (typeof App !== "undefined" ? App : undefined);`,
+    );
+    component = factory(React, { createRoot });
+  } catch (err) {
+    reportError(`Compile error: ${(err as Error)?.message ?? String(err)}`, (err as Error)?.stack);
+    return;
+  }
+  if (typeof component !== "function") {
+    reportError("No component found. Export a default React component (e.g. `export default function App() { … }`).");
+    return;
+  }
+  try {
+    createRoot(root).render(React.createElement(component as React.ComponentType));
+  } catch (err) {
+    reportError(`Render error: ${(err as Error)?.message ?? String(err)}`, (err as Error)?.stack);
+  }
+}
+sandboxWindow.__mount = mount;
+
+// Surface uncaught errors from the rendered component (event handlers, effects).
+window.addEventListener("error", (e) => reportError(e.message, e.error?.stack));
+window.addEventListener("unhandledrejection", (e) =>
+  reportError(`Unhandled rejection: ${String((e as PromiseRejectionEvent).reason)}`),
+);
+
+// Auto-mount: render the first `<script type="text/jsx">` into `#root`. The
+// phase-2 srcDoc builder emits exactly this shape.
+function boot() {
+  const root = document.getElementById("root");
+  const source = document.querySelector<HTMLScriptElement>('script[type="text/jsx"]');
+  if (root && source) mount(source.textContent ?? "", root);
+}
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", boot);
+} else {
+  boot();
+}


### PR DESCRIPTION
## What

**Phase 1** of the React/JSX preview follow-up (spec discussed on #953). Ships the foundation: a self-contained browser **runtime** the Sketch preview iframe can load to render React components **fully offline**, with isolation unchanged.

It does **not** yet wire React artifacts into the Sketch UI — that's phases 2–3 (artifact `kind`, srcDoc harness builder, node error overlay, prompt updates). This PR is independently useful and verifiable on its own.

## How

- `src/sandbox/runtime-entry.ts` bundles the app's **own React 19** (which ships no UMD build) + the **sucrase** transpiler. It exposes `window.React` / `window.ReactDOM` and `__transpile` / `__mount`; strips ESM module syntax (React is a global), transpiles JSX/TSX, evaluates the default-exported component, and renders it into `#root`.
- **Errors never blank silently**: compile/render/uncaught errors `postMessage({type:"sandbox-error"})` to the parent (the only channel across the sandbox boundary) for phase 3's node overlay to show.
- `scripts/build-sandbox-runtime.mjs` esbuilds it to `public/sandbox/react-runtime.js` (IIFE, minified, `NODE_ENV=production`), wired into **`prebuild`** so CI's `pnpm build` produces it; output is **gitignored** like `server.mjs`.
- **No CDN** — React and the transpiler are inlined (~391 KB minified), so JSX preview works offline. Isolation is unchanged: the asset runs inside the existing `sandbox="allow-scripts"` (no `allow-same-origin`) iframe; it can load the script from our origin but can't reach Cave's DOM/cookies/storage.

## Why sucrase + bundled React

React 19 dropped UMD, so a runtime must be bundled from the installed packages. sucrase is a purpose-built JSX/TS transpiler ~10× smaller than `@babel/standalone` and does exactly the single-file transform we need.

## Tests / verification

- `scripts/build-sandbox-runtime.test.mjs` (wired into the `api` suite): builds the asset and asserts it's emitted, non-trivial in size, exposes the runtime surface (`__transpile`/`__mount`/`createRoot`/`sandbox-error`), references **no CDN**, and bundles **production** React.
- Full `pnpm test:app` (289) + `test:api` (74) green; `tsc` clean; `pnpm build` succeeds and the `prebuild` hook emits the asset.
- **Real-chromium functional check** (Playwright, run outside CI): a JSX counter renders `count: 0`, a click updates to `count: 1` (hooks work), and a deliberate syntax error surfaces via the `postMessage` error channel rather than a blank frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)