### PR TITLE
feat(board): press "/" to jump to the task search

### DIFF
--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import "@/styles/board.css";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { DEMO_BOARD_CARDS } from "@/lib/demo-seed";
 import { DEMO_MODE_EVENT, isDemoModeEnabled } from "@/lib/demo-mode";
@@ -48,6 +48,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
   const [viewMode, setViewMode] = useState<ViewMode>(() => loadPref("cave:board:viewMode", "kanban", ["kanban", "table", "gantt"]));
   const [groupBy, setGroupBy] = useState<GroupBy>(() => loadPref("cave:board:groupBy", "status", ["status", "familiar", "project"]));
   const [searchQuery, setSearchQuery] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [modalDefaultStatus, setModalDefaultStatus] = useState<CardStatus>("backlog");
@@ -83,6 +84,22 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
   }, []);
 
   useEffect(() => { void load(); }, [load]);
+
+  // "/" jumps to the task search (GitHub-style) while the board is shown,
+  // unless the user is already typing in a field or holding a modifier.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== "/" || e.metaKey || e.ctrlKey || e.altKey) return;
+      const t = e.target as HTMLElement | null;
+      if (t && (t.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName))) return;
+      const el = searchRef.current;
+      if (!el) return;
+      e.preventDefault();
+      el.focus();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, []);
   useEffect(() => {
     const onDemoModeChange = () => { void load(); };
     window.addEventListener(DEMO_MODE_EVENT, onDemoModeChange);
@@ -330,6 +347,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
           <Icon name="ph:magnifying-glass" width={13} className="board-search-icon" />
           <label className="sr-only" htmlFor="board-search">Search tasks</label>
           <input
+            ref={searchRef}
             id="board-search"
             className="board-search-input"
             value={searchQuery}
@@ -342,6 +360,9 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
             }}
             placeholder='Search tasks or type is:open cwd:coven-cave url:github'
           />
+          {!searchQuery ? (
+            <kbd aria-hidden className="board-search-kbd">/</kbd>
+          ) : null}
           {searchQuery ? (
             <button
               type="button"

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -18,6 +18,7 @@
 .board-search-input { width:100%; height:30px; padding:0 30px 0 30px; border-radius:7px; border:1px solid var(--border-strong); background:var(--bg-raised); color:var(--text-primary); outline:none; transition:background .12s,border-color .12s; }
 .board-search-input::placeholder { color:var(--text-muted); }
 .board-search-input:focus { border-color:color-mix(in oklch,var(--accent-presence) 52%,transparent); background:var(--bg-hover); }
+.board-search-kbd { position:absolute; right:7px; display:flex; align-items:center; justify-content:center; min-width:16px; height:16px; padding:0 4px; border:1px solid var(--border-hairline); border-radius:4px; background:var(--bg-base); color:var(--text-muted); font-family:var(--font-mono); font-size:10px; line-height:1; pointer-events:none; }
 .board-search-clear { position:absolute; right:5px; display:flex; align-items:center; justify-content:center; width:20px; height:20px; border:0; border-radius:5px; background:transparent; color:var(--text-muted); cursor:pointer; transition:background .1s,color .1s; }
 .board-search-clear:hover { background:var(--bg-hover); color:var(--text-primary); }
 .board-search-clear:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }


### PR DESCRIPTION
## What

Completes the `/` search-focus arc (#1323 Familiars, #1324 Projects, #1325 Capabilities, #1328 Sessions) on the **Board** — the last search surface. Pressing `/` focuses the task search while the board is shown, ignored when the user is already typing or holding a modifier, with a discoverable `/` badge in the empty field (mutually exclusive with the existing clear button). Pairs with the Escape-to-clear shipped in #1276.

## Verify
- `board-ux-polish.test.ts` — pass; `pnpm build` — clean
- Identical, already-live-verified pattern from #1323–#1328; live-drive on the board surface included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)