### PR TITLE
fix(familiar): avatar image fills the switcher trigger square

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4712,6 +4712,17 @@ button:active > .edge-rail-chip {
               border-color var(--duration-fast) var(--ease-standard);
 }
 
+/* Avatar image fills the trigger square edge-to-edge. FamiliarAvatar renders a
+   fixed 16px img, which sits centered in the 28px button and leaves a dark gap;
+   stretch it to the button's inner box instead. The glyph fallback is a vector
+   icon — intentionally NOT targeted here, so it stays centered at its own size. */
+.familiar-switcher__trigger img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: calc(var(--radius-control) - 1px);
+}
+
 .familiar-switcher__trigger:hover {
   color: var(--text-primary);
   background: var(--bg-hover);


### PR DESCRIPTION
## What

The FamiliarSwitcher trigger is a 28px square, but `FamiliarAvatar` renders the avatar at a fixed **16px, centered** — leaving a ~6px dark gap on all sides. This shows in the desktop menu bar and the mobile top bar (both use the same trigger).

Scope one rule to `.familiar-switcher__trigger img` so the image fills the button's inner box:

```css
.familiar-switcher__trigger img {
  width: 100%;
  height: 100%;
  object-fit: cover;
  border-radius: calc(var(--radius-control) - 1px);
}
```

## Why scoped to the trigger

`FamiliarAvatar` is shared across 20+ usages (chat, board, sidebar, inspector, studio…), so changing the component or its default classes would ripple everywhere. Targeting the trigger keeps the change to the switcher only. The vector-**glyph** fallback is intentionally not targeted — stretching an icon edge-to-edge would look wrong, so it stays centered.

## Verification

Ran the web build and measured the real trigger with the shipped CSS: image goes from a fixed 16px centered (6px gap) to **26×26 with a 1px inset** (just the button's hairline border) — `object-fit: cover`, inner radius. Confirmed visually that the avatar now covers the full rounded square.

🤖 Generated with [Claude Code](https://claude.com/claude-code)