### PR TITLE
fix(datetime): honor the user's clock/date pref in remaining timestamps

### DIFF
--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
-import { formatTimestamp } from "@/lib/datetime-format";
+import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 // Shared relative-time formatter, imported as `age` so the call sites read the
 // same — standardizes this surface on the app-wide "2m ago / 3h ago / Jun 12" style.
 import { relativeTime as age } from "@/lib/relative-time";
@@ -370,7 +370,7 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
               </div>
               <div className="flex items-center gap-2.5">
                 {lastLoadedAt ? (
-                  <span className="text-[10px] text-[var(--text-muted)]" title={`Last refreshed ${formatTimestamp(lastLoadedAt)}`}>
+                  <span className="text-[10px] text-[var(--text-muted)]" title={`Last refreshed ${formatTimestamp(lastLoadedAt, readDateTimePrefs())}`}>
                     Updated {age(lastLoadedAt)}
                   </span>
                 ) : null}

--- a/src/components/session-changes-panel.tsx
+++ b/src/components/session-changes-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
-import { formatTimestamp } from "@/lib/datetime-format";
+import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 import { SyntaxBlock } from "@/components/message-bubble";
 import { useChatDebugSnapshot } from "@/lib/chat-debug-store";
 
@@ -52,7 +52,7 @@ function checkpointLabel(name: string): string {
   );
   const d = new Date(iso);
   // Honor the app's clock + date preferences instead of the raw browser locale.
-  return Number.isNaN(d.getTime()) ? name : formatTimestamp(iso);
+  return Number.isNaN(d.getTime()) ? name : formatTimestamp(iso, readDateTimePrefs());
 }
 
 function formatBytes(n: number): string {

--- a/src/components/workflows/workflow-runs-panel.tsx
+++ b/src/components/workflows/workflow-runs-panel.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { relativeTime } from "@/lib/relative-time";
-import { formatTimestamp } from "@/lib/datetime-format";
+import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 import type { WorkflowPlaybackState } from "@/lib/workflow-playback";
 import type {
   WorkflowRunRecord,
@@ -106,7 +106,7 @@ export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayR
                   <span className={`workflow-run-chip workflow-run-chip-${run.status}`}>{run.status}</span>
                   <span className="workflow-run-kind">{run.kind}</span>
                   <span className="workflow-run-detail">{stepRollup(run)}</span>
-                  <span className="workflow-run-time" title={formatTimestamp(run.startedAt)}>
+                  <span className="workflow-run-time" title={formatTimestamp(run.startedAt, readDateTimePrefs())}>
                     {relativeTime(run.startedAt)}
                   </span>
                 </button>
@@ -129,7 +129,7 @@ export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayR
                       </div>
                       <div>
                         <dt>Started</dt>
-                        <dd title={formatTimestamp(run.startedAt)}>{relativeTime(run.startedAt)}</dd>
+                        <dd title={formatTimestamp(run.startedAt, readDateTimePrefs())}>{relativeTime(run.startedAt)}</dd>
                       </div>
                     </dl>
                     {run.summary && <p className="workflow-run-summary-line">{run.summary}</p>}


### PR DESCRIPTION
## What

Several timestamp displays called `formatTimestamp(iso)` **without** the prefs argument, so they silently fell back to the `12h` / `MM.DD` defaults even when the user had selected `24h` or `DD.MM`. This includes spots whose own comments claimed to honor the preference.

Pass `readDateTimePrefs()` at each remaining site:
- **familiars memory view** — the "Last refreshed" tooltip (regression from #1243)
- **session changes panel** — the per-change timestamp (comment said it honored prefs; it didn't)
- **workflow runs panel** — the run-start tooltips

(The Schedules detail was just fixed the same way in #1298.)

## Verify
- `workflow-studio.test.ts`, `familiars-memory-master-detail.test.ts` — pass; `pnpm build` — clean (test:app + test:mobile)
- Pure argument-passing change using the same `readDateTimePrefs()` helper already proven in #1287/#1290/#1298; no UI/layout change. Only visible for users on non-default (24h / DD.MM) prefs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)