### PR TITLE
feat(ios): Developer tab — code browser/editor, terminal, GitHub

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/DevModels.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/DevModels.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+// Models backing the Developer tab: projects, the file tree, file contents,
+// code search, and GitHub activity. All mirror the desktop REST contracts the
+// web Code workspace already uses (/api/projects, /api/project-tree,
+// /api/project-file, /api/project/search, /api/github/*).
+
+// MARK: - Projects
+
+/// A configured project root (`GET /api/projects` → `{ projects: [...] }`).
+struct ProjectInfo: Codable, Identifiable, Hashable {
+    var id: String
+    var name: String
+    var root: String
+    var color: String?
+    var updatedAt: String?
+}
+
+struct ProjectsResponse: Decodable { var ok: Bool; var projects: [ProjectInfo] }
+
+// MARK: - File tree
+
+/// One entry in a project's file tree (`GET /api/project-tree`). `children` is
+/// present only for directories that were expanded server-side.
+struct TreeEntry: Codable, Identifiable, Hashable {
+    var name: String
+    var path: String
+    var isDir: Bool
+    var children: [TreeEntry]?
+
+    var id: String { path }
+}
+
+struct TreeResponse: Decodable { var ok: Bool; var entries: [TreeEntry]?; var error: String? }
+
+// MARK: - File contents
+
+/// A read file (`GET /api/project-file?path=`). Text files carry `content`;
+/// images carry a base64 `dataUrl`.
+struct FileContent: Decodable {
+    var ok: Bool
+    var kind: String?         // "text" | "image"
+    var content: String?
+    var dataUrl: String?
+    var mimeType: String?
+    var size: Int?
+    var error: String?
+
+    var isImage: Bool { kind == "image" }
+}
+
+struct FileWriteResponse: Decodable { var ok: Bool; var size: Int?; var error: String? }
+
+// MARK: - Code search
+
+struct SearchMatch: Decodable, Identifiable, Hashable {
+    var line: Int             // 1-based line number
+    var column: Int?
+    var preview: String       // matched line text
+    var id: Int { line }
+}
+
+/// One file group from `/api/project/search`. `path` is **relative** to the
+/// searched root, so absolute path = `root + "/" + path`.
+struct SearchFile: Decodable, Identifiable, Hashable {
+    var path: String
+    var matches: [SearchMatch]
+    var id: String { path }
+}
+
+struct SearchResponse: Decodable {
+    var ok: Bool
+    var repo: Bool?
+    var files: [SearchFile]?
+    var totalMatches: Int?
+    var truncated: Bool?
+    var error: String?
+}
+
+// MARK: - GitHub
+
+struct GitHubItem: Decodable, Identifiable, Hashable {
+    var kind: String          // "pr" | "issue" | "review_request" | "notification"
+    var id: String
+    var title: String
+    var repo: String
+    var number: Int?
+    var url: String
+    var state: String?
+    var updatedAt: String
+    var draft: Bool?
+    var labels: [String]?
+
+    var isPull: Bool { kind == "pr" || kind == "review_request" }
+}
+
+struct GitHubActivityResponse: Decodable {
+    var ok: Bool
+    var authed: Bool?
+    var login: String?
+    var items: [GitHubItem]?
+    var error: String?
+    var hint: String?
+}
+
+struct GitHubPerson: Decodable, Hashable {
+    var login: String
+    var avatarUrl: String?
+    var url: String?
+}
+
+struct GitHubLabel: Decodable, Hashable {
+    var name: String
+    var color: String
+}
+
+struct GitHubItemDetail: Decodable {
+    var ok: Bool
+    var title: String?
+    var number: Int?
+    var state: String?
+    var isPull: Bool?
+    var merged: Bool?
+    var draft: Bool?
+    var body: String?
+    var author: GitHubPerson?
+    var assignees: [GitHubPerson]?
+    var labels: [GitHubLabel]?
+    var createdAt: String?
+    var updatedAt: String?
+    var htmlUrl: String?
+    var comments: Int?
+    var error: String?
+}

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient+Dev.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient+Dev.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// Developer-tab REST calls (code browsing/editing, search, GitHub). Kept in
+/// its own extension so it stays self-contained: it builds requests straight
+/// from `connection.baseURL` (with proper query-item encoding) rather than the
+/// core client's path-only helper.
+extension CaveClient {
+    private var devSession: URLSession {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 25
+        config.waitsForConnectivity = false
+        return URLSession(configuration: config)
+    }
+
+    /// Build a request against `<base>/<path>` with optional query items.
+    private func devRequest(
+        _ path: String,
+        query: [URLQueryItem] = [],
+        method: String = "GET",
+        body: Data? = nil
+    ) throws -> URLRequest {
+        guard let base = connection.baseURL else { throw CaveError.notConfigured }
+        guard var comps = URLComponents(url: base.appendingPathComponent(path),
+                                        resolvingAgainstBaseURL: false) else {
+            throw CaveError.notConfigured
+        }
+        if !query.isEmpty { comps.queryItems = query }
+        guard let url = comps.url else { throw CaveError.notConfigured }
+        var req = URLRequest(url: url)
+        req.httpMethod = method
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let body {
+            req.httpBody = body
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        return req
+    }
+
+    private func devData(_ req: URLRequest) async throws -> Data {
+        let (data, resp) = try await devSession.data(for: req)
+        if let http = resp as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            // Many dev routes answer 4xx with a JSON `{ ok:false, error }` body;
+            // hand the body back so callers can decode the message.
+            return data
+        }
+        return data
+    }
+
+    private func devDecode<T: Decodable>(_ type: T.Type, _ data: Data) throws -> T {
+        do { return try JSONDecoder().decode(T.self, from: data) }
+        catch { throw CaveError.decoding(String(describing: error)) }
+    }
+
+    // MARK: - Projects
+
+    func projects() async throws -> [ProjectInfo] {
+        let data = try await devData(try devRequest("api/projects"))
+        return try devDecode(ProjectsResponse.self, data).projects
+    }
+
+    // MARK: - File tree
+
+    func projectTree(root: String, depth: Int = 1) async throws -> [TreeEntry] {
+        let req = try devRequest("api/project-tree", query: [
+            .init(name: "root", value: root),
+            .init(name: "depth", value: String(depth)),
+        ])
+        let decoded = try devDecode(TreeResponse.self, try await devData(req))
+        if let entries = decoded.entries { return entries }
+        throw CaveError.transport(decoded.error ?? "Couldn’t read the directory.")
+    }
+
+    // MARK: - File contents
+
+    func readFile(path: String) async throws -> FileContent {
+        let req = try devRequest("api/project-file", query: [.init(name: "path", value: path)])
+        return try devDecode(FileContent.self, try await devData(req))
+    }
+
+    @discardableResult
+    func writeFile(path: String, content: String) async throws -> Int {
+        let payload = try JSONEncoder().encode(["path": path, "content": content])
+        let req = try devRequest("api/project-file", method: "POST", body: payload)
+        let decoded = try devDecode(FileWriteResponse.self, try await devData(req))
+        if decoded.ok { return decoded.size ?? 0 }
+        throw CaveError.transport(decoded.error ?? "Save failed.")
+    }
+
+    // MARK: - Code search
+
+    func searchProject(root: String, query: String) async throws -> SearchResponse {
+        let req = try devRequest("api/project/search", query: [
+            .init(name: "root", value: root),
+            .init(name: "q", value: query),
+        ])
+        return try devDecode(SearchResponse.self, try await devData(req))
+    }
+
+    // MARK: - GitHub
+
+    func githubActivity() async throws -> GitHubActivityResponse {
+        try devDecode(GitHubActivityResponse.self,
+                      try await devData(try devRequest("api/github/activity")))
+    }
+
+    func githubItem(repo: String, number: Int) async throws -> GitHubItemDetail {
+        let req = try devRequest("api/github/item", query: [
+            .init(name: "repo", value: repo),
+            .init(name: "number", value: String(number)),
+        ])
+        return try devDecode(GitHubItemDetail.self, try await devData(req))
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift
@@ -34,6 +34,15 @@ struct CaveConnection: Codable, Equatable {
         return URL(string: "http://\(trimmed):3000")
     }
 
+    /// WebSocket base derived from `baseURL` (https→wss, http→ws). Used by the
+    /// Developer tab's terminal to reach `/api/pty-ws`.
+    var wsBaseURL: URL? {
+        guard let base = baseURL,
+              var comps = URLComponents(url: base, resolvingAgainstBaseURL: false) else { return nil }
+        comps.scheme = (comps.scheme == "https") ? "wss" : "ws"
+        return comps.url
+    }
+
     static let storageKey = "cave.connection.host"
 
     static func load() -> CaveConnection? {

--- a/apps/ios/CovenCave/CovenCave/Networking/PtyTerminal.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/PtyTerminal.swift
@@ -1,0 +1,231 @@
+import Foundation
+import Observation
+
+/// A live terminal session bridged over `/api/pty-ws`.
+///
+/// Wire protocol (binary frames, matching server.ts):
+///   server → client:  [0x01] + utf8 output  |  [0x02] + int32LE exit code
+///   client → server:  [0x03] + utf8 input   |  [0x04] + u16LE cols + u16LE rows
+///
+/// Output is run through a small line-discipline (`TerminalScreen`) that strips
+/// ANSI escapes and honours CR/BS so progress bars and prompts read correctly —
+/// it is not a full emulator, but it makes ordinary command output legible.
+@Observable
+@MainActor
+final class PtyTerminal {
+    private(set) var text = ""
+    private(set) var connected = false
+    private(set) var exited = false
+    private(set) var exitCode: Int32?
+    private(set) var error: String?
+
+    private var task: URLSessionWebSocketTask?
+    private var screen = TerminalScreen()
+    private var receiveLoop: Task<Void, Never>?
+
+    func connect(wsBase: URL, threadId: String, projectRoot: String?, cols: Int, rows: Int) {
+        disconnect()
+        screen = TerminalScreen()
+        text = ""
+        exited = false
+        exitCode = nil
+        error = nil
+
+        guard var comps = URLComponents(url: wsBase.appendingPathComponent("api/pty-ws"),
+                                        resolvingAgainstBaseURL: false) else {
+            error = "Bad terminal URL."
+            return
+        }
+        var items = [URLQueryItem(name: "threadId", value: threadId)]
+        if let projectRoot, !projectRoot.isEmpty {
+            items.append(URLQueryItem(name: "projectRoot", value: projectRoot))
+        }
+        comps.queryItems = items
+        guard let url = comps.url else { error = "Bad terminal URL."; return }
+
+        let session = URLSession(configuration: .default)
+        let ws = session.webSocketTask(with: url)
+        task = ws
+        ws.resume()
+        connected = true
+        sendResize(cols: cols, rows: rows)
+        startReceiving()
+    }
+
+    func disconnect() {
+        receiveLoop?.cancel()
+        receiveLoop = nil
+        task?.cancel(with: .goingAway, reason: nil)
+        task = nil
+        connected = false
+    }
+
+    // MARK: - Sending
+
+    func sendInput(_ string: String) {
+        guard let task else { return }
+        var frame = Data([0x03])
+        frame.append(Data(string.utf8))
+        task.send(.data(frame)) { _ in }
+    }
+
+    func sendResize(cols: Int, rows: Int) {
+        guard let task, cols > 0, rows > 0 else { return }
+        var frame = Data([0x04])
+        var c = UInt16(min(cols, 0xFFFF)).littleEndian
+        var r = UInt16(min(rows, 0xFFFF)).littleEndian
+        withUnsafeBytes(of: &c) { frame.append(contentsOf: $0) }
+        withUnsafeBytes(of: &r) { frame.append(contentsOf: $0) }
+        task.send(.data(frame)) { _ in }
+    }
+
+    // MARK: - Receiving
+
+    private func startReceiving() {
+        // The closure inherits this class's @MainActor isolation, so member
+        // access is synchronous; only `task.receive()` actually suspends.
+        receiveLoop = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self, let task = self.task else { break }
+                do {
+                    let message = try await task.receive()
+                    self.handle(message)
+                } catch {
+                    self.fail(error)
+                    break
+                }
+            }
+        }
+    }
+
+    private func handle(_ message: URLSessionWebSocketTask.Message) {
+        switch message {
+        case .data(let data):
+            handleFrame(data)
+        case .string(let s):
+            // Server speaks binary; tolerate stray text frames as raw output.
+            screen.feed(s)
+            text = screen.render()
+        @unknown default:
+            break
+        }
+    }
+
+    private func handleFrame(_ data: Data) {
+        guard let tag = data.first else { return }
+        switch tag {
+        case 0x01:
+            let payload = data.subdata(in: 1..<data.count)
+            screen.feed(String(decoding: payload, as: UTF8.self))
+            text = screen.render()
+        case 0x02:
+            if data.count >= 5 {
+                exitCode = data.subdata(in: 1..<5).withUnsafeBytes { $0.load(as: Int32.self) }
+            }
+            exited = true
+            connected = false
+        default:
+            break
+        }
+    }
+
+    private func fail(_ error: Error) {
+        // A clean close after exit is not an error worth surfacing.
+        if exited { return }
+        self.error = error.localizedDescription
+        connected = false
+    }
+}
+
+/// Minimal terminal line-discipline: strips ANSI/OSC escapes and applies CR,
+/// BS and NL so ordinary command output (and single-line progress redraws) read
+/// correctly. Not a grid emulator — no cursor addressing, colors, or scroll
+/// regions — but enough to make a phone terminal usable.
+struct TerminalScreen {
+    private var lines: [[Character]] = [[]]
+    private var cursor = 0          // column within the last line
+    private let maxLines = 4000
+
+    mutating func feed(_ raw: String) {
+        let cleaned = TerminalScreen.stripEscapes(raw)
+        for ch in cleaned {
+            switch ch {
+            case "\n":
+                lines.append([])
+                cursor = 0
+                trim()
+            case "\r":
+                cursor = 0
+            case "\u{08}":          // backspace
+                if cursor > 0 { cursor -= 1 }
+            case "\t":
+                let spaces = 4 - (cursor % 4)
+                for _ in 0..<spaces { put(" ") }
+            default:
+                if ch.isASCII && ch.asciiValue! < 0x20 { continue }  // drop other control chars
+                put(ch)
+            }
+        }
+    }
+
+    private mutating func put(_ ch: Character) {
+        var last = lines[lines.count - 1]
+        if cursor < last.count {
+            last[cursor] = ch
+        } else {
+            while last.count < cursor { last.append(" ") }
+            last.append(ch)
+        }
+        lines[lines.count - 1] = last
+        cursor += 1
+    }
+
+    private mutating func trim() {
+        if lines.count > maxLines {
+            lines.removeFirst(lines.count - maxLines)
+        }
+    }
+
+    func render() -> String {
+        lines.map { String($0) }.joined(separator: "\n")
+    }
+
+    /// Remove CSI (`ESC [ … letter`), OSC (`ESC ] … BEL/ST`) and other single
+    /// escape sequences, plus the standalone BEL.
+    static func stripEscapes(_ s: String) -> String {
+        var out = String.UnicodeScalarView()
+        let iter = Array(s.unicodeScalars)
+        var i = 0
+        let esc: Unicode.Scalar = "\u{1B}"
+        while i < iter.count {
+            let c = iter[i]
+            if c == esc, i + 1 < iter.count {
+                let n = iter[i + 1]
+                if n == "[" {                     // CSI: ESC [ params... final(0x40–0x7E)
+                    i += 2
+                    while i < iter.count {
+                        let v = iter[i].value
+                        i += 1
+                        if v >= 0x40 && v <= 0x7E { break }
+                    }
+                    continue
+                } else if n == "]" {              // OSC: ESC ] ... (BEL or ST)
+                    i += 2
+                    while i < iter.count {
+                        if iter[i] == "\u{07}" { i += 1; break }
+                        if iter[i] == esc, i + 1 < iter.count, iter[i + 1] == "\\" { i += 2; break }
+                        i += 1
+                    }
+                    continue
+                } else {                          // other 2-char escape
+                    i += 2
+                    continue
+                }
+            }
+            if c == "\u{07}" { i += 1; continue }  // bell
+            out.append(c)
+            i += 1
+        }
+        return String(out)
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -1,9 +1,9 @@
 import Foundation
 import Observation
 
-/// The two bottom tabs. Lifted out of the view so slash commands (`/board`,
+/// The bottom tabs. Lifted out of the view so slash commands (`/board`,
 /// `/chats`) can drive tab selection from anywhere.
-enum AppTab: String { case chats, canvas, read, tasks }
+enum AppTab: String { case chats, canvas, read, tasks, dev }
 
 /// A transient confirmation banner shown over the chat after a command runs.
 struct ToastMessage: Identifiable, Equatable {
@@ -87,6 +87,13 @@ final class AppModel {
     /// The familiar's reply text as it streams in (for the "sketching…" preview).
     var canvasStreamText = ""
 
+    // MARK: - Developer tab
+
+    /// Configured project roots, shared across the Code and Terminal surfaces.
+    var projects: [ProjectInfo] = []
+    var projectsError: String?
+    var projectsLoaded = false
+
     var client: CaveClient? {
         guard let connection else { return nil }
         return CaveClient(connection: connection)
@@ -124,6 +131,19 @@ final class AppModel {
             readingError = error.localizedDescription
         }
         readingLoaded = true
+    }
+
+    // MARK: - Developer tab actions
+
+    func loadProjects() async {
+        guard let client else { return }
+        do {
+            projects = try await client.projects()
+            projectsError = nil
+        } catch {
+            projectsError = error.localizedDescription
+        }
+        projectsLoaded = true
     }
 
     /// Optimistically set an item's status, then reconcile with the server's

--- a/apps/ios/CovenCave/CovenCave/Views/CodeBrowserView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/CodeBrowserView.swift
@@ -1,0 +1,244 @@
+import SwiftUI
+
+// Navigation values for the code browser's push stack.
+
+/// A directory level to drill into.
+struct DirNode: Hashable {
+    var path: String
+    var name: String
+    var searchRoot: String   // the project root, for project-wide search
+}
+
+/// A file to open in the editor.
+struct FileRef: Hashable {
+    var path: String
+    var name: String
+}
+
+/// Code section: pick a project, browse its tree, search it, open a file.
+struct CodeBrowserView: View {
+    @Environment(AppModel.self) private var app
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Projects")
+                .navigationDestination(for: DirNode.self) { node in
+                    DirectoryView(node: node)
+                }
+                .navigationDestination(for: FileRef.self) { file in
+                    CodeEditorView(path: file.path, name: file.name)
+                }
+                .refreshable { await app.loadProjects() }
+                .task { if !app.projectsLoaded { await app.loadProjects() } }
+        }
+    }
+
+    @ViewBuilder private var content: some View {
+        if !app.projectsLoaded {
+            ProgressView().controlSize(.large)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error = app.projectsError, app.projects.isEmpty {
+            ContentUnavailableView {
+                Label("Couldn’t load projects", systemImage: "exclamationmark.triangle")
+            } description: { Text(error) } actions: {
+                Button("Retry") { Task { await app.loadProjects() } }
+                    .buttonStyle(.borderedProminent)
+            }
+        } else if app.projects.isEmpty {
+            ContentUnavailableView {
+                Label("No projects", systemImage: "folder.badge.questionmark")
+            } description: {
+                Text("Add a project on the desktop and it’ll appear here.")
+            }
+        } else {
+            List(app.projects) { project in
+                NavigationLink(value: DirNode(path: project.root,
+                                              name: project.name,
+                                              searchRoot: project.root)) {
+                    HStack(spacing: 12) {
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(Color(hex: project.color) ?? .accentColor)
+                            .frame(width: 10, height: 28)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(project.name).font(.callout.weight(.medium))
+                            Text(project.root)
+                                .font(.caption2.monospaced())
+                                .foregroundStyle(.tertiary)
+                                .lineLimit(1)
+                                .truncationMode(.head)
+                        }
+                    }
+                }
+            }
+            .listStyle(.insetGrouped)
+        }
+    }
+}
+
+/// One directory level: lazy tree listing + project-wide search.
+struct DirectoryView: View {
+    @Environment(AppModel.self) private var app
+    let node: DirNode
+
+    @State private var entries: [TreeEntry] = []
+    @State private var loading = true
+    @State private var error: String?
+    @State private var query = ""
+    @State private var results: [SearchFile] = []
+    @State private var searching = false
+    @State private var searchTruncated = false
+
+    var body: some View {
+        Group {
+            if !query.trimmingCharacters(in: .whitespaces).isEmpty {
+                searchResults
+            } else {
+                tree
+            }
+        }
+        .navigationTitle(node.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .searchable(text: $query, prompt: "Search this project")
+        .task(id: query) { await runSearch() }
+        .task { await load() }
+    }
+
+    // MARK: Tree
+
+    @ViewBuilder private var tree: some View {
+        if loading {
+            ProgressView().controlSize(.large)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error {
+            ContentUnavailableView {
+                Label("Couldn’t open folder", systemImage: "exclamationmark.triangle")
+            } description: { Text(error) } actions: {
+                Button("Retry") { Task { await load() } }.buttonStyle(.borderedProminent)
+            }
+        } else if entries.isEmpty {
+            ContentUnavailableView("Empty folder", systemImage: "folder")
+        } else {
+            List(entries) { entry in
+                if entry.isDir {
+                    NavigationLink(value: DirNode(path: entry.path,
+                                                  name: entry.name,
+                                                  searchRoot: node.searchRoot)) {
+                        Label(entry.name, systemImage: "folder.fill")
+                            .foregroundStyle(.primary)
+                    }
+                } else {
+                    NavigationLink(value: FileRef(path: entry.path, name: entry.name)) {
+                        Label {
+                            Text(entry.name)
+                        } icon: {
+                            Image(systemName: fileIcon(entry.name))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+            .listStyle(.plain)
+        }
+    }
+
+    private func load() async {
+        guard let client = app.client else { return }
+        loading = true
+        do {
+            entries = try await client.projectTree(root: node.path, depth: 1)
+            error = nil
+        } catch {
+            self.error = error.localizedDescription
+        }
+        loading = false
+    }
+
+    // MARK: Search
+
+    @ViewBuilder private var searchResults: some View {
+        if searching {
+            ProgressView().controlSize(.large)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if results.isEmpty {
+            ContentUnavailableView.search(text: query)
+        } else {
+            List {
+                if searchTruncated {
+                    Text("Showing first matches — refine to narrow.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+                ForEach(results) { file in
+                    Section {
+                        ForEach(file.matches) { match in
+                            NavigationLink(value: FileRef(path: absolute(file.path),
+                                                          name: lastComponent(file.path))) {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(match.preview.trimmingCharacters(in: .whitespaces))
+                                        .font(.caption.monospaced())
+                                        .lineLimit(2)
+                                    Text("line \(match.line)")
+                                        .font(.caption2).foregroundStyle(.tertiary)
+                                }
+                            }
+                        }
+                    } header: {
+                        Text(file.path).font(.caption2.monospaced()).foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .listStyle(.insetGrouped)
+        }
+    }
+
+    private func runSearch() async {
+        let q = query.trimmingCharacters(in: .whitespaces)
+        guard q.count >= 2, let client = app.client else {
+            results = []; searchTruncated = false; return
+        }
+        // Light debounce so each keystroke doesn't spawn a ripgrep run.
+        try? await Task.sleep(for: .milliseconds(300))
+        if Task.isCancelled { return }
+        searching = true
+        defer { searching = false }
+        do {
+            let resp = try await client.searchProject(root: node.searchRoot, query: q)
+            if Task.isCancelled { return }
+            results = resp.files ?? []
+            searchTruncated = resp.truncated ?? false
+        } catch {
+            results = []; searchTruncated = false
+        }
+    }
+
+    private func absolute(_ relative: String) -> String {
+        node.searchRoot.hasSuffix("/") ? node.searchRoot + relative
+                                       : node.searchRoot + "/" + relative
+    }
+
+    private func lastComponent(_ p: String) -> String {
+        p.split(separator: "/").last.map(String.init) ?? p
+    }
+}
+
+/// SF Symbol for a file based on its extension.
+func fileIcon(_ name: String) -> String {
+    let ext = name.split(separator: ".").last.map(String.init)?.lowercased() ?? ""
+    switch ext {
+    case "swift", "ts", "tsx", "js", "jsx", "mjs", "cjs", "rs", "go", "py", "rb",
+         "c", "h", "cpp", "hpp", "java", "kt", "lua", "zig":
+        return "chevron.left.forwardslash.chevron.right"
+    case "json", "yaml", "yml", "toml", "xml", "ini", "conf", "cfg", "lock":
+        return "doc.text.fill"
+    case "md", "mdx", "txt":
+        return "doc.richtext"
+    case "png", "jpg", "jpeg", "gif", "webp", "svg", "avif", "bmp":
+        return "photo"
+    case "css", "html":
+        return "paintbrush"
+    case "sh":
+        return "terminal"
+    default:
+        return "doc"
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/CodeEditorView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/CodeEditorView.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+
+/// View and edit a single text file (or preview an image). Saves via
+/// `POST /api/project-file`, which only overwrites existing text files.
+struct CodeEditorView: View {
+    @Environment(AppModel.self) private var app
+    let path: String
+    let name: String
+
+    @State private var loaded: FileContent?
+    @State private var loading = true
+    @State private var loadError: String?
+
+    @State private var text = ""
+    @State private var original = ""
+    @State private var saving = false
+    @State private var editing = false
+
+    private var isDirty: Bool { text != original }
+    private var isEditable: Bool {
+        guard let loaded, loaded.ok, loaded.kind == "text" else { return false }
+        // Redacted .env reads come back as a placeholder — never let a save
+        // clobber the real secrets with it.
+        return !name.hasPrefix(".env")
+    }
+
+    var body: some View {
+        content
+            .navigationTitle(name)
+            .navigationBarTitleDisplayMode(.inline)
+            .task { await load() }
+            .toolbar {
+                if isEditable {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        if saving {
+                            ProgressView()
+                        } else if editing {
+                            Button("Save") { Task { await save() } }
+                                .fontWeight(.semibold)
+                                .disabled(!isDirty)
+                        } else {
+                            Button("Edit") { editing = true }
+                        }
+                    }
+                }
+            }
+    }
+
+    @ViewBuilder private var content: some View {
+        if loading {
+            ProgressView().controlSize(.large)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let loadError {
+            ContentUnavailableView {
+                Label("Couldn’t open file", systemImage: "exclamationmark.triangle")
+            } description: { Text(loadError) } actions: {
+                Button("Retry") { Task { await load() } }.buttonStyle(.borderedProminent)
+            }
+        } else if let loaded, loaded.isImage, let image = decodedImage(loaded.dataUrl) {
+            ScrollView([.horizontal, .vertical]) {
+                image.resizable().scaledToFit().padding()
+            }
+        } else if let loaded, loaded.kind == "text" {
+            editor(loaded)
+        } else {
+            ContentUnavailableView("Can’t preview this file",
+                                   systemImage: "doc.questionmark",
+                                   description: Text(loaded?.error ?? "Unsupported file type."))
+        }
+    }
+
+    @ViewBuilder private func editor(_ loaded: FileContent) -> some View {
+        VStack(spacing: 0) {
+            if name.hasPrefix(".env") {
+                banner("Contents redacted — .env files aren’t editable here.",
+                       systemImage: "lock.fill")
+            } else if !editing {
+                EmptyView()
+            }
+            TextEditor(text: $text)
+                .font(.system(.footnote, design: .monospaced))
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .scrollContentBackground(.hidden)
+                .background(Color(.systemBackground))
+                .disabled(!editing || !isEditable)
+                .overlay(alignment: .bottomTrailing) {
+                    if let size = loaded.size {
+                        Text("\(size) bytes")
+                            .font(.caption2).foregroundStyle(.tertiary)
+                            .padding(6)
+                    }
+                }
+        }
+    }
+
+    private func banner(_ message: String, systemImage: String) -> some View {
+        Label(message, systemImage: systemImage)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 16).padding(.vertical, 8)
+            .background(.bar)
+    }
+
+    private func load() async {
+        guard let client = app.client else { return }
+        loading = true
+        do {
+            let file = try await client.readFile(path: path)
+            loaded = file
+            if file.kind == "text" {
+                text = file.content ?? ""
+                original = text
+            }
+            loadError = file.ok ? nil : (file.error ?? "Couldn’t read file.")
+        } catch {
+            loadError = error.localizedDescription
+        }
+        loading = false
+    }
+
+    private func save() async {
+        guard let client = app.client, isDirty else { return }
+        saving = true
+        defer { saving = false }
+        do {
+            try await client.writeFile(path: path, content: text)
+            original = text
+            editing = false
+            app.showToast("Saved \(name)", systemImage: "checkmark.circle.fill")
+        } catch {
+            app.showToast(error.localizedDescription,
+                          systemImage: "exclamationmark.triangle.fill", style: .error)
+        }
+    }
+
+    private func decodedImage(_ dataUrl: String?) -> Image? {
+        guard let dataUrl,
+              let comma = dataUrl.firstIndex(of: ","),
+              let data = Data(base64Encoded: String(dataUrl[dataUrl.index(after: comma)...])),
+              let ui = UIImage(data: data) else { return nil }
+        return Image(uiImage: ui)
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/DeveloperView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/DeveloperView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// The Developer tab: a single surface for browsing/editing project code,
+/// driving a live terminal, and triaging GitHub activity — the three things
+/// you reach for between chats. A segmented switcher picks the section; each
+/// section owns its own navigation stack.
+enum DevSection: String, CaseIterable, Identifiable {
+    case code, terminal, github
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .code: return "Code"
+        case .terminal: return "Terminal"
+        case .github: return "GitHub"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .code: return "folder"
+        case .terminal: return "terminal"
+        case .github: return "arrow.triangle.branch"
+        }
+    }
+}
+
+struct DeveloperView: View {
+    @AppStorage("cave.dev.section") private var sectionRaw = DevSection.code.rawValue
+
+    private var section: Binding<DevSection> {
+        Binding(
+            get: { DevSection(rawValue: sectionRaw) ?? .code },
+            set: { sectionRaw = $0.rawValue }
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("Section", selection: section) {
+                ForEach(DevSection.allCases) { s in
+                    Label(s.label, systemImage: s.systemImage).tag(s)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(.bar)
+
+            Divider()
+
+            switch section.wrappedValue {
+            case .code: CodeBrowserView()
+            case .terminal: TerminalView()
+            case .github: GitHubView()
+            }
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
@@ -1,0 +1,274 @@
+import SwiftUI
+
+/// GitHub section: the authenticated user's live activity (open PRs, review
+/// requests, assigned issues, notifications) with a tappable detail view.
+struct GitHubView: View {
+    @Environment(AppModel.self) private var app
+
+    @State private var items: [GitHubItem] = []
+    @State private var login: String?
+    @State private var authed = false
+    @State private var loading = true
+    @State private var error: String?
+    @State private var hint: String?
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("GitHub")
+                .navigationDestination(for: GitHubItem.self) { item in
+                    GitHubItemDetailView(item: item)
+                }
+                .toolbar {
+                    if let login {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            Label("@\(login)", systemImage: authed ? "person.crop.circle.badge.checkmark" : "person.crop.circle")
+                                .font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .refreshable { await load() }
+                .task { await load() }
+        }
+    }
+
+    @ViewBuilder private var content: some View {
+        if loading && items.isEmpty {
+            ProgressView().controlSize(.large)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error {
+            ContentUnavailableView {
+                Label("GitHub unavailable", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(hint ?? error)
+            } actions: {
+                Button("Retry") { Task { await load() } }.buttonStyle(.borderedProminent)
+            }
+        } else if items.isEmpty {
+            ContentUnavailableView {
+                Label("Nothing open", systemImage: "checkmark.seal")
+            } description: {
+                Text("No open pull requests, review requests, or assigned issues.")
+            }
+        } else {
+            List {
+                ForEach(groups, id: \.title) { group in
+                    Section(group.title) {
+                        ForEach(group.items) { item in
+                            row(item)
+                        }
+                    }
+                }
+            }
+            .listStyle(.insetGrouped)
+        }
+    }
+
+    @ViewBuilder private func row(_ item: GitHubItem) -> some View {
+        if item.number != nil {
+            NavigationLink(value: item) { GitHubItemRow(item: item) }
+        } else if let url = URL(string: item.url) {
+            Link(destination: url) { GitHubItemRow(item: item) }
+        } else {
+            GitHubItemRow(item: item)
+        }
+    }
+
+    // MARK: - Grouping
+
+    struct Group { let title: String; let items: [GitHubItem] }
+
+    private var groups: [Group] {
+        let order: [(String, (GitHubItem) -> Bool)] = [
+            ("Review requests", { $0.kind == "review_request" }),
+            ("Your pull requests", { $0.kind == "pr" }),
+            ("Issues", { $0.kind == "issue" }),
+            ("Notifications", { $0.kind == "notification" }),
+        ]
+        return order.compactMap { title, match in
+            let matched = items.filter(match)
+            return matched.isEmpty ? nil : Group(title: title, items: matched)
+        }
+    }
+
+    private func load() async {
+        guard let client = app.client else { return }
+        loading = true
+        defer { loading = false }
+        do {
+            let resp = try await client.githubActivity()
+            if resp.ok {
+                items = resp.items ?? []
+                login = resp.login
+                authed = resp.authed ?? false
+                error = nil
+                hint = nil
+            } else {
+                error = resp.error ?? "Couldn’t load GitHub activity."
+                hint = resp.hint
+            }
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}
+
+struct GitHubItemRow: View {
+    let item: GitHubItem
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: icon)
+                .foregroundStyle(tint)
+                .font(.callout)
+                .frame(width: 20)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(item.title).font(.callout).lineLimit(2)
+                HStack(spacing: 6) {
+                    Text(item.repo).font(.caption2.monospaced()).foregroundStyle(.secondary)
+                    if let number = item.number {
+                        Text("#\(number)").font(.caption2).foregroundStyle(.tertiary)
+                    }
+                    if item.draft == true {
+                        Text("draft").font(.caption2)
+                            .padding(.horizontal, 5).padding(.vertical, 1)
+                            .background(Color(.tertiarySystemFill), in: Capsule())
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var icon: String {
+        switch item.kind {
+        case "pr": return "arrow.triangle.pull"
+        case "review_request": return "eye"
+        case "issue": return "smallcircle.circle"
+        case "notification": return "bell"
+        default: return "circle"
+        }
+    }
+
+    private var tint: Color {
+        switch item.kind {
+        case "review_request": return .orange
+        case "pr": return .purple
+        case "issue": return .green
+        default: return .secondary
+        }
+    }
+}
+
+/// Full detail of one issue / PR (`GET /api/github/item`).
+struct GitHubItemDetailView: View {
+    @Environment(AppModel.self) private var app
+    let item: GitHubItem
+
+    @State private var detail: GitHubItemDetail?
+    @State private var loading = true
+    @State private var error: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if loading {
+                    ProgressView().frame(maxWidth: .infinity).padding(.top, 40)
+                } else if let error {
+                    ContentUnavailableView {
+                        Label("Couldn’t load", systemImage: "exclamationmark.triangle")
+                    } description: { Text(error) }
+                } else if let detail {
+                    header(detail)
+                    if let body = detail.body, !body.isEmpty {
+                        Text(markdown(body))
+                            .font(.callout)
+                            .textSelection(.enabled)
+                    } else {
+                        Text("No description.").foregroundStyle(.secondary).font(.callout)
+                    }
+                }
+            }
+            .padding(16)
+        }
+        .navigationTitle(item.number.map { "#\($0)" } ?? "Item")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if let url = URL(string: item.url) {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Link(destination: url) { Image(systemName: "safari") }
+                }
+            }
+        }
+        .task { await load() }
+    }
+
+    @ViewBuilder private func header(_ d: GitHubItemDetail) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(d.title ?? item.title).font(.title3.weight(.semibold))
+            HStack(spacing: 8) {
+                statePill(d)
+                if let author = d.author {
+                    Text("by @\(author.login)").font(.caption).foregroundStyle(.secondary)
+                }
+                if let comments = d.comments, comments > 0 {
+                    Label("\(comments)", systemImage: "text.bubble")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+            }
+            if let labels = d.labels, !labels.isEmpty {
+                labelFlow(labels)
+            }
+        }
+    }
+
+    private func statePill(_ d: GitHubItemDetail) -> some View {
+        let (text, color): (String, Color) = {
+            if d.merged == true { return ("merged", .purple) }
+            if d.state == "closed" { return ("closed", .red) }
+            if d.draft == true { return ("draft", .gray) }
+            return ("open", .green)
+        }()
+        return Text(text)
+            .font(.caption.weight(.semibold))
+            .padding(.horizontal, 8).padding(.vertical, 3)
+            .background(color.opacity(0.18), in: Capsule())
+            .foregroundStyle(color)
+    }
+
+    private func labelFlow(_ labels: [GitHubLabel]) -> some View {
+        // Simple wrapping isn't built-in; a horizontal scroll keeps it tidy.
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(labels, id: \.name) { label in
+                    Text(label.name)
+                        .font(.caption2)
+                        .padding(.horizontal, 7).padding(.vertical, 2)
+                        .background((Color(hex: "#" + label.color) ?? .secondary).opacity(0.22), in: Capsule())
+                }
+            }
+        }
+    }
+
+    private func markdown(_ raw: String) -> AttributedString {
+        (try? AttributedString(
+            markdown: raw,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )) ?? AttributedString(raw)
+    }
+
+    private func load() async {
+        guard let client = app.client, let number = item.number else {
+            error = "No detail available."; loading = false; return
+        }
+        loading = true
+        defer { loading = false }
+        do {
+            let d = try await client.githubItem(repo: item.repo, number: number)
+            if d.ok { detail = d } else { error = d.error ?? "Not found." }
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -49,6 +49,9 @@ struct MainTabView: View {
             Tab("Tasks", systemImage: "checklist", value: AppTab.tasks) {
                 TasksView()
             }
+            Tab("Developer", systemImage: "chevron.left.forwardslash.chevron.right", value: AppTab.dev) {
+                DeveloperView()
+            }
         }
         // TabView wins a layout race at cold launch and resets its selection to
         // the first tab, overriding any seeded value — but the binding DOES drive

--- a/apps/ios/CovenCave/CovenCave/Views/TerminalView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TerminalView.swift
@@ -1,0 +1,190 @@
+import SwiftUI
+
+/// A live shell on the desktop, over `/api/pty-ws`. The working directory can be
+/// any configured project (or Home); each directory keeps its own persistent
+/// shell (the server adopts the session and replays scrollback on reconnect).
+struct TerminalView: View {
+    @Environment(AppModel.self) private var app
+    @Environment(\.scenePhase) private var scenePhase
+
+    @State private var terminal = PtyTerminal()
+    @State private var input = ""
+    @State private var cwd: String?          // nil = Home
+    @State private var size = CGSize(width: 0, height: 0)
+    @FocusState private var inputFocused: Bool
+
+    private let charWidth: CGFloat = 7.2     // ~ width of SF Mono at 12pt
+    private let lineHeight: CGFloat = 15
+
+    private var cols: Int { max(20, Int(size.width / charWidth)) }
+    private var rows: Int { max(10, Int(size.height / lineHeight)) }
+
+    /// Per-cwd thread id → one durable shell per working directory.
+    private var threadId: String { "ios-terminal::" + (cwd ?? "home") }
+
+    private var cwdLabel: String {
+        guard let cwd else { return "Home" }
+        if let name = app.projects.first(where: { $0.root == cwd })?.name { return name }
+        let last = cwd.split(separator: "/").last
+        return last.map(String.init) ?? cwd
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                screen
+                Divider()
+                keyRow
+                inputBar
+            }
+            .navigationTitle("Terminal")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) { cwdMenu }
+                ToolbarItem(placement: .topBarTrailing) { statusButton }
+            }
+            .task { if !app.projectsLoaded { await app.loadProjects() } }
+            .onChange(of: scenePhase) { _, phase in
+                if phase == .active, !terminal.connected, !terminal.exited { connect() }
+            }
+        }
+    }
+
+    // MARK: - Screen
+
+    private var screen: some View {
+        GeometryReader { geo in
+            ScrollViewReader { proxy in
+                ScrollView {
+                    Text(terminal.text.isEmpty ? "Connecting…" : terminal.text)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundStyle(terminal.text.isEmpty ? .secondary : .primary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                        .padding(8)
+                    Color.clear.frame(height: 1).id("bottom")
+                }
+                .background(Color(.systemBackground))
+                .onChange(of: terminal.text) { _, _ in
+                    withAnimation(.linear(duration: 0.1)) { proxy.scrollTo("bottom", anchor: .bottom) }
+                }
+                .onAppear {
+                    size = geo.size
+                    if !terminal.connected && !terminal.exited { connect() }
+                }
+                .onChange(of: geo.size) { _, newValue in
+                    size = newValue
+                    terminal.sendResize(cols: cols, rows: rows)
+                }
+            }
+        }
+    }
+
+    // MARK: - Key row
+
+    private var keyRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                keyButton("esc") { terminal.sendInput("\u{1B}") }
+                keyButton("tab") { terminal.sendInput("\t") }
+                keyButton("⌃C") { terminal.sendInput("\u{03}") }
+                keyButton("⌃D") { terminal.sendInput("\u{04}") }
+                keyButton("↑") { terminal.sendInput("\u{1B}[A") }
+                keyButton("↓") { terminal.sendInput("\u{1B}[B") }
+                keyButton("←") { terminal.sendInput("\u{1B}[D") }
+                keyButton("→") { terminal.sendInput("\u{1B}[C") }
+                keyButton("clear") { terminal.sendInput("clear\n") }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+        }
+        .background(.bar)
+    }
+
+    private func keyButton(_ label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(.system(.footnote, design: .monospaced))
+                .padding(.horizontal, 10).padding(.vertical, 5)
+                .background(Color(.tertiarySystemFill), in: RoundedRectangle(cornerRadius: 7))
+        }
+        .buttonStyle(.plain)
+        .disabled(!terminal.connected)
+    }
+
+    // MARK: - Input bar
+
+    private var inputBar: some View {
+        HStack(spacing: 8) {
+            TextField("Type a command…", text: $input)
+                .textFieldStyle(.plain)
+                .font(.system(.callout, design: .monospaced))
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .focused($inputFocused)
+                .submitLabel(.send)
+                .onSubmit(send)
+                .padding(.horizontal, 12).padding(.vertical, 9)
+                .background(Color(.secondarySystemBackground), in: Capsule())
+                .disabled(!terminal.connected)
+
+            Button(action: send) {
+                Image(systemName: "arrow.up.circle.fill").font(.title2)
+            }
+            .disabled(!terminal.connected)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+        .background(.bar)
+    }
+
+    private func send() {
+        guard terminal.connected else { return }
+        terminal.sendInput(input + "\n")   // shell echoes the line back itself
+        input = ""
+    }
+
+    // MARK: - Toolbar
+
+    private var cwdMenu: some View {
+        Menu {
+            Button { switchCwd(nil) } label: {
+                Label("Home", systemImage: cwd == nil ? "checkmark" : "house")
+            }
+            if !app.projects.isEmpty {
+                Divider()
+                ForEach(app.projects) { project in
+                    Button { switchCwd(project.root) } label: {
+                        Label(project.name, systemImage: cwd == project.root ? "checkmark" : "folder")
+                    }
+                }
+            }
+        } label: {
+            Label(cwdLabel, systemImage: "folder")
+                .font(.subheadline)
+        }
+    }
+
+    @ViewBuilder private var statusButton: some View {
+        if terminal.exited || terminal.error != nil {
+            Button { connect() } label: { Label("Reconnect", systemImage: "arrow.clockwise") }
+        } else {
+            Circle()
+                .fill(terminal.connected ? Color.green : Color.orange)
+                .frame(width: 9, height: 9)
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    private func connect() {
+        guard let wsBase = app.connection?.wsBaseURL else { return }
+        terminal.connect(wsBase: wsBase, threadId: threadId,
+                         projectRoot: cwd, cols: cols, rows: rows)
+    }
+
+    private func switchCwd(_ root: String?) {
+        guard root != cwd else { return }
+        cwd = root
+        connect()   // threadId is derived from cwd → fresh/persistent per directory
+    }
+}

--- a/server.mjs
+++ b/server.mjs
@@ -84,8 +84,9 @@ function sameOrigin(value, expectedOrigin) {
 }
 function isAllowedUpgradeSource(req) {
   const host = req.headers.host;
-  if (!isLoopbackHost(host)) return false;
   if (!isLoopbackAddress(req.socket.remoteAddress)) return false;
+  const tailnetTrusted = process.env.COVEN_CAVE_TAILNET_TRUST === "1";
+  if (!tailnetTrusted && !isLoopbackHost(host)) return false;
   return sameOrigin(req.headers.origin, `http://${host}`);
 }
 function isAuthorized(req, query) {

--- a/server.ts
+++ b/server.ts
@@ -136,8 +136,20 @@ function sameOrigin(value: string | undefined, expectedOrigin: string): boolean 
 
 function isAllowedUpgradeSource(req: IncomingMessage): boolean {
   const host = req.headers.host;
-  if (!isLoopbackHost(host)) return false;
+  // The peer must always be loopback: `tailscale serve` terminates TLS and
+  // forwards to 127.0.0.1, so a legitimate tailnet client still arrives over
+  // loopback. A non-loopback peer is a direct LAN/WAN connection — never trust.
   if (!isLoopbackAddress(req.socket.remoteAddress)) return false;
+  // Tokenless native-app mode (COVEN_CAVE_TAILNET_TRUST=1, set only by
+  // `pnpm mobile:tailscale:app`): `tailscale serve` forwards the request's
+  // `<host>.ts.net` Host — NOT 127.0.0.1 — so the loopback host gate would
+  // otherwise 403 the iOS terminal over the tailnet. Trusting the host here is
+  // safe because tailnet membership is the ingress boundary in this mode, and
+  // the sameOrigin gate below still blocks cross-site browser upgrades (a native
+  // WebSocket sends no Origin). This mirrors the REST trust gate in proxy.ts.
+  // By default (no flag) WebSocket upgrades remain loopback-host only.
+  const tailnetTrusted = process.env.COVEN_CAVE_TAILNET_TRUST === "1";
+  if (!tailnetTrusted && !isLoopbackHost(host)) return false;
   return sameOrigin(req.headers.origin, `http://${host}`);
 }
 

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -48,6 +48,15 @@ assert.match(src, /tag === 0x04/, "server receives resize tag 0x04");
 // Always loopback by default (both dev and prod)
 assert.match(src, /isAllowedUpgradeSource/, "server validates WebSocket upgrade host and origin");
 assert.match(src, /isLoopbackHost\(host\)/, "server only accepts loopback WebSocket hosts by default");
+// The peer address is always loopback-gated, even in tokenless tailnet mode —
+// tailscale serve forwards from 127.0.0.1, so a non-loopback peer is a direct
+// LAN/WAN connection that must never be trusted.
+assert.match(src, /isLoopbackAddress\(req\.socket\.remoteAddress\)/, "server verifies the WebSocket peer address, not only the Host header");
+// Tokenless native-app mode (COVEN_CAVE_TAILNET_TRUST=1) relaxes ONLY the
+// loopback *host* gate, so the iOS terminal reaches /api/pty-ws over the tailnet
+// (tailscale serve forwards the <host>.ts.net Host). Mirrors the REST gate in
+// proxy.ts; the sameOrigin gate still blocks cross-site browser upgrades.
+assert.match(src, /process\.env\.COVEN_CAVE_TAILNET_TRUST === "1"/, "tokenless tailnet app mode relaxes the WebSocket host gate for tailnet-forwarded upgrades");
 assert.match(packageJson.scripts.postinstall ?? "", /fix-node-pty-spawn-helper\.mjs/, "postinstall repairs node-pty spawn-helper mode");
 assert.equal(
   existsSync(new URL("../scripts/fix-node-pty-spawn-helper.mjs", import.meta.url)),


### PR DESCRIPTION
## What

Adds an **ultimate Developer tab** to the native iOS app — a single surface for the three things you reach for between chats: browsing/editing project code, driving a live terminal, and triaging GitHub activity. A segmented switcher (Code · Terminal · GitHub) sits at the top; each section owns its own navigation stack.

### Code
- Project picker (`/api/projects`) → drill-in file tree (`/api/project-tree`, lazy per level) → file viewer/editor.
- Editor reads via `/api/project-file` and saves via `POST /api/project-file` (existing text files only). Images preview inline; `.env` shows the server's redaction and is read-only.
- Project-wide search powered by ripgrep (`/api/project/search`) with tap-to-open results.

### Terminal
- A real shell over the existing `/api/pty-ws` WebSocket bridge (binary framing: `0x01/0x02` out, `0x03/0x04` in).
- A small line-discipline (`TerminalScreen`) strips ANSI/OSC escapes and honours CR/BS/NL so ordinary output and progress redraws read correctly on a phone — not a full grid emulator, but legible.
- Working directory selectable (Home or any project); each cwd keeps its own durable shell (server adopts the session + replays scrollback on reconnect). Soft-keyboard helper row for esc/tab/⌃C/⌃D/arrows/clear.

### GitHub
- Live activity (`/api/github/activity`): review requests, your PRs, issues, notifications — grouped, with a detail view (`/api/github/item`) rendering body, state, author, labels, and an Open-in-Safari link.

## Backend change — terminal over the tailnet

The `/api/pty-ws` upgrade gate in `server.ts` was **loopback-host only**, so the iOS terminal could never reach it over `tailscale serve` (which forwards the `<host>.ts.net` Host, not `127.0.0.1`). It now honours `COVEN_CAVE_TAILNET_TRUST=1` (set only by `pnpm mobile:tailscale:app`) to relax **only** the loopback *host* gate — the peer address stays loopback-gated (tailscaled forwards from `127.0.0.1`, so a non-loopback peer is a direct LAN/WAN connection that's never trusted), and the `sameOrigin` gate still blocks cross-site browser upgrades. This mirrors the existing REST trust gate in `proxy.ts`. `server.mjs` rebuilt via `pnpm build:server`.

## Verification
- `xcodebuild ... -destination 'generic/platform=iOS Simulator'` → **BUILD SUCCEEDED** (note: iOS Swift isn't compiled by CI, so this was verified locally).
- `src/server-pty-ws.test.ts` (incl. a new assertion documenting the tailnet relaxation), `src/middleware.test.ts`, and `scripts/mobile-tailscale.test.mjs` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)