### PR TITLE
style(sidebar): thicken the New chat outline border (1px → 2px)

### DIFF
--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -128,7 +128,7 @@
 .sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row {
   background: transparent;
   color: var(--accent-presence);
-  border: 1px solid var(--accent-presence);
+  border: 2px solid var(--accent-presence);
   font-weight: 600;
 }
 


### PR DESCRIPTION
Bumps the outlined New chat CTA's border from 1px to 2px so the accent outline reads a bit stronger. One-line change in `sidebar-minimal.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)