### PR TITLE
feat(ui): density pref applies live on 5 more relative-time surfaces (batch 2)

### DIFF
--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
 import { copyText } from "@/lib/clipboard";
 import { relativeTime } from "@/lib/relative-time";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { MarkdownBlock } from "@/components/message-bubble";
@@ -111,6 +112,7 @@ export function CapabilitiesViewSurface({
 }: {
   activeHarness?: string | null;
 }) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [items, setItems] = useState<HarnessCapabilityManifest[]>([]);
   const [covenSkills, setCovenSkills] = useState<CovenSkill[]>([]);
   const [scannedAt, setScannedAt] = useState<string | null>(null);

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -6,6 +6,7 @@ import { Tabs } from "@/components/ui/tabs";
 // Shared relative-time formatter, imported as `age` so the call sites read the
 // same — standardizes this surface on the app-wide "2m ago / 3h ago / Jun 12" style.
 import { relativeTime as age } from "@/lib/relative-time";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { FamiliarsMemoryView, MemoryFilesList } from "@/components/familiars-memory-view";
@@ -67,6 +68,7 @@ export function FamiliarsView({
   onOpenMemoryFile,
   onOpenOnboarding,
 }: AgentsViewProps) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [covenEntries, setCovenEntries] = useState<CovenMemoryEntry[]>([]);
   const [fileEntries, setFileEntries] = useState<FileMemoryEntry[]>([]);
   const [memoryError, setMemoryError] = useState<string | null>(null);

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -3,6 +3,7 @@
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { relativeTime } from "@/lib/relative-time";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import type { Familiar } from "@/lib/types";
@@ -1247,6 +1248,7 @@ const COLS: ColDef[] = [
 // ── Main component ────────────────────────────────────────────────────────────
 
 export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [activity, setActivity] = useState<ActivityResult | null>(null);
   const [patStatus, setPatStatus] = useState<PatStatus | null>(null);
   const [loading, setLoading] = useState(true);

--- a/src/components/new-chat-launch.tsx
+++ b/src/components/new-chat-launch.tsx
@@ -4,7 +4,7 @@ import { Icon } from "@/lib/icon";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { relativeTime } from "@/lib/relative-time";
-import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
+import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
 import type { Familiar, SessionRow } from "@/lib/types";
 
 /**
@@ -26,6 +26,7 @@ export function NewChatLaunch({
   onResume: (sessionId: string) => void;
   pendingProjectRoot?: string | null;
 }) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   // Resolve glyphs/avatars/order the same way the rest of the app does so the
   // cards match the switcher (and FamiliarAvatar gets a ResolvedFamiliar).
   const resolved = useResolvedFamiliars(familiars);

--- a/src/components/workflows/workflow-runs-panel.tsx
+++ b/src/components/workflows/workflow-runs-panel.tsx
@@ -5,6 +5,7 @@ import { Tabs, type TabItem } from "@/components/ui/tabs";
 import { Icon, type IconName } from "@/lib/icon";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { relativeTime } from "@/lib/relative-time";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 import type { WorkflowPlaybackState } from "@/lib/workflow-playback";
@@ -77,6 +78,7 @@ function summarizeRuns(runs: WorkflowRunRecord[]): string {
 
 /** Run history for the selected workflow: plan snapshots and executions. */
 export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayRun, onClearRuns }: WorkflowRunsPanelProps) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [filter, setFilter] = useState<WorkflowRunFilter>("all");
   const replaying = playback?.source === "replay" && playback.workflowId === workflow?.id;


### PR DESCRIPTION
**Batch 2** of the relative-time unify sweep (batch 1 = #1596).

These 5 surfaces already render timestamps via the canonical `relativeTime()` helper but never **subscribed** to the date/time density preference — so toggling Appearance → **Compact / Verbose** only took effect after a navigation/remount. Adding a bare `useDateTimePrefs()` call makes them re-render when the pref changes, so `relativeTime()` re-reads it live.

**Surfaces wired:**
- `familiars-view.tsx`
- `capabilities-view.tsx`
- `github-view.tsx`
- `workflows/workflow-runs-panel.tsx`
- `new-chat-launch.tsx`

**No visual change** at a fixed density — purely makes the density toggle apply live. Scoped to surfaces *already* on the canonical helper (bare-compact formats like `board-table` are deliberately excluded — migrating them changes rendered text, a product call).

- typecheck clean
- `pnpm test:app` → 369 files pass (incl. all pinned source-text tests for these surfaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)