### PR TITLE
feat(workflows): run-prompt preview, import, duplicate step, keyboard shortcuts

### DIFF
--- a/src/components/workflows-view.tsx
+++ b/src/components/workflows-view.tsx
@@ -557,6 +557,34 @@ export function WorkflowsView({
     showNotice(`Created ${saved.id} from the ${input.pattern} pattern.`);
   };
 
+  const handleImport = async (manifest: Record<string, unknown>) => {
+    if (!confirmDiscard()) return;
+    // Land imports in the user's personal library with a unique id; clear the
+    // public flag so the runtime routes the copy to ~/.coven (never the repo).
+    const rawName = typeof manifest.name === "string" ? manifest.name : "";
+    const rawId = typeof manifest.id === "string" && manifest.id.trim() ? manifest.id : rawName || "imported-workflow";
+    const id = uniqueId(slugifyWorkflowId(rawId) || "imported-workflow");
+    const visibility = {
+      ...(manifest.visibility && typeof manifest.visibility === "object" ? (manifest.visibility as Record<string, unknown>) : {}),
+      public: false,
+      personal: true,
+    };
+    const result = await saveWorkflow({ ...manifest, id, visibility });
+    if (!result.ok) {
+      showNotice(result.error ?? "import failed — check the manifest is valid CWF-01");
+      return;
+    }
+    await load(true);
+    const saved = result.workflow;
+    if (saved) {
+      setSelectedWorkflowId(saved.id);
+      setSelectedNodeId(null);
+      setDraftState(initialWorkflowDraft(saved));
+      void loadRuns(saved.id);
+    }
+    showNotice(`Imported ${id}.`);
+  };
+
   const handleDuplicate = async (workflow: WorkflowSummary) => {
     const id = uniqueId(`${slugifyWorkflowId(workflow.id)}-copy`);
     const copy = duplicateWorkflow(workflow, id);
@@ -707,10 +735,12 @@ export function WorkflowsView({
       onUpdateStep={(id, patch) => dispatchDraft({ type: "update-step", id, patch })}
       onUpdateMeta={(patch) => dispatchDraft({ type: "update-meta", patch })}
       onRemoveStep={(id) => dispatchDraft({ type: "remove-step", id })}
+      onDuplicateStep={(id) => dispatchDraft({ type: "duplicate-step", id })}
       onConnect={(source, target) => dispatchDraft({ type: "connect", source, target })}
       onSavePositions={handleSavePositions}
       onDisconnect={(source, target) => dispatchDraft({ type: "disconnect", source, target })}
       onCreate={(input) => void handleCreate(input)}
+      onImport={(manifest) => void handleImport(manifest)}
       onDuplicate={(workflow) => void handleDuplicate(workflow)}
       onDelete={(workflow) => void handleDelete(workflow)}
       onAttachRole={(role, attach) => void handleAttachRole(role, attach)}

--- a/src/components/workflows/workflow-create-dialog.tsx
+++ b/src/components/workflows/workflow-create-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useRef, useState } from "react";
+import { parse as parseYaml } from "yaml";
 import { Icon } from "@/lib/icon";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { slugifyWorkflowId } from "@/lib/workflow-edit";
@@ -221,6 +222,89 @@ export function WorkflowRunInputsDialog({ workflow, inputSteps, onClose, onRun }
           <button type="button" className="workflow-play-button workflow-primary-button" onClick={submit}>
             <Icon name="ph:lightning-bold" width={13} />
             {filledCount > 0 ? `Run with ${filledCount} input${filledCount === 1 ? "" : "s"}` : "Run"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type WorkflowImportDialogProps = {
+  onClose: () => void;
+  onImport: (manifest: Record<string, unknown>) => void;
+};
+
+/**
+ * Import a workflow by pasting its manifest (YAML or JSON — `yaml.parse` reads
+ * both). The round-trip partner to the manifest Copy button: copy a manifest
+ * from one workflow, paste it here to recreate it. Schema validation happens on
+ * Save; this dialog only guards that the paste is a single manifest object.
+ */
+export function WorkflowImportDialog({ onClose, onImport }: WorkflowImportDialogProps) {
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(true, dialogRef, { onEscape: onClose, focusFirst: false });
+
+  const submit = () => {
+    if (!text.trim()) {
+      setError("Paste a workflow manifest first.");
+      return;
+    }
+    let parsed: unknown;
+    try {
+      parsed = parseYaml(text);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Couldn't parse the manifest.");
+      return;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      setError("A manifest must be a single YAML/JSON object.");
+      return;
+    }
+    onImport(parsed as Record<string, unknown>);
+  };
+
+  return (
+    <div className="workflow-dialog-backdrop" role="presentation" onClick={onClose}>
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        className="workflow-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Import workflow"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="workflow-panel-heading">
+          <div>
+            <p className="workflow-eyebrow">Import workflow</p>
+            <h2>Paste a manifest</h2>
+          </div>
+          <button type="button" className="workflow-icon-button" onClick={onClose} aria-label="Close">
+            <Icon name="ph:x" width={14} />
+          </button>
+        </div>
+        <p className="workflow-muted">YAML or JSON. Imported as a personal copy; the id is de-duplicated if it collides.</p>
+        <textarea
+          className="workflow-run-input-field workflow-import-field"
+          rows={10}
+          autoFocus
+          placeholder={"id: my-workflow\nversion: 0.1.0\nsteps:\n  - id: input\n    kind: input\n  - id: output\n    kind: output"}
+          value={text}
+          onChange={(event) => {
+            setText(event.target.value);
+            if (error) setError(null);
+          }}
+        />
+        {error && <p className="workflow-import-error">{error}</p>}
+        <div className="workflow-dialog-actions">
+          <button type="button" onClick={onClose}>
+            Cancel
+          </button>
+          <button type="button" className="workflow-primary-button" disabled={text.trim().length === 0} onClick={submit}>
+            <Icon name="ph:clipboard-text" width={13} />
+            Import
           </button>
         </div>
       </div>

--- a/src/components/workflows/workflow-inspector.tsx
+++ b/src/components/workflows/workflow-inspector.tsx
@@ -32,6 +32,8 @@ type WorkflowInspectorProps = {
   onUpdateStep: (id: string, patch: Partial<WorkflowStepSummary>) => void;
   onUpdateMeta: (patch: Partial<WorkflowSummary>) => void;
   onRemoveStep: (id: string) => void;
+  /** Clone the selected step (config + prerequisites) as a new sibling step. */
+  onDuplicateStep?: (id: string) => void;
   /** Jump to a step by id (e.g. from a validation issue that names it). */
   onSelectStep?: (id: string) => void;
   /** Make `target` require `source` (same edge the canvas draws). */
@@ -204,6 +206,7 @@ export function WorkflowInspector({
   onUpdateStep,
   onUpdateMeta,
   onRemoveStep,
+  onDuplicateStep,
   onSelectStep,
   onConnect,
   onDisconnect,
@@ -236,15 +239,28 @@ export function WorkflowInspector({
           </div>
         </div>
         {step && (
-          <button
-            type="button"
-            className="workflow-icon-button workflow-icon-button-danger"
-            onClick={() => onRemoveStep(step.id)}
-            title="Remove step"
-            aria-label={`Remove step ${step.id}`}
-          >
-            <Icon name="ph:trash" width={13} />
-          </button>
+          <div className="workflow-heading-actions">
+            {onDuplicateStep && (
+              <button
+                type="button"
+                className="workflow-icon-button"
+                onClick={() => onDuplicateStep(step.id)}
+                title="Duplicate step"
+                aria-label={`Duplicate step ${step.id}`}
+              >
+                <Icon name="ph:copy" width={13} />
+              </button>
+            )}
+            <button
+              type="button"
+              className="workflow-icon-button workflow-icon-button-danger"
+              onClick={() => onRemoveStep(step.id)}
+              title="Remove step"
+              aria-label={`Remove step ${step.id}`}
+            >
+              <Icon name="ph:trash" width={13} />
+            </button>
+          </div>
         )}
       </div>
 

--- a/src/components/workflows/workflow-library.tsx
+++ b/src/components/workflows/workflow-library.tsx
@@ -14,6 +14,7 @@ type WorkflowLibraryProps = {
   onRefresh: () => void;
   onSelectWorkflow: (workflow: WorkflowSummary) => void;
   onCreateRequest: () => void;
+  onImportRequest: () => void;
   onDuplicate: (workflow: WorkflowSummary) => void;
   onDelete: (workflow: WorkflowSummary) => void;
 };
@@ -50,6 +51,7 @@ export function WorkflowLibrary({
   onRefresh,
   onSelectWorkflow,
   onCreateRequest,
+  onImportRequest,
   onDuplicate,
   onDelete,
 }: WorkflowLibraryProps) {
@@ -118,6 +120,15 @@ export function WorkflowLibrary({
             aria-label="New workflow"
           >
             <Icon name="ph:plus-bold" width={14} />
+          </button>
+          <button
+            type="button"
+            className="workflow-icon-button"
+            onClick={onImportRequest}
+            title="Import workflow from a manifest"
+            aria-label="Import workflow from a manifest"
+          >
+            <Icon name="ph:clipboard-text" width={14} />
           </button>
           <button
             type="button"

--- a/src/components/workflows/workflow-manifest-preview.tsx
+++ b/src/components/workflows/workflow-manifest-preview.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { workflowToYaml } from "@/lib/workflow-edit";
+import { buildWorkflowRunPrompt } from "@/lib/workflow-run-prompt";
 import type { WorkflowSummary } from "@/lib/workflows";
 
 type WorkflowManifestPreviewProps = {
@@ -12,18 +13,30 @@ type WorkflowManifestPreviewProps = {
   changedFields?: string[];
 };
 
-/** Live canonical YAML for the current draft — what Save writes to disk. */
+type ManifestView = "manifest" | "prompt";
+
+/**
+ * Two honest views of the current draft: the canonical YAML manifest (what Save
+ * writes) and the compiled run prompt (what the agent is actually told when you
+ * Play). The run prompt is the same `buildWorkflowRunPrompt` the run route uses,
+ * so the preview can't drift from the real execution.
+ */
 export function WorkflowManifestPreview({ workflow, dirty, changedFields }: WorkflowManifestPreviewProps) {
-  const yaml = useMemo(() => (workflow ? workflowToYaml(workflow) : null), [workflow]);
-  // The manifest with its schema banner is exactly what Save writes, so copying
-  // it hands off a paste-ready manifest (to share, or check in by hand).
-  const manifestText = yaml ? `# schema_version: CWF-01\n${yaml}` : null;
+  const [view, setView] = useState<ManifestView>("manifest");
   const [copied, setCopied] = useState(false);
 
-  const copyManifest = async () => {
-    if (!manifestText) return;
+  const yaml = useMemo(() => (workflow ? workflowToYaml(workflow) : null), [workflow]);
+  const manifestText = yaml ? `# schema_version: CWF-01\n${yaml}` : null;
+  // No inputs here: the preview shows the prompt's structure; the actual values
+  // are captured by the run-inputs dialog and filled in at Play time.
+  const promptText = useMemo(() => (workflow ? buildWorkflowRunPrompt(workflow) : null), [workflow]);
+
+  const activeText = view === "manifest" ? manifestText : promptText;
+
+  const copyActive = async () => {
+    if (!activeText) return;
     try {
-      await navigator.clipboard.writeText(manifestText);
+      await navigator.clipboard.writeText(activeText);
       setCopied(true);
       setTimeout(() => setCopied(false), 1600);
     } catch {
@@ -36,39 +49,61 @@ export function WorkflowManifestPreview({ workflow, dirty, changedFields }: Work
       <div className="workflow-panel-heading">
         <div className="workflow-heading-lead">
           <div>
-            <p className="workflow-eyebrow">WORKFLOW.md / .workflow.yaml</p>
+            <p className="workflow-eyebrow">
+              {view === "manifest" ? "WORKFLOW.md / .workflow.yaml" : "What the agent is told on Play"}
+            </p>
             <h2>
-              Manifest
+              {view === "manifest" ? "Manifest" : "Run prompt"}
               {dirty && <span className="workflow-dirty-dot" title="Unsaved changes" />}
             </h2>
           </div>
         </div>
-        {manifestText && (
+        {activeText && (
           <button
             type="button"
             className="workflow-icon-button"
-            onClick={copyManifest}
-            title="Copy manifest YAML"
-            aria-label={copied ? "Manifest copied" : "Copy manifest YAML"}
+            onClick={copyActive}
+            title={view === "manifest" ? "Copy manifest YAML" : "Copy run prompt"}
+            aria-label={copied ? "Copied" : view === "manifest" ? "Copy manifest YAML" : "Copy run prompt"}
           >
             <Icon name={copied ? "ph:check-bold" : "ph:copy"} width={13} />
           </button>
         )}
       </div>
-      {dirty && changedFields && changedFields.length > 0 && (
+      {workflow && (
+        <div className="workflow-manifest-views" role="tablist" aria-label="Preview mode">
+          {(["manifest", "prompt"] as ManifestView[]).map((id) => (
+            <button
+              key={id}
+              type="button"
+              role="tab"
+              aria-selected={view === id}
+              className={`workflow-manifest-view${view === id ? " is-active" : ""}`}
+              onClick={() => setView(id)}
+            >
+              {id === "manifest" ? "Manifest" : "Run prompt"}
+            </button>
+          ))}
+        </div>
+      )}
+      {view === "manifest" && dirty && changedFields && changedFields.length > 0 && (
         <p className="workflow-manifest-changes">
           <Icon name="ph:pencil-simple" width={12} aria-hidden />
           Unsaved changes: {changedFields.join(", ")}
         </p>
       )}
-      {manifestText ? (
+      {activeText ? (
         <pre className="workflow-manifest-yaml">
-          <code>{manifestText}</code>
+          <code>{activeText}</code>
         </pre>
       ) : (
         <p className="workflow-muted">Select a workflow to preview its canonical manifest.</p>
       )}
-      <p className="workflow-muted">Cave-only layout stays in WORKFLOW.cave.json.</p>
+      <p className="workflow-muted">
+        {view === "manifest"
+          ? "Cave-only layout stays in WORKFLOW.cave.json."
+          : "Run inputs are filled in at Play time; this preview leaves them blank."}
+      </p>
     </section>
   );
 }

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -437,4 +437,26 @@ assert.match(runsPanel, /window\.confirm/, "Clearing run history should confirm 
 assert.match(studio, /onClearRuns=\{props\.onClearRuns\}/, "Studio should thread the clear-history handler");
 assert.match(css, /\.workflow-runs-clear/, "CSS should style the clear-history button");
 
+// --- Run-prompt preview, import, duplicate-step, keyboard shortcuts ---
+
+// The manifest panel toggles between the YAML manifest and the compiled run prompt.
+assert.match(manifestPreview, /buildWorkflowRunPrompt/, "Manifest preview should compile the run prompt");
+assert.match(manifestPreview, /Run prompt/, "Manifest preview should offer a run-prompt view");
+assert.match(manifestPreview, /workflow-manifest-views/, "Manifest preview should render a view toggle");
+assert.match(css, /\.workflow-manifest-view\b/, "CSS should style the manifest view toggle");
+
+// Import a workflow from a pasted manifest.
+assert.match(dialogs, /export function WorkflowImportDialog/, "An import dialog should parse a pasted manifest");
+assert.match(dialogs, /parseYaml/, "Import should parse YAML/JSON");
+assert.match(studio, /WorkflowImportDialog/, "Studio should wire the import dialog");
+assert.match(library, /onImportRequest/, "Library should expose an import affordance");
+
+// Duplicate a configured step.
+assert.match(inspector, /onDuplicateStep/, "Inspector should offer a duplicate-step affordance");
+assert.match(studio, /onDuplicateStep=\{props\.onDuplicateStep\}/, "Studio should thread duplicate-step into the inspector");
+
+// Studio keyboard shortcuts (save / dry-run / undo-redo).
+assert.match(studio, /event\.metaKey \|\| event\.ctrlKey/, "Studio should bind Cmd/Ctrl keyboard shortcuts");
+assert.match(studio, /addEventListener\("keydown"/, "Studio should attach a keydown listener while mounted");
+
 console.log("workflow-studio.test.ts: ok");

--- a/src/components/workflows/workflow-studio.tsx
+++ b/src/components/workflows/workflow-studio.tsx
@@ -2,7 +2,7 @@
 
 import "@/styles/workflows.css";
 
-import { useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react";
+import { useEffect, useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import { useIsMobile } from "@/lib/use-viewport";
 import { Tabs } from "@/components/ui/tabs";
@@ -24,7 +24,7 @@ import { WorkflowAttachments } from "./workflow-attachments";
 import type { WorkflowFamiliarOption } from "./workflow-attachments";
 import { WorkflowCanvas } from "./workflow-canvas";
 import { WorkflowStepList } from "./workflow-step-list";
-import { WorkflowCreateDialog, WorkflowRunInputsDialog, WorkflowScheduleDialog } from "./workflow-create-dialog";
+import { WorkflowCreateDialog, WorkflowImportDialog, WorkflowRunInputsDialog, WorkflowScheduleDialog } from "./workflow-create-dialog";
 import { WorkflowInspector, type WorkflowUsesOption } from "./workflow-inspector";
 import { WorkflowLibrary } from "./workflow-library";
 import { WorkflowManifestPreview } from "./workflow-manifest-preview";
@@ -111,10 +111,12 @@ export type WorkflowStudioProps = {
   onUpdateStep: (id: string, patch: Partial<WorkflowStepSummary>) => void;
   onUpdateMeta: (patch: Partial<WorkflowSummary>) => void;
   onRemoveStep: (id: string) => void;
+  onDuplicateStep: (id: string) => void;
   onConnect: (source: string, target: string) => void;
   onSavePositions: (positions: WorkflowNodePositions) => void;
   onDisconnect: (source: string, target: string) => void;
   onCreate: (input: { name: string; pattern: WorkflowPattern; familiar?: string }) => void;
+  onImport: (manifest: Record<string, unknown>) => void;
   onDuplicate: (workflow: WorkflowSummary) => void;
   onDelete: (workflow: WorkflowSummary) => void;
   onAttachRole: (role: WorkflowRoleSummary, attach: boolean) => void;
@@ -133,6 +135,7 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
     error,
   } = props;
   const [createOpen, setCreateOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
   const [scheduleOpen, setScheduleOpen] = useState(false);
   const [runInputsOpen, setRunInputsOpen] = useState(false);
   // Clicking Play captures the workflow's declared input(s) first when it has
@@ -146,6 +149,47 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
     }
     props.onPlay(workflow);
   };
+
+  // Studio keyboard shortcuts (active only while the studio is mounted):
+  //   ⌘/Ctrl+S        save (always preventDefault so the browser's save dialog
+  //                   never steals it)
+  //   ⌘/Ctrl+Enter    dry-run the selected workflow
+  //   ⌘/Ctrl+Z        undo · ⌘/Ctrl+Shift+Z redo — only outside a text field, so
+  //                   native text-editing undo still works while typing.
+  const { onSave, onDryRun, onUndo, onRedo, dirty, canUndo, canRedo } = props;
+  const anyBusy = busyId !== null;
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey)) return;
+      const key = event.key.toLowerCase();
+      const target = event.target as HTMLElement | null;
+      const editing = Boolean(
+        target && (target.isContentEditable || ["INPUT", "TEXTAREA", "SELECT"].includes(target.tagName)),
+      );
+      if (key === "s") {
+        event.preventDefault();
+        if (selectedWorkflow && dirty && !anyBusy) onSave(selectedWorkflow);
+      } else if (key === "enter") {
+        if (selectedWorkflow && !anyBusy) {
+          event.preventDefault();
+          onDryRun(selectedWorkflow);
+        }
+      } else if (key === "z" && !editing) {
+        if (event.shiftKey) {
+          if (canRedo) {
+            event.preventDefault();
+            onRedo();
+          }
+        } else if (canUndo) {
+          event.preventDefault();
+          onUndo();
+        }
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [selectedWorkflow, dirty, anyBusy, canUndo, canRedo, onSave, onDryRun, onUndo, onRedo]);
+
   // Below the shell breakpoint the React Flow canvas (pan/zoom/drag-connect) is
   // awkward on touch, so we swap it for a linear, scrollable step list that reads
   // from the same graph source.
@@ -223,6 +267,7 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
             onRefresh={props.onRefresh}
             onSelectWorkflow={props.onSelectWorkflow}
             onCreateRequest={() => setCreateOpen(true)}
+            onImportRequest={() => setImportOpen(true)}
             onDuplicate={props.onDuplicate}
             onDelete={props.onDelete}
           />
@@ -361,6 +406,7 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
                 onUpdateStep={props.onUpdateStep}
                 onUpdateMeta={props.onUpdateMeta}
                 onRemoveStep={props.onRemoveStep}
+                onDuplicateStep={props.onDuplicateStep}
                 onSelectStep={props.onSelectStep}
                 onConnect={props.onConnect}
                 onDisconnect={props.onDisconnect}
@@ -388,6 +434,15 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
           onCreate={(input) => {
             setCreateOpen(false);
             props.onCreate(input);
+          }}
+        />
+      )}
+      {importOpen && (
+        <WorkflowImportDialog
+          onClose={() => setImportOpen(false)}
+          onImport={(manifest) => {
+            setImportOpen(false);
+            props.onImport(manifest);
           }}
         />
       )}

--- a/src/lib/workflow-draft.test.ts
+++ b/src/lib/workflow-draft.test.ts
@@ -111,4 +111,30 @@ for (let i = 0; i < 60; i += 1) {
 }
 assert.ok(state.past.length <= 50, `history is capped (got ${state.past.length})`);
 
+// --- duplicate-step: clones config + prerequisites, inserts after, unique id ---
+state = fresh();
+state = workflowDraftReducer(state, { type: "duplicate-step", id: "execute" });
+{
+  const ids = (state.draft.steps ?? []).map((s) => s.id);
+  assert.deepEqual(ids, ["plan", "execute", "execute-copy"], "duplicate inserts a copy right after the original");
+  const copy = state.draft.steps!.find((s) => s.id === "execute-copy")!;
+  assert.equal(copy.kind, "agent", "copy keeps the original kind");
+  assert.deepEqual(copy.requires, ["plan"], "copy keeps the original prerequisites");
+  assert.equal(copy.name, "Execute copy", "copy gets a distinct name");
+  assert.equal(state.dirty, true, "duplicate marks the draft dirty");
+}
+// second duplicate dedupes the id
+state = workflowDraftReducer(state, { type: "duplicate-step", id: "execute" });
+assert.ok(
+  (state.draft.steps ?? []).some((s) => s.id === "execute-copy-2"),
+  "a colliding copy id is de-duplicated",
+);
+// duplicating a missing step is a no-op
+{
+  const before = state.draft.steps!.length;
+  const next = workflowDraftReducer(state, { type: "duplicate-step", id: "nope" });
+  assert.equal(next, state, "duplicating an unknown step returns the same state");
+  assert.equal(next.draft.steps!.length, before);
+}
+
 console.log("workflow-draft.test.ts: ok");

--- a/src/lib/workflow-draft.ts
+++ b/src/lib/workflow-draft.ts
@@ -22,6 +22,7 @@ export type WorkflowDraftAction =
   | { type: "update-meta"; patch: Partial<WorkflowSummary> }
   | { type: "add-step"; kind: WorkflowStepKind }
   | { type: "update-step"; id: string; patch: Partial<WorkflowStepSummary> }
+  | { type: "duplicate-step"; id: string }
   | { type: "remove-step"; id: string }
   | { type: "connect"; source: string; target: string }
   | { type: "disconnect"; source: string; target: string }
@@ -100,6 +101,31 @@ export function workflowDraftReducer(
           }
         }
       }
+      return commit(state, draft);
+    }
+
+    case "duplicate-step": {
+      const steps = state.draft.steps ?? [];
+      const index = steps.findIndex((step) => step.id === action.id);
+      if (index === -1) return state;
+      const original = steps[index];
+      const taken = new Set(steps.map((step) => step.id));
+      let copyId = `${action.id}-copy`;
+      let n = 2;
+      while (taken.has(copyId)) {
+        copyId = `${action.id}-copy-${n}`;
+        n += 1;
+      }
+      // Clone the step's config and prerequisites verbatim; insert right after
+      // the original so the duplicate reads as a sibling. Nothing depends on the
+      // copy yet, so no other step's `requires` changes.
+      const clone: WorkflowStepSummary = {
+        ...structuredClone(original),
+        id: copyId,
+        name: original.name ? `${original.name} copy` : copyId,
+      };
+      const draft = structuredClone(state.draft);
+      draft.steps!.splice(index + 1, 0, clone);
       return commit(state, draft);
     }
 

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -299,6 +299,66 @@
   margin-bottom: 12px;
 }
 
+/* Step heading actions (duplicate + remove), kept together on the right. */
+.workflow-heading-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: none;
+}
+
+/* Manifest ⇄ Run-prompt segmented toggle. */
+.workflow-manifest-views {
+  display: flex;
+  gap: 2px;
+  margin-bottom: 8px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-base);
+}
+
+.workflow-manifest-view {
+  flex: 1;
+  min-height: 24px;
+  padding: 2px 10px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 11.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.workflow-manifest-view:hover {
+  color: var(--text-primary);
+}
+
+.workflow-manifest-view.is-active {
+  border-color: color-mix(in oklch, var(--accent-presence) 45%, var(--border));
+  background: var(--card);
+  color: var(--text-primary);
+}
+
+.workflow-manifest-view:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
+}
+
+/* Import dialog: monospace paste area + parse-error line. */
+.workflow-import-field {
+  min-height: 200px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  white-space: pre;
+}
+
+.workflow-import-error {
+  margin: 0;
+  font-size: 11.5px;
+  color: var(--color-danger, #e5484d);
+}
+
 /* Library actions toolbar — the panel header owns the title, so this is just
    a right-aligned row of create/refresh buttons. */
 .workflow-library-toolbar {
@@ -1885,6 +1945,7 @@
 }
 
 .workflow-manifest-preview .workflow-panel-heading,
+.workflow-manifest-preview .workflow-manifest-views,
 .workflow-manifest-preview .workflow-manifest-changes,
 .workflow-manifest-preview > .workflow-muted:last-child {
   flex-shrink: 0;


### PR DESCRIPTION
## What

Four authoring + transparency improvements to the Workflows studio.

### 1. Compiled run-prompt preview (headline)
The manifest side-panel now toggles between two honest views of the draft: the **Manifest** (canonical YAML, what Save writes) and the **Run prompt** (the compiled orchestration prompt the agent actually receives on Play, via the same `buildWorkflowRunPrompt` the run route uses). You can now see exactly what the agent is told before spawning a real session. Copy works on whichever view is active.

### 2. Import a workflow from a manifest
The round-trip partner to the manifest Copy button: a library **Import** action opens a paste dialog (YAML *or* JSON), parses it, and creates a personal copy with a de-duplicated id. Schema validation happens on Save.

### 3. Duplicate a configured step
New `duplicate-step` draft-reducer action + an inspector affordance — clones a step's config and prerequisites as a sibling instead of rebuilding it by hand. Cycle-safe (nothing depends on the new copy yet); id de-duplicated.

### 4. Keyboard shortcuts
While the studio is mounted: **Cmd/Ctrl+S** save · **Cmd/Ctrl+Enter** dry-run · **Cmd/Ctrl+Z** / **Shift+Cmd+Z** undo/redo (gated out of text fields so native text-editing undo still works while typing).

## Testing
- `pnpm typecheck` — clean
- `pnpm test:app` (339) + `pnpm test:mobile` (16) — pass, incl. a new `duplicate-step` reducer test + studio source assertions
- `pnpm build` — pass
- Rebased onto current `main` to pick up the v0.0.109 release version-sync fix (#1362).

🤖 Generated with [Claude Code](https://claude.com/claude-code)