### PR TITLE
feat(sidebar): move Library into Tools, drop the lone Knowledge section

### DIFF
--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -33,10 +33,12 @@ assert.match(
   'Sidebar Work section must filter on group === "work"',
 );
 
-assert.match(
+// The standalone Knowledge section is gone — Library folded into Tools, so the
+// sidebar renders just Work and Tools (no group === "knowledge" filter remains).
+assert.doesNotMatch(
   source,
-  /fm\.group === "knowledge"/,
-  'Sidebar Knowledge section must filter on group === "knowledge"',
+  /"knowledge"/,
+  "Knowledge section removed — Library now lives in Tools",
 );
 
 assert.match(
@@ -98,24 +100,17 @@ assert.match(
 
 assert.match(
   source,
-  /\{ id: "library", label: "Library"/,
-  "Library remains the sole Knowledge surface",
+  /\{ id: "library", label: "Library", iconName: "ph:books", group: "tools", kbd: "⌘6", description:/,
+  "Library is now a Tools surface keeping its ⌘6 shortcut",
 );
 
 // Library is a gated add-on (default off): the nav filter hides it until the
-// add-on is enabled, mirroring GitHub. Without the gate the Knowledge section
-// would always render Library.
+// add-on is enabled, mirroring GitHub. Tools always has non-gated surfaces
+// (Browser/Terminal/Code/Roles/Workflows), so it never renders an empty header.
 assert.match(
   source,
   /if \(fm\.id === "library"\) return addons\?\.library === true;/,
   "Library nav entry is gated on the library add-on",
-);
-
-// The Knowledge section must not render an empty header when Library is hidden.
-assert.match(
-  source,
-  /knowledgeModes\.length > 0 \? \(/,
-  "Knowledge section only renders when it has visible surfaces",
 );
 
 assert.match(

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -7,8 +7,7 @@
  *   1. Familiar scope selector + New chat CTA
  *   2. App destinations grouped by purpose:
  *      Work  (Home / Familiars / Board / Calendar / Schedules)
- *      Knowledge (Library)
- *      Tools (Browser / Terminal / Code / Roles / Workflows / GitHub)
+ *      Tools (Browser / Terminal / Code / Library / Roles / Workflows / GitHub)
  *   3. Footer: Notifications, mobile handoff, Settings
  */
 
@@ -70,7 +69,7 @@ const FOLDER_MODES: Array<{
   label: string;
   iconName: Parameters<typeof Icon>[0]["name"];
   badge?: (props: SidebarMinimalProps) => string | undefined;
-  group: "work" | "knowledge" | "tools" | "addons";
+  group: "work" | "tools" | "addons";
   kbd?: string;
   // One-line hover/long-press help. Differentiates the surfaces that read
   // alike at a glance — especially Roles (who) vs Workflows (steps).
@@ -83,12 +82,11 @@ const FOLDER_MODES: Array<{
   { id: "journal", label: "Journal", iconName: "ph:book-open", group: "work", description: "Your daily journal and generated sketches" },
   { id: "calendar", label: "Calendar", iconName: "ph:calendar-blank", group: "work", kbd: "⌘4", description: "Schedule and timeline of work" },
   { id: "inbox", label: "Schedules", iconName: "ph:calendar-bold", group: "work", kbd: "⌘5", description: "Reminders and recurring agent automations" },
-  // Knowledge
-  { id: "library", label: "Library", iconName: "ph:books", group: "knowledge", kbd: "⌘6", description: "Saved docs, links, and reading" },
   // Tools
   { id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘7", description: "Built-in web browser" },
   { id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools", kbd: "⌘8", description: "Shell session in your project" },
   { id: "code", label: "Code", iconName: "ph:code", group: "tools", kbd: "⌘0", description: "Chat with a familiar beside your files and terminal" },
+  { id: "library", label: "Library", iconName: "ph:books", group: "tools", kbd: "⌘6", description: "Saved docs, links, and reading" },
   { id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools", description: "Agent personas, workflows, skills, and the capabilities your familiars can use" },
   { id: "workflows", label: "Workflows", iconName: "ph:git-branch-bold", group: "tools", description: "Multi-step pipelines that orchestrate familiars" },
   // Add-ons (gated)
@@ -221,7 +219,6 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
   });
 
   const workModes = visibleFolderModes.filter((fm) => fm.group === "work");
-  const knowledgeModes = visibleFolderModes.filter((fm) => fm.group === "knowledge");
   const toolsModes = visibleFolderModes.filter((fm) => fm.group === "tools" || fm.group === "addons");
 
   return (
@@ -259,24 +256,6 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
             />
           ))}
         </SidebarSection>
-
-        {knowledgeModes.length > 0 ? (
-          <SidebarSection label="Knowledge">
-            {knowledgeModes.map((fm) => (
-              <FolderRow
-                key={fm.id}
-                id={fm.id}
-                label={fm.label}
-                iconName={fm.iconName}
-                active={mode === fm.id}
-                badge={fm.badge?.(props)}
-                kbd={fm.kbd}
-                description={fm.description}
-                onClick={() => handleModeSelect(fm.id)}
-              />
-            ))}
-          </SidebarSection>
-        ) : null}
 
         <SidebarSection label="Tools">
           {toolsModes.map((fm) => (


### PR DESCRIPTION
## What

The left side panel had three nav groups — **Work**, **Knowledge**, and **Tools** — where **Knowledge** held a single gated entry: Library. This folds Library into **Tools** (placed right after Code, keeping its ⌘6 shortcut and gated add-on behavior) and removes the now-empty Knowledge section.

Result: two clean nav groups, **Work** and **Tools**.

Tools section is now: Browser · Terminal · Code · Library · Roles · Workflows · GitHub.

## Why

A section with one gated item reads as visual noise — it renders an extra header for a row that's hidden by default. Library is a utility surface, so Tools is its natural home.

## Notes

- Library stays a gated add-on (hidden until enabled in Settings → Add-ons), unchanged.
- Removed the `"knowledge"` group from the `FolderMode` union and the `knowledgeModes` filter / Knowledge `<SidebarSection>`.
- Updated the source-text assertions in `sidebar-minimal.test.ts` to match (Library now asserted as a Tools surface; Knowledge-section assertions removed).
- Full `test:app` suite green (323 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)