### PR TITLE
fix(projects): full-bleed session-row hover highlight in project cards

### DIFF
--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -77,7 +77,7 @@ function ProjectChatRow({
         onKeyDown={(e) => {
           if (e.key === "Enter") onOpen();
         }}
-        className="flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+        className="flex w-full items-center gap-2 px-4 py-1 text-left text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
       >
         <button
           type="button"
@@ -383,7 +383,7 @@ function ProjectRow({
       {chats.length > 0 ? (
         <>
           <SortableContext items={visibleChats.map((s) => s.id)} strategy={verticalListSortingStrategy}>
-            <ul className="mt-2 flex flex-col gap-0.5 border-t border-[var(--border-hairline)] pt-2">
+            <ul className="-mx-2 mt-2 flex flex-col gap-0.5 border-t border-[var(--border-hairline)] pt-2">
               {visibleChats.map((session) => (
                 <ProjectChatRow
                   key={session.id}


### PR DESCRIPTION
## What

Session rows under each project card highlighted on hover/active, but the highlight stopped ~8px short of the card edges — it sat inside the card's `px-2` padding and had its own `rounded-md` inset. This makes the highlight span the **full card width**, edge to edge.

## Change

`src/components/projects-view.tsx`:
- `<ul>` of session rows: add `-mx-2` so the list bleeds to the card's border-box edges.
- Row button: `rounded-md px-2` → `px-4`, so the bullet, title, and trash button stay in their exact current positions while the background reaches both edges.

No layout shift — only the highlight extends. The row divider becomes full-bleed to match.

## Verification

- Built and ran the app, opened the Projects tab on a real project (Coven Cave, 135 sessions), hovered a row: highlight now spans the full width edge-to-edge (before: inset ~8px each side, rounded).
- `projects-view.test.ts` and `chat-surface-projects-tab.test.ts` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)