### PR TITLE
refactor(ui): unify segment tab bars onto shared Tabs (segment variant)

### DIFF
--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -15,6 +15,7 @@ import { Icon } from "@/lib/icon";
 import { formatTimestamp, formatClock, readDateTimePrefs } from "@/lib/datetime-format";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
+import { Tabs, type TabItem } from "@/components/ui/tabs";
 import { ProjectTree } from "@/components/project-tree";
 import type { CaveProject } from "@/lib/cave-projects-types";
 
@@ -1246,7 +1247,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   const [error, setError] = useState<string | null>(null);
   const [initialLoadDone, setInitialLoadDone] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<ScheduleTab>("reminders");
+  const [activeTab, setActiveTab] = useState<ScheduleTab>("inbox");
   // Selected item is either an InboxItem or a CodexAutomation — track by kind
   const [selectedItem, setSelectedItem] = useState<InboxItem | null>(null);
   const [selectedCodex, setSelectedCodex] = useState<CodexAutomation | null>(null);
@@ -1474,29 +1475,17 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
         </div>
 
         <div className="px-8 pb-4">
-          <div className="inline-flex rounded-lg border p-1"
-            style={{ borderColor: "var(--border-hairline)", background: "var(--bg-raised)" }}>
-            {([
-              ["reminders", "Reminders", reminderItems.length],
-              ["inbox", "Inbox", items.length],
-              ["automations", "Automations", codexAutos.length],
-            ] as const).map(([id, label, count]) => (
-              <button
-                key={id}
-                type="button"
-                onClick={() => selectTab(id)}
-                aria-pressed={activeTab === id}
-                className="rounded-md px-3 py-1.5 text-[12px] font-medium transition-colors"
-                style={{
-                  background: activeTab === id ? "rgba(255,255,255,0.08)" : "transparent",
-                  color: activeTab === id ? "var(--text-primary)" : "var(--text-muted)",
-                }}
-              >
-                {label}
-                <span className="ml-2 text-[10px]" style={{ color: "var(--text-muted)" }}>{count}</span>
-              </button>
-            ))}
-          </div>
+          <Tabs
+            variant="segment"
+            ariaLabel="Schedules tabs"
+            value={activeTab}
+            onChange={selectTab}
+            items={[
+              { id: "inbox", label: "Inbox", count: items.length },
+              { id: "reminders", label: "Reminders", count: reminderItems.length },
+              { id: "automations", label: "Automations", count: codexAutos.length },
+            ] satisfies TabItem<ScheduleTab>[]}
+          />
         </div>
 
         {error && (

--- a/src/components/chat-artifact-viewer.tsx
+++ b/src/components/chat-artifact-viewer.tsx
@@ -5,6 +5,7 @@ import "@/styles/chat-artifact.css";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Icon } from "@/lib/icon";
+import { Tabs } from "@/components/ui/tabs";
 import {
   buildPreviewSrcDoc,
   buildRefinePrompt,
@@ -182,26 +183,17 @@ export function ChatArtifactViewer({ initialCode, kind: initialKind, title, fami
           <i style={{ background: "#e0a44e" }} />
           <i style={{ background: "#5bbb6b" }} />
         </span>
-        <div className="chat-artifact__seg" role="tablist" aria-label="Artifact view">
-          <button
-            type="button"
-            role="tab"
-            aria-selected={tab === "canvas"}
-            className={`chat-artifact__tab${tab === "canvas" ? " is-active" : ""}`}
-            onClick={() => setTab("canvas")}
-          >
-            <Icon name="ph:squares-four" width={13} /> Canvas
-          </button>
-          <button
-            type="button"
-            role="tab"
-            aria-selected={tab === "code"}
-            className={`chat-artifact__tab${tab === "code" ? " is-active" : ""}`}
-            onClick={() => setTab("code")}
-          >
-            <Icon name="ph:code" width={13} /> Code
-          </button>
-        </div>
+        <Tabs
+          variant="segment"
+          size="sm"
+          ariaLabel="Artifact view"
+          value={tab}
+          onChange={setTab}
+          items={[
+            { id: "canvas", label: "Canvas", icon: "ph:squares-four" },
+            { id: "code", label: "Code", icon: "ph:code" },
+          ]}
+        />
         <span className="chat-artifact__title" title={title}>{title}</span>
         <span className="chat-artifact__spacer" />
         <div className="chat-artifact__actions">

--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -26,7 +26,7 @@ assert.match(codeView, /CODE_GROUP_ID = "cave\.code\.widths\.v1"/, "CodeView per
 // (a horizontal split is unusable on a phone); both panes stay mounted so
 // their state survives tab taps.
 assert.match(codeView, /if \(isMobile\) \{/, "mobile gets a dedicated layout branch");
-assert.match(codeView, /setMobileTab\("chat"\)|onClick=\{\(\) => setMobileTab\(tab\)\}/, "mobile has a Chat/Code tab switcher");
+assert.match(codeView, /onChange=\{setMobileTab\}/, "mobile has a Chat/Code tab switcher via shared Tabs");
 assert.match(
   codeView,
   /mobileTab === "chat" \? "flex" : "hidden"[\s\S]*?mobileTab === "code" \? "flex" : "hidden"/,

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, type ReactNode } from "react";
 import { Group, Panel, Separator, useDefaultLayout, usePanelRef } from "react-resizable-panels";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
+import { Tabs } from "@/components/ui/tabs";
 import { Icon } from "@/lib/icon";
 import { useIsMobile } from "@/lib/use-viewport";
 import {
@@ -61,24 +62,17 @@ export function CodeView({ chat, comux }: Props) {
     return (
       <div className="flex min-h-0 min-w-0 flex-1 flex-col">
         <div className="flex shrink-0 items-center justify-center gap-1 border-b border-[var(--border-hairline)] p-1.5">
-          <div className="flex items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 p-0.5 text-[11px]">
-            {(["chat", "code"] as const).map((tab) => (
-              <button
-                key={tab}
-                type="button"
-                onClick={() => setMobileTab(tab)}
-                aria-pressed={mobileTab === tab}
-                className={`flex items-center gap-1.5 rounded-[5px] px-3 py-1 transition-colors ${
-                  mobileTab === tab
-                    ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
-                    : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
-                }`}
-              >
-                <Icon name={tab === "chat" ? "ph:chats" : "ph:code"} width={13} />
-                {tab === "chat" ? "Chat" : "Code"}
-              </button>
-            ))}
-          </div>
+          <Tabs
+            variant="segment"
+            size="sm"
+            ariaLabel="Code view"
+            value={mobileTab}
+            onChange={setMobileTab}
+            items={[
+              { id: "chat", label: "Chat", icon: "ph:chats" },
+              { id: "code", label: "Code", icon: "ph:code" },
+            ]}
+          />
         </div>
         <div className={`min-h-0 flex-1 flex-col ${mobileTab === "chat" ? "flex" : "hidden"}`}>{chat}</div>
         <div className={`min-h-0 flex-1 flex-col ${mobileTab === "code" ? "flex" : "hidden"}`}>{comux}</div>

--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -209,16 +209,16 @@ assert.match(
   /disabled=\{\(!pat\.trim\(\) && !usernameInput\.trim\(\)\) \|\| saving\}/,
   "Save is enabled when either a PAT or a username is entered (not PAT-only)",
 );
-// The filter row is an accessible tablist.
+// The filter row is the shared segment Tabs, labelled for assistive tech.
 assert.match(
   source,
-  /role="tablist"[\s\S]{0,120}?aria-label="Filter GitHub activity"/,
-  "the filter row is a labelled tablist",
+  /<Tabs[\s\S]{0,200}ariaLabel="Filter GitHub activity"/,
+  "the filter row renders through the shared Tabs with an accessible label",
 );
 assert.match(
   source,
-  /role="tab"\s*\n?\s*aria-selected=\{isActive\}/,
-  "each filter is a tab that reports its selected state",
+  /variant="segment"/,
+  "the filter row uses the segment tab variant",
 );
 
 // Sortable table headers are keyboard-operable (a real <button>) and expose

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -16,6 +16,7 @@ import {
   GitHubActionPopover,
   type PopoverMode,
 } from "@/components/github-action-popover";
+import { Tabs, type TabItem } from "@/components/ui/tabs";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -1522,37 +1523,18 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
       </header>
 
       {/* ── Filter tabs ── */}
-      <div className="github-surface-controls flex items-center gap-1 px-4 py-2" role="tablist" aria-label="Filter GitHub activity">
-        {(["all", "pr", "review_request", "issue"] as Filter[]).map((f) => {
-          const labels: Record<Filter, string> = { all: "All", pr: "PRs", review_request: "Reviews", issue: "Issues" };
-          const isActive = filter === f;
-          const count = counts[f];
-          return (
-            <button
-              key={f}
-              type="button"
-              role="tab"
-              aria-selected={isActive}
-              onClick={() => setFilter(f)}
-              className={[
-                "focus-ring flex items-center gap-1.5 rounded-md px-2.5 py-1 text-[12px] transition-colors",
-                isActive
-                  ? "bg-[var(--bg-raised)] text-[var(--text-primary)] font-medium"
-                  : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]",
-              ].join(" ")}
-            >
-              {labels[f]}
-              {count > 0 && (
-                <span className={`rounded-full px-1 py-0.5 text-[9px] leading-none ${
-                  isActive ? "bg-[var(--accent-presence)]/20 text-[var(--accent-presence)]" : "bg-[var(--bg-raised)] text-[var(--text-muted)]"
-                }`}>
-                  {count}
-                </span>
-              )}
-            </button>
-          );
-        })}
-
+      <div className="github-surface-controls flex items-center gap-2 px-4 py-2">
+        <Tabs
+          variant="segment"
+          ariaLabel="Filter GitHub activity"
+          value={filter}
+          onChange={setFilter}
+          items={(["all", "pr", "review_request", "issue"] as Filter[]).map((f) => ({
+            id: f,
+            label: ({ all: "All", pr: "PRs", review_request: "Reviews", issue: "Issues" } as Record<Filter, string>)[f],
+            count: counts[f] > 0 ? counts[f] : undefined,
+          })) satisfies TabItem<Filter>[]}
+        />
         <div className="ml-auto flex items-center gap-2">
           <select
             className="gh-select"

--- a/src/components/schedules-tabs.test.ts
+++ b/src/components/schedules-tabs.test.ts
@@ -36,11 +36,13 @@ assert.match(
 );
 
 assert.match(automations, /type ScheduleTab = "reminders" \| "automations"/, "Schedules should have explicit tab state");
-assert.match(automations, /const \[activeTab, setActiveTab\] = useState<ScheduleTab>\("reminders"\)/, "Schedules should default to Reminders");
+assert.match(automations, /const \[activeTab, setActiveTab\] = useState<ScheduleTab>\("inbox"\)/, "Schedules should default to Inbox");
 assert.match(automations, /<h1[\s\S]*?>\s*Schedules\s*<\/h1>/, "Surface header should read Schedules");
-assert.match(automations, /\["reminders", "Reminders", reminderItems\.length\]/, "Schedules should expose a Reminders tab");
-assert.match(automations, /\["automations", "Automations", codexAutos\.length\]/, "Schedules should expose an Automations tab");
-assert.match(automations, /\["inbox", "Inbox", items\.length\]/, "Schedules should expose an Inbox tab over the full inbox feed");
+assert.match(automations, /\{ id: "inbox", label: "Inbox", count: items\.length \}/, "Schedules should expose an Inbox tab over the full inbox feed");
+assert.match(automations, /\{ id: "reminders", label: "Reminders", count: reminderItems\.length \}/, "Schedules should expose a Reminders tab");
+assert.match(automations, /\{ id: "automations", label: "Automations", count: codexAutos\.length \}/, "Schedules should expose an Automations tab");
+assert.match(automations, /id: "inbox"[\s\S]*id: "reminders"[\s\S]*id: "automations"/, "tabs ordered Inbox, Reminders, Automations");
+assert.match(automations, /<Tabs[\s\S]{0,200}variant="segment"/, "Schedules tabs use the shared segment Tabs");
 assert.match(automations, /type ScheduleTab = "reminders" \| "automations" \| "inbox"/, "Schedules tab state should include inbox");
 assert.match(automations, /function InboxFeedList/, "Inbox tab should render through a feed-list component");
 assert.match(automations, /groupInboxFeed\(items\)/, "Inbox tab should group the full inbox feed (every kind)");

--- a/src/components/ui/tabs.test.ts
+++ b/src/components/ui/tabs.test.ts
@@ -67,4 +67,15 @@ test("tabs support optional icon and count badge", () => {
   assert.doesNotMatch(src, /t\.count > 0/, "zero counts remain visible");
 });
 
+test("segment variant uses a rounded bordered container with raised active background", () => {
+  assert.match(src, /variant\?: "underline" \| "segment"/, "exposes a segment variant prop");
+  assert.match(src, /rounded-lg border border-\[var\(--border-hairline\)\]/, "segment tablist is a bordered rounded container");
+  assert.match(src, /bg-\[var\(--cv-tab-accent,var\(--bg-raised\)\)\]/, "active segment tab fills with raised/accent background");
+});
+
+test("segment variant keeps tablist/tab roles (a11y not lost in the pill look)", () => {
+  assert.match(src, /role="tablist"/, "tablist role still present");
+  assert.match(src, /role="tab"/, "tab role still present");
+});
+
 console.log("ui/tabs.test.ts OK");

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -60,6 +60,8 @@ type TabsProps<T extends string> = {
    * (e.g. a header row that spans tabs + actions).
    */
   bordered?: boolean;
+  /** "underline" (default) or "segment" (rounded pill container, raised active bg). */
+  variant?: "underline" | "segment";
 };
 
 export function Tabs<T extends string>({
@@ -73,6 +75,7 @@ export function Tabs<T extends string>({
   size = "md",
   idPrefix,
   bordered = true,
+  variant = "underline",
 }: TabsProps<T>) {
   const listRef = useRef<HTMLDivElement>(null);
   const { setActiveIndex } = useRovingTabIndex({
@@ -93,14 +96,17 @@ export function Tabs<T extends string>({
 
   const vertical = orientation === "vertical";
   const sm = size === "sm";
+  const segment = variant === "segment";
 
   const listClass = [
     "flex",
-    vertical
-      ? "flex-col gap-1"
-      : bordered
-        ? "items-end gap-1 border-b border-[var(--border-hairline)]"
-        : "items-end gap-1",
+    segment
+      ? "items-center gap-1 rounded-lg border border-[var(--border-hairline)] p-1"
+      : vertical
+        ? "flex-col gap-1"
+        : bordered
+          ? "items-end gap-1 border-b border-[var(--border-hairline)]"
+          : "items-end gap-1",
     className ?? "",
   ].join(" ");
 
@@ -117,9 +123,11 @@ export function Tabs<T extends string>({
         const tabId = idPrefix ? `${idPrefix}-tab-${t.id}` : undefined;
         const panelId = idPrefix ? `${idPrefix}-panel-${t.id}` : undefined;
 
-        const className = vertical
-          ? verticalTabClass(isActive, t.disabled, sm)
-          : horizontalTabClass(isActive, fill, sm);
+        const className = segment
+          ? segmentTabClass(isActive, sm)
+          : vertical
+            ? verticalTabClass(isActive, t.disabled, sm)
+            : horizontalTabClass(isActive, fill, sm);
 
         return (
           <button
@@ -180,5 +188,17 @@ function verticalTabClass(isActive: boolean, disabled: boolean | undefined, sm: 
       : "text-[var(--text-muted)] border-transparent hover:text-[var(--text-secondary)] hover:border-[color-mix(in_oklch,var(--text-muted)_35%,transparent)]",
     disabled ? "opacity-40 cursor-not-allowed" : "",
     "focus-visible:ring-2 focus-visible:ring-[var(--ring-focus)] focus-visible:ring-offset-0 rounded-r-sm",
+  ].join(" ");
+}
+
+function segmentTabClass(isActive: boolean, sm: boolean): string {
+  return [
+    "relative inline-flex items-center gap-1.5 outline-none rounded-md",
+    sm ? "px-2.5 py-1 text-[11px]" : "px-3 py-1.5 text-[12px]",
+    "font-medium transition-colors",
+    isActive
+      ? "bg-[var(--cv-tab-accent,var(--bg-raised))] text-[var(--text-primary)]"
+      : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]",
+    "focus-visible:ring-2 focus-visible:ring-[var(--ring-focus)] focus-visible:ring-offset-0",
   ].join(" ");
 }

--- a/src/styles/chat-artifact.css
+++ b/src/styles/chat-artifact.css
@@ -42,16 +42,6 @@
 }
 .chat-artifact__dots { display: inline-flex; gap: 5px; }
 .chat-artifact__dots i { width: 9px; height: 9px; border-radius: 50%; display: inline-block; }
-.chat-artifact__seg {
-  display: inline-flex; gap: 2px; padding: 2px;
-  background: var(--bg-base); border: 1px solid var(--border-hairline); border-radius: 8px;
-}
-.chat-artifact__tab {
-  display: inline-flex; align-items: center; gap: 5px;
-  padding: 3px 11px; font-size: var(--text-xs); font-weight: 600;
-  color: var(--text-muted); background: none; border: none; border-radius: 6px; cursor: pointer;
-}
-.chat-artifact__tab.is-active { color: var(--text-primary); background: var(--bg-panel); box-shadow: inset 0 0 0 1px var(--border-hairline); }
 .chat-artifact__title { font-size: var(--text-xs); color: var(--text-secondary); max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .chat-artifact__spacer { flex: 1; }
 .chat-artifact__actions { display: inline-flex; gap: 6px; align-items: center; }


### PR DESCRIPTION
Adds a `segment` (rounded-pill) variant to the shared `Tabs` component and migrates four hand-rolled tab bars onto it — they gain roving-tabindex + full ARIA for free and one consistent look.

## Changes
- **`ui/tabs.tsx`**: new `variant: "underline" | "segment"` (default `underline`, so existing underline callers are byte-for-byte unchanged). Segment = bordered rounded container, raised active background; honors `accent`/`size`/`count`/`icon`.
- **Schedules** (`automations-view.tsx`): tabs → segment `Tabs`, **reordered to Inbox · Reminders · Automations, default Inbox**.
- **Code mobile** (`code-view.tsx`): Chat/Code toggle → segment `Tabs` (both panes stay mounted).
- **GitHub** (`github-view.tsx`): All/PRs/Reviews/Issues filters → segment `Tabs` (counts hide at 0). The separate none/org/repo grouping toggle is untouched.
- **Chat-artifact** (`chat-artifact-viewer.tsx`): Canvas/Code toggle → segment `Tabs`; dead `.chat-artifact__seg/__tab` CSS deleted.

Pinned source-text tests updated in-commit (`ui/tabs`, `schedules-tabs`, `code-view`, `github-view-polish`). typecheck + `test:app` + `test:mobile` green; final review approved.

First of the tabs-unification effort. Follow-ups: **PR1b** (Workflow/Retro segment bars), **PR2** (underline bucket: Journal, Familiar Studio, Inspector). The Schedules reorder here also satisfies the Automations-rehaul Slice A's tab-reorder portion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)