### PR TITLE
fix(code): match the file editor background to the read code surface

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -66,6 +66,9 @@
      Semantic names called out in the spec. Resolve to the same
      palette as above so either vocabulary works. */
   --bg-base: var(--background);
+  /* Fixed near-opaque dark "ink" for code surfaces — read code blocks AND the
+     file editor share it so the Code page's read↔edit toggle keeps one bg. */
+  --code-surface: oklch(0.12 0.012 280 / 92%);
   --bg-panel: oklch(0.10 0.020 293);        /* deepest — app shell / sidebar floor */
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.20 0.028 293);     /* dropdowns / popovers */

--- a/src/components/code-editor.test.ts
+++ b/src/components/code-editor.test.ts
@@ -29,7 +29,7 @@ assert.match(editor, /key: "Escape", run: \(\) => \{ onCancel\(\); return true; 
 
 // Editor chrome is themed to the app's CSS tokens (not the generic dark theme).
 assert.match(editor, /const appTheme = EditorView\.theme\(/, "a CodeMirror theme is defined from app tokens");
-assert.match(editor, /backgroundColor: "var\(--bg-base\)"/, "editor background uses the app surface token");
+assert.match(editor, /backgroundColor: "var\(--code-surface\)"/, "editor background matches the read code surface via --code-surface");
 assert.match(editor, /caretColor: "var\(--accent-presence\)"/, "caret uses the app accent token");
 assert.match(editor, /theme=\{appTheme\}/, "the editor uses the app theme");
 

--- a/src/components/code-editor.tsx
+++ b/src/components/code-editor.tsx
@@ -12,7 +12,7 @@ import { loadLanguage, type LanguageName } from "@uiw/codemirror-extensions-lang
 const appTheme = EditorView.theme(
   {
     "&": {
-      backgroundColor: "var(--bg-base)",
+      backgroundColor: "var(--code-surface)",
       color: "var(--text-primary)",
       height: "100%",
       fontSize: "12px",
@@ -22,7 +22,7 @@ const appTheme = EditorView.theme(
       caretColor: "var(--accent-presence)",
     },
     ".cm-gutters": {
-      backgroundColor: "var(--bg-base)",
+      backgroundColor: "var(--code-surface)",
       color: "var(--text-muted)",
       border: "none",
     },

--- a/src/components/message-bubble-code-header.test.ts
+++ b/src/components/message-bubble-code-header.test.ts
@@ -203,20 +203,34 @@ assert.match(
 
 // The fixed dark surfaces must be near-opaque so they stay self-consistent
 // over a light --bg-base (a 60%-alpha wash goes muddy), and must not mix
-// with theme surfaces.
-for (const selector of [".cave-code-wrap", ".cave-bubble-system"]) {
-  const block = ruleBlock(selector);
-  assert.match(
-    block,
-    /background:\s*oklch\([^)]*\/\s*9\d%\)/,
-    `${selector} surface must be a near-opaque fixed dark oklch`,
-  );
-  assert.doesNotMatch(
-    block,
-    /var\(--bg-/,
-    `${selector} surface must not mix with theme backgrounds`,
-  );
-}
+// with theme surfaces. The code-block read surface (.cave-code-wrap) draws its
+// ink from the shared --code-surface token so the Code page's file editor can
+// match it exactly; the system bubble keeps the literal.
+const codeSurfaceToken = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
+assert.match(
+  codeSurfaceToken,
+  /--code-surface:\s*oklch\([^)]*\/\s*9\d%\)/,
+  "--code-surface token must resolve to a near-opaque fixed dark oklch",
+);
+
+const codeWrapSurface = ruleBlock(".cave-code-wrap");
+assert.match(
+  codeWrapSurface,
+  /background:\s*var\(--code-surface\)/,
+  ".cave-code-wrap surface must draw from the shared --code-surface token",
+);
+
+const systemBubble = ruleBlock(".cave-bubble-system");
+assert.match(
+  systemBubble,
+  /background:\s*oklch\([^)]*\/\s*9\d%\)/,
+  ".cave-bubble-system surface must be a near-opaque fixed dark oklch",
+);
+assert.doesNotMatch(
+  systemBubble,
+  /var\(--bg-/,
+  ".cave-bubble-system surface must not mix with theme backgrounds",
+);
 
 // ---------------------------------------------------------------------------
 // CHAT-D7-02 — the code-block header must be sticky inside the block's own

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -452,8 +452,8 @@
   border-radius: 9px;
   border: 1px solid var(--border-hairline);
   /* Near-opaque fixed dark: a 60%-alpha wash went muddy over a light
-     --bg-base (CHAT-D13-01). */
-  background: oklch(0.12 0.012 280 / 92%);
+     --bg-base (CHAT-D13-01). Shared with the file editor via --code-surface. */
+  background: var(--code-surface);
   box-shadow:
     0 1px 3px oklch(0 0 0 / 30%),
     inset 0 1px 0 oklch(0.985 0 0 / 4%);


### PR DESCRIPTION
In the Code page's file preview, the **read** view (syntax-highlighted `.cave-code-wrap`, a fixed near-opaque dark "ink") and the **edit** view (CodeMirror) used different backgrounds — the editor followed the theme via `--bg-base`, so on a light theme it went pale while the reader stayed dark. Toggling read↔edit flashed the surface.

- New shared `--code-surface` token in `globals.css` (the existing `oklch(0.12 0.012 280 / 92%)` ink).
- `.cave-code-wrap` read surface and the CodeMirror editor/gutters both draw from `--code-surface` → identical background in both views.
- `.cave-bubble-system` (chat system bubble) keeps its literal — out of scope.
- Tests updated: code-editor pins `--code-surface`; code-header test asserts `.cave-code-wrap` uses the token and the token itself is a near-opaque oklch.

test:app + test:mobile + build green.
🤖 Generated with [Claude Code](https://claude.com/claude-code)