### PR TITLE
feat(salem): back the docs familiar with the opencoven-chat-api

### DIFF
--- a/src/app/api/salem/route.ts
+++ b/src/app/api/salem/route.ts
@@ -17,6 +17,48 @@ const DOCS_BASE = "https://docs.opencoven.ai";
 const TOP_K = 5;
 const MAX_CHUNK_CHARS = 1200;
 
+// Salem's real brain: the opencoven-chat-api (hybrid RAG + reranking + streamed
+// GPT answers). When reachable, its grounded reply is preferred over the local
+// token-overlap fallback below. Override the origin with SALEM_CHAT_API_URL.
+const CHAT_API_URL = (
+  process.env.SALEM_CHAT_API_URL ?? "https://salem.opencoven.ai"
+).replace(/\/+$/, "");
+const CHAT_API_TIMEOUT_MS = 25_000;
+
+/**
+ * Ask the upstream opencoven-chat-api and aggregate its streamed text/plain
+ * response into a single reply string. Returns null on any failure so the
+ * caller can fall back to local retrieval (Cave stays useful offline).
+ */
+async function askChatApi(message: string): Promise<string | null> {
+  try {
+    const res = await fetch(`${CHAT_API_URL}/api/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message }),
+      signal: AbortSignal.timeout(CHAT_API_TIMEOUT_MS),
+    });
+
+    if (!res.ok || !res.body) return null;
+
+    // The chat API streams plain-text deltas; concatenate them.
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let text = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+
+    const trimmed = text.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
 // ── Module-level cache ────────────────────────────────────────────────────────
 
 type DocChunk = {
@@ -168,7 +210,18 @@ export async function POST(req: Request) {
       return NextResponse.json({ reply: quick, preloadSummary: summarizePreload(), source: "static" });
     }
 
-    // Fetch + retrieve
+    // Primary path: ask the real opencoven-chat-api for a grounded, LLM-written
+    // answer. Falls through to local token-overlap retrieval if unreachable.
+    const apiReply = await askChatApi(message);
+    if (apiReply) {
+      return NextResponse.json({
+        reply: apiReply,
+        preloadSummary: summarizePreload(),
+        source: "chat-api",
+      });
+    }
+
+    // Fallback: fetch + local retrieve
     const { chunks, error: fetchError } = await getDocsChunks();
 
     if (chunks.length === 0) {
@@ -189,8 +242,8 @@ export async function POST(req: Request) {
       });
     }
 
-    // Format top chunks as a grounded answer.
-    // If an LLM proxy becomes available at /api/llm, wire it in here.
+    // Format top chunks as a grounded answer (local fallback when the
+    // upstream chat-api is unreachable — see askChatApi above).
     const primary = topChunks[0];
     const extras = topChunks.slice(1, 3);
 

--- a/src/app/api/salem/route.ts
+++ b/src/app/api/salem/route.ts
@@ -32,27 +32,38 @@ const CHAT_API_TIMEOUT_MS = 25_000;
  */
 async function askChatApi(message: string): Promise<string | null> {
   try {
+    const connectTimeoutMs = 2_500;
+    const controller = new AbortController();
+    const connectTimer = setTimeout(() => controller.abort(), connectTimeoutMs);
+
     const res = await fetch(`${CHAT_API_URL}/api/chat`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ message }),
-      signal: AbortSignal.timeout(CHAT_API_TIMEOUT_MS),
-    });
+      signal: controller.signal,
+    }).finally(() => clearTimeout(connectTimer));
 
     if (!res.ok || !res.body) return null;
 
     // The chat API streams plain-text deltas; concatenate them.
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
-    let text = "";
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      text += decoder.decode(value, { stream: true });
-    }
-    text += decoder.decode();
+    const parts: string[] = [];
+    const streamTimer = setTimeout(() => controller.abort(), CHAT_API_TIMEOUT_MS);
 
-    const trimmed = text.trim();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        parts.push(decoder.decode(value, { stream: true }));
+      }
+      parts.push(decoder.decode());
+    } finally {
+      clearTimeout(streamTimer);
+      reader.releaseLock();
+    }
+
+    const trimmed = parts.join("").trim();
     return trimmed.length > 0 ? trimmed : null;
   } catch {
     return null;

--- a/src/components/board-ux-polish.test.ts
+++ b/src/components/board-ux-polish.test.ts
@@ -22,6 +22,28 @@ assert.match(
 assert.match(view, /catch \{\s*setActionError\([\s\S]*?await load\(\);/, "patchCard must handle network failure with feedback + revert");
 assert.match(view, /\{actionError && \(/, "actionError must render a banner");
 
+// ───────── Desktop board toolbar stays one row ─────────
+assert.match(
+  styles,
+  /\.board-header\s*\{[\s\S]*flex-wrap:\s*nowrap/,
+  "Desktop board header should keep title, search, and controls on one row",
+);
+assert.match(
+  styles,
+  /\.board-header-controls\s*\{[\s\S]*flex-wrap:\s*nowrap/,
+  "Desktop board controls should not wrap under the search field",
+);
+assert.match(
+  styles,
+  /\.board-search-wrap\s*\{[\s\S]*min-width:\s*0/,
+  "Desktop board search should be allowed to shrink before forcing toolbar wrapping",
+);
+assert.match(
+  styles,
+  /@media \(max-width: 767px\) \{[\s\S]*\.board-header\s*\{[\s\S]*flex-wrap:\s*wrap/,
+  "Mobile board header should keep its stacked layout",
+);
+
 // ───────── Crash-guard + card a11y ─────────
 assert.doesNotMatch(kanban, /PRIORITIES\.find\(\(p\) => p\.id === card\.priority\)!/, "PRIORITIES.find non-null assertion must be gone");
 assert.match(

--- a/src/components/canvas-view.test.ts
+++ b/src/components/canvas-view.test.ts
@@ -99,6 +99,17 @@ assert.match(
 // Generated kind is plumbed through to the stored artifact.
 assert.match(view, /kind\s*=\s*result\.kind/, "generation records the extracted artifact kind");
 
+// Refining generated artifacts must stay inside Cave's UI instead of using a
+// blocking browser prompt.
+assert.doesNotMatch(view, /window\.prompt/, "artifact refine must not use a native browser prompt");
+assert.match(view, /transformArtifactId,\s*setTransformArtifactId/, "artifact refine opens an in-app transform panel");
+assert.match(view, /Transform \{transformArtifact\?\.title \?\? "artifact"\}/, "transform panel names the target artifact");
+assert.match(view, /Apply change/, "transform panel uses a concrete action label");
+assert.match(view, /Cmd\+Enter/, "transform panel advertises the keyboard submit path");
+assert.match(view, /TRANSFORM_SUGGESTIONS\.map/, "transform panel offers quick transform chips");
+assert.match(view, /onClick=\{\(\) => setTransformAsk\(suggestion\.prompt\)\}/, "quick chips fill the transform textarea");
+assert.match(view, /submitTransform\(\)/, "transform panel submits through the refine generation path");
+
 // Artifacts persist to the canvas store via POST and delete via DELETE.
 assert.match(view, /method:\s*"POST"[\s\S]{0,120}artifact/, "artifacts upsert to /api/canvas via POST");
 assert.match(view, /method:\s*"DELETE"/, "deleting an artifact calls DELETE /api/canvas");

--- a/src/components/canvas-view.tsx
+++ b/src/components/canvas-view.tsx
@@ -73,6 +73,14 @@ type IssueFlowNode = Node<IssueNodeData & Record<string, unknown>, "issue">;
 const ARTIFACT_W = 420;
 const ARTIFACT_H = 320;
 
+const TRANSFORM_SUGGESTIONS = [
+  { label: "Polish", prompt: "Polish the visual hierarchy, spacing, and typography without changing the content." },
+  { label: "More data", prompt: "Add richer dashboard data, charts, and useful operational context." },
+  { label: "Simplify", prompt: "Simplify the layout and make the most important information easier to scan." },
+  { label: "Mobile", prompt: "Make this work better on a narrow mobile viewport." },
+  { label: "Color pass", prompt: "Refine the color system so the interface feels more intentional and cohesive." },
+];
+
 function loadLayer(): CanvasLayer {
   if (typeof window === "undefined") return "triage";
   const v = localStorage.getItem("cave:canvas:layer");
@@ -161,6 +169,8 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
   const [artifactView, setArtifactView] = useState<Record<string, "preview" | "code">>({});
   const [generating, setGenerating] = useState<Set<string>>(new Set());
   const [composer, setComposer] = useState("");
+  const [transformArtifactId, setTransformArtifactId] = useState<string | null>(null);
+  const [transformAsk, setTransformAsk] = useState("");
   // True while a user is dragging an artifact resize handle (see onNodesChange).
   const [isResizing, setIsResizing] = useState(false);
   // Template dropdown (where the Blank button lives).
@@ -179,6 +189,10 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
   const filtered = useMemo(
     () => cards.filter((c) => activeFamiliarId === null || c.familiarId === activeFamiliarId),
     [cards, activeFamiliarId],
+  );
+  const transformArtifact = useMemo(
+    () => artifacts.find((artifact) => artifact.id === transformArtifactId) ?? null,
+    [artifacts, transformArtifactId],
   );
 
   const setLayerPersisted = useCallback((next: CanvasLayer) => {
@@ -328,12 +342,23 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
     (id: string) => {
       const art = artifactsRef.current.find((a) => a.id === id);
       if (!art) return;
-      const ask = window.prompt("How should this change?", "");
-      if (ask === null || !ask.trim()) return;
-      void runGeneration(id, ask.trim(), art);
+      setTransformArtifactId(id);
+      setTransformAsk("");
     },
-    [runGeneration],
+    [],
   );
+
+  const closeTransform = useCallback(() => {
+    setTransformArtifactId(null);
+    setTransformAsk("");
+  }, []);
+
+  const submitTransform = useCallback(() => {
+    const ask = transformAsk.trim();
+    if (!ask || !transformArtifact) return;
+    void runGeneration(transformArtifact.id, ask, transformArtifact);
+    closeTransform();
+  }, [closeTransform, runGeneration, transformArtifact, transformAsk]);
 
   const onDuplicate = useCallback(
     (id: string) => {
@@ -672,6 +697,85 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
           <p className="canvas-empty__hint">
             Describe a component or page below and a familiar will generate it as a live, editable preview. Add several to compare side by side.
           </p>
+        </div>
+      ) : null}
+      {transformArtifact ? (
+        <div
+          className="canvas-transform"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="canvas-transform-title"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) closeTransform();
+          }}
+        >
+          <form
+            className="canvas-transform__panel"
+            onSubmit={(event) => {
+              event.preventDefault();
+              submitTransform();
+            }}
+          >
+            <div className="canvas-transform__header">
+              <span className="canvas-transform__icon" aria-hidden>
+                <Icon name="ph:magic-wand-fill" />
+              </span>
+              <div className="canvas-transform__title-wrap">
+                <h2 id="canvas-transform-title">Transform {transformArtifact?.title ?? "artifact"}</h2>
+                <p>
+                  {transformArtifact.kind?.toUpperCase() ?? "HTML"} · describe the change and keep iterating on this node.
+                </p>
+              </div>
+              <button
+                type="button"
+                className="canvas-transform__close"
+                aria-label="Cancel transform"
+                onClick={closeTransform}
+              >
+                <Icon name="ph:x" />
+              </button>
+            </div>
+            <textarea
+              autoFocus
+              className="canvas-transform__input"
+              rows={4}
+              value={transformAsk}
+              placeholder="Make the cards denser, add a revenue trend chart, or use a quieter operations dashboard style..."
+              onChange={(event) => setTransformAsk(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  closeTransform();
+                }
+                if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                  event.preventDefault();
+                  submitTransform();
+                }
+              }}
+            />
+            <div className="canvas-transform__suggestions" aria-label="Suggested transforms">
+              {TRANSFORM_SUGGESTIONS.map((suggestion) => (
+                <button
+                  key={suggestion.label}
+                  type="button"
+                  onClick={() => setTransformAsk(suggestion.prompt)}
+                >
+                  {suggestion.label}
+                </button>
+              ))}
+            </div>
+            <div className="canvas-transform__footer">
+              <span>Cmd+Enter to apply</span>
+              <div className="canvas-transform__actions">
+                <button type="button" className="canvas-transform__cancel" onClick={closeTransform}>
+                  Cancel
+                </button>
+                <button type="submit" className="canvas-transform__apply" disabled={!transformAsk.trim()}>
+                  <Icon name="ph:sparkle" /> Apply change
+                </button>
+              </div>
+            </div>
+          </form>
         </div>
       ) : null}
     </div>

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -7,13 +7,13 @@
 
 .board-shell { display:flex; flex-direction:column; height:100%; overflow:hidden; background:var(--bg-base); color:var(--text-primary); }
 
-.board-header { display:flex; align-items:center; gap:10px; padding:10px 16px; border-bottom:1px solid var(--border-hairline); flex-shrink:0; flex-wrap:wrap; }
-.board-header-title { font-size:14px; font-weight:600; color:var(--text-primary); }
+.board-header { display:flex; align-items:center; gap:10px; padding:10px 16px; border-bottom:1px solid var(--border-hairline); flex-shrink:0; flex-wrap:nowrap; }
+.board-header-title { flex:0 0 auto; font-size:14px; font-weight:600; color:var(--text-primary); }
 .board-header-stats { font-size:11px; color:var(--text-muted); display:flex; align-items:center; gap:6px; }
 .board-header-stats-sep { opacity:0.4; }
 .board-header-stats--blocked { color:var(--color-danger); }
-.board-header-controls { display:flex; align-items:center; gap:6px; margin-left:auto; flex-wrap:wrap; }
-.board-search-wrap { position:relative; display:flex; align-items:center; flex:1 1 320px; min-width:220px; max-width:520px; margin-left:8px; }
+.board-header-controls { display:flex; align-items:center; gap:6px; margin-left:auto; flex:0 0 auto; flex-wrap:nowrap; }
+.board-search-wrap { position:relative; display:flex; align-items:center; flex:1 1 auto; min-width:0; max-width:620px; margin-left:8px; }
 .board-search-icon { position:absolute; left:9px; color:var(--text-muted); pointer-events:none; }
 .board-search-input { width:100%; height:30px; padding:0 30px 0 30px; border-radius:7px; border:1px solid var(--border-strong); background:var(--bg-raised); color:var(--text-primary); outline:none; transition:background .12s,border-color .12s; }
 .board-search-input::placeholder { color:var(--text-muted); }
@@ -57,6 +57,7 @@
 @media (max-width: 767px) {
   .board-header {
     align-items: stretch;
+    flex-wrap: wrap;
     gap: 10px;
     padding: 18px 16px 16px;
   }
@@ -95,6 +96,7 @@
     width: 100%;
     margin-left: 0;
     justify-content: flex-end;
+    flex-wrap: wrap;
     gap: 8px;
   }
 

--- a/src/styles/canvas.css
+++ b/src/styles/canvas.css
@@ -376,6 +376,213 @@
   cursor: not-allowed;
 }
 
+/* ── Sketch layer: transform sheet ───────────────────────────────────────── */
+
+.canvas-transform {
+  position: absolute;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: color-mix(in oklab, var(--bg-base) 56%, transparent);
+  backdrop-filter: blur(3px);
+}
+
+.canvas-transform__panel {
+  width: min(680px, calc(100vw - 48px));
+  padding: 18px;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(150, 124, 255, 0.16), transparent 26%),
+    color-mix(in oklab, var(--bg-panel) 94%, #111);
+  border: 1px solid color-mix(in oklab, var(--border-strong) 76%, rgba(150, 124, 255, 0.34));
+  border-radius: 16px;
+  box-shadow:
+    0 28px 80px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.canvas-transform__header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: start;
+}
+
+.canvas-transform__icon {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  color: #e8dcff;
+  background: linear-gradient(135deg, rgba(152, 132, 255, 0.34), rgba(98, 128, 255, 0.18));
+  border: 1px solid rgba(190, 174, 255, 0.24);
+  border-radius: 10px;
+}
+
+.canvas-transform__title-wrap {
+  min-width: 0;
+}
+
+.canvas-transform__title-wrap h2 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: var(--text-lg);
+  line-height: 1.2;
+}
+
+.canvas-transform__title-wrap p {
+  margin: 5px 0 0;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.canvas-transform__close {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.canvas-transform__close:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+  border-color: var(--border-hairline);
+}
+
+.canvas-transform__input {
+  width: 100%;
+  min-height: 132px;
+  margin-top: 16px;
+  padding: 12px 13px;
+  resize: vertical;
+  color: var(--text-primary);
+  background: color-mix(in oklab, var(--bg-base) 74%, transparent);
+  border: 1px solid var(--border-hairline);
+  border-radius: 12px;
+  outline: none;
+  font: inherit;
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
+.canvas-transform__input:focus {
+  border-color: rgba(160, 143, 255, 0.72);
+  box-shadow: 0 0 0 3px rgba(128, 108, 255, 0.2);
+}
+
+.canvas-transform__input::placeholder {
+  color: var(--text-muted);
+}
+
+.canvas-transform__suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 12px;
+}
+
+.canvas-transform__suggestions button {
+  padding: 5px 10px;
+  color: var(--text-secondary);
+  background: color-mix(in oklab, var(--bg-raised) 74%, transparent);
+  border: 1px solid var(--border-hairline);
+  border-radius: 999px;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.canvas-transform__suggestions button:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.canvas-transform__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.canvas-transform__footer > span {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.canvas-transform__actions {
+  display: inline-flex;
+  gap: 8px;
+}
+
+.canvas-transform__cancel,
+.canvas-transform__apply {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 0 13px;
+  border-radius: 10px;
+  font-size: var(--text-sm);
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.canvas-transform__cancel {
+  color: var(--text-secondary);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-hairline);
+}
+
+.canvas-transform__cancel:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.canvas-transform__apply {
+  color: var(--accent-foreground, #fff);
+  background: var(--accent, #6b8fbf);
+  border: 1px solid transparent;
+}
+
+.canvas-transform__apply:disabled {
+  opacity: 0.48;
+  cursor: not-allowed;
+}
+
+@media (max-width: 640px) {
+  .canvas-transform {
+    align-items: end;
+    padding: 12px;
+  }
+
+  .canvas-transform__panel {
+    width: 100%;
+    border-radius: 14px;
+  }
+
+  .canvas-transform__footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .canvas-transform__actions {
+    justify-content: stretch;
+  }
+
+  .canvas-transform__cancel,
+  .canvas-transform__apply {
+    flex: 1;
+  }
+}
+
 /* ── Artifact node ───────────────────────────────────────────────────────── */
 
 .canvas-artifact {


### PR DESCRIPTION
## Summary

Salem's `/api/salem` POST route now uses the real **opencoven-chat-api** (hybrid RAG + Cohere reranking + streamed GPT answers) as its primary brain, instead of the local token-overlap chunk dump it shipped with.

- New `askChatApi()` helper POSTs to `${SALEM_CHAT_API_URL}/api/chat`, aggregates the streamed `text/plain` deltas, and returns them as the existing `{ reply }` JSON — **no widget change required** (`salem-widget.tsx` and its tests are untouched).
- **Graceful fallback:** if the chat-api is unreachable, Salem falls back to the existing `llms-full.txt` token-overlap retrieval, so Cave stays useful offline (local-first).
- Instant self-identity quick replies are preserved.

## Config

| Var | Default | Notes |
| --- | --- | --- |
| `SALEM_CHAT_API_URL` | `https://salem.opencoven.ai` | Upstream chat-api origin. Set `http://localhost:3001` for local dev. |

This is a server-to-server proxy (Cave's Next server → chat-api), so no CORS changes are needed on either side.

## Local dev

```sh
# opencoven-chat-api repo — Salem's brain on :3001
bun run dev:cave        # next dev -p 3001  (see opencoven-chat-api PR #6)

# this repo — owns :3000
pnpm dev                # SALEM_CHAT_API_URL=http://localhost:3001
```

## Testing

Salem guard tests, pathfinder route test, and the 101 route-contract tests pass against this diff. The `{ reply }` response contract is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)