### PR TITLE
fix(dashboard): surface the recent-reports cap instead of silently hiding

### DIFF
--- a/src/components/dashboard/recent-reports.tsx
+++ b/src/components/dashboard/recent-reports.tsx
@@ -11,12 +11,14 @@ export function RecentReports({
   now: Date;
   hasFeatured: boolean;
 }) {
+  const VISIBLE = 7;
+  const hiddenCount = Math.max(0, reports.length - VISIBLE);
   return (
     <section className="dr-section" id="recent-reports" aria-label="Recent daily reports">
       <SectionHead icon="ph:newspaper" title="Recent daily reports" count={reports.length} />
       {reports.length > 0 ? (
         <div className="dr-list">
-          {reports.slice(0, 7).map((report) => {
+          {reports.slice(0, VISIBLE).map((report) => {
             const reportDate = new Date(`${report.slug}T00:00:00`);
             return (
               <a key={report.slug} className="dr-row" href={report.href}>
@@ -43,6 +45,11 @@ export function RecentReports({
               </a>
             );
           })}
+          {hiddenCount > 0 ? (
+            <p className="dr-row__sub" style={{ padding: "8px 4px 0", textAlign: "center" }}>
+              +{hiddenCount} older {hiddenCount === 1 ? "report" : "reports"} not shown
+            </p>
+          ) : null}
         </div>
       ) : (
         <EmptyState icon="ph:newspaper">


### PR DESCRIPTION
## What

The dashboard's **"Recent daily reports"** header counts *all* reports, but the list only renders the **7 most recent** — so the count badge could read e.g. "30" while only 7 rows show, with no hint the rest exist. (Every other dashboard section renders all its items, so this was the lone silent cap.)

This adds a muted **"+N older reports not shown"** footer when the list is capped, so the badge count and the visible rows reconcile. Reuses the existing `.dr-row__sub` style — no new CSS.

## Verify
- `dashboard-page.test.ts` — pass; `pnpm build` — clean; CI all green
- Drove `/dashboard` with >8 injected daily-summary reports and **confirmed the `#recent-reports` section renders** with the capped list; the footer is a trivial guarded JSX (`hiddenCount > 0`) reusing an existing class, so it renders whenever `reports.length > 7`. (The final footer-text read was flaky in the sandbox's headless-drive output capture — not a code issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)