### PR TITLE
fix(vault): confirm before deleting a secret

### DIFF
--- a/src/components/vault-panel.tsx
+++ b/src/components/vault-panel.tsx
@@ -162,6 +162,7 @@ export function VaultPanel() {
   useEffect(() => { void load(); }, []);
 
   async function handleDelete(key: string) {
+    if (!window.confirm(`Delete the secret “${key}”? Anything mapped to it will stop resolving. This can't be undone.`)) return;
     setDeleting(key);
     try {
       await fetch("/api/vault", {


### PR DESCRIPTION
## What

Deleting a mapping in the Secret Vault fired an immediate, **irreversible** `DELETE /api/vault` with no confirmation. An accidental click silently breaks anything that resolves through that key.

This adds a `window.confirm` guard naming the secret — matching the app's other destructive-action confirms (workflow delete, canvas delete, and the reminder delete in #1310).

## Verify
- `surface-error-states.test.ts`, `surface-loading-states.test.ts` (both read vault-panel.tsx) — pass; `pnpm build` — clean
- Guarded early-return before the existing delete; uses the app's established `window.confirm` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)