### PR TITLE
feat(familiars): route roster empty states through shared EmptyState

### DIFF
--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -11,6 +11,8 @@ import { FamiliarsMemoryView, MemoryFilesList } from "@/components/familiars-mem
 import type { FileMemoryEntry } from "@/components/familiars-memory-view";
 import { FamiliarDailyNotes } from "@/components/familiar-daily-notes";
 import { Modal } from "@/components/ui/modal";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Button } from "@/components/ui/button";
 import {
   buildFamiliarCardStats,
   type FamiliarCardStats,
@@ -291,21 +293,17 @@ function emptyStats(): FamiliarCardStats {
 
 function FamiliarsEmptyState({ onOpenOnboarding }: { onOpenOnboarding: () => void }) {
   return (
-    <div className="familiars-view__empty mx-auto flex max-w-md flex-col items-center px-6 py-16 text-center">
-      <Icon name="ph:sparkle" width={28} className="text-[var(--accent-presence)]" />
-      <h2 className="mt-3 text-[14px] font-semibold text-[var(--text-primary)]">No familiars yet</h2>
-      <p className="mt-1 text-[12px] text-[var(--text-muted)]">
-        Set up your first familiar to populate the roster.
-      </p>
-      <button
-        type="button"
-        onClick={onOpenOnboarding}
-        className="mt-4 inline-flex h-8 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 text-[12px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)]/80"
-      >
-        <Icon name="ph:plus" width={12} />
-        Set up your first familiar
-      </button>
-    </div>
+    <EmptyState
+      className="familiars-view__empty mx-auto my-16 max-w-md"
+      icon="ph:sparkle"
+      headline="No familiars yet"
+      subtitle="Set up your first familiar to populate the roster."
+      actions={
+        <Button leadingIcon="ph:plus" onClick={onOpenOnboarding}>
+          Set up your first familiar
+        </Button>
+      }
+    />
   );
 }
 
@@ -670,9 +668,12 @@ function FamiliarDetailPanel({
               </span>
             </div>
             {familiarSessions.length === 0 ? (
-              <div className="grid min-h-[120px] place-items-center rounded-lg border border-dashed border-[var(--border-hairline)] text-[12px] text-[var(--text-muted)]">
-                No sessions for this familiar yet.
-              </div>
+              <EmptyState
+                compact
+                icon="ph:chats-circle"
+                headline="No sessions for this familiar yet"
+                subtitle="Sessions started with this familiar will show up here."
+              />
             ) : (
               <ul className="divide-y divide-[var(--border-hairline)] rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/25">
                 {familiarSessions.map((s) => (


### PR DESCRIPTION
## What

The Familiars roster had two hand-rolled empty states:
- the first-run **"No familiars yet"** screen (bespoke Tailwind block + custom button), and
- the per-familiar **"No sessions for this familiar yet"** detail placeholder.

Both now render through the shared `ui/EmptyState` (with `ui/Button` for the onboarding CTA) — same icon badge + headline + subtitle + action idiom as the recent Library empty-state pass (#1110) and the rest of the app.

## Why

Continues the empty-state consistency arc. These were duplicating what `EmptyState` already does; routing them through the primitive removes ~the bespoke markup and keeps the first-run experience visually consistent with every other surface.

## Scope / safety

`familiars-view.tsx` only. Left untouched on purpose:
- the roster card's inline memory micro-copy ("No sessions yet" / "Loading memory…" / "Memory unavailable" / "No memories yet") — these are inline status text, and are source-pinned by `familiar-roster-card.test.ts`.
- `familiars-memory-view`'s empty, which was already unified (its `familiars-memory-view-rail.test.ts` "Task 6: unified rail empty state").

## Tests / verification

- `familiar-roster-card.test.ts` and `familiars-memory-view-rail.test.ts` — pass (my edits don't touch their pinned strings).
- Full `pnpm build` (test:app + next build) green; `tsc --noEmit` clean.
- Live-verified: navigated to the Familiars surface with `/api/familiars` mocked empty — the new "No familiars yet" `EmptyState` renders with its sparkle badge + "Set up your first familiar" CTA. Screenshot confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)