### PR TITLE
feat(report): shared hover-able sparkline on cockpit + daily-report metrics

### DIFF
--- a/src/app/daily-report/[date]/page.tsx
+++ b/src/app/daily-report/[date]/page.tsx
@@ -8,7 +8,9 @@ import {
   parseDateSlug,
   parseRecentSessions,
   parseStatsFromBody,
+  recentReports,
   relativeTime,
+  type DailyReportStats,
 } from "@/lib/daily-report";
 
 export const dynamic = "force-dynamic";
@@ -62,6 +64,25 @@ export default async function DailyReportPage({ params }: Props) {
 
   const stats = item.media?.stats ?? parseStatsFromBody(item.body);
   const breakdown = breakdownForDay(inbox.items, parsedDate ?? new Date());
+
+  // 7-day trend per metric, ending on this report's date, from the daily reports.
+  const slugFor = (d: Date) =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  const statBySlug = new Map(recentReports(inbox.items).map((r) => [r.slug, r.stats]));
+  const trendBase = parsedDate ?? new Date();
+  const trendFor = (metric: keyof DailyReportStats) => {
+    const out: { label: string; value: number | null }[] = [];
+    for (let i = 6; i >= 0; i--) {
+      const d = new Date(trendBase);
+      d.setDate(trendBase.getDate() - i);
+      const s = statBySlug.get(slugFor(d));
+      out.push({
+        label: d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" }),
+        value: s ? s[metric] : null,
+      });
+    }
+    return out;
+  };
   const recentSessions = parseRecentSessions(item.body);
   const generatedAt = item.firedAt ?? item.updatedAt ?? null;
   const totalEvents = stats
@@ -130,6 +151,7 @@ export default async function DailyReportPage({ params }: Props) {
               label="Reminders fired"
               caption={stats.reminders === 1 ? "1 reminder" : `${stats.reminders} reminders`}
               accent="amber"
+              trend={trendFor("reminders")}
             />
             <MetricCard
               icon="ph:chat-circle-dots"
@@ -137,6 +159,7 @@ export default async function DailyReportPage({ params }: Props) {
               label="Responses waiting"
               caption="Need your reply"
               accent="rose"
+              trend={trendFor("responses")}
             />
             <MetricCard
               icon="ph:sparkle"
@@ -144,6 +167,7 @@ export default async function DailyReportPage({ params }: Props) {
               label="Familiar updates"
               caption="From your agents"
               accent="lavender"
+              trend={trendFor("familiars")}
             />
             <MetricCard
               icon="ph:graph-bold"
@@ -151,6 +175,7 @@ export default async function DailyReportPage({ params }: Props) {
               label="Sessions updated"
               caption="Coding & chat work"
               accent="green"
+              trend={trendFor("sessions")}
             />
           </section>
         ) : null}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7857,6 +7857,7 @@ a.mobile-handoff__link:hover {
 .dr-metric__value { font-size: 38px; font-weight: 720; line-height: 1; letter-spacing: -0.02em; }
 .dr-metric__label { margin-top: 8px; font-size: 13px; font-weight: 560; color: var(--text-primary); }
 .dr-metric__caption { margin-top: 2px; font-size: 12px; color: var(--text-muted); }
+.dr-metric__spark { margin-top: 10px; height: 26px; }
 .dr-metric--muted .dr-metric__value { color: var(--text-muted); }
 /* Linkable metric cards get a hover lift + a reveal-on-hover go affordance. */
 a.dr-metric--link { display: block; color: inherit; text-decoration: none; }

--- a/src/components/daily-report-ui.tsx
+++ b/src/components/daily-report-ui.tsx
@@ -7,6 +7,7 @@
 import type { ReactNode } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import type { InboxItem } from "@/lib/cave-inbox";
+import { Sparkline, type SparkPoint } from "@/components/ui/sparkline";
 import {
   KIND_ICON,
   KIND_LABEL,
@@ -32,6 +33,7 @@ export function MetricCard({
   caption,
   accent = "lavender",
   href,
+  trend,
 }: {
   icon: IconName;
   value: number | string;
@@ -39,6 +41,8 @@ export function MetricCard({
   caption?: string;
   accent?: Accent;
   href?: string;
+  /** Optional 7-day trend — renders a hover-able sparkline under the metric. */
+  trend?: SparkPoint[];
 }) {
   const muted = value === 0 || value === "0";
   const className = `dr-metric${muted ? " dr-metric--muted" : ""}${href ? " dr-metric--link" : ""}`;
@@ -58,6 +62,11 @@ export function MetricCard({
       <div className="dr-metric__value">{value}</div>
       <div className="dr-metric__label">{label}</div>
       {caption ? <div className="dr-metric__caption">{caption}</div> : null}
+      {trend && trend.length ? (
+        <div className="dr-metric__spark">
+          <Sparkline points={trend} color={ACCENT_VAR[accent]} height={26} />
+        </div>
+      ) : null}
     </>
   );
   if (href) {

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -10,6 +10,7 @@ import type { GitHubItem } from "@/lib/github-tasks";
 import type { InboxItem } from "@/lib/cave-inbox";
 import { relativeTime } from "@/lib/daily-report";
 import { SectionHead, EmptyState, QuickLink } from "@/components/daily-report-ui";
+import { Sparkline, type SparkPoint } from "@/components/ui/sparkline";
 import { ActionInbox } from "@/components/dashboard/action-inbox";
 import { TodaySummary } from "@/components/dashboard/today-summary";
 import { RecentReports } from "@/components/dashboard/recent-reports";
@@ -76,14 +77,17 @@ function dayKey(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
-/** Last `TREND_DAYS` values for one metric, oldest→newest; null for missing days. */
-function seriesFor(store: TrendStore, key: TrendKey, now: Date): (number | null)[] {
-  const out: (number | null)[] = [];
+/** Last `TREND_DAYS` points for one metric, oldest→newest; null value for missing days. */
+function seriesFor(store: TrendStore, key: TrendKey, now: Date): SparkPoint[] {
+  const out: SparkPoint[] = [];
   for (let i = TREND_DAYS - 1; i >= 0; i--) {
     const d = new Date(now);
     d.setDate(now.getDate() - i);
     const v = store[dayKey(d)]?.[key];
-    out.push(typeof v === "number" ? v : null);
+    out.push({
+      label: d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" }),
+      value: typeof v === "number" ? v : null,
+    });
   }
   return out;
 }
@@ -356,9 +360,9 @@ const KPI_ACCENT: Record<KpiSpec["accent"], string> = {
   blue: "var(--color-info)", amber: "var(--color-warning)",
 };
 
-function KpiTile({ icon, value, label, accent, href, loading, series }: KpiSpec & { loading: boolean; series: (number | null)[] }) {
+function KpiTile({ icon, value, label, accent, href, loading, series }: KpiSpec & { loading: boolean; series: SparkPoint[] }) {
   const color = KPI_ACCENT[accent];
-  const pts = series.filter((v): v is number => v != null);
+  const pts = series.map((p) => p.value).filter((v): v is number => v != null);
   const delta = pts.length >= 2 ? pts[pts.length - 1] - pts[0] : 0;
   const inner = (
     <>
@@ -374,30 +378,10 @@ function KpiTile({ icon, value, label, accent, href, loading, series }: KpiSpec 
       </span>
       <span className="cockpit-kpi__value">{loading ? "—" : value}</span>
       <span className="cockpit-kpi__label">{label}</span>
-      <Sparkline values={series} color={color} />
+      <Sparkline points={series} color={color} height={22} />
     </>
   );
   return href ? <a className="cockpit-kpi" href={href}>{inner}</a> : <div className="cockpit-kpi">{inner}</div>;
-}
-
-/** Inline 7-day sparkline — line + faint area fill. Sparse data degrades to a
- *  flat baseline; <2 points renders nothing (the trend is still accumulating). */
-function Sparkline({ values, color }: { values: (number | null)[]; color: string }) {
-  const pts = values.map((v, i) => ({ v, i })).filter((p): p is { v: number; i: number } => p.v != null);
-  if (pts.length < 2) return <span className="cockpit-spark cockpit-spark--flat" aria-hidden />;
-  const W = 100, H = 22, P = 2;
-  const vs = pts.map((p) => p.v);
-  const min = Math.min(...vs), max = Math.max(...vs), range = max - min || 1;
-  const x = (i: number) => (i / (TREND_DAYS - 1)) * W;
-  const y = (v: number) => H - P - ((v - min) / range) * (H - 2 * P);
-  const line = pts.map((p, idx) => `${idx === 0 ? "M" : "L"}${x(p.i).toFixed(1)},${y(p.v).toFixed(1)}`).join(" ");
-  const area = `${line} L${x(pts[pts.length - 1].i).toFixed(1)},${H} L${x(pts[0].i).toFixed(1)},${H} Z`;
-  return (
-    <svg className="cockpit-spark" viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" aria-hidden>
-      <path d={area} fill={color} opacity="0.13" />
-      <path d={line} fill="none" stroke={color} strokeWidth="1.6" strokeLinejoin="round" strokeLinecap="round" />
-    </svg>
-  );
 }
 
 // ─── Board snapshot ──────────────────────────────────────────────────────────────

--- a/src/components/ui/sparkline.tsx
+++ b/src/components/ui/sparkline.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export type SparkPoint = { label: string; value: number | null };
+
+/**
+ * A compact trend sparkline (line + faint area fill) with a hover tooltip
+ * showing the value for the day under the cursor. Width is measured so the
+ * line and the hovered marker stay crisp (no non-uniform SVG scaling).
+ */
+export function Sparkline({ points, color, height = 26 }: { points: SparkPoint[]; color: string; height?: number }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [w, setW] = useState(120);
+  const [hover, setHover] = useState<number | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width;
+      if (width) setW(width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const n = points.length;
+  const valid = points.map((p, i) => ({ ...p, i })).filter((p): p is { label: string; value: number; i: number } => p.value != null);
+  if (valid.length < 2) {
+    return <div className="spark spark--flat" style={{ height }} aria-hidden />;
+  }
+
+  const vs = valid.map((p) => p.value);
+  const min = Math.min(...vs), max = Math.max(...vs), range = max - min || 1;
+  const PAD = 3;
+  const x = (i: number) => (n <= 1 ? w / 2 : (i / (n - 1)) * w);
+  const y = (v: number) => height - PAD - ((v - min) / range) * (height - 2 * PAD);
+  const line = valid.map((p, idx) => `${idx === 0 ? "M" : "L"}${x(p.i).toFixed(1)},${y(p.value).toFixed(1)}`).join(" ");
+  const area = `${line} L${x(valid[valid.length - 1].i).toFixed(1)},${height} L${x(valid[0].i).toFixed(1)},${height} Z`;
+
+  const hp = hover != null ? points[hover] : null;
+  const hoverActive = hp != null && hp.value != null;
+
+  return (
+    <div
+      ref={ref}
+      className="spark"
+      style={{ height }}
+      onMouseLeave={() => setHover(null)}
+      onMouseMove={(e) => {
+        const rect = e.currentTarget.getBoundingClientRect();
+        const rel = (e.clientX - rect.left) / (rect.width || 1);
+        setHover(Math.max(0, Math.min(n - 1, Math.round(rel * (n - 1)))));
+      }}
+    >
+      <svg width={w} height={height} viewBox={`0 0 ${w} ${height}`} preserveAspectRatio="none" aria-hidden>
+        <path d={area} fill={color} opacity="0.13" />
+        <path d={line} fill="none" stroke={color} strokeWidth="1.6" strokeLinejoin="round" strokeLinecap="round" />
+        {hover != null ? (
+          <line x1={x(hover)} y1="0" x2={x(hover)} y2={height} stroke="var(--border-strong)" strokeWidth="1" />
+        ) : null}
+        {hoverActive ? (
+          <circle cx={x(hover!)} cy={y(hp!.value as number)} r="2.6" fill={color} stroke="var(--bg-raised)" strokeWidth="1.5" />
+        ) : null}
+      </svg>
+      {hoverActive ? (
+        <span className="spark-tip" style={{ left: `${(x(hover!) / (w || 1)) * 100}%` }}>
+          <b>{hp!.value}</b> · {hp!.label}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -216,10 +216,18 @@ a.cockpit-kpi:hover { border-color: var(--border-strong); transform: translateY(
 .cockpit-kpi__delta { font-size: 10px; font-weight: 700; color: var(--text-muted); font-variant-numeric: tabular-nums; letter-spacing: -0.02em; }
 .cockpit-kpi__value { font-size: 24px; font-weight: 700; line-height: 1.1; color: var(--text-primary); font-variant-numeric: tabular-nums; }
 .cockpit-kpi__label { font-size: 11.5px; color: var(--text-secondary); }
-/* 7-day trend sparkline */
-.cockpit-spark { display: block; width: 100%; height: 22px; margin-top: 7px; overflow: visible; }
-.cockpit-spark--flat { display: block; width: 100%; height: 22px; margin-top: 7px;
-  border-bottom: 1px dashed var(--border-hairline); opacity: 0.6; }
+/* Shared hover-able trend sparkline (cockpit KPIs + report metric cards) */
+.spark { position: relative; display: block; width: 100%; overflow: visible; }
+.spark svg { display: block; width: 100%; height: 100%; }
+.spark--flat { width: 100%; border-bottom: 1px dashed var(--border-hairline); opacity: 0.6; }
+.spark-tip { position: absolute; top: -7px; transform: translate(-50%, -100%);
+  white-space: nowrap; pointer-events: none; z-index: 4;
+  padding: 3px 7px; border-radius: 6px; font-size: 10.5px; line-height: 1.2;
+  color: var(--text-primary); background: var(--bg-elevated, var(--bg-raised));
+  border: 1px solid var(--border-strong); box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
+  font-variant-numeric: tabular-nums; }
+.spark-tip b { font-weight: 700; }
+.cockpit-kpi .spark { margin-top: 7px; }
 
 /* Main grid */
 .cockpit-grid { display: grid; grid-template-columns: minmax(0, 1.7fr) minmax(0, 1fr); gap: 16px; align-items: start; }


### PR DESCRIPTION
## What

Promote the inline cockpit `Sparkline` into a shared `components/ui/sparkline.tsx` so the daily-report `MetricCard` can reuse the same hover-tooltip trend chart. Same look as the cockpit; same crisp rendering; same date-on-hover behavior.

## Why

The daily-report metric cards had value + caption but no sense of trend — you couldn't tell at a glance whether reminders/responses/familiar updates were trending up or down. The cockpit already solved this with a private `Sparkline` component; promoting it means parity, no drift, less code.

## What changed

- **`src/components/ui/sparkline.tsx`** (new, 74 lines) — shared component accepting `points: SparkPoint[]` (`{label, value}`), a `color`, optional `height`. Measures own width via ResizeObserver, line + faint area fill, hover tooltip showing the day label + value, `.spark--flat` fallback for sparse series.
- **`dashboard-cockpit.tsx`** — drop the local `Sparkline`; `seriesFor` now returns `SparkPoint[]` with formatted date labels; `KpiTile` types adjusted.
- **`daily-report-ui.tsx`** — `MetricCard` gains an optional `trend?: SparkPoint[]` prop, renders inside `.dr-metric__spark` slot.
- **`daily-report/[date]/page.tsx`** — assembles a 7-day series per metric (reminders, responses, familiar updates) from `recentReports(inbox.items)`, ending on the report's date; passes through to each `MetricCard`.
- **`dashboard.css`** — old `.cockpit-spark` rules replaced by shared `.spark` + `.spark-tip` rules. `.cockpit-kpi .spark` retains the 7px top-margin.
- **`globals.css`** — add `.dr-metric__spark` slot.

## Diff size

`6 files changed, +132, -31` (net +101 with the new shared component).

## Notes

- Branch was 52 commits behind main pre-rebase; rebased clean onto today's tip.
- Pre-commit hook clean.

🐾 — Kitty (committed on Val's behalf)