### PR TITLE
fix(menu-bar): size top-bar action icons to the text (1.15em, not fixed 22px)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -349,6 +349,7 @@ export const SUITES = {
     "src/components/security/sidecar-auth-bridge.test.ts",
     "src/components/familiar-switcher.test.ts",
     "src/components/familiar-menu-bar.test.ts",
+    "src/components/menu-bar-icon-size.test.ts",
     "src/components/familiar-quick-switch.test.ts",
     "src/components/familiar-pin-order.test.ts",
     "src/lib/familiar-quick-switch.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4722,6 +4722,15 @@ button:active > .edge-rail-chip {
     border-color var(--duration-fast) var(--ease-standard);
 }
 
+/* Size the button icon relative to its label (mirrors .menu-bar__search-icon)
+   so it stays balanced with the 17px text and scales under magnification,
+   instead of a fixed 22px glyph that visually dwarfed the label. */
+.menu-bar__task > svg {
+  flex-shrink: 0;
+  width: 1.15em;
+  height: 1.15em;
+}
+
 .menu-bar__new {
   flex: 0 0 auto;
   color: var(--foreground);

--- a/src/components/menu-bar-icon-size.test.ts
+++ b/src/components/menu-bar-icon-size.test.ts
@@ -1,0 +1,7 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+// Top-bar action icons scale with their label (em), matching .menu-bar__search-icon.
+assert.match(css, /\.menu-bar__task > svg\s*\{[\s\S]*?width:\s*1\.15em[\s\S]*?height:\s*1\.15em/, "task icon is 1.15em (balanced with text)");
+console.log("menu-bar-icon-size.test.ts passed");


### PR DESCRIPTION
The top-bar **Enhance / Tasks / Inbox** buttons used **fixed 22px** icons against **17px** labels (~1.3×), so the icons looked oversized next to the text (see before/after). The search box already does this right — icon at `1.15em`, scaling with the label.

## Fix
Size the action icons at `1.15em` (mirrors `.menu-bar__search-icon`) so they're balanced with the label and scale under magnification, instead of a fixed-px glyph.

Measured on the live menu bar (CSS injected): **22×22 → 20×20**, both dimensions (no width-only no-op), now matching the search-icon ratio. Vertical alignment was already centered (`iconMidY === textMidY`), so this is purely the size mismatch.

## Tests
`menu-bar-icon-size.test.ts` locks the `1.15em` rule. `tsc --noEmit` clean; `check:tests-wired` ✓ (456); full `test:app` running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)