### PR TITLE
feat(daily-report): world-class overhaul of the daily-report surface

### DIFF
--- a/src/app/daily-report-page.test.ts
+++ b/src/app/daily-report-page.test.ts
@@ -8,10 +8,19 @@ assert.equal(existsSync(pageUrl), true, "daily report route should exist at /dai
 
 const page = existsSync(pageUrl) ? readFileSync(pageUrl, "utf8") : "";
 
+// Data resolution + frozen image/body (preserved through the overhaul).
 assert.match(page, /loadInbox/, "daily report page should load persisted inbox data");
 assert.match(page, /daily-summary:\$\{date\}/, "daily report page should resolve the daily summary by auto key");
 assert.match(page, /<img[\s\S]*src=\{item\.media\.imageUrl\}/, "daily report page should render the generated summary image");
 assert.match(page, /whiteSpace:\s*"pre-line"/, "daily report page should preserve summary body line breaks");
 assert.match(page, /Daily report not found/, "daily report page should have an empty/not-found state");
+
+// World-class overhaul: metric cards, live actionable lists, dashboard link.
+assert.match(page, /MetricCard/, "report should render headline metric cards");
+assert.match(page, /breakdownForDay/, "report should compute the live per-day breakdown");
+assert.match(page, /Needs attention/, "report should surface an actionable needs-attention list");
+assert.match(page, /ItemRow/, "report should render deep-linkable item rows");
+assert.match(page, /href="\/dashboard"/, "report should link back to the dashboard");
+assert.match(page, /dr-page/, "report should use the shared daily-report surface styling");
 
 console.log("daily-report-page.test.ts: ok");

--- a/src/app/daily-report/[date]/page.tsx
+++ b/src/app/daily-report/[date]/page.tsx
@@ -1,4 +1,14 @@
 import { loadInbox } from "@/lib/cave-inbox";
+import { Icon } from "@/lib/icon";
+import { CopyLinkButton } from "@/components/copy-link-button";
+import { EmptyState, ItemRow, MetricCard, QuickLink, SectionHead } from "@/components/daily-report-ui";
+import {
+  breakdownForDay,
+  longDateLabel,
+  parseDateSlug,
+  parseRecentSessions,
+  relativeTime,
+} from "@/lib/daily-report";
 
 export const dynamic = "force-dynamic";
 
@@ -6,65 +16,238 @@ type Props = {
   params: Promise<{ date: string }>;
 };
 
-function statLabel(count: number, label: string): string {
-  return `${count} ${label}${count === 1 ? "" : "s"}`;
-}
-
 export default async function DailyReportPage({ params }: Props) {
   const { date } = await params;
   const inbox = await loadInbox();
   const item = inbox.items.find((candidate) => candidate.auto === `daily-summary:${date}`);
+  const parsedDate = parseDateSlug(date);
 
   if (!item) {
     return (
-      <main style={{ minHeight: "100vh", overflowY: "auto", background: "var(--bg-base)", color: "var(--text-primary)", padding: 32 }}>
-        <a href="/" style={{ color: "var(--text-secondary)", fontSize: 12 }}>Back to CovenCave</a>
-        <section style={{ margin: "96px auto", maxWidth: 720 }}>
-          <p style={{ color: "var(--text-muted)", fontSize: 12, textTransform: "uppercase", letterSpacing: 2 }}>Daily report</p>
-          <h1 style={{ marginTop: 12, fontSize: 32 }}>Daily report not found</h1>
-          <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
-            No generated daily summary exists for {date}.
-          </p>
-        </section>
+      <main className="dr-page">
+        <div className="dr-topbar">
+          <a className="dr-back" href="/dashboard">
+            <Icon name="ph:arrow-left" aria-hidden />
+            Dashboard
+          </a>
+        </div>
+        <div className="dr-shell">
+          <section className="dr-hero" style={{ marginTop: 64 }}>
+            <p className="dr-eyebrow">
+              <span className="dr-eyebrow__dot" aria-hidden />
+              Daily report
+            </p>
+            <h1 className="dr-title">Daily report not found</h1>
+            <p className="dr-subtitle">
+              No generated daily summary exists for{" "}
+              {parsedDate ? longDateLabel(parsedDate) : date}. Reports are created automatically
+              once there is activity to summarize.
+            </p>
+            <div className="dr-actions">
+              <a className="dr-btn dr-btn--primary" href="/dashboard">
+                <Icon name="ph:squares-four" aria-hidden />
+                Go to dashboard
+              </a>
+              <a className="dr-btn" href="/">
+                <Icon name="ph:house-bold" aria-hidden />
+                Back to CovenCave
+              </a>
+            </div>
+          </section>
+        </div>
       </main>
     );
   }
 
   const stats = item.media?.stats;
+  const breakdown = breakdownForDay(inbox.items, parsedDate ?? new Date());
+  const recentSessions = parseRecentSessions(item.body);
+  const generatedAt = item.firedAt ?? item.updatedAt ?? null;
+  const totalEvents = stats
+    ? stats.reminders + stats.responses + stats.familiars + stats.sessions
+    : 0;
+
   return (
-    <main style={{ minHeight: "100vh", overflowY: "auto", background: "var(--bg-base)", color: "var(--text-primary)", padding: 32 }}>
-      <a href="/" style={{ color: "var(--text-secondary)", fontSize: 12 }}>Back to CovenCave</a>
-      <article style={{ margin: "32px auto 72px", maxWidth: 960 }}>
-        <header style={{ marginBottom: 24 }}>
-          <p style={{ color: "var(--text-muted)", fontSize: 12, textTransform: "uppercase", letterSpacing: 2 }}>Daily report</p>
-          <h1 style={{ margin: "10px 0 8px", fontSize: 40, lineHeight: 1.1 }}>{item.title}</h1>
-          <p style={{ color: "var(--text-secondary)", fontSize: 13 }}>
-            Generated {item.firedAt ? new Date(item.firedAt).toLocaleString() : "today"}
+    <main className="dr-page">
+      <div className="dr-topbar">
+        <nav className="dr-topbar__crumbs" aria-label="Breadcrumb">
+          <a className="dr-back" href="/dashboard">
+            <Icon name="ph:arrow-left" aria-hidden />
+            Dashboard
+          </a>
+          <span className="dr-crumb-sep" aria-hidden>/</span>
+          <span className="dr-crumb-current">{item.title}</span>
+        </nav>
+        <div className="dr-topbar__actions">
+          <CopyLinkButton />
+          <a className="dr-btn dr-btn--sm" href="/">
+            <Icon name="ph:house-bold" aria-hidden />
+            Open CovenCave
+          </a>
+        </div>
+      </div>
+
+      <div className="dr-shell">
+        <header className="dr-hero">
+          <p className="dr-eyebrow">
+            <span className="dr-eyebrow__dot" aria-hidden />
+            Daily report
           </p>
+          <h1 className="dr-title">{parsedDate ? longDateLabel(parsedDate) : item.title}</h1>
+          <p className="dr-subtitle">
+            {totalEvents > 0
+              ? `An auto-generated snapshot of your cave — ${totalEvents} ${
+                  totalEvents === 1 ? "event" : "events"
+                } across reminders, responses, familiars, and sessions.`
+              : "An auto-generated snapshot of your cave activity for the day."}
+          </p>
+          <div className="dr-meta-row">
+            <span className="dr-meta-row__item">
+              <Icon name="ph:clock" aria-hidden />
+              Generated {generatedAt ? relativeTime(generatedAt) : "today"}
+            </span>
+            {breakdown.openItems.length > 0 ? (
+              <span className="dr-meta-row__item">
+                <Icon name="ph:warning-circle" aria-hidden />
+                {breakdown.openItems.length} still open
+              </span>
+            ) : (
+              <span className="dr-meta-row__item">
+                <Icon name="ph:check-circle" aria-hidden />
+                Nothing left open
+              </span>
+            )}
+          </div>
         </header>
 
-        {item.media?.imageUrl ? (
-          <img
-            src={item.media.imageUrl}
-            alt={item.media.alt}
-            style={{ display: "block", width: "100%", borderRadius: 8, border: "1px solid var(--border-hairline)", marginBottom: 24 }}
-          />
-        ) : null}
-
+        {/* Headline metrics — the frozen snapshot captured at generation time. */}
         {stats ? (
-          <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 12, marginBottom: 24 }}>
-            <div style={{ border: "1px solid var(--border-hairline)", borderRadius: 8, padding: 16 }}>{statLabel(stats.reminders, "reminder")}</div>
-            <div style={{ border: "1px solid var(--border-hairline)", borderRadius: 8, padding: 16 }}>{statLabel(stats.responses, "response")}</div>
-            <div style={{ border: "1px solid var(--border-hairline)", borderRadius: 8, padding: 16 }}>{statLabel(stats.familiars, "familiar update")}</div>
-            <div style={{ border: "1px solid var(--border-hairline)", borderRadius: 8, padding: 16 }}>{statLabel(stats.sessions, "session")}</div>
+          <section className="dr-metrics" aria-label="Day at a glance">
+            <MetricCard
+              icon="ph:bell"
+              value={stats.reminders}
+              label="Reminders fired"
+              caption={stats.reminders === 1 ? "1 reminder" : `${stats.reminders} reminders`}
+              accent="amber"
+            />
+            <MetricCard
+              icon="ph:chat-circle-dots"
+              value={stats.responses}
+              label="Responses waiting"
+              caption="Need your reply"
+              accent="rose"
+            />
+            <MetricCard
+              icon="ph:sparkle"
+              value={stats.familiars}
+              label="Familiar updates"
+              caption="From your agents"
+              accent="lavender"
+            />
+            <MetricCard
+              icon="ph:graph-bold"
+              value={stats.sessions}
+              label="Sessions updated"
+              caption="Coding & chat work"
+              accent="green"
+            />
           </section>
         ) : null}
 
-        <section style={{ border: "1px solid var(--border-hairline)", borderRadius: 8, padding: 20, background: "var(--bg-raised)" }}>
-          <h2 style={{ marginTop: 0, fontSize: 18 }}>Summary</h2>
-          <p style={{ whiteSpace: "pre-line", color: "var(--text-secondary)", lineHeight: 1.7 }}>{item.body}</p>
+        {/* Actionable: what still needs attention right now (live inbox state). */}
+        <section className="dr-section" aria-label="Needs attention">
+          <SectionHead
+            icon="ph:warning-circle"
+            title="Needs attention"
+            count={breakdown.openItems.length}
+            hint="Live — updates as you act"
+          />
+          {breakdown.openItems.length > 0 ? (
+            <div className="dr-list">
+              {breakdown.openItems.map((open) => (
+                <ItemRow key={open.id} item={open} />
+              ))}
+            </div>
+          ) : (
+            <EmptyState icon="ph:check-circle">
+              You&apos;re all caught up — no open reminders or responses from this day.
+            </EmptyState>
+          )}
         </section>
-      </article>
+
+        {/* Familiar updates from the day. */}
+        {breakdown.familiars.length > 0 ? (
+          <section className="dr-section" aria-label="Familiar updates">
+            <SectionHead
+              icon="ph:sparkle"
+              title="Familiar updates"
+              count={breakdown.familiars.length}
+            />
+            <div className="dr-list">
+              {breakdown.familiars.map((fam) => (
+                <ItemRow key={fam.id} item={fam} />
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {/* Sessions — recovered from the frozen summary body (daemon-backed). */}
+        {recentSessions.length > 0 ? (
+          <section className="dr-section" aria-label="Recent sessions">
+            <SectionHead
+              icon="ph:graph-bold"
+              title="Recent sessions"
+              count={recentSessions.length}
+            />
+            <div className="dr-list">
+              {recentSessions.map((line, i) => (
+                <div key={i} className="dr-row" style={{ ["--row-accent" as string]: "var(--color-success)" }}>
+                  <span className="dr-row__icon">
+                    <Icon name="ph:code-bold" aria-hidden />
+                  </span>
+                  <span className="dr-row__body">
+                    <span className="dr-row__title">{line}</span>
+                  </span>
+                </div>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        <section
+          className="dr-section"
+          aria-label="Summary"
+          style={{ display: "grid", gridTemplateColumns: "minmax(0, 1fr)", gap: 16 }}
+        >
+          <div className="dr-panel">
+            <h2 className="dr-panel__title">Summary</h2>
+            <p className="dr-summary-body" style={{ whiteSpace: "pre-line" }}>{item.body}</p>
+          </div>
+          {item.media?.imageUrl ? (
+            <img
+              className="dr-cardimg"
+              src={item.media.imageUrl}
+              alt={item.media.alt}
+            />
+          ) : null}
+        </section>
+
+        <section className="dr-section" aria-label="Jump back in">
+          <SectionHead icon="ph:squares-four" title="Jump back in" />
+          <div className="dr-quicklinks">
+            <QuickLink href="/dashboard" icon="ph:squares-four" label="Dashboard" sub="Overview & reports" />
+            <QuickLink href="/" icon="ph:house-bold" label="Home" sub="Your cave" />
+            <QuickLink href="/#card-" icon="ph:kanban-bold" label="Board" sub="Cards & tasks" />
+            <QuickLink href="/" icon="ph:calendar-bold" label="Calendar" sub="Reminders & agenda" />
+          </div>
+        </section>
+
+        <footer className="dr-footer">
+          Daily reports are generated automatically from your inbox and session activity. Headline
+          numbers reflect the day this report was created; the &ldquo;Needs attention&rdquo; list
+          stays live.
+        </footer>
+      </div>
     </main>
   );
 }

--- a/src/components/daily-report-ui.tsx
+++ b/src/components/daily-report-ui.tsx
@@ -92,6 +92,7 @@ const ROW_ACCENT: Record<InboxItem["kind"], string> = {
   reminder: ACCENT_VAR.amber,
   agent: ACCENT_VAR.lavender,
   "response-needed": ACCENT_VAR.rose,
+  "daily-summary": ACCENT_VAR.blue,
 };
 
 /** A single actionable inbox item. Renders as a deep link when it has a target. */

--- a/src/lib/daily-report.ts
+++ b/src/lib/daily-report.ts
@@ -94,12 +94,14 @@ export const KIND_LABEL: Record<ItemKind, string> = {
   reminder: "Reminder",
   agent: "Familiar update",
   "response-needed": "Response needed",
+  "daily-summary": "Daily report",
 };
 
 export const KIND_ICON: Record<ItemKind, string> = {
   reminder: "ph:bell",
   agent: "ph:sparkle",
   "response-needed": "ph:chat-circle-dots",
+  "daily-summary": "ph:newspaper",
 };
 
 /**
@@ -199,23 +201,9 @@ export type RecentReport = {
 /**
  * All generated daily-summary items in the inbox, newest first, mapped to the
  * dashboard's "recent reports" rows.
- *
- * The `daily-summary` inbox kind and its `media.stats` payload ship with the
- * (separate) daily-report generator. This reads them through a loose shape so
- * the dashboard compiles today and lights up automatically once those items
- * start appearing in the inbox — no change needed here.
  */
-type SummaryShape = {
-  kind: string;
-  auto?: string | null;
-  title: string;
-  firedAt?: string | null;
-  updatedAt?: string | null;
-  media?: { stats?: DailyReportStats | null } | null;
-};
-
 export function recentReports(items: InboxItem[]): RecentReport[] {
-  return (items as unknown as SummaryShape[])
+  return items
     .filter((item) => item.kind === "daily-summary" && typeof item.auto === "string")
     .map((item) => {
       const slug = (item.auto ?? "").replace(/^daily-summary:/, "");


### PR DESCRIPTION
## What

Comprehensively overhauls the **`/daily-report/[date]`** surface from a basic stat list into a clear, actionable report built on the shared dashboard foundation from #972. Completes the two-part goal alongside the dashboard (#972).

### The overhauled report
- **Sticky breadcrumb top bar** — `← Dashboard / <report>` + Copy link + Open CovenCave.
- **Hero** — full long date, an event-count subtitle, and a **live "N still open / nothing left open"** indicator.
- **Headline metric cards** — reminders / responses / familiars / sessions from the frozen `media.stats` snapshot, each accented and icon-led.
- **Needs attention** — a **live, deep-linkable** list of the day's still-open reminders & responses that jump back into the workspace (`/#card-`, `/#chat-`, `/#memory:`).
- **Familiar updates**, **Recent sessions** (recovered from the summary body), the **generated summary image**, and a **"Jump back in"** quick-link grid.
- **Graceful** when `media`/`stats` are absent (older items): metric cards + image are simply omitted (verified against a real inbox item with no media).

The dashboard already links here (#972); the report now links back, closing the loop.

## Also: fixes a latent `main` type break

#972 shipped `KIND_LABEL` / `KIND_ICON` / `ROW_ACCENT` as `Record<ItemKind, …>` with three keys; #973 then added the `daily-summary` `ItemKind` **without touching those records**, leaving `main` with an exhaustiveness error (`tsc` TS2741 / `next build`). This PR adds the missing `daily-summary` entry to each, restoring a clean typecheck. (`tsc --noEmit` was red on `origin/main`'s `daily-report.ts`, green here.)

## Files
- `src/app/daily-report/[date]/page.tsx` — the overhauled report
- `src/lib/daily-report.ts` — exhaustive kind records; drop the now-unneeded loose cast in `recentReports`
- `src/components/daily-report-ui.tsx` — `ROW_ACCENT` gains `daily-summary`
- `src/app/daily-report-page.test.ts` — assert the new structure (metric cards, live breakdown, dashboard link) while preserving the frozen-image / pre-line-body / not-found invariants

## Verification
- `tsc --noEmit` clean; `pnpm build` — both `/daily-report/[date]` and `/dashboard` routes emit.
- `pnpm test:app` (305) + `pnpm test:api` (74) — green.
- Rendered and eyeballed in the real app — hero, live needs-attention, recent sessions, summary, quick links — no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)