### PR TITLE
feat(code): merge layout presets + panel toggle onto the Sessions/Memory tab row

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3397,6 +3397,53 @@ button:active > .edge-rail-chip {
   display: none;
 }
 
+/* Code surface hoists the companion-panel toggle onto its tab row
+   (.code-panel-toggle in CodeInlineToolbar), so hide the shell's floating right
+   toggle while that surface is mounted — otherwise there'd be two. */
+:root[data-code-inline-toolbar] .shell-panel-float--right {
+  display: none;
+}
+
+/* Code mode crowds the tab row (familiar scope + Sessions/Memory tabs + layout
+   presets + panel toggle), so tighten its padding/gaps to fit the narrowest
+   chat-pane preset (Review, ~30%) without the presets overlapping the tabs. */
+:root[data-code-inline-toolbar] .chat-scope-tabs--minimal {
+  padding-inline: 8px;
+  gap: 8px;
+}
+:root[data-code-inline-toolbar] .chat-scope-tabs--minimal > div:first-child {
+  gap: 8px;
+}
+
+/* Inline companion-panel toggle on the Code surface tab row. Mirrors the shell
+   float's affordance but sits in normal flow beside the layout presets. */
+.code-panel-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  border: 1px solid var(--border-hairline);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 120ms ease, background 120ms ease, border-color 120ms ease;
+}
+.code-panel-toggle:hover {
+  color: var(--text-secondary);
+}
+.code-panel-toggle[aria-pressed="true"] {
+  color: var(--text-primary);
+  background: color-mix(in oklch, var(--accent-presence) 18%, var(--bg-raised));
+  border-color: color-mix(in oklch, var(--accent-presence) 58%, var(--border-hairline));
+}
+/* The sidebar glyph points at the left rail by default; mirror it so it reads
+   as the RIGHT companion panel, matching the shell float. */
+.code-panel-toggle > svg {
+  transform: scaleX(-1);
+}
+
 /* ────────────────────────────────────────────────
    Companion rail — right-side per-familiar pane
    (Phase 2, shell-ia-redesign)

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -14,6 +14,7 @@ import { useIsMobile } from "@/lib/use-viewport";
 import { Tabs } from "@/components/ui/tabs";
 import { Icon } from "@/lib/icon";
 import { FamiliarSwitcher } from "@/components/familiar-switcher";
+import { CodeInlineToolbar } from "@/components/code-inline-toolbar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { Familiar, SessionRow } from "@/lib/types";
@@ -448,6 +449,16 @@ export function ChatSurface({
     return () => root.removeAttribute("data-right-panel-open");
   }, [rightPanel, isMobile, scope]);
 
+  // The Code surface hosts the companion-panel toggle inline (CodeInlineToolbar
+  // on the tab row), so flag the root to hide the shell's floating right toggle
+  // while this surface is mounted — otherwise there'd be two of them.
+  useEffect(() => {
+    if (!isCodeSurface) return;
+    const root = document.documentElement;
+    root.setAttribute("data-code-inline-toolbar", "");
+    return () => root.removeAttribute("data-code-inline-toolbar");
+  }, [isCodeSurface]);
+
   // Keep the shell's floating toggles (left nav, expand, side-panel trigger)
   // vertically centered on the LIVE side-panel header. Its top can shift while
   // the layout settles after load (e.g. transient chrome above the panel), so a
@@ -519,7 +530,13 @@ export function ChatSurface({
         {/* ── Ultra-minimalist header ────────────────────────────────────── */}
         <div className="chat-scope-tabs chat-scope-tabs--minimal flex shrink-0 items-center justify-between gap-3 border-b border-[var(--border-hairline)] px-4">
           <div className="flex min-w-0 items-center gap-3">
-            <div className="chat-surface__familiar-scope flex w-[min(220px,34vw)] min-w-0 shrink-0 py-1.5 max-sm:w-[min(168px,42vw)]">
+            {/* Code mode crowds this row with layout presets + the panel toggle,
+                so the familiar scope collapses to a compact avatar there. */}
+            <div
+              className={`chat-surface__familiar-scope flex min-w-0 shrink-0 py-1.5 ${
+                isCodeSurface ? "" : "w-[min(220px,34vw)] max-sm:w-[min(168px,42vw)]"
+              }`}
+            >
               <FamiliarSwitcher
                 familiars={resolvedFamiliars}
                 activeFamiliarId={activeFamiliarId}
@@ -530,7 +547,7 @@ export function ChatSurface({
                   window.setTimeout(() => routerRef.current?.goToList(), 0);
                 }}
                 placement="bottom-start"
-                labeled
+                labeled={!isCodeSurface}
               />
             </div>
             <span aria-hidden className="h-5 w-px shrink-0 bg-[var(--border-hairline)]" />
@@ -561,6 +578,9 @@ export function ChatSurface({
               }
             />
           </div>
+          {/* Code workspace: layout presets + companion-panel toggle ride on
+              this row so the Code surface needs no separate toolbar row. */}
+          {isCodeSurface ? <CodeInlineToolbar /> : null}
         </div>
 
         {scope === "memory" ? (

--- a/src/components/code-inline-toolbar.tsx
+++ b/src/components/code-inline-toolbar.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Icon } from "@/lib/icon";
+import {
+  CODE_PRESETS,
+  CODE_PRESET_EVENT,
+  CODE_PRESET_HIDES_PROJECT_LIST,
+  CODE_PRESET_HINTS,
+  CODE_PRESET_ICONS,
+  CODE_PRESET_LABELS,
+  CODE_PROJECT_LIST_EVENT,
+  readCodePreset,
+  writeCodePreset,
+  writeProjectListCollapsed,
+  type CodePreset,
+} from "@/lib/code-layout-preset";
+
+/** The inline toggle asks the Shell to show/hide the companion panel (the Shell
+ *  owns the panel ref, so we go over an event rather than reaching into it). */
+export const TOGGLE_RIGHT_PANEL_EVENT = "cave:toggle-right-panel";
+/** The Shell broadcasts the companion (familiar) panel's open state so this
+ *  toggle can mirror it. `detail.open: boolean`; the Shell also sets the
+ *  matching `:root[data-familiar-open]` attribute for the initial read. */
+export const FAMILIAR_OPEN_EVENT = "cave:familiar-open";
+
+/** Persist + broadcast a preset pick. The chat-pane resize (code-view) and the
+ *  comux right-pane (comux-view) both listen for CODE_PRESET_EVENT, so this
+ *  toolbar never has to reach into either pane. */
+function applyPreset(next: CodePreset) {
+  writeCodePreset(next);
+  const collapsed = CODE_PRESET_HIDES_PROJECT_LIST[next];
+  writeProjectListCollapsed(collapsed);
+  window.dispatchEvent(new CustomEvent(CODE_PROJECT_LIST_EVENT, { detail: { collapsed } }));
+  window.dispatchEvent(new CustomEvent(CODE_PRESET_EVENT, { detail: { preset: next } }));
+}
+
+/**
+ * Code workspace layout controls — Chat/Split/Review presets + the companion
+ * panel toggle — hoisted onto the Sessions/Memory tab row so the Code surface
+ * no longer needs a separate toolbar row above the split.
+ */
+export function CodeInlineToolbar() {
+  const [preset, setPreset] = useState<CodePreset>(() => readCodePreset());
+  const [panelOpen, setPanelOpen] = useState(false);
+
+  useEffect(() => {
+    const onPreset = (e: Event) => {
+      const p = (e as CustomEvent<{ preset?: CodePreset }>).detail?.preset;
+      if (p) setPreset(p);
+    };
+    const onPanel = (e: Event) => {
+      const open = (e as CustomEvent<{ open?: boolean }>).detail?.open;
+      if (typeof open === "boolean") setPanelOpen(open);
+    };
+    window.addEventListener(CODE_PRESET_EVENT, onPreset as EventListener);
+    window.addEventListener(FAMILIAR_OPEN_EVENT, onPanel as EventListener);
+    setPanelOpen(document.documentElement.hasAttribute("data-familiar-open"));
+    return () => {
+      window.removeEventListener(CODE_PRESET_EVENT, onPreset as EventListener);
+      window.removeEventListener(FAMILIAR_OPEN_EVENT, onPanel as EventListener);
+    };
+  }, []);
+
+  return (
+    <div className="flex shrink-0 items-center gap-1.5">
+      <div className="flex items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 p-0.5 text-[11px]">
+        {CODE_PRESETS.map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => {
+              setPreset(p);
+              applyPreset(p);
+            }}
+            aria-pressed={preset === p}
+            aria-label={CODE_PRESET_LABELS[p]}
+            title={`${CODE_PRESET_LABELS[p]} — ${CODE_PRESET_HINTS[p]}`}
+            className={`flex items-center justify-center rounded-[5px] px-1.5 py-1 transition-colors ${
+              preset === p
+                ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
+                : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+            }`}
+          >
+            {/* Icon-only: the chat pane (esp. the Review preset) is too narrow
+                for labels alongside the familiar scope + Sessions/Memory tabs.
+                The active chip is highlighted; tooltips name each layout. */}
+            <Icon name={CODE_PRESET_ICONS[p]} width={14} />
+          </button>
+        ))}
+      </div>
+      <button
+        type="button"
+        className="code-panel-toggle focus-ring"
+        aria-label={panelOpen ? "Hide side panel" : "Show side panel"}
+        aria-pressed={panelOpen}
+        title={panelOpen ? "Hide side panel" : "Show side panel"}
+        onClick={() => window.dispatchEvent(new CustomEvent(TOGGLE_RIGHT_PANEL_EVENT))}
+      >
+        <Icon name={panelOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={14} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -11,6 +11,10 @@ const sidebar = await readFile(new URL("./sidebar-minimal.tsx", import.meta.url)
 const comux = await readFile(new URL("./comux-view.tsx", import.meta.url), "utf8");
 const modeType = await readFile(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
 const preset = await readFile(new URL("../lib/code-layout-preset.ts", import.meta.url), "utf8");
+// The Chat/Split/Review presets + companion-panel toggle now ride on the chat
+// surface's Sessions/Memory tab row, in a self-contained toolbar.
+const toolbar = await readFile(new URL("./code-inline-toolbar.tsx", import.meta.url), "utf8");
+const chatSurface = await readFile(new URL("./chat-surface.tsx", import.meta.url), "utf8");
 
 // ── CodeView is a two-pane resizable shell, chat | comux ─────────────────────
 assert.match(codeView, /orientation="horizontal"/, "CodeView lays the panes out horizontally");
@@ -32,19 +36,25 @@ assert.match(
 assert.match(codeView, /panelIds: \["code-chat", "code-comux"\]/, "desktop mounts both panels in the split");
 
 // ── Layout presets (Chat / Split / Review) re-weight the desktop split ───────
-// A preset toolbar resizes the chat panel imperatively (usePanelRef) — no
-// remount, so the comux terminals/preview keep their state. The chip selection
-// persists under its own key; pane sizes persist under CODE_GROUP_ID.
+// The preset chips live on the chat surface's tab row (CodeInlineToolbar) and
+// broadcast CODE_PRESET_EVENT; code-view owns the chat-panel resize via a
+// listener — no remount, so the comux terminals/preview keep their state. The
+// chip selection persists under its own key; pane sizes persist under CODE_GROUP_ID.
 assert.match(codeView, /usePanelRef/, "desktop uses a panel ref to drive presets");
 assert.match(codeView, /panelRef=\{chatPanelRef\}/, "the chat panel takes the preset handle via panelRef");
+assert.match(codeView, /addEventListener\(CODE_PRESET_EVENT/, "code-view listens for the preset broadcast");
 assert.match(codeView, /chatPanelRef\.current\?\.resize\(CODE_PRESET_CHAT_SIZE\[/, "presets resize the chat panel (comux fills the rest)");
-assert.match(codeView, /writeCodePreset\(next\)/, "selecting a preset persists the chip");
+assert.match(toolbar, /writeCodePreset\(next\)/, "selecting a preset persists the chip");
 assert.match(
   codeView,
   /codeStorage\.getItem\(CODE_GROUP_ID\) == null/,
   "the stored preset is applied only when no dragged layout exists (no clobbering manual drags)",
 );
-assert.match(codeView, /CODE_PRESETS\.map\(/, "the toolbar renders a chip per preset");
+assert.match(toolbar, /CODE_PRESETS\.map\(/, "the toolbar renders a chip per preset");
+// The toolbar is mounted on the Code surface's tab row + carries the panel toggle.
+assert.match(chatSurface, /isCodeSurface \? <CodeInlineToolbar \/> : null/, "the Code tab row hosts the inline toolbar");
+assert.match(toolbar, /code-panel-toggle/, "the toolbar includes the companion-panel toggle");
+assert.match(toolbar, /cave:toggle-right-panel/, "the panel toggle asks the shell to toggle the companion panel");
 
 // ── The projects-list collapse lives in the list's OWN header (in comux) ──────
 // It collapses only the 200px projects column — never the code/comux Panel —
@@ -69,17 +79,17 @@ assert.doesNotMatch(
 // Presets are task setups, not just widths: each broadcasts a context preset
 // and shows/hides the projects list (Chat focuses the conversation).
 assert.match(
-  codeView,
+  toolbar,
   /new CustomEvent\(CODE_PRESET_EVENT, \{ detail: \{ preset: next \} \}\)/,
   "selecting a preset broadcasts the context preset",
 );
 assert.match(
-  codeView,
+  toolbar,
   /new CustomEvent\(CODE_PROJECT_LIST_EVENT, \{ detail: \{ collapsed \} \}\)/,
   "a preset shows/hides the projects list over CODE_PROJECT_LIST_EVENT",
 );
 assert.match(
-  codeView,
+  toolbar,
   /CODE_PRESET_HIDES_PROJECT_LIST\[next\]/,
   "the preset's list visibility comes from its definition",
 );

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -8,16 +8,7 @@ import { useIsMobile } from "@/lib/use-viewport";
 import {
   CODE_PRESET_CHAT_SIZE,
   CODE_PRESET_EVENT,
-  CODE_PRESET_HIDES_PROJECT_LIST,
-  CODE_PRESET_HINTS,
-  CODE_PRESET_ICONS,
-  CODE_PRESET_LABELS,
-  CODE_PRESETS,
-  CODE_PROJECT_LIST_EVENT,
-  DEFAULT_CODE_PRESET,
   readCodePreset,
-  writeCodePreset,
-  writeProjectListCollapsed,
   type CodePreset,
 } from "@/lib/code-layout-preset";
 
@@ -107,62 +98,31 @@ function DesktopCodeView({ chat, comux }: Props) {
     storage: codeStorage,
   });
   const chatPanelRef = usePanelRef();
-  // Tracks the highlighted chip. The actual sizes live in the panels' own
-  // persisted layout (CODE_GROUP_ID); this only records the last preset chosen.
-  const [preset, setPreset] = useState<CodePreset>(DEFAULT_CODE_PRESET);
 
   useEffect(() => {
-    setPreset(readCodePreset());
     // Apply the stored preset's width ONLY on a first-ever load (no dragged
     // layout persisted yet), so we never clobber a manual drag on reload — the
     // "default only when unstored" idiom. After this, useDefaultLayout restores
-    // the persisted sizes and the chip is purely cosmetic until the next click.
+    // the persisted sizes.
     if (codeStorage.getItem(CODE_GROUP_ID) == null) {
       chatPanelRef.current?.resize(CODE_PRESET_CHAT_SIZE[readCodePreset()]);
     }
+    // The preset chips now live on the chat surface's tab row (CodeInlineToolbar)
+    // and broadcast CODE_PRESET_EVENT; here we own the chat-pane resize. Going
+    // through onLayoutChanged persists the size, and there's no remount so the
+    // comux terminals/file preview keep their state.
+    const onPreset = (e: Event) => {
+      const preset = (e as CustomEvent<{ preset?: CodePreset }>).detail?.preset;
+      if (preset) chatPanelRef.current?.resize(CODE_PRESET_CHAT_SIZE[preset]);
+    };
+    window.addEventListener(CODE_PRESET_EVENT, onPreset as EventListener);
+    return () => window.removeEventListener(CODE_PRESET_EVENT, onPreset as EventListener);
     // run once on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const applyPreset = (next: CodePreset) => {
-    setPreset(next);
-    writeCodePreset(next);
-    // Resize the chat panel; the comux pane fills the remainder (clamped to its
-    // own minSize). This goes through onLayoutChanged, so it persists — no
-    // remount, so the comux terminals/file preview keep their state.
-    chatPanelRef.current?.resize(CODE_PRESET_CHAT_SIZE[next]);
-    // A preset is a task setup, not just a width: show/hide the comux projects
-    // list (the toggle itself lives in that list's header) and tell comux which
-    // right pane (files vs. git changes) to show.
-    const collapsed = CODE_PRESET_HIDES_PROJECT_LIST[next];
-    writeProjectListCollapsed(collapsed);
-    window.dispatchEvent(new CustomEvent(CODE_PROJECT_LIST_EVENT, { detail: { collapsed } }));
-    window.dispatchEvent(new CustomEvent(CODE_PRESET_EVENT, { detail: { preset: next } }));
-  };
-
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-      <div className="flex shrink-0 items-center justify-end gap-1 border-b border-[var(--border-hairline)] px-2 py-1">
-        <div className="flex items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 p-0.5 text-[11px]">
-          {CODE_PRESETS.map((p) => (
-            <button
-              key={p}
-              type="button"
-              onClick={() => applyPreset(p)}
-              aria-pressed={preset === p}
-              title={CODE_PRESET_HINTS[p]}
-              className={`flex items-center gap-1.5 rounded-[5px] px-2.5 py-1 transition-colors ${
-                preset === p
-                  ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
-                  : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
-              }`}
-            >
-              <Icon name={CODE_PRESET_ICONS[p]} width={13} />
-              {CODE_PRESET_LABELS[p]}
-            </button>
-          ))}
-        </div>
-      </div>
       <Group
         className="flex min-h-0 min-w-0 flex-1"
         orientation="horizontal"

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -367,6 +367,13 @@ function ShellInner({
 
   useEffect(() => {
     onFamiliarOpenChange?.(familiarOpen);
+    // Mirror the companion panel's open state to the document root + a window
+    // event so an inline toggle (e.g. the Code surface's, outside this subtree)
+    // can reflect it without prop-drilling.
+    const root = document.documentElement;
+    if (familiarOpen) root.setAttribute("data-familiar-open", "");
+    else root.removeAttribute("data-familiar-open");
+    window.dispatchEvent(new CustomEvent("cave:familiar-open", { detail: { open: familiarOpen } }));
   }, [familiarOpen, onFamiliarOpenChange]);
 
   useEffect(() => {
@@ -415,11 +422,18 @@ function ShellInner({
         togglePanel(bottomRef.current);
       }
     };
+    // Let an inline toggle (e.g. the Code surface toolbar) flip the companion
+    // panel without reaching into the Shell's panel ref.
+    const onToggleRight = () => {
+      if (hasFamiliar) toggleFamiliarPanel();
+    };
     window.addEventListener("keydown", handler);
     window.addEventListener("keydown", bottomToggle);
+    window.addEventListener("cave:toggle-right-panel", onToggleRight);
     return () => {
       window.removeEventListener("keydown", handler);
       window.removeEventListener("keydown", bottomToggle);
+      window.removeEventListener("cave:toggle-right-panel", onToggleRight);
     };
   }, [twoPane, hasFamiliar, hasBottom, isMobile, panelShortcuts]);
 


### PR DESCRIPTION
## What

The Code workspace had **two** stacked header rows on the left: a full-width **Chat/Split/Review** preset row above the split, and below it the chat pane's **Sessions/Memory** tab row. This merges them — the preset row is removed and its height reclaimed, so the split shifts up. The Chat/Split/Review presets **and** the companion-panel toggle now ride on the Sessions/Memory tab row.

## How (event-decoupled, matching the existing `CODE_PRESET_EVENT` pattern)
- **New `CodeInlineToolbar`** renders on the chat-surface tab row when `isCodeSurface`. Self-contained: presets persist + broadcast `CODE_PRESET_EVENT` / `CODE_PROJECT_LIST_EVENT` (comux already listens), and the panel button dispatches `cave:toggle-right-panel`.
- **`code-view`** drops its standalone preset row and listens for `CODE_PRESET_EVENT` to drive the chat-pane resize (no remount → terminals/preview keep state).
- **`shell`** listens for `cave:toggle-right-panel` → toggles the companion panel; mirrors `familiarOpen` to `:root[data-familiar-open]` + a `cave:familiar-open` event so the inline toggle reflects state. The floating right toggle is hidden on the Code surface (`data-code-inline-toolbar`) so there's only one.
- **Fit the narrow chat pane** (incl. the 30% Review preset): the familiar scope collapses to a compact avatar, the preset chips go icon-only (tooltips + active highlight), and row padding/gaps tighten in code mode.

## Verification (live, web build, demo data)
- **No overlap** at all three presets — measured tab/toolbar bounds at Chat (767px), Split (531px), Review (354px): `overlaps: []` for each.
- **Functional**: clicking *Chat* widened the chat pane 531→767 (resize via the new listener) and shows `aria-pressed`; clicking the panel toggle flipped `data-familiar-open` false→true and mirrors `aria-pressed`.
- `pnpm typecheck` ✓, `pnpm build` ✓, full `pnpm test:app` (311 files) ✓ — `code-view.test.ts` updated to assert the new toolbar location + the code-view listener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)