### PR TITLE
feat(reminders): fire-time preview honors the 12h/24h clock preference

### DIFF
--- a/src/components/new-reminder-modal.tsx
+++ b/src/components/new-reminder-modal.tsx
@@ -7,6 +7,7 @@ import { parseWhen } from "@/lib/parse-when";
 import { draftReminderFromText } from "@/lib/reminder-draft";
 import { parseCron } from "@/lib/cron";
 import { Icon } from "@/lib/icon";
+import { readDateTimePrefs } from "@/lib/datetime-format";
 import { useIsCoarsePointer } from "@/lib/use-viewport";
 import { ReminderLinkField } from "@/components/reminder-link-field";
 import type { LinkRef } from "@/lib/cave-inbox";
@@ -260,6 +261,8 @@ export function NewReminderModal({
         day: "numeric",
         hour: "numeric",
         minute: "2-digit",
+        // Honor the user's 12h/24h clock preference for the fire-time preview.
+        hour12: readDateTimePrefs().clock !== "24h",
       })
     : null;
 


### PR DESCRIPTION
## What

The new-reminder modal's **"when it fires" preview** ("Fri, Jun 19, 2:30 PM") formatted the time with the browser's default hour cycle. It now passes `hour12` derived from the user's clock preference, so a 24-hour user sees "Fri, Jun 19, 14:30" and a 12-hour user keeps "Fri, Jun 19, 2:30 PM". (Kept the existing `toLocaleString` date format; only the hour cycle is now pref-driven.)

Continues the datetime-pref consistency thread (#1072 / #1108 / #1187 / #1189 / #1199 / #1203 / #1206).

## Tests / verification

- `new-reminder-modal.test.ts` and `reminder-link-field.test.ts` — pass; neither pins the preview format.
- `tsc --noEmit` clean; full `pnpm build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)