### PR TITLE
feat(sidebar): show running/failed status dots on the Recent list

### DIFF
--- a/src/components/recent-activity-rollup.tsx
+++ b/src/components/recent-activity-rollup.tsx
@@ -22,6 +22,10 @@ const POLL_MS = 15_000;
 const MAX_ROWS = 8;
 // Remember whether the roll-up is collapsed across reloads and remounts.
 const OPEN_STORAGE_KEY = "cave:recent-activity:open";
+// Only "notable" states get a status dot (running pulses, failed/queued/paused
+// tint); completed/idle sessions stay dotless so the list isn't speckled.
+// Mirrors the ⌘K palette + Projects-tab status dots.
+const NOTABLE_STATUS = new Set(["running", "failed", "queued", "paused"]);
 
 function projectLabel(root: string | undefined): string {
   if (!root) return "";
@@ -111,6 +115,7 @@ export function RecentActivityRollup({ activeSessionId, onOpenSession }: Props) 
             const add = s.diff?.additions ?? 0;
             const del = s.diff?.deletions ?? 0;
             const proj = projectLabel(s.project_root);
+            const showStatus = NOTABLE_STATUS.has(s.status);
             return (
               <li key={s.id}>
                 <button
@@ -120,6 +125,13 @@ export function RecentActivityRollup({ activeSessionId, onOpenSession }: Props) 
                   title={s.title}
                 >
                   <div className="recent-activity__row1">
+                    {showStatus ? (
+                      <span
+                        role="img"
+                        aria-label={`${s.status} session`}
+                        className={`recent-activity__status recent-activity__status--${s.status}`}
+                      />
+                    ) : null}
                     <span className="recent-activity__title">{s.title || "Untitled session"}</span>
                     {proj ? <span className="recent-activity__project">{proj}</span> : null}
                   </div>

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -963,6 +963,13 @@
 .recent-activity__card--active::before { content: ""; position: absolute; left: 0; top: 8px; bottom: 8px; width: 3px; border-radius: 0 3px 3px 0; background: var(--accent-presence); }
 .recent-activity__row1, .recent-activity__row2 { display: flex; align-items: center; justify-content: space-between; gap: 8px; min-width: 0; }
 .recent-activity__title { min-width: 0; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12.5px; font-weight: 550; color: var(--text-primary); }
+.recent-activity__status { flex-shrink: 0; width: 7px; height: 7px; border-radius: 999px; background: var(--text-muted); }
+.recent-activity__status--running { background: var(--color-success); animation: recent-activity-status-pulse 1.6s ease-in-out infinite; }
+.recent-activity__status--failed { background: var(--color-danger); }
+.recent-activity__status--queued { background: var(--color-warning); }
+.recent-activity__status--paused { background: var(--accent-presence-soft); }
+@keyframes recent-activity-status-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+@media (prefers-reduced-motion: reduce) { .recent-activity__status--running { animation: none; } }
 .recent-activity__project { flex-shrink: 0; max-width: 42%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 11px; color: var(--text-muted); }
 .recent-activity__model { display: inline-flex; align-items: center; gap: 5px; min-width: 0; color: var(--text-secondary); }
 .recent-activity__model-icon { flex-shrink: 0; opacity: 0.85; }


### PR DESCRIPTION
## What

The always-visible **Recent Activity** roll-up in the sidebar showed title / project / model / `+N −N` diff / time but **ignored `status`** — a currently-running agent or a failed session looked identical to a completed one. It's the one glanceable session list that didn't answer "is that still going / did it fail?"

Now each row carries a small status dot before the title: **running pulses green**, failed/queued/paused tint red/amber/soft-accent, completed and idle stay dotless.

## How

- `recent-activity-rollup.tsx`: a `NOTABLE_STATUS` set gates the dot; rendered as a `role="img"` span with an `aria-label` (e.g. "running session").
- `sidebar-minimal.css`: `.recent-activity__status` + per-status modifiers, a pulse keyframe, and a `prefers-reduced-motion` guard.

Reuses the exact pattern already shipped for the ⌘K palette (#1381) and Projects tab (#1117), so it's visually consistent — no new design vocabulary.

## Verification

- `pnpm typecheck` clean, `pnpm test:app` → 339 files pass, `pnpm build` green.
- Live (route-mocked running/failed/completed/paused sessions): dots resolve to running (green) / failed (red) / paused (soft) with completed dotless; aria-labels correct. Screenshot confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)