### PR TITLE
fix(nav): gate Library sidebar entry behind its add-on (default off)

### DIFF
--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -102,6 +102,22 @@ assert.match(
   "Library remains the sole Knowledge surface",
 );
 
+// Library is a gated add-on (default off): the nav filter hides it until the
+// add-on is enabled, mirroring GitHub. Without the gate the Knowledge section
+// would always render Library.
+assert.match(
+  source,
+  /if \(fm\.id === "library"\) return addons\?\.library === true;/,
+  "Library nav entry is gated on the library add-on",
+);
+
+// The Knowledge section must not render an empty header when Library is hidden.
+assert.match(
+  source,
+  /knowledgeModes\.length > 0 \? \(/,
+  "Knowledge section only renders when it has visible surfaces",
+);
+
 assert.match(
   source,
   /\{ id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘7", description:/,

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -211,9 +211,11 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
     onModeChange(id);
   };
 
-  // Filter out disabled add-on items. GitHub is gated; library is always shown.
+  // Filter out disabled add-on items. GitHub and Library are gated add-ons,
+  // hidden from the nav until enabled in Settings → Add-ons (both default off).
   const visibleFolderModes = FOLDER_MODES.filter((fm) => {
     if (fm.id === "github") return addons?.github === true;
+    if (fm.id === "library") return addons?.library === true;
     return true;
   });
 
@@ -267,21 +269,23 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
           ))}
         </SidebarSection>
 
-        <SidebarSection label="Knowledge">
-          {knowledgeModes.map((fm) => (
-            <FolderRow
-              key={fm.id}
-              id={fm.id}
-              label={fm.label}
-              iconName={fm.iconName}
-              active={mode === fm.id}
-              badge={fm.badge?.(props)}
-              kbd={fm.kbd}
-              description={fm.description}
-              onClick={() => handleModeSelect(fm.id)}
-            />
-          ))}
-        </SidebarSection>
+        {knowledgeModes.length > 0 ? (
+          <SidebarSection label="Knowledge">
+            {knowledgeModes.map((fm) => (
+              <FolderRow
+                key={fm.id}
+                id={fm.id}
+                label={fm.label}
+                iconName={fm.iconName}
+                active={mode === fm.id}
+                badge={fm.badge?.(props)}
+                kbd={fm.kbd}
+                description={fm.description}
+                onClick={() => handleModeSelect(fm.id)}
+              />
+            ))}
+          </SidebarSection>
+        ) : null}
 
         <SidebarSection label="Tools">
           {toolsModes.map((fm) => (


### PR DESCRIPTION
## What

The **Library** was meant to be a gated add-on — it has a default of `false` in `cave-config`, a **Settings → Add-ons** toggle, and the `addons.library` flag is already plumbed into the sidebar — but the nav filter only ever gated **GitHub**. So Library always showed in the sidebar regardless of the add-on. This makes the Library nav entry **not show by default**, only appearing when the add-on is enabled.

## Change

`src/components/sidebar-minimal.tsx`:
- Gate the Library nav entry on `addons?.library === true`, mirroring GitHub.
- Render the **Knowledge** section only when it has visible surfaces, so hiding Library doesn't leave an empty section header (Library is its sole member).

`src/components/sidebar-minimal.test.ts`: assert the Library gate and the empty-Knowledge guard.

## Verification

Built + ran the app:
- **Default** (`addons.library: false`): sidebar shows `Work` + `Tools` only — no Library, no Knowledge header.
- After `PATCH /api/config {addons:{library:true}}` (what the Settings toggle sends): `Library` returns under a `Knowledge` section.
- `sidebar-minimal.test.ts` passes.

Config left at its default (`library: false`) on disk afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)