### PR TITLE
perf: O(1) familiar lookups + score-once stale sort (round 2)

### DIFF
--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -282,6 +282,7 @@ export function CommandPalette({
     setSalemError(null);
   }, [initialQuery, open]);
 
+  const familiarById = useMemo(() => new Map(familiars.map((f) => [f.id, f])), [familiars]);
   const rows: Row[] = useMemo(() => {
     const { token, rest } = parseFamiliarToken(query);
     const q = rest.trim().toLowerCase();
@@ -336,7 +337,7 @@ export function CommandPalette({
         id: `s:${s.id}`,
         kind: "session",
         session: s,
-        familiar: familiars.find((f) => f.id === s.familiarId) ?? null,
+        familiar: familiarById.get(s.familiarId) ?? null,
       }));
 
     const cardRows: Row[] = cards
@@ -357,7 +358,7 @@ export function CommandPalette({
         id: `card:${c.id}`,
         kind: "card",
         card: c,
-        familiar: familiars.find((f) => f.id === c.familiarId) ?? null,
+        familiar: familiarById.get(c.familiarId) ?? null,
       }));
 
     const covenMemoryRows: Row[] = covenMemory
@@ -375,7 +376,7 @@ export function CommandPalette({
         id: `cm:${e.id}`,
         kind: "coven-memory",
         entry: e,
-        familiar: familiars.find((f) => f.id === e.familiar_id) ?? null,
+        familiar: familiarById.get(e.familiar_id) ?? null,
       }));
 
     // fs-memory, slash commands, and shortcuts are not familiar-scoped, so
@@ -572,7 +573,7 @@ export function CommandPalette({
       : [];
 
     return [...salemRows, ...localRows];
-  }, [familiars, sessions, cards, covenMemory, fsMemory, query, activeFamiliarId, projects, addons]);
+  }, [familiars, familiarById, sessions, cards, covenMemory, fsMemory, query, activeFamiliarId, projects, addons]);
 
   useEffect(() => {
     if (activeIdx >= rows.length) setActiveIdx(Math.max(0, rows.length - 1));

--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -234,18 +234,21 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
   );
 
   const visibleFiles = useMemo(() => {
+    // Precompute staleness once per entry (detectStale + normalizeFileEntry are not
+    // free); reused by the staleOnly filter and the staleFirst comparator so neither
+    // recomputes per element / per comparison.
+    const staleByEntry = new Map(familiarScopedFiles.map((entry) => [entry, detectStale(normalizeFileEntry(entry)).stale]));
     const cmp: Record<typeof sortMode, (a: FileMemoryEntry, b: FileMemoryEntry) => number> = {
       recent: (a, b) => (a.modified < b.modified ? 1 : a.modified > b.modified ? -1 : 0),
       oldest: (a, b) => (a.modified > b.modified ? 1 : a.modified < b.modified ? -1 : 0),
       name: (a, b) => fileBase(a.relPath).localeCompare(fileBase(b.relPath)),
       size: (a, b) => (b.size ?? 0) - (a.size ?? 0),
-      staleFirst: (a, b) =>
-        Number(detectStale(normalizeFileEntry(b)).stale) - Number(detectStale(normalizeFileEntry(a)).stale),
+      staleFirst: (a, b) => Number(staleByEntry.get(b)) - Number(staleByEntry.get(a)),
     };
     return familiarScopedFiles
       .filter((entry) => sourceFilter === "all" || entry.sourceKind === sourceFilter)
       .filter((entry) => memoryMatches(entry, q))
-      .filter((entry) => !staleOnly || detectStale(normalizeFileEntry(entry)).stale)
+      .filter((entry) => !staleOnly || (staleByEntry.get(entry) ?? false))
       .sort(cmp[sortMode]);
   }, [familiarScopedFiles, q, sourceFilter, sortMode, staleOnly]);
 

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -780,7 +780,7 @@ function GitHubItemGlassPanel({
                   card={card}
                   familiar={
                     card.familiarId
-                      ? familiars.find((familiar) => familiar.id === card.familiarId) ?? null
+                      ? resolvedById.get(card.familiarId) ?? null
                       : null
                   }
                   onFocusCard={onFocusCard}
@@ -1376,7 +1376,7 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
                                 card={c}
                                 familiar={
                                   c.familiarId
-                                    ? familiars.find((f) => f.id === c.familiarId) ?? null
+                                    ? resolvedById.get(c.familiarId) ?? null
                                     : null
                                 }
                                 onFocusCard={onFocusCard}


### PR DESCRIPTION
Round 2 of the performance pass — the same hot-path patterns round 1 fixed in board-table/board-kanban/library/projects, found in three more high-traffic surfaces:

### command-palette
The session / card / coven-memory result chains each did `familiars.find()` **per row** — and the palette rebuilds these on **every keystroke** while open. Build a `familiarById` Map once; use O(1) `.get()`.

### github-view
Two `LinkedTaskChip` render sites (table rows + detail glass panel) did `familiars.find()` **per chip per row** (O(N·M)). Reuse the `resolvedById` Map the component **already builds** — also makes these consistent with the rest of the view (which already resolves via that Map). `LinkedTaskChip.familiar` is structurally typed, so the swap is type-safe.

### familiars-memory-view
The `staleFirst` comparator ran `detectStale(normalizeFileEntry())` **twice per comparison** (O(N log N · 2)), and the `staleOnly` filter ran it per entry. Precompute staleness **once per entry** into a Map, reused by both the filter and the comparator.

No behavior change. command-palette + all 13 familiars-memory + github-view-polish tests stay green; verified no orphaned imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)