### PR TITLE
refactor(time): standardize the remaining relative-time formats

### DIFF
--- a/src/components/eval-loop-panel.tsx
+++ b/src/components/eval-loop-panel.tsx
@@ -15,6 +15,9 @@
 import { useEffect, useState } from "react";
 import { Icon } from "@/lib/icon";
 import type { IconName } from "@/lib/icon";
+// Shared relative-time formatter, imported as `age` so the call sites read the
+// same — standardizes this surface on the app-wide "2m ago / 3h ago / Jun 12" style.
+import { relativeTime as age } from "@/lib/relative-time";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -49,17 +52,6 @@ type Props = {
 };
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
-
-function age(iso: string): string {
-  const ms = Math.abs(Date.now() - new Date(iso).getTime());
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return s + "s ago";
-  const m = Math.floor(s / 60);
-  if (m < 60) return m + "m ago";
-  const h = Math.floor(m / 60);
-  if (h < 48) return h + "h ago";
-  return Math.floor(h / 24) + "d ago";
-}
 
 function deltaColor(delta: number): string {
   if (delta > 0) return "text-[var(--color-success)]";

--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -2,6 +2,9 @@
 
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
+// Shared relative-time formatter, imported as `age` so the call sites read the
+// same — standardizes this surface on the app-wide "2m ago / 3h ago / Jun 12" style.
+import { relativeTime as age } from "@/lib/relative-time";
 import type { Familiar } from "@/lib/types";
 import type { CovenMemoryEntry } from "@/components/familiars-view-stats";
 import { MarkdownBlock } from "@/components/message-bubble";
@@ -59,18 +62,6 @@ type CovenMemoryResponse =
 type FileMemoryResponse =
   | { ok: true; entries: FileMemoryEntry[] }
   | { ok: false; entries?: FileMemoryEntry[]; error?: string };
-
-function age(iso: string | undefined): string {
-  if (!iso) return "";
-  const ms = Date.now() - new Date(iso).getTime();
-  if (!Number.isFinite(ms)) return "";
-  if (ms < 60_000) return "just now";
-  const m = Math.floor(ms / 60_000);
-  if (m < 60) return `${m}m ago`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
-  return `${Math.floor(h / 24)}d ago`;
-}
 
 function compactPath(path: string): string {
   const collapsed = path.replace(/^\/Users\/[^/]+/, "~");

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -2,6 +2,9 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
+// Shared relative-time formatter, imported as `age` so the call sites read the
+// same — standardizes this surface on the app-wide "2m ago / 3h ago / Jun 12" style.
+import { relativeTime as age } from "@/lib/relative-time";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { FamiliarsMemoryView, MemoryFilesList } from "@/components/familiars-memory-view";
@@ -38,18 +41,6 @@ type AgentsViewProps = {
   onOpenMemoryFile: (path: string) => void;
   onOpenOnboarding: () => void;
 };
-
-function age(iso: string | null | undefined): string {
-  if (!iso) return "";
-  const ms = Date.now() - new Date(iso).getTime();
-  if (!Number.isFinite(ms)) return "";
-  if (ms < 60_000) return "just now";
-  const m = Math.floor(ms / 60_000);
-  if (m < 60) return `${m}m ago`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
-  return `${Math.floor(h / 24)}d ago`;
-}
 
 function familiarMatches(familiar: Familiar, query: string): boolean {
   if (!query) return true;


### PR DESCRIPTION
Finishes the relative-time standardization started by #1085. Per the audit, the formatters were split across surfaces with subtly different output; this points the stragglers at the shared `relativeTime`.

## Change
`familiars-view`, `familiars-memory-view`, and `eval-loop-panel` each had a local `age()` with its own format (eval-loop kept seconds-precision; none of the three fell back to a short date for items older than a week). They now `import { relativeTime as age } from "@/lib/relative-time"`, so they render the app-wide **"2m ago / 3h ago / 1d ago / Jun 12"** style — zero call-site churn, the local copies deleted.

(`recent-activity-rollup`, `workflow-runs-panel`, and `retro-runs-view` were already migrated to the shared helper on main.)

## Intentionally left distinct
- **chat-list `age`** — verbose + always-relative *because* it's paired with an absolute date in the same row; the shared form returns a date past a week, which would print the date twice.
- **inspector-pane `age`** — returns a *bare* duration ("5m") that call sites wrap as "fired 5m ago" / "in 5m"; the shared "5m ago" would double the suffix.

## Verification
- `pnpm build` clean; `familiars-view`, `eval-loop-panel`, and the familiars-memory suites pass (none assert time strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)