### PR TITLE
feat(ui): hover tooltips on truncated names/titles so full text is recoverable

### DIFF
--- a/src/components/chat-project-sidebar.tsx
+++ b/src/components/chat-project-sidebar.tsx
@@ -184,7 +184,7 @@ function ThreadRow({
             <Icon name="ph:dots-six-vertical" width={11} aria-hidden />
           </button>
         </span>
-        <span className="min-w-0 flex-1 truncate">{title}</span>
+        <span className="min-w-0 flex-1 truncate" title={title}>{title}</span>
         <span className="chat-thread-age shrink-0 font-mono text-[10px] text-[var(--text-muted)] group-hover/row:hidden">
           {shortAge(session.updated_at)}
         </span>
@@ -284,7 +284,7 @@ function FolderChatRow({
             <Icon name="ph:dots-six-vertical" width={10} aria-hidden />
           </button>
         </span>
-        <span className="min-w-0 flex-1 truncate">{title}</span>
+        <span className="min-w-0 flex-1 truncate" title={title}>{title}</span>
       </div>
     </li>
   );

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -234,7 +234,7 @@ export function NotificationBell({
                   const muted = prefs.mutedFamiliars.includes(f.id);
                   return (
                     <li key={f.id} className="flex items-center justify-between">
-                      <span className="truncate text-[var(--text-secondary)]">{f.display_name}</span>
+                      <span className="truncate text-[var(--text-secondary)]" title={f.display_name}>{f.display_name}</span>
                       <button
                         onClick={() => toggleMute(f.id)}
                         className={`focus-ring rounded border px-1.5 py-0.5 text-[10px] transition-colors ${
@@ -281,7 +281,7 @@ export function NotificationBell({
                       height="0.95rem"
                     />
                     <div className="min-w-0 flex-1">
-                      <div className="truncate text-[12px] font-medium text-[var(--text-primary)]">{it.title}</div>
+                      <div className="truncate text-[12px] font-medium text-[var(--text-primary)]" title={it.title}>{it.title}</div>
                       {it.body ? (
                         <div className="mt-0.5 line-clamp-2 text-[11px] leading-snug text-[var(--text-muted)]">
                           {it.body}

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -152,7 +152,7 @@ function ProjectChatRow({
           </button>
         )}
         <span aria-hidden className={`h-1.5 w-1.5 shrink-0 rounded-full ${chatDotClass(session.status)}`} />
-        <span className="min-w-0 flex-1 truncate">{title}</span>
+        <span className="min-w-0 flex-1 truncate" title={title}>{title}</span>
         {selectMode ? null : confirmDelete ? (
           <span className="flex shrink-0 items-center gap-1">
             <button

--- a/src/components/skill-card.tsx
+++ b/src/components/skill-card.tsx
@@ -108,10 +108,10 @@ export function SkillCard({
 
       {/* Name + meta + description */}
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-[13px] font-medium text-[var(--text-primary)]">
+        <span className="block truncate text-[13px] font-medium text-[var(--text-primary)]" title={skill.name}>
           {skill.name}
         </span>
-        <span className="block truncate text-[12px] text-[var(--text-muted)]">
+        <span className="block truncate text-[12px] text-[var(--text-muted)]" title={meta}>
           {meta}
         </span>
         {skill.description && (


### PR DESCRIPTION
Truncated labels showed an ellipsis with no way to read the full text on hover. Add `title={fullText}` so the complete value is recoverable:

- **chat-project-sidebar** — thread-rail session titles (the 230px rail truncates aggressively), both pinned and project-grouped rows
- **projects-view** — session row titles
- **notification-bell** — familiar display names + inbox item titles
- **skill-card** — skill name + meta line

Purely additive (a native `title` attribute — no layout or markup change). Spots that already had a `title` (project name/path buttons, comux breadcrumb) were left alone.

typecheck clean · `pnpm test:app` 369 · `pnpm test:mobile` 18. DOM check (titles present) in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)