### PR TITLE
feat(automations): live run status + visible ⌘-click filter hint

### DIFF
--- a/src/components/automation-familiar-select.tsx
+++ b/src/components/automation-familiar-select.tsx
@@ -64,6 +64,11 @@ export function FamiliarMultiSelect({ familiars, selected, onChange }: Props) {
           </button>
         );
       })}
+      {familiars.length > 1 && (
+        <span className="ml-1 text-[11px]" style={{ color: "var(--text-muted)" }}>
+          ⌘-click to combine
+        </span>
+      )}
     </div>
   );
 }

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -1362,6 +1362,18 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     }
   }, [selectedCodex?.id, refreshRuns]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // While a run is in flight, poll so its status + log fill in without a manual refresh.
+  useEffect(() => {
+    if (!selectedCodex?.id) return;
+    if (!automationRuns.some((r) => r.status === "running")) return;
+    const id = selectedCodex.id;
+    const t = setInterval(() => {
+      void refreshRuns(id);
+      void refreshLastRuns();
+    }, 2500);
+    return () => clearInterval(t);
+  }, [selectedCodex?.id, automationRuns, refreshRuns, refreshLastRuns]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Refresh last-run map whenever the automation list changes
   useEffect(() => {
     if (codexAutos.length > 0) void refreshLastRuns();


### PR DESCRIPTION
Two small Automations-surface UX wins:

- **Live run status**: after Run now, the detail panel now auto-polls the runs (every 2.5s) while any run is `running`, so it flips to succeeded/failed and the log fills in without a manual refresh; polling stops once nothing's in flight.
- **Discoverability**: the familiar filter shows a subtle "⌘-click to combine" hint (when >1 familiar) so the multi-select affordance is visible, not just a hover tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)