### PR TITLE
feat(notifications): add "Clear all" to the bell dropdown

### DIFF
--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -101,6 +101,21 @@ export function NotificationBell({
     await fetch(`/api/inbox/${id}/dismiss`, { method: "POST" });
   }, []);
 
+  // Fired notifications are the dismissible stack the badge counts; response-
+  // needed bridges aren't dismissed here (they need a reply, not a clear).
+  const dismissableIds = useMemo(
+    () => items.filter((i) => i.status === "fired").map((i) => i.id),
+    [items],
+  );
+
+  const dismissAll = useCallback(async () => {
+    // Fan out the existing per-item dismiss; the inbox SSE reconciles the list
+    // and badge (same path the single ✕ uses).
+    await Promise.all(
+      dismissableIds.map((id) => fetch(`/api/inbox/${id}/dismiss`, { method: "POST" })),
+    );
+  }, [dismissableIds]);
+
   const snooze = useCallback(async (id: string) => {
     await fetch(`/api/inbox/${id}/snooze`, {
       method: "POST",
@@ -148,6 +163,15 @@ export function NotificationBell({
               >
                 <Icon name="ph:gear-six-bold" aria-hidden />
               </button>
+              {dismissableIds.length > 0 ? (
+                <button
+                  onClick={() => void dismissAll()}
+                  className="notification-bell__clear-all focus-ring rounded text-[11px] text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]"
+                  title={`Dismiss all ${dismissableIds.length} notification${dismissableIds.length !== 1 ? "s" : ""}`}
+                >
+                  Clear all
+                </button>
+              ) : null}
               <button
                 onClick={() => {
                   setOpen(false);


### PR DESCRIPTION
## What

The notification bell dropdown only let you dismiss fired notifications **one at a time** — clearing a stacked badge meant N clicks. Added a **"Clear all"** action to the popover header (between the settings gear and "Open Schedules →"), shown only when there are fired items.

## How

- `notification-bell.tsx`: `dismissableIds` (fired items) gates the button; `dismissAll` fans out the existing `POST /api/inbox/{id}/dismiss` in parallel. The inbox SSE reconciles the list + badge — the same path the single ✕ uses. Response-needed bridges are left untouched (they need a reply, not a dismiss).

## Verification

- `pnpm typecheck` clean, `pnpm test:app` → 340 files pass, `pnpm build` green.
- Live (mobile viewport, SSE-mocked with 3 fired items): the header shows "Clear all" (title "Dismiss all 3 notifications"); clicking it fired dismiss for all three (n1/n2/n3). Screenshot confirms the header layout. The button is hidden when there are no fired items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)