### PR TITLE
feat(chat-list): jump to the matched message from a content-search hit

### DIFF
--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -233,8 +233,8 @@ assert.match(
 );
 assert.match(
   source,
-  /onClick=\{\(\) => \{ setActiveId\(hit\.sessionId\); onOpen\(hit\.sessionId, row\.familiarId\); \}\}/,
-  "Clicking a content hit opens the session via the existing onOpen path",
+  /onClick=\{\(\) => \{ setActiveId\(hit\.sessionId\); onOpen\(hit\.sessionId, row\.familiarId, search\.trim\(\)\); \}\}/,
+  "Clicking a content hit opens the session via onOpen, passing the query so it jumps to the match",
 );
 
 // ── CHAT-D13-02: micro-type legibility ─────────────────────────────────────

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -67,7 +67,7 @@ type Props = {
   familiars?: Familiar[];
   sessions: SessionRow[];
   daemonRunning?: boolean;
-  onOpen: (sessionId: string, familiarId?: string | null) => void;
+  onOpen: (sessionId: string, familiarId?: string | null, findQuery?: string) => void;
   onNewChat: (projectRoot?: string, familiarId?: string | null) => void;
   onSessionsChanged?: () => void;
   /** false while the workspace's first /api/sessions/list fetch is in
@@ -1163,9 +1163,9 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                       <div
                         role="button"
                         tabIndex={0}
-                        onClick={() => { setActiveId(hit.sessionId); onOpen(hit.sessionId, row.familiarId); }}
+                        onClick={() => { setActiveId(hit.sessionId); onOpen(hit.sessionId, row.familiarId, search.trim()); }}
                         onKeyDown={(e) => {
-                          if (e.key === "Enter") { setActiveId(hit.sessionId); onOpen(hit.sessionId, row.familiarId); }
+                          if (e.key === "Enter") { setActiveId(hit.sessionId); onOpen(hit.sessionId, row.familiarId, search.trim()); }
                         }}
                         className="focus-ring-inset group flex cursor-pointer flex-col gap-0.5 px-4 py-2.5 transition-colors hover:bg-[var(--bg-raised)]/50"
                       >

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -315,9 +315,11 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
         sessionsLoaded={sessionsLoaded}
         compact={compact}
         onSessionsChanged={onSessionsChanged}
-        onOpen={(sessionId, familiarId) => {
+        onOpen={(sessionId, familiarId, findQuery) => {
           const next = selectFamiliarForChat(familiarId);
           setView({ kind: "chat", sessionId, familiarId: next?.id ?? familiarId ?? null });
+          const fq = findQuery?.trim();
+          if (fq) setPendingFind({ query: fq, nonce: Date.now() });
         }}
         onNewChat={(projectRoot, familiarId) => {
           const next = selectFamiliarForChat(familiarId);


### PR DESCRIPTION
## What

The chat-list search box surfaces conversation **content** hits (the original consumer of `/api/chat/search`), but clicking one opened the chat **without jumping to the match** — unlike the ⌘K Conversations hit (#1456). Two search entry points, only one jumped. Now they behave the same.

## How

Thread the search query through the chat-list's content-hit click, **reusing the #1456 plumbing**: `chat-list.onOpen` gains an optional `findQuery`; the content-hit `onClick`/Enter passes `search.trim()`; chat-router's `onOpen` handler sets the same `pendingFind` state that already feeds `ChatView`'s `openFindQuery` prop → in-thread find opens on the match. No new infrastructure (2 files + a source-pin update).

## Verification

- `pnpm typecheck` clean, `pnpm test:app` → 340 pass (updated the `chat-list-delete.test.ts` onClick source-pin for the new query arg), `pnpm build` green.
- Live (mocked search + transcript): typing "gantt" in the chat-list search, clicking the content hit, opened "Board planning" (3 turns) with in-thread find on **"gantt"** at **"1 / 2"** — jumped to the first of 2 matches. Screenshot confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)