### PR TITLE
feat(github): flag PRs with failing CI checks in the GitHub view

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -32,6 +32,7 @@ export const SUITES = {
     "src/lib/demo-mode.test.ts",
     "src/lib/cave-projects.test.ts",
     "src/lib/project-status.test.ts",
+    "src/lib/github-checks.test.ts",
     "src/lib/chat-projects.test.ts",
     "src/lib/chat-project-selection.test.ts",
     "src/lib/chat-session-order.test.ts",

--- a/src/app/api/github/activity/route.ts
+++ b/src/app/api/github/activity/route.ts
@@ -17,11 +17,14 @@
 
 import { NextResponse } from "next/server";
 import { resolveSecret } from "@/lib/vault";
+import { summarizeChecks, type CheckSummary } from "@/lib/github-checks";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 const GH = "https://api.github.com";
+// Cap per-PR check enrichment so a long PR list can't blow the rate budget.
+const CHECK_ENRICH_CAP = 15;
 
 type GitHubItem = {
   kind: "pr" | "issue" | "review_request" | "notification";
@@ -34,7 +37,30 @@ type GitHubItem = {
   updatedAt: string;
   draft?: boolean;
   labels?: string[];
+  checkStatus?: CheckSummary;
 };
+
+/**
+ * Best-effort CI rollup for one PR: resolve the head SHA, read its check-runs
+ * (falling back to the legacy combined status), and summarize. Any failure
+ * returns null so the row simply renders without a pip. Uses core REST quota,
+ * so callers must gate this behind a token (the public 60/hr budget can't
+ * absorb it).
+ */
+async function fetchPrChecks(repo: string, number: number, token: string | null): Promise<CheckSummary> {
+  try {
+    const { res, data } = await ghFetch(`/repos/${repo}/pulls/${number}`, token);
+    const sha = (data as { head?: { sha?: string } } | null)?.head?.sha;
+    if (!res.ok || !sha) return null;
+    const { data: cr } = await ghFetch(`/repos/${repo}/commits/${sha}/check-runs?per_page=100`, token);
+    const runs = ((cr as { check_runs?: unknown[] } | null)?.check_runs ?? []) as Array<{ status?: string; conclusion?: string }>;
+    if (runs.length > 0) return summarizeChecks(runs);
+    const { data: st } = await ghFetch(`/repos/${repo}/commits/${sha}/status`, token);
+    return summarizeChecks([], (st as { state?: string } | null)?.state);
+  } catch {
+    return null;
+  }
+}
 
 type ActivityResult = {
   ok: true;
@@ -170,6 +196,21 @@ export async function GET() {
       });
     }
   } catch { /* non-fatal */ }
+
+  // Enrich PR rows with their CI rollup. Token-gated: this spends core REST
+  // quota (a few calls per PR), which the public 60/hr budget can't absorb —
+  // mirrors how review-requested PRs already require a token. Best-effort and
+  // parallel; the UI only surfaces a `failing` pip.
+  if (token) {
+    const prRows = items
+      .filter((it) => (it.kind === "pr" || it.kind === "review_request") && typeof it.number === "number")
+      .slice(0, CHECK_ENRICH_CAP);
+    await Promise.all(
+      prRows.map(async (it) => {
+        it.checkStatus = await fetchPrChecks(it.repo, it.number as number, token);
+      }),
+    );
+  }
 
   // sort all by updatedAt desc
   items.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -1364,6 +1364,16 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
                         {item.draft && (
                           <span className="gh-badge gh-badge--muted">draft</span>
                         )}
+                        {item.checkStatus === "failing" && (
+                          <span
+                            className="gh-badge gh-badge--danger"
+                            role="img"
+                            aria-label="CI checks failing"
+                            title="CI checks failing"
+                          >
+                            checks failed
+                          </span>
+                        )}
                       </td>
                       <td>
                         {linked.length === 0 ? (

--- a/src/lib/github-checks.test.ts
+++ b/src/lib/github-checks.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { summarizeChecks } from "./github-checks.ts";
+
+// ── Check-runs (GitHub Actions) take precedence over the legacy status ───────
+
+assert.equal(
+  summarizeChecks([
+    { status: "completed", conclusion: "success" },
+    { status: "completed", conclusion: "success" },
+  ]),
+  "passing",
+  "all completed + success → passing",
+);
+
+assert.equal(
+  summarizeChecks([
+    { status: "completed", conclusion: "success" },
+    { status: "completed", conclusion: "failure" },
+  ]),
+  "failing",
+  "any completed failure → failing",
+);
+
+// Failure outranks pending: a real failed check is actionable even while a
+// perpetual bot / required context is still "in progress". This is what makes
+// the `failing` pip reliable in repos with never-completing checks.
+assert.equal(
+  summarizeChecks([
+    { status: "completed", conclusion: "failure" },
+    { status: "in_progress", conclusion: null },
+  ]),
+  "failing",
+  "a real failure outranks a still-running check → failing",
+);
+
+assert.equal(
+  summarizeChecks([
+    { status: "completed", conclusion: "success" },
+    { status: "in_progress", conclusion: null },
+  ]),
+  "pending",
+  "no failure + a running check → pending",
+);
+
+assert.equal(
+  summarizeChecks([{ status: "queued", conclusion: null }]),
+  "pending",
+  "queued check → pending",
+);
+
+assert.equal(
+  summarizeChecks([
+    { status: "completed", conclusion: "success" },
+    { status: "completed", conclusion: "skipped" },
+    { status: "completed", conclusion: "neutral" },
+  ]),
+  "passing",
+  "skipped/neutral are not failures",
+);
+
+for (const bad of ["failure", "timed_out", "action_required", "startup_failure"]) {
+  assert.equal(
+    summarizeChecks([{ status: "completed", conclusion: bad }]),
+    "failing",
+    `${bad} conclusion → failing`,
+  );
+}
+
+// cancelled / stale are superseded runs, NOT genuine breakage — don't flag red.
+for (const benign of ["cancelled", "stale"]) {
+  assert.equal(
+    summarizeChecks([
+      { status: "completed", conclusion: "success" },
+      { status: "completed", conclusion: benign },
+    ]),
+    "passing",
+    `${benign} is not treated as a failure`,
+  );
+}
+
+// ── Legacy combined-status fallback (no check-runs) ──────────────────────────
+
+assert.equal(summarizeChecks([], "success"), "passing", "combined success → passing");
+assert.equal(summarizeChecks([], "failure"), "failing", "combined failure → failing");
+assert.equal(summarizeChecks([], "error"), "failing", "combined error → failing");
+assert.equal(summarizeChecks([], "pending"), "pending", "combined pending → pending");
+
+// ── No signal at all → null ──────────────────────────────────────────────────
+
+assert.equal(summarizeChecks([]), null, "no checks + no status → null");
+assert.equal(summarizeChecks([], undefined), null, "no checks + undefined status → null");
+assert.equal(summarizeChecks([], "unknown_state"), null, "unrecognized combined state → null");
+
+console.log("github-checks.test.ts OK");

--- a/src/lib/github-checks.ts
+++ b/src/lib/github-checks.ts
@@ -1,0 +1,61 @@
+/**
+ * Aggregate a pull request's CI signals into a single rollup status for the
+ * GitHub view's per-PR status pip. Pure + dependency-free so it's unit-testable
+ * without touching the network.
+ *
+ * NOTE: only the `failing` result is surfaced in the UI. `passing` / `pending`
+ * are computed honestly here but not rendered, because repos with a perpetual
+ * bot check (e.g. an always-in-progress reviewer) or "expected" required
+ * contexts that never run will read as `pending` forever — so a green/amber pip
+ * would mislead. A genuine `failure` conclusion, by contrast, only comes from a
+ * real CI job that ran and failed, which is the reliable, actionable signal.
+ */
+
+export type CheckSummary = "passing" | "failing" | "pending" | null;
+
+export type CheckRun = { status?: string | null; conclusion?: string | null };
+
+// GitHub check-run conclusions that mean a real job ran and did not pass.
+// "neutral", "skipped", "success", "cancelled", and "stale" are NOT treated as
+// failures: cancelled/stale are usually superseded runs, not genuine breakage.
+const FAIL_CONCLUSIONS = new Set([
+  "failure",
+  "timed_out",
+  "action_required",
+  "startup_failure",
+]);
+
+/**
+ * Roll up GitHub Actions check-runs (preferred) with the legacy combined
+ * commit-status state as a fallback:
+ *   - `failing`  — at least one completed check-run failed.
+ *   - `pending`  — no failure, but at least one check-run is still running.
+ *   - `passing`  — at least one check-run, all completed, none failed.
+ *   - `null`     — no CI signal at all.
+ *
+ * Failure takes precedence over pending: a PR with a failed check needs
+ * attention even if other checks are still running.
+ */
+export function summarizeChecks(
+  checkRuns: CheckRun[],
+  combinedState?: string | null,
+): CheckSummary {
+  if (checkRuns.length > 0) {
+    const failed = checkRuns.some((run) => FAIL_CONCLUSIONS.has(run.conclusion ?? ""));
+    if (failed) return "failing";
+    const pending = checkRuns.some((run) => run.status !== "completed");
+    return pending ? "pending" : "passing";
+  }
+
+  switch (combinedState) {
+    case "success":
+      return "passing";
+    case "failure":
+    case "error":
+      return "failing";
+    case "pending":
+      return "pending";
+    default:
+      return null;
+  }
+}

--- a/src/lib/github-tasks.ts
+++ b/src/lib/github-tasks.ts
@@ -19,6 +19,9 @@ export type GitHubItem = {
   updatedAt: string;
   draft?: boolean;
   labels?: string[];
+  /** CI rollup for PR rows; only "failing" is surfaced in the UI. See
+   *  {@link import("./github-checks").summarizeChecks}. */
+  checkStatus?: "passing" | "failing" | "pending" | null;
 };
 
 export type GitHubItemContext = {

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -566,6 +566,7 @@
 .gh-title:hover { color:var(--accent-presence); text-decoration:underline; }
 .gh-badge { display:inline-flex; align-items:center; padding:1px 6px; margin-left:6px; border-radius:9999px; font-size:9.5px; line-height:1.4; vertical-align:middle; }
 .gh-badge--muted { background:var(--bg-raised); color:var(--text-muted); }
+.gh-badge--danger { background:color-mix(in oklch,var(--color-danger) 16%,transparent); color:var(--color-danger); font-weight:560; }
 .gh-empty-cell { color:color-mix(in oklch,var(--text-muted) 55%,transparent); font-size:11px; }
 
 .gh-task-chip-list { display:inline-flex; align-items:center; gap:4px; flex-wrap:wrap; max-width:230px; }


### PR DESCRIPTION
## What

PR rows in the GitHub view showed kind / repo / title / tasks / time but nothing about CI. Now a PR whose checks have genuinely **failed** gets a red **"checks failed"** badge, so you can spot broken PRs at a glance.

## Honest scope (important)

I investigated showing the full passing/pending/failing pip and found the clean signals are **unreliable in this repo**: GraphQL `statusCheckRollup` and raw `/check-runs` both report `PENDING` for PRs that actually merged green — because of a perpetual `copilot-pull-request-reviewer` check that never completes and the documented CodeQL "expected" `Analyze (<lang>)` contexts (see CLAUDE.md). A green/amber pip would show "pending" on nearly every PR forever.

A genuine `failure` conclusion, by contrast, only comes from a real CI job that ran and failed — unambiguous and actionable. So I surface **only** the failing signal. `summarizeChecks` still computes passing/pending honestly (and the UI can show them later if the upstream noise is fixed); they're just not rendered today.

## How

- `src/lib/github-checks.ts` — pure, unit-tested `summarizeChecks` (failure outranks pending; cancelled/stale aren't failures). 16 cases.
- `api/github/activity` — per-PR `fetchPrChecks` (head SHA → check-runs → summarize), **token-gated** (spends core REST quota the public 60/hr budget can't absorb — same gate review-requested PRs already use), capped at 15, parallel, best-effort.
- `github-view.tsx` + `board.css` — red `gh-badge--danger` "checks failed" badge, rendered only for `checkStatus === "failing"`.

## Verification

- `summarizeChecks` unit test (16 cases) — wired into the app suite (`check:tests-wired` green; 340 files).
- Fetch path validated against **real** public coven-cave PRs (shapes correct) and cross-checked vs `gh pr checks` — this is how I found the phantom-check problem.
- `pnpm typecheck` clean, `pnpm test:app` 340 pass, `pnpm build` green.
- UI live (mocked API): only the failing PR shows the red badge; passing/pending suppressed; draft badge unaffected. Screenshot confirms.

Note: the enrichment is token-gated, so it activates once a `GITHUB_PAT` is configured (this dev env has only `GITHUB_USERNAME`), matching the existing review-request behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)