### PR TITLE
style(chat): make the recommended follow-up pulse more noticeable

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8326,7 +8326,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   border-color: var(--color-success);
 }
 @keyframes cave-next-path-pulse {
-  0%, 100% { border-color: color-mix(in oklch, var(--color-success) 55%, var(--border-hairline)); }
+  0%, 100% { border-color: color-mix(in oklch, var(--color-success) 35%, var(--border-hairline)); }
   50% { border-color: var(--color-success); }
 }
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Widen the border-color pulse swing (dim trough 55% → 35% green) so the recommended next-step reads more clearly, still border-only. One-value change in `globals.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)