### PR TITLE
feat(automations): folder picker for the Working directories field

### DIFF
--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -11,6 +11,8 @@ import type {
   CodexAutomationPatch,
 } from "@/lib/codex-automations-types";
 import { Icon } from "@/lib/icon";
+import { ProjectTree } from "@/components/project-tree";
+import type { CaveProject } from "@/lib/cave-projects-types";
 
 // AutomationsView — Schedules surface, redesigned June 2026
 // Clean list layout matching the sleek/professional reference design:
@@ -551,6 +553,9 @@ function CodexDetailPanel({
   const [executionEnvironment, setExecutionEnvironment] = useState(auto.executionEnvironment ?? "worktree");
   const [tagsText, setTagsText] = useState(commaInput(auto.tags));
   const [cwdsText, setCwdsText] = useState(listInput(auto.cwds));
+  // Folder-picker ("browse") state for the Working directories field.
+  const [cwdPickerOpen, setCwdPickerOpen] = useState(false);
+  const [cwdProjects, setCwdProjects] = useState<CaveProject[]>([]);
   const [scheduleMode, setScheduleMode] = useState<"daily" | "weekly" | "raw">(parsedSchedule.mode);
   const [scheduleTime, setScheduleTime] = useState(parsedSchedule.time);
   const [scheduleDays, setScheduleDays] = useState(parsedSchedule.days);
@@ -576,6 +581,28 @@ function CodexDetailPanel({
   const nextRrule = buildCodexRrule(scheduleMode, scheduleTime, scheduleDays, rawRrule);
   const tags = parseListInput(tagsText);
   const cwds = parseListInput(cwdsText);
+  const cwdSet = useMemo(() => new Set(cwds), [cwdsText]); // eslint-disable-line react-hooks/exhaustive-deps
+  const addCwd = useCallback((dir: string) => {
+    const clean = dir.trim();
+    if (!clean) return;
+    setCwdsText((prev) => {
+      const list = parseListInput(prev);
+      if (list.includes(clean)) return prev;
+      return listInput([...list, clean]);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!cwdPickerOpen || cwdProjects.length > 0) return;
+    let alive = true;
+    void fetch("/api/projects")
+      .then((res) => res.json())
+      .then((data: { ok?: boolean; projects?: CaveProject[] }) => {
+        if (alive && data.ok && Array.isArray(data.projects)) setCwdProjects(data.projects);
+      })
+      .catch(() => undefined);
+    return () => { alive = false; };
+  }, [cwdPickerOpen, cwdProjects.length]);
   const promptDirty = goals !== promptParts.goals || deliverables !== promptParts.deliverables;
   const nextPrompt = promptDirty
     ? composeAutomationPrompt(goals, deliverables, promptParts.hasStructuredSections || deliverables.trim().length > 0)
@@ -777,7 +804,16 @@ function CodexDetailPanel({
             </select>
           </div>
           <div>
-            <FieldLabel>Working directories</FieldLabel>
+            <div className="flex items-center justify-between">
+              <FieldLabel>Working directories</FieldLabel>
+              <button
+                type="button"
+                onClick={() => setCwdPickerOpen(true)}
+                className="mb-1 inline-flex items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 py-0.5 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+              >
+                <Icon name="ph:folder-open" width={12} /> Browse…
+              </button>
+            </div>
             <textarea
               value={cwdsText}
               onChange={(event) => setCwdsText(event.target.value)}
@@ -786,6 +822,77 @@ function CodexDetailPanel({
               style={fieldStyle}
             />
           </div>
+
+          {cwdPickerOpen && (
+            <div
+              className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Pick working directories"
+              onClick={() => setCwdPickerOpen(false)}
+            >
+              <div
+                className="flex max-h-[80vh] w-[460px] max-w-full flex-col overflow-hidden rounded-lg border border-[var(--border-hairline)] shadow-xl"
+                style={{ background: "var(--bg-panel)" }}
+                onClick={(event) => event.stopPropagation()}
+              >
+                <div className="flex items-center justify-between border-b border-[var(--border-hairline)] px-3 py-2">
+                  <span className="text-[13px] font-semibold text-[var(--text-primary)]">Working directories</span>
+                  <button
+                    type="button"
+                    onClick={() => setCwdPickerOpen(false)}
+                    aria-label="Close"
+                    className="grid h-6 w-6 place-items-center rounded text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+                  >
+                    <Icon name="ph:x" width={14} />
+                  </button>
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto p-2">
+                  {cwdProjects.length === 0 ? (
+                    <p className="px-2 py-4 text-[12px] text-[var(--text-muted)]">
+                      No projects found. Add a project in the Code workspace first, or type a path into the field.
+                    </p>
+                  ) : (
+                    cwdProjects.map((proj) => (
+                      <div key={proj.root} className="mb-2">
+                        <div className="flex items-center justify-between gap-2 px-1 py-1">
+                          <span className="min-w-0 flex-1 truncate text-[11px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                            {proj.name}
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() => addCwd(proj.root)}
+                            className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
+                              cwdSet.has(proj.root)
+                                ? "text-[var(--accent-presence)]"
+                                : "text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+                            }`}
+                          >
+                            {cwdSet.has(proj.root) ? "Added" : "Use root"}
+                          </button>
+                        </div>
+                        <ProjectTree root={proj.root} onDirSelect={addCwd} selectedDirs={cwdSet} />
+                      </div>
+                    ))
+                  )}
+                </div>
+                <div className="flex items-center justify-between border-t border-[var(--border-hairline)] px-3 py-2">
+                  <span className="text-[11px] text-[var(--text-muted)]">
+                    {cwds.length} {cwds.length === 1 ? "directory" : "directories"} selected
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setCwdPickerOpen(false)}
+                    className="rounded-md px-3 py-1 text-[12px] font-medium text-white"
+                    style={{ background: "var(--accent-presence)" }}
+                  >
+                    Done
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
           <div>
             <FieldLabel>Tags</FieldLabel>
             <input

--- a/src/components/project-tree.tsx
+++ b/src/components/project-tree.tsx
@@ -28,6 +28,13 @@ type Props = {
   /** Controlled selection — path of the currently open file */
   selectedPath?: string | null;
   onFileClick?: (path: string) => void;
+  /**
+   * When set, folder rows expose an "Add" affordance that picks the directory
+   * (folder-picker mode). Clicking a folder name still expands it for browsing.
+   */
+  onDirSelect?: (path: string) => void;
+  /** Paths already picked — folder-picker mode marks them as added. */
+  selectedDirs?: Set<string>;
 };
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -108,7 +115,7 @@ async function fetchChildren(dirPath: string): Promise<TreeEntry[]> {
 // ─── Root component ───────────────────────────────────────────────────────────
 
 export const ProjectTree = forwardRef<ProjectTreeHandle, Props>(
-  function ProjectTree({ root: rootProp, selectedPath, onFileClick }, ref) {
+  function ProjectTree({ root: rootProp, selectedPath, onFileClick, onDirSelect, selectedDirs }, ref) {
     const [root, setRoot] = useState<string>("");
     const [entries, setEntries] = useState<TreeEntry[]>([]);
     const [loading, setLoading] = useState(true);
@@ -164,6 +171,8 @@ export const ProjectTree = forwardRef<ProjectTreeHandle, Props>(
             root={root}
             selectedPath={selectedPath}
             onFileClick={onFileClick}
+            onDirSelect={onDirSelect}
+            selectedDirs={selectedDirs}
           />
         ))}
       </div>
@@ -179,12 +188,16 @@ function TreeRow({
   root,
   selectedPath,
   onFileClick,
+  onDirSelect,
+  selectedDirs,
 }: {
   entry: TreeEntry;
   depth: number;
   root: string;
   selectedPath?: string | null;
   onFileClick?: (path: string) => void;
+  onDirSelect?: (path: string) => void;
+  selectedDirs?: Set<string>;
 }) {
   const startsExpanded =
     entry.isDir && depth === 0 && !HIDDEN_BY_DEFAULT.has(entry.name);
@@ -197,6 +210,7 @@ function TreeRow({
 
   const isSelected = !entry.isDir && entry.path === selectedPath;
   const isHidden = HIDDEN_BY_DEFAULT.has(entry.name);
+  const added = entry.isDir && (selectedDirs?.has(entry.path) ?? false);
 
   // Indent: 8px base + 16px per depth level; chevron takes 16px, icon takes 16px
   const indentPx = 4 + depth * 16;
@@ -282,6 +296,32 @@ function TreeRow({
         >
           {entry.name}
         </span>
+
+        {/* Folder-picker affordance — pick this directory without leaving the
+            tree. Uses role=button (not <button>) to avoid nesting inside the row
+            button; stops propagation so it doesn't also toggle expand. */}
+        {entry.isDir && onDirSelect ? (
+          <span
+            role="button"
+            tabIndex={0}
+            aria-label={added ? `${entry.name} added as working directory` : `Use ${entry.name} as working directory`}
+            onClick={(event) => { event.stopPropagation(); onDirSelect(entry.path); }}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                event.stopPropagation();
+                onDirSelect(entry.path);
+              }
+            }}
+            className={`ml-auto mr-1 shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium transition-opacity ${
+              added
+                ? "text-[var(--accent-presence)]"
+                : "text-[var(--text-muted)] opacity-0 hover:bg-[var(--bg-base)] group-hover:opacity-100"
+            }`}
+          >
+            {added ? "Added" : "Use"}
+          </span>
+        ) : null}
       </button>
 
       {/* Children — no extra wrapper div, rows flow inline */}
@@ -294,6 +334,8 @@ function TreeRow({
             root={root}
             selectedPath={selectedPath}
             onFileClick={onFileClick}
+            onDirSelect={onDirSelect}
+            selectedDirs={selectedDirs}
           />
         ))
       }


### PR DESCRIPTION
## What

The automation **Working directories** field was free-text only. Adds a **Browse…** button that opens a folder picker:

- Lists your **projects** (`/api/projects`) and renders each as a browsable **folder tree** (`/api/project-tree`).
- Click a folder's **Use** affordance to add it as a working directory; **Use root** picks the project root. Picked folders show **Added** and are deduped into the cwds list. The textarea stays for manual entry.

## Changes

- `project-tree.tsx` — optional, backward-compatible folder-picker mode (`onDirSelect` + `selectedDirs`): folder rows get a hover "Use"/"Added" affordance via a `role=button` span (no nested `<button>`); folder click still expands for browsing. Existing Code-workspace usage (no `onDirSelect`) is unchanged.
- `automations-view.tsx` — Browse button + modal that fetches projects and renders a `ProjectTree` per project, wiring `onDirSelect`/`selectedDirs` to the cwds list.

## Verification

`tsc --noEmit` clean · `node scripts/run-tests.mjs app` → 316 files pass (incl. `automations-detail-inputs` field-primitive guards). Projects/automations/project-tree APIs confirmed returning data on dev.

Note: the modal couldn't be reliably driven by the automated browser harness (navigation kept landing on the Browser surface), so it's best eyeballed manually: Schedules → Automations → select one → Working directories → Browse….

🤖 Generated with [Claude Code](https://claude.com/claude-code)