### PR TITLE
fix(code): guard file-editor save against concurrent Cmd-S double-fire

### DIFF
--- a/src/components/comux-view-edit.test.ts
+++ b/src/components/comux-view-edit.test.ts
@@ -45,4 +45,11 @@ assert.match(
   "edit mode must render CodeEditor wired to the edit state (value/onChange/onSave/onCancel)",
 );
 
+// Save is guarded against re-entrancy: Cmd-S in the editor calls onSave directly,
+// bypassing the Save button's disabled={saving}, so a synchronous ref blocks
+// concurrent POSTs. The save error is announced via role=alert.
+assert.ok(source.includes("if (!previewPath || savingRef.current) return;"), "saveEdit guards against concurrent saves");
+assert.ok(source.includes("savingRef.current = true;"), "saveEdit marks the in-flight ref synchronously");
+assert.ok(source.includes('<span role="alert" className="shrink-0 truncate text-[10px] text-[var(--color-danger,#f87171)]"'), "save error is announced via role=alert");
+
 console.log("comux-view-edit.test.ts: ok");

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -693,8 +693,13 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
     setSaveError(null);
   }, []);
 
+  // Synchronous in-flight guard: Cmd-S in the editor calls onSave directly,
+  // bypassing the Save button's disabled={saving}. A ref (not the saving state,
+  // which would be stale in this callback) blocks concurrent POSTs.
+  const savingRef = useRef(false);
   const saveEdit = useCallback(async () => {
-    if (!previewPath) return;
+    if (!previewPath || savingRef.current) return;
+    savingRef.current = true;
     setSaving(true);
     setSaveError(null);
     try {
@@ -716,6 +721,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
       setSaveError(String(err));
     } finally {
       setSaving(false);
+      savingRef.current = false;
     }
   }, [previewPath, editValue]);
 
@@ -1556,7 +1562,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                         {editing ? (
                           <>
                             {saveError && (
-                              <span className="shrink-0 truncate text-[10px] text-[var(--color-danger,#f87171)]" title={saveError}>
+                              <span role="alert" className="shrink-0 truncate text-[10px] text-[var(--color-danger,#f87171)]" title={saveError}>
                                 {saveError}
                               </span>
                             )}


### PR DESCRIPTION
From a review of the Code workspace. Two related fixes in the editable Projects file preview (`comux-view.tsx`).

## 1. Cmd-S could fire concurrent saves (correctness bug)
The Save button is disabled while a save is in flight (`disabled={saving}`), but the CodeMirror editor's `Mod-s` keymap calls `onSave` (→ `saveEdit`) **directly**, bypassing the button entirely. `saveEdit` had no internal re-entrancy check, so mashing Cmd-S on a slow connection fired multiple concurrent `POST /api/project-file` requests.

A `saving`-state check inside the callback wouldn't help — it's a stale closure (the callback deps are `[previewPath, editValue]`). Fix: a synchronous `savingRef` set at the top of `saveEdit` and cleared in `finally`, so re-entrant calls bail immediately regardless of render timing.

## 2. Save error wasn't announced
The save-error label rendered as a tiny inline header string with no `role`. Added `role="alert"` so screen readers announce it when a save fails (the editor stays open so the user can retry).

## Tests
Extended `comux-view-edit.test.ts` to assert the re-entrancy guard (`savingRef`) and the `role="alert"` error. Ran 6 comux/code source-text suites — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)