### PR TITLE
feat(canvas): syntax-highlight the in-chat artifact Code tab

### DIFF
--- a/src/components/chat-artifact-viewer.tsx
+++ b/src/components/chat-artifact-viewer.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/canvas-artifacts";
 import { buildReactSrcDoc } from "@/lib/canvas-react-harness";
 import { generateArtifactCode } from "@/lib/canvas-generate";
+import { highlightToHtml } from "@/components/message-bubble";
 
 type Props = {
   initialCode: string;
@@ -209,7 +210,7 @@ export function ChatArtifactViewer({ initialCode, kind: initialKind, title, fami
             onChange={(e) => { setCode(e.target.value); setSaveState("idle"); }}
           />
         ) : (
-          <pre className="chat-artifact__code"><code>{code}</code></pre>
+          <ArtifactCode code={code} kind={kind} />
         )}
       </div>
 
@@ -229,5 +230,35 @@ export function ChatArtifactViewer({ initialCode, kind: initialKind, title, fami
         </button>
       </div>
     </div>
+  );
+}
+
+/**
+ * The Code tab's read-only view: the same code, Shiki-highlighted to match the
+ * chat code blocks. Falls back to plain text until the (lazy) highlighter
+ * resolves, and on any highlight failure, so the code is always shown. React
+ * artifacts highlight as TSX; everything else as HTML.
+ */
+function ArtifactCode({ code, kind }: { code: string; kind: ArtifactKind }) {
+  const [html, setHtml] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setHtml(null);
+    void highlightToHtml(code, kind === "react" ? "tsx" : "html")
+      .then((h) => { if (!cancelled) setHtml(h); })
+      .catch(() => { if (!cancelled) setHtml(null); });
+    return () => { cancelled = true; };
+  }, [code, kind]);
+
+  if (!html) {
+    return <pre className="chat-artifact__code"><code>{code}</code></pre>;
+  }
+  return (
+    <div
+      className="chat-artifact__code chat-artifact__code--hl"
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
   );
 }

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -202,6 +202,18 @@ async function renderCodeBlock(
   return `<div class="cave-code-wrap">${headerHtml}${lineWrapped}${expandHtml}</div>`;
 }
 
+/**
+ * Highlight a snippet to a *bare* Shiki `<pre class="shiki">…</pre>` — no
+ * cave-code-wrap header, copy button, or line gutters. For surfaces that
+ * already supply their own chrome (e.g. the in-chat Canvas artifact viewer,
+ * which has its own header + actions) and just want colored code. Reuses the
+ * same lazy singleton as the chat code blocks, so no extra Shiki/WASM load.
+ */
+export async function highlightToHtml(code: string, lang: string): Promise<string> {
+  const hl = await getHighlighter();
+  return hl.codeToHtml(code, { lang: resolveShikiLang(lang), theme: "mood-c-dark" });
+}
+
 // ---------------------------------------------------------------------------
 // SyntaxBlock — exported for tool I/O and other raw-code surfaces
 // ---------------------------------------------------------------------------

--- a/src/styles/chat-artifact.css
+++ b/src/styles/chat-artifact.css
@@ -49,6 +49,15 @@
   color: var(--text-primary); background: var(--bg-base); border: 0;
 }
 .chat-artifact__code-edit { resize: vertical; white-space: pre; }
+/* Highlighted (read-only) code: the wrapper scrolls; Shiki's own <pre> drops
+   its padding/background so the box inherits the artifact's surface + spacing. */
+.chat-artifact__code--hl { padding: 0; }
+.chat-artifact__code--hl pre.shiki {
+  margin: 0; padding: 12px 14px; min-height: 100%; box-sizing: border-box;
+  background: transparent !important;
+  font: inherit; white-space: pre;
+}
+.chat-artifact__code--hl code { font: inherit; }
 .chat-artifact__error {
   position: absolute; left: 10px; right: 10px; bottom: 10px;
   display: flex; align-items: center; gap: 8px;


### PR DESCRIPTION
## What

The in-chat Canvas artifact viewer rendered its **Code** tab as a plain `<pre><code>` — no syntax highlighting. This adds Shiki highlighting that matches the chat code blocks.

## How

- Added a bare `highlightToHtml()` export to `message-bubble.tsx` that reuses the existing lazy Shiki **singleton** + `mood-c-dark` theme (no second WASM load).
- New `ArtifactCode` view in `chat-artifact-viewer.tsx`: highlights React artifacts as TSX, everything else as HTML. Falls back to plain text while the highlighter resolves and on any failure, so the code is always shown.
- "Bare" output (no `cave-code-wrap` header/copy/collapse chrome) so the artifact's own header + Refine bar stay uncluttered — no duplicate Copy button.
- CSS: the highlighted wrapper scrolls; Shiki's `<pre>` drops its own padding/background to inherit the artifact surface.

## Verification

- `pnpm test:app` — all 315 test files pass (including the source-text contract tests for the artifact viewer and message-bubble code header).
- `tsc --noEmit` clean.
- Ran the prod build and screenshotted both tabs: Code tab shows highlighted HTML; Canvas (preview) tab still renders the live artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)