### PR TITLE
fix(menu-bar): harden top search bar against screen magnification

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3771,8 +3771,10 @@ button:active > .edge-rail-chip {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 0 12px;
-  height: 44px;
+  padding: 6px 12px;
+  /* min-height (not a fixed height) so the bar grows with scaled-up content
+     under screen magnification instead of clipping the search row. */
+  min-height: 44px;
   background: var(--bg-panel);
   border-bottom: 1px solid var(--border-hairline);
   font-size: var(--text-sm);
@@ -3830,6 +3832,12 @@ button:active > .edge-rail-chip {
 
 .menu-bar__search-icon {
   flex-shrink: 0;
+  /* Center the icon on the search row and size it relative to the text so it
+     scales together with the input under screen magnification (rem fonts)
+     instead of staying a tiny fixed-px glyph pinned to the top. */
+  align-self: center;
+  width: 1.15em;
+  height: 1.15em;
 }
 
 .menu-bar__search-input {
@@ -3840,6 +3848,7 @@ button:active > .edge-rail-chip {
   background: transparent;
   color: var(--text-primary);
   font: inherit;
+  line-height: 1.4;
 }
 
 .menu-bar__search-input::placeholder {

--- a/tests/mobile/foundations.spec.ts
+++ b/tests/mobile/foundations.spec.ts
@@ -185,6 +185,12 @@ test.describe("mobile foundations", () => {
     });
     await page.reload();
     await page.waitForSelector(".shell-frame");
+    // Wait for the ScreenMagnificationController effect to fire and stamp the
+    // data-screen-scale attribute on <html> before reading metrics.
+    await page.waitForFunction(
+      () => document.documentElement.hasAttribute("data-screen-scale"),
+      { timeout: 5000 },
+    );
 
     const metrics = await page.evaluate(() => {
       const frame = document.querySelector(".shell-frame");


### PR DESCRIPTION
## What

The desktop menu-bar search row used a fixed `44px` bar height and a fixed-px search icon. At normal zoom it's aligned, but under **screen magnification** the row can clip and the small fixed icon looks stranded above the scaled-up "Search or ask Salem…" text (per a reported screenshot).

- `.menu-bar` → `min-height` instead of a fixed `height`, so the bar grows with scaled content instead of clipping.
- `.menu-bar__search-icon` → `em`-sized and explicitly `align-self: center`, so it scales with the input text and stays vertically centered at any magnification.
- `.menu-bar__search-input` → controlled `line-height`.

## Verification

Standalone harness (real `.menu-bar` CSS), measured at normal and magnified text:
- Normal (12px): bar 44px; icon/input/⌘K all centered (cy≈21.5) — no regression.
- Magnified (22px): bar grows to ~58px (no clip); icon scales 13.8→25.3px with the text; all elements centered (cy≈28.4).

`tsc --noEmit` clean · `node scripts/run-tests.mjs app` → 315 files pass · `familiar-menu-bar.test.ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)