### PR TITLE
feat(shell): move side-panel triggers up into the top menu bar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3184,231 +3184,79 @@ button:active > .edge-rail-chip {
 }
 
 /* ────────────────────────────────────────────────
-   Edge panel toggles (Codex-style)
-   Full-height invisible strips pinned to the shell's left/right edges. Hover
-   or keyboard focus reveals the small aligned chip; clicking anywhere along
-   the strip toggles the corresponding side panel.
+   Top-bar panel toggles
+   The side-panel triggers live in the desktop top menu bar: the nav toggle
+   anchors the bar's left edge, the side-panel + expand toggles its right edge.
+   They share the bar's height/background so they read as one continuous strip.
+   Desktop-only — they're rendered only when !isMobile (≥1024px), matching the
+   `.menu-bar` breakpoint; below that the mobile `.top-bar` carries its own.
    ──────────────────────────────────────────────── */
-.shell-body--floats {
-  position: relative;
+.shell-top {
+  display: flex;
+  align-items: stretch;
+  flex: 0 0 auto;
 }
 
-/* Clear the floating top-left toggle so it doesn't sit on top of the sidebar
-   wordmark, while keeping the wordmark's left edge aligned with the nav-card
-   content column below it (Salem / New session / Home). The left float is 28px
-   wide at left:8 (right edge 36); 15px lands the wordmark just clear of it, at
-   the same indent as the card icons. Scoped to the desktop shell — the floats
-   are desktop-only. */
-.shell-body--floats .sidebar-header--static {
-  padding-left: 15px;
+.shell-top__bar {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
-.shell-panel-float {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  z-index: 40;
-  display: block;
-  width: 44px;
-  height: 100%;
+.shell-top-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 40px;
+  height: 44px;
   border: 0;
-  border-radius: 0;
-  background: transparent;
+  border-bottom: 1px solid var(--border-hairline);
+  background: var(--bg-panel);
   color: color-mix(in oklch, var(--text-secondary) 86%, var(--text-primary));
-  box-shadow: none;
   cursor: pointer;
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
-  transition: color 120ms ease;
+  transition: color 120ms ease, background 120ms ease;
 }
 
-.shell-panel-float::before {
-  content: "";
-  position: absolute;
-  z-index: 1;
-  /* Vertically centered on the side-panel header row — the 38px Inspector/Debug/
-     Changes tab strip that sits directly below the ~45px chat scope-tabs header.
-     The trigger + expand toggle read as part of that header rather than floating
-     above it; both side strips use this same value so the chips stay level.
-     ChatSurface measures the live header and publishes --shell-float-top so the
-     floats track it through the post-load settle (no fixed-offset flash); the
-     50px fallback matches the settled position when no panel is open. */
-  top: var(--shell-float-top, 50px);
-  left: 50%;
-  width: 28px;
-  height: 28px;
-  border-radius: 8px;
-  border: 1px solid color-mix(in oklch, var(--text-muted) 34%, transparent);
-  background: color-mix(in oklch, var(--bg-raised) 86%, var(--bg-elevated));
-  color: color-mix(in oklch, var(--text-secondary) 86%, var(--text-primary));
-  box-shadow:
-    inset 0 1px 0 color-mix(in oklch, var(--text-primary) 10%, transparent),
-    0 6px 16px color-mix(in oklch, black 22%, transparent);
-  /* Fades in by cursor proximity (--float-prox, set per-float in shell.tsx);
-     :hover/:focus-visible below force it fully visible for direct interaction. */
-  opacity: var(--float-prox, 0);
-  transform: translateX(-50%);
-  -webkit-backdrop-filter: blur(8px);
-  backdrop-filter: blur(8px);
-  transition: background 120ms ease, border-color 120ms ease, box-shadow 120ms ease, opacity 120ms ease, transform 80ms ease;
+.shell-top-toggle:hover,
+.shell-top-toggle:focus-visible {
+  color: var(--text-primary);
+  background: color-mix(in oklch, var(--bg-raised) 70%, var(--bg-panel));
 }
 
-/* Pulsing accent halo behind the chip — gated by --float-prox so it only shows
-   (and pulses) as the cursor approaches the toggle. */
-.shell-panel-float::after {
-  content: "";
-  position: absolute;
-  top: var(--shell-float-top, 50px);
-  left: 50%;
-  width: 28px;
-  height: 28px;
-  border-radius: 10px;
-  z-index: 0;
-  pointer-events: none;
-  background: radial-gradient(circle, color-mix(in oklch, var(--accent-presence) 60%, transparent), transparent 70%);
-  opacity: 0;
-  transform: translateX(-50%) scale(1);
-  animation: shell-float-pulse 1800ms ease-in-out infinite;
-}
-
-@keyframes shell-float-pulse {
-  0%,
-  100% {
-    opacity: calc(var(--float-prox, 0) * 0.6);
-    transform: translateX(-50%) scale(1);
-  }
-  50% {
-    opacity: calc(var(--float-prox, 0) * 1);
-    transform: translateX(-50%) scale(1.55);
-  }
-}
-
-@keyframes shell-corner-float-pulse {
-  0%,
-  100% {
-    opacity: calc(var(--float-prox, 0) * 0.85);
-    transform: translate(var(--shell-float-glow-x), -14px) scale(1);
-  }
-  50% {
-    opacity: calc(var(--float-prox, 0) * 1.2);
-    transform: translate(var(--shell-float-glow-x), -14px) scale(1.7);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .shell-panel-float::after {
-    animation: none;
-    opacity: calc(var(--float-prox, 0) * 0.4);
-  }
-}
-
-.shell-panel-float > svg {
-  position: absolute;
-  top: calc(var(--shell-float-top, 50px) + 6.5px);
-  left: 50%;
-  z-index: 2;
-  opacity: var(--float-prox, 0);
-  pointer-events: none;
-  transform: translateX(-50%);
-  transition: opacity 120ms ease, color 120ms ease, transform 80ms ease;
-}
-
-.shell-panel-float--left {
-  left: 0;
-}
-
-.shell-panel-float--right {
-  right: 0;
-}
-
-/* Expand-to-cover toggle: pinned one button-width + gap to the left of the
-   side-panel trigger (8 + 28 + 8). Hidden until a chat right panel is actually
-   open, and re-hidden while expanded (the in-panel Restore button takes over). */
-.shell-panel-float--expand {
-  top: var(--shell-float-top, 50px);
-  right: 44px;
-  bottom: auto;
-  z-index: 40;
-  place-items: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 8px;
-  border: 1px solid color-mix(in oklch, var(--text-muted) 34%, transparent);
-  background: color-mix(in oklch, var(--bg-raised) 86%, var(--bg-elevated));
-  box-shadow:
-    inset 0 1px 0 color-mix(in oklch, var(--text-primary) 10%, transparent),
-    0 6px 16px color-mix(in oklch, black 22%, transparent);
-  -webkit-backdrop-filter: blur(8px);
-  backdrop-filter: blur(8px);
-  display: none;
-}
-.shell-panel-float--expand::before {
-  content: none;
-}
-.shell-panel-float--expand > svg {
-  position: static;
-  opacity: 1;
-  transform: none;
-}
-.shell-panel-float--expand:active {
+.shell-top-toggle:active {
   transform: scale(0.94);
 }
-:root[data-right-panel-open] .shell-panel-float--expand {
-  display: grid;
-}
-:root[data-right-panel-expanded] .shell-panel-float--expand {
-  display: none;
+
+/* Open state: accent-tinted to match the panel it controls. */
+.shell-top-toggle--active {
+  color: var(--accent-presence);
 }
 
 /* The Phosphor sidebar glyph points at a left panel; mirror it on the right
    toggle so it reads as a right-edge panel. */
-.shell-panel-float--right > svg {
-  transform: translateX(-50%) scaleX(-1);
+.shell-top-toggle--right > svg {
+  transform: scaleX(-1);
 }
 
-.shell-panel-float:hover,
-.shell-panel-float:focus-visible {
-  color: var(--text-primary);
+/* Expand-to-cover toggle: hidden until a chat right panel is actually open
+   (:root[data-right-panel-open]), and re-hidden while expanded (the in-panel
+   Restore button takes over). */
+.shell-top-toggle--expand {
+  display: none;
 }
-
-.shell-panel-float:hover::before,
-.shell-panel-float:focus-visible::before,
-.shell-panel-float:hover > svg,
-.shell-panel-float:focus-visible > svg {
-  opacity: 1;
+:root[data-right-panel-open] .shell-top-toggle--expand {
+  display: inline-flex;
 }
-
-.shell-panel-float:hover::before,
-.shell-panel-float:focus-visible::before {
-  background: var(--bg-elevated);
-  border-color: color-mix(in oklch, var(--text-muted) 48%, transparent);
-}
-
-.shell-panel-float:active::before {
-  transform: translateX(-50%) scale(0.94);
-}
-
-/* Open state: accent-tinted, matching the edge-rail "expanded" treatment. */
-.shell-panel-float--active {
-  color: var(--text-primary);
-}
-
-.shell-panel-float--active::before {
-  border-color: color-mix(in oklch, var(--accent-presence) 58%, var(--border-hairline));
-  background: color-mix(in oklch, var(--accent-presence) 18%, var(--bg-raised));
-}
-
-/* When the chat right panel is expanded it covers the whole chat surface; the
-   right edge-rail float would otherwise float above it (z-40) and intercept the
-   panel's top-right Close button. Hide it while expanded. */
-:root[data-right-panel-expanded] .shell-panel-float--right {
+:root[data-right-panel-expanded] .shell-top-toggle--expand {
   display: none;
 }
 
-/* Code surface hoists the companion-panel toggle onto its tab row
-   (.code-panel-toggle in CodeInlineToolbar), so hide the shell's floating right
-   toggle while that surface is mounted — otherwise there'd be two. */
-:root[data-code-inline-toolbar] .shell-panel-float--right {
+/* While the chat right panel is expanded it covers the whole surface, so the
+   side-panel toggle is redundant; and the Code surface hoists its own companion
+   toggle onto its tab row (.code-panel-toggle), so suppress the shell's there
+   too — otherwise there'd be two. */
+:root[data-right-panel-expanded] .shell-top-toggle--right,
+:root[data-code-inline-toolbar] .shell-top-toggle--right {
   display: none;
 }
 
@@ -3571,10 +3419,8 @@ button:active > .edge-rail-chip {
 .companion-rail__tabs {
   display: flex;
   gap: 2px;
-  /* The side-panel trigger is now pinned flush into the top-right window corner
-     (.shell-panel-float--right::before — a 35px notch at top:0), not centered on
-     --shell-float-top. Sit the tab strip flush at the panel's top so its icon row
-     lines up with that corner trigger instead of dropping ~50px below it. */
+  /* The side-panel trigger lives in the top menu bar now; sit the tab strip
+     flush at the panel's top so its icon row reads as the panel's own header. */
   margin-top: 0;
   padding: 5px 8px;
   border-bottom: 1px solid var(--border-hairline);
@@ -6524,92 +6370,35 @@ a.mobile-handoff__link:hover {
   border-radius: 4px;
 }
 
-/* ── Corner sidepanel triggers ───────────────────────────────────────────────
-   Pin the left/right sidepanel toggles flush into the upper window corners:
-   inset 0, with the two window-meeting edges squared and a tighter radius so
-   each reads as a compact notch carved into the corner. Border + a soft
-   shadow live only on the inner edges (facing the content). Overrides the
-   hover-reveal, --shell-float-top-centered base for --left/--right only; the
-   expand toggle keeps its centered position. */
-.shell-panel-float--left::before,
-.shell-panel-float--right::before {
-  top: 0;
-  width: 35px;
-  height: 35px;
-  opacity: 1;
-  border: none;
+/* ── Magic cast: sparkle the side-panel toggle on click ──────────────────────
+   When MagicTriggers fires a top-bar panel toggle, flash a one-shot purple
+   sparkle centered on the button — a small "spell cast" pulse. Purple is fixed
+   (not theme accent) so the magic always reads violet. */
+.shell-top-toggle {
+  position: relative;
 }
-.shell-panel-float--left > svg,
-.shell-panel-float--right > svg {
-  top: 10px;
-  opacity: 1;
+.shell-top-toggle.magic-cast::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 28px;
+  height: 28px;
+  border-radius: 10px;
   pointer-events: none;
-}
-.shell-panel-float--left::after,
-.shell-panel-float--right::after {
-  top: 0;
-  width: 64px;
-  height: 64px;
-  background: radial-gradient(circle, color-mix(in oklch, var(--accent-presence) 95%, transparent), transparent 70%);
-  animation-name: shell-corner-float-pulse;
-}
-.shell-panel-float--left::before {
-  left: 0;
-  transform: none;
-  border-radius: 8px 0 6px 0;
-  border-right: 1px solid color-mix(in oklch, var(--text-muted) 34%, transparent);
-  border-bottom: 1px solid color-mix(in oklch, var(--text-muted) 34%, transparent);
-  box-shadow: 3px 3px 12px color-mix(in oklch, black 22%, transparent);
-}
-.shell-panel-float--left > svg {
-  left: 10px;
-  transform: none;
-}
-.shell-panel-float--left::after {
-  left: 0;
-  --shell-float-glow-x: -14px;
-  transform: translate(-14px, -14px) scale(1);
-}
-.shell-panel-float--right::before {
-  left: auto;
-  right: 0;
-  transform: none;
-  border-radius: 0 8px 0 6px;
-  border-left: 1px solid color-mix(in oklch, var(--text-muted) 34%, transparent);
-  border-bottom: 1px solid color-mix(in oklch, var(--text-muted) 34%, transparent);
-  box-shadow: -3px 3px 12px color-mix(in oklch, black 22%, transparent);
-}
-.shell-panel-float--right > svg {
-  left: auto;
-  right: 10px;
-  transform: none;
-}
-.shell-panel-float--right::after {
-  left: auto;
-  right: 0;
-  --shell-float-glow-x: 14px;
-  transform: translate(14px, -14px) scale(1);
-}
-
-/* ── Magic cast: open the sidepanel from a distance ──────────────────────────
-   When MagicTriggers fires the corner toggle (cursor close enough that the glow
-   has gone purple), flash a one-shot purple sparkle by overriding the proximity
-   halo (::after) with an expanding bright-purple burst — a small "spell cast"
-   pulse. Purple is fixed (not theme accent) so the magic always reads violet. */
-.shell-panel-float.magic-cast::after {
+  z-index: 1;
   /* White-hot violet core + a 4-point sparkle star (two crossed bright lines),
      flashing and bursting outward with a rotate — a dramatic one-shot spell. */
   background:
     radial-gradient(circle, #ffffff 0%, color-mix(in oklch, #a855f7 92%, white 22%) 22%, color-mix(in oklch, #a855f7 72%, transparent) 46%, transparent 66%),
     linear-gradient(0deg, transparent 46%, color-mix(in oklch, #ffffff 82%, #a855f7) 49%, color-mix(in oklch, #ffffff 82%, #a855f7) 51%, transparent 54%),
-    linear-gradient(90deg, transparent 46%, color-mix(in oklch, #ffffff 82%, #a855f7) 49%, color-mix(in oklch, #ffffff 82%, #a855f7) 51%, transparent 54%) !important;
-  opacity: 1 !important;
-  animation: magic-cast-sparkle 820ms cubic-bezier(0.18, 0.7, 0.2, 1) !important;
+    linear-gradient(90deg, transparent 46%, color-mix(in oklch, #ffffff 82%, #a855f7) 49%, color-mix(in oklch, #ffffff 82%, #a855f7) 51%, transparent 54%);
+  animation: magic-cast-sparkle 820ms cubic-bezier(0.18, 0.7, 0.2, 1);
 }
 @keyframes magic-cast-sparkle {
   0% {
     opacity: 1;
-    transform: translate(var(--shell-float-glow-x, 0px), -14px) scale(0.3) rotate(0deg);
+    transform: scale(0.3) rotate(0deg);
     filter: brightness(2.4) drop-shadow(0 0 12px color-mix(in oklch, #a855f7 90%, transparent));
   }
   55% {
@@ -6617,8 +6406,13 @@ a.mobile-handoff__link:hover {
   }
   100% {
     opacity: 0;
-    transform: translate(var(--shell-float-glow-x, 0px), -14px) scale(5) rotate(45deg);
+    transform: scale(2.4) rotate(45deg);
     filter: brightness(1) drop-shadow(0 0 0 transparent);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .shell-top-toggle.magic-cast::after {
+    animation: none;
   }
 }
 

--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -89,14 +89,13 @@ assert.doesNotMatch(
   "The inline project-chip picker is folded into the session overflow menu",
 );
 
-// The right floating panel toggle (.shell-panel-float--right) overlays the
-// top-right corner; with no right panel open the header runs full-width and its
-// actions (find + ⋮ menu) would land under the toggle. A guarded gutter clears
-// them — without it the session overflow menu is unclickable.
-assert.match(
+// The side-panel toggle moved up into the top menu bar, so it no longer overlays
+// the chat header's top-right corner — the panel-closed right gutter that used
+// to clear it is gone, and the header runs flush to the edge.
+assert.doesNotMatch(
   styles,
   /:root:not\(\[data-right-panel-open\]\)\s*\.cave-chat-linear-header\s*\{[^}]*padding-right:\s*44px/,
-  "Chat header reserves a right gutter (panel-closed) so its actions clear the floating panel toggle",
+  "Chat header no longer reserves a right gutter for the retired floating panel toggle",
 );
 
 assert.doesNotMatch(

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -426,8 +426,8 @@ export function ChatSurface({
     return () => window.removeEventListener("keydown", onKey);
   }, [rightExpanded]);
 
-  // The expand affordance lives in the shell's floating toggle cluster
-  // (.shell-panel-float--expand), a different subtree, so it reaches the expand
+  // The expand affordance lives in the shell's top-bar toggle cluster
+  // (.shell-top-toggle--expand), a different subtree, so it reaches the expand
   // state through a window event — the same bridge pattern as cave:inspector-open.
   // The reset effect above clears rightExpanded if the panel closes, so this is
   // safe to fire unconditionally.
@@ -437,7 +437,7 @@ export function ChatSurface({
     return () => window.removeEventListener("cave:right-panel-expand", onExpand);
   }, []);
 
-  // Flag right-panel-open on the document root so the shell's floating expand
+  // Flag right-panel-open on the document root so the shell's top-bar expand
   // toggle (in shell.tsx, outside this subtree) shows only when there's actually
   // a panel to expand. Mirrors the desktop placement: conversation scope only.
   useEffect(() => {
@@ -449,7 +449,7 @@ export function ChatSurface({
   }, [rightPanel, isMobile, scope]);
 
   // The Code surface hosts the companion-panel toggle inline (CodeInlineToolbar
-  // on the tab row), so flag the root to hide the shell's floating right toggle
+  // on the tab row), so flag the root to hide the shell's top-bar right toggle
   // while this surface is mounted — otherwise there'd be two of them.
   useEffect(() => {
     if (!isCodeSurface) return;
@@ -458,61 +458,10 @@ export function ChatSurface({
     return () => root.removeAttribute("data-code-inline-toolbar");
   }, [isCodeSurface]);
 
-  // Keep the shell's floating toggles (left nav, expand, side-panel trigger)
-  // vertically centered on the LIVE side-panel header. Its top can shift while
-  // the layout settles after load (e.g. transient chrome above the panel), so a
-  // fixed CSS offset flashes out of alignment. Publish the header's centered top
-  // as a root CSS var the floats consume (--shell-float-top), and track it via a
-  // short rAF loop that runs only until the value holds steady, plus a resize
-  // re-arm. Falls back to the CSS default when there's no panel to align to.
-  useEffect(() => {
-    if (isMobile || scope !== "conversation" || rightPanel === null || rightExpanded) return;
-    const root = document.documentElement;
-    const FLOAT_H = 28;
-    let raf = 0;
-    let steady = 0;
-    let last = Number.NaN;
-    const measure = () => {
-      const header = document.querySelector(".right-panel-tabs");
-      if (header) {
-        const r = header.getBoundingClientRect();
-        const top = Math.round(r.top + (r.height - FLOAT_H) / 2);
-        if (top !== last) {
-          root.style.setProperty("--shell-float-top", `${top}px`);
-          last = top;
-          steady = 0;
-        } else {
-          steady += 1;
-        }
-      }
-    };
-    const loop = () => {
-      measure();
-      // Stop once the measurement holds for ~6 frames — covers the post-load
-      // settle without polling forever.
-      if (steady < 6) raf = requestAnimationFrame(loop);
-    };
-    loop();
-    const rearm = () => {
-      steady = 0;
-      last = Number.NaN;
-      cancelAnimationFrame(raf);
-      loop();
-    };
-    window.addEventListener("resize", rearm);
-    return () => {
-      cancelAnimationFrame(raf);
-      window.removeEventListener("resize", rearm);
-      root.style.removeProperty("--shell-float-top");
-    };
-  }, [isMobile, scope, rightPanel, rightExpanded]);
-
-  // While the right panel is expanded it covers the chat surface, but the
-  // shell's right edge-rail float (.shell-panel-float--right, z-40) sits above
-  // the overlay's trapped z-index and intercepts clicks on the panel's
-  // top-right Close button. Flag the expanded state on the document root so CSS
-  // can hide that float while expanded (it's redundant under a full-surface
-  // panel anyway). Restore/Esc clear it; the cleanup guards against unmount.
+  // While the right panel is expanded it covers the chat surface; flag the
+  // expanded state on the document root so CSS can hide the top-bar side-panel
+  // toggle while expanded (it's redundant under a full-surface panel anyway).
+  // Restore/Esc clear it; the cleanup guards against unmount.
   useEffect(() => {
     const root = document.documentElement;
     if (rightExpanded) root.setAttribute("data-right-panel-expanded", "");

--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -132,13 +132,13 @@ assert.doesNotMatch(
   "the old grouping dropdown is gone",
 );
 
-console.log("github-view-polish.test.ts OK");
-
-// The header must reserve a right gutter so its actions clear the floating
-// right panel-toggle (.shell-panel-float--right, a 44px strip) — otherwise the
-// Add PAT / Refresh buttons render under it and become unclickable.
-assert.match(
+// The side-panel toggle moved up into the top menu bar, so it no longer overlays
+// the header's right edge — the 44px (pr-11) gutter that used to clear it is
+// gone and the header uses a symmetric pr-5.
+assert.doesNotMatch(
   source,
   /github-surface-header[^"]*\bpr-11\b/,
-  "GitHub header reserves a 44px (pr-11) right gutter for the floating panel toggle",
+  "GitHub header no longer reserves a gutter for the retired floating panel toggle",
 );
+
+console.log("github-view-polish.test.ts OK");

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -1111,11 +1111,7 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
       )}
 
       {/* ── Header ── */}
-      {/* pr-11 (44px) reserves a gutter for the floating right panel-toggle
-          (.shell-panel-float--right, a full-height 44px strip overlaying the
-          surface's right edge), so the Add PAT / Refresh buttons don't sit
-          under it and become unclickable — same gutter the chat header uses. */}
-      <header className="github-surface-header flex items-center gap-3 pl-5 pr-11 py-2">
+      <header className="github-surface-header flex items-center gap-3 pl-5 pr-5 py-2">
         <div className="flex items-center gap-2">
           {activity?.login && (
             <span className="text-[12px] text-[var(--text-secondary)]">@{activity.login}</span>

--- a/src/components/magic-triggers.tsx
+++ b/src/components/magic-triggers.tsx
@@ -3,11 +3,9 @@
 import { useEffect } from "react";
 
 /**
- * Sparkle the corner sidepanel trigger on an actual click. Opening is
- * click-to-open — there is no proximity auto-open. shell.tsx still fades in the
- * purple proximity glow as hover feedback (and `.shell-panel-float` is
- * `cursor: pointer`, so hovering shows the hand); clicking the trigger fires its
- * own toggle and adds a one-shot purple `.magic-cast` sparkle.
+ * Sparkle the top-bar sidepanel trigger on an actual click. Clicking the nav or
+ * side-panel toggle (`.shell-top-toggle--nav` / `.shell-top-toggle--right`)
+ * fires its own toggle and adds a one-shot purple `.magic-cast` sparkle.
  */
 
 const CAST_MS = 650;
@@ -18,7 +16,7 @@ export function MagicTriggers() {
 
     const onClick = (e: MouseEvent) => {
       const target = e.target as HTMLElement | null;
-      const el = target?.closest(".shell-panel-float--left, .shell-panel-float--right");
+      const el = target?.closest(".shell-top-toggle--nav, .shell-top-toggle--right");
       if (!(el instanceof HTMLElement)) return;
       if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
       el.classList.add("magic-cast");

--- a/src/components/misc-aria-fixes.test.ts
+++ b/src/components/misc-aria-fixes.test.ts
@@ -21,14 +21,14 @@ function read(file: string) {
   );
 }
 
-// 2. Sidebar collapse moved to the shell's floating top-left toggle, which
-// exposes aria-expanded (covered by shell-edge-rails.test.ts). The sidebar
-// header itself is now a static wordmark with no collapse button.
+// 2. Sidebar collapse moved to the top-bar nav toggle, which exposes
+// aria-expanded (covered by shell-edge-rails.test.ts). The sidebar header
+// itself is now a static wordmark with no collapse button.
 {
   const shell = read("shell.tsx");
   assert.ok(
-    /shell-panel-float--left[\s\S]*?aria-expanded=\{navOpen\}/.test(shell),
-    "the floating left toggle exposes aria-expanded (in shell.tsx)",
+    /shell-top-toggle--nav[\s\S]*?aria-expanded=\{navOpen\}/.test(shell),
+    "the top-bar nav toggle exposes aria-expanded (in shell.tsx)",
   );
 }
 

--- a/src/components/right-panel-expand.test.ts
+++ b/src/components/right-panel-expand.test.ts
@@ -16,65 +16,46 @@ assert.match(src, /onSetPanel\("changes"\)/, "Changes is selectable as a tab whe
 assert.match(src, /rightExpanded/, "ChatSurface tracks rightExpanded");
 assert.match(src, /chat-right-expanded/, "expanded overlay container");
 
-// While expanded, the shell's right edge-rail float is hidden (via a root data
-// attribute + CSS) so it can't intercept clicks on the top-right Close button.
+// While expanded, the shell's top-bar side-panel toggle is hidden (via a root
+// data attribute + CSS) since it's redundant under a full-surface panel.
 assert.match(src, /data-right-panel-expanded/, "flags expanded state on the document root");
 
-// The expand affordance is a floating toggle pinned just left of the side-panel
-// trigger in the shell, not an in-header button. ChatSurface bridges it via a
-// window event and flags right-panel-open on the root so the float can show only
-// when there is a panel to expand.
+// The expand affordance is a top-bar toggle in the shell, not an in-header
+// button. ChatSurface bridges it via a window event and flags right-panel-open
+// on the root so the toggle can show only when there is a panel to expand.
 assert.match(
   src,
   /addEventListener\("cave:right-panel-expand"/,
-  "ChatSurface listens for the shell float's expand event",
+  "ChatSurface listens for the shell toggle's expand event",
 );
 assert.match(
   src,
   /data-right-panel-open/,
-  "ChatSurface flags right-panel-open on the root for the shell float's visibility",
+  "ChatSurface flags right-panel-open on the root for the expand toggle's visibility",
 );
 
 const shell = readFileSync(new URL("./shell.tsx", import.meta.url), "utf8");
 assert.match(
   shell,
-  /shell-panel-float--expand/,
-  "shell renders the floating expand toggle",
+  /shell-top-toggle--expand/,
+  "shell renders the top-bar expand toggle",
 );
 assert.match(
   shell,
   /dispatchEvent\(new CustomEvent\("cave:right-panel-expand"\)\)/,
-  "the expand float dispatches the bridge event",
+  "the expand toggle dispatches the bridge event",
 );
 
 const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 assert.match(
   css,
-  /\[data-right-panel-open\]\s*\.shell-panel-float--expand/,
-  "expand float is shown only when a right panel is open",
+  /\[data-right-panel-open\]\s*\.shell-top-toggle--expand/,
+  "expand toggle is shown only when a right panel is open",
 );
 assert.match(
   css,
-  /\[data-right-panel-expanded\]\s*\.shell-panel-float--expand[\s\S]*?display:\s*none/,
-  "expand float is hidden again while the panel is expanded",
-);
-
-// The floats track the live side-panel header position via a measured CSS var so
-// they stay aligned through the post-load layout settle (no fixed-offset flash).
-assert.match(
-  css,
-  /\.shell-panel-float::before\s*\{[\s\S]*?top:\s*var\(--shell-float-top,\s*50px\)[\s\S]*?\.shell-panel-float--expand\s*\{[\s\S]*?top:\s*var\(--shell-float-top,\s*50px\)/,
-  "side-panel chips and the expand float consume the measured --shell-float-top (with a 50px fallback)",
-);
-assert.match(
-  src,
-  /setProperty\("--shell-float-top"/,
-  "ChatSurface publishes the live header center to --shell-float-top",
-);
-assert.match(
-  src,
-  /querySelector\("\.right-panel-tabs"\)[\s\S]*getBoundingClientRect/,
-  "the float position is derived from the measured side-panel header rect",
+  /\[data-right-panel-expanded\]\s*\.shell-top-toggle--expand[\s\S]*?display:\s*none/,
+  "expand toggle is hidden again while the panel is expanded",
 );
 
 console.log("right-panel-expand.test.ts: ok");

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -1,8 +1,8 @@
 // @ts-nocheck
-// Side panels must stay discoverable without visual chrome noise:
-//   - desktop shell owns a left and right full-height edge strip
-//   - the strips are clickable across their full height
-//   - the aligned chip/icon stays invisible until hover or keyboard focus
+// Side panel toggles live in the desktop top menu bar:
+//   - the nav toggle anchors the bar's left edge
+//   - the side-panel + expand toggles its right edge
+//   - they share the bar's height/background so they read as one strip
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
@@ -12,118 +12,117 @@ const projectSidebar = readFileSync(new URL("./chat-project-sidebar.tsx", import
 const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 const shortcuts = readFileSync(new URL("../lib/keyboard-shortcuts.ts", import.meta.url), "utf8");
 
-// Codex-style side panel toggles: two full-height invisible edge strips
-// (left = nav sidebar, right = active side panel) replace the old
-// collapsed-only left edge rail.
+// The panel toggles are hoisted into the top bar (a flex row wrapping the
+// rendered top bar), desktop-only — they're built only when !isMobile.
 assert.match(
   shell,
-  /const panelFloats = !isMobile/,
-  "shell builds the floating panel toggles on desktop only",
+  /const navToggle = !isMobile/,
+  "shell builds the nav toggle on desktop only",
 );
 assert.match(
   shell,
-  /shell-panel-float shell-panel-float--left/,
-  "shell renders a floating left toggle for the nav sidebar",
+  /const rightToggles = !isMobile && hasFamiliar/,
+  "shell builds the right side-panel toggles on desktop only, when a familiar is active",
 );
 assert.match(
   shell,
-  /shell-panel-float--right/,
-  "shell renders a floating right toggle for the active side panel",
+  /<div className="shell-top">[\s\S]*?\{navToggle\}[\s\S]*?<div className="shell-top__bar">\{renderedTopBar\}<\/div>[\s\S]*?\{rightToggles\}/,
+  "the top bar row flanks the rendered top bar with the nav (left) and side-panel (right) toggles",
 );
 assert.match(
   shell,
-  /shell-panel-float--left[\s\S]*?aria-label=\{navOpen \? "Hide navigation" : "Show navigation"\}/,
-  "left float label reflects nav state",
+  /shell-top-toggle shell-top-toggle--nav/,
+  "shell renders a top-bar nav toggle for the sidebar",
 );
 assert.match(
   shell,
-  /shell-panel-float--left[\s\S]*?aria-expanded=\{navOpen\}/,
-  "left float exposes nav expanded state",
+  /shell-top-toggle--right/,
+  "shell renders a top-bar right toggle for the active side panel",
 );
 assert.match(
   shell,
-  /shell-panel-float--left[\s\S]*?navOpen \? "ph:sidebar-simple-fill" : "ph:sidebar-simple"/,
-  "left float icon reflects nav state",
+  /shell-top-toggle--nav[\s\S]*?aria-label=\{navOpen \? "Hide navigation" : "Show navigation"\}/,
+  "nav toggle label reflects nav state",
+);
+assert.match(
+  shell,
+  /shell-top-toggle--nav[\s\S]*?aria-expanded=\{navOpen\}/,
+  "nav toggle exposes nav expanded state",
+);
+assert.match(
+  shell,
+  /shell-top-toggle--nav[\s\S]*?navOpen \? "ph:sidebar-simple-fill" : "ph:sidebar-simple"/,
+  "nav toggle icon reflects nav state",
 );
 assert.match(
   shell,
   /const toggleNavPanel = \(\) => \{[\s\S]*?panel\.expand\(\); setNavOpen\(true\)[\s\S]*?panel\.collapse\(\); setNavOpen\(false\)/,
-  "left float collapses and expands the nav panel",
+  "nav toggle collapses and expands the nav panel",
 );
 assert.match(
   shell,
-  /shell-panel-float--right[\s\S]*?aria-expanded=\{familiarOpen\}/,
-  "right float exposes the active side-panel state",
+  /shell-top-toggle--right[\s\S]*?aria-expanded=\{familiarOpen\}/,
+  "right toggle exposes the active side-panel state",
 );
 assert.match(
   shell,
   /const toggleRightPanel = \(\) => \{[\s\S]*?familiarRef\.current[\s\S]*?setFamiliarOpen/,
-  "right float toggles the active right panel via familiarRef",
+  "right toggle toggles the active right panel via familiarRef",
 );
-// Floats are always visible (open or closed) — the old collapsed-only left
-// edge rail is gone.
+// The old collapsed-only left edge rail and full-height corner floats are gone.
 assert.doesNotMatch(
   shell,
   /familiar-trigger-rail--left/,
   "the old collapsed-only left edge rail is removed from the shell",
 );
+assert.doesNotMatch(
+  shell,
+  /shell-panel-float/,
+  "the old absolutely-positioned corner floats are removed from the shell",
+);
 
+// The toggles share the menu bar's 44px height + panel background so they read
+// as one continuous strip, and tint accent in their open state.
 assert.match(
   css,
-  /\.shell-panel-float\s*\{[\s\S]*?top:\s*0;[\s\S]*?bottom:\s*0;[\s\S]*?width:\s*44px;[\s\S]*?height:\s*100%;[\s\S]*?background:\s*transparent;/,
-  "left/right panel toggles should be full-height invisible edge strips",
+  /\.shell-top\s*\{[\s\S]*?display:\s*flex;[\s\S]*?align-items:\s*stretch;/,
+  "the top bar row is a stretch flex container",
 );
 assert.match(
   css,
-  /\.shell-panel-float::before\s*\{[\s\S]*?top:\s*var\(--shell-float-top,\s*50px\);[\s\S]*?opacity:\s*0;/,
-  "panel toggle chip should share the measured top and stay hidden by default",
+  /\.shell-top__bar\s*\{[\s\S]*?flex:\s*1 1 auto;/,
+  "the rendered top bar flexes to fill between the toggles",
 );
 assert.match(
   css,
-  /\.shell-panel-float > svg\s*\{[\s\S]*?top:\s*calc\(var\(--shell-float-top,\s*50px\) \+ 6\.5px\);[\s\S]*?opacity:\s*0;/,
-  "panel toggle icon should share the same measured top and stay hidden by default",
+  /\.shell-top-toggle\s*\{[\s\S]*?height:\s*44px;[\s\S]*?border-bottom:\s*1px solid var\(--border-hairline\);[\s\S]*?background:\s*var\(--bg-panel\);/,
+  "top-bar toggles match the menu bar's height, hairline and panel background",
 );
 assert.match(
   css,
-  /\.shell-panel-float:hover::before,[\s\S]*?\.shell-panel-float:focus-visible::before,[\s\S]*?\.shell-panel-float:hover > svg,[\s\S]*?\.shell-panel-float:focus-visible > svg\s*\{[\s\S]*?opacity:\s*1;/,
-  "panel toggle chip and icon should reveal on hover or keyboard focus",
-);
-assert.match(css, /\.shell-panel-float--left\s*\{[\s\S]*?left:\s*0;/, "left strip is pinned to the left edge");
-assert.match(css, /\.shell-panel-float--right\s*\{[\s\S]*?right:\s*0;/, "right strip is pinned to the right edge");
-assert.match(
-  css,
-  /\.shell-panel-float--left::before,[\s\S]*?\.shell-panel-float--right::before\s*\{[\s\S]*?width:\s*35px;[\s\S]*?height:\s*35px;/,
-  "corner side-panel tabs should be 25% larger than the base 28px chip",
+  /\.shell-top-toggle--active\s*\{[\s\S]*?color:\s*var\(--accent-presence\);/,
+  "an open panel's toggle tints accent",
 );
 assert.match(
   css,
-  /\.shell-panel-float--left::before\s*\{[\s\S]*?border-radius:\s*8px 0 6px 0;/,
-  "left corner side-panel tab should use a tighter radius",
+  /\.shell-top-toggle--right > svg\s*\{[\s\S]*?transform:\s*scaleX\(-1\);/,
+  "the right toggle mirrors the sidebar glyph so it reads as a right-edge panel",
 );
-assert.match(
-  css,
-  /\.shell-panel-float--right::before\s*\{[\s\S]*?border-radius:\s*0 8px 0 6px;/,
-  "right corner side-panel tab should use a tighter radius",
+
+// The float is gone — no proximity-glow tracking or --shell-float-top plumbing.
+assert.doesNotMatch(
+  shell,
+  /--float-prox/,
+  "shell no longer tracks cursor proximity for the floats",
 );
-assert.match(
+assert.doesNotMatch(
   css,
-  /\.shell-panel-float--left > svg,[\s\S]*?\.shell-panel-float--right > svg\s*\{[\s\S]*?top:\s*10px;/,
-  "corner side-panel tab icons should stay centered in the larger 35px chip",
-);
-assert.match(
-  css,
-  /\.shell-panel-float--left::after,[\s\S]*?\.shell-panel-float--right::after\s*\{[\s\S]*?top:\s*0;[\s\S]*?width:\s*64px;[\s\S]*?height:\s*64px;/,
-  "corner side-panel glows should be pinned to the actual corner tab locations",
-);
-assert.match(
-  css,
-  /@keyframes shell-corner-float-pulse \{[\s\S]*opacity: calc\(var\(--float-prox, 0\) \* 0\.85\);[\s\S]*opacity: calc\(var\(--float-prox, 0\) \* 1\.2\);/,
-  "corner side-panel glow should be more prominent as the cursor approaches",
+  /shell-panel-float/,
+  "the float CSS is pruned",
 );
 
 // The edge-rail chip survives — the collapsed chat-projects strip still uses it
-// for its reopen tab. The familiar trigger-rail CSS that used to share it was
-// pruned along with the rails themselves.
+// for its reopen tab.
 assert.match(css, /\.edge-rail-chip \{/, "edge-rail chip class exists");
 assert.match(
   css,
@@ -141,8 +140,8 @@ assert.doesNotMatch(
   "the dead familiar trigger-rail CSS is pruned",
 );
 
-// The right edge-rail tab toggle was retired — the shell's floating top-right
-// toggle now owns showing/hiding the companion panel.
+// The right edge-rail tab toggle was retired — the top-bar right toggle now owns
+// showing/hiding the companion panel.
 assert.doesNotMatch(
   workspace,
   /familiarPanelRail=/,
@@ -183,42 +182,12 @@ assert.match(shortcuts, /keys: "⌘B"[\s\S]*Toggle the left sidebar/, "shortcut 
 assert.match(shortcuts, /keys: "⌘⇧B"[\s\S]*Toggle the right side panel/, "shortcut sheet documents the default right panel toggle");
 
 // The CompanionRail's in-panel Hide button was removed along with its
-// cave:familiar-panel-toggle bridge — the floating top-right toggle (and ⌘⇧B)
-// own hiding the right panel now.
+// cave:familiar-panel-toggle bridge — the top-bar right toggle (and ⌘⇧B) own
+// hiding the right panel now.
 assert.doesNotMatch(
   shell,
   /cave:familiar-panel-toggle/,
   "Shell no longer wires the retired in-panel collapse event",
-);
-
-// Proximity glow: floats fade in (and pulse) as the cursor approaches. shell.tsx
-// tracks mousemove distance and sets --float-prox per float; the CSS drives the
-// chip opacity + the pulse halo from it.
-assert.match(shell, /addEventListener\("mousemove"/, "shell listens for mousemove to track cursor proximity");
-assert.match(
-  shell,
-  /setProperty\("--float-prox"/,
-  "shell sets a per-float --float-prox from cursor distance",
-);
-assert.match(
-  shell,
-  /el\.classList\.contains\("shell-panel-float--left"\)[\s\S]*?r\.left \+ 17\.5/,
-  "left corner float proximity should target the actual 35px corner tab center",
-);
-assert.match(
-  shell,
-  /el\.classList\.contains\("shell-panel-float--right"\)[\s\S]*?r\.right - 17\.5/,
-  "right corner float proximity should target the actual 35px corner tab center",
-);
-assert.match(
-  css,
-  /\.shell-panel-float::before \{[\s\S]*?opacity: var\(--float-prox, 0\)/,
-  "the float chip fades in by cursor proximity",
-);
-assert.match(
-  css,
-  /@keyframes shell-float-pulse \{[\s\S]*?var\(--float-prox, 0\)/,
-  "the proximity halo pulses with intensity gated by --float-prox",
 );
 
 console.log("shell-edge-rails.test.ts OK");

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -325,42 +325,6 @@ function ShellInner({
     return () => window.clearTimeout(t);
   }, [mounted]);
 
-  // Proximity glow: as the cursor moves toward a floating panel toggle, fade in
-  // (and pulse) its chip. Each float gets a `--float-prox` (0→1) driven by the
-  // cursor's distance to the chip; the CSS uses it for opacity + the pulse.
-  useEffect(() => {
-    if (!mounted || isMobile) return;
-    const RANGE = 160; // px — how far out the glow starts responding (tighter: kicks in closer to the toggle)
-    let raf = 0;
-    const onMove = (e: MouseEvent) => {
-      if (raf) return;
-      raf = window.requestAnimationFrame(() => {
-        raf = 0;
-        const floatTop =
-          parseFloat(
-            getComputedStyle(document.documentElement).getPropertyValue("--shell-float-top"),
-          ) || 50;
-        for (const el of document.querySelectorAll<HTMLElement>(".shell-panel-float")) {
-          const r = el.getBoundingClientRect();
-          // Chip center: corner tabs are pinned at 35px; the expand toggle keeps
-          // the measured header position.
-          const isLeftCorner = el.classList.contains("shell-panel-float--left");
-          const isRightCorner = el.classList.contains("shell-panel-float--right");
-          const cx = isLeftCorner ? r.left + 17.5 : isRightCorner ? r.right - 17.5 : r.left + r.width / 2;
-          const cy = isLeftCorner || isRightCorner ? r.top + 17.5 : r.top + floatTop + 14;
-          const dist = Math.hypot(e.clientX - cx, e.clientY - cy);
-          const prox = Math.max(0, Math.min(1, 1 - dist / RANGE));
-          el.style.setProperty("--float-prox", prox.toFixed(3));
-        }
-      });
-    };
-    window.addEventListener("mousemove", onMove, { passive: true });
-    return () => {
-      window.removeEventListener("mousemove", onMove);
-      if (raf) window.cancelAnimationFrame(raf);
-    };
-  }, [mounted, isMobile]);
-
   useEffect(() => {
     onNavOpenChange?.(navOpen);
   }, [navOpen, onNavOpenChange]);
@@ -440,7 +404,9 @@ function ShellInner({
   if (!mounted) {
     return (
       <div className="shell-frame flex h-full w-full flex-col">
-        {renderedTopBar}
+        <div className="shell-top">
+          <div className="shell-top__bar">{renderedTopBar}</div>
+        </div>
         <div className="shell-body flex flex-1 min-h-0">
           <div className="shell-root flex-1 min-h-0" />
         </div>
@@ -539,12 +505,11 @@ function ShellInner({
     "--shell-right-gap-px": `${detailGaps.right}px`,
     "--shell-home-center-shift-px": `${homeCenterShift}px`,
   };
-  // Codex-style floating panel toggles. Two always-visible rounded buttons
-  // pinned to the shell's top corners that show/hide the side panels: the
-  // left one toggles the navigation sidebar, the right one toggles whichever
-  // right panel is active (the companion/inspector/browser slot). They replace
-  // the old collapsed-only edge rails and the in-panel collapse toggles, so a
-  // single persistent control owns each panel regardless of its open state.
+  // Panel toggles, hoisted into the top menu bar. The nav toggle anchors the
+  // bar's left edge and the side-panel + expand toggles its right edge, so a
+  // single persistent control owns each panel regardless of its open state
+  // (replacing the old corner edge-rail floats). Desktop-only — below 1024px the
+  // mobile `.top-bar` carries its own drawer toggles.
   const rightPanelShortcutLabel = labelPanelShortcut(panelShortcuts.toggleRightPanel);
   const toggleNavPanel = () => {
     const panel = navRef.current;
@@ -558,45 +523,42 @@ function ShellInner({
     if (panel.isCollapsed()) { panel.expand(); setFamiliarOpen(true); }
     else { panel.collapse(); setFamiliarOpen(false); }
   };
-  const panelFloats = !isMobile ? (
+  const navToggle = !isMobile ? (
+    <button
+      type="button"
+      className={`shell-top-toggle shell-top-toggle--nav focus-ring${navOpen ? " shell-top-toggle--active" : ""}`}
+      aria-label={navOpen ? "Hide navigation" : "Show navigation"}
+      aria-expanded={navOpen}
+      title={navOpen ? `Hide navigation (${leftPanelShortcutLabel})` : `Show navigation (${leftPanelShortcutLabel})`}
+      onClick={toggleNavPanel}
+    >
+      <Icon name={navOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={15} />
+    </button>
+  ) : null;
+  const rightToggles = !isMobile && hasFamiliar ? (
     <>
+      {/* Expand-to-cover toggle. CSS keeps it hidden until a chat right panel is
+          actually open (:root[data-right-panel-open]) and re-hides it while
+          expanded. It reaches the chat surface's expand state via a window event. */}
       <button
         type="button"
-        className={`shell-panel-float shell-panel-float--left focus-ring${navOpen ? " shell-panel-float--active" : ""}`}
-        aria-label={navOpen ? "Hide navigation" : "Show navigation"}
-        aria-expanded={navOpen}
-        title={navOpen ? `Hide navigation (${leftPanelShortcutLabel})` : `Show navigation (${leftPanelShortcutLabel})`}
-        onClick={toggleNavPanel}
+        className="shell-top-toggle shell-top-toggle--expand focus-ring"
+        aria-label="Expand side panel"
+        title="Expand side panel"
+        onClick={() => window.dispatchEvent(new CustomEvent("cave:right-panel-expand"))}
       >
-        <Icon name={navOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={15} />
+        <Icon name="ph:arrows-out-simple" width={14} />
       </button>
-      {hasFamiliar ? (
-        <>
-          {/* Expand-to-cover toggle, pinned just left of the side-panel trigger.
-              CSS keeps it hidden until a chat right panel is actually open
-              (:root[data-right-panel-open]) and re-hides it while expanded. It
-              reaches the chat surface's expand state via a window event. */}
-          <button
-            type="button"
-            className="shell-panel-float shell-panel-float--expand focus-ring"
-            aria-label="Expand side panel"
-            title="Expand side panel"
-            onClick={() => window.dispatchEvent(new CustomEvent("cave:right-panel-expand"))}
-          >
-            <Icon name="ph:arrows-out-simple" width={14} />
-          </button>
-          <button
-            type="button"
-            className={`shell-panel-float shell-panel-float--right focus-ring${familiarOpen ? " shell-panel-float--active" : ""}`}
-            aria-label={familiarOpen ? "Hide side panel" : "Show side panel"}
-            aria-expanded={familiarOpen}
-            title={familiarOpen ? `Hide side panel (${rightPanelShortcutLabel})` : `Show side panel (${rightPanelShortcutLabel})`}
-            onClick={toggleRightPanel}
-          >
-            <Icon name={familiarOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={15} />
-          </button>
-        </>
-      ) : null}
+      <button
+        type="button"
+        className={`shell-top-toggle shell-top-toggle--right focus-ring${familiarOpen ? " shell-top-toggle--active" : ""}`}
+        aria-label={familiarOpen ? "Hide side panel" : "Show side panel"}
+        aria-expanded={familiarOpen}
+        title={familiarOpen ? `Hide side panel (${rightPanelShortcutLabel})` : `Show side panel (${rightPanelShortcutLabel})`}
+        onClick={toggleRightPanel}
+      >
+        <Icon name={familiarOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={15} />
+      </button>
     </>
   ) : null;
 
@@ -606,9 +568,12 @@ function ShellInner({
       style={shellFrameStyle}
       data-settled={settled ? "" : undefined}
     >
-      {renderedTopBar}
-      <div className="shell-body shell-body--floats flex flex-1 min-h-0">
-        {panelFloats}
+      <div className="shell-top">
+        {navToggle}
+        <div className="shell-top__bar">{renderedTopBar}</div>
+        {rightToggles}
+      </div>
+      <div className="shell-body flex flex-1 min-h-0">
         {hasBottom ? (
           <Group
             className="flex-1 min-h-0"

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1836,17 +1836,6 @@ details[open] > .cave-tool-summary::before {
   padding: 4px 10px 5px;
 }
 
-/* The right floating panel toggle (.shell-panel-float--right — right:8px, 28px
-   wide) overlays the top-right corner. With no right panel open the chat header
-   runs full-width to the viewport edge, so its right-edge actions (in-transcript
-   find + the ⋮ session menu) land under the toggle and become unclickable.
-   Reserve a gutter (8px edge + 28px button + 8px gap = 44px) so they clear it.
-   A panel open stops the header at the panel edge with the toggle over the
-   panel, so the base padding is correct there — hence the :not() guard. */
-:root:not([data-right-panel-open]) .cave-chat-linear-header {
-  padding-right: 44px;
-}
-
 .cave-mobile-header-identity,
 .cave-mobile-header-task,
 .cave-mobile-action-strip,


### PR DESCRIPTION
## What

Moves the side-panel **triggers** (nav toggle, side-panel toggle, expand toggle) up out of the floating corner strips and into the desktop **top menu bar**.

Previously these were full-height invisible edge strips overlaying the surface's left/right edges, revealing a chip on cursor proximity. Now:

- **Nav toggle** anchors the menu bar's **left** edge.
- **Side-panel + expand toggles** sit at the menu bar's **right** edge.
- All share the bar's 44px height and panel background, reading as one continuous strip.
- The floating chips and their cursor-proximity glow are gone.

## Changes

- `shell.tsx` — render `navToggle` / `rightToggles` inside a new `.shell-top` flex row that wraps the rendered top bar; remove the absolute floats and the `mousemove` proximity-glow effect.
- `globals.css` — replace `.shell-panel-float*` CSS (strips, chips, corner tabs, pulse keyframes) with `.shell-top` / `.shell-top-toggle` rules. The data-attr visibility guards are preserved, rebased onto the new classes: expand shows only on `[data-right-panel-open]`, hides on `[data-right-panel-expanded]`; the right toggle hides while expanded or under the Code surface's inline toolbar.
- `chat-surface.tsx` — drop the now-dead `--shell-float-top` header-measurement effect (a fixed-height bar doesn't need to track the panel header).
- Reclaim the 44px right gutters surfaces reserved for the overlaying float: chat header (`cave-chat.css`) and GitHub header (`pr-11` → `pr-5`).
- `magic-triggers.tsx` — retarget the one-shot click sparkle to the new toggles.
- Source-text tests updated to assert the top-bar markup/CSS.

## Verification

- `pnpm test:app` — 315 test files pass.
- `pnpm typecheck` + `pnpm build` — clean.
- Driven in the running app (1440×900): **0 floats** in the DOM; nav toggle at `(0,0,40×44)`, side-panel toggle at `(1400,0,40×44)`, expand toggle hidden until a panel opens; the menu bar flexes between them (`40→1400`). No stray chips overlaying surface corners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)