### PR TITLE
feat(workflows): skeleton placeholder while run history loads

### DIFF
--- a/src/components/workflows/workflow-runs-panel.tsx
+++ b/src/components/workflows/workflow-runs-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
+import { SkeletonRows } from "@/components/ui/skeleton";
 import { relativeTime } from "@/lib/relative-time";
 import { formatTimestamp } from "@/lib/datetime-format";
 import type { WorkflowPlaybackState } from "@/lib/workflow-playback";
@@ -77,6 +78,8 @@ export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayR
       </div>
       {!workflow ? (
         <p className="workflow-muted">Select a workflow to see its run history.</p>
+      ) : runs.length === 0 && loading ? (
+        <SkeletonRows count={3} className="workflow-runs-loading" />
       ) : runs.length === 0 && !loading ? (
         <p className="workflow-muted">
           No runs yet — dry-run snapshots and daemon executions land here.


### PR DESCRIPTION
## What

The Workflow Studio runs panel rendered a **blank body** during its initial load: when `loading` is true and no runs have arrived yet, the existing branches fell through to an empty `<ol>`, so only the heading's "loading" label hinted anything was happening.

This adds a `SkeletonRows` placeholder for that `runs.length === 0 && loading` case, matching the loading-skeleton pattern used elsewhere (e.g. the Coven Floor widget, #1244). The "No runs yet" empty state and the populated list are unchanged.

## Verify
- `workflow-studio.test.ts` — pass (pins on "No runs yet" copy + `WorkflowRunRecord` still satisfied)
- `pnpm build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)