### PR TITLE
feat(chat): add a delete button to the chat session header

### DIFF
--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -128,6 +128,19 @@ assert.match(
   "Successful delete refreshes sessions and navigates back to the list",
 );
 
+// A standalone delete (trash) button sits at the top of the session, beside the
+// overflow menu, opening a confirm popover before it commits via deleteChat.
+assert.match(
+  source,
+  /function HeaderDeleteButton[\s\S]*?aria-label="Delete chat"[\s\S]*?Delete this chat permanently\?[\s\S]*?disabled=\{deleting\} onSelect=\{\(\) => onDelete\(\)\}/,
+  "HeaderDeleteButton renders a guarded trash trigger that confirms before deleting",
+);
+assert.match(
+  source,
+  /<HeaderDeleteButton onDelete=\{\(\) => void deleteChat\(\)\} deleting=\{deleting\} \/>/,
+  "the chat header mounts the standalone delete button wired to deleteChat",
+);
+
 // ── Collapsed tool rows show a one-line arg summary (CHAT-D4-02) ─────────────
 // The summary is derived by the pure helper in src/lib/tool-arg-summary.ts so
 // a run can be audited (`Read(src/foo.ts)`-style) without expanding blocks.

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -771,6 +771,56 @@ function SessionOverflowMenu({
   );
 }
 
+/** Standalone delete control for the chat header — a one-click trash button that
+ *  opens a small confirm popover before committing. Mirrors the overflow menu's
+ *  two-step guard, but surfaced at the top of the session for quick access. Uses
+ *  its own open state so it never collides with the kebab's armed state; the
+ *  in-flight `deleting` flag and the actual delete are shared via props. */
+function HeaderDeleteButton({
+  onDelete,
+  deleting,
+}: {
+  onDelete: () => void;
+  deleting: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="focus-ring cave-chat-delete-trigger"
+        aria-label="Delete chat"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title="Delete chat"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <Icon name="ph:trash" width={15} aria-hidden />
+      </button>
+      <Popover
+        open={open}
+        onOpenChange={setOpen}
+        anchorRef={triggerRef}
+        placement="bottom-end"
+        minWidth={216}
+        ariaLabel="Delete chat"
+      >
+        <PopoverBody>
+          <PopoverLabel>Delete this chat permanently?</PopoverLabel>
+          <PopoverItem icon="ph:x" onSelect={() => setOpen(false)}>
+            Cancel
+          </PopoverItem>
+          <PopoverItem icon="ph:trash" danger disabled={deleting} onSelect={() => onDelete()}>
+            {deleting ? "Deleting…" : "Delete chat"}
+          </PopoverItem>
+        </PopoverBody>
+      </Popover>
+    </>
+  );
+}
+
 function ChatHistoryNotice({
   title,
   body,
@@ -3263,6 +3313,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 onPrev={findPrev}
               />
             ) : null}
+            {sessionId && (
+              <HeaderDeleteButton onDelete={() => void deleteChat()} deleting={deleting} />
+            )}
             {sessionId && (
               <SessionOverflowMenu
                 projects={projects}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2259,6 +2259,14 @@ details[open] > .cave-tool-summary::before {
   color: var(--text-primary);
 }
 
+/* The header delete trigger reads as destructive on hover/open. */
+.cave-chat-session-actions > .cave-chat-delete-trigger:hover:not(:disabled),
+.cave-chat-session-actions > .cave-chat-delete-trigger[aria-expanded="true"] {
+  border-color: color-mix(in oklch, var(--color-danger) 55%, transparent);
+  background: color-mix(in oklch, var(--color-danger) 14%, transparent);
+  color: var(--color-danger);
+}
+
 .cave-chat-session-actions .voice-call-button:disabled {
   opacity: 0.45;
 }


### PR DESCRIPTION
## What

Surfaces chat deletion at the **top of the session** instead of only inside the ⋮ overflow menu.

- New `HeaderDeleteButton` — a trash icon in the header action cluster (beside the find + overflow controls). Click opens a small confirm popover (**"Delete this chat permanently?"** → Cancel / Delete chat) before committing.
- Commits via the existing `deleteChat()` handler: `DELETE /api/chat/conversation/:id`, then `onSessionsChanged()` + `onBack()` (refresh list, navigate away).
- Uses its own `open` state so it never collides with the kebab's armed state; the in-flight `deleting` flag is shared. The trigger reads destructive (danger color) on hover/when the popover is open.
- The overflow-menu delete is left intact (quick header access + grouped-in-overflow both work).

## Verify

Route-mocked a session and drove the real chat header (1440px):
- Trash button renders in the header between the cwd breadcrumb and the kebab.
- Clicking opens the confirm popover with Cancel / Delete chat (danger).
- `chat-header-row.test.ts` gains assertions for the new button + its wiring to `deleteChat`. Full `test:app` suite green (370 files).

![header](#) Trash button sits at top-right of the session header; confirm popover gates the delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)