### PR TITLE
fix(sidebar): align Settings row with Dashboard/Notifications in the footer

### DIFF
--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -331,15 +331,6 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
         <div className="sidebar-foot-utility-row">
           <button
             type="button"
-            className="sidebar-foot-icon-btn"
-            onClick={onOpenMobileHandoff}
-            aria-label="Open on phone"
-            title="Open on phone"
-          >
-            <Icon name="ph:device-mobile" width={14} className="sidebar-foot-icon" />
-          </button>
-          <button
-            type="button"
             className="sidebar-foot-btn"
             onClick={onOpenSettings}
             aria-label="Settings"
@@ -349,6 +340,15 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
               <Icon name="ph:gear-six" width={14} className="sidebar-foot-icon" />
             </span>
             <span className="sidebar-foot-label">Settings</span>
+          </button>
+          <button
+            type="button"
+            className="sidebar-foot-icon-btn"
+            onClick={onOpenMobileHandoff}
+            aria-label="Open on phone"
+            title="Open on phone"
+          >
+            <Icon name="ph:device-mobile" width={14} className="sidebar-foot-icon" />
           </button>
         </div>
       </div>

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -297,7 +297,10 @@
 
 .sidebar-foot-utility-row {
   display: grid;
-  grid-template-columns: 34px minmax(0, 1fr);
+  /* Settings leads in the 1fr column so its icon + label line up exactly with
+     Dashboard/Notifications above; the phone handoff trails as a 34px icon cell
+     on the right rather than indenting Settings. */
+  grid-template-columns: minmax(0, 1fr) 34px;
   gap: 4px;
 }
 


### PR DESCRIPTION
The sidebar footer's Settings row didn't line up with Dashboard / Notifications above it — its gear icon and label were shoved ~38px to the right.

## Cause
`.sidebar-foot-utility-row` was a `grid-template-columns: 34px minmax(0, 1fr)` grid with the **"Open on phone" handoff in the leading 34px column**, so the Settings button started after it and indented its whole content.

## Fix
- Flip the grid to `minmax(0, 1fr) 34px` and **lead with the Settings button**, so its icon + label occupy the same left columns as the rows above. The phone handoff trails as a right-aligned 34px icon cell.
- No behavior change — the handoff button (and its `aria-label="Open on phone"` / `ph:device-mobile` icon that `mobile-handoff.test.ts` checks) is unchanged, just reordered.

## Verification
- `pnpm build` clean; `mobile-handoff.test.ts` passes.
- Live-measured in the running app: Dashboard / Notifications / Settings icon-cells all at x=30, labels all at x=68; the phone button sits to the right of the Settings label. Screenshot reviewed — clean column alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)