### PR TITLE
feat(familiars): no-results state when a roster search matches nothing

### DIFF
--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -245,6 +245,19 @@ export function FamiliarsView({
               onOpenMemoryFile={onOpenMemoryFile}
             />
           </div>
+        ) : visibleFamiliars.length === 0 ? (
+          <div className="p-4">
+            <EmptyState
+              icon="ph:magnifying-glass"
+              headline="No familiars match your search"
+              subtitle={`Nothing matches “${query.trim()}”. Try a different name or clear the search.`}
+              actions={
+                <Button leadingIcon="ph:x" onClick={() => setQuery("")}>
+                  Clear search
+                </Button>
+              }
+            />
+          </div>
         ) : (
           <div className="p-4">
             <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">


### PR DESCRIPTION
## What

Searching the Familiars roster for a term that matched no one rendered a **blank grid** — no feedback that the search hid everything. It now shows the shared `EmptyState`: a search-icon badge, "No familiars match your search", the query, and a **Clear search** button that resets the search.

Mirrors the board's filter-aware empty state (#1146). The genuinely-empty roster ("No familiars yet", #1114) still takes precedence.

## Tests / verification

- `familiar-roster-card.test.ts` passes (it reads `familiars-view.tsx`; no pin affected).
- Full `pnpm build` green; `tsc --noEmit` clean.
- Live-verified: a no-match roster search shows the state + query; clicking **Clear search** clears the input and the familiars return. Screenshot confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)