### PR TITLE
fix(menu-bar): shrink top-bar avatar tiles to match the compact chrome

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4706,6 +4706,14 @@ button:active > .edge-rail-chip {
   max-width: clamp(280px, 40vw, 600px);
 }
 
+/* Compact avatar tiles to match the standardized top-bar icons (14px) and
+   13px labels — smaller than the default 28px strip bubble, scoped to the
+   desktop menu bar so the mobile `.top-bar` strip is unaffected. */
+.menu-bar .familiar-quickswitch__btn {
+  width: 22px;
+  height: 22px;
+}
+
 .menu-bar__new,
 .menu-bar__task {
   display: inline-flex;

--- a/src/components/menu-bar-icon-size.test.ts
+++ b/src/components/menu-bar-icon-size.test.ts
@@ -12,4 +12,6 @@ assert.match(css, /\.menu-bar__search-input\s*\{[\s\S]*?font-size:\s*var\(--text
 // The sidepanel/nav toggle glyph stays unified with the action icons.
 const iconLib = readFileSync(new URL("../lib/icon.tsx", import.meta.url), "utf8");
 assert.match(iconLib, /shellToggle:\s*"var\(--icon-sm\)"/, "sidepanel toggle glyph is var(--icon-sm)");
+// Avatar tiles are shrunk in the desktop menu bar to match the compact chrome.
+assert.match(css, /\.menu-bar \.familiar-quickswitch__btn\s*\{[\s\S]*?width:\s*22px[\s\S]*?height:\s*22px/, "menu-bar avatar tiles are 22px");
 console.log("menu-bar-icon-size.test.ts passed");


### PR DESCRIPTION
## What

The familiar quick-switch avatar bubbles in the desktop top bar stayed at **28px** after the chrome was standardized to 14px icons / 13px labels (#1592), so they looked oversized next to everything else. Shrink them to **22px**.

- `.menu-bar .familiar-quickswitch__btn`: `28px` → `22px`, scoped to the desktop menu bar so the mobile `.top-bar` strip keeps its own sizing.

## Verify

Rendered the real top bar (demo, 1440px): all 11 avatar tiles now measure **22px** and sit in proportion with the 14px icons and 13px text. `menu-bar-icon-size.test.ts` pins the avatar-tile rule to `22px`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)