### PR TITLE
fix(automations): explain why Save is disabled

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -174,6 +174,7 @@ export const SUITES = {
     "src/components/familiar-roster-card.test.ts",
     "src/components/familiars-view-stats.test.ts",
     "src/components/automations-detail-inputs.test.ts",
+    "src/components/automations-view.test.ts",
     "src/components/schedules-tabs.test.ts",
     "src/lib/daily-summary-notifications.test.ts",
     "src/components/daily-summary-notifications.test.ts",

--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -1,0 +1,42 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./automations-view.tsx", import.meta.url), "utf8");
+
+// Save is gated on a valid, changed form: not busy, dirty, named, and a valid
+// schedule (weekly needs ≥1 day).
+assert.match(
+  source,
+  /const canSave = !busy && dirty && name\.trim\(\)\.length > 0 && !invalidSchedule;/,
+  "Save is disabled unless the form is changed, named, and has a valid schedule",
+);
+assert.match(
+  source,
+  /scheduleMode === "weekly" && scheduleDays\.length === 0/,
+  "a weekly schedule with no days selected is treated as invalid",
+);
+
+// A disabled Save must explain itself rather than being a dead button.
+assert.match(
+  source,
+  /const saveBlockedReason =/,
+  "an explicit reason is computed when the form blocks saving",
+);
+assert.match(
+  source,
+  /Pick at least one day for a weekly schedule\./,
+  "weekly-with-no-days surfaces a specific, actionable message",
+);
+assert.match(
+  source,
+  /\{saveBlockedReason \?[\s\S]{0,160}?role="alert"/,
+  "the blocking reason renders as an alert above the Save button",
+);
+assert.match(
+  source,
+  /disabled=\{!canSave\}/,
+  "the Save button stays disabled while canSave is false",
+);
+
+console.log("automations-view.test.ts: ok");

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -620,6 +620,17 @@ function CodexDetailPanel({
     nextRrule !== (auto.rrule ?? "");
   const canSave = !busy && dirty && name.trim().length > 0 && !invalidSchedule;
 
+  // When Save is disabled because the form is invalid (not merely unchanged),
+  // explain why instead of leaving the user with a dead button.
+  const saveBlockedReason =
+    name.trim().length === 0
+      ? "Give the automation a name."
+      : scheduleMode === "weekly" && scheduleDays.length === 0
+        ? "Pick at least one day for a weekly schedule."
+        : !nextRrule.startsWith("RRULE:")
+          ? "Enter a valid schedule."
+          : null;
+
   const toggleDay = (day: string) => {
     setScheduleDays((prev) =>
       prev.includes(day) ? prev.filter((item) => item !== day) : [...prev, day],
@@ -916,6 +927,11 @@ function CodexDetailPanel({
       {/* Actions */}
       <div className="border-t px-5 py-4 space-y-2"
         style={{ borderColor: "var(--border-hairline)" }}>
+        {saveBlockedReason ? (
+          <p className="text-[11px]" style={{ color: "oklch(0.7 0.16 35)" }} role="alert">
+            {saveBlockedReason}
+          </p>
+        ) : null}
         <button
           type="button"
           disabled={!canSave}


### PR DESCRIPTION
The automation editor already disables **Save** on an invalid form (`canSave` checks `!invalidSchedule`, where a weekly schedule with zero days selected is invalid) — but it gave **no reason**, leaving the user with a dead button and no idea what to fix.

Adds an inline `role="alert"` message above Save that names the specific problem:
- "Give the automation a name."
- "Pick at least one day for a weekly schedule."
- "Enter a valid schedule."

Shown only for genuinely invalid input (not for a merely-unchanged form). Also adds the **first test coverage** for `automations-view` (source-text guards for the `canSave` gate, the weekly-no-days rule, and the new reason).

This was audit item #5. The audit thought the disable itself was missing — that part was already correct on `main`; the real gap was the missing explanation.

tsc clean, full `test:app` (328 files) green, new test wired into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)