### PR TITLE
fix(familiars): accessible shared Tabs for detail panel + memory toggle focus ring

### DIFF
--- a/src/components/familiars-memory-reader.test.ts
+++ b/src/components/familiars-memory-reader.test.ts
@@ -36,4 +36,7 @@ assert.match(source, /isFileLoading \?[\s\S]*?<Skeleton[^>]*variant="text"/, "lo
 assert.doesNotMatch(source, />Loading memory…</, "reader no longer shows a bare 'Loading memory…' line");
 assert.match(source, /fileError \?[\s\S]*?<ErrorState/, "file load failure uses the shared ErrorState");
 
+// Rendered/Raw toggle segments show a visible keyboard focus ring.
+assert.match(source, /focus-ring-inset px-2 py-1 transition-colors/, "rendered/raw toggle has a focus ring");
+
 console.log("familiars-memory-reader: all assertions passed");

--- a/src/components/familiars-memory-reader.tsx
+++ b/src/components/familiars-memory-reader.tsx
@@ -95,7 +95,7 @@ export function MemoryReaderPane({
                   type="button"
                   aria-pressed={mode === m}
                   onClick={() => setMode(m)}
-                  className={`px-2 py-1 transition-colors ${
+                  className={`focus-ring-inset px-2 py-1 transition-colors ${
                     mode === m
                       ? "bg-[var(--accent-presence)]/15 text-[var(--text-primary)]"
                       : "text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]"

--- a/src/components/familiars-view.test.ts
+++ b/src/components/familiars-view.test.ts
@@ -222,4 +222,11 @@ assert.match(
   "Daily Notes tab renders FamiliarDailyNotes scoped to the selected familiar",
 );
 
+// Detail tabs use the shared accessible <Tabs> (role=tab/aria-selected/roving),
+// not a hand-rolled button strip with aria-current="page".
+assert.match(source, /import \{ Tabs \} from "@\/components\/ui\/tabs"/, "imports shared Tabs");
+assert.match(source, /<Tabs[\s\S]{0,200}?idPrefix="familiar-detail"/, "detail panel uses shared Tabs with idPrefix");
+assert.match(source, /role="tabpanel"[\s\S]{0,120}?aria-labelledby=\{`familiar-detail-tab-/, "content area is a labelled tabpanel");
+assert.doesNotMatch(source, /aria-current=\{tab === id \? "page"/, "old aria-current=page tab pattern is gone");
+
 console.log("familiars-view: all assertions passed");

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { Tabs } from "@/components/ui/tabs";
 // Shared relative-time formatter, imported as `age` so the call sites read the
 // same — standardizes this surface on the app-wide "2m ago / 3h ago / Jun 12" style.
 import { relativeTime as age } from "@/lib/relative-time";
@@ -620,25 +621,21 @@ function FamiliarDetailPanel({
         </div>
       </header>
 
-      <div className="flex shrink-0 border-b border-[var(--border-hairline)] px-3">
-        {DETAIL_TABS.map(({ id, label }) => (
-          <button
-            key={id}
-            type="button"
-            onClick={() => setTab(id)}
-            className={`focus-ring familiars-view__tab inline-flex h-9 items-center gap-1.5 px-3 text-[12px] transition-colors ${
-              tab === id
-                ? "border-b-2 border-[var(--accent-presence)] text-[var(--text-primary)]"
-                : "border-b-2 border-transparent text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
-            }`}
-            aria-current={tab === id ? "page" : undefined}
-          >
-            {label}
-          </button>
-        ))}
-      </div>
+      <Tabs
+        items={DETAIL_TABS}
+        value={tab}
+        onChange={setTab}
+        ariaLabel="Familiar details"
+        idPrefix="familiar-detail"
+        className="shrink-0 px-3"
+      />
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div
+        className="flex min-h-0 flex-1 flex-col overflow-hidden"
+        role="tabpanel"
+        id={`familiar-detail-panel-${tab}`}
+        aria-labelledby={`familiar-detail-tab-${tab}`}
+      >
         {tab === "memory" ? (
           <FamiliarsMemoryView
             familiars={familiars}


### PR DESCRIPTION
Two verified a11y fixes on the Familiars surface.

## 1. Detail-panel tabs used the wrong ARIA pattern
The familiar detail panel's **Memory / Daily Notes / Files / Sessions** tabs were a hand-rolled `<button>` strip with `aria-current="page"` — the breadcrumb/nav idiom, not the tab idiom. No `role="tablist"`/`role="tab"`, no `aria-selected`, no `role="tabpanel"`, and no arrow-key navigation. Screen readers announced them as generic buttons in a confusing "current page" state.

The codebase already has a canonical shared `<Tabs>` primitive (`ui/tabs.tsx`) with `role=tab`/`aria-selected`/roving arrow-key nav built in, which **chat-surface, inspector-pane, workflow-studio, and board-card-stack** already delegate to (and Familiar Studio's tabs were already converted — see `familiar-studio-tabs.test.ts`). This swaps the detail panel onto it and marks the content area as a labelled `role="tabpanel"`. The `familiars-view__tab` class had **no CSS** (styling was inline Tailwind), so this is pure markup with the same underline visual language.

## 2. Memory reader Rendered/Raw toggle had no visible focus
`familiars-memory-reader.tsx` — the two segmented toggle buttons had `aria-pressed` but no focus-ring class, while their sibling Expand button uses `focus-ring`. Keyboard focus was invisible. Added `focus-ring-inset` (inset so the `overflow-hidden` pill border can't clip the outline).

## Tests
Extended `familiars-view.test.ts` (asserts shared Tabs import + `idPrefix`, labelled tabpanel, and that the old `aria-current=page` pattern is gone) and `familiars-memory-reader.test.ts` (focus ring on the toggle). Ran the six familiars/memory source-text tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)