### PR TITLE
feat(chat): actionable new-chat launch surface (familiar chooser + resume)

### DIFF
--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -4,6 +4,7 @@ import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRe
 import { ChatList } from "@/components/chat-list";
 import { ChatProjectSidebar } from "@/components/chat-project-sidebar";
 import { ChatView } from "@/components/chat-view";
+import { NewChatLaunch } from "@/components/new-chat-launch";
 import { FamiliarChatoutCodexSurface } from "@/components/familiar-chatout-codex";
 import { caveChatoutCodex } from "@/lib/feature-flags";
 import { useIsMobile } from "@/lib/use-viewport";
@@ -323,16 +324,26 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
 
   if (!chatFamiliar) {
     return (
-      <section className="flex h-full flex-col items-center justify-center gap-4 bg-[var(--bg-base)] px-6 text-center text-sm text-[var(--text-muted)]">
-        <div>
-          <p className="text-[15px] font-medium text-[var(--text-secondary)]">
-            Choose a familiar to start chatting
-          </p>
-          <p className="mt-1 text-[12px]">
-            Pick who should handle the conversation from the sidebar selector.
-          </p>
-        </div>
-      </section>
+      <NewChatLaunch
+        familiars={familiars}
+        sessions={sessions}
+        pendingProjectRoot={pendingProjectRoot}
+        onPick={(familiarId) => {
+          const next = selectFamiliarForChat(familiarId);
+          setView({
+            kind: "chat",
+            sessionId: null,
+            projectRoot: view.kind === "chat" ? view.projectRoot : undefined,
+            initialPrompt: view.kind === "chat" ? view.initialPrompt : undefined,
+            familiarId: next?.id ?? familiarId,
+          });
+        }}
+        onResume={(sessionId) => {
+          const session = sessions.find((entry) => entry.id === sessionId);
+          const next = selectFamiliarForChat(session?.familiarId ?? null);
+          setView({ kind: "chat", sessionId, familiarId: next?.id ?? session?.familiarId ?? null });
+        }}
+      />
     );
   }
 

--- a/src/components/new-chat-launch.tsx
+++ b/src/components/new-chat-launch.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { Icon } from "@/lib/icon";
+import { FamiliarAvatar } from "@/components/familiar-avatar";
+import { relativeTime } from "@/lib/relative-time";
+import type { Familiar, SessionRow } from "@/lib/types";
+
+/**
+ * The new-chat launch surface. Replaces the old dead-end ("pick a familiar from
+ * the sidebar selector") with an actionable hub: choose who handles the chat
+ * from an inline familiar grid, or resume a recent thread — one click into the
+ * composer either way.
+ */
+export function NewChatLaunch({
+  familiars,
+  sessions,
+  onPick,
+  onResume,
+  pendingProjectRoot,
+}: {
+  familiars: Familiar[];
+  sessions: SessionRow[];
+  onPick: (familiarId: string) => void;
+  onResume: (sessionId: string) => void;
+  pendingProjectRoot?: string | null;
+}) {
+  const recents = [...sessions]
+    .filter((s) => !s.archived_at)
+    .sort((a, b) => (b.updated_at ?? "").localeCompare(a.updated_at ?? ""))
+    .slice(0, 5);
+  const famName = (id?: string | null) =>
+    id ? familiars.find((f) => f.id === id)?.display_name : undefined;
+
+  return (
+    <section className="cave-launch" aria-label="Start a new chat">
+      <div className="cave-launch__shell">
+        <header className="cave-launch__hero">
+          <span className="cave-launch__mark" aria-hidden>
+            <Icon name="ph:sparkle-bold" width={18} aria-hidden />
+          </span>
+          <h2 className="cave-launch__title">Start a new chat</h2>
+          <p className="cave-launch__subtitle">
+            {pendingProjectRoot
+              ? "Choose a familiar to start this chat in the pending project."
+              : "Choose a familiar to handle the conversation."}
+          </p>
+        </header>
+
+        <div className="cave-launch__section" aria-label="Familiars">
+          <p className="cave-launch__label">Familiars</p>
+          <div className="cave-launch__grid">
+            {familiars.map((f) => (
+              <button
+                key={f.id}
+                type="button"
+                className="cave-launch__card"
+                onClick={() => onPick(f.id)}
+              >
+                <FamiliarAvatar familiar={f} size="md" />
+                <span className="cave-launch__card-copy">
+                  <span className="cave-launch__card-name">{f.display_name}</span>
+                  {f.harness || f.model ? (
+                    <span className="cave-launch__card-meta">
+                      {[f.harness, f.model].filter(Boolean).join(" · ")}
+                    </span>
+                  ) : null}
+                </span>
+                <Icon name="ph:arrow-right-bold" width={13} className="cave-launch__card-go" aria-hidden />
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {recents.length > 0 ? (
+          <div className="cave-launch__section" aria-label="Recent threads">
+            <p className="cave-launch__label">Pick up where you left off</p>
+            <div className="cave-launch__recents">
+              {recents.map((s) => (
+                <button
+                  key={s.id}
+                  type="button"
+                  className="cave-launch__recent"
+                  onClick={() => onResume(s.id)}
+                >
+                  <Icon name="ph:chat-circle-dots" width={15} className="cave-launch__recent-icon" aria-hidden />
+                  <span className="cave-launch__recent-copy">
+                    <span className="cave-launch__recent-title">{s.title || "New chat"}</span>
+                    <span className="cave-launch__recent-meta">
+                      {famName(s.familiarId) ? `${famName(s.familiarId)} · ` : ""}
+                      {relativeTime(s.updated_at)}
+                    </span>
+                  </span>
+                  <Icon name="ph:arrow-right-bold" width={12} className="cave-launch__recent-go" aria-hidden />
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/components/new-chat-launch.tsx
+++ b/src/components/new-chat-launch.tsx
@@ -2,6 +2,7 @@
 
 import { Icon } from "@/lib/icon";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
+import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { relativeTime } from "@/lib/relative-time";
 import type { Familiar, SessionRow } from "@/lib/types";
 
@@ -24,12 +25,15 @@ export function NewChatLaunch({
   onResume: (sessionId: string) => void;
   pendingProjectRoot?: string | null;
 }) {
+  // Resolve glyphs/avatars/order the same way the rest of the app does so the
+  // cards match the switcher (and FamiliarAvatar gets a ResolvedFamiliar).
+  const resolved = useResolvedFamiliars(familiars);
   const recents = [...sessions]
     .filter((s) => !s.archived_at)
     .sort((a, b) => (b.updated_at ?? "").localeCompare(a.updated_at ?? ""))
     .slice(0, 5);
   const famName = (id?: string | null) =>
-    id ? familiars.find((f) => f.id === id)?.display_name : undefined;
+    id ? resolved.find((f) => f.id === id)?.display_name : undefined;
 
   return (
     <section className="cave-launch" aria-label="Start a new chat">
@@ -49,7 +53,7 @@ export function NewChatLaunch({
         <div className="cave-launch__section" aria-label="Familiars">
           <p className="cave-launch__label">Familiars</p>
           <div className="cave-launch__grid">
-            {familiars.map((f) => (
+            {resolved.map((f) => (
               <button
                 key={f.id}
                 type="button"

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -3406,3 +3406,78 @@ details[open] > .cave-tool-summary::before {
 .familiar-inline-card__memory-title { font-size: 12px; font-weight: 500; color: var(--text-primary, #ddd); }
 .familiar-inline-card__memory-excerpt { font-size: 11px; color: var(--text-secondary, #999); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .familiar-inline-card__memory-time { font-size: 10px; color: var(--text-secondary, #777); }
+
+/* ── New-chat launch surface ───────────────────────────────────────────────
+   Shown when a chat is opened without a resolved familiar. Replaces the old
+   "pick from the sidebar selector" dead-end with an actionable hub: an inline
+   familiar chooser + recent threads, one click into the composer. */
+.cave-launch {
+  display: grid;
+  place-items: center;
+  height: 100%;
+  padding: clamp(24px, 6vh, 56px) clamp(16px, 4vw, 36px);
+  background: var(--bg-base);
+  overflow: auto;
+}
+.cave-launch__shell { width: min(720px, 100%); display: grid; gap: 22px; }
+.cave-launch__hero { display: grid; justify-items: center; gap: 7px; text-align: center; }
+.cave-launch__mark {
+  display: grid; place-items: center; width: 46px; height: 46px; margin-bottom: 3px;
+  border-radius: 12px; color: var(--accent-presence);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 26%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 10%, var(--bg-raised));
+  box-shadow: 0 10px 28px oklch(0 0 0 / 22%), inset 0 1px 0 oklch(1 0 0 / 7%);
+}
+.cave-launch__title { margin: 0; font-size: 22px; font-weight: 680; color: var(--text-primary); line-height: 1.15; }
+.cave-launch__subtitle { margin: 0; font-size: 13px; color: var(--text-muted); }
+.cave-launch__section { display: grid; gap: 10px; }
+.cave-launch__label {
+  margin: 0; font-size: 11px; font-weight: 600; letter-spacing: 0.06em;
+  text-transform: uppercase; color: var(--text-muted);
+}
+.cave-launch__grid {
+  display: grid; gap: 10px;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+}
+.cave-launch__card {
+  display: flex; align-items: center; gap: 11px; text-align: left;
+  padding: 12px 13px; border-radius: 11px;
+  border: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-raised) 78%, transparent);
+  cursor: pointer;
+  transition: border-color 140ms ease, background 140ms ease, transform 140ms ease;
+}
+.cave-launch__card:hover {
+  border-color: color-mix(in oklch, var(--accent-presence) 40%, var(--border-panel));
+  background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-raised));
+  transform: translateY(-1px);
+}
+.cave-launch__card-copy { display: grid; gap: 2px; min-width: 0; flex: 1; }
+.cave-launch__card-name {
+  font-size: 13px; font-weight: 600; color: var(--text-primary);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.cave-launch__card-meta {
+  font-size: 11px; color: var(--text-muted);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.cave-launch__card-go { color: var(--text-muted); flex: 0 0 auto; opacity: 0; transition: opacity 140ms ease, color 140ms ease; }
+.cave-launch__card:hover .cave-launch__card-go { opacity: 1; color: var(--accent-presence); }
+.cave-launch__recents { display: grid; gap: 5px; }
+.cave-launch__recent {
+  display: flex; align-items: center; gap: 10px; text-align: left;
+  padding: 9px 11px; border-radius: 9px;
+  border: 1px solid transparent; background: transparent; cursor: pointer;
+  transition: background 140ms ease, border-color 140ms ease;
+}
+.cave-launch__recent:hover { background: var(--bg-raised); border-color: var(--border-hairline); }
+.cave-launch__recent-icon { color: var(--text-muted); flex: 0 0 auto; }
+.cave-launch__recent-copy { display: grid; gap: 1px; min-width: 0; flex: 1; }
+.cave-launch__recent-title {
+  font-size: 13px; color: var(--text-primary);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.cave-launch__recent-meta { font-size: 11px; color: var(--text-muted); }
+.cave-launch__recent-go { color: var(--text-muted); flex: 0 0 auto; opacity: 0; transition: opacity 140ms ease; }
+.cave-launch__recent:hover .cave-launch__recent-go { opacity: 1; }


### PR DESCRIPTION
## Problem

Clicking **New chat** without a specific familiar scoped (e.g. "All familiars") dead-ended on a near-empty void: *"Choose a familiar to start chatting — Pick who should handle the conversation from the sidebar selector."* No affordance on the page; it just told you to go use the sidebar.

## What

Replace that empty state (`chat-router.tsx`'s `!chatFamiliar` branch) with a world-class **launch hub**:

- **"Start a new chat"** hero (sparkle mark + greeting).
- **Familiar chooser grid** — a card per familiar (resolved avatar + name + runtime·model). One click starts the chat with that familiar and drops you straight into the composer.
- **"Pick up where you left off"** — up to 5 most-recent threads to resume (shown when sessions exist).

New `NewChatLaunch` component + `.cave-launch*` styles in `cave-chat.css`. Familiars are resolved via `useResolvedFamiliars` so glyphs/avatars/order match the switcher.

## Verified (real build)

- Launch surface renders with the familiar grid.
- Clicking a card → launch dismisses → lands in `ChatEmptyState` with composer `Message <Familiar>… ↵ to send`.
- `tsc --noEmit` clean; full `test:app` green (333 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)