### PR TITLE
feat(board): card + Gantt dates honor the date-order preference

### DIFF
--- a/src/components/board-card-stack.tsx
+++ b/src/components/board-card-stack.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { Card, CardStatus } from "@/lib/cave-board-types";
 import { scheduleLabel, scheduleUrgency } from "@/lib/board-schedule";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 import { Icon } from "@/lib/icon";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { LifecycleBadge } from "@/components/ui/lifecycle-badge";
@@ -61,6 +62,8 @@ export function BoardCardStack({
   // Resolved after mount so schedule-urgency colors stay hydration-safe.
   const [todayMs, setTodayMs] = useState<number | null>(null);
   useEffect(() => setTodayMs(Date.now()), []);
+  // Re-render card dates when the date-format preference changes.
+  useDateTimePrefs();
 
   const counts = useMemo(() => {
     const acc: Record<CardStatus, number> = {

--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import type { Card } from "@/lib/cave-board-types";
+import { useDateTimePrefs, readDateTimePrefs } from "@/lib/datetime-format";
 
 type Props = {
   cards: Card[];
@@ -22,7 +23,10 @@ function parseDate(value: string | null | undefined): Date | null {
 }
 
 function formatLabel(date: Date): string {
-  return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", timeZone: "UTC" }).format(date);
+  const month = new Intl.DateTimeFormat("en-US", { month: "short", timeZone: "UTC" }).format(date);
+  const day = date.getUTCDate();
+  // Order by the user's date preference (month-first vs day-first).
+  return readDateTimePrefs().date === "ddmm" ? `${day} ${month}` : `${month} ${day}`;
 }
 
 function daysBetween(start: Date, end: Date): number {
@@ -35,6 +39,8 @@ export function BoardGantt({ cards, selectedCardId, onSelect }: Props) {
   // after mount — the line simply isn't drawn for the first client render.
   const [todayMs, setTodayMs] = useState<number | null>(null);
   useEffect(() => setTodayMs(Date.now()), []);
+  // Re-render axis + row dates when the date-format preference changes.
+  useDateTimePrefs();
 
   const scheduled: ScheduledCard[] = [];
   const unscheduled: Card[] = [];

--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { Card, CardStatus, CardPriority } from "@/lib/cave-board-types";
 import { scheduleLabel, scheduleUrgency } from "@/lib/board-schedule";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 import type { CaveProject } from "@/lib/cave-projects";
 import { LifecycleBadge } from "@/components/ui/lifecycle-badge";
 import { Icon } from "@/lib/icon";
@@ -82,6 +83,8 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
   // mismatch (the server has no "now").
   const [todayMs, setTodayMs] = useState<number | null>(null);
   useEffect(() => setTodayMs(Date.now()), []);
+  // Re-render card dates when the date-format preference changes.
+  useDateTimePrefs();
   const { announce } = useAnnouncer();
   const draggingIdRef = useRef<string | null>(null);
   const railRefs = useRef<Map<string, HTMLDivElement>>(new Map());

--- a/src/lib/board-schedule.ts
+++ b/src/lib/board-schedule.ts
@@ -1,13 +1,17 @@
 import type { CardStatus } from "@/lib/cave-board-types";
+import { readDateTimePrefs } from "@/lib/datetime-format";
 
 export type ScheduleUrgency = "overdue" | "due-soon" | "none";
 
-/** Compact "MM/DD" from an ISO date string ("2026-06-19" -> "06/19"). */
+/**
+ * Compact board date from an ISO date string ("2026-06-19"), ordered by the
+ * user's date preference: "06/19" (month-first) or "19/06" (day-first).
+ */
 export function formatBoardDate(value: string | null | undefined): string {
   if (!value) return "";
   const [year, month, day] = value.split("-");
   if (!year || !month || !day) return value;
-  return `${month}/${day}`;
+  return readDateTimePrefs().date === "ddmm" ? `${day}/${month}` : `${month}/${day}`;
 }
 
 /** Compact schedule-window label shown on board cards (kanban + mobile rail). */


### PR DESCRIPTION
The board was the last surface ignoring the 12h/24h + date-order preference: schedule chips (`formatBoardDate`) and the Gantt axis/row dates (`formatLabel`) always rendered month-first (`MM/DD`, `Jun 19`).

Both now order by the user's setting — day-first users see `DD/MM` and `19 Jun` on the board too. The board components subscribe via `useDateTimePrefs()` so a pref change re-renders live; **no signature changes** (so existing tests are untouched).

Verified live — Gantt under `DD.MM`: axis `16 Jun … 25 Jun`, rows `16 Jun–22 Jun · 7d`; under `MM.DD`: `Jun 16 … Jun 25`, `Jun 16–Jun 22 · 7d`. Card chips use the same shared `formatBoardDate`.

test:app (338) + test:mobile (16) + build green. Closes the board's part of the timestamp-consistency arc.
🤖 Generated with [Claude Code](https://claude.com/claude-code)