### PR TITLE
feat(journal): real empty state + inline generate for the entry pane

### DIFF
--- a/src/components/journal/journal-entries.tsx
+++ b/src/components/journal/journal-entries.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Button } from "@/components/ui/button";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { dateSlug, longDateLabel, relativeDayLabel, relativeTime, parseDateSlug } from "@/lib/daily-report";
 import { generateReflection } from "@/lib/journal-generate";
@@ -291,10 +293,26 @@ export function JournalEntries({
                 </div>
               </>
             ) : (
-              <div className="journal-empty">
-                No reflection yet for this day.
-                {day.date === today ? " Use “Generate today's entry” to write one." : ""}
-              </div>
+              <EmptyState
+                icon="ph:book-open"
+                headline="No reflection yet for this day"
+                subtitle={
+                  day.date === today
+                    ? "Generate today's entry to capture what happened."
+                    : "No familiar wrote a reflection for this day."
+                }
+                actions={
+                  day.date === today ? (
+                    <Button
+                      leadingIcon="ph:sparkle"
+                      onClick={generate}
+                      disabled={!canGenerate || generating}
+                    >
+                      {generating ? "Reflecting…" : "Generate today's entry"}
+                    </Button>
+                  ) : undefined
+                }
+              />
             )}
           </>
         ) : (


### PR DESCRIPTION
## What

When you select a day with no reflection, the Journal's **detail pane** (the large right area) showed a single bare line: "No reflection yet for this day. Use …". It now renders the shared `ui/EmptyState` — book icon badge, headline, subtitle — and, when the selected day is **today**, an inline **Generate today's entry** button wired to the same `generate` action as the header toolbar.

## Why

- Consistency: the Journal's sibling **Canvas** tab already uses the shared empty state; the Journal tab was the odd one out with bespoke `.journal-empty` text.
- Usability: you can generate the reflection right from the empty pane instead of reaching for the header control.

## Tests / verification

- `journal-view.test.ts` passes; no test pins the placeholder text.
- Full `pnpm build` (test:app + next build) green; `tsc --noEmit` clean. (Note: `ph:notebook` isn't in the Icon allowlist — used `ph:book-open`, the Journal nav icon.)
- Live-verified with `/api/journal` mocked (today, no reflection): the detail pane renders the book-icon `EmptyState` with the headline/subtitle and a working "Generate today's entry" button. Screenshot confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)