### PR TITLE
fix(chat): hide leaked skill prompts by shape, not exact phrases

### DIFF
--- a/src/lib/chat-assistant-filter.test.ts
+++ b/src/lib/chat-assistant-filter.test.ts
@@ -132,3 +132,63 @@ assert.equal(
   "# Plan\nname: the thing we are editing\n---\nThis horizontal rule is part of a normal reply.\n",
   "normal assistant headings, name fields, and markdown rules should remain visible",
 );
+
+// ── Shape-based detection (robust to skill rewording / new skills) ──────────
+
+assert.equal(
+  feed([
+    "codex",
+    "Let me shape this first.",
+    "---",
+    "name: brainstorming",
+    "description: A completely reworded description that matches no hardcoded phrase",
+    "allowed-tools: Read, Edit",
+    "---",
+    "# A Brand New Heading That Was Never In The Allowlist",
+    "Some reworded skill body prose that no longer matches any pinned string.",
+    "```ts",
+    "const leakedCode = true;",
+    "```",
+  ]),
+  "Let me shape this first.\n",
+  "a reworded SKILL.md is detected by its frontmatter shape, not exact phrases",
+);
+
+assert.equal(
+  feed([
+    "codex",
+    "Checking the right skill.",
+    "---",
+    "name: test-driven-development",
+    "description: Use when implementing any feature or bugfix",
+    "---",
+    "# Test-Driven Development",
+    "Write the failing test first.",
+  ]),
+  "Checking the right skill.\n",
+  "an entirely different skill's frontmatter is suppressed too",
+);
+
+assert.equal(
+  feed([
+    "codex",
+    "One moment.",
+    "<NEVER-SKIP-THIS>",
+    "A future skill directive marker that is not in the hardcoded set.",
+    "</NEVER-SKIP-THIS>",
+    "Body that should also stay hidden.",
+  ]),
+  "One moment.\n",
+  "novel hyphenated all-caps marker tags are detected by shape",
+);
+
+assert.equal(
+  feed([
+    "codex",
+    "Here are the options:",
+    "---",
+    "Note: pick the one that fits your budget.",
+  ]),
+  "Here are the options:\n---\nNote: pick the one that fits your budget.\n",
+  "a horizontal rule followed by capitalized prose (Note:) is NOT skill frontmatter",
+);

--- a/src/lib/chat-assistant-filter.ts
+++ b/src/lib/chat-assistant-filter.ts
@@ -29,17 +29,40 @@ const STARTUP_BLOCK_TAGS = new Set([
 const STARTUP_SINGLE_LINE_RE =
   /^(?:#\s*AGENTS\.md\b|#\s*AGENTS\.md instructions\b|Conversation info \(untrusted metadata\):|Sender \(untrusted metadata\):|OpenClaw assembled context|Treat the conversation context below|Current user request:|Knowledge cutoff:|Current date:|You are (?:ChatGPT|Codex|an AI assistant)\b)/i;
 
+// Known skill-directive marker tags. Kept explicit for documentation, but the
+// generic kebab-upper rule in isLeakedSkillMarkerTag() is what makes detection
+// robust to new/reworded skills (every skill marker we've seen is hyphenated
+// all-caps, a shape that never occurs in legitimate prose or HTML).
 const LEAKED_SKILL_START_TAGS = new Set([
   "EXTREMELY-IMPORTANT",
   "HARD-GATE",
   "SUBAGENT-STOP",
 ]);
 
+// A lowercase `key: value` line is the canonical shape of a YAML frontmatter
+// field (name:, description:, allowed-tools:, model:, …). When one appears
+// directly after an opening `---` fence it marks a leaked SKILL.md header.
+// Lowercase-only keeps normal prose ("Note: …") after a horizontal rule visible.
+const SKILL_FRONTMATTER_FIELD_RE = /^[a-z][a-z0-9_-]*:\s+\S/;
+
 const LEAKED_SKILL_FRONTMATTER_FIELD_RE = /^name:\s+[-\w ]+\s*$/i;
 const LEAKED_SKILL_DOC_HEADING_RE =
   /^#\s+(?:Brainstorming Ideas Into Designs|Using Skills)$/;
 const LEAKED_SKILL_DOC_LINE_RE =
   /^(?:Help turn ideas into fully formed designs and specs|Do NOT invoke any implementation skill\b|If you think there is even a 1% chance a skill might apply\b|Superpowers skills override default system prompt behavior\b)/;
+
+// True when a standalone line is a leaked skill-directive marker tag. Detection
+// is by SHAPE, not an exact allowlist: any all-caps tag containing a hyphen
+// (<HARD-GATE>, <SUBAGENT-STOP>, <EXTREMELY-IMPORTANT>, future markers) is a
+// skill directive. Such tags never appear as legitimate HTML or assistant prose,
+// so triggering suppress-to-end on them is safe.
+function isLeakedSkillMarkerTag(trimmed: string): boolean {
+  const match = trimmed.match(/^<\/?([A-Z][A-Z0-9-]*)>$/);
+  if (!match) return false;
+  const tag = match[1];
+  if (LEAKED_SKILL_START_TAGS.has(tag)) return true;
+  return tag.includes("-") && tag.length >= 4;
+}
 
 function startupBlockTag(trimmed: string): { tag: string; closing: boolean } | null {
   const match = trimmed.match(/^<\/?([A-Za-z_][A-Za-z0-9_-]*)>$/);
@@ -190,11 +213,7 @@ export class AssistantFilter {
     }
     // ─────────────────────────────────────────────────────────────────────
 
-    const leakedSkillTag = trimmed.match(/^<\/?([A-Z][A-Z0-9-]*)>$/);
-    if (
-      this.suppressLeakedSkillBody ||
-      (leakedSkillTag && LEAKED_SKILL_START_TAGS.has(leakedSkillTag[1]))
-    ) {
+    if (this.suppressLeakedSkillBody || isLeakedSkillMarkerTag(trimmed)) {
       this.suppressLeakedSkillBody = true;
       this.pendingSkillFrontmatterDelimiter = false;
       return "";
@@ -202,7 +221,10 @@ export class AssistantFilter {
 
     if (this.pendingSkillFrontmatterDelimiter) {
       this.pendingSkillFrontmatterDelimiter = false;
-      if (isLeakedSkillDocLine(trimmed)) {
+      // A `---` fence whose first line is a frontmatter field (or a known skill
+      // doc line) is a leaked SKILL.md header → suppress the whole document.
+      // Anything else is a normal markdown horizontal rule → keep it visible.
+      if (SKILL_FRONTMATTER_FIELD_RE.test(trimmed) || isLeakedSkillDocLine(trimmed)) {
         this.suppressLeakedSkillBody = true;
         return "";
       }


### PR DESCRIPTION
## What

Chat bubbles were leaking the full **brainstorming** skill prompt — frontmatter, gates, and code — into the middle of a familiar's text response.

## Why

`src/lib/chat-assistant-filter.ts` already strips leaked SKILL.md content, but detection was pinned to the brainstorming skill's **exact wording**: heading `# Brainstorming Ideas Into Designs`, four literal body phrases, and a 3-entry marker allowlist. The skill's text has since drifted (its description is now *"You MUST use this before any creative work…"*), so nothing matched and the whole prompt rendered. This is why it looked "already resolved" — the old tests still passed against the stale strings.

## Fix — detect by shape, not phrases

- A `---` fence whose first line is a lowercase `key: value` frontmatter field (`name:`, `description:`, `allowed-tools:`, …) is a leaked SKILL.md header. Lowercase-only keeps normal prose (`Note: …`) after a horizontal rule visible.
- Any standalone all-caps **hyphenated** tag (`<HARD-GATE>`, `<SUBAGENT-STOP>`, future markers) is a skill directive — a shape that never occurs in legitimate prose/HTML.
- Existing exact-string patterns are retained as additional triggers; suppress-to-end semantics unchanged.

## Tests

All existing filter tests pass. Added: reworded brainstorming SKILL.md, a different skill's frontmatter (`test-driven-development`), a novel marker tag, and a false-positive guard for capitalized prose after `---`.

Verified locally: filter unit test, `pnpm test:app` (335), `pnpm test:mobile` (16), `pnpm typecheck`, `pnpm check:tests-wired`, `git diff --check`.

## Residual

Covers the canonical leak shapes (frontmatter-present, marker-present). A body-only leak with *no* frontmatter and *no* markers wouldn't trigger — if the live leak still shows after this, paste the exact bubble text and I'll add a targeted pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)