### PR TITLE
feat(ui): unify category-B bare-compact timestamps onto canonical relativeTime

### DIFF
--- a/src/components/board-table.tsx
+++ b/src/components/board-table.tsx
@@ -9,6 +9,8 @@ import { Icon } from "@/lib/icon";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
+import { relativeTime } from "@/lib/relative-time";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 
 export type GroupBy = "status" | "familiar" | "project";
 export type SortKey = "title" | "status" | "priority" | "familiar" | "lifecycle" | "startDate" | "endDate" | "updatedAt";
@@ -75,15 +77,10 @@ function groupCards(cards: Card[], by: GroupBy, familiars: Familiar[], projects:
   return entries;
 }
 
+// Density-aware relative age, shared with the rest of the app: "2m ago" /
+// "2 minutes ago" depending on the Appearance → Relative time preference.
 function relTime(iso: string): string {
-  try {
-    const s = (Date.now() - new Date(iso).getTime()) / 1000;
-    if (s < 60) return `${Math.round(s)}s`;
-    if (s < 3600) return `${Math.round(s / 60)}m`;
-    if (s < 86400) return `${Math.round(s / 3600)}h`;
-    const d = Math.round(s / 86400);
-    return d < 30 ? `${d}d` : `${Math.round(d / 30)}mo`;
-  } catch { return ""; }
+  return relativeTime(iso);
 }
 
 function formatBoardDate(value: string | null | undefined): string {
@@ -116,6 +113,7 @@ type Props = {
 };
 
 export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId, onSelect, onPatch }: Props) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [sortKey, setSortKey] = useState<SortKey>("updatedAt");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set(["done"]));

--- a/src/components/chat-project-sidebar.tsx
+++ b/src/components/chat-project-sidebar.tsx
@@ -7,6 +7,7 @@ import { selectionKey, type ProjectSelection } from "@/lib/chat-project-selectio
 import { setProjectOverride } from "@/lib/chat-project-overrides";
 import { stripLeadingTrailingEmoji } from "@/lib/cave-chat-titles";
 import { sessionRailTitle } from "@/lib/session-rail-title";
+import { relativeTime } from "@/lib/relative-time";
 import {
   PINNED_SESSIONS_KEY,
   isSessionPinned,
@@ -71,19 +72,14 @@ function statusDotClass(status: string): string {
   return "bg-[var(--text-muted)]";
 }
 
-/** Compact relative age for the thread-rail rows (kept terse for the 230px width). */
+/**
+ * Compact relative age for the thread-rail rows. Delegates to the shared
+ * `relativeTime` helper for "Xm ago"/"Xh ago" wording (consistent with the rest
+ * of the app), but PINNED to compact density regardless of the Appearance →
+ * Relative time preference — the 230px rail has no room for "X minutes ago".
+ */
 function shortAge(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
-  if (Number.isNaN(ms)) return "";
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return "now";
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h`;
-  const d = Math.floor(h / 24);
-  if (d < 7) return `${d}d`;
-  return `${Math.floor(d / 7)}w`;
+  return relativeTime(iso, Date.now(), "compact");
 }
 
 function repoLabel(group: ChatProjectGroup): string {

--- a/src/components/library-timeline-row.tsx
+++ b/src/components/library-timeline-row.tsx
@@ -3,6 +3,8 @@
 import { Icon, type IconName } from "@/lib/icon";
 import type { TimelineEntry } from "@/app/api/library/all/route";
 import type { Familiar } from "@/lib/types";
+import { relativeTime } from "@/lib/relative-time";
+import { useDateTimePrefs } from "@/lib/datetime-format";
 
 function listIcon(list: TimelineEntry["list"]): IconName {
   if (list === "github") return "ph:github-logo";
@@ -10,18 +12,10 @@ function listIcon(list: TimelineEntry["list"]): IconName {
   return "ph:bookmark-simple";
 }
 
+// Density-aware relative age, shared with the rest of the app: "2m ago" /
+// "2 minutes ago" depending on the Appearance → Relative time preference.
 function relTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  if (Number.isNaN(diff) || diff < 0) return "now";
-  const s = Math.floor(diff / 1000);
-  if (s < 60) return `${s}s`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h`;
-  const d = Math.floor(h / 24);
-  if (d < 7) return `${d}d`;
-  return `${Math.floor(d / 7)}w`;
+  return relativeTime(iso);
 }
 
 function EntryIcon({ entry }: { entry: TimelineEntry }) {
@@ -46,6 +40,7 @@ export function LibraryTimelineRow({
   selected: boolean;
   onSelect: () => void;
 }) {
+  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const fam = familiars.find((f) => f.id === entry.familiar);
   const title = entry.item.title || (entry.item as { url?: string }).url || "Untitled";
 


### PR DESCRIPTION
Completes the relative-time unify work. The **category-B** surfaces — board task table, library timeline rows, and the chat project sidebar rail — hand-rolled a **bare-compact** relative age (`5m`/`5h`/`5w`, no "ago") that sat outside the density preference and read differently from every other surface.

Per the design decision (full `X ago` + density-aware, sidebar pinned compact):

- **`board-table` + `library-timeline-row`** — fully density-aware via the shared `relativeTime()` helper: `2m ago` (Compact) / `2 minutes ago` (Verbose), subscribed via `useDateTimePrefs()` so the Appearance → Relative time toggle applies **live**.
- **`chat-project-sidebar`** — pinned to **Compact** (`relativeTime(iso, now, "compact")`) so the narrow **230px** thread rail gains the consistent "ago" wording but never expands to `2 minutes ago` and never wraps.

Past a week these now show a short absolute date (`Jun 12`) instead of `5w`/`5mo`, matching the canonical helper. The local `relTime`/`shortAge` wrappers are kept as thin delegators (call sites unchanged), which also keeps the existing source-text tests green.

- typecheck clean
- `pnpm test:app` → 370 files pass · `pnpm test:mobile` → 18 files pass
- Visual verification of rendered widths (esp. the 230px rail) attached in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)