### PR TITLE
feat(board): filter-aware empty state when a search/scope hides every task

### DIFF
--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -12,6 +12,8 @@ import { cardMatchesBoardSearch } from "@/lib/board-search";
 import { BoardKanban } from "@/components/board-kanban";
 import { BoardGantt } from "@/components/board-gantt";
 import { BoardTable, type GroupBy } from "@/components/board-table";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Button } from "@/components/ui/button";
 import { BoardCardStack } from "@/components/board-card-stack";
 import { BoardInspector } from "@/components/board-inspector";
 import { useIsMobile } from "@/lib/use-viewport";
@@ -536,6 +538,38 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
                 New task
               </button>
             </div>
+          </div>
+        ) : filtered.length === 0 && !error ? (
+          // The board has cards, but the active search/scope hides them all.
+          // Every view mode lands here so the kanban no longer silently shows
+          // empty columns when nothing matches.
+          <div className="flex h-full items-center justify-center p-6">
+            {searchQuery.trim() ? (
+              <EmptyState
+                icon="ph:magnifying-glass"
+                headline="No tasks match your search"
+                subtitle={`Nothing matches “${searchQuery.trim()}”. Try a different term or clear the search.`}
+                actions={
+                  <Button leadingIcon="ph:x" onClick={() => setSearchQuery("")}>
+                    Clear search
+                  </Button>
+                }
+              />
+            ) : (
+              <EmptyState
+                icon="ph:kanban"
+                headline="No tasks for this familiar yet"
+                subtitle="Switch scope from the familiar menu, or add a task for this one."
+                actions={
+                  <Button
+                    leadingIcon="ph:plus"
+                    onClick={() => { setModalDefaultStatus("backlog"); setModalOpen(true); }}
+                  >
+                    New task
+                  </Button>
+                }
+              />
+            )}
           </div>
         ) : isMobile ? (
           <BoardCardStack cards={filtered} familiars={familiars} sessions={sessions}


### PR DESCRIPTION
## What

When the board has cards but the active **search** or **familiar scope** matches none of them, the default kanban view silently rendered empty columns — no signal that a filter was hiding everything (the table view said "No cards match" but the kanban/gantt said nothing). `board-view` now renders one shared `EmptyState` for that case, for **all** view modes:

- search active → **"No tasks match your search"** + the query + a **Clear search** button (resets the search).
- only the familiar scope is filtering → **"No tasks for this familiar yet"** + a **New task** action.

The genuinely-empty board ("Queue your first task") and the loading spinner branch are unchanged and still take precedence (`!hasLoaded` → `cards.length === 0` → `filtered.length === 0` → views).

## Why

This was the one real headroom item on the Board, which only just landed its overhaul. Searching and getting silent empty columns reads as broken; now there's honest feedback and a one-click recovery. Uses the shared empty-state primitive (no `board.css` touched).

## Tests / verification

- `board-ux-polish.test.ts` passes (it pins the loading-branch-first ordering, which is preserved).
- Full `pnpm build` (test:app + next build) green; `tsc --noEmit` clean.
- Live-verified on the demo board: a no-match search renders "No tasks match your search" + the query + Clear search; clicking it clears the search and the cards return. Screenshot confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)