### PR TITLE
feat(workflows): a real empty state for the unselected builder canvas

### DIFF
--- a/src/components/workflows/workflow-canvas.tsx
+++ b/src/components/workflows/workflow-canvas.tsx
@@ -259,7 +259,15 @@ export function WorkflowCanvas({
   if (!workflow) {
     return (
       <section className="workflow-canvas workflow-canvas-empty" aria-label="Workflow canvas">
-        <p>Select a workflow to preview its graph.</p>
+        <div className="workflow-canvas-empty-inner">
+          <span className="workflow-canvas-empty-icon" aria-hidden>
+            <Icon name="ph:graph" width={22} />
+          </span>
+          <p className="workflow-canvas-empty-title">No workflow selected</p>
+          <p className="workflow-canvas-empty-hint">
+            Pick a workflow from the library on the left, or create a new one to start building its graph.
+          </p>
+        </div>
       </section>
     );
   }

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -705,6 +705,38 @@
   font-size: 13px;
 }
 
+.workflow-canvas-empty-inner {
+  display: grid;
+  justify-items: center;
+  gap: 6px;
+  max-width: 320px;
+  text-align: center;
+}
+
+.workflow-canvas-empty-icon {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  margin-bottom: 4px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--muted-foreground);
+}
+
+.workflow-canvas-empty-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.workflow-canvas-empty-hint {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--muted-foreground);
+}
+
 .workflow-node {
   width: 172px;
   border: 1px solid var(--border);


### PR DESCRIPTION
## What

When no workflow is selected, the workflow builder's **central canvas** — the largest panel on screen — showed a single bare line: "Select a workflow to preview its graph." It now renders a proper empty state: an icon badge, a **"No workflow selected"** title, and a hint pointing to the library / create flow.

Styled with the builder's own design tokens (`--border`, `--card`, `--muted-foreground`, `--text-primary`) rather than forcing the shared `ui/EmptyState` into the dense editor. The small inline placeholders in the narrow side-panels (inspector, steps, runs, manifest) are intentionally left as-is — a heavy centered empty state would be wrong there.

## Why

It's the first thing you see when you open Workflows without a selection, and the barren one-liner made the surface feel unfinished.

## Tests / verification

- No test pins the canvas placeholder text.
- Full `pnpm build` (test:app + next build) green; `tsc --noEmit` clean.
- Live-verified: navigating to the Workflows surface with nothing selected renders the icon badge + "No workflow selected" + hint, centered in the canvas. Screenshot confirmed.

> Note: rebased onto `main` after #1139 (which repaired a red `main` caused by #1124's botched revert of `library-doc-list.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)