### PR TITLE
feat(automations): expandable run logs + outcome-colored last-run badge

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -434,6 +434,7 @@ export const SUITES = {
     "src/lib/server/familiar-startup-context.test.ts",
     "src/lib/server/memory-file-paths.test.ts",
     "src/lib/server/skill-file-paths.test.ts",
+    "src/lib/server/automation-log-paths.test.ts",
     "src/lib/voice/registry.test.ts",
     "src/lib/voice/hydrate-instructions.test.ts",
     "src/lib/voice/append-voice-turn.test.ts",
@@ -526,6 +527,7 @@ const ALIAS_LOADER = new Set([
   "src/lib/server/familiar-avatar.test.ts",
   "src/lib/workflow-generate.test.ts",
   "src/lib/server/automation-runner.test.ts",
+  "src/lib/server/automation-log-paths.test.ts",
 ]);
 
 /** Build the `node` argv (flags + file) for a single test path. */

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -33,6 +33,7 @@ const contracts: RouteContract[] = [
   { route: "/codex-automations/[id]", methods: ["GET", "PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/codex-automations/[id]/run", methods: ["POST"], kind: "json", localOriginGuard: true },
   { route: "/codex-automations/[id]/runs", methods: ["GET"], kind: "json" },
+  { route: "/codex-automations/[id]/runs/[runId]/log", methods: ["GET"], kind: "json" },
   { route: "/codex-automations", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/config", methods: ["GET", "PATCH"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/coven-calls", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },

--- a/src/app/api/codex-automations/[id]/runs/[runId]/log/route.ts
+++ b/src/app/api/codex-automations/[id]/runs/[runId]/log/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { readFile } from "node:fs/promises";
+import { listRuns } from "@/lib/automation-runs";
+import { isAllowedAutomationLogPath, MAX_RUN_LOG_BYTES } from "@/lib/server/automation-log-paths";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string; runId: string }> }) {
+  const { id, runId } = await params;
+  const run = (await listRuns(id)).find((r) => r.id === runId);
+  if (!run?.logPath) return NextResponse.json({ ok: false, error: "no log for this run" }, { status: 404 });
+  if (!(await isAllowedAutomationLogPath(run.logPath))) {
+    return NextResponse.json({ ok: false, error: "log not available" }, { status: 404 });
+  }
+  let text = await readFile(run.logPath, "utf8");
+  let truncated = false;
+  if (text.length > MAX_RUN_LOG_BYTES) {
+    text = text.slice(text.length - MAX_RUN_LOG_BYTES); // tail
+    truncated = true;
+  }
+  return NextResponse.json({ ok: true, log: text, truncated });
+}

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -525,6 +525,24 @@ function CodexDetailPanel({
   const isActive = auto.status === "ACTIVE";
   const parsedSchedule = useMemo(() => parseCodexRrule(auto.rrule), [auto.rrule]);
   const promptParts = splitAutomationPrompt(auto.prompt);
+  const [openRunId, setOpenRunId] = useState<string | null>(null);
+  const [runLog, setRunLog] = useState<string>("");
+  const [runLogLoading, setRunLogLoading] = useState(false);
+  const toggleRunLog = async (runId: string) => {
+    if (openRunId === runId) { setOpenRunId(null); return; }
+    setOpenRunId(runId);
+    setRunLog("");
+    setRunLogLoading(true);
+    try {
+      const res = await fetch(`/api/codex-automations/${encodeURIComponent(auto.id)}/runs/${encodeURIComponent(runId)}/log`, { cache: "no-store" });
+      const json = await res.json().catch(() => null);
+      setRunLog(json?.ok ? (json.truncated ? "…(truncated)…\n" : "") + (json.log ?? "") : (json?.error ?? "no log"));
+    } catch {
+      setRunLog("failed to load log");
+    } finally {
+      setRunLogLoading(false);
+    }
+  };
   const [name, setName] = useState(auto.name);
   const [goals, setGoals] = useState(promptParts.goals);
   const [deliverables, setDeliverables] = useState(promptParts.deliverables);
@@ -914,11 +932,25 @@ function CodexDetailPanel({
             <FieldLabel>Recent runs</FieldLabel>
             <ul className="mt-1 space-y-1">
               {runs.slice(0, 10).map((r) => (
-                <li key={r.id} className="flex items-center gap-2 text-[12px]">
-                  <span className="h-2 w-2 shrink-0 rounded-full" style={{ background:
-                    r.status === "succeeded" ? "var(--accent-presence)" : r.status === "failed" ? "var(--color-danger)" : "var(--text-muted)" }} />
-                  <span style={{ color: "var(--text-secondary)" }}>{relTime(r.startedAt)}</span>
-                  {r.summary && <span className="truncate" style={{ color: "var(--text-muted)" }}>{r.summary}</span>}
+                <li key={r.id}>
+                  <button
+                    type="button"
+                    onClick={() => void toggleRunLog(r.id)}
+                    className="flex w-full items-center gap-2 rounded px-1 py-0.5 text-left text-[12px] hover:bg-white/5"
+                  >
+                    <span className="h-2 w-2 shrink-0 rounded-full" style={{ background:
+                      r.status === "succeeded" ? "var(--accent-presence)" : r.status === "failed" ? "var(--color-danger)" : "var(--text-muted)" }} />
+                    <span style={{ color: "var(--text-secondary)" }}>{relTime(r.startedAt)}</span>
+                    {r.summary && <span className="truncate" style={{ color: "var(--text-muted)" }}>{r.summary}</span>}
+                    <span className="ml-auto shrink-0" style={{ color: "var(--text-muted)", lineHeight: 0 }}>
+                      <Icon name={openRunId === r.id ? "ph:caret-down" : "ph:caret-right"} width={11} />
+                    </span>
+                  </button>
+                  {openRunId === r.id && (
+                    <pre className="mt-1 max-h-48 overflow-auto rounded bg-[var(--bg-base)] p-2 text-[10px] leading-snug" style={{ color: "var(--text-muted)", whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+                      {runLogLoading ? "Loading…" : (runLog || "(empty log)")}
+                    </pre>
+                  )}
                 </li>
               ))}
             </ul>
@@ -1027,7 +1059,10 @@ function AutomationScheduleRow({
           </span>
         )}
         {lastRun && (
-          <span className="shrink-0 text-[11px]" style={{ color: "var(--text-muted)" }}>
+          <span className="shrink-0 text-[11px]" style={{ color:
+            lastRun.status === "failed" ? "var(--color-danger)"
+            : lastRun.status === "running" ? "var(--accent-presence)"
+            : "var(--text-muted)" }}>
             Run {relTime(lastRun.startedAt)}
           </span>
         )}

--- a/src/lib/server/automation-log-paths.test.ts
+++ b/src/lib/server/automation-log-paths.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { test, before, after } from "node:test";
+import { mkdtemp, mkdir, writeFile, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+let home: string;
+before(async () => {
+  home = await mkdtemp(path.join(tmpdir(), "coven-home-"));
+  process.env.COVEN_HOME = home;
+  await mkdir(path.join(home, "automation-run-logs"), { recursive: true });
+});
+after(async () => { delete process.env.COVEN_HOME; await rm(home, { recursive: true, force: true }); });
+
+test("accepts a real .log inside the run-logs dir; rejects outside / non-log / symlink", async () => {
+  const { isAllowedAutomationLogPath } = await import("./automation-log-paths.ts");
+  const good = path.join(home, "automation-run-logs", "abc.log");
+  await writeFile(good, "hi", "utf8");
+  assert.ok(await isAllowedAutomationLogPath(good));
+  assert.ok(!(await isAllowedAutomationLogPath(path.join(home, "automation-run-logs", "abc.txt")))); // not .log (missing file too)
+  const outside = path.join(home, "secret.log");
+  await writeFile(outside, "nope", "utf8");
+  assert.ok(!(await isAllowedAutomationLogPath(outside))); // outside the dir
+  const link = path.join(home, "automation-run-logs", "link.log");
+  await symlink(outside, link);
+  assert.ok(!(await isAllowedAutomationLogPath(link))); // symlink rejected
+});

--- a/src/lib/server/automation-log-paths.ts
+++ b/src/lib/server/automation-log-paths.ts
@@ -1,0 +1,27 @@
+import { lstat, realpath } from "node:fs/promises";
+import path from "node:path";
+import { covenHome } from "@/lib/coven-paths";
+
+export const MAX_RUN_LOG_BYTES = 256 * 1024;
+
+function logsRoot(): string {
+  return path.join(covenHome(), "automation-run-logs");
+}
+
+function isWithinRoot(resolved: string, root: string): boolean {
+  return resolved === root || resolved.startsWith(root + path.sep);
+}
+
+/** True iff `fullPath` is a real (non-symlink) `.log` file inside the automation run-logs dir. */
+export async function isAllowedAutomationLogPath(fullPath: string): Promise<boolean> {
+  if (!fullPath || path.extname(fullPath) !== ".log") return false;
+  try {
+    const st = await lstat(fullPath);
+    if (st.isSymbolicLink() || !st.isFile()) return false;
+    const resolved = await realpath(fullPath);
+    const root = await realpath(logsRoot());
+    return isWithinRoot(resolved, root);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Polish on the Slice C run-history (#1583), completing the run-now loop.

- **Run-log viewer**: each "Recent runs" row in the detail panel is now clickable → lazily fetches + inline-expands that run's captured output (`GET /api/codex-automations/[id]/runs/[runId]/log`, guarded to `~/.coven/automation-run-logs/*.log` via a realpath-containment helper, tailed at 256KB).
- **Failed-run visibility**: the row's last-run badge now colors by outcome (danger when the last run failed, accent while running) so a broken automation is visible at a glance.

Path guard + route are unit/contract-tested; the UI is straightforward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)