### PR TITLE
feat(ios): render task notes as markdown + open in full-screen Reader

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
@@ -7,6 +7,8 @@ struct TaskDetailView: View {
 
     @State private var showFamiliarPicker = false
     @State private var confirmingDelete = false
+    @State private var notesHeight: CGFloat = 0
+    @State private var notesReader: ResponseReaderItem?
 
     /// The current card from the store, so status/priority/step edits made here
     /// reflect immediately; falls back to the passed-in snapshot.
@@ -44,6 +46,9 @@ struct TaskDetailView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: { Text(live.title) }
+        .sheet(item: $notesReader) { item in
+            ResponseReaderView(item: item)
+        }
     }
 
     private var actionsMenu: some View {
@@ -188,13 +193,25 @@ struct TaskDetailView: View {
     }
 
     private func notesCard(_ notes: String) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Notes").font(.headline)
-            Text(notes)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .textSelection(.enabled)
-                .fixedSize(horizontal: false, vertical: true)
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("Notes").font(.headline)
+                Spacer()
+                Button {
+                    notesReader = ResponseReaderItem(title: "Notes", markdown: notes)
+                    Haptics.tap()
+                } label: {
+                    Image(systemName: "arrow.up.left.and.arrow.down.right")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(7)
+                        .background(.thinMaterial, in: Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Open notes in reader")
+            }
+            MarkdownWebView(markdown: notes, height: $notesHeight)
+                .frame(height: max(notesHeight, 1))
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)

--- a/scripts/ios-task-notes-reader.test.mjs
+++ b/scripts/ios-task-notes-reader.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+
+const taskDetail = read("apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift");
+const runner = read("scripts/run-tests.mjs");
+
+assert.match(
+  taskDetail,
+  /MarkdownWebView\(markdown: notes, height: \$notesHeight\)/,
+  "Task notes should render through the markdown renderer, not plain Text",
+);
+
+assert.doesNotMatch(
+  taskDetail,
+  /Text\(notes\)/,
+  "the plain-text notes fallback should be gone in favor of markdown",
+);
+
+assert.match(
+  taskDetail,
+  /@State private var notesReader: ResponseReaderItem\?/,
+  "TaskDetailView should own the presented notes reader state",
+);
+
+assert.match(
+  taskDetail,
+  /notesReader = ResponseReaderItem\(title: "Notes", markdown: notes\)/,
+  "the expand affordance should wire the notes into the reader presenter",
+);
+
+assert.match(
+  taskDetail,
+  /\.accessibilityLabel\("Open notes in reader"\)/,
+  "the notes reader expand button should be accessible",
+);
+
+assert.match(
+  taskDetail,
+  /\.sheet\(item: \$notesReader\) \{ item in[\s\S]*ResponseReaderView\(item: item\)/,
+  "TaskDetailView should present the shared response reader for notes",
+);
+
+assert.match(
+  runner,
+  /"scripts\/ios-task-notes-reader\.test\.mjs"/,
+  "mobile test suite should run the task notes reader coverage",
+);
+
+console.log("ios-task-notes-reader.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -483,6 +483,7 @@ export const SUITES = {
     "scripts/ios-code-viewer.test.mjs",
     "scripts/ios-message-reader.test.mjs",
     "scripts/ios-task-actions.test.mjs",
+    "scripts/ios-task-notes-reader.test.mjs",
     "scripts/mobile-tailscale.test.mjs",
     "scripts/mobile-tailscale-native.test.mjs",
     "src/components/mobile-handoff.test.ts",


### PR DESCRIPTION
## Summary

Task notes in the iOS Task detail view were rendered as plain `Text`, so markdown (headings, lists, code, tables) showed as raw syntax with no comfortable way to read long notes. This:

- Renders notes through `MarkdownWebView` — the same auto-height pipeline as chat replies and desktop.
- Adds an **"Open in Reader"** expand button on the Notes header that presents the shared full-screen `ResponseReaderView` (Copy + Done), reusing the existing `ResponseReaderItem`/`ResponseReaderView` from the chat reader.

Rebased onto current `main` (the chat-reply Reader landed separately as #1633; main's task-management work #1635 is preserved — status/priority/delete actions menu and the delete confirmation dialog coexist with the new notes sheet).

## Tests
- `scripts/ios-task-notes-reader.test.mjs` (registered in `run-tests.mjs`) — asserts notes render via `MarkdownWebView`, the plain-text fallback is gone, and the reader sheet/state/affordance are wired.

## Verification
- `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED** (iOS Swift isn't compiled by the required CI checks; verified locally).
- `ios-task-notes-reader`, `ios-task-actions`, and `ios-message-reader` test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)