### PR TITLE
feat(library): 3-way segmented toggle for reading status

### DIFF
--- a/src/components/library-polish.test.ts
+++ b/src/components/library-polish.test.ts
@@ -142,8 +142,8 @@ assert.match(
 );
 assert.match(
   reading,
-  /className="library-reading-col-status"[\s\S]{0,200}<select[\s\S]{0,120}className="library-status-badge library-status-select"/,
-  "Reading status controls should live in a targetable column so they can keep a readable width",
+  /className="library-reading-col-status"[\s\S]{0,200}className="library-status-toggle"[\s\S]{0,120}role="radiogroup"/,
+  "Reading status should be a 3-way segmented toggle living in a targetable column",
 );
 assert.match(
   libraryCss,

--- a/src/components/library-reading-list.tsx
+++ b/src/components/library-reading-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { Icon } from "@/lib/icon";
+import { Icon, type IconName } from "@/lib/icon";
 import { useUndoDelete } from "@/lib/use-undo-delete";
 import { LibraryUndoToast } from "@/components/library-undo-toast";
 import type { LibraryReadingItem, ReadingStatus } from "@/lib/library-types";
@@ -12,7 +12,16 @@ import { useIsCoarsePointer } from "@/lib/use-viewport";
 type SortKey = "title" | "status" | "addedAt";
 type SortDir = "asc" | "desc";
 type GroupBy = "status" | "sourceType" | "none";
-const INLINE_STATUS_OPTIONS: ReadingStatus[] = ["want-to-read", "reading", "done"];
+const INLINE_STATUS_OPTIONS = ["want-to-read", "reading", "done"] as const;
+type InlineStatus = (typeof INLINE_STATUS_OPTIONS)[number];
+
+// Inline 3-way status toggle: full label for the active state + tooltip, short
+// label for the segmented control, icon for the compact/touch layout.
+const STATUS_META: Record<InlineStatus, { label: string; short: string; icon: IconName }> = {
+  "want-to-read": { label: "Want to read", short: "Want", icon: "ph:bookmark-simple" },
+  reading: { label: "Reading", short: "Reading", icon: "ph:book-open" },
+  done: { label: "Read", short: "Read", icon: "ph:check-circle" },
+};
 
 const STATUS_ORDER: Record<ReadingStatus, number> = {
   "want-to-read": 0,
@@ -394,23 +403,38 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
                         )}
                       </td>
                       <td className="library-reading-col-status">
-                        <select
-                          className="library-status-badge library-status-select"
-                          style={statusBadgeStyle(item.status)}
-                          value={item.status}
-                          onClick={(e) => e.stopPropagation()}
-                          onChange={(e) => {
-                            e.stopPropagation();
-                            void handleStatusChange(item, e.target.value as ReadingStatus);
-                          }}
+                        <div
+                          className="library-status-toggle"
+                          role="radiogroup"
                           aria-label={`Status for ${item.title}`}
+                          onClick={(e) => e.stopPropagation()}
                         >
-                          {INLINE_STATUS_OPTIONS.map((status) => (
-                            <option key={status} value={status}>
-                              {status.replace(/-/g, " ")}
-                            </option>
-                          ))}
-                        </select>
+                          {INLINE_STATUS_OPTIONS.map((status) => {
+                            const meta = STATUS_META[status];
+                            const active = item.status === status;
+                            return (
+                              <button
+                                key={status}
+                                type="button"
+                                role="radio"
+                                aria-checked={active}
+                                data-status={status}
+                                className={`library-status-toggle__opt${active ? " is-active" : ""}`}
+                                style={active ? statusBadgeStyle(status) : undefined}
+                                title={meta.label}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  if (!active) void handleStatusChange(item, status);
+                                }}
+                              >
+                                <Icon name={meta.icon} width={13} aria-hidden />
+                                {active && (
+                                  <span className="library-status-toggle__label">{meta.short}</span>
+                                )}
+                              </button>
+                            );
+                          })}
+                        </div>
                       </td>
                       <td className="library-reading-col-added">
                         <span className="board-table-muted">{relTime(item.addedAt)}</span>

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -1288,6 +1288,50 @@ tr:focus-within .library-row-delete {
   outline-offset: 1px;
 }
 
+/* Inline 3-way reading-status toggle (segmented control replacing the select). */
+.library-status-toggle {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 8px;
+  border: 1px solid var(--border-strong);
+  background-color: color-mix(in oklch, var(--bg-raised) 76%, transparent);
+  max-width: 100%;
+}
+.library-status-toggle__opt {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  min-width: 0;
+  min-height: 24px;
+  padding: 0 9px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.library-status-toggle__opt:hover {
+  color: var(--text-primary);
+  background: color-mix(in oklch, var(--text-primary) 8%, transparent);
+}
+.library-status-toggle__opt.is-active {
+  color: var(--text-primary);
+  font-weight: 560;
+  /* background + border come from statusBadgeStyle() inline, per status accent. */
+}
+.library-status-toggle__opt:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
+}
+.library-status-toggle__label { overflow: hidden; text-overflow: ellipsis; }
+
 /* ── progress bar ──────────────────────────────────────────────── */
 .library-progress-bar {
   height: 4px;
@@ -3068,6 +3112,9 @@ h3:hover .library-heading-anchor,
   width: 100%;
   text-transform: capitalize;
 }
+.library-reading-table .library-status-toggle__opt {
+  text-transform: capitalize;
+}
 /* Bookmarks: Title is the row's identity and must stay the priority column.
    Use auto layout + a fluid first column (max-width:0 + width:100%) so the
    Title absorbs all leftover space and *clips* — instead of fixed-layout,
@@ -3173,6 +3220,16 @@ h3:hover .library-heading-anchor,
     width: 100%;
     padding-left: 10px;
     padding-right: 24px;
+  }
+  /* Narrow status column on touch: tighter segments; only the active one
+     carries a label, so the control still fits the compact status column. */
+  .library-reading-table .library-status-toggle {
+    width: 100%;
+    justify-content: space-between;
+  }
+  .library-reading-table .library-status-toggle__opt {
+    padding: 0 6px;
+    min-height: 30px;
   }
 }
 


### PR DESCRIPTION
## What

Replaces the inline reading-status `<select>` dropdown in the Library reading list with a **3-way segmented toggle** — Want to read / Reading / Read.

### Behavior
- Each status is a radio in a `role="radiogroup"`. The **active** segment shows its short label and the per-status accent (reused from `statusBadgeStyle`: neutral for *want*, accent for *reading*, success-green for *read*); inactive segments are **icon-only with a tooltip**, keeping the control compact and unambiguous (no truncated "W../R../R..").
- Clicking a segment fires the existing optimistic `handleStatusChange` PATCH to `/api/library/reading`; clicking the already-active segment is a no-op.
- Narrow/touch status column tightens segment padding; the active-only label keeps the toggle within the compact column.

### Files
- `library-reading-list.tsx` — `STATUS_META` (label/short/icon), select → segmented toggle.
- `library.css` — `.library-status-toggle` segmented-control styles + responsive rules.
- `library-polish.test.ts` — assertion updated from the `<select>` to the toggle markup.

## Verification
- `pnpm typecheck` ✓
- `pnpm build` ✓ (Frontend build)
- `library-polish.test.ts` ✓
- Visually verified the three active states + accents in a CSS harness inlining the real `library.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)