### PR TITLE
fix(ios): repair broken ChatView build + auto-relocate to working port

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift
@@ -43,6 +43,41 @@ struct CaveConnection: Codable, Equatable {
         return comps.url
     }
 
+    /// Ordered base URLs to try when the configured one is unreachable — the fix
+    /// for a host entered without the proper port. `tailscale serve` usually
+    /// terminates TLS on `:8443`, so a `.ts.net` host typed without a port
+    /// (which resolves to plain `:443`) never connects; we probe `:8443` and
+    /// relocate to it. A fully-qualified `http(s)://…` URL is trusted verbatim
+    /// (the user was explicit), so it gets no alternates.
+    var candidateBaseURLs: [URL] {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        var out: [URL] = []
+        func add(_ string: String) {
+            guard let url = URL(string: string), !out.contains(url) else { return }
+            out.append(url)
+        }
+
+        let lower = trimmed.lowercased()
+        if lower.hasPrefix("http://") || lower.hasPrefix("https://") {
+            if let url = URL(string: trimmed) { out.append(url) }
+            return out
+        }
+
+        if let primary = baseURL { out.append(primary) }
+
+        let hostname = trimmed.split(separator: ":").first.map(String.init) ?? trimmed
+        if hostname.lowercased().hasSuffix(".ts.net") {
+            add("https://\(hostname):8443")   // Tailscale Serve's usual TLS port
+            add("https://\(hostname)")        // bare 443
+        } else {
+            for port in ["3000", "4500", "4555", "8443"] { add("http://\(hostname):\(port)") }
+            add("https://\(hostname):8443")
+        }
+        return out
+    }
+
     static let storageKey = "cave.connection.host"
 
     static func load() -> CaveConnection? {

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -371,15 +371,46 @@ final class AppModel {
     }
 
     func refreshConnection() async {
-        guard let client else { connectionState = .unconfigured; return }
+        guard let connection else { connectionState = .unconfigured; return }
         connectionState = .checking
-        let reachable = await client.ping()
-        guard reachable else {
+
+        // Try the configured endpoint first, then auto-relocate to a working
+        // port (e.g. the user typed a `.ts.net` host without `:8443`).
+        let configured = connection.baseURL
+        guard let working = await Self.discoverBaseURL(connection.candidateBaseURLs) else {
             connectionState = .unreachable("Couldn’t reach the desktop. Is it on the tailnet and running?")
             return
         }
+
+        if working != configured {
+            // Relocate: persist the working URL so future launches connect directly.
+            let relocated = CaveConnection(host: working.absoluteString)
+            self.connection = relocated
+            relocated.save()
+            if let port = working.port {
+                showToast("Connected on port \(port)", systemImage: "antenna.radiowaves.left.and.right")
+            }
+        }
         connectionState = .connected
         await loadFamiliars()
+    }
+
+    /// Probe candidate base URLs in order; return the first that answers. Uses a
+    /// short per-candidate timeout so trying a few ports stays snappy.
+    static func discoverBaseURL(_ candidates: [URL]) async -> URL? {
+        for base in candidates where await probe(base) { return base }
+        return nil
+    }
+
+    /// Lightweight reachability check against `<base>/api/familiars`.
+    private static func probe(_ base: URL) async -> Bool {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 6
+        config.waitsForConnectivity = false
+        var req = URLRequest(url: base.appendingPathComponent("api/familiars"))
+        req.timeoutInterval = 6
+        guard let (_, resp) = try? await URLSession(configuration: config).data(for: req) else { return false }
+        return (resp as? HTTPURLResponse).map { (200..<500).contains($0.statusCode) } ?? false
     }
 
     func loadFamiliars() async {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -20,6 +20,10 @@ struct ChatView: View {
     @State private var showCommands = false
     @State private var showFamiliarPicker = false
     @State private var showTasks = false
+    @State private var atBottom = true
+    @State private var dictation = SpeechDictation()
+    @State private var photoItem: PhotosPickerItem?
+    @State private var pendingImage: PendingImage?
 
     // The slash autocomplete is driven purely off the in-progress draft: a
     // leading "/" on the first word (no whitespace committed yet).


### PR DESCRIPTION
Two iOS changes (the first is an urgent build fix).

## 1. Fix broken iOS build (regression)
`main`'s iOS app currently **doesn't compile**: #1482 ("link tasks and chats", a duplicate of the already-merged #1457) was based on a pre-#1464 `ChatView` and, on merge, **dropped four `@State` declarations** — `atBottom`, `dictation`, `photoItem`, `pendingImage` (the #1464 composer mic + image-attach state) — while keeping all their usages. Because iOS Swift isn't compiled by CI, it landed red. This restores the four declarations. (`SpeechDictation`, `PhotosUI`, `PendingImage`, and the `atBottom` usages all still exist, so this fully fixes it.)

## 2. Auto-relocate to a working port
A Tailscale host typed without the Serve port (`mb-black.…ts.net` instead of `…:8443`) resolves to plain `:443` and never connects. `refreshConnection` now probes an ordered list of candidate base URLs (`CaveConnection.candidateBaseURLs` — `:8443` then `:443` for `.ts.net`; common dev ports for bare hosts/IPs) with a short timeout, and on the first that answers it **relocates** — persisting the working URL so future launches connect directly — instead of dropping to "unreachable". A fully-qualified `http(s)://` host is trusted verbatim (no probing). Shows a brief "Connected on port N" toast when it auto-corrects.

## Verification
- `xcodebuild … -destination 'generic/platform=iOS Simulator'` → **BUILD SUCCEEDED** (was BUILD FAILED on main before commit 1; iOS isn't in CI, so verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)