### PR TITLE
feat(chat): polish the with-familiar new-chat empty state

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -537,10 +537,9 @@ function splitReasoning(text: string): { visible: string; reasoning: string } {
 // to start a conversation rather than staring at a blank pane.
 
 const STARTER_PROMPTS = [
-  "What are you working on?",
-  "Summarise recent work",
-  "Help me plan something",
-  "Run a quick task",
+  "Review my recent changes",
+  "Plan a feature and break it into board cards",
+  "Summarise what I worked on today",
 ];
 
 function ChatEmptyState({
@@ -562,13 +561,18 @@ function ChatEmptyState({
   fileMentions?: boolean;
 }) {
   const project = (projectId ? chatProjectById(projectId, projects) ?? projects[0] : projects[0]) ?? null;
+  // App-contextual starters; the last is project-aware when a root is known.
+  const prompts = [
+    ...STARTER_PROMPTS,
+    project ? `Start a task in ${project.name}` : "Start a focused task",
+  ];
 
   return (
     <div className="cave-chat-empty select-none">
       <div className="cave-chat-empty-shell">
         <div className="cave-chat-empty-familiar">
           <div className="cave-chat-empty-mark">
-            <Icon name="ph:sparkle-bold" width={17} aria-hidden />
+            <FamiliarIcon familiar={familiar} size="lg" />
           </div>
           <div className="cave-chat-empty-familiar-copy">
             <h2 className="cave-chat-empty-title">
@@ -607,7 +611,7 @@ function ChatEmptyState({
 
         {onPrompt && (
           <div className="cave-chat-empty-prompts" aria-label="Starter prompts">
-            {STARTER_PROMPTS.map((p) => (
+            {prompts.map((p) => (
               <button
                 key={p}
                 type="button"

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -934,13 +934,13 @@
   flex: 0 0 auto;
   width: 44px;
   height: 44px;
-  border: 1px solid color-mix(in oklch, var(--accent-presence) 26%, transparent);
-  border-radius: 8px;
-  background: color-mix(in oklch, var(--accent-presence) 9%, var(--bg-raised));
   color: var(--accent-presence);
-  box-shadow:
-    0 10px 28px oklch(0 0 0 / 22%),
-    inset 0 1px 0 oklch(1 0 0 / 7%);
+}
+/* The mark now holds the real familiar avatar/glyph (which carries its own
+   color), so the frame stays neutral — no competing accent box. */
+.cave-chat-empty-mark img,
+.cave-chat-empty-mark > * {
+  border-radius: 9px;
 }
 
 .cave-chat-empty-familiar-copy {


### PR DESCRIPTION
## What

Brings the *with-familiar* new-chat empty state (`ChatEmptyState`) up to the same bar as the new launch surface (#1201):

- **Real familiar avatar/glyph** via the existing `FamiliarIcon` helper instead of a generic sparkle — the agent feels present. The mark frame goes neutral since the avatar carries its own color.
- **App-contextual starter prompts** replacing the bland placeholders ("What are you working on?" / "Run a quick task"):
  - Review my recent changes
  - Plan a feature and break it into board cards
  - Summarise what I worked on today
  - **Project-aware:** "Start a task in *<project>*" when a root is known, else "Start a focused task".

Prompts still seed the composer (no auto-send), classes/grid unchanged so the polish tests stay green.

## Verified

`tsc --noEmit` clean; full `test:app` green (335 files). Screenshot to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)