### PR TITLE
feat(familiars): extend multiselect scope to Calendar + Journal

### DIFF
--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -10,6 +10,7 @@ import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { SnoozeMenu } from "@/components/snooze-menu";
 import { itemDate, packEventColumns } from "@/lib/calendar-layout";
+import { familiarInScope } from "@/lib/familiar-multiselect";
 import { useIsMobile } from "@/lib/use-viewport";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -35,6 +36,9 @@ type Props = {
    *  Defensive null escape: bypass the familiar filter entirely. Mirrors
    *  BoardView's hard-scope. */
   activeFamiliarId?: string | null;
+  /** Multiselect scope (empty = All). When supplied, the calendar filters to
+   *  the union of these familiars; takes precedence over `activeFamiliarId`. */
+  scopeFamiliarIds?: ReadonlySet<string>;
   onAddEntry?: (defaults?: { fireAt?: string; title?: string; whenText?: string }) => void;
   onOpenItem?: (item: InboxItem) => void;
   /** Reschedule an item to a new time (drag-and-drop). Optimistic; SSE reconciles. */
@@ -1307,7 +1311,7 @@ function ItemDetailPanel({
 
 // ─── Main CalendarView ────────────────────────────────────────────────────────
 
-export function CalendarView({ items, familiars, activeFamiliarId, deadlines, onAddEntry, onOpenItem, onReschedule, onComplete, onDismiss, onSnooze, onOpenDeadline }: Props) {
+export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliarIds, deadlines, onAddEntry, onOpenItem, onReschedule, onComplete, onDismiss, onSnooze, onOpenDeadline }: Props) {
   const isMobile = useIsMobile();
   // SSR returns false from useIsMobile, so initial render is always "week"
   // on the server; the effect below snaps to agenda on mount when the
@@ -1327,25 +1331,30 @@ export function CalendarView({ items, familiars, activeFamiliarId, deadlines, on
 
   // Hard-scope: filter every downstream view (agenda/day/week/month) to the
   // active familiar. Defensive null escape: bypass the filter entirely.
+  const inScope = useMemo(
+    () =>
+      (familiarId: string | null | undefined): boolean =>
+        scopeFamiliarIds
+          ? familiarInScope(scopeFamiliarIds, familiarId)
+          : activeFamiliarId == null || familiarId === activeFamiliarId,
+    [scopeFamiliarIds, activeFamiliarId],
+  );
+
   const scopedItems = useMemo(
     () =>
-      (activeFamiliarId == null
-        ? items
-        : items.filter((it) => it.familiarId === activeFamiliarId)
-      // Dismissed items are removed from the calendar so a Dismiss reads as
-      // "gone"; done items stay (rendered with a completed treatment).
-      ).filter((it) => it.status !== "dismissed"),
-    [items, activeFamiliarId],
+      items
+        .filter((it) => inScope(it.familiarId))
+        // Dismissed items are removed from the calendar so a Dismiss reads as
+        // "gone"; done items stay (rendered with a completed treatment).
+        .filter((it) => it.status !== "dismissed"),
+    [items, inScope],
   );
 
   // Mirror the items hard-scope for deadlines, so a scoped familiar's calendar
   // only shows that familiar's task due-dates.
   const scopedDeadlines = useMemo(
-    () =>
-      activeFamiliarId == null
-        ? (deadlines ?? [])
-        : (deadlines ?? []).filter((d) => d.familiarId === activeFamiliarId),
-    [deadlines, activeFamiliarId],
+    () => (deadlines ?? []).filter((d) => inScope(d.familiarId)),
+    [deadlines, inScope],
   );
 
   useEffect(() => {

--- a/src/components/inbox-calendar-familiar-scope.test.ts
+++ b/src/components/inbox-calendar-familiar-scope.test.ts
@@ -34,10 +34,22 @@ assert.match(
   "CalendarView must accept an optional activeFamiliarId prop",
 );
 
+// The scope predicate honors the multiselect set (empty = All) and falls back
+// to the single activeFamiliarId; scopedItems filters every sub-view through it.
 assert.match(
   calendar,
-  /const scopedItems = useMemo[\s\S]*?it\.familiarId === activeFamiliarId[\s\S]*?\[items, activeFamiliarId\]/,
-  "Calendar must derive a scopedItems memo filtering on item.familiarId",
+  /scopeFamiliarIds\s*\?\s*familiarInScope\(scopeFamiliarIds, familiarId\)\s*:\s*activeFamiliarId == null \|\| familiarId === activeFamiliarId/,
+  "Calendar's scope predicate uses the multiselect set, falling back to activeFamiliarId",
+);
+assert.match(
+  calendar,
+  /const scopedItems = useMemo[\s\S]*?\.filter\(\(it\) => inScope\(it\.familiarId\)\)[\s\S]*?\[items, inScope\]/,
+  "Calendar must derive a scopedItems memo filtering by the scope predicate",
+);
+assert.match(
+  calendar,
+  /const scopedDeadlines = useMemo[\s\S]*?\.filter\(\(d\) => inScope\(d\.familiarId\)\)/,
+  "Calendar deadlines respect the same scope predicate",
 );
 
 for (const view of ["AgendaView", "DayView", "WeekView", "MonthView"]) {

--- a/src/components/journal/journal-entries.tsx
+++ b/src/components/journal/journal-entries.tsx
@@ -10,7 +10,12 @@ import { extractNextPaths } from "@/lib/next-paths";
 import { dateSlug, longDateLabel, relativeDayLabel, relativeTime, parseDateSlug } from "@/lib/daily-report";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import { generateReflection } from "@/lib/journal-generate";
+import { familiarInScope } from "@/lib/familiar-multiselect";
 import type { Familiar } from "@/lib/types";
+
+// Stable empty-scope fallback so the filteredDays memo's identity is steady
+// when no scope set is supplied.
+const EMPTY_SCOPE: ReadonlySet<string> = new Set();
 
 type JournalSummary = { date: string; preview: string; reflectedBy: string | null; modified: string | null };
 type JournalStats = { covenOrigin: number; externalRuntimes: number; runtimeMemory: number };
@@ -49,9 +54,13 @@ function JournalReflection({ text }: { text: string }) {
 export function JournalEntries({
   familiars,
   activeFamiliarId,
+  scopeFamiliarIds,
 }: {
   familiars: Familiar[];
   activeFamiliarId: string | null;
+  /** Multiselect scope (empty = All) — the reflections list filters to days
+   *  whose `reflectedBy` is in this set. */
+  scopeFamiliarIds?: ReadonlySet<string>;
 }) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const today = dateSlug(new Date());
@@ -76,10 +85,12 @@ export function JournalEntries({
   // Client-side filter over the day list — matches the date (slug + human
   // labels), the preview text, and the reflecting familiar's name.
   const filteredDays = useMemo(() => {
+    const scope = scopeFamiliarIds ?? EMPTY_SCOPE;
     const q = filter.trim().toLowerCase();
-    if (!q) return days;
     const now = new Date();
     return days.filter((d) => {
+      if (!familiarInScope(scope, d.reflectedBy)) return false;
+      if (!q) return true;
       const dateObj = parseDateSlug(d.date) ?? now;
       const hay = [
         d.date,
@@ -92,12 +103,13 @@ export function JournalEntries({
         .toLowerCase();
       return hay.includes(q);
     });
-  }, [days, filter, familiarName]);
+  }, [days, filter, familiarName, scopeFamiliarIds]);
 
+  // Fetch the full day list once; the familiar multiselect scope is applied
+  // client-side in `filteredDays` so switching scope never needs a refetch.
   const loadDays = useCallback(async () => {
     try {
-      const listQuery = selectedFamiliarId ? `?familiar=${encodeURIComponent(selectedFamiliarId)}` : "";
-      const res = await fetch(`/api/journal${listQuery}`, { cache: "no-store" });
+      const res = await fetch(`/api/journal`, { cache: "no-store" });
       const json = await res.json().catch(() => ({}));
       if (json.ok) setDays(Array.isArray(json.days) ? json.days : []);
     } catch {
@@ -105,12 +117,14 @@ export function JournalEntries({
     } finally {
       setDaysLoaded(true);
     }
-  }, [selectedFamiliarId]);
+  }, []);
 
   const loadDay = useCallback(async (slug: string) => {
     try {
-      const detailQuery = selectedFamiliarId
-        ? `date=${encodeURIComponent(slug)}&familiar=${encodeURIComponent(selectedFamiliarId)}`
+      // Scope the day's memory stats to the single active familiar; with 0 or
+      // ≥ 2 selected (activeFamiliarId null) the record + stats are unscoped.
+      const detailQuery = activeFamiliarId
+        ? `date=${encodeURIComponent(slug)}&familiar=${encodeURIComponent(activeFamiliarId)}`
         : `date=${encodeURIComponent(slug)}`;
       const res = await fetch(`/api/journal?${detailQuery}`, { cache: "no-store" });
       const json = await res.json().catch(() => ({}));
@@ -118,7 +132,7 @@ export function JournalEntries({
     } catch {
       setDay(null);
     }
-  }, [selectedFamiliarId]);
+  }, [activeFamiliarId]);
 
   useEffect(() => {
     void loadDays();

--- a/src/components/journal/journal-view.test.ts
+++ b/src/components/journal/journal-view.test.ts
@@ -77,8 +77,12 @@ assert.match(entries, /onKeyDown=\{\(e\) => \{[\s\S]*?e\.key === "Escape"[\s\S]*
 
 // JournalEntries is scoped to the selected familiar and its memory coverage.
 assert.match(entries, /const selectedFamiliarId = activeFamiliarId \?\? familiars\[0\]\?\.id \?\? null/, "JournalEntries derives one selected familiar scope");
-assert.match(entries, /const listQuery = selectedFamiliarId \? `\?familiar=\$\{encodeURIComponent\(selectedFamiliarId\)\}` : ""/, "JournalEntries loads only selected-familiar journal summaries");
-assert.match(entries, /const detailQuery = selectedFamiliarId\s*\?\s*`date=\$\{encodeURIComponent\(slug\)\}&familiar=\$\{encodeURIComponent\(selectedFamiliarId\)\}`\s*:\s*`date=\$\{encodeURIComponent\(slug\)\}`/, "JournalEntries loads selected-familiar journal details");
+// The list is now fetched whole and filtered client-side by the multiselect
+// scope (empty = All), so switching familiars/scope never refetches.
+assert.match(entries, /await fetch\(`\/api\/journal`, \{ cache: "no-store" \}\)/, "JournalEntries fetches the full journal day list");
+assert.match(entries, /if \(!familiarInScope\(scope, d\.reflectedBy\)\) return false/, "JournalEntries filters the day list by the familiar multiselect scope");
+// The day detail scopes its memory stats to the single active familiar (null at 0/≥ 2).
+assert.match(entries, /const detailQuery = activeFamiliarId\s*\?\s*`date=\$\{encodeURIComponent\(slug\)\}&familiar=\$\{encodeURIComponent\(activeFamiliarId\)\}`\s*:\s*`date=\$\{encodeURIComponent\(slug\)\}`/, "JournalEntries scopes day detail stats to the active familiar");
 assert.match(entries, /day\.stats\.covenOrigin[\s\S]*?coven files/, "Journal stats include Coven-origin memory files");
 assert.match(entries, /day\.stats\.externalRuntimes[\s\S]*?external runtime files/, "Journal stats include external runtime memory files");
 assert.match(entries, /day\.stats\.runtimeMemory[\s\S]*?runtime files/, "Journal stats include runtime memory files");

--- a/src/components/journal/journal-view.tsx
+++ b/src/components/journal/journal-view.tsx
@@ -22,9 +22,13 @@ function isTab(v: unknown): v is JournalTab {
 export function JournalView({
   familiars,
   activeFamiliarId,
+  scopeFamiliarIds,
 }: {
   familiars: Familiar[];
   activeFamiliarId: string | null;
+  /** Multiselect scope (empty = All) — filters the reflections list to the
+   *  union of these familiars. */
+  scopeFamiliarIds?: ReadonlySet<string>;
 }) {
   const [tab, setTab] = useState<JournalTab>("journal");
 
@@ -84,7 +88,7 @@ export function JournalView({
         {tab === "canvas" ? (
           <CanvasList familiars={familiars} activeFamiliarId={activeFamiliarId} />
         ) : (
-          <JournalEntries familiars={familiars} activeFamiliarId={activeFamiliarId} />
+          <JournalEntries familiars={familiars} activeFamiliarId={activeFamiliarId} scopeFamiliarIds={scopeFamiliarIds} />
         )}
       </div>
     </div>

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1798,7 +1798,7 @@ export function Workspace() {
         }}
       />
     ) : mode === "journal" ? (
-      <JournalView familiars={familiars} activeFamiliarId={activeId} />
+      <JournalView familiars={familiars} activeFamiliarId={activeId} scopeFamiliarIds={scopeIds} />
     ) : mode === "inbox" ? (
       <InboxEscalationsView
         onOpenSource={(item) => {
@@ -1855,6 +1855,7 @@ export function Workspace() {
         items={inboxItems}
         familiars={familiars}
         activeFamiliarId={calendarFamiliarId}
+        scopeFamiliarIds={scopeIds}
         deadlines={boardDeadlines}
         onOpenDeadline={(id) => {
           setMode("board");


### PR DESCRIPTION
## What

Follow-up to #1625 — the top-bar familiar **multiselect** now also filters the **Calendar** and the **Journal** reflections list (the Board already did).

- **CalendarView:** a shared `inScope` predicate (`familiarInScope` when a scope set is supplied, else the single `activeFamiliarId`) drives both `scopedItems` and `scopedDeadlines`. Workspace passes `scopeFamiliarIds={scopeIds}`.
- **JournalEntries:** fetches the full day list once and filters client-side by `reflectedBy ∈ scope` (no API change). Day-detail memory stats stay scoped to the single active familiar (unscoped at 0/≥2). Workspace → JournalView → JournalEntries thread the scope.
- **Empty scope now means truly All** on both surfaces — previously both defaulted to the first familiar (`activeFamiliarId ?? familiars[0]`), so "All familiars" showed only one. This is the consistent/correct behavior.

## Verify

- `pnpm typecheck` clean; full `test:app` **369 files green** (updated the `journal-view` + `inbox-calendar-familiar-scope` source-text tests for the new shape).
- The Board multiselect (#1625) was runtime-verified (Nova=21 → Nova+Sage=61 cards). Calendar/Journal reuse the identical `familiarInScope` predicate.

> Note: built via the repo's atomic worktree pattern after build worktrees repeatedly vanished under heavy concurrency (10 live sessions); the exact diff was typecheck- + test-verified before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)