### PR TITLE
feat(calendar): relative day words in the Agenda date headers

### DIFF
--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -77,6 +77,19 @@ function fmtDateHeading(d: Date): string {
   return formatDate(d, undefined, { weekday: true, month: "long" });
 }
 
+// Agenda group headers read better with a relative day word for the days right
+// around now ("Today" / "Tomorrow" / "Yesterday"), falling back to the full
+// weekday + date for anything further out.
+function agendaDayLabel(date: Date): string {
+  const days = Math.round(
+    (startOfDay(date).getTime() - startOfDay(new Date()).getTime()) / 86_400_000,
+  );
+  if (days === 0) return "Today";
+  if (days === 1) return "Tomorrow";
+  if (days === -1) return "Yesterday";
+  return fmtDateHeading(date);
+}
+
 function fmtHourLabel(h: number): string {
   // Honor the 24-hour clock preference for the time axis. Wrapped so the
   // helper still works if prefs are unavailable (SSR / isolated unit runs),
@@ -274,7 +287,7 @@ function AgendaView({
                   : "text-[var(--text-primary)]"
               }`}
             >
-              {isSameDay(date, new Date()) ? "Today" : fmtDateHeading(date)}
+              {agendaDayLabel(date)}
             </span>
             <span className="ml-auto font-mono text-[11px] text-[var(--text-secondary)] opacity-80">
               {groupItems.length} item{groupItems.length !== 1 ? "s" : ""}


### PR DESCRIPTION
## What

The calendar **Agenda** grouped items under "Today" or an absolute heading ("Saturday, June 20"). Days right around now now read as **"Tomorrow"** / **"Yesterday"** too (via a small future-aware `agendaDayLabel`), falling back to the full weekday + date for anything further out — easier to scan. The today highlight (accent color) is unchanged.

`relativeDayLabel` in daily-report.ts wasn't reused because it's past-oriented (no "Tomorrow") and shared with the dashboard — so this is a small local helper.

## Tests / verification

- `calendar-view-polish`, `calendar-actions`, `calendar-keyboard` — pass; no test pins the agenda header.
- `tsc --noEmit` clean; full `pnpm build` green.
- Unit-verified the helper: today→"Today", +1→"Tomorrow", −1→"Yesterday", +12→full date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)