### PR TITLE
feat(ios): add a mobile-optimized Read tab for the library reading list

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/ReadingItem.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/ReadingItem.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// One entry in the Cave library's reading list — the data behind the Read tab.
+/// Mirrors `LibraryReadingItem` (src/lib/library-types.ts). Items are created on
+/// the desktop (e.g. `/save <url> reading`); the phone reads and curates them.
+///
+/// `status` and `sourceType` are decoded as raw strings (BoardCard-style) so an
+/// unexpected value from a newer desktop never fails the whole decode.
+struct ReadingItem: Identifiable, Codable, Hashable {
+    let id: String
+    var title: String
+    var url: String?
+    var author: String?
+    var statusRaw: String
+    var sourceTypeRaw: String
+    var progress: Double?
+    var notes: String?
+    var tags: [String]?
+    var addedAt: String?
+    var finishedAt: String?
+    var familiar: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, title, url, author
+        case statusRaw = "status"
+        case sourceTypeRaw = "sourceType"
+        case progress, notes, tags, addedAt, finishedAt, familiar
+    }
+
+    var status: ReadingStatus { ReadingStatus(lenient: statusRaw) }
+    var sourceType: ReadingSourceType { ReadingSourceType(raw: sourceTypeRaw) }
+    var tagList: [String] { tags ?? [] }
+
+    /// The link, if it's a usable web URL.
+    var link: URL? {
+        guard let url, let u = URL(string: url),
+              let scheme = u.scheme?.lowercased(), scheme == "http" || scheme == "https"
+        else { return nil }
+        return u
+    }
+
+    /// Bare host for the byline, e.g. "arxiv.org".
+    var domain: String? {
+        link?.host.map { $0.hasPrefix("www.") ? String($0.dropFirst(4)) : $0 }
+    }
+
+    var addedDate: Date? { addedAt.flatMap(ReadingDates.parse) }
+
+    var progressPercent: Int? { progress.map { Int($0.rounded()) } }
+}
+
+/// Where an item came from / how to read it. Unknown → `.other`.
+enum ReadingSourceType: String, CaseIterable {
+    case article, paper, book, thread, video, other
+
+    init(raw: String) { self = ReadingSourceType(rawValue: raw.lowercased()) ?? .other }
+
+    var label: String {
+        switch self {
+        case .article: return "Article"
+        case .paper: return "Paper"
+        case .book: return "Book"
+        case .thread: return "Thread"
+        case .video: return "Video"
+        case .other: return "Link"
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .article: return "newspaper"
+        case .paper: return "graduationcap"
+        case .book: return "book"
+        case .thread: return "bubble.left.and.text.bubble.right"
+        case .video: return "play.rectangle"
+        case .other: return "doc.text"
+        }
+    }
+}
+
+/// Reading progress lifecycle. Legacy `"read"` folds to `.done`; unknown →
+/// `.wantToRead` (matches the web list's normalisation).
+enum ReadingStatus: String, CaseIterable, Identifiable {
+    case wantToRead = "want-to-read"
+    case reading
+    case done
+    case abandoned
+
+    var id: String { rawValue }
+
+    init(lenient raw: String) {
+        if raw == "read" { self = .done; return }
+        self = ReadingStatus(rawValue: raw) ?? .wantToRead
+    }
+
+    var label: String {
+        switch self {
+        case .wantToRead: return "Want to read"
+        case .reading: return "Reading"
+        case .done: return "Read"
+        case .abandoned: return "Abandoned"
+        }
+    }
+
+    /// Short form for compact filter chips and badges.
+    var chipLabel: String {
+        switch self {
+        case .wantToRead: return "Want"
+        case .reading: return "Reading"
+        case .done: return "Read"
+        case .abandoned: return "Done-ish"
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .wantToRead: return "bookmark"
+        case .reading: return "book"
+        case .done: return "checkmark.circle.fill"
+        case .abandoned: return "xmark.bin"
+        }
+    }
+}
+
+/// ISO-8601 parsing that tolerates fractional seconds (the store writes
+/// `…789Z`) and plain second precision.
+enum ReadingDates {
+    private static let withFraction: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    private static let plain = ISO8601DateFormatter()
+
+    static func parse(_ s: String) -> Date? {
+        withFraction.date(from: s) ?? plain.date(from: s)
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -234,6 +234,48 @@ struct CaveClient {
         return try JSONDecoder().decode(RouteLinkResult.self, from: data)
     }
 
+    // MARK: - Reading list (library)
+
+    private struct ReadingListResponse: Decodable { var items: [ReadingItem] }
+    private struct ReadingItemResponse: Decodable { var ok: Bool; var item: ReadingItem? }
+
+    /// `GET /api/library/reading` — the reading list, newest first (server-sorted).
+    func reading() async throws -> [ReadingItem] {
+        let req = try request("api/library/reading")
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        do {
+            return try JSONDecoder().decode(ReadingListResponse.self, from: data).items
+        } catch {
+            throw CaveError.decoding(String(describing: error))
+        }
+    }
+
+    private struct ReadingPatch: Encodable {
+        var id: String
+        var status: String
+        var progress: Double?   // synthesised Encodable omits this when nil
+    }
+
+    /// `PATCH /api/library/reading` — change an item's status (and optionally
+    /// progress). Returns the server's updated item.
+    @discardableResult
+    func updateReading(id: String, status: ReadingStatus, progress: Double? = nil) async throws -> ReadingItem? {
+        let payload = try JSONEncoder().encode(ReadingPatch(id: id, status: status.rawValue, progress: progress))
+        let req = try request("api/library/reading", method: "PATCH", body: payload)
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        return try? JSONDecoder().decode(ReadingItemResponse.self, from: data).item
+    }
+
+    /// `DELETE /api/library/reading?id=…` — remove an item.
+    func deleteReading(id: String) async throws {
+        let escaped = id.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? id
+        let req = try request("api/library/reading?id=\(escaped)", method: "DELETE")
+        let (_, resp) = try await session.data(for: req)
+        try Self.check(resp)
+    }
+
     // MARK: - Helpers
 
     private static func check(_ resp: URLResponse) throws {

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -3,7 +3,7 @@ import Observation
 
 /// The two bottom tabs. Lifted out of the view so slash commands (`/board`,
 /// `/chats`) can drive tab selection from anywhere.
-enum AppTab: String { case chats, tasks }
+enum AppTab: String { case chats, read, tasks }
 
 /// A transient confirmation banner shown over the chat after a command runs.
 struct ToastMessage: Identifiable, Equatable {
@@ -71,6 +71,12 @@ final class AppModel {
     var tasksError: String?
     var tasksLoaded = false
 
+    // MARK: - Reading list
+
+    var reading: [ReadingItem] = []
+    var readingError: String?
+    var readingLoaded = false
+
     var client: CaveClient? {
         guard let connection else { return nil }
         return CaveClient(connection: connection)
@@ -95,6 +101,55 @@ final class AppModel {
             tasksError = error.localizedDescription
         }
         tasksLoaded = true
+    }
+
+    // MARK: - Reading list actions
+
+    func loadReading() async {
+        guard let client else { return }
+        do {
+            reading = try await client.reading()
+            readingError = nil
+        } catch {
+            readingError = error.localizedDescription
+        }
+        readingLoaded = true
+    }
+
+    /// Optimistically set an item's status, then reconcile with the server's
+    /// echoed item (it also stamps `finishedAt` on transition to done).
+    func setReadingStatus(_ item: ReadingItem, _ status: ReadingStatus) async {
+        guard let client else { return }
+        let previous = reading
+        apply(id: item.id) { $0.statusRaw = status.rawValue }
+        do {
+            if let updated = try await client.updateReading(id: item.id, status: status) {
+                apply(id: item.id) { $0 = updated }
+            }
+        } catch {
+            reading = previous
+            readingError = error.localizedDescription
+        }
+    }
+
+    /// Remove an item, optimistically; restore on failure.
+    func deleteReading(_ item: ReadingItem) async {
+        guard let client else { return }
+        let previous = reading
+        reading.removeAll { $0.id == item.id }
+        do {
+            try await client.deleteReading(id: item.id)
+        } catch {
+            reading = previous
+            readingError = error.localizedDescription
+        }
+    }
+
+    private func apply(id: String, _ mutate: (inout ReadingItem) -> Void) {
+        guard let idx = reading.firstIndex(where: { $0.id == id }) else { return }
+        var item = reading[idx]
+        mutate(&item)
+        reading[idx] = item
     }
 
     // MARK: - Connection lifecycle

--- a/apps/ios/CovenCave/CovenCave/Views/ReadingView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ReadingView.swift
@@ -79,6 +79,9 @@ struct ReadingView: View {
             .padding(.horizontal, 16)
             .padding(.vertical, 10)
         }
+        // A horizontal ScrollView reports a flexible (≈zero) ideal height, so
+        // without a fixed height it collapses inside a VStack / safeAreaInset.
+        .frame(height: 56)
         .background(.bar)
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/ReadingView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ReadingView.swift
@@ -1,0 +1,316 @@
+import SwiftUI
+
+/// The Read tab — a mobile-first reading list over the Cave library's `reading`
+/// section. Filter by status, search, then tap to read in-app (Safari Reader).
+/// Swipe to mark read or remove; long-press for the full set of actions.
+struct ReadingView: View {
+    @Environment(AppModel.self) private var app
+    @State private var filter: ReadingFilter = .all
+    @State private var query = ""
+    @State private var reader: ReaderLink?
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if app.client == nil {
+                    notConnected
+                } else if !app.readingLoaded && app.reading.isEmpty {
+                    ProgressView().controlSize(.large)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    listBody
+                }
+            }
+            .navigationTitle("Reading")
+            .searchable(text: $query, prompt: "Search titles, authors, tags")
+            .refreshable { await app.loadReading() }
+            .task { if !app.readingLoaded { await app.loadReading() } }
+            .sheet(item: $reader) { link in
+                SafariReaderView(url: link.url).ignoresSafeArea()
+            }
+        }
+    }
+
+    // MARK: - Body
+
+    private var listBody: some View {
+        Group {
+            if visible.isEmpty {
+                emptyState
+            } else {
+                List {
+                    ForEach(visible) { item in
+                        Button { open(item) } label: { ReadingCard(item: item) }
+                            .buttonStyle(.plain)
+                            .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                Button(role: .destructive) { remove(item) } label: {
+                                    Label("Remove", systemImage: "trash")
+                                }
+                            }
+                            .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                                leadingSwipe(item)
+                            }
+                            .contextMenu { contextMenu(item) }
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+        // Pin the filter chips above the list (and empty state) with their
+        // natural height — a horizontal ScrollView inside a VStack next to a
+        // greedy List collapses to zero height.
+        .safeAreaInset(edge: .top, spacing: 0) { filterBar }
+    }
+
+    // MARK: - Filter chips
+
+    private var filterBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                chip(.all, "All", "tray.full")
+                chip(.status(.wantToRead), ReadingStatus.wantToRead.chipLabel, ReadingStatus.wantToRead.symbol)
+                chip(.status(.reading), ReadingStatus.reading.chipLabel, ReadingStatus.reading.symbol)
+                chip(.status(.done), ReadingStatus.done.chipLabel, ReadingStatus.done.symbol)
+                if count(.status(.abandoned)) > 0 {
+                    chip(.status(.abandoned), "Abandoned", ReadingStatus.abandoned.symbol)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+        }
+        .background(.bar)
+    }
+
+    private func chip(_ value: ReadingFilter, _ label: String, _ symbol: String) -> some View {
+        let selected = filter == value
+        let n = count(value)
+        return Button {
+            withAnimation(.snappy(duration: 0.18)) { filter = value }
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: symbol).font(.caption2)
+                Text(label).font(.subheadline.weight(.medium))
+                if n > 0 {
+                    Text("\(n)")
+                        .font(.caption2.weight(.semibold).monospacedDigit())
+                        .foregroundStyle(selected ? Color.accentColor : .secondary)
+                }
+            }
+            .padding(.horizontal, 13).padding(.vertical, 7)
+            .background(selected ? Color.accentColor.opacity(0.16) : Color(.secondarySystemBackground),
+                        in: Capsule())
+            .foregroundStyle(selected ? Color.accentColor : .primary)
+            .overlay(Capsule().strokeBorder(selected ? Color.accentColor.opacity(0.4) : .clear, lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Swipe / context actions
+
+    @ViewBuilder private func leadingSwipe(_ item: ReadingItem) -> some View {
+        if item.status == .done {
+            Button { setStatus(item, .wantToRead) } label: {
+                Label("Unread", systemImage: "arrow.uturn.backward")
+            }
+            .tint(.orange)
+        } else {
+            Button { setStatus(item, .done) } label: {
+                Label("Read", systemImage: "checkmark")
+            }
+            .tint(.green)
+        }
+    }
+
+    @ViewBuilder private func contextMenu(_ item: ReadingItem) -> some View {
+        if let link = item.link {
+            Button { reader = ReaderLink(url: link) } label: {
+                Label("Read now", systemImage: "book")
+            }
+            ShareLink(item: link) { Label("Share", systemImage: "square.and.arrow.up") }
+            Button { UIPasteboard.general.url = link } label: {
+                Label("Copy link", systemImage: "doc.on.doc")
+            }
+        }
+        Divider()
+        ForEach(ReadingStatus.allCases) { status in
+            Button { setStatus(item, status) } label: {
+                Label(status.label, systemImage: item.status == status ? "checkmark" : status.symbol)
+            }
+        }
+        Divider()
+        Button(role: .destructive) { remove(item) } label: {
+            Label("Remove", systemImage: "trash")
+        }
+    }
+
+    // MARK: - Empty / disconnected states
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label(query.isEmpty ? "Nothing here yet" : "No matches",
+                  systemImage: query.isEmpty ? "books.vertical" : "magnifyingglass")
+        } description: {
+            Text(emptyDescription)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var emptyDescription: String {
+        if !query.isEmpty { return "Try a different search." }
+        switch filter {
+        case .all:
+            return "Save articles to your reading list from the desktop — or in chat with “/save <url> reading”."
+        case .status(let s):
+            return "Nothing marked “\(s.label)”."
+        }
+    }
+
+    private var notConnected: some View {
+        ContentUnavailableView {
+            Label("Not connected", systemImage: "wifi.slash")
+        } description: {
+            Text("Connect to your desktop to see your reading list.")
+        }
+    }
+
+    // MARK: - Derived data
+
+    private var visible: [ReadingItem] {
+        let base: [ReadingItem]
+        switch filter {
+        case .all: base = app.reading
+        case .status(let s): base = app.reading.filter { $0.status == s }
+        }
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let searched = q.isEmpty ? base : base.filter { item in
+            item.title.lowercased().contains(q)
+                || (item.author?.lowercased().contains(q) ?? false)
+                || (item.domain?.lowercased().contains(q) ?? false)
+                || item.tagList.joined(separator: " ").lowercased().contains(q)
+        }
+        return searched.sorted { ($0.addedDate ?? .distantPast) > ($1.addedDate ?? .distantPast) }
+    }
+
+    private func count(_ value: ReadingFilter) -> Int {
+        switch value {
+        case .all: return app.reading.count
+        case .status(let s): return app.reading.filter { $0.status == s }.count
+        }
+    }
+
+    // MARK: - Actions
+
+    private func open(_ item: ReadingItem) {
+        if let link = item.link {
+            reader = ReaderLink(url: link)
+        } else {
+            app.showToast("No link to open", systemImage: "link.badge.plus", style: .warning)
+        }
+    }
+
+    private func setStatus(_ item: ReadingItem, _ status: ReadingStatus) {
+        Task {
+            await app.setReadingStatus(item, status)
+            app.showToast("Marked “\(status.label)”", systemImage: status.symbol, style: .success)
+        }
+    }
+
+    private func remove(_ item: ReadingItem) {
+        Task {
+            await app.deleteReading(item)
+            app.showToast("Removed from reading", systemImage: "trash", style: .info)
+        }
+    }
+}
+
+/// All / by-status filter selector.
+enum ReadingFilter: Hashable {
+    case all
+    case status(ReadingStatus)
+}
+
+/// A single reading-list row: type glyph, title, byline, progress, meta.
+struct ReadingCard: View {
+    let item: ReadingItem
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            glyph
+            VStack(alignment: .leading, spacing: 5) {
+                Text(item.title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(3)
+                if let byline { Text(byline).font(.subheadline).foregroundStyle(.secondary).lineLimit(1) }
+                if item.status == .reading, let pct = item.progressPercent { progressBar(pct) }
+                metaRow
+            }
+        }
+        .padding(.vertical, 2)
+        .contentShape(Rectangle())
+    }
+
+    private var glyph: some View {
+        Image(systemName: item.sourceType.symbol)
+            .font(.system(size: 16, weight: .medium))
+            .foregroundStyle(Color.accentColor)
+            .frame(width: 38, height: 38)
+            .background(Color.accentColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private var byline: String? {
+        let parts = [item.author, item.domain].compactMap { $0 }.filter { !$0.isEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    private func progressBar(_ pct: Int) -> some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule().fill(Color.secondary.opacity(0.18))
+                Capsule().fill(Color.accentColor)
+                    .frame(width: max(4, geo.size.width * CGFloat(pct) / 100))
+            }
+        }
+        .frame(height: 4)
+        .padding(.top, 1)
+    }
+
+    private var metaRow: some View {
+        HStack(spacing: 6) {
+            statusBadge
+            ForEach(item.tagList.prefix(2), id: \.self) { tag in
+                Text("#\(tag)")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 4)
+            if let date = item.addedDate {
+                Text(date, format: .relative(presentation: .numeric))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    private var statusBadge: some View {
+        let status = item.status
+        return HStack(spacing: 3) {
+            Image(systemName: status.symbol).font(.system(size: 9))
+            Text(status.chipLabel).font(.caption2.weight(.medium))
+        }
+        .padding(.horizontal, 7).padding(.vertical, 2)
+        .background(badgeColor.opacity(0.15), in: Capsule())
+        .foregroundStyle(badgeColor)
+    }
+
+    private var badgeColor: Color {
+        switch item.status {
+        case .wantToRead: return .secondary
+        case .reading: return .accentColor
+        case .done: return .green
+        case .abandoned: return .orange
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -40,6 +40,9 @@ struct MainTabView: View {
             Tab("Chats", systemImage: "bubble.left.and.bubble.right.fill", value: AppTab.chats) {
                 ChatsHomeView()
             }
+            Tab("Read", systemImage: "books.vertical.fill", value: AppTab.read) {
+                ReadingView()
+            }
             Tab("Tasks", systemImage: "checklist", value: AppTab.tasks) {
                 TasksView()
             }

--- a/apps/ios/CovenCave/CovenCave/Views/SafariReaderView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SafariReaderView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+import SafariServices
+
+/// In-app reader: an `SFSafariViewController` that opens straight into Reader
+/// mode when the page supports it, for a clean, mobile-first reading view that
+/// never leaves the app.
+struct SafariReaderView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        let config = SFSafariViewController.Configuration()
+        config.entersReaderIfAvailable = true
+        config.barCollapsingEnabled = true
+        let controller = SFSafariViewController(url: url, configuration: config)
+        controller.dismissButtonStyle = .done
+        controller.preferredControlTintColor = UIColor.tintColor
+        return controller
+    }
+
+    func updateUIViewController(_ controller: SFSafariViewController, context: Context) {}
+}
+
+/// Identifiable URL wrapper so a tapped link can drive `.sheet(item:)`.
+struct ReaderLink: Identifiable, Equatable {
+    let id = UUID()
+    let url: URL
+}


### PR DESCRIPTION
## What

A new bottom tab — **Chats · Read · Tasks** — dedicated to reading your saved articles on the phone, backed by the Cave library's `reading` section (where `/save <url> reading` routes). Until now the reading list was desktop-only.

## Mobile-optimized reading

- **Status filter chips** — All / Want / Reading / Read (with live counts); an Abandoned chip appears only when relevant.
- **Search** across title, author, domain, and tags.
- **Scannable cards**, newest first: a source-type glyph (article/paper/book/thread/video), title, `author · domain` byline, a status badge, up to two tags, a progress bar while reading, and a relative saved-date.
- **Tap to read in-app** via `SFSafariViewController` with **Reader mode** on — a clean, distraction-free read that never leaves the app.
- **Swipe** to mark Read / Unread (leading) or Remove (trailing); **long-press** for the full set (status changes, Share, Copy link, Remove).
- **Pull-to-refresh**, plus tailored empty and disconnected states.

Status and delete are **optimistic with rollback** on failure, and reconcile against the server's echoed item (which also stamps `finishedAt` on completion).

## Files

- `Models/ReadingItem.swift` — `Decodable` mirror of `LibraryReadingItem`; status/sourceType decode as raw strings (BoardCard-style) so a newer desktop never breaks the decode; fractional-second ISO-8601 parsing; link/domain/progress helpers.
- `Views/ReadingView.swift` — the tab (filter chips, search, cards, swipe/context actions). Chips are pinned via `safeAreaInset` so they don't collapse next to the list.
- `Views/SafariReaderView.swift` — `SFSafariViewController` wrapper (Reader mode).
- `Networking/CaveClient.swift` — `reading()` GET, `updateReading()` PATCH, `deleteReading()` DELETE against `/api/library/reading`.
- `State/AppModel.swift` — `AppTab.read`; reading state + optimistic actions.
- `Views/RootView.swift` — the Read tab.

## Verification

- `xcodebuild` **BUILD SUCCEEDED** (iPhone 16 Pro sim).
- Launched against the **live library** — the tab renders all **22 real reading items** with source icons, domains (arxiv.org, github.com, addyosmani.com…), Want/Read badges, tags, and relative dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)