### PR TITLE
fix(titles): reject runtime-scope preamble leak in session titles

### DIFF
--- a/src/lib/cave-chat-titles.ts
+++ b/src/lib/cave-chat-titles.ts
@@ -24,12 +24,17 @@ export function normalizeChatTitle(input: unknown): string | null {
 const MAX_PROMPT_TITLE_LENGTH = 64;
 
 /** Default title for a chat session started from a user prompt: the prompt
- *  itself, whitespace-collapsed and truncated to a title-sized string. */
+ *  itself, whitespace-collapsed and truncated to a title-sized string. The cut
+ *  backs up to the last word boundary (unless that would lose too much) so the
+ *  title doesn't end mid-word — "…the changes we made" not "…the changes we ma". */
 export function chatTitleFromPrompt(prompt: string | null | undefined): string | null {
   const normalized = normalizeChatTitle(prompt);
   if (!normalized) return null;
   if (normalized.length <= MAX_PROMPT_TITLE_LENGTH) return normalized;
-  return `${normalized.slice(0, MAX_PROMPT_TITLE_LENGTH - 1).trimEnd()}…`;
+  const slice = normalized.slice(0, MAX_PROMPT_TITLE_LENGTH - 1);
+  const lastSpace = slice.lastIndexOf(" ");
+  const trimmed = lastSpace >= MAX_PROMPT_TITLE_LENGTH * 0.6 ? slice.slice(0, lastSpace) : slice;
+  return `${trimmed.trimEnd()}…`;
 }
 
 // Matches the current header ("Coven identity canon:") and legacy variants
@@ -41,13 +46,23 @@ const CANON_TITLE_LEAK_RE = new RegExp(
   `^${COVEN_IDENTITY_CANON_HEADER.replace(/:$/, "")}\\s*(\\([^)]*\\))?\\s*:`,
 );
 
-/** Reject harness-derived titles that leaked the identity-canon preamble the
- *  chat route prepends to every harness prompt. Returns the normalized title,
- *  or null when the caller should fall back to a default. */
+// The other preamble the chat route prepends to every harness prompt is the
+// runtime filesystem boundary (see buildRuntimeScopePreamble in
+// chat-runtime-scope.ts, kept server-only — hence the literal here, tied to the
+// source by session-title-canon.test.ts). Daemon-derived titles leak it as
+// "Runtime filesystem boundary: - This is the local…", duplicated across every
+// chat in a project. Reject it so those fall back to a neutral title.
+const RUNTIME_SCOPE_TITLE_LEAK_RE = /^Runtime filesystem boundary\s*:/;
+
+/** Reject harness-derived titles that leaked one of the preambles the chat
+ *  route prepends to every harness prompt (identity canon or runtime scope).
+ *  Returns the normalized title, or null when the caller should fall back to a
+ *  default. */
 export function sanitizeSessionTitle(title: string | null | undefined): string | null {
   const normalized = normalizeChatTitle(title);
   if (!normalized) return null;
   if (CANON_TITLE_LEAK_RE.test(normalized)) return null;
+  if (RUNTIME_SCOPE_TITLE_LEAK_RE.test(normalized)) return null;
   return normalized;
 }
 

--- a/src/lib/session-title-canon.test.ts
+++ b/src/lib/session-title-canon.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./cave-chat-titles.ts";
 import { mergeSessionRows } from "./session-list-merge.ts";
 import { buildPromptWithCovenIdentityCanon } from "./coven-identity-canon.ts";
+import { buildRuntimeScopePreamble } from "./chat-runtime-scope.ts";
 
 // ── chatTitleFromPrompt ──
 assert.equal(
@@ -31,6 +32,18 @@ assert.ok(
   "long prompts truncate to a title-sized string",
 );
 assert.equal(chatTitleFromPrompt("   "), null, "blank prompts yield no title");
+// Long multi-word prompts truncate at a word boundary, never mid-word.
+const longSentence = "please commit and push and open a pull request for the changes we made to the runtime";
+const truncated = chatTitleFromPrompt(longSentence) ?? "";
+const kept = truncated.slice(0, -1); // drop the trailing ellipsis
+assert.ok(truncated.length <= 64, "stays title-sized");
+assert.ok(truncated.endsWith("…"), "marks the truncation");
+assert.ok(longSentence.startsWith(kept), "the kept portion is a clean prefix of the prompt");
+assert.equal(
+  longSentence[kept.length],
+  " ",
+  "the cut lands on a word boundary — the next prompt char is a space, so no word is split",
+);
 
 // ── sanitizeSessionTitle ──
 const canonPrompt = buildPromptWithCovenIdentityCanon("hello", "nova");
@@ -54,6 +67,24 @@ assert.equal(
   sanitizeSessionTitle("Coven identity canon (binding)"),
   "Coven identity canon (binding)",
   "a colon-less canon-themed name is a legitimate human title and passes through",
+);
+// The runtime-scope preamble is the other prompt prefix that leaks into daemon
+// titles ("Runtime filesystem boundary: - This is the local…", duplicated per
+// project). Tie the rejection to the real builder so the literal can't drift.
+assert.equal(
+  sanitizeSessionTitle(buildRuntimeScopePreamble({ kind: "local", root: "/Users/buns/proj" })),
+  null,
+  "titles that leaked the runtime-scope preamble are rejected",
+);
+assert.equal(
+  sanitizeSessionTitle(buildRuntimeScopePreamble({ kind: "ssh", host: "beacon", root: "/srv/app" })),
+  null,
+  "the remote runtime-scope preamble is rejected too",
+);
+assert.equal(
+  sanitizeSessionTitle("Runtime filesystem boundaries between teams"),
+  "Runtime filesystem boundaries between teams",
+  "a human title that merely starts with similar words (no colon) passes through",
 );
 
 // ── merge layer falls back when the daemon title is canon-leaked ──
@@ -112,6 +143,31 @@ const rows2 = mergeSessionRows({
   includeArchived: false,
 });
 assert.equal(rows2[0].title, "My chat", "explicit title overrides still win");
+
+// runtime-scope leak falls back at the merge layer too
+const rows3 = mergeSessionRows({
+  daemonSessions: [
+    {
+      id: "def67890-dead-beef-0000-000000000000",
+      project_root: "/Users/buns/proj",
+      harness: "claude",
+      title: "Runtime filesystem boundary: - This is the local runtime boundary for this Cave",
+      status: "completed",
+      exit_code: 0,
+      archived_at: null,
+      created_at: "2026-06-11T00:00:00Z",
+      updated_at: "2026-06-11T00:00:00Z",
+    },
+  ],
+  localConversations: [],
+  state,
+  includeArchived: false,
+});
+assert.equal(
+  rows3[0].title,
+  defaultChatTitleForSession("def67890-dead-beef-0000-000000000000"),
+  "runtime-scope-leaked daemon titles fall back to the default session title",
+);
 
 // ── chat/send route titles sessions from the user prompt, early ──
 const route = await readFile(


### PR DESCRIPTION
First of the UX-improvement backlog: session titles. The noisiest case in the list (e.g. the Projects tab) is **"Runtime filesystem boundary: - This is the local"** repeated across every chat in a project.

## Root cause
The chat route prepends a runtime-scope preamble (`buildRuntimeScopePreamble`) to every harness prompt. The daemon derives a session's title from that harness prompt, so untitled sessions leak the preamble as their title. `sanitizeSessionTitle` already rejects the **identity-canon** header but not the **runtime-scope** one — so it slips through, normalized + duplicated.

## Fix
1. **Reject the runtime-scope preamble** in `sanitizeSessionTitle` (alongside the canon header) → those titles fall back to the neutral `New Session <id>`. The literal `"Runtime filesystem boundary:"` is tied to the real (server-only) builder via the test, so it can't drift. A human title that merely starts with similar words (no colon) still passes.
2. **Word-boundary truncation** in `chatTitleFromPrompt` — it hard-sliced at 64 chars, cutting mid-word ("…the changes we ma"). Now it backs up to the last word boundary (unless that loses too much, e.g. one very long word).

## Scope note
This is the Cave-side display fix. Generating *better* titles for daemon-created sessions (deriving from the first real user message instead of `New Session <hash>`) is a deeper follow-up in the daemon/coven layer — out of scope here.

## Verification
- `pnpm build` clean.
- `session-title-canon.test.ts` extended (runtime-scope rejection tied to the builder, local + ssh, merge-layer fallback, word-boundary truncation) + `cave-chat-titles` / `session-rail-title` / `harness-routing` title tests pass. Not live-reproducible in demo mode (needs real daemon sessions carrying the leak), so covered by the unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)