### PR TITLE
feat(calendar): flag overdue reminders with a warning dot

### DIFF
--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -118,7 +118,19 @@ function defaultEntryFireAt(day: Date): string {
   return fallback.toISOString();
 }
 
+// A reminder still pending after its fire time never fired — flag it so it
+// stands out on the calendar like it does in the Schedules list.
+function isOverdueReminder(item: InboxItem): boolean {
+  return (
+    item.kind === "reminder" &&
+    item.status === "pending" &&
+    !!item.fireAt &&
+    new Date(item.fireAt).getTime() < Date.now()
+  );
+}
+
 function urgencyColor(item: InboxItem): string {
+  if (isOverdueReminder(item)) return "bg-[var(--color-warning)]";
   const meta = (item as unknown as { comms?: { urgency?: string } }).comms;
   if (!meta) return "bg-[var(--text-muted)]";
   if (meta.urgency === "expiring") return "bg-[var(--accent-presence)]";


### PR DESCRIPTION
## What

A reminder still **pending** after its fire time has passed (it never fired) now gets a warning-colored urgency dot in every calendar view (agenda / week / day / month), so an overdue item stands out the same way it does in the Schedules list (#1215 / #1221). Folded into the existing `urgencyColor`, so all six render sites get it from one change. Other items are unaffected.

`isOverdueReminder` = `kind === "reminder"` + `status === "pending"` + a past `fireAt` (the same notion as the Schedules overdue flag; kept as a small local predicate to avoid re-touching `automations-view`).

## Tests / verification

- `calendar-view-polish`, `calendar-actions` pass; `calendar-layout` passes within the build's `test:app` (a standalone re-run hit a transient worktree FS glitch, not a real failure). `tsc --noEmit` clean; full `pnpm build` green.
- Logic mirrors the Schedules overdue predicate, which was live-verified in #1215/#1221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)