### PR TITLE
fix(schedules): confirm before deleting a reminder

### DIFF
--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -1191,6 +1191,9 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
 
   const removeItem = useCallback(async (id: string) => {
     if (id.startsWith("eph:")) return;
+    const target = items.find((i) => i.id === id);
+    const label = target?.title ? `“${target.title}”` : "this reminder";
+    if (!window.confirm(`Delete ${label}? This can't be undone.`)) return;
     setBusyId(id);
     try {
       const res = await fetch(`/api/inbox/${id}`, { method: "DELETE" });
@@ -1200,7 +1203,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     } catch (err) {
       setError(err instanceof Error ? err.message : "delete failed");
     } finally { setBusyId(null); }
-  }, [load]);
+  }, [items, load]);
 
   const runNow = (id: string) =>
     patchItem(id, { fireAt: new Date().toISOString(), status: "pending" });


### PR DESCRIPTION
## What

Deleting a reminder/automation from the Schedules detail fired an immediate, **irreversible** `DELETE /api/inbox/:id` with no confirmation — unlike the rest of the app, where destructive actions (workflow delete, canvas artifact delete) go through a `window.confirm` guard.

This adds the same guard, naming the reminder being deleted: *Delete "<title>"? This can't be undone.*

## Verify
- `automations-view.test.ts`, `automations-detail-inputs.test.ts` — pass; `pnpm build` — clean
- Uses the app's established `window.confirm` pattern (same as `workflows-view`/`canvas-artifact-node`). Demo mode has no reminders, so the dialog wasn't exercised live; the change is a guarded early-return before the existing delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)