### PR TITLE
perf(chat-search): cache conversation content by mtime

### DIFF
--- a/src/lib/cave-conversations.test.ts
+++ b/src/lib/cave-conversations.test.ts
@@ -267,3 +267,33 @@ if (previousHome === undefined) {
 await rm(home, { recursive: true, force: true });
 
 console.log("cave-conversations.test.ts: ok");
+
+// ── searchConversations content cache invalidates on mtime (perf) ────────────
+{
+  const { searchConversations, CONV_DIR } = await import("./cave-conversations.ts");
+  const { writeFile, utimes, mkdir } = await import("node:fs/promises");
+  await mkdir(CONV_DIR, { recursive: true });
+  const file = path.join(CONV_DIR, "cache-test.json");
+  const mk = (text) =>
+    JSON.stringify({
+      sessionId: "cache-test",
+      title: "Cache test",
+      updatedAt: new Date().toISOString(),
+      turns: [{ id: "t1", role: "user", text }],
+    });
+  await writeFile(file, mk("alpha unique-marker-aaa"), "utf8");
+  let hits = await searchConversations("unique-marker-aaa");
+  assert.equal(hits.length, 1, "first search finds the original content");
+
+  await writeFile(file, mk("beta unique-marker-bbb"), "utf8");
+  const future = new Date(Date.now() + 60_000);
+  await utimes(file, future, future);
+  hits = await searchConversations("unique-marker-bbb");
+  assert.equal(hits.length, 1, "after edit, search finds the NEW content (mtime invalidation)");
+  const stale = await searchConversations("unique-marker-aaa");
+  assert.equal(stale.length, 0, "old content is no longer matched after the edit");
+
+  const again = await searchConversations("unique-marker-bbb");
+  assert.equal(again.length, 1, "repeat search via the cache returns the same hit");
+}
+console.log("cave-conversations cache test OK");

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -213,6 +213,13 @@ function searchSnippet(text: string, index: number, matchLength: number): string
   return excerpt;
 }
 
+// Per-file content cache, keyed by absolute path and invalidated by mtime, so
+// repeated searches don't re-read + re-parse unchanged conversations (the
+// dominant cost as the transcript count grows). A saveConversation/appendTurn
+// write bumps the mtime, so the next search refreshes just that one file.
+type ConvCacheEntry = { mtimeMs: number; lower: string; conv: ConversationFile | null };
+const searchCache = new Map<string, ConvCacheEntry>();
+
 export async function searchConversations(
   query: string,
   opts: { limit?: number; maxFileBytes?: number } = {},
@@ -230,18 +237,40 @@ export async function searchConversations(
     return [];
   }
 
+  // Drop cache entries for conversations that have since been deleted.
+  if (searchCache.size > 0) {
+    const live = new Set(
+      entries.filter((n) => n.endsWith(".json")).map((n) => path.join(CONV_DIR, n)),
+    );
+    for (const key of searchCache.keys()) if (!live.has(key)) searchCache.delete(key);
+  }
+
   const hits: Array<ConversationSearchHit & { updatedAt: string }> = [];
   for (const name of entries) {
     if (!name.endsWith(".json")) continue;
     try {
       const file = path.join(CONV_DIR, name);
       const info = await stat(file);
-      if (info.size > maxFileBytes) continue; // huge body — skip gracefully
-      const raw = await readFile(file, "utf8");
-      // Cheap substring pre-filter on the raw text before paying for parse.
-      if (!raw.toLowerCase().includes(qLower)) continue;
-      const conv = JSON.parse(raw) as ConversationFile;
-      if (!Array.isArray(conv?.turns)) continue;
+      if (info.size > maxFileBytes) {
+        searchCache.delete(file); // too big now — don't keep a stale entry
+        continue;
+      }
+      let entry = searchCache.get(file);
+      if (!entry || entry.mtimeMs !== info.mtimeMs) {
+        const raw = await readFile(file, "utf8");
+        let parsed: ConversationFile | null = null;
+        try {
+          parsed = JSON.parse(raw) as ConversationFile;
+        } catch {
+          parsed = null;
+        }
+        entry = { mtimeMs: info.mtimeMs, lower: raw.toLowerCase(), conv: parsed };
+        searchCache.set(file, entry);
+      }
+      // Cheap substring pre-filter before scanning turns.
+      if (!entry.lower.includes(qLower)) continue;
+      const conv = entry.conv;
+      if (!conv || !Array.isArray(conv.turns)) continue;
       let matchCount = 0;
       let snippet = "";
       for (const turn of conv.turns) {


### PR DESCRIPTION
## What (Phase 3 of 3: global chat search)

`searchConversations` (the backend behind the chat-list search and the new ⌘K Conversations group, #1443) re-read and re-parsed **every** transcript on **every** query. Add a module-level content cache keyed by file path and invalidated by **mtime**, so unchanged conversations are skipped (just a `stat`) and only edited files are re-read. Deleted files are pruned from the cache each run.

This is purely an I/O optimization — **results are unchanged** — that matters as the transcript count grows (hundreds/thousands of sessions).

## How

- `cave-conversations.ts`: `searchCache: Map<path, {mtimeMs, lower, conv}>`. On each file: `stat`; reuse the cached lowercased text + parsed conv if `mtimeMs` matches, else re-read/parse and refresh. A `saveConversation`/`appendTurn` write bumps the mtime, so the next search picks it up. Oversized (>2MB) files drop their cache entry and are skipped, as before.

## Verification

- New test in `cave-conversations.test.ts`: search finds original content → file overwritten + mtime bumped → search finds the **new** content and no longer the old (proves mtime invalidation); a repeat search via the cache returns the same hit.
- `pnpm typecheck` clean, `pnpm test:app` → 340 pass, `pnpm build` green.

Completes the arc: #1443 (palette Conversations group) + jump-to-match (next) + this index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)