### PR TITLE
feat(workflows): icon + Retry on the workflow-library load error

### DIFF
--- a/src/components/workflows/workflow-library.tsx
+++ b/src/components/workflows/workflow-library.tsx
@@ -146,7 +146,16 @@ export function WorkflowLibrary({
       {!loaded ? (
         <div className="workflow-library-state">Loading workflow manifests...</div>
       ) : error ? (
-        <div className="workflow-library-state workflow-library-state-error">Workflows unavailable: {error}</div>
+        <div className="workflow-library-state workflow-library-state-error" role="alert">
+          <span className="workflow-library-state-error-msg">
+            <Icon name="ph:warning-circle" width={13} aria-hidden />
+            Workflows unavailable: {error}
+          </span>
+          <button type="button" className="workflow-primary-button" onClick={onRefresh}>
+            <Icon name="ph:arrow-clockwise" width={13} />
+            Retry
+          </button>
+        </div>
       ) : workflows.length === 0 ? (
         <div className="workflow-library-state">
           No WORKFLOW.md or .workflow.yaml manifests found.

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -483,7 +483,17 @@
 }
 
 .workflow-library-state-error {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
   color: var(--destructive);
+}
+
+.workflow-library-state-error-msg {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .workflow-health {


### PR DESCRIPTION
## What

When the workflow manifest list failed to load, the library column showed a bare red line — "Workflows unavailable: \<error\>" — with no icon and **no way to recover**. It now carries a warning icon and a **Retry** button (wired to the existing `onRefresh` reload), and announces as `role="alert"`, matching the app's load-failure convention (Board / Inbox / Library lists).

Reuses the library's own `workflow-primary-button`; only the `-error` variant gains a flex column so the message and Retry stack.

## Tests / verification

- Full `pnpm build` (test:app + next build) green; `tsc --noEmit` clean. No test pins this markup.
- Live-verified with `/api/workflows` mocked to fail: the library shows the warning icon + "Workflows unavailable: Daemon offline." + a Retry button (`role="alert"`). Screenshot confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)