### PR TITLE
fix(test): unbreak main — familiar-avatar gate regex tolerates Boolean() wrap

### DIFF
--- a/src/components/familiar-avatar.test.ts
+++ b/src/components/familiar-avatar.test.ts
@@ -17,7 +17,7 @@ assert.match(source, /alt=/, "img must have alt text for a11y");
 // on this). The <img> must carry an onError that flips to the fallback, and
 // the render must be gated on that error state.
 assert.match(source, /onError=\{\(\) => setErrored\(true\)\}/, "img must fall back on load error");
-assert.match(source, /familiar\.avatarImage && !errored/, "render must gate the img on the not-errored state");
+assert.match(source, /familiar\.avatarImage\)? && !errored/, "render must gate the img on the not-errored state");
 assert.match(source, /useEffect\(\s*\(\) => \{\s*setErrored\(false\);\s*\}, \[familiar\.avatarImage\]\)/, "error state must reset when the avatar src changes");
 
 console.log("familiar-avatar.test.ts: ok");


### PR DESCRIPTION
Main is red: `familiar-avatar.test.ts` requires the literal `familiar.avatarImage && !errored`, but the expandable-avatar commit (7577126d) wrote `Boolean(familiar.avatarImage) && !errored`, failing `test:app` for every PR. The render is still gated on the not-errored state; this relaxes the regex to accept the optional `)`. No component change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)