### PR TITLE
fix(library): make row actions real buttons (keyboard a11y)

### DIFF
--- a/src/components/library-bookmarks-list.tsx
+++ b/src/components/library-bookmarks-list.tsx
@@ -178,6 +178,7 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
   const [groupSelectorOpen, setGroupSelectorOpen] = useState(false);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [adding, setAdding] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
   const [addedToBoardId, setAddedToBoardId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -215,14 +216,23 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
   }
 
   async function handleAdd(url: string, title: string, tags: string[]) {
-    setAdding(false);
-    const res = await fetch("/api/library/bookmarks", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ url, title, tags }),
-    });
-    const json = await res.json();
-    if (json.ok) setItems((prev) => [json.item, ...prev]);
+    setAddError(null);
+    try {
+      const res = await fetch("/api/library/bookmarks", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url, title, tags }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.ok) {
+        setAddError(json?.error ?? "Couldn't save the bookmark — try again.");
+        return;
+      }
+      setItems((prev) => [json.item, ...prev]);
+      setAdding(false);
+    } catch {
+      setAddError("Couldn't save the bookmark — network error.");
+    }
   }
 
   const { pending: undoPending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<LibraryBookmark>();
@@ -335,7 +345,12 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
 
       {/* Add form */}
       {adding && (
-        <AddBookmarkForm onAdd={handleAdd} onCancel={() => setAdding(false)} />
+        <>
+          <AddBookmarkForm onAdd={handleAdd} onCancel={() => { setAdding(false); setAddError(null); }} />
+          {addError && (
+            <p role="alert" className="px-3 py-1.5 text-[11px] text-[var(--color-danger)]">{addError}</p>
+          )}
+        </>
       )}
 
       {/* Table */}

--- a/src/components/library-bookmarks-list.tsx
+++ b/src/components/library-bookmarks-list.tsx
@@ -452,9 +452,11 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
                                 <Icon name="ph:check" width={11} />
                               </span>
                             ) : (
-                              <span
+                              <button
+                                type="button"
                                 className="library-row-delete"
                                 title="Add to Board"
+                                aria-label={`Add "${item.title}" to Board`}
                                 onClick={() => {
                                   onAddToBoard(item);
                                   setAddedToBoardId(item.id);
@@ -462,16 +464,18 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
                                 }}
                               >
                                 <Icon name="ph:kanban" width={11} />
-                              </span>
+                              </button>
                             )
                           )}
-                          <span
+                          <button
+                            type="button"
                             className="library-row-delete"
                             title="Remove"
+                            aria-label={`Remove "${item.title}"`}
                             onClick={() => { handleDelete(item); }}
                           >
                             <Icon name="ph:x" width={11} />
-                          </span>
+                          </button>
                         </span>
                       </td>
                     </tr>

--- a/src/components/library-github-list.tsx
+++ b/src/components/library-github-list.tsx
@@ -591,6 +591,7 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
   const [groupBy, setGroupBy] = useState<GroupBy>("repo");
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [adding, setAdding] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
   const [attachItem, setAttachItem] = useState<LibraryGitHubItem | null>(null);
   const [handoffItem, setHandoffItem] = useState<LibraryGitHubItem | null>(null);
   const [query, setQuery] = useState("");
@@ -619,14 +620,23 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
   }
 
   async function handleAdd(url: string, title: string) {
-    setAdding(false);
-    const res = await fetch("/api/library/github", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ url, title }),
-    });
-    const json = await res.json();
-    if (json.ok) setItems((prev) => [json.item, ...prev]);
+    setAddError(null);
+    try {
+      const res = await fetch("/api/library/github", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url, title }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.ok) {
+        setAddError(json?.error ?? "Couldn't save the link — try again.");
+        return;
+      }
+      setItems((prev) => [json.item, ...prev]);
+      setAdding(false);
+    } catch {
+      setAddError("Couldn't save the link — network error.");
+    }
   }
 
   const { pending: undoPending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<LibraryGitHubItem>();
@@ -703,7 +713,12 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
 
       {/* Add form */}
       {adding && (
-        <AddGitHubForm onAdd={handleAdd} onCancel={() => setAdding(false)} />
+        <>
+          <AddGitHubForm onAdd={handleAdd} onCancel={() => { setAdding(false); setAddError(null); }} />
+          {addError && (
+            <p role="alert" className="px-3 py-1.5 text-[11px] text-[var(--color-danger)]">{addError}</p>
+          )}
+        </>
       )}
 
       {/* Table */}

--- a/src/components/library-reading-list.tsx
+++ b/src/components/library-reading-list.tsx
@@ -213,6 +213,7 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
   const [groupBy, setGroupBy] = useState<GroupBy>("status");
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [adding, setAdding] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [error, setError] = useState<string | null>(null);
 
@@ -247,14 +248,23 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
   }
 
   async function handleAdd(title: string, sourceType: LibraryReadingItem["sourceType"], status: ReadingStatus, url?: string) {
-    setAdding(false);
-    const res = await fetch("/api/library/reading", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ title, sourceType, status, url: url || undefined }),
-    });
-    const json = await res.json();
-    if (json.ok) setItems((prev) => [json.item, ...prev]);
+    setAddError(null);
+    try {
+      const res = await fetch("/api/library/reading", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title, sourceType, status, url: url || undefined }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.ok) {
+        setAddError(json?.error ?? "Couldn't add to the reading list — try again.");
+        return;
+      }
+      setItems((prev) => [json.item, ...prev]);
+      setAdding(false);
+    } catch {
+      setAddError("Couldn't add to the reading list — network error.");
+    }
   }
 
   async function handleStatusChange(item: LibraryReadingItem, status: ReadingStatus) {
@@ -339,7 +349,12 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
 
       {/* Add form */}
       {adding && (
-        <AddReadingForm onAdd={handleAdd} onCancel={() => setAdding(false)} />
+        <>
+          <AddReadingForm onAdd={handleAdd} onCancel={() => { setAdding(false); setAddError(null); }} />
+          {addError && (
+            <p role="alert" className="px-3 py-1.5 text-[11px] text-[var(--color-danger)]">{addError}</p>
+          )}
+        </>
       )}
 
       {/* Table */}

--- a/src/components/library-reading-list.tsx
+++ b/src/components/library-reading-list.tsx
@@ -483,10 +483,16 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
                           <span className="board-table-muted">—</span>
                         )}
                       </td>
-                      <td className="library-reading-col-actions" onClick={(e) => { e.stopPropagation(); handleDelete(item); }}>
-                        <span className="library-row-delete" title="Remove">
+                      <td className="library-reading-col-actions">
+                        <button
+                          type="button"
+                          className="library-row-delete"
+                          title="Remove"
+                          aria-label={`Remove "${item.title}"`}
+                          onClick={(e) => { e.stopPropagation(); handleDelete(item); }}
+                        >
                           <Icon name="ph:x" width={11} />
-                        </span>
+                        </button>
                       </td>
                     </tr>
                   ))}

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -1300,6 +1300,10 @@
   justify-content: center;
   opacity: 0;
   cursor: pointer;
+  /* Reset button chrome so the now-<button> row actions match the old <span>. */
+  border: none;
+  background: none;
+  font: inherit;
   color: var(--text-muted);
   border-radius: 4px;
   padding: 2px;


### PR DESCRIPTION
Companion a11y PR to #1218 (stacked on it — base will be retargeted to `main` once #1218 merges).

The per-row **"Add to Board"** and **"Remove"** controls in the bookmarks and reading lists were click-only `<span>`s (no `role`, `title`-only) — not keyboard-reachable and not announced as buttons. Converted to real `<button>`s with `aria-label`s; the reading list's click handler moves off the `<td>` onto the button. Added `border/background/font` resets to `.library-row-delete` so the now-`<button>` is visually identical to the old `<span>` (the class already had `:focus-visible` styling that now actually applies). The GitHub list's remove was already a proper button.

Left as a noted follow-up: the table **group-toggle `<tr onClick>`** rows (Tags/Domain) still lack keyboard support — a separate, slightly riskier change.

tsc clean; full `test:app` (335) and `test:mobile` (16) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)