### PR TITLE
feat(sessions): press "/" to jump to the sessions search

### DIFF
--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -337,10 +337,18 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     [grouped, effectiveSelection],
   );
 
-  // Focus search on Cmd+F / Ctrl+F
+  // Focus search on Cmd+F / Ctrl+F, or "/" (GitHub-style) when the user isn't
+  // already typing in a field or holding a modifier.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === "f") {
+        e.preventDefault();
+        searchRef.current?.focus();
+        return;
+      }
+      if (e.key === "/" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        const t = e.target as HTMLElement | null;
+        if (t && (t.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName))) return;
         e.preventDefault();
         searchRef.current?.focus();
       }
@@ -692,6 +700,14 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               placeholder="Search sessions…"
               className="min-w-0 flex-1 bg-transparent text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none"
             />
+            {!search && (
+              <kbd
+                aria-hidden
+                className="pointer-events-none shrink-0 rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-1 font-mono text-[10px] leading-tight text-[var(--text-muted)]"
+              >
+                /
+              </kbd>
+            )}
             {search && (
               <button
                 type="button"


### PR DESCRIPTION
## What

Completes the `/` search-focus arc (#1323 Familiars, #1324 Projects, #1325 Capabilities) on the **chat sessions list**, alongside the existing **Cmd/Ctrl+F**. Pressing `/` focuses the sessions search unless the user is already typing in a field or holding a modifier, with a discoverable `/` badge in the empty field.

`ChatList` and `ProjectsView` are mutually exclusive branches in `chat-surface.tsx` (scope `"projects"` vs the else branch), so this never collides with the Projects-tab `/` handler.

## Verify
- `chat-list-mobile-rail-port.test.ts`, `chat-rail-modern-redesign.test.ts` — pass; `pnpm build` — clean (test:app + test:mobile)
- Identical, already-live-verified pattern from #1323/#1324/#1325; the `/` guard skips inputs so it won't fire while typing in the composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)