### PR TITLE
refactor(stores): DRY four hand-rolled atomic writes onto writeJsonAtomic

### DIFF
--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -1,6 +1,7 @@
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { homedir } from "node:os";
+import { writeJsonAtomic } from "./server/atomic-write.ts";
 
 import {
   DEFAULT_MAX_RETRIES,
@@ -198,19 +199,14 @@ function withBoardLock<T>(fn: () => Promise<T>): Promise<T> {
   return next;
 }
 
-let boardTmpCounter = 0;
-
 export async function saveBoard(board: BoardFile): Promise<void> {
   await ensureDir();
-  // Atomic write: plain writeFile truncates-then-writes, so a concurrent reader
-  // can observe a half-written file. loadBoard() then fails to parse it and
-  // falls back to an empty board, making cards momentarily "vanish" — e.g. a
-  // task-chat POST 404ing ("not found") on a card that actually exists. Write to
-  // a temp file and rename() instead: rename is atomic on POSIX, so a reader
-  // always sees a complete old-or-new file, never a torn one.
-  const tmp = `${BOARD_PATH}.${process.pid}.${boardTmpCounter++}.tmp`;
-  await writeFile(tmp, JSON.stringify(board, null, 2), "utf8");
-  await rename(tmp, BOARD_PATH);
+  // Atomic write (temp file + rename): a plain writeFile truncates-then-writes,
+  // so a concurrent reader can observe a half-written file, loadBoard() fails to
+  // parse it and falls back to an empty board — cards momentarily "vanish" (e.g.
+  // a task-chat POST 404ing on a card that exists). The write lock above
+  // serializes mutations; writeJsonAtomic makes each write torn-read-safe.
+  await writeJsonAtomic(BOARD_PATH, board);
 }
 
 export type NewCardInput = {

--- a/src/lib/cave-canvas.ts
+++ b/src/lib/cave-canvas.ts
@@ -6,9 +6,10 @@
 // owner (and the many other sessions that mutate it) never has to know the
 // canvas exists, and a canvas write can never clobber card data.
 
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { homedir } from "node:os";
+import { writeJsonAtomic } from "./server/atomic-write.ts";
 
 import type { CanvasPosition, CanvasPositions } from "@/lib/canvas-layout";
 import { sanitizeArtifacts, type CanvasArtifact } from "@/lib/canvas-artifacts";
@@ -87,15 +88,9 @@ function withLock<T>(fn: () => Promise<T>): Promise<T> {
   return next;
 }
 
-let tmpCounter = 0;
-
 export async function saveCanvas(file: CanvasFile): Promise<void> {
   await ensureDir();
-  // Atomic write via temp-file + rename so a concurrent reader never observes a
-  // half-written file (rename is atomic on POSIX).
-  const tmp = `${CANVAS_PATH}.${process.pid}.${tmpCounter++}.tmp`;
-  await writeFile(tmp, JSON.stringify(file, null, 2), "utf8");
-  await rename(tmp, CANVAS_PATH);
+  await writeJsonAtomic(CANVAS_PATH, file);
 }
 
 /**

--- a/src/lib/coven-calls.ts
+++ b/src/lib/coven-calls.ts
@@ -3,9 +3,10 @@
 // Pure types + aggregator live in coven-calls-types so client code
 // can import without pulling in node:fs.
 
-import { mkdir, readFile, writeFile, rename } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { homedir } from "node:os";
+import { writeJsonAtomic } from "./server/atomic-write.ts";
 import { randomUUID } from "node:crypto";
 
 import type {
@@ -49,9 +50,7 @@ export async function loadCalls(): Promise<CallsFile> {
 
 export async function saveCalls(file: CallsFile): Promise<void> {
   await ensureDir();
-  const tmp = `${FILE_PATH}.${process.pid}.tmp`;
-  await writeFile(tmp, JSON.stringify(file, null, 2), "utf8");
-  await rename(tmp, FILE_PATH);
+  await writeJsonAtomic(FILE_PATH, file);
 }
 
 export async function recordCall(input: CovenCallInput): Promise<CovenCall> {

--- a/src/lib/library-store.ts
+++ b/src/lib/library-store.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { homedir } from "node:os";
 import type { LibraryBookmark, LibraryReadingItem, LibraryGitHubItem } from "./library-types";
+import { writeFileAtomic } from "./server/atomic-write.ts";
 
 export type IndexEntry = {
   url: string;
@@ -39,9 +40,7 @@ async function readJson<T>(p: string, fallback: T): Promise<T> {
 
 async function writeJsonAtomic(p: string, value: unknown): Promise<void> {
   await fs.mkdir(path.dirname(p), { recursive: true });
-  const tmp = `${p}.tmp-${process.pid}-${Date.now()}`;
-  await fs.writeFile(tmp, JSON.stringify(value, null, 2), "utf-8");
-  await fs.rename(tmp, p);
+  await writeFileAtomic(p, JSON.stringify(value, null, 2));
 }
 
 export function createLibraryStore(root: string = DEFAULT_ROOT) {


### PR DESCRIPTION
Follow-up to #1617. Four stores still hand-rolled their own temp-file+rename; route them through the shared `writeFileAtomic`/`writeJsonAtomic` (unique-tmp + rename + **rm-on-error**, which several lacked):

- **cave-board** — keeps its write lock; atomic mechanics move to the helper (race test still green).
- **cave-canvas** — drops its per-process `tmpCounter`.
- **coven-calls** — used a **fixed** `${FILE_PATH}.${pid}.tmp`, so two saves in the same process raced on one temp file (the #1516 class, intra-process). The shared helper's unique tmp **fixes that latent race**.
- **library-store** — replaces its own local `writeJsonAtomic` (keeps the mkdir, delegates the atomic write); call sites unchanged.

**Left on purpose:** `theme-store` (its regression test pins the inline pattern; it's the reference the helper was modeled on) and `memory-trash` (not the race class — uniquely-named `${trashId}.json` + atomic file *moves*, with a `mode 0o600` the helper doesn't set).

typecheck clean · `cave-board-atomic` race test passes (no lost updates / torn reads, lock intact) · `pnpm test:app` 369 · `pnpm test:mobile` 18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)