### PR TITLE
fix(familiar-studio): focus trap + restore focus after name edit

### DIFF
--- a/src/components/familiar-studio.test.ts
+++ b/src/components/familiar-studio.test.ts
@@ -76,4 +76,23 @@ assert.match(
   "Open Brain Studio should persist the Brain tab and leave the side panel for the full Settings surface",
 );
 
+// The drawer traps focus, focuses on open, wires Escape, and restores focus on
+// close via the shared useFocusTrap hook (replacing the ad-hoc Escape listener).
+assert.match(
+  source,
+  /useFocusTrap\(drawerOpen, drawerRef, \{ onEscape: closeFamiliarStudio \}\)/,
+  "Studio drawer uses the shared focus trap",
+);
+assert.doesNotMatch(
+  source,
+  /addEventListener\("keydown"/,
+  "the ad-hoc Escape keydown listener is gone (folded into useFocusTrap)",
+);
+// Inline name edit returns focus to the name button when the input closes.
+assert.match(
+  source,
+  /refocusRef\.current = false;\s*buttonRef\.current\?\.focus\(\)/,
+  "renaming the familiar restores focus to the name button on commit/cancel",
+);
+
 console.log("familiar-studio.test.ts: ok");

--- a/src/components/familiar-studio.tsx
+++ b/src/components/familiar-studio.tsx
@@ -7,6 +7,7 @@ import { useFamiliarImageUpload, FAMILIAR_IMAGE_ACCEPT } from "@/lib/familiar-im
 import { useFamiliarStudio, type FamiliarStudioTab } from "@/lib/familiar-studio-context";
 import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 import { useResolvedFamiliars, type ResolvedFamiliar } from "@/lib/familiar-resolve";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 import {
   setFamiliarOverride,
   clearFamiliarOverrideField,
@@ -68,18 +69,11 @@ export function FamiliarStudio({ familiars }: Props) {
     orientation: "vertical",
   });
 
-  // Esc to close
-  useEffect(() => {
-    if (!drawerOpen) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        closeFamiliarStudio();
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [drawerOpen, closeFamiliarStudio]);
+  // Trap keyboard focus inside the open drawer, focus it on open, wire Escape,
+  // and restore focus to the trigger on close — matching every other modal
+  // (capabilities, board-inspector, …). Replaces the ad-hoc Escape listener.
+  const drawerRef = useRef<HTMLElement | null>(null);
+  useFocusTrap(drawerOpen, drawerRef, { onEscape: closeFamiliarStudio });
 
   // Automatic activation: switch activeTab whenever the roving focus lands on
   // a new tab. Studio tab panels are cheap, so APG recommends auto activation.
@@ -106,6 +100,7 @@ export function FamiliarStudio({ familiars }: Props) {
       <>
         <StudioScrim onClose={closeFamiliarStudio} />
       <aside
+        ref={drawerRef}
         role="dialog"
         aria-label="Familiar Studio"
         className="familiar-studio__drawer familiar-studio__drawer--empty"
@@ -128,6 +123,7 @@ export function FamiliarStudio({ familiars }: Props) {
     <>
       <StudioScrim onClose={closeFamiliarStudio} />
     <aside
+      ref={drawerRef}
       role="dialog"
       aria-label={`Familiar Studio${familiar ? ` — ${familiar.display_name}` : ""}`}
       className="familiar-studio__drawer"
@@ -307,6 +303,16 @@ function HeaderName({ familiar }: { familiar: ResolvedFamiliar }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(familiar.display_name);
   const coarse = useIsCoarsePointer();
+  // Return focus to the name button when the edit input closes, so keyboard
+  // focus doesn't drop to <body> after committing/cancelling a rename.
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const refocusRef = useRef(false);
+  useEffect(() => {
+    if (!editing && refocusRef.current) {
+      refocusRef.current = false;
+      buttonRef.current?.focus();
+    }
+  }, [editing]);
 
   function enter() {
     setDraft(familiar.display_name);
@@ -314,6 +320,7 @@ function HeaderName({ familiar }: { familiar: ResolvedFamiliar }) {
   }
 
   function commit() {
+    refocusRef.current = true;
     setEditing(false);
     if (draft.trim() === "") {
       clearFamiliarOverrideField(familiar.id, "display_name");
@@ -323,6 +330,7 @@ function HeaderName({ familiar }: { familiar: ResolvedFamiliar }) {
   }
 
   function cancel() {
+    refocusRef.current = true;
     setDraft(familiar.display_name);
     setEditing(false);
   }
@@ -351,6 +359,7 @@ function HeaderName({ familiar }: { familiar: ResolvedFamiliar }) {
 
   return (
     <button
+      ref={buttonRef}
       type="button"
       className="familiar-studio__name"
       onClick={enter}


### PR DESCRIPTION
From a deep review of Familiar Studio. Two real focus-management fixes:

- **No focus trap on the drawer.** It had `role="dialog"` + a manual Escape listener but no trap — focus could tab out to the page behind it and didn't restore on close. Replaced the ad-hoc listener with the shared **`useFocusTrap`** (focus-on-open + trap + Escape + return-focus), applied to both the editor drawer and the "no longer available" drawer.
- **Inline name edit lost focus.** Editing the display name and committing/cancelling dropped focus to `<body>` when the input unmounted. Now restores focus to the name button.

Filtered out the review's non-issues: the close button and color swatches already have `aria-label`s, and the brain-tab daemon-offline error *is* rendered on `manifestState === "error"`. Left as noted M follow-ups: unsaved-changes-on-close warning (fields auto-save on blur) and a loading skeleton for slow roster loads.

Guard assertions added in `familiar-studio.test.ts`. tsc clean; full `test:app` (335) and `test:mobile` (16) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)