### PR TITLE
fix(nav): restore icons to reasonable sizes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8574,8 +8574,6 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   .cave-next-path--recommended { animation: none; border-color: var(--color-success); }
 }
 
-/* Bigger desktop search glyph (overrides the 1.15em default). */
-.menu-bar__search-icon { width: 2.5em; height: 2.5em; }
 
 /* ── Terminal chrome polish (PR1) ─────────────────────────────────────────── */
 .comux-terminal-pane-cwd {

--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -95,7 +95,7 @@ export function FamiliarMenuBar({
           onOpenSearch();
         }}
       >
-        <Icon name="ph:magnifying-glass" width={36} className="menu-bar__search-icon" aria-hidden />
+        <Icon name="ph:magnifying-glass" width={20} className="menu-bar__search-icon" aria-hidden />
         <input
           type="search"
           className="menu-bar__search-input"
@@ -119,7 +119,7 @@ export function FamiliarMenuBar({
             aria-label={enrichingTasks ? `Enhancing tasks ${enrichLabel}` : activeFamiliarId ? ENRICH_TASKS_TITLE : "Select a familiar to enhance tasks"}
             title={activeFamiliarId ? ENRICH_TASKS_TITLE : "Select a familiar to enhance tasks"}
           >
-            <Icon name="ph:sparkle" width={38} height={38} aria-hidden />
+            <Icon name="ph:sparkle" width={22} height={22} aria-hidden />
             <span>{enrichingTasks ? enrichLabel : "Enhance"}</span>
           </button>
         ) : null}
@@ -129,7 +129,7 @@ export function FamiliarMenuBar({
           onClick={onViewTasks}
           aria-label={taskCount > 0 ? `View tasks — ${taskCount} open` : "View tasks"}
         >
-          <Icon name="ph:kanban" width={38} height={38} aria-hidden />
+          <Icon name="ph:kanban" width={22} height={22} aria-hidden />
           <span>Tasks</span>
           {taskCount > 0 ? <span className="menu-bar__badge">{fmtBadge(taskCount)}</span> : null}
         </button>
@@ -139,7 +139,7 @@ export function FamiliarMenuBar({
           onClick={onViewInbox}
           aria-label={inboxCount > 0 ? `View inbox — ${inboxCount} need attention` : "View inbox"}
         >
-          <Icon name="ph:tray" width={38} height={38} aria-hidden />
+          <Icon name="ph:tray" width={22} height={22} aria-hidden />
           <span>Inbox</span>
           {inboxCount > 0 ? (
             <span className="menu-bar__badge menu-bar__badge--alert">{fmtBadge(inboxCount)}</span>

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -190,7 +190,7 @@ function FolderRow({
       title={title}
       onClick={onClick}
     >
-      <Icon name={iconName} width={42} className="sidebar-folder-icon" />
+      <Icon name={iconName} width={20} className="sidebar-folder-icon" />
       <span className="sidebar-folder-label">{label}</span>
       {badge && <span className="sidebar-badge">{badge}</span>}
       {/* The ⌘-number shortcut is no longer shown as a chip here: the numbers
@@ -307,7 +307,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
           title="Dashboard — activity overview and daily reports"
         >
           <span className="sidebar-foot-icon-cell" aria-hidden="true">
-            <Icon name="ph:squares-four" width={40} className="sidebar-foot-icon" />
+            <Icon name="ph:squares-four" width={20} className="sidebar-foot-icon" />
           </span>
           <span className="sidebar-foot-label">Dashboard</span>
         </a>
@@ -322,9 +322,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
             <span className="sidebar-foot-icon-cell" aria-hidden="true">
               <Icon
                 name={unreadCount > 0 ? "ph:bell-fill" : "ph:bell"}
-                width={40}
-                className="sidebar-foot-icon"
-              />
+                width={20}
             </span>
             <span className="sidebar-foot-label">Notifications</span>
             {unreadCount > 0 ? (
@@ -342,7 +340,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
           title="Settings"
         >
           <span className="sidebar-foot-icon-cell" aria-hidden="true">
-            <Icon name="ph:gear-six" width={40} className="sidebar-foot-icon" />
+            <Icon name="ph:gear-six" width={20} className="sidebar-foot-icon" />
           </span>
           <span className="sidebar-foot-label">Settings</span>
         </button>

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -118,7 +118,7 @@ export function TopBar(props: Props) {
             aria-controls="nav"
             title={navDrawerOpen ? "Close navigation" : "Open navigation"}
           >
-            <Icon name="ph:sidebar-simple" width={40} height={40} />
+            <Icon name="ph:sidebar-simple" width={24} height={24} />
           </button>
         ) : null}
         {onToggleList ? (
@@ -132,7 +132,7 @@ export function TopBar(props: Props) {
             aria-controls="list"
             title={listDrawerOpen ? "Close list" : "Open list"}
           >
-            <Icon name="ph:list-checks-bold" width={40} height={40} />
+            <Icon name="ph:list-checks-bold" width={24} height={24} />
           </button>
         ) : null}
       </div>
@@ -150,7 +150,7 @@ export function TopBar(props: Props) {
           onOpenPalette();
         }}
       >
-        <Icon name="ph:magnifying-glass" width={32} height={32} className="top-bar__search-icon" />
+        <Icon name="ph:magnifying-glass" width={20} height={20} className="top-bar__search-icon" />
         <input
           type="search"
           className="top-bar__search-input"
@@ -185,7 +185,7 @@ export function TopBar(props: Props) {
             aria-label={activeFamiliar ? enrichLabel : "Select a familiar to enhance tasks"}
             title={activeFamiliar ? ENRICH_TASKS_TITLE : "Select a familiar to enhance tasks"}
           >
-            <Icon name="ph:sparkle" width={38} height={38} />
+            <Icon name="ph:sparkle" width={22} height={22} />
           </button>
         ) : null}
         {onViewTasks ? (
@@ -196,7 +196,7 @@ export function TopBar(props: Props) {
             aria-label={taskCount && taskCount > 0 ? `View tasks — ${taskCount} open` : "View tasks"}
             title="View tasks"
           >
-            <Icon name="ph:kanban" width={38} height={38} />
+            <Icon name="ph:kanban" width={22} height={22} />
             {taskCount && taskCount > 0 ? (
               <span className="top-bar__tasks-badge">{taskCount > 99 ? "99+" : taskCount}</span>
             ) : null}
@@ -209,7 +209,7 @@ export function TopBar(props: Props) {
           aria-label="Open on phone"
           title="Open on phone"
         >
-          <Icon name="ph:device-mobile" width={36} height={36} />
+          <Icon name="ph:device-mobile" width={22} height={22} />
         </button>
         <NotificationBell
           items={inboxItems}
@@ -227,7 +227,7 @@ export function TopBar(props: Props) {
           aria-label="Account / settings"
           title="Settings (⌘,)"
         >
-          <Icon name="ph:user" width={36} height={36} />
+          <Icon name="ph:user" width={22} height={22} />
         </button>
         {onToggleFamiliar ? (
           <button
@@ -240,7 +240,7 @@ export function TopBar(props: Props) {
             aria-controls="agent"
             title={familiarDrawerOpen ? "Close familiar panel" : "Open familiar panel"}
           >
-            <Icon name="ph:cat" width={40} height={40} />
+            <Icon name="ph:cat" width={24} height={24} />
           </button>
         ) : null}
       </div>


### PR DESCRIPTION
The series of icon-enlargement PRs went too far — icons are now 38–42px across the nav and top-bar, which is extremely large.

This reverts them to sensible values:
- top-bar: sidebar/cat toggles 24px, action icons 22px, search 20px
- sidebar: folder + foot icons 20px (note-pencil compose stays 28px)
- menu-bar: search 20px, nav action icons 22px
- CSS: removes the stray `2.5em` search-icon override