### PR TITLE
feat(calendar): quick-add a reminder on a month-view day

### DIFF
--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -629,11 +629,13 @@ function MonthView({
   anchor,
   onOpenItem,
   onDayClick,
+  onAddEntry,
 }: {
   items: InboxItem[];
   anchor: Date;
   onOpenItem?: (item: InboxItem) => void;
   onDayClick?: (day: Date) => void;
+  onAddEntry?: (opts: { fireAt: string }) => void;
 }) {
   const today = new Date();
   const monthStart = startOfMonth(anchor);
@@ -690,12 +692,26 @@ function MonthView({
                       onDayClick?.(day);
                     }
                   }}
-                  className={`focus-ring-inset flex cursor-pointer flex-col overflow-hidden p-1.5 transition-colors ${
+                  className={`group relative focus-ring-inset flex cursor-pointer flex-col overflow-hidden p-1.5 transition-colors ${
                     isCurrentMonth
                       ? "bg-[var(--bg-panel)] hover:bg-[var(--bg-raised)]"
                       : "bg-[var(--bg-base)] hover:bg-[var(--bg-panel)]"
                   } ${isToday ? "ring-1 ring-inset ring-[var(--accent-presence)]" : ""}`}
                 >
+                  {onAddEntry && isCurrentMonth && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onAddEntry({ fireAt: defaultEntryFireAt(day) });
+                      }}
+                      aria-label={`Add a reminder on ${fmtDateHeading(day)}`}
+                      title="Add reminder"
+                      className="focus-ring absolute right-1 top-1 hidden h-4 w-4 items-center justify-center rounded text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--accent-presence)] group-hover:flex group-focus-within:flex"
+                    >
+                      <Icon name="ph:plus" width={10} aria-hidden />
+                    </button>
+                  )}
                   <span
                     className={`mb-1 flex h-5 w-5 items-center justify-center rounded-full text-[11px] font-medium ${
                       isToday
@@ -1207,6 +1223,7 @@ export function CalendarView({ items, familiars, activeFamiliarId, onAddEntry, o
             items={scopedItems}
             anchor={anchor}
             onOpenItem={(item) => setSelectedItem(item)}
+            onAddEntry={onAddEntry}
             onDayClick={(day) => {
               setAnchor(day);
               setViewMode("day");


### PR DESCRIPTION
## What

Month-view day cells only *navigated into* the day on click; to create a reminder for a specific day you had to click in, then use the global Add button. Each **current-month** cell now reveals a small **"+"** on hover/focus that calls `onAddEntry` with that day's default time — drop a reminder straight onto a day.

The cell stays fully keyboard-operable (`role="button"` / Enter / `onDayClick` unchanged), the today ring is untouched, and the "+" is `group-hover` / `group-focus-within` revealed so it doesn't add visual noise.

## Tests / verification

- `calendar-view-polish`, `calendar-actions`, `calendar-keyboard` tests pass; `tsc --noEmit` clean **for this change** (calendar-view.tsx).

> ⚠️ CI note: `main` is currently red due to an unrelated broken `library-doc-list.tsx` (missing `relativeTime` import — a separate session is mid-fix). The Frontend build will go green once that lands; I'll rebase before merging. This PR touches only `calendar-view.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)