### PR TITLE
feat(sidebar): collapsible section dividers with full-height toggle

### DIFF
--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -109,10 +109,43 @@ function SidebarSection({
   className?: string;
   children: React.ReactNode;
 }) {
+  const storageKey = label
+    ? `cave:sidebar:section:${label.toLowerCase().replace(/\s+/g, "-")}`
+    : null;
+  const [collapsed, setCollapsed] = React.useState(false);
+  // Hydrate the persisted collapse state after mount so the SSR markup (always
+  // expanded) matches the first client render, then reconcile from storage.
+  React.useEffect(() => {
+    if (!storageKey) return;
+    setCollapsed(localStorage.getItem(storageKey) === "1");
+  }, [storageKey]);
+  const toggle = React.useCallback(() => {
+    setCollapsed((v) => {
+      const next = !v;
+      if (storageKey) localStorage.setItem(storageKey, next ? "1" : "0");
+      return next;
+    });
+  }, [storageKey]);
   return (
     <div className={`sidebar-folders ${className}`.trim()}>
-      {label ? <div className="sidebar-section-label">{label}</div> : null}
-      {children}
+      {label ? (
+        // The whole header is the hit target — clicking anywhere across its full
+        // height/width collapses or expands the section.
+        <button
+          type="button"
+          className="sidebar-section-label"
+          aria-expanded={!collapsed}
+          onClick={toggle}
+        >
+          <span className="sidebar-section-label__text">{label}</span>
+          <Icon
+            name="ph:caret-down-bold"
+            width="0.7rem"
+            className={`sidebar-section-label__chevron${collapsed ? " sidebar-section-label__chevron--collapsed" : ""}`}
+          />
+        </button>
+      ) : null}
+      {collapsed ? null : children}
     </div>
   );
 }

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -391,17 +391,46 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  width: 100%;
   margin: 2px 6px 8px;
   padding: 6px 10px;
   border-radius: 7px;
   background: color-mix(in oklch, var(--bg-base) 70%, var(--foreground) 30%);
   border: 1px solid color-mix(in oklch, var(--border-hairline) 95%, var(--foreground) 5%);
+  font-family: inherit;
   font-size: 12px;
   font-weight: 800;
   letter-spacing: 0.11em;
   text-transform: uppercase;
+  text-align: left;
   color: var(--text-primary);
+  cursor: pointer;
   user-select: none;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+
+.sidebar-section-label:hover {
+  background: color-mix(in oklch, var(--bg-base) 58%, var(--foreground) 42%);
+}
+
+.sidebar-section-label:focus-visible {
+  outline: 2px solid var(--accent, currentColor);
+  outline-offset: 1px;
+}
+
+.sidebar-section-label__text {
+  flex: 1;
+  min-width: 0;
+}
+
+.sidebar-section-label__chevron {
+  flex: none;
+  opacity: 0.7;
+  transition: transform 140ms ease;
+}
+
+.sidebar-section-label__chevron--collapsed {
+  transform: rotate(-90deg);
 }
 
 /* A short accent tick before the label so each section reads as a deliberate


### PR DESCRIPTION
## What

Make every sidebar section divider — **WORK**, **TOOLS** (and **Knowledge** when present) — a collapse toggle for its section, matching the existing **RECENT ACTIVITY** behavior. The **entire height** of the header is the hit target.

## Changes

- `sidebar-minimal.tsx` — `SidebarSection` now renders its label as a full-width `<button>` (with a rotating caret) that collapses/expands its children. State persists per section in `localStorage` (`cave:sidebar:section:<slug>`), hydrated after mount to keep SSR markup stable.
- `sidebar-minimal.css` — the section-label pill becomes an interactive button: full width, pointer cursor, hover/focus-visible states, a right-aligned chevron that rotates when collapsed. The accent tick and predominant styling from #989 are preserved.

## Verification

Built and driven in the real app (demo mode):

- Clicking a header **1px from the top edge** and **1px from the bottom edge** both toggle it — confirming the full height is clickable (not just the caret).
- `aria-expanded` flips correctly and the section's items hide/show.
- Collapse state **persists across reload**.
- WORK, TOOLS, and RECENT ACTIVITY all behave consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)