### PR TITLE
feat(board): add schedule windows and timeline view

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -318,6 +318,7 @@ export const SUITES = {
     "src/lib/vault-bundle.test.ts",
     "src/lib/cave-board-atomic.test.ts",
     "src/lib/env-local-bundle.test.ts",
+    "src/lib/cave-board-schedule.test.ts",
     "src/components/ui/tabs.test.ts",
     "src/components/security/sidecar-auth-bridge.test.ts",
     "src/components/familiar-switcher.test.ts",
@@ -351,6 +352,7 @@ export const SUITES = {
     "src/components/right-panel-expand.test.ts",
     "src/lib/next-paths.test.ts",
     "src/components/board-clear-done.test.ts",
+    "src/components/board-schedule-window.test.ts",
   ],
   api: [
     "scripts/dependency-policy.test.mjs",
@@ -472,6 +474,7 @@ const ALIAS_LOADER = new Set([
   "src/lib/cave-config-state-race.test.ts",
   "src/lib/cave-board-atomic.test.ts",
   "src/lib/cave-board-steps.test.ts",
+  "src/lib/cave-board-schedule.test.ts",
   "src/lib/salem/pathfinder-feedback.test.ts",
   "src/lib/session-rail-title.test.ts",
   "src/lib/server/familiar-contract-files.test.ts",

--- a/src/app/api/board/[id]/route.ts
+++ b/src/app/api/board/[id]/route.ts
@@ -30,6 +30,8 @@ export async function PATCH(
     links: string[];
     github: CardGitHubLink[];
     labels: string[];
+    startDate: string | null;
+    endDate: string | null;
     needsHuman: boolean;
     runningSince: string | undefined;
     steps: CardStep[];

--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -27,6 +27,8 @@ export async function POST(req: Request) {
     links?: string[];
     github?: CardGitHubLink[];
     labels?: string[];
+    startDate?: string | null;
+    endDate?: string | null;
     template?: string | null;
     steps?: { text: string }[];
   };
@@ -50,6 +52,8 @@ export async function POST(req: Request) {
     links: body.links,
     github: body.github,
     labels: body.labels,
+    startDate: body.startDate,
+    endDate: body.endDate,
     template: body.template,
     steps: body.steps,
   });

--- a/src/components/board-card-stack.tsx
+++ b/src/components/board-card-stack.tsx
@@ -21,6 +21,23 @@ const SECTIONS: { id: CardStatus; label: string }[] = [
   { id: "done", label: "Done" },
 ];
 
+function formatBoardDate(value: string | null | undefined): string {
+  if (!value) return "";
+  const [year, month, day] = value.split("-");
+  if (!year || !month || !day) return value;
+  return `${month}/${day}`;
+}
+
+function scheduleLabel(startDate: string | null | undefined, endDate: string | null | undefined): string {
+  if (startDate && endDate) {
+    if (startDate === endDate) return formatBoardDate(startDate);
+    return `${formatBoardDate(startDate)}-${formatBoardDate(endDate)}`;
+  }
+  if (startDate) return `Starts ${formatBoardDate(startDate)}`;
+  if (endDate) return `Ends ${formatBoardDate(endDate)}`;
+  return "";
+}
+
 type FilterValue = "all" | CardStatus;
 
 type Props = {
@@ -168,6 +185,7 @@ function BoardCardStackRow({
   );
   const resolvedFamiliar = resolvedFamiliars[0] ?? null;
   const session = sessions.find((s) => s.id === card.sessionId) ?? null;
+  const schedule = scheduleLabel(card.startDate, card.endDate);
 
   return (
     <li
@@ -204,6 +222,12 @@ function BoardCardStackRow({
               {resolvedFamiliar?.display_name ?? "Unassigned"}
             </span>
           </span>
+          {schedule ? (
+            <span className="board-card-stack__row-schedule" title={`Scheduled ${schedule}`}>
+              <Icon name="ph:calendar-blank" width={11} />
+              {schedule}
+            </span>
+          ) : null}
           {session ? (
             <span
               className="board-card-stack__row-action board-card-stack__row-action--chat"

--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import type { Card } from "@/lib/cave-board-types";
+
+type Props = {
+  cards: Card[];
+  selectedCardId: string | null;
+  onSelect: (id: string) => void;
+};
+
+type ScheduledCard = {
+  card: Card;
+  start: Date;
+  end: Date;
+};
+
+function parseDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function formatLabel(date: Date): string {
+  return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", timeZone: "UTC" }).format(date);
+}
+
+function daysBetween(start: Date, end: Date): number {
+  return Math.round((end.getTime() - start.getTime()) / 86_400_000);
+}
+
+export function BoardGantt({ cards, selectedCardId, onSelect }: Props) {
+  const scheduled: ScheduledCard[] = [];
+  const unscheduled: Card[] = [];
+
+  for (const card of cards) {
+    const startDate = parseDate(card.startDate);
+    const endDate = parseDate(card.endDate);
+    if (!startDate && !endDate) {
+      unscheduled.push(card);
+      continue;
+    }
+    const start = startDate ?? endDate!;
+    const end = endDate ?? startDate!;
+    scheduled.push({ card, start: start <= end ? start : end, end: start <= end ? end : start });
+  }
+
+  if (scheduled.length === 0) {
+    return (
+      <div className="board-gantt board-gantt--empty">
+        <p>No tasks have start and end dates yet.</p>
+        {unscheduled.length > 0 ? (
+          <span>{unscheduled.length} task{unscheduled.length === 1 ? "" : "s"} without dates</span>
+        ) : null}
+      </div>
+    );
+  }
+
+  const min = new Date(Math.min(...scheduled.map((item) => item.start.getTime())));
+  const max = new Date(Math.max(...scheduled.map((item) => item.end.getTime())));
+  const span = Math.max(1, daysBetween(min, max) + 1);
+
+  return (
+    <div className="board-gantt">
+      <div className="board-gantt-header">
+        <span>{formatLabel(min)}</span>
+        <span>{formatLabel(max)}</span>
+      </div>
+      <div className="board-gantt-list">
+        {scheduled
+          .sort((a, b) => a.start.getTime() - b.start.getTime() || a.end.getTime() - b.end.getTime())
+          .map(({ card, start, end }) => {
+            const offset = Math.max(0, daysBetween(min, start));
+            const duration = Math.max(1, daysBetween(start, end) + 1);
+            const left = `${(offset / span) * 100}%`;
+            const width = `${Math.max(5, (duration / span) * 100)}%`;
+            return (
+              <button
+                key={card.id}
+                type="button"
+                className={`board-gantt-row${selectedCardId === card.id ? " board-gantt-row--selected" : ""}`}
+                onClick={() => onSelect(card.id)}
+              >
+                <span className="board-gantt-row__title">{card.title}</span>
+                <span className="board-gantt-row__track" aria-hidden>
+                  <span className={`board-gantt-row__bar board-gantt-row__bar--${card.priority}`} style={{ left, width }} />
+                </span>
+                <span className="board-gantt-row__dates">
+                  {formatLabel(start)}-{formatLabel(end)}
+                </span>
+              </button>
+            );
+          })}
+      </div>
+      {unscheduled.length > 0 ? (
+        <div className="board-gantt-unscheduled">
+          {unscheduled.length} task{unscheduled.length === 1 ? "" : "s"} without dates
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -956,6 +956,27 @@ export function BoardInspector({ card, familiars, sessions, projects, onClose, o
               </div>
             </div>
 
+            <div className="board-drawer-grid-2">
+              <div className="board-drawer-field">
+                <div className="board-drawer-field-label">Start date</div>
+                <input
+                  className="board-drawer-field-input"
+                  type="date"
+                  value={card.startDate ?? ""}
+                  onChange={(e) => onPatch(card.id, { startDate: e.target.value || null })}
+                />
+              </div>
+              <div className="board-drawer-field">
+                <div className="board-drawer-field-label">End date</div>
+                <input
+                  className="board-drawer-field-input"
+                  type="date"
+                  value={card.endDate ?? ""}
+                  onChange={(e) => onPatch(card.id, { endDate: e.target.value || null })}
+                />
+              </div>
+            </div>
+
             <div className="board-drawer-field">
               <div className="board-drawer-field-label board-drawer-field-label--split">
                 <span>Project</span>

--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -27,6 +27,23 @@ const PRIORITIES: { id: CardPriority; label: string }[] = [
   { id: "low",    label: "Low" },
 ];
 
+function formatBoardDate(value: string | null | undefined): string {
+  if (!value) return "";
+  const [year, month, day] = value.split("-");
+  if (!year || !month || !day) return value;
+  return `${month}/${day}`;
+}
+
+function scheduleLabel(startDate: string | null | undefined, endDate: string | null | undefined): string {
+  if (startDate && endDate) {
+    if (startDate === endDate) return formatBoardDate(startDate);
+    return `${formatBoardDate(startDate)}-${formatBoardDate(endDate)}`;
+  }
+  if (startDate) return `Starts ${formatBoardDate(startDate)}`;
+  if (endDate) return `Ends ${formatBoardDate(endDate)}`;
+  return "";
+}
+
 type Props = {
   cards: Card[];
   familiars: Familiar[];
@@ -492,7 +509,8 @@ function KanbanCard({ card, familiars, sessions, isDragging, isSelected, isGrabb
   // must not crash the whole board render.
   const pri = PRIORITIES.find((p) => p.id === card.priority) ?? { id: card.priority, label: card.priority };
   const statusLabel = COLUMNS.find((c) => c.id === card.status)?.label ?? card.status;
-  const hasChips = !!card.cwd || card.links.length > 0 || card.labels.length > 0 || !!session;
+  const schedule = scheduleLabel(card.startDate, card.endDate);
+  const hasChips = !!schedule || !!card.cwd || card.links.length > 0 || card.labels.length > 0 || !!session;
 
   return (
     <li draggable
@@ -527,6 +545,12 @@ function KanbanCard({ card, familiars, sessions, isDragging, isSelected, isGrabb
             >
               <Icon name="ph:chat-circle-dots" width={9} />
               Chat
+            </span>
+          )}
+          {schedule && (
+            <span className="board-kanban-card-chip board-kanban-card-chip--schedule" title={`Scheduled ${schedule}`}>
+              <Icon name="ph:calendar-blank" width={9} />
+              {schedule}
             </span>
           )}
           {card.cwd && (

--- a/src/components/board-schedule-window.test.ts
+++ b/src/components/board-schedule-window.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const boardTypes = readFileSync("src/lib/cave-board-types.ts", "utf8");
+const boardStore = readFileSync("src/lib/cave-board.ts", "utf8");
+const createRoute = readFileSync("src/app/api/board/route.ts", "utf8");
+const updateRoute = readFileSync("src/app/api/board/[id]/route.ts", "utf8");
+const modal = readFileSync("src/components/new-card-modal.tsx", "utf8");
+const inspector = readFileSync("src/components/board-inspector.tsx", "utf8");
+const kanban = readFileSync("src/components/board-kanban.tsx", "utf8");
+const table = readFileSync("src/components/board-table.tsx", "utf8");
+const stack = readFileSync("src/components/board-card-stack.tsx", "utf8");
+const view = readFileSync("src/components/board-view.tsx", "utf8");
+const gantt = readFileSync("src/components/board-gantt.tsx", "utf8");
+const styles = readFileSync("src/styles/board.css", "utf8");
+
+assert.match(boardTypes, /startDate\?: string \| null/, "Task cards persist an optional start date");
+assert.match(boardTypes, /endDate\?: string \| null/, "Task cards persist an optional end date");
+assert.match(boardStore, /function normalizeBoardDate/, "Task persistence normalizes schedule dates");
+assert.match(boardStore, /startDate: normalizeBoardDate\(input\.startDate\)/, "Task creation stores normalized start dates");
+assert.match(boardStore, /endDate: normalizeBoardDate\(input\.endDate\)/, "Task creation stores normalized end dates");
+assert.match(boardStore, /startDate: "startDate" in patch \? normalizeBoardDate\(patch\.startDate\) : current\.startDate \?\? null/, "Task updates patch normalized start dates");
+assert.match(boardStore, /endDate: "endDate" in patch \? normalizeBoardDate\(patch\.endDate\) : current\.endDate \?\? null/, "Task updates patch normalized end dates");
+assert.match(createRoute, /startDate\?: string \| null/, "Create API accepts startDate");
+assert.match(createRoute, /endDate\?: string \| null/, "Create API accepts endDate");
+assert.match(updateRoute, /startDate: string \| null/, "Update API accepts startDate");
+assert.match(updateRoute, /endDate: string \| null/, "Update API accepts endDate");
+
+assert.match(modal, /startDate,\s*setStartDate/, "New task modal tracks start date");
+assert.match(modal, /endDate,\s*setEndDate/, "New task modal tracks end date");
+assert.match(modal, /<Field label="Start date">[\s\S]*?type="date"[\s\S]*?value=\{startDate\}/, "New task modal renders a start-date input");
+assert.match(modal, /<Field label="End date">[\s\S]*?type="date"[\s\S]*?value=\{endDate\}/, "New task modal renders an end-date input");
+assert.match(modal, /startDate: startDate \|\| null/, "New task modal includes startDate in create payload");
+assert.match(modal, /endDate: endDate \|\| null/, "New task modal includes endDate in create payload");
+assert.match(inspector, /<div className="board-drawer-field-label">Start date<\/div>[\s\S]*?type="date"[\s\S]*?value=\{card\.startDate \?\? ""\}/, "Inspector exposes a start-date editor");
+assert.match(inspector, /<div className="board-drawer-field-label">End date<\/div>[\s\S]*?type="date"[\s\S]*?value=\{card\.endDate \?\? ""\}/, "Inspector exposes an end-date editor");
+assert.match(inspector, /onPatch\(card\.id, \{ startDate: e\.target\.value \|\| null \}\)/, "Inspector patches startDate");
+assert.match(inspector, /onPatch\(card\.id, \{ endDate: e\.target\.value \|\| null \}\)/, "Inspector patches endDate");
+
+assert.match(kanban, /scheduleLabel\(card\.startDate, card\.endDate\)[\s\S]*?board-kanban-card-chip--schedule/, "Kanban cards show schedule chips");
+assert.match(table, /key: "startDate"[\s\S]*?label: "Start"/, "Table has a start-date column");
+assert.match(table, /key: "endDate"[\s\S]*?label: "End"/, "Table has an end-date column");
+assert.match(table, /formatBoardDate\(card\.startDate\)/, "Table renders formatted start dates");
+assert.match(table, /formatBoardDate\(card\.endDate\)/, "Table renders formatted end dates");
+assert.match(stack, /scheduleLabel\(card\.startDate, card\.endDate\)[\s\S]*?board-card-stack__row-schedule/, "Mobile task rows show schedule windows");
+assert.match(view, /type ViewMode = "kanban" \| "table" \| "gantt"/, "BoardView includes Gantt as the third view mode");
+assert.match(view, /<BoardGantt cards=\{filtered\}/, "BoardView renders the Gantt view");
+assert.match(gantt, /export function BoardGantt/, "BoardGantt component exists");
+assert.match(gantt, /startDate/, "BoardGantt reads start dates");
+assert.match(gantt, /endDate/, "BoardGantt reads end dates");
+assert.match(gantt, /board-gantt-row__bar/, "BoardGantt renders timeline bars");
+assert.match(styles, /\.board-gantt/, "Board Gantt styles are defined");
+
+console.log("board-schedule-window.test.ts: ok");

--- a/src/components/board-table.tsx
+++ b/src/components/board-table.tsx
@@ -11,7 +11,7 @@ import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 
 export type GroupBy = "status" | "familiar" | "project";
-export type SortKey = "title" | "status" | "priority" | "familiar" | "lifecycle" | "updatedAt";
+export type SortKey = "title" | "status" | "priority" | "familiar" | "lifecycle" | "startDate" | "endDate" | "updatedAt";
 export type SortDir = "asc" | "desc";
 
 const STATUS_ORDER: Record<CardStatus, number> = { backlog: 0, inbox: 1, running: 2, review: 3, blocked: 4, done: 5 };
@@ -27,6 +27,8 @@ function sortCards(cards: Card[], key: SortKey, dir: SortDir, familiars: Familia
       case "priority": cmp = PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority]; break;
       case "familiar": cmp = fname(a.familiarId).localeCompare(fname(b.familiarId)); break;
       case "lifecycle": cmp = a.lifecycle.localeCompare(b.lifecycle); break;
+      case "startDate": cmp = (a.startDate ?? "9999-12-31").localeCompare(b.startDate ?? "9999-12-31"); break;
+      case "endDate": cmp = (a.endDate ?? "9999-12-31").localeCompare(b.endDate ?? "9999-12-31"); break;
       case "updatedAt": cmp = (b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""); break;
     }
     return dir === "asc" ? cmp : -cmp;
@@ -81,6 +83,13 @@ function relTime(iso: string): string {
   } catch { return ""; }
 }
 
+function formatBoardDate(value: string | null | undefined): string {
+  if (!value) return "—";
+  const [year, month, day] = value.split("-");
+  if (!year || !month || !day) return value;
+  return `${month}/${day}/${year.slice(-2)}`;
+}
+
 type ColDef = { key: SortKey; label: string; width?: string };
 const COLS: ColDef[] = [
   { key: "title",     label: "Title" },
@@ -88,6 +97,8 @@ const COLS: ColDef[] = [
   { key: "priority",  label: "Priority",  width: "90px" },
   { key: "familiar",  label: "Familiar",  width: "130px" },
   { key: "lifecycle", label: "Lifecycle", width: "100px" },
+  { key: "startDate", label: "Start",     width: "84px" },
+  { key: "endDate",   label: "End",       width: "84px" },
   { key: "updatedAt", label: "Updated",   width: "80px" },
 ];
 
@@ -235,6 +246,8 @@ export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId
                       </span>
                     </td>
                     <td><LifecycleBadge lifecycle={card.lifecycle} needsHuman={card.needsHuman} /></td>
+                    <td><span className="board-table-cell-date">{formatBoardDate(card.startDate)}</span></td>
+                    <td><span className="board-table-cell-date">{formatBoardDate(card.endDate)}</span></td>
                     <td style={{ textAlign: "right" }}><span className="board-table-cell-time">{relTime(card.updatedAt)}</span></td>
                   </tr>
                 );
@@ -246,4 +259,3 @@ export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId
     </div>
   );
 }
-

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -10,6 +10,7 @@ import { Icon } from "@/lib/icon";
 import { type Card, type CardStatus } from "@/lib/cave-board-types";
 import { cardMatchesBoardSearch } from "@/lib/board-search";
 import { BoardKanban } from "@/components/board-kanban";
+import { BoardGantt } from "@/components/board-gantt";
 import { BoardTable, type GroupBy } from "@/components/board-table";
 import { BoardCardStack } from "@/components/board-card-stack";
 import { BoardInspector } from "@/components/board-inspector";
@@ -17,7 +18,7 @@ import { useIsMobile } from "@/lib/use-viewport";
 import { chatProjectById } from "@/lib/chat-projects";
 import { useProjects } from "@/lib/use-projects";
 
-type ViewMode = "kanban" | "table";
+type ViewMode = "kanban" | "table" | "gantt";
 
 function loadPref<T extends string>(key: string, fallback: T, valid: T[]): T {
   if (typeof window === "undefined") return fallback;
@@ -42,7 +43,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
   const [hasLoaded, setHasLoaded] = useState(false);
   // Transient feedback when an optimistic mutation fails and is reverted.
   const [actionError, setActionError] = useState<string | null>(null);
-  const [viewMode, setViewMode] = useState<ViewMode>(() => loadPref("cave:board:viewMode", "kanban", ["kanban", "table"]));
+  const [viewMode, setViewMode] = useState<ViewMode>(() => loadPref("cave:board:viewMode", "kanban", ["kanban", "table", "gantt"]));
   const [groupBy, setGroupBy] = useState<GroupBy>(() => loadPref("cave:board:groupBy", "status", ["status", "familiar", "project"]));
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
@@ -263,6 +264,8 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
               links: c.links,
               github: c.github,
               labels: c.labels,
+              startDate: c.startDate,
+              endDate: c.endDate,
               template: c.template,
               steps: c.steps.map((s) => ({ text: s.text })),
             }),
@@ -390,6 +393,11 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
               className={`board-view-toggle-btn${viewMode === "table" ? " board-view-toggle-btn--active" : ""}`}
               onClick={() => setViewMode("table")}>
               <Icon name="ph:rows" width={14} />
+            </button>
+            <button type="button" aria-label="Timeline view"
+              className={`board-view-toggle-btn${viewMode === "gantt" ? " board-view-toggle-btn--active" : ""}`}
+              onClick={() => setViewMode("gantt")}>
+              <Icon name="ph:chart-bar-bold" width={14} />
             </button>
           </div>
 
@@ -546,6 +554,10 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
             onJumpToSession={onJumpToSession}
             onOpenTaskChat={onOpenTaskChat}
             chatLinkingId={chatLinkingId} />
+        ) : viewMode === "gantt" ? (
+          <BoardGantt cards={filtered}
+            selectedCardId={selectedCardId}
+            onSelect={setSelectedCardId} />
         ) : (
           <BoardTable cards={filtered} familiars={familiars} projects={projects}
             groupBy={effectiveGroupBy} selectedCardId={selectedCardId}

--- a/src/components/new-card-modal.tsx
+++ b/src/components/new-card-modal.tsx
@@ -24,6 +24,8 @@ export type NewCardDraft = {
   cwd: string | null;
   links: string[];
   labels: string[];
+  startDate: string | null;
+  endDate: string | null;
   template: null;
 };
 
@@ -66,6 +68,8 @@ export function NewCardModal({
   const [cwd, setCwd] = useState("");
   const [links, setLinks] = useState("");
   const [labels, setLabels] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const coarse = useIsCoarsePointer();
@@ -82,6 +86,8 @@ export function NewCardModal({
     setCwd("");
     setLinks(defaultLinks ? defaultLinks.join("\n") : "");
     setLabels(defaultLabels ? defaultLabels.join(", ") : "");
+    setStartDate("");
+    setEndDate("");
     setError(null);
   }, [open, defaultStatus, defaultFamiliarId, defaultTitle, defaultLinks, defaultNotes, defaultLabels]);
 
@@ -105,6 +111,8 @@ export function NewCardModal({
         cwd: cwd.trim() || null,
         links: parseDelimited(links),
         labels: parseDelimited(labels),
+        startDate: startDate || null,
+        endDate: endDate || null,
         template: null,
       });
       onClose();
@@ -247,6 +255,23 @@ export function NewCardModal({
               { value: "", label: "No project" },
               ...projects.map((p) => ({ value: p.id, label: p.name })),
             ]}
+          />
+        </Field>
+
+        <Field label="Start date">
+          <input
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground focus:border-border-strong"
+          />
+        </Field>
+        <Field label="End date">
+          <input
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground focus:border-border-strong"
           />
         </Field>
       </div>

--- a/src/lib/cave-board-schedule.test.ts
+++ b/src/lib/cave-board-schedule.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+const tmpHome = await mkdtemp(path.join(tmpdir(), "cave-board-schedule-"));
+process.env.HOME = tmpHome;
+
+const board = await import("./cave-board.ts");
+
+const card = await board.createCard({
+  title: "Timeline card",
+  startDate: "2026-06-20",
+  endDate: "2026-06-24",
+});
+
+assert.equal(card.startDate, "2026-06-20", "createCard stores a valid start date");
+assert.equal(card.endDate, "2026-06-24", "createCard stores a valid end date");
+
+const updated = await board.updateCard(card.id, {
+  startDate: "2026-06-21",
+  endDate: "2026-06-25",
+});
+assert.equal(updated?.startDate, "2026-06-21", "updateCard patches a start date");
+assert.equal(updated?.endDate, "2026-06-25", "updateCard patches an end date");
+
+const cleared = await board.updateCard(card.id, { startDate: null, endDate: null });
+assert.equal(cleared?.startDate, null, "updateCard clears start date to null");
+assert.equal(cleared?.endDate, null, "updateCard clears end date to null");
+
+const invalid = await board.createCard({
+  title: "Invalid dates",
+  startDate: "not-a-date",
+  endDate: "2026-02-31",
+});
+assert.equal(invalid.startDate, null, "invalid start dates normalize to null");
+assert.equal(invalid.endDate, null, "invalid end dates normalize to null");
+
+const reloaded = await board.loadBoard();
+assert.equal(reloaded.cards.find((c) => c.id === card.id)?.startDate, null, "cleared start date persisted");
+assert.equal(reloaded.cards.find((c) => c.id === card.id)?.endDate, null, "cleared end date persisted");
+assert.equal(reloaded.cards.find((c) => c.id === invalid.id)?.startDate, null, "invalid start date persisted as null");
+assert.equal(reloaded.cards.find((c) => c.id === invalid.id)?.endDate, null, "invalid end date persisted as null");
+
+console.log("cave-board-schedule.test.ts OK");

--- a/src/lib/cave-board-types.ts
+++ b/src/lib/cave-board-types.ts
@@ -47,6 +47,8 @@ export type Card = {
   links: string[];
   github: CardGitHubLink[];
   labels: string[];
+  startDate?: string | null;
+  endDate?: string | null;
   template?: string | null;
   createdAt: string;
   updatedAt: string;

--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -96,14 +96,23 @@ function normalizeCwd(value: string | null | undefined): string | null {
 
 type LegacyCard = Omit<
   Card,
-  "cwd" | "projectId" | "links" | "github" | "lifecycle" | "lifecycleAt" | "retryCount" | "maxRetries" | "steps"
+  "cwd" | "projectId" | "links" | "github" | "lifecycle" | "lifecycleAt" | "retryCount" | "maxRetries" | "steps" | "startDate" | "endDate"
 > &
   Partial<
     Pick<
       Card,
-      "cwd" | "projectId" | "links" | "github" | "lifecycle" | "lifecycleAt" | "retryCount" | "maxRetries" | "steps"
+      "cwd" | "projectId" | "links" | "github" | "lifecycle" | "lifecycleAt" | "retryCount" | "maxRetries" | "steps" | "startDate" | "endDate"
     >
   >;
+
+function normalizeBoardDate(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return null;
+  const date = new Date(`${trimmed}T00:00:00.000Z`);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString().slice(0, 10) === trimmed ? trimmed : null;
+}
 
 function backfillCard(c: Card | LegacyCard): Card {
   const lifecycle = c.lifecycle ?? inferLifecycle(c.status);
@@ -117,6 +126,8 @@ function backfillCard(c: Card | LegacyCard): Card {
     links,
     github,
     labels: normalizeList(c.labels),
+    startDate: normalizeBoardDate(c.startDate),
+    endDate: normalizeBoardDate(c.endDate),
     lifecycle,
     lifecycleAt: c.lifecycleAt ?? c.updatedAt,
     retryCount: c.retryCount ?? 0,
@@ -214,6 +225,8 @@ export type NewCardInput = {
   links?: string[];
   github?: CardGitHubLink[];
   labels?: string[];
+  startDate?: string | null;
+  endDate?: string | null;
   template?: string | null;
   /** Optional checklist steps to seed the card with (e.g. a Salem path). */
   steps?: { text: string }[];
@@ -238,6 +251,8 @@ export async function createCard(input: NewCardInput): Promise<Card> {
     links: mergeLinksWithGitHub(normalizeLinks(input.links), github),
     github,
     labels: normalizeList(input.labels),
+    startDate: normalizeBoardDate(input.startDate),
+    endDate: normalizeBoardDate(input.endDate),
     template: input.template ?? null,
     createdAt: now,
     updatedAt: now,
@@ -288,6 +303,8 @@ export async function updateCard(
     cwd: "cwd" in patch ? normalizeCwd(patch.cwd) : current.cwd,
     projectId: "projectId" in patch ? patch.projectId ?? null : current.projectId ?? null,
     sessionId: "sessionId" in patch ? patch.sessionId ?? null : current.sessionId,
+    startDate: "startDate" in patch ? normalizeBoardDate(patch.startDate) : current.startDate ?? null,
+    endDate: "endDate" in patch ? normalizeBoardDate(patch.endDate) : current.endDate ?? null,
     steps: patch.steps ?? current.steps,
   };
   if (next.lifecycle === "running" && !next.runningSince) {

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -215,6 +215,7 @@
 .board-table-cell-links { display:inline-flex; align-items:center; gap:4px; color:var(--text-secondary); font-size:11px; }
 .board-table-cell-links svg { color:var(--text-muted); }
 .board-table-cell-empty { color:color-mix(in oklch,var(--text-muted) 50%,transparent); font-size:11px; }
+.board-table-cell-date { color:var(--text-secondary); font-size:11px; font-variant-numeric:tabular-nums; white-space:nowrap; }
 .board-table-cell-time { color:var(--text-muted); font-size:11px; font-variant-numeric:tabular-nums; }
 
 .board-swimlane { flex-shrink:0; border-bottom:1px solid var(--border-hairline); }
@@ -309,6 +310,8 @@
 .board-kanban-card-chip--more { color:var(--text-muted); background:transparent; border-color:transparent; padding:1px 2px; }
 .board-kanban-card-chip--chat { color:var(--accent-presence); background:color-mix(in oklch,var(--accent-presence) 12%,transparent); border-color:color-mix(in oklch,var(--accent-presence) 35%,var(--border-hairline)); }
 .board-kanban-card-chip--chat svg { color:var(--accent-presence); }
+.board-kanban-card-chip--schedule { color:var(--color-warning); background:color-mix(in oklch,var(--color-warning) 12%,transparent); border-color:color-mix(in oklch,var(--color-warning) 32%,var(--border-hairline)); }
+.board-kanban-card-chip--schedule svg { color:var(--color-warning); }
 
 .board-kanban-card-footer { display:flex; align-items:center; justify-content:space-between; gap:6px; padding-top:6px; border-top:1px dashed var(--border-hairline); }
 .board-kanban-card-familiar { display:inline-flex; align-items:center; gap:5px; min-width:0; flex:1; }
@@ -1126,6 +1129,14 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.board-card-stack__row-schedule {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--color-warning);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
 .board-card-stack__row-action {
   margin-left: auto;
   display: inline-flex;
@@ -1141,6 +1152,92 @@
 .board-card-stack__row-action:hover {
   background: var(--bg-hover);
   color: var(--text-primary);
+}
+
+/* Board Gantt */
+.board-gantt {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 14px;
+}
+.board-gantt--empty {
+  display: grid;
+  place-content: center;
+  gap: 6px;
+  text-align: center;
+  color: var(--text-muted);
+}
+.board-gantt-header {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 10px 8px 180px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+.board-gantt-list {
+  display: grid;
+  gap: 8px;
+}
+.board-gantt-row {
+  display: grid;
+  grid-template-columns: minmax(140px, 180px) minmax(220px, 1fr) minmax(96px, auto);
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 42px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 8px;
+  background: var(--bg-raised);
+  color: var(--text-primary);
+  padding: 8px 10px;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color .12s, background .12s;
+}
+.board-gantt-row:hover,
+.board-gantt-row--selected {
+  border-color: color-mix(in oklch,var(--accent-presence) 42%,var(--border-hairline));
+  background: color-mix(in oklch,var(--accent-presence) 8%,var(--bg-raised));
+}
+.board-gantt-row__title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 600;
+}
+.board-gantt-row__track {
+  position: relative;
+  height: 12px;
+  border-radius: 999px;
+  background: var(--bg-base);
+  border: 1px solid var(--border-hairline);
+  overflow: hidden;
+}
+.board-gantt-row__bar {
+  position: absolute;
+  top: 2px;
+  bottom: 2px;
+  min-width: 12px;
+  border-radius: 999px;
+  background: var(--accent-presence);
+}
+.board-gantt-row__bar--urgent { background: var(--color-danger); }
+.board-gantt-row__bar--high { background: var(--color-warning); }
+.board-gantt-row__bar--medium { background: var(--accent-presence); }
+.board-gantt-row__bar--low { background: color-mix(in oklch,var(--text-muted) 55%,transparent); }
+.board-gantt-row__dates {
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.board-gantt-unscheduled {
+  margin-top: 10px;
+  color: var(--text-muted);
+  font-size: 11px;
 }
 
 .board-card-stack__row-menu-trigger {


### PR DESCRIPTION
## Summary
- Add Board start/end date fields across persistence, create/update APIs, new-card modal, inspector, Kanban/mobile chips, and table columns.
- Add a Board timeline view based on start/end windows.
- Add focused persistence and UI wiring tests for schedule windows and wire them into the app test suite.

## Verification
- node scripts/check-tests-wired.mjs
- git diff --check
- pnpm typecheck
- pnpm test:app
- pnpm build