### PR TITLE
feat(ios): full native slash-command suite in the chat composer

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/SlashCommand.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/SlashCommand.swift
@@ -1,0 +1,269 @@
+import Foundation
+
+/// Native slash-command catalog for the iOS app.
+///
+/// Mirrors the web/TUI vocabulary (`src/lib/slash-commands.ts` →
+/// `coven/crates/coven-cli/src/tui/chat/app.rs`) so a muscle-memory `/clear`,
+/// `/board`, `/save …` does the same thing on the phone as on the desktop.
+/// Aliases are first-class: `/h`, `/cls`, `/q` resolve to their canonical command.
+///
+/// Each command also carries an `action` (what it does on mobile) and an
+/// `availability`. Commands whose surface only exists on the desktop
+/// (terminal, projects, journal…) are still recognised and answered with an
+/// honest redirect rather than being silently sent to the familiar as text.
+struct SlashCommand: Identifiable, Hashable {
+    enum Section: String, CaseIterable {
+        case chat, familiar, daemon, view, launch
+
+        var label: String {
+            switch self {
+            case .chat: return "Chat"
+            case .familiar: return "Familiars"
+            case .daemon: return "Daemon"
+            case .view: return "View / Sessions"
+            case .launch: return "Launch"
+            }
+        }
+    }
+
+    /// Whether the command has a real surface on mobile, or politely redirects.
+    enum Availability { case native, desktopOnly }
+
+    /// What dispatch should do when this command runs.
+    enum Action: Hashable {
+        case help                  // present the Commands reference sheet
+        case clearTranscript
+        case quitToList            // pop back to the chat list
+        case newChat               // start a fresh chat with the same familiar(s)
+        case familiarPicker        // switch familiar (arg = name) or open the picker
+        case openSessions          // jump to the Chats list
+        case openBoard             // switch to the Tasks tab
+        case sendAsPrompt          // /run /codex /claude — send the args as a message
+        case sketch                // /canvas — send a sketch-building prompt
+        case saveLink              // /save <url> … — route a URL into the library
+        case daemonStatus          // /daemon — fetch + show status inline
+        case doctor                // /doctor — run `coven doctor` inline
+        case desktopOnly(String)   // recognised, but lives on the desktop
+    }
+
+    let name: String
+    var aliases: [String] = []
+    let hint: String
+    let description: String
+    var argPlaceholder: String?
+    let section: Section
+    let availability: Availability
+    let action: Action
+
+    var id: String { name }
+
+    /// Every typeable token for this command (canonical name + aliases).
+    var tokens: [String] { [name] + aliases }
+}
+
+enum SlashCatalog {
+    /// The full catalog, ordered for display. Kept in lock-step with the web
+    /// `SLASH_COMMANDS` array so the two surfaces never drift.
+    static let all: [SlashCommand] = [
+        // MARK: Chat
+        SlashCommand(name: "/help", aliases: ["/h"], hint: "show help",
+                     description: "Show every command grouped by section.",
+                     section: .chat, availability: .native, action: .help),
+        SlashCommand(name: "/clear", aliases: ["/cls"], hint: "clear transcript",
+                     description: "Clear the local view (the session is untouched).",
+                     section: .chat, availability: .native, action: .clearTranscript),
+        SlashCommand(name: "/quit", aliases: ["/exit", "/q"], hint: "back to chats",
+                     description: "Close this chat and return to the chat list.",
+                     section: .chat, availability: .native, action: .quitToList),
+        SlashCommand(name: "/new", hint: "new chat",
+                     description: "Start a fresh chat with the same familiar.",
+                     section: .chat, availability: .native, action: .newChat),
+        SlashCommand(name: "/palette", hint: "commands",
+                     description: "Open the command reference.",
+                     section: .chat, availability: .native, action: .help),
+        SlashCommand(name: "/shortcuts", aliases: ["/keys"], hint: "commands",
+                     description: "Show the command reference.",
+                     section: .chat, availability: .native, action: .help),
+
+        // MARK: Familiar
+        SlashCommand(name: "/familiar", aliases: ["/agent"], hint: "switch",
+                     description: "Open the familiar picker. Pass a name to switch directly.",
+                     argPlaceholder: "name", section: .familiar,
+                     availability: .native, action: .familiarPicker),
+
+        // MARK: Daemon / health
+        SlashCommand(name: "/daemon", hint: "daemon status",
+                     description: "Show the desktop daemon status inline.",
+                     section: .daemon, availability: .native, action: .daemonStatus),
+        SlashCommand(name: "/doctor", hint: "setup checks",
+                     description: "Run `coven doctor` and print the result inline.",
+                     section: .daemon, availability: .native, action: .doctor),
+
+        // MARK: View / Sessions
+        SlashCommand(name: "/sessions", hint: "all sessions",
+                     description: "Open the chat list.",
+                     section: .view, availability: .native, action: .openSessions),
+        SlashCommand(name: "/chats", aliases: ["/agents", "/chat"], hint: "Chats",
+                     description: "Switch back to the Chats view.",
+                     section: .view, availability: .native, action: .openSessions),
+        SlashCommand(name: "/board", hint: "Tasks",
+                     description: "Open the Tasks board.",
+                     section: .view, availability: .native, action: .openBoard),
+        SlashCommand(name: "/canvas", hint: "sketch a UI",
+                     description: "Ask the familiar to sketch a UI.",
+                     argPlaceholder: "describe a UI…", section: .view,
+                     availability: .native, action: .sketch),
+        SlashCommand(name: "/save", aliases: ["/bookmark", "/read"],
+                     hint: "/save <url> [bookmarks|reading|github] [#tag]",
+                     description: "Route a URL into the library (auto-classified).",
+                     argPlaceholder: "url …", section: .view,
+                     availability: .native, action: .saveLink),
+        SlashCommand(name: "/journal", hint: "Journal",
+                     description: "Your daily journal — open it on the desktop.",
+                     section: .view, availability: .desktopOnly, action: .desktopOnly("Journal")),
+        SlashCommand(name: "/inbox", hint: "Schedules",
+                     description: "Schedules live on the desktop.",
+                     section: .view, availability: .desktopOnly, action: .desktopOnly("Schedules")),
+        SlashCommand(name: "/remind", hint: "new reminder",
+                     description: "Create a reminder — on the desktop for now.",
+                     argPlaceholder: "when + text", section: .view,
+                     availability: .desktopOnly, action: .desktopOnly("Reminders")),
+        SlashCommand(name: "/terminal", aliases: ["/comux"], hint: "Terminal",
+                     description: "The integrated terminal lives on the desktop.",
+                     section: .view, availability: .desktopOnly, action: .desktopOnly("Terminal")),
+        SlashCommand(name: "/projects", hint: "Projects",
+                     description: "The project browser lives on the desktop.",
+                     section: .view, availability: .desktopOnly, action: .desktopOnly("Projects")),
+        SlashCommand(name: "/attach", hint: "open session",
+                     description: "Open a daemon session by id — desktop for now.",
+                     argPlaceholder: "session-id", section: .view,
+                     availability: .desktopOnly, action: .desktopOnly("Attach session")),
+        SlashCommand(name: "/tui", hint: "open in Coven Code",
+                     description: "Open the session in the desktop Coven Code TUI.",
+                     section: .view, availability: .desktopOnly, action: .desktopOnly("Coven Code")),
+
+        // MARK: Launch
+        SlashCommand(name: "/run", hint: "run task",
+                     description: "Run a task through the active familiar.",
+                     argPlaceholder: "task…", section: .launch,
+                     availability: .native, action: .sendAsPrompt),
+        SlashCommand(name: "/codex", hint: "codex runtime",
+                     description: "Send a task (runs through the active familiar on mobile).",
+                     argPlaceholder: "task…", section: .launch,
+                     availability: .native, action: .sendAsPrompt),
+        SlashCommand(name: "/claude", hint: "claude runtime",
+                     description: "Send a task (runs through the active familiar on mobile).",
+                     argPlaceholder: "task…", section: .launch,
+                     availability: .native, action: .sendAsPrompt),
+    ]
+
+    /// alias/name → command, for O(1) canonical resolution.
+    private static let byToken: [String: SlashCommand] = {
+        var map: [String: SlashCommand] = [:]
+        for command in all {
+            for token in command.tokens { map[token.lowercased()] = command }
+        }
+        return map
+    }()
+
+    /// Resolve a leading `/token` to its command, or nil if unknown.
+    static func command(for token: String) -> SlashCommand? {
+        guard token.hasPrefix("/") else { return nil }
+        return byToken[token.lowercased()]
+    }
+
+    /// Typeahead: every command whose name or an alias starts with `prefix`.
+    /// `prefix` is the partial first word, e.g. `/sa`. Empty after `/` → all.
+    static func matches(_ prefix: String) -> [SlashCommand] {
+        guard prefix.hasPrefix("/") else { return [] }
+        let q = prefix.lowercased()
+        if q == "/" { return all }
+        return all.filter { command in
+            command.tokens.contains { $0.lowercased().hasPrefix(q) }
+        }
+    }
+}
+
+/// A parsed composer input: either a recognised command (+ its arguments),
+/// an unknown `/token`, or plain prose to send as a message.
+enum SlashInput {
+    case command(SlashCommand, args: String)
+    case unknown(token: String)
+    case prose(String)
+
+    /// Parse raw composer text. Only treats it as a command when it starts with
+    /// `/` and the leading token has no embedded slash beyond the first char.
+    static func parse(_ raw: String) -> SlashInput {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("/") else { return .prose(trimmed) }
+
+        let firstSpace = trimmed.firstIndex(where: { $0 == " " || $0 == "\n" })
+        let token = firstSpace.map { String(trimmed[trimmed.startIndex..<$0]) } ?? trimmed
+        let args = firstSpace
+            .map { String(trimmed[trimmed.index(after: $0)...]) }
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) } ?? ""
+
+        if let command = SlashCatalog.command(for: token) {
+            return .command(command, args: args)
+        }
+        return .unknown(token: token)
+    }
+
+    /// Whether the in-progress text should surface the autocomplete menu:
+    /// a leading `/` on the first word (no whitespace committed yet).
+    static func isTypingCommand(_ raw: String) -> Bool {
+        guard raw.hasPrefix("/") else { return false }
+        return !raw.contains(" ") && !raw.contains("\n")
+    }
+}
+
+/// Parsed `/save` arguments — Swift port of `src/lib/slash-save-parser.ts`.
+struct SlashSaveArgs {
+    var url: String?
+    var listHint: String?
+    var tags: [String]
+}
+
+/// `/save <url> [bookmarks|reading|github] [#tag…]`. Returns a nil url when the
+/// first token isn't a valid http(s) URL.
+func parseSaveArgs(_ args: String) -> SlashSaveArgs {
+    let tokens = args
+        .split(whereSeparator: { $0 == " " || $0 == "\n" || $0 == "\t" })
+        .map(String.init)
+    guard let first = tokens.first,
+          let url = URL(string: first),
+          let scheme = url.scheme?.lowercased(),
+          scheme == "http" || scheme == "https" else {
+        return SlashSaveArgs(url: nil, listHint: nil, tags: [])
+    }
+    let validHints: Set<String> = ["bookmarks", "reading", "github"]
+    var listHint: String?
+    var tags: [String] = []
+    for token in tokens.dropFirst() {
+        if token.hasPrefix("#") {
+            let tag = String(token.dropFirst())
+            if !tag.isEmpty { tags.append(tag) }
+        } else if validHints.contains(token) {
+            listHint = token
+        }
+    }
+    return SlashSaveArgs(url: first, listHint: listHint, tags: tags)
+}
+
+/// Build the sketch prompt sent for `/canvas` — a trimmed Swift port of the web
+/// `buildSketchPrompt` (src/lib/canvas-artifacts.ts) so a familiar returns one
+/// self-contained, renderable code block.
+func buildSketchPrompt(_ userPrompt: String) -> String {
+    let ask = userPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        ? "a simple example UI"
+        : userPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+    return [
+        "You are generating a UI for a live preview.",
+        "Output EXACTLY ONE fenced code block and nothing else — no prose before or after.",
+        "Use a ```html block: a COMPLETE self-contained document starting with `<!doctype html>`,",
+        "with all CSS in <style> and all JS in <script>. No external files, no network access.",
+        "Make it polished and responsive.",
+        "",
+        "Build this: \(ask)",
+    ].joined(separator: "\n")
+}

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -158,6 +158,82 @@ struct CaveClient {
         }
     }
 
+    // MARK: - Slash-command services
+
+    struct DaemonStatus: Decodable {
+        var running: Bool
+        var apiVersion: String?
+        var covenVersion: String?
+        var reason: String?
+        var workspacePath: String?
+    }
+
+    /// `/daemon` — desktop daemon health (`GET /api/daemon/status`).
+    func daemonStatus() async throws -> DaemonStatus {
+        let req = try request("api/daemon/status")
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        return try JSONDecoder().decode(DaemonStatus.self, from: data)
+    }
+
+    struct CovenExecResult: Decodable {
+        var ok: Bool
+        var exitCode: Int?
+        var stdout: String?
+        var stderr: String?
+        var error: String?
+
+        /// Combined, trimmed output for inline display.
+        var output: String {
+            [stdout, stderr].compactMap { $0 }
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+                .joined(separator: "\n")
+        }
+    }
+
+    /// `/doctor` — run an allow-listed coven subcommand (`POST /api/coven/exec`).
+    /// The server allow-lists `doctor` and `daemon`; the route can answer 5xx
+    /// with a JSON body, so decode the body regardless of HTTP status.
+    func covenExec(_ command: String) async throws -> CovenExecResult {
+        let payload = try JSONEncoder().encode(["command": command])
+        var req = try request("api/coven/exec", method: "POST", body: payload)
+        req.timeoutInterval = 30
+        let (data, _) = try await session.data(for: req)
+        return try JSONDecoder().decode(CovenExecResult.self, from: data)
+    }
+
+    struct RouteLinkBody: Encodable {
+        struct Source: Encodable {
+            var kind = "slash"
+            var originSessionId: String?
+        }
+        var url: String
+        var familiar: String
+        var source: Source
+        var tags: [String]?
+        var listHint: String?
+    }
+
+    struct RouteLinkResult: Decodable {
+        var ok: Bool
+        var deduped: Bool?
+        var error: String?
+        var item: Item?
+        var classify: Classify?
+        struct Item: Decodable { var title: String? }
+        struct Classify: Decodable { var rule: String? }
+    }
+
+    /// `/save` — route a URL into the library (`POST /api/library/route-link`).
+    func routeLink(_ body: RouteLinkBody) async throws -> RouteLinkResult {
+        let payload = try JSONEncoder().encode(body)
+        let req = try request("api/library/route-link", method: "POST", body: payload)
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        return try JSONDecoder().decode(RouteLinkResult.self, from: data)
+    }
+
     // MARK: - Helpers
 
     private static func check(_ resp: URLResponse) throws {

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -1,6 +1,19 @@
 import Foundation
 import Observation
 
+/// The two bottom tabs. Lifted out of the view so slash commands (`/board`,
+/// `/chats`) can drive tab selection from anywhere.
+enum AppTab: String { case chats, tasks }
+
+/// A transient confirmation banner shown over the chat after a command runs.
+struct ToastMessage: Identifiable, Equatable {
+    enum Style { case success, info, warning, error }
+    let id = UUID()
+    var text: String
+    var systemImage: String
+    var style: Style = .info
+}
+
 @Observable
 @MainActor
 final class AppModel {
@@ -18,6 +31,41 @@ final class AppModel {
     var familiarsError: String?
 
     var threads: [ChatThread] = []
+
+    // MARK: - Cross-view command routing
+
+    /// The selected bottom tab. Bound by `MainTabView`; set by `/board` / `/chats`.
+    var selectedTab: AppTab = .chats
+
+    /// A thread a command asked to open. `ChatsHomeView` observes this, pushes
+    /// the thread, and clears it back to nil (one-shot navigation intent).
+    var threadToOpen: ChatThread?
+
+    /// The active confirmation toast, auto-dismissed by the overlay.
+    var toast: ToastMessage?
+
+    /// Show a confirmation toast (replaces any in-flight one).
+    func showToast(_ text: String, systemImage: String = "checkmark.circle.fill",
+                   style: ToastMessage.Style = .success) {
+        toast = ToastMessage(text: text, systemImage: systemImage, style: style)
+    }
+
+    /// Ask the chat list to open a thread (switches to Chats first).
+    func requestOpen(_ thread: ChatThread) {
+        selectedTab = .chats
+        threadToOpen = thread
+    }
+
+    /// Resolve a free-text familiar reference (id or display name, fuzzy) to a
+    /// familiar — used by `/familiar <name>`.
+    func resolveFamiliar(_ query: String) -> Familiar? {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !q.isEmpty else { return nil }
+        if let exact = familiars.first(where: { $0.id.lowercased() == q
+            || $0.displayName.lowercased() == q }) { return exact }
+        return familiars.first { $0.displayName.lowercased().contains(q)
+            || $0.id.lowercased().contains(q) }
+    }
 
     var tasks: [BoardCard] = []
     var tasksError: String?
@@ -104,6 +152,17 @@ final class AppModel {
     func createGroup(familiarIds: [String], title: String?) -> ChatThread {
         let names = familiarIds.compactMap { familiar($0)?.displayName ?? $0 }
         let derived = title?.isEmpty == false ? title! : names.joined(separator: ", ")
+        let thread = ChatThread(title: derived, familiarIds: familiarIds)
+        threads.insert(thread, at: 0)
+        persistThreads()
+        return thread
+    }
+
+    /// Always create a brand-new thread (no reuse) — backs `/new`. Works for a
+    /// single familiar (direct) or several (group).
+    func startFreshThread(familiarIds: [String], title: String? = nil) -> ChatThread {
+        let names = familiarIds.compactMap { familiar($0)?.displayName ?? $0 }
+        let derived = (title?.isEmpty == false) ? title! : names.joined(separator: ", ")
         let thread = ChatThread(title: derived, familiarIds: familiarIds)
         threads.insert(thread, at: 0)
         persistThreads()

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -4,7 +4,9 @@ import Observation
 /// A message as shown in the thread UI. For group threads, assistant messages
 /// carry the `familiarId` that produced them so we can attribute + colour them.
 struct DisplayMessage: Identifiable, Codable, Hashable {
-    enum Role: String, Codable { case user, assistant }
+    /// `system` carries inline slash-command output (help, `/daemon`, `/save`
+    /// results) — rendered as a centred note, never sent to a familiar.
+    enum Role: String, Codable { case user, assistant, system }
     var id: String = UUID().uuidString
     var role: Role
     var familiarId: String?
@@ -72,11 +74,19 @@ final class ChatThread: Identifiable, Hashable {
     }
 
     /// Send a user message and stream replies from every familiar in the thread.
-    func send(_ text: String, client: CaveClient, onChange: @escaping () -> Void) {
+    ///
+    /// `displayText` lets a caller show a short label in the user bubble while
+    /// sending a longer prompt to the familiar — e.g. `/canvas` shows the ask
+    /// but sends the full sketch instruction.
+    func send(_ text: String, displayText: String? = nil,
+              client: CaveClient, onChange: @escaping () -> Void) {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
+        let shown = (displayText?.trimmingCharacters(in: .whitespacesAndNewlines)).flatMap {
+            $0.isEmpty ? nil : $0
+        } ?? trimmed
 
-        messages.append(DisplayMessage(role: .user, familiarId: nil, text: trimmed))
+        messages.append(DisplayMessage(role: .user, familiarId: nil, text: shown))
         updatedAt = Date()
         onChange()
 
@@ -92,6 +102,28 @@ final class ChatThread: Identifiable, Hashable {
 
     func deleteMessage(_ messageId: String) {
         messages.removeAll { $0.id == messageId }
+        updatedAt = Date()
+    }
+
+    /// Append an inline system note (slash-command output) and return its id so
+    /// callers can stream into it — e.g. `/daemon`'s "running…" → result.
+    @discardableResult
+    func appendSystem(_ text: String, isError: Bool = false) -> String {
+        let message = DisplayMessage(role: .system, familiarId: nil, text: text, isError: isError)
+        messages.append(message)
+        updatedAt = Date()
+        return message.id
+    }
+
+    /// Replace the text of a previously-appended message (by id).
+    func updateText(_ messageId: String, _ text: String, isError: Bool = false) {
+        mutate(messageId) { $0.text = text; if isError { $0.isError = true } }
+        updatedAt = Date()
+    }
+
+    /// Remove every message, keeping the thread (mirrors web `/clear`).
+    func clearMessages() {
+        messages.removeAll()
         updatedAt = Date()
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -2,9 +2,20 @@ import SwiftUI
 
 struct ChatView: View {
     @Environment(AppModel.self) private var app
+    @Environment(\.dismiss) private var dismiss
     @Bindable var thread: ChatThread
     @State private var draft: String = ""
     @FocusState private var composerFocused: Bool
+    @State private var showCommands = false
+    @State private var showFamiliarPicker = false
+
+    // The slash autocomplete is driven purely off the in-progress draft: a
+    // leading "/" on the first word (no whitespace committed yet).
+    private var slashMatches: [SlashCommand] {
+        guard SlashInput.isTypingCommand(draft) else { return [] }
+        return SlashCatalog.matches(draft)
+    }
+    private var showingSlashMenu: Bool { !slashMatches.isEmpty }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -24,6 +35,21 @@ struct ChatView: View {
                         Text(role).font(.caption2).foregroundStyle(.secondary)
                     }
                 }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button { showCommands = true } label: {
+                    Image(systemName: "command")
+                }
+                .accessibilityLabel("Commands")
+            }
+        }
+        .sheet(isPresented: $showCommands) {
+            CommandsSheet { command in prefill(command) }
+        }
+        .sheet(isPresented: $showFamiliarPicker) {
+            FamiliarPickerSheet { familiar in
+                showFamiliarPicker = false
+                switchTo(familiar)
             }
         }
     }
@@ -55,9 +81,24 @@ struct ChatView: View {
         }
     }
 
+    // MARK: - Composer
+
     private var composer: some View {
+        VStack(spacing: 8) {
+            if showingSlashMenu {
+                SlashCommandMenu(commands: slashMatches) { command in pickFromMenu(command) }
+                    .padding(.horizontal, 12)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+            composerBar
+        }
+        .animation(.snappy(duration: 0.18), value: showingSlashMenu)
+        .background(.bar)
+    }
+
+    private var composerBar: some View {
         HStack(alignment: .bottom, spacing: 10) {
-            // Attachment / app drawer (wired in Phase 2).
+            // Attachment / app drawer (wired in a later phase).
             Button(action: {}) {
                 Image(systemName: "plus")
                     .font(.system(size: 18, weight: .semibold))
@@ -68,7 +109,7 @@ struct ChatView: View {
             .accessibilityLabel("Add attachment")
 
             // Hairline capsule with the field and a trailing control inside it:
-            // a mic when empty, a filled send button once there's text.
+            // a mic when empty, a filled send/run button once there's text.
             HStack(alignment: .bottom, spacing: 4) {
                 TextField("Message", text: $draft, axis: .vertical)
                     .lineLimit(1...6)
@@ -81,12 +122,13 @@ struct ChatView: View {
                         Button(action: send) {
                             Image(systemName: "arrow.up.circle.fill")
                                 .font(.system(size: 29))
-                                .foregroundStyle(Color.accentColor)
+                                .foregroundStyle(isCommand ? Color.green : Color.accentColor)
                                 .background(Circle().fill(.white).padding(3))
                         }
                         .padding(.trailing, 3)
                         .padding(.bottom, 2)
                         .transition(.scale.combined(with: .opacity))
+                        .accessibilityLabel(isCommand ? "Run command" : "Send")
                     } else {
                         Image(systemName: "mic.fill")
                             .font(.system(size: 17))
@@ -96,28 +138,274 @@ struct ChatView: View {
                     }
                 }
             }
-            .overlay(Capsule().strokeBorder(Color(.separator), lineWidth: 1))
+            .overlay(Capsule().strokeBorder(borderColor, lineWidth: 1))
             .animation(.snappy(duration: 0.18), value: canSend)
+            .animation(.snappy(duration: 0.18), value: isCommand)
         }
         .padding(.horizontal, 12)
         .padding(.top, 6)
         .padding(.bottom, 8)
-        .background(.bar)
     }
 
     private var canSend: Bool {
         !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    /// True when the draft is a recognised command — tints the send affordance
+    /// green so the user knows tapping will run a command, not send a message.
+    private var isCommand: Bool {
+        if case .command = SlashInput.parse(draft) { return true }
+        return false
+    }
+
+    private var borderColor: Color {
+        isCommand ? Color.green.opacity(0.5) : Color(.separator)
+    }
+
+    // MARK: - Send / dispatch
+
     private func send() {
+        let raw = draft
+        switch SlashInput.parse(raw) {
+        case .command(let command, let args):
+            draft = ""
+            dispatch(command, args: args)
+        case .unknown(let token):
+            draft = ""
+            thread.appendSystem("Unknown command \(token). Tap ⌘ or type /help for the full list.",
+                                isError: true)
+            app.touch(thread)
+        case .prose(let text):
+            guard !text.isEmpty, let client = app.client else { return }
+            draft = ""
+            thread.send(text, client: client) { app.touch(thread) }
+        }
+    }
+
+    /// Tap a row in the inline autocomplete. Commands that take arguments get
+    /// prefilled (keyboard stays up); zero-arg commands run immediately.
+    private func pickFromMenu(_ command: SlashCommand) {
+        if command.argPlaceholder != nil {
+            draft = command.name + " "
+            composerFocused = true
+        } else {
+            draft = ""
+            dispatch(command, args: "")
+        }
+    }
+
+    /// Pick from the full Commands sheet — always prefill so the user sees the
+    /// command land in the composer, then sends/edits it.
+    private func prefill(_ command: SlashCommand) {
+        draft = command.name + (command.argPlaceholder != nil ? " " : "")
+        composerFocused = true
+    }
+
+    private func dispatch(_ command: SlashCommand, args: String) {
+        switch command.action {
+        case .help:
+            showCommands = true
+        case .clearTranscript:
+            thread.clearMessages()
+            app.touch(thread)
+            app.showToast("Transcript cleared", systemImage: "eraser.fill", style: .info)
+        case .quitToList:
+            dismiss()
+        case .newChat:
+            let fresh = app.startFreshThread(familiarIds: thread.familiarIds,
+                                             title: thread.isGroup ? thread.title : nil)
+            app.requestOpen(fresh)
+            app.showToast("Started a new chat", systemImage: "square.and.pencil", style: .info)
+        case .familiarPicker:
+            if args.isEmpty {
+                showFamiliarPicker = true
+            } else if let familiar = app.resolveFamiliar(args) {
+                switchTo(familiar)
+            } else {
+                thread.appendSystem("No familiar matches “\(args)”. Type /familiar to pick one.",
+                                    isError: true)
+                app.touch(thread)
+            }
+        case .openSessions:
+            app.selectedTab = .chats
+            dismiss()
+        case .openBoard:
+            app.selectedTab = .tasks
+            app.showToast("Opened Tasks", systemImage: "checklist", style: .info)
+        case .sendAsPrompt:
+            sendPrompt(args, command: command)
+        case .sketch:
+            sendSketch(args)
+        case .saveLink:
+            Task { await saveLink(args) }
+        case .daemonStatus:
+            Task { await runDaemonStatus() }
+        case .doctor:
+            Task { await runDoctor() }
+        case .desktopOnly(let surface):
+            app.showToast("\(surface) lives on your desktop", systemImage: "desktopcomputer",
+                          style: .warning)
+        }
+    }
+
+    // MARK: - Command handlers
+
+    private func switchTo(_ familiar: Familiar) {
+        if !thread.isGroup, thread.familiarIds == [familiar.id] {
+            app.showToast("Already chatting with \(familiar.displayName)",
+                          systemImage: "checkmark.circle.fill")
+            return
+        }
+        app.requestOpen(app.directThread(for: familiar.id))
+        app.showToast("Switched to \(familiar.displayName)", systemImage: "arrow.left.arrow.right")
+    }
+
+    private func sendPrompt(_ args: String, command: SlashCommand) {
+        let trimmed = args.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            thread.appendSystem("\(command.name) needs a task — e.g. \(command.name) fix the build",
+                                isError: true)
+            app.touch(thread)
+            return
+        }
         guard let client = app.client else { return }
-        let text = draft
-        draft = ""
-        thread.send(text, client: client) { app.touch(thread) }
+        thread.send(trimmed, client: client) { app.touch(thread) }
+    }
+
+    private func sendSketch(_ args: String) {
+        guard let client = app.client else { return }
+        let ask = args.trimmingCharacters(in: .whitespacesAndNewlines)
+        let label = ask.isEmpty ? "/canvas" : "/canvas \(ask)"
+        thread.send(buildSketchPrompt(ask), displayText: label, client: client) { app.touch(thread) }
+        app.showToast("Asking for a UI sketch…", systemImage: "paintbrush.fill", style: .info)
+    }
+
+    private func saveLink(_ args: String) async {
+        guard let client = app.client else { return }
+        let parsed = parseSaveArgs(args)
+        guard let url = parsed.url else {
+            thread.appendSystem("Usage: /save <url> [bookmarks|reading|github] [#tag]", isError: true)
+            app.touch(thread)
+            return
+        }
+        let noteId = thread.appendSystem("Saving \(url) …")
+        app.touch(thread)
+
+        let familiarId = thread.familiarIds.first ?? "cody"
+        let originSessionId = thread.familiarIds.first.flatMap { thread.sessionIds[$0] }
+        let body = CaveClient.RouteLinkBody(
+            url: url,
+            familiar: familiarId,
+            source: .init(originSessionId: originSessionId),
+            tags: parsed.tags.isEmpty ? nil : parsed.tags,
+            listHint: parsed.listHint)
+        do {
+            let result = try await client.routeLink(body)
+            if result.ok {
+                let deduped = result.deduped ?? false
+                let destination = (parsed.listHint ?? "library").capitalized
+                let headline = deduped ? "Already in library" : "Saved to \(destination)"
+                let title = result.item?.title.map { " · \($0)" } ?? ""
+                thread.updateText(noteId, "\(headline)\(title)")
+                app.showToast(headline, systemImage: "bookmark.fill")
+            } else {
+                thread.updateText(noteId, "Couldn’t save: \(result.error ?? "unknown error")",
+                                  isError: true)
+                app.showToast("Couldn’t save link", systemImage: "xmark.circle.fill", style: .error)
+            }
+        } catch {
+            thread.updateText(noteId, "Couldn’t save: \(error.localizedDescription)", isError: true)
+            app.showToast("Couldn’t save link", systemImage: "xmark.circle.fill", style: .error)
+        }
+        app.touch(thread)
+    }
+
+    private func runDaemonStatus() async {
+        guard let client = app.client else { return }
+        let noteId = thread.appendSystem("coven daemon status\nchecking…")
+        app.touch(thread)
+        do {
+            let status = try await client.daemonStatus()
+            let text: String
+            if status.running {
+                var lines = ["coven daemon — running"]
+                if let v = status.covenVersion { lines.append("version \(v)") }
+                if let a = status.apiVersion { lines.append("api \(a)") }
+                if let w = status.workspacePath { lines.append(w) }
+                text = lines.joined(separator: "\n")
+            } else {
+                text = "coven daemon — not running" + (status.reason.map { "\n\($0)" } ?? "")
+            }
+            thread.updateText(noteId, text, isError: !status.running)
+        } catch {
+            thread.updateText(noteId, "coven daemon — error: \(error.localizedDescription)", isError: true)
+        }
+        app.touch(thread)
+    }
+
+    private func runDoctor() async {
+        guard let client = app.client else { return }
+        let noteId = thread.appendSystem("$ coven doctor\nrunning…")
+        app.touch(thread)
+        do {
+            let result = try await client.covenExec("doctor")
+            let out = result.output.isEmpty ? "(no output)" : result.output
+            let header = result.ok
+                ? "coven doctor — exit 0"
+                : "coven doctor — failed" + (result.exitCode.map { " (exit \($0))" } ?? "")
+            thread.updateText(noteId, "\(header)\n\n\(out)", isError: !result.ok)
+        } catch {
+            thread.updateText(noteId, "coven doctor — error: \(error.localizedDescription)", isError: true)
+        }
+        app.touch(thread)
     }
 
     private func deleteMessage(_ message: DisplayMessage) {
         thread.deleteMessage(message.id)
         app.touch(thread)
+    }
+}
+
+/// A lightweight familiar chooser for `/familiar` with no argument.
+struct FamiliarPickerSheet: View {
+    @Environment(AppModel.self) private var app
+    @Environment(\.dismiss) private var dismiss
+    let onPick: (Familiar) -> Void
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if app.familiars.isEmpty {
+                    Text("No familiars found. Pull to refresh on the Chats screen.")
+                        .font(.footnote).foregroundStyle(.secondary)
+                }
+                ForEach(app.familiars) { familiar in
+                    Button { onPick(familiar) } label: {
+                        HStack(spacing: 12) {
+                            AvatarView(familiar: familiar,
+                                       url: app.client?.avatarURL(for: familiar),
+                                       size: 40)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(familiar.displayName).font(.body).foregroundStyle(.primary)
+                                if let role = familiar.role, !role.isEmpty {
+                                    Text(role).font(.caption).foregroundStyle(.secondary)
+                                }
+                            }
+                            Spacer()
+                            Image(systemName: "arrow.up.left")
+                                .font(.caption).foregroundStyle(.tertiary)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .navigationTitle("Switch familiar")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -42,6 +42,12 @@ struct ChatsHomeView: View {
             }
             .refreshable { await app.loadFamiliars() }
             .onAppear(perform: openDeepLinkedThread)
+            // A slash command (`/new`, `/familiar <name>`) asked to open a thread.
+            .onChange(of: app.threadToOpen) { _, thread in
+                guard let thread else { return }
+                if path.last?.id != thread.id { path.append(thread) }
+                app.threadToOpen = nil
+            }
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/CommandsSheet.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/CommandsSheet.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+/// The command reference — the mobile equivalent of the web `/help` block and
+/// the ⌘K palette. Grouped by section, searchable, and tappable: picking a
+/// command drops it into the composer ready to run.
+struct CommandsSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    /// Called with the chosen command's canonical name (e.g. "/save ").
+    let onPick: (SlashCommand) -> Void
+
+    @State private var query = ""
+
+    private var sections: [(SlashCommand.Section, [SlashCommand])] {
+        SlashCommand.Section.allCases.compactMap { section in
+            let items = filtered.filter { $0.section == section }
+            return items.isEmpty ? nil : (section, items)
+        }
+    }
+
+    private var filtered: [SlashCommand] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !q.isEmpty else { return SlashCatalog.all }
+        return SlashCatalog.all.filter { command in
+            command.tokens.contains { $0.lowercased().contains(q) }
+                || command.description.lowercased().contains(q)
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if filtered.isEmpty {
+                    ContentUnavailableView.search(text: query)
+                }
+                ForEach(sections, id: \.0) { section, commands in
+                    Section(section.label) {
+                        ForEach(commands) { command in
+                            Button { onPick(command); dismiss() } label: { row(command) }
+                                .buttonStyle(.plain)
+                        }
+                    }
+                }
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("Commands")
+            .navigationBarTitleDisplayMode(.inline)
+            .searchable(text: $query, placement: .navigationBarDrawer(displayMode: .always),
+                        prompt: "Search commands")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func row(_ command: SlashCommand) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 6) {
+                    Text(command.name)
+                        .font(.system(.body, design: .monospaced).weight(.semibold))
+                        .foregroundStyle(.primary)
+                    if let arg = command.argPlaceholder {
+                        Text("<\(arg)>")
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                Text(command.description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                if !command.aliases.isEmpty {
+                    Text("also " + command.aliases.joined(separator: ", "))
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            Spacer(minLength: 6)
+            if command.availability == .desktopOnly {
+                Text("Desktop")
+                    .font(.system(size: 10, weight: .semibold))
+                    .padding(.horizontal, 7).padding(.vertical, 3)
+                    .background(Color.secondary.opacity(0.16), in: Capsule())
+                    .foregroundStyle(.secondary)
+            } else {
+                Image(systemName: "arrow.up.left")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.vertical, 3)
+        .contentShape(Rectangle())
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -9,6 +9,43 @@ struct MessageBubble: View {
     private var isUser: Bool { message.role == .user }
 
     var body: some View {
+        if message.role == .system {
+            systemNote
+        } else {
+            chatBubble
+        }
+    }
+
+    /// Inline slash-command output — a subtle monospaced card so it reads as
+    /// system feedback rather than a familiar's reply.
+    private var systemNote: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: message.isError ? "exclamationmark.triangle.fill" : "terminal.fill")
+                .font(.caption)
+                .foregroundStyle(message.isError ? Color.red : Color.secondary)
+                .padding(.top, 2)
+            Text(message.text.isEmpty ? " " : message.text)
+                .font(.callout.monospaced())
+                .foregroundStyle(message.isError ? Color.red : Color.secondary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 14).padding(.vertical, 10)
+        .background(Color(.secondarySystemBackground).opacity(0.6),
+                    in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(Color(.separator).opacity(0.5), lineWidth: 1)
+        )
+        .padding(.horizontal, 24)
+        .contextMenu {
+            Button(role: .destructive, action: onDelete) {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+    }
+
+    private var chatBubble: some View {
         HStack(alignment: .bottom, spacing: 8) {
             if isUser { Spacer(minLength: 48) }
 

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -26,17 +26,17 @@ struct RootView: View {
 /// launch, clobbering any restored value; the value-based `Tab` API honours the
 /// initial selection, so the app reliably reopens on the last-used tab.
 struct MainTabView: View {
-    enum AppTab: String { case chats, tasks }
+    @Environment(AppModel.self) private var app
 
     // @AppStorage holds the durable saved tab (read reliably at view init); the
-    // visible tab is a plain @State the TabView can own without being fought by
-    // the cold-launch reset.
+    // live selection is `app.selectedTab` so slash commands (`/board`, `/chats`)
+    // can drive the tab from inside a pushed chat view.
     @AppStorage("cave.tab") private var savedTab = AppTab.chats.rawValue
-    @State private var selection: AppTab = .chats
     @State private var restored = false
 
     var body: some View {
-        TabView(selection: $selection) {
+        @Bindable var app = app
+        TabView(selection: $app.selectedTab) {
             Tab("Chats", systemImage: "bubble.left.and.bubble.right.fill", value: AppTab.chats) {
                 ChatsHomeView()
             }
@@ -52,13 +52,16 @@ struct MainTabView: View {
         // over the saved value first.
         .task {
             try? await Task.sleep(for: .milliseconds(300))
-            if let saved = AppTab(rawValue: savedTab) { selection = saved }
+            if let saved = AppTab(rawValue: savedTab) { app.selectedTab = saved }
             restored = true
         }
-        .onChange(of: selection) { _, newValue in
+        .onChange(of: app.selectedTab) { _, newValue in
             guard restored else { return }
             savedTab = newValue.rawValue
         }
+        // Command confirmations float above the whole tab bar so they're visible
+        // whether a command stays in chat or jumps to the Tasks tab.
+        .toast($app.toast)
     }
 }
 

--- a/apps/ios/CovenCave/CovenCave/Views/SlashCommandMenu.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SlashCommandMenu.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+/// Autocomplete surface that floats above the composer while the user is typing
+/// a `/command`. Mirrors the web composer popover: name · description · arg hint,
+/// with desktop-only commands tagged so nothing is a surprise on tap.
+struct SlashCommandMenu: View {
+    /// Commands matching the current partial token.
+    let commands: [SlashCommand]
+    /// Invoked when a row is tapped.
+    let onSelect: (SlashCommand) -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(commands) { command in
+                        Button { onSelect(command) } label: { row(command) }
+                            .buttonStyle(.plain)
+                        if command.id != commands.last?.id {
+                            Divider().padding(.leading, 16)
+                        }
+                    }
+                }
+            }
+            .frame(maxHeight: 248)
+
+            footer
+        }
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(Color(.separator).opacity(0.6), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.14), radius: 16, y: 6)
+    }
+
+    private func row(_ command: SlashCommand) -> some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(command.name)
+                        .font(.system(.subheadline, design: .monospaced).weight(.semibold))
+                        .foregroundStyle(.primary)
+                    if let arg = command.argPlaceholder {
+                        Text(arg)
+                            .font(.system(.caption2, design: .monospaced))
+                            .foregroundStyle(.tertiary)
+                    }
+                    if command.availability == .desktopOnly {
+                        Text("Desktop")
+                            .font(.system(size: 9, weight: .semibold))
+                            .padding(.horizontal, 5).padding(.vertical, 1)
+                            .background(Color.secondary.opacity(0.18), in: Capsule())
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Text(command.description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 4)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 9)
+        .contentShape(Rectangle())
+    }
+
+    private var footer: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "command")
+                .font(.system(size: 9))
+            Text("Tap to run · type to filter")
+                .font(.system(size: 10))
+        }
+        .foregroundStyle(.tertiary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 16).padding(.vertical, 7)
+        .background(Color(.secondarySystemBackground).opacity(0.5))
+        .overlay(Divider(), alignment: .top)
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/ToastView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ToastView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// A small confirmation banner that floats in from the top and auto-dismisses.
+/// Used to acknowledge slash commands ("Transcript cleared", "Saved to
+/// Bookmarks") without stealing focus from the conversation.
+struct ToastView: View {
+    let message: ToastMessage
+
+    var body: some View {
+        HStack(spacing: 9) {
+            Image(systemName: message.systemImage)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(tint)
+            Text(message.text)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.primary)
+                .lineLimit(2)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 11)
+        .background(.regularMaterial, in: Capsule())
+        .overlay(Capsule().strokeBorder(tint.opacity(0.35), lineWidth: 1))
+        .shadow(color: .black.opacity(0.12), radius: 12, y: 4)
+        .padding(.horizontal, 24)
+    }
+
+    private var tint: Color {
+        switch message.style {
+        case .success: return .green
+        case .info: return .accentColor
+        case .warning: return .orange
+        case .error: return .red
+        }
+    }
+}
+
+private struct ToastModifier: ViewModifier {
+    @Binding var message: ToastMessage?
+    @State private var dismissTask: Task<Void, Never>?
+
+    func body(content: Content) -> some View {
+        content.overlay(alignment: .top) {
+            if let message {
+                ToastView(message: message)
+                    .padding(.top, 6)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+                    .id(message.id)
+                    .onAppear { scheduleDismiss(message.id) }
+                    // Tap to dismiss immediately.
+                    .onTapGesture { withAnimation(.snappy) { self.message = nil } }
+            }
+        }
+        .animation(.snappy(duration: 0.28), value: message)
+    }
+
+    private func scheduleDismiss(_ id: UUID) {
+        dismissTask?.cancel()
+        dismissTask = Task {
+            try? await Task.sleep(for: .seconds(2.6))
+            guard !Task.isCancelled, message?.id == id else { return }
+            withAnimation(.snappy) { message = nil }
+        }
+    }
+}
+
+extension View {
+    /// Float a transient `ToastMessage` over this view; binding clears on dismiss.
+    func toast(_ message: Binding<ToastMessage?>) -> some View {
+        modifier(ToastModifier(message: message))
+    }
+}


### PR DESCRIPTION
## What

Brings the complete Coven slash-command vocabulary (web/TUI parity) to the **native iOS app**, with an inline autocomplete, a searchable command reference, and explicit confirmation of success for every command. Until now the iOS composer sent everything as plain text — `/clear`, `/board`, `/save …` did nothing.

## How it works

**Typing `/`** surfaces an autocomplete popover above the composer (name · description · arg hint). Zero-arg commands run on tap; arg-taking commands prefill and keep the keyboard up. The send button turns **green** when the draft is a recognised command so it's obvious a tap will *run* rather than *send*.

**A ⌘ toolbar button** opens a searchable **Commands** sheet (the mobile `/help` + ⌘K), grouped by section; picking a command drops it into the composer.

**Every command is answered** — nothing silently breaks:

| Native | Behaviour |
|---|---|
| `/help` `/palette` `/shortcuts` | Open the Commands reference |
| `/clear` | Clear transcript + toast |
| `/quit` `/exit` `/q` | Back to chat list |
| `/new` | Fresh chat with the same familiar(s) |
| `/familiar [name]` `/agent` | Switch familiar, or open a picker |
| `/sessions` `/chats` | Jump to the chat list |
| `/board` | Switch to the Tasks tab |
| `/run` `/codex` `/claude` | Send the task to the familiar |
| `/canvas <ask>` | Send a sketch prompt (short label in the bubble) |
| `/save <url> [list] [#tag]` `/bookmark` `/read` | Route into the library, inline result |
| `/daemon` | Desktop daemon status, inline |
| `/doctor` | `coven doctor`, inline |

Desktop-only surfaces (`/journal` `/inbox` `/remind` `/terminal` `/projects` `/attach` `/tui`) are recognised and tagged **Desktop** in the menu, and answered with an honest "lives on your desktop" toast instead of being sent as chat text.

**Confirmation** comes three ways: a floating **toast** for quick acks, inline **system-role messages** for command output (`/daemon`, `/doctor`, `/save`), and the green run affordance.

## Files

- `Models/SlashCommand.swift` — catalog (24 cmds + aliases), canonicalization, typeahead, input parsing, `/save` parser, sketch-prompt builder. Kept in lock-step with `src/lib/slash-commands.ts`.
- `Views/SlashCommandMenu.swift`, `Views/CommandsSheet.swift`, `Views/ToastView.swift` — new UI.
- `Views/ChatView.swift` — composer wiring + dispatch + handlers + familiar picker.
- `Networking/CaveClient.swift` — `daemonStatus`, `covenExec`, `routeLink`.
- `State/AppModel.swift`, `State/ChatThread.swift`, `Views/RootView.swift`, `Views/ChatsHomeView.swift`, `Views/MessageBubble.swift` — tab/thread routing, system messages, toast host, system-note rendering.

## Verification

- `xcodebuild` **BUILD SUCCEEDED** (iPhone 16 Pro sim).
- A Swift harness exercises parsing, canonicalization, all aliases, the `/save` parser, the sketch builder, and desktop-only tagging — **all assertions pass**.
- App launches **connected** and renders the new composer + ⌘ button live in ChatView.
- Interactive menu/toast capture was blocked by simulator UI-automation permissions; the build + logic harness cover dispatch correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)