### PR TITLE
feat(menu-bar): show all familiars in the top bar, not just 6

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4695,14 +4695,16 @@ button:active > .edge-rail-chip {
   max-width: 180px;
 }
 
-/* Desktop top bar: cap the quick-switch strip so the labeled switcher and
-   search keep their room; overflow scrolls within the strip. */
+/* Desktop top bar: the strip surfaces every familiar. Let it grow with the
+   available width (responsive cap) so they're visible rather than hidden behind
+   a 6-avatar limit; the search keeps its min-width and the strip scrolls
+   horizontally only when the familiars genuinely overflow the cap. */
 .menu-bar__group--chat .familiar-quickswitch {
   min-width: 0;
 }
 
 .menu-bar__group--chat .familiar-quickswitch__strip {
-  max-width: 280px;
+  max-width: clamp(280px, 40vw, 600px);
 }
 
 .menu-bar__new,

--- a/src/components/familiar-menu-bar.test.ts
+++ b/src/components/familiar-menu-bar.test.ts
@@ -54,6 +54,12 @@ assert.match(
   /<FamiliarQuickSwitch[\s\S]*onSelectFamiliar=\{onSelectFamiliar\}/,
   "embeds the quick-switch strip + switcher for scope/full list",
 );
+// The top bar surfaces EVERY familiar, not just the default 6 most-recent.
+assert.match(
+  source,
+  /<FamiliarQuickSwitch[\s\S]*max=\{familiars\.length\}/,
+  "passes max={familiars.length} so the strip shows all familiars",
+);
 // The avatar bubbles + presence live inside FamiliarQuickSwitch, not inlined
 // here — the menu bar must not hand-roll its own bubble/presence markup.
 assert.doesNotMatch(

--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -79,6 +79,10 @@ export function FamiliarMenuBar({
           onSelectFamiliar={onSelectFamiliar}
           placement="bottom-start"
           labeled
+          // Surface every familiar in the top bar, not just the 6 most-recent.
+          // The strip stays pin/recency-ordered and scrolls horizontally when
+          // they overflow the available width.
+          max={familiars.length}
         />
       </div>
 


### PR DESCRIPTION
## What

The desktop top-bar familiar strip was capped at `QUICK_SWITCH_MAX` (6 pinned/recent familiars). Now it surfaces **every** familiar for one-tap switching.

- `FamiliarMenuBar`: pass `max={familiars.length}` to `FamiliarQuickSwitch`.
- `.menu-bar__group--chat .familiar-quickswitch__strip`: cap `280px` → `clamp(280px, 40vw, 600px)` so they're visible rather than hidden behind the old 6-avatar limit; the strip still scrolls horizontally only when familiars genuinely overflow.

Pin + recency ordering is unchanged — all familiars just appear instead of being truncated.

## Verify

Rendered the real top bar (demo, 1440px): all **11** demo familiars now render in the strip (was 6), no scroll needed at this width (`overflowing: false`). `familiar-menu-bar.test.ts` asserts the bar passes `max={familiars.length}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)