### PR TITLE
fix(ui): name modal dialogs from breadcrumb + focus ring on AiToggle

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -315,6 +315,7 @@ export const SUITES = {
     "src/lib/recent-colors.test.ts",
     "src/components/ui/color-picker.test.ts",
     "src/components/ui/popover.test.ts",
+    "src/components/ui/modal.test.ts",
     "src/lib/workflow-source-bundle.test.ts",
     "src/lib/vault-bundle.test.ts",
     "src/lib/cave-board-atomic.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1367,6 +1367,11 @@ select {
   color: var(--foreground);
 }
 
+.ui-ai-toggle:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: var(--ring-offset);
+}
+
 /* When in Agent mode, replace the hairline border with a lavender
    gradient stroke. Implemented as a doubled background so the inner
    tile keeps the bg colour while the outer pseudo carries the

--- a/src/components/ui/modal.test.ts
+++ b/src/components/ui/modal.test.ts
@@ -1,0 +1,28 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./modal.tsx", import.meta.url), "utf8");
+
+// The dialog must carry an accessible name. Most call sites pass a breadcrumb and
+// no ariaLabel, so the breadcrumb header has to name the dialog via aria-labelledby
+// (fall back to aria-label only when there's no breadcrumb). Without this, screen
+// readers announce those dialogs with no title.
+assert.match(
+  src,
+  /aria-labelledby=\{breadcrumb \? headingId : undefined\}/,
+  "dialog names itself from the breadcrumb header when present",
+);
+assert.match(
+  src,
+  /aria-label=\{breadcrumb \? undefined : ariaLabel\}/,
+  "dialog falls back to ariaLabel only when there's no breadcrumb",
+);
+assert.match(src, /const headingId = useId\(\)/, "modal mints a stable id via useId");
+assert.match(
+  src,
+  /className="ui-modal-header-breadcrumb" id=\{headingId\}/,
+  "the breadcrumb header carries the id referenced by aria-labelledby",
+);
+
+console.log("modal.test.ts: ok");

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, type ReactNode } from "react";
+import { useId, useRef, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { Icon } from "@/lib/icon";
 import { useFocusTrap } from "@/lib/use-focus-trap";
@@ -34,6 +34,7 @@ export function Modal({
   ariaLabel,
 }: ModalProps) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
+  const headingId = useId();
 
   useFocusTrap(open, dialogRef, { onEscape: onClose });
 
@@ -51,12 +52,17 @@ export function Modal({
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
-        aria-label={ariaLabel}
+        // Prefer naming the dialog from its breadcrumb header (the common case —
+        // most call sites pass a breadcrumb and no ariaLabel). Without this the
+        // dialog announces with no accessible name. Fall back to ariaLabel only
+        // when there's no breadcrumb to point at.
+        aria-labelledby={breadcrumb ? headingId : undefined}
+        aria-label={breadcrumb ? undefined : ariaLabel}
         tabIndex={-1}
       >
         {breadcrumb ? (
           <header className="ui-modal-header">
-            <div className="ui-modal-header-breadcrumb">
+            <div className="ui-modal-header-breadcrumb" id={headingId}>
               {breadcrumb.map((segment, i) => (
                 <span key={i} className="contents">
                   {i > 0 ? (


### PR DESCRIPTION
Two verified a11y fixes on shared UI primitives (from a deep review of `src/components/ui/*`).

## 1. Modal dialogs had no accessible name
`Modal` set `aria-label={ariaLabel}`, but most call sites pass a `breadcrumb` and **no** `ariaLabel` — new-card-modal, csv-import-modal, and chooser-modal all do. Result: a screen reader opens those dialogs and announces just "dialog" with no title.

Fix: mint a stable `useId()`, put it on the breadcrumb header, and wire `aria-labelledby` to it when a breadcrumb is present. Fall back to `aria-label` only when there's no breadcrumb. Content-only change; very high blast radius (Modal backs ~8 surfaces).

## 2. AiToggle had no focus-visible ring
`.ui-ai-toggle` had only `:hover` and `--agent` rules — no `:focus-visible` — and the button carries no `focus-ring` class, so keyboard users got no focus indicator. Added the standard ring (`--ring-width`/`--ring-focus`/`--ring-offset`), matching `.focus-ring`.

## Tests
New `src/components/ui/modal.test.ts` source-text guard for the aria-labelledby/aria-label wiring; registered in `run-tests.mjs` (`check:tests-wired` green, 428 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)