### PR TITLE
feat(sidebar): collapse the left nav to an icons-only rail

### DIFF
--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -141,7 +141,7 @@ assert.match(
 
 assert.match(
   shell,
-  /<aside className="shell-nav" aria-label="Sidebar">/,
+  /className=\{`shell-nav\$\{[^}]*\}`\}[\s\S]*?aria-label="Sidebar"/,
   "Shell nav panel must carry a distinct accessible name (axe landmark-unique)",
 );
 assert.match(

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -41,7 +41,7 @@ assert.match(
 );
 assert.match(
   shell,
-  /shell-top-toggle--nav[\s\S]*?aria-label=\{navOpen \? "Hide navigation" : "Show navigation"\}/,
+  /shell-top-toggle--nav[\s\S]*?aria-label=\{navOpen \? "Collapse navigation to icons" : "Expand navigation"\}/,
   "nav toggle label reflects nav state",
 );
 assert.match(

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -80,6 +80,10 @@ function togglePanel(panel: PanelImperativeHandle | null) {
 // (the strip, or 0 when not peeking) read as "panel closed".
 const RAIL_PEEK_PX = 56;
 const RAIL_OPEN_THRESHOLD_PX = RAIL_PEEK_PX + 16;
+// The left nav collapses to an icons-only rail (instead of vanishing) so the
+// destination icons stay reachable. Sizes at/below the rail read as "collapsed".
+const NAV_RAIL_PX = 56;
+const NAV_OPEN_THRESHOLD_PX = NAV_RAIL_PX + 16;
 
 export type ShellNavSection = {
   label?: string;
@@ -443,15 +447,22 @@ function ShellInner({
         minSize="14%"
         maxSize="28%"
         collapsible
-        collapsedSize={0}
+        // Desktop collapses to an icons-only rail; mobile uses the slide-in
+        // drawer (position is CSS-overridden there), so it still collapses to 0.
+        collapsedSize={isMobile ? 0 : NAV_RAIL_PX}
         panelRef={navRef}
         onResize={(size) => {
-          setNavOpen((size.asPercentage ?? 0) > 0);
+          setNavOpen((size.inPixels ?? 0) > NAV_OPEN_THRESHOLD_PX);
         }}
       >
         {/* CHAT-D13-05: every complementary landmark carries a distinct
             accessible name (axe landmark-unique). */}
-        <aside className="shell-nav" aria-label="Sidebar">{nav}</aside>
+        <aside
+          className={`shell-nav${!isMobile && !navOpen ? " shell-nav--rail" : ""}`}
+          aria-label="Sidebar"
+        >
+          {nav}
+        </aside>
       </Panel>
       <Separator className="shell-separator" />
       {!twoPane && (
@@ -554,9 +565,9 @@ function ShellInner({
     <button
       type="button"
       className={`shell-top-toggle shell-top-toggle--nav focus-ring${navOpen ? " shell-top-toggle--active" : ""}`}
-      aria-label={navOpen ? "Hide navigation" : "Show navigation"}
+      aria-label={navOpen ? "Collapse navigation to icons" : "Expand navigation"}
       aria-expanded={navOpen}
-      title={navOpen ? `Hide navigation (${leftPanelShortcutLabel})` : `Show navigation (${leftPanelShortcutLabel})`}
+      title={navOpen ? `Collapse navigation (${leftPanelShortcutLabel})` : `Expand navigation (${leftPanelShortcutLabel})`}
       onClick={toggleNavPanel}
     >
       <Icon name={navOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={15} />

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -250,7 +250,7 @@ assert.match(
 // affordance on every breakpoint.
 assert.match(
   source,
-  /<div className="sidebar-actions">\s*<button type="button" className="sidebar-action-row focus-ring" onClick=\{onNewChat\}>/,
+  /<div className="sidebar-actions">\s*<button type="button" className="sidebar-action-row focus-ring" onClick=\{onNewChat\}[^>]*>/,
   "the sidebar renders a New chat CTA at the top, wired to onNewChat",
 );
 assert.match(

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -238,7 +238,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
       </div>
 
       <div className="sidebar-actions">
-        <button type="button" className="sidebar-action-row focus-ring" onClick={onNewChat}>
+        <button type="button" className="sidebar-action-row focus-ring" onClick={onNewChat} title="New chat">
           <Icon name="ph:note-pencil" width={16} aria-hidden />
           <span>New chat</span>
         </button>

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -970,3 +970,73 @@
 .recent-activity__add { color: color-mix(in oklch, #3fb950 80%, var(--text-secondary)); }
 .recent-activity__del { color: color-mix(in oklch, #f85149 80%, var(--text-secondary)); }
 .recent-activity__time { font-size: 10.5px; color: var(--text-muted); }
+
+/* ── Collapsed icon rail (desktop) ───────────────────────────────────────────
+ * When the left nav is collapsed it shrinks to a ~56px rail rather than
+ * vanishing. Strip every text label and section header and center the
+ * destination icons so only the icons remain; each control keeps its native
+ * `title` so hovering names the surface. Mobile is unaffected — it slides the
+ * full drawer in and out (the rail class is only applied on desktop). */
+.shell-nav--rail .sidebar-minimal {
+  padding: 10px 0;
+  gap: 6px;
+  align-items: center;
+}
+
+/* Wordmark, section headers, and the recent-activity rollup have no compact
+   form, so they drop out entirely in the rail. */
+.shell-nav--rail .sidebar-header,
+.shell-nav--rail .sidebar-section-label,
+.shell-nav--rail .recent-activity {
+  display: none;
+}
+
+/* Labels and count pills collapse away; the icon is all that stays per row.
+   (Footer icons live in `.sidebar-foot-icon-cell`, which is preserved.) */
+.shell-nav--rail .sidebar-folder-label,
+.shell-nav--rail .sidebar-action-label,
+.shell-nav--rail .sidebar-actions .sidebar-action-row > span,
+.shell-nav--rail .sidebar-foot-label,
+.shell-nav--rail .sidebar-foot-badge,
+.shell-nav--rail .sidebar-badge {
+  display: none;
+}
+
+/* Drop the horizontal padding so the centered icons sit dead-center in the
+   rail, and let the nav region grow without a scrollbar gutter. */
+.shell-nav--rail .sidebar-actions,
+.shell-nav--rail .sidebar-nav-scroll,
+.shell-nav--rail .sidebar-foot {
+  padding-left: 0;
+  padding-right: 0;
+}
+.shell-nav--rail .sidebar-nav-scroll {
+  gap: 6px;
+  align-items: center;
+  scrollbar-width: none;
+}
+.shell-nav--rail .sidebar-folders {
+  width: 100%;
+  align-items: center;
+}
+
+/* Each row becomes a centered 40px square hit target — comfortable for the
+   icon, still a wide-enough click area. */
+.shell-nav--rail .sidebar-folder-row,
+.shell-nav--rail .sidebar-action-row,
+.shell-nav--rail .sidebar-foot-btn,
+.shell-nav--rail .sidebar-foot-icon-btn {
+  justify-content: center;
+  gap: 0;
+  width: 40px;
+  padding: 0;
+  margin: 0 auto;
+}
+
+/* The footer's "Settings + phone" two-column grid stacks into the single rail
+   column. */
+.shell-nav--rail .sidebar-foot-utility-row {
+  grid-template-columns: 1fr;
+  justify-items: center;
+  gap: 4px;
+}


### PR DESCRIPTION
The left navigation collapsed to **zero width** — collapsing it hid every destination until you re-opened it. Now it collapses to an **icons-only rail** (~56px): the floating toggle and ⌘B switch between the full labeled sidebar and the rail, and the destination icons stay reachable (native-title tooltips name each surface). There's no longer a fully-hidden desktop state.

- **shell:** nav panel `collapsedSize` → `NAV_RAIL_PX` (56) on desktop instead of 0 (mobile still collapses to 0 — it uses the slide-in drawer). `navOpen` derives from the panel width crossing the rail threshold; the `.shell-nav` aside gets a `--rail` modifier when collapsed on desktop; toggle copy reads "Collapse/Expand navigation".
- **sidebar CSS:** a rail block hides the wordmark, section headers, recent-activity rollup, and every label/badge, and centers each control as a 40px square hit target.
- New chat button gains a `title` so it's identifiable in the rail.

Verified visually (full ↔ rail). test:app (335) + test:mobile (16) + build green.
🤖 Generated with [Claude Code](https://claude.com/claude-code)