### PR TITLE
refactor: extract OpenClaw bridge helpers

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -408,6 +408,7 @@ export const SUITES = {
     "src/lib/coven-daemon.test.ts",
     "src/lib/coven-bin.test.ts",
     "src/lib/openclaw-bin.test.ts",
+    "src/lib/openclaw-bridge.test.ts",
     "src/lib/coven-identity-canon.test.ts",
     "src/lib/familiar-runtime.test.ts",
     "src/lib/harness-adapters.test.ts",

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -19,6 +19,10 @@ const chatRoute = await readFile(
   new URL("./route.ts", import.meta.url),
   "utf8",
 );
+const openclawBridge = await readFile(
+  new URL("../../../../lib/openclaw-bridge.ts", import.meta.url),
+  "utf8",
+);
 const boardRoute = await readFile(
   new URL("../../board/enrich-steps/route.ts", import.meta.url),
   "utf8",
@@ -85,13 +89,13 @@ assert.match(
 );
 
 assert.match(
-  chatRoute,
+  openclawBridge,
   /"agent"[\s\S]*"--agent"[\s\S]*agentId[\s\S]*"--message"[\s\S]*harnessPrompt[\s\S]*"--json"/,
   "OpenClaw native chat should call openclaw agent with the resolved agent id and JSON output",
 );
 
 assert.match(
-  chatRoute,
+  openclawBridge,
   /spawn\(openClawBin\(\), openClawSpawnArgs\(\["agents", "list", "--json"\]\)[\s\S]*env: openClawSpawnEnv\(\),[\s\S]*shell: openClawNeedsShell\(\)/,
   "OpenClaw agent listing should launch Windows npm .cmd shims correctly",
 );
@@ -108,7 +112,7 @@ assert.match(
 //    OpenClaw's durable identity; session ids rotate on reset/compaction;
 // 2. the gateway's session id is never adopted as the conversation key.
 assert.match(
-  chatRoute,
+  openclawBridge,
   /"--session-key",\s*\n?\s*openClawSessionKey\(conversationId\)/,
   "OpenClaw native chat must pin a per-conversation session key",
 );

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { stripAnsi } from "@/lib/ansi";
@@ -38,10 +38,17 @@ import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 import { loadProjects, projectForRoot } from "@/lib/cave-projects";
 import { openClawBin, openClawNeedsShell, openClawSpawnArgs, openClawSpawnEnv } from "@/lib/openclaw-bin";
 import {
-  covenHome,
   familiarWorkspacesRoot,
   readFamiliarWorkspaces,
 } from "@/lib/coven-paths";
+import {
+  extractOpenClawSessionId,
+  extractOpenClawText,
+  openClawAgentArgs,
+  openClawSessionKey,
+  resolveOpenClawAgentId,
+  type OpenClawAgentJson,
+} from "@/lib/openclaw-bridge";
 import { isTrustedChatHarness, covenRunSupportsModelFlag } from "@/lib/harness-adapters";
 import {
   type ConversationFile,
@@ -505,164 +512,6 @@ function buildPromptWithResponseControls(prompt: string, body: SendBody): string
     "",
     prompt,
   ].join("\n");
-}
-
-type OpenClawAgentJson = {
-  status?: string;
-  summary?: string;
-  sessionId?: string;
-  result?: {
-    payloads?: Array<{ text?: string; content?: unknown }>;
-    sessionId?: string;
-    meta?: { agentMeta?: { sessionId?: string } };
-  };
-  meta?: { agentMeta?: { sessionId?: string } };
-};
-
-type OpenClawAgentSummary = {
-  id?: string;
-  name?: string;
-  identityName?: string;
-  isDefault?: boolean;
-};
-
-function readTomlString(block: string, key: string): string | null {
-  const quoted = block.match(new RegExp(`^\\s*${key}\\s*=\\s*(['"])(.*?)\\1\\s*(?:#.*)?$`, "m"));
-  if (quoted) return quoted[2];
-  const bare = block.match(new RegExp(`^\\s*${key}\\s*=\\s*([^\\s#]+)\\s*(?:#.*)?$`, "m"));
-  return bare?.[1] ?? null;
-}
-
-function slugifyAgentName(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
-
-async function readOpenClawAgentBinding(familiarId: string): Promise<string | null> {
-  try {
-    const raw = await readFile(path.join(covenHome(), "familiars.toml"), "utf8");
-    const blocks = raw.split(/^\s*\[\[familiar\]\]\s*$/m).slice(1);
-    for (const block of blocks) {
-      if (readTomlString(block, "id") !== familiarId) continue;
-      return readTomlString(block, "openclaw_agent");
-    }
-  } catch {
-    /* no familiar binding file */
-  }
-  return null;
-}
-
-function listOpenClawAgents(): Promise<OpenClawAgentSummary[]> {
-  return new Promise((resolve) => {
-    const child = spawn(openClawBin(), openClawSpawnArgs(["agents", "list", "--json"]), {
-      stdio: ["ignore", "pipe", "ignore"],
-      env: openClawSpawnEnv(),
-      shell: openClawNeedsShell(),
-    });
-    let stdout = "";
-    child.stdout.on("data", (data: Buffer) => {
-      stdout += data.toString("utf8");
-    });
-    child.on("error", () => resolve([]));
-    child.on("close", () => {
-      try {
-        const parsed = JSON.parse(stdout.trim()) as OpenClawAgentSummary[];
-        resolve(Array.isArray(parsed) ? parsed : []);
-      } catch {
-        resolve([]);
-      }
-    });
-  });
-}
-
-async function resolveOpenClawAgentId(familiarId: string): Promise<string> {
-  const explicit = await readOpenClawAgentBinding(familiarId);
-  if (explicit) return explicit;
-
-  const agents = await listOpenClawAgents();
-  const exact = agents.find((agent) => agent.id === familiarId)?.id;
-  if (exact) return exact;
-
-  const named = agents.find(
-    (agent) =>
-      (agent.name && slugifyAgentName(agent.name) === familiarId) ||
-      (agent.identityName && slugifyAgentName(agent.identityName) === familiarId),
-  )?.id;
-  if (named) return named;
-
-  return familiarId;
-}
-
-function extractOpenClawText(json: OpenClawAgentJson): string {
-  const payloads = json.result?.payloads ?? [];
-  const text = payloads
-    .map((payload) => {
-      if (typeof payload.text === "string") return payload.text;
-      if (Array.isArray(payload.content)) {
-        return payload.content
-          .map((part) =>
-            part &&
-            typeof part === "object" &&
-            "text" in part &&
-            typeof part.text === "string"
-              ? part.text
-              : "",
-          )
-          .join("");
-      }
-      return "";
-    })
-    .filter(Boolean)
-    .join("\n\n")
-    .trim();
-  return text || json.summary?.trim() || "";
-}
-
-function extractOpenClawSessionId(
-  json: OpenClawAgentJson,
-  fallback?: string,
-): string | null {
-  return (
-    json.sessionId ??
-    json.result?.sessionId ??
-    json.result?.meta?.agentMeta?.sessionId ??
-    json.meta?.agentMeta?.sessionId ??
-    fallback ??
-    null
-  );
-}
-
-/**
- * Conversation identity for the OpenClaw bridge is CAVE-owned. OpenClaw
- * sessions are persisted per session *key* (`agent:<id>:<key>`); the
- * `sessionId` inside an entry rotates on daily resets, `/new`, and
- * compaction. Pinning each Cave chat to its own `--session-key` keeps one
- * durable gateway session per conversation. Without a key, every turn lands
- * in the shared `agent:<id>:main` session — id rotation then forked each
- * Cave chat into a brand-new conversation, and concurrent chats with the
- * same familiar interleaved context.
- */
-function openClawSessionKey(conversationId: string): string {
-  return `cave-${conversationId.toLowerCase().replace(/[^a-z0-9-]/g, "-")}`;
-}
-
-function openClawAgentArgs(
-  harnessPrompt: string,
-  agentId: string,
-  conversationId: string,
-): string[] {
-  return [
-    "agent",
-    "--agent",
-    agentId,
-    "--message",
-    harnessPrompt,
-    "--json",
-    "--session-key",
-    openClawSessionKey(conversationId),
-  ];
 }
 
 function openClawChatResponse(args: {

--- a/src/lib/openclaw-bridge.test.ts
+++ b/src/lib/openclaw-bridge.test.ts
@@ -1,11 +1,15 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import {
   extractOpenClawSessionId,
   extractOpenClawText,
   openClawAgentArgs,
   openClawSessionKey,
   readTomlString,
+  resolveOpenClawAgentId,
   resolveOpenClawAgentIdFromSources,
   slugifyOpenClawAgentName,
 } from "./openclaw-bridge.ts";
@@ -50,6 +54,31 @@ assert.equal(
   "unknown",
   "unknown familiars intentionally fall back to the familiar id",
 );
+
+const previousCovenHome = process.env.COVEN_HOME;
+const tempCovenHome = await mkdtemp(path.join(tmpdir(), "openclaw-bridge-"));
+try {
+  await mkdir(tempCovenHome, { recursive: true });
+  await writeFile(
+    path.join(tempCovenHome, "familiars.toml"),
+    [
+      "[[familiar]]",
+      'id = "nova"',
+      'openclaw_agent = "nova-explicit"',
+    ].join("\n"),
+    "utf8",
+  );
+  process.env.COVEN_HOME = tempCovenHome;
+  assert.equal(
+    await resolveOpenClawAgentId("nova"),
+    "nova-explicit",
+    "explicit openclaw_agent binding should return before listing OpenClaw agents",
+  );
+} finally {
+  if (previousCovenHome === undefined) delete process.env.COVEN_HOME;
+  else process.env.COVEN_HOME = previousCovenHome;
+  await rm(tempCovenHome, { recursive: true, force: true });
+}
 
 assert.equal(openClawSessionKey("ABC_123:Weird"), "cave-abc-123-weird");
 assert.deepEqual(openClawAgentArgs("hi", "nova", "ABC_123"), [

--- a/src/lib/openclaw-bridge.test.ts
+++ b/src/lib/openclaw-bridge.test.ts
@@ -1,0 +1,96 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  extractOpenClawSessionId,
+  extractOpenClawText,
+  openClawAgentArgs,
+  openClawSessionKey,
+  readTomlString,
+  resolveOpenClawAgentIdFromSources,
+  slugifyOpenClawAgentName,
+} from "./openclaw-bridge.ts";
+
+assert.equal(readTomlString('id = "nova"', "id"), "nova");
+assert.equal(readTomlString("openclaw_agent = cody-main # comment", "openclaw_agent"), "cody-main");
+assert.equal(readTomlString("role = ''", "role"), "");
+assert.equal(readTomlString("id = \"nova\"", "openclaw_agent"), null);
+
+assert.equal(slugifyOpenClawAgentName("Cody Main"), "cody-main");
+assert.equal(slugifyOpenClawAgentName("  Nova / Release Review  "), "nova-release-review");
+
+const candidateAgents = [
+  { id: "fallback-match", name: "Nova", identityName: "Nova Identity" },
+  { id: "nova", name: "Wrong Exact Name" },
+  { id: "cody-main", name: "Cody Main" },
+  { id: "identity-hit", identityName: "Release Review" },
+];
+
+assert.equal(
+  resolveOpenClawAgentIdFromSources("nova", "explicit-nova", candidateAgents),
+  "explicit-nova",
+  "explicit openclaw_agent binding should win over every discovered agent",
+);
+assert.equal(
+  resolveOpenClawAgentIdFromSources("nova", null, candidateAgents),
+  "nova",
+  "exact agent id should win over slugified display or identity name",
+);
+assert.equal(
+  resolveOpenClawAgentIdFromSources("cody-main", null, candidateAgents),
+  "cody-main",
+  "slugified agent display name should resolve when no exact id exists",
+);
+assert.equal(
+  resolveOpenClawAgentIdFromSources("release-review", null, candidateAgents),
+  "identity-hit",
+  "slugified identity name should resolve when no exact id or display name exists",
+);
+assert.equal(
+  resolveOpenClawAgentIdFromSources("unknown", null, candidateAgents),
+  "unknown",
+  "unknown familiars intentionally fall back to the familiar id",
+);
+
+assert.equal(openClawSessionKey("ABC_123:Weird"), "cave-abc-123-weird");
+assert.deepEqual(openClawAgentArgs("hi", "nova", "ABC_123"), [
+  "agent",
+  "--agent",
+  "nova",
+  "--message",
+  "hi",
+  "--json",
+  "--session-key",
+  "cave-abc-123",
+]);
+assert.equal(
+  openClawAgentArgs("hi", "nova", "ABC_123").includes("--session-id"),
+  false,
+  "OpenClaw bridge must never use raw session ids for resume",
+);
+
+assert.equal(
+  extractOpenClawText({
+    result: {
+      payloads: [
+        { text: "first" },
+        { content: [{ type: "text", text: "second" }] },
+      ],
+    },
+  }),
+  "first\n\nsecond",
+);
+assert.equal(extractOpenClawText({ summary: "fallback summary" }), "fallback summary");
+
+assert.equal(extractOpenClawSessionId({ sessionId: "top" }), "top");
+assert.equal(extractOpenClawSessionId({ result: { sessionId: "result" } }), "result");
+assert.equal(
+  extractOpenClawSessionId({ result: { meta: { agentMeta: { sessionId: "result-meta" } } } }),
+  "result-meta",
+);
+assert.equal(
+  extractOpenClawSessionId({ meta: { agentMeta: { sessionId: "meta" } } }),
+  "meta",
+);
+assert.equal(extractOpenClawSessionId({}, "fallback"), "fallback");
+
+console.log("openclaw-bridge.test.ts: ok");

--- a/src/lib/openclaw-bridge.ts
+++ b/src/lib/openclaw-bridge.ts
@@ -1,0 +1,176 @@
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { covenHome } from "./coven-paths.ts";
+
+export type OpenClawAgentJson = {
+  status?: string;
+  summary?: string;
+  sessionId?: string;
+  result?: {
+    payloads?: Array<{ text?: string; content?: unknown }>;
+    sessionId?: string;
+    meta?: { agentMeta?: { sessionId?: string } };
+  };
+  meta?: { agentMeta?: { sessionId?: string } };
+};
+
+export type OpenClawAgentSummary = {
+  id?: string;
+  name?: string;
+  identityName?: string;
+  isDefault?: boolean;
+};
+
+export function readTomlString(block: string, key: string): string | null {
+  const quoted = block.match(new RegExp(`^\\s*${key}\\s*=\\s*(['"])(.*?)\\1\\s*(?:#.*)?$`, "m"));
+  if (quoted) return quoted[2];
+  const bare = block.match(new RegExp(`^\\s*${key}\\s*=\\s*([^\\s#]+)\\s*(?:#.*)?$`, "m"));
+  return bare?.[1] ?? null;
+}
+
+export function slugifyOpenClawAgentName(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export async function readOpenClawAgentBinding(familiarId: string): Promise<string | null> {
+  try {
+    const raw = await readFile(path.join(covenHome(), "familiars.toml"), "utf8");
+    const blocks = raw.split(/^\s*\[\[familiar\]\]\s*$/m).slice(1);
+    for (const block of blocks) {
+      if (readTomlString(block, "id") !== familiarId) continue;
+      return readTomlString(block, "openclaw_agent");
+    }
+  } catch {
+    /* no familiar binding file */
+  }
+  return null;
+}
+
+export async function listOpenClawAgents(): Promise<OpenClawAgentSummary[]> {
+  const {
+    openClawBin,
+    openClawNeedsShell,
+    openClawSpawnArgs,
+    openClawSpawnEnv,
+  } = await import("./openclaw-bin.ts");
+  return new Promise((resolve) => {
+    const child = spawn(openClawBin(), openClawSpawnArgs(["agents", "list", "--json"]), {
+      stdio: ["ignore", "pipe", "ignore"],
+      env: openClawSpawnEnv(),
+      shell: openClawNeedsShell(),
+    });
+    let stdout = "";
+    child.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString("utf8");
+    });
+    child.on("error", () => resolve([]));
+    child.on("close", () => {
+      try {
+        const parsed = JSON.parse(stdout.trim()) as OpenClawAgentSummary[];
+        resolve(Array.isArray(parsed) ? parsed : []);
+      } catch {
+        resolve([]);
+      }
+    });
+  });
+}
+
+export function resolveOpenClawAgentIdFromSources(
+  familiarId: string,
+  explicit: string | null,
+  agents: OpenClawAgentSummary[],
+): string {
+  if (explicit) return explicit;
+
+  const exact = agents.find((agent) => agent.id === familiarId)?.id;
+  if (exact) return exact;
+
+  const named = agents.find(
+    (agent) =>
+      (agent.name && slugifyOpenClawAgentName(agent.name) === familiarId) ||
+      (agent.identityName && slugifyOpenClawAgentName(agent.identityName) === familiarId),
+  )?.id;
+  if (named) return named;
+
+  return familiarId;
+}
+
+export async function resolveOpenClawAgentId(familiarId: string): Promise<string> {
+  const explicit = await readOpenClawAgentBinding(familiarId);
+  const agents = await listOpenClawAgents();
+  return resolveOpenClawAgentIdFromSources(familiarId, explicit, agents);
+}
+
+export function extractOpenClawText(json: OpenClawAgentJson): string {
+  const payloads = json.result?.payloads ?? [];
+  const text = payloads
+    .map((payload) => {
+      if (typeof payload.text === "string") return payload.text;
+      if (Array.isArray(payload.content)) {
+        return payload.content
+          .map((part) =>
+            part &&
+            typeof part === "object" &&
+            "text" in part &&
+            typeof part.text === "string"
+              ? part.text
+              : "",
+          )
+          .join("");
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n\n")
+    .trim();
+  return text || json.summary?.trim() || "";
+}
+
+export function extractOpenClawSessionId(
+  json: OpenClawAgentJson,
+  fallback?: string,
+): string | null {
+  return (
+    json.sessionId ??
+    json.result?.sessionId ??
+    json.result?.meta?.agentMeta?.sessionId ??
+    json.meta?.agentMeta?.sessionId ??
+    fallback ??
+    null
+  );
+}
+
+/**
+ * Conversation identity for the OpenClaw bridge is CAVE-owned. OpenClaw
+ * sessions are persisted per session *key* (`agent:<id>:<key>`); the
+ * `sessionId` inside an entry rotates on daily resets, `/new`, and
+ * compaction. Pinning each Cave chat to its own `--session-key` keeps one
+ * durable gateway session per conversation. Without a key, every turn lands
+ * in the shared `agent:<id>:main` session — id rotation then forked each
+ * Cave chat into a brand-new conversation, and concurrent chats with the
+ * same familiar interleaved context.
+ */
+export function openClawSessionKey(conversationId: string): string {
+  return `cave-${conversationId.toLowerCase().replace(/[^a-z0-9-]/g, "-")}`;
+}
+
+export function openClawAgentArgs(
+  harnessPrompt: string,
+  agentId: string,
+  conversationId: string,
+): string[] {
+  return [
+    "agent",
+    "--agent",
+    agentId,
+    "--message",
+    harnessPrompt,
+    "--json",
+    "--session-key",
+    openClawSessionKey(conversationId),
+  ];
+}

--- a/src/lib/openclaw-bridge.ts
+++ b/src/lib/openclaw-bridge.ts
@@ -101,8 +101,10 @@ export function resolveOpenClawAgentIdFromSources(
 
 export async function resolveOpenClawAgentId(familiarId: string): Promise<string> {
   const explicit = await readOpenClawAgentBinding(familiarId);
+  if (explicit) return explicit;
+
   const agents = await listOpenClawAgents();
-  return resolveOpenClawAgentIdFromSources(familiarId, explicit, agents);
+  return resolveOpenClawAgentIdFromSources(familiarId, null, agents);
 }
 
 export function extractOpenClawText(json: OpenClawAgentJson): string {


### PR DESCRIPTION
## Summary

- Extract OpenClaw-specific chat helpers into `src/lib/openclaw-bridge.ts`
- Keep `/api/chat/send` orchestration behavior unchanged while delegating agent resolution, session-key, argv, and JSON parsing helpers
- Add resolver precedence and bridge contract regression coverage, wired into the API suite

## Context

Part of #1613. This is the conservative first PR slice: behavior-preserving bridge extraction before capability reporting or deeper runtime/provider changes.

## Verification

- `pnpm typecheck`
- `pnpm check:tests-wired`
- `node scripts/run-tests.mjs api`