### PR TITLE
refactor(time): use the canonical relativeTime formatter everywhere

### DIFF
--- a/src/components/recent-activity-rollup.tsx
+++ b/src/components/recent-activity-rollup.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
+import { relativeTime } from "@/lib/relative-time";
 import type { SessionRow } from "@/lib/types";
 
 /**
@@ -22,19 +23,6 @@ function projectLabel(root: string | undefined): string {
   if (!root) return "";
   const parts = root.replace(/\/+$/, "").split("/");
   return parts[parts.length - 1] || root;
-}
-
-function relativeTime(iso: string | undefined): string {
-  if (!iso) return "";
-  const then = Date.parse(iso);
-  if (Number.isNaN(then)) return "";
-  const s = Math.max(0, Math.round((Date.now() - then) / 1000));
-  if (s < 45) return "now";
-  const m = Math.round(s / 60);
-  if (m < 60) return `${m}m`;
-  const h = Math.round(m / 60);
-  if (h < 24) return `${h}h`;
-  return `${Math.round(h / 24)}d`;
 }
 
 function modelIcon(model: string | null | undefined): IconName {

--- a/src/components/retro-runs-view.tsx
+++ b/src/components/retro-runs-view.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { relativeTime } from "@/lib/relative-time";
 import type { RetroOutcome, RetroRun, RetroRunsSnapshot, RetroTrack } from "@/lib/retro-runs";
 
 type RetroApiResponse = {
@@ -35,17 +36,10 @@ const EMPTY_SNAPSHOT: RetroRunsSnapshot = {
   runs: [],
 };
 
-function relativeTime(iso: string | null): string {
-  if (!iso) return "never";
-  const time = new Date(iso).getTime();
-  if (!Number.isFinite(time)) return "unknown";
-  const seconds = Math.max(0, Math.floor((Date.now() - time) / 1000));
-  if (seconds < 60) return `${seconds}s ago`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 48) return `${hours}h ago`;
-  return `${Math.floor(hours / 24)}d ago`;
+// Retro rows fall back to "never" when a familiar has no last run; the time
+// math itself is the shared canonical formatter.
+function lastRunLabel(iso: string | null): string {
+  return relativeTime(iso) || "never";
 }
 
 function scoreLabel(delta: number): string {
@@ -221,7 +215,7 @@ export function RetroRunsView({
         </div>
         <div className="retro-metric">
           <Icon name="ph:clock-countdown" aria-hidden />
-          <span>{relativeTime(snapshot.summary.lastRun)}</span>
+          <span>{lastRunLabel(snapshot.summary.lastRun)}</span>
           <p>Latest run</p>
         </div>
       </div>
@@ -285,7 +279,7 @@ export function RetroRunsView({
                 <li key={familiar.familiarId}>
                   <span>
                     <b>{familiar.familiarName}</b>
-                    <small>{familiar.runs.length} runs · {familiar.running ? "running" : relativeTime(familiar.lastRun)}</small>
+                    <small>{familiar.runs.length} runs · {familiar.running ? "running" : lastRunLabel(familiar.lastRun)}</small>
                   </span>
                   <i aria-hidden={familiar.running ? "false" : "true"} className={familiar.running ? "is-running" : ""} />
                 </li>

--- a/src/components/workflows/workflow-runs-panel.tsx
+++ b/src/components/workflows/workflow-runs-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
+import { relativeTime } from "@/lib/relative-time";
 import type { WorkflowPlaybackState } from "@/lib/workflow-playback";
 import type {
   WorkflowRunRecord,
@@ -17,17 +18,6 @@ type WorkflowRunsPanelProps = {
   onReplayRun: (run: WorkflowRunRecord) => void;
 };
 
-function relativeTime(iso: string): string {
-  const then = Date.parse(iso);
-  if (Number.isNaN(then)) return iso;
-  const seconds = Math.round((Date.now() - then) / 1000);
-  if (seconds < 60) return "just now";
-  const minutes = Math.round(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.round(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  return `${Math.round(hours / 24)}d ago`;
-}
 
 /** Human duration between started/finished, or null when a run never finished. */
 function runDuration(run: WorkflowRunRecord): string | null {


### PR DESCRIPTION
Three components each shipped their own `relativeTime` with drifting thresholds and output:

- `recent-activity-rollup.tsx` — `"now" / "5m" / "3h" / "2d"` (no "ago")
- `retro-runs-view.tsx` — `"5s ago"`, hours up to 48h, `"never" / "unknown"` sentinels
- `workflows/workflow-runs-panel.tsx` — `"just now" / "5m ago"`, no week→date cutoff

All three now use the shared `src/lib/relative-time.ts` (`just now / 5m ago / 3h ago / 1d ago / Jun 12`), already the standard on the dashboard, projects, and journal. Retro keeps its `"never"` fallback via a thin `lastRunLabel` wrapper so empty last-run cells stay meaningful.

tsc clean, full `test:app` (323 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)