### PR TITLE
feat(time): shared <RelativeTime> with exact-time tooltip + <time> semantics

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -316,6 +316,7 @@ export const SUITES = {
     "src/components/ui/color-picker.test.ts",
     "src/components/ui/popover.test.ts",
     "src/components/ui/modal.test.ts",
+    "src/components/ui/relative-time.test.ts",
     "src/lib/workflow-source-bundle.test.ts",
     "src/lib/vault-bundle.test.ts",
     "src/lib/cave-board-atomic.test.ts",

--- a/src/components/library-bookmarks-list.tsx
+++ b/src/components/library-bookmarks-list.tsx
@@ -10,7 +10,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
-import { relativeTime } from "@/lib/relative-time";
+import { RelativeTime } from "@/components/ui/relative-time";
 import type { LibraryBookmark } from "@/lib/library-types";
 import { useIsCoarsePointer } from "@/lib/use-viewport";
 
@@ -460,7 +460,7 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
                         </span>
                       </td>
                       <td style={{ textAlign: "right" }}>
-                        <span className="board-table-muted">{relativeTime(item.savedAt)}</span>
+                        <RelativeTime iso={item.savedAt} className="board-table-muted" />
                       </td>
                       <td onClick={(e) => e.stopPropagation()}>
                         <span style={{ display: "flex", alignItems: "center", gap: 4 }}>

--- a/src/components/library-github-list.tsx
+++ b/src/components/library-github-list.tsx
@@ -8,7 +8,7 @@ import { LibraryUndoToast } from "@/components/library-undo-toast";
 import { EmptyState } from "@/components/ui/empty-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
-import { relativeTime } from "@/lib/relative-time";
+import { RelativeTime } from "@/components/ui/relative-time";
 import type { CardGitHubLink, CardStatus } from "@/lib/cave-board-types";
 import type { LibraryGitHubItem, GitHubItemKind } from "@/lib/library-types";
 import {
@@ -805,7 +805,7 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
                             <span className="board-table-muted gh-repo-cell">{item.repo}</span>
                           </td>
                           <td className="gh-col-saved">
-                            <span className="board-table-muted">{relativeTime(item.savedAt)}</span>
+                            <RelativeTime iso={item.savedAt} className="board-table-muted" />
                           </td>
                           <td className="gh-col-kind">
                             <span className="board-table-muted library-source-type gh-kind-pill">

--- a/src/components/retro-runs-view.tsx
+++ b/src/components/retro-runs-view.tsx
@@ -6,6 +6,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { relativeTime } from "@/lib/relative-time";
+import { RelativeTime } from "@/components/ui/relative-time";
 import type { RetroOutcome, RetroRun, RetroRunsSnapshot, RetroTrack } from "@/lib/retro-runs";
 
 type RetroApiResponse = {
@@ -95,7 +96,7 @@ function RunRow({ run }: { run: RetroRun }) {
             {scoreLabel(run.delta)}
           </span>
           <span>{run.metricBefore.toFixed(2)} -&gt; {run.metricAfter.toFixed(2)}</span>
-          <span>{relativeTime(run.timestamp)}</span>
+          <RelativeTime iso={run.timestamp} />
         </div>
 
         {run.notes ? <p className="retro-run-row__notes">{run.notes}</p> : null}

--- a/src/components/ui/relative-time.test.ts
+++ b/src/components/ui/relative-time.test.ts
@@ -1,0 +1,14 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./relative-time.tsx", import.meta.url), "utf8");
+
+assert.match(src, /<time\b/, "renders a semantic <time> element");
+assert.match(src, /dateTime=\{iso\}/, "sets a machine-readable dateTime");
+assert.match(src, /title=\{exact\}/, "exposes the exact timestamp on hover");
+assert.match(src, /relativeTime\(iso, now, prefs\.density\)/, "uses shared relativeTime honoring density");
+assert.match(src, /formatDate\(iso, prefs/, "builds the exact title from the shared absolute formatter");
+assert.match(src, /useDateTimePrefs\(\)/, "subscribes to date/time prefs so changes apply live");
+
+console.log("ui/relative-time.test.ts: ok");

--- a/src/components/ui/relative-time.tsx
+++ b/src/components/ui/relative-time.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { relativeTime } from "@/lib/relative-time";
+import { formatClock, formatDate, useDateTimePrefs } from "@/lib/datetime-format";
+
+/**
+ * Renders a relative timestamp ("5m ago") as a semantic <time> element, with an
+ * exact, preference-aware absolute string in the title (hover) — e.g.
+ * "Monday, June 16, 2026 at 1:31 PM". Subscribes to the date/time prefs so the
+ * compact/verbose density (plus clock + date order) apply live.
+ */
+export function RelativeTime({
+  iso,
+  now,
+  className,
+}: {
+  iso: string | null | undefined;
+  now?: number;
+  className?: string;
+}) {
+  const prefs = useDateTimePrefs();
+  if (!iso) return null;
+  const rel = relativeTime(iso, now, prefs.density);
+  if (!rel) return null;
+  const exact = `${formatDate(iso, prefs, { year: true, weekday: true })} at ${formatClock(iso, prefs)}`;
+  return (
+    <time dateTime={iso} title={exact} className={className}>
+      {rel}
+    </time>
+  );
+}


### PR DESCRIPTION
Capstone to the relative-time arc. A small reusable component that turns any relative timestamp into a richer, semantic, hover-inspectable one.

## What
`src/components/ui/relative-time.tsx` — `<RelativeTime iso={…} />` renders the relative phrase ("5m ago") as a **semantic `<time dateTime={iso}>`** with the **exact, preference-aware timestamp in the `title`** (hover) — e.g. *"Monday, June 16, 2026 at 1:31 PM"*. It subscribes to `useDateTimePrefs()`, so the new compact/verbose **density** (and clock + date order) apply **live** at every adopting site.

Built from existing shared pieces: `relativeTime`, `formatDate`, `formatClock`, `useDateTimePrefs`.

## Adoption
Adopted at three list timestamps that previously rendered bare text with **no hover detail**: retro runs, library GitHub list, library bookmarks. (Surfaces like recent-activity and new-chat recents already had a `title={formatTimestamp(...)}` tooltip, so they weren't targets.)

A tooltip is a progressive enhancement — invisible until hover — so incremental adoption is non-jarring; the component is available to migrate the rest over time.

## Tests
New `ui/relative-time.test.ts` (wired into `run-tests.mjs`, 430 files) asserts the `<time>`/`dateTime`/`title` semantics and that it routes through the shared formatters honoring density. Ran the full library + retro test suites — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)