### PR TITLE
feat(projects): filter box + per-project status dots

### DIFF
--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -109,8 +109,28 @@ assert.doesNotMatch(projectsView, /defaultExpanded/, "no project auto-expands â€
 
 // Projects are ordered by most-recent session activity, not API order.
 assert.match(projectsView, /const sortedProjects = useMemo/, "projects are sorted before rendering");
-assert.match(projectsView, /sortedProjects\.map\(\(project\)/, "the sorted list drives the render");
 assert.match(projectsView, /function lastActiveMs/, "recency is derived from each project's latest session");
+
+// A filter box narrows the (sorted) list by name or path; the filtered list
+// drives the render and an empty result shows a no-match message.
+assert.match(projectsView, /const visibleProjects = useMemo/, "projects are filtered after sorting");
+assert.match(
+  projectsView,
+  /p\.name\.toLowerCase\(\)\.includes\(q\) \|\| p\.root\.toLowerCase\(\)\.includes\(q\)/,
+  "the filter matches on project name or path",
+);
+assert.match(projectsView, /visibleProjects\.map\(\(project\)/, "the filtered list drives the render");
+assert.match(projectsView, /aria-label="Filter projects"/, "there is a labeled filter input");
+assert.match(projectsView, /No projects match/, "a no-match message shows when the filter excludes everything");
+
+// Each project row carries a glanceable status dot: accent when a session is
+// running, danger when the most-recent session failed.
+assert.match(
+  projectsView,
+  /const projectStatus[\s\S]*?status === "running"[\s\S]*?\? "running"[\s\S]*?\? "failed"/,
+  "row status is running (any) > failed (most recent) > idle",
+);
+assert.match(projectsView, /projectStatus \? \(/, "the status dot renders only when running or failed");
 
 // Paths are home-collapsed + truncated so the identical absolute prefix stops
 // dominating; the full path stays in the title and the editor.

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -200,6 +200,19 @@ function ProjectRow({
   const lastActiveIso =
     chats.reduce((acc, s) => (!acc || s.updated_at > acc ? s.updated_at : acc), "") || project.updatedAt;
   const lastActiveLabel = relativeTime(lastActiveIso);
+  // Glanceable status: a session running anywhere in the project → accent dot;
+  // otherwise the most-recent session having failed → danger dot; idle → none.
+  const mostRecentChat = chats.reduce<SessionRow | null>(
+    (acc, s) => (!acc || s.updated_at > acc.updated_at ? s : acc),
+    null,
+  );
+  const projectStatus: "running" | "failed" | null = chats.some((s) => s.status === "running")
+    ? "running"
+    : mostRecentChat && (mostRecentChat.status === "failed" || mostRecentChat.status === "error")
+      ? "failed"
+      : null;
+  const statusLabel =
+    projectStatus === "running" ? ", a session is running" : projectStatus === "failed" ? ", last session failed" : "";
   const [showAllChats, setShowAllChats] = useState(false);
   const visibleChats = showAllChats ? chats : chats.slice(0, CHAT_CAP);
   const { setNodeRef: setDropRef, isOver } = useDroppable({
@@ -264,17 +277,28 @@ function ProjectRow({
           type="button"
           onClick={() => setExpanded((value) => !value)}
           aria-expanded={expanded}
-          aria-label={expanded ? `Collapse ${project.name}` : `Expand ${project.name}`}
+          aria-label={`${expanded ? "Collapse" : "Expand"} ${project.name}${statusLabel}`}
           className="focus-ring -ml-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-secondary)]"
         >
           <Icon name={expanded ? "ph:caret-down" : "ph:caret-right"} width={12} aria-hidden />
         </button>
-        <Icon
-          name="ph:folder-open-bold"
-          width={15}
-          className="shrink-0 text-[var(--accent-presence)]"
-          aria-hidden
-        />
+        <span className="relative shrink-0">
+          <Icon
+            name="ph:folder-open-bold"
+            width={15}
+            className="text-[var(--accent-presence)]"
+            aria-hidden
+          />
+          {projectStatus ? (
+            <span
+              className={`absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full ring-2 ring-[var(--bg-base)] ${chatDotClass(
+                projectStatus,
+              )}${projectStatus === "running" ? " animate-pulse" : ""}`}
+              title={projectStatus === "running" ? "A session is running" : "Last session failed"}
+              aria-hidden
+            />
+          ) : null}
+        </span>
         {editingName ? (
           <input
             autoFocus
@@ -472,6 +496,7 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: Pr
     reload,
   } = useProjects();
   const [showForm, setShowForm] = useState(false);
+  const [query, setQuery] = useState("");
   const [nameDraft, setNameDraft] = useState("");
   const [rootDraft, setRootDraft] = useState("");
   const [creating, setCreating] = useState(false);
@@ -517,6 +542,16 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: Pr
       0;
     return [...projects].sort((a, b) => score(b) - score(a));
   }, [projects, chatsByRoot]);
+
+  // Filter by name or path so the (recency-sorted) list stays scannable when
+  // there are many projects.
+  const visibleProjects = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return sortedProjects;
+    return sortedProjects.filter(
+      (p) => p.name.toLowerCase().includes(q) || p.root.toLowerCase().includes(q),
+    );
+  }, [sortedProjects, query]);
 
   function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event;
@@ -588,7 +623,9 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: Pr
       <header className="shrink-0 border-b border-[var(--border-hairline)] px-4 py-2.5 sm:px-6">
         <div className="flex items-center justify-between gap-3">
           <span className="text-[12px] text-[var(--text-muted)]">
-            {projects.length} {projects.length === 1 ? "project" : "projects"}
+            {query.trim() && visibleProjects.length !== projects.length
+              ? `${visibleProjects.length} of ${projects.length} projects`
+              : `${projects.length} ${projects.length === 1 ? "project" : "projects"}`}
           </span>
           <div className="flex items-center gap-2">
             <button
@@ -611,6 +648,24 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: Pr
             </button>
           </div>
         </div>
+        {projects.length > 1 ? (
+          <div className="relative mt-2">
+            <Icon
+              name="ph:magnifying-glass"
+              width={13}
+              className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-muted)]"
+              aria-hidden
+            />
+            <input
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Filter projects by name or path…"
+              aria-label="Filter projects"
+              className="focus-ring h-8 w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] pl-8 pr-2.5 text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"
+            />
+          </div>
+        ) : null}
       </header>
 
       {showForm ? (
@@ -736,21 +791,27 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: Pr
                 </button>
               </div>
             ) : null}
-            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-              {sortedProjects.map((project) => (
-                <ProjectRow
-                  key={project.id}
-                  project={project}
-                  chats={chatsByRoot.get(normalizeProjectRoot(project.root)) ?? []}
-                  onRename={renameProject}
-                  onUpdateRoot={updateRoot}
-                  onDelete={deleteProject}
-                  onNewChat={onNewChat}
-                  onOpenSession={openSessionById}
-                  onDeleteSession={handleDeleteSession}
-                />
-              ))}
-            </DndContext>
+            {visibleProjects.length === 0 ? (
+              <p className="px-2 py-6 text-center text-[12px] text-[var(--text-muted)]">
+                No projects match “{query.trim()}”.
+              </p>
+            ) : (
+              <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                {visibleProjects.map((project) => (
+                  <ProjectRow
+                    key={project.id}
+                    project={project}
+                    chats={chatsByRoot.get(normalizeProjectRoot(project.root)) ?? []}
+                    onRename={renameProject}
+                    onUpdateRoot={updateRoot}
+                    onDelete={deleteProject}
+                    onNewChat={onNewChat}
+                    onOpenSession={openSessionById}
+                    onDeleteSession={handleDeleteSession}
+                  />
+                ))}
+              </DndContext>
+            )}
           </div>
         )}
       </main>


### PR DESCRIPTION
Next UX-backlog item, building on the Projects tab redesign (#1077/#1079). With many projects there was no quick way to find one or to see which are active.

## Changes
- **Filter box** (shown when there's more than one project): narrows the recency-sorted list by name or path. The header count reads "N of M projects" while filtering, and an empty result shows a "No projects match …" message.
- **Status dot** on each project's folder icon: accent + pulsing when any session is **running**, danger when the **most-recent** session failed, nothing when idle (so it draws attention only to projects that need it). The status is also folded into the row's expand/collapse `aria-label` for screen readers.

## Verification
- `pnpm build` clean; `projects-view.test.ts` updated (filtered list drives render, filter matches name/path, no-match message, status-dot logic) and passing.
- Live-verified in the running app (projects mocked): filter input renders, typing "code" narrows 6→2, "zzz" shows the no-match message, and one status dot renders on the project with a running session. Screenshot reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)