### PR TITLE
test(e2e): repair the rotted e2e suite against the current UI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,8 +22,15 @@ export default defineConfig({
   testDir: "./tests",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 1 : 0,
+  // Retry once everywhere: the dev server compiles routes on first hit, so under
+  // parallel load a cold route can exceed a test's timeout on the first try and
+  // pass once warm. A genuinely broken spec still fails both attempts.
+  retries: 1,
   workers: process.env.CI ? 2 : undefined,
+  // The webServer is `next dev`, which compiles routes on demand; under parallel
+  // load the first interactive paint can run past Playwright's 30s default. Give
+  // each test 60s so a busy machine doesn't read slow-compile as a real failure.
+  timeout: 60_000,
   reporter: process.env.CI ? "github" : "list",
   use: {
     baseURL: BASE_URL,

--- a/tests/chat-thread-rail.spec.ts
+++ b/tests/chat-thread-rail.spec.ts
@@ -1,9 +1,10 @@
 import { expect, test, type Page } from "@playwright/test";
 
-// Verifies the Codex-style chat thread rail (chat-project-sidebar) renders
-// every chat flat, exposes the mode filters, and launches new chats.
-// Desktop only — the rail is `hidden lg:flex`. Demo mode supplies familiars;
-// /api/sessions/list is mocked so the rail content is deterministic.
+// Verifies the chat thread rail (chat-project-sidebar) — the desktop session
+// navigator reached via ⌘2. The rail groups sessions under their project
+// folders (expanded), exposes an "All sessions" scope and a session search that
+// surfaces a flat "Results" section. Desktop only — the rail is `hidden lg:flex`.
+// Demo mode supplies familiars; /api/sessions/list is mocked for determinism.
 
 const ISO = "2026-06-12T10:00:00.000Z";
 const SESSIONS = [
@@ -38,46 +39,37 @@ async function gotoChat(page: Page) {
   await page.waitForSelector(".chat-thread-rail", { timeout: 30_000 });
 }
 
-test.describe("chat thread rail (Codex-style visibility)", () => {
-  test("lists every chat flat with mode filters and a New launcher", async ({ page }) => {
+test.describe("chat thread rail (session navigator)", () => {
+  test("groups every session under its project with all-sessions + search controls", async ({ page }) => {
     await gotoChat(page);
     const rail = page.locator(".chat-thread-rail");
 
-    // Every session is visible in the flat list — no folder expansion needed.
+    // Scope + search controls.
+    await expect(rail.getByRole("button", { name: "All sessions" })).toBeVisible();
+    await expect(rail.getByRole("textbox", { name: "Search sessions" })).toBeVisible();
+
+    // One folder per project root (basename), expanded by default. Target the
+    // folder toggle (aria-label "Collapse/Expand <name> sessions"), not the
+    // per-folder "New session in <name>" button which also contains the name.
+    await expect(rail.getByRole("button", { name: /(Collapse|Expand) alpha sessions/ })).toBeVisible();
+    await expect(rail.getByRole("button", { name: /(Collapse|Expand) beta sessions/ })).toBeVisible();
+
+    // Every session is visible in its project group — no expansion needed.
     for (const s of SESSIONS) {
       await expect(rail.getByText(s.title, { exact: false }).first()).toBeVisible();
     }
-
-    // Mode filter chips exist (All / Active / Tasks / Pinned).
-    for (const label of ["All", "Active", "Tasks", "Pinned"]) {
-      await expect(rail.getByRole("tab", { name: new RegExp(label) })).toBeVisible();
-    }
-
-    // Prominent New launcher.
-    await expect(rail.getByRole("button", { name: "New chat", exact: true })).toBeVisible();
   });
 
-  test("Active filter narrows to running chats; Tasks to board-originated", async ({ page }) => {
+  test("search surfaces matching sessions in a Results section, with an empty state", async ({ page }) => {
     await gotoChat(page);
     const rail = page.locator(".chat-thread-rail");
+    const search = rail.getByRole("textbox", { name: "Search sessions" });
 
-    await rail.getByRole("tab", { name: /Active/ }).click();
-    await expect(rail.getByText("Refactor auth flow")).toBeVisible(); // running
-    await expect(rail.getByText("Wire deploy pipeline")).toBeVisible(); // running
-    await expect(rail.getByText("Fix eslint config")).toHaveCount(0); // completed
-    await expect(rail.getByText("Write API docs")).toHaveCount(0); // completed
+    await search.fill("deploy");
+    await expect(rail.getByText("Results")).toBeVisible();
+    await expect(rail.getByText("Wire deploy pipeline").first()).toBeVisible();
 
-    await rail.getByRole("tab", { name: /Tasks/ }).click();
-    await expect(rail.getByText("Fix eslint config")).toBeVisible(); // board
-    await expect(rail.getByText("Wire deploy pipeline")).toBeVisible(); // board
-    await expect(rail.getByText("Refactor auth flow")).toHaveCount(0); // chat origin
-  });
-
-  test("search filters the flat list by title", async ({ page }) => {
-    await gotoChat(page);
-    const rail = page.locator(".chat-thread-rail");
-    await rail.getByRole("textbox", { name: "Search chats" }).fill("deploy");
-    await expect(rail.getByText("Wire deploy pipeline")).toBeVisible();
-    await expect(rail.getByText("Refactor auth flow")).toHaveCount(0);
+    await search.fill("no-such-session-xyz");
+    await expect(rail.getByText("No sessions match your search")).toBeVisible();
   });
 });

--- a/tests/mobile/command-center-pages.spec.ts
+++ b/tests/mobile/command-center-pages.spec.ts
@@ -23,7 +23,11 @@ async function expectNoHorizontalOverflow(page: Page, label: string) {
 }
 
 test.describe("mobile command center pages", () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    // This spec asserts phone geometry against the mobile bottom-tab chrome,
+    // which only renders under the mobile breakpoint — skip it on the desktop
+    // project (the pixel-5 / iphone-13 projects cover it).
+    test.skip(testInfo.project.name === "desktop", "mobile-only: requires .mobile-bottom-tabs");
     await page.addInitScript(() => {
       window.localStorage.setItem("cave:active-familiar", "nova");
     });
@@ -48,7 +52,7 @@ test.describe("mobile command center pages", () => {
   });
 
   test("Chat index and new chat detail keep stable mobile geometry", async ({ page }) => {
-    await page.getByRole("tab", { name: "Chat" }).click();
+    await page.getByRole("tab", { name: "Familiars" }).click();
     await page.waitForSelector(".chat-surface");
 
     await expectNoHorizontalOverflow(page, "Chat index");
@@ -60,7 +64,7 @@ test.describe("mobile command center pages", () => {
     expect(chatTabs.top, "Chat tabs should sit below the app top bar").toBeGreaterThanOrEqual(topBar.bottom - 1);
     expect(chatTabs.bottom, "Chat tabs should not run into bottom tabs").toBeLessThan(bottomTabs.top);
 
-    await page.locator(".chat-scope-tabs button").filter({ hasText: /^\s*New\s*$/ }).click();
+    await page.locator(".chat-surface").getByRole("button", { name: "Session", exact: true }).first().click();
     await page.waitForSelector(".cave-chat-linear");
 
     await expectNoHorizontalOverflow(page, "Chat detail");

--- a/tests/mobile/foundations.spec.ts
+++ b/tests/mobile/foundations.spec.ts
@@ -64,7 +64,7 @@ test.describe("mobile foundations", () => {
     await page.goto("/");
     await page.waitForSelector(".shell-frame");
 
-    const surfaces = ["Home", "Chat", "Board", "Automations", "Library", "Browser", "Terminal"];
+    const surfaces = ["Home", "Familiars", "Board", "Calendar", "Browser", "Terminal", "Code"];
     const sidebar = page.locator(".sidebar-nav-scroll");
 
     for (const surface of surfaces) {
@@ -123,6 +123,15 @@ test.describe("mobile foundations", () => {
       });
     });
 
+    // The Library surface is an addon, gated out of the sidebar by default —
+    // enable it (passthrough-patch the config) so the nav entry renders.
+    await page.route("**/api/config**", async (route) => {
+      const res = await route.fetch();
+      const json = await res.json().catch(() => ({}));
+      const config = { ...(json.config ?? {}), addons: { ...(json.config?.addons ?? {}), library: true } };
+      await route.fulfill({ json: { ...json, ok: true, config } });
+    });
+
     await page.goto("/");
     await page.waitForSelector(".shell-frame");
 
@@ -174,7 +183,11 @@ test.describe("mobile foundations", () => {
       const frameRect = frame?.getBoundingClientRect();
       return {
         scale: document.documentElement.getAttribute("data-screen-scale"),
-        bodyZoom: getComputedStyle(document.body).zoom,
+        // Magnification is rem-based root font scaling (not an app-wide zoom,
+        // which broke getBoundingClientRect math): :root sets --cave-screen-scale
+        // and html font-size = calc(16px * var). 125% → 20px root font.
+        scaleVar: getComputedStyle(document.documentElement).getPropertyValue("--cave-screen-scale").trim(),
+        rootFontSize: getComputedStyle(document.documentElement).fontSize,
         documentOverflow: document.documentElement.scrollHeight - document.documentElement.clientHeight,
         bodyOverflow: document.body.scrollHeight - document.body.clientHeight,
         frameBottom: frameRect?.bottom ?? 0,
@@ -183,7 +196,8 @@ test.describe("mobile foundations", () => {
     });
 
     expect(metrics.scale).toBe("125");
-    expect(metrics.bodyZoom).toBe("1.25");
+    expect(metrics.scaleVar).toBe("1.25");
+    expect(metrics.rootFontSize).toBe("20px");
     expect(metrics.documentOverflow, "document should not be vertically scrollable at 125%").toBeLessThanOrEqual(1);
     expect(metrics.bodyOverflow, "body should not be vertically scrollable at 125%").toBeLessThanOrEqual(1);
     expect(metrics.frameBottom, "magnified app frame should still fit the viewport").toBeLessThanOrEqual(metrics.viewportHeight + 1);


### PR DESCRIPTION
The Playwright e2e suite (never run in CI, so it had silently rotted against UI refactors) is brought back to green.

## Fixes
- **chat-thread-rail.spec.ts** — rewritten for the redesigned rail: it's now a project-folder navigator with an **All sessions** scope and a **Search sessions** box that surfaces a flat **Results** section. The old flat-list + All/Active/Tasks/Pinned filter tabs + "New chat" + "Search chats" no longer exist.
- **mobile/foundations.spec.ts**
  - desktop-shell nav labels updated (Chat→**Familiars**; use current always-present items)
  - **Library** is an addon — passthrough-patch `/api/config` to enable it so the gated nav entry renders
  - magnification assertion fixed: scaling moved from `body { zoom }` to rem-based root font scaling (`--cave-screen-scale` → `html` font-size = 20px at 125%)
- **mobile/command-center-pages.spec.ts** — skipped on the `desktop` project (it asserts phone-only `.mobile-bottom-tabs` geometry); bottom-tab name fixed (Chat→**Familiars**); mobile new-chat affordance fixed (**"Session"**).
- **playwright.config.ts** — `retries: 1` everywhere + 60s test timeout so `next dev` cold-compile under parallel load isn't misread as a failure.

## Verification (live dev server)
- Serial: **29 passed, 2 skipped, 0 failed**
- Parallel (as `pnpm test:e2e` runs it): **28 passed, 2 skipped, 1 flaky → passed on retry, 0 hard failures**

The 2 skipped are command-center on desktop (intentionally mobile-only). Note: e2e is not a CI gate, so this doesn't change required checks — it makes the manual/throwaway-worktree e2e flow green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)