### PR TITLE
feat(sidepanel): hover-to-peek the collapsed nav rail

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -105,6 +105,7 @@ export const SUITES = {
     "src/components/sidebar-minimal.test.ts",
     "src/components/sidepanel-badges.test.ts",
     "src/components/sidepanel-badge-dots.test.ts",
+    "src/components/sidepanel-nav-peek.test.ts",
     "src/components/recent-activity-rollup.test.ts",
     "src/components/sidebar-familiar-filter.test.ts",
     "src/components/shell-edge-rails.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -460,7 +460,7 @@ select {
 }
 
 /* Inner panel border — subtle dividing line on the right edge of side panels */
-.shell-nav-panel { border-right: 1px solid var(--border-hairline); }
+.shell-nav-panel { border-right: 1px solid var(--border-hairline); position: relative; }
 .shell-familiar-panel { border-left: 1px solid var(--border-hairline); }
 .shell-list-panel { border-right: 1px solid var(--border-hairline); }
 
@@ -658,6 +658,30 @@ select {
   backdrop-filter: blur(14px) saturate(140%);
   -webkit-backdrop-filter: blur(14px) saturate(140%);
   overflow-y: auto;
+}
+
+/* Hover-to-peek: a collapsed nav rail floats open as an overlay on hover. The
+   aside drops its --rail class (content renders fully expanded) and gains
+   --peek, which lifts it out of the 56px panel box and over the content. */
+.shell-nav-panel:has(> .shell-nav--peek) {
+  overflow: visible !important;
+  z-index: 60;
+}
+.shell-nav-panel > .shell-nav--peek {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 232px;
+  z-index: 60;
+  background: var(--bg-raised);
+  border-right: 1px solid var(--border-hairline);
+  box-shadow: 0 12px 40px rgb(0 0 0 / 0.35);
+  animation: shellNavPeekIn 0.13s ease;
+}
+@keyframes shellNavPeekIn {
+  from { opacity: 0; transform: translateX(-8px); }
+  to { opacity: 1; transform: translateX(0); }
 }
 
 .shell-nav-header {

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -288,6 +288,14 @@ function ShellInner({
     return typeof pct !== "number" || pct > 0;
   });
 
+  // Hover-to-peek: when the desktop nav is collapsed to its icon rail, hovering
+  // floats it open as an overlay (navPeeking) without changing the collapse
+  // state. Reset whenever the rail goes away (expanded or mobile).
+  const [navPeeking, setNavPeeking] = useState(false);
+  useEffect(() => {
+    if (navOpen || isMobile) setNavPeeking(false);
+  }, [navOpen, isMobile]);
+
   // Track the detail panel's REAL left/right viewport gaps (side panels +
   // separators + edge rails — everything between the detail box and the
   // viewport edges) so child surfaces (e.g. the Home composer) can visually
@@ -458,8 +466,10 @@ function ShellInner({
         {/* CHAT-D13-05: every complementary landmark carries a distinct
             accessible name (axe landmark-unique). */}
         <aside
-          className={`shell-nav${!isMobile && !navOpen ? " shell-nav--rail" : ""}`}
+          className={`shell-nav${!isMobile && !navOpen ? (navPeeking ? " shell-nav--peek" : " shell-nav--rail") : ""}`}
           aria-label="Sidebar"
+          onMouseEnter={!isMobile && !navOpen ? () => setNavPeeking(true) : undefined}
+          onMouseLeave={!isMobile && !navOpen ? () => setNavPeeking(false) : undefined}
         >
           {nav}
         </aside>

--- a/src/components/sidepanel-nav-peek.test.ts
+++ b/src/components/sidepanel-nav-peek.test.ts
@@ -1,0 +1,19 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const shell = readFileSync(new URL("./shell.tsx", import.meta.url), "utf8");
+const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+
+// Hover-to-peek state + handlers on the collapsed nav rail.
+assert.match(shell, /const \[navPeeking, setNavPeeking\] = useState\(false\)/, "shell tracks a nav peek state");
+assert.match(shell, /navPeeking \? " shell-nav--peek" : " shell-nav--rail"/, "hovering the rail swaps it to the peek overlay");
+assert.match(shell, /onMouseEnter=\{!isMobile && !navOpen \? \(\) => setNavPeeking\(true\)/, "hovering the collapsed rail starts the peek");
+assert.match(shell, /onMouseLeave=\{!isMobile && !navOpen \? \(\) => setNavPeeking\(false\)/, "leaving the rail ends the peek");
+assert.match(shell, /if \(navOpen \|\| isMobile\) setNavPeeking\(false\)/, "peek resets when the rail goes away");
+
+// The peek overlay escapes the 56px rail box and floats over content.
+assert.match(globals, /\.shell-nav-panel:has\(> \.shell-nav--peek\) \{[\s\S]*?overflow: visible/, "peek lets the nav escape its panel box");
+assert.match(globals, /\.shell-nav--peek \{[\s\S]*?position: absolute[\s\S]*?box-shadow/, "peek floats as a shadowed overlay");
+
+console.log("sidepanel-nav-peek.test.ts: ok");


### PR DESCRIPTION
When the desktop sidebar is collapsed to its 56px icon rail, **hovering it now floats the full sidebar open as an overlay** — labels one hover away — then re-collapses on mouse-out. You keep the reclaimed screen space without a click or ⌘B. (VS Code / macOS Finder pattern.)

## How
A `navPeeking` state swaps the aside's `--rail` class for a `--peek` class on hover, so the content renders **fully expanded** (rather than reverting each collapse rule individually). `.shell-nav--peek` is absolutely positioned and the nav panel flips to `overflow: visible` (via `:has(> .shell-nav--peek)`) so the 232px overlay escapes the 56px box and floats over the content with a shadow + a quick slide-in. Peek resets whenever the rail goes away (expanded or mobile). The className is kept a single `${...}` interpolation so the existing sidebar-landmark test still matches.

## Verification
`pnpm typecheck` clean; `pnpm test:app` **349/349** (new `sidepanel-nav-peek.test.ts` pins the peek state/handlers + the overlay CSS; the landmark-className test still passes). Pure CSS/state interaction — no daemon needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)