### PR TITLE
fix(canvas): persist artifact resize from any edge + smooth iframe drag

### DIFF
--- a/src/components/canvas-view.tsx
+++ b/src/components/canvas-view.tsx
@@ -161,6 +161,8 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
   const [artifactView, setArtifactView] = useState<Record<string, "preview" | "code">>({});
   const [generating, setGenerating] = useState<Set<string>>(new Set());
   const [composer, setComposer] = useState("");
+  // True while a user is dragging an artifact resize handle (see onNodesChange).
+  const [isResizing, setIsResizing] = useState(false);
   // Template dropdown (where the Blank button lives).
   const [templatesOpen, setTemplatesOpen] = useState(false);
   const templatesAnchorRef = useRef<HTMLButtonElement | null>(null);
@@ -450,10 +452,16 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
         resizingNodeIds.current.delete(change.id);
         const { width, height } = change.dimensions;
         if (!Number.isFinite(width) || !Number.isFinite(height)) continue;
-        const saved = positions[change.id] ?? nodes.find((node) => node.id === change.id)?.position;
+        // Resizing from the top/left edge moves the node as well as sizing it, so
+        // persist the node's CURRENT position — the stale saved entry would snap the
+        // window back to its pre-resize origin on reload.
+        const saved = nodes.find((node) => node.id === change.id)?.position ?? positions[change.id];
         if (!saved) continue;
         savePosition(change.id, { x: saved.x, y: saved.y, width, height });
       }
+      // While any artifact is actively resizing, suppress iframe pointer capture so
+      // the drag tracks the cursor smoothly even as it passes over a live preview.
+      setIsResizing(resizingNodeIds.current.size > 0);
     }
     setNodes((prev) => applyNodeChanges(changes, prev));
   }, [layer, nodes, positions, savePosition]);
@@ -510,7 +518,7 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
   const sketchEmpty = hasLoaded && isSketch && artifacts.length === 0;
 
   return (
-    <div className="canvas-view" data-mode="canvas" data-layer={layer}>
+    <div className={`canvas-view${isResizing ? " is-resizing" : ""}`} data-mode="canvas" data-layer={layer}>
       <ReactFlow
         nodes={nodes}
         edges={[]}

--- a/src/styles/canvas.css
+++ b/src/styles/canvas.css
@@ -502,7 +502,15 @@
 }
 
 .canvas-artifact-resizer__handle:hover {
-  transform: scale(1.08);
+  transform: scale(1.12);
+  opacity: 1;
+}
+
+/* While a resize drag is in flight the cursor must keep tracking the handle even
+   as it sweeps across an artifact preview — the sandboxed iframe would otherwise
+   swallow the pointer and stall the drag. */
+.canvas-view.is-resizing .canvas-artifact__frame {
+  pointer-events: none;
 }
 
 .canvas-artifact__frame {


### PR DESCRIPTION
## What

Make resizable canvas (Sketch) artifact windows **easy to resize** and have them **stay at their resized position** across reloads.

## Why

Two issues with the artifact resizing added in `ad3f4c3c`:

1. **Resize from the top/left edge didn't stay put.** The `NodeResizer` moves a node's `x/y` as well as its size when you drag a top or left handle, but `onNodesChange` persisted the *stale* saved `x/y` (the `positions[id]` entry, which always existed, so it never fell through to the live position). On reload the window snapped back to its pre-resize origin.

2. **Drag could stutter over the preview.** Each artifact body is a sandboxed iframe that swallows pointer events, so a resize drag sweeping across the preview could stall.

## Changes

- `canvas-view.tsx` — persist the node's **current** position on resize-end (prefer the live node position over the stale saved entry).
- `canvas-view.tsx` + `canvas.css` — track an `is-resizing` state and disable `pointer-events` on artifact iframes while a resize drag is in flight, so the drag tracks the cursor smoothly.
- `canvas.css` — corner handles go fully opaque and scale a touch more (1.12) on hover for a clearer grab target.

## Verification

Unit suite (`canvas-view.test.ts`, `canvas-templates-ui.test.ts`) + `tsc --noEmit` pass.

Live-driven (Playwright on a prod build, real `/api/canvas` persistence):

| Action | Persisted |
|---|---|
| Start | `x:120, y:120` |
| Grow from bottom-right | `x:120, y:120, w:520, h:400` (origin unchanged) |
| Drag top-left out | `x:60, y:73, w:580, h:447` (origin moved correctly — was reverting to 120,120) |
| After full reload | `x:60, y:73, w:580, h:447` (identical — stays put) |

iframe `pointer-events` confirmed flipping `all → none → all` across an active drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)