### PR TITLE
feat(ui): exact-time hover tooltips on bare relative timestamps (adopt <RelativeTime>)

### DIFF
--- a/src/components/board-table.tsx
+++ b/src/components/board-table.tsx
@@ -9,8 +9,7 @@ import { Icon } from "@/lib/icon";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
-import { relativeTime } from "@/lib/relative-time";
-import { useDateTimePrefs } from "@/lib/datetime-format";
+import { RelativeTime } from "@/components/ui/relative-time";
 
 export type GroupBy = "status" | "familiar" | "project";
 export type SortKey = "title" | "status" | "priority" | "familiar" | "lifecycle" | "startDate" | "endDate" | "updatedAt";
@@ -77,12 +76,6 @@ function groupCards(cards: Card[], by: GroupBy, familiars: Familiar[], projects:
   return entries;
 }
 
-// Density-aware relative age, shared with the rest of the app: "2m ago" /
-// "2 minutes ago" depending on the Appearance → Relative time preference.
-function relTime(iso: string): string {
-  return relativeTime(iso);
-}
-
 function formatBoardDate(value: string | null | undefined): string {
   if (!value) return "—";
   const [year, month, day] = value.split("-");
@@ -113,7 +106,6 @@ type Props = {
 };
 
 export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId, onSelect, onPatch }: Props) {
-  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [sortKey, setSortKey] = useState<SortKey>("updatedAt");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set(["done"]));
@@ -258,7 +250,7 @@ export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId
                     <td><LifecycleBadge lifecycle={card.lifecycle} needsHuman={card.needsHuman} /></td>
                     <td><span className="board-table-cell-date">{formatBoardDate(card.startDate)}</span></td>
                     <td><span className="board-table-cell-date">{formatBoardDate(card.endDate)}</span></td>
-                    <td style={{ textAlign: "right" }}><span className="board-table-cell-time">{relTime(card.updatedAt)}</span></td>
+                    <td style={{ textAlign: "right" }}><RelativeTime iso={card.updatedAt} className="board-table-cell-time" /></td>
                   </tr>
                 );
               })}

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -1136,7 +1136,7 @@ function GitHubItemGlassPanel({
               {" · "}
               {item.repo}
               {" · "}
-              {relativeTime(detail?.createdAt ?? item.updatedAt)}
+              <RelativeTime iso={detail?.createdAt ?? item.updatedAt} />
             </span>
           </div>
         </div>

--- a/src/components/library-timeline-row.tsx
+++ b/src/components/library-timeline-row.tsx
@@ -3,19 +3,12 @@
 import { Icon, type IconName } from "@/lib/icon";
 import type { TimelineEntry } from "@/app/api/library/all/route";
 import type { Familiar } from "@/lib/types";
-import { relativeTime } from "@/lib/relative-time";
-import { useDateTimePrefs } from "@/lib/datetime-format";
+import { RelativeTime } from "@/components/ui/relative-time";
 
 function listIcon(list: TimelineEntry["list"]): IconName {
   if (list === "github") return "ph:github-logo";
   if (list === "reading") return "ph:book-open";
   return "ph:bookmark-simple";
-}
-
-// Density-aware relative age, shared with the rest of the app: "2m ago" /
-// "2 minutes ago" depending on the Appearance → Relative time preference.
-function relTime(iso: string): string {
-  return relativeTime(iso);
 }
 
 function EntryIcon({ entry }: { entry: TimelineEntry }) {
@@ -40,7 +33,6 @@ export function LibraryTimelineRow({
   selected: boolean;
   onSelect: () => void;
 }) {
-  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const fam = familiars.find((f) => f.id === entry.familiar);
   const title = entry.item.title || (entry.item as { url?: string }).url || "Untitled";
 
@@ -73,9 +65,7 @@ export function LibraryTimelineRow({
       </span>
 
       {/* recency */}
-      <span className="library-timeline-row-time shrink-0 tabular-nums">
-        {relTime(entry.capturedAt)}
-      </span>
+      <RelativeTime iso={entry.capturedAt} className="library-timeline-row-time shrink-0 tabular-nums" />
     </button>
   );
 }


### PR DESCRIPTION
The "hover a relative timestamp to see the exact time" idea — **reframed during research**: the app already has a `<RelativeTime>` component (`ui/relative-time.tsx`) that renders a relative time as a semantic `<time>` element with the full preference-aware absolute timestamp in the `title` (e.g. *"Monday, June 16, 2026 at 1:31 PM"*) and self-subscribes to the density pref. It's already used in 6 surfaces, and many others render the same `<span title={formatTimestamp(...)}>` pattern inline. The gap is the surfaces that render **bare** `relativeTime()` text with no tooltip at all.

This adopts `<RelativeTime>` at three such gaps:
- **`board-table`** — the "Updated" cell. Also drops the now-dead local `relTime` wrapper + manual `useDateTimePrefs()` (RelativeTime handles both).
- **`library-timeline-row`** — the recency stamp (same cleanup).
- **`github-view`** — the "opened … · `<repo>` · `<when>`" line; the file already imports `<RelativeTime>`, so this removes the one inconsistent bare call.

Net: these now show the exact date+time on hover, stay density-live, and carry less per-surface boilerplate (−23/+5 lines). No tests pin these render sites.

This is **batch 1** — more bare-relative-time gaps remain (coven-floor, familiar-status-card, familiars-view/-memory, inspector-pane), but several have `"never"`/signed-future semantics that need per-site care, so they're follow-ups.

- typecheck clean · `pnpm test:app` 370 + `pnpm test:mobile` 18 pass
- Tooltip + density verified live in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)