### PR TITLE
feat(roles): make role-card Skills chips open the skill detail

### DIFF
--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -42,6 +42,21 @@ type LocalSkillEntry = {
   familiar: string;
 };
 
+// Map a scanned local skill to the detail-drawer's shape (shared by the Skills
+// tab and the role-card skill chips).
+function toSkillDetail(skill: LocalSkillEntry): SkillDetailEntry {
+  return {
+    id: skill.id,
+    name: skill.name,
+    description: skill.description,
+    version: skill.version,
+    category: skill.kind,
+    owner: skill.familiar,
+    tags: skill.tags,
+    source: skill.path,
+  };
+}
+
 type Props = {
   onOpenChat: () => void;
   onOpenWorkflow?: (id: string) => void;
@@ -274,6 +289,26 @@ export function PluginsView({
     }
   }, [tabSet, onCreateSkill]);
 
+  // A role-card skill chip opens that skill's detail drawer (resolving the
+  // chip's name against the scanned local skills). Unknown/not-yet-loaded
+  // skills fall back to the Skills tab, pre-filtered to the name.
+  const openSkillByName = useCallback(
+    (name: string) => {
+      const match = skills.find(
+        (s) => s.id === name || s.name.toLowerCase() === name.toLowerCase(),
+      );
+      if (match) {
+        setSelectedSkill(toSkillDetail(match));
+        return;
+      }
+      if (tabSet.includes("skills")) {
+        setTab("skills");
+        setQuery(name);
+      }
+    },
+    [skills, tabSet],
+  );
+
   return (
     <section className="plugins-view flex min-h-0 flex-1 flex-col bg-[var(--bg-base)]">
       <div className="border-b border-[var(--border-hairline)] px-4 py-3 sm:px-6">
@@ -344,6 +379,7 @@ export function PluginsView({
               onToggleRole={toggleRole}
               onOpenChat={onOpenChat}
               onOpenWorkflow={onOpenWorkflow}
+              onOpenSkill={openSkillByName}
             />
           ) : tab === "workflows" ? (
             <WorkflowsTab workflows={filteredWorkflows} loaded={workflowsLoaded} query={query} onClearQuery={() => setQuery("")} onOpenWorkflow={onOpenWorkflow} />
@@ -354,18 +390,7 @@ export function PluginsView({
               query={query}
               onClearQuery={() => setQuery("")}
               onCreateSkill={openCapabilities}
-              onSelectSkill={(skill) =>
-                setSelectedSkill({
-                  id: skill.id,
-                  name: skill.name,
-                  description: skill.description,
-                  version: skill.version,
-                  category: skill.kind,
-                  owner: skill.familiar,
-                  tags: skill.tags,
-                  source: skill.path,
-                })
-              }
+              onSelectSkill={(skill) => setSelectedSkill(toSkillDetail(skill))}
             />
           )}
         </div>
@@ -389,6 +414,7 @@ function RolesTab({
   onToggleRole,
   onOpenChat,
   onOpenWorkflow,
+  onOpenSkill,
 }: {
   roles: RoleEntry[];
   loaded: boolean;
@@ -398,6 +424,7 @@ function RolesTab({
   onToggleRole: (role: RoleEntry) => void;
   onOpenChat: () => void;
   onOpenWorkflow?: (id: string) => void;
+  onOpenSkill?: (name: string) => void;
 }) {
   if (!loaded) return <ListSkeleton />;
   if (roles.length === 0)
@@ -454,7 +481,13 @@ function RolesTab({
             </div>
 
             <dl className="mt-3 space-y-2">
-              <CapabilityRow label="Skills" items={role.skills} />
+              <CapabilityRow
+                label="Skills"
+                items={role.skills}
+                onOpen={onOpenSkill}
+                openHint="Open skill"
+                icon={ICONS.tabSkills}
+              />
               <CapabilityRow label="Tools" items={role.tools} />
               <CapabilityRow
                 label="Workflows"
@@ -475,11 +508,13 @@ function CapabilityRow({
   items,
   onOpen,
   openHint,
+  icon = ICONS.workflowChip,
 }: {
   label: string;
   items: string[];
   onOpen?: (id: string) => void;
   openHint?: string;
+  icon?: IconName;
 }) {
   return (
     <div className="plugins-role-capability grid grid-cols-[78px_minmax(0,1fr)] items-start gap-2">
@@ -500,7 +535,7 @@ function CapabilityRow({
                   title={openHint ? `${openHint}: ${item}` : item}
                   className="plugins-role-chip plugins-role-chip--action focus-ring inline-flex items-center gap-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2 py-1 text-[11px] text-[var(--text-primary)] hover:border-[var(--border-strong)] hover:text-[var(--accent-text)]"
                 >
-                  <Icon name={ICONS.workflowChip} width={10} aria-hidden />
+                  <Icon name={icon} width={10} aria-hidden />
                   {item}
                 </button>
               ) : (


### PR DESCRIPTION
## What

On a role card in the Roles tab, **Workflow** chips were already clickable (they open the workflow), but **Skills** chips were inert static text. Now clicking a Skills chip opens that skill's detail drawer — the same drawer you get from the Skills tab — so the role → capability map is actually navigable.

- Resolves the chip's name against the scanned local skills (`/api/skills/local`) and opens the detail drawer.
- Unknown / not-yet-loaded skill → falls back to the Skills tab, pre-filtered to that name.
- **Tools** chips stay inert — there's no Tools surface to navigate to.

## How

- `plugins-view.tsx`: extract the `LocalSkillEntry → SkillDetailEntry` mapping into a shared `toSkillDetail()` helper (reused by the Skills tab and the chips); add an `openSkillByName()` callback threaded to `RolesTab` as `onOpenSkill`; wire the Skills `CapabilityRow` with `onOpen`/`openHint`/`icon`. `CapabilityRow` gains a configurable chip `icon` so skills show a sparkle and workflows keep their lightning.

## Verification

- `pnpm typecheck` clean, `pnpm test:app` → 339 files pass, `pnpm build` green.
- Live (route-mocked matching role+skill): clicking the Skills chip opened the detail drawer for "library-curation" (owner · skill · v1.0.0, description, tag, assigned-to list); the card showed 2 action chips (skill + workflow), Tools inert. Screenshot confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)