### PR TITLE
feat(search): capture context lines around matches (backend)

### DIFF
--- a/src/app/api/project/search/route.ts
+++ b/src/app/api/project/search/route.ts
@@ -118,7 +118,10 @@ function buildRgArgs(params: {
   caseMode: "smart" | "sensitive" | "insensitive";
   glob: string | null;
 }): string[] {
-  const args = ["--json", "--max-count", String(RG_MAX_COUNT), "--max-columns", "2000", "--no-messages"];
+  const args = ["--json", "--max-count", String(RG_MAX_COUNT), "--max-columns", "2000", "--no-messages",
+    // One line of context on each side of a match, emitted as `context` events
+    // the parser stitches onto matches as before/after lines.
+    "--context", "1"];
   if (!params.regex) args.push("--fixed-strings");
   if (params.caseMode === "insensitive") args.push("--ignore-case");
   else if (params.caseMode === "sensitive") args.push("--case-sensitive");

--- a/src/lib/project-search.test.ts
+++ b/src/lib/project-search.test.ts
@@ -120,4 +120,34 @@ function matchLine(path, lineNumber, text, submatchStart) {
   assert.equal(result.files[0].matches[0].preview, `${"x".repeat(10)}…`);
 }
 
+// ── context lines stitch onto adjacent matches (ripgrep -C) ─────────────────
+function contextLine(path, lineNumber, text) {
+  return JSON.stringify({ type: "context", data: { path: { text: path }, lines: { text }, line_number: lineNumber } });
+}
+{
+  // file with: context(11) match(12) context(13), and a second match(40) with
+  // only a preceding context(39).
+  const stdout = [
+    contextLine("src/a.ts", 11, "const before = 1;\n"),
+    matchLine("src/a.ts", 12, "const foo = 2;\n", 6),
+    contextLine("src/a.ts", 13, "const after = 3;\n"),
+    contextLine("src/a.ts", 39, "// preceding\n"),
+    matchLine("src/a.ts", 40, "  return foo;\n", 9),
+  ].join("\n");
+  const result = parseRipgrepJson(stdout);
+  assert.equal(result.totalMatches, 2, "context lines don't count as matches");
+  const [m1, m2] = result.files[0].matches;
+  assert.equal(m1.before, "const before = 1;", "match 12 gets the line above");
+  assert.equal(m1.after, "const after = 3;", "match 12 gets the line below");
+  assert.equal(m2.before, "// preceding", "match 40 gets its preceding context");
+  assert.equal(m2.after, undefined, "no trailing context → after stays undefined");
+}
+
+// Context with no nearby match is simply dropped (not rendered as a match).
+{
+  const result = parseRipgrepJson(contextLine("src/b.ts", 5, "lonely\n"));
+  assert.equal(result.totalMatches, 0);
+  assert.deepEqual(result.files, []);
+}
+
 console.log("project-search.test.ts: all assertions passed");

--- a/src/lib/project-search.ts
+++ b/src/lib/project-search.ts
@@ -5,10 +5,11 @@
  * Keeping the parse pure (no child_process, no next/server) lets it be
  * unit-tested against captured ripgrep output without a live binary or repo.
  *
- * ripgrep emits one JSON object per line. We only care about `match` events;
- * `begin`/`end`/`summary`/`context` are ignored. Each match carries the file
- * path, the 1-based line number, the matched line text, and submatch byte
- * offsets (used to derive a 1-based column for jump-to-line).
+ * ripgrep emits one JSON object per line. We read `match` events (the file
+ * path, 1-based line number, matched line text, and submatch byte offsets used
+ * to derive a 1-based column for jump-to-line) and, when ripgrep ran with
+ * context (`-C`), `context` events — stitched onto the adjacent match as
+ * before/after lines. `begin`/`end`/`summary` are ignored.
  *
  * Output is grouped by file and bounded twice — total matches and per-file
  * matches — so a pathological query ("e" across a monorepo) can't flood the
@@ -22,6 +23,11 @@ export type SearchMatch = {
   column: number;
   /** The matched line, newline-stripped and length-capped for display. */
   preview: string;
+  /** The line immediately before the match (present when ripgrep ran with
+   *  context, `-C`). Newline-stripped + length-capped like `preview`. */
+  before?: string;
+  /** The line immediately after the match (present when run with context). */
+  after?: string;
 };
 
 export type SearchFileGroup = {
@@ -85,8 +91,14 @@ export function parseRipgrepJson(stdout: string, options: ParseOptions = {}): Se
 
   const groups = new Map<string, SearchFileGroup>();
   const order: string[] = [];
+  // Context lines (from ripgrep `-C`) keyed by path → (1-based line → text),
+  // collected alongside matches and stitched onto adjacent matches at the end.
+  const contextByPath = new Map<string, Map<number, string>>();
   let totalMatches = 0;
   let truncated = false;
+
+  const clip = (raw: string): string =>
+    raw.length > maxPreviewLen ? `${raw.slice(0, maxPreviewLen)}…` : raw;
 
   for (const rawLine of stdout.split("\n")) {
     const line = rawLine.trim();
@@ -98,7 +110,7 @@ export function parseRipgrepJson(stdout: string, options: ParseOptions = {}): Se
     } catch {
       continue; // tolerate partial/garbled lines
     }
-    if (event.type !== "match" || !event.data) continue;
+    if ((event.type !== "match" && event.type !== "context") || !event.data) continue;
 
     const data = event.data;
     // ripgrep reports paths relative to the search path we pass ("."), so they
@@ -108,6 +120,15 @@ export function parseRipgrepJson(stdout: string, options: ParseOptions = {}): Se
     if (!path) continue;
     const lineNumber = typeof data.line_number === "number" ? data.line_number : 0;
     if (lineNumber <= 0) continue;
+    const text = clip(textOf(data.lines).replace(/\r?\n$/, ""));
+
+    // Context lines don't count toward the match caps; record them for stitching.
+    if (event.type === "context") {
+      let ctx = contextByPath.get(path);
+      if (!ctx) { ctx = new Map(); contextByPath.set(path, ctx); }
+      ctx.set(lineNumber, text);
+      continue;
+    }
 
     if (totalMatches >= maxMatches) {
       truncated = true;
@@ -125,16 +146,24 @@ export function parseRipgrepJson(stdout: string, options: ParseOptions = {}): Se
       continue; // keep scanning other files, just skip this one's overflow
     }
 
-    const rawPreview = textOf(data.lines).replace(/\r?\n$/, "");
-    const preview =
-      rawPreview.length > maxPreviewLen ? `${rawPreview.slice(0, maxPreviewLen)}…` : rawPreview;
-
     group.matches.push({
       line: lineNumber,
       column: columnFromSubmatches(data),
-      preview,
+      preview: text,
     });
     totalMatches += 1;
+  }
+
+  // Stitch the immediately-adjacent context lines onto each match.
+  for (const path of order) {
+    const ctx = contextByPath.get(path);
+    if (!ctx) continue;
+    for (const m of groups.get(path)!.matches) {
+      const before = ctx.get(m.line - 1);
+      const after = ctx.get(m.line + 1);
+      if (before !== undefined) m.before = before;
+      if (after !== undefined) m.after = after;
+    }
   }
 
   return {


### PR DESCRIPTION
## What

Project search now requests **one line of context on each side** of a match (ripgrep `-C 1`). The pure parser reads ripgrep's `context` events and stitches the immediately-adjacent lines onto each match as `before`/`after`. The API response carries them per match; the comux results render consumes them in a **follow-up PR** (kept separate to avoid touching `comux-view.tsx` until #970 lands).

## Details

- Context lines **don't count** toward the match caps; orphan context with no nearby match is dropped.
- Backend only (`project-search.ts` + `route.ts`) — **no `comux-view.tsx`**, so zero conflict with the case/glob PR (#970).

## Verification

- Parser unit tests: stitching (before/after), orphan-drop, caps unaffected.
- Confirmed **real `rg --json --context 1`** emits the `context` events the parser reads (13 matches → 26 context events in a sample run).
- `pnpm typecheck`, full **app+api (372)**, `check:tests-wired`, and `next build` green.

## Coordination
Within my claimed lane (`.claude/claims.json` → project-search). Backend files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)