### PR TITLE
fix(terminal): tab-rename UX + key-bar focus ring

### DIFF
--- a/src/components/comux-view-terminal.test.ts
+++ b/src/components/comux-view-terminal.test.ts
@@ -313,4 +313,18 @@ assert.match(
   /removeSession[\s\S]{0,900}pty_stop/,
   "closing a tab is the one place the desktop PTY is killed",
 );
+
+// Tab rename: Escape aborts (restores the label), and blank/whitespace names
+// are rejected so a cleared tab keeps its label.
+assert.match(
+  source,
+  /e\.key === "Escape"[\s\S]{0,260}?e\.currentTarget\.textContent = s\.label/,
+  "Escape during a tab rename restores the original label (no save)",
+);
+assert.match(
+  source,
+  /const trimmed = label\.trim\(\);\s*if \(!trimmed\) return;/,
+  "renameSession ignores blank/whitespace-only names",
+);
+
 console.log("comux terminal chord/close assertions: ok");

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -455,7 +455,11 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   const renameSession = useCallback((idx: number, label: string) => {
     const session = sessions[idx];
     if (!session) return;
-    dispatchTerminalLayout({ type: "rename", sessionId: session.id, label });
+    // Ignore blank/whitespace-only names so a cleared tab keeps its label
+    // instead of becoming an empty tab.
+    const trimmed = label.trim();
+    if (!trimmed) return;
+    dispatchTerminalLayout({ type: "rename", sessionId: session.id, label: trimmed });
   }, [sessions]);
 
   const visiblePaneSessionIds = useMemo(
@@ -989,9 +993,16 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                       if (e.key === "Enter") {
                         e.preventDefault();
                         (e.target as HTMLElement).blur();
+                      } else if (e.key === "Escape") {
+                        // Abort the rename: restore the original label before
+                        // blur so the onBlur save is a no-op.
+                        e.preventDefault();
+                        e.currentTarget.textContent = s.label;
+                        (e.target as HTMLElement).blur();
                       }
                     }}
-                    className="max-w-[120px] truncate outline-none"
+                    title="Click to rename · Enter to save · Esc to cancel"
+                    className="max-w-[120px] truncate rounded-[3px] px-0.5 outline-none focus:bg-[var(--bg-base)] focus:ring-1 focus:ring-[var(--accent-presence)]"
                   >
                     {s.label}
                   </span>

--- a/src/components/terminal-key-bar.tsx
+++ b/src/components/terminal-key-bar.tsx
@@ -24,7 +24,7 @@ type Props = {
 };
 
 const KEY_CLASS =
-  "terminal-key inline-flex min-h-[var(--touch-target)] min-w-[var(--touch-target)] flex-shrink-0 items-center justify-center rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2.5 text-[12px] font-medium text-[var(--text-secondary)] active:bg-[var(--bg-hover)]";
+  "terminal-key focus-ring inline-flex min-h-[var(--touch-target)] min-w-[var(--touch-target)] flex-shrink-0 items-center justify-center rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2.5 text-[12px] font-medium text-[var(--text-secondary)] active:bg-[var(--bg-hover)]";
 
 /**
  * Touch-only accessory bar for the mobile terminal. iOS/Android soft keyboards


### PR DESCRIPTION
From a deep review of the Terminal surface. The core is solid (xterm/ResizeObserver/WS listeners all clean up, resize wired, screen-reader mirror, disposal-race guard, reconnect-with-backoff). Four real fixes, clustered on **tab rename**:

- **Escape can't cancel a rename** (`comux-view.tsx`): the `contentEditable` tab name handled Enter but not Escape — Escape just typed a character. Now Escape restores the original label and blurs (the `onBlur` save becomes a no-op).
- **Blank tab names accepted**: `onBlur` saved `textContent ?? s.label`, but `??` only guards `null` — clearing the name saved `""`. `renameSession` now `.trim()`s and ignores empty/whitespace names.
- **No edit affordance**: the name used `outline-none`; added a focus ring + bg on edit and a `"Click to rename · Enter to save · Esc to cancel"` title.
- **Mobile key-bar buttons had no focus ring** (`terminal-key-bar.tsx` `KEY_CLASS`): only `:active`; added `focus-ring`.

Left as noted follow-ups (bigger): semantic `role=tablist` + arrow-key nav for the tab strip, and the hover-only close button (keyboard-unreachable).

Guard assertions added in `comux-view-terminal.test.ts`. tsc clean; full `test:app` (335) and `test:mobile` (16) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)