### PR TITLE
feat(empty-states): route Vault + Retro Runs through shared state primitives

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2638,12 +2638,6 @@ select {
   font-size: 11px;
   color: var(--color-danger);
 }
-.vault-empty {
-  padding: 24px 16px;
-  font-size: 12px;
-  color: var(--text-muted);
-  text-align: center;
-}
 .vault-footer-note {
   flex-shrink: 0;
   padding: 8px 14px;
@@ -7787,6 +7781,9 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   color: var(--text-secondary);
   font-size: 13px;
 }
+.retro-callout-retry {
+  margin-left: auto;
+}
 .retro-content {
   display: grid;
   grid-template-columns: minmax(210px, 250px) minmax(0, 1fr);
@@ -7971,30 +7968,6 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   background: color-mix(in oklch, var(--color-danger) 14%, transparent);
   color: var(--color-danger);
 }
-.retro-empty,
-.retro-skeleton {
-  min-height: 112px;
-  border: 1px dashed var(--border-hairline);
-  border-radius: var(--radius-card);
-  background: color-mix(in oklch, var(--bg-raised) 62%, transparent);
-}
-.retro-empty {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  color: var(--text-muted);
-  font-size: 13px;
-}
-.retro-skeleton {
-  border-style: solid;
-  animation: retro-pulse 1.3s ease-in-out infinite;
-}
-@keyframes retro-pulse {
-  0%, 100% { opacity: 0.5; }
-  50% { opacity: 1; }
-}
-
 @media (max-width: 560px) {
   .dr-metric__value { font-size: 32px; }
   .dr-row__open span { display: none; }

--- a/src/components/retro-runs-view.tsx
+++ b/src/components/retro-runs-view.tsx
@@ -2,6 +2,9 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { EmptyState } from "@/components/ui/empty-state";
+import { SkeletonRows } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import { relativeTime } from "@/lib/relative-time";
 import type { RetroOutcome, RetroRun, RetroRunsSnapshot, RetroTrack } from "@/lib/retro-runs";
 
@@ -259,9 +262,18 @@ export function RetroRunsView({
       </div>
 
       {error ? (
-        <div className="retro-callout" role="status">
+        <div className="retro-callout" role="alert">
           <Icon name="ph:warning-circle" aria-hidden />
           <span>{error}</span>
+          <Button
+            size="xs"
+            variant="ghost"
+            leadingIcon="ph:arrow-clockwise"
+            onClick={() => void load()}
+            className="retro-callout-retry"
+          >
+            Retry
+          </Button>
         </div>
       ) : null}
 
@@ -290,16 +302,15 @@ export function RetroRunsView({
 
         <div className="retro-runs-list" aria-busy={loading || refreshing}>
           {loading ? (
-            Array.from({ length: 4 }, (_, index) => (
-              <div key={index} className="retro-skeleton" />
-            ))
+            <SkeletonRows count={4} />
           ) : filteredRuns.length > 0 ? (
             filteredRuns.map((run) => <RunRow key={run.id} run={run} />)
           ) : (
-            <div className="retro-empty">
-              <Icon name="ph:lock-simple-bold" aria-hidden />
-              <span>No matching retro runs.</span>
-            </div>
+            <EmptyState
+              compact
+              icon="ph:lock-simple-bold"
+              headline="No matching retro runs."
+            />
           )}
         </div>
       </div>

--- a/src/components/surface-error-states.test.ts
+++ b/src/components/surface-error-states.test.ts
@@ -45,4 +45,33 @@ assert.match(
   "Library doc-list empty state has title + hint instead of bare text",
 );
 
+const vault = read("./vault-panel.tsx");
+assert.match(
+  vault,
+  /catch \(e\)[\s\S]*?setError\(/,
+  "Vault panel surfaces fetch failures instead of swallowing them in an empty catch",
+);
+assert.match(
+  vault,
+  /<ErrorState[\s\S]*?void load\(\)[\s\S]*?Retry/,
+  "Vault panel load failure uses the shared ErrorState with Retry wired to load()",
+);
+assert.match(
+  vault,
+  /<EmptyState[\s\S]*?No mappings yet[\s\S]*?Add mapping/,
+  "Vault panel empty state has an Add mapping action, not bare text",
+);
+
+const retro = read("./retro-runs-view.tsx");
+assert.match(
+  retro,
+  /\{error \?[\s\S]*?role="alert"[\s\S]*?ph:warning-circle[\s\S]*?void load\(\)[\s\S]*?Retry/,
+  "Retro runs error banner is role=alert with a Retry wired to load()",
+);
+assert.match(
+  retro,
+  /<EmptyState[\s\S]*?No matching retro runs\./,
+  "Retro runs empty state uses the shared EmptyState",
+);
+
 console.log("surface-error-states.test.ts: ok");

--- a/src/components/surface-loading-states.test.ts
+++ b/src/components/surface-loading-states.test.ts
@@ -80,4 +80,28 @@ assert.match(
   "Settings integrations shows skeleton rows while the daemon status loads",
 );
 
+const vault = read("./vault-panel.tsx");
+assert.doesNotMatch(
+  vault,
+  />Loading…</,
+  "Vault panel no longer shows a bare Loading… line",
+);
+assert.match(
+  vault,
+  /\{loading \? \(\s*<SkeletonRows/,
+  "Vault panel shows skeleton rows while the first /api/vault fetch is in flight",
+);
+
+const retro = read("./retro-runs-view.tsx");
+assert.match(
+  retro,
+  /\{loading \? \(\s*<SkeletonRows/,
+  "Retro runs shows shared skeleton rows on first load instead of hand-rolled divs",
+);
+assert.doesNotMatch(
+  retro,
+  /className="retro-skeleton"/,
+  "Retro runs no longer hand-rolls retro-skeleton placeholder divs",
+);
+
 console.log("surface-loading-states.test.ts: ok");

--- a/src/components/vault-panel.tsx
+++ b/src/components/vault-panel.tsx
@@ -2,6 +2,10 @@
 
 import { useEffect, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorState } from "@/components/ui/error-state";
+import { SkeletonRows } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -134,6 +138,7 @@ function AddMappingForm({
 export function VaultPanel() {
   const [mappings, setMappings]     = useState<Mapping[]>([]);
   const [loading, setLoading]       = useState(true);
+  const [error, setError]           = useState<string | null>(null);
   const [adding, setAdding]         = useState(false);
   const [editing, setEditing]       = useState<Mapping | null>(null);
   const [deleting, setDeleting]     = useState<string | null>(null);
@@ -142,9 +147,15 @@ export function VaultPanel() {
     setLoading(true);
     try {
       const res = await fetch("/api/vault", { cache: "no-store" });
-      const j = await res.json() as { ok: boolean; mappings?: Mapping[] };
-      if (j.ok) setMappings(j.mappings ?? []);
-    } catch { /**/ }
+      const j = await res.json() as { ok: boolean; mappings?: Mapping[]; error?: string };
+      if (!j.ok) throw new Error(j.error ?? "Couldn't load vault mappings.");
+      setMappings(j.mappings ?? []);
+      setError(null);
+    } catch (e) {
+      // Previously swallowed — a failed fetch left a bare "No mappings yet"
+      // that read as "you have none" rather than "something broke".
+      setError(e instanceof Error ? e.message : "Couldn't load vault mappings.");
+    }
     finally { setLoading(false); }
   }
 
@@ -206,11 +217,35 @@ export function VaultPanel() {
 
       {/* Mapping list */}
       {loading ? (
-        <div className="vault-empty">Loading…</div>
+        <SkeletonRows count={3} className="vault-skeleton" />
+      ) : error ? (
+        <ErrorState
+          compact
+          headline="Couldn't load the vault"
+          subtitle={error}
+          actions={
+            <Button size="xs" leadingIcon="ph:arrow-clockwise" onClick={() => void load()}>
+              Retry
+            </Button>
+          }
+        />
       ) : mappings.length === 0 ? (
-        <div className="vault-empty">
-          No mappings yet. Add one to pull secrets from 1Password automatically.
-        </div>
+        <EmptyState
+          compact
+          icon="ph:vault"
+          headline="No mappings yet"
+          subtitle="Add one to pull secrets from 1Password automatically."
+          actions={
+            <Button
+              size="xs"
+              leadingIcon="ph:plus"
+              onClick={() => { setAdding(true); setEditing(null); }}
+              disabled={adding}
+            >
+              Add mapping
+            </Button>
+          }
+        />
       ) : (
         <div className="vault-list">
           {mappings.map((m) => (


### PR DESCRIPTION
## What

Continues the empty/loading/error consistency sweep (#1110 Library, #1114 Familiars) into the **agent runs & reports** cluster — the Secret Vault panel and the Retro Runs view now use the shared `ui/EmptyState`, `ui/ErrorState`, and `ui/SkeletonRows` primitives.

## Why / changes

**Vault panel** — the real gap:
- Loading was bare **"Loading…"** text → `SkeletonRows`.
- The fetch error was **silently swallowed** (`catch { /**/ }`), so a failed load showed "No mappings yet" — reading as *"you have none"* rather than *"something broke."* Now caught into an `error` state and rendered via `ErrorState` (role=alert) with **Retry**.
- Empty was a bare div → `EmptyState` with a vault icon and an **Add mapping** action.

**Retro Runs:**
- Hand-rolled `.retro-skeleton` divs → `SkeletonRows`.
- `.retro-empty` → shared `EmptyState`.
- The error callout had `role="status"` and no recovery → `role="alert"` + a **Retry** button (kept as an inline non-blocking banner — the block-shaped `ErrorState` is wrong for a top banner that coexists with partial data).
- Removed the now-orphaned `.retro-empty` / `.retro-skeleton` / `.vault-empty` CSS.

**daily-report-ui is intentionally untouched** — it's a presentational primitive library that already exports its own `.dr-*` EmptyState consumed by other files; converting it would be churn + visual regression for ~zero consistency gain.

## Verification

- Live-verified all four states via route-mocked `/api/retro-runs` and `/api/vault`: retro empty (EmptyState), retro error (alert banner + Retry), vault empty (EmptyState + Add mapping), vault error (ErrorState "Couldn't load the vault" + Retry).
- Added assertions to `surface-error-states.test.ts` + `surface-loading-states.test.ts`.
- `pnpm test:app` — ✓ 327 test file(s) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)