### PR TITLE
docs(shortcuts): document "/" search focus and ⌘F in the catalog

### DIFF
--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -13,6 +13,8 @@
  *   - palette, surfaces, familiars, new chat, this sheet: src/components/workspace.tsx
  *   - composer + slash menu: src/components/chat-view.tsx onComposerKey and
  *     src/components/home-composer.tsx handleKeyDown
+ *   - "/" search focus: each surface's view (familiars-view, projects-view,
+ *     capabilities-view, chat-list); "⌘F" sessions search: chat-list.tsx
  */
 
 export type ShortcutEntry = {
@@ -44,6 +46,8 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: "⌥1–⌥9", description: "Select the Nth familiar" },
       { keys: "⌘↑ / ⌘↓", description: "Cycle through familiars" },
       { keys: "⌘N", description: "New chat (on the Chat surface)" },
+      { keys: "/", description: "Focus the search (Familiars, Projects, Capabilities, Sessions)" },
+      { keys: "⌘F", description: "Focus the sessions search" },
     ],
   },
   {


### PR DESCRIPTION
## What

The `/` search-focus shortcut (#1323/#1324/#1325/#1328) and the pre-existing **⌘F** sessions-search focus weren't listed in the keyboard-shortcut catalog, so they never appeared in the **Shortcuts sheet** (⌘/ or `?`) or the `/help` keyboard section.

Add both entries to the "Panels & navigation" group and note their source locations in the catalog's doc-comment — keeping the catalog truthful and complete.

## Verify
- `roles-tools-navigation.test.ts`, `shell-edge-rails.test.ts` (both read the catalog) — pass; `pnpm build` — clean
- The Shortcuts sheet renders entries data-driven from `SHORTCUT_GROUPS`, so the new rows appear automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)