### PR TITLE
perf(chat): cache replyFor's parse by turn ref (streaming hot path)

### DIFF
--- a/src/components/chat-view-render-optimization.test.ts
+++ b/src/components/chat-view-render-optimization.test.ts
@@ -106,4 +106,21 @@ assert.match(
   "memo comparator compares the stable turn ref and action availability, not callback identity",
 );
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 5: replyFor caches its parse by the stable turn ref (CHAT-D3-07) so the
+// per-row Reply decision isn't recomputed for the whole transcript each token.
+// ─────────────────────────────────────────────────────────────────────────────
+
+assert.match(
+  chatViewSource,
+  /const replyableTurnCache = new WeakMap<Turn, boolean>\(\);/,
+  "replyFor's parse decision is cached in a turn-keyed WeakMap",
+);
+
+assert.match(
+  chatViewSource,
+  /function replyFor\(turn: Turn\)[\s\S]*?replyableTurnCache\.get\(turn\)[\s\S]*?replyableTurnCache\.set\(turn, canReply\)/,
+  "replyFor reads then populates the WeakMap cache instead of re-parsing every render",
+);
+
 console.log("✓ All render optimization tests pass");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -122,6 +122,15 @@ type Turn = {
   voiceCallId?: string;
 };
 
+// CHAT-D3-07 perf: `replyFor` runs for every row on every render and parses the
+// turn text (strip reasoning + Next paths) to decide whether the Reply action
+// shows. During streaming that would re-parse the whole settled transcript on
+// each token. Cache the boolean decision by the stable turn reference — settled
+// turns keep their object, so they hit; only the streaming turn gets a fresh ref
+// (correct miss). Module-scoped and keyed weakly, so dead turns are GC'd; the
+// value is a pure function of the turn, so sharing across instances is safe.
+const replyableTurnCache = new WeakMap<Turn, boolean>();
+
 type Props = {
   familiar: Familiar;
   sessionId: string | null;
@@ -2509,9 +2518,17 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   /** Build the Reply action for a settled, non-empty turn (undefined hides it). */
   function replyFor(turn: Turn): (() => void) | undefined {
     if (turn.pending) return undefined;
-    const source = turn.role === "assistant" ? extractNextPaths(splitReasoning(turn.text).visible).visible : turn.text;
-    if (!source.trim()) return undefined;
-    return () => replyToTurn(turn);
+    // Cache the expensive replyable decision by the stable turn ref (see
+    // `replyableTurnCache`); rebuild the cheap closure fresh so it never
+    // captures a stale `replyToTurn`.
+    let canReply = replyableTurnCache.get(turn);
+    if (canReply === undefined) {
+      const source =
+        turn.role === "assistant" ? extractNextPaths(splitReasoning(turn.text).visible).visible : turn.text;
+      canReply = source.trim().length > 0;
+      replyableTurnCache.set(turn, canReply);
+    }
+    return canReply ? () => replyToTurn(turn) : undefined;
   }
 
   // CHAT-D6-02: regenerate. Re-sends the PRECEDING user turn (text +


### PR DESCRIPTION
Follow-up to #1054 (TurnRow memoization).

## Problem
After memoizing `TurnRow`, the remaining per-token cost was the **parent** render loop: `onReply={replyFor(t)}` runs for every row on every render, and `replyFor` parses the turn text (`splitReasoning` + `extractNextPaths`) to decide whether the Reply action shows. During streaming the parent re-renders on each token, so it re-parsed the entire settled transcript many times per second.

## Fix
Cache the boolean "is this turn replyable" decision in a module-level `WeakMap<Turn, boolean>` keyed by the **stable turn reference**:
- Settled turns keep their object → cache hit → no re-parse.
- The streaming turn gets a fresh ref each token → correct cache miss → recompute.

The cheap closure (`() => replyToTurn(turn)`) is rebuilt fresh each render so it never captures a stale `replyToTurn`, and #1054's memo comparator already compares `onReply` by **presence**, so the closure's identity churn doesn't defeat memoization.

## Safety
- Weak keys → dead turns are GC'd.
- The cached value is a pure function of the turn (text + role), so the module-scoped cache is safe across instances.
- Turn objects are immutable (`setTurns` replaces), so a ref-keyed cache never goes stale.
- `regenerateFor` is intentionally left as-is — it's blessed by the existing perf test and does no parsing (only an `O(n)` `findIndex`).

## Tests
- `pnpm build` clean (typecheck + lint).
- New assertions in `chat-view-render-optimization.test.ts` lock in the WeakMap + cache read/populate.
- Affected suites pass: render-optimization, reply-wiring, lifecycle, polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)