### PR TITLE
feat(roles): "Open chat" starts a chat with that role's familiar

### DIFF
--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -58,7 +58,7 @@ function toSkillDetail(skill: LocalSkillEntry): SkillDetailEntry {
 }
 
 type Props = {
-  onOpenChat: () => void;
+  onOpenChat: (familiarId: string) => void;
   onOpenWorkflow?: (id: string) => void;
   onCreateSkill?: () => void;
   familiars?: FamiliarForSkill[];
@@ -422,7 +422,7 @@ function RolesTab({
   onClearQuery: () => void;
   busyRoleKey: string | null;
   onToggleRole: (role: RoleEntry) => void;
-  onOpenChat: () => void;
+  onOpenChat: (familiarId: string) => void;
   onOpenWorkflow?: (id: string) => void;
   onOpenSkill?: (name: string) => void;
 }) {
@@ -472,7 +472,7 @@ function RolesTab({
                 </button>
                 <button
                   type="button"
-                  onClick={onOpenChat}
+                  onClick={() => onOpenChat(role.familiar)}
                   className="focus-ring rounded-md bg-[var(--text-primary)] px-3 py-1.5 text-[12px] text-[var(--bg-base)]"
                 >
                   Open chat

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1744,7 +1744,7 @@ export function Workspace() {
         initialTab={mode === "capabilities" ? "capabilities" : "roles"}
         activeHarness={active?.harness ?? null}
         familiars={resolvedFamiliars}
-        onOpenChat={() => setMode("chat")}
+        onOpenChat={(familiarId) => startFamiliarChat(familiarId)}
         onOpenWorkflow={(id) => { setWorkflowDeepLink(id); setMode("workflows"); }}
         onCreateSkill={() => setMode("capabilities")}
       />


### PR DESCRIPTION
## What

The role-card **"Open chat"** button was wired to `() => setMode("chat")` — it just flipped to the chat surface and **dropped the role**. Clicking it on the Librarian card behaved identically to the Copywriter card: you landed in a generic chat with whatever familiar was already active. The primary CTA on every role card ignored which role you clicked.

Now "Open chat" starts a fresh chat **with that role's familiar**.

## How

Thread the role's familiar through `onOpenChat(familiarId)` and route it to `startFamiliarChat` — the same path the command palette's new-chat intent already uses (sets the active familiar, queues a new chat, switches to chat mode). Four-line change across `plugins-view.tsx` (signature + button) and `workspace.tsx` (handler).

## Verification

- `pnpm typecheck` clean, `pnpm test:app` → 339 files pass, `pnpm build` green.
- Live (route-mocked Librarian→sage, Copywriter→charm): clicking "Open chat" on the Copywriter card opened a new chat scoped to **Charm** (header "Charm · claude", composer "Message Charm…"). Screenshot confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)