### PR TITLE
fix(library): clear reading finishedAt when an item leaves done

### DIFF
--- a/src/app/api/library/reading/route.ts
+++ b/src/app/api/library/reading/route.ts
@@ -66,13 +66,20 @@ export async function PATCH(req: NextRequest) {
   }
 
   try {
+    const nextStatus = body.status as ReadingStatus;
     const item = await store.updateReading(body.id, (existing) => ({
       ...existing,
-      status: body.status as ReadingStatus,
+      status: nextStatus,
       progress: body.progress ?? existing.progress,
-      finishedAt: body.status === "done" && existing.status !== "done"
-        ? new Date().toISOString()
-        : existing.finishedAt,
+      // Stamp finishedAt when an item first becomes done; clear it whenever it
+      // leaves done (so an un-marked item doesn't keep a stale completion date);
+      // otherwise preserve the existing stamp.
+      finishedAt:
+        nextStatus !== "done"
+          ? undefined
+          : existing.status === "done"
+            ? existing.finishedAt
+            : new Date().toISOString(),
     }));
     if (!item) return NextResponse.json({ ok: false, error: "not found" }, { status: 404 });
     return NextResponse.json({ ok: true, item });


### PR DESCRIPTION
## What

The reading-list `PATCH /api/library/reading` stamped `finishedAt` when an item became **done**, but never cleared it. Un-marking an item (done → want-to-read / reading / abandoned) left a stale completion date on the record.

## Fix

Clear `finishedAt` whenever the next status isn't `done`; keep the existing stamp while the item stays `done`; stamp `now` on the fresh transition into `done`.

```ts
finishedAt:
  nextStatus !== "done"        ? undefined
  : existing.status === "done" ? existing.finishedAt
  :                              new Date().toISOString(),
```

The store replaces the item and writes via `JSON.stringify` (drops `undefined`), so the key is removed from `reading.json`.

## Context

Surfaced while verifying the new iOS "mark read" checkbox (#1438): marking read then unread left `finishedAt` set. Cosmetic (nothing displays it today) but it's wrong data. No behavior change for items that stay done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)