### PR TITLE
feat(comux): broadcast input — type once, mirror to every pane

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -152,6 +152,7 @@ export const SUITES = {
     "src/lib/terminal-layout.test.ts",
     "src/lib/terminal-nav.test.ts",
     "src/lib/terminal-broadcast.test.ts",
+    "src/components/comux-broadcast-wiring.test.ts",
     "src/components/comux-pane-nav-wiring.test.ts",
     "src/components/library-polish.test.ts",
     "src/components/library-file-actions.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -151,6 +151,7 @@ export const SUITES = {
     "src/lib/tool-target-file.test.ts",
     "src/lib/terminal-layout.test.ts",
     "src/lib/terminal-nav.test.ts",
+    "src/lib/terminal-broadcast.test.ts",
     "src/components/comux-pane-nav-wiring.test.ts",
     "src/components/library-polish.test.ts",
     "src/components/library-file-actions.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2224,6 +2224,24 @@ select {
   color: var(--accent-presence);
 }
 
+/* Broadcast ("sync panes") mode: the toolbar toggle lights up and every pane
+   gets a warm ring, so it's unmistakable that a keystroke fans out to all
+   panes. The active pane keeps its accent top hairline atop the warm ring. */
+.comux-terminal-toolbar-button[data-broadcast-active="true"] {
+  background: color-mix(in oklch, var(--color-warning) 20%, transparent);
+  color: var(--color-warning);
+}
+
+.comux-terminal-pane[data-broadcast="true"] {
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--color-warning) 45%, transparent);
+}
+
+.comux-terminal-pane[data-broadcast="true"][data-active="true"] {
+  box-shadow:
+    inset 0 0 0 1px color-mix(in oklch, var(--color-warning) 60%, transparent),
+    inset 0 1.5px 0 0 color-mix(in oklch, var(--accent-presence) 55%, transparent);
+}
+
 .comux-terminal-pane-action:hover {
   background: var(--bg-hover);
   color: var(--text-primary);

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -55,11 +55,32 @@ export function BottomTerminal({
   threadId,
   active = true,
   projectRoot,
+  paneId,
+  registerWriter,
+  onUserInput,
 }: {
   threadId: string;
   active?: boolean;
   projectRoot?: string;
+  /** Stable id for comux's broadcast registry (defaults to threadId). */
+  paneId?: string;
+  /** Register/unregister this pane's PTY writer so broadcast can fan input in. */
+  registerWriter?: (paneId: string, write: ((data: string) => void) | null) => void;
+  /** Called with every keystroke (post Ctrl-transform) so comux can mirror it
+   *  to sibling panes when broadcast mode is on. */
+  onUserInput?: (paneId: string, data: string) => void;
 }) {
+  const broadcastPaneId = paneId ?? threadId;
+  // Writer set by whichever transport (Tauri / WS) is live; the registered
+  // wrapper reads this ref at call time so registration can precede attach.
+  const writerRef = useRef<((data: string) => void) | null>(null);
+  const onUserInputRef = useRef(onUserInput);
+  onUserInputRef.current = onUserInput;
+  useEffect(() => {
+    if (!registerWriter) return;
+    registerWriter(broadcastPaneId, (data: string) => writerRef.current?.(data));
+    return () => registerWriter(broadcastPaneId, null);
+  }, [registerWriter, broadcastPaneId]);
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const fitRef = useRef<(() => void) | null>(null);
   const termRef = useRef<import("@xterm/xterm").Terminal | null>(null);
@@ -343,7 +364,13 @@ export function BottomTerminal({
           threadId: threadId,
           bytes: Array.from(new TextEncoder().encode(out)),
         }).catch((err) => log("pty_write FAILED", err));
+        onUserInputRef.current?.(broadcastPaneId, out);
       });
+      writerRef.current = (d) =>
+        void bridge.invoke("pty_write", {
+          threadId: threadId,
+          bytes: Array.from(new TextEncoder().encode(d)),
+        }).catch((err) => log("pty_write FAILED", err));
 
       if (!attachToRunning) {
         log("pty_start: invoking with projectRoot=", projectRootRef.current);
@@ -581,7 +608,9 @@ export function BottomTerminal({
           return;
         }
         bridge.write(new TextEncoder().encode(data));
+        onUserInputRef.current?.(broadcastPaneId, data);
       });
+      writerRef.current = (d) => bridge.write(new TextEncoder().encode(d));
 
       const doResize = () => {
         try {

--- a/src/components/comux-broadcast-wiring.test.ts
+++ b/src/components/comux-broadcast-wiring.test.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+// Locks broadcast-input ("sync panes") wiring across comux-view + BottomTerminal
+// so the fan-out path (register writer → mirror keystroke to siblings) can't be
+// silently dropped.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const comux = readFileSync(new URL("./comux-view.tsx", import.meta.url), "utf8");
+const term = readFileSync(new URL("./bottom-terminal.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+
+// comux: state, registry, stable handlers using the pure helper.
+assert.match(comux, /from "@\/lib\/terminal-broadcast"/, "imports the broadcast helper");
+assert.match(comux, /const \[broadcast, setBroadcast\] = useState\(false\)/, "broadcast state");
+assert.match(comux, /paneWritersRef = useRef\(new Map<string, \(data: string\) => void>\(\)\)/, "writer registry");
+assert.match(comux, /const registerPaneWriter = useCallback\(/, "registerPaneWriter");
+assert.match(comux, /broadcastTargetIds\(\[\.\.\.paneWritersRef\.current\.keys\(\)\], originSessionId\)/, "fan-out uses the pure helper over registered panes");
+assert.match(comux, /if \(!broadcastRef\.current\) return;/, "input handler no-ops when broadcast is off");
+
+// comux: ⌘⇧B toggle.
+assert.match(comux, /e\.shiftKey && \(e\.key === "b" \|\| e\.key === "B"\)[\s\S]{0,80}setBroadcast\(\(v\) => !v\)/, "⌘⇧B toggles broadcast");
+
+// comux: visible pane wires the broadcast props (and ONLY the visible pane —
+// the hidden keepalive stays active={false} with no broadcast props).
+assert.match(comux, /active=\{active && isActive\}[\s\S]{0,160}paneId=\{s\.id\}[\s\S]{0,80}registerWriter=\{registerPaneWriter\}[\s\S]{0,80}onUserInput=\{handlePaneInput\}/, "visible pane registers + emits input");
+
+// comux: discoverable toggle button + sync ring + footer hint.
+assert.match(comux, /data-broadcast-active=\{broadcast \? "true" : undefined\}/, "toolbar toggle reflects state");
+assert.match(comux, /data-broadcast=\{broadcast \? "true" : undefined\}/, "pane carries the broadcast flag for the ring");
+assert.match(comux, /⌘⇧B broadcast/, "footer advertises ⌘⇧B");
+
+// BottomTerminal: props + writer + input emit on BOTH transports.
+assert.match(term, /registerWriter\?: \(paneId: string, write: \(\(data: string\) => void\) \| null\) => void/, "registerWriter prop");
+assert.match(term, /onUserInput\?: \(paneId: string, data: string\) => void/, "onUserInput prop");
+assert.match(term, /const writerRef = useRef<\(\(data: string\) => void\) \| null>\(null\)/, "writer ref");
+assert.match(term, /registerWriter\(broadcastPaneId, \(data: string\) => writerRef\.current\?\.\(data\)\)/, "registers a stable writer wrapper");
+// Two emit sites (Tauri pty_write + WS bridge.write) and two writer assignments.
+assert.equal((term.match(/onUserInputRef\.current\?\.\(broadcastPaneId,/g) || []).length, 2, "emits user input on both transports");
+assert.equal((term.match(/writerRef\.current = \(d\) =>/g) || []).length, 2, "exposes a writer on both transports");
+
+// CSS for the broadcast ring/toggle exists.
+assert.match(css, /\.comux-terminal-pane\[data-broadcast="true"\]/, "broadcast pane ring styled");
+assert.match(css, /\.comux-terminal-toolbar-button\[data-broadcast-active="true"\]/, "broadcast toggle styled");
+
+console.log("comux-broadcast-wiring.test.ts passed");

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -55,6 +55,7 @@ import {
   sessionAtPaneNumber,
   type PaneDirection,
 } from "@/lib/terminal-nav";
+import { broadcastTargetIds } from "@/lib/terminal-broadcast";
 import type { SessionRow } from "@/lib/types";
 
 type ComuxViewMode = "terminal" | "projects";
@@ -469,6 +470,31 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   // its siblings stay alive (PTYs untouched) behind it. 1-based pane numbers
   // back the badges + ⌘1…9 quick-jump.
   const [zoomedSessionId, setZoomedSessionId] = useState<string | null>(null);
+
+  // Broadcast input ("sync panes"): a keystroke in any pane is mirrored to every
+  // other live pane. Each BottomTerminal registers its PTY writer; refs keep the
+  // input handler stable so toggling broadcast never re-mounts a pane.
+  const [broadcast, setBroadcast] = useState(false);
+  const broadcastRef = useRef(false);
+  broadcastRef.current = broadcast;
+  const paneWritersRef = useRef(new Map<string, (data: string) => void>());
+  const registerPaneWriter = useCallback(
+    (paneSessionId: string, write: ((data: string) => void) | null) => {
+      if (write) paneWritersRef.current.set(paneSessionId, write);
+      else paneWritersRef.current.delete(paneSessionId);
+    },
+    [],
+  );
+  const handlePaneInput = useCallback((originSessionId: string, data: string) => {
+    if (!broadcastRef.current) return;
+    for (const id of broadcastTargetIds([...paneWritersRef.current.keys()], originSessionId)) {
+      try {
+        paneWritersRef.current.get(id)?.(data);
+      } catch {
+        /* pane unmounted mid-broadcast — drop it */
+      }
+    }
+  }, []);
   const paneNumbers = useMemo(() => paneNumberMap(terminalLayout), [terminalLayout]);
   useEffect(() => {
     if (zoomedSessionId && !visiblePaneSessionIds.includes(zoomedSessionId)) {
@@ -583,6 +609,11 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
         if (dir && activeId) {
           focusPane(directionalNeighbor(terminalLayout, activeId, dir));
         }
+        return;
+      }
+      if (e.shiftKey && (e.key === "b" || e.key === "B")) {
+        e.preventDefault();
+        setBroadcast((v) => !v);
         return;
       }
       if (e.shiftKey) return;
@@ -967,6 +998,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
             className="comux-terminal-pane"
             data-terminal-pane-id={s.id}
             data-active={isActive ? "true" : undefined}
+            data-broadcast={broadcast ? "true" : undefined}
             onClick={() => focusSessionById(s.id)}
           >
             <div
@@ -1033,6 +1065,9 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                 threadId={`cave.comux.${s.id}`}
                 active={active && isActive}
                 projectRoot={s.projectRoot ?? selectedProjectRoot ?? daemonProjectRoot}
+                paneId={s.id}
+                registerWriter={registerPaneWriter}
+                onUserInput={handlePaneInput}
               />
             </div>
           </div>
@@ -1083,6 +1118,9 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
       splitSessionIntoPane,
       visiblePaneCount,
       zoomedSessionId,
+      broadcast,
+      handlePaneInput,
+      registerPaneWriter,
     ],
   );
 
@@ -1171,6 +1209,18 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
               </div>
               <button
                 type="button"
+                onClick={() => setBroadcast((v) => !v)}
+                aria-pressed={broadcast}
+                disabled={visiblePaneCount < 2 && !broadcast}
+                className="comux-terminal-toolbar-button inline-flex items-center gap-1 rounded-[5px] px-1.5 py-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] disabled:pointer-events-none disabled:opacity-40"
+                data-broadcast-active={broadcast ? "true" : undefined}
+                title="Broadcast input to all panes (⌘⇧B)"
+              >
+                <Icon name="ph:share-network" width={12} aria-hidden />
+                <span>{broadcast ? "Broadcasting" : "Broadcast"}</span>
+              </button>
+              <button
+                type="button"
                 onClick={() => addSession()}
                 aria-label="New terminal"
                 title="New terminal (⌘N)"
@@ -1225,7 +1275,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
             )}
           </div>
           <footer className="shrink-0 border-t border-[var(--border-hairline)] px-3 py-1.5 text-center text-[10px] text-[var(--text-muted)]">
-            ⌘N new · ⌘W close · drag tabs or pane bars onto pane edges to split &amp; reorganize · drag dividers to resize · ⌘⌥arrows focus · ⌘[ ⌘] cycle · ⌘1–9 jump · ⌘⏎ zoom
+            ⌘N new · ⌘W close · drag tabs or pane bars onto pane edges to split &amp; reorganize · drag dividers to resize · ⌘⌥arrows focus · ⌘[ ⌘] cycle · ⌘1–9 jump · ⌘⏎ zoom · ⌘⇧B broadcast
           </footer>
         </div>
       ) : (

--- a/src/lib/terminal-broadcast.test.ts
+++ b/src/lib/terminal-broadcast.test.ts
@@ -1,0 +1,17 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { broadcastTargetIds, broadcastIsActionable } from "./terminal-broadcast.ts";
+
+assert.deepEqual(broadcastTargetIds(["a", "b", "c"], "a"), ["b", "c"]);
+assert.deepEqual(broadcastTargetIds(["a", "b", "c"], "b"), ["a", "c"]);
+assert.deepEqual(broadcastTargetIds(["solo"], "solo"), [], "no targets when origin is the only pane");
+assert.deepEqual(broadcastTargetIds([], "a"), []);
+assert.deepEqual(broadcastTargetIds(["a", "b", "b", "c", "a"], "a"), ["b", "c"]);
+assert.deepEqual(broadcastTargetIds(["a", "", "b"], "a"), ["b"]);
+assert.deepEqual(broadcastTargetIds(["a", "b"], "ghost"), ["a", "b"]);
+assert.equal(broadcastIsActionable(true, 2), true);
+assert.equal(broadcastIsActionable(true, 1), false, "single pane → nothing to broadcast to");
+assert.equal(broadcastIsActionable(false, 5), false, "disabled → never");
+assert.equal(broadcastIsActionable(true, 0), false);
+
+console.log("terminal-broadcast.test.ts passed");

--- a/src/lib/terminal-broadcast.ts
+++ b/src/lib/terminal-broadcast.ts
@@ -1,0 +1,27 @@
+// Pure helper for broadcast-input ("sync panes") mode: when a keystroke is typed
+// in one pane, it is mirrored to every OTHER live pane. The origin pane has
+// already written to its own PTY, so it must be excluded to avoid a double
+// write. Kept DOM-free so the fan-out target selection is unit-testable.
+
+/**
+ * The pane ids that should receive a mirrored keystroke originating in
+ * `originId`: every id except the origin, de-duplicated, in input order.
+ */
+export function broadcastTargetIds(
+  paneIds: readonly string[],
+  originId: string,
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of paneIds) {
+    if (!id || id === originId || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
+/** Broadcast only does something useful with two or more live panes. */
+export function broadcastIsActionable(enabled: boolean, paneCount: number): boolean {
+  return enabled && paneCount > 1;
+}


### PR DESCRIPTION
## What

The flagship multi-pane power feature, completing the comux upgrade arc (after #1525's directional focus / cycle / quick-jump / zoom): **broadcast input** — the classic tmux `synchronize-panes`.

Toggle it with **⌘⇧B** (or the toolbar **Broadcast** button) and a keystroke in any pane fans out to every other live pane at once — type a command once, run it in all your shells.

## How

- Each visible `BottomTerminal` registers its PTY **writer** in a comux registry and reports keystrokes (post Ctrl-transform) via `onUserInput`, on **both** transports (Tauri `pty_write` + the WebSocket bridge).
- When broadcast is on, the origin pane's input is mirrored to every *other* registered pane (the origin already wrote its own PTY — no double-write). Registry-based, so toggling broadcast never re-mounts a pane or drops scrollback.
- Hidden keepalive panes don't register, so broadcast targets exactly the visible split.
- A warm ring on every pane + a lit toolbar toggle make the mode unmistakable; the footer advertises ⌘⇧B.

Fan-out target selection is the pure, exhaustively-tested `broadcastTargetIds` (origin excluded, de-duped).

## Tests

- `terminal-broadcast.test.ts` — pure target selection (origin exclusion, dedupe, single-pane, actionable).
- `comux-broadcast-wiring.test.ts` — locks the integration: registry + `⌘⇧B` + the visible-pane props + dual-transport emit/writer + the toggle/ring CSS.

Both registered in `run-tests.mjs`. Full `test:app` (354) + `tsc --noEmit` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)