### PR TITLE
feat(palette): open a project from the command palette

### DIFF
--- a/src/components/command-palette.test.ts
+++ b/src/components/command-palette.test.ts
@@ -149,4 +149,32 @@ assert.match(
   "workspace navigates to the chosen surface on a go-to-surface intent",
 );
 
+// ── "Open project" navigation ──
+assert.match(
+  source,
+  /kind:\s*"open-project";\s*root:\s*string/,
+  "palette exposes an open-project intent",
+);
+assert.match(
+  source,
+  /const \{ projects \} = useProjects\(\)/,
+  "palette reads the project list to offer project navigation",
+);
+assert.match(
+  source,
+  /name:\s*`Open project \$\{p\.name\}`/,
+  "each project renders an 'Open project <name>' row",
+);
+assert.match(
+  source,
+  /intent:\s*\{ kind: "open-project", root: p\.root \}/,
+  "an open-project row carries the project root",
+);
+// Consumer: workspace opens the Projects tab then focuses the chosen project.
+assert.match(
+  workspace,
+  /intent\.kind === "open-project"[\s\S]{0,320}?CHAT_OPEN_PROJECTS_EVENT[\s\S]{0,200}?CHAT_FOCUS_PROJECT_EVENT, \{ detail: \{ root \} \}/,
+  "workspace opens the Projects tab then focuses the chosen project",
+);
+
 console.log("command-palette.test.ts OK");

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -10,6 +10,12 @@ import { useFocusTrap } from "@/lib/use-focus-trap";
 import { parseFamiliarToken, resolveFamiliarIds } from "@/lib/command-palette-scope";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { FOLDER_MODES, type FolderMode, type AddonsConfig } from "@/components/sidebar-minimal";
+import { useProjects } from "@/lib/use-projects";
+
+function shortProjectRoot(root: string): string {
+  const parts = root.replace(/\/+$/, "").split("/").filter(Boolean);
+  return parts.length <= 2 ? root : `…/${parts.slice(-2).join("/")}`;
+}
 
 type PaletteIntent =
   | { kind: "switch-familiar"; familiarId: string }
@@ -20,6 +26,7 @@ type PaletteIntent =
   | { kind: "open-tui-session"; sessionId: string }
   | { kind: "open-board" }
   | { kind: "go-to-surface"; mode: FolderMode }
+  | { kind: "open-project"; root: string }
   | { kind: "focus-card"; cardId: string }
   | { kind: "create-task"; title: string }
   | { kind: "open-memory-file"; path: string };
@@ -178,6 +185,7 @@ export function CommandPalette({
   onIntent,
   addons,
 }: Props) {
+  const { projects } = useProjects();
   const [query, setQuery] = useState("");
   const [activeIdx, setActiveIdx] = useState(0);
   const [cards, setCards] = useState<Card[]>([]);
@@ -472,6 +480,21 @@ export function CommandPalette({
             intent: { kind: "go-to-surface", mode: fm.id },
           }));
 
+    // "Open project <name>" rows jump into a project's chats (the Projects tab,
+    // expanded + scrolled to that project). Hidden while scoped or typing slash.
+    const projectRows: Row[] = (scoped || slashToken)
+      ? []
+      : projects
+          .filter((p) => !q || p.name.toLowerCase().includes(q) || p.root.toLowerCase().includes(q))
+          .slice(0, 6)
+          .map((p) => ({
+            id: `project:${p.id}`,
+            kind: "command" as const,
+            name: `Open project ${p.name}`,
+            hint: shortProjectRoot(p.root),
+            intent: { kind: "open-project", root: p.root },
+          }));
+
     const localRows: Row[] = [
       ...familiarRows,
       ...sessionRows,
@@ -481,6 +504,7 @@ export function CommandPalette({
       ...saveRows,
       ...cmdRows,
       ...surfaceRows,
+      ...projectRows,
       ...shortcutRows,
       ...createRows,
     ];
@@ -490,7 +514,7 @@ export function CommandPalette({
       : [];
 
     return [...salemRows, ...localRows];
-  }, [familiars, sessions, cards, covenMemory, fsMemory, query, activeFamiliarId]);
+  }, [familiars, sessions, cards, covenMemory, fsMemory, query, activeFamiliarId, projects, addons]);
 
   useEffect(() => {
     if (activeIdx >= rows.length) setActiveIdx(Math.max(0, rows.length - 1));

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -151,4 +151,22 @@ assert.match(projectsView, /\{shortRoot\(project\.root\)\}/, "the displayed path
 assert.match(projectsView, /title=\{project\.root\}/, "the full path remains available via the title");
 assert.match(projectsView, /relativeTime\(/, "each row shows a relative last-active label (shared relative-time helper)");
 
+// A project card expands + scrolls into view when the command palette's
+// "Open project" navigation fires CHAT_FOCUS_PROJECT_EVENT for its root.
+assert.match(
+  projectsView,
+  /addEventListener\(CHAT_FOCUS_PROJECT_EVENT/,
+  "project cards listen for the focus-project event",
+);
+assert.match(
+  projectsView,
+  /normalizeProjectRoot\(detail\.root\) !== cardKey[\s\S]{0,120}?setExpanded\(true\)/,
+  "a matching focus event expands the card",
+);
+assert.match(
+  projectsView,
+  /id=\{`pcard-el:\$\{cardKey\}`\}/,
+  "the card carries a stable id so it can be scrolled into view",
+);
+
 console.log("projects-view.test.ts: ok");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -6,6 +6,7 @@ import { Icon } from "@/lib/icon";
 import { relativeTime } from "@/lib/relative-time";
 import type { CaveProject } from "@/lib/cave-projects-types";
 import { normalizeProjectRoot } from "@/lib/cave-projects-types";
+import { CHAT_FOCUS_PROJECT_EVENT } from "@/lib/chat-tab-events";
 import type { SessionRow } from "@/lib/types";
 import { stripLeadingTrailingEmoji, disambiguateSessionTitles } from "@/lib/cave-chat-titles";
 import {
@@ -206,6 +207,24 @@ function ProjectRow({
   // Every project starts collapsed to a single scannable row; expanding reveals
   // the path + its sessions.
   const [expanded, setExpanded] = useState(false);
+  const cardKey = normalizeProjectRoot(project.root);
+
+  // The command palette's "Open project" rows expand + scroll a project into
+  // view via this event (the Projects tab is opened first, then focused).
+  useEffect(() => {
+    const onFocus = (e: Event) => {
+      const detail = (e as CustomEvent<{ root?: string }>).detail;
+      if (!detail?.root || normalizeProjectRoot(detail.root) !== cardKey) return;
+      setExpanded(true);
+      window.requestAnimationFrame(() => {
+        document
+          .getElementById(`pcard-el:${cardKey}`)
+          ?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+      });
+    };
+    window.addEventListener(CHAT_FOCUS_PROJECT_EVENT, onFocus);
+    return () => window.removeEventListener(CHAT_FOCUS_PROJECT_EVENT, onFocus);
+  }, [cardKey]);
   const lastActiveIso =
     chats.reduce((acc, s) => (!acc || s.updated_at > acc ? s.updated_at : acc), "") || project.updatedAt;
   const lastActiveLabel = relativeTime(lastActiveIso);
@@ -272,6 +291,7 @@ function ProjectRow({
   return (
     <article
       ref={setDropRef}
+      id={`pcard-el:${cardKey}`}
       data-drop-over={isOver ? "true" : undefined}
       className={[
         "group border-b border-[var(--border-hairline)] px-2 py-3 transition-colors",

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -42,7 +42,7 @@ import { LibraryView } from "@/components/library-view";
 import { PluginsView } from "@/components/plugins-view";
 import { WorkflowsView } from "@/components/workflows-view";
 import { RetroRunsView } from "@/components/retro-runs-view";
-import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
+import { CHAT_OPEN_PROJECTS_EVENT, CHAT_FOCUS_PROJECT_EVENT } from "@/lib/chat-tab-events";
 import { HomeComposer } from "@/components/home-composer";
 import { ChatSurface, type RightPanelKind } from "@/components/chat-surface";
 import { SalemChatPanel } from "@/components/salem/salem-widget";
@@ -1202,6 +1202,21 @@ export function Workspace() {
     if (intent.kind === "go-to-surface") {
       setMode(intent.mode as WorkspaceMode);
       shellRef.current?.dismissNavMobile();
+      return;
+    }
+    if (intent.kind === "open-project") {
+      // Open the Chat surface's Projects tab, then ask it to expand + scroll the
+      // chosen project into view once it has mounted.
+      setMode("chat");
+      shellRef.current?.dismissNavMobile();
+      const root = intent.root;
+      window.setTimeout(() => {
+        window.dispatchEvent(new CustomEvent(CHAT_OPEN_PROJECTS_EVENT));
+        window.setTimeout(
+          () => window.dispatchEvent(new CustomEvent(CHAT_FOCUS_PROJECT_EVENT, { detail: { root } })),
+          60,
+        );
+      }, 0);
       return;
     }
     if (intent.kind === "focus-card") {

--- a/src/lib/chat-tab-events.ts
+++ b/src/lib/chat-tab-events.ts
@@ -1,2 +1,6 @@
 /** Window event that asks the chat surface to select its Projects tab. */
 export const CHAT_OPEN_PROJECTS_EVENT = "cave:chat-open-projects";
+
+/** Window event that asks the Projects tab to expand and scroll a specific
+ *  project into view. `detail.root` is the project's (un-normalized) root. */
+export const CHAT_FOCUS_PROJECT_EVENT = "cave:chat-focus-project";


### PR DESCRIPTION
Follow-up to palette surface navigation (#1142): ⌘K could jump to surfaces but **not projects** (only sessions/familiars/board).

Adds **"Open project <name>"** rows:
- built from `useProjects()`, query-filtered (name or path), capped at 6
- hidden while typing a familiar scope (`@…`) or slash command, like the surface rows
- selecting one opens the Chat surface's **Projects tab**, then fires a new `CHAT_FOCUS_PROJECT_EVENT` so the matching `ProjectCard` **expands and scrolls into view** (it carries a stable `id` for the scroll)

Also fixes the palette rows `useMemo` to depend on `addons` (was missing from the deps after #1142 — harmless in practice but correct now).

New event constant in `chat-tab-events.ts`. Guard tests added in `command-palette.test.ts` (intent, project rows, workspace consumer) and `projects-view.test.ts` (focus listener + card id). tsc clean; full `test:app` (332) and `test:mobile` (16) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)