### PR TITLE
feat(datetime): apply the 12h/24h clock preference app-wide

### DIFF
--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -5,6 +5,7 @@ import type { InboxItem } from "@/lib/cave-inbox";
 import type { Familiar } from "@/lib/types";
 import { Icon } from "@/lib/icon";
 import type { IconName } from "@/lib/icon";
+import { formatClock } from "@/lib/datetime-format";
 import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { SnoozeMenu } from "@/components/snooze-menu";
@@ -69,10 +70,7 @@ function isSameDay(a: Date, b: Date): boolean {
 }
 
 function fmtTime(iso: string): string {
-  return new Date(iso).toLocaleTimeString(undefined, {
-    hour: "numeric",
-    minute: "2-digit",
-  });
+  return formatClock(iso);
 }
 
 function fmtDateHeading(d: Date): string {

--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { Icon } from "@/lib/icon";
 import { copyText } from "@/lib/clipboard";
+import { formatClock } from "@/lib/datetime-format";
 import { MarkdownBlock } from "@/components/message-bubble";
 import type { HarnessCapabilityManifest } from "@/components/capability-card";
 import {
@@ -331,10 +332,7 @@ export function CapabilitiesViewSurface({
               <div className="flex shrink-0 items-center gap-2 text-[11px] text-muted-foreground">
                 {scannedAt && (
                   <span title={scannedAt}>
-                    Scanned {new Date(scannedAt).toLocaleTimeString([], {
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })}
+                    Scanned {formatClock(scannedAt)}
                   </span>
                 )}
                 <button

--- a/src/components/capability-card.tsx
+++ b/src/components/capability-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Icon } from "@/lib/icon";
+import { formatClock } from "@/lib/datetime-format";
 
 export type GlobalInstructions = {
   present: boolean;
@@ -148,10 +149,7 @@ function HarnessCapabilityCard({ manifest }: { manifest: HarnessCapabilityManife
           </p>
         </div>
         <span className="text-[10px] text-muted-foreground sm:ml-auto">
-          {new Date(manifest.scanned_at).toLocaleTimeString([], {
-            hour: "2-digit",
-            minute: "2-digit",
-          })}
+          {formatClock(manifest.scanned_at)}
         </span>
       </div>
 

--- a/src/components/coven-floor.tsx
+++ b/src/components/coven-floor.tsx
@@ -4,6 +4,7 @@ import "@/styles/board.css";
 
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { formatClock } from "@/lib/datetime-format";
 import type { CovenStatusResponse, FamiliarCard, SessionSummary } from "@/lib/coven-status-types";
 import { statusColor, statusLabel } from "@/lib/coven-status-types";
 import { SessionInitiatorChip } from "@/components/ui/session-initiator-chip";
@@ -311,7 +312,7 @@ export function CovenFloor() {
           </span>
           {computedAt ? (
             <span className="text-[10px] text-[var(--text-muted)]">
-              updated {new Date(computedAt).toLocaleTimeString()}
+              updated {formatClock(computedAt)}
             </span>
           ) : null}
           <button

--- a/src/components/debug-pane.tsx
+++ b/src/components/debug-pane.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { Icon } from "@/lib/icon";
 import { copyText } from "@/lib/clipboard";
+import { formatClock } from "@/lib/datetime-format";
 import {
   stripPreviewOnlyAttachmentFields,
   type ChatAttachment,
@@ -167,7 +168,7 @@ function EventRow({ event }: { event: CovenEvent }) {
         <span className="w-10 shrink-0 font-mono text-[var(--text-muted)]">{event.seq}</span>
         <span className="min-w-0 flex-1 truncate font-medium text-[var(--text-secondary)]">{event.kind}</span>
         <span className="shrink-0 font-mono text-[var(--text-muted)]">
-          {new Date(event.created_at).toLocaleTimeString()}
+          {formatClock(event.created_at, undefined, { seconds: true })}
         </span>
       </button>
       {open ? (

--- a/src/components/settings-fonts.tsx
+++ b/src/components/settings-fonts.tsx
@@ -472,16 +472,18 @@ export function FontSettings() {
         </div>
       </div>
 
-      {/* Chat timestamps — how the per-message time/date renders in chat. The
-          model, working directory, and duration that used to sit alongside it
-          live in the debug pane now. */}
+      {/* Date & time — the Clock setting applies to every time shown in the app
+          (calendar, capabilities, debug, …); the Date format applies to the chat
+          message timestamp, where model/cwd/duration used to sit (now in debug). */}
       <div className="flex flex-col gap-2">
         <div>
-          <h4 className="text-[12px] font-semibold text-[var(--text-primary)]">Chat timestamps</h4>
-          <p className="text-[11px] text-[var(--text-muted)]">Shown on each chat message.</p>
+          <h4 className="text-[12px] font-semibold text-[var(--text-primary)]">Date &amp; time</h4>
+          <p className="text-[11px] text-[var(--text-muted)]">
+            Clock applies across the app; the date format applies to chat message timestamps.
+          </p>
         </div>
         <div className="divide-y divide-[var(--border-hairline)] rounded-lg border border-[var(--border-hairline)] px-3">
-          <ReadingRow label="Clock">
+          <ReadingRow label="Clock" hint="Across the app">
             <div className={segWrap}>
               {CLOCK_OPTIONS.map((option) => (
                 <button
@@ -497,7 +499,7 @@ export function FontSettings() {
               ))}
             </div>
           </ReadingRow>
-          <ReadingRow label="Date">
+          <ReadingRow label="Date" hint="Chat messages">
             <div className={segWrap}>
               {DATE_OPTIONS.map((option) => (
                 <button

--- a/src/lib/datetime-format.test.ts
+++ b/src/lib/datetime-format.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import {
   DEFAULT_CLOCK,
   DEFAULT_DATE,
+  formatClock,
   formatTimestamp,
   normalizeClock,
   normalizeDate,
@@ -48,4 +49,24 @@ test("date Off returns the time only", () => {
 test("unparseable input renders nothing", () => {
   assert.equal(formatTimestamp("not-a-date"), "");
   assert.equal(formatTimestamp(""), "");
+});
+
+test("formatClock honors the clock pref, time only (app-wide entry point)", () => {
+  const twelve = formatClock(ISO, { clock: "12h", date: "mmdd" });
+  assert.match(twelve, /1:31/);
+  assert.match(twelve, /[AP]M/i);
+  assert.ok(!twelve.includes("06.19"), "formatClock never emits a date even if the date pref is set");
+
+  const twentyFour = formatClock(ISO, { clock: "24h", date: "mmdd" });
+  assert.match(twentyFour, /13:31/);
+  assert.doesNotMatch(twentyFour, /[AP]M/i);
+});
+
+test("formatClock can include seconds (debug log)", () => {
+  assert.match(formatClock(ISO, { clock: "24h", date: "off" }, { seconds: true }), /13:31:00/);
+  assert.doesNotMatch(formatClock(ISO, { clock: "24h", date: "off" }), /:00\b/);
+});
+
+test("formatClock renders nothing for bad input", () => {
+  assert.equal(formatClock("not-a-date", { clock: "24h", date: "off" }), "");
 });

--- a/src/lib/datetime-format.ts
+++ b/src/lib/datetime-format.ts
@@ -144,19 +144,37 @@ function pad2(n: number): string {
 }
 
 /**
+ * Time only ("1:31 AM" / "13:31"), honoring the clock (12h/24h) preference.
+ * This is the app-wide entry point: any surface that shows a time (calendar
+ * events, capability scan times, debug events, …) routes through here so the
+ * clock setting is global, not chat-only. `prefs` defaults to the persisted
+ * preference, so callers outside a React tree can use it directly; pass
+ * `{ seconds: true }` where second precision matters (e.g. the debug log).
+ */
+export function formatClock(
+  iso: string,
+  prefs: DateTimePrefs = readDateTimePrefs(),
+  opts: { seconds?: boolean } = {},
+): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+    ...(opts.seconds ? { second: "2-digit" } : {}),
+    hour12: prefs.clock === "12h",
+  });
+}
+
+/**
  * Format an ISO timestamp per the given prefs. The date portion is built from
  * the local month/day (so it's locale-stable: "06.19"), and the time portion
- * uses the platform locale's clock with `hour12` driven by the pref. Returns
- * "" for an unparseable input.
+ * uses {@link formatClock}. Returns "" for an unparseable input.
  */
 export function formatTimestamp(iso: string, prefs: DateTimePrefs = DEFAULT_PREFS): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return "";
-  const time = d.toLocaleTimeString([], {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: prefs.clock === "12h",
-  });
+  const time = formatClock(iso, prefs);
   const mm = pad2(d.getMonth() + 1);
   const dd = pad2(d.getDate());
   const datePart = prefs.date === "mmdd" ? `${mm}.${dd}` : prefs.date === "ddmm" ? `${dd}.${mm}` : "";


### PR DESCRIPTION
Follow-up to the chat timestamp feature — makes the clock preference global instead of chat-only.

## What
- Added `formatClock(iso, prefs?, opts?)` to `src/lib/datetime-format.ts` — time-only, honors the 12h/24h pref, defaults to the persisted prefs (so non-React callers work), and takes `{ seconds: true }` where second precision matters. `formatTimestamp` now reuses it.
- Routed the five **time** displays through it so the clock setting applies everywhere:
  - `calendar-view` event times
  - `capability-card` + `capabilities-view` scan times
  - `coven-floor` "updated …"
  - `debug-pane` event log (keeps seconds)
- Relabeled the settings group **"Chat timestamps" → "Date & time"** with scope hints (Clock = across the app, Date = chat messages).

## Deliberately scoped
The **date format** pref (`MM.DD`/`DD.MM`) stays chat-specific. The verbose date-only displays — library doc list, memory inspector, calendar day header — keep their month-name + year. Forcing `MM.DD` there would drop the year and read worse; happy to extend if you want the compact form there too.

## Verification
- `pnpm build` clean (typecheck + lint).
- `datetime-format.test.ts`: 9 tests pass, incl. new `formatClock` cases (12h keeps AM/PM, 24h → `13:31` no AM/PM, never emits a date, optional seconds).
- No tests pinned the old `toLocaleTimeString` calls or the "Chat timestamps" label, so nothing else needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)