### PR TITLE
style(mobile): enlarge the bottom tab bar labels (and square the icons)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6824,7 +6824,7 @@ a.mobile-handoff__link:hover {
   line-height: 0;
 }
 .mobile-bottom-tab__label {
-  font-size: 11px;
+  font-size: 13px;
   line-height: 1.1;
   font-weight: 500;
   letter-spacing: 0;

--- a/src/components/mobile-bottom-tabs.tsx
+++ b/src/components/mobile-bottom-tabs.tsx
@@ -64,7 +64,7 @@ export function MobileBottomTabs({
             onClick={() => onSelect(tab.id)}
           >
             <span className="mobile-bottom-tab__icon-wrap" aria-hidden>
-              <Icon name={tab.iconName} width={20} />
+              <Icon name={tab.iconName} width={24} height={24} />
               {showBadge ? (
                 <span className="mobile-bottom-tab__badge" aria-hidden>
                   {inboxBadgeCount > 99 ? "99+" : inboxBadgeCount}


### PR DESCRIPTION
The mobile bottom tab bar (Home / Familiars / Board / Sched / Library):

- tab labels (`.mobile-bottom-tab__label`) 11 → 13px
- tab icons render square at 24px (were `width={20}` with a default 1em height → squished to ~13px tall); now a proper 24px icon over the 13px label

`pnpm typecheck` clean; `pnpm test:app` 355/355; screenshot-verified all 5 tabs fit cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)