### PR TITLE
style(top-bar): enlarge the mobile top-bar search text

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4897,6 +4897,7 @@ button:active > .edge-rail-chip {
   background: transparent;
   color: var(--text-primary);
   font: inherit;
+  font-size: 16px;
 }
 
 .top-bar__search-input::placeholder {


### PR DESCRIPTION
Follow-up to #1536 (mobile top-bar icons 36–40px). The mobile top bar's buttons are **icon-only** (no text labels), so the search input is its only text — bumped 12 → 16px. The search shows on narrow/tablet widths; on phones the top bar is icon-only.

`pnpm typecheck` clean; `pnpm test:app` 355/355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)