### PR TITLE
feat(journal): world-class empty state for the Canvas with starter prompts

### DIFF
--- a/src/components/journal/canvas-list.tsx
+++ b/src/components/journal/canvas-list.tsx
@@ -17,7 +17,17 @@ import {
 import { buildReactSrcDoc } from "@/lib/canvas-react-harness";
 import { generateArtifactCode } from "@/lib/canvas-generate";
 import { highlightToHtml } from "@/components/message-bubble";
+import { EmptyState } from "@/components/ui/empty-state";
 import type { Familiar } from "@/lib/types";
+
+// Example prompts shown in the empty state so the blank Canvas isn't a dead
+// end — tapping one seeds the composer so the user can run or edit it.
+const STARTER_SKETCH_PROMPTS: readonly string[] = [
+  "A pricing page with three tiers and a highlighted plan",
+  "A sign-in form with email, password, and social buttons",
+  "A weather dashboard card with an animated icon",
+  "A kanban column with draggable task cards",
+];
 
 function srcDocFor(art: CanvasArtifact): string {
   return art.kind === "react" ? buildReactSrcDoc(art.code) : buildPreviewSrcDoc(art.code);
@@ -69,6 +79,19 @@ export function CanvasList({
   const [refineOpen, setRefineOpen] = useState(false);
   const [refineText, setRefineText] = useState("");
   const refineRef = useRef<HTMLTextAreaElement | null>(null);
+  const composerRef = useRef<HTMLInputElement | null>(null);
+
+  // Seed the generate composer from an example prompt and focus it, so the
+  // empty-state starters are one tap from a ready-to-run sketch.
+  const applyStarter = useCallback((text: string) => {
+    setPrompt(text);
+    requestAnimationFrame(() => {
+      const el = composerRef.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(el.value.length, el.value.length);
+    });
+  }, []);
 
   const load = useCallback(async () => {
     if (isDemoModeEnabled()) {
@@ -224,6 +247,7 @@ export function CanvasList({
           }}
         >
           <input
+            ref={composerRef}
             className="journal-composer__input"
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
@@ -242,7 +266,10 @@ export function CanvasList({
         ) : null}
         <div className="journal-list__cap">Generated sketches</div>
         {artifacts.length === 0 ? (
-          <div className="journal-empty">No sketches yet. Generate one above.</div>
+          <div className="journal-empty">
+            <Icon name="ph:sparkle" width={15} aria-hidden />
+            No sketches yet — describe one above to get started.
+          </div>
         ) : (
           <ul className="journal-list__items">
             {[...artifacts].reverse().map((a) => (
@@ -369,7 +396,34 @@ export function CanvasList({
             <div className="journal-detail__prompt">Prompt: “{selected.prompt}”</div>
           </>
         ) : (
-          <div className="journal-empty journal-empty--pane">Select a sketch to preview it.</div>
+          <div className="journal-empty journal-empty--pane">
+            <EmptyState
+              icon="ph:sparkle"
+              headline={artifacts.length ? "Select a sketch to preview it" : "Sketch a UI with a familiar"}
+              subtitle={
+                artifacts.length
+                  ? "Pick a sketch from the list to preview, refine, and iterate on it."
+                  : "Describe a screen or component and a familiar generates a live, editable preview. Try a starting point:"
+              }
+              actions={
+                artifacts.length ? undefined : (
+                  <div className="journal-starters">
+                    {STARTER_SKETCH_PROMPTS.map((s) => (
+                      <button
+                        key={s}
+                        type="button"
+                        className="journal-starter"
+                        disabled={!canGenerate}
+                        onClick={() => applyStarter(s)}
+                      >
+                        {s}
+                      </button>
+                    ))}
+                  </div>
+                )
+              }
+            />
+          </div>
         )}
       </section>
     </div>

--- a/src/styles/journal.css
+++ b/src/styles/journal.css
@@ -241,10 +241,41 @@
 .journal-detail__code--hl code { font: inherit; }
 .journal-detail__prompt { font-size: 11px; color: var(--text-muted); }
 .journal-empty {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   font-size: 12.5px;
   color: var(--text-muted);
   padding: 16px 4px;
 }
+.journal-empty svg { flex: none; color: var(--accent-presence); opacity: 0.8; }
+
+/* Empty-state starter prompts — one tap seeds the generate composer. */
+.journal-starters {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  width: 100%;
+  max-width: 340px;
+  margin: 4px auto 0;
+}
+.journal-starter {
+  font-size: 12px;
+  color: var(--text-secondary);
+  background: var(--bg-base);
+  border: 1px solid var(--border-hairline);
+  border-radius: 9px;
+  padding: 8px 12px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.journal-starter:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: color-mix(in oklch, var(--accent-presence) 40%, var(--border-hairline));
+}
+.journal-starter:disabled { opacity: 0.5; cursor: default; }
 .journal-empty--pane {
   flex: 1;
   display: flex;


### PR DESCRIPTION
## What

The Journal **Canvas** tab's empty state was bare text — "Select a sketch to preview it." and "No sketches yet. Generate one above." A blank Canvas gave no guidance and no way in.

This replaces the detail-pane empty with a proper **EmptyState**: an icon, a "Sketch a UI with a familiar" headline, a one-line explanation, and **four one-tap starter prompts** (pricing page, sign-in form, weather card, kanban column) that seed the generate composer so you're one tap from a ready-to-run sketch. The rail empty gets an icon and clearer copy.

Together with the refine space (#1093), the Journal Canvas section is now comprehensively polished — friendly **starting points** for generation and a dedicated **refine space** for iteration.

## Verification
- `journal-view.test.ts` + full `pnpm test:app` green (323 files).
- Verified live in demo mode: the empty Canvas renders the rich EmptyState with 4 starter chips (screenshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)