### PR TITLE
fix(chrome): hold daemon-offline banner until status resolves; clear GitHub header from the panel float

### DIFF
--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -133,3 +133,12 @@ assert.doesNotMatch(
 );
 
 console.log("github-view-polish.test.ts OK");
+
+// The header must reserve a right gutter so its actions clear the floating
+// right panel-toggle (.shell-panel-float--right, a 44px strip) — otherwise the
+// Add PAT / Refresh buttons render under it and become unclickable.
+assert.match(
+  source,
+  /github-surface-header[^"]*\bpr-11\b/,
+  "GitHub header reserves a 44px (pr-11) right gutter for the floating panel toggle",
+);

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -1111,7 +1111,11 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
       )}
 
       {/* ── Header ── */}
-      <header className="github-surface-header flex items-center gap-3 px-5 py-2">
+      {/* pr-11 (44px) reserves a gutter for the floating right panel-toggle
+          (.shell-panel-float--right, a full-height 44px strip overlaying the
+          surface's right edge), so the Add PAT / Refresh buttons don't sit
+          under it and become unclickable — same gutter the chat header uses. */}
+      <header className="github-surface-header flex items-center gap-3 pl-5 pr-11 py-2">
         <div className="flex items-center gap-2">
           {activity?.login && (
             <span className="text-[12px] text-[var(--text-secondary)]">@{activity.login}</span>

--- a/src/components/workspace-sessions-navigation.test.ts
+++ b/src/components/workspace-sessions-navigation.test.ts
@@ -29,3 +29,11 @@ assert.match(
   /name: "\/sessions"[\s\S]*description: "Open all sessions across familiars and runtimes\."/,
   "Slash command help should describe Sessions as cross-familiar and cross-runtime",
 );
+
+// The daemon-offline banner must only appear once the status poll has resolved
+// — never during the initial unknown window (which flashed the banner on load).
+assert.match(
+  workspace,
+  /else if \(daemonStatusResolved\)/,
+  "daemon-offline banner is gated on a resolved status, not the initial unknown state",
+);

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -160,6 +160,9 @@ export function Workspace() {
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [mode, setMode] = useState<WorkspaceMode>("home");
+  // Whether the first daemon status poll has resolved. Until it has, the daemon
+  // state is *unknown* (not "offline"), so the offline banner must stay hidden.
+  const [daemonStatusResolved, setDaemonStatusResolved] = useState(false);
   // Pending Workflow Studio deep link (set when opening a workflow from Roles).
   const [workflowDeepLink, setWorkflowDeepLink] = useState<string | null>(null);
   const browserPaneRef = useRef<BrowserPaneHandle>(null);
@@ -219,6 +222,10 @@ export function Workspace() {
       setDaemonRunning(json.running === true);
     } catch {
       setDaemonRunning(false);
+    } finally {
+      // The first poll has now produced a real answer — only after this may the
+      // offline banner appear, so a fresh load doesn't flash it before we know.
+      setDaemonStatusResolved(true);
     }
   }, []);
 
@@ -364,7 +371,9 @@ export function Workspace() {
     if (daemonRunning) {
       dismissBanner("daemon-offline");
       dismissBanner("daemon-start-error");
-    } else {
+    } else if (daemonStatusResolved) {
+      // Only show the offline banner once the status has actually resolved to
+      // "not running" — never during the initial unknown window.
       pushBanner({
         id: "daemon-offline",
         severity: "warning",
@@ -377,7 +386,7 @@ export function Workspace() {
         },
       });
     }
-  }, [daemonRunning, pushBanner, dismissBanner, startDaemon]);
+  }, [daemonRunning, daemonStatusResolved, pushBanner, dismissBanner, startDaemon]);
 
   const loadFamiliars = useCallback(async () => {
     try {


### PR DESCRIPTION
Two small chrome fixes from reported UI issues.

## 1. Daemon-offline banner flashed on every load
`daemonRunning` initialized to `false`, so the banner effect pushed the "Daemon offline" banner on first paint — *before* the first `/api/daemon/status` poll resolved — then dismissed it a moment later when status came back online. On a healthy machine that's a flash of a false warning on every load.

**Fix:** track a `daemonStatusResolved` flag (set in the poll's `finally`) and only push the banner when status has actually resolved to "not running" (`else if (daemonStatusResolved)`). Until the first poll resolves the state is *unknown*, not offline, so nothing shows.

## 2. GitHub header right controls hidden under the panel toggle
The floating right panel-toggle (`.shell-panel-float--right`) is a full-height **44px** strip at `z-40` overlaying every surface's right edge. The GitHub header's right group (Add PAT + Refresh) hugged the right edge and rendered *under* it — visually clipped and unclickable.

**Fix:** reserve a 44px right gutter on the header (`px-5` → `pl-5 pr-11`), the same gutter the chat header already uses for this float (`cave-chat.css`).

## Verification
- `tsc` clean; full `pnpm test:app` (298) green, incl. new guards in `github-view-polish` (header reserves `pr-11`) and `workspace-sessions-navigation` (banner gated on resolved status).
- Built + ran the surface in a real browser: the Refresh button's right edge now lands exactly at the float's left edge (measured `refreshUnderFloat: false`); Add PAT + Refresh are fully visible with a clear gap before the toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)