### PR TITLE
feat(prefs): honor the date/clock preference across more surfaces

### DIFF
--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -21,6 +21,7 @@ import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
+import { useDateTimePrefs, formatDate, formatClock } from "@/lib/datetime-format";
 
 const DEFAULT_TIMEOUT_MS = 2 * 60 * 60 * 1000;
 
@@ -817,6 +818,7 @@ function StepsSection({
 }
 
 export function BoardInspector({ card, familiars, sessions, projects, onClose, onPatch, onMoveStatus, onDelete, onCardReplaced, onJumpToSession, onOpenTaskChat, onOpenUrl, chatLinking = false, chatLinkError }: Props) {
+  const dtPrefs = useDateTimePrefs();
   const [closing, setClosing] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState(false);
   const [lifecycleBusy, setLifecycleBusy] = useState<CardLifecycle | null>(null);
@@ -1149,9 +1151,9 @@ export function BoardInspector({ card, familiars, sessions, projects, onClose, o
                 </div>
 
                 <div className="board-drawer-stamps">
-                  <span><span className="board-drawer-stamp-label">Created</span> {new Date(card.createdAt).toLocaleString()}</span>
+                  <span><span className="board-drawer-stamp-label">Created</span> {`${formatDate(card.createdAt, dtPrefs, { year: true })} ${formatClock(card.createdAt, dtPrefs)}`}</span>
                   <span className="board-drawer-stamp-sep">·</span>
-                  <span><span className="board-drawer-stamp-label">Updated</span> {new Date(card.updatedAt).toLocaleString()}</span>
+                  <span><span className="board-drawer-stamp-label">Updated</span> {`${formatDate(card.updatedAt, dtPrefs, { year: true })} ${formatClock(card.updatedAt, dtPrefs)}`}</span>
                 </div>
               </>
             )}

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -969,10 +969,12 @@ function ItemDetailPanel({
           <div className="flex items-center gap-1.5 text-[var(--text-muted)]">
             <Icon name="ph:clock" width={12} />
             <span>
-              {new Date((item.fireAt ?? item.firedAt)!).toLocaleString(undefined, {
-                weekday: "short", month: "short", day: "numeric",
-                hour: "numeric", minute: "2-digit",
-              })}
+              {(() => {
+                const at = (item.fireAt ?? item.firedAt)!;
+                // Short weekday isn't a preference; the date order + clock are.
+                const weekday = new Date(at).toLocaleDateString([], { weekday: "short" });
+                return `${weekday}, ${formatDate(at, undefined, { month: "short" })} ${formatClock(at)}`;
+              })()}
             </span>
           </div>
         )}

--- a/src/components/chat-all-familiars-project-list.test.ts
+++ b/src/components/chat-all-familiars-project-list.test.ts
@@ -46,13 +46,13 @@ assert.match(
 
 assert.match(
   chatList,
-  /function chatDate\(iso: string\): string/,
-  "ChatList should expose an absolute chat date formatter for visible metadata",
+  /function chatDate\(iso: string, prefs: DateTimePrefs\): string/,
+  "ChatList should expose an absolute chat date formatter (pref-aware) for visible metadata",
 );
 
 assert.match(
   chatList,
-  /\{chatDate\(s\.updated_at\)\}[\s\S]*\{rel\}/,
+  /\{chatDate\(s\.updated_at, dtPrefs\)\}[\s\S]*\{rel\}/,
   "Chat rows should show the absolute date next to the relative updated age",
 );
 

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -12,6 +12,7 @@ import { SessionInitiatorChip } from "@/components/ui/session-initiator-chip";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { relativeTime, isRelativePhrase } from "@/lib/relative-time";
+import { useDateTimePrefs, formatDate, type DateTimePrefs } from "@/lib/datetime-format";
 import {
   deriveChatProjectGroups,
   filterVisibleChatSessions,
@@ -78,14 +79,10 @@ type Props = {
   compact?: boolean;
 };
 
-function chatDate(iso: string): string {
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return "";
-  return new Intl.DateTimeFormat([], {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  }).format(date);
+function chatDate(iso: string, prefs: DateTimePrefs): string {
+  // Absolute session date — honors the user's date-order preference
+  // (month-first "Jun 19, 2026" vs day-first "19 Jun 2026") set in Settings.
+  return formatDate(iso, prefs, { year: true });
 }
 
 /** Repo name — last non-empty path segment. */
@@ -234,6 +231,7 @@ function ChatListSection({
 export function ChatList({ familiar, familiars = [], sessions, daemonRunning, onOpen, onNewChat, onSessionsChanged, sessionsLoaded = true, compact = false }: Props) {
   const { projects } = useProjects();
   const projectOverrides = useProjectOverrides();
+  const dtPrefs = useDateTimePrefs();
   const [error, setError] = useState<string | null>(null);
   // Two-step delete: first trash click arms the row (inline Cancel/Delete
   // confirm replaces the row actions); only the explicit Delete commits.
@@ -977,7 +975,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                                 ) : null}
                               </span>
                               <span className="chat-list-row-time flex shrink-0 items-baseline gap-1 text-[11px] text-[var(--text-muted)]">
-                                <span>{chatDate(s.updated_at)}</span>
+                                <span>{chatDate(s.updated_at, dtPrefs)}</span>
                                 {isRelativePhrase(rel) ? (
                                   <>
                                     <span aria-hidden>·</span>

--- a/src/components/library-doc-preview.tsx
+++ b/src/components/library-doc-preview.tsx
@@ -18,6 +18,7 @@ import type {
 } from "@/lib/library-types";
 import type { Skill } from "@/components/library-collection-rail";
 import { useFocusTrap } from "@/lib/use-focus-trap";
+import { formatDate, readDateTimePrefs } from "@/lib/datetime-format";
 
 // ── Discriminated union ──────────────────────────────────────────
 export type SelectedItem =
@@ -43,10 +44,13 @@ const EMPTY_TEXT: Record<LibrarySectionKind, string> = {
 };
 
 // ── Helpers ──────────────────────────────────────────────────────
-const dateFmt = new Intl.DateTimeFormat([], { year: "numeric", month: "short", day: "numeric" });
 function fmtDate(iso?: string): string {
   if (!iso) return "—";
-  try { return dateFmt.format(new Date(iso)); } catch { return iso; }
+  // Honors the user's date-order preference (month-first vs day-first). Reads
+  // the persisted snapshot rather than the hook so the existing call sites in
+  // the preview's sub-components stay unchanged; an already-open preview picks
+  // up a pref change on its next render.
+  return formatDate(iso, readDateTimePrefs(), { year: true }) || iso;
 }
 
 type UrlOpenKind = "web" | "github" | "vscode-file";


### PR DESCRIPTION
The app already has a **12h/24h + date-order preference** (`datetime-format.ts`, wired into ~10 surfaces), but several still formatted dates with raw `Intl`/`toLocale` and **ignored the setting** — so dates read differently depending on where you looked. This routes the divergent user-facing surfaces through the existing pref-aware helpers:

- **Sessions list** (`chat-list`): `chatDate()` now uses `formatDate(..., { year: true })` so the absolute session date follows the user's date order (month-first vs day-first).
- **Board inspector**: Created/Updated stamps use `formatDate` + `formatClock` (was `toLocaleString()`).
- **Library** doc preview: `fmtDate()` uses `formatDate` (via the persisted snapshot, so existing call sites stay unchanged).
- **Calendar**: reminder fire-time uses `formatDate` + `formatClock` (honors clock + order; the short weekday stays raw — it isn't a preference).

**`relativeTime` is intentionally left untouched** — it's documented pure/server-safe (re-exported by `daily-report` for server pages), so it must not import the `"use client"` datetime-format module. Its ≥7d absolute fallback only shows where it's the sole date; chat-list's own ≥7d rows fall back to the now-pref-aware `chatDate`.

test:app (335) + test:mobile (16) + build green.
🤖 Generated with [Claude Code](https://claude.com/claude-code)