### PR TITLE
feat(code): reveal & highlight chat-clicked files in the project tree

### DIFF
--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -587,6 +587,19 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
         : selectedRoot
           ? `${selectedRoot.replace(/\/$/, "")}/${detail.path.replace(/^\.?\//, "")}`
           : detail.path;
+      // If the file lives inside a project we already track, reveal it in the
+      // tree too: switch to that project so the tree is rooted there, and make
+      // sure the file column is open. The tree then auto-expands to the file and
+      // highlights it (via selectedPath). Files outside any known project still
+      // open in the preview — just without the tree reveal.
+      const within = projects.find((project) => {
+        const r = project.root.replace(/\/$/, "");
+        return path === r || path.startsWith(`${r}/`);
+      });
+      if (within) {
+        if (within.root !== selectedProjectRoot) setSelectedProjectRoot(within.root);
+        setProjectDetailCollapsed(false);
+      }
       // A user-initiated file open is an explicit view choice — pin it so the
       // diff-first auto-switch doesn't yank them back to Changes.
       pinnedRightViewRef.current = true;
@@ -609,7 +622,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
       window.removeEventListener("cave:open-project-file", onOpenFile as EventListener);
       window.removeEventListener("cave:open-file-diff", onOpenDiff as EventListener);
     };
-  }, [active, openFilePreview, selectedRoot]);
+  }, [active, openFilePreview, selectedRoot, projects, selectedProjectRoot]);
 
   // Code workspace toolbar wiring (projects view only): the Projects toggle
   // shows/hides this column, and a layout preset additionally switches the

--- a/src/components/message-bubble-file-links.test.ts
+++ b/src/components/message-bubble-file-links.test.ts
@@ -56,4 +56,24 @@ assert.match(
 // Affordance styling exists.
 assert.match(css, /code\.cave-file-link \{[\s\S]*?cursor: pointer/, "file-link affordance is styled");
 
+// Opening a file that lives inside a tracked project also reveals it in the
+// tree: comux switches to the containing project and opens the file column.
+const tree = await readFile(new URL("./project-tree.tsx", import.meta.url), "utf8");
+assert.match(
+  comux,
+  /const within = projects\.find\(\(project\) => \{[\s\S]*?path\.startsWith\(`\$\{r\}\/`\)/,
+  "comux matches the opened path against existing project roots",
+);
+assert.match(
+  comux,
+  /if \(within\) \{[\s\S]*?setSelectedProjectRoot\(within\.root\)[\s\S]*?setProjectDetailCollapsed\(false\)/,
+  "an in-project file switches to that project and opens the file column",
+);
+// The tree auto-expands ancestors of the selected file so the highlight shows.
+assert.match(
+  tree,
+  /selectedPath\.startsWith\(`\$\{entry\.path\}\/`\)/,
+  "tree reveals the selected file by expanding its ancestor folders",
+);
+
 console.log("message-bubble-file-links.test.ts: ok");

--- a/src/components/project-tree.tsx
+++ b/src/components/project-tree.tsx
@@ -230,6 +230,29 @@ function TreeRow({
     }
   }, [entry, expanded, children, onFileClick]);
 
+  // Reveal-to-selection: when the selected (open) file lives somewhere under
+  // this folder, auto-expand so the highlighted row becomes visible. This is
+  // what makes "click a file in chat → open AND reveal it in the tree" work:
+  // each ancestor expands (lazily fetching its children), and the next ancestor
+  // mounts and repeats, cascading down to the file. We only ever expand here,
+  // never collapse — a user's manual layout is preserved.
+  const revealedRef = useRef(false);
+  useEffect(() => {
+    if (!entry.isDir || !selectedPath) return;
+    if (selectedPath === entry.path || !selectedPath.startsWith(`${entry.path}/`)) return;
+    setExpanded(true);
+    if (children !== null || revealedRef.current) return;
+    revealedRef.current = true;
+    let alive = true;
+    setFetching(true);
+    void fetchChildren(entry.path).then((fetched) => {
+      if (!alive) return;
+      setChildren(fetched);
+      setFetching(false);
+    });
+    return () => { alive = false; };
+  }, [selectedPath, entry.isDir, entry.path, children]);
+
   return (
     <div role="treeitem" aria-expanded={entry.isDir ? expanded : undefined}>
       {/* Row */}


### PR DESCRIPTION
## What

Clicking a file path inside a chat message (the monospace pills like `skills/higgsfield/docs/references.md`) already opens that file in the Code workspace preview. This adds the second half of that interaction: **when the file lives inside a project we already track, it's also revealed and highlighted in the file tree.**

- The file tree **switches to the containing project** so it's rooted correctly, **opens the file column**, and **auto-expands the file's ancestor folders** so the highlighted row is visible.
- Files **outside** any known project still open in the preview exactly as before — the tree is left untouched. This is the "only when the path is in a project we already created" gate.

## How

- `project-tree.tsx` — `TreeRow` auto-expands (lazily fetching children) whenever the selected path is a descendant of that folder. The cascade walks down ancestor → ancestor to the file. It **only ever expands, never collapses**, so a user's manual tree layout is preserved.
- `comux-view.tsx` — `onOpenFile` matches the resolved absolute path against the existing (session-derived) project roots; an in-project hit switches `selectedProjectRoot` and opens the project detail column before the preview opens.

## Verification

- `pnpm typecheck` clean; `pnpm test:app` → **343/343** files pass (extended `message-bubble-file-links.test.ts` to pin the project-match + reveal wiring).
- The end-to-end reveal needs a live daemon with real project sessions (that's what populates the tracked-project list), so I verified the logic + wiring rather than a live click; the tree-expansion is deterministic from `selectedPath`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)