### PR TITLE
feat(settings): choose familiar top-bar style — avatars or dropdown

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -326,6 +326,7 @@ export const SUITES = {
     "src/components/familiar-menu-bar.test.ts",
     "src/components/familiar-quick-switch.test.ts",
     "src/lib/familiar-quick-switch.test.ts",
+    "src/lib/familiar-switcher-style.test.ts",
     "src/lib/salem/happy-paths.test.ts",
     "src/lib/salem/pathfinder-match.test.ts",
     "src/lib/salem/pathfinder-card.test.ts",

--- a/src/components/familiar-quick-switch.test.ts
+++ b/src/components/familiar-quick-switch.test.ts
@@ -40,6 +40,20 @@ assert.match(
   "pinned familiars show a pin badge in the strip",
 );
 
+// The strip honors the user's preference — "dropdown" hides it, leaving only
+// the switcher menu.
+assert.match(
+  source,
+  /useFamiliarSwitcherStyle\(\)/,
+  "reads the familiar-switcher style preference",
+);
+assert.match(
+  source,
+  /const showStrip = switcherStyle === "avatars" && quick\.length > 1/,
+  "the avatar strip only renders in the 'avatars' style with 2+ familiars",
+);
+assert.match(source, /\{showStrip \? \(/, "the strip render is gated on showStrip");
+
 // The full switcher (full list, pinning, create/manage/reorder) sits beside the
 // strip — the strip is a shortcut, not a replacement.
 assert.match(source, /<FamiliarSwitcher/, "embeds the full FamiliarSwitcher menu beside the strip");

--- a/src/components/familiar-quick-switch.tsx
+++ b/src/components/familiar-quick-switch.tsx
@@ -6,6 +6,7 @@ import { FamiliarSwitcher } from "@/components/familiar-switcher";
 import { computePresence, REMOTE_HARNESSES } from "@/lib/presence";
 import { computeQuickSwitch, QUICK_SWITCH_MAX } from "@/lib/familiar-quick-switch";
 import { useFamiliarLastUsed, useFamiliarPins } from "@/lib/use-familiar-quick-switch";
+import { useFamiliarSwitcherStyle } from "@/lib/familiar-switcher-style";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { SessionRow } from "@/lib/types";
 
@@ -44,6 +45,7 @@ export function FamiliarQuickSwitch({
 }: Props) {
   const pins = useFamiliarPins();
   const lastUsed = useFamiliarLastUsed();
+  const switcherStyle = useFamiliarSwitcherStyle();
   const pinnedSet = useMemo(() => new Set(pins), [pins]);
 
   const quick = useMemo(
@@ -51,9 +53,12 @@ export function FamiliarQuickSwitch({
     [familiars, pins, lastUsed, activeFamiliarId, max],
   );
 
+  // "dropdown" preference hides the avatar strip, leaving only the switcher menu.
+  const showStrip = switcherStyle === "avatars" && quick.length > 1;
+
   return (
     <div className="familiar-quickswitch">
-      {quick.length > 1 ? (
+      {showStrip ? (
         <ul className="familiar-quickswitch__strip" role="listbox" aria-label="Quick switch familiar">
           {quick.map((f) => {
             const isActive = f.id === activeFamiliarId;

--- a/src/components/settings-appearance.test.ts
+++ b/src/components/settings-appearance.test.ts
@@ -321,6 +321,18 @@ assert.match(
   "Root layout should mount the global screen magnification controller",
 );
 
+// Familiar switcher style — choose the top-bar control (avatar strip vs dropdown).
+assert.match(
+  settings,
+  /Familiar switcher/,
+  "Appearance settings should expose a Familiar switcher style control",
+);
+assert.match(
+  settings,
+  /setFamiliarSwitcherStyle\(option\)/,
+  "the familiar-switcher control writes the chosen style preference",
+);
+
 // Corner radius drives the shared --radius tokens app-wide, so its boot block
 // must run before paint (ThemeScript) and its controller must mount in layout.
 assert.match(

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -26,6 +26,12 @@ import {
   type CornerRadius,
 } from "@/lib/appearance-corner-radius";
 import {
+  FAMILIAR_SWITCHER_STYLE_OPTIONS,
+  FAMILIAR_SWITCHER_STYLE_LABELS,
+  setFamiliarSwitcherStyle,
+  useFamiliarSwitcherStyle,
+} from "@/lib/familiar-switcher-style";
+import {
   DEMO_MODE_EVENT,
   clearDemoModeData,
   demoModeFetchHeaders,
@@ -823,6 +829,7 @@ function AppearanceSection() {
   // colorEditorBase: the preset that seeds the color editor; null = editor hidden.
   const [colorEditorBase, setColorEditorBase] = useState<PresetTheme | null>(null);
   const [cornerRadius, setCornerRadius] = useState<CornerRadius>("default");
+  const familiarSwitcherStyle = useFamiliarSwitcherStyle();
 
   // Read persisted theme + mode on mount
   useEffect(() => {
@@ -1090,6 +1097,45 @@ function AppearanceSection() {
       </SettingsGroup>
 
       <FontSettings />
+
+      {/* ── Familiar switcher ── choose the top-bar familiar control: a row of
+          quick-switch avatars, or just the switcher dropdown. */}
+      <SettingsGroup label="Familiar switcher">
+        <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2 px-4 py-3">
+          <div className="min-w-0">
+            <div className="text-[12px] font-medium text-[var(--text-secondary)]">
+              Top-bar style
+            </div>
+            <div className="text-[11px] text-[var(--text-muted)]">
+              Show recent &amp; pinned familiars as a row of avatars, or just the switcher dropdown.
+            </div>
+          </div>
+          <div
+            role="group"
+            aria-label="Familiar switcher style"
+            className="flex w-fit shrink-0 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-base)] p-0.5"
+          >
+            {FAMILIAR_SWITCHER_STYLE_OPTIONS.map((option) => {
+              const active = familiarSwitcherStyle === option;
+              return (
+                <button
+                  key={option}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => setFamiliarSwitcherStyle(option)}
+                  className={`focus-ring rounded-md px-2.5 py-1.5 text-[11px] font-medium transition-colors ${
+                    active
+                      ? "bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
+                      : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+                  }`}
+                >
+                  {FAMILIAR_SWITCHER_STYLE_LABELS[option]}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </SettingsGroup>
 
       {/* ── Corner radius ── a minor shape tweak (drives the shared --radius
           tokens), kept last so the primary color/theme and text controls lead. */}

--- a/src/lib/familiar-switcher-style.test.ts
+++ b/src/lib/familiar-switcher-style.test.ts
@@ -1,0 +1,26 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  DEFAULT_FAMILIAR_SWITCHER_STYLE,
+  FAMILIAR_SWITCHER_STYLE_LABELS,
+  FAMILIAR_SWITCHER_STYLE_OPTIONS,
+  normalizeFamiliarSwitcherStyle,
+} from "./familiar-switcher-style.ts";
+
+// The two styles the top-bar control toggles between.
+assert.deepEqual([...FAMILIAR_SWITCHER_STYLE_OPTIONS], ["avatars", "dropdown"], "exactly two styles");
+assert.equal(DEFAULT_FAMILIAR_SWITCHER_STYLE, "avatars", "default keeps the new avatar strip");
+
+// Every option has a human label.
+for (const option of FAMILIAR_SWITCHER_STYLE_OPTIONS) {
+  assert.equal(typeof FAMILIAR_SWITCHER_STYLE_LABELS[option], "string", `label for ${option}`);
+}
+
+// normalize accepts known values and falls back to the default for anything else.
+assert.equal(normalizeFamiliarSwitcherStyle("avatars"), "avatars");
+assert.equal(normalizeFamiliarSwitcherStyle("dropdown"), "dropdown");
+assert.equal(normalizeFamiliarSwitcherStyle("bogus"), DEFAULT_FAMILIAR_SWITCHER_STYLE, "unknown → default");
+assert.equal(normalizeFamiliarSwitcherStyle(null), DEFAULT_FAMILIAR_SWITCHER_STYLE, "null → default");
+assert.equal(normalizeFamiliarSwitcherStyle(undefined), DEFAULT_FAMILIAR_SWITCHER_STYLE, "undefined → default");
+
+console.log("familiar-switcher-style: all assertions passed");

--- a/src/lib/familiar-switcher-style.ts
+++ b/src/lib/familiar-switcher-style.ts
@@ -1,0 +1,86 @@
+"use client";
+
+/**
+ * User preference for how the familiar control renders in the top bars:
+ *
+ *   • "avatars"  — a row of one-tap avatars (pinned + most-recent) beside the
+ *                  switcher menu (the default; see FamiliarQuickSwitch).
+ *   • "dropdown" — just the account-style switcher menu, no avatar strip.
+ *
+ * Cave-local, persisted in localStorage under `cave:familiar-switcher-style`.
+ * Reactive via useSyncExternalStore so the top bars re-render the moment the
+ * Settings control flips it. Same shape as cave-familiar-order.
+ */
+
+import { useSyncExternalStore } from "react";
+
+export const FAMILIAR_SWITCHER_STYLE_KEY = "cave:familiar-switcher-style";
+
+export const FAMILIAR_SWITCHER_STYLE_OPTIONS = ["avatars", "dropdown"] as const;
+
+export type FamiliarSwitcherStyle = (typeof FAMILIAR_SWITCHER_STYLE_OPTIONS)[number];
+
+export const DEFAULT_FAMILIAR_SWITCHER_STYLE = "avatars" as const;
+
+export const FAMILIAR_SWITCHER_STYLE_LABELS: Record<FamiliarSwitcherStyle, string> = {
+  avatars: "Avatars",
+  dropdown: "Dropdown",
+};
+
+export function normalizeFamiliarSwitcherStyle(value: unknown): FamiliarSwitcherStyle {
+  return FAMILIAR_SWITCHER_STYLE_OPTIONS.includes(value as FamiliarSwitcherStyle)
+    ? (value as FamiliarSwitcherStyle)
+    : DEFAULT_FAMILIAR_SWITCHER_STYLE;
+}
+
+let cached: FamiliarSwitcherStyle | null = null;
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const fn of listeners) fn();
+}
+
+function read(): FamiliarSwitcherStyle {
+  if (typeof window === "undefined") return DEFAULT_FAMILIAR_SWITCHER_STYLE;
+  try {
+    return normalizeFamiliarSwitcherStyle(window.localStorage.getItem(FAMILIAR_SWITCHER_STYLE_KEY));
+  } catch {
+    return DEFAULT_FAMILIAR_SWITCHER_STYLE;
+  }
+}
+
+function getSnapshot(): FamiliarSwitcherStyle {
+  if (cached === null) cached = read();
+  return cached;
+}
+
+/** Persist the preference and notify subscribers. */
+export function setFamiliarSwitcherStyle(style: FamiliarSwitcherStyle): void {
+  const normalized = normalizeFamiliarSwitcherStyle(style);
+  cached = normalized;
+  if (typeof window !== "undefined") {
+    try { window.localStorage.setItem(FAMILIAR_SWITCHER_STYLE_KEY, normalized); } catch { /* ignore */ }
+  }
+  notify();
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (e) => {
+    if (e.key === FAMILIAR_SWITCHER_STYLE_KEY) {
+      cached = null;
+      notify();
+    }
+  });
+}
+
+function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+const getServerSnapshot = () => DEFAULT_FAMILIAR_SWITCHER_STYLE;
+
+/** React hook: the current familiar-switcher style. Re-renders on change. */
+export function useFamiliarSwitcherStyle(): FamiliarSwitcherStyle {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
## What

Adds a user preference in **Settings → Appearance** to choose how the familiar control renders in the top bars:

- **Avatars** (default) — the row of recent + pinned quick-switch avatars beside the switcher menu (the #1202 behavior).
- **Dropdown** — just the account-style switcher menu, no avatar strip.

The control is a segmented toggle under a new "Familiar switcher" group, mirroring the existing corner-radius control. The preference is reactive, so both top bars (mobile `.top-bar` and desktop `.menu-bar`) update the instant you flip it — no reload.

## Files

- `src/lib/familiar-switcher-style.ts` — preference store (`cave:familiar-switcher-style`, default `avatars`) with `useFamiliarSwitcherStyle()` hook + `setFamiliarSwitcherStyle()`, using the `useSyncExternalStore` pattern from `cave-familiar-order`.
- `src/components/familiar-quick-switch.tsx` — gates the avatar strip on `switcherStyle === "avatars"`.
- `src/components/settings-shell.tsx` — the segmented control in the Appearance section.

## Tests

- New unit test for the store (options/labels/default/normalize).
- Updated the quick-switch component test (strip gated on the preference) and the settings-appearance test (control present + wired).
- `pnpm typecheck`, `test:app` (336), `test:mobile` (16), `build`, tests-wired guard all green locally.
- Live-verified: setting renders; default shows 6 strip avatars; switching to Dropdown drops the strip to 0 (only the switcher remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)