### PR TITLE
style(projects): make the Projects list full width

### DIFF
--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -616,7 +616,7 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: Pr
             }
           />
         ) : loading && projects.length === 0 ? (
-          <div className="mx-auto flex w-full max-w-[1100px] flex-col gap-2">
+          <div className="flex w-full flex-col gap-2">
             <SkeletonRows count={4} />
           </div>
         ) : projects.length === 0 ? (
@@ -649,7 +649,7 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: Pr
             }
           />
         ) : (
-          <div className="mx-auto flex w-full max-w-[1100px] flex-col">
+          <div className="flex w-full flex-col">
             {error ? (
               <div
                 role="alert"


### PR DESCRIPTION
## What

The **Projects** view header spans the full surface width, but the project list below it was capped at `max-w-[1100px]` and centered — leaving large empty gutters on wide screens (see the report). Now the list fills the available width, matching the header.

## How

Removed `mx-auto max-w-[1100px]` from the project-list container (and the matching loading-skeleton container) in `projects-view.tsx`. The list keeps the surrounding `<main>`'s `px-4 sm:px-6` padding, so it's flush with the header's edges.

## Verification

- `pnpm typecheck` ✅ · `pnpm test:app` (319 files) ✅ · `projects-view.test.ts` ✅
- No test pinned the old width cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)