### PR TITLE
fix(ios): render assistant replies — never blank when markdown bundle missing

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/MarkdownWebView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MarkdownWebView.swift
@@ -8,6 +8,10 @@ import WebKit
 struct MarkdownWebView: UIViewRepresentable {
     let markdown: String
     @Binding var height: CGFloat
+    /// Called if the bundled renderer can't run (missing/stale `markdown.html`,
+    /// `window.caveRender` undefined, or a JS error) so the caller can fall back
+    /// to native `Text` instead of leaving the reply as a blank sliver.
+    var onFailure: (() -> Void)? = nil
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
@@ -19,6 +23,7 @@ struct MarkdownWebView: UIViewRepresentable {
         context.coordinator.onHeight = { h in
             if abs(h - height) > 0.5 { height = h }
         }
+        context.coordinator.onFailure = onFailure
         context.coordinator.render(markdown)
     }
 
@@ -26,7 +31,9 @@ struct MarkdownWebView: UIViewRepresentable {
     final class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate {
         let webView: WKWebView
         var onHeight: ((CGFloat) -> Void)?
+        var onFailure: (() -> Void)?
         private var ready = false
+        private var failed = false
         private var pending: String?
         private var lastRendered: String?
 
@@ -46,6 +53,10 @@ struct MarkdownWebView: UIViewRepresentable {
             webView.scrollView.contentInset = .zero
             if let url = Bundle.main.url(forResource: "markdown", withExtension: "html") {
                 webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
+            } else {
+                // The renderer bundle (gitignored, built by scripts/build-ios-markdown.mjs)
+                // is missing from this build — never leave the reply blank.
+                failed = true
             }
         }
 
@@ -53,20 +64,43 @@ struct MarkdownWebView: UIViewRepresentable {
             guard md != lastRendered else { return }
             lastRendered = md
             pending = md
+            if failed { reportFailure(); return }
             flush()
         }
+
+        private func reportFailure() {
+            guard !failedReported else { return }
+            failedReported = true
+            failed = true
+            // Defer past the current SwiftUI update cycle — `render()` runs inside
+            // `updateUIView`, and mutating the caller's @State synchronously there
+            // is dropped ("Modifying state during view update").
+            let callback = onFailure
+            DispatchQueue.main.async { callback?() }
+        }
+
+        private var failedReported = false
 
         private func flush() {
             guard ready, let md = pending else { return }
             pending = nil
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                let value = try? await self.webView.callAsyncJavaScript(
-                    "await window.caveRender(md); return Math.ceil(document.body.getBoundingClientRect().height);",
-                    arguments: ["md": md],
-                    contentWorld: .page
-                )
-                if let h = value as? Double { self.onHeight?(CGFloat(h)) }
+                do {
+                    let value = try await self.webView.callAsyncJavaScript(
+                        "if (typeof window.caveRender !== 'function') throw new Error('caveRender unavailable'); await window.caveRender(md); return Math.ceil(document.body.getBoundingClientRect().height);",
+                        arguments: ["md": md],
+                        contentWorld: .page
+                    )
+                    if let h = value as? Double, h > 0 {
+                        self.onHeight?(CGFloat(h))
+                    } else {
+                        // Rendered but produced no measurable content — degrade to Text.
+                        self.reportFailure()
+                    }
+                } catch {
+                    self.reportFailure()
+                }
             }
         }
 

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -13,6 +13,10 @@ struct MessageBubble: View {
     var onRetry: (() -> Void)? = nil
 
     @State private var mdHeight: CGFloat = 0
+    /// Set when the markdown WebView can't render (missing/stale bundle, JS
+    /// error) — flips this bubble back to plain `Text` so the reply is never
+    /// shown as a blank sliver.
+    @State private var markdownFailed = false
 
     private var isUser: Bool { message.role == .user }
 
@@ -53,7 +57,7 @@ struct MessageBubble: View {
     /// Render the desktop-parity markdown WebView only for a settled, non-error
     /// assistant reply. Streaming / user / error messages stay native Text.
     private var rendersMarkdown: Bool {
-        !isUser && !message.streaming && !message.isError && !parsed.visible.isEmpty
+        !isUser && !message.streaming && !message.isError && !parsed.visible.isEmpty && !markdownFailed
     }
 
     private var canOpenReader: Bool {
@@ -153,7 +157,8 @@ struct MessageBubble: View {
                 .padding(.horizontal, 14).padding(.vertical, 11)
                 .background(bubbleBackground, in: bubbleShape)
         } else if rendersMarkdown {
-            MarkdownWebView(markdown: parsed.visible, height: $mdHeight)
+            MarkdownWebView(markdown: parsed.visible, height: $mdHeight,
+                            onFailure: { markdownFailed = true })
                 .frame(height: max(mdHeight, 1))
                 .padding(.horizontal, 14).padding(.vertical, 10)
                 .background(bubbleBackground, in: bubbleShape)

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -19,6 +19,28 @@ targets:
     platform: iOS
     sources:
       - path: CovenCave
+    preBuildScripts:
+      - name: Generate web bundles (markdown.html + terminal.html)
+        # markdown.html / terminal.html are gitignored, build-generated bundles
+        # the WebViews load. A build that ships without them renders assistant
+        # replies as blank slivers (markdown) / a dead terminal. Regenerate them
+        # on every build so a fresh checkout is never missing them. Non-fatal:
+        # if node can't be found we warn and rely on the Swift Text fallback.
+        basedOnDependencyAnalysis: false
+        script: |
+          set -u
+          REPO="$SRCROOT/../../.."
+          if ! command -v node >/dev/null 2>&1; then
+            for p in /opt/homebrew/bin /usr/local/bin "$HOME/.volta/bin" "$HOME/.nvm/versions/node"/*/bin; do
+              [ -x "$p/node" ] && export PATH="$p:$PATH" && break
+            done
+          fi
+          if ! command -v node >/dev/null 2>&1; then
+            echo "warning: node not found — skipping web bundle generation (using fallbacks)"
+            exit 0
+          fi
+          ( cd "$REPO" && node scripts/build-ios-markdown.mjs && node scripts/build-ios-terminal.mjs ) \
+            || echo "warning: web bundle generation failed — using fallbacks"
     settings:
       base:
         INFOPLIST_FILE: CovenCave/Info.plist


### PR DESCRIPTION
## Problem

In the native iOS chat, assistant replies rendered as **blank dark slivers** ("just lines") between the user's purple bubbles.

## Root cause

`markdown.html` — the WKWebView renderer bundle that `MarkdownWebView` loads — is **gitignored and build-generated** by `scripts/build-ios-markdown.mjs`, but **nothing regenerated it at build time**. A build shipped without it → the WebView loaded nothing → `window.caveRender` was undefined → the height callback never fired → the bubble collapsed to `frame(height: max(0, 1))` = a 1pt line. Same class as the earlier `terminal.html` blank-bundle issue.

## Fix (three parts)

1. **`MarkdownWebView`** — detect a missing/stale bundle or JS render failure (`caveRender` undefined, `callAsyncJavaScript` throws, or zero measured height) and surface an `onFailure` callback, deferred off the SwiftUI update cycle (so the caller's `@State` mutation isn't dropped during `updateUIView`).
2. **`MessageBubble`** — on failure, fall back to native `Text`, so a reply is always readable (rich markdown when available, plain text otherwise) — never blank.
3. **`project.yml`** — add a **non-fatal** pre-build script that regenerates `markdown.html` + `terminal.html` on every build, so a fresh checkout / CI / TestFlight build is never missing them. If `node` can't be found on Xcode's stripped PATH it warns and relies on the Swift fallback.

## Verification

Built + run on the iPhone 16 Pro simulator (iOS not in CI):

- **Bundle present** → full markdown: heading, bold/italic/inline-code, bullet list, syntax-highlighted Swift code block, table, link.
- **Bundle removed** → readable plain-text fallback instead of a blank sliver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)