### PR TITLE
feat(ui): complete the keyboard-shortcut catalog (Terminal + Browser groups)

### DIFF
--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -15,6 +15,10 @@
  *     src/components/home-composer.tsx handleKeyDown
  *   - "/" search focus: each surface's view (familiars-view, projects-view,
  *     capabilities-view, chat-list); "⌘F" sessions search: chat-list.tsx
+ *   - terminal & panes: src/components/comux-view.tsx keydown handlers
+ *   - browser pane: src/components/browser-pane.tsx (⌘L / ⌘K / [)
+ *   - ⌘S save: familiar-daily-notes.tsx + journal/canvas-list.tsx;
+ *     artifact refine ⌘↵: chat-artifact-viewer.tsx
  */
 
 export type ShortcutEntry = {
@@ -24,7 +28,7 @@ export type ShortcutEntry = {
 };
 
 export type ShortcutGroup = {
-  id: "panels" | "composer" | "slash-menu" | "other";
+  id: "panels" | "terminal" | "browser" | "composer" | "slash-menu" | "other";
   label: string;
   entries: ShortcutEntry[];
 };
@@ -48,6 +52,28 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: "⌘N", description: "New chat (on the Chat surface)" },
       { keys: "/", description: "Focus the search (Familiars, Projects, Capabilities, Sessions)" },
       { keys: "⌘F", description: "Focus the sessions search" },
+    ],
+  },
+  {
+    id: "terminal",
+    label: "Terminal & panes",
+    entries: [
+      { keys: "⌘N", description: "New terminal session" },
+      { keys: "⌘W", description: "Close the focused pane" },
+      { keys: "⌘⌥←→↑↓", description: "Focus the pane in that direction" },
+      { keys: "⌘[ / ⌘]", description: "Cycle to the previous / next pane" },
+      { keys: "⌘1–⌘9", description: "Jump to pane N" },
+      { keys: "⌘↵", description: "Zoom the focused pane (toggle)" },
+      { keys: "⌘⇧B", description: "Broadcast input to every visible pane" },
+    ],
+  },
+  {
+    id: "browser",
+    label: "Browser",
+    entries: [
+      { keys: "⌘L", description: "Focus the address bar" },
+      { keys: "⌘K", description: "Open quick-open" },
+      { keys: "[", description: "Toggle the rail pin" },
     ],
   },
   {
@@ -75,6 +101,8 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
     label: "Other",
     entries: [
       { keys: "⌘,", description: "Open Settings" },
+      { keys: "⌘S", description: "Save (daily notes, journal)" },
+      { keys: "⌘↵", description: "Run the refine (artifact viewer)" },
       { keys: "⌘/", description: "Open this shortcuts sheet" },
       { keys: "?", description: "Open the shortcuts sheet (when not typing in a field)" },
       { keys: "Esc", description: "Close dialogs and modals" },


### PR DESCRIPTION
Third of the latest UX round. **Reframed during research:** the pitch was "add a shortcut cheat-sheet overlay" — but one already exists (`shortcuts-sheet.tsx`, opened with `⌘/` or `?`). The real gap was that its catalog (`SHORTCUT_GROUPS`) only listed ~14 of the app's ~30+ shortcuts, so the entire **Terminal/pane** and **Browser-pane** sets were undiscoverable.

Completes the catalog (every entry verified against the actual keydown handler):

**Terminal & panes** (`comux-view.tsx`) — ⌘N new · ⌘W close · ⌘⌥arrows directional focus · ⌘[ / ⌘] cycle · ⌘1–9 jump · ⌘↵ zoom · ⌘⇧B broadcast
**Browser** (`browser-pane.tsx`) — ⌘L address bar · ⌘K quick-open · `[` rail pin
**Other** — ⌘S save (daily notes / journal) · ⌘↵ run refine (artifact viewer)

The two new groups slot in after "Panels & navigation", so the existing catalog-order assertion (`Panels → Composer → Slash menu → Other`) still holds, and the sheet renders them automatically (it maps `SHORTCUT_GROUPS`). The file's "keep this truthful" source-of-truth comment is updated to point at the new handlers.

- typecheck clean
- `pnpm test:app` → 370 files pass · `pnpm test:mobile` → 18 files pass (incl. the 2 catalog-referencing tests)
- Rendered-sheet screenshot attached in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)