### PR TITLE
feat(code): render file-preview load errors as an error state, not fake code

### DIFF
--- a/src/components/comux-view-terminal.test.ts
+++ b/src/components/comux-view-terminal.test.ts
@@ -279,7 +279,7 @@ assert.match(
 // unsupported-extension code block.
 assert.match(
   source,
-  /type ProjectFilePreview =[\s\S]*?\| \{ kind: "image"; dataUrl: string; mimeType: string; size\?: number \};/,
+  /type ProjectFilePreview =[\s\S]*?\| \{ kind: "image"; dataUrl: string; mimeType: string; size\?: number \}/,
   "Projects file preview state tracks image previews separately from text",
 );
 assert.match(

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -62,7 +62,8 @@ type Props = {
 
 type ProjectFilePreview =
   | { kind: "text"; content: string; size?: number }
-  | { kind: "image"; dataUrl: string; mimeType: string; size?: number };
+  | { kind: "image"; dataUrl: string; mimeType: string; size?: number }
+  | { kind: "error"; message: string };
 
 const STORAGE_SESSIONS = "cave:comux:sessions";
 const STORAGE_LAYOUT = "cave:comux:terminal-layout:v1";
@@ -559,10 +560,10 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
       } else if (json.ok && typeof json.content === "string") {
         setPreview({ kind: "text", content: json.content, size: json.size });
       } else {
-        setPreview({ kind: "text", content: `// Error: ${json.error ?? "unknown"}` });
+        setPreview({ kind: "error", message: json.error ?? "Could not load this file." });
       }
     } catch (err) {
-      setPreview({ kind: "text", content: `// Fetch failed: ${String(err)}` });
+      setPreview({ kind: "error", message: `Could not load this file. ${String(err)}` });
     } finally {
       setPreviewLoading(false);
     }
@@ -1591,7 +1592,15 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                             />
                           </div>
                         ) : (
-                          preview?.kind === "image" ? (
+                          preview?.kind === "error" ? (
+                            <div className="flex h-full min-h-[240px] flex-col items-center justify-center gap-2 rounded-md border border-dashed border-[var(--border-hairline)] bg-[var(--bg-base)] p-4 text-center" role="alert">
+                              <Icon name="ph:warning-circle" width={28} className="text-[var(--color-danger)] opacity-80" />
+                              <p className="text-[12px] text-[var(--text-secondary)]">{preview.message}</p>
+                              {previewPath ? (
+                                <p className="font-mono text-[10px] text-[var(--text-muted)]">{previewPath.split("/").pop()}</p>
+                              ) : null}
+                            </div>
+                          ) : preview?.kind === "image" ? (
                             <div className="flex h-full min-h-[240px] flex-col items-center justify-center gap-3 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] p-4">
                               <img
                                 src={preview.dataUrl}


### PR DESCRIPTION
## What

When a file failed to load in the Code file preview, the error was stuffed into the preview as **fake source** — `// Error: <msg>` — rendered with syntax highlighting, line numbers, and an enabled **Edit** button, as if it were the file's real content.

Added a dedicated preview `kind: "error"` that renders a centered warning icon + the message + the filename (`role="alert"`). The Edit / Save / raw-toggle controls already gate on `kind === "text"`, so they correctly stay disabled for the error state.

## Tests / verification

- Full `pnpm build` (test:app + next build) green; `tsc --noEmit` clean (the new union variant didn't break the existing `preview?.content` accesses).
- Live-verified with `/api/project-file` mocked to fail: clicking a file shows a `role="alert"` with the warning icon + "Permission denied." + filename, and the old `// Error:` fake-code content is gone. Confirmed programmatically (`fakeCode: false`) + screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)