### PR TITLE
chore: release cave v0.0.111

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.110",
+  "version": "0.0.111",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.110"
+version = "0.0.111"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.110"
+version = "0.0.111"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.110</string>
+	<string>0.0.111</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.110</string>
+	<string>0.0.111</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.110</string>
+	<string>0.0.111</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.110</string>
+	<string>0.0.111</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.110",
+  "version": "0.0.111",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -252,14 +252,14 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /const chatProjectId = sshRuntime[\s\S]*return chatProjectAccessId\(\{[\s\S]*requestedProjectRoot: body\.projectRoot,[\s\S]*resumeCwd,[\s\S]*resolvedCwd: cwd,[\s\S]*\}\);[\s\S]*await assertProjectAccess\(\{ familiarId: body\.familiarId \}, chatProjectId, "chat"\);/,
+  /const chatProjectId = sshRuntime[\s\S]*await chatProjectAccessId\(\{[\s\S]*requestedProjectRoot: body\.projectRoot,[\s\S]*resumeCwd,[\s\S]*resolvedCwd: cwd,[\s\S]*\}\);[\s\S]*await assertProjectAccess\(\{ familiarId: body\.familiarId \}, chatProjectId, "chat"\);/,
   "Local project-scoped chat must assert project access before building the harness prompt",
 );
 
-assert.match(
+assert.doesNotMatch(
   chatRoute,
-  /bootstrapConfiguredFamiliarProjectGrants\([\s\S]*await loadProjects\(\),[\s\S]*\[body\.familiarId, \.\.\.Object\.keys\(config\.familiars\)\]/,
-  "Chat send should migrate legacy configured-familiar grants before enforcing the new project permission chokepoint",
+  /bootstrapConfiguredFamiliarProjectGrants/,
+  "Chat send must not grant configured familiars project access before enforcing the chokepoint",
 );
 
 assert.match(

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -62,7 +62,6 @@ import {
   type RuntimeScope,
 } from "@/lib/chat-runtime-scope";
 import {
-  bootstrapConfiguredFamiliarProjectGrants,
   ProjectAccessDeniedError,
   assertProjectAccess,
 } from "@/lib/project-permissions";
@@ -1030,17 +1029,11 @@ export async function POST(req: Request) {
   }
   const chatProjectId = sshRuntime
     ? null
-    : await (async () => {
-        await bootstrapConfiguredFamiliarProjectGrants(
-          await loadProjects(),
-          [body.familiarId, ...Object.keys(config.familiars)],
-        );
-        return chatProjectAccessId({
-          requestedProjectRoot: body.projectRoot,
-          resumeCwd,
-          resolvedCwd: cwd,
-        });
-      })();
+    : await chatProjectAccessId({
+        requestedProjectRoot: body.projectRoot,
+        resumeCwd,
+        resolvedCwd: cwd,
+      });
   if (chatProjectId) {
     try {
       await assertProjectAccess({ familiarId: body.familiarId }, chatProjectId, "chat");

--- a/src/app/api/project-permission-routes.test.ts
+++ b/src/app/api/project-permission-routes.test.ts
@@ -33,10 +33,10 @@ assert.match(
   /export async function assertProjectApiAccess\([\s\S]*familiarId[\s\S]*projectRootForPath[\s\S]*await assertProjectAccess\(\{ familiarId \}, project\.id, surface\)/,
   "project API request helper should resolve a registered project from the requested path/root and assert access",
 );
-assert.match(
+assert.doesNotMatch(
   helper,
-  /bootstrapConfiguredFamiliarProjectGrants\([\s\S]*projects,[\s\S]*familiarId,[\s\S]*\.\.\.Object\.keys\(config\.familiars\)/,
-  "project API request helper should run the legacy configured-familiar grant bootstrap before enforcing access",
+  /bootstrapConfiguredFamiliarProjectGrants/,
+  "project API request helper must not auto-grant configured familiars before enforcing access",
 );
 assert.match(
   helper,

--- a/src/app/api/projects/route.test.ts
+++ b/src/app/api/projects/route.test.ts
@@ -7,10 +7,10 @@ const itemRoute = readFileSync(new URL("./[id]/route.ts", import.meta.url), "utf
 const seedRoute = readFileSync(new URL("./seed/route.ts", import.meta.url), "utf8");
 
 assert.match(listRoute, /seedDefaultProjectsIfEmpty/, "GET /api/projects should seed defaults before listing");
-assert.match(
+assert.doesNotMatch(
   listRoute,
-  /bootstrapConfiguredFamiliarProjectGrants\(projects, Object\.keys\(config\.familiars\)\)/,
-  "GET /api/projects should migrate legacy configured-familiar grants before familiar-scoped filtering",
+  /bootstrapConfiguredFamiliarProjectGrants/,
+  "GET /api/projects must not auto-grant configured familiars before familiar-scoped filtering",
 );
 assert.match(listRoute, /export async function GET\(req: Request\)/, "projects route should expose GET");
 assert.match(listRoute, /searchParams\.get\("familiarId"\)/, "GET /api/projects should accept familiar-scoped listing");

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,11 +1,7 @@
 import { NextResponse } from "next/server";
 
-import { loadConfig } from "@/lib/cave-config";
 import { createProject, loadProjects, seedDefaultProjectsIfEmpty } from "@/lib/cave-projects";
-import {
-  bootstrapConfiguredFamiliarProjectGrants,
-  filterProjectsForFamiliar,
-} from "@/lib/project-permissions";
+import { filterProjectsForFamiliar } from "@/lib/project-permissions";
 import { isValidFamiliarId } from "@/lib/server/familiar-id";
 
 export const dynamic = "force-dynamic";
@@ -13,8 +9,6 @@ export const dynamic = "force-dynamic";
 export async function GET(req: Request) {
   await seedDefaultProjectsIfEmpty();
   const projects = await loadProjects();
-  const config = await loadConfig();
-  await bootstrapConfiguredFamiliarProjectGrants(projects, Object.keys(config.familiars));
   const familiarId = new URL(req.url).searchParams.get("familiarId")?.trim() || null;
   if (!familiarId) return NextResponse.json({ ok: true, projects });
   if (!isValidFamiliarId(familiarId)) {

--- a/src/lib/project-permissions.test.ts
+++ b/src/lib/project-permissions.test.ts
@@ -12,7 +12,6 @@ process.env.CAVE_SUPREME_FAMILIAR_ID = "supreme";
 try {
   const {
     assertProjectAccess,
-    bootstrapConfiguredFamiliarProjectGrants,
     bootstrapSupremeProjectGrants,
     canAccessProject,
     createGrantProposal,
@@ -110,45 +109,13 @@ try {
     [["cave", "bootstrap"], ["docs", "bootstrap"]],
     "bootstrap records Supreme grants for all existing projects",
   );
-
-  const legacyTmp = await mkdtemp(path.join(tmpdir(), "project-permissions-legacy-"));
-  process.env.CAVE_PROJECT_PERMISSIONS_PATH_OVERRIDE = path.join(legacyTmp, "permissions.json");
-  try {
-    const changed = await bootstrapConfiguredFamiliarProjectGrants(projects, [
-      "nova",
-      "sage",
-      "",
-      "../bad",
-    ]);
-    assert.equal(changed, true, "legacy bootstrap should run once for empty grant stores");
-    const legacyBootstrapped = await loadProjectPermissions();
-    assert.deepEqual(
-      legacyBootstrapped.projectGrants.map((grant) => [
-        grant.familiarId,
-        grant.projectId,
-        grant.source,
-      ]),
-      [
-        ["nova", "cave", "bootstrap"],
-        ["nova", "docs", "bootstrap"],
-        ["sage", "cave", "bootstrap"],
-        ["sage", "docs", "bootstrap"],
-      ],
-      "legacy bootstrap grants every configured familiar to existing projects explicitly",
-    );
-    assert.ok(
-      legacyBootstrapped.legacyConfiguredGrantsBootstrappedAt,
-      "legacy bootstrap should record a migration marker",
-    );
-    assert.equal(
-      await bootstrapConfiguredFamiliarProjectGrants(projects, ["cody"]),
-      false,
-      "legacy bootstrap should not run again after the marker is written",
-    );
-  } finally {
-    await rm(legacyTmp, { recursive: true, force: true });
-    process.env.CAVE_PROJECT_PERMISSIONS_PATH_OVERRIDE = path.join(tmp, "permissions.json");
-  }
+  assert.deepEqual(
+    bootstrapped.projectGrants
+      .filter((grant) => grant.familiarId !== "supreme")
+      .map((grant) => grant.familiarId),
+    ["nova"],
+    "bootstrap must not grant every configured familiar to existing projects",
+  );
 
   console.log("project-permissions.test.ts: ok");
 } finally {

--- a/src/lib/project-permissions.ts
+++ b/src/lib/project-permissions.ts
@@ -50,7 +50,6 @@ type ProjectPermissionsFile = {
   projectGrants: ProjectGrant[];
   grantProposals: GrantProposal[];
   permissionAudit: PermissionAuditEntry[];
-  legacyConfiguredGrantsBootstrappedAt?: string;
 };
 
 type HumanPermissionConfigFile = {
@@ -122,10 +121,6 @@ export async function loadProjectPermissions(): Promise<ProjectPermissionsFile> 
     projectGrants: Array.isArray(parsed.projectGrants) ? parsed.projectGrants : [],
     grantProposals: Array.isArray(parsed.grantProposals) ? parsed.grantProposals : [],
     permissionAudit: Array.isArray(parsed.permissionAudit) ? parsed.permissionAudit : [],
-    legacyConfiguredGrantsBootstrappedAt:
-      typeof parsed.legacyConfiguredGrantsBootstrappedAt === "string"
-        ? parsed.legacyConfiguredGrantsBootstrappedAt
-        : undefined,
   };
 }
 
@@ -290,47 +285,6 @@ export async function bootstrapSupremeProjectGrants(projects: CaveProject[]): Pr
       source: "bootstrap",
     });
   }
-}
-
-function configuredFamiliarIds(values: readonly string[]): string[] {
-  const unique = new Set<string>();
-  for (const value of values) {
-    const familiarId = value.trim();
-    if (/^[a-z0-9_-]+$/i.test(familiarId)) unique.add(familiarId);
-  }
-  return [...unique];
-}
-
-export async function bootstrapConfiguredFamiliarProjectGrants(
-  projects: CaveProject[],
-  familiarIds: readonly string[],
-): Promise<boolean> {
-  const targetFamiliarIds = configuredFamiliarIds(familiarIds);
-  if (projects.length === 0 || targetFamiliarIds.length === 0) return false;
-
-  return withWriteMutex(async () => {
-    const file = await loadProjectPermissions();
-    if (
-      file.legacyConfiguredGrantsBootstrappedAt ||
-      file.projectGrants.length > 0 ||
-      file.grantProposals.length > 0
-    ) {
-      return false;
-    }
-
-    for (const familiarId of targetFamiliarIds) {
-      for (const project of projects) {
-        ensureProjectGrant(file, {
-          familiarId,
-          projectId: project.id,
-          source: "bootstrap",
-        });
-      }
-    }
-    file.legacyConfiguredGrantsBootstrappedAt = new Date().toISOString();
-    await saveProjectPermissions(file);
-    return true;
-  });
 }
 
 export async function createGrantProposal(input: {

--- a/src/lib/server/project-permission-requests.ts
+++ b/src/lib/server/project-permission-requests.ts
@@ -1,12 +1,10 @@
 import path from "node:path";
 
-import { loadConfig } from "@/lib/cave-config";
 import { loadProjects } from "@/lib/cave-projects";
 import type { CaveProject } from "@/lib/cave-projects-types";
 import {
   ProjectAccessDeniedError,
   assertProjectAccess,
-  bootstrapConfiguredFamiliarProjectGrants,
   type ProjectPermissionSurface,
 } from "@/lib/project-permissions";
 import { MOBILE_ACCESS_HEADER } from "@/proxy-helpers";
@@ -47,11 +45,6 @@ export async function assertProjectApiAccess(args: {
     throw new ProjectAccessDeniedError("missing project path for permission check");
   }
   const projects = await loadProjects();
-  const config = await loadConfig();
-  await bootstrapConfiguredFamiliarProjectGrants(projects, [
-    familiarId,
-    ...Object.keys(config.familiars),
-  ]);
   const project = projectRootForPath(requestedPath, projects);
   if (!project) {
     throw new ProjectAccessDeniedError("project is not registered for permission checks");


### PR DESCRIPTION
## Summary
- Bump CovenCave release metadata to v0.0.111.
- Remove the configured-familiar legacy bootstrap that auto-granted every configured familiar to every project on empty permission stores.
- Add/adjust guards so chat send, project picker, and project file APIs do not auto-grant before enforcing project access.

## Verification
- node --experimental-strip-types src/lib/project-permissions.test.ts
- node --experimental-strip-types src/lib/app-version.test.ts
- node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts
- node --experimental-strip-types src/app/api/projects/route.test.ts
- node --experimental-strip-types src/app/api/project-permission-routes.test.ts
- pnpm check:tests-wired
- pnpm typecheck
- pnpm test:app
- pnpm test:api
- pnpm test:mobile
- pnpm build
- cargo test -q (src-tauri)
- git diff --check