### PR TITLE
fix(chat): full-width responsive grid for next-path suggestion chips

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6389,10 +6389,18 @@ a.mobile-handoff__link:hover {
 /* ── Chat next-path suggestion chips ─────────────────────────────────────────
    Clickable next-step chips under an assistant reply (parsed from the
    <coven:next-paths> block); clicking sends the suggestion as the next turn. */
-.cave-next-paths { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
+.cave-next-paths {
+  display: grid; grid-template-columns: 1fr; gap: 6px; margin-top: 10px; width: 100%;
+}
+@container chatturn (min-width: 540px) {
+  .cave-next-paths { grid-template-columns: repeat(2, 1fr); }
+}
+@container chatturn (min-width: 760px) {
+  .cave-next-paths { grid-template-columns: repeat(3, 1fr); }
+}
 .cave-next-path {
-  display: inline-flex; align-items: center; max-width: 100%;
-  padding: 5px 11px; border-radius: 999px;
+  display: inline-flex; align-items: center; width: 100%; max-width: 100%;
+  padding: 7px 12px; border-radius: 8px;
   border: 1px solid color-mix(in oklch, var(--accent-presence) 38%, var(--border-hairline));
   background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
   color: var(--text-secondary); font-size: 12px; line-height: 1.2;

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2530,6 +2530,8 @@ details[open] > .cave-tool-summary::before {
 
 .cave-linear-turn-body {
   min-width: 0;
+  container-type: inline-size;
+  container-name: chatturn;
 }
 
 .cave-chat-linear .cave-bubble-assistant {


### PR DESCRIPTION
## What

The `<coven:next-paths>` suggestion chips under an assistant reply were loose, pill-shaped (`border-radius: 999px`) inline-flex items. This makes them a **full-width responsive grid** with squared-off corners.

- **3 columns** when the chat turn is ≥760px wide
- **2 columns** at ≥540px
- **1 per row** below that
- Corners go from pill (`999px`) → `8px`; each chip stretches to fill its cell

## How

The grid keys off the **chat turn's own width**, not the viewport: `.cave-linear-turn-body` is now an inline-size container named `chatturn`, and `.cave-next-paths` uses `@container chatturn (...)` queries. So a narrow split/drawer pane on a wide screen correctly drops to fewer columns.

## Verification

Ran the real Cave web build and drove it with a mocked `<coven:next-paths>` chat turn. Computed `grid-template-columns` tracked the turn body width (829px→3, 629px→2, 489px→1) and corners rendered at 8px. Screenshots confirmed full-width chips at all three bands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)