### PR TITLE
feat(ios): manage tasks (status, priority, steps, delete) from the Tasks tab

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -112,6 +112,42 @@ struct CaveClient {
     @discardableResult
     func updateTaskSession(cardId: String, sessionId: String?) async throws -> BoardCard {
         let payload = try JSONEncoder().encode(SessionPatch(sessionId: sessionId))
+        return try await patchTask(cardId: cardId, payload: payload)
+    }
+
+    /// Fields a task edit can carry. Only the non-nil ones are sent, since the
+    /// board patch updates a field only when its key is present in the body.
+    struct TaskFieldsPatch: Encodable {
+        var status: CardStatus?
+        var priority: CardPriority?
+        var steps: [CardStep]?
+        enum CodingKeys: String, CodingKey { case status, priority, steps }
+        func encode(to encoder: Encoder) throws {
+            var c = encoder.container(keyedBy: CodingKeys.self)
+            if let status { try c.encode(status.rawValue, forKey: .status) }
+            if let priority { try c.encode(priority.rawValue, forKey: .priority) }
+            if let steps { try c.encode(steps, forKey: .steps) }
+        }
+    }
+
+    /// PATCH a task's editable fields (status, priority, steps). Returns the
+    /// server's updated card.
+    @discardableResult
+    func updateTask(cardId: String, status: CardStatus? = nil,
+                    priority: CardPriority? = nil, steps: [CardStep]? = nil) async throws -> BoardCard {
+        let payload = try JSONEncoder().encode(
+            TaskFieldsPatch(status: status, priority: priority, steps: steps))
+        return try await patchTask(cardId: cardId, payload: payload)
+    }
+
+    /// `DELETE /api/board/{id}` — remove a task.
+    func deleteTask(cardId: String) async throws {
+        let req = try request("api/board/\(cardId)", method: "DELETE")
+        let (_, resp) = try await session.data(for: req)
+        try Self.check(resp)
+    }
+
+    private func patchTask(cardId: String, payload: Data) async throws -> BoardCard {
         let req = try request("api/board/\(cardId)", method: "PATCH", body: payload)
         let (data, resp) = try await session.data(for: req)
         try Self.check(resp)

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -144,6 +144,74 @@ final class AppModel {
         tasksLoaded = true
     }
 
+    // MARK: - Task actions
+
+    /// Optimistically set a task's status, then reconcile with the server's
+    /// echoed card (it stamps lifecycle/updatedAt). Reverts on failure.
+    func setTaskStatus(_ card: BoardCard, _ status: CardStatus) async {
+        guard let client, status != card.status else { return }
+        let previous = tasks
+        applyTask(id: card.id) { $0.statusRaw = status.rawValue }
+        do {
+            let updated = try await client.updateTask(cardId: card.id, status: status)
+            applyTask(id: card.id) { $0 = updated }
+        } catch {
+            tasks = previous
+            tasksError = error.localizedDescription
+        }
+    }
+
+    /// Optimistically set a task's priority; reconcile/revert like status.
+    func setTaskPriority(_ card: BoardCard, _ priority: CardPriority) async {
+        guard let client, priority != card.priority else { return }
+        let previous = tasks
+        applyTask(id: card.id) { $0.priorityRaw = priority.rawValue }
+        do {
+            let updated = try await client.updateTask(cardId: card.id, priority: priority)
+            applyTask(id: card.id) { $0 = updated }
+        } catch {
+            tasks = previous
+            tasksError = error.localizedDescription
+        }
+    }
+
+    /// Toggle a checklist step's done flag, persisting the whole step list.
+    func toggleStep(_ card: BoardCard, stepId: String) async {
+        guard let client, var steps = card.steps,
+              let idx = steps.firstIndex(where: { $0.id == stepId }) else { return }
+        steps[idx].done.toggle()
+        let newSteps = steps
+        let previous = tasks
+        applyTask(id: card.id) { $0.steps = newSteps }
+        do {
+            let updated = try await client.updateTask(cardId: card.id, steps: newSteps)
+            applyTask(id: card.id) { $0 = updated }
+        } catch {
+            tasks = previous
+            tasksError = error.localizedDescription
+        }
+    }
+
+    /// Optimistically remove a task, then DELETE it. Reinserts on failure.
+    func deleteTask(_ card: BoardCard) async {
+        guard let client else { return }
+        let previous = tasks
+        tasks.removeAll { $0.id == card.id }
+        do {
+            try await client.deleteTask(cardId: card.id)
+        } catch {
+            tasks = previous
+            tasksError = error.localizedDescription
+        }
+    }
+
+    private func applyTask(id: String, _ mutate: (inout BoardCard) -> Void) {
+        guard let idx = tasks.firstIndex(where: { $0.id == id }) else { return }
+        var card = tasks[idx]
+        mutate(&card)
+        tasks[idx] = card
+    }
+
     // MARK: - Reading list actions
 
     func loadReading() async {

--- a/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
@@ -2,11 +2,16 @@ import SwiftUI
 
 struct TaskDetailView: View {
     @Environment(AppModel.self) private var app
+    @Environment(\.dismiss) private var dismiss
     let card: BoardCard
 
     @State private var showFamiliarPicker = false
+    @State private var confirmingDelete = false
 
-    private var familiar: Familiar? { card.familiarId.flatMap(app.familiar) }
+    /// The current card from the store, so status/priority/step edits made here
+    /// reflect immediately; falls back to the passed-in snapshot.
+    private var live: BoardCard { app.tasks.first { $0.id == card.id } ?? card }
+    private var familiar: Familiar? { live.familiarId.flatMap(app.familiar) }
 
     var body: some View {
         ScrollView {
@@ -14,22 +19,57 @@ struct TaskDetailView: View {
                 header
                 if let familiar { assigneeRow(familiar) }
                 chatCard
-                if card.hasSteps { stepsCard }
-                if let notes = card.notes, !notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                if live.hasSteps { stepsCard }
+                if let notes = live.notes, !notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     notesCard(notes)
                 }
-                if !card.labelList.isEmpty { labelsRow }
+                if !live.labelList.isEmpty { labelsRow }
                 metaCard
             }
             .padding(20)
         }
         .navigationTitle("Task")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar { ToolbarItem(placement: .topBarTrailing) { actionsMenu } }
         .sheet(isPresented: $showFamiliarPicker) {
             FamiliarPickerSheet { fam in
                 showFamiliarPicker = false
                 app.openChat(for: card, familiarId: fam.id)
             }
+        }
+        .confirmationDialog("Delete this task?", isPresented: $confirmingDelete,
+                            titleVisibility: .visible) {
+            Button("Delete", role: .destructive) {
+                Task { await app.deleteTask(card); dismiss() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { Text(live.title) }
+    }
+
+    private var actionsMenu: some View {
+        Menu {
+            Menu {
+                ForEach(CardStatus.allCases, id: \.self) { status in
+                    Button { Task { await app.setTaskStatus(live, status) } } label: {
+                        Label(status.label, systemImage: live.status == status ? "checkmark" : status.systemImage)
+                    }
+                }
+            } label: { Label("Status", systemImage: "circle.dashed") }
+
+            Menu {
+                ForEach(CardPriority.allCases, id: \.self) { priority in
+                    Button { Task { await app.setTaskPriority(live, priority) } } label: {
+                        Label(priority.label, systemImage: live.priority == priority ? "checkmark" : "flag")
+                    }
+                }
+            } label: { Label("Priority", systemImage: "flag") }
+
+            Divider()
+            Button(role: .destructive) { confirmingDelete = true } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
         }
     }
 
@@ -81,20 +121,20 @@ struct TaskDetailView: View {
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text(card.title)
+            Text(live.title)
                 .font(.title2.bold())
                 .fixedSize(horizontal: false, vertical: true)
             HStack(spacing: 8) {
-                StatusPill(status: card.status)
+                StatusPill(status: live.status)
                 priorityBadge
-                if card.needsHuman == true { NeedsYouBadge() }
+                if live.needsHuman == true { NeedsYouBadge() }
             }
         }
     }
 
     private var priorityBadge: some View {
-        let color = Theme.color(for: card.priority)
-        return Label(card.priority.label, systemImage: "flag.fill")
+        let color = Theme.color(for: live.priority)
+        return Label(live.priority.label, systemImage: "flag.fill")
             .font(.caption.weight(.semibold))
             .padding(.horizontal, 8).padding(.vertical, 3)
             .background(color.opacity(0.16), in: Capsule())
@@ -121,22 +161,25 @@ struct TaskDetailView: View {
             HStack {
                 Text("Steps").font(.headline)
                 Spacer()
-                Text("\(card.doneStepCount)/\(card.stepCount)")
+                Text("\(live.doneStepCount)/\(live.stepCount)")
                     .font(.subheadline.monospacedDigit()).foregroundStyle(.secondary)
             }
-            ProgressView(value: card.stepFraction)
-                .tint(Theme.color(for: card.status))
+            ProgressView(value: live.stepFraction)
+                .tint(Theme.color(for: live.status))
             VStack(alignment: .leading, spacing: 10) {
-                ForEach(card.steps ?? []) { step in
-                    HStack(alignment: .top, spacing: 10) {
-                        Image(systemName: step.done ? "checkmark.circle.fill" : "circle")
-                            .foregroundStyle(step.done ? Color.green : Color.secondary)
-                        Text(step.text)
-                            .strikethrough(step.done, color: .secondary)
-                            .foregroundStyle(step.done ? .secondary : .primary)
-                            .fixedSize(horizontal: false, vertical: true)
-                        Spacer(minLength: 0)
+                ForEach(live.steps ?? []) { step in
+                    Button { Task { await app.toggleStep(live, stepId: step.id) } } label: {
+                        HStack(alignment: .top, spacing: 10) {
+                            Image(systemName: step.done ? "checkmark.circle.fill" : "circle")
+                                .foregroundStyle(step.done ? Color.green : Color.secondary)
+                            Text(step.text)
+                                .strikethrough(step.done, color: .secondary)
+                                .foregroundStyle(step.done ? .secondary : .primary)
+                                .fixedSize(horizontal: false, vertical: true)
+                            Spacer(minLength: 0)
+                        }
                     }
+                    .buttonStyle(.plain)
                 }
             }
         }
@@ -162,17 +205,17 @@ struct TaskDetailView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Labels").font(.headline)
             FlowRow(spacing: 8) {
-                ForEach(card.labelList, id: \.self) { LabelChip(text: $0) }
+                ForEach(live.labelList, id: \.self) { LabelChip(text: $0) }
             }
         }
     }
 
     private var metaCard: some View {
         VStack(alignment: .leading, spacing: 8) {
-            metaRow("Created", caveParseISO(card.createdAt))
-            metaRow("Updated", caveParseISO(card.updatedAt))
-            if card.startDate != nil { metaRow("Start", caveParseISO(card.startDate)) }
-            if card.endDate != nil { metaRow("Due", caveParseISO(card.endDate)) }
+            metaRow("Created", caveParseISO(live.createdAt))
+            metaRow("Updated", caveParseISO(live.updatedAt))
+            if live.startDate != nil { metaRow("Start", caveParseISO(live.startDate)) }
+            if live.endDate != nil { metaRow("Due", caveParseISO(live.endDate)) }
         }
         .font(.footnote)
     }

--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -16,6 +16,8 @@ struct TasksView: View {
     @AppStorage("cave.tasks.groupBy") private var groupByRaw = GroupBy.status.rawValue
     @State private var query = ""
     @State private var path: [BoardCard] = []
+    /// A task awaiting delete confirmation (swipe or context menu).
+    @State private var pendingDelete: BoardCard?
 
     /// How the task list is partitioned into sections.
     enum GroupBy: String, CaseIterable, Identifiable {
@@ -40,6 +42,46 @@ struct TasksView: View {
                 .onAppear(perform: openRequestedCard)
                 // A chat asked to open one of its linked tasks.
                 .onChange(of: app.cardToOpen) { _, card in openRequestedCard() }
+                .confirmationDialog("Delete this task?",
+                                    isPresented: deleteDialogBinding,
+                                    titleVisibility: .visible,
+                                    presenting: pendingDelete) { card in
+                    Button("Delete", role: .destructive) { Task { await app.deleteTask(card) } }
+                    Button("Cancel", role: .cancel) {}
+                } message: { card in Text(card.title) }
+        }
+    }
+
+    private var deleteDialogBinding: Binding<Bool> {
+        Binding(get: { pendingDelete != nil }, set: { if !$0 { pendingDelete = nil } })
+    }
+
+    /// Status / priority / delete actions, shared by the row context menu and
+    /// the detail-view toolbar menu.
+    @ViewBuilder private func taskMenu(_ card: BoardCard) -> some View {
+        Menu {
+            ForEach(CardStatus.allCases, id: \.self) { status in
+                Button {
+                    Task { await app.setTaskStatus(card, status) }
+                } label: {
+                    Label(status.label, systemImage: card.status == status ? "checkmark" : status.systemImage)
+                }
+            }
+        } label: { Label("Status", systemImage: "circle.dashed") }
+
+        Menu {
+            ForEach(CardPriority.allCases, id: \.self) { priority in
+                Button {
+                    Task { await app.setTaskPriority(card, priority) }
+                } label: {
+                    Label(priority.label, systemImage: card.priority == priority ? "checkmark" : "flag")
+                }
+            }
+        } label: { Label("Priority", systemImage: "flag") }
+
+        Divider()
+        Button(role: .destructive) { pendingDelete = card } label: {
+            Label("Delete", systemImage: "trash")
         }
     }
 
@@ -85,6 +127,17 @@ struct TasksView: View {
                         Button { path.append(card) } label: { TaskRow(card: card) }
                             .buttonStyle(.plain)
                             .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 12))
+                            .contextMenu { taskMenu(card) }
+                            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                Button(role: .destructive) { pendingDelete = card } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                                Button { Task { await app.setTaskStatus(card, card.status == .done ? .running : .done) } } label: {
+                                    Label(card.status == .done ? "Reopen" : "Done",
+                                          systemImage: card.status == .done ? "arrow.uturn.backward" : "checkmark")
+                                }
+                                .tint(card.status == .done ? .orange : .green)
+                            }
                     }
                 } header: {
                     HStack(spacing: 6) {

--- a/scripts/ios-task-actions.test.mjs
+++ b/scripts/ios-task-actions.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const client = await readFile(
+  new URL("../apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift", import.meta.url),
+  "utf8",
+);
+const model = await readFile(
+  new URL("../apps/ios/CovenCave/CovenCave/State/AppModel.swift", import.meta.url),
+  "utf8",
+);
+const list = await readFile(
+  new URL("../apps/ios/CovenCave/CovenCave/Views/TasksView.swift", import.meta.url),
+  "utf8",
+);
+const detail = await readFile(
+  new URL("../apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift", import.meta.url),
+  "utf8",
+);
+
+// Client speaks the board mutation contract.
+assert.match(
+  client,
+  /func updateTask\(cardId: String, status: CardStatus\? = nil,\s*priority: CardPriority\? = nil, steps: \[CardStep\]\? = nil\) async throws -> BoardCard/,
+  "CaveClient should expose updateTask(status:priority:steps:)",
+);
+assert.match(
+  client,
+  /func deleteTask\(cardId: String\) async throws \{[\s\S]*method: "DELETE"/,
+  "CaveClient.deleteTask should DELETE /api/board/{id}",
+);
+assert.match(
+  client,
+  /private func patchTask\(cardId: String, payload: Data\) async throws -> BoardCard/,
+  "PATCH plumbing should funnel through a shared patchTask helper",
+);
+
+// Model exposes optimistic actions that revert on failure.
+for (const fn of ["setTaskStatus", "setTaskPriority", "toggleStep", "deleteTask"]) {
+  assert.match(model, new RegExp(`func ${fn}\\(`), `AppModel should expose ${fn}`);
+}
+assert.match(
+  model,
+  /func deleteTask\(_ card: BoardCard\) async \{[\s\S]*let previous = tasks[\s\S]*tasks\.removeAll[\s\S]*catch[\s\S]*tasks = previous/,
+  "deleteTask should optimistically remove and revert on failure",
+);
+assert.match(
+  model,
+  /private func applyTask\(id: String, _ mutate: \(inout BoardCard\) -> Void\)/,
+  "AppModel should have an applyTask mutation helper",
+);
+
+// List surfaces swipe + context-menu actions with a delete confirmation.
+assert.match(list, /\.contextMenu \{ taskMenu\(card\) \}/, "rows should attach the task context menu");
+assert.match(
+  list,
+  /\.swipeActions\(edge: \.trailing, allowsFullSwipe: true\)/,
+  "rows should have trailing swipe actions",
+);
+assert.match(
+  list,
+  /await app\.setTaskStatus\(card, card\.status == \.done \? \.running : \.done\)/,
+  "swipe should toggle Done/Reopen",
+);
+assert.match(list, /confirmationDialog\("Delete this task\?"/, "list should confirm deletes");
+assert.match(
+  list,
+  /Menu \{[\s\S]*ForEach\(CardStatus\.allCases[\s\S]*ForEach\(CardPriority\.allCases/,
+  "taskMenu should offer status and priority submenus",
+);
+
+// Detail view reads the live card and offers an actions menu + tappable steps.
+assert.match(
+  detail,
+  /private var live: BoardCard \{ app\.tasks\.first \{ \$0\.id == card\.id \} \?\? card \}/,
+  "detail view should read the live card from the store",
+);
+assert.match(detail, /private var actionsMenu: some View/, "detail view should have an actions menu");
+assert.match(
+  detail,
+  /Button \{ Task \{ await app\.toggleStep\(live, stepId: step\.id\) \} \}/,
+  "detail steps should be tappable to toggle done",
+);
+assert.match(
+  detail,
+  /Button\("Delete", role: \.destructive\) \{\s*Task \{ await app\.deleteTask\(card\); dismiss\(\) \}/,
+  "deleting from the detail view should pop back",
+);
+
+console.log("ios-task-actions.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -482,6 +482,7 @@ export const SUITES = {
     "scripts/ios-app-store-assets.test.mjs",
     "scripts/ios-code-viewer.test.mjs",
     "scripts/ios-message-reader.test.mjs",
+    "scripts/ios-task-actions.test.mjs",
     "scripts/mobile-tailscale.test.mjs",
     "scripts/mobile-tailscale-native.test.mjs",
     "src/components/mobile-handoff.test.ts",


### PR DESCRIPTION
## What

Adds task management to the iOS **Tasks** tab — previously read-only. You can now change a task's status and priority, toggle checklist steps, and delete tasks, both from the list and the detail view.

## Changes

**Networking — `CaveClient.swift`**
- `updateTask(cardId:status:priority:steps:)` → `PATCH /api/board/{id}` (only sends the fields you set).
- `deleteTask(cardId:)` → `DELETE /api/board/{id}`.
- Refactored both plus `updateTaskSession` onto a shared `patchTask` helper.

**State — `AppModel.swift`**
- `setTaskStatus` / `setTaskPriority` / `toggleStep` / `deleteTask`, all **optimistic** with server reconcile and revert-on-failure (mirrors the existing reading-list pattern), plus an `applyTask` mutation helper.

**List — `TasksView.swift`**
- Row **context menu**: Status submenu, Priority submenu, Delete.
- Trailing **swipe actions**: Delete (full-swipe) and a Done/Reopen toggle.
- Delete **confirmation dialog**.

**Detail — `TaskDetailView.swift`**
- Reads the **live** card from the store so edits reflect immediately.
- Toolbar **actions menu** (Status / Priority / Delete-with-confirmation that pops back).
- Checklist **steps are tappable** to toggle done.

## Verification

- `node scripts/ios-task-actions.test.mjs` → **ok** (new source-assertion test, wired into `run-tests.mjs`).
- `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED**.

Interactive gestures (swipe, long-press menu, delete confirmation) can't be driven in the headless simulator without `idb`, so those were verified by compilation + the assertion test rather than a live tap-through; the server PATCH/DELETE contract and optimistic-revert logic follow the existing reading-list actions.

> Note: built in an isolated worktree off `main` because a concurrent session is editing `AppModel.swift`/`RootView.swift` (Canvas-tab removal). This PR only touches the task-action code paths; no overlap with that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)