### PR TITLE
chore: release 0.0.107

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ A coding-experience arc: turning the Projects/Code surfaces into a Codex/Cursor-
 ### Fixed
 - **Code workspace** — the unified surface now shows the coding panes (file tree, editor, search, change review), not just a terminal (#949).
 
+## [0.0.107] - 2026-06-19
+
+Patch release: a desktop UX pass on the left sidebar and the top menu bar, plus an in-panel YouTube viewer.
+
+### Added
+- **Companion-rail video tab** — a "Video" toggle in the right companion panel splits it into a resizable bottom pane with a YouTube viewer; the editable bar accepts any YouTube link, video ID, or playlist (#1025).
+
+### Changed
+- **Left sidebar declutter** — the familiar scope switcher and "New session" button moved out of the left panel (they already live in the desktop top menu bar and the mobile top bar), so the nav flows directly under the wordmark and sits flush against the panel edge (#1029). The panel now opens at the same width as the right companion panel, and the WORK/KNOWLEDGE/TOOLS section labels are widened (#1032).
+
+### Fixed
+- **Top search bar** — the desktop menu-bar search no longer clips or strands its icon under screen magnification: the bar grows to fit and the search icon scales with the text and stays centered (#1034).
+
 ## [0.0.104] - 2026-06-18
 
 Patch release: the Workflow Studio's **Play** now actually runs a workflow, plus terminal-split survival, a fullscreen diagram viewer, and assorted UI polish.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A familiar is not just a chat window. It has a name, role, runtime, memory, tool
 
 ## Status
 
-- Current app version: `0.0.104`
+- Current app version: `0.0.107`
 - Native shell: Tauri 2
 - Frontend: Next.js 16, React 19, Tailwind v4
 - Runtime dependency: a healthy local `coven` CLI/daemon plus at least one runtime source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.106",
+  "version": "0.0.107",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.106"
+version = "0.0.107"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.106"
+version = "0.0.107"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.106</string>
+	<string>0.0.107</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.106</string>
+	<string>0.0.107</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.106</string>
+	<string>0.0.107</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.106</string>
+	<string>0.0.107</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.106",
+  "version": "0.0.107",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Release 0.0.107

Bumps all version-bearing files to **0.0.107** and adds the changelog entry.

### Included since 0.0.106
- **Companion-rail Video tab** — resizable in-panel YouTube viewer (link / video ID / playlist) (#1025)
- **Left sidebar declutter** — switcher + New session removed (they live in the top bars), flush-left, parity width with the right panel, widened section labels (#1029, #1032)
- **Top search bar** — hardened against screen magnification: bar grows instead of clipping, icon scales with the text and stays centered (#1034)

### Version files bumped
package.json · src-tauri/tauri.conf.json · src-tauri/Cargo.toml · src-tauri/Cargo.lock (app) · src-tauri/Info.ios.plist · src-tauri/gen/apple/app_iOS/Info.plist · README · CHANGELOG

### Verification
`app-version.test.ts` passes (all 8 files consistent) · `node scripts/run-tests.mjs app` → 315 files pass.

After merge: a signed `v0.0.107` tag will trigger `release.yml` to publish the DMG/AppImage/MSI assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)