### PR TITLE
feat(new-chat): show the familiar's avatar on recent threads

### DIFF
--- a/src/components/new-chat-launch.tsx
+++ b/src/components/new-chat-launch.tsx
@@ -79,14 +79,20 @@ export function NewChatLaunch({
           <div className="cave-launch__section" aria-label="Recent threads">
             <p className="cave-launch__label">Pick up where you left off</p>
             <div className="cave-launch__recents">
-              {recents.map((s) => (
+              {recents.map((s) => {
+                const fam = s.familiarId ? resolved.find((f) => f.id === s.familiarId) : undefined;
+                return (
                 <button
                   key={s.id}
                   type="button"
                   className="cave-launch__recent"
                   onClick={() => onResume(s.id)}
                 >
-                  <Icon name="ph:chat-circle-dots" width={15} className="cave-launch__recent-icon" aria-hidden />
+                  {fam ? (
+                    <FamiliarAvatar familiar={fam} size="sm" className="cave-launch__recent-icon" />
+                  ) : (
+                    <Icon name="ph:chat-circle-dots" width={15} className="cave-launch__recent-icon" aria-hidden />
+                  )}
                   <span className="cave-launch__recent-copy">
                     <span className="cave-launch__recent-title">{s.title || "New chat"}</span>
                     <span className="cave-launch__recent-meta">
@@ -96,7 +102,8 @@ export function NewChatLaunch({
                   </span>
                   <Icon name="ph:arrow-right-bold" width={12} className="cave-launch__recent-go" aria-hidden />
                 </button>
-              ))}
+                );
+              })}
             </div>
           </div>
         ) : null}


### PR DESCRIPTION
## What

The new-chat launch surface's **"Pick up where you left off"** recents all rendered the same generic chat icon, even though the surface already resolves familiars for the familiar grid directly above it. This renders each recent thread's **familiar avatar** instead (falling back to the chat icon when a session has no resolved familiar), so threads are recognizable by who handles them — matching the grid.

Reuses `FamiliarAvatar` (`size="sm"`) exactly as the familiar grid in the same file already does.

## Verify
- `pnpm build` — clean (runs test:app + test:mobile); no tests pin the recents markup
- Note: the empty new-chat launch state isn't reachable in demo mode (demo always has an active familiar chat), so this was verified via the build + the identical, already-proven `FamiliarAvatar` usage in the grid above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)