### PR TITLE
feat(calendar): quick-add a reminder from a week-view day header

### DIFF
--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -593,10 +593,21 @@ function WeekView({
           {columns.map((col, i) => (
             <div
               key={i}
-              className={`flex-1 min-w-[80px] px-2 py-2 text-center ${
+              className={`group relative flex-1 min-w-[80px] px-2 py-2 text-center ${
                 col.isToday ? "bg-[color-mix(in_oklch,var(--accent-presence)_10%,transparent)]" : ""
               }`}
             >
+              {onAddEntry && (
+                <button
+                  type="button"
+                  onClick={() => onAddEntry({ fireAt: defaultEntryFireAt(col.date) })}
+                  aria-label={`Add a reminder on ${fmtDateHeading(col.date)}`}
+                  title="Add reminder"
+                  className="focus-ring absolute right-1 top-1 hidden h-4 w-4 items-center justify-center rounded text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--accent-presence)] group-hover:flex group-focus-within:flex"
+                >
+                  <Icon name="ph:plus" width={10} aria-hidden />
+                </button>
+              )}
               <div className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)]">
                 {WEEKDAYS[col.date.getDay()]}
               </div>


### PR DESCRIPTION
## What

Extends the month-view quick-add (#1180) to the **Week** view. Each of the seven day-column headers now reveals a small **"+"** on hover/focus that calls `onAddEntry` with that day's default time — drop a reminder onto any day of the week without first navigating into it.

The "+" lives in the **header** (a real, keyboard-focusable button with a per-day aria-label like "Add a reminder on Friday, June 19") — deliberately separate from the time-grid columns, so it doesn't nest interactive elements inside the event grid.

## Tests / verification

- `calendar-view-polish` (incl. the "WeekView must always render TimeGrid" pin — `<TimeGrid columns={columns} onOpenItem={onOpenItem} />` is unchanged), `calendar-actions`, `calendar-keyboard` — all pass. `tsc --noEmit` clean; full `pnpm build` green.
- Live-verified in the running app: Week view shows exactly **7** day-header "+" buttons with correct per-day labels (e.g. "Add a reminder on Sunday, June 14"), positioned top-right of each header, revealed on hover/focus. Screenshot confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)