### PR TITLE
feat(menu-bar): fold quick chat + tasks into the mobile top bar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4460,6 +4460,31 @@ button:active > .edge-rail-chip {
   color: var(--text-primary);
 }
 
+/* Tasks quick action (folded in from the desktop menu bar) — an icon button
+   with a small open-task count badge. */
+.top-bar__tasks {
+  position: relative;
+}
+
+.top-bar__tasks-badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 15px;
+  height: 15px;
+  padding: 0 4px;
+  border-radius: 8px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--accent-presence-foreground);
+  background: color-mix(in oklch, var(--accent-presence) 65%, transparent);
+  pointer-events: none;
+}
+
 /* Mobile drawer toggles. Hidden on desktop; CSS @media block below
    reveals them and gives them a 44px hit area. The TopBar omits them
    from JSX when the surface has no relevant pane (e.g. two-pane modes

--- a/src/components/top-bar.test.ts
+++ b/src/components/top-bar.test.ts
@@ -103,4 +103,34 @@ assert.match(
   "Selection handler is nullable so the menu can scope to all familiars",
 );
 
+// Mobile quick actions folded in from the desktop menu bar: New chat + Tasks.
+// (The top bar is the single mobile bar — display:none on desktop — so these
+// render only on mobile; the inbox stays on the NotificationBell, the switcher
+// is already present, so nothing is duplicated.)
+assert.match(
+  source,
+  /onStartChat\?: \(\) => void/,
+  "Top bar accepts a New chat handler for the mobile quick action",
+);
+assert.match(
+  source,
+  /onViewTasks\?: \(\) => void/,
+  "Top bar accepts a View tasks handler for the mobile quick action",
+);
+assert.match(
+  source,
+  /onStartChat \?[\s\S]*aria-label="New chat"[\s\S]*ph:chat-circle-dots/,
+  "Top bar renders a New chat button when wired",
+);
+assert.match(
+  source,
+  /onViewTasks \?[\s\S]*className="top-bar__icon-btn top-bar__tasks"[\s\S]*onClick=\{onViewTasks\}/,
+  "Top bar renders a Tasks button when wired",
+);
+assert.match(
+  source,
+  /taskCount && taskCount > 0 \? \(\s*<span className="top-bar__tasks-badge">/,
+  "Tasks button shows an open-task count badge, hidden at zero",
+);
+
 console.log("top-bar.test.ts: ok");

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -27,6 +27,15 @@ type Props = {
   activeFamiliar?: ResolvedFamiliar | null;
   familiarOptions?: ResolvedFamiliar[];
   onSelectFamiliar?: (id: string | null) => void;
+  /** Mobile quick actions folded in from the desktop menu bar: start a chat
+   *  with the active familiar and jump to the task board. The top bar is the
+   *  one mobile bar (it's `display:none` on desktop, where the dedicated
+   *  `FamiliarMenuBar` carries these), so these render only on mobile. Omit
+   *  either handler to hide that button. */
+  onStartChat?: () => void;
+  onViewTasks?: () => void;
+  /** Open task count (board cards not yet done) — drives the Tasks badge. */
+  taskCount?: number;
   /** Live session rows + reply-needed set drive the menu's presence dots and
    *  reply badges (and the unread dot on the collapsed profile button). */
   sessions?: SessionRow[];
@@ -65,6 +74,9 @@ export function TopBar(props: Props) {
     activeFamiliar,
     familiarOptions,
     onSelectFamiliar,
+    onStartChat,
+    onViewTasks,
+    taskCount,
     sessions,
     responseNeeded,
     familiarSwitcherLabeled,
@@ -131,6 +143,31 @@ export function TopBar(props: Props) {
             placement="bottom-end"
             labeled={familiarSwitcherLabeled}
           />
+        ) : null}
+        {onStartChat ? (
+          <button
+            type="button"
+            className="top-bar__icon-btn"
+            onClick={onStartChat}
+            aria-label="New chat"
+            title="New chat"
+          >
+            <Icon name="ph:chat-circle-dots" width={15} />
+          </button>
+        ) : null}
+        {onViewTasks ? (
+          <button
+            type="button"
+            className="top-bar__icon-btn top-bar__tasks"
+            onClick={onViewTasks}
+            aria-label={taskCount && taskCount > 0 ? `View tasks — ${taskCount} open` : "View tasks"}
+            title="View tasks"
+          >
+            <Icon name="ph:kanban" width={15} />
+            {taskCount && taskCount > 0 ? (
+              <span className="top-bar__tasks-badge">{taskCount > 99 ? "99+" : taskCount}</span>
+            ) : null}
+          </button>
         ) : null}
         <button
           type="button"

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1705,6 +1705,9 @@ export function Workspace() {
             activeFamiliar={resolvedFamiliars.find((f) => f.id === activeId) ?? null}
             familiarOptions={resolvedFamiliars}
             onSelectFamiliar={selectFamiliarScope}
+            onStartChat={() => startFamiliarChat(activeId)}
+            onViewTasks={() => setMode("board")}
+            taskCount={boardTaskCount}
             sessions={sessions}
             responseNeeded={responseNeeded}
             familiarSwitcherLabeled={mode === "chat"}


### PR DESCRIPTION
## Summary
The desktop `FamiliarMenuBar` is hidden below 1024px. This adds its two core actions to the **existing mobile top bar** instead of stacking a second bar (which would also duplicate the familiar switcher):

- **New chat** (💬) → starts a chat with the active familiar.
- **Tasks** (▦, with an open-task count badge) → jumps to the board.

The familiar switcher is already in the mobile top bar and the inbox stays on the `NotificationBell`, so nothing is duplicated. The buttons live in the top bar, which is `display:none` on desktop — so they render only on mobile.

## Test Plan
- `pnpm typecheck`
- `pnpm test:app` (315 files) + `pnpm check:tests-wired`
- `pnpm build`
- Verified in a real browser at a 390px mobile viewport: menu-bar hidden, top-bar shown with New chat + Tasks (badge), exactly one switcher; tapping Tasks → Board and New chat → Familiars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)