### PR TITLE
feat(ios): wire the composer mic (voice dictation) and + (image attach)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Info.plist
+++ b/apps/ios/CovenCave/CovenCave/Info.plist
@@ -40,6 +40,10 @@
 	</array>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Coven Cave connects to your desktop over your private Tailscale network to chat with your familiars.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Coven Cave uses the microphone so you can dictate messages to your familiars.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Coven Cave transcribes your speech into the message field when you dictate.</string>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_tailscale._tcp</string>

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -133,10 +133,19 @@ struct CaveClient {
 
     // MARK: - Chat streaming
 
+    /// An image attachment the server delivers to the familiar alongside the
+    /// prompt. `dataUrl` is a `data:image/...;base64,...` string.
+    struct ChatAttachment: Encodable {
+        var name: String
+        var mimeType: String
+        var dataUrl: String
+    }
+
     struct SendBody: Encodable {
         var familiarId: String
         var prompt: String
         var sessionId: String?
+        var attachments: [ChatAttachment]?
     }
 
     /// Open the SSE stream for a chat send. Yields decoded `StreamEvent`s.

--- a/apps/ios/CovenCave/CovenCave/SpeechDictation.swift
+++ b/apps/ios/CovenCave/CovenCave/SpeechDictation.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Speech
+import AVFoundation
+
+/// Live speech-to-text for the composer mic button. Streams partial results via
+/// `onUpdate` while recording; the caller feeds them into the draft.
+@MainActor
+@Observable
+final class SpeechDictation {
+    private(set) var isRecording = false
+
+    /// Called with the running transcript as the user speaks.
+    var onUpdate: (String) -> Void = { _ in }
+
+    private let recognizer = SFSpeechRecognizer()
+    private let audioEngine = AVAudioEngine()
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var task: SFSpeechRecognitionTask?
+
+    var isAvailable: Bool { recognizer?.isAvailable ?? false }
+
+    func toggle() {
+        isRecording ? stop() : start()
+    }
+
+    func start() {
+        guard !isRecording else { return }
+        SFSpeechRecognizer.requestAuthorization { status in
+            Task { @MainActor in
+                guard status == .authorized else { return }
+                self.beginSession()
+            }
+        }
+    }
+
+    private func beginSession() {
+        guard let recognizer, recognizer.isAvailable else { return }
+
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.record, mode: .measurement, options: .duckOthers)
+            try session.setActive(true, options: .notifyOthersOnDeactivation)
+        } catch {
+            return
+        }
+
+        let req = SFSpeechAudioBufferRecognitionRequest()
+        req.shouldReportPartialResults = true
+        request = req
+
+        let node = audioEngine.inputNode
+        let format = node.outputFormat(forBus: 0)
+        node.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+            self?.request?.append(buffer)
+        }
+
+        audioEngine.prepare()
+        do {
+            try audioEngine.start()
+        } catch {
+            cleanUp()
+            return
+        }
+        isRecording = true
+
+        task = recognizer.recognitionTask(with: req) { [weak self] result, error in
+            guard let self else { return }
+            Task { @MainActor in
+                if let result {
+                    self.onUpdate(result.bestTranscription.formattedString)
+                }
+                if error != nil || (result?.isFinal ?? false) {
+                    self.stop()
+                }
+            }
+        }
+    }
+
+    func stop() {
+        guard isRecording else { return }
+        cleanUp()
+    }
+
+    private func cleanUp() {
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        request?.endAudio()
+        task?.cancel()
+        request = nil
+        task = nil
+        isRecording = false
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -14,6 +14,8 @@ struct DisplayMessage: Identifiable, Codable, Hashable {
     var streaming: Bool = false
     var isError: Bool = false
     var createdAt: Date = Date()
+    /// Image attachments sent with this (user) message, as `data:` URLs.
+    var attachmentDataUrls: [String] = []
 }
 
 /// Plain Codable snapshot used for on-disk persistence.
@@ -79,14 +81,17 @@ final class ChatThread: Identifiable, Hashable {
     /// sending a longer prompt to the familiar — e.g. `/canvas` shows the ask
     /// but sends the full sketch instruction.
     func send(_ text: String, displayText: String? = nil,
+              attachments: [CaveClient.ChatAttachment] = [],
               client: CaveClient, onChange: @escaping () -> Void) {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        // An image with no caption is a valid prompt (the familiar reads it).
+        guard !trimmed.isEmpty || !attachments.isEmpty else { return }
         let shown = (displayText?.trimmingCharacters(in: .whitespacesAndNewlines)).flatMap {
             $0.isEmpty ? nil : $0
         } ?? trimmed
 
-        messages.append(DisplayMessage(role: .user, familiarId: nil, text: shown))
+        messages.append(DisplayMessage(role: .user, familiarId: nil, text: shown,
+                                       attachmentDataUrls: attachments.map(\.dataUrl)))
         updatedAt = Date()
         onChange()
 
@@ -96,7 +101,8 @@ final class ChatThread: Identifiable, Hashable {
             messages.append(placeholder)
             let messageId = placeholder.id
             Task { await self.stream(familiarId: familiarId, prompt: trimmed,
-                                     into: messageId, client: client, onChange: onChange) }
+                                     attachments: attachments, into: messageId,
+                                     client: client, onChange: onChange) }
         }
     }
 
@@ -127,10 +133,12 @@ final class ChatThread: Identifiable, Hashable {
         updatedAt = Date()
     }
 
-    private func stream(familiarId: String, prompt: String, into messageId: String,
+    private func stream(familiarId: String, prompt: String,
+                        attachments: [CaveClient.ChatAttachment] = [], into messageId: String,
                         client: CaveClient, onChange: @escaping () -> Void) async {
         let body = CaveClient.SendBody(familiarId: familiarId, prompt: prompt,
-                                       sessionId: sessionIds[familiarId])
+                                       sessionId: sessionIds[familiarId],
+                                       attachments: attachments.isEmpty ? nil : attachments)
         do {
             for try await event in client.sendStream(body) {
                 switch event {

--- a/apps/ios/CovenCave/CovenCave/UIImage+Resize.swift
+++ b/apps/ios/CovenCave/CovenCave/UIImage+Resize.swift
@@ -1,0 +1,26 @@
+import UIKit
+
+extension UIImage {
+    /// Downscale so the longest side is at most `maxDimension`, preserving the
+    /// aspect ratio — keeps attachment payloads under the server's image cap.
+    func resizedForUpload(maxDimension: CGFloat = 1280) -> UIImage {
+        let maxSide = max(size.width, size.height)
+        guard maxSide > maxDimension, maxSide > 0 else { return self }
+        let scale = maxDimension / maxSide
+        let newSize = CGSize(width: (size.width * scale).rounded(),
+                             height: (size.height * scale).rounded())
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = 1
+        return UIGraphicsImageRenderer(size: newSize, format: format).image { _ in
+            draw(in: CGRect(origin: .zero, size: newSize))
+        }
+    }
+
+    /// Decode a `data:image/...;base64,...` URL into a `UIImage`.
+    static func fromDataUrl(_ dataUrl: String) -> UIImage? {
+        guard let comma = dataUrl.firstIndex(of: ",") else { return nil }
+        let base64 = String(dataUrl[dataUrl.index(after: comma)...])
+        guard let data = Data(base64Encoded: base64) else { return nil }
+        return UIImage(data: data)
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -1,4 +1,15 @@
 import SwiftUI
+import PhotosUI
+import UIKit
+
+/// An image chosen in the composer, pending send.
+struct PendingImage: Identifiable {
+    let id = UUID()
+    let image: UIImage
+    let dataUrl: String
+    let mimeType: String
+    let name: String
+}
 
 struct ChatView: View {
     @Environment(AppModel.self) private var app
@@ -10,6 +21,9 @@ struct ChatView: View {
     @State private var showFamiliarPicker = false
     @State private var showTasks = false
     @State private var atBottom = true
+    @State private var dictation = SpeechDictation()
+    @State private var photoItem: PhotosPickerItem?
+    @State private var pendingImage: PendingImage?
 
     // The slash autocomplete is driven purely off the in-progress draft: a
     // leading "/" on the first word (no whitespace committed yet).
@@ -147,23 +161,83 @@ struct ChatView: View {
                     .padding(.horizontal, 12)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
+            if let pendingImage {
+                attachmentPreview(pendingImage)
+            }
             composerBar
         }
         .animation(.snappy(duration: 0.18), value: showingSlashMenu)
+        .animation(.snappy(duration: 0.18), value: pendingImage?.id)
         .background(.bar)
+        // Live dictation streams its running transcript into the draft.
+        .onAppear { dictation.onUpdate = { draft = $0 } }
+        .onChange(of: photoItem) { _, item in
+            guard let item else { return }
+            Task { await loadPickedImage(item) }
+        }
+    }
+
+    /// Thumbnail of the attached image above the composer, with a remove button.
+    private func attachmentPreview(_ pending: PendingImage) -> some View {
+        HStack {
+            ZStack(alignment: .topTrailing) {
+                Image(uiImage: pending.image)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 64, height: 64)
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(Color(.separator).opacity(0.5), lineWidth: 1))
+                Button {
+                    pendingImage = nil
+                    photoItem = nil
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 18))
+                        .foregroundStyle(.white, .black.opacity(0.55))
+                }
+                .offset(x: 6, y: -6)
+                .accessibilityLabel("Remove image")
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 4)
+    }
+
+    private func startDictation() {
+        composerFocused = false
+        Haptics.tap()
+        dictation.start()
+    }
+
+    /// Decode the picked photo, downscale it to keep the payload under the
+    /// server's image cap, and stage it as a `data:` URL.
+    private func loadPickedImage(_ item: PhotosPickerItem) async {
+        guard let data = try? await item.loadTransferable(type: Data.self),
+              let image = UIImage(data: data) else { return }
+        let resized = image.resizedForUpload()
+        guard let jpeg = resized.jpegData(compressionQuality: 0.8) else { return }
+        let dataUrl = "data:image/jpeg;base64,\(jpeg.base64EncodedString())"
+        await MainActor.run {
+            pendingImage = PendingImage(image: resized, dataUrl: dataUrl,
+                                        mimeType: "image/jpeg", name: "photo.jpg")
+            photoItem = nil
+            Haptics.tap()
+        }
     }
 
     private var composerBar: some View {
         HStack(alignment: .bottom, spacing: 10) {
-            // Attachment / app drawer (wired in a later phase).
-            Button(action: {}) {
+            // Attach an image; the server delivers it to the familiar.
+            PhotosPicker(selection: $photoItem, matching: .images, photoLibrary: .shared()) {
                 Image(systemName: "plus")
                     .font(.system(size: 18, weight: .semibold))
                     .foregroundStyle(.secondary)
                     .frame(width: 34, height: 34)
                     .background(Color(.secondarySystemBackground), in: Circle())
             }
-            .accessibilityLabel("Add attachment")
+            .accessibilityLabel("Attach image")
 
             // Hairline capsule with the field and a trailing control inside it:
             // a mic when empty, a filled send/run button once there's text.
@@ -175,7 +249,19 @@ struct ChatView: View {
                     .focused($composerFocused)
 
                 Group {
-                    if canSend {
+                    if dictation.isRecording {
+                        Button { dictation.stop() } label: {
+                            Image(systemName: "stop.circle.fill")
+                                .font(.system(size: 29))
+                                .foregroundStyle(.red)
+                                .symbolEffect(.pulse, isActive: true)
+                                .background(Circle().fill(.white).padding(3))
+                        }
+                        .padding(.trailing, 3)
+                        .padding(.bottom, 2)
+                        .transition(.scale.combined(with: .opacity))
+                        .accessibilityLabel("Stop dictation")
+                    } else if canSend {
                         Button(action: send) {
                             Image(systemName: "arrow.up.circle.fill")
                                 .font(.system(size: 29))
@@ -187,17 +273,21 @@ struct ChatView: View {
                         .transition(.scale.combined(with: .opacity))
                         .accessibilityLabel(isCommand ? "Run command" : "Send")
                     } else {
-                        Image(systemName: "mic.fill")
-                            .font(.system(size: 17))
-                            .foregroundStyle(.secondary)
-                            .padding(.trailing, 12)
-                            .padding(.bottom, 8)
+                        Button { startDictation() } label: {
+                            Image(systemName: "mic.fill")
+                                .font(.system(size: 17))
+                                .foregroundStyle(.secondary)
+                                .padding(.trailing, 12)
+                                .padding(.bottom, 8)
+                        }
+                        .accessibilityLabel("Dictate")
                     }
                 }
             }
-            .overlay(Capsule().strokeBorder(borderColor, lineWidth: 1))
+            .overlay(Capsule().strokeBorder(dictation.isRecording ? Color.red.opacity(0.5) : borderColor, lineWidth: 1))
             .animation(.snappy(duration: 0.18), value: canSend)
             .animation(.snappy(duration: 0.18), value: isCommand)
+            .animation(.snappy(duration: 0.18), value: dictation.isRecording)
         }
         .padding(.horizontal, 12)
         .padding(.top, 6)
@@ -205,7 +295,7 @@ struct ChatView: View {
     }
 
     private var canSend: Bool {
-        !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || pendingImage != nil
     }
 
     /// True when the draft is a recognised command — tints the send affordance
@@ -222,6 +312,7 @@ struct ChatView: View {
     // MARK: - Send / dispatch
 
     private func send() {
+        dictation.stop()
         let raw = draft
         switch SlashInput.parse(raw) {
         case .command(let command, let args):
@@ -233,10 +324,15 @@ struct ChatView: View {
                                 isError: true)
             app.touch(thread)
         case .prose(let text):
-            guard !text.isEmpty, let client = app.client else { return }
+            guard let client = app.client else { return }
+            let attachments = pendingImage.map {
+                [CaveClient.ChatAttachment(name: $0.name, mimeType: $0.mimeType, dataUrl: $0.dataUrl)]
+            } ?? []
+            guard !text.isEmpty || !attachments.isEmpty else { return }
             draft = ""
+            pendingImage = nil
             Haptics.tap()
-            thread.send(text, client: client) { app.touch(thread) }
+            thread.send(text, attachments: attachments, client: client) { app.touch(thread) }
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -95,8 +95,15 @@ struct MessageBubble: View {
                         .foregroundStyle(Theme.color(for: familiar))
                         .padding(.leading, 4)
                 }
-                bubble
-                    .contextMenu { messageActions }
+                if !message.attachmentDataUrls.isEmpty {
+                    attachmentImages
+                        .contextMenu { messageActions }
+                }
+                // Hide the (empty) text bubble for image-only messages.
+                if !parsed.visible.isEmpty || message.attachmentDataUrls.isEmpty {
+                    bubble
+                        .contextMenu { messageActions }
+                }
 
                 if !isUser, isLast, !message.streaming, !parsed.suggestions.isEmpty {
                     SuggestionPills(suggestions: parsed.suggestions, onTap: onSuggestion)
@@ -104,6 +111,22 @@ struct MessageBubble: View {
             }
 
             if !isUser { Spacer(minLength: 48) }
+        }
+    }
+
+    @ViewBuilder private var attachmentImages: some View {
+        VStack(alignment: isUser ? .trailing : .leading, spacing: 4) {
+            ForEach(message.attachmentDataUrls, id: \.self) { url in
+                if let image = UIImage.fromDataUrl(url) {
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxWidth: 240, maxHeight: 240)
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                        .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous)
+                            .strokeBorder(Color(.separator).opacity(0.4), lineWidth: 1))
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## What

Wires the two composer stubs in the native iOS chat.

### 🎙 Mic → voice dictation
Tap the mic in an empty composer to dictate. Live `SFSpeechRecognizer` transcription streams into the draft; a red **stop** button replaces the mic while recording. New `SpeechDictation` helper (AVAudioEngine + Speech) and the `NSMicrophoneUsageDescription` / `NSSpeechRecognitionUsageDescription` Info.plist strings.

### ➕ Attach → image
The `+` button is now a `PhotosPicker`. The chosen image is downscaled (≤1280px, JPEG 0.8) to stay under the server's image cap, staged as a removable thumbnail chip above the composer, and sent as a `ChatAttachment` (`data:` URL) — which the existing `/api/chat/send` delivers to the familiar. Image-only messages (no caption) are allowed, and the sent image renders in the user's bubble. `DisplayMessage` gains a back-compatible `attachmentDataUrls`.

Plus light haptics on dictation start, image pick, and send.

## Verification

- `xcodebuild` (iOS Simulator) → **BUILD SUCCEEDED**
- `scripts/mobile-tailscale-native.test.mjs` (exit 0) + `pnpm test:mobile` (16/16) — the source-text checks CI runs on the Swift
- **Runtime not yet device-verified** (dictation needs mic/speech permission + the picker needs interaction; the chat only renders connected). Standard iOS patterns used; a quick on-device check is the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)