### PR TITLE
DO NOT MERGE: e2e gate probe (intentional failure)

### DIFF
--- a/tests/__e2e_gate_probe.spec.ts
+++ b/tests/__e2e_gate_probe.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from "@playwright/test";
+
+// THROWAWAY PROBE — do not merge. Intentionally fails so we can confirm the
+// required "E2E (Playwright)" status check blocks merges. The PR is closed,
+// never merged, and this file never lands on main.
+test("e2e gate probe — intentional failure", async () => {
+  expect(1, "intentional failure to verify the e2e required-check gate").toBe(2);
+});


### PR DESCRIPTION
Throwaway probe to verify the **E2E (Playwright)** required check blocks merges. Contains one intentionally-failing e2e test. Expected: E2E check FAILS, merge is blocked, PR closed without merging.