### PR TITLE
fix(salem/canvas/skills): harden docs-familiar follow-ups

### DIFF
--- a/src/app/api/salem/route.ts
+++ b/src/app/api/salem/route.ts
@@ -23,7 +23,8 @@ const MAX_CHUNK_CHARS = 1200;
 const CHAT_API_URL = (
   process.env.SALEM_CHAT_API_URL ?? "https://salem.opencoven.ai"
 ).replace(/\/+$/, "");
-const CHAT_API_TIMEOUT_MS = 25_000;
+const CHAT_API_CONNECT_TIMEOUT_MS = 20_000;
+const CHAT_API_TIMEOUT_MS = 45_000;
 
 /**
  * Ask the upstream opencoven-chat-api and aggregate its streamed text/plain
@@ -32,9 +33,8 @@ const CHAT_API_TIMEOUT_MS = 25_000;
  */
 async function askChatApi(message: string): Promise<string | null> {
   try {
-    const connectTimeoutMs = 2_500;
     const controller = new AbortController();
-    const connectTimer = setTimeout(() => controller.abort(), connectTimeoutMs);
+    const connectTimer = setTimeout(() => controller.abort(), CHAT_API_CONNECT_TIMEOUT_MS);
 
     const res = await fetch(`${CHAT_API_URL}/api/chat`, {
       method: "POST",

--- a/src/app/api/skills/route.ts
+++ b/src/app/api/skills/route.ts
@@ -17,7 +17,6 @@ export async function GET() {
   if (!res.ok || !res.data) {
     return NextResponse.json(
       { ok: false, error: res.error ?? `daemon http ${res.status}`, skills: [] },
-      { status: 503 },
     );
   }
   return NextResponse.json({ ok: true, skills: res.data });

--- a/src/components/canvas-view.test.ts
+++ b/src/components/canvas-view.test.ts
@@ -35,6 +35,7 @@ assert.match(view, /setActionError/, "a failed mutation must surface an error to
 
 assert.match(view, /fetch\("\/api\/canvas",\s*\{\s*method:\s*"PUT"/, "moved nodes must persist to /api/canvas");
 assert.match(view, /resolvePositions/, "nodes must be built from resolved (saved + auto-placed) positions");
+assert.match(view, /useNodesState<Node>\(\[\]\)/, "canvas should use React Flow's managed node-state hook");
 assert.match(view, /change\.type !== "dimensions"[\s\S]*?const \{ width,\s*height \} = change\.dimensions/, "artifact resize changes must capture dimensions");
 assert.match(view, /savePosition\(change\.id,\s*\{[\s\S]*?width,[\s\S]*?height[\s\S]*?\}\)/, "resized artifacts must persist width/height");
 assert.match(view, /const resizingNodeIds = useRef<Set<string>>\(new Set\(\)\)/, "canvas must track user-initiated artifact resizes");

--- a/src/components/canvas-view.tsx
+++ b/src/components/canvas-view.tsx
@@ -4,13 +4,13 @@ import "@xyflow/react/dist/style.css";
 import "@/styles/canvas.css";
 
 import {
-  applyNodeChanges,
   Background,
   Controls,
   MiniMap,
   Panel,
   ReactFlow,
   ReactFlowProvider,
+  useNodesState,
   useViewport,
   type Node,
   type NodeChange,
@@ -163,7 +163,7 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
   const [cards, setCards] = useState<Card[]>([]);
   const [positions, setPositions] = useState<CanvasPositions>({});
   const [artifacts, setArtifacts] = useState<CanvasArtifact[]>([]);
-  const [nodes, setNodes] = useState<Node[]>([]);
+  const [nodes, setNodes, applyNodesChange] = useNodesState<Node>([]);
   const [hasLoaded, setHasLoaded] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [artifactView, setArtifactView] = useState<Record<string, "preview" | "code">>({});
@@ -488,8 +488,8 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
       // the drag tracks the cursor smoothly even as it passes over a live preview.
       setIsResizing(resizingNodeIds.current.size > 0);
     }
-    setNodes((prev) => applyNodeChanges(changes, prev));
-  }, [layer, nodes, positions, savePosition]);
+    applyNodesChange(changes);
+  }, [applyNodesChange, layer, nodes, positions, savePosition]);
 
   const patchStatus = useCallback(async (id: string, status: CardStatus) => {
     const prevStatus = cards.find((c) => c.id === id)?.status;

--- a/src/components/eval-loop-panel.test.ts
+++ b/src/components/eval-loop-panel.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./eval-loop-panel.tsx", import.meta.url), "utf8");
+const skillsRoute = readFileSync(new URL("../app/api/skills/route.ts", import.meta.url), "utf8");
 const evalLoopRoute = readFileSync(new URL("../app/api/skills/eval-loop/[familiarId]/route.ts", import.meta.url), "utf8");
 const evalLoopRunRoute = readFileSync(new URL("../app/api/skills/eval-loop/[familiarId]/run/route.ts", import.meta.url), "utf8");
 
@@ -40,6 +41,18 @@ assert.doesNotMatch(
   evalLoopRoute,
   /\{\s*status:\s*503\s*\}/,
   "inactive/offline eval-loop reads should not create browser-console 503 noise",
+);
+
+assert.match(
+  skillsRoute,
+  /NextResponse\.json\([\s\S]*?ok: false,[\s\S]*?skills: \[\]/,
+  "offline skills reads should return a quiet ok:false payload",
+);
+
+assert.doesNotMatch(
+  skillsRoute,
+  /\{\s*status:\s*503\s*\}/,
+  "offline skills reads should not create browser-console 503 noise",
 );
 
 assert.match(

--- a/src/components/salem/salem.test.ts
+++ b/src/components/salem/salem.test.ts
@@ -61,6 +61,9 @@ const route = await readFile(path.join(root, "src/app/api/salem/route.ts"), "utf
 assert.match(route, /POST/, "must export POST handler");
 assert.match(route, /GET/, "must expose preloaded context to the widget");
 assert.match(route, /SALEM_PRELOAD_CONTEXT/, "must use shared preload context");
+assert.match(route, /CHAT_API_CONNECT_TIMEOUT_MS\s*=\s*20_000/, "Salem upstream chat API connect timeout must allow the hosted stream to start");
+assert.match(route, /CHAT_API_TIMEOUT_MS\s*=\s*45_000/, "Salem upstream chat API stream timeout must allow full hosted replies");
+assert.doesNotMatch(route, /const connectTimeoutMs = 2_500/, "Salem must not abort the upstream chat API before it can stream");
 assert.match(route, /familiar|familiar/, "must know about familiars");
 assert.match(route, /role|Role/, "must know about roles");
 assert.match(route, /plugin|Plugin/, "must know about plugins");

--- a/src/lib/server/project-paths.test.ts
+++ b/src/lib/server/project-paths.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -11,6 +11,7 @@ const originalEnv = {
   WORKSPACE_ROOT: process.env.WORKSPACE_ROOT,
   NEXT_PUBLIC_WORKSPACE_ROOT: process.env.NEXT_PUBLIC_WORKSPACE_ROOT,
   OPENCLAW_WORKSPACE_ROOT: process.env.OPENCLAW_WORKSPACE_ROOT,
+  CAVE_PROJECTS_PATH_OVERRIDE: process.env.CAVE_PROJECTS_PATH_OVERRIDE,
 };
 
 function restoreEnv() {
@@ -27,6 +28,7 @@ const tmp = await mkdtemp(path.join(tmpdir(), "coven-project-paths-"));
 
 try {
   process.env.COVEN_HOME = path.join(tmp, ".coven");
+  process.env.CAVE_PROJECTS_PATH_OVERRIDE = path.join(tmp, "cave-projects.json");
   delete process.env.COVEN_WORKSPACES_ROOT;
   delete process.env.COVEN_WORKSPACE_ROOT;
   delete process.env.WORKSPACE_ROOT;
@@ -34,7 +36,16 @@ try {
   delete process.env.OPENCLAW_WORKSPACE_ROOT;
 
   const canonical = path.join(process.env.COVEN_HOME, "workspaces", "familiars", "sage");
+  const savedProjectRoot = path.join(tmp, "Documents", "GitHub", "OpenCoven", "coven-docs");
   await mkdir(canonical, { recursive: true });
+  await mkdir(path.join(savedProjectRoot, "docs"), { recursive: true });
+  await writeFile(
+    process.env.CAVE_PROJECTS_PATH_OVERRIDE,
+    JSON.stringify({
+      version: 1,
+      projects: [{ id: "docs", name: "Coven Docs", root: savedProjectRoot }],
+    }),
+  );
 
   const { resolveAllowedProjectPath } = await import("./project-paths.ts");
   const legacy = path.join(process.env.COVEN_HOME, "workspace", "familiars", "sage");
@@ -43,6 +54,12 @@ try {
     resolveAllowedProjectPath(legacy),
     await realpath(canonical),
     "legacy ~/.coven/workspace familiar paths normalize to canonical ~/.coven/workspaces paths",
+  );
+
+  assert.equal(
+    resolveAllowedProjectPath(path.join(savedProjectRoot, "docs")),
+    await realpath(path.join(savedProjectRoot, "docs")),
+    "saved Cave project roots are allowed for file tree browsing",
   );
 } finally {
   restoreEnv();

--- a/src/lib/server/project-paths.ts
+++ b/src/lib/server/project-paths.ts
@@ -22,6 +22,25 @@ function normalizeLegacyCovenWorkspacePath(value: string): string {
   return path.join(path.resolve(path.join(covenHome(), "workspaces")), path.relative(legacyRoot, resolved));
 }
 
+function caveProjectsFilePath(): string {
+  return process.env.CAVE_PROJECTS_PATH_OVERRIDE ?? path.join(homedir(), ".coven", "cave-projects.json");
+}
+
+function savedCaveProjectRoots(): string[] {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(caveProjectsFilePath(), "utf8")) as {
+      projects?: Array<{ root?: unknown }>;
+    };
+    if (!Array.isArray(parsed.projects)) return [];
+    return parsed.projects
+      .map((project) => project.root)
+      .filter((root): root is string => typeof root === "string" && path.isAbsolute(root.trim()))
+      .map((root) => root.trim());
+  } catch {
+    return [];
+  }
+}
+
 const ALLOWED_ROOTS = Array.from(
   new Set(
     [
@@ -32,6 +51,7 @@ const ALLOWED_ROOTS = Array.from(
       process.env.OPENCLAW_WORKSPACE_ROOT,
       path.join(homedir(), ".openclaw", "workspace"),
       process.cwd(),
+      ...savedCaveProjectRoots(),
     ]
       .filter((value): value is string => Boolean(value))
       .map(realpathOrResolve),


### PR DESCRIPTION
Recovers and lands the uncommitted follow-up work from a dropped session, polishing the docs-familiar / opencoven-chat-api work (#1002). Four small, independently-tested fixes:

- **salem** — raise upstream chat API timeouts (connect `2.5s→20s`, stream `25s→45s`) so the hosted stream has time to start and complete a full reply instead of aborting mid-response.
- **skills** — drop the `503` status on offline-daemon reads; return a quiet `ok:false` payload so the browser console isn't flooded with 503 noise (mirrors the eval-loop route).
- **canvas** — use React Flow's managed `useNodesState` hook instead of manual `applyNodeChanges`/`setNodes`.
- **project-paths** — allow saved Cave project roots (`cave-projects.json`) as permitted file-tree browsing roots.

Each change ships with an accompanying test.

## Verification
- `pnpm test:app` — ✅ 314 test files pass
- `pnpm typecheck` — ✅ clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)