### PR TITLE
feat(search): Escape clears the board and capabilities search fields

### DIFF
--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -334,6 +334,12 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
             className="board-search-input"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape" && searchQuery) {
+                e.preventDefault();
+                setSearchQuery("");
+              }
+            }}
             placeholder='Search tasks or type is:open cwd:coven-cave url:github'
           />
           {searchQuery ? (

--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -379,6 +379,12 @@ export function CapabilitiesViewSurface({
                     aria-label="Search capabilities"
                     value={query}
                     onChange={(e) => applyQueryFilter(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Escape" && query) {
+                        e.preventDefault();
+                        applyQueryFilter("");
+                      }
+                    }}
                     placeholder="Search skills, plugins, paths, commands"
                     className="min-w-0 flex-1 bg-transparent text-foreground outline-none placeholder:text-muted-foreground"
                   />


### PR DESCRIPTION
## What

Both the **board task search** and the **capabilities search** offered only a click target (or the browser's native widget) to clear a query — pressing **Escape**, the near-universal expectation in a search field, did nothing.

This adds an Escape-to-clear handler to both inputs. Escape is only consumed when there's a query to clear (`e.preventDefault()` guarded on a non-empty value), so an empty field still lets the key bubble (e.g. to close an enclosing surface).

## Verify
- `board-ux-polish.test.ts`, `capabilities-view.test.ts` — pass
- `pnpm build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)