### PR TITLE
fix(projects): default every project row to collapsed

### DIFF
--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -100,16 +100,16 @@ assert.match(
   "Project rows should be flat rows separated by a hairline divider",
 );
 
-// Projects collapse to one scannable row by default and expand to reveal the
-// path + sessions; the most-recently-active project opens first.
-assert.match(projectsView, /const \[expanded, setExpanded\] = useState\(defaultExpanded\)/, "each project row owns a collapse/expand state");
+// Projects collapse to one scannable row and expand to reveal the path +
+// sessions; every project starts collapsed.
+assert.match(projectsView, /const \[expanded, setExpanded\] = useState\(false\)/, "each project row starts collapsed");
 assert.match(projectsView, /aria-expanded=\{expanded\}/, "the disclosure control reports expanded state");
 assert.match(projectsView, /\{expanded \? \(/, "path + sessions render only when the row is expanded");
-assert.match(projectsView, /defaultExpanded=\{index === 0\}/, "the most-recent project starts expanded");
+assert.doesNotMatch(projectsView, /defaultExpanded/, "no project auto-expands — the list stays a flat, scannable set of rows");
 
 // Projects are ordered by most-recent session activity, not API order.
 assert.match(projectsView, /const sortedProjects = useMemo/, "projects are sorted before rendering");
-assert.match(projectsView, /sortedProjects\.map\(\(project, index\)/, "the sorted list drives the render");
+assert.match(projectsView, /sortedProjects\.map\(\(project\)/, "the sorted list drives the render");
 assert.match(projectsView, /function lastActiveMs/, "recency is derived from each project's latest session");
 
 // Paths are home-collapsed + truncated so the identical absolute prefix stops

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -194,8 +194,6 @@ type ProjectRowProps = {
   onNewChat?: (projectRoot: string) => void;
   onOpenSession?: (sessionId: string) => void;
   onDeleteSession: (sessionId: string) => Promise<void>;
-  /** Start expanded — used to open the most-recently-active project by default. */
-  defaultExpanded?: boolean;
 };
 
 function ProjectRow({
@@ -207,12 +205,11 @@ function ProjectRow({
   onNewChat,
   onOpenSession,
   onDeleteSession,
-  defaultExpanded = false,
 }: ProjectRowProps) {
   const chatCount = chats.length;
-  // Projects collapse to a single scannable row by default; expanding reveals
-  // the path + its sessions. The most-recent project starts open.
-  const [expanded, setExpanded] = useState(defaultExpanded);
+  // Every project starts collapsed to a single scannable row; expanding reveals
+  // the path + its sessions.
+  const [expanded, setExpanded] = useState(false);
   const lastActiveIso =
     chats.reduce((acc, s) => (!acc || s.updated_at > acc ? s.updated_at : acc), "") || project.updatedAt;
   const lastActiveLabel = relativeAge(lastActiveIso);
@@ -755,7 +752,7 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: Pr
               </div>
             ) : null}
             <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-              {sortedProjects.map((project, index) => (
+              {sortedProjects.map((project) => (
                 <ProjectRow
                   key={project.id}
                   project={project}
@@ -766,7 +763,6 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: Pr
                   onNewChat={onNewChat}
                   onOpenSession={openSessionById}
                   onDeleteSession={handleDeleteSession}
-                  defaultExpanded={index === 0}
                 />
               ))}
             </DndContext>


### PR DESCRIPTION
Follow-up to #1077. The most-recent project auto-expanded, but which one that was depended on async session-load timing (the recency sort settles as session data arrives), so it was non-deterministic. Default **all** project rows to collapsed instead — a flat, fully scannable list — and let the user expand on demand. Drops the now-unused `defaultExpanded` prop.

Verification: `pnpm build` clean; `projects-view.test.ts` updated (asserts `useState(false)` and that no project auto-expands) and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)