### PR TITLE
chore: remove the dead ShellNav* cluster + unused SkeletonGrid export

### DIFF
--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -85,22 +85,6 @@ const RAIL_OPEN_THRESHOLD_PX = RAIL_PEEK_PX + 16;
 const NAV_RAIL_PX = 56;
 const NAV_OPEN_THRESHOLD_PX = NAV_RAIL_PX + 16;
 
-export type ShellNavSection = {
-  label?: string;
-  items: ShellNavItem[];
-  customContent?: ReactNode;
-};
-
-export type ShellNavItem = {
-  id: string;
-  label: string;
-  icon: IconName;
-  kbd?: string;
-  active?: boolean;
-  onClick?: () => void;
-  presence?: "active" | "idle";
-};
-
 export type ShellHandle = {
   openFamiliar: () => void;
   closeFamiliar: () => void;
@@ -659,75 +643,6 @@ function ShellInner({
 }
 
 export const Shell = forwardRef<ShellHandle, Parameters<typeof ShellInner>[0]>(ShellInner);
-
-export function ShellNav({
-  header,
-  sections,
-}: {
-  header?: ReactNode;
-  sections: ShellNavSection[];
-}) {
-  return (
-    <>
-      {header}
-      {sections.map((section, idx) => (
-        <div key={section.label ?? `section-${idx}`}>
-          {section.label && (
-            <div className="shell-nav-eyebrow">{section.label}</div>
-          )}
-          {section.customContent ?? section.items.map((item) => (
-            <ShellNavButton key={item.id} item={item} />
-          ))}
-        </div>
-      ))}
-    </>
-  );
-}
-
-export function ShellNavButton({ item }: { item: ShellNavItem }) {
-  return (
-    <button
-      type="button"
-      className={`shell-nav-item${item.active ? " shell-nav-item--active" : ""}`}
-      onClick={item.onClick}
-    >
-      <span className="shell-nav-item-icon">
-        <Icon name={item.icon} width={CAVE_ICON_SIZE.shellNav} height={CAVE_ICON_SIZE.shellNav} />
-      </span>
-      <span>{item.label}</span>
-      {item.presence && (
-        <span
-          aria-hidden
-          className={`shell-presence-dot ml-auto${item.presence === "idle" ? " shell-presence-dot--idle" : ""}`}
-        />
-      )}
-      {item.kbd && !item.presence && (
-        <span className="shell-nav-kbd">{item.kbd}</span>
-      )}
-    </button>
-  );
-}
-
-export function ShellNavHeader({
-  initial,
-  label,
-}: {
-  initial: string;
-  label: string;
-}) {
-  return (
-    <button type="button" className="shell-nav-header">
-      <span className="shell-nav-avatar">{initial}</span>
-      <span>{label}</span>
-      <Icon
-        name="ph:caret-down"
-        width={CAVE_ICON_SIZE.shellInline}
-        height={CAVE_ICON_SIZE.shellInline}
-        className="ml-auto opacity-60"
-      />
-    </button>
-  );
-}
 
 function ShellBannerStrip() {
   const { banners, dismissBanner } = useShellBanners();

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -41,16 +41,6 @@ export function SkeletonGroup({ children, className }: { children: ReactNode; cl
   return <div className={["ui-skeleton-group", className ?? ""].filter(Boolean).join(" ")}>{children}</div>;
 }
 
-export function SkeletonGrid({ count = 6, className }: { count?: number; className?: string }) {
-  return (
-    <div className={["ui-skeleton-grid", className ?? ""].filter(Boolean).join(" ")} aria-hidden>
-      {Array.from({ length: count }).map((_, i) => (
-        <Skeleton key={i} variant="card" />
-      ))}
-    </div>
-  );
-}
-
 export function SkeletonRows({ count = 4, className }: { count?: number; className?: string }) {
   return (
     <SkeletonGroup className={className}>


### PR DESCRIPTION
Follow-up to #1620 — the **in-file dead exports** it flagged:

- **`shell.tsx`**: `ShellNav` / `ShellNavButton` / `ShellNavHeader` were a self-contained dead cluster (`ShellNav` had zero callers; `ShellNavButton`'s only use was inside the dead `ShellNav`; `ShellNavHeader` unused). Removed all three + the `ShellNavSection` / `ShellNavItem` types only the cluster referenced. The live `Shell`/`ShellInner` export is untouched.
- **`ui/skeleton.tsx`**: `SkeletonGrid` had no callers. Removed (`Skeleton` / `SkeletonGroup` / `SkeletonRows` stay — all used).

−95 lines, pure deletion. typecheck clean · no test referenced them · `pnpm test:app` 369 · `pnpm test:mobile` 18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)