### PR TITLE
style(nav): enlarge sidepanel/header/top-bar icons to +40%

### DIFF
--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -95,7 +95,7 @@ export function FamiliarMenuBar({
           onOpenSearch();
         }}
       >
-        <Icon name="ph:magnifying-glass" width={16} className="menu-bar__search-icon" aria-hidden />
+        <Icon name="ph:magnifying-glass" width={18} className="menu-bar__search-icon" aria-hidden />
         <input
           type="search"
           className="menu-bar__search-input"
@@ -119,7 +119,7 @@ export function FamiliarMenuBar({
             aria-label={enrichingTasks ? `Enhancing tasks ${enrichLabel}` : activeFamiliarId ? ENRICH_TASKS_TITLE : "Select a familiar to enhance tasks"}
             title={activeFamiliarId ? ENRICH_TASKS_TITLE : "Select a familiar to enhance tasks"}
           >
-            <Icon name="ph:sparkle" width={18} aria-hidden />
+            <Icon name="ph:sparkle" width={21} aria-hidden />
             <span>{enrichingTasks ? enrichLabel : "Enhance"}</span>
           </button>
         ) : null}
@@ -129,7 +129,7 @@ export function FamiliarMenuBar({
           onClick={onViewTasks}
           aria-label={taskCount > 0 ? `View tasks — ${taskCount} open` : "View tasks"}
         >
-          <Icon name="ph:kanban" width={18} aria-hidden />
+          <Icon name="ph:kanban" width={21} aria-hidden />
           <span>Tasks</span>
           {taskCount > 0 ? <span className="menu-bar__badge">{fmtBadge(taskCount)}</span> : null}
         </button>
@@ -139,7 +139,7 @@ export function FamiliarMenuBar({
           onClick={onViewInbox}
           aria-label={inboxCount > 0 ? `View inbox — ${inboxCount} need attention` : "View inbox"}
         >
-          <Icon name="ph:tray" width={18} aria-hidden />
+          <Icon name="ph:tray" width={21} aria-hidden />
           <span>Inbox</span>
           {inboxCount > 0 ? (
             <span className="menu-bar__badge menu-bar__badge--alert">{fmtBadge(inboxCount)}</span>

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -144,7 +144,7 @@ function SidebarSection({
           <span className="sidebar-section-label__text">{label}</span>
           <Icon
             name="ph:caret-down-bold"
-            width="0.84rem"
+            width="0.98rem"
             className={`sidebar-section-label__chevron${collapsed ? " sidebar-section-label__chevron--collapsed" : ""}`}
           />
         </button>
@@ -189,7 +189,7 @@ function FolderRow({
       title={title}
       onClick={onClick}
     >
-      <Icon name={iconName} width={18} className="sidebar-folder-icon" />
+      <Icon name={iconName} width={21} className="sidebar-folder-icon" />
       <span className="sidebar-folder-label">{label}</span>
       {badge && <span className="sidebar-badge">{badge}</span>}
       {/* The ⌘-number shortcut is no longer shown as a chip here: the numbers
@@ -247,7 +247,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
 
       <div className="sidebar-actions">
         <button type="button" className="sidebar-action-row focus-ring" onClick={onNewChat} title="New chat">
-          <Icon name="ph:note-pencil" width={19} aria-hidden />
+          <Icon name="ph:note-pencil" width={22} aria-hidden />
           <span>New chat</span>
         </button>
       </div>
@@ -301,7 +301,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
           title="Dashboard — activity overview and daily reports"
         >
           <span className="sidebar-foot-icon-cell" aria-hidden="true">
-            <Icon name="ph:squares-four" width={17} className="sidebar-foot-icon" />
+            <Icon name="ph:squares-four" width={20} className="sidebar-foot-icon" />
           </span>
           <span className="sidebar-foot-label">Dashboard</span>
         </a>
@@ -316,7 +316,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
             <span className="sidebar-foot-icon-cell" aria-hidden="true">
               <Icon
                 name={unreadCount > 0 ? "ph:bell-fill" : "ph:bell"}
-                width={17}
+                width={20}
                 className="sidebar-foot-icon"
               />
             </span>
@@ -336,7 +336,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
           title="Settings"
         >
           <span className="sidebar-foot-icon-cell" aria-hidden="true">
-            <Icon name="ph:gear-six" width={17} className="sidebar-foot-icon" />
+            <Icon name="ph:gear-six" width={20} className="sidebar-foot-icon" />
           </span>
           <span className="sidebar-foot-label">Settings</span>
         </button>

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -118,7 +118,7 @@ export function TopBar(props: Props) {
             aria-controls="nav"
             title={navDrawerOpen ? "Close navigation" : "Open navigation"}
           >
-            <Icon name="ph:sidebar-simple" width={22} />
+            <Icon name="ph:sidebar-simple" width={25} />
           </button>
         ) : null}
         {onToggleList ? (
@@ -132,7 +132,7 @@ export function TopBar(props: Props) {
             aria-controls="list"
             title={listDrawerOpen ? "Close list" : "Open list"}
           >
-            <Icon name="ph:list-checks-bold" width={22} />
+            <Icon name="ph:list-checks-bold" width={25} />
           </button>
         ) : null}
       </div>
@@ -150,7 +150,7 @@ export function TopBar(props: Props) {
           onOpenPalette();
         }}
       >
-        <Icon name="ph:magnifying-glass" width={14} className="top-bar__search-icon" />
+        <Icon name="ph:magnifying-glass" width={17} className="top-bar__search-icon" />
         <input
           type="search"
           className="top-bar__search-input"
@@ -185,7 +185,7 @@ export function TopBar(props: Props) {
             aria-label={activeFamiliar ? enrichLabel : "Select a familiar to enhance tasks"}
             title={activeFamiliar ? ENRICH_TASKS_TITLE : "Select a familiar to enhance tasks"}
           >
-            <Icon name="ph:sparkle" width={18} />
+            <Icon name="ph:sparkle" width={21} />
           </button>
         ) : null}
         {onViewTasks ? (
@@ -196,7 +196,7 @@ export function TopBar(props: Props) {
             aria-label={taskCount && taskCount > 0 ? `View tasks — ${taskCount} open` : "View tasks"}
             title="View tasks"
           >
-            <Icon name="ph:kanban" width={18} />
+            <Icon name="ph:kanban" width={21} />
             {taskCount && taskCount > 0 ? (
               <span className="top-bar__tasks-badge">{taskCount > 99 ? "99+" : taskCount}</span>
             ) : null}
@@ -209,7 +209,7 @@ export function TopBar(props: Props) {
           aria-label="Open on phone"
           title="Open on phone"
         >
-          <Icon name="ph:device-mobile" width={17} />
+          <Icon name="ph:device-mobile" width={20} />
         </button>
         <NotificationBell
           items={inboxItems}
@@ -227,7 +227,7 @@ export function TopBar(props: Props) {
           aria-label="Account / settings"
           title="Settings (⌘,)"
         >
-          <Icon name="ph:user" width={16} />
+          <Icon name="ph:user" width={18} />
         </button>
         {onToggleFamiliar ? (
           <button
@@ -240,7 +240,7 @@ export function TopBar(props: Props) {
             aria-controls="agent"
             title={familiarDrawerOpen ? "Close familiar panel" : "Open familiar panel"}
           >
-            <Icon name="ph:cat" width={22} />
+            <Icon name="ph:cat" width={25} />
           </button>
         ) : null}
       </div>


### PR DESCRIPTION
Follow-up to #1499 — bumps the nav icons from +20% to **+40%** of their original size (round(original × 1.4)).

| Surface | Before(orig) → Now(+40%) |
|---|---|
| Sidebar nav | 15 → 21 · new-chat 16 → 22 · footer 14 → 20 · caret 0.7→0.98rem |
| Header | search 13 → 18 · Enhance/Tasks/Inbox 15 → 21 |
| Mobile top-bar | toggle/tasks/cat 18 → 25 · search 12 → 17 · device 14 → 20 · user 13 → 18 · Enhance/Tasks 15 → 21 |

Typecheck passes; no tests pin these widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)