### PR TITLE
fix(automations): Working directories field on the same row as Browse

### DIFF
--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -804,23 +804,23 @@ function CodexDetailPanel({
             </select>
           </div>
           <div>
-            <div className="flex items-center justify-between">
-              <FieldLabel>Working directories</FieldLabel>
+            <FieldLabel>Working directories</FieldLabel>
+            <div className="flex items-start gap-2">
+              <textarea
+                value={cwdsText}
+                onChange={(event) => setCwdsText(event.target.value)}
+                rows={3}
+                className={`${automationMonoTextareaClass} min-w-0 flex-1`}
+                style={fieldStyle}
+              />
               <button
                 type="button"
                 onClick={() => setCwdPickerOpen(true)}
-                className="mb-1 inline-flex items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 py-0.5 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+                className="inline-flex shrink-0 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 py-1.5 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
               >
                 <Icon name="ph:folder-open" width={12} /> Browse…
               </button>
             </div>
-            <textarea
-              value={cwdsText}
-              onChange={(event) => setCwdsText(event.target.value)}
-              rows={3}
-              className={automationMonoTextareaClass}
-              style={fieldStyle}
-            />
           </div>
 
           {cwdPickerOpen && (


### PR DESCRIPTION
The automations editor showed the **"Browse…" button on the label row**, with the directories field on a separate row below it. Move Browse down beside the field it populates.

## Change
- Label ("Working directories") on its own line.
- A flex row below: directories textarea (`flex-1 min-w-0`) + **Browse… button (`shrink-0`, top-aligned)** — so the field and Browse share one row.

Pure layout restructure; the Browse handler, the textarea binding, and the picker dialog are unchanged.

## Verification
- `pnpm build` clean; `automations-detail-inputs.test.ts` passes (no layout assertion). Not demo-screenshot-able — the form only renders when editing a Codex automation (needs `~/.codex/automations` data + the daemon), so it's covered by build + the structural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)