### PR TITLE
style(header): enlarge the desktop menu-bar labels to match the bigger icons

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4657,6 +4657,7 @@ button:active > .edge-rail-chip {
   background: transparent;
   color: var(--text-primary);
   font: inherit;
+  font-size: 16px;
   line-height: 1.4;
 }
 
@@ -4714,7 +4715,7 @@ button:active > .edge-rail-chip {
   border-radius: var(--radius-control);
   background: var(--bg-base);
   color: var(--foreground);
-  font-size: var(--text-sm);
+  font-size: 17px;
   white-space: nowrap;
   cursor: pointer;
   transition: background var(--duration-fast) var(--ease-standard),


### PR DESCRIPTION
Follow-up to #1536 (38px header icons): the menu-bar labels were tiny (12px, `var(--text-sm)`).

- Enhance/Tasks/Inbox button labels (`.menu-bar__task`) 12 → 17px
- search input text (`.menu-bar__search-input`) inherited 12 → 16px

`pnpm typecheck` clean; `pnpm test:app` 354/354; screenshot-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)