### PR TITLE
fix(comux): align Terminal & New chat buttons with the collapse toggle

### DIFF
--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -1195,7 +1195,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                           <button
                             type="button"
                             onClick={() => addSession(selectedProject.root)}
-                            className="flex items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+                            className="flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
                           >
                             <Icon name="ph:plus" width={12} />
                             Terminal
@@ -1203,7 +1203,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                           <button
                             type="button"
                             onClick={() => onNewChat(selectedProject.root)}
-                            className="flex items-center gap-1 rounded-md bg-[var(--accent-presence)] px-2.5 py-1 text-[11px] font-medium text-white hover:opacity-85"
+                            className="flex h-7 items-center gap-1 rounded-md bg-[var(--accent-presence)] px-2.5 text-[11px] font-medium text-white hover:opacity-85"
                           >
                             <Icon name="ph:chat-circle-dots" width={12} />
                             New chat


### PR DESCRIPTION
## What

In the project-detail header toolbar, **"+ Terminal"** and **"New chat"** were text buttons sized by padding (`py-1`, ~24px) while the adjacent **collapse toggle** is a 28px (`h-7`) square — so the row didn't line up. Give both text buttons a fixed `h-7` (dropping `py-1`) so all three controls are the same 28px height on one baseline.

## Verification (live, web build)
- Measured all three buttons: Terminal / New chat / Hide-details → **height 28px each, same `top`** (`allEqualHeight: true`, `allEqualTop: true`).
- `pnpm typecheck` ✓, full `pnpm test:app` (311 files) ✓, `pnpm build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)