### PR TITLE
feat(companion-rail): YouTube viewer in a resizable bottom pane

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3469,6 +3469,101 @@ button:active > .edge-rail-chip {
   display: none;
 }
 
+/* ── Video toggle: active tab content on top, YouTube viewer in a resizable
+   bottom pane (the "Video" tab in the rail tab strip). ── */
+.companion-rail__split {
+  flex: 1;
+  min-height: 0;
+}
+
+.companion-rail__split-pane {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.companion-rail__resize {
+  position: relative;
+  height: 1px;
+  background: var(--border-hairline);
+}
+
+.youtube-viewer {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  background: var(--bg-panel);
+}
+
+.youtube-viewer__bar {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.youtube-viewer__icon {
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+.youtube-viewer__input {
+  min-width: 0;
+  flex: 1;
+  padding: 4px 8px;
+  border-radius: var(--radius-control);
+  border: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-base) 40%, transparent);
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+}
+
+.youtube-viewer__input::placeholder {
+  color: var(--text-muted);
+}
+
+.youtube-viewer__load {
+  flex-shrink: 0;
+  padding: 4px 10px;
+  border-radius: var(--radius-control);
+  border: 1px solid var(--border-hairline);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  transition: color 0.1s, background 0.1s;
+}
+
+.youtube-viewer__load:hover {
+  background: var(--bg-raised);
+  color: var(--text-primary);
+}
+
+.youtube-viewer__error {
+  flex-shrink: 0;
+  padding: 4px 10px;
+  font-size: var(--text-xs);
+  color: var(--color-danger, #f87171);
+}
+
+.youtube-viewer__frame {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  background: #000;
+}
+
+.youtube-viewer__frame iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
 /* ────────────────────────────────────────────────
    Rail-pane empty + memory styles
    (Phase 2, shell-ia-redesign)

--- a/src/components/companion-rail.tsx
+++ b/src/components/companion-rail.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { forwardRef, useEffect, useState, type ReactNode } from "react";
+import { Group, Panel, Separator } from "react-resizable-panels";
 import { Icon } from "@/lib/icon";
+import { SeparatorHandle } from "@/components/ui/separator-handle";
+import { YoutubeViewer } from "@/components/youtube-viewer";
 import type { ChatRouterHandle } from "@/components/chat-router";
 import type { Familiar } from "@/lib/types";
 
@@ -43,6 +46,10 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
       hideChatTab = false,
     } = props;
     const [tab, setTab] = useState<CompanionTab>(defaultTab);
+    // The Video tab is a toggle, not a mutually-exclusive section: when on, the
+    // YouTube viewer drops into a resizable bottom pane below the active tab's
+    // content rather than replacing it.
+    const [youtubeOpen, setYoutubeOpen] = useState(false);
     const requestedTab = activeTab ?? tab;
     const fallbackTab: CompanionTab = browserSlot ? "browser" : salemSlot ? "salem" : "memory";
     const selectedTab =
@@ -86,6 +93,33 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
       setTab(next);
       onTabChange?.(next);
     };
+
+    // The active tab's content. Rendered once; either fills the body or sits in
+    // the top pane of the split when the Video toggle is on.
+    const panes = (
+      <>
+        {!familiar || hideChatTab ? null : (
+          <div hidden={selectedTab !== "chat"} className="companion-rail__pane">
+            {chatSlot}
+          </div>
+        )}
+        {familiar ? (
+          <div hidden={selectedTab !== "memory"} className="companion-rail__pane">
+            {memorySlot}
+          </div>
+        ) : null}
+        {browserSlot ? (
+          <div hidden={selectedTab !== "browser"} className="companion-rail__pane companion-rail__pane--browser">
+            {selectedTab === "browser" ? browserSlot : null}
+          </div>
+        ) : null}
+        {salemSlot ? (
+          <div hidden={selectedTab !== "salem"} className="companion-rail__pane">
+            {selectedTab === "salem" ? salemSlot : null}
+          </div>
+        ) : null}
+      </>
+    );
 
     return (
       <aside className="companion-rail">
@@ -136,28 +170,42 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
               <Icon name="ph:book-open" width={14} />
             </button>
           ) : null}
+          <button
+            type="button"
+            className={`companion-rail__tab${youtubeOpen ? " companion-rail__tab--active" : ""}`}
+            onClick={() => setYoutubeOpen((open) => !open)}
+            aria-pressed={youtubeOpen}
+            title="Video"
+          >
+            <Icon name="ph:video" width={14} />
+          </button>
         </nav>
         <div className="companion-rail__body">
-          {!familiar || hideChatTab ? null : (
-            <div hidden={selectedTab !== "chat"} className="companion-rail__pane">
-              {chatSlot}
-            </div>
+          {youtubeOpen ? (
+            <Group orientation="vertical" className="companion-rail__split">
+              <Panel
+                id="companion-rail-main"
+                minSize={20}
+                defaultSize={58}
+                className="companion-rail__split-pane"
+              >
+                {panes}
+              </Panel>
+              <Separator className="companion-rail__resize shrink-0" data-orientation="row">
+                <SeparatorHandle orientation="row" />
+              </Separator>
+              <Panel
+                id="companion-rail-youtube"
+                minSize={20}
+                defaultSize={42}
+                className="companion-rail__split-pane"
+              >
+                <YoutubeViewer />
+              </Panel>
+            </Group>
+          ) : (
+            panes
           )}
-          {familiar ? (
-            <div hidden={selectedTab !== "memory"} className="companion-rail__pane">
-              {memorySlot}
-            </div>
-          ) : null}
-          {browserSlot ? (
-            <div hidden={selectedTab !== "browser"} className="companion-rail__pane companion-rail__pane--browser">
-              {selectedTab === "browser" ? browserSlot : null}
-            </div>
-          ) : null}
-          {salemSlot ? (
-            <div hidden={selectedTab !== "salem"} className="companion-rail__pane">
-              {selectedTab === "salem" ? salemSlot : null}
-            </div>
-          ) : null}
         </div>
       </aside>
     );

--- a/src/components/youtube-viewer.tsx
+++ b/src/components/youtube-viewer.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+import { Icon } from "@/lib/icon";
+
+// The playlist the panel opens on by default.
+const DEFAULT_PLAYLIST_ID = "PLp61JrZcGK7-uuXOWzezyZkz61RQb0XOG";
+const DEFAULT_SRC = playlistEmbed(DEFAULT_PLAYLIST_ID);
+
+const ID_RE = /^[a-zA-Z0-9_-]{11}$/;
+const PLAYLIST_RE = /^[a-zA-Z0-9_-]{12,}$/;
+
+// Shared params: `list=...` exposes YouTube's in-player playlist list/menu so you
+// can browse and jump between entries without leaving the panel.
+function playlistEmbed(listId: string, videoId?: string): string {
+  const base = videoId ? `https://www.youtube.com/embed/${videoId}` : "https://www.youtube.com/embed/videoseries";
+  return `${base}?list=${encodeURIComponent(listId)}`;
+}
+
+function videoEmbed(videoId: string): string {
+  return `https://www.youtube.com/embed/${videoId}`;
+}
+
+/**
+ * Turn whatever the user pasted into a YouTube embed src. Handles playlists
+ * (any `list=` link, a `videoseries` embed, or a bare playlist id), watch URLs,
+ * youtu.be / shorts / live links, /embed/ URLs, and bare 11-char video ids.
+ * Returns null when nothing usable is found.
+ */
+export function parseYoutubeEmbed(raw: string): string | null {
+  const value = raw.trim();
+  if (!value) return null;
+  if (ID_RE.test(value)) return videoEmbed(value);
+  if (value.startsWith("PL") || value.startsWith("UU") || value.startsWith("FL") || value.startsWith("RD")) {
+    if (PLAYLIST_RE.test(value)) return playlistEmbed(value);
+  }
+  try {
+    const url = new URL(value.startsWith("http") ? value : `https://${value}`);
+    const host = url.hostname.replace(/^www\./, "");
+    const list = url.searchParams.get("list");
+    if (host === "youtu.be") {
+      const id = url.pathname.slice(1).split("/")[0];
+      if (list) return playlistEmbed(list, ID_RE.test(id) ? id : undefined);
+      return ID_RE.test(id) ? videoEmbed(id) : null;
+    }
+    if (host === "youtube.com" || host.endsWith(".youtube.com")) {
+      const v = url.searchParams.get("v");
+      if (list) return playlistEmbed(list, v && ID_RE.test(v) ? v : undefined);
+      if (v && ID_RE.test(v)) return videoEmbed(v);
+      const parts = url.pathname.split("/").filter(Boolean);
+      const idx = parts.findIndex((p) => p === "embed" || p === "shorts" || p === "live");
+      if (idx >= 0 && parts[idx + 1] && ID_RE.test(parts[idx + 1])) return videoEmbed(parts[idx + 1]);
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+/**
+ * A compact YouTube player with an editable URL bar. Lives in the companion
+ * rail's resizable bottom pane (the "Video" toggle). Paste any YouTube link,
+ * video id, or playlist; the embed reloads when you hit Load / Enter.
+ */
+export function YoutubeViewer({ defaultSrc = DEFAULT_SRC }: { defaultSrc?: string }) {
+  const [src, setSrc] = useState(defaultSrc);
+  const [input, setInput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const load = () => {
+    const next = parseYoutubeEmbed(input);
+    if (!next) {
+      setError("Enter a YouTube link, video ID, or playlist");
+      return;
+    }
+    setError(null);
+    setSrc(next);
+    setInput("");
+  };
+
+  return (
+    <div className="youtube-viewer">
+      <form
+        className="youtube-viewer__bar"
+        onSubmit={(e) => {
+          e.preventDefault();
+          load();
+        }}
+      >
+        <Icon name="ph:video" width={14} className="youtube-viewer__icon" />
+        <input
+          type="text"
+          className="youtube-viewer__input focus-ring"
+          value={input}
+          onChange={(e) => {
+            setInput(e.target.value);
+            if (error) setError(null);
+          }}
+          placeholder="Paste a YouTube link, video ID, or playlist…"
+          aria-label="YouTube link, video ID, or playlist"
+          aria-invalid={error ? true : undefined}
+        />
+        <button type="submit" className="youtube-viewer__load focus-ring">
+          Load
+        </button>
+      </form>
+      {error ? (
+        <p className="youtube-viewer__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+      <div className="youtube-viewer__frame">
+        <iframe
+          key={src}
+          src={src}
+          title="YouTube video player"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          referrerPolicy="strict-origin-when-cross-origin"
+          allowFullScreen
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds a **Video** toggle to the companion rail (the right-side panel with Chat / Memory / Browser / Salem). When enabled, the rail body splits vertically: the active tab's content stays on top and a YouTube viewer drops into a **resizable bottom pane** (drag the divider).

The viewer has an editable URL bar that accepts any YouTube link, video ID, or playlist (`watch` / `youtu.be` / `shorts` / `embed` / `videoseries`). It opens on a default playlist embed and keeps the `list=` param so in-player playlist navigation is enabled.

## Files

- `src/components/youtube-viewer.tsx` — new viewer (editable URL bar + iframe; `parseYoutubeEmbed` URL/ID/playlist parser)
- `src/components/companion-rail.tsx` — Video toggle + `react-resizable-panels` split (mirrors the terminal split pattern)
- `src/app/globals.css` — split + viewer styles

## Verification

- `tsc --noEmit` clean
- `node scripts/run-tests.mjs app` → 315 test files pass
- Live-verified in dev: Video tab splits the rail, iframe fills the bottom pane (measured full width/height), default playlist loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)