### PR TITLE
feat(workflows): standardize the input→steps→output run contract + capture run inputs

### DIFF
--- a/src/components/workflows-view.tsx
+++ b/src/components/workflows-view.tsx
@@ -351,10 +351,12 @@ export function WorkflowsView({
     }
   };
 
-  const runPlay = async (workflow: WorkflowSummary) => {
+  const runPlay = async (workflow: WorkflowSummary, inputs?: Record<string, string>) => {
     setBusyId(`${workflow.id}:play`);
     try {
-      const result = await runWorkflow({ id: workflow.id });
+      // Captured input values (from the run-inputs dialog) ride into the run so
+      // the compiled agent prompt carries them instead of asking for them.
+      const result = await runWorkflow({ id: workflow.id, ...(inputs ? { inputs } : {}) });
       if (result.unavailable) {
         setEngineUnavailable(true);
         // Daemon unreachable, so no agent session can be spawned: rather than
@@ -617,7 +619,7 @@ export function WorkflowsView({
       onClearNode={() => setSelectedNodeId(null)}
       onValidate={(workflow) => void runValidate(workflow)}
       onDryRun={(workflow) => void runDryRun(workflow)}
-      onPlay={(workflow) => void runPlay(workflow)}
+      onPlay={(workflow, inputs) => void runPlay(workflow, inputs)}
       onSave={(workflow) => void runSave(workflow)}
       onUndo={() => dispatchDraft({ type: "undo" })}
       onRedo={() => dispatchDraft({ type: "redo" })}

--- a/src/components/workflows/workflow-create-dialog.tsx
+++ b/src/components/workflows/workflow-create-dialog.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { slugifyWorkflowId } from "@/lib/workflow-edit";
 import type {
   WorkflowPattern,
   WorkflowScheduleRecurrence,
+  WorkflowStepSummary,
   WorkflowSummary,
 } from "@/lib/workflows";
 
@@ -127,6 +128,104 @@ function defaultFireAt(): string {
   next.setSeconds(0, 0);
   const pad = (n: number) => String(n).padStart(2, "0");
   return `${next.getFullYear()}-${pad(next.getMonth() + 1)}-${pad(next.getDate())}T${pad(next.getHours())}:${pad(next.getMinutes())}`;
+}
+
+type WorkflowRunInputsDialogProps = {
+  workflow: WorkflowSummary;
+  /** The workflow's declared `input` steps — one capture field per node. */
+  inputSteps: WorkflowStepSummary[];
+  onClose: () => void;
+  onRun: (inputs: Record<string, string>) => void;
+};
+
+/** The label a captured value is keyed by in the run prompt (name wins over id). */
+function inputKey(step: WorkflowStepSummary): string {
+  return step.name?.trim() || step.id;
+}
+
+/**
+ * Capture the value(s) for a workflow's declared input node(s) before running.
+ * A runnable workflow always has at least one `input` node (the run gate
+ * requires it), so this is the moment its input is actually supplied — the
+ * compiled run prompt carries these values instead of asking the agent to chase
+ * them down. Every field is optional: leaving one blank falls back to the
+ * prompt's existing "ask for the missing value" behaviour, so this never blocks
+ * a quick run.
+ */
+export function WorkflowRunInputsDialog({ workflow, inputSteps, onClose, onRun }: WorkflowRunInputsDialogProps) {
+  const [values, setValues] = useState<Record<string, string>>({});
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(true, dialogRef, { onEscape: onClose, focusFirst: false });
+
+  const filledCount = useMemo(
+    () => Object.values(values).filter((value) => value.trim().length > 0).length,
+    [values],
+  );
+
+  const submit = () => {
+    const inputs: Record<string, string> = {};
+    for (const step of inputSteps) {
+      const value = values[step.id]?.trim();
+      if (value) inputs[inputKey(step)] = value;
+    }
+    onRun(inputs);
+  };
+
+  return (
+    <div className="workflow-dialog-backdrop" role="presentation" onClick={onClose}>
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        className="workflow-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Run inputs"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="workflow-panel-heading">
+          <div>
+            <p className="workflow-eyebrow">Run inputs</p>
+            <h2>{workflow.name ?? workflow.id}</h2>
+          </div>
+          <button type="button" className="workflow-icon-button" onClick={onClose} aria-label="Close">
+            <Icon name="ph:x" width={14} />
+          </button>
+        </div>
+        <p className="workflow-muted">
+          Supply the value for each input node. Anything left blank, the agent will ask for as it runs.
+        </p>
+        <div className="workflow-run-inputs-list">
+          {inputSteps.map((step, index) => (
+            <label className="workflow-field" key={step.id}>
+              <span>{step.name?.trim() || step.id}</span>
+              {step.summary?.trim() && (
+                <span className="workflow-run-input-hint">{step.summary.trim()}</span>
+              )}
+              <textarea
+                className="workflow-run-input-field"
+                rows={2}
+                autoFocus={index === 0}
+                placeholder="Value for this input…"
+                value={values[step.id] ?? ""}
+                onChange={(event) =>
+                  setValues((current) => ({ ...current, [step.id]: event.target.value }))
+                }
+              />
+            </label>
+          ))}
+        </div>
+        <div className="workflow-dialog-actions">
+          <button type="button" onClick={onClose}>
+            Cancel
+          </button>
+          <button type="button" className="workflow-play-button workflow-primary-button" onClick={submit}>
+            <Icon name="ph:lightning-bold" width={13} />
+            {filledCount > 0 ? `Run with ${filledCount} input${filledCount === 1 ? "" : "s"}` : "Run"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 /**

--- a/src/components/workflows/workflow-inspector.tsx
+++ b/src/components/workflows/workflow-inspector.tsx
@@ -3,7 +3,11 @@
 import { Icon } from "@/lib/icon";
 import type { WorkflowGraphNode } from "@/lib/workflow-graph";
 import {
+  workflowInputSteps,
   workflowIssueSummary,
+  workflowOutputSteps,
+  workflowRunBlockReason,
+  type WorkflowStepKind,
   type WorkflowStepSummary,
   type WorkflowSummary,
   type WorkflowValidationIssue,
@@ -19,7 +23,24 @@ type WorkflowInspectorProps = {
   onRemoveStep: (id: string) => void;
 };
 
-const STEP_KINDS = ["agent", "skill", "tool", "human-gate", "workflow"];
+// The canonical CWF-01 step-kind vocabulary, in execution order so the dropdown
+// mirrors the palette (Input first, Output last). Kept in sync with the palette
+// and the run gate (workflowRunBlockReason) — input/output belong here so a step
+// can be reclassified into the I/O kinds the runner requires, not just the
+// middle kinds. Labels match the palette's casing ("Human gate", not the raw id).
+const STEP_KINDS: Array<{ value: WorkflowStepKind; label: string }> = [
+  { value: "input", label: "Input" },
+  { value: "agent", label: "Agent" },
+  { value: "skill", label: "Skill" },
+  { value: "tool", label: "Tool" },
+  { value: "human-gate", label: "Human gate" },
+  { value: "workflow", label: "Workflow" },
+  { value: "output", label: "Output" },
+];
+
+function stepKindLabel(kind: WorkflowStepKind): string {
+  return STEP_KINDS.find((entry) => entry.value === kind)?.label ?? kind;
+}
 
 const PATTERNS = [
   "sequential",
@@ -89,12 +110,23 @@ export function WorkflowInspector({
     ? workflow?.steps?.find((entry) => entry.id === selectedNode.id) ?? null
     : null;
 
+  // Run readiness reads the input → steps → output contract the runner enforces
+  // (workflowRunBlockReason). Surfacing it here — where the workflow is built —
+  // makes the execution contract legible without hovering the disabled Play
+  // button. The counts split the graph into its declared input(s), the work
+  // between, and the produced output(s).
+  const runBlock = workflowRunBlockReason(workflow);
+  const inputCount = workflow ? workflowInputSteps(workflow).length : 0;
+  const outputCount = workflow ? workflowOutputSteps(workflow).length : 0;
+  const middleCount = Math.max(0, (workflow?.steps?.length ?? 0) - inputCount - outputCount);
+  const count = (n: number, noun: string) => `${n} ${noun}${n === 1 ? "" : "s"}`;
+
   return (
     <section className="workflow-panel workflow-inspector" aria-label="Workflow inspector">
       <div className="workflow-panel-heading">
         <div className="workflow-heading-lead">
           <div>
-            <p className="workflow-eyebrow">{step ? "Selected node" : "Workflow"}</p>
+            <p className="workflow-eyebrow">{step ? `Selected node · ${stepKindLabel(step.kind)}` : "Workflow"}</p>
             <h2>{step ? (step.name ?? step.id) : (workflow?.name ?? workflow?.id ?? "No workflow")}</h2>
           </div>
         </div>
@@ -127,11 +159,13 @@ export function WorkflowInspector({
             <span>Kind</span>
             <select value={step.kind} onChange={(event) => onUpdateStep(step.id, { kind: event.target.value })}>
               {STEP_KINDS.map((kind) => (
-                <option key={kind} value={kind}>
-                  {kind}
+                <option key={kind.value} value={kind.value}>
+                  {kind.label}
                 </option>
               ))}
-              {!STEP_KINDS.includes(step.kind) && <option value={step.kind}>{step.kind}</option>}
+              {!STEP_KINDS.some((entry) => entry.value === step.kind) && (
+                <option value={step.kind}>{step.kind}</option>
+              )}
             </select>
           </label>
           <Field
@@ -164,6 +198,28 @@ export function WorkflowInspector({
         </div>
       ) : workflow ? (
         <div className="workflow-editor">
+          <div
+            className={`workflow-run-readiness${runBlock ? " is-blocked" : " is-ready"}`}
+            role="status"
+          >
+            <Icon name={runBlock ? "ph:warning-circle" : "ph:check-circle-bold"} width={14} />
+            <div className="workflow-run-readiness-text">
+              <span className="workflow-run-readiness-label">
+                {runBlock ? "Not runnable yet" : "Ready to run"}
+              </span>
+              <span className="workflow-run-readiness-contract">
+                {runBlock ?? (
+                  <>
+                    {count(inputCount, "input")}
+                    <Icon name="ph:arrow-right-bold" width={11} aria-hidden />
+                    {count(middleCount, "step")}
+                    <Icon name="ph:arrow-right-bold" width={11} aria-hidden />
+                    {count(outputCount, "output")}
+                  </>
+                )}
+              </span>
+            </div>
+          </div>
           <Field label="Name" value={workflow.name ?? ""} onCommit={(next) => onUpdateMeta({ name: next || undefined })} />
           <Field label="Version" value={workflow.version} onCommit={(next) => onUpdateMeta({ version: next || workflow.version })} />
           <label className="workflow-field">

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -345,4 +345,27 @@ assert.match(css, /\.workflow-studio-main\.is-run-preview-split\s*\{[\s\S]*grid-
 assert.match(css, /\.workflow-dialog/, "CSS should style dialogs");
 assert.match(css, /\.workflow-field/, "CSS should style editor fields");
 
+// --- Standardized step-kind vocabulary + I/O run contract ---
+
+// The inspector's Kind dropdown must offer the full CWF-01 vocabulary, including
+// the input/output kinds the run gate requires — not just the middle kinds.
+assert.match(inspector, /value:\s*"input"/, "Inspector kind dropdown should offer the input kind (the run gate requires an input node)");
+assert.match(inspector, /value:\s*"output"/, "Inspector kind dropdown should offer the output kind (the run gate requires an output node)");
+assert.match(inspector, /value:\s*"human-gate",\s*label:\s*"Human gate"/, "Inspector kind labels should match the palette's casing");
+
+// The workflow inspector surfaces the input → steps → output run contract where
+// the workflow is built, not only on the disabled Play button's tooltip.
+assert.match(inspector, /workflowRunBlockReason/, "Inspector should read the run gate for its readiness banner");
+assert.match(inspector, /workflow-run-readiness/, "Inspector should render a run-readiness contract banner");
+assert.match(inspector, /Ready to run/, "Inspector readiness banner should confirm a runnable workflow");
+assert.match(css, /\.workflow-run-readiness/, "CSS should style the run-readiness banner");
+
+// Play captures the workflow's declared input(s) before running so the run
+// carries real input instead of an empty payload.
+assert.match(dialogs, /export function WorkflowRunInputsDialog/, "A run-inputs dialog should capture declared input values before a run");
+assert.match(studio, /WorkflowRunInputsDialog/, "Studio should wire the run-inputs dialog");
+assert.match(studio, /workflowInputSteps\(workflow\)\.length > 0/, "Play should capture inputs when the workflow declares input nodes");
+assert.match(studio, /onPlay\(selectedWorkflow,\s*inputs\)/, "Captured run inputs should flow into the play handler");
+assert.match(css, /\.workflow-run-input-field/, "CSS should style run-input capture fields");
+
 console.log("workflow-studio.test.ts: ok");

--- a/src/components/workflows/workflow-studio.tsx
+++ b/src/components/workflows/workflow-studio.tsx
@@ -8,22 +8,23 @@ import { useIsMobile } from "@/lib/use-viewport";
 import { Tabs } from "@/components/ui/tabs";
 import type { WorkflowGraphNode, WorkflowLayoutDirection, WorkflowNodePositions } from "@/lib/workflow-graph";
 import type { WorkflowPlaybackState } from "@/lib/workflow-playback";
-import type {
-  WorkflowDryRunPlan,
-  WorkflowPattern,
-  WorkflowRoleSummary,
-  WorkflowRunRecord,
-  WorkflowScheduleRecurrence,
-  WorkflowStepKind,
-  WorkflowStepSummary,
-  WorkflowSummary,
-  WorkflowValidationResult,
+import {
+  workflowInputSteps,
+  type WorkflowDryRunPlan,
+  type WorkflowPattern,
+  type WorkflowRoleSummary,
+  type WorkflowRunRecord,
+  type WorkflowScheduleRecurrence,
+  type WorkflowStepKind,
+  type WorkflowStepSummary,
+  type WorkflowSummary,
+  type WorkflowValidationResult,
 } from "@/lib/workflows";
 import { WorkflowAttachments } from "./workflow-attachments";
 import type { WorkflowFamiliarOption } from "./workflow-attachments";
 import { WorkflowCanvas } from "./workflow-canvas";
 import { WorkflowStepList } from "./workflow-step-list";
-import { WorkflowCreateDialog, WorkflowScheduleDialog } from "./workflow-create-dialog";
+import { WorkflowCreateDialog, WorkflowRunInputsDialog, WorkflowScheduleDialog } from "./workflow-create-dialog";
 import { WorkflowInspector } from "./workflow-inspector";
 import { WorkflowLibrary } from "./workflow-library";
 import { WorkflowManifestPreview } from "./workflow-manifest-preview";
@@ -97,7 +98,7 @@ export type WorkflowStudioProps = {
   onClearNode: () => void;
   onValidate: (workflow: WorkflowSummary) => void;
   onDryRun: (workflow: WorkflowSummary) => void;
-  onPlay: (workflow: WorkflowSummary) => void;
+  onPlay: (workflow: WorkflowSummary, inputs?: Record<string, string>) => void;
   onSave: (workflow: WorkflowSummary) => void;
   onUndo: () => void;
   onRedo: () => void;
@@ -128,6 +129,18 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
   } = props;
   const [createOpen, setCreateOpen] = useState(false);
   const [scheduleOpen, setScheduleOpen] = useState(false);
+  const [runInputsOpen, setRunInputsOpen] = useState(false);
+  // Clicking Play captures the workflow's declared input(s) first when it has
+  // any (a runnable workflow always does — the gate requires an input node), so
+  // the run carries real input instead of an empty payload. No input nodes ⇒
+  // run straight through.
+  const requestRun = (workflow: WorkflowSummary) => {
+    if (workflowInputSteps(workflow).length > 0) {
+      setRunInputsOpen(true);
+      return;
+    }
+    props.onPlay(workflow);
+  };
   // Below the shell breakpoint the React Flow canvas (pan/zoom/drag-connect) is
   // awkward on touch, so we swap it for a linear, scrollable step list that reads
   // from the same graph source.
@@ -252,7 +265,7 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
           playback={props.playback}
           onValidate={props.onValidate}
           onDryRun={props.onDryRun}
-          onPlay={props.onPlay}
+          onPlay={requestRun}
           onSave={props.onSave}
           onUndo={props.onUndo}
           onRedo={props.onRedo}
@@ -375,6 +388,17 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
           onSchedule={(fireAt, recurrence) => {
             setScheduleOpen(false);
             props.onSchedule(fireAt, recurrence);
+          }}
+        />
+      )}
+      {runInputsOpen && selectedWorkflow && (
+        <WorkflowRunInputsDialog
+          workflow={selectedWorkflow}
+          inputSteps={workflowInputSteps(selectedWorkflow)}
+          onClose={() => setRunInputsOpen(false)}
+          onRun={(inputs) => {
+            setRunInputsOpen(false);
+            props.onPlay(selectedWorkflow, inputs);
           }}
         />
       )}

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -1202,6 +1202,100 @@
   gap: 8px;
 }
 
+/* Run-readiness contract banner (workflow inspector). Reads the input → steps →
+   output gate the runner enforces, tinted green when runnable and amber when a
+   node is missing. */
+.workflow-run-readiness {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 4px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-base);
+}
+
+.workflow-run-readiness > .iconify {
+  flex: none;
+  margin-top: 1px;
+}
+
+.workflow-run-readiness.is-ready {
+  border-color: color-mix(in oklch, var(--color-success, #57c878) 45%, var(--border));
+  background: color-mix(in oklch, var(--color-success, #57c878) 9%, transparent);
+}
+
+.workflow-run-readiness.is-ready > .iconify {
+  color: var(--color-success, #57c878);
+}
+
+.workflow-run-readiness.is-blocked {
+  border-color: color-mix(in oklch, var(--color-warning, #d9a13c) 45%, var(--border));
+  background: color-mix(in oklch, var(--color-warning, #d9a13c) 10%, transparent);
+}
+
+.workflow-run-readiness.is-blocked > .iconify {
+  color: var(--color-warning, #d9a13c);
+}
+
+.workflow-run-readiness-text {
+  display: grid;
+  gap: 1px;
+  min-width: 0;
+}
+
+.workflow-run-readiness-label {
+  font-size: 12px;
+  font-weight: 650;
+  color: var(--text-primary);
+}
+
+.workflow-run-readiness-contract {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 5px;
+  font-size: 11.5px;
+  color: var(--muted-foreground);
+}
+
+.workflow-run-readiness-contract .iconify {
+  flex: none;
+  opacity: 0.7;
+}
+
+/* Run-inputs dialog: one capture field per declared input node. */
+.workflow-run-inputs-list {
+  display: grid;
+  gap: 10px;
+}
+
+.workflow-run-input-hint {
+  font-size: 11px;
+  line-height: 1.35;
+  color: var(--muted-foreground);
+}
+
+.workflow-run-input-field {
+  width: 100%;
+  resize: vertical;
+  min-height: 48px;
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.45;
+  padding: 6px 8px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--muted) 55%, transparent);
+  color: var(--text-primary, inherit);
+}
+
+.workflow-run-input-field:focus {
+  outline: none;
+  border-color: color-mix(in oklch, var(--accent-presence) 65%, transparent);
+}
+
 .workflow-issue-list {
   margin: 6px 0 0;
   padding: 0;


### PR DESCRIPTION
## What

Polishes the Workflows studio around its **execution contract** so a workflow's inputs, outputs, and the steps between read consistently end to end.

### 1. Standardized step-kind vocabulary
The inspector's **Kind** dropdown previously offered only the middle kinds (`agent, skill, tool, human-gate, workflow`) — it omitted `input` and `output`, the two kinds the run gate *requires*. So a step could never be reclassified into the very kinds a runnable workflow needs. It now offers the full CWF-01 vocabulary in execution order, with labels matching the palette's casing ("Human gate", not the raw id). The selected-node eyebrow reads its standardized kind too ("Selected node · Agent").

### 2. Run-readiness contract banner
The workflow inspector now shows a small banner reading the **input → steps → output** contract (`workflowRunBlockReason`) — green/"Ready to run · 1 input → N steps → 1 output" when runnable, amber with the specific missing-node reason when not. The contract is now legible *where you build the workflow*, not only on the disabled Play button's hover tooltip.

### 3. Capture run inputs before Play
A runnable workflow always declares ≥1 `input` node, but Play/dry-run always sent an empty payload — so the compiled agent prompt fell back to "ask Val for the value." Play now opens a lightweight **Run inputs** dialog (one field per input node, with the node's summary as a hint) and threads the captured values into the run (`runWorkflow({ id, inputs })` → `buildWorkflowRunPrompt`). Fields are optional, so a quick run still works; anything left blank keeps the existing "agent asks as it runs" behaviour.

## Testing
- `pnpm typecheck` — clean
- `pnpm test:app` (338 files) + `pnpm test:mobile` (16 files) — pass
- `pnpm build` (Next build + ESLint + server bundle) — pass
- New source assertions added to `workflow-studio.test.ts` pinning the vocabulary, the readiness banner, and the run-inputs capture wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)