### PR TITLE
fix(stores): atomic JSON writes for the inbox/config/runs/prefs file stores

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -347,6 +347,7 @@ export const SUITES = {
     "src/lib/workflow-source-bundle.test.ts",
     "src/lib/vault-bundle.test.ts",
     "src/lib/cave-board-atomic.test.ts",
+    "src/lib/server/atomic-write.test.ts",
     "src/lib/env-local-bundle.test.ts",
     "src/lib/cave-board-schedule.test.ts",
     "src/components/ui/tabs.test.ts",

--- a/src/lib/automation-runs.ts
+++ b/src/lib/automation-runs.ts
@@ -1,6 +1,7 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
+import { writeJsonAtomic } from "./server/atomic-write.ts";
 import path from "node:path";
 
 /**
@@ -52,7 +53,7 @@ function withRunsLock<T>(fn: () => Promise<T>): Promise<T> {
 
 async function persist(file: RunsFile): Promise<void> {
   await mkdir(path.dirname(runsPath()), { recursive: true });
-  await writeFile(runsPath(), JSON.stringify(file, null, 2), "utf8");
+  await writeJsonAtomic(runsPath(), file);
 }
 
 export async function recordRun(input: Omit<AutomationRunRecord, "id">): Promise<AutomationRunRecord> {

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -1,6 +1,7 @@
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { readFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { homedir } from "node:os";
+import { writeJsonAtomic } from "./server/atomic-write.ts";
 import {
   type FamiliarRuntime,
   normalizeFamiliarRuntime,
@@ -188,7 +189,7 @@ export async function saveConfig(patch: CaveConfigPatch): Promise<CaveConfig> {
     roles: patch.roles !== undefined ? patch.roles : current.roles,
   };
   await mkdir(path.dirname(CONFIG_PATH), { recursive: true });
-  await writeFile(CONFIG_PATH, JSON.stringify(updated, null, 2), "utf8");
+  await writeJsonAtomic(CONFIG_PATH, updated);
   return updated;
 }
 
@@ -209,7 +210,7 @@ export async function installMarketplacePlugin(
     },
   };
   await mkdir(path.dirname(CONFIG_PATH), { recursive: true });
-  await writeFile(CONFIG_PATH, JSON.stringify(updated, null, 2), "utf8");
+  await writeJsonAtomic(CONFIG_PATH, updated);
   return installedAt;
 }
 
@@ -222,7 +223,7 @@ export async function uninstallMarketplacePlugin(pluginName: string): Promise<vo
     marketplace: { installed },
   };
   await mkdir(path.dirname(CONFIG_PATH), { recursive: true });
-  await writeFile(CONFIG_PATH, JSON.stringify(updated, null, 2), "utf8");
+  await writeJsonAtomic(CONFIG_PATH, updated);
 }
 
 export function bindingFor(config: CaveConfig, familiarId: string): FamiliarBinding {
@@ -261,7 +262,7 @@ export async function loadState(): Promise<CaveState> {
 
 async function saveState(state: CaveState): Promise<void> {
   await mkdir(path.dirname(STATE_PATH), { recursive: true });
-  await writeFile(STATE_PATH, JSON.stringify(state, null, 2), "utf8");
+  await writeJsonAtomic(STATE_PATH, state);
 }
 
 // In-process serialization of cave-state.json mutations. Without this, two
@@ -371,5 +372,5 @@ export async function upsertRoleConfig(
     cfg.roles.push({ id: roleId, familiar, active, activatedAt: active ? now : undefined });
   }
   await mkdir(path.dirname(CONFIG_PATH), { recursive: true });
-  await writeFile(CONFIG_PATH, JSON.stringify(cfg, null, 2), "utf8");
+  await writeJsonAtomic(CONFIG_PATH, cfg);
 }

--- a/src/lib/cave-inbox-prefs.ts
+++ b/src/lib/cave-inbox-prefs.ts
@@ -1,6 +1,7 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { homedir } from "node:os";
+import { writeJsonAtomic } from "./server/atomic-write.ts";
 
 const PREFS_PATH = path.join(homedir(), ".coven", "cave-inbox-prefs.json");
 
@@ -51,7 +52,7 @@ export async function loadPrefs(): Promise<InboxPrefs> {
 
 export async function savePrefs(prefs: InboxPrefs): Promise<void> {
   await ensureDir();
-  await writeFile(PREFS_PATH, JSON.stringify(prefs, null, 2), "utf8");
+  await writeJsonAtomic(PREFS_PATH, prefs);
 }
 
 export async function patchPrefs(

--- a/src/lib/cave-inbox.ts
+++ b/src/lib/cave-inbox.ts
@@ -1,7 +1,8 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { homedir } from "node:os";
 import { computeNextOccurrence, type Recurrence } from "@/lib/inbox-recurrence";
+import { writeJsonAtomic } from "./server/atomic-write.ts";
 
 const INBOX_PATH = path.join(homedir(), ".coven", "cave-inbox.json");
 
@@ -85,7 +86,7 @@ export async function loadInbox(): Promise<InboxFile> {
 
 export async function saveInbox(file: InboxFile): Promise<void> {
   await ensureDir();
-  await writeFile(INBOX_PATH, JSON.stringify(file, null, 2), "utf8");
+  await writeJsonAtomic(INBOX_PATH, file);
 }
 
 // Serialize all read-modify-write sequences against the inbox file. Without

--- a/src/lib/server/atomic-write.test.ts
+++ b/src/lib/server/atomic-write.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { writeFileAtomic, writeJsonAtomic } from "./atomic-write.ts";
+
+const dir = await mkdtemp(path.join(tmpdir(), "atomic-write-"));
+const target = path.join(dir, "data.json");
+const tmps = async () => (await readdir(dir)).filter((f) => f.endsWith(".tmp"));
+
+// 1. Replaces contents; leaves no temp files behind.
+await writeFileAtomic(target, "hello");
+assert.equal(await readFile(target, "utf8"), "hello", "first write lands");
+await writeJsonAtomic(target, { a: 1 });
+assert.deepEqual(JSON.parse(await readFile(target, "utf8")), { a: 1 }, "second write replaces");
+assert.deepEqual(await tmps(), [], "no .tmp lingers after a write");
+
+// 2. Concurrent writers all settle without ENOENT. A shared `.tmp` made the
+//    second rename race to ENOENT and crash (#1516); unique temp names let each
+//    writer rename its own file. Last writer wins; the file is never torn.
+await Promise.all(Array.from({ length: 25 }, (_, i) => writeJsonAtomic(target, { i })));
+const final = JSON.parse(await readFile(target, "utf8"));
+assert.equal(typeof final.i, "number", "a complete JSON object survives concurrent writes");
+assert.deepEqual(await tmps(), [], "no .tmp lingers after concurrent writes");
+
+// 3. On failure (target directory missing) the error propagates and the temp
+//    file does not leak.
+await assert.rejects(() => writeFileAtomic(path.join(dir, "nope", "data.json"), "x"), "write into a missing dir rejects");
+assert.deepEqual(await tmps(), [], "a failed write leaves no .tmp behind");
+
+await rm(dir, { recursive: true, force: true });
+console.log("atomic-write.test.ts: ok");

--- a/src/lib/server/atomic-write.ts
+++ b/src/lib/server/atomic-write.ts
@@ -1,0 +1,31 @@
+import { rename, rm, writeFile } from "node:fs/promises";
+import { randomBytes } from "node:crypto";
+
+/**
+ * Atomically replace `path`'s contents with `data`.
+ *
+ * Writes to a UNIQUE temp file in the same directory, then renames it over the
+ * target. `rename(2)` is atomic on POSIX, so a reader never observes a
+ * half-written file and a crash mid-write leaves the previous file intact. The
+ * temp name is per-write (pid + random) so concurrent writers — including
+ * separate processes sharing `~/.coven` (daemon, desktop, iOS) — never collide
+ * on a shared `.tmp` and hit `ENOENT` on the second rename (the #1516
+ * theme-store crash). Last writer wins.
+ *
+ * The target's directory must already exist (callers typically `mkdir` first).
+ */
+export async function writeFileAtomic(path: string, data: string): Promise<void> {
+  const tmp = `${path}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`;
+  try {
+    await writeFile(tmp, data, "utf8");
+    await rename(tmp, path);
+  } catch (err) {
+    await rm(tmp, { force: true }).catch(() => {});
+    throw err;
+  }
+}
+
+/** {@link writeFileAtomic} for JSON values — pretty-printed with 2-space indent. */
+export async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
+  await writeFileAtomic(path, JSON.stringify(value, null, 2));
+}

--- a/src/lib/workflow-runs.ts
+++ b/src/lib/workflow-runs.ts
@@ -1,6 +1,7 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
+import { writeJsonAtomic } from "./server/atomic-write.ts";
 import path from "node:path";
 
 /**
@@ -56,7 +57,7 @@ export async function recordRun(input: Omit<WorkflowRunRecord, "id">): Promise<W
     file.runs.unshift(record);
     if (file.runs.length > RUNS_HISTORY_CAP) file.runs.length = RUNS_HISTORY_CAP;
     await mkdir(path.dirname(runsPath()), { recursive: true });
-    await writeFile(runsPath(), JSON.stringify(file, null, 2), "utf8");
+    await writeJsonAtomic(runsPath(), file);
   });
   return record;
 }
@@ -80,7 +81,7 @@ export async function clearRuns(workflowId?: string): Promise<number> {
     const removed = before - file.runs.length;
     if (removed > 0) {
       await mkdir(path.dirname(runsPath()), { recursive: true });
-      await writeFile(runsPath(), JSON.stringify(file, null, 2), "utf8");
+      await writeJsonAtomic(runsPath(), file);
     }
     return removed;
   });


### PR DESCRIPTION
First structural PR (of the data-integrity track). Five `~/.coven` JSON stores wrote with a plain `writeFile` (no temp+rename), so a crash or a concurrent writer mid-write could leave a **truncated/corrupt file** — and these stores fall back to *empty* on a parse error, i.e. **silent data loss**. Same class as the #1516 theme-store write-race crash.

- **New `src/lib/server/atomic-write.ts`** — `writeFileAtomic` / `writeJsonAtomic`: write to a **unique** temp file (pid + random) then atomic `rename`, mirroring the hardened theme-store pattern. The per-write temp name keeps concurrent writers — even across the daemon / desktop / iOS processes that share `~/.coven` — from racing on a shared `.tmp` and hitting `ENOENT` on the second rename. **Behavioral test** (real fs in a temp dir): replace-contents, 25 concurrent writers settle with no torn file / no leaked `.tmp`, failure cleanup.
- **Adopt `writeJsonAtomic`** in the five direct-writers: `cave-inbox`, `automation-runs`, `cave-config` (×5 sites), `workflow-runs`, `cave-inbox-prefs`.

Already-atomic stores (board, canvas, library, coven-calls, theme) keep their hand-rolled versions — a **follow-up** can DRY them onto the shared helper (and fix `memory-trash`'s fixed-tmp).

- typecheck clean · `check:tests-wired` ✓ (467) · `pnpm test:app` 370 (incl. the existing `cave-config-state-race` + `cave-board-atomic` race tests) · `pnpm test:mobile` 18

🤖 Generated with [Claude Code](https://claude.com/claude-code)