### PR TITLE
feat(capabilities): icon + clear-filters on the no-match state

### DIFF
--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -476,6 +476,12 @@ export function CapabilitiesViewSurface({
                 onCopy={copyCapabilityDetail}
                 onOpenPath={openLocalPath}
                 onSelectHarness={applyHarnessFilter}
+                onClearFilters={() => {
+                  setQuery("");
+                  setHarnessFilter(null);
+                  setTypeFilter("all");
+                  setStatusFilter("all");
+                }}
               />
             </>
           )}
@@ -498,6 +504,7 @@ function CapabilityMap({
   onCopy,
   onOpenPath,
   onSelectHarness,
+  onClearFilters,
 }: {
   items: CapabilityMapItem[];
   selectedId: string | null;
@@ -508,6 +515,7 @@ function CapabilityMap({
   onCopy: (key: string, value?: string) => void;
   onOpenPath: (path?: string) => void;
   onSelectHarness: (id: string | null) => void;
+  onClearFilters: () => void;
 }) {
   const grouped = useMemo(() => {
     const map = new Map<CapabilityType, CapabilityMapItem[]>();
@@ -521,9 +529,16 @@ function CapabilityMap({
 
   if (items.length === 0) {
     return (
-      <div className="rounded-lg border border-dashed border-border px-4 py-10 text-center text-[13px] text-muted-foreground">
-        No capabilities match the current filters.
-      </div>
+      <EmptyState
+        icon="ph:magnifying-glass"
+        headline="No capabilities match"
+        subtitle="Nothing matches the current search and filters. Clear them to see the full operator map."
+        actions={
+          <Button leadingIcon="ph:x" onClick={onClearFilters}>
+            Clear filters
+          </Button>
+        }
+      />
     );
   }
 


### PR DESCRIPTION
## What

The Capabilities tab's filtered-empty case was a bare line — "No capabilities match the current filters." It now uses the shared `EmptyState`: search icon, headline, subtitle, and a **Clear filters** button that resets the search + harness + type + status filters.

This is the 4th and final tab of the Roles & capability map; with #1152 (Roles/Workflows/Skills) it means all four tabs now share one no-results idiom. Continues the search-no-results consistency thread (Board #1146, Familiars #1149, Roles tabs #1152).

## Tests / verification

- `capabilities-view-polish.test.ts` passes; no test pins the empty text.
- Full `pnpm build` green; `tsc --noEmit` clean.
- Live-verified on real `/api/capabilities` data: a no-match search shows "No capabilities match" + Clear filters; clicking it resets the search and the operator map returns. Screenshot confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)