### PR TITLE
feat(ios): add a copy button to chat code blocks

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/MarkdownWebView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MarkdownWebView.swift
@@ -85,6 +85,11 @@ struct MarkdownWebView: UIViewRepresentable {
                     if let href = body["href"] as? String, let url = URL(string: href) {
                         await UIApplication.shared.open(url)
                     }
+                case "copy":
+                    if let text = body["text"] as? String, !text.isEmpty {
+                        UIPasteboard.general.string = text
+                        Haptics.tap()
+                    }
                 default:
                     break
                 }

--- a/apps/ios/markdown/entry.mjs
+++ b/apps/ios/markdown/entry.mjs
@@ -72,7 +72,9 @@ function highlightCode(code, rawLang) {
   if (lang && hljs.getLanguage(lang)) {
     try { inner = hljs.highlight(code, { language: lang, ignoreIllegals: true }).value; } catch {}
   }
-  return `<pre class="hljs"><code class="hljs">${inner}</code></pre>`;
+  // Wrap in a positioned container with a copy button; the button reads the
+  // <code> textContent (raw, de-highlighted) and hands it to native on tap.
+  return `<div class="code-block"><button class="code-copy" type="button" aria-label="Copy code">Copy</button><pre class="hljs"><code class="hljs">${inner}</code></pre></div>`;
 }
 
 async function renderMarkdown(md) {
@@ -126,6 +128,19 @@ document.addEventListener("click", (e) => {
   if (!a) return;
   e.preventDefault();
   window.webkit?.messageHandlers?.cave?.postMessage({ type: "link", href: a.getAttribute("href") });
+});
+
+// Copy a code block: native owns the clipboard (UIPasteboard), so post the raw
+// text and flip the button to a confirmation briefly.
+document.addEventListener("click", (e) => {
+  const btn = e.target?.closest?.(".code-copy");
+  if (!btn) return;
+  const text = btn.parentElement?.querySelector("code")?.textContent ?? "";
+  window.webkit?.messageHandlers?.cave?.postMessage({ type: "copy", text });
+  btn.textContent = "Copied";
+  btn.classList.add("is-copied");
+  clearTimeout(btn._t);
+  btn._t = setTimeout(() => { btn.textContent = "Copy"; btn.classList.remove("is-copied"); }, 1400);
 });
 
 window.webkit?.messageHandlers?.cave?.postMessage({ type: "ready" });

--- a/apps/ios/markdown/markdown.css
+++ b/apps/ios/markdown/markdown.css
@@ -66,6 +66,24 @@ pre code {
   font-size: 0.86em; line-height: 1.5; border-radius: 0;
   white-space: pre;
 }
+/* fenced code block: a copy button pinned top-right (no hover on touch, so it
+   stays gently visible and brightens on tap / after copy). */
+.code-block { position: relative; }
+.code-copy {
+  position: absolute; top: 8px; right: 8px;
+  -webkit-appearance: none; appearance: none;
+  font: 600 11px -apple-system, system-ui, sans-serif;
+  padding: 3px 9px; border-radius: 7px;
+  border: 1px solid rgba(255,255,255,0.14);
+  background: rgba(255,255,255,0.07);
+  color: rgba(255,255,255,0.62);
+  opacity: 0.7; cursor: pointer;
+  transition: opacity 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.code-copy:active { opacity: 1; background: rgba(255,255,255,0.12); }
+.code-copy.is-copied {
+  opacity: 1; color: #57C878; border-color: rgba(87,200,120,0.5);
+}
 
 /* tables */
 table { border-collapse: collapse; width: 100%; margin: 0 0 0.7em; font-size: 0.92em; display: block; overflow-x: auto; }


### PR DESCRIPTION
## What

Each fenced **code block** in the iOS chat (rendered by the markdown WebView, with highlight.js) now has a small **Copy** button in its top-right corner.

- On tap it posts the block's raw text (the `<code>` `textContent`, de-highlighted) to native, which copies it via `UIPasteboard` and fires a light haptic. Using the native bridge (the WebView already has a `cave` message handler) avoids WKWebView clipboard-API gesture/secure-context pitfalls.
- The button flips to **"Copied"** for ~1.4s as confirmation. It stays gently visible (no hover on touch) and brightens on tap.

Source: `apps/ios/markdown/entry.mjs` (code-block wrapper + click handler) and `markdown.css` (button styling); the generated `markdown.html` is gitignored and rebuilt via `scripts/build-ios-markdown.mjs`. Native handler: a `"copy"` case in `MarkdownWebView`.

## Verification

- Regenerated `markdown.html` (`node scripts/build-ios-markdown.mjs`) and `xcodebuild` (iOS Simulator) → **BUILD SUCCEEDED**
- `pnpm test:mobile` (16/16)
- Runtime not device-verified (chat code blocks only render when connected); standard WKWebView↔native bridge pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)