### PR TITLE
feat(palette): show a running-session status dot on ⌘K rows

### DIFF
--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -43,6 +43,16 @@ function browseGroup(row: Row): string {
   }
 }
 
+// Status → dot class for session rows, mirroring the Sessions tab's colors. Only
+// "notable" states get a dot (running pulses green, failed/queued/paused tint);
+// completed/idle sessions stay dotless so the Recent list doesn't get speckled.
+const SESSION_DOT: Record<string, string> = {
+  running: "bg-[var(--color-success)] animate-pulse",
+  failed: "bg-[var(--color-danger)]",
+  queued: "bg-[var(--color-warning)]",
+  paused: "bg-[var(--accent-presence-soft)]",
+};
+
 type PaletteIntent =
   | { kind: "switch-familiar"; familiarId: string }
   | { kind: "open-session"; sessionId: string; familiarId?: string | null }
@@ -779,6 +789,8 @@ export function CommandPalette({
               row.kind === "session"
                 ? relativeTime(row.session.updated_at || row.session.created_at)
                 : "";
+            const sessionDot =
+              row.kind === "session" ? SESSION_DOT[row.session.status] : undefined;
             return (
               <Fragment key={row.id}>
                 {showHeader ? (
@@ -820,8 +832,17 @@ export function CommandPalette({
                     <>
                       <Icon name="ph:chat-circle-dots-bold" className="text-[var(--text-secondary)]" width="1.1rem" height="1.1rem" />
                       <span className="flex min-w-0 flex-1 flex-col">
-                        <span className="truncate text-[var(--text-primary)]">
-                          {row.session.title || "(untitled chat)"}
+                        <span className="flex min-w-0 items-center gap-1.5">
+                          {sessionDot ? (
+                            <span
+                              role="img"
+                              aria-label={`${row.session.status} session`}
+                              className={`block h-2 w-2 shrink-0 rounded-full ${sessionDot}`}
+                            />
+                          ) : null}
+                          <span className="truncate text-[var(--text-primary)]">
+                            {row.session.title || "(untitled chat)"}
+                          </span>
                         </span>
                         <span className="truncate text-[10px] text-[var(--text-muted)]">
                           {row.familiar?.display_name ?? row.session.familiarId} ·{" "}


### PR DESCRIPTION
## What

Follow-up to #1372 / #1374. The ⌘K **Recent** list now carries the same status signal as the Sessions tab: a small colored dot precedes the session title — **running pulses green**, failed/queued/paused tint red/amber/soft-accent. Completed and idle sessions stay **dotless** so the list isn't speckled, keeping the running ones easy to spot at a glance.

## How

- `command-palette.tsx`: a module-level `SESSION_DOT` status→class map (mirroring the Sessions tab's colors), rendered as a `h-2 w-2 rounded-full` dot before the title with `role="img"` + an `aria-label` ("running session") so the status is announced, not just colored.

## Verification

- `pnpm typecheck` clean, `pnpm test:app` → 339 files pass, `pnpm build` green.
- Live (route-mocked): dot appears only on the running (green) + failed (red) rows; the two completed rows are dotless; aria-labels resolve to "running session" / "failed session". Screenshot confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)