### PR TITLE
fix(salem): remove archetype subtitle from the Salem side panel

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6599,11 +6599,6 @@ a.mobile-handoff__link:hover {
   color: var(--text-primary);
   letter-spacing: 0.02em;
 }
-.salem-panel__subtitle {
-  font-size: var(--text-2xs);
-  color: var(--text-secondary);
-  margin-top: 1px;
-}
 .salem-panel__header-actions {
   display: flex;
   align-items: center;

--- a/src/components/salem/salem-widget.tsx
+++ b/src/components/salem/salem-widget.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useRef, useEffect, type FormEvent } from "react";
 import { Icon } from "@/lib/icon";
-import type { SalemPreloadContext } from "./salem-context";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { useIsCoarsePointer } from "@/lib/use-viewport";
 import { SalemPathfinderCard } from "./salem-pathfinder-card";
@@ -21,7 +20,6 @@ export function SalemChatPanel({ familiarId, model }: { familiarId?: string | nu
   ]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
-  const [preload, setPreload] = useState<SalemPreloadContext | null>(null);
   const [pathfinderCard, setPathfinderCard] = useState<SalemPathfinderCardData | null>(null);
   const [pathfinding, setPathfinding] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -99,19 +97,6 @@ export function SalemChatPanel({ familiarId, model }: { familiarId?: string | nu
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  useEffect(() => {
-    let alive = true;
-    fetch("/api/salem")
-      .then((res) => res.json())
-      .then((data: { preload?: SalemPreloadContext }) => {
-        if (alive && data.preload) {
-          setPreload(data.preload);
-        }
-      })
-      .catch(() => { if (alive) setPreload(null); });
-    return () => { alive = false; };
-  }, []);
-
   const send = async (e?: FormEvent) => {
     e?.preventDefault();
     const text = input.trim();
@@ -151,9 +136,6 @@ export function SalemChatPanel({ familiarId, model }: { familiarId?: string | nu
         <div className="salem-panel__header-identity">
           <div>
             <div className="salem-panel__name">Salem</div>
-            <div className="salem-panel__subtitle">
-              {preload?.persona.archetype ?? "Male docs familiar"}
-            </div>
           </div>
         </div>
         <div className="salem-panel__header-actions">


### PR DESCRIPTION
Removes the **"Male docs familiar"** archetype subtitle shown under Salem's name in the companion side panel (`salem-widget.tsx` header).

With the subtitle gone, the `preload` state and the `/api/salem` fetch effect that fed it become dead code, so this also drops them plus the now-orphaned `.salem-panel__subtitle` CSS and the unused `SalemPreloadContext` import. Salem's name stays in the header; the chat persona (Salem's in-conversation self-description) is untouched.

Net: 23 deletions, no behavioral change beyond removing the subtitle.

## Verification
- Salem/aria/labels source-text tests pass
- `pnpm build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)