### PR TITLE
feat(sessions): clean up noisy session titles

### DIFF
--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment, useMemo, useState, useEffect, useRef, type CSSProperties, type ReactNode } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
-import { stripLeadingTrailingEmoji } from "@/lib/cave-chat-titles";
+import { stripLeadingTrailingEmoji, disambiguateSessionTitles } from "@/lib/cave-chat-titles";
 import { Icon } from "@/lib/icon";
 import { useKeySymbols } from "@/lib/platform-keys";
 import { useIsMobile } from "@/lib/use-viewport";
@@ -821,6 +821,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               // the desktop rail. firstPinnedIdx/firstRestIdx place each header
               // before its first member, so it reads right regardless of order.
               const pinnedFlags = rows.map((r) => isSessionPinned(pinnedIds, r.id));
+              const sessionTitles = disambiguateSessionTitles(rows);
               const pinnedCount = pinnedFlags.filter(Boolean).length;
               const restCount = rows.length - pinnedCount;
               const firstPinnedIdx = pinnedFlags.indexOf(true);
@@ -943,7 +944,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                                   ? "text-white"
                                   : "text-[var(--text-primary)]",
                               ].join(" ")}>
-                                {stripLeadingTrailingEmoji(s.title || "(untitled chat)")}
+                                {stripLeadingTrailingEmoji((sessionTitles.get(s.id) ?? s.title) || "(untitled chat)")}
                               </span>
                             </span>
 

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -7,7 +7,7 @@ import { relativeTime } from "@/lib/relative-time";
 import type { CaveProject } from "@/lib/cave-projects-types";
 import { normalizeProjectRoot } from "@/lib/cave-projects-types";
 import type { SessionRow } from "@/lib/types";
-import { stripLeadingTrailingEmoji } from "@/lib/cave-chat-titles";
+import { stripLeadingTrailingEmoji, disambiguateSessionTitles } from "@/lib/cave-chat-titles";
 import {
   applyManualOrder,
   mergeVisibleOrder,
@@ -77,10 +77,12 @@ function shortRoot(p: string): string {
 // deletes the chat with a two-step confirm, mirroring the Chats list.
 function ProjectChatRow({
   session,
+  displayTitle,
   onOpen,
   onDelete,
 }: {
   session: SessionRow;
+  displayTitle?: string;
   onOpen: () => void;
   onDelete: (id: string) => Promise<void>;
 }) {
@@ -88,7 +90,7 @@ function ProjectChatRow({
     id: session.id,
   });
   const style: CSSProperties = { transform: CSS.Translate.toString(transform), transition };
-  const title = stripLeadingTrailingEmoji(session.title || "(untitled chat)");
+  const title = stripLeadingTrailingEmoji(displayTitle ?? (session.title || "(untitled chat)"));
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
   return (
@@ -215,6 +217,7 @@ function ProjectRow({
     projectStatus === "running" ? ", a session is running" : projectStatus === "failed" ? ", last session failed" : "";
   const [showAllChats, setShowAllChats] = useState(false);
   const visibleChats = showAllChats ? chats : chats.slice(0, CHAT_CAP);
+  const chatTitles = useMemo(() => disambiguateSessionTitles(chats), [chats]);
   const { setNodeRef: setDropRef, isOver } = useDroppable({
     id: `pcard:${normalizeProjectRoot(project.root)}`,
   });
@@ -456,6 +459,7 @@ function ProjectRow({
                 <ProjectChatRow
                   key={session.id}
                   session={session}
+                  displayTitle={chatTitles.get(session.id)}
                   onOpen={() => onOpenSession?.(session.id)}
                   onDelete={onDeleteSession}
                 />

--- a/src/lib/cave-chat-titles.test.ts
+++ b/src/lib/cave-chat-titles.test.ts
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import {
   defaultChatTitleForSession,
+  disambiguateSessionTitles,
   mergeSessionTitleOverrides,
   normalizeChatTitle,
 } from "./cave-chat-titles.ts";
@@ -15,8 +16,9 @@ assert.equal(normalizeChatTitle("  Renamed chat  "), "Renamed chat");
 assert.equal(normalizeChatTitle("one\n  two\tthree"), "one two three");
 assert.equal(normalizeChatTitle("   "), null);
 assert.equal(normalizeChatTitle("x".repeat(130)), "x".repeat(120));
-assert.equal(defaultChatTitleForSession("session-1234567890"), "New Session 12345678");
-assert.equal(defaultChatTitleForSession(""), "New Session");
+assert.equal(defaultChatTitleForSession("session-1234567890"), "New chat");
+assert.equal(defaultChatTitleForSession(""), "New chat");
+assert.equal(defaultChatTitleForSession(null), "New chat");
 
 assert.deepEqual(
   mergeSessionTitleOverrides(sessions, {
@@ -29,3 +31,31 @@ assert.deepEqual(
     { id: "s2", title: "keep me", updated_at: "2026-06-01T00:00:01.000Z" },
   ],
 );
+
+// disambiguateSessionTitles — collisions get a relative-time suffix; uniques don't.
+{
+  const now = new Date();
+  const iso = (minsAgo) => new Date(now.getTime() - minsAgo * 60000).toISOString();
+  const rows = [
+    { id: "a", title: "New chat", updated_at: iso(5) },
+    { id: "b", title: "New chat", updated_at: iso(120) },
+    { id: "c", title: "Fix the parser bug", updated_at: iso(10) },
+  ];
+  const map = disambiguateSessionTitles(rows);
+  assert.notEqual(map.get("a"), "New chat", "colliding title gets a suffix");
+  assert.notEqual(map.get("b"), "New chat", "the other colliding title gets a suffix");
+  assert.notEqual(map.get("a"), map.get("b"), "the two collisions are now distinct");
+  assert.match(map.get("a"), /^New chat · /, "suffix is appended after the title");
+  assert.equal(map.get("c"), "Fix the parser bug", "a unique title is unchanged");
+}
+// missing updated_at on a collision → no crash, falls back to the bare title.
+{
+  const map = disambiguateSessionTitles([
+    { id: "x", title: "New chat" },
+    { id: "y", title: "New chat" },
+  ]);
+  assert.equal(map.get("x"), "New chat", "no time => no suffix, no crash");
+  assert.equal(map.get("y"), "New chat");
+}
+
+console.log("cave-chat-titles.test.ts ok");

--- a/src/lib/cave-chat-titles.ts
+++ b/src/lib/cave-chat-titles.ts
@@ -1,4 +1,5 @@
 import { COVEN_IDENTITY_CANON_HEADER } from "./coven-identity-canon.ts";
+import { relativeTime } from "./daily-report.ts";
 
 type SessionLike = {
   id: string;
@@ -98,13 +99,14 @@ export function sanitizeSessionTitle(title: string | null | undefined): string |
   return normalized;
 }
 
-export function defaultChatTitleForSession(sessionId: string | null | undefined): string {
-  const normalized = normalizeChatTitle(sessionId);
-  const compactId = (normalized?.replace(/^session[-_:\s]*/i, "") || normalized || "")
-    .replace(/[^a-zA-Z0-9]/g, "")
-    .slice(0, 8);
-  const shortId = compactId || normalized?.slice(0, 8);
-  return shortId ? `New Session ${shortId}` : "New Session";
+/**
+ * Neutral title for an untitled session. We intentionally do NOT encode the
+ * session id (the old "New Session <first-8-of-id>" was pure noise); rows are
+ * disambiguated at display time by `disambiguateSessionTitles`. `sessionId` is
+ * kept in the signature for call-site stability.
+ */
+export function defaultChatTitleForSession(_sessionId?: string | null): string {
+  return "New chat";
 }
 
 export function mergeSessionTitleOverrides<T extends SessionLike>(
@@ -115,4 +117,27 @@ export function mergeSessionTitleOverrides<T extends SessionLike>(
     const title = normalizeChatTitle(titles[session.id]);
     return title ? { ...session, title } : session;
   });
+}
+
+/**
+ * Within one rendered session list, suffix any title shared by 2+ rows with its
+ * relative time so the rows stay distinguishable (two "New chat" or two
+ * "Workflow: Annotate Document" sessions). Titles appearing once are returned
+ * unchanged. Pure — returns a map keyed by row id.
+ */
+export function disambiguateSessionTitles(
+  rows: { id: string; title: string; updated_at?: string | null }[],
+): Map<string, string> {
+  const counts = new Map<string, number>();
+  for (const r of rows) counts.set(r.title, (counts.get(r.title) ?? 0) + 1);
+  const out = new Map<string, string>();
+  for (const r of rows) {
+    if ((counts.get(r.title) ?? 0) > 1) {
+      const when = relativeTime(r.updated_at ?? undefined);
+      out.set(r.id, when ? `${r.title} · ${when}` : r.title);
+    } else {
+      out.set(r.id, r.title);
+    }
+  }
+  return out;
 }

--- a/src/lib/openclaw-conversation.test.ts
+++ b/src/lib/openclaw-conversation.test.ts
@@ -53,7 +53,7 @@ try {
   assert.equal(conv?.sessionId, "session-1");
   assert.equal(conv?.familiarId, "nova");
   assert.equal(conv?.harness, "openclaw");
-  assert.equal(conv?.title, "New Session 1");
+  assert.equal(conv?.title, "New chat");
   assert.deepEqual(
     conv?.turns.map((turn) => [turn.role, turn.text]),
     [


### PR DESCRIPTION
Two display/compute-time fixes for noisy session titles (no migration, no daemon change):

- **Drop the hash.** `defaultChatTitleForSession` returns a plain **"New chat"** instead of `New Session <first-8-of-id>`. The intentional neutral-title-for-fresh-chats behavior is preserved; only the meaningless id suffix is gone. (Complements #1098's prompt-filler cleanup — different code paths.)
- **Disambiguate duplicates.** New pure `disambiguateSessionTitles` suffixes any title shared by 2+ rows in a rendered list with ` · <relative time>` (reusing the unified `relativeTime`), so two `Workflow: Annotate Document` runs — or two `New chat` rows — aren't pixel-identical. Applied in the Projects tab and the Sessions tab.

First-message-derived titles (needs a per-session preview source) are a separate follow-up.

Spec: docs/superpowers/specs/2026-06-20-session-title-hygiene-design.md
🤖 Generated with [Claude Code](https://claude.com/claude-code)