### PR TITLE
feat(ios): syntax-highlight code blocks in chat (highlight.js)

### DIFF
--- a/apps/ios/markdown/entry.mjs
+++ b/apps/ios/markdown/entry.mjs
@@ -1,26 +1,106 @@
 // Browser-side markdown renderer for the native iOS app's WKWebView.
-// Uses the SAME packages the desktop chat uses (@create-markdown/* + mermaid)
-// so rendered responses match the desktop pixel-for-pixel, including Mermaid
-// diagrams. Bundled to a single self-contained HTML by scripts/build-ios-markdown.mjs.
+// Same @create-markdown/* + mermaid pipeline as the desktop chat, with
+// highlight.js for code syntax colours (shiki doesn't bundle into a browser
+// IIFE via esbuild — @shikijs/vscode-textmate's Resolver breaks). Bundled to a
+// self-contained HTML by scripts/build-ios-markdown.mjs.
 
 import { parse } from "@create-markdown/core";
 import { renderAsync } from "@create-markdown/preview";
 import { mermaidPlugin } from "@create-markdown/preview-mermaid";
+import hljs from "highlight.js/lib/core";
+
+import langSwift from "highlight.js/lib/languages/swift";
+import langPython from "highlight.js/lib/languages/python";
+import langJavascript from "highlight.js/lib/languages/javascript";
+import langTypescript from "highlight.js/lib/languages/typescript";
+import langRust from "highlight.js/lib/languages/rust";
+import langGo from "highlight.js/lib/languages/go";
+import langRuby from "highlight.js/lib/languages/ruby";
+import langBash from "highlight.js/lib/languages/bash";
+import langJson from "highlight.js/lib/languages/json";
+import langYaml from "highlight.js/lib/languages/yaml";
+import langSql from "highlight.js/lib/languages/sql";
+import langXml from "highlight.js/lib/languages/xml";
+import langCss from "highlight.js/lib/languages/css";
+import langScss from "highlight.js/lib/languages/scss";
+import langMarkdown from "highlight.js/lib/languages/markdown";
+import langDiff from "highlight.js/lib/languages/diff";
+import langDockerfile from "highlight.js/lib/languages/dockerfile";
+import langJava from "highlight.js/lib/languages/java";
+import langKotlin from "highlight.js/lib/languages/kotlin";
+import langC from "highlight.js/lib/languages/c";
+import langCpp from "highlight.js/lib/languages/cpp";
+import langPhp from "highlight.js/lib/languages/php";
+import langLua from "highlight.js/lib/languages/lua";
+
+const REGISTER = {
+  swift: langSwift, python: langPython, javascript: langJavascript,
+  typescript: langTypescript, rust: langRust, go: langGo, ruby: langRuby,
+  bash: langBash, json: langJson, yaml: langYaml, sql: langSql, xml: langXml,
+  css: langCss, scss: langScss, markdown: langMarkdown, diff: langDiff,
+  dockerfile: langDockerfile, java: langJava, kotlin: langKotlin, c: langC,
+  cpp: langCpp, php: langPhp, lua: langLua,
+};
+for (const [name, def] of Object.entries(REGISTER)) hljs.registerLanguage(name, def);
+hljs.configure({ classPrefix: "hljs-" });
+
+// highlight.js already knows common aliases (js, ts, py, sh, yml, html, c++, …);
+// a few extras it doesn't infer from our registered set:
+const ALIASES = { sh: "bash", shell: "bash", zsh: "bash", html: "xml", "objective-c": "c" };
 
 const mermaid = mermaidPlugin({ theme: "dark", config: { securityLevel: "strict" } });
+let mermaidReady = null;
+function initMermaid() {
+  if (!mermaidReady) mermaidReady = Promise.resolve(mermaid.init?.());
+  return mermaidReady;
+}
 
-// Render a markdown string to sanitized HTML (Mermaid diagrams resolved to SVG).
+function isMermaid(block) {
+  if (block.type !== "codeBlock") return false;
+  return (block.props?.language ?? block.props?.info ?? "").trim().toLowerCase() === "mermaid";
+}
+function codeText(block) {
+  return (block.content ?? []).map((s) => s.text).join("");
+}
+function escapeHtml(s) {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+function highlightCode(code, rawLang) {
+  let lang = (rawLang ?? "").trim().toLowerCase().split(/\s+/)[0];
+  lang = ALIASES[lang] ?? lang;
+  let inner = escapeHtml(code);
+  if (lang && hljs.getLanguage(lang)) {
+    try { inner = hljs.highlight(code, { language: lang, ignoreIllegals: true }).value; } catch {}
+  }
+  return `<pre class="hljs"><code class="hljs">${inner}</code></pre>`;
+}
+
 async function renderMarkdown(md) {
   const blocks = parse(md || "");
-  return await renderAsync(blocks, {
-    plugins: [mermaid],
+  const codeBlocks = blocks.filter((b) => b.type === "codeBlock");
+  const hasMermaid = codeBlocks.some(isMermaid);
+  if (hasMermaid) await initMermaid();
+
+  const replacements = new Array(codeBlocks.length);
+  codeBlocks.forEach((block, i) => {
+    if (hasMermaid && isMermaid(block)) {
+      replacements[i] = mermaid.renderBlock?.(block, () => "") ?? "";
+      return;
+    }
+    replacements[i] = highlightCode(codeText(block), block.props?.language ?? block.props?.info ?? "");
+  });
+
+  let idx = 0;
+  let html = await renderAsync(blocks, {
     linkTarget: "_blank",
     sanitize: true,
+    customRenderers: { codeBlock: () => replacements[idx++] ?? "" },
   });
+  if (hasMermaid && mermaid.postProcess) html = await mermaid.postProcess(html);
+  return html;
 }
 
 function reportHeight() {
-  // Two frames so Mermaid SVGs / fonts have laid out before we measure.
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
       const h = Math.ceil(document.body.getBoundingClientRect().height);
@@ -29,7 +109,6 @@ function reportHeight() {
   });
 }
 
-// Native entry point: render markdown into #root and report the content height.
 window.caveRender = async (md) => {
   const root = document.getElementById("root");
   if (!root) return;
@@ -42,7 +121,6 @@ window.caveRender = async (md) => {
   reportHeight();
 };
 
-// Intercept link taps → hand off to native (open in Safari).
 document.addEventListener("click", (e) => {
   const a = e.target?.closest?.("a[href]");
   if (!a) return;

--- a/apps/ios/markdown/markdown.css
+++ b/apps/ios/markdown/markdown.css
@@ -87,3 +87,17 @@ img { max-width: 100%; border-radius: 8px; }
 
 .task-list-item { list-style: none; }
 .task-list-item input { margin-right: 0.4em; }
+
+/* highlight.js token theme (mood-c-dark-ish dark palette) */
+pre.hljs { background: var(--code-bg) !important; }
+.hljs { color: #E6E6EF; background: transparent; }
+.hljs-comment, .hljs-quote { color: #6E6E80; font-style: italic; }
+.hljs-keyword, .hljs-selector-tag, .hljs-literal, .hljs-section, .hljs-doctag { color: #C4B5FD; }
+.hljs-built_in, .hljs-type, .hljs-class .hljs-title, .hljs-title.class_ { color: #93C5FD; }
+.hljs-string, .hljs-attr, .hljs-template-tag, .hljs-symbol, .hljs-bullet, .hljs-addition, .hljs-meta-string { color: #86EFAC; }
+.hljs-number, .hljs-meta, .hljs-regexp, .hljs-link { color: #FCD34D; }
+.hljs-title, .hljs-title.function_, .hljs-function .hljs-title, .hljs-selector-id, .hljs-selector-class { color: #7DD3FC; }
+.hljs-variable, .hljs-template-variable, .hljs-name, .hljs-attribute, .hljs-tag { color: #F0ABFC; }
+.hljs-deletion { color: #FCA5A5; }
+.hljs-emphasis { font-style: italic; }
+.hljs-strong { font-weight: 700; }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@types/react-dom": "19.2.3",
     "@types/ws": "8.18.1",
     "esbuild": "0.28.0",
+    "highlight.js": "11.11.1",
     "sharp": "0.34.5",
     "tailwindcss": "4.3.0",
     "typescript": "5.9.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       esbuild:
         specifier: 0.28.0
         version: 0.28.0
+      highlight.js:
+        specifier: 11.11.1
+        version: 11.11.1
       sharp:
         specifier: 0.34.5
         version: 0.34.5
@@ -1511,6 +1514,10 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -3455,6 +3462,8 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  highlight.js@11.11.1: {}
 
   html-void-elements@3.0.0: {}
 


### PR DESCRIPTION
## What
Code blocks in native iOS replies now get **syntax colours**, completing the markdown rendering.

shiki (the desktop's highlighter) **wouldn't bundle** into the WKWebView's browser IIFE via esbuild — `@shikijs/vscode-textmate`'s `Resolver` breaks across IIFE *and* ESM output, with both the JS and oniguruma-WASM engines (works in Node, not bundled). Per the chosen path, code blocks use **highlight.js** instead — pure JS, no WASM — with a dark token theme tuned to resemble the desktop's `mood-c-dark`.

- ~26 common languages registered (aliases handled); unknown langs fall back to plain escaped text.
- Keeps the `@create-markdown` + Mermaid pipeline; only code-block highlighting changed.
- Bundle drops back to **~3 MB** (was ~6 MB with shiki's WASM).
- `highlight.js` added as a **pinned devDependency** (build-only — bundled into the gitignored `markdown.html`; run `scripts/build-ios-markdown.mjs`).

## Verification
Headless: `class="hljs"` + 11 `hljs-*` token spans + a table + a Mermaid SVG, no console errors. (Simulator screenshot to follow.)

## Note
Not byte-identical to desktop shiki, but visually close (lavender keywords, green strings, amber numbers, blue functions). True shiki parity would need a different bundler (rollup/vite) — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)