### PR TITLE
feat(chat): per-turn metadata peek without opening the debug pane

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -301,6 +301,30 @@ assert.doesNotMatch(
   "Turn meta should drop per-turn duration — the header MetaLine carries the session duration",
 );
 
+// Per-turn provenance peek: model/cwd/duration aren't shown inline (above), but
+// a quiet ⓘ in the meta row reveals them on hover so older turns are
+// inspectable without opening the debug pane.
+assert.match(
+  source,
+  /function turnMetaPeekTitle\(turn: Turn\): string \| null/,
+  "A turnMetaPeekTitle helper assembles a turn's model · cwd · duration · usage line",
+);
+assert.match(
+  turnRow,
+  /const metaPeek = turn\.pending \? null : turnMetaPeekTitle\(turn\)/,
+  "Settled assistant turns compute a meta peek (skipped while streaming)",
+);
+assert.match(
+  turnRow,
+  /className="cave-turn-peek focus-ring"[\s\S]{0,120}title=\{metaPeek\}/,
+  "The peek renders as a focusable cave-turn-peek affordance with the meta as its title tooltip",
+);
+assert.match(
+  styles,
+  /\.cave-turn-peek\s*\{[\s\S]*?opacity:\s*0\.45/,
+  "The peek is faint by default so the turn meta row stays clean",
+);
+
 assert.doesNotMatch(
   source,
   /\{modKey\}↵ to send/,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -974,6 +974,26 @@ function metaLineSegments(args: {
   return segs;
 }
 
+/** One-line provenance peek for a settled assistant turn — model · cwd ·
+ *  duration · tokens · cost. These are the same facts the header MetaLine shows
+ *  for the LATEST turn, assembled here for an arbitrary turn so they can hang
+ *  off a per-turn hover affordance — older turns become inspectable without a
+ *  trip through the debug pane. Uses the full cwd path (not the truncated
+ *  label) since it lands in a title tooltip. Returns null when the turn carries
+ *  no such metadata (e.g. a bridge harness that emits no usage/runtime). */
+function turnMetaPeekTitle(turn: Turn): string | null {
+  const parts: string[] = [];
+  const model = responseMetadataModel(turn.responseMetadata);
+  if (model) parts.push(model);
+  const runtime = formatRuntime(turn.responseMetadata?.runtime ?? null);
+  if (runtime) parts.push(runtime.title);
+  const dur = fmtDuration(turn.durationMs);
+  if (dur) parts.push(dur);
+  const usage = usageSummary(turn.usage, turn.costUsd);
+  if (usage) parts.push(usage);
+  return parts.length ? parts.join(" · ") : null;
+}
+
 /** In-transcript find bar (CHAT-D9-04). Collapsed: a search icon button in
  *  the meta line. Expanded: query input + `n / m` matching-TURN count +
  *  prev/next/close, styled to extend the meta line without displacing the
@@ -3831,6 +3851,12 @@ function TurnRowImpl({
     renderSegments = split.some((s) => s.kind === "block") ? split : undefined;
   }
 
+  // Per-turn provenance peek (see turnMetaPeekTitle): the model/cwd/duration
+  // that used to sit inline here now live only in the debug pane, so a quiet
+  // hover affordance brings them back for THIS turn on demand. Skipped while
+  // streaming (the header MetaLine already narrates the live turn).
+  const metaPeek = turn.pending ? null : turnMetaPeekTitle(turn);
+
   return (
     <div
       data-turn-id={turn.id}
@@ -3886,6 +3912,17 @@ function TurnRowImpl({
               <span className="opacity-60">{formatTimestamp(turn.createdAt, dtPrefs)}</span>
             ) : null}
             <UsageText usage={turn.usage} costUsd={turn.costUsd} />
+            {metaPeek ? (
+              <span
+                className="cave-turn-peek focus-ring"
+                title={metaPeek}
+                tabIndex={0}
+                role="note"
+                aria-label={`Turn details — ${metaPeek}`}
+              >
+                <Icon name="ph:info" width={11} aria-hidden />
+              </span>
+            ) : null}
             {/* CHAT-D13-01: settled turns hide tool activity by default —
                 this chip is the only way back to it, so it must not be
                 hover-gated. Hidden while streaming (tools are inline then). */}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2536,6 +2536,24 @@ details[open] > .cave-tool-summary::before {
   line-height: 1.4;
 }
 
+/* Per-turn provenance peek: a quiet ⓘ in the turn meta row whose title tooltip
+   reveals model · cwd · duration · tokens · cost for that turn. Faint by
+   default so the row stays clean; brightens on hover/focus. */
+.cave-turn-peek {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-muted);
+  opacity: 0.45;
+  cursor: help;
+  transition: opacity 0.12s ease, color 0.12s ease;
+}
+
+.cave-turn-peek:hover,
+.cave-turn-peek:focus-visible {
+  opacity: 1;
+  color: var(--text-secondary);
+}
+
 .cave-linear-turn-name {
   font-size: 13px;
   font-weight: 600;


### PR DESCRIPTION
## What

Each settled assistant turn now has a quiet **ⓘ** in its meta row. Hovering (or focusing) it shows that turn's **model · cwd · duration · tokens · cost** — without opening the debug pane.

## Why

Per-turn model/cwd/duration were intentionally removed from the inline turn meta row to keep it clean — they only live in the debug pane now. That means checking an older turn's provenance (which model answered? how long did it take? where did it run?) requires opening debug. This adds a lightweight, on-demand peek for the same facts the header MetaLine already shows for the *latest* turn.

## Change

- `turnMetaPeekTitle(turn)` assembles the one-line summary (full cwd path for the tooltip), reusing the existing `responseMetadataModel` / `formatRuntime` / `fmtDuration` / `usageSummary` helpers. Returns null when a turn has no such metadata (e.g. a bridge harness with no usage/runtime).
- A `.cave-turn-peek` affordance: faint (opacity 0.45) so the row stays clean, brightening on hover/focus; focusable with an `aria-label` for keyboard/AT.
- Skipped while streaming (the header MetaLine narrates the live turn). Inline duration/model **text** stays gone — the existing `chat-view-polish` polish assertions still pass; this only adds an on-demand peek.
- New source-text assertions pin the helper, the per-turn affordance, and its faint default.

## Verification

- Live-verified with a mocked conversation: the ⓘ renders on the assistant turn and the tooltip reads `claude-opus-4-8 · ~/…/coven-cave · 7s · 12.4k tok · $0.08`. Only assistant turns get it; user turns don't.
- `pnpm test:app` — ✓ 326 test file(s) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)