### PR TITLE
fix(memory): strictly scope in-chat memory files to the active familiar

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -310,6 +310,8 @@ export const SUITES = {
     "src/components/chat-surface-projects-tab.test.ts",
     "src/components/composer-density.test.ts",
     "src/lib/memory-rows.test.ts",
+    "src/lib/memory-file-scope.test.ts",
+    "src/components/inspector-memory-familiar-scope.test.ts",
     "src/components/familiars-memory-row.test.ts",
     "src/components/familiars-memory-reader.test.ts",
     "src/components/familiars-memory-master-detail.test.ts",

--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -1,11 +1,28 @@
 import { NextResponse } from "next/server";
 import { listMemoryFileEntries } from "@/lib/server/memory-file-inventory";
+import { scopeMemoryFilesToFamiliar } from "@/lib/memory-file-scope";
 
 export const dynamic = "force-dynamic";
 
 export type { MemoryEntry } from "@/lib/server/memory-file-inventory";
 
-export async function GET() {
+export async function GET(req: Request) {
   const entries = await listMemoryFileEntries();
+
+  // When a chat session asks for a specific familiar's memory, scope at the
+  // source so another familiar's file metadata never crosses the wire: keep the
+  // familiar's own files plus ownerless/global pools, drop every other
+  // familiar's. With no `familiarId` (e.g. the cross-familiar management view)
+  // the full inventory is returned unchanged.
+  const familiarId = new URL(req.url).searchParams.get("familiarId");
+  if (familiarId) {
+    const scoped = scopeMemoryFilesToFamiliar(entries, familiarId);
+    return NextResponse.json({
+      ok: true,
+      entries: scoped.visible,
+      hiddenForeignCount: scoped.hiddenForeignCount,
+    });
+  }
+
   return NextResponse.json({ ok: true, entries });
 }

--- a/src/components/inspector-memory-familiar-scope.test.ts
+++ b/src/components/inspector-memory-familiar-scope.test.ts
@@ -1,0 +1,69 @@
+// @ts-nocheck
+// Regression guard for the chat-session memory leak: the in-chat inspector's
+// "Files" mode must scope memory files to the active familiar, and the
+// `/api/memory` route must scope at the source. These lock the wiring so a
+// future refactor can't silently re-introduce cross-familiar file exposure.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const read = (rel) => readFileSync(path.join(process.cwd(), rel), "utf8");
+
+// ── /api/memory route scopes by familiarId at the source ────────────────────
+{
+  const route = read("src/app/api/memory/route.ts");
+  assert.match(route, /scopeMemoryFilesToFamiliar/, "route must use the shared scoping helper");
+  assert.match(
+    route,
+    /searchParams\.get\(\s*["']familiarId["']\s*\)/,
+    "route must read the familiarId query param",
+  );
+  assert.match(
+    route,
+    /scopeMemoryFilesToFamiliar\(\s*entries\s*,\s*familiarId\s*\)/,
+    "route must scope the inventory to the requested familiar",
+  );
+}
+
+// ── Inspector "Files" mode scopes to the active familiar ────────────────────
+{
+  const src = read("src/components/inspector-pane.tsx");
+
+  assert.match(
+    src,
+    /from\s+["']@\/lib\/memory-file-scope["']/,
+    "inspector must import the scoping helper",
+  );
+
+  // The file inventory is fetched scoped to the active familiar...
+  assert.match(
+    src,
+    /\/api\/memory\?familiarId=\$\{encodeURIComponent\(familiar\.id\)\}/,
+    "inspector must request the familiar-scoped memory list",
+  );
+
+  // ...and the fetch re-runs when the active familiar changes (a `[]` dep here
+  // was the original leak: the list was fetched once, unscoped, and reused).
+  const fetchEffect = src.slice(src.indexOf('const url = familiar'));
+  assert.match(
+    fetchEffect.slice(0, 800),
+    /\}, \[familiar\?\.id\]\);/,
+    "the memory-list effect must depend on familiar?.id",
+  );
+
+  // Defense in depth: rows are also scoped client-side for ownership + ordering.
+  assert.match(
+    src,
+    /scopeMemoryFilesToFamiliar\(entries,\s*familiar\?\.id\)/,
+    "inspector must scope rows client-side too",
+  );
+
+  // The unscoped fetch (the bug) must be gone.
+  assert.doesNotMatch(
+    src,
+    /fetch\(\s*["']\/api\/memory["']\s*,/,
+    "inspector must not fetch the unscoped /api/memory list",
+  );
+}
+
+console.log("inspector-memory-familiar-scope.test.ts passed");

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -16,6 +16,7 @@ import type { HarnessCapabilityManifest } from "@/app/api/capabilities/route";
 import type { RoleEntry } from "@/app/api/roles/route";
 import type { LocalSkillEntry } from "@/app/api/skills/local/route";
 import type { AdapterReport } from "@/lib/harness-adapters";
+import { scopeMemoryFilesToFamiliar } from "@/lib/memory-file-scope";
 
 type Tab = "memory" | "familiar" | "inbox" | "vault";
 
@@ -28,6 +29,9 @@ type MemoryEntry = {
   fullPath: string;
   size: number;
   modified: string;
+  /** Familiar id when this file belongs to a specific agent workspace; absent
+   *  for ownerless/global pools. Drives strict per-familiar scoping in chat. */
+  familiarId?: string | null;
 };
 
 type MemoryFile = {
@@ -591,6 +595,16 @@ type CovenMemoryEntry = {
   excerpt?: string;
 };
 
+/** Marks a row that belongs to a shared/global pool (no familiar owner) rather
+ *  than the active familiar — so "Files" never silently mixes scopes. */
+function OwnershipTag() {
+  return (
+    <span className="rounded bg-[var(--bg-raised)] px-1 py-px text-[9px] normal-case tracking-normal text-[var(--text-muted)]">
+      shared
+    </span>
+  );
+}
+
 function MemoryTab({
   familiar,
   onOpenFullView,
@@ -627,10 +641,17 @@ function MemoryTab({
     })();
   }, []);
 
+  // Scope the file inventory to the active familiar AT THE SOURCE so another
+  // familiar's file metadata never reaches this chat session. The server keeps
+  // this familiar's files + ownerless/global pools and drops every other
+  // familiar's. Re-fetch when the active familiar changes.
   useEffect(() => {
     void (async () => {
       try {
-        const res = await fetch("/api/memory", { cache: "no-store" });
+        const url = familiar
+          ? `/api/memory?familiarId=${encodeURIComponent(familiar.id)}`
+          : "/api/memory";
+        const res = await fetch(url, { cache: "no-store" });
         const json = await res.json();
         if (!json.ok) {
           setError(json.error ?? "memory list failed");
@@ -641,7 +662,7 @@ function MemoryTab({
         setError(err instanceof Error ? err.message : "fetch failed");
       }
     })();
-  }, []);
+  }, [familiar?.id]);
 
   useEffect(() => {
     if (!openPath) {
@@ -670,11 +691,20 @@ function MemoryTab({
     })();
   }, [openPath, reveal]);
 
+  // Strict per-familiar scoping (defense in depth alongside the server filter):
+  // owned files first, then ownerless/global; another familiar's files are never
+  // shown. `ownership` labels each row; `hiddenForeignCount` reports how many
+  // other-familiar files were withheld.
+  const filesScope = useMemo(
+    () => scopeMemoryFilesToFamiliar(entries, familiar?.id),
+    [entries, familiar?.id],
+  );
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
-    if (!q) return entries;
-    return entries.filter((e) => e.relPath.toLowerCase().includes(q) || e.rootLabel.toLowerCase().includes(q));
-  }, [entries, query]);
+    const rows = filesScope.visible;
+    if (!q) return rows;
+    return rows.filter((e) => e.relPath.toLowerCase().includes(q) || e.rootLabel.toLowerCase().includes(q));
+  }, [filesScope, query]);
 
   const covenFiltered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -823,8 +853,9 @@ function MemoryTab({
             >
               <span className="flex min-w-0 flex-col">
                 <span className="truncate text-[var(--text-primary)]">{e.relPath}</span>
-                <span className="truncate text-[10px] uppercase tracking-widest text-[var(--text-muted)]">
-                  {e.rootLabel}
+                <span className="flex items-center gap-1 truncate text-[10px] uppercase tracking-widest text-[var(--text-muted)]">
+                  {e.ownership === "shared" ? <OwnershipTag /> : null}
+                  <span className="truncate">{e.rootLabel}</span>
                 </span>
               </span>
               <span className="shrink-0 font-mono text-[10px] text-[var(--text-muted)]">{age(e.modified)}</span>
@@ -834,6 +865,12 @@ function MemoryTab({
         {filtered.length > 200 ? (
           <li className="px-2 py-2 text-center text-[10px] text-[var(--text-muted)]">
             +{filtered.length - 200} more — filter to narrow
+          </li>
+        ) : null}
+        {familiar && filesScope.hiddenForeignCount > 0 ? (
+          <li className="px-2 py-2 text-center text-[10px] text-[var(--text-muted)]">
+            {filesScope.hiddenForeignCount} other familiar
+            {filesScope.hiddenForeignCount === 1 ? "’s" : "s’"} memory hidden — scoped to {familiar.display_name}
           </li>
         ) : null}
       </ul>

--- a/src/lib/memory-file-scope.test.ts
+++ b/src/lib/memory-file-scope.test.ts
@@ -1,0 +1,110 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  scopeMemoryFilesToFamiliar,
+  visibleMemoryFilesForFamiliar,
+} from "./memory-file-scope.ts";
+
+const entry = (id, familiarId) => ({ id, familiarId });
+
+// ── The core guarantee: a chat with one familiar never surfaces another's memory.
+{
+  const entries = [
+    entry("echo-1", "echo"),
+    entry("sage-1", "sage"),
+    entry("echo-2", "echo"),
+    entry("global-1", null),
+    entry("nova-1", "nova"),
+  ];
+  const res = scopeMemoryFilesToFamiliar(entries, "echo");
+  const ids = res.visible.map((e) => e.id);
+  assert.deepEqual(ids, ["echo-1", "echo-2", "global-1"], "owned first, then shared; foreign dropped");
+  assert.ok(!ids.includes("sage-1"), "another familiar's memory is excluded");
+  assert.ok(!ids.includes("nova-1"), "another familiar's memory is excluded");
+  assert.equal(res.ownedCount, 2);
+  assert.equal(res.sharedCount, 1);
+  assert.equal(res.hiddenForeignCount, 2, "both foreign entries counted as hidden");
+}
+
+// ── Ownership labels are correct.
+{
+  const res = scopeMemoryFilesToFamiliar(
+    [entry("a", "echo"), entry("b", null), entry("c", "sage")],
+    "echo",
+  );
+  assert.deepEqual(
+    res.visible.map((e) => [e.id, e.ownership]),
+    [["a", "owned"], ["b", "shared"]],
+    "owned for the active familiar, shared for ownerless; foreign absent",
+  );
+}
+
+// ── Ordering: every owned entry precedes every shared entry, input order kept.
+{
+  const res = scopeMemoryFilesToFamiliar(
+    [entry("g1", null), entry("o1", "echo"), entry("g2", null), entry("o2", "echo")],
+    "echo",
+  );
+  assert.deepEqual(res.visible.map((e) => e.id), ["o1", "o2", "g1", "g2"]);
+}
+
+// ── No active familiar → no scoping, everything visible as "shared", nothing hidden.
+for (const none of [null, undefined, "", "   "]) {
+  const res = scopeMemoryFilesToFamiliar([entry("a", "echo"), entry("b", "sage"), entry("c", null)], none);
+  assert.equal(res.visible.length, 3, `passthrough when active familiar is ${JSON.stringify(none)}`);
+  assert.ok(res.visible.every((e) => e.ownership === "shared"));
+  assert.equal(res.hiddenForeignCount, 0, "no boundary to enforce ⇒ nothing hidden");
+}
+
+// ── Whitespace + nullish owner ids are normalized (no accidental foreign match).
+{
+  const res = scopeMemoryFilesToFamiliar(
+    [entry("a", " echo "), entry("b", "echo"), entry("c", undefined), entry("d", "")],
+    "echo",
+  );
+  assert.deepEqual(res.visible.map((e) => e.id), ["a", "b", "c", "d"], "trimmed owner matches; empty/undefined owner ⇒ shared");
+  assert.equal(res.hiddenForeignCount, 0);
+}
+
+// ── The active id is trimmed too, so a padded active familiar still scopes right.
+{
+  const res = scopeMemoryFilesToFamiliar([entry("a", "echo"), entry("b", "sage")], "  echo ");
+  assert.deepEqual(res.visible.map((e) => e.id), ["a"]);
+  assert.equal(res.hiddenForeignCount, 1);
+}
+
+// ── Empty input is safe.
+{
+  const res = scopeMemoryFilesToFamiliar([], "echo");
+  assert.deepEqual(res.visible, []);
+  assert.equal(res.ownedCount, 0);
+  assert.equal(res.sharedCount, 0);
+  assert.equal(res.hiddenForeignCount, 0);
+}
+
+// ── All-foreign input → nothing visible, all hidden (the strongest leak guard).
+{
+  const res = scopeMemoryFilesToFamiliar([entry("a", "sage"), entry("b", "nova")], "echo");
+  assert.deepEqual(res.visible, []);
+  assert.equal(res.hiddenForeignCount, 2);
+}
+
+// ── The function does not mutate input entries; it returns annotated copies.
+{
+  const input = [entry("a", "echo")];
+  const res = scopeMemoryFilesToFamiliar(input, "echo");
+  assert.equal("ownership" in input[0], false, "original entry left untouched");
+  assert.equal(res.visible[0].ownership, "owned");
+  assert.notEqual(res.visible[0], input[0], "returns a copy");
+}
+
+// ── visibleMemoryFilesForFamiliar is the convenience projection of `.visible`.
+{
+  const entries = [entry("a", "echo"), entry("b", "sage"), entry("c", null)];
+  assert.deepEqual(
+    visibleMemoryFilesForFamiliar(entries, "echo").map((e) => e.id),
+    scopeMemoryFilesToFamiliar(entries, "echo").visible.map((e) => e.id),
+  );
+}
+
+console.log("memory-file-scope.test.ts passed");

--- a/src/lib/memory-file-scope.ts
+++ b/src/lib/memory-file-scope.ts
@@ -1,0 +1,90 @@
+// Strict per-familiar scoping for memory FILE entries surfaced inside a chat
+// session (the inspector/rail Memory tab). The rule mirrors `buildMemoryRows`'s
+// file policy so the whole app agrees on what "this familiar's memory" means:
+//
+//   • owned   — the entry belongs to the active familiar's workspace.
+//   • shared  — the entry has no familiar owner (global/runtime pools, e.g.
+//               ~/.coven/memory, the OpenClaw workspace index, Codex runtime).
+//   • foreign — the entry belongs to a DIFFERENT familiar. These are dropped:
+//               a chat with familiar A must never surface familiar B's memory.
+//
+// This module is framework- and fs-free so it can run on the server (to scope
+// `/api/memory?familiarId=` at the source) and on the client (to order + label
+// rows) from a single, unit-tested source of truth.
+
+export type MemoryOwnership = "owned" | "shared";
+
+/** An entry with enough shape to be scoped — anything carrying `familiarId`. */
+export type FamiliarScopable = { familiarId?: string | null };
+
+export type ScopedMemoryEntry<T> = T & { ownership: MemoryOwnership };
+
+export type MemoryScopeResult<T> = {
+  /** Visible entries, owned first then shared; foreign entries excluded.
+   *  Input order is preserved within each ownership group. */
+  visible: ScopedMemoryEntry<T>[];
+  ownedCount: number;
+  sharedCount: number;
+  /** How many entries were dropped because they belong to another familiar. */
+  hiddenForeignCount: number;
+};
+
+function normalizeId(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+/**
+ * Scope memory file `entries` to `activeFamiliarId`.
+ *
+ * When `activeFamiliarId` is empty/absent there is no familiar context to scope
+ * against (e.g. the inspector with no familiar selected), so every entry is
+ * returned and labelled `shared` and nothing is hidden — this is NOT a chat
+ * session, so there is no cross-familiar boundary to enforce.
+ *
+ * When a familiar IS active (the chat-session case), foreign entries are
+ * strictly excluded and the rest are labelled owned/shared and ordered
+ * owned-first.
+ */
+export function scopeMemoryFilesToFamiliar<T extends FamiliarScopable>(
+  entries: readonly T[],
+  activeFamiliarId: string | null | undefined,
+): MemoryScopeResult<T> {
+  const active = normalizeId(activeFamiliarId);
+
+  if (!active) {
+    const visible = entries.map((e) => ({ ...e, ownership: "shared" as const }));
+    return { visible, ownedCount: 0, sharedCount: visible.length, hiddenForeignCount: 0 };
+  }
+
+  const owned: ScopedMemoryEntry<T>[] = [];
+  const shared: ScopedMemoryEntry<T>[] = [];
+  let hiddenForeignCount = 0;
+
+  for (const entry of entries) {
+    const owner = normalizeId(entry.familiarId);
+    if (owner === null) {
+      shared.push({ ...entry, ownership: "shared" });
+    } else if (owner === active) {
+      owned.push({ ...entry, ownership: "owned" });
+    } else {
+      hiddenForeignCount += 1; // a different familiar's memory — never surfaced
+    }
+  }
+
+  return {
+    visible: [...owned, ...shared],
+    ownedCount: owned.length,
+    sharedCount: shared.length,
+    hiddenForeignCount,
+  };
+}
+
+/** Convenience: just the scoped, visible entries (owned + shared, ordered). */
+export function visibleMemoryFilesForFamiliar<T extends FamiliarScopable>(
+  entries: readonly T[],
+  activeFamiliarId: string | null | undefined,
+): ScopedMemoryEntry<T>[] {
+  return scopeMemoryFilesToFamiliar(entries, activeFamiliarId).visible;
+}


### PR DESCRIPTION
## When & why memory was NOT limited to a single familiar

The in-chat memory surface is `InspectorPane` → **Memory tab** (the chat rail/inspector). It has two modes:

- **Coven mode** — filtered by `e.familiar_id === familiar.id` → already strictly scoped ✅
- **Files mode** — fetched the **unscoped** `/api/memory` inventory (once, `useEffect([])`) and filtered **only by search text**. So a chat with familiar **A** listed familiar **B**'s — and every other familiar's — memory files. **This was the leak.**

For completeness, the paths that were already correct: the agent **context injection** in `/api/chat/send` only loads the active familiar's daily memory, and the Coven mode above.

## Fix

- **`scopeMemoryFilesToFamiliar`** — a new pure, framework/fs-free helper encoding the same policy the rest of the app already uses (`buildMemoryRows`): keep the familiar's **own** files + **ownerless/global** pools (`~/.coven/memory`, OpenClaw index, Codex runtime), and **drop every other familiar's**. Single source of truth, runs on both server and client.
- **`/api/memory?familiarId=`** scopes the inventory **at the source** — another familiar's file metadata never crosses the wire to a chat session. With no param (the deliberate cross-familiar *management* view) the full inventory is returned unchanged.
- **Inspector Files mode** now fetches the scoped list (effect keyed on `familiar?.id` — the `[]` dep was the bug), scopes again client-side for ownership ordering/labels, tags shared/global rows, and shows *“N other familiars’ memory hidden — scoped to <familiar>.”*

## Tests

- `memory-file-scope.test.ts` — exhaustive: owned/shared/foreign classification, owned-first ordering, hidden-count, null/whitespace handling, immutability, empty + all-foreign (the strongest leak guard).
- `inspector-memory-familiar-scope.test.ts` — regression guard locking the route + inspector wiring so the unscoped fetch can't silently return.

Both registered in `run-tests.mjs` (app suite). Full `test:app` (343 files) + `tsc --noEmit` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)