### PR TITLE
fix(shortcut): wire the ⌘, Settings shortcut

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -132,6 +132,7 @@ export const SUITES = {
     "src/components/comux-view-changes.test.ts",
     "src/components/code-editor.test.ts",
     "src/components/code-view.test.ts",
+    "src/components/settings-shortcut.test.ts",
     "src/components/bottom-terminal-sr-mirror.test.ts",
     "src/components/terminal-key-bar.test.ts",
     "src/components/voice-call-button.test.ts",

--- a/src/components/settings-shortcut.test.ts
+++ b/src/components/settings-shortcut.test.ts
@@ -1,0 +1,27 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// The TopBar account button's tooltip advertises "Settings (⌘,)", but the
+// shortcut was never wired. workspace.tsx's global keydown handler must handle
+// ⌘/Ctrl+, and navigate to /settings.
+const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
+const topBar = await readFile(new URL("./top-bar.tsx", import.meta.url), "utf8");
+
+// The tooltip that promises the shortcut (the contract this fix honors).
+assert.match(topBar, /Settings \(⌘,\)/, "TopBar advertises the ⌘, settings shortcut");
+
+// ⌘/Ctrl+, is handled in the global keydown handler and opens settings.
+assert.match(
+  workspace,
+  /e\.key === ","\s*\)\s*\{[\s\S]*?nextRouter\.push\("\/settings"\)/,
+  "workspace handles meta/ctrl + ',' by navigating to /settings",
+);
+// It's gated to the meta/ctrl path (not a bare comma), matching ⌘1..⌘9 / ⌘0.
+assert.match(
+  workspace,
+  /meta && !alt && e\.key === ","/,
+  "the ',' shortcut requires the meta/ctrl modifier",
+);
+
+console.log("settings-shortcut.test.ts: ok");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -877,6 +877,14 @@ export function Workspace() {
         return;
       }
 
+      // ⌘, -> Settings (the TopBar account button advertises this shortcut in
+      // its tooltip, but nothing was wired to handle it).
+      if (meta && !alt && e.key === ",") {
+        e.preventDefault();
+        nextRouter.push("/settings");
+        return;
+      }
+
       // ⌥1..⌥9 → Nth familiar
       if (alt && !meta && /^[1-9]$/.test(e.key)) {
         const idx = parseInt(e.key, 10) - 1;
@@ -908,7 +916,7 @@ export function Workspace() {
 
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [familiars, activeId, mode, selectFamiliar, startFamiliarChat]);
+  }, [familiars, activeId, mode, selectFamiliar, startFamiliarChat, nextRouter]);
 
   const showFamiliarChatList = useCallback(() => {
     setPendingChatAction({ kind: "list", nonce: Date.now() });


### PR DESCRIPTION
## What

The TopBar account button's tooltip advertises **"Settings (⌘,)"**, but **no handler was ever wired for ⌘,** — pressing it did nothing, so the advertised keyboard path to open Settings was dead.

(The button *click* itself is fine: I verified it live on the dev app at both desktop and mobile widths — it navigates to `/settings` via `onOpenSettings` and the settings UI renders, no console errors. The defect was specifically the missing shortcut.)

## Fix

Add `⌘/Ctrl+,` to `workspace.tsx`'s global keydown handler, alongside the existing `⌘0` (Code) and `⌘1..⌘9` surface shortcuts → `nextRouter.push("/settings")`.

## Verify

- New `settings-shortcut.test.ts` asserts the TopBar advertises the shortcut and that `workspace` handles `meta/ctrl + ','` → `/settings`.
- `tsc` clean; `check:tests-wired` green (386).

🤖 Generated with [Claude Code](https://claude.com/claude-code)