### PR TITLE
feat(familiars): skeleton for the inline card's memory peek while loading

### DIFF
--- a/src/components/familiar-inline-card.tsx
+++ b/src/components/familiar-inline-card.tsx
@@ -8,6 +8,7 @@ import { useFamiliarOverrides } from "@/lib/cave-familiar-overrides";
 import { resolveFamiliar } from "@/lib/familiar-resolve";
 import { useFamiliarStudio } from "@/lib/familiar-studio-context";
 import { Icon } from "@/lib/icon";
+import { SkeletonRows } from "@/components/ui/skeleton";
 import type { Familiar } from "@/lib/types";
 import {
   pickFamiliarMemory,
@@ -187,7 +188,7 @@ export function FamiliarInlineCard({
           </button>
         </div>
         {loading ? (
-          <div className="familiar-inline-card__memory-muted">Loading…</div>
+          <SkeletonRows count={3} className="familiar-inline-card__memory-loading" />
         ) : entries.length === 0 ? (
           <div className="familiar-inline-card__memory-muted">No memory yet</div>
         ) : (


### PR DESCRIPTION
## What

The familiar inline card's **"Recent memory"** block flashed a plain `Loading…` line before its entries arrived. This swaps it for `SkeletonRows`, matching the loading-skeleton pattern now used across the app (Coven Floor #1244, workflow runs #1249, journal #1251). The "No memory yet" empty state is unchanged.

## Verify
- `familiar-inline-card.test.ts` — pass (pins the "No memory yet" empty state)
- `pnpm build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)