### PR TITLE
feat(ios): chat interaction polish — copy/retry, scroll-to-bottom, haptics

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Haptics.swift
+++ b/apps/ios/CovenCave/CovenCave/Haptics.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+/// Lightweight haptic feedback for chat interactions (send, copy, retry).
+enum Haptics {
+    static func tap(_ style: UIImpactFeedbackGenerator.FeedbackStyle = .light) {
+        UIImpactFeedbackGenerator(style: style).impactOccurred()
+    }
+
+    static func success() {
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -9,6 +9,7 @@ struct ChatView: View {
     @State private var showCommands = false
     @State private var showFamiliarPicker = false
     @State private var showTasks = false
+    @State private var atBottom = true
 
     // The slash autocomplete is driven purely off the in-progress draft: a
     // leading "/" on the first word (no whitespace committed yet).
@@ -90,7 +91,8 @@ struct ChatView: View {
                                       familiar: message.familiarId.flatMap(app.familiar),
                                       isLast: message.id == thread.messages.last?.id,
                                       onDelete: { deleteMessage(message) },
-                                      onSuggestion: { sendSuggestion($0) })
+                                      onSuggestion: { sendSuggestion($0) },
+                                      onRetry: canRetry(message) ? { retryAssistant(message) } : nil)
                         .id(message.id)
                     }
                     Color.clear.frame(height: 1).id("bottom")
@@ -99,6 +101,33 @@ struct ChatView: View {
                 .padding(.vertical, 14)
             }
             .scrollDismissesKeyboard(.interactively)
+            // Track whether the user is parked at the latest message so a
+            // "jump to bottom" button can appear when they've scrolled up.
+            .onScrollGeometryChange(for: Bool.self) { geo in
+                geo.contentOffset.y >= geo.contentSize.height - geo.containerSize.height - 24
+            } action: { _, nowAtBottom in
+                atBottom = nowAtBottom
+            }
+            .overlay(alignment: .bottomTrailing) {
+                if !atBottom {
+                    Button {
+                        withAnimation(.easeOut(duration: 0.2)) { proxy.scrollTo("bottom", anchor: .bottom) }
+                    } label: {
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(.primary)
+                            .frame(width: 36, height: 36)
+                            .background(.regularMaterial, in: Circle())
+                            .overlay(Circle().strokeBorder(Color(.separator).opacity(0.4), lineWidth: 1))
+                            .shadow(color: .black.opacity(0.15), radius: 6, y: 2)
+                    }
+                    .padding(.trailing, 14)
+                    .padding(.bottom, 10)
+                    .transition(.scale.combined(with: .opacity))
+                    .accessibilityLabel("Scroll to latest")
+                }
+            }
+            .animation(.snappy(duration: 0.2), value: atBottom)
             .onChange(of: thread.messages.last?.text) { _, _ in
                 withAnimation(.easeOut(duration: 0.15)) { proxy.scrollTo("bottom", anchor: .bottom) }
             }
@@ -206,6 +235,7 @@ struct ChatView: View {
         case .prose(let text):
             guard !text.isEmpty, let client = app.client else { return }
             draft = ""
+            Haptics.tap()
             thread.send(text, client: client) { app.touch(thread) }
         }
     }
@@ -214,6 +244,30 @@ struct ChatView: View {
     private func sendSuggestion(_ text: String) {
         guard let client = app.client else { return }
         thread.send(text, client: client) { app.touch(thread) }
+    }
+
+    /// Retry is offered on the latest, settled assistant reply of a 1:1 chat
+    /// (group fan-out would re-trigger every familiar, duplicating replies).
+    private func canRetry(_ message: DisplayMessage) -> Bool {
+        guard !thread.isGroup, message.role == .assistant, !message.streaming,
+              message.id == thread.messages.last?.id,
+              let idx = thread.messages.firstIndex(where: { $0.id == message.id }),
+              idx > 0, thread.messages[idx - 1].role == .user else { return false }
+        return true
+    }
+
+    /// Regenerate the latest reply: drop it and the user prompt that produced
+    /// it, then re-send that prompt (a clean replace, not a duplicate).
+    private func retryAssistant(_ assistant: DisplayMessage) {
+        guard let client = app.client,
+              let idx = thread.messages.firstIndex(where: { $0.id == assistant.id }),
+              idx > 0, thread.messages[idx - 1].role == .user else { return }
+        let userMessage = thread.messages[idx - 1]
+        let prompt = userMessage.text
+        thread.deleteMessage(assistant.id)
+        thread.deleteMessage(userMessage.id)
+        Haptics.tap()
+        thread.send(prompt, client: client) { app.touch(thread) }
     }
 
     /// Tap a row in the inline autocomplete. Commands that take arguments get

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct MessageBubble: View {
     let message: DisplayMessage
@@ -7,10 +8,33 @@ struct MessageBubble: View {
     var isLast: Bool = false
     var onDelete: () -> Void
     var onSuggestion: (String) -> Void = { _ in }
+    /// Regenerate this reply (assistant messages only); nil hides the action.
+    var onRetry: (() -> Void)? = nil
 
     @State private var mdHeight: CGFloat = 0
 
     private var isUser: Bool { message.role == .user }
+
+    /// Long-press actions shared by the bubble and the system note: copy the
+    /// text, optionally retry (regenerate), and delete.
+    @ViewBuilder private var messageActions: some View {
+        if !message.text.isEmpty {
+            Button {
+                UIPasteboard.general.string = message.text
+                Haptics.tap()
+            } label: {
+                Label("Copy", systemImage: "doc.on.doc")
+            }
+        }
+        if let onRetry {
+            Button(action: onRetry) {
+                Label("Retry", systemImage: "arrow.clockwise")
+            }
+        }
+        Button(role: .destructive, action: onDelete) {
+            Label("Delete Message", systemImage: "trash")
+        }
+    }
 
     /// Assistant text minus the `<coven:next-paths>` block (parsed into chips).
     private var parsed: (visible: String, suggestions: [String]) {
@@ -53,11 +77,7 @@ struct MessageBubble: View {
                 .strokeBorder(Color(.separator).opacity(0.5), lineWidth: 1)
         )
         .padding(.horizontal, 24)
-        .contextMenu {
-            Button(role: .destructive, action: onDelete) {
-                Label("Delete", systemImage: "trash")
-            }
-        }
+        .contextMenu { messageActions }
     }
 
     private var chatBubble: some View {
@@ -76,11 +96,7 @@ struct MessageBubble: View {
                         .padding(.leading, 4)
                 }
                 bubble
-                    .contextMenu {
-                        Button(role: .destructive, action: onDelete) {
-                            Label("Delete Message", systemImage: "trash")
-                        }
-                    }
+                    .contextMenu { messageActions }
 
                 if !isUser, isLast, !message.streaming, !parsed.suggestions.isEmpty {
                     SuggestionPills(suggestions: parsed.suggestions, onTap: onSuggestion)


### PR DESCRIPTION
## What

Three interaction improvements to the native iOS chat:

1. **Copy & Retry message actions.** The long-press menu only had *Delete*. It now offers **Copy** (any message → clipboard) and **Retry** on the latest 1:1 assistant reply — regenerate cleanly by dropping that reply *and* the prompt that produced it, then re-sending the prompt (a replace, not a duplicate). Group chats omit Retry (fan-out would re-trigger every familiar). Shared between the bubble and system-note menus.
2. **Scroll-to-bottom button.** A floating chevron appears when you've scrolled up (tracked via `onScrollGeometryChange`); tapping jumps to the latest message.
3. **Haptics.** Light `UIImpactFeedbackGenerator` feedback on send, copy, and retry (new `Haptics` helper).

## Verification

iOS Swift isn't compiled by the web CI checks, so I built it directly: `xcodegen generate` + `xcodebuild ... -destination 'generic/platform=iOS Simulator'` → **BUILD SUCCEEDED** (incl. after rebasing over three concurrent iOS PRs that touched ChatView/MessageBubble). A live screenshot needs a connected Cave server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)