### PR TITLE
feat(canvas): render generated React components in Sketch (phases 2-3 of JSX preview)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -106,6 +106,7 @@ export const SUITES = {
     "src/lib/calendar-layout.test.ts",
     "src/lib/canvas-layout.test.ts",
     "src/lib/canvas-artifacts.test.ts",
+    "src/lib/canvas-react-harness.test.ts",
     "src/lib/canvas-generate.test.ts",
     "src/lib/cave-canvas.test.ts",
     "src/components/canvas-view.test.ts",

--- a/src/components/canvas-artifact-node.tsx
+++ b/src/components/canvas-artifact-node.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { NodeResizer, type NodeProps, type Node } from "@xyflow/react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { buildPreviewSrcDoc, type CanvasArtifact } from "@/lib/canvas-artifacts";
+import { buildReactSrcDoc } from "@/lib/canvas-react-harness";
 
 export type ArtifactNodeData = {
   artifact: CanvasArtifact;
@@ -20,6 +22,30 @@ export type ArtifactFlowNode = Node<ArtifactNodeData & Record<string, unknown>, 
 
 export function ArtifactNode({ data, selected }: NodeProps<ArtifactFlowNode>) {
   const { artifact, view, generating } = data;
+  const isReact = artifact.kind === "react";
+  const frameRef = useRef<HTMLIFrameElement | null>(null);
+  const [runtimeError, setRuntimeError] = useState<string | null>(null);
+
+  const srcDoc = useMemo(
+    () => (isReact ? buildReactSrcDoc(artifact.code) : buildPreviewSrcDoc(artifact.code)),
+    [isReact, artifact.code],
+  );
+
+  // The sandbox runtime reports compile/render/runtime failures via postMessage
+  // (the only channel out of the no-same-origin iframe). Match messages to THIS
+  // node's frame by comparing the event source to its contentWindow.
+  useEffect(() => {
+    setRuntimeError(null); // a fresh srcDoc reloads the frame; clear stale errors
+    function onMessage(e: MessageEvent) {
+      if (e.source !== frameRef.current?.contentWindow) return;
+      if (e.data?.type === "sandbox-error" && typeof e.data.message === "string") {
+        setRuntimeError(e.data.message);
+      }
+    }
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [srcDoc]);
+
   return (
     <div className={`canvas-artifact${selected ? " is-selected" : ""}`}>
       <NodeResizer minWidth={260} minHeight={200} isVisible={selected} />
@@ -30,12 +56,13 @@ export function ArtifactNode({ data, selected }: NodeProps<ArtifactFlowNode>) {
           {generating ? <span className="canvas-artifact__spinner" aria-hidden /> : <Icon name="ph:bounding-box" />}
           {artifact.title || "Untitled"}
         </span>
+        <span className="canvas-artifact__kind">{isReact ? "React" : "HTML"}</span>
         <div className="canvas-artifact__actions nodrag">
           <button
             type="button"
             className={`canvas-artifact__btn${view === "preview" ? " is-active" : ""}`}
-            title="Preview"
-            aria-label="Preview"
+            title={view === "preview" ? "Show code" : "Show preview"}
+            aria-label={view === "preview" ? "Show code" : "Show preview"}
             onClick={() => data.onToggleView(artifact.id)}
           >
             <Icon name={view === "preview" ? "ph:code" : "ph:squares-four"} />
@@ -86,24 +113,40 @@ export function ArtifactNode({ data, selected }: NodeProps<ArtifactFlowNode>) {
             className="canvas-artifact__code"
             spellCheck={false}
             value={artifact.code}
-            placeholder="<!doctype html> …"
+            placeholder={isReact ? "export default function App() { … }" : "<!doctype html> …"}
             onChange={(e) => data.onEditCode(artifact.id, e.target.value)}
           />
         ) : artifact.code ? (
-          // Untrusted generated markup runs ONLY inside this sandbox:
-          // allow-scripts WITHOUT allow-same-origin means scripts execute but
-          // can't reach Cave's origin, cookies, or storage.
+          // Untrusted generated code runs ONLY inside this sandbox: allow-scripts
+          // WITHOUT allow-same-origin means scripts execute but can't reach Cave's
+          // origin, cookies, or storage. React artifacts additionally load the
+          // offline sandbox runtime (same-origin asset, opaque-origin iframe).
           <iframe
+            ref={frameRef}
             className="canvas-artifact__frame"
             title={artifact.title || "preview"}
             sandbox="allow-scripts allow-popups allow-modals"
-            srcDoc={buildPreviewSrcDoc(artifact.code)}
+            srcDoc={srcDoc}
           />
         ) : (
           <div className="canvas-artifact__placeholder">
             {generating ? "Generating…" : "No preview yet"}
           </div>
         )}
+
+        {runtimeError && view === "preview" ? (
+          <div className="canvas-artifact__error" role="alert">
+            <Icon name="ph:warning-circle-fill" />
+            <span className="canvas-artifact__error-msg">{runtimeError}</span>
+            <button
+              type="button"
+              className="canvas-artifact__error-fix nodrag"
+              onClick={() => data.onToggleView(artifact.id)}
+            >
+              View code
+            </button>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/src/components/canvas-view.test.ts
+++ b/src/components/canvas-view.test.ts
@@ -63,13 +63,28 @@ assert.match(
 // The preview MUST be a sandboxed iframe WITHOUT allow-same-origin, so
 // generated (untrusted) code can't reach Cave's origin.
 assert.match(artifactNode, /<iframe/, "artifacts render in an iframe");
-assert.match(artifactNode, /srcDoc=\{buildPreviewSrcDoc/, "the iframe is fed a framed srcDoc");
+assert.match(artifactNode, /srcDoc=\{srcDoc\}/, "the iframe is fed the framed srcDoc");
 assert.match(artifactNode, /sandbox="allow-scripts/, "the preview iframe must be sandboxed (scripts allowed)");
 assert.doesNotMatch(
   artifactNode,
   /sandbox="[^"]*allow-same-origin/,
   "the preview must NOT grant allow-same-origin — that would break isolation",
 );
+
+// React artifacts use the offline-runtime harness; HTML artifacts the plain doc.
+assert.match(artifactNode, /buildReactSrcDoc\(artifact\.code\)/, "react artifacts build the runtime harness srcDoc");
+assert.match(artifactNode, /buildPreviewSrcDoc\(artifact\.code\)/, "html artifacts build the plain srcDoc");
+assert.match(artifactNode, /artifact\.kind === "react"/, "the node branches the preview on artifact kind");
+
+// Runtime errors from the sandbox surface in the node (not a blank frame),
+// matched to THIS frame by comparing the postMessage source.
+assert.match(artifactNode, /addEventListener\("message"/, "the node listens for sandbox postMessage errors");
+assert.match(artifactNode, /e\.source !== frameRef\.current\?\.contentWindow/, "errors are matched to this node's iframe");
+assert.match(artifactNode, /sandbox-error/, "the node handles the runtime's sandbox-error message");
+assert.match(artifactNode, /canvas-artifact__error/, "a runtime error renders an overlay");
+
+// Generated kind is plumbed through to the stored artifact.
+assert.match(view, /kind\s*=\s*result\.kind/, "generation records the extracted artifact kind");
 
 // Artifacts persist to the canvas store via POST and delete via DELETE.
 assert.match(view, /method:\s*"POST"[\s\S]{0,120}artifact/, "artifacts upsert to /api/canvas via POST");

--- a/src/components/canvas-view.tsx
+++ b/src/components/canvas-view.tsx
@@ -45,6 +45,7 @@ import {
   titleFromPrompt,
   type CanvasArtifact,
 } from "@/lib/canvas-artifacts";
+import { buildReactSrcDoc } from "@/lib/canvas-react-harness";
 import { generateArtifactCode } from "@/lib/canvas-generate";
 import { ArtifactNode, type ArtifactFlowNode } from "@/components/canvas-artifact-node";
 
@@ -245,7 +246,9 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
       }
       setActionError(null);
       setGenerating((prev) => new Set(prev).add(id));
-      const sendPrompt = refineOf ? buildRefinePrompt(refineOf.code, ask) : buildSketchPrompt(ask);
+      const sendPrompt = refineOf
+        ? buildRefinePrompt(refineOf.code, ask, refineOf.kind ?? "html")
+        : buildSketchPrompt(ask);
       const result = await generateArtifactCode({ prompt: sendPrompt, familiarId });
       setGenerating((prev) => {
         const next = new Set(prev);
@@ -254,9 +257,10 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
       });
       if (result.code) {
         const code = clampArtifactCode(result.code);
+        const kind = result.kind ?? "html";
         const updatedAt = new Date().toISOString();
         const current = artifactsRef.current.find((a) => a.id === id);
-        const updated: CanvasArtifact | null = current ? { ...current, code, updatedAt } : null;
+        const updated: CanvasArtifact | null = current ? { ...current, code, kind, updatedAt } : null;
         if (updated) {
           setArtifacts((prev) => prev.map((a) => (a.id === id ? updated : a)));
           setArtifactView((prev) => ({ ...prev, [id]: "preview" }));
@@ -286,6 +290,7 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
         title: opts?.blank ? "Blank sketch" : titleFromPrompt(prompt),
         prompt,
         code: opts?.blank ? STARTER_ARTIFACT_HTML : "",
+        kind: "html",
         createdAt: now,
         updatedAt: now,
       };
@@ -364,7 +369,10 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
     const art = artifactsRef.current.find((a) => a.id === id);
     if (!art) return;
     try {
-      const blob = new Blob([buildPreviewSrcDoc(art.code)], { type: "text/html" });
+      // blob: inherits our origin, so the React harness's /sandbox runtime path
+      // still resolves in the opened tab.
+      const doc = art.kind === "react" ? buildReactSrcDoc(art.code) : buildPreviewSrcDoc(art.code);
+      const blob = new Blob([doc], { type: "text/html" });
       window.open(URL.createObjectURL(blob), "_blank", "noopener");
     } catch {
       /* popup blocked or unsupported — preview node still works */

--- a/src/lib/canvas-artifacts.test.ts
+++ b/src/lib/canvas-artifacts.test.ts
@@ -6,6 +6,7 @@ import {
   buildRefinePrompt,
   buildSketchPrompt,
   clampArtifactCode,
+  extractArtifact,
   extractHtmlArtifact,
   isFullDocument,
   MAX_ARTIFACT_CODE_CHARS,
@@ -63,7 +64,7 @@ const huge = "y".repeat(MAX_ARTIFACT_CODE_CHARS + 500);
 assert.equal(clampArtifactCode(huge).length, MAX_ARTIFACT_CODE_CHARS, "code is clamped to the storage cap");
 
 const prompt = buildSketchPrompt("a login form");
-assert.match(prompt, /ONE fenced ```html code block/, "sketch prompt constrains output to one html block");
+assert.match(prompt, /EXACTLY ONE fenced code block/, "sketch prompt constrains output to one code block");
 assert.match(prompt, /a login form/, "sketch prompt carries the user's ask");
 assert.match(buildSketchPrompt("  "), /a simple example UI/, "blank ask gets a sensible default");
 
@@ -90,5 +91,60 @@ assert.equal(
   "build a thing",
   "a missing title is derived from the prompt",
 );
+
+// ── extractArtifact: classify React vs HTML ────────────────────────────────
+
+assert.deepEqual(
+  extractArtifact("```tsx\nexport default function App(){return <h1>hi</h1>}\n```"),
+  { kind: "react", code: "export default function App(){return <h1>hi</h1>}" },
+  "a tsx fence is classified as React",
+);
+assert.equal(extractArtifact("```jsx\n<App/>\n```").kind, "react", "jsx fence ⇒ react");
+assert.equal(
+  extractArtifact("```html\n<!doctype html><html></html>\n```").kind,
+  "html",
+  "html fence ⇒ html",
+);
+// A react fence wins even if an html fence is also present.
+assert.equal(
+  extractArtifact("```html\n<div/>\n```\n```tsx\nexport default ()=><i/>\n```").kind,
+  "react",
+  "react fence is preferred over html",
+);
+// Untagged fence classified by content.
+assert.equal(
+  extractArtifact("```\nexport default function App(){const [n]=React.useState(0);return null}\n```").kind,
+  "react",
+  "untagged fence with export default + hooks ⇒ react",
+);
+assert.equal(extractArtifact("```\n<section>hi</section>\n```").kind, "html", "untagged markup ⇒ html");
+assert.equal(extractArtifact("nothing renderable"), null, "no code ⇒ null");
+// extractHtmlArtifact stays for back-compat.
+assert.equal(typeof extractHtmlArtifact, "function", "extractHtmlArtifact is still exported");
+
+// ── kind is persisted and prompts cover both forms ─────────────────────────
+
+const reactArt = sanitizeArtifacts([{ id: "r", prompt: "p", code: "x", kind: "react" }])[0];
+assert.equal(reactArt.kind, "react", "kind survives sanitization");
+assert.equal(
+  sanitizeArtifacts([{ id: "h", prompt: "p", code: "x" }])[0].kind,
+  "html",
+  "absent kind defaults to html (back-compat)",
+);
+assert.equal(
+  sanitizeArtifacts([{ id: "b", prompt: "p", code: "x", kind: "bogus" }])[0].kind,
+  "html",
+  "unknown kind coerces to html",
+);
+
+const sketch = buildSketchPrompt("a counter");
+assert.match(sketch, /```tsx/, "sketch prompt offers a tsx/React option");
+assert.match(sketch, /default-exported|DEFAULT-EXPORTED/i, "sketch prompt states the default-export contract");
+assert.match(sketch, /do NOT .*import|import React/i, "sketch prompt forbids importing react (it's global)");
+
+const refineReact = buildRefinePrompt("export default function App(){}", "add a button", "react");
+assert.match(refineReact, /```tsx/, "refining a react artifact asks for tsx, not html");
+const refineHtml = buildRefinePrompt("<!doctype html>", "make it blue", "html");
+assert.match(refineHtml, /```html/, "refining an html artifact asks for html");
 
 console.log("canvas-artifacts.test.ts ✓");

--- a/src/lib/canvas-artifacts.ts
+++ b/src/lib/canvas-artifacts.ts
@@ -4,14 +4,21 @@
 // preview, and persist it. Everything here is framework-/fs-free so it can be
 // unit-tested without a DOM, a daemon, or React Flow.
 
+// An artifact is either a self-contained HTML document or a single React
+// component (transpiled + rendered by the sandbox runtime). Older records
+// (pre-React) have no `kind` and are treated as "html".
+export type ArtifactKind = "html" | "react";
+
 export type CanvasArtifact = {
   id: string;
   /** Short human label, derived from the prompt (editable later). */
   title: string;
   /** The natural-language description the user asked for. */
   prompt: string;
-  /** The self-contained HTML document rendered in the preview. */
+  /** The HTML document, or React component source, rendered in the preview. */
   code: string;
+  /** How `code` should be previewed. Absent ⇒ "html" (back-compat). */
+  kind?: ArtifactKind;
   createdAt: string;
   updatedAt: string;
 };
@@ -43,6 +50,36 @@ export function extractHtmlArtifact(text: string): string | null {
   // No usable fence — accept a bare document if one is present.
   const docMatch = text.match(/<!doctype html[\s\S]*<\/html>/i) ?? text.match(/<html[\s\S]*<\/html>/i);
   if (docMatch) return docMatch[0].trim();
+
+  return null;
+}
+
+/** Heuristic: does this fenced code look like a React component vs HTML? */
+function looksLikeReact(code: string): boolean {
+  if (/<!doctype html/i.test(code) || /<html[\s>]/i.test(code)) return false;
+  return /\bexport\s+default\b/.test(code) || /\bfunction\s+App\b/.test(code) || /\buse(State|Effect|Ref|Memo|Callback)\b/.test(code);
+}
+
+/**
+ * Pull a renderable artifact out of a familiar's response and classify it. A
+ * `tsx`/`jsx` fence ⇒ React; an `html` fence (or bare `<!doctype>`) ⇒ HTML; an
+ * untagged fence is classified by content. Returns null when nothing renders.
+ */
+export function extractArtifact(text: string): { kind: ArtifactKind; code: string } | null {
+  if (typeof text !== "string" || !text.trim()) return null;
+
+  const fences = [...text.matchAll(/```([\w-]*)\n([\s\S]*?)```/g)];
+  if (fences.length > 0) {
+    const react = fences.find((m) => /^(tsx|jsx|react|javascriptreact|typescriptreact)$/i.test(m[1] ?? ""));
+    if (react && react[2]?.trim()) return { kind: "react", code: react[2].trim() };
+    const html = fences.find((m) => /^(html?|markup|xml)$/i.test(m[1] ?? ""));
+    if (html && html[2]?.trim()) return { kind: "html", code: html[2].trim() };
+    const first = (fences[0][2] ?? "").trim();
+    if (first) return { kind: looksLikeReact(first) ? "react" : "html", code: first };
+  }
+
+  const docMatch = text.match(/<!doctype html[\s\S]*<\/html>/i) ?? text.match(/<html[\s\S]*<\/html>/i);
+  if (docMatch) return { kind: "html", code: docMatch[0].trim() };
 
   return null;
 }
@@ -102,12 +139,20 @@ export function buildSketchPrompt(userPrompt: string): string {
   return [
     "You are generating a UI for a live preview sandbox inside a design canvas.",
     "",
-    "Rules:",
-    "- Output EXACTLY ONE fenced ```html code block and nothing else — no prose, no explanation before or after.",
-    "- The block must be a COMPLETE, self-contained document starting with `<!doctype html>`.",
-    "- Inline all CSS in a <style> tag and all JS in a <script> tag. Do not reference local files or build tooling.",
-    "- It must render on its own with no network access. If you need a library (e.g. React), load it from a CDN such as https://esm.sh, but prefer plain HTML/CSS/JS when it suffices.",
-    "- Make it visually polished and responsive; fill the viewport sensibly.",
+    "Output EXACTLY ONE fenced code block and nothing else — no prose before or after.",
+    "Choose ONE of these two forms:",
+    "",
+    "(A) A ```html block: a COMPLETE self-contained document starting with `<!doctype html>`,",
+    "    with all CSS inlined in <style> and all JS inlined in <script>. No external files.",
+    "",
+    "(B) A ```tsx block: a single React component, DEFAULT-EXPORTED and named `App`",
+    "    (e.g. `export default function App() { … }`). React 19 and its hooks are available",
+    "    as globals — use `React.useState`, or destructure `const { useState } = React`.",
+    "    Do NOT write `import React`/`import ReactDOM` and do NOT load anything from a CDN.",
+    "    There is no Tailwind/CSS framework — style with inline `style={{…}}` or a <style> element.",
+    "",
+    "Prefer (B) tsx for interactive components; (A) html for static pages or plain markup.",
+    "It must render on its own with no network access. Make it polished and responsive.",
     "",
     `Build this: ${ask}`,
   ].join("\n");
@@ -118,14 +163,20 @@ export function buildSketchPrompt(userPrompt: string): string {
  * document plus the change request, keeping the same one-document output
  * contract so the result drops straight back onto the canvas.
  */
-export function buildRefinePrompt(currentCode: string, changeRequest: string): string {
+export function buildRefinePrompt(
+  currentCode: string,
+  changeRequest: string,
+  kind: ArtifactKind = "html",
+): string {
   const ask = (changeRequest ?? "").trim() || "improve it";
+  const lang = kind === "react" ? "tsx" : "html";
+  const noun = kind === "react" ? "React component" : "document";
   return [
     buildSketchPrompt(`Apply this change: ${ask}`),
     "",
-    "Modify the document below. Return the FULL updated document, not a diff:",
+    `Modify the ${noun} below. Keep the same ${lang} form and return the FULL updated ${noun}, not a diff:`,
     "",
-    "```html",
+    "```" + lang,
     (currentCode ?? "").trim(),
     "```",
   ].join("\n");
@@ -160,9 +211,10 @@ export function sanitizeArtifact(value: unknown): CanvasArtifact | null {
   const prompt = typeof v.prompt === "string" ? v.prompt : "";
   const code = clampArtifactCode(typeof v.code === "string" ? v.code : "");
   const title = typeof v.title === "string" && v.title.trim() ? v.title.trim().slice(0, MAX_TITLE_CHARS) : titleFromPrompt(prompt);
+  const kind: ArtifactKind = v.kind === "react" ? "react" : "html";
   const createdAt = typeof v.createdAt === "string" ? v.createdAt : "";
   const updatedAt = typeof v.updatedAt === "string" ? v.updatedAt : createdAt;
-  return { id, title, prompt, code, createdAt, updatedAt };
+  return { id, title, prompt, code, kind, createdAt, updatedAt };
 }
 
 /** Sanitize an array of artifact records, dropping any that are unusable. */

--- a/src/lib/canvas-generate.ts
+++ b/src/lib/canvas-generate.ts
@@ -3,7 +3,7 @@
 // Cave has no server-side LLM, so generation routes through the daemon agent).
 // The SSE frame parser is exported pure so it can be unit-tested.
 
-import { extractHtmlArtifact } from "@/lib/canvas-artifacts";
+import { extractArtifact, type ArtifactKind } from "@/lib/canvas-artifacts";
 
 export type SketchStreamEvent = {
   kind?: string;
@@ -27,6 +27,7 @@ export function parseSseFrame(frame: string): SketchStreamEvent | null {
 
 export type GenerateResult = {
   code: string | null;
+  kind: ArtifactKind | null;
   text: string;
   sessionId: string | null;
   error: string | null;
@@ -58,10 +59,10 @@ export async function generateArtifactCode(opts: {
       signal: opts.signal,
     });
   } catch (err) {
-    return { code: null, text: "", sessionId: null, error: (err as Error)?.message ?? "request failed" };
+    return { code: null, kind: null, text: "", sessionId: null, error: (err as Error)?.message ?? "request failed" };
   }
   if (!res.ok || !res.body) {
-    return { code: null, text: "", sessionId: null, error: `chat bridge ${res.status}` };
+    return { code: null, kind: null, text: "", sessionId: null, error: `chat bridge ${res.status}` };
   }
 
   const reader = res.body.getReader();
@@ -100,9 +101,15 @@ export async function generateArtifactCode(opts: {
     }
   }
 
-  const code = extractHtmlArtifact(text);
-  if (!code && !error) {
-    error = "The familiar didn't return an HTML document. Try rephrasing.";
+  const extracted = extractArtifact(text);
+  if (!extracted && !error) {
+    error = "The familiar didn't return a renderable UI. Try rephrasing.";
   }
-  return { code, text, sessionId, error };
+  return {
+    code: extracted?.code ?? null,
+    kind: extracted?.kind ?? null,
+    text,
+    sessionId,
+    error,
+  };
 }

--- a/src/lib/canvas-react-harness.test.ts
+++ b/src/lib/canvas-react-harness.test.ts
@@ -1,0 +1,34 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+
+import { buildReactSrcDoc, escapeForScriptTag, SANDBOX_RUNTIME_SRC } from "./canvas-react-harness.ts";
+
+// escapeForScriptTag: component source must not be able to break out of the
+// embedding <script> tag.
+assert.equal(
+  escapeForScriptTag('const s = "</script><img onerror=alert(1)>";'),
+  'const s = "<\\/script><img onerror=alert(1)>";',
+  "</script> is neutralized to <\\/script>",
+);
+assert.equal(escapeForScriptTag("const s = `</SCRIPT>`"), "const s = `<\\/SCRIPT>`", "case-insensitive");
+assert.equal(escapeForScriptTag("no closing tag"), "no closing tag", "ordinary code is untouched");
+
+// buildReactSrcDoc: a complete preview document that loads the offline runtime
+// and embeds the (escaped) component source.
+const doc = buildReactSrcDoc("export default function App(){return <b>hi</b>}");
+assert.match(doc, /^<!doctype html>/i, "is a full document");
+assert.match(doc, /<div id="root"><\/div>/, "has the React mount point");
+assert.match(doc, /<script type="text\/jsx">/, "embeds the component in a jsx script tag");
+assert.match(doc, /export default function App/, "carries the component source");
+assert.ok(doc.includes(`<script src="${SANDBOX_RUNTIME_SRC}">`), "loads the offline sandbox runtime");
+assert.equal(SANDBOX_RUNTIME_SRC, "/sandbox/react-runtime.js", "runtime path matches the built asset");
+
+// Escaping is applied through the builder.
+const malicious = buildReactSrcDoc('const x = "</script><script>steal()</script>";');
+assert.doesNotMatch(
+  malicious.replace(/<script type="text\/jsx">[\s\S]*?<\/script>/, "JSX_BLOCK"),
+  /steal\(\)/,
+  "embedded </script> can't inject a sibling script",
+);
+
+console.log("canvas-react-harness.test.ts ✓");

--- a/src/lib/canvas-react-harness.ts
+++ b/src/lib/canvas-react-harness.ts
@@ -1,0 +1,44 @@
+// Builds the <iframe srcdoc> document that previews a React artifact. The doc
+// embeds the component source in a <script type="text/jsx"> and loads the
+// offline sandbox runtime (public/sandbox/react-runtime.js, built in prebuild),
+// which transpiles + mounts it. Pure + DOM-free so it's unit-testable.
+//
+// Isolation is unchanged from the HTML path: the result runs in an
+// <iframe sandbox="allow-scripts"> (no allow-same-origin). The runtime asset is
+// same-origin to our server but the iframe stays an opaque origin — loading a
+// script is allowed; reaching Cave's DOM/cookies is not.
+
+/** Absolute path (resolved against the parent's base URL inside about:srcdoc). */
+export const SANDBOX_RUNTIME_SRC = "/sandbox/react-runtime.js";
+
+/**
+ * Neutralize `</script>` so component source can't break out of the embedding
+ * <script> tag. (`<\/script>` is equivalent JS inside the tag.)
+ */
+export function escapeForScriptTag(code: string): string {
+  // Insert a backslash before the slash, preserving the original case so the
+  // component's string contents aren't altered.
+  return (typeof code === "string" ? code : "").replace(/<\/(script>)/gi, "<\\/$1");
+}
+
+/** Frame React component source into a full preview document. */
+export function buildReactSrcDoc(code: string): string {
+  return [
+    "<!doctype html>",
+    '<html lang="en">',
+    "<head>",
+    '<meta charset="utf-8" />',
+    '<meta name="viewport" content="width=device-width, initial-scale=1" />',
+    "<style>",
+    "  :root { color-scheme: light dark; }",
+    "  body { margin: 0; font-family: system-ui, -apple-system, sans-serif; }",
+    "</style>",
+    "</head>",
+    "<body>",
+    '<div id="root"></div>',
+    `<script type="text/jsx">${escapeForScriptTag(code)}</script>`,
+    `<script src="${SANDBOX_RUNTIME_SRC}"></script>`,
+    "</body>",
+    "</html>",
+  ].join("\n");
+}

--- a/src/styles/canvas.css
+++ b/src/styles/canvas.css
@@ -506,3 +506,59 @@
 @keyframes canvas-spin {
   to { transform: rotate(360deg); }
 }
+
+/* ── Artifact: kind badge + runtime error overlay ────────────────────────── */
+
+.canvas-artifact__kind {
+  flex: none;
+  margin-right: 4px;
+  padding: 1px 7px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-hairline);
+  border-radius: 999px;
+}
+
+.canvas-artifact__error {
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  font-size: 12px;
+  color: #fff;
+  background: #b95050;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+}
+
+.canvas-artifact__error svg {
+  flex: none;
+}
+
+.canvas-artifact__error-msg {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.canvas-artifact__error-fix {
+  flex: none;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 6px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## What

Phases 2–3 of the React/JSX preview follow-up, building on the offline runtime shipped in #959. **A Sketch artifact can now be a React component**, not just HTML — the familiar may emit a ` ```tsx ` block and it renders live in the same sandboxed iframe, editable and refinable like the HTML path.

## How

- **`kind: "html" | "react"`** added to artifacts (absent ⇒ `html`, back-compat with #953 records). `extractArtifact()` classifies the familiar's response — a `tsx`/`jsx` fence ⇒ React, an `html` fence or bare `<!doctype>` ⇒ HTML, an untagged fence by content. The sketch/refine prompts now offer both forms; for React they specify the contract: default-export `App`, React is a global (no `import`/CDN), inline styles (no Tailwind).
- **`canvas-react-harness.ts`** (pure) frames React source into a srcDoc that embeds it in a `<script type="text/jsx">` (with `</script>` neutralized, case-preserving) and loads the offline `/sandbox/react-runtime.js`. The node selects the harness by `kind`.
- **Error overlay**: compile/render/uncaught errors the runtime posts via `postMessage` surface as an in-node overlay — matched to *this* node's iframe by comparing the message source — with a "View code" affordance, instead of a blank frame.
- **Isolation unchanged**: still `sandbox="allow-scripts"` with no `allow-same-origin`; the React harness only adds loading the same-origin runtime asset into the opaque-origin iframe.

## Tests / verification

- New `canvas-react-harness.test.ts` (srcDoc shape, runtime path, `</script>` escaping); `canvas-artifacts.test.ts` extended for `extractArtifact` kind classification, `kind` persistence, and the dual-form prompts; `canvas-view.test.ts` extended to assert the node branches preview by `kind`, wires the postMessage error overlay matched to its own frame, and keeps the **no-`allow-same-origin`** isolation invariant.
- Full `pnpm test:app` (291) + `test:api` (74) green; `tsc` clean; `pnpm build` succeeds (prebuild emits the runtime asset).
- **Real-chromium check** (Playwright, outside CI) using the *actual* `buildReactSrcDoc` output: a generated React counter renders, hooks update on click, and a deliberate syntax error reports via the `sandbox-error` postMessage channel.

With this, the canvas spins up both HTML and React UIs ad hoc — the full ChatGPT/Codex-style loop. Optional v2 (deferred): Tailwind support in the React sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)