### PR TITLE
feat(time): timestamp density pref applies live (subscribe surfaces)

### DIFF
--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -13,7 +13,7 @@ import type {
 } from "@/lib/codex-automations-types";
 import type { AutomationRunRecord } from "@/lib/automation-runs";
 import { Icon } from "@/lib/icon";
-import { formatTimestamp, formatClock, readDateTimePrefs } from "@/lib/datetime-format";
+import { formatTimestamp, formatClock, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
 import { relativeTimeSigned } from "@/lib/relative-time";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
@@ -1277,6 +1277,7 @@ function InboxFeedList({
 
 // ── Root ──────────────────────────────────────────────────────────────────────
 export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdit, onOpenLink }: Props) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [items, setItems] = useState<InboxItem[]>([]);
   const [codexAutos, setCodexAutos] = useState<CodexAutomation[]>([]);
   const [error, setError] = useState<string | null>(null);

--- a/src/components/familiar-status-card.tsx
+++ b/src/components/familiar-status-card.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { relativeTime } from "@/lib/relative-time";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 import { FamiliarGlyph } from "@/components/familiar-glyph";
 import { parseGlyphString } from "@/lib/familiar-glyph";
 import { Icon } from "@/lib/icon";
@@ -163,6 +164,7 @@ type Props = {
 };
 
 export function FamiliarStatusCard({ card, expanded, onToggle }: Props) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const statusClr = statusColor(card.status);
   const label = statusLabel(card.status);
 

--- a/src/components/library-doc-list.tsx
+++ b/src/components/library-doc-list.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
-import { formatDate } from "@/lib/datetime-format";
+import { formatDate, useDateTimePrefs } from "@/lib/datetime-format";
 import { relativeTime } from "@/lib/relative-time";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
@@ -59,6 +59,7 @@ export function LibraryDocList({
   error,
   onRetry,
 }: Props) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const filtered = useMemo(() => filterDocs(docs, searchQuery), [docs, searchQuery]);
   const movableCollections = useMemo(() => collections.filter((collection) => collection.id !== "all"), [collections]);
   const movableCollectionIds = useMemo(() => new Set(movableCollections.map((c) => c.id)), [movableCollections]);

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { relativeTime } from "@/lib/relative-time";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { Familiar } from "@/lib/types";
 import type { InboxPrefs, SoundMode } from "@/lib/cave-inbox-prefs";
@@ -30,6 +31,7 @@ export function NotificationBell({
   onOpenItem,
   onPrefsChanged,
 }: Props) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [open, setOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement | null>(null);

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState, type CSSProperties, type FormEven
 
 import { Icon } from "@/lib/icon";
 import { relativeTime } from "@/lib/relative-time";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 import { useMinuteTick } from "@/lib/use-minute-tick";
 import type { CaveProject } from "@/lib/cave-projects-types";
 import { normalizeProjectRoot } from "@/lib/cave-projects-types";
@@ -543,6 +544,7 @@ function ProjectRow({
 }
 
 export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: ProjectsViewProps) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   useMinuteTick(); // keep the per-project "last active" relative times current
   const {
     projects,


### PR DESCRIPTION
The compact/verbose timestamp-density pref already has a `useSyncExternalStore` store (`useDateTimePrefs`) with `notify()` on change — but timestamp surfaces called `relativeTime` without subscribing, so the toggle only took effect on next navigation. This subscribes the high-traffic surfaces (Automations, notifications, projects, library docs, familiar status) so flipping Compact/Verbose re-renders their timestamps instantly.

Follow-up to #1586/#1587 (the relativeTimeSigned unification). 

Note: ~20 other surfaces still hand-roll bespoke "Xm ago" strings (they ignore the pref entirely) — migrating those to `relativeTime` is a separate incremental sweep, tracked for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)