### PR TITLE
feat(menu-bar): quick-chat dropdown on the desktop New chat button

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3980,6 +3980,84 @@ button:active > .edge-rail-chip {
   background: var(--color-warning);
 }
 
+/* New-chat quick-compose dropdown (anchored to the "New chat" button). The
+   popover container carries `.ui-popover .menu-bar__compose`. */
+.menu-bar__compose {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+}
+
+.menu-bar__compose-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.menu-bar__compose-label {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.menu-bar__compose-select {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 5px 8px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-base);
+  color: var(--foreground);
+  font-size: var(--text-sm);
+}
+
+.menu-bar__compose-input {
+  width: 100%;
+  max-height: 160px;
+  resize: none;
+  padding: 8px 10px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-base);
+  color: var(--foreground);
+  font: inherit;
+  font-size: var(--text-sm);
+  line-height: 1.4;
+}
+
+.menu-bar__compose-input:focus-visible {
+  outline: none;
+  border-color: color-mix(in oklch, var(--accent-presence) 55%, transparent);
+}
+
+.menu-bar__compose-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.menu-bar__compose-send {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 55%, transparent);
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--accent-presence) 26%, transparent);
+  color: var(--foreground);
+  font-size: var(--text-sm);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.menu-bar__compose-send:hover {
+  background: color-mix(in oklch, var(--accent-presence) 38%, transparent);
+}
+
+.menu-bar__compose-kbd {
+  font-size: 11px;
+  opacity: 0.7;
+}
+
 .top-bar {
   display: none;
   grid-template-columns: 1fr minmax(auto, 560px) 1fr;

--- a/src/components/familiar-menu-bar.test.ts
+++ b/src/components/familiar-menu-bar.test.ts
@@ -36,10 +36,39 @@ assert.match(
   /computePresence\(\{/,
   "avatars compute presence for the status dot",
 );
+// The New chat button opens a quick-compose dropdown (a popover) rather than
+// starting a chat on the first click.
 assert.match(
   source,
-  /className="menu-bar__new focus-ring"[\s\S]*onClick=\{\(\) => onChatWithFamiliar\(activeFamiliarId\)\}/,
-  "the New chat button starts a chat with the active familiar",
+  /className="menu-bar__new focus-ring"[\s\S]*aria-haspopup="dialog"/,
+  "the New chat button opens a dropdown",
+);
+assert.match(
+  source,
+  /<Popover[\s\S]*className="menu-bar__compose"/,
+  "the dropdown is a popover anchored to the New chat button",
+);
+assert.match(
+  source,
+  /className="menu-bar__compose-select"/,
+  "the dropdown has a familiar selector",
+);
+assert.match(
+  source,
+  /className="menu-bar__compose-input"/,
+  "the dropdown has a compose box",
+);
+// Submitting with text starts a composed chat; submitting empty opens a blank
+// chat with the selected familiar.
+assert.match(
+  source,
+  /if \(prompt\) onComposeChat\(selectedId, prompt\);/,
+  "typed text starts a chat that auto-sends the message",
+);
+assert.match(
+  source,
+  /else onChatWithFamiliar\(selectedId\);/,
+  "an empty box opens a blank chat with the selected familiar",
 );
 
 // Right group — tasks. A Tasks button (board) and an Inbox button, each with a
@@ -71,6 +100,11 @@ assert.match(
   workspace,
   /<FamiliarMenuBar[\s\S]*onChatWithFamiliar=\{\(id\) => startFamiliarChat\(id\)\}/,
   "the bar's chat handler starts a real familiar chat",
+);
+assert.match(
+  workspace,
+  /onComposeChat=\{\(id, prompt\) => startFamiliarChat\(id, null, prompt\)\}/,
+  "the compose handler starts a familiar chat with an initial prompt",
 );
 assert.match(
   workspace,

--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import type { CSSProperties } from "react";
+import { useCallback, useEffect, useRef, useState, type CSSProperties, type KeyboardEvent } from "react";
 import { Icon } from "@/lib/icon";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { FamiliarSwitcher } from "@/components/familiar-switcher";
+import { Popover } from "@/components/ui/popover";
 import { computePresence, REMOTE_HARNESSES } from "@/lib/presence";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { SessionRow } from "@/lib/types";
@@ -19,6 +20,8 @@ type Props = {
   inboxCount: number;
   /** Start a chat with a familiar (`null` = the active/default familiar). */
   onChatWithFamiliar: (id: string | null) => void;
+  /** Start a chat with a familiar and an opening message (auto-sent on entry). */
+  onComposeChat: (id: string | null, prompt: string) => void;
   /** Change the active-familiar scope (the switcher menu's "All"/per-familiar). */
   onSelectFamiliar: (id: string | null) => void;
   /** Jump to the task board. */
@@ -50,6 +53,7 @@ export function FamiliarMenuBar({
   taskCount,
   inboxCount,
   onChatWithFamiliar,
+  onComposeChat,
   onSelectFamiliar,
   onViewTasks,
   onViewInbox,
@@ -99,15 +103,12 @@ export function FamiliarMenuBar({
           </ul>
         ) : null}
 
-        <button
-          type="button"
-          className="menu-bar__new focus-ring"
-          onClick={() => onChatWithFamiliar(activeFamiliarId)}
-          aria-label="Start a new chat"
-        >
-          <Icon name="ph:chat-circle-dots" width={14} aria-hidden />
-          <span>New chat</span>
-        </button>
+        <NewChatMenu
+          familiars={familiars}
+          activeFamiliarId={activeFamiliarId}
+          onChatWithFamiliar={onChatWithFamiliar}
+          onComposeChat={onComposeChat}
+        />
       </div>
 
       <div className="menu-bar__group menu-bar__group--tasks">
@@ -135,5 +136,131 @@ export function FamiliarMenuBar({
         </button>
       </div>
     </nav>
+  );
+}
+
+/**
+ * The "New chat" control: a button that opens a small quick-chat dropdown — pick
+ * a familiar and (optionally) type an opening message. Submitting with text
+ * starts the chat and auto-sends the message; submitting empty just opens a
+ * blank chat with the selected familiar.
+ */
+function NewChatMenu({
+  familiars,
+  activeFamiliarId,
+  onChatWithFamiliar,
+  onComposeChat,
+}: {
+  familiars: ResolvedFamiliar[];
+  activeFamiliarId: string | null;
+  onChatWithFamiliar: (id: string | null) => void;
+  onComposeChat: (id: string | null, prompt: string) => void;
+}) {
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(activeFamiliarId);
+
+  // Each time the dropdown opens, default the selection to the active familiar
+  // (or the first one) and focus the composer so you can type straight away.
+  useEffect(() => {
+    if (!open) return;
+    setSelectedId(activeFamiliarId ?? familiars[0]?.id ?? null);
+    const t = window.setTimeout(() => textareaRef.current?.focus(), 0);
+    return () => window.clearTimeout(t);
+  }, [open, activeFamiliarId, familiars]);
+
+  const selectedName = familiars.find((f) => f.id === selectedId)?.display_name ?? "a familiar";
+
+  const autoGrow = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
+  }, []);
+
+  const handleStart = useCallback(() => {
+    const prompt = text.trim();
+    if (prompt) onComposeChat(selectedId, prompt);
+    else onChatWithFamiliar(selectedId);
+    setText("");
+    setOpen(false);
+  }, [text, selectedId, onComposeChat, onChatWithFamiliar]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      // plain Enter sends; Shift+Enter inserts a newline
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        handleStart();
+      }
+    },
+    [handleStart],
+  );
+
+  return (
+    <>
+      <button
+        type="button"
+        ref={triggerRef}
+        className="menu-bar__new focus-ring"
+        onClick={() => setOpen((v) => !v)}
+        aria-label="Start a new chat"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+      >
+        <Icon name="ph:chat-circle-dots" width={14} aria-hidden />
+        <span>New chat</span>
+      </button>
+      <Popover
+        open={open}
+        onOpenChange={setOpen}
+        anchorRef={triggerRef}
+        placement="bottom-start"
+        minWidth={300}
+        className="menu-bar__compose"
+      >
+        <div className="menu-bar__compose-row">
+          <label className="menu-bar__compose-label" htmlFor="menu-bar-compose-familiar">
+            To
+          </label>
+          <select
+            id="menu-bar-compose-familiar"
+            className="menu-bar__compose-select"
+            value={selectedId ?? ""}
+            onChange={(e) => setSelectedId(e.target.value || null)}
+          >
+            {familiars.map((f) => (
+              <option key={f.id} value={f.id}>
+                {f.display_name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <textarea
+          ref={textareaRef}
+          className="menu-bar__compose-input"
+          placeholder={`Ask ${selectedName} anything…`}
+          rows={3}
+          value={text}
+          onChange={(e) => {
+            setText(e.target.value);
+            autoGrow();
+          }}
+          onKeyDown={handleKeyDown}
+          aria-label="Message"
+          enterKeyHint="send"
+        />
+        <div className="menu-bar__compose-actions">
+          <button type="button" className="menu-bar__compose-send focus-ring" onClick={handleStart}>
+            <span>Open chat</span>
+            <kbd className="menu-bar__compose-kbd" aria-hidden>
+              ↵
+            </kbd>
+          </button>
+        </div>
+      </Popover>
+    </>
   );
 }

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1690,6 +1690,7 @@ export function Workspace() {
               taskCount={boardTaskCount}
               inboxCount={inboxBadgeCount}
               onChatWithFamiliar={(id) => startFamiliarChat(id)}
+              onComposeChat={(id, prompt) => startFamiliarChat(id, null, prompt)}
               onSelectFamiliar={selectFamiliarScope}
               onViewTasks={() => setMode("board")}
               onViewInbox={() => setMode("inbox")}


### PR DESCRIPTION
## What

The desktop menu bar's **New chat** icon (`ph:chat-circle-dots`, shown ≥1024px) used to start a chat with the active familiar on a single click. It now opens a **dropdown quick-chat**:

- **Familiar selector** — a native `<select>` defaulting to the active familiar.
- **Compose box** — auto-grow textarea; **Enter** sends, **Shift+Enter** newlines.
- **Open chat** — submitting with text opens the chat *and auto-sends* the message; submitting **empty** opens a blank chat with the selected familiar (type there instead).

## How

- New internal `NewChatMenu` in `familiar-menu-bar.tsx`, built on the shared `ui/popover` primitive (portal, Escape/outside-click/scroll-close) and mirroring `home-composer`'s auto-grow + key handling.
- New `onComposeChat(id, prompt)` prop wired in `workspace.tsx` to the existing `startFamiliarChat(id, null, prompt)`, which threads `initialPrompt` into `ChatView` (auto-sent on mount). **No new API or events.**
- Existing avatar-strip / FamiliarSwitcher / Tasks / Inbox behavior is unchanged.

## Verification

- `pnpm test:app` — all 315 test files pass (updated the source-text guards in `familiar-menu-bar.test.ts`).
- **Live in the running app** at 1440px: opened the dropdown (selector + composer render), picked a familiar, typed a message, pressed Enter → landed in that familiar's chat with the message sent. Re-opened and pressed **Open chat** with an empty box → blank chat opened, no stray message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)