### PR TITLE
refactor(library): unify relative-time across the Library tabs

### DIFF
--- a/src/components/library-bookmarks-list.tsx
+++ b/src/components/library-bookmarks-list.tsx
@@ -10,6 +10,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
+import { relativeTime } from "@/lib/relative-time";
 import type { LibraryBookmark } from "@/lib/library-types";
 import { useIsCoarsePointer } from "@/lib/use-viewport";
 
@@ -24,17 +25,6 @@ const BOOKMARK_GROUP_OPTIONS: Array<{ id: GroupBy; label: string; icon: IconName
   { id: "domain", label: "Group: Domain", icon: "ph:globe" },
   { id: "none", label: "No grouping", icon: "ph:list-bullets" },
 ];
-
-function relTime(iso: string): string {
-  try {
-    const s = (Date.now() - new Date(iso).getTime()) / 1000;
-    if (s < 60) return `${Math.round(s)}s`;
-    if (s < 3600) return `${Math.round(s / 60)}m`;
-    if (s < 86400) return `${Math.round(s / 3600)}h`;
-    const d = Math.round(s / 86400);
-    return d < 30 ? `${d}d` : `${Math.round(d / 30)}mo`;
-  } catch { return ""; }
-}
 
 function sortItems(items: LibraryBookmark[], key: SortKey, dir: SortDir): LibraryBookmark[] {
   return [...items].sort((a, b) => {
@@ -444,7 +434,7 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
                         </span>
                       </td>
                       <td style={{ textAlign: "right" }}>
-                        <span className="board-table-muted">{relTime(item.savedAt)}</span>
+                        <span className="board-table-muted">{relativeTime(item.savedAt)}</span>
                       </td>
                       <td onClick={(e) => e.stopPropagation()}>
                         <span style={{ display: "flex", alignItems: "center", gap: 4 }}>

--- a/src/components/library-doc-list.tsx
+++ b/src/components/library-doc-list.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Icon } from "@/lib/icon";
 import { formatDate } from "@/lib/datetime-format";
+import { relativeTime } from "@/lib/relative-time";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
@@ -25,20 +26,13 @@ type Props = {
   onRetry?: () => void;
 };
 
-const relDateFmt = new Intl.RelativeTimeFormat([], { numeric: "auto" });
-
 function relDate(iso: string): string {
-  try {
-    const diff = new Date(iso).getTime() - Date.now();
-    const absDiff = Math.abs(diff);
-    if (absDiff < 60_000) return "just now";
-    if (absDiff < 3_600_000) return relDateFmt.format(Math.round(diff / 60_000), "minutes");
-    if (absDiff < 86_400_000) return relDateFmt.format(Math.round(diff / 3_600_000), "hours");
-    if (absDiff < 86_400_000 * 30) return relDateFmt.format(Math.round(diff / 86_400_000), "days");
-    return formatDate(iso);
-  } catch {
-    return "";
-  }
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  // Older than a week → date-pref-aware absolute date; recent → the shared
+  // compact relative time so every Library tab reads identically.
+  if (Date.now() - then >= 7 * 86_400_000) return formatDate(iso);
+  return relativeTime(iso);
 }
 
 function filterDocs(docs: LibraryDoc[], query: string): LibraryDoc[] {

--- a/src/components/library-github-list.tsx
+++ b/src/components/library-github-list.tsx
@@ -8,6 +8,7 @@ import { LibraryUndoToast } from "@/components/library-undo-toast";
 import { EmptyState } from "@/components/ui/empty-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
+import { relativeTime } from "@/lib/relative-time";
 import type { CardGitHubLink, CardStatus } from "@/lib/cave-board-types";
 import type { LibraryGitHubItem, GitHubItemKind } from "@/lib/library-types";
 import {
@@ -23,17 +24,6 @@ import { useIsCoarsePointer } from "@/lib/use-viewport";
 type SortKey = "title" | "repo" | "savedAt";
 type SortDir = "asc" | "desc";
 type GroupBy = "repo" | "kind" | "none";
-
-function relTime(iso: string): string {
-  try {
-    const s = (Date.now() - new Date(iso).getTime()) / 1000;
-    if (s < 60) return `${Math.round(s)}s`;
-    if (s < 3600) return `${Math.round(s / 60)}m`;
-    if (s < 86400) return `${Math.round(s / 3600)}h`;
-    const d = Math.round(s / 86400);
-    return d < 30 ? `${d}d` : `${Math.round(d / 30)}mo`;
-  } catch { return ""; }
-}
 
 function sortItems(items: LibraryGitHubItem[], key: SortKey, dir: SortDir): LibraryGitHubItem[] {
   return [...items].sort((a, b) => {
@@ -794,7 +784,7 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
                             <span className="board-table-muted gh-repo-cell">{item.repo}</span>
                           </td>
                           <td className="gh-col-saved">
-                            <span className="board-table-muted">{relTime(item.savedAt)}</span>
+                            <span className="board-table-muted">{relativeTime(item.savedAt)}</span>
                           </td>
                           <td className="gh-col-kind">
                             <span className="board-table-muted library-source-type gh-kind-pill">


### PR DESCRIPTION
## What

The Library's sibling tabs rendered their "Saved"/"Modified" timestamps in **three different relative-time styles**:
- **Bookmarks** & **GitHub** — an inline `relTime()` producing `2d` / `1mo` (no "ago", and a made-up "Nmo" unit)
- **Documents** — a verbose Intl `RelativeTimeFormat` producing `5 days ago`

All three now route through the shared `relativeTime()` helper (`@/lib/relative-time`), so a timestamp reads identically across the tabs: `3d ago` within the last week, a short `May 11` date beyond it.

Documents keeps its date-pref-aware `formatDate()` for the older-than-a-week case, so the **Date ordering** preference (#1108) still applies to old docs.

## Why

Finishes the relative-time unification (#1085/#1099) on the one surface where the divergence was visible side-by-side. Removes two bespoke `relTime()` helpers and a verbose Intl path (net −26 lines).

## Tests / verification

- `library-polish.test.ts` — pass (it pins the reading list's *absence* of a relTime column, unaffected).
- Full `pnpm build` (test:app + next build) green; `tsc --noEmit` clean.
- Live-verified with mocked items (one 3 days old, one 40 days old): Bookmarks → `["3d ago","May 11"]`, GitHub → `["May 11","3d ago"]` — the shared format, with the old `2d`/`1mo` gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)