### PR TITLE
fix(board): repair the Gantt group-header row layout

### DIFF
--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1661,7 +1661,10 @@
 /* group header row */
 .cg-grouprow { display: flex; align-items: stretch; }
 .cg-grouprow .cg-left {
-  grid-template-columns: 1fr auto; gap: 6px; height: var(--cg-row-h);
+  /* caret · name (fills) · count — three children, so three columns. With only
+     two (1fr auto) the caret ate the 1fr, shoving the name over the timeline
+     and wrapping the count to a second line. */
+  grid-template-columns: auto 1fr auto; gap: 6px; height: var(--cg-row-h);
   background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-raised));
 }
 .cg-grouptl { background-color: color-mix(in oklch, var(--accent-presence) 4%, transparent); }


### PR DESCRIPTION
## Bug

In the Tasks → Gantt (timeline) view, the grouped-by-project header rows were broken: the **project name was shoved to the right, over the timeline**, and the **count badge wrapped to a second line**.

## Cause

`.cg-grouprow .cg-left` declared `grid-template-columns: 1fr auto` (two columns), but the group row has **three** children — caret `▾`, project name, and count. The caret absorbed the `1fr`, pushing the name right; the count, as the 3rd item in a 2-column grid, wrapped to a second row.

## Fix

One line: `grid-template-columns: auto 1fr auto` — caret stays content-sized, the name fills `1fr` (left-aligned in the Group/Task column), and the count sits at the right edge.

## Verification

Rendered the Gantt against mocked board data (two projects, dated cards) before/after:
- **Before:** "Coven Cave" / "Mobile App" floating over the week grid, counts on a second line
- **After:** rows read `▾ Coven Cave  4` / `▾ Mobile App  2`, correctly inside the sticky left table

CSS-only; doesn't touch what the Gantt tests pin (`.board-gantt`, `board-gantt-row__bar`, view mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)