### PR TITLE
feat(board): add a "today" guide and per-bar duration to the Gantt

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import type { Card } from "@/lib/cave-board-types";
 
 type Props = {
@@ -29,6 +30,12 @@ function daysBetween(start: Date, end: Date): number {
 }
 
 export function BoardGantt({ cards, selectedCardId, onSelect }: Props) {
+  // "Today" is derived from the clock, so it can't be computed during SSR
+  // without risking a hydration mismatch (and the guide would jump). Resolve it
+  // after mount — the line simply isn't drawn for the first client render.
+  const [todayMs, setTodayMs] = useState<number | null>(null);
+  useEffect(() => setTodayMs(Date.now()), []);
+
   const scheduled: ScheduledCard[] = [];
   const unscheduled: Card[] = [];
 
@@ -59,37 +66,70 @@ export function BoardGantt({ cards, selectedCardId, onSelect }: Props) {
   const max = new Date(Math.max(...scheduled.map((item) => item.end.getTime())));
   const span = Math.max(1, daysBetween(min, max) + 1);
 
+  // Today as a percentage across the [min, max] span, matched to the same UTC
+  // midnight coordinate the bars use. Null when out of range so we don't draw a
+  // guide pinned to the edge for a board whose work is all past or all future.
+  let todayPct: number | null = null;
+  if (todayMs !== null) {
+    const now = new Date(todayMs);
+    const todayUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+    const todayOffset = daysBetween(min, todayUtc);
+    if (todayOffset >= 0 && todayOffset <= span) todayPct = (todayOffset / span) * 100;
+  }
+  const todayLeft = todayPct === null ? undefined : `${todayPct}%`;
+
   return (
     <div className="board-gantt">
       <div className="board-gantt-header">
-        <span>{formatLabel(min)}</span>
-        <span>{formatLabel(max)}</span>
+        <span aria-hidden />
+        <span className="board-gantt-axis">
+          <span>{formatLabel(min)}</span>
+          {todayLeft !== undefined ? (
+            <span className="board-gantt-axis__today" style={{ left: todayLeft }}>Today</span>
+          ) : null}
+          <span>{formatLabel(max)}</span>
+        </span>
+        <span aria-hidden />
       </div>
-      <div className="board-gantt-list">
-        {scheduled
-          .sort((a, b) => a.start.getTime() - b.start.getTime() || a.end.getTime() - b.end.getTime())
-          .map(({ card, start, end }) => {
-            const offset = Math.max(0, daysBetween(min, start));
-            const duration = Math.max(1, daysBetween(start, end) + 1);
-            const left = `${(offset / span) * 100}%`;
-            const width = `${Math.max(5, (duration / span) * 100)}%`;
-            return (
-              <button
-                key={card.id}
-                type="button"
-                className={`board-gantt-row${selectedCardId === card.id ? " board-gantt-row--selected" : ""}`}
-                onClick={() => onSelect(card.id)}
-              >
-                <span className="board-gantt-row__title">{card.title}</span>
-                <span className="board-gantt-row__track" aria-hidden>
-                  <span className={`board-gantt-row__bar board-gantt-row__bar--${card.priority}`} style={{ left, width }} />
-                </span>
-                <span className="board-gantt-row__dates">
-                  {formatLabel(start)}-{formatLabel(end)}
-                </span>
-              </button>
-            );
-          })}
+      <div className="board-gantt-plot">
+        {/* One full-height guide spanning the whole list reads as a continuous
+            line, where a per-row marker would break across the row gaps. It
+            shares the rows' column grid so it lands in the same track column. */}
+        {todayLeft !== undefined ? (
+          <div className="board-gantt-today" aria-hidden>
+            <span />
+            <span className="board-gantt-today__col">
+              <span className="board-gantt-today__line" style={{ left: todayLeft }} />
+            </span>
+            <span />
+          </div>
+        ) : null}
+        <div className="board-gantt-list">
+          {scheduled
+            .sort((a, b) => a.start.getTime() - b.start.getTime() || a.end.getTime() - b.end.getTime())
+            .map(({ card, start, end }) => {
+              const offset = Math.max(0, daysBetween(min, start));
+              const duration = Math.max(1, daysBetween(start, end) + 1);
+              const left = `${(offset / span) * 100}%`;
+              const width = `${Math.max(5, (duration / span) * 100)}%`;
+              return (
+                <button
+                  key={card.id}
+                  type="button"
+                  className={`board-gantt-row${selectedCardId === card.id ? " board-gantt-row--selected" : ""}`}
+                  onClick={() => onSelect(card.id)}
+                >
+                  <span className="board-gantt-row__title">{card.title}</span>
+                  <span className="board-gantt-row__track" aria-hidden>
+                    <span className={`board-gantt-row__bar board-gantt-row__bar--${card.priority}`} style={{ left, width }} />
+                  </span>
+                  <span className="board-gantt-row__dates">
+                    {formatLabel(start)}–{formatLabel(end)} · {duration}d
+                  </span>
+                </button>
+              );
+            })}
+        </div>
       </div>
       {unscheduled.length > 0 ? (
         <div className="board-gantt-unscheduled">

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1174,21 +1174,66 @@
   text-align: center;
   color: var(--text-muted);
 }
+/* Title / timeline / dates columns are fixed so the header axis and the "today"
+   overlay (which reuse this exact grid) line up with the bar tracks. */
 .board-gantt-header {
-  display: flex;
-  justify-content: space-between;
-  padding: 0 10px 8px 180px;
+  display: grid;
+  grid-template-columns: 180px minmax(0, 1fr) 132px;
+  gap: 10px;
+  /* 11px = a row's 1px border + 10px padding, so the axis column starts exactly
+     where the tracks below it do. */
+  padding: 0 11px 8px;
   color: var(--text-muted);
   font-size: 11px;
   font-variant-numeric: tabular-nums;
+}
+/* The timeline axis cell carries the start/end labels and the "today" caption,
+   positioned by the same percentage the overlay line uses. */
+.board-gantt-axis {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+}
+.board-gantt-axis__today {
+  position: absolute;
+  top: 0;
+  transform: translateX(-50%);
+  color: var(--accent-presence);
+  font-weight: 650;
+  white-space: nowrap;
+}
+.board-gantt-plot {
+  position: relative;
 }
 .board-gantt-list {
   display: grid;
   gap: 4px;
 }
+/* Full-height vertical "today" guide over the whole list. Mirrors a row's grid
+   + 11px inset so its middle column maps onto the bar tracks. */
+.board-gantt-today {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: 180px minmax(0, 1fr) 132px;
+  gap: 10px;
+  padding: 0 11px;
+  pointer-events: none;
+  z-index: 1;
+}
+.board-gantt-today__col {
+  position: relative;
+}
+.board-gantt-today__line {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 0;
+  border-left: 1px dashed color-mix(in oklch, var(--accent-presence) 60%, transparent);
+}
 .board-gantt-row {
   display: grid;
-  grid-template-columns: minmax(140px, 180px) minmax(220px, 1fr) minmax(96px, auto);
+  grid-template-columns: 180px minmax(0, 1fr) 132px;
   align-items: center;
   gap: 10px;
   width: 100%;
@@ -1239,6 +1284,9 @@
   font-size: 11px;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: right;
 }
 .board-gantt-unscheduled {
   margin-top: 10px;


### PR DESCRIPTION
The board Gantt had no anchor for the current day, and bars showed only a start–end range — hard to read at a glance.

- **"Today" guide**: a full-height dashed vertical line spans the list at today's position, plus a **"Today"** caption on the timeline axis. It's an overlay that shares the rows' column grid, so it lands exactly on the bar tracks (a per-row marker would break across the row gaps). Computed after mount (hydration-safe) and only drawn when today falls within the board's date range.
- **Per-bar duration**: each row's date cell now shows the length in days, e.g. `Jun 16–Jun 22 · 7d`.
- Title/timeline/dates columns are now fixed-width so the header axis and the overlay line up precisely with the tracks.

Verified live (screenshot): the guide sits on Jun 20 with the caption aligned above it; durations render per row.

test:app (336) + test:mobile (16) + build green.

_Note: built in a hostile multi-session window — two worktrees were reaped mid-edit; recovered by staging content and committing+pushing in one shot._
🤖 Generated with [Claude Code](https://claude.com/claude-code)