### PR TITLE
feat(sidepanel): arrow-key navigation for nav rows and rail tabs

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -106,6 +106,7 @@ export const SUITES = {
     "src/components/sidepanel-badges.test.ts",
     "src/components/sidepanel-badge-dots.test.ts",
     "src/components/sidepanel-nav-peek.test.ts",
+    "src/components/sidepanel-keyboard-nav.test.ts",
     "src/components/recent-activity-rollup.test.ts",
     "src/components/sidebar-familiar-filter.test.ts",
     "src/components/shell-edge-rails.test.ts",

--- a/src/components/companion-rail.tsx
+++ b/src/components/companion-rail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { forwardRef, useEffect, useState, type ReactNode } from "react";
+import { forwardRef, useEffect, useRef, useState, type ReactNode } from "react";
+import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
 import { Icon } from "@/lib/icon";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
@@ -81,6 +82,11 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
       panelIds: ["companion-rail-main", "companion-rail-youtube"],
       storage: railSplitStorage,
     });
+
+    // Arrow-key navigation across the rail section tabs (graceful: tabs stay
+    // tab-focusable if the rail mounts before a familiar is bound).
+    const tabsRef = useRef<HTMLElement | null>(null);
+    useRovingTabIndex({ containerRef: tabsRef, itemSelector: ".companion-rail__tab", orientation: "both", loop: true });
     // The Video tab is a toggle, not a mutually-exclusive section: when on, the
     // YouTube viewer drops into a resizable bottom pane below the active tab's
     // content rather than replacing it. The on/off state can be lifted to the
@@ -186,7 +192,7 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
         ) : null}
         {/* Familiar header removed — the tab strip is the panel's top row and
             its trigger band aligns with the left sidebar's floating toggle. */}
-        <nav className="companion-rail__tabs" aria-label="Companion sections">
+        <nav className="companion-rail__tabs" ref={tabsRef} aria-label="Companion sections">
           {!familiar || hideChatTab ? null : (
             <button
               type="button"

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -23,7 +23,7 @@ assert.doesNotMatch(workspace, /case "\/delegations":|case "\/calls":|setMode\("
 
 assert.match(
   source,
-  /<div className="sidebar-nav-scroll">/,
+  /<div className="sidebar-nav-scroll"/,
   "Sidebar should keep the main navigation in one continuous scrollable rail",
 );
 

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -12,6 +12,7 @@
  */
 
 import React from "react";
+import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 import { Icon } from "@/lib/icon";
 import { RecentActivityRollup } from "@/components/recent-activity-rollup";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
@@ -216,6 +217,11 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
 
   const unreadCount = notificationBadgeCount ?? 0;
 
+  // Arrow-key navigation across the nav rows (Work + Tools): one tab stop,
+  // Up/Down moves focus, Home/End jumps. Uses the shared roving-tabindex hook.
+  const navScrollRef = React.useRef<HTMLDivElement | null>(null);
+  useRovingTabIndex({ containerRef: navScrollRef, itemSelector: ".sidebar-folder-row", orientation: "vertical" });
+
   // Projects lives only inside the Familiars surface's Projects tab now (and ⌘9 /
   // the /projects deep-link in workspace.tsx open it there) — no sidebar entry.
   const handleModeSelect = (id: FolderMode) => {
@@ -252,7 +258,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
         </button>
       </div>
 
-      <div className="sidebar-nav-scroll">
+      <div className="sidebar-nav-scroll" ref={navScrollRef}>
         <SidebarSection label="Work">
           {workModes.map((fm) => (
             <FolderRow

--- a/src/components/sidepanel-keyboard-nav.test.ts
+++ b/src/components/sidepanel-keyboard-nav.test.ts
@@ -1,0 +1,18 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const rail = readFileSync(new URL("./companion-rail.tsx", import.meta.url), "utf8");
+
+// Left nav rows are arrow-navigable via the shared roving-tabindex hook.
+assert.match(sidebar, /import \{ useRovingTabIndex \} from "@\/lib\/use-roving-tabindex"/, "sidebar imports the roving hook");
+assert.match(sidebar, /useRovingTabIndex\(\{[\s\S]*?itemSelector: "\.sidebar-folder-row"[\s\S]*?orientation: "vertical"/, "nav rows rove vertically");
+assert.match(sidebar, /<div className="sidebar-nav-scroll" ref=\{navScrollRef\}>/, "the nav scroll container is the roving keydown target");
+
+// Companion-rail tabs are arrow-navigable too.
+assert.match(rail, /import \{ useRovingTabIndex \} from "@\/lib\/use-roving-tabindex"/, "rail imports the roving hook");
+assert.match(rail, /useRovingTabIndex\(\{[\s\S]*?itemSelector: "\.companion-rail__tab"/, "rail tabs rove");
+assert.match(rail, /<nav className="companion-rail__tabs" ref=\{tabsRef\} aria-label="Companion sections">/, "the tab strip is the roving keydown target");
+
+console.log("sidepanel-keyboard-nav.test.ts: ok");


### PR DESCRIPTION
Makes the side panels keyboard-operable like the board/calendar, using the shared `useRovingTabIndex` hook (WAI-ARIA roving tabindex).

## What
- **Left nav** — Up/Down moves between the Work/Tools rows (one tab stop), Home/End jumps to the ends, Enter/Space activate (native buttons). Collapsed sections are skipped automatically since their rows aren't in the DOM.
- **Companion-rail tabs** — arrow keys cycle the section tabs (loops). Degrades gracefully: tabs stay normally tab-focusable if the rail happens to mount before a familiar is bound.

## How
Each container gets a ref + `useRovingTabIndex({ containerRef, itemSelector, orientation })`; the hook wires the keydown listener and the tabindex roving itself. No new behavior code — reuses the proven hook.

## Verification
`pnpm typecheck` clean; `pnpm test:app` **350/350** (new `sidepanel-keyboard-nav.test.ts` pins the hook wiring; relaxed one sidebar source-text assertion to tolerate the new ref). End-to-end arrow-key movement verified with Playwright on the rendered sidebar (see PR thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)