### PR TITLE
fix(inspector): show search-no-results message for coven memory filter

### DIFF
--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -765,6 +765,8 @@ function MemoryTab({
                     Browse memory files →
                   </button>
                 </span>
+              ) : query.trim() ? (
+                `No coven memory matches “${query.trim()}”.`
               ) : familiar ? (
                 `No coven memory entries for ${familiar.display_name} yet.`
               ) : (


### PR DESCRIPTION
## What

When a coven-memory filter (search query) is active in the inspector pane and matches nothing — but entries do exist — the panel showed the genuinely-empty message *"No coven memory entries yet."* That reads as "you have no memory" when really the filter just didn't match.

This adds a distinct branch: **"No coven memory matches …"** when a query is active and `covenFiltered` is empty but `covenEntries` is not.

Same bug class previously fixed for Board (#1146) and Roles (#1152).

## Verify
- `inspector-pane-polish.test.ts` — pass (no pins on the empty copy)
- `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)