### PR TITLE
fix: quiet localhost port probing + accurate per-harness capabilities error

### DIFF
--- a/src/app/api/capabilities/route.ts
+++ b/src/app/api/capabilities/route.ts
@@ -118,14 +118,28 @@ export async function GET(req: Request) {
   const harness = url.searchParams.get("harness");
 
   if (harness) {
-    const manifest = await fetchHarnessManifest(harness, refresh);
-    if (!manifest) {
-      return NextResponse.json(
-        { ok: false, error: "daemon offline", coven_skills: [], harness_capabilities: [], scanned_at: new Date().toISOString() },
-        { status: 503 },
-      );
+    const res = await callDaemon<HarnessCapabilityManifest>({
+      path: `/api/v1/capabilities/${encodeURIComponent(harness)}${refresh}`,
+    });
+    if (res.ok && isManifest(res.data)) {
+      const manifest = await supplementClaudeSkills(res.data);
+      return NextResponse.json({ ok: true, coven_skills: [], harness_capabilities: [manifest], scanned_at: manifest.scanned_at });
     }
-    return NextResponse.json({ ok: true, coven_skills: [], harness_capabilities: [manifest], scanned_at: manifest.scanned_at });
+    // The daemon may be up but simply have no manifest for this harness —
+    // e.g. openclaw ships as its own CLI flow, not a daemon-scanned harness.
+    // Only report "daemon offline" when the socket is genuinely unreachable;
+    // otherwise say so accurately so the UI doesn't blame an outage.
+    const offline = res.status === 0 || (res.error != null && /(ENOENT|ECONNREFUSED|ETIMEDOUT|socket|connect)/i.test(res.error));
+    return NextResponse.json(
+      {
+        ok: false,
+        error: offline ? "daemon offline" : `no capabilities manifest for harness "${harness}"`,
+        coven_skills: [],
+        harness_capabilities: [],
+        scanned_at: new Date().toISOString(),
+      },
+      { status: 503 },
+    );
   }
 
   // Newer daemons repurposed the aggregate /api/v1/capabilities for

--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -436,9 +436,13 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
   }, [bridge, nativeBrowserAvailable, activeTab?.url, activeTab?.id]);
 
   // ── Localhost probe ───────────────────────────────────────────────
+  // Each closed port logs an ERR_CONNECTION_REFUSED in the console (a no-cors
+  // fetch can't be silenced), so probe sparingly: only while the document is
+  // visible, and on a slow cadence — never poll a backgrounded window.
   useEffect(() => {
     let cancelled = false;
     const probe = async () => {
+      if (typeof document !== "undefined" && document.visibilityState !== "visible") return;
       for (const port of LOCALHOST_PORTS) {
         if (cancelled) break;
         const live = await probeLocalhost(port);
@@ -468,8 +472,16 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
       }
     };
     void probe();
-    const interval = setInterval(() => void probe(), 8000);
-    return () => { cancelled = true; clearInterval(interval); };
+    const interval = setInterval(() => void probe(), 30000);
+    // Re-probe promptly when the user returns to the tab rather than waiting
+    // out the slow interval.
+    const onVisible = () => { if (document.visibilityState === "visible") void probe(); };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
   }, []);
 
   // ── Tab actions ───────────────────────────────────────────────────


### PR DESCRIPTION
## What

Addresses console errors surfaced while using the desktop app.

### 1. Localhost port-probe console flood
`browser-pane.tsx` probed 6 common dev ports (3000/3001/5173/8080/4000/4321) on mount **and every 8 seconds, forever**. Each closed port logs an `ERR_CONNECTION_REFUSED` (a `no-cors` fetch can't be silenced), so the console filled with refusals continuously. Now it:
- probes **only while the document is visible** (never polls a backgrounded window),
- uses a **30s** cadence instead of 8s,
- re-probes promptly on tab focus (`visibilitychange`).

Local-dev-server auto-detection still works; the noise is cut to a slow trickle and stops entirely when the window isn't in front.

### 2. Misleading "daemon offline" capabilities error
`GET /api/capabilities?harness=X` returned `{ error: "daemon offline" }` (503) whenever a harness had no manifest — even when the daemon was up (`/api/daemon/status` → `running: true`). This hit **openclaw**, which ships as its own CLI flow rather than a daemon-scanned harness. The route now distinguishes a genuinely unreachable socket (ENOENT/ECONNREFUSED/… → "daemon offline") from a reachable daemon that simply has no manifest for that harness (→ `no capabilities manifest for harness "X"`).

### Not changed (working as designed)
The `/api/chat/conversation/<id>` **404** is a session that exists in the list but has no transcript; chat-view already handles it with the "Chat history unavailable" state. The `gstatic` favicon 404 is an external lookup for a saved link. Both are benign.

## Verification
- `pnpm typecheck` → 0; `pnpm test:app` → **341 passed**; `pnpm test:mobile` → 16 passed (incl. `capabilities/route.test.ts`, `browser-pane-*` tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)