### PR TITLE
perf(board-table): O(1) familiar lookups in sort + hoist per-row select options

### DIFF
--- a/src/components/board-table.tsx
+++ b/src/components/board-table.tsx
@@ -18,7 +18,10 @@ const STATUS_ORDER: Record<CardStatus, number> = { backlog: 0, inbox: 1, running
 const PRIORITY_ORDER: Record<CardPriority, number> = { urgent: 0, high: 1, medium: 2, low: 3 };
 
 function sortCards(cards: Card[], key: SortKey, dir: SortDir, familiars: Familiar[]): Card[] {
-  const fname = (id: string | null) => familiars.find((f) => f.id === id)?.display_name ?? "";
+  // Precompute id->name once (O(M)) instead of an O(M) find per comparison
+  // (which made the "familiar" sort O(N log N · M)).
+  const nameById = new Map(familiars.map((f) => [f.id, f.display_name]));
+  const fname = (id: string | null) => (id ? nameById.get(id) ?? "" : "");
   return [...cards].sort((a, b) => {
     let cmp = 0;
     switch (key) {
@@ -125,6 +128,12 @@ export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId
 
   const sorted = useMemo(() => sortCards(cards, sortKey, sortDir, familiars), [cards, sortKey, sortDir, familiars]);
   const groups = useMemo(() => groupCards(sorted, groupBy, familiars, projects), [sorted, groupBy, familiars, projects]);
+  // The familiar <select> options are identical for every row — build them once
+  // instead of rebuilding M <option> elements per row on each render.
+  const familiarOptions = useMemo(
+    () => familiars.map((f) => <option key={f.id} value={f.id}>{f.display_name}</option>),
+    [familiars],
+  );
 
   const tbodyRef = useRef<HTMLTableSectionElement | null>(null);
   useRovingTabIndex({
@@ -244,9 +253,7 @@ export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId
                           onChange={(e) => onPatch(card.id, { familiarId: e.target.value || null })}
                         >
                           <option value="">Unassigned</option>
-                          {familiars.map((f) => (
-                            <option key={f.id} value={f.id}>{f.display_name}</option>
-                          ))}
+                          {familiarOptions}
                         </select>
                       </span>
                     </td>


### PR DESCRIPTION
First of a few performance passes. Two verified render-cost hotspots in the board Table:

### 1. O(N log N · M) sort → O(N log N)
`sortCards()` called `familiars.find()` **inside the comparator**, so sorting by the Familiar column did a linear scan of all familiars on every comparison. Precompute an `id → name` Map once (O(M)) and do O(1) lookups in the comparator. With large boards + many familiars this was a real stall on sort/re-sort.

### 2. Per-row `<select>` option rebuild
The inline familiar `<select>` rebuilt its entire `<option>` list (M familiars) for **every row** on **every render** — M·N option allocations. The options are identical across rows, so build them once via `useMemo` and reuse them. Drops it to M.

No behavior change. The inline-select contract (`board-table-familiar-select.test.ts`) plus keyboard/grouping/polish tests all stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)