### PR TITLE
feat(ios): add a Tasks tab — native board-task list with world-class UX

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/BoardCard.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/BoardCard.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// A board task as returned by `GET /api/board` (`{ ok, cards: [...] }`).
+/// Mirrors the server `Card` type; only the fields the app uses are modelled
+/// (Codable ignores the rest). `status`/`priority` decode leniently via raw
+/// strings so an unknown future value never fails the whole list.
+
+enum CardStatus: String, CaseIterable {
+    case running, review, blocked, inbox, backlog, done
+
+    var label: String {
+        switch self {
+        case .running: return "In progress"
+        case .review: return "In review"
+        case .blocked: return "Blocked"
+        case .inbox: return "Inbox"
+        case .backlog: return "Up next"
+        case .done: return "Done"
+        }
+    }
+
+    /// Display order for grouped sections (active work first).
+    var sectionOrder: Int {
+        switch self {
+        case .running: return 0
+        case .review: return 1
+        case .blocked: return 2
+        case .inbox: return 3
+        case .backlog: return 4
+        case .done: return 5
+        }
+    }
+
+    var isActive: Bool { self != .done }
+    var systemImage: String {
+        switch self {
+        case .running: return "play.circle.fill"
+        case .review: return "eye.circle.fill"
+        case .blocked: return "exclamationmark.octagon.fill"
+        case .inbox: return "tray.circle.fill"
+        case .backlog: return "circle.dashed"
+        case .done: return "checkmark.circle.fill"
+        }
+    }
+}
+
+enum CardPriority: String, CaseIterable {
+    case urgent, high, medium, low
+
+    var label: String { rawValue.capitalized }
+    var rank: Int {
+        switch self {
+        case .urgent: return 0
+        case .high: return 1
+        case .medium: return 2
+        case .low: return 3
+        }
+    }
+}
+
+struct CardStep: Identifiable, Codable, Hashable {
+    let id: String
+    var text: String
+    var done: Bool
+    var doneAt: String?
+}
+
+struct BoardCard: Identifiable, Codable, Hashable {
+    let id: String
+    var title: String
+    var notes: String?
+    var statusRaw: String
+    var priorityRaw: String
+    var familiarId: String?
+    var sessionId: String?
+    var labels: [String]?
+    var startDate: String?
+    var endDate: String?
+    var createdAt: String?
+    var updatedAt: String?
+    var needsHuman: Bool?
+    var steps: [CardStep]?
+
+    enum CodingKeys: String, CodingKey {
+        case id, title, notes
+        case statusRaw = "status"
+        case priorityRaw = "priority"
+        case familiarId, sessionId, labels, startDate, endDate
+        case createdAt, updatedAt, needsHuman, steps
+    }
+
+    var status: CardStatus { CardStatus(rawValue: statusRaw) ?? .backlog }
+    var priority: CardPriority { CardPriority(rawValue: priorityRaw) ?? .medium }
+
+    var stepCount: Int { steps?.count ?? 0 }
+    var doneStepCount: Int { steps?.filter(\.done).count ?? 0 }
+    var hasSteps: Bool { stepCount > 0 }
+    var stepFraction: Double { stepCount == 0 ? 0 : Double(doneStepCount) / Double(stepCount) }
+    var labelList: [String] { labels ?? [] }
+}
+
+struct BoardResponse: Codable {
+    let ok: Bool
+    let error: String?
+    let cards: [BoardCard]
+}

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -76,6 +76,19 @@ struct CaveClient {
         }
     }
 
+    // MARK: - Tasks (board)
+
+    func tasks() async throws -> [BoardCard] {
+        let req = try request("api/board")
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        do {
+            return try JSONDecoder().decode(BoardResponse.self, from: data).cards
+        } catch {
+            throw CaveError.decoding(String(describing: error))
+        }
+    }
+
     func conversation(sessionId: String) async throws -> Conversation? {
         let req = try request("api/chat/conversation/\(sessionId)")
         let (data, resp) = try await session.data(for: req)

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -19,6 +19,10 @@ final class AppModel {
 
     var threads: [ChatThread] = []
 
+    var tasks: [BoardCard] = []
+    var tasksError: String?
+    var tasksLoaded = false
+
     var client: CaveClient? {
         guard let connection else { return nil }
         return CaveClient(connection: connection)
@@ -32,6 +36,17 @@ final class AppModel {
 
     func familiar(_ id: String) -> Familiar? {
         familiars.first { $0.id == id }
+    }
+
+    func loadTasks() async {
+        guard let client else { return }
+        do {
+            tasks = try await client.tasks()
+            tasksError = nil
+        } catch {
+            tasksError = error.localizedDescription
+        }
+        tasksLoaded = true
     }
 
     // MARK: - Connection lifecycle

--- a/apps/ios/CovenCave/CovenCave/Theme/Theme.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/Theme.swift
@@ -52,4 +52,26 @@ enum Theme {
         let letters = parts.compactMap { $0.first }.map(String.init)
         return letters.isEmpty ? "?" : letters.joined().uppercased()
     }
+
+    // MARK: - Tasks
+
+    static func color(for status: CardStatus) -> Color {
+        switch status {
+        case .running: return Color(hex: "#3B82F6")!   // blue
+        case .review: return Color(hex: "#8B5CF6")!    // violet
+        case .blocked: return Color(hex: "#EF4444")!   // red
+        case .inbox: return Color(hex: "#14B8A6")!     // teal
+        case .backlog: return Color(hex: "#94A3B8")!   // slate
+        case .done: return Color(hex: "#10B981")!      // green
+        }
+    }
+
+    static func color(for priority: CardPriority) -> Color {
+        switch priority {
+        case .urgent: return Color(hex: "#EF4444")!
+        case .high: return Color(hex: "#F59E0B")!
+        case .medium: return Color(hex: "#3B82F6")!
+        case .low: return Color(hex: "#94A3B8")!
+        }
+    }
 }

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -11,8 +11,34 @@ struct RootView: View {
             case .checking where app.connection != nil && app.familiars.isEmpty:
                 ConnectingView()
             default:
-                ChatsHomeView()
+                MainTabView()
             }
+        }
+    }
+}
+
+/// Bottom tab bar shown once connected: Chats + Tasks.
+struct MainTabView: View {
+    enum Tab: String { case chats, tasks }
+    // Plain-String storage (RawRepresentable @AppStorage bridging is unreliable);
+    // persisted so the app reopens on the last-used tab.
+    @AppStorage("cave.tab") private var rawTab: String = Tab.chats.rawValue
+
+    private var selection: Binding<Tab> {
+        Binding(
+            get: { Tab(rawValue: rawTab) ?? .chats },
+            set: { rawTab = $0.rawValue }
+        )
+    }
+
+    var body: some View {
+        TabView(selection: selection) {
+            ChatsHomeView()
+                .tabItem { Label("Chats", systemImage: "bubble.left.and.bubble.right.fill") }
+                .tag(Tab.chats)
+            TasksView()
+                .tabItem { Label("Tasks", systemImage: "checklist") }
+                .tag(Tab.tasks)
         }
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+
+struct TaskDetailView: View {
+    @Environment(AppModel.self) private var app
+    let card: BoardCard
+
+    private var familiar: Familiar? { card.familiarId.flatMap(app.familiar) }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                header
+                if let familiar { assigneeRow(familiar) }
+                if card.hasSteps { stepsCard }
+                if let notes = card.notes, !notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    notesCard(notes)
+                }
+                if !card.labelList.isEmpty { labelsRow }
+                metaCard
+            }
+            .padding(20)
+        }
+        .navigationTitle("Task")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(card.title)
+                .font(.title2.bold())
+                .fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 8) {
+                StatusPill(status: card.status)
+                priorityBadge
+                if card.needsHuman == true { NeedsYouBadge() }
+            }
+        }
+    }
+
+    private var priorityBadge: some View {
+        let color = Theme.color(for: card.priority)
+        return Label(card.priority.label, systemImage: "flag.fill")
+            .font(.caption.weight(.semibold))
+            .padding(.horizontal, 8).padding(.vertical, 3)
+            .background(color.opacity(0.16), in: Capsule())
+            .foregroundStyle(color)
+    }
+
+    private func assigneeRow(_ familiar: Familiar) -> some View {
+        HStack(spacing: 12) {
+            AvatarView(familiar: familiar, url: app.client?.avatarURL(for: familiar), size: 40)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(familiar.displayName).font(.headline)
+                if let role = familiar.role, !role.isEmpty {
+                    Text(role).font(.caption).foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+        }
+        .padding(14)
+        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    private var stepsCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Steps").font(.headline)
+                Spacer()
+                Text("\(card.doneStepCount)/\(card.stepCount)")
+                    .font(.subheadline.monospacedDigit()).foregroundStyle(.secondary)
+            }
+            ProgressView(value: card.stepFraction)
+                .tint(Theme.color(for: card.status))
+            VStack(alignment: .leading, spacing: 10) {
+                ForEach(card.steps ?? []) { step in
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: step.done ? "checkmark.circle.fill" : "circle")
+                            .foregroundStyle(step.done ? Color.green : Color.secondary)
+                        Text(step.text)
+                            .strikethrough(step.done, color: .secondary)
+                            .foregroundStyle(step.done ? .secondary : .primary)
+                            .fixedSize(horizontal: false, vertical: true)
+                        Spacer(minLength: 0)
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    private func notesCard(_ notes: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Notes").font(.headline)
+            Text(notes)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    private var labelsRow: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Labels").font(.headline)
+            FlowRow(spacing: 8) {
+                ForEach(card.labelList, id: \.self) { LabelChip(text: $0) }
+            }
+        }
+    }
+
+    private var metaCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            metaRow("Created", caveParseISO(card.createdAt))
+            metaRow("Updated", caveParseISO(card.updatedAt))
+            if card.startDate != nil { metaRow("Start", caveParseISO(card.startDate)) }
+            if card.endDate != nil { metaRow("Due", caveParseISO(card.endDate)) }
+        }
+        .font(.footnote)
+    }
+
+    private func metaRow(_ label: String, _ date: Date?) -> some View {
+        HStack {
+            Text(label).foregroundStyle(.tertiary)
+            Spacer()
+            Text(date.map { $0.formatted(date: .abbreviated, time: .shortened) } ?? "—")
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+/// Minimal wrapping HStack for label chips.
+struct FlowRow: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var x: CGFloat = 0, y: CGFloat = 0, rowHeight: CGFloat = 0
+        for view in subviews {
+            let size = view.sizeThatFits(.unspecified)
+            if x + size.width > maxWidth {
+                x = 0; y += rowHeight + spacing; rowHeight = 0
+            }
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+        return CGSize(width: maxWidth == .infinity ? x : maxWidth, height: y + rowHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var x = bounds.minX, y = bounds.minY, rowHeight: CGFloat = 0
+        for view in subviews {
+            let size = view.sizeThatFits(.unspecified)
+            if x + size.width > bounds.maxX {
+                x = bounds.minX; y += rowHeight + spacing; rowHeight = 0
+            }
+            view.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -1,0 +1,219 @@
+import SwiftUI
+
+/// Parse an ISO-8601 timestamp (with or without fractional seconds).
+func caveParseISO(_ iso: String?) -> Date? {
+    guard let iso, !iso.isEmpty else { return nil }
+    let withFrac = ISO8601DateFormatter()
+    withFrac.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let d = withFrac.date(from: iso) { return d }
+    let plain = ISO8601DateFormatter()
+    plain.formatOptions = [.withInternetDateTime]
+    return plain.date(from: iso)
+}
+
+struct TasksView: View {
+    @Environment(AppModel.self) private var app
+    @State private var scope: Scope = .active
+    @State private var query = ""
+    @State private var path: [BoardCard] = []
+
+    enum Scope: String, CaseIterable, Identifiable {
+        case active = "Active", all = "All", done = "Done"
+        var id: String { rawValue }
+    }
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            content
+                .navigationTitle("Tasks")
+                .navigationDestination(for: BoardCard.self) { TaskDetailView(card: $0) }
+                .searchable(text: $query, prompt: "Search tasks")
+                .refreshable { await app.loadTasks() }
+                .task { if !app.tasksLoaded { await app.loadTasks() } }
+                .safeAreaInset(edge: .top) { scopeBar }
+        }
+    }
+
+    private var scopeBar: some View {
+        Picker("Scope", selection: $scope) {
+            ForEach(Scope.allCases) { s in Text(s.rawValue).tag(s) }
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(.bar)
+    }
+
+    @ViewBuilder private var content: some View {
+        if !app.tasksLoaded {
+            ProgressView().controlSize(.large)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error = app.tasksError, app.tasks.isEmpty {
+            ContentUnavailableView {
+                Label("Couldn’t load tasks", systemImage: "exclamationmark.triangle")
+            } description: { Text(error) } actions: {
+                Button("Retry") { Task { await app.loadTasks() } }.buttonStyle(.borderedProminent)
+            }
+        } else if sections.isEmpty {
+            emptyState
+        } else {
+            taskList
+        }
+    }
+
+    private var taskList: some View {
+        List {
+            ForEach(sections, id: \.status) { section in
+                Section {
+                    ForEach(section.cards) { card in
+                        Button { path.append(card) } label: { TaskRow(card: card) }
+                            .buttonStyle(.plain)
+                            .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 12))
+                    }
+                } header: {
+                    HStack(spacing: 6) {
+                        Image(systemName: section.status.systemImage)
+                        Text(section.status.label)
+                        Spacer()
+                        Text("\(section.cards.count)").monospacedDigit()
+                    }
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.color(for: section.status))
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label(query.isEmpty ? "No \(scope.rawValue.lowercased()) tasks" : "No matches",
+                  systemImage: "checkmark.circle")
+        } description: {
+            Text(query.isEmpty ? "Tasks from your board appear here." : "Try a different search.")
+        }
+    }
+
+    // MARK: - Grouping
+
+    struct StatusSection { let status: CardStatus; let cards: [BoardCard] }
+
+    private var filtered: [BoardCard] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return app.tasks.filter { card in
+            switch scope {
+            case .active: if !card.status.isActive { return false }
+            case .done: if card.status != .done { return false }
+            case .all: break
+            }
+            guard !q.isEmpty else { return true }
+            if card.title.lowercased().contains(q) { return true }
+            return card.labelList.contains { $0.lowercased().contains(q) }
+        }
+    }
+
+    private var sections: [StatusSection] {
+        Dictionary(grouping: filtered, by: \.status)
+            .map { StatusSection(status: $0.key, cards: sortCards($0.value)) }
+            .sorted { $0.status.sectionOrder < $1.status.sectionOrder }
+    }
+
+    private func sortCards(_ cards: [BoardCard]) -> [BoardCard] {
+        cards.sorted { a, b in
+            if a.priority.rank != b.priority.rank { return a.priority.rank < b.priority.rank }
+            let da = caveParseISO(a.updatedAt) ?? .distantPast
+            let db = caveParseISO(b.updatedAt) ?? .distantPast
+            return da > db
+        }
+    }
+}
+
+// MARK: - Row
+
+struct TaskRow: View {
+    @Environment(AppModel.self) private var app
+    let card: BoardCard
+
+    private var familiar: Familiar? { card.familiarId.flatMap(app.familiar) }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Capsule()
+                .fill(Theme.color(for: card.status))
+                .frame(width: 3)
+                .frame(maxHeight: .infinity)
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 6) {
+                    if card.priority == .urgent || card.priority == .high {
+                        Image(systemName: "flag.fill")
+                            .font(.caption2)
+                            .foregroundStyle(Theme.color(for: card.priority))
+                    }
+                    Text(card.title)
+                        .font(.callout.weight(.medium))
+                        .foregroundStyle(.primary)
+                        .lineLimit(2)
+                }
+
+                HStack(spacing: 8) {
+                    if card.needsHuman == true { NeedsYouBadge() }
+                    if card.hasSteps {
+                        Label("\(card.doneStepCount)/\(card.stepCount)", systemImage: "checklist")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    ForEach(card.labelList.prefix(2), id: \.self) { LabelChip(text: $0) }
+                    if let updated = caveParseISO(card.updatedAt) {
+                        Text(updated, format: .relative(presentation: .numeric))
+                            .font(.caption2).foregroundStyle(.tertiary)
+                    }
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            if let familiar {
+                AvatarView(familiar: familiar,
+                           url: app.client?.avatarURL(for: familiar),
+                           size: 30)
+            }
+        }
+        .padding(.vertical, 2)
+        .contentShape(Rectangle())
+    }
+}
+
+struct NeedsYouBadge: View {
+    var body: some View {
+        Text("Needs you")
+            .font(.caption2.weight(.semibold))
+            .padding(.horizontal, 6).padding(.vertical, 2)
+            .background(Color.orange.opacity(0.18), in: Capsule())
+            .foregroundStyle(.orange)
+    }
+}
+
+struct LabelChip: View {
+    let text: String
+    var body: some View {
+        Text(text)
+            .font(.caption2)
+            .padding(.horizontal, 6).padding(.vertical, 2)
+            .background(Color(.tertiarySystemFill), in: Capsule())
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+    }
+}
+
+struct StatusPill: View {
+    let status: CardStatus
+    var body: some View {
+        let color = Theme.color(for: status)
+        Label(status.label, systemImage: status.systemImage)
+            .font(.caption.weight(.semibold))
+            .padding(.horizontal, 8).padding(.vertical, 3)
+            .background(color.opacity(0.16), in: Capsule())
+            .foregroundStyle(color)
+    }
+}


### PR DESCRIPTION
## What

Adds a bottom **TabView** to the native iOS app (**Chats + Tasks**). The new **Tasks** tab is a genuinely native list of your board tasks, fetched from `GET /api/board` over the same tokenless Tailscale connection.

## UX

- **Scope filter** — Active / All / Done segmented control.
- **Grouped sections** by status (In progress / In review / Blocked / Inbox / Up next / Done) with colored headers + counts.
- **Rows** — status accent bar, priority flag (urgent/high), title, step progress (e.g. `2/4`), label chips, a "Needs you" badge, relative time, and the assigned familiar's avatar.
- **Search** across titles + labels; **pull-to-refresh**.
- **Detail view** — status/priority badges, assignee, a steps checklist with a progress bar, notes, wrapping labels (a custom `FlowRow` `Layout`), and meta dates.
- Selected tab is persisted (`@AppStorage`).

## Files

- `Models/BoardCard.swift` — `Card`/`CardStep` with lenient `status`/`priority` decoding (unknown values never fail the list).
- `CaveClient.tasks()`; `AppModel` task state + `loadTasks()`.
- `Views/TasksView.swift`, `Views/TaskDetailView.swift`, `Views/RootView.swift` (`MainTabView`).
- `Theme.swift` — per-status / per-priority colours.

## Verification

Built and run on the iPhone 16 Pro simulator against a mock implementing `/api/board` (+ familiars + chat). The grouped, filtered Tasks list renders with avatars, step progress, "Needs you" badges, and label chips. Screenshot captured.

> Coordination: branched off latest `main` and confined to the iOS surface per `docs/ios-native-rebuild.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)