### PR TITLE
feat(ios): Canvas tab — generate & preview UI artifacts

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/CanvasArtifact.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/CanvasArtifact.swift
@@ -1,0 +1,295 @@
+import Foundation
+
+/// How an artifact's `code` should be previewed. A `react` artifact is a single
+/// default-exported component transpiled by the offline sandbox runtime; an
+/// `html` artifact is a self-contained document. Absent on older records ⇒ html.
+enum ArtifactKind: String, Codable {
+    case html
+    case react
+
+    var label: String { self == .react ? "React" : "HTML" }
+    var symbol: String { self == .react ? "atom" : "chevron.left.forwardslash.chevron.right" }
+}
+
+/// One Canvas artifact — a generated, self-contained UI document. Mirrors the
+/// web record persisted at `~/.coven/cave-canvas.json` via `/api/canvas`, so the
+/// JSON shape (and `kind` back-compat) matches the desktop exactly.
+struct CanvasArtifact: Identifiable, Codable, Hashable {
+    var id: String
+    /// Short human label, derived from the prompt.
+    var title: String
+    /// The natural-language description the user asked for.
+    var prompt: String
+    /// The HTML document or React component source rendered in the preview.
+    var code: String
+    /// How `code` previews. Absent in JSON ⇒ `.html` (back-compat).
+    var kind: ArtifactKind
+    /// ISO-8601 timestamps, kept as strings to round-trip the server record.
+    var createdAt: String
+    var updatedAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case id, title, prompt, code, kind, createdAt, updatedAt
+    }
+
+    init(id: String, title: String, prompt: String, code: String,
+         kind: ArtifactKind, createdAt: String, updatedAt: String) {
+        self.id = id
+        self.title = title
+        self.prompt = prompt
+        self.code = code
+        self.kind = kind
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        prompt = (try? c.decode(String.self, forKey: .prompt)) ?? ""
+        code = (try? c.decode(String.self, forKey: .code)) ?? ""
+        kind = (try? c.decode(ArtifactKind.self, forKey: .kind)) ?? .html
+        let decodedTitle = (try? c.decode(String.self, forKey: .title)) ?? ""
+        title = decodedTitle.isEmpty ? CanvasArtifact.titleFromPrompt(prompt) : decodedTitle
+        let created = (try? c.decode(String.self, forKey: .createdAt)) ?? ""
+        createdAt = created
+        updatedAt = (try? c.decode(String.self, forKey: .updatedAt)) ?? created
+    }
+
+    /// Best-effort parse of `updatedAt` for relative-time display.
+    var updatedDate: Date? { CanvasArtifact.isoFormatter.date(from: updatedAt) }
+
+    /// The framed document fed to a `WKWebView` preview (HTML or React).
+    var previewSrcDoc: String {
+        kind == .react ? CanvasArtifact.buildReactSrcDoc(code)
+                       : CanvasArtifact.buildPreviewSrcDoc(code)
+    }
+
+    // MARK: - Timestamps
+
+    static let isoFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    static func nowISO() -> String { isoFormatter.string(from: Date()) }
+}
+
+// MARK: - Pure helpers (port of src/lib/canvas-artifacts.ts + canvas-react-harness.ts)
+
+extension CanvasArtifact {
+    static let maxCodeChars = 200_000
+    private static let maxTitleChars = 60
+
+    /// A compact title from a prompt: first non-empty line, collapsed, clamped.
+    static func titleFromPrompt(_ prompt: String) -> String {
+        let firstLine = prompt
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .first(where: { !$0.isEmpty }) ?? "Untitled"
+        let collapsed = firstLine.replacingOccurrences(
+            of: "\\s+", with: " ", options: .regularExpression
+        ).trimmingCharacters(in: .whitespaces)
+        if collapsed.isEmpty { return "Untitled" }
+        if collapsed.count <= maxTitleChars { return collapsed }
+        return String(collapsed.prefix(maxTitleChars - 1)).trimmingCharacters(in: .whitespaces) + "…"
+    }
+
+    /// Clamp code to the storage cap, preserving the head of the document.
+    static func clampCode(_ code: String) -> String {
+        code.count > maxCodeChars ? String(code.prefix(maxCodeChars)) : code
+    }
+
+    /// True when `code` already looks like a full HTML document (vs a fragment).
+    static func isFullDocument(_ code: String) -> Bool {
+        matches(code, #"<html[\s>]"#) || matches(code, #"<!doctype html"#)
+    }
+
+    /// A single renderable artifact pulled from a familiar's chat response.
+    struct Extracted { let kind: ArtifactKind; let code: String }
+
+    /// Pull a renderable artifact out of a familiar's response and classify it.
+    /// A `tsx`/`jsx` fence ⇒ React; an `html` fence (or bare `<!doctype>`) ⇒
+    /// HTML; an untagged fence is classified by content. Nil ⇒ nothing renders.
+    static func extractArtifact(_ text: String) -> Extracted? {
+        guard !text.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
+
+        let fences = fencedBlocks(text)
+        if !fences.isEmpty {
+            if let react = fences.first(where: { isReactLang($0.lang) && !$0.code.isEmpty }) {
+                return Extracted(kind: .react, code: react.code)
+            }
+            if let html = fences.first(where: { isHtmlLang($0.lang) && !$0.code.isEmpty }) {
+                return Extracted(kind: .html, code: html.code)
+            }
+            let first = fences[0].code
+            if !first.isEmpty {
+                return Extracted(kind: looksLikeReact(first) ? .react : .html, code: first)
+            }
+        }
+
+        if let doc = bareDocument(text) { return Extracted(kind: .html, code: doc) }
+        return nil
+    }
+
+    // MARK: Preview framing
+
+    /// Frame artifact HTML for the preview. Full documents pass through; a bare
+    /// fragment is wrapped in a minimal document with neutral base styling.
+    static func buildPreviewSrcDoc(_ code: String) -> String {
+        if isFullDocument(code) { return code }
+        return """
+        <!doctype html>
+        <html lang="en">
+        <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <style>
+          :root { color-scheme: light dark; }
+          body { margin: 0; padding: 16px; font-family: system-ui, -apple-system, sans-serif; }
+        </style>
+        </head>
+        <body>\(code)</body>
+        </html>
+        """
+    }
+
+    /// Absolute paths to the offline sandbox runtime, resolved against the
+    /// preview's base URL (the Cave server) — same assets the desktop uses.
+    static let sandboxRuntimeSrc = "/sandbox/react-runtime.js"
+    static let sandboxTailwindSrc = "/sandbox/tailwind.js"
+
+    /// Neutralize `</script>` so component source can't break out of the tag.
+    static func escapeForScriptTag(_ code: String) -> String {
+        code.replacingOccurrences(
+            of: "</(script>)", with: "<\\/$1",
+            options: [.regularExpression, .caseInsensitive]
+        )
+    }
+
+    /// Frame React component source into a full preview document. Requires the
+    /// preview WKWebView's base URL to be the Cave server so `/sandbox/*` loads.
+    static func buildReactSrcDoc(_ code: String) -> String {
+        """
+        <!doctype html>
+        <html lang="en">
+        <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <style>
+          :root { color-scheme: light dark; }
+          body { margin: 0; font-family: system-ui, -apple-system, sans-serif; }
+        </style>
+        <script src="\(sandboxTailwindSrc)"></script>
+        </head>
+        <body>
+        <div id="root"></div>
+        <script type="text/jsx">\(escapeForScriptTag(code))</script>
+        <script src="\(sandboxRuntimeSrc)"></script>
+        </body>
+        </html>
+        """
+    }
+
+    // MARK: Prompts
+
+    /// The instruction wrapped around the user's description before it goes to
+    /// the familiar — constrains output to one self-contained document.
+    static func buildSketchPrompt(_ userPrompt: String) -> String {
+        let ask = userPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let body = ask.isEmpty ? "a simple example UI" : ask
+        return """
+        You are generating a UI for a live preview sandbox inside a design canvas.
+
+        Output EXACTLY ONE fenced code block and nothing else — no prose before or after.
+        Choose ONE of these two forms:
+
+        (A) A ```html block: a COMPLETE self-contained document starting with `<!doctype html>`,
+            with all CSS inlined in <style> and all JS inlined in <script>. No external files.
+
+        (B) A ```tsx block: a single React component, DEFAULT-EXPORTED and named `App`
+            (e.g. `export default function App() { … }`). React 19 and its hooks are available
+            as globals — use `React.useState`, or destructure `const { useState } = React`.
+            Do NOT write `import React`/`import ReactDOM` and do NOT load anything from a CDN.
+            Tailwind utility classes ARE available — style with `className="…"` (e.g. `flex gap-4 rounded-xl`)
+            and/or inline `style={{…}}`. Both work.
+
+        Prefer (B) tsx for interactive components; (A) html for static pages or plain markup.
+        It must render on its own with no network access. Make it polished and responsive.
+
+        Build this: \(body)
+        """
+    }
+
+    /// Prompt for iterating on an existing artifact: hand the familiar the
+    /// current document plus the change request, same one-document contract.
+    static func buildRefinePrompt(currentCode: String, changeRequest: String,
+                                  kind: ArtifactKind) -> String {
+        let ask = changeRequest.trimmingCharacters(in: .whitespacesAndNewlines)
+        let request = ask.isEmpty ? "improve it" : ask
+        let lang = kind == .react ? "tsx" : "html"
+        let noun = kind == .react ? "React component" : "document"
+        return """
+        \(buildSketchPrompt("Apply this change: \(request)"))
+
+        Modify the \(noun) below. Keep the same \(lang) form and return the FULL updated \(noun), not a diff:
+
+        ```\(lang)
+        \(currentCode.trimmingCharacters(in: .whitespacesAndNewlines))
+        ```
+        """
+    }
+
+    // MARK: - Private regex helpers
+
+    private struct Fence { let lang: String; let code: String }
+
+    private static func isReactLang(_ lang: String) -> Bool {
+        ["tsx", "jsx", "react", "javascriptreact", "typescriptreact"].contains(lang.lowercased())
+    }
+
+    private static func isHtmlLang(_ lang: String) -> Bool {
+        ["html", "htm", "markup", "xml"].contains(lang.lowercased())
+    }
+
+    private static func looksLikeReact(_ code: String) -> Bool {
+        if matches(code, #"<!doctype html"#) || matches(code, #"<html[\s>]"#) { return false }
+        return matches(code, #"\bexport\s+default\b"#)
+            || matches(code, #"\bfunction\s+App\b"#)
+            || matches(code, #"\buse(State|Effect|Ref|Memo|Callback)\b"#)
+    }
+
+    /// All fenced ```lang\n…``` blocks, in source order, trimmed.
+    private static func fencedBlocks(_ text: String) -> [Fence] {
+        let pattern = "```([\\w-]*)\\n([\\s\\S]*?)```"
+        guard let re = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let ns = text as NSString
+        return re.matches(in: text, range: NSRange(location: 0, length: ns.length)).compactMap { m in
+            let lang = ns.substring(with: m.range(at: 1)).trimmingCharacters(in: .whitespaces)
+            let code = ns.substring(with: m.range(at: 2)).trimmingCharacters(in: .whitespacesAndNewlines)
+            return Fence(lang: lang, code: code)
+        }
+    }
+
+    /// First bare `<!doctype html>…</html>` (or `<html>…</html>`) span, if any.
+    private static func bareDocument(_ text: String) -> String? {
+        for pattern in [#"<!doctype html[\s\S]*</html>"#, #"<html[\s\S]*</html>"#] {
+            if let re = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) {
+                let ns = text as NSString
+                if let m = re.firstMatch(in: text, range: NSRange(location: 0, length: ns.length)) {
+                    return ns.substring(with: m.range).trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func matches(_ text: String, _ pattern: String) -> Bool {
+        guard let re = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return false
+        }
+        let ns = text as NSString
+        return re.firstMatch(in: text, range: NSRange(location: 0, length: ns.length)) != nil
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -276,6 +276,41 @@ struct CaveClient {
         try Self.check(resp)
     }
 
+    // MARK: - Canvas (generated artifacts)
+
+    private struct CanvasResponse: Decodable { var ok: Bool?; var artifacts: [CanvasArtifact]? }
+    private struct UpsertBody: Encodable { var artifact: CanvasArtifact }
+
+    /// `GET /api/canvas` — the saved canvas artifacts.
+    func canvasArtifacts() async throws -> [CanvasArtifact] {
+        let req = try request("api/canvas")
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        do {
+            return try JSONDecoder().decode(CanvasResponse.self, from: data).artifacts ?? []
+        } catch {
+            throw CaveError.decoding(String(describing: error))
+        }
+    }
+
+    /// `POST /api/canvas` — upsert an artifact; returns the full updated list.
+    @discardableResult
+    func saveCanvasArtifact(_ artifact: CanvasArtifact) async throws -> [CanvasArtifact] {
+        let payload = try JSONEncoder().encode(UpsertBody(artifact: artifact))
+        let req = try request("api/canvas", method: "POST", body: payload)
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        return (try? JSONDecoder().decode(CanvasResponse.self, from: data).artifacts) ?? []
+    }
+
+    /// `DELETE /api/canvas` — remove an artifact by id.
+    func deleteCanvasArtifact(id: String) async throws {
+        let payload = try JSONEncoder().encode(["id": id])
+        let req = try request("api/canvas", method: "DELETE", body: payload)
+        let (_, resp) = try await session.data(for: req)
+        try Self.check(resp)
+    }
+
     // MARK: - Helpers
 
     private static func check(_ resp: URLResponse) throws {

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -3,7 +3,7 @@ import Observation
 
 /// The two bottom tabs. Lifted out of the view so slash commands (`/board`,
 /// `/chats`) can drive tab selection from anywhere.
-enum AppTab: String { case chats, read, tasks }
+enum AppTab: String { case chats, canvas, read, tasks }
 
 /// A transient confirmation banner shown over the chat after a command runs.
 struct ToastMessage: Identifiable, Equatable {
@@ -76,6 +76,16 @@ final class AppModel {
     var reading: [ReadingItem] = []
     var readingError: String?
     var readingLoaded = false
+
+    // MARK: - Canvas (generated UI artifacts)
+
+    var canvasArtifacts: [CanvasArtifact] = []
+    var canvasError: String?
+    var canvasLoaded = false
+    /// True while a generate/refine stream is in flight.
+    var isGeneratingCanvas = false
+    /// The familiar's reply text as it streams in (for the "sketching…" preview).
+    var canvasStreamText = ""
 
     var client: CaveClient? {
         guard let connection else { return nil }
@@ -150,6 +160,140 @@ final class AppModel {
         var item = reading[idx]
         mutate(&item)
         reading[idx] = item
+    }
+
+    // MARK: - Canvas actions
+
+    func loadCanvas() async {
+        guard let client else { return }
+        do {
+            canvasArtifacts = sortedArtifacts(try await client.canvasArtifacts())
+            canvasError = nil
+        } catch {
+            canvasError = error.localizedDescription
+        }
+        canvasLoaded = true
+    }
+
+    /// Generate a new artifact from `prompt` via `familiarId`'s chat bridge,
+    /// extract the renderable document, persist it, and return it. Cancellation
+    /// (the caller cancelling its Task) aborts the stream and returns nil.
+    func generateArtifact(prompt: String, familiarId: String) async -> CanvasArtifact? {
+        guard let client else { return nil }
+        let userPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !userPrompt.isEmpty else { return nil }
+
+        isGeneratingCanvas = true
+        canvasStreamText = ""
+        canvasError = nil
+        defer { isGeneratingCanvas = false }
+
+        do {
+            let text = try await streamText(
+                CanvasArtifact.buildSketchPrompt(userPrompt),
+                familiarId: familiarId, client: client
+            )
+            guard !Task.isCancelled else { return nil }
+            guard let extracted = CanvasArtifact.extractArtifact(text) else {
+                canvasError = "The familiar didn’t return a renderable UI. Try rephrasing."
+                return nil
+            }
+            let now = CanvasArtifact.nowISO()
+            let artifact = CanvasArtifact(
+                id: UUID().uuidString,
+                title: CanvasArtifact.titleFromPrompt(userPrompt),
+                prompt: userPrompt,
+                code: CanvasArtifact.clampCode(extracted.code),
+                kind: extracted.kind,
+                createdAt: now, updatedAt: now
+            )
+            canvasArtifacts = sortedArtifacts(try await client.saveCanvasArtifact(artifact))
+            return artifact
+        } catch is CancellationError {
+            return nil
+        } catch {
+            canvasError = error.localizedDescription
+            return nil
+        }
+    }
+
+    /// Re-generate an existing artifact with a change request, keeping its id.
+    func refineArtifact(_ artifact: CanvasArtifact, changeRequest: String,
+                        familiarId: String) async -> CanvasArtifact? {
+        guard let client else { return nil }
+        let ask = changeRequest.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !ask.isEmpty else { return nil }
+
+        isGeneratingCanvas = true
+        canvasStreamText = ""
+        canvasError = nil
+        defer { isGeneratingCanvas = false }
+
+        do {
+            let text = try await streamText(
+                CanvasArtifact.buildRefinePrompt(
+                    currentCode: artifact.code, changeRequest: ask, kind: artifact.kind
+                ),
+                familiarId: familiarId, client: client
+            )
+            guard !Task.isCancelled else { return nil }
+            guard let extracted = CanvasArtifact.extractArtifact(text) else {
+                canvasError = "The familiar didn’t return an updated UI. Try rephrasing."
+                return nil
+            }
+            var updated = artifact
+            updated.code = CanvasArtifact.clampCode(extracted.code)
+            updated.kind = extracted.kind
+            updated.updatedAt = CanvasArtifact.nowISO()
+            canvasArtifacts = sortedArtifacts(try await client.saveCanvasArtifact(updated))
+            return updated
+        } catch is CancellationError {
+            return nil
+        } catch {
+            canvasError = error.localizedDescription
+            return nil
+        }
+    }
+
+    /// Remove an artifact, optimistically; restore on failure.
+    func deleteArtifact(_ artifact: CanvasArtifact) async {
+        guard let client else { return }
+        let previous = canvasArtifacts
+        canvasArtifacts.removeAll { $0.id == artifact.id }
+        do {
+            try await client.deleteCanvasArtifact(id: artifact.id)
+        } catch {
+            canvasArtifacts = previous
+            canvasError = error.localizedDescription
+        }
+    }
+
+    /// Consume the chat SSE stream for `prompt`, accumulating assistant text into
+    /// `canvasStreamText`. Throws on a stream `error` event with no text yet.
+    private func streamText(_ prompt: String, familiarId: String,
+                            client: CaveClient) async throws -> String {
+        var text = ""
+        let body = CaveClient.SendBody(familiarId: familiarId, prompt: prompt, sessionId: nil)
+        for try await event in client.sendStream(body) {
+            try Task.checkCancellation()
+            switch event {
+            case .assistantChunk(let chunk):
+                text += chunk
+                canvasStreamText = text
+            case .error(let message):
+                if text.isEmpty { throw CaveError.transport(message) }
+            default:
+                break
+            }
+        }
+        return text
+    }
+
+    /// Newest-updated first; the canvas gallery's stable order.
+    private func sortedArtifacts(_ artifacts: [CanvasArtifact]) -> [CanvasArtifact] {
+        artifacts.sorted {
+            ($0.updatedDate ?? .distantPast) > ($1.updatedDate ?? .distantPast)
+        }
     }
 
     // MARK: - Connection lifecycle

--- a/apps/ios/CovenCave/CovenCave/Views/ArtifactDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ArtifactDetailView.swift
@@ -1,0 +1,151 @@
+import SwiftUI
+
+/// Full-screen view of a single Canvas artifact: a live, interactive preview
+/// with a refine composer at the bottom and share/copy/delete in the toolbar.
+/// Refining re-generates the document in place, keeping the artifact's identity.
+struct ArtifactDetailView: View {
+    @Environment(AppModel.self) private var app
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var current: CanvasArtifact
+    let familiarId: String
+
+    @State private var refinePrompt = ""
+    @State private var showCode = false
+    @State private var refineTask: Task<Void, Never>?
+    @FocusState private var refineFocused: Bool
+
+    init(artifact: CanvasArtifact, familiarId: String) {
+        _current = State(initialValue: artifact)
+        self.familiarId = familiarId
+    }
+
+    var body: some View {
+        ZStack {
+            if showCode { codeView } else { previewView }
+            if app.isGeneratingCanvas { refiningOverlay }
+        }
+        .navigationTitle(current.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar { toolbarContent }
+        .safeAreaInset(edge: .bottom) { refineBar }
+        .onDisappear { refineTask?.cancel() }
+    }
+
+    // MARK: - Preview / code
+
+    private var previewView: some View {
+        ArtifactWebView(artifact: current,
+                        serverBaseURL: app.connection?.baseURL,
+                        interactive: true)
+            .background(Color(.systemBackground))
+            .ignoresSafeArea(edges: .horizontal)
+    }
+
+    private var codeView: some View {
+        ScrollView([.vertical, .horizontal]) {
+            Text(current.code)
+                .font(.system(size: 12, design: .monospaced))
+                .textSelection(.enabled)
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(Color(.secondarySystemBackground))
+    }
+
+    // MARK: - Refining overlay
+
+    private var refiningOverlay: some View {
+        VStack(spacing: 12) {
+            ProgressView().controlSize(.large)
+            Text("Refining…").font(.subheadline.weight(.semibold))
+            Button(role: .destructive) { refineTask?.cancel() } label: {
+                Text("Cancel")
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding(28)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .shadow(radius: 20)
+    }
+
+    // MARK: - Toolbar
+
+    @ToolbarContentBuilder private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
+            Menu {
+                Toggle(isOn: $showCode) {
+                    Label("View code", systemImage: "chevron.left.forwardslash.chevron.right")
+                }
+                Button { UIPasteboard.general.string = current.code } label: {
+                    Label("Copy code", systemImage: "doc.on.doc")
+                }
+                ShareLink(item: current.code) {
+                    Label("Share code", systemImage: "square.and.arrow.up")
+                }
+                Divider()
+                Button(role: .destructive) { delete() } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+            } label: {
+                Image(systemName: "ellipsis.circle")
+            }
+        }
+    }
+
+    // MARK: - Refine bar
+
+    private var refineBar: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "wand.and.stars")
+                .foregroundStyle(.secondary)
+            TextField("Describe a change…", text: $refinePrompt, axis: .vertical)
+                .lineLimit(1...3)
+                .focused($refineFocused)
+                .disabled(app.isGeneratingCanvas)
+            Button {
+                refine()
+            } label: {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.title2)
+                    .foregroundStyle(canRefine ? Color.accentColor : Color.secondary)
+            }
+            .buttonStyle(.plain)
+            .disabled(!canRefine)
+        }
+        .padding(.horizontal, 14).padding(.vertical, 10)
+        .background(.bar)
+    }
+
+    // MARK: - Derived + actions
+
+    private var canRefine: Bool {
+        !app.isGeneratingCanvas
+            && !familiarId.isEmpty
+            && !refinePrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func refine() {
+        let ask = refinePrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !ask.isEmpty, !familiarId.isEmpty, !app.isGeneratingCanvas else { return }
+        refineFocused = false
+        refineTask?.cancel()
+        refineTask = Task {
+            if let updated = await app.refineArtifact(current, changeRequest: ask, familiarId: familiarId) {
+                current = updated
+                refinePrompt = ""
+                app.showToast("Updated", systemImage: "checkmark.circle.fill", style: .success)
+            } else if let error = app.canvasError {
+                app.showToast(error, systemImage: "exclamationmark.triangle.fill", style: .warning)
+            }
+        }
+    }
+
+    private func delete() {
+        Task {
+            await app.deleteArtifact(current)
+            app.showToast("Deleted", systemImage: "trash", style: .info)
+            dismiss()
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/ArtifactWebView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ArtifactWebView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+import WebKit
+
+/// Renders a Canvas artifact in a WKWebView. HTML artifacts load with an opaque
+/// origin (`baseURL: nil`) so they stay self-contained; React artifacts load
+/// against the Cave server base URL so the offline `/sandbox/*` runtime + the
+/// Tailwind engine resolve (the same assets the desktop preview uses).
+///
+/// Use `interactive: false` for gallery thumbnails — scrolling and touch are
+/// disabled so the card behaves like a static preview that the row tap owns.
+struct ArtifactWebView: UIViewRepresentable {
+    let artifact: CanvasArtifact
+    /// The Cave server base URL — required to preview React artifacts.
+    let serverBaseURL: URL?
+    var interactive: Bool = true
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.defaultWebpagePreferences.allowsContentJavaScript = true
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = context.coordinator
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.scrollView.backgroundColor = .clear
+        webView.scrollView.isScrollEnabled = interactive
+        webView.scrollView.bounces = interactive
+        if !interactive {
+            webView.isUserInteractionEnabled = false
+            webView.scrollView.contentInset = .zero
+        }
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        // Reload only when the rendered document actually changes (refine swaps
+        // the code in place) — avoids a flash on every SwiftUI update pass.
+        let doc = artifact.previewSrcDoc
+        let base = artifact.kind == .react ? serverBaseURL : nil
+        let signature = "\(base?.absoluteString ?? "")\u{1}\(doc.hashValue)"
+        guard context.coordinator.lastSignature != signature else { return }
+        context.coordinator.lastSignature = signature
+        webView.loadHTMLString(doc, baseURL: base)
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        var lastSignature: String?
+
+        // Keep the preview contained: the first load (about:blank → srcdoc) is
+        // allowed; afterwards, a user-driven navigation to a real URL opens in
+        // the system browser instead of replacing the preview.
+        nonisolated func webView(_ webView: WKWebView,
+                                 decidePolicyFor navigationAction: WKNavigationAction,
+                                 decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+            let url = navigationAction.request.url
+            let isExternalTap = navigationAction.navigationType == .linkActivated
+                && (url?.scheme == "http" || url?.scheme == "https")
+            if isExternalTap, let url {
+                decisionHandler(.cancel)
+                Task { @MainActor in await UIApplication.shared.open(url) }
+                return
+            }
+            decisionHandler(.allow)
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/CanvasView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/CanvasView.swift
@@ -1,0 +1,366 @@
+import SwiftUI
+
+/// The Canvas tab — generate self-contained UIs from a prompt and browse them
+/// as a live gallery. A pinned composer (prompt + familiar + quick-starts) sits
+/// above an adaptive grid of artifact cards, each a live preview. Tap a card to
+/// open it full-screen, where it can be refined, shared, or deleted.
+struct CanvasView: View {
+    @Environment(AppModel.self) private var app
+
+    @State private var prompt = ""
+    @State private var selectedFamiliarId: String?
+    @State private var genTask: Task<Void, Never>?
+    @State private var detail: CanvasArtifact?
+    @FocusState private var promptFocused: Bool
+
+    private let columns = [GridItem(.adaptive(minimum: 158), spacing: 12)]
+
+    /// One-tap starter prompts shown under the composer.
+    private let starters: [(label: String, symbol: String, prompt: String)] = [
+        ("Pricing page", "tag", "A modern SaaS pricing page with three tiers and a highlighted plan"),
+        ("To-do app", "checklist", "An interactive to-do list app where I can add, check off, and delete tasks"),
+        ("Sign-in", "person.crop.circle", "A polished centered sign-in card with email, password, and a submit button"),
+        ("Dashboard", "square.grid.2x2", "An analytics dashboard with stat cards and a simple bar chart"),
+        ("Hero", "sparkles", "An animated landing-page hero with a gradient background and a call-to-action"),
+    ]
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if app.client == nil {
+                    notConnected
+                } else if !app.canvasLoaded && app.canvasArtifacts.isEmpty {
+                    ProgressView().controlSize(.large)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    gallery
+                }
+            }
+            .toolbar(.hidden, for: .navigationBar)
+            .task { if !app.canvasLoaded { await app.loadCanvas() } }
+            .onAppear { if selectedFamiliarId == nil { selectedFamiliarId = app.familiars.first?.id } }
+            .navigationDestination(item: $detail) { artifact in
+                ArtifactDetailView(artifact: artifact, familiarId: generationFamiliarId)
+            }
+        }
+    }
+
+    // MARK: - Gallery
+
+    private var gallery: some View {
+        ScrollView {
+            LazyVStack(spacing: 16) {
+                if app.isGeneratingCanvas { generatingCard }
+                if app.canvasArtifacts.isEmpty && !app.isGeneratingCanvas {
+                    emptyState
+                } else {
+                    LazyVGrid(columns: columns, spacing: 12) {
+                        ForEach(app.canvasArtifacts) { artifact in
+                            artifactCard(artifact)
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                }
+            }
+            .padding(.top, 12)
+            .padding(.bottom, 28)
+        }
+        .scrollDismissesKeyboard(.interactively)
+        .refreshable { await app.loadCanvas() }
+        .safeAreaInset(edge: .top, spacing: 0) { header }
+    }
+
+    // MARK: - Header + composer
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Canvas")
+                    .font(.largeTitle.weight(.bold))
+                Spacer()
+                if !app.canvasArtifacts.isEmpty {
+                    Text("^[\(app.canvasArtifacts.count) artifact](inflect: true)")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            composer
+            starterBar
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+        .padding(.bottom, 12)
+        .background(.bar)
+    }
+
+    private var composer: some View {
+        VStack(spacing: 10) {
+            TextField("Describe a UI to generate…", text: $prompt, axis: .vertical)
+                .lineLimit(1...4)
+                .focused($promptFocused)
+                .submitLabel(.return)
+                .font(.body)
+            HStack(spacing: 10) {
+                familiarPicker
+                Spacer(minLength: 8)
+                generateButton
+            }
+        }
+        .padding(12)
+        .background(Color(.secondarySystemBackground),
+                    in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .strokeBorder(promptFocused ? Color.accentColor.opacity(0.5) : .clear, lineWidth: 1)
+        )
+    }
+
+    private var familiarPicker: some View {
+        Menu {
+            ForEach(app.familiars) { familiar in
+                Button {
+                    selectedFamiliarId = familiar.id
+                } label: {
+                    Label(familiar.displayName,
+                          systemImage: selectedFamiliarId == familiar.id ? "checkmark" : "")
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                if let familiar = currentFamiliar {
+                    AvatarView(familiar: familiar,
+                               url: app.client?.avatarURL(for: familiar), size: 22)
+                    Text(familiar.displayName)
+                        .font(.subheadline.weight(.medium))
+                        .lineLimit(1)
+                } else {
+                    Image(systemName: "wand.and.stars")
+                    Text("Familiar").font(.subheadline.weight(.medium))
+                }
+                Image(systemName: "chevron.down")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(.secondary)
+            }
+            .foregroundStyle(.primary)
+            .padding(.vertical, 5).padding(.horizontal, 9)
+            .background(Color(.tertiarySystemBackground), in: Capsule())
+        }
+        .disabled(app.familiars.isEmpty || app.isGeneratingCanvas)
+    }
+
+    private var generateButton: some View {
+        Button {
+            generate(prompt)
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "sparkles")
+                Text("Generate").fontWeight(.semibold)
+            }
+            .font(.subheadline)
+            .padding(.vertical, 8).padding(.horizontal, 14)
+            .background(canGenerate ? Color.accentColor : Color.gray.opacity(0.3),
+                        in: Capsule())
+            .foregroundStyle(canGenerate ? Color.white : Color.secondary)
+        }
+        .buttonStyle(.plain)
+        .disabled(!canGenerate)
+    }
+
+    private var starterBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(starters, id: \.label) { starter in
+                    Button {
+                        prompt = starter.prompt
+                        generate(starter.prompt)
+                    } label: {
+                        HStack(spacing: 5) {
+                            Image(systemName: starter.symbol).font(.caption2)
+                            Text(starter.label).font(.subheadline.weight(.medium))
+                        }
+                        .padding(.horizontal, 12).padding(.vertical, 7)
+                        .background(Color(.secondarySystemBackground), in: Capsule())
+                        .foregroundStyle(.primary)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(app.isGeneratingCanvas)
+                }
+            }
+            .padding(.vertical, 2)
+        }
+        // A horizontal ScrollView reports ≈zero ideal height and collapses inside
+        // a VStack without a fixed height.
+        .frame(height: 38)
+    }
+
+    // MARK: - Generating card
+
+    private var generatingCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 10) {
+                ProgressView().controlSize(.small)
+                Text("Sketching your UI…")
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                Button(role: .destructive) {
+                    genTask?.cancel()
+                } label: {
+                    Text("Cancel").font(.subheadline.weight(.medium))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.red)
+            }
+            if !app.canvasStreamText.isEmpty {
+                Text(streamTail)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .animation(.default, value: app.canvasStreamText)
+            }
+        }
+        .padding(14)
+        .background(Color.accentColor.opacity(0.08),
+                    in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(Color.accentColor.opacity(0.25), lineWidth: 1)
+        )
+        .padding(.horizontal, 16)
+    }
+
+    /// The trailing slice of the streaming reply — the part most likely showing
+    /// live progress, kept short so it doesn't dominate the card.
+    private var streamTail: String {
+        let text = app.canvasStreamText
+        return text.count > 220 ? "…" + text.suffix(220) : text
+    }
+
+    // MARK: - Artifact card
+
+    private func artifactCard(_ artifact: CanvasArtifact) -> some View {
+        Button {
+            promptFocused = false
+            detail = artifact
+        } label: {
+            VStack(alignment: .leading, spacing: 0) {
+                ArtifactWebView(artifact: artifact,
+                                serverBaseURL: app.connection?.baseURL,
+                                interactive: false)
+                    .frame(height: 150)
+                    .frame(maxWidth: .infinity)
+                    .background(Color(.systemBackground))
+                    .clipped()
+                    .overlay(alignment: .topTrailing) { kindBadge(artifact.kind) }
+                    .allowsHitTesting(false)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(artifact.title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    if let date = artifact.updatedDate {
+                        Text(date, format: .relative(presentation: .numeric))
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                .padding(10)
+            }
+            .background(Color(.secondarySystemBackground),
+                        in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .strokeBorder(Color.primary.opacity(0.06), lineWidth: 1)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .contextMenu { cardMenu(artifact) }
+    }
+
+    private func kindBadge(_ kind: ArtifactKind) -> some View {
+        HStack(spacing: 3) {
+            Image(systemName: kind.symbol).font(.system(size: 8, weight: .bold))
+            Text(kind.label).font(.system(size: 9, weight: .bold))
+        }
+        .padding(.horizontal, 6).padding(.vertical, 3)
+        .background(.ultraThinMaterial, in: Capsule())
+        .padding(6)
+    }
+
+    @ViewBuilder private func cardMenu(_ artifact: CanvasArtifact) -> some View {
+        Button { detail = artifact } label: {
+            Label("Open", systemImage: "arrow.up.left.and.arrow.down.right")
+        }
+        Button { UIPasteboard.general.string = artifact.code } label: {
+            Label("Copy code", systemImage: "doc.on.doc")
+        }
+        ShareLink(item: artifact.code) { Label("Share code", systemImage: "square.and.arrow.up") }
+        Divider()
+        Button(role: .destructive) {
+            Task {
+                await app.deleteArtifact(artifact)
+                app.showToast("Deleted", systemImage: "trash", style: .info)
+            }
+        } label: {
+            Label("Delete", systemImage: "trash")
+        }
+    }
+
+    // MARK: - Empty / disconnected
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("Nothing on the canvas yet", systemImage: "wand.and.stars")
+        } description: {
+            Text("Describe a UI above — a pricing page, a to-do app, a dashboard — and a familiar will sketch it live.")
+        }
+        .frame(maxWidth: .infinity, minHeight: 320)
+    }
+
+    private var notConnected: some View {
+        ContentUnavailableView {
+            Label("Not connected", systemImage: "wifi.slash")
+        } description: {
+            Text("Connect to your desktop to generate and browse canvas artifacts.")
+        }
+    }
+
+    // MARK: - Derived + actions
+
+    private var currentFamiliar: Familiar? {
+        guard let id = selectedFamiliarId ?? app.familiars.first?.id else { return nil }
+        return app.familiar(id)
+    }
+
+    private var generationFamiliarId: String {
+        selectedFamiliarId ?? app.familiars.first?.id ?? ""
+    }
+
+    private var canGenerate: Bool {
+        !app.isGeneratingCanvas
+            && !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !app.familiars.isEmpty
+    }
+
+    private func generate(_ text: String) {
+        let toSend = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !toSend.isEmpty, !app.isGeneratingCanvas else { return }
+        guard let familiarId = selectedFamiliarId ?? app.familiars.first?.id else {
+            app.showToast("No familiar available", systemImage: "wand.and.stars", style: .warning)
+            return
+        }
+        promptFocused = false
+        genTask?.cancel()
+        genTask = Task {
+            if let artifact = await app.generateArtifact(prompt: toSend, familiarId: familiarId) {
+                prompt = ""
+                detail = artifact
+            } else if let error = app.canvasError {
+                app.showToast(error, systemImage: "exclamationmark.triangle.fill", style: .warning)
+            }
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -40,6 +40,9 @@ struct MainTabView: View {
             Tab("Chats", systemImage: "bubble.left.and.bubble.right.fill", value: AppTab.chats) {
                 ChatsHomeView()
             }
+            Tab("Canvas", systemImage: "wand.and.stars", value: AppTab.canvas) {
+                CanvasView()
+            }
             Tab("Read", systemImage: "books.vertical.fill", value: AppTab.read) {
                 ReadingView()
             }


### PR DESCRIPTION
## What

Brings the desktop **Canvas (Sketch)** experience to the native iOS app as a new third bottom tab. Describe a UI in natural language → a familiar generates one self-contained document → it renders live in a WKWebView gallery, where it can be refined, shared, or deleted.

## UX

- **Composer** (pinned): multiline prompt field, familiar picker chip, a `sparkles` **Generate** button, and a row of one-tap starters (Pricing page, To-do app, Sign-in, Dashboard, Hero).
- **Live generation**: a "Sketching your UI…" card streams the familiar's reply as it arrives, with Cancel.
- **Gallery**: adaptive 2-column grid of artifact cards, each a live (non-interactive) preview with an HTML/React badge and relative time; tap to open, long-press for copy/share/delete.
- **Detail**: full-screen interactive preview + an in-place **refine** composer ("Describe a change…"), a view-code toggle, copy/share code, and delete.

## How it works

- Reuses the existing streaming `/api/chat/send` bridge (Cave has no server LLM — generation routes through the daemon agent) and the `/api/canvas` REST store, matching the desktop contract exactly.
- `CanvasArtifact` is a Swift port of `src/lib/canvas-artifacts.ts` + `canvas-react-harness.ts` (fence extraction, kind classification, sketch/refine prompts, preview framing).
- `ArtifactWebView`: HTML artifacts load with an opaque origin (`baseURL: nil`, self-contained); React artifacts load against the Cave server base URL so the offline `/sandbox/react-runtime.js` + Tailwind engine resolve.

## Verification

- `xcodebuild` for the iOS Simulator: **BUILD SUCCEEDED**.
- Installed on the iPhone 16 Pro simulator against a live Cave server — the Canvas tab appears in the tab bar and connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)