### PR TITLE
fix(menu-bar): size avatar tiles to match the action-button height (28px)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4706,12 +4706,12 @@ button:active > .edge-rail-chip {
   max-width: clamp(280px, 40vw, 600px);
 }
 
-/* Compact avatar tiles to match the standardized top-bar icons (14px) and
-   13px labels — smaller than the default 28px strip bubble, scoped to the
+/* Avatar tiles match the height of the top-bar action buttons / search box
+   (~28px) so the strip lines up with the rest of the bar. Scoped to the
    desktop menu bar so the mobile `.top-bar` strip is unaffected. */
 .menu-bar .familiar-quickswitch__btn {
-  width: 22px;
-  height: 22px;
+  width: 28px;
+  height: 28px;
 }
 
 .menu-bar__new,

--- a/src/components/menu-bar-icon-size.test.ts
+++ b/src/components/menu-bar-icon-size.test.ts
@@ -12,6 +12,6 @@ assert.match(css, /\.menu-bar__search-input\s*\{[\s\S]*?font-size:\s*var\(--text
 // The sidepanel/nav toggle glyph stays unified with the action icons.
 const iconLib = readFileSync(new URL("../lib/icon.tsx", import.meta.url), "utf8");
 assert.match(iconLib, /shellToggle:\s*"var\(--icon-sm\)"/, "sidepanel toggle glyph is var(--icon-sm)");
-// Avatar tiles are shrunk in the desktop menu bar to match the compact chrome.
-assert.match(css, /\.menu-bar \.familiar-quickswitch__btn\s*\{[\s\S]*?width:\s*22px[\s\S]*?height:\s*22px/, "menu-bar avatar tiles are 22px");
+// Avatar tiles match the top-bar button/search height so the strip lines up.
+assert.match(css, /\.menu-bar \.familiar-quickswitch__btn\s*\{[\s\S]*?width:\s*28px[\s\S]*?height:\s*28px/, "menu-bar avatar tiles match the button height (28px)");
 console.log("menu-bar-icon-size.test.ts passed");


### PR DESCRIPTION
## What

The top-bar familiar avatar tiles were shrunk to 22px in #1594, but that left them shorter than the ~28–29px action buttons and search box. Revert to **28px** so the strip lines up with the rest of the bar.

- `.menu-bar .familiar-quickswitch__btn`: `22px` → `28px` (still scoped to the desktop menu bar; mobile `.top-bar` unaffected).

## Verify

Rendered the real top bar (demo, 1440px): avatar tiles measure **28px**, matching the search box (28.2px) and just under the task buttons (29.5px) — visually aligned. `menu-bar-icon-size.test.ts` updated to pin the tile rule to `28px`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)