### PR TITLE
fix(sidebar): drop the ⌘-number chips, complete the Shortcuts sheet

### DIFF
--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -183,7 +183,11 @@ function FolderRow({
       <Icon name={iconName} width={15} className="sidebar-folder-icon" />
       <span className="sidebar-folder-label">{label}</span>
       {badge && <span className="sidebar-badge">{badge}</span>}
-      {kbd && !badge && <kbd className="sidebar-folder-kbd">{kbd}</kbd>}
+      {/* The ⌘-number shortcut is no longer shown as a chip here: the numbers
+          don't ascend with row position (e.g. ⌘0 Code sits above ⌘6 Library),
+          so a visible column read as scrambled. The binding still works, the
+          hover/title tooltip still names it, and the Shortcuts sheet (⌘/)
+          is the canonical, complete catalog. */}
     </button>
   );
 }

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -38,6 +38,8 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: "⌘\\", description: "Toggle the list panel" },
       { keys: "⌃`", description: "Toggle the integrated terminal (desktop app)" },
       { keys: "⌘1–⌘8", description: "Jump to a sidebar surface (Home … Terminal)" },
+      { keys: "⌘0", description: "Jump to the Code workspace" },
+      { keys: "⌘9", description: "Jump to Projects (Chat surface)" },
       { keys: "⌥1–⌥9", description: "Select the Nth familiar" },
       { keys: "⌘↑ / ⌘↓", description: "Cycle through familiars" },
       { keys: "⌘N", description: "New chat (on the Chat surface)" },
@@ -67,6 +69,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
     id: "other",
     label: "Other",
     entries: [
+      { keys: "⌘,", description: "Open Settings" },
       { keys: "⌘/", description: "Open this shortcuts sheet" },
       { keys: "?", description: "Open the shortcuts sheet (when not typing in a field)" },
       { keys: "Esc", description: "Close dialogs and modals" },

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -905,20 +905,6 @@
   place-items: center;
 }
 
-.sidebar-folder-kbd {
-  margin-left: auto;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  color: var(--text-secondary);
-  opacity: 0.85;
-  letter-spacing: 0.02em;
-}
-
-.sidebar-folder-row:hover .sidebar-folder-kbd {
-  opacity: 1;
-  color: var(--text-primary);
-}
-
 
 @media (max-height: 760px) {
   .sidebar-minimal {


### PR DESCRIPTION
## What

The sidebar no longer shows a ⌘-number chip on each surface row. The keyboard shortcuts are unchanged and still work; the **Shortcuts sheet** (⌘/ or `?`) is now the complete, canonical catalog.

## Why

The chips advertised each surface's ⌘-number, but the numbers don't ascend with row position:

```
WORK                 TOOLS
  Home      ⌘1         Browser   ⌘7
  Familiars ⌘2         Terminal  ⌘8
  Board     ⌘3         Code      ⌘0
  Journal   —          Library   ⌘6   ← 6 after 0
  Calendar  ⌘4         Roles     —
  Schedules ⌘5         Workflows —
```

Tools read 7,8,0,6, which breaks the "⌘N = Nth item" mental model. Renumbering would break muscle memory; reordering nav would disturb the recently-shipped Journal and Library-into-Tools placements. So the scrambled visible column simply goes away.

## Change

- Remove the visible `<kbd>` chip from the sidebar rows and the now-dead `.sidebar-folder-kbd` CSS. Bindings are untouched; the row's hover/title tooltip still names its shortcut.
- Round out the Shortcuts sheet catalog (`keyboard-shortcuts.ts`) with the surface bindings it was missing — **⌘0** Code, **⌘9** Projects, **⌘,** Settings — all already wired in `workspace.tsx`.

## Verification

- Built and ran the app (web build, demo mode):
  - Sidebar renders clean with no ⌘ chips.
  - Shortcuts sheet (opened via ⌘/) lists ⌘1–⌘8, ⌘0 Code, ⌘9 Projects, and ⌘, Settings.
- `pnpm test:app` — ✓ 326 test file(s) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)