### PR TITLE
feat(chat): slim message meta row to name + timestamp; configurable format

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -286,6 +286,7 @@ export const SUITES = {
     "src/lib/reading-weight.test.ts",
     "src/lib/reading-hyphens.test.ts",
     "src/lib/reading-dropcap.test.ts",
+    "src/lib/datetime-format.test.ts",
     "src/lib/appearance-corner-radius.test.ts",
     "src/lib/code-layout-preset.test.ts",
     "src/lib/use-changes-summary.test.ts",

--- a/src/components/chat-response-metadata.test.ts
+++ b/src/components/chat-response-metadata.test.ts
@@ -116,10 +116,10 @@ assert.doesNotMatch(
   "The misleading 'model:'/'runtime:' label helpers should be gone — openclaw-local is not a model and the runtime is a cwd",
 );
 
-assert.match(
+assert.doesNotMatch(
   chatView,
-  /<ResponseMetadataText metadata=\{turn\.responseMetadata\} \/>/,
-  "Assistant turn rows should show the model/runtime metadata for each response",
+  /ResponseMetadataText/,
+  "The model/runtime metadata no longer renders inline in the turn meta row — it lives in the debug pane's per-turn JSON",
 );
 
 assert.match(

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -280,8 +280,8 @@ const usageTurnRow =
 assert.ok(usageTurnRow, "TurnRow body should be extractable (CHAT-D12-02)");
 assert.match(
   usageTurnRow,
-  /fmtTime\(turn\.createdAt\)[\s\S]{0,180}?<DurationText durationMs=\{turn\.durationMs\} \/>[\s\S]{0,180}?<UsageText usage=\{turn\.usage\} costUsd=\{turn\.costUsd\} \/>/,
-  "Assistant turn meta row appends duration and the muted usage/cost readout after the timestamp (CHAT-D12-02)",
+  /formatTimestamp\(turn\.createdAt, dtPrefs\)[\s\S]{0,220}?<UsageText usage=\{turn\.usage\} costUsd=\{turn\.costUsd\} \/>/,
+  "Assistant turn meta row shows the muted usage/cost readout after the timestamp; model/cwd/duration moved to the debug pane (CHAT-D12-02)",
 );
 
 // ── CHAT-D9-04: find highlight timer cleanup ──

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -49,6 +49,7 @@ import { VoiceCallOverlay } from "./voice-call-overlay";
 import { CsvImportModal } from "./csv-import-modal";
 import { looksLikeCsv } from "@/lib/csv-import";
 import { usageBreakdown, usageSummary, type TurnUsage } from "@/lib/usage-format";
+import { formatTimestamp, useDateTimePrefs } from "@/lib/datetime-format";
 import { computeContextMeter } from "@/lib/context-meter";
 import {
   formatRuntime,
@@ -358,15 +359,6 @@ function lifecycleLabel(lifecycle: ChatTurnLifecycle): string {
       return "Failed";
     case "complete":
       return "Complete";
-  }
-}
-
-function fmtTime(iso: string): string {
-  try {
-    const d = new Date(iso);
-    return d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
-  } catch {
-    return "";
   }
 }
 
@@ -891,27 +883,6 @@ function ChatTitleEditable({
     >
       {display}
     </button>
-  );
-}
-
-function ResponseMetadataText({ metadata }: { metadata?: ChatResponseMetadata }) {
-  const model = responseMetadataModel(metadata);
-  const dir = formatRuntime(metadata?.runtime);
-  if (!model && !dir) return null;
-  return (
-    <span
-      className="font-mono text-[10px] text-[var(--text-muted)] inline-flex items-center gap-1"
-      title={[metadata?.harness, model, dir?.title].filter(Boolean).join(" · ") || undefined}
-    >
-      {model}
-      {model && dir ? " · " : null}
-      {dir ? (
-        <span className="inline-flex items-center gap-1">
-          <Icon name="ph:folder" width={10} aria-hidden />
-          {dir.label}
-        </span>
-      ) : null}
-    </span>
   );
 }
 
@@ -3715,6 +3686,10 @@ function TurnRow({
   // collapses tools on its own because the settled default is hidden.
   const [showToolsOverride, setShowToolsOverride] = useState<boolean | null>(null);
   const showTools = turn.pending ? true : (showToolsOverride ?? false);
+  // Chat timestamp format (12h/24h clock + MM.DD/DD.MM/Off date) — a user
+  // preference; the model/cwd/duration that used to sit here now live only in
+  // the debug pane's per-turn JSON.
+  const dtPrefs = useDateTimePrefs();
 
   // Click-away dismissal for the inline familiar card. Hooks are placed here
   // (before any early return) so React's rules-of-hooks are never violated.
@@ -3758,7 +3733,9 @@ function TurnRow({
             {turn.role === "system" ? (
               <span className="font-medium text-[var(--text-secondary)]">System</span>
             ) : null}
-            {showTimestamp && turn.createdAt ? <span className="opacity-60">{fmtTime(turn.createdAt)}</span> : null}
+            {showTimestamp && turn.createdAt ? (
+              <span className="opacity-60">{formatTimestamp(turn.createdAt, dtPrefs)}</span>
+            ) : null}
             {turn.attachments?.length ? <span className="opacity-60">{turn.attachments.length} file{turn.attachments.length === 1 ? "" : "s"}</span> : null}
           </div>
           <MessageBubble
@@ -3884,9 +3861,9 @@ function TurnRow({
                 Retry
               </button>
             ) : null}
-            {showTimestamp && turn.createdAt ? <span className="opacity-60">{fmtTime(turn.createdAt)}</span> : null}
-            <ResponseMetadataText metadata={turn.responseMetadata} />
-            <DurationText durationMs={turn.durationMs} />
+            {showTimestamp && turn.createdAt ? (
+              <span className="opacity-60">{formatTimestamp(turn.createdAt, dtPrefs)}</span>
+            ) : null}
             <UsageText usage={turn.usage} costUsd={turn.costUsd} />
             {/* CHAT-D13-01: settled turns hide tool activity by default —
                 this chip is the only way back to it, so it must not be

--- a/src/components/settings-fonts.tsx
+++ b/src/components/settings-fonts.tsx
@@ -67,6 +67,15 @@ import {
   readReadingDropcap,
   type ReadingDropcap,
 } from "@/lib/reading-dropcap";
+import {
+  CLOCK_LABEL,
+  CLOCK_OPTIONS,
+  DATE_LABEL,
+  DATE_OPTIONS,
+  setClockFormat,
+  setDateFormat,
+  useDateTimePrefs,
+} from "@/lib/datetime-format";
 
 const DROPCAP_LABEL: Record<ReadingDropcap, string> = {
   off: "Off",
@@ -200,6 +209,9 @@ export function FontSettings() {
   const [weight, setWeight] = useState<ReadingWeight>(DEFAULT_READING_WEIGHT);
   const [hyphens, setHyphens] = useState<ReadingHyphens>(DEFAULT_READING_HYPHENS);
   const [dropcap, setDropcap] = useState<ReadingDropcap>(DEFAULT_READING_DROPCAP);
+  // Chat timestamp format prefs come straight from the reactive store (no local
+  // mirror needed) — the segmented controls write through to it on click.
+  const dtPrefs = useDateTimePrefs();
 
   useEffect(() => {
     const sans = readFontPref("sans");
@@ -453,6 +465,50 @@ export function FontSettings() {
                   className={segBtn(dropcap === option)}
                 >
                   {DROPCAP_LABEL[option]}
+                </button>
+              ))}
+            </div>
+          </ReadingRow>
+        </div>
+      </div>
+
+      {/* Chat timestamps — how the per-message time/date renders in chat. The
+          model, working directory, and duration that used to sit alongside it
+          live in the debug pane now. */}
+      <div className="flex flex-col gap-2">
+        <div>
+          <h4 className="text-[12px] font-semibold text-[var(--text-primary)]">Chat timestamps</h4>
+          <p className="text-[11px] text-[var(--text-muted)]">Shown on each chat message.</p>
+        </div>
+        <div className="divide-y divide-[var(--border-hairline)] rounded-lg border border-[var(--border-hairline)] px-3">
+          <ReadingRow label="Clock">
+            <div className={segWrap}>
+              {CLOCK_OPTIONS.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  onClick={() => setClockFormat(option)}
+                  aria-pressed={dtPrefs.clock === option}
+                  aria-label={`Clock ${CLOCK_LABEL[option]}`}
+                  className={segBtn(dtPrefs.clock === option)}
+                >
+                  {CLOCK_LABEL[option]}
+                </button>
+              ))}
+            </div>
+          </ReadingRow>
+          <ReadingRow label="Date">
+            <div className={segWrap}>
+              {DATE_OPTIONS.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  onClick={() => setDateFormat(option)}
+                  aria-pressed={dtPrefs.date === option}
+                  aria-label={`Date ${DATE_LABEL[option]}`}
+                  className={segBtn(dtPrefs.date === option)}
+                >
+                  {DATE_LABEL[option]}
                 </button>
               ))}
             </div>

--- a/src/lib/datetime-format.test.ts
+++ b/src/lib/datetime-format.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  DEFAULT_CLOCK,
+  DEFAULT_DATE,
+  formatTimestamp,
+  normalizeClock,
+  normalizeDate,
+} from "./datetime-format.ts";
+
+// A no-Z ISO is parsed as LOCAL time, so the month/day are timezone-stable.
+const ISO = "2026-06-19T13:31:00";
+
+test("normalize falls back to defaults for junk", () => {
+  assert.equal(normalizeClock("nonsense"), DEFAULT_CLOCK);
+  assert.equal(normalizeClock(null), DEFAULT_CLOCK);
+  assert.equal(normalizeClock("24h"), "24h");
+  assert.equal(normalizeDate("nonsense"), DEFAULT_DATE);
+  assert.equal(normalizeDate(undefined), DEFAULT_DATE);
+  assert.equal(normalizeDate("ddmm"), "ddmm");
+});
+
+test("default prefs render MM.DD + 12-hour", () => {
+  const out = formatTimestamp(ISO);
+  assert.ok(out.startsWith("06.19 "), `expected MM.DD prefix, got "${out}"`);
+  assert.match(out, /1:31/);
+  assert.match(out, /[AP]M/i, "12-hour clock keeps an AM/PM marker");
+});
+
+test("24-hour clock drops AM/PM and shows 13:31", () => {
+  const out = formatTimestamp(ISO, { clock: "24h", date: "off" });
+  assert.match(out, /13:31/);
+  assert.doesNotMatch(out, /[AP]M/i);
+  assert.ok(!/^\d\d\./.test(out), "date Off omits the date prefix");
+});
+
+test("DD.MM reverses the date ordering", () => {
+  const out = formatTimestamp(ISO, { clock: "12h", date: "ddmm" });
+  assert.ok(out.startsWith("19.06 "), `expected DD.MM prefix, got "${out}"`);
+});
+
+test("date Off returns the time only", () => {
+  const out = formatTimestamp(ISO, { clock: "12h", date: "off" });
+  assert.match(out, /1:31/);
+  assert.ok(!out.includes("06.19") && !out.includes("19.06"));
+});
+
+test("unparseable input renders nothing", () => {
+  assert.equal(formatTimestamp("not-a-date"), "");
+  assert.equal(formatTimestamp(""), "");
+});

--- a/src/lib/datetime-format.ts
+++ b/src/lib/datetime-format.ts
@@ -1,0 +1,164 @@
+"use client";
+
+/**
+ * Cave-local date/time formatting preferences for chat message timestamps.
+ *
+ * Two independent picks, persisted in localStorage and mirrored across tabs +
+ * components via a tiny `useSyncExternalStore` store (same shape as
+ * `cave-glyph-overrides`):
+ *   - clock: 12-hour ("1:31 AM") vs 24-hour ("13:31")
+ *   - date:  MM.DD ("06.19"), DD.MM ("19.06"), or Off (time only)
+ *
+ * This is purely a UI-side preference (no daemon write) — it changes how the
+ * chat renders existing `createdAt` ISO strings, nothing on disk. The default
+ * ("MM.DD" + 12-hour) renders "06.19 1:31 AM".
+ *
+ * `getServerSnapshot` returns the frozen defaults so SSR and the first client
+ * hydration render agree; React re-renders with the persisted pick right after
+ * hydration, so a non-default setting never trips a hydration mismatch.
+ */
+
+import { useSyncExternalStore } from "react";
+
+export const DATETIME_CLOCK_KEY = "cave:datetime-clock";
+export const DATETIME_DATE_KEY = "cave:datetime-date";
+
+export const CLOCK_OPTIONS = ["12h", "24h"] as const;
+export type ClockFormat = (typeof CLOCK_OPTIONS)[number];
+export const DEFAULT_CLOCK: ClockFormat = "12h";
+
+export const DATE_OPTIONS = ["mmdd", "ddmm", "off"] as const;
+export type DateFormat = (typeof DATE_OPTIONS)[number];
+export const DEFAULT_DATE: DateFormat = "mmdd";
+
+export type DateTimePrefs = { clock: ClockFormat; date: DateFormat };
+
+export const CLOCK_LABEL: Record<ClockFormat, string> = {
+  "12h": "12-hour",
+  "24h": "24-hour",
+};
+
+export const DATE_LABEL: Record<DateFormat, string> = {
+  mmdd: "MM.DD",
+  ddmm: "DD.MM",
+  off: "Off",
+};
+
+export function normalizeClock(value: unknown): ClockFormat {
+  return CLOCK_OPTIONS.includes(value as ClockFormat) ? (value as ClockFormat) : DEFAULT_CLOCK;
+}
+
+export function normalizeDate(value: unknown): DateFormat {
+  return DATE_OPTIONS.includes(value as DateFormat) ? (value as DateFormat) : DEFAULT_DATE;
+}
+
+// ── In-memory mirror + change broadcaster ──────────────────────────────────────
+
+const DEFAULT_PREFS: DateTimePrefs = Object.freeze({ clock: DEFAULT_CLOCK, date: DEFAULT_DATE });
+let snapshot: DateTimePrefs | null = null;
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const fn of listeners) fn();
+}
+
+function readFromStorage(): DateTimePrefs {
+  if (typeof window === "undefined") return DEFAULT_PREFS;
+  try {
+    return {
+      clock: normalizeClock(window.localStorage.getItem(DATETIME_CLOCK_KEY)),
+      date: normalizeDate(window.localStorage.getItem(DATETIME_DATE_KEY)),
+    };
+  } catch {
+    return DEFAULT_PREFS;
+  }
+}
+
+function getSnapshot(): DateTimePrefs {
+  if (snapshot === null) snapshot = readFromStorage();
+  return snapshot;
+}
+
+function getServerSnapshot(): DateTimePrefs {
+  return DEFAULT_PREFS;
+}
+
+/** Non-hook accessor for one-shot reads that can't take a hook. */
+export function readDateTimePrefs(): DateTimePrefs {
+  return getSnapshot();
+}
+
+// ── Mutators (always go through these so listeners fire) ────────────────────────
+
+export function setClockFormat(value: ClockFormat): void {
+  const clock = normalizeClock(value);
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem(DATETIME_CLOCK_KEY, clock);
+    } catch {
+      /* storage unavailable — keep the in-memory pick */
+    }
+  }
+  snapshot = { ...getSnapshot(), clock };
+  notify();
+}
+
+export function setDateFormat(value: DateFormat): void {
+  const date = normalizeDate(value);
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem(DATETIME_DATE_KEY, date);
+    } catch {
+      /* storage unavailable — keep the in-memory pick */
+    }
+  }
+  snapshot = { ...getSnapshot(), date };
+  notify();
+}
+
+// ── Cross-tab + cross-component sync ────────────────────────────────────────────
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (e) => {
+    if (e.key === DATETIME_CLOCK_KEY || e.key === DATETIME_DATE_KEY) {
+      snapshot = null;
+      notify();
+    }
+  });
+}
+
+function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+/** React hook: current date/time prefs. Re-renders on any change. */
+export function useDateTimePrefs(): DateTimePrefs {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+// ── Pure formatter ──────────────────────────────────────────────────────────────
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+/**
+ * Format an ISO timestamp per the given prefs. The date portion is built from
+ * the local month/day (so it's locale-stable: "06.19"), and the time portion
+ * uses the platform locale's clock with `hour12` driven by the pref. Returns
+ * "" for an unparseable input.
+ */
+export function formatTimestamp(iso: string, prefs: DateTimePrefs = DEFAULT_PREFS): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const time = d.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: prefs.clock === "12h",
+  });
+  const mm = pad2(d.getMonth() + 1);
+  const dd = pad2(d.getDate());
+  const datePart = prefs.date === "mmdd" ? `${mm}.${dd}` : prefs.date === "ddmm" ? `${dd}.${mm}` : "";
+  return datePart ? `${datePart} ${time}` : time;
+}


### PR DESCRIPTION
## What

The chat message metadata row showed the author, time, **model**, **working directory**, and **duration** inline. Per request, it's slimmed to just the author + a configurable timestamp (the compact token/cost readout stays).

Before: `Nova  1:31 AM  anthropic/claude-opus-4-8 · 📁 ~/…/nova  3s`
After: `Nova  06.19 1:31 AM`

Nothing is lost — model, cwd, and duration are still in the **debug pane** (per-turn JSON + the session's model/project-root rows).

## Timestamp format is now configurable

New **Settings → Appearance → Chat timestamps** control:
- **Clock** — 12-hour (`1:31 AM`) or 24-hour (`13:31`)
- **Date** — `MM.DD`, `DD.MM`, or `Off` (time only)

Default renders `06.19 1:31 AM`. Backed by a localStorage `useSyncExternalStore` store (`src/lib/datetime-format.ts`) mirroring the existing reading-preference pattern; `getServerSnapshot` returns defaults so SSR/hydration agree.

## Changes
- `src/lib/datetime-format.ts` (+ test, wired into `run-tests.mjs`) — pref store + pure `formatTimestamp()`
- `src/components/chat-view.tsx` — both turn rows use `formatTimestamp`; removed inline `ResponseMetadataText` (model+cwd) and per-turn `DurationText`; dropped now-dead `fmtTime`
- `src/components/settings-fonts.tsx` — "Chat timestamps" segmented controls
- Updated the two source-text tests that pinned the old row shape (CHAT-D12-02, response-metadata)

## Verification
- `pnpm build` clean (typecheck + lint)
- `pnpm check:tests-wired` green; new suite wired
- Affected suites pass: `datetime-format`, `chat-response-metadata`, `chat-view-lifecycle`, `settings-fonts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)