### PR TITLE
feat(journal): dedicated refine space for Canvas sketches

### DIFF
--- a/src/components/journal/canvas-list.tsx
+++ b/src/components/journal/canvas-list.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { isDemoModeEnabled } from "@/lib/demo-mode";
 import { relativeTime } from "@/lib/daily-report";
+import { DEFAULT_REFINE_SUGGESTIONS, generateRefineSuggestions } from "@/lib/refine-suggestions";
 import {
   buildPreviewSrcDoc,
   buildRefinePrompt,
@@ -65,6 +66,9 @@ export function CanvasList({
   const [generating, setGenerating] = useState<Set<string>>(new Set());
   const [prompt, setPrompt] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [refineOpen, setRefineOpen] = useState(false);
+  const [refineText, setRefineText] = useState("");
+  const refineRef = useRef<HTMLTextAreaElement | null>(null);
 
   const load = useCallback(async () => {
     if (isDemoModeEnabled()) {
@@ -170,6 +174,43 @@ export function CanvasList({
 
   const selected = artifacts.find((a) => a.id === selectedId) ?? null;
   const canGenerate = Boolean(activeFamiliarId ?? familiars[0]?.id);
+  const selectedBusy = selected ? generating.has(selected.id) : false;
+
+  // Context-aware refine ideas for the selected sketch (cheap string scan).
+  const generatedSuggestions = useMemo(
+    () => (selected ? generateRefineSuggestions(selected.code, selected.kind ?? "html") : []),
+    [selected],
+  );
+
+  // The refine space resets when switching sketches so a draft doesn't leak
+  // across artifacts.
+  useEffect(() => {
+    setRefineOpen(false);
+    setRefineText("");
+  }, [selectedId]);
+
+  const openRefine = useCallback(() => {
+    setRefineOpen(true);
+    requestAnimationFrame(() => refineRef.current?.focus());
+  }, []);
+
+  const applySuggestion = useCallback((text: string) => {
+    setRefineText(text);
+    requestAnimationFrame(() => {
+      const el = refineRef.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(el.value.length, el.value.length);
+    });
+  }, []);
+
+  const submitRefine = useCallback(() => {
+    const ask = refineText.trim();
+    if (!selected || !ask || generating.has(selected.id)) return;
+    void runGeneration(selected.id, ask, selected);
+    setRefineText("");
+    setRefineOpen(false);
+  }, [refineText, selected, generating, runGeneration]);
 
   return (
     <div className="journal-list">
@@ -252,11 +293,12 @@ export function CanvasList({
               <div className="journal-detail__actions">
                 <button
                   type="button"
-                  className="journal-act"
-                  disabled={!canGenerate || generating.has(selected.id)}
-                  onClick={() => runGeneration(selected.id, selected.prompt, selected)}
+                  className={`journal-act${refineOpen ? " journal-act--on" : ""}`}
+                  disabled={!canGenerate || selectedBusy}
+                  aria-expanded={refineOpen}
+                  onClick={() => (refineOpen ? setRefineOpen(false) : openRefine())}
                 >
-                  <Icon name="ph:arrows-clockwise" aria-hidden /> Refine
+                  <Icon name="ph:arrows-clockwise" aria-hidden /> {selectedBusy ? "Refining…" : "Refine"}
                 </button>
                 <button
                   type="button"
@@ -268,6 +310,52 @@ export function CanvasList({
                 </button>
               </div>
             </div>
+            {refineOpen ? (
+              <div className="journal-refine" role="group" aria-label="Refine sketch">
+                <textarea
+                  ref={refineRef}
+                  className="journal-refine__text"
+                  aria-label="Describe the optimization you want"
+                  placeholder="Describe the optimization you want…"
+                  rows={2}
+                  value={refineText}
+                  disabled={selectedBusy}
+                  onChange={(e) => setRefineText(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) { e.preventDefault(); submitRefine(); }
+                    if (e.key === "Escape") { e.preventDefault(); setRefineOpen(false); }
+                  }}
+                />
+                <p className="journal-refine__label">Suggestions</p>
+                <div className="journal-refine__chips">
+                  {DEFAULT_REFINE_SUGGESTIONS.map((s) => (
+                    <button key={s} type="button" className="journal-refine__chip" disabled={selectedBusy} onClick={() => applySuggestion(s)}>
+                      {s}
+                    </button>
+                  ))}
+                </div>
+                {generatedSuggestions.length ? (
+                  <>
+                    <p className="journal-refine__label"><Icon name="ph:sparkle" width={11} aria-hidden /> From this sketch</p>
+                    <div className="journal-refine__chips">
+                      {generatedSuggestions.map((s) => (
+                        <button key={s} type="button" className="journal-refine__chip journal-refine__chip--gen" disabled={selectedBusy} onClick={() => applySuggestion(s)}>
+                          {s}
+                        </button>
+                      ))}
+                    </div>
+                  </>
+                ) : null}
+                <div className="journal-refine__foot">
+                  <span className="journal-refine__hint">⌘↵ to refine</span>
+                  <span style={{ flex: 1 }} />
+                  <button type="button" className="journal-act" onClick={() => setRefineOpen(false)}>Cancel</button>
+                  <button type="button" className="journal-refine__go" disabled={selectedBusy || !refineText.trim()} onClick={submitRefine}>
+                    {selectedBusy ? "Refining…" : "Refine"}
+                  </button>
+                </div>
+              </div>
+            ) : null}
             {view === "preview" ? (
               <iframe
                 className="journal-detail__frame"

--- a/src/styles/journal.css
+++ b/src/styles/journal.css
@@ -153,6 +153,54 @@
 }
 .journal-act:disabled { opacity: 0.5; cursor: default; }
 .journal-act--danger { color: var(--color-danger); }
+.journal-act--on {
+  border-color: color-mix(in oklch, var(--accent-presence) 45%, var(--border-strong));
+  color: var(--text-primary);
+}
+
+/* Dedicated refine space — describe the optimization, or tap a suggestion. */
+.journal-refine {
+  display: flex; flex-direction: column; gap: 9px;
+  padding: 11px 12px; margin: 2px 0;
+  border: 1px solid var(--border-hairline); border-radius: 10px; background: var(--bg-raised);
+}
+.journal-refine__text {
+  width: 100%; min-height: 50px; resize: vertical; font: inherit; font-size: 12px; line-height: 1.5;
+  color: var(--text-primary); background: var(--bg-base);
+  border: 1px solid var(--border-hairline); border-radius: 8px; padding: 8px 10px; outline: none;
+  transition: border-color 0.12s ease;
+}
+.journal-refine__text:focus { border-color: color-mix(in oklch, var(--accent-presence) 55%, var(--border-hairline)); }
+.journal-refine__label {
+  display: flex; align-items: center; gap: 4px; margin: 0;
+  font-size: 10px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--text-muted);
+}
+.journal-refine__chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.journal-refine__chip {
+  font-size: 12px; color: var(--text-secondary);
+  background: var(--bg-base); border: 1px solid var(--border-hairline); border-radius: 999px;
+  padding: 5px 11px; cursor: pointer; text-align: left;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.journal-refine__chip:hover:not(:disabled) {
+  background: var(--bg-hover); color: var(--text-primary);
+  border-color: color-mix(in oklch, var(--accent-presence) 40%, var(--border-hairline));
+}
+.journal-refine__chip:disabled { opacity: 0.5; cursor: default; }
+.journal-refine__chip--gen {
+  background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-base));
+  border-color: color-mix(in oklch, var(--accent-presence) 22%, var(--border-hairline));
+  color: color-mix(in oklch, var(--accent-presence) 75%, var(--text-primary));
+}
+.journal-refine__foot { display: flex; align-items: center; gap: 8px; }
+.journal-refine__hint { font-size: 10px; color: var(--text-muted); }
+.journal-refine__go {
+  flex: none; font-size: 11.5px; font-weight: 600; color: #fff;
+  background: var(--accent, #6b8fbf); border: 0; border-radius: 8px; padding: 6px 14px; cursor: pointer;
+  transition: filter 0.12s ease;
+}
+.journal-refine__go:hover:not(:disabled) { filter: brightness(1.08); }
+.journal-refine__go:disabled { opacity: 0.5; cursor: default; }
 .journal-detail__frame {
   flex: 1;
   min-height: 0;


### PR DESCRIPTION
## What

The Canvas (Journal) **Refine** action re-ran the sketch's *original prompt* verbatim — there was no way to specify what to optimize. This wires it to the **dedicated refine space** introduced for in-chat artifacts in #1089, so the two refine surfaces are now consistent:

- A real **textarea** to describe the optimization you want.
- **Suggestions** — default always-useful chips (visual hierarchy, accessibility, motion).
- **From this sketch** — generated chips derived from the sketch's own code (shared `src/lib/refine-suggestions`), accent-tinted to distinguish them.

Tap a chip to seed the textarea; **⌘↵** runs, **Esc** closes. The space resets when switching sketches so a draft can't leak across artifacts.

## Verification
- `journal-view.test.ts` + full `pnpm test:app` green (323 files).
- Rendered the panel against the real shipped `journal.css` — matches the in-chat refine space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)