### PR TITLE
docs(ios): build terminal.html in the documented build steps

### DIFF
--- a/apps/ios/CovenCave/README.md
+++ b/apps/ios/CovenCave/README.md
@@ -16,9 +16,11 @@ phased plan and architecture.
 ## Build & run
 
 ```bash
-# from the repo root: build the markdown renderer bundle (Resources/markdown.html,
-# generated & gitignored — the Xcode build can't run node). Needs `pnpm install`.
+# from the repo root: build the web bundles the app embeds (Resources/markdown.html
+# and Resources/terminal.html — generated & gitignored, the Xcode build can't run
+# node). Needs `pnpm install`. Skipping the terminal bundle ships a blank Terminal tab.
 node scripts/build-ios-markdown.mjs
+node scripts/build-ios-terminal.mjs
 
 cd apps/ios/CovenCave
 xcodegen generate          # produces CovenCave.xcodeproj from project.yml


### PR DESCRIPTION
## Why
The iOS **Developer → Terminal** tab rendered **blank** (green "connected" dot, no shell). `XtermWebView` loads `Resources/terminal.html` — a **generated + gitignored** xterm.js bundle (`scripts/build-ios-terminal.mjs`) — but the README "Build & run" steps only generate `markdown.html`, never `terminal.html`. A by-the-book build ships an app missing that resource → `Bundle.main.url(...)` is nil → the WebView never loads → PTY output queues forever.

(The PTY WebSocket itself is fine — verified `wss://…:8443/api/pty-ws` streams a shell.)

## Fix
Add `node scripts/build-ios-terminal.mjs` next to the markdown step, and note that skipping it ships a blank Terminal tab. Mirrors the existing `markdown.html` convention.

Follow-up worth considering: a `preBuildScripts` phase in `project.yml` to regenerate both bundles automatically so it can't be forgotten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)