### PR TITLE
feat(vault): copy a secret's 1Password reference

### DIFF
--- a/src/components/vault-panel.tsx
+++ b/src/components/vault-panel.tsx
@@ -142,6 +142,17 @@ export function VaultPanel() {
   const [adding, setAdding]         = useState(false);
   const [editing, setEditing]       = useState<Mapping | null>(null);
   const [deleting, setDeleting]     = useState<string | null>(null);
+  const [copiedKey, setCopiedKey]   = useState<string | null>(null);
+
+  async function handleCopyRef(key: string, ref: string) {
+    try {
+      await navigator.clipboard.writeText(ref);
+      setCopiedKey(key);
+      window.setTimeout(() => setCopiedKey((k) => (k === key ? null : k)), 1600);
+    } catch {
+      // Clipboard blocked (insecure context / permissions) — no-op.
+    }
+  }
 
   async function load() {
     setLoading(true);
@@ -266,6 +277,17 @@ export function VaultPanel() {
                 <div className="vault-row-error">{m.error}</div>
               )}
               <div className="vault-row-actions">
+                {m.ref && (
+                  <button
+                    type="button"
+                    className="vault-action-btn"
+                    title={copiedKey === m.key ? "Copied" : "Copy reference"}
+                    aria-label={`Copy the 1Password reference for ${m.key}`}
+                    onClick={() => void handleCopyRef(m.key, m.ref!)}
+                  >
+                    <Icon name={copiedKey === m.key ? "ph:check" : "ph:copy"} width={11} />
+                  </button>
+                )}
                 <button
                   type="button"
                   className="vault-action-btn"


### PR DESCRIPTION
## What

The Secret Vault (inspector → Vault tab) showed each mapping's `op://…` reference as plain text with no quick way to reuse it. This adds a per-row **copy button** (rendered only when a reference exists) that writes the `op://` path to the clipboard with brief "Copied" feedback — handy when wiring the same secret elsewhere. The button has an `aria-label` for screen readers.

Reuses the app's clipboard pattern (`navigator.clipboard.writeText`, same as `CopyLinkButton`).

## Verify
- `surface-error-states.test.ts` (reads vault-panel.tsx) — pass; `pnpm build` — clean
- Confirmed the data path live: seeded a `COVEN_VAULT_FILE` mapping and `GET /api/vault` returned it with its `ref`, so the button renders. (Full click-through needs the inspector's Vault tab opened, which I didn't automate end-to-end; the change is additive and uses the proven clipboard helper.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)