### PR TITLE
feat(familiars): Escape-to-clear + accessible name on the search input

### DIFF
--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -196,8 +196,16 @@ export function FamiliarsView({
               className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-muted)]"
             />
             <input
+              type="search"
+              aria-label="Search familiars"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Escape" && query) {
+                  event.preventDefault();
+                  setQuery("");
+                }
+              }}
               placeholder="Search familiars…"
               className="focus-ring h-8 w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 pl-7 pr-3 text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent-presence)]"
             />


### PR DESCRIPTION
## What

The Familiars search input was the **one primary search field missing the Escape-to-clear convention** (board #1276, capabilities #1276, projects/sessions #1278 all have it), and it had **no accessible name** — a screen reader announced an unlabeled text box.

This adds `type="search"`, `aria-label="Search familiars"`, and the same guarded Escape-to-clear handler (only consumes Escape when there's a query to clear).

## Verify
- `familiars-view.test.ts` — pass; `pnpm build` — clean
- **Live-verified** (Familiars surface, demo): the input resolves by its `aria-label`, and typing then pressing **Escape** clears it (`cleared: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)