### PR TITLE
feat(palette): navigate to surfaces from the command palette

### DIFF
--- a/src/components/command-palette.test.ts
+++ b/src/components/command-palette.test.ts
@@ -10,6 +10,10 @@ const globals = readFileSync(
   new URL("../app/globals.css", import.meta.url),
   "utf8",
 );
+const workspace = readFileSync(
+  new URL("./workspace.tsx", import.meta.url),
+  "utf8",
+);
 
 // Input is labelled.
 assert.match(
@@ -111,5 +115,38 @@ assert.ok(stripMatch, "create-task title strips a leading /task prefix via repla
   assert.equal(strip("fix /task login"), "fix /task login", "mid-string '/task' untouched");
   assert.equal(strip("/taskforce roster"), "/taskforce roster", "'/taskforce' is not stripped");
 }
+
+// ── Surface navigation ("Go to <surface>") makes ⌘K a launcher ──
+assert.match(
+  source,
+  /kind:\s*"go-to-surface";\s*mode:\s*FolderMode/,
+  "palette exposes a go-to-surface intent",
+);
+assert.match(
+  source,
+  /import \{ FOLDER_MODES[\s\S]*?from "@\/components\/sidebar-minimal"/,
+  "surface rows are built from the shared FOLDER_MODES list (single source of truth)",
+);
+assert.match(
+  source,
+  /name:\s*`Go to \$\{fm\.label\}`/,
+  "each navigable surface renders a 'Go to <label>' row",
+);
+assert.match(
+  source,
+  /fm\.id === "github"[\s\S]{0,80}?addons\?\.github === true/,
+  "surface rows respect the same add-on gating as the sidebar (GitHub)",
+);
+assert.match(
+  source,
+  /\(scoped \|\| slashToken\)\s*\n?\s*\?\s*\[\]/,
+  "surface rows are hidden while typing a familiar scope or a slash command",
+);
+// Consumer: workspace switches surfaces on the intent.
+assert.match(
+  workspace,
+  /intent\.kind === "go-to-surface"[\s\S]{0,80}?setMode\(intent\.mode as WorkspaceMode\)/,
+  "workspace navigates to the chosen surface on a go-to-surface intent",
+);
 
 console.log("command-palette.test.ts OK");

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -9,6 +9,7 @@ import { platformizeHint, useKeySymbols } from "@/lib/platform-keys";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { parseFamiliarToken, resolveFamiliarIds } from "@/lib/command-palette-scope";
 import { MarkdownBlock } from "@/components/message-bubble";
+import { FOLDER_MODES, type FolderMode, type AddonsConfig } from "@/components/sidebar-minimal";
 
 type PaletteIntent =
   | { kind: "switch-familiar"; familiarId: string }
@@ -18,6 +19,7 @@ type PaletteIntent =
   | { kind: "back-to-list" }
   | { kind: "open-tui-session"; sessionId: string }
   | { kind: "open-board" }
+  | { kind: "go-to-surface"; mode: FolderMode }
   | { kind: "focus-card"; cardId: string }
   | { kind: "create-task"; title: string }
   | { kind: "open-memory-file"; path: string };
@@ -57,6 +59,8 @@ type Props = {
   initialQuery?: string;
   onQueryChange?: (query: string) => void;
   onIntent: (intent: PaletteIntent) => void;
+  /** Add-on gating so palette navigation matches the sidebar's visible surfaces. */
+  addons?: AddonsConfig;
 };
 
 type Row =
@@ -172,6 +176,7 @@ export function CommandPalette({
   initialQuery = "",
   onQueryChange,
   onIntent,
+  addons,
 }: Props) {
   const [query, setQuery] = useState("");
   const [activeIdx, setActiveIdx] = useState(0);
@@ -442,6 +447,31 @@ export function CommandPalette({
       ? [{ id: "create-task", kind: "create-task", title: trimmedTitle }]
       : [];
 
+    // "Go to <surface>" rows make ⌘K a launcher for the sidebar surfaces. Gated
+    // the same way the sidebar gates them, and hidden while typing a slash
+    // command or a familiar scope (where surface nav would be noise).
+    const surfaceRows: Row[] = (scoped || slashToken)
+      ? []
+      : FOLDER_MODES.filter((fm) => {
+          if (fm.id === "github") return addons?.github === true;
+          if (fm.id === "library") return addons?.library === true;
+          return true;
+        })
+          .filter(
+            (fm) =>
+              !q ||
+              fm.label.toLowerCase().includes(q) ||
+              fm.id.includes(q) ||
+              fm.description.toLowerCase().includes(q),
+          )
+          .map((fm) => ({
+            id: `surface:${fm.id}`,
+            kind: "command" as const,
+            name: `Go to ${fm.label}`,
+            hint: fm.kbd ? `${fm.description} · ${fm.kbd}` : fm.description,
+            intent: { kind: "go-to-surface", mode: fm.id },
+          }));
+
     const localRows: Row[] = [
       ...familiarRows,
       ...sessionRows,
@@ -450,6 +480,7 @@ export function CommandPalette({
       ...fsMemoryRows,
       ...saveRows,
       ...cmdRows,
+      ...surfaceRows,
       ...shortcutRows,
       ...createRows,
     ];

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1185,6 +1185,11 @@ export function Workspace() {
       setMode("board");
       return;
     }
+    if (intent.kind === "go-to-surface") {
+      setMode(intent.mode as WorkspaceMode);
+      shellRef.current?.dismissNavMobile();
+      return;
+    }
     if (intent.kind === "focus-card") {
       // Navigate to the board and signal which card to focus via URL hash.
       // BoardView listens for `#card-<id>` and selects the matching card.
@@ -1909,6 +1914,7 @@ export function Workspace() {
         initialQuery={topSearchQuery}
         onQueryChange={setTopSearchQuery}
         onIntent={onPaletteIntent}
+        addons={addons}
       />
 
       <ShortcutsSheet open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />


### PR DESCRIPTION
⌘K is the app's primary navigator, but I confirmed it had **no way to jump to surfaces** — it handled familiar chats, fs-memory, slash commands, and two toggles, but typing "board" or "library" matched nothing.

Adds **"Go to <surface>"** rows to the palette:
- built from the shared `FOLDER_MODES` list (single source of truth — already exported from `sidebar-minimal`), so they stay in sync with the sidebar and the ⌘-digit shortcuts
- each row shows the surface description + its ⌘-digit hint (e.g. *"Track tasks across projects · ⌘3"*)
- wired through a new `go-to-surface` intent → `setMode` in `workspace.tsx`
- respect the **same add-on gating** as the sidebar (GitHub/Library hidden unless enabled)
- hidden while typing a familiar scope (`@…`) or a slash command, where surface nav would be noise

This makes ⌘K a real launcher and complements the recent ⌘-digit shortcut reordering.

Note: branched onto `main` *after* #1139 (which repaired a tsc-red `library-doc-list` on main); this change is unrelated to that.

New test assertions in `command-palette.test.ts` (intent, shared-list source, gating, scoping, workspace consumer). tsc clean, full `test:app` (330 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)