### PR TITLE
feat(sidebar): declutter left nav — drop duplicated switcher + New session, flush-left

### DIFF
--- a/src/components/sidebar-familiar-filter.test.ts
+++ b/src/components/sidebar-familiar-filter.test.ts
@@ -24,13 +24,14 @@ assert.doesNotMatch(
   "Sidebar should no longer render the global search action in the left panel",
 );
 
-// The horizontal dock is replaced by a single profile switcher (FamiliarSwitcher),
-// rendered in the sidebar header (desktop) and the mobile top bar.
+// The horizontal dock is gone, and the profile switcher is not in the left
+// panel: scope selection lives in the top bars (FamiliarMenuBar on desktop, the
+// mobile top bar). The sidebar is pure navigation.
 assert.doesNotMatch(sidebar, /<FamiliarDock/, "the horizontal familiar dock is replaced");
-assert.match(
+assert.doesNotMatch(
   sidebar,
-  /<FamiliarSwitcher[\s\S]*onSelectFamiliar=\{onFamiliarScopeChange\}/,
-  "sidebar mounts the familiar profile switcher wired to the scope handler",
+  /<FamiliarSwitcher/,
+  "the familiar switcher is no longer mounted in the left sidebar",
 );
 
 assert.doesNotMatch(

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -57,14 +57,14 @@ assert.doesNotMatch(
   "Familiars subpage should not appear as a Work navigation row",
 );
 
-// The horizontal dock is replaced by a single profile switcher. The sidebar
-// header mounts FamiliarSwitcher (the same control also renders in the mobile
-// top bar) wired to the nullable familiar scope.
+// The horizontal dock is gone, and the profile switcher no longer lives in the
+// left panel either: familiar scope selection moved to the desktop top menu bar
+// (FamiliarMenuBar) and the mobile top bar, leaving the sidebar as pure nav.
 assert.doesNotMatch(source, /<FamiliarDock/, "the old horizontal familiar dock is gone");
-assert.match(
+assert.doesNotMatch(
   source,
-  /<FamiliarSwitcher[\s\S]*activeFamiliarId=\{activeFamiliarId\}[\s\S]*onSelectFamiliar=\{onFamiliarScopeChange\}/,
-  "Sidebar header mounts the familiar profile switcher wired to scope",
+  /<FamiliarSwitcher/,
+  "the familiar switcher is no longer mounted in the left sidebar (it lives in the top bars)",
 );
 assert.match(
   source,

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -14,7 +14,6 @@
 
 import React from "react";
 import { Icon } from "@/lib/icon";
-import { FamiliarSwitcher } from "@/components/familiar-switcher";
 import { RecentActivityRollup } from "@/components/recent-activity-rollup";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { SessionRow } from "@/lib/types";
@@ -151,30 +150,6 @@ function SidebarSection({
 }
 
 
-function ActionRow({
-  icon,
-  label,
-  active,
-  onClick,
-}: {
-  icon: React.ReactNode;
-  label: string;
-  active?: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      className={`sidebar-action-row ${active ? "sidebar-action-row--active" : ""}`}
-      aria-current={active ? "page" : undefined}
-      onClick={onClick}
-    >
-      <span className="sidebar-action-icon">{icon}</span>
-      <span className="sidebar-action-label">{label}</span>
-    </button>
-  );
-}
-
 function FolderRow({
   id,
   label,
@@ -220,18 +195,12 @@ function FolderRow({
 export function SidebarMinimal(props: SidebarMinimalProps) {
   const {
     mode,
-    sessions,
-    onNewChat,
     onOpenSettings,
     onOpenMobileHandoff,
     onModeChange,
     onOpenSession,
     activeSessionId,
     addons,
-    familiars,
-    activeFamiliarId,
-    onFamiliarScopeChange,
-    responseNeeded,
     notificationBadgeCount,
     onOpenInbox,
   } = props;
@@ -261,28 +230,11 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
       {/* Static wordmark. Collapsing the sidebar is now owned by the shell's
           floating top-left toggle (and ⌘B), so the header is no longer a
           button — it just leaves room for the float. */}
+      {/* Familiar scope selection and New session live in the desktop top
+          menu bar (FamiliarMenuBar) and the mobile top bar — the left panel is
+          pure navigation now, so the nav flows straight under the wordmark. */}
       <div className="sidebar-header sidebar-header--static">
         <span className="sidebar-title">Coven Cave</span>
-      </div>
-
-      {/* Header actions: familiar profile switcher + New session. The same switcher
-          also renders in the mobile top bar; on desktop this is its home. */}
-      <div className="sidebar-actions sidebar-action-stack">
-        <div className="sidebar-familiar-slot">
-          <FamiliarSwitcher
-            familiars={familiars}
-            activeFamiliarId={activeFamiliarId}
-            sessions={sessions}
-            responseNeeded={responseNeeded}
-            onSelectFamiliar={onFamiliarScopeChange}
-            labeled
-          />
-        </div>
-        <ActionRow
-          icon={<Icon name="ph:note-pencil" width={14} />}
-          label="New session"
-          onClick={onNewChat}
-        />
       </div>
 
       <div className="sidebar-nav-scroll">

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -18,7 +18,7 @@
 }
 
 .shell-nav-panel--open .sidebar-minimal {
-  transform: translateX(8px);
+  transform: translateX(0);
 }
 
 /* ── Panel toggle (Dia-style) ────────────────────────────────────────────── */


### PR DESCRIPTION
## What

The left navigation sidebar carried a familiar **scope switcher** ("All familiars") and a **New session** button that are already present in the desktop top menu bar (FamiliarMenuBar) and the mobile top bar. This removes that duplication: the left panel is now pure navigation, with the WORK/KNOWLEDGE/TOOLS groups flowing directly under the "Coven Cave" wordmark.

It also removes the `translateX(8px)` right-shift applied to the open nav panel, which left a dead gap on the left — the panel content now sits flush against the window's left edge (just the standard 8px inner padding).

## Changes

- `src/components/sidebar-minimal.tsx` — remove the familiar switcher + New session action block (and the now-unused `ActionRow`, import, and destructures). `onFamiliarScopeChange` etc. stay on the props type for the top-bar wiring.
- `src/styles/sidebar-minimal.css` — `translateX(8px)` → `translateX(0)` on the open nav panel.
- `sidebar-minimal.test.ts` / `sidebar-familiar-filter.test.ts` — assert the switcher is no longer mounted in the sidebar (it lives in the top bars, which other tests already cover).

## Verification

- `tsc --noEmit` clean
- `node scripts/run-tests.mjs app` → 315 test files pass
- Live-verified in dev: switcher + New session gone, nav flows under the wordmark, content flush-left (measured 8px from panel edge, no gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)