### PR TITLE
feat(sessions): sort the All view by recency (most-recent-first)

### DIFF
--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -119,7 +119,7 @@ assert.match(source, /<SortableContext items=\{displayIds\} strategy=\{verticalL
 assert.match(source, /useSortable\(\{ id \}\)/, "ChatList rows should be individually sortable by session id");
 assert.match(source, /setSessionOrder\(readSessionOrder\(\)\)/, "ChatList should hydrate the persisted manual order after mount");
 assert.match(source, /if \(effectiveSelection === "all"\) \{[\s\S]*scopedGroups\.flatMap\(\(group\) => group\.sessions\)/, "All chats should flatten groups so cross-project drag order can stick");
-assert.match(source, /partitionPinnedFirst\(rows, pinnedIds\)/, "Pinned rows should still float in the flat All chats view until manual drag order exists");
+assert.match(source, /partitionPinnedFirst\(sortByRecency\(rows\), pinnedIds\)/, "Pinned rows still float, over a recency-sorted rest, in the flat All chats view until manual drag order exists");
 assert.match(source, /applyManualOrder\(group\.sessions, sessionOrder\)/, "ChatList should apply the manual order inside visible project groups");
 assert.match(source, /mergeVisibleOrder\(prev\.length > 0 \? prev : fallbackOrderIds, nextVisible\)/, "ChatList should merge dragged visible rows back into the full saved order");
 assert.match(source, /const pruned = merged\.filter\(\(id\) => liveSessionIds\.has\(id\)\)/, "ChatList should prune stale session ids before persisting drag order");
@@ -301,6 +301,16 @@ assert.doesNotMatch(
   source,
   /touch-always-visible shrink-0 rounded border border-\[var\(--border-hairline\)\] px-1\.5 py-0\.5/,
   "Old non-uniform px-1.5 py-0.5 action-button chrome must be gone",
+);
+
+// The flat "All" view sorts by recency (most-recent-first), restoring the
+// global order the per-project flatMap drops — while still honoring an explicit
+// manual drag order and floating pinned sessions first.
+assert.match(source, /function sortByRecency\(rows: SessionRow\[\]\)/, "a recency sorter exists");
+assert.match(
+  source,
+  /sessionOrder\.length === 0\s*\?\s*partitionPinnedFirst\(sortByRecency\(rows\), pinnedIds\)\s*:\s*applyManualOrder\(rows, sessionOrder\)/,
+  "the All view sorts by recency by default, defers to manual order when the user has dragged, and keeps pinned-first",
 );
 
 console.log("chat-list-delete.test.ts: ok");

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -109,6 +109,18 @@ function repoName(p: string): string {
   return parts[parts.length - 1] ?? p;
 }
 
+/** Most-recent-first by last activity. The merge layer already sorts globally,
+ *  but the flat "All" view flattens per-project groups (concatenating them),
+ *  which loses that order — a recent chat in one project would sink below older
+ *  chats in another. Re-sorting the flattened rows restores global recency. */
+function sortByRecency(rows: SessionRow[]): SessionRow[] {
+  return [...rows].sort((a, b) => {
+    const at = Date.parse(a.updated_at || a.created_at) || 0;
+    const bt = Date.parse(b.updated_at || b.created_at) || 0;
+    return bt - at;
+  });
+}
+
 const STATUS_STYLES: Record<string, { dot: string; label: string; preview: string }> = {
   running: { dot: "bg-[var(--color-success)] animate-pulse", label: "running", preview: "text-[var(--color-success)]" },
   completed: { dot: "bg-[var(--text-muted)]", label: "done", preview: "text-[var(--text-muted)]" },
@@ -406,7 +418,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     if (effectiveSelection === "all") {
       let rows = scopedGroups.flatMap((group) => group.sessions);
       rows = sessionOrder.length === 0
-        ? partitionPinnedFirst(rows, pinnedIds)
+        ? partitionPinnedFirst(sortByRecency(rows), pinnedIds)
         : applyManualOrder(rows, sessionOrder);
       const latest = rows[0] ?? null;
       return [{


### PR DESCRIPTION
Next UX-backlog item: the Sessions tab. Per the investigation, the tab is **already feature-rich** (search, content-search, pin, drag-reorder, archive, status chips, relative timestamps) — it does **not** need the Projects-style collapse. The one genuine gap is ordering.

## Problem
`mergeSessionRows` sorts the session list globally by `updated_at` desc, but the flat **"All"** view rebuilds rows via `scopedGroups.flatMap((g) => g.sessions)` — concatenating per-project groups — which **drops the global order**. So a chat you touched 2 minutes ago in project B can sit below week-old chats in project A. You have to scroll to find recent work.

## Fix
Re-sort the flattened "All" rows by recency (`sortByRecency`) before `partitionPinnedFirst`, restoring most-recent-first. Behavior preserved:
- **Manual drag order still wins** when `sessionOrder` is set (the user explicitly arranged).
- **Pinned sessions still float first** (`partitionPinnedFirst` is stable, so the rest stays recency-sorted under them).
- Grouped (per-familiar) views are unaffected — they were already recency-ordered within each group.

One focused change; no restructure, no collapse.

## Verification
- `pnpm build` clean.
- `chat-list-delete.test.ts` updated (the pinned-first assertion now expects `partitionPinnedFirst(sortByRecency(rows), pinnedIds)`) + a new assertion that the All view sorts by recency by default but defers to manual order; all chat-list suites pass.
- Not cleanly reproducible in demo mode (needs multiple projects with interleaved session times), so covered by the source-text test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)