### PR TITLE
feat(workflows): dry-run preflight estimate + input ergonomics

### DIFF
--- a/src/components/workflows/workflow-inspector.tsx
+++ b/src/components/workflows/workflow-inspector.tsx
@@ -8,6 +8,7 @@ import {
   workflowIssueSummary,
   workflowOutputSteps,
   workflowRunBlockReason,
+  type WorkflowDryRunPlan,
   type WorkflowStepKind,
   type WorkflowStepSummary,
   type WorkflowSummary,
@@ -79,9 +80,45 @@ const PATTERNS = [
   "custom",
 ];
 
+// The standard CWF-01 on-error dispositions. A blank value means "inherit the
+// workflow default"; an unrecognized manifest value is preserved as a fallback
+// option so editing never silently drops it.
+const ON_ERROR_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "", label: "Default" },
+  { value: "retry", label: "Retry" },
+  { value: "halt", label: "Halt" },
+  { value: "escalate", label: "Escalate" },
+];
+
 function issuesForAction(action: WorkflowStudioActionState | null): WorkflowValidationIssue[] {
   if (!action?.result || !("issues" in action.result)) return [];
   return action.result.issues ?? [];
+}
+
+/** The dry-run preflight estimate (what the run will cost / need), if the current action carries one. */
+function estimatesForAction(action: WorkflowStudioActionState | null): WorkflowDryRunPlan["estimates"] | null {
+  if (action?.kind !== "dry-run") return null;
+  return (action.result as WorkflowDryRunPlan).estimates ?? null;
+}
+
+/** Flatten the dry-run estimate into the present (label, value) rows worth showing. */
+function preflightRows(estimates: NonNullable<WorkflowDryRunPlan["estimates"]>): Array<{ label: string; value: string }> {
+  const rows: Array<{ label: string; value: string }> = [];
+  if (typeof estimates.maxAgents === "number") rows.push({ label: "Agents", value: String(estimates.maxAgents) });
+  if (typeof estimates.timeoutS === "number") rows.push({ label: "Timeout", value: `${estimates.timeoutS}s` });
+  if (typeof estimates.costCeilingUsd === "number") {
+    rows.push({ label: "Cost ceiling", value: `$${estimates.costCeilingUsd}` });
+  }
+  if (estimates.requiredCapabilities?.length) {
+    rows.push({ label: "Capabilities", value: estimates.requiredCapabilities.join(", ") });
+  }
+  if (estimates.requiredExternalAccounts?.length) {
+    rows.push({ label: "External accounts", value: estimates.requiredExternalAccounts.join(", ") });
+  }
+  if (estimates.humanGates?.length) {
+    rows.push({ label: "Human gates", value: String(estimates.humanGates.length) });
+  }
+  return rows;
 }
 
 function parseCsv(value: string): string[] | undefined {
@@ -99,6 +136,7 @@ function Field({
   onCommit,
   suggestions,
   listId,
+  multiline,
 }: {
   label: string;
   value: string;
@@ -107,8 +145,27 @@ function Field({
   /** Optional autocomplete candidates rendered as a native <datalist>. */
   suggestions?: WorkflowUsesOption[];
   listId?: string;
+  /** Render a textarea (for prose like summaries that feed the run prompt). */
+  multiline?: boolean;
 }) {
   const hasSuggestions = Boolean(listId && suggestions && suggestions.length > 0);
+  if (multiline) {
+    return (
+      <label className="workflow-field">
+        <span>{label}</span>
+        <textarea
+          className="workflow-field-textarea"
+          rows={2}
+          defaultValue={value}
+          placeholder={placeholder}
+          key={`${label}:${value}`}
+          onBlur={(event) => {
+            if (event.target.value !== value) onCommit(event.target.value);
+          }}
+        />
+      </label>
+    );
+  }
   return (
     <label className="workflow-field">
       <span>{label}</span>
@@ -161,6 +218,8 @@ export function WorkflowInspector({
   // makes the execution contract legible without hovering the disabled Play
   // button. The counts split the graph into its declared input(s), the work
   // between, and the produced output(s).
+  const estimates = estimatesForAction(action);
+  const preflight = estimates ? preflightRows(estimates) : [];
   const runBlock = workflowRunBlockReason(workflow);
   const inputCount = workflow ? workflowInputSteps(workflow).length : 0;
   const outputCount = workflow ? workflowOutputSteps(workflow).length : 0;
@@ -225,6 +284,7 @@ export function WorkflowInspector({
           <Field
             label="Summary"
             value={step.summary ?? ""}
+            multiline
             onCommit={(next) => onUpdateStep(step.id, { summary: next || undefined })}
           />
           <Field
@@ -233,12 +293,22 @@ export function WorkflowInspector({
             placeholder="repo.read, web.fetch"
             onCommit={(next) => onUpdateStep(step.id, { permissions: parseCsv(next) })}
           />
-          <Field
-            label="On error"
-            value={step.on_error ?? ""}
-            placeholder="retry · halt · escalate"
-            onCommit={(next) => onUpdateStep(step.id, { on_error: next || undefined })}
-          />
+          <label className="workflow-field">
+            <span>On error</span>
+            <select
+              value={step.on_error ?? ""}
+              onChange={(event) => onUpdateStep(step.id, { on_error: event.target.value || undefined })}
+            >
+              {ON_ERROR_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+              {step.on_error && !ON_ERROR_OPTIONS.some((option) => option.value === step.on_error) && (
+                <option value={step.on_error}>{step.on_error}</option>
+              )}
+            </select>
+          </label>
           {(() => {
             // Dependency editor — the canvas-free way to wire `requires`, so a
             // step's prerequisites are editable on mobile (where the React Flow
@@ -339,6 +409,7 @@ export function WorkflowInspector({
           <Field
             label="Summary"
             value={workflow.summary ?? ""}
+            multiline
             onCommit={(next) => onUpdateMeta({ summary: next || undefined })}
           />
           <Field
@@ -425,6 +496,21 @@ export function WorkflowInspector({
             );
           })}
         </ul>
+      )}
+
+      {preflight.length > 0 && (
+        <>
+          <h3>Preflight</h3>
+          <p className="workflow-muted workflow-preflight-lead">What a run would need, from the dry-run plan.</p>
+          <dl className="workflow-detail-list workflow-preflight-list">
+            {preflight.map((row) => (
+              <div key={row.label}>
+                <dt>{row.label}</dt>
+                <dd>{row.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </>
       )}
       </>
     </section>

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -405,4 +405,22 @@ assert.match(studio, /onConnect=\{props\.onConnect\}[\s\S]{0,80}onDisconnect=\{p
 assert.match(css, /\.workflow-requires-chip\s*\{/, "CSS should style dependency toggle chips");
 assert.match(css, /\.workflow-requires-chip\s*\{\s*min-height:\s*var\(--touch-target\)/, "Dependency chips should meet the touch target on mobile");
 
+// --- Preflight estimate + input ergonomics ---
+// The dry-run plan's estimate (cost/agents/capabilities/accounts/gates) is no
+// longer discarded — the inspector surfaces it as a Preflight panel.
+assert.match(inspector, /function estimatesForAction/, "Inspector should read the dry-run estimate");
+assert.match(inspector, /function preflightRows/, "Inspector should flatten the estimate into displayable rows");
+assert.match(inspector, /requiredExternalAccounts/, "Preflight should surface required external accounts");
+assert.match(inspector, /<h3>Preflight<\/h3>/, "Inspector should render a Preflight section");
+assert.match(css, /\.workflow-preflight-list/, "CSS should style the preflight estimate grid");
+
+// On-error is a standardized select (retry/halt/escalate), not freeform text.
+assert.match(inspector, /ON_ERROR_OPTIONS/, "On error should be a standardized select");
+assert.match(inspector, /value:\s*"escalate"/, "On error options should include the CWF-01 dispositions");
+
+// Summaries that feed the run prompt are multi-line.
+assert.match(inspector, /multiline\?: boolean/, "Field should support a multiline (textarea) variant");
+assert.match(inspector, /<textarea/, "Multiline field should render a textarea");
+assert.match(css, /\.workflow-field-textarea/, "CSS should style the multiline field");
+
 console.log("workflow-studio.test.ts: ok");

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -1163,7 +1163,8 @@
 }
 
 .workflow-field input,
-.workflow-field select {
+.workflow-field select,
+.workflow-field-textarea {
   width: 100%;
   font-size: 12px;
   padding: 4px 8px;
@@ -1171,6 +1172,13 @@
   border-radius: 6px;
   background: color-mix(in srgb, var(--muted) 55%, transparent);
   color: var(--text-primary, inherit);
+}
+
+.workflow-field-textarea {
+  font-family: inherit;
+  line-height: 1.45;
+  resize: vertical;
+  min-height: 46px;
 }
 
 /* Compact, engine-consistent selects: native appearance ignores the field
@@ -1187,9 +1195,25 @@
 }
 
 .workflow-field input:focus,
-.workflow-field select:focus {
+.workflow-field select:focus,
+.workflow-field-textarea:focus {
   outline: none;
   border-color: color-mix(in oklch, var(--accent-presence) 65%, transparent);
+}
+
+/* Preflight estimate (from the dry-run plan): a compact two-column key/value
+   grid so "what the run needs" reads at a glance under Validation. */
+.workflow-preflight-lead {
+  margin: 0 0 6px;
+}
+
+.workflow-preflight-list {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px 14px;
+}
+
+.workflow-preflight-list dd {
+  font-variant-numeric: tabular-nums;
 }
 
 .workflow-field-inline {


### PR DESCRIPTION
## What

Three inspector improvements around run preparation — building on the input→steps→output contract work.

### 1. Surface the dry-run preflight estimate (headline)
The dry-run plan already computes `estimates: { maxAgents, timeoutS, costCeilingUsd, requiredCapabilities, requiredExternalAccounts, humanGates }` — but **no component rendered any of it**; you only saw "ready/blocked + N issues". The inspector now shows a compact **Preflight** key/value grid under Validation (only the fields the plan provides), so you can see *what a run will cost and need* before pressing Play.

### 2. Standardize `On error`
Was freeform text (placeholder "retry · halt · escalate"). Now a select — **Default / Retry / Halt / Escalate** — matching the Kind dropdown's pattern. A non-standard manifest value is preserved as a fallback option so editing never silently drops it.

### 3. Multi-line summaries
Step and workflow `Summary` fields are now textareas. They feed the compiled run prompt, so longer descriptions are now usable.

## Testing
- `pnpm typecheck` — clean
- `pnpm test:app` (338) + `pnpm test:mobile` (16) — pass
- `pnpm build` — pass
- New source assertions in `workflow-studio.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)