### PR TITLE
feat(sidebar): move New chat to the top of the left panel

### DIFF
--- a/src/components/familiar-menu-bar.test.ts
+++ b/src/components/familiar-menu-bar.test.ts
@@ -69,22 +69,17 @@ assert.doesNotMatch(
   /\.menu-bar__(familiars|familiar|presence|familiar-unread)\b/,
   "unused top-panel familiar bubble styles should be removed",
 );
-// The New chat button opens a quick-compose dropdown (a popover) rather than
-// starting a chat on the first click.
-assert.match(
+// The New chat control now lives at the top of the left sidebar
+// (SidebarMinimal), not the desktop menu bar — the bar keeps only the switcher.
+assert.doesNotMatch(
   source,
-  /className="menu-bar__new focus-ring"[\s\S]*aria-haspopup="dialog"/,
-  "the New chat button opens a dropdown",
+  /menu-bar__new|menu-bar__compose|NewChatMenu/,
+  "the New chat / quick-compose control has moved out of the desktop menu bar",
 );
-assert.match(
+assert.doesNotMatch(
   source,
-  /<Popover[\s\S]*className="menu-bar__compose"/,
-  "the dropdown is a popover anchored to the New chat button",
-);
-assert.match(
-  source,
-  /className="menu-bar__compose-select"/,
-  "the dropdown has a familiar selector",
+  /onChatWithFamiliar|onComposeChat/,
+  "the menu bar no longer owns the chat-start handlers",
 );
 assert.match(
   menuBarSwitcherRule,
@@ -95,23 +90,6 @@ assert.doesNotMatch(
   menuBarSwitcherRule,
   /width:\s*auto;/,
   "desktop menu-bar familiar selector must not use content-width sizing after the label/caret were removed",
-);
-assert.match(
-  source,
-  /className="menu-bar__compose-input"/,
-  "the dropdown has a compose box",
-);
-// Submitting with text starts a composed chat; submitting empty opens a blank
-// chat with the selected familiar.
-assert.match(
-  source,
-  /if \(prompt\) onComposeChat\(selectedId, prompt\);/,
-  "typed text starts a chat that auto-sends the message",
-);
-assert.match(
-  source,
-  /else onChatWithFamiliar\(selectedId\);/,
-  "an empty box opens a blank chat with the selected familiar",
 );
 
 // Right group — tasks. A Tasks button (board) and an Inbox button, each with a
@@ -138,17 +116,7 @@ assert.match(
 );
 
 // Wiring in the workspace: the bar mounts in the Shell topBar slot with the
-// real chat/scope/navigation handlers and live counts.
-assert.match(
-  workspace,
-  /<FamiliarMenuBar[\s\S]*onChatWithFamiliar=\{\(id\) => startFamiliarChat\(id\)\}/,
-  "the bar's chat handler starts a real familiar chat",
-);
-assert.match(
-  workspace,
-  /onComposeChat=\{\(id, prompt\) => startFamiliarChat\(id, null, prompt\)\}/,
-  "the compose handler starts a familiar chat with an initial prompt",
-);
+// real scope/navigation handlers and live counts.
 assert.match(
   workspace,
   /onViewTasks=\{\(\) => setMode\("board"\)\}/,

--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { Icon } from "@/lib/icon";
 import { FamiliarSwitcher } from "@/components/familiar-switcher";
-import { Popover } from "@/components/ui/popover";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { SessionRow } from "@/lib/types";
 
@@ -16,10 +14,6 @@ type Props = {
   taskCount: number;
   /** Items needing attention — drives the Inbox badge. */
   inboxCount: number;
-  /** Start a chat with a familiar (`null` = the active/default familiar). */
-  onChatWithFamiliar: (id: string | null) => void;
-  /** Start a chat with a familiar and an opening message (auto-sent on entry). */
-  onComposeChat: (id: string | null, prompt: string) => void;
   /** Open the shared context-aware search palette. */
   onOpenSearch: () => void;
   /** Shared top-search query, mirrored with the mobile top bar and palette. */
@@ -51,8 +45,6 @@ export function FamiliarMenuBar({
   responseNeeded,
   taskCount,
   inboxCount,
-  onChatWithFamiliar,
-  onComposeChat,
   onOpenSearch,
   searchQuery,
   onSearchQueryChange,
@@ -71,13 +63,6 @@ export function FamiliarMenuBar({
           onSelectFamiliar={onSelectFamiliar}
           placement="bottom-start"
           labeled
-        />
-
-        <NewChatMenu
-          familiars={familiars}
-          activeFamiliarId={activeFamiliarId}
-          onChatWithFamiliar={onChatWithFamiliar}
-          onComposeChat={onComposeChat}
         />
       </div>
 
@@ -136,128 +121,3 @@ export function FamiliarMenuBar({
   );
 }
 
-/**
- * The "New chat" control: a button that opens a small quick-chat dropdown — pick
- * a familiar and (optionally) type an opening message. Submitting with text
- * starts the chat and auto-sends the message; submitting empty just opens a
- * blank chat with the selected familiar.
- */
-function NewChatMenu({
-  familiars,
-  activeFamiliarId,
-  onChatWithFamiliar,
-  onComposeChat,
-}: {
-  familiars: ResolvedFamiliar[];
-  activeFamiliarId: string | null;
-  onChatWithFamiliar: (id: string | null) => void;
-  onComposeChat: (id: string | null, prompt: string) => void;
-}) {
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const [open, setOpen] = useState(false);
-  const [text, setText] = useState("");
-  const [selectedId, setSelectedId] = useState<string | null>(activeFamiliarId);
-
-  // Each time the dropdown opens, default the selection to the active familiar
-  // (or the first one) and focus the composer so you can type straight away.
-  useEffect(() => {
-    if (!open) return;
-    setSelectedId(activeFamiliarId ?? familiars[0]?.id ?? null);
-    const t = window.setTimeout(() => textareaRef.current?.focus(), 0);
-    return () => window.clearTimeout(t);
-  }, [open, activeFamiliarId, familiars]);
-
-  const selectedName = familiars.find((f) => f.id === selectedId)?.display_name ?? "a familiar";
-
-  const autoGrow = useCallback(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = "auto";
-    el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
-  }, []);
-
-  const handleStart = useCallback(() => {
-    const prompt = text.trim();
-    if (prompt) onComposeChat(selectedId, prompt);
-    else onChatWithFamiliar(selectedId);
-    setText("");
-    setOpen(false);
-  }, [text, selectedId, onComposeChat, onChatWithFamiliar]);
-
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLTextAreaElement>) => {
-      // plain Enter sends; Shift+Enter inserts a newline
-      if (e.key === "Enter" && !e.shiftKey) {
-        e.preventDefault();
-        handleStart();
-      }
-    },
-    [handleStart],
-  );
-
-  return (
-    <>
-      <button
-        type="button"
-        ref={triggerRef}
-        className="menu-bar__new focus-ring"
-        onClick={() => setOpen((v) => !v)}
-        aria-label="Start a new chat"
-        aria-haspopup="dialog"
-        aria-expanded={open}
-      >
-        <Icon name="ph:chat-circle-dots" width={14} aria-hidden />
-        <span>New chat</span>
-      </button>
-      <Popover
-        open={open}
-        onOpenChange={setOpen}
-        anchorRef={triggerRef}
-        placement="bottom-start"
-        minWidth={300}
-        className="menu-bar__compose"
-      >
-        <div className="menu-bar__compose-row">
-          <label className="menu-bar__compose-label" htmlFor="menu-bar-compose-familiar">
-            To
-          </label>
-          <select
-            id="menu-bar-compose-familiar"
-            className="menu-bar__compose-select"
-            value={selectedId ?? ""}
-            onChange={(e) => setSelectedId(e.target.value || null)}
-          >
-            {familiars.map((f) => (
-              <option key={f.id} value={f.id}>
-                {f.display_name}
-              </option>
-            ))}
-          </select>
-        </div>
-        <textarea
-          ref={textareaRef}
-          className="menu-bar__compose-input"
-          placeholder={`Ask ${selectedName} anything…`}
-          rows={3}
-          value={text}
-          onChange={(e) => {
-            setText(e.target.value);
-            autoGrow();
-          }}
-          onKeyDown={handleKeyDown}
-          aria-label="Message"
-          enterKeyHint="send"
-        />
-        <div className="menu-bar__compose-actions">
-          <button type="button" className="menu-bar__compose-send focus-ring" onClick={handleStart}>
-            <span>Open chat</span>
-            <kbd className="menu-bar__compose-kbd" aria-hidden>
-              ↵
-            </kbd>
-          </button>
-        </div>
-      </Popover>
-    </>
-  );
-}

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -249,11 +249,20 @@ assert.match(
   "Recent Activity must receive activeSessionId to highlight the open session",
 );
 
-// PR #322 wrapped the New Chat ActionRow in .sidebar-new-chat-row so desktop
-// CSS could hide it (the FamiliarSwitcher had its own + button to dedupe
-// against). PR #304 replaced the switcher with a plain dropdown that has no
-// + button, so the New Chat ActionRow is the sole new-chat affordance now —
-// no wrapper, no responsive hide.
+// "New chat" is the left panel's top CTA: it sits directly under the wordmark
+// (above the nav scroll) and calls onNewChat. It moved here from the desktop
+// menu bar and the mobile top bar, so the sidebar now owns the only new-chat
+// affordance on every breakpoint.
+assert.match(
+  source,
+  /<div className="sidebar-actions">\s*<button type="button" className="sidebar-action-row focus-ring" onClick=\{onNewChat\}>/,
+  "the sidebar renders a New chat CTA at the top, wired to onNewChat",
+);
+assert.match(
+  source,
+  /<Icon name="ph:note-pencil"[\s\S]*?<span>New chat<\/span>/,
+  "the New chat CTA is labelled and iconed",
+);
 
 // The sidebar header is a static wordmark — collapsing the panel is owned by
 // the shell's floating top-left toggle (and ⌘B), so the header is no longer a

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -193,6 +193,7 @@ function FolderRow({
 export function SidebarMinimal(props: SidebarMinimalProps) {
   const {
     mode,
+    onNewChat,
     onOpenSettings,
     onOpenMobileHandoff,
     onModeChange,
@@ -228,11 +229,18 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
       {/* Static wordmark. Collapsing the sidebar is now owned by the shell's
           floating top-left toggle (and ⌘B), so the header is no longer a
           button — it just leaves room for the float. */}
-      {/* Familiar scope selection and New session live in the desktop top
-          menu bar (FamiliarMenuBar) and the mobile top bar — the left panel is
-          pure navigation now, so the nav flows straight under the wordmark. */}
+      {/* Familiar scope selection lives in the desktop top menu bar
+          (FamiliarMenuBar) and the mobile top bar. "New chat" is the left
+          panel's top CTA, so the nav flows under it. */}
       <div className="sidebar-header sidebar-header--static">
         <span className="sidebar-title">Coven Cave</span>
+      </div>
+
+      <div className="sidebar-actions">
+        <button type="button" className="sidebar-action-row focus-ring" onClick={onNewChat}>
+          <Icon name="ph:note-pencil" width={16} aria-hidden />
+          <span>New chat</span>
+        </button>
       </div>
 
       <div className="sidebar-nav-scroll">

--- a/src/components/top-bar.test.ts
+++ b/src/components/top-bar.test.ts
@@ -138,24 +138,18 @@ assert.match(
   "Selection handler is nullable so the menu can scope to all familiars",
 );
 
-// Mobile quick actions folded in from the desktop menu bar: New chat + Tasks.
-// (The top bar is the single mobile bar — display:none on desktop — so these
-// render only on mobile; the inbox stays on the NotificationBell, the switcher
-// is already present, so nothing is duplicated.)
-assert.match(
-  source,
-  /onStartChat\?: \(\) => void/,
-  "Top bar accepts a New chat handler for the mobile quick action",
-);
+// Mobile quick actions: Tasks. New chat now lives at the top of the left
+// sidebar (SidebarMinimal) for both desktop and mobile, so the top bar no
+// longer renders a New chat button.
 assert.match(
   source,
   /onViewTasks\?: \(\) => void/,
   "Top bar accepts a View tasks handler for the mobile quick action",
 );
-assert.match(
+assert.doesNotMatch(
   source,
-  /onStartChat \?[\s\S]*aria-label="New chat"[\s\S]*ph:chat-circle-dots/,
-  "Top bar renders a New chat button when wired",
+  /aria-label="New chat"/,
+  "the New chat button has moved out of the mobile top bar to the sidebar",
 );
 assert.match(
   source,

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -78,7 +78,6 @@ export function TopBar(props: Props) {
     activeFamiliar,
     familiarOptions,
     onSelectFamiliar,
-    onStartChat,
     onViewTasks,
     taskCount,
     sessions,
@@ -163,17 +162,6 @@ export function TopBar(props: Props) {
             placement="bottom-end"
             labeled={familiarSwitcherLabeled}
           />
-        ) : null}
-        {onStartChat ? (
-          <button
-            type="button"
-            className="top-bar__icon-btn"
-            onClick={onStartChat}
-            aria-label="New chat"
-            title="New chat"
-          >
-            <Icon name="ph:chat-circle-dots" width={15} />
-          </button>
         ) : null}
         {onViewTasks ? (
           <button

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1707,8 +1707,6 @@ export function Workspace() {
               responseNeeded={responseNeeded}
               taskCount={boardTaskCount}
               inboxCount={inboxBadgeCount}
-              onChatWithFamiliar={(id) => startFamiliarChat(id)}
-              onComposeChat={(id, prompt) => startFamiliarChat(id, null, prompt)}
               onOpenSearch={() => setPaletteOpen(true)}
               searchQuery={topSearchQuery}
               onSearchQueryChange={(query) => {


### PR DESCRIPTION
Moves the **New chat** affordance from the desktop menu bar (`FamiliarMenuBar`) and the mobile top bar (`TopBar`) into a single top-of-sidebar CTA in `SidebarMinimal`, directly under the wordmark and above the nav. Wired to the existing `onNewChat` handler, so it works on every breakpoint.

- **SidebarMinimal** — new `.sidebar-actions` New chat button (reuses the existing `.sidebar-action-row` top-CTA styling).
- **FamiliarMenuBar** — drops the `NewChatMenu` button + quick-compose dropdown (the `FamiliarSwitcher` already covers picking a familiar); keeps the switcher, search, and Tasks/Inbox.
- **TopBar** — drops the mobile New chat icon button; keeps Tasks.
- Source-text tests updated for all three surfaces.

`tsc` clean, full `test:app` (322 files) green, `check:tests-wired` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)