### PR TITLE
feat(salem): synthesize through the local familiar (with no-regression fallback)

### DIFF
--- a/docs/salem-chat-api-model.md
+++ b/docs/salem-chat-api-model.md
@@ -1,54 +1,65 @@
-# opencoven-chat-api: honor a `model` field for generation + AI-credit billing
+# opencoven-chat-api: serve a `mode: "context"` retrieval response
 
 > Hand this to the agent/dev working in the **opencoven-chat-api** repo (the
-> service behind `salem.opencoven.ai`). The Coven Cave side already ships the
-> change that sends `model` — see `src/app/api/salem/route.ts` (`askChatApi`
-> posts `{ message, model }`) and PR #1037. This service must read and honor it.
+> service behind `salem.opencoven.ai`). Coven Cave's Salem feature now does its
+> own answer synthesis through the **user's selected familiar/model** (so the
+> user's connected provider owns billing) and only needs this service for the
+> **retrieved docs context**. See `src/app/api/salem/route.ts`
+> (`askChatApiContext` → local `askLocalFamiliar` synthesis via `/api/chat/send`).
 
 ## Task
 
-Honor a `model` field on `POST /api/chat` so the generation step **and** the AI-credit
-billing use the caller-supplied model instead of a hardcoded default.
+Add a `mode: "context"` branch to `POST /api/chat` that returns the **retrieved
+documentation context only** (no generated answer), as JSON, so Cave can
+synthesize the reply locally through the selected familiar.
 
-## Context
+## Why
 
-Coven Cave's Salem feature ("ask Salem" / the docs companion) calls this service for
-grounded, RAG-backed answers. Cave now sends the **local familiar's** model in every
-request so the AI credits attribute to that model rather than this service's default.
-This service currently ignores `model`, so credits still bill the default — fix that.
+Previously Cave forwarded a `model` and let this service generate the answer, so
+AI credits billed this service's default model. Cave now generates locally
+through the user's familiar (their connected model pays). For that, Cave needs
+the **retrieval/RAG context** from this service, not a finished answer.
 
-## Current request contract (must stay backward-compatible)
+## Required: `mode: "context"`
 
-- `POST /api/chat`, `Content-Type: application/json`
-- Body: `{ "message": string }` — and now optionally `{ "message": string, "model": string }`
-- Response: streamed `text/plain` deltas (Cave concatenates them). **Do not** change the
-  response shape.
-- Cave aborts after **20s to first byte** and **45s total**, so keep time-to-first-token fast.
+When the request body contains `"mode": "context"`, respond with **JSON**
+(not the streamed `text/plain` answer):
 
-## Required changes
+```jsonc
+// POST /api/chat   { "message": "...", "mode": "context" }
+{
+  "mode": "context",
+  "systemPrompt": "…the Salem system prompt…",   // string (required)
+  "context": "…retrieved + reranked doc chunks as markdown, with source links…", // string
+  "results": [ /* optional structured matches: {title, url, snippet, ...} */ ]
+}
+```
 
-1. Parse an optional `model: string` from the request body.
-2. When `model` is present and valid, use it for the LLM **generation** step (answer
-   synthesis after retrieval/reranking). Retrieval/index behavior stays the same.
-3. **Attribute usage/billing** (AI credits, token accounting, logs) to the supplied
-   `model` — this is the whole point. Ensure the credit meter reads the per-request
-   model, not a module-level constant.
-4. Validate against an allowlist of supported model IDs. On missing/empty/invalid
-   `model`, fall back to the existing default model and behavior (older callers and the
-   offline/local-fallback case stay unaffected).
-5. Keep the streamed `text/plain` output format identical.
+- `systemPrompt` (string) is **required** — Cave keys off it to decide context
+  mode succeeded (`typeof json.systemPrompt === "string"`).
+- `context` (string) should be the reranked doc passages Cave will ground the
+  local answer on, with markdown source links preserved.
+- Do the vector search + reranking exactly as you do for a normal answer; just
+  stop before generation and return the material instead.
+
+## Keep the existing default behavior
+
+Requests **without** `mode: "context"` (i.e. `{ "message": "..." }`) must keep
+streaming a `text/plain` answer exactly as today. Cave uses that as a
+**no-regression fallback** (`askChatApiAnswer`) until context mode ships, so
+nothing breaks in the meantime — Salem keeps giving good hosted answers and
+automatically upgrades to local-familiar synthesis once this endpoint serves
+context mode.
+
+## Timeouts
+
+Cave aborts the context request after **20s**. Keep it fast (no generation step).
 
 ## Acceptance criteria
 
-- `POST /api/chat` with `{"message":"...","model":"<allowed-id>"}` generates with that
-  model and the credit/usage record shows that model.
-- `POST /api/chat` with `{"message":"..."}` (no model) behaves exactly as today (default model).
-- An unsupported/garbage `model` value cleanly falls back to the default (no 5xx).
-- Streaming response and latency budget unchanged.
-- Add tests covering: model honored, model omitted → default, invalid model → default.
-
-## Model-ID vocabulary
-
-Cave passes the familiar's configured `model` string **verbatim** (e.g. `claude-opus-4-8`,
-`gpt-...`). Confirm this matches what the service expects; if they differ, add a mapping
-layer **here** rather than changing Cave.
+- `POST /api/chat` with `{"message":"...","mode":"context"}` returns JSON with a
+  string `systemPrompt` and a `context` string of reranked doc passages; **no**
+  generated answer.
+- `POST /api/chat` with `{"message":"..."}` (no mode) streams a `text/plain`
+  answer exactly as today.
+- Add tests for both shapes.

--- a/src/app/api/salem/route.ts
+++ b/src/app/api/salem/route.ts
@@ -17,9 +17,9 @@ const DOCS_BASE = "https://docs.opencoven.ai";
 const TOP_K = 5;
 const MAX_CHUNK_CHARS = 1200;
 
-// Salem's real brain: the opencoven-chat-api (hybrid RAG + reranking + streamed
-// GPT answers). When reachable, its grounded reply is preferred over the local
-// token-overlap fallback below. Override the origin with SALEM_CHAT_API_URL.
+// Hosted docs retrieval: the opencoven-chat-api owns the vector index and
+// reranking. Cave uses it for context, then synthesizes locally through the
+// selected familiar/model so user-connected providers own billing.
 const CHAT_API_URL = (
   process.env.SALEM_CHAT_API_URL ?? "https://salem.opencoven.ai"
 ).replace(/\/+$/, "");
@@ -38,36 +38,62 @@ type SalemSearchContext = {
   matches?: unknown;
 };
 
+type ChatApiContextResponse = {
+  mode?: unknown;
+  systemPrompt?: unknown;
+  context?: unknown;
+  results?: unknown;
+};
+
 /**
- * Ask the upstream opencoven-chat-api and aggregate its streamed text/plain
- * response into a single reply string. Returns null on any failure so the
- * caller can fall back to local retrieval (Cave stays useful offline).
+ * Ask the upstream opencoven-chat-api for retrieved docs context only. Cave
+ * owns the synthesis call so arbitrary connected user models stay local.
  */
-async function askChatApi(message: string, model?: string | null): Promise<string | null> {
+async function askChatApiContext(message: string): Promise<ChatApiContextResponse | null> {
   try {
     const controller = new AbortController();
     const connectTimer = setTimeout(() => controller.abort(), CHAT_API_CONNECT_TIMEOUT_MS);
 
-    // Forward the local familiar's model so the chat-api generates with it and
-    // the AI credits attribute to that model rather than the chat-api default.
-    // (The chat-api must honor `model` for the credit attribution to take effect.)
-    const payload = model ? { message, model } : { message };
+    const res = await fetch(`${CHAT_API_URL}/api/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message, mode: "context" }),
+      signal: controller.signal,
+    }).finally(() => clearTimeout(connectTimer));
+
+    if (!res.ok) return null;
+    const json = (await res.json()) as ChatApiContextResponse;
+    return typeof json.systemPrompt === "string" ? json : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * No-regression fallback: ask the hosted chat-api for a fully-written answer
+ * (its legacy streamed text/plain behavior). Used when `mode: "context"` is not
+ * yet supported by the backend, so Salem keeps giving grounded hosted answers
+ * instead of dropping to weak local token-overlap retrieval. Once the backend
+ * serves context mode, the local-familiar synthesis path above takes over.
+ */
+async function askChatApiAnswer(message: string): Promise<string | null> {
+  try {
+    const controller = new AbortController();
+    const connectTimer = setTimeout(() => controller.abort(), CHAT_API_CONNECT_TIMEOUT_MS);
 
     const res = await fetch(`${CHAT_API_URL}/api/chat`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
+      body: JSON.stringify({ message }),
       signal: controller.signal,
     }).finally(() => clearTimeout(connectTimer));
 
     if (!res.ok || !res.body) return null;
 
-    // The chat API streams plain-text deltas; concatenate them.
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
     const parts: string[] = [];
     const streamTimer = setTimeout(() => controller.abort(), CHAT_API_TIMEOUT_MS);
-
     try {
       while (true) {
         const { done, value } = await reader.read();
@@ -75,6 +101,81 @@ async function askChatApi(message: string, model?: string | null): Promise<strin
         parts.push(decoder.decode(value, { stream: true }));
       }
       parts.push(decoder.decode());
+    } finally {
+      clearTimeout(streamTimer);
+      reader.releaseLock();
+    }
+
+    const trimmed = parts.join("").trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+function buildLocalSalemPrompt(message: string, context: ChatApiContextResponse): string {
+  const systemPrompt = typeof context.systemPrompt === "string" ? context.systemPrompt.trim() : "";
+  const docsContext = typeof context.context === "string" && context.context.trim()
+    ? `\n\nRetrieved documentation context:\n${context.context.trim()}`
+    : "";
+
+  return [
+    systemPrompt,
+    docsContext,
+    "",
+    "Answer the user's question as Salem. Use the retrieved documentation when it is relevant, cite sources as markdown links, and say when the docs do not contain the answer.",
+    "",
+    `User question:\n${message}`,
+  ].filter(Boolean).join("\n");
+}
+
+async function askLocalFamiliar(args: {
+  req: Request;
+  familiarId: string;
+  message: string;
+  model: string | null;
+}): Promise<string | null> {
+  try {
+    const controller = new AbortController();
+    const streamTimer = setTimeout(() => controller.abort(), CHAT_API_TIMEOUT_MS);
+    const res = await fetch(new URL("/api/chat/send", args.req.url), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        familiarId: args.familiarId,
+        prompt: args.message,
+        ...(args.model ? { modelOverride: args.model, modelOverrideScope: "next-message" } : {}),
+      }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok || !res.body) {
+      clearTimeout(streamTimer);
+      return null;
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    const parts: string[] = [];
+    let buffer = "";
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const frames = buffer.split("\n\n");
+        buffer = frames.pop() ?? "";
+        for (const frame of frames) {
+          const line = frame.split(/\r?\n/).find((item) => item.startsWith("data:"));
+          if (!line) continue;
+          try {
+            const event = JSON.parse(line.slice(5).trim()) as { kind?: string; text?: string };
+            if (event.kind === "assistant_chunk" && event.text) parts.push(event.text);
+          } catch {
+            /* ignore malformed SSE frames */
+          }
+        }
+      }
     } finally {
       clearTimeout(streamTimer);
       reader.releaseLock();
@@ -256,10 +357,13 @@ export async function GET() {
 
 export async function POST(req: Request) {
   try {
-    const body = (await req.json()) as { message?: string; context?: SalemSearchContext; model?: string };
+    const body = (await req.json()) as { message?: string; context?: SalemSearchContext; model?: string; familiarId?: string };
     const message = (body.message ?? "").trim();
     // The model of the local familiar this ask is scoped to (credit attribution).
     const model = typeof body.model === "string" && body.model.trim() ? body.model.trim() : null;
+    const familiarId = typeof body.familiarId === "string" && body.familiarId.trim()
+      ? body.familiarId.trim()
+      : null;
 
     if (!message) {
       return NextResponse.json({ error: "No message provided." }, { status: 400 });
@@ -275,12 +379,41 @@ export async function POST(req: Request) {
     const searchContext = formatSearchContextForPrompt(context);
     const messageForApi = searchContext ? `${message}\n\n${searchContext}` : message;
 
-    // Primary path: ask the real opencoven-chat-api for a grounded, LLM-written
-    // answer. Falls through to local token-overlap retrieval if unreachable.
-    const apiReply = await askChatApi(messageForApi, model);
-    if (apiReply) {
+    // Primary Cave path: use the hosted RAG index for context, then synthesize
+    // through the local familiar so the user's connected model/provider pays.
+    const apiContext = await askChatApiContext(messageForApi);
+    if (apiContext && familiarId) {
+      const apiReply = await askLocalFamiliar({
+        req,
+        familiarId,
+        message: buildLocalSalemPrompt(messageForApi, apiContext),
+        model,
+      });
+      if (apiReply) {
+        return NextResponse.json({
+          reply: apiReply,
+          preloadSummary: summarizePreload(),
+          source: "local-familiar",
+          localContextUsed: Boolean(searchContext),
+        });
+      }
+    }
+
+    if (apiContext && typeof apiContext.context === "string" && apiContext.context.trim()) {
       return NextResponse.json({
-        reply: apiReply,
+        reply: apiContext.context.trim(),
+        preloadSummary: summarizePreload(),
+        source: "chat-api-context",
+        localContextUsed: Boolean(searchContext),
+      });
+    }
+
+    // No-regression fallback: the backend doesn't serve context mode yet, so use
+    // its hosted streamed answer rather than dropping to weak local retrieval.
+    const hostedReply = await askChatApiAnswer(messageForApi);
+    if (hostedReply) {
+      return NextResponse.json({
+        reply: hostedReply,
         preloadSummary: summarizePreload(),
         source: "chat-api",
         localContextUsed: Boolean(searchContext),

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -483,8 +483,13 @@ export function CommandPalette({
     setSalemAnswer(null);
     setSalemError(null);
     try {
-      // Use the local familiar's model (the one you're scoped to, falling back
-      // to Salem's own) so the chat-api's AI credits attribute to it.
+      // Use the local familiar (the one you're scoped to, falling back to Salem)
+      // so the answer is synthesized through it and the AI credits attribute to
+      // its connected model.
+      const localFamiliarId =
+        activeFamiliarId ??
+        familiars.find((f) => f.id === "salem")?.id ??
+        "salem";
       const localModel =
         familiars.find((f) => f.id === activeFamiliarId)?.model ??
         familiars.find((f) => f.id === "salem")?.model ??
@@ -495,6 +500,7 @@ export function CommandPalette({
         body: JSON.stringify({
           message: query.trim(),
           context: buildSalemSearchContext(rows, query.trim()),
+          familiarId: localFamiliarId,
           model: localModel,
         }),
       });

--- a/src/components/familiar-menu-bar.test.ts
+++ b/src/components/familiar-menu-bar.test.ts
@@ -155,7 +155,7 @@ assert.match(
 );
 assert.match(
   workspace,
-  /salemSlot=\{[\s\S]*?<SalemChatPanel\s+model=\{/,
+  /salemSlot=\{[\s\S]*?<SalemChatPanel\s+familiarId=\{[\s\S]*?model=\{/,
   "Salem should remain available in the companion sidepanel",
 );
 assert.doesNotMatch(

--- a/src/components/salem/salem-widget.tsx
+++ b/src/components/salem/salem-widget.tsx
@@ -17,7 +17,7 @@ type SalemMood = "idle" | "thinking" | "happy" | "listening";
 
 const GREETING = "I'm Salem, your Coven docs familiar. Yes, the black-cat-in-the-corner thing is intentional. I'm preloaded with Coven docs, tool context, guide skills, and Cave route awareness. Ask me about familiars, plugins, roles, the marketplace, or how Cave works.";
 
-export function SalemChatPanel({ model }: { model?: string | null } = {}) {
+export function SalemChatPanel({ familiarId, model }: { familiarId?: string | null; model?: string | null } = {}) {
   const [mood, setMood] = useState<SalemMood>("idle");
   const [messages, setMessages] = useState<Message[]>([
     { role: "salem", text: GREETING },
@@ -128,8 +128,11 @@ export function SalemChatPanel({ model }: { model?: string | null } = {}) {
       const res = await fetch("/api/salem", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        // Carry the local familiar's model so the chat-api's credits attribute to it.
-        body: JSON.stringify(model ? { message: text, model } : { message: text }),
+        body: JSON.stringify({
+          message: text,
+          ...(familiarId ? { familiarId } : {}),
+          ...(model ? { model } : {}),
+        }),
       });
       const data = (await res.json()) as { reply?: string; error?: string };
       const raw = data.reply ?? data.error ?? "Hmm, I couldn't find that one. Try rephrasing?";

--- a/src/components/salem/salem.test.ts
+++ b/src/components/salem/salem.test.ts
@@ -57,8 +57,11 @@ assert.match(route, /CHAT_API_TIMEOUT_MS\s*=\s*45_000/, "Salem upstream chat API
 assert.doesNotMatch(route, /const connectTimeoutMs = 2_500/, "Salem must not abort the upstream chat API before it can stream");
 assert.match(route, /type SalemSearchContext/, "Salem API should accept structured local search context");
 assert.match(route, /formatSearchContextForPrompt\(context\)/, "Salem API should format top-bar search context into the hosted prompt");
-assert.match(route, /askChatApi\(messageForApi, model\)/, "Hosted Salem responses should receive the context-aware prompt and the local familiar's model");
-assert.match(route, /payload = model \? \{ message, model \} : \{ message \}/, "Salem must forward the local familiar's model to the chat-api so AI credits attribute to it");
+assert.match(route, /askChatApiContext\(messageForApi\)/, "Cave Salem should ask the hosted chat-api for retrieved docs context, not hosted synthesis");
+assert.match(route, /askLocalFamiliar\([\s\S]*?familiarId[\s\S]*?model/, "Cave Salem must synthesize through the local familiar so the user's connected model pays for the run");
+assert.match(route, /modelOverride:\s*args\.model/, "local Salem synthesis must forward the exact selected model as a next-message override");
+assert.match(route, /modelOverrideScope:\s*"next-message"/, "Salem must not persist the one-off model override as a session default");
+assert.match(route, /askChatApiAnswer\(messageForApi\)/, "Salem must keep a hosted-answer fallback when the backend does not serve context mode, so it never regresses to weak local retrieval");
 assert.match(route, /localContextUsed/, "Salem API response should disclose whether local context was included");
 assert.match(route, /familiar|familiar/, "must know about familiars");
 assert.match(route, /role|Role/, "must know about roles");
@@ -85,7 +88,8 @@ assert.match(workspace, /shellRef\.current\?\.openFamiliar\(\)/, "Salem launcher
 assert.match(workspace, /setRailTab\("salem"\)/, "Salem launcher must select the Salem rail tab");
 assert.match(workspace, /import \{ SalemChatPanel \}/, "workspace should import only the Salem sidepanel surface");
 assert.doesNotMatch(workspace, /SalemWidget|salemRetreating/, "workspace must not render or compute floating Salem state");
-assert.match(workspace, /salemSlot=\{[\s\S]*?<SalemChatPanel\s+model=\{/, "workspace must render Salem in the companion rail with the local familiar's model");
+assert.match(workspace, /salemSlot=\{[\s\S]*?<SalemChatPanel\s+familiarId=\{/, "workspace must render Salem in the companion rail with the local familiar id");
+assert.match(workspace, /salemSlot=\{[\s\S]*?<SalemChatPanel[\s\S]*?model=\{/, "workspace must render Salem in the companion rail with the local familiar's model");
 assert.match(companionRail, /"salem"/, "companion rail must expose a Salem tab");
 
 // 7. CSS classes present

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1782,6 +1782,7 @@ export function Workspace() {
               }
               salemSlot={
                 <SalemChatPanel
+                  familiarId={active?.id ?? familiars.find((f) => f.id === "salem")?.id ?? "salem"}
                   model={active?.model ?? familiars.find((f) => f.id === "salem")?.model ?? null}
                 />
               }


### PR DESCRIPTION
## What

Reconciles the in-progress local-synthesis Salem rework with the merged #1037 model-forwarding approach — **local synthesis wins**, with a fallback so nothing regresses before the backend is ready.

Salem now:
1. Asks the hosted chat-api for **retrieved docs context only** (`mode:"context"`).
2. **Synthesizes the answer locally through the selected familiar** via Cave's own `/api/chat/send` (`modelOverride`, `next-message` scope) — so the user's connected model/provider does the generation and owns the AI credits.
3. **No-regression fallback:** the hosted chat-api doesn't serve `mode:"context"` yet, so when context mode is unavailable Cave uses the hosted **streamed answer** (today's behavior) instead of dropping to weak local token-overlap retrieval. Auto-upgrades to local synthesis once the backend ships context mode.
4. Final fallback: local doc retrieval (offline).

Callers (command palette + Salem panel via workspace) now pass the local `familiarId` (+ `model`).

## Why a fallback

I probed `salem.opencoven.ai/api/chat` with `{mode:"context"}` and it currently **ignores `mode` and returns a normal answer**. Landing the rework alone would regress Salem to weak local retrieval until the backend ships context mode; the fallback prevents that.

## Backend dependency

`docs/salem-chat-api-model.md` rewritten to spec the `mode:"context"` JSON contract (`{systemPrompt, context}`) the backend must add. Until then, the hosted-answer fallback keeps Salem working.

## Verification

`tsc --noEmit` clean · `node scripts/run-tests.mjs app` → 315 files pass. **Live-verified**: `POST /api/salem` with a `familiarId` returns a grounded hosted answer (`source: "chat-api"`) via the fallback — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)