### PR TITLE
fix(library): reading-status toggle — fit active label + handle legacy "read"

### DIFF
--- a/src/components/library-reading-list.tsx
+++ b/src/components/library-reading-list.tsx
@@ -15,6 +15,16 @@ type GroupBy = "status" | "sourceType" | "none";
 const INLINE_STATUS_OPTIONS = ["want-to-read", "reading", "done"] as const;
 type InlineStatus = (typeof INLINE_STATUS_OPTIONS)[number];
 
+// Some legacy items were persisted with status "read" (and other variants)
+// before the canonical enum settled on "done". Fold them onto a toggle option
+// so the active segment renders correctly; the raw status is still what we
+// compare against on click, so re-picking the option heals it to "done".
+function toggleStatus(status: ReadingStatus | string): InlineStatus {
+  if (status === "read" || status === "done") return "done";
+  if (status === "reading") return "reading";
+  return "want-to-read";
+}
+
 // Inline 3-way status toggle: full label for the active state + tooltip, short
 // label for the segmented control, icon for the compact/touch layout.
 const STATUS_META: Record<InlineStatus, { label: string; short: string; icon: IconName }> = {
@@ -199,7 +209,7 @@ type Props = {
 
 const COLS: { key: SortKey; label: string; className: string; width?: string }[] = [
   { key: "title",   label: "Title",  className: "library-reading-col-title" },
-  { key: "status",  label: "Status", className: "library-reading-col-status", width: "128px" },
+  { key: "status",  label: "Status", className: "library-reading-col-status", width: "196px" },
   { key: "addedAt", label: "Added",  className: "library-reading-col-added",  width: "64px" },
 ];
 
@@ -411,7 +421,7 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
                         >
                           {INLINE_STATUS_OPTIONS.map((status) => {
                             const meta = STATUS_META[status];
-                            const active = item.status === status;
+                            const active = toggleStatus(item.status) === status;
                             return (
                               <button
                                 key={status}
@@ -424,7 +434,9 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
                                 title={meta.label}
                                 onClick={(e) => {
                                   e.stopPropagation();
-                                  if (!active) void handleStatusChange(item, status);
+                                  // Compare raw status (not the folded one) so picking
+                                  // the active option on a legacy "read" item heals it.
+                                  if (item.status !== status) void handleStatusChange(item, status);
                                 }}
                               >
                                 <Icon name={meta.icon} width={13} aria-hidden />

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -1330,7 +1330,11 @@ tr:focus-within .library-row-delete {
   outline: var(--ring-width) solid var(--ring-focus);
   outline-offset: 1px;
 }
-.library-status-toggle__label { overflow: hidden; text-overflow: ellipsis; }
+/* The active segment owns its label and must never clip it; inactive
+   (icon-only) segments stay minimal so the control fits the status column. */
+.library-status-toggle__opt.is-active { padding: 0 10px; }
+.library-status-toggle__opt:not(.is-active) { padding: 0 7px; }
+.library-status-toggle__label { overflow: visible; white-space: nowrap; flex: 0 0 auto; }
 
 /* ── progress bar ──────────────────────────────────────────────── */
 .library-progress-bar {


### PR DESCRIPTION
## What

Follow-up to #985 (the 3-way reading-status toggle), from **live-app verification**. Two issues showed up only with real data:

1. **Clipped active label.** The status column was a fixed `128px`, so the active segment's label truncated — "Want" → "W..", "Reading" → "Readi…". Fix: widen the column to `196px`, give active/inactive segments asymmetric padding, and stop the active label from shrinking. All three labels now render in full.
2. **Legacy `"read"` status.** 12 of 20 real items are persisted with status `"read"` (the canonical enum is `"done"`), so no segment matched and those rows showed *no* active state. (The old `<select>` masked this by defaulting to the first option — the source of the original screenshot's confusing "Want To Read" on READ rows.) Fix: `toggleStatus()` folds `"read"` onto the `"done"` option for display; the click guard compares the **raw** status, so re-picking the option heals the item to `"done"`.

## Verification
Driven in the running web build against the real `~/.coven` reading data (20 items):
- Active distribution across rows: `want-to-read: 7, reading: 1, done: 12` — every row now has a correct active segment.
- Zoomed screenshots confirm "Want", "Reading", and "Read" all render unclipped.
- `pnpm typecheck` ✓, `pnpm build` ✓, `library-polish.test.ts` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)