### PR TITLE
feat(ios): full-screen Reader for assistant replies and task notes

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -11,6 +11,12 @@ struct PendingImage: Identifiable {
     let name: String
 }
 
+struct ResponseReaderItem: Identifiable {
+    let id = UUID()
+    let title: String
+    let markdown: String
+}
+
 struct ChatView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.dismiss) private var dismiss
@@ -24,6 +30,7 @@ struct ChatView: View {
     @State private var dictation = SpeechDictation()
     @State private var photoItem: PhotosPickerItem?
     @State private var pendingImage: PendingImage?
+    @State private var responseReader: ResponseReaderItem?
     // Tap-to-enlarge target (image attachment, or a table/diagram/image lifted
     // from the markdown WebView). Driven by the `.caveZoomContent` notification.
     @State private var zoomTarget: ZoomTarget?
@@ -91,6 +98,9 @@ struct ChatView: View {
         .sheet(isPresented: $showTasks) {
             LinkedTasksSheet(thread: thread)
         }
+        .sheet(item: $responseReader) { item in
+            ResponseReaderView(item: item)
+        }
         // A new chat linked to a task acquires its server session only after the
         // first reply; once streaming stops, push that sessionId onto the card.
         .onChange(of: thread.isStreaming) { _, streaming in
@@ -117,6 +127,7 @@ struct ChatView: View {
                                       isLast: message.id == thread.messages.last?.id,
                                       onDelete: { deleteMessage(message) },
                                       onSuggestion: { sendSuggestion($0) },
+                                      onOpenReader: { openReader(text: $0, familiar: message.familiarId.flatMap(app.familiar)) },
                                       onRetry: canRetry(message) ? { retryAssistant(message) } : nil)
                         .id(message.id)
                     }
@@ -558,6 +569,41 @@ struct ChatView: View {
     private func deleteMessage(_ message: DisplayMessage) {
         thread.deleteMessage(message.id)
         app.touch(thread)
+    }
+
+    private func openReader(text: String, familiar: Familiar?) {
+        responseReader = ResponseReaderItem(title: familiar?.displayName ?? "Response", markdown: text)
+    }
+}
+
+struct ResponseReaderView: View {
+    @Environment(\.dismiss) private var dismiss
+    let item: ResponseReaderItem
+    @State private var mdHeight: CGFloat = 0
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                MarkdownWebView(markdown: item.markdown, height: $mdHeight)
+                    .frame(height: max(mdHeight, 1))
+                    .padding(20)
+            }
+            .navigationTitle(item.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button {
+                        UIPasteboard.general.string = item.markdown
+                        Haptics.tap()
+                    } label: {
+                        Label("Copy", systemImage: "doc.on.doc")
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
     }
 }
 

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -8,6 +8,7 @@ struct MessageBubble: View {
     var isLast: Bool = false
     var onDelete: () -> Void
     var onSuggestion: (String) -> Void = { _ in }
+    var onOpenReader: ((String) -> Void)? = nil
     /// Regenerate this reply (assistant messages only); nil hides the action.
     var onRetry: (() -> Void)? = nil
 
@@ -24,6 +25,14 @@ struct MessageBubble: View {
                 Haptics.tap()
             } label: {
                 Label("Copy", systemImage: "doc.on.doc")
+            }
+        }
+        if canOpenReader {
+            Button {
+                onOpenReader?(parsed.visible)
+                Haptics.tap()
+            } label: {
+                Label("Open in Reader", systemImage: "text.page")
             }
         }
         if let onRetry {
@@ -45,6 +54,10 @@ struct MessageBubble: View {
     /// assistant reply. Streaming / user / error messages stay native Text.
     private var rendersMarkdown: Bool {
         !isUser && !message.streaming && !message.isError && !parsed.visible.isEmpty
+    }
+
+    private var canOpenReader: Bool {
+        !isUser && !message.streaming && !message.isError && !parsed.visible.isEmpty && onOpenReader != nil
     }
 
     var body: some View {
@@ -144,6 +157,23 @@ struct MessageBubble: View {
                 .frame(height: max(mdHeight, 1))
                 .padding(.horizontal, 14).padding(.vertical, 10)
                 .background(bubbleBackground, in: bubbleShape)
+                .overlay(alignment: .topTrailing) {
+                    if canOpenReader {
+                        Button {
+                            onOpenReader?(parsed.visible)
+                            Haptics.tap()
+                        } label: {
+                            Image(systemName: "arrow.up.left.and.arrow.down.right")
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                                .padding(7)
+                                .background(.thinMaterial, in: Circle())
+                        }
+                        .buttonStyle(.plain)
+                        .padding(6)
+                        .accessibilityLabel("Open response in reader")
+                    }
+                }
         } else {
             Text(parsed.visible.isEmpty ? " " : parsed.visible)
                 .textSelection(.enabled)

--- a/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
@@ -5,6 +5,8 @@ struct TaskDetailView: View {
     let card: BoardCard
 
     @State private var showFamiliarPicker = false
+    @State private var notesHeight: CGFloat = 0
+    @State private var notesReader: ResponseReaderItem?
 
     private var familiar: Familiar? { card.familiarId.flatMap(app.familiar) }
 
@@ -30,6 +32,9 @@ struct TaskDetailView: View {
                 showFamiliarPicker = false
                 app.openChat(for: card, familiarId: fam.id)
             }
+        }
+        .sheet(item: $notesReader) { item in
+            ResponseReaderView(item: item)
         }
     }
 
@@ -145,13 +150,25 @@ struct TaskDetailView: View {
     }
 
     private func notesCard(_ notes: String) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Notes").font(.headline)
-            Text(notes)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .textSelection(.enabled)
-                .fixedSize(horizontal: false, vertical: true)
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("Notes").font(.headline)
+                Spacer()
+                Button {
+                    notesReader = ResponseReaderItem(title: "Notes", markdown: notes)
+                    Haptics.tap()
+                } label: {
+                    Image(systemName: "arrow.up.left.and.arrow.down.right")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(7)
+                        .background(.thinMaterial, in: Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Open notes in reader")
+            }
+            MarkdownWebView(markdown: notes, height: $notesHeight)
+                .frame(height: max(notesHeight, 1))
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)

--- a/scripts/ios-message-reader.test.mjs
+++ b/scripts/ios-message-reader.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+
+const messageBubble = read("apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift");
+const chatView = read("apps/ios/CovenCave/CovenCave/Views/ChatView.swift");
+const runner = read("scripts/run-tests.mjs");
+
+assert.match(
+  messageBubble,
+  /var onOpenReader: \(\(String\) -> Void\)\? = nil/,
+  "MessageBubble should accept an optional reader action",
+);
+
+assert.match(
+  messageBubble,
+  /private var canOpenReader: Bool \{[\s\S]*!isUser[\s\S]*!message\.streaming[\s\S]*!message\.isError[\s\S]*!parsed\.visible\.isEmpty[\s\S]*onOpenReader != nil/,
+  "reader action should only be available for settled non-error assistant responses",
+);
+
+assert.match(
+  messageBubble,
+  /Label\("Open in Reader", systemImage: "text\.page"\)/,
+  "reader action should be exposed from the message context menu",
+);
+
+assert.match(
+  messageBubble,
+  /\.accessibilityLabel\("Open response in reader"\)/,
+  "reader expand button should be directly accessible from the assistant bubble",
+);
+
+assert.match(
+  chatView,
+  /@State private var responseReader: ResponseReaderItem\?/,
+  "ChatView should own the presented response reader state",
+);
+
+assert.match(
+  chatView,
+  /onOpenReader: \{ openReader\(text: \$0, familiar: message\.familiarId\.flatMap\(app\.familiar\)\) \}/,
+  "ChatView should wire assistant messages into the reader presenter",
+);
+
+assert.match(
+  chatView,
+  /\.sheet\(item: \$responseReader\) \{ item in[\s\S]*ResponseReaderView\(item: item\)/,
+  "ChatView should present the response reader as an item sheet",
+);
+
+assert.match(
+  chatView,
+  /struct ResponseReaderView: View[\s\S]*MarkdownWebView\(markdown: item\.markdown, height: \$mdHeight\)/,
+  "ResponseReaderView should render the full response through the markdown renderer",
+);
+
+assert.match(
+  chatView,
+  /ToolbarItem\(placement: \.confirmationAction\) \{[\s\S]*Button\("Done"\)/,
+  "ResponseReaderView should provide a Done toolbar action",
+);
+
+assert.match(
+  runner,
+  /"scripts\/ios-message-reader\.test\.mjs"/,
+  "mobile test suite should run the response reader coverage",
+);
+
+console.log("ios-message-reader.test.mjs: ok");

--- a/scripts/ios-task-notes-reader.test.mjs
+++ b/scripts/ios-task-notes-reader.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+
+const taskDetail = read("apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift");
+const runner = read("scripts/run-tests.mjs");
+
+assert.match(
+  taskDetail,
+  /MarkdownWebView\(markdown: notes, height: \$notesHeight\)/,
+  "Task notes should render through the markdown renderer, not plain Text",
+);
+
+assert.doesNotMatch(
+  taskDetail,
+  /Text\(notes\)/,
+  "the plain-text notes fallback should be gone in favor of markdown",
+);
+
+assert.match(
+  taskDetail,
+  /@State private var notesReader: ResponseReaderItem\?/,
+  "TaskDetailView should own the presented notes reader state",
+);
+
+assert.match(
+  taskDetail,
+  /notesReader = ResponseReaderItem\(title: "Notes", markdown: notes\)/,
+  "the expand affordance should wire the notes into the reader presenter",
+);
+
+assert.match(
+  taskDetail,
+  /\.accessibilityLabel\("Open notes in reader"\)/,
+  "the notes reader expand button should be accessible",
+);
+
+assert.match(
+  taskDetail,
+  /\.sheet\(item: \$notesReader\) \{ item in[\s\S]*ResponseReaderView\(item: item\)/,
+  "TaskDetailView should present the shared response reader for notes",
+);
+
+assert.match(
+  runner,
+  /"scripts\/ios-task-notes-reader\.test\.mjs"/,
+  "mobile test suite should run the task notes reader coverage",
+);
+
+console.log("ios-task-notes-reader.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -482,6 +482,7 @@ export const SUITES = {
     "scripts/ios-app-store-assets.test.mjs",
     "scripts/ios-code-viewer.test.mjs",
     "scripts/ios-message-reader.test.mjs",
+    "scripts/ios-task-notes-reader.test.mjs",
     "scripts/mobile-tailscale.test.mjs",
     "scripts/mobile-tailscale-native.test.mjs",
     "src/components/mobile-handoff.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -481,6 +481,7 @@ export const SUITES = {
     "src/lib/mobile-handoff.test.ts",
     "scripts/ios-app-store-assets.test.mjs",
     "scripts/ios-code-viewer.test.mjs",
+    "scripts/ios-message-reader.test.mjs",
     "scripts/mobile-tailscale.test.mjs",
     "scripts/mobile-tailscale-native.test.mjs",
     "src/components/mobile-handoff.test.ts",


### PR DESCRIPTION
## Summary

Adds a full-screen **Reader** to the iOS app for both assistant chat replies and task notes, and upgrades task notes to render real markdown.

### Chat replies (`4331c147`)
- "Open in Reader" affordance on settled assistant messages — a context-menu item plus an expand button overlaid on the rendered bubble.
- Tapping presents a full-screen `ResponseReaderView` that renders the reply's markdown with a Copy action.

### Task notes (`5166c360`)
- Task notes were shown as plain `Text`, so markdown (headings, lists, code, tables) rendered as raw syntax with no comfortable way to read long notes.
- Notes now render through `MarkdownWebView` — the same auto-height pipeline as chat replies.
- The Notes header gains an "Open in Reader" expand button that presents the shared `ResponseReaderView` full screen, reusing the existing `ResponseReaderItem`/`ResponseReaderView`.

## Tests
- `scripts/ios-message-reader.test.mjs` — chat reader coverage.
- `scripts/ios-task-notes-reader.test.mjs` — task notes markdown + reader coverage.
- Both registered in `run-tests.mjs`.

## Verification
- `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED**. (iOS Swift is not compiled by the required CI checks, so this was verified locally.)
- Both reader test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)