### PR TITLE
fix(command-palette): actually guard nullable familiarId before Map.get (red main)

### DIFF
--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -337,7 +337,7 @@ export function CommandPalette({
         id: `s:${s.id}`,
         kind: "session",
         session: s,
-        familiar: familiarById.get(s.familiarId) ?? null,
+        familiar: s.familiarId ? familiarById.get(s.familiarId) ?? null : null,
       }));
 
     const cardRows: Row[] = cards
@@ -358,7 +358,7 @@ export function CommandPalette({
         id: `card:${c.id}`,
         kind: "card",
         card: c,
-        familiar: familiarById.get(c.familiarId) ?? null,
+        familiar: c.familiarId ? familiarById.get(c.familiarId) ?? null : null,
       }));
 
     const covenMemoryRows: Row[] = covenMemory


### PR DESCRIPTION
## Why

`main` is **red on typecheck**. The prior fix (1d314da4, "guard nullable familiarId before Map.get") switched session/card lookups to a `familiarById` Map but the `.get()` calls still pass a nullable `familiarId`, so `pnpm typecheck` (a required step of **Frontend build**) fails:

```
command-palette.tsx(340): 'string | undefined' not assignable to 'string'
command-palette.tsx(361): 'string | null' not assignable to 'string'
```

This blocks **every** open PR via the required Frontend build check.

## Fix

Guard the key before the lookup on both the session and card rows (`familiarId ? get(...) ?? null : null`). Coven-memory's `familiar_id` is already a plain string, so it's untouched. Two-line change.

## Verification

- `pnpm typecheck` clean (was failing on these two lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)