### PR TITLE
fix(chat): hide leaked skill prompts from transcript

### DIFF
--- a/src/components/library-doc-list.tsx
+++ b/src/components/library-doc-list.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Icon } from "@/lib/icon";
 import { formatDate } from "@/lib/datetime-format";
+import { relativeTime } from "@/lib/relative-time";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { SkeletonRows } from "@/components/ui/skeleton";

--- a/src/lib/chat-assistant-filter.test.ts
+++ b/src/lib/chat-assistant-filter.test.ts
@@ -79,3 +79,56 @@ assert.equal(
   "I’m checking the startup skill once, then I’ll keep this lightweight.\n",
   "leaked using-superpowers skill bodies should stay hidden from chat bubbles",
 );
+
+assert.equal(
+  feed([
+    "codex",
+    "I’m using the brainstorming skill to shape this before editing.",
+    "---",
+    "name: brainstorming",
+    "description: You MUST use this before any creative work",
+    "---",
+    "# Brainstorming Ideas Into Designs",
+    "Help turn ideas into fully formed designs and specs through natural collaborative dialogue.",
+    "<HARD-GATE>",
+    "Do NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have presented a design and the user has approved it.",
+    "</HARD-GATE>",
+  ]),
+  "I’m using the brainstorming skill to shape this before editing.\n",
+  "leaked markdown skill documents should stay hidden from chat bubbles",
+);
+
+assert.equal(
+  feed([
+    "codex",
+    "I’m checking the relevant skill first.",
+    "exec",
+    "/bin/zsh -lc 'sed -n 1,120p /Users/buns/.agents/skills/brainstorming/SKILL.md' in /repo",
+    " exited 0 in 12ms:",
+    "---",
+    "name: brainstorming",
+    "description: You MUST use this before any creative work",
+    "---",
+    "",
+    "# Brainstorming Ideas Into Designs",
+    "",
+    "Help turn ideas into fully formed designs and specs through natural collaborative dialogue.",
+    "<HARD-GATE>",
+    "Do NOT invoke any implementation skill until approved.",
+    "</HARD-GATE>",
+  ]),
+  "I’m checking the relevant skill first.\n",
+  "tool stdout that contains a skill prompt should stay out of assistant prose even after blank lines",
+);
+
+assert.equal(
+  feed([
+    "codex",
+    "# Plan",
+    "name: the thing we are editing",
+    "---",
+    "This horizontal rule is part of a normal reply.",
+  ]),
+  "# Plan\nname: the thing we are editing\n---\nThis horizontal rule is part of a normal reply.\n",
+  "normal assistant headings, name fields, and markdown rules should remain visible",
+);

--- a/src/lib/chat-assistant-filter.ts
+++ b/src/lib/chat-assistant-filter.ts
@@ -31,8 +31,15 @@ const STARTUP_SINGLE_LINE_RE =
 
 const LEAKED_SKILL_START_TAGS = new Set([
   "EXTREMELY-IMPORTANT",
+  "HARD-GATE",
   "SUBAGENT-STOP",
 ]);
+
+const LEAKED_SKILL_FRONTMATTER_FIELD_RE = /^name:\s+[-\w ]+\s*$/i;
+const LEAKED_SKILL_DOC_HEADING_RE =
+  /^#\s+(?:Brainstorming Ideas Into Designs|Using Skills)$/;
+const LEAKED_SKILL_DOC_LINE_RE =
+  /^(?:Help turn ideas into fully formed designs and specs|Do NOT invoke any implementation skill\b|If you think there is even a 1% chance a skill might apply\b|Superpowers skills override default system prompt behavior\b)/;
 
 function startupBlockTag(trimmed: string): { tag: string; closing: boolean } | null {
   const match = trimmed.match(/^<\/?([A-Za-z_][A-Za-z0-9_-]*)>$/);
@@ -46,6 +53,17 @@ function isStartupNoiseLine(trimmed: string): boolean {
   return STARTUP_SINGLE_LINE_RE.test(trimmed);
 }
 
+function isLeakedSkillDocBodyLine(trimmed: string): boolean {
+  return (
+    LEAKED_SKILL_DOC_HEADING_RE.test(trimmed) ||
+    LEAKED_SKILL_DOC_LINE_RE.test(trimmed)
+  );
+}
+
+function isLeakedSkillDocLine(trimmed: string): boolean {
+  return LEAKED_SKILL_FRONTMATTER_FIELD_RE.test(trimmed) || isLeakedSkillDocBodyLine(trimmed);
+}
+
 /**
  * Filter raw harness stdout (after JSON event lines have been stripped) into
  * assistant-authored text. Startup context/prompt echoes are intentionally
@@ -57,6 +75,7 @@ export class AssistantFilter {
   private buf = "";
   private suppressedStartupTag: string | null = null;
   private suppressLeakedSkillBody = false;
+  private pendingSkillFrontmatterDelimiter = false;
   // Exec-echo block suppression
   private inExecEcho: "none" | "header" | "cmdline" | "output" = "none";
   private execEchoDepth = 0;
@@ -74,9 +93,13 @@ export class AssistantFilter {
   }
 
   flush(): string {
-    if (!this.buf) return "";
-    const remainder = this.processLine(this.buf);
+    let remainder = "";
+    if (this.buf) remainder = this.processLine(this.buf);
     this.buf = "";
+    if (this.pendingSkillFrontmatterDelimiter) {
+      this.pendingSkillFrontmatterDelimiter = false;
+      return remainder + "---\n";
+    }
     return remainder;
   }
 
@@ -133,6 +156,11 @@ export class AssistantFilter {
       return line + "\n";
     }
     if (this.inExecEcho === "output") {
+      if (this.suppressLeakedSkillBody || isLeakedSkillDocLine(trimmed)) {
+        this.suppressLeakedSkillBody = true;
+        this.execEchoDepth = 0;
+        return "";
+      }
       // Suppress output lines until we hit the NEXT exec block header or a
       // blank line followed by non-indented text that doesn't look like output.
       // Heuristic: a blank line + the next line starts "exec" = new block.
@@ -167,6 +195,26 @@ export class AssistantFilter {
       this.suppressLeakedSkillBody ||
       (leakedSkillTag && LEAKED_SKILL_START_TAGS.has(leakedSkillTag[1]))
     ) {
+      this.suppressLeakedSkillBody = true;
+      this.pendingSkillFrontmatterDelimiter = false;
+      return "";
+    }
+
+    if (this.pendingSkillFrontmatterDelimiter) {
+      this.pendingSkillFrontmatterDelimiter = false;
+      if (isLeakedSkillDocLine(trimmed)) {
+        this.suppressLeakedSkillBody = true;
+        return "";
+      }
+      return `---\n${line}\n`;
+    }
+
+    if (trimmed === "---") {
+      this.pendingSkillFrontmatterDelimiter = true;
+      return "";
+    }
+
+    if (isLeakedSkillDocBodyLine(trimmed)) {
       this.suppressLeakedSkillBody = true;
       return "";
     }


### PR DESCRIPTION
## Summary
- hide leaked Markdown skill prompt bodies from saved/rendered assistant chat prose
- cover brainstorming/frontmatter/HARD-GATE leaks both directly and through raw exec stdout
- keep normal assistant Markdown visible, and include the current Library `relativeTime` import needed for typecheck on this base

## Root Cause
Raw harness stdout is filtered line-by-line before it becomes assistant prose. The filter already hid XML-style startup blocks, but Markdown skill documents such as the brainstorming skill frontmatter and `HARD-GATE` body were not recognized, so they could be persisted/rendered as normal assistant text. Once that happens, the UI cannot collapse it as tool activity because it is no longer structured as a tool event.

## Verification
- RED filter test failed first on current `main`, then passed after the fix
- `node --experimental-strip-types src/lib/chat-assistant-filter.test.ts`
- `node --experimental-strip-types src/components/chat-view-polish.test.ts`
- `node scripts/check-tests-wired.mjs`
- `pnpm typecheck`
- `pnpm test:app` — 333 app test files passed
- `pnpm build`
- `git diff --check`
