### PR TITLE
fix(github): make sortable table headers keyboard-accessible

### DIFF
--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -191,4 +191,17 @@ assert.match(
   "each filter is a tab that reports its selected state",
 );
 
+// Sortable table headers are keyboard-operable (a real <button>) and expose
+// sort state to assistive tech via aria-sort.
+assert.match(
+  source,
+  /aria-sort=\{[\s\S]{0,400}?"ascending"[\s\S]{0,120}?"descending"[\s\S]{0,120}?"none"/,
+  "sortable column headers expose aria-sort (ascending/descending/none)",
+);
+assert.match(
+  source,
+  /<button[\s\S]{0,250}?onClick=\{\(\) => handleSortClick\(col\.key!\)\}/,
+  "the sort control is a real keyboard-operable button",
+);
+
 console.log("github-view-polish.test.ts OK");

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -1279,21 +1279,46 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
                     {COLS.map((col, i) => (
                       <th
                         key={`${col.label}-${i}`}
-                        style={{
-                          width: col.width,
-                          textAlign: col.align ?? "left",
-                          cursor: col.key ? "pointer" : "default",
-                        }}
+                        style={{ width: col.width, textAlign: col.align ?? "left" }}
                         className={col.key && sortKey === col.key ? "sorted" : ""}
-                        onClick={() => col.key && handleSortClick(col.key)}
+                        aria-sort={
+                          col.key
+                            ? sortKey === col.key
+                              ? sortDir === "asc"
+                                ? "ascending"
+                                : "descending"
+                              : "none"
+                            : undefined
+                        }
                       >
-                        {col.label}
-                        {col.key && (
-                          <span className="board-table-sort-icon">
-                            {sortKey === col.key
-                              ? <Icon name={sortDir === "asc" ? "ph:caret-up" : "ph:caret-down-fill"} width={9} />
-                              : <Icon name="ph:caret-up-down" width={9} />}
-                          </span>
+                        {col.key ? (
+                          // A real <button> so the column is sortable by keyboard;
+                          // styled inline to avoid touching the shared board-table CSS.
+                          <button
+                            type="button"
+                            className="focus-ring"
+                            onClick={() => handleSortClick(col.key!)}
+                            style={{
+                              display: "inline-flex",
+                              alignItems: "center",
+                              gap: 2,
+                              background: "none",
+                              border: "none",
+                              padding: 0,
+                              font: "inherit",
+                              color: "inherit",
+                              cursor: "pointer",
+                            }}
+                          >
+                            {col.label}
+                            <span className="board-table-sort-icon">
+                              {sortKey === col.key
+                                ? <Icon name={sortDir === "asc" ? "ph:caret-up" : "ph:caret-down-fill"} width={9} />
+                                : <Icon name="ph:caret-up-down" width={9} />}
+                            </span>
+                          </button>
+                        ) : (
+                          col.label
                         )}
                       </th>
                     ))}


### PR DESCRIPTION
Deferred follow-up from the GitHub-view review. The sortable column headers were clickable `<th onClick>` — **not keyboard-operable** and with **no `aria-sort`**, so keyboard users couldn't sort and screen readers didn't announce sort state.

- Each sortable header label is now wrapped in a real `<button>` (keyboard-operable), styled **inline** so the shared `board-table-*` CSS isn't touched (a Board session is in flight).
- The `<th>` gets `aria-sort` = `ascending` / `descending` / `none`, so the active column + direction are announced.

Guard assertions added in `github-view-polish.test.ts`. tsc clean; full `test:app` (336) and `test:mobile` (16) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)