### PR TITLE
fix(ios): align the Chats header flush to the top like the other tabs

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -17,7 +17,11 @@ struct ChatsHomeView: View {
                     threadList
                 }
             }
-            .navigationTitle("Chats")
+            // Flush large-title header at the very top, matching Canvas / Read /
+            // Tasks (which hide the nav bar and supply their own top inset) so
+            // every tab's header aligns. Search + compose stay in the bottom bar.
+            .toolbar(.hidden, for: .navigationBar)
+            .safeAreaInset(edge: .top, spacing: 0) { header }
             .navigationDestination(for: ChatThread.self) { thread in
                 ChatView(thread: thread)
             }
@@ -48,6 +52,25 @@ struct ChatsHomeView: View {
               let id = ProcessInfo.processInfo.environment["CAVE_OPEN_THREAD"],
               let thread = app.threads.first(where: { $0.id == id }) else { return }
         path.append(thread)
+    }
+
+    /// Large-title header pinned to the top, mirroring the Canvas / Read / Tasks
+    /// tabs so every tab's title aligns at the same flush position.
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text("Chats")
+                .font(.largeTitle.weight(.bold))
+            Spacer()
+            if !app.threads.isEmpty {
+                Text("^[\(app.threads.count) chat](inflect: true)")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+        .padding(.bottom, 12)
+        .background(.bar)
     }
 
     private var threadList: some View {


### PR DESCRIPTION
## What

The Chats tab was the only one whose header sat **lower** than the rest — it used a standard `.navigationTitle("Chats")`, while Canvas / Read / Tasks all hide the nav bar and pin their header flush to the top via `.safeAreaInset(.top)`. This gives Chats the same treatment so every tab's title aligns at the same position.

## Before → After

| Before | After |
|---|---|
| `.navigationTitle("Chats")` — large title with a gap above it | flush large-title header on a `.bar` background, pinned to the top |

Search + compose stay in the iMessage-style bottom bar; the header just adds a chat count on the right, matching Canvas.

## Verification

iOS Simulator (iPhone 16 Pro): the "Chats" title now sits flush at the top, level with Canvas/Read/Tasks. `** BUILD SUCCEEDED **` (iOS isn't in CI, so the local build is the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)