### PR TITLE
fix(a11y): label icon-only / placeholder-only controls

### DIFF
--- a/src/components/github-action-popover.tsx
+++ b/src/components/github-action-popover.tsx
@@ -139,6 +139,7 @@ function BoardMode({
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search open cards…"
+            aria-label="Search open cards"
             className="w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2.5 py-1.5 text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent-presence)] focus:outline-none"
           />
           <ul className="max-h-40 overflow-y-auto space-y-0.5">

--- a/src/components/library-view.tsx
+++ b/src/components/library-view.tsx
@@ -456,6 +456,8 @@ export function LibraryView({ sessions, onOpenSession, onNewProjectChat }: Libra
             type="button"
             className="library-list-toggle-btn"
             onClick={() => setListPinned((v) => !v)}
+            aria-label={listPinned ? "Collapse list" : "Pin list open"}
+            aria-pressed={listPinned}
             title={listPinned ? "Collapse list" : "Pin list open"}
           >
             <Icon

--- a/src/components/terminal-key-bar.tsx
+++ b/src/components/terminal-key-bar.tsx
@@ -38,7 +38,7 @@ export function TerminalKeyBar({ onKey, ctrlActive, onToggleCtrl }: Props) {
       role="toolbar"
       aria-label="Terminal keys"
     >
-      <button type="button" className={KEY_CLASS} onClick={() => onKey(KEYS.esc)}>
+      <button type="button" className={KEY_CLASS} onClick={() => onKey(KEYS.esc)} aria-label="Escape">
         esc
       </button>
       <button type="button" className={KEY_CLASS} onClick={() => onKey(KEYS.tab)} aria-label="Tab">


### PR DESCRIPTION
A small bundle of accessible-name fixes for controls that relied on `title` or `placeholder` (neither is reliably announced by screen readers):

- **Library list-panel toggle** (`library-view.tsx`) — icon-only button had only a `title`; add `aria-label` + `aria-pressed` so its purpose and pinned/collapsed state are exposed.
- **GitHub action popover search** (`github-action-popover.tsx`) — "Search open cards" input had only a placeholder (vanishes on focus); add `aria-label`.
- **Terminal key bar "esc"** (`terminal-key-bar.tsx`) — add `aria-label="Escape"` for parity with the sibling "tab" button.

From a second UX audit; these were the genuinely real items (the rest were false positives — controls already named by their visible text, or intentional design like the YouTube embed remount and companion-rail caret).

Pure attribute additions, no behavior change. tsc clean, full `test:app` (329 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)