### PR TITLE
feat(sidebar): widen section labels + match left panel start width to right

### DIFF
--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -425,9 +425,9 @@ function ShellInner({
       <Panel
         id="nav"
         className={`shell-nav-panel${navOpen ? " shell-nav-panel--open" : ""}`}
-        defaultSize="18%"
+        defaultSize="24%"
         minSize="14%"
-        maxSize="25%"
+        maxSize="28%"
         collapsible
         collapsedSize={0}
         panelRef={navRef}

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -392,7 +392,7 @@
   align-items: center;
   gap: 8px;
   width: 100%;
-  margin: 2px 6px 8px;
+  margin: 2px 2px 8px;
   padding: 6px 10px;
   border-radius: 7px;
   background: color-mix(in oklch, var(--bg-base) 70%, var(--foreground) 30%);


### PR DESCRIPTION
## What

Follow-up sidebar polish:

- **Left panel start width → parity with the right.** The left nav panel opened at `18%` while the right companion panel opens at `24%`. Bump the nav `defaultSize` to `24%` so both sides start at the same width (max nudged `25%` → `28%` for resize headroom).
- **Widen the section-label pills.** The WORK / KNOWLEDGE / TOOLS header pills had a 6px side margin; drop to 2px so the section names span more of the (now wider) panel.

## Changes

- `src/components/shell.tsx` — nav `Panel` `defaultSize` `18%` → `24%`, `maxSize` `25%` → `28%`.
- `src/styles/sidebar-minimal.css` — `.sidebar-section-label` margin `2px 6px 8px` → `2px 2px 8px`.

## Verification

- `tsc --noEmit` clean
- `node scripts/run-tests.mjs app` → 315 test files pass
- Live-verified in dev (worktree, port 3100): nav panel renders 346px (24% of 1440, matching the right panel's 24%); section pills span nearly the full panel width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)