### PR TITLE
feat(ios): Settings tab + iMessage-style bottom search/compose on Chats

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -3,7 +3,7 @@ import Observation
 
 /// The bottom tabs. Lifted out of the view so slash commands (`/board`,
 /// `/chats`) can drive tab selection from anywhere.
-enum AppTab: String { case chats, canvas, read, tasks, dev }
+enum AppTab: String { case chats, canvas, read, tasks, settings }
 
 /// A transient confirmation banner shown over the chat after a command runs.
 struct ToastMessage: Identifiable, Equatable {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct ChatsHomeView: View {
     @Environment(AppModel.self) private var app
     @State private var showNewChat = false
-    @State private var showSettings = false
+    @State private var query = ""
     @State private var path: [ChatThread] = []
 
     var body: some View {
@@ -11,6 +11,8 @@ struct ChatsHomeView: View {
             Group {
                 if app.threads.isEmpty {
                     emptyState
+                } else if filteredThreads.isEmpty {
+                    ContentUnavailableView.search(text: query)
                 } else {
                     threadList
                 }
@@ -19,26 +21,14 @@ struct ChatsHomeView: View {
             .navigationDestination(for: ChatThread.self) { thread in
                 ChatView(thread: thread)
             }
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button { showSettings = true } label: {
-                        Image(systemName: "gearshape")
-                    }
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button { showNewChat = true } label: {
-                        Image(systemName: "square.and.pencil")
-                    }
-                }
-            }
+            // Search + compose live in a floating bottom bar (iMessage-style),
+            // not the top toolbar; Settings is now its own tab.
+            .safeAreaInset(edge: .bottom) { bottomBar }
             .sheet(isPresented: $showNewChat) {
                 NewChatView { thread in
                     showNewChat = false
                     path.append(thread)
                 }
-            }
-            .sheet(isPresented: $showSettings) {
-                SettingsView()
             }
             .refreshable { await app.loadFamiliars() }
             .onAppear(perform: openDeepLinkedThread)
@@ -62,7 +52,7 @@ struct ChatsHomeView: View {
 
     private var threadList: some View {
         List {
-            ForEach(app.threads) { thread in
+            ForEach(filteredThreads) { thread in
                 Button { path.append(thread) } label: {
                     ThreadRow(thread: thread)
                 }
@@ -70,10 +60,63 @@ struct ChatsHomeView: View {
                 .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
             }
             .onDelete { offsets in
-                offsets.map { app.threads[$0] }.forEach(app.deleteThread)
+                offsets.map { filteredThreads[$0] }.forEach(app.deleteThread)
             }
         }
         .listStyle(.plain)
+    }
+
+    /// Threads matching the search query (title, last-message preview, or a
+    /// participating familiar's name). Empty query shows everything.
+    private var filteredThreads: [ChatThread] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !q.isEmpty else { return app.threads }
+        return app.threads.filter { thread in
+            if thread.title.lowercased().contains(q) { return true }
+            if let last = thread.messages.last?.text, last.lowercased().contains(q) { return true }
+            return thread.familiarIds.compactMap(app.familiar).contains {
+                $0.displayName.lowercased().contains(q)
+            }
+        }
+    }
+
+    /// Floating bottom bar: a search field beside a circular compose button,
+    /// styled after iOS Messages.
+    private var bottomBar: some View {
+        HStack(spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("Search", text: $query)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                if !query.isEmpty {
+                    Button {
+                        query = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Clear search")
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 11)
+            .background(.regularMaterial, in: Capsule())
+
+            Button {
+                showNewChat = true
+            } label: {
+                Image(systemName: "square.and.pencil")
+                    .font(.system(size: 19, weight: .medium))
+                    .frame(width: 50, height: 50)
+                    .background(.regularMaterial, in: Circle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("New chat")
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
     }
 
     private var emptyState: some View {

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -49,8 +49,8 @@ struct MainTabView: View {
             Tab("Tasks", systemImage: "checklist", value: AppTab.tasks) {
                 TasksView()
             }
-            Tab("Developer", systemImage: "chevron.left.forwardslash.chevron.right", value: AppTab.dev) {
-                DeveloperView()
+            Tab("Settings", systemImage: "gearshape.fill", value: AppTab.settings) {
+                SettingsView()
             }
         }
         // TabView wins a layout race at cold launch and resets its selection to

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -4,10 +4,24 @@ struct SettingsView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.dismiss) private var dismiss
     @State private var editingHost: String = ""
+    @State private var showDeveloper = false
 
     var body: some View {
         NavigationStack {
             Form {
+                Section {
+                    Button {
+                        showDeveloper = true
+                    } label: {
+                        Label("Developer", systemImage: "chevron.left.forwardslash.chevron.right")
+                            .foregroundStyle(.primary)
+                    }
+                } header: {
+                    Text("Tools")
+                } footer: {
+                    Text("Code browser, terminal, and GitHub.")
+                }
+
                 Section("Desktop") {
                     LabeledContent("Address") {
                         Text(app.connection?.host ?? "—")
@@ -45,12 +59,16 @@ struct SettingsView: View {
             }
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") { dismiss() }
-                }
-            }
             .onAppear { editingHost = app.connection?.host ?? "" }
+            // Developer (code/terminal/GitHub) was demoted from a tab; present it
+            // as a full-height sheet so its sub-views' own navigation stacks
+            // render cleanly. Wrapping it in another NavigationStack (e.g. for a
+            // push) would double-nest the nav bars; the sheet's grabber handles
+            // dismissal instead.
+            .sheet(isPresented: $showDeveloper) {
+                DeveloperView()
+                    .presentationDragIndicator(.visible)
+            }
         }
     }
 


### PR DESCRIPTION
## What

Two requested changes to the native iOS app:

### 1. Settings → its own tab
Previously Settings was a gear button in the Chats top toolbar (opening a sheet). It's now a proper **Settings** tab (`AppTab.settings` + a `Tab` in `MainTabView`). The gear button and the Settings sheet are removed from Chats, and `SettingsView`'s sheet-only "Done" button is dropped (it's a tab root now).

### 2. Bottom search + compose bar on the Chats list (iMessage-style)
Search and compose move from the top toolbar to a **floating bottom bar**: a translucent (`.regularMaterial`) rounded search pill beside a circular compose button — matching the iOS Messages layout. The top compose button is gone.

The search field actually filters the thread list (by title, last-message preview, or a participating familiar's name), with `ContentUnavailableView.search` for no matches.

## Verification

iOS Swift isn't compiled by the web CI checks, so I built it directly: `xcodegen generate` + `xcodebuild ... -destination 'generic/platform=iOS Simulator'` → **BUILD SUCCEEDED**. (A live screenshot needs a connected Cave server, since the tab UI only shows once connected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)