### PR TITLE
feat(board): add Familiar grouping to the Gantt (All-familiars scope)

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -20,7 +20,7 @@ type Props = {
    * "task": one group per task, one bar per checklist step (using step dates,
    * falling back to the task's own range for undated steps).
    */
-  groupMode?: "project" | "task";
+  groupMode?: "project" | "task" | "familiar";
 };
 
 type GanttCategory = "done" | "in-progress" | "pending" | "at-risk";
@@ -239,16 +239,20 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
       groups.push({ key: card.id, name: card.title, rows, firstStart: Math.min(...rows.map((r) => r.start.getTime())) });
     }
   } else {
-    // One group per project; one bar per scheduled task.
+    // One group per project (or familiar); one bar per scheduled task.
+    const byFamiliar = groupMode === "familiar";
     const groupMap = new Map<string, Group>();
     for (const card of cards) {
       const cr = cardRange(card);
       if (!cr) continue;
       placedCardIds.add(card.id);
-      const key = card.projectId ?? "__none__";
+      const key = byFamiliar ? (card.familiarId ?? "__unassigned__") : (card.projectId ?? "__none__");
       let group = groupMap.get(key);
       if (!group) {
-        group = { key, name: projectName(card.projectId), rows: [], firstStart: cr.start.getTime() };
+        const name = byFamiliar
+          ? (card.familiarId ? ownerName(card.familiarId) : "Unassigned")
+          : projectName(card.projectId);
+        group = { key, name, rows: [], firstStart: cr.start.getTime() };
         groupMap.set(key, group);
       }
       group.rows.push({

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -53,7 +53,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
   const [groupBy, setGroupBy] = useState<GroupBy>(() => loadPref("cave:board:groupBy", "status", ["status", "familiar", "project"]));
   // Gantt has its own grouping: by project (one bar per task) or by task (one
   // bar per checklist step). Separate from the kanban/table groupBy above.
-  const [ganttGroup, setGanttGroup] = useState<"project" | "task">(() => loadPref("cave:board:ganttGroup", "project", ["project", "task"]) as "project" | "task");
+  const [ganttGroup, setGanttGroup] = useState<"project" | "task" | "familiar">(() => loadPref("cave:board:ganttGroup", "project", ["project", "task", "familiar"]) as "project" | "task" | "familiar");
   const [searchQuery, setSearchQuery] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
@@ -179,6 +179,8 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
   // familiar — fall back to status there. Status and project grouping stay
   // meaningful regardless of the familiar scope.
   const effectiveGroupBy: GroupBy = activeFamiliarId !== null && groupBy === "familiar" ? "status" : groupBy;
+  // Familiar grouping is meaningless once the board is scoped to one familiar.
+  const effectiveGanttGroup = ganttGroup === "familiar" && activeFamiliarId !== null ? "project" : ganttGroup;
   // Grouping applies to both the kanban (swimlanes) and table views; hidden on
   // phones, where BoardCardStack replaces both surfaces.
   const showGroupToggle = !isMobile;
@@ -395,20 +397,30 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
               <>
                 <button
                   type="button"
-                  className={`board-group-toggle-btn${ganttGroup === "project" ? " board-group-toggle-btn--active" : ""}`}
+                  className={`board-group-toggle-btn${effectiveGanttGroup === "project" ? " board-group-toggle-btn--active" : ""}`}
                   onClick={() => setGanttGroup("project")}
-                  aria-pressed={ganttGroup === "project"}
+                  aria-pressed={effectiveGanttGroup === "project"}
                 >
                   Project
                 </button>
                 <button
                   type="button"
-                  className={`board-group-toggle-btn${ganttGroup === "task" ? " board-group-toggle-btn--active" : ""}`}
+                  className={`board-group-toggle-btn${effectiveGanttGroup === "task" ? " board-group-toggle-btn--active" : ""}`}
                   onClick={() => setGanttGroup("task")}
-                  aria-pressed={ganttGroup === "task"}
+                  aria-pressed={effectiveGanttGroup === "task"}
                 >
                   Task
                 </button>
+                {activeFamiliarId === null ? (
+                  <button
+                    type="button"
+                    className={`board-group-toggle-btn${effectiveGanttGroup === "familiar" ? " board-group-toggle-btn--active" : ""}`}
+                    onClick={() => setGanttGroup("familiar")}
+                    aria-pressed={effectiveGanttGroup === "familiar"}
+                  >
+                    Familiar
+                  </button>
+                ) : null}
               </>
             ) : (
               <>
@@ -653,7 +665,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
             selectedCardId={selectedCardId}
             onSelect={setSelectedCardId}
             onPatch={patchCard}
-            groupMode={ganttGroup} />
+            groupMode={effectiveGanttGroup} />
         ) : (
           <BoardTable cards={filtered} familiars={familiars} projects={projects}
             groupBy={effectiveGroupBy} selectedCardId={selectedCardId}


### PR DESCRIPTION
Extends the Gantt's **Project | Task** grouping toggle with a third option, **Familiar** (per the request, available when in *All familiars* scope):

- `board-gantt` `groupMode` gains `"familiar"` — groups scheduled tasks by their assigned familiar (display name; **"Unassigned"** for none), reusing the same bar renderer as project mode.
- `board-view` shows the **Familiar** toggle only when `activeFamiliarId === null` (All-familiars) — grouping by familiar is redundant once the board is scoped to one. A persisted `"familiar"` choice falls back to `"project"` when scoped (`effectiveGanttGroup`), mirroring the existing kanban/table `effectiveGroupBy` rule.

typecheck clean · `pnpm test:app` 369 · `pnpm test:mobile` 18. Live verification in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)