### PR TITLE
feat(chat): collapsible code blocks in the chat transcript

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -71,6 +71,8 @@ export const SUITES = {
     "src/components/message-bubble-markdown.test.ts",
     "src/components/mermaid-viewer.test.ts",
     "src/components/message-bubble-code-header.test.ts",
+    "src/components/message-bubble-code-collapse.test.ts",
+    "src/lib/code-block-collapse.test.ts",
     "src/components/message-bubble-jump-to-line.test.ts",
     "src/components/message-bubble-file-links.test.ts",
     "src/components/library-reader-polish.test.ts",

--- a/src/components/message-bubble-code-collapse.test.ts
+++ b/src/components/message-bubble-code-collapse.test.ts
@@ -1,0 +1,52 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Chat code blocks render in a container that is collapsible (fold to header),
+// height-expandable ("Show more"), and max-height scrollable — with Shiki
+// syntax highlighting. This pins the collapse affordance + the scroll/expand
+// container so the presentation can't silently regress.
+
+const bubble = await readFile(new URL("./message-bubble.tsx", import.meta.url), "utf8");
+const css = await readFile(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
+
+// ── renderCodeBlock chrome: collapse chevron + line count in the header ──────
+assert.match(
+  bubble,
+  /class="cave-code-collapse-btn"[\s\S]*?aria-expanded="true"[\s\S]*?cave-code-chevron/,
+  "the code header has a collapse toggle (chevron, expanded by default)",
+);
+assert.match(bubble, /class="cave-code-lines"[\s\S]*?\$\{lineCount\} lines/, "the header shows a line count");
+// Header order: collapse chevron, then language, then the rest.
+assert.match(
+  bubble,
+  /cave-code-header">\$\{collapseBtn\}\$\{labelHtml\}/,
+  "the collapse toggle leads the header",
+);
+
+// ── wireCopyButtons wires the chevron to the (unit-tested) collapse toggle ───
+assert.match(
+  bubble,
+  /querySelectorAll<HTMLButtonElement>\("\.cave-code-collapse-btn"\)[\s\S]*?addEventListener\("click"[\s\S]*?toggleCodeBlockCollapse\(wrap, btn\)/,
+  "clicking the chevron calls toggleCodeBlockCollapse (collapse logic lives in @/lib/code-block-collapse, unit-tested)",
+);
+
+// ── CSS: collapsed hides the body; chevron rotates ───────────────────────────
+assert.match(
+  css,
+  /\.cave-code-wrap--collapsed > pre,[\s\S]*?\.cave-code-wrap--collapsed > \.cave-code-expand \{[\s\S]*?display: none/,
+  "collapsed state hides the code body and the Show-more footer",
+);
+assert.match(css, /\.cave-code-wrap--collapsed \.cave-code-chevron \{[\s\S]*?rotate\(-90deg\)/, "chevron rotates when collapsed");
+assert.match(css, /\.cave-code-collapse-btn \{[\s\S]*?order: -1/, "collapse toggle is leftmost in the header");
+
+// ── regression: the scrollable, height-expandable, highlighted container ─────
+assert.match(
+  css,
+  /\.cave-code-wrap \{[\s\S]*?max-height: min\(60vh, 520px\)[\s\S]*?overflow-y: auto/,
+  "code container keeps its max-height scroll cap",
+);
+assert.match(css, /\.cave-code-wrap--expanded \{[\s\S]*?max-height: none/, '"Show more" still lifts the height cap');
+assert.match(bubble, /hl\.codeToHtml\(code, \{[\s\S]*?theme: "mood-c-dark"/, "Shiki syntax highlighting is applied");
+
+console.log("message-bubble-code-collapse.test.ts: ok");

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -34,6 +34,7 @@ import { sanitizeHtml } from "@/lib/html-sanitize";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { SHIKI_LANGS, resolveShikiLang } from "@/lib/code-lang";
 import { parseFileRef } from "@/lib/file-ref";
+import { toggleCodeBlockCollapse } from "@/lib/code-block-collapse";
 import { wireMermaidDiagrams } from "./mermaid-viewer";
 
 // ---------------------------------------------------------------------------
@@ -184,10 +185,16 @@ async function renderCodeBlock(
   const filenameHtml = filename
     ? `<span class="cave-code-filename">${escHtml(filename)}</span>`
     : "";
+  // Collapse toggle (chevron) folds the block down to just this header so a
+  // long code dump can be tucked away; blocks render expanded by default. The
+  // line count hints at size while collapsed.
+  const lineCount = lines[lines.length - 1] === "" ? lines.length - 1 : lines.length;
+  const collapseBtn = `<button type="button" class="cave-code-collapse-btn" aria-label="Collapse code" aria-expanded="true"><svg class="cave-code-chevron" width="10" height="10" viewBox="0 0 10 10" aria-hidden="true"><path d="M2 3.5 L5 6.5 L8 3.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg></button>`;
+  const linesHtml = lineCount > 1 ? `<span class="cave-code-lines" aria-hidden="true">${lineCount} lines</span>` : "";
   // No data-code attribute (CHAT-D7-04): wireCopyButtons reads the code text
   // back out of the rendered DOM at click time instead of carrying a second
   // copy of every block's source in an attribute.
-  const headerHtml = `<div class="cave-code-header">${labelHtml}${filenameHtml}<button type="button" class="cave-copy-btn cave-copy-btn-mounted">Copy</button></div>`;
+  const headerHtml = `<div class="cave-code-header">${collapseBtn}${labelHtml}${filenameHtml}${linesHtml}<button type="button" class="cave-copy-btn cave-copy-btn-mounted">Copy</button></div>`;
   const expandHtml = lines.length >= CODE_EXPAND_MIN_LINES
     ? `<div class="cave-code-expand"><button type="button" class="cave-code-expand-btn">Show more</button></div>`
     : "";
@@ -612,6 +619,16 @@ function wireCopyButtons(container: HTMLElement) {
           btn.classList.remove("cave-copy-btn--confirmed");
         }, 2000);
       });
+    });
+  }
+  // Collapse toggle: fold the whole block down to its header (and back).
+  for (const btn of Array.from(container.querySelectorAll<HTMLButtonElement>(".cave-code-collapse-btn"))) {
+    if ((btn as HTMLButtonElement & { _wired?: boolean })._wired) continue;
+    (btn as HTMLButtonElement & { _wired?: boolean })._wired = true;
+    btn.addEventListener("click", () => {
+      const wrap = btn.closest(".cave-code-wrap");
+      if (!wrap) return;
+      toggleCodeBlockCollapse(wrap, btn);
     });
   }
   // Show more / Show less footer on height-clamped blocks (CHAT-D7-03).

--- a/src/lib/code-block-collapse.test.ts
+++ b/src/lib/code-block-collapse.test.ts
@@ -1,0 +1,44 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+
+const { toggleCodeBlockCollapse, CODE_COLLAPSED_CLASS } = await import("./code-block-collapse.ts");
+
+function makeWrap() {
+  const set = new Set();
+  return {
+    classList: {
+      toggle(t) { if (set.has(t)) { set.delete(t); return false; } set.add(t); return true; },
+      contains: (t) => set.has(t),
+    },
+    has: (t) => set.has(t),
+  };
+}
+function makeBtn() {
+  const attrs = {};
+  return { setAttribute: (k, v) => { attrs[k] = v; }, attrs };
+}
+
+// First click collapses; aria reflects collapsed (expanded=false, "Expand code").
+{
+  const wrap = makeWrap();
+  const btn = makeBtn();
+  const collapsed = toggleCodeBlockCollapse(wrap, btn);
+  assert.equal(collapsed, true, "first toggle collapses");
+  assert.ok(wrap.has(CODE_COLLAPSED_CLASS), "collapsed class added");
+  assert.equal(btn.attrs["aria-expanded"], "false");
+  assert.equal(btn.attrs["aria-label"], "Expand code");
+}
+
+// Second click expands; aria reflects expanded (expanded=true, "Collapse code").
+{
+  const wrap = makeWrap();
+  const btn = makeBtn();
+  toggleCodeBlockCollapse(wrap, btn);
+  const collapsed = toggleCodeBlockCollapse(wrap, btn);
+  assert.equal(collapsed, false, "second toggle expands");
+  assert.ok(!wrap.has(CODE_COLLAPSED_CLASS), "collapsed class removed");
+  assert.equal(btn.attrs["aria-expanded"], "true");
+  assert.equal(btn.attrs["aria-label"], "Collapse code");
+}
+
+console.log("code-block-collapse.test.ts: ok");

--- a/src/lib/code-block-collapse.ts
+++ b/src/lib/code-block-collapse.ts
@@ -1,0 +1,21 @@
+// Collapse/expand toggle for chat code blocks. Pure (operates on the minimal
+// DOM surface it needs) so the behavior is unit-testable without a browser —
+// the click listener that calls this is attached in message-bubble's
+// wireCopyButtons, the same path that wires the (shipped) Copy button.
+
+type ClassListLike = { toggle(token: string): boolean };
+type WrapLike = { classList: ClassListLike };
+type BtnLike = { setAttribute(name: string, value: string): void };
+
+export const CODE_COLLAPSED_CLASS = "cave-code-wrap--collapsed";
+
+/**
+ * Toggle a code block's collapsed state and keep the toggle button's a11y
+ * attributes in sync. Returns the new collapsed state.
+ */
+export function toggleCodeBlockCollapse(wrap: WrapLike, btn: BtnLike): boolean {
+  const collapsed = wrap.classList.toggle(CODE_COLLAPSED_CLASS);
+  btn.setAttribute("aria-expanded", String(!collapsed));
+  btn.setAttribute("aria-label", collapsed ? "Expand code" : "Collapse code");
+  return collapsed;
+}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -473,6 +473,55 @@
   max-height: none;
 }
 
+/* Collapsed: fold the block to just its sticky header (toggled by the chevron
+   in wireCopyButtons' collapse wiring). The code body + "Show more" footer are
+   hidden; the header — language, filename, line count, Copy — stays. */
+.cave-code-wrap--collapsed {
+  max-height: none;
+  overflow: hidden;
+}
+.cave-code-wrap--collapsed > pre,
+.cave-code-wrap--collapsed > .cave-code-expand {
+  display: none;
+}
+
+.cave-code-collapse-btn {
+  order: -1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: 4px;
+}
+.cave-code-collapse-btn:hover {
+  color: var(--text-secondary);
+  background: color-mix(in oklch, var(--foreground) 8%, transparent);
+}
+.cave-code-collapse-btn:focus-visible {
+  outline: 2px solid var(--accent-presence);
+  outline-offset: 1px;
+}
+.cave-code-chevron {
+  transition: transform 0.12s ease;
+}
+.cave-code-wrap--collapsed .cave-code-chevron {
+  transform: rotate(-90deg);
+}
+
+.cave-code-lines {
+  font-size: 10px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
 .cave-code-wrap::-webkit-scrollbar { width: 4px; }
 .cave-code-wrap::-webkit-scrollbar-track { background: transparent; }
 .cave-code-wrap::-webkit-scrollbar-thumb {


### PR DESCRIPTION
## What

Chat code blocks already render in a **max-height-scrollable** (`min(60vh,520px)`, `overflow:auto`), **height-expandable** ("Show more") container with **Shiki syntax highlighting**. This adds the one missing affordance from the request: a **collapse chevron** in the sticky header that folds the whole block down to just its header (language · filename · line count · Copy) and expands it back. Blocks stay expanded by default.

So the chat code container is now: **collapsible · height-expandable · max-height scrollable · syntax-highlighted**.

## How

- `renderCodeBlock`: header gains a collapse chevron (`aria-expanded`) + a line count.
- The chevron is wired in `wireCopyButtons` (the same path as Copy / "Show more") and calls `toggleCodeBlockCollapse` from a new pure helper `@/lib/code-block-collapse` — **unit-tested** (collapse/expand + aria sync).
- CSS: collapsed state hides the code body + Show-more footer; the chevron rotates.

## Verification

- **Rendering — live-verified** in the running chat (standalone prod build, headless): the chevron, line count, Shiki highlighting, and the `520px` max-height scroll cap (`overflow:auto`) all render on a real chat code block.
- **Toggle logic — deterministically unit-tested** (`code-block-collapse.test.ts`).
- The chevron wires via the **identical `wireCopyButtons` call** as the chat's Copy button. (Note: my headless harness could not click-verify *either* button — the shipped Copy button also reads inert in it, in dev and prod — so the click itself wasn't eyeballed in-browser; it's wired the same way as the working Copy button and the logic is unit-tested.)
- `pnpm typecheck`, full **app+api (368)**, `check:tests-wired` (384), and `next build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)