### PR TITLE
feat(journal): syntax-highlight the Canvas Code tab

### DIFF
--- a/src/components/journal/canvas-list.tsx
+++ b/src/components/journal/canvas-list.tsx
@@ -10,14 +10,46 @@ import {
   buildSketchPrompt,
   clampArtifactCode,
   titleFromPrompt,
+  type ArtifactKind,
   type CanvasArtifact,
 } from "@/lib/canvas-artifacts";
 import { buildReactSrcDoc } from "@/lib/canvas-react-harness";
 import { generateArtifactCode } from "@/lib/canvas-generate";
+import { highlightToHtml } from "@/components/message-bubble";
 import type { Familiar } from "@/lib/types";
 
 function srcDocFor(art: CanvasArtifact): string {
   return art.kind === "react" ? buildReactSrcDoc(art.code) : buildPreviewSrcDoc(art.code);
+}
+
+/**
+ * The Code tab's read-only view: Shiki-highlighted to match the app's other code
+ * surfaces (chat code blocks, the in-chat artifact viewer). Falls back to plain
+ * text until the lazy highlighter resolves and on any failure, so the code is
+ * always shown. React artifacts highlight as TSX; everything else as HTML.
+ */
+function SketchCode({ code, kind }: { code: string; kind: ArtifactKind }) {
+  const [html, setHtml] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setHtml(null);
+    void highlightToHtml(code, kind === "react" ? "tsx" : "html")
+      .then((h) => { if (!cancelled) setHtml(h); })
+      .catch(() => { if (!cancelled) setHtml(null); });
+    return () => { cancelled = true; };
+  }, [code, kind]);
+
+  if (!html) {
+    return <pre className="journal-detail__code"><code>{code}</code></pre>;
+  }
+  return (
+    <div
+      className="journal-detail__code journal-detail__code--hl"
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
 }
 
 export function CanvasList({
@@ -244,7 +276,7 @@ export function CanvasList({
                 srcDoc={srcDocFor(selected)}
               />
             ) : (
-              <textarea className="journal-detail__code" readOnly value={selected.code} aria-label="Sketch code" />
+              <SketchCode code={selected.code} kind={selected.kind ?? "html"} />
             )}
             <div className="journal-detail__prompt">Prompt: “{selected.prompt}”</div>
           </>

--- a/src/styles/journal.css
+++ b/src/styles/journal.css
@@ -165,15 +165,32 @@
   flex: 1;
   min-height: 0;
   width: 100%;
-  resize: none;
-  font-family: var(--font-mono, monospace);
+  margin: 0;
+  box-sizing: border-box;
+  overflow: auto;
+  white-space: pre;
+  font-family: var(--font-mono, ui-monospace, "SF Mono", Menlo, Consolas, monospace);
   font-size: 12px;
+  line-height: 1.6;
   padding: 12px;
   border-radius: 10px;
   border: 1px solid var(--border-hairline);
   background: var(--bg-panel, var(--bg-base));
   color: var(--text-primary);
 }
+/* Highlighted (read-only): the wrapper scrolls; Shiki's own <pre> drops its
+   padding/background so the box keeps the surface + spacing above. */
+.journal-detail__code--hl { padding: 0; }
+.journal-detail__code--hl pre.shiki {
+  margin: 0;
+  padding: 12px;
+  min-height: 100%;
+  box-sizing: border-box;
+  background: transparent !important;
+  font: inherit;
+  white-space: pre;
+}
+.journal-detail__code--hl code { font: inherit; }
 .journal-detail__prompt { font-size: 11px; color: var(--text-muted); }
 .journal-empty {
   font-size: 12.5px;


### PR DESCRIPTION
The Canvas sketch viewer's **Code** tab was a plain read-only `<textarea>`. This swaps it for a Shiki-highlighted read-only view via the existing `highlightToHtml` — the same highlighter the chat code blocks and the in-chat artifact viewer's Code tab use — so it matches the rest of the app.

- React artifacts highlight as `tsx`, everything else as `html`.
- Plain-text `<pre>` fallback until the lazy highlighter resolves and on any failure (code is always shown).
- New `.journal-detail__code--hl` CSS lets Shiki's `<pre>` keep the box's surface + padding (mirrors `chat-artifact__code--hl`).

Full `test:app` (322 files) + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)