### PR TITLE
feat(familiars): multiselect familiar scope in the top-bar avatar strip

### DIFF
--- a/src/components/board-view-familiar-scope.test.ts
+++ b/src/components/board-view-familiar-scope.test.ts
@@ -14,8 +14,16 @@ assert.match(
 
 assert.match(
   source,
-  /\[cards, familiarsById, searchQuery, activeFamiliarId\]/,
-  "BoardView filtered memo dependency array must include activeFamiliarId so re-filter triggers on familiar switch",
+  /\[cards, familiarsById, searchQuery, activeFamiliarId, scopeFamiliarIds\]/,
+  "BoardView filtered memo deps include activeFamiliarId + scopeFamiliarIds so re-filter triggers on familiar switch / multiselect change",
+);
+
+// Multiselect: when a scope set is supplied, the board filters to the union via
+// the shared familiarInScope predicate (empty set = All).
+assert.match(
+  source,
+  /scopeFamiliarIds\s*\?\s*familiarInScope\(scopeFamiliarIds, c\.familiarId\)/,
+  "BoardView filters by the multiselect scope set when provided",
 );
 
 // Stats must reflect the visible (filtered) set, not the full unfiltered

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -9,6 +9,7 @@ import { NewCardModal, type NewCardDraft } from "@/components/new-card-modal";
 import { Icon } from "@/lib/icon";
 import { type Card, type CardStatus } from "@/lib/cave-board-types";
 import { cardMatchesBoardSearch } from "@/lib/board-search";
+import { familiarInScope } from "@/lib/familiar-multiselect";
 import { BoardKanban } from "@/components/board-kanban";
 import { BoardGantt } from "@/components/board-gantt";
 import { BoardTable, type GroupBy } from "@/components/board-table";
@@ -32,11 +33,14 @@ type Props = {
   familiars: Familiar[];
   sessions: SessionRow[];
   activeFamiliarId: string | null;
+  /** Multiselect scope (empty = All). When ≥2 are selected the board filters to
+   *  the union; `activeFamiliarId` stays the single-primary for chrome. */
+  scopeFamiliarIds?: ReadonlySet<string>;
   onJumpToSession?: (sessionId: string, familiarId: string | null) => void;
   onOpenUrl?: (url: string) => void;
 };
 
-export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSession, onOpenUrl }: Props) {
+export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliarIds, onJumpToSession, onOpenUrl }: Props) {
   const isMobile = useIsMobile();
   const [cards, setCards] = useState<Card[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -142,10 +146,12 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
     () =>
       cards.filter(
         (c) =>
-          (activeFamiliarId === null || c.familiarId === activeFamiliarId) &&
+          (scopeFamiliarIds
+            ? familiarInScope(scopeFamiliarIds, c.familiarId)
+            : activeFamiliarId === null || c.familiarId === activeFamiliarId) &&
           cardMatchesBoardSearch(c, searchQuery, familiarsById),
       ),
-    [cards, familiarsById, searchQuery, activeFamiliarId],
+    [cards, familiarsById, searchQuery, activeFamiliarId, scopeFamiliarIds],
   );
 
   const stats = useMemo(() => ({

--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -8,6 +8,9 @@ import type { SessionRow } from "@/lib/types";
 type Props = {
   familiars: ResolvedFamiliar[];
   activeFamiliarId: string | null;
+  /** The full multiselect scope (empty = All). Drives multi-highlight in the
+   *  avatar strip; `activeFamiliarId` stays the single-primary for the rest. */
+  selectedFamiliarIds?: ReadonlySet<string>;
   sessions: SessionRow[];
   responseNeeded?: Set<string>;
   /** Open task count (board cards not yet done) — drives the Tasks badge. */
@@ -20,8 +23,9 @@ type Props = {
   searchQuery: string;
   /** Update shared top-search query. */
   onSearchQueryChange: (query: string) => void;
-  /** Change the active-familiar scope (the switcher menu's "All"/per-familiar). */
-  onSelectFamiliar: (id: string | null) => void;
+  /** Change the familiar scope. `opts.multi` (⌘/Ctrl-click) toggles the id in
+   *  the multiselect set; a plain click selects only that one (`null` = All). */
+  onSelectFamiliar: (id: string | null, opts?: { multi?: boolean }) => void;
   /** Jump to the task board. */
   onViewTasks: () => void;
   /** Enrich active tasks for the selected familiar. */
@@ -48,6 +52,7 @@ function fmtBadge(n: number): string {
 export function FamiliarMenuBar({
   familiars,
   activeFamiliarId,
+  selectedFamiliarIds,
   sessions,
   responseNeeded,
   taskCount,
@@ -74,6 +79,7 @@ export function FamiliarMenuBar({
         <FamiliarQuickSwitch
           familiars={familiars}
           activeFamiliarId={activeFamiliarId}
+          selectedFamiliarIds={selectedFamiliarIds}
           sessions={sessions}
           responseNeeded={responseNeeded}
           onSelectFamiliar={onSelectFamiliar}

--- a/src/components/familiar-quick-switch.test.ts
+++ b/src/components/familiar-quick-switch.test.ts
@@ -28,10 +28,17 @@ assert.match(
 );
 
 // Each strip entry is a one-tap switch button with an avatar + presence dot.
+// A plain tap selects only that familiar; ⌘/Ctrl-click toggles multiselect.
 assert.match(
   source,
-  /onClick=\{\(\) => onSelectFamiliar\(f\.id\)\}/,
-  "tapping a strip avatar switches to that familiar",
+  /onClick=\{\(e\) => onSelectFamiliar\(f\.id, \{ multi: e\.metaKey \|\| e\.ctrlKey \}\)\}/,
+  "tapping a strip avatar scopes to it; ⌘/Ctrl-click toggles it in the multiselect set",
+);
+// The strip highlights every member of the multiselect scope when supplied.
+assert.match(
+  source,
+  /selectedFamiliarIds\s*\?\s*selectedFamiliarIds\.has\(f\.id\)\s*:\s*f\.id === activeFamiliarId/,
+  "strip marks all selected familiars active (falls back to the single active id)",
 );
 assert.match(source, /<FamiliarAvatar familiar=\{f\} size="sm" \/>/, "renders each familiar's avatar");
 assert.match(

--- a/src/components/familiar-quick-switch.tsx
+++ b/src/components/familiar-quick-switch.tsx
@@ -14,10 +14,14 @@ import type { SessionRow } from "@/lib/types";
 type Props = {
   familiars: ResolvedFamiliar[];
   activeFamiliarId?: string | null;
+  /** The full multiselect scope (empty/undefined = All). When ≥2 are selected
+   *  every member is highlighted; falls back to `activeFamiliarId` otherwise. */
+  selectedFamiliarIds?: ReadonlySet<string>;
   sessions: SessionRow[];
   responseNeeded?: Set<string>;
-  /** `null` scopes to "All familiars". */
-  onSelectFamiliar: (id: string | null) => void;
+  /** `null` scopes to "All familiars". `opts.multi` (⌘/Ctrl-click) toggles the
+   *  id in the multiselect set instead of replacing the scope. */
+  onSelectFamiliar: (id: string | null, opts?: { multi?: boolean }) => void;
   /** Menu placement of the embedded full switcher. */
   placement?: "bottom-start" | "bottom-end" | "top-start" | "top-end";
   /** Labels the embedded switcher's trigger with the active familiar name. */
@@ -37,6 +41,7 @@ type Props = {
 export function FamiliarQuickSwitch({
   familiars,
   activeFamiliarId,
+  selectedFamiliarIds,
   sessions,
   responseNeeded,
   onSelectFamiliar,
@@ -63,7 +68,11 @@ export function FamiliarQuickSwitch({
       {showStrip ? (
         <ul className="familiar-quickswitch__strip" role="listbox" aria-label="Quick switch familiar">
           {quick.map((f) => {
-            const isActive = f.id === activeFamiliarId;
+            // Highlight every member of the multiselect scope; fall back to the
+            // single active id when no scope set was supplied.
+            const isActive = selectedFamiliarIds
+              ? selectedFamiliarIds.has(f.id)
+              : f.id === activeFamiliarId;
             const needsReply = responseNeeded?.has(f.id) ?? false;
             const presence = computePresence({
               familiar: f,
@@ -80,8 +89,10 @@ export function FamiliarQuickSwitch({
                   aria-selected={isActive}
                   className={`familiar-quickswitch__btn focus-ring${isActive ? " is-active" : ""}`}
                   style={{ ["--familiar-accent" as string]: f.color } as CSSProperties}
-                  onClick={() => onSelectFamiliar(f.id)}
-                  title={`${f.display_name}${isPinned ? " · pinned" : ""} · ${presence.label}`}
+                  // ⌘/Ctrl-click toggles this familiar in the scope (multiselect);
+                  // a plain click selects only it.
+                  onClick={(e) => onSelectFamiliar(f.id, { multi: e.metaKey || e.ctrlKey })}
+                  title={`${f.display_name}${isPinned ? " · pinned" : ""} · ${presence.label} · ⌘-click to multi-select`}
                   aria-label={`Switch to ${f.display_name}${isPinned ? " (pinned)" : ""}`}
                 >
                   <span className="familiar-quickswitch__avatar">

--- a/src/components/workspace-familiars-landing.test.ts
+++ b/src/components/workspace-familiars-landing.test.ts
@@ -111,23 +111,28 @@ assert.match(
 
 assert.match(
   workspace,
-  /const \[activeId, setActiveId\] = useState<string \| null>\(null\)/,
-  "Workspace should SSR-render active familiar as null so server/client first render match",
+  /const \[scopeIds, setScopeIds\] = useState<Set<string>>\(\(\) => new Set\(\)\)/,
+  "Workspace should SSR-render the familiar scope as an empty set so server/client first render match",
+);
+assert.match(
+  workspace,
+  /const activeId = scopeIds\.size === 1 \? \[\.\.\.scopeIds\]\[0\]! : null/,
+  "activeId is the derived single-primary (lone scoped id, else null)",
 );
 assert.doesNotMatch(
   workspace,
-  /useState<string \| null>\(\(\) => getActiveFamiliar\(\)\)/,
-  "Workspace must not read localStorage in the active familiar useState initializer",
+  /useState<Set<string>>\(\(\) => new Set\(getFamiliarScope\(\)\)\)/,
+  "Workspace must not read localStorage in the scope useState initializer",
 );
 assert.match(
   workspace,
-  /setActiveId\(getActiveFamiliar\(\)\);[\s\S]*setActiveFamiliarHydrated\(true\);/,
-  "Workspace should restore the persisted active familiar after mount",
+  /setScopeIds\(new Set\(getFamiliarScope\(\)\)\);[\s\S]*setActiveFamiliarHydrated\(true\);/,
+  "Workspace should restore the persisted familiar scope after mount",
 );
 assert.match(
   workspace,
-  /if \(!activeFamiliarHydrated\) return;[\s\S]*setActiveFamiliar\(activeId\)/,
-  "Workspace should not write active familiar storage until after the mount restore runs",
+  /if \(!activeFamiliarHydrated\) return;[\s\S]*setFamiliarScope\(\[\.\.\.scopeIds\]\)/,
+  "Workspace should not write scope storage until after the mount restore runs",
 );
 
 assert.doesNotMatch(

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -26,14 +26,15 @@ import { CompanionRail, type CompanionTab } from "@/components/companion-rail";
 import { RailInspector } from "@/components/inspector-pane";
 import { FamiliarsView } from "@/components/familiars-view";
 import {
-  getActiveFamiliar,
-  setActiveFamiliar,
+  getFamiliarScope,
+  setFamiliarScope,
   getLastSurface,
   setLastSurface,
   getRailOpen,
   setRailOpen,
 } from "@/lib/familiar-memory";
 import { recordFamiliarUsed } from "@/lib/familiar-quick-switch";
+import { toggleFamiliarSelection } from "@/lib/familiar-multiselect";
 import { ChooserModal, type ChooserOption } from "@/components/ui/chooser-modal";
 import { FamiliarPanel } from "@/components/familiar-panel";
 import { BrowserPane, type BrowserPaneHandle } from "@/components/browser-pane";
@@ -156,7 +157,17 @@ export function Workspace() {
   const nextRouter = useRouter();
   const routerRef = useRef<ChatRouterHandle | null>(null);
   const shellRef = useRef<ShellHandle | null>(null);
-  const [activeId, setActiveId] = useState<string | null>(null);
+  // Multiselect familiar scope. Empty set = "All familiars". `activeId` is the
+  // derived single "primary" — the lone scoped id, or null when 0 or ≥2 are
+  // selected — so all the existing single-familiar chrome/per-familiar state
+  // behaves exactly as before at 0–1 selections; ≥2 is the new filter case.
+  const [scopeIds, setScopeIds] = useState<Set<string>>(() => new Set());
+  const activeId = scopeIds.size === 1 ? [...scopeIds][0]! : null;
+  // Back-compat shim for the call sites that scope to a single familiar (e.g.
+  // opening a session) or clear to All: writes the multiselect set accordingly.
+  const setActiveId = useCallback((id: string | null) => {
+    setScopeIds(id == null ? new Set<string>() : new Set([id]));
+  }, []);
   const [activeFamiliarHydrated, setActiveFamiliarHydrated] = useState(false);
   const [familiars, setFamiliars] = useState<Familiar[]>([]);
   const resolvedFamiliars = useResolvedFamiliars(familiars);
@@ -304,14 +315,14 @@ export function Workspace() {
   }, []);
 
   useEffect(() => {
-    setActiveId(getActiveFamiliar());
+    setScopeIds(new Set(getFamiliarScope()));
     setActiveFamiliarHydrated(true);
   }, []);
 
   useEffect(() => {
     if (!activeFamiliarHydrated) return;
-    setActiveFamiliar(activeId);
-  }, [activeId, activeFamiliarHydrated]);
+    setFamiliarScope([...scopeIds]);
+  }, [scopeIds, activeFamiliarHydrated]);
 
   useEffect(() => {
     if (!activeId) {
@@ -472,11 +483,17 @@ export function Workspace() {
     }
   }, [demoMode]);
 
-  const selectFamiliarScope = useCallback((id: string | null) => {
-    setActiveId(id);
+  // Scope the view to a familiar. `null` clears to "All". With `opts.multi`
+  // (⌘/Ctrl-click) the id is toggled in/out of the multiselect set; a plain
+  // click replaces the scope with just that familiar (today's behavior).
+  const selectFamiliarScope = useCallback((id: string | null, opts?: { multi?: boolean }) => {
+    setScopeIds((prev) => (id == null ? new Set<string>() : toggleFamiliarSelection(prev, id, opts?.multi ?? false)));
     if (!id) return;
     // Stamp recency so the top-bar quick-switch strip reflects real usage.
     recordFamiliarUsed(id);
+    // A multi-toggle shouldn't yank the surface around — only a plain single
+    // select restores that familiar's last-viewed surface.
+    if (opts?.multi) return;
     const last = getLastSurface(id);
     // Guard against retired/unknown persisted modes (e.g. the removed
     // "projects" standalone surface). Only restore if the stored string is
@@ -1771,6 +1788,7 @@ export function Workspace() {
         familiars={familiars}
         sessions={sessions}
         activeFamiliarId={activeId}
+        scopeFamiliarIds={scopeIds}
         onOpenUrl={(url) => {
           setMode("browser");
           requestAnimationFrame(() => browserPaneRef.current?.navigateTo(url));
@@ -1902,6 +1920,7 @@ export function Workspace() {
             <FamiliarMenuBar
               familiars={resolvedFamiliars}
               activeFamiliarId={activeId}
+              selectedFamiliarIds={scopeIds}
               sessions={sessions}
               responseNeeded={responseNeeded}
               taskCount={boardTaskCount}

--- a/src/lib/familiar-memory.ts
+++ b/src/lib/familiar-memory.ts
@@ -4,6 +4,10 @@
 // All readers SSR-guard (Next.js renders this code on both server and client).
 
 const ACTIVE_KEY = "cave:active-familiar";
+// The full multiselect scope (JSON string[]). Empty/absent = "All familiars".
+// ACTIVE_KEY is kept in sync as the single "primary" (the lone id when exactly
+// one is scoped, else null) so other readers — e.g. the iOS app — still work.
+const SCOPE_KEY = "cave:familiar-scope";
 
 function safeGet(key: string): string | null {
   if (typeof window === "undefined") return null;
@@ -24,6 +28,30 @@ export function getActiveFamiliar(): string | null {
 
 export function setActiveFamiliar(id: string | null): void {
   safeSet(ACTIVE_KEY, id);
+}
+
+/**
+ * The persisted multiselect scope. Falls back to the legacy single
+ * `cave:active-familiar` (so existing users keep their scoped familiar) when no
+ * scope set has been written yet.
+ */
+export function getFamiliarScope(): string[] {
+  const raw = safeGet(SCOPE_KEY);
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (Array.isArray(parsed)) return parsed.filter((x): x is string => typeof x === "string");
+    } catch { /* corrupt — fall through to the legacy single key */ }
+  }
+  const single = getActiveFamiliar();
+  return single ? [single] : [];
+}
+
+/** Persist the scope set and keep the legacy single key in sync (lone id or null). */
+export function setFamiliarScope(ids: readonly string[]): void {
+  const deduped = [...new Set(ids.filter((x) => typeof x === "string"))];
+  safeSet(SCOPE_KEY, JSON.stringify(deduped));
+  setActiveFamiliar(deduped.length === 1 ? deduped[0]! : null);
 }
 
 export function getLastSurface(familiarId: string): string | null {

--- a/src/lib/familiar-multiselect.test.ts
+++ b/src/lib/familiar-multiselect.test.ts
@@ -5,7 +5,24 @@ import {
   selectAll,
   isAllSelected,
   automationMatchesFilter,
+  familiarInScope,
 } from "./familiar-multiselect.ts";
+
+test("familiarInScope: empty scope matches everything (incl. ownerless)", () => {
+  const all = new Set<string>();
+  assert.equal(familiarInScope(all, "nova"), true);
+  assert.equal(familiarInScope(all, null), true);
+  assert.equal(familiarInScope(all, undefined), true);
+});
+
+test("familiarInScope: non-empty scope matches only members; ownerless excluded", () => {
+  const scope = new Set(["nova", "salem"]);
+  assert.equal(familiarInScope(scope, "nova"), true);
+  assert.equal(familiarInScope(scope, "salem"), true);
+  assert.equal(familiarInScope(scope, "cody"), false);
+  assert.equal(familiarInScope(scope, null), false);
+  assert.equal(familiarInScope(scope, undefined), false);
+});
 
 test("plain click selects only that familiar", () => {
   const next = toggleFamiliarSelection(new Set(["nova"]), "salem", false);

--- a/src/lib/familiar-multiselect.ts
+++ b/src/lib/familiar-multiselect.ts
@@ -29,6 +29,20 @@ export function isAllSelected(selected: ReadonlySet<string>): boolean {
 }
 
 /**
+ * Does a single item (a card/event/etc. owned by `familiarId`) pass a scope
+ * selection? Empty scope → everything. A `null`/`undefined` owner only passes
+ * the "All" scope. Mirrors {@link automationMatchesFilter} for single-owner
+ * surfaces (board, calendar, inbox).
+ */
+export function familiarInScope(
+  scope: ReadonlySet<string>,
+  familiarId: string | null | undefined,
+): boolean {
+  if (scope.size === 0) return true;
+  return familiarId != null && scope.has(familiarId);
+}
+
+/**
  * Does an automation pass the filter? Empty filter → everything. Otherwise the
  * automation must be scoped to at least one selected familiar.
  */


### PR DESCRIPTION
## What

⌘/Ctrl-click avatars in the top-bar strip to scope the view to **multiple** familiars at once — the board filters to the **union**. A plain click still selects just one; an empty selection is "All".

### How
- **Scope is now a `Set<string>`** in `Workspace`; `activeFamiliarId` is **derived** as the single "primary" (the lone scoped id, else `null`). So every existing single-familiar idiom — chrome highlights, the header, per-familiar rail-tab/last-surface state — behaves **identically at 0–1 selections**; ≥2 is the only new case. A small `setActiveId` shim keeps all the single-select call sites unchanged.
- Reuses the already-tested `toggleFamiliarSelection` helper (empty Set = All, ⌘-click toggle) and adds a shared `familiarInScope(scope, id)` predicate.
- **Persistence:** `cave:familiar-scope` (JSON `string[]`); the legacy `cave:active-familiar` stays in sync as the lone/none primary so other readers (e.g. iOS) keep working.
- `FamiliarQuickSwitch` toggles on ⌘/Ctrl-click and highlights **every** scope member; `FamiliarMenuBar` threads `selectedFamiliarIds`; `BoardView` filters by the set.

### Scope of this PR
Wired for the **Board** (the primary scoped surface). Calendar (single-default model) and Journal/Inbox (Inbox/Automations has its own multiselect filter) continue to use the derived single-primary — at ≥2 selected they show "All". Easy follow-ups if you want them too.

## Verify

Rendered the real app (demo, 1440px):
- Plain-click Nova → scope `["nova"]`, 1 avatar highlighted, board = 21 cards.
- ⌘-click Sage → scope `["nova","sage"]`, **2** avatars highlighted, `cave:active-familiar` synced to `null`, board = **61** cards (the union grows).
- Tests: new `familiarInScope` unit tests; updated `familiar-quick-switch` / `board-view-familiar-scope` / `workspace-familiars-landing` source-text tests for the new shape. Full `test:app` (369) + `test:mobile` (18) green; typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)