### PR TITLE
fix(library): restore missing imports + relDateFmt in library-doc-list (unbreak main)

### DIFF
--- a/src/components/library-doc-list.tsx
+++ b/src/components/library-doc-list.tsx
@@ -3,6 +3,10 @@
 import { useState } from "react";
 import { Icon } from "@/lib/icon";
 import { formatDate } from "@/lib/datetime-format";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorState } from "@/components/ui/error-state";
+import { SkeletonRows } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import type { LibraryCollection, LibraryDoc } from "@/lib/library-types";
 
 type Props = {
@@ -20,6 +24,8 @@ type Props = {
   /** Triggered when the user clicks Retry in the error state. */
   onRetry?: () => void;
 };
+
+const relDateFmt = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
 
 function relDate(iso: string): string {
   try {


### PR DESCRIPTION
## Why

`main` is **red**: `pnpm typecheck` (a required step in the Frontend build CI job) fails on `src/components/library-doc-list.tsx`, which references `EmptyState`/`ErrorState`/`SkeletonRows`/`Button` without importing them and calls a dropped `relDateFmt`. This blocks **every** open PR.

It's a semantic clash from concurrent library merges — #1110 (unify empty/loading/error states) added those components to the other three Library tabs, #1124 (app-wide date pref) reworked dates — and the doc-list tab was left half-migrated.

## Fix

- Add the four shared-UI imports, mirroring the sibling tabs (`library-reading-list.tsx`, etc.): `@/components/ui/{empty-state,error-state,skeleton,button}`.
- Restore the module-scope `const relDateFmt = new Intl.RelativeTimeFormat(...)` that `relDate()` uses — behavior-preserving.

`tsc --noEmit` → **0 errors**. Surgical, one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)