### PR TITLE
feat(schedules): add an Inbox tab for viewing all inbox items

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -180,6 +180,7 @@ export const SUITES = {
     "src/components/automations-detail-inputs.test.ts",
     "src/components/automations-view.test.ts",
     "src/components/schedules-tabs.test.ts",
+    "src/lib/inbox-feed.test.ts",
     "src/lib/daily-summary-notifications.test.ts",
     "src/components/daily-summary-notifications.test.ts",
     "src/app/daily-report-page.test.ts",

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import type { Familiar } from "@/lib/types";
 import type { InboxItem, LinkRef } from "@/lib/cave-inbox";
 import type { Recurrence } from "@/lib/inbox-recurrence";
+import { groupInboxFeed, inboxKindLabel } from "@/lib/inbox-feed";
 import type {
   AutomationStatus,
   CodexAutomation,
@@ -39,7 +40,7 @@ function linkLabel(link: LinkRef): string {
   return "Memory";
 }
 
-type ScheduleTab = "reminders" | "automations";
+type ScheduleTab = "reminders" | "automations" | "inbox";
 
 const WEEKDAY = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 const DAY_INITIALS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
@@ -1102,6 +1103,142 @@ function AutomationsPanel({
   );
 }
 
+// ── Inbox feed (full inbox: reminders, summaries, agent + response items) ─────
+function InboxKindBadge({ kind }: { kind: InboxItem["kind"] }) {
+  return (
+    <span
+      className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide"
+      style={{ background: "var(--bg-base)", border: "1px solid var(--border-hairline)", color: "var(--text-muted)" }}
+    >
+      {inboxKindLabel(kind)}
+    </span>
+  );
+}
+
+function InboxFeedRow({
+  item,
+  selected,
+  familiarLabel,
+  onSelect,
+}: {
+  item: InboxItem;
+  selected: boolean;
+  familiarLabel: (fid?: string | null) => string | null;
+  onSelect: (item: InboxItem) => void;
+}) {
+  const workspace = familiarLabel(item.familiarId);
+  const when = item.firedAt
+    ? `fired ${relTime(item.firedAt)}`
+    : item.fireAt
+    ? relTime(item.fireAt)
+    : relTime(item.updatedAt);
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onSelect(item)}
+        className="focus-ring-inset automation-list-row group flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors"
+        style={{ background: selected ? "rgba(255,255,255,0.05)" : "transparent" }}
+        onMouseEnter={(e) => { if (!selected) (e.currentTarget as HTMLButtonElement).style.background = "rgba(255,255,255,0.03)"; }}
+        onMouseLeave={(e) => { if (!selected) (e.currentTarget as HTMLButtonElement).style.background = "transparent"; }}
+      >
+        <StatusIcon item={item} />
+        <span className="flex-1 min-w-0 flex items-center gap-2">
+          <span className="text-[13px] truncate" style={{ color: "var(--text-primary)" }}>
+            {item.title}
+          </span>
+          <InboxKindBadge kind={item.kind} />
+          {workspace && (
+            <span className="shrink-0 text-[11px]" style={{ color: "var(--text-muted)" }}>
+              {workspace}
+            </span>
+          )}
+        </span>
+        <span className="shrink-0 text-[12px] tabular-nums" style={{ color: "var(--text-muted)" }}>
+          {when}
+        </span>
+      </button>
+    </li>
+  );
+}
+
+function InboxFeedSection({
+  title,
+  accent,
+  items,
+  selectedId,
+  familiarLabel,
+  onSelect,
+}: {
+  title: string;
+  accent?: boolean;
+  items: InboxItem[];
+  selectedId: string | null;
+  familiarLabel: (fid?: string | null) => string | null;
+  onSelect: (item: InboxItem) => void;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <div className="mb-6">
+      <div className="flex items-center gap-3 mb-1 rounded-md px-3 py-1.5"
+        style={{ background: "color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%)", borderBottom: "1px solid var(--border-hairline)" }}>
+        <span className="text-[12px] font-bold" style={{ color: "var(--text-primary)" }}>
+          {title}
+        </span>
+        <span
+          className="rounded px-1.5 py-0.5 text-[10px] font-semibold"
+          style={
+            accent
+              ? { background: "color-mix(in oklch, var(--color-warning) 18%, transparent)", color: "var(--color-warning)" }
+              : { background: "var(--bg-raised)", color: "var(--text-muted)" }
+          }
+        >
+          {items.length}
+        </span>
+      </div>
+      <ul>
+        {items.map((item) => (
+          <InboxFeedRow
+            key={item.id}
+            item={item}
+            selected={selectedId === item.id}
+            familiarLabel={familiarLabel}
+            onSelect={onSelect}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function InboxFeedList({
+  needsYou,
+  active,
+  resolved,
+  selectedId,
+  familiarLabel,
+  onSelect,
+}: {
+  needsYou: InboxItem[];
+  active: InboxItem[];
+  resolved: InboxItem[];
+  selectedId: string | null;
+  familiarLabel: (fid?: string | null) => string | null;
+  onSelect: (item: InboxItem) => void;
+}) {
+  return (
+    <>
+      <InboxFeedSection title="Needs you" accent items={needsYou} selectedId={selectedId}
+        familiarLabel={familiarLabel} onSelect={onSelect} />
+      <InboxFeedSection title="Active" items={active} selectedId={selectedId}
+        familiarLabel={familiarLabel} onSelect={onSelect} />
+      <InboxFeedSection title="Resolved" items={resolved} selectedId={selectedId}
+        familiarLabel={familiarLabel} onSelect={onSelect} />
+    </>
+  );
+}
+
 // ── Root ──────────────────────────────────────────────────────────────────────
 export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdit, onOpenLink }: Props) {
   const [items, setItems] = useState<InboxItem[]>([]);
@@ -1294,15 +1431,20 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     [codexAutos],
   );
 
+  // Inbox tab: the FULL feed (every kind), grouped by attention tier.
+  const inboxFeed = useMemo(() => groupInboxFeed(items), [items]);
   const remindersEmpty = current.length + paused.length + oneShots.length + history.length === 0;
   const automationsEmpty = codexAutos.length === 0;
+  const inboxEmpty = items.length === 0;
   const selectedReminderId = selectedItem?.id ?? null;
   const selectedAutomationId = selectedCodex?.id ?? null;
 
   const selectTab = (tab: ScheduleTab) => {
     setActiveTab(tab);
-    if (tab === "reminders") setSelectedCodex(null);
-    else setSelectedItem(null);
+    // Reminders and Inbox both select InboxItems (DetailPanel); Automations
+    // selects CodexAutomations. Clear the other selection on switch.
+    if (tab === "automations") setSelectedItem(null);
+    else setSelectedCodex(null);
   };
 
   return (
@@ -1336,6 +1478,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
             style={{ borderColor: "var(--border-hairline)", background: "var(--bg-raised)" }}>
             {([
               ["reminders", "Reminders", reminderItems.length],
+              ["inbox", "Inbox", items.length],
               ["automations", "Automations", codexAutos.length],
             ] as const).map(([id, label, count]) => (
               <button
@@ -1405,6 +1548,13 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
               headline="No automations configured"
               subtitle="Automations run a familiar on a schedule — set one up to get started."
             />
+          ) : activeTab === "inbox" && inboxEmpty ? (
+            <EmptyState
+              className="mt-12"
+              icon="ph:tray"
+              headline="Inbox is empty"
+              subtitle="Reminders, responses, and agent notifications all land here."
+            />
           ) : (
             <>
               {activeTab === "reminders" ? (
@@ -1413,6 +1563,15 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
                   paused={paused}
                   oneShots={oneShots}
                   history={history}
+                  selectedId={selectedReminderId}
+                  familiarLabel={familiarLabel}
+                  onSelect={(item) => { setSelectedItem(item); setSelectedCodex(null); }}
+                />
+              ) : activeTab === "inbox" ? (
+                <InboxFeedList
+                  needsYou={inboxFeed.needsYou}
+                  active={inboxFeed.active}
+                  resolved={inboxFeed.resolved}
                   selectedId={selectedReminderId}
                   familiarLabel={familiarLabel}
                   onSelect={(item) => { setSelectedItem(item); setSelectedCodex(null); }}

--- a/src/components/schedules-tabs.test.ts
+++ b/src/components/schedules-tabs.test.ts
@@ -40,6 +40,10 @@ assert.match(automations, /const \[activeTab, setActiveTab\] = useState<Schedule
 assert.match(automations, /<h1[\s\S]*?>\s*Schedules\s*<\/h1>/, "Surface header should read Schedules");
 assert.match(automations, /\["reminders", "Reminders", reminderItems\.length\]/, "Schedules should expose a Reminders tab");
 assert.match(automations, /\["automations", "Automations", codexAutos\.length\]/, "Schedules should expose an Automations tab");
+assert.match(automations, /\["inbox", "Inbox", items\.length\]/, "Schedules should expose an Inbox tab over the full inbox feed");
+assert.match(automations, /type ScheduleTab = "reminders" \| "automations" \| "inbox"/, "Schedules tab state should include inbox");
+assert.match(automations, /function InboxFeedList/, "Inbox tab should render through a feed-list component");
+assert.match(automations, /groupInboxFeed\(items\)/, "Inbox tab should group the full inbox feed (every kind)");
 
 assert.match(
   automations,

--- a/src/lib/inbox-feed.test.ts
+++ b/src/lib/inbox-feed.test.ts
@@ -1,0 +1,89 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { groupInboxFeed, inboxActivityTime, inboxKindLabel } from "./inbox-feed.ts";
+
+const item = (over = {}) => ({
+  id: over.id ?? Math.random().toString(36).slice(2),
+  kind: over.kind ?? "reminder",
+  title: over.title ?? "t",
+  status: over.status ?? "pending",
+  createdAt: over.createdAt ?? "2026-06-01T00:00:00Z",
+  updatedAt: over.updatedAt ?? "2026-06-01T00:00:00Z",
+  recurrence: over.recurrence ?? { type: "none" },
+  source: over.source ?? "user",
+  ...over,
+});
+
+// ── Each item lands in exactly one tier, by status then kind ────────────────
+{
+  const items = [
+    item({ id: "fired", status: "fired" }),
+    item({ id: "resp", kind: "response-needed", status: "pending" }),
+    item({ id: "pending", status: "pending" }),
+    item({ id: "snoozed", status: "snoozed" }),
+    item({ id: "done", status: "done" }),
+    item({ id: "dismissed", status: "dismissed" }),
+  ];
+  const g = groupInboxFeed(items);
+  assert.deepEqual(g.needsYou.map((i) => i.id).sort(), ["fired", "resp"], "fired + response-needed need you");
+  assert.deepEqual(g.active.map((i) => i.id).sort(), ["pending", "snoozed"], "pending/snoozed are active");
+  assert.deepEqual(g.resolved.map((i) => i.id).sort(), ["dismissed", "done"], "done/dismissed are resolved");
+  // No item is duplicated or dropped across tiers.
+  assert.equal(g.needsYou.length + g.active.length + g.resolved.length, items.length);
+}
+
+// ── Terminal status wins over kind: a resolved response-needed is resolved ──
+{
+  const g = groupInboxFeed([
+    item({ id: "a", kind: "response-needed", status: "done" }),
+    item({ id: "b", kind: "response-needed", status: "dismissed" }),
+  ]);
+  assert.equal(g.needsYou.length, 0, "resolved response items don't nag");
+  assert.deepEqual(g.resolved.map((i) => i.id).sort(), ["a", "b"]);
+}
+
+// ── Ordering is most-recent-activity first within a group ────────────────────
+{
+  const g = groupInboxFeed([
+    item({ id: "old", status: "pending", updatedAt: "2026-06-01T00:00:00Z" }),
+    item({ id: "new", status: "pending", updatedAt: "2026-06-10T00:00:00Z" }),
+    item({ id: "mid", status: "pending", updatedAt: "2026-06-05T00:00:00Z" }),
+  ]);
+  assert.deepEqual(g.active.map((i) => i.id), ["new", "mid", "old"]);
+}
+
+// ── activityTime prefers firedAt > fireAt > updatedAt > createdAt ────────────
+{
+  assert.equal(
+    inboxActivityTime(item({ firedAt: "2026-06-09T00:00:00Z", fireAt: "2026-06-01T00:00:00Z", updatedAt: "2026-06-02T00:00:00Z" })),
+    Date.parse("2026-06-09T00:00:00Z"),
+    "firedAt wins",
+  );
+  assert.equal(
+    inboxActivityTime(item({ firedAt: null, fireAt: "2026-06-03T00:00:00Z", updatedAt: "2026-06-02T00:00:00Z" })),
+    Date.parse("2026-06-03T00:00:00Z"),
+    "fireAt next",
+  );
+  assert.equal(
+    inboxActivityTime(item({ firedAt: null, fireAt: null, updatedAt: "2026-06-04T00:00:00Z" })),
+    Date.parse("2026-06-04T00:00:00Z"),
+    "updatedAt next",
+  );
+  assert.equal(inboxActivityTime(item({ firedAt: null, fireAt: null, updatedAt: "bogus", createdAt: "also-bogus" })), 0, "unparseable ⇒ 0");
+}
+
+// ── Empty input → empty groups ──────────────────────────────────────────────
+{
+  const g = groupInboxFeed([]);
+  assert.deepEqual(g, { needsYou: [], active: [], resolved: [] });
+}
+
+// ── Kind labels cover every ItemKind ────────────────────────────────────────
+{
+  assert.equal(inboxKindLabel("reminder"), "Reminder");
+  assert.equal(inboxKindLabel("daily-summary"), "Summary");
+  assert.equal(inboxKindLabel("response-needed"), "Response");
+  assert.equal(inboxKindLabel("agent"), "Agent");
+}
+
+console.log("inbox-feed.test.ts passed");

--- a/src/lib/inbox-feed.ts
+++ b/src/lib/inbox-feed.ts
@@ -1,0 +1,67 @@
+// Pure grouping/ordering for the Schedules → Inbox tab, which shows the FULL
+// inbox feed (every InboxItem kind), not just the schedule-shaped items the
+// Reminders tab covers. Framework/fs-free so it's unit-testable without a DOM
+// or the node-only cave-inbox store.
+
+import type { InboxItem, ItemKind } from "@/lib/cave-inbox";
+
+export type InboxFeedGroups = {
+  /** Demands attention now: fired items + anything awaiting a response. */
+  needsYou: InboxItem[];
+  /** Live but not (yet) demanding: pending / snoozed. */
+  active: InboxItem[];
+  /** Closed out: done or dismissed. */
+  resolved: InboxItem[];
+};
+
+/** The most recent meaningful timestamp for ordering a feed row. */
+export function inboxActivityTime(item: InboxItem): number {
+  const iso = item.firedAt ?? item.fireAt ?? item.updatedAt ?? item.createdAt;
+  const t = iso ? Date.parse(iso) : NaN;
+  return Number.isNaN(t) ? 0 : t;
+}
+
+/**
+ * Partition the inbox into three attention tiers, each sorted by most-recent
+ * activity. An item is in exactly one group:
+ *   • resolved — status done | dismissed (terminal), regardless of kind.
+ *   • needsYou — fired, OR a response-needed item (and not yet resolved).
+ *   • active   — everything else still live (pending | snoozed).
+ */
+export function groupInboxFeed(items: readonly InboxItem[]): InboxFeedGroups {
+  const needsYou: InboxItem[] = [];
+  const active: InboxItem[] = [];
+  const resolved: InboxItem[] = [];
+
+  for (const item of items) {
+    if (item.status === "done" || item.status === "dismissed") {
+      resolved.push(item);
+    } else if (item.status === "fired" || item.kind === "response-needed") {
+      needsYou.push(item);
+    } else {
+      active.push(item);
+    }
+  }
+
+  const byRecent = (a: InboxItem, b: InboxItem) => inboxActivityTime(b) - inboxActivityTime(a);
+  needsYou.sort(byRecent);
+  active.sort(byRecent);
+  resolved.sort(byRecent);
+  return { needsYou, active, resolved };
+}
+
+/** Human label for an inbox item kind (used by the feed's kind badge). */
+export function inboxKindLabel(kind: ItemKind): string {
+  switch (kind) {
+    case "reminder":
+      return "Reminder";
+    case "daily-summary":
+      return "Summary";
+    case "response-needed":
+      return "Response";
+    case "agent":
+      return "Agent";
+    default:
+      return kind;
+  }
+}


### PR DESCRIPTION
## What

Adds an **Inbox** tab to the Schedules page (`automations-view.tsx`) for viewing inbox items as a single feed.

The page already had **Reminders** (reminder + daily-summary items, grouped by schedule) and **Automations** (Codex automations). But `agent` and `response-needed` inbox items — and the inbox as one chronological feed — had no surface here. The new tab covers the full `/api/inbox` feed.

## How

- **`groupInboxFeed`** (`src/lib/inbox-feed.ts`) — pure, framework/fs-free: partitions every `InboxItem` into three attention tiers, each sorted by most-recent activity:
  - **Needs you** — `fired` items + anything `response-needed` (not yet resolved)
  - **Active** — `pending` / `snoozed`
  - **Resolved** — `done` / `dismissed`
- **AutomationsView** gains the `inbox` tab (count = all items) with `InboxFeedList` (status icon + title + kind badge + familiar + relative time), an empty state (`ph:tray`), and row click → the existing `DetailPanel` (reusing its actions). Tab order: Reminders · Inbox · Automations; default stays Reminders.

## Tests

- `inbox-feed.test.ts` — exhaustive: tier partitioning (each item in exactly one), terminal-status-wins-over-kind, recency ordering, `firedAt > fireAt > updatedAt > createdAt` activity-time precedence, empty input, kind labels.
- Extended `schedules-tabs.test.ts` to lock the new tab + feed wiring.

Both registered in `run-tests.mjs`. Full `test:app` (344 files) + `tsc --noEmit` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)