### PR TITLE
feat(sidebar): remove the Open-on-phone button from the desktop sidebar

### DIFF
--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -14,12 +14,11 @@ const tauriLib = await readFile(new URL("../../src-tauri/src/lib.rs", import.met
 assert.match(topBar, /onOpenMobileHandoff/, "TopBar should accept a mobile handoff opener");
 assert.match(topBar, /ph:device-mobile/, "TopBar should render a mobile-phone icon");
 assert.match(topBar, /top-bar__mobile-handoff/, "TopBar handoff button should have a stable desktop-only class");
-assert.match(sidebar, /onOpenMobileHandoff/, "Sidebar should accept a mobile handoff opener");
-assert.match(sidebar, /aria-label="Open on phone"/, "Sidebar should expose the phone handoff as an icon button");
-assert.match(sidebar, /ph:device-mobile/, "Sidebar should render the mobile-phone handoff icon");
+// The desktop sidebar no longer carries a phone-handoff button — the feature is
+// reached from the (mobile) TopBar. The sidebar must not re-introduce it.
+assert.doesNotMatch(sidebar, /onOpenMobileHandoff/, "Sidebar should not carry a mobile handoff button");
+assert.doesNotMatch(sidebar, /Open on phone/, "Sidebar should not expose an Open-on-phone control");
 assert.match(workspace, /MobileHandoffModal/, "Workspace should mount the mobile handoff modal");
-assert.match(workspace, /setMobileHandoffCopyRequest\(\(value\) => value \+ 1\)/, "Sidebar handoff trigger should request invite copy");
-assert.match(workspace, /autoCopyRequest=\{mobileHandoffCopyRequest\}/, "Workspace should pass sidebar copy intent into the modal");
 assert.match(modal, /\/api\/mobile-handoff/, "Modal should call the mobile handoff API");
 assert.match(modal, /dangerouslySetInnerHTML/, "Modal should render the QR SVG returned by the API");
 assert.match(modal, /expiresAtIso/, "Modal should display the invite expiry");

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -8,7 +8,7 @@
  *   2. App destinations grouped by purpose:
  *      Work  (Home / Familiars / Board / Calendar / Schedules)
  *      Tools (Browser / Terminal / Code / Library / Roles / Workflows / GitHub)
- *   3. Footer: Notifications, mobile handoff, Settings
+ *   3. Footer: Notifications, Settings
  */
 
 import React from "react";
@@ -47,7 +47,6 @@ export type SidebarMinimalProps = {
   activeSessionId?: string | null;
   onNewChat: () => void;
   onOpenSettings: () => void;
-  onOpenMobileHandoff: () => void;
   onModeChange: (mode: string) => void;
   onOpenSession: (id: string) => void;
   addons?: AddonsConfig;
@@ -197,7 +196,6 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
     mode,
     onNewChat,
     onOpenSettings,
-    onOpenMobileHandoff,
     onModeChange,
     onOpenSession,
     activeSessionId,
@@ -331,15 +329,6 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
               <Icon name="ph:gear-six" width={14} className="sidebar-foot-icon" />
             </span>
             <span className="sidebar-foot-label">Settings</span>
-          </button>
-          <button
-            type="button"
-            className="sidebar-foot-icon-btn"
-            onClick={onOpenMobileHandoff}
-            aria-label="Open on phone"
-            title="Open on phone"
-          >
-            <Icon name="ph:device-mobile" width={14} className="sidebar-foot-icon" />
           </button>
         </div>
       </div>

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -220,7 +220,6 @@ export function Workspace() {
   const [glyphPickerFor, setGlyphPickerFor] = useState<Familiar | null>(null);
   const [addChooserOpen, setAddChooserOpen] = useState(false);
   const [mobileHandoffOpen, setMobileHandoffOpen] = useState(false);
-  const [mobileHandoffCopyRequest, setMobileHandoffCopyRequest] = useState(0);
   const [addons, setAddons] = useState<{ github?: boolean; library?: boolean }>({});
   const responseNeededRef = useRef(responseNeeded);
   responseNeededRef.current = responseNeeded;
@@ -1516,12 +1515,6 @@ export function Workspace() {
     startFamiliarChat(activeId, projectRoot);
   }, [activeId, startFamiliarChat]);
 
-  const openSidebarMobileHandoff = useCallback(() => {
-    shellRef.current?.dismissNavMobile();
-    setMobileHandoffCopyRequest((value) => value + 1);
-    setMobileHandoffOpen(true);
-  }, []);
-
   const sidebar = (
     <SidebarMinimal
       mode={mode}
@@ -1536,7 +1529,6 @@ export function Workspace() {
         shellRef.current?.dismissNavMobile();
         nextRouter.push("/settings");
       }}
-      onOpenMobileHandoff={openSidebarMobileHandoff}
       onModeChange={(m) => {
         if (m === "browser") {
           setMode("browser");
@@ -2059,7 +2051,6 @@ export function Workspace() {
       <MobileHandoffModal
         open={mobileHandoffOpen}
         onClose={() => setMobileHandoffOpen(false)}
-        autoCopyRequest={mobileHandoffCopyRequest}
       />
     </FamiliarStudioProvider>
   );


### PR DESCRIPTION
## What

Removes the **"Open on phone"** (phone-icon) button from the left sidebar footer, as requested. The sidebar footer is now just Notifications + Settings.

Along with the button, this removes its sidebar-specific dead wiring:
- `openSidebarMobileHandoff` callback + the `onOpenMobileHandoff` prop on `SidebarMinimal`
- the `mobileHandoffCopyRequest` state and the modal's `autoCopyRequest` pass (an auto-copy-invite convenience that only the sidebar button triggered)

**The mobile-handoff feature is unchanged otherwise** — it stays reachable from the TopBar, and `MobileHandoffModal` is untouched (its `autoCopyRequest` prop is optional, default 0).

## Testing
- `pnpm typecheck` — clean (no unused-var fallout)
- `pnpm test:app` (339) + `pnpm test:mobile` (16) — pass; `mobile-handoff.test.ts` updated to assert the sidebar no longer carries the button while keeping the TopBar + modal contract
- `pnpm build` — pass
- Live-verified: sidebar footer = Dashboard / Notifications / Settings, no phone button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)