### PR TITLE
feat(schedules): flag overdue reminders instead of a quiet "3h ago"

### DIFF
--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -423,10 +423,20 @@ function ReminderTaskRow({
   onSelect: (item: InboxItem) => void;
 }) {
   const workspace = familiarLabel(item.familiarId);
+  // A one-shot reminder still pending after its fire time never fired (e.g. the
+  // daemon was offline) — surface that instead of a quiet "3h ago".
+  const isOverdue =
+    item.kind !== "daily-summary" &&
+    (item.recurrence?.type ?? "none") === "none" &&
+    item.status === "pending" &&
+    !!item.fireAt &&
+    new Date(item.fireAt).getTime() < Date.now();
   const schedule = item.kind === "daily-summary"
     ? "Daily summary"
     : item.recurrence?.type !== "none"
     ? humanSchedule(item.recurrence)
+    : isOverdue
+    ? "Overdue"
     : item.fireAt
     ? relTime(item.fireAt)
     : "Paused";
@@ -458,7 +468,7 @@ function ReminderTaskRow({
             </span>
           )}
         </span>
-        <span className="shrink-0 text-[12px] tabular-nums" style={{ color: "var(--text-muted)" }}>
+        <span className="shrink-0 text-[12px] tabular-nums" style={{ color: isOverdue ? "var(--color-warning)" : "var(--text-muted)" }}>
           {schedule}
         </span>
       </button>


### PR DESCRIPTION
## What

A one-shot reminder still in the **pending** state after its fire time has passed never actually fired (e.g. the daemon was offline). The Reminders row now shows a **warning-colored "Overdue"** in the schedule slot instead of a muted "3h ago", so it stands out as needing attention. Recurring reminders, and fired/snoozed/future items, are unaffected.

`isOverdue` = one-shot (`recurrence none`) + `status === "pending"` + `fireAt` in the past.

## Tests / verification

- `schedules-tabs.test.ts` passes (pins `ReminderTaskRow` existence, which is unchanged). `tsc --noEmit` clean; full `pnpm build` green.
- Live-verified: a pending reminder with a past fire time renders "Overdue" in `--color-warning` (rgb(246,188,93)); a future one stays "in 2h" muted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)