### PR TITLE
feat(home): skeleton loading for the Coven Floor widget

### DIFF
--- a/src/components/coven-floor.tsx
+++ b/src/components/coven-floor.tsx
@@ -8,6 +8,7 @@ import { formatClock } from "@/lib/datetime-format";
 import type { CovenStatusResponse, FamiliarCard, SessionSummary } from "@/lib/coven-status-types";
 import { statusColor, statusLabel } from "@/lib/coven-status-types";
 import { SessionInitiatorChip } from "@/components/ui/session-initiator-chip";
+import { SkeletonRows } from "@/components/ui/skeleton";
 
 const MAX_VISIBLE_SESSIONS = 12;
 
@@ -326,7 +327,7 @@ export function CovenFloor() {
         </div>
 
         {loading && sortedFamiliars.length === 0 ? (
-          <div className="flex items-center justify-center py-16 text-sm text-[var(--text-muted)]">Loading…</div>
+          <SkeletonRows count={4} className="py-2" />
         ) : sortedFamiliars.length === 0 ? (
           <div className="flex items-center justify-center rounded-lg border border-dashed border-[var(--border-hairline)] py-16 text-sm text-[var(--text-secondary)]">
             No familiar activity found.


### PR DESCRIPTION
## What

The Floor widget (ambient on the Home composer) showed a bare centered "Loading…" while the coven status loaded. It now renders the shared `SkeletonRows` shimmer, matching the loading affordance used elsewhere in the app. The empty ("No familiar activity found.") and populated states are unchanged.

## Tests / verification

- `coven-floor-table.test.ts` passes within the build's `test:app` (it pins the populated-table structure, which is unchanged). `tsc --noEmit` clean; full `pnpm build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)