### PR TITLE
fix(search): allow exiting top search via Esc and click-off

### DIFF
--- a/src/components/familiar-menu-bar.test.ts
+++ b/src/components/familiar-menu-bar.test.ts
@@ -37,8 +37,13 @@ assert.match(
 );
 assert.match(
   source,
+  /onClick=\{onOpenSearch\}/,
+  "clicking desktop menu bar search should open the context-aware palette (open on click, not focus, so the palette's focus-restore on close can't reopen it)",
+);
+assert.doesNotMatch(
+  source,
   /onFocus=\{onOpenSearch\}/,
-  "focusing desktop menu bar search should open the context-aware palette",
+  "desktop menu bar search must NOT open on focus — the palette restores focus to this input on close, which would reopen it and trap the user",
 );
 
 // Left group — chat. The top panel should keep only the dropdown selector and

--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -84,6 +84,11 @@ export function FamiliarMenuBar({
       <form
         className="menu-bar__search"
         role="search"
+        // Open the palette on an explicit click (or Enter via onSubmit), NOT on
+        // focus. The palette restores focus to this input when it closes, so
+        // opening on focus would immediately reopen it — making Escape and
+        // click-off impossible to escape.
+        onClick={onOpenSearch}
         onSubmit={(e) => {
           e.preventDefault();
           onOpenSearch();
@@ -95,7 +100,6 @@ export function FamiliarMenuBar({
           className="menu-bar__search-input"
           value={searchQuery}
           onChange={(e) => onSearchQueryChange(e.target.value)}
-          onFocus={onOpenSearch}
           placeholder="Search or ask Salem..."
           aria-label="Search anything or ask Salem"
           autoComplete="off"

--- a/src/components/top-bar.test.ts
+++ b/src/components/top-bar.test.ts
@@ -66,8 +66,13 @@ assert.match(
 
 assert.match(
   source,
+  /onClick=\{onOpenPalette\}/,
+  "Clicking the top search should open the context-aware palette (open on click, not focus, so the palette's focus-restore on close can't reopen it)",
+);
+assert.doesNotMatch(
+  source,
   /onFocus=\{onOpenPalette\}/,
-  "Focusing the top search input should open the context-aware palette",
+  "Top search must NOT open on focus — the palette restores focus to this input on close, which would reopen it and trap the user",
 );
 
 assert.match(

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -128,6 +128,11 @@ export function TopBar(props: Props) {
       <form
         className="top-bar__search"
         role="search"
+        // Open the palette on an explicit click (or Enter via onSubmit), NOT on
+        // focus. The palette restores focus to this input when it closes, so
+        // opening on focus would immediately reopen it — making Escape and
+        // click-off impossible to escape.
+        onClick={onOpenPalette}
         onSubmit={(e) => {
           e.preventDefault();
           onOpenPalette();
@@ -139,7 +144,6 @@ export function TopBar(props: Props) {
           className="top-bar__search-input"
           value={searchQuery}
           onChange={(e) => onSearchQueryChange(e.target.value)}
-          onFocus={onOpenPalette}
           placeholder="Search or ask Salem..."
           aria-label="Search anything or ask Salem"
           autoComplete="off"


### PR DESCRIPTION
## Problem

The desktop menu-bar and mobile top-bar search inputs opened the command palette **on focus**. When the palette closes, `useFocusTrap` restores focus to the input that opened it (standard focus-trap accessibility). So pressing **Escape** or **clicking off** closed the palette — but the focus-restore immediately re-triggered `onFocus` and **reopened it**, trapping the user in search with no way out.

The palette's own dismissal was never broken: Escape (window keydown listener in `useFocusTrap`) and click-off (backdrop `onClick={onClose}`) both fired `onClose`. The reopen loop was the bug.

## Fix

Open the palette on an explicit `onClick` (Enter still works via the existing `onSubmit`) instead of `onFocus`, in both `familiar-menu-bar.tsx` (desktop) and `top-bar.tsx` (mobile). The programmatic focus-restore on close no longer reopens the palette, while clicking the bar or typing still opens it. Focus-restore-to-trigger a11y is preserved.

Updated the two source-text tests to require `onClick` and forbid the `onFocus` open handler.

## Test

- `node --experimental-strip-types src/components/familiar-menu-bar.test.ts` ✅
- `node --experimental-strip-types src/components/top-bar.test.ts` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)