### PR TITLE
fix(library): keyboard-operable group-toggle rows

### DIFF
--- a/src/components/library-bookmarks-list.tsx
+++ b/src/components/library-bookmarks-list.tsx
@@ -404,7 +404,16 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
               {groups.map(({ key, label, items: gi }) => (
                 <React.Fragment key={key}>
                   {groupBy !== "none" && (
-                    <tr className="board-table-group-row" onClick={() => toggleGroup(key)}>
+                    <tr
+                      className="board-table-group-row focus-ring-inset"
+                      role="button"
+                      tabIndex={0}
+                      aria-expanded={!collapsed.has(key)}
+                      onClick={() => toggleGroup(key)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleGroup(key); }
+                      }}
+                    >
                       <td colSpan={4}>
                         <span className="board-table-group-caret">
                           <Icon name={collapsed.has(key) ? "ph:caret-right" : "ph:caret-down"} width={10} />

--- a/src/components/library-reading-list.tsx
+++ b/src/components/library-reading-list.tsx
@@ -410,7 +410,16 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
               {groups.map(({ key, label, items: gi }) => (
                 <React.Fragment key={key}>
                   {groupBy !== "none" && (
-                    <tr className="board-table-group-row" onClick={() => toggleGroup(key)}>
+                    <tr
+                      className="board-table-group-row focus-ring-inset"
+                      role="button"
+                      tabIndex={0}
+                      aria-expanded={!collapsed.has(key)}
+                      onClick={() => toggleGroup(key)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleGroup(key); }
+                      }}
+                    >
                       <td colSpan={5}>
                         <span className="board-table-group-caret">
                           <Icon name={collapsed.has(key) ? "ph:caret-right" : "ph:caret-down"} width={10} />


### PR DESCRIPTION
Deferred follow-up from the Library review. The collapsible **group-header rows** (Tags / Domain) in the bookmarks and reading lists were `<tr onClick>` — collapsing/expanding a group was mouse-only.

Each group row now has `role="button"`, `tabIndex={0}`, `aria-expanded` (reflecting collapsed state), a `focus-ring-inset`, and an Enter/Space `onKeyDown` — so it's keyboard-operable and announced as an expandable control.

tsc clean; full `test:app` (336) and `test:mobile` (16) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)