### PR TITLE
feat(canvas): expand the in-chat artifact to a real fullscreen overlay

### DIFF
--- a/src/components/chat-artifact-viewer.test.ts
+++ b/src/components/chat-artifact-viewer.test.ts
@@ -17,4 +17,17 @@ assert.match(src, /buildRefinePrompt/, "refine wraps with the refine prompt");
 assert.match(src, /\/api\/canvas/, "save posts to the canvas store");
 assert.match(src, /cave:navigate-mode/, "open-in-canvas navigates to the canvas page");
 
+// Expand-to-fullscreen: a toggle action enters a fullscreen overlay, Escape
+// exits, and — critically — the overlay is PORTALED to document.body so it
+// escapes the chat turn's content-visibility containing block. Without the
+// portal the fixed overlay would be clipped to the turn row and "expand"
+// wouldn't visibly expand.
+assert.match(src, /fullscreen,\s*setFullscreen/, "tracks fullscreen artifact state");
+assert.match(src, /aria-label=\{fullscreen \? "Exit fullscreen" : "Expand artifact fullscreen"\}/, "renders a fullscreen toggle action");
+assert.match(src, /Icon name=\{fullscreen \? "ph:arrows-in-simple" : "ph:arrows-out-simple"\}/, "fullscreen toggle uses expand/collapse icons");
+assert.match(src, /e\.key === "Escape"[\s\S]*?setFullscreen\(false\)/, "Escape exits fullscreen mode");
+assert.match(src, /chat-artifact--fullscreen/, "fullscreen state applies the overlay class");
+assert.match(src, /import \{ createPortal \} from "react-dom"/, "imports createPortal");
+assert.match(src, /createPortal\(shell, document\.body\)/, "fullscreen overlay is portaled to document.body to escape the turn's containing block");
+
 console.log("chat-artifact-viewer source contract: ok");

--- a/src/components/chat-artifact-viewer.tsx
+++ b/src/components/chat-artifact-viewer.tsx
@@ -3,6 +3,7 @@
 import "@/styles/chat-artifact.css";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Icon } from "@/lib/icon";
 import {
   buildPreviewSrcDoc,
@@ -38,6 +39,7 @@ export function ChatArtifactViewer({ initialCode, kind: initialKind, title, fami
   const [refineText, setRefineText] = useState("");
   const [refineOpen, setRefineOpen] = useState(false);
   const [saveState, setSaveState] = useState<SaveState>("idle");
+  const [fullscreen, setFullscreen] = useState(false);
   const frameRef = useRef<HTMLIFrameElement | null>(null);
   const refineRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -67,6 +69,16 @@ export function ChatArtifactViewer({ initialCode, kind: initialKind, title, fami
     window.addEventListener("message", onMessage);
     return () => window.removeEventListener("message", onMessage);
   }, [srcDoc]);
+
+  // Escape exits the expanded (fullscreen) artifact view.
+  useEffect(() => {
+    if (!fullscreen) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setFullscreen(false);
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [fullscreen]);
 
   const copyCode = useCallback(() => {
     void navigator.clipboard?.writeText(code).catch(() => undefined);
@@ -162,8 +174,8 @@ export function ChatArtifactViewer({ initialCode, kind: initialKind, title, fami
     window.dispatchEvent(new Event("cave:board:reload"));
   }, []);
 
-  return (
-    <div className="chat-artifact">
+  const shell = (
+    <div className={`chat-artifact${fullscreen ? " chat-artifact--fullscreen" : ""}`}>
       <div className="chat-artifact__head">
         <span className="chat-artifact__dots" aria-hidden>
           <i style={{ background: "#e0666b" }} />
@@ -200,6 +212,16 @@ export function ChatArtifactViewer({ initialCode, kind: initialKind, title, fami
           ) : null}
           <button type="button" className="chat-artifact__btn" title="Copy code" aria-label="Copy code" onClick={copyCode}>
             <Icon name="ph:copy" width={14} />
+          </button>
+          <button
+            type="button"
+            className={`chat-artifact__btn${fullscreen ? " is-active" : ""}`}
+            title={fullscreen ? "Exit fullscreen" : "Expand fullscreen"}
+            aria-label={fullscreen ? "Exit fullscreen" : "Expand artifact fullscreen"}
+            aria-pressed={fullscreen}
+            onClick={() => setFullscreen((v) => !v)}
+          >
+            <Icon name={fullscreen ? "ph:arrows-in-simple" : "ph:arrows-out-simple"} width={14} />
           </button>
           <button type="button" className="chat-artifact__btn" title="Open in browser" aria-label="Open in browser" onClick={openInBrowser}>
             <Icon name="ph:arrow-square-out" width={14} />
@@ -341,6 +363,16 @@ export function ChatArtifactViewer({ initialCode, kind: initialKind, title, fami
       )}
     </div>
   );
+
+  // When expanded, portal the shell to <body> so it escapes the chat turn's
+  // containing block. The turn row (.cave-linear-turn) uses
+  // `content-visibility: auto`, which implies `contain: layout paint` — that
+  // makes it a containing block for position:fixed descendants, so an inline
+  // `.chat-artifact--fullscreen` overlay would be clipped to the turn's box
+  // instead of filling the viewport. Inline (non-fullscreen) stays in place.
+  return fullscreen && typeof document !== "undefined"
+    ? createPortal(shell, document.body)
+    : shell;
 }
 
 /**

--- a/src/styles/chat-artifact.css
+++ b/src/styles/chat-artifact.css
@@ -7,6 +7,31 @@
   border-radius: 10px;
   overflow: hidden;
 }
+/* Expanded view. The shell is portaled to <body> (see chat-artifact-viewer.tsx)
+   so this fixed overlay positions against the viewport — escaping the chat
+   turn's content-visibility containing block — and fills the screen. */
+.chat-artifact--fullscreen {
+  position: fixed;
+  inset: 14px;
+  z-index: 1200;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+}
+.chat-artifact--fullscreen .chat-artifact__body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+.chat-artifact--fullscreen .chat-artifact__preview-wrap,
+.chat-artifact--fullscreen .chat-artifact__code,
+.chat-artifact--fullscreen .chat-artifact__code-edit {
+  flex: 1;
+  width: 100%;
+  height: auto;
+  min-height: 0;
+}
 .chat-artifact__head {
   display: flex;
   align-items: center;
@@ -37,6 +62,7 @@
   border: 1px solid var(--border-hairline); border-radius: 6px; cursor: pointer; font-size: var(--text-xs);
 }
 .chat-artifact__btn:hover { color: var(--text-primary); }
+.chat-artifact__btn.is-active { color: var(--text-primary); background: var(--bg-raised); box-shadow: inset 0 0 0 1px var(--border-hairline); }
 .chat-artifact__btn:disabled { opacity: 0.55; cursor: default; }
 .chat-artifact__btn--text { padding: 0 10px; color: var(--text-secondary); }
 .chat-artifact__body { position: relative; }


### PR DESCRIPTION
## What

Adds an **Expand** control to the in-chat Canvas artifact viewer (between Copy and Open-in-browser). It maximizes the Canvas/Code panes to a fullscreen overlay; **Escape** or the same button exits.

## The catch — why a naive overlay doesn't actually expand

A `.chat-artifact--fullscreen { position: fixed; inset: 14px }` overlay rendered inline gets **trapped inside the chat turn**. The turn row (`.cave-linear-turn`) uses `content-visibility: auto`, which implies paint/layout containment — and a contained element becomes the **containing block for `position: fixed` descendants**. So the "fullscreen" overlay positions against the turn's box, not the viewport, and barely grows.

**Fix:** portal the shell to `document.body` when expanded (`createPortal(shell, document.body)`), so the fixed overlay escapes the containing block and fills the screen. Inline (non-expanded) rendering is unchanged.

## Verified in a real build

Reproduced the exact nesting with the shipped CSS and an on-screen `content-visibility` turn, then measured the overlay rect (viewport 1440×900):

| case | rect | fills viewport? |
|---|---|---|
| inline (descendant of turn) | `top:15, height:4` — clipped to the turn | ❌ (the bug) |
| portaled to `<body>` | `14,14, 1412×872` = inset-14 fullscreen | ✅ (the fix) |

## Tests

`chat-artifact-viewer.test.ts` pins the toggle, Escape-to-exit, the overlay class, and the `createPortal(shell, document.body)` escape. Full `test:app` green (327 files); `tsc --noEmit` clean.

## Note

This feature was also in-progress as uncommitted local edits in a shared checkout (not on `main`, no open PR). This PR is a clean, self-contained implementation built off `main` in an isolated worktree — it does the containing-block fix that the WIP version was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)