### PR TITLE
feat(recent-activity): remember the collapsed state

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -100,6 +100,7 @@ export const SUITES = {
     "src/components/surface-loading-states.test.ts",
     "src/components/chat-header-row.test.ts",
     "src/components/sidebar-minimal.test.ts",
+    "src/components/recent-activity-rollup.test.ts",
     "src/components/sidebar-familiar-filter.test.ts",
     "src/components/shell-edge-rails.test.ts",
     "src/components/workflows-view.test.ts",

--- a/src/components/recent-activity-rollup.test.ts
+++ b/src/components/recent-activity-rollup.test.ts
@@ -1,0 +1,30 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./recent-activity-rollup.tsx", import.meta.url), "utf8");
+
+// The collapse state persists across reloads and remounts via localStorage,
+// but defaults to open for SSR / first paint so the markup hydrates cleanly.
+assert.match(
+  source,
+  /const \[open, setOpen\] = useState\(true\)/,
+  "defaults to open for SSR + first client paint (avoids a hydration mismatch)",
+);
+assert.match(
+  source,
+  /localStorage\.getItem\(OPEN_STORAGE_KEY\)[\s\S]{0,120}?setOpen\(stored !== "false"\)/,
+  "hydrates the saved open/collapsed preference after mount",
+);
+assert.match(
+  source,
+  /localStorage\.setItem\(OPEN_STORAGE_KEY, String\(next\)\)/,
+  "persists the preference whenever the user toggles the section",
+);
+assert.match(
+  source,
+  /onClick=\{toggleOpen\}/,
+  "the header toggle writes through the persisting handler",
+);
+
+console.log("recent-activity-rollup.test.ts: ok");

--- a/src/components/recent-activity-rollup.tsx
+++ b/src/components/recent-activity-rollup.tsx
@@ -19,6 +19,8 @@ import type { SessionRow } from "@/lib/types";
 
 const POLL_MS = 15_000;
 const MAX_ROWS = 8;
+// Remember whether the roll-up is collapsed across reloads and remounts.
+const OPEN_STORAGE_KEY = "cave:recent-activity:open";
 
 function projectLabel(root: string | undefined): string {
   if (!root) return "";
@@ -33,8 +35,31 @@ type Props = {
 
 export function RecentActivityRollup({ activeSessionId, onOpenSession }: Props) {
   const [sessions, setSessions] = useState<SessionRow[]>([]);
+  // Default open for SSR + first paint, then hydrate the saved preference after
+  // mount so the server and client markup match.
   const [open, setOpen] = useState(true);
   const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(OPEN_STORAGE_KEY);
+      if (stored != null) setOpen(stored !== "false");
+    } catch {
+      // ignore unavailable storage
+    }
+  }, []);
+
+  const toggleOpen = () => {
+    setOpen((v) => {
+      const next = !v;
+      try {
+        window.localStorage.setItem(OPEN_STORAGE_KEY, String(next));
+      } catch {
+        // ignore unavailable storage
+      }
+      return next;
+    });
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -68,7 +93,7 @@ export function RecentActivityRollup({ activeSessionId, onOpenSession }: Props) 
         type="button"
         className="recent-activity__head"
         aria-expanded={open}
-        onClick={() => setOpen((v) => !v)}
+        onClick={toggleOpen}
       >
         <span className="recent-activity__label">Recent</span>
         <Icon


### PR DESCRIPTION
The Recent Activity roll-up (`recent-activity-rollup.tsx`) reset to **expanded** on every reload and remount (`useState(true)`), so collapsing it didn't stick — and the component remounts/re-renders around its 15s poll.

Persist the open/collapsed preference to `localStorage` (`cave:recent-activity:open`):
- default **open** for SSR + first client paint, so server and client markup match (no hydration mismatch)
- **hydrate** the saved value in a mount effect
- **write through** on toggle

Audit item #6. Adds the first test coverage for the component (SSR-safe default, hydrate, persist-on-toggle).

tsc clean, full `test:app` (329 files) green, new test wired into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)