### PR TITLE
feat(sidepanel): live nav badges, per-familiar rail tab, persistent video split

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -102,6 +102,7 @@ export const SUITES = {
     "src/components/surface-loading-states.test.ts",
     "src/components/chat-header-row.test.ts",
     "src/components/sidebar-minimal.test.ts",
+    "src/components/sidepanel-badges.test.ts",
     "src/components/recent-activity-rollup.test.ts",
     "src/components/sidebar-familiar-filter.test.ts",
     "src/components/shell-edge-rails.test.ts",

--- a/src/components/companion-rail.tsx
+++ b/src/components/companion-rail.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { forwardRef, useEffect, useState, type ReactNode } from "react";
-import { Group, Panel, Separator } from "react-resizable-panels";
+import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
 import { Icon } from "@/lib/icon";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
 import { YoutubeViewer } from "@/components/youtube-viewer";
@@ -39,6 +39,18 @@ type Props = {
   onExpandRail?: () => void;
 };
 
+// SSR-safe localStorage shim for the split-layout persistence below.
+const railSplitStorage = {
+  getItem(key: string): string | null {
+    if (typeof window === "undefined") return null;
+    try { return window.localStorage.getItem(key); } catch { return null; }
+  },
+  setItem(key: string, value: string): void {
+    if (typeof window === "undefined") return;
+    try { window.localStorage.setItem(key, value); } catch { /* ignore */ }
+  },
+};
+
 // forwardRef handle is wired in Task 2.3; ref is forwarded to the chatSlot consumer.
 const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
   function CompanionRailInner(props, _ref) {
@@ -60,6 +72,12 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
       onExpandRail,
     } = props;
     const [tab, setTab] = useState<CompanionTab>(defaultTab);
+    // Persist the chat-vs-video split ratio so the divider survives reloads.
+    const { defaultLayout: splitLayout, onLayoutChanged: onSplitLayout } = useDefaultLayout({
+      id: "cave:companion-rail-split",
+      panelIds: ["companion-rail-main", "companion-rail-youtube"],
+      storage: railSplitStorage,
+    });
     // The Video tab is a toggle, not a mutually-exclusive section: when on, the
     // YouTube viewer drops into a resizable bottom pane below the active tab's
     // content rather than replacing it. The on/off state can be lifted to the
@@ -222,7 +240,7 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
         </nav>
         <div className="companion-rail__body">
           {youtubeOpen ? (
-            <Group orientation="vertical" className="companion-rail__split">
+            <Group orientation="vertical" className="companion-rail__split" defaultLayout={splitLayout} onLayoutChanged={onSplitLayout}>
               <Panel
                 id="companion-rail-main"
                 minSize={20}

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -61,7 +61,17 @@ export type SidebarMinimalProps = {
   onOpenInbox?: () => void;
   onOpenInboxItem?: (item: InboxItem) => void;
   onNotificationPrefsChanged?: () => void;
+  /** Live counts surfaced as small nav badges (omitted/0 -> no badge). */
+  boardOpenCount?: number;
+  scheduleNeedsCount?: number;
+  githubAssignedCount?: number;
 };
+
+// Format a count as a compact nav badge; 0/undefined yields no badge.
+function badgeText(n?: number): string | undefined {
+  if (!n || n <= 0) return undefined;
+  return n > 99 ? "99+" : String(n);
+}
 
 const FOLDER_MODES: Array<{
   id: FolderMode;
@@ -77,10 +87,10 @@ const FOLDER_MODES: Array<{
   // Work
   { id: "home", label: "Home", iconName: "ph:house-bold", group: "work", kbd: "⌘1", description: "Overview and quick actions" },
   { id: "chat", label: "Familiars", iconName: "ph:chats", group: "work", kbd: "⌘2", description: "Talk with your familiars" },
-  { id: "board", label: "Board", iconName: "ph:kanban", group: "work", kbd: "⌘3", description: "Track tasks across projects" },
+  { id: "board", label: "Board", iconName: "ph:kanban", group: "work", kbd: "⌘3", description: "Track tasks across projects", badge: (p) => badgeText(p.boardOpenCount) },
   { id: "journal", label: "Journal", iconName: "ph:book-open", group: "work", description: "Your daily journal and generated sketches" },
   { id: "calendar", label: "Calendar", iconName: "ph:calendar-blank", group: "work", kbd: "⌘4", description: "Schedule and timeline of work" },
-  { id: "inbox", label: "Schedules", iconName: "ph:calendar-bold", group: "work", kbd: "⌘5", description: "Reminders and recurring agent automations" },
+  { id: "inbox", label: "Schedules", iconName: "ph:calendar-bold", group: "work", kbd: "⌘5", description: "Reminders and recurring agent automations", badge: (p) => badgeText(p.scheduleNeedsCount) },
   // Tools
   { id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘6", description: "Built-in web browser" },
   { id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools", kbd: "⌘7", description: "Shell session in your project" },
@@ -89,7 +99,7 @@ const FOLDER_MODES: Array<{
   { id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools", description: "Agent personas, workflows, skills, and the capabilities your familiars can use" },
   { id: "workflows", label: "Workflows", iconName: "ph:git-branch-bold", group: "tools", description: "Multi-step pipelines that orchestrate familiars" },
   // Add-ons (gated)
-  { id: "github", label: "GitHub", iconName: "ph:github-logo", group: "addons", description: "Issues and PRs assigned to you" },
+  { id: "github", label: "GitHub", iconName: "ph:github-logo", group: "addons", description: "Issues and PRs assigned to you", badge: (p) => badgeText(p.githubAssignedCount) },
 ];
 
 export { FOLDER_MODES };

--- a/src/components/sidepanel-badges.test.ts
+++ b/src/components/sidepanel-badges.test.ts
@@ -1,0 +1,34 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+const rail = readFileSync(new URL("./companion-rail.tsx", import.meta.url), "utf8");
+
+// ── Nav badges ───────────────────────────────────────────────────────────────
+assert.match(sidebar, /function badgeText\(n\?: number\)/, "badge formatter exists");
+assert.match(sidebar, /boardOpenCount\?: number/, "sidebar accepts a board count");
+assert.match(sidebar, /scheduleNeedsCount\?: number/, "sidebar accepts a schedules count");
+assert.match(sidebar, /githubAssignedCount\?: number/, "sidebar accepts a github count");
+assert.match(sidebar, /badge: \(p\) => badgeText\(p\.boardOpenCount\)/, "Board nav badge wired");
+assert.match(sidebar, /badge: \(p\) => badgeText\(p\.scheduleNeedsCount\)/, "Schedules nav badge wired");
+assert.match(sidebar, /badge: \(p\) => badgeText\(p\.githubAssignedCount\)/, "GitHub nav badge wired");
+
+assert.match(workspace, /boardOpenCount=\{boardTaskCount\}/, "board count passed to sidebar");
+assert.match(workspace, /scheduleNeedsCount=\{scheduleNeedsCount\}/, "schedules count passed");
+assert.match(workspace, /githubAssignedCount=\{githubAssignedCount\}/, "github count passed");
+assert.match(workspace, /groupInboxFeed\(inboxItemsWithEphemeral\)\.needsYou\.length/, "schedules badge = needs-you group");
+
+// ── Per-familiar rail tab ──────────────────────────────────────────────────────
+assert.match(workspace, /const persistRailTab = useCallback/, "explicit tab choices persist per familiar");
+assert.match(workspace, /"cave:rail\.tab:" \+ \(activeIdRef\.current \?\? "all"\)/, "tab stored under the active familiar");
+assert.match(workspace, /"cave:rail\.tab:" \+ \(activeId \?\? "all"\)/, "tab restored for the active familiar");
+assert.match(workspace, /onTabChange=\{persistRailTab\}/, "rail tab clicks persist");
+
+// ── Video split persistence ────────────────────────────────────────────────────
+assert.match(rail, /useDefaultLayout/, "rail split uses the layout-persistence hook");
+assert.match(rail, /cave:companion-rail-split/, "split layout has a stable storage id");
+assert.match(rail, /defaultLayout=\{splitLayout\} onLayoutChanged=\{onSplitLayout\}/, "split layout wired to the Group");
+
+console.log("sidepanel-badges.test.ts: ok");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { SidebarMinimal } from "@/components/sidebar-minimal";
+import { groupInboxFeed } from "@/lib/inbox-feed";
 import type { ChatRouterHandle } from "@/components/chat-router";
 import type { WorkspaceMode as WorkspaceModeFromDaemon } from "@/lib/workspace-mode";
 import { CommandPalette, type PaletteIntent } from "@/components/command-palette";
@@ -198,6 +199,7 @@ export function Workspace() {
   const [onboardingOpen, setOnboardingOpen] = useState(false);
   const [inboxItems, setInboxItems] = useState<InboxItem[]>([]);
   const [escalationsUnresolved, setEscalationsUnresolved] = useState(0);
+  const [githubAssignedCount, setGithubAssignedCount] = useState(0);
   // Open (not-done) board cards, kept with their familiar so the Tasks badge can
   // show a per-familiar count when a familiar is scoped, and the grand total
   // only when "All familiars" is selected.
@@ -235,6 +237,8 @@ export function Workspace() {
   sessionsLoadedRef.current = sessionsLoaded;
   const modeRef = useRef(mode);
   modeRef.current = mode;
+  const activeIdRef = useRef(activeId);
+  activeIdRef.current = activeId;
 
   const refreshDaemonStatus = useCallback(async () => {
     try {
@@ -317,9 +321,31 @@ export function Workspace() {
     });
   }, [activeId]);
 
+  // Per-familiar rail tab. persistRailTab handles explicit tab choices: it
+  // writes the active familiar slot (plus a global fallback for first paint).
+  // Restoring a familiar tab on scope change uses plain setRailTab so it never
+  // rewrites. Keyed on activeId ("all" when no familiar scope).
+  const persistRailTab = useCallback((next: CompanionTab) => {
+    setRailTab(next);
+    try {
+      window.localStorage.setItem("cave:rail.tab:" + (activeIdRef.current ?? "all"), next);
+      window.localStorage.setItem("cave:rail.tab", next);
+    } catch {
+      /* ignore storage failures */
+    }
+  }, []);
+
   useEffect(() => {
-    if (typeof window !== "undefined") window.localStorage.setItem("cave:rail.tab", railTab);
-  }, [railTab]);
+    if (!activeFamiliarHydrated || typeof window === "undefined") return;
+    try {
+      const stored =
+        window.localStorage.getItem("cave:rail.tab:" + (activeId ?? "all")) ??
+        window.localStorage.getItem("cave:rail.tab");
+      if (stored) setRailTab(stored === "inspector" ? "memory" : (stored as CompanionTab));
+    } catch {
+      /* ignore storage failures */
+    }
+  }, [activeId, activeFamiliarHydrated]);
 
   useEffect(() => {
     const openSalem = () => {
@@ -482,6 +508,7 @@ export function Workspace() {
 
         const githubTasksJson = await githubTasksPromise;
         if (githubTasksJson) {
+          setGithubAssignedCount(Array.isArray(githubTasksJson.tasks) ? githubTasksJson.tasks.length : 0);
           setSessions((currentSessions) =>
             attachGitHubTaskContext(
               currentSessions.length > 0 ? currentSessions : baseSessions,
@@ -1481,6 +1508,13 @@ export function Workspace() {
     return [...inboxItems, ...ephemeral];
   }, [inboxItems, responseNeeded, familiars, sessions]);
 
+  // Schedules nav badge: how many inbox items currently need you (fired or
+  // response-needed) - mirrors the Schedules > Inbox tab "needs you" group.
+  const scheduleNeedsCount = useMemo(
+    () => groupInboxFeed(inboxItemsWithEphemeral).needsYou.length,
+    [inboxItemsWithEphemeral],
+  );
+
   // Mood C three-pane Shell:
   //   nav   = always present (mode switcher + command launchers)
   //   list  = unused by Familiars; Inbox/Board/Plugins
@@ -1498,7 +1532,7 @@ export function Workspace() {
     railTab === "browser" || railTab === "salem" || (mode !== "browser" && mode !== "agents");
 
   const openCompanionTab = useCallback((tab: CompanionTab) => {
-    setRailTab(tab);
+    persistRailTab(tab);
     if (familiarPanelOpen && railTab === tab) {
       shellRef.current?.closeFamiliar();
       return;
@@ -1559,6 +1593,9 @@ export function Workspace() {
         }
       }}
       onNotificationPrefsChanged={refreshPrefs}
+      boardOpenCount={boardTaskCount}
+      scheduleNeedsCount={scheduleNeedsCount}
+      githubAssignedCount={githubAssignedCount}
     />
   );
 
@@ -1890,7 +1927,7 @@ export function Workspace() {
               familiar={active}
               defaultTab={railTab}
               activeTab={railTab}
-              onTabChange={setRailTab}
+              onTabChange={persistRailTab}
               daemonRunning={daemonRunning}
               onCreateFamiliar={openOnboarding}
               youtubeActive={railVideoActive}


### PR DESCRIPTION
Three side-panel polish wins (plus a drive-by main-red fix — see note).

## 1. Live nav badges
**Board** (open tasks), **Schedules** (items needing you), and **GitHub** (assigned) now show a small accent count in the left nav, turning it into an at-a-glance status read. The badge infra already existed on `FOLDER_MODES` (a `badge?(props)` hook + `.sidebar-badge`) but was unused — this wires the live counts through from the workspace: `boardTaskCount`, the inbox feed's **needs-you** group (`groupInboxFeed(...).needsYou.length`, same grouping as the Schedules → Inbox tab), and the GitHub tasks length. Counts cap at `99+`; zero/undefined renders no badge.

## 2. Per-familiar rail tab
The companion-rail tab (Chat/Memory/Browser/Salem) was stored globally (`cave:rail.tab`), so switching familiars bumped you off the tab you were on. It's now remembered **per familiar** (`cave:rail.tab:<id>`, `"all"` when unscoped). Explicit choices persist via `persistRailTab` (writes the familiar slot + a global fallback for first paint); restoring on scope change uses plain `setRailTab` so it never overwrites. Contextual forces (Salem/browser launch bridges) stay non-sticky.

## 3. Persistent video split
The chat-vs-video divider in the rail reset every reload (in-session only). It now survives via `useDefaultLayout` (id `cave:companion-rail-split`), the same persistence the main shell already uses.

## ⚠️ Note: also unblocks a pre-existing main-red
Commit 1 (`fix(test)`) is unrelated to the feature: main was **red** (commit `7577126d`, the expandable-avatar PR) because that change refactored the render gate to `Boolean(familiar.avatarImage) && !errored` but left `familiar-avatar.test.ts` asserting the old literal regex — a CI-gating test, so it was blocking every PR in the queue. The gating intent is unchanged (still gated via `hasImage`); the commit just updates the stale assertion. Happy to split this out if preferred.

## Verification
`pnpm typecheck` clean; `pnpm test:app` **346/346** (new `sidepanel-badges.test.ts` pins the badge wiring, per-familiar key, and split persistence). Live UI of the rail surfaces is hard to drive in demo mode (needs a daemon + enhance-familiar binding), so the rail-tab/split pieces are verified at the source/test layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)