### PR TITLE
feat(docs): in-app Docs surface embedding docs.opencoven.ai

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -108,6 +108,7 @@ export const SUITES = {
     "src/components/surface-loading-states.test.ts",
     "src/components/chat-header-row.test.ts",
     "src/components/sidebar-minimal.test.ts",
+    "src/components/docs-pane.test.ts",
     "src/components/sidepanel-badges.test.ts",
     "src/components/sidepanel-badge-dots.test.ts",
     "src/components/sidepanel-nav-peek.test.ts",

--- a/src/components/docs-pane.test.ts
+++ b/src/components/docs-pane.test.ts
@@ -1,0 +1,35 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./docs-pane.tsx", import.meta.url), "utf8");
+
+assert.match(
+  source,
+  /const DOCS_URL = "https:\/\/docs\.opencoven\.ai"/,
+  "DocsPane points at the OpenCoven docs site",
+);
+
+assert.match(
+  source,
+  /<iframe[\s\S]*src=\{DOCS_URL\}/,
+  "DocsPane embeds the docs URL in an iframe",
+);
+
+// The framed docs must never be able to navigate the whole app away from
+// itself — `allow-top-navigation` is intentionally omitted from the sandbox.
+assert.match(source, /sandbox="[^"]*allow-scripts[^"]*"/, "iframe allows scripts (docs search/nav need JS)");
+assert.doesNotMatch(
+  source,
+  /sandbox="[^"]*allow-top-navigation[^"]*"/,
+  "iframe sandbox must not allow top navigation",
+);
+
+// An external escape hatch is kept in case the docs host ever refuses framing.
+assert.match(
+  source,
+  /href=\{DOCS_URL\}[\s\S]*target="_blank"[\s\S]*rel="noopener noreferrer"/,
+  "DocsPane keeps an open-in-new-tab link to the docs",
+);
+
+console.log("docs-pane.test.ts passed");

--- a/src/components/docs-pane.tsx
+++ b/src/components/docs-pane.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+
+import { Icon } from "@/lib/icon";
+
+/** The OpenCoven documentation site, embedded in-app. */
+export const DOCS_URL = "https://docs.opencoven.ai";
+
+/**
+ * DocsPane — embeds the OpenCoven docs site (docs.opencoven.ai) inside the app
+ * as a full-height iframe. The site sends no `X-Frame-Options` and no
+ * frame-blocking CSP, so it frames cleanly in both the Tauri desktop webview
+ * and plain web / mobile Safari. A thin header keeps an "open externally"
+ * escape hatch in case the docs host ever starts refusing to be framed.
+ *
+ * The iframe sandbox intentionally omits `allow-top-navigation` so the framed
+ * docs can never navigate the whole app away from itself; `allow-popups` lets
+ * external links in the docs open in a new tab as usual.
+ */
+export function DocsPane() {
+  const [loaded, setLoaded] = useState(false);
+
+  return (
+    <div className="relative flex h-full min-h-0 flex-col bg-[var(--bg-base)]">
+      <div className="flex items-center gap-2 border-b border-[var(--border-hairline)] px-4 py-2">
+        <Icon name="ph:book-bookmark" width={16} height={16} aria-hidden />
+        <span className="text-[13px] font-semibold text-[var(--text-primary)]">Docs</span>
+        <span className="truncate text-[12px] text-[var(--text-muted)]">docs.opencoven.ai</span>
+        <a
+          href={DOCS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="ui-btn ui-btn--ghost ui-btn--sm focus-ring ml-auto"
+        >
+          <Icon name="ph:arrow-square-out" width={14} height={14} aria-hidden />
+          Open
+        </a>
+      </div>
+      <div className="relative min-h-0 flex-1">
+        {!loaded ? (
+          <div className="absolute inset-0 flex items-center justify-center text-[13px] text-[var(--text-muted)]">
+            Loading docs…
+          </div>
+        ) : null}
+        <iframe
+          src={DOCS_URL}
+          title="Documentation"
+          onLoad={() => setLoaded(true)}
+          className="absolute inset-0 h-full w-full border-0 bg-[var(--bg-base)]"
+          sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -140,6 +140,12 @@ assert.match(
   "Library is the last shortcut Tools surface, on ⌘0 (shortcuts ascend with sidebar order)",
 );
 
+assert.match(
+  source,
+  /\{ id: "docs", label: "Docs", iconName: "ph:book-bookmark", group: "tools", description:/,
+  "Docs is a Tools surface embedding the OpenCoven docs site",
+);
+
 // Library is a gated add-on (default off): the nav filter hides it until the
 // add-on is enabled, mirroring GitHub. Tools always has non-gated surfaces
 // (Browser/Terminal/Code/Roles/Workflows), so it never renders an empty header.

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -35,7 +35,8 @@ export type FolderMode =
   | "workflows"
   | "library"
   | "capabilities"
-  | "journal";
+  | "journal"
+  | "docs";
 
 export type AddonsConfig = {
   github?: boolean;
@@ -97,6 +98,7 @@ const FOLDER_MODES: Array<{
   { id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools", kbd: "⌘7", description: "Shell session in your project" },
   { id: "code", label: "Code", iconName: "ph:code", group: "tools", kbd: "⌘8", description: "Chat with a familiar beside your files and terminal" },
   { id: "library", label: "Library", iconName: "ph:books", group: "tools", kbd: "⌘0", description: "Saved docs, links, and reading" },
+  { id: "docs", label: "Docs", iconName: "ph:book-bookmark", group: "tools", description: "OpenCoven documentation and guides" },
   { id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools", description: "Agent personas, workflows, skills, and the capabilities your familiars can use" },
   { id: "workflows", label: "Workflows", iconName: "ph:git-branch-bold", group: "tools", description: "Multi-step pipelines that orchestrate familiars" },
   // Add-ons (gated)

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -41,6 +41,7 @@ import { ComuxView } from "@/components/comux-view";
 import { CodeView } from "@/components/code-view";
 import { GitHubView } from "@/components/github-view";
 import { LibraryView } from "@/components/library-view";
+import { DocsPane } from "@/components/docs-pane";
 import { PluginsView } from "@/components/plugins-view";
 import { WorkflowsView } from "@/components/workflows-view";
 import { RetroRunsView } from "@/components/retro-runs-view";
@@ -95,6 +96,7 @@ const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = {
   retro: "Retro Runs",
   capabilities: "Capabilities",
   journal: "Journal",
+  docs: "Docs",
 };
 
 // Chat deep links (CHAT-D9-01): `#chat-<sessionId>` re-enters a specific
@@ -1802,6 +1804,8 @@ export function Workspace() {
       />
     ) : mode === "browser" ? (
       <BrowserPane ref={browserPaneRef} label="main" activeFamiliarId={active?.id ?? null} />
+    ) : mode === "docs" ? (
+      <DocsPane />
     ) : mode === "github" ? (
       <GitHubView
         onJumpToSession={openFamiliarSession}

--- a/src/lib/workspace-mode.ts
+++ b/src/lib/workspace-mode.ts
@@ -14,4 +14,5 @@ export type WorkspaceMode =
   | "workflows"
   | "retro"
   | "capabilities"
-  | "journal";
+  | "journal"
+  | "docs";


### PR DESCRIPTION
## What

Adds a **Docs** tab to the Tools section of the left nav that opens the OpenCoven documentation site (**docs.opencoven.ai**) embedded inside the app.

## How

- New `docs` `WorkspaceMode` + `FolderMode`, a nav entry (`ph:book-bookmark`, Tools group), a `WORKSPACE_MODE_TITLES` title, and a render case in `workspace.tsx`.
- `src/components/docs-pane.tsx` — `DocsPane` renders a full-height `<iframe>` of the docs site with a thin header (title + "Open ↗" external link).
  - The docs host (Vercel) sends **no `X-Frame-Options` and no frame-blocking CSP**, so it frames cleanly in the Tauri desktop webview and in plain web / mobile Safari.
  - The iframe `sandbox` intentionally **omits `allow-top-navigation`** so the framed docs can never navigate the whole app away; `allow-popups` lets external links open in a new tab. The header's "Open ↗" link is an escape hatch if the host ever starts refusing framing.

## Tests

- `docs-pane.test.ts` — pins the URL, the iframe embed, the sandbox (scripts allowed, top-navigation disallowed), and the open-externally link.
- `sidebar-minimal.test.ts` — pins the new Docs nav entry.
- Both wired into `scripts/run-tests.mjs`.

Local: `pnpm typecheck` clean · `pnpm check:tests-wired` ✓ (465) · full `test:app` 369 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)