### PR TITLE
style(board): tighten the Gantt rows so items sit closer

### DIFF
--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1184,7 +1184,7 @@
 }
 .board-gantt-list {
   display: grid;
-  gap: 8px;
+  gap: 4px;
 }
 .board-gantt-row {
   display: grid;
@@ -1192,12 +1192,12 @@
   align-items: center;
   gap: 10px;
   width: 100%;
-  min-height: 42px;
+  min-height: 34px;
   border: 1px solid var(--border-hairline);
   border-radius: 8px;
   background: var(--bg-raised);
   color: var(--text-primary);
-  padding: 8px 10px;
+  padding: 5px 10px;
   text-align: left;
   cursor: pointer;
   transition: border-color .12s, background .12s;


### PR DESCRIPTION
The board's Gantt view spaced its rows with more air than the compact bars need (8px list gap, 42px row min-height, 8px vertical padding). Tighten so the timeline reads denser and the items sit closer together:

- list gap `8px → 4px`
- row min-height `42px → 34px`
- row vertical padding `8px → 5px`

The 12px track, title, and date labels stay comfortable — verified visually against a 6-task schedule.
🤖 Generated with [Claude Code](https://claude.com/claude-code)