### PR TITLE
feat(projects): multiselect to bulk-delete chats in a project card

### DIFF
--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -19,17 +19,82 @@ assert.match(projectsView, /chats=\{chatsByRoot\.get\(normalizeProjectRoot\(proj
 // Nested chats are draggable: reorder within a project, move across projects.
 assert.match(projectsView, /<DndContext[\s\S]{0,120}onDragEnd=\{handleDragEnd\}/, "Projects view wraps the cards in a DndContext");
 assert.match(projectsView, /function ProjectChatRow/, "chats render as sortable rows");
-// The chat row is a div role="button"; keep it keyboard-accessible — both Enter
-// and Space activate (ARIA button pattern) and it shows a visible focus ring.
+// The chat row is a div that toggles role button↔checkbox with select mode; keep
+// it keyboard-accessible — both Enter and Space activate (ARIA pattern) and it
+// shows a visible focus ring. In select mode activate toggles selection.
 assert.match(
   projectsView,
-  /role="button"[\s\S]{0,400}?e\.key === "Enter" \|\| e\.key === " "[\s\S]{0,120}?onOpen\(\)/,
+  /role=\{selectMode \? "checkbox" : "button"\}/,
+  "the chat row is a button normally and a checkbox in select mode",
+);
+assert.match(
+  projectsView,
+  /const activate = \(\) => \(selectMode \? onToggleSelect\(session\.id\) : onOpen\(\)\)/,
+  "activate toggles selection in select mode, otherwise opens the chat",
+);
+assert.match(
+  projectsView,
+  /e\.key === "Enter" \|\| e\.key === " "[\s\S]{0,120}?activate\(\)/,
   "the chat row activates on both Enter and Space",
 );
 assert.match(
   projectsView,
-  /role="button"[\s\S]{0,700}?className="focus-ring /,
+  /role=\{selectMode \? "checkbox" : "button"\}[\s\S]{0,900}?className="focus-ring /,
   "the chat row has a visible keyboard focus ring",
+);
+
+// Bulk multiselect: a Select toggle puts the card into select mode, each chat
+// row becomes a checkbox, and a toolbar deletes all selected chats at once.
+assert.match(
+  projectsView,
+  /const \[selectMode, setSelectMode\] = useState\(false\)/,
+  "each project card tracks its own select mode",
+);
+assert.match(
+  projectsView,
+  /const \[selectedIds, setSelectedIds\] = useState<Set<string>>/,
+  "selected chat ids are held in a Set",
+);
+assert.match(
+  projectsView,
+  /onDeleteSessions: \(sessionIds: string\[\]\) => Promise<void>/,
+  "project rows receive a bulk-delete callback",
+);
+assert.match(
+  projectsView,
+  /const handleDeleteSessions = async \(sessionIds: string\[\]\)/,
+  "ProjectsView implements a bulk-delete handler",
+);
+assert.match(
+  projectsView,
+  /Promise\.all\(sessionIds\.map\(\(id\) => deleteOneSession\(id\)\)\)/,
+  "bulk delete runs the per-chat deletes in parallel",
+);
+assert.match(
+  projectsView,
+  /results\.some\(Boolean\)\) onSessionsChanged/,
+  "bulk delete refetches once if any chat was deleted",
+);
+assert.match(
+  projectsView,
+  /\{allVisibleSelected \? "Clear" : "Select all"\}/,
+  "the select toolbar offers select-all / clear",
+);
+assert.match(
+  projectsView,
+  /\{selectedIds\.size\} selected/,
+  "the toolbar shows how many chats are selected",
+);
+assert.match(
+  projectsView,
+  /onDeleteSessions=\{handleDeleteSessions\}/,
+  "the bulk-delete handler is wired into project rows",
+);
+// Selection resets whenever the card's chat set changes, so deleted ids never linger.
+assert.match(
+  projectsView,
+  /const chatIdKey = chats\.map\(\(c\) => c\.id\)\.join\(","\)/,
+  "selection is keyed to the current chat ids",
 );
 assert.match(projectsView, /useDroppable\(\{\s*id: `pcard:/, "project cards are drop targets");
 assert.match(projectsView, /applyProjectOverrides\(sessions, projectOverrides\)/, "chats are grouped with Cave-local project overrides applied");
@@ -68,6 +133,8 @@ for (const icon of [
   "ph:terminal-window-bold",
   "ph:trash-bold",
   "ph:pencil-simple-bold",
+  "ph:list-checks-bold",
+  "ph:check-bold",
 ]) {
   assert.match(iconSource, new RegExp(`"${icon}"`), `${icon} should be in the icon allowlist`);
 }

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -80,16 +80,26 @@ function shortRoot(p: string): string {
 // event the chat surface already listens for); the handle drags it to reorder
 // within the project or onto another project card to move it. The trash button
 // deletes the chat with a two-step confirm, mirroring the Chats list.
+//
+// In select mode the leading drag handle becomes a checkbox and the row's
+// primary click toggles selection instead of opening the chat, so several chats
+// can be deleted together via the card's bulk toolbar.
 function ProjectChatRow({
   session,
   displayTitle,
   onOpen,
   onDelete,
+  selectMode,
+  selected,
+  onToggleSelect,
 }: {
   session: SessionRow;
   displayTitle?: string;
   onOpen: () => void;
   onDelete: (id: string) => Promise<void>;
+  selectMode: boolean;
+  selected: boolean;
+  onToggleSelect: (id: string) => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: session.id,
@@ -98,36 +108,52 @@ function ProjectChatRow({
   const title = stripLeadingTrailingEmoji(displayTitle ?? (session.title || "(untitled chat)"));
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const activate = () => (selectMode ? onToggleSelect(session.id) : onOpen());
   return (
     <li ref={setNodeRef} style={style} data-dragging={isDragging ? "true" : undefined} className="group/pc relative">
       <div
-        role="button"
+        role={selectMode ? "checkbox" : "button"}
+        aria-checked={selectMode ? selected : undefined}
         tabIndex={0}
-        onClick={onOpen}
+        onClick={activate}
         onKeyDown={(e) => {
-          // ARIA button pattern: Enter and Space both activate. preventDefault on
-          // Space stops the page from scrolling when the row has focus.
+          // ARIA button/checkbox pattern: Enter and Space both activate.
+          // preventDefault on Space stops the page from scrolling when focused.
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
-            onOpen();
+            activate();
           }
         }}
-        className="focus-ring flex w-full items-center gap-2 px-4 py-1 text-left text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+        data-selected={selectMode && selected ? "true" : undefined}
+        className="focus-ring flex w-full items-center gap-2 px-4 py-1 text-left text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] data-[selected=true]:bg-[var(--accent-presence)]/10 data-[selected=true]:text-[var(--text-primary)]"
       >
-        <button
-          type="button"
-          {...attributes}
-          {...listeners}
-          onClick={(e) => e.stopPropagation()}
-          title="Drag to reorder or move to another project"
-          aria-label={`Move ${title}`}
-          className="grid h-4 w-3 shrink-0 cursor-grab touch-none place-items-center text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover/pc:opacity-100"
-        >
-          <Icon name="ph:dots-six-vertical" width={10} aria-hidden />
-        </button>
+        {selectMode ? (
+          <span
+            aria-hidden
+            className={`grid h-3.5 w-3.5 shrink-0 place-items-center rounded border ${
+              selected
+                ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-[var(--text-primary)]"
+                : "border-[var(--border-strong)] text-transparent"
+            }`}
+          >
+            <Icon name="ph:check-bold" width={9} aria-hidden />
+          </span>
+        ) : (
+          <button
+            type="button"
+            {...attributes}
+            {...listeners}
+            onClick={(e) => e.stopPropagation()}
+            title="Drag to reorder or move to another project"
+            aria-label={`Move ${title}`}
+            className="grid h-4 w-3 shrink-0 cursor-grab touch-none place-items-center text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover/pc:opacity-100"
+          >
+            <Icon name="ph:dots-six-vertical" width={10} aria-hidden />
+          </button>
+        )}
         <span aria-hidden className={`h-1.5 w-1.5 shrink-0 rounded-full ${chatDotClass(session.status)}`} />
         <span className="min-w-0 flex-1 truncate">{title}</span>
-        {confirmDelete ? (
+        {selectMode ? null : confirmDelete ? (
           <span className="flex shrink-0 items-center gap-1">
             <button
               type="button"
@@ -193,6 +219,7 @@ type ProjectRowProps = {
   onNewChat?: (projectRoot: string) => void;
   onOpenSession?: (sessionId: string) => void;
   onDeleteSession: (sessionId: string) => Promise<void>;
+  onDeleteSessions: (sessionIds: string[]) => Promise<void>;
 };
 
 function ProjectRow({
@@ -204,6 +231,7 @@ function ProjectRow({
   onNewChat,
   onOpenSession,
   onDeleteSession,
+  onDeleteSessions,
 }: ProjectRowProps) {
   const chatCount = chats.length;
   // Every project starts collapsed to a single scannable row; expanding reveals
@@ -244,6 +272,49 @@ function ProjectRow({
   const [showAllChats, setShowAllChats] = useState(false);
   const visibleChats = showAllChats ? chats : chats.slice(0, CHAT_CAP);
   const chatTitles = useMemo(() => disambiguateSessionTitles(chats), [chats]);
+
+  // Bulk-select: pick several chats and delete them in one pass. Selection is
+  // scoped to this project card and resets when the set of chats changes (e.g.
+  // after a delete) so stale ids never linger.
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+  const [bulkDeleting, setBulkDeleting] = useState(false);
+  const chatIdKey = chats.map((c) => c.id).join(",");
+  useEffect(() => {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+  }, [chatIdKey]);
+  const toggleSelect = (id: string) =>
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  // Visible-aware select-all: acts on the chats currently shown (respects the
+  // Show all / Show less cap) and flips to "Clear" once they're all picked.
+  const allVisibleSelected =
+    visibleChats.length > 0 && visibleChats.every((s) => selectedIds.has(s.id));
+  const toggleSelectAllVisible = () =>
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (allVisibleSelected) for (const s of visibleChats) next.delete(s.id);
+      else for (const s of visibleChats) next.add(s.id);
+      return next;
+    });
+  const exitSelect = () => {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+  };
+  const deleteSelected = async () => {
+    const ids = chats.map((s) => s.id).filter((id) => selectedIds.has(id));
+    if (ids.length === 0) return;
+    setBulkDeleting(true);
+    await onDeleteSessions(ids);
+    setBulkDeleting(false);
+    exitSelect();
+  };
+
   const { setNodeRef: setDropRef, isOver } = useDroppable({
     id: `pcard:${normalizeProjectRoot(project.root)}`,
   });
@@ -508,8 +579,53 @@ function ProjectRow({
 
       {chats.length > 0 ? (
         <>
+          <div className="-mx-2 mt-2 flex items-center justify-between gap-2 border-t border-[var(--border-hairline)] px-4 pt-2">
+            {selectMode ? (
+              <>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={toggleSelectAllVisible}
+                    className="focus-ring rounded px-1.5 py-0.5 text-[11px] font-medium text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-secondary)]"
+                  >
+                    {allVisibleSelected ? "Clear" : "Select all"}
+                  </button>
+                  <span className="text-[11px] text-[var(--text-muted)]">
+                    {selectedIds.size} selected
+                  </span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={exitSelect}
+                    className="focus-ring rounded px-1.5 py-0.5 text-[11px] text-[var(--text-muted)] hover:bg-[var(--bg-hover)]"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    disabled={bulkDeleting || selectedIds.size === 0}
+                    onClick={() => void deleteSelected()}
+                    className="focus-ring inline-flex items-center gap-1 rounded border border-[var(--color-danger)]/50 bg-[var(--color-danger)]/10 px-1.5 py-0.5 text-[11px] text-[var(--color-danger)] hover:bg-[var(--color-danger)]/15 disabled:opacity-50"
+                  >
+                    <Icon name="ph:trash-bold" width={11} aria-hidden />
+                    {bulkDeleting ? "Deleting…" : `Delete${selectedIds.size ? ` ${selectedIds.size}` : ""}`}
+                  </button>
+                </div>
+              </>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setSelectMode(true)}
+                className="focus-ring ml-auto inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-secondary)]"
+              >
+                <Icon name="ph:list-checks-bold" width={12} aria-hidden />
+                Select
+              </button>
+            )}
+          </div>
           <SortableContext items={visibleChats.map((s) => s.id)} strategy={verticalListSortingStrategy}>
-            <ul className="-mx-2 mt-2 flex flex-col gap-0.5 border-t border-[var(--border-hairline)] pt-2">
+            <ul className="-mx-2 mt-1 flex flex-col gap-0.5">
               {visibleChats.map((session) => (
                 <ProjectChatRow
                   key={session.id}
@@ -517,6 +633,9 @@ function ProjectRow({
                   displayTitle={chatTitles.get(session.id)}
                   onOpen={() => onOpenSession?.(session.id)}
                   onDelete={onDeleteSession}
+                  selectMode={selectMode}
+                  selected={selectedIds.has(session.id)}
+                  onToggleSelect={toggleSelect}
                 />
               ))}
             </ul>
@@ -684,22 +803,38 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: Pr
     setShowForm(false);
   };
 
-  // Delete a chat from its project card, mirroring the Chats list delete
-  // (DELETE /api/chat/conversation/:id), then ask the parent to refetch
-  // sessions so the row disappears everywhere.
-  const handleDeleteSession = async (sessionId: string) => {
-    setSessionError(null);
+  // Delete one chat, mirroring the Chats list delete (DELETE
+  // /api/chat/conversation/:id). Returns whether it succeeded; callers refetch.
+  const deleteOneSession = async (sessionId: string): Promise<boolean> => {
     try {
       const res = await fetch(`/api/chat/conversation/${encodeURIComponent(sessionId)}`, { method: "DELETE" });
       const json = await res.json().catch(() => ({ ok: false }));
       if (!res.ok || !json.ok) {
         setSessionError(json.error ?? "delete failed");
-        return;
+        return false;
       }
-      onSessionsChanged?.();
+      return true;
     } catch (err) {
       setSessionError(err instanceof Error ? err.message : "delete failed");
+      return false;
     }
+  };
+
+  // Delete a single chat from its project card, then ask the parent to refetch
+  // sessions so the row disappears everywhere.
+  const handleDeleteSession = async (sessionId: string) => {
+    setSessionError(null);
+    if (await deleteOneSession(sessionId)) onSessionsChanged?.();
+  };
+
+  // Bulk-delete the chats selected in a project card. Runs the deletes in
+  // parallel, then refetches once if anything succeeded so the surviving rows
+  // (if a delete failed) stay accurate.
+  const handleDeleteSessions = async (sessionIds: string[]) => {
+    setSessionError(null);
+    if (sessionIds.length === 0) return;
+    const results = await Promise.all(sessionIds.map((id) => deleteOneSession(id)));
+    if (results.some(Boolean)) onSessionsChanged?.();
   };
 
   return (
@@ -907,6 +1042,7 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: Pr
                     onNewChat={onNewChat}
                     onOpenSession={openSessionById}
                     onDeleteSession={handleDeleteSession}
+                    onDeleteSessions={handleDeleteSessions}
                   />
                 ))}
               </DndContext>


### PR DESCRIPTION
## What

Adds **multiselect bulk-delete** for chats inside each project card on the **Projects tab** (Familiars → Chat → Projects). Previously you could only delete chats one at a time via the per-row trash + two-step confirm.

## How it works

- Each expanded project card shows a subtle **"Select"** toggle (list-checks icon) above its chat list.
- In select mode, every chat row's drag handle becomes a **checkbox**; the row's primary click / Enter / Space toggles selection instead of opening the chat (`role` flips `button`↔`checkbox`, with `aria-checked` and an accent-highlighted selected state).
- A toolbar appears with **visible-aware "Select all / Clear"** (respects the Show all cap), an **"N selected"** count, **Cancel**, and a red **"Delete N"**.
- `handleDeleteSessions` runs the per-chat `DELETE /api/chat/conversation/:id` calls in parallel, then refetches sessions once if any succeeded.
- Selection auto-resets whenever the card's chat set changes, so deleted ids never linger.

## Verification

- `node scripts/run-tests.mjs app` → **370 test files pass** (incl. updated `projects-view.test.ts`)
- `pnpm typecheck` → clean
- **Visual**: built + ran the app with mocked projects/sessions and confirmed both the "Select" toggle (normal view) and the checkboxes + "Delete N" toolbar (select mode) render and select correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)