### PR TITLE
fix(schedules): honor datetime prefs + absolute-time tooltips on run times

### DIFF
--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -11,7 +11,7 @@ import type {
   CodexAutomationPatch,
 } from "@/lib/codex-automations-types";
 import { Icon } from "@/lib/icon";
-import { formatTimestamp, formatClock } from "@/lib/datetime-format";
+import { formatTimestamp, formatClock, readDateTimePrefs } from "@/lib/datetime-format";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
 import { ProjectTree } from "@/components/project-tree";
@@ -108,7 +108,7 @@ function relTime(iso: string | undefined | null): string {
   if (d <= 6) return delta > 0 ? `in ${d}d` : `${d}d ago`;
   // Beyond a week the relative form ("in 42d") is hard to parse — show the
   // actual date + time, honoring the user's clock and date preferences.
-  return formatTimestamp(iso);
+  return formatTimestamp(iso, readDateTimePrefs());
 }
 
 function parseCodexRrule(rrule: string | null): {
@@ -340,14 +340,22 @@ function DetailPanel({
           {!isDailySummary && (
             <div>
               <FieldLabel>Next run</FieldLabel>
-              <p className="text-[12px]" style={{ color: "var(--text-primary)" }}>
+              <p
+                className="text-[12px]"
+                style={{ color: "var(--text-primary)" }}
+                title={item.fireAt ? formatTimestamp(item.fireAt, readDateTimePrefs()) : undefined}
+              >
                 {relTime(item.fireAt)}
               </p>
             </div>
           )}
           <div>
             <FieldLabel>{isDailySummary ? "Sent" : "Last run"}</FieldLabel>
-            <p className="text-[12px]" style={{ color: item.firedAt ? "oklch(0.75 0.1 150)" : "var(--text-muted)" }}>
+            <p
+              className="text-[12px]"
+              style={{ color: item.firedAt ? "oklch(0.75 0.1 150)" : "var(--text-muted)" }}
+              title={item.firedAt ? formatTimestamp(item.firedAt, readDateTimePrefs()) : undefined}
+            >
               {item.firedAt ? relTime(item.firedAt) : "Never"}
             </p>
           </div>


### PR DESCRIPTION
## What

Two fixes in the Schedules (reminders/automations) detail:

1. **Honor the datetime preference.** `relTime` falls back to an absolute date+time for anything beyond a week, and its comment says it honors the user's clock/date preference — but it called `formatTimestamp(iso)` with the **default** prefs, so a 24-hour user still saw a 12-hour time. Now it passes `readDateTimePrefs()`.
2. **Absolute-time tooltips.** The **Next run** and **Last run** values showed only a relative string; add a pref-aware absolute-time tooltip on each, matching the recent-session / inbox tooltips (#1287, #1290).

## Verify
- `automations-view.test.ts`, `automations-detail-inputs.test.ts` — pass; `pnpm build` — clean
- Smoke-checked the Schedules surface renders with **0 page errors** after the change (demo has no reminders, so the detail panel/tooltips weren't exercised live; the helpers are the same proven ones from #1287/#1290).

🤖 Generated with [Claude Code](https://claude.com/claude-code)