### PR TITLE
perf(chat): render-virtualize turns with content-visibility on long threads

### DIFF
--- a/src/components/chat-view-render-optimization.test.ts
+++ b/src/components/chat-view-render-optimization.test.ts
@@ -19,6 +19,11 @@ const messageBubbleSource = readFileSync(
   "utf8",
 );
 
+const caveChatCss = readFileSync(
+  new URL("../styles/cave-chat.css", import.meta.url),
+  "utf8",
+);
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Test 1: Turn index map for O(1) lookup (CHAT-D10-02 fix)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -121,6 +126,17 @@ assert.match(
   chatViewSource,
   /function replyFor\(turn: Turn\)[\s\S]*?replyableTurnCache\.get\(turn\)[\s\S]*?replyableTurnCache\.set\(turn, canReply\)/,
   "replyFor reads then populates the WeakMap cache instead of re-parsing every render",
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 6: turns are render-virtualized via content-visibility (CHAT-D3-07) so
+// the browser skips layout/paint for rows scrolled out of view on long threads.
+// ─────────────────────────────────────────────────────────────────────────────
+
+assert.match(
+  caveChatCss,
+  /\.cave-linear-turn \{[\s\S]*?content-visibility:\s*auto;[\s\S]*?contain-intrinsic-size:\s*auto 160px;[\s\S]*?\}/,
+  "the turn row sets content-visibility:auto with a contain-intrinsic-size estimate",
 );
 
 console.log("✓ All render optimization tests pass");

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2422,6 +2422,16 @@ details[open] > .cave-tool-summary::before {
   flex-direction: column;
   padding: 14px 0 12px;
   border-bottom: 1px solid color-mix(in oklch, var(--foreground) 5%, transparent);
+  /* CHAT-D3-07 render virtualization: let the browser skip layout + paint for
+     turns scrolled out of view (the React side is already memoized, so this is
+     the remaining cost on long threads). `contain-intrinsic-size: auto <est>`
+     gives an off-screen row a placeholder height and remembers its real size
+     once rendered, so the scrollbar stays stable. Stick-to-bottom and
+     scroll-to-bottom are unaffected — the on-screen bottom rows always render
+     at their true height; only off-screen rows use the estimate. On-screen
+     rows are not contained, so position:sticky descendants behave normally. */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 160px;
 }
 
 .cave-linear-turn:last-child {


### PR DESCRIPTION
Uses CSS content-visibility:auto to skip layout/paint of off-screen turns on long chat threads, reducing render cost significantly.