### PR TITLE
fix(chat): re-selecting the same file no longer silently drops the attach

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -829,3 +829,14 @@ assert.match(
   /cave-next-path--recommended/,
   "the first follow-up is marked as the recommended next step",
 );
+
+// File picker resets its value synchronously so re-selecting the same file (or
+// re-attaching after the CSV / 10-cap early returns) still fires onChange.
+assert.ok(
+  source.includes("const files = e.currentTarget.files ? Array.from(e.currentTarget.files) : null;"),
+  "file input snapshots files before reset",
+);
+assert.ok(
+  source.includes('e.currentTarget.value = "";') && !source.includes('fileInputRef.current.value = ""'),
+  "file input resets value synchronously in onChange, not after the async attach",
+);

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2668,7 +2668,6 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     if (selected.length === 0) return;
     const next = await Promise.all(selected.map(fileToAttachment));
     setAttachments((prev) => [...prev, ...next]);
-    if (fileInputRef.current) fileInputRef.current.value = "";
     inputRef.current?.focus();
   };
 
@@ -3582,7 +3581,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   type="file"
                   multiple
                   className="hidden"
-                  onChange={(e) => void attachFiles(e.currentTarget.files)}
+                  onChange={(e) => {
+                    // Snapshot the files and clear the input synchronously so picking the
+                    // SAME file again still fires onChange (e.g. re-attach after the CSV
+                    // or 10-attachment-cap early returns in attachFiles).
+                    const files = e.currentTarget.files ? Array.from(e.currentTarget.files) : null;
+                    e.currentTarget.value = "";
+                    void attachFiles(files);
+                  }}
                 />
                 <button
                   type="button"


### PR DESCRIPTION
## Bug
`attachFiles` in `chat-view.tsx` reset the file input's `value` only **after** `await Promise.all(...)`, and several branches returned *before* that reset ever ran — the CSV branch (`setCsvRaw(text); return`) and the 10-attachment cap (`selected.length === 0`).

A file `<input>` doesn't re-fire `onChange` when you pick a file whose value matches the current one. So:
- Attaching the **same file twice** in a row silently did nothing.
- Re-attaching after the CSV path or after hitting the 10-file cap silently did nothing.

No error, no feedback — the user thinks the file attached but it didn't.

## Fix
Snapshot the files into an array and clear `e.currentTarget.value` **synchronously** in the `onChange` handler (before any async work), so `onChange` always re-fires regardless of which branch `attachFiles` takes. Removed the now-dead late reset.

## Tests
Extended `chat-view-polish.test.ts` to assert the input snapshots files before reset and resets synchronously in `onChange` (and that the old late reset is gone). Ran 7 chat-view source-text suites — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)