### PR TITLE
fix(copy): route GitHub copy buttons through context-safe copyText + add useCopy hook

### DIFF
--- a/src/components/debug-pane.tsx
+++ b/src/components/debug-pane.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { Icon } from "@/lib/icon";
-import { copyText } from "@/lib/clipboard";
+import { useCopy } from "@/lib/use-copy";
 import { formatClock } from "@/lib/datetime-format";
 import {
   stripPreviewOnlyAttachmentFields,
@@ -39,24 +39,14 @@ function statusColor(status: string | undefined): string {
 // ── Small building blocks ─────────────────────────────────────────────────────
 
 function CopyButton({ getText, label }: { getText: () => string; label?: string }) {
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopy();
   return (
     <button
       type="button"
       className="focus-ring inline-flex shrink-0 items-center gap-1 rounded px-1 py-0.5 text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]"
       title={label ?? "Copy"}
       aria-label={label ?? "Copy"}
-      onClick={() => {
-        copyText(getText())
-          .then(() => {
-            setCopied(true);
-            window.setTimeout(() => setCopied(false), 1500);
-          })
-          .catch(() => {
-            // Clipboard unavailable (insecure context / permission denied) —
-            // skip the "Copied" feedback rather than crash the pane.
-          });
-      }}
+      onClick={() => copy(getText())}
     >
       <Icon name={copied ? "ph:check" : "ph:copy"} width={11} aria-hidden />
       {label ? <span>{copied ? "Copied" : label}</span> : null}

--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -278,4 +278,14 @@ assert.match(
   "safe merge action should be wired into the selected-item panel actions",
 );
 
+// Copy buttons must use the context-safe copyText (via useCopy), not raw
+// navigator.clipboard — the latter silently no-ops in the Tauri webview and
+// over non-secure Tailscale Serve.
+assert.doesNotMatch(
+  source,
+  /navigator\.clipboard/,
+  "GitHub copy buttons go through the context-safe copyText (useCopy), not raw navigator.clipboard",
+);
+assert.match(source, /useCopy/, "GitHub view copies via the shared useCopy hook");
+
 console.log("github-view-polish.test.ts OK");

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -8,6 +8,7 @@ import { RelativeTime } from "@/components/ui/relative-time";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
 import { SkeletonRows } from "@/components/ui/skeleton";
+import { useCopy } from "@/lib/use-copy";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import type { Familiar } from "@/lib/types";
 import type { Card, CardStatus } from "@/lib/cave-board-types";
@@ -703,7 +704,7 @@ function useGitHubItemDetail(item: GitHubItem | null): DetailState {
 
 /** A tiny copy-to-clipboard affordance for the issue number. */
 function CopyButton({ value, label }: { value: string; label: string }) {
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopy(1200);
   return (
     <button
       type="button"
@@ -712,13 +713,7 @@ function CopyButton({ value, label }: { value: string; label: string }) {
       aria-label={label}
       onClick={(e) => {
         e.stopPropagation();
-        navigator.clipboard?.writeText(value).then(
-          () => {
-            setCopied(true);
-            window.setTimeout(() => setCopied(false), 1200);
-          },
-          () => {},
-        );
+        copy(value);
       }}
     >
       <Icon name={copied ? "ph:check" : "ph:copy"} width={11} />

--- a/src/components/library-doc-preview.tsx
+++ b/src/components/library-doc-preview.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import { Icon } from "@/lib/icon";
 import { Skeleton, SkeletonGroup } from "@/components/ui/skeleton";
 import { copyText } from "@/lib/clipboard";
+import { useCopy } from "@/lib/use-copy";
 import { sanitizeHtml } from "@/lib/html-sanitize";
 import { parseLeadingMetadata, type MetaEntry } from "@/lib/library-metadata";
 import { isSafeGitHubUrl, isSafeHttpUrl, isSafeVscodeFileUrl } from "@/lib/url-safety";
@@ -95,16 +96,12 @@ async function openUrl(url: string, kind: UrlOpenKind = "web") {
 }
 
 function CopyButton({ text, label, compact }: { text: string; label: string; compact?: boolean }) {
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopy(2000);
   return (
     <button
       type="button"
       className={`library-preview-action-btn${compact ? " library-preview-action-btn--compact" : ""}`}
-      onClick={() => {
-        copyText(text)
-          .then(() => { setCopied(true); setTimeout(() => setCopied(false), 2000); })
-          .catch(() => undefined);
-      }}
+      onClick={() => copy(text)}
     >
       <Icon name={copied ? "ph:check" : "ph:copy"} width={compact ? 12 : 13} />
       <span>{copied ? "Copied!" : label}</span>

--- a/src/lib/use-copy.ts
+++ b/src/lib/use-copy.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+import { copyText } from "@/lib/clipboard";
+
+/**
+ * Copy-to-clipboard with transient "copied" feedback — the shared shape behind
+ * the various copy buttons (debug pane, library preview, GitHub rows, …) that
+ * each used to re-implement the same `useState` + `setTimeout` dance.
+ *
+ * Uses the context-safe {@link copyText} (not `navigator.clipboard` directly),
+ * so copies still land — and the "Copied" confirmation only shows on real
+ * success — inside the Tauri webview and over non-secure Tailscale Serve.
+ *
+ * `copied` flips true on a successful copy and resets after `resetMs`.
+ */
+export function useCopy(resetMs = 1500): { copied: boolean; copy: (text: string) => void } {
+  const [copied, setCopied] = useState(false);
+  const copy = (text: string) => {
+    void copyText(text).then((ok) => {
+      if (!ok) return;
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), resetMs);
+    });
+  };
+  return { copied, copy };
+}


### PR DESCRIPTION
**Reframed during research:** copy-to-clipboard is already broadly covered — a shared context-safe `copyText` helper, plus copy-message, copy-code-block, copy-path (comux breadcrumb), copy-session-id/JSON (debug pane), copy-link, vault/capabilities/settings/workflow. There's **no meaningful coverage gap**.

The one genuine issue found is a **correctness bug**: `github-view`'s `CopyButton` used raw `navigator.clipboard?.writeText`, which throws/no-ops in the Tauri webview and over non-secure Tailscale Serve — so the GitHub copy buttons **silently failed off-localhost** (precisely the case `src/lib/clipboard.ts`'s `copyText` was written to handle).

- **New `src/lib/use-copy.ts`** — `useCopy(resetMs)` → `{ copied, copy }`, encapsulating the `copyText` + transient-"copied" dance that **three** local `CopyButton` definitions (debug-pane, library-doc-preview, github-view) each hand-rolled.
- Adopt `useCopy` in all three. **github-view now copies via `copyText` (bug fixed)**; debug-pane drops its now-unused `copyText` import.
- Guard: `github-view-polish.test.ts` asserts no raw `navigator.clipboard` + `useCopy` present.

No visual change (behind-the-scenes correctness + DRY). typecheck clean · `pnpm test:app` 369 · `pnpm test:mobile` 18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)