### PR TITLE
style(salem): declutter the docs panel header

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6116,10 +6116,6 @@ a.mobile-handoff__link:hover {
   background: var(--bg-panel);
   box-shadow: none;
   backdrop-filter: none;
-  /* Size-query the rail so its own width (not the viewport) drives the
-     responsive header — lets the "Find your next path" trigger collapse to a
-     bare icon when the companion panel is dragged down to its min width. */
-  container: salem-rail / inline-size;
 }
 
 .salem-panel__header {
@@ -6168,45 +6164,7 @@ a.mobile-handoff__link:hover {
   background: color-mix(in oklch, var(--accent-presence) 15%, transparent);
 }
 
-/* Find-your-next-path trigger + pathfinder card */
-.salem-panel__pathfind {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 4px 9px;
-  border-radius: 999px;
-  border: 1px solid var(--border-hairline);
-  background: var(--bg-raised);
-  color: var(--text-secondary);
-  font-size: 11px;
-  cursor: pointer;
-  white-space: nowrap;
-  flex-shrink: 0;
-  transition: color 0.14s, background 0.14s;
-}
-.salem-panel__pathfind:hover:not(:disabled) {
-  color: var(--text-primary);
-  background: color-mix(in oklch, var(--accent-presence) 15%, transparent);
-}
-.salem-panel__pathfind:disabled { opacity: 0.5; cursor: default; }
-.salem-panel__pathfind-text { white-space: nowrap; }
-
-/* Narrow rail: drop the pill label so the trigger reads as a subtle, square
-   icon-only button that still fits at the companion panel's min width. */
-@container salem-rail (max-width: 300px) {
-  .salem-panel__pathfind-text { display: none; }
-  .salem-panel__pathfind {
-    gap: 0;
-    padding: 5px;
-    border-color: transparent;
-    background: transparent;
-    color: var(--text-muted);
-  }
-  .salem-panel__pathfind:hover:not(:disabled) {
-    background: color-mix(in oklch, var(--accent-presence) 15%, transparent);
-  }
-}
-
+/* Pathfinder recommendation card (rendered in the Salem panel message list). */
 .salem-pf {
   width: 100%;
   border: 1px solid var(--border-hairline);

--- a/src/components/salem/salem-pathfinder-card.test.ts
+++ b/src/components/salem/salem-pathfinder-card.test.ts
@@ -24,7 +24,6 @@ assert.doesNotMatch(card, /[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/u, "no emoji g
 // Panel integration
 assert.match(widget, /import \{ SalemPathfinderCard \}/, "panel imports the card");
 assert.match(widget, /\/api\/salem\/pathfinder/, "panel posts to the pathfinder route");
-assert.match(widget, /Find your next path/, "panel exposes a Find-your-next-path trigger");
 assert.match(widget, /<SalemPathfinderCard /, "panel renders the card when present");
 
 console.log("salem-pathfinder-card.test.ts OK");

--- a/src/components/salem/salem-widget.tsx
+++ b/src/components/salem/salem-widget.tsx
@@ -7,9 +7,6 @@ import { MarkdownBlock } from "@/components/message-bubble";
 import { useIsCoarsePointer } from "@/lib/use-viewport";
 import { SalemPathfinderCard } from "./salem-pathfinder-card";
 import type { SalemPathfinderCard as SalemPathfinderCardData } from "@/lib/salem/pathfinder-types";
-// Salem's 2D cat avatar. Replaced the former Three.js scene to drop the heavy
-// WebGL `three` dependency.
-import { SalemCat } from "./salem-cat";
 
 type Message = { role: "user" | "salem"; text: string };
 
@@ -152,7 +149,6 @@ export function SalemChatPanel({ familiarId, model }: { familiarId?: string | nu
       {/* Header */}
       <div className="salem-panel__header">
         <div className="salem-panel__header-identity">
-          <SalemCat mood={mood} size={40} />
           <div>
             <div className="salem-panel__name">Salem</div>
             <div className="salem-panel__subtitle">
@@ -161,17 +157,6 @@ export function SalemChatPanel({ familiarId, model }: { familiarId?: string | nu
           </div>
         </div>
         <div className="salem-panel__header-actions">
-          <button
-            type="button"
-            className="salem-panel__pathfind"
-            onClick={findPath}
-            disabled={pathfinding}
-            aria-label="Find your next path"
-            title="Find your next path"
-          >
-            <Icon name="ph:sparkle" width={13} aria-hidden />
-            <span className="salem-panel__pathfind-text">Find your next path</span>
-          </button>
           <Icon name="ph:book-open" width={14} />
         </div>
       </div>

--- a/src/components/salem/salem.test.ts
+++ b/src/components/salem/salem.test.ts
@@ -21,7 +21,7 @@ assert.match(cat, /rim|accent-presence/i, "black cat must keep a colored rim for
 // 2. SalemChatPanel wires chat + API. The floating perch was removed; Salem
 //    stays available through the companion sidepanel and context-aware search.
 const widget = await readFile(path.join(root, "src/components/salem/salem-widget.tsx"), "utf8");
-assert.match(widget, /<SalemCat\b/, "sidepanel must embed the 2D SalemCat");
+assert.doesNotMatch(widget, /<SalemCat\b|from "\.\/salem-cat"/, "sidepanel header no longer embeds the cat avatar");
 assert.doesNotMatch(widget, /SalemCat3D|from "three"/, "widget must not reference the removed 3D cat or three");
 assert.match(widget, /SalemChatPanel/, "must export SalemChatPanel for the right rail");
 assert.doesNotMatch(widget, /export function SalemWidget|type SalemWidgetProps|salem-perch|--salem-proximity/, "floating Salem widget/perch should stay removed");


### PR DESCRIPTION
## What

Two removals from the Salem docs side-panel header (per request):

- **"Find your next path"** pathfinder trigger button.
- The **SalemCat avatar** to the left of the "Salem" name.

## Details

- `salem-widget.tsx` — drop the button + the cat render and its import.
- `globals.css` — remove the now-dead `.salem-panel__pathfind` styles and the `salem-rail` container context (it only existed to collapse the trigger on narrow rails).
- The pathfinder **save-to-board / feedback wiring** (`findPath`, the card render, board + feedback handlers) is intentionally **retained** — it's still covered by the pathfinder-card / home-entry / feedback-capture contracts — so the feature can be re-surfaced later. Only the visible trigger is gone.
- Updated the two source-text assertions that pinned the trigger (`salem-pathfinder-card.test.ts`) and the embedded cat (`salem.test.ts` → now asserts the cat is no longer embedded).

## Verification

- `tsc --noEmit` clean; `pnpm test:app` — all 316 test files pass.
- Built the prod app and screenshotted the panel: header shows just "Salem" + subtitle on the left and the book icon on the right — no cat, no pathfinder button.

Note: Salem's greeting still says "the black-cat-in-the-corner thing is intentional" (persona flavor text, left untouched). Happy to adjust that copy if you'd like it to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)