### PR TITLE
fix(reminders): cron "Next fire" preview honors the 12h/24h clock pref

### DIFF
--- a/src/components/new-reminder-modal.tsx
+++ b/src/components/new-reminder-modal.tsx
@@ -390,6 +390,8 @@ export function NewReminderModal({
                     day: "numeric",
                     hour: "numeric",
                     minute: "2-digit",
+                    // Match the fire-time preview above — honor the 12h/24h pref.
+                    hour12: readDateTimePrefs().clock !== "24h",
                   })}`
                 : "Try “0 9 * * 1-5” for weekdays at 9am."}
             </div>


### PR DESCRIPTION
## What

In the New Reminder modal, the main fire-time preview already respects the user's clock preference (`hour12: prefs.clock !== "24h"`), but the cron **"Next fire → …"** preview lower down didn't pass `hour12` — so a 24-hour user saw that one line rendered in 12-hour time.

This adds the same `hour12` flag so both previews agree.

## Verify
- `new-reminder-modal.test.ts` — pass; `pnpm build` — clean
- One-line change mirroring the existing, proven `hour12` usage a few lines above in the same component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)