### PR TITLE
feat(ui): keep relative timestamps live with a shared minute tick

### DIFF
--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -12,6 +12,7 @@ import { SessionInitiatorChip } from "@/components/ui/session-initiator-chip";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { relativeTime, isRelativePhrase } from "@/lib/relative-time";
+import { useMinuteTick } from "@/lib/use-minute-tick";
 import { useDateTimePrefs, formatDate, type DateTimePrefs } from "@/lib/datetime-format";
 import {
   deriveChatProjectGroups,
@@ -229,6 +230,7 @@ function ChatListSection({
 // ── Main component ────────────────────────────────────────────────────────────
 
 export function ChatList({ familiar, familiars = [], sessions, daemonRunning, onOpen, onNewChat, onSessionsChanged, sessionsLoaded = true, compact = false }: Props) {
+  useMinuteTick(); // keep the "Xm ago" timestamps current without a data refresh
   const { projects } = useProjects();
   const projectOverrides = useProjectOverrides();
   const dtPrefs = useDateTimePrefs();

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState, type CSSProperties, type FormEven
 
 import { Icon } from "@/lib/icon";
 import { relativeTime } from "@/lib/relative-time";
+import { useMinuteTick } from "@/lib/use-minute-tick";
 import type { CaveProject } from "@/lib/cave-projects-types";
 import { normalizeProjectRoot } from "@/lib/cave-projects-types";
 import { CHAT_FOCUS_PROJECT_EVENT } from "@/lib/chat-tab-events";
@@ -542,6 +543,7 @@ function ProjectRow({
 }
 
 export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: ProjectsViewProps) {
+  useMinuteTick(); // keep the per-project "last active" relative times current
   const {
     projects,
     loading,

--- a/src/lib/use-minute-tick.ts
+++ b/src/lib/use-minute-tick.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Re-renders the calling component about once a minute so relative-time labels
+ * ("4m ago") stay current without waiting for a data refresh. The returned
+ * counter is incidental — callers don't need to read it; the state change is
+ * what triggers the re-render.
+ *
+ * Cheap by design: a single 60s interval per consumer, cleared on unmount.
+ */
+export function useMinuteTick(): number {
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => clearInterval(id);
+  }, []);
+  return tick;
+}


### PR DESCRIPTION
## What

"Xm ago" labels in the **sessions list** (chat-list) and the **Projects tab** were computed once and only refreshed when their data reloaded — so idling on those lists left timestamps stale ("4m ago" on a chat that's actually 18m old). There was no shared "now" tick anywhere in the app.

## How

- `src/lib/use-minute-tick.ts` — a tiny `useMinuteTick()` hook (one 60s interval → re-render, cleared on unmount).
- Called in `ChatList` and `ProjectsView`. `relativeTime()` reads the clock on each render, so the labels stay current. Neither component memoizes its rows, so the single top-level tick cascades to every timestamp.
- Left as-is: the recent-activity roll-up already polls every 15s, and the command palette is transient.

## Verification

- `pnpm typecheck` clean, `pnpm test:app` → 340 files pass, `pnpm build` green.
- Live (Playwright fixed clock): a session showing **"4m ago"** updated to **"19m ago"** after fast-forwarding the clock 15 minutes with **static** session data — proving the relabel comes from the tick, not a data refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)