### PR TITLE
feat(sessions): absolute-time tooltip on recent-session timestamps

### DIFF
--- a/src/components/new-chat-launch.tsx
+++ b/src/components/new-chat-launch.tsx
@@ -4,6 +4,7 @@ import { Icon } from "@/lib/icon";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { relativeTime } from "@/lib/relative-time";
+import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 import type { Familiar, SessionRow } from "@/lib/types";
 
 /**
@@ -95,7 +96,10 @@ export function NewChatLaunch({
                   )}
                   <span className="cave-launch__recent-copy">
                     <span className="cave-launch__recent-title">{s.title || "New chat"}</span>
-                    <span className="cave-launch__recent-meta">
+                    <span
+                      className="cave-launch__recent-meta"
+                      title={s.updated_at ? formatTimestamp(s.updated_at, readDateTimePrefs()) : undefined}
+                    >
                       {famName(s.familiarId) ? `${famName(s.familiarId)} · ` : ""}
                       {relativeTime(s.updated_at)}
                     </span>

--- a/src/components/recent-activity-rollup.tsx
+++ b/src/components/recent-activity-rollup.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { relativeTime } from "@/lib/relative-time";
+import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 import { modelIcon } from "@/lib/model-label";
 import type { SessionRow } from "@/lib/types";
 
@@ -134,7 +135,12 @@ export function RecentActivityRollup({ activeSessionId, onOpenSession }: Props) 
                           <span className="recent-activity__del">−{del}</span>
                         </span>
                       ) : null}
-                      <span className="recent-activity__time">{relativeTime(s.updated_at)}</span>
+                      <span
+                        className="recent-activity__time"
+                        title={s.updated_at ? formatTimestamp(s.updated_at, readDateTimePrefs()) : undefined}
+                      >
+                        {relativeTime(s.updated_at)}
+                      </span>
                     </span>
                   </div>
                 </button>


### PR DESCRIPTION
## What

The **Recent Activity** roll-up (left sidebar) and the new-chat **"Pick up where you left off"** recents both showed only a relative time ("2h ago") with no way to see the exact moment.

This adds a pref-aware absolute-time tooltip (`formatTimestamp` + `readDateTimePrefs`) on each timestamp — hovering reveals e.g. `06.20 2:14 PM`, honoring the user's clock/date prefs. Matches the "Last refreshed" tooltip pattern from the familiars memory view (#1243).

## Verify
- `recent-activity-rollup.test.ts` — pass; `pnpm build` — clean
- Note: the roll-up needs daemon-backed `/api/sessions/list` rows to render, which demo mode doesn't provide, so this was verified via the build + the proven `formatTimestamp` helper (purely additive `title` attribute, no layout/logic change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)