### PR TITLE
feat(projects): clicking a project name toggles its dropdown

### DIFF
--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -294,12 +294,10 @@ function ProjectRow({
         ) : (
           <button
             type="button"
-            onClick={() => {
-              setNameDraft(project.name);
-              setEditingName(true);
-            }}
+            onClick={() => setExpanded((value) => !value)}
+            aria-expanded={expanded}
             className="focus-ring min-w-0 flex-1 truncate rounded-md px-1 py-0.5 text-left text-[13px] font-semibold text-[var(--text-primary)] hover:text-[var(--accent-presence)]"
-            title="Rename project"
+            title={expanded ? `Collapse ${project.name}` : `Expand ${project.name}`}
           >
             {project.name}
           </button>


### PR DESCRIPTION
In the Projects tab (Familiars/Chat surface), clicking a project **name** now expands/collapses the project — matching the caret — instead of entering inline rename.

Rename was the name's old click action, but the row already has a dedicated **pencil** button in its hover actions, so rename is unchanged and more discoverable. The name button gains `aria-expanded` and an Expand/Collapse `title`.

Net: a 3-line behavior change; `projects-view.test.ts` + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)