### PR TITLE
perf(chat): memoize TurnRow so streamed tokens don't re-render the whole thread

### DIFF
--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -276,7 +276,7 @@ assert.match(
 
 // The readout lives in the assistant turn's meta row, after the timestamp.
 const usageTurnRow =
-  source.match(/function TurnRow[\s\S]*?\n}\n\nfunction AttachmentLightbox/)?.[0] ?? "";
+  source.match(/function TurnRowImpl[\s\S]*?\n}\n\ntype TurnRowProps/)?.[0] ?? "";
 assert.ok(usageTurnRow, "TurnRow body should be extractable (CHAT-D12-02)");
 assert.match(
   usageTurnRow,

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
 const styles = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
-const turnRow = source.match(/function TurnRow[\s\S]*?\n}\n\nfunction AttachmentLightbox/)?.[0] ?? "";
+const turnRow = source.match(/function TurnRowImpl[\s\S]*?\n}\n\ntype TurnRowProps/)?.[0] ?? "";
 const splitReasoning = source.match(/function splitReasoning[\s\S]*?\n}\n\n\/\/ ── ChatEmptyState/)?.[0] ?? "";
 
 assert.match(

--- a/src/components/chat-view-render-optimization.test.ts
+++ b/src/components/chat-view-render-optimization.test.ts
@@ -86,4 +86,24 @@ assert.match(
 // during normal render; the main win is replacing the per-row indexOf(t) in the
 // render loop (lines 2570, 2601) which is called for every turn on every render.
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 4: TurnRow is memoized (CHAT-D3-07) so a streamed token re-renders only
+// the streaming row, not every settled row in the thread.
+// ─────────────────────────────────────────────────────────────────────────────
+
+assert.match(
+  chatViewSource,
+  /const TurnRow = memo\(TurnRowImpl, areTurnRowPropsEqual\);/,
+  "TurnRow wraps TurnRowImpl in React.memo with a custom comparator",
+);
+
+// The comparator must ignore callback identity (those closures are recreated on
+// every parent render) and instead track the stable turn ref + action presence,
+// or memoization would never bail out during streaming.
+assert.match(
+  chatViewSource,
+  /function areTurnRowPropsEqual\(prev: TurnRowProps, next: TurnRowProps\): boolean \{[\s\S]*?prev\.turn === next\.turn[\s\S]*?Boolean\(prev\.onRegenerate\) === Boolean\(next\.onRegenerate\)/,
+  "memo comparator compares the stable turn ref and action availability, not callback identity",
+);
+
 console.log("✓ All render optimization tests pass");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, Fragment, useCallback, useEffect, useId, useImperativeHandle, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+import { forwardRef, Fragment, memo, useCallback, useEffect, useId, useImperativeHandle, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { RichText } from "@/components/rich-text";
 import { MessageBubble, SyntaxBlock, type MessageBubbleSegment } from "@/components/message-bubble";
@@ -3648,7 +3648,11 @@ function splitTextForArtifacts(
   return out;
 }
 
-function TurnRow({
+// CHAT-D3-07 perf: the implementation is memoized as `TurnRow` below, so a
+// streamed token re-renders only the streaming row rather than every settled
+// row in the thread (settled turns keep a stable `turn` reference because
+// setTurns replaces just the changed turn). See `areTurnRowPropsEqual`.
+function TurnRowImpl({
   turn,
   familiar,
   showTimestamp = true,
@@ -4113,6 +4117,32 @@ function ToolBlock({ tool }: { tool: ToolEvent }) {
     </details>
   );
 }
+
+type TurnRowProps = Parameters<typeof TurnRowImpl>[0];
+
+/**
+ * Memo comparator for {@link TurnRow}. Callback props are recreated on every
+ * parent render (e.g. `onRegenerate={regenerateFor(t)}`), so comparing them by
+ * identity would defeat memoization entirely. Instead we compare the stable
+ * data (`turn` ref, familiar, the booleans) and the *presence* of each action —
+ * the Edit / Regenerate / Reply buttons appear and disappear based on whether
+ * the callback is defined (e.g. Regenerate hides while busy), and that flip is
+ * what a row must re-render for. Returns true to skip the re-render.
+ */
+function areTurnRowPropsEqual(prev: TurnRowProps, next: TurnRowProps): boolean {
+  return (
+    prev.turn === next.turn &&
+    prev.familiar === next.familiar &&
+    prev.showTimestamp === next.showTimestamp &&
+    prev.found === next.found &&
+    prev.expanded === next.expanded &&
+    Boolean(prev.onEdit) === Boolean(next.onEdit) &&
+    Boolean(prev.onRegenerate) === Boolean(next.onRegenerate) &&
+    Boolean(prev.onReply) === Boolean(next.onReply)
+  );
+}
+
+const TurnRow = memo(TurnRowImpl, areTurnRowPropsEqual);
 
 function AttachmentLightbox({ attachment, onClose }: { attachment: ChatAttachment; onClose: () => void }) {
   const isImage = (attachment.mimeType ?? attachment.type)?.startsWith("image/");


### PR DESCRIPTION
## Problem

Each streamed assistant token calls `setTurns`, which maps the array and replaces **only** the streaming turn — every other turn keeps a stable object reference. But `TurnRow` was an unmemoized function component, so React re-rendered **all N rows** on every token. For each settled row that meant re-running `splitReasoning` / `extractNextPaths` / `segmentTurn` / `splitTextForArtifacts` and reconciling the markdown subtree — many times per second on a long thread.

## Fix

Wrap `TurnRow` (now `TurnRowImpl`) in `React.memo` with a custom comparator:

- Compares the **stable data**: `turn` ref, `familiar`, `showTimestamp`, `found`, `expanded`.
- Compares the **presence** of each action callback (`onEdit` / `onRegenerate` / `onReply`) rather than its identity — those closures (`onRegenerate={regenerateFor(t)}` etc.) are recreated every parent render, so identity comparison would defeat memo entirely. Presence is what matters: e.g. Regenerate hides while busy, and that flip must still re-render the row.

Result: a streamed token re-renders just the streaming row; settled rows bail out. The timestamp-format hook (`useDateTimePrefs`, `useSyncExternalStore`) still updates every row independently when the setting changes — `memo` doesn't block store-driven updates.

## Correctness notes
- Settled turns keep a stable `turn` ref (immutable `setTurns`), so ref equality is a valid change signal.
- Action buttons appearing/disappearing is captured via the `Boolean(...)` presence checks.
- No prop-contract or JSX changes at the call sites (`<TurnRow .../>` is unchanged); only the declaration is renamed and wrapped.

## Tests
- Updated the two source-text extraction anchors (`chat-view-lifecycle`, `chat-view-polish`) for the `TurnRowImpl` rename.
- Added assertions to `chat-view-render-optimization.test.ts` locking in `memo(TurnRowImpl, areTurnRowPropsEqual)` and the comparator's shape.
- `pnpm build` clean (typecheck + lint); affected suites pass (render-optimization, lifecycle, polish, response-metadata, reply-wiring, router-switching).

## Follow-ups (not in this PR)
- The parent still computes `replyFor(t)`/`regenerateFor(t)` per row per render (the former parses text); a `WeakMap<Turn, …>` cache keyed by the stable turn ref would remove that parent-side cost too.
- No list virtualization yet — long threads still mount every row in the DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)