### PR TITLE
refactor(time): extract one shared relativeTime helper

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -292,6 +292,7 @@ export const SUITES = {
     "src/lib/reading-hyphens.test.ts",
     "src/lib/reading-dropcap.test.ts",
     "src/lib/datetime-format.test.ts",
+    "src/lib/relative-time.test.ts",
     "src/lib/appearance-corner-radius.test.ts",
     "src/lib/code-layout-preset.test.ts",
     "src/lib/use-changes-summary.test.ts",

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -116,6 +116,6 @@ assert.match(projectsView, /function lastActiveMs/, "recency is derived from eac
 // dominating; the full path stays in the title and the editor.
 assert.match(projectsView, /\{shortRoot\(project\.root\)\}/, "the displayed path is shortened");
 assert.match(projectsView, /title=\{project\.root\}/, "the full path remains available via the title");
-assert.match(projectsView, /relativeAge\(/, "each row shows a relative last-active label");
+assert.match(projectsView, /relativeTime\(/, "each row shows a relative last-active label (shared relative-time helper)");
 
 console.log("projects-view.test.ts: ok");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState, type CSSProperties, type FormEvent } from "react";
 
 import { Icon } from "@/lib/icon";
+import { relativeTime } from "@/lib/relative-time";
 import type { CaveProject } from "@/lib/cave-projects-types";
 import { normalizeProjectRoot } from "@/lib/cave-projects-types";
 import type { SessionRow } from "@/lib/types";
@@ -48,20 +49,6 @@ function chatDotClass(status: string): string {
   return "bg-[var(--text-muted)]";
 }
 
-/** Compact "2m ago" / "3d ago" relative label (older than a week → a short date). */
-function relativeAge(iso: string | null | undefined, now = Date.now()): string {
-  if (!iso) return "";
-  const then = new Date(iso).getTime();
-  if (Number.isNaN(then)) return "";
-  const mins = Math.round((now - then) / 60000);
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.round(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.round(hours / 24);
-  if (days < 7) return `${days}d ago`;
-  return new Intl.DateTimeFormat([], { month: "short", day: "numeric" }).format(then);
-}
 
 /** Most-recent activity across a project's sessions (epoch ms; 0 when empty). */
 function lastActiveMs(chats: SessionRow[]): number {
@@ -212,7 +199,7 @@ function ProjectRow({
   const [expanded, setExpanded] = useState(false);
   const lastActiveIso =
     chats.reduce((acc, s) => (!acc || s.updated_at > acc ? s.updated_at : acc), "") || project.updatedAt;
-  const lastActiveLabel = relativeAge(lastActiveIso);
+  const lastActiveLabel = relativeTime(lastActiveIso);
   const [showAllChats, setShowAllChats] = useState(false);
   const visibleChats = showAllChats ? chats : chats.slice(0, CHAT_CAP);
   const { setNodeRef: setDropRef, isOver } = useDroppable({

--- a/src/lib/daily-report.ts
+++ b/src/lib/daily-report.ts
@@ -74,21 +74,10 @@ export function relativeDayLabel(date: Date, now = new Date()): string {
   return new Intl.DateTimeFormat([], { month: "short", day: "numeric" }).format(date);
 }
 
-/** Compact "3h ago" / "2d ago" / clock time relative phrase. */
-export function relativeTime(iso: string | null | undefined, now = new Date()): string {
-  if (!iso) return "";
-  const then = new Date(iso);
-  if (Number.isNaN(then.getTime())) return "";
-  const diffMs = now.getTime() - then.getTime();
-  const mins = Math.round(diffMs / 60000);
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.round(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.round(hours / 24);
-  if (days < 7) return `${days}d ago`;
-  return new Intl.DateTimeFormat([], { month: "short", day: "numeric" }).format(then);
-}
+// The compact "3h ago" / "2d ago" / short-date phrase now lives in the shared
+// relative-time module; re-export it so existing dashboard/daily-report
+// importers (and the daily-report test) keep working unchanged.
+export { relativeTime } from "./relative-time.ts";
 
 export const KIND_LABEL: Record<ItemKind, string> = {
   reminder: "Reminder",

--- a/src/lib/relative-time.test.ts
+++ b/src/lib/relative-time.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { relativeTime } from "./relative-time.ts";
+import { relativeTime as reExported } from "./daily-report.ts";
+
+const NOW = new Date("2026-06-18T12:00:00.000Z");
+const NOW_MS = NOW.getTime();
+const ago = (mins: number) => new Date(NOW_MS - mins * 60_000).toISOString();
+
+test("buckets: just now / minutes / hours / days, then short date", () => {
+  assert.equal(relativeTime(ago(0), NOW), "just now");
+  assert.equal(relativeTime(ago(2), NOW), "2m ago");
+  assert.equal(relativeTime(ago(180), NOW), "3h ago");
+  assert.equal(relativeTime(ago(60 * 24), NOW), "1d ago");
+  assert.equal(relativeTime(ago(60 * 24 * 3), NOW), "3d ago");
+  // 8 days ago → past the week, falls through to a short month/day date.
+  const out = relativeTime(ago(60 * 24 * 8), NOW);
+  assert.match(out, /^[A-Za-z]{3} \d{1,2}$/, `expected a "Mon D" date, got "${out}"`);
+  assert.doesNotMatch(out, /ago/);
+});
+
+test("now accepts a number (epoch ms) or a Date, identically", () => {
+  assert.equal(relativeTime(ago(2), NOW_MS), relativeTime(ago(2), NOW));
+});
+
+test("empty/invalid input renders nothing", () => {
+  assert.equal(relativeTime(null), "");
+  assert.equal(relativeTime(undefined), "");
+  assert.equal(relativeTime(""), "");
+  assert.equal(relativeTime("not-a-date"), "");
+});
+
+test("daily-report re-exports the same function (no behavior drift)", () => {
+  assert.equal(reExported, relativeTime);
+  assert.equal(reExported(ago(2), NOW), "2m ago");
+});

--- a/src/lib/relative-time.ts
+++ b/src/lib/relative-time.ts
@@ -1,0 +1,26 @@
+// Canonical relative-time formatter shared across surfaces (dashboard, daily
+// report, journal, projects, …): compact "just now" / "2m ago" / "3h ago" /
+// "1d ago" for the last week, then a short month/day date ("Jun 12"). Returns
+// "" for null/undefined/invalid input.
+//
+// Pure and client-safe (no `node:` imports) so server pages, client components,
+// and the browser-bundled tests can all import it. `now` accepts a number
+// (epoch ms) or a Date, so callers can pass either without converting.
+
+export function relativeTime(
+  iso: string | null | undefined,
+  now: number | Date = Date.now(),
+): string {
+  if (!iso) return "";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const nowMs = typeof now === "number" ? now : now.getTime();
+  const mins = Math.round((nowMs - then) / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Intl.DateTimeFormat([], { month: "short", day: "numeric" }).format(then);
+}


### PR DESCRIPTION
Backlog tech-debt cleanup: the relative-time formatters were duplicated. This unifies the **output-identical** pair without changing any rendered string.

## What
- New `src/lib/relative-time.ts` — the canonical compact formatter ("just now" / "2m ago" / "3h ago" / "1d ago" → short date past a week). Client-safe (no `node:` imports); `now` accepts a number or a Date so callers can pass either.
- `daily-report.ts` re-exports it → its 8 importers and the daily-report test are unchanged.
- `projects-view.tsx` imports it and drops its verbatim local copy (`relativeAge`).

## Why only these two
A full audit found ~10 relative-time helpers, but only `daily-report:relativeTime` and `projects-view:relativeAge` are **output-identical**. The rest diverge by design:
- `chat-list:age` → verbose "Yesterday" / "2 weeks ago"
- `recent-activity:relativeTime` → no "ago" suffix, "now"
- `eval-loop` / `retro-runs` / `workflow-runs` → seconds-precision, "never"/"unknown" fallbacks
- `familiars-*:age` → compact, no short-date

Folding those in would **change displayed strings** across many surfaces — that's a UX decision ("standardize on one format app-wide?"), not a silent refactor, so it's left as a follow-up. This PR is the zero-risk, zero-output-change part.

## Verification
- `pnpm build` clean; `check:tests-wired` green (new suite wired).
- New `relative-time.test.ts` (buckets, number-vs-Date `now`, invalid input, and that daily-report's re-export is the same fn) + existing `daily-report` / `projects-view` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)