### PR TITLE
feat(canvas): remove the triage layer — Canvas is sketch-only

### DIFF
--- a/src/components/canvas-view.test.ts
+++ b/src/components/canvas-view.test.ts
@@ -18,23 +18,21 @@ assert.match(workspace, /import \{ CanvasView \} from "@\/components\/canvas-vie
 assert.match(sidebar, /id: "canvas"/, "sidebar must list a canvas destination");
 assert.match(sidebar, /\|\s*"canvas"/, "FolderMode union must include canvas");
 
-// ── The triage gesture: drag across a band → PATCH the card's status ───────
+// ── Sketch-only canvas: the triage layer (board cards / status bands) is gone ─
 
 assert.match(view, /onNodeDragStop/, "canvas must react to drag completion");
-assert.match(view, /bandForX\(centerX\)/, "drop position must map to a status band");
-assert.match(
+assert.match(view, /data-layer="sketch"/, "canvas renders only the sketch layer");
+assert.doesNotMatch(
   view,
-  /fetch\(`\/api\/board\/\$\{id\}`,\s*\{\s*method:\s*"PATCH"/,
-  "a band change must PATCH the card status on the board",
+  /BandGuides|bandForX|cave:canvas:layer|"triage"/,
+  "the triage layer, its bands, and the layer toggle must be removed",
 );
-// Optimistic mutation must revert on failure (board-view lesson: review the failure path).
-assert.match(view, /status:\s*prevStatus/, "a failed status PATCH must revert to the previous status");
+assert.doesNotMatch(view, /\/api\/board/, "the sketch canvas no longer reads or mutates the board");
 assert.match(view, /setActionError/, "a failed mutation must surface an error to the user");
 
-// ── Positions persist to the dedicated canvas store, not the board ─────────
+// ── Positions persist to the dedicated canvas store ────────────────────────
 
 assert.match(view, /fetch\("\/api\/canvas",\s*\{\s*method:\s*"PUT"/, "moved nodes must persist to /api/canvas");
-assert.match(view, /resolvePositions/, "nodes must be built from resolved (saved + auto-placed) positions");
 assert.match(view, /useNodesState<Node>\(\[\]\)/, "canvas should use React Flow's managed node-state hook");
 assert.match(view, /change\.type !== "dimensions"[\s\S]*?const \{ width,\s*height \} = change\.dimensions/, "artifact resize changes must capture dimensions");
 assert.match(view, /savePosition\(change\.id,\s*\{[\s\S]*?width,[\s\S]*?height[\s\S]*?\}\)/, "resized artifacts must persist width/height");
@@ -44,21 +42,9 @@ assert.match(view, /change\.type !== "dimensions" \|\| change\.resizing \|\| !ch
 assert.match(view, /width:\s*saved\.width \?\? ARTIFACT_W/, "artifact nodes must restore saved width");
 assert.match(view, /height:\s*saved\.height \?\? ARTIFACT_H/, "artifact nodes must restore saved height");
 
-// ── Familiar scoping mirrors the Board ─────────────────────────────────────
-
-assert.match(
-  view,
-  /activeFamiliarId === null \|\| c\.familiarId === activeFamiliarId/,
-  "canvas must scope cards to the active familiar the same way the board does",
-);
-
 // ── Sketch layer: generate UIs ad hoc, render in a sandboxed iframe ────────
 
 const artifactNode = await readFile(new URL("./canvas-artifact-node.tsx", import.meta.url), "utf8");
-
-// Layer toggle is persisted and gates the bands (triage-only).
-assert.match(view, /cave:canvas:layer/, "the Triage/Sketch layer choice must persist");
-assert.match(view, /isSketch \? null : <BandGuides/, "status bands must only render in the triage layer");
 
 // Generation routes through the chat bridge (Cave has no server LLM).
 assert.match(view, /generateArtifactCode/, "Sketch must generate via the chat-bridge helper");

--- a/src/components/canvas-view.tsx
+++ b/src/components/canvas-view.tsx
@@ -11,32 +11,17 @@ import {
   ReactFlow,
   ReactFlowProvider,
   useNodesState,
-  useViewport,
   type Node,
   type NodeChange,
-  type NodeProps,
   type NodeTypes,
 } from "@xyflow/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Icon } from "@/lib/icon";
 import { Popover, PopoverBody, PopoverItem, PopoverLabel, PopoverSeparator } from "@/components/ui/popover";
-import { type Card, type CardStatus } from "@/lib/cave-board-types";
 import type { Familiar } from "@/lib/types";
-import { DEMO_BOARD_CARDS } from "@/lib/demo-seed";
 import { DEMO_MODE_EVENT, isDemoModeEnabled } from "@/lib/demo-mode";
-import {
-  autoArrange,
-  bandForX,
-  bandLeft,
-  BAND_LABELS,
-  BAND_WIDTH,
-  CANVAS_BANDS,
-  CANVAS_NODE_WIDTH,
-  resolvePositions,
-  type CanvasPosition,
-  type CanvasPositions,
-} from "@/lib/canvas-layout";
+import { type CanvasPosition, type CanvasPositions } from "@/lib/canvas-layout";
 import {
   buildPreviewSrcDoc,
   buildRefinePrompt,
@@ -52,23 +37,14 @@ import { buildReactSrcDoc } from "@/lib/canvas-react-harness";
 import { generateArtifactCode } from "@/lib/canvas-generate";
 import { ArtifactNode, type ArtifactFlowNode } from "@/components/canvas-artifact-node";
 
-type CanvasLayer = "triage" | "sketch";
-
 type Props = {
   familiars: Familiar[];
   activeFamiliarId: string | null;
+  // Accepted for call-site compatibility with the workspace; the sketch canvas
+  // doesn't render board cards, so they're unused here.
   onOpenCard?: (cardId: string) => void;
   onOpenUrl?: (url: string) => void;
 };
-
-type IssueNodeData = {
-  card: Card;
-  familiarName: string | null;
-  onOpenCard?: (cardId: string) => void;
-  onOpenUrl?: (url: string) => void;
-};
-
-type IssueFlowNode = Node<IssueNodeData & Record<string, unknown>, "issue">;
 
 const ARTIFACT_W = 420;
 const ARTIFACT_H = 320;
@@ -81,86 +57,11 @@ const TRANSFORM_SUGGESTIONS = [
   { label: "Color pass", prompt: "Refine the color system so the interface feels more intentional and cohesive." },
 ];
 
-function loadLayer(): CanvasLayer {
-  if (typeof window === "undefined") return "triage";
-  const v = localStorage.getItem("cave:canvas:layer");
-  return v === "sketch" ? "sketch" : "triage";
-}
-
-// ── Issue node (triage) ─────────────────────────────────────────────────────
-
-function IssueNode({ data }: NodeProps<IssueFlowNode>) {
-  const { card, familiarName, onOpenCard, onOpenUrl } = data;
-  const gh = card.github?.[0];
-  const ghUrl = gh?.url ?? card.links?.[0];
-  return (
-    <div className={`canvas-issue canvas-issue--${card.status}`}>
-      <div className="canvas-issue__top">
-        <span className={`canvas-issue__prio canvas-issue__prio--${card.priority}`} aria-hidden />
-        <span className="canvas-issue__status">{BAND_LABELS[card.status]}</span>
-        {gh?.number ? <span className="canvas-issue__num">#{gh.number}</span> : null}
-      </div>
-      <button
-        type="button"
-        className="canvas-issue__title nodrag"
-        title="Open this card"
-        onClick={() => onOpenCard?.(card.id)}
-      >
-        {card.title || "Untitled"}
-      </button>
-      <div className="canvas-issue__meta">
-        {familiarName ? <span className="canvas-issue__familiar">{familiarName}</span> : null}
-        {card.labels?.slice(0, 3).map((label) => (
-          <span key={label} className="canvas-issue__label">
-            {label}
-          </span>
-        ))}
-      </div>
-      {ghUrl ? (
-        <button
-          type="button"
-          className="canvas-issue__open nodrag"
-          title="Open link"
-          aria-label="Open link"
-          onClick={() => onOpenUrl?.(ghUrl)}
-        >
-          <Icon name="ph:arrow-square-out" />
-        </button>
-      ) : null}
-    </div>
-  );
-}
-
-const nodeTypes: NodeTypes = { issue: IssueNode, artifact: ArtifactNode };
-
-// ── Band guides (triage only) ───────────────────────────────────────────────
-//
-// The triage bands live in world space but are drawn as a screen overlay that
-// re-projects on every pan/zoom (React Flow keeps node DOM in a transformed
-// layer we can't inject into, so we mirror the transform ourselves).
-
-function BandGuides() {
-  const { x, zoom } = useViewport();
-  return (
-    <div className="canvas-bands" aria-hidden>
-      {CANVAS_BANDS.map((status, i) => {
-        const left = bandLeft(i) * zoom + x;
-        const width = BAND_WIDTH * zoom;
-        return (
-          <div key={status} className="canvas-band" style={{ left, width }}>
-            <div className="canvas-band__header">{BAND_LABELS[status]}</div>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
+const nodeTypes: NodeTypes = { artifact: ArtifactNode };
 
 // ── Surface ───────────────────────────────────────────────────────────────--
 
-function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: Props) {
-  const [layer, setLayer] = useState<CanvasLayer>(loadLayer);
-  const [cards, setCards] = useState<Card[]>([]);
+function CanvasSurface({ familiars, activeFamiliarId }: Props) {
   const [positions, setPositions] = useState<CanvasPositions>({});
   const [artifacts, setArtifacts] = useState<CanvasArtifact[]>([]);
   const [nodes, setNodes, applyNodesChange] = useNodesState<Node>([]);
@@ -184,38 +85,22 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
   const editTimers = useRef<Record<string, number>>({});
   const resizingNodeIds = useRef<Set<string>>(new Set());
 
-  const familiarsById = useMemo(() => new Map(familiars.map((f) => [f.id, f])), [familiars]);
-
-  const filtered = useMemo(
-    () => cards.filter((c) => activeFamiliarId === null || c.familiarId === activeFamiliarId),
-    [cards, activeFamiliarId],
-  );
   const transformArtifact = useMemo(
     () => artifacts.find((artifact) => artifact.id === transformArtifactId) ?? null,
     [artifacts, transformArtifactId],
   );
 
-  const setLayerPersisted = useCallback((next: CanvasLayer) => {
-    setLayer(next);
-    setActionError(null);
-    if (typeof window !== "undefined") localStorage.setItem("cave:canvas:layer", next);
-  }, []);
-
   const load = useCallback(async () => {
     if (isDemoModeEnabled()) {
-      setCards(DEMO_BOARD_CARDS as Card[]);
+      // Demo mode has no persisted artifacts — start from the empty state.
+      setArtifacts([]);
       setPositions({});
       setHasLoaded(true);
       return;
     }
     try {
-      const [boardRes, canvasRes] = await Promise.all([
-        fetch("/api/board", { cache: "no-store" }),
-        fetch("/api/canvas", { cache: "no-store" }),
-      ]);
-      const boardJson = await boardRes.json();
+      const canvasRes = await fetch("/api/canvas", { cache: "no-store" });
       const canvasJson = await canvasRes.json().catch(() => ({}));
-      if (boardJson?.ok) setCards(boardJson.cards as Card[]);
       setPositions((canvasJson?.positions as CanvasPositions) ?? {});
       setArtifacts((canvasJson?.artifacts as CanvasArtifact[]) ?? []);
     } catch {
@@ -231,12 +116,8 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
 
   useEffect(() => {
     const onReload = () => load();
-    window.addEventListener("cave:board:reload", onReload);
     window.addEventListener(DEMO_MODE_EVENT, onReload);
-    return () => {
-      window.removeEventListener("cave:board:reload", onReload);
-      window.removeEventListener(DEMO_MODE_EVENT, onReload);
-    };
+    return () => window.removeEventListener(DEMO_MODE_EVENT, onReload);
   }, [load]);
 
   // ── Artifact persistence ──────────────────────────────────────────────────
@@ -418,26 +299,9 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
     }
   }, []);
 
-  // ── Node assembly (per layer) ──────────────────────────────────────────────
+  // ── Node assembly ──────────────────────────────────────────────────────────
 
   useEffect(() => {
-    if (layer === "triage") {
-      const resolved = resolvePositions(filtered, positions);
-      setNodes(
-        filtered.map((card) => ({
-          id: card.id,
-          type: "issue" as const,
-          position: resolved[card.id] ?? { x: 0, y: 0 },
-          data: {
-            card,
-            familiarName: card.familiarId ? familiarsById.get(card.familiarId)?.name ?? null : null,
-            onOpenCard,
-            onOpenUrl,
-          },
-        })),
-      );
-      return;
-    }
     setNodes(
       artifacts.map((art, i) => {
         const saved = positions[art.id] ?? placementFor(i);
@@ -462,75 +326,39 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
       }) as ArtifactFlowNode[],
     );
   }, [
-    layer, filtered, positions, familiarsById, onOpenCard, onOpenUrl, artifacts, artifactView,
-    generating, placementFor, onToggleView, onRefine, onDuplicate, onDeleteArtifact, onEditCode, onOpenInBrowser,
+    positions, artifacts, artifactView, generating, placementFor,
+    onToggleView, onRefine, onDuplicate, onDeleteArtifact, onEditCode, onOpenInBrowser,
   ]);
 
   const onNodesChange = useCallback((changes: NodeChange[]) => {
-    if (layer === "sketch") {
-      for (const change of changes) {
-        if (change.type === "dimensions" && change.resizing) {
-          resizingNodeIds.current.add(change.id);
-          continue;
-        }
-        if (change.type !== "dimensions" || change.resizing || !change.dimensions || !resizingNodeIds.current.has(change.id)) continue;
-        resizingNodeIds.current.delete(change.id);
-        const { width, height } = change.dimensions;
-        if (!Number.isFinite(width) || !Number.isFinite(height)) continue;
-        // Resizing from the top/left edge moves the node as well as sizing it, so
-        // persist the node's CURRENT position — the stale saved entry would snap the
-        // window back to its pre-resize origin on reload.
-        const saved = nodes.find((node) => node.id === change.id)?.position ?? positions[change.id];
-        if (!saved) continue;
-        savePosition(change.id, { x: saved.x, y: saved.y, width, height });
+    for (const change of changes) {
+      if (change.type === "dimensions" && change.resizing) {
+        resizingNodeIds.current.add(change.id);
+        continue;
       }
-      // While any artifact is actively resizing, suppress iframe pointer capture so
-      // the drag tracks the cursor smoothly even as it passes over a live preview.
-      setIsResizing(resizingNodeIds.current.size > 0);
+      if (change.type !== "dimensions" || change.resizing || !change.dimensions || !resizingNodeIds.current.has(change.id)) continue;
+      resizingNodeIds.current.delete(change.id);
+      const { width, height } = change.dimensions;
+      if (!Number.isFinite(width) || !Number.isFinite(height)) continue;
+      // Resizing from the top/left edge moves the node as well as sizing it, so
+      // persist the node's CURRENT position — the stale saved entry would snap the
+      // window back to its pre-resize origin on reload.
+      const saved = nodes.find((node) => node.id === change.id)?.position ?? positions[change.id];
+      if (!saved) continue;
+      savePosition(change.id, { x: saved.x, y: saved.y, width, height });
     }
+    // While any artifact is actively resizing, suppress iframe pointer capture so
+    // the drag tracks the cursor smoothly even as it passes over a live preview.
+    setIsResizing(resizingNodeIds.current.size > 0);
     applyNodesChange(changes);
-  }, [applyNodesChange, layer, nodes, positions, savePosition]);
-
-  const patchStatus = useCallback(async (id: string, status: CardStatus) => {
-    const prevStatus = cards.find((c) => c.id === id)?.status;
-    if (!prevStatus || prevStatus === status) return;
-    setCards((prev) => prev.map((c) => (c.id === id ? { ...c, status } : c)));
-    setActionError(null);
-    try {
-      const res = await fetch(`/api/board/${id}`, {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ status }),
-      });
-      if (!res.ok) throw new Error(String(res.status));
-    } catch {
-      setCards((prev) => prev.map((c) => (c.id === id ? { ...c, status: prevStatus } : c)));
-      setActionError("Couldn't move that card — change reverted.");
-    }
-  }, [cards]);
+  }, [applyNodesChange, nodes, positions, savePosition]);
 
   const onNodeDragStop = useCallback(
     (_e: unknown, node: Node) => {
       savePosition(node.id, { x: node.position.x, y: node.position.y });
-      // Triage cards retriage by which band they land in; artifacts are free.
-      if (node.type === "issue") {
-        const centerX = node.position.x + CANVAS_NODE_WIDTH / 2;
-        void patchStatus(node.id, bandForX(centerX));
-      }
     },
-    [savePosition, patchStatus],
+    [savePosition],
   );
-
-  const arrange = useCallback(() => {
-    const next = autoArrange(filtered);
-    setPositions((prev) => ({ ...prev, ...next }));
-    if (isDemoModeEnabled()) return;
-    void fetch("/api/canvas", {
-      method: "PUT",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ positions: next }),
-    }).catch(() => undefined);
-  }, [filtered]);
 
   const submitComposer = useCallback(() => {
     if (!composer.trim()) return;
@@ -538,12 +366,10 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
     setComposer("");
   }, [composer, createArtifact]);
 
-  const isSketch = layer === "sketch";
-  const triageEmpty = hasLoaded && !isSketch && filtered.length === 0;
-  const sketchEmpty = hasLoaded && isSketch && artifacts.length === 0;
+  const sketchEmpty = hasLoaded && artifacts.length === 0;
 
   return (
-    <div className={`canvas-view${isResizing ? " is-resizing" : ""}`} data-mode="canvas" data-layer={layer}>
+    <div className={`canvas-view${isResizing ? " is-resizing" : ""}`} data-mode="canvas" data-layer="sketch">
       <ReactFlow
         nodes={nodes}
         edges={[]}
@@ -557,7 +383,6 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
         maxZoom={1.5}
         proOptions={{ hideAttribution: true }}
       >
-        {isSketch ? null : <BandGuides />}
         <Background gap={24} size={1} />
         <Controls showInteractive={false} />
         {/* Nothing to map on an empty canvas — the minimap would just render a
@@ -568,41 +393,7 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
           <span className="canvas-toolbar__title">
             <Icon name="ph:bounding-box" /> Canvas
           </span>
-          <div className="canvas-segmented" role="tablist" aria-label="Canvas mode">
-            <button
-              type="button"
-              role="tab"
-              aria-selected={!isSketch}
-              className={`canvas-segmented__btn${!isSketch ? " is-active" : ""}`}
-              onClick={() => setLayerPersisted("triage")}
-            >
-              Triage
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={isSketch}
-              className={`canvas-segmented__btn${isSketch ? " is-active" : ""}`}
-              onClick={() => setLayerPersisted("sketch")}
-            >
-              Sketch
-            </button>
-          </div>
-          {isSketch ? (
-            <span className="canvas-toolbar__count">{artifacts.length} examples</span>
-          ) : (
-            <>
-              <span className="canvas-toolbar__count">{filtered.length} issues</span>
-              <button
-                type="button"
-                className="canvas-toolbar__btn"
-                onClick={arrange}
-                title="Tidy cards into their status bands"
-              >
-                <Icon name="ph:arrows-clockwise" /> Auto-arrange
-              </button>
-            </>
-          )}
+          <span className="canvas-toolbar__count">{artifacts.length} examples</span>
         </Panel>
 
         {actionError ? (
@@ -611,85 +402,74 @@ function CanvasSurface({ familiars, activeFamiliarId, onOpenCard, onOpenUrl }: P
           </Panel>
         ) : null}
 
-        {isSketch ? (
-          <Panel position="bottom-center" className="canvas-composer">
-            <textarea
-              className="canvas-composer__input"
-              placeholder="Describe a UI to spin up — e.g. “a pricing page with three tiers and a toggle”"
-              value={composer}
-              rows={2}
-              onChange={(e) => setComposer(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-                  e.preventDefault();
-                  submitComposer();
-                }
-              }}
-            />
-            <div className="canvas-composer__actions">
-              <span className="canvas-composer__new">
-                <button
-                  ref={templatesAnchorRef}
-                  type="button"
-                  className="canvas-composer__blank"
-                  title="Start from a blank sketch or a template"
-                  aria-haspopup="menu"
-                  aria-expanded={templatesOpen}
-                  onClick={() => setTemplatesOpen((v) => !v)}
-                >
-                  <Icon name="ph:plus" /> Blank
-                  <Icon name="ph:caret-down" width={11} />
-                </button>
-                <Popover
-                  open={templatesOpen}
-                  onOpenChange={setTemplatesOpen}
-                  anchorRef={templatesAnchorRef}
-                  placement="top-start"
-                  minWidth={232}
-                >
-                  <PopoverBody>
-                    <PopoverItem
-                      icon="ph:file-dashed"
-                      onSelect={() => { createArtifact("", { blank: true }); setTemplatesOpen(false); }}
-                    >
-                      Blank sketch
-                    </PopoverItem>
-                    <PopoverSeparator />
-                    <PopoverLabel>Templates</PopoverLabel>
-                    {CANVAS_TEMPLATES.map((t) => (
-                      <PopoverItem
-                        key={t.id}
-                        icon={t.icon}
-                        onSelect={() => { createArtifact("", { template: t }); setTemplatesOpen(false); }}
-                      >
-                        {t.label}
-                      </PopoverItem>
-                    ))}
-                  </PopoverBody>
-                </Popover>
-              </span>
+        <Panel position="bottom-center" className="canvas-composer">
+          <textarea
+            className="canvas-composer__input"
+            placeholder="Describe a UI to spin up — e.g. “a pricing page with three tiers and a toggle”"
+            value={composer}
+            rows={2}
+            onChange={(e) => setComposer(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                submitComposer();
+              }
+            }}
+          />
+          <div className="canvas-composer__actions">
+            <span className="canvas-composer__new">
               <button
+                ref={templatesAnchorRef}
                 type="button"
-                className="canvas-composer__send"
-                disabled={!composer.trim()}
-                onClick={submitComposer}
+                className="canvas-composer__blank"
+                title="Start from a blank sketch or a template"
+                aria-haspopup="menu"
+                aria-expanded={templatesOpen}
+                onClick={() => setTemplatesOpen((v) => !v)}
               >
-                <Icon name="ph:sparkle" /> Generate
+                <Icon name="ph:plus" /> Blank
+                <Icon name="ph:caret-down" width={11} />
               </button>
-            </div>
-          </Panel>
-        ) : null}
+              <Popover
+                open={templatesOpen}
+                onOpenChange={setTemplatesOpen}
+                anchorRef={templatesAnchorRef}
+                placement="top-start"
+                minWidth={232}
+              >
+                <PopoverBody>
+                  <PopoverItem
+                    icon="ph:file-dashed"
+                    onSelect={() => { createArtifact("", { blank: true }); setTemplatesOpen(false); }}
+                  >
+                    Blank sketch
+                  </PopoverItem>
+                  <PopoverSeparator />
+                  <PopoverLabel>Templates</PopoverLabel>
+                  {CANVAS_TEMPLATES.map((t) => (
+                    <PopoverItem
+                      key={t.id}
+                      icon={t.icon}
+                      onSelect={() => { createArtifact("", { template: t }); setTemplatesOpen(false); }}
+                    >
+                      {t.label}
+                    </PopoverItem>
+                  ))}
+                </PopoverBody>
+              </Popover>
+            </span>
+            <button
+              type="button"
+              className="canvas-composer__send"
+              disabled={!composer.trim()}
+              onClick={submitComposer}
+            >
+              <Icon name="ph:sparkle" /> Generate
+            </button>
+          </div>
+        </Panel>
       </ReactFlow>
 
-      {triageEmpty ? (
-        <div className="canvas-empty">
-          <Icon name="ph:bounding-box" />
-          <p className="canvas-empty__title">No issues to triage</p>
-          <p className="canvas-empty__hint">
-            Cards from the Board appear here. Drag a card across a band to retriage it, or switch to Sketch to build UIs.
-          </p>
-        </div>
-      ) : null}
       {sketchEmpty ? (
         <div className="canvas-empty">
           <Icon name="ph:sparkle" />

--- a/src/styles/canvas.css
+++ b/src/styles/canvas.css
@@ -1,5 +1,5 @@
-/* Triage Canvas surface — infinite spatial board over the Board's cards.
-   Bands are status columns; dragging a card across a band retriages it. */
+/* Sketch Canvas surface — an infinite spatial board for generating, editing,
+   and arranging live UI artifacts. */
 
 .canvas-view {
   position: relative;
@@ -11,43 +11,6 @@
 
 .canvas-view .react-flow {
   background: var(--bg-base);
-}
-
-/* ── Band guides ─────────────────────────────────────────────────────────── */
-
-.canvas-bands {
-  position: absolute;
-  inset: 0;
-  overflow: hidden;
-  pointer-events: none;
-  z-index: 1;
-}
-
-.canvas-band {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  border-left: 1px dashed var(--border-hairline);
-}
-
-.canvas-band:first-child {
-  border-left-color: transparent;
-}
-
-.canvas-band__header {
-  position: sticky;
-  top: 0;
-  display: inline-block;
-  margin: 8px 0 0 10px;
-  padding: 2px 10px;
-  font-size: var(--text-xs);
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-  background: color-mix(in oklab, var(--bg-panel) 80%, transparent);
-  border: 1px solid var(--border-hairline);
-  border-radius: 999px;
 }
 
 /* ── Toolbar ─────────────────────────────────────────────────────────────── */
@@ -104,146 +67,6 @@
   border-radius: 8px;
 }
 
-/* ── Issue node ──────────────────────────────────────────────────────────── */
-
-.canvas-issue {
-  position: relative;
-  width: 264px;
-  padding: 10px 12px;
-  background: var(--bg-panel);
-  border: 1px solid var(--border-hairline);
-  border-left: 3px solid var(--border-strong);
-  border-radius: 10px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  cursor: grab;
-}
-
-.canvas-issue:active {
-  cursor: grabbing;
-}
-
-.canvas-issue--running {
-  border-left-color: #6b8fbf;
-}
-.canvas-issue--review {
-  border-left-color: #b5892f;
-}
-.canvas-issue--blocked {
-  border-left-color: #b95050;
-}
-.canvas-issue--done {
-  border-left-color: #3f8f5b;
-}
-.canvas-issue--inbox,
-.canvas-issue--backlog {
-  border-left-color: var(--border-strong);
-}
-
-.canvas-issue__top {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-bottom: 6px;
-}
-
-.canvas-issue__prio {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--text-muted);
-  flex: none;
-}
-.canvas-issue__prio--urgent {
-  background: #d2533e;
-}
-.canvas-issue__prio--high {
-  background: #d98a2b;
-}
-.canvas-issue__prio--medium {
-  background: #6b8fbf;
-}
-.canvas-issue__prio--low {
-  background: var(--text-muted);
-}
-
-.canvas-issue__status {
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  color: var(--text-muted);
-}
-
-.canvas-issue__num {
-  margin-left: auto;
-  font-size: 11px;
-  color: var(--text-muted);
-}
-
-.canvas-issue__title {
-  display: block;
-  width: 100%;
-  text-align: left;
-  font-size: var(--text-sm);
-  font-weight: 600;
-  line-height: 1.3;
-  color: var(--text-primary);
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-.canvas-issue__title:hover {
-  color: var(--accent, var(--text-primary));
-}
-
-.canvas-issue__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  margin-top: 8px;
-}
-
-.canvas-issue__familiar {
-  font-size: 11px;
-  color: var(--text-secondary);
-}
-
-.canvas-issue__label {
-  font-size: 10px;
-  padding: 1px 6px;
-  border-radius: 999px;
-  background: var(--bg-raised);
-  color: var(--text-muted);
-  border: 1px solid var(--border-hairline);
-}
-
-.canvas-issue__open {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  color: var(--text-muted);
-  background: var(--bg-raised);
-  border: 1px solid var(--border-hairline);
-  border-radius: 6px;
-  cursor: pointer;
-}
-
-.canvas-issue__open:hover {
-  color: var(--text-primary);
-  background: var(--bg-hover);
-}
-
 /* ── Empty state ─────────────────────────────────────────────────────────── */
 
 .canvas-empty {
@@ -274,34 +97,6 @@
 .canvas-empty__hint {
   font-size: var(--text-sm);
   max-width: 340px;
-}
-
-/* ── Sketch layer: segmented toggle ──────────────────────────────────────── */
-
-.canvas-segmented {
-  display: inline-flex;
-  padding: 2px;
-  gap: 2px;
-  background: var(--bg-raised);
-  border: 1px solid var(--border-hairline);
-  border-radius: 8px;
-}
-
-.canvas-segmented__btn {
-  padding: 3px 12px;
-  font-size: var(--text-xs);
-  font-weight: 600;
-  color: var(--text-muted);
-  background: none;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-}
-
-.canvas-segmented__btn.is-active {
-  color: var(--text-primary);
-  background: var(--bg-panel);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
 }
 
 /* ── Sketch layer: prompt composer ───────────────────────────────────────── */


### PR DESCRIPTION
Recovers a dropped session's branch (`feat/canvas-remove-triage` @ 25b209d5) and lands it rebased onto current `main`.

Removes the Canvas **triage layer** entirely — the status bands, the layer toggle (`cave:canvas:layer`), and all board reads/mutations (`/api/board`). Canvas is now **sketch-only**: an infinite surface for ad-hoc generated UIs rendered in sandboxed iframes.

`canvas-view.tsx` shrinks by ~412 lines and `canvas.css` by ~209.

## Rebase / conflict resolution
The branch's base predated #1015 (sketch-delete confirm) and #1017 (React Flow `useNodesState`), both of which rewrote `canvas-view.tsx`. Resolved by keeping those improvements on top of the sketch-only structure:
- kept #1017's managed `useNodesState` / `applyNodesChange` (dropped the old manual `applyNodeChanges`/`setNodes`)
- dropped the board `patchStatus` handler and the now-unused `useViewport` import (both were triage-only)
- updated the test to assert the managed node-state hook and drop the removed `resolvePositions` assertion

Landed on a fresh branch (`feat/canvas-sketch-only`) rather than force-pushing the original, since another live session was operating on that worktree.

## Verification
- `pnpm typecheck` — ✅ clean
- `pnpm test:app` — ✅ 314 test files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)