### PR TITLE
feat(familiars): daily notes v2 — richer digest, continuity, safe regen, persona voice

### DIFF
--- a/automations/familiar-daily-notes.toml
+++ b/automations/familiar-daily-notes.toml
@@ -20,10 +20,13 @@ Storage & format (must match exactly so the Cave UI parses it):
 
 Steps:
 1. Enumerate familiars from `~/.coven/familiars.toml` (plus the default ids), and resolve each workspace.
-2. Scaffold the factual digest first by running, from a Coven Cave checkout:
-   `node --experimental-strip-types scripts/generate-daily-notes.mjs`
-   This writes/refreshes each familiar's `## Notes` activity digest and seeds the reflection prompts (it never overwrites a note that already has content).
-3. For each familiar, review its day — recent sessions, memory changes, and inbox/board items tagged to it — and REPLACE the seeded reflection prompts with a genuine, first-person Self-reflection written as that familiar: what went well, what was hard, and what to try next time. Keep the `## Notes` digest factual.
+2. Refresh the factual digest first by running, from a Coven Cave checkout:
+   `node --experimental-strip-types scripts/generate-daily-notes.mjs --section notes`
+   `--section notes` rewrites each familiar's `## Notes` activity digest (sessions + memory touched) but PRESERVES any reflection already there — so re-running never wipes a prior reflection.
+3. For each familiar, write the `## Self-reflection` IN THAT FAMILIAR'S VOICE:
+   - Read its `SOUL.md` and `IDENTITY.md` (in its workspace) so the reflection sounds like that familiar, not a generic template.
+   - Read YESTERDAY's note (`notes/<yesterday>.md`) and follow up on any intention it set ("last time I planned to … — did I?"). Make the reflection cumulative, not isolated.
+   - Ground it in today's real work (the digest, sessions, memory, inbox/board items tagged to it): what went well, what was hard, what to try next time. First person, honest, concise.
 4. Only write to each familiar's own `notes/` directory. Do not touch other familiars' files, memory, or unrelated state.
 
 Deliverable: a one-line-per-familiar summary of which daily notes you wrote or updated, and any familiar whose day had nothing worth noting.'''

--- a/automations/familiar-weekly-reflection.toml
+++ b/automations/familiar-weekly-reflection.toml
@@ -1,0 +1,21 @@
+version = 1
+id = "familiar-weekly-reflection"
+kind = "cron"
+name = "Familiar Weekly Reflection"
+status = "PAUSED"
+rrule = "RRULE:FREQ=WEEKLY;BYHOUR=21;BYMINUTE=30;BYDAY=SU"
+reasoning_effort = "medium"
+execution_environment = "worktree"
+cwds = []
+tags = ["coven", "familiars", "daily-notes", "reflection", "weekly"]
+prompt = '''Synthesize a weekly reflection for every Coven familiar from its daily notes.
+
+For each familiar (enumerate from `~/.coven/familiars.toml` plus the default ids):
+1. Read this week's daily notes in `~/.coven/workspaces/familiars/<familiarId>/notes/` (the last 7 `<YYYY-MM-DD>.md` files). Each has a `## Notes` digest and a `## Self-reflection`.
+2. In that familiar's voice (read its `SOUL.md` / `IDENTITY.md`), write a short weekly synthesis: the throughline of the week, what improved, recurring friction, and one concrete intention for next week. Reference the daily reflections — note where a stated intention was followed through and where it slipped.
+3. Write it to the familiar's MEMORY (so it surfaces in Cave's Familiars → Memory tab), as:
+   `~/.coven/workspaces/familiars/<familiarId>/memory/weekly-reflection-<YYYY>-W<ww>.md`
+   with a `# Weekly Reflection — <YYYY> week <ww>` title. Do not overwrite an existing week's file unless it's clearly a re-run of the same week.
+4. Only write to each familiar's own memory directory; touch nothing else.
+
+Deliverable: a one-line-per-familiar summary of the week's throughline and next-week intention.'''

--- a/scripts/generate-daily-notes.mjs
+++ b/scripts/generate-daily-notes.mjs
@@ -4,27 +4,40 @@
  *
  * Writes `~/.coven/workspaces/familiars/<id>/notes/<YYYY-MM-DD>.md` for each
  * familiar, in the same Markdown format the Familiars → Daily Notes tab reads
- * (## Notes + ## Self-reflection — see src/lib/daily-note.ts). The Notes section
- * is a deterministic activity digest (memory files the familiar touched that
- * day); the Self-reflection section is seeded with guiding prompts for the
- * familiar/user to complete — Cave has no server-side LLM, so this script never
- * fabricates a reflection. The companion Codex automation
- * (automations/familiar-daily-notes.toml) is what fills in genuine,
- * agent-authored reflections on a schedule.
+ * (## Notes + ## Self-reflection — see src/lib/daily-note.ts).
  *
- * Idempotent: a note that already has content is left alone unless --force, so
- * re-runs (and the daily automation) never clobber human/agent edits.
+ * The `## Notes` section is a deterministic activity digest: the sessions the
+ * familiar ran that day (from the daemon) plus the memory files it touched
+ * (with excerpts). The `## Self-reflection` section is seeded with guiding
+ * prompts — Cave has no server-side LLM, so this script never fabricates a
+ * reflection; the companion Codex automation (automations/familiar-daily-notes.toml)
+ * fills in genuine, agent-authored reflections on a schedule.
+ *
+ * Section-targeted + safe by default:
+ *   (no flag)            idempotent — skip a note that already has content.
+ *   --section notes      refresh ONLY the activity digest; keep any reflection
+ *                        already there (authored or seeded). Safe to re-run.
+ *   --section reflection reset ONLY the reflection to the seed prompts; keep the
+ *                        digest. Use before re-authoring reflections.
+ *   --section all        rewrite both (digest + seed reflection). Full reset.
  *
  * Usage:
- *   node --experimental-strip-types scripts/generate-daily-notes.mjs [YYYY-MM-DD] [--force]
+ *   node --experimental-strip-types scripts/generate-daily-notes.mjs [YYYY-MM-DD] [--section notes|reflection|all]
  *
  * (The strip-types flag is needed because this imports the TS source of truth
  * for path resolution + the note format, keeping it from drifting.)
  */
+import { request } from "node:http";
 import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { familiarIds, familiarWorkspace } from "../src/lib/coven-paths.ts";
-import { formatDailyNote, isEmptyNote, parseDailyNote } from "../src/lib/daily-note.ts";
+import { covenHome, familiarIds, familiarWorkspace } from "../src/lib/coven-paths.ts";
+import {
+  buildActivityDigest,
+  excerptOf,
+  formatDailyNote,
+  isEmptyNote,
+  parseDailyNote,
+} from "../src/lib/daily-note.ts";
 
 function localDateSlug(d) {
   const y = d.getFullYear();
@@ -33,8 +46,13 @@ function localDateSlug(d) {
   return `${y}-${m}-${day}`;
 }
 
-const dateArg = process.argv.slice(2).find((a) => /^\d{4}-\d{2}-\d{2}$/.test(a)) ?? localDateSlug(new Date());
-const force = process.argv.includes("--force");
+const argv = process.argv.slice(2);
+const dateArg = argv.find((a) => /^\d{4}-\d{2}-\d{2}$/.test(a)) ?? localDateSlug(new Date());
+const sectionFlag = (() => {
+  const i = argv.indexOf("--section");
+  const val = i >= 0 ? argv[i + 1] : argv.includes("--force") ? "all" : null;
+  return ["notes", "reflection", "all"].includes(val) ? val : null; // null = default idempotent
+})();
 
 const REFLECTION_SEED = [
   "- What went well today?",
@@ -42,7 +60,41 @@ const REFLECTION_SEED = [
   "- What will I do differently next time?",
 ].join("\n");
 
-/** Collect the names of memory files a familiar touched on the target day. */
+/** GET a daemon endpoint over the unix socket. Best-effort: resolves null on any failure. */
+function daemonGet(reqPath) {
+  return new Promise((resolve) => {
+    const req = request(
+      { socketPath: path.join(covenHome(), "coven.sock"), path: reqPath, method: "GET", timeout: 4000 },
+      (res) => {
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => {
+          try {
+            resolve(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+          } catch {
+            resolve(null);
+          }
+        });
+      },
+    );
+    req.on("error", () => resolve(null));
+    req.on("timeout", () => {
+      req.destroy();
+      resolve(null);
+    });
+    req.end();
+  });
+}
+
+/** Sessions the daemon recorded for `familiarId`, updated on the target day. */
+function sessionsForDay(allSessions, familiarId, slug) {
+  return allSessions
+    .filter((s) => s.familiar_id === familiarId && localDateSlug(new Date(s.updated_at)) === slug)
+    .sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1))
+    .map((s) => ({ title: s.title, harness: s.harness }));
+}
+
+/** Memory files a familiar touched on the target day, with a short excerpt each. */
 async function memoryActivity(workspace, slug) {
   const root = path.join(workspace, "memory");
   const touched = [];
@@ -60,7 +112,12 @@ async function memoryActivity(workspace, slug) {
       } else if (entry.isFile()) {
         try {
           const info = await stat(full);
-          if (localDateSlug(info.mtime) === slug) touched.push(path.relative(root, full));
+          if (localDateSlug(info.mtime) !== slug) continue;
+          let excerpt = "";
+          if (/\.(md|txt)$/i.test(entry.name)) {
+            excerpt = excerptOf(await readFile(full, "utf8").catch(() => ""));
+          }
+          touched.push({ file: path.relative(root, full), excerpt });
         } catch {
           // unreadable file — skip
         }
@@ -68,23 +125,12 @@ async function memoryActivity(workspace, slug) {
     }
   }
   await walk(root);
-  return touched.sort();
-}
-
-function buildDigest(touched) {
-  if (touched.length === 0) {
-    return "_No tracked memory activity for this day yet._";
-  }
-  const lines = [`Touched ${touched.length} memory file${touched.length === 1 ? "" : "s"}:`, ""];
-  for (const file of touched.slice(0, 20)) lines.push(`- \`${file}\``);
-  if (touched.length > 20) lines.push(`- …and ${touched.length - 20} more`);
-  return lines.join("\n");
+  return touched.sort((a, b) => (a.file < b.file ? -1 : 1));
 }
 
 async function readExisting(file) {
   try {
-    const raw = await readFile(file, "utf8");
-    return parseDailyNote(raw);
+    return parseDailyNote(await readFile(file, "utf8"));
   } catch {
     return null;
   }
@@ -92,6 +138,10 @@ async function readExisting(file) {
 
 async function main() {
   const ids = await familiarIds();
+  const allSessions = (await daemonGet("/api/v1/sessions")) || [];
+  const sessionList = Array.isArray(allSessions) ? allSessions : allSessions.sessions || [];
+  const daemonNote = Array.isArray(allSessions) || allSessions?.sessions ? "" : " (daemon offline — sessions skipped)";
+
   let written = 0;
   let skipped = 0;
 
@@ -99,19 +149,25 @@ async function main() {
     const workspace = await familiarWorkspace(id);
     const notesDir = path.join(workspace, "notes");
     const file = path.join(notesDir, `${dateArg}.md`);
+    const existing = (await readExisting(file)) ?? { notes: "", reflection: "" };
+    const hasContent = !isEmptyNote(existing);
 
-    const existing = await readExisting(file);
-    if (existing && !isEmptyNote(existing) && !force) {
+    // Default mode is idempotent: never disturb a note that already has content.
+    if (sectionFlag === null && hasContent) {
       console.log(`skip   ${id} (${dateArg}.md already has content)`);
       skipped += 1;
       continue;
     }
 
-    const touched = await memoryActivity(workspace, dateArg);
+    const digest = buildActivityDigest(sessionsForDay(sessionList, id, dateArg), await memoryActivity(workspace, dateArg));
+    const seededReflection = existing.reflection.trim() ? existing.reflection : REFLECTION_SEED;
+
+    // Decide each section per the targeting flag (default writes both for a fresh note).
+    const writeNotes = sectionFlag === null || sectionFlag === "notes" || sectionFlag === "all";
+    const resetReflection = sectionFlag === "reflection" || sectionFlag === "all";
     const note = {
-      notes: buildDigest(touched),
-      // Preserve any reflection already authored; otherwise seed the prompts.
-      reflection: existing?.reflection?.trim() ? existing.reflection : REFLECTION_SEED,
+      notes: writeNotes ? digest : existing.notes,
+      reflection: resetReflection ? REFLECTION_SEED : seededReflection,
     };
 
     await mkdir(notesDir, { recursive: true });
@@ -120,7 +176,10 @@ async function main() {
     written += 1;
   }
 
-  console.log(`\nDaily notes for ${dateArg}: ${written} written, ${skipped} skipped (${ids.length} familiars).`);
+  console.log(
+    `\nDaily notes for ${dateArg}: ${written} written, ${skipped} skipped (${ids.length} familiars)` +
+      `${sectionFlag ? ` [section=${sectionFlag}]` : ""}${daemonNote}.`,
+  );
 }
 
 main().catch((err) => {

--- a/src/lib/daily-note.test.ts
+++ b/src/lib/daily-note.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import {
+  buildActivityDigest,
   DAILY_NOTE_SECTIONS,
+  excerptOf,
   formatDailyNote,
   isEmptyNote,
   isValidNoteDate,
@@ -49,5 +51,33 @@ assert.equal(
 assert.ok(notePreview({ notes: "x".repeat(300), reflection: "" }).endsWith("…"), "long previews are truncated");
 
 assert.equal(DAILY_NOTE_SECTIONS.reflection, "Self-reflection", "the reflection section is named Self-reflection");
+
+// ── excerptOf ────────────────────────────────────────────────────────────────
+assert.equal(excerptOf("# Heading\n\nThe **real** body line."), "The real body line.", "strips headings + markdown");
+assert.equal(excerptOf(""), "", "empty input yields empty excerpt");
+assert.ok(excerptOf("x".repeat(300)).endsWith("…"), "long excerpts are truncated");
+
+// ── buildActivityDigest ──────────────────────────────────────────────────────
+assert.equal(
+  buildActivityDigest([], []),
+  "_No tracked activity for this day yet._",
+  "empty activity yields the honest empty state",
+);
+
+const digest = buildActivityDigest(
+  [{ title: "Letta research", harness: "claude" }, { title: "Deck pass" }],
+  [{ file: "2026-06-18.md", excerpt: "sharpened identity contrast" }],
+);
+assert.match(digest, /2 sessions today:/, "counts sessions");
+assert.match(digest, /- Letta research _\(claude\)_/, "lists session title + harness");
+assert.match(digest, /- Deck pass$/m, "a session without a harness omits the suffix");
+assert.match(digest, /Memory touched \(1\):/, "counts memory files");
+assert.match(digest, /- `2026-06-18\.md` — sharpened identity contrast/, "shows memory excerpt");
+
+assert.equal(
+  buildActivityDigest([{ title: "only a session" }], []).includes("Memory touched"),
+  false,
+  "omits the memory block when there are no memory files",
+);
 
 console.log("daily-note: all assertions passed");

--- a/src/lib/daily-note.ts
+++ b/src/lib/daily-note.ts
@@ -92,3 +92,59 @@ export function notePreview(note: DailyNote, max = 120): string {
 function trimLeadingBlankLines(value: string): string {
   return value.replace(/^\s*\n/, "").replace(/\s+$/, "");
 }
+
+// ── Activity digest (the factual `## Notes` body the seeder writes) ──────────
+
+export type ActivitySession = { title: string; harness?: string };
+export type ActivityMemory = { file: string; excerpt?: string };
+
+/** A single-line, markdown-stripped excerpt of a memory file's content. */
+export function excerptOf(text: string, max = 100): string {
+  const s = (text || "")
+    .replace(/^#.*$/gm, "") // drop heading lines
+    .replace(/[#*_`>]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!s) return "";
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}
+
+/**
+ * Build the `## Notes` activity digest from a familiar's day — sessions it ran
+ * (titles + harness) and memory files it touched (with excerpts). This is the
+ * deterministic, factual half of a daily note; the reflection is authored
+ * separately. Returns a clear empty-state line when there's nothing tracked.
+ */
+export function buildActivityDigest(sessions: ActivitySession[], memory: ActivityMemory[]): string {
+  const blocks: string[] = [];
+
+  if (sessions.length) {
+    blocks.push(`${sessions.length} session${sessions.length === 1 ? "" : "s"} today:`, "");
+    // Session "titles" can be entire multi-line workflow prompts and often
+    // repeat — flatten each to one short line and collapse duplicates with a ×N.
+    const seen = new Map<string, { harness?: string; count: number }>();
+    for (const s of sessions) {
+      const title = excerptOf(s.title, 80) || "(untitled session)";
+      const entry = seen.get(title) ?? { harness: s.harness, count: 0 };
+      entry.count += 1;
+      seen.set(title, entry);
+    }
+    const rows = [...seen.entries()];
+    for (const [title, { harness, count }] of rows.slice(0, 15)) {
+      blocks.push(`- ${title}${harness ? ` _(${harness})_` : ""}${count > 1 ? ` ×${count}` : ""}`);
+    }
+    if (rows.length > 15) blocks.push(`- …and ${rows.length - 15} more`);
+  }
+
+  if (memory.length) {
+    if (blocks.length) blocks.push("");
+    blocks.push(`Memory touched (${memory.length}):`, "");
+    for (const m of memory.slice(0, 15)) {
+      blocks.push(m.excerpt ? `- \`${m.file}\` — ${m.excerpt}` : `- \`${m.file}\``);
+    }
+    if (memory.length > 15) blocks.push(`- …and ${memory.length - 15} more`);
+  }
+
+  if (!blocks.length) return "_No tracked activity for this day yet._";
+  return blocks.join("\n");
+}


### PR DESCRIPTION
Builds on the v1 Daily Notes surface (#981) with the four improvements requested.

## 1. Richer activity digest
`## Notes` now reflects what the familiar actually *did*: its **daemon sessions** for the day (deduped, multi-line/workflow titles flattened to one line with `×N` counts + harness) and **memory files touched with excerpts** — not just filenames. New pure helpers `buildActivityDigest` / `excerptOf` in `daily-note.ts` (unit-tested). The seeder pulls sessions over the daemon unix socket, best-effort (skips cleanly if the daemon is offline).

## 2. Safe, section-targeted regeneration
`generate-daily-notes.mjs` gains `--section notes|reflection|all`:
- `--section notes` — refresh the digest, **preserve any authored reflection** (no more `--force` nuking reflections)
- `--section reflection` — reset only the reflection to the seed prompts (for re-authoring)
- `--section all` — full reset; default (no flag) stays idempotent (skip notes with content)

## 3. Continuity + persona voice
The daily automation now refreshes the digest with `--section notes`, then authors each reflection **in the familiar's own voice** (reads `SOUL.md`/`IDENTITY.md`) and **follows up on yesterday's note** ("last time I planned to… — did I?"), so reflections are cumulative, not isolated.

## 4. Weekly rollup
New `automations/familiar-weekly-reflection.toml` (PAUSED) synthesizes the week's daily notes into a per-familiar weekly reflection saved to the familiar's **memory** (surfaces in the Memory tab — reuses an existing surface).

## Verification
- Unit test: digest formatting, excerpt stripping, dedupe/×N, empty-state.
- `pnpm typecheck`, `check:tests-wired`, full `test:app` (311) + `test:api` (76) green.
- Live: `--section notes` enriched the real digests with sessions + memory excerpts and **left the agent-authored reflections intact** (verified on sage's 06-18 note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)