### PR TITLE
feat(chat): collect tool usage into a designated section

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -89,18 +89,14 @@ assert.doesNotMatch(
   "Thinking and tool-use disclosures must not default open",
 );
 
-// --- CHAT-D13-01: tool activity hidden by default on settled turns ---
+// --- Tool activity renders in a designated section on settled turns ---
 
-assert.match(
+// No per-turn show/hide toggle: the designated section is always present
+// (collapsed) instead, so prose and tool usage are cleanly separated.
+assert.doesNotMatch(
   turnRow,
-  /const showTools = turn\.pending \? true : \(showToolsOverride \?\? false\)/,
-  "Tool activity should stay visible while streaming and default hidden once the response has fully generated",
-);
-
-assert.match(
-  turnRow,
-  /cave-turn-tools-toggle[\s\S]{0,300}aria-pressed=\{showTools\}/,
-  "Settled turns with tools should expose an always-visible toggle chip with pressed state",
+  /showTools|showToolsOverride|cave-turn-tools-toggle/,
+  "the settled-turn tool show/hide toggle is gone — tools live in a designated section",
 );
 
 assert.match(
@@ -112,13 +108,13 @@ assert.match(
 assert.match(
   turnRow,
   /renderSegments = split\.some\(\(s\) => s\.kind === "block"\) \? split : undefined/,
-  "Hiding tools still falls back to plain prose unless the message has a renderable artifact",
+  "settled turns render prose (+ artifacts) only — tool blocks are not woven into the text",
 );
 
 assert.match(
   turnRow,
-  /showTools && !segments && turn\.tools\?\.length \? <ToolGroup/,
-  "The legacy trailing ToolGroup should honor the same hidden-by-default contract",
+  /!turn\.pending && turn\.tools\?\.length \? <ToolGroup/,
+  "every settled turn that used tools renders the designated ToolGroup section",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3757,13 +3757,11 @@ function TurnRowImpl({
   expanded?: boolean;
   onToggleAvatar?: () => void;
 }) {
-  // CHAT-D13-01: tool activity stays visible while a turn streams (watching
-  // tools run IS the live feedback), then hides once the response has fully
-  // generated and sent — a "N tools" chip in the meta row toggles it back.
-  // Only an explicit click records an override; the pending→settled flip
-  // collapses tools on its own because the settled default is hidden.
-  const [showToolsOverride, setShowToolsOverride] = useState<boolean | null>(null);
-  const showTools = turn.pending ? true : (showToolsOverride ?? false);
+  // Tool activity renders inline while a turn streams (watching tools run IS the
+  // live feedback). Once the turn settles, the prose is shown uninterrupted and
+  // every tool call is collected into one designated, collapsed "Tool activity"
+  // section below it (the ToolGroup) — so a familiar's response reads cleanly and
+  // its tool usage is clearly separated rather than woven through the text.
   // Chat timestamp format (12h/24h clock + MM.DD/DD.MM/Off date) — a user
   // preference; the model/cwd/duration that used to sit here now live only in
   // the debug pane's per-turn JSON.
@@ -3872,18 +3870,17 @@ function TurnRowImpl({
   );
 
   // Auto-detect renderable artifacts and inject the tabbed viewer. Applies to
-  // SETTLED turns only (streaming shows plain code until the fence closes), and
-  // independently of showTools so the viewer appears even when tools are hidden.
+  // SETTLED turns only (streaming shows plain code until the fence closes).
   const artifactCtx = { familiarId: familiar.id };
-  const expandArtifacts = (segs: MessageBubbleSegment[]): MessageBubbleSegment[] =>
-    segs.flatMap((seg) => (seg.kind === "text" ? splitTextForArtifacts(seg.text, artifactCtx) : [seg]));
 
   let renderSegments: MessageBubbleSegment[] | undefined;
   if (turn.pending) {
-    renderSegments = showTools ? bubbleSegments : undefined;
-  } else if (showTools && bubbleSegments) {
-    renderSegments = expandArtifacts(bubbleSegments);
+    // Streaming: interleave tool blocks inline at their chronological offset so
+    // you can watch them run as live feedback.
+    renderSegments = bubbleSegments;
   } else {
+    // Settled: prose only (+ artifact viewers). Tools are NOT woven into the
+    // text — they render in the designated ToolGroup section below.
     const split = splitTextForArtifacts(visible, artifactCtx);
     renderSegments = split.some((s) => s.kind === "block") ? split : undefined;
   }
@@ -3960,22 +3957,6 @@ function TurnRowImpl({
                 <Icon name="ph:info" width={11} aria-hidden />
               </span>
             ) : null}
-            {/* CHAT-D13-01: settled turns hide tool activity by default —
-                this chip is the only way back to it, so it must not be
-                hover-gated. Hidden while streaming (tools are inline then). */}
-            {!turn.pending && (turn.tools?.length ?? 0) > 0 ? (
-              <button
-                type="button"
-                className={`cave-turn-tools-toggle${showTools ? " is-active" : ""}`}
-                aria-pressed={showTools}
-                aria-label={showTools ? "Hide tool activity" : "Show tool activity"}
-                title={showTools ? "Hide tool activity" : "Show tool activity"}
-                onClick={() => setShowToolsOverride(!showTools)}
-              >
-                <Icon name="ph:wrench" width={11} aria-hidden />
-                {turn.tools!.length} tool{turn.tools!.length === 1 ? "" : "s"}
-              </button>
-            ) : null}
           </div>
 
           <div className="cave-linear-turn-body">
@@ -4022,10 +4003,11 @@ function TurnRowImpl({
                 ))}
               </div>
             ) : null}
-            {/* Legacy trailing rollup — ONLY for turns whose tools predate
-                textOffset; segmented turns render their tools inline.
-                CHAT-D13-01: same default-hidden contract as inline tools. */}
-            {showTools && !segments && turn.tools?.length ? <ToolGroup tools={turn.tools} /> : null}
+            {/* Designated "Tool activity" section: on every settled turn that
+                used tools, collect them into one collapsed group below the prose
+                (which renders uninterrupted above). Streaming turns show tools
+                inline instead — see renderSegments. */}
+            {!turn.pending && turn.tools?.length ? <ToolGroup tools={turn.tools} /> : null}
           </div>
         </div>
       </div>

--- a/src/lib/session-debug.test.ts
+++ b/src/lib/session-debug.test.ts
@@ -227,8 +227,8 @@ assert.match(
 );
 assert.match(
   chatViewSource,
-  /\{showTools && !segments && turn\.tools\?\.length \? <ToolGroup tools=\{turn\.tools\} \/> : null\}/,
-  "CHAT-D4-01: trailing ToolGroup rollup survives ONLY for legacy turns without offsets",
+  /\{!turn\.pending && turn\.tools\?\.length \? <ToolGroup tools=\{turn\.tools\} \/> : null\}/,
+  "every settled turn with tools renders the designated trailing ToolGroup section",
 );
 assert.match(
   chatViewSource,


### PR DESCRIPTION
Reviewing familiar responses, tool usage was muddled into the reply: on settled turns it was hidden behind a "N tools" toggle chip and, when shown, **interleaved inline** between prose paragraphs.

Now a **settled** turn renders its **prose uninterrupted**, and every tool call is collected into one **designated, collapsed "Tool activity" section** (the existing `ToolGroup` disclosure) beneath the response — always present when a turn used tools, click to expand.

```
Familiar reply prose…  (never interrupted by tool blocks)

▸ Tool activity · 3 tools     ← collapsed by default, click to expand
```

- **Streaming** turns still interleave tools inline at their chronological offset (live feedback) — unchanged.
- Removes the per-turn show/hide toggle chip and `showTools`/`showToolsOverride` state (the always-present collapsed section replaces it) and the now-unused `expandArtifacts` helper.

Updated the source-text tests in `chat-view-polish.test.ts` and `session-debug.test.ts` that pinned the old hidden-by-default/inline contract. tsc clean; full `test:app` (333) and `test:mobile` (16) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)