### PR TITLE
fix(workflows): Stop actually stops a running workflow's agent session

### DIFF
--- a/src/components/workflows-view.tsx
+++ b/src/components/workflows-view.tsx
@@ -268,7 +268,17 @@ export function WorkflowsView({
     return () => clearTimeout(timer);
   }, [playback]);
 
-  const stopPlayback = useCallback(() => setPlayback(null), []);
+  const stopPlayback = useCallback(() => {
+    // A session-executor run spawns a real agent session, so stopping must kill
+    // it on the daemon — clearing the local playback alone would leave the
+    // workflow's agent running. Plan previews/replays have no session to stop.
+    if (playback?.live && playback.sessionId) {
+      void fetch(`/api/sessions/${encodeURIComponent(playback.sessionId)}/kill`, {
+        method: "POST",
+      }).catch(() => undefined);
+    }
+    setPlayback(null);
+  }, [playback]);
 
   // Deep-link into the live agent session a session-executor run spawned. Same
   // `#chat-<sessionId>` idiom the workspace uses to restore a thread; the

--- a/src/components/workflows/workflow-run-strip.tsx
+++ b/src/components/workflows/workflow-run-strip.tsx
@@ -194,7 +194,14 @@ export function WorkflowRunStrip({
             type="button"
             className="workflow-playback-stop"
             onClick={onStopPlayback}
-            title={playbackRunning ? "Stop playback" : "Clear playback"}
+            title={
+              activePlayback.live
+                ? "Stop the running workflow — kills its agent session"
+                : playbackRunning
+                  ? "Stop playback"
+                  : "Clear playback"
+            }
+            aria-label={activePlayback.live ? "Stop running workflow" : undefined}
           >
             <Icon name={playbackRunning ? "ph:stop-fill" : "ph:x-bold"} width={12} />
             {playbackRunning ? "Stop" : "Clear"}


### PR DESCRIPTION
## Problem

A session-executor workflow run spawns a **real agent session** (`/api/workflows/run` → `/api/v1/sessions`), but the **Stop** control only did `setPlayback(null)` — it cleared the local playback animation while the agent **kept running**. So you couldn't actually stop a running workflow.

## Fix

`stopPlayback` now, when the playback is a live run (`playback.live && playback.sessionId`), kills the agent session via `POST /api/sessions/<id>/kill` (the existing owned-session, local-only kill endpoint) before clearing the UI. Plan previews/replays (no session) clear as before.

Also made the Stop button's title/aria accurate for live runs.

## Verification

`tsc --noEmit` clean · `node scripts/run-tests.mjs app` → 319 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)