### PR TITLE
feat(calendar): click an empty time slot to add an event there

### DIFF
--- a/src/components/calendar-view-polish.test.ts
+++ b/src/components/calendar-view-polish.test.ts
@@ -43,14 +43,14 @@ assert.match(
 // ───────── Task 3: Week view always renders TimeGrid ─────────
 assert.match(
   source,
-  /function WeekView\([\s\S]*?<TimeGrid columns=\{columns\} onOpenItem=\{onOpenItem\} \/>/,
+  /function WeekView\([\s\S]*?<TimeGrid columns=\{columns\} onOpenItem=\{onOpenItem\}/,
   "WeekView must always render TimeGrid",
 );
 
 // ───────── Task 4: Today indicator ─────────
 assert.match(
   source,
-  /col\.isToday\s*\?\s*"flex-1 relative min-w-\[80px\] bg-\[color-mix\(in_oklch,var\(--accent-presence\)_6%,transparent\)\]"\s*:\s*"flex-1 relative min-w-\[80px\]"/,
+  /col\.isToday \? "bg-\[color-mix\(in_oklch,var\(--accent-presence\)_6%,transparent\)\]" : ""/,
   "TimeGrid column body must tint today's column with accent-presence at 6%",
 );
 assert.match(

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -403,9 +403,11 @@ const HOUR_HEIGHT = 56;
 function TimeGrid({
   columns,
   onOpenItem,
+  onAddEntry,
 }: {
   columns: { label: string; date: Date; isToday: boolean; items: InboxItem[] }[];
   onOpenItem?: (item: InboxItem) => void;
+  onAddEntry?: (defaults?: { fireAt?: string; title?: string; whenText?: string }) => void;
 }) {
   const nowRef = useRef<HTMLDivElement>(null);
   const gridRef = useRef<HTMLDivElement | null>(null);
@@ -452,10 +454,24 @@ function TimeGrid({
         {columns.map((col, ci) => (
           <div
             key={ci}
-            className={col.isToday
-              ? "flex-1 relative min-w-[80px] bg-[color-mix(in_oklch,var(--accent-presence)_6%,transparent)]"
-              : "flex-1 relative min-w-[80px]"}
+            className={`calendar-daycol flex-1 relative min-w-[80px] ${
+              col.isToday ? "bg-[color-mix(in_oklch,var(--accent-presence)_6%,transparent)]" : ""
+            } ${onAddEntry ? "cursor-pointer" : ""}`}
             style={{ height: totalHeight }}
+            title={onAddEntry ? "Click an empty slot to add an event" : undefined}
+            onClick={
+              onAddEntry
+                ? (e) => {
+                    // Clicking an existing event opens it; only empty slots create.
+                    if ((e.target as HTMLElement).closest("[data-calendar-event]")) return;
+                    const rect = e.currentTarget.getBoundingClientRect();
+                    const hour = Math.max(0, Math.min(23, Math.floor((e.clientY - rect.top) / HOUR_HEIGHT)));
+                    const slot = new Date(col.date);
+                    slot.setHours(hour, 0, 0, 0);
+                    onAddEntry({ fireAt: slot.toISOString() });
+                  }
+                : undefined
+            }
           >
             {/* Hour lines */}
             {HOURS.map((h) => (
@@ -576,7 +592,7 @@ function DayView({
       )}
       {/* Time grid — always rendered for visual parity with Week */}
       <div className="relative flex flex-1 overflow-hidden">
-        <TimeGrid columns={columns} onOpenItem={onOpenItem} />
+        <TimeGrid columns={columns} onOpenItem={onOpenItem} onAddEntry={onAddEntry} />
       </div>
     </div>
   );
@@ -666,7 +682,7 @@ function WeekView({
         <AllDayStrip columns={allDayColumns} onOpenItem={onOpenItem} />
       )}
       <div className="relative flex flex-1 overflow-hidden">
-        <TimeGrid columns={columns} onOpenItem={onOpenItem} />
+        <TimeGrid columns={columns} onOpenItem={onOpenItem} onAddEntry={onAddEntry} />
       </div>
     </div>
   );


### PR DESCRIPTION
## What

In the Calendar's Day/Week views the hour grid wasn't clickable to create — adding an event meant the toolbar button (defaulted to the anchor day's time, then you adjust). The most common calendar gesture — *click 3pm Thursday to make an event there* — was missing.

Now clicking an empty slot in a day column opens the new-entry modal **pre-filled with that day and hour**.

## How

`TimeGrid`'s day columns get an `onClick` that computes the hour from the click offset (`(clientY − columnTop) ÷ HOUR_HEIGHT`) and calls the existing `onAddEntry({ fireAt })` — the same path the toolbar button uses, which opens the reminder modal pre-filled. Clicking an existing event still opens it (guarded by `data-calendar-event`). `onAddEntry` is threaded through DayView/WeekView into TimeGrid; columns get `cursor-pointer` + a title hint.

This stays compatible with the "single labeled Add-event button" rule (#calendar polish) — it's a transparent click handler, not another visible "Add event" button/overlay.

## Verification

- `pnpm typecheck` clean, `pnpm test:app` → 352 pass (updated two TimeGrid/today-column source pins for the refactor), `pnpm build` green.
- Live (served build): Week view → clicking a slot in the 3rd day column opened the New-reminder modal prefilled with **06/23/2026, 03:00** ("Remind Tue, Jun 23, 3:00 AM") — the column's day + the hour from the click position. Screenshot confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)