### PR TITLE
feat(ui): density pref applies live on 5 more relative-time surfaces

### DIFF
--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -9,6 +9,7 @@ import { platformizeHint, useKeySymbols } from "@/lib/platform-keys";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { parseFamiliarToken, resolveFamiliarIds } from "@/lib/command-palette-scope";
 import { relativeTime } from "@/lib/relative-time";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { FOLDER_MODES, type FolderMode, type AddonsConfig } from "@/components/sidebar-minimal";
 import { useProjects } from "@/lib/use-projects";
@@ -239,6 +240,7 @@ export function CommandPalette({
   onIntent,
   addons,
 }: Props) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const { projects } = useProjects();
   const [query, setQuery] = useState("");
   const [activeIdx, setActiveIdx] = useState(0);

--- a/src/components/coven-floor.tsx
+++ b/src/components/coven-floor.tsx
@@ -5,7 +5,7 @@ import { relativeTime } from "@/lib/relative-time";
 
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
-import { formatClock } from "@/lib/datetime-format";
+import { formatClock, useDateTimePrefs } from "@/lib/datetime-format";
 import type { CovenStatusResponse, FamiliarCard, SessionSummary } from "@/lib/coven-status-types";
 import { statusColor, statusLabel } from "@/lib/coven-status-types";
 import { SessionInitiatorChip } from "@/components/ui/session-initiator-chip";
@@ -237,6 +237,7 @@ function SessionSummaryRow({ counts }: { counts: ReturnType<typeof sessionCounts
 }
 
 export function CovenFloor() {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [familiars, setFamiliars] = useState<FamiliarCard[]>([]);
   const [computedAt, setComputedAt] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/src/components/dashboard/action-inbox.tsx
+++ b/src/components/dashboard/action-inbox.tsx
@@ -5,7 +5,7 @@ import { Icon, type IconName } from "@/lib/icon";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import type { InboxItem } from "@/lib/cave-inbox";
 import { KIND_ICON, KIND_LABEL, itemHasTarget, itemHref, relativeTime } from "@/lib/daily-report";
-import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
+import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
 import { nextItemsAfterAction } from "@/lib/dashboard-model";
 
 type Action = "done" | "dismiss" | "snooze";
@@ -27,6 +27,7 @@ function minutesUntilTomorrowMorning(): number {
 }
 
 export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [items, setItems] = useState<InboxItem[]>(initialItems);
   const [error, setError] = useState<string | null>(null);
   const [snoozeOpenId, setSnoozeOpenId] = useState<string | null>(null);

--- a/src/components/health-strip.tsx
+++ b/src/components/health-strip.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { relativeTime } from "@/lib/relative-time";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 import type { Familiar } from "@/lib/types";
 
 type DaemonHealth = {
@@ -65,6 +66,7 @@ function relTime(iso: string): string {
 }
 
 export function HealthStrip({ familiars }: { familiars: Familiar[] }) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [daemon, setDaemon] = useState<DaemonHealth | null>(null);
   const [sessions, setSessions] = useState<SessionLite[]>([]);
   const [open, setOpen] = useState<string | null>(null);

--- a/src/components/recent-activity-rollup.tsx
+++ b/src/components/recent-activity-rollup.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { relativeTime } from "@/lib/relative-time";
-import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
+import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
 import { modelIcon } from "@/lib/model-label";
 import type { SessionRow } from "@/lib/types";
 
@@ -39,6 +39,7 @@ type Props = {
 };
 
 export function RecentActivityRollup({ activeSessionId, onOpenSession }: Props) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [sessions, setSessions] = useState<SessionRow[]>([]);
   // Default open for SSR + first paint, then hydrate the saved preference after
   // mount so the server and client markup match.


### PR DESCRIPTION
**Batch 1** of the relative-time unify sweep (the deferred #4 from the timestamp-polish arc).

These 5 surfaces already render timestamps via the canonical `relativeTime()` helper, but they never **subscribed** to the date/time density preference — so toggling Appearance → **Compact / Verbose** only took effect after a navigation/remount. Adding a bare `useDateTimePrefs()` call (the same pattern wired into 5 surfaces in #1591) makes them re-render when the pref changes, so `relativeTime()` re-reads it live.

**Surfaces wired:**
- `dashboard/action-inbox.tsx`
- `command-palette.tsx`
- `coven-floor.tsx`
- `health-strip.tsx`
- `recent-activity-rollup.tsx`

**No visual change** at a fixed density — purely makes the density toggle apply live.

Scoped intentionally to surfaces *already* on the canonical helper. Surfaces that hand-roll a **bare compact** format (`board-table`, `library-timeline-row` → "5m"/"5w", no "ago") are deliberately excluded: migrating those changes the rendered text, which is a product call, not a mechanical unify.

- typecheck clean
- `pnpm test:app` → 368 files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)