### PR TITLE
feat(ui): skeleton loading states on 5 more surfaces

### DIFF
--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -7,6 +7,7 @@ import type { Card, CardLifecycle, CardPriority, CardStatus } from "@/lib/cave-b
 import { STATUSES, PRIORITIES } from "@/lib/cave-board-types";
 import type { CaveProject } from "@/lib/cave-projects";
 import { LifecycleBadge, formatTimeoutBadge } from "@/components/ui/lifecycle-badge";
+import { SkeletonRows } from "@/components/ui/skeleton";
 import type { CardStep } from "@/lib/cave-board-types";
 import type { GitHubItem } from "@/lib/github-tasks";
 import {
@@ -320,7 +321,7 @@ function GitHubAttachSection({
 
           <div style={{ maxHeight: 240, overflowY: "auto" }}>
             {loading && (
-              <div style={{ padding: "12px 10px", fontSize: 11, color: "var(--text-muted)", textAlign: "center" }}>Loading…</div>
+              <div style={{ padding: "10px" }}><SkeletonRows count={4} /></div>
             )}
             {err && (
               <div style={{ padding: "10px", fontSize: 11, color: "var(--color-danger)" }}>{err}</div>

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -7,6 +7,7 @@ import { useDateTimePrefs } from "@/lib/datetime-format";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
+import { SkeletonRows } from "@/components/ui/skeleton";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import type { Familiar } from "@/lib/types";
 import type { Card, CardStatus } from "@/lib/cave-board-types";
@@ -1695,8 +1696,8 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
       <div className="github-surface-body min-h-0 flex-1 overflow-hidden">
 
         {loading ? (
-          <div className="flex h-full items-center justify-center">
-            <span className="text-[12px] text-[var(--text-muted)]">Loading…</span>
+          <div className="p-2">
+            <SkeletonRows count={8} />
           </div>
 
         ) : error === "no_user" ? (

--- a/src/components/journal/journal-entries.tsx
+++ b/src/components/journal/journal-entries.tsx
@@ -382,7 +382,7 @@ export function JournalEntries({
             )}
           </>
         ) : (
-          <div className="journal-empty journal-empty--pane">Loading…</div>
+          <div className="journal-empty journal-empty--pane"><SkeletonRows count={5} /></div>
         )}
       </section>
     </div>

--- a/src/components/library-doc-preview.tsx
+++ b/src/components/library-doc-preview.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { Icon } from "@/lib/icon";
+import { Skeleton, SkeletonGroup } from "@/components/ui/skeleton";
 import { copyText } from "@/lib/clipboard";
 import { sanitizeHtml } from "@/lib/html-sanitize";
 import { parseLeadingMetadata, type MetaEntry } from "@/lib/library-metadata";
@@ -1239,7 +1240,13 @@ export function LibraryDocPreview({ selected, loading, activeSection, docNav, on
   if (loading && !selected) {
     return (
       <div className="library-preview library-preview--empty">
-        <span className="library-preview-empty-text">Loading…</span>
+        <SkeletonGroup className="w-full max-w-prose">
+          <Skeleton variant="text" width="55%" />
+          <Skeleton variant="text" />
+          <Skeleton variant="text" />
+          <Skeleton variant="text" width="80%" />
+          <Skeleton variant="text" width="70%" />
+        </SkeletonGroup>
       </div>
     );
   }

--- a/src/components/project-tree.tsx
+++ b/src/components/project-tree.tsx
@@ -9,6 +9,7 @@ import {
   useImperativeHandle,
 } from "react";
 import { Icon } from "@/lib/icon";
+import { SkeletonRows } from "@/components/ui/skeleton";
 import { nextVisibleIndex, parentIndexByDepth } from "@/lib/tree-keynav";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -217,9 +218,8 @@ export const ProjectTree = forwardRef<ProjectTreeHandle, Props>(
 
     if (loading) {
       return (
-        <div className="flex items-center gap-1.5 py-3 pl-1 text-[11px] text-[var(--text-muted)]">
-          <Icon name="ph:arrow-clockwise" width={11} className="animate-spin shrink-0" />
-          Loading…
+        <div className="py-2 pl-1">
+          <SkeletonRows count={6} />
         </div>
       );
     }

--- a/src/components/surface-loading-states.test.ts
+++ b/src/components/surface-loading-states.test.ts
@@ -104,4 +104,19 @@ assert.doesNotMatch(
   "Retro runs no longer hand-rolls retro-skeleton placeholder divs",
 );
 
+// More surfaces converted from a bare "Loading…" string to the shared skeleton.
+for (const [file, label] of [
+  ["./github-view.tsx", "GitHub activity"],
+  ["./board-inspector.tsx", "Board inspector linked context"],
+  ["./project-tree.tsx", "Project tree"],
+  ["./journal/journal-entries.tsx", "Journal entries pane"],
+]) {
+  const src = read(file);
+  assert.doesNotMatch(src, />Loading…</, `${label} no longer shows a bare Loading… line`);
+  assert.match(src, /<SkeletonRows/, `${label} shows shared skeleton rows on first load`);
+}
+const docPreview = read("./library-doc-preview.tsx");
+assert.doesNotMatch(docPreview, /library-preview-empty-text">Loading…</, "Library doc preview no longer shows a bare Loading… line");
+assert.match(docPreview, /<SkeletonGroup[\s\S]{0,200}<Skeleton variant="text"/, "Library doc preview shows a document-shaped skeleton on first load");
+
 console.log("surface-loading-states.test.ts: ok");


### PR DESCRIPTION
First of the latest UX round. Extends the established first-fetch-skeleton convention (enforced by `surface-loading-states.test.ts`) to the surfaces that still flashed a bare **"Loading…"** string instead of a layout-stable shimmer:

- **github-view** (activity list) → `<SkeletonRows>`
- **board-inspector** (linked-context list) → `<SkeletonRows>`
- **project-tree** (file tree) → `<SkeletonRows>` (drops the spinner + text)
- **journal/journal-entries** (entry pane) → `<SkeletonRows>`
- **library-doc-preview** (reader pane) → document-shaped `<Skeleton>` text lines

The guard test is extended with `doesNotMatch(/>Loading…</)` + `match(/<Skeleton…/)` for each, so the convention sticks.

**Intentionally left as-is** (not content loads): `onboarding-overlay` (its "Loading..." is a *button label*) and `automations-view` run-log (it streams log *text* into a `<pre>`).

- typecheck clean · `pnpm test:app` 369 + `pnpm test:mobile` 18 pass
- Skeletons verified rendering live in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)