### PR TITLE
fix(capabilities): backfill harnesses the daemon aggregate omits

### DIFF
--- a/src/app/api/capabilities/route.test.ts
+++ b/src/app/api/capabilities/route.test.ts
@@ -22,6 +22,18 @@ assert.match(
 
 assert.match(
   source,
+  /ensureAdapterCoverage\(reported, refresh\)/,
+  "Daemon aggregate manifests are backfilled so every supported harness stays covered",
+);
+
+assert.match(
+  source,
+  /const missing = COMPATIBILITY_ADAPTERS\.map\(\(adapter\) => adapter\.id\)\.filter\(\(id\) => !present\.has\(id\)\)/,
+  "Coverage backfill only fetches harnesses the daemon aggregate omitted",
+);
+
+assert.match(
+  source,
   /supplementClaudeSkills/,
   "Claude manifests are supplemented with the local ~/.claude/skills scan",
 );

--- a/src/app/api/capabilities/route.ts
+++ b/src/app/api/capabilities/route.ts
@@ -112,6 +112,28 @@ async function fetchHarnessManifest(harness: string, refresh: string): Promise<H
   return supplementClaudeSkills(res.data);
 }
 
+/**
+ * The daemon's aggregate /api/v1/capabilities can return a harness_capabilities
+ * list that omits a harness Cave knows about (e.g. the aggregate scanner skipped
+ * it, but its per-harness endpoint still serves a manifest). Trusting the
+ * aggregate verbatim under-reports coverage, so the panel silently drops that
+ * harness. Backfill any COMPATIBILITY_ADAPTERS harness missing from the
+ * aggregate by fetching its per-harness manifest; aggregate-reported manifests
+ * always win on id collisions.
+ */
+async function ensureAdapterCoverage(
+  manifests: HarnessCapabilityManifest[],
+  refresh: string,
+): Promise<HarnessCapabilityManifest[]> {
+  const present = new Set(manifests.map((m) => m.harness_id));
+  const missing = COMPATIBILITY_ADAPTERS.map((adapter) => adapter.id).filter((id) => !present.has(id));
+  if (missing.length === 0) return manifests;
+  const backfilled = (await Promise.all(missing.map((id) => fetchHarnessManifest(id, refresh)))).filter(
+    (m): m is HarnessCapabilityManifest => m !== null,
+  );
+  return [...manifests, ...backfilled];
+}
+
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const refresh = url.searchParams.get("refresh") === "1" ? "?refresh=1" : "";
@@ -148,7 +170,8 @@ export async function GET(req: Request) {
   // per-harness endpoints (which still serve manifests).
   const aggregate = await callDaemon<CapabilitiesResponse>({ path: `/api/v1/capabilities${refresh}` });
   if (aggregate.ok && Array.isArray(aggregate.data?.harness_capabilities)) {
-    const manifests = await Promise.all(aggregate.data.harness_capabilities.map(supplementClaudeSkills));
+    const reported = await Promise.all(aggregate.data.harness_capabilities.map(supplementClaudeSkills));
+    const manifests = await ensureAdapterCoverage(reported, refresh);
     return NextResponse.json({
       ok: true,
       coven_skills: aggregate.data.coven_skills ?? [],


### PR DESCRIPTION
## What

The Capabilities panel consumes the daemon's `GET /api/v1/capabilities`. When the daemon returns an aggregate `harness_capabilities` list, Cave trusted it verbatim — but that list can omit a harness Cave supports (the aggregate scanner skipped it) even though the harness's **per-harness** endpoint (`/api/v1/capabilities/:harness_id`) still serves a manifest. Result: the panel silently under-reported coverage and dropped that harness.

## Fix

New `ensureAdapterCoverage()` helper: after building the aggregate manifests, any `COMPATIBILITY_ADAPTERS` harness missing from the aggregate is backfilled by fetching its per-harness manifest. Aggregate-reported manifests still win on id collisions, so nothing the daemon reported is overwritten.

- Read-only — no daemon writes (daemon is read-only by design).
- The fallback path already fanned out to every adapter, so this only closes the gap on the aggregate-success path.

## Test

Extended `capabilities/route.test.ts` (source-text assertions) to pin the backfill call and the missing-harness filter. `node src/app/api/capabilities/route.test.ts` → `ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)