### PR TITLE
refactor(ui): migrate Workflow + Retro tab bars onto shared segment Tabs (PR1b)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8324,30 +8324,6 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   /* No font-size override — inherit the global `max(16px, 1em)` rule so iOS
      Safari doesn't auto-zoom on focus (enforced by composer-zoom-smoke). */
 }
-.retro-tabs {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-  height: 40px;
-  padding: 3px;
-  border: 1px solid var(--border-hairline);
-  border-radius: var(--radius-control);
-  background: var(--bg-raised);
-}
-.retro-tabs button {
-  height: 32px;
-  border: 0;
-  border-radius: calc(var(--radius-control) - 3px);
-  background: transparent;
-  color: var(--text-secondary);
-  padding: 0 10px;
-  font-size: 12px;
-  font-weight: 560;
-}
-.retro-tabs button.is-active {
-  background: var(--accent-presence);
-  color: var(--accent-presence-foreground, #fff);
-}
 .retro-select {
   height: 40px;
   min-width: 140px;
@@ -8565,7 +8541,6 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 @media (max-width: 920px) {
   .retro-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .retro-controls { grid-template-columns: 1fr; }
-  .retro-tabs { width: 100%; overflow-x: auto; justify-content: flex-start; }
   .retro-select { width: 100%; }
   .retro-content { grid-template-columns: 1fr; }
   .retro-familiar-panel { position: static; }

--- a/src/components/retro-runs-view.test.ts
+++ b/src/components/retro-runs-view.test.ts
@@ -20,7 +20,8 @@ assert.match(
 assert.match(component, /fetch\(apiPath/, "RetroRunsView loads retro runs through the scoped API path");
 assert.match(component, /downloadRetroSnapshot/, "RetroRunsView offers a sanitized export");
 assert.match(component, /JSON\.stringify\(snapshot/, "exports the API snapshot rather than raw daemon payloads");
-assert.match(component, /role="tablist"/, "track filters use a segmented tablist control");
+assert.match(component, /<Tabs[\s\S]{0,160}variant="segment"/, "track filters use the shared segment Tabs");
+assert.match(component, /ariaLabel="Retro track filter"/, "track filter tablist is labelled");
 assert.match(component, /aria-label="Refresh retro runs"/, "refresh is an icon button with an accessible name");
 assert.match(apiRoute, /redactSecretsDeep/, "aggregate retro API redacts daemon data at the route boundary");
 assert.match(evalLoopRoute, /redactSecretsDeep/, "per-familiar eval-loop proxy redacts daemon data too");

--- a/src/components/retro-runs-view.tsx
+++ b/src/components/retro-runs-view.tsx
@@ -5,6 +5,7 @@ import { Icon } from "@/lib/icon";
 import { EmptyState } from "@/components/ui/empty-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
+import { Tabs } from "@/components/ui/tabs";
 import { relativeTime } from "@/lib/relative-time";
 import { RelativeTime } from "@/components/ui/relative-time";
 import type { RetroOutcome, RetroRun, RetroRunsSnapshot, RetroTrack } from "@/lib/retro-runs";
@@ -235,20 +236,14 @@ export function RetroRunsView({
           />
         </label>
 
-        <div className="retro-tabs" role="tablist" aria-label="Retro track filter">
-          {TRACKS.map((item) => (
-            <button
-              key={item.id}
-              type="button"
-              role="tab"
-              aria-selected={track === item.id}
-              className={track === item.id ? "is-active" : ""}
-              onClick={() => setTrack(item.id)}
-            >
-              {item.label}
-            </button>
-          ))}
-        </div>
+        <Tabs
+          variant="segment"
+          size="sm"
+          ariaLabel="Retro track filter"
+          value={track}
+          onChange={setTrack}
+          items={TRACKS}
+        />
 
         <select
           className="retro-select"

--- a/src/components/workflows/workflow-create-dialog.tsx
+++ b/src/components/workflows/workflow-create-dialog.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useRef, useState } from "react";
 import { parse as parseYaml } from "yaml";
 import { Icon } from "@/lib/icon";
+import { Tabs } from "@/components/ui/tabs";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { slugifyWorkflowId } from "@/lib/workflow-edit";
 import {
@@ -155,26 +156,17 @@ export function WorkflowCreateDialog({ familiarOptions, onClose, onCreate, onCre
           </button>
         </div>
 
-        <div className="workflow-create-mode-toggle" role="tablist" aria-label="Create mode">
-          <button
-            type="button"
-            role="tab"
-            aria-selected={mode === "describe"}
-            className={`workflow-create-mode${mode === "describe" ? " is-active" : ""}`}
-            onClick={() => setMode("describe")}
-          >
-            <Icon name="ph:sparkle" width={13} /> Describe
-          </button>
-          <button
-            type="button"
-            role="tab"
-            aria-selected={mode === "pattern"}
-            className={`workflow-create-mode${mode === "pattern" ? " is-active" : ""}`}
-            onClick={() => setMode("pattern")}
-          >
-            Pattern
-          </button>
-        </div>
+        <Tabs
+          variant="segment"
+          size="sm"
+          ariaLabel="Create mode"
+          value={mode}
+          onChange={setMode}
+          items={[
+            { id: "describe", label: "Describe", icon: "ph:sparkle" },
+            { id: "pattern", label: "Pattern" },
+          ]}
+        />
 
         {mode === "pattern" ? (
           <>

--- a/src/components/workflows/workflow-manifest-preview.tsx
+++ b/src/components/workflows/workflow-manifest-preview.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { Tabs } from "@/components/ui/tabs";
 import { workflowToYaml } from "@/lib/workflow-edit";
 import { buildWorkflowRunPrompt } from "@/lib/workflow-run-prompt";
 import type { WorkflowSummary } from "@/lib/workflows";
@@ -71,20 +72,18 @@ export function WorkflowManifestPreview({ workflow, dirty, changedFields }: Work
         )}
       </div>
       {workflow && (
-        <div className="workflow-manifest-views" role="tablist" aria-label="Preview mode">
-          {(["manifest", "prompt"] as ManifestView[]).map((id) => (
-            <button
-              key={id}
-              type="button"
-              role="tab"
-              aria-selected={view === id}
-              className={`workflow-manifest-view${view === id ? " is-active" : ""}`}
-              onClick={() => setView(id)}
-            >
-              {id === "manifest" ? "Manifest" : "Run prompt"}
-            </button>
-          ))}
-        </div>
+        <Tabs
+          variant="segment"
+          size="sm"
+          className="shrink-0"
+          ariaLabel="Preview mode"
+          value={view}
+          onChange={setView}
+          items={[
+            { id: "manifest", label: "Manifest" },
+            { id: "prompt", label: "Run prompt" },
+          ]}
+        />
       )}
       {view === "manifest" && dirty && changedFields && changedFields.length > 0 && (
         <p className="workflow-manifest-changes">

--- a/src/components/workflows/workflow-runs-panel.tsx
+++ b/src/components/workflows/workflow-runs-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { Tabs, type TabItem } from "@/components/ui/tabs";
 import { Icon, type IconName } from "@/lib/icon";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { relativeTime } from "@/lib/relative-time";
@@ -112,24 +113,18 @@ export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayR
       {/* Filter history once there's more than a couple of runs — a busy
           workflow's plan snapshots otherwise bury its real executions. */}
       {workflow && runs.length > 2 && (
-        <div className="workflow-runs-filter" role="tablist" aria-label="Filter runs">
-          {RUN_FILTERS.map((entry) => {
-            const matchCount = entry.id === "all" ? runs.length : runs.filter(entry.match).length;
-            return (
-              <button
-                key={entry.id}
-                type="button"
-                role="tab"
-                aria-selected={filter === entry.id}
-                className={`workflow-runs-filter-chip${filter === entry.id ? " is-active" : ""}`}
-                onClick={() => setFilter(entry.id)}
-              >
-                {entry.label}
-                <span className="workflow-runs-filter-count">{matchCount}</span>
-              </button>
-            );
-          })}
-        </div>
+        <Tabs
+          variant="segment"
+          size="sm"
+          ariaLabel="Filter runs"
+          value={filter}
+          onChange={setFilter}
+          items={RUN_FILTERS.map((entry) => ({
+            id: entry.id,
+            label: entry.label,
+            count: entry.id === "all" ? runs.length : runs.filter(entry.match).length,
+          })) satisfies TabItem<WorkflowRunFilter>[]}
+        />
       )}
       {!workflow ? (
         <p className="workflow-muted">Select a workflow to see its run history.</p>

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -386,9 +386,8 @@ assert.match(css, /\.workflow-issue-jump/, "CSS should style the issue jump affo
 
 // Runs history filter: plan snapshots vs executions vs problems.
 assert.match(runsPanel, /RUN_FILTERS/, "Runs panel should define history filters");
-assert.match(runsPanel, /workflow-runs-filter/, "Runs panel should render filter chips");
+assert.match(runsPanel, /variant="segment"/, "Runs panel should render filter via shared segment Tabs");
 assert.match(runsPanel, /visibleRuns/, "Runs panel should render the filtered run set");
-assert.match(css, /\.workflow-runs-filter-chip/, "CSS should style runs filter chips");
 
 // Manifest copy: hand off the canonical YAML.
 assert.match(manifestPreview, /navigator\.clipboard\.writeText/, "Manifest preview should copy the canonical YAML");

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -441,8 +441,8 @@ assert.match(css, /\.workflow-runs-clear/, "CSS should style the clear-history b
 // The manifest panel toggles between the YAML manifest and the compiled run prompt.
 assert.match(manifestPreview, /buildWorkflowRunPrompt/, "Manifest preview should compile the run prompt");
 assert.match(manifestPreview, /Run prompt/, "Manifest preview should offer a run-prompt view");
-assert.match(manifestPreview, /workflow-manifest-views/, "Manifest preview should render a view toggle");
-assert.match(css, /\.workflow-manifest-view\b/, "CSS should style the manifest view toggle");
+assert.match(manifestPreview, /variant="segment"/, "Manifest preview should render a segment tab toggle");
+assert.match(manifestPreview, /ariaLabel="Preview mode"/, "Manifest preview segment tabs should have an aria-label");
 
 // Import a workflow from a pasted manifest.
 assert.match(dialogs, /export function WorkflowImportDialog/, "An import dialog should parse a pasted manifest");

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -2375,33 +2375,6 @@
   }
 }
 
-/* Create-dialog mode toggle (Describe / Pattern) */
-.workflow-create-mode-toggle {
-  display: inline-flex;
-  gap: 2px;
-  padding: 2px;
-  margin-bottom: 12px;
-  border-radius: 8px;
-  background: var(--bg-panel, rgba(127, 127, 127, 0.12));
-}
-.workflow-create-mode {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 5px 12px;
-  border: none;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--color-muted, inherit);
-  font: inherit;
-  cursor: pointer;
-}
-.workflow-create-mode.is-active {
-  background: var(--bg-base, var(--background, #fff));
-  color: var(--color-text, inherit);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
-}
-
 /* Review step list */
 .workflow-review-steps {
   list-style: none;

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -1514,55 +1514,6 @@
   color: var(--text-primary);
 }
 
-/* Runs history filter chips (plan snapshots vs real executions vs problems). */
-.workflow-runs-filter {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  margin-bottom: 8px;
-}
-
-.workflow-runs-filter-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  min-height: 24px;
-  padding: 0 8px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: var(--bg-base);
-  color: var(--muted-foreground);
-  font-size: 11px;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.workflow-runs-filter-chip:hover {
-  border-color: var(--border-strong);
-  color: var(--text-primary);
-}
-
-.workflow-runs-filter-chip.is-active {
-  border-color: color-mix(in oklch, var(--accent-presence) 50%, var(--border));
-  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
-  color: var(--text-primary);
-}
-
-.workflow-runs-filter-chip:focus-visible {
-  outline: var(--ring-width) solid var(--ring-focus);
-  outline-offset: 1px;
-}
-
-.workflow-runs-filter-count {
-  font-size: 10px;
-  font-variant-numeric: tabular-nums;
-  color: var(--muted-foreground);
-}
-
-.workflow-runs-filter-chip.is-active .workflow-runs-filter-count {
-  color: var(--text-primary);
-}
-
 .workflow-role-list {
   margin: 0;
   padding: 0 4px 0 0;

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -307,45 +307,6 @@
   flex: none;
 }
 
-/* Manifest ⇄ Run-prompt segmented toggle. */
-.workflow-manifest-views {
-  display: flex;
-  gap: 2px;
-  margin-bottom: 8px;
-  padding: 2px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--bg-base);
-}
-
-.workflow-manifest-view {
-  flex: 1;
-  min-height: 24px;
-  padding: 2px 10px;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--muted-foreground);
-  font-size: 11.5px;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.workflow-manifest-view:hover {
-  color: var(--text-primary);
-}
-
-.workflow-manifest-view.is-active {
-  border-color: color-mix(in oklch, var(--accent-presence) 45%, var(--border));
-  background: var(--card);
-  color: var(--text-primary);
-}
-
-.workflow-manifest-view:focus-visible {
-  outline: var(--ring-width) solid var(--ring-focus);
-  outline-offset: 1px;
-}
-
 /* Import dialog: monospace paste area + parse-error line. */
 .workflow-import-field {
   min-height: 200px;
@@ -1896,7 +1857,6 @@
 }
 
 .workflow-manifest-preview .workflow-panel-heading,
-.workflow-manifest-preview .workflow-manifest-views,
 .workflow-manifest-preview .workflow-manifest-changes,
 .workflow-manifest-preview > .workflow-muted:last-child {
   flex-shrink: 0;


### PR DESCRIPTION
Second slice of the tabs unification (follows #1555). Migrates the four remaining toggle/filter bars to the shared `Tabs` segment variant, deleting their bespoke CSS — each gains roving-tabindex + full ARIA for free:

- **Workflow runs filter** (All/Problems/Runs/Plans, counts)
- **Workflow manifest preview** (Manifest / Run prompt)
- **Workflow create dialog** (Describe / Pattern)
- **Retro runs** track filter (All/Synthesis/Prompt/Memory)

Pinned source-text tests updated in-commit (`workflow-studio.test.ts`, `retro-runs-view.test.ts`). typecheck + test:app + test:mobile green; all dead `.workflow-runs-filter*`/`.workflow-manifest-view*`/`.workflow-create-mode*`/`.retro-tabs*` CSS removed.

Follow-up: PR2 (underline bucket — Journal, Familiar Studio, Inspector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)