### PR TITLE
fix(chrome): standardize top-chrome icons to the avatar size (16px)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4641,11 +4641,12 @@ button:active > .edge-rail-chip {
 
 .menu-bar__search-icon {
   flex-shrink: 0;
-  /* Match the sidepanel toggle glyph (.shell-top-toggle uses var(--icon-sm))
-     so the top-chrome icons all read at one consistent size. */
+  /* One standard size across the top chrome: var(--icon-md) matches the
+     familiar avatars (FamiliarAvatar "sm" / the labeled trigger img) and the
+     sidepanel toggle glyph, so icons and avatars all read at 16px. */
   align-self: center;
-  width: var(--icon-sm);
-  height: var(--icon-sm);
+  width: var(--icon-md);
+  height: var(--icon-md);
 }
 
 .menu-bar__search-input {
@@ -4721,13 +4722,13 @@ button:active > .edge-rail-chip {
     border-color var(--duration-fast) var(--ease-standard);
 }
 
-/* Match the sidepanel toggle glyph (.shell-top-toggle uses var(--icon-sm)) so
-   the Enhance/Tasks/Inbox icons read at the same size as the rest of the top
-   chrome, rather than scaling with their own label. */
+/* One standard size across the top chrome (var(--icon-md), 16px): the
+   Enhance/Tasks/Inbox glyphs match the familiar avatars and the sidepanel
+   toggle, rather than scaling with their own label. */
 .menu-bar__task > svg {
   flex-shrink: 0;
-  width: var(--icon-sm);
-  height: var(--icon-sm);
+  width: var(--icon-md);
+  height: var(--icon-md);
 }
 
 .menu-bar__new {

--- a/src/components/menu-bar-icon-size.test.ts
+++ b/src/components/menu-bar-icon-size.test.ts
@@ -2,12 +2,14 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
-// Top-bar action + search glyphs match the sidepanel toggle (var(--icon-sm))
-// so the whole top chrome reads at one consistent icon size.
-assert.match(css, /\.menu-bar__task > svg\s*\{[\s\S]*?width:\s*var\(--icon-sm\)[\s\S]*?height:\s*var\(--icon-sm\)/, "task icon matches sidepanel toggle (var(--icon-sm))");
-assert.match(css, /\.menu-bar__search-icon\s*\{[\s\S]*?width:\s*var\(--icon-sm\)[\s\S]*?height:\s*var\(--icon-sm\)/, "search icon matches sidepanel toggle (var(--icon-sm))");
-// Sanity-check the reference: the sidepanel toggle glyph is sized var(--icon-sm)
-// in code (CAVE_ICON_SIZE.shellToggle); keep this match in sync if that changes.
+// One standard top-chrome glyph size, var(--icon-md) — the same as the familiar
+// avatars (FamiliarAvatar "sm" / the labeled trigger img) — so icons, toggles,
+// and avatars all read at 16px.
+assert.match(css, /\.menu-bar__task > svg\s*\{[\s\S]*?width:\s*var\(--icon-md\)[\s\S]*?height:\s*var\(--icon-md\)/, "task icon is var(--icon-md) (avatar size)");
+assert.match(css, /\.menu-bar__search-icon\s*\{[\s\S]*?width:\s*var\(--icon-md\)[\s\S]*?height:\s*var\(--icon-md\)/, "search icon is var(--icon-md) (avatar size)");
+// The sidepanel/nav toggle glyph and the familiar avatar share the same token.
 const iconLib = readFileSync(new URL("../lib/icon.tsx", import.meta.url), "utf8");
-assert.match(iconLib, /shellToggle:\s*"var\(--icon-sm\)"/, "sidepanel toggle glyph is var(--icon-sm)");
+assert.match(iconLib, /shellToggle:\s*"var\(--icon-md\)"/, "sidepanel toggle glyph is var(--icon-md)");
+const avatar = readFileSync(new URL("./familiar-avatar.tsx", import.meta.url), "utf8");
+assert.match(avatar, /sm:\s*16/, "familiar avatar 'sm' is 16px (= var(--icon-md))");
 console.log("menu-bar-icon-size.test.ts passed");

--- a/src/lib/icon.tsx
+++ b/src/lib/icon.tsx
@@ -287,7 +287,9 @@ export const CAVE_ICON_SIZE = {
   headerToggle: "var(--icon-md)",
   headerAction: "var(--icon-md)",
   headerSearch: "var(--icon-sm)",
-  shellToggle: "var(--icon-sm)",
+  // The top sidepanel/nav toggles share the standard top-chrome glyph size so
+  // they match the familiar avatars and the menu-bar action icons (16px).
+  shellToggle: "var(--icon-md)",
   shellNav: "var(--icon-sm)",
   shellInline: "var(--icon-xs)",
   shellDismiss: "var(--icon-xs)",


### PR DESCRIPTION
## What

Standardize every glyph in the top chrome to `var(--icon-md)` (16px) — the same size as the familiar avatars (`FamiliarAvatar "sm"` / the labeled switcher img):

- `.menu-bar__task > svg` (Enhance / Tasks / Inbox): `var(--icon-sm)` → `var(--icon-md)`
- `.menu-bar__search-icon`: `var(--icon-sm)` → `var(--icon-md)`
- `CAVE_ICON_SIZE.shellToggle` (sidepanel / nav top toggles): `var(--icon-sm)` → `var(--icon-md)`

Now the avatars, the toggle, and all the menu-bar action icons read at one consistent 16px.

## Context

Follow-up to #1581 (which had matched the icons to the 14px sidepanel toggle). Per request, the standard moves to the avatar size. Confirmed the target is the avatar **image** (16px), not the 28px avatar tile.

## Verify

Rendered the real top bar (demo, 1440px): sidepanel toggle glyph, search icon, and all three task icons measure **16px** — matching the familiar avatar image. `menu-bar-icon-size.test.ts` pins the menu-bar rules + the `shellToggle` token to `var(--icon-md)` and cross-checks `FamiliarAvatar` "sm" = 16px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)