### PR TITLE
feat(tasks): scope the Tasks badge count to the selected familiar

### DIFF
--- a/src/components/familiar-menu-bar.test.ts
+++ b/src/components/familiar-menu-bar.test.ts
@@ -169,11 +169,20 @@ assert.doesNotMatch(
   "Workspace should not render a floating Salem perch",
 );
 
-// The board task count is polled from /api/board (open = not done).
+// The open (not-done) board cards are polled from /api/board, kept with their
+// familiar so the Tasks badge can scope the count.
 assert.match(
   workspace,
-  /fetch\("\/api\/board"[\s\S]*\.filter\(\s*\(c\) => c\.status !== "done",?\s*\)\.length/,
-  "boardTaskCount counts cards that are not yet done",
+  /fetch\("\/api\/board"[\s\S]*\.filter\(\s*\(c\) => c\.status !== "done",?\s*\)[\s\S]*\.map\(\s*\(c\) => \(\{ familiarId: c\.familiarId \?\? null \}\)\s*\)/,
+  "open (not-done) board cards are collected with their familiarId",
+);
+
+// The Tasks badge count is scoped: per-familiar when one is selected, the grand
+// total only when "All familiars" (activeId === null) is selected.
+assert.match(
+  workspace,
+  /boardTaskCount = useMemo\([\s\S]*activeId === null[\s\S]*openTaskCards\.length[\s\S]*openTaskCards\.filter\(\(c\) => c\.familiarId === activeId\)\.length/,
+  "boardTaskCount is the active familiar's open-card count, or the grand total for All familiars",
 );
 
 // Desktop-only: the bar shows ≥1024px (where the mobile .top-bar is hidden).

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -194,7 +194,10 @@ export function Workspace() {
   const [onboardingOpen, setOnboardingOpen] = useState(false);
   const [inboxItems, setInboxItems] = useState<InboxItem[]>([]);
   const [escalationsUnresolved, setEscalationsUnresolved] = useState(0);
-  const [boardTaskCount, setBoardTaskCount] = useState(0);
+  // Open (not-done) board cards, kept with their familiar so the Tasks badge can
+  // show a per-familiar count when a familiar is scoped, and the grand total
+  // only when "All familiars" is selected.
+  const [openTaskCards, setOpenTaskCards] = useState<{ familiarId: string | null }[]>([]);
   const [inboxPrefs, setInboxPrefs] = useState<InboxPrefs>({
     version: 1,
     mutedFamiliars: [],
@@ -785,10 +788,10 @@ export function Workspace() {
         const json = await res.json();
         if (cancelled) return;
         if (json.ok && Array.isArray(json.cards)) {
-          const open = (json.cards as Array<{ status?: string }>).filter(
-            (c) => c.status !== "done",
-          ).length;
-          setBoardTaskCount(open);
+          const open = (json.cards as Array<{ status?: string; familiarId?: string | null }>)
+            .filter((c) => c.status !== "done")
+            .map((c) => ({ familiarId: c.familiarId ?? null }));
+          setOpenTaskCards(open);
         }
       } catch {
         /* keep last value on transient failure */
@@ -1299,6 +1302,16 @@ export function Workspace() {
   };
 
   const active = familiars.find((f) => f.id === activeId) ?? null;
+
+  // Tasks badge count: scoped to the active familiar's open cards, or the grand
+  // total of all open cards when "All familiars" (activeId === null) is selected.
+  const boardTaskCount = useMemo(
+    () =>
+      activeId === null
+        ? openTaskCards.length
+        : openTaskCards.filter((c) => c.familiarId === activeId).length,
+    [openTaskCards, activeId],
+  );
 
   // Ephemeral bridge: turn each "needs response" familiar into a transient
   // InboxItem so the bell badge, inbox view, and inspector tab all surface it


### PR DESCRIPTION
## What

The Tasks badge (desktop menu bar + mobile top bar) always showed the **grand total** of open board cards regardless of which familiar was scoped. Now:

- A **specific familiar selected** → the badge shows **that familiar's** open-card count.
- **"All familiars"** selected (`activeId === null`) → the badge shows the **grand total**.

## How

- The `/api/board` poll now keeps the open (not-done) cards with their `familiarId` (`openTaskCards`) instead of just a count.
- `boardTaskCount` is derived via `useMemo`: `activeId === null` → all open cards; otherwise open cards where `familiarId === activeId`.
- No component changes — both the menu bar and top bar already render `taskCount`; only the value's scoping changed.

## Verification

- `pnpm typecheck` ✅ · `pnpm test:app` (315 files) ✅
- Updated the source-text assertions in `familiar-menu-bar.test.ts` for the new shape.
- **Live-verified** against the real board (130 open cards) by switching scope in the familiar switcher: **All → 99+**, **Sage → 40**, **Nova → 22**, **Cody → 53** — exact per-familiar subsets, grand total only for All.

🤖 Generated with [Claude Code](https://claude.com/claude-code)