### PR TITLE
feat(workflows): friendly hover timestamp on workflow run times

### DIFF
--- a/src/components/workflows/workflow-runs-panel.tsx
+++ b/src/components/workflows/workflow-runs-panel.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import { relativeTime } from "@/lib/relative-time";
+import { formatTimestamp } from "@/lib/datetime-format";
 import type { WorkflowPlaybackState } from "@/lib/workflow-playback";
 import type {
   WorkflowRunRecord,
@@ -102,7 +103,7 @@ export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayR
                   <span className={`workflow-run-chip workflow-run-chip-${run.status}`}>{run.status}</span>
                   <span className="workflow-run-kind">{run.kind}</span>
                   <span className="workflow-run-detail">{stepRollup(run)}</span>
-                  <span className="workflow-run-time" title={run.startedAt}>
+                  <span className="workflow-run-time" title={formatTimestamp(run.startedAt)}>
                     {relativeTime(run.startedAt)}
                   </span>
                 </button>
@@ -125,7 +126,7 @@ export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayR
                       </div>
                       <div>
                         <dt>Started</dt>
-                        <dd title={run.startedAt}>{relativeTime(run.startedAt)}</dd>
+                        <dd title={formatTimestamp(run.startedAt)}>{relativeTime(run.startedAt)}</dd>
                       </div>
                     </dl>
                     {run.summary && <p className="workflow-run-summary-line">{run.summary}</p>}


### PR DESCRIPTION
## What

In the Workflows runs panel, each run shows a relative time ("3h ago") with a hover tooltip — but the tooltip was the **raw ISO string** ("2026-06-19T14:30:00.000Z"). It now uses the shared `formatTimestamp`, so hovering reveals a readable, pref-aware "06.19 2:30 PM" (honoring the user's clock + date preferences). The relative-time display is unchanged.

Two `title={run.startedAt}` sites swapped to `title={formatTimestamp(run.startedAt)}`. Continues the datetime-pref consistency thread (#1072 / #1108 / #1187 / #1189 / #1199).

## Tests / verification

- No test pins these tooltips.
- `tsc --noEmit` clean; full `pnpm build` green. `formatTimestamp` output format is already covered (12 datetime-format tests; e.g. produces "08.01 12:09 PM").

🤖 Generated with [Claude Code](https://claude.com/claude-code)