### PR TITLE
fix(permissions): bootstrap legacy familiar project grants

### DIFF
--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -252,8 +252,14 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /const chatProjectId = sshRuntime[\s\S]*await chatProjectAccessId\(\{[\s\S]*requestedProjectRoot: body\.projectRoot,[\s\S]*resumeCwd,[\s\S]*resolvedCwd: cwd,[\s\S]*\}\);[\s\S]*await assertProjectAccess\(\{ familiarId: body\.familiarId \}, chatProjectId, "chat"\);/,
+  /const chatProjectId = sshRuntime[\s\S]*return chatProjectAccessId\(\{[\s\S]*requestedProjectRoot: body\.projectRoot,[\s\S]*resumeCwd,[\s\S]*resolvedCwd: cwd,[\s\S]*\}\);[\s\S]*await assertProjectAccess\(\{ familiarId: body\.familiarId \}, chatProjectId, "chat"\);/,
   "Local project-scoped chat must assert project access before building the harness prompt",
+);
+
+assert.match(
+  chatRoute,
+  /bootstrapConfiguredFamiliarProjectGrants\([\s\S]*await loadProjects\(\),[\s\S]*\[body\.familiarId, \.\.\.Object\.keys\(config\.familiars\)\]/,
+  "Chat send should migrate legacy configured-familiar grants before enforcing the new project permission chokepoint",
 );
 
 assert.match(

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -62,6 +62,7 @@ import {
   type RuntimeScope,
 } from "@/lib/chat-runtime-scope";
 import {
+  bootstrapConfiguredFamiliarProjectGrants,
   ProjectAccessDeniedError,
   assertProjectAccess,
 } from "@/lib/project-permissions";
@@ -1029,11 +1030,17 @@ export async function POST(req: Request) {
   }
   const chatProjectId = sshRuntime
     ? null
-    : await chatProjectAccessId({
-        requestedProjectRoot: body.projectRoot,
-        resumeCwd,
-        resolvedCwd: cwd,
-      });
+    : await (async () => {
+        await bootstrapConfiguredFamiliarProjectGrants(
+          await loadProjects(),
+          [body.familiarId, ...Object.keys(config.familiars)],
+        );
+        return chatProjectAccessId({
+          requestedProjectRoot: body.projectRoot,
+          resumeCwd,
+          resolvedCwd: cwd,
+        });
+      })();
   if (chatProjectId) {
     try {
       await assertProjectAccess({ familiarId: body.familiarId }, chatProjectId, "chat");

--- a/src/app/api/project-permission-routes.test.ts
+++ b/src/app/api/project-permission-routes.test.ts
@@ -35,6 +35,11 @@ assert.match(
 );
 assert.match(
   helper,
+  /bootstrapConfiguredFamiliarProjectGrants\([\s\S]*projects,[\s\S]*familiarId,[\s\S]*\.\.\.Object\.keys\(config\.familiars\)/,
+  "project API request helper should run the legacy configured-familiar grant bootstrap before enforcing access",
+);
+assert.match(
+  helper,
   /ProjectAccessDeniedError\("missing familiarId for project access"\)/,
   "project API request helper should fail closed when no familiarId is supplied",
 );

--- a/src/app/api/projects/route.test.ts
+++ b/src/app/api/projects/route.test.ts
@@ -7,6 +7,11 @@ const itemRoute = readFileSync(new URL("./[id]/route.ts", import.meta.url), "utf
 const seedRoute = readFileSync(new URL("./seed/route.ts", import.meta.url), "utf8");
 
 assert.match(listRoute, /seedDefaultProjectsIfEmpty/, "GET /api/projects should seed defaults before listing");
+assert.match(
+  listRoute,
+  /bootstrapConfiguredFamiliarProjectGrants\(projects, Object\.keys\(config\.familiars\)\)/,
+  "GET /api/projects should migrate legacy configured-familiar grants before familiar-scoped filtering",
+);
 assert.match(listRoute, /export async function GET\(req: Request\)/, "projects route should expose GET");
 assert.match(listRoute, /searchParams\.get\("familiarId"\)/, "GET /api/projects should accept familiar-scoped listing");
 assert.match(listRoute, /isValidFamiliarId\(familiarId\)/, "GET /api/projects should validate familiar id before scoping");

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server";
 
+import { loadConfig } from "@/lib/cave-config";
 import { createProject, loadProjects, seedDefaultProjectsIfEmpty } from "@/lib/cave-projects";
-import { filterProjectsForFamiliar } from "@/lib/project-permissions";
+import {
+  bootstrapConfiguredFamiliarProjectGrants,
+  filterProjectsForFamiliar,
+} from "@/lib/project-permissions";
 import { isValidFamiliarId } from "@/lib/server/familiar-id";
 
 export const dynamic = "force-dynamic";
@@ -9,6 +13,8 @@ export const dynamic = "force-dynamic";
 export async function GET(req: Request) {
   await seedDefaultProjectsIfEmpty();
   const projects = await loadProjects();
+  const config = await loadConfig();
+  await bootstrapConfiguredFamiliarProjectGrants(projects, Object.keys(config.familiars));
   const familiarId = new URL(req.url).searchParams.get("familiarId")?.trim() || null;
   if (!familiarId) return NextResponse.json({ ok: true, projects });
   if (!isValidFamiliarId(familiarId)) {

--- a/src/lib/project-permissions.test.ts
+++ b/src/lib/project-permissions.test.ts
@@ -12,6 +12,7 @@ process.env.CAVE_SUPREME_FAMILIAR_ID = "supreme";
 try {
   const {
     assertProjectAccess,
+    bootstrapConfiguredFamiliarProjectGrants,
     bootstrapSupremeProjectGrants,
     canAccessProject,
     createGrantProposal,
@@ -109,6 +110,45 @@ try {
     [["cave", "bootstrap"], ["docs", "bootstrap"]],
     "bootstrap records Supreme grants for all existing projects",
   );
+
+  const legacyTmp = await mkdtemp(path.join(tmpdir(), "project-permissions-legacy-"));
+  process.env.CAVE_PROJECT_PERMISSIONS_PATH_OVERRIDE = path.join(legacyTmp, "permissions.json");
+  try {
+    const changed = await bootstrapConfiguredFamiliarProjectGrants(projects, [
+      "nova",
+      "sage",
+      "",
+      "../bad",
+    ]);
+    assert.equal(changed, true, "legacy bootstrap should run once for empty grant stores");
+    const legacyBootstrapped = await loadProjectPermissions();
+    assert.deepEqual(
+      legacyBootstrapped.projectGrants.map((grant) => [
+        grant.familiarId,
+        grant.projectId,
+        grant.source,
+      ]),
+      [
+        ["nova", "cave", "bootstrap"],
+        ["nova", "docs", "bootstrap"],
+        ["sage", "cave", "bootstrap"],
+        ["sage", "docs", "bootstrap"],
+      ],
+      "legacy bootstrap grants every configured familiar to existing projects explicitly",
+    );
+    assert.ok(
+      legacyBootstrapped.legacyConfiguredGrantsBootstrappedAt,
+      "legacy bootstrap should record a migration marker",
+    );
+    assert.equal(
+      await bootstrapConfiguredFamiliarProjectGrants(projects, ["cody"]),
+      false,
+      "legacy bootstrap should not run again after the marker is written",
+    );
+  } finally {
+    await rm(legacyTmp, { recursive: true, force: true });
+    process.env.CAVE_PROJECT_PERMISSIONS_PATH_OVERRIDE = path.join(tmp, "permissions.json");
+  }
 
   console.log("project-permissions.test.ts: ok");
 } finally {

--- a/src/lib/project-permissions.ts
+++ b/src/lib/project-permissions.ts
@@ -50,6 +50,7 @@ type ProjectPermissionsFile = {
   projectGrants: ProjectGrant[];
   grantProposals: GrantProposal[];
   permissionAudit: PermissionAuditEntry[];
+  legacyConfiguredGrantsBootstrappedAt?: string;
 };
 
 type HumanPermissionConfigFile = {
@@ -121,6 +122,10 @@ export async function loadProjectPermissions(): Promise<ProjectPermissionsFile> 
     projectGrants: Array.isArray(parsed.projectGrants) ? parsed.projectGrants : [],
     grantProposals: Array.isArray(parsed.grantProposals) ? parsed.grantProposals : [],
     permissionAudit: Array.isArray(parsed.permissionAudit) ? parsed.permissionAudit : [],
+    legacyConfiguredGrantsBootstrappedAt:
+      typeof parsed.legacyConfiguredGrantsBootstrappedAt === "string"
+        ? parsed.legacyConfiguredGrantsBootstrappedAt
+        : undefined,
   };
 }
 
@@ -285,6 +290,47 @@ export async function bootstrapSupremeProjectGrants(projects: CaveProject[]): Pr
       source: "bootstrap",
     });
   }
+}
+
+function configuredFamiliarIds(values: readonly string[]): string[] {
+  const unique = new Set<string>();
+  for (const value of values) {
+    const familiarId = value.trim();
+    if (/^[a-z0-9_-]+$/i.test(familiarId)) unique.add(familiarId);
+  }
+  return [...unique];
+}
+
+export async function bootstrapConfiguredFamiliarProjectGrants(
+  projects: CaveProject[],
+  familiarIds: readonly string[],
+): Promise<boolean> {
+  const targetFamiliarIds = configuredFamiliarIds(familiarIds);
+  if (projects.length === 0 || targetFamiliarIds.length === 0) return false;
+
+  return withWriteMutex(async () => {
+    const file = await loadProjectPermissions();
+    if (
+      file.legacyConfiguredGrantsBootstrappedAt ||
+      file.projectGrants.length > 0 ||
+      file.grantProposals.length > 0
+    ) {
+      return false;
+    }
+
+    for (const familiarId of targetFamiliarIds) {
+      for (const project of projects) {
+        ensureProjectGrant(file, {
+          familiarId,
+          projectId: project.id,
+          source: "bootstrap",
+        });
+      }
+    }
+    file.legacyConfiguredGrantsBootstrappedAt = new Date().toISOString();
+    await saveProjectPermissions(file);
+    return true;
+  });
 }
 
 export async function createGrantProposal(input: {

--- a/src/lib/server/project-permission-requests.ts
+++ b/src/lib/server/project-permission-requests.ts
@@ -1,10 +1,12 @@
 import path from "node:path";
 
+import { loadConfig } from "@/lib/cave-config";
 import { loadProjects } from "@/lib/cave-projects";
 import type { CaveProject } from "@/lib/cave-projects-types";
 import {
   ProjectAccessDeniedError,
   assertProjectAccess,
+  bootstrapConfiguredFamiliarProjectGrants,
   type ProjectPermissionSurface,
 } from "@/lib/project-permissions";
 import { MOBILE_ACCESS_HEADER } from "@/proxy-helpers";
@@ -44,7 +46,13 @@ export async function assertProjectApiAccess(args: {
   if (!requestedPath) {
     throw new ProjectAccessDeniedError("missing project path for permission check");
   }
-  const project = projectRootForPath(requestedPath, await loadProjects());
+  const projects = await loadProjects();
+  const config = await loadConfig();
+  await bootstrapConfiguredFamiliarProjectGrants(projects, [
+    familiarId,
+    ...Object.keys(config.familiars),
+  ]);
+  const project = projectRootForPath(requestedPath, projects);
   if (!project) {
     throw new ProjectAccessDeniedError("project is not registered for permission checks");
   }


### PR DESCRIPTION
## Summary
- Bootstrap one-time explicit project grants for configured familiars when legacy installs have no grant/proposal state.
- Run the bootstrap at shared project API, chat send, and project listing permission boundaries before enforcing scoped access.
- Add guard tests for chat, project listing, project API helpers, and invalid familiar ids.

## Test Plan
- node --experimental-strip-types src/lib/project-permissions.test.ts
- node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts
- node --experimental-strip-types src/app/api/projects/route.test.ts
- node --experimental-strip-types src/app/api/project-permission-routes.test.ts
- git diff --check origin/main...HEAD
- pnpm typecheck
- pnpm test:api (81 test files)

Co-authored-by: Nova <nova@openclaw.local>