### PR TITLE
feat(projects): "recently active" status dot

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -31,6 +31,7 @@ export const SUITES = {
     "src/lib/screen-magnification.test.ts",
     "src/lib/demo-mode.test.ts",
     "src/lib/cave-projects.test.ts",
+    "src/lib/project-status.test.ts",
     "src/lib/chat-projects.test.ts",
     "src/lib/chat-project-selection.test.ts",
     "src/lib/chat-session-order.test.ts",

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -127,9 +127,10 @@ assert.match(projectsView, /No projects match/, "a no-match message shows when t
 // running, danger when the most-recent session failed.
 assert.match(
   projectsView,
-  /const projectStatus[\s\S]*?status === "running"[\s\S]*?\? "running"[\s\S]*?\? "failed"/,
-  "row status is running (any) > failed (most recent) > idle",
+  /const projectStatus = deriveProjectStatus\(chats\)/,
+  "row status comes from the shared deriveProjectStatus helper",
 );
+assert.match(projectsView, /import \{ deriveProjectStatus \} from "@\/lib\/project-status"/, "imports the status helper");
 assert.match(projectsView, /projectStatus \? \(/, "the status dot renders only when running or failed");
 
 // Paths are home-collapsed + truncated so the identical absolute prefix stops

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -17,6 +17,7 @@ import {
 import { applyProjectOverrides, setProjectOverride } from "@/lib/chat-project-overrides";
 import { useProjectOverrides } from "@/lib/use-project-overrides";
 import { useProjects } from "@/lib/use-projects";
+import { deriveProjectStatus } from "@/lib/project-status";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
@@ -46,6 +47,7 @@ const CHAT_CAP = 8;
 function chatDotClass(status: string): string {
   if (status === "running") return "bg-[var(--accent-presence)]";
   if (status === "failed" || status === "error") return "bg-[var(--color-danger)]";
+  if (status === "recent") return "bg-[var(--color-success)]";
   return "bg-[var(--text-muted)]";
 }
 
@@ -202,19 +204,17 @@ function ProjectRow({
   const lastActiveIso =
     chats.reduce((acc, s) => (!acc || s.updated_at > acc ? s.updated_at : acc), "") || project.updatedAt;
   const lastActiveLabel = relativeTime(lastActiveIso);
-  // Glanceable status: a session running anywhere in the project → accent dot;
-  // otherwise the most-recent session having failed → danger dot; idle → none.
-  const mostRecentChat = chats.reduce<SessionRow | null>(
-    (acc, s) => (!acc || s.updated_at > acc.updated_at ? s : acc),
-    null,
-  );
-  const projectStatus: "running" | "failed" | null = chats.some((s) => s.status === "running")
-    ? "running"
-    : mostRecentChat && (mostRecentChat.status === "failed" || mostRecentChat.status === "error")
-      ? "failed"
-      : null;
+  // Glanceable status: running (any) > failed (most recent) > recently active
+  // (≤24h) > dormant (no dot). Derivation is pure + unit-tested.
+  const projectStatus = deriveProjectStatus(chats);
   const statusLabel =
-    projectStatus === "running" ? ", a session is running" : projectStatus === "failed" ? ", last session failed" : "";
+    projectStatus === "running"
+      ? ", a session is running"
+      : projectStatus === "failed"
+        ? ", last session failed"
+        : projectStatus === "recent"
+          ? ", active recently"
+          : "";
   const [showAllChats, setShowAllChats] = useState(false);
   const visibleChats = showAllChats ? chats : chats.slice(0, CHAT_CAP);
   const chatTitles = useMemo(() => disambiguateSessionTitles(chats), [chats]);
@@ -297,7 +297,13 @@ function ProjectRow({
               className={`absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full ring-2 ring-[var(--bg-base)] ${chatDotClass(
                 projectStatus,
               )}${projectStatus === "running" ? " animate-pulse" : ""}`}
-              title={projectStatus === "running" ? "A session is running" : "Last session failed"}
+              title={
+                projectStatus === "running"
+                  ? "A session is running"
+                  : projectStatus === "failed"
+                    ? "Last session failed"
+                    : "Active recently"
+              }
               aria-hidden
             />
           ) : null}

--- a/src/lib/project-status.test.ts
+++ b/src/lib/project-status.test.ts
@@ -1,0 +1,25 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { deriveProjectStatus, RECENT_ACTIVE_MS } from "./project-status.ts";
+
+const NOW = 1_700_000_000_000;
+const isoAgo = (ms) => new Date(NOW - ms).toISOString();
+const sess = (over) => ({ id: "x", status: "ended", updated_at: isoAgo(0), ...over });
+
+assert.equal(deriveProjectStatus([sess({ status: "running", updated_at: isoAgo(10 * 24 * 3600_000) })], NOW), "running");
+assert.equal(deriveProjectStatus([sess({ status: "failed", updated_at: isoAgo(60_000) })], NOW), "failed");
+assert.equal(deriveProjectStatus([sess({ status: "error", updated_at: isoAgo(60_000) })], NOW), "failed");
+assert.equal(deriveProjectStatus([sess({ status: "ended", updated_at: isoAgo(3600_000) })], NOW), "recent");
+assert.equal(deriveProjectStatus([sess({ status: "ended", updated_at: isoAgo(30 * 3600_000) })], NOW), null);
+assert.equal(deriveProjectStatus([sess({ updated_at: isoAgo(RECENT_ACTIVE_MS - 1000) })], NOW), "recent");
+assert.equal(deriveProjectStatus([sess({ updated_at: isoAgo(RECENT_ACTIVE_MS + 1000) })], NOW), null);
+assert.equal(deriveProjectStatus([], NOW), null);
+assert.equal(
+  deriveProjectStatus(
+    [sess({ status: "running", updated_at: isoAgo(2 * 3600_000) }), sess({ status: "failed", updated_at: isoAgo(60_000) })],
+    NOW,
+  ),
+  "running",
+);
+
+console.log("project-status.test.ts: ok");

--- a/src/lib/project-status.ts
+++ b/src/lib/project-status.ts
@@ -1,0 +1,35 @@
+// Pure project status derivation for the Projects tab dot. Self-contained (no
+// React, no fs) so it can be unit-tested in isolation; type-only import keeps it
+// safe under the strip-types test runner.
+
+import type { SessionRow } from "./types.ts";
+
+/** A project counts as "recently active" if its newest session moved within this window. */
+export const RECENT_ACTIVE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Glanceable status for a project's dot, in precedence order:
+ *   running  — any session running
+ *   failed   — the most-recent session failed/errored
+ *   recent   — newest activity within RECENT_ACTIVE_MS (idle but fresh)
+ *   null     — dormant (no dot)
+ */
+export function deriveProjectStatus(
+  chats: SessionRow[],
+  now: number = Date.now(),
+): "running" | "failed" | "recent" | null {
+  if (chats.some((s) => s.status === "running")) return "running";
+
+  let max = 0;
+  let mostRecent: SessionRow | null = null;
+  for (const s of chats) {
+    const t = new Date(s.updated_at).getTime();
+    if (Number.isFinite(t) && t > max) {
+      max = t;
+      mostRecent = s;
+    }
+  }
+  if (mostRecent && (mostRecent.status === "failed" || mostRecent.status === "error")) return "failed";
+  if (max > 0 && now - max <= RECENT_ACTIVE_MS) return "recent";
+  return null;
+}


### PR DESCRIPTION
Adds a fourth project status to the Projects-tab folder dot: **recently active** (newest session ≤24h), between "failed" and dormant. So an idle project that moved an hour ago reads differently from one untouched for months.

- New pure `src/lib/project-status.ts` → `deriveProjectStatus(chats, now)` (`running > failed > recent > null`, 24h window), unit-tested.
- `projects-view.tsx` uses it; `recent` → `var(--color-success)` with an "active recently" a11y label + dot title.
- Search/filter and the running/failed dot already existed; this only adds the recency state.

test:app (328) + test:mobile (16) + build green. Spec: docs/superpowers/specs/2026-06-20-projects-recent-dot-design.md
🤖 Generated with [Claude Code](https://claude.com/claude-code)