### PR TITLE
fix(appearance): selecting a theme applies it without opening the color editor

### DIFF
--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -845,8 +845,10 @@ function AppearanceSection() {
     setActiveTheme(id);
     setCustomData(null);
     applyPreset(id);
-    // Open the color editor seeded with this preset.
-    setColorEditorBase(id);
+    // Selecting a preset just applies it. The color editor is opened explicitly
+    // via "Customize colors" so a plain pick doesn't drop into edit mode (which
+    // would flip data-theme to "custom").
+    setColorEditorBase(null);
   };
 
   const handleSetCornerRadius = (next: CornerRadius) => {
@@ -1030,7 +1032,22 @@ function AppearanceSection() {
           ))}
         </div>
 
-        {/* ── Color editor: shown when a preset is selected ── */}
+        {/* Open the color editor explicitly — selecting a preset above only
+            applies it, so this is the way into custom tweaking. */}
+        {!colorEditorBase && (
+          <div className="border-t border-[var(--border-hairline)] px-4 py-3">
+            <button
+              type="button"
+              onClick={() => setColorEditorBase(activeTheme === "custom" ? "coven" : activeTheme)}
+              className="focus-ring inline-flex items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-3 py-1.5 text-[12px] font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+            >
+              <Icon name="ph:paint-brush" width={13} />
+              Customize colors
+            </button>
+          </div>
+        )}
+
+        {/* ── Color editor: shown when "Customize colors" is opened ── */}
         {colorEditorBase && (
           <div className="border-t border-[var(--border-hairline)] p-4">
             <ThemeColorEditor


### PR DESCRIPTION
Picking a preset theme used to immediately open the color editor, which live-previews as `data-theme="custom"` — so the live `<html data-theme>` read `custom` instead of the chosen preset id (caught while testing the themes).

Now **selection just applies the preset** (`data-theme=<id>`), and a new **"Customize colors"** button opens the editor explicitly when you want to tweak.

Verified live: selecting Claude/Bane/Tide sets `data-theme` to `claude`/`bane`/`tide` (no editor opens); clicking Customize colors opens the editor (`data-theme=custom`).

`tsc --noEmit` clean · `node scripts/run-tests.mjs app` → 319 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)