### PR TITLE
fix(ui): give popovers an accessible name + return focus on close

### DIFF
--- a/src/components/board-card-stack.tsx
+++ b/src/components/board-card-stack.tsx
@@ -276,6 +276,7 @@ function BoardCardStackRow({
         anchorRef={menuButtonRef}
         placement="bottom-end"
         minWidth={180}
+        ariaLabel="Move card to section"
       >
         <PopoverBody>
           <PopoverLabel>Move to</PopoverLabel>

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -693,6 +693,7 @@ function SessionOverflowMenu({
         anchorRef={triggerRef}
         placement="bottom-end"
         minWidth={216}
+        ariaLabel="Chat options"
       >
         <PopoverBody>
           <PopoverItem

--- a/src/components/familiar-switcher.tsx
+++ b/src/components/familiar-switcher.tsx
@@ -144,6 +144,7 @@ export function FamiliarSwitcher({
         placement={placement}
         minWidth={264}
         className="familiar-switcher__popover"
+        ariaLabel="Switch familiar"
       >
         <div className="familiar-switcher" role="dialog" aria-label="Familiars">
           {/* Header: the current scope + a path straight into its full profile. */}

--- a/src/components/library-bookmarks-list.tsx
+++ b/src/components/library-bookmarks-list.tsx
@@ -288,6 +288,7 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
               placement="bottom-start"
               className="library-bookmark-selector__popover"
               minWidth={180}
+              ariaLabel="Choose bookmark group"
             >
               <PopoverBody>
                 <PopoverLabel>Group bookmarks</PopoverLabel>

--- a/src/components/theme-color-editor.tsx
+++ b/src/components/theme-color-editor.tsx
@@ -194,6 +194,7 @@ function ColorSlot({ label, description, value, onChange, themeSwatches, recents
         anchorRef={anchorRef}
         placement="bottom-start"
         offset={8}
+        ariaLabel="Color picker"
       >
         <div className="rounded-lg border border-[var(--border-strong)] bg-[var(--bg-elevated)] shadow-xl">
           <ColorPicker value={pickerHex} onChange={onChange} themeSwatches={themeSwatches} recents={recents} />

--- a/src/components/ui/popover.test.ts
+++ b/src/components/ui/popover.test.ts
@@ -33,4 +33,19 @@ assert.match(
   "recomputes when the visual viewport resizes (keyboard show/hide)",
 );
 
+// role="dialog" requires an accessible name. The popover takes an optional ariaLabel
+// prop and wires it onto the dialog; without it screen readers announce the popover
+// with no title.
+assert.match(src, /ariaLabel\?: string/, "popover accepts an ariaLabel prop");
+assert.match(src, /aria-label=\{ariaLabel\}/, "popover wires aria-label onto the dialog");
+
+// On close the popover returns focus to the trigger when focus would otherwise be
+// lost to document.body (Escape, item-select, outside-click on empty space), so
+// keyboard users aren't stranded — but leaves focus alone if moved to another control.
+assert.match(
+  src,
+  /active === document\.body[\s\S]{0,40}?anchor\?\.focus/,
+  "popover restores focus to the anchor when it would otherwise land on body",
+);
+
 console.log("popover.test.ts: ok");

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -24,6 +24,9 @@ export type PopoverProps = {
   /** Optional minimum width override; defaults to anchor width. */
   minWidth?: number;
   className?: string;
+  /** Accessible name for the dialog. role="dialog" requires a name; without one
+   *  screen readers announce the popover with no title. */
+  ariaLabel?: string;
   children: ReactNode;
 };
 
@@ -40,6 +43,7 @@ export function Popover({
   offset = 6,
   minWidth,
   className,
+  ariaLabel,
   children,
 }: PopoverProps) {
   const popoverRef = useRef<HTMLDivElement | null>(null);
@@ -145,6 +149,19 @@ export function Popover({
     };
   }, [open, onOpenChange, anchorRef, compute]);
 
+  // Return focus to the trigger when the popover closes, so keyboard users aren't
+  // stranded (Escape, item-select, or outside-click on empty space all leave focus
+  // on document.body once the popover unmounts). If the user moved focus to another
+  // control, leave it there — only reclaim focus when it would otherwise be lost.
+  useEffect(() => {
+    if (!open) return;
+    const anchor = anchorRef.current;
+    return () => {
+      const active = document.activeElement;
+      if (!active || active === document.body) anchor?.focus?.();
+    };
+  }, [open, anchorRef]);
+
   if (!open || typeof document === "undefined") return null;
 
   return createPortal(
@@ -154,6 +171,7 @@ export function Popover({
         className={["ui-popover", className ?? ""].filter(Boolean).join(" ")}
         style={style}
         role="dialog"
+        aria-label={ariaLabel}
       >
         {children}
       </div>


### PR DESCRIPTION
Third and final finding from the deep review of `src/components/ui/*`.

## Problem
`Popover` renders `role="dialog"` (popover.tsx) but:
1. Had **no accessible name** — ARIA requires dialogs to have one; screen readers announced every popover with no title.
2. Unlike `Modal`, it **never returned focus to its trigger on close**. After Escape or selecting an item, focus was stranded on `document.body`.

## Fix
- Add an optional `ariaLabel` prop, wired onto the dialog.
- On close, restore focus to the anchor **only when focus would otherwise be lost to `document.body`** (Escape, item-select, outside-click on empty space). If the user moved focus to another control, leave it — this matches the APG menu-button pattern and avoids stealing focus.
- Name all five call sites: **Move card to section** (board card menu), **Color picker** (theme editor), **Chat options** (chat header menu), **Switch familiar** (familiar switcher), **Choose bookmark group** (library).

## Tests
Extended `src/components/ui/popover.test.ts` with guards for the `ariaLabel` prop/wiring and the focus-restore-to-anchor behavior. Re-ran the 29 source-text tests touching the five edited call sites — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)