### PR TITLE
feat(settings): default the familiar top-bar style back to avatars

### DIFF
--- a/src/lib/familiar-switcher-style.test.ts
+++ b/src/lib/familiar-switcher-style.test.ts
@@ -9,7 +9,7 @@ import {
 
 // The two styles the top-bar control toggles between.
 assert.deepEqual([...FAMILIAR_SWITCHER_STYLE_OPTIONS], ["avatars", "dropdown"], "exactly two styles");
-assert.equal(DEFAULT_FAMILIAR_SWITCHER_STYLE, "dropdown", "default is the plain switcher dropdown");
+assert.equal(DEFAULT_FAMILIAR_SWITCHER_STYLE, "avatars", "default is the avatar quick-switch strip");
 
 // Every option has a human label.
 for (const option of FAMILIAR_SWITCHER_STYLE_OPTIONS) {

--- a/src/lib/familiar-switcher-style.ts
+++ b/src/lib/familiar-switcher-style.ts
@@ -4,9 +4,8 @@
  * User preference for how the familiar control renders in the top bars:
  *
  *   • "avatars"  — a row of one-tap avatars (pinned + most-recent) beside the
- *                  switcher menu (see FamiliarQuickSwitch).
- *   • "dropdown" — just the account-style switcher menu, no avatar strip
- *                  (the default).
+ *                  switcher menu (the default; see FamiliarQuickSwitch).
+ *   • "dropdown" — just the account-style switcher menu, no avatar strip.
  *
  * Cave-local, persisted in localStorage under `cave:familiar-switcher-style`.
  * Reactive via useSyncExternalStore so the top bars re-render the moment the
@@ -21,7 +20,7 @@ export const FAMILIAR_SWITCHER_STYLE_OPTIONS = ["avatars", "dropdown"] as const;
 
 export type FamiliarSwitcherStyle = (typeof FAMILIAR_SWITCHER_STYLE_OPTIONS)[number];
 
-export const DEFAULT_FAMILIAR_SWITCHER_STYLE = "dropdown" as const;
+export const DEFAULT_FAMILIAR_SWITCHER_STYLE = "avatars" as const;
 
 export const FAMILIAR_SWITCHER_STYLE_LABELS: Record<FamiliarSwitcherStyle, string> = {
   avatars: "Avatars",


### PR DESCRIPTION
Makes the **avatar quick-switch strip** the default top-bar familiar style again (reverting the #1239 default back to #1220's). The plain **Dropdown** remains selectable in Settings → Appearance → Familiar switcher → Top-bar style.

One-line change to `DEFAULT_FAMILIAR_SWITCHER_STYLE` + the store unit test.

- `pnpm typecheck`, `test:app` (336) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)