### PR TITLE
style(chat): extend the user message bubble to full width

### DIFF
--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1193,10 +1193,12 @@
   border: 1px solid var(--border-hairline);
   border-radius: 8px;
   padding: 10px 13px;
-  /* Wider bubble (2026-06-18): pairs with the full-width thread — the user
-     message uses most of the pane instead of a narrow 640px cap, while still
-     right-aligning so it reads as the user's turn. */
-  max-width: min(85%, 1100px);
+  /* Full-width user turn: the message fills the chat pane (matching the
+     assistant prose) instead of a right-aligned narrow bubble. The left accent
+     stripe + border still mark it as the operator's turn; the action row and
+     timestamp below stay right-aligned via the column's items-end. */
+  max-width: 100%;
+  width: 100%;
   word-break: break-word;
   overflow-wrap: anywhere;
   box-shadow:


### PR DESCRIPTION
## What

The in-chat **user** message bubble was capped at `min(85%, 1100px)` and right-aligned. This lets it fill the full width of the chat pane so it lines up with the assistant prose.

## How

`.cave-bubble-user` → `max-width: 100%; width: 100%`. The left accent stripe + border still mark it as the operator's turn; the action row and timestamp below stay right-aligned via the column's `items-end`. CSS-only.

## Verification

- `pnpm test:app` — all 315 test files pass.
- Built the prod app and screenshotted a user + assistant turn: the user bubble now spans the pane edge-to-edge, matching the assistant message width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)