### PR TITLE
feat(workflows): unsaved-changes summary + clear run history

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -116,7 +116,7 @@ const contracts: RouteContract[] = [
   { route: "/workflows/dry-run", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
   { route: "/workflows/layout", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/workflows/run", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
-  { route: "/workflows/runs", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/workflows/runs", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/workflows/save", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/workflows/validate", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
   { route: "/workflows", methods: ["GET"], kind: "json" },

--- a/src/app/api/workflows/runs/route.ts
+++ b/src/app/api/workflows/runs/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { listRuns, recordRun, type WorkflowRunRecord } from "@/lib/workflow-runs";
+import { clearRuns, listRuns, recordRun, type WorkflowRunRecord } from "@/lib/workflow-runs";
 
 export const dynamic = "force-dynamic";
 
@@ -43,4 +43,12 @@ export async function POST(req: Request) {
     source: body.source === "daemon" ? "daemon" : "cave",
   });
   return NextResponse.json({ ok: true, run });
+}
+
+/** Clear run history — one workflow's runs (`?workflowId=`) or the whole store. */
+export async function DELETE(req: Request) {
+  const url = new URL(req.url);
+  const workflowId = url.searchParams.get("workflowId") ?? undefined;
+  const cleared = await clearRuns(workflowId);
+  return NextResponse.json({ ok: true, cleared });
 }

--- a/src/components/workflows-view.tsx
+++ b/src/components/workflows-view.tsx
@@ -14,6 +14,7 @@ import {
   createWorkflowFromTemplate,
   duplicateWorkflow,
   slugifyWorkflowId,
+  summarizeWorkflowChanges,
   workflowToManifest,
 } from "@/lib/workflow-edit";
 import {
@@ -24,6 +25,7 @@ import {
 } from "@/lib/workflow-draft";
 import {
   attachWorkflowToRole,
+  clearWorkflowRuns,
   isPublicTemplate,
   loadWorkflowLayout,
   saveWorkflowLayout,
@@ -290,6 +292,16 @@ export function WorkflowsView({
     return options;
   }, [capabilityUses, draft?.id, familiars, workflows]);
 
+  // When the draft is dirty, name the top-level fields a Save would write, diffed
+  // against the saved manifest (matched by the selected id, not the draft id —
+  // editing the id field shouldn't lose the baseline).
+  const changedFields = useMemo<string[]>(() => {
+    if (!dirty || !draft) return [];
+    const saved = workflows.find((workflow) => workflow.id === selectedWorkflowId);
+    if (!saved) return [];
+    return summarizeWorkflowChanges(saved, draft);
+  }, [dirty, draft, selectedWorkflowId, workflows]);
+
   useEffect(() => {
     if (!selectedNodeId) return;
     if (!selectedGraph?.nodes.some((node) => node.id === selectedNodeId)) {
@@ -453,6 +465,16 @@ export function WorkflowsView({
       return;
     }
     setPlayback(playbackFromRun(run));
+  }, [showNotice]);
+
+  const clearRuns = useCallback(async (workflowId: string) => {
+    const result = await clearWorkflowRuns(workflowId);
+    if (!result.ok) {
+      showNotice(result.error ?? "couldn't clear run history");
+      return;
+    }
+    setRuns([]);
+    showNotice(result.cleared ? `Cleared ${result.cleared} run${result.cleared === 1 ? "" : "s"}.` : "Run history already empty.");
   }, [showNotice]);
 
   const runSave = async (workflow: WorkflowSummary) => {
@@ -656,6 +678,7 @@ export function WorkflowsView({
       runsLoading={runsLoading}
       familiarOptions={familiarOptions}
       usesOptions={usesOptions}
+      changedFields={changedFields}
       roles={roles}
       engineUnavailable={engineUnavailable}
       notice={notice}
@@ -666,6 +689,7 @@ export function WorkflowsView({
       onStopPlayback={stopPlayback}
       onOpenSession={openWorkflowSession}
       onReplayRun={replayRun}
+      onClearRuns={() => selectedWorkflowId && void clearRuns(selectedWorkflowId)}
       onResetView={resetWorkflowView}
       onSwitchLayout={switchWorkflowLayout}
       onRefresh={() => void load(true)}

--- a/src/components/workflows/workflow-manifest-preview.tsx
+++ b/src/components/workflows/workflow-manifest-preview.tsx
@@ -8,10 +8,12 @@ import type { WorkflowSummary } from "@/lib/workflows";
 type WorkflowManifestPreviewProps = {
   workflow: WorkflowSummary | null;
   dirty: boolean;
+  /** Top-level fields that differ from the saved manifest (what Save would write). */
+  changedFields?: string[];
 };
 
 /** Live canonical YAML for the current draft — what Save writes to disk. */
-export function WorkflowManifestPreview({ workflow, dirty }: WorkflowManifestPreviewProps) {
+export function WorkflowManifestPreview({ workflow, dirty, changedFields }: WorkflowManifestPreviewProps) {
   const yaml = useMemo(() => (workflow ? workflowToYaml(workflow) : null), [workflow]);
   // The manifest with its schema banner is exactly what Save writes, so copying
   // it hands off a paste-ready manifest (to share, or check in by hand).
@@ -53,6 +55,12 @@ export function WorkflowManifestPreview({ workflow, dirty }: WorkflowManifestPre
           </button>
         )}
       </div>
+      {dirty && changedFields && changedFields.length > 0 && (
+        <p className="workflow-manifest-changes">
+          <Icon name="ph:pencil-simple" width={12} aria-hidden />
+          Unsaved changes: {changedFields.join(", ")}
+        </p>
+      )}
       {manifestText ? (
         <pre className="workflow-manifest-yaml">
           <code>{manifestText}</code>

--- a/src/components/workflows/workflow-runs-panel.tsx
+++ b/src/components/workflows/workflow-runs-panel.tsx
@@ -18,6 +18,8 @@ type WorkflowRunsPanelProps = {
   workflow: WorkflowSummary | null;
   playback: WorkflowPlaybackState | null;
   onReplayRun: (run: WorkflowRunRecord) => void;
+  /** Clear this workflow's recorded run history. */
+  onClearRuns: () => void;
 };
 
 
@@ -72,13 +74,19 @@ function summarizeRuns(runs: WorkflowRunRecord[]): string {
 }
 
 /** Run history for the selected workflow: plan snapshots and executions. */
-export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayRun }: WorkflowRunsPanelProps) {
+export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayRun, onClearRuns }: WorkflowRunsPanelProps) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [filter, setFilter] = useState<WorkflowRunFilter>("all");
   const replaying = playback?.source === "replay" && playback.workflowId === workflow?.id;
 
   const activeFilter = RUN_FILTERS.find((entry) => entry.id === filter) ?? RUN_FILTERS[0];
   const visibleRuns = filter === "all" ? runs : runs.filter(activeFilter.match);
+
+  const handleClear = () => {
+    if (window.confirm("Clear this workflow's run history? Recorded plan snapshots and run records are removed.")) {
+      onClearRuns();
+    }
+  };
 
   return (
     <section className="workflow-runs-panel" aria-label="Workflow run history">
@@ -88,6 +96,17 @@ export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayR
         <span className="workflow-runs-count">
           {loading ? "loading" : summarizeRuns(runs)}
         </span>
+        {workflow && runs.length > 0 && (
+          <button
+            type="button"
+            className="workflow-runs-clear"
+            onClick={handleClear}
+            title="Clear run history for this workflow"
+          >
+            <Icon name="ph:trash" width={12} />
+            Clear
+          </button>
+        )}
       </div>
       {/* Filter history once there's more than a couple of runs — a busy
           workflow's plan snapshots otherwise bury its real executions. */}

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -423,4 +423,18 @@ assert.match(inspector, /multiline\?: boolean/, "Field should support a multilin
 assert.match(inspector, /<textarea/, "Multiline field should render a textarea");
 assert.match(css, /\.workflow-field-textarea/, "CSS should style the multiline field");
 
+// --- Backlog: changed-fields hint + clear run history ---
+// The manifest preview names what an unsaved Save would write.
+assert.match(manifestPreview, /changedFields/, "Manifest preview should accept the changed-field summary");
+assert.match(manifestPreview, /Unsaved changes:/, "Manifest preview should label unsaved changes");
+assert.match(studio, /changedFields=\{props\.changedFields\}/, "Studio should thread changed fields into the manifest preview");
+assert.match(css, /\.workflow-manifest-changes/, "CSS should style the unsaved-changes summary");
+
+// The runs panel can clear this workflow's history.
+assert.match(runsPanel, /onClearRuns/, "Runs panel should accept a clear-history handler");
+assert.match(runsPanel, /workflow-runs-clear/, "Runs panel should render a clear-history button");
+assert.match(runsPanel, /window\.confirm/, "Clearing run history should confirm first");
+assert.match(studio, /onClearRuns=\{props\.onClearRuns\}/, "Studio should thread the clear-history handler");
+assert.match(css, /\.workflow-runs-clear/, "CSS should style the clear-history button");
+
 console.log("workflow-studio.test.ts: ok");

--- a/src/components/workflows/workflow-studio.tsx
+++ b/src/components/workflows/workflow-studio.tsx
@@ -81,6 +81,8 @@ export type WorkflowStudioProps = {
   runsLoading: boolean;
   familiarOptions: WorkflowFamiliarOption[];
   usesOptions?: WorkflowUsesOption[];
+  /** Top-level fields the unsaved draft changes vs the saved manifest. */
+  changedFields?: string[];
   roles: WorkflowRoleSummary[];
   engineUnavailable: boolean;
   notice: string | null;
@@ -91,6 +93,7 @@ export type WorkflowStudioProps = {
   onStopPlayback: () => void;
   onOpenSession: (sessionId: string) => void;
   onReplayRun: (run: WorkflowRunRecord) => void;
+  onClearRuns: () => void;
   onResetView: () => void;
   onSwitchLayout: () => void;
   onRefresh: () => void;
@@ -308,6 +311,7 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
             workflow={selectedWorkflow}
             playback={props.playback}
             onReplayRun={props.onReplayRun}
+            onClearRuns={props.onClearRuns}
           />
         </section>
       </main>
@@ -373,7 +377,7 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
               />
             )}
             {sidePanelSection === "manifest" && (
-              <WorkflowManifestPreview workflow={selectedWorkflow} dirty={props.dirty} />
+              <WorkflowManifestPreview workflow={selectedWorkflow} dirty={props.dirty} changedFields={props.changedFields} />
             )}
           </div>
         </div>

--- a/src/lib/workflow-edit.test.ts
+++ b/src/lib/workflow-edit.test.ts
@@ -4,6 +4,7 @@ import {
   createWorkflowFromTemplate,
   duplicateWorkflow,
   slugifyWorkflowId,
+  summarizeWorkflowChanges,
   WORKFLOW_TEMPLATES,
   workflowToManifest,
   workflowToYaml,
@@ -76,5 +77,55 @@ assert.equal(copy.name, "Release Review copy");
 assert.equal(copy.path, undefined, "duplicate is detached from the source file");
 assert.notEqual(copy.steps, workflow.steps, "duplicate deep-copies steps");
 assert.equal(validateManifest(workflowToManifest(copy)).ok, true);
+
+// --- summarizeWorkflowChanges ---
+const saved: WorkflowSummary = {
+  id: "wf",
+  version: "0.1.0",
+  name: "WF",
+  summary: "do a thing",
+  permissions: ["repo.read"],
+  tags: ["a"],
+  limits: { max_agents: 2 },
+  steps: [
+    { id: "input", kind: "input", name: "Input" },
+    { id: "work", kind: "agent", name: "Work", requires: ["input"] },
+    { id: "output", kind: "output", name: "Output", requires: ["work"] },
+  ],
+};
+assert.deepEqual(summarizeWorkflowChanges(saved, saved), [], "identical workflows report no changes");
+assert.deepEqual(
+  summarizeWorkflowChanges(saved, { ...saved, name: "WF2" }),
+  ["name"],
+  "a changed scalar is named",
+);
+assert.deepEqual(
+  summarizeWorkflowChanges(saved, { ...saved, permissions: ["repo.read", "web.fetch"] }),
+  ["permissions"],
+  "a changed list is named",
+);
+assert.deepEqual(
+  summarizeWorkflowChanges(saved, { ...saved, limits: { max_agents: 4 } }),
+  ["limits"],
+  "a changed limit is named",
+);
+{
+  const draft: WorkflowSummary = {
+    ...saved,
+    steps: [
+      ...saved.steps!.slice(0, 2),
+      { id: "review", kind: "agent", name: "Review", requires: ["work"] },
+      saved.steps![2],
+    ],
+  };
+  assert.deepEqual(summarizeWorkflowChanges(saved, draft), ["steps (1 added)"], "step additions are counted");
+}
+{
+  const draft: WorkflowSummary = {
+    ...saved,
+    steps: saved.steps!.map((step) => (step.id === "work" ? { ...step, uses: "nova" } : step)),
+  };
+  assert.deepEqual(summarizeWorkflowChanges(saved, draft), ["steps (1 changed)"], "step edits are counted");
+}
 
 console.log("workflow-edit.test.ts: ok");

--- a/src/lib/workflow-edit.ts
+++ b/src/lib/workflow-edit.ts
@@ -191,3 +191,69 @@ export function duplicateWorkflow(workflow: WorkflowSummary, newId: string): Wor
   copy.name = `${workflow.name ?? workflow.id} copy`;
   return copy;
 }
+
+/** Order-independent signature of a step's editable fields, for change detection. */
+function stepSignature(step: WorkflowStepSummary): string {
+  return JSON.stringify({
+    id: step.id,
+    kind: step.kind,
+    name: step.name ?? null,
+    uses: step.uses ?? null,
+    summary: step.summary ?? null,
+    on_error: step.on_error ?? null,
+    requires: [...(step.requires ?? [])].sort(),
+    permissions: [...(step.permissions ?? [])].sort(),
+  });
+}
+
+/** Human summary of how `draft`'s steps differ from `saved`'s (added/removed/changed). */
+function summarizeStepChanges(saved: WorkflowStepSummary[], draft: WorkflowStepSummary[]): string | null {
+  const savedById = new Map(saved.map((step) => [step.id, step]));
+  const draftIds = new Set(draft.map((step) => step.id));
+  let added = 0;
+  let changed = 0;
+  for (const step of draft) {
+    const prior = savedById.get(step.id);
+    if (!prior) added += 1;
+    else if (stepSignature(prior) !== stepSignature(step)) changed += 1;
+  }
+  const removed = saved.filter((step) => !draftIds.has(step.id)).length;
+  const parts: string[] = [];
+  if (added) parts.push(`${added} added`);
+  if (removed) parts.push(`${removed} removed`);
+  if (changed) parts.push(`${changed} changed`);
+  return parts.length > 0 ? `steps (${parts.join(", ")})` : null;
+}
+
+/**
+ * The list of top-level fields that differ between the saved workflow and the
+ * working draft — what an unsaved Save would write. Pure, so the studio can show
+ * "Unsaved changes: name, permissions, steps (1 added)" without re-deriving it.
+ */
+export function summarizeWorkflowChanges(saved: WorkflowSummary, draft: WorkflowSummary): string[] {
+  const changes: string[] = [];
+  const scalar = (a: unknown, b: unknown, label: string) => {
+    if ((a ?? "") !== (b ?? "")) changes.push(label);
+  };
+  if (saved.id !== draft.id) changes.push("id");
+  scalar(saved.name, draft.name, "name");
+  scalar(saved.version, draft.version, "version");
+  scalar(saved.summary, draft.summary, "summary");
+  scalar(saved.pattern, draft.pattern, "pattern");
+  scalar(saved.familiar, draft.familiar, "familiar");
+
+  const listChanged = (a?: string[], b?: string[]) => (a ?? []).join(" ") !== (b ?? []).join(" ");
+  if (listChanged(saved.tags, draft.tags)) changes.push("tags");
+  if (listChanged(saved.permissions, draft.permissions)) changes.push("permissions");
+
+  const limitChanged = (key: keyof NonNullable<WorkflowSummary["limits"]>) =>
+    (saved.limits?.[key] ?? undefined) !== (draft.limits?.[key] ?? undefined);
+  if (limitChanged("max_agents") || limitChanged("timeout_s") || limitChanged("cost_ceiling_usd")) {
+    changes.push("limits");
+  }
+
+  const stepChange = summarizeStepChanges(saved.steps ?? [], draft.steps ?? []);
+  if (stepChange) changes.push(stepChange);
+
+  return changes;
+}

--- a/src/lib/workflow-runs.test.ts
+++ b/src/lib/workflow-runs.test.ts
@@ -8,7 +8,7 @@ const runsPath = path.join(dir, "workflow-runs.json");
 process.env.COVEN_WORKFLOW_RUNS_PATH = runsPath;
 
 // Import AFTER the env override so the module resolves the test path.
-const { listRuns, recordRun, RUNS_HISTORY_CAP } = await import("./workflow-runs.ts");
+const { clearRuns, listRuns, recordRun, RUNS_HISTORY_CAP } = await import("./workflow-runs.ts");
 
 try {
   // --- record assigns an id and newest-first ordering ---
@@ -66,6 +66,17 @@ try {
     source: "cave",
   });
   assert.equal((await listRuns())[0].id, recovered.id, "store recovers after corruption");
+
+  // --- clearRuns drops one workflow's runs, then all ---
+  await recordRun({ workflowId: "keep", kind: "dry-run", status: "plan", startedAt: "2026-06-11T05:00:00.000Z", steps: [], source: "cave" });
+  const demoCount = (await listRuns("demo")).length;
+  const clearedDemo = await clearRuns("demo");
+  assert.equal(clearedDemo, demoCount, "clearRuns returns how many it removed");
+  assert.deepEqual(await listRuns("demo"), [], "scoped clear empties that workflow");
+  assert.ok((await listRuns("keep")).length > 0, "scoped clear leaves other workflows");
+  const total = (await listRuns()).length;
+  assert.equal(await clearRuns(), total, "clearRuns() with no id removes everything");
+  assert.deepEqual(await listRuns(), [], "unscoped clear empties the store");
 } finally {
   delete process.env.COVEN_WORKFLOW_RUNS_PATH;
   await rm(dir, { recursive: true, force: true });

--- a/src/lib/workflow-runs.ts
+++ b/src/lib/workflow-runs.ts
@@ -67,3 +67,21 @@ export async function listRuns(workflowId?: string): Promise<WorkflowRunRecord[]
   if (!workflowId) return file.runs;
   return file.runs.filter((run) => run.workflowId === workflowId);
 }
+
+/**
+ * Drop run history — one workflow's runs when `workflowId` is given, otherwise
+ * the whole store. Returns how many records were removed.
+ */
+export async function clearRuns(workflowId?: string): Promise<number> {
+  return withRunsLock(async () => {
+    const file = await loadRunsFile();
+    const before = file.runs.length;
+    file.runs = workflowId ? file.runs.filter((run) => run.workflowId !== workflowId) : [];
+    const removed = before - file.runs.length;
+    if (removed > 0) {
+      await mkdir(path.dirname(runsPath()), { recursive: true });
+      await writeFile(runsPath(), JSON.stringify(file, null, 2), "utf8");
+    }
+    return removed;
+  });
+}

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -256,6 +256,16 @@ export async function recordWorkflowRun(
   );
 }
 
+/** Clear run history for one workflow (or all when omitted). */
+export async function clearWorkflowRuns(
+  workflowId?: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<{ ok: boolean; cleared?: number; error?: string }> {
+  const query = workflowId ? `?workflowId=${encodeURIComponent(workflowId)}` : "";
+  const res = await fetchImpl(`/api/workflows/runs${query}`, { method: "DELETE", cache: "no-store" });
+  return res.json() as Promise<{ ok: boolean; cleared?: number; error?: string }>;
+}
+
 export type WorkflowNodePositionsMap = Record<string, { x: number; y: number }>;
 
 /** Saved cave-only canvas positions for a workflow. */

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -1667,6 +1667,32 @@
   color: var(--muted-foreground);
 }
 
+/* Clear-history action, pinned to the right of the runs heading. */
+.workflow-runs-clear {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+  padding: 2px 8px;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.workflow-runs-clear:hover {
+  border-color: color-mix(in oklch, var(--color-danger, #e5484d) 50%, var(--border));
+  color: var(--color-danger, #e5484d);
+}
+
+.workflow-runs-clear:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
+}
+
 .workflow-runs-list {
   margin: 0;
   padding: 0;
@@ -1859,8 +1885,28 @@
 }
 
 .workflow-manifest-preview .workflow-panel-heading,
+.workflow-manifest-preview .workflow-manifest-changes,
 .workflow-manifest-preview > .workflow-muted:last-child {
   flex-shrink: 0;
+}
+
+/* "Unsaved changes: …" summary above the YAML — what a Save would write. */
+.workflow-manifest-changes {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin: 0 0 8px;
+  padding: 5px 8px;
+  border: 1px solid color-mix(in oklch, var(--color-warning, #d9a13c) 40%, var(--border));
+  border-radius: 7px;
+  background: color-mix(in oklch, var(--color-warning, #d9a13c) 10%, transparent);
+  color: var(--text-primary);
+  font-size: 11.5px;
+}
+
+.workflow-manifest-changes .iconify {
+  flex: none;
+  color: var(--color-warning, #d9a13c);
 }
 
 .workflow-manifest-preview .workflow-manifest-yaml {


### PR DESCRIPTION
## What

The two remaining backlog items for the Workflows studio.

### 1. Unsaved-changes summary
When the draft is dirty you could see the *current* manifest YAML but not *what changed*. The manifest preview now shows a compact summary — e.g. **"Unsaved changes: name, permissions, steps (1 added)"** — diffed against the saved manifest by a new pure helper `summarizeWorkflowChanges` (scalars, lists, limits, and per-step added/removed/changed counts). Matched by the selected id, so editing the id field doesn't lose the baseline.

### 2. Clear run history
The run-history store (`~/.coven/workflow-runs.json`, capped at 200) was append-only with no way to prune. The runs panel gains a **Clear** action (with a confirm), backed by a new `DELETE /api/workflows/runs` (`?workflowId=` scoped, or the whole store) and a `clearRuns` store function that returns how many it removed.

## Testing
- `pnpm typecheck` — clean
- `pnpm test:app` (338) + `pnpm test:mobile` (16) — pass, incl. new unit tests for `clearRuns` (scoped + global) and `summarizeWorkflowChanges`, and the updated api-contracts manifest (DELETE on `/workflows/runs`)
- `pnpm build` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)