### PR TITLE
feat(sidepanel): nav-badge dots when collapsed + Chat tab needs-reply dot

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -103,6 +103,7 @@ export const SUITES = {
     "src/components/chat-header-row.test.ts",
     "src/components/sidebar-minimal.test.ts",
     "src/components/sidepanel-badges.test.ts",
+    "src/components/sidepanel-badge-dots.test.ts",
     "src/components/recent-activity-rollup.test.ts",
     "src/components/sidebar-familiar-filter.test.ts",
     "src/components/shell-edge-rails.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3941,6 +3941,7 @@ button:active > .edge-rail-chip {
 }
 
 .companion-rail__tab {
+  position: relative;
   display: inline-grid;
   place-items: center;
   width: 30px;
@@ -3961,6 +3962,18 @@ button:active > .edge-rail-chip {
 .companion-rail__tab--active {
   background: color-mix(in oklch, var(--accent-presence) 18%, transparent);
   color: var(--accent-presence);
+}
+
+/* Needs-attention dot on a rail tab (e.g. Chat when the familiar needs a reply). */
+.companion-rail__tab-dot {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--accent-presence);
+  box-shadow: 0 0 0 2px var(--bg-panel);
 }
 
 .companion-rail__body {

--- a/src/components/companion-rail.tsx
+++ b/src/components/companion-rail.tsx
@@ -27,6 +27,8 @@ type Props = {
    * render a second redundant CTA. */
   suppressEmpty?: boolean;
   hideChatTab?: boolean;
+  /** Show a needs-attention dot on the Chat tab (e.g. the familiar needs a reply). */
+  chatBadge?: boolean;
   /** Whether the YouTube ("Video") pane is on. Lift this to the parent so the
    *  shell can keep the rail peeking (as a rotated video strip) when collapsed.
    *  Uncontrolled (local state) when omitted. */
@@ -66,6 +68,7 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
       onTabChange,
       suppressEmpty = false,
       hideChatTab = false,
+      chatBadge = false,
       youtubeActive,
       onYoutubeActiveChange,
       videoStrip = false,
@@ -193,6 +196,7 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
               title="Chat"
             >
               <Icon name="ph:chats" width={14} />
+              {chatBadge ? <span className="companion-rail__tab-dot" aria-hidden="true" /> : null}
             </button>
           )}
           {familiar ? (

--- a/src/components/sidepanel-badge-dots.test.ts
+++ b/src/components/sidepanel-badge-dots.test.ts
@@ -1,0 +1,36 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const sidebarCss = readFileSync(new URL("../styles/sidebar-minimal.css", import.meta.url), "utf8");
+const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const rail = readFileSync(new URL("./companion-rail.tsx", import.meta.url), "utf8");
+const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+
+// ── #1 collapsed-rail badge dots ────────────────────────────────────────────
+// The collapsed icon rail no longer hides the nav badge outright — it restyles
+// it into an accent dot so Board/Schedules/GitHub still signal at a glance.
+assert.match(
+  sidebarCss,
+  /\.shell-nav--rail \.sidebar-badge \{[\s\S]*?position: absolute[\s\S]*?border-radius: 999px/,
+  "collapsed rail shows the nav badge as a dot, not display:none",
+);
+assert.match(
+  sidebarCss,
+  /\.shell-nav--rail \.sidebar-folder-row \{[\s\S]*?position: relative/,
+  "collapsed folder row is the positioning context for the dot",
+);
+
+// ── #2 companion-rail tab badge ─────────────────────────────────────────────
+assert.match(rail, /chatBadge\?: boolean/, "rail accepts a chat badge flag");
+assert.match(rail, /chatBadge = false/, "chat badge defaults off");
+assert.match(rail, /className="companion-rail__tab-dot"/, "Chat tab renders a needs-attention dot");
+assert.match(globals, /\.companion-rail__tab-dot \{[\s\S]*?position: absolute/, "tab dot is styled");
+assert.match(globals, /\.companion-rail__tab \{\n\s*position: relative;/, "tab is the dot's positioning context");
+assert.match(
+  workspace,
+  /chatBadge=\{active \? responseNeeded\.has\(active\.id\) : false\}/,
+  "Chat tab dot lights when the active familiar needs a reply",
+);
+
+console.log("sidepanel-badge-dots.test.ts: ok");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1928,6 +1928,7 @@ export function Workspace() {
               defaultTab={railTab}
               activeTab={railTab}
               onTabChange={persistRailTab}
+              chatBadge={active ? responseNeeded.has(active.id) : false}
               daemonRunning={daemonRunning}
               onCreateFamiliar={openOnboarding}
               youtubeActive={railVideoActive}

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -1006,9 +1006,29 @@
 .shell-nav--rail .sidebar-action-label,
 .shell-nav--rail .sidebar-actions .sidebar-action-row > span,
 .shell-nav--rail .sidebar-foot-label,
-.shell-nav--rail .sidebar-foot-badge,
-.shell-nav--rail .sidebar-badge {
+.shell-nav--rail .sidebar-foot-badge {
   display: none;
+}
+
+/* The collapsed icon rail has no room for the count text, so render the nav
+   badge as a small accent dot in the icon top-right corner — Board/Schedules/
+   GitHub still signal at a glance when the sidebar is collapsed. */
+.shell-nav--rail .sidebar-folder-row {
+  position: relative;
+}
+.shell-nav--rail .sidebar-badge {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  min-width: 7px;
+  width: 7px;
+  height: 7px;
+  padding: 0;
+  font-size: 0;
+  line-height: 0;
+  border-radius: 999px;
+  background: var(--accent-presence);
+  color: transparent;
 }
 
 /* Drop the horizontal padding so the centered icons sit dead-center in the


### PR DESCRIPTION
Finishes the #1502 badges so the at-a-glance signal survives a collapse and reaches the companion rail.

## 1. Collapsed-rail badge dots
When the sidebar collapses to its icon-only rail (⌘B), the Board/Schedules/GitHub nav counts used to vanish entirely (`.shell-nav--rail .sidebar-badge { display: none }`). They now restyle into a small accent **dot** in the icon's top-right corner, so the signal stays alive when collapsed.

## 2. Companion-rail Chat tab dot
The rail tabs had no counts. A needs-attention dot (`.companion-rail__tab-dot`) now lights on the **Chat** tab when the active familiar needs a reply (`responseNeeded`), via a new `chatBadge` prop — mirroring the nav-badge pattern on the rail.

## Verification
`pnpm typecheck` clean; `pnpm test:app` **347/347** (new `sidepanel-badge-dots.test.ts` pins the collapsed-dot CSS, the `chatBadge` wiring, and the tab-dot style). The rail surfaces are hard to drive in demo mode (need a daemon + enhance-familiar binding), so verified at the source/test layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)