### PR TITLE
fix(projects): make chat rows keyboard-accessible

### DIFF
--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -19,6 +19,18 @@ assert.match(projectsView, /chats=\{chatsByRoot\.get\(normalizeProjectRoot\(proj
 // Nested chats are draggable: reorder within a project, move across projects.
 assert.match(projectsView, /<DndContext[\s\S]{0,120}onDragEnd=\{handleDragEnd\}/, "Projects view wraps the cards in a DndContext");
 assert.match(projectsView, /function ProjectChatRow/, "chats render as sortable rows");
+// The chat row is a div role="button"; keep it keyboard-accessible — both Enter
+// and Space activate (ARIA button pattern) and it shows a visible focus ring.
+assert.match(
+  projectsView,
+  /role="button"[\s\S]{0,400}?e\.key === "Enter" \|\| e\.key === " "[\s\S]{0,120}?onOpen\(\)/,
+  "the chat row activates on both Enter and Space",
+);
+assert.match(
+  projectsView,
+  /role="button"[\s\S]{0,700}?className="focus-ring /,
+  "the chat row has a visible keyboard focus ring",
+);
 assert.match(projectsView, /useDroppable\(\{\s*id: `pcard:/, "project cards are drop targets");
 assert.match(projectsView, /applyProjectOverrides\(sessions, projectOverrides\)/, "chats are grouped with Cave-local project overrides applied");
 assert.match(projectsView, /setProjectOverride\(activeId, targetRoot\)/, "cross-project drop moves the chat via an override");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -100,9 +100,14 @@ function ProjectChatRow({
         tabIndex={0}
         onClick={onOpen}
         onKeyDown={(e) => {
-          if (e.key === "Enter") onOpen();
+          // ARIA button pattern: Enter and Space both activate. preventDefault on
+          // Space stops the page from scrolling when the row has focus.
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onOpen();
+          }
         }}
-        className="flex w-full items-center gap-2 px-4 py-1 text-left text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+        className="focus-ring flex w-full items-center gap-2 px-4 py-1 text-left text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
       >
         <button
           type="button"


### PR DESCRIPTION
The Projects-tab chat rows (`ProjectChatRow` in `projects-view.tsx`) are a `div role="button"` — a real `<button>` can't be used because each row wraps a nested drag-handle `<button>` (nested buttons are invalid HTML). But the div only handled **Enter** and had **no visible focus indicator**.

Fix (ARIA button pattern):
- activate on **Enter and Space** (with `preventDefault` on Space so the page doesn't scroll while a row is focused)
- add the shared **`focus-ring`** class so keyboard users can see which row has focus

Surfaced by a read-only UX audit; this was the top *genuine* finding (the higher-ranked aria-label items turned out to be false positives — those buttons already derive accessible names from their visible text).

Source-text test guards both behaviors. tsc clean, full `test:app` (327 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)