### PR TITLE
fix(sidebar): make the New chat CTA high-contrast

### DIFF
--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -122,17 +122,23 @@
   color: var(--text-primary);
 }
 
-/* "New chat" is the top CTA — give it a subtle pill feel */
-.sidebar-actions:first-child .sidebar-action-row {
-  background: var(--bg-raised);
-  color: var(--text-secondary);
-  border: 1px solid var(--border-hairline);
+/* "New chat" is the top CTA — make it the highest-contrast action in the
+   panel with a solid accent fill so it reads as the primary thing to do. */
+.sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row {
+  background: var(--accent-presence);
+  color: #fff;
+  border: 1px solid transparent;
+  font-weight: 600;
 }
 
-.sidebar-actions:first-child .sidebar-action-row:hover {
-  background: var(--bg-elevated);
-  color: var(--text-primary);
-  border-color: var(--border-strong);
+.sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row:hover {
+  background: color-mix(in oklch, var(--accent-presence) 88%, #000);
+  color: #fff;
+  border-color: transparent;
+}
+
+.sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row .sidebar-action-icon {
+  opacity: 1;
 }
 
 .sidebar-action-icon {


### PR DESCRIPTION
## What

The **New chat** CTA at the top of the left sidebar now renders as a solid accent-colored pill (white semibold text, full-opacity icon) instead of a plain transparent row.

## Why

The CTA styling was scoped to `.sidebar-actions:first-child`, but `.sidebar-header` (the wordmark) is the nav's actual first child — so the selector matched nothing and the button silently rendered with no background, indistinguishable from the nav items below it.

## Change

- Re-scope the rule to `.sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row` (the top actions block is the only live `.sidebar-actions`; the footer keeps its plain rows).
- Solid `--accent-presence` fill, `#fff` semibold label, full-opacity icon; hover darkens the accent.

## Verification

- Built and ran the app (web build, demo mode) — confirmed via screenshot the button is now a high-contrast accent pill and footer rows are unchanged.
- `pnpm test:app` — ✓ 323 test file(s) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)