### PR TITLE
style(sidebar): make the New chat CTA an outlined accent button

### DIFF
--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -122,19 +122,20 @@
   color: var(--text-primary);
 }
 
-/* "New chat" is the top CTA — make it the highest-contrast action in the
-   panel with a solid accent fill so it reads as the primary thing to do. */
+/* "New chat" is the top CTA — an outlined accent button: the accent reads on
+   the border + label rather than a solid fill, so it stays prominent without
+   dominating the panel. A faint accent wash on hover gives press feedback. */
 .sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row {
-  background: var(--accent-presence);
-  color: #fff;
-  border: 1px solid transparent;
+  background: transparent;
+  color: var(--accent-presence);
+  border: 1px solid var(--accent-presence);
   font-weight: 600;
 }
 
 .sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row:hover {
-  background: color-mix(in oklch, var(--accent-presence) 88%, #000);
-  color: #fff;
-  border-color: transparent;
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+  color: var(--accent-presence);
+  border-color: var(--accent-presence);
 }
 
 .sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row .sidebar-action-icon {


### PR DESCRIPTION
## What

The sidebar's top **New chat** CTA used a solid accent fill. This makes it an **outlined** button instead — transparent background, accent color on the border and label, with a faint accent wash on hover for press feedback.

Scoped to `.sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row` in `sidebar-minimal.css`; nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)