### PR TITLE
feat(code): Projects toggle collapses only the list; presets switch context

### DIFF
--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -10,6 +10,7 @@ const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "u
 const sidebar = await readFile(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
 const comux = await readFile(new URL("./comux-view.tsx", import.meta.url), "utf8");
 const modeType = await readFile(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
+const preset = await readFile(new URL("../lib/code-layout-preset.ts", import.meta.url), "utf8");
 
 // ── CodeView is a two-pane resizable shell, chat | comux ─────────────────────
 assert.match(codeView, /orientation="horizontal"/, "CodeView lays the panes out horizontally");
@@ -44,6 +45,54 @@ assert.match(
   "the stored preset is applied only when no dragged layout exists (no clobbering manual drags)",
 );
 assert.match(codeView, /CODE_PRESETS\.map\(/, "the toolbar renders a chip per preset");
+
+// ── Projects toggle collapses ONLY the projects list (not the whole code pane) ─
+// The toolbar's Projects button drives the comux projects-list column over a
+// window event; it must NOT collapse the code/comux Panel itself.
+assert.match(codeView, /onClick=\{toggleProjects\}/, "the toolbar has a Projects toggle");
+assert.match(
+  codeView,
+  /const toggleProjects = \(\) => setProjectList\(!projectsCollapsed\)/,
+  "the toggle flips the projects-list collapse, nothing else",
+);
+assert.match(
+  codeView,
+  /new CustomEvent\(CODE_PROJECT_LIST_EVENT, \{ detail: \{ collapsed \} \}\)/,
+  "collapse is broadcast to comux over CODE_PROJECT_LIST_EVENT",
+);
+assert.doesNotMatch(
+  codeView,
+  /\.collapse\(\)|collapsedSize|collapsible/,
+  "the code/comux Panel is never collapsed — only the projects list is",
+);
+
+// Presets are task setups, not just widths: each broadcasts a context preset
+// and toggles the projects list (Chat focuses the conversation).
+assert.match(
+  codeView,
+  /new CustomEvent\(CODE_PRESET_EVENT, \{ detail: \{ preset: next \} \}\)/,
+  "selecting a preset broadcasts the context preset",
+);
+assert.match(
+  codeView,
+  /setProjectList\(CODE_PRESET_HIDES_PROJECT_LIST\[next\]\)/,
+  "a preset shows/hides the projects list per its definition",
+);
+
+// ── comux reacts: hides the projects list + switches the right pane per preset ─
+assert.match(comux, /projectListCollapsed \? null : \(/, "comux hides the projects list column when collapsed");
+assert.match(comux, /addEventListener\(CODE_PROJECT_LIST_EVENT/, "comux listens for the projects-list toggle");
+assert.match(comux, /addEventListener\(CODE_PRESET_EVENT/, "comux listens for the layout preset");
+assert.match(
+  comux,
+  /CODE_PRESET_RIGHT_VIEW\[preset\][\s\S]*?setRightView\(nextRight\)/,
+  "a preset switches comux's right pane (Review → Changes, Split → Files)",
+);
+
+// The Review preset must target the git diff, and Split the files view —
+// otherwise the chips are just width tweaks.
+assert.match(preset, /review: "changes"/, "Review opens the git changes/diff");
+assert.match(preset, /split: "files"/, "Split shows the file tree & preview");
 
 // ── ComuxView accepts a storage namespace so Code-mode terminals are isolated ─
 assert.match(comux, /storageNamespace\?: string/, "ComuxView accepts a storageNamespace prop");

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -1,18 +1,24 @@
 "use client";
 
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { Group, Panel, Separator, useDefaultLayout, usePanelRef } from "react-resizable-panels";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
 import { Icon } from "@/lib/icon";
 import { useIsMobile } from "@/lib/use-viewport";
 import {
   CODE_PRESET_CHAT_SIZE,
+  CODE_PRESET_EVENT,
+  CODE_PRESET_HIDES_PROJECT_LIST,
+  CODE_PRESET_HINTS,
   CODE_PRESET_ICONS,
   CODE_PRESET_LABELS,
   CODE_PRESETS,
+  CODE_PROJECT_LIST_EVENT,
   DEFAULT_CODE_PRESET,
   readCodePreset,
+  readProjectListCollapsed,
   writeCodePreset,
+  writeProjectListCollapsed,
   type CodePreset,
 } from "@/lib/code-layout-preset";
 
@@ -105,9 +111,15 @@ function DesktopCodeView({ chat, comux }: Props) {
   // Tracks the highlighted chip. The actual sizes live in the panels' own
   // persisted layout (CODE_GROUP_ID); this only records the last preset chosen.
   const [preset, setPreset] = useState<CodePreset>(DEFAULT_CODE_PRESET);
+  // Whether the comux *projects list* (the 200px column inside the code pane)
+  // is hidden — NOT the whole code pane. The comux surface owns the actual
+  // column; we mirror the boolean here for the toolbar's pressed state and
+  // drive it over CODE_PROJECT_LIST_EVENT.
+  const [projectsCollapsed, setProjectsCollapsed] = useState(false);
 
   useEffect(() => {
     setPreset(readCodePreset());
+    setProjectsCollapsed(readProjectListCollapsed());
     // Apply the stored preset's width ONLY on a first-ever load (no dragged
     // layout persisted yet), so we never clobber a manual drag on reload — the
     // "default only when unstored" idiom. After this, useDefaultLayout restores
@@ -119,6 +131,14 @@ function DesktopCodeView({ chat, comux }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Show/hide the comux projects list. Persists and notifies comux-view; the
+  // code pane itself is never collapsed.
+  const setProjectList = (collapsed: boolean) => {
+    setProjectsCollapsed(collapsed);
+    writeProjectListCollapsed(collapsed);
+    window.dispatchEvent(new CustomEvent(CODE_PROJECT_LIST_EVENT, { detail: { collapsed } }));
+  };
+
   const applyPreset = (next: CodePreset) => {
     setPreset(next);
     writeCodePreset(next);
@@ -126,11 +146,28 @@ function DesktopCodeView({ chat, comux }: Props) {
     // own minSize). This goes through onLayoutChanged, so it persists — no
     // remount, so the comux terminals/file preview keep their state.
     chatPanelRef.current?.resize(CODE_PRESET_CHAT_SIZE[next]);
+    // A preset is a task setup, not just a width: hide/show the projects list
+    // and tell comux which right pane (files vs. git changes) to show.
+    setProjectList(CODE_PRESET_HIDES_PROJECT_LIST[next]);
+    window.dispatchEvent(new CustomEvent(CODE_PRESET_EVENT, { detail: { preset: next } }));
   };
+
+  const toggleProjects = () => setProjectList(!projectsCollapsed);
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-      <div className="flex shrink-0 items-center justify-end gap-1 border-b border-[var(--border-hairline)] px-2 py-1">
+      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-[var(--border-hairline)] px-2 py-1">
+        <button
+          type="button"
+          onClick={toggleProjects}
+          aria-pressed={!projectsCollapsed}
+          aria-label={projectsCollapsed ? "Show projects list" : "Hide projects list"}
+          title={projectsCollapsed ? "Show projects list" : "Hide projects list"}
+          className="flex h-7 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 px-2 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+        >
+          <Icon name={projectsCollapsed ? "ph:sidebar-simple" : "ph:sidebar-simple-fill"} width={13} />
+          <span>Projects</span>
+        </button>
         <div className="flex items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 p-0.5 text-[11px]">
           {CODE_PRESETS.map((p) => (
             <button
@@ -138,7 +175,7 @@ function DesktopCodeView({ chat, comux }: Props) {
               type="button"
               onClick={() => applyPreset(p)}
               aria-pressed={preset === p}
-              title={`${CODE_PRESET_LABELS[p]} layout`}
+              title={CODE_PRESET_HINTS[p]}
               className={`flex items-center gap-1.5 rounded-[5px] px-2.5 py-1 transition-colors ${
                 preset === p
                   ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -11,6 +11,13 @@ import { SessionChangesInner } from "@/components/session-changes-panel";
 import { useChangesSummary } from "@/lib/use-changes-summary";
 import { CodeEditor } from "@/components/code-editor";
 import { resolveLangLabel } from "@/lib/code-lang";
+import {
+  CODE_PRESET_EVENT,
+  CODE_PRESET_RIGHT_VIEW,
+  CODE_PROJECT_LIST_EVENT,
+  readProjectListCollapsed,
+  type CodePreset,
+} from "@/lib/code-layout-preset";
 import type { SearchResult } from "@/lib/project-search";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
 import {
@@ -284,6 +291,10 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [sessionsCollapsed, setSessionsCollapsed] = useState(false);
+  // Projects list (the 200px column) visibility, driven by the Code workspace
+  // toolbar's Projects toggle and its layout presets over window events. Lives
+  // here because comux owns the column; code-view only mirrors the boolean.
+  const [projectListCollapsed, setProjectListCollapsed] = useState(false);
   // Right pane view: the file preview, or the project's git changes/diff review.
   const [rightView, setRightView] = useState<"files" | "changes">("files");
   // Diff-first review: auto-switch to Changes the first time an agent run
@@ -592,6 +603,36 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
       window.removeEventListener("cave:open-file-diff", onOpenDiff as EventListener);
     };
   }, [active, openFilePreview, selectedRoot]);
+
+  // Code workspace toolbar wiring (projects view only): the Projects toggle
+  // shows/hides this column, and a layout preset additionally switches the
+  // right pane (Review → Changes, Split → Files). Sync the initial collapse
+  // state from storage so a reload remembers it.
+  useEffect(() => {
+    if (view !== "projects") return;
+    setProjectListCollapsed(readProjectListCollapsed());
+    const onProjectList = (event: Event) => {
+      const detail = (event as CustomEvent<{ collapsed?: boolean }>).detail;
+      setProjectListCollapsed(Boolean(detail?.collapsed));
+    };
+    const onPreset = (event: Event) => {
+      const preset = (event as CustomEvent<{ preset?: CodePreset }>).detail?.preset;
+      if (!preset) return;
+      const nextRight = CODE_PRESET_RIGHT_VIEW[preset];
+      if (nextRight) {
+        // An explicit preset is a deliberate view choice — pin it so diff-first
+        // auto-switch doesn't override.
+        pinnedRightViewRef.current = true;
+        setRightView(nextRight);
+      }
+    };
+    window.addEventListener(CODE_PROJECT_LIST_EVENT, onProjectList as EventListener);
+    window.addEventListener(CODE_PRESET_EVENT, onPreset as EventListener);
+    return () => {
+      window.removeEventListener(CODE_PROJECT_LIST_EVENT, onProjectList as EventListener);
+      window.removeEventListener(CODE_PRESET_EVENT, onPreset as EventListener);
+    };
+  }, [view]);
 
   const copyPreview = useCallback(() => {
     if (!preview || preview.kind !== "text") return;
@@ -1009,7 +1050,8 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
       ) : (
         /* Project tab */
         <div className="flex flex-1 min-h-0">
-          {/* Project list */}
+          {/* Project list — hidden via the Code toolbar's Projects toggle / Chat preset */}
+          {projectListCollapsed ? null : (
           <div className="w-[200px] shrink-0 overflow-y-auto border-r border-[var(--border-hairline)] py-2 text-[12px]">
             <div className="mb-1 flex items-center gap-1.5 px-3 pb-1">
               <span className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">Projects</span>
@@ -1061,6 +1103,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
               })}
             </div>
           </div>
+          )}
 
           {/* Project detail */}
           <div className="flex min-w-0 min-h-0 flex-1 flex-col">

--- a/src/lib/code-layout-preset.ts
+++ b/src/lib/code-layout-preset.ts
@@ -39,6 +39,63 @@ export const CODE_PRESET_ICONS: Record<CodePreset, IconName> = {
   review: "ph:git-diff",
 };
 
+/** One-line hint shown in each preset chip's tooltip — what the mode is *for*. */
+export const CODE_PRESET_HINTS: Record<CodePreset, string> = {
+  chat: "Focus the conversation — widen chat, hide the projects list",
+  split: "Balanced — chat beside the file tree & preview",
+  review: "Review changes — widen code and open the git diff",
+};
+
+/**
+ * A preset is more than a width: it sets up the whole Code workspace for a task.
+ * These maps let the chat-pane toolbar (code-view) and the coding surface
+ * (comux-view) agree on the *context* each preset implies, dispatched over the
+ * events below so neither component has to reach into the other.
+ */
+
+/** Whether a preset hides the comux projects list (Chat focuses the chat). */
+export const CODE_PRESET_HIDES_PROJECT_LIST: Record<CodePreset, boolean> = {
+  chat: true,
+  split: false,
+  review: false,
+};
+
+/** Which comux right-pane a preset switches to, or null to leave it untouched. */
+export const CODE_PRESET_RIGHT_VIEW: Record<CodePreset, "files" | "changes" | null> = {
+  chat: null, // conversation-forward: don't disturb whatever's open
+  split: "files", // balanced working layout → file tree & preview
+  review: "changes", // review-forward → the git diff
+};
+
+/** localStorage key for whether the comux projects list is collapsed. */
+export const CODE_PROJECT_LIST_KEY = "cave.code.projectListCollapsed.v1";
+
+/** Fired by the Code toolbar (code-view) → consumed by comux-view to show/hide
+ *  the projects list. `detail.collapsed: boolean`. */
+export const CODE_PROJECT_LIST_EVENT = "cave:code-project-list";
+
+/** Fired when a preset is chosen → comux-view switches its right pane to match.
+ *  `detail.preset: CodePreset`. */
+export const CODE_PRESET_EVENT = "cave:code-preset";
+
+export function readProjectListCollapsed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(CODE_PROJECT_LIST_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function writeProjectListCollapsed(collapsed: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(CODE_PROJECT_LIST_KEY, collapsed ? "1" : "0");
+  } catch {
+    /* ignore unavailable storage */
+  }
+}
+
 export function normalizeCodePreset(value: unknown): CodePreset {
   return CODE_PRESETS.includes(value as CodePreset)
     ? (value as CodePreset)


### PR DESCRIPTION
## What

Two fixes to the **Code workspace** toolbar, per request.

### 1. The Projects toggle collapses only the projects list
A **Projects** toggle in the toolbar now hides/shows **only the comux projects-list column** (the 200px list), instead of collapsing the whole code pane. It drives the column over a window event and persists across reloads; the code/comux `Panel` itself is never collapsed.

### 2. Chat / Split / Review presets are now task setups, not just widths
Each preset sets up the whole workspace for what you're doing:

| Preset | Width | Projects list | Code surface |
|--------|-------|---------------|--------------|
| **Chat** | wide chat | hidden | (unchanged — focus the conversation) |
| **Split** | balanced | shown | **Files** (file tree & preview) |
| **Review** | wide code | shown | **Changes** (git diff) |

The preset broadcasts an event; `comux-view` switches its right pane (Files/Changes) to match and **pins** it so the diff-first auto-switch won't fight the explicit choice. The chips also gained task-describing tooltips.

Shared event names, the storage key, and the per-preset context maps live in `code-layout-preset.ts` so `code-view` and `comux-view` stay in sync without reaching into each other.

## Files
- `src/lib/code-layout-preset.ts` — event names, storage key, `CODE_PRESET_HIDES_PROJECT_LIST`, `CODE_PRESET_RIGHT_VIEW`, `CODE_PRESET_HINTS`, read/write helpers
- `src/components/code-view.tsx` — Projects toggle + presets dispatch context
- `src/components/comux-view.tsx` — hides the list column; listens for the toggle/preset; switches the right pane
- `src/components/code-view.test.ts` — asserts the new wiring (list-only collapse, no panel collapse, preset→right-pane)

## Verification
- `tsc --noEmit` clean; `pnpm build` clean.
- `pnpm test:app` (306) + `pnpm test:api` (74) — green.
- Driven in the real app: Split shows the list → **Chat hides it** → **Projects toggle re-shows it** → **Review keeps it and opens Changes**. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)