### PR TITLE
fix(library): repair broken library-doc-list (red main)

### DIFF
--- a/src/components/library-doc-list.tsx
+++ b/src/components/library-doc-list.tsx
@@ -3,6 +3,11 @@
 import { useState } from "react";
 import { Icon } from "@/lib/icon";
 import { formatDate } from "@/lib/datetime-format";
+import { relativeTime } from "@/lib/relative-time";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorState } from "@/components/ui/error-state";
+import { SkeletonRows } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import type { LibraryCollection, LibraryDoc } from "@/lib/library-types";
 
 type Props = {
@@ -22,17 +27,12 @@ type Props = {
 };
 
 function relDate(iso: string): string {
-  try {
-    const diff = new Date(iso).getTime() - Date.now();
-    const absDiff = Math.abs(diff);
-    if (absDiff < 60_000) return "just now";
-    if (absDiff < 3_600_000) return relDateFmt.format(Math.round(diff / 60_000), "minutes");
-    if (absDiff < 86_400_000) return relDateFmt.format(Math.round(diff / 3_600_000), "hours");
-    if (absDiff < 86_400_000 * 30) return relDateFmt.format(Math.round(diff / 86_400_000), "days");
-    return formatDate(iso);
-  } catch {
-    return "";
-  }
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  // Older than a week → date-pref-aware absolute date; recent → the shared
+  // compact relative time so every Library tab reads identically.
+  if (Date.now() - then >= 7 * 86_400_000) return formatDate(iso);
+  return relativeTime(iso);
 }
 
 function filterDocs(docs: LibraryDoc[], query: string): LibraryDoc[] {


### PR DESCRIPTION
## 🔴 main is currently RED — this unblocks it

`src/components/library-doc-list.tsx` does not type-check on `main`, so the **Frontend build** check fails for every PR.

### Root cause
PR #1124 ("route verbose dates through the app-wide date pref" — a near-duplicate of #1108 from a parallel session) botched a revert when it squash-merged on a stale base:
- it **removed** the `relativeTime`, `EmptyState`, `ErrorState`, `SkeletonRows`, `Button` imports and reintroduced a `relDateFmt.format(...)` call whose `const relDateFmt` declaration was already gone (deleted by #1115),
- but the component still **renders** `<EmptyState>`, `<SkeletonRows>`, `<ErrorState>`, `<Button>` (from #1110).

Result: `Cannot find name 'relDateFmt' / 'EmptyState' / 'SkeletonRows' / 'Button'`. Later PRs (#1126, #1134–#1136) merged anyway because branch protection validated them against their own green branch heads, not the post-#1124 main (the classic merge-unvalidated gap).

### Fix
Restore `library-doc-list.tsx` to its last self-consistent state (#1115 / `b5908cdf`): shared `relativeTime()` for recent dates + date-pref `formatDate()` for older, with the shared empty/error/skeleton primitives properly imported. #1124 touched **only** this file, so this is a clean, complete repair with no behavior change beyond compiling.

### Verification
Full `pnpm build` (test:app + next build) green in a fresh worktree off current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)