### PR TITLE
docs: note E2E (Playwright) is now a required check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 **Current settings** (verified live; `gh api repos/OpenCoven/coven-cave/branches/main/protection`):
 
 - PR required before merging — **0 approvals** (you can self-merge once checks pass; no second human needed for solo work).
-- Required status checks (all must pass): `Frontend build`, `Rust check`, `CodeQL`. (Require the **aggregate** `CodeQL` check, not the individual `Analyze (<lang>)` jobs — those are matched ambiguously by branch protection and get stuck as "expected", which blocks every PR.)
+- Required status checks (all must pass): `Frontend build`, `Rust check`, `CodeQL`, `E2E (Playwright)`. (Require the **aggregate** `CodeQL` check, not the individual `Analyze (<lang>)` jobs — those are matched ambiguously by branch protection and get stuck as "expected", which blocks every PR.) The `E2E (Playwright)` job runs daemon-less (`COVEN_CAVE_E2E=1`), so e2e specs must be self-contained — dismiss onboarding (`cave:onboarding:dismissed=1`) and drive surfaces via demo mode / route mocks rather than a live daemon.
 - `enforce_admins = true` — admins are **not** exempt.
 - Force-pushes and deletion of `main` are blocked.
 


### PR DESCRIPTION
Updates the repo CLAUDE.md branch-protection section to list the 4th required check (`E2E (Playwright)`, added + gated in #1000), plus a note that the e2e job runs daemon-less so specs must be self-contained (onboarding dismissed + demo/mocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)