### PR TITLE
feat(comux): tmux-grade pane navigation — directional focus, cycle, jump, zoom

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -149,6 +149,7 @@ export const SUITES = {
     "src/lib/project-search.test.ts",
     "src/lib/tool-target-file.test.ts",
     "src/lib/terminal-layout.test.ts",
+    "src/lib/terminal-nav.test.ts",
     "src/components/library-polish.test.ts",
     "src/components/library-file-actions.test.ts",
     "src/components/eval-loop-panel.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -150,6 +150,7 @@ export const SUITES = {
     "src/lib/tool-target-file.test.ts",
     "src/lib/terminal-layout.test.ts",
     "src/lib/terminal-nav.test.ts",
+    "src/components/comux-pane-nav-wiring.test.ts",
     "src/components/library-polish.test.ts",
     "src/components/library-file-actions.test.ts",
     "src/components/eval-loop-panel.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2202,6 +2202,28 @@ select {
   opacity: 1;
 }
 
+/* Pane number badge — backs ⌘1…9 quick-jump and reads like a tmux pane index.
+   Tints to the brand accent on the focused pane. */
+.comux-terminal-pane-num {
+  display: inline-grid;
+  place-items: center;
+  min-width: 15px;
+  height: 15px;
+  padding: 0 3px;
+  border-radius: 4px;
+  background: color-mix(in oklch, var(--text-muted) 22%, transparent);
+  color: var(--text-secondary);
+  font-size: 9px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.comux-terminal-pane[data-active="true"] .comux-terminal-pane-num {
+  background: color-mix(in oklch, var(--accent-presence) 30%, transparent);
+  color: var(--accent-presence);
+}
+
 .comux-terminal-pane-action:hover {
   background: var(--bg-hover);
   color: var(--text-primary);

--- a/src/components/comux-pane-nav-wiring.test.ts
+++ b/src/components/comux-pane-nav-wiring.test.ts
@@ -1,0 +1,51 @@
+// @ts-nocheck
+// Locks the comux multi-pane navigation wiring (directional focus, cycle,
+// quick-jump, zoom) so a refactor can't silently drop the tmux-grade shortcuts.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./comux-view.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+
+// Imports the pure nav helpers.
+assert.match(src, /from "@\/lib\/terminal-nav"/, "comux imports the terminal-nav module");
+for (const fn of ["directionalNeighbor", "cycleVisibleSession", "paneNumberMap", "sessionAtPaneNumber"]) {
+  assert.match(src, new RegExp(`\\b${fn}\\b`), `comux uses ${fn}`);
+}
+
+// Directional focus (⌘⌥Arrow) maps each arrow to a PaneDirection.
+assert.match(src, /e\.altKey/, "directional nav gated on altKey (⌘⌥)");
+for (const [key, dir] of [["ArrowLeft", "left"], ["ArrowRight", "right"], ["ArrowUp", "up"], ["ArrowDown", "down"]]) {
+  assert.match(src, new RegExp(`"${key}"\\s*\\?\\s*"${dir}"`), `${key} → ${dir}`);
+}
+assert.match(src, /directionalNeighbor\(terminalLayout, activeId, dir\)/, "directional focus calls directionalNeighbor");
+
+// Cycle (⌘[ / ⌘]) and quick-jump (⌘1…9).
+assert.match(src, /e\.key === "\]" \? 1 : -1/, "⌘] next / ⌘[ prev cycle");
+assert.match(src, /cycleVisibleSession\(terminalLayout, activeId,/, "cycle calls cycleVisibleSession");
+assert.match(src, /e\.key >= "1" && e\.key <= "9"/, "quick-jump on ⌘1…9");
+assert.match(src, /sessionAtPaneNumber\(terminalLayout, Number\(e\.key\)\)/, "quick-jump resolves pane number");
+
+// Zoom: state, ⌘Enter toggle, and the render branch that shows one pane.
+assert.match(src, /const \[zoomedSessionId, setZoomedSessionId\] = useState<string \| null>\(null\)/, "zoom state");
+assert.match(src, /e\.key === "Enter"[\s\S]{0,160}setZoomedSessionId\(\(z\) => \(z \? null : activeId\)\)/, "⌘Enter toggles zoom");
+assert.match(
+  src,
+  /zoomedSessionId && visiblePaneSessionIds\.includes\(zoomedSessionId\)[\s\S]{0,120}renderTerminalNode\(\{ kind: "leaf", sessionId: zoomedSessionId \}\)/,
+  "zoom render shows only the zoomed pane",
+);
+// Zoom follows focus while navigating.
+assert.match(src, /setZoomedSessionId\(\(z\) => \(z \? id : z\)\)/, "zoom follows the focused pane during navigation");
+
+// Pane number badge + zoom/restore button in the pane bar.
+assert.match(src, /comux-terminal-pane-num/, "pane number badge rendered");
+assert.match(src, /paneNumbers\.get\(s\.id\)/, "badge shows the pane number");
+assert.match(src, /aria-label=\{zoomedSessionId === s\.id \? `Restore \$\{s\.label\}` : `Zoom \$\{s\.label\}`\}/, "zoom/restore button labeled");
+
+// Footer advertises the new shortcuts.
+assert.match(src, /⌘\[ ⌘\] cycle · ⌘1–9 jump · ⌘⏎ zoom/, "footer hint lists the new shortcuts");
+
+// CSS for the badge exists.
+assert.match(css, /\.comux-terminal-pane-num\s*\{/, "pane number badge has styles");
+
+console.log("comux-pane-nav-wiring.test.ts passed");

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -48,6 +48,13 @@ import {
   type TerminalSplitDirection,
   type TerminalSplitSide,
 } from "@/lib/terminal-layout";
+import {
+  directionalNeighbor,
+  cycleVisibleSession,
+  paneNumberMap,
+  sessionAtPaneNumber,
+  type PaneDirection,
+} from "@/lib/terminal-nav";
 import type { SessionRow } from "@/lib/types";
 
 type ComuxViewMode = "terminal" | "projects";
@@ -458,6 +465,17 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
     [terminalLayout],
   );
 
+  // Zoom/maximize: when set, the surface renders only this pane full-size while
+  // its siblings stay alive (PTYs untouched) behind it. 1-based pane numbers
+  // back the badges + ⌘1…9 quick-jump.
+  const [zoomedSessionId, setZoomedSessionId] = useState<string | null>(null);
+  const paneNumbers = useMemo(() => paneNumberMap(terminalLayout), [terminalLayout]);
+  useEffect(() => {
+    if (zoomedSessionId && !visiblePaneSessionIds.includes(zoomedSessionId)) {
+      setZoomedSessionId(null);
+    }
+  }, [zoomedSessionId, visiblePaneSessionIds]);
+
   const hiddenPaneSessions = useMemo(() => {
     const visibleIds = new Set(visiblePaneSessionIds);
     return sessions.filter((session) => !visibleIds.has(session.id));
@@ -532,6 +550,65 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [view, active, addSession, removeSession, currentIdx, sessions.length]);
+
+  // Multi-pane navigation (tmux-grade): directional focus (⌘⌥Arrow), cycle
+  // (⌘[ / ⌘]), quick-jump (⌘1…9), and zoom toggle (⌘Enter). All gated to ⌘/Ctrl
+  // chords the shell never sees; zoom follows focus so navigating while zoomed
+  // moves the maximized pane.
+  useEffect(() => {
+    if (view !== "terminal" || !active) return;
+    const onKey = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod) return;
+      const target = e.target as HTMLElement | null;
+      if (target?.isContentEditable) return;
+      if (e.ctrlKey && !e.metaKey && target?.closest?.(".xterm")) return;
+
+      const activeId = terminalLayout.activeSessionId;
+      const focusPane = (id: string | null) => {
+        if (!id) return;
+        e.preventDefault();
+        dispatchTerminalLayout({ type: "focus", sessionId: id });
+        setZoomedSessionId((z) => (z ? id : z)); // zoom follows the focused pane
+      };
+
+      // Directional focus — ⌘⌥Arrow.
+      if (e.altKey && !e.shiftKey) {
+        const dir: PaneDirection | null =
+          e.key === "ArrowLeft" ? "left"
+          : e.key === "ArrowRight" ? "right"
+          : e.key === "ArrowUp" ? "up"
+          : e.key === "ArrowDown" ? "down"
+          : null;
+        if (dir && activeId) {
+          focusPane(directionalNeighbor(terminalLayout, activeId, dir));
+        }
+        return;
+      }
+      if (e.shiftKey) return;
+
+      // Cycle visible panes — ⌘] (next) / ⌘[ (prev).
+      if (e.key === "]" || e.key === "[") {
+        focusPane(cycleVisibleSession(terminalLayout, activeId, e.key === "]" ? 1 : -1));
+        return;
+      }
+      // Quick-jump to pane N — ⌘1…9.
+      if (e.key >= "1" && e.key <= "9") {
+        const id = sessionAtPaneNumber(terminalLayout, Number(e.key));
+        if (id) focusPane(id);
+        return;
+      }
+      // Zoom / restore the active pane — ⌘Enter.
+      if (e.key === "Enter") {
+        if (!activeId) return;
+        if (visiblePaneSessionIds.length <= 1 && !zoomedSessionId) return;
+        e.preventDefault();
+        setZoomedSessionId((z) => (z ? null : activeId));
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [view, active, terminalLayout, zoomedSessionId, visiblePaneSessionIds]);
 
   const openFilePreview = useCallback(async (path: string, line?: number) => {
     setPreviewPath(path);
@@ -910,8 +987,27 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                   ?.removeAttribute("data-dragging");
               }}
             >
-              <Icon name="ph:terminal-window" width={12} aria-hidden />
+              {visiblePaneCount > 1 ? (
+                <span className="comux-terminal-pane-num" aria-hidden>{paneNumbers.get(s.id)}</span>
+              ) : (
+                <Icon name="ph:terminal-window" width={12} aria-hidden />
+              )}
               <span className="min-w-0 flex-1 truncate">{s.label}</span>
+              {visiblePaneCount > 1 || zoomedSessionId === s.id ? (
+                <button
+                  type="button"
+                  draggable={false}
+                  className="comux-terminal-pane-action"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setZoomedSessionId((z) => (z === s.id ? null : s.id));
+                  }}
+                  aria-label={zoomedSessionId === s.id ? `Restore ${s.label}` : `Zoom ${s.label}`}
+                  title={zoomedSessionId === s.id ? "Restore split (⌘⏎)" : "Zoom pane (⌘⏎)"}
+                >
+                  <Icon name={zoomedSessionId === s.id ? "ph:arrows-in-simple" : "ph:arrows-out-simple"} width={10} aria-hidden />
+                </button>
+              ) : null}
               {visiblePaneCount > 1 ? (
                 <button
                   type="button"
@@ -981,10 +1077,12 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
       daemonProjectRoot,
       focusSessionById,
       nodeKey,
+      paneNumbers,
       selectedProjectRoot,
       sessionById,
       splitSessionIntoPane,
       visiblePaneCount,
+      zoomedSessionId,
     ],
   );
 
@@ -1108,7 +1206,11 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
               </div>
             ) : (
               <>
-                {terminalLayout.root ? renderTerminalNode(terminalLayout.root) : null}
+                {terminalLayout.root
+                  ? zoomedSessionId && visiblePaneSessionIds.includes(zoomedSessionId)
+                    ? renderTerminalNode({ kind: "leaf", sessionId: zoomedSessionId })
+                    : renderTerminalNode(terminalLayout.root)
+                  : null}
                 <div className="comux-terminal-keepalive" aria-hidden="true">
                   {hiddenPaneSessions.map((s) => (
                     <BottomTerminal
@@ -1123,7 +1225,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
             )}
           </div>
           <footer className="shrink-0 border-t border-[var(--border-hairline)] px-3 py-1.5 text-center text-[10px] text-[var(--text-muted)]">
-            ⌘N new · ⌘W close · drag tabs or pane bars onto pane edges to split &amp; reorganize · drag dividers to resize
+            ⌘N new · ⌘W close · drag tabs or pane bars onto pane edges to split &amp; reorganize · drag dividers to resize · ⌘⌥arrows focus · ⌘[ ⌘] cycle · ⌘1–9 jump · ⌘⏎ zoom
           </footer>
         </div>
       ) : (

--- a/src/lib/terminal-nav.test.ts
+++ b/src/lib/terminal-nav.test.ts
@@ -1,0 +1,146 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  paneRects,
+  directionalNeighbor,
+  cycleVisibleSession,
+  paneNumberMap,
+  sessionAtPaneNumber,
+} from "./terminal-nav.ts";
+
+const leaf = (id) => ({ kind: "leaf", sessionId: id });
+const hsplit = (...kids) => ({ kind: "horizontal", children: kids.map((node) => ({ size: 100 / kids.length, node })) });
+const vsplit = (...kids) => ({ kind: "vertical", children: kids.map((node) => ({ size: 100 / kids.length, node })) });
+const state = (root, active) => ({ version: 1, sessions: [], activeSessionId: active ?? null, root });
+const rectOf = (root, id) => paneRects(state(root)).find((r) => r.sessionId === id);
+
+// ── paneRects geometry ──────────────────────────────────────────────────────
+{
+  // Single pane fills the viewport.
+  const r = paneRects(state(leaf("a")));
+  assert.deepEqual(r, [{ sessionId: "a", x: 0, y: 0, w: 100, h: 100 }]);
+}
+{
+  // Horizontal split → left/right halves.
+  const r = paneRects(state(hsplit(leaf("a"), leaf("b"))));
+  const a = r.find((x) => x.sessionId === "a");
+  const b = r.find((x) => x.sessionId === "b");
+  assert.deepEqual([a.x, a.w], [0, 50]);
+  assert.deepEqual([b.x, b.w], [50, 50]);
+  assert.equal(a.h, 100); assert.equal(b.h, 100);
+}
+{
+  // Vertical split → top/bottom halves.
+  const r = paneRects(state(vsplit(leaf("a"), leaf("b"))));
+  assert.deepEqual([rectOf(vsplit(leaf("a"), leaf("b")), "a").y, rectOf(vsplit(leaf("a"), leaf("b")), "a").h], [0, 50]);
+  assert.deepEqual([r.find((x) => x.sessionId === "b").y, r.find((x) => x.sessionId === "b").h], [50, 50]);
+}
+{
+  // Weighted children honor sizes (70/30).
+  const root = { kind: "horizontal", children: [{ size: 70, node: leaf("a") }, { size: 30, node: leaf("b") }] };
+  assert.equal(rectOf(root, "a").w, 70);
+  assert.equal(rectOf(root, "b").x, 70);
+  assert.equal(rectOf(root, "b").w, 30);
+}
+
+// ── directionalNeighbor: 2-pane horizontal ──────────────────────────────────
+{
+  const s = state(hsplit(leaf("a"), leaf("b")), "a");
+  assert.equal(directionalNeighbor(s, "a", "right"), "b");
+  assert.equal(directionalNeighbor(s, "b", "left"), "a");
+  assert.equal(directionalNeighbor(s, "a", "left"), null, "nothing left of leftmost");
+  assert.equal(directionalNeighbor(s, "a", "up"), null, "no vertical neighbor in a horizontal split");
+  assert.equal(directionalNeighbor(s, "b", "right"), null);
+}
+
+// ── directionalNeighbor: 2-pane vertical ────────────────────────────────────
+{
+  const s = state(vsplit(leaf("top"), leaf("bot")), "top");
+  assert.equal(directionalNeighbor(s, "top", "down"), "bot");
+  assert.equal(directionalNeighbor(s, "bot", "up"), "top");
+  assert.equal(directionalNeighbor(s, "top", "up"), null);
+  assert.equal(directionalNeighbor(s, "top", "left"), null);
+}
+
+// ── directionalNeighbor: 2×2 grid (rows of columns) ─────────────────────────
+{
+  //  TL TR
+  //  BL BR
+  const grid = vsplit(hsplit(leaf("TL"), leaf("TR")), hsplit(leaf("BL"), leaf("BR")));
+  const s = state(grid, "TL");
+  assert.equal(directionalNeighbor(s, "TL", "right"), "TR");
+  assert.equal(directionalNeighbor(s, "TL", "down"), "BL");
+  assert.equal(directionalNeighbor(s, "BR", "left"), "BL");
+  assert.equal(directionalNeighbor(s, "BR", "up"), "TR");
+  assert.equal(directionalNeighbor(s, "TR", "down"), "BR");
+  assert.equal(directionalNeighbor(s, "BL", "right"), "BR");
+  assert.equal(directionalNeighbor(s, "TL", "left"), null);
+  assert.equal(directionalNeighbor(s, "TL", "up"), null);
+}
+
+// ── directionalNeighbor: cross-axis overlap preference ──────────────────────
+{
+  // Left column is one tall pane "L"; right column is two stacked "RT"/"RB".
+  // Moving right from L should land on whichever right pane shares more height —
+  // they're equal here, so it picks the closer-gap/closer-center one (RT, the
+  // top, has center nearer L's center=50? both equidistant) — accept either of
+  // the two right panes, but moving right must NOT return null and must be a
+  // right-column pane.
+  const root = hsplit(leaf("L"), vsplit(leaf("RT"), leaf("RB")));
+  const s = state(root, "L");
+  const right = directionalNeighbor(s, "L", "right");
+  assert.ok(right === "RT" || right === "RB", `right of L is a right-column pane, got ${right}`);
+  // From RT, left is unambiguously L; up is null (top of its column).
+  assert.equal(directionalNeighbor(s, "RT", "left"), "L");
+  assert.equal(directionalNeighbor(s, "RT", "down"), "RB");
+  assert.equal(directionalNeighbor(s, "RT", "up"), null);
+}
+{
+  // Overlap tie-break: a wide bottom pane under two top panes — moving down from
+  // the top-LEFT pane should reach the bottom pane (full overlap), not null.
+  const root = vsplit(hsplit(leaf("TL"), leaf("TR")), leaf("B"));
+  const s = state(root, "TL");
+  assert.equal(directionalNeighbor(s, "TL", "down"), "B");
+  assert.equal(directionalNeighbor(s, "TR", "down"), "B");
+  assert.equal(directionalNeighbor(s, "B", "up"), "TL", "from wide bottom, up picks the most-overlapping top (TL spans 0–50, TR 50–100; ties → closest center → TL by sort stability)");
+}
+
+// ── unknown source id → null ────────────────────────────────────────────────
+{
+  const s = state(hsplit(leaf("a"), leaf("b")), "a");
+  assert.equal(directionalNeighbor(s, "ghost", "right"), null);
+  assert.equal(directionalNeighbor(state(null), "a", "right"), null);
+}
+
+// ── cycleVisibleSession ─────────────────────────────────────────────────────
+{
+  const s = state(hsplit(leaf("a"), leaf("b"), leaf("c")), "a");
+  assert.equal(cycleVisibleSession(s, "a", 1), "b");
+  assert.equal(cycleVisibleSession(s, "b", 1), "c");
+  assert.equal(cycleVisibleSession(s, "c", 1), "a", "next wraps to first");
+  assert.equal(cycleVisibleSession(s, "a", -1), "c", "prev wraps to last");
+  assert.equal(cycleVisibleSession(s, "b", -1), "a");
+  assert.equal(cycleVisibleSession(s, null, 1), "a", "null start → first going forward");
+  assert.equal(cycleVisibleSession(s, null, -1), "c", "null start → last going backward");
+  assert.equal(cycleVisibleSession(s, "ghost", 1), "a", "unknown start → first");
+}
+{
+  assert.equal(cycleVisibleSession(state(leaf("solo"), "solo"), "solo", 1), "solo", "single pane → itself");
+  assert.equal(cycleVisibleSession(state(null), null, 1), null, "no panes → null");
+}
+
+// ── pane numbers + quick jump ───────────────────────────────────────────────
+{
+  const s = state(hsplit(leaf("a"), leaf("b"), leaf("c")), "a");
+  const map = paneNumberMap(s);
+  assert.equal(map.get("a"), 1);
+  assert.equal(map.get("b"), 2);
+  assert.equal(map.get("c"), 3);
+  assert.equal(sessionAtPaneNumber(s, 1), "a");
+  assert.equal(sessionAtPaneNumber(s, 3), "c");
+  assert.equal(sessionAtPaneNumber(s, 4), null, "out of range → null");
+  assert.equal(sessionAtPaneNumber(s, 0), null);
+  assert.equal(sessionAtPaneNumber(s, 1.5), null, "non-integer → null");
+}
+
+console.log("terminal-nav.test.ts passed");

--- a/src/lib/terminal-nav.ts
+++ b/src/lib/terminal-nav.ts
@@ -1,0 +1,170 @@
+// Pure spatial + ordinal navigation over the comux pane tree. The terminal
+// surface needs tmux-grade movement — focus the pane to the left/right/up/down,
+// cycle through panes, and jump to pane N — without any of the rendering layer.
+// Everything here is computed from `TerminalLayoutState` (the same tree the view
+// renders) so it's deterministic and unit-testable with no DOM.
+
+import {
+  terminalLayoutVisibleSessionIds,
+  type TerminalLayoutNode,
+  type TerminalLayoutState,
+} from "./terminal-layout.ts";
+
+export type PaneRect = {
+  sessionId: string;
+  /** Percent-of-viewport geometry: x/y top-left, w/h extent (0–100). */
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+};
+
+export type PaneDirection = "left" | "right" | "up" | "down";
+
+/**
+ * Lay the pane tree out into percentage rectangles, mirroring how the resizable
+ * Group/Panel renderer splits space: a `horizontal` branch divides width by its
+ * children's sizes, a `vertical` branch divides height. Sizes are treated as
+ * weights (normalized), matching `equalize`/react-resizable-panels behavior.
+ */
+export function paneRects(state: TerminalLayoutState): PaneRect[] {
+  const out: PaneRect[] = [];
+  walk(state.root, 0, 0, 100, 100, out);
+  return out;
+}
+
+function walk(
+  node: TerminalLayoutNode | null,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  out: PaneRect[],
+): void {
+  if (!node) return;
+  if (node.kind === "leaf") {
+    out.push({ sessionId: node.sessionId, x, y, w, h });
+    return;
+  }
+  const total = node.children.reduce((sum, c) => sum + (c.size > 0 ? c.size : 0), 0);
+  const weight = total > 0 ? total : node.children.length || 1;
+  let cursor = node.kind === "horizontal" ? x : y;
+  for (const childEntry of node.children) {
+    const fraction = (childEntry.size > 0 ? childEntry.size : 0) / weight;
+    if (node.kind === "horizontal") {
+      const cw = w * fraction;
+      walk(childEntry.node, cursor, y, cw, h, out);
+      cursor += cw;
+    } else {
+      const ch = h * fraction;
+      walk(childEntry.node, x, cursor, w, ch, out);
+      cursor += ch;
+    }
+  }
+}
+
+function centerX(r: PaneRect): number {
+  return r.x + r.w / 2;
+}
+function centerY(r: PaneRect): number {
+  return r.y + r.h / 2;
+}
+
+/** Do two 1-D intervals [aStart,aEnd] and [bStart,bEnd] overlap, and by how much. */
+function overlap(aStart: number, aEnd: number, bStart: number, bEnd: number): number {
+  return Math.max(0, Math.min(aEnd, bEnd) - Math.max(aStart, bStart));
+}
+
+/**
+ * The nearest visible pane in `direction` from `fromSessionId`, or null when
+ * there's nothing that way. A candidate must lie on the correct side (its near
+ * edge is beyond the source's center along the axis); among those we prefer the
+ * one that overlaps the source's cross-axis span the most (so moving "right"
+ * from a tall pane lands on the pane sharing the most height), breaking ties by
+ * the smallest axis gap, then by cross-axis center distance.
+ */
+export function directionalNeighbor(
+  state: TerminalLayoutState,
+  fromSessionId: string,
+  direction: PaneDirection,
+): string | null {
+  const rects = paneRects(state);
+  const from = rects.find((r) => r.sessionId === fromSessionId);
+  if (!from) return null;
+
+  type Scored = { id: string; gap: number; cross: number; ocross: number };
+  const scored: Scored[] = [];
+
+  for (const r of rects) {
+    if (r.sessionId === fromSessionId) continue;
+    let onSide = false;
+    let gap = 0;
+    let crossOverlap = 0;
+    let crossDist = 0;
+
+    if (direction === "left") {
+      onSide = r.x + r.w <= from.x + 0.01 + from.w / 2 && centerX(r) < centerX(from);
+      gap = from.x - (r.x + r.w);
+      crossOverlap = overlap(r.y, r.y + r.h, from.y, from.y + from.h);
+      crossDist = Math.abs(centerY(r) - centerY(from));
+    } else if (direction === "right") {
+      onSide = r.x >= from.x + from.w / 2 - 0.01 && centerX(r) > centerX(from);
+      gap = r.x - (from.x + from.w);
+      crossOverlap = overlap(r.y, r.y + r.h, from.y, from.y + from.h);
+      crossDist = Math.abs(centerY(r) - centerY(from));
+    } else if (direction === "up") {
+      onSide = r.y + r.h <= from.y + 0.01 + from.h / 2 && centerY(r) < centerY(from);
+      gap = from.y - (r.y + r.h);
+      crossOverlap = overlap(r.x, r.x + r.w, from.x, from.x + from.w);
+      crossDist = Math.abs(centerX(r) - centerX(from));
+    } else {
+      onSide = r.y >= from.y + from.h / 2 - 0.01 && centerY(r) > centerY(from);
+      gap = r.y - (from.y + from.h);
+      crossOverlap = overlap(r.x, r.x + r.w, from.x, from.x + from.w);
+      crossDist = Math.abs(centerX(r) - centerX(from));
+    }
+
+    if (!onSide) continue;
+    scored.push({ id: r.sessionId, gap: Math.max(0, gap), cross: crossDist, ocross: crossOverlap });
+  }
+
+  if (scored.length === 0) return null;
+  scored.sort((a, b) => {
+    if (b.ocross !== a.ocross) return b.ocross - a.ocross; // most cross-axis overlap wins
+    if (a.gap !== b.gap) return a.gap - b.gap; // then the closest along the axis
+    return a.cross - b.cross; // then the closest cross-axis center
+  });
+  return scored[0].id;
+}
+
+/**
+ * The next/previous visible pane in document order, wrapping around. `delta` is
+ * +1 (next) or -1 (prev). Returns null when there are no panes; returns the
+ * same id when there's only one.
+ */
+export function cycleVisibleSession(
+  state: TerminalLayoutState,
+  fromSessionId: string | null,
+  delta: number,
+): string | null {
+  const ids = terminalLayoutVisibleSessionIds(state);
+  if (ids.length === 0) return null;
+  const step = delta < 0 ? -1 : 1;
+  const idx = fromSessionId ? ids.indexOf(fromSessionId) : -1;
+  if (idx < 0) return step > 0 ? ids[0] : ids[ids.length - 1];
+  const next = (idx + step + ids.length) % ids.length;
+  return ids[next];
+}
+
+/** 1-based pane numbers in visible document order, for badges + quick-jump. */
+export function paneNumberMap(state: TerminalLayoutState): Map<string, number> {
+  const map = new Map<string, number>();
+  terminalLayoutVisibleSessionIds(state).forEach((id, index) => map.set(id, index + 1));
+  return map;
+}
+
+/** The visible session at 1-based pane number `n` (⌘1…⌘9 quick-jump), or null. */
+export function sessionAtPaneNumber(state: TerminalLayoutState, n: number): string | null {
+  if (!Number.isInteger(n) || n < 1) return null;
+  return terminalLayoutVisibleSessionIds(state)[n - 1] ?? null;
+}


### PR DESCRIPTION
## What

Levels the comux terminal up to a world-class multi-paning experience by adding the multiplexer movement primitives it was missing. The pane tree, PTY transport, drag-to-split, and resize were already solid — this adds keyboard-driven **navigation and zoom** on top.

## New capabilities

| Shortcut | Action |
|---|---|
| `⌘⌥←/→/↑/↓` | Focus the geometrically-nearest pane in that direction |
| `⌘]` / `⌘[` | Cycle to the next / previous visible pane (wraps) |
| `⌘1`…`⌘9` | Jump to pane N (panes show a number badge) |
| `⌘⏎` | Zoom/maximize the active pane (siblings stay alive); toggles back |

- Pane bars gain a **number badge** and a **zoom/restore button**.
- **Zoom follows focus** — navigating while zoomed moves the maximized pane.
- The keyboard-hint footer advertises the new chords.

## How

- New pure, DOM-free `src/lib/terminal-nav.ts` computes everything from the existing `TerminalLayoutState`:
  - `paneRects` lays the tree into percentage rectangles (mirrors the resizable Group/Panel split math, honoring child sizes).
  - `directionalNeighbor` picks the nearest pane in a direction — most cross-axis overlap, then smallest axis gap, then nearest center.
  - `cycleVisibleSession`, `paneNumberMap`, `sessionAtPaneNumber` back cycling, badges, and quick-jump.
- `comux-view.tsx` adds a ⌘/Ctrl-gated keydown effect + a `zoomedSessionId` render branch. Shortcuts skip `contentEditable` and shell-owned Ctrl chords inside `.xterm`, so they never steal keystrokes from the terminal.

## Tests

- `terminal-nav.test.ts` — exhaustive pure logic: single/split/grid/weighted geometry, all directions, edges→null, cross-axis overlap tie-breaks, cycle wrap, quick-jump bounds.
- `comux-pane-nav-wiring.test.ts` — locks the view integration (each shortcut, zoom render, badge, footer, CSS).

Both registered in `run-tests.mjs`. Full `test:app` (351 files) + `tsc --noEmit` pass locally.

Note: this is the first of a planned arc — broadcast-input (type once → all panes) and keyboard pane-resize are natural follow-ups on this foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)