### PR TITLE
feat(workflows): require explicit input + output nodes; gate run on them

### DIFF
--- a/src/app/api/workflows/run/route.ts
+++ b/src/app/api/workflows/run/route.ts
@@ -6,7 +6,7 @@ import { isAllowedHarness, MAX_SESSION_JSON_BYTES, normalizeProjectRoot } from "
 import { buildWorkflowRunPrompt } from "@/lib/workflow-run-prompt";
 import { recordRun } from "@/lib/workflow-runs";
 import { loadLocalWorkflowList } from "@/lib/workflow-source";
-import type { WorkflowSummary } from "@/lib/workflows";
+import { workflowRunBlockReason, type WorkflowSummary } from "@/lib/workflows";
 
 export const dynamic = "force-dynamic";
 
@@ -59,6 +59,17 @@ export async function POST(req: Request) {
 
   if (!body.id && !body.path) {
     return NextResponse.json({ ok: false, error: "id or path required" }, { status: 400 });
+  }
+
+  // I/O contract gate: refuse to run a workflow with no input node (no defined
+  // input) or no output node (no produced artifact). Enforced here so the rule
+  // holds for any caller, not just the Studio's Play button.
+  const gateWorkflow = await resolveWorkflow(body);
+  if (gateWorkflow) {
+    const blocked = workflowRunBlockReason(gateWorkflow);
+    if (blocked) {
+      return NextResponse.json({ ok: false, error: blocked }, { status: 400 });
+    }
   }
 
   // 1. Native daemon engine first (forward-compatible).

--- a/src/components/workflows/workflow-canvas.tsx
+++ b/src/components/workflows/workflow-canvas.tsx
@@ -106,6 +106,7 @@ function workflowMiniMapNodeColor(node: Node): string {
   const data = node.data as Partial<WorkflowGraphNodeData> | undefined;
   if (data?.status === "blocked") return "#b95050";
   if (data?.status === "ready") return "#3f8f5b";
+  if (data?.tone === "input") return "#4f9d69";
   if (data?.tone === "agent") return "#6b8fbf";
   if (data?.tone === "gate") return "#b5892f";
   if (data?.tone === "tool") return "#7c9b70";

--- a/src/components/workflows/workflow-palette.tsx
+++ b/src/components/workflows/workflow-palette.tsx
@@ -9,11 +9,13 @@ type WorkflowPaletteProps = {
 };
 
 const PALETTE: Array<{ kind: WorkflowStepKind; label: string; icon: IconName; tone: string }> = [
+  { kind: "input", label: "Input", icon: "ph:tray", tone: "input" },
   { kind: "agent", label: "Agent", icon: "ph:brain", tone: "agent" },
   { kind: "skill", label: "Skill", icon: "ph:sparkle", tone: "tool" },
   { kind: "tool", label: "Tool", icon: "ph:wrench", tone: "tool" },
   { kind: "human-gate", label: "Human gate", icon: "ph:hand", tone: "gate" },
   { kind: "workflow", label: "Workflow", icon: "ph:graph", tone: "workflow" },
+  { kind: "output", label: "Output", icon: "ph:package-bold", tone: "output" },
 ];
 
 /** Node palette: one click appends a step of the given CWF-01 kind. */

--- a/src/components/workflows/workflow-run-strip.tsx
+++ b/src/components/workflows/workflow-run-strip.tsx
@@ -7,7 +7,7 @@ import {
   playbackSummary,
   type WorkflowPlaybackState,
 } from "@/lib/workflow-playback";
-import { isPublicTemplate, workflowIssueSummary, type WorkflowValidationIssue, type WorkflowSummary } from "@/lib/workflows";
+import { isPublicTemplate, workflowIssueSummary, workflowRunBlockReason, type WorkflowValidationIssue, type WorkflowSummary } from "@/lib/workflows";
 import type { WorkflowStudioActionState } from "./workflow-studio";
 
 type WorkflowRunStripProps = {
@@ -76,6 +76,9 @@ export function WorkflowRunStrip({
   // Templates are read-only; saving an edit forks a personal copy to ~/.coven.
   const forking = workflow ? isPublicTemplate(workflow) : false;
   const saveLabel = saveBusy ? (forking ? "Forking" : "Saving") : forking ? "Fork & Save" : "Save";
+  // The I/O contract gate: no input node (no defined input) or no output node
+  // (no produced artifact) ⇒ the workflow can't be run.
+  const ioBlock = workflowRunBlockReason(workflow);
 
   // Playback transport: when a plan/run is walking the graph, surface progress,
   // the live step, and a stop control. Cleared by switching workflows or stop.
@@ -137,14 +140,16 @@ export function WorkflowRunStrip({
           type="button"
           className="workflow-play-button"
           aria-label="Play workflow"
-          disabled={!workflow || anyBusy || dirty}
+          disabled={!workflow || anyBusy || dirty || ioBlock !== null}
           onClick={() => workflow && onPlay(workflow)}
           title={
-            dirty
-              ? "Save before running"
-              : engineUnavailable
-                ? "Daemon offline — plays the plan as a preview, no execution"
-                : "Run the workflow as a live agent session"
+            ioBlock
+              ? ioBlock
+              : dirty
+                ? "Save before running"
+                : engineUnavailable
+                  ? "Daemon offline — plays the plan as a preview, no execution"
+                  : "Run the workflow as a live agent session"
           }
         >
           <Icon name="ph:lightning-bold" width={14} />
@@ -207,7 +212,9 @@ export function WorkflowRunStrip({
                 ? `${action.kind === "validate" ? "Validation" : "Dry-run"} ${action.result.ok ? "ready" : "blocked"} · ${
                     action.result.error ?? workflowIssueSummary(issues)
                   }`
-                : "Validate to check the manifest · Dry-run previews · Play runs it as a live agent session."}
+                : ioBlock
+                  ? ioBlock
+                  : "Validate to check the manifest · Dry-run previews · Play runs it as a live agent session."}
           </p>
         </>
       )}

--- a/src/lib/workflow-edit.test.ts
+++ b/src/lib/workflow-edit.test.ts
@@ -39,8 +39,10 @@ const workflow: WorkflowSummary = {
   path: "release-review",    // cave-only, must NOT serialize
   storage: "public",         // cave-only, must NOT serialize
   steps: [
-    { id: "gate", kind: "human-gate", name: "Approval", uses: "valentina" },
+    { id: "input", kind: "input", name: "Input", summary: "The change to review." },
+    { id: "gate", kind: "human-gate", name: "Approval", uses: "valentina", requires: ["input"] },
     { id: "review", kind: "agent", uses: "nova", requires: ["gate"] },
+    { id: "output", kind: "output", name: "Output", summary: "The reviewed result.", requires: ["review"] },
   ],
   limits: { max_agents: 4 },
 };
@@ -54,8 +56,9 @@ assert.equal(manifest.summary, undefined, "absent fields are stripped, not seria
 const yamlText = workflowToYaml(workflow);
 const reparsed = parseYaml(yamlText) as Record<string, unknown>;
 assert.equal(reparsed.id, "release-review");
+const reparsedReview = (reparsed.steps as Array<Record<string, unknown>>).find((s) => s.id === "review");
 assert.deepEqual(
-  (reparsed.steps as Array<Record<string, unknown>>)[1].requires,
+  reparsedReview?.requires,
   ["gate"],
   "requires edges survive the YAML round-trip",
 );

--- a/src/lib/workflow-edit.ts
+++ b/src/lib/workflow-edit.ts
@@ -103,45 +103,60 @@ function step(
 }
 
 /**
- * Starter step scaffolds per CWF-01 pattern. Each template validates clean so
- * a freshly created workflow is immediately saveable and runnable-by-plan.
+ * Starter step scaffolds per CWF-01 pattern. Each template is bracketed by an
+ * `input` node (the required input) and an `output` node (the produced
+ * artifact) so a freshly created workflow already satisfies the I/O contract and
+ * is immediately saveable, validatable, and runnable-by-plan.
  */
 export const WORKFLOW_TEMPLATES: Record<WorkflowPattern, WorkflowStepSummary[]> = {
   "sequential": [
-    step("plan", "agent", "Plan", "Break the goal into ordered work."),
+    step("input", "input", "Input", "The goal and any context the workflow needs to start."),
+    step("plan", "agent", "Plan", "Break the goal into ordered work.", ["input"]),
     step("execute", "agent", "Execute", "Carry out the plan.", ["plan"]),
     step("review", "human-gate", "Review", "Hold for human sign-off on the result.", ["execute"]),
+    step("output", "output", "Output", "The reviewed deliverable.", ["review"]),
   ],
   "fan-out-and-synthesize": [
-    step("fan-out", "agent", "Fan out", "Dispatch parallel workers over the input set."),
+    step("input", "input", "Input", "The input set to fan workers out over."),
+    step("fan-out", "agent", "Fan out", "Dispatch parallel workers over the input set.", ["input"]),
     step("synthesize", "agent", "Synthesize", "Merge worker results into one deliverable.", ["fan-out"]),
-    step("deliver", "tool", "Deliver", "Emit the synthesized output.", ["synthesize"]),
+    step("output", "output", "Output", "The synthesized deliverable.", ["synthesize"]),
   ],
   "classify-and-act": [
-    step("classify", "agent", "Classify", "Label each input with its handling route."),
+    step("input", "input", "Input", "The items to classify and act on."),
+    step("classify", "agent", "Classify", "Label each input with its handling route.", ["input"]),
     step("act", "agent", "Act", "Apply the route-specific action per item.", ["classify"]),
+    step("output", "output", "Output", "The acted-on result per item.", ["act"]),
   ],
   "adversarial-verification": [
-    step("propose", "agent", "Propose", "Produce candidate findings or output."),
+    step("input", "input", "Input", "The claim or material to verify."),
+    step("propose", "agent", "Propose", "Produce candidate findings or output.", ["input"]),
     step("refute", "agent", "Refute", "Adversarially attack each candidate.", ["propose"]),
     step("verdict", "agent", "Verdict", "Keep only candidates that survive refutation.", ["refute"]),
+    step("output", "output", "Output", "The verified findings.", ["verdict"]),
   ],
   "generate-and-filter": [
-    step("generate", "agent", "Generate", "Produce a wide pool of candidates."),
+    step("input", "input", "Input", "The brief the candidates should satisfy."),
+    step("generate", "agent", "Generate", "Produce a wide pool of candidates.", ["input"]),
     step("filter", "agent", "Filter", "Score and keep the best candidates.", ["generate"]),
+    step("output", "output", "Output", "The selected best candidates.", ["filter"]),
   ],
   "tournament": [
-    step("seed", "agent", "Seed", "Generate bracket entrants."),
+    step("input", "input", "Input", "The pool to seed the bracket from."),
+    step("seed", "agent", "Seed", "Generate bracket entrants.", ["input"]),
     step("rounds", "agent", "Rounds", "Run pairwise elimination rounds.", ["seed"]),
-    step("champion", "tool", "Champion", "Emit the winning entry.", ["rounds"]),
+    step("output", "output", "Output", "The winning entry.", ["rounds"]),
   ],
   "loop-until-done": [
-    step("attempt", "agent", "Attempt", "Run one iteration toward the goal."),
+    step("input", "input", "Input", "The goal and the done-condition."),
+    step("attempt", "agent", "Attempt", "Run one iteration toward the goal.", ["input"]),
     step("check", "agent", "Check", "Decide whether the goal is met or another loop is needed.", ["attempt"]),
+    step("output", "output", "Output", "The completed result once the goal is met.", ["check"]),
   ],
   "custom": [
-    step("start", "agent", "Start", "First step of the custom flow."),
-    step("finish", "tool", "Finish", "Emit the final output.", ["start"]),
+    step("input", "input", "Input", "What this workflow needs to start."),
+    step("work", "agent", "Work", "Do the workflow's main work.", ["input"]),
+    step("output", "output", "Output", "The artifact this workflow produces.", ["work"]),
   ],
 };
 

--- a/src/lib/workflow-graph.test.ts
+++ b/src/lib/workflow-graph.test.ts
@@ -33,6 +33,8 @@ assert.equal(graph.nodes[0].data.kind, "human-gate", "node data preserves step k
 assert.equal(graph.nodes[0].data.tone, "gate", "human gates use gate tone");
 assert.equal(graph.nodes[1].position.x > graph.nodes[0].position.x, true, "nodes are laid out left to right");
 assert.equal(workflowNodeTone("workflow"), "workflow", "nested workflow nodes get workflow tone");
+assert.equal(workflowNodeTone("input"), "input", "input nodes get input tone");
+assert.equal(workflowNodeTone("output"), "output", "output nodes get output tone");
 
 const verticalGraph = workflowToGraph(workflow, undefined, undefined, "vertical");
 assert.equal(

--- a/src/lib/workflow-graph.ts
+++ b/src/lib/workflow-graph.ts
@@ -1,6 +1,6 @@
 import type { WorkflowDryRunPlan, WorkflowStepKind, WorkflowStepSummary, WorkflowSummary } from "./workflows.ts";
 
-export type WorkflowNodeTone = "agent" | "gate" | "tool" | "workflow" | "output" | "unknown";
+export type WorkflowNodeTone = "input" | "agent" | "gate" | "tool" | "workflow" | "output" | "unknown";
 
 export type WorkflowGraphNodeData = {
   label: string;
@@ -39,6 +39,7 @@ export type WorkflowGraph = {
 export type WorkflowLayoutDirection = "horizontal" | "vertical";
 
 export function workflowNodeTone(kind: WorkflowStepKind): WorkflowNodeTone {
+  if (kind === "input") return "input";
   if (kind === "agent") return "agent";
   if (kind === "human-gate") return "gate";
   if (kind === "skill" || kind === "tool") return "tool";

--- a/src/lib/workflow-source.test.ts
+++ b/src/lib/workflow-source.test.ts
@@ -34,8 +34,10 @@ async function exists(file: string): Promise<boolean> {
     pattern: "sequential",
     limits: { max_agents: 4 },
     steps: [
-      { id: "gate", kind: "human-gate" },
+      { id: "input", kind: "input", summary: "The change to review." },
+      { id: "gate", kind: "human-gate", requires: ["input"] },
       { id: "review", kind: "agent", requires: ["gate"] },
+      { id: "output", kind: "output", summary: "The reviewed result.", requires: ["review"] },
     ],
   };
   const result = validateManifest(raw);
@@ -44,7 +46,7 @@ async function exists(file: string): Promise<boolean> {
 
   const summary = coerceManifest(raw, "nova-release-review");
   assert.equal(summary.validation_state, "valid", "clean manifest is valid");
-  assert.equal(summary.steps?.length, 2, "steps are coerced");
+  assert.equal(summary.steps?.length, 4, "steps are coerced");
   assert.equal(summary.path, "nova-release-review", "source becomes the path");
 }
 
@@ -83,7 +85,11 @@ async function exists(file: string): Promise<boolean> {
     id: "wf",
     version: "1.0.0",
     pattern: "made-up",
-    steps: [{ id: "a", kind: "agent" }],
+    steps: [
+      { id: "input", kind: "input", summary: "in" },
+      { id: "a", kind: "agent", requires: ["input"] },
+      { id: "output", kind: "output", summary: "out", requires: ["a"] },
+    ],
   };
   const result = validateManifest(raw);
   assert.equal(result.ok, true, "unknown pattern is a soft warning");
@@ -99,8 +105,10 @@ async function exists(file: string): Promise<boolean> {
       version: "1.0.0",
       limits: { max_agents: 6, timeout_s: 120 },
       steps: [
-        { id: "gate", kind: "human-gate" },
+        { id: "input", kind: "input", summary: "in" },
+        { id: "gate", kind: "human-gate", requires: ["input"] },
         { id: "go", kind: "agent", requires: ["gate"] },
+        { id: "output", kind: "output", summary: "out", requires: ["go"] },
       ],
     },
     "wf",
@@ -126,12 +134,47 @@ async function exists(file: string): Promise<boolean> {
     id: "draft",
     version: "0.1.0",
     steps: [
-      { id: "a", kind: "agent" },
+      { id: "input", kind: "input", summary: "in" },
+      { id: "a", kind: "agent", requires: ["input"] },
       { id: "b", kind: "agent", requires: ["a"] },
+      { id: "output", kind: "output", summary: "out", requires: ["b"] },
     ],
   });
   assert.equal(plan.ok, true, "draft manifest plans ok");
-  assert.equal(plan.steps?.length, 2);
+  assert.equal(plan.steps?.length, 4);
+}
+
+// I/O contract: a workflow can't validate or plan without an input + output.
+{
+  const noInput = validateManifest({
+    id: "wf",
+    version: "1.0.0",
+    steps: [
+      { id: "a", kind: "agent" },
+      { id: "output", kind: "output", summary: "out", requires: ["a"] },
+    ],
+  });
+  assert.equal(noInput.ok, false, "no input node fails validation");
+  assert.ok(noInput.issues.some((i) => i.code === "missing_input"), "flags missing input");
+
+  const noOutput = validateManifest({
+    id: "wf",
+    version: "1.0.0",
+    steps: [
+      { id: "input", kind: "input", summary: "in" },
+      { id: "a", kind: "agent", requires: ["input"] },
+    ],
+  });
+  assert.equal(noOutput.ok, false, "no output node fails validation");
+  assert.ok(noOutput.issues.some((i) => i.code === "missing_output"), "flags missing output");
+
+  // The dry-run plan is likewise blocked without the I/O pair.
+  const plan = planDryRun(coerceManifest({ id: "wf", version: "1.0.0", steps: [{ id: "a", kind: "agent" }] }, "wf"));
+  assert.equal(plan.ok, false, "plan is blocked without input/output");
+  assert.ok(
+    plan.issues?.some((i) => i.code === "missing_input") && plan.issues?.some((i) => i.code === "missing_output"),
+    "plan reports both missing-I/O blockers",
+  );
 }
 
 // Save and delete round-trip against a temp workflows dir.
@@ -150,8 +193,10 @@ await (async () => {
       pattern: "sequential",
       visibility: { public: true, coven_cave: true },
       steps: [
-        { id: "plan", kind: "agent" },
+        { id: "input", kind: "input", summary: "in" },
+        { id: "plan", kind: "agent", requires: ["input"] },
         { id: "go", kind: "agent", requires: ["plan"] },
+        { id: "output", kind: "output", summary: "out", requires: ["go"] },
       ],
     };
 

--- a/src/lib/workflow-source.ts
+++ b/src/lib/workflow-source.ts
@@ -278,6 +278,41 @@ export function validateManifest(raw: unknown, source?: string): WorkflowValidat
         }
       }
     }
+
+    // I/O contract: a workflow can't run without a defined input, and can't
+    // finish without producing an output artifact. Both are hard errors.
+    const kinds = steps.map((step) =>
+      asString((step && typeof step === "object" ? (step as Record<string, unknown>) : {}).kind),
+    );
+    if (!kinds.includes("input")) {
+      hardError = true;
+      issues.push(issue("semantic", "missing_input", "Workflow must declare an input node — it can't run without a defined input.", {
+        path: "steps",
+        suggestion: "Add a step with kind: input describing the required input.",
+      }));
+    }
+    if (!kinds.includes("output")) {
+      hardError = true;
+      issues.push(issue("semantic", "missing_output", "Workflow must declare an output node — it can't finish without producing an artifact.", {
+        path: "steps",
+        suggestion: "Add a step with kind: output describing the produced artifact.",
+      }));
+    }
+    // Nudge (non-blocking): input/output nodes should describe their contract.
+    for (const [index, step] of steps.entries()) {
+      const s = (step && typeof step === "object" ? step : {}) as Record<string, unknown>;
+      const kind = asString(s.kind);
+      if (kind === "input" && !asString(s.summary)) {
+        issues.push(issue("preflight", "input_undocumented", `Describe what input \`${asString(s.id) ?? index}\` requires.`, {
+          path: `steps[${index}].summary`,
+        }));
+      }
+      if (kind === "output" && !asString(s.summary)) {
+        issues.push(issue("preflight", "output_undocumented", `Describe the artifact \`${asString(s.id) ?? index}\` produces.`, {
+          path: `steps[${index}].summary`,
+        }));
+      }
+    }
   }
 
   const pattern = asString(obj.pattern);
@@ -336,8 +371,17 @@ export function planDryRun(workflow: WorkflowSummary): WorkflowDryRunPlan {
     ...new Set(steps.flatMap((step) => step.permissions ?? []).concat(workflow.permissions ?? [])),
   ];
 
+  // I/O gate: no run is "ready" without an input node and an output node.
+  const structuralBlockers: WorkflowValidationIssue[] = [];
+  if (!steps.some((step) => step.kind === "input")) {
+    structuralBlockers.push(issue("semantic", "missing_input", "Add an input node — a workflow can't run without a defined input."));
+  }
+  if (!steps.some((step) => step.kind === "output")) {
+    structuralBlockers.push(issue("semantic", "missing_output", "Add an output node — a workflow can't finish without producing an artifact."));
+  }
+
   return {
-    ok: planSteps.every((step) => step.status === "ready"),
+    ok: planSteps.every((step) => step.status === "ready") && structuralBlockers.length === 0,
     workflowId: workflow.id,
     version: workflow.version,
     steps: planSteps,
@@ -348,7 +392,7 @@ export function planDryRun(workflow: WorkflowSummary): WorkflowDryRunPlan {
       requiredCapabilities: requiredCapabilities.length > 0 ? requiredCapabilities : undefined,
       humanGates: humanGates.length > 0 ? humanGates : undefined,
     },
-    issues: planSteps.flatMap((step) => step.blockers ?? []),
+    issues: [...structuralBlockers, ...planSteps.flatMap((step) => step.blockers ?? [])],
   };
 }
 

--- a/src/lib/workflows.test.ts
+++ b/src/lib/workflows.test.ts
@@ -7,7 +7,39 @@ const {
   validateWorkflow,
   dryRunWorkflow,
   workflowIssueSummary,
+  workflowRunBlockReason,
+  workflowInputSteps,
+  workflowOutputSteps,
 } = await import("./workflows.ts");
+
+// I/O contract gate: needs both an input and an output node to be runnable.
+{
+  const wf = (steps) => ({ id: "w", version: "1", steps });
+  assert.match(
+    workflowRunBlockReason(wf([{ id: "a", kind: "agent" }])),
+    /input node and an output node/,
+    "no I/O nodes ⇒ blocked for both",
+  );
+  assert.match(
+    workflowRunBlockReason(wf([{ id: "i", kind: "input" }, { id: "a", kind: "agent" }])),
+    /output node/,
+    "input only ⇒ blocked on output",
+  );
+  assert.match(
+    workflowRunBlockReason(wf([{ id: "a", kind: "agent" }, { id: "o", kind: "output" }])),
+    /input node/,
+    "output only ⇒ blocked on input",
+  );
+  assert.equal(
+    workflowRunBlockReason(wf([{ id: "i", kind: "input" }, { id: "o", kind: "output" }])),
+    null,
+    "input + output ⇒ runnable",
+  );
+  assert.equal(workflowRunBlockReason(null), "Select a workflow first.", "null workflow is blocked");
+  const both = wf([{ id: "i", kind: "input" }, { id: "a", kind: "agent" }, { id: "o", kind: "output" }]);
+  assert.equal(workflowInputSteps(both).length, 1, "finds the input node");
+  assert.equal(workflowOutputSteps(both).length, 1, "finds the output node");
+}
 
 {
   assert.equal(

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -8,7 +8,15 @@ export type WorkflowPattern =
   | "sequential"
   | "custom";
 
-export type WorkflowStepKind = "agent" | "skill" | "tool" | "human-gate" | "workflow" | string;
+export type WorkflowStepKind =
+  | "input"
+  | "agent"
+  | "skill"
+  | "tool"
+  | "human-gate"
+  | "workflow"
+  | "output"
+  | string;
 
 export type WorkflowStepSummary = {
   id: string;
@@ -338,6 +346,39 @@ export async function scheduleWorkflow(
     },
     fetchImpl,
   );
+}
+
+/** Steps that declare the workflow's required input(s). */
+export function workflowInputSteps(workflow: WorkflowSummary): WorkflowStepSummary[] {
+  return (workflow.steps ?? []).filter((step) => step.kind === "input");
+}
+
+/** Steps that declare the artifact(s) the workflow produces. */
+export function workflowOutputSteps(workflow: WorkflowSummary): WorkflowStepSummary[] {
+  return (workflow.steps ?? []).filter((step) => step.kind === "output");
+}
+
+/**
+ * Why a workflow may not be run, or null when it is structurally complete.
+ * A workflow needs a declared **input** node (it can't run without a defined
+ * input) and an **output** node (it can't finish without producing an
+ * artifact). This is the single source of truth the Studio's Play gate and the
+ * run route both consult.
+ */
+export function workflowRunBlockReason(workflow: WorkflowSummary | null): string | null {
+  if (!workflow) return "Select a workflow first.";
+  const hasInput = workflowInputSteps(workflow).length > 0;
+  const hasOutput = workflowOutputSteps(workflow).length > 0;
+  if (!hasInput && !hasOutput) {
+    return "Add an input node and an output node before running.";
+  }
+  if (!hasInput) {
+    return "Add an input node — a workflow can't run without a defined input.";
+  }
+  if (!hasOutput) {
+    return "Add an output node — a workflow can't finish without producing an artifact.";
+  }
+  return null;
 }
 
 export function workflowIssueSummary(issues: WorkflowValidationIssue[]): string {

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -702,6 +702,11 @@
   outline-offset: 2px;
 }
 
+.workflow-node-input {
+  border-color: #4f9d69;
+  border-left-width: 3px;
+}
+
 .workflow-node-agent {
   border-color: #6b8fbf;
 }
@@ -720,6 +725,7 @@
 
 .workflow-node-output {
   border-color: #5f9ea0;
+  border-right-width: 3px;
 }
 
 .workflow-node-unknown {
@@ -988,6 +994,8 @@
   opacity: 0.45;
 }
 
+.workflow-palette-input { border-left: 3px solid #4f9d69; }
+.workflow-palette-output { border-left: 3px solid #5f9ea0; }
 .workflow-palette-agent { border-left: 3px solid color-mix(in oklch, var(--color-info, #6aa6ff) 70%, transparent); }
 .workflow-palette-tool { border-left: 3px solid color-mix(in oklch, var(--color-success, #57c878) 70%, transparent); }
 .workflow-palette-gate { border-left: 3px solid color-mix(in oklch, var(--color-warning, #d9a13c) 70%, transparent); }

--- a/workflows/annotate-document.yaml
+++ b/workflows/annotate-document.yaml
@@ -18,11 +18,17 @@ visibility:
   public: true
   coven_cave: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: intake
     kind: agent
     name: Document intake
     uses: sage
     summary: Identify the document, requested angle, citation needs, and output location.
+    requires:
+      - input
   - id: read-pass
     kind: agent
     name: Read for structure
@@ -51,3 +57,9 @@ steps:
     summary: Write the annotation packet to the library with tags and retrieval metadata.
     requires:
       - verify-citations
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - save-notes

--- a/workflows/archive-memory.yaml
+++ b/workflows/archive-memory.yaml
@@ -19,11 +19,17 @@ visibility:
   public: true
   coven_cave: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: collect-context
     kind: agent
     name: Collect context
     uses: echo
     summary: Gather daily notes, decisions, open loops, and relevant project summaries.
+    requires:
+      - input
   - id: separate-records
     kind: agent
     name: Separate records
@@ -52,3 +58,9 @@ steps:
     summary: Save the approved archive packet with open loops and review notes.
     requires:
       - review-gate
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - write-archive

--- a/workflows/bug-diagnosis.yaml
+++ b/workflows/bug-diagnosis.yaml
@@ -20,11 +20,17 @@ visibility:
   coven_cave: true
   coven_code: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: reproduce
     kind: agent
     name: Reproduce failure
     uses: cody
     summary: Run or inspect the failing path before proposing a cause.
+    requires:
+      - input
   - id: trace
     kind: agent
     name: Trace root cause
@@ -60,3 +66,9 @@ steps:
     summary: Report root cause, changed files, verification, and residual risk.
     requires:
       - verify
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - handoff

--- a/workflows/coordination-router.yaml
+++ b/workflows/coordination-router.yaml
@@ -18,11 +18,17 @@ visibility:
   public: true
   coven_cave: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: classify-task
     kind: agent
     name: Classify task
     uses: astra
     summary: Identify whether the work is research, implementation, memory, comms, strategy, or orchestration.
+    requires:
+      - input
   - id: map-dependencies
     kind: agent
     name: Map dependencies
@@ -51,3 +57,9 @@ steps:
     summary: Emit context, acceptance criteria, stop conditions, owner, and next action.
     requires:
       - escalation-check
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - handoff

--- a/workflows/coven-orchestration.yaml
+++ b/workflows/coven-orchestration.yaml
@@ -20,11 +20,17 @@ visibility:
   public: true
   coven_cave: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: define-goal
     kind: agent
     name: Define goal and gates
     uses: nova
     summary: Capture Val's goal, hard constraints, approval gates, and completion proof.
+    requires:
+      - input
   - id: route-lanes
     kind: workflow
     name: Route lanes
@@ -67,3 +73,9 @@ steps:
     summary: Report outcome, evidence, remaining risks, and whether the work can be archived.
     requires:
       - preserve-memory
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - completion-report

--- a/workflows/curate-reading-list.yaml
+++ b/workflows/curate-reading-list.yaml
@@ -19,11 +19,17 @@ visibility:
   public: true
   coven_cave: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: load-library
     kind: agent
     name: Load library context
     uses: sage
     summary: Read current bookmarks, reading statuses, collections, and active project needs.
+    requires:
+      - input
   - id: classify-items
     kind: agent
     name: Classify items
@@ -52,3 +58,9 @@ steps:
     summary: Save the curated list with rationale, tags, and next reading actions.
     requires:
       - prune-gate
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - update-list

--- a/workflows/devrel-response.yaml
+++ b/workflows/devrel-response.yaml
@@ -18,11 +18,17 @@ visibility:
   public: true
   coven_cave: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: gather-status
     kind: agent
     name: Gather status
     uses: charm
     summary: Collect issue, release, support, or community context plus current project status.
+    requires:
+      - input
   - id: verify-facts
     kind: agent
     name: Verify facts
@@ -51,3 +57,9 @@ steps:
     summary: Save the reply draft and approval state for the target surface.
     requires:
       - approval-gate
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - save-draft

--- a/workflows/draft-copy.yaml
+++ b/workflows/draft-copy.yaml
@@ -18,11 +18,17 @@ visibility:
   public: true
   coven_cave: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: define-brief
     kind: agent
     name: Define brief
     uses: charm
     summary: Capture audience, surface, desired outcome, voice, constraints, and source material.
+    requires:
+      - input
   - id: generate-options
     kind: agent
     name: Generate options
@@ -51,3 +57,9 @@ steps:
     summary: Save the final draft, alternates, assumptions, and approval needs.
     requires:
       - revise-tone
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - approval-notes

--- a/workflows/nova-release-review.yaml
+++ b/workflows/nova-release-review.yaml
@@ -20,11 +20,17 @@ visibility:
   coven_cave: true
   coven_code: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: gate
     kind: human-gate
     name: Val approval
     uses: valentina
     summary: Hold until Val approves cutting the release.
+    requires:
+      - input
   - id: review
     kind: agent
     name: Nova review
@@ -46,3 +52,9 @@ steps:
     summary: Produce the human-facing release brief.
     requires:
       - lint
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - brief

--- a/workflows/prepare-social-post.yaml
+++ b/workflows/prepare-social-post.yaml
@@ -18,11 +18,17 @@ visibility:
   public: true
   coven_cave: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: brief
     kind: agent
     name: Social brief
     uses: charm
     summary: Identify platform, audience, target action, constraints, and source truth.
+    requires:
+      - input
   - id: draft-posts
     kind: agent
     name: Draft posts
@@ -51,3 +57,9 @@ steps:
     summary: Save approved draft, target platform, approval status, and posting notes.
     requires:
       - approval-gate
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - store-state

--- a/workflows/research-brief.yaml
+++ b/workflows/research-brief.yaml
@@ -19,11 +19,17 @@ visibility:
   public: true
   coven_cave: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: scope-question
     kind: agent
     name: Scope question
     uses: sage
     summary: Define the research question, decision context, constraints, and evidence standard.
+    requires:
+      - input
   - id: gather-primary
     kind: agent
     name: Gather primary sources
@@ -60,3 +66,9 @@ steps:
     summary: Save the cited brief and next-step recommendations.
     requires:
       - synthesize
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - deliver

--- a/workflows/retrospective-synthesis.yaml
+++ b/workflows/retrospective-synthesis.yaml
@@ -19,11 +19,17 @@ visibility:
   public: true
   coven_cave: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: intake-packet
     kind: agent
     name: Intake packet
     uses: echo
     summary: Read curated notes, project summaries, and explicit retrospective scope.
+    requires:
+      - input
   - id: extract-decisions
     kind: agent
     name: Extract decisions
@@ -52,3 +58,9 @@ steps:
     summary: Save the retrospective with decisions, open loops, and memory-review notes.
     requires:
       - propose-memory
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - write-retro

--- a/workflows/review-diff.yaml
+++ b/workflows/review-diff.yaml
@@ -19,11 +19,17 @@ visibility:
   coven_cave: true
   coven_code: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: load-context
     kind: agent
     name: Load context
     uses: cody
     summary: Read the diff, requirements, related tests, and touched ownership boundaries.
+    requires:
+      - input
   - id: inspect-behavior
     kind: agent
     name: Inspect behavior
@@ -53,3 +59,9 @@ steps:
     summary: Lead with actionable findings by severity, then questions and residual risk.
     requires:
       - adversarial-pass
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - report-findings

--- a/workflows/sage-research-sweep.yaml
+++ b/workflows/sage-research-sweep.yaml
@@ -19,11 +19,17 @@ visibility:
   public: true
   coven_cave: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: plan
     kind: agent
     name: Scope the question
     uses: sage
     summary: Decompose the research question into independent search angles.
+    requires:
+      - input
   - id: gather-web
     kind: agent
     name: Web sweep
@@ -53,3 +59,9 @@ steps:
     summary: Synthesize the surviving findings into a cited brief.
     requires:
       - verify
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - synthesize

--- a/workflows/scoped-implementation.yaml
+++ b/workflows/scoped-implementation.yaml
@@ -20,11 +20,17 @@ visibility:
   coven_cave: true
   coven_code: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: inspect-scope
     kind: agent
     name: Inspect scope
     uses: cody
     summary: Read requirements, current code, conventions, and unrelated dirty work.
+    requires:
+      - input
   - id: failing-test
     kind: skill
     name: Write failing test
@@ -60,3 +66,9 @@ steps:
     summary: Summarize files changed, proof, caveats, and next safe action.
     requires:
       - approval-gate
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - handoff

--- a/workflows/strategy-map.yaml
+++ b/workflows/strategy-map.yaml
@@ -19,11 +19,17 @@ visibility:
   public: true
   coven_cave: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: clarify-goal
     kind: agent
     name: Clarify goal
     uses: astra
     summary: State the desired outcome, constraints, timing, and decision owner.
+    requires:
+      - input
   - id: map-options
     kind: agent
     name: Map options
@@ -52,3 +58,9 @@ steps:
     summary: Emit owners, lane handoffs, stopping points, and immediate next steps.
     requires:
       - recommend-route
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - next-moves

--- a/workflows/synthesize-sources.yaml
+++ b/workflows/synthesize-sources.yaml
@@ -19,11 +19,17 @@ visibility:
   public: true
   coven_cave: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: select-cluster
     kind: agent
     name: Select source cluster
     uses: sage
     summary: Identify the topic cluster and confirm enough sources are ready for synthesis.
+    requires:
+      - input
   - id: extract-source-notes
     kind: agent
     name: Extract source notes
@@ -52,3 +58,9 @@ steps:
     summary: Save the synthesis doc and update library metadata for retrieval.
     requires:
       - write-synthesis
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - save-synthesis

--- a/workflows/system-architecture-review.yaml
+++ b/workflows/system-architecture-review.yaml
@@ -19,11 +19,17 @@ visibility:
   public: true
   coven_cave: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: gather-context
     kind: agent
     name: Gather context
     uses: nova
     summary: Read requirements, existing architecture, repo boundaries, and relevant memory.
+    requires:
+      - input
   - id: define-boundaries
     kind: agent
     name: Define boundaries
@@ -59,3 +65,9 @@ steps:
     summary: Prepare a scoped plan with tasks, tests, gates, and handoff criteria.
     requires:
       - approval-gate
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - implementation-plan

--- a/workflows/tag-and-organize.yaml
+++ b/workflows/tag-and-organize.yaml
@@ -18,11 +18,17 @@ visibility:
   public: true
   coven_cave: true
 steps:
+  - id: input
+    kind: input
+    name: Input
+    summary: The input this workflow needs to start.
   - id: scan-items
     kind: agent
     name: Scan items
     uses: sage
     summary: Read target library entries, current tags, collections, titles, and statuses.
+    requires:
+      - input
   - id: normalize-metadata
     kind: agent
     name: Normalize metadata
@@ -58,3 +64,9 @@ steps:
     summary: Save metadata updates and a short rationale for future retrieval.
     requires:
       - deletion-gate
+  - id: output
+    kind: output
+    name: Output
+    summary: The artifact this workflow produces.
+    requires:
+      - write-library


### PR DESCRIPTION
## What

Workflows now have a first-class **I/O contract**: an **`input`** node (the required input) and an **`output`** node (the produced artifact). A workflow **can't run without an input**, and **can't finish without an output**.

```
[ Input ]──►[ step ]──►…──►[ step ]──►[ Output ]
 required      agent           agent     artifact
```

## Changes
- **New `input` / `output` step kinds** with their own tone + node styling, and **Input / Output entries in the builder palette**.
- **Validation** (`validateManifest`) hard-errors on a missing input node (`missing_input`) or missing output node (`missing_output`); nudges (preflight) when either lacks a description.
- **Dry-run** (`planDryRun`) is `ok: false` without the I/O pair.
- **Play is gated**: the Studio's Play button is disabled — with an explanatory reason (`workflowRunBlockReason`) — until both nodes exist, and the **same gate is enforced server-side in `/api/workflows/run` (HTTP 400)** so no caller can bypass it.
- **New-workflow templates** are bracketed `Input → … → Output`, so a fresh workflow already satisfies the contract.
- **All 19 shipped templates migrated** to add input/output nodes (wired to their roots/terminals) so the library keeps validating and running.

## Verification
- `tsc --noEmit` clean; `pnpm build` clean.
- `pnpm test:app` (306) + `pnpm test:api` (74) — green (added gate coverage across `workflows`, `workflow-source`, `workflow-graph`, `workflow-edit`).
- Driven in the real app: palette shows **Input/Output**, a migrated template renders **both nodes**, Play is **enabled** with the pair.
- Live-tested the server gate: saving a workflow without an output flags `missing_output`, and `POST /api/workflows/run` returns **HTTP 400** — *"Add an output node — a workflow can't finish without producing an artifact."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)