### PR TITLE
feat(dashboard): snooze the action inbox for a chosen duration

### DIFF
--- a/src/components/dashboard/action-inbox.tsx
+++ b/src/components/dashboard/action-inbox.tsx
@@ -8,11 +8,28 @@ import { nextItemsAfterAction } from "@/lib/dashboard-model";
 
 type Action = "done" | "dismiss" | "snooze";
 
+/** Snooze durations offered in the per-row menu. `minutes` resolves at click. */
+const SNOOZE_OPTIONS: { label: string; minutes: () => number }[] = [
+  { label: "1 hour", minutes: () => 60 },
+  { label: "3 hours", minutes: () => 180 },
+  { label: "Tomorrow morning", minutes: () => minutesUntilTomorrowMorning() },
+];
+
+/** Whole minutes from now until 9am the next calendar day. */
+function minutesUntilTomorrowMorning(): number {
+  const now = new Date();
+  const target = new Date(now);
+  target.setDate(target.getDate() + 1);
+  target.setHours(9, 0, 0, 0);
+  return Math.max(1, Math.round((target.getTime() - now.getTime()) / 60_000));
+}
+
 export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
   const [items, setItems] = useState<InboxItem[]>(initialItems);
   const [error, setError] = useState<string | null>(null);
+  const [snoozeOpenId, setSnoozeOpenId] = useState<string | null>(null);
 
-  async function act(item: InboxItem, action: Action) {
+  async function act(item: InboxItem, action: Action, minutes = 60) {
     const prev = items;
     setItems(nextItemsAfterAction(items, item.id)); // optimistic remove
     setError(null);
@@ -22,7 +39,7 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
           ? {
               method: "POST",
               headers: { "content-type": "application/json" },
-              body: JSON.stringify({ minutes: 60 }),
+              body: JSON.stringify({ minutes }),
             }
           : { method: "POST" };
       const res = await fetch(`/api/inbox/${item.id}/${action}`, init);
@@ -75,9 +92,44 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
                   Open
                 </a>
               ) : null}
-              <button type="button" className="dash-act" onClick={() => act(item, "snooze")}>
-                Snooze
-              </button>
+              <div className="dash-snooze">
+                <button
+                  type="button"
+                  className="dash-act"
+                  aria-haspopup="menu"
+                  aria-expanded={snoozeOpenId === item.id}
+                  onClick={() => setSnoozeOpenId(snoozeOpenId === item.id ? null : item.id)}
+                >
+                  Snooze
+                  <Icon name="ph:caret-down" aria-hidden />
+                </button>
+                {snoozeOpenId === item.id ? (
+                  <>
+                    <button
+                      type="button"
+                      className="dash-snooze__backdrop"
+                      aria-label="Close snooze menu"
+                      onClick={() => setSnoozeOpenId(null)}
+                    />
+                    <div className="dash-snooze__menu" role="menu" aria-label="Snooze for">
+                      {SNOOZE_OPTIONS.map((opt) => (
+                        <button
+                          key={opt.label}
+                          type="button"
+                          role="menuitem"
+                          className="dash-snooze__opt"
+                          onClick={() => {
+                            setSnoozeOpenId(null);
+                            void act(item, "snooze", opt.minutes());
+                          }}
+                        >
+                          {opt.label}
+                        </button>
+                      ))}
+                    </div>
+                  </>
+                ) : null}
+              </div>
               <button type="button" className="dash-act dash-act--primary" onClick={() => act(item, "done")}>
                 Done
               </button>

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -76,6 +76,46 @@
 .dash-act--ghost { padding: 5px 8px; color: var(--text-muted); }
 .dash-act--ghost svg { width: 15px; height: 15px; }
 
+/* Snooze split: button opens a small duration menu. */
+.dash-snooze { position: relative; display: inline-flex; }
+.dash-snooze .dash-act svg { width: 12px; height: 12px; opacity: 0.7; }
+.dash-snooze__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  background: transparent;
+  border: none;
+  cursor: default;
+}
+.dash-snooze__menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 31;
+  display: flex;
+  flex-direction: column;
+  min-width: 150px;
+  padding: 4px;
+  border-radius: 10px;
+  background: var(--bg-panel, var(--bg-base));
+  border: 1px solid var(--border-strong);
+  box-shadow: 0 10px 30px -12px rgb(0 0 0 / 0.45);
+}
+.dash-snooze__opt {
+  display: flex;
+  align-items: center;
+  padding: 7px 10px;
+  border: none;
+  border-radius: 6px;
+  background: none;
+  color: var(--text-primary);
+  font-size: 0.8rem;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+}
+.dash-snooze__opt:hover { background: var(--bg-hover, color-mix(in oklch, var(--foreground) 8%, transparent)); }
+
 /* Compact launcher (busy state): single dense row, hide subtitles. */
 .dr-quicklinks.dash-launcher--compact {
   grid-template-columns: repeat(4, minmax(0, 1fr));


### PR DESCRIPTION
## What

The dashboard **"Needs you"** inbox's Snooze button silently snoozed each item for a hardcoded **60 minutes** with no indication of how long. This replaces it with a small duration menu:

- **1 hour**
- **3 hours**
- **Tomorrow morning** (9am the next day)

Each option reuses the existing `/api/inbox/:id/snooze` `minutes` param — no API change. The button now exposes `aria-haspopup`/`aria-expanded`, the menu uses `role="menu"`/`role="menuitem"`, and a transparent backdrop closes it on outside click.

## Verify
- `dashboard-page.test.ts` — pass
- `pnpm build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)