### PR TITLE
fix(about): Docs link → docs.opencoven.ai

### DIFF
--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -1331,7 +1331,7 @@ function AboutSection() {
         <div className="flex flex-wrap gap-2 px-4 py-3">
           {[
             { label: "GitHub",   href: "https://github.com/OpenCoven/coven-cave", icon: "ph:github-logo" as const },
-            { label: "Docs",     href: "https://docs.openclaw.ai",                icon: "ph:file-text" as const },
+            { label: "Docs",     href: "https://docs.opencoven.ai",               icon: "ph:file-text" as const },
             { label: "X",        href: "https://x.com/OpenCvn",                   icon: "ph:x-logo-bold" as const },
             { label: "Discord",  href: "https://discord.gg/opencoven",            icon: "ph:discord-logo" as const },
             { label: "Grimoire", href: "https://mind.opencoven.ai",               icon: "ph:book-open" as const },


### PR DESCRIPTION
The Settings → About → Links **Docs** entry pointed at the legacy `docs.openclaw.ai`. Every other link in that group already uses the `opencoven.ai` domain, and `docs.opencoven.ai` resolves (200). One-line href fix in `settings-shell.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)