### PR TITLE
feat(schedules): proper empty states for Reminders and Automations

### DIFF
--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -11,6 +11,8 @@ import type {
   CodexAutomationPatch,
 } from "@/lib/codex-automations-types";
 import { Icon } from "@/lib/icon";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Button } from "@/components/ui/button";
 import { ProjectTree } from "@/components/project-tree";
 import type { CaveProject } from "@/lib/cave-projects-types";
 
@@ -1326,20 +1328,26 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
               ))}
             </div>
           ) : activeTab === "reminders" && remindersEmpty ? (
-            <div className="mt-12 text-center text-[13px]" style={{ color: "var(--text-muted)" }}>
-              No reminders yet.{" "}
-              {onNewReminder && (
-                <button type="button" onClick={onNewReminder}
-                  className="underline underline-offset-2 hover:opacity-80"
-                  style={{ color: "var(--text-secondary)" }}>
-                  Create one via chat.
-                </button>
-              )}
-            </div>
+            <EmptyState
+              className="mt-12"
+              icon="ph:bell"
+              headline="No reminders yet"
+              subtitle="Reminders nudge you or a familiar at a scheduled time."
+              actions={
+                onNewReminder ? (
+                  <Button leadingIcon="ph:plus" onClick={onNewReminder}>
+                    Create via chat
+                  </Button>
+                ) : undefined
+              }
+            />
           ) : activeTab === "automations" && automationsEmpty ? (
-            <div className="mt-12 text-center text-[13px]" style={{ color: "var(--text-muted)" }}>
-              No automations configured.
-            </div>
+            <EmptyState
+              className="mt-12"
+              icon="ph:robot"
+              headline="No automations configured"
+              subtitle="Automations run a familiar on a schedule — set one up to get started."
+            />
           ) : (
             <>
               {activeTab === "reminders" ? (


### PR DESCRIPTION
## What

The Schedules surface rendered its zero-state as a single line of bare centered text — "No reminders yet. Create one via chat." Both the **Reminders** and **Automations** empty states now use the shared `ui/EmptyState`:

- **Reminders** — bell icon + "No reminders yet" + "Reminders nudge you or a familiar at a scheduled time." + a **Create via chat** action button.
- **Automations** — robot icon + "No automations configured" + "Automations run a familiar on a schedule — set one up to get started."

This matches the empty-state idiom now used on the Library (#1110) and Familiars (#1114) surfaces.

## Why

It's the production first-run experience for Schedules, and it looked unfinished next to the rest of the app. The loading skeleton and its gate (`!initialLoadDone ? <skeleton> : … remindersEmpty ? …`) are **unchanged** — only the contents of the two empty branches were swapped.

## Tests / verification

- `surface-loading-states.test.ts` (pins the skeleton-before-empty gate structure) and `surface-error-states.test.ts` (pins the load-failure banner) — both pass; neither was touched.
- Full `pnpm build` (test:app + next build) green; `tsc --noEmit` clean.
- Live-verified with `/api/inbox` and `/api/codex-automations` mocked empty: Reminders → bell badge + headline + subtitle + "Create via chat" button; Automations → robot badge + headline + subtitle. Screenshot confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)