### PR TITLE
fix(comux): full-height-clickable collapsed projects rail + aligned toggle

### DIFF
--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -1062,23 +1062,25 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
           {/* Project list — collapse from its own header; a thin rail re-opens it.
               The Code layout presets also drive this (Chat hides it). */}
           {projectListCollapsed ? (
-          <div className="flex w-[34px] shrink-0 flex-col items-center gap-2 border-r border-[var(--border-hairline)] py-2">
-            <button
-              type="button"
-              onClick={() => setProjectListVisible(true)}
-              aria-label="Show projects list"
-              title="Show projects list"
-              className="grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
-            >
+          // The whole rail is the click target — its full height re-opens the
+          // list, not just the icon at the top.
+          <button
+            type="button"
+            onClick={() => setProjectListVisible(true)}
+            aria-label="Show projects list"
+            title="Show projects list"
+            className="flex w-[34px] shrink-0 flex-col items-center gap-1 self-stretch border-r border-[var(--border-hairline)] py-2 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+          >
+            <span className="grid h-7 w-7 place-items-center">
               <Icon name="ph:sidebar-simple" width={15} />
-            </button>
+            </span>
             <span
-              className="mt-1 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)]"
+              className="mt-1 text-[10px] font-semibold uppercase tracking-widest"
               style={{ writingMode: "vertical-rl" }}
             >
               Projects
             </span>
-          </div>
+          </button>
           ) : (
           <div className="w-[200px] shrink-0 overflow-y-auto border-r border-[var(--border-hairline)] py-2 text-[12px]">
             <div className="mb-1 flex items-center gap-1.5 px-3 pb-1">
@@ -1091,9 +1093,9 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                 onClick={() => setProjectListVisible(false)}
                 aria-label="Hide projects list"
                 title="Hide projects list"
-                className="ml-auto grid h-5 w-5 place-items-center rounded text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+                className="-my-1 ml-auto grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
               >
-                <Icon name="ph:sidebar-simple-fill" width={13} />
+                <Icon name="ph:sidebar-simple-fill" width={15} />
               </button>
             </div>
             <div className="space-y-px px-1">


### PR DESCRIPTION
## What

In the Code workspace's comux pane, the **collapsed projects-list rail** only re-opened when you clicked the small icon button pinned at its top — the rest of the 34px-wide strip was dead. This makes the **entire rail height** the click target and aligns the toggle so it doesn't change size between states.

- The collapsed rail is now a single full-height `<button>` (`self-stretch`); a click anywhere down its height re-opens the list. Icon + vertical "Projects" label stay at the top, and the hover affordance now spans the whole rail.
- The expanded header's **"Hide projects list"** toggle was `h-5` (20px) while the rail's **"Show"** toggle was `h-7` (28px) — normalized both to `h-7` / 15px icon (negative margin keeps the header row compact) so the control stays put when you collapse/expand.

## Scope note
Limited to the **projects-list** rail (what's currently on `main`). The project-detail and file-preview collapse rails visible in some screenshots are being built in a **separate, in-progress change** and are intentionally left untouched here to avoid colliding with that work.

## Verification (live, web build)
- Collapsed rail measured as a `<button>` filling the full pane height (900px = pane height); **clicking near the bottom** of the rail expanded the list — full height is interactive.
- `pnpm typecheck` ✓, `pnpm build` ✓, `code-view.test.ts` (asserts the Show/Hide controls + ternary) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)