### PR TITLE
feat(search): case-sensitivity toggle + file-glob filter for project search

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -132,6 +132,7 @@ export const SUITES = {
     "src/components/comux-view-terminal.test.ts",
     "src/components/comux-view-edit.test.ts",
     "src/components/comux-view-changes.test.ts",
+    "src/components/comux-view-search-options.test.ts",
     "src/components/code-editor.test.ts",
     "src/components/code-view.test.ts",
     "src/components/settings-shortcut.test.ts",

--- a/src/components/comux-view-search-options.test.ts
+++ b/src/components/comux-view-search-options.test.ts
@@ -1,0 +1,24 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Project search (#932) gains case-sensitivity + file-glob options. The route
+// already accepted ?case= and ?glob=; this wires the UI to them.
+const src = await readFile(new URL("./comux-view.tsx", import.meta.url), "utf8");
+
+// State.
+assert.match(src, /const \[searchCaseSensitive, setSearchCaseSensitive\] = useState\(false\)/, "case-sensitivity state");
+assert.match(src, /const \[searchGlob, setSearchGlob\] = useState\(""\)/, "glob filter state");
+
+// Fetch wires the params (and only when set).
+assert.match(src, /if \(searchCaseSensitive\) params\.set\("case", "sensitive"\)/, "case param sent when sensitive");
+assert.match(src, /const glob = searchGlob\.trim\(\);[\s\S]*?if \(glob\) params\.set\("glob", glob\)/, "glob param sent when present");
+assert.match(src, /\}, \[searchInput, searchRegex, searchCaseSensitive, searchGlob, searchRoot\]\)/, "effect re-runs on the new options");
+
+// UI controls.
+assert.match(src, /onClick=\{\(\) => setSearchCaseSensitive\(\(v\) => !v\)\}[\s\S]*?aria-pressed=\{searchCaseSensitive\}/, "Aa case toggle wired");
+assert.match(src, /onChange=\{\(e\) => setSearchGlob\(e\.target\.value\)\}/, "glob filter input updates state");
+assert.match(src, /aria-label="Filter files by glob"/, "glob filter input is labelled");
+assert.match(src, /placeholder="Filter files — e\.g\. \*\.ts/, "glob input has a helpful placeholder");
+
+console.log("comux-view-search-options.test.ts: ok");

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -298,6 +298,8 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   // Project-wide code search (CODE-SEARCH-01).
   const [searchInput, setSearchInput] = useState("");
   const [searchRegex, setSearchRegex] = useState(false);
+  const [searchCaseSensitive, setSearchCaseSensitive] = useState(false);
+  const [searchGlob, setSearchGlob] = useState("");
   const [searchResult, setSearchResult] = useState<SearchResult | null>(null);
   const [searchLoading, setSearchLoading] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
@@ -661,6 +663,9 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
     const timer = setTimeout(() => {
       const params = new URLSearchParams({ root: searchRoot, q: query });
       if (searchRegex) params.set("regex", "1");
+      if (searchCaseSensitive) params.set("case", "sensitive");
+      const glob = searchGlob.trim();
+      if (glob) params.set("glob", glob);
       fetch(`/api/project/search?${params.toString()}`, { cache: "no-store" })
         .then((res) => res.json())
         .then((json: SearchResult & { ok: boolean; repo?: boolean; error?: string }) => {
@@ -686,7 +691,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
       cancelled = true;
       clearTimeout(timer);
     };
-  }, [searchInput, searchRegex, searchRoot]);
+  }, [searchInput, searchRegex, searchCaseSensitive, searchGlob, searchRoot]);
 
   // Open a search match: search paths are relative to the searched root, so
   // rejoin them to the project root before handing off to the file preview.
@@ -1111,21 +1116,54 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                           onChange={(e) => setSearchInput(e.target.value)}
                           placeholder="Search in project…"
                           aria-label="Search in project"
-                          className="w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/60 py-1.5 pl-7 pr-14 text-[11px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--border-strong)] focus:outline-none"
+                          className="w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/60 py-1.5 pl-7 pr-[3.75rem] text-[11px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--border-strong)] focus:outline-none"
                         />
-                        <button
-                          type="button"
-                          onClick={() => setSearchRegex((v) => !v)}
-                          aria-pressed={searchRegex}
-                          title={searchRegex ? "Regex search on" : "Regex search off — matching literal text"}
-                          className={`absolute right-1.5 top-1/2 -translate-y-1/2 rounded px-1 py-0.5 font-mono text-[10px] transition-colors ${
-                            searchRegex
-                              ? "bg-[var(--accent-presence,var(--bg-raised))] text-[var(--text-primary)]"
-                              : "text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)]"
-                          }`}
-                        >
-                          .*
-                        </button>
+                        <div className="absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-0.5">
+                          <button
+                            type="button"
+                            onClick={() => setSearchCaseSensitive((v) => !v)}
+                            aria-pressed={searchCaseSensitive}
+                            title={searchCaseSensitive ? "Case-sensitive" : "Case-insensitive (smart case)"}
+                            className={`rounded px-1 py-0.5 font-mono text-[10px] transition-colors ${
+                              searchCaseSensitive
+                                ? "bg-[var(--accent-presence,var(--bg-raised))] text-[var(--text-primary)]"
+                                : "text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)]"
+                            }`}
+                          >
+                            Aa
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setSearchRegex((v) => !v)}
+                            aria-pressed={searchRegex}
+                            title={searchRegex ? "Regex search on" : "Regex search off — matching literal text"}
+                            className={`rounded px-1 py-0.5 font-mono text-[10px] transition-colors ${
+                              searchRegex
+                                ? "bg-[var(--accent-presence,var(--bg-raised))] text-[var(--text-primary)]"
+                                : "text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)]"
+                            }`}
+                          >
+                            .*
+                          </button>
+                        </div>
+                      </div>
+                      {/* File-glob include filter (passes ?glob= to ripgrep). */}
+                      <div className="relative mt-1.5">
+                        <Icon
+                          name="ph:funnel"
+                          width={11}
+                          className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-[var(--text-muted)]"
+                        />
+                        <input
+                          type="text"
+                          value={searchGlob}
+                          onChange={(e) => setSearchGlob(e.target.value)}
+                          placeholder="Filter files — e.g. *.ts, src/**"
+                          aria-label="Filter files by glob"
+                          spellCheck={false}
+                          autoComplete="off"
+                          className="w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/60 py-1 pl-7 pr-2 font-mono text-[10px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--border-strong)] focus:outline-none"
+                        />
                       </div>
                       {searchInput.trim() && (
                         <div className="mt-2">


### PR DESCRIPTION
## What

Extends project-wide search (#932) with two options in the comux search UI. The `/api/project/search` route already accepted `?case=` and `?glob=` — this exposes them:

- **`Aa` case-sensitivity toggle** beside the regex (`.*`) toggle — off = ripgrep smart-case, on = case-sensitive.
- **File-glob include filter** ("Filter files — e.g. `*.ts`, `src/**`") below the search box → `?glob=`.

Both feed the debounced search and re-run on change.

## Verification

**Live** (custom `server.mjs`, comux pointed at a real git repo): searching `export` matched **146 files**; adding glob `*.md` narrowed to **5 files**, `*.ts` to **132** — the glob filter demonstrably changes the result set through real ripgrep. Case toggle + glob input both present and wired (screenshot captured).

Source-asserted (`comux-view-search-options.test.ts`); `pnpm typecheck`, full **app+api (373)**, `check:tests-wired` (389), and `next build` all green.

## Coordination
Built within my claimed lane (`.claude/claims.json` → project-search): only the **search block** of `comux-view.tsx` is touched — not the file tree, editor, Files/Changes, or terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)