### PR TITLE
feat(ui): Escape clears the shared SearchInput

### DIFF
--- a/src/components/ui/search-input.tsx
+++ b/src/components/ui/search-input.tsx
@@ -25,6 +25,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(functi
     placeholder = "Search…",
     className,
     containerClassName,
+    onKeyDown,
     ...rest
   },
   ref,
@@ -43,6 +44,17 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(functi
           value={value}
           placeholder={placeholder}
           onChange={(e) => onValueChange(e.target.value)}
+          onKeyDown={(e) => {
+            onKeyDown?.(e);
+            // Escape clears a non-empty query (consumers opt in via onClear),
+            // matching the app's other search fields. Defers to a consumer
+            // handler that already consumed the event.
+            if (!e.defaultPrevented && e.key === "Escape" && value && onClear) {
+              e.preventDefault();
+              onClear();
+              onValueChange("");
+            }
+          }}
           {...rest}
         />
         {showClear ? (


### PR DESCRIPTION
## What

The shared `<SearchInput>` (`ui/search-input.tsx`) offered only a click target to clear a query. This adds **Escape-to-clear** (for consumers that pass `onClear`), matching the app's other search fields — and because it's the shared primitive, it propagates to **every** consumer at once (library timeline, comux file search, view headers).

It defers to a consumer-supplied `onKeyDown` and only clears when the consumer opted in via `onClear` and the event wasn't already handled.

## Verify
- `library-timeline.test.ts` — pass; `pnpm build` — clean
- Live-verified on the Library timeline (a SearchInput consumer with `onClear`): typing then Escape clears the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)