### PR TITLE
fix(sidebar): make the nav rows fill the panel width

### DIFF
--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -8,7 +8,7 @@
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-  padding: 10px 8px 10px;
+  padding: 10px 6px 10px;
   font-size: 13px;
   color: var(--text-secondary);
   gap: 10px;
@@ -91,7 +91,7 @@
 
 /* ── Header CTA ──────────────────────────────────────────────────────────── */
 .sidebar-actions {
-  padding: 0 7px 6px;
+  padding: 0 0 6px;
   flex-shrink: 0;
 }
 
@@ -268,7 +268,7 @@
   /* Sections are separated by whitespace alone (no rules) for a calmer,
      Codex-style nav. */
   gap: 16px;
-  padding: 2px 4px 2px;
+  padding: 2px 0 2px;
 }
 
 /* ── Bottom: Notifications + Settings ─────────────────────────────────────── */
@@ -403,7 +403,7 @@
   align-items: center;
   gap: 8px;
   width: 100%;
-  margin: 12px 2px 2px;
+  margin: 12px 0 2px;
   padding: 4px 10px;
   border-radius: 7px;
   background: transparent;
@@ -944,10 +944,10 @@
    Collapsible "Recent Activity" list in the left panel, styled after the
    Superconductor activity sidebar: stacked cards with title · project · model ·
    +N -N diff · relative time, the active session marked by a left accent bar. */
-.recent-activity { display: flex; flex-direction: column; gap: 6px; padding: 0 2px; }
+.recent-activity { display: flex; flex-direction: column; gap: 6px; padding: 0; }
 /* Quiet eyebrow header, matching .sidebar-section-label so RECENT doesn't
    outweigh the nav items it sits beside. */
-.recent-activity__head { display: flex; align-items: center; justify-content: space-between; gap: 8px; width: 100%; margin: 12px 2px 2px; padding: 4px 10px; border: 1px solid transparent; border-radius: 7px; background: transparent;
+.recent-activity__head { display: flex; align-items: center; justify-content: space-between; gap: 8px; width: 100%; margin: 12px 0 2px; padding: 4px 10px; border: 1px solid transparent; border-radius: 7px; background: transparent;
   cursor: pointer; color: var(--text-secondary); transition: background 0.12s ease, color 0.12s ease; }
 .recent-activity__head:hover { background: var(--bg-raised); color: var(--text-primary); }
 .recent-activity__label { display: flex; align-items: center; gap: 8px; font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; }


### PR DESCRIPTION
## What

The left sidebar's nav rows (Home, Familiars, …), the **New chat** CTA, and the section labels were inset from the panel edges by a noticeable gutter. They now **fill the panel width**.

## Why

Each element stacked its own horizontal padding/margin on top of the shell's, adding up to a ~12–15px gutter that left the row backgrounds (and the New-chat pill / active highlight) floating well inside the panel. Harmonized to a single uniform ~6px gutter:

- `.sidebar-minimal` padding `10px 8px` → `10px 6px`
- `.sidebar-nav-scroll` `2px 4px` → `2px 0`
- `.sidebar-actions` (New chat) `0 7px 6px` → `0 0 6px`
- `.sidebar-section-label` + `.recent-activity__head` margin `12px 2px` → `12px 0`
- `.recent-activity` padding `0 2px` → `0`

Row **internal** padding is unchanged, so icons/labels keep their breathing room — only the row/background width grows, and everything aligns to one gutter.

## Verification

- Live-verified (web build, demo mode): rows, New chat, and section eyebrows fill the width and align to a consistent edge.
- `pnpm test:app` — ✓ 337 test file(s) passed.
- Built clean on current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)