### PR TITLE
feat(familiars): pref-aware "Last refreshed" tooltip in the memory view

### DIFF
--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -2,6 +2,7 @@
 
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { formatTimestamp } from "@/lib/datetime-format";
 // Shared relative-time formatter, imported as `age` so the call sites read the
 // same — standardizes this surface on the app-wide "2m ago / 3h ago / Jun 12" style.
 import { relativeTime as age } from "@/lib/relative-time";
@@ -369,7 +370,7 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
               </div>
               <div className="flex items-center gap-2.5">
                 {lastLoadedAt ? (
-                  <span className="text-[10px] text-[var(--text-muted)]" title={`Last refreshed ${new Date(lastLoadedAt).toLocaleString()}`}>
+                  <span className="text-[10px] text-[var(--text-muted)]" title={`Last refreshed ${formatTimestamp(lastLoadedAt)}`}>
                     Updated {age(lastLoadedAt)}
                   </span>
                 ) : null}


### PR DESCRIPTION
## What

The Familiars memory view's "Last refreshed" hover tooltip used the raw browser-locale `toLocaleString` ("6/13/2026, 7:00:33 AM"). It now uses the shared `formatTimestamp`, so it honors the user's clock + date preferences — consistent with the workflow run tooltips (#1203) and the rest of the datetime-pref work.

## Tests / verification

- No test pins the tooltip. `familiars-memory-view-detail` + `-rail` tests pass; `tsc --noEmit` clean; full `pnpm build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)