### PR TITLE
feat(sidebar): add Dashboard link and soften footer dividers

### DIFF
--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -293,8 +293,20 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
         <RecentActivityRollup activeSessionId={activeSessionId} onOpenSession={onOpenSession} />
       </div>
 
-      {/* Bottom: Notifications + Settings */}
+      {/* Bottom: Dashboard + Notifications + Settings */}
       <div className="sidebar-foot">
+        {/* Dashboard is a standalone Next route (/dashboard), not a workspace
+            mode — navigate with a real link rather than onModeChange. */}
+        <a
+          className="sidebar-foot-btn"
+          href="/dashboard"
+          title="Dashboard — activity overview and daily reports"
+        >
+          <span className="sidebar-foot-icon-cell" aria-hidden="true">
+            <Icon name="ph:squares-four" width={14} className="sidebar-foot-icon" />
+          </span>
+          <span className="sidebar-foot-label">Dashboard</span>
+        </a>
         {onOpenInbox ? (
           <button
             type="button"

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -127,7 +127,11 @@
   background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
   color: color-mix(in oklch, var(--accent-presence) 85%, var(--text-primary));
   border: 1px solid color-mix(in oklch, var(--accent-presence) 18%, transparent);
-  white-space: nowrap;
+  /* Wrap long inline code gracefully instead of overflowing the bubble.
+     break-word keeps short snippets intact but lets oversized tokens break. */
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 /* Inline file references linkified by wireFilePathLinks — clickable, with an

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -268,7 +268,9 @@
 .sidebar-foot {
   flex-shrink: 0;
   padding: 8px 6px 0;
-  border-top: 1px solid var(--border-hairline);
+  /* Softer than a full hairline — the footer should read as a calm boundary,
+     not a hard rule competing with the nav. */
+  border-top: 1px solid color-mix(in oklch, var(--border-hairline) 45%, transparent);
   display: grid;
   flex-direction: column;
   gap: 4px;
@@ -598,7 +600,7 @@
   padding: 0 0 10px;
   padding-top: 6px;
   padding-bottom: 8px;
-  border-bottom: 1px solid var(--border-hairline);
+  border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 45%, transparent);
 }
 
 /* Footer rows slightly smaller/dimmer than header rows */
@@ -619,7 +621,7 @@
 .sidebar-bottom {
   flex-shrink: 0;
   padding: 6px 7px 8px;
-  border-top: 1px solid var(--border-hairline);
+  border-top: 1px solid color-mix(in oklch, var(--border-hairline) 45%, transparent);
 }
 
 .sidebar-settings-row {


### PR DESCRIPTION
## What

- **Dashboard link** in the sidebar footer (above Notifications). `/dashboard` is a standalone Next route, not a workspace mode, so it navigates via a real `<a href="/dashboard">` rather than `onModeChange`, using the whitelisted `ph:squares-four` icon.
- **Softer dividers** — the sidebar divider lines (`.sidebar-foot`, `.sidebar-bottom`, `.sidebar-actions--footer`) drop to ~45% hairline strength so they read as calm boundaries instead of hard rules competing with the nav.
- **Inline-code wrapping in chat** — long inline `code` chips (`.cave-md` inline code) were forced onto one line with `white-space: nowrap`, overflowing the message bubble and getting clipped. They now wrap gracefully (`white-space: normal` + `overflow-wrap: anywhere` + `word-break: break-word`).

## Verification

- `src/components/sidebar-minimal.test.ts` passes.
- Ran the web build and screenshotted the sidebar — Dashboard link renders with the softened divider above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)