### PR TITLE
feat(ui): actionable empty states for GitHub + Workflows surfaces

### DIFF
--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -5,6 +5,8 @@ import { Icon } from "@/lib/icon";
 import { relativeTime } from "@/lib/relative-time";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import { RelativeTime } from "@/components/ui/relative-time";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Button } from "@/components/ui/button";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import type { Familiar } from "@/lib/types";
 import type { Card, CardStatus } from "@/lib/cave-board-types";
@@ -1600,43 +1602,40 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
           </div>
 
         ) : error === "no_user" ? (
-          <div className="flex h-full flex-col items-center justify-center gap-4 px-8 text-center">
-            <Icon name="ph:github-logo" width={28} className="text-[var(--text-muted)]" />
-            <div>
-              <p className="text-[14px] font-medium text-[var(--text-primary)] mb-1">Connect your GitHub account</p>
-              <p className="text-[12px] text-[var(--text-muted)] max-w-xs">
-                Cave uses the public GitHub API (no auth needed) or your own PAT for private repos and reviews.
-              </p>
-            </div>
-            <div className="flex flex-col gap-2 items-center">
-              <button
-                type="button"
-                onClick={() => setShowPatModal(true)}
-                className="rounded-lg bg-[var(--accent-presence)] px-5 py-2 text-[13px] font-medium text-white hover:opacity-90 transition-opacity"
-              >
-                Set up GitHub
-              </button>
-            </div>
+          <div className="flex h-full items-center justify-center px-8">
+            <EmptyState
+              icon="ph:github-logo"
+              headline="Connect your GitHub account"
+              subtitle="Cave uses the public GitHub API (no auth needed) or your own PAT for private repos and reviews."
+              actions={
+                <Button variant="primary" leadingIcon="ph:github-logo" onClick={() => setShowPatModal(true)}>
+                  Set up GitHub
+                </Button>
+              }
+            />
           </div>
 
         ) : error ? (
-          <div className="flex h-full flex-col items-center justify-center gap-3 px-8 text-center">
-            <p className="text-[12px] text-[var(--color-danger)]">{error}</p>
-            <button
-              type="button"
-              onClick={() => void fetchActivity()}
-              className="text-[11px] text-[var(--accent-presence)] hover:underline"
-            >
-              Retry
-            </button>
+          <div className="flex h-full items-center justify-center px-8">
+            <EmptyState
+              icon="ph:warning-circle"
+              headline="Couldn't load GitHub"
+              subtitle={error}
+              actions={
+                <Button variant="secondary" leadingIcon="ph:arrow-clockwise" onClick={() => void fetchActivity()}>
+                  Retry
+                </Button>
+              }
+            />
           </div>
 
         ) : sorted.length === 0 ? (
-          <div className="flex h-full flex-col items-center justify-center gap-2 text-center">
-            <Icon name="ph:check-circle" width={22} className="text-[var(--text-muted)]" />
-            <p className="text-[13px] text-[var(--text-muted)]">
-              {filter === "all" ? "Nothing open right now." : `No open ${filter === "review_request" ? "review requests" : filter + "s"}.`}
-            </p>
+          <div className="flex h-full items-center justify-center px-8">
+            <EmptyState
+              icon="ph:check-circle"
+              headline={filter === "all" ? "Nothing open right now" : `No open ${filter === "review_request" ? "review requests" : filter + "s"}`}
+              subtitle={filter === "all" ? "Pull requests, reviews, and issues that need you will show up here." : undefined}
+            />
           </div>
 
         ) : (

--- a/src/components/workflows/workflow-library.tsx
+++ b/src/components/workflows/workflow-library.tsx
@@ -3,6 +3,8 @@
 import { useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { isPersonalWorkflow, isPublicTemplate, type WorkflowSummary } from "@/lib/workflows";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Button } from "@/components/ui/button";
 
 type WorkflowLibraryProps = {
   workflows: WorkflowSummary[];
@@ -174,13 +176,16 @@ export function WorkflowLibrary({
           </button>
         </div>
       ) : workflows.length === 0 ? (
-        <div className="workflow-library-state">
-          No WORKFLOW.md or .workflow.yaml manifests found.
-          <button type="button" className="workflow-primary-button" onClick={onCreateRequest}>
-            <Icon name="ph:plus-bold" width={13} />
-            New workflow
-          </button>
-        </div>
+        <EmptyState
+          icon="ph:graph"
+          headline="No workflows yet"
+          subtitle="No WORKFLOW.md or .workflow.yaml manifests found. Create one to chain steps into a repeatable run."
+          actions={
+            <Button variant="primary" leadingIcon="ph:plus" onClick={onCreateRequest}>
+              New workflow
+            </Button>
+          }
+        />
       ) : (
         <div className="workflow-library-list">
           {visible.length === 0 && (


### PR DESCRIPTION
First of three UX improvements from the latest round.

The GitHub and Workflows surfaces hand-rolled their empty / not-configured states with custom centered divs and inline-styled `<button>`s, diverging from the rest of the app (which already has a mature shared `<EmptyState>` + `<Button>`). Standardize them:

- **`github-view`** — the "Connect your GitHub account" (no PAT), load-error, and "nothing open" states now render via `<EmptyState>` with a real `<Button>` CTA (**Set up GitHub** / **Retry**), replacing the inline-styled accent button.
- **`workflows/workflow-library`** — the "no workflows yet" state uses `<EmptyState>` + a primary **New workflow** `<Button>` instead of bare text + a custom button.

Same handlers (`setShowPatModal`, `fetchActivity`, `onCreateRequest`) — purely a markup/consistency change.

`eval-loop-panel` was reviewed and **left as-is**: it already has a dashed "No iterations yet" empty state and an actionable "start synthesis" error state.

- typecheck clean · icon-subset allowlist green
- `pnpm test:app` → 370 files pass · `pnpm test:mobile` → 18 files pass
- Visual verification attached in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)