### PR TITLE
fix(plugins): inset the Skills tab highlight so it doesn't butt the edge

### DIFF
--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -524,7 +524,7 @@ function SkillsTab({
   }
 
   return (
-    <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-panel)] px-4">
+    <div className="flex flex-col gap-1.5">
       {skills.map((skill) => (
         <SkillCard
           key={`${skill.familiar}:${skill.id}:${skill.path}`}

--- a/src/components/skill-card.tsx
+++ b/src/components/skill-card.tsx
@@ -99,7 +99,7 @@ export function SkillCard({
     <button
       type="button"
       onClick={onClick}
-      className="group flex w-full items-center gap-4 px-0 py-3 border-b border-[var(--border-hairline)] last:border-b-0 transition-colors hover:bg-[var(--bg-raised)] cursor-pointer text-left"
+      className="group flex w-full items-center gap-4 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-panel)] px-4 py-3 transition-colors hover:border-[color-mix(in_srgb,var(--foreground)_24%,var(--border-hairline))] hover:bg-[var(--bg-raised)] cursor-pointer text-left"
     >
       {/* Icon */}
       <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">


### PR DESCRIPTION
The Plugins → Skills rows lived in one bordered box as full-bleed `border-b` rows, so the hover/selection highlight ran edge-to-edge and butted against the container with no breathing room.

Now each skill is its own rounded, bordered, padded card in a gapped list — matching the Roles tab and the workflows library — so the highlight is an inset rounded rectangle with internal space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)