### PR TITLE
fix(github): allow username-only setup + a11y pass

### DIFF
--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -167,4 +167,23 @@ assert.doesNotMatch(
   "GitHub header no longer reserves a gutter for the retired floating panel toggle",
 );
 
+// Setup Save accepts a username-only submission (public data, no PAT) — the
+// disabled gate must mirror save()'s "PAT OR username" rule, not require a PAT.
+assert.match(
+  source,
+  /disabled=\{\(!pat\.trim\(\) && !usernameInput\.trim\(\)\) \|\| saving\}/,
+  "Save is enabled when either a PAT or a username is entered (not PAT-only)",
+);
+// The filter row is an accessible tablist.
+assert.match(
+  source,
+  /role="tablist"[\s\S]{0,120}?aria-label="Filter GitHub activity"/,
+  "the filter row is a labelled tablist",
+);
+assert.match(
+  source,
+  /role="tab"\s*\n?\s*aria-selected=\{isActive\}/,
+  "each filter is a tab that reports its selected state",
+);
+
 console.log("github-view-polish.test.ts OK");

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -298,7 +298,7 @@ function PatSetupModal({
             </a>
             <button
               type="submit"
-              disabled={!pat.trim() || saving}
+              disabled={(!pat.trim() && !usernameInput.trim()) || saving}
               className="rounded-lg bg-[var(--accent-presence)] px-4 py-1.5 text-[12px] font-medium text-white disabled:opacity-40 hover:opacity-90 transition-opacity"
             >
               {saving ? "Verifying…" : "Save"}
@@ -447,7 +447,7 @@ function OpenChatAction({
         <span className="gh-action-btn-label">{label}</span>
       </button>
 
-      {error && <span className="gh-action-error" title={error}>!</span>}
+      {error && <span className="gh-action-error" role="img" aria-label={`Error: ${error}`} title={error}>!</span>}
 
       {pickerOpen && linkedCards.length > 1 && (
         <div ref={pickerRef} className="gh-action-popover" onClick={(e) => e.stopPropagation()}>
@@ -1128,7 +1128,8 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
               reloadCards();
             }}
             title="Refresh (⌘R)"
-            className="rounded-md p-1 text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] transition-colors"
+            aria-label="Refresh GitHub activity"
+            className="focus-ring rounded-md p-1 text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] transition-colors"
           >
             <Icon name="ph:arrows-clockwise" width={13} />
           </button>
@@ -1136,7 +1137,7 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
       </header>
 
       {/* ── Filter tabs ── */}
-      <div className="github-surface-controls flex items-center gap-1 px-4 py-2">
+      <div className="github-surface-controls flex items-center gap-1 px-4 py-2" role="tablist" aria-label="Filter GitHub activity">
         {(["all", "pr", "review_request", "issue"] as Filter[]).map((f) => {
           const labels: Record<Filter, string> = { all: "All", pr: "PRs", review_request: "Reviews", issue: "Issues" };
           const isActive = filter === f;
@@ -1145,9 +1146,11 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
             <button
               key={f}
               type="button"
+              role="tab"
+              aria-selected={isActive}
               onClick={() => setFilter(f)}
               className={[
-                "flex items-center gap-1.5 rounded-md px-2.5 py-1 text-[12px] transition-colors",
+                "focus-ring flex items-center gap-1.5 rounded-md px-2.5 py-1 text-[12px] transition-colors",
                 isActive
                   ? "bg-[var(--bg-raised)] text-[var(--text-primary)] font-medium"
                   : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]",
@@ -1413,6 +1416,7 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
                             target="_blank"
                             rel="noreferrer"
                             title="Open on GitHub"
+                            aria-label="Open on GitHub"
                             className="gh-action-btn gh-action-btn--icon"
                             onClick={(e) => e.stopPropagation()}
                           >


### PR DESCRIPTION
From a deep review of the GitHub view (verified against the code).

**Functional bug — username-only setup was blocked.** `save()` explicitly supports a **username-only** path (the copy: "Enter a GitHub username for public data **or** a PAT for private data"), but the Save button was `disabled={!pat.trim() || saving}` — so entering only a username left the button disabled and the no-token path unreachable. Now gated on **PAT *or* username**, matching the handler.

**A11y pass (cheap, real):**
- `aria-label` on the icon-only **Refresh** button and the per-row **"Open on GitHub"** link (they had `title` only).
- **Filter row** is now a proper `role="tablist"` with `role="tab"` + `aria-selected` on each filter.
- Inline error **"!"** indicator gets `role="img"` + `aria-label`.
- `focus-ring` on the refresh + filter buttons.

Left as noted follow-ups (bigger/behavior-changing): sortable `<th>` keyboard support, and switching the local `relTime()` to the shared `relativeTime`.

Guard assertions added in `github-view-polish.test.ts`. tsc clean; full `test:app` (333) and `test:mobile` (16) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)