### PR TITLE
fix(chat): remove the redundant delete from the overflow menu

### DIFF
--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -104,19 +104,9 @@ assert.doesNotMatch(
   "Standalone lifecycle status bar CSS is removed (folded into meta line)",
 );
 
-// In-chat delete: header trash action with the same two-step confirm as the
-// Chats-page rows — first click only ARMS, the explicit Delete commits, and
-// success refreshes the session list and navigates back.
-assert.match(
-  source,
-  /danger onSelect=\{\(\) => onConfirmDeleteChange\(true\)\}>\s*Delete chat/,
-  "Overflow-menu Delete only arms the confirmation — it must not delete",
-);
-assert.match(
-  source,
-  /confirmDelete \?[\s\S]*?Cancel[\s\S]*?Confirm delete/,
-  "Armed state offers explicit Cancel and Delete actions",
-);
+// In-chat delete lives ONLY in the header trash button now — it opens a confirm
+// popover, the explicit Delete commits via deleteChat, and success refreshes the
+// session list and navigates back. The overflow menu no longer carries delete.
 assert.match(
   source,
   /const deleteChat = async[\s\S]*?fetch\(`\/api\/chat\/conversation\/\$\{encodeURIComponent\(sessionId\)\}`, \{ method: "DELETE" \}\)/,
@@ -137,8 +127,19 @@ assert.match(
 );
 assert.match(
   source,
-  /<HeaderDeleteButton onDelete=\{\(\) => void deleteChat\(\)\} deleting=\{deleting\} \/>/,
-  "the chat header mounts the standalone delete button wired to deleteChat",
+  /<HeaderDeleteButton key=\{sessionId\} onDelete=\{\(\) => void deleteChat\(\)\} deleting=\{deleting\} \/>/,
+  "the chat header mounts the standalone delete button (keyed on sessionId) wired to deleteChat",
+);
+// The overflow (kebab) menu no longer offers delete — it's header-only.
+assert.doesNotMatch(
+  source,
+  /onConfirmDeleteChange/,
+  "the overflow menu's two-step delete wiring is removed",
+);
+assert.doesNotMatch(
+  source,
+  /Confirm delete/,
+  "no 'Confirm delete' item remains in the overflow menu",
 );
 
 // ── Collapsed tool rows show a one-line arg summary (CHAT-D4-02) ─────────────

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -640,10 +640,10 @@ function ChatEmptyState({
 }
 
 /** Codex/ChatGPT-style overflow menu. Collapses the session's secondary
- *  controls — project switch, voice call, debug, delete — into a single kebab
- *  so the header reads as title + quiet metadata instead of a row of competing
- *  icons. Find stays inline (one-click, frequently used); everything else lives
- *  one click away here. */
+ *  controls — project switch, voice call, debug — into a single kebab so the
+ *  header reads as title + quiet metadata instead of a row of competing icons.
+ *  Find and Delete stay inline (one-click); everything else lives one click away
+ *  here. */
 function SessionOverflowMenu({
   projects,
   projectId,
@@ -652,10 +652,6 @@ function SessionOverflowMenu({
   voiceActive,
   onOpenVoice,
   onOpenDebug,
-  onDelete,
-  deleting,
-  confirmDelete,
-  onConfirmDeleteChange,
 }: {
   projects: CaveProject[];
   projectId: string | null;
@@ -664,20 +660,13 @@ function SessionOverflowMenu({
   voiceActive: boolean;
   onOpenVoice: () => void;
   onOpenDebug: () => void;
-  onDelete: () => void;
-  deleting: boolean;
-  confirmDelete: boolean;
-  onConfirmDeleteChange: (next: boolean) => void;
 }) {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const activeProject = (projectId ? chatProjectById(projectId, projects) ?? projects[0] : projects[0]) ?? null;
   const voiceConfigured = Boolean(familiar.voiceProvider);
 
-  const close = () => {
-    setOpen(false);
-    onConfirmDeleteChange(false);
-  };
+  const close = () => setOpen(false);
 
   return (
     <>
@@ -750,21 +739,6 @@ function SessionOverflowMenu({
           >
             Debug session
           </PopoverItem>
-          <PopoverSeparator />
-          {confirmDelete ? (
-            <>
-              <PopoverItem icon="ph:x" onSelect={() => onConfirmDeleteChange(false)}>
-                Cancel
-              </PopoverItem>
-              <PopoverItem icon="ph:trash" danger disabled={deleting} onSelect={() => onDelete()}>
-                {deleting ? "Deleting…" : "Confirm delete"}
-              </PopoverItem>
-            </>
-          ) : (
-            <PopoverItem icon="ph:trash" danger onSelect={() => onConfirmDeleteChange(true)}>
-              Delete chat
-            </PopoverItem>
-          )}
         </PopoverBody>
       </Popover>
     </>
@@ -1679,9 +1653,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const [expandedAvatarTurnId, setExpandedAvatarTurnId] = useState<string | null>(null);
   const expandedAvatarTurnIdRef = useRef<string | null>(null);
   expandedAvatarTurnIdRef.current = expandedAvatarTurnId;
-  // Two-step delete, matching the Chats-page rows: the trash icon only ARMS
-  // the inline Cancel/Delete confirm; only the explicit Delete commits.
-  const [confirmDelete, setConfirmDelete] = useState(false);
+  // Two-step delete via the header trash button: it opens a confirm popover and
+  // only the explicit Delete commits (HeaderDeleteButton owns the armed state).
   const [deleting, setDeleting] = useState(false);
   const { projects } = useProjects();
   const firstProject = projects[0] ?? null;
@@ -3105,15 +3078,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     writeComposerHistory(COMPOSER_HISTORY_KEY, inputHistory);
   }, [inputHistory]);
 
-  // Disarm a pending delete confirmation and sync the selected project when
-  // switching sessions. Drop staged file mentions because they are scoped to
-  // the previous session/root.
-  // Sync draft when the session/root changes. Also initialise the draft the
-  // first time projects load (when it is still null). Do NOT overwrite a
+  // Sync the selected project when switching sessions. Also initialise the draft
+  // the first time projects load (when it is still null). Do NOT overwrite a
   // user-set draft just because the projects list was re-fetched (e.g. after a
-  // rename or create), which would discard an in-session selection.
+  // rename or create), which would discard an in-session selection. (The header
+  // delete confirm resets itself — HeaderDeleteButton is keyed on sessionId.)
   useEffect(() => {
-    setConfirmDelete(false);
     setProjectIdDraft((prev) => {
       const resolved =
         projectIdForRoot(session?.project_root ?? projectRoot, projects) ??
@@ -3181,7 +3151,6 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       setError(err instanceof Error ? err.message : "delete failed");
     } finally {
       setDeleting(false);
-      setConfirmDelete(false);
     }
   };
 
@@ -3314,7 +3283,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               />
             ) : null}
             {sessionId && (
-              <HeaderDeleteButton onDelete={() => void deleteChat()} deleting={deleting} />
+              <HeaderDeleteButton key={sessionId} onDelete={() => void deleteChat()} deleting={deleting} />
             )}
             {sessionId && (
               <SessionOverflowMenu
@@ -3325,10 +3294,6 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 voiceActive={voiceCallOpen}
                 onOpenVoice={() => setVoiceCallOpen(true)}
                 onOpenDebug={openDebug}
-                onDelete={() => void deleteChat()}
-                deleting={deleting}
-                confirmDelete={confirmDelete}
-                onConfirmDeleteChange={setConfirmDelete}
               />
             )}
           </div>


### PR DESCRIPTION
## What

Now that the chat header has a dedicated delete (trash) button (#1603), remove the duplicate two-step delete from the ⋮ overflow menu so deletion lives in one place.

- `SessionOverflowMenu` loses its delete props (`onDelete`, `deleting`, `confirmDelete`, `onConfirmDeleteChange`) and the Delete chat / Cancel / Confirm delete items. Its remaining items: Rename, Project, Voice, Debug.
- The now-dead `confirmDelete` state and its two reset sites are removed (`deleting` stays — the header button uses it).
- `HeaderDeleteButton` is keyed on `sessionId` so its confirm popover resets when switching sessions (replacing the old `confirmDelete` reset on session change).

Net `-62 / +28` lines.

## Verify

Route-mocked a session and drove the real chat header (1440px):
- Header trash button present (count 1); clicking opens the **Cancel / Delete chat** confirm popover.
- ⋮ overflow menu now shows only Rename + Project (+ Voice/Debug) — **no delete**.
- `chat-header-row.test.ts`: kebab-delete assertions removed; added `doesNotMatch` guards for `onConfirmDeleteChange` / "Confirm delete", and the header-button mount assertion updated for `key={sessionId}`. Full `test:app` suite green (370 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)