### PR TITLE
fix(top-bar): match familiar switcher height to the other action buttons

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5363,6 +5363,14 @@ a.mobile-handoff__link:hover {
     border-radius: var(--radius-control);
     background: transparent;
   }
+  /* Match the familiar switcher's height to the other action buttons so the
+     row reads as one consistent set. Width stays content-based to fit its
+     avatar + caret (the bell/account are square icon buttons). */
+  .top-bar__actions .familiar-switcher__trigger,
+  .top-bar__actions .familiar-switcher__trigger[data-labeled="true"] {
+    height: var(--touch-target);
+    min-height: var(--touch-target);
+  }
   .top-bar__actions .notification-bell {
     position: static;
   }


### PR DESCRIPTION
## What

In the mobile/tablet top bar (`<1024px`), the action cluster on the right had inconsistent heights: the notification bell, account, and drawer toggles all use the 44px `--touch-target` size, but the **familiar switcher** (sparkle + caret) kept its base **26px** height — so it was shorter than its neighbours and sat misaligned.

## Fix

Give `.top-bar__actions .familiar-switcher__trigger` the same `--touch-target` height in the mobile block. Width stays content-based to fit its avatar + caret (the bell/account stay square icon buttons).

## Verification

Measured live in the running app at 900px wide, before vs after:

| control | before | after |
|---|---|---|
| familiar switcher | 39×**26** | 39×**44** |
| notification bell | 44×44 | 44×44 |
| account | 44×44 | 44×44 |
| drawer toggle | 44×44 | 44×44 |

Screenshot confirmed the row now aligns as one consistent set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)