### PR TITLE
feat(menu-bar): "Avatars shown" appearance setting; default pinned-only

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -359,6 +359,7 @@ export const SUITES = {
     "src/components/familiar-pin-order.test.ts",
     "src/lib/familiar-quick-switch.test.ts",
     "src/lib/familiar-switcher-style.test.ts",
+    "src/lib/familiar-strip-scope.test.ts",
     "src/lib/salem/happy-paths.test.ts",
     "src/lib/salem/pathfinder-match.test.ts",
     "src/lib/salem/pathfinder-card.test.ts",

--- a/src/components/familiar-quick-switch.test.ts
+++ b/src/components/familiar-quick-switch.test.ts
@@ -18,8 +18,13 @@ assert.match(
 );
 assert.match(
   source,
-  /computeQuickSwitch\(familiars, \{ pins, lastUsed, activeId: activeFamiliarId, max \}\)/,
-  "computes the strip from pins, recency, and the active familiar",
+  /computeQuickSwitch\(familiars, \{ pins, lastUsed, activeId: activeFamiliarId, max, scope: stripScope \}\)/,
+  "computes the strip from pins, recency, the active familiar, and the scope preference",
+);
+assert.match(
+  source,
+  /useFamiliarStripScope\(\)/,
+  "subscribes to the pinned-only / all scope preference",
 );
 
 // Each strip entry is a one-tap switch button with an avatar + presence dot.

--- a/src/components/familiar-quick-switch.tsx
+++ b/src/components/familiar-quick-switch.tsx
@@ -7,6 +7,7 @@ import { computePresence, REMOTE_HARNESSES } from "@/lib/presence";
 import { computeQuickSwitch, QUICK_SWITCH_MAX } from "@/lib/familiar-quick-switch";
 import { useFamiliarLastUsed, useFamiliarPins } from "@/lib/use-familiar-quick-switch";
 import { useFamiliarSwitcherStyle } from "@/lib/familiar-switcher-style";
+import { useFamiliarStripScope } from "@/lib/familiar-strip-scope";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { SessionRow } from "@/lib/types";
 
@@ -46,11 +47,12 @@ export function FamiliarQuickSwitch({
   const pins = useFamiliarPins();
   const lastUsed = useFamiliarLastUsed();
   const switcherStyle = useFamiliarSwitcherStyle();
+  const stripScope = useFamiliarStripScope();
   const pinnedSet = useMemo(() => new Set(pins), [pins]);
 
   const quick = useMemo(
-    () => computeQuickSwitch(familiars, { pins, lastUsed, activeId: activeFamiliarId, max }),
-    [familiars, pins, lastUsed, activeFamiliarId, max],
+    () => computeQuickSwitch(familiars, { pins, lastUsed, activeId: activeFamiliarId, max, scope: stripScope }),
+    [familiars, pins, lastUsed, activeFamiliarId, max, stripScope],
   );
 
   // "dropdown" preference hides the avatar strip, leaving only the switcher menu.

--- a/src/components/settings-appearance.test.ts
+++ b/src/components/settings-appearance.test.ts
@@ -342,6 +342,17 @@ assert.match(
   /familiarSwitcherStyle === "avatars" \?[\s\S]*<FamiliarPinOrder/,
   "the pin-order manager only shows for the avatar strip style",
 );
+// "Avatars shown" — restrict the strip to pinned familiars (default) or show all.
+assert.match(
+  settings,
+  /Avatars shown[\s\S]*setFamiliarStripScope\(option\)/,
+  "the avatar style exposes a pinned-only / all scope control",
+);
+assert.match(
+  settings,
+  /familiarSwitcherStyle === "avatars" \?[\s\S]*setFamiliarStripScope/,
+  "the scope control only shows for the avatar strip style",
+);
 
 // Corner radius drives the shared --radius tokens app-wide, so its boot block
 // must run before paint (ThemeScript) and its controller must mount in layout.

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -33,6 +33,12 @@ import {
   useFamiliarSwitcherStyle,
 } from "@/lib/familiar-switcher-style";
 import {
+  FAMILIAR_STRIP_SCOPE_OPTIONS,
+  FAMILIAR_STRIP_SCOPE_LABELS,
+  setFamiliarStripScope,
+  useFamiliarStripScope,
+} from "@/lib/familiar-strip-scope";
+import {
   DEMO_MODE_EVENT,
   clearDemoModeData,
   demoModeFetchHeaders,
@@ -862,6 +868,7 @@ function AppearanceSection() {
   const [colorEditorBase, setColorEditorBase] = useState<PresetTheme | null>(null);
   const [cornerRadius, setCornerRadius] = useState<CornerRadius>("default");
   const familiarSwitcherStyle = useFamiliarSwitcherStyle();
+  const familiarStripScope = useFamiliarStripScope();
 
   // Read persisted theme + mode on mount
   useEffect(() => {
@@ -1168,20 +1175,57 @@ function AppearanceSection() {
           </div>
         </div>
 
-        {/* Pin order — only meaningful for the avatar strip, so it follows the
-            style toggle and shows only when that style is active. */}
+        {/* Avatars shown + Pin order — only meaningful for the avatar strip, so
+            they follow the style toggle and show only when that style is active. */}
         {familiarSwitcherStyle === "avatars" ? (
-          <div className="border-t border-[var(--border-hairline)] px-4 py-3">
-            <div className="mb-2 min-w-0">
-              <div className="text-[12px] font-medium text-[var(--text-secondary)]">
-                Pin order
+          <>
+            <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2 border-t border-[var(--border-hairline)] px-4 py-3">
+              <div className="min-w-0">
+                <div className="text-[12px] font-medium text-[var(--text-secondary)]">
+                  Avatars shown
+                </div>
+                <div className="text-[11px] text-[var(--text-muted)]">
+                  Show only your pinned familiars in the strip, or every familiar.
+                </div>
               </div>
-              <div className="text-[11px] text-[var(--text-muted)]">
-                Drag to set the order pinned familiars appear in the avatar strip.
+              <div
+                role="group"
+                aria-label="Familiars shown in the avatar strip"
+                className="flex w-fit shrink-0 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-base)] p-0.5"
+              >
+                {FAMILIAR_STRIP_SCOPE_OPTIONS.map((option) => {
+                  const active = familiarStripScope === option;
+                  return (
+                    <button
+                      key={option}
+                      type="button"
+                      aria-pressed={active}
+                      onClick={() => setFamiliarStripScope(option)}
+                      className={`focus-ring rounded-md px-2.5 py-1.5 text-[11px] font-medium transition-colors ${
+                        active
+                          ? "bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
+                          : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+                      }`}
+                    >
+                      {FAMILIAR_STRIP_SCOPE_LABELS[option]}
+                    </button>
+                  );
+                })}
               </div>
             </div>
-            <FamiliarPinOrder />
-          </div>
+
+            <div className="border-t border-[var(--border-hairline)] px-4 py-3">
+              <div className="mb-2 min-w-0">
+                <div className="text-[12px] font-medium text-[var(--text-secondary)]">
+                  Pin order
+                </div>
+                <div className="text-[11px] text-[var(--text-muted)]">
+                  Drag to set the order pinned familiars appear in the avatar strip.
+                </div>
+              </div>
+              <FamiliarPinOrder />
+            </div>
+          </>
         ) : null}
       </SettingsGroup>
 

--- a/src/lib/familiar-quick-switch.test.ts
+++ b/src/lib/familiar-quick-switch.test.ts
@@ -45,6 +45,47 @@ const fam = (id, extra = {}) => ({ id, last_seen: undefined, ...extra });
   assert.deepEqual(computeQuickSwitch(familiars, { max: 0 }), [], "max 0 → empty");
 }
 
+// scope "pinned" → ONLY the pinned familiars, in pin order; no active/recent fill.
+{
+  const familiars = [fam("a"), fam("b"), fam("c"), fam("d")];
+  const out = computeQuickSwitch(familiars, {
+    pins: ["c", "a"],
+    activeId: "d",
+    lastUsed: { b: 999, d: 500 },
+    scope: "pinned",
+  });
+  assert.deepEqual(out.map((f) => f.id), ["c", "a"], "pinned scope shows only pinned, in pin order");
+}
+
+// scope "pinned" with no pins → empty strip (even with an active familiar).
+{
+  const familiars = [fam("a"), fam("b")];
+  const out = computeQuickSwitch(familiars, { activeId: "a", scope: "pinned" });
+  assert.deepEqual(out, [], "pinned scope + no pins → empty");
+}
+
+// scope "pinned" still honors max and drops unknown pin ids.
+{
+  const familiars = [fam("a"), fam("b"), fam("c")];
+  assert.deepEqual(
+    computeQuickSwitch(familiars, { pins: ["a", "b", "c"], max: 2, scope: "pinned" }).map((f) => f.id),
+    ["a", "b"],
+    "pinned scope respects max",
+  );
+  assert.deepEqual(
+    computeQuickSwitch(familiars, { pins: ["ghost", "b"], scope: "pinned" }).map((f) => f.id),
+    ["b"],
+    "pinned scope skips unknown pin ids",
+  );
+}
+
+// scope "all" (the default) is unchanged — pinned, then active, then recency.
+{
+  const familiars = [fam("a"), fam("b"), fam("c")];
+  const out = computeQuickSwitch(familiars, { pins: ["a"], activeId: "c", lastUsed: { b: 999 }, scope: "all" });
+  assert.deepEqual(out.map((f) => f.id), ["a", "c", "b"], "all scope keeps active + recency fill");
+}
+
 // Pins/active referencing absent familiars are ignored (no crash, no holes).
 {
   const familiars = [fam("a"), fam("b")];

--- a/src/lib/familiar-quick-switch.ts
+++ b/src/lib/familiar-quick-switch.ts
@@ -150,6 +150,13 @@ type QuickSwitchOpts = {
   /** The active familiar is always surfaced (treated as most-recent). */
   activeId?: string | null;
   max?: number;
+  /**
+   * Which familiars the strip surfaces:
+   *   • "all"    — pinned, then active, then recency-ranked (the default).
+   *   • "pinned" — ONLY the pinned familiars, in pin order. The active/recent
+   *                fill steps are skipped so the strip is a curated set.
+   */
+  scope?: "all" | "pinned";
 };
 
 /**
@@ -159,6 +166,9 @@ type QuickSwitchOpts = {
  *   3. remaining familiars by most-recent use (cave last-used, then daemon
  *      `last_seen`), preserving the input order as a stable tiebreak.
  * Capped at `max` (default {@link QUICK_SWITCH_MAX}).
+ *
+ * When `scope` is "pinned", only step 1 runs — the strip is exactly the pinned
+ * familiars (still present), in pin order.
  */
 export function computeQuickSwitch<T extends { id: string; last_seen?: string }>(
   familiars: readonly T[],
@@ -169,6 +179,7 @@ export function computeQuickSwitch<T extends { id: string; last_seen?: string }>
   const pins = opts.pins ?? [];
   const lastUsed = opts.lastUsed ?? {};
   const activeId = opts.activeId ?? null;
+  const scope = opts.scope ?? "all";
 
   const byId = new Map<string, T>();
   familiars.forEach((f) => byId.set(f.id, f));
@@ -183,6 +194,8 @@ export function computeQuickSwitch<T extends { id: string; last_seen?: string }>
 
   // 1. pins (in order)
   for (const id of pins) take(byId.get(id));
+  // "pinned" scope stops here — the strip is exactly the pinned familiars.
+  if (scope === "pinned") return out;
   // 2. active familiar
   if (activeId) take(byId.get(activeId));
   // 3. recency-ranked remainder

--- a/src/lib/familiar-strip-scope.test.ts
+++ b/src/lib/familiar-strip-scope.test.ts
@@ -1,0 +1,26 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  DEFAULT_FAMILIAR_STRIP_SCOPE,
+  FAMILIAR_STRIP_SCOPE_LABELS,
+  FAMILIAR_STRIP_SCOPE_OPTIONS,
+  normalizeFamiliarStripScope,
+} from "./familiar-strip-scope.ts";
+
+// The two scopes the "Avatars shown" control toggles between.
+assert.deepEqual([...FAMILIAR_STRIP_SCOPE_OPTIONS], ["pinned", "all"], "exactly two scopes");
+assert.equal(DEFAULT_FAMILIAR_STRIP_SCOPE, "pinned", "default surfaces only pinned familiars");
+
+// Every option has a human label.
+for (const option of FAMILIAR_STRIP_SCOPE_OPTIONS) {
+  assert.equal(typeof FAMILIAR_STRIP_SCOPE_LABELS[option], "string", `label for ${option}`);
+}
+
+// normalize accepts known values and falls back to the default for anything else.
+assert.equal(normalizeFamiliarStripScope("pinned"), "pinned");
+assert.equal(normalizeFamiliarStripScope("all"), "all");
+assert.equal(normalizeFamiliarStripScope("bogus"), DEFAULT_FAMILIAR_STRIP_SCOPE, "unknown → default");
+assert.equal(normalizeFamiliarStripScope(null), DEFAULT_FAMILIAR_STRIP_SCOPE, "null → default");
+assert.equal(normalizeFamiliarStripScope(undefined), DEFAULT_FAMILIAR_STRIP_SCOPE, "undefined → default");
+
+console.log("familiar-strip-scope: all assertions passed");

--- a/src/lib/familiar-strip-scope.ts
+++ b/src/lib/familiar-strip-scope.ts
@@ -1,0 +1,87 @@
+"use client";
+
+/**
+ * User preference for WHICH familiars the top-bar avatar strip surfaces (only
+ * relevant when the switcher style is "avatars"):
+ *
+ *   • "pinned" — only the user's pinned familiars (in pin order). The default;
+ *                keeps the strip a deliberate, curated set.
+ *   • "all"    — every familiar (pin/recency-ordered), scrolling on overflow.
+ *
+ * Cave-local, persisted in localStorage under `cave:familiar-strip-scope`.
+ * Reactive via useSyncExternalStore so the top bars re-render the moment the
+ * Settings control flips it. Mirrors {@link familiar-switcher-style}.
+ */
+
+import { useSyncExternalStore } from "react";
+
+export const FAMILIAR_STRIP_SCOPE_KEY = "cave:familiar-strip-scope";
+
+export const FAMILIAR_STRIP_SCOPE_OPTIONS = ["pinned", "all"] as const;
+
+export type FamiliarStripScope = (typeof FAMILIAR_STRIP_SCOPE_OPTIONS)[number];
+
+export const DEFAULT_FAMILIAR_STRIP_SCOPE = "pinned" as const;
+
+export const FAMILIAR_STRIP_SCOPE_LABELS: Record<FamiliarStripScope, string> = {
+  pinned: "Pinned only",
+  all: "All familiars",
+};
+
+export function normalizeFamiliarStripScope(value: unknown): FamiliarStripScope {
+  return FAMILIAR_STRIP_SCOPE_OPTIONS.includes(value as FamiliarStripScope)
+    ? (value as FamiliarStripScope)
+    : DEFAULT_FAMILIAR_STRIP_SCOPE;
+}
+
+let cached: FamiliarStripScope | null = null;
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const fn of listeners) fn();
+}
+
+function read(): FamiliarStripScope {
+  if (typeof window === "undefined") return DEFAULT_FAMILIAR_STRIP_SCOPE;
+  try {
+    return normalizeFamiliarStripScope(window.localStorage.getItem(FAMILIAR_STRIP_SCOPE_KEY));
+  } catch {
+    return DEFAULT_FAMILIAR_STRIP_SCOPE;
+  }
+}
+
+function getSnapshot(): FamiliarStripScope {
+  if (cached === null) cached = read();
+  return cached;
+}
+
+/** Persist the preference and notify subscribers. */
+export function setFamiliarStripScope(scope: FamiliarStripScope): void {
+  const normalized = normalizeFamiliarStripScope(scope);
+  cached = normalized;
+  if (typeof window !== "undefined") {
+    try { window.localStorage.setItem(FAMILIAR_STRIP_SCOPE_KEY, normalized); } catch { /* ignore */ }
+  }
+  notify();
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (e) => {
+    if (e.key === FAMILIAR_STRIP_SCOPE_KEY) {
+      cached = null;
+      notify();
+    }
+  });
+}
+
+function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+const getServerSnapshot = () => DEFAULT_FAMILIAR_STRIP_SCOPE;
+
+/** React hook: which familiars the avatar strip surfaces. Re-renders on change. */
+export function useFamiliarStripScope(): FamiliarStripScope {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
## What

Adds an Appearance setting controlling **which** familiars appear in the desktop top-bar avatar strip, and defaults it to **pinned-only** (per request).

- **New preference** `cave:familiar-strip-scope` (`src/lib/familiar-strip-scope.ts`), mirroring `familiar-switcher-style`: `"pinned"` (default) or `"all"`.
- **Settings → Appearance:** an "Avatars shown" segmented control (**Pinned only** / **All familiars**), shown only for the avatar-strip style, sitting between "Top-bar style" and "Pin order".
- **`computeQuickSwitch`** gains a `scope` option — `"pinned"` returns only the pinned familiars (in pin order), skipping the active/recency fill; still honors `max` and drops absent pin ids. `"all"` is the prior #1588 behavior.
- `FamiliarQuickSwitch` reads the scope and passes it through.

With the pinned default and no pins, the strip is empty and falls back to the switcher dropdown — pin a familiar (the existing "Add a pin" chips, or the switcher rows) to populate it.

## Verify

Rendered the real app (demo, 1440px):
- Default (pinned) + pins `[sage, nova]` → strip shows exactly **Sage, Nova** in pin order.
- Default (pinned) + no pins → strip empty → switcher dropdown shown.
- Scope flipped to "all" → all 11 familiars shown.
- Settings → Appearance shows the new "Avatars shown" control.

Tests: new `familiar-strip-scope.test.ts` (registered in `run-tests.mjs`); `familiar-quick-switch.test.ts` gains pinned-scope cases; `familiar-quick-switch.test.ts` (component) + `settings-appearance.test.ts` updated for the new wiring. Full `test:app` suite green (370 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)