### PR TITLE
feat(settings): drag-to-reorder pinned familiars in Appearance

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -326,6 +326,7 @@ export const SUITES = {
     "src/components/familiar-switcher.test.ts",
     "src/components/familiar-menu-bar.test.ts",
     "src/components/familiar-quick-switch.test.ts",
+    "src/components/familiar-pin-order.test.ts",
     "src/lib/familiar-quick-switch.test.ts",
     "src/lib/familiar-switcher-style.test.ts",
     "src/lib/salem/happy-paths.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5154,6 +5154,159 @@ button:active > .edge-rail-chip {
   box-shadow: 0 0 0 2px var(--bg-base);
 }
 
+/* ── Settings: pinned-familiar order ───────────────────────────────────────── */
+.familiar-pin-order {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.familiar-pin-order__hint {
+  margin: 0;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.familiar-pin-order__list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.familiar-pin-order__row {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.familiar-pin-order__row[data-dragging] {
+  opacity: 0.6;
+}
+
+.familiar-pin-order__handle {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  padding: 7px 8px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 8px;
+  background: var(--bg-base);
+  color: var(--text-secondary);
+  cursor: grab;
+  text-align: left;
+}
+
+.familiar-pin-order__handle:active {
+  cursor: grabbing;
+}
+
+.familiar-pin-order__grip {
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+.familiar-pin-order__avatar {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+}
+
+.familiar-pin-order__name {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.familiar-pin-order__role {
+  flex-shrink: 0;
+  max-width: 96px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.familiar-pin-order__unpin {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  flex-shrink: 0;
+  border: 1px solid var(--border-hairline);
+  border-radius: 8px;
+  background: var(--bg-base);
+  color: var(--accent-presence);
+  cursor: pointer;
+}
+
+.familiar-pin-order__unpin:hover {
+  background: var(--bg-hover);
+}
+
+.familiar-pin-order__add {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.familiar-pin-order__add-label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.familiar-pin-order__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.familiar-pin-order__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px 4px 5px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 999px;
+  background: var(--bg-base);
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--ease-standard),
+              border-color var(--duration-fast) var(--ease-standard),
+              background var(--duration-fast) var(--ease-standard);
+}
+
+.familiar-pin-order__chip:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+  border-color: color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 45%, var(--border-hairline));
+}
+
+.familiar-pin-order__chip-name {
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .familiar-switcher__sortable[data-dragging] {
   opacity: 0.6;
 }

--- a/src/components/familiar-pin-order.test.ts
+++ b/src/components/familiar-pin-order.test.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./familiar-pin-order.tsx", import.meta.url), "utf8");
+const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+
+// Sources its own roster (Settings has no workspace context) and resolves it.
+assert.match(
+  source,
+  /fetch\("\/api\/familiars"/,
+  "fetches the familiar roster",
+);
+assert.match(source, /useResolvedFamiliars\(rawFamiliars\)/, "resolves familiars (avatars/names)");
+assert.match(source, /useFamiliarPins\(\)/, "reads the current pin list");
+
+// Pinned familiars are drag-to-reorder and persisted via setPins(arrayMove(...)).
+assert.match(
+  source,
+  /setPins\(arrayMove\(pinnedIds, oldIndex, newIndex\)\)/,
+  "drag reorder persists the new pin order via setPins",
+);
+assert.match(source, /<DndContext[\s\S]*<SortableContext/, "uses dnd-kit sortable context");
+assert.match(source, /useSortable\(\{\s*id: familiar\.id/, "each pinned row is sortable by familiar id");
+
+// Unpin from a row; pin an unpinned familiar from the chip row.
+assert.match(
+  source,
+  /familiar-pin-order__unpin[\s\S]*onClick=\{\(\) => togglePin\(familiar\.id\)\}/,
+  "each pinned row has an unpin button",
+);
+assert.match(
+  source,
+  /familiar-pin-order__chip[\s\S]*onClick=\{\(\) => togglePin\(f\.id\)\}/,
+  "unpinned familiars can be pinned from the chip row",
+);
+
+// Empty state when nothing is pinned.
+assert.match(source, /No pinned familiars yet/, "shows an empty-state hint when no pins");
+
+// CSS hooks exist.
+assert.match(globals, /\.familiar-pin-order__row\[data-dragging\] \{/, "dragging row has a fade style");
+assert.match(globals, /\.familiar-pin-order__chip \{/, "pin chips are styled");
+
+console.log("familiar-pin-order component: all assertions passed");

--- a/src/components/familiar-pin-order.tsx
+++ b/src/components/familiar-pin-order.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { Icon } from "@/lib/icon";
+import { FamiliarAvatar } from "@/components/familiar-avatar";
+import { useResolvedFamiliars, type ResolvedFamiliar } from "@/lib/familiar-resolve";
+import { useFamiliarPins } from "@/lib/use-familiar-quick-switch";
+import { setPins, togglePin } from "@/lib/familiar-quick-switch";
+import { demoModeFetchHeaders, isDemoModeEnabled } from "@/lib/demo-mode";
+import { DEMO_FAMILIARS } from "@/lib/demo-seed";
+import type { Familiar } from "@/lib/types";
+import {
+  DndContext, PointerSensor, KeyboardSensor, useSensor, useSensors, closestCenter,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext, useSortable, arrayMove, sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
+/**
+ * Settings control for the order pinned familiars appear in the top-bar avatar
+ * strip. Pinned familiars are drag-to-reorder (persisted via `setPins`); each
+ * can be unpinned, and any unpinned familiar can be pinned from the chip row.
+ *
+ * Standalone like the other Settings panels — it sources its own familiar
+ * roster (resolved with cave overrides) rather than relying on workspace state.
+ */
+export function FamiliarPinOrder() {
+  const [rawFamiliars, setRawFamiliars] = useState<Familiar[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const resolved = useResolvedFamiliars(rawFamiliars);
+  const pins = useFamiliarPins();
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const res = await fetch("/api/familiars", { cache: "no-store", headers: demoModeFetchHeaders() });
+        const json = await res.json();
+        if (cancelled) return;
+        if (json.ok) setRawFamiliars((json.familiars ?? []) as Familiar[]);
+        else if (isDemoModeEnabled()) setRawFamiliars(DEMO_FAMILIARS);
+      } catch {
+        /* transient — keep last good list */
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    };
+    void load();
+    return () => { cancelled = true; };
+  }, []);
+
+  const byId = useMemo(() => {
+    const m = new Map<string, ResolvedFamiliar>();
+    resolved.forEach((f) => m.set(f.id, f));
+    return m;
+  }, [resolved]);
+
+  // Pinned, in pin order, dropping any that no longer exist.
+  const pinned = useMemo(
+    () => pins.map((id) => byId.get(id)).filter((f): f is ResolvedFamiliar => Boolean(f)),
+    [pins, byId],
+  );
+  const unpinned = useMemo(
+    () => resolved.filter((f) => !pins.includes(f.id)),
+    [resolved, pins],
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+  const pinnedIds = useMemo(() => pinned.map((f) => f.id), [pinned]);
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = pinnedIds.indexOf(String(active.id));
+    const newIndex = pinnedIds.indexOf(String(over.id));
+    if (oldIndex < 0 || newIndex < 0) return;
+    setPins(arrayMove(pinnedIds, oldIndex, newIndex));
+  }
+
+  if (!loaded) {
+    return <p className="familiar-pin-order__hint" role="status" aria-busy="true">Loading familiars…</p>;
+  }
+
+  return (
+    <div className="familiar-pin-order">
+      {pinned.length > 0 ? (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={pinnedIds} strategy={verticalListSortingStrategy}>
+            <ul className="familiar-pin-order__list" aria-label="Reorder pinned familiars">
+              {pinned.map((f) => (
+                <SortablePinRow key={f.id} familiar={f} />
+              ))}
+            </ul>
+          </SortableContext>
+        </DndContext>
+      ) : (
+        <p className="familiar-pin-order__hint">
+          No pinned familiars yet — pin one below to keep it at the front of the avatar strip.
+        </p>
+      )}
+
+      {unpinned.length > 0 ? (
+        <div className="familiar-pin-order__add">
+          <span className="familiar-pin-order__add-label">Add a pin</span>
+          <ul className="familiar-pin-order__chips" aria-label="Pin a familiar">
+            {unpinned.map((f) => (
+              <li key={f.id}>
+                <button
+                  type="button"
+                  className="familiar-pin-order__chip focus-ring"
+                  style={{ ["--familiar-accent" as string]: f.color } as CSSProperties}
+                  onClick={() => togglePin(f.id)}
+                  aria-label={`Pin ${f.display_name}`}
+                  title={`Pin ${f.display_name}`}
+                >
+                  <FamiliarAvatar familiar={f} size="sm" />
+                  <span className="familiar-pin-order__chip-name">{f.display_name}</span>
+                  <Icon name="ph:push-pin" width={11} aria-hidden />
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SortablePinRow({ familiar }: { familiar: ResolvedFamiliar }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: familiar.id,
+  });
+  const style: CSSProperties = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+    ["--familiar-accent" as string]: familiar.color,
+  } as CSSProperties;
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className="familiar-pin-order__row"
+      data-dragging={isDragging || undefined}
+    >
+      <button
+        type="button"
+        className="familiar-pin-order__handle"
+        {...attributes}
+        {...listeners}
+        aria-label={`Drag to reorder ${familiar.display_name}`}
+      >
+        <Icon name="ph:dots-six-vertical" width={13} className="familiar-pin-order__grip" aria-hidden />
+        <span className="familiar-pin-order__avatar">
+          <FamiliarAvatar familiar={familiar} size="sm" />
+        </span>
+        <span className="familiar-pin-order__name">{familiar.display_name}</span>
+        {familiar.role ? <span className="familiar-pin-order__role">{familiar.role}</span> : null}
+      </button>
+      <button
+        type="button"
+        className="familiar-pin-order__unpin focus-ring"
+        onClick={() => togglePin(familiar.id)}
+        aria-label={`Unpin ${familiar.display_name}`}
+        title="Unpin from quick switch"
+      >
+        <Icon name="ph:push-pin-fill" width={12} aria-hidden />
+      </button>
+    </li>
+  );
+}

--- a/src/components/settings-appearance.test.ts
+++ b/src/components/settings-appearance.test.ts
@@ -332,6 +332,16 @@ assert.match(
   /setFamiliarSwitcherStyle\(option\)/,
   "the familiar-switcher control writes the chosen style preference",
 );
+assert.match(
+  settings,
+  /Pin order[\s\S]*<FamiliarPinOrder \/>/,
+  "the avatar style exposes a drag-to-reorder pin-order manager",
+);
+assert.match(
+  settings,
+  /familiarSwitcherStyle === "avatars" \?[\s\S]*<FamiliarPinOrder/,
+  "the pin-order manager only shows for the avatar strip style",
+);
 
 // Corner radius drives the shared --radius tokens app-wide, so its boot block
 // must run before paint (ThemeScript) and its controller must mount in layout.

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -6,6 +6,7 @@ import { Icon } from "@/lib/icon";
 import { SettingsGroup } from "@/components/ui/settings-group";
 import { FamiliarStudioInlinePanel } from "@/components/familiar-studio-inline";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
+import { FamiliarPinOrder } from "@/components/familiar-pin-order";
 import { DEMO_FAMILIARS } from "@/lib/demo-seed";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { OpenCovenToolsUpdate } from "@/components/open-coven-tools-update";
@@ -1145,6 +1146,22 @@ function AppearanceSection() {
             })}
           </div>
         </div>
+
+        {/* Pin order — only meaningful for the avatar strip, so it follows the
+            style toggle and shows only when that style is active. */}
+        {familiarSwitcherStyle === "avatars" ? (
+          <div className="border-t border-[var(--border-hairline)] px-4 py-3">
+            <div className="mb-2 min-w-0">
+              <div className="text-[12px] font-medium text-[var(--text-secondary)]">
+                Pin order
+              </div>
+              <div className="text-[11px] text-[var(--text-muted)]">
+                Drag to set the order pinned familiars appear in the avatar strip.
+              </div>
+            </div>
+            <FamiliarPinOrder />
+          </div>
+        ) : null}
       </SettingsGroup>
 
       {/* ── Corner radius ── a minor shape tweak (drives the shared --radius

--- a/src/lib/familiar-quick-switch.test.ts
+++ b/src/lib/familiar-quick-switch.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { computeQuickSwitch, QUICK_SWITCH_MAX } from "./familiar-quick-switch.ts";
+import { computeQuickSwitch, QUICK_SWITCH_MAX, getPins, setPins, togglePin } from "./familiar-quick-switch.ts";
 
 const fam = (id, extra = {}) => ({ id, last_seen: undefined, ...extra });
 
@@ -57,6 +57,22 @@ const fam = (id, extra = {}) => ({ id, last_seen: undefined, ...extra });
   const familiars = [fam("a"), fam("b")];
   const out = computeQuickSwitch(familiars, { pins: ["a"], activeId: "a", lastUsed: { a: 5 } });
   assert.deepEqual(out.map((f) => f.id), ["a", "b"], "an id appears at most once");
+}
+
+// setPins replaces the whole pin list in the given order (drag-to-reorder),
+// deduping; togglePin removes a pin. (No window in Node → state lives in the
+// module cache, which is what the hooks read.)
+{
+  setPins(["c", "a", "b"]);
+  assert.deepEqual(getPins(), ["c", "a", "b"], "setPins establishes a new order");
+  setPins(["b", "c", "a"]);
+  assert.deepEqual(getPins(), ["b", "c", "a"], "setPins reorders");
+  setPins(["a", "a", "b"]);
+  assert.deepEqual(getPins(), ["a", "b"], "setPins dedupes");
+  togglePin("a");
+  assert.deepEqual(getPins(), ["b"], "togglePin removes an existing pin");
+  setPins([]);
+  assert.deepEqual(getPins(), [], "setPins can clear all pins");
 }
 
 console.log("familiar-quick-switch: all assertions passed");

--- a/src/lib/familiar-quick-switch.ts
+++ b/src/lib/familiar-quick-switch.ts
@@ -85,6 +85,12 @@ export function togglePin(id: string): void {
   writePins(current.includes(id) ? current.filter((x) => x !== id) : [...current, id]);
 }
 
+/** Replace the full pin list in a new order (e.g. drag-to-reorder in Settings).
+ *  Deduped on write; the sequence given becomes the strip's pin order. */
+export function setPins(ids: string[]): void {
+  writePins(ids);
+}
+
 // ── last-used recency ────────────────────────────────────────────────────────
 
 let cachedLastUsed: Record<string, number> | null = null;


### PR DESCRIPTION
## What

Adds a **Pin order** manager in **Settings → Appearance → Familiar switcher** (shown when the Top-bar style is *Avatars*) to control the order pinned familiars appear in the top-bar quick-switch strip.

- **Drag to reorder** pinned familiars (dnd-kit), persisted to the pin list.
- **Unpin** any pinned familiar from its row.
- **Add a pin** — pin any not-yet-pinned familiar from a chip row.
- Empty state when nothing is pinned.

## Files

- `src/lib/familiar-quick-switch.ts` — new `setPins(ids)` export (replace the pin list in order; deduped). Mirrors `togglePin`.
- `src/components/familiar-pin-order.tsx` — the manager; self-sources `/api/familiars` → `useResolvedFamiliars`, reuses the familiar-switcher dnd-kit reorder pattern.
- `src/components/settings-shell.tsx` — renders it under the Familiar switcher group, gated on the avatars style.
- CSS for the reorder rows + chips.

## Tests

- `setPins` reorder/dedupe/clear added to the store test.
- New source-text test for `FamiliarPinOrder`; settings-appearance test asserts the gated Pin-order manager.
- `pnpm typecheck`, `test:app` (338), `test:mobile` (16), `build`, tests-wired guard all green locally.
- Live-verified: seeded 2 pins → 2 reorder rows + 9 add-chips; clicking a chip appended the pin and persisted to `cave:familiar-pins:v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)