### PR TITLE
fix(calendar): visible keyboard focus ring on event buttons

### DIFF
--- a/src/components/calendar-view-polish.test.ts
+++ b/src/components/calendar-view-polish.test.ts
@@ -164,3 +164,14 @@ assert.match(
   /@media \(max-width: 767px\) \{[\s\S]*\.calendar-toolbar-icon\s*\{[\s\S]*width:\s*var\(--touch-target\)[\s\S]*height:\s*var\(--touch-target\)/,
   "Mobile calendar icon buttons should be square touch targets",
 );
+
+// Calendar event buttons show a visible keyboard focus ring. The time-grid
+// events are arrow-navigable via roving tabindex, so focus must be visible.
+assert.ok(
+  source.includes("focus-ring-inset absolute flex items-center gap-1 rounded px-1.5 py-0.5 text-left text-[10px]"),
+  "time-grid event buttons have a focus ring",
+);
+assert.ok(
+  source.includes("focus-ring-inset flex items-center gap-1 rounded px-1.5 py-0.5 text-[9px]"),
+  "all-day event buttons have a focus ring",
+);

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -366,7 +366,7 @@ function AllDayStrip({
               <button
                 key={item.id}
                 onClick={() => onOpenItem?.(item)}
-                className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[9px] bg-[var(--accent-presence)]/15 border border-[var(--accent-presence)]/30 hover:bg-[var(--accent-presence)]/25 transition-colors w-full text-left truncate"
+                className="focus-ring-inset flex items-center gap-1 rounded px-1.5 py-0.5 text-[9px] bg-[var(--accent-presence)]/15 border border-[var(--accent-presence)]/30 hover:bg-[var(--accent-presence)]/25 transition-colors w-full text-left truncate"
               >
                 <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${urgencyColor(item)}`} />
                 <span className="truncate text-[var(--text-primary)]">{item.title}</span>
@@ -375,7 +375,7 @@ function AllDayStrip({
             {col.items.length > MAX_ALLDAY_VISIBLE && (
               <button
                 onClick={() => onDayClick?.(col.date)}
-                className="text-[9px] text-[var(--text-muted)] px-1 hover:text-[var(--accent-presence)] transition-colors text-left w-full"
+                className="focus-ring-inset text-[9px] text-[var(--text-muted)] px-1 hover:text-[var(--accent-presence)] transition-colors text-left w-full"
                 title={`${col.items.length - MAX_ALLDAY_VISIBLE} more — click to see all`}
               >
                 +{col.items.length - MAX_ALLDAY_VISIBLE} more
@@ -491,7 +491,7 @@ function TimeGrid({
                   data-calendar-event="true"
                   onClick={() => onOpenItem?.(ev.item)}
                   title={ev.item.title}
-                  className={`absolute flex items-center gap-1 rounded px-1.5 py-0.5 text-left text-[10px] border transition-colors overflow-hidden ${
+                  className={`focus-ring-inset absolute flex items-center gap-1 rounded px-1.5 py-0.5 text-left text-[10px] border transition-colors overflow-hidden ${
                     done
                       ? "border-[var(--border-hairline)] bg-[var(--bg-raised)] opacity-60"
                       : "border-[var(--accent-presence)]/30 bg-[var(--accent-presence)]/15 hover:bg-[var(--accent-presence)]/25"


### PR DESCRIPTION
From a review of the command palette, shortcuts sheet, and calendar (the first two came back clean).

## Problem
Calendar event buttons had no `focus-ring` class, so keyboard focus was invisible. The important case: the **time-grid event buttons are arrow-key navigable** via `useRovingTabIndex` (`data-calendar-event`), so you could move focus between events but couldn't *see* which one was focused — defeating the roving-nav investment. The all-day item buttons and the "+N more" button had the same gap.

## Fix
Add `focus-ring-inset` to all three (all-day items, "+N more", time-grid events). Inset rather than the outset `focus-ring` so the outline isn't clipped by the calendar's scroll container or overlapping adjacent events.

## Tests
Extended `calendar-view-polish.test.ts` to assert the time-grid and all-day event buttons carry a focus ring. `calendar-view-polish`, `calendar-keyboard`, and `calendar-actions` all green.

## Also reviewed (clean)
The **command palette** (listbox/option roles, `aria-activedescendant`, roving arrow nav, focus-trap, pending guard on Salem) and the **shortcuts sheet** (shared Modal + focus-trap) checked out — no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)