### PR TITLE
fix(board): keyboard-operable sort headers, group rows, and swimlanes

### DIFF
--- a/src/components/board-kanban-keyboard.test.ts
+++ b/src/components/board-kanban-keyboard.test.ts
@@ -78,4 +78,8 @@ assert.match(
   "touch drop should reuse the board status move callback",
 );
 
+// Swimlane collapse is a real <button> with aria-expanded (keyboard-operable).
+assert.match(source, /board-swimlane-toggle/, "swimlane toggle is a button");
+assert.match(source, /aria-expanded=\{!isCollapsed\}/, "swimlane toggle announces expanded state");
+
 console.log("board-kanban-keyboard.test.ts OK");

--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -371,10 +371,17 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
         return (
           <div key={key} className={isMultiSwimlane ? "board-swimlane" : ""} style={isMultiSwimlane ? {} : { display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
             {showSwimlanes && (
-              <div className="board-swimlane-header" onClick={() => toggleGroup(key)}>
-                <Icon name={isCollapsed ? "ph:caret-right" : "ph:caret-down"} width={10} />
-                {label}
-                <span className="board-swimlane-badge">{gc.length}</span>
+              <div className="board-swimlane-header">
+                <button
+                  type="button"
+                  className="board-swimlane-toggle focus-ring"
+                  onClick={() => toggleGroup(key)}
+                  aria-expanded={!isCollapsed}
+                >
+                  <Icon name={isCollapsed ? "ph:caret-right" : "ph:caret-down"} width={10} />
+                  {label}
+                  <span className="board-swimlane-badge">{gc.length}</span>
+                </button>
                 {isMultiSwimlane && (
                   <div className="board-swimlane-scroll-group">
                     <button

--- a/src/components/board-table-keyboard.test.ts
+++ b/src/components/board-table-keyboard.test.ts
@@ -35,4 +35,11 @@ assert.match(
   "card rows expose data-card-id",
 );
 
+// Sortable headers: keyboard-operable <button> + aria-sort state announced.
+assert.match(source, /aria-sort=\{sortKey === col\.key/, "th announces aria-sort");
+assert.match(source, /board-table-sort-btn/, "header label is a real button");
+// Group rows: keyboard collapse/expand.
+assert.match(source, /board-table-group-row" role="button" tabIndex=\{0\}/, "group row is a button");
+assert.match(source, /aria-expanded=\{!collapsed\.has\(key\)\}/, "group row announces expanded state");
+
 console.log("board-table-keyboard.test.ts OK");

--- a/src/components/board-table.tsx
+++ b/src/components/board-table.tsx
@@ -179,13 +179,15 @@ export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId
             {COLS.map((col) => (
               <th key={col.key} style={col.width ? { width: col.width } : undefined}
                 className={sortKey === col.key ? "sorted" : ""}
-                onClick={() => handleCol(col.key)}>
-                {col.label}
-                <span className="board-table-sort-icon">
-                  {sortKey === col.key
-                    ? <Icon name={sortDir === "asc" ? "ph:caret-up" : "ph:caret-down-fill"} width={9} />
-                    : <Icon name="ph:caret-up-down" width={9} />}
-                </span>
+                aria-sort={sortKey === col.key ? (sortDir === "asc" ? "ascending" : "descending") : "none"}>
+                <button type="button" className="board-table-sort-btn focus-ring" onClick={() => handleCol(col.key)}>
+                  {col.label}
+                  <span className="board-table-sort-icon">
+                    {sortKey === col.key
+                      ? <Icon name={sortDir === "asc" ? "ph:caret-up" : "ph:caret-down-fill"} width={9} />
+                      : <Icon name="ph:caret-up-down" width={9} />}
+                  </span>
+                </button>
               </th>
             ))}
           </tr>
@@ -193,7 +195,10 @@ export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId
         <tbody ref={tbodyRef}>
           {groups.map(({ key, label, cards: gc }) => (
             <React.Fragment key={key}>
-              <tr key={`g-${key}`} className="board-table-group-row" onClick={() => toggleGroup(key)}>
+              <tr key={`g-${key}`} className="board-table-group-row" role="button" tabIndex={0}
+                aria-expanded={!collapsed.has(key)}
+                onClick={() => toggleGroup(key)}
+                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleGroup(key); } }}>
                 <td colSpan={COLS.length}>
                   <span className="board-table-group-caret">
                     <Icon name={collapsed.has(key) ? "ph:caret-right" : "ph:caret-down"} width={10} />

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -169,6 +169,7 @@
 .board-table { width:100%; border-collapse:collapse; font-size:12px; }
 .board-table thead th { position:sticky; top:0; background:var(--bg-base); border-bottom:1px solid var(--border-strong); padding:7px 10px; text-align:left; font-size:11px; font-weight:500; color:var(--text-muted); white-space:nowrap; z-index:10; cursor:pointer; user-select:none; }
 .board-table thead th:hover,.board-table thead th.sorted { color:var(--text-primary); }
+.board-table-sort-btn { display:inline-flex; align-items:center; width:100%; gap:0; padding:0; margin:0; background:none; border:none; font:inherit; color:inherit; letter-spacing:inherit; cursor:pointer; text-align:left; }
 .board-table-sort-icon { display:inline-flex; align-items:center; margin-left:3px; vertical-align:middle; opacity:0.6; }
 .board-table tbody tr { border-bottom:1px solid var(--border-hairline); cursor:pointer; transition:background .1s; }
 .board-table tbody tr:hover { background:var(--bg-hover); }
@@ -219,8 +220,9 @@
 .board-table-cell-time { color:var(--text-muted); font-size:11px; font-variant-numeric:tabular-nums; }
 
 .board-swimlane { flex-shrink:0; border-bottom:1px solid var(--border-hairline); }
-.board-swimlane-header { display:flex; align-items:center; gap:8px; padding:8px 16px 6px; font-size:11px; font-weight:600; color:var(--text-secondary); letter-spacing:.05em; text-transform:uppercase; cursor:pointer; user-select:none; }
-.board-swimlane-header:hover { color:var(--text-primary); }
+.board-swimlane-header { display:flex; align-items:center; gap:8px; padding:8px 16px 6px; font-size:11px; font-weight:600; color:var(--text-secondary); letter-spacing:.05em; text-transform:uppercase; user-select:none; }
+.board-swimlane-toggle { display:inline-flex; align-items:center; gap:8px; background:none; border:none; padding:0; margin:0; font:inherit; color:inherit; letter-spacing:inherit; text-transform:inherit; cursor:pointer; }
+.board-swimlane-toggle:hover { color:var(--text-primary); }
 .board-swimlane-badge { display:inline-flex; align-items:center; justify-content:center; min-width:18px; height:16px; padding:0 5px; border-radius:8px; background:var(--bg-raised); border:1px solid var(--border-hairline); color:var(--text-muted); font-size:10px; font-weight:500; }
 .board-swimlane-rail { overflow-x:auto; overflow-y:hidden; scroll-behavior:smooth; cursor:grab; touch-action:pan-x pan-y; }
 .board-swimlane-rail.board-kanban-rail-wrap--grabbing { cursor:grabbing; scroll-behavior:auto; user-select:none; }


### PR DESCRIPTION
Completes the table/board keyboard-a11y sweep already shipped for **GitHub (#1245)** and **Library (#1246)**, applied to the Board's own Table and Kanban surfaces.

## Fixes
1. **Table sortable headers** (`board-table.tsx`) — were `<th onClick>` with no `aria-sort` and no inner button. Screen readers couldn't announce sort state; keyboard users couldn't sort at all. Now the label is a real `<button class="board-table-sort-btn focus-ring">` and the `<th>` carries `aria-sort={ascending|descending|none}`.
2. **Table group rows** (`board-table.tsx`) — collapse/expand was `<tr onClick>` only. Added `role="button"`, `tabIndex={0}`, Enter/Space handler, and `aria-expanded`. (Verified the row has no nested interactive elements.)
3. **Kanban swimlane headers** (`board-kanban.tsx`) — collapse was `<div onClick>`. Wrapped the caret/label/badge in a `<button aria-expanded>`; the lane-scroll buttons stay siblings so we don't nest interactive elements.

CSS resets (`board.css`) keep the new buttons visually identical to the old headers (chrome stripped, typography inherited, full-cell width).

## Tests
Extended `board-table-keyboard.test.ts` (aria-sort, sort button, group-row role/aria-expanded) and `board-kanban-keyboard.test.ts` (swimlane toggle button + aria-expanded). Ran board-table-keyboard, board-kanban-keyboard, board-ux-polish, board-grouping — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)