### PR TITLE
feat(calendar): press N to add a reminder at the current view

### DIFF
--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -1076,11 +1076,16 @@ export function CalendarView({ items, familiars, activeFamiliarId, onAddEntry, o
         case "w": case "W": setViewMode("week");   break;
         case "m": case "M": setViewMode("month");  break;
         case "a": case "A": setViewMode("agenda"); break;
+        case "n": case "N":
+          if (onAddEntry) { e.preventDefault(); onAddEntry({ fireAt: defaultEntryFireAt(anchor) }); }
+          break;
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [viewMode]); // re-bind when viewMode changes so navigate() closure is current
+    // re-bind when viewMode/anchor changes so navigate() and the new-entry
+    // shortcut close over the current values.
+  }, [viewMode, anchor, onAddEntry]);
 
   function navigate(dir: -1 | 1) {
     setAnchor((prev) => {
@@ -1247,7 +1252,7 @@ export function CalendarView({ items, familiars, activeFamiliarId, onAddEntry, o
       <footer
         className="hidden shrink-0 border-t border-[var(--border-hairline)] px-3 py-1.5 text-[10px] text-[var(--text-muted)] sm:px-6 md:block"
       >
-        ← → navigate · T today · D Day · W Week · M Month · A Agenda
+        ← → navigate · T today · D Day · W Week · M Month · A Agenda{onAddEntry ? " · N new" : ""}
       </footer>
       {selectedItem && (
         <ItemDetailPanel


### PR DESCRIPTION
## What

The calendar had keyboard shortcuts for navigation (← →, T) and views (D/W/M/A) but **no way to start a new entry from the keyboard**. Pressing **N** now calls `onAddEntry` with the anchored day's default time (ignored while typing in an input/textarea/select), and the footer hint documents it ("· N new").

The keydown effect now also closes over the current `anchor` (added to its deps) so the shortcut targets the day you're looking at, not a stale one.

## Tests / verification

- `calendar-keyboard` (roving-tabindex / event-button pins), `calendar-view-polish`, `calendar-actions` — all pass; the test suite doesn't pin the switch cases. `tsc --noEmit` clean; full `pnpm build` green.
- Live-verified: the footer reads "… · A Agenda · **N new**", and pressing N opens the add flow. Confirmed in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)