### PR TITLE
chore: release cave v0.0.110

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.109",
+  "version": "0.0.110",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.109"
+version = "0.0.110"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.109"
+version = "0.0.110"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.109</string>
+	<string>0.0.110</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.109</string>
+	<string>0.0.110</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.109</string>
+	<string>0.0.110</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.109</string>
+	<string>0.0.110</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.109",
+  "version": "0.0.110",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Version bump for the v0.0.110 release.

**What's in this release** (since v0.0.108):
- 🐈 New hooded-familiar app icon across iOS, macOS, Windows, Linux
- 🧩 App-wide tab unification — every tab bar now renders through `ui/tabs.tsx` (Workflow, Retro, Inspector, Familiar Studio, Journal, Code workspace)
- 📱 iOS: bottom tab bar labels + squared icons, top-bar search-text sizing, in-app DMG updates, terminal.html in documented build steps, mobile/touch terminal ergonomics
- ✨ Code workspace: file-preview breadcrumb + copy-path, project-tree keyboard navigation
- 📅 Calendar: deadlines on board, drag-to-reschedule
- 📊 Changes panel: per-file +/- with aggregate header total
- 🎨 Nav chrome: icons restored to compact, scale-token sizes across top-bar/sidebar/menu-bar
- 🛠️ Numerous fixes: red-main unblocks, regex escaping, icon RGBA encoding for tauri::generate_context!