### PR TITLE
feat(board): redesign Tasks Gantt into a grouped-by-project compact timeline

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -1,20 +1,26 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { Card } from "@/lib/cave-board-types";
+import type { Card, CardStatus } from "@/lib/cave-board-types";
+import type { Familiar } from "@/lib/types";
 import { useDateTimePrefs, readDateTimePrefs } from "@/lib/datetime-format";
+
+type ProjectLike = { id: string; name: string };
 
 type Props = {
   cards: Card[];
+  familiars?: Familiar[];
+  projects?: ProjectLike[];
   selectedCardId: string | null;
   onSelect: (id: string) => void;
 };
 
-type ScheduledCard = {
-  card: Card;
-  start: Date;
-  end: Date;
-};
+type ScheduledCard = { card: Card; start: Date; end: Date };
+type Group = { key: string; name: string; tasks: ScheduledCard[]; firstStart: number };
+type GanttCategory = "done" | "in-progress" | "pending" | "at-risk";
+
+const DAY_W = 22; // px per day column — keep in sync with --cg-day in board.css
+const LEFT_W = 416; // sum of the left table columns — keep in sync with .cg-left
 
 function parseDate(value: string | null | undefined): Date | null {
   if (!value) return null;
@@ -25,7 +31,6 @@ function parseDate(value: string | null | undefined): Date | null {
 function formatLabel(date: Date): string {
   const month = new Intl.DateTimeFormat("en-US", { month: "short", timeZone: "UTC" }).format(date);
   const day = date.getUTCDate();
-  // Order by the user's date preference (month-first vs day-first).
   return readDateTimePrefs().date === "ddmm" ? `${day} ${month}` : `${month} ${day}`;
 }
 
@@ -33,18 +38,46 @@ function daysBetween(start: Date, end: Date): number {
   return Math.round((end.getTime() - start.getTime()) / 86_400_000);
 }
 
-export function BoardGantt({ cards, selectedCardId, onSelect }: Props) {
-  // "Today" is derived from the clock, so it can't be computed during SSR
-  // without risking a hydration mismatch (and the guide would jump). Resolve it
-  // after mount — the line simply isn't drawn for the first client render.
+function addDays(d: Date, n: number): Date {
+  const x = new Date(d);
+  x.setUTCDate(x.getUTCDate() + n);
+  return x;
+}
+
+function startOfWeekMon(d: Date): Date {
+  const x = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const dow = (x.getUTCDay() + 6) % 7; // Monday = 0
+  x.setUTCDate(x.getUTCDate() - dow);
+  return x;
+}
+
+function isoWeek(d: Date): number {
+  const x = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const dow = (x.getUTCDay() + 6) % 7;
+  x.setUTCDate(x.getUTCDate() - dow + 3); // nearest Thursday
+  const firstThursday = new Date(Date.UTC(x.getUTCFullYear(), 0, 4));
+  const ftDow = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - ftDow + 3);
+  return 1 + Math.round((x.getTime() - firstThursday.getTime()) / (7 * 86_400_000));
+}
+
+// Map the board's status vocabulary onto the Gantt's four colour categories.
+function statusCategory(status: CardStatus): GanttCategory {
+  if (status === "done") return "done";
+  if (status === "running") return "in-progress";
+  if (status === "blocked") return "at-risk";
+  return "pending"; // backlog · inbox · review
+}
+
+export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelect }: Props) {
+  // "Today" depends on the clock, so resolve it after mount to avoid an SSR
+  // hydration mismatch — the line just isn't drawn on the first client render.
   const [todayMs, setTodayMs] = useState<number | null>(null);
   useEffect(() => setTodayMs(Date.now()), []);
-  // Re-render axis + row dates when the date-format preference changes.
   useDateTimePrefs();
 
   const scheduled: ScheduledCard[] = [];
   const unscheduled: Card[] = [];
-
   for (const card of cards) {
     const startDate = parseDate(card.startDate);
     const endDate = parseDate(card.endDate);
@@ -68,73 +101,141 @@ export function BoardGantt({ cards, selectedCardId, onSelect }: Props) {
     );
   }
 
-  const min = new Date(Math.min(...scheduled.map((item) => item.start.getTime())));
-  const max = new Date(Math.max(...scheduled.map((item) => item.end.getTime())));
-  const span = Math.max(1, daysBetween(min, max) + 1);
+  const ownerName = (id: string | null): string =>
+    (id ? familiars?.find((f) => f.id === id)?.display_name : undefined) ?? "—";
+  const projectName = (id: string | null | undefined): string =>
+    (id ? projects?.find((p) => p.id === id)?.name : undefined) ?? "No project";
 
-  // Today as a percentage across the [min, max] span, matched to the same UTC
-  // midnight coordinate the bars use. Null when out of range so we don't draw a
-  // guide pinned to the edge for a board whose work is all past or all future.
-  let todayPct: number | null = null;
+  // Group scheduled tasks by project, each group sorted by start date.
+  const groupMap = new Map<string, Group>();
+  for (const item of scheduled) {
+    const key = item.card.projectId ?? "__none__";
+    let group = groupMap.get(key);
+    if (!group) {
+      group = { key, name: projectName(item.card.projectId), tasks: [], firstStart: item.start.getTime() };
+      groupMap.set(key, group);
+    }
+    group.tasks.push(item);
+    group.firstStart = Math.min(group.firstStart, item.start.getTime());
+  }
+  const groups = [...groupMap.values()].sort((a, b) => a.firstStart - b.firstStart);
+  for (const g of groups) {
+    g.tasks.sort((a, b) => a.start.getTime() - b.start.getTime() || a.end.getTime() - b.end.getTime());
+  }
+
+  const min = new Date(Math.min(...scheduled.map((i) => i.start.getTime())));
+  const max = new Date(Math.max(...scheduled.map((i) => i.end.getTime())));
+  const rangeStart = startOfWeekMon(min);
+  const rangeEnd = addDays(startOfWeekMon(max), 7); // complete the final week
+  const totalDays = Math.max(7, daysBetween(rangeStart, rangeEnd));
+  const timelineW = totalDays * DAY_W;
+
+  const weeks: Array<{ left: number; width: number; label: string }> = [];
+  for (let i = 0; i < totalDays; i += 7) {
+    weeks.push({ left: i * DAY_W, width: 7 * DAY_W, label: `Week ${isoWeek(addDays(rangeStart, i))}` });
+  }
+
+  let todayX: number | null = null;
   if (todayMs !== null) {
     const now = new Date(todayMs);
     const todayUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-    const todayOffset = daysBetween(min, todayUtc);
-    if (todayOffset >= 0 && todayOffset <= span) todayPct = (todayOffset / span) * 100;
+    const offset = daysBetween(rangeStart, todayUtc);
+    if (offset >= 0 && offset <= totalDays) todayX = offset * DAY_W + DAY_W / 2;
   }
-  const todayLeft = todayPct === null ? undefined : `${todayPct}%`;
 
   return (
     <div className="board-gantt">
-      <div className="board-gantt-header">
-        <span aria-hidden />
-        <span className="board-gantt-axis">
-          <span>{formatLabel(min)}</span>
-          {todayLeft !== undefined ? (
-            <span className="board-gantt-axis__today" style={{ left: todayLeft }}>Today</span>
-          ) : null}
-          <span>{formatLabel(max)}</span>
-        </span>
-        <span aria-hidden />
-      </div>
-      <div className="board-gantt-plot">
-        {/* One full-height guide spanning the whole list reads as a continuous
-            line, where a per-row marker would break across the row gaps. It
-            shares the rows' column grid so it lands in the same track column. */}
-        {todayLeft !== undefined ? (
-          <div className="board-gantt-today" aria-hidden>
-            <span />
-            <span className="board-gantt-today__col">
-              <span className="board-gantt-today__line" style={{ left: todayLeft }} />
-            </span>
-            <span />
+      <div className="board-gantt__scroll">
+        <div className="cg" style={{ ["--cg-day" as string]: `${DAY_W}px`, ["--cg-tl" as string]: `${timelineW}px` }}>
+          {/* Header: left column titles + week band */}
+          <div className="cg-head">
+            <div className="cg-left cg-left--head">
+              <span className="cg-c-task">Group / Task</span>
+              <span className="cg-c-owner">Owner</span>
+              <span className="cg-c-date">Start</span>
+              <span className="cg-c-date">End</span>
+              <span className="cg-c-st">St</span>
+            </div>
+            <div className="cg-weeks" style={{ width: `${timelineW}px` }}>
+              {weeks.map((w) => (
+                <span key={w.left} className="cg-week" style={{ left: `${w.left}px`, width: `${w.width}px` }}>
+                  {w.label}
+                </span>
+              ))}
+            </div>
           </div>
-        ) : null}
-        <div className="board-gantt-list">
-          {scheduled
-            .sort((a, b) => a.start.getTime() - b.start.getTime() || a.end.getTime() - b.end.getTime())
-            .map(({ card, start, end }) => {
-              const offset = Math.max(0, daysBetween(min, start));
-              const duration = Math.max(1, daysBetween(start, end) + 1);
-              const left = `${(offset / span) * 100}%`;
-              const width = `${Math.max(5, (duration / span) * 100)}%`;
-              return (
-                <button
-                  key={card.id}
-                  type="button"
-                  className={`board-gantt-row${selectedCardId === card.id ? " board-gantt-row--selected" : ""}`}
-                  onClick={() => onSelect(card.id)}
-                >
-                  <span className="board-gantt-row__title">{card.title}</span>
-                  <span className="board-gantt-row__track" aria-hidden>
-                    <span className={`board-gantt-row__bar board-gantt-row__bar--${card.priority}`} style={{ left, width }} />
-                  </span>
-                  <span className="board-gantt-row__dates">
-                    {formatLabel(start)}–{formatLabel(end)} · {duration}d
-                  </span>
-                </button>
-              );
-            })}
+
+          {/* Body: today line + grouped rows */}
+          <div className="cg-body">
+            {todayX !== null ? (
+              <span className="cg-today" style={{ left: `calc(${LEFT_W}px + ${todayX}px)` }} aria-hidden>
+                <span className="cg-today__flag">TODAY</span>
+              </span>
+            ) : null}
+
+            {groups.map((g) => (
+              <div key={g.key} className="cg-group">
+                <div className="cg-grouprow">
+                  <div className="cg-left cg-left--group">
+                    <span className="cg-caret" aria-hidden>▾</span>
+                    <span className="cg-groupname">{g.name}</span>
+                    <span className="cg-count">{g.tasks.length}</span>
+                  </div>
+                  <div className="cg-grouptl" style={{ width: `${timelineW}px` }} aria-hidden />
+                </div>
+
+                {g.tasks.map(({ card, start, end }) => {
+                  const cat = statusCategory(card.status);
+                  const offset = Math.max(0, daysBetween(rangeStart, start));
+                  const dur = Math.max(1, daysBetween(start, end) + 1);
+                  const left = offset * DAY_W;
+                  const milestone = dur === 1;
+                  return (
+                    <button
+                      key={card.id}
+                      type="button"
+                      className={`cg-row${selectedCardId === card.id ? " cg-row--sel" : ""}`}
+                      onClick={() => onSelect(card.id)}
+                      title={`${card.title} · ${formatLabel(start)}–${formatLabel(end)}`}
+                    >
+                      <span className="cg-left">
+                        <span className="cg-c-task">{card.title}</span>
+                        <span className="cg-c-owner">{ownerName(card.familiarId)}</span>
+                        <span className="cg-c-date">{formatLabel(start)}</span>
+                        <span className="cg-c-date">{formatLabel(end)}</span>
+                        <span className="cg-c-st"><span className={`cg-dot cg-dot--${cat}`} aria-hidden /></span>
+                      </span>
+                      <span className="cg-track" style={{ width: `${timelineW}px` }} aria-hidden>
+                        {milestone ? (
+                          <span
+                            className={`board-gantt-row__bar board-gantt-row__bar--${cat} cg-diamond`}
+                            style={{ left: `${left + DAY_W / 2}px` }}
+                          />
+                        ) : (
+                          <span
+                            className={`board-gantt-row__bar board-gantt-row__bar--${cat} cg-bar`}
+                            style={{ left: `${left}px`, width: `${Math.max(DAY_W, dur * DAY_W - 3)}px` }}
+                          >
+                            <span className="cg-bar__cap" aria-hidden />
+                          </span>
+                        )}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+
+          {/* Legend */}
+          <div className="cg-legend">
+            <span className="cg-leg"><span className="cg-sw cg-sw--done" aria-hidden />Done</span>
+            <span className="cg-leg"><span className="cg-sw cg-sw--in-progress" aria-hidden />In Progress</span>
+            <span className="cg-leg"><span className="cg-sw cg-sw--pending" aria-hidden />Pending</span>
+            <span className="cg-leg"><span className="cg-sw cg-sw--at-risk" aria-hidden />At Risk</span>
+            <span className="cg-leg"><span className="cg-diamond cg-diamond--leg" aria-hidden />Milestone</span>
+            <span className="cg-leg"><span className="cg-today-sw" aria-hidden />Today</span>
+          </div>
         </div>
       </div>
       {unscheduled.length > 0 ? (

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -595,7 +595,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
             onOpenTaskChat={onOpenTaskChat}
             chatLinkingId={chatLinkingId} />
         ) : viewMode === "gantt" ? (
-          <BoardGantt cards={filtered}
+          <BoardGantt cards={filtered} familiars={familiars} projects={projects}
             selectedCardId={selectedCardId}
             onSelect={setSelectedCardId} />
         ) : (

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1329,3 +1329,143 @@
   outline: var(--ring-width) solid var(--ring-focus);
   outline-offset: -2px;
 }
+
+/* ── Compact Gantt (grouped by project) ──────────────────────────────────────
+   Dense dark timeline: sticky left table (Group/Task · Owner · Start · End ·
+   status dot) + a day/week grid with status-coloured bars, milestone diamonds,
+   a red TODAY line, and a legend. Redefines .board-gantt-row__bar by category. */
+.board-gantt__scroll { overflow-x: auto; overflow-y: visible; }
+.cg {
+  --cg-row-h: 26px;
+  width: max-content;
+  min-width: 100%;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+}
+
+/* shared sticky left table block */
+.cg-left {
+  position: sticky;
+  left: 0;
+  z-index: 2;
+  flex: 0 0 416px;
+  display: grid;
+  grid-template-columns: 190px 84px 58px 58px 26px;
+  align-items: center;
+  background: var(--bg-base);
+  border-right: 1px solid var(--border-strong);
+}
+.cg-left > span { padding: 0 8px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cg-c-owner, .cg-c-date { font-size: 11px; color: var(--text-secondary); }
+.cg-c-date { text-align: right; }
+.cg-c-st { display: flex; justify-content: center; }
+
+/* header */
+.cg-head {
+  position: sticky; top: 0; z-index: 5;
+  display: flex; align-items: stretch; height: 30px;
+  background: var(--bg-raised);
+  border-bottom: 1px solid var(--border-strong);
+}
+.cg-head .cg-left {
+  z-index: 6; background: var(--bg-raised);
+  font-size: 10px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; color: var(--text-muted);
+}
+.cg-weeks { position: relative; height: 30px; flex: 0 0 auto; }
+.cg-week {
+  position: absolute; top: 0; bottom: 0;
+  display: flex; align-items: center; padding-left: 7px;
+  font-size: 10px; font-weight: 600; color: var(--text-secondary);
+  border-left: 1px solid var(--border-strong);
+}
+
+/* body */
+.cg-body { position: relative; padding-bottom: 22px; }
+
+/* day (light) + week (strong) gridlines behind every track */
+.cg-track, .cg-grouptl {
+  position: relative; height: var(--cg-row-h); flex: 0 0 auto;
+  background:
+    repeating-linear-gradient(to right, transparent 0, transparent calc(var(--cg-day) - 1px),
+      color-mix(in oklch, var(--border-hairline) 55%, transparent) calc(var(--cg-day) - 1px), color-mix(in oklch, var(--border-hairline) 55%, transparent) var(--cg-day)),
+    repeating-linear-gradient(to right, transparent 0, transparent calc(var(--cg-day) * 7 - 1px),
+      var(--border-strong) calc(var(--cg-day) * 7 - 1px), var(--border-strong) calc(var(--cg-day) * 7));
+}
+
+/* group header row */
+.cg-grouprow { display: flex; align-items: stretch; }
+.cg-grouprow .cg-left {
+  grid-template-columns: 1fr auto; gap: 6px; height: var(--cg-row-h);
+  background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-raised));
+}
+.cg-grouptl { background-color: color-mix(in oklch, var(--accent-presence) 4%, transparent); }
+.cg-caret { color: var(--text-muted); font-size: 10px; padding-left: 8px; }
+.cg-groupname { font-size: 11px; font-weight: 700; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; align-self: center; }
+.cg-count {
+  justify-self: end; margin-right: 8px; align-self: center;
+  min-width: 16px; height: 15px; padding: 0 4px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 10px; color: var(--text-secondary);
+  background: var(--bg-base); border: 1px solid var(--border-hairline); border-radius: 999px;
+}
+
+/* task row */
+.cg-row {
+  display: flex; align-items: stretch; width: 100%;
+  border: 0; border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 45%, transparent);
+  background: transparent; cursor: pointer; text-align: left; padding: 0;
+}
+.cg-row:hover .cg-left { background: color-mix(in oklch, var(--accent-presence) 9%, var(--bg-base)); }
+.cg-row:hover .cg-track { background-color: color-mix(in oklch, var(--accent-presence) 5%, transparent); }
+.cg-row--sel .cg-left { background: color-mix(in oklch, var(--accent-presence) 15%, var(--bg-base)); }
+.cg-c-task { font-size: 12px; font-weight: 600; padding-left: 18px !important; }
+
+/* bars (redefines the legacy .board-gantt-row__bar by status category) */
+.board-gantt-row__bar {
+  position: absolute; top: 50%; transform: translateY(-50%);
+  height: 12px; min-width: var(--cg-day); border-radius: 4px;
+  display: flex; align-items: center; justify-content: flex-end;
+}
+.board-gantt-row__bar--done { background: color-mix(in oklch, var(--text-secondary) 50%, var(--text-muted)); }
+.board-gantt-row__bar--in-progress { background: var(--color-info); }
+.board-gantt-row__bar--pending { background: var(--color-warning); }
+.board-gantt-row__bar--at-risk { background: var(--color-danger); }
+.cg-bar__cap { width: 8px; height: 8px; margin-right: -4px; transform: rotate(45deg); background: var(--text-primary); border-radius: 2px; }
+
+/* milestone diamond (single-day task) */
+.cg-diamond {
+  height: 12px !important; width: 12px; min-width: 12px !important; padding: 0;
+  transform: translate(-50%, -50%) rotate(45deg);
+  border-radius: 2px; background: var(--text-primary) !important;
+}
+.cg-diamond--leg { position: static; display: inline-block; width: 9px; height: 9px; transform: rotate(45deg); background: var(--text-primary); }
+
+/* today line + flag */
+.cg-today { position: absolute; top: 0; bottom: 0; width: 0; border-left: 2px solid var(--color-danger); z-index: 3; pointer-events: none; }
+.cg-today__flag {
+  position: absolute; bottom: 2px; left: 50%; transform: translateX(-50%);
+  font-size: 9px; font-weight: 700; letter-spacing: 0.06em; color: #fff;
+  background: var(--color-danger); padding: 1px 5px; border-radius: 3px; white-space: nowrap;
+}
+
+/* status dots */
+.cg-dot { width: 7px; height: 7px; border-radius: 50%; display: inline-block; }
+.cg-dot--done { background: color-mix(in oklch, var(--text-secondary) 50%, var(--text-muted)); }
+.cg-dot--in-progress { background: var(--color-info); }
+.cg-dot--pending { background: var(--color-warning); }
+.cg-dot--at-risk { background: var(--color-danger); }
+
+/* legend */
+.cg-legend {
+  position: sticky; left: 0;
+  display: flex; flex-wrap: wrap; gap: 16px; align-items: center;
+  margin-top: 12px; padding: 10px 8px 2px;
+  font-size: 11px; color: var(--text-secondary);
+}
+.cg-leg { display: inline-flex; align-items: center; gap: 6px; }
+.cg-sw { width: 14px; height: 9px; border-radius: 2px; display: inline-block; }
+.cg-sw--done { background: color-mix(in oklch, var(--text-secondary) 50%, var(--text-muted)); }
+.cg-sw--in-progress { background: var(--color-info); }
+.cg-sw--pending { background: var(--color-warning); }
+.cg-sw--at-risk { background: var(--color-danger); }
+.cg-today-sw { width: 0; height: 12px; border-left: 2px solid var(--color-danger); display: inline-block; }


### PR DESCRIPTION
## What

Restyles the Tasks → Gantt view to match a dense, dark **"Compact Gantt — Grouped by Project"** design.

**Before:** a flat list of bars colored by priority, with a 3-column row (title · track · date text).

**After:**
- **Sticky left table**: Group/Task · Owner · Start · End · status dot.
- **Grouped by project** — tasks sit under project header rows (caret · name · count); owners resolve from familiars, groups from projects.
- **Day/week timeline grid**: week band (Week N) + day/week gridlines.
- **Status-categorized bars** mapped from `card.status` → Done (gray) · In Progress (blue) · Pending (amber) · At Risk (red). Single-day tasks render as **milestone diamonds**.
- **Red TODAY line** + flag at the current day.
- **Legend** below (Done · In Progress · Pending · At Risk · Milestone · Today).

Kept the test-pinned `board-gantt-row__bar` class and `.board-gantt` root; wired `familiars` + `projects` into `<BoardGantt>` from board-view.

## Verified (real build)

Mocked board + projects with 3 projects / 10 tasks / varied statuses & milestones around today: renders 3 groups, week band (24–27), status bars, white milestone diamonds, owners (Nova/Sage/Charm…), red TODAY line + legend. `tsc` clean; full `test:app` green (338 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)