### PR TITLE
feat(code): checkpoint timestamps honor the clock + date preferences

### DIFF
--- a/src/components/session-changes-panel.tsx
+++ b/src/components/session-changes-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { formatTimestamp } from "@/lib/datetime-format";
 import { SyntaxBlock } from "@/components/message-bubble";
 import { useChatDebugSnapshot } from "@/lib/chat-debug-store";
 
@@ -50,7 +51,8 @@ function checkpointLabel(name: string): string {
     "$1T$2:$3:$4.$5Z",
   );
   const d = new Date(iso);
-  return Number.isNaN(d.getTime()) ? name : d.toLocaleString();
+  // Honor the app's clock + date preferences instead of the raw browser locale.
+  return Number.isNaN(d.getTime()) ? name : formatTimestamp(iso);
 }
 
 function formatBytes(n: number): string {


### PR DESCRIPTION
## What

The Code **Changes** panel labeled each saved checkpoint with the raw browser-locale `toLocaleString()` ("6/13/2026, 7:00:33 AM"). It now uses the shared `formatTimestamp`, so the label respects the user's clock (12h/24h) and date (MM.DD / DD.MM) preferences ("06.13 7:00 AM"). Invalid/unparseable names still fall back to the raw filename.

Continues the datetime-pref consistency thread (#1072 / #1108 / #1187 / #1189 / #1199 / #1203).

## Tests / verification

- `comux-view-changes.test.ts` and `debug-pane.test.ts` (both read `session-changes-panel.tsx`) — pass; neither pins the label format.
- `tsc --noEmit` clean; full `pnpm build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)