### PR TITLE
fix(journal): lift the next-paths block out of the reflection markdown

### DIFF
--- a/src/components/journal/journal-entries.tsx
+++ b/src/components/journal/journal-entries.tsx
@@ -6,6 +6,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { MarkdownBlock } from "@/components/message-bubble";
+import { extractNextPaths } from "@/lib/next-paths";
 import { dateSlug, longDateLabel, relativeDayLabel, relativeTime, parseDateSlug } from "@/lib/daily-report";
 import { generateReflection } from "@/lib/journal-generate";
 import type { Familiar } from "@/lib/types";
@@ -20,6 +21,29 @@ type JournalDay = {
   stats: JournalStats;
   context: string;
 };
+
+/** Render a journal reflection. The reflection is generated through the chat
+ *  pipeline, which appends a `<coven:next-paths>` suggestions block; lift it out
+ *  (as chat-view does) so the tags don't leak into the markdown, and show the
+ *  suggestions as a quiet "Next" list below the reflection. */
+function JournalReflection({ text }: { text: string }) {
+  const { visible, suggestions } = extractNextPaths(text);
+  return (
+    <>
+      <MarkdownBlock text={visible} className="journal-entry__reflection" />
+      {suggestions.length > 0 ? (
+        <div className="journal-entry__next">
+          <span className="journal-entry__next-label">Next</span>
+          <ul className="journal-entry__next-list">
+            {suggestions.map((s, i) => (
+              <li key={i}>{s}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </>
+  );
+}
 
 export function JournalEntries({
   familiars,
@@ -290,7 +314,7 @@ export function JournalEntries({
                     autoFocus
                   />
                 ) : (
-                  <MarkdownBlock text={day.entry.reflection} className="journal-entry__reflection" />
+                  <JournalReflection text={day.entry.reflection} />
                 )}
                 <div className="journal-entry__by">
                   <Icon name="ph:sparkle" aria-hidden />

--- a/src/styles/journal.css
+++ b/src/styles/journal.css
@@ -454,6 +454,33 @@
   outline-offset: 2px;
 }
 .journal-entry__reflection { line-height: 1.6; color: var(--text-secondary); font-size: 13px; }
+/* Reflective "next-paths" prompts lifted out of the reflection markdown. */
+.journal-entry__next {
+  margin-top: 16px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 10px;
+  background: color-mix(in oklch, var(--bg-raised) 55%, transparent);
+}
+.journal-entry__next-label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.journal-entry__next-list {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
 .journal-entry__by {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What

Journal entries were rendering the raw `<coven:next-paths>` / `</coven:next-paths>` tags as literal text inside the reflection.

## Why

Journal reflections are generated through the chat pipeline, which appends a `<coven:next-paths>` suggestions block. **Chat-view** extracts that block (`extractNextPaths`) and renders it as suggestion chips — but the journal passed the **raw** reflection straight to `MarkdownBlock`, so the tags leaked through.

## Change

A small `JournalReflection` component reuses the existing `@/lib/next-paths` `extractNextPaths` helper: render the tag-free body via `MarkdownBlock`, and render the suggestions as a quiet boxed **"Next"** list below the reflection. Entry metadata (the stats row + "Reflected by …") is unchanged. Fixes both the existing entry and all future ones.

Touches only `journal-entries.tsx` + `journal.css` (clean, not fleet-churned).

## Verification

- Deterministic: `extractNextPaths` on the real Jun 20 reflection returns the 2 suggestions and a tag-free body.
- Live-verified: the entry no longer shows the raw `<coven:next-paths>` tags; the two reflective prompts ("Jot down one thing you're grateful for" / "Set a small intent for tomorrow") render as a boxed "Next" list; stats row + Reflected-by intact.
- `pnpm typecheck` clean, `pnpm build` clean, `pnpm test:app` ✓ 339 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)