### PR TITLE
feat(canvas): dedicated refine space with default + generated suggestions

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -120,6 +120,7 @@ export const SUITES = {
     "src/lib/calendar-layout.test.ts",
     "src/lib/canvas-layout.test.ts",
     "src/lib/canvas-artifacts.test.ts",
+    "src/lib/refine-suggestions.test.ts",
     "src/lib/canvas-templates.test.ts",
     "src/lib/canvas-react-harness.test.ts",
     "src/lib/canvas-generate.test.ts",

--- a/src/components/chat-artifact-viewer.tsx
+++ b/src/components/chat-artifact-viewer.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/canvas-artifacts";
 import { buildReactSrcDoc } from "@/lib/canvas-react-harness";
 import { generateArtifactCode } from "@/lib/canvas-generate";
+import { DEFAULT_REFINE_SUGGESTIONS, generateRefineSuggestions } from "@/lib/refine-suggestions";
 import { highlightToHtml } from "@/components/message-bubble";
 
 type Props = {
@@ -35,8 +36,18 @@ export function ChatArtifactViewer({ initialCode, kind: initialKind, title, fami
   const [generating, setGenerating] = useState(false);
   const [runtimeError, setRuntimeError] = useState<string | null>(null);
   const [refineText, setRefineText] = useState("");
+  const [refineOpen, setRefineOpen] = useState(false);
   const [saveState, setSaveState] = useState<SaveState>("idle");
   const frameRef = useRef<HTMLIFrameElement | null>(null);
+  const refineRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Context-aware ideas derived from the artifact itself; recomputed only when
+  // the code/kind changes (cheap string scans). Paired with the static defaults
+  // so the refine space always offers a starting point.
+  const generatedSuggestions = useMemo(
+    () => generateRefineSuggestions(code, kind),
+    [code, kind],
+  );
 
   const srcDoc = useMemo(
     () => (kind === "react" ? buildReactSrcDoc(code) : buildPreviewSrcDoc(code)),
@@ -84,6 +95,7 @@ export function ChatArtifactViewer({ initialCode, kind: initialKind, title, fami
       setCode(clampArtifactCode(result.code));
       if (result.kind) setKind(result.kind);
       setRefineText("");
+      setRefineOpen(false);
       setEditing(false);
       setTab("canvas");
       setSaveState("idle");
@@ -91,6 +103,25 @@ export function ChatArtifactViewer({ initialCode, kind: initialKind, title, fami
       setRuntimeError(result.error || "Refine failed — try a different description.");
     }
   }, [refineText, familiarId, generating, code, kind]);
+
+  const openRefine = useCallback(() => {
+    if (!familiarId) return;
+    setRefineOpen(true);
+    // Focus after the panel mounts so the cursor lands in the textarea.
+    requestAnimationFrame(() => refineRef.current?.focus());
+  }, [familiarId]);
+
+  // Tapping a suggestion seeds the textarea (replacing any draft) and refocuses,
+  // so the user can run it as-is or tweak it first.
+  const applySuggestion = useCallback((text: string) => {
+    setRefineText(text);
+    requestAnimationFrame(() => {
+      const el = refineRef.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(el.value.length, el.value.length);
+    });
+  }, []);
 
   const saveToCanvas = useCallback(async () => {
     if (saveState === "saving") return;
@@ -215,21 +246,99 @@ export function ChatArtifactViewer({ initialCode, kind: initialKind, title, fami
         )}
       </div>
 
-      <div className="chat-artifact__refine">
-        <Icon name="ph:sparkle" width={14} className="chat-artifact__refine-icon" />
-        <input
-          className="chat-artifact__refine-input"
-          aria-label="Refine artifact"
-          placeholder={familiarId ? "Refine — describe a change…" : "Pick a familiar to refine"}
-          value={refineText}
-          disabled={!familiarId || generating}
-          onChange={(e) => setRefineText(e.target.value)}
-          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); void runRefine(); } }}
-        />
-        <button type="button" className="chat-artifact__refine-go" disabled={!familiarId || generating || !refineText.trim()} onClick={() => void runRefine()}>
-          {generating ? "Refining…" : "Refine"}
+      {refineOpen ? (
+        <div className="chat-artifact__refine-panel" role="group" aria-label="Refine artifact">
+          <div className="chat-artifact__refine-head">
+            <Icon name="ph:sparkle" width={14} className="chat-artifact__refine-icon" />
+            <span className="chat-artifact__refine-title">Refine</span>
+            <span className="chat-artifact__spacer" />
+            <button
+              type="button"
+              className="chat-artifact__btn"
+              title="Close refine"
+              aria-label="Close refine"
+              onClick={() => setRefineOpen(false)}
+            >
+              <Icon name="ph:x" width={13} />
+            </button>
+          </div>
+          <textarea
+            ref={refineRef}
+            className="chat-artifact__refine-text"
+            aria-label="Describe the optimization you want"
+            placeholder="Describe the optimization you want…"
+            rows={2}
+            value={refineText}
+            disabled={generating}
+            onChange={(e) => setRefineText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) { e.preventDefault(); void runRefine(); }
+              if (e.key === "Escape") { e.preventDefault(); setRefineOpen(false); }
+            }}
+          />
+          <div className="chat-artifact__suggests">
+            <p className="chat-artifact__suggests-label">Suggestions</p>
+            <div className="chat-artifact__chips">
+              {DEFAULT_REFINE_SUGGESTIONS.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  className="chat-artifact__chip"
+                  disabled={generating}
+                  onClick={() => applySuggestion(s)}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+            {generatedSuggestions.length ? (
+              <>
+                <p className="chat-artifact__suggests-label">
+                  <Icon name="ph:sparkle" width={11} /> From this artifact
+                </p>
+                <div className="chat-artifact__chips">
+                  {generatedSuggestions.map((s) => (
+                    <button
+                      key={s}
+                      type="button"
+                      className="chat-artifact__chip chat-artifact__chip--gen"
+                      disabled={generating}
+                      onClick={() => applySuggestion(s)}
+                    >
+                      {s}
+                    </button>
+                  ))}
+                </div>
+              </>
+            ) : null}
+          </div>
+          <div className="chat-artifact__refine-foot">
+            <span className="chat-artifact__refine-hint">⌘↵ to refine</span>
+            <span className="chat-artifact__spacer" />
+            <button type="button" className="chat-artifact__btn chat-artifact__btn--text" onClick={() => setRefineOpen(false)}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="chat-artifact__refine-go"
+              disabled={generating || !refineText.trim()}
+              onClick={() => void runRefine()}
+            >
+              {generating ? "Refining…" : "Refine"}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          className="chat-artifact__refine-trigger"
+          disabled={!familiarId}
+          onClick={openRefine}
+        >
+          <Icon name="ph:sparkle" width={14} className="chat-artifact__refine-icon" />
+          {familiarId ? "Refine the artifact…" : "Pick a familiar to refine"}
         </button>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/lib/refine-suggestions.test.ts
+++ b/src/lib/refine-suggestions.test.ts
@@ -1,0 +1,43 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_REFINE_SUGGESTIONS,
+  generateRefineSuggestions,
+} from "./refine-suggestions.ts";
+
+test("defaults are a small, stable trio", () => {
+  assert.equal(DEFAULT_REFINE_SUGGESTIONS.length, 3);
+  assert.ok(DEFAULT_REFINE_SUGGESTIONS.every((s) => typeof s === "string" && s.length > 0));
+});
+
+test("always returns at least one suggestion, capped at the limit", () => {
+  assert.ok(generateRefineSuggestions("", "html").length >= 1);
+  assert.ok(generateRefineSuggestions("", "html").length <= 3);
+  assert.equal(generateRefineSuggestions("<button>hi</button>", "html", 2).length, 2);
+});
+
+test("generated suggestions never duplicate the defaults", () => {
+  const gen = generateRefineSuggestions("<h1>Title</h1>", "html");
+  const defaults = new Set(DEFAULT_REFINE_SUGGESTIONS.map((s) => s.toLowerCase()));
+  assert.ok(gen.every((s) => !defaults.has(s.toLowerCase())));
+});
+
+test("buttons without hover states surface an interaction-states idea", () => {
+  const gen = generateRefineSuggestions("<button>Click</button>", "html");
+  assert.ok(gen.some((s) => /hover.*active.*focus/i.test(s)));
+});
+
+test("a form surfaces a validation idea", () => {
+  const gen = generateRefineSuggestions("<form><input /></form>", "html");
+  assert.ok(gen.some((s) => /validation/i.test(s)));
+});
+
+test("a plain html document with no media query suggests responsiveness", () => {
+  const gen = generateRefineSuggestions("<div style='width:600px'>x</div>", "html");
+  assert.ok(gen.some((s) => /responsive/i.test(s)));
+});
+
+test("react artifacts don't get the html-only responsive rule but can get loading states", () => {
+  const gen = generateRefineSuggestions("export default function App(){ const [n,setN]=useState(0); return <div/> }", "react");
+  assert.ok(gen.some((s) => /loading and empty/i.test(s)));
+});

--- a/src/lib/refine-suggestions.ts
+++ b/src/lib/refine-suggestions.ts
@@ -1,0 +1,99 @@
+import type { ArtifactKind } from "@/lib/canvas-artifacts";
+
+/**
+ * Refine suggestions power the artifact "Refine" space: a couple of one-tap
+ * starting points so the user never faces a blank box. There are two rows —
+ *
+ *   • DEFAULT_REFINE_SUGGESTIONS — always-useful optimizations that apply to
+ *     any artifact (visual polish, accessibility, motion).
+ *   • generateRefineSuggestions(code, kind) — context-aware ideas derived from
+ *     what's actually in the artifact (buttons without hover states, a form
+ *     with no validation, a fixed-width layout, etc.).
+ *
+ * Both return plain instruction strings; tapping one drops it into the refine
+ * textarea so the user can run it as-is or edit first. Heuristics are cheap
+ * string scans — no parsing, no familiar round-trip — so they're instant.
+ */
+
+export const DEFAULT_REFINE_SUGGESTIONS: readonly string[] = [
+  "Polish the visual hierarchy, spacing, and alignment",
+  "Improve accessibility — color contrast, labels, and focus states",
+  "Add subtle motion and micro-interactions",
+];
+
+type Rule = {
+  /** True when this idea is relevant to the artifact. */
+  when: (code: string, kind: ArtifactKind) => boolean;
+  /** The suggestion text shown on the chip and sent as the refine ask. */
+  text: string;
+};
+
+// Ordered by usefulness; generateRefineSuggestions takes the first few matches.
+const RULES: Rule[] = [
+  {
+    when: (c) => /<button|role=["']button["']|<a\s/i.test(c) && !/:hover|:active|transition/i.test(c),
+    text: "Add hover, active, and focus states to the interactive elements",
+  },
+  {
+    when: (c) => /<form|<input|<textarea|<select/i.test(c),
+    text: "Add inline validation with clear empty, loading, and error states",
+  },
+  {
+    when: (c, kind) => kind !== "react" && !/@media|clamp\(|minmax\(|flex-wrap|grid-template-columns:\s*repeat\([^)]*auto/i.test(c),
+    text: "Make the layout responsive and fluid on small screens",
+  },
+  {
+    when: (c, kind) => kind === "react" && /useState|useReducer/.test(c) && !/loading|isLoading|empty|skeleton/i.test(c),
+    text: "Add loading and empty states for the dynamic content",
+  },
+  {
+    when: (c) => /#0|#1|background:\s*#0|background:\s*#1|rgb\(\s*1?\d?\d?,?\s*1?\d/i.test(c) && !/prefers-color-scheme|data-theme|light/i.test(c),
+    text: "Add a light-mode variant with a theme toggle",
+  },
+  {
+    when: (c) => !/@keyframes|transition|animation:/i.test(c),
+    text: "Animate the entrance with a gentle fade and rise",
+  },
+  {
+    when: (c) => /<svg|<img|background-image/i.test(c),
+    text: "Refine the imagery and iconography for a more cohesive look",
+  },
+];
+
+const FALLBACKS: string[] = [
+  "Tighten the color palette and add depth with shadows",
+  "Add a clear header with a title and supporting subtitle",
+  "Increase the contrast and make the primary action stand out",
+];
+
+/**
+ * Up to `limit` context-aware suggestions for this artifact, de-duplicated
+ * against the defaults so the two rows never repeat an idea. Always returns at
+ * least one item by topping up from neutral fallbacks.
+ */
+export function generateRefineSuggestions(
+  code: string,
+  kind: ArtifactKind = "html",
+  limit = 3,
+): string[] {
+  const src = code ?? "";
+  const taken = new Set(DEFAULT_REFINE_SUGGESTIONS.map((s) => s.toLowerCase()));
+  const out: string[] = [];
+
+  const add = (text: string) => {
+    const key = text.toLowerCase();
+    if (taken.has(key) || out.length >= limit) return;
+    taken.add(key);
+    out.push(text);
+  };
+
+  for (const rule of RULES) {
+    if (out.length >= limit) break;
+    if (rule.when(src, kind)) add(rule.text);
+  }
+  for (const fb of FALLBACKS) {
+    if (out.length >= limit) break;
+    add(fb);
+  }
+  return out;
+}

--- a/src/styles/chat-artifact.css
+++ b/src/styles/chat-artifact.css
@@ -66,18 +66,64 @@
 }
 .chat-artifact__error-msg { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
 .chat-artifact__error-fix { color: #fff; background: rgba(0,0,0,0.2); border: 0; border-radius: 6px; padding: 3px 8px; cursor: pointer; }
-.chat-artifact__refine {
-  display: flex; align-items: center; gap: 8px;
-  padding: 8px 10px; border-top: 1px solid var(--border-hairline); background: var(--bg-raised);
+.chat-artifact__refine-icon { color: var(--accent-presence, var(--text-muted)); flex: none; }
+
+/* Collapsed state: a calm full-width trigger that opens the refine space. */
+.chat-artifact__refine-trigger {
+  display: flex; align-items: center; gap: 8px; width: 100%;
+  padding: 9px 12px; border: 0; border-top: 1px solid var(--border-hairline);
+  background: var(--bg-raised); color: var(--text-secondary);
+  font-size: var(--text-xs); text-align: left; cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
 }
-.chat-artifact__refine-icon { color: var(--text-muted); flex: none; }
-.chat-artifact__refine-input {
-  flex: 1; min-width: 0; font-size: var(--text-xs);
-  color: var(--text-primary); background: var(--bg-base);
-  border: 1px solid var(--border-hairline); border-radius: 7px; padding: 6px 10px; outline: none;
+.chat-artifact__refine-trigger:hover:not(:disabled) { background: var(--bg-hover); color: var(--text-primary); }
+.chat-artifact__refine-trigger:disabled { opacity: 0.6; cursor: default; }
+
+/* Expanded "dedicated space": textarea + suggestion rows + actions. */
+.chat-artifact__refine-panel {
+  display: flex; flex-direction: column; gap: 10px;
+  padding: 10px 12px 12px; border-top: 1px solid var(--border-hairline); background: var(--bg-raised);
 }
+.chat-artifact__refine-head { display: flex; align-items: center; gap: 7px; }
+.chat-artifact__refine-title { font-size: var(--text-xs); font-weight: 600; color: var(--text-primary); }
+.chat-artifact__refine-text {
+  width: 100%; min-height: 52px; resize: vertical; font: inherit; font-size: var(--text-xs);
+  line-height: 1.5; color: var(--text-primary); background: var(--bg-base);
+  border: 1px solid var(--border-hairline); border-radius: 8px; padding: 8px 10px; outline: none;
+  transition: border-color 0.12s ease;
+}
+.chat-artifact__refine-text:focus { border-color: color-mix(in oklch, var(--accent-presence) 55%, var(--border-hairline)); }
+
+.chat-artifact__suggests { display: flex; flex-direction: column; gap: 6px; }
+.chat-artifact__suggests-label {
+  display: flex; align-items: center; gap: 4px; margin: 2px 0 0;
+  font-size: 10px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase;
+  color: var(--text-muted);
+}
+.chat-artifact__chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.chat-artifact__chip {
+  font-size: var(--text-xs); color: var(--text-secondary);
+  background: var(--bg-base); border: 1px solid var(--border-hairline); border-radius: 999px;
+  padding: 5px 11px; cursor: pointer; text-align: left;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.chat-artifact__chip:hover:not(:disabled) {
+  background: var(--bg-hover); color: var(--text-primary);
+  border-color: color-mix(in oklch, var(--accent-presence) 40%, var(--border-hairline));
+}
+.chat-artifact__chip:disabled { opacity: 0.5; cursor: default; }
+.chat-artifact__chip--gen {
+  background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-base));
+  border-color: color-mix(in oklch, var(--accent-presence) 22%, var(--border-hairline));
+  color: color-mix(in oklch, var(--accent-presence) 75%, var(--text-primary));
+}
+
+.chat-artifact__refine-foot { display: flex; align-items: center; gap: 8px; }
+.chat-artifact__refine-hint { font-size: 10px; color: var(--text-muted); }
 .chat-artifact__refine-go {
   flex: none; font-size: var(--text-xs); font-weight: 600; color: #fff;
   background: var(--accent, #6b8fbf); border: 0; border-radius: 7px; padding: 6px 14px; cursor: pointer;
+  transition: filter 0.12s ease;
 }
+.chat-artifact__refine-go:hover:not(:disabled) { filter: brightness(1.08); }
 .chat-artifact__refine-go:disabled { opacity: 0.5; cursor: default; }


### PR DESCRIPTION
## What

The artifact **Refine** action was a single cramped one-line input. This replaces it with a **dedicated refine space** — a focused panel for describing the optimization you want, with one-tap starting points so you never face a blank box.

**Two rows of suggestion chips:**
- **Suggestions** (default) — always-useful optimizations: visual hierarchy & spacing, accessibility (contrast/labels/focus), subtle motion.
- **From this artifact** (generated) — context-aware ideas derived from the artifact's own code via cheap string-scan heuristics: buttons without hover states → "Add hover, active, and focus states"; a `<form>` → "Add inline validation…"; a fixed-width HTML layout → "Make the layout responsive…"; etc. De-duplicated against the defaults and topped up from neutral fallbacks so there's always at least one.

Tapping a chip seeds the textarea (editable before running). Opens from a calm full-width trigger; runs with **⌘↵**, **Esc** to close.

## Implementation
- New shared, unit-tested lib `src/lib/refine-suggestions.ts` (`DEFAULT_REFINE_SUGGESTIONS` + `generateRefineSuggestions(code, kind)`).
- `chat-artifact-viewer.tsx` refine section rebuilt into the panel; underlying `buildRefinePrompt`/generator wiring unchanged.
- Scoped styles in `chat-artifact.css` (default chips neutral, generated chips accent-tinted to distinguish them).

## Verification
- New `refine-suggestions.test.ts` (7 cases) + existing viewer contract tests pass.
- Full `pnpm test:app` green (322 files).
- Rendered the panel against the real shipped CSS — screenshot confirms hierarchy, chip distinction, and layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)