### PR TITLE
feat(schedules): schedule times honor the 12h/24h clock preference

### DIFF
--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -54,14 +54,10 @@ const RRULE_DAY_LABEL: Record<string, string> = {
   SA: "Sat",
 };
 
-function pad(n: number) {
-  return n.toString().padStart(2, "0");
-}
-
 // Format a schedule's hour:minute honoring the user's 12h/24h clock pref
 // (so "Daily at 14:00" reads as "Daily at 2:00 PM" when 12-hour is selected).
 function scheduleTime(hour: number, minute: number): string {
-  return formatClock(new Date(2000, 0, 1, hour, minute, 0));
+  return formatClock(new Date(2000, 0, 1, hour, minute, 0).toISOString());
 }
 
 function humanSchedule(rec: Recurrence | undefined): string {

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -11,7 +11,7 @@ import type {
   CodexAutomationPatch,
 } from "@/lib/codex-automations-types";
 import { Icon } from "@/lib/icon";
-import { formatTimestamp } from "@/lib/datetime-format";
+import { formatTimestamp, formatClock } from "@/lib/datetime-format";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
 import { ProjectTree } from "@/components/project-tree";
@@ -58,6 +58,12 @@ function pad(n: number) {
   return n.toString().padStart(2, "0");
 }
 
+// Format a schedule's hour:minute honoring the user's 12h/24h clock pref
+// (so "Daily at 14:00" reads as "Daily at 2:00 PM" when 12-hour is selected).
+function scheduleTime(hour: number, minute: number): string {
+  return formatClock(new Date(2000, 0, 1, hour, minute, 0));
+}
+
 function humanSchedule(rec: Recurrence | undefined): string {
   if (!rec || rec.type === "none") return "One-shot";
   if (rec.type === "interval") {
@@ -68,10 +74,10 @@ function humanSchedule(rec: Recurrence | undefined): string {
     return `Every ${Math.round(h / 24)}d`;
   }
   if (rec.type === "daily")
-    return `Daily at ${pad(rec.hour)}:${pad(rec.minute)}`;
+    return `Daily at ${scheduleTime(rec.hour, rec.minute)}`;
   if (rec.type === "weekly") {
     const days = rec.days.map((d) => WEEKDAY[d] ?? "?").join("/");
-    return `${days}s at ${pad(rec.hour)}:${pad(rec.minute)}`;
+    return `${days}s at ${scheduleTime(rec.hour, rec.minute)}`;
   }
   if (rec.type === "cron") return `Cron: ${rec.expr}`;
   return "Scheduled";


### PR DESCRIPTION
## What

`humanSchedule` rendered reminder schedule times as raw 24-hour — "Daily at 14:00", "Weds at 09:00" — regardless of the user's clock preference. It now formats the hour:minute through the shared `formatClock`, so a 12-hour user sees **"Daily at 2:00 PM"** and a 24-hour user keeps **"Daily at 14:00"**. Consistent with the app-wide clock pref (#1072) and the reminder fire times (#1187).

(`formatClock` takes an ISO string, so the helper builds a local Date and `.toISOString()`s it — round-trips the local hour:minute across timezones. The now-unused `pad()` helper was removed.)

## Tests / verification

- No test pins `humanSchedule`'s output.
- `tsc --noEmit` clean; full `pnpm build` green.
- Verified the formatting: local 2:30 PM → "2:30 PM" (12h pref) / "14:30" (24h pref).

🤖 Generated with [Claude Code](https://claude.com/claude-code)