### PR TITLE
feat(journal): filter the entries list by date, content, and familiar

### DIFF
--- a/src/components/journal/journal-entries.tsx
+++ b/src/components/journal/journal-entries.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { EmptyState } from "@/components/ui/empty-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
@@ -63,12 +63,34 @@ export function JournalEntries({
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState("");
   const selectedFamiliarId = activeFamiliarId ?? familiars[0]?.id ?? null;
 
   const familiarName = useCallback(
     (id: string | null) => (id ? familiars.find((f) => f.id === id)?.display_name ?? id : null),
     [familiars],
   );
+
+  // Client-side filter over the day list — matches the date (slug + human
+  // labels), the preview text, and the reflecting familiar's name.
+  const filteredDays = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return days;
+    const now = new Date();
+    return days.filter((d) => {
+      const dateObj = parseDateSlug(d.date) ?? now;
+      const hay = [
+        d.date,
+        longDateLabel(dateObj),
+        relativeDayLabel(dateObj, now),
+        d.preview ?? "",
+        familiarName(d.reflectedBy) ?? "",
+      ]
+        .join(" ")
+        .toLowerCase();
+      return hay.includes(q);
+    });
+  }, [days, filter, familiarName]);
 
   const loadDays = useCallback(async () => {
     try {
@@ -213,13 +235,25 @@ export function JournalEntries({
           </div>
         ) : null}
         <div className="journal-list__cap">Your days</div>
+        {days.length > 0 ? (
+          <input
+            type="search"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Filter entries…"
+            aria-label="Filter journal entries"
+            className="journal-list__filter focus-ring-inset"
+          />
+        ) : null}
         {!daysLoaded && days.length === 0 ? (
           <SkeletonRows count={4} className="journal-list__loading" />
         ) : days.length === 0 ? (
           <div className="journal-empty">No journal entries yet. Generate today's above.</div>
+        ) : filteredDays.length === 0 ? (
+          <div className="journal-empty">No entries match “{filter.trim()}”.</div>
         ) : (
           <ul className="journal-list__items">
-            {days.map((d) => (
+            {filteredDays.map((d) => (
               <li key={d.date}>
                 <button
                   type="button"

--- a/src/styles/journal.css
+++ b/src/styles/journal.css
@@ -98,6 +98,22 @@
   color: var(--text-muted);
   margin: 4px 2px 2px;
 }
+.journal-list__filter {
+  width: 100%;
+  margin: 2px 0 8px;
+  padding: 6px 10px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 8px;
+  background: color-mix(in oklch, var(--bg-raised) 60%, transparent);
+  font-size: 12.5px;
+  color: var(--text-primary);
+  transition: border-color 0.12s ease, background 0.12s ease;
+}
+.journal-list__filter::placeholder { color: var(--text-muted); }
+.journal-list__filter:focus-visible {
+  border-color: color-mix(in oklch, var(--accent-presence) 50%, transparent);
+  background: var(--bg-raised);
+}
 .journal-list__items { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
 .journal-art {
   width: 100%;


### PR DESCRIPTION
## What

The Journal's **"Your days"** list (`journal-entries.tsx`) was scroll-only — no way to find a past reflection. It's the one content log in the app you couldn't search (chat, terminal, library, ⌘K, and the Code workspace all have find). Adds a filter box above the list.

## How

A `filteredDays` `useMemo` over the already-loaded day summaries, matched against a combined haystack: the date (slug + `longDateLabel` + `relativeDayLabel`), the `preview` text, and the reflecting familiar's name. Pure client-side; a no-match state mirrors the empty state. `.journal-list__filter` styled to match the list rail.

## Verification

- `pnpm typecheck` clean, `pnpm test:app` → 349 pass (incl. journal-view.test.ts), `pnpm build` green.
- Live (served build, **real** data): the "Filter entries…" box renders above "Your days"; typing a non-matching query narrows to 0 with "No entries match …"; clearing restores the list. Screenshot confirms.

Note: a headless-mock drive initially crashed on a pre-existing line (`day.entry.reflection.trim()` when the mocked `day` lacked `entry`) — confirmed identical on clean main, i.e. a test-data-shape artifact, not this change; real data renders cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)