### PR TITLE
style(sidebar): strengthen the New chat hover wash (12% → 20%)

### DIFF
--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -133,7 +133,7 @@
 }
 
 .sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row:hover {
-  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 20%, transparent);
   color: var(--accent-presence);
   border-color: var(--accent-presence);
 }


### PR DESCRIPTION
Bumps the outlined New chat CTA's hover background tint from 12% to 20% accent for more noticeable press feedback. One-line change in `sidebar-minimal.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)