### PR TITLE
fix(types): familiar-avatar-src uses structural AvatarFields (unblock red main)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -22,6 +22,7 @@ import { fileURLToPath } from "node:url";
 export const SUITES = {
   app: [
     "src/lib/app-version.test.ts",
+    "src/lib/familiar-avatar-src.test.ts",
     "src/lib/app-update.test.ts",
     "src/lib/coven-version.test.ts",
     "src/components/update-available.test.ts",

--- a/src/lib/familiar-avatar-src.ts
+++ b/src/lib/familiar-avatar-src.ts
@@ -1,5 +1,3 @@
-import type { ResolvedFamiliar } from "./familiar-resolve.ts";
-
 /**
  * Pure decision helpers for resolving a familiar's avatar `<img src>`.
  *
@@ -9,7 +7,21 @@ import type { ResolvedFamiliar } from "./familiar-resolve.ts";
  * without a React runtime.
  */
 
-type AvatarFields = Pick<ResolvedFamiliar, "avatarPath" | "avatarImage" | "avatarVersion">;
+/**
+ * Structural shape of the avatar fields these helpers read. Kept independent
+ * of the `Familiar`/`ResolvedFamiliar` types so the helpers stay testable with
+ * minimal fixtures and so future avatar fields don't drag the whole familiar
+ * type into this leaf module.
+ *
+ * - `avatarPath`: absolute on-disk workspace file path (Tauri-resolved at runtime)
+ * - `avatarImage`: SSR-safe data URL or fully-resolved http(s) URL
+ * - `avatarVersion`: optional mtime/version used to cache-bust the asset URL
+ */
+export type AvatarFields = {
+  avatarPath?: string;
+  avatarImage?: string;
+  avatarVersion?: number;
+};
 
 /**
  * The `<img src>` to use before any client-side asset resolution runs.


### PR DESCRIPTION
**Unblocks red main** since ede6ba5 ("Support more text/file types and avatar utils").

`src/lib/familiar-avatar-src.ts` references three fields via `Pick<ResolvedFamiliar, ...>`:
`avatarPath`, `avatarImage`, `avatarVersion` — but only `avatarImage` exists on `ResolvedFamiliar` today, so `Pick` raises TS2344 and `Frontend build` fails on every PR.

**Fix:** replace the `Pick` with a local `AvatarFields` structural type. The helpers are pure decision functions and the test already passes plain object literals — no caller change needed. Decouples this leaf from `Familiar`'s evolving shape.

Verified: `pnpm typecheck` is clean locally on this branch.

Once merged, PR #1574 (tabs unify – drawer + inspector) can re-run and merge.

Source: a hopefully-final-strand of the tabs-unify arc, plus parallel sessions overlapping each other.