### PR TITLE
feat(chat-list): show a model chip on each session row

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -294,6 +294,7 @@ export const SUITES = {
     "src/lib/reading-dropcap.test.ts",
     "src/lib/datetime-format.test.ts",
     "src/lib/relative-time.test.ts",
+    "src/lib/model-label.test.ts",
     "src/lib/appearance-corner-radius.test.ts",
     "src/lib/code-layout-preset.test.ts",
     "src/lib/use-changes-summary.test.ts",

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -4,6 +4,7 @@ import { Fragment, useMemo, useState, useEffect, useRef, type CSSProperties, typ
 import type { Familiar, SessionRow } from "@/lib/types";
 import { stripLeadingTrailingEmoji } from "@/lib/cave-chat-titles";
 import { Icon } from "@/lib/icon";
+import { modelIcon, modelLabel } from "@/lib/model-label";
 import { useKeySymbols } from "@/lib/platform-keys";
 import { useIsMobile } from "@/lib/use-viewport";
 import { OriginChip } from "@/components/ui/origin-chip";
@@ -917,6 +918,15 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                                 </span>
                                 {s.origin ? <OriginChip origin={s.origin} /> : null}
                                 <SessionInitiatorChip initiator={s.initiator} />
+                                {s.model ? (
+                                  <span
+                                    className="chat-list-row-model inline-flex shrink-0 items-center gap-0.5 rounded-[4px] bg-[var(--bg-raised)]/70 px-1 py-px text-[10px] font-medium text-[var(--text-muted)]"
+                                    title={`Model: ${s.model}`}
+                                  >
+                                    <Icon name={modelIcon(s.model)} width={10} aria-hidden />
+                                    <span className="truncate">{modelLabel(s.model)}</span>
+                                  </span>
+                                ) : null}
                               </span>
                               <span className="chat-list-row-time flex shrink-0 items-baseline gap-1 text-[11px] text-[var(--text-muted)]">
                                 <span>{chatDate(s.updated_at)}</span>

--- a/src/components/recent-activity-rollup.tsx
+++ b/src/components/recent-activity-rollup.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Icon, type IconName } from "@/lib/icon";
+import { Icon } from "@/lib/icon";
 import { relativeTime } from "@/lib/relative-time";
+import { modelIcon } from "@/lib/model-label";
 import type { SessionRow } from "@/lib/types";
 
 /**
@@ -23,13 +24,6 @@ function projectLabel(root: string | undefined): string {
   if (!root) return "";
   const parts = root.replace(/\/+$/, "").split("/");
   return parts[parts.length - 1] || root;
-}
-
-function modelIcon(model: string | null | undefined): IconName {
-  const m = (model ?? "").toLowerCase();
-  if (m.includes("gpt") || m.includes("openai") || m.includes("codex")) return "ph:robot";
-  if (m.includes("claude") || m.includes("opus") || m.includes("sonnet") || m.includes("haiku")) return "ph:sparkle";
-  return "ph:cube-bold";
 }
 
 type Props = {

--- a/src/lib/model-label.test.ts
+++ b/src/lib/model-label.test.ts
@@ -1,0 +1,22 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { modelLabel, modelIcon } from "./model-label.ts";
+
+// ── modelLabel ──
+assert.equal(modelLabel("claude-opus-4-8"), "Opus 4.8", "Claude family + version");
+assert.equal(modelLabel("claude-opus-4-8[1m]"), "Opus 4.8", "bracket suffix is ignored");
+assert.equal(modelLabel("claude-sonnet-4-6"), "Sonnet 4.6", "Sonnet family");
+assert.equal(modelLabel("claude-haiku-4-5-20251001"), "Haiku 4.5", "build date is ignored");
+assert.equal(modelLabel("claude-fable-5"), "Fable 5", "Fable family");
+assert.equal(modelLabel("gpt-5-codex"), "Codex", "codex wins over gpt");
+assert.equal(modelLabel("gpt-5"), "GPT-5", "GPT family + version");
+assert.equal(modelLabel("anthropic/some-future-model"), "some-future-model", "provider prefix dropped");
+assert.equal(modelLabel(""), "", "empty input yields empty label");
+assert.equal(modelLabel(null), "", "null input yields empty label");
+
+// ── modelIcon ──
+assert.equal(modelIcon("claude-opus-4-8"), "ph:sparkle", "Claude → sparkle");
+assert.equal(modelIcon("gpt-5-codex"), "ph:robot", "GPT/Codex → robot");
+assert.equal(modelIcon("mystery-model"), "ph:cube-bold", "unknown → cube");
+
+console.log("model-label.test.ts: ok");

--- a/src/lib/model-label.ts
+++ b/src/lib/model-label.ts
@@ -1,0 +1,38 @@
+// Shared, glanceable model presentation used by session lists and roll-ups.
+// `modelLabel` turns a raw model id ("claude-opus-4-8[1m]", "gpt-5-codex") into
+// a short human label ("Opus 4.8", "Codex"); `modelIcon` picks a family glyph.
+// Pure and client-safe (no `node:` imports) so every surface can share it.
+
+import type { IconName } from "@/lib/icon";
+
+const FAMILIES = ["opus", "sonnet", "haiku", "fable"] as const;
+
+function capitalize(word: string): string {
+  return word ? word.charAt(0).toUpperCase() + word.slice(1) : word;
+}
+
+/** A short, human-friendly label for a model id. Returns "" for empty input. */
+export function modelLabel(model: string | null | undefined): string {
+  const raw = (model ?? "").trim();
+  if (!raw) return "";
+  const lower = raw.toLowerCase();
+  // First version-ish token, e.g. "4-8" / "4.8" → "4.8" (ignores a trailing
+  // build date like "-20251001" because the first match wins).
+  const version = (lower.match(/\d+(?:[.\-]\d+)?/)?.[0] ?? "").replace("-", ".");
+  for (const family of FAMILIES) {
+    if (lower.includes(family)) return version ? `${capitalize(family)} ${version}` : capitalize(family);
+  }
+  if (lower.includes("codex")) return "Codex";
+  if (lower.includes("gpt")) return version ? `GPT-${version}` : "GPT";
+  // Unknown model: drop a provider prefix ("anthropic/…") and a bracket suffix
+  // ("…[1m]") so the raw id at least reads cleanly.
+  return raw.replace(/^[a-z0-9.]+\//i, "").replace(/\s*\[[^\]]*\]\s*$/, "");
+}
+
+/** A family glyph for a model id (sparkle for Claude, robot for GPT/Codex). */
+export function modelIcon(model: string | null | undefined): IconName {
+  const m = (model ?? "").toLowerCase();
+  if (m.includes("gpt") || m.includes("openai") || m.includes("codex")) return "ph:robot";
+  if (m.includes("claude") || FAMILIES.some((f) => m.includes(f))) return "ph:sparkle";
+  return "ph:cube-bold";
+}


### PR DESCRIPTION
Adds a glanceable **model chip** to each session row in the chat rail, so you can tell which model a session ran on without opening it.

- New shared `src/lib/model-label.ts`: `modelLabel` turns a raw id (`claude-opus-4-8[1m]`, `gpt-5-codex`) into a short label (**"Opus 4.8"**, **"Codex"**); `modelIcon` picks a family glyph (sparkle / robot / cube).
- `recent-activity-rollup.tsx` now imports the shared `modelIcon` instead of its own copy — same dedup spirit as the recent relative-time unification.
- `chat-list.tsx` renders the chip in each row's meta line (only when `model` is set), with the full id in the tooltip.

Scope note: a per-row **message count** was part of the original pitch but isn't carried on `SessionRow`, so it's left out rather than bolted on with a half-measure.

New `model-label.test.ts` (wired into the app suite), tsc clean, full `test:app` (324 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)