### PR TITLE
feat(workflows): uses autocomplete, navigable validation issues, runs filter, manifest copy

### DIFF
--- a/src/components/workflows-view.tsx
+++ b/src/components/workflows-view.tsx
@@ -48,6 +48,7 @@ import {
   WorkflowStudio,
   type WorkflowStudioActionState,
 } from "./workflows/workflow-studio";
+import type { WorkflowUsesOption } from "./workflows/workflow-inspector";
 
 export function WorkflowsView({
   initialWorkflowId = null,
@@ -72,6 +73,10 @@ export function WorkflowsView({
   const [runs, setRuns] = useState<WorkflowRunRecord[]>([]);
   const [runsLoading, setRunsLoading] = useState(false);
   const [familiars, setFamiliars] = useState<Familiar[]>([]);
+  // Skill/tool `uses` candidates from the capability registry (daemon-backed, so
+  // best-effort: empty offline, in which case familiars + sub-workflows still
+  // populate the autocomplete).
+  const [capabilityUses, setCapabilityUses] = useState<WorkflowUsesOption[]>([]);
   const [roles, setRoles] = useState<WorkflowRoleSummary[]>([]);
   const [engineUnavailable, setEngineUnavailable] = useState(false);
   const [nodePositions, setNodePositions] = useState<Record<string, { x: number; y: number }> | null>(null);
@@ -160,11 +165,40 @@ export function WorkflowsView({
     }
   }, []);
 
+  // Skills (and harness plugins/tools) discovered by the capability scanner feed
+  // the step `uses` autocomplete. Daemon-backed, so failure is silent — the
+  // field stays freeform and the always-available familiar/sub-workflow options
+  // still suggest.
+  const loadCapabilities = useCallback(async () => {
+    try {
+      const response = await fetch("/api/capabilities", { cache: "no-store" });
+      const result = (await response.json()) as {
+        ok: boolean;
+        coven_skills?: Array<{ id: string }>;
+        harness_capabilities?: Array<{
+          skills?: Array<{ id: string }>;
+          plugins?: Array<{ id: string; kind?: string }>;
+        }>;
+      };
+      if (!result.ok) return;
+      const options: WorkflowUsesOption[] = [];
+      for (const skill of result.coven_skills ?? []) options.push({ value: skill.id, group: "Skill" });
+      for (const manifest of result.harness_capabilities ?? []) {
+        for (const skill of manifest.skills ?? []) options.push({ value: skill.id, group: "Skill" });
+        for (const plugin of manifest.plugins ?? []) options.push({ value: plugin.id, group: "Tool" });
+      }
+      setCapabilityUses(options);
+    } catch {
+      // capability discovery is an enhancement; freeform `uses` still works
+    }
+  }, []);
+
   useEffect(() => {
     void load(false);
     void loadFamiliars();
     void loadRoles();
-  }, [load, loadFamiliars, loadRoles]);
+    void loadCapabilities();
+  }, [load, loadFamiliars, loadRoles, loadCapabilities]);
 
   // Keep a valid selection as the library changes; seed the draft for it.
   useEffect(() => {
@@ -235,6 +269,26 @@ export function WorkflowsView({
       .map(([id, label]) => ({ id, label }))
       .sort((a, b) => a.label.localeCompare(b.label));
   }, [draft?.familiar, familiars, roles, workflows]);
+
+  // Step `uses` autocomplete candidates: familiars (agents), other workflows
+  // (sub-workflow refs), and discovered skills/tools. Deduped by value, first
+  // origin wins, sorted within group order so the native datalist reads tidily.
+  const usesOptions = useMemo<WorkflowUsesOption[]>(() => {
+    const seen = new Set<string>();
+    const options: WorkflowUsesOption[] = [];
+    const add = (value: string | undefined | null, group: string) => {
+      const trimmed = value?.trim();
+      if (!trimmed || seen.has(trimmed)) return;
+      seen.add(trimmed);
+      options.push({ value: trimmed, group });
+    };
+    for (const familiar of familiars) add(familiar.id, "Familiar");
+    for (const workflow of workflows) {
+      if (workflow.id !== draft?.id) add(workflow.id, "Workflow");
+    }
+    for (const option of capabilityUses) add(option.value, option.group);
+    return options;
+  }, [capabilityUses, draft?.id, familiars, workflows]);
 
   useEffect(() => {
     if (!selectedNodeId) return;
@@ -601,6 +655,7 @@ export function WorkflowsView({
       runs={runs}
       runsLoading={runsLoading}
       familiarOptions={familiarOptions}
+      usesOptions={usesOptions}
       roles={roles}
       engineUnavailable={engineUnavailable}
       notice={notice}
@@ -616,6 +671,7 @@ export function WorkflowsView({
       onRefresh={() => void load(true)}
       onSelectWorkflow={selectWorkflow}
       onSelectNode={(node) => setSelectedNodeId(node.id)}
+      onSelectStep={(id) => setSelectedNodeId(id)}
       onClearNode={() => setSelectedNodeId(null)}
       onValidate={(workflow) => void runValidate(workflow)}
       onDryRun={(workflow) => void runDryRun(workflow)}

--- a/src/components/workflows/workflow-inspector.tsx
+++ b/src/components/workflows/workflow-inspector.tsx
@@ -14,14 +14,35 @@ import {
 } from "@/lib/workflows";
 import type { WorkflowStudioActionState } from "./workflow-studio";
 
+/** A binding candidate for a step's `uses` field (familiar, skill, tool, sub-workflow). */
+export type WorkflowUsesOption = {
+  value: string;
+  /** Short origin label shown beside the value in the suggestion list. */
+  group: string;
+};
+
 type WorkflowInspectorProps = {
   workflow: WorkflowSummary | null;
   selectedNode: WorkflowGraphNode | null;
   action: WorkflowStudioActionState | null;
+  /** Binding candidates offered as `uses` autocomplete. */
+  usesOptions?: WorkflowUsesOption[];
   onUpdateStep: (id: string, patch: Partial<WorkflowStepSummary>) => void;
   onUpdateMeta: (patch: Partial<WorkflowSummary>) => void;
   onRemoveStep: (id: string) => void;
+  /** Jump to a step by id (e.g. from a validation issue that names it). */
+  onSelectStep?: (id: string) => void;
 };
+
+/** The step a validation issue points at, resolved from its path (longest id wins). */
+function stepIdForIssue(issue: WorkflowValidationIssue, steps: WorkflowStepSummary[]): string | null {
+  if (!issue.path) return null;
+  let best: string | null = null;
+  for (const step of steps) {
+    if (issue.path.includes(step.id) && (!best || step.id.length > best.length)) best = step.id;
+  }
+  return best;
+}
 
 // The canonical CWF-01 step-kind vocabulary, in execution order so the dropdown
 // mirrors the palette (Input first, Output last). Kept in sync with the palette
@@ -71,12 +92,18 @@ function Field({
   value,
   placeholder,
   onCommit,
+  suggestions,
+  listId,
 }: {
   label: string;
   value: string;
   placeholder?: string;
   onCommit: (next: string) => void;
+  /** Optional autocomplete candidates rendered as a native <datalist>. */
+  suggestions?: WorkflowUsesOption[];
+  listId?: string;
 }) {
+  const hasSuggestions = Boolean(listId && suggestions && suggestions.length > 0);
   return (
     <label className="workflow-field">
       <span>{label}</span>
@@ -84,6 +111,7 @@ function Field({
         type="text"
         defaultValue={value}
         placeholder={placeholder}
+        list={hasSuggestions ? listId : undefined}
         key={`${label}:${value}`}
         onBlur={(event) => {
           if (event.target.value !== value) onCommit(event.target.value);
@@ -92,6 +120,15 @@ function Field({
           if (event.key === "Enter") (event.target as HTMLInputElement).blur();
         }}
       />
+      {hasSuggestions && (
+        <datalist id={listId}>
+          {suggestions!.map((option) => (
+            <option key={`${option.group}:${option.value}`} value={option.value}>
+              {option.group}
+            </option>
+          ))}
+        </datalist>
+      )}
     </label>
   );
 }
@@ -101,9 +138,11 @@ export function WorkflowInspector({
   workflow,
   selectedNode,
   action,
+  usesOptions,
   onUpdateStep,
   onUpdateMeta,
   onRemoveStep,
+  onSelectStep,
 }: WorkflowInspectorProps) {
   const issues = issuesForAction(action);
   const step = selectedNode
@@ -172,6 +211,8 @@ export function WorkflowInspector({
             label="Uses"
             value={step.uses ?? ""}
             placeholder="nova · cwf-validator@^1.0.0 · cave.output"
+            suggestions={usesOptions}
+            listId="workflow-uses-options"
             onCommit={(next) => onUpdateStep(step.id, { uses: next || undefined })}
           />
           <Field
@@ -297,15 +338,35 @@ export function WorkflowInspector({
       </p>
       {issues.length > 0 && (
         <ul className="workflow-issue-list">
-          {issues.slice(0, 6).map((issue, index) => (
-            <li key={`${issue.code}:${issue.path ?? index}`}>
-              <span className={`workflow-issue-tier workflow-issue-${issue.tier}`}>{issue.tier}</span>
-              <span>
-                {issue.message ?? issue.code}
-                {issue.suggestion ? ` — ${issue.suggestion}` : ""}
-              </span>
-            </li>
-          ))}
+          {issues.slice(0, 6).map((issue, index) => {
+            const targetStep = onSelectStep ? stepIdForIssue(issue, workflow?.steps ?? []) : null;
+            const body = (
+              <>
+                <span className={`workflow-issue-tier workflow-issue-${issue.tier}`}>{issue.tier}</span>
+                <span>
+                  {issue.message ?? issue.code}
+                  {issue.suggestion ? ` — ${issue.suggestion}` : ""}
+                </span>
+              </>
+            );
+            return (
+              <li key={`${issue.code}:${issue.path ?? index}`}>
+                {targetStep ? (
+                  <button
+                    type="button"
+                    className="workflow-issue-jump"
+                    onClick={() => onSelectStep!(targetStep)}
+                    title={`Go to step ${targetStep}`}
+                  >
+                    {body}
+                    <Icon name="ph:arrow-right-bold" width={10} aria-hidden className="workflow-issue-jump-icon" />
+                  </button>
+                ) : (
+                  body
+                )}
+              </li>
+            );
+          })}
         </ul>
       )}
       </>

--- a/src/components/workflows/workflow-manifest-preview.tsx
+++ b/src/components/workflows/workflow-manifest-preview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import { Icon } from "@/lib/icon";
 import { workflowToYaml } from "@/lib/workflow-edit";
 import type { WorkflowSummary } from "@/lib/workflows";
 
@@ -12,6 +13,21 @@ type WorkflowManifestPreviewProps = {
 /** Live canonical YAML for the current draft — what Save writes to disk. */
 export function WorkflowManifestPreview({ workflow, dirty }: WorkflowManifestPreviewProps) {
   const yaml = useMemo(() => (workflow ? workflowToYaml(workflow) : null), [workflow]);
+  // The manifest with its schema banner is exactly what Save writes, so copying
+  // it hands off a paste-ready manifest (to share, or check in by hand).
+  const manifestText = yaml ? `# schema_version: CWF-01\n${yaml}` : null;
+  const [copied, setCopied] = useState(false);
+
+  const copyManifest = async () => {
+    if (!manifestText) return;
+    try {
+      await navigator.clipboard.writeText(manifestText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    } catch {
+      // clipboard can be blocked (permissions / insecure context); silently no-op
+    }
+  };
 
   return (
     <section className="workflow-panel workflow-manifest-preview" aria-label="Workflow manifest preview">
@@ -25,10 +41,21 @@ export function WorkflowManifestPreview({ workflow, dirty }: WorkflowManifestPre
             </h2>
           </div>
         </div>
+        {manifestText && (
+          <button
+            type="button"
+            className="workflow-icon-button"
+            onClick={copyManifest}
+            title="Copy manifest YAML"
+            aria-label={copied ? "Manifest copied" : "Copy manifest YAML"}
+          >
+            <Icon name={copied ? "ph:check-bold" : "ph:copy"} width={13} />
+          </button>
+        )}
       </div>
-      {yaml ? (
+      {manifestText ? (
         <pre className="workflow-manifest-yaml">
-          <code>{`# schema_version: CWF-01\n${yaml}`}</code>
+          <code>{manifestText}</code>
         </pre>
       ) : (
         <p className="workflow-muted">Select a workflow to preview its canonical manifest.</p>

--- a/src/components/workflows/workflow-runs-panel.tsx
+++ b/src/components/workflows/workflow-runs-panel.tsx
@@ -54,6 +54,15 @@ function isProblemRun(run: WorkflowRunRecord): boolean {
   return run.status === "blocked" || run.status === "failed";
 }
 
+type WorkflowRunFilter = "all" | "problems" | "executions" | "plans";
+
+const RUN_FILTERS: Array<{ id: WorkflowRunFilter; label: string; match: (run: WorkflowRunRecord) => boolean }> = [
+  { id: "all", label: "All", match: () => true },
+  { id: "problems", label: "Problems", match: isProblemRun },
+  { id: "executions", label: "Runs", match: (run) => run.kind === "execution" },
+  { id: "plans", label: "Plans", match: (run) => run.kind === "dry-run" },
+];
+
 /** Header rollup: total, problem count, and the most recent run's age. */
 function summarizeRuns(runs: WorkflowRunRecord[]): string {
   if (runs.length === 0) return "0 recorded";
@@ -65,7 +74,11 @@ function summarizeRuns(runs: WorkflowRunRecord[]): string {
 /** Run history for the selected workflow: plan snapshots and executions. */
 export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayRun }: WorkflowRunsPanelProps) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [filter, setFilter] = useState<WorkflowRunFilter>("all");
   const replaying = playback?.source === "replay" && playback.workflowId === workflow?.id;
+
+  const activeFilter = RUN_FILTERS.find((entry) => entry.id === filter) ?? RUN_FILTERS[0];
+  const visibleRuns = filter === "all" ? runs : runs.filter(activeFilter.match);
 
   return (
     <section className="workflow-runs-panel" aria-label="Workflow run history">
@@ -76,6 +89,28 @@ export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayR
           {loading ? "loading" : summarizeRuns(runs)}
         </span>
       </div>
+      {/* Filter history once there's more than a couple of runs — a busy
+          workflow's plan snapshots otherwise bury its real executions. */}
+      {workflow && runs.length > 2 && (
+        <div className="workflow-runs-filter" role="tablist" aria-label="Filter runs">
+          {RUN_FILTERS.map((entry) => {
+            const matchCount = entry.id === "all" ? runs.length : runs.filter(entry.match).length;
+            return (
+              <button
+                key={entry.id}
+                type="button"
+                role="tab"
+                aria-selected={filter === entry.id}
+                className={`workflow-runs-filter-chip${filter === entry.id ? " is-active" : ""}`}
+                onClick={() => setFilter(entry.id)}
+              >
+                {entry.label}
+                <span className="workflow-runs-filter-count">{matchCount}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
       {!workflow ? (
         <p className="workflow-muted">Select a workflow to see its run history.</p>
       ) : runs.length === 0 && loading ? (
@@ -84,9 +119,11 @@ export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayR
         <p className="workflow-muted">
           No runs yet — dry-run snapshots and daemon executions land here.
         </p>
+      ) : visibleRuns.length === 0 ? (
+        <p className="workflow-muted">No {activeFilter.label.toLowerCase()} runs in this history.</p>
       ) : (
         <ol className="workflow-runs-list">
-          {runs.map((run) => {
+          {visibleRuns.map((run) => {
             const expanded = expandedId === run.id;
             const duration = runDuration(run);
             const replayable = run.steps.length > 0;

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -368,4 +368,30 @@ assert.match(studio, /workflowInputSteps\(workflow\)\.length > 0/, "Play should 
 assert.match(studio, /onPlay\(selectedWorkflow,\s*inputs\)/, "Captured run inputs should flow into the play handler");
 assert.match(css, /\.workflow-run-input-field/, "CSS should style run-input capture fields");
 
+// --- Studio clarity pass: uses autocomplete, navigable issues, runs filter, manifest copy ---
+
+// `uses` autocomplete: the step Uses field offers binding candidates via a native datalist.
+assert.match(inspector, /export type WorkflowUsesOption/, "Inspector should export the uses-option type for the studio to thread");
+assert.match(inspector, /<datalist id=\{listId\}>/, "Inspector should render a datalist for uses autocomplete");
+assert.match(inspector, /suggestions=\{usesOptions\}/, "The Uses field should be fed the uses options");
+assert.match(studio, /usesOptions\?: WorkflowUsesOption\[\]/, "Studio props should carry uses options");
+assert.match(studio, /usesOptions=\{props\.usesOptions\}/, "Studio should thread uses options into the inspector");
+
+// Validation issue → step: an issue that names a step renders as a jump button.
+assert.match(inspector, /function stepIdForIssue/, "Inspector should resolve a validation issue to its step");
+assert.match(inspector, /workflow-issue-jump/, "Inspector should render issues as jump-to-step affordances");
+assert.match(inspector, /onSelectStep/, "Inspector should accept an onSelectStep callback");
+assert.match(studio, /onSelectStep=\{props\.onSelectStep\}/, "Studio should thread onSelectStep into the inspector");
+assert.match(css, /\.workflow-issue-jump/, "CSS should style the issue jump affordance");
+
+// Runs history filter: plan snapshots vs executions vs problems.
+assert.match(runsPanel, /RUN_FILTERS/, "Runs panel should define history filters");
+assert.match(runsPanel, /workflow-runs-filter/, "Runs panel should render filter chips");
+assert.match(runsPanel, /visibleRuns/, "Runs panel should render the filtered run set");
+assert.match(css, /\.workflow-runs-filter-chip/, "CSS should style runs filter chips");
+
+// Manifest copy: hand off the canonical YAML.
+assert.match(manifestPreview, /navigator\.clipboard\.writeText/, "Manifest preview should copy the canonical YAML");
+assert.match(manifestPreview, /Copy manifest YAML/, "Manifest preview should expose a copy affordance");
+
 console.log("workflow-studio.test.ts: ok");

--- a/src/components/workflows/workflow-studio.tsx
+++ b/src/components/workflows/workflow-studio.tsx
@@ -25,7 +25,7 @@ import type { WorkflowFamiliarOption } from "./workflow-attachments";
 import { WorkflowCanvas } from "./workflow-canvas";
 import { WorkflowStepList } from "./workflow-step-list";
 import { WorkflowCreateDialog, WorkflowRunInputsDialog, WorkflowScheduleDialog } from "./workflow-create-dialog";
-import { WorkflowInspector } from "./workflow-inspector";
+import { WorkflowInspector, type WorkflowUsesOption } from "./workflow-inspector";
 import { WorkflowLibrary } from "./workflow-library";
 import { WorkflowManifestPreview } from "./workflow-manifest-preview";
 import { WorkflowPalette } from "./workflow-palette";
@@ -80,6 +80,7 @@ export type WorkflowStudioProps = {
   runs: WorkflowRunRecord[];
   runsLoading: boolean;
   familiarOptions: WorkflowFamiliarOption[];
+  usesOptions?: WorkflowUsesOption[];
   roles: WorkflowRoleSummary[];
   engineUnavailable: boolean;
   notice: string | null;
@@ -95,6 +96,7 @@ export type WorkflowStudioProps = {
   onRefresh: () => void;
   onSelectWorkflow: (workflow: WorkflowSummary) => void;
   onSelectNode: (node: WorkflowGraphNode) => void;
+  onSelectStep: (id: string) => void;
   onClearNode: () => void;
   onValidate: (workflow: WorkflowSummary) => void;
   onDryRun: (workflow: WorkflowSummary) => void;
@@ -351,9 +353,11 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
                 workflow={selectedWorkflow}
                 selectedNode={selectedNode}
                 action={action}
+                usesOptions={props.usesOptions}
                 onUpdateStep={props.onUpdateStep}
                 onUpdateMeta={props.onUpdateMeta}
                 onRemoveStep={props.onRemoveStep}
+                onSelectStep={props.onSelectStep}
               />
             )}
             {sidePanelSection === "attachments" && (

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -1325,6 +1325,95 @@
 .workflow-issue-semantic { color: var(--color-warning, #d9a13c); }
 .workflow-issue-preflight { color: var(--color-info, #6aa6ff); }
 
+/* An issue that names a step renders as a button that selects it — closing the
+   loop between "blocked" and "fix it here". Matches the static row's baseline
+   layout so clickable and non-clickable issues read the same. */
+.workflow-issue-jump {
+  display: flex;
+  width: 100%;
+  gap: 6px;
+  align-items: baseline;
+  margin: -1px -4px;
+  padding: 1px 4px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.workflow-issue-jump:hover {
+  border-color: color-mix(in oklch, var(--accent-presence) 40%, var(--border));
+  background: color-mix(in oklch, var(--accent-presence) 9%, transparent);
+}
+
+.workflow-issue-jump:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
+}
+
+.workflow-issue-jump-icon {
+  flex: none;
+  align-self: center;
+  margin-left: auto;
+  color: var(--muted-foreground);
+}
+
+.workflow-issue-jump:hover .workflow-issue-jump-icon {
+  color: var(--text-primary);
+}
+
+/* Runs history filter chips (plan snapshots vs real executions vs problems). */
+.workflow-runs-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.workflow-runs-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 24px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-base);
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.workflow-runs-filter-chip:hover {
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+
+.workflow-runs-filter-chip.is-active {
+  border-color: color-mix(in oklch, var(--accent-presence) 50%, var(--border));
+  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
+  color: var(--text-primary);
+}
+
+.workflow-runs-filter-chip:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
+}
+
+.workflow-runs-filter-count {
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted-foreground);
+}
+
+.workflow-runs-filter-chip.is-active .workflow-runs-filter-count {
+  color: var(--text-primary);
+}
+
 .workflow-role-list {
   margin: 0;
   padding: 0 4px 0 0;


### PR DESCRIPTION
## What

Four self-contained clarity improvements to the Workflows studio, building on the input→steps→output contract work (#1291).

### 1. `uses` autocomplete
The step **Uses** field was freeform text (`nova · cwf-validator@^1.0.0 · cave.output`) — easy to typo, no discovery. It now offers binding candidates via a native `<datalist>`, sourced from:
- **Familiars** (agents) and **other workflows** (sub-workflow refs) — always available client-side
- **Skills / tools** discovered from `/api/capabilities` — best-effort (daemon-backed; degrades to freeform + familiar/workflow suggestions when offline)

### 2. Navigable validation issues
Validation issues that name a step (resolved from `issue.path`) now render as a button that selects that step on click — closing the loop between "blocked" and "fix it here". Issues that don't resolve to a step stay as static text.

### 3. Runs history filter
The run history gains a compact filter — **All / Problems / Runs / Plans** (with counts) — shown once there are more than a couple of runs, so a busy workflow's real executions aren't buried under dry-run plan snapshots.

### 4. Manifest copy
The manifest preview gets a copy-to-clipboard button for the canonical YAML (the exact text Save writes, schema banner included).

## Testing
- `pnpm typecheck` — clean
- `pnpm test:app` (338) + `pnpm test:mobile` (16) — pass
- `pnpm build` (Next + ESLint + server bundle) — pass
- New source assertions in `workflow-studio.test.ts` pin all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)