### PR TITLE
Add familiar menu bar

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -306,6 +306,7 @@ export const SUITES = {
     "src/components/ui/tabs.test.ts",
     "src/components/security/sidecar-auth-bridge.test.ts",
     "src/components/familiar-switcher.test.ts",
+    "src/components/familiar-menu-bar.test.ts",
     "src/lib/salem/happy-paths.test.ts",
     "src/lib/salem/pathfinder-match.test.ts",
     "src/lib/salem/pathfinder-card.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3821,6 +3821,165 @@ button:active > .edge-rail-chip {
    keyboard shortcuts keep search available.
    ──────────────────────────────────────────────── */
 
+/* Desktop top menu bar — quick chat with familiars (left) + view tasks
+   (right). Hidden below 1024px, where the mobile `.top-bar` takes over (the
+   two are mutually exclusive so they never both render). Lives in the Shell's
+   `topBar` slot above `.shell-body`. */
+.menu-bar {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 12px;
+  height: 44px;
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border-hairline);
+  font-size: var(--text-sm);
+  user-select: none;
+}
+
+@media (min-width: 1024px) {
+  .menu-bar {
+    display: flex;
+  }
+}
+
+.menu-bar__group {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.menu-bar__group--chat {
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+
+.menu-bar__group--tasks {
+  flex: 0 0 auto;
+}
+
+/* The labeled switcher trigger is full-width in the sidebar; in the menu bar it
+   should size to its content so the avatar strip takes the flexible space. */
+.menu-bar__group--chat .familiar-switcher__trigger {
+  flex: 0 0 auto;
+  width: auto;
+  max-width: 200px;
+}
+
+.menu-bar__familiars {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin: 0;
+  padding: 0 2px;
+  list-style: none;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.menu-bar__familiars::-webkit-scrollbar {
+  display: none;
+}
+
+.menu-bar__familiar {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius-control);
+  background: transparent;
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+
+.menu-bar__familiar:hover {
+  background: color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 16%, transparent);
+  border-color: color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 40%, transparent);
+}
+
+.menu-bar__presence {
+  position: absolute;
+  right: 1px;
+  bottom: 1px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  border: 1.5px solid var(--bg-panel);
+}
+
+.menu-bar__familiar-unread {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-warning);
+  border: 1.5px solid var(--bg-panel);
+}
+
+.menu-bar__new,
+.menu-bar__task {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-base);
+  color: var(--foreground);
+  font-size: var(--text-sm);
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+
+.menu-bar__new {
+  flex: 0 0 auto;
+  color: var(--foreground);
+  background: color-mix(in oklch, var(--accent-presence) 26%, transparent);
+  border-color: color-mix(in oklch, var(--accent-presence) 55%, transparent);
+}
+
+.menu-bar__new:hover {
+  background: color-mix(in oklch, var(--accent-presence) 38%, transparent);
+}
+
+.menu-bar__task:hover {
+  background: var(--bg-raised);
+  border-color: var(--border-strong);
+}
+
+.menu-bar__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 17px;
+  height: 17px;
+  padding: 0 5px;
+  border-radius: 9px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--accent-presence-foreground);
+  background: color-mix(in oklch, var(--accent-presence) 60%, transparent);
+}
+
+.menu-bar__badge--alert {
+  color: #fff;
+  background: var(--color-warning);
+}
+
 .top-bar {
   display: none;
   grid-template-columns: 1fr minmax(auto, 560px) 1fr;

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -85,10 +85,13 @@ assert.match(
   /\{\s*id:\s*"memory",\s*label:\s*"Memory"\s*\}/,
   "ChatSurface should label the secondary primary tab Memory instead of Traces",
 );
-assert.match(
+// Familiar selection now lives in the global top menu bar (and the sidebar /
+// mobile top-bar switcher), so the chat header carries only its scope tabs —
+// no duplicate switcher here.
+assert.doesNotMatch(
   chatSurface,
-  /<FamiliarSwitcher[\s\S]*activeFamiliarId=\{activeFamiliarId\}[\s\S]*onSelectFamiliar=\{\(id\) => \{/,
-  "ChatSurface should move familiar selection into the page header",
+  /<FamiliarSwitcher/,
+  "ChatSurface should not duplicate the global familiar switcher in its header",
 );
 assert.match(
   chatSurface,

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -13,7 +13,6 @@ import { SeparatorHandle } from "@/components/ui/separator-handle";
 import { useIsMobile } from "@/lib/use-viewport";
 import { Tabs } from "@/components/ui/tabs";
 import { Icon } from "@/lib/icon";
-import { FamiliarSwitcher } from "@/components/familiar-switcher";
 import { CodeInlineToolbar } from "@/components/code-inline-toolbar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import type { InboxItem } from "@/lib/cave-inbox";
@@ -530,29 +529,9 @@ export function ChatSurface({
         {/* ── Ultra-minimalist header ────────────────────────────────────── */}
         <div className="chat-scope-tabs chat-scope-tabs--minimal flex shrink-0 items-center justify-between gap-3 border-b border-[var(--border-hairline)] px-4">
           <div className="flex min-w-0 items-center gap-3">
-            {/* Code mode crowds this row with layout presets + the panel toggle,
-                so the familiar scope collapses to a compact avatar there. */}
-            <div
-              className={`chat-surface__familiar-scope flex min-w-0 shrink-0 py-1.5 ${
-                isCodeSurface ? "" : "w-[min(220px,34vw)] max-sm:w-[min(168px,42vw)]"
-              }`}
-            >
-              <FamiliarSwitcher
-                familiars={resolvedFamiliars}
-                activeFamiliarId={activeFamiliarId}
-                sessions={sessions}
-                onSelectFamiliar={(id) => {
-                  onSetActiveFamiliar(id);
-                  setScope("conversation");
-                  window.setTimeout(() => routerRef.current?.goToList(), 0);
-                }}
-                placement="bottom-start"
-                labeled={!isCodeSurface}
-              />
-            </div>
-            <span aria-hidden className="h-5 w-px shrink-0 bg-[var(--border-hairline)]" />
-            {/* Tabs flush left — Vercel-style underline tabs. The header row
-                already draws the divider, so the tablist itself is borderless. */}
+            {/* The active familiar is selected from the global top menu bar /
+                switcher now, so the chat header carries only its scope tabs.
+                Vercel-style borderless underline tabs, flush left. */}
             <Tabs<FamiliarsScope>
               bordered={false}
               value={scope}

--- a/src/components/familiar-menu-bar.test.ts
+++ b/src/components/familiar-menu-bar.test.ts
@@ -1,0 +1,106 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./familiar-menu-bar.tsx", import.meta.url), "utf8");
+const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+
+// The bar has exactly two jobs: chat with familiars (left) and view tasks
+// (right). It is a labelled landmark so screen readers can find it.
+assert.match(
+  source,
+  /<nav className="menu-bar" aria-label="Chat with familiars and view tasks">/,
+  "renders a labelled menu-bar landmark",
+);
+
+// Left group — chat. Includes the full switcher plus a one-click avatar strip
+// where clicking an avatar starts a chat with that familiar.
+assert.match(
+  source,
+  /<FamiliarSwitcher[\s\S]*onSelectFamiliar=\{onSelectFamiliar\}/,
+  "embeds the familiar switcher for scope/full list",
+);
+assert.match(
+  source,
+  /className="menu-bar__familiar focus-ring"[\s\S]*onClick=\{\(\) => onChatWithFamiliar\(f\.id\)\}/,
+  "clicking a familiar avatar starts a chat with that familiar",
+);
+assert.match(
+  source,
+  /aria-label=\{`Chat with \$\{f\.display_name\}`\}/,
+  "each avatar button names the familiar it chats with",
+);
+assert.match(
+  source,
+  /computePresence\(\{/,
+  "avatars compute presence for the status dot",
+);
+assert.match(
+  source,
+  /className="menu-bar__new focus-ring"[\s\S]*onClick=\{\(\) => onChatWithFamiliar\(activeFamiliarId\)\}/,
+  "the New chat button starts a chat with the active familiar",
+);
+
+// Right group — tasks. A Tasks button (board) and an Inbox button, each with a
+// live count badge that is hidden at zero.
+assert.match(
+  source,
+  /className="menu-bar__task focus-ring"[\s\S]*onClick=\{onViewTasks\}/,
+  "the Tasks button jumps to the board",
+);
+assert.match(
+  source,
+  /taskCount > 0 \? <span className="menu-bar__badge">\{fmtBadge\(taskCount\)\}<\/span> : null/,
+  "the Tasks badge shows the open-task count and hides at zero",
+);
+assert.match(
+  source,
+  /onClick=\{onViewInbox\}/,
+  "the Inbox button jumps to the inbox",
+);
+assert.match(
+  source,
+  /inboxCount > 0 \? \(\s*<span className="menu-bar__badge menu-bar__badge--alert">/,
+  "the Inbox badge shows the attention count and hides at zero",
+);
+
+// Wiring in the workspace: the bar mounts in the Shell topBar slot with the
+// real chat/scope/navigation handlers and live counts.
+assert.match(
+  workspace,
+  /<FamiliarMenuBar[\s\S]*onChatWithFamiliar=\{\(id\) => startFamiliarChat\(id\)\}/,
+  "the bar's chat handler starts a real familiar chat",
+);
+assert.match(
+  workspace,
+  /onViewTasks=\{\(\) => setMode\("board"\)\}/,
+  "View tasks switches to the board surface",
+);
+assert.match(
+  workspace,
+  /onViewInbox=\{\(\) => setMode\("inbox"\)\}/,
+  "View inbox switches to the inbox surface",
+);
+assert.match(
+  workspace,
+  /taskCount=\{boardTaskCount\}[\s\S]*inboxCount=\{inboxBadgeCount\}/,
+  "the bar is fed the live board task count and inbox badge count",
+);
+
+// The board task count is polled from /api/board (open = not done).
+assert.match(
+  workspace,
+  /fetch\("\/api\/board"[\s\S]*\.filter\(\s*\(c\) => c\.status !== "done",?\s*\)\.length/,
+  "boardTaskCount counts cards that are not yet done",
+);
+
+// Desktop-only: the bar shows ≥1024px (where the mobile .top-bar is hidden).
+assert.match(globals, /\.menu-bar \{\s*display: none;/, "menu bar is hidden by default");
+assert.match(
+  globals,
+  /@media \(min-width: 1024px\) \{\s*\.menu-bar \{\s*display: flex;/,
+  "menu bar shows on desktop (≥1024px)",
+);
+
+console.log("familiar-menu-bar.test.ts: ok");

--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { Icon } from "@/lib/icon";
+import { FamiliarAvatar } from "@/components/familiar-avatar";
+import { FamiliarSwitcher } from "@/components/familiar-switcher";
+import { computePresence, REMOTE_HARNESSES } from "@/lib/presence";
+import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
+import type { SessionRow } from "@/lib/types";
+
+type Props = {
+  familiars: ResolvedFamiliar[];
+  activeFamiliarId: string | null;
+  sessions: SessionRow[];
+  responseNeeded?: Set<string>;
+  /** Open task count (board cards not yet done) — drives the Tasks badge. */
+  taskCount: number;
+  /** Items needing attention — drives the Inbox badge. */
+  inboxCount: number;
+  /** Start a chat with a familiar (`null` = the active/default familiar). */
+  onChatWithFamiliar: (id: string | null) => void;
+  /** Change the active-familiar scope (the switcher menu's "All"/per-familiar). */
+  onSelectFamiliar: (id: string | null) => void;
+  /** Jump to the task board. */
+  onViewTasks: () => void;
+  /** Jump to the inbox / schedules. */
+  onViewInbox: () => void;
+};
+
+// How many familiars get a one-click chat avatar before the rest fold into the
+// switcher menu. Keeps the bar legible on narrower desktop widths.
+const MAX_QUICK_CHAT = 6;
+
+function fmtBadge(n: number): string {
+  return n > 99 ? "99+" : String(n);
+}
+
+/**
+ * A slim, always-visible desktop top menu bar with exactly two jobs: start a
+ * chat with a familiar (the avatar strip + switcher on the left) and view tasks
+ * (the Tasks/Inbox buttons with live counts on the right). It is the desktop
+ * counterpart to the mobile `.top-bar` (which stays hidden ≥1024px); this bar
+ * is hidden below 1024px so the two never both render.
+ */
+export function FamiliarMenuBar({
+  familiars,
+  activeFamiliarId,
+  sessions,
+  responseNeeded,
+  taskCount,
+  inboxCount,
+  onChatWithFamiliar,
+  onSelectFamiliar,
+  onViewTasks,
+  onViewInbox,
+}: Props) {
+  const quickChat = familiars.slice(0, MAX_QUICK_CHAT);
+
+  return (
+    <nav className="menu-bar" aria-label="Chat with familiars and view tasks">
+      <div className="menu-bar__group menu-bar__group--chat">
+        <FamiliarSwitcher
+          familiars={familiars}
+          activeFamiliarId={activeFamiliarId}
+          sessions={sessions}
+          responseNeeded={responseNeeded}
+          onSelectFamiliar={onSelectFamiliar}
+          placement="bottom-start"
+          labeled
+        />
+
+        {quickChat.length > 0 ? (
+          <ul className="menu-bar__familiars" aria-label="Chat with a familiar">
+            {quickChat.map((f) => {
+              const needsReply = responseNeeded?.has(f.id) ?? false;
+              const presence = computePresence({
+                familiar: f,
+                sessions,
+                needsReply,
+                isRemoteHarness: f.harness ? REMOTE_HARNESSES.has(f.harness) : false,
+              });
+              return (
+                <li key={f.id}>
+                  <button
+                    type="button"
+                    className="menu-bar__familiar focus-ring"
+                    style={{ ["--familiar-accent" as string]: f.color } as CSSProperties}
+                    onClick={() => onChatWithFamiliar(f.id)}
+                    aria-label={`Chat with ${f.display_name}`}
+                    title={`Chat with ${f.display_name} · ${presence.label}`}
+                  >
+                    <FamiliarAvatar familiar={f} size="sm" />
+                    <span className={`menu-bar__presence ${presence.dot}`} aria-hidden />
+                    {needsReply ? <span className="menu-bar__familiar-unread" aria-hidden /> : null}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
+
+        <button
+          type="button"
+          className="menu-bar__new focus-ring"
+          onClick={() => onChatWithFamiliar(activeFamiliarId)}
+          aria-label="Start a new chat"
+        >
+          <Icon name="ph:chat-circle-dots" width={14} aria-hidden />
+          <span>New chat</span>
+        </button>
+      </div>
+
+      <div className="menu-bar__group menu-bar__group--tasks">
+        <button
+          type="button"
+          className="menu-bar__task focus-ring"
+          onClick={onViewTasks}
+          aria-label={taskCount > 0 ? `View tasks — ${taskCount} open` : "View tasks"}
+        >
+          <Icon name="ph:kanban" width={15} aria-hidden />
+          <span>Tasks</span>
+          {taskCount > 0 ? <span className="menu-bar__badge">{fmtBadge(taskCount)}</span> : null}
+        </button>
+        <button
+          type="button"
+          className="menu-bar__task focus-ring"
+          onClick={onViewInbox}
+          aria-label={inboxCount > 0 ? `View inbox — ${inboxCount} need attention` : "View inbox"}
+        >
+          <Icon name="ph:tray" width={15} aria-hidden />
+          <span>Inbox</span>
+          {inboxCount > 0 ? (
+            <span className="menu-bar__badge menu-bar__badge--alert">{fmtBadge(inboxCount)}</span>
+          ) : null}
+        </button>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -68,6 +68,7 @@ import {
 } from "@/lib/demo-mode";
 import { useShellBanners } from "@/lib/shell-banners";
 import { TopBar } from "@/components/top-bar";
+import { FamiliarMenuBar } from "@/components/familiar-menu-bar";
 import type { PendingChatAction } from "@/lib/pending-chat-action";
 
 type WorkspaceMode = WorkspaceModeFromDaemon;
@@ -188,6 +189,7 @@ export function Workspace() {
   const [onboardingOpen, setOnboardingOpen] = useState(false);
   const [inboxItems, setInboxItems] = useState<InboxItem[]>([]);
   const [escalationsUnresolved, setEscalationsUnresolved] = useState(0);
+  const [boardTaskCount, setBoardTaskCount] = useState(0);
   const [inboxPrefs, setInboxPrefs] = useState<InboxPrefs>({
     version: 1,
     mutedFamiliars: [],
@@ -762,6 +764,33 @@ export function Workspace() {
     };
     void tick();
     const t = setInterval(tick, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, []);
+
+  // Poll the board for the count of open task cards (anything not yet "done")
+  // — drives the desktop menu bar's Tasks badge. Cheap GET every 60s.
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const res = await fetch("/api/board", { cache: "no-store" });
+        const json = await res.json();
+        if (cancelled) return;
+        if (json.ok && Array.isArray(json.cards)) {
+          const open = (json.cards as Array<{ status?: string }>).filter(
+            (c) => c.status !== "done",
+          ).length;
+          setBoardTaskCount(open);
+        }
+      } catch {
+        /* keep last value on transient failure */
+      }
+    };
+    void tick();
+    const t = setInterval(tick, 60_000);
     return () => {
       cancelled = true;
       clearInterval(t);
@@ -1652,7 +1681,20 @@ export function Workspace() {
           if (activeId) setRailOpen(activeId, open);
         }}
         topBar={({ navDrawerOpen, listDrawerOpen, familiarDrawerOpen }) => (
-          <TopBar
+          <>
+            <FamiliarMenuBar
+              familiars={resolvedFamiliars}
+              activeFamiliarId={activeId}
+              sessions={sessions}
+              responseNeeded={responseNeeded}
+              taskCount={boardTaskCount}
+              inboxCount={inboxBadgeCount}
+              onChatWithFamiliar={(id) => startFamiliarChat(id)}
+              onSelectFamiliar={selectFamiliarScope}
+              onViewTasks={() => setMode("board")}
+              onViewInbox={() => setMode("inbox")}
+            />
+            <TopBar
             onOpenPalette={() => setPaletteOpen(true)}
             onOpenInbox={() => setMode("inbox")}
             onOpenSettings={() => nextRouter.push("/settings")}
@@ -1685,6 +1727,7 @@ export function Workspace() {
                 : undefined
             }
           />
+          </>
         )}
         nav={sidebar}
         list={list}


### PR DESCRIPTION
## Summary
- Add `FamiliarMenuBar` for desktop familiar chat/task access.
- Integrate the menu bar into `Workspace` and wire board task counts from `/api/board`.
- Remove the duplicate familiar switcher from the chat surface and wire the new component test into the app suite.

## Test Plan
- `pnpm check:tests-wired`
- `node --experimental-strip-types src/components/familiar-menu-bar.test.ts`
- `node --experimental-strip-types src/components/chat-surface.test.ts`
- `pnpm typecheck`
- `pnpm build`