### PR TITLE
feat(board): assign tasks to a chat, unlink, show all linked tasks

### DIFF
--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -1020,20 +1020,31 @@ export function BoardInspector({ card, familiars, sessions, projects, onClose, o
           <div className="board-drawer-field">
             <div className="board-drawer-field-label">Chat</div>
             {session ? (
-              <button
-                type="button"
-                className="board-drawer-chat-card board-drawer-chat-card--linked"
-                onClick={() => onJumpToSession?.(session.id, session.familiarId ?? null)}
-              >
-                <span className="board-drawer-chat-icon" aria-hidden>
-                  <Icon name="ph:chat-circle-dots" width={14} />
-                </span>
-                <span className="board-drawer-chat-body">
-                  <span className="board-drawer-chat-title">{session.title || "(untitled)"}</span>
-                  <span className="board-drawer-chat-desc">Open conversation</span>
-                </span>
-                <Icon name="ph:arrow-square-out" width={12} className="board-drawer-chat-trail" />
-              </button>
+              <div className="board-drawer-chat-linked-row">
+                <button
+                  type="button"
+                  className="board-drawer-chat-card board-drawer-chat-card--linked"
+                  onClick={() => onJumpToSession?.(session.id, session.familiarId ?? null)}
+                >
+                  <span className="board-drawer-chat-icon" aria-hidden>
+                    <Icon name="ph:chat-circle-dots" width={14} />
+                  </span>
+                  <span className="board-drawer-chat-body">
+                    <span className="board-drawer-chat-title">{session.title || "(untitled)"}</span>
+                    <span className="board-drawer-chat-desc">Open conversation</span>
+                  </span>
+                  <Icon name="ph:arrow-square-out" width={12} className="board-drawer-chat-trail" />
+                </button>
+                <button
+                  type="button"
+                  className="board-drawer-chat-unlink"
+                  title="Unlink chat"
+                  aria-label="Unlink chat"
+                  onClick={() => onPatch(card.id, { sessionId: null })}
+                >
+                  <Icon name="ph:x" width={13} />
+                </button>
+              </div>
             ) : (
               <div className="board-drawer-chat-card board-drawer-chat-card--empty">
                 <span className="board-drawer-chat-icon board-drawer-chat-icon--empty" aria-hidden>

--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -50,8 +50,8 @@ assert.match(
 
 assert.match(
   source,
-  /function LinkedContextRow[\s\S]*?if \(!task && github\.length === 0\) return null/,
-  "LinkedContextRow only renders when linked context has entries",
+  /function LinkedContextRow[\s\S]*?if \(!task && github\.length === 0 && !canLink\) return null/,
+  "LinkedContextRow renders when there's linked context OR a chat session that can link a task",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -26,6 +26,8 @@ import {
   shouldShowChatArchiveNudge,
 } from "@/lib/chat-archive-nudge";
 import type { ChatLinkedContext } from "@/lib/chat-linked-context";
+import type { Card } from "@/lib/cave-board-types";
+import { TaskLinkPicker } from "@/components/task-link-picker";
 import {
   MAX_ATTACHMENT_IMAGE_BYTES,
   MAX_ATTACHMENT_TEXT_CHARS,
@@ -1292,43 +1294,102 @@ function MetaLine({
   );
 }
 
+function TaskChip({
+  task,
+  onOpenTask,
+}: {
+  task: NonNullable<ChatLinkedContext["task"]>;
+  onOpenTask?: (cardId: string) => void;
+}) {
+  const base =
+    "cave-chat-linked-chip cave-chat-linked-chip--task inline-flex min-w-0 max-w-[24rem] items-center gap-1.5 rounded-md border border-[color-mix(in_oklch,var(--accent-presence)_35%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_12%,transparent)] px-2 py-1 text-[11px] text-[var(--text-secondary)]";
+  const body = (
+    <>
+      <Icon name="ph:kanban" width={12} className="shrink-0 text-[var(--accent-presence)]" />
+      <span className="shrink-0 font-medium">Task</span>
+      <span className="min-w-0 truncate">{task.title}</span>
+      <span className="shrink-0 text-[var(--text-muted)]">{task.status}</span>
+      <span className="shrink-0 text-[var(--text-muted)]">{task.priority}</span>
+    </>
+  );
+  return onOpenTask ? (
+    <button
+      type="button"
+      onClick={() => onOpenTask(task.id)}
+      title={`Open task: ${task.title}`}
+      className={`${base} focus-ring transition-colors hover:border-[color-mix(in_oklch,var(--accent-presence)_55%,transparent)] hover:bg-[color-mix(in_oklch,var(--accent-presence)_18%,transparent)] hover:text-[var(--text-primary)]`}
+    >
+      {body}
+      <Icon name="ph:arrow-square-out" width={10} className="shrink-0 text-[var(--text-muted)]" />
+    </button>
+  ) : (
+    <span className={base}>{body}</span>
+  );
+}
+
 function LinkedContextRow({
   linkedContext,
   onOpenTask,
+  sessionId,
+  onLinkedContextChange,
 }: {
   linkedContext: ChatLinkedContext | null;
   onOpenTask?: (cardId: string) => void;
+  sessionId?: string | null;
+  onLinkedContextChange?: (updater: (prev: ChatLinkedContext | null) => ChatLinkedContext | null) => void;
 }) {
+  const [pickerOpen, setPickerOpen] = useState(false);
   const task = linkedContext?.task ?? null;
+  const tasks = linkedContext?.tasks ?? (task ? [task] : []);
   const github = linkedContext?.github ?? [];
-  if (!task && github.length === 0) return null;
+  const canLink = Boolean(sessionId && onLinkedContextChange);
+  if (!task && github.length === 0 && !canLink) return null;
+
+  const linkedIds = new Set(tasks.map((t) => t.id));
+
+  const onAssigned = (card: Card) => {
+    const linked = {
+      id: card.id,
+      title: card.title,
+      status: card.status,
+      priority: card.priority,
+      lifecycle: card.lifecycle,
+      labels: card.labels,
+      cwd: card.cwd,
+      notes: card.notes.trim() || null,
+    };
+    onLinkedContextChange?.((prev) => {
+      const baseCtx = prev ?? { task: null, tasks: [], github: [] };
+      if (baseCtx.tasks.some((t) => t.id === linked.id)) return baseCtx;
+      return { ...baseCtx, task: baseCtx.task ?? linked, tasks: [...baseCtx.tasks, linked] };
+    });
+  };
 
   return (
     <div className="cave-chat-linked-context">
-      {task ? (
-        onOpenTask ? (
+      {tasks.map((t) => (
+        <TaskChip key={t.id} task={t} onOpenTask={onOpenTask} />
+      ))}
+      {canLink ? (
+        <span className="relative inline-flex">
           <button
             type="button"
-            onClick={() => onOpenTask(task.id)}
-            title={`Open task: ${task.title}`}
-            className="cave-chat-linked-chip cave-chat-linked-chip--task focus-ring inline-flex min-w-0 max-w-[24rem] items-center gap-1.5 rounded-md border border-[color-mix(in_oklch,var(--accent-presence)_35%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_12%,transparent)] px-2 py-1 text-[11px] text-[var(--text-secondary)] transition-colors hover:border-[color-mix(in_oklch,var(--accent-presence)_55%,transparent)] hover:bg-[color-mix(in_oklch,var(--accent-presence)_18%,transparent)] hover:text-[var(--text-primary)]"
+            onClick={() => setPickerOpen((open) => !open)}
+            title="Link a task to this chat"
+            className="cave-chat-linked-chip focus-ring inline-flex items-center gap-1 rounded-md border border-dashed border-[var(--border-strong)] bg-transparent px-2 py-1 text-[11px] text-[var(--text-muted)] transition-colors hover:border-[var(--accent-presence)] hover:text-[var(--text-primary)]"
           >
-            <Icon name="ph:kanban" width={12} className="shrink-0 text-[var(--accent-presence)]" />
-            <span className="shrink-0 font-medium">Task</span>
-            <span className="min-w-0 truncate">{task.title}</span>
-            <span className="shrink-0 text-[var(--text-muted)]">{task.status}</span>
-            <span className="shrink-0 text-[var(--text-muted)]">{task.priority}</span>
-            <Icon name="ph:arrow-square-out" width={10} className="shrink-0 text-[var(--text-muted)]" />
+            <Icon name="ph:plus" width={11} className="shrink-0" />
+            <span>Link task</span>
           </button>
-        ) : (
-          <span className="cave-chat-linked-chip cave-chat-linked-chip--task inline-flex min-w-0 max-w-[24rem] items-center gap-1.5 rounded-md border border-[color-mix(in_oklch,var(--accent-presence)_35%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_12%,transparent)] px-2 py-1 text-[11px] text-[var(--text-secondary)]">
-            <Icon name="ph:kanban" width={12} className="shrink-0 text-[var(--accent-presence)]" />
-            <span className="shrink-0 font-medium">Task</span>
-            <span className="min-w-0 truncate">{task.title}</span>
-            <span className="shrink-0 text-[var(--text-muted)]">{task.status}</span>
-            <span className="shrink-0 text-[var(--text-muted)]">{task.priority}</span>
-          </span>
-        )
+          {pickerOpen && sessionId ? (
+            <TaskLinkPicker
+              sessionId={sessionId}
+              linkedIds={linkedIds}
+              onAssigned={onAssigned}
+              onClose={() => setPickerOpen(false)}
+            />
+          ) : null}
+        </span>
       ) : null}
       {github.map((item) => (
         <a
@@ -3218,7 +3279,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             )}
           </div>
         </MetaLine>
-        <LinkedContextRow linkedContext={linkedContext} onOpenTask={onOpenTask} />
+        <LinkedContextRow
+          linkedContext={linkedContext}
+          onOpenTask={onOpenTask}
+          sessionId={sessionId}
+          onLinkedContextChange={setLinkedContext}
+        />
       </header>
       <RunActivityStrip activeTurn={activePendingTurn} lastTurn={lastSettledAssistantTurn} />
       <div ref={scrollRef} tabIndex={0} className="cave-chat-transcript relative min-h-0 flex-1 overflow-y-auto">

--- a/src/components/task-link-picker.tsx
+++ b/src/components/task-link-picker.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Icon } from "@/lib/icon";
+import type { Card } from "@/lib/cave-board-types";
+
+/**
+ * Popover for linking an existing board task to the current chat. Lists the
+ * board's cards (minus those already linked to this session) and, on pick,
+ * PATCHes the card's `sessionId` to this chat — the chat→task assign side that
+ * mirrors the board's "Start chat from task" flow.
+ */
+export function TaskLinkPicker({
+  sessionId,
+  linkedIds,
+  onAssigned,
+  onClose,
+}: {
+  sessionId: string;
+  linkedIds: Set<string>;
+  onAssigned: (card: Card) => void;
+  onClose: () => void;
+}) {
+  const [cards, setCards] = useState<Card[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
+      try {
+        const res = await fetch("/api/board", { cache: "no-store" });
+        const json = await res.json();
+        if (!alive) return;
+        if (json.ok) setCards(json.cards as Card[]);
+        else setError(json.error ?? "Failed to load tasks");
+      } catch (err) {
+        if (alive) setError(err instanceof Error ? err.message : "Failed to load tasks");
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [onClose]);
+
+  const results = useMemo(() => {
+    if (!cards) return [];
+    const q = query.trim().toLowerCase();
+    return cards
+      .filter((c) => !linkedIds.has(c.id))
+      .filter((c) => !q || c.title.toLowerCase().includes(q))
+      .slice(0, 50);
+  }, [cards, linkedIds, query]);
+
+  const assign = async (card: Card) => {
+    setBusyId(card.id);
+    setError(null);
+    try {
+      const res = await fetch(`/api/board/${card.id}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sessionId }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.ok) throw new Error(json.error ?? "Failed to link task");
+      onAssigned(json.card as Card);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to link task");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div
+      ref={ref}
+      role="dialog"
+      aria-label="Link a task to this chat"
+      className="absolute left-0 top-full z-30 mt-1 w-[20rem] max-w-[80vw] overflow-hidden rounded-lg border border-[var(--border-strong)] bg-[var(--bg-raised)] shadow-lg"
+    >
+      <div className="flex items-center gap-1.5 border-b border-[var(--border-hairline)] px-2.5 py-2">
+        <Icon name="ph:magnifying-glass" width={13} className="shrink-0 text-[var(--text-muted)]" />
+        <input
+          autoFocus
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Link a task…"
+          aria-label="Search tasks to link"
+          className="min-w-0 flex-1 bg-transparent text-[12px] text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)]"
+        />
+      </div>
+      {error ? (
+        <div className="px-2.5 py-1.5 text-[11px] text-[var(--color-danger,#ef4444)]">{error}</div>
+      ) : null}
+      <div className="max-h-[16rem] overflow-y-auto py-1">
+        {cards === null ? (
+          <div className="px-2.5 py-2 text-[11px] text-[var(--text-muted)]">Loading tasks…</div>
+        ) : results.length === 0 ? (
+          <div className="px-2.5 py-2 text-[11px] text-[var(--text-muted)]">
+            {query ? "No matches." : "No other tasks to link."}
+          </div>
+        ) : (
+          results.map((card) => (
+            <button
+              key={card.id}
+              type="button"
+              disabled={busyId !== null}
+              onClick={() => void assign(card)}
+              className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-50"
+            >
+              <Icon name="ph:kanban" width={12} className="shrink-0 text-[var(--accent-presence)]" />
+              <span className="min-w-0 flex-1 truncate">{card.title}</span>
+              <span className="shrink-0 text-[var(--text-muted)]">{busyId === card.id ? "linking…" : card.status}</span>
+              {busyId === card.id ? null : <Icon name="ph:plus" width={12} className="shrink-0 text-[var(--text-muted)]" />}
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/chat-linked-context.ts
+++ b/src/lib/chat-linked-context.ts
@@ -1,7 +1,21 @@
 import { loadBoard } from "@/lib/cave-board";
 import type { CardGitHubKind } from "@/lib/cave-board-types";
 
+type LinkedTask = {
+  id: string;
+  title: string;
+  status: string;
+  priority: string;
+  lifecycle: string;
+  labels: string[];
+  cwd: string | null;
+  notes: string | null;
+};
+
 export type ChatLinkedContext = {
+  // `task` is the primary (first) linked task, kept for single-task consumers
+  // (mobile header, meta title, lifecycle chip); `tasks` lists every card that
+  // shares this chat's session.
   task:
     | {
         id: string;
@@ -14,6 +28,7 @@ export type ChatLinkedContext = {
         notes: string | null;
       }
     | null;
+  tasks: LinkedTask[];
   github: Array<{
     id: string;
     kind: CardGitHubKind;
@@ -28,29 +43,39 @@ export type ChatLinkedContext = {
 
 export async function linkedContextForSession(sessionId: string): Promise<ChatLinkedContext | null> {
   const board = await loadBoard();
-  const card = board.cards.find((card) => card.sessionId === sessionId);
-  if (!card) return null;
+  const cards = board.cards.filter((card) => card.sessionId === sessionId);
+  if (cards.length === 0) return null;
 
-  return {
-    task: {
-      id: card.id,
-      title: card.title,
-      status: card.status,
-      priority: card.priority,
-      lifecycle: card.lifecycle,
-      labels: card.labels,
-      cwd: card.cwd,
-      notes: card.notes.trim() || null,
-    },
-    github: card.github.map((item) => ({
-      id: item.id,
-      kind: item.kind,
-      repo: item.repo,
-      number: item.number,
-      title: item.title,
-      url: item.url,
-      state: item.state,
-      labels: item.labels,
-    })),
-  };
+  const tasks: LinkedTask[] = cards.map((card) => ({
+    id: card.id,
+    title: card.title,
+    status: card.status,
+    priority: card.priority,
+    lifecycle: card.lifecycle,
+    labels: card.labels,
+    cwd: card.cwd,
+    notes: card.notes.trim() || null,
+  }));
+
+  // Aggregate GitHub links across every linked card, de-duped by id.
+  const github: ChatLinkedContext["github"] = [];
+  const seen = new Set<string>();
+  for (const card of cards) {
+    for (const item of card.github) {
+      if (seen.has(item.id)) continue;
+      seen.add(item.id);
+      github.push({
+        id: item.id,
+        kind: item.kind,
+        repo: item.repo,
+        number: item.number,
+        title: item.title,
+        url: item.url,
+        state: item.state,
+        labels: item.labels,
+      });
+    }
+  }
+
+  return { task: tasks[0] ?? null, tasks, github };
 }

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -421,6 +421,10 @@
 .board-drawer-chat-cta { display:inline-flex; align-items:center; gap:5px; min-height:28px; padding:0 10px; border-radius:7px; border:1px solid color-mix(in oklch,var(--accent-presence) 50%,transparent); background:color-mix(in oklch,var(--accent-presence) 18%,transparent); color:var(--text-primary); font-size:11.5px; font-weight:500; cursor:pointer; flex-shrink:0; transition:background .12s,border-color .12s; }
 .board-drawer-chat-cta:hover:not(:disabled) { background:color-mix(in oklch,var(--accent-presence) 28%,transparent); border-color:color-mix(in oklch,var(--accent-presence) 75%,transparent); }
 .board-drawer-chat-cta:disabled { opacity:.55; cursor:wait; }
+.board-drawer-chat-linked-row { display:flex; align-items:stretch; gap:6px; }
+.board-drawer-chat-linked-row .board-drawer-chat-card { flex:1; min-width:0; }
+.board-drawer-chat-unlink { display:flex; align-items:center; justify-content:center; width:32px; border-radius:8px; border:1px solid var(--border-hairline); background:var(--bg-base); color:var(--text-muted); cursor:pointer; flex-shrink:0; transition:background .12s,border-color .12s,color .12s; }
+.board-drawer-chat-unlink:hover { background:var(--bg-hover); border-color:color-mix(in oklch,var(--color-danger,#ef4444) 50%,var(--border-hairline)); color:var(--color-danger,#ef4444); }
 
 /* CWD path field */
 .board-drawer-path-shell { position:relative; display:block; width:100%; }


### PR DESCRIPTION
## What

Brings the **desktop** task↔chat linking up to parity with the iOS app. The core round-trip already existed (start/open a chat from a task; a task chip in the chat that jumps back to the board). This fills the three gaps:

1. **Assign a task from the chat** — the chat header's linked-context row gains a **"Link task"** picker (`task-link-picker.tsx`): search the board's tasks and attach one to the current conversation. It PATCHes the card's `sessionId` and optimistically shows the new chip.
2. **Unlink** — the board inspector's **Chat** section gains an **Unlink** button (×) next to "Open conversation" that clears the link (`sessionId → null`).
3. **Show all linked tasks** — a chat now lists **every** task sharing its session, not just the first. `linkedContextForSession` returns all matching cards (`tasks[]`) with GitHub links aggregated/de-duped; the existing `task` (first) field is kept for the mobile header / meta-title / lifecycle-chip consumers.

## Notes
- No new API routes — reuses `GET /api/board` (picker) and `PATCH /api/board/[id]` (link/unlink). The `ChatLinkedContext` type keeps its inline `task` shape and adds `tasks: LinkedTask[]`.
- `LinkedContextRow` now renders when there's linked context **or** a live session that can link a task (so the "Link task" affordance shows on an as-yet-unlinked chat). Updated the `chat-header-row` guard assertion accordingly.

## Verification
- `pnpm typecheck` → 0 errors
- `pnpm test:app` → **341 files passed** (incl. `board-chat-link`, `chat-linked-context`, `chat-header-row`)
- `pnpm test:mobile` → 16 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)