### PR TITLE
feat(time): adopt <RelativeTime> at remaining clean JSX timestamp sites

### DIFF
--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
 import { copyText } from "@/lib/clipboard";
 import { relativeTime } from "@/lib/relative-time";
+import { RelativeTime } from "@/components/ui/relative-time";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { MarkdownBlock } from "@/components/message-bubble";
 import type { HarnessCapabilityManifest } from "@/components/capability-card";
@@ -359,7 +360,7 @@ export function CapabilitiesViewSurface({
               <div className="flex shrink-0 items-center gap-2 text-[11px] text-muted-foreground">
                 {scannedAt && (
                   <span title={scannedAt}>
-                    Scanned {relativeTime(scannedAt)}
+                    Scanned <RelativeTime iso={scannedAt} />
                   </span>
                 )}
                 <button

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -3,6 +3,7 @@
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { relativeTime } from "@/lib/relative-time";
+import { RelativeTime } from "@/components/ui/relative-time";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import type { Familiar } from "@/lib/types";
 import type { Card, CardStatus } from "@/lib/cave-board-types";
@@ -1408,7 +1409,7 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
                         )}
                       </td>
                       <td style={{ textAlign: "right" }}>
-                        <span className="board-table-cell-time">{relativeTime(item.updatedAt)}</span>
+                        <RelativeTime iso={item.updatedAt} className="board-table-cell-time" />
                       </td>
                       <td style={{ textAlign: "right" }}>
                         <div className="gh-actions">

--- a/src/components/workflows/workflow-runs-panel.tsx
+++ b/src/components/workflows/workflow-runs-panel.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { relativeTime } from "@/lib/relative-time";
+import { RelativeTime } from "@/components/ui/relative-time";
 import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 import type { WorkflowPlaybackState } from "@/lib/workflow-playback";
 import type {
@@ -163,7 +164,7 @@ export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayR
                   <span className="workflow-run-kind">{run.kind}</span>
                   <span className="workflow-run-detail">{stepRollup(run)}</span>
                   <span className="workflow-run-time" title={formatTimestamp(run.startedAt, readDateTimePrefs())}>
-                    {relativeTime(run.startedAt)}
+                    <RelativeTime iso={run.startedAt} />
                   </span>
                 </button>
                 {expanded && (


### PR DESCRIPTION
Finishes the `<RelativeTime>` adoption (from #1332) at the timestamp sites where the value is a real **JSX element** (not a string interpolation, which can't host a component/tooltip):

- **Capabilities** — the "Scanned {time}" stamp
- **Workflow runs panel** — the per-run start time
- **GitHub list** — the "updated" time column

Each now renders a semantic `<time dateTime>` with the full exact timestamp on hover and live compact/verbose density. Each file keeps `relativeTime` for its remaining non-element uses (string interpolations / `value` props), so no orphaned imports.

Remaining bare `relativeTime()` renders (journal entry/canvas stamps, daily-notes "Saved", dashboard summaries, workflow-runs summary string) are **string interpolations** and intentionally left as-is — they'd need restructuring into elements to host a tooltip.

## Tests
Capabilities + github-view-polish + the `<RelativeTime>` component tests pass; each edited file retains its other `relativeTime` usage (verified no orphaned imports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)