### PR TITLE
refactor(sessions): unify chat-list relative-time onto the shared helper

### DIFF
--- a/src/components/chat-all-familiars-project-list.test.ts
+++ b/src/components/chat-all-familiars-project-list.test.ts
@@ -52,7 +52,7 @@ assert.match(
 
 assert.match(
   chatList,
-  /\{chatDate\(s\.updated_at\)\}[\s\S]*\{age\(s\.updated_at\)\}/,
+  /\{chatDate\(s\.updated_at\)\}[\s\S]*\{rel\}/,
   "Chat rows should show the absolute date next to the relative updated age",
 );
 

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -11,6 +11,7 @@ import { OriginChip } from "@/components/ui/origin-chip";
 import { SessionInitiatorChip } from "@/components/ui/session-initiator-chip";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
+import { relativeTime, isRelativePhrase } from "@/lib/relative-time";
 import {
   deriveChatProjectGroups,
   filterVisibleChatSessions,
@@ -76,22 +77,6 @@ type Props = {
    *  companion panel (e.g. the Browser right-rail). */
   compact?: boolean;
 };
-
-function age(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return `${s}s ago`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
-  if (h < 48) return "Yesterday";
-  const d = Math.floor(h / 24);
-  if (d < 7) return `${d} days ago`;
-  if (d < 14) return "1 week ago";
-  if (d < 21) return "2 weeks ago";
-  return `${Math.floor(d / 7)} weeks ago`;
-}
 
 function chatDate(iso: string): string {
   const date = new Date(iso);
@@ -900,6 +885,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                 <ul className="divide-y divide-[var(--border-hairline)]">
                   {rows.map((s, idx) => {
                     const st = statusStyle(s.status);
+                    const rel = relativeTime(s.updated_at);
                     const project = repoName(s.project_root ?? "");
                     const isActive = activeId === s.id;
                     const rowFamiliar = s.familiarId ? familiarsById.get(s.familiarId) : null;
@@ -992,8 +978,12 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                               </span>
                               <span className="chat-list-row-time flex shrink-0 items-baseline gap-1 text-[11px] text-[var(--text-muted)]">
                                 <span>{chatDate(s.updated_at)}</span>
-                                <span aria-hidden>·</span>
-                                <span>{age(s.updated_at)}</span>
+                                {isRelativePhrase(rel) ? (
+                                  <>
+                                    <span aria-hidden>·</span>
+                                    <span>{rel}</span>
+                                  </>
+                                ) : null}
                               </span>
                             </span>
 

--- a/src/lib/relative-time.test.ts
+++ b/src/lib/relative-time.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { relativeTime } from "./relative-time.ts";
+import { relativeTime, isRelativePhrase } from "./relative-time.ts";
 import { relativeTime as reExported } from "./daily-report.ts";
 
 const NOW = new Date("2026-06-18T12:00:00.000Z");
@@ -33,4 +33,13 @@ test("empty/invalid input renders nothing", () => {
 test("daily-report re-exports the same function (no behavior drift)", () => {
   assert.equal(reExported, relativeTime);
   assert.equal(reExported(ago(2), NOW), "2m ago");
+});
+
+test("isRelativePhrase distinguishes relative phrases from the absolute fallback", () => {
+  assert.equal(isRelativePhrase("just now"), true);
+  assert.equal(isRelativePhrase("5m ago"), true);
+  assert.equal(isRelativePhrase("2h ago"), true);
+  assert.equal(isRelativePhrase("3d ago"), true);
+  assert.equal(isRelativePhrase("Jun 6"), false);
+  assert.equal(isRelativePhrase(""), false);
 });

--- a/src/lib/relative-time.ts
+++ b/src/lib/relative-time.ts
@@ -24,3 +24,12 @@ export function relativeTime(
   if (days < 7) return `${days}d ago`;
   return new Intl.DateTimeFormat([], { month: "short", day: "numeric" }).format(then);
 }
+
+/**
+ * True when `relativeTime`'s output is a relative phrase ("just now" / "… ago")
+ * rather than its ≥7-day absolute "Mon D" fallback. Lets a caller that already
+ * shows an absolute date suppress the relative span when it would just repeat it.
+ */
+export function isRelativePhrase(value: string): boolean {
+  return value === "just now" || value.endsWith(" ago");
+}


### PR DESCRIPTION
chat-list had its own `age()` formatter ("Yesterday", "N days ago", "N weeks ago", seconds). Replace it with the shared `relativeTime()` so the Sessions tab reads with the same "X ago" language as Projects/Dashboard.

- New pure `isRelativePhrase` in `relative-time.ts` (relative output is "just now"/"… ago"; ≥7d is an absolute date).
- chat-list drops its local `age()`, and hides the relative span **and its `·` separator** when it would just repeat the absolute `chatDate` (sessions ≥7d old).
- inspector-pane's `age()` is a distinct bare-duration/future-aware helper — left untouched.

test:app (330) + test:mobile (16) + build green; updated the one source-text test that pinned the old `{age(...)}` markup.

Spec: docs/superpowers/specs/2026-06-20-unify-relative-time-design.md
🤖 Generated with [Claude Code](https://claude.com/claude-code)