### PR TITLE
feat(dashboard): world-class overview dashboard linking to daily reports

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -50,6 +50,8 @@ export const SUITES = {
     "src/lib/chat-reply.test.ts",
     "src/components/chat-reply-wiring.test.ts",
     "src/lib/reminder-draft.test.ts",
+    "src/lib/daily-report.test.ts",
+    "src/app/dashboard-page.test.ts",
     "src/components/dev-cache-reset-script.test.ts",
     "src/components/pwa-register.test.ts",
     "src/lib/readable-text-color.test.ts",

--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -1,0 +1,23 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+
+const pageUrl = new URL("./dashboard/page.tsx", import.meta.url);
+
+assert.equal(existsSync(pageUrl), true, "dashboard route should exist at /dashboard");
+
+const page = existsSync(pageUrl) ? readFileSync(pageUrl, "utf8") : "";
+
+assert.match(page, /loadInbox/, "dashboard should load persisted inbox data");
+assert.match(page, /liveSnapshot/, "dashboard should compute a live snapshot");
+assert.match(page, /recentReports/, "dashboard should list recent daily reports");
+assert.match(
+  page,
+  /href=\{(featuredReport|report)\.href\}/,
+  "dashboard should link to a daily report via the report href",
+);
+assert.match(page, /dr-cta/, "dashboard should feature a primary report CTA");
+assert.match(page, /Needs attention/, "dashboard should surface an actionable needs-attention list");
+assert.match(page, /dr-page/, "dashboard should use the shared surface styling");
+
+console.log("dashboard-page.test.ts: ok");

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,228 @@
+import { loadInbox } from "@/lib/cave-inbox";
+import { Icon } from "@/lib/icon";
+import { CopyLinkButton } from "@/components/copy-link-button";
+import { EmptyState, ItemRow, MetricCard, QuickLink, SectionHead } from "@/components/daily-report-ui";
+import {
+  breakdownForDay,
+  dateSlug,
+  liveSnapshot,
+  longDateLabel,
+  recentReports,
+  relativeDayLabel,
+  relativeTime,
+} from "@/lib/daily-report";
+
+export const dynamic = "force-dynamic";
+
+export default async function DashboardPage() {
+  const inbox = await loadInbox();
+  const now = new Date();
+  const snapshot = liveSnapshot(inbox.items, now);
+  const breakdown = breakdownForDay(inbox.items, now);
+  const reports = recentReports(inbox.items);
+  const todaySlug = dateSlug(now);
+  const todaysReport = reports.find((report) => report.slug === todaySlug) ?? null;
+  const latestReport = reports[0] ?? null;
+  const featuredReport = todaysReport ?? latestReport;
+  const openCount = breakdown.openItems.length;
+
+  return (
+    <main className="dr-page">
+      <div className="dr-topbar">
+        <nav className="dr-topbar__crumbs" aria-label="Breadcrumb">
+          <a className="dr-back" href="/">
+            <Icon name="ph:arrow-left" aria-hidden />
+            CovenCave
+          </a>
+          <span className="dr-crumb-sep" aria-hidden>/</span>
+          <span className="dr-crumb-current">Dashboard</span>
+        </nav>
+        <div className="dr-topbar__actions">
+          <CopyLinkButton />
+        </div>
+      </div>
+
+      <div className="dr-shell">
+        <header className="dr-hero">
+          <p className="dr-eyebrow">
+            <span className="dr-eyebrow__dot" aria-hidden />
+            Dashboard
+          </p>
+          <h1 className="dr-title">Today in your cave</h1>
+          <p className="dr-subtitle">
+            A live overview of what needs you and what your familiars have been up to. {longDateLabel(now)}.
+          </p>
+          <div className="dr-meta-row">
+            <span className="dr-meta-row__item">
+              <Icon name="ph:clock" aria-hidden />
+              Updated {relativeTime(now.toISOString(), now) || "just now"}
+            </span>
+            {openCount > 0 ? (
+              <span className="dr-meta-row__item">
+                <Icon name="ph:warning-circle" aria-hidden />
+                {openCount} {openCount === 1 ? "item needs" : "items need"} attention
+              </span>
+            ) : (
+              <span className="dr-meta-row__item">
+                <Icon name="ph:check-circle" aria-hidden />
+                All caught up
+              </span>
+            )}
+          </div>
+        </header>
+
+        {/* Primary CTA → today's (or the latest) daily report. */}
+        {featuredReport ? (
+          <a className="dr-cta" href={featuredReport.href}>
+            <div style={{ display: "flex", alignItems: "center", gap: 16, minWidth: 0 }}>
+              <span className="dr-cta__icon">
+                <Icon name="ph:newspaper" aria-hidden />
+              </span>
+              <span style={{ minWidth: 0 }}>
+                <div className="dr-cta__title">
+                  {todaysReport ? "Today's daily report is ready" : "Latest daily report"}
+                </div>
+                <div className="dr-cta__sub">
+                  {featuredReport.title}
+                  {featuredReport.generatedAt
+                    ? ` · generated ${relativeTime(featuredReport.generatedAt, now)}`
+                    : ""}
+                </div>
+              </span>
+            </div>
+            <span className="dr-btn dr-btn--primary" aria-hidden>
+              Read report
+              <Icon name="ph:arrow-right-bold" aria-hidden />
+            </span>
+          </a>
+        ) : (
+          <div className="dr-cta" style={{ cursor: "default" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 16, minWidth: 0 }}>
+              <span className="dr-cta__icon">
+                <Icon name="ph:newspaper" aria-hidden />
+              </span>
+              <span style={{ minWidth: 0 }}>
+                <div className="dr-cta__title">No daily report yet</div>
+                <div className="dr-cta__sub">
+                  A daily report is generated automatically once there&apos;s activity to
+                  summarize — it&apos;ll appear here.
+                </div>
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* Live snapshot metrics. */}
+        <section className="dr-metrics" aria-label="Today at a glance">
+          <MetricCard
+            icon="ph:bell"
+            value={snapshot.reminders}
+            label="Reminders today"
+            caption="Fired today"
+            accent="amber"
+          />
+          <MetricCard
+            icon="ph:chat-circle-dots"
+            value={snapshot.responses}
+            label="Responses waiting"
+            caption="Need your reply"
+            accent="rose"
+          />
+          <MetricCard
+            icon="ph:sparkle"
+            value={snapshot.familiars}
+            label="Familiar updates"
+            caption="From your agents"
+            accent="lavender"
+          />
+          <MetricCard
+            icon="ph:newspaper"
+            value={reports.length}
+            label="Daily reports"
+            caption="Archived snapshots"
+            accent="blue"
+          />
+        </section>
+
+        {/* Needs attention — actionable, live. */}
+        <section className="dr-section" aria-label="Needs attention">
+          <SectionHead
+            icon="ph:warning-circle"
+            title="Needs attention"
+            count={openCount}
+            hint="Click to jump back in"
+          />
+          {openCount > 0 ? (
+            <div className="dr-list">
+              {breakdown.openItems.slice(0, 8).map((open) => (
+                <ItemRow key={open.id} item={open} now={now} />
+              ))}
+            </div>
+          ) : (
+            <EmptyState icon="ph:check-circle">
+              Nothing needs you right now. Your reminders and responses are all handled.
+            </EmptyState>
+          )}
+        </section>
+
+        {/* Recent daily reports. */}
+        <section className="dr-section" aria-label="Recent daily reports">
+          <SectionHead icon="ph:newspaper" title="Recent daily reports" count={reports.length} />
+          {reports.length > 0 ? (
+            <div className="dr-list">
+              {reports.slice(0, 7).map((report) => {
+                const reportDate = new Date(`${report.slug}T00:00:00`);
+                return (
+                  <a key={report.slug} className="dr-row" href={report.href}>
+                    <span className="dr-row__icon" style={{ ["--row-accent" as string]: "var(--color-info)" }}>
+                      <Icon name="ph:newspaper" aria-hidden />
+                    </span>
+                    <span className="dr-row__body dr-report-row">
+                      <span style={{ minWidth: 0, flex: 1 }}>
+                        <span className="dr-row__title">{relativeDayLabel(reportDate, now)}</span>
+                        <span className="dr-row__sub">{report.title}</span>
+                      </span>
+                      {report.stats ? (
+                        <span className="dr-report-row__stats">
+                          <span className="dr-mini-stat"><b>{report.stats.reminders}</b> rem</span>
+                          <span className="dr-mini-stat"><b>{report.stats.responses}</b> resp</span>
+                          <span className="dr-mini-stat"><b>{report.stats.sessions}</b> sess</span>
+                        </span>
+                      ) : null}
+                    </span>
+                    <span className="dr-row__open">
+                      <span>Open</span>
+                      <Icon name="ph:arrow-right-bold" aria-hidden />
+                    </span>
+                  </a>
+                );
+              })}
+            </div>
+          ) : (
+            <EmptyState icon="ph:newspaper">
+              No daily reports yet. They&apos;re generated automatically as you use the cave.
+            </EmptyState>
+          )}
+        </section>
+
+        {/* Jump-off quick links into the app shell. */}
+        <section className="dr-section" aria-label="Workspaces">
+          <SectionHead icon="ph:squares-four" title="Workspaces" />
+          <div className="dr-quicklinks">
+            <QuickLink href="/" icon="ph:house-bold" label="Home" sub="Your cave" />
+            <QuickLink href="/#card-" icon="ph:kanban-bold" label="Board" sub="Cards & tasks" />
+            <QuickLink href="/" icon="ph:calendar-bold" label="Calendar" sub="Reminders & agenda" />
+            <QuickLink href="/" icon="ph:books-bold" label="Library" sub="Saved knowledge" />
+            <QuickLink href="/settings" icon="ph:gear-six" label="Settings" sub="Preferences" />
+            <QuickLink href="/aesthetic" icon="ph:paint-brush" label="Aesthetic" sub="Design tokens" />
+          </div>
+        </section>
+
+        <footer className="dr-footer">
+          This dashboard reads your local inbox and session activity. Metrics are live; daily reports
+          are point-in-time snapshots generated automatically.
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6348,3 +6348,397 @@ a.mobile-handoff__link:hover {
   background: color-mix(in oklch, var(--accent-presence) 18%, transparent);
   border-color: var(--accent-presence); color: var(--text-primary);
 }
+
+
+/* ── Daily report + Dashboard surfaces ───────────────────────────────────────
+   Standalone full-page routes (`/daily-report/[date]`, `/dashboard`) that live
+   outside the app shell. They share one visual language: a quiet lavender-tinted
+   canvas, lifted metric cards, and actionable item rows that deep-link back into
+   the workspace. Prefixed `.dr-` so they never collide with shell styles. */
+.dr-page {
+  min-height: 100vh;
+  height: 100vh;
+  overflow-y: auto;
+  background:
+    radial-gradient(1100px 520px at 82% -8%, color-mix(in oklch, var(--accent-presence) 18%, transparent), transparent 70%),
+    radial-gradient(900px 480px at -6% 2%, color-mix(in oklch, var(--accent-presence) 9%, transparent), transparent 64%),
+    var(--bg-base);
+  color: var(--text-primary);
+  font-family: var(--font-sans), system-ui, sans-serif;
+}
+
+.dr-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px clamp(20px, 5vw, 64px);
+  background: color-mix(in oklch, var(--bg-base) 78%, transparent);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--border-hairline);
+}
+.dr-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: color 0.14s ease;
+}
+.dr-back:hover { color: var(--text-primary); }
+.dr-topbar__crumbs { display: inline-flex; align-items: center; gap: 8px; min-width: 0; }
+.dr-crumb-sep { color: var(--text-muted); font-size: 12px; }
+.dr-crumb-current { font-size: 13px; color: var(--text-primary); font-weight: 560; }
+.dr-topbar__actions { display: inline-flex; align-items: center; gap: 8px; flex-shrink: 0; }
+
+.dr-shell {
+  width: 100%;
+  max-width: 1060px;
+  margin: 0 auto;
+  padding: clamp(28px, 4vw, 56px) clamp(20px, 5vw, 64px) 96px;
+}
+
+/* Hero ---------------------------------------------------------------------- */
+.dr-hero { margin-bottom: 36px; }
+.dr-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent-presence);
+  margin: 0 0 14px;
+}
+.dr-eyebrow__dot {
+  width: 7px; height: 7px; border-radius: 999px;
+  background: var(--accent-presence);
+  box-shadow: 0 0 0 4px color-mix(in oklch, var(--accent-presence) 22%, transparent);
+}
+.dr-title {
+  margin: 0 0 10px;
+  font-size: clamp(30px, 5vw, 46px);
+  line-height: 1.06;
+  font-weight: 720;
+  letter-spacing: -0.02em;
+}
+.dr-subtitle {
+  margin: 0;
+  max-width: 60ch;
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+.dr-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 16px;
+  margin-top: 16px;
+  font-size: 12.5px;
+  color: var(--text-muted);
+}
+.dr-meta-row__item { display: inline-flex; align-items: center; gap: 6px; }
+.dr-actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 22px; }
+
+/* Buttons ------------------------------------------------------------------- */
+.dr-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 38px;
+  padding: 0 16px;
+  border-radius: var(--radius-control);
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-raised);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 560;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.14s ease, border-color 0.14s ease, transform 0.06s ease;
+}
+.dr-btn:hover { background: var(--muted); border-color: var(--border-strong); }
+.dr-btn:active { transform: translateY(1px); }
+.dr-btn--primary {
+  background: var(--accent-presence);
+  border-color: transparent;
+  color: var(--accent-presence-foreground, #fff);
+}
+.dr-btn--primary:hover {
+  background: color-mix(in oklch, var(--accent-presence) 88%, #000);
+  border-color: transparent;
+}
+.dr-btn--sm { height: 32px; padding: 0 12px; font-size: 12.5px; }
+
+/* Metric cards -------------------------------------------------------------- */
+.dr-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 14px;
+  margin-bottom: 40px;
+}
+.dr-metric {
+  position: relative;
+  overflow: hidden;
+  padding: 18px 18px 16px;
+  border-radius: var(--radius-card);
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-raised);
+  transition: border-color 0.16s ease, transform 0.16s ease, box-shadow 0.16s ease;
+}
+.dr-metric::after {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--metric-accent, var(--accent-presence)), transparent);
+  opacity: 0.55;
+}
+.dr-metric:hover {
+  border-color: var(--border-strong);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px -18px color-mix(in oklch, var(--accent-presence) 60%, #000);
+}
+.dr-metric__top { display: flex; align-items: center; justify-content: space-between; margin-bottom: 14px; }
+.dr-metric__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px; height: 34px;
+  border-radius: 9px;
+  font-size: 18px;
+  color: var(--metric-accent, var(--accent-presence));
+  background: color-mix(in oklch, var(--metric-accent, var(--accent-presence)) 16%, transparent);
+}
+.dr-metric__value { font-size: 38px; font-weight: 720; line-height: 1; letter-spacing: -0.02em; }
+.dr-metric__label { margin-top: 8px; font-size: 13px; font-weight: 560; color: var(--text-primary); }
+.dr-metric__caption { margin-top: 2px; font-size: 12px; color: var(--text-muted); }
+.dr-metric--muted .dr-metric__value { color: var(--text-muted); }
+
+/* Sections ------------------------------------------------------------------ */
+.dr-section { margin-bottom: 34px; }
+.dr-section__head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.dr-section__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  margin: 0;
+  font-size: 16px;
+  font-weight: 620;
+  letter-spacing: -0.01em;
+}
+.dr-section__title svg { color: var(--accent-presence); font-size: 18px; }
+.dr-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 7px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: var(--muted);
+}
+.dr-section__hint { margin-left: auto; font-size: 12px; color: var(--text-muted); }
+
+/* Item rows ----------------------------------------------------------------- */
+.dr-list { display: flex; flex-direction: column; gap: 8px; }
+.dr-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 13px;
+  padding: 13px 14px;
+  border-radius: var(--radius-card);
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-raised);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.14s ease, background 0.14s ease, transform 0.06s ease;
+}
+a.dr-row:hover {
+  border-color: var(--border-strong);
+  background: color-mix(in oklch, var(--accent-presence) 6%, var(--bg-raised));
+}
+a.dr-row:active { transform: translateY(1px); }
+.dr-row__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px; height: 32px;
+  flex-shrink: 0;
+  border-radius: 9px;
+  font-size: 17px;
+  color: var(--row-accent, var(--accent-presence));
+  background: color-mix(in oklch, var(--row-accent, var(--accent-presence)) 14%, transparent);
+}
+.dr-row__body { min-width: 0; flex: 1; }
+.dr-row__title {
+  font-size: 14px;
+  font-weight: 560;
+  line-height: 1.35;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+.dr-row__sub {
+  margin-top: 3px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+}
+.dr-row__metaline { display: flex; flex-wrap: wrap; align-items: center; gap: 6px 10px; margin-top: 7px; }
+.dr-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 560;
+  color: var(--row-accent, var(--text-secondary));
+  background: color-mix(in oklch, var(--row-accent, var(--accent-presence)) 12%, transparent);
+}
+.dr-row__time { font-size: 11.5px; color: var(--text-muted); }
+.dr-row__open {
+  align-self: center;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-muted);
+  transition: color 0.14s ease, transform 0.14s ease;
+}
+a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: translateX(2px); }
+
+/* Empty states -------------------------------------------------------------- */
+.dr-empty {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 20px;
+  border-radius: var(--radius-card);
+  border: 1px dashed var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-raised) 60%, transparent);
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+.dr-empty svg { font-size: 22px; color: var(--color-success, var(--accent-presence)); flex-shrink: 0; }
+
+/* Summary + generated card -------------------------------------------------- */
+.dr-panel {
+  padding: 20px 22px;
+  border-radius: var(--radius-panel);
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-raised);
+}
+.dr-panel__title { margin: 0 0 12px; font-size: 14px; font-weight: 620; }
+.dr-summary-body { margin: 0; white-space: pre-line; line-height: 1.75; font-size: 14px; color: var(--text-secondary); }
+.dr-cardimg {
+  display: block;
+  width: 100%;
+  border-radius: var(--radius-panel);
+  border: 1px solid var(--border-hairline);
+  box-shadow: 0 24px 60px -36px color-mix(in oklch, var(--accent-presence) 70%, #000);
+}
+
+/* Dashboard quick links ----------------------------------------------------- */
+.dr-quicklinks {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(168px, 1fr));
+  gap: 12px;
+}
+.dr-quicklink {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 15px;
+  border-radius: var(--radius-card);
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-raised);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.14s ease, background 0.14s ease, transform 0.12s ease;
+}
+.dr-quicklink:hover {
+  border-color: var(--border-strong);
+  background: color-mix(in oklch, var(--accent-presence) 7%, var(--bg-raised));
+  transform: translateY(-2px);
+}
+.dr-quicklink__icon {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 36px; height: 36px; border-radius: 10px; font-size: 19px; flex-shrink: 0;
+  color: var(--accent-presence);
+  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
+}
+.dr-quicklink__label { font-size: 13.5px; font-weight: 560; }
+.dr-quicklink__sub { font-size: 11.5px; color: var(--text-muted); margin-top: 1px; }
+
+/* Dashboard primary CTA ----------------------------------------------------- */
+.dr-cta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  flex-wrap: wrap;
+  padding: 22px 24px;
+  margin-bottom: 40px;
+  border-radius: var(--radius-panel);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 30%, var(--border-hairline));
+  background:
+    linear-gradient(120deg, color-mix(in oklch, var(--accent-presence) 16%, transparent), transparent 62%),
+    var(--bg-raised);
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.16s ease, transform 0.12s ease;
+}
+.dr-cta:hover { border-color: var(--accent-presence); transform: translateY(-2px); }
+.dr-cta__icon {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 46px; height: 46px; border-radius: 12px; font-size: 24px; flex-shrink: 0;
+  color: var(--accent-presence);
+  background: color-mix(in oklch, var(--accent-presence) 18%, transparent);
+}
+.dr-cta__title { font-size: 16px; font-weight: 620; }
+.dr-cta__sub { font-size: 13px; color: var(--text-secondary); margin-top: 2px; }
+
+/* Recent report rows -------------------------------------------------------- */
+.dr-report-row { display: flex; align-items: center; gap: 14px; }
+.dr-report-row__stats { display: inline-flex; gap: 12px; flex-shrink: 0; }
+.dr-mini-stat { display: inline-flex; align-items: baseline; gap: 4px; font-size: 12px; color: var(--text-muted); }
+.dr-mini-stat b { font-size: 13.5px; font-weight: 650; color: var(--text-secondary); }
+
+.dr-footer {
+  margin-top: 12px;
+  padding-top: 22px;
+  border-top: 1px solid var(--border-hairline);
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+@media (max-width: 560px) {
+  .dr-metric__value { font-size: 32px; }
+  .dr-row__open span { display: none; }
+}

--- a/src/components/copy-link-button.tsx
+++ b/src/components/copy-link-button.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Icon } from "@/lib/icon";
+
+/**
+ * Copies the current page URL to the clipboard with brief inline feedback.
+ * Used in the daily-report / dashboard top bars so a report is one click to
+ * share. Falls back silently when the clipboard API is unavailable.
+ */
+export function CopyLinkButton({ label = "Copy link" }: { label?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch {
+      // Clipboard blocked (insecure context / permissions) — no-op.
+    }
+  }, []);
+
+  return (
+    <button type="button" className="dr-btn dr-btn--sm focus-ring" onClick={onCopy}>
+      <Icon name={copied ? "ph:check" : "ph:link"} aria-hidden />
+      {copied ? "Copied" : label}
+    </button>
+  );
+}

--- a/src/components/daily-report-ui.tsx
+++ b/src/components/daily-report-ui.tsx
@@ -1,0 +1,166 @@
+// Presentational building blocks shared by the standalone `/daily-report/[date]`
+// and `/dashboard` routes. These are server components — they render the
+// client-only <Icon> as a leaf island, which Next.js allows. Keeping them here
+// means both pages speak the same visual grammar (metric cards, item rows,
+// section headers) without copy-paste drift.
+
+import type { ReactNode } from "react";
+import { Icon, type IconName } from "@/lib/icon";
+import type { InboxItem } from "@/lib/cave-inbox";
+import {
+  KIND_ICON,
+  KIND_LABEL,
+  itemHasTarget,
+  itemHref,
+  relativeTime,
+} from "@/lib/daily-report";
+
+export type Accent = "lavender" | "amber" | "rose" | "green" | "blue";
+
+const ACCENT_VAR: Record<Accent, string> = {
+  lavender: "var(--accent-presence)",
+  amber: "var(--color-warning)",
+  rose: "var(--color-danger)",
+  green: "var(--color-success)",
+  blue: "var(--color-info)",
+};
+
+export function MetricCard({
+  icon,
+  value,
+  label,
+  caption,
+  accent = "lavender",
+}: {
+  icon: IconName;
+  value: number | string;
+  label: string;
+  caption?: string;
+  accent?: Accent;
+}) {
+  const muted = value === 0 || value === "0";
+  return (
+    <div
+      className={`dr-metric${muted ? " dr-metric--muted" : ""}`}
+      style={{ ["--metric-accent" as string]: ACCENT_VAR[accent] }}
+    >
+      <div className="dr-metric__top">
+        <span className="dr-metric__icon">
+          <Icon name={icon} aria-hidden />
+        </span>
+      </div>
+      <div className="dr-metric__value">{value}</div>
+      <div className="dr-metric__label">{label}</div>
+      {caption ? <div className="dr-metric__caption">{caption}</div> : null}
+    </div>
+  );
+}
+
+export function SectionHead({
+  icon,
+  title,
+  count,
+  hint,
+}: {
+  icon: IconName;
+  title: string;
+  count?: number;
+  hint?: string;
+}) {
+  return (
+    <div className="dr-section__head">
+      <h2 className="dr-section__title">
+        <Icon name={icon} aria-hidden />
+        {title}
+      </h2>
+      {typeof count === "number" ? <span className="dr-count">{count}</span> : null}
+      {hint ? <span className="dr-section__hint">{hint}</span> : null}
+    </div>
+  );
+}
+
+export function EmptyState({ icon, children }: { icon: IconName; children: ReactNode }) {
+  return (
+    <div className="dr-empty">
+      <Icon name={icon} aria-hidden />
+      <span>{children}</span>
+    </div>
+  );
+}
+
+const ROW_ACCENT: Record<InboxItem["kind"], string> = {
+  reminder: ACCENT_VAR.amber,
+  agent: ACCENT_VAR.lavender,
+  "response-needed": ACCENT_VAR.rose,
+};
+
+/** A single actionable inbox item. Renders as a deep link when it has a target. */
+export function ItemRow({ item, now }: { item: InboxItem; now?: Date }) {
+  const hasTarget = itemHasTarget(item);
+  const accent = ROW_ACCENT[item.kind];
+  const when = relativeTime(item.firedAt ?? item.updatedAt, now);
+  const inner = (
+    <>
+      <span className="dr-row__icon">
+        <Icon name={KIND_ICON[item.kind] as IconName} aria-hidden />
+      </span>
+      <span className="dr-row__body">
+        <span className="dr-row__title">{item.title}</span>
+        {item.body ? <span className="dr-row__sub">{item.body}</span> : null}
+        <span className="dr-row__metaline">
+          <span className="dr-tag">{KIND_LABEL[item.kind]}</span>
+          {when ? <span className="dr-row__time">{when}</span> : null}
+        </span>
+      </span>
+      {hasTarget ? (
+        <span className="dr-row__open">
+          <span>Open</span>
+          <Icon name="ph:arrow-right-bold" aria-hidden />
+        </span>
+      ) : null}
+    </>
+  );
+
+  if (hasTarget) {
+    return (
+      <a
+        className="dr-row"
+        href={itemHref(item)}
+        style={{ ["--row-accent" as string]: accent }}
+      >
+        {inner}
+      </a>
+    );
+  }
+  return (
+    <div className="dr-row" style={{ ["--row-accent" as string]: accent }}>
+      {inner}
+    </div>
+  );
+}
+
+export function QuickLink({
+  href,
+  icon,
+  label,
+  sub,
+}: {
+  href: string;
+  icon: IconName;
+  label: string;
+  sub?: string;
+}) {
+  return (
+    <a className="dr-quicklink" href={href}>
+      <span className="dr-quicklink__icon">
+        <Icon name={icon} aria-hidden />
+      </span>
+      <span style={{ minWidth: 0 }}>
+        <span className="dr-quicklink__label" style={{ display: "block" }}>
+          {label}
+        </span>
+        {sub ? <span className="dr-quicklink__sub" style={{ display: "block" }}>{sub}</span> : null}
+      </span>
+    </a>
+  );
+}

--- a/src/lib/daily-report.test.ts
+++ b/src/lib/daily-report.test.ts
@@ -1,0 +1,152 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  breakdownForDay,
+  dateSlug,
+  itemHasTarget,
+  itemHref,
+  liveSnapshot,
+  longDateLabel,
+  parseDateSlug,
+  parseRecentSessions,
+  recentReports,
+  relativeDayLabel,
+  relativeTime,
+} from "./daily-report.ts";
+
+function item(overrides) {
+  return {
+    id: overrides.id ?? "x",
+    kind: "reminder",
+    title: "T",
+    status: "fired",
+    createdAt: "2026-06-18T10:00:00.000Z",
+    updatedAt: "2026-06-18T12:00:00.000Z",
+    firedAt: "2026-06-18T12:00:00.000Z",
+    recurrence: { type: "none" },
+    source: "user",
+    link: null,
+    auto: null,
+    ...overrides,
+  };
+}
+
+// parseDateSlug -------------------------------------------------------------
+{
+  const d = parseDateSlug("2026-06-18");
+  assert.ok(d, "valid slug parses");
+  assert.equal(d.getFullYear(), 2026);
+  assert.equal(d.getMonth(), 5);
+  assert.equal(d.getDate(), 18);
+  assert.equal(parseDateSlug("nonsense"), null, "garbage slug rejected");
+  assert.equal(parseDateSlug("2026-13-40"), null, "out-of-range slug rejected");
+  assert.equal(dateSlug(d), "2026-06-18", "round-trips through dateSlug");
+}
+
+// labels --------------------------------------------------------------------
+{
+  const d = new Date(2026, 5, 18, 9, 0, 0);
+  assert.match(longDateLabel(d), /2026/, "long label includes year");
+  assert.equal(relativeDayLabel(d, d), "Today");
+  assert.equal(
+    relativeDayLabel(new Date(2026, 5, 17), new Date(2026, 5, 18)),
+    "Yesterday",
+  );
+}
+
+// relativeTime --------------------------------------------------------------
+{
+  const now = new Date("2026-06-18T12:00:00.000Z");
+  assert.equal(relativeTime("2026-06-18T11:58:30.000Z", now), "2m ago");
+  assert.equal(relativeTime("2026-06-18T09:00:00.000Z", now), "3h ago");
+  assert.equal(relativeTime(null, now), "");
+}
+
+// itemHref / itemHasTarget --------------------------------------------------
+{
+  assert.equal(itemHref(item({ link: { kind: "card", ref: "c1" } })), "/#card-c1");
+  assert.equal(itemHref(item({ link: { kind: "session", ref: "s1" } })), "/#chat-s1");
+  assert.equal(
+    itemHref(item({ link: { kind: "memory", ref: "a/b c" } })),
+    "/#memory:a%2Fb%20c",
+  );
+  assert.equal(itemHref(item({ link: { kind: "url", ref: "https://x" } })), "https://x");
+  assert.equal(itemHref(item({ sessionId: "sess9", link: null })), "/#chat-sess9");
+  assert.equal(itemHref(item({ link: null })), "/", "no target falls back to home");
+  assert.equal(itemHasTarget(item({ link: { kind: "card", ref: "c1" } })), true);
+  assert.equal(itemHasTarget(item({ link: null })), false);
+}
+
+// breakdownForDay -----------------------------------------------------------
+{
+  const day = new Date(2026, 5, 18);
+  const items = [
+    item({ id: "r1", kind: "reminder", status: "fired" }),
+    item({ id: "r2", kind: "reminder", status: "done" }), // excluded (not fired)
+    item({ id: "resp1", kind: "response-needed", status: "pending" }),
+    item({ id: "fam1", kind: "agent", status: "fired" }),
+    item({
+      id: "old",
+      kind: "reminder",
+      status: "fired",
+      firedAt: "2026-06-10T12:00:00.000Z",
+      updatedAt: "2026-06-10T12:00:00.000Z",
+    }), // excluded (different day)
+  ];
+  const b = breakdownForDay(items, day);
+  assert.equal(b.reminders.length, 1, "one fired reminder this day");
+  assert.equal(b.responses.length, 1, "one waiting response");
+  assert.equal(b.familiars.length, 1, "one familiar update");
+  assert.equal(b.openItems.length, 2, "open = response + fired reminder");
+  assert.ok(
+    b.openItems.every((it) => it.status === "pending" || it.status === "fired"),
+    "open items are only pending/fired",
+  );
+}
+
+// liveSnapshot --------------------------------------------------------------
+{
+  const now = new Date();
+  const todayIso = now.toISOString();
+  const snap = liveSnapshot(
+    [item({ id: "r", kind: "reminder", status: "fired", firedAt: todayIso, updatedAt: todayIso })],
+    now,
+  );
+  assert.equal(snap.reminders, 1);
+  assert.equal(snap.sessions, 0, "sessions live behind daemon → 0 here");
+}
+
+// recentReports -------------------------------------------------------------
+{
+  const reports = recentReports([
+    item({
+      id: "d1",
+      kind: "daily-summary",
+      auto: "daily-summary:2026-06-17",
+      title: "Daily summary · Jun 17",
+      media: { kind: "summary-card", imageUrl: "", alt: "", stats: { reminders: 2, responses: 1, familiars: 0, sessions: 3 }, generatedAt: "" },
+    }),
+    item({
+      id: "d2",
+      kind: "daily-summary",
+      auto: "daily-summary:2026-06-18",
+      title: "Daily summary · Jun 18",
+    }),
+    item({ id: "r", kind: "reminder", auto: null }), // not a report
+  ]);
+  assert.equal(reports.length, 2, "only daily-summary items");
+  assert.equal(reports[0].slug, "2026-06-18", "newest first");
+  assert.equal(reports[0].href, "/daily-report/2026-06-18");
+  assert.equal(reports[1].stats.sessions, 3, "stats carried through");
+}
+
+// parseRecentSessions -------------------------------------------------------
+{
+  const body = "1 reminder fired\n2 sessions updated\nRecent: Fix auth (+12 -3) · Polish board";
+  const sessions = parseRecentSessions(body);
+  assert.deepEqual(sessions, ["Fix auth (+12 -3)", "Polish board"]);
+  assert.deepEqual(parseRecentSessions("no recent line"), []);
+  assert.deepEqual(parseRecentSessions(undefined), []);
+}
+
+console.log("daily-report.test.ts: ok");

--- a/src/lib/daily-report.ts
+++ b/src/lib/daily-report.ts
@@ -1,0 +1,263 @@
+// Pure helpers that shape inbox data into the daily-report and dashboard
+// surfaces. Kept free of `node:` imports so both the server pages and the
+// (browser-bundled) tests can import it without dragging fs/promises along.
+//
+// The daily-report page renders a *frozen* snapshot (the stat counts captured
+// in `media.stats` when the summary was generated) alongside *live* actionable
+// lists derived from the current inbox. These helpers compute the live slices
+// and turn each item into a deep link the standalone report/dashboard routes
+// can hand back to the app shell.
+
+import type { InboxItem, ItemKind, LinkRef } from "./cave-inbox";
+
+export type DailyReportStats = {
+  reminders: number;
+  responses: number;
+  familiars: number;
+  sessions: number;
+};
+
+/** Parse a `YYYY-MM-DD` slug into a local Date at midnight. */
+export function parseDateSlug(slug: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(slug.trim());
+  if (!match) return null;
+  const [, y, m, d] = match;
+  const year = Number(y);
+  const month = Number(m);
+  const day = Number(d);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+  const date = new Date(year, month - 1, day, 0, 0, 0, 0);
+  if (Number.isNaN(date.getTime())) return null;
+  return date;
+}
+
+/** `YYYY-MM-DD` for a Date in local time. */
+export function dateSlug(date: Date): string {
+  const y = date.getFullYear();
+  const m = `${date.getMonth() + 1}`.padStart(2, "0");
+  const d = `${date.getDate()}`.padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0, 0);
+}
+
+export function isSameLocalDay(iso: string | null | undefined, day: Date): boolean {
+  if (!iso) return false;
+  const value = new Date(iso);
+  if (Number.isNaN(value.getTime())) return false;
+  const start = startOfLocalDay(day).getTime();
+  return value.getTime() >= start && value.getTime() < start + 24 * 60 * 60 * 1000;
+}
+
+/** Long human label, e.g. "Thursday, June 18, 2026". */
+export function longDateLabel(date: Date): string {
+  return new Intl.DateTimeFormat([], {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
+
+/** "Today" / "Yesterday" / weekday for dates inside the last week, else short date. */
+export function relativeDayLabel(date: Date, now = new Date()): string {
+  const days = Math.round(
+    (startOfLocalDay(now).getTime() - startOfLocalDay(date).getTime()) / (24 * 60 * 60 * 1000),
+  );
+  if (days === 0) return "Today";
+  if (days === 1) return "Yesterday";
+  if (days > 1 && days < 7) {
+    return new Intl.DateTimeFormat([], { weekday: "long" }).format(date);
+  }
+  return new Intl.DateTimeFormat([], { month: "short", day: "numeric" }).format(date);
+}
+
+/** Compact "3h ago" / "2d ago" / clock time relative phrase. */
+export function relativeTime(iso: string | null | undefined, now = new Date()): string {
+  if (!iso) return "";
+  const then = new Date(iso);
+  if (Number.isNaN(then.getTime())) return "";
+  const diffMs = now.getTime() - then.getTime();
+  const mins = Math.round(diffMs / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Intl.DateTimeFormat([], { month: "short", day: "numeric" }).format(then);
+}
+
+export const KIND_LABEL: Record<ItemKind, string> = {
+  reminder: "Reminder",
+  agent: "Familiar update",
+  "response-needed": "Response needed",
+};
+
+export const KIND_ICON: Record<ItemKind, string> = {
+  reminder: "ph:bell",
+  agent: "ph:sparkle",
+  "response-needed": "ph:chat-circle-dots",
+};
+
+/**
+ * Turn an inbox item into an href the standalone routes can use. In-app
+ * targets resolve to `/#<hash>` so the workspace deep-link listeners
+ * (`#card-`, `#chat-`, `#memory:`) re-enter the right surface; bare urls pass
+ * through. Items with no actionable target return `/` (the home shell).
+ */
+export function itemHref(item: InboxItem): string {
+  const link: LinkRef | null | undefined = item.link;
+  if (link) {
+    switch (link.kind) {
+      case "card":
+        return `/#card-${link.ref}`;
+      case "session":
+        return `/#chat-${link.ref}`;
+      case "memory":
+        return `/#memory:${encodeURIComponent(link.ref)}`;
+      case "url":
+        return link.ref || "/";
+    }
+  }
+  if (item.sessionId) return `/#chat-${item.sessionId}`;
+  return "/";
+}
+
+/** Whether an item resolves to a real, navigable destination. */
+export function itemHasTarget(item: InboxItem): boolean {
+  return Boolean(item.link?.ref || item.sessionId);
+}
+
+export type DailyReportBreakdown = {
+  reminders: InboxItem[];
+  responses: InboxItem[];
+  familiars: InboxItem[];
+  /** Subset still demanding attention right now (live, not frozen). */
+  openItems: InboxItem[];
+};
+
+function sortByRecent(a: InboxItem, b: InboxItem): number {
+  const at = a.firedAt ?? a.updatedAt ?? a.createdAt ?? "";
+  const bt = b.firedAt ?? b.updatedAt ?? b.createdAt ?? "";
+  return bt.localeCompare(at);
+}
+
+/**
+ * Slice the live inbox into the categories that make up a day's report. The
+ * filters mirror `buildDailySummaryNotification` so the live lists line up with
+ * the frozen headline counts.
+ */
+export function breakdownForDay(items: InboxItem[], day: Date): DailyReportBreakdown {
+  const reminders = items
+    .filter(
+      (item) =>
+        item.kind === "reminder" &&
+        item.status === "fired" &&
+        isSameLocalDay(item.firedAt ?? item.updatedAt, day),
+    )
+    .sort(sortByRecent);
+
+  const responses = items
+    .filter(
+      (item) =>
+        item.kind === "response-needed" &&
+        (item.status === "pending" || item.status === "fired") &&
+        isSameLocalDay(item.updatedAt, day),
+    )
+    .sort(sortByRecent);
+
+  const familiars = items
+    .filter(
+      (item) =>
+        item.kind === "agent" &&
+        item.status === "fired" &&
+        isSameLocalDay(item.firedAt ?? item.updatedAt, day),
+    )
+    .sort(sortByRecent);
+
+  // "Open" = still actionable: responses awaiting a reply plus reminders that
+  // fired but were never completed/dismissed. Excludes done/dismissed/snoozed.
+  const openItems = [...responses, ...reminders]
+    .filter((item) => item.status === "pending" || item.status === "fired")
+    .sort(sortByRecent);
+
+  return { reminders, responses, familiars, openItems };
+}
+
+export type RecentReport = {
+  date: string;
+  slug: string;
+  title: string;
+  generatedAt: string | null;
+  stats: DailyReportStats | null;
+  href: string;
+};
+
+/**
+ * All generated daily-summary items in the inbox, newest first, mapped to the
+ * dashboard's "recent reports" rows.
+ *
+ * The `daily-summary` inbox kind and its `media.stats` payload ship with the
+ * (separate) daily-report generator. This reads them through a loose shape so
+ * the dashboard compiles today and lights up automatically once those items
+ * start appearing in the inbox — no change needed here.
+ */
+type SummaryShape = {
+  kind: string;
+  auto?: string | null;
+  title: string;
+  firedAt?: string | null;
+  updatedAt?: string | null;
+  media?: { stats?: DailyReportStats | null } | null;
+};
+
+export function recentReports(items: InboxItem[]): RecentReport[] {
+  return (items as unknown as SummaryShape[])
+    .filter((item) => item.kind === "daily-summary" && typeof item.auto === "string")
+    .map((item) => {
+      const slug = (item.auto ?? "").replace(/^daily-summary:/, "");
+      return {
+        date: slug,
+        slug,
+        title: item.title,
+        generatedAt: item.firedAt ?? item.updatedAt ?? null,
+        stats: item.media?.stats ?? null,
+        href: `/daily-report/${slug}`,
+      };
+    })
+    .filter((report) => /^\d{4}-\d{2}-\d{2}$/.test(report.slug))
+    .sort((a, b) => b.slug.localeCompare(a.slug));
+}
+
+/** Live, at-a-glance counts for "today" used on the dashboard hero. */
+export function liveSnapshot(items: InboxItem[], now = new Date()): DailyReportStats {
+  const breakdown = breakdownForDay(items, now);
+  return {
+    reminders: breakdown.reminders.length,
+    responses: breakdown.responses.length,
+    familiars: breakdown.familiars.length,
+    sessions: 0,
+  };
+}
+
+/**
+ * Parse the `Recent: a · b · c` line the summary builder writes into the body.
+ * Sessions live behind the daemon, so the report surfaces them as read-only
+ * context recovered from the frozen body text.
+ */
+export function parseRecentSessions(body: string | undefined): string[] {
+  if (!body) return [];
+  const line = body
+    .split("\n")
+    .map((l) => l.trim())
+    .find((l) => l.startsWith("Recent:"));
+  if (!line) return [];
+  return line
+    .replace(/^Recent:\s*/, "")
+    .split("·")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}


### PR DESCRIPTION
## What

Adds a standalone **`/dashboard`** surface — a world-class, at-a-glance overview of the cave that links into the daily report.


### Highlights
- **Hero + live status** — "Today in your cave" with today's date and a live "needs attention / all caught up" indicator.
- **Featured report CTA** — surfaces today's (or the latest) daily report with a prominent "Read report →" button; gracefully shows a non-navigating "no report yet" state when none exists.
- **Live metric cards** — reminders today, responses waiting, familiar updates, and archived daily-report count, each with an accent and icon.
- **"Needs attention"** — actionable list of still-open responses/reminders that **deep-link back into the workspace** (`/#card-…`, `/#chat-…`, `/#memory:…`).
- **Recent daily reports** — newest-first archive with per-report mini-stats.
- **Workspaces** — quick links into Home, Board, Calendar, Library, Settings, Aesthetic.

## Why "dashboard now, report later"

The daily-report feature (the `daily-summary` inbox kind, `media.stats`, the summary generator + route) is **in-progress work that is not yet on `main`**. Rather than duplicate that data layer (and collide with the session building it), this PR ships only the additive dashboard + a **forward-compatible** shared layer:

- `daily-report.ts` `recentReports()` reads the `daily-summary` kind through a loose shape, so the dashboard **compiles on `main` today** and **lights up automatically** once those inbox items start appearing.
- The shared `daily-report-ui.tsx` components and `.dr-*` styling are designed for the daily-report overhaul to layer straight on top later.

## Files
- `src/app/dashboard/page.tsx` — the dashboard (server component)
- `src/lib/daily-report.ts` (+ `.test.ts`) — pure inbox→report/dashboard helpers
- `src/components/daily-report-ui.tsx` — shared metric / row / section / quick-link UI
- `src/components/copy-link-button.tsx` — share-link affordance
- `src/app/globals.css` — `.dr-*` surface styling
- `scripts/run-tests.mjs` — wire the two new test files

## Verification
- `pnpm build` — `/dashboard` route emitted, type-checks clean.
- `pnpm test:app` (300 files) + `pnpm test:api` (74 files) — green.
- Rendered and eyeballed in the real app (hero, CTA, metric cards, needs-attention, recent reports, workspaces) — no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
