### PR TITLE
feat(comux): file-preview breadcrumb + copy-path (Code workspace)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -155,6 +155,7 @@ export const SUITES = {
     "src/components/comux-broadcast-wiring.test.ts",
     "src/components/comux-chrome-wiring.test.ts",
     "src/components/comux-touch-wiring.test.ts",
+    "src/components/comux-preview-crumbs.test.ts",
     "src/components/comux-pane-nav-wiring.test.ts",
     "src/components/library-polish.test.ts",
     "src/components/library-file-actions.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8689,3 +8689,9 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
     font-size: 11px;
   }
 }
+
+/* ── Code workspace: file-preview breadcrumb (PR3) ────────────────────────── */
+.comux-preview-crumb-sep {
+  color: color-mix(in oklch, var(--text-muted) 55%, transparent);
+  flex-shrink: 0;
+}

--- a/src/components/comux-preview-crumbs.test.ts
+++ b/src/components/comux-preview-crumbs.test.ts
@@ -1,0 +1,13 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+const comux = readFileSync(new URL("./comux-view.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+assert.match(comux, /comux-preview-crumbs/, "preview path is a breadcrumb");
+assert.match(comux, /comux-preview-crumb-sep/, "breadcrumb separators");
+assert.match(comux, /const \[copiedPath, setCopiedPath\] = useState\(false\)/, "copy-path state");
+assert.match(comux, /void copyText\(previewPath\)/, "copy-path copies the file path");
+assert.match(comux, /aria-label="Copy file path"/, "copy-path button labeled");
+assert.match(comux, /name=\{copiedPath \? "ph:check" : "ph:copy"\}/, "copy-path icon reflects state");
+assert.match(css, /\.comux-preview-crumb-sep/, "breadcrumb separator styled");
+console.log("comux-preview-crumbs.test.ts passed");

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -286,6 +286,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [copiedPath, setCopiedPath] = useState(false);
   const [previewRaw, setPreviewRaw] = useState(false);
   // 1-based line to scroll the preview to (set when opened from a search match,
   // cleared when opened from the file tree).
@@ -1753,11 +1754,34 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                           width={12}
                           className="shrink-0 text-[var(--text-muted)]"
                         />
-                        <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-[var(--text-muted)]">
-                          {previewPath.startsWith(selectedProject.root)
+                        <nav className="comux-preview-crumbs min-w-0 flex-1 flex items-center gap-1 truncate font-mono text-[11px] text-[var(--text-muted)]" aria-label="File path">
+                          {(previewPath.startsWith(selectedProject.root)
                             ? previewPath.slice(selectedProject.root.length).replace(/^\//, "")
-                            : previewPath}
-                        </span>
+                            : previewPath)
+                            .split("/")
+                            .filter(Boolean)
+                            .map((seg, i, segs) => (
+                              <span key={i} className="flex min-w-0 items-center gap-1">
+                                {i > 0 ? <span className="comux-preview-crumb-sep" aria-hidden>›</span> : null}
+                                <span className={i === segs.length - 1 ? "truncate text-[var(--text-secondary)]" : "truncate"}>
+                                  {seg}
+                                </span>
+                              </span>
+                            ))}
+                        </nav>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            void copyText(previewPath);
+                            setCopiedPath(true);
+                            setTimeout(() => setCopiedPath(false), 1500);
+                          }}
+                          className="comux-preview-copypath shrink-0 rounded-[5px] border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 px-1.5 py-px text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)]"
+                          aria-label="Copy file path"
+                          title={copiedPath ? "Copied!" : "Copy path"}
+                        >
+                          <Icon name={copiedPath ? "ph:check" : "ph:copy"} width={11} aria-hidden />
+                        </button>
                         {previewLangLabel && (
                           <span className="comux-preview-lang shrink-0 rounded-[5px] border border-[var(--border-hairline)] bg-[var(--bg-raised)]/50 px-1.5 py-px font-mono text-[10px] uppercase tracking-wide text-[var(--text-secondary)]">
                             {previewLangLabel}


### PR DESCRIPTION
**PR3 of the terminal/Code UX arc** (chrome ✅ #1549 → touch ✅ #1553 → **Code workspace**).

The Code workspace file preview shows its path as a real **breadcrumb** (path segments with the filename emphasized) and adds a **copy-path** button.

## Honest scoping note
Auditing the Code workspace for this PR, most of it was already well-polished:
- **Active-file highlight** in the project tree already exists and is strong (full accent background) — nothing to do.
- **Per-file diff +/− counts** need API support (`/api/changes` returns file *count*, not per-file line deltas) — deferred to a backend-touching PR.
- **Full project-tree keyboard navigation** is a real refactor (the tree uses decentralized, lazily-loaded per-node state) — deferred to its own dedicated PR rather than rushed here.

So this PR ships the one clean, self-contained win (preview breadcrumb + copy-path) and flags the rest as honest follow-ups.

## Tests
`comux-preview-crumbs.test.ts` locks the breadcrumb + copy-path wiring. `tsc --noEmit` clean; full `test:app` running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)