### PR TITLE
feat(chat): inline "ready to archive" nudge for completed task chats

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -236,6 +236,8 @@ export const SUITES = {
     "src/lib/task-chat-context.test.ts",
     "src/lib/task-archive-nudge.test.ts",
     "src/lib/task-archive-nudge-wiring.test.ts",
+    "src/lib/chat-archive-nudge.test.ts",
+    "src/components/chat-archive-nudge.test.ts",
     "src/lib/theme-palettes.test.ts",
     "src/lib/title-enricher.test.ts",
     "src/lib/url-safety.test.ts",

--- a/src/components/chat-archive-nudge.test.ts
+++ b/src/components/chat-archive-nudge.test.ts
@@ -1,0 +1,133 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// Source-text contract test for the in-chat archive nudge: the banner that
+// surfaces inside a chat tied to a task once that task's execution lifecycle
+// reaches `completed`. We assert the component's API, the chat-view's
+// import/state/handler/render wiring, and the lifecycle->session->nudge chain
+// the user actually sees — so a future refactor that quietly drops the inline
+// surface fails CI instead of just disappearing the feature.
+
+const componentSrc = readFileSync(
+  new URL("./chat-archive-nudge.tsx", import.meta.url),
+  "utf8",
+);
+const chatViewSrc = readFileSync(
+  new URL("./chat-view.tsx", import.meta.url),
+  "utf8",
+);
+const libSrc = readFileSync(
+  new URL("../lib/chat-archive-nudge.ts", import.meta.url),
+  "utf8",
+);
+
+// ── Component surface ─────────────────────────────────────────────────────
+assert.match(
+  componentSrc,
+  /export function ChatArchiveNudge\(/,
+  "ChatArchiveNudge is exported from chat-archive-nudge.tsx",
+);
+assert.match(
+  componentSrc,
+  /taskTitle: string;[\s\S]*onArchive: \(\) => void;[\s\S]*onDismiss: \(\) => void;[\s\S]*archiving\?: boolean;/,
+  "ChatArchiveNudgeProps exposes taskTitle / onArchive / onDismiss / archiving",
+);
+assert.match(
+  componentSrc,
+  /role="status"/,
+  "renders as a live-status region so screen readers announce it",
+);
+assert.match(
+  componentSrc,
+  /aria-label=\{`Ready to archive: \$\{title\}`\}/,
+  "labels itself with the linked task title so the announcement is specific",
+);
+assert.match(
+  componentSrc,
+  /Archive chat/,
+  "primary CTA reads 'Archive chat'",
+);
+// X-close + secondary Dismiss both wired to onDismiss so the user can quit
+// from either affordance.
+assert.match(
+  componentSrc,
+  /aria-label="Dismiss archive nudge"[\s\S]*onClick=\{onDismiss\}/,
+  "header close button is wired to onDismiss",
+);
+// Disabled state during the archive request.
+assert.match(
+  componentSrc,
+  /\{archiving \? "Archiving…" : "Archive chat"\}/,
+  "primary CTA label flips while archiving",
+);
+// Icon must come from the icon whitelist — ph:archive-box is NOT registered.
+assert.doesNotMatch(
+  componentSrc,
+  /ph:archive-box/,
+  "does NOT use ph:archive-box (not in ICON_NAMES); use ph:archive instead",
+);
+assert.match(componentSrc, /ph:archive/, "uses the whitelisted ph:archive icon");
+
+// ── Lib helper surface ────────────────────────────────────────────────────
+for (const symbol of [
+  "shouldShowChatArchiveNudge",
+  "isChatArchiveNudgeDismissed",
+  "markChatArchiveNudgeDismissed",
+  "chatArchiveNudgeDismissKey",
+]) {
+  assert.match(
+    libSrc,
+    new RegExp(`export (function|const) ${symbol}\\b`),
+    `chat-archive-nudge.ts exports ${symbol}`,
+  );
+}
+
+// ── chat-view wiring ─────────────────────────────────────────────────────
+assert.match(
+  chatViewSrc,
+  /import \{ ChatArchiveNudge \} from "@\/components\/chat-archive-nudge"/,
+  "chat-view imports the ChatArchiveNudge component",
+);
+assert.match(
+  chatViewSrc,
+  /import \{[\s\S]*isChatArchiveNudgeDismissed,[\s\S]*markChatArchiveNudgeDismissed,[\s\S]*shouldShowChatArchiveNudge,[\s\S]*\} from "@\/lib\/chat-archive-nudge"/,
+  "chat-view imports all three nudge helpers from the lib",
+);
+assert.match(
+  chatViewSrc,
+  /\[archiveNudgeDismissed, setArchiveNudgeDismissed\] = useState<boolean>/,
+  "chat-view holds the per-session dismiss flag in state",
+);
+assert.match(
+  chatViewSrc,
+  /\[archivingChat, setArchivingChat\] = useState\(false\)/,
+  "chat-view tracks an in-flight archive request",
+);
+// Re-sync the dismiss flag when the active sessionId changes.
+assert.match(
+  chatViewSrc,
+  /setArchiveNudgeDismissed\(isChatArchiveNudgeDismissed\(sessionId \?\? "", window\.localStorage\)\)/,
+  "chat-view re-reads the per-session dismiss flag whenever sessionId changes",
+);
+// archiveChat handler PATCHes /api/sessions/[id] with archived:true and
+// triggers the existing onSessionsChanged + onBack flow.
+assert.match(
+  chatViewSrc,
+  /const archiveChat = useCallback\(async \(\) => \{[\s\S]*\/api\/sessions\/\$\{encodeURIComponent\(sessionId\)\}[\s\S]*archived: true[\s\S]*onSessionsChanged\?\.\(\)[\s\S]*onBack\?\.\(\)/,
+  "archiveChat PATCHes the session as archived and tells the host to refresh + leave",
+);
+assert.match(
+  chatViewSrc,
+  /const dismissArchiveNudge = useCallback\([\s\S]*markChatArchiveNudgeDismissed\(sessionId, window\.localStorage\)/,
+  "dismissArchiveNudge persists the per-session flag to localStorage",
+);
+// Banner is mounted inside the chat thread, just before tailRef so the new
+// turn appears below it visually.
+assert.match(
+  chatViewSrc,
+  /shouldShowChatArchiveNudge\(\{\s*taskLifecycle: linkedContext\?\.task\?\.lifecycle \?\? null,\s*sessionArchived: Boolean\(session\?\.archived_at\),\s*dismissed: archiveNudgeDismissed,\s*\}\) \? \(\s*<ChatArchiveNudge[\s\S]*taskTitle=\{linkedContext\?\.task\?\.title \?\? ""\}[\s\S]*onArchive=\{\(\) => void archiveChat\(\)\}[\s\S]*onDismiss=\{dismissArchiveNudge\}[\s\S]*archiving=\{archivingChat\}/,
+  "chat-view renders ChatArchiveNudge gated on shouldShowChatArchiveNudge with the live task lifecycle, session.archived, and dismissed",
+);
+
+console.log("chat-archive-nudge.test.ts ok");

--- a/src/components/chat-archive-nudge.tsx
+++ b/src/components/chat-archive-nudge.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+/**
+ * ChatArchiveNudge — the inline "final nudge" rendered at the bottom of a
+ * chat transcript when the chat is tied to a task whose execution lifecycle
+ * has reached `completed`. Companion to the global inbox toast (see
+ * `task-archive-nudge.ts`): the toast catches the user wherever they are, this
+ * banner persists inside the chat itself so it's still here when they come
+ * back to read the thread.
+ *
+ * Visibility decision lives in {@link shouldShowChatArchiveNudge}; this
+ * component is purely presentational and renders whatever it's told to render.
+ */
+
+import { Icon } from "@/lib/icon";
+
+export type ChatArchiveNudgeProps = {
+  /** Title of the linked task — surfaced in the nudge body for context. */
+  taskTitle: string;
+  /** Invoked when the user clicks the primary "Archive chat" CTA. */
+  onArchive: () => void;
+  /** Invoked when the user dismisses the nudge for this session. */
+  onDismiss: () => void;
+  /** Disables the archive button while the archive request is in flight. */
+  archiving?: boolean;
+};
+
+export function ChatArchiveNudge({
+  taskTitle,
+  onArchive,
+  onDismiss,
+  archiving = false,
+}: ChatArchiveNudgeProps) {
+  const title = taskTitle.trim() || "this task";
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label={`Ready to archive: ${title}`}
+      className="cave-chat-archive-nudge focus-ring relative mx-auto my-4 flex w-full max-w-[42rem] items-start gap-3 rounded-xl border border-[color-mix(in_oklch,var(--accent-presence)_38%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_10%,var(--bg-raised))] px-4 py-3 text-[13px] text-[var(--text-primary)] shadow-[0_1px_0_color-mix(in_oklch,var(--accent-presence)_20%,transparent)]"
+      data-testid="chat-archive-nudge"
+    >
+      <Icon
+        name="ph:archive"
+        width={18}
+        className="mt-0.5 shrink-0 text-[var(--accent-presence)]"
+        aria-hidden
+      />
+      <div className="min-w-0 flex-1">
+        <div className="font-medium text-[var(--text-primary)]">
+          Ready to archive
+        </div>
+        <p className="mt-0.5 text-[12px] text-[var(--text-secondary)]">
+          <span className="font-medium text-[var(--text-primary)]">{title}</span>
+          {" is complete. Archive this chat to clear it from your active sessions."}
+        </p>
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={onArchive}
+            disabled={archiving}
+            className="focus-ring inline-flex items-center gap-1.5 rounded-md border border-[color-mix(in_oklch,var(--accent-presence)_55%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_18%,transparent)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-primary)] transition-colors hover:bg-[color-mix(in_oklch,var(--accent-presence)_28%,transparent)] disabled:opacity-50"
+          >
+            <Icon name="ph:archive" width={12} aria-hidden />
+            {archiving ? "Archiving…" : "Archive chat"}
+          </button>
+          <button
+            type="button"
+            onClick={onDismiss}
+            disabled={archiving}
+            className="focus-ring inline-flex items-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-[11px] font-medium text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)] disabled:opacity-50"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+      <button
+        type="button"
+        aria-label="Dismiss archive nudge"
+        onClick={onDismiss}
+        disabled={archiving}
+        className="focus-ring absolute right-2 top-2 inline-flex h-6 w-6 items-center justify-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] disabled:opacity-50"
+      >
+        <Icon name="ph:x" width={12} aria-hidden />
+      </button>
+    </div>
+  );
+}

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -17,6 +17,12 @@ import { useFamiliarOverrides } from "@/lib/cave-familiar-overrides";
 import { resolveFamiliar } from "@/lib/familiar-resolve";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { FamiliarInlineCard } from "@/components/familiar-inline-card";
+import { ChatArchiveNudge } from "@/components/chat-archive-nudge";
+import {
+  isChatArchiveNudgeDismissed,
+  markChatArchiveNudgeDismissed,
+  shouldShowChatArchiveNudge,
+} from "@/lib/chat-archive-nudge";
 import type { ChatLinkedContext } from "@/lib/chat-linked-context";
 import {
   MAX_ATTACHMENT_IMAGE_BYTES,
@@ -1497,6 +1503,15 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const [historyRetryKey, setHistoryRetryKey] = useState(0);
   const retryHistory = useCallback(() => setHistoryRetryKey((k) => k + 1), []);
   const [linkedContext, setLinkedContext] = useState<ChatLinkedContext | null>(null);
+  // In-chat "final nudge" — surfaces when the linked task hits `completed`
+  // lifecycle. Dismiss is persisted per-session in localStorage so the banner
+  // doesn't reappear on every reload after the user waved it off.
+  const [archiveNudgeDismissed, setArchiveNudgeDismissed] = useState<boolean>(() =>
+    typeof window === "undefined"
+      ? false
+      : isChatArchiveNudgeDismissed(sessionId ?? "", window.localStorage),
+  );
+  const [archivingChat, setArchivingChat] = useState(false);
   const [modelState, setModelState] = useState<ChatModelState | null>(null);
   const [thinkingEffort, setThinkingEffort] = useState<ComposerThinkingEffort>(() => readComposerPrefs().thinkingEffort);
   const [responseSpeed, setResponseSpeed] = useState<ComposerResponseSpeed>(() => readComposerPrefs().responseSpeed);
@@ -2878,6 +2893,44 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId, session?.project_root, projectRoot, firstProject?.id]);
 
+  // Re-read the per-session dismiss flag whenever the active chat changes, so
+  // dismissing one chat doesn't silently hide the nudge on a different chat.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setArchiveNudgeDismissed(isChatArchiveNudgeDismissed(sessionId ?? "", window.localStorage));
+  }, [sessionId]);
+
+  const dismissArchiveNudge = useCallback(() => {
+    if (typeof window !== "undefined" && sessionId) {
+      markChatArchiveNudgeDismissed(sessionId, window.localStorage);
+    }
+    setArchiveNudgeDismissed(true);
+  }, [sessionId]);
+
+  const archiveChat = useCallback(async () => {
+    if (!sessionId || archivingChat) return;
+    setArchivingChat(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ archived: true }),
+      });
+      const json = await res.json().catch(() => ({ ok: false }));
+      if (!res.ok || !json.ok) {
+        setError(json.error ?? "archive failed");
+        return;
+      }
+      onSessionsChanged?.();
+      onBack?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "archive failed");
+    } finally {
+      setArchivingChat(false);
+    }
+  }, [sessionId, archivingChat, onSessionsChanged, onBack]);
+
   const deleteChat = async () => {
     if (!sessionId || deleting) return;
     setDeleting(true);
@@ -3182,6 +3235,18 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               );
             });
           })()}
+          {shouldShowChatArchiveNudge({
+            taskLifecycle: linkedContext?.task?.lifecycle ?? null,
+            sessionArchived: Boolean(session?.archived_at),
+            dismissed: archiveNudgeDismissed,
+          }) ? (
+            <ChatArchiveNudge
+              taskTitle={linkedContext?.task?.title ?? ""}
+              onArchive={() => void archiveChat()}
+              onDismiss={dismissArchiveNudge}
+              archiving={archivingChat}
+            />
+          ) : null}
           <div ref={tailRef} />
         </div>
 

--- a/src/lib/chat-archive-nudge.test.ts
+++ b/src/lib/chat-archive-nudge.test.ts
@@ -1,0 +1,157 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  chatArchiveNudgeDismissKey,
+  clearChatArchiveNudgeDismissed,
+  isChatArchiveNudgeDismissed,
+  markChatArchiveNudgeDismissed,
+  shouldShowChatArchiveNudge,
+} from "./chat-archive-nudge.ts";
+
+// Fresh in-memory storage per case so dismissals from one case don't bleed.
+function makeStorage() {
+  const map = new Map();
+  return {
+    getItem: (key) => (map.has(key) ? map.get(key) : null),
+    setItem: (key, value) => map.set(key, String(value)),
+    removeItem: (key) => map.delete(key),
+    _dump: () => Object.fromEntries(map),
+  };
+}
+
+// 1. Dismiss key is namespaced per session and deterministic — we rely on this
+//    being stable so an old dismiss stays honored across builds.
+assert.equal(
+  chatArchiveNudgeDismissKey("s-1"),
+  "cave:chat-archive-nudge-dismissed:s-1",
+  "dismiss key is namespaced and includes the session id",
+);
+
+// 2. shouldShowChatArchiveNudge — happy path: completed + active + not dismissed.
+assert.equal(
+  shouldShowChatArchiveNudge({
+    taskLifecycle: "completed",
+    sessionArchived: false,
+    dismissed: false,
+  }),
+  true,
+  "shows when task is completed and chat is active and not dismissed",
+);
+
+// 3. Suppressed when the session is already archived (no nudge after the fact).
+assert.equal(
+  shouldShowChatArchiveNudge({
+    taskLifecycle: "completed",
+    sessionArchived: true,
+    dismissed: false,
+  }),
+  false,
+  "hides once the chat is archived",
+);
+
+// 4. Suppressed when the user previously dismissed the nudge for this session.
+assert.equal(
+  shouldShowChatArchiveNudge({
+    taskLifecycle: "completed",
+    sessionArchived: false,
+    dismissed: true,
+  }),
+  false,
+  "hides once the user dismissed it for this session",
+);
+
+// 5. Suppressed for every non-terminal lifecycle.
+for (const lifecycle of ["queued", "dispatched", "running", "review", "failed", "cancelled"]) {
+  assert.equal(
+    shouldShowChatArchiveNudge({
+      taskLifecycle: lifecycle,
+      sessionArchived: false,
+      dismissed: false,
+    }),
+    false,
+    `does not show for lifecycle=${lifecycle}`,
+  );
+}
+
+// 6. Suppressed when there's no linked task at all (chat with no task tie).
+for (const lifecycle of [null, undefined, ""]) {
+  assert.equal(
+    shouldShowChatArchiveNudge({
+      taskLifecycle: lifecycle,
+      sessionArchived: false,
+      dismissed: false,
+    }),
+    false,
+    `does not show when taskLifecycle is ${JSON.stringify(lifecycle)}`,
+  );
+}
+
+// 7. Dismiss storage round-trip — write, read back as dismissed, clear.
+{
+  const storage = makeStorage();
+  assert.equal(
+    isChatArchiveNudgeDismissed("s-2", storage),
+    false,
+    "starts out not dismissed",
+  );
+  markChatArchiveNudgeDismissed("s-2", storage);
+  assert.equal(
+    isChatArchiveNudgeDismissed("s-2", storage),
+    true,
+    "is dismissed after mark",
+  );
+  assert.equal(
+    storage._dump()["cave:chat-archive-nudge-dismissed:s-2"],
+    "1",
+    "persists as the literal '1' marker so future reads stay cheap",
+  );
+  clearChatArchiveNudgeDismissed("s-2", storage);
+  assert.equal(
+    isChatArchiveNudgeDismissed("s-2", storage),
+    false,
+    "no longer dismissed after clear",
+  );
+}
+
+// 8. Per-session isolation — dismissing one session does NOT dismiss another.
+{
+  const storage = makeStorage();
+  markChatArchiveNudgeDismissed("s-a", storage);
+  assert.equal(isChatArchiveNudgeDismissed("s-a", storage), true);
+  assert.equal(
+    isChatArchiveNudgeDismissed("s-b", storage),
+    false,
+    "dismiss is per-session and does not leak across sessions",
+  );
+}
+
+// 9. Tolerates a missing or throwing storage (Safari private mode, no-window).
+{
+  assert.equal(
+    isChatArchiveNudgeDismissed("s-3", null),
+    false,
+    "treats missing storage as not-dismissed",
+  );
+  // Should not throw on a hostile storage either.
+  const hostile = {
+    getItem: () => {
+      throw new Error("denied");
+    },
+    setItem: () => {
+      throw new Error("denied");
+    },
+    removeItem: () => {
+      throw new Error("denied");
+    },
+  };
+  assert.equal(
+    isChatArchiveNudgeDismissed("s-3", hostile),
+    false,
+    "swallows read errors from a hostile storage",
+  );
+  // These must not throw.
+  markChatArchiveNudgeDismissed("s-3", hostile);
+  clearChatArchiveNudgeDismissed("s-3", hostile);
+}
+
+console.log("chat-archive-nudge.test.ts ok");

--- a/src/lib/chat-archive-nudge.ts
+++ b/src/lib/chat-archive-nudge.ts
@@ -1,0 +1,94 @@
+/**
+ * In-chat archive nudge — the "final nudge" surfaced inline at the end of a
+ * chat transcript when the linked task has reached the end of its execution
+ * lifecycle (card lifecycle → `completed`) and the chat is ready to archive.
+ *
+ * The toast variant (see {@link ./task-archive-nudge}) lives in the global
+ * inbox and auto-dismisses after a few seconds; it is easy to miss when the
+ * user is heads-down in the chat. This module powers a persistent inline
+ * banner that stays put until the user either archives the chat or dismisses
+ * the prompt.
+ *
+ * Pure helpers only — no IO. Storage and network calls are the caller's
+ * concern so this module stays trivially testable in node.
+ */
+
+/** Status passed in from {@link ChatLinkedContext}["task"]["lifecycle"]. */
+const COMPLETED: string = "completed";
+
+/** localStorage key used to remember a per-session dismiss. */
+export function chatArchiveNudgeDismissKey(sessionId: string): string {
+  return `cave:chat-archive-nudge-dismissed:${sessionId}`;
+}
+
+/**
+ * Minimal `Storage`-like surface so callers can pass `window.localStorage`,
+ * `globalThis.localStorage`, or a test fake.
+ */
+export type DismissStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+/** True when the user has previously dismissed the nudge for this session. */
+export function isChatArchiveNudgeDismissed(
+  sessionId: string,
+  storage: DismissStorage | null | undefined,
+): boolean {
+  if (!storage) return false;
+  try {
+    return storage.getItem(chatArchiveNudgeDismissKey(sessionId)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/** Persist a per-session dismiss so the banner stays hidden across reloads. */
+export function markChatArchiveNudgeDismissed(
+  sessionId: string,
+  storage: DismissStorage | null | undefined,
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(chatArchiveNudgeDismissKey(sessionId), "1");
+  } catch {
+    /* swallow — storage may be unavailable (private mode, quota) */
+  }
+}
+
+/** Clear a previous dismiss (e.g. if we ever expose an "undo" path). */
+export function clearChatArchiveNudgeDismissed(
+  sessionId: string,
+  storage: DismissStorage | null | undefined,
+): void {
+  if (!storage) return;
+  try {
+    storage.removeItem(chatArchiveNudgeDismissKey(sessionId));
+  } catch {
+    /* swallow */
+  }
+}
+
+/**
+ * Inputs that determine whether the inline archive nudge should render.
+ * Kept narrow and string-typed so {@link ChatLinkedContext}["task"]["lifecycle"]
+ * (already a `string` at the type level) feeds in directly without coupling
+ * this lib to the board card types.
+ */
+export type ChatArchiveNudgeInputs = {
+  /** Lifecycle of the task linked to this chat, or `null` when no task. */
+  taskLifecycle: string | null | undefined;
+  /** Whether the chat session has already been archived. */
+  sessionArchived: boolean;
+  /** Whether the user has dismissed the nudge for this session. */
+  dismissed: boolean;
+};
+
+/**
+ * Decide whether to render the inline archive nudge for the current chat.
+ * Returns true only when there's a linked task at end-of-lifecycle, the
+ * session is still active, and the user hasn't already dismissed it.
+ */
+export function shouldShowChatArchiveNudge(inputs: ChatArchiveNudgeInputs): boolean {
+  if (inputs.sessionArchived) return false;
+  if (inputs.dismissed) return false;
+  if (!inputs.taskLifecycle) return false;
+  return inputs.taskLifecycle === COMPLETED;
+}


### PR DESCRIPTION
Renders a persistent banner at the bottom of a chat transcript when the chat is tied to a task whose execution lifecycle has reached `completed` — companion to the global inbox toast (`task-archive-nudge`), so the prompt is still there when you return to read the thread. **Archive** / **Dismiss** CTAs; the per-session dismiss persists in `localStorage`.

## Changes

- `src/components/chat-archive-nudge.tsx` — presentational banner (Archive / Dismiss / close); pure props, no new deps, no CSS rule needed (inline Tailwind).
- `src/lib/chat-archive-nudge.ts` — `shouldShowChatArchiveNudge` + `is`/`markChatArchiveNudgeDismissed` (visibility decision + per-session dismiss state).
- `chat-view.tsx` wires the dismiss state and renders the nudge at the bottom of the transcript (additive — 65 lines, 0 deletions).
- New unit + component tests, registered in `run-tests.mjs`.

## Provenance

Assembled from in-progress working-tree changes into a clean, self-contained commit (only the chat-archive-nudge files — the unrelated WIP in the tree was left untouched).

## Verify

- `tsc --noEmit` clean; `check:tests-wired` green (390 wired).
- `chat-archive-nudge` (lib + component) tests pass; `chat-view` / `chat-view-polish` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)