### PR TITLE
feat(ios): link tasks ↔ chats with two-way navigation

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -89,6 +89,37 @@ struct CaveClient {
         }
     }
 
+    struct BoardPatchResponse: Decodable {
+        var ok: Bool
+        var error: String?
+        var card: BoardCard?
+    }
+
+    /// Encodable that always emits `sessionId` (null when clearing) — the board
+    /// patch only updates a field when its key is present in the body.
+    private struct SessionPatch: Encodable {
+        let sessionId: String?
+        enum CodingKeys: String, CodingKey { case sessionId }
+        func encode(to encoder: Encoder) throws {
+            var c = encoder.container(keyedBy: CodingKeys.self)
+            if let sessionId { try c.encode(sessionId, forKey: .sessionId) }
+            else { try c.encodeNil(forKey: .sessionId) }
+        }
+    }
+
+    /// PATCH a card's linked chat session (`PATCH /api/board/{id}`). Pass nil to
+    /// unlink. Returns the server's updated card.
+    @discardableResult
+    func updateTaskSession(cardId: String, sessionId: String?) async throws -> BoardCard {
+        let payload = try JSONEncoder().encode(SessionPatch(sessionId: sessionId))
+        let req = try request("api/board/\(cardId)", method: "PATCH", body: payload)
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        let decoded = try JSONDecoder().decode(BoardPatchResponse.self, from: data)
+        if let card = decoded.card { return card }
+        throw CaveError.transport(decoded.error ?? "Task update did not return a card.")
+    }
+
     func conversation(sessionId: String) async throws -> Conversation? {
         let req = try request("api/chat/conversation/\(sessionId)")
         let (data, resp) = try await session.data(for: req)

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -472,7 +472,9 @@ final class AppModel {
     /// After a thread finishes streaming it may have just acquired its server
     /// session; PATCH any locally-linked card that doesn't yet carry it.
     func reconcileCardLinks(for thread: ChatThread) async {
-        guard let sid = primarySessionId(of: thread) else { return }
+        guard cardThreadLinks.values.contains(thread.id),
+              let sid = primarySessionId(of: thread) else { return }
+        if !tasksLoaded { await loadTasks() }
         let cardIds = cardThreadLinks.filter { $0.value == thread.id }.map(\.key)
         for cardId in cardIds where (tasks.first { $0.id == cardId })?.sessionId != sid {
             await patchCardSession(cardId: cardId, sessionId: sid)

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -41,6 +41,10 @@ final class AppModel {
     /// the thread, and clears it back to nil (one-shot navigation intent).
     var threadToOpen: ChatThread?
 
+    /// A task the user asked to open from a chat. `TasksView` observes this,
+    /// pushes the card, and clears it (mirrors `threadToOpen`).
+    var cardToOpen: BoardCard?
+
     /// The active confirmation toast, auto-dismissed by the overlay.
     var toast: ToastMessage?
 
@@ -54,6 +58,12 @@ final class AppModel {
     func requestOpen(_ thread: ChatThread) {
         selectedTab = .chats
         threadToOpen = thread
+    }
+
+    /// Ask the Tasks tab to open a card's detail (switches to Tasks first).
+    func requestOpenTask(_ card: BoardCard) {
+        selectedTab = .tasks
+        cardToOpen = card
     }
 
     /// Resolve a free-text familiar reference (id or display name, fuzzy) to a
@@ -70,6 +80,15 @@ final class AppModel {
     var tasks: [BoardCard] = []
     var tasksError: String?
     var tasksLoaded = false
+
+    // MARK: - Task ↔ chat links
+
+    /// cardId → local thread id. The iOS-immediate source of truth for the
+    /// task↔chat relationship: it works before a server `sessionId` exists
+    /// (a brand-new chat), and for group threads. When a thread does have a
+    /// server session, `card.sessionId` is PATCHed too so the link is visible
+    /// on the desktop/web board. Persisted to `cave-card-links.json`.
+    var cardThreadLinks: [String: String] = [:]
 
     // MARK: - Reading list
 
@@ -102,6 +121,7 @@ final class AppModel {
     init() {
         connection = CaveConnection.load()
         loadThreads()
+        loadCardLinks()
         if connection != nil { connectionState = .checking }
     }
 
@@ -354,6 +374,137 @@ final class AppModel {
         }
     }
 
+    // MARK: - Task ↔ chat linking
+
+    /// The thread linked to a card, if any: prefer the explicit local link,
+    /// then fall back to matching the card's server `sessionId` to a thread's
+    /// per-familiar session (covers links made on another device / the desktop).
+    func linkedThread(for card: BoardCard) -> ChatThread? {
+        if let tid = cardThreadLinks[card.id],
+           let thread = threads.first(where: { $0.id == tid }) {
+            return thread
+        }
+        if let sid = card.sessionId, !sid.isEmpty {
+            return threads.first { $0.sessionIds.values.contains(sid) }
+        }
+        return nil
+    }
+
+    /// Cards linked to a thread (local link map ∪ session-id match).
+    func linkedTasks(for thread: ChatThread) -> [BoardCard] {
+        let sessionIds = Set(thread.sessionIds.values.filter { !$0.isEmpty })
+        return tasks.filter { card in
+            if cardThreadLinks[card.id] == thread.id { return true }
+            if let sid = card.sessionId, !sid.isEmpty { return sessionIds.contains(sid) }
+            return false
+        }
+    }
+
+    /// True when a card has any linked chat (cheap, for list indicators).
+    func hasLinkedChat(_ card: BoardCard) -> Bool {
+        if cardThreadLinks[card.id] != nil { return true }
+        if let sid = card.sessionId, !sid.isEmpty {
+            return threads.contains { $0.sessionIds.values.contains(sid) }
+        }
+        return false
+    }
+
+    /// A thread's primary server session (first familiar's), if assigned.
+    private func primarySessionId(of thread: ChatThread) -> String? {
+        for familiarId in thread.familiarIds {
+            if let sid = thread.sessionIds[familiarId], !sid.isEmpty { return sid }
+        }
+        return thread.sessionIds.values.first { !$0.isEmpty }
+    }
+
+    /// Open (or create) the chat linked to a card and navigate to it. For an
+    /// unlinked card it starts a fresh thread with `familiarId` (the card's
+    /// assignee, or a caller-supplied pick) and links it. Returns nil only if no
+    /// familiar could be resolved.
+    @discardableResult
+    func openChat(for card: BoardCard, familiarId: String? = nil) -> ChatThread? {
+        if let existing = linkedThread(for: card) {
+            cardThreadLinks[card.id] = existing.id   // backfill from a sessionId match
+            persistCardLinks()
+            requestOpen(existing)
+            return existing
+        }
+        guard let familiarId = familiarId ?? card.familiarId else { return nil }
+        let title = "Task: \(card.title)"
+        let thread: ChatThread
+        if let sid = card.sessionId, !sid.isEmpty {
+            // The card already points at a server session (e.g. started on the
+            // desktop) but no local thread carries it — bind one and pull history.
+            thread = ChatThread(title: title, familiarIds: [familiarId],
+                                sessionIds: [familiarId: sid])
+            threads.insert(thread, at: 0)
+            Task { await loadHistory(into: thread, sessionId: sid) }
+        } else {
+            thread = ChatThread(title: title, familiarIds: [familiarId])
+            threads.insert(thread, at: 0)
+        }
+        cardThreadLinks[card.id] = thread.id
+        persistThreads()
+        persistCardLinks()
+        requestOpen(thread)
+        return thread
+    }
+
+    /// Link an existing task to a thread (from the chat side). Best-effort PATCH
+    /// of the card's `sessionId` so the desktop board sees the link too.
+    func linkTask(_ card: BoardCard, to thread: ChatThread) {
+        cardThreadLinks[card.id] = thread.id
+        persistCardLinks()
+        if let sid = primarySessionId(of: thread), card.sessionId != sid {
+            Task { await patchCardSession(cardId: card.id, sessionId: sid) }
+        }
+    }
+
+    /// Remove a card's chat link (local map + server sessionId).
+    func unlinkTask(_ card: BoardCard) {
+        cardThreadLinks[card.id] = nil
+        persistCardLinks()
+        if card.sessionId != nil {
+            Task { await patchCardSession(cardId: card.id, sessionId: nil) }
+        }
+    }
+
+    /// After a thread finishes streaming it may have just acquired its server
+    /// session; PATCH any locally-linked card that doesn't yet carry it.
+    func reconcileCardLinks(for thread: ChatThread) async {
+        guard let sid = primarySessionId(of: thread) else { return }
+        let cardIds = cardThreadLinks.filter { $0.value == thread.id }.map(\.key)
+        for cardId in cardIds where (tasks.first { $0.id == cardId })?.sessionId != sid {
+            await patchCardSession(cardId: cardId, sessionId: sid)
+        }
+    }
+
+    private func patchCardSession(cardId: String, sessionId: String?) async {
+        guard let client else { return }
+        do {
+            let updated = try await client.updateTaskSession(cardId: cardId, sessionId: sessionId)
+            if let idx = tasks.firstIndex(where: { $0.id == cardId }) { tasks[idx] = updated }
+        } catch {
+            // Non-fatal: the local link still drives in-app navigation.
+        }
+    }
+
+    /// Pull a session's history into a freshly-bound thread so opening a chat
+    /// linked elsewhere isn't blank.
+    private func loadHistory(into thread: ChatThread, sessionId: String) async {
+        guard let client, thread.messages.isEmpty,
+              let convo = try? await client.conversation(sessionId: sessionId) else { return }
+        let assignee = thread.familiarIds.first
+        thread.messages = convo.turns.map { turn in
+            let role = DisplayMessage.Role(rawValue: turn.role) ?? .assistant
+            return DisplayMessage(role: role,
+                                  familiarId: role == .assistant ? assignee : nil,
+                                  text: turn.text,
+                                  isError: turn.isError ?? false)
+        }
+        persistThreads()
+    }
+
     // MARK: - Threads
 
     /// Find an existing direct thread for a familiar, or create one.
@@ -428,5 +579,28 @@ final class AppModel {
         threads = snapshots
             .sorted { $0.updatedAt > $1.updatedAt }
             .map { ChatThread(snapshot: $0) }
+    }
+
+    private var cardLinksFileURL: URL {
+        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("cave-card-links.json")
+    }
+
+    func persistCardLinks() {
+        do {
+            let data = try JSONEncoder().encode(cardThreadLinks)
+            try data.write(to: cardLinksFileURL, options: .atomic)
+        } catch {
+            // Non-fatal: best-effort persistence.
+        }
+    }
+
+    private func loadCardLinks() {
+        guard let data = try? Data(contentsOf: cardLinksFileURL),
+              let map = try? JSONDecoder().decode([String: String].self, from: data) else {
+            return
+        }
+        cardThreadLinks = map
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -8,6 +8,7 @@ struct ChatView: View {
     @FocusState private var composerFocused: Bool
     @State private var showCommands = false
     @State private var showFamiliarPicker = false
+    @State private var showTasks = false
 
     // The slash autocomplete is driven purely off the in-progress draft: a
     // leading "/" on the first word (no whitespace committed yet).
@@ -37,6 +38,23 @@ struct ChatView: View {
                 }
             }
             ToolbarItem(placement: .topBarTrailing) {
+                Button { showTasks = true } label: {
+                    let count = app.linkedTasks(for: thread).count
+                    Image(systemName: count > 0 ? "checklist.checked" : "checklist")
+                        .overlay(alignment: .topTrailing) {
+                            if count > 0 {
+                                Text("\(count)")
+                                    .font(.system(size: 10, weight: .bold))
+                                    .foregroundStyle(.white)
+                                    .padding(3)
+                                    .background(Color.accentColor, in: Circle())
+                                    .offset(x: 8, y: -8)
+                            }
+                        }
+                }
+                .accessibilityLabel("Linked tasks")
+            }
+            ToolbarItem(placement: .topBarTrailing) {
                 Button { showCommands = true } label: {
                     Image(systemName: "command")
                 }
@@ -51,6 +69,14 @@ struct ChatView: View {
                 showFamiliarPicker = false
                 switchTo(familiar)
             }
+        }
+        .sheet(isPresented: $showTasks) {
+            LinkedTasksSheet(thread: thread)
+        }
+        // A new chat linked to a task acquires its server session only after the
+        // first reply; once streaming stops, push that sessionId onto the card.
+        .onChange(of: thread.isStreaming) { _, streaming in
+            if !streaming { Task { await app.reconcileCardLinks(for: thread) } }
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/LinkedTasksSheet.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/LinkedTasksSheet.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+/// From within a chat: see the tasks linked to it, jump straight to a task, or
+/// assign another task to this chat. Backs the chat toolbar's checklist button.
+struct LinkedTasksSheet: View {
+    @Environment(AppModel.self) private var app
+    @Environment(\.dismiss) private var dismiss
+    let thread: ChatThread
+
+    @State private var query = ""
+
+    private var linked: [BoardCard] { app.linkedTasks(for: thread) }
+
+    private var assignable: [BoardCard] {
+        let q = query.trimmingCharacters(in: .whitespaces).lowercased()
+        return app.tasks.filter { card in
+            !linked.contains(where: { $0.id == card.id })
+                && (q.isEmpty || card.title.lowercased().contains(q))
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if !linked.isEmpty {
+                    Section("Linked to this chat") {
+                        ForEach(linked) { card in
+                            Button { open(card) } label: {
+                                HStack(spacing: 8) {
+                                    TaskRow(card: card)
+                                    Image(systemName: "chevron.right")
+                                        .font(.caption).foregroundStyle(.tertiary)
+                                }
+                            }
+                            .buttonStyle(.plain)
+                            .swipeActions {
+                                Button(role: .destructive) { app.unlinkTask(card) } label: {
+                                    Label("Unlink", systemImage: "link.badge.minus")
+                                }
+                            }
+                        }
+                    }
+                }
+                Section("Assign a task") {
+                    if !app.tasksLoaded {
+                        HStack { ProgressView(); Text("Loading tasks…").foregroundStyle(.secondary) }
+                    } else if assignable.isEmpty {
+                        Text(query.isEmpty ? "No other tasks to assign." : "No matches.")
+                            .font(.footnote).foregroundStyle(.secondary)
+                    } else {
+                        ForEach(assignable) { card in
+                            Button { app.linkTask(card, to: thread) } label: {
+                                HStack(spacing: 8) {
+                                    TaskRow(card: card)
+                                    Image(systemName: "plus.circle.fill").foregroundStyle(.tint)
+                                }
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+            }
+            .listStyle(.insetGrouped)
+            .searchable(text: $query, prompt: "Search tasks to assign")
+            .navigationTitle("Tasks")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) { Button("Done") { dismiss() } }
+            }
+            .task { if !app.tasksLoaded { await app.loadTasks() } }
+        }
+    }
+
+    private func open(_ card: BoardCard) {
+        dismiss()
+        app.requestOpenTask(card)
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
@@ -4,6 +4,8 @@ struct TaskDetailView: View {
     @Environment(AppModel.self) private var app
     let card: BoardCard
 
+    @State private var showFamiliarPicker = false
+
     private var familiar: Familiar? { card.familiarId.flatMap(app.familiar) }
 
     var body: some View {
@@ -11,6 +13,7 @@ struct TaskDetailView: View {
             VStack(alignment: .leading, spacing: 20) {
                 header
                 if let familiar { assigneeRow(familiar) }
+                chatCard
                 if card.hasSteps { stepsCard }
                 if let notes = card.notes, !notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     notesCard(notes)
@@ -22,6 +25,58 @@ struct TaskDetailView: View {
         }
         .navigationTitle("Task")
         .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $showFamiliarPicker) {
+            FamiliarPickerSheet { fam in
+                showFamiliarPicker = false
+                app.openChat(for: card, familiarId: fam.id)
+            }
+        }
+    }
+
+    // MARK: - Linked chat
+
+    private var chatCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Chat").font(.headline)
+            if let thread = app.linkedThread(for: card) {
+                Button { app.openChat(for: card) } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: "bubble.left.and.bubble.right.fill")
+                            .foregroundStyle(.tint)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(thread.title).font(.callout.weight(.medium)).foregroundStyle(.primary)
+                            Text(chatSubtitle(thread)).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                        }
+                        Spacer(minLength: 0)
+                        Image(systemName: "chevron.right").font(.caption).foregroundStyle(.tertiary)
+                    }
+                }
+                .buttonStyle(.plain)
+                Button(role: .destructive) { app.unlinkTask(card) } label: {
+                    Label("Unlink chat", systemImage: "link.badge.minus").font(.caption)
+                }
+            } else {
+                Text("No chat linked yet.").font(.caption).foregroundStyle(.secondary)
+                Button {
+                    if card.familiarId != nil { app.openChat(for: card) }
+                    else { showFamiliarPicker = true }
+                } label: {
+                    Label("Start a chat", systemImage: "plus.bubble.fill")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    private func chatSubtitle(_ thread: ChatThread) -> String {
+        if let last = thread.messages.last?.text, !last.isEmpty {
+            return last.replacingOccurrences(of: "\n", with: " ")
+        }
+        return "Tap to open"
     }
 
     private var header: some View {

--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -31,7 +31,17 @@ struct TasksView: View {
                 .refreshable { await app.loadTasks() }
                 .task { if !app.tasksLoaded { await app.loadTasks() } }
                 .safeAreaInset(edge: .top) { scopeBar }
+                .onAppear(perform: openRequestedCard)
+                // A chat asked to open one of its linked tasks.
+                .onChange(of: app.cardToOpen) { _, card in openRequestedCard() }
         }
+    }
+
+    /// Consume a cross-tab "open this task" intent set by `requestOpenTask`.
+    private func openRequestedCard() {
+        guard let card = app.cardToOpen else { return }
+        if path.last?.id != card.id { path.append(card) }
+        app.cardToOpen = nil
     }
 
     private var scopeBar: some View {
@@ -162,6 +172,12 @@ struct TaskRow: View {
                         Label("\(card.doneStepCount)/\(card.stepCount)", systemImage: "checklist")
                             .font(.caption2)
                             .foregroundStyle(.secondary)
+                    }
+                    if app.hasLinkedChat(card) {
+                        Image(systemName: "bubble.left.and.bubble.right.fill")
+                            .font(.caption2)
+                            .foregroundStyle(.tint)
+                            .accessibilityLabel("Has linked chat")
                     }
                     ForEach(card.labelList.prefix(2), id: \.self) { LabelChip(text: $0) }
                     if let updated = caveParseISO(card.updatedAt) {


### PR DESCRIPTION
## What

Lets you move fluidly between a **task** and the **chat** working on it, in the native iOS app.

### From a task → its chat
`TaskDetailView` gains a **Chat** card:
- **Open chat** when a chat is already linked (shows the thread + last message).
- **Start a chat** when none is linked — opens a fresh thread with the task's assigned familiar (or a familiar picker if unassigned) and links it automatically. The new thread is titled `Task: <title>`.
- **Unlink chat** to drop the relationship.

### From a chat → its tasks
`ChatView` toolbar gains a **checklist** button (with a count badge) opening a `LinkedTasksSheet`:
- See tasks linked to this chat and **tap to jump** straight to the task (switches to the Tasks tab and pushes its detail).
- **Assign a task** to this chat from a searchable list of your other tasks.
- Swipe to **unlink**.

### Navigating between
Task→chat uses the existing `requestOpen` intent (switch to Chats, push the thread); chat→task mirrors it with a new `requestOpenTask`/`cardToOpen` intent on the Tasks tab. The Tasks list shows a small chat bubble on any task that has a linked chat.

## Linking model

The link is stored two ways, by design:
- **Local `cardId → threadId` map** (`cave-card-links.json`) — the iOS source of truth. It works *immediately*, before a brand-new chat has a server session, and for group threads. Drives all in-app navigation.
- **Best-effort `card.sessionId` PATCH** via `PATCH /api/board/{id}` — so a link made on the phone is also visible on the desktop/web board. A chat started from a task acquires its server session only after the first reply, so `ChatView` reconciles the card's `sessionId` once streaming stops. Opening a task whose `sessionId` was set elsewhere binds a local thread and pulls its history.

(The web `/api/board/[id]/chat` route is daemon-based and `rejectNonLocalRequest`-gated — not reachable from iOS over Tailscale — so this is an iOS-native flow built on the already-reachable `/api/board` PATCH.)

## Verification
- `xcodebuild ... -destination 'generic/platform=iOS Simulator'` → **BUILD SUCCEEDED** (iOS Swift isn't compiled by CI, so verified locally).
- No backend/web changes; no test files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)