### PR TITLE
ci: run the Playwright e2e suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,27 @@ jobs:
           touch resources/node/.cargo-check-placeholder
 
       - run: cargo check --locked
+
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+
+      - run: pnpm install --frozen-lockfile
+
+      # Browsers + their Linux system libraries. The e2e projects use chromium
+      # (desktop, pixel-5) and webkit (iphone-13); --with-deps installs the apt
+      # packages those engines need on the runner.
+      - run: pnpm exec playwright install --with-deps chromium webkit
+
+      # The Playwright config self-starts `next dev` on :3100 (COVEN_CAVE_E2E=1)
+      # and runs the three viewport projects. CI=true makes the config use
+      # workers:2 + retries:1; per-test timeout is 60s for dev-server compile.
+      - run: pnpm exec playwright test

--- a/tests/board-touch.spec.ts
+++ b/tests/board-touch.spec.ts
@@ -8,6 +8,8 @@ test("touch long-press drag moves a card between columns", async ({ page }) => {
   await page.route("**/api/escalations**", (r) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, count: 0 }) }));
   await page.route("**/api/board/*", async (r) => { patches.push(JSON.parse(r.request().postData() || "{}")); r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, card: mk("c1","Drag me","inbox") }) }); });
   await page.route("**/api/board", (r) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, cards: [mk("c1", "Drag me", "backlog")] }) }));
+  // Dismiss the onboarding overlay (covers the shell on a fresh CI profile).
+  await page.addInitScript(() => window.localStorage.setItem("cave:onboarding:dismissed", "1"));
   await page.goto("/"); await page.waitForSelector(".shell-frame", { timeout: 60000 });
   await page.locator(".sidebar-nav-scroll").getByRole("button", { name: /^Board\b/ }).click();
   await page.waitForSelector(".board-kanban-card", { timeout: 60000 });

--- a/tests/chat-thread-rail.spec.ts
+++ b/tests/chat-thread-rail.spec.ts
@@ -27,6 +27,7 @@ async function gotoChat(page: Page) {
     window.localStorage.setItem("cave:demo-mode", "1");
     window.localStorage.setItem("cave:active-familiar", "nova");
     window.localStorage.setItem("cave:familiar:nova:last-surface", "chat");
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
   });
   await page.route("**/api/sessions/list**", (route) =>
     route.fulfill({ json: { ok: true, sessions: SESSIONS } }),

--- a/tests/mobile/command-center-pages.spec.ts
+++ b/tests/mobile/command-center-pages.spec.ts
@@ -30,6 +30,9 @@ test.describe("mobile command center pages", () => {
     test.skip(testInfo.project.name === "desktop", "mobile-only: requires .mobile-bottom-tabs");
     await page.addInitScript(() => {
       window.localStorage.setItem("cave:active-familiar", "nova");
+      // On a fresh profile (CI) the onboarding overlay covers the app and
+      // intercepts pointer events — dismiss it so the shell is interactive.
+      window.localStorage.setItem("cave:onboarding:dismissed", "1");
     });
     await page.goto("/");
     await page.waitForSelector(".mobile-bottom-tabs");

--- a/tests/mobile/command-center-pages.spec.ts
+++ b/tests/mobile/command-center-pages.spec.ts
@@ -33,8 +33,12 @@ test.describe("mobile command center pages", () => {
       // On a fresh profile (CI) the onboarding overlay covers the app and
       // intercepts pointer events — dismiss it so the shell is interactive.
       window.localStorage.setItem("cave:onboarding:dismissed", "1");
+      // CI has no daemon, so drive the surfaces from self-contained demo data
+      // (same approach as the other chat specs) instead of a live backend.
+      window.localStorage.setItem("cave:demo-mode", "1");
     });
-    await page.goto("/");
+    await page.route("**/api/sessions/list**", (route) => route.fulfill({ json: { ok: true, sessions: [] } }));
+    await page.goto("/?demo=1");
     await page.waitForSelector(".mobile-bottom-tabs");
   });
 

--- a/tests/mobile/foundations.spec.ts
+++ b/tests/mobile/foundations.spec.ts
@@ -16,6 +16,14 @@ import { expect, test } from "@playwright/test";
 // "did the foundation land at all" canary.
 
 test.describe("mobile foundations", () => {
+  test.beforeEach(async ({ page }) => {
+    // On a fresh profile (CI) the onboarding overlay covers the app and
+    // intercepts clicks on the sidebar/shell — dismiss it before each test.
+    await page.addInitScript(() => {
+      window.localStorage.setItem("cave:onboarding:dismissed", "1");
+    });
+  });
+
   test("viewport meta sets viewport-fit=cover", async ({ page }) => {
     await page.goto("/");
     const viewport = await page


### PR DESCRIPTION
Adds an **E2E (Playwright)** job to `ci.yml` so the e2e suite is exercised on every PR/push — it was never CI-gated, which is exactly how it silently rotted (see #999).

## The job
- installs deps, then `playwright install --with-deps chromium webkit` (the engines the desktop / pixel-5 / iphone-13 projects use, plus their Linux libs)
- runs `pnpm exec playwright test` — the config self-starts `next dev` on :3100 (`COVEN_CAVE_E2E=1`) and, under CI, uses `workers:2` + `retries:1` with a 60s per-test timeout for dev-server compile

## Scope
Added as a **non-required** check (not in branch protection) so a transient e2e flake can't block merges before it's proven stable. Once it's green across a few runs, it can be promoted to a required status check.

This PR's own run is the live verification — the new "E2E (Playwright)" check will execute the suite in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)