### PR TITLE
fix(workflows): right detail panel spans full column height like the left

### DIFF
--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -73,6 +73,11 @@ assert.match(
 );
 assert.match(
   css,
+  /\.workflow-studio-side-content \.workflow-panel\s*\{[\s\S]*flex:\s*1 1 auto;/,
+  "Each detail section card should grow to fill the column height (full-height side surface, like the left library) — not float as a short card above empty space",
+);
+assert.match(
+  css,
   /\.workflow-manifest-preview\s*\{[\s\S]*display:\s*flex;[\s\S]*flex-direction:\s*column;/,
   "Workflow manifest preview should use a vertical flex layout",
 );

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -184,6 +184,12 @@
 
 .workflow-studio-side-content .workflow-panel {
   padding-top: 10px;
+  /* Fill the column height so each detail section reads as a full-height side
+     surface — like the populated library panel on the left — instead of a short
+     card floating above empty space. The tab panel is already a flex column
+     with min-height:100% (see below); grow the section card into it. The
+     manifest preview sets the same flex on itself to expand its YAML editor. */
+  flex: 1 1 auto;
 }
 
 .workflow-panel-collapse-button {


### PR DESCRIPTION
## What

In the Workflow Studio, the **right detail panel** (Inspect / Bind / Manifest) rendered its section card sized to its content — a short card floating above a large empty void. The **left library panel** fills the full column height. This makes the right emulate the left.

| Before | After |
|---|---|
| Inspector card ~134px tall, void below | Card fills the full column (786px), content at top |

## Why it was off

The side-panel tab container (`.workflow-studio-side-content > [role="tabpanel"]`) is already a flex column with `min-height: 100%` — its existing test even says panels "should fill the side panel instead of shrinking around their contents." And `.workflow-manifest-preview` already sets `flex: 1 1 auto` on itself to expand its YAML editor. But the **Inspector** and **Attachments** section cards (`.workflow-panel`) kept the default `flex: 0 1 auto`, so they never grew into that space.

## Change

Generalize the fill that the manifest preview already uses:

```css
.workflow-studio-side-content .workflow-panel {
  flex: 1 1 auto;   /* grow to fill the column, like the left library card */
}
```

Long content still grows the card and scrolls the side panel (`min-height: auto` won't clip); the manifest preview keeps its own `min-height: 0` for its inner YAML scroll. Locked in with a CSS source-text assertion.

## Verification

- `pnpm test:app` — 315 test files pass; `pnpm typecheck` + `pnpm build` clean.
- Driven in the running app: the Inspect card height went `134px → 786px`, its bordered surface running top-to-bottom with content at the top — mirroring the left library panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)