### PR TITLE
style(nav): double the sidepanel and top-bar icons (×2 of original)

### DIFF
--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -95,7 +95,7 @@ export function FamiliarMenuBar({
           onOpenSearch();
         }}
       >
-        <Icon name="ph:magnifying-glass" width={18} className="menu-bar__search-icon" aria-hidden />
+        <Icon name="ph:magnifying-glass" width={26} className="menu-bar__search-icon" aria-hidden />
         <input
           type="search"
           className="menu-bar__search-input"
@@ -119,7 +119,7 @@ export function FamiliarMenuBar({
             aria-label={enrichingTasks ? `Enhancing tasks ${enrichLabel}` : activeFamiliarId ? ENRICH_TASKS_TITLE : "Select a familiar to enhance tasks"}
             title={activeFamiliarId ? ENRICH_TASKS_TITLE : "Select a familiar to enhance tasks"}
           >
-            <Icon name="ph:sparkle" width={21} aria-hidden />
+            <Icon name="ph:sparkle" width={30} aria-hidden />
             <span>{enrichingTasks ? enrichLabel : "Enhance"}</span>
           </button>
         ) : null}
@@ -129,7 +129,7 @@ export function FamiliarMenuBar({
           onClick={onViewTasks}
           aria-label={taskCount > 0 ? `View tasks — ${taskCount} open` : "View tasks"}
         >
-          <Icon name="ph:kanban" width={21} aria-hidden />
+          <Icon name="ph:kanban" width={30} aria-hidden />
           <span>Tasks</span>
           {taskCount > 0 ? <span className="menu-bar__badge">{fmtBadge(taskCount)}</span> : null}
         </button>
@@ -139,7 +139,7 @@ export function FamiliarMenuBar({
           onClick={onViewInbox}
           aria-label={inboxCount > 0 ? `View inbox — ${inboxCount} need attention` : "View inbox"}
         >
-          <Icon name="ph:tray" width={21} aria-hidden />
+          <Icon name="ph:tray" width={30} aria-hidden />
           <span>Inbox</span>
           {inboxCount > 0 ? (
             <span className="menu-bar__badge menu-bar__badge--alert">{fmtBadge(inboxCount)}</span>

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -145,7 +145,7 @@ function SidebarSection({
           <span className="sidebar-section-label__text">{label}</span>
           <Icon
             name="ph:caret-down-bold"
-            width="0.98rem"
+            width="1.4rem"
             className={`sidebar-section-label__chevron${collapsed ? " sidebar-section-label__chevron--collapsed" : ""}`}
           />
         </button>
@@ -190,7 +190,7 @@ function FolderRow({
       title={title}
       onClick={onClick}
     >
-      <Icon name={iconName} width={21} className="sidebar-folder-icon" />
+      <Icon name={iconName} width={30} className="sidebar-folder-icon" />
       <span className="sidebar-folder-label">{label}</span>
       {badge && <span className="sidebar-badge">{badge}</span>}
       {/* The ⌘-number shortcut is no longer shown as a chip here: the numbers
@@ -253,7 +253,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
 
       <div className="sidebar-actions">
         <button type="button" className="sidebar-action-row focus-ring" onClick={onNewChat} title="New chat">
-          <Icon name="ph:note-pencil" width={22} aria-hidden />
+          <Icon name="ph:note-pencil" width={32} aria-hidden />
           <span>New chat</span>
         </button>
       </div>
@@ -307,7 +307,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
           title="Dashboard — activity overview and daily reports"
         >
           <span className="sidebar-foot-icon-cell" aria-hidden="true">
-            <Icon name="ph:squares-four" width={20} className="sidebar-foot-icon" />
+            <Icon name="ph:squares-four" width={28} className="sidebar-foot-icon" />
           </span>
           <span className="sidebar-foot-label">Dashboard</span>
         </a>
@@ -322,7 +322,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
             <span className="sidebar-foot-icon-cell" aria-hidden="true">
               <Icon
                 name={unreadCount > 0 ? "ph:bell-fill" : "ph:bell"}
-                width={20}
+                width={28}
                 className="sidebar-foot-icon"
               />
             </span>
@@ -342,7 +342,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
           title="Settings"
         >
           <span className="sidebar-foot-icon-cell" aria-hidden="true">
-            <Icon name="ph:gear-six" width={20} className="sidebar-foot-icon" />
+            <Icon name="ph:gear-six" width={28} className="sidebar-foot-icon" />
           </span>
           <span className="sidebar-foot-label">Settings</span>
         </button>

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -118,7 +118,7 @@ export function TopBar(props: Props) {
             aria-controls="nav"
             title={navDrawerOpen ? "Close navigation" : "Open navigation"}
           >
-            <Icon name="ph:sidebar-simple" width={25} />
+            <Icon name="ph:sidebar-simple" width={36} />
           </button>
         ) : null}
         {onToggleList ? (
@@ -132,7 +132,7 @@ export function TopBar(props: Props) {
             aria-controls="list"
             title={listDrawerOpen ? "Close list" : "Open list"}
           >
-            <Icon name="ph:list-checks-bold" width={25} />
+            <Icon name="ph:list-checks-bold" width={36} />
           </button>
         ) : null}
       </div>
@@ -150,7 +150,7 @@ export function TopBar(props: Props) {
           onOpenPalette();
         }}
       >
-        <Icon name="ph:magnifying-glass" width={17} className="top-bar__search-icon" />
+        <Icon name="ph:magnifying-glass" width={24} className="top-bar__search-icon" />
         <input
           type="search"
           className="top-bar__search-input"
@@ -185,7 +185,7 @@ export function TopBar(props: Props) {
             aria-label={activeFamiliar ? enrichLabel : "Select a familiar to enhance tasks"}
             title={activeFamiliar ? ENRICH_TASKS_TITLE : "Select a familiar to enhance tasks"}
           >
-            <Icon name="ph:sparkle" width={21} />
+            <Icon name="ph:sparkle" width={30} />
           </button>
         ) : null}
         {onViewTasks ? (
@@ -196,7 +196,7 @@ export function TopBar(props: Props) {
             aria-label={taskCount && taskCount > 0 ? `View tasks — ${taskCount} open` : "View tasks"}
             title="View tasks"
           >
-            <Icon name="ph:kanban" width={21} />
+            <Icon name="ph:kanban" width={30} />
             {taskCount && taskCount > 0 ? (
               <span className="top-bar__tasks-badge">{taskCount > 99 ? "99+" : taskCount}</span>
             ) : null}
@@ -209,7 +209,7 @@ export function TopBar(props: Props) {
           aria-label="Open on phone"
           title="Open on phone"
         >
-          <Icon name="ph:device-mobile" width={20} />
+          <Icon name="ph:device-mobile" width={28} />
         </button>
         <NotificationBell
           items={inboxItems}
@@ -227,7 +227,7 @@ export function TopBar(props: Props) {
           aria-label="Account / settings"
           title="Settings (⌘,)"
         >
-          <Icon name="ph:user" width={18} />
+          <Icon name="ph:user" width={26} />
         </button>
         {onToggleFamiliar ? (
           <button
@@ -240,7 +240,7 @@ export function TopBar(props: Props) {
             aria-controls="agent"
             title={familiarDrawerOpen ? "Close familiar panel" : "Open familiar panel"}
           >
-            <Icon name="ph:cat" width={25} />
+            <Icon name="ph:cat" width={36} />
           </button>
         ) : null}
       </div>


### PR DESCRIPTION
Follow-up to the icon-enlargement arc (#1499 +20% → #1512 +40%): bumps the sidepanel / header / top-bar icons to **2× their original size** (`round(original × 2)`), the clean next step in that progression.

- **sidebar**: folder 30, new-chat 32, footer 28, section caret 1.4rem
- **desktop menu bar**: search 26, Enhance/Tasks/Inbox 30
- **mobile top bar**: sidebar/tasks/cat 36, search 24, Enhance/Tasks 30, device 28, user 26

## Verification
`pnpm typecheck` clean; `pnpm test:app` **350/350**. Screenshotted both the desktop sidebar and the mobile top bar — the larger icons render cleanly and the rows/button cells accommodate them without breaking layout or alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)