### PR TITLE
feat(projects): collapse projects to scannable rows, sort by recency

### DIFF
--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -100,4 +100,22 @@ assert.match(
   "Project rows should be flat rows separated by a hairline divider",
 );
 
+// Projects collapse to one scannable row by default and expand to reveal the
+// path + sessions; the most-recently-active project opens first.
+assert.match(projectsView, /const \[expanded, setExpanded\] = useState\(defaultExpanded\)/, "each project row owns a collapse/expand state");
+assert.match(projectsView, /aria-expanded=\{expanded\}/, "the disclosure control reports expanded state");
+assert.match(projectsView, /\{expanded \? \(/, "path + sessions render only when the row is expanded");
+assert.match(projectsView, /defaultExpanded=\{index === 0\}/, "the most-recent project starts expanded");
+
+// Projects are ordered by most-recent session activity, not API order.
+assert.match(projectsView, /const sortedProjects = useMemo/, "projects are sorted before rendering");
+assert.match(projectsView, /sortedProjects\.map\(\(project, index\)/, "the sorted list drives the render");
+assert.match(projectsView, /function lastActiveMs/, "recency is derived from each project's latest session");
+
+// Paths are home-collapsed + truncated so the identical absolute prefix stops
+// dominating; the full path stays in the title and the editor.
+assert.match(projectsView, /\{shortRoot\(project\.root\)\}/, "the displayed path is shortened");
+assert.match(projectsView, /title=\{project\.root\}/, "the full path remains available via the title");
+assert.match(projectsView, /relativeAge\(/, "each row shows a relative last-active label");
+
 console.log("projects-view.test.ts: ok");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -48,6 +48,42 @@ function chatDotClass(status: string): string {
   return "bg-[var(--text-muted)]";
 }
 
+/** Compact "2m ago" / "3d ago" relative label (older than a week → a short date). */
+function relativeAge(iso: string | null | undefined, now = Date.now()): string {
+  if (!iso) return "";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const mins = Math.round((now - then) / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Intl.DateTimeFormat([], { month: "short", day: "numeric" }).format(then);
+}
+
+/** Most-recent activity across a project's sessions (epoch ms; 0 when empty). */
+function lastActiveMs(chats: SessionRow[]): number {
+  let max = 0;
+  for (const s of chats) {
+    const t = new Date(s.updated_at).getTime();
+    if (Number.isFinite(t) && t > max) max = t;
+  }
+  return max;
+}
+
+/** Collapse $HOME to ~ and left-truncate long paths to "first/…/repo" so the
+ *  identical absolute prefix stops dominating each row. Full path stays in the
+ *  title attribute (and the inline editor still edits the real root). */
+function shortRoot(p: string): string {
+  const home = p.replace(/^\/(?:Users|home)\/[^/]+(?=\/|$)/, "~");
+  const isAbs = home.startsWith("/");
+  const parts = home.split("/").filter(Boolean);
+  if (parts.length <= 2) return home;
+  return `${isAbs ? "/" : ""}${parts[0]}/…/${parts[parts.length - 1]}`;
+}
+
 // A chat under a project card: click opens it (via the agents-open-session
 // event the chat surface already listens for); the handle drags it to reorder
 // within the project or onto another project card to move it. The trash button
@@ -158,6 +194,8 @@ type ProjectRowProps = {
   onNewChat?: (projectRoot: string) => void;
   onOpenSession?: (sessionId: string) => void;
   onDeleteSession: (sessionId: string) => Promise<void>;
+  /** Start expanded — used to open the most-recently-active project by default. */
+  defaultExpanded?: boolean;
 };
 
 function ProjectRow({
@@ -169,8 +207,15 @@ function ProjectRow({
   onNewChat,
   onOpenSession,
   onDeleteSession,
+  defaultExpanded = false,
 }: ProjectRowProps) {
   const chatCount = chats.length;
+  // Projects collapse to a single scannable row by default; expanding reveals
+  // the path + its sessions. The most-recent project starts open.
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const lastActiveIso =
+    chats.reduce((acc, s) => (!acc || s.updated_at > acc ? s.updated_at : acc), "") || project.updatedAt;
+  const lastActiveLabel = relativeAge(lastActiveIso);
   const [showAllChats, setShowAllChats] = useState(false);
   const visibleChats = showAllChats ? chats : chats.slice(0, CHAT_CAP);
   const { setNodeRef: setDropRef, isOver } = useDroppable({
@@ -231,6 +276,15 @@ function ProjectRow({
       ].join(" ")}
     >
       <div className="flex min-w-0 items-center gap-2">
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          aria-expanded={expanded}
+          aria-label={expanded ? `Collapse ${project.name}` : `Expand ${project.name}`}
+          className="focus-ring -ml-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-secondary)]"
+        >
+          <Icon name={expanded ? "ph:caret-down" : "ph:caret-right"} width={12} aria-hidden />
+        </button>
         <Icon
           name="ph:folder-open-bold"
           width={15}
@@ -270,6 +324,12 @@ function ProjectRow({
         <span className="shrink-0 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">
           {chatCount} {chatCount === 1 ? "session" : "sessions"}
         </span>
+
+        {lastActiveLabel ? (
+          <span className="hidden shrink-0 text-[10px] text-[var(--text-muted)] sm:inline" title={`Last active ${lastActiveLabel}`}>
+            {lastActiveLabel}
+          </span>
+        ) : null}
 
         <div className="flex shrink-0 items-center gap-1 opacity-100 transition-opacity motion-reduce:transition-none sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100">
           <button
@@ -342,6 +402,8 @@ function ProjectRow({
         </div>
       </div>
 
+      {expanded ? (
+        <>
       <div className="mt-2 flex min-w-0 items-center gap-2 pl-6">
         <Icon
           name="ph:folder-simple-dashed"
@@ -375,7 +437,7 @@ function ProjectRow({
             className="focus-ring min-w-0 flex-1 truncate rounded-md px-1 py-0.5 text-left font-mono text-[11px] text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
             title={project.root}
           >
-            {project.root}
+            {shortRoot(project.root)}
           </button>
         )}
       </div>
@@ -410,6 +472,8 @@ function ProjectRow({
           No sessions yet — drag one here or start a new session.
         </p>
       )}
+        </>
+      ) : null}
     </article>
   );
 }
@@ -461,6 +525,16 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: Pr
     for (const [root, list] of chatsByRoot) for (const s of list) map.set(s.id, root);
     return map;
   }, [chatsByRoot]);
+
+  // Surface the projects you're actually working in: order by most-recent
+  // session activity, falling back to the project's own updatedAt.
+  const sortedProjects = useMemo(() => {
+    const score = (p: CaveProject) =>
+      lastActiveMs(chatsByRoot.get(normalizeProjectRoot(p.root)) ?? []) ||
+      new Date(p.updatedAt).getTime() ||
+      0;
+    return [...projects].sort((a, b) => score(b) - score(a));
+  }, [projects, chatsByRoot]);
 
   function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event;
@@ -681,7 +755,7 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: Pr
               </div>
             ) : null}
             <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-              {projects.map((project) => (
+              {sortedProjects.map((project, index) => (
                 <ProjectRow
                   key={project.id}
                   project={project}
@@ -692,6 +766,7 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: Pr
                   onNewChat={onNewChat}
                   onOpenSession={openSessionById}
                   onDeleteSession={handleDeleteSession}
+                  defaultExpanded={index === 0}
                 />
               ))}
             </DndContext>


### PR DESCRIPTION
## Problem
The Projects tab rendered every project as a **tall block** — name + full absolute path + up to 8 session previews + "Show all" — so only ~3 of 12 projects fit on screen and the list couldn't be scanned. Most of that height was low-signal: repetitive/truncated session titles and the same long `/Users/buns/Documents/GitHub/OpenCoven/` prefix on every row.

## Change
- **Collapse each project to one row** (disclosure caret · name · session count · relative last-active). Expanding reveals the path + sessions; the existing `CHAT_CAP` / "Show all N sessions" behaviour inside is unchanged. The most-recently-active project starts expanded.
- **Sort projects by most-recent session activity** (falling back to the project's `updatedAt`) instead of API order, so the ones you're working in float to the top.
- **Shorten the displayed path** — home-collapsed + `first/…/repo` — so the identical absolute prefix stops dominating. Full path stays in the `title` and the inline editor still edits the real root.

Reuses the existing flat-row styling, dnd wiring, and row actions — nothing pinned by `projects-view.test.ts` was removed.

## Verification
- `pnpm build` clean (typecheck + lint).
- `projects-view.test.ts` / `chat-surface-projects-tab.test.ts` pass, plus new assertions locking in the collapse/expand, sort-by-recency, and shortened-path behaviour.
- Live-verified in the running app (projects API mocked, since the demo build has no daemon projects): **10 projects render as compact rows**, one expanded by default, order reflects recency, path shows as `~/…/coven-cave`. Screenshot in the session.

Before: each project a tall block, ~3 visible. After: all projects visible as a scannable list, drill in on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)