### PR TITLE
feat(chat): flag the recommended follow-up with a green pulsing border

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8155,3 +8155,35 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   .retro-run-row__top { align-items: stretch; flex-direction: column; }
   .retro-pill { width: max-content; }
 }
+
+/* Recommended follow-up: the agent lists next steps best-first, so the top
+   suggested next step gets a green, gently pulsing border as a recommendation
+   indicator (static green under reduced-motion). A leading dot pairs with the
+   color so the signal isn't color-only. */
+.cave-next-path--recommended {
+  border-color: var(--color-success);
+  background: color-mix(in oklch, var(--color-success) 12%, transparent);
+  color: var(--text-primary);
+  animation: cave-next-path-pulse 1.8s ease-in-out infinite;
+}
+.cave-next-path--recommended:hover {
+  border-color: var(--color-success);
+  background: color-mix(in oklch, var(--color-success) 20%, transparent);
+}
+.cave-next-path__dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--color-success); flex: 0 0 auto; margin-right: 7px;
+}
+@keyframes cave-next-path-pulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 color-mix(in oklch, var(--color-success) 0%, transparent);
+    border-color: color-mix(in oklch, var(--color-success) 55%, var(--border-hairline));
+  }
+  50% {
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--color-success) 24%, transparent);
+    border-color: var(--color-success);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cave-next-path--recommended { animation: none; border-color: var(--color-success); }
+}

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -821,3 +821,11 @@ assert.match(
   /const mentionedFiles = imagesSupported\s*\n\s*\? await resolveMentionedFiles\(\s*\n\s*body\.mentionedFiles,\s*\n\s*resolvedFamiliarWorkspace,/,
   "Mentions are only delivered to harnesses that can Read this machine's filesystem, against the validated familiar workspace",
 );
+
+// The top suggested follow-up is flagged as the recommendation (green pulsing
+// border + leading dot), so the most useful next step stands out.
+assert.match(
+  source,
+  /cave-next-path--recommended/,
+  "the first follow-up is marked as the recommended next step",
+);

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -4008,11 +4008,24 @@ function TurnRowImpl({
                 aren't pushed up the turn by the tool-activity section. */}
             {nextPaths.length > 0 && !turn.pending ? (
               <div className="cave-next-paths">
-                {nextPaths.map((s, i) => (
-                  <button key={i} type="button" className="cave-next-path" onClick={() => onSuggestion?.(s)}>
-                    {s}
-                  </button>
-                ))}
+                {nextPaths.map((s, i) => {
+                  // The agent lists next steps best-first, so flag the top one as
+                  // the recommendation (green pulsing border + leading dot).
+                  const recommended = i === 0;
+                  return (
+                    <button
+                      key={i}
+                      type="button"
+                      className={`cave-next-path${recommended ? " cave-next-path--recommended" : ""}`}
+                      onClick={() => onSuggestion?.(s)}
+                      aria-label={recommended ? `Recommended: ${s}` : undefined}
+                      title={recommended ? "Recommended next step" : undefined}
+                    >
+                      {recommended ? <span className="cave-next-path__dot" aria-hidden /> : null}
+                      {s}
+                    </button>
+                  );
+                })}
               </div>
             ) : null}
           </div>


### PR DESCRIPTION
## What

Chat follow-ups (suggested next steps) are listed best-first by the agent but read as a flat row. This marks **the top one as the recommendation** so the most useful next step stands out:

- Green, gently **pulsing border** (`cave-next-path-pulse`) as the recommendation indicator.
- A leading **green dot** so the cue isn't color-only (a11y).
- Honors **`prefers-reduced-motion`** → static green border, no animation.
- `aria-label="Recommended: …"` + title on the chip.

Keeps the existing `.cave-next-path` classes/grid; styles paired with the base rule in `globals.css`.

## Verified (real build)

Mocked a turn ending in a `<coven:next-paths>` block:
- 3 chips render; the first ("Review the diff before merging") gets `cave-next-path--recommended` → green border (`--color-success`), leading dot, `cave-next-path-pulse` animation; the others stay on the default accent style.
- `tsc --noEmit` clean; full `test:app` green (335 files). Source-text assertion added to `chat-view-polish.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)