### PR TITLE
feat(salem): ask the real index using the local familiar's model (AI credits)

### DIFF
--- a/src/app/api/salem/route.ts
+++ b/src/app/api/salem/route.ts
@@ -43,15 +43,20 @@ type SalemSearchContext = {
  * response into a single reply string. Returns null on any failure so the
  * caller can fall back to local retrieval (Cave stays useful offline).
  */
-async function askChatApi(message: string): Promise<string | null> {
+async function askChatApi(message: string, model?: string | null): Promise<string | null> {
   try {
     const controller = new AbortController();
     const connectTimer = setTimeout(() => controller.abort(), CHAT_API_CONNECT_TIMEOUT_MS);
 
+    // Forward the local familiar's model so the chat-api generates with it and
+    // the AI credits attribute to that model rather than the chat-api default.
+    // (The chat-api must honor `model` for the credit attribution to take effect.)
+    const payload = model ? { message, model } : { message };
+
     const res = await fetch(`${CHAT_API_URL}/api/chat`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ message }),
+      body: JSON.stringify(payload),
       signal: controller.signal,
     }).finally(() => clearTimeout(connectTimer));
 
@@ -251,8 +256,10 @@ export async function GET() {
 
 export async function POST(req: Request) {
   try {
-    const body = (await req.json()) as { message?: string; context?: SalemSearchContext };
+    const body = (await req.json()) as { message?: string; context?: SalemSearchContext; model?: string };
     const message = (body.message ?? "").trim();
+    // The model of the local familiar this ask is scoped to (credit attribution).
+    const model = typeof body.model === "string" && body.model.trim() ? body.model.trim() : null;
 
     if (!message) {
       return NextResponse.json({ error: "No message provided." }, { status: 400 });
@@ -270,7 +277,7 @@ export async function POST(req: Request) {
 
     // Primary path: ask the real opencoven-chat-api for a grounded, LLM-written
     // answer. Falls through to local token-overlap retrieval if unreachable.
-    const apiReply = await askChatApi(messageForApi);
+    const apiReply = await askChatApi(messageForApi, model);
     if (apiReply) {
       return NextResponse.json({
         reply: apiReply,

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -483,12 +483,19 @@ export function CommandPalette({
     setSalemAnswer(null);
     setSalemError(null);
     try {
+      // Use the local familiar's model (the one you're scoped to, falling back
+      // to Salem's own) so the chat-api's AI credits attribute to it.
+      const localModel =
+        familiars.find((f) => f.id === activeFamiliarId)?.model ??
+        familiars.find((f) => f.id === "salem")?.model ??
+        undefined;
       const res = await fetch("/api/salem", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           message: query.trim(),
           context: buildSalemSearchContext(rows, query.trim()),
+          model: localModel,
         }),
       });
       const data = (await res.json()) as { reply?: string; error?: string };

--- a/src/components/familiar-menu-bar.test.ts
+++ b/src/components/familiar-menu-bar.test.ts
@@ -155,7 +155,7 @@ assert.match(
 );
 assert.match(
   workspace,
-  /salemSlot=\{<SalemChatPanel \/>\}/,
+  /salemSlot=\{[\s\S]*?<SalemChatPanel\s+model=\{/,
   "Salem should remain available in the companion sidepanel",
 );
 assert.doesNotMatch(

--- a/src/components/salem/salem-widget.tsx
+++ b/src/components/salem/salem-widget.tsx
@@ -17,7 +17,7 @@ type SalemMood = "idle" | "thinking" | "happy" | "listening";
 
 const GREETING = "I'm Salem, your Coven docs familiar. Yes, the black-cat-in-the-corner thing is intentional. I'm preloaded with Coven docs, tool context, guide skills, and Cave route awareness. Ask me about familiars, plugins, roles, the marketplace, or how Cave works.";
 
-export function SalemChatPanel() {
+export function SalemChatPanel({ model }: { model?: string | null } = {}) {
   const [mood, setMood] = useState<SalemMood>("idle");
   const [messages, setMessages] = useState<Message[]>([
     { role: "salem", text: GREETING },
@@ -128,7 +128,8 @@ export function SalemChatPanel() {
       const res = await fetch("/api/salem", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: text }),
+        // Carry the local familiar's model so the chat-api's credits attribute to it.
+        body: JSON.stringify(model ? { message: text, model } : { message: text }),
       });
       const data = (await res.json()) as { reply?: string; error?: string };
       const raw = data.reply ?? data.error ?? "Hmm, I couldn't find that one. Try rephrasing?";

--- a/src/components/salem/salem.test.ts
+++ b/src/components/salem/salem.test.ts
@@ -57,7 +57,8 @@ assert.match(route, /CHAT_API_TIMEOUT_MS\s*=\s*45_000/, "Salem upstream chat API
 assert.doesNotMatch(route, /const connectTimeoutMs = 2_500/, "Salem must not abort the upstream chat API before it can stream");
 assert.match(route, /type SalemSearchContext/, "Salem API should accept structured local search context");
 assert.match(route, /formatSearchContextForPrompt\(context\)/, "Salem API should format top-bar search context into the hosted prompt");
-assert.match(route, /askChatApi\(messageForApi\)/, "Hosted Salem responses should receive the context-aware prompt");
+assert.match(route, /askChatApi\(messageForApi, model\)/, "Hosted Salem responses should receive the context-aware prompt and the local familiar's model");
+assert.match(route, /payload = model \? \{ message, model \} : \{ message \}/, "Salem must forward the local familiar's model to the chat-api so AI credits attribute to it");
 assert.match(route, /localContextUsed/, "Salem API response should disclose whether local context was included");
 assert.match(route, /familiar|familiar/, "must know about familiars");
 assert.match(route, /role|Role/, "must know about roles");
@@ -84,7 +85,7 @@ assert.match(workspace, /shellRef\.current\?\.openFamiliar\(\)/, "Salem launcher
 assert.match(workspace, /setRailTab\("salem"\)/, "Salem launcher must select the Salem rail tab");
 assert.match(workspace, /import \{ SalemChatPanel \}/, "workspace should import only the Salem sidepanel surface");
 assert.doesNotMatch(workspace, /SalemWidget|salemRetreating/, "workspace must not render or compute floating Salem state");
-assert.match(workspace, /salemSlot=\{<SalemChatPanel \/>\}/, "workspace must render Salem in the companion rail");
+assert.match(workspace, /salemSlot=\{[\s\S]*?<SalemChatPanel\s+model=\{/, "workspace must render Salem in the companion rail with the local familiar's model");
 assert.match(companionRail, /"salem"/, "companion rail must expose a Salem tab");
 
 // 7. CSS classes present

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1767,7 +1767,11 @@ export function Workspace() {
               browserSlot={
                 <BrowserPane ref={companionBrowserPaneRef} label="companion" activeFamiliarId={active?.id ?? null} />
               }
-              salemSlot={<SalemChatPanel />}
+              salemSlot={
+                <SalemChatPanel
+                  model={active?.model ?? familiars.find((f) => f.id === "salem")?.model ?? null}
+                />
+              }
             />
           ) : undefined
         }


### PR DESCRIPTION
## What

"Ask Salem" (the top search bar's ask path + the Salem companion panel) already pings the **real index** — `/api/salem` calls the opencoven-chat-api (`salem.opencoven.ai/api/chat`, hybrid RAG + reranking over the docs index), only falling back to local doc retrieval when that's unreachable.

But it sent only `{ message }`, so the chat-api generated with **its own default model** and the AI credits never attributed to the user's familiar.

This threads the **local familiar's model** through so the generation — and its AI credits — attribute to it:
- Command palette ("ask Salem") and the Salem panel send the **active/scoped familiar's `model`**, falling back to Salem's own configured model.
- `/api/salem` forwards it to the chat-api as `{ message, model }` (omitted when absent, so offline/local fallback is unchanged).

## ⚠️ Backend dependency

The chat-api must **honor the `model` field** for the credit attribution to actually move. Cave now always supplies it; the `salem.opencoven.ai` backend needs to read it.

## Verification

`tsc --noEmit` clean · `node scripts/run-tests.mjs app` → 315 files pass. New assertions in `salem.test.ts` pin the `{ message, model }` payload + the `askChatApi(messageForApi, model)` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)