### PR TITLE
feat(home): persist the home composer draft across reloads

### DIFF
--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -153,3 +153,21 @@ assert.doesNotMatch(
   /scope: "session"/,
   "HomeComposer must not use session scope — there is no session at home",
 );
+
+// The home prompt draft survives a reload: text initialises from localStorage,
+// is written back on change, and is removed when emptied (e.g. after a send).
+assert.match(
+  source,
+  /const \[text, setText\] = useState\(\(\) => readHomeDraft\(\)\)/,
+  "home composer text initialises from the persisted draft",
+);
+assert.match(
+  source,
+  /useEffect\(\(\) => \{\s*writeHomeDraft\(text\);\s*\}, \[text\]\)/,
+  "the home draft is persisted whenever the prompt changes",
+);
+assert.match(
+  source,
+  /if \(text\) window\.localStorage\.setItem\(HOME_DRAFT_KEY, text\);\s*else window\.localStorage\.removeItem\(HOME_DRAFT_KEY\)/,
+  "an emptied home draft removes the key (sent prompts don't reappear on reload)",
+);

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -63,6 +63,29 @@ const SEED_SUGGESTIONS = [
   "Remind me to review PRs tomorrow at 10 AM",
 ];
 
+// Persist the in-progress prompt so a page reload doesn't eat what you were
+// typing on the home screen (mirrors the chat composer's draft persistence).
+const HOME_DRAFT_KEY = "cave:home-composer-draft:v1";
+
+function readHomeDraft(): string {
+  if (typeof window === "undefined") return "";
+  try {
+    return window.localStorage.getItem(HOME_DRAFT_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function writeHomeDraft(text: string) {
+  if (typeof window === "undefined") return;
+  try {
+    if (text) window.localStorage.setItem(HOME_DRAFT_KEY, text);
+    else window.localStorage.removeItem(HOME_DRAFT_KEY);
+  } catch {
+    /* best effort */
+  }
+}
+
 // ─── HomeComposer ─────────────────────────────────────────────────────────────
 
 export function HomeComposer({
@@ -76,7 +99,7 @@ export function HomeComposer({
   onToast,
   onSlash,
 }: Props) {
-  const [text, setText] = useState("");
+  const [text, setText] = useState(() => readHomeDraft());
   const [destination, setDestination] = useState<Destination>("chat");
   const [sending, setSending] = useState(false);
   const [suggestions, setSuggestions] = useState<string[]>([]);
@@ -154,6 +177,12 @@ export function HomeComposer({
 
   useEffect(() => {
     setSlashIdx(0);
+  }, [text]);
+
+  // Persist the draft so a reload restores it; cleared when the input empties
+  // (e.g. after a send), so sent prompts don't reappear.
+  useEffect(() => {
+    writeHomeDraft(text);
   }, [text]);
 
   // Focus on mount


### PR DESCRIPTION
The home/landing composer's prompt was lost on a page reload — `text` was plain component state. This mirrors the chat composer draft persistence (#1147) for the home screen, which is the first surface you land on.

Persist to `localStorage` (`cave:home-composer-draft:v1`, SSR-guarded):
- the prompt initialises from the saved draft (`useState(() => readHomeDraft())`)
- written back whenever it changes
- the key is **removed** when the input empties (e.g. after a send), so sent prompts never reappear

tsc clean; full `test:app` (332) and `test:mobile` (16) green; guard assertions added in `home-composer.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)