### PR TITLE
feat(companion-rail): keep YouTube playing as a rotated strip when the panel is closed

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3308,6 +3308,7 @@ button:active > .edge-rail-chip {
 .companion-rail {
   display: flex;
   flex-direction: column;
+  position: relative;
   height: 100%;
   min-height: 0;
   background: var(--bg-raised);
@@ -3570,7 +3571,9 @@ button:active > .edge-rail-chip {
    so it runs top→bottom. The YouTube iframe stays mounted across the
    collapse (CSS-only restyle, no remount) so playback continues. */
 
-/* Slim re-expand button — hidden until the rail is a strip. */
+/* Re-expand affordance — hidden until the rail is a strip, where it becomes a
+   full-area transparent overlay so tapping anywhere on the video expands the
+   panel (a caret hint sits at the top for discoverability). */
 .companion-rail__strip-expand {
   display: none;
 }
@@ -3596,22 +3599,31 @@ button:active > .edge-rail-chip {
 
 .companion-rail--video-strip .companion-rail__strip-expand {
   display: flex;
-  align-items: center;
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  align-items: flex-start;
   justify-content: center;
-  flex-shrink: 0;
-  width: 100%;
-  height: 26px;
+  padding-top: 7px;
   border: 0;
-  border-bottom: 1px solid var(--border-hairline);
-  background: var(--bg-panel);
-  color: var(--text-muted);
+  /* A soft top fade keeps the caret legible over a bright video; the rest of
+     the overlay stays transparent so the video shows through. */
+  background: linear-gradient(
+    to bottom,
+    color-mix(in oklch, var(--bg-base) 70%, transparent),
+    transparent 38px
+  );
+  color: #fff;
   cursor: pointer;
-  transition: color 0.1s, background 0.1s;
+  transition: background 0.12s;
 }
 
 .companion-rail--video-strip .companion-rail__strip-expand:hover {
-  background: var(--bg-raised);
-  color: var(--text-primary);
+  background: linear-gradient(
+    to bottom,
+    color-mix(in oklch, var(--bg-base) 80%, transparent),
+    color-mix(in oklch, var(--bg-base) 22%, transparent)
+  );
 }
 
 .companion-rail--video-strip #companion-rail-youtube {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3564,6 +3564,78 @@ button:active > .edge-rail-chip {
   border: 0;
 }
 
+/* ── Collapsed video strip ──────────────────────────────────────────────
+   When the companion rail is collapsed to its peek width while the Video
+   pane is on, it becomes a thin sliver showing only the video, rotated 90°
+   so it runs top→bottom. The YouTube iframe stays mounted across the
+   collapse (CSS-only restyle, no remount) so playback continues. */
+
+/* Slim re-expand button — hidden until the rail is a strip. */
+.companion-rail__strip-expand {
+  display: none;
+}
+
+.companion-rail--video-strip {
+  overflow: hidden;
+}
+
+/* Drop the tab strip + the top (chat/memory/etc.) pane and its resizer;
+   the video pane fills the whole strip. The split panes are sized by
+   react-resizable-panels via inline `flex` on the id'd wrappers, so we
+   override those with `!important` (and hide the unused pane outright). */
+.companion-rail--video-strip .companion-rail__tabs,
+.companion-rail--video-strip .youtube-viewer__bar,
+.companion-rail--video-strip .youtube-viewer__error {
+  display: none;
+}
+
+.companion-rail--video-strip #companion-rail-main,
+.companion-rail--video-strip .companion-rail__resize {
+  display: none !important;
+}
+
+.companion-rail--video-strip .companion-rail__strip-expand {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 100%;
+  height: 26px;
+  border: 0;
+  border-bottom: 1px solid var(--border-hairline);
+  background: var(--bg-panel);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.1s, background 0.1s;
+}
+
+.companion-rail--video-strip .companion-rail__strip-expand:hover {
+  background: var(--bg-raised);
+  color: var(--text-primary);
+}
+
+.companion-rail--video-strip #companion-rail-youtube {
+  flex: 1 1 auto !important;
+}
+
+/* Rotate the video to run top→bottom and fill the tall, narrow strip.
+   `container-type: size` lets the iframe size off the frame's box: its
+   pre-rotation width = frame height, height = frame width, so after a 90°
+   turn it covers the frame exactly. */
+.companion-rail--video-strip .youtube-viewer__frame {
+  container-type: size;
+}
+
+.companion-rail--video-strip .youtube-viewer__frame iframe {
+  inset: auto;
+  top: 50%;
+  left: 50%;
+  width: 100cqh;
+  height: 100cqw;
+  transform: translate(-50%, -50%) rotate(90deg);
+  transform-origin: center;
+}
+
 /* ────────────────────────────────────────────────
    Rail-pane empty + memory styles
    (Phase 2, shell-ia-redesign)

--- a/src/components/companion-rail.test.ts
+++ b/src/components/companion-rail.test.ts
@@ -46,3 +46,36 @@ assert.doesNotMatch(
   /new CustomEvent\("cave:familiar-panel-toggle"\)/,
   "rail no longer dispatches the cave:familiar-panel-toggle collapse event",
 );
+
+// Video ("Video" toggle) state is liftable to the parent so the shell can keep
+// the rail peeking as a rotated video strip when it's collapsed.
+assert.match(
+  source,
+  /youtubeActive\?: boolean/,
+  "rail accepts a controlled youtubeActive prop",
+);
+assert.match(
+  source,
+  /onYoutubeActiveChange\?:/,
+  "rail reports Video on/off changes to the parent",
+);
+assert.match(
+  source,
+  /const youtubeOpen = youtubeActive \?\? localYoutubeOpen/,
+  "Video state is controlled when youtubeActive is provided, else local",
+);
+assert.match(
+  source,
+  /companion-rail--video-strip/,
+  "rail applies the collapsed-video-strip class when videoStrip is set",
+);
+assert.match(
+  source,
+  /companion-rail__split-pane--video/,
+  "the YouTube split pane is tagged so the strip CSS can target it",
+);
+assert.match(
+  source,
+  /companion-rail__strip-expand/,
+  "rail renders a re-expand affordance for the collapsed video strip",
+);

--- a/src/components/companion-rail.tsx
+++ b/src/components/companion-rail.tsx
@@ -27,6 +27,16 @@ type Props = {
    * render a second redundant CTA. */
   suppressEmpty?: boolean;
   hideChatTab?: boolean;
+  /** Whether the YouTube ("Video") pane is on. Lift this to the parent so the
+   *  shell can keep the rail peeking (as a rotated video strip) when collapsed.
+   *  Uncontrolled (local state) when omitted. */
+  youtubeActive?: boolean;
+  onYoutubeActiveChange?: (active: boolean) => void;
+  /** True when the rail is collapsed to its peek strip while video is on — the
+   *  rail then shows only the video, rotated to run top→bottom. */
+  videoStrip?: boolean;
+  /** Re-expand the rail from the collapsed video strip. */
+  onExpandRail?: () => void;
 };
 
 // forwardRef handle is wired in Task 2.3; ref is forwarded to the chatSlot consumer.
@@ -44,12 +54,22 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
       onTabChange,
       suppressEmpty = false,
       hideChatTab = false,
+      youtubeActive,
+      onYoutubeActiveChange,
+      videoStrip = false,
+      onExpandRail,
     } = props;
     const [tab, setTab] = useState<CompanionTab>(defaultTab);
     // The Video tab is a toggle, not a mutually-exclusive section: when on, the
     // YouTube viewer drops into a resizable bottom pane below the active tab's
-    // content rather than replacing it.
-    const [youtubeOpen, setYoutubeOpen] = useState(false);
+    // content rather than replacing it. The on/off state can be lifted to the
+    // parent (controlled) so the shell can keep the rail peeking when collapsed.
+    const [localYoutubeOpen, setLocalYoutubeOpen] = useState(false);
+    const youtubeOpen = youtubeActive ?? localYoutubeOpen;
+    const setYoutubeOpen = (next: boolean) => {
+      setLocalYoutubeOpen(next);
+      onYoutubeActiveChange?.(next);
+    };
     const requestedTab = activeTab ?? tab;
     const fallbackTab: CompanionTab = browserSlot ? "browser" : salemSlot ? "salem" : "memory";
     const selectedTab =
@@ -122,7 +142,25 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
     );
 
     return (
-      <aside className="companion-rail">
+      <aside
+        className={`companion-rail${videoStrip ? " companion-rail--video-strip" : ""}`}
+        data-video-strip={videoStrip ? "" : undefined}
+      >
+        {/* Collapsed-strip affordance: when the rail is peeking as a rotated
+            video, the tab strip is hidden (CSS) and this slim button re-expands
+            the panel. Rendered whenever video is on so toggling collapse never
+            remounts the iframe; CSS shows it only in strip mode. */}
+        {youtubeOpen && onExpandRail ? (
+          <button
+            type="button"
+            className="companion-rail__strip-expand"
+            onClick={onExpandRail}
+            aria-label="Expand video panel"
+            title="Expand"
+          >
+            <Icon name="ph:caret-left" width={13} />
+          </button>
+        ) : null}
         {/* Familiar header removed — the tab strip is the panel's top row and
             its trigger band aligns with the left sidebar's floating toggle. */}
         <nav className="companion-rail__tabs" aria-label="Companion sections">
@@ -173,7 +211,7 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
           <button
             type="button"
             className={`companion-rail__tab${youtubeOpen ? " companion-rail__tab--active" : ""}`}
-            onClick={() => setYoutubeOpen((open) => !open)}
+            onClick={() => setYoutubeOpen(!youtubeOpen)}
             aria-pressed={youtubeOpen}
             title="Video"
           >
@@ -187,7 +225,7 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
                 id="companion-rail-main"
                 minSize={20}
                 defaultSize={58}
-                className="companion-rail__split-pane"
+                className="companion-rail__split-pane companion-rail__split-pane--main"
               >
                 {panes}
               </Panel>
@@ -198,7 +236,7 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
                 id="companion-rail-youtube"
                 minSize={20}
                 defaultSize={42}
-                className="companion-rail__split-pane"
+                className="companion-rail__split-pane companion-rail__split-pane--video"
               >
                 <YoutubeViewer />
               </Panel>

--- a/src/components/companion-rail.tsx
+++ b/src/components/companion-rail.tsx
@@ -147,16 +147,18 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
         data-video-strip={videoStrip ? "" : undefined}
       >
         {/* Collapsed-strip affordance: when the rail is peeking as a rotated
-            video, the tab strip is hidden (CSS) and this slim button re-expands
-            the panel. Rendered whenever video is on so toggling collapse never
-            remounts the iframe; CSS shows it only in strip mode. */}
+            video, the tab strip is hidden (CSS) and this button becomes a
+            full-area transparent overlay so tapping anywhere on the video
+            re-expands the panel (a caret hint sits at the top). Rendered
+            whenever video is on so toggling collapse never remounts the iframe;
+            CSS shows it only in strip mode. */}
         {youtubeOpen && onExpandRail ? (
           <button
             type="button"
             className="companion-rail__strip-expand"
             onClick={onExpandRail}
             aria-label="Expand video panel"
-            title="Expand"
+            title="Tap to expand"
           >
             <Icon name="ph:caret-left" width={13} />
           </button>

--- a/src/components/right-panel-expand.test.ts
+++ b/src/components/right-panel-expand.test.ts
@@ -58,4 +58,33 @@ assert.match(
   "expand toggle is hidden again while the panel is expanded",
 );
 
+// ── Collapsed YouTube strip ────────────────────────────────────────────────
+// When a video is playing, "closing" the right panel leaves a thin peek strip
+// (rotated video) instead of collapsing to nothing.
+assert.match(
+  shell,
+  /rightPanelPeek\?:\s*boolean/,
+  "shell accepts a rightPanelPeek prop",
+);
+assert.match(
+  shell,
+  /collapsedSize=\{rightPanelPeek \? `\$\{RAIL_PEEK_PX\}px` : 0\}/,
+  "the agent panel collapses to a peek strip (not 0) while peeking",
+);
+assert.match(
+  shell,
+  /familiarOpen \|\| rightPanelPeek \? agent : null/,
+  "the rail content stays mounted while peeking so the video keeps playing",
+);
+assert.match(
+  css,
+  /\.companion-rail--video-strip[\s\S]*?rotate\(90deg\)/,
+  "the collapsed strip rotates the video 90° to run top→bottom",
+);
+assert.match(
+  css,
+  /\.companion-rail--video-strip\s+\.youtube-viewer__frame\s*\{[\s\S]*?container-type:\s*size/,
+  "the strip uses a size container so the rotated iframe fills it",
+);
+
 console.log("right-panel-expand.test.ts: ok");

--- a/src/components/right-panel-expand.test.ts
+++ b/src/components/right-panel-expand.test.ts
@@ -86,5 +86,10 @@ assert.match(
   /\.companion-rail--video-strip\s+\.youtube-viewer__frame\s*\{[\s\S]*?container-type:\s*size/,
   "the strip uses a size container so the rotated iframe fills it",
 );
+assert.match(
+  css,
+  /\.companion-rail--video-strip\s+\.companion-rail__strip-expand\s*\{[\s\S]*?position:\s*absolute[\s\S]*?inset:\s*0/,
+  "the re-expand affordance is a full-area overlay so tapping the video expands it",
+);
 
 console.log("right-panel-expand.test.ts: ok");

--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -151,6 +151,6 @@ assert.match(
 );
 assert.match(
   shell,
-  /<aside className="shell-familiar" aria-label="Companion">/,
+  /<aside\s+className="shell-familiar"[\s\S]*?aria-label="Companion"/,
   "Shell agent panel must carry a distinct accessible name (axe landmark-unique)",
 );

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -74,6 +74,13 @@ function togglePanel(panel: PanelImperativeHandle | null) {
   else panel.collapse();
 }
 
+// Width of the right-panel "peek" strip — the thin sliver the companion rail
+// collapses to (instead of vanishing) when `rightPanelPeek` is on, e.g. to keep
+// a rotated YouTube video visible while the panel is closed. Sizes below this
+// (the strip, or 0 when not peeking) read as "panel closed".
+const RAIL_PEEK_PX = 56;
+const RAIL_OPEN_THRESHOLD_PX = RAIL_PEEK_PX + 16;
+
 export type ShellNavSection = {
   label?: string;
   items: ShellNavItem[];
@@ -125,6 +132,7 @@ function ShellInner({
   mobileTabs,
   onNavOpenChange,
   onFamiliarOpenChange,
+  rightPanelPeek = false,
   panelShortcutOverrides,
 }: {
   nav: ReactNode;
@@ -139,6 +147,12 @@ function ShellInner({
   mobileTabs?: ReactNode;
   onNavOpenChange?: (open: boolean) => void;
   onFamiliarOpenChange?: (open: boolean) => void;
+  /** When true, "closing" the right (companion) panel leaves a thin peek strip
+   *  instead of collapsing to nothing, and keeps the panel's content mounted so
+   *  e.g. a playing video survives the collapse. Drives the YouTube-in-a-strip
+   *  behaviour: the companion rail renders its minimized (rotated video) view at
+   *  the peek width. */
+  rightPanelPeek?: boolean;
   panelShortcutOverrides?: Partial<PanelShortcutBindings>;
 }, ref: ForwardedRef<ShellHandle>) {
   const navRef = useRef<PanelImperativeHandle | null>(null);
@@ -474,13 +488,26 @@ function ShellInner({
             minSize="14%"
             maxSize="50%"
             collapsible
-            collapsedSize={0}
+            // When peeking, collapse to a thin strip instead of nothing so the
+            // companion rail can keep e.g. a playing video visible (rotated).
+            collapsedSize={rightPanelPeek ? `${RAIL_PEEK_PX}px` : 0}
             panelRef={familiarRef}
             onResize={(size) => {
-              setFamiliarOpen((size.asPercentage ?? 0) > 0);
+              // The panel is "open" only when it's wider than the peek strip —
+              // at the strip (or fully collapsed) the rail shows its minimized
+              // view, not the full content.
+              setFamiliarOpen((size.inPixels ?? 0) > RAIL_OPEN_THRESHOLD_PX);
             }}
           >
-            <aside className="shell-familiar" aria-label="Companion">{familiarOpen ? agent : null}</aside>
+            {/* Keep the rail mounted while peeking so the video survives the
+                collapse; otherwise unmount it when closed (the default). */}
+            <aside
+              className="shell-familiar"
+              aria-label="Companion"
+              data-rail-peek={rightPanelPeek && !familiarOpen ? "" : undefined}
+            >
+              {familiarOpen || rightPanelPeek ? agent : null}
+            </aside>
           </Panel>
         </>
       )}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -185,6 +185,10 @@ export function Workspace() {
     return (stored as CompanionTab) ?? "chat";
   });
   const [familiarPanelOpen, setFamiliarPanelOpen] = useState(false);
+  // YouTube ("Video") toggle state, lifted out of the companion rail so the
+  // shell can keep the right panel peeking as a rotated video strip when the
+  // user collapses it instead of vanishing (and stopping playback).
+  const [railVideoActive, setRailVideoActive] = useState(false);
   const [pendingProjectChatRoot, setPendingProjectChatRoot] = useState<string | null>(null);
   const [pendingChatAction, setPendingChatAction] = useState<PendingChatAction>(null);
   const [onboardingOpen, setOnboardingOpen] = useState(false);
@@ -1667,6 +1671,9 @@ export function Workspace() {
       <Shell
         ref={shellRef}
         mobileTabs={mobileTabs}
+        // While a video is playing in the rail, collapsing the right panel
+        // leaves a thin peek strip (rotated video) instead of closing fully.
+        rightPanelPeek={showCompanionRail && railVideoActive}
         onFamiliarOpenChange={(open) => {
           setFamiliarPanelOpen(open);
           if (activeId) setRailOpen(activeId, open);
@@ -1747,6 +1754,12 @@ export function Workspace() {
               onTabChange={setRailTab}
               daemonRunning={daemonRunning}
               onCreateFamiliar={openOnboarding}
+              youtubeActive={railVideoActive}
+              onYoutubeActiveChange={setRailVideoActive}
+              // When the panel is collapsed (peek) with video on, show only the
+              // rotated video strip; the top-bar toggle / this button re-expand.
+              videoStrip={railVideoActive && !familiarPanelOpen}
+              onExpandRail={() => shellRef.current?.openFamiliar()}
               hideChatTab={mode === "chat"}
               // Chat surface already shows a "Choose a familiar" CTA in the
               // detail panel — suppress the rail's duplicate prompt there.


### PR DESCRIPTION
## What

When you close the right-hand companion side panel while a YouTube video is playing, the panel no longer fully collapses (which unmounted the iframe and stopped playback). Instead it leaves a thin **peek strip** on the edge showing the video **rotated 90° so it runs top→bottom**, and it keeps playing.

Requested behavior, confirmed via the chosen option: *"Rotate 90° into a vertical strip — the panel stays as a thin strip on the edge; the video runs top→bottom and keeps playing."*

## How

- **Lift the Video toggle state** out of `CompanionRail` into `Workspace` (`railVideoActive`) so the shell knows when a video is active.
- **Shell**: a new `rightPanelPeek` prop. When set, the agent panel collapses to a **56px peek strip** (`collapsedSize`) instead of `0`, and the rail content stays **mounted** across the collapse so the iframe — and playback — survive. "Open" is measured against the strip width rather than just `> 0`.
- **CompanionRail**: a `videoStrip` mode renders only the video (rotated), hides the tab strip + URL bar, and adds a slim re-expand caret. The iframe keeps the **same tree slot** across the collapse (CSS-only restyle, no remount), so it doesn't restart.
- **CSS**: the strip uses a size container (`container-type: size`) so the 90°-rotated iframe fills the tall, narrow sliver; the resizable-panels inline `flex` on the id'd pane wrappers is overridden so the video pane takes the full height.

Re-expand via the existing top-bar side-panel toggle or the in-strip caret.

## Verification

- `pnpm typecheck` ✅ · `pnpm test:app` (315 files) ✅ · `pnpm check:tests-wired` ✅
- New source-text coverage in `companion-rail.test.ts` and `right-panel-expand.test.ts`.
- **Live-verified in the web build** (Playwright): expanded mode shows the upright video in the split pane; collapsing leaves a full-height rotated strip (`transform: matrix(0,1,-1,0,…)` = 90°, iframe 54×829 in an 855px-tall rail) that keeps playing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)