### PR TITLE
feat(workflows): mobile-friendly step dependency editing

### DIFF
--- a/src/components/workflows/workflow-inspector.tsx
+++ b/src/components/workflows/workflow-inspector.tsx
@@ -2,6 +2,7 @@
 
 import { Icon } from "@/lib/icon";
 import type { WorkflowGraphNode } from "@/lib/workflow-graph";
+import { wouldCreateCycle } from "@/lib/workflow-draft";
 import {
   workflowInputSteps,
   workflowIssueSummary,
@@ -32,6 +33,10 @@ type WorkflowInspectorProps = {
   onRemoveStep: (id: string) => void;
   /** Jump to a step by id (e.g. from a validation issue that names it). */
   onSelectStep?: (id: string) => void;
+  /** Make `target` require `source` (same edge the canvas draws). */
+  onConnect?: (source: string, target: string) => void;
+  /** Drop the `target`-requires-`source` dependency. */
+  onDisconnect?: (source: string, target: string) => void;
 };
 
 /** The step a validation issue points at, resolved from its path (longest id wins). */
@@ -143,6 +148,8 @@ export function WorkflowInspector({
   onUpdateMeta,
   onRemoveStep,
   onSelectStep,
+  onConnect,
+  onDisconnect,
 }: WorkflowInspectorProps) {
   const issues = issuesForAction(action);
   const step = selectedNode
@@ -232,10 +239,60 @@ export function WorkflowInspector({
             placeholder="retry · halt · escalate"
             onCommit={(next) => onUpdateStep(step.id, { on_error: next || undefined })}
           />
-          <p className="workflow-muted">
-            Requires: {step.requires?.length ? step.requires.join(", ") : "none"} — draw edges on the
-            canvas to change dependencies.
-          </p>
+          {(() => {
+            // Dependency editor — the canvas-free way to wire `requires`, so a
+            // step's prerequisites are editable on mobile (where the React Flow
+            // canvas is swapped for the linear step list) as well as on desktop.
+            // Toggling a chip draws/removes the same edge the canvas would:
+            // making this step require another is connect(other → this). Options
+            // that would close a cycle are disabled (the reducer rejects them
+            // anyway; disabling makes that legible instead of a silent no-op).
+            const steps = workflow?.steps ?? [];
+            const others = steps.filter((entry) => entry.id !== step.id);
+            return (
+              <div className="workflow-field workflow-requires-field">
+                <span>Requires</span>
+                {others.length === 0 ? (
+                  <p className="workflow-muted workflow-requires-empty">No other steps to depend on yet.</p>
+                ) : (
+                  <div className="workflow-requires-options" role="group" aria-label="Step dependencies">
+                    {others.map((other) => {
+                      const active = step.requires?.includes(other.id) ?? false;
+                      const cyclic = !active && wouldCreateCycle(steps, other.id, step.id);
+                      const label = other.name ?? other.id;
+                      return (
+                        <button
+                          key={other.id}
+                          type="button"
+                          className={`workflow-requires-chip${active ? " is-active" : ""}`}
+                          aria-pressed={active}
+                          disabled={cyclic || (!onConnect && !onDisconnect)}
+                          title={
+                            cyclic
+                              ? `Requiring ${label} would create a dependency cycle`
+                              : active
+                                ? `Stop requiring ${label}`
+                                : `Require ${label} to finish first`
+                          }
+                          onClick={() =>
+                            active
+                              ? onDisconnect?.(other.id, step.id)
+                              : onConnect?.(other.id, step.id)
+                          }
+                        >
+                          {active && <Icon name="ph:check-bold" width={10} aria-hidden />}
+                          {label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+                <p className="workflow-muted workflow-requires-hint">
+                  Pick the steps that must finish first. On desktop you can also draw edges on the canvas.
+                </p>
+              </div>
+            );
+          })()}
         </div>
       ) : workflow ? (
         <div className="workflow-editor">

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -394,4 +394,15 @@ assert.match(css, /\.workflow-runs-filter-chip/, "CSS should style runs filter c
 assert.match(manifestPreview, /navigator\.clipboard\.writeText/, "Manifest preview should copy the canonical YAML");
 assert.match(manifestPreview, /Copy manifest YAML/, "Manifest preview should expose a copy affordance");
 
+// --- Mobile-friendly dependency editing ---
+// The inspector edits `requires` without the canvas (which mobile swaps for the
+// linear step list), so step prerequisites are editable on every viewport.
+assert.match(inspector, /workflow-requires-options/, "Inspector should render a dependency editor");
+assert.match(inspector, /wouldCreateCycle/, "Dependency editor should disable options that would cycle");
+assert.match(inspector, /onConnect\?\.\(other\.id, step\.id\)/, "Toggling a dependency on should connect other → this step");
+assert.match(inspector, /onDisconnect\?\.\(other\.id, step\.id\)/, "Toggling a dependency off should disconnect it");
+assert.match(studio, /onConnect=\{props\.onConnect\}[\s\S]{0,80}onDisconnect=\{props\.onDisconnect\}\s*\/>/, "Studio should thread connect/disconnect into the inspector");
+assert.match(css, /\.workflow-requires-chip\s*\{/, "CSS should style dependency toggle chips");
+assert.match(css, /\.workflow-requires-chip\s*\{\s*min-height:\s*var\(--touch-target\)/, "Dependency chips should meet the touch target on mobile");
+
 console.log("workflow-studio.test.ts: ok");

--- a/src/components/workflows/workflow-studio.tsx
+++ b/src/components/workflows/workflow-studio.tsx
@@ -358,6 +358,8 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
                 onUpdateMeta={props.onUpdateMeta}
                 onRemoveStep={props.onRemoveStep}
                 onSelectStep={props.onSelectStep}
+                onConnect={props.onConnect}
+                onDisconnect={props.onDisconnect}
               />
             )}
             {sidePanelSection === "attachments" && (

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -1196,6 +1196,71 @@
   margin-top: 4px;
 }
 
+/* Dependency (`requires`) editor — canvas-free way to wire prerequisites, so
+   step dependencies are editable on mobile too. One toggle chip per other step. */
+.workflow-requires-field > span {
+  margin-bottom: 4px;
+}
+
+.workflow-requires-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.workflow-requires-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 26px;
+  padding: 2px 9px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-base);
+  color: var(--text-secondary);
+  font-size: 11.5px;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.workflow-requires-chip:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+
+.workflow-requires-chip.is-active {
+  border-color: color-mix(in oklch, var(--accent-presence) 55%, var(--border));
+  background: color-mix(in oklch, var(--accent-presence) 16%, transparent);
+  color: var(--text-primary);
+}
+
+.workflow-requires-chip:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.workflow-requires-chip:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
+}
+
+.workflow-requires-empty,
+.workflow-requires-hint {
+  margin: 0;
+}
+
+.workflow-requires-hint {
+  margin-top: 5px;
+  font-size: 11px;
+}
+
+@media (max-width: 767px) {
+  .workflow-requires-chip {
+    min-height: var(--touch-target);
+    -webkit-tap-highlight-color: transparent;
+  }
+}
+
 .workflow-limits-row {
   display: grid;
   grid-template-columns: repeat(3, 1fr);


### PR DESCRIPTION
## What

Step dependencies (`requires`) were only editable by drawing edges on the React Flow canvas — but mobile swaps that canvas for the linear step list, so there was **no way to change a step's prerequisites on a phone**.

The inspector's static line —

> Requires: input — draw edges on the canvas to change dependencies.

is now an **interactive dependency editor**: a toggle chip per other step, checked when this step requires it. Toggling draws or removes the same edge the canvas would (`connect(other → this step)`). Since tapping a step on mobile already opens the shared inspector, this makes dependency editing work on every viewport — and gives desktop a canvas-free path too.

- Options that would close a dependency **cycle are disabled** (the draft reducer rejects them anyway via `wouldCreateCycle`; disabling makes that legible instead of a silent no-op).
- Chips meet the 44px touch target on mobile.

## Testing
- `pnpm typecheck` — clean
- `pnpm test:app` (338) + `pnpm test:mobile` (16) — pass
- `pnpm build` — pass
- New source assertions in `workflow-studio.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)