### PR TITLE
feat(chat): persist the composer draft across reloads

### DIFF
--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -412,4 +412,22 @@ assert.match(
   "Elapsed ticker uses tabular digits so the meta line doesn't jitter (CHAT-D3-06)",
 );
 
+// The composer draft survives a reload: input initialises from localStorage
+// and is written back on change (and cleared when emptied, e.g. after a send).
+assert.match(
+  source,
+  /const \[input, setInput\] = useState\(\(\) => readComposerDraft\(\)\)/,
+  "composer input initialises from the persisted draft",
+);
+assert.match(
+  source,
+  /useEffect\(\(\) => \{\s*writeComposerDraft\(input\);\s*\}, \[input\]\)/,
+  "the draft is persisted whenever the composer input changes",
+);
+assert.match(
+  source,
+  /if \(text\) window\.localStorage\.setItem\(COMPOSER_DRAFT_KEY, text\);\s*else window\.localStorage\.removeItem\(COMPOSER_DRAFT_KEY\)/,
+  "an emptied draft removes the key (sent messages don't reappear on reload)",
+);
+
 console.log("chat-view-lifecycle.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -180,6 +180,10 @@ type ComposerResponseSpeed = "fast" | "balanced" | "careful";
 
 const COMPOSER_MAX_HEIGHT = 220;
 const COMPOSER_PREFS_KEY = "cave:chat-composer-controls:v1";
+// Persist the in-progress composer text so a page reload doesn't eat a
+// half-written message. The composer is a single shared input (it isn't
+// remounted per session), so one key mirrors the in-memory behaviour.
+const COMPOSER_DRAFT_KEY = "cave:chat-composer-draft:v1";
 const THINKING_OPTIONS: Array<{ value: ComposerThinkingEffort; label: string }> = [
   { value: "low", label: "Low" },
   { value: "medium", label: "Medium" },
@@ -218,6 +222,25 @@ function writeComposerPrefs(prefs: {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(COMPOSER_PREFS_KEY, JSON.stringify(prefs));
+  } catch {
+    /* best effort */
+  }
+}
+
+function readComposerDraft(): string {
+  if (typeof window === "undefined") return "";
+  try {
+    return window.localStorage.getItem(COMPOSER_DRAFT_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function writeComposerDraft(text: string) {
+  if (typeof window === "undefined") return;
+  try {
+    if (text) window.localStorage.setItem(COMPOSER_DRAFT_KEY, text);
+    else window.localStorage.removeItem(COMPOSER_DRAFT_KEY);
   } catch {
     /* best effort */
   }
@@ -1518,7 +1541,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const [modelState, setModelState] = useState<ChatModelState | null>(null);
   const [thinkingEffort, setThinkingEffort] = useState<ComposerThinkingEffort>(() => readComposerPrefs().thinkingEffort);
   const [responseSpeed, setResponseSpeed] = useState<ComposerResponseSpeed>(() => readComposerPrefs().responseSpeed);
-  const [input, setInput] = useState("");
+  const [input, setInput] = useState(() => readComposerDraft());
   // CHAT-D11-04: Input history navigation (↑↓), matching HomeComposer pattern
   const [inputHistory, setInputHistory] = useState<string[]>([]);
   const [inputHistoryIdx, setInputHistoryIdx] = useState<number>(-1);
@@ -2905,6 +2928,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       cancelSend();
     }
   };
+
+  // Persist the composer draft so a reload restores a half-written message.
+  // Cleared (key removed) when the input empties — e.g. after a send.
+  useEffect(() => {
+    writeComposerDraft(input);
+  }, [input]);
 
   // Disarm a pending delete confirmation and sync the selected project when
   // switching sessions. Drop staged file mentions because they are scoped to


### PR DESCRIPTION
A half-written message in the chat composer was lost on a page reload — `input` only lived in React state.

Persist it to `localStorage` (`cave:chat-composer-draft:v1`), reusing the same SSR-guarded read/write pattern as the existing composer prefs:
- the composer `input` initialises from the saved draft (`useState(() => readComposerDraft())`)
- it's written back whenever the input changes
- emptying the input (e.g. after a **send**) **removes** the key, so sent messages never reappear on reload

One key mirrors the existing behaviour: the composer is a single shared input (ChatView isn't remounted per session, and `initialPrompt` auto-sends via `sendRaw` rather than populating the composer, so there's no conflict). On reload the `#chat-<sessionId>` hash reopens the same session, so the restored draft lands where it was typed.

tsc clean; full `test:app` (332) and `test:mobile` (16) green; guard assertions added in `chat-view-lifecycle.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)