### PR TITLE
feat(theme): expose the desktop theme via /api/theme (cross-device sync enabler)

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -109,6 +109,7 @@ const contracts: RouteContract[] = [
   { route: "/skills/eval-loop/[familiarId]/run", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
   { route: "/skills/local", methods: ["GET"], kind: "json" },
   { route: "/skills", methods: ["GET"], kind: "json" },
+  { route: "/theme", methods: ["GET", "PUT"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/vault", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
   { route: "/voice/session", methods: ["POST"], kind: "json", readsJson: true },
   { route: "/voice/transcript", methods: ["POST"], kind: "json", readsJson: true },

--- a/src/app/api/theme/route.ts
+++ b/src/app/api/theme/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+
+import { loadTheme, saveTheme } from "@/lib/server/theme-store";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const theme = await loadTheme();
+  return NextResponse.json({ ok: true, theme });
+}
+
+export async function PUT(req: Request) {
+  let body: { themeId?: unknown; mode?: unknown; tokens?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 });
+  }
+  if (!body || typeof body.themeId !== "string") {
+    return NextResponse.json({ ok: false, error: "themeId required" }, { status: 400 });
+  }
+  const theme = await saveTheme(body);
+  return NextResponse.json({ ok: true, theme });
+}

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -617,6 +617,38 @@ function applyMode(mode: Mode) {
   localStorage.setItem(COVEN_MODE_KEY, mode);
 }
 
+// Color tokens mirrored to the daemon so other clients (e.g. the iOS app over
+// Tailscale) can match the desktop theme via GET /api/theme.
+const THEME_SYNC_KEYS = [
+  "--bg-base", "--bg-raised", "--bg-elevated",
+  "--text-primary", "--text-secondary", "--text-muted",
+  "--border-hairline", "--accent-presence",
+] as const;
+
+function persistThemeTokens() {
+  if (typeof window === "undefined") return;
+  try {
+    const html = document.documentElement;
+    const cs = getComputedStyle(html);
+    const tokens: Record<string, string> = {};
+    for (const key of THEME_SYNC_KEYS) {
+      const value = cs.getPropertyValue(key).trim();
+      if (value) tokens[key] = value;
+    }
+    void fetch("/api/theme", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        themeId: html.getAttribute("data-theme") ?? "coven",
+        mode: html.getAttribute("data-mode") ?? "dark",
+        tokens,
+      }),
+    }).catch(() => {});
+  } catch {
+    /* best-effort sync; never block the UI */
+  }
+}
+
 function applyCustomVars(cssVars: CustomThemeData["cssVars"], mode: Mode) {
   const html = document.documentElement;
   html.setAttribute("data-theme", "custom");
@@ -817,6 +849,12 @@ function AppearanceSection() {
   const [activeTheme, setActiveTheme] = useState<ActiveTheme>("coven");
   const [mode, setMode] = useState<Mode>("dark");
   const [customData, setCustomData] = useState<CustomThemeData | null>(null);
+
+  // Mirror the active theme + resolved tokens to the daemon on change (and mount)
+  // so cross-device clients can read it. Best-effort; failures are swallowed.
+  useEffect(() => {
+    persistThemeTokens();
+  }, [activeTheme, mode, customData]);
   const [importUrl, setImportUrl] = useState("");
   const [importing, setImporting] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);

--- a/src/lib/server/theme-store.ts
+++ b/src/lib/server/theme-store.ts
@@ -1,0 +1,56 @@
+// Persists the desktop's active theme + resolved color tokens to
+// ~/.coven/cave-theme.json so other clients (the iOS app over Tailscale)
+// can read it from GET /api/theme. Fixed filename — no user-controlled path.
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { homedir } from "node:os";
+
+const THEME_PATH = path.join(homedir(), ".coven", "cave-theme.json");
+
+export type ThemeSnapshot = {
+  themeId: string;
+  mode: string;
+  tokens: Record<string, string>;
+  updatedAt: string;
+};
+
+const DEFAULT_SNAPSHOT: ThemeSnapshot = { themeId: "coven", mode: "dark", tokens: {}, updatedAt: "" };
+
+function sanitizeTokens(input: unknown): Record<string, string> {
+  if (!input || typeof input !== "object") return {};
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    if (typeof key === "string" && key.startsWith("--") && typeof value === "string" && value.length <= 64) {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+export async function loadTheme(): Promise<ThemeSnapshot> {
+  try {
+    const parsed = JSON.parse(await readFile(THEME_PATH, "utf8")) as Partial<ThemeSnapshot>;
+    return {
+      themeId: typeof parsed.themeId === "string" ? parsed.themeId : DEFAULT_SNAPSHOT.themeId,
+      mode: typeof parsed.mode === "string" ? parsed.mode : DEFAULT_SNAPSHOT.mode,
+      tokens: sanitizeTokens(parsed.tokens),
+      updatedAt: typeof parsed.updatedAt === "string" ? parsed.updatedAt : "",
+    };
+  } catch {
+    return DEFAULT_SNAPSHOT;
+  }
+}
+
+export async function saveTheme(input: { themeId?: unknown; mode?: unknown; tokens?: unknown }): Promise<ThemeSnapshot> {
+  const snap: ThemeSnapshot = {
+    themeId: typeof input.themeId === "string" && input.themeId ? input.themeId : DEFAULT_SNAPSHOT.themeId,
+    mode: typeof input.mode === "string" && input.mode ? input.mode : DEFAULT_SNAPSHOT.mode,
+    tokens: sanitizeTokens(input.tokens),
+    updatedAt: new Date().toISOString(),
+  };
+  await mkdir(path.dirname(THEME_PATH), { recursive: true });
+  const tmp = THEME_PATH + ".tmp";
+  await writeFile(tmp, JSON.stringify(snap, null, 2), "utf8");
+  await rename(tmp, THEME_PATH);
+  return snap;
+}


### PR DESCRIPTION
The desktop/web half of "desktop theme → iOS" (Task C). The iOS app already reads the desktop's `/api` over Tailscale, but the theme lived only in browser localStorage and wasn't reachable by any client.

## What
- **`src/lib/server/theme-store.ts`** — `load/saveTheme({themeId, mode, tokens})` → `~/.coven/cave-theme.json` (fixed path, atomic write, token sanitization).
- **`src/app/api/theme/route.ts`** — `GET` serves the snapshot; `PUT` persists it (invalid-JSON guarded).
- **`settings-shell`** — on theme/mode/custom change (and mount), reads the **resolved** CSS color tokens via `getComputedStyle` and `PUT`s them. Best-effort; never blocks the UI.
- **api-contracts manifest** updated; route validated by `api-contracts.test.ts`.

## Contract (for the iOS side)
`GET /api/theme` → `{ ok, theme: { themeId, mode, tokens: { "--bg-base": "#…", "--bg-raised", "--bg-elevated", "--text-primary", "--text-secondary", "--text-muted", "--border-hairline", "--accent-presence" }, updatedAt } }`

## Scope note
This is the **web/daemon enabler only**. The iOS consumption (fetch `/api/theme`, build a native SwiftUI palette from the tokens, apply app-wide) is **net-new native work in the coordinated iOS app (#1365)** and is filed as a separate issue with this exact contract — deliberately not attempted here to avoid blind cross-session work on the Swift app.

Tests: api-contracts + settings (shell-polish / appearance / fonts) + tests-wired all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)