### PR TITLE
fix(menu-bar): standardize top-bar icons + buttons smaller/on-token

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4579,11 +4579,11 @@ button:active > .edge-rail-chip {
   display: none;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  padding: 6px 12px;
+  gap: 12px;
+  padding: 5px 12px;
   /* min-height (not a fixed height) so the bar grows with scaled-up content
      under screen magnification instead of clipping the search row. */
-  min-height: 44px;
+  min-height: 38px;
   background: var(--bg-panel);
   border-bottom: 1px solid var(--border-hairline);
   font-size: var(--text-sm);
@@ -4619,7 +4619,7 @@ button:active > .edge-rail-chip {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 5px 12px;
+  padding: 4px 10px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
@@ -4641,12 +4641,11 @@ button:active > .edge-rail-chip {
 
 .menu-bar__search-icon {
   flex-shrink: 0;
-  /* One standard size across the top chrome: var(--icon-md) matches the
-     familiar avatars (FamiliarAvatar "sm" / the labeled trigger img) and the
-     sidepanel toggle glyph, so icons and avatars all read at 16px. */
+  /* Compact top-chrome standard (var(--icon-sm), 14px) — shared with the
+     menu-bar action icons and the sidepanel toggle glyph. */
   align-self: center;
-  width: var(--icon-md);
-  height: var(--icon-md);
+  width: var(--icon-sm);
+  height: var(--icon-sm);
 }
 
 .menu-bar__search-input {
@@ -4657,7 +4656,7 @@ button:active > .edge-rail-chip {
   background: transparent;
   color: var(--text-primary);
   font: inherit;
-  font-size: 16px;
+  font-size: var(--text-base);
   line-height: 1.4;
 }
 
@@ -4712,25 +4711,25 @@ button:active > .edge-rail-chip {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 5px 10px;
+  padding: 4px 9px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
   color: var(--foreground);
-  font-size: 17px;
+  font-size: var(--text-base);
   white-space: nowrap;
   cursor: pointer;
   transition: background var(--duration-fast) var(--ease-standard),
     border-color var(--duration-fast) var(--ease-standard);
 }
 
-/* One standard size across the top chrome (var(--icon-md), 16px): the
-   Enhance/Tasks/Inbox glyphs match the familiar avatars and the sidepanel
-   toggle, rather than scaling with their own label. */
+/* One compact standard across the top chrome (var(--icon-sm), 14px): the
+   Enhance/Tasks/Inbox glyphs, the search glyph, and the sidepanel toggle all
+   share this size, rather than scaling with their own label. */
 .menu-bar__task > svg {
   flex-shrink: 0;
-  width: var(--icon-md);
-  height: var(--icon-md);
+  width: var(--icon-sm);
+  height: var(--icon-sm);
 }
 
 .menu-bar__new {
@@ -4753,11 +4752,11 @@ button:active > .edge-rail-chip {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 17px;
-  height: 17px;
+  min-width: 15px;
+  height: 15px;
   padding: 0 5px;
-  border-radius: 9px;
-  font-size: 11px;
+  border-radius: 8px;
+  font-size: 10px;
   font-weight: 600;
   line-height: 1;
   color: var(--accent-presence-foreground);

--- a/src/components/menu-bar-icon-size.test.ts
+++ b/src/components/menu-bar-icon-size.test.ts
@@ -2,14 +2,14 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
-// One standard top-chrome glyph size, var(--icon-md) — the same as the familiar
-// avatars (FamiliarAvatar "sm" / the labeled trigger img) — so icons, toggles,
-// and avatars all read at 16px.
-assert.match(css, /\.menu-bar__task > svg\s*\{[\s\S]*?width:\s*var\(--icon-md\)[\s\S]*?height:\s*var\(--icon-md\)/, "task icon is var(--icon-md) (avatar size)");
-assert.match(css, /\.menu-bar__search-icon\s*\{[\s\S]*?width:\s*var\(--icon-md\)[\s\S]*?height:\s*var\(--icon-md\)/, "search icon is var(--icon-md) (avatar size)");
-// The sidepanel/nav toggle glyph and the familiar avatar share the same token.
+// One compact top-chrome glyph size, var(--icon-sm) (14px) — shared by the
+// menu-bar action icons, the search glyph, and the sidepanel toggle.
+assert.match(css, /\.menu-bar__task > svg\s*\{[\s\S]*?width:\s*var\(--icon-sm\)[\s\S]*?height:\s*var\(--icon-sm\)/, "task icon is var(--icon-sm)");
+assert.match(css, /\.menu-bar__search-icon\s*\{[\s\S]*?width:\s*var\(--icon-sm\)[\s\S]*?height:\s*var\(--icon-sm\)/, "search icon is var(--icon-sm)");
+// Action buttons + search input use the design-token body size, not ad-hoc px.
+assert.match(css, /\.menu-bar__new,\s*\n\.menu-bar__task\s*\{[\s\S]*?font-size:\s*var\(--text-base\)/, "menu-bar buttons use var(--text-base)");
+assert.match(css, /\.menu-bar__search-input\s*\{[\s\S]*?font-size:\s*var\(--text-base\)/, "search input uses var(--text-base)");
+// The sidepanel/nav toggle glyph stays unified with the action icons.
 const iconLib = readFileSync(new URL("../lib/icon.tsx", import.meta.url), "utf8");
-assert.match(iconLib, /shellToggle:\s*"var\(--icon-md\)"/, "sidepanel toggle glyph is var(--icon-md)");
-const avatar = readFileSync(new URL("./familiar-avatar.tsx", import.meta.url), "utf8");
-assert.match(avatar, /sm:\s*16/, "familiar avatar 'sm' is 16px (= var(--icon-md))");
+assert.match(iconLib, /shellToggle:\s*"var\(--icon-sm\)"/, "sidepanel toggle glyph is var(--icon-sm)");
 console.log("menu-bar-icon-size.test.ts passed");

--- a/src/lib/icon.tsx
+++ b/src/lib/icon.tsx
@@ -288,9 +288,9 @@ export const CAVE_ICON_SIZE = {
   headerToggle: "var(--icon-md)",
   headerAction: "var(--icon-md)",
   headerSearch: "var(--icon-sm)",
-  // The top sidepanel/nav toggles share the standard top-chrome glyph size so
-  // they match the familiar avatars and the menu-bar action icons (16px).
-  shellToggle: "var(--icon-md)",
+  // The top sidepanel/nav toggles share the compact top-chrome glyph size so
+  // they stay unified with the menu-bar action icons (14px).
+  shellToggle: "var(--icon-sm)",
   shellNav: "var(--icon-sm)",
   shellInline: "var(--icon-xs)",
   shellDismiss: "var(--icon-xs)",


### PR DESCRIPTION
## What

The desktop top bar mixed ad-hoc pixel sizes (17px button labels, 16px search text, 16px icons) on a 44px floor. Standardize onto the design tokens and make it more compact.

- **Buttons + search text:** `17px` / `16px` → `var(--text-base)` (13px); tighter padding (task `5px 10px` → `4px 9px`, search `5px 12px` → `4px 10px`).
- **Icons:** `var(--icon-md)` → `var(--icon-sm)` (14px) for the Enhance/Tasks/Inbox glyphs, the search glyph, **and** the sidepanel toggle — the whole top chrome stays unified at one size.
- **Badge:** `17px`→`15px`, `11px`→`10px`. **Bar:** gap `16`→`12`, padding `6`→`5`, min-height `44`→`38`.

## Verify

Rendered the real top bar (demo, 1440px): button text 13px, all icons (task / search / toggle) 14px, bar height **44px** (was ~50px). `menu-bar-icon-size.test.ts` pins the icon rules to `var(--icon-sm)`, the button/search text to `var(--text-base)`, and the `shellToggle` token to `var(--icon-sm)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)