### PR TITLE
feat(time): compact/verbose timestamp density preference

### DIFF
--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -14,6 +14,7 @@ import type {
 import type { AutomationRunRecord } from "@/lib/automation-runs";
 import { Icon } from "@/lib/icon";
 import { formatTimestamp, formatClock, readDateTimePrefs } from "@/lib/datetime-format";
+import { relativeTimeSigned } from "@/lib/relative-time";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
 import { Tabs, type TabItem } from "@/components/ui/tabs";
@@ -113,18 +114,7 @@ function isReminderOverdue(item: InboxItem): boolean {
 
 function relTime(iso: string | undefined | null): string {
   if (!iso) return "—";
-  const delta = new Date(iso).getTime() - Date.now();
-  const abs = Math.abs(delta);
-  const m = Math.round(abs / 60000);
-  if (m < 1) return delta > 0 ? "soon" : "just now";
-  if (m < 60) return delta > 0 ? `in ${m}m` : `${m}m ago`;
-  const h = Math.round(m / 60);
-  if (h < 24) return delta > 0 ? `in ${h}h` : `${h}h ago`;
-  const d = Math.round(h / 24);
-  if (d <= 6) return delta > 0 ? `in ${d}d` : `${d}d ago`;
-  // Beyond a week the relative form ("in 42d") is hard to parse — show the
-  // actual date + time, honoring the user's clock and date preferences.
-  return formatTimestamp(iso, readDateTimePrefs());
+  return relativeTimeSigned(iso);
 }
 
 function listInput(values: string[]): string {

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -40,6 +40,15 @@ import {
   setDemoModeEnabled,
 } from "@/lib/demo-mode";
 import { readableTextColor } from "@/lib/readable-text-color";
+import {
+  DATETIME_DENSITY_KEY,
+  DENSITY_OPTIONS,
+  DENSITY_LABEL,
+  normalizeDensity,
+  setDensityFormat,
+  type DensityFormat,
+} from "@/lib/datetime-format";
+import { relativeTimeSigned } from "@/lib/relative-time";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -862,12 +871,14 @@ function AppearanceSection() {
   const [colorEditorBase, setColorEditorBase] = useState<PresetTheme | null>(null);
   const [cornerRadius, setCornerRadius] = useState<CornerRadius>("default");
   const familiarSwitcherStyle = useFamiliarSwitcherStyle();
+  const [density, setDensity] = useState<DensityFormat>("compact");
 
   // Read persisted theme + mode on mount
   useEffect(() => {
     setActiveTheme(readPersistedTheme());
     setMode(readPersistedMode());
     setCornerRadius(readCornerRadius());
+    setDensity(normalizeDensity(typeof window !== "undefined" ? window.localStorage.getItem(DATETIME_DENSITY_KEY) : null));
     const saved = localStorage.getItem(COVEN_THEME_KEY);
     if (saved === "custom") {
       const raw = localStorage.getItem(COVEN_CUSTOM_THEME_KEY);
@@ -894,6 +905,11 @@ function AppearanceSection() {
   const handleSetCornerRadius = (next: CornerRadius) => {
     setCornerRadius(next);
     applyCornerRadius(next);
+  };
+
+  const handleSetDensity = (next: DensityFormat) => {
+    setDensity(next);
+    setDensityFormat(next);
   };
 
   const handleSetMode = (next: Mode) => {
@@ -1129,6 +1145,36 @@ function AppearanceSection() {
       </SettingsGroup>
 
       <FontSettings />
+
+      {/* ── Date & time ── compact vs verbose timestamp density */}
+      <SettingsGroup label="Date &amp; time">
+        <div className="px-4 py-3">
+          <p className="mb-2 text-[12px] text-[var(--text-muted)]">Timestamp density</p>
+          <div className="inline-flex items-center rounded-md border border-[var(--border-hairline)] p-0.5">
+            {DENSITY_OPTIONS.map((opt) => (
+              <button
+                key={opt}
+                type="button"
+                aria-pressed={density === opt}
+                onClick={() => handleSetDensity(opt)}
+                className={`rounded-[5px] px-3 py-1 text-[12px] font-medium transition-colors ${
+                  density === opt
+                    ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
+                    : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                }`}
+              >
+                {DENSITY_LABEL[opt]}
+              </button>
+            ))}
+          </div>
+          <p className="mt-2 text-[11px] text-[var(--text-muted)]">
+            Preview:{" "}
+            {relativeTimeSigned(new Date(Date.now() - 5 * 60000).toISOString(), Date.now(), density)}
+            {" · "}
+            {relativeTimeSigned(new Date(Date.now() - 3 * 86400000).toISOString(), Date.now(), density)}
+          </p>
+        </div>
+      </SettingsGroup>
 
       {/* ── Familiar switcher ── choose the top-bar familiar control: a row of
           quick-switch avatars, or just the switcher dropdown. */}

--- a/src/lib/relative-time.test.ts
+++ b/src/lib/relative-time.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { relativeTime, isRelativePhrase } from "./relative-time.ts";
+import { relativeTime, isRelativePhrase, relativeTimeSigned } from "./relative-time.ts";
 import { relativeTime as reExported } from "./daily-report.ts";
 import { readFileSync } from "node:fs";
 
@@ -72,4 +72,18 @@ test("isRelativePhrase distinguishes relative phrases from the absolute fallback
   assert.equal(isRelativePhrase("3d ago"), true);
   assert.equal(isRelativePhrase("Jun 6"), false);
   assert.equal(isRelativePhrase(""), false);
+});
+
+test("relativeTimeSigned handles past and future, compact + verbose", () => {
+  const now = new Date("2026-01-01T12:00:00Z").getTime();
+  // compact
+  assert.equal(relativeTimeSigned("2026-01-01T11:58:00Z", now, "compact"), "2m ago");
+  assert.equal(relativeTimeSigned("2026-01-01T12:05:00Z", now, "compact"), "in 5m");
+  assert.equal(relativeTimeSigned("2026-01-01T11:59:40Z", now, "compact"), "just now");
+  assert.equal(relativeTimeSigned("2026-01-01T12:00:20Z", now, "compact"), "soon");
+  // verbose
+  assert.equal(relativeTimeSigned("2026-01-01T10:00:00Z", now, "verbose"), "2 hours ago");
+  assert.equal(relativeTimeSigned("2026-01-01T14:00:00Z", now, "verbose"), "in 2 hours");
+  // null
+  assert.equal(relativeTimeSigned(null, now, "compact"), "");
 });

--- a/src/lib/relative-time.ts
+++ b/src/lib/relative-time.ts
@@ -56,3 +56,41 @@ export function relativeTime(
 export function isRelativePhrase(value: string): boolean {
   return value === "just now" || value.endsWith(" ago");
 }
+
+/**
+ * Bidirectional, density-aware relative time: "2m ago" / "in 5m" (compact) or
+ * "2 minutes ago" / "in 5 minutes" (verbose); "just now"/"soon" under a minute;
+ * an absolute date past ~a week. Unlike `relativeTime` (past-only), this also
+ * formats future instants — used for next-fire schedule times.
+ */
+export function relativeTimeSigned(
+  iso: string | null | undefined,
+  now: number | Date = Date.now(),
+  density: DensityFormat = readDensity(),
+): string {
+  if (!iso) return "";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const nowMs = typeof now === "number" ? now : now.getTime();
+  const deltaMs = nowMs - then; // >0 past, <0 future
+  const future = deltaMs < 0;
+  const deltaMin = Math.round(Math.abs(deltaMs) / 60000);
+  const m = deltaMin;
+  const verbose = density === "verbose";
+  const phrase = (n: number, compactUnit: string, verboseUnit: string): string => {
+    const body = verbose ? `${n} ${n === 1 ? verboseUnit : verboseUnit + "s"}` : `${n}${compactUnit}`;
+    return future ? `in ${body}` : `${body} ago`;
+  };
+  if (m < 1) return future ? "soon" : "just now";
+  if (m < 60) return phrase(m, "m", "minute");
+  const hours = Math.round(m / 60);
+  if (hours < 24) return phrase(hours, "h", "hour");
+  const days = Math.round(hours / 24);
+  if (days < 7) return phrase(days, "d", "day");
+  const sameYear = new Date(then).getFullYear() === new Date(nowMs).getFullYear();
+  return new Intl.DateTimeFormat([], {
+    month: verbose ? "long" : "short",
+    day: "numeric",
+    ...(sameYear ? {} : { year: "numeric" }),
+  }).format(then);
+}


### PR DESCRIPTION
Closes the relative-time backlog items: a settable timestamp density + a unified helper.

- **Settings → Appearance → Date & time**: a Compact/Verbose toggle (writes the existing `cave:datetime-density` pref, which `relativeTime`/`relativeTimeSigned`/`formatTimestamp` already read), with a live preview.
- **Unified helper**: new bidirectional, density-aware `relativeTimeSigned(iso, now?, density?)` in `relative-time.ts` (handles future "in 5m" for next-fire schedules, which the past-only `relativeTime` didn't). `automations-view`'s bespoke local `relTime` now delegates to it — so flipping the toggle visibly changes automation timestamps to "5 minutes ago" / "in 5 minutes".

Follows the run-history polish (#1584). Pure helper unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)