### PR TITLE
feat(settings): use the full pane width instead of a narrow centered column

### DIFF
--- a/src/components/settings-shell-polish.test.ts
+++ b/src/components/settings-shell-polish.test.ts
@@ -115,4 +115,6 @@ assert.match(
   "the custom-theme reset button names the theme it resets",
 );
 
+assert.match(source, /<div className="max-w-none space-y-6">/, "settings pages fill the full pane width (no narrow max-w-2xl column on desktop)");
+
 console.log("settings-shell-polish.test.ts OK");

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -1239,7 +1239,7 @@ function AboutSection() {
 
 function SettingsPage({ title, description, children }: { title: string; description?: string; children: React.ReactNode }) {
   return (
-    <div className="mx-auto max-w-2xl space-y-6">
+    <div className="max-w-none space-y-6">
       <div>
         <h1 className="text-[18px] font-semibold text-[var(--text-primary)]">{title}</h1>
         {description && <p className="mt-1 text-[12px] text-[var(--text-muted)]">{description}</p>}


### PR DESCRIPTION
Every settings page was wrapped in `mx-auto max-w-2xl` (~672px centered), so on desktop most of the settings pane sat empty. The settings pane already provides its own padding (`px-4` / `md:px-8`), so this drops the width cap and lets the content fill the available width.

One-line change in the shared `SettingsPage` primitive (applies to all settings pages). Guard added to `settings-shell-polish.test.ts`; settings tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)