### PR TITLE
feat(time): compact/verbose relative-time density preference

### DIFF
--- a/src/components/settings-fonts.tsx
+++ b/src/components/settings-fonts.tsx
@@ -73,8 +73,11 @@ import {
   CLOCK_OPTIONS,
   DATE_LABEL,
   DATE_OPTIONS,
+  DENSITY_LABEL,
+  DENSITY_OPTIONS,
   setClockFormat,
   setDateFormat,
+  setDensityFormat,
   useDateTimePrefs,
 } from "@/lib/datetime-format";
 
@@ -500,6 +503,22 @@ export function FontSettings() {
                   className={segBtn(dtPrefs.date === option)}
                 >
                   {DATE_LABEL[option]}
+                </button>
+              ))}
+            </div>
+          </ReadingRow>
+          <ReadingRow label="Relative time" hint="Across the app">
+            <div className={segWrap}>
+              {DENSITY_OPTIONS.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  onClick={() => setDensityFormat(option)}
+                  aria-pressed={dtPrefs.density === option}
+                  aria-label={`Relative time ${DENSITY_LABEL[option]}`}
+                  className={segBtn(dtPrefs.density === option)}
+                >
+                  {DENSITY_LABEL[option]}
                 </button>
               ))}
             </div>

--- a/src/lib/datetime-format.test.ts
+++ b/src/lib/datetime-format.test.ts
@@ -8,6 +8,9 @@ import {
   formatTimestamp,
   normalizeClock,
   normalizeDate,
+  normalizeDensity,
+  setDensityFormat,
+  readDateTimePrefs,
 } from "./datetime-format.ts";
 
 // A no-Z ISO is parsed as LOCAL time, so the month/day are timezone-stable.
@@ -92,4 +95,13 @@ test("formatDate supports weekday + long month, and accepts a Date", () => {
 
 test("formatDate renders nothing for bad input", () => {
   assert.equal(formatDate("not-a-date", { clock: "12h", date: "mmdd" }), "");
+});
+
+test("density preference normalizes and round-trips through the store", () => {
+  assert.equal(normalizeDensity("verbose"), "verbose");
+  assert.equal(normalizeDensity("bogus"), "compact");
+  setDensityFormat("verbose");
+  assert.equal(readDateTimePrefs().density, "verbose");
+  setDensityFormat("compact");
+  assert.equal(readDateTimePrefs().density, "compact");
 });

--- a/src/lib/datetime-format.ts
+++ b/src/lib/datetime-format.ts
@@ -22,6 +22,7 @@ import { useSyncExternalStore } from "react";
 
 export const DATETIME_CLOCK_KEY = "cave:datetime-clock";
 export const DATETIME_DATE_KEY = "cave:datetime-date";
+export const DATETIME_DENSITY_KEY = "cave:datetime-density";
 
 export const CLOCK_OPTIONS = ["12h", "24h"] as const;
 export type ClockFormat = (typeof CLOCK_OPTIONS)[number];
@@ -31,7 +32,11 @@ export const DATE_OPTIONS = ["mmdd", "ddmm", "off"] as const;
 export type DateFormat = (typeof DATE_OPTIONS)[number];
 export const DEFAULT_DATE: DateFormat = "mmdd";
 
-export type DateTimePrefs = { clock: ClockFormat; date: DateFormat };
+export const DENSITY_OPTIONS = ["compact", "verbose"] as const;
+export type DensityFormat = (typeof DENSITY_OPTIONS)[number];
+export const DEFAULT_DENSITY: DensityFormat = "compact";
+
+export type DateTimePrefs = { clock: ClockFormat; date: DateFormat; density?: DensityFormat };
 
 export const CLOCK_LABEL: Record<ClockFormat, string> = {
   "12h": "12-hour",
@@ -44,6 +49,11 @@ export const DATE_LABEL: Record<DateFormat, string> = {
   off: "Off",
 };
 
+export const DENSITY_LABEL: Record<DensityFormat, string> = {
+  compact: "Compact",
+  verbose: "Verbose",
+};
+
 export function normalizeClock(value: unknown): ClockFormat {
   return CLOCK_OPTIONS.includes(value as ClockFormat) ? (value as ClockFormat) : DEFAULT_CLOCK;
 }
@@ -52,9 +62,13 @@ export function normalizeDate(value: unknown): DateFormat {
   return DATE_OPTIONS.includes(value as DateFormat) ? (value as DateFormat) : DEFAULT_DATE;
 }
 
+export function normalizeDensity(value: unknown): DensityFormat {
+  return DENSITY_OPTIONS.includes(value as DensityFormat) ? (value as DensityFormat) : DEFAULT_DENSITY;
+}
+
 // ── In-memory mirror + change broadcaster ──────────────────────────────────────
 
-const DEFAULT_PREFS: DateTimePrefs = Object.freeze({ clock: DEFAULT_CLOCK, date: DEFAULT_DATE });
+const DEFAULT_PREFS: DateTimePrefs = Object.freeze({ clock: DEFAULT_CLOCK, date: DEFAULT_DATE, density: DEFAULT_DENSITY });
 let snapshot: DateTimePrefs | null = null;
 const listeners = new Set<() => void>();
 
@@ -68,6 +82,7 @@ function readFromStorage(): DateTimePrefs {
     return {
       clock: normalizeClock(window.localStorage.getItem(DATETIME_CLOCK_KEY)),
       date: normalizeDate(window.localStorage.getItem(DATETIME_DATE_KEY)),
+      density: normalizeDensity(window.localStorage.getItem(DATETIME_DENSITY_KEY)),
     };
   } catch {
     return DEFAULT_PREFS;
@@ -116,11 +131,24 @@ export function setDateFormat(value: DateFormat): void {
   notify();
 }
 
+export function setDensityFormat(value: DensityFormat): void {
+  const density = normalizeDensity(value);
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem(DATETIME_DENSITY_KEY, density);
+    } catch {
+      /* storage unavailable — keep the in-memory pick */
+    }
+  }
+  snapshot = { ...getSnapshot(), density };
+  notify();
+}
+
 // ── Cross-tab + cross-component sync ────────────────────────────────────────────
 
 if (typeof window !== "undefined") {
   window.addEventListener("storage", (e) => {
-    if (e.key === DATETIME_CLOCK_KEY || e.key === DATETIME_DATE_KEY) {
+    if (e.key === DATETIME_CLOCK_KEY || e.key === DATETIME_DATE_KEY || e.key === DATETIME_DENSITY_KEY) {
       snapshot = null;
       notify();
     }

--- a/src/lib/relative-time.test.ts
+++ b/src/lib/relative-time.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { relativeTime, isRelativePhrase } from "./relative-time.ts";
 import { relativeTime as reExported } from "./daily-report.ts";
+import { readFileSync } from "node:fs";
 
 const NOW = new Date("2026-06-18T12:00:00.000Z");
 const NOW_MS = NOW.getTime();
@@ -25,6 +26,27 @@ test("dates from a prior year include the year (Mon D, YYYY)", () => {
   assert.match(out, /2025/);
   // a same-year date older than a week still omits the year
   assert.doesNotMatch(relativeTime(ago(60 * 24 * 8), NOW), /\d{4}/);
+});
+
+test("density key stays in sync with datetime-format (no drift)", () => {
+  const dt = readFileSync(new URL("./datetime-format.ts", import.meta.url), "utf8");
+  const rt = readFileSync(new URL("./relative-time.ts", import.meta.url), "utf8");
+  const key = dt.match(/DATETIME_DENSITY_KEY = "([^"]+)"/)?.[1];
+  assert.ok(key, "datetime-format defines DATETIME_DENSITY_KEY");
+  assert.ok(rt.includes(`"${key}"`), "relative-time reads the same density key");
+});
+
+test("verbose density spells out phrases and uses long month names", () => {
+  assert.equal(relativeTime(ago(0), NOW, "verbose"), "just now");
+  assert.equal(relativeTime(ago(1), NOW, "verbose"), "1 minute ago");
+  assert.equal(relativeTime(ago(5), NOW, "verbose"), "5 minutes ago");
+  assert.equal(relativeTime(ago(60), NOW, "verbose"), "1 hour ago");
+  assert.equal(relativeTime(ago(180), NOW, "verbose"), "3 hours ago");
+  assert.equal(relativeTime(ago(60 * 24), NOW, "verbose"), "1 day ago");
+  const out = relativeTime(ago(60 * 24 * 8), NOW, "verbose");
+  assert.match(out, /^[A-Za-z]{4,} \d{1,2}$/, `expected a long-month date, got "${out}"`);
+  // compact remains the default when no density is passed
+  assert.equal(relativeTime(ago(5), NOW), "5m ago");
 });
 
 test("now accepts a number (epoch ms) or a Date, identically", () => {

--- a/src/lib/relative-time.ts
+++ b/src/lib/relative-time.ts
@@ -7,9 +7,24 @@
 // and the browser-bundled tests can all import it. `now` accepts a number
 // (epoch ms) or a Date, so callers can pass either without converting.
 
+// Relative-time "density" preference. Read localStorage directly (not via the
+// "use client" datetime-format store) so this module stays pure and server-safe.
+// The key MUST match DATETIME_DENSITY_KEY in datetime-format.ts.
+type DensityFormat = "compact" | "verbose";
+
+function readDensity(): DensityFormat {
+  if (typeof window === "undefined") return "compact";
+  try {
+    return window.localStorage.getItem("cave:datetime-density") === "verbose" ? "verbose" : "compact";
+  } catch {
+    return "compact";
+  }
+}
+
 export function relativeTime(
   iso: string | null | undefined,
   now: number | Date = Date.now(),
+  density: DensityFormat = readDensity(),
 ): string {
   if (!iso) return "";
   const then = new Date(iso).getTime();
@@ -17,17 +32,20 @@ export function relativeTime(
   const nowMs = typeof now === "number" ? now : now.getTime();
   const mins = Math.round((nowMs - then) / 60000);
   if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m ago`;
+  const verbose = density === "verbose";
+  if (mins < 60) return verbose ? `${mins} ${mins === 1 ? "minute" : "minutes"} ago` : `${mins}m ago`;
   const hours = Math.round(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
+  if (hours < 24) return verbose ? `${hours} ${hours === 1 ? "hour" : "hours"} ago` : `${hours}h ago`;
   const days = Math.round(hours / 24);
-  if (days < 7) return `${days}d ago`;
-  // Past a week, show an absolute date. Include the year when it is not the
-  // current year, so e.g. "Jan 5, 2025" is not ambiguous with this year's Jan 5.
+  if (days < 7) return verbose ? `${days} ${days === 1 ? "day" : "days"} ago` : `${days}d ago`;
+  // Past a week, show an absolute date. Long month when verbose; include the year
+  // when it is not the current year, so e.g. "Jan 5, 2025" is not ambiguous.
   const sameYear = new Date(then).getFullYear() === new Date(nowMs).getFullYear();
-  return new Intl.DateTimeFormat([], sameYear
-    ? { month: "short", day: "numeric" }
-    : { month: "short", day: "numeric", year: "numeric" }).format(then);
+  return new Intl.DateTimeFormat([], {
+    month: verbose ? "long" : "short",
+    day: "numeric",
+    ...(sameYear ? {} : { year: "numeric" }),
+  }).format(then);
 }
 
 /**


### PR DESCRIPTION
Builds on the relative-time unification (#1309, #1315) — now that every surface routes through the one shared `relativeTime`, a single preference can change relative-time verbosity app-wide.

## What
A third date/time preference alongside Clock (12h/24h) and Date order: **Relative time** density.

| | Compact (default) | Verbose |
|---|---|---|
| recent | `5m ago` | `5 minutes ago` |
| hours | `3h ago` | `3 hours ago` |
| this year | `Jun 12` | `June 12` |
| prior year | `Jan 5, 2025` | `January 5, 2025` |

Compact is the default, so **nothing changes unless a user opts in.**

## How
- **`datetime-format.ts`** — new `density` pref (left **optional** on `DateTimePrefs` so existing `{ clock, date }` literals still typecheck): key, options/label, `normalizeDensity`, `setDensityFormat`, default-prefs, and storage/cross-tab sync — same shape as the existing clock/date prefs.
- **`relative-time.ts`** — `relativeTime(iso, now, density?)`. The default reads a **self-contained** localStorage helper rather than importing the `"use client"` store, keeping this widely server-imported module pure/SSR-safe. A test guards the storage key against drift from `DATETIME_DENSITY_KEY`.
- **Settings** — a "Relative time" segmented picker next to Clock/Date in `settings-fonts.tsx`.

## Tests
Extended `relative-time.test.ts` (verbose phrases + long-month dates + compact-default + key-drift guard → 8 tests) and `datetime-format.test.ts` (density normalize/round-trip → 13 tests). Verified settings-fonts, settings-appearance, dashboard-model, and several runtime `relativeTime` consumers stay green; `check:tests-wired` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)