### PR TITLE
fix(menu-bar): match top-bar icons to the sidepanel toggle size

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4641,12 +4641,11 @@ button:active > .edge-rail-chip {
 
 .menu-bar__search-icon {
   flex-shrink: 0;
-  /* Center the icon on the search row and size it relative to the text so it
-     scales together with the input under screen magnification (rem fonts)
-     instead of staying a tiny fixed-px glyph pinned to the top. */
+  /* Match the sidepanel toggle glyph (.shell-top-toggle uses var(--icon-sm))
+     so the top-chrome icons all read at one consistent size. */
   align-self: center;
-  width: 1.35em;
-  height: 1.35em;
+  width: var(--icon-sm);
+  height: var(--icon-sm);
 }
 
 .menu-bar__search-input {
@@ -4722,14 +4721,13 @@ button:active > .edge-rail-chip {
     border-color var(--duration-fast) var(--ease-standard);
 }
 
-/* Size the button icon relative to its label (mirrors .menu-bar__search-icon)
-   so it scales under magnification instead of a fixed-px glyph. At 1.35em the
-   icon reads as matched to the 17px label — prominent enough not to look dainty
-   (1.15em did), without dwarfing the text. */
+/* Match the sidepanel toggle glyph (.shell-top-toggle uses var(--icon-sm)) so
+   the Enhance/Tasks/Inbox icons read at the same size as the rest of the top
+   chrome, rather than scaling with their own label. */
 .menu-bar__task > svg {
   flex-shrink: 0;
-  width: 1.35em;
-  height: 1.35em;
+  width: var(--icon-sm);
+  height: var(--icon-sm);
 }
 
 .menu-bar__new {

--- a/src/components/menu-bar-icon-size.test.ts
+++ b/src/components/menu-bar-icon-size.test.ts
@@ -2,8 +2,12 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
-// Top-bar action icons scale with their label (em), matching .menu-bar__search-icon.
-assert.match(css, /\.menu-bar__task > svg\s*\{[\s\S]*?width:\s*1\.35em[\s\S]*?height:\s*1\.35em/, "task icon is 1.35em (matched to text, not dainty)");
-// The search-row glyph scales with its row text the same way.
-assert.match(css, /\.menu-bar__search-icon\s*\{[\s\S]*?width:\s*1\.35em[\s\S]*?height:\s*1\.35em/, "search icon is 1.35em");
+// Top-bar action + search glyphs match the sidepanel toggle (var(--icon-sm))
+// so the whole top chrome reads at one consistent icon size.
+assert.match(css, /\.menu-bar__task > svg\s*\{[\s\S]*?width:\s*var\(--icon-sm\)[\s\S]*?height:\s*var\(--icon-sm\)/, "task icon matches sidepanel toggle (var(--icon-sm))");
+assert.match(css, /\.menu-bar__search-icon\s*\{[\s\S]*?width:\s*var\(--icon-sm\)[\s\S]*?height:\s*var\(--icon-sm\)/, "search icon matches sidepanel toggle (var(--icon-sm))");
+// Sanity-check the reference: the sidepanel toggle glyph is sized var(--icon-sm)
+// in code (CAVE_ICON_SIZE.shellToggle); keep this match in sync if that changes.
+const iconLib = readFileSync(new URL("../lib/icon.tsx", import.meta.url), "utf8");
+assert.match(iconLib, /shellToggle:\s*"var\(--icon-sm\)"/, "sidepanel toggle glyph is var(--icon-sm)");
 console.log("menu-bar-icon-size.test.ts passed");


### PR DESCRIPTION
## What

Size the Enhance / Tasks / Inbox action icons and the search-row magnifying glass to `var(--icon-sm)` (14px) — the exact token the sidepanel show/hide toggle (`.shell-top-toggle`, `CAVE_ICON_SIZE.shellToggle`) uses. Now every glyph in the top chrome reads at one consistent size.

- `.menu-bar__task > svg`: `1.35em` → `var(--icon-sm)`
- `.menu-bar__search-icon`: `1.35em` → `var(--icon-sm)`

## Context

Follow-up to #1579 (which used em-relative `1.35em`). Per request, the top-bar action icons should match the sidepanel trigger glyph rather than scale with their own labels.

## Verify

Rendered the real top bar (demo mode, 1440px): sidepanel toggle glyph, search icon, and all three task icons measure **14px**. `menu-bar-icon-size.test.ts` pins both rules to `var(--icon-sm)` and asserts the toggle reference is still `var(--icon-sm)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)