### PR TITLE
fix(ios): tailnet-trust host gate (tokenless app connects over Tailscale) + 18px bubbles

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UIKit
 
 struct MessageBubble: View {
     let message: DisplayMessage
@@ -34,13 +33,13 @@ struct MessageBubble: View {
         if message.text.isEmpty && message.streaming {
             TypingIndicator()
                 .padding(.horizontal, 14).padding(.vertical, 11)
-                .background(bubbleBackground, in: BubbleShape(isUser: isUser))
+                .background(bubbleBackground, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
         } else {
             Text(message.text.isEmpty ? " " : message.text)
                 .textSelection(.enabled)
                 .foregroundStyle(isUser ? Color.white : Color.primary)
                 .padding(.horizontal, 14).padding(.vertical, 9)
-                .background(bubbleBackground, in: BubbleShape(isUser: isUser))
+                .background(bubbleBackground, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
                 .overlay(alignment: .bottomTrailing) {
                     if message.streaming {
                         StreamingDot().padding(6)
@@ -53,32 +52,6 @@ struct MessageBubble: View {
         if message.isError { return Color.red.opacity(0.85) }
         if isUser { return Color.accentColor }
         return Color(.secondarySystemBackground)
-    }
-}
-
-/// Rounded message bubble with one squared "tail" corner on the sender's side,
-/// iMessage-style.
-struct BubbleShape: Shape {
-    var isUser: Bool
-    func path(in rect: CGRect) -> Path {
-        let r: CGFloat = 18
-        let tail: CGFloat = 5
-        let corners: UIRectCorner = isUser
-            ? [.topLeft, .topRight, .bottomLeft]   // squared bottom-right tail
-            : [.topLeft, .topRight, .bottomRight]  // squared bottom-left tail
-        let path = UIBezierPath(
-            roundedRect: rect,
-            byRoundingCorners: corners,
-            cornerRadii: CGSize(width: r, height: r)
-        )
-        // Soften the tail corner instead of a hard 90°.
-        let tailPath = UIBezierPath(
-            roundedRect: rect,
-            byRoundingCorners: isUser ? [.bottomRight] : [.bottomLeft],
-            cornerRadii: CGSize(width: tail, height: tail)
-        )
-        path.append(tailPath)
-        return Path(path.cgPath)
     }
 }
 

--- a/docs/ios-native-rebuild.md
+++ b/docs/ios-native-rebuild.md
@@ -100,13 +100,27 @@ settings. **Verified on the iPhone 16 Pro simulator** against a mock implementin
 above: native render (no webview), familiars loaded tokenlessly, group thread with attributed
 replies.
 
-### Remaining for Phase 1 (next, separate PRs)
-- **Server: drop the token gate for tailnet traffic.** Relax `proxy.ts` `mobileAccessGate` /
-  sidecar-token enforcement so requests arriving over the Tailscale interface need no token,
-  and update `middleware.test.ts` accordingly. Security-sensitive + touches shared code → its
-  own focused PR (Phase 1b), not bundled with this additive scaffold.
-- **Live streaming send** wired against a real desktop (the SSE client is built; needs the
-  server change above to connect tokenlessly).
+### Phase 1b — tokenless server, DONE (with a correction)
+`pnpm mobile:tailscale:app` starts the loopback Next server with no token (no
+`COVEN_CAVE_ACCESS_TOKEN`/`COVEN_CAVE_AUTH_TOKEN`, not bundled) and `tailscale serve`s it.
+
+**Correction (verified against a real tailnet, 2026-06-20):** an earlier draft claimed this
+needed *no* proxy change because Serve forwards `Host: 127.0.0.1`. That is **false** for current
+Tailscale — Serve forwards the request's `<host>.ts.net` Host, so `isAllowedApiHost` returned
+**403 "forbidden host"** for every tokenless tailnet request. The fix: the app mode sets
+`COVEN_CAVE_TAILNET_TRUST=1`, which `proxy.ts` feeds into the host gate as
+`isAllowedApiHost(requestHost, mobileAccessAuthenticated || tailnetTrusted)`. The CSRF
+Origin/Referer gate still blocks cross-site browser requests; a native client sends no Origin and
+passes. The packaged desktop app does **not** set the flag, so its gate is unchanged. Pinned by
+`middleware.test.ts` + `proxy-behavior.test.ts`.
+
+End-to-end verified: the iOS app on the simulator loaded the real 11 familiars (incl. avatar
+images) and a real `claude` harness session was driven via `POST /api/chat/send`, all tokenless
+over `https://<host>.ts.net:<port>`.
+
+### Remaining (next, separate PRs)
+- **Live streaming send in-app** end-to-end against a real desktop (the SSE client is built and
+  the path is proven via curl; needs in-app verification, blocked locally by lack of tap tooling).
 - History load on thread open (client method exists; wire into `ChatView.onAppear`).
 
 ## Phased rollout

--- a/scripts/mobile-tailscale.sh
+++ b/scripts/mobile-tailscale.sh
@@ -193,10 +193,12 @@ start_with_tmux() {
     # still blocks any drive-by browser request (those always carry an Origin);
     # a native client sends none, so it passes the gate, and with neither
     # COVEN_CAVE_ACCESS_TOKEN nor COVEN_CAVE_AUTH_TOKEN set (and not bundled) the
-    # /api/ proxy falls through to NextResponse.next(). Tailnet membership is the
-    # trust boundary — see docs/ios-native-rebuild.md.
+    # /api/ proxy falls through to NextResponse.next(). COVEN_CAVE_TAILNET_TRUST=1
+    # relaxes the loopback host gate because Tailscale Serve forwards the
+    # <host>.ts.net Host (not 127.0.0.1). Tailnet membership is the trust
+    # boundary — see docs/ios-native-rebuild.md.
     tmux new-session -d -s "$TMUX_SESSION" -c "$PWD" \
-      "bash -lc 'unset COVEN_CAVE_ACCESS_TOKEN COVEN_CAVE_AUTH_TOKEN COVEN_CAVE_BUNDLE; exec pnpm exec next dev -H \"$HOST\" -p \"$PORT\" >>\"$LOG_FILE\" 2>&1'"
+      "bash -lc 'unset COVEN_CAVE_ACCESS_TOKEN COVEN_CAVE_AUTH_TOKEN COVEN_CAVE_BUNDLE; export COVEN_CAVE_TAILNET_TRUST=1; exec pnpm exec next dev -H \"$HOST\" -p \"$PORT\" >>\"$LOG_FILE\" 2>&1'"
     tmux display-message -p -t "$TMUX_SESSION" '#{pane_pid}' >"$PID_FILE"
     return 0
   fi
@@ -221,6 +223,7 @@ start_with_nohup() {
   if [ "${CAVE_MOBILE_APP:-0}" = "1" ]; then
     # Tokenless native-app server. See start_with_tmux for the trust rationale.
     nohup env -u COVEN_CAVE_ACCESS_TOKEN -u COVEN_CAVE_AUTH_TOKEN -u COVEN_CAVE_BUNDLE \
+      COVEN_CAVE_TAILNET_TRUST=1 \
       pnpm exec next dev -H "$HOST" -p "$PORT" >"$LOG_FILE" 2>&1 </dev/null &
     echo "$!" >"$PID_FILE"
     return 0

--- a/scripts/mobile-tailscale.test.mjs
+++ b/scripts/mobile-tailscale.test.mjs
@@ -34,6 +34,10 @@ test("mobile tailscale app mode serves the native client with no token", () => {
   );
   assert.match(script, /-u COVEN_CAVE_ACCESS_TOKEN -u COVEN_CAVE_AUTH_TOKEN -u COVEN_CAVE_BUNDLE/);
   assert.match(script, /tokenless app mode: do not mint or load any token/);
+  // Tailscale Serve forwards the <host>.ts.net Host, so the tokenless server must
+  // run with COVEN_CAVE_TAILNET_TRUST=1 to relax the loopback host gate.
+  assert.match(script, /export COVEN_CAVE_TAILNET_TRUST=1/);
+  assert.match(script, /COVEN_CAVE_TAILNET_TRUST=1/);
 });
 
 test("mobile tailscale runner persists state for remote invite regeneration", () => {

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -17,7 +17,8 @@ assert.match(source, /process\.env\.COVEN_CAVE_BUNDLE === "1"[\s\S]*missing side
 assert.match(source, /req\.headers\.get\("origin"\)/, "middleware should reject unsafe origins");
 assert.match(source, /req\.headers\.get\("host"\)/, "middleware should reject unsafe hosts");
 assert.match(source, /const requestHost = req\.headers\.get\("host"\)/, "proxy should capture the forwarded request host once");
-assert.match(source, /isAllowedApiHost\(requestHost, mobileAccessAuthenticated\)/, "valid mobile access should satisfy the API host gate");
+assert.match(source, /isAllowedApiHost\(requestHost, mobileAccessAuthenticated \|\| tailnetTrusted\)/, "valid mobile access or tailnet-trust should satisfy the API host gate");
+assert.match(source, /const tailnetTrusted = process\.env\.COVEN_CAVE_TAILNET_TRUST === "1"/, "tokenless app mode (COVEN_CAVE_TAILNET_TRUST) should relax the host gate for tailnet-forwarded requests");
 assert.match(source, /isAllowedRequestSource\(req\.headers\.get\("origin"\), expectedOrigin\)/, "API origin gate should require same-origin sources unless header-CSRF-trusted");
 assert.match(source, /isAllowedRequestSource\(req\.headers\.get\("referer"\), expectedOrigin\)/, "API referer gate should require same-origin sources unless header-CSRF-trusted");
 assert.match(source, /unsupported content-type/, "middleware should reject unsafe content types before body parsing");
@@ -49,7 +50,7 @@ assert.doesNotMatch(
 // the bypass ran first and silently let non-loopback callers through during
 // `pnpm dev` if anything ever bound the dev server outside 127.0.0.1.
 {
-  const hostIdx = source.indexOf("isAllowedApiHost(requestHost, mobileAccessAuthenticated)");
+  const hostIdx = source.indexOf("isAllowedApiHost(requestHost, mobileAccessAuthenticated || tailnetTrusted)");
   const originIdx = source.indexOf('isAllowedRequestSource(req.headers.get("origin")');
   const refererIdx = source.indexOf('isAllowedRequestSource(req.headers.get("referer")');
   const contentTypeIdx = source.indexOf("unsupported content-type");

--- a/src/proxy-behavior.test.ts
+++ b/src/proxy-behavior.test.ts
@@ -194,17 +194,24 @@ assert.equal(
 
 // ─── Native iOS app (tokenless, over Tailscale Serve) contract ─────────────
 // The native SwiftUI client (pnpm mobile:tailscale:app) is NOT a browser: it
-// sends no Origin and no Referer, and Tailscale Serve forwards Host: 127.0.0.1
-// to the loopback server. With neither COVEN_CAVE_ACCESS_TOKEN nor
-// COVEN_CAVE_AUTH_TOKEN configured (and not bundled), proxy() falls through to
-// NextResponse.next() AFTER these source gates pass. These assertions pin the
-// gate-level behavior that flow depends on; the proxy() body ordering is pinned
-// by middleware.test.ts. A malicious same-machine BROWSER page is still blocked
-// because it always carries a cross-origin Origin (rejected just above).
+// sends no Origin and no Referer. IMPORTANT (verified against a real tailnet,
+// 2026-06-20): Tailscale Serve forwards the request's `<host>.ts.net` Host —
+// NOT 127.0.0.1 — so the loopback host gate alone 403s every tailnet request.
+// The tokenless app mode therefore sets COVEN_CAVE_TAILNET_TRUST=1, which proxy()
+// feeds into the host gate as `mobileAccessAuthenticated || tailnetTrusted`, so
+// the ts.net Host is accepted. The CSRF Origin/Referer gate still applies (a
+// malicious same-machine BROWSER page carries a cross-origin Origin and is
+// rejected); a native client sends none and passes. Ordering is pinned by
+// middleware.test.ts.
 assert.equal(
-  isAllowedApiHost("127.0.0.1:3000", false),
+  isAllowedApiHost("mb-black.example.ts.net:8443", false),
+  false,
+  "tokenless app: without trust, the forwarded ts.net Host is NOT a loopback host",
+);
+assert.equal(
+  isAllowedApiHost("mb-black.example.ts.net:8443", true),
   true,
-  "tokenless app: Tailscale Serve forwards loopback Host, which is allowed",
+  "tokenless app: COVEN_CAVE_TAILNET_TRUST feeds `true` so the ts.net Host is accepted",
 );
 assert.equal(
   isAllowedRequestSource(null, expected),
@@ -214,7 +221,7 @@ assert.equal(
 assert.equal(
   isAllowedRequestSource(null, "http://127.0.0.1:3000"),
   true,
-  "tokenless app: absent Referer at the loopback Serve backend passes",
+  "tokenless app: absent Referer passes the source gate",
 );
 
 // ─── shouldRequireMobileAccessCredential ──────────────────────────────────

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -137,7 +137,15 @@ export async function proxy(req: NextRequest) {
   const mobileAccessAuthenticated = mobileAccessToken
     ? Boolean(await mobileAccessVerification(req, mobileAccessToken))
     : false;
-  if (!isAllowedApiHost(requestHost, mobileAccessAuthenticated)) {
+  // Tokenless native-app mode (COVEN_CAVE_TAILNET_TRUST=1, set only by
+  // `pnpm mobile:tailscale:app`): the server is reachable only over loopback and
+  // via `tailscale serve`, which forwards the request's `<host>.ts.net` Host —
+  // NOT 127.0.0.1 — so the loopback host gate would otherwise 403 every tailnet
+  // request. Trusting the host here is safe because tailnet membership is the
+  // ingress boundary in this mode; the CSRF Origin/Referer gate below still
+  // blocks cross-site browser requests. The packaged app does NOT set this flag.
+  const tailnetTrusted = process.env.COVEN_CAVE_TAILNET_TRUST === "1";
+  if (!isAllowedApiHost(requestHost, mobileAccessAuthenticated || tailnetTrusted)) {
     return jsonError(403, "forbidden host");
   }
 


### PR DESCRIPTION
## What

Two follow-ups after running the native iOS app (#1319) against a **real desktop over Tailscale**.

### 1. Tokenless connection actually works now (the important one)

Running #1319's `pnpm mobile:tailscale:app` against a real tailnet surfaced that an earlier claim — "no proxy change needed because Tailscale Serve forwards `Host: 127.0.0.1`" — is **false** for current Tailscale. Verified against a live tailnet: **Serve forwards the request's `<host>.ts.net` Host**, so `isAllowedApiHost` returned **403 "forbidden host"** for every tokenless request, and the native app could not connect to a real desktop.

**Fix:** the app launch mode sets `COVEN_CAVE_TAILNET_TRUST=1`, and `proxy.ts` feeds it into the host gate:
```
isAllowedApiHost(requestHost, mobileAccessAuthenticated || tailnetTrusted)
```
Safe because in this mode the server is reachable only over loopback + `tailscale serve` (tailnet = ingress boundary), and the **CSRF Origin/Referer gate still applies** — a drive-by browser carries a cross-origin Origin and is rejected; a native client sends none and passes. The **packaged desktop app does not set the flag**, so its gate is unchanged.

Pinned by `middleware.test.ts` + `proxy-behavior.test.ts`; `mobile-tailscale.test.mjs` asserts the app mode exports the flag; `docs/ios-native-rebuild.md` corrected.

### 2. Bubbles → fully-rounded 18px (iOS continuous corners)

Per request: replace the squared-tail shape with a continuous 18px `RoundedRectangle` for both sides (drops the UIKit dependency).

## Verified end-to-end against the real desktop over Tailscale

- `https://<host>.ts.net:<port>/api/familiars` → real **11 familiars** (200), tokenless.
- iOS app on the simulator loaded the real familiars **incl. avatar images** over the tailnet.
- A real `claude` harness session was driven via `POST /api/chat/send` (clean SSE `session`→`done`); the empty *content* was a desktop-side daemon `database is locked` issue (concurrent servers), not the app/transport.
- Rounded-bubble screenshot captured against real data.

All tests pass locally: proxy-behavior, middleware, mobile-tailscale (8), mobile-tailscale-native (1), shell syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)