### PR TITLE
feat(library): unify empty/loading/error states across the 4 list tabs

### DIFF
--- a/src/components/library-bookmarks-list.tsx
+++ b/src/components/library-bookmarks-list.tsx
@@ -6,6 +6,10 @@ import { Popover, PopoverBody, PopoverItem, PopoverLabel } from "@/components/ui
 import { Icon, type IconName } from "@/lib/icon";
 import { useUndoDelete } from "@/lib/use-undo-delete";
 import { LibraryUndoToast } from "@/components/library-undo-toast";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorState } from "@/components/ui/error-state";
+import { SkeletonRows } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import type { LibraryBookmark } from "@/lib/library-types";
 import { useIsCoarsePointer } from "@/lib/use-viewport";
 
@@ -357,27 +361,31 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
 
       {/* Table */}
       {loading ? (
-        <div className="library-list-empty">Loading…</div>
+        <SkeletonRows count={5} className="library-list-skeleton" />
       ) : error ? (
-        <div className="library-list-empty" role="alert">
-          <div className="library-list-error-title">
-            <Icon name="ph:warning-circle" width={13} aria-hidden />
-            Couldn&rsquo;t load bookmarks.
-          </div>
-          <div className="library-list-error-message">{error}</div>
-          <button
-            type="button"
-            onClick={() => { void load(); }}
-            className="library-list-retry-btn"
-          >
-            <Icon name="ph:arrow-clockwise" width={11} />
-            Retry
-          </button>
-        </div>
+        <ErrorState
+          icon="ph:warning-circle"
+          headline={<>Couldn&rsquo;t load bookmarks.</>}
+          subtitle={error}
+          actions={
+            <Button size="xs" leadingIcon="ph:arrow-clockwise" onClick={() => { void load(); }}>
+              Retry
+            </Button>
+          }
+        />
       ) : items.length === 0 ? (
-        <div className="library-list-empty">No bookmarks yet. Add one above.</div>
+        <EmptyState
+          icon="ph:bookmark-simple"
+          headline="No bookmarks yet"
+          subtitle="Save links you want to keep close at hand."
+          actions={
+            <Button size="sm" leadingIcon="ph:plus" onClick={() => setAdding(true)}>
+              Add bookmark
+            </Button>
+          }
+        />
       ) : filtered.length === 0 ? (
-        <div className="library-list-empty">No results for &quot;{query}&quot;.</div>
+        <EmptyState compact icon="ph:magnifying-glass" headline={`No results for “${query}”`} />
       ) : (
         <div className="board-table-wrap">
           <table aria-label="Bookmarks" className="board-table library-bookmarks-table">

--- a/src/components/library-doc-list.tsx
+++ b/src/components/library-doc-list.tsx
@@ -3,6 +3,10 @@
 import { useState } from "react";
 import { Icon } from "@/lib/icon";
 import { formatDate } from "@/lib/datetime-format";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorState } from "@/components/ui/error-state";
+import { SkeletonRows } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import type { LibraryCollection, LibraryDoc } from "@/lib/library-types";
 
 type Props = {
@@ -136,35 +140,30 @@ export function LibraryDocList({
       {/* List */}
       <div className="library-doclist-items">
         {loading ? (
-          <div className="library-doclist-empty">Loading…</div>
+          <SkeletonRows count={5} className="library-doclist-skeleton" />
         ) : error ? (
-          <div className="library-doclist-empty" role="alert">
-            <div className="inline-flex items-center gap-1.5 text-[var(--color-danger)]">
-              <Icon name="ph:warning-circle" width={13} aria-hidden />
-              Couldn&rsquo;t load documents.
-            </div>
-            <div className="mt-1 text-[11px] text-[var(--text-muted)]">{error}</div>
-            {onRetry ? (
-              <button
-                type="button"
-                onClick={onRetry}
-                className="mt-3 inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
-              >
-                <Icon name="ph:arrow-clockwise" width={11} />
-                Retry
-              </button>
-            ) : null}
-          </div>
+          <ErrorState
+            icon="ph:warning-circle"
+            headline={<>Couldn&rsquo;t load documents.</>}
+            subtitle={error}
+            actions={
+              onRetry ? (
+                <Button size="xs" leadingIcon="ph:arrow-clockwise" onClick={onRetry}>
+                  Retry
+                </Button>
+              ) : undefined
+            }
+          />
         ) : filtered.length === 0 ? (
-          <div className="library-doclist-empty">
-            <Icon name="ph:books" width={18} className="mx-auto mb-2 block text-[var(--text-muted)]" aria-hidden />
-            <div className="text-[13px] font-medium text-[var(--text-primary)]">
-              {searchQuery ? "No documents match your search." : "No documents yet."}
-            </div>
-            <p className="mt-1 text-[11px] leading-5 text-[var(--text-muted)]">
-              {searchQuery ? "Try a shorter query or clear the search." : "Documents your familiars collect or you import will appear here."}
-            </p>
-          </div>
+          <EmptyState
+            icon="ph:books"
+            headline={searchQuery ? "No documents match your search." : "No documents yet."}
+            subtitle={
+              searchQuery
+                ? "Try a shorter query or clear the search."
+                : "Documents your familiars collect or you import will appear here."
+            }
+          />
         ) : (
           filtered.map((doc) => {
             const isEditing = editingId === doc.id;

--- a/src/components/library-github-list.tsx
+++ b/src/components/library-github-list.tsx
@@ -5,6 +5,9 @@ import { createPortal } from "react-dom";
 import { Icon } from "@/lib/icon";
 import { useUndoDelete } from "@/lib/use-undo-delete";
 import { LibraryUndoToast } from "@/components/library-undo-toast";
+import { EmptyState } from "@/components/ui/empty-state";
+import { SkeletonRows } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import type { CardGitHubLink, CardStatus } from "@/lib/cave-board-types";
 import type { LibraryGitHubItem, GitHubItemKind } from "@/lib/library-types";
 import {
@@ -708,11 +711,20 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
 
       {/* Table */}
       {loading ? (
-        <div className="library-list-empty">Loading…</div>
+        <SkeletonRows count={5} className="library-list-skeleton" />
       ) : items.length === 0 ? (
-        <div className="library-list-empty">No GitHub items saved yet. Add one above.</div>
+        <EmptyState
+          icon="ph:github-logo"
+          headline="No GitHub items yet"
+          subtitle="Save issues, PRs, and repos to attach to tasks or hand off to familiars."
+          actions={
+            <Button size="sm" leadingIcon="ph:plus" onClick={() => setAdding(true)}>
+              Add GitHub item
+            </Button>
+          }
+        />
       ) : filtered.length === 0 ? (
-        <div className="library-list-empty">No results for &quot;{query}&quot;.</div>
+        <EmptyState compact icon="ph:magnifying-glass" headline={`No results for “${query}”`} />
       ) : (
         <div className="board-table-wrap">
           <table className="board-table library-github-table">

--- a/src/components/library-reading-list.tsx
+++ b/src/components/library-reading-list.tsx
@@ -4,6 +4,10 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import { useUndoDelete } from "@/lib/use-undo-delete";
 import { LibraryUndoToast } from "@/components/library-undo-toast";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorState } from "@/components/ui/error-state";
+import { SkeletonRows } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import type { LibraryReadingItem, ReadingStatus } from "@/lib/library-types";
 import { useIsCoarsePointer } from "@/lib/use-viewport";
 
@@ -333,27 +337,31 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
 
       {/* Table */}
       {loading ? (
-        <div className="library-list-empty">Loading…</div>
+        <SkeletonRows count={5} className="library-list-skeleton" />
       ) : error ? (
-        <div className="library-list-empty" role="alert">
-          <div className="library-list-error-title">
-            <Icon name="ph:warning-circle" width={13} aria-hidden />
-            Couldn&rsquo;t load reading.
-          </div>
-          <div className="library-list-error-message">{error}</div>
-          <button
-            type="button"
-            onClick={() => { void load(); }}
-            className="library-list-retry-btn"
-          >
-            <Icon name="ph:arrow-clockwise" width={11} />
-            Retry
-          </button>
-        </div>
+        <ErrorState
+          icon="ph:warning-circle"
+          headline={<>Couldn&rsquo;t load reading.</>}
+          subtitle={error}
+          actions={
+            <Button size="xs" leadingIcon="ph:arrow-clockwise" onClick={() => { void load(); }}>
+              Retry
+            </Button>
+          }
+        />
       ) : items.length === 0 ? (
-        <div className="library-list-empty">No reading list items yet. Add one above.</div>
+        <EmptyState
+          icon="ph:books"
+          headline="No reading yet"
+          subtitle="Track papers, books, and articles you want to read."
+          actions={
+            <Button size="sm" leadingIcon="ph:plus" onClick={() => setAdding(true)}>
+              Add reading
+            </Button>
+          }
+        />
       ) : filtered.length === 0 ? (
-        <div className="library-list-empty">No results for &quot;{query}&quot;.</div>
+        <EmptyState compact icon="ph:magnifying-glass" headline={`No results for “${query}”`} />
       ) : (
         <div className="board-table-wrap">
           <table aria-label="Reading list" className="board-table library-reading-table">


### PR DESCRIPTION
## What

The Library has four list tabs — **Documents, Reading, Bookmarks, GitHub** — that sit right next to each other, yet each hand-rolled its own empty/loading/error markup: a bespoke "No X yet" div, a bare `Loading…` string, and a custom retry banner. This routes all four through the existing shared primitives:

- **Empty** → `EmptyState` (icon + headline + subtitle). The three editable lists also gain a real **Add …** call-to-action button in place of the old "Add one above." text.
- **Loading** → `SkeletonRows` shimmer instead of a bare `Loading…`.
- **Load failure** → the shared danger `ErrorState` (`role="alert"` + Retry).
- **No search results** → a compact `EmptyState`.

## Why

`ui/empty-state.tsx`, `ui/error-state.tsx`, and `ui/skeleton.tsx` already existed but only three surfaces app-wide used them. The Library tabs were the most visible holdouts — the inconsistency was literally side-by-side. Same unification pattern as the recent relative-time / SettingsGroup / FontSettings consolidations.

## Scope

The 4 Library **list** tabs only. `library-doc-preview` is intentionally left alone — its states are document-viewer semantics ("Unsafe URL blocked", "Could not load PDF"), a different domain.

## Tests / verification

- `surface-error-states.test.ts` and `library-error-retry.test.ts` (both pin doc-list's error headline, empty copy, retry wiring, and `role="alert"` a11y) — **pass**. Behavior preserved: `ErrorState` hardcodes `role="alert"`.
- Full `pnpm build` (test:app + next build) — **green**; `tsc --noEmit` clean.
- Live-verified in the running app (routes mocked empty / failing): Reading, Bookmarks, and GitHub render the new `EmptyState`; Bookmarks renders the new `ErrorState` with Retry. Screenshots confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)