### PR TITLE
feat(daily-report): recover headline stats from the body when media.stats absent

### DIFF
--- a/src/app/daily-report/[date]/page.tsx
+++ b/src/app/daily-report/[date]/page.tsx
@@ -7,6 +7,7 @@ import {
   longDateLabel,
   parseDateSlug,
   parseRecentSessions,
+  parseStatsFromBody,
   relativeTime,
 } from "@/lib/daily-report";
 
@@ -59,7 +60,7 @@ export default async function DailyReportPage({ params }: Props) {
     );
   }
 
-  const stats = item.media?.stats;
+  const stats = item.media?.stats ?? parseStatsFromBody(item.body);
   const breakdown = breakdownForDay(inbox.items, parsedDate ?? new Date());
   const recentSessions = parseRecentSessions(item.body);
   const generatedAt = item.firedAt ?? item.updatedAt ?? null;

--- a/src/lib/daily-report.test.ts
+++ b/src/lib/daily-report.test.ts
@@ -9,6 +9,7 @@ import {
   longDateLabel,
   parseDateSlug,
   parseRecentSessions,
+  parseStatsFromBody,
   recentReports,
   relativeDayLabel,
   relativeTime,
@@ -147,6 +148,29 @@ function item(overrides) {
   assert.deepEqual(sessions, ["Fix auth (+12 -3)", "Polish board"]);
   assert.deepEqual(parseRecentSessions("no recent line"), []);
   assert.deepEqual(parseRecentSessions(undefined), []);
+}
+
+// parseStatsFromBody --------------------------------------------------------
+{
+  const body = "0 reminders fired\n0 responses waiting\n1 familiar updates\n8 sessions updated\nRecent: a · b";
+  assert.deepEqual(parseStatsFromBody(body), { reminders: 0, responses: 0, familiars: 1, sessions: 8 });
+  // tolerant of singular/plural wording
+  assert.deepEqual(parseStatsFromBody("1 reminder fired\n1 session updated"), { reminders: 1, responses: 0, familiars: 0, sessions: 1 });
+  // no count lines → null (don't fabricate zeros for a non-summary body)
+  assert.equal(parseStatsFromBody("just some prose, nothing countable"), null);
+  assert.equal(parseStatsFromBody(undefined), null);
+
+  // recentReports recovers stats from the body when media.stats is absent
+  const reports = recentReports([
+    item({
+      id: "d",
+      kind: "daily-summary",
+      auto: "daily-summary:2026-06-18",
+      title: "Daily summary · Jun 18",
+      body: "0 reminders fired\n0 responses waiting\n0 familiar updates\n5 sessions updated",
+    }),
+  ]);
+  assert.equal(reports[0].stats.sessions, 5, "stats recovered from body when media.stats absent");
 }
 
 console.log("daily-report.test.ts: ok");

--- a/src/lib/daily-report.ts
+++ b/src/lib/daily-report.ts
@@ -211,7 +211,7 @@ export function recentReports(items: InboxItem[]): RecentReport[] {
         slug,
         title: item.title,
         generatedAt: item.firedAt ?? item.updatedAt ?? null,
-        stats: item.media?.stats ?? null,
+        stats: item.media?.stats ?? parseStatsFromBody(item.body),
         href: `/daily-report/${slug}`,
       };
     })
@@ -247,4 +247,33 @@ export function parseRecentSessions(body: string | undefined): string[] {
     .split("·")
     .map((s) => s.trim())
     .filter(Boolean);
+}
+
+/**
+ * Recover the headline counts from the summary body text — the lines the
+ * summary builder writes ("N reminders fired", "N responses waiting", "N
+ * familiar updates", "N sessions updated"). Older reports were generated before
+ * the counts were frozen into `media.stats`; this lets the dashboard rows and
+ * the report page still show their stats. Returns null when the body carries
+ * none of the four count lines (so a non-summary body yields no zeros).
+ */
+export function parseStatsFromBody(body: string | undefined): DailyReportStats | null {
+  if (!body) return null;
+  const count = (re: RegExp): number | null => {
+    const m = body.match(re);
+    return m ? Number.parseInt(m[1], 10) : null;
+  };
+  const reminders = count(/(\d+)\s+reminders?\s+fired/i);
+  const responses = count(/(\d+)\s+responses?\s+waiting/i);
+  const familiars = count(/(\d+)\s+familiar\s+updates?/i);
+  const sessions = count(/(\d+)\s+sessions?\s+updated/i);
+  if (reminders === null && responses === null && familiars === null && sessions === null) {
+    return null;
+  }
+  return {
+    reminders: reminders ?? 0,
+    responses: responses ?? 0,
+    familiars: familiars ?? 0,
+    sessions: sessions ?? 0,
+  };
 }


### PR DESCRIPTION
## What

Daily reports generated before the headline counts were frozen into `media.stats` showed **no metadata**: their dashboard recent-reports row had no `rem/resp/sess` mini-stats, and the report page rendered no metric cards — even though the counts sit right in the body text (`N reminders fired / N responses waiting / N familiar updates / N sessions updated`).

## Change

Add `parseStatsFromBody(body)` to `lib/daily-report.ts` and fall back to it (`media.stats ?? parseStatsFromBody(body)`) in both `recentReports()` and the report page. Singular/plural tolerant; returns `null` when the body has none of the four count lines, so a non-summary body never fabricates zeros.

## Verification

- Live-verified on real data: the **Jun 18** report (no `media.stats`) now shows its mini-stats on the dashboard recent-reports row (**0 rem · 0 resp · 8 sess**, was bare) and **all four metric cards** on the report page (was none). The Jun 19/20 reports (which already had `media.stats`) are unchanged.
- New `parseStatsFromBody` unit test + a `recentReports` body-fallback case.
- `pnpm typecheck` clean, `pnpm build` clean, `pnpm test:app` ✓ 338 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)