### PR TITLE
fix(settings): add-on toggle failure feedback + a11y

### DIFF
--- a/src/components/settings-shell-polish.test.ts
+++ b/src/components/settings-shell-polish.test.ts
@@ -90,4 +90,29 @@ assert.match(
   "comingSoon rows get opacity-50",
 );
 
+// Add-on toggle must treat a non-ok response as a failure (fetch only throws on
+// network errors), revert, and surface the error — not silently stick.
+assert.match(
+  source,
+  /if \(!res\.ok\) throw new Error\(`save failed \(\$\{res\.status\}\)`\)/,
+  "add-on toggle checks res.ok so a 4xx/5xx is treated as a failed save",
+);
+assert.match(
+  source,
+  /setToggleError\("Couldn't save that change/,
+  "a failed add-on toggle surfaces an inline error",
+);
+// Settings section nav exposes the active section to assistive tech.
+assert.match(
+  source,
+  /aria-current=\{section === s\.id && !showPicker \? "page" : undefined\}/,
+  "the active settings section is marked aria-current",
+);
+// The custom-theme reset button is labelled with the actual theme name.
+assert.match(
+  source,
+  /aria-label=\{`Reset \$\{customData\.name\}`\}/,
+  "the custom-theme reset button names the theme it resets",
+);
+
 console.log("settings-shell-polish.test.ts OK");

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -170,6 +170,7 @@ export function SettingsShell() {
                 key={s.id}
                 type="button"
                 onClick={() => openSection(s.id)}
+                aria-current={section === s.id && !showPicker ? "page" : undefined}
                 className={`focus-ring flex w-full items-center rounded-[5px] px-2.5 text-left transition-colors ${
                   showPicker
                     ? "min-h-[var(--touch-target)] gap-3 py-3 text-[14px]"
@@ -419,6 +420,7 @@ function AddonsSection() {
     library: false,
   });
   const [loading, setLoading] = useState(true);
+  const [toggleError, setToggleError] = useState<string | null>(null);
 
   useEffect(() => {
     fetch("/api/config", { cache: "no-store" })
@@ -439,20 +441,28 @@ function AddonsSection() {
     const newValue = !addons[key];
     // Optimistic update
     setAddons((prev) => ({ ...prev, [key]: newValue }));
+    setToggleError(null);
     try {
-      await fetch("/api/config", {
+      const res = await fetch("/api/config", {
         method: "PATCH",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ addons: { [key]: newValue } }),
       });
+      // fetch only throws on network errors — a 4xx/5xx still "succeeds", so a
+      // failed save would otherwise leave the toggle stuck in the wrong state.
+      if (!res.ok) throw new Error(`save failed (${res.status})`);
     } catch {
-      // Revert on failure
+      // Revert + surface the failure instead of silently flipping back.
       setAddons((prev) => ({ ...prev, [key]: !newValue }));
+      setToggleError("Couldn't save that change — check the daemon and try again.");
     }
   };
 
   return (
     <SettingsPage title="Add-ons" description="Optional integrations. Disabled add-ons are hidden from the sidebar.">
+      {toggleError && (
+        <p role="alert" className="mb-2 px-1 text-[12px] text-[var(--color-danger)]">{toggleError}</p>
+      )}
       <SettingsGroup label="Integrations">
         {loading ? (
           <div aria-hidden className="animate-pulse space-y-3 px-4 py-3">
@@ -975,7 +985,7 @@ function AppearanceSection() {
                 type="button"
                 onClick={handleResetCustom}
                 className="focus-ring ml-1 inline-flex h-3.5 w-3.5 items-center justify-center rounded-full opacity-70 hover:opacity-100"
-                aria-label="Reset to Mood C"
+                aria-label={`Reset ${customData.name}`}
               >
                 <Icon name="ph:x-bold" width={9} />
               </button>


### PR DESCRIPTION
From a deep review of the Settings **shell** (deliberately avoided the appearance/fonts sub-panels, which another session is actively polishing).

- **Add-on toggle could silently stick (functional).** `toggle()` optimistically flips, PATCHes `/api/config`, and only reverts in `catch` — but `fetch` doesn't throw on 4xx/5xx, so a *server* failure left the toggle showing the new state while nothing saved, with no feedback. Now checks `res.ok`, reverts on any failure, and shows an inline `role="alert"` error.
- **Section nav missing `aria-current`.** The left-nav section buttons showed active state visually but didn't expose it to assistive tech. Added `aria-current="page"` on the active section.
- **Stale custom-theme reset label.** The "×" reset button was hardcoded `aria-label="Reset to Mood C"` regardless of theme; now `aria-label={`Reset ${customData.name}`}`.

Verified solid (not touched): section keyboard nav, add-on `role="switch"`/`aria-checked`, theme-preset `aria-pressed`, mode/corner-radius/familiar groups, theme-import error handling, save/apply lifecycle.

Guard assertions added in `settings-shell-polish.test.ts`. tsc clean; full `test:app` (336) and `test:mobile` (16) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)