### PR TITLE
refactor(time): route ad-hoc relative-time helpers through the shared formatter

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -467,6 +467,7 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/lib/familiar-card-data.test.ts",
   "src/lib/dashboard-model.test.ts",
   "src/lib/slash-commands.test.ts",
   "src/lib/canvas-generate.test.ts",

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Fragment, useCallback, useEffect, useMemo, useReducer, useRef, useState, type DragEvent, type ReactNode } from "react";
+import { relativeTime } from "@/lib/relative-time";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { BottomTerminal } from "@/components/bottom-terminal";
 import { Icon } from "@/lib/icon";
@@ -252,18 +253,7 @@ function formatBytes(bytes: number | undefined): string | null {
 }
 
 function shortProjectTime(iso: string | null): string {
-  if (!iso) return "No sessions yet";
-  try {
-    const diffSec = (Date.now() - new Date(iso).getTime()) / 1000;
-    if (diffSec < 60) return "just now";
-    if (diffSec < 3600) return `${Math.round(diffSec / 60)}m ago`;
-    if (diffSec < 86400) return `${Math.round(diffSec / 3600)}h ago`;
-    const days = Math.round(diffSec / 86400);
-    if (days < 30) return `${days}d ago`;
-    return `${Math.round(days / 30)}mo ago`;
-  } catch {
-    return "No sessions yet";
-  }
+  return iso ? relativeTime(iso) : "No sessions yet";
 }
 
 export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNewChat, active = true, storageNamespace = "" }: Props) {

--- a/src/components/coven-floor.tsx
+++ b/src/components/coven-floor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import "@/styles/board.css";
+import { relativeTime } from "@/lib/relative-time";
 
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
@@ -13,12 +14,7 @@ import { SkeletonRows } from "@/components/ui/skeleton";
 const MAX_VISIBLE_SESSIONS = 12;
 
 function relTime(iso: string | null): string {
-  if (!iso) return "never";
-  const diffMs = Date.now() - new Date(iso).getTime();
-  if (diffMs < 60_000) return "just now";
-  if (diffMs < 3_600_000) return `${Math.floor(diffMs / 60_000)}m ago`;
-  if (diffMs < 86_400_000) return `${Math.floor(diffMs / 3_600_000)}h ago`;
-  return `${Math.floor(diffMs / 86_400_000)}d ago`;
+  return iso ? relativeTime(iso) : "never";
 }
 
 function fmtRuntime(ms: number | undefined): string | null {

--- a/src/components/familiar-status-card.tsx
+++ b/src/components/familiar-status-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { relativeTime } from "@/lib/relative-time";
 import { FamiliarGlyph } from "@/components/familiar-glyph";
 import { parseGlyphString } from "@/lib/familiar-glyph";
 import { Icon } from "@/lib/icon";
@@ -10,12 +11,7 @@ import { statusColor, statusLabel } from "@/lib/coven-status-types";
 // ── Relative time ─────────────────────────────────────────────────────────────
 
 function relTime(iso: string | null): string {
-  if (!iso) return "never";
-  const diffMs = Date.now() - new Date(iso).getTime();
-  if (diffMs < 60_000) return "just now";
-  if (diffMs < 3_600_000) return `${Math.floor(diffMs / 60_000)}m ago`;
-  if (diffMs < 86_400_000) return `${Math.floor(diffMs / 3_600_000)}h ago`;
-  return `${Math.floor(diffMs / 86_400_000)}d ago`;
+  return iso ? relativeTime(iso) : "never";
 }
 
 // ── Format runtime ────────────────────────────────────────────────────────────

--- a/src/components/health-strip.tsx
+++ b/src/components/health-strip.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { relativeTime } from "@/lib/relative-time";
 import type { Familiar } from "@/lib/types";
 
 type DaemonHealth = {
@@ -60,15 +61,7 @@ function dotColor(state: DotState): string {
 }
 
 function relTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  if (Number.isNaN(diff) || diff < 0) return "just now";
-  const s = Math.floor(diff / 1000);
-  if (s < 60) return `${s}s ago`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
-  return `${Math.floor(h / 24)}d ago`;
+  return relativeTime(iso);
 }
 
 export function HealthStrip({ familiars }: { familiars: Familiar[] }) {

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { relativeTime } from "@/lib/relative-time";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { Familiar } from "@/lib/types";
 import type { InboxPrefs, SoundMode } from "@/lib/cave-inbox-prefs";
@@ -17,14 +18,7 @@ type Props = {
 };
 
 function relTime(iso: string | null | undefined): string {
-  if (!iso) return "—";
-  const diff = Date.now() - new Date(iso).getTime();
-  const mins = Math.round(Math.abs(diff) / 60_000);
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.round(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.round(hrs / 24)}d ago`;
+  return iso ? relativeTime(iso) : "—";
 }
 
 export function NotificationBell({

--- a/src/lib/familiar-card-data.test.ts
+++ b/src/lib/familiar-card-data.test.ts
@@ -25,10 +25,12 @@ assert.equal(pickFamiliarMemory([{ relPath: "m/f.md", modified: "2026-06-12T00:0
 
 // formatRelTime
 assert.equal(formatRelTime(null), "never");
-assert.equal(formatRelTime(new Date(Date.now() - 30_000).toISOString()), "just now");
+assert.equal(formatRelTime(new Date(Date.now() - 10_000).toISOString()), "just now");
 assert.match(formatRelTime(new Date(Date.now() - 5 * 60_000).toISOString()), /^5m ago$/);
 assert.match(formatRelTime(new Date(Date.now() - 3 * 3_600_000).toISOString()), /^3h ago$/);
 assert.match(formatRelTime(new Date(Date.now() - 2 * 86_400_000).toISOString()), /^2d ago$/);
+// Past a week, items show a real date (shared relativeTime), not an ever-growing "Nd ago".
+assert.match(formatRelTime(new Date(Date.now() - 30 * 86_400_000).toISOString()), /^[A-Z][a-z]{2} \d{1,2}$/);
 
 // statusMeta: known status → label + non-empty color; unknown → neutral, no pulse
 const active = statusMeta("active");

--- a/src/lib/familiar-card-data.ts
+++ b/src/lib/familiar-card-data.ts
@@ -3,6 +3,8 @@
  * No React, no fetch — unit-tested in familiar-card-data.test.ts.
  */
 
+import { relativeTime } from "@/lib/relative-time";
+
 /** Minimal shape of a /api/memory entry this card consumes. */
 export type RawMemoryEntry = {
   familiarId?: string;
@@ -51,12 +53,7 @@ export function pickFamiliarMemory(
 
 /** Relative time, mirrors familiar-status-card's relTime. */
 export function formatRelTime(iso: string | null | undefined): string {
-  if (!iso) return "never";
-  const diffMs = Date.now() - new Date(iso).getTime();
-  if (diffMs < 60_000) return "just now";
-  if (diffMs < 3_600_000) return `${Math.floor(diffMs / 60_000)}m ago`;
-  if (diffMs < 86_400_000) return `${Math.floor(diffMs / 3_600_000)}h ago`;
-  return `${Math.floor(diffMs / 86_400_000)}d ago`;
+  return iso ? relativeTime(iso) : "never";
 }
 
 export type StatusMeta = { label: string; color: string; pulse: boolean };


### PR DESCRIPTION
Follow-up to #1309 (which did github-view). Six more surfaces each had their own copy-pasted `"Nm ago / Nh ago / Nd ago"` helper with **no date fallback** (so old items read "45d ago" / "5mo ago") and inconsistent rounding/seconds handling.

## Change
Route them through the canonical `relativeTime` (`@/lib/relative-time`, already used by dashboard/journal/projects/board) — so every surface gains `"just now"` and a real `"Jun 12"` date past a week — while **preserving each surface's empty-state word** via a thin wrapper:

| Surface | Empty-state word kept |
|---|---|
| notification-bell | "—" |
| coven-floor | "never" |
| familiar-status-card | "never" |
| familiar-card-data (`formatRelTime`, exported) | "never" |
| comux-view (`shortProjectTime`) | "No sessions yet" |
| health-strip | (n/a) |

Net −48/+17 lines.

## Deliberately excluded (verified, not oversights)
- **board-table** and **library-timeline-row** — compact `"5m"` / `"5w"` with no "ago", intentional for dense columns; widening to verbose/date would risk overflow.
- **automations-view** — its helper is **bidirectional** (`"in 2h"` for future schedules); the shared formatter doesn't do future times.

## Tests
- `familiar-card-data.ts` now reaches the `@/` alias, so its test is added to the `ALIAS_LOADER` set in `run-tests.mjs`.
- Its `"just now"` case now uses a sub-30s delta — the shared formatter rounds minutes (`30s → "1m ago"`), which is the app-wide canonical behavior.
- Added a runtime assertion that items >1 week old format as a date.
- Ran all affected suites (card-data, familiar-inline-card, coven-floor-table, comux ×2, schedules-tabs, daily-summary-notifications, chat-surface, mobile-shell-smoke, relative-time) + `check:tests-wired` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)