### PR TITLE
feat(roles): unify the Roles & capability map empty states

### DIFF
--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { Icon } from "@/lib/icon";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Button } from "@/components/ui/button";
 import { copyText } from "@/lib/clipboard";
 import { formatClock } from "@/lib/datetime-format";
 import { MarkdownBlock } from "@/components/message-bubble";
@@ -1087,18 +1089,16 @@ function CapabilitiesError({ error, onRefresh }: { error: string; onRefresh: () 
 
 function CapabilitiesEmpty({ onRefresh }: { onRefresh: () => void }) {
   return (
-    <div className="rounded-lg border border-dashed border-border px-4 py-8 text-center">
-      <p className="text-[13px] text-muted-foreground">
-        No runtime capabilities found. Start the daemon or add a local runtime to see its instructions, skills, and plugins.
-      </p>
-      <button
-        type="button"
-        onClick={onRefresh}
-        className="focus-ring mt-3 rounded-md border border-border px-3 py-1.5 text-[12px] text-foreground hover:bg-muted"
-      >
-        Refresh
-      </button>
-    </div>
+    <EmptyState
+      icon="ph:lightning-bold"
+      headline="No runtime capabilities found"
+      subtitle="Start the daemon or add a local runtime to see its instructions, skills, and plugins."
+      actions={
+        <Button leadingIcon="ph:arrow-clockwise" onClick={onRefresh}>
+          Refresh
+        </Button>
+      }
+    />
   );
 }
 

--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -9,6 +9,8 @@ import {
 } from "@/components/skill-detail-drawer";
 import { listWorkflows, type WorkflowSummary } from "@/lib/workflows";
 import { Icon } from "@/lib/icon";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Button } from "@/components/ui/button";
 import { CapabilitiesViewSurface } from "@/components/capabilities-view";
 
 type Tab = "roles" | "workflows" | "skills" | "capabilities";
@@ -390,7 +392,7 @@ function RolesTab({
   onOpenWorkflow?: (id: string) => void;
 }) {
   if (!loaded) return <ListSkeleton />;
-  if (roles.length === 0) return <EmptyPanel title="No roles found" body="Add ROLE.md files to a familiar workspace to populate this view." />;
+  if (roles.length === 0) return <EmptyPanel icon={ICONS.tabRoles} title="No roles found" body="Add ROLE.md files to a familiar workspace to populate this view." />;
 
   return (
     <div className="flex flex-col gap-2">
@@ -516,7 +518,7 @@ function WorkflowsTab({
   onOpenWorkflow?: (id: string) => void;
 }) {
   if (!loaded) return <ListSkeleton />;
-  if (workflows.length === 0) return <EmptyPanel title="No workflows found" body="Workflow manifests will appear here once the library scan succeeds." />;
+  if (workflows.length === 0) return <EmptyPanel icon={ICONS.tabWorkflows} title="No workflows found" body="Workflow manifests will appear here once the library scan succeeds." />;
 
   return (
     <div className="divide-y divide-[var(--border-hairline)] rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-panel)]">
@@ -558,7 +560,7 @@ function SkillsTab({
 }) {
   if (!loaded) return <ListSkeleton />;
   if (skills.length === 0) {
-    return <EmptyPanel title="No local skills found" body="Create or install skills to make them available to familiars." actionLabel="Open Capabilities" onAction={onCreateSkill} />;
+    return <EmptyPanel icon={ICONS.tabSkills} title="No local skills found" body="Create or install skills to make them available to familiars." actionLabel="Open Capabilities" onAction={onCreateSkill} />;
   }
 
   return (
@@ -584,30 +586,29 @@ function SkillsTab({
 }
 
 function EmptyPanel({
+  icon,
   title,
   body,
   actionLabel,
   onAction,
 }: {
+  icon: IconName;
   title: string;
   body: string;
   actionLabel?: string;
   onAction?: () => void;
 }) {
   return (
-    <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-panel)] px-5 py-8 text-center">
-      <p className="text-[14px] font-medium text-[var(--text-primary)]">{title}</p>
-      <p className="mx-auto mt-1 max-w-md text-[12px] text-[var(--text-muted)]">{body}</p>
-      {actionLabel && onAction ? (
-        <button
-          type="button"
-          onClick={onAction}
-          className="focus-ring mt-4 rounded-md border border-[var(--border-hairline)] px-3 py-1.5 text-[12px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
-        >
-          {actionLabel}
-        </button>
-      ) : null}
-    </div>
+    <EmptyState
+      icon={icon}
+      headline={title}
+      subtitle={body}
+      actions={
+        actionLabel && onAction ? (
+          <Button onClick={onAction}>{actionLabel}</Button>
+        ) : undefined
+      }
+    />
   );
 }
 


### PR DESCRIPTION
## What

The Roles surface ("Role and capability map" — Roles / Workflows / Skills / Capabilities tabs) rendered its zero-states with two local, **iconless** boxes: `EmptyPanel` (Roles/Workflows/Skills) and `CapabilitiesEmpty` (Capabilities). Both now use the shared `ui/EmptyState`, so each tab's empty state gets the icon badge + headline + subtitle + action treatment used across Library (#1110), Familiars (#1114), and Schedules (#1119).

- Roles → mask icon, Workflows → graph icon, Skills → sparkle icon (reusing the existing per-tab `ICONS`), Capabilities → lightning icon.
- `EmptyPanel` becomes a thin adapter over `EmptyState` that takes an `icon` prop, so the three call sites are a one-line change each.

## Why

Consistency: these were the last iconless, hand-rolled empty panels on a primary surface. The skeletons and data paths are untouched.

## Tests / verification

- `capabilities-view-polish.test.ts` passes; no test pins `EmptyPanel`/`CapabilitiesEmpty` or the empty titles.
- Full `pnpm build` (test:app + next build) green; `tsc --noEmit` clean.
- Live-verified with `/api/roles`, `/api/skills/local`, `/api/workflows`, `/api/capabilities` mocked empty: Roles, Skills, and Capabilities all render the shared `EmptyState` (icon badge + headline + subtitle, plus "Open Capabilities" / "Refresh" actions). Screenshot confirmed the Roles mask-icon badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)