### PR TITLE
feat(ios): mark reading items in-progress (auto-on-open + swipe)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ReadingView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ReadingView.swift
@@ -140,10 +140,18 @@ struct ReadingView: View {
             }
             .tint(.orange)
         } else {
+            // Full-swipe triggers the first button (Read); a partial swipe also
+            // reveals "Reading" to explicitly mark an item in-progress.
             Button { setStatus(item, .done) } label: {
                 Label("Read", systemImage: "checkmark")
             }
             .tint(.green)
+            if item.status != .reading {
+                Button { setStatus(item, .reading) } label: {
+                    Label("Reading", systemImage: "book")
+                }
+                .tint(.accentColor)
+            }
         }
     }
 
@@ -227,10 +235,18 @@ struct ReadingView: View {
     // MARK: - Actions
 
     private func open(_ item: ReadingItem) {
-        if let link = item.link {
-            reader = ReaderLink(url: link)
-        } else {
+        guard let link = item.link else {
             app.showToast("No link to open", systemImage: "link.badge.plus", style: .warning)
+            return
+        }
+        reader = ReaderLink(url: link)
+        // Opening an unread item starts it: Want → Reading (once, the first open).
+        // Items already Reading/Read/Abandoned are left as-is.
+        if item.status == .wantToRead {
+            Task {
+                await app.setReadingStatus(item, .reading)
+                app.showToast("Started reading", systemImage: "book", style: .info)
+            }
         }
     }
 


### PR DESCRIPTION
## What

The **Reading** filter chip already existed, but nothing easily set an item to *reading* status (only the long-press menu). This adds two discoverable ways to mark an item **in-progress**, so the Reading filter actually fills up:

- **Auto on open** — opening an item to read it advances **Want → Reading** the first time (with a "Started reading" toast). Items already Reading/Read/Abandoned are left as-is, so re-opening a finished article won't un-complete it.
- **"Reading" swipe action** — a leading-swipe button alongside **Read**. Full-swipe still marks Read; a partial swipe reveals **Reading** for explicit control.

Both flow into the existing Reading filter and the in-card progress UI.

## Verification

- `xcodebuild` **BUILD SUCCEEDED** (iPhone 16 Pro sim). Changes are behavioral (tap/swipe handlers), not layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)