### PR TITLE
style(nav): enlarge the sidepanel labels to match the bigger icons

### DIFF
--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -106,7 +106,7 @@
   border: none;
   background: transparent;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: 18px;
   cursor: pointer;
   text-align: left;
   transition: background 0.1s ease, color 0.1s ease;
@@ -411,7 +411,7 @@
   background: transparent;
   border: 1px solid transparent;
   font-family: inherit;
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -478,7 +478,7 @@
   border: none;
   background: transparent;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: 18px;
   cursor: pointer;
   text-align: left;
   transition: background 0.1s ease, color 0.1s ease;


### PR DESCRIPTION
Follow-up to #1536 (40px nav icons): the 13px labels looked dwarfed, so bump them.

- nav item labels (`.sidebar-folder-row`) 13 → 18px
- New chat CTA (`.sidebar-action-row`) 13 → 18px
- WORK / TOOLS section eyebrows (`.sidebar-section-label`) 11 → 13px

`pnpm typecheck` clean; `pnpm test:app` 354/354; screenshot-verified the label/icon balance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)