### PR TITLE
fix(chat): wire code-block Copy/collapse in single-render previews

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -72,6 +72,7 @@ export const SUITES = {
     "src/components/mermaid-viewer.test.ts",
     "src/components/message-bubble-code-header.test.ts",
     "src/components/message-bubble-code-collapse.test.ts",
+    "src/components/message-bubble-rewire.test.ts",
     "src/lib/code-block-collapse.test.ts",
     "src/components/message-bubble-jump-to-line.test.ts",
     "src/components/message-bubble-file-links.test.ts",

--- a/src/components/mermaid-viewer.test.ts
+++ b/src/components/mermaid-viewer.test.ts
@@ -17,7 +17,7 @@ assert.match(
 );
 assert.match(
   bubble,
-  /wireMermaidDiagrams\(containerRef\.current\)/,
+  /wireMermaidDiagrams\(el\)/,
   "wireMermaidDiagrams runs in the shared useWireCopyButtons post-render hook",
 );
 

--- a/src/components/message-bubble-code-header.test.ts
+++ b/src/components/message-bubble-code-header.test.ts
@@ -50,7 +50,7 @@ const source = await readFile(new URL("./message-bubble.tsx", import.meta.url), 
 
 assert.match(
   source,
-  /function useWireCopyButtons\([\s\S]*?wireCopyButtons\(containerRef\.current\)/,
+  /function useWireCopyButtons\([\s\S]*?wireCopyButtons\(el\)/,
   "A shared post-render hook should wire copy buttons once the injected HTML lands",
 );
 

--- a/src/components/message-bubble-markdown.test.ts
+++ b/src/components/message-bubble-markdown.test.ts
@@ -184,7 +184,7 @@ assert.match(
 );
 assert.match(
   source,
-  /wireMarkdownLinks\(containerRef\.current, onOpenUrl\)/,
+  /wireMarkdownLinks\(el, onOpenUrl\)/,
   "MarkdownContent should wire rendered markdown links through the chat link-open callback",
 );
 assert.match(

--- a/src/components/message-bubble-rewire.test.ts
+++ b/src/components/message-bubble-rewire.test.ts
@@ -1,0 +1,18 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// useWireCopyButtons must re-wire on DOM mutations so code-block Copy / collapse
+// / expand buttons get listeners even when the highlighter populates them after
+// the first render. Without this, single-render surfaces (the comux file /
+// markdown preview's SyntaxBlock & MarkdownBlock) left those buttons inert,
+// while the chat's repeatedly-rendering MarkdownContent happened to wire them.
+
+const bubble = await readFile(new URL("./message-bubble.tsx", import.meta.url), "utf8");
+
+assert.match(bubble, /const observer = new MutationObserver\(\(\) => wireAll\(\)\)/, "a MutationObserver re-runs the wiring");
+assert.match(bubble, /observer\.observe\(el, \{ childList: true, subtree: true \}\)/, "it observes added nodes in the container subtree");
+assert.match(bubble, /return \(\) => observer\.disconnect\(\)/, "the observer is disconnected on cleanup");
+assert.match(bubble, /const wireAll = \(\) => \{[\s\S]*?wireCopyButtons\(el\)[\s\S]*?\};[\s\S]*?wireAll\(\);/, "initial pass wires immediately, then the observer re-wires");
+
+console.log("message-bubble-rewire.test.ts: ok");

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -710,12 +710,26 @@ function wireFilePathLinks(container: HTMLElement) {
 function useWireCopyButtons(html: string | null, onOpenUrl?: (url: string) => void, linkifyPaths = false) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
-    if (html && containerRef.current) {
-      wireCopyButtons(containerRef.current);
-      wireMarkdownLinks(containerRef.current, onOpenUrl);
-      wireMermaidDiagrams(containerRef.current);
-      if (linkifyPaths) wireFilePathLinks(containerRef.current);
-    }
+    const el = containerRef.current;
+    if (!html || !el) return;
+    const wireAll = () => {
+      wireCopyButtons(el);
+      wireMarkdownLinks(el, onOpenUrl);
+      wireMermaidDiagrams(el);
+      if (linkifyPaths) wireFilePathLinks(el);
+    };
+    wireAll();
+    // Re-wire when nodes are added after the first pass. Components that render
+    // once (e.g. the comux file/markdown preview's MarkdownBlock/SyntaxBlock,
+    // vs the chat's repeatedly-re-rendering MarkdownContent) could otherwise
+    // leave a code block's Copy/collapse/expand buttons unwired if the
+    // highlighter populated them after this effect ran. All wiring is
+    // idempotent (guarded per element), and the wiring itself only touches
+    // attributes/listeners — not childList — so it never re-triggers the
+    // observer into a loop.
+    const observer = new MutationObserver(() => wireAll());
+    observer.observe(el, { childList: true, subtree: true });
+    return () => observer.disconnect();
   }, [html, onOpenUrl, linkifyPaths]);
   return containerRef;
 }


### PR DESCRIPTION
## What

Code blocks in the **comux file/markdown preview** had **inert Copy** buttons (and, after #963's collapsible code blocks, an inert collapse chevron). Their `SyntaxBlock`/`MarkdownBlock` render **once**, so when the highlighter populated a block's buttons *after* `useWireCopyButtons`' single wiring pass, those buttons never got listeners. The chat's `MarkdownContent` only worked by luck — it re-renders repeatedly and happened to re-wire.

This is the "comux copy button" issue, now properly root-caused (it's a wiring-timing bug, not the comux toolbar Copy, which always worked).

## Fix

`useWireCopyButtons` now also attaches a **`MutationObserver`** that re-runs the (idempotent) wiring whenever nodes are added to the container — so Copy / collapse / expand / link / mermaid wiring lands regardless of *when* the buttons appear. The wiring only touches attributes + listeners (never `childList`), so it can't loop the observer.

## How it was found & verified

Using the **demo-mode app harness** (`run-cave-app` + the custom **`server.mjs`** — the correct way to run the app; the standalone-server harness I'd used earlier never executed client wiring at all):
- **Before:** comux toolbar Copy worked, but a code block inside a rendered markdown preview had a **dead** Copy + chevron.
- **After (live):** the comux markdown-preview code block now **copies** ("Copied") and **collapses/expands**; the chat block still does too.

New `message-bubble-rewire.test.ts` pins the observer; updated 3 source-assertion tests for the `containerRef.current` → captured-`el` rename. `pnpm typecheck`, full **app+api (369)**, `check:tests-wired` (385), and `next build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)