### PR TITLE
feat(dashboard): fold today's daily summary into one world-class page

### DIFF
--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -17,5 +17,7 @@ const view = readFileSync(viewUrl, "utf8");
 assert.match(view, /dashboardLayout/, "view should order zones via dashboardLayout");
 assert.match(view, /ActionInbox/, "view should include the action inbox zone");
 assert.match(view, /LauncherGrid/, "view should include the launcher zone");
+assert.match(view, /MetricsStrip/, "view should include the day-at-a-glance metrics");
+assert.match(view, /TodaySummary/, "view folds today's daily summary into the dashboard");
 
 console.log("dashboard-page.test.ts: ok");

--- a/src/components/dashboard/dashboard-hero.tsx
+++ b/src/components/dashboard/dashboard-hero.tsx
@@ -1,17 +1,19 @@
 import { Icon } from "@/lib/icon";
-import { longDateLabel, relativeTime } from "@/lib/daily-report";
+import { greeting, longDateLabel, relativeTime } from "@/lib/daily-report";
 
-/** Adaptive hero: "All caught up" vs "N things need you". */
+/** Adaptive hero: greeting + "All caught up" vs "N things need you". */
 export function DashboardHero({ now, needsCount }: { now: Date; needsCount: number }) {
   const caughtUp = needsCount === 0;
+  const hour = now.getHours();
+  const greetIcon = hour < 6 || hour >= 19 ? "ph:moon" : "ph:sun";
   const title = caughtUp
     ? "All caught up"
     : `${needsCount} ${needsCount === 1 ? "thing needs" : "things need"} you`;
   return (
     <header className="dr-hero">
       <p className="dr-eyebrow">
-        <span className="dr-eyebrow__dot" aria-hidden />
-        Dashboard
+        <Icon name={greetIcon} className="dr-eyebrow__icon" aria-hidden />
+        {greeting(now)}
       </p>
       <h1 className="dr-title">{title}</h1>
       <p className="dr-subtitle">

--- a/src/components/dashboard/dashboard-view.tsx
+++ b/src/components/dashboard/dashboard-view.tsx
@@ -2,11 +2,17 @@ import { dashboardLayout, type DashboardModel } from "@/lib/dashboard-model";
 import { DashboardHero } from "./dashboard-hero";
 import { ActionInbox } from "./action-inbox";
 import { CaughtUpStrip } from "./caught-up-strip";
-import { ReportCallout } from "./report-callout";
+import { MetricsStrip } from "./metrics-strip";
+import { TodaySummary } from "./today-summary";
+import { FamiliarUpdates } from "./familiar-updates";
 import { LauncherGrid } from "./launcher-grid";
 import { RecentReports } from "./recent-reports";
 
-/** Adaptive shell: renders the hero, then the ordered zones for the state. */
+/**
+ * Adaptive single-page shell: renders the hero, then the ordered zones for the
+ * current state. Today's daily summary (metrics, narrative, familiar updates)
+ * lives inline here — the dashboard is the day's report plus live triage.
+ */
 export function DashboardView({ model }: { model: DashboardModel }) {
   const zones = dashboardLayout(model);
   return (
@@ -18,15 +24,19 @@ export function DashboardView({ model }: { model: DashboardModel }) {
             return <CaughtUpStrip key={zone} />;
           case "actionInbox":
             return <ActionInbox key={zone} initialItems={model.needsAttention} />;
-          case "reportCallout":
+          case "metrics":
+            return <MetricsStrip key={zone} metrics={model.metrics} live={model.metricsLive} />;
+          case "todaySummary":
             return (
-              <ReportCallout
+              <TodaySummary
                 key={zone}
+                summary={model.todaySummary}
                 featured={model.featuredReport}
-                isToday={Boolean(model.todaysReport)}
                 now={model.date}
               />
             );
+          case "familiarUpdates":
+            return <FamiliarUpdates key={zone} items={model.familiarUpdates} now={model.date} />;
           case "launcher":
             return <LauncherGrid key={zone} variant={model.caughtUp ? "full" : "compact"} />;
           case "recentReports":
@@ -43,8 +53,8 @@ export function DashboardView({ model }: { model: DashboardModel }) {
         }
       })}
       <footer className="dr-footer">
-        This dashboard reads your local inbox and session activity. Reminders and replies are live; daily
-        reports are point-in-time snapshots generated automatically.
+        This dashboard reads your local inbox and session activity. Reminders and replies are live;
+        today&apos;s summary and headline numbers come from the auto-generated daily report.
       </footer>
     </div>
   );

--- a/src/components/dashboard/familiar-updates.tsx
+++ b/src/components/dashboard/familiar-updates.tsx
@@ -1,0 +1,21 @@
+import { ItemRow, SectionHead } from "@/components/daily-report-ui";
+import type { InboxItem } from "@/lib/cave-inbox";
+
+/**
+ * Familiar updates that fired today (live). Hidden entirely when none — the
+ * calm dashboard shouldn't render an empty section. Reuses the shared ItemRow
+ * so updates deep-link back into the familiar's session.
+ */
+export function FamiliarUpdates({ items, now }: { items: InboxItem[]; now: Date }) {
+  if (items.length === 0) return null;
+  return (
+    <section className="dr-section" aria-label="Familiar updates">
+      <SectionHead icon="ph:sparkle" title="Familiar updates" count={items.length} />
+      <div className="dr-list">
+        {items.map((item) => (
+          <ItemRow key={item.id} item={item} now={now} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/dashboard/metrics-strip.tsx
+++ b/src/components/dashboard/metrics-strip.tsx
@@ -1,0 +1,50 @@
+import { MetricCard, SectionHead } from "@/components/daily-report-ui";
+import type { DailyReportStats } from "@/lib/daily-report";
+
+/**
+ * Day-at-a-glance metric cards. Mirrors the standalone daily report's headline
+ * row, but lives inline on the dashboard so today's numbers and the live triage
+ * share one page. `live` flips the hint between the at-this-moment snapshot and
+ * the frozen counts captured when today's report generated.
+ */
+export function MetricsStrip({ metrics, live }: { metrics: DailyReportStats; live: boolean }) {
+  return (
+    <section className="dr-section" aria-label="Day at a glance">
+      <SectionHead
+        icon="ph:graph-bold"
+        title="Today at a glance"
+        hint={live ? "Live — right now" : "From today's report"}
+      />
+      <div className="dr-metrics">
+        <MetricCard
+          icon="ph:bell"
+          value={metrics.reminders}
+          label="Reminders fired"
+          caption={metrics.reminders === 1 ? "1 reminder" : `${metrics.reminders} reminders`}
+          accent="amber"
+        />
+        <MetricCard
+          icon="ph:chat-circle-dots"
+          value={metrics.responses}
+          label="Responses waiting"
+          caption="Need your reply"
+          accent="rose"
+        />
+        <MetricCard
+          icon="ph:sparkle"
+          value={metrics.familiars}
+          label="Familiar updates"
+          caption="From your agents"
+          accent="lavender"
+        />
+        <MetricCard
+          icon="ph:graph-bold"
+          value={metrics.sessions}
+          label="Sessions updated"
+          caption="Coding & chat work"
+          accent="green"
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/components/dashboard/today-summary.tsx
+++ b/src/components/dashboard/today-summary.tsx
@@ -1,0 +1,67 @@
+import { Icon } from "@/lib/icon";
+import { SectionHead } from "@/components/daily-report-ui";
+import { relativeTime, type RecentReport } from "@/lib/daily-report";
+import type { TodaySummary } from "@/lib/dashboard-model";
+import { ReportCallout } from "./report-callout";
+
+/**
+ * Today's daily summary, folded inline so the dashboard *is* the day's report:
+ * the auto-generated narrative, its illustration, and the recovered session
+ * names. Before today's report exists it degrades to the callout that links
+ * the latest available report (or a calm "nothing yet" note).
+ */
+export function TodaySummary({
+  summary,
+  featured,
+  now,
+}: {
+  summary: TodaySummary | null;
+  featured: RecentReport | null;
+  now: Date;
+}) {
+  if (!summary) {
+    return <ReportCallout featured={featured} isToday={false} now={now} />;
+  }
+
+  const hasBody = summary.body.trim().length > 0;
+  return (
+    <section className="dr-section dash-today" aria-label="Today's report">
+      <SectionHead
+        icon="ph:newspaper"
+        title="Today's report"
+        hint={summary.generatedAt ? `Generated ${relativeTime(summary.generatedAt, now)}` : undefined}
+      />
+      <div className={`dash-today__grid${summary.imageUrl ? " dash-today__grid--media" : ""}`}>
+        <div className="dr-panel dash-today__panel">
+          {hasBody ? (
+            <p className="dr-summary-body" style={{ whiteSpace: "pre-line" }}>
+              {summary.body}
+            </p>
+          ) : (
+            <p className="dr-summary-body dash-today__placeholder">
+              Today&apos;s summary is still taking shape — it fills in as activity lands.
+            </p>
+          )}
+          {summary.recentSessions.length > 0 ? (
+            <div className="dash-today__sessions" aria-label="Recent sessions">
+              <span className="dash-today__sessions-label">
+                <Icon name="ph:code-bold" aria-hidden />
+                Recent sessions
+              </span>
+              <div className="dash-today__chips">
+                {summary.recentSessions.map((name, i) => (
+                  <span key={i} className="dash-today__chip">
+                    {name}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+        {summary.imageUrl ? (
+          <img className="dr-cardimg dash-today__img" src={summary.imageUrl} alt={summary.alt} />
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/daily-report.ts
+++ b/src/lib/daily-report.ts
@@ -51,6 +51,16 @@ export function isSameLocalDay(iso: string | null | undefined, day: Date): boole
   return value.getTime() >= start && value.getTime() < start + 24 * 60 * 60 * 1000;
 }
 
+/** Time-of-day greeting for the dashboard hero. */
+export function greeting(date: Date): string {
+  const h = date.getHours();
+  if (h < 5) return "Still up";
+  if (h < 12) return "Good morning";
+  if (h < 17) return "Good afternoon";
+  if (h < 21) return "Good evening";
+  return "Good night";
+}
+
 /** Long human label, e.g. "Thursday, June 18, 2026". */
 export function longDateLabel(date: Date): string {
   return new Intl.DateTimeFormat([], {

--- a/src/lib/dashboard-model.test.ts
+++ b/src/lib/dashboard-model.test.ts
@@ -36,7 +36,7 @@ function summary(slug) {
   const model = buildDashboardModel([summary("2026-06-19")], now);
   assert.equal(model.caughtUp, true, "no open items => caught up");
   assert.equal(model.needsAttention.length, 0);
-  assert.deepEqual(dashboardLayout(model), ["caughtUpStrip", "reportCallout", "launcher", "recentReports"]);
+  assert.deepEqual(dashboardLayout(model), ["caughtUpStrip", "metrics", "todaySummary", "familiarUpdates", "launcher", "recentReports"]);
 }
 
 // busy when a response is pending today
@@ -47,7 +47,7 @@ function summary(slug) {
   );
   assert.equal(model.caughtUp, false, "open item => busy");
   assert.equal(model.needsAttention.length, 1);
-  assert.deepEqual(dashboardLayout(model), ["actionInbox", "reportCallout", "launcher"]);
+  assert.deepEqual(dashboardLayout(model), ["actionInbox", "metrics", "todaySummary", "launcher", "recentReports"]);
 }
 
 // needsAttention is capped at 8
@@ -66,6 +66,35 @@ function summary(slug) {
   assert.equal(model.todaysReport?.slug, "2026-06-20");
   assert.equal(model.featuredReport?.slug, "2026-06-20");
   assert.deepEqual(model.recentReports.map((r) => r.slug), ["2026-06-19"]);
+}
+
+// today's summary is folded in: narrative + frozen metrics from today's report
+{
+  const today = item({
+    id: "s-2026-06-20",
+    kind: "daily-summary",
+    title: "Report 2026-06-20",
+    body: "You shipped 3 things.\nRecent: alpha · beta",
+    auto: "daily-summary:2026-06-20",
+    media: { kind: "summary-card", imageUrl: "img.png", alt: "card", stats: { reminders: 1, responses: 2, familiars: 4, sessions: 3 }, generatedAt: ISO },
+  });
+  const model = buildDashboardModel([today], now);
+  assert.ok(model.todaySummary, "today summary present when today's report exists");
+  assert.equal(model.todaySummary.imageUrl, "img.png");
+  assert.deepEqual(model.todaySummary.recentSessions, ["alpha", "beta"], "recovers session names from body");
+  assert.equal(model.metricsLive, false, "metrics are frozen when today's report exists");
+  assert.deepEqual(model.metrics, { reminders: 1, responses: 2, familiars: 4, sessions: 3 });
+}
+
+// before today's report exists, metrics fall back to the live snapshot
+{
+  const model = buildDashboardModel(
+    [item({ id: "rem", kind: "reminder", status: "fired" })],
+    now,
+  );
+  assert.equal(model.todaySummary, null, "no today summary before a report generates");
+  assert.equal(model.metricsLive, true, "metrics are the live snapshot");
+  assert.equal(model.metrics.reminders, 1, "live snapshot counts today's fired reminder");
 }
 
 // with no today report, latest is featured

--- a/src/lib/dashboard-model.ts
+++ b/src/lib/dashboard-model.ts
@@ -1,26 +1,58 @@
-// Pure view-model for the /dashboard surface. Composes the existing
-// daily-report helpers and decides, from the live inbox, whether the page
-// leads with triage (something needs you) or the launcher (caught up).
+// Pure view-model for the unified /dashboard surface. Composes the existing
+// daily-report helpers and decides, from the live inbox, how to order the
+// single-page layout: triage-first when something needs you, calm-first when
+// caught up. Today's daily summary (metrics, narrative, familiar updates) is
+// folded in here so the dashboard *is* the day's report — the standalone
+// /daily-report/[date] route remains for historical days.
 //
 // Kept free of `node:` imports — `InboxItem` is a type-only import — so the
 // client action-inbox island and the strip-types tests can import it safely.
 
 import type { InboxItem } from "./cave-inbox";
-import { breakdownForDay, dateSlug, recentReports, type RecentReport } from "./daily-report";
+import {
+  breakdownForDay,
+  dateSlug,
+  liveSnapshot,
+  parseRecentSessions,
+  recentReports,
+  type DailyReportStats,
+  type RecentReport,
+} from "./daily-report";
 
 /** Zones the dashboard can render, in display order. Presence varies by state. */
 export type DashboardZone =
   | "caughtUpStrip"
   | "actionInbox"
-  | "reportCallout"
+  | "metrics"
+  | "todaySummary"
+  | "familiarUpdates"
   | "launcher"
   | "recentReports";
+
+/** Today's generated daily summary, surfaced inline on the dashboard. */
+export type TodaySummary = {
+  title: string;
+  body: string;
+  imageUrl: string | null;
+  alt: string;
+  generatedAt: string | null;
+  /** Read-only session names recovered from the frozen summary body. */
+  recentSessions: string[];
+};
 
 export type DashboardModel = {
   date: Date;
   caughtUp: boolean;
   /** Open, actionable items — same set the old "Needs attention" list showed, capped. */
   needsAttention: InboxItem[];
+  /** Day-at-a-glance counts. Frozen (from today's report) when available, else live. */
+  metrics: DailyReportStats;
+  /** True when `metrics` is the live inbox snapshot rather than a frozen report. */
+  metricsLive: boolean;
+  /** Familiar updates fired today (live). */
+  familiarUpdates: InboxItem[];
+  /** Today's generated summary narrative, or null before one exists. */
+  todaySummary: TodaySummary | null;
   todaysReport: RecentReport | null;
   featuredReport: RecentReport | null;
   /** Reports other than the featured one (newest first). */
@@ -35,22 +67,58 @@ export function buildDashboardModel(items: InboxItem[], now: Date): DashboardMod
   const todaySlug = dateSlug(now);
   const todaysReport = reports.find((r) => r.slug === todaySlug) ?? null;
   const featuredReport = todaysReport ?? reports[0] ?? null;
+
+  const todayItem = items.find(
+    (item) => item.kind === "daily-summary" && item.auto === `daily-summary:${todaySlug}`,
+  );
+  const todaySummary: TodaySummary | null = todayItem
+    ? {
+        title: todayItem.title,
+        body: todayItem.body ?? "",
+        imageUrl: todayItem.media?.imageUrl ?? null,
+        alt: todayItem.media?.alt ?? "",
+        generatedAt: todayItem.firedAt ?? todayItem.updatedAt ?? null,
+        recentSessions: parseRecentSessions(todayItem.body),
+      }
+    : null;
+
+  // Prefer the frozen counts captured when today's report ran (they include
+  // daemon-backed session counts the client can't see); fall back to the live
+  // snapshot before any report exists.
+  const frozen = todayItem?.media?.stats ?? null;
+  const metrics = frozen ?? liveSnapshot(items, now);
+
   return {
     date: now,
     caughtUp: breakdown.openItems.length === 0,
     needsAttention: breakdown.openItems.slice(0, NEEDS_ATTENTION_CAP),
+    metrics,
+    metricsLive: frozen === null,
+    familiarUpdates: breakdown.familiars,
+    todaySummary,
     todaysReport,
     featuredReport,
     recentReports: reports.filter((r) => r.slug !== featuredReport?.slug),
   };
 }
 
-/** Ordered zones for the current state. Launcher/report variants are decided in the view. */
+/**
+ * Ordered zones for the current state on the single unified page.
+ *
+ * - Busy → lead with the action inbox (triage), then the day at a glance,
+ *   today's summary, the launcher, and recent reports.
+ * - Caught up → lead with the calm strip, then metrics, today's story,
+ *   familiar updates, the launcher, and recent reports.
+ *
+ * The `metrics` and `todaySummary` zones always render: `metrics` shows live
+ * counts before a report exists, and `todaySummary` falls back to a callout
+ * linking the latest report when today's hasn't generated yet.
+ */
 export function dashboardLayout(model: DashboardModel): DashboardZone[] {
   if (model.caughtUp) {
-    return ["caughtUpStrip", "reportCallout", "launcher", "recentReports"];
+    return ["caughtUpStrip", "metrics", "todaySummary", "familiarUpdates", "launcher", "recentReports"];
   }
-  return ["actionInbox", "reportCallout", "launcher"];
+  return ["actionInbox", "metrics", "todaySummary", "launcher", "recentReports"];
 }
 
 /**

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -86,3 +86,60 @@
   .dash-inbox__actions { flex-wrap: wrap; justify-content: flex-end; }
   .dr-quicklinks.dash-launcher--compact { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
+
+/* ── Unified dashboard: today's daily summary, folded inline ───────────────
+   The narrative panel sits beside its generated illustration on wide screens
+   and stacks on narrow ones. Reuses the shared .dr-panel / .dr-cardimg look. */
+.dash-today__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+@media (min-width: 720px) {
+  .dash-today__grid--media {
+    grid-template-columns: minmax(0, 1.4fr) minmax(220px, 0.9fr);
+  }
+}
+.dash-today__panel { display: flex; flex-direction: column; gap: 16px; }
+.dash-today__img {
+  width: 100%;
+  height: 100%;
+  max-height: 360px;
+  object-fit: cover;
+  border-radius: 14px;
+  border: 1px solid var(--border-hairline);
+}
+.dash-today__placeholder { color: var(--text-muted); font-style: italic; }
+
+.dash-today__sessions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border-hairline);
+}
+.dash-today__sessions-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.dash-today__chips { display: flex; flex-wrap: wrap; gap: 7px; }
+.dash-today__chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  background: var(--bg-base);
+  border: 1px solid var(--border-hairline);
+}
+
+/* Greeting eyebrow icon — replaces the old presence dot with a sun/moon. */
+.dr-eyebrow__icon { font-size: 0.85rem; color: var(--accent-presence); }


### PR DESCRIPTION
## What

Merges the **daily summary into the dashboard** so it reads as one page. Today's metrics, the auto-generated narrative + illustration, and live familiar updates now render inline alongside the action inbox and launcher — no bouncing to `/daily-report` for today. The standalone `/daily-report/[date]` route stays for historical days (linked from Recent reports).

## Changes

- **`dashboard-model.ts`** — adds `metrics` (frozen from today's report when it exists, else the live snapshot), `metricsLive`, `todaySummary` (narrative / image / recovered session names), and `familiarUpdates`; reworks the adaptive zone order (triage-first when busy, calm-first when caught up).
- **New zones** — `MetricsStrip` ("Today at a glance"), `TodaySummary` (narrative + illustration; falls back to the report callout before today's generates), `FamiliarUpdates`.
- **Hero** — time-of-day greeting (`greeting()` helper).
- **`dashboard.css`** — responsive narrative/illustration grid + session chips.
- Icons limited to the existing `ICON_NAMES` allowlist (`ph:sun`/`ph:moon`/`ph:graph-bold`).

## Tests

`dashboard-model.test.ts` covers the new metrics/today-summary/familiar fields and the reworked layout; `dashboard-page.test.ts` pins the folded-in zones. Full `test:app` green.

## ⚠️ Note on CI

`main` is currently **red** on an unrelated break — `src/components/library-doc-list.tsx` references undefined `relDateFmt`/`Button`/`EmptyState`/`SkeletonRows` (a semantic clash from the concurrent library #1110/#1115/#1124 merges). This fails `pnpm typecheck` for every PR. This PR does **not** touch library files; it will go green once main is fixed (or after rebasing onto a fixed main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)