### PR TITLE
refactor(code): move the projects-list collapse into the list's own header

### DIFF
--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -46,19 +46,19 @@ assert.match(
 );
 assert.match(codeView, /CODE_PRESETS\.map\(/, "the toolbar renders a chip per preset");
 
-// ── Projects toggle collapses ONLY the projects list (not the whole code pane) ─
-// The toolbar's Projects button drives the comux projects-list column over a
-// window event; it must NOT collapse the code/comux Panel itself.
-assert.match(codeView, /onClick=\{toggleProjects\}/, "the toolbar has a Projects toggle");
+// ── The projects-list collapse lives in the list's OWN header (in comux) ──────
+// It collapses only the 200px projects column — never the code/comux Panel —
+// and a thin rail re-opens it. The Code toolbar no longer carries the toggle.
+assert.doesNotMatch(codeView, /toggleProjects|aria-label=\{?"?(Hide|Show) projects/i, "the collapse toggle is not in the Code toolbar anymore");
+assert.match(comux, /onClick=\{\(\) => setProjectListVisible\(false\)\}/, "the projects-list header has a Hide control");
+assert.match(comux, /aria-label="Hide projects list"/, "the header collapse control is labelled");
+assert.match(comux, /onClick=\{\(\) => setProjectListVisible\(true\)\}/, "a collapsed rail re-opens the projects list");
+assert.match(comux, /aria-label="Show projects list"/, "the re-open control is labelled");
+assert.match(comux, /projectListCollapsed \? \(/, "comux swaps the column for a thin rail when collapsed");
 assert.match(
-  codeView,
-  /const toggleProjects = \(\) => setProjectList\(!projectsCollapsed\)/,
-  "the toggle flips the projects-list collapse, nothing else",
-);
-assert.match(
-  codeView,
-  /new CustomEvent\(CODE_PROJECT_LIST_EVENT, \{ detail: \{ collapsed \} \}\)/,
-  "collapse is broadcast to comux over CODE_PROJECT_LIST_EVENT",
+  comux,
+  /const setProjectListVisible = useCallback\([\s\S]*?writeProjectListCollapsed\(!visible\)/,
+  "toggling visibility persists so a reload remembers it",
 );
 assert.doesNotMatch(
   codeView,
@@ -67,7 +67,7 @@ assert.doesNotMatch(
 );
 
 // Presets are task setups, not just widths: each broadcasts a context preset
-// and toggles the projects list (Chat focuses the conversation).
+// and shows/hides the projects list (Chat focuses the conversation).
 assert.match(
   codeView,
   /new CustomEvent\(CODE_PRESET_EVENT, \{ detail: \{ preset: next \} \}\)/,
@@ -75,12 +75,16 @@ assert.match(
 );
 assert.match(
   codeView,
-  /setProjectList\(CODE_PRESET_HIDES_PROJECT_LIST\[next\]\)/,
-  "a preset shows/hides the projects list per its definition",
+  /new CustomEvent\(CODE_PROJECT_LIST_EVENT, \{ detail: \{ collapsed \} \}\)/,
+  "a preset shows/hides the projects list over CODE_PROJECT_LIST_EVENT",
+);
+assert.match(
+  codeView,
+  /CODE_PRESET_HIDES_PROJECT_LIST\[next\]/,
+  "the preset's list visibility comes from its definition",
 );
 
 // ── comux reacts: hides the projects list + switches the right pane per preset ─
-assert.match(comux, /projectListCollapsed \? null : \(/, "comux hides the projects list column when collapsed");
 assert.match(comux, /addEventListener\(CODE_PROJECT_LIST_EVENT/, "comux listens for the projects-list toggle");
 assert.match(comux, /addEventListener\(CODE_PRESET_EVENT/, "comux listens for the layout preset");
 assert.match(

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -16,7 +16,6 @@ import {
   CODE_PROJECT_LIST_EVENT,
   DEFAULT_CODE_PRESET,
   readCodePreset,
-  readProjectListCollapsed,
   writeCodePreset,
   writeProjectListCollapsed,
   type CodePreset,
@@ -111,15 +110,9 @@ function DesktopCodeView({ chat, comux }: Props) {
   // Tracks the highlighted chip. The actual sizes live in the panels' own
   // persisted layout (CODE_GROUP_ID); this only records the last preset chosen.
   const [preset, setPreset] = useState<CodePreset>(DEFAULT_CODE_PRESET);
-  // Whether the comux *projects list* (the 200px column inside the code pane)
-  // is hidden — NOT the whole code pane. The comux surface owns the actual
-  // column; we mirror the boolean here for the toolbar's pressed state and
-  // drive it over CODE_PROJECT_LIST_EVENT.
-  const [projectsCollapsed, setProjectsCollapsed] = useState(false);
 
   useEffect(() => {
     setPreset(readCodePreset());
-    setProjectsCollapsed(readProjectListCollapsed());
     // Apply the stored preset's width ONLY on a first-ever load (no dragged
     // layout persisted yet), so we never clobber a manual drag on reload — the
     // "default only when unstored" idiom. After this, useDefaultLayout restores
@@ -131,14 +124,6 @@ function DesktopCodeView({ chat, comux }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Show/hide the comux projects list. Persists and notifies comux-view; the
-  // code pane itself is never collapsed.
-  const setProjectList = (collapsed: boolean) => {
-    setProjectsCollapsed(collapsed);
-    writeProjectListCollapsed(collapsed);
-    window.dispatchEvent(new CustomEvent(CODE_PROJECT_LIST_EVENT, { detail: { collapsed } }));
-  };
-
   const applyPreset = (next: CodePreset) => {
     setPreset(next);
     writeCodePreset(next);
@@ -146,28 +131,18 @@ function DesktopCodeView({ chat, comux }: Props) {
     // own minSize). This goes through onLayoutChanged, so it persists — no
     // remount, so the comux terminals/file preview keep their state.
     chatPanelRef.current?.resize(CODE_PRESET_CHAT_SIZE[next]);
-    // A preset is a task setup, not just a width: hide/show the projects list
-    // and tell comux which right pane (files vs. git changes) to show.
-    setProjectList(CODE_PRESET_HIDES_PROJECT_LIST[next]);
+    // A preset is a task setup, not just a width: show/hide the comux projects
+    // list (the toggle itself lives in that list's header) and tell comux which
+    // right pane (files vs. git changes) to show.
+    const collapsed = CODE_PRESET_HIDES_PROJECT_LIST[next];
+    writeProjectListCollapsed(collapsed);
+    window.dispatchEvent(new CustomEvent(CODE_PROJECT_LIST_EVENT, { detail: { collapsed } }));
     window.dispatchEvent(new CustomEvent(CODE_PRESET_EVENT, { detail: { preset: next } }));
   };
 
-  const toggleProjects = () => setProjectList(!projectsCollapsed);
-
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-[var(--border-hairline)] px-2 py-1">
-        <button
-          type="button"
-          onClick={toggleProjects}
-          aria-pressed={!projectsCollapsed}
-          aria-label={projectsCollapsed ? "Show projects list" : "Hide projects list"}
-          title={projectsCollapsed ? "Show projects list" : "Hide projects list"}
-          className="flex h-7 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 px-2 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
-        >
-          <Icon name={projectsCollapsed ? "ph:sidebar-simple" : "ph:sidebar-simple-fill"} width={13} />
-          <span>Projects</span>
-        </button>
+      <div className="flex shrink-0 items-center justify-end gap-1 border-b border-[var(--border-hairline)] px-2 py-1">
         <div className="flex items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 p-0.5 text-[11px]">
           {CODE_PRESETS.map((p) => (
             <button

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -16,6 +16,7 @@ import {
   CODE_PRESET_RIGHT_VIEW,
   CODE_PROJECT_LIST_EVENT,
   readProjectListCollapsed,
+  writeProjectListCollapsed,
   type CodePreset,
 } from "@/lib/code-layout-preset";
 import type { SearchResult } from "@/lib/project-search";
@@ -634,6 +635,14 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
     };
   }, [view]);
 
+  // Show/hide the projects list from its own header (and the collapsed rail).
+  // Persists so a reload remembers; the Code presets also drive this over the
+  // event above.
+  const setProjectListVisible = useCallback((visible: boolean) => {
+    setProjectListCollapsed(!visible);
+    writeProjectListCollapsed(!visible);
+  }, []);
+
   const copyPreview = useCallback(() => {
     if (!preview || preview.kind !== "text") return;
     void copyText(preview.content).then(() => {
@@ -1050,14 +1059,42 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
       ) : (
         /* Project tab */
         <div className="flex flex-1 min-h-0">
-          {/* Project list — hidden via the Code toolbar's Projects toggle / Chat preset */}
-          {projectListCollapsed ? null : (
+          {/* Project list — collapse from its own header; a thin rail re-opens it.
+              The Code layout presets also drive this (Chat hides it). */}
+          {projectListCollapsed ? (
+          <div className="flex w-[34px] shrink-0 flex-col items-center gap-2 border-r border-[var(--border-hairline)] py-2">
+            <button
+              type="button"
+              onClick={() => setProjectListVisible(true)}
+              aria-label="Show projects list"
+              title="Show projects list"
+              className="grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+            >
+              <Icon name="ph:sidebar-simple" width={15} />
+            </button>
+            <span
+              className="mt-1 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)]"
+              style={{ writingMode: "vertical-rl" }}
+            >
+              Projects
+            </span>
+          </div>
+          ) : (
           <div className="w-[200px] shrink-0 overflow-y-auto border-r border-[var(--border-hairline)] py-2 text-[12px]">
             <div className="mb-1 flex items-center gap-1.5 px-3 pb-1">
               <span className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">Projects</span>
-              <span className="ml-auto rounded-full bg-[var(--bg-raised)] px-1.5 py-px text-[9px] text-[var(--text-muted)]">
+              <span className="rounded-full bg-[var(--bg-raised)] px-1.5 py-px text-[9px] text-[var(--text-muted)]">
                 {projects.length}
               </span>
+              <button
+                type="button"
+                onClick={() => setProjectListVisible(false)}
+                aria-label="Hide projects list"
+                title="Hide projects list"
+                className="ml-auto grid h-5 w-5 place-items-center rounded text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+              >
+                <Icon name="ph:sidebar-simple-fill" width={13} />
+              </button>
             </div>
             <div className="space-y-px px-1">
               {projects.map((project) => {


### PR DESCRIPTION
## What

Follow-up to #977: the projects-list collapse control now lives in the **comux projects-list header**, not the Code toolbar.

- A small **Hide** button sits in the projects-list header (next to the count).
- When collapsed, the 200px column becomes a **thin rail** with a sidebar icon and a vertical "Projects" label; clicking it re-opens the list.
- Visibility **persists** so a reload remembers it.
- The Code toolbar drops its Projects button and goes back to just the preset chips. Presets still drive the list (Chat hides it) over the same `CODE_PROJECT_LIST_EVENT`, so everything stays in sync.

Behaviour is unchanged: only the projects list collapses, never the code pane.

## Files
- `src/components/comux-view.tsx` — header Hide control + collapsed rail + `setProjectListVisible` (persists)
- `src/components/code-view.tsx` — remove the toolbar toggle; presets still broadcast the collapse state
- `src/components/code-view.test.ts` — assert the control now lives in comux (with a re-open rail) and not in the toolbar

## Verification
- `tsc --noEmit` clean; `pnpm build` clean.
- `pnpm test:app` (306) + `pnpm test:api` (74) — green.
- Driven in the real app: Hide collapses to the rail → the rail re-opens it → the toolbar no longer carries the toggle. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)