### PR TITLE
fix(library): lift the metadata grid when a subtitle precedes it

### DIFF
--- a/src/lib/library-metadata.test.ts
+++ b/src/lib/library-metadata.test.ts
@@ -53,10 +53,34 @@ assert.equal(
   null,
   "a single label is not enough to qualify",
 );
+// ── A single leading subtitle/heading before the metadata is allowed ──
+// Sage's notes commonly open with a bold tagline or an `## …` subtitle and
+// THEN the metadata run; the grid should still lift the metadata, keeping the
+// subtitle in the body (it renders below the grid).
+const headed = parseLeadingMetadata("## Five products, one shape\n\n**A:** one **B:** two\n\nbody prose");
+assert.ok(headed, "metadata after a single heading subtitle is detected");
+assert.deepEqual(headed.entries.map((e) => e.key), ["A", "B"]);
+assert.match(headed.rest, /^## Five products, one shape/, "subtitle stays at the top of the body");
+assert.ok(!headed.rest.includes("**A:**"), "metadata removed from the body");
+assert.match(headed.rest, /body prose/, "trailing body content is preserved");
+
+const taglined = parseLeadingMetadata("**A bold tagline**\n\n**A:** one **B:** two\n\nrest");
+assert.ok(taglined, "metadata after a single bold tagline is detected");
+assert.deepEqual(taglined.entries.map((e) => e.key), ["A", "B"]);
+assert.match(taglined.rest, /^\*\*A bold tagline\*\*/, "bold tagline stays in the body");
+
+// But only ONE leading block is skipped — metadata buried under real prose
+// (subtitle + a prose paragraph) is NOT swallowed.
 assert.equal(
-  parseLeadingMetadata("# Heading\n\n**A:** one **B:** two"),
+  parseLeadingMetadata("## Heading\n\nSome intro prose.\n\n**A:** one **B:** two"),
   null,
-  "metadata must be the first paragraph, not preceded by other content",
+  "metadata past a subtitle AND a prose paragraph is not treated as leading metadata",
+);
+// A multi-line first block (real prose, not a one-line subtitle) is not skipped.
+assert.equal(
+  parseLeadingMetadata("First line of prose\nsecond line\n\n**A:** one **B:** two"),
+  null,
+  "a multi-line opening paragraph is not treated as a skippable subtitle",
 );
 
 console.log("library-metadata.test.ts: all assertions passed");

--- a/src/lib/library-metadata.ts
+++ b/src/lib/library-metadata.ts
@@ -1,11 +1,11 @@
 // Leading-metadata extraction for library research notes.
 //
 // Sage's research notes open with a metadata paragraph — a run of
-// `**Date:** … **Source:** … **Stars:** …` bold-label pairs written as the
-// first body paragraph. Rendered inline it's a hard-to-scan wrapped blob, so
-// the preview lifts it out of the markdown and renders it as a collapsible
-// key/value grid. This module is the pure parser (no JSX) so it can be tested
-// directly under `node --experimental-strip-types`.
+// `**Date:** … **Source:** … **Stars:** …` bold-label pairs. Rendered inline
+// it's a hard-to-scan wrapped blob, so the preview lifts it out of the markdown
+// and renders it as a collapsible key/value grid. This module is the pure
+// parser (no JSX) so it can be tested directly under
+// `node --experimental-strip-types`.
 
 export interface MetaEntry {
   key: string;
@@ -18,42 +18,86 @@ export interface LeadingMetadata {
   rest: string;
 }
 
-/**
- * Detect a leading metadata paragraph and split it into entries.
- *
- * Qualifies only when the first non-empty paragraph opens with a `**Label:**`
- * bold label and carries at least two of them — so ordinary prose that merely
- * starts with bold text isn't swallowed. Returns `null` when no metadata
- * paragraph is present, leaving the body untouched.
- */
-export function parseLeadingMetadata(body: string): LeadingMetadata | null {
-  const lines = body.split("\n");
-  let i = 0;
-  while (i < lines.length && lines[i].trim() === "") i++;
+// A `**Label:**` bold label (colon immediately before the closing `**`).
+const LABEL_RE = /\*\*\s*[^*\n]+?\s*:\s*\*\*/g;
+const ENTRY_RE = /\*\*\s*([^*\n]+?)\s*:\s*\*\*\s*([\s\S]*?)(?=\s*\*\*\s*[^*\n]+?\s*:\s*\*\*|$)/g;
 
-  // Gather the first paragraph (up to the next blank line).
-  const para: string[] = [];
-  while (i < lines.length && lines[i].trim() !== "") {
-    para.push(lines[i]);
-    i++;
-  }
-  const text = para.join(" ").trim();
-
-  // Must open with a bold label and carry ≥2 of them.
+/** Parse a paragraph's text into metadata entries, or null when it isn't a
+ *  bold-label run with at least two labels. */
+function metadataEntries(text: string): MetaEntry[] | null {
   if (!/^\*\*\s*[^*\n]+?\s*:\s*\*\*/.test(text)) return null;
-  const labelCount = (text.match(/\*\*\s*[^*\n]+?\s*:\s*\*\*/g) ?? []).length;
-  if (labelCount < 2) return null;
-
+  if ((text.match(LABEL_RE) ?? []).length < 2) return null;
   const entries: MetaEntry[] = [];
-  const re = /\*\*\s*([^*\n]+?)\s*:\s*\*\*\s*([\s\S]*?)(?=\s*\*\*\s*[^*\n]+?\s*:\s*\*\*|$)/g;
+  const re = new RegExp(ENTRY_RE.source, "g");
   let m: RegExpExecArray | null;
   while ((m = re.exec(text)) !== null) {
     const key = m[1].trim();
     const value = m[2].trim();
     if (key) entries.push({ key, value });
   }
-  if (entries.length < 2) return null;
+  return entries.length >= 2 ? entries : null;
+}
 
-  const rest = lines.slice(i).join("\n").replace(/^\n+/, "");
-  return { entries, rest };
+/** Gather the paragraph at/after `from` (skipping blank lines). Returns its
+ *  start/end line indices and joined text, or null past end of body. */
+function gatherParagraph(
+  lines: string[],
+  from: number,
+): { start: number; end: number; text: string } | null {
+  let i = from;
+  while (i < lines.length && lines[i].trim() === "") i++;
+  if (i >= lines.length) return null;
+  const start = i;
+  const para: string[] = [];
+  while (i < lines.length && lines[i].trim() !== "") {
+    para.push(lines[i]);
+    i++;
+  }
+  return { start, end: i, text: para.join(" ").trim() };
+}
+
+/** A single-line bold tagline (`**…**`) or a markdown heading (`## …`) — the
+ *  kind of subtitle research notes place between the title and the metadata
+ *  run. Used to allow ONE leading subtitle before the metadata. */
+function isLeadingSubtitle(lines: string[], start: number, end: number): boolean {
+  if (end - start !== 1) return false; // single line only
+  const line = lines[start].trim();
+  return /^#{1,6}\s/.test(line) || /^\*\*[^*].*\*\*$/.test(line);
+}
+
+/**
+ * Detect a leading metadata paragraph and split it into entries.
+ *
+ * Qualifies when the metadata run is the first paragraph, OR when it's the
+ * second paragraph and the first is a single-line subtitle/heading (a bold
+ * tagline or `## …`) — many notes open with such a subtitle before the
+ * metadata. The subtitle is kept in `rest` (it renders below the lifted grid);
+ * only the metadata paragraph is removed. Skips at most one leading subtitle,
+ * so a metadata-looking paragraph buried under real prose isn't swallowed.
+ * Returns `null` when no leading metadata paragraph is present.
+ */
+export function parseLeadingMetadata(body: string): LeadingMetadata | null {
+  const lines = body.split("\n");
+
+  const first = gatherParagraph(lines, 0);
+  if (!first) return null;
+
+  // Case 1 — metadata is the very first paragraph.
+  const firstEntries = metadataEntries(first.text);
+  if (firstEntries) {
+    const rest = lines.slice(first.end).join("\n").replace(/^\n+/, "");
+    return { entries: firstEntries, rest };
+  }
+
+  // Case 2 — a single leading subtitle/heading precedes the metadata run.
+  if (!isLeadingSubtitle(lines, first.start, first.end)) return null;
+  const second = gatherParagraph(lines, first.end);
+  if (!second) return null;
+  const secondEntries = metadataEntries(second.text);
+  if (!secondEntries) return null;
+
+  const subtitle = lines.slice(first.start, first.end).join("\n");
+  const after = lines.slice(second.end).join("\n").replace(/^\n+/, "");
+  const rest = after ? `${subtitle}\n\n${after}` : subtitle;
+  return { entries: secondEntries, rest };
 }


### PR DESCRIPTION
## What

The library reader's leading-metadata grid now fires when the bold-label run is preceded by a **one-line subtitle** (a bold tagline or an `## …` heading), not just when it's the literal first paragraph.

## Why

`parseLeadingMetadata` only qualified the metadata run as the *first* body paragraph. But the research notes routinely open with a subtitle before the metadata, e.g. the Cockpit Cluster note:

```
# The Cockpit Cluster — …        (title, stripped)
**Five products, one architectural shape, no identity layer**   ← subtitle
                                  (blank)
**Author:** Sage 🌿 **Date:** … **Status:** … **Sources:** … **Captured:** …
```

So the grid never lifted and the run-on `**Author:** … **Date:** …` blob rendered inline. Verified live: before, `meta-grid` element count was **0** on this doc.

## Change

Allow **one** leading single-line subtitle/heading before the metadata paragraph. The grid lifts the metadata; the subtitle stays in the body (renders just below the grid). Conservative — only a single one-line block is skipped, so:
- metadata buried under a subtitle **and** a prose paragraph → still `null`
- a multi-line opening paragraph (real prose) → still `null`

**Note:** this intentionally reverses the prior "metadata must be the first paragraph" rule (the old test pinned `# Heading\n\n**A:** **B:**` → null) — that rule excluded exactly the subtitle-first shape these notes use. Test updated to the new intent + guards for the not-skipped cases. Only `library-metadata.ts` (+ its test) changes; the grid render and CSS already exist.

## Verification

- Live-verified on the real Cockpit Cluster doc: grid now renders (Author/Date/Status/Sources/Captured as a key/value grid; subtitle leads the body below). `meta-grid` count 0 → 6.
- Parser unit test + `pnpm test:app` — ✓ 338 test file(s) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)