### PR TITLE
refactor(board): share schedule helpers; flag overdue on the mobile rail

### DIFF
--- a/src/components/board-card-stack.tsx
+++ b/src/components/board-card-stack.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { Card, CardStatus } from "@/lib/cave-board-types";
+import { scheduleLabel, scheduleUrgency } from "@/lib/board-schedule";
 import { Icon } from "@/lib/icon";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { LifecycleBadge } from "@/components/ui/lifecycle-badge";
@@ -20,23 +21,6 @@ const SECTIONS: { id: CardStatus; label: string }[] = [
   { id: "blocked", label: "Blocked" },
   { id: "done", label: "Done" },
 ];
-
-function formatBoardDate(value: string | null | undefined): string {
-  if (!value) return "";
-  const [year, month, day] = value.split("-");
-  if (!year || !month || !day) return value;
-  return `${month}/${day}`;
-}
-
-function scheduleLabel(startDate: string | null | undefined, endDate: string | null | undefined): string {
-  if (startDate && endDate) {
-    if (startDate === endDate) return formatBoardDate(startDate);
-    return `${formatBoardDate(startDate)}-${formatBoardDate(endDate)}`;
-  }
-  if (startDate) return `Starts ${formatBoardDate(startDate)}`;
-  if (endDate) return `Ends ${formatBoardDate(endDate)}`;
-  return "";
-}
 
 type FilterValue = "all" | CardStatus;
 
@@ -74,6 +58,9 @@ export function BoardCardStack({
   chatLinkingId,
 }: Props) {
   const [filter, setFilter] = useState<FilterValue>("all");
+  // Resolved after mount so schedule-urgency colors stay hydration-safe.
+  const [todayMs, setTodayMs] = useState<number | null>(null);
+  useEffect(() => setTodayMs(Date.now()), []);
 
   const counts = useMemo(() => {
     const acc: Record<CardStatus, number> = {
@@ -141,6 +128,7 @@ export function BoardCardStack({
                   isSelected={card.id === selectedCardId}
                   onSelect={() => onSelect(card.id)}
                   onMoveStatus={(status) => onMoveStatus(card.id, status)}
+                  todayMs={todayMs}
                   onJumpToSession={onJumpToSession}
                   onOpenTaskChat={onOpenTaskChat}
                   chatLinking={chatLinkingId === card.id}
@@ -161,6 +149,7 @@ function BoardCardStackRow({
   isSelected,
   onSelect,
   onMoveStatus,
+  todayMs,
   onJumpToSession,
   onOpenTaskChat,
   chatLinking,
@@ -169,6 +158,7 @@ function BoardCardStackRow({
   familiars: Familiar[];
   sessions: SessionRow[];
   isSelected: boolean;
+  todayMs: number | null;
   onSelect: () => void;
   onMoveStatus: (status: CardStatus) => void;
   onJumpToSession?: (sessionId: string, familiarId: string | null) => void;
@@ -186,6 +176,7 @@ function BoardCardStackRow({
   const resolvedFamiliar = resolvedFamiliars[0] ?? null;
   const session = sessions.find((s) => s.id === card.sessionId) ?? null;
   const schedule = scheduleLabel(card.startDate, card.endDate);
+  const urgency = scheduleUrgency(card.endDate, card.status, todayMs);
 
   return (
     <li
@@ -223,8 +214,23 @@ function BoardCardStackRow({
             </span>
           </span>
           {schedule ? (
-            <span className="board-card-stack__row-schedule" title={`Scheduled ${schedule}`}>
-              <Icon name="ph:calendar-blank" width={11} />
+            <span
+              className={`board-card-stack__row-schedule${
+                urgency === "overdue"
+                  ? " board-card-stack__row-schedule--overdue"
+                  : urgency === "due-soon"
+                  ? " board-card-stack__row-schedule--due-soon"
+                  : ""
+              }`}
+              title={
+                urgency === "overdue"
+                  ? `Overdue \u2014 was due ${schedule}`
+                  : urgency === "due-soon"
+                  ? `Due soon \u2014 ${schedule}`
+                  : `Scheduled ${schedule}`
+              }
+            >
+              <Icon name={urgency === "overdue" ? "ph:warning-circle" : "ph:calendar-blank"} width={11} />
               {schedule}
             </span>
           ) : null}

--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { Card, CardStatus, CardPriority } from "@/lib/cave-board-types";
+import { scheduleLabel, scheduleUrgency } from "@/lib/board-schedule";
 import type { CaveProject } from "@/lib/cave-projects";
 import { LifecycleBadge } from "@/components/ui/lifecycle-badge";
 import { Icon } from "@/lib/icon";
@@ -26,45 +27,6 @@ const PRIORITIES: { id: CardPriority; label: string }[] = [
   { id: "medium", label: "Medium" },
   { id: "low",    label: "Low" },
 ];
-
-function formatBoardDate(value: string | null | undefined): string {
-  if (!value) return "";
-  const [year, month, day] = value.split("-");
-  if (!year || !month || !day) return value;
-  return `${month}/${day}`;
-}
-
-function scheduleLabel(startDate: string | null | undefined, endDate: string | null | undefined): string {
-  if (startDate && endDate) {
-    if (startDate === endDate) return formatBoardDate(startDate);
-    return `${formatBoardDate(startDate)}-${formatBoardDate(endDate)}`;
-  }
-  if (startDate) return `Starts ${formatBoardDate(startDate)}`;
-  if (endDate) return `Ends ${formatBoardDate(endDate)}`;
-  return "";
-}
-
-type ScheduleUrgency = "overdue" | "due-soon" | "none";
-
-// Whether a card's end date has passed (overdue) or is within two days (due
-// soon), used to color the schedule chip. Done cards never flag, and `todayMs`
-// is null until mount so the first client render matches SSR.
-function scheduleUrgency(
-  endDate: string | null | undefined,
-  status: CardStatus,
-  todayMs: number | null,
-): ScheduleUrgency {
-  if (!endDate || status === "done" || todayMs === null) return "none";
-  const [y, m, d] = endDate.split("-").map(Number);
-  if (!y || !m || !d) return "none";
-  const due = new Date(y, m - 1, d).getTime();
-  const now = new Date(todayMs);
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
-  const diffDays = Math.round((due - today) / 86_400_000);
-  if (diffDays < 0) return "overdue";
-  if (diffDays <= 2) return "due-soon";
-  return "none";
-}
 
 type Props = {
   cards: Card[];

--- a/src/lib/board-schedule.ts
+++ b/src/lib/board-schedule.ts
@@ -1,0 +1,48 @@
+import type { CardStatus } from "@/lib/cave-board-types";
+
+export type ScheduleUrgency = "overdue" | "due-soon" | "none";
+
+/** Compact "MM/DD" from an ISO date string ("2026-06-19" -> "06/19"). */
+export function formatBoardDate(value: string | null | undefined): string {
+  if (!value) return "";
+  const [year, month, day] = value.split("-");
+  if (!year || !month || !day) return value;
+  return `${month}/${day}`;
+}
+
+/** Compact schedule-window label shown on board cards (kanban + mobile rail). */
+export function scheduleLabel(
+  startDate: string | null | undefined,
+  endDate: string | null | undefined,
+): string {
+  if (startDate && endDate) {
+    if (startDate === endDate) return formatBoardDate(startDate);
+    return `${formatBoardDate(startDate)}-${formatBoardDate(endDate)}`;
+  }
+  if (startDate) return `Starts ${formatBoardDate(startDate)}`;
+  if (endDate) return `Ends ${formatBoardDate(endDate)}`;
+  return "";
+}
+
+/**
+ * Whether a card's end date has passed (overdue) or is within two days (due
+ * soon) — drives the schedule chip color on both the kanban and the mobile
+ * rail. Done cards never flag, and `todayMs` is null until mount so the first
+ * client render matches SSR (callers resolve it in an effect).
+ */
+export function scheduleUrgency(
+  endDate: string | null | undefined,
+  status: CardStatus,
+  todayMs: number | null,
+): ScheduleUrgency {
+  if (!endDate || status === "done" || todayMs === null) return "none";
+  const [y, m, d] = endDate.split("-").map(Number);
+  if (!y || !m || !d) return "none";
+  const due = new Date(y, m - 1, d).getTime();
+  const now = new Date(todayMs);
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const diffDays = Math.round((due - today) / 86_400_000);
+  if (diffDays < 0) return "overdue";
+  if (diffDays <= 2) return "due-soon";
+  return "none";
+}

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1143,10 +1143,12 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  color: var(--color-warning);
+  color: var(--text-secondary);
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
 }
+.board-card-stack__row-schedule--due-soon { color: var(--color-warning); }
+.board-card-stack__row-schedule--overdue { color: var(--color-danger); font-weight: 600; }
 .board-card-stack__row-action {
   margin-left: auto;
   display: inline-flex;


### PR DESCRIPTION
Follow-up to #1242. The kanban colors its schedule chip by urgency, but the **mobile task rail** still showed a plain always-amber chip — and both components duplicated `scheduleLabel`/`formatBoardDate`.

- **Dedup**: extract `scheduleLabel` / `formatBoardDate` / `scheduleUrgency` into a shared `src/lib/board-schedule.ts` (single source of truth); kanban + mobile rail both import it.
- **Mobile parity**: the rail's schedule chip is now urgency-colored — overdue (red, warning icon), due soon (amber), otherwise neutral. Hydration-safe today, done cards never flag.

Verified live on a mobile viewport: overdue→red `rgb(255,122,117)`, due-soon→amber `rgb(246,188,93)`, future→neutral (screenshot + chip-class/color assertions), matching the kanban exactly.

test:app (336) + test:mobile (16) + build green.
🤖 Generated with [Claude Code](https://claude.com/claude-code)