### PR TITLE
feat(familiars): shared empty/loading/error states in the memory reader

### DIFF
--- a/src/components/familiars-memory-reader.test.ts
+++ b/src/components/familiars-memory-reader.test.ts
@@ -29,4 +29,11 @@ assert.match(source, /Select a memory to read/, "empty state when no row selecte
 assert.match(source, /onOpenFile/, "reader exposes an open-file callback");
 assert.match(source, /onExpand/, "reader exposes an expand callback");
 
+// Shared state primitives: no-selection / loading / error states use
+// ui/EmptyState, ui/Skeleton, and ui/ErrorState instead of bare text.
+assert.match(source, /<EmptyState[\s\S]*?Select a memory to read/, "no-selection state uses the shared EmptyState");
+assert.match(source, /isFileLoading \?[\s\S]*?<Skeleton[^>]*variant="text"/, "loading shows skeleton text lines, not a bare 'Loading…'");
+assert.doesNotMatch(source, />Loading memory…</, "reader no longer shows a bare 'Loading memory…' line");
+assert.match(source, /fileError \?[\s\S]*?<ErrorState/, "file load failure uses the shared ErrorState");
+
 console.log("familiars-memory-reader: all assertions passed");

--- a/src/components/familiars-memory-reader.tsx
+++ b/src/components/familiars-memory-reader.tsx
@@ -5,6 +5,9 @@ import { copyText } from "@/lib/clipboard";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { useMemoryFile } from "@/lib/use-memory-file";
 import type { MemoryRow } from "@/lib/memory-rows";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorState } from "@/components/ui/error-state";
+import { Skeleton } from "@/components/ui/skeleton";
 
 function compactPath(path: string): string {
   const collapsed = path.replace(/^\/Users\/[^/]+/, "~");
@@ -40,12 +43,12 @@ export function MemoryReaderPane({
 
   if (!row) {
     return (
-      <div className="grid h-full min-h-0 place-items-center rounded-lg border border-dashed border-[var(--border-hairline)] bg-[var(--bg-raised)]/20 p-8 text-center">
-        <div>
-          <Icon name="ph:book-open" width={24} className="mx-auto text-[var(--text-muted)]" aria-hidden />
-          <p className="mt-3 text-[13px] font-medium text-[var(--text-primary)]">Select a memory to read</p>
-          <p className="mt-1 text-[11px] text-[var(--text-muted)]">Pick an entry on the left to view its contents.</p>
-        </div>
+      <div className="grid h-full min-h-0 place-items-center rounded-lg border border-dashed border-[var(--border-hairline)] bg-[var(--bg-raised)]/20 p-8">
+        <EmptyState
+          icon="ph:book-open"
+          headline="Select a memory to read"
+          subtitle="Pick an entry on the left to view its contents."
+        />
       </div>
     );
   }
@@ -156,9 +159,17 @@ export function MemoryReaderPane({
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto p-4">
         {fileError ? (
-          <p className="text-[12px] text-[var(--color-warning)]">{fileError}</p>
+          <ErrorState
+            compact
+            headline="Couldn't load this memory"
+            subtitle={fileError}
+          />
         ) : isFileLoading ? (
-          <p className="text-[12px] text-[var(--text-muted)]">Loading memory…</p>
+          <div className="space-y-2.5" aria-label="Loading memory" aria-busy="true">
+            {["92%", "85%", "97%", "78%", "90%", "70%"].map((w, i) => (
+              <Skeleton key={i} variant="text" width={w} />
+            ))}
+          </div>
         ) : content.trim() === "" ? (
           <p className="text-[12px] text-[var(--text-muted)]">{emptyMsg}</p>
         ) : mode === "rendered" ? (


### PR DESCRIPTION
## What

Routes the familiar **memory reader** pane (`MemoryReaderPane`) through the shared state primitives, continuing the empty/loading/error consistency sweep (#1110 Library, #1114 Familiars roster, #1121 Vault/Retro, #1123 Roles, #1129 Schedules).

## Why / changes

The reader's three data-driven states were hand-rolled bare text:
- **No selection** → a custom icon+text block → shared `EmptyState` (keeps the "Select a memory to read" copy).
- **Content loading** → a bare "Loading memory…" line → **skeleton text lines** (matches the prose it stands in for; no flash).
- **File load failure** → bare warning text → shared `ErrorState` (compact) with the underlying message as the subtitle.

Scoped to the reader pane only: the roster card's compact memory micro-copy and the contract-tab status line are intentionally test-pinned and left as-is; the broader `familiars-memory-view` master-detail surfaces errors with a "see error above" pattern and is a sensible separate follow-up.

## Verification

- `pnpm test:app` — ✓ 332 test file(s) passed (added assertions to `familiars-memory-reader.test.ts`).
- Built clean on current `main`.

Note: this branch was rebased onto the post-#1139 `main` (an unrelated RED-main build break in `library-doc-list` from a concurrent merge-race, since fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)