### PR TITLE
fix(library): import relativeTime in library-doc-list (red main)

### DIFF
--- a/src/components/library-doc-list.tsx
+++ b/src/components/library-doc-list.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Icon } from "@/lib/icon";
 import { formatDate } from "@/lib/datetime-format";
+import { relativeTime } from "@/lib/relative-time";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
@@ -24,8 +25,6 @@ type Props = {
   /** Triggered when the user clicks Retry in the error state. */
   onRetry?: () => void;
 };
-
-const relDateFmt = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
 
 function relDate(iso: string): string {
   const then = new Date(iso).getTime();


### PR DESCRIPTION
`main` is **tsc-red**: `src/components/library-doc-list.tsx:36` (`relDate()`) calls `relativeTime(iso)`, but the symbol is **neither imported nor defined** — so `tsc --noEmit` / `next build` fail, blocking every PR's **Frontend build** check.

This is fallout from the relative-time unification (#1179) + the partial restore (#1178), which re-added `formatDate`/`relDateFmt` but missed `relativeTime`.

Fix:
- import `relativeTime` from the shared `@/lib/relative-time`
- drop the now-unused `relDateFmt` const (dead after the switch to the shared helper)

tsc clean, full `test:app` (333) green. Self-merging ASAP to unblock the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)