### PR TITLE
feat(workflows): Escape clears the workflow-library search

### DIFF
--- a/src/components/workflows/workflow-library.tsx
+++ b/src/components/workflows/workflow-library.tsx
@@ -151,6 +151,12 @@ export function WorkflowLibrary({
           placeholder="Search id, tag, familiar…"
           aria-label="Search workflows"
           onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Escape" && query) {
+              event.preventDefault();
+              setQuery("");
+            }
+          }}
         />
       </label>
 


### PR DESCRIPTION
## What

The Workflow Library search had **no quick-clear affordance at all** — no clear button and no Escape handling, so resetting it meant select-all + delete. This adds **Escape-to-clear**, matching the app's other search fields (board, capabilities, projects, sessions, familiars, and the shared SearchInput).

## Verify
- `workflow-studio.test.ts` — pass; `pnpm build` — clean
- Live-verified on the Workflows surface: typing then Escape clears the search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)