### PR TITLE
fix(canvas): preserve window size when moving (don't snap to default)

### DIFF
--- a/src/components/canvas-view.tsx
+++ b/src/components/canvas-view.tsx
@@ -131,7 +131,10 @@ function CanvasSurface({ familiars, activeFamiliarId }: Props) {
   }, []);
 
   const savePosition = useCallback((id: string, pos: CanvasPosition) => {
-    setPositions((prev) => ({ ...prev, [id]: pos }));
+    // Deep-merge so a position-only update (a drag sending just {x,y}) keeps the
+    // window's existing width/height instead of snapping it back to the default
+    // size. The server applies the same per-window merge.
+    setPositions((prev) => ({ ...prev, [id]: { ...prev[id], ...pos } }));
     void fetch("/api/canvas", {
       method: "PUT",
       headers: { "content-type": "application/json" },

--- a/src/lib/cave-canvas.ts
+++ b/src/lib/cave-canvas.ts
@@ -109,9 +109,16 @@ export async function mergeCanvasPositions(
   const clean = sanitizePositions(positions);
   return withLock(async () => {
     const current = await loadCanvas();
+    // Deep-merge per window so a position-only write (e.g. a drag that sends
+    // just {x,y}) preserves the window's saved width/height instead of dropping
+    // it and snapping the window back to its default size on reload.
+    const mergedPositions = { ...current.positions };
+    for (const [id, pos] of Object.entries(clean)) {
+      mergedPositions[id] = { ...mergedPositions[id], ...pos };
+    }
     const merged: CanvasFile = {
       ...current,
-      positions: { ...current.positions, ...clean },
+      positions: mergedPositions,
     };
     await saveCanvas(merged);
     return merged;


### PR DESCRIPTION
## What

Moving a canvas window reset its size back to the default (`ARTIFACT_W/H`). Dragging only saves `{x,y}`, but both the client state update (`savePosition`) and the server merge (`mergeCanvasPositions`) **replaced** the whole per-window entry — so the saved `width`/`height` were dropped and the window snapped to the starting size.

## Fix

Deep-merge per window at both layers so a position-only write preserves the existing `width`/`height`:
- `canvas-view.tsx` `savePosition` → `{ ...prev[id], ...pos }` (stops the visible snap on drag).
- `cave-canvas.ts` `mergeCanvasPositions` → per-id `{ ...current[id], ...pos }` (stops the snap on reload).

Resizing (which writes the full `{x,y,width,height}`) is unaffected.

## Verification

`tsc --noEmit` clean · `node scripts/run-tests.mjs app` → 315 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)