### PR TITLE
feat(dashboard): label the recent-report mini-stat abbreviations

### DIFF
--- a/src/components/dashboard/recent-reports.tsx
+++ b/src/components/dashboard/recent-reports.tsx
@@ -30,9 +30,9 @@ export function RecentReports({
                   </span>
                   {report.stats ? (
                     <span className="dr-report-row__stats">
-                      <span className="dr-mini-stat"><b>{report.stats.reminders}</b> rem</span>
-                      <span className="dr-mini-stat"><b>{report.stats.responses}</b> resp</span>
-                      <span className="dr-mini-stat"><b>{report.stats.sessions}</b> sess</span>
+                      <span className="dr-mini-stat" title="Reminders fired"><b>{report.stats.reminders}</b> rem</span>
+                      <span className="dr-mini-stat" title="Responses waiting"><b>{report.stats.responses}</b> resp</span>
+                      <span className="dr-mini-stat" title="Sessions updated"><b>{report.stats.sessions}</b> sess</span>
                     </span>
                   ) : null}
                 </span>


### PR DESCRIPTION
## What

The dashboard's "Recent daily reports" rows show compact per-day counts as **"N rem / N resp / N sess"** with no explanation of the abbreviations. This adds `title` tooltips — *Reminders fired / Responses waiting / Sessions updated* — so the numbers are decodable on hover while the row stays compact.

## Verify
- `dashboard-page.test.ts` — pass; `pnpm build` — clean
- Static `title` attributes in a server component; no behavior/layout change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)