### PR TITLE
feat(search): Escape clears the projects filter and sessions search

### DIFF
--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -683,6 +683,12 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               type="text"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape" && search) {
+                  e.preventDefault();
+                  setSearch("");
+                }
+              }}
               placeholder="Search sessions…"
               className="min-w-0 flex-1 bg-transparent text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none"
             />

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -695,6 +695,12 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: Pr
               type="search"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Escape" && query) {
+                  event.preventDefault();
+                  setQuery("");
+                }
+              }}
               placeholder="Filter projects by name or path…"
               aria-label="Filter projects"
               className="focus-ring h-8 w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] pl-8 pr-2.5 text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"


### PR DESCRIPTION
## What

Follow-up to #1276 (board + capabilities Escape-to-clear). The **Projects tab filter** and the **chat sessions search** are the remaining major search fields, and neither cleared on Escape.

This adds the same guarded handler to both: Escape clears a non-empty query, and an empty field still lets the key bubble. Escape-to-clear is now consistent across all four primary search inputs.

## Verify
- `projects-view.test.ts`, `chat-list-mobile-rail-port.test.ts` — pass
- `pnpm build` — clean (runs test:app + test:mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)