### PR TITLE
fix(github): use the app-canonical relativeTime for timestamps

### DIFF
--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -209,4 +209,10 @@ assert.match(
   "the sort control is a real keyboard-operable button",
 );
 
+// GitHub timestamps use the app-canonical relativeTime (which formats "2m ago"
+// / "Jun 12" itself), not a local relTime helper with a manually-appended " ago"
+// that disagreed between call sites.
+assert.ok(source.includes('import { relativeTime } from "@/lib/relative-time"'), "imports shared relativeTime");
+assert.ok(!source.includes("relTime"), "local relTime helper and its call sites are gone");
+
 console.log("github-view-polish.test.ts OK");

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -2,6 +2,7 @@
 
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { relativeTime } from "@/lib/relative-time";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import type { Familiar } from "@/lib/types";
 import type { Card, CardStatus } from "@/lib/cave-board-types";
@@ -81,17 +82,6 @@ function useCards(): { cards: Card[]; reload: () => void } {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function relTime(iso: string): string {
-  const ts = Date.parse(iso);
-  if (!Number.isFinite(ts)) return "";
-  const s = (Date.now() - ts) / 1000;
-  if (s < 60) return `${Math.round(s)}s`;
-  if (s < 3600) return `${Math.round(s / 60)}m`;
-  if (s < 86400) return `${Math.round(s / 3600)}h`;
-  const d = Math.round(s / 86400);
-  return d < 30 ? `${d}d` : `${Math.round(d / 30)}mo`;
-}
 
 const KIND_ICON: Record<string, "ph:git-pull-request" | "ph:circle-dashed" | "ph:bell" | "ph:github-logo"> = {
   pr: "ph:git-pull-request",
@@ -749,7 +739,7 @@ function GitHubItemGlassPanel({
             {" · "}
             {item.repo}
             {" · "}
-            {relTime(detail?.createdAt ?? item.updatedAt)} ago
+            {relativeTime(detail?.createdAt ?? item.updatedAt)}
           </span>
         </div>
       </div>
@@ -1418,7 +1408,7 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
                         )}
                       </td>
                       <td style={{ textAlign: "right" }}>
-                        <span className="board-table-cell-time">{relTime(item.updatedAt)}</span>
+                        <span className="board-table-cell-time">{relativeTime(item.updatedAt)}</span>
                       </td>
                       <td style={{ textAlign: "right" }}>
                         <div className="gh-actions">


### PR DESCRIPTION
## Problem
GitHub view had a local `relTime()` helper that:
- returned `"5m"` / `"3h"` / `"2d"` **without** "ago", and
- never fell back to a date — a months-old PR read `"5mo"`.

Its two call sites disagreed: the detail header rendered `{relTime(...)} ago` → **"5m ago"**, while the list rendered `{relTime(...)}` → **"5m"**. Two different formats for the same kind of timestamp within one view, and neither matched the rest of the app.

## Fix
Replace the local helper with the shared, app-canonical `relativeTime` from `@/lib/relative-time` (already used by dashboard, journal, projects, board): consistent `"just now"` / `"2m ago"` / `"3h ago"` / `"1d ago"`, then a real `"Jun 12"` date past a week. `relativeTime` formats the suffix/date itself, so the manual `" ago"` is dropped.

Net: GitHub timestamps are now internally consistent and aligned with every other surface.

## Tests
Extended `github-view-polish.test.ts` to assert the shared import is used and no `relTime` remains. Ran github-view-polish and relative-time suites — green.

## Note
The broader sweep (notification-bell, coven-floor, automations-view, comux-view, inspector-pane, health-strip, library-timeline still have their own ad-hoc helpers) is intentionally left as a separate, deliberate follow-up — those have differing output formats and changing them all at once is a larger, behavior-changing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)