### PR TITLE
fix(theme): stop concurrent /api/theme writes from crashing the server

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -430,6 +430,7 @@ export const SUITES = {
     "src/proxy-behavior.test.ts",
     "src/lib/server/memory-file-sources-coven-familiar.test.ts",
     "src/lib/server/memory-trash.test.ts",
+    "src/lib/server/theme-store.test.ts",
     "src/app/api/memory-coven-workspaces.test.ts",
     "src/app/api/memory-excerpt.test.ts",
     "src/app/api/memory-mutation-routes.test.ts",

--- a/src/app/api/theme/route.ts
+++ b/src/app/api/theme/route.ts
@@ -19,6 +19,15 @@ export async function PUT(req: Request) {
   if (!body || typeof body.themeId !== "string") {
     return NextResponse.json({ ok: false, error: "themeId required" }, { status: 400 });
   }
-  const theme = await saveTheme(body);
-  return NextResponse.json({ ok: true, theme });
+  try {
+    const theme = await saveTheme(body);
+    return NextResponse.json({ ok: true, theme });
+  } catch (err) {
+    // A failed write must never escape the handler — an unhandled rejection
+    // here previously took the whole server down.
+    return NextResponse.json(
+      { ok: false, error: err instanceof Error ? err.message : "failed to save theme" },
+      { status: 500 },
+    );
+  }
 }

--- a/src/lib/server/theme-store.test.ts
+++ b/src/lib/server/theme-store.test.ts
@@ -1,0 +1,36 @@
+// @ts-nocheck
+// Guards the fix for the theme-write crash: a fixed `.tmp` filename let
+// concurrent PUT /api/theme requests race (first rename consumed the temp,
+// second hit ENOENT and crashed the dev server). The write must use a unique
+// temp name and never let a failure escape the route handler.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const store = await readFile(new URL("./theme-store.ts", import.meta.url), "utf8");
+const route = await readFile(new URL("../../app/api/theme/route.ts", import.meta.url), "utf8");
+
+assert.doesNotMatch(
+  store,
+  /const tmp = THEME_PATH \+ "\.tmp"/,
+  "theme-store must not use a single fixed temp filename (concurrent writes race on it)",
+);
+
+assert.match(
+  store,
+  /const tmp = `\$\{THEME_PATH\}\.\$\{process\.pid\}\.\$\{randomBytes\(/,
+  "theme-store should write to a per-process, randomized temp file so parallel saves don't collide",
+);
+
+assert.match(
+  store,
+  /catch \(err\) \{[\s\S]*rm\(tmp, \{ force: true \}\)[\s\S]*throw err/,
+  "a failed write should clean up its temp file and rethrow (no orphaned temp, no swallowed error)",
+);
+
+assert.match(
+  route,
+  /try \{[\s\S]*await saveTheme\(body\)[\s\S]*\} catch[\s\S]*status: 500/,
+  "PUT /api/theme must wrap saveTheme so a write failure returns 500 instead of crashing the server",
+);
+
+console.log("theme-store.test.ts: ok");

--- a/src/lib/server/theme-store.ts
+++ b/src/lib/server/theme-store.ts
@@ -1,7 +1,8 @@
 // Persists the desktop's active theme + resolved color tokens to
 // ~/.coven/cave-theme.json so other clients (the iOS app over Tailscale)
 // can read it from GET /api/theme. Fixed filename — no user-controlled path.
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { randomBytes } from "node:crypto";
 import path from "node:path";
 import { homedir } from "node:os";
 
@@ -49,8 +50,17 @@ export async function saveTheme(input: { themeId?: unknown; mode?: unknown; toke
     updatedAt: new Date().toISOString(),
   };
   await mkdir(path.dirname(THEME_PATH), { recursive: true });
-  const tmp = THEME_PATH + ".tmp";
-  await writeFile(tmp, JSON.stringify(snap, null, 2), "utf8");
-  await rename(tmp, THEME_PATH);
+  // Unique temp name per write: a fixed `.tmp` made concurrent PUTs race —
+  // both wrote the same file, the first rename consumed it, and the second
+  // rename hit ENOENT, crashing the dev server. A per-write name lets parallel
+  // saves each rename their own file (last writer wins) without colliding.
+  const tmp = `${THEME_PATH}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`;
+  try {
+    await writeFile(tmp, JSON.stringify(snap, null, 2), "utf8");
+    await rename(tmp, THEME_PATH);
+  } catch (err) {
+    await rm(tmp, { force: true }).catch(() => {});
+    throw err;
+  }
   return snap;
 }


### PR DESCRIPTION
## What

A live crash, caught while verifying the phone's connection: the dev server went down with
```
ENOENT: rename '~/.coven/cave-theme.json.tmp' → 'cave-theme.json'
PUT /api/theme 500
 ELIFECYCLE  Command failed.
```

**Root cause:** `saveTheme` wrote to a **fixed** temp filename (`cave-theme.json.tmp`). Two concurrent `PUT /api/theme` requests — the iOS app connecting while the desktop syncs its theme — both wrote that same file; the first `rename` consumed it, the second `rename` hit `ENOENT`, and the unhandled rejection crashed the whole server.

## Fix
- **Unique per-write temp name** (`…cave-theme.json.<pid>.<random>.tmp`) so parallel saves each rename their own file (last writer wins) without colliding.
- **Clean up the temp on failure** and rethrow (no orphaned temp, no swallowed error).
- **Guard the route**: wrap `saveTheme` so a write failure returns a clean **500** instead of escaping the handler.
- Regression test (`theme-store.test.ts`, registered in `run-tests.mjs`).

## Verification
- new test passes; `pnpm typecheck` → 0; `pnpm test:app` → **349 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)