### PR TITLE
fix(library): surface add failures instead of swallowing them

### DIFF
--- a/src/components/library-bookmarks-list.tsx
+++ b/src/components/library-bookmarks-list.tsx
@@ -178,6 +178,7 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
   const [groupSelectorOpen, setGroupSelectorOpen] = useState(false);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [adding, setAdding] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
   const [addedToBoardId, setAddedToBoardId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -215,14 +216,23 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
   }
 
   async function handleAdd(url: string, title: string, tags: string[]) {
-    setAdding(false);
-    const res = await fetch("/api/library/bookmarks", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ url, title, tags }),
-    });
-    const json = await res.json();
-    if (json.ok) setItems((prev) => [json.item, ...prev]);
+    setAddError(null);
+    try {
+      const res = await fetch("/api/library/bookmarks", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url, title, tags }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.ok) {
+        setAddError(json?.error ?? "Couldn't save the bookmark — try again.");
+        return;
+      }
+      setItems((prev) => [json.item, ...prev]);
+      setAdding(false);
+    } catch {
+      setAddError("Couldn't save the bookmark — network error.");
+    }
   }
 
   const { pending: undoPending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<LibraryBookmark>();
@@ -335,7 +345,12 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
 
       {/* Add form */}
       {adding && (
-        <AddBookmarkForm onAdd={handleAdd} onCancel={() => setAdding(false)} />
+        <>
+          <AddBookmarkForm onAdd={handleAdd} onCancel={() => { setAdding(false); setAddError(null); }} />
+          {addError && (
+            <p role="alert" className="px-3 py-1.5 text-[11px] text-[var(--color-danger)]">{addError}</p>
+          )}
+        </>
       )}
 
       {/* Table */}

--- a/src/components/library-github-list.tsx
+++ b/src/components/library-github-list.tsx
@@ -591,6 +591,7 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
   const [groupBy, setGroupBy] = useState<GroupBy>("repo");
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [adding, setAdding] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
   const [attachItem, setAttachItem] = useState<LibraryGitHubItem | null>(null);
   const [handoffItem, setHandoffItem] = useState<LibraryGitHubItem | null>(null);
   const [query, setQuery] = useState("");
@@ -619,14 +620,23 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
   }
 
   async function handleAdd(url: string, title: string) {
-    setAdding(false);
-    const res = await fetch("/api/library/github", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ url, title }),
-    });
-    const json = await res.json();
-    if (json.ok) setItems((prev) => [json.item, ...prev]);
+    setAddError(null);
+    try {
+      const res = await fetch("/api/library/github", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url, title }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.ok) {
+        setAddError(json?.error ?? "Couldn't save the link — try again.");
+        return;
+      }
+      setItems((prev) => [json.item, ...prev]);
+      setAdding(false);
+    } catch {
+      setAddError("Couldn't save the link — network error.");
+    }
   }
 
   const { pending: undoPending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<LibraryGitHubItem>();
@@ -703,7 +713,12 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
 
       {/* Add form */}
       {adding && (
-        <AddGitHubForm onAdd={handleAdd} onCancel={() => setAdding(false)} />
+        <>
+          <AddGitHubForm onAdd={handleAdd} onCancel={() => { setAdding(false); setAddError(null); }} />
+          {addError && (
+            <p role="alert" className="px-3 py-1.5 text-[11px] text-[var(--color-danger)]">{addError}</p>
+          )}
+        </>
       )}
 
       {/* Table */}

--- a/src/components/library-reading-list.tsx
+++ b/src/components/library-reading-list.tsx
@@ -213,6 +213,7 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
   const [groupBy, setGroupBy] = useState<GroupBy>("status");
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [adding, setAdding] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [error, setError] = useState<string | null>(null);
 
@@ -247,14 +248,23 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
   }
 
   async function handleAdd(title: string, sourceType: LibraryReadingItem["sourceType"], status: ReadingStatus, url?: string) {
-    setAdding(false);
-    const res = await fetch("/api/library/reading", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ title, sourceType, status, url: url || undefined }),
-    });
-    const json = await res.json();
-    if (json.ok) setItems((prev) => [json.item, ...prev]);
+    setAddError(null);
+    try {
+      const res = await fetch("/api/library/reading", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title, sourceType, status, url: url || undefined }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.ok) {
+        setAddError(json?.error ?? "Couldn't add to the reading list — try again.");
+        return;
+      }
+      setItems((prev) => [json.item, ...prev]);
+      setAdding(false);
+    } catch {
+      setAddError("Couldn't add to the reading list — network error.");
+    }
   }
 
   async function handleStatusChange(item: LibraryReadingItem, status: ReadingStatus) {
@@ -339,7 +349,12 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
 
       {/* Add form */}
       {adding && (
-        <AddReadingForm onAdd={handleAdd} onCancel={() => setAdding(false)} />
+        <>
+          <AddReadingForm onAdd={handleAdd} onCancel={() => { setAdding(false); setAddError(null); }} />
+          {addError && (
+            <p role="alert" className="px-3 py-1.5 text-[11px] text-[var(--color-danger)]">{addError}</p>
+          )}
+        </>
       )}
 
       {/* Table */}


### PR DESCRIPTION
From a deep review of the Library. **Functional bug:** the bookmark, reading-list, and GitHub "Add" forms each did `setAdding(false)` **before** the POST and only acted on success — so if the save failed (invalid URL, 4xx, network drop), the form closed and the item just **never appeared, with no feedback**. The user assumes it saved.

Fix (all three lists):
- wrap the POST in try/catch
- on `!res.ok || !json.ok` (or a network throw), keep the form open and show an inline `role="alert"` error
- only `setAdding(false)` on success; clear the error on cancel

tsc clean; full `test:app` (335) and `test:mobile` (16) green. (Companion a11y PR — converting the per-row "Add to Board"/"Remove" `<span onClick>` controls to real buttons — follows next.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)