### PR TITLE
refactor(security): centralize the duplicated isLocalOrigin route guard (route audit)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -348,6 +348,7 @@ export const SUITES = {
     "src/lib/vault-bundle.test.ts",
     "src/lib/cave-board-atomic.test.ts",
     "src/lib/server/atomic-write.test.ts",
+    "src/lib/server/local-origin.test.ts",
     "src/lib/env-local-bundle.test.ts",
     "src/lib/cave-board-schedule.test.ts",
     "src/components/ui/tabs.test.ts",

--- a/src/app/api/codex-automations/[id]/route.ts
+++ b/src/app/api/codex-automations/[id]/route.ts
@@ -7,16 +7,11 @@ import {
   toCodexAutomationPayload,
   updateCodexAutomation,
 } from "@/lib/codex-automations";
+import { isLocalOrigin } from "@/lib/server/local-origin";
 
 export const dynamic = "force-dynamic";
 
 type Params = { params: Promise<{ id: string }> };
-
-function isLocalOrigin(req: Request): boolean {
-  const host = req.headers.get("host") ?? "";
-  const bare = host.split(":")[0];
-  return bare === "127.0.0.1" || bare === "localhost" || bare === "[::1]";
-}
 
 export async function GET(_req: Request, { params }: Params) {
   const { id } = await params;

--- a/src/app/api/codex-automations/[id]/run/route.ts
+++ b/src/app/api/codex-automations/[id]/run/route.ts
@@ -1,16 +1,11 @@
 import { NextResponse } from "next/server";
 import { getCodexAutomation } from "@/lib/codex-automations";
 import { startAutomationRun } from "@/lib/server/automation-runner";
+import { isLocalOrigin } from "@/lib/server/local-origin";
 
 export const dynamic = "force-dynamic";
 
 type Params = { params: Promise<{ id: string }> };
-
-function isLocalOrigin(req: Request): boolean {
-  const host = req.headers.get("host") ?? "";
-  const bare = host.split(":")[0];
-  return bare === "127.0.0.1" || bare === "localhost" || bare === "[::1]";
-}
 
 export async function POST(req: Request, { params }: Params) {
   if (!isLocalOrigin(req)) {

--- a/src/app/api/codex-automations/route.ts
+++ b/src/app/api/codex-automations/route.ts
@@ -1,13 +1,8 @@
 import { NextResponse } from "next/server";
 import { createCodexAutomation, listCodexAutomations, toCodexAutomationPayload } from "@/lib/codex-automations";
+import { isLocalOrigin } from "@/lib/server/local-origin";
 
 export const dynamic = "force-dynamic";
-
-function isLocalOrigin(req: Request): boolean {
-  const host = req.headers.get("host") ?? "";
-  const bare = host.split(":")[0];
-  return bare === "127.0.0.1" || bare === "localhost" || bare === "[::1]";
-}
 
 export async function GET() {
   try {

--- a/src/app/api/inbox/daily-summary/route.ts
+++ b/src/app/api/inbox/daily-summary/route.ts
@@ -8,16 +8,11 @@ import {
 import { broadcastCreated, startScheduler } from "@/lib/inbox-scheduler";
 import { buildDailySummaryNotification } from "@/lib/daily-summary-notifications";
 import type { SessionRow } from "@/lib/types";
+import { isLocalOrigin } from "@/lib/server/local-origin";
 
 export const dynamic = "force-dynamic";
 
 startScheduler();
-
-function isLocalOrigin(req: Request): boolean {
-  const host = req.headers.get("host") ?? "";
-  const bare = host.split(":")[0];
-  return bare === "127.0.0.1" || bare === "localhost" || bare === "[::1]";
-}
 
 export async function POST(req: Request) {
   if (!isLocalOrigin(req)) {

--- a/src/app/api/inbox/route.ts
+++ b/src/app/api/inbox/route.ts
@@ -9,17 +9,12 @@ import {
   type Recurrence,
 } from "@/lib/cave-inbox";
 import { broadcastCreated, startScheduler } from "@/lib/inbox-scheduler";
+import { isLocalOrigin } from "@/lib/server/local-origin";
 
 export const dynamic = "force-dynamic";
 
 // Guarantee the scheduler is alive even if instrumentation.ts was bypassed.
 startScheduler();
-
-function isLocalOrigin(req: Request): boolean {
-  const host = req.headers.get("host") ?? "";
-  const bare = host.split(":")[0];
-  return bare === "127.0.0.1" || bare === "localhost" || bare === "[::1]";
-}
 
 export async function GET(req: Request) {
   const url = new URL(req.url);

--- a/src/lib/server/local-origin.test.ts
+++ b/src/lib/server/local-origin.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { isLocalOrigin } from "./local-origin.ts";
+
+const withHost = (host?: string) =>
+  new Request("http://x/", { headers: host === undefined ? {} : { host } });
+
+// Loopback hosts (with or without a port) are accepted.
+assert.equal(isLocalOrigin(withHost("127.0.0.1:3000")), true, "127.0.0.1 accepted");
+assert.equal(isLocalOrigin(withHost("localhost:8443")), true, "localhost accepted");
+assert.equal(isLocalOrigin(withHost("localhost")), true, "bare localhost accepted");
+
+// Non-loopback hosts are rejected — including the tailnet host the phone uses
+// (a 100.64.0.0/10 CGNAT address, or the equivalent magic-DNS name), which is
+// the whole point: these routes are desktop-only, not phone-reachable.
+assert.equal(isLocalOrigin(withHost("100.101.102.103:8443")), false, "tailnet host rejected (desktop-only)");
+assert.equal(isLocalOrigin(withHost("192.168.1.5:8443")), false, "LAN host rejected");
+assert.equal(isLocalOrigin(withHost("evil.example.com")), false, "remote host rejected");
+assert.equal(isLocalOrigin(withHost(undefined)), false, "missing Host rejected");
+
+console.log("local-origin.test.ts: ok");

--- a/src/lib/server/local-origin.ts
+++ b/src/lib/server/local-origin.ts
@@ -1,0 +1,19 @@
+/**
+ * True when the request's Host header is loopback (127.0.0.1 / localhost / [::1]).
+ *
+ * Defense-in-depth gate for DESKTOP-ONLY routes (codex exec, automation
+ * create/delete/run, inbox writes). The server already authenticates every
+ * request (access token + same-origin — see server.ts); this adds the
+ * requirement that the Host be loopback, so these routes are NOT reachable
+ * from the phone / tailnet. Over `tailscale serve` the Host is
+ * `<name>.ts.net`, which this rejects BY DESIGN — do not add this guard to
+ * routes the iOS app legitimately needs (board, chat, inbox read).
+ *
+ * Previously copy-pasted verbatim into each such route; centralized here so the
+ * check has a single, test-covered source of truth.
+ */
+export function isLocalOrigin(req: Request): boolean {
+  const host = req.headers.get("host") ?? "";
+  const bare = host.split(":")[0];
+  return bare === "127.0.0.1" || bare === "localhost" || bare === "[::1]";
+}


### PR DESCRIPTION
Second structural PR (security track). I audited all **113 API routes** for auth + path-traversal safety. The headline is a **clean bill of health** — both surfaces are already handled well:

- **Auth is layered & intentional.** `server.ts` authenticates every request (access token + same-origin + loopback/tailnet trust). A handful of *desktop-only* routes (codex exec, automation create/delete/run, inbox writes) additionally require a loopback Host via `isLocalOrigin`, so they're not phone/tailnet-reachable. This is deliberate — spreading that guard would **break** legit iOS/Tailscale access, so it is *not* a gap.
- **Path-traversal is contained everywhere.** All 8 routes taking a user-supplied path validate + contain it (`resolveAllowedProject*`, `isAllowedSkillFilePath`, `resolveAllowedMemoryFilePath`, and the gold-standard `readLocalPdfFile`: filename validation + realpath containment + symlink rejection + `O_NOFOLLOW` + size cap). No traversal gap.

**The one real issue:** `isLocalOrigin` — a *security* check — was copy-pasted **verbatim into 5 route files**, with no single source of truth (a bug fixed in one copy could be missed in the others). Centralize it:
- New `src/lib/server/local-origin.ts` (documents the desktop-only intent) + a test pinning the semantics (loopback accepted; tailnet/LAN/remote rejected).
- The 5 routes import the shared guard; behavior is **byte-identical**.

typecheck clean · `check:tests-wired` ✓ (468) · `pnpm test:app` 371 · `pnpm test:mobile` 18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)