### PR TITLE
fix: unblock red main — link-viewer test + v0.0.109 release sync

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.108"
+version = "0.0.109"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.108</string>
+	<string>0.0.109</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.108</string>
+	<string>0.0.109</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.108</string>
+	<string>0.0.109</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.108</string>
+	<string>0.0.109</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src/components/library-link-viewer.test.ts
+++ b/src/components/library-link-viewer.test.ts
@@ -48,10 +48,14 @@ assert.match(
   "Embedded Library link viewer should expose a collapsed header class",
 );
 
+// The link viewer redesign (#797a1507) replaced the sandboxed browser-fallback
+// iframe with a native read-only webview surface plus, where that is unavailable,
+// a non-embedding fallback card that links out externally. The native path stays
+// read-only (asserted above + in browser.rs); the web fallback embeds nothing.
 assert.match(
   preview,
-  /<iframe[\s\S]*className="library-link-viewer-frame"[\s\S]*sandbox="allow-same-origin allow-scripts allow-forms"/,
-  "Browser fallback should use a sandboxed iframe without top-navigation permission",
+  /library-link-viewer-fallback__card[\s\S]{0,500}href=\{url\}[\s\S]{0,160}rel="noreferrer"/,
+  "When the native webview is unavailable, the link viewer falls back to a safe external link (no embedded iframe)",
 );
 
 assert.doesNotMatch(
@@ -66,10 +70,12 @@ assert.match(
   "Bookmark selections should render the embedded Library link viewer",
 );
 
+// Reading items get a dedicated metadata/notes detail view (with the source as a
+// link), not the embedded viewer; bookmarks and GitHub items keep <LibraryLinkViewer>.
 assert.match(
   preview,
-  /function ReadingDetail[\s\S]*if \(item\.url\)[\s\S]*<LibraryLinkViewer/,
-  "Reading URL selections should render the embedded Library link viewer",
+  /function ReadingDetail[\s\S]*library-reading-detail__url" href=\{item\.url\}/,
+  "Reading items render a structured detail view exposing the source URL as a link",
 );
 
 assert.match(


### PR DESCRIPTION
`main` was **red on two required checks** (Frontend build *and* Rust check), blocking every open PR. Three independent pre-existing breakages from recent commits, all fixed here:

### 1. `library-link-viewer.test.ts` (Frontend build)
Commit `797a1507` redesigned the Library preview but didn't update this test. Realigned the two stale assertions to the shipped design (native read-only webview surface + non-embedding "open externally" card; `ReadingDetail` now a metadata/notes view while bookmarks/GitHub keep `<LibraryLinkViewer>`). Test-only.

### 2. iOS plist version drift (Frontend build — `app-version.test.ts`)
The v0.0.109 release (`4536f789`) bumped `package.json`/`Cargo.toml` but not the iOS plists. Bumped marketing + build versions `0.0.108 → 0.0.109` in `src-tauri/Info.ios.plist` and `src-tauri/gen/apple/app_iOS/Info.plist`.

### 3. `Cargo.lock` drift (Rust check — `cargo check --locked`)
Same release bumped `Cargo.toml` to 0.0.109 without updating `Cargo.lock`. Synced the local `app` crate `0.0.108 → 0.0.109` — **version bump only, no dependency changes**.

## Verification
Full `test:app` (339 files) and `test:mobile` (16) green; `cargo metadata --locked --offline` passes. No production logic changed — this is test realignment + release-metadata sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)