### PR TITLE
feat(shortcuts): cycle surfaces with ⌘[ and ⌘]

### DIFF
--- a/src/components/workspace-familiars-landing.test.ts
+++ b/src/components/workspace-familiars-landing.test.ts
@@ -64,6 +64,13 @@ assert.match(
   "SURFACE_ORDER ascends with the sidebar top-to-bottom order (⌘1..⌘8)",
 );
 
+// ⌘[ / ⌘] cycle to the previous / next surface through SURFACE_ORDER (wraps).
+assert.match(
+  workspace,
+  /e\.key === "\[" \|\| e\.key === "\]"[\s\S]{0,450}?SURFACE_ORDER\[next\]/,
+  "⌘[ / ⌘] step through SURFACE_ORDER and setMode to the neighbouring surface",
+);
+
 // After the top-bar streamline: no breadcrumb, no Home button, no brand
 // mark. The sidebar carries section + familiar identity instead.
 assert.doesNotMatch(

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1033,6 +1033,20 @@ export function Workspace() {
         return;
       }
 
+      // ⌘[ / ⌘] -> previous / next surface, cycling through SURFACE_ORDER in the
+      // same top-to-bottom order as ⌘1..⌘8 (wraps at the ends). From an off-list
+      // surface (Journal/Roles/Workflows), ⌘] lands on the first surface and ⌘[
+      // on the last.
+      if (meta && !alt && (e.key === "[" || e.key === "]")) {
+        e.preventDefault();
+        const step = e.key === "]" ? 1 : -1;
+        const cur = SURFACE_ORDER.indexOf(mode as WorkspaceMode);
+        const base = cur === -1 ? (step === 1 ? -1 : 0) : cur;
+        const next = (base + step + SURFACE_ORDER.length) % SURFACE_ORDER.length;
+        setMode(SURFACE_ORDER[next]);
+        return;
+      }
+
       // ⌘, -> Settings (the TopBar account button advertises this shortcut in
       // its tooltip, but nothing was wired to handle it).
       if (meta && !alt && e.key === ",") {

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -40,6 +40,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: "⌘1–⌘8", description: "Jump to a sidebar surface (Home … Code)" },
       { keys: "⌘0", description: "Jump to the Library" },
       { keys: "⌘9", description: "Jump to Projects (Chat surface)" },
+      { keys: "⌘[ / ⌘]", description: "Previous / next surface" },
       { keys: "⌥1–⌥9", description: "Select the Nth familiar" },
       { keys: "⌘↑ / ⌘↓", description: "Cycle through familiars" },
       { keys: "⌘N", description: "New chat (on the Chat surface)" },


### PR DESCRIPTION
Rounds out the surface-navigation story:
- **⌘1–8** — jump to a specific surface
- **⌘K** — navigate by name (just shipped, #1142)
- **⌘[ / ⌘]** — *previous / next* surface (new)

⌘[ / ⌘] step through `SURFACE_ORDER` in the same top-to-bottom order as the sidebar, wrapping at the ends. From an off-list surface (Journal/Roles/Workflows), ⌘] lands on the first surface and ⌘[ on the last. Added to the keyboard cheatsheet (⌘/).

Note on browser shortcuts: ⌘[ / ⌘] are Chrome back/forward, but the app already claims ⌘1–9 (Chrome's tab shortcuts), so this is consistent — and there's no conflict in the desktop app.

tsc clean, full `test:app` (332 files) green; guard assertion added in `workspace-familiars-landing.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)