### PR TITLE
feat(composer): persist ↑/↓ prompt history across reloads

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -301,6 +301,7 @@ export const SUITES = {
     "src/lib/datetime-format.test.ts",
     "src/lib/relative-time.test.ts",
     "src/lib/model-label.test.ts",
+    "src/lib/composer-history.test.ts",
     "src/lib/appearance-corner-radius.test.ts",
     "src/lib/code-layout-preset.test.ts",
     "src/lib/use-changes-summary.test.ts",

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -430,4 +430,17 @@ assert.match(
   "an emptied draft removes the key (sent messages don't reappear on reload)",
 );
 
+// The ↑/↓ prompt-history survives a reload: it initialises from localStorage
+// and is persisted whenever it changes.
+assert.match(
+  source,
+  /const \[inputHistory, setInputHistory\] = useState<string\[\]>\(\(\) => readComposerHistory\(COMPOSER_HISTORY_KEY\)\)/,
+  "input history initialises from the persisted recall stack",
+);
+assert.match(
+  source,
+  /writeComposerHistory\(COMPOSER_HISTORY_KEY, inputHistory\)/,
+  "input history is persisted when it changes",
+);
+
 console.log("chat-view-lifecycle.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -66,6 +66,7 @@ import { toolArgSummary } from "@/lib/tool-arg-summary";
 import { toolInputAsDiff, toolTargetFile } from "@/lib/tool-input-diff";
 import { findMatchingTurnIds } from "@/lib/transcript-find";
 import { isSyntheticLocalModel, type ChatModelState } from "@/lib/chat-model-state";
+import { readComposerHistory, writeComposerHistory } from "@/lib/composer-history";
 
 type ToolEvent = {
   id: string;
@@ -184,6 +185,8 @@ const COMPOSER_PREFS_KEY = "cave:chat-composer-controls:v1";
 // half-written message. The composer is a single shared input (it isn't
 // remounted per session), so one key mirrors the in-memory behaviour.
 const COMPOSER_DRAFT_KEY = "cave:chat-composer-draft:v1";
+// Persisted ↑/↓ prompt-history recall stack for the chat composer.
+const COMPOSER_HISTORY_KEY = "cave:chat-composer-history:v1";
 const THINKING_OPTIONS: Array<{ value: ComposerThinkingEffort; label: string }> = [
   { value: "low", label: "Low" },
   { value: "medium", label: "Medium" },
@@ -1543,7 +1546,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const [responseSpeed, setResponseSpeed] = useState<ComposerResponseSpeed>(() => readComposerPrefs().responseSpeed);
   const [input, setInput] = useState(() => readComposerDraft());
   // CHAT-D11-04: Input history navigation (↑↓), matching HomeComposer pattern
-  const [inputHistory, setInputHistory] = useState<string[]>([]);
+  const [inputHistory, setInputHistory] = useState<string[]>(() => readComposerHistory(COMPOSER_HISTORY_KEY));
   const [inputHistoryIdx, setInputHistoryIdx] = useState<number>(-1);
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
   // Reply to Chat: the turn the next message quotes, shown as a composer chip
@@ -2934,6 +2937,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   useEffect(() => {
     writeComposerDraft(input);
   }, [input]);
+
+  // Persist the ↑/↓ prompt-history so past prompts survive a reload.
+  useEffect(() => {
+    writeComposerHistory(COMPOSER_HISTORY_KEY, inputHistory);
+  }, [inputHistory]);
 
   // Disarm a pending delete confirmation and sync the selected project when
   // switching sessions. Drop staged file mentions because they are scoped to

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -171,3 +171,15 @@ assert.match(
   /if \(text\) window\.localStorage\.setItem\(HOME_DRAFT_KEY, text\);\s*else window\.localStorage\.removeItem\(HOME_DRAFT_KEY\)/,
   "an emptied home draft removes the key (sent prompts don't reappear on reload)",
 );
+
+// The ↑/↓ prompt-history also survives a reload.
+assert.match(
+  source,
+  /const \[history, setHistory\] = useState<string\[\]>\(\(\) => readComposerHistory\(HOME_HISTORY_KEY\)\)/,
+  "home prompt history initialises from the persisted recall stack",
+);
+assert.match(
+  source,
+  /writeComposerHistory\(HOME_HISTORY_KEY, history\)/,
+  "home prompt history is persisted when it changes",
+);

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -22,6 +22,7 @@ import { Icon, type IconName } from "@/lib/icon";
 import { ChatModelControl } from "@/components/chat-model-control";
 import type { ChatModelState } from "@/lib/chat-model-state";
 import { draftReminderFromText } from "@/lib/reminder-draft";
+import { readComposerHistory, writeComposerHistory } from "@/lib/composer-history";
 import { canonicalize, matchSlash, type SlashCommand } from "@/lib/slash-commands";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -66,6 +67,8 @@ const SEED_SUGGESTIONS = [
 // Persist the in-progress prompt so a page reload doesn't eat what you were
 // typing on the home screen (mirrors the chat composer's draft persistence).
 const HOME_DRAFT_KEY = "cave:home-composer-draft:v1";
+// Persisted ↑/↓ prompt-history recall stack for the home composer.
+const HOME_HISTORY_KEY = "cave:home-composer-history:v1";
 
 function readHomeDraft(): string {
   if (typeof window === "undefined") return "";
@@ -104,7 +107,7 @@ export function HomeComposer({
   const [sending, setSending] = useState(false);
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [suggestionsLoading, setSuggestionsLoading] = useState(true);
-  const [history, setHistory] = useState<string[]>([]);
+  const [history, setHistory] = useState<string[]>(() => readComposerHistory(HOME_HISTORY_KEY));
   const [historyIdx, setHistoryIdx] = useState<number>(-1);
   const [slashIdx, setSlashIdx] = useState(0);
   // Stable per-mount listbox id — the chat composer mounts its own slash menu,
@@ -184,6 +187,11 @@ export function HomeComposer({
   useEffect(() => {
     writeHomeDraft(text);
   }, [text]);
+
+  // Persist the ↑/↓ prompt-history so past prompts survive a reload.
+  useEffect(() => {
+    writeComposerHistory(HOME_HISTORY_KEY, history);
+  }, [history]);
 
   // Focus on mount
   useEffect(() => {

--- a/src/lib/composer-history.test.ts
+++ b/src/lib/composer-history.test.ts
@@ -1,0 +1,41 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readComposerHistory, writeComposerHistory } from "./composer-history.ts";
+
+// A tiny in-memory localStorage stand-in (the helpers are SSR-guarded on
+// `window`, so provide a global window for the node test run).
+const store = new Map();
+globalThis.window = {
+  localStorage: {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+  },
+};
+
+const KEY = "cave:test-history";
+
+assert.deepEqual(readComposerHistory(KEY), [], "missing key reads as empty history");
+
+writeComposerHistory(KEY, ["one", "two", "three"]);
+assert.deepEqual(readComposerHistory(KEY), ["one", "two", "three"], "round-trips a history array");
+
+// Empty history removes the key rather than storing "[]".
+writeComposerHistory(KEY, []);
+assert.equal(store.has(KEY), false, "empty history clears the stored key");
+
+// Capped at 50 most-recent entries.
+const big = Array.from({ length: 70 }, (_, i) => `p${i}`);
+writeComposerHistory(KEY, big);
+const stored = readComposerHistory(KEY);
+assert.equal(stored.length, 50, "history is capped at 50 entries");
+assert.equal(stored[0], "p20", "the oldest entries are dropped (keeps the most recent)");
+assert.equal(stored[49], "p69", "the most recent entry is kept");
+
+// Malformed JSON / non-array falls back to empty.
+store.set(KEY, "{not json");
+assert.deepEqual(readComposerHistory(KEY), [], "malformed storage falls back to empty");
+store.set(KEY, JSON.stringify({ nope: 1 }));
+assert.deepEqual(readComposerHistory(KEY), [], "non-array storage falls back to empty");
+
+console.log("composer-history.test.ts: ok");

--- a/src/lib/composer-history.ts
+++ b/src/lib/composer-history.ts
@@ -1,0 +1,28 @@
+// Shared persistence for composer prompt-history (the ↑/↓ recall stack).
+// Both the chat composer and the home composer keep an in-memory history of
+// sent prompts; these helpers persist it to localStorage so ↑ still recalls
+// past prompts after a page reload. Pure + SSR-guarded (no `node:` imports).
+
+// Cap the stored history so localStorage can't grow without bound.
+const HISTORY_CAP = 50;
+
+export function readComposerHistory(key: string): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(key);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed.filter((x) => typeof x === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeComposerHistory(key: string, history: string[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (history.length === 0) window.localStorage.removeItem(key);
+    else window.localStorage.setItem(key, JSON.stringify(history.slice(-HISTORY_CAP)));
+  } catch {
+    /* best effort */
+  }
+}


### PR DESCRIPTION
The chat and home composers keep a ↑/↓ recall stack of sent prompts, but it lived in memory only — pressing ↑ after a reload recalled nothing.

Adds a small shared `src/lib/composer-history.ts` (SSR-guarded, capped at 50 entries to bound localStorage) used by both composers:
- history **initialises** from localStorage (`useState(() => readComposerHistory(KEY))`)
- and is **persisted** whenever it changes
- per-composer keys: `cave:chat-composer-history:v1` and `cave:home-composer-history:v1`

Completes the composer-persistence arc alongside draft persistence (chat #1147, home #1150).

New `composer-history.test.ts` (round-trip, cap, empty-clears, malformed fallback — wired into CI) plus guard assertions in `chat-view-lifecycle.test.ts` and `home-composer.test.ts`. tsc clean; full `test:app` (333) and `test:mobile` (16) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)