### PR TITLE
fix(release): sync iOS plist + Cargo.lock versions to 0.0.109 (unblocks main)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.108"
+version = "0.0.109"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.108</string>
+	<string>0.0.109</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.108</string>
+	<string>0.0.109</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.108</string>
+	<string>0.0.109</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.108</string>
+	<string>0.0.109</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
## What

**Main is red on every PR** because the v0.0.109 release (`4536f789`) bumped `package.json`, `tauri.conf.json`, and `Cargo.toml` to 0.0.109 but left the iOS plists and `Cargo.lock` at 0.0.108. Two required checks fail on every branch:

- **Frontend build** — `app-version.test.ts`: *"Source/Generated iOS plist marketing version must match package.json"*
- **Rust check** — `cargo check --locked` refuses to update the stale `Cargo.lock`

This bumps `CFBundleShortVersionString`/`CFBundleVersion` in both iOS plists (`src-tauri/Info.ios.plist`, `src-tauri/gen/apple/app_iOS/Info.plist`) and the `app` package version in `src-tauri/Cargo.lock` to **0.0.109**, so all version sources agree.

## Verify
- `app-version.test.ts` — pass (was the failing assertion)
- `Cargo.lock` now matches `Cargo.toml` (0.0.109), so `cargo check --locked` no longer needs to touch it
- Pure version-string sync; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)