### PR TITLE
perf(library): virtualize off-screen doc rows with content-visibility

### DIFF
--- a/src/components/library-polish.test.ts
+++ b/src/components/library-polish.test.ts
@@ -685,3 +685,10 @@ assert.doesNotMatch(
   /@media \(max-width: 767px\) \{[\s\S]*?\.library-rail-item\s*\{[^}]*border-radius:\s*999px;/,
   "Mobile Library tabs must not render as oversized pill tabs",
 );
+
+// Long doc lists virtualize off-screen rows via content-visibility (perf).
+assert.match(
+  libraryCss,
+  /\.library-doclist-item \{[\s\S]*?content-visibility:\s*auto;[\s\S]*?contain-intrinsic-size:/,
+  "library doc rows skip off-screen rendering via content-visibility",
+);

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -699,6 +699,11 @@
 }
 
 .library-doclist-item {
+  /* Skip rendering off-screen rows; the auto intrinsic-size caches each row's
+     real height after first paint, so scrolling never jumps. The rows are
+     self-contained (no fixed/portaled descendants), so containment is safe. */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 64px;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: start;


### PR DESCRIPTION
The library doc list renders every row to the DOM. Add `content-visibility: auto` to `.library-doclist-item` so the browser skips layout/paint for off-screen rows — the same technique already proven on chat turns (`.cave-linear-turn`).

- `contain-intrinsic-size: auto 64px` caches each row's real height after first paint, so scrolling doesn't jump.
- Verified the rows are **self-contained** — no Popover / `createPortal` / `position:fixed` descendants (count 0) — so containment won't clip an overlay (the trap from the chat-artifact fix).
- **Not** applied to the chat session list, which is drag-and-drop sortable (content-visibility would feed wrong rects to dnd-kit's measurement).

Caveat: this is a *visual/rendering* optimization. With no stable dev server this session I verified it by reasoning + a source guard rather than eyeballing — the conservative `auto` intrinsic-size means no visual change during normal scrolling. Easy to revert if anything looks off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)