### PR TITLE
feat(palette): show a recency hint ("4m ago") on ⌘K session rows

### DIFF
--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -8,6 +8,7 @@ import { Icon } from "@/lib/icon";
 import { platformizeHint, useKeySymbols } from "@/lib/platform-keys";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { parseFamiliarToken, resolveFamiliarIds } from "@/lib/command-palette-scope";
+import { relativeTime } from "@/lib/relative-time";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { FOLDER_MODES, type FolderMode, type AddonsConfig } from "@/components/sidebar-minimal";
 import { useProjects } from "@/lib/use-projects";
@@ -771,6 +772,13 @@ export function CommandPalette({
             const group = browsing ? browseGroup(row) : "";
             const showHeader =
               browsing && group !== "" && (i === 0 || browseGroup(rows[i - 1]) !== group);
+            // Recency hint for session rows ("4m ago" / "just now"), honoring the
+            // user's compact/verbose density pref. Right-aligned in place of the
+            // redundant "open" affordance label.
+            const sessionAgo =
+              row.kind === "session"
+                ? relativeTime(row.session.updated_at || row.session.created_at)
+                : "";
             return (
               <Fragment key={row.id}>
                 {showHeader ? (
@@ -820,7 +828,7 @@ export function CommandPalette({
                           {row.session.harness}
                         </span>
                       </span>
-                      <span className="text-[10px] text-[var(--text-muted)]">open</span>
+                      <span className="shrink-0 text-[10px] text-[var(--text-muted)]">{sessionAgo || "open"}</span>
                     </>
                   ) : null}
                   {row.kind === "card" ? (


### PR DESCRIPTION
## What

Follow-up to #1372. The ⌘K **Recent** jump-list ranks sessions by recency but didn't say *how* recent. Each session row now shows a relative-time hint — "just now" / "4m ago" / "2h ago" — right-aligned, in place of the redundant "open" affordance label (the chat icon + Enter already imply it). Falls back to "open" if a row has no usable timestamp.

## How

- `command-palette.tsx`: compute `sessionAgo = relativeTime(updated_at || created_at)` per session row via the shared `@/lib/relative-time` helper (honors the compact/verbose density pref), rendered as the trailing hint.

## Verification

- `pnpm typecheck` clean, `pnpm test:app` → 339 files pass, `pnpm build` green.
- Live (route-mocked): Recent rows render `4m ago / 18m ago / 2h ago / 10h ago`, recency-ordered. Screenshot matches the pitch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)