### PR TITLE
fix(canvas): theme React Flow chrome + hide empty minimap (no white boxes)

### DIFF
--- a/src/components/canvas-view.test.ts
+++ b/src/components/canvas-view.test.ts
@@ -90,4 +90,13 @@ assert.match(view, /kind\s*=\s*result\.kind/, "generation records the extracted 
 assert.match(view, /method:\s*"POST"[\s\S]{0,120}artifact/, "artifacts upsert to /api/canvas via POST");
 assert.match(view, /method:\s*"DELETE"/, "deleting an artifact calls DELETE /api/canvas");
 
+// Chrome: the MiniMap is gated on having nodes (an empty canvas would render a
+// blank box), and React Flow's MiniMap/Controls are themed to the dark surface
+// (they default to white, which the workflow canvas only fixes under its own
+// scope).
+assert.match(view, /nodes\.length > 0 \? <MiniMap/, "MiniMap only renders when there are nodes");
+const canvasCss = await readFile(new URL("../styles/canvas.css", import.meta.url), "utf8");
+assert.match(canvasCss, /\.canvas-view \.react-flow__minimap\s*\{/, "canvas themes the React Flow minimap");
+assert.match(canvasCss, /\.canvas-view \.react-flow__controls-button\s*\{/, "canvas themes the React Flow controls");
+
 console.log("canvas-view.test.ts ✓");

--- a/src/components/canvas-view.tsx
+++ b/src/components/canvas-view.tsx
@@ -497,7 +497,9 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
         {isSketch ? null : <BandGuides />}
         <Background gap={24} size={1} />
         <Controls showInteractive={false} />
-        <MiniMap pannable zoomable nodeStrokeWidth={2} />
+        {/* Nothing to map on an empty canvas — the minimap would just render a
+            blank box, so only show it once there are nodes. */}
+        {nodes.length > 0 ? <MiniMap pannable zoomable nodeStrokeWidth={2} /> : null}
 
         <Panel position="top-left" className="canvas-toolbar">
           <span className="canvas-toolbar__title">

--- a/src/styles/canvas.css
+++ b/src/styles/canvas.css
@@ -562,3 +562,47 @@
   border-radius: 6px;
   cursor: pointer;
 }
+
+/* ── React Flow chrome: theme to match the dark surface ──────────────────── */
+/* Without these, the MiniMap renders a solid white box and the Controls show
+   white buttons (the workflow canvas themes them only under .workflow-canvas). */
+
+.canvas-view .react-flow__controls {
+  border: 1px solid var(--border-hairline);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+}
+
+.canvas-view .react-flow__controls-button {
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border-hairline);
+  color: var(--text-primary);
+  fill: currentColor;
+}
+
+.canvas-view .react-flow__controls-button:hover {
+  background: var(--bg-hover);
+}
+
+.canvas-view .react-flow__minimap {
+  border: 1px solid var(--border-hairline);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--bg-panel);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.3);
+}
+
+.canvas-view .react-flow__minimap-mask {
+  fill: rgba(0, 0, 0, 0.55);
+}
+
+.canvas-view .react-flow__minimap-node {
+  fill: color-mix(in oklab, var(--accent, #6b8fbf) 45%, transparent);
+}
+
+/* Lift the empty-state copy above the bottom composer so it doesn't sit dead
+   center with a large gap below it. */
+.canvas-view[data-layer="sketch"] .canvas-empty {
+  padding-bottom: 160px;
+}


### PR DESCRIPTION
## What

Fixes the two white blank spots on the Canvas surface and tidies the empty Sketch layout.

The Canvas rendered React Flow's **MiniMap** as a solid white box (bottom-right) and its zoom **Controls** as white buttons (bottom-left) — the workflow canvas themes those only under its own `.workflow-canvas` scope, so the Canvas surface fell back to React Flow's light defaults.

## Changes

- Theme `.canvas-view .react-flow__minimap` (+ `-mask`, `-node`) and `.react-flow__controls(-button)` to the dark surface tokens, mirroring the workflow canvas.
- **Hide the MiniMap when there are no nodes** — on an empty Sketch canvas it was just a blank white rectangle with nothing to map.
- Lift the Sketch empty-state copy above the bottom composer so it isn't marooned dead-center.

## Verification

- `tsc` clean; `pnpm build` clean; full `pnpm test:app` (294) green, incl. a new guard in `canvas-view.test.ts` asserting the MiniMap is gated on `nodes.length` and the chrome is themed.
- **Real-chromium check**: Sketch empty state now shows **no white box** (minimap hidden, controls dark); Triage shows a **dark-themed** minimap + controls. Empty-state DOM verified present and lifted above the composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)