### PR TITLE
feat(palette): jump to the matched message when opening a Conversations hit

### DIFF
--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -58,7 +58,7 @@ type Props = {
 export type ChatRouterHandle = {
   goToList: () => void;
   newChat: (projectRoot?: string, initialPrompt?: string, familiarId?: string | null) => void;
-  openSession: (sessionId: string) => void;
+  openSession: (sessionId: string, findQuery?: string) => void;
   currentSessionId: () => string | null;
   clearTranscript: () => void;
   runSlash: (command: string) => void;
@@ -98,6 +98,9 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
   ref,
 ) {
   const [view, setView] = useState<View>({ kind: "list" });
+  // Set when a conversation-search hit asks the opened chat to jump to a query;
+  // handed to ChatView (nonce-keyed) so it opens in-thread find on the match.
+  const [pendingFind, setPendingFind] = useState<{ query: string; nonce: number } | null>(null);
   const viewHandle = useRef<ChatViewHandle | null>(null);
   const previousFamiliarIdRef = useRef<string | null | undefined>(undefined);
   const sidebarPrefsLoadedRef = useRef(false);
@@ -253,10 +256,12 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
           familiarId: next?.id ?? familiarId ?? null,
         });
       },
-      openSession: (sessionId: string) => {
+      openSession: (sessionId: string, findQuery?: string) => {
         const session = sessions.find((entry) => entry.id === sessionId);
         const next = selectFamiliarForChat(session?.familiarId ?? null);
         setView({ kind: "chat", sessionId, familiarId: next?.id ?? session?.familiarId ?? null });
+        const fq = findQuery?.trim();
+        if (fq) setPendingFind({ query: fq, nonce: Date.now() });
       },
       currentSessionId: () => (view.kind === "chat" ? view.sessionId : null),
       clearTranscript: () => viewHandle.current?.clearTranscript(),
@@ -392,6 +397,8 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
             session={activeSession}
             projectRoot={view.kind === "chat" ? view.projectRoot : undefined}
             initialPrompt={view.kind === "chat" ? view.initialPrompt : undefined}
+            openFindQuery={pendingFind?.query}
+            openFindNonce={pendingFind?.nonce}
             daemonRunning={daemonRunning}
             onSessionsChanged={onSessionsChanged}
             onBack={() => setView({ kind: "list" })}

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -393,7 +393,8 @@ export function ChatSurface({
     if (pendingChatAction.kind === "open") {
       if (pendingChatAction.familiarId) onSetActiveFamiliar(pendingChatAction.familiarId);
       setScope("conversation");
-      window.setTimeout(() => routerRef.current?.openSession(pendingChatAction.sessionId), 0);
+      const findQuery = pendingChatAction.findQuery;
+      window.setTimeout(() => routerRef.current?.openSession(pendingChatAction.sessionId, findQuery), 0);
       onPendingChatActionHandled();
       return;
     }

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -140,6 +140,10 @@ type Props = {
   /** Prompt handed off from the home composer. Auto-sent once on mount so the
    *  send runs through this view's streaming path instead of a detached fetch. */
   initialPrompt?: string;
+  /** When set (with a changing nonce), opens the in-thread find on this query —
+   *  used by the ⌘K Conversations result to jump to the matched message. */
+  openFindQuery?: string;
+  openFindNonce?: number;
   daemonRunning?: boolean;
   onSessionStarted?: (sessionId: string) => void;
   onSessionsChanged?: () => void;
@@ -1509,7 +1513,7 @@ function MobileChatActionStrip({
 // ── ChatView ──────────────────────────────────────────────────────────────────
 
 export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
-  { familiar, sessionId, session, projectRoot, initialPrompt, daemonRunning, onSessionStarted, onSessionsChanged, onBack, onSlashCommand, onOpenOnboarding, onOpenTask, onOpenUrl, onProjectRootChange },
+  { familiar, sessionId, session, projectRoot, initialPrompt, openFindQuery, openFindNonce, daemonRunning, onSessionStarted, onSessionsChanged, onBack, onSlashCommand, onOpenOnboarding, onOpenTask, onOpenUrl, onProjectRootChange },
   ref,
 ) {
   const [turns, setTurns] = useState<Turn[]>([]);
@@ -1811,6 +1815,20 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     clearFoundHighlightTimer();
     setFoundTurnId(null);
   }, [clearFoundHighlightTimer, sessionId]);
+
+  // Open in-thread find on a query handed in from a ⌘K Conversations hit. Keyed
+  // on the nonce so it fires once per request, and declared AFTER the session
+  // reset above so it wins when both run on the same session switch. The find
+  // effect then auto-scrolls to the first match once the transcript loads.
+  const openFindNonceRef = useRef(0);
+  useEffect(() => {
+    if (!openFindNonce || openFindNonce === openFindNonceRef.current) return;
+    openFindNonceRef.current = openFindNonce;
+    const q = (openFindQuery ?? "").trim();
+    if (!q) return;
+    setFindOpen(true);
+    setFindQuery(q);
+  }, [openFindNonce, openFindQuery]);
 
   // ⌘F/Ctrl+F is scoped to the chat section via this React keydown handler
   // on the section root — NOT a window-level listener — so ChatList's ⌘F

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -63,7 +63,7 @@ const SESSION_DOT: Record<string, string> = {
 
 type PaletteIntent =
   | { kind: "switch-familiar"; familiarId: string }
-  | { kind: "open-session"; sessionId: string; familiarId?: string | null }
+  | { kind: "open-session"; sessionId: string; familiarId?: string | null; findQuery?: string }
   | { kind: "new-chat"; familiarId?: string }
   | { kind: "slash"; command: string; args?: string }
   | { kind: "back-to-list" }
@@ -729,7 +729,13 @@ export function CommandPalette({
       onIntent({ kind: "create-task", title: row.title });
     } else if (row.kind === "conversation-hit") {
       const familiarId = sessions.find((s) => s.id === row.hit.sessionId)?.familiarId ?? null;
-      onIntent({ kind: "open-session", sessionId: row.hit.sessionId, familiarId });
+      // Carry the matched query so the opened chat jumps to it via in-thread find.
+      onIntent({
+        kind: "open-session",
+        sessionId: row.hit.sessionId,
+        familiarId,
+        findQuery: parseFamiliarToken(query).rest.trim(),
+      });
     } else {
       onIntent(row.intent);
     }

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -926,12 +926,13 @@ export function Workspace() {
     setToasts((prev) => prev.filter((t) => t.id !== toast.id));
   }, []);
 
-  const openFamiliarSession = useCallback((sessionId: string, familiarId?: string | null) => {
+  const openFamiliarSession = useCallback((sessionId: string, familiarId?: string | null, findQuery?: string) => {
     if (familiarId) setActiveId(familiarId);
     setPendingChatAction({
       kind: "open",
       sessionId,
       familiarId,
+      ...(findQuery ? { findQuery } : {}),
       nonce: Date.now(),
     });
     setMode("chat");
@@ -1178,7 +1179,7 @@ export function Workspace() {
       return;
     }
     if (intent.kind === "open-session") {
-      openFamiliarSession(intent.sessionId, intent.familiarId);
+      openFamiliarSession(intent.sessionId, intent.familiarId, intent.findQuery);
       return;
     }
     if (intent.kind === "new-chat") {

--- a/src/lib/pending-chat-action.ts
+++ b/src/lib/pending-chat-action.ts
@@ -8,6 +8,6 @@ export type PendingChatAction =
       initialPrompt?: string | null;
       nonce: number;
     }
-  | { kind: "open"; sessionId: string; familiarId?: string | null; nonce: number }
+  | { kind: "open"; sessionId: string; familiarId?: string | null; findQuery?: string; nonce: number }
   | { kind: "list"; nonce: number }
   | null;


### PR DESCRIPTION
## What (Phase 2 of 3: global chat search — completes the arc)

Selecting a ⌘K **Conversations** result (#1443) already opened the chat; now it also **jumps to the matched message**. The in-thread find opens on the search query and scrolls to the first hit.

## How

The query threads through the chat-open path: palette `open-session` intent (now carries `findQuery`) → `workspace.openFamiliarSession` → the `PendingChatAction` "open" variant → `chat-surface` → `chat-router`, which hands it to `ChatView` as a **nonce-keyed `openFindQuery` prop**. ChatView opens its find on that query in an effect declared **after** the per-session find-reset (so it wins on the same session switch); the existing find logic then auto-scrolls to the first match once the transcript loads. No timing hacks.

## Verification

- `pnpm typecheck` clean, `pnpm test:app` → 340 pass (incl. command-palette + chat-view-render-optimization source pins), `pnpm build` green.
- Live (mocked search + sessions + transcript): clicking the "Board planning" conversation hit opened that chat (3 turns) and opened in-thread find on **"gantt"** showing **"1 / 2"** — i.e. jumped to the first of 2 matches. Screenshot confirms.

Completes the arc: #1443 (Conversations group) + #1455 (mtime cache) + this (jump-to-match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)