### PR TITLE
feat(ui): exact-time tooltips on the remaining relative-time gaps (batch 2)

### DIFF
--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -930,7 +930,7 @@ function CodexDetailPanel({
                   >
                     <span className="h-2 w-2 shrink-0 rounded-full" style={{ background:
                       r.status === "succeeded" ? "var(--accent-presence)" : r.status === "failed" ? "var(--color-danger)" : "var(--text-muted)" }} />
-                    <span style={{ color: "var(--text-secondary)" }}>{relTime(r.startedAt)}</span>
+                    <span style={{ color: "var(--text-secondary)" }} title={r.startedAt ? formatTimestamp(r.startedAt, readDateTimePrefs()) : undefined}>{relTime(r.startedAt)}</span>
                     {r.summary && <span className="truncate" style={{ color: "var(--text-muted)" }}>{r.summary}</span>}
                     <span className="ml-auto shrink-0" style={{ color: "var(--text-muted)", lineHeight: 0 }}>
                       <Icon name={openRunId === r.id ? "ph:caret-down" : "ph:caret-right"} width={11} />
@@ -1049,7 +1049,7 @@ function AutomationScheduleRow({
           </span>
         )}
         {lastRun && (
-          <span className="shrink-0 text-[11px]" style={{ color:
+          <span className="shrink-0 text-[11px]" title={lastRun.startedAt ? formatTimestamp(lastRun.startedAt, readDateTimePrefs()) : undefined} style={{ color:
             lastRun.status === "failed" ? "var(--color-danger)"
             : lastRun.status === "running" ? "var(--accent-presence)"
             : "var(--text-muted)" }}>

--- a/src/components/coven-floor.tsx
+++ b/src/components/coven-floor.tsx
@@ -1,21 +1,17 @@
 "use client";
 
 import "@/styles/board.css";
-import { relativeTime } from "@/lib/relative-time";
 
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { formatClock, useDateTimePrefs } from "@/lib/datetime-format";
+import { RelativeTime } from "@/components/ui/relative-time";
 import type { CovenStatusResponse, FamiliarCard, SessionSummary } from "@/lib/coven-status-types";
 import { statusColor, statusLabel } from "@/lib/coven-status-types";
 import { SessionInitiatorChip } from "@/components/ui/session-initiator-chip";
 import { SkeletonRows } from "@/components/ui/skeleton";
 
 const MAX_VISIBLE_SESSIONS = 12;
-
-function relTime(iso: string | null): string {
-  return iso ? relativeTime(iso) : "never";
-}
 
 function fmtRuntime(ms: number | undefined): string | null {
   if (!ms) return null;
@@ -139,7 +135,7 @@ function SessionTableCells({ session }: { session: SessionSummary }) {
         </span>
       </td>
       <td>
-        <span className="board-table-muted">{relTime(session.updatedAt)}</span>
+        <RelativeTime iso={session.updatedAt} fallback="never" className="board-table-muted" />
       </td>
       <td className="floor-trace-cell">
         <span className="board-table-muted">{session.isSubagent ? "Subagent" : "Session"}</span>
@@ -211,7 +207,7 @@ function EmptySessionRow({ card }: { card: FamiliarCard }) {
         <span className="board-table-muted">No recent sessions for this familiar.</span>
       </td>
       <td>
-        <span className="board-table-muted">{relTime(card.lastActiveAt)}</span>
+        <RelativeTime iso={card.lastActiveAt} fallback="never" className="board-table-muted" />
       </td>
       <td className="floor-trace-cell">
         <span className="board-table-muted">Empty</span>
@@ -395,7 +391,7 @@ export function CovenFloor() {
                           </span>
                         </td>
                         <td>
-                          <span className="board-table-muted">{relTime(card.lastActiveAt)}</span>
+                          <RelativeTime iso={card.lastActiveAt} fallback="never" className="board-table-muted" />
                         </td>
                         <td className="floor-trace-cell">
                           <span className="board-table-muted">{expandedId === card.id ? "Hide traces" : "Show traces"}</span>

--- a/src/components/familiar-status-card.tsx
+++ b/src/components/familiar-status-card.tsx
@@ -1,19 +1,12 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { relativeTime } from "@/lib/relative-time";
-import { useDateTimePrefs } from "@/lib/datetime-format";
+import { RelativeTime } from "@/components/ui/relative-time";
 import { FamiliarGlyph } from "@/components/familiar-glyph";
 import { parseGlyphString } from "@/lib/familiar-glyph";
 import { Icon } from "@/lib/icon";
 import type { FamiliarCard, SessionSummary } from "@/lib/coven-status-types";
 import { statusColor, statusLabel } from "@/lib/coven-status-types";
-
-// ── Relative time ─────────────────────────────────────────────────────────────
-
-function relTime(iso: string | null): string {
-  return iso ? relativeTime(iso) : "never";
-}
 
 // ── Format runtime ────────────────────────────────────────────────────────────
 
@@ -148,9 +141,11 @@ function SessionItem({ session, indent }: { session: SessionSummary; indent: boo
       <span className={`shrink-0 text-[10px] font-medium ${statusCls}`}>{session.status}</span>
 
       {/* timestamp */}
-      <span className="ml-auto shrink-0 text-[10px] text-[var(--text-muted)]">
-        {relTime(session.updatedAt)}
-      </span>
+      <RelativeTime
+        iso={session.updatedAt}
+        fallback="never"
+        className="ml-auto shrink-0 text-[10px] text-[var(--text-muted)]"
+      />
     </li>
   );
 }
@@ -164,7 +159,6 @@ type Props = {
 };
 
 export function FamiliarStatusCard({ card, expanded, onToggle }: Props) {
-  useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const statusClr = statusColor(card.status);
   const label = statusLabel(card.status);
 
@@ -285,9 +279,7 @@ export function FamiliarStatusCard({ card, expanded, onToggle }: Props) {
             <span className="text-[10px] text-[var(--text-secondary)]">{label}</span>
           </div>
           {card.lastActiveAt && (
-            <span className="text-[10px] text-[var(--text-muted)]">
-              {relTime(card.lastActiveAt)}
-            </span>
+            <RelativeTime iso={card.lastActiveAt} className="text-[10px] text-[var(--text-muted)]" />
           )}
         </div>
 

--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -6,6 +6,7 @@ import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/date
 // Shared relative-time formatter, imported as `age` so the call sites read the
 // same — standardizes this surface on the app-wide "2m ago / 3h ago / Jun 12" style.
 import { relativeTime as age } from "@/lib/relative-time";
+import { RelativeTime } from "@/components/ui/relative-time";
 import type { Familiar } from "@/lib/types";
 import type { CovenMemoryEntry } from "@/components/familiars-view-stats";
 import { MarkdownBlock } from "@/components/message-bubble";
@@ -626,7 +627,7 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
                           <span className="rounded bg-[var(--bg-elevated)] px-1.5 py-0.5 text-[var(--text-secondary)]">
                             {familiar?.display_name ?? entry.familiar_id}
                           </span>
-                          <span>{age(entry.updated_at)}</span>
+                          <RelativeTime iso={entry.updated_at} />
                         </div>
                         <h4 className="mt-2 line-clamp-2 text-[13px] font-medium text-[var(--text-primary)]">{entry.title}</h4>
                       </div>
@@ -951,7 +952,7 @@ export function MemoryFilesList({
                     </span>
                   ) : null}
                 </span>
-                <span className="shrink-0 text-[10px] text-[var(--text-muted)]">{age(entry.modified)}</span>
+                <RelativeTime iso={entry.modified} className="shrink-0 text-[10px] text-[var(--text-muted)]" />
               </button>
               <div className="flex items-center gap-1 pr-2">
                 <ExpandMemoryButton path={entry.fullPath} title={entry.relPath} variant="compact" />

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -7,6 +7,7 @@ import { Tabs } from "@/components/ui/tabs";
 // same — standardizes this surface on the app-wide "2m ago / 3h ago / Jun 12" style.
 import { relativeTime as age } from "@/lib/relative-time";
 import { useDateTimePrefs } from "@/lib/datetime-format";
+import { RelativeTime } from "@/components/ui/relative-time";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { FamiliarsMemoryView, MemoryFilesList } from "@/components/familiars-memory-view";
@@ -738,9 +739,7 @@ function FamiliarDetailPanel({
                           {s.harness} · {s.status}
                         </span>
                       </span>
-                      <span className="shrink-0 text-[10px] text-[var(--text-muted)]">
-                        {age(s.updated_at)}
-                      </span>
+                      <RelativeTime iso={s.updated_at} className="shrink-0 text-[10px] text-[var(--text-muted)]" />
                     </button>
                   </li>
                 ))}

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -16,6 +16,7 @@ import type { RoleEntry } from "@/app/api/roles/route";
 import type { LocalSkillEntry } from "@/app/api/skills/local/route";
 import type { AdapterReport } from "@/lib/harness-adapters";
 import { scopeMemoryFilesToFamiliar } from "@/lib/memory-file-scope";
+import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 
 type Tab = "memory" | "familiar" | "inbox" | "vault";
 
@@ -824,7 +825,7 @@ function MemoryTab({
                   <span className="truncate">{e.rootLabel}</span>
                 </span>
               </span>
-              <span className="shrink-0 font-mono text-[10px] text-[var(--text-muted)]">{age(e.modified)}</span>
+              <span className="shrink-0 font-mono text-[10px] text-[var(--text-muted)]" title={e.modified ? formatTimestamp(e.modified, readDateTimePrefs()) : undefined}>{age(e.modified)}</span>
             </button>
           </li>
         ))}

--- a/src/components/ui/relative-time.test.ts
+++ b/src/components/ui/relative-time.test.ts
@@ -10,5 +10,6 @@ assert.match(src, /title=\{exact\}/, "exposes the exact timestamp on hover");
 assert.match(src, /relativeTime\(iso, now, prefs\.density\)/, "uses shared relativeTime honoring density");
 assert.match(src, /formatDate\(iso, prefs/, "builds the exact title from the shared absolute formatter");
 assert.match(src, /useDateTimePrefs\(\)/, "subscribes to date/time prefs so changes apply live");
+assert.match(src, /fallback != null \? <span className=\{className\}>\{fallback\}<\/span> : null/, "renders the styled fallback (e.g. \"never\") when there is no timestamp");
 
 console.log("ui/relative-time.test.ts: ok");

--- a/src/components/ui/relative-time.tsx
+++ b/src/components/ui/relative-time.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { relativeTime } from "@/lib/relative-time";
 import { formatClock, formatDate, useDateTimePrefs } from "@/lib/datetime-format";
 
@@ -8,20 +9,25 @@ import { formatClock, formatDate, useDateTimePrefs } from "@/lib/datetime-format
  * exact, preference-aware absolute string in the title (hover) — e.g.
  * "Monday, June 16, 2026 at 1:31 PM". Subscribes to the date/time prefs so the
  * compact/verbose density (plus clock + date order) apply live.
+ *
+ * When `iso` is missing/invalid, renders `fallback` (carrying `className` so it
+ * stays styled like the timestamp it replaces) — e.g. `fallback="never"` for a
+ * familiar that has never run. Without a fallback it renders nothing.
  */
 export function RelativeTime({
   iso,
   now,
   className,
+  fallback = null,
 }: {
   iso: string | null | undefined;
   now?: number;
   className?: string;
+  fallback?: ReactNode;
 }) {
   const prefs = useDateTimePrefs();
-  if (!iso) return null;
-  const rel = relativeTime(iso, now, prefs.density);
-  if (!rel) return null;
+  const rel = iso ? relativeTime(iso, now, prefs.density) : "";
+  if (!iso || !rel) return fallback != null ? <span className={className}>{fallback}</span> : null;
   const exact = `${formatDate(iso, prefs, { year: true, weekday: true })} at ${formatClock(iso, prefs)}`;
   return (
     <time dateTime={iso} title={exact} className={className}>


### PR DESCRIPTION
Batch 2 — finishes spreading the exact-time hover tooltip to the surfaces that still rendered **bare** relative timestamps, handling each per its semantics (the "per-site care" the gaps needed).

**Component**: `<RelativeTime>` gains an optional `fallback?: ReactNode` — rendered (carrying `className`) when there's no timestamp, e.g. `fallback="never"` for a familiar that never ran.

**Adopted `<RelativeTime>`** (no text change, + tooltip, + dedupe):
- **coven-floor** (3 sites) + **familiar-status-card** (2 sites) — `fallback="never"`; drops their local `relTime` wrappers (and familiar-status-card's now-redundant `useDateTimePrefs()`).
- **familiars-view** (1) + **familiars-memory-view** (2) — at the standalone row stamps; their `age` is just `relativeTime` aliased, so text is unchanged. The prose/template `age()` uses keep their existing subscription.

**Inline `title=`** where the component can't fit without changing text:
- **inspector-pane** (local bare `"5m"` age + manual `"ago"`/`"in"` templates) and **automations-view** (bidirectional `relativeTimeSigned`) — get `title={formatTimestamp(iso, readDateTimePrefs())}` on the bare row stamps. Same exact-time hover, zero text/semantic change.

This closes out the relative-time tooltip work begun in #1607.

- typecheck clean · `ui/relative-time.test.ts` updated for the fallback · `pnpm test:app` 370 + `pnpm test:mobile` 18 pass
- Tooltip + `fallback="never"` verified live in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)