### PR TITLE
feat(datetime): route verbose dates through the app-wide date pref

### DIFF
--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -5,7 +5,7 @@ import type { InboxItem } from "@/lib/cave-inbox";
 import type { Familiar } from "@/lib/types";
 import { Icon } from "@/lib/icon";
 import type { IconName } from "@/lib/icon";
-import { formatClock } from "@/lib/datetime-format";
+import { formatClock, formatDate } from "@/lib/datetime-format";
 import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { SnoozeMenu } from "@/components/snooze-menu";
@@ -74,11 +74,7 @@ function fmtTime(iso: string): string {
 }
 
 function fmtDateHeading(d: Date): string {
-  return d.toLocaleDateString(undefined, {
-    weekday: "long",
-    month: "long",
-    day: "numeric",
-  });
+  return formatDate(d, undefined, { weekday: true, month: "long" });
 }
 
 function fmtHourLabel(h: number): string {

--- a/src/components/library-doc-list.tsx
+++ b/src/components/library-doc-list.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Icon } from "@/lib/icon";
+import { formatDate } from "@/lib/datetime-format";
 import type { LibraryCollection, LibraryDoc } from "@/lib/library-types";
 
 type Props = {
@@ -30,7 +31,7 @@ function relDate(iso: string): string {
     if (absDiff < 3_600_000) return relDateFmt.format(Math.round(diff / 60_000), "minutes");
     if (absDiff < 86_400_000) return relDateFmt.format(Math.round(diff / 3_600_000), "hours");
     if (absDiff < 86_400_000 * 30) return relDateFmt.format(Math.round(diff / 86_400_000), "days");
-    return new Date(iso).toLocaleDateString([], { month: "short", day: "numeric" });
+    return formatDate(iso);
   } catch {
     return "";
   }

--- a/src/components/memory-inspector-panel.tsx
+++ b/src/components/memory-inspector-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { formatDate as formatPrefDate } from "@/lib/datetime-format";
 import type { Familiar } from "@/lib/types";
 
 type FailureDistillation = {
@@ -66,7 +67,7 @@ function formatDate(value: string | null): string {
   if (!value) return "missing";
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleDateString([], { month: "short", day: "numeric", year: "numeric" });
+  return formatPrefDate(date, undefined, { year: true });
 }
 
 export function MemoryInspectorPanel({ familiar }: { familiar: Familiar | null }) {

--- a/src/components/settings-fonts.tsx
+++ b/src/components/settings-fonts.tsx
@@ -465,12 +465,13 @@ export function FontSettings() {
           </ReadingRow>
       </SettingsGroup>
 
-      {/* Date & time — the Clock setting applies to every time shown in the app
-          (calendar, capabilities, debug, …); the Date format applies to the chat
-          message timestamp, where model/cwd/duration used to sit (now in debug). */}
+      {/* Date & time — both apply across the app: the Clock to every time shown
+          (calendar, capabilities, debug, …), and the Date ordering to every date
+          (library, memory, calendar, chat). "Off" only hides the date on chat
+          timestamps; elsewhere it falls back to month-first. */}
       <SettingsGroup
         label="Date & time"
-        description="Clock applies across the app; the date format applies to chat message timestamps."
+        description="Clock and date format apply across the app. Off hides the date on chat timestamps."
       >
           <ReadingRow label="Clock" hint="Across the app">
             <div className={segWrap}>
@@ -488,7 +489,7 @@ export function FontSettings() {
               ))}
             </div>
           </ReadingRow>
-          <ReadingRow label="Date" hint="Chat messages">
+          <ReadingRow label="Date" hint="Across the app">
             <div className={segWrap}>
               {DATE_OPTIONS.map((option) => (
                 <button

--- a/src/lib/datetime-format.test.ts
+++ b/src/lib/datetime-format.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_CLOCK,
   DEFAULT_DATE,
   formatClock,
+  formatDate,
   formatTimestamp,
   normalizeClock,
   normalizeDate,
@@ -69,4 +70,26 @@ test("formatClock can include seconds (debug log)", () => {
 
 test("formatClock renders nothing for bad input", () => {
   assert.equal(formatClock("not-a-date", { clock: "24h", date: "off" }), "");
+});
+
+test("formatDate honors the date ORDERING for verbose dates (keeps month name)", () => {
+  const mmdd = { clock: "12h", date: "mmdd" } as const;
+  const ddmm = { clock: "12h", date: "ddmm" } as const;
+  // month-first vs day-first, short month, no year
+  assert.equal(formatDate(ISO, mmdd), "Jun 19");
+  assert.equal(formatDate(ISO, ddmm), "19 Jun");
+  // with year: US "Jun 19, 2026" vs EU "19 Jun 2026"
+  assert.equal(formatDate(ISO, mmdd, { year: true }), "Jun 19, 2026");
+  assert.equal(formatDate(ISO, ddmm, { year: true }), "19 Jun 2026");
+  // the chat-only "off" behaves as month-first for verbose dates (still shows one)
+  assert.equal(formatDate(ISO, { clock: "12h", date: "off" }), "Jun 19");
+});
+
+test("formatDate supports weekday + long month, and accepts a Date", () => {
+  const out = formatDate(new Date(ISO), { clock: "12h", date: "mmdd" }, { weekday: true, month: "long" });
+  assert.match(out, /^[A-Za-z]+, June 19$/, `expected "Weekday, June 19", got "${out}"`);
+});
+
+test("formatDate renders nothing for bad input", () => {
+  assert.equal(formatDate("not-a-date", { clock: "12h", date: "mmdd" }), "");
 });

--- a/src/lib/datetime-format.ts
+++ b/src/lib/datetime-format.ts
@@ -180,3 +180,31 @@ export function formatTimestamp(iso: string, prefs: DateTimePrefs = DEFAULT_PREF
   const datePart = prefs.date === "mmdd" ? `${mm}.${dd}` : prefs.date === "ddmm" ? `${dd}.${mm}` : "";
   return datePart ? `${datePart} ${time}` : time;
 }
+
+/**
+ * Verbose date honoring the date preference's ORDERING (month-first vs
+ * day-first), keeping the month name (+ optional year/weekday) — so non-chat
+ * date displays (library list, memory inspector, calendar header) follow the
+ * user's regional date order without being forced into the compact "06.19"
+ * form. `ddmm` → day-first ("19 Jun" / "19 Jun 2026"); anything else (mmdd, the
+ * chat-only "off") → month-first ("Jun 19" / "Jun 19, 2026"). Accepts an ISO
+ * string, epoch ms, or a Date. Returns "" for unparseable input.
+ */
+export function formatDate(
+  input: string | number | Date,
+  prefs: DateTimePrefs = readDateTimePrefs(),
+  opts: { year?: boolean; weekday?: boolean; month?: "short" | "long" } = {},
+): string {
+  const d = input instanceof Date ? input : new Date(input);
+  if (Number.isNaN(d.getTime())) return "";
+  const dayFirst = prefs.date === "ddmm";
+  const month = d.toLocaleDateString([], { month: opts.month ?? "short" });
+  const day = d.getDate();
+  const dm = dayFirst ? `${day} ${month}` : `${month} ${day}`;
+  const withYear = opts.year
+    ? dayFirst
+      ? `${dm} ${d.getFullYear()}`
+      : `${dm}, ${d.getFullYear()}`
+    : dm;
+  return opts.weekday ? `${d.toLocaleDateString([], { weekday: "long" })}, ${withYear}` : withYear;
+}


### PR DESCRIPTION
## What

Extends the Settings → Fonts **Date** preference (month-first vs day-first) beyond chat timestamps to the three surfaces that show a verbose, written-out date:

- **Calendar** day heading (e.g. *Friday, June 20* ↔ *Friday, 20 June*)
- **Library** doc list — the "last modified" fallback once a doc is older than ~30 days
- **Memory inspector** — the tier's "last modified" date (keeps the year)

All three now call a new `formatDate(input, prefs?, opts?)` in `src/lib/datetime-format.ts` that honors the date ordering and optionally adds the year / weekday / long month name. `formatClock` (time-only) and `formatTimestamp` (chat) are unchanged.

## Why

The date-format pref previously only affected chat timestamps. A user who sets day-first ordering still saw `June 20` in the calendar and library. This makes the pref genuinely app-wide.

## Tests

- `datetime-format.test.ts` — 12 pass, including new `formatDate` cases: month-first vs day-first, with/without year, weekday + long month, and bad-input → `""`.
- Full `pnpm build` green.
- Routing verified: no remaining `toLocaleDateString` date assembly at the three call sites; all go through `formatDate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)