### PR TITLE
refactor(dashboard): tidy callout inline styles + dedupe relativeTime

### DIFF
--- a/src/components/dashboard/action-inbox.tsx
+++ b/src/components/dashboard/action-inbox.tsx
@@ -50,7 +50,9 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
         </div>
       ) : null}
       <div className="dr-list">
-        {items.map((item) => (
+        {items.map((item) => {
+          const when = relativeTime(item.firedAt ?? item.updatedAt);
+          return (
           <div
             key={item.id}
             className="dr-row dash-inbox__row"
@@ -64,9 +66,7 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
               {item.body ? <span className="dr-row__sub">{item.body}</span> : null}
               <span className="dr-row__metaline">
                 <span className="dr-tag">{KIND_LABEL[item.kind]}</span>
-                {relativeTime(item.firedAt ?? item.updatedAt) ? (
-                  <span className="dr-row__time">{relativeTime(item.firedAt ?? item.updatedAt)}</span>
-                ) : null}
+                {when ? <span className="dr-row__time">{when}</span> : null}
               </span>
             </span>
             <span className="dash-inbox__actions">
@@ -91,7 +91,8 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
               </button>
             </span>
           </div>
-        ))}
+          );
+        })}
       </div>
     </section>
   );

--- a/src/components/dashboard/recent-reports.tsx
+++ b/src/components/dashboard/recent-reports.tsx
@@ -20,11 +20,11 @@ export function RecentReports({
             const reportDate = new Date(`${report.slug}T00:00:00`);
             return (
               <a key={report.slug} className="dr-row" href={report.href}>
-                <span className="dr-row__icon" style={{ ["--row-accent" as string]: "var(--color-info)" }}>
+                <span className="dr-row__icon dash-row--info">
                   <Icon name="ph:newspaper" aria-hidden />
                 </span>
                 <span className="dr-row__body dr-report-row">
-                  <span style={{ minWidth: 0, flex: 1 }}>
+                  <span className="dash-report-row__main">
                     <span className="dr-row__title">{relativeDayLabel(reportDate, now)}</span>
                     <span className="dr-row__sub">{report.title}</span>
                   </span>

--- a/src/components/dashboard/report-callout.tsx
+++ b/src/components/dashboard/report-callout.tsx
@@ -12,12 +12,12 @@ export function ReportCallout({
 }) {
   if (!featured) {
     return (
-      <div className="dr-cta" style={{ cursor: "default" }}>
-        <div style={{ display: "flex", alignItems: "center", gap: 16, minWidth: 0 }}>
+      <div className="dr-cta dash-cta--static">
+        <div className="dash-cta__row">
           <span className="dr-cta__icon">
             <Icon name="ph:newspaper" aria-hidden />
           </span>
-          <span style={{ minWidth: 0 }}>
+          <span className="dash-cta__text">
             <div className="dr-cta__title">No daily report yet</div>
             <div className="dr-cta__sub">
               A daily report is generated automatically once there&apos;s activity to summarize — it&apos;ll appear here.
@@ -29,11 +29,11 @@ export function ReportCallout({
   }
   return (
     <a className="dr-cta" href={featured.href}>
-      <div style={{ display: "flex", alignItems: "center", gap: 16, minWidth: 0 }}>
+      <div className="dash-cta__row">
         <span className="dr-cta__icon">
           <Icon name="ph:newspaper" aria-hidden />
         </span>
-        <span style={{ minWidth: 0 }}>
+        <span className="dash-cta__text">
           <div className="dr-cta__title">{isToday ? "Today's daily report is ready" : "Latest daily report"}</div>
           <div className="dr-cta__sub">
             {featured.title}

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -2,6 +2,23 @@
    globals.css; these add only what the adaptive triage/launcher surface needs.
    Namespaced .dash-* so they never collide with /daily-report. */
 
+/* Report callout (today's/latest report) inner layout. */
+.dash-cta--static { cursor: default; }
+.dash-cta__row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  min-width: 0;
+}
+.dash-cta__text { min-width: 0; }
+
+/* Recent-report rows. */
+.dash-row--info { --row-accent: var(--color-info); }
+.dash-report-row__main {
+  min-width: 0;
+  flex: 1;
+}
+
 .dash-strip {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Follow-up to #1074 addressing the **minor** items from that PR's code review.

## Changes
- **Inline styles → scoped classes (#2).** The `display:flex / min-width / cursor` inline styles in `report-callout.tsx` and `recent-reports.tsx` move into namespaced `.dash-*` classes (`.dash-cta__row`, `.dash-cta__text`, `.dash-cta--static`, `.dash-row--info`, `.dash-report-row__main`) in `dashboard.css`, matching the PR's "scoped `.dash-*`" discipline. The class values are byte-for-byte equivalent to the inline styles they replace.
- **Dedupe `relativeTime()` (#3).** `action-inbox.tsx` called `relativeTime(item.firedAt ?? item.updatedAt)` twice per row; hoisted into one `when` const.

**No behavioral or visual change** — pure tidy-up.

## Deliberately not included
- **Placeholder nav targets (#1).** The reviewer flagged Calendar/Library linking to `/`. There is no uniform deep-link mechanism: only `#card-`/`#chat-`/`#memory:`/`#library:` auto-route on load — Board already uses `#card-`, but Calendar has no hash/route, so "fixing" Library alone would make the launcher inconsistent. Left until real surface routes exist, as the reviewer scoped it ("if/when those exist").

## Verification
- `dashboard-model.test.ts` + `dashboard-page.test.ts` pass
- `pnpm build` green (`/dashboard` compiles)
- No source-text test referenced the removed inline styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)