### PR TITLE
fix(menu-bar): bump top-bar action + search icons to 1.35em

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4645,8 +4645,8 @@ button:active > .edge-rail-chip {
      scales together with the input under screen magnification (rem fonts)
      instead of staying a tiny fixed-px glyph pinned to the top. */
   align-self: center;
-  width: 1.15em;
-  height: 1.15em;
+  width: 1.35em;
+  height: 1.35em;
 }
 
 .menu-bar__search-input {
@@ -4723,12 +4723,13 @@ button:active > .edge-rail-chip {
 }
 
 /* Size the button icon relative to its label (mirrors .menu-bar__search-icon)
-   so it stays balanced with the 17px text and scales under magnification,
-   instead of a fixed 22px glyph that visually dwarfed the label. */
+   so it scales under magnification instead of a fixed-px glyph. At 1.35em the
+   icon reads as matched to the 17px label — prominent enough not to look dainty
+   (1.15em did), without dwarfing the text. */
 .menu-bar__task > svg {
   flex-shrink: 0;
-  width: 1.15em;
-  height: 1.15em;
+  width: 1.35em;
+  height: 1.35em;
 }
 
 .menu-bar__new {

--- a/src/components/menu-bar-icon-size.test.ts
+++ b/src/components/menu-bar-icon-size.test.ts
@@ -3,5 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 // Top-bar action icons scale with their label (em), matching .menu-bar__search-icon.
-assert.match(css, /\.menu-bar__task > svg\s*\{[\s\S]*?width:\s*1\.15em[\s\S]*?height:\s*1\.15em/, "task icon is 1.15em (balanced with text)");
+assert.match(css, /\.menu-bar__task > svg\s*\{[\s\S]*?width:\s*1\.35em[\s\S]*?height:\s*1\.35em/, "task icon is 1.35em (matched to text, not dainty)");
+// The search-row glyph scales with its row text the same way.
+assert.match(css, /\.menu-bar__search-icon\s*\{[\s\S]*?width:\s*1\.35em[\s\S]*?height:\s*1\.35em/, "search icon is 1.35em");
 console.log("menu-bar-icon-size.test.ts passed");


### PR DESCRIPTION
## What

The Enhance / Tasks / Inbox icons in the desktop top bar (and the search-row magnifying glass) looked too small next to their labels — daintier than the 17px text. This bumps them so the glyph matches the label's visual weight.

- `.menu-bar__task > svg`: `1.15em` → `1.35em` (renders ~23px against the 17px label)
- `.menu-bar__search-icon`: `1.15em` → `1.35em` (better proportioned to the 16px input)

## Context

Follow-up to #1578, which had sized these to `1.15em` (down from a fixed 22px). `1.15em` over-corrected — the icons read as undersized. `1.35em` lands in the balanced range: clearly bigger than the dainty `1.15em`, without the optical "dwarfing" of the old fixed-px glyph. Verified by rendering 1.15 / 1.3 / 1.45 / 1.6em side by side and picking the matched value.

## Verify

Rendered the real top bar (demo mode, 1440px) — icons now measure ~22.9px and visually match the labels. `menu-bar-icon-size.test.ts` updated to pin `1.35em` for both rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)