### PR TITLE
fix(time): include the year in relativeTime's date fallback for prior years

### DIFF
--- a/src/lib/relative-time.test.ts
+++ b/src/lib/relative-time.test.ts
@@ -19,6 +19,14 @@ test("buckets: just now / minutes / hours / days, then short date", () => {
   assert.doesNotMatch(out, /ago/);
 });
 
+test("dates from a prior year include the year (Mon D, YYYY)", () => {
+  const out = relativeTime("2025-01-05T12:00:00.000Z", NOW);
+  assert.match(out, /^[A-Za-z]{3} \d{1,2}, \d{4}$/, `expected "Mon D, YYYY", got "${out}"`);
+  assert.match(out, /2025/);
+  // a same-year date older than a week still omits the year
+  assert.doesNotMatch(relativeTime(ago(60 * 24 * 8), NOW), /\d{4}/);
+});
+
 test("now accepts a number (epoch ms) or a Date, identically", () => {
   assert.equal(relativeTime(ago(2), NOW_MS), relativeTime(ago(2), NOW));
 });

--- a/src/lib/relative-time.ts
+++ b/src/lib/relative-time.ts
@@ -22,7 +22,12 @@ export function relativeTime(
   if (hours < 24) return `${hours}h ago`;
   const days = Math.round(hours / 24);
   if (days < 7) return `${days}d ago`;
-  return new Intl.DateTimeFormat([], { month: "short", day: "numeric" }).format(then);
+  // Past a week, show an absolute date. Include the year when it is not the
+  // current year, so e.g. "Jan 5, 2025" is not ambiguous with this year's Jan 5.
+  const sameYear = new Date(then).getFullYear() === new Date(nowMs).getFullYear();
+  return new Intl.DateTimeFormat([], sameYear
+    ? { month: "short", day: "numeric" }
+    : { month: "short", day: "numeric", year: "numeric" }).format(then);
 }
 
 /**


### PR DESCRIPTION
## Problem
The shared `relativeTime` helper's older-than-a-week fallback formatted dates as `"Jun 12"` with **no year**:
```js
new Intl.DateTimeFormat([], { month: "short", day: "numeric" }).format(then)
```
So a timestamp from a previous year (e.g. January 2025 viewed in 2026) rendered as `"Jan 5"` — indistinguishable from this year's Jan 5. Every surface that shows older items inherits this ambiguity (projects, github, library, capabilities "Scanned …", journal, retro runs, workflow runs).

## Fix
Include the year **only when the timestamp isn't in the current year** → `"Jan 5, 2025"` for prior years, `"Jun 12"` unchanged for this year. One shared formatter, so the fix lands everywhere at once with no change to the common recent-item case.

## Tests
Added a `node:test` case asserting prior-year dates render `"Mon D, YYYY"` and that same-year (>1 week) dates still omit the year. All 6 relative-time tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)