### PR TITLE
fix(library): lift the metadata grid past italic taglines & stacked headings

### DIFF
--- a/src/lib/library-metadata.test.ts
+++ b/src/lib/library-metadata.test.ts
@@ -69,8 +69,25 @@ assert.ok(taglined, "metadata after a single bold tagline is detected");
 assert.deepEqual(taglined.entries.map((e) => e.key), ["A", "B"]);
 assert.match(taglined.rest, /^\*\*A bold tagline\*\*/, "bold tagline stays in the body");
 
-// But only ONE leading block is skipped — metadata buried under real prose
-// (subtitle + a prose paragraph) is NOT swallowed.
+// ── An italic tagline subtitle before the metadata is allowed ────
+const italic = parseLeadingMetadata("*A working synthesis on agent memory.*\n\n**Author:** Sage **Started:** 2026-05-30\n\nbody");
+assert.ok(italic, "metadata after a single italic tagline is detected");
+assert.deepEqual(italic.entries.map((e) => e.key), ["Author", "Started"]);
+assert.match(italic.rest, /^\*A working synthesis on agent memory\.\*/, "italic tagline stays in the body");
+
+// ── A stack of leading headings before the metadata is allowed ───
+const stacked = parseLeadingMetadata("## Internal Synthesis Note\n### 2026-06-13\n\n**Prepared by:** Sage **Status:** Definitive\n\nbody");
+assert.ok(stacked, "metadata after stacked headings is detected");
+assert.deepEqual(stacked.entries.map((e) => e.key), ["Prepared by", "Status"]);
+assert.match(stacked.rest, /^## Internal Synthesis Note\n### 2026-06-13/, "stacked headings stay in the body");
+
+// ── Two separate subtitle blocks (heading then italic tagline) are skipped ──
+const twoBlocks = parseLeadingMetadata("## Heading\n\n*tagline*\n\n**A:** one **B:** two");
+assert.ok(twoBlocks, "metadata after two separate subtitle blocks is detected");
+assert.deepEqual(twoBlocks.entries.map((e) => e.key), ["A", "B"]);
+
+// Only subtitle/heading blocks are skipped — metadata buried under real prose
+// (subtitle + a PROSE paragraph) is NOT swallowed; skipping stops at prose.
 assert.equal(
   parseLeadingMetadata("## Heading\n\nSome intro prose.\n\n**A:** one **B:** two"),
   null,

--- a/src/lib/library-metadata.ts
+++ b/src/lib/library-metadata.ts
@@ -56,25 +56,38 @@ function gatherParagraph(
   return { start, end: i, text: para.join(" ").trim() };
 }
 
-/** A single-line bold tagline (`**…**`) or a markdown heading (`## …`) — the
- *  kind of subtitle research notes place between the title and the metadata
- *  run. Used to allow ONE leading subtitle before the metadata. */
-function isLeadingSubtitle(lines: string[], start: number, end: number): boolean {
-  if (end - start !== 1) return false; // single line only
-  const line = lines[start].trim();
-  return /^#{1,6}\s/.test(line) || /^\*\*[^*].*\*\*$/.test(line);
+// A "subtitle" line: a markdown heading (`## …`), a bold tagline (`**…**`), or
+// an italic tagline (`*…*`). Research notes place these between the title and
+// the metadata run.
+const SUBTITLE_LINE_RE = /^(?:#{1,6}\s|\*\*[^*].*\*\*$|\*[^*].*\*$)/;
+
+/** A subtitle block: every line is a heading/bold/italic tagline (a block may
+ *  be multi-line, e.g. a stacked `## …` + `### …`). Used to skip the
+ *  subtitle/heading region notes place before the metadata run. */
+function isSubtitleBlock(lines: string[], start: number, end: number): boolean {
+  if (end <= start) return false;
+  for (let i = start; i < end; i++) {
+    if (!SUBTITLE_LINE_RE.test(lines[i].trim())) return false;
+  }
+  return true;
 }
+
+// Cap on how many leading subtitle/heading blocks we skip looking for the
+// metadata run — enough for a stacked-heading + tagline opener, low enough that
+// a metadata-looking paragraph buried in real prose is never swallowed.
+const MAX_SUBTITLE_SKIP = 3;
 
 /**
  * Detect a leading metadata paragraph and split it into entries.
  *
- * Qualifies when the metadata run is the first paragraph, OR when it's the
- * second paragraph and the first is a single-line subtitle/heading (a bold
- * tagline or `## …`) — many notes open with such a subtitle before the
- * metadata. The subtitle is kept in `rest` (it renders below the lifted grid);
- * only the metadata paragraph is removed. Skips at most one leading subtitle,
- * so a metadata-looking paragraph buried under real prose isn't swallowed.
- * Returns `null` when no leading metadata paragraph is present.
+ * Qualifies when the metadata run is the first paragraph, OR when it follows a
+ * short leading run of subtitle/heading blocks — a bold or italic tagline,
+ * `## …` headings, or a stack of them — which research notes routinely place
+ * between the title and the metadata. The skipped subtitles are kept in `rest`
+ * (they render below the lifted grid); only the metadata paragraph is removed.
+ * At most MAX_SUBTITLE_SKIP all-subtitle blocks are skipped, and skipping stops
+ * at the first non-subtitle block, so a metadata-looking paragraph buried under
+ * real prose isn't swallowed. Returns `null` when no leading metadata is found.
  */
 export function parseLeadingMetadata(body: string): LeadingMetadata | null {
   const lines = body.split("\n");
@@ -89,15 +102,23 @@ export function parseLeadingMetadata(body: string): LeadingMetadata | null {
     return { entries: firstEntries, rest };
   }
 
-  // Case 2 — a single leading subtitle/heading precedes the metadata run.
-  if (!isLeadingSubtitle(lines, first.start, first.end)) return null;
-  const second = gatherParagraph(lines, first.end);
-  if (!second) return null;
-  const secondEntries = metadataEntries(second.text);
-  if (!secondEntries) return null;
-
-  const subtitle = lines.slice(first.start, first.end).join("\n");
-  const after = lines.slice(second.end).join("\n").replace(/^\n+/, "");
-  const rest = after ? `${subtitle}\n\n${after}` : subtitle;
-  return { entries: secondEntries, rest };
+  // Case 2 — the metadata run follows a short run of leading subtitle blocks.
+  const skipped: string[] = [];
+  let block: ReturnType<typeof gatherParagraph> = first;
+  let skips = 0;
+  while (block && isSubtitleBlock(lines, block.start, block.end) && skips < MAX_SUBTITLE_SKIP) {
+    skipped.push(lines.slice(block.start, block.end).join("\n"));
+    skips++;
+    const next = gatherParagraph(lines, block.end);
+    if (!next) return null;
+    const entries = metadataEntries(next.text);
+    if (entries) {
+      const after = lines.slice(next.end).join("\n").replace(/^\n+/, "");
+      const head = skipped.join("\n\n");
+      const rest = after ? `${head}\n\n${after}` : head;
+      return { entries, rest };
+    }
+    block = next; // not metadata — keep going only if it's another subtitle block
+  }
+  return null;
 }


### PR DESCRIPTION
## What

Follow-up to the metadata-grid subtitle-skip fix. An audit of **all 226 research notes** found the grid still missed two more common opener shapes; this covers both.

## Why (audit-driven)

- **Italic tagline** before the metadata — `*A working synthesis…*` then `**Author:** …` (agent-memory, 9router, multica).
- **Stacked headings** before it — `## …` then `### …` then `**Prepared by:** …` (vercel-ai-sdk).

## Change

Generalize the skip: instead of one single-line bold/heading subtitle, skip a short leading run (**≤3**) of *subtitle blocks* — blocks whose every line is a heading (`## …`), a bold tagline (`**…**`), or an italic tagline (`*…*`), including multi-line stacks. Skipping **stops at the first non-subtitle block**, so a metadata-looking paragraph buried under real prose is still left alone. Skipped subtitles stay in the body (below the lifted grid).

Only `library-metadata.ts` (+ its test) changes; the grid render/CSS already exist.

## Verification

- **Audit across 226 notes:** grid now fires on **61** (was 57) — the +4 are exactly the 3 italic-tagline notes and the 1 stacked-heading note. No false positives (no-grid count moved by exactly 4).
- Remaining 7 labelled-but-unlifted notes are **out of scope by design**: blockquote metadata (`> **X:**`, 2) and same-paragraph byline prefixes (2), plus genuine single-label / inline-label prose (3 true negatives).
- Live-verified the `Vercel AI SDK` note (stacked headings) now renders the grid (5 entries).
- Parser unit tests + `pnpm test:app` — ✓ 338 test file(s) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)