### PR TITLE
feat(canvas): add a Copy button to the sketch Code tab

### DIFF
--- a/src/components/journal/canvas-list.tsx
+++ b/src/components/journal/canvas-list.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { copyText } from "@/lib/clipboard";
 import { isDemoModeEnabled } from "@/lib/demo-mode";
 import { relativeTime } from "@/lib/daily-report";
 import { DEFAULT_REFINE_SUGGESTIONS, generateRefineSuggestions } from "@/lib/refine-suggestions";
@@ -82,6 +83,10 @@ export function CanvasList({
   const composerRef = useRef<HTMLInputElement | null>(null);
   const [editingTitleId, setEditingTitleId] = useState<string | null>(null);
   const [editingTitleDraft, setEditingTitleDraft] = useState("");
+  // Transient "Copied" confirmation for the Code tab's copy button.
+  const [copied, setCopied] = useState(false);
+  const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (copiedTimer.current) clearTimeout(copiedTimer.current); }, []);
 
   // Seed the generate composer from an example prompt and focus it, so the
   // empty-state starters are one tap from a ready-to-run sketch.
@@ -389,6 +394,21 @@ export function CanvasList({
                 </button>
               </div>
               <div className="journal-detail__actions">
+                {view === "code" ? (
+                  <button
+                    type="button"
+                    className={`journal-act${copied ? " journal-act--on" : ""}`}
+                    aria-label={copied ? "Copied" : "Copy code"}
+                    onClick={async () => {
+                      if (!(await copyText(selected.code))) return;
+                      setCopied(true);
+                      if (copiedTimer.current) clearTimeout(copiedTimer.current);
+                      copiedTimer.current = setTimeout(() => setCopied(false), 2000);
+                    }}
+                  >
+                    <Icon name={copied ? "ph:check" : "ph:copy"} aria-hidden /> {copied ? "Copied" : "Copy"}
+                  </button>
+                ) : null}
                 <button
                   type="button"
                   className={`journal-act${refineOpen ? " journal-act--on" : ""}`}

--- a/src/components/journal/journal-view.test.ts
+++ b/src/components/journal/journal-view.test.ts
@@ -39,6 +39,13 @@ assert.doesNotMatch(list, /@xyflow\/react/, "CanvasList does not use React Flow"
 assert.match(list, /editingTitleId,\s*setEditingTitleId/, "CanvasList tracks which canvas item title is being renamed");
 assert.match(list, /aria-label=\{`Rename \$\{a\.title \|\| "Untitled sketch"\}`\}/, "Canvas item rows expose a rename button");
 assert.match(list, /commitRename/, "CanvasList persists renamed canvas item titles");
+
+// The Code tab offers a Copy button (only while the code view is active) that
+// copies the artifact source via the robust clipboard helper.
+assert.match(list, /import \{ copyText \} from "@\/lib\/clipboard"/, "CanvasList imports the clipboard helper");
+assert.match(list, /view === "code" \? \(/, "Copy button is gated to the Code tab");
+assert.match(list, /copyText\(selected\.code\)/, "Copy button copies the selected artifact's code");
+assert.match(list, /name=\{copied \? "ph:check" : "ph:copy"\}/, "Copy button shows a copied confirmation icon");
 assert.match(list, /onKeyDown=\{\(e\) => \{[\s\S]*?e\.key === "Enter"[\s\S]*?commitRename/, "Canvas item rename input commits on Enter");
 assert.match(list, /onKeyDown=\{\(e\) => \{[\s\S]*?e\.key === "Escape"[\s\S]*?cancelRename/, "Canvas item rename input cancels on Escape");
 


### PR DESCRIPTION
## What

The Canvas (Sketch) item's **Code** tab displayed the artifact source with no quick way to grab it. This adds a **Copy** button to the detail action bar, shown only while the Code tab is active (mirroring how Edit is contextual to the code view in the in-chat artifact viewer).

- Copies the artifact source via the shared `copyText` helper — clipboard API with an `execCommand` fallback for Tauri webviews / non-secure contexts.
- Flips to a "Copied" check for 2s, then reverts. Timer is cleaned up on unmount.
- Reuses the existing `journal-act` button styling, so no new CSS.

## Where

`src/components/journal/canvas-list.tsx` — the `journal-detail__actions` bar, gated on `view === "code"`.

## Tests

Added source-text assertions to `journal-view.test.ts` pinning the gated Copy button, the `copyText(selected.code)` call, and the copied-state icon. Full `test:app` green (326 files); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)