### PR TITLE
feat(workflows): describe-with-familiar workflow creation

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -40,6 +40,7 @@ export const SUITES = {
     "src/lib/chat-project-overrides.test.ts",
     "src/components/chat-project-sidebar-dnd.test.ts",
     "src/lib/workflows.test.ts",
+    "src/lib/workflow-generate.test.ts",
     "src/lib/git-changes.test.ts",
     "src/lib/env-file.test.ts",
     "src/lib/workflow-graph.test.ts",
@@ -497,6 +498,7 @@ const ALIAS_LOADER = new Set([
   "src/lib/server/session-project-roots.test.ts",
   "src/app/api/library/doc/route.test.ts",
   "src/lib/server/familiar-avatar.test.ts",
+  "src/lib/workflow-generate.test.ts",
 ]);
 
 /** Build the `node` argv (flags + file) for a single test path. */

--- a/src/components/workflows-view.tsx
+++ b/src/components/workflows-view.tsx
@@ -585,6 +585,37 @@ export function WorkflowsView({
     showNotice(`Imported ${id}.`);
   };
 
+  const handleCreateFromManifest = async (manifest: Record<string, unknown>) => {
+    if (!confirmDiscard()) return;
+    // Same landing rules as import: personal library, unique id, cave-visible.
+    const rawName = typeof manifest.name === "string" && manifest.name.trim() ? manifest.name : "";
+    const rawId = typeof manifest.id === "string" && manifest.id.trim() ? manifest.id : rawName || "workflow";
+    const id = uniqueId(slugifyWorkflowId(rawId) || "workflow");
+    const version = typeof manifest.version === "string" && manifest.version.trim() ? manifest.version : "0.1.0";
+    const visibility = {
+      ...(manifest.visibility && typeof manifest.visibility === "object"
+        ? (manifest.visibility as Record<string, unknown>)
+        : {}),
+      personal: true,
+      coven_cave: true,
+    };
+    const result = await saveWorkflow({ ...manifest, id, version, visibility });
+    if (!result.ok) {
+      showNotice(result.error ?? "couldn't save the generated workflow — try regenerating");
+      return;
+    }
+    await load(true);
+    const saved = result.workflow;
+    if (saved) {
+      if (result.validation) setAction({ id: saved.id, kind: "validate", result: result.validation });
+      setSelectedWorkflowId(saved.id);
+      setSelectedNodeId(null);
+      setDraftState(initialWorkflowDraft(saved));
+      void loadRuns(saved.id);
+    }
+    showNotice(`Created ${id} with the familiar's help.`);
+  };
+
   const handleDuplicate = async (workflow: WorkflowSummary) => {
     const id = uniqueId(`${slugifyWorkflowId(workflow.id)}-copy`);
     const copy = duplicateWorkflow(workflow, id);
@@ -741,6 +772,7 @@ export function WorkflowsView({
       onDisconnect={(source, target) => dispatchDraft({ type: "disconnect", source, target })}
       onCreate={(input) => void handleCreate(input)}
       onImport={(manifest) => void handleImport(manifest)}
+      onCreateManifest={(manifest) => void handleCreateFromManifest(manifest)}
       onDuplicate={(workflow) => void handleDuplicate(workflow)}
       onDelete={(workflow) => void handleDelete(workflow)}
       onAttachRole={(role, attach) => void handleAttachRole(role, attach)}

--- a/src/components/workflows-view.tsx
+++ b/src/components/workflows-view.tsx
@@ -596,6 +596,7 @@ export function WorkflowsView({
       ...(manifest.visibility && typeof manifest.visibility === "object"
         ? (manifest.visibility as Record<string, unknown>)
         : {}),
+      public: false,
       personal: true,
       coven_cave: true,
     };

--- a/src/components/workflows/workflow-create-dialog.tsx
+++ b/src/components/workflows/workflow-create-dialog.tsx
@@ -5,6 +5,13 @@ import { parse as parseYaml } from "yaml";
 import { Icon } from "@/lib/icon";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { slugifyWorkflowId } from "@/lib/workflow-edit";
+import {
+  generateWorkflowManifest,
+  generateWorkflowQuestions,
+  type GeneratedAnswer,
+  type GeneratedQuestion,
+} from "@/lib/workflow-generate";
+import type { WorkflowFamiliarOption } from "@/components/workflows/workflow-attachments";
 import type {
   WorkflowPattern,
   WorkflowScheduleRecurrence,
@@ -24,20 +31,108 @@ const PATTERNS: Array<{ id: WorkflowPattern; hint: string }> = [
 ];
 
 type WorkflowCreateDialogProps = {
+  familiarOptions: WorkflowFamiliarOption[];
   onClose: () => void;
   onCreate: (input: { name: string; pattern: WorkflowPattern; familiar?: string }) => void;
+  onCreateManifest: (manifest: Record<string, unknown>) => void;
 };
 
-/** New-workflow dialog: name + CWF-01 pattern template + optional familiar. */
-export function WorkflowCreateDialog({ onClose, onCreate }: WorkflowCreateDialogProps) {
-  const [name, setName] = useState("");
-  const [pattern, setPattern] = useState<WorkflowPattern>("sequential");
-  const [familiar, setFamiliar] = useState("");
-  const id = slugifyWorkflowId(name);
+type CreateMode = "describe" | "pattern";
+type DescribeStep = "describe" | "questions" | "review";
+
+/** Lightweight read of a parsed manifest object for the review summary. */
+function reviewSummary(manifest: Record<string, unknown>): {
+  pattern: string;
+  familiar: string | null;
+  steps: Array<{ id: string; kind: string; name?: string }>;
+} {
+  const rawSteps = Array.isArray(manifest.steps) ? manifest.steps : [];
+  const steps = rawSteps.map((step) => {
+    const s = (step && typeof step === "object" ? step : {}) as Record<string, unknown>;
+    return {
+      id: typeof s.id === "string" ? s.id : "?",
+      kind: typeof s.kind === "string" ? s.kind : "?",
+      name: typeof s.name === "string" ? s.name : undefined,
+    };
+  });
+  return {
+    pattern: typeof manifest.pattern === "string" ? manifest.pattern : "custom",
+    familiar: typeof manifest.familiar === "string" ? manifest.familiar : null,
+    steps,
+  };
+}
+
+/**
+ * New-workflow dialog. Two modes:
+ *  - "describe" (default): the picked familiar asks 2-3 clarifying questions, then
+ *    generates a full manifest the user reviews before creating.
+ *  - "pattern": the original name + CWF-01 template + optional familiar form.
+ */
+export function WorkflowCreateDialog({ familiarOptions, onClose, onCreate, onCreateManifest }: WorkflowCreateDialogProps) {
+  const [mode, setMode] = useState<CreateMode>("describe");
   const dialogRef = useRef<HTMLDivElement>(null);
-  // Trap Tab/Shift+Tab inside the modal and close on Escape. focusFirst is off
-  // so the Name input's autoFocus keeps the initial focus.
   useFocusTrap(true, dialogRef, { onEscape: onClose, focusFirst: false });
+
+  // Shared name field (used by both modes).
+  const [name, setName] = useState("");
+  const id = slugifyWorkflowId(name);
+
+  // Pattern-mode state.
+  const [pattern, setPattern] = useState<WorkflowPattern>("sequential");
+  const [patternFamiliar, setPatternFamiliar] = useState("");
+
+  // Describe-mode state.
+  const [step, setStep] = useState<DescribeStep>("describe");
+  const [goal, setGoal] = useState("");
+  const [familiarId, setFamiliarId] = useState("");
+  const [questions, setQuestions] = useState<GeneratedQuestion[]>([]);
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [manifest, setManifest] = useState<Record<string, unknown> | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [genError, setGenError] = useState<string | null>(null);
+
+  const familiarName = useMemo(
+    () => familiarOptions.find((option) => option.id === familiarId)?.label ?? familiarId,
+    [familiarId, familiarOptions],
+  );
+
+  const runQuestions = async () => {
+    setBusy(true);
+    setGenError(null);
+    const result = await generateWorkflowQuestions({ goal, familiarId });
+    setBusy(false);
+    if (!result.questions) {
+      setGenError(result.error ?? "couldn't get questions — try again");
+      return;
+    }
+    setQuestions(result.questions);
+    setStep("questions");
+  };
+
+  const runManifest = async () => {
+    setBusy(true);
+    setGenError(null);
+    const payload: GeneratedAnswer[] = questions.map((question) => ({
+      id: question.id,
+      question: question.question,
+      answer: answers[question.id]?.trim() ?? "",
+    }));
+    const result = await generateWorkflowManifest({
+      goal,
+      answers: payload,
+      familiarId,
+      suggestedName: name.trim() || undefined,
+    });
+    setBusy(false);
+    if (!result.manifest) {
+      setGenError(result.error ?? "couldn't build the workflow — regenerate");
+      return;
+    }
+    setManifest(result.manifest);
+    setStep("review");
+  };
+
+  const describeDisabled = busy || familiarId.trim().length === 0 || goal.trim().length === 0;
 
   return (
     <div className="workflow-dialog-backdrop" role="presentation" onClick={onClose}>
@@ -53,61 +148,202 @@ export function WorkflowCreateDialog({ onClose, onCreate }: WorkflowCreateDialog
         <div className="workflow-panel-heading">
           <div>
             <p className="workflow-eyebrow">New workflow</p>
-            <h2>Create from pattern</h2>
+            <h2>{mode === "describe" ? "Describe it — your familiar builds it" : "Create from pattern"}</h2>
           </div>
           <button type="button" className="workflow-icon-button" onClick={onClose} aria-label="Close">
             <Icon name="ph:x" width={14} />
           </button>
         </div>
-        <label className="workflow-field">
-          <span>Name</span>
-          <input
-            type="text"
-            value={name}
-            autoFocus
-            placeholder="Nightly release review"
-            onChange={(event) => setName(event.target.value)}
-          />
-        </label>
-        <p className="workflow-muted">Saved as workflows/{id}.yaml</p>
-        <div className="workflow-pattern-grid" role="radiogroup" aria-label="Pattern">
-          {PATTERNS.map((entry) => (
-            <button
-              key={entry.id}
-              type="button"
-              role="radio"
-              aria-checked={pattern === entry.id}
-              className={`workflow-pattern-option${pattern === entry.id ? " is-active" : ""}`}
-              onClick={() => setPattern(entry.id)}
-            >
-              <span className="workflow-pattern-name">{entry.id}</span>
-              <span className="workflow-pattern-hint">{entry.hint}</span>
-            </button>
-          ))}
-        </div>
-        <label className="workflow-field">
-          <span>Familiar (optional)</span>
-          <input
-            type="text"
-            value={familiar}
-            placeholder="nova"
-            onChange={(event) => setFamiliar(event.target.value)}
-          />
-        </label>
-        <div className="workflow-dialog-actions">
-          <button type="button" onClick={onClose}>
-            Cancel
+
+        <div className="workflow-create-mode-toggle" role="tablist" aria-label="Create mode">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === "describe"}
+            className={`workflow-create-mode${mode === "describe" ? " is-active" : ""}`}
+            onClick={() => setMode("describe")}
+          >
+            <Icon name="ph:sparkle" width={13} /> Describe
           </button>
           <button
             type="button"
-            className="workflow-primary-button"
-            disabled={name.trim().length === 0}
-            onClick={() => onCreate({ name, pattern, familiar: familiar || undefined })}
+            role="tab"
+            aria-selected={mode === "pattern"}
+            className={`workflow-create-mode${mode === "pattern" ? " is-active" : ""}`}
+            onClick={() => setMode("pattern")}
           >
-            <Icon name="ph:plus-bold" width={13} />
-            Create workflow
+            Pattern
           </button>
         </div>
+
+        {mode === "pattern" ? (
+          <>
+            <label className="workflow-field">
+              <span>Name</span>
+              <input
+                type="text"
+                value={name}
+                autoFocus
+                placeholder="Nightly release review"
+                onChange={(event) => setName(event.target.value)}
+              />
+            </label>
+            <p className="workflow-muted">Saved as workflows/{id}.yaml</p>
+            <div className="workflow-pattern-grid" role="radiogroup" aria-label="Pattern">
+              {PATTERNS.map((entry) => (
+                <button
+                  key={entry.id}
+                  type="button"
+                  role="radio"
+                  aria-checked={pattern === entry.id}
+                  className={`workflow-pattern-option${pattern === entry.id ? " is-active" : ""}`}
+                  onClick={() => setPattern(entry.id)}
+                >
+                  <span className="workflow-pattern-name">{entry.id}</span>
+                  <span className="workflow-pattern-hint">{entry.hint}</span>
+                </button>
+              ))}
+            </div>
+            <label className="workflow-field">
+              <span>Familiar (optional)</span>
+              <input
+                type="text"
+                value={patternFamiliar}
+                placeholder="nova"
+                onChange={(event) => setPatternFamiliar(event.target.value)}
+              />
+            </label>
+            <div className="workflow-dialog-actions">
+              <button type="button" onClick={onClose}>
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="workflow-primary-button"
+                disabled={name.trim().length === 0}
+                onClick={() => onCreate({ name, pattern, familiar: patternFamiliar || undefined })}
+              >
+                <Icon name="ph:plus-bold" width={13} />
+                Create workflow
+              </button>
+            </div>
+          </>
+        ) : step === "describe" ? (
+          <>
+            <label className="workflow-field">
+              <span>Name</span>
+              <input
+                type="text"
+                value={name}
+                autoFocus
+                placeholder="Triage inbound bugs"
+                onChange={(event) => setName(event.target.value)}
+              />
+            </label>
+            <label className="workflow-field">
+              <span>Familiar</span>
+              <select value={familiarId} onChange={(event) => setFamiliarId(event.target.value)}>
+                <option value="">Choose a familiar…</option>
+                {familiarOptions.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="workflow-field">
+              <span>What should this workflow do?</span>
+              <textarea
+                className="workflow-run-input-field"
+                rows={4}
+                placeholder="Describe the goal in your own words…"
+                value={goal}
+                onChange={(event) => setGoal(event.target.value)}
+              />
+            </label>
+            {genError && <p className="workflow-import-error">{genError}</p>}
+            <div className="workflow-dialog-actions">
+              <button type="button" onClick={onClose}>
+                Cancel
+              </button>
+              <button type="button" className="workflow-primary-button" disabled={describeDisabled} onClick={() => void runQuestions()}>
+                {busy ? <Icon name="ph:circle-notch-bold" width={13} className="workflow-spin" /> : <Icon name="ph:sparkle" width={13} />}
+                {busy ? "Thinking…" : "Continue"}
+              </button>
+            </div>
+          </>
+        ) : step === "questions" ? (
+          <>
+            <p className="workflow-muted">{familiarName} wants to know a few things:</p>
+            <div className="workflow-run-inputs-list">
+              {questions.map((question, index) => (
+                <label className="workflow-field" key={question.id}>
+                  <span>{question.question}</span>
+                  {question.hint && <span className="workflow-run-input-hint">{question.hint}</span>}
+                  <textarea
+                    className="workflow-run-input-field"
+                    rows={2}
+                    autoFocus={index === 0}
+                    placeholder="Your answer…"
+                    value={answers[question.id] ?? ""}
+                    onChange={(event) => setAnswers((current) => ({ ...current, [question.id]: event.target.value }))}
+                  />
+                </label>
+              ))}
+            </div>
+            {genError && <p className="workflow-import-error">{genError}</p>}
+            <div className="workflow-dialog-actions">
+              <button type="button" onClick={() => setStep("describe")}>
+                Back
+              </button>
+              <button type="button" className="workflow-primary-button" disabled={busy} onClick={() => void runManifest()}>
+                {busy ? <Icon name="ph:circle-notch-bold" width={13} className="workflow-spin" /> : <Icon name="ph:sparkle" width={13} />}
+                {busy ? "Building…" : "Generate workflow"}
+              </button>
+            </div>
+          </>
+        ) : (
+          (() => {
+            const summary = manifest ? reviewSummary(manifest) : null;
+            return (
+              <>
+                <p className="workflow-muted">
+                  {summary
+                    ? `Proposed: pattern ${summary.pattern} · ${summary.steps.length} steps${summary.familiar ? ` · familiar ${summary.familiar}` : ""}`
+                    : "No workflow generated."}
+                </p>
+                {summary && (
+                  <ol className="workflow-review-steps">
+                    {summary.steps.map((s) => (
+                      <li key={s.id} className="workflow-review-step">
+                        <span className={`workflow-review-kind workflow-review-kind--${s.kind}`}>{s.kind}</span>
+                        <span className="workflow-review-name">{s.name ?? s.id}</span>
+                      </li>
+                    ))}
+                  </ol>
+                )}
+                {genError && <p className="workflow-import-error">{genError}</p>}
+                <div className="workflow-dialog-actions">
+                  <button type="button" onClick={() => setStep("questions")}>
+                    Back
+                  </button>
+                  <button type="button" disabled={busy} onClick={() => void runManifest()}>
+                    {busy ? "Regenerating…" : "Regenerate"}
+                  </button>
+                  <button
+                    type="button"
+                    className="workflow-primary-button"
+                    disabled={!manifest}
+                    onClick={() => manifest && onCreateManifest(manifest)}
+                  >
+                    <Icon name="ph:plus-bold" width={13} />
+                    Create & open
+                  </button>
+                </div>
+              </>
+            );
+          })()
+        )}
       </div>
     </div>
   );

--- a/src/components/workflows/workflow-create-dialog.tsx
+++ b/src/components/workflows/workflow-create-dialog.tsx
@@ -293,7 +293,7 @@ export function WorkflowCreateDialog({ familiarOptions, onClose, onCreate, onCre
             </div>
             {genError && <p className="workflow-import-error">{genError}</p>}
             <div className="workflow-dialog-actions">
-              <button type="button" onClick={() => setStep("describe")}>
+              <button type="button" onClick={() => { setGenError(null); setStep("describe"); }}>
                 Back
               </button>
               <button type="button" className="workflow-primary-button" disabled={busy} onClick={() => void runManifest()}>
@@ -324,7 +324,7 @@ export function WorkflowCreateDialog({ familiarOptions, onClose, onCreate, onCre
                 )}
                 {genError && <p className="workflow-import-error">{genError}</p>}
                 <div className="workflow-dialog-actions">
-                  <button type="button" onClick={() => setStep("questions")}>
+                  <button type="button" onClick={() => { setGenError(null); setStep("questions"); }}>
                     Back
                   </button>
                   <button type="button" disabled={busy} onClick={() => void runManifest()}>

--- a/src/components/workflows/workflow-studio.tsx
+++ b/src/components/workflows/workflow-studio.tsx
@@ -116,6 +116,7 @@ export type WorkflowStudioProps = {
   onSavePositions: (positions: WorkflowNodePositions) => void;
   onDisconnect: (source: string, target: string) => void;
   onCreate: (input: { name: string; pattern: WorkflowPattern; familiar?: string }) => void;
+  onCreateManifest: (manifest: Record<string, unknown>) => void;
   onImport: (manifest: Record<string, unknown>) => void;
   onDuplicate: (workflow: WorkflowSummary) => void;
   onDelete: (workflow: WorkflowSummary) => void;
@@ -430,10 +431,15 @@ export function WorkflowStudio(props: WorkflowStudioProps) {
       </aside>
       {createOpen && (
         <WorkflowCreateDialog
+          familiarOptions={props.familiarOptions}
           onClose={() => setCreateOpen(false)}
           onCreate={(input) => {
             setCreateOpen(false);
             props.onCreate(input);
+          }}
+          onCreateManifest={(manifest) => {
+            setCreateOpen(false);
+            props.onCreateManifest(manifest);
           }}
         />
       )}

--- a/src/lib/workflow-generate.test.ts
+++ b/src/lib/workflow-generate.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  buildQuestionsPrompt,
+  buildManifestPrompt,
+  parseQuestionsResponse,
+  parseManifestResponse,
+  WorkflowGenerateError,
+} from "./workflow-generate.ts";
+
+test("buildQuestionsPrompt embeds the goal and asks for 2-3 fenced JSON questions", () => {
+  const prompt = buildQuestionsPrompt("triage inbound bug reports");
+  assert.match(prompt, /triage inbound bug reports/);
+  assert.match(prompt, /2-3/);
+  assert.match(prompt, /```json/);
+  assert.match(prompt, /input/i);
+  assert.match(prompt, /output|artifact/i);
+});
+
+test("buildManifestPrompt embeds goal, answers, familiar, and asks for fenced yaml", () => {
+  const prompt = buildManifestPrompt({
+    goal: "triage bugs",
+    answers: [{ id: "q1", question: "What triggers it?", answer: "a new GitHub issue" }],
+    familiarId: "salem",
+    suggestedName: "Bug triage",
+  });
+  assert.match(prompt, /triage bugs/);
+  assert.match(prompt, /What triggers it\?/);
+  assert.match(prompt, /a new GitHub issue/);
+  assert.match(prompt, /salem/);
+  assert.match(prompt, /```yaml/);
+  assert.match(prompt, /human-gate/);
+});
+
+test("parseQuestionsResponse extracts a fenced JSON block and clamps to 3", () => {
+  const text = [
+    "Sure — a few questions:",
+    "```json",
+    JSON.stringify({
+      questions: [
+        { id: "q1", question: "What triggers it?", hint: "e.g. a new issue" },
+        { id: "q2", question: "What should it produce?" },
+        { id: "q3", question: "Any tools it must use?" },
+        { id: "q4", question: "Extra one to drop" },
+      ],
+    }),
+    "```",
+  ].join("\n");
+  const questions = parseQuestionsResponse(text);
+  assert.equal(questions.length, 3);
+  assert.equal(questions[0].id, "q1");
+  assert.equal(questions[0].hint, "e.g. a new issue");
+});
+
+test("parseQuestionsResponse parses bare JSON with no fence", () => {
+  const text = JSON.stringify({ questions: [{ id: "q1", question: "Goal?" }] });
+  assert.equal(parseQuestionsResponse(text).length, 1);
+});
+
+test("parseQuestionsResponse throws on malformed output", () => {
+  assert.throws(() => parseQuestionsResponse("no questions here"), WorkflowGenerateError);
+  assert.throws(() => parseQuestionsResponse("```json\n{\"questions\":[]}\n```"), WorkflowGenerateError);
+});
+
+test("parseManifestResponse extracts a fenced yaml manifest object", () => {
+  const text = [
+    "Here's the workflow:",
+    "```yaml",
+    "id: triage",
+    "version: 0.1.0",
+    "pattern: classify-and-act",
+    "steps:",
+    "  - id: input",
+    "    kind: input",
+    "  - id: output",
+    "    kind: output",
+    "```",
+  ].join("\n");
+  const manifest = parseManifestResponse(text);
+  assert.equal((manifest.steps as unknown[]).length, 2);
+  assert.equal(manifest.pattern, "classify-and-act");
+});
+
+test("parseManifestResponse throws when steps are missing or it isn't an object", () => {
+  assert.throws(() => parseManifestResponse("```yaml\nid: x\nversion: 0.1.0\n```"), WorkflowGenerateError);
+  assert.throws(() => parseManifestResponse("```yaml\n- 1\n- 2\n```"), WorkflowGenerateError);
+  assert.throws(() => parseManifestResponse("nothing fenced here"), WorkflowGenerateError);
+});

--- a/src/lib/workflow-generate.ts
+++ b/src/lib/workflow-generate.ts
@@ -1,0 +1,139 @@
+// Client helper: ask a familiar to author a workflow by streaming /api/chat/send
+// (the same daemon-agent bridge canvas + journal generation use — Cave has no
+// server-side LLM). Two passes: (1) goal -> 2-3 clarifying questions, (2) goal +
+// answers -> a CWF-01 manifest. Prompt builders and parsers are pure and unit-
+// tested; the streaming wrappers mirror canvas-generate. Generated manifests are
+// validated server-side on save (same as import), so parsing here only guards
+// the structural shape.
+
+import { parse as parseYaml } from "yaml";
+import { parseSseFrame } from "@/lib/canvas-generate";
+
+/** A single familiar-authored clarifying question. */
+export type GeneratedQuestion = { id: string; question: string; hint?: string };
+
+/** A question paired with the user's typed answer, fed into the manifest pass. */
+export type GeneratedAnswer = { id: string; question: string; answer: string };
+
+/** Thrown when the familiar's output can't be parsed into the expected shape. */
+export class WorkflowGenerateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkflowGenerateError";
+  }
+}
+
+const STEP_KINDS = "input, agent, skill, tool, human-gate, workflow, output";
+
+/** Pass 1 prompt: ask the familiar for the 2-3 questions that fully scope the workflow. */
+export function buildQuestionsPrompt(goal: string): string {
+  return [
+    "I want to create an automated workflow. Here is the goal in my words:",
+    "",
+    goal.trim() || "(no goal given yet — ask the broadest scoping questions)",
+    "",
+    "Before you design it, ask me the 2-3 most important clarifying questions you need so the",
+    "workflow is fully specified. Together your questions must cover these aspects: what input or",
+    "trigger starts it, what output artifact it should produce, how we'll know it succeeded, which",
+    "skills/tools/agents/sub-workflows it must use, and any limits (max agents, timeout, cost).",
+    "Fold related aspects into a single question — never ask more than 3.",
+    "",
+    "Reply with ONLY a fenced json block in exactly this shape:",
+    "```json",
+    '{ "questions": [ { "id": "q1", "question": "…", "hint": "optional example" } ] }',
+    "```",
+  ].join("\n");
+}
+
+/** Pass 2 prompt: hand the goal + answers back and ask for a CWF-01 manifest. */
+export function buildManifestPrompt(opts: {
+  goal: string;
+  answers: GeneratedAnswer[];
+  familiarId?: string;
+  suggestedName?: string;
+}): string {
+  const qa = opts.answers
+    .map((a) => `- ${a.question}\n  ${a.answer.trim() || "(no answer — use a sensible default)"}`)
+    .join("\n");
+  return [
+    `Design a workflow that achieves this goal: ${opts.goal.trim() || "(see answers below)"}`,
+    "",
+    "My answers to your questions:",
+    qa || "(none)",
+    "",
+    "Produce a single CWF-01 workflow manifest as a fenced yaml block. Requirements:",
+    `- Top-level keys: id, version (use "0.1.0"), name${opts.suggestedName ? ` (use "${opts.suggestedName}")` : ""}, summary, pattern, steps.`,
+    opts.familiarId ? `- Set "familiar: ${opts.familiarId}".` : "- Omit the familiar field.",
+    "- Pick the closest pattern: sequential, fan-out-and-synthesize, classify-and-act,",
+    "  adversarial-verification, generate-and-filter, tournament, loop-until-done, or custom.",
+    `- Every step needs an "id" and a "kind" (one of: ${STEP_KINDS}).`,
+    "- Start with one input step and end with one output step. Use \"requires: [ids]\" for ordering,",
+    "  \"uses\" to bind an agent/skill/tool/sub-workflow, and a short \"summary\" per step.",
+    "- Reply with ONLY the fenced yaml manifest — no prose before or after.",
+    "```yaml",
+    "id: example",
+    "version: 0.1.0",
+    "steps:",
+    "  - id: input",
+    "    kind: input",
+    "  - id: output",
+    "    kind: output",
+    "    requires: [input]",
+    "```",
+  ].join("\n");
+}
+
+/** First fenced ``` block in the text, or the whole trimmed text as a fallback. */
+function fencedBody(text: string): string {
+  const match = text.match(/```[\w-]*\n([\s\S]*?)```/);
+  return (match ? match[1] : text).trim();
+}
+
+/** Extract + parse the questions block; clamp to the first 3; throw if unusable. */
+export function parseQuestionsResponse(text: string): GeneratedQuestion[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fencedBody(text));
+  } catch {
+    throw new WorkflowGenerateError("The familiar didn't return readable questions. Try again.");
+  }
+  const raw = (parsed && typeof parsed === "object" && Array.isArray((parsed as { questions?: unknown }).questions))
+    ? (parsed as { questions: unknown[] }).questions
+    : null;
+  if (!raw || raw.length === 0) {
+    throw new WorkflowGenerateError("The familiar didn't return any questions. Try again.");
+  }
+  const questions: GeneratedQuestion[] = [];
+  for (const [index, entry] of raw.slice(0, 3).entries()) {
+    const obj = (entry && typeof entry === "object" ? entry : {}) as Record<string, unknown>;
+    const question = typeof obj.question === "string" ? obj.question.trim() : "";
+    if (!question) continue;
+    questions.push({
+      id: typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : `q${index + 1}`,
+      question,
+      hint: typeof obj.hint === "string" && obj.hint.trim() ? obj.hint.trim() : undefined,
+    });
+  }
+  if (questions.length === 0) {
+    throw new WorkflowGenerateError("The familiar didn't return any questions. Try again.");
+  }
+  return questions;
+}
+
+/** Extract + parse the manifest block; structural guard only (save validates fully). */
+export function parseManifestResponse(text: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(fencedBody(text));
+  } catch {
+    throw new WorkflowGenerateError("The familiar's workflow couldn't be parsed. Regenerate to try again.");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new WorkflowGenerateError("The familiar didn't return a workflow object. Regenerate to try again.");
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (!Array.isArray(obj.steps) || obj.steps.length === 0) {
+    throw new WorkflowGenerateError("The generated workflow has no steps. Regenerate to try again.");
+  }
+  return obj;
+}

--- a/src/lib/workflow-generate.ts
+++ b/src/lib/workflow-generate.ts
@@ -137,3 +137,93 @@ export function parseManifestResponse(text: string): Record<string, unknown> {
   }
   return obj;
 }
+
+/** Stream the assistant's full text for `prompt` from `familiarId`. */
+async function streamFamiliarText(opts: {
+  familiarId: string;
+  prompt: string;
+  signal?: AbortSignal;
+}): Promise<{ text: string; error: string | null }> {
+  let res: Response;
+  try {
+    res = await fetch("/api/chat/send", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ familiarId: opts.familiarId, prompt: opts.prompt }),
+      signal: opts.signal,
+    });
+  } catch (err) {
+    return { text: "", error: (err as Error)?.message ?? "request failed" };
+  }
+  if (!res.ok || !res.body) return { text: "", error: `chat bridge ${res.status}` };
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let text = "";
+  let error: string | null = null;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let idx;
+    while ((idx = buffer.indexOf("\n\n")) >= 0) {
+      const frame = buffer.slice(0, idx);
+      buffer = buffer.slice(idx + 2);
+      const ev = parseSseFrame(frame);
+      if (!ev) continue;
+      if (ev.kind === "assistant_chunk") text += ev.text ?? "";
+      else if (ev.kind === "done" && ev.isError) error = error ?? "the familiar reported an error";
+      else if (ev.kind === "error") error = ev.message ?? "generation error";
+    }
+  }
+  return { text, error };
+}
+
+export type QuestionsResult = { questions: GeneratedQuestion[] | null; error: string | null };
+export type ManifestResult = { manifest: Record<string, unknown> | null; error: string | null };
+
+/** Pass 1: get the familiar's 2-3 clarifying questions for `goal`. */
+export async function generateWorkflowQuestions(opts: {
+  goal: string;
+  familiarId: string;
+  signal?: AbortSignal;
+}): Promise<QuestionsResult> {
+  const { text, error } = await streamFamiliarText({
+    familiarId: opts.familiarId,
+    prompt: buildQuestionsPrompt(opts.goal),
+    signal: opts.signal,
+  });
+  if (error) return { questions: null, error };
+  try {
+    return { questions: parseQuestionsResponse(text), error: null };
+  } catch (err) {
+    return { questions: null, error: err instanceof Error ? err.message : "couldn't read questions" };
+  }
+}
+
+/** Pass 2: get the generated manifest from `goal` + `answers`. */
+export async function generateWorkflowManifest(opts: {
+  goal: string;
+  answers: GeneratedAnswer[];
+  familiarId: string;
+  suggestedName?: string;
+  signal?: AbortSignal;
+}): Promise<ManifestResult> {
+  const { text, error } = await streamFamiliarText({
+    familiarId: opts.familiarId,
+    prompt: buildManifestPrompt({
+      goal: opts.goal,
+      answers: opts.answers,
+      familiarId: opts.familiarId,
+      suggestedName: opts.suggestedName,
+    }),
+    signal: opts.signal,
+  });
+  if (error) return { manifest: null, error };
+  try {
+    return { manifest: parseManifestResponse(text), error: null };
+  } catch (err) {
+    return { manifest: null, error: err instanceof Error ? err.message : "couldn't read the workflow" };
+  }
+}

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -2463,3 +2463,73 @@
     min-height: calc(var(--touch-target) * 2) !important;
   }
 }
+
+/* Create-dialog mode toggle (Describe / Pattern) */
+.workflow-create-mode-toggle {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  margin-bottom: 12px;
+  border-radius: 8px;
+  background: var(--bg-panel, rgba(127, 127, 127, 0.12));
+}
+.workflow-create-mode {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-muted, inherit);
+  font: inherit;
+  cursor: pointer;
+}
+.workflow-create-mode.is-active {
+  background: var(--bg-base, var(--background, #fff));
+  color: var(--color-text, inherit);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+
+/* Review step list */
+.workflow-review-steps {
+  list-style: none;
+  margin: 8px 0 4px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.workflow-review-step {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.workflow-review-kind {
+  flex: none;
+  min-width: 84px;
+  padding: 1px 6px;
+  border-radius: 5px;
+  font-size: 11px;
+  text-align: center;
+  background: var(--bg-panel, rgba(127, 127, 127, 0.14));
+  color: var(--color-muted, inherit);
+}
+.workflow-review-kind--input,
+.workflow-review-kind--output {
+  background: color-mix(in srgb, var(--color-accent, #6366f1) 18%, transparent);
+  color: var(--color-accent, inherit);
+}
+.workflow-review-name {
+  font-size: 13px;
+}
+
+/* Spinner used in the generate buttons */
+.workflow-spin {
+  animation: workflow-spin 0.8s linear infinite;
+}
+@keyframes workflow-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
Adds a **"describe it and let the selected familiar build it"** mode to the new-workflow flow.

## What it does
- **Describe mode (default):** pick a familiar + describe the goal in plain language → the familiar asks **2-3 clarifying questions** (familiar-authored, covering input/output/success/tools/limits) → generates a CWF-01 manifest → **review** the proposed steps → **Create & open** in the Studio.
- **Pattern mode (toggle):** the original name + 8-template picker + optional familiar, unchanged.

## How it works
- New client lib `src/lib/workflow-generate.ts` mirrors `canvas-generate`/`journal-generate`: streams `/api/chat/send` twice (questions, then manifest). Cave has no server LLM, so the familiar does the work — **no new API route**.
- Pure prompt builders + parsers are unit-tested (`workflow-generate.test.ts`, 7 tests); generated manifests are validated **server-side on save** via the existing `/api/workflows/save`, exactly like import.
- `WorkflowCreateDialog` gains the mode toggle + 3-step describe flow, reusing the existing familiar picker (`familiarOptions`) and modal CSS.

## Notes
- Spec + plan: `docs/superpowers/specs|plans/2026-06-21-familiar-built-workflows*` (gitignored, not in this PR).
- Manual verify the live questions→manifest path needs a daemon/familiar; CI E2E is daemon-less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)