### PR TITLE
feat(ios): browse chats by familiar — select familiar → its threads → distinct chat

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -436,6 +436,76 @@ final class AppModel {
         }
     }
 
+    // MARK: - Sessions (server-side, for per-familiar thread lists)
+
+    /// Chat sessions known to the server (`GET /api/sessions/list`) — including
+    /// conversations started on the desktop/web that have no local thread yet.
+    /// Merged with on-device threads to build each familiar's thread list.
+    var serverSessions: [SessionRow] = []
+    var sessionsError: String?
+    var sessionsLoaded = false
+
+    func loadSessions() async {
+        guard let client else { return }
+        do {
+            serverSessions = try await client.sessions()
+            sessionsError = nil
+        } catch {
+            sessionsError = error.localizedDescription
+        }
+        sessionsLoaded = true
+    }
+
+    /// Direct (1:1) on-device threads for a familiar, newest-updated first.
+    func directThreads(for familiarId: String) -> [ChatThread] {
+        threads
+            .filter { !$0.isGroup && $0.familiarIds == [familiarId] }
+            .sorted { $0.updatedAt > $1.updatedAt }
+    }
+
+    /// Every group thread, newest first — shown as its own rows on the Chats
+    /// home (a group has no single familiar to file it under).
+    var groupThreads: [ChatThread] {
+        threads.filter(\.isGroup).sorted { $0.updatedAt > $1.updatedAt }
+    }
+
+    /// Server sessions for a familiar that no local thread already carries —
+    /// i.e. conversations to surface but not yet materialised on this device.
+    func serverOnlySessions(for familiarId: String) -> [SessionRow] {
+        let bound = Set(threads.flatMap { $0.sessionIds.values }.filter { !$0.isEmpty })
+        return serverSessions
+            .filter { $0.familiarId == familiarId && $0.archivedAt == nil && !bound.contains($0.id) }
+            .sorted { (caveParseISO($0.updatedAt) ?? .distantPast) > (caveParseISO($1.updatedAt) ?? .distantPast) }
+    }
+
+    /// How many conversations a familiar has (local direct + server-only).
+    func threadCount(for familiarId: String) -> Int {
+        directThreads(for: familiarId).count + serverOnlySessions(for: familiarId).count
+    }
+
+    /// Most recent activity across a familiar's local + server conversations.
+    func lastActivity(for familiarId: String) -> Date? {
+        let local = directThreads(for: familiarId).map(\.updatedAt)
+        let server = serverOnlySessions(for: familiarId).compactMap { caveParseISO($0.updatedAt) }
+        return (local + server).max()
+    }
+
+    /// Materialise a server session as a local thread (binding its `sessionId`
+    /// and pulling history) and return it, so it opens like any other thread.
+    /// Reuses an existing local thread that already carries the session id.
+    func openServerSession(_ row: SessionRow, familiarId: String) -> ChatThread {
+        if let existing = threads.first(where: { $0.sessionIds.values.contains(row.id) }) {
+            return existing
+        }
+        let title = row.title.isEmpty ? (familiar(familiarId)?.displayName ?? familiarId) : row.title
+        let thread = ChatThread(title: title, familiarIds: [familiarId],
+                                sessionIds: [familiarId: row.id])
+        threads.insert(thread, at: 0)
+        persistThreads()
+        Task { await loadHistory(into: thread, sessionId: row.id) }
+        return thread
+    }
+
     // MARK: - Task ↔ chat linking
 
     /// The thread linked to a card, if any: prefer the explicit local link,

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -1,20 +1,31 @@
 import SwiftUI
 
+/// A destination on the Chats navigation stack. Selecting a familiar drills into
+/// that familiar's thread list; selecting a thread opens the conversation. Both
+/// are pushed onto one shared stack so the back button walks the chain.
+enum ChatRoute: Hashable {
+    case familiar(Familiar)
+    case thread(ChatThread)
+}
+
+/// The Chats tab: a list of familiars (tap one to see its threads) plus any
+/// group chats as their own rows. Tapping a familiar pushes `FamiliarThreadsView`;
+/// tapping a thread pushes `ChatView`.
 struct ChatsHomeView: View {
     @Environment(AppModel.self) private var app
     @State private var showNewChat = false
     @State private var query = ""
-    @State private var path: [ChatThread] = []
+    @State private var path: [ChatRoute] = []
 
     var body: some View {
         NavigationStack(path: $path) {
             Group {
-                if app.threads.isEmpty {
+                if app.familiars.isEmpty && app.threads.isEmpty {
                     emptyState
-                } else if filteredThreads.isEmpty {
+                } else if filteredFamiliars.isEmpty && filteredGroups.isEmpty {
                     ContentUnavailableView.search(text: query)
                 } else {
-                    threadList
+                    homeList
                 }
             }
             // Flush large-title header at the very top, matching Canvas / Read /
@@ -22,8 +33,13 @@ struct ChatsHomeView: View {
             // every tab's header aligns. Search + compose stay in the bottom bar.
             .toolbar(.hidden, for: .navigationBar)
             .safeAreaInset(edge: .top, spacing: 0) { header }
-            .navigationDestination(for: ChatThread.self) { thread in
-                ChatView(thread: thread)
+            .navigationDestination(for: ChatRoute.self) { route in
+                switch route {
+                case .familiar(let familiar):
+                    FamiliarThreadsView(familiar: familiar, path: $path)
+                case .thread(let thread):
+                    ChatView(thread: thread)
+                }
             }
             // Search + compose live in a floating bottom bar (iMessage-style),
             // not the top toolbar; Settings is now its own tab.
@@ -31,18 +47,30 @@ struct ChatsHomeView: View {
             .sheet(isPresented: $showNewChat) {
                 NewChatView { thread in
                     showNewChat = false
-                    path.append(thread)
+                    path.append(.thread(thread))
                 }
             }
-            .refreshable { await app.loadFamiliars() }
+            .refreshable {
+                await app.loadFamiliars()
+                await app.loadSessions()
+            }
+            .task { await app.loadSessions() }
             .onAppear(perform: openDeepLinkedThread)
-            // A slash command (`/new`, `/familiar <name>`) asked to open a thread.
+            // A slash command (`/new`, `/familiar <name>`) or a task link asked to
+            // open a specific thread — push it straight onto the stack.
             .onChange(of: app.threadToOpen) { _, thread in
                 guard let thread else { return }
-                if path.last?.id != thread.id { path.append(thread) }
+                if lastThreadId != thread.id { path.append(.thread(thread)) }
                 app.threadToOpen = nil
             }
         }
+    }
+
+    /// The id of the thread currently on top of the stack, if any (so a repeat
+    /// `requestOpen` of the same thread doesn't double-push it).
+    private var lastThreadId: String? {
+        if case .thread(let t) = path.last { return t.id }
+        return nil
     }
 
     /// Open a thread named by the `CAVE_OPEN_THREAD` launch env var. This is the
@@ -51,7 +79,7 @@ struct ChatsHomeView: View {
         guard path.isEmpty,
               let id = ProcessInfo.processInfo.environment["CAVE_OPEN_THREAD"],
               let thread = app.threads.first(where: { $0.id == id }) else { return }
-        path.append(thread)
+        path.append(.thread(thread))
     }
 
     /// Large-title header pinned to the top, mirroring the Canvas / Read / Tasks
@@ -61,8 +89,8 @@ struct ChatsHomeView: View {
             Text("Chats")
                 .font(.largeTitle.weight(.bold))
             Spacer()
-            if !app.threads.isEmpty {
-                Text("^[\(app.threads.count) chat](inflect: true)")
+            if !app.familiars.isEmpty {
+                Text("^[\(app.familiars.count) familiar](inflect: true)")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
@@ -73,30 +101,49 @@ struct ChatsHomeView: View {
         .background(.bar)
     }
 
-    private var threadList: some View {
+    private var homeList: some View {
         List {
-            ForEach(filteredThreads) { thread in
-                Button { path.append(thread) } label: {
-                    ThreadRow(thread: thread)
+            Section(filteredFamiliars.isEmpty ? "" : "Familiars") {
+                ForEach(filteredFamiliars) { familiar in
+                    NavigationLink(value: ChatRoute.familiar(familiar)) {
+                        FamiliarRow(familiar: familiar)
+                    }
+                    .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
                 }
-                .buttonStyle(.plain)
-                .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
             }
-            .onDelete { offsets in
-                offsets.map { filteredThreads[$0] }.forEach(app.deleteThread)
+            if !filteredGroups.isEmpty {
+                Section("Groups") {
+                    ForEach(filteredGroups) { thread in
+                        Button { path.append(.thread(thread)) } label: {
+                            ThreadRow(thread: thread)
+                        }
+                        .buttonStyle(.plain)
+                        .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                    }
+                    .onDelete { offsets in
+                        offsets.map { filteredGroups[$0] }.forEach(app.deleteThread)
+                    }
+                }
             }
         }
         .listStyle(.plain)
     }
 
-    /// Threads matching the search query (title, last-message preview, or a
-    /// participating familiar's name). Empty query shows everything.
-    private var filteredThreads: [ChatThread] {
+    /// Familiars matching the search query (name or role). Empty query → all.
+    private var filteredFamiliars: [Familiar] {
         let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !q.isEmpty else { return app.threads }
-        return app.threads.filter { thread in
+        guard !q.isEmpty else { return app.familiars }
+        return app.familiars.filter {
+            $0.displayName.lowercased().contains(q) || ($0.role?.lowercased().contains(q) ?? false)
+        }
+    }
+
+    /// Group threads matching the search query (title or a member's name).
+    private var filteredGroups: [ChatThread] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !q.isEmpty else { return app.groupThreads }
+        return app.groupThreads.filter { thread in
             if thread.title.lowercased().contains(q) { return true }
-            if let last = thread.messages.last?.text, last.lowercased().contains(q) { return true }
             return thread.familiarIds.compactMap(app.familiar).contains {
                 $0.displayName.lowercased().contains(q)
             }
@@ -144,13 +191,46 @@ struct ChatsHomeView: View {
 
     private var emptyState: some View {
         ContentUnavailableView {
-            Label("No chats yet", systemImage: "bubble.left.and.bubble.right")
+            Label("No familiars yet", systemImage: "bubble.left.and.bubble.right")
         } description: {
-            Text("Start a conversation with one familiar — or group several together.")
+            Text("Pull to refresh once your desktop is connected, or start a group chat.")
         } actions: {
             Button("New chat") { showNewChat = true }
                 .buttonStyle(.borderedProminent)
         }
+    }
+}
+
+/// A familiar row on the Chats home: avatar, name, role, and a trailing summary
+/// of how many conversations they have and when they were last active.
+struct FamiliarRow: View {
+    @Environment(AppModel.self) private var app
+    let familiar: Familiar
+
+    var body: some View {
+        HStack(spacing: 12) {
+            AvatarView(familiar: familiar,
+                       url: app.client?.avatarURL(for: familiar),
+                       size: 48)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(familiar.displayName).font(.headline).lineLimit(1)
+                if let role = familiar.role, !role.isEmpty {
+                    Text(role).font(.subheadline).foregroundStyle(.secondary).lineLimit(1)
+                }
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 3) {
+                let count = app.threadCount(for: familiar.id)
+                if let last = app.lastActivity(for: familiar.id) {
+                    Text(last, format: .relative(presentation: .numeric))
+                        .font(.caption).foregroundStyle(.tertiary)
+                }
+                Text(count == 0 ? "No chats" : "^[\(count) chat](inflect: true)")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 2)
+        .contentShape(Rectangle())
     }
 }
 

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -1,0 +1,159 @@
+import SwiftUI
+
+/// The threads belonging to a single familiar. Reached by tapping a familiar on
+/// the Chats home; lists every conversation with that familiar — on-device
+/// threads merged with server sessions started elsewhere (desktop/web) — newest
+/// first, each opening into its own distinct chat. A "New chat" action starts a
+/// fresh, separate thread.
+struct FamiliarThreadsView: View {
+    @Environment(AppModel.self) private var app
+    let familiar: Familiar
+    @Binding var path: [ChatRoute]
+
+    /// One row in the list: an on-device thread or a server-only session.
+    private enum Entry: Identifiable {
+        case local(ChatThread)
+        case server(SessionRow)
+
+        var id: String {
+            switch self {
+            case .local(let t): return "local-\(t.id)"
+            case .server(let r): return "server-\(r.id)"
+            }
+        }
+        @MainActor var date: Date {
+            switch self {
+            case .local(let t): return t.updatedAt
+            case .server(let r): return caveParseISO(r.updatedAt) ?? .distantPast
+            }
+        }
+    }
+
+    /// On-device threads + server-only sessions, newest activity first.
+    private var entries: [Entry] {
+        let local = app.directThreads(for: familiar.id).map(Entry.local)
+        let server = app.serverOnlySessions(for: familiar.id).map(Entry.server)
+        return (local + server).sorted { $0.date > $1.date }
+    }
+
+    var body: some View {
+        Group {
+            if entries.isEmpty {
+                emptyState
+            } else {
+                threadList
+            }
+        }
+        .navigationTitle(familiar.displayName)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                VStack(spacing: 1) {
+                    Text(familiar.displayName).font(.headline).lineLimit(1)
+                    if let role = familiar.role, !role.isEmpty {
+                        Text(role).font(.caption2).foregroundStyle(.secondary).lineLimit(1)
+                    }
+                }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(action: startNewChat) {
+                    Image(systemName: "square.and.pencil")
+                }
+                .accessibilityLabel("New chat")
+            }
+        }
+        .refreshable { await app.loadSessions() }
+        .task { await app.loadSessions() }
+    }
+
+    private var threadList: some View {
+        List {
+            ForEach(entries) { entry in
+                Button { open(entry) } label: { row(entry) }
+                    .buttonStyle(.plain)
+                    .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+            }
+            .onDelete(perform: delete)
+        }
+        .listStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func row(_ entry: Entry) -> some View {
+        switch entry {
+        case .local(let thread):
+            ThreadRow(thread: thread)
+        case .server(let session):
+            ServerSessionRow(session: session)
+        }
+    }
+
+    private func open(_ entry: Entry) {
+        switch entry {
+        case .local(let thread):
+            path.append(.thread(thread))
+        case .server(let session):
+            // Bind the server session to a local thread (and pull its history),
+            // then open it like any other.
+            let thread = app.openServerSession(session, familiarId: familiar.id)
+            path.append(.thread(thread))
+        }
+    }
+
+    /// Swipe-to-delete removes on-device threads; a server-only session can't be
+    /// deleted from here (it lives on the desktop), so those rows are skipped.
+    private func delete(_ offsets: IndexSet) {
+        for index in offsets {
+            if case .local(let thread) = entries[index] { app.deleteThread(thread) }
+        }
+    }
+
+    private func startNewChat() {
+        let thread = app.startFreshThread(familiarIds: [familiar.id], title: familiar.displayName)
+        Haptics.tap()
+        path.append(.thread(thread))
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("No chats with \(familiar.displayName)", systemImage: "bubble.left")
+        } description: {
+            Text("Start a conversation — it'll appear here and stay separate from your other chats.")
+        } actions: {
+            Button("New chat", action: startNewChat)
+                .buttonStyle(.borderedProminent)
+        }
+    }
+}
+
+/// A server-side session not yet materialised on this device — tapping it pulls
+/// the conversation down. Mirrors `ThreadRow`'s layout with a synced-elsewhere hint.
+private struct ServerSessionRow: View {
+    @Environment(AppModel.self) private var app
+    let session: SessionRow
+
+    var body: some View {
+        HStack(spacing: 12) {
+            AvatarView(familiar: session.familiarId.flatMap(app.familiar),
+                       url: session.familiarId.flatMap(app.familiar).flatMap { app.client?.avatarURL(for: $0) },
+                       size: 48)
+            VStack(alignment: .leading, spacing: 3) {
+                HStack {
+                    Text(session.title.isEmpty ? "Untitled chat" : session.title)
+                        .font(.headline).lineLimit(1)
+                    Spacer()
+                    if let date = caveParseISO(session.updatedAt) {
+                        Text(date, format: .relative(presentation: .numeric))
+                            .font(.caption).foregroundStyle(.tertiary)
+                    }
+                }
+                Label("Synced from another device", systemImage: "desktopcomputer")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+        .padding(.vertical, 2)
+        .contentShape(Rectangle())
+    }
+}


### PR DESCRIPTION
## What

Reworks the iOS Chats tab from a flat thread list into a **two-level drill-down**, as requested:

1. **Chats home** now lists **familiars** — each row shows the familiar, a per-familiar conversation count, and last-active time. Group chats keep their own section and open directly.
2. Tapping a familiar opens **`FamiliarThreadsView`** — that familiar's threads, newest-first.
3. Tapping a thread opens its **distinct chat** (existing `ChatView`).

## Where the threads come from

A familiar's list **merges on-device threads with the server's sessions** (`GET /api/sessions/list` — already wired in `CaveClient` but previously unused), so conversations started on the desktop/web also surface on the phone, tagged *"Synced from another device"*. Opening a server-only session binds it to a local thread and pulls its history (reusing the existing card-link load path). A `New chat` action starts a fresh, separate thread for that familiar.

The floating search + New-chat compose bar is preserved; `requestOpen` / `/familiar` / task-link navigation still pushes straight to a chat via a new shared `ChatRoute` stack.

## Files

- `Views/ChatsHomeView.swift` — familiar-list home + `ChatRoute` navigation + `FamiliarRow`
- `Views/FamiliarThreadsView.swift` *(new)* — per-familiar merged thread list
- `State/AppModel.swift` — `loadSessions()`, `serverSessions`, per-familiar merge helpers, `openServerSession()`

No server changes (the endpoint already returns `familiarId`). iOS-only — not exercised by CI.

## Verification

Built for the iOS Simulator (`BUILD SUCCEEDED`) and run against a live desktop:

- **Home**: familiar list with correct counts (e.g. Nova "1 chat · 20 minutes ago").
- **Drill-in**: Nova's thread list shows its full server-backed history newest-first ("Task: Rollout Mobile Cave", "OpenClaw Bridge", "Show a mermaid diagram", …), each labeled "Synced from another device".

🤖 Generated with [Claude Code](https://claude.com/claude-code)