### PR TITLE
refactor(ui): migrate Familiar Studio drawer + Inspector tab rows onto shared underline Tabs (PR2 cont.)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5956,46 +5956,6 @@ a.mobile-handoff__link:hover {
 @media (prefers-reduced-motion: reduce) {
   .familiar-studio__drawer { animation: none; }
 }
-.familiar-studio__tabstrip {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-  padding: var(--space-3) var(--space-2);
-  background: color-mix(in oklch, var(--bg-raised) 40%, transparent);
-  border-right: 1px solid var(--border-hairline);
-}
-.familiar-studio__tab {
-  display: grid;
-  place-items: center;
-  gap: 4px;
-  padding: 9px 2px;
-  border-radius: var(--radius-control);
-  font-size: var(--text-2xs);
-  font-weight: 500;
-  letter-spacing: 0.01em;
-  color: var(--text-muted);
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  transition: color var(--duration-fast) var(--ease-standard),
-    background var(--duration-fast) var(--ease-standard);
-}
-.familiar-studio__tab:hover:not([aria-disabled="true"]):not(.familiar-studio__tab--active) {
-  color: var(--text-secondary);
-  background: color-mix(in oklch, var(--bg-elevated) 60%, transparent);
-}
-.familiar-studio__tab--active {
-  color: var(--familiar-accent, var(--accent-presence));
-  background: color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 14%, transparent);
-}
-.familiar-studio__tab:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--ring-focus);
-}
-.familiar-studio__tab[aria-disabled="true"] {
-  opacity: 0.35;
-  cursor: not-allowed;
-}
 .familiar-studio__main { display: grid; grid-template-rows: auto 1fr auto; min-height: 0; }
 .familiar-studio__header { display: flex; align-items: center; gap: var(--space-3); padding: var(--space-4) var(--space-5); border-bottom: 1px solid var(--border-hairline); }
 .familiar-studio__heading { display: flex; flex-direction: column; gap: 1px; min-width: 0; flex: 1; }
@@ -6429,7 +6389,6 @@ a.mobile-handoff__link:hover {
 
 /* Focus-visible rings for every interactive control in the studio drawer.
    Keyboard Tab landed invisibly across the modal before this. */
-.familiar-studio__tab:focus-visible,
 .familiar-studio__close:focus-visible,
 .familiar-studio__name:focus-visible,
 .familiar-studio-identity__reset:focus-visible,

--- a/src/components/familiar-studio-tabs.test.ts
+++ b/src/components/familiar-studio-tabs.test.ts
@@ -7,12 +7,9 @@ const source = readFileSync(
   "utf8",
 );
 
-// Tablist container exists.
-assert.match(source, /role="tablist"/, "tabstrip container has role=tablist");
-
-// Tab items use role=tab and aria-selected (not aria-current=page).
-assert.match(source, /role="tab"/, "tab buttons use role=tab");
-assert.match(source, /aria-selected=/, "tab buttons expose aria-selected");
+// Drawer tabstrip uses the shared underline Tabs component.
+assert.match(source, /<Tabs[\s\S]{0,220}variant="underline"/, "drawer tabstrip uses the shared underline Tabs");
+assert.match(source, /orientation="vertical"/, "drawer tabstrip stays vertical");
 
 // Tabpanel area is labelled by the active tab.
 assert.match(source, /role="tabpanel"/, "tab content area is a tabpanel");
@@ -22,16 +19,8 @@ assert.match(
   "tabpanel is labelled by its tab",
 );
 
-// Roving tabindex hook adopted.
-assert.match(
-  source,
-  /import\s+\{[^}]*useRovingTabIndex[^}]*\}\s+from\s+["']@\/lib\/use-roving-tabindex["']/,
-  "imports useRovingTabIndex",
-);
-assert.match(source, /useRovingTabIndex\(/, "calls useRovingTabIndex(...)");
-
 // Old aria-current="page" pattern on tabs is gone (still OK elsewhere in the file).
-const tabBlock = source.match(/role="tab"[\s\S]{0,200}/g)?.join("") ?? "";
+const tabBlock = source.match(/orientation="vertical"[\s\S]{0,200}/g)?.join("") ?? "";
 assert.doesNotMatch(
   tabBlock,
   /aria-current="page"/,

--- a/src/components/familiar-studio.test.ts
+++ b/src/components/familiar-studio.test.ts
@@ -9,7 +9,7 @@ assert.match(source, /useFamiliarStudio/, "Must consume FamiliarStudio context")
 assert.match(source, /activeFamiliarId/, "Reads activeFamiliarId from context");
 assert.match(source, /Escape/, "Esc dismiss is wired");
 assert.match(source, /familiar-studio__drawer/, "Drawer root class must be present");
-assert.match(source, /familiar-studio__tabstrip/, "Tab strip class must be present");
+assert.match(source, /variant="underline"/, "Tab strip uses the shared underline Tabs component");
 assert.match(source, /role="dialog"/, "Drawer must have dialog role for a11y");
 assert.match(source, /aria-label/, "Drawer must have an accessible name");
 assert.match(source, /function HeaderName/, "Header must use inline-edit HeaderName component");
@@ -26,8 +26,8 @@ assert.match(
 
 assert.match(
   source,
-  /const tablistRef = useRef[\s\S]*if \(!drawerOpen\) return null/,
-  "Familiar Studio should call tabstrip hooks before early returns to keep hook order stable",
+  /const drawerOpen = Boolean[\s\S]*if \(!drawerOpen\) return null/,
+  "Familiar Studio computes drawerOpen before early returns to keep hook order stable",
 );
 
 // The header avatar is a click-to-upload control wired to the shared image hook.

--- a/src/components/familiar-studio.tsx
+++ b/src/components/familiar-studio.tsx
@@ -5,9 +5,9 @@ import { Icon, type IconName } from "@/lib/icon";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useFamiliarImageUpload, FAMILIAR_IMAGE_ACCEPT } from "@/lib/familiar-image-upload";
 import { useFamiliarStudio, type FamiliarStudioTab } from "@/lib/familiar-studio-context";
-import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 import { useResolvedFamiliars, type ResolvedFamiliar } from "@/lib/familiar-resolve";
 import { useFocusTrap } from "@/lib/use-focus-trap";
+import { Tabs } from "@/components/ui/tabs";
 import {
   setFamiliarOverride,
   clearFamiliarOverrideField,
@@ -57,39 +57,11 @@ export function FamiliarStudio({ familiars }: Props) {
     window.location.assign("/settings");
   }, [setActiveTab]);
 
-  // Roving tabindex over the tablist. Arrow keys move focus across enabled
-  // tabs; Home/End jump to ends. We pair this with an effect below to also
-  // switch the active tab when focus moves (automatic activation per APG).
-  const tablistRef = useRef<HTMLDivElement | null>(null);
-  const { activeIndex } = useRovingTabIndex({
-    containerRef: tablistRef,
-    itemSelector: '[role="tab"]:not([aria-disabled="true"])',
-    // Tabstrip is visually a column (`flex-direction: column`), so vertical
-    // arrow keys move focus across tabs. aria-orientation below mirrors this.
-    orientation: "vertical",
-  });
-
   // Trap keyboard focus inside the open drawer, focus it on open, wire Escape,
   // and restore focus to the trigger on close — matching every other modal
   // (capabilities, board-inspector, …). Replaces the ad-hoc Escape listener.
   const drawerRef = useRef<HTMLElement | null>(null);
   useFocusTrap(drawerOpen, drawerRef, { onEscape: closeFamiliarStudio });
-
-  // Automatic activation: switch activeTab whenever the roving focus lands on
-  // a new tab. Studio tab panels are cheap, so APG recommends auto activation.
-  useEffect(() => {
-    if (!drawerOpen) return;
-    const enabledTabs = TABS.filter((t) =>
-      disableNonLifecycle ? t.id === "lifecycle" : true,
-    );
-    const target = enabledTabs[activeIndex];
-    if (target && target.id !== activeTab) {
-      setActiveTab(target.id);
-    }
-    // Intentionally omit activeTab/setActiveTab from deps: this effect drives
-    // activeTab from activeIndex, not the other way around.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeIndex, disableNonLifecycle, drawerOpen]);
 
   // No drawer when nothing is open.
   if (!drawerOpen) return null;
@@ -130,34 +102,20 @@ export function FamiliarStudio({ familiars }: Props) {
       style={familiar ? ({ ["--familiar-accent"]: familiar.color } as CSSProperties) : undefined}
     >
       {/* Tabstrip */}
-      <div
-        role="tablist"
-        aria-label="Studio sections"
-        aria-orientation="vertical"
-        ref={tablistRef}
-        className="familiar-studio__tabstrip"
-      >
-        {TABS.map((t) => {
-          const disabled = disableNonLifecycle && t.id !== "lifecycle";
-          const selected = drawerActiveTab === t.id;
-          return (
-            <button
-              key={t.id}
-              type="button"
-              role="tab"
-              id={`familiar-studio-tab-${t.id}`}
-              aria-selected={selected}
-              aria-controls={`familiar-studio-panel-${t.id}`}
-              aria-disabled={disabled ? true : undefined}
-              onClick={() => !disabled && setActiveTab(t.id)}
-              className={`familiar-studio__tab${selected ? " familiar-studio__tab--active" : ""}`}
-            >
-              <Icon name={t.icon} width={18} />
-              <span>{t.label}</span>
-            </button>
-          );
-        })}
-      </div>
+        <Tabs
+          variant="underline"
+          orientation="vertical"
+          idPrefix="familiar-studio"
+          ariaLabel="Studio sections"
+          value={drawerActiveTab}
+          onChange={setActiveTab}
+          items={TABS.map((t) => ({
+            id: t.id,
+            label: t.label,
+            icon: t.icon,
+            disabled: disableNonLifecycle && t.id !== "lifecycle",
+          }))}
+        />
 
       {/* Main column */}
       <div className="familiar-studio__main">

--- a/src/components/inspector-pane-polish.test.ts
+++ b/src/components/inspector-pane-polish.test.ts
@@ -7,12 +7,10 @@ import { dirname, resolve } from "node:path";
 const here = dirname(fileURLToPath(import.meta.url));
 const src = readFileSync(resolve(here, "./inspector-pane.tsx"), "utf8");
 
-test("outer tab nav is a WAI-ARIA tablist with rounded underline", () => {
-  assert.match(src, /role="tablist"[^>]*aria-label="Inspector sections"/, "outer nav has tablist role + label");
-  assert.match(src, /role="tab"/, "tabs have role=tab");
-  assert.match(src, /aria-selected=\{isActive\}/, "aria-selected wired");
-  assert.match(src, /after:h-\[2px\]/, "2px underline pseudo-element");
-  assert.match(src, /after:rounded-full/, "rounded underline");
+test("outer tab nav uses the shared underline Tabs, labelled + filled", () => {
+  assert.match(src, /<Tabs[\s\S]{0,240}ariaLabel="Inspector sections"/, "outer nav uses shared Tabs");
+  assert.match(src, /variant="underline"/, "outer nav is underline");
+  assert.match(src, /\bfill\b/, "outer tabs stretch to fill the row");
 });
 
 test("inbox badge is softened from danger to warning tone", () => {
@@ -76,20 +74,3 @@ test("inspector empty helper imports IconName for type-safe icon prop", () => {
   assert.match(src, /icon: IconName;/, "InspectorEmpty.icon typed as IconName");
 });
 
-// ── Tab flicker regression ────────────────────────────────────────────────
-// The roving-tabindex sync must be ONE-WAY (tab → activeIndex). The old
-// bidirectional pair oscillated forever on any non-memory tab: activeIndex
-// dragged tab back to memory while tab pushed activeIndex forward, every
-// commit, flickering the pane.
-assert.doesNotMatch(  src,
-  /INSPECTOR_TABS\[activeIndex\][\s\S]{0,120}setTab/,
-  "activeIndex must never drive setTab — that effect pair oscillates on non-memory tabs",
-);
-assert.match(  src,
-  /const tabIndex = INSPECTOR_TABS\.indexOf\(tab\);\s*if \(tabIndex >= 0 && tabIndex !== activeIndex\) setActiveIndex\(tabIndex\)/,
-  "roving tab stop follows the selected tab one-way",
-);
-assert.match(  src,
-  /onFocus=\{\(\) => setTab\(t\)\}/,
-  "selection follows focus so arrow-key roving still switches tabs (ARIA APG)",
-);

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import type { Familiar } from "@/lib/types";
 import type { InboxItem } from "@/lib/cave-inbox";
@@ -11,7 +11,6 @@ import { SnoozeMenu } from "@/components/snooze-menu";
 import { Icon, type IconName } from "@/lib/icon";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { Tabs } from "@/components/ui/tabs";
-import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 import type { HarnessCapabilityManifest } from "@/app/api/capabilities/route";
 import type { RoleEntry } from "@/app/api/roles/route";
 import type { LocalSkillEntry } from "@/app/api/skills/local/route";
@@ -124,24 +123,6 @@ export function InspectorPane({
   onOpenFullView,
 }: Props) {
   const [tab, setTab] = useState<Tab>("memory");
-  const tablistRef = useRef<HTMLElement | null>(null);
-  const { activeIndex, setActiveIndex } = useRovingTabIndex({
-    containerRef: tablistRef,
-    itemSelector: '[role="tab"]',
-    orientation: "horizontal",
-  });
-
-  // `tab` is the single source of truth. The roving tab stop follows it
-  // one-way; selection follows focus (onFocus on each tab button, per the
-  // ARIA APG tabs pattern) so arrow-key roving still switches tabs. The
-  // previous BIDIRECTIONAL effect pair (activeIndex → setTab as well)
-  // oscillated forever whenever tab !== memory: each effect saw the other's
-  // stale half and flipped it back every commit, flickering the pane
-  // between Memory and the selected tab.
-  useEffect(() => {
-    const tabIndex = INSPECTOR_TABS.indexOf(tab);
-    if (tabIndex >= 0 && tabIndex !== activeIndex) setActiveIndex(tabIndex);
-  }, [tab, activeIndex, setActiveIndex]);
 
   const familiarInbox = useMemo(() => {
     if (!familiar) return [];
@@ -167,46 +148,31 @@ export function InspectorPane({
   return (
     <aside className={shellClassName}>
       {!compact && (
-        <nav
-          ref={tablistRef}
-          role="tablist"
-          aria-label="Inspector sections"
-          className="flex items-end gap-1 border-b border-[var(--border-hairline)] px-1 text-[11px]"
-        >
-          {INSPECTOR_TABS.map((t) => {
-            const isActive = tab === t;
-            return (
-              <button
-                key={t}
-                type="button"
-                role="tab"
-                id={`inspector-tab-${t}`}
-                aria-selected={isActive}
-                aria-controls={`inspector-panel-${t}`}
-                onClick={() => setTab(t)}
-                onFocus={() => setTab(t)}
-                className={[
-                  "relative flex-1 px-3 py-2.5 font-medium tracking-normal transition-colors outline-none",
-                  "after:absolute after:bottom-0 after:left-3 after:right-3 after:h-[2px] after:rounded-full after:transition-colors",
-                  isActive
-                    ? "text-[var(--text-primary)] after:bg-[var(--text-primary)]"
-                    : "text-[var(--text-muted)] hover:text-[var(--text-secondary)] after:bg-transparent hover:after:bg-[color-mix(in_oklch,var(--text-muted)_45%,transparent)]",
-                  "focus-visible:ring-2 focus-visible:ring-[var(--ring-focus)] focus-visible:ring-offset-0 rounded-t-sm",
-                ].join(" ")}
-              >
-                {TAB_LABEL[t]}
-                {t === "inbox" && inboxBadge > 0 ? (
+        <Tabs
+          variant="underline"
+          fill
+          idPrefix="inspector"
+          ariaLabel="Inspector sections"
+          value={tab}
+          onChange={setTab}
+          items={INSPECTOR_TABS.map((t) => ({
+            id: t,
+            label:
+              t === "inbox" && inboxBadge > 0 ? (
+                <>
+                  {TAB_LABEL[t]}
                   <span
                     className="ml-1 inline-flex min-w-[14px] items-center justify-center rounded-full bg-[color-mix(in_oklch,var(--color-warning)_28%,transparent)] px-1 text-[9px] font-semibold text-[var(--color-warning)]"
                     aria-label={`${inboxBadge} fired reminder${inboxBadge === 1 ? "" : "s"}`}
                   >
                     {inboxBadge}
                   </span>
-                ) : null}
-              </button>
-            );
-          })}
-        </nav>
+                </>
+              ) : (
+                TAB_LABEL[t]
+              ),
+          }))}
+        />
       )}
 
       <div


### PR DESCRIPTION
Completes the underline-bucket migration (Journal + Familiar Studio inline already landed via #1571). Migrates the last two hand-rolled underline tab bars onto the shared `Tabs` component, deleting bespoke CSS:

- **Familiar Studio drawer** — `orientation="vertical"` + per-item `disabled` (non-lifecycle tabs in list-view stay disabled).
- **Inspector outer tab row** — `fill`; the inbox **warning-tinted count badge is preserved** as a `ReactNode` label.

Accepted UX delta: both move from focus-activation to `Tabs`' click/arrow activation. Pinned source-text tests updated (`familiar-studio-tabs`, `familiar-studio`, `inspector-pane-polish`). typecheck + test:app green.

This finishes the app-wide tab unification: **every tab bar now renders through `src/components/ui/tabs.tsx`** (#1555 segment bucket, #1565 workflow/retro, #1571 journal/inline, this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)