### PR TITLE
feat(projects): copy a project's full path

### DIFF
--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -251,6 +251,17 @@ function ProjectRow({
   const [rootDraft, setRootDraft] = useState(project.root);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [busy, setBusy] = useState<"name" | "root" | "delete" | null>(null);
+  const [copiedRoot, setCopiedRoot] = useState(false);
+
+  const copyRoot = async () => {
+    try {
+      await navigator.clipboard.writeText(project.root);
+      setCopiedRoot(true);
+      window.setTimeout(() => setCopiedRoot(false), 1600);
+    } catch {
+      // Clipboard blocked (insecure context / permissions) — no-op.
+    }
+  };
 
   const commitName = async () => {
     const next = nameDraft.trim();
@@ -478,6 +489,17 @@ function ProjectRow({
             title={project.root}
           >
             {shortRoot(project.root)}
+          </button>
+        )}
+        {!editingRoot && (
+          <button
+            type="button"
+            onClick={copyRoot}
+            className="focus-ring shrink-0 rounded-md p-1 text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+            title={copiedRoot ? "Copied" : "Copy path"}
+            aria-label={`Copy path ${project.root}`}
+          >
+            <Icon name={copiedRoot ? "ph:check" : "ph:copy"} width={12} aria-hidden />
           </button>
         )}
       </div>


### PR DESCRIPTION
## What

Project cards show a **shortened** root path (the full path is only in the title tooltip), with no quick way to grab the real path. This adds a **copy button** next to the path that writes the full project root to the clipboard with brief "Copied" feedback — handy for `cd`-ing there or pasting elsewhere.

The button is labeled for screen readers and is hidden while the root is being edited inline.

## Verify
- `projects-view.test.ts` — pass; `pnpm build` — clean
- **Live-verified** (Projects tab, `/api/projects` route-mocked): clicking copied the full path `/Users/buns/Documents/GitHub/OpenCoven/coven-cave` to the clipboard and the button flipped to "Copied".

🤖 Generated with [Claude Code](https://claude.com/claude-code)