### PR TITLE
feat(canvas): confirm before deleting a sketch window

### DIFF
--- a/src/components/canvas-artifact-node.tsx
+++ b/src/components/canvas-artifact-node.tsx
@@ -107,7 +107,13 @@ export function ArtifactNode({ data, selected }: NodeProps<ArtifactFlowNode>) {
             className="canvas-artifact__btn canvas-artifact__btn--danger"
             title="Delete"
             aria-label="Delete"
-            onClick={() => data.onDelete(artifact.id)}
+            onClick={() => {
+              // Deleting a sketch is destructive and not undoable, so confirm first.
+              const name = artifact.title?.trim() || "this sketch";
+              if (window.confirm(`Delete ${name}? This can't be undone.`)) {
+                data.onDelete(artifact.id);
+              }
+            }}
           >
             <Icon name="ph:trash" />
           </button>

--- a/src/components/canvas-view.test.ts
+++ b/src/components/canvas-view.test.ts
@@ -114,6 +114,14 @@ assert.match(view, /submitTransform\(\)/, "transform panel submits through the r
 assert.match(view, /method:\s*"POST"[\s\S]{0,120}artifact/, "artifacts upsert to /api/canvas via POST");
 assert.match(view, /method:\s*"DELETE"/, "deleting an artifact calls DELETE /api/canvas");
 
+// Deleting a sketch is destructive + not undoable, so the trash control must
+// confirm before calling onDelete.
+assert.match(
+  artifactNode,
+  /window\.confirm\([\s\S]{0,80}\)\s*\)\s*\{\s*data\.onDelete\(artifact\.id\)/,
+  "the artifact delete button must confirm before deleting",
+);
+
 // Chrome: the MiniMap is gated on having nodes (an empty canvas would render a
 // blank box), and React Flow's MiniMap/Controls are themed to the dark surface
 // (they default to white, which the workflow canvas only fixes under its own


### PR DESCRIPTION
## What

The Canvas Sketch artifact window's **trash** button deleted immediately and irreversibly (removed from local state + `DELETE /api/canvas`, no undo). Gate it behind a **`window.confirm`** that names the sketch — matching the codebase's existing single-destructive-delete pattern (`workflows-view`) — so an accidental click can't destroy a generated sketch.

```
Delete <sketch title>? This can't be undone.
```

## Verification (live, web build, seeded artifact)
- Clicking the trash control pops the confirm naming the sketch.
- **Cancel** → artifact stays (delete-button count unchanged 3→3).
- **Accept** → artifact removed (3→2).
- `pnpm typecheck` ✓, full `pnpm test:app` (314 files) ✓ — added a `canvas-view.test.ts` assertion that the delete button confirms before `onDelete`. `pnpm build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)