### PR TITLE
fix(dashboard): keyboard-operable snooze menu

### DIFF
--- a/src/components/dashboard/action-inbox.tsx
+++ b/src/components/dashboard/action-inbox.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 import type { InboxItem } from "@/lib/cave-inbox";
 import { KIND_ICON, KIND_LABEL, itemHasTarget, itemHref, relativeTime } from "@/lib/daily-report";
 import { nextItemsAfterAction } from "@/lib/dashboard-model";
@@ -92,44 +93,15 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
                   Open
                 </a>
               ) : null}
-              <div className="dash-snooze">
-                <button
-                  type="button"
-                  className="dash-act"
-                  aria-haspopup="menu"
-                  aria-expanded={snoozeOpenId === item.id}
-                  onClick={() => setSnoozeOpenId(snoozeOpenId === item.id ? null : item.id)}
-                >
-                  Snooze
-                  <Icon name="ph:caret-down" aria-hidden />
-                </button>
-                {snoozeOpenId === item.id ? (
-                  <>
-                    <button
-                      type="button"
-                      className="dash-snooze__backdrop"
-                      aria-label="Close snooze menu"
-                      onClick={() => setSnoozeOpenId(null)}
-                    />
-                    <div className="dash-snooze__menu" role="menu" aria-label="Snooze for">
-                      {SNOOZE_OPTIONS.map((opt) => (
-                        <button
-                          key={opt.label}
-                          type="button"
-                          role="menuitem"
-                          className="dash-snooze__opt"
-                          onClick={() => {
-                            setSnoozeOpenId(null);
-                            void act(item, "snooze", opt.minutes());
-                          }}
-                        >
-                          {opt.label}
-                        </button>
-                      ))}
-                    </div>
-                  </>
-                ) : null}
-              </div>
+              <SnoozeMenu
+                open={snoozeOpenId === item.id}
+                onToggle={() => setSnoozeOpenId(snoozeOpenId === item.id ? null : item.id)}
+                onClose={() => setSnoozeOpenId(null)}
+                onPick={(minutes) => {
+                  setSnoozeOpenId(null);
+                  void act(item, "snooze", minutes);
+                }}
+              />
               <button type="button" className="dash-act dash-act--primary" onClick={() => act(item, "done")}>
                 Done
               </button>
@@ -147,5 +119,63 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
         })}
       </div>
     </section>
+  );
+}
+
+/**
+ * Snooze split button + duration menu. Trapping focus inside the open menu
+ * (via the shared useFocusTrap) gives it the keyboard behaviour the rest of
+ * the app's popovers have: the first option is focused on open, Tab/Shift+Tab
+ * cycle the options, Escape closes the menu and returns focus to the trigger.
+ */
+function SnoozeMenu({
+  open,
+  onToggle,
+  onClose,
+  onPick,
+}: {
+  open: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+  onPick: (minutes: number) => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(open, menuRef, { onEscape: onClose });
+  return (
+    <div className="dash-snooze">
+      <button
+        type="button"
+        className="dash-act"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={onToggle}
+      >
+        Snooze
+        <Icon name="ph:caret-down" aria-hidden />
+      </button>
+      {open ? (
+        <>
+          <button
+            type="button"
+            className="dash-snooze__backdrop"
+            aria-label="Close snooze menu"
+            onClick={onClose}
+          />
+          <div ref={menuRef} className="dash-snooze__menu" role="menu" aria-label="Snooze for">
+            {SNOOZE_OPTIONS.map((opt) => (
+              <button
+                key={opt.label}
+                type="button"
+                role="menuitem"
+                className="dash-snooze__opt"
+                onClick={() => onPick(opt.minutes())}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </>
+      ) : null}
+    </div>
   );
 }

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -115,6 +115,11 @@
   cursor: pointer;
 }
 .dash-snooze__opt:hover { background: var(--bg-hover, color-mix(in oklch, var(--foreground) 8%, transparent)); }
+.dash-snooze__opt:focus-visible {
+  background: var(--bg-hover, color-mix(in oklch, var(--foreground) 8%, transparent));
+  outline: 2px solid var(--accent-presence);
+  outline-offset: -2px;
+}
 
 /* Compact launcher (busy state): single dense row, hide subtitles. */
 .dr-quicklinks.dash-launcher--compact {


### PR DESCRIPTION
## What

The dashboard inbox's snooze duration menu (#1255) only closed on a **backdrop click** — a keyboard user couldn't dismiss it or reach its options. This extracts it into a `SnoozeMenu` component wired to the app's shared `useFocusTrap`, giving it the same keyboard behaviour as the rest of the app's popovers:

- the first option is **focused on open**
- **Tab / Shift+Tab** cycle the options (focus trapped in the menu)
- **Escape** closes the menu and **returns focus to the Snooze trigger**
- a `:focus-visible` ring marks the focused option (keyboard only, not mouse)

No behaviour change for mouse users; the durations and the `/api/inbox/:id/snooze` call are unchanged.

## Verify
- `dashboard-page.test.ts` — pass; `pnpm build` — clean
- **Live-verified** (Playwright on `/dashboard`): opening focuses "1 hour"; Escape closes the menu, sets `aria-expanded=false`, and returns focus to "Snooze".

🤖 Generated with [Claude Code](https://claude.com/claude-code)