### PR TITLE
refactor(settings): reorder the Appearance tab into a logical flow

### DIFF
--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -955,47 +955,6 @@ function AppearanceSection() {
         </div>
       </SettingsGroup>
 
-      {/* Text size lives in the Typography block (<FontSettings />) below. */}
-
-      {/* ── Corner radius ── one control drives the shared --radius tokens, so
-          buttons, inputs, cards, and the familiar pill all round together. */}
-      <SettingsGroup label="Corners">
-        <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2 px-4 py-3">
-          <div className="min-w-0">
-            <div className="text-[12px] font-medium text-[var(--text-secondary)]">
-              Corner radius
-            </div>
-            <div className="text-[11px] text-[var(--text-muted)]">
-              Roundedness of buttons, cards, and the familiar switcher.
-            </div>
-          </div>
-          <div
-            role="group"
-            aria-label="Corner radius"
-            className="flex w-fit shrink-0 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-base)] p-0.5"
-          >
-            {CORNER_RADIUS_OPTIONS.map((option) => {
-              const active = cornerRadius === option;
-              return (
-                <button
-                  key={option}
-                  type="button"
-                  aria-pressed={active}
-                  onClick={() => handleSetCornerRadius(option)}
-                  className={`focus-ring rounded-md px-2.5 py-1.5 text-[11px] font-medium transition-colors ${
-                    active
-                      ? "bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
-                      : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
-                  }`}
-                >
-                  {CORNER_RADIUS_LABELS[option]}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      </SettingsGroup>
-
       {/* ── Preset themes ── */}
       <SettingsGroup label="Theme">
         {/* Custom theme chip */}
@@ -1130,6 +1089,45 @@ function AppearanceSection() {
       </SettingsGroup>
 
       <FontSettings />
+
+      {/* ── Corner radius ── a minor shape tweak (drives the shared --radius
+          tokens), kept last so the primary color/theme and text controls lead. */}
+      <SettingsGroup label="Corners">
+        <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2 px-4 py-3">
+          <div className="min-w-0">
+            <div className="text-[12px] font-medium text-[var(--text-secondary)]">
+              Corner radius
+            </div>
+            <div className="text-[11px] text-[var(--text-muted)]">
+              Roundedness of buttons, cards, and the familiar switcher.
+            </div>
+          </div>
+          <div
+            role="group"
+            aria-label="Corner radius"
+            className="flex w-fit shrink-0 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-base)] p-0.5"
+          >
+            {CORNER_RADIUS_OPTIONS.map((option) => {
+              const active = cornerRadius === option;
+              return (
+                <button
+                  key={option}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => handleSetCornerRadius(option)}
+                  className={`focus-ring rounded-md px-2.5 py-1.5 text-[11px] font-medium transition-colors ${
+                    active
+                      ? "bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
+                      : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+                  }`}
+                >
+                  {CORNER_RADIUS_LABELS[option]}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </SettingsGroup>
     </SettingsPage>
   );
 }


### PR DESCRIPTION
The Appearance tab is already grouped (Mode / Theme / Import + the Typography / Reading / Date & time blocks), but **Corners** — a minor shape tweak — sat *second*, above the headline Theme grid, pushing the primary control down the page.

## Change
Move the **Corners** group to the end so the tab clusters logically:
**color/theme** (Mode, Theme, Import) → **text** (Typography, Reading, Date & time) → **shape** (Corners).

One-file JSX reorder; no control behavior changes. (The deeper consistency pass — unifying the FontSettings `h3`/`h4` sub-sections with the boxed `SettingsGroup` style used by Mode/Theme — is a larger, riskier follow-up left for a separate change.)

## Verification
- `pnpm build` clean; no test pins the section order.
- Live-screenshotted before/after: section order is now `Mode → Theme → Import → Typography → Reading text → Date & time → Corners`. Theme grid is prominent near the top; Corners is tucked last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)