### PR TITLE
feat(ui): density pref applies live on the remaining relative-time surfaces (batch 3)

### DIFF
--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -2,6 +2,7 @@
 
 import { Fragment, useCallback, useEffect, useMemo, useReducer, useRef, useState, type DragEvent, type ReactNode } from "react";
 import { relativeTime } from "@/lib/relative-time";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { BottomTerminal } from "@/components/bottom-terminal";
 import { Icon } from "@/lib/icon";
@@ -266,6 +267,7 @@ function shortProjectTime(iso: string | null): string {
 }
 
 export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNewChat, active = true, storageNamespace = "" }: Props) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const layoutKey = STORAGE_LAYOUT + storageNamespace;
   const sessionsKey = STORAGE_SESSIONS + storageNamespace;
   const [terminalLayout, dispatchTerminalLayout] = useReducer(

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -9,6 +9,7 @@ import type { Familiar } from "@/lib/types";
 import type { GitHubItem } from "@/lib/github-tasks";
 import type { InboxItem } from "@/lib/cave-inbox";
 import { relativeTime } from "@/lib/daily-report";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 import { SectionHead, EmptyState, QuickLink } from "@/components/daily-report-ui";
 import { Sparkline, type SparkPoint } from "@/components/ui/sparkline";
 import { ActionInbox } from "@/components/dashboard/action-inbox";
@@ -107,6 +108,7 @@ const STATUS_ORDER: CardStatus[] = ["running", "review", "blocked", "inbox", "ba
 // ─── Root ───────────────────────────────────────────────────────────────────────
 
 export function DashboardCockpit({ model }: { model: DashboardModel }) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [data, setData] = useState<CockpitData>(EMPTY);
   // Each source populates independently so a panel renders the moment its data
   // lands — the slow ones (sessions) never block the fast ones (board, agents).

--- a/src/components/eval-loop-panel.tsx
+++ b/src/components/eval-loop-panel.tsx
@@ -18,7 +18,7 @@ import type { IconName } from "@/lib/icon";
 // Shared relative-time formatter, imported as `age` so the call sites read the
 // same — standardizes this surface on the app-wide "2m ago / 3h ago / Jun 12" style.
 import { relativeTime as age } from "@/lib/relative-time";
-import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
+import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -75,6 +75,7 @@ const TRACK_LABEL: Record<Track, string> = {
 // ── Component ────────────────────────────────────────────────────────────────
 
 export function EvalLoopPanel({ familiarId, familiarName }: Props) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [state, setState] = useState<EvalLoopState | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/src/components/familiar-daily-notes.tsx
+++ b/src/components/familiar-daily-notes.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { DAILY_NOTE_SECTIONS } from "@/lib/daily-note";
 import { dateSlug, longDateLabel, parseDateSlug, relativeTime } from "@/lib/daily-report";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 
 type DailyNotesFamiliar = { id: string; display_name: string };
 
@@ -28,6 +29,7 @@ function shiftDay(slug: string, delta: number): string {
  * autosave on blur and can be saved explicitly with ⌘/Ctrl+S.
  */
 export function FamiliarDailyNotes({ familiar }: Props) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const today = useMemo(() => dateSlug(new Date()), []);
   const [date, setDate] = useState<string>(today);
   const [notes, setNotes] = useState("");

--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
-import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
+import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
 // Shared relative-time formatter, imported as `age` so the call sites read the
 // same — standardizes this surface on the app-wide "2m ago / 3h ago / Jun 12" style.
 import { relativeTime as age } from "@/lib/relative-time";
@@ -122,6 +122,7 @@ function memoryMatches(entry: CovenMemoryEntry | FileMemoryEntry, query: string)
 }
 
 export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, limit, lockToFamiliar, compact }: Props) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [covenEntries, setCovenEntries] = useState<CovenMemoryEntry[]>([]);
   const [fileEntries, setFileEntries] = useState<FileMemoryEntry[]>([]);
   const [query, setQuery] = useState("");
@@ -897,6 +898,7 @@ export function MemoryFilesList({
   onShowMore,
   onDelete,
 }: MemoryFilesListProps) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const sliced = entries.slice(0, limit ?? entries.length);
   const hidden = entries.length - sliced.length;
   return (

--- a/src/components/journal/canvas-list.tsx
+++ b/src/components/journal/canvas-list.tsx
@@ -6,6 +6,7 @@ import { Icon } from "@/lib/icon";
 import { copyText } from "@/lib/clipboard";
 import { isDemoModeEnabled } from "@/lib/demo-mode";
 import { relativeTime } from "@/lib/daily-report";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 import { DEFAULT_REFINE_SUGGESTIONS, generateRefineSuggestions } from "@/lib/refine-suggestions";
 import {
   buildPreviewSrcDoc,
@@ -50,6 +51,7 @@ export function CanvasList({
   familiars: Familiar[];
   activeFamiliarId: string | null;
 }) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [artifacts, setArtifacts] = useState<CanvasArtifact[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [view, setView] = useState<"preview" | "code">("preview");

--- a/src/components/journal/journal-entries.tsx
+++ b/src/components/journal/journal-entries.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { extractNextPaths } from "@/lib/next-paths";
 import { dateSlug, longDateLabel, relativeDayLabel, relativeTime, parseDateSlug } from "@/lib/daily-report";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 import { generateReflection } from "@/lib/journal-generate";
 import type { Familiar } from "@/lib/types";
 
@@ -52,6 +53,7 @@ export function JournalEntries({
   familiars: Familiar[];
   activeFamiliarId: string | null;
 }) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const today = dateSlug(new Date());
   const [days, setDays] = useState<JournalSummary[]>([]);
   const [daysLoaded, setDaysLoaded] = useState(false);

--- a/src/components/retro-runs-view.tsx
+++ b/src/components/retro-runs-view.tsx
@@ -7,6 +7,7 @@ import { SkeletonRows } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { Tabs } from "@/components/ui/tabs";
 import { relativeTime } from "@/lib/relative-time";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 import { RelativeTime } from "@/components/ui/relative-time";
 import type { RetroOutcome, RetroRun, RetroRunsSnapshot, RetroTrack } from "@/lib/retro-runs";
 
@@ -118,6 +119,7 @@ export function RetroRunsView({
   standalone?: boolean;
   familiarId?: string | null;
 }) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [snapshot, setSnapshot] = useState<RetroRunsSnapshot>(EMPTY_SNAPSHOT);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);


### PR DESCRIPTION
**Batch 3 (final)** of the relative-time unify sweep (batches 1+2 = #1596/#1597).

These surfaces already render timestamps via the canonical `relativeTime()` helper but never **subscribed** to the date/time density preference — so toggling Appearance → **Compact / Verbose** only took effect after a navigation/remount. Adding a bare `useDateTimePrefs()` call makes them re-render when the pref changes, so `relativeTime()` re-reads it live.

**Surfaces wired (8 files, 10 surfaces):**
- `familiar-daily-notes.tsx`
- `comux-view.tsx`
- `eval-loop-panel.tsx`
- `familiars-memory-view.tsx` (both `FamiliarsMemoryView` + `MemoryFilesList`)
- `retro-runs-view.tsx`
- `journal/canvas-list.tsx`
- `journal/journal-entries.tsx`
- `dashboard/dashboard-cockpit.tsx` — the `"use client"` island; covers its `TodaySummary` → `ReportCallout` children (presentational, no client boundary of their own), so a single hook makes the whole dashboard timestamp subtree live without touching those files.

**No visual change** at a fixed density — purely makes the density toggle apply live. Excludes `daily-report-ui` and `dashboard-hero` (no `"use client"` directive — adding a hook there is a client-boundary product call, not a mechanical unify).

**This completes the sweep** — every category-A surface (already on the canonical helper) now applies the density pref live.

- typecheck clean
- `pnpm test:app` → 369 files pass · `pnpm test:mobile` → 18 files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)