### PR TITLE
feat(board): Gantt "group by Task" (step bars) + click-to-focus groups

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -15,11 +15,28 @@ type Props = {
   onSelect: (id: string) => void;
   /** Persist a card change — used to drag a bar to reschedule its dates. */
   onPatch?: (id: string, patch: Partial<Card>) => void;
+  /**
+   * "project" (default): one bar per scheduled task, grouped by project.
+   * "task": one group per task, one bar per checklist step (using step dates,
+   * falling back to the task's own range for undated steps).
+   */
+  groupMode?: "project" | "task";
 };
 
-type ScheduledCard = { card: Card; start: Date; end: Date };
-type Group = { key: string; name: string; tasks: ScheduledCard[]; firstStart: number };
 type GanttCategory = "done" | "in-progress" | "pending" | "at-risk";
+
+// A single timeline bar. In project mode it's a task; in task mode it's a step.
+type GanttRow = {
+  rowId: string;        // unique within the chart
+  cardId: string;       // the task this row belongs to (selected on click)
+  stepId?: string;      // set in task mode — the step this bar drags/patches
+  label: string;
+  owner: string;
+  start: Date;
+  end: Date;
+  category: GanttCategory;
+};
+type Group = { key: string; name: string; rows: GanttRow[]; firstStart: number };
 
 const DAY_W = 22; // px per day column — keep in sync with --cg-day in board.css
 const LEFT_W = 416; // sum of the left table columns — keep in sync with .cg-left
@@ -79,7 +96,9 @@ function statusCategory(status: CardStatus): GanttCategory {
   return "pending"; // backlog · inbox · review
 }
 
-export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelect, onPatch }: Props) {
+export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelect, onPatch, groupMode = "project" }: Props) {
+  // Click a group header to focus it (hide the others); click again to show all.
+  const [focusedKey, setFocusedKey] = useState<string | null>(null);
   // "Today" depends on the clock, so resolve it after mount to avoid an SSR
   // hydration mismatch — the line just isn't drawn on the first client render.
   const [todayMs, setTodayMs] = useState<number | null>(null);
@@ -94,14 +113,14 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
   // Suppresses the row's select-click that would otherwise fire after a drag.
   const suppressClickRef = useRef(false);
 
-  const beginDrag = (e: React.PointerEvent, cardId: string) => {
+  const beginDrag = (e: React.PointerEvent, rowId: string) => {
     if (!draggable) return;
     // Don't preventDefault — that would also swallow the click we rely on to
     // select a bar that was tapped (not dragged).
     e.stopPropagation();
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-    dragRef.current = { id: cardId, startX: e.clientX, moved: false };
-    setDrag({ id: cardId, deltaDays: 0 });
+    dragRef.current = { id: rowId, startX: e.clientX, moved: false };
+    setDrag({ id: rowId, deltaDays: 0 });
   };
   const moveDrag = (e: React.PointerEvent) => {
     const d = dragRef.current;
@@ -110,7 +129,7 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
     if (Math.abs(dx) > 3) d.moved = true;
     setDrag({ id: d.id, deltaDays: Math.round(dx / DAY_W) });
   };
-  const endDrag = (e: React.PointerEvent, card: Card) => {
+  const endDrag = (e: React.PointerEvent, row: GanttRow) => {
     const d = dragRef.current;
     const active = drag;
     dragRef.current = null;
@@ -118,65 +137,131 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
     if (!d) return;
     if (d.moved) suppressClickRef.current = true; // swallow the trailing click
     const delta = active?.deltaDays ?? 0;
-    if (d.moved && delta !== 0 && onPatch) {
+    if (!(d.moved && delta !== 0 && onPatch)) return;
+    const newStart = fmtISO(addDays(row.start, delta));
+    const newEnd = fmtISO(addDays(row.end, delta));
+    if (row.stepId) {
+      // Task mode: shift this step's dates (promoting a card-range fallback to
+      // explicit step dates), leaving the other steps untouched.
+      const card = cards.find((c) => c.id === row.cardId);
+      if (!card) return;
+      const steps = (card.steps ?? []).map((s) =>
+        s.id === row.stepId ? { ...s, startDate: newStart, endDate: newEnd } : s,
+      );
+      onPatch(row.cardId, { steps });
+    } else {
+      // Project mode: shift whichever of the task's own dates are set.
+      const card = cards.find((c) => c.id === row.cardId);
       const patch: Partial<Card> = {};
-      const s = parseDate(card.startDate);
-      const en = parseDate(card.endDate);
-      if (s) patch.startDate = fmtISO(addDays(s, delta));
-      if (en) patch.endDate = fmtISO(addDays(en, delta));
-      if (patch.startDate || patch.endDate) onPatch(card.id, patch);
+      if (parseDate(card?.startDate)) patch.startDate = newStart;
+      if (parseDate(card?.endDate)) patch.endDate = newEnd;
+      if (patch.startDate || patch.endDate) onPatch(row.cardId, patch);
     }
   };
-
-  const scheduled: ScheduledCard[] = [];
-  const unscheduled: Card[] = [];
-  for (const card of cards) {
-    const startDate = parseDate(card.startDate);
-    const endDate = parseDate(card.endDate);
-    if (!startDate && !endDate) {
-      unscheduled.push(card);
-      continue;
-    }
-    const start = startDate ?? endDate!;
-    const end = endDate ?? startDate!;
-    scheduled.push({ card, start: start <= end ? start : end, end: start <= end ? end : start });
-  }
-
-  if (scheduled.length === 0) {
-    return (
-      <div className="board-gantt board-gantt--empty">
-        <p>No tasks have start and end dates yet.</p>
-        {unscheduled.length > 0 ? (
-          <span>{unscheduled.length} task{unscheduled.length === 1 ? "" : "s"} without dates</span>
-        ) : null}
-      </div>
-    );
-  }
 
   const ownerName = (id: string | null): string =>
     (id ? familiars?.find((f) => f.id === id)?.display_name : undefined) ?? "—";
   const projectName = (id: string | null | undefined): string =>
     (id ? projects?.find((p) => p.id === id)?.name : undefined) ?? "No project";
 
-  // Group scheduled tasks by project, each group sorted by start date.
-  const groupMap = new Map<string, Group>();
-  for (const item of scheduled) {
-    const key = item.card.projectId ?? "__none__";
-    let group = groupMap.get(key);
-    if (!group) {
-      group = { key, name: projectName(item.card.projectId), tasks: [], firstStart: item.start.getTime() };
-      groupMap.set(key, group);
+  // A card's own date range; start/end fall back to each other. null if neither.
+  const cardRange = (card: Card): { start: Date; end: Date } | null => {
+    const s = parseDate(card.startDate);
+    const e = parseDate(card.endDate);
+    if (!s && !e) return null;
+    const a = s ?? e!;
+    const b = e ?? s!;
+    return a <= b ? { start: a, end: b } : { start: b, end: a };
+  };
+
+  const groups: Group[] = [];
+  const placedCardIds = new Set<string>();
+
+  if (groupMode === "task") {
+    // One group per task; one bar per step, placed by the step's own dates and
+    // falling back to the task's range for undated steps.
+    for (const card of cards) {
+      const steps = card.steps ?? [];
+      if (steps.length === 0) continue;
+      const cr = cardRange(card);
+      const rows: GanttRow[] = [];
+      for (const step of steps) {
+        let s = parseDate(step.startDate);
+        let e = parseDate(step.endDate);
+        if (!s && !e) {
+          if (!cr) continue; // no step dates and no task range — can't place it
+          s = cr.start;
+          e = cr.end;
+        }
+        const a = s ?? e!;
+        const b = e ?? s!;
+        rows.push({
+          rowId: `${card.id}:${step.id}`,
+          cardId: card.id,
+          stepId: step.id,
+          label: step.text,
+          owner: "",
+          start: a <= b ? a : b,
+          end: a <= b ? b : a,
+          category: step.done ? "done" : statusCategory(card.status),
+        });
+      }
+      if (rows.length === 0) continue;
+      placedCardIds.add(card.id);
+      groups.push({ key: card.id, name: card.title, rows, firstStart: Math.min(...rows.map((r) => r.start.getTime())) });
     }
-    group.tasks.push(item);
-    group.firstStart = Math.min(group.firstStart, item.start.getTime());
-  }
-  const groups = [...groupMap.values()].sort((a, b) => a.firstStart - b.firstStart);
-  for (const g of groups) {
-    g.tasks.sort((a, b) => a.start.getTime() - b.start.getTime() || a.end.getTime() - b.end.getTime());
+  } else {
+    // One group per project; one bar per scheduled task.
+    const groupMap = new Map<string, Group>();
+    for (const card of cards) {
+      const cr = cardRange(card);
+      if (!cr) continue;
+      placedCardIds.add(card.id);
+      const key = card.projectId ?? "__none__";
+      let group = groupMap.get(key);
+      if (!group) {
+        group = { key, name: projectName(card.projectId), rows: [], firstStart: cr.start.getTime() };
+        groupMap.set(key, group);
+      }
+      group.rows.push({
+        rowId: card.id,
+        cardId: card.id,
+        label: card.title,
+        owner: ownerName(card.familiarId),
+        start: cr.start,
+        end: cr.end,
+        category: statusCategory(card.status),
+      });
+      group.firstStart = Math.min(group.firstStart, cr.start.getTime());
+    }
+    groups.push(...groupMap.values());
   }
 
-  const min = new Date(Math.min(...scheduled.map((i) => i.start.getTime())));
-  const max = new Date(Math.max(...scheduled.map((i) => i.end.getTime())));
+  groups.sort((a, b) => a.firstStart - b.firstStart);
+  for (const g of groups) {
+    g.rows.sort((a, b) => a.start.getTime() - b.start.getTime() || a.end.getTime() - b.end.getTime());
+  }
+
+  const allRows = groups.flatMap((g) => g.rows);
+  const unscheduledCount = cards.filter((c) => !placedCardIds.has(c.id)).length;
+
+  if (allRows.length === 0) {
+    return (
+      <div className="board-gantt board-gantt--empty">
+        <p>{groupMode === "task" ? "No tasks have steps with dates yet." : "No tasks have start and end dates yet."}</p>
+        {unscheduledCount > 0 ? (
+          <span>{unscheduledCount} task{unscheduledCount === 1 ? "" : "s"} without dates</span>
+        ) : null}
+      </div>
+    );
+  }
+
+  // Focus: when a group is clicked, render only it (range stays global so bars don't jump).
+  const focused = focusedKey && groups.some((g) => g.key === focusedKey) ? focusedKey : null;
+  const visibleGroups = focused ? groups.filter((g) => g.key === focused) : groups;
+
+  const min = new Date(Math.min(...allRows.map((r) => r.start.getTime())));
+  const max = new Date(Math.max(...allRows.map((r) => r.end.getTime())));
   const rangeStart = startOfWeekMon(min);
   const rangeEnd = addDays(startOfWeekMon(max), 7); // complete the final week
   const totalDays = Math.max(7, daysBetween(rangeStart, rangeEnd));
@@ -225,48 +310,55 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
               </span>
             ) : null}
 
-            {groups.map((g) => (
+            {visibleGroups.map((g) => (
               <div key={g.key} className="cg-group">
-                <div className="cg-grouprow">
-                  <div className="cg-left cg-left--group">
-                    <span className="cg-caret" aria-hidden>▾</span>
+                <button
+                  type="button"
+                  className={`cg-grouprow cg-grouprow--btn${focused === g.key ? " cg-grouprow--focused" : ""}`}
+                  onClick={() => setFocusedKey((cur) => (cur === g.key ? null : g.key))}
+                  aria-pressed={focused === g.key}
+                  title={focused === g.key ? "Show all groups" : `Focus ${g.name}`}
+                >
+                  <span className="cg-left cg-left--group">
+                    <span className="cg-caret" aria-hidden>{focused === g.key ? "▸" : "▾"}</span>
                     <span className="cg-groupname">{g.name}</span>
-                    <span className="cg-count">{g.tasks.length}</span>
-                  </div>
-                  <div className="cg-grouptl" style={{ width: `${timelineW}px` }} aria-hidden />
-                </div>
+                    <span className="cg-count">{g.rows.length}</span>
+                  </span>
+                  <span className="cg-grouptl" style={{ width: `${timelineW}px` }} aria-hidden />
+                </button>
 
-                {g.tasks.map(({ card, start, end }) => {
-                  const cat = statusCategory(card.status);
+                {g.rows.map((row) => {
+                  const { start, end } = row;
+                  const cat = row.category;
                   const offset = Math.max(0, daysBetween(rangeStart, start));
                   const dur = Math.max(1, daysBetween(start, end) + 1);
                   const milestone = dur === 1;
-                  const dragDelta = drag?.id === card.id ? drag.deltaDays : 0;
-                  const dragging = drag?.id === card.id && dragDelta !== 0;
+                  const dragDelta = drag?.id === row.rowId ? drag.deltaDays : 0;
+                  const dragging = drag?.id === row.rowId && dragDelta !== 0;
                   const left = (offset + dragDelta) * DAY_W;
                   const barClass = (base: string) =>
                     `${base}${draggable ? " cg-bar--grab" : ""}${dragging ? " cg-bar--dragging" : ""}`;
                   const handlers = draggable
                     ? {
-                        onPointerDown: (e: React.PointerEvent) => beginDrag(e, card.id),
+                        onPointerDown: (e: React.PointerEvent) => beginDrag(e, row.rowId),
                         onPointerMove: moveDrag,
-                        onPointerUp: (e: React.PointerEvent) => endDrag(e, card),
+                        onPointerUp: (e: React.PointerEvent) => endDrag(e, row),
                       }
                     : {};
                   return (
                     <button
-                      key={card.id}
+                      key={row.rowId}
                       type="button"
-                      className={`cg-row${selectedCardId === card.id ? " cg-row--sel" : ""}`}
+                      className={`cg-row${selectedCardId === row.cardId ? " cg-row--sel" : ""}`}
                       onClick={() => {
                         if (suppressClickRef.current) { suppressClickRef.current = false; return; }
-                        onSelect(card.id);
+                        onSelect(row.cardId);
                       }}
-                      title={`${card.title} · ${formatLabel(addDays(start, dragDelta))}–${formatLabel(addDays(end, dragDelta))}${draggable ? " · drag to reschedule" : ""}`}
+                      title={`${row.label} · ${formatLabel(addDays(start, dragDelta))}–${formatLabel(addDays(end, dragDelta))}${draggable ? " · drag to reschedule" : ""}`}
                     >
                       <span className="cg-left">
-                        <span className="cg-c-task">{card.title}</span>
-                        <span className="cg-c-owner">{ownerName(card.familiarId)}</span>
+                        <span className="cg-c-task">{row.label}</span>
+                        <span className="cg-c-owner">{row.owner}</span>
                         <span className="cg-c-date">{formatLabel(addDays(start, dragDelta))}</span>
                         <span className="cg-c-date">{formatLabel(addDays(end, dragDelta))}</span>
                         <span className="cg-c-st"><span className={`cg-dot cg-dot--${cat}`} aria-hidden /></span>
@@ -312,9 +404,9 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
           </div>
         </div>
       </div>
-      {unscheduled.length > 0 ? (
+      {unscheduledCount > 0 ? (
         <div className="board-gantt-unscheduled">
-          {unscheduled.length} task{unscheduled.length === 1 ? "" : "s"} without dates
+          {unscheduledCount} task{unscheduledCount === 1 ? "" : "s"} {groupMode === "task" ? "without scheduled steps" : "without dates"}
         </div>
       ) : null}
     </div>

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -652,6 +652,13 @@ function StepsSection({
     onPatch(card.id, { steps: steps.filter((s) => s.id !== id) });
   }
 
+  // Schedule a step on the Gantt (group-by-task). Empty string clears the date.
+  function setStepDate(id: string, field: "startDate" | "endDate", value: string) {
+    onPatch(card.id, {
+      steps: steps.map((s) => (s.id === id ? { ...s, [field]: value || null } : s)),
+    });
+  }
+
   function reorderStep(id: string, dir: -1 | 1) {
     const idx = steps.findIndex((s) => s.id === id);
     if (idx < 0) return;
@@ -714,6 +721,7 @@ function StepsSection({
               key={step.id}
               style={{
                 display: "flex",
+                flexWrap: "wrap",
                 alignItems: "flex-start",
                 gap: 8,
                 padding: "6px 8px",
@@ -776,6 +784,25 @@ function StepsSection({
                   <Icon name="ph:x-bold" width={9} />
                 </button>
               </span>
+
+              {/* Step schedule — places this step on the Gantt under "group by Task". */}
+              <div style={{ display: "flex", flexBasis: "100%", gap: 6, alignItems: "center", paddingLeft: 23 }}>
+                <input
+                  type="date"
+                  aria-label={`Start date for step: ${step.text}`}
+                  value={step.startDate ?? ""}
+                  onChange={(e) => setStepDate(step.id, "startDate", e.target.value)}
+                  style={{ fontSize: 11, padding: "1px 4px", borderRadius: 4, border: "1px solid var(--border-hairline)", background: "var(--bg-base)", color: "var(--text-secondary)" }}
+                />
+                <span style={{ fontSize: 11, color: "var(--text-muted)" }} aria-hidden>→</span>
+                <input
+                  type="date"
+                  aria-label={`End date for step: ${step.text}`}
+                  value={step.endDate ?? ""}
+                  onChange={(e) => setStepDate(step.id, "endDate", e.target.value)}
+                  style={{ fontSize: 11, padding: "1px 4px", borderRadius: 4, border: "1px solid var(--border-hairline)", background: "var(--bg-base)", color: "var(--text-secondary)" }}
+                />
+              </div>
             </li>
           ))}
         </ul>

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -47,6 +47,9 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
   const [actionError, setActionError] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>(() => loadPref("cave:board:viewMode", "kanban", ["kanban", "table", "gantt"]));
   const [groupBy, setGroupBy] = useState<GroupBy>(() => loadPref("cave:board:groupBy", "status", ["status", "familiar", "project"]));
+  // Gantt has its own grouping: by project (one bar per task) or by task (one
+  // bar per checklist step). Separate from the kanban/table groupBy above.
+  const [ganttGroup, setGanttGroup] = useState<"project" | "task">(() => loadPref("cave:board:ganttGroup", "project", ["project", "task"]) as "project" | "task");
   const [searchQuery, setSearchQuery] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
@@ -107,6 +110,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
   }, [load]);
   useEffect(() => { localStorage.setItem("cave:board:viewMode", viewMode); }, [viewMode]);
   useEffect(() => { localStorage.setItem("cave:board:groupBy", groupBy); }, [groupBy]);
+  useEffect(() => { localStorage.setItem("cave:board:ganttGroup", ganttGroup); }, [ganttGroup]);
 
   // External create paths dispatch `cave:board:reload` after POST so the board
   // picks up the new card without a full surface remount.
@@ -380,7 +384,28 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
               "Project". The Familiar option is dropped while the board is
               already scoped to one familiar, where it would be redundant. */}
           {showGroupToggle ? (
-            <div className="board-group-toggle" role="group" aria-label="Group tasks by">
+            <div className="board-group-toggle" role="group" aria-label={viewMode === "gantt" ? "Group Gantt by" : "Group tasks by"}>
+            {viewMode === "gantt" ? (
+              <>
+                <button
+                  type="button"
+                  className={`board-group-toggle-btn${ganttGroup === "project" ? " board-group-toggle-btn--active" : ""}`}
+                  onClick={() => setGanttGroup("project")}
+                  aria-pressed={ganttGroup === "project"}
+                >
+                  Project
+                </button>
+                <button
+                  type="button"
+                  className={`board-group-toggle-btn${ganttGroup === "task" ? " board-group-toggle-btn--active" : ""}`}
+                  onClick={() => setGanttGroup("task")}
+                  aria-pressed={ganttGroup === "task"}
+                >
+                  Task
+                </button>
+              </>
+            ) : (
+              <>
             <button
               type="button"
               className={`board-group-toggle-btn${effectiveGroupBy === "status" ? " board-group-toggle-btn--active" : ""}`}
@@ -407,6 +432,8 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
             >
               Project
             </button>
+              </>
+            )}
             </div>
           ) : null}
 
@@ -619,7 +646,8 @@ export function BoardView({ familiars, sessions, activeFamiliarId, onJumpToSessi
           <BoardGantt cards={filtered} familiars={familiars} projects={projects}
             selectedCardId={selectedCardId}
             onSelect={setSelectedCardId}
-            onPatch={patchCard} />
+            onPatch={patchCard}
+            groupMode={ganttGroup} />
         ) : (
           <BoardTable cards={filtered} familiars={familiars} projects={projects}
             groupBy={effectiveGroupBy} selectedCardId={selectedCardId}

--- a/src/lib/cave-board-types.ts
+++ b/src/lib/cave-board-types.ts
@@ -15,6 +15,8 @@ export type CardStep = {
   done: boolean;     // completed?
   addedAt: string;   // ISO timestamp when step was created
   doneAt?: string;   // ISO timestamp when step was checked off
+  startDate?: string | null; // YYYY-MM-DD — schedules the step on the Gantt (group-by-task)
+  endDate?: string | null;   // YYYY-MM-DD
 };
 
 export type CardGitHubKind = "repo" | "issue" | "pr" | "discussion" | "review_request" | "notification";


### PR DESCRIPTION
Two Gantt enhancements (from the two requests):

**1. Group by Task.** The Gantt gets a **Project | Task** grouping toggle (gantt view only, persisted). In **Task** mode each task is a group and its checklist **steps** are the bars:
- `CardStep` gains optional `startDate`/`endDate` (the board store already round-trips steps verbatim — no persistence change needed).
- Step bars are placed by the step's own dates, **falling back to the task's range** for undated steps; dragging a step bar promotes/shifts just that step's dates; done steps use the "done" colour.
- The **inspector** step list gains per-step start/end date inputs to schedule them.

**2. Click-to-focus.** Clicking a group header **focuses it and hides the others** (click again to show all) — works in both Project and Task modes. The timeline range stays global so bars don't jump.

`board-gantt` was generalized to a `GanttRow` model feeding the same bar renderer for both modes, preserving the `board-gantt-row__bar` / `cg-*` markup the tests pin. The group toggle stays gated behind `showGroupToggle` (test-pinned), branching its buttons on `viewMode`.

typecheck clean · `board-grouping` + `board-schedule-window` green · `pnpm test:app` 369 · `pnpm test:mobile` 18. Live verification attached in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)