### PR TITLE
fix(daily-report): add daily-summary to exhaustive ItemKind maps (unbreaks next build)

### DIFF
--- a/src/components/daily-report-ui.tsx
+++ b/src/components/daily-report-ui.tsx
@@ -92,6 +92,7 @@ const ROW_ACCENT: Record<InboxItem["kind"], string> = {
   reminder: ACCENT_VAR.amber,
   agent: ACCENT_VAR.lavender,
   "response-needed": ACCENT_VAR.rose,
+  "daily-summary": ACCENT_VAR.blue,
 };
 
 /** A single actionable inbox item. Renders as a deep link when it has a target. */

--- a/src/lib/daily-report.ts
+++ b/src/lib/daily-report.ts
@@ -94,12 +94,14 @@ export const KIND_LABEL: Record<ItemKind, string> = {
   reminder: "Reminder",
   agent: "Familiar update",
   "response-needed": "Response needed",
+  "daily-summary": "Daily summary",
 };
 
 export const KIND_ICON: Record<ItemKind, string> = {
   reminder: "ph:bell",
   agent: "ph:sparkle",
   "response-needed": "ph:chat-circle-dots",
+  "daily-summary": "ph:newspaper",
 };
 
 /**


### PR DESCRIPTION
## Problem

`main`'s production build (`next build` / `tsc`) is **currently broken**. The `"daily-summary"` `ItemKind` (added in #973) is missing from three exhaustive `Record<ItemKind, …>` maps in the daily-report files (merged separately and never updated for the new kind):

```
src/components/daily-report-ui.tsx:91  ROW_ACCENT
src/lib/daily-report.ts:93             KIND_LABEL
src/lib/daily-report.ts:99             KIND_ICON
```

Found while verifying the merged features in the running app — `pnpm build` failed with `Property '"daily-summary"' is missing in type … Record<ItemKind, string>`.

## Fix

Add the `"daily-summary"` entry to each map, matching the `calendar-view` / `inbox-toast` convention:
- `ROW_ACCENT` → `ACCENT_VAR.blue`
- `KIND_LABEL` → `"Daily summary"`
- `KIND_ICON` → `"ph:newspaper"`

`pnpm build` is green again locally.

## ⚠️ CI gap (worth addressing separately)

This reached `main` because the **"Frontend build" required check runs the source-text test suite, not `next build`/`tsc`** — so type errors aren't caught pre-merge. Recommend adding `pnpm typecheck` (or `pnpm build`) to CI so this class of cross-PR `ItemKind`-exhaustiveness break is caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)