### PR TITLE
feat(ios): expand & copy code blocks in chat

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ContentZoom.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ContentZoom.swift
@@ -10,8 +10,18 @@ struct ZoomTarget: Identifiable {
     enum Content {
         case image(UIImage)
         case html(String)
+        /// A code block: the highlighted `<pre>` HTML for display plus the raw
+        /// text so the zoom surface can copy it natively.
+        case code(html: String, text: String)
     }
     let content: Content
+
+    /// The raw text a "Copy" affordance should place on the pasteboard, if this
+    /// target carries copyable text (code blocks do).
+    var copyText: String? {
+        if case .code(_, let text) = content, !text.isEmpty { return text }
+        return nil
+    }
 }
 
 extension Notification.Name {
@@ -29,6 +39,9 @@ enum ContentZoom {
     }
     static func image(_ image: UIImage) { present(ZoomTarget(content: .image(image))) }
     static func html(_ html: String) { present(ZoomTarget(content: .html(html))) }
+    static func code(html: String, text: String) {
+        present(ZoomTarget(content: .code(html: html, text: text)))
+    }
 }
 
 /// Full-screen zoom surface with a close button. Images zoom natively; HTML
@@ -37,30 +50,54 @@ enum ContentZoom {
 struct ZoomableContentView: View {
     let target: ZoomTarget
     @Environment(\.dismiss) private var dismiss
+    @State private var copied = false
 
     var body: some View {
-        ZStack(alignment: .topTrailing) {
+        ZStack(alignment: .top) {
             Color.black.ignoresSafeArea()
             Group {
                 switch target.content {
                 case .image(let image): ZoomableImageView(image: image)
                 case .html(let html): ZoomableHTMLView(html: html)
+                case .code(let html, _): ZoomableCodeView(html: html)
                 }
             }
             .ignoresSafeArea(edges: .bottom)
 
-            Button { dismiss() } label: {
-                Image(systemName: "xmark.circle.fill")
-                    .font(.system(size: 30))
-                    .symbolRenderingMode(.palette)
-                    .foregroundStyle(.white, .black.opacity(0.35))
-                    .padding(8)
+            // Top bar: a Copy affordance (when the content carries copyable text,
+            // i.e. a code block) on the left, and a Close button on the right.
+            HStack {
+                if let text = target.copyText {
+                    Button { copy(text) } label: {
+                        Label(copied ? "Copied" : "Copy",
+                              systemImage: copied ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 12).padding(.vertical, 7)
+                            .background(copied ? Color.green.opacity(0.85)
+                                               : Color.white.opacity(0.16), in: Capsule())
+                    }
+                    .accessibilityLabel("Copy code")
+                }
+                Spacer()
+                Button { dismiss() } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 30))
+                        .symbolRenderingMode(.palette)
+                        .foregroundStyle(.white, .black.opacity(0.35))
+                }
+                .accessibilityLabel("Close")
             }
-            .accessibilityLabel("Close")
             .padding(.top, 8)
-            .padding(.trailing, 12)
+            .padding(.horizontal, 12)
         }
         .statusBarHidden(true)
+    }
+
+    private func copy(_ text: String) {
+        UIPasteboard.general.string = text
+        Haptics.tap()
+        withAnimation(.snappy) { copied = true }
     }
 }
 
@@ -145,6 +182,52 @@ private struct ZoomableHTMLView: UIViewRepresentable {
         #zoom { width:100%; }
         #zoom table { display:table; width:auto; min-width:100%; overflow:visible; font-size:1em; }
         #zoom img, #zoom svg { max-width:100%; height:auto; }
+        </style>
+        </head><body><div id="zoom">\(fragment)</div></body></html>
+        """
+    }
+
+    private static var cssURL: URL {
+        Bundle.main.url(forResource: "markdown", withExtension: "css")
+            ?? URL(fileURLWithPath: "/dev/null")
+    }
+}
+
+/// Renders a code block (its highlighted `<pre>` HTML) full-screen: top-left
+/// aligned, scrollable in both axes (long lines don't wrap), pinch-zoomable, and
+/// styled with the bundled markdown CSS so syntax colours match the chat.
+private struct ZoomableCodeView: UIViewRepresentable {
+    let html: String
+
+    func makeUIView(context: Context) -> WKWebView {
+        let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.scrollView.backgroundColor = .clear
+        webView.scrollView.indicatorStyle = .white
+        webView.loadHTMLString(Self.document(for: html), baseURL: nil)
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+
+    private static func document(for fragment: String) -> String {
+        let css = (try? String(contentsOf: cssURL, encoding: .utf8)) ?? ""
+        return """
+        <!doctype html><html><head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=yes">
+        <style>
+        \(css)
+        html,body { margin:0; background:transparent; }
+        /* leave room for the top bar; sit flush top-left so reading starts at the
+           first line, and let long lines scroll horizontally rather than wrap. */
+        body { padding:56px 16px 24px; }
+        #zoom pre {
+          margin:0; border:0; background:transparent;
+          white-space:pre; overflow:visible;
+        }
+        #zoom code { font-size:0.95em; line-height:1.55; white-space:pre; }
         </style>
         </head><body><div id="zoom">\(fragment)</div></body></html>
         """

--- a/apps/ios/CovenCave/CovenCave/Views/MarkdownWebView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MarkdownWebView.swift
@@ -91,11 +91,17 @@ struct MarkdownWebView: UIViewRepresentable {
                         Haptics.tap()
                     }
                 case "enlarge":
-                    // A tapped table / Mermaid diagram / inline image — hand its
-                    // HTML to the full-screen zoom surface (ChatView presents it).
+                    // A tapped table / Mermaid diagram / inline image, or an
+                    // expanded code block — hand it to the full-screen zoom
+                    // surface (ChatView presents it). Code carries its raw text
+                    // so the zoom view's Copy button works.
                     if let html = body["html"] as? String, !html.isEmpty {
                         Haptics.tap()
-                        ContentZoom.html(html)
+                        if body["kind"] as? String == "code" {
+                            ContentZoom.code(html: html, text: body["text"] as? String ?? "")
+                        } else {
+                            ContentZoom.html(html)
+                        }
                     }
                 default:
                     break

--- a/apps/ios/markdown/entry.mjs
+++ b/apps/ios/markdown/entry.mjs
@@ -70,12 +70,23 @@ function highlightCode(code, rawLang) {
   let lang = (rawLang ?? "").trim().toLowerCase().split(/\s+/)[0];
   lang = ALIASES[lang] ?? lang;
   let inner = escapeHtml(code);
+  let resolved = "";
   if (lang && hljs.getLanguage(lang)) {
+    resolved = lang;
     try { inner = hljs.highlight(code, { language: lang, ignoreIllegals: true }).value; } catch {}
   }
-  // Wrap in a positioned container with a copy button; the button reads the
-  // <code> textContent (raw, de-highlighted) and hands it to native on tap.
-  return `<div class="code-block"><button class="code-copy" type="button" aria-label="Copy code">Copy</button><pre class="hljs"><code class="hljs">${inner}</code></pre></div>`;
+  // A header bar (language label + Expand + Copy) sits above the code, like the
+  // desktop chat. Expand lifts the highlighted <pre> to a full-screen viewer;
+  // Copy reads the <code> textContent (raw, de-highlighted) and hands it to
+  // native. Both are explicit buttons so reading/scrolling code never triggers
+  // them by accident.
+  const label = resolved ? `<span class="code-lang">${escapeHtml(resolved)}</span>` : `<span class="code-lang"></span>`;
+  return `<div class="code-block">`
+    + `<div class="code-toolbar">${label}<span class="code-actions">`
+    + `<button class="code-btn code-expand" type="button" aria-label="Expand code">⤢ Expand</button>`
+    + `<button class="code-btn code-copy" type="button" aria-label="Copy code">Copy</button>`
+    + `</span></div>`
+    + `<pre class="hljs"><code class="hljs">${inner}</code></pre></div>`;
 }
 
 async function renderMarkdown(md) {
@@ -145,12 +156,29 @@ document.addEventListener("click", (e) => {
 document.addEventListener("click", (e) => {
   const btn = e.target?.closest?.(".code-copy");
   if (!btn) return;
-  const text = btn.parentElement?.querySelector("code")?.textContent ?? "";
+  const text = btn.closest(".code-block")?.querySelector("code")?.textContent ?? "";
   window.webkit?.messageHandlers?.cave?.postMessage({ type: "copy", text });
   btn.textContent = "Copied";
   btn.classList.add("is-copied");
   clearTimeout(btn._t);
   btn._t = setTimeout(() => { btn.textContent = "Copy"; btn.classList.remove("is-copied"); }, 1400);
+});
+
+// Expand a code block: lift the highlighted <pre> into a full-screen, scrollable
+// code viewer (native owns the surface) and pass the raw text so the viewer's
+// own Copy button works without round-tripping through the WebView again.
+document.addEventListener("click", (e) => {
+  const btn = e.target?.closest?.(".code-expand");
+  if (!btn) return;
+  const block = btn.closest(".code-block");
+  const pre = block?.querySelector("pre");
+  const text = block?.querySelector("code")?.textContent ?? "";
+  window.webkit?.messageHandlers?.cave?.postMessage({
+    type: "enlarge",
+    kind: "code",
+    html: pre?.outerHTML ?? "",
+    text,
+  });
 });
 
 // Tap a table, Mermaid diagram, or inline image to enlarge it full-screen —

--- a/apps/ios/markdown/markdown.css
+++ b/apps/ios/markdown/markdown.css
@@ -51,7 +51,23 @@ code {
   border-radius: 5px;
 }
 
-/* fenced code block */
+/* fenced code block — the .code-block container owns the frame (border/radius/
+   background) so the header bar and <pre> share one rounded card. */
+.code-block {
+  position: relative;
+  margin: 0 0 0.7em;
+  background: var(--code-bg);
+  border: 1px solid var(--code-border);
+  border-radius: 11px;
+  overflow: hidden;
+}
+.code-block pre {
+  margin: 0; border: 0; border-radius: 0; background: transparent;
+  padding: 12px 14px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+/* bare <pre> (e.g. lifted into the zoom view without the container) keeps a frame */
 pre {
   margin: 0 0 0.7em;
   background: var(--code-bg);
@@ -66,24 +82,34 @@ pre code {
   font-size: 0.86em; line-height: 1.5; border-radius: 0;
   white-space: pre;
 }
-/* fenced code block: a copy button pinned top-right (no hover on touch, so it
-   stays gently visible and brightens on tap / after copy). */
-.code-block { position: relative; }
-.code-copy {
-  position: absolute; top: 8px; right: 8px;
+
+/* code block header: language label on the left, actions (Expand / Copy) on the
+   right. No hover on touch, so the buttons stay clearly visible. */
+.code-toolbar {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  padding: 5px 8px 5px 12px;
+  background: rgba(255,255,255,0.035);
+  border-bottom: 1px solid var(--code-border);
+}
+.code-lang {
+  font: 600 10.5px ui-monospace, "SF Mono", Menlo, monospace;
+  letter-spacing: 0.05em; text-transform: uppercase;
+  color: var(--txt-muted);
+}
+.code-actions { display: inline-flex; gap: 6px; flex: none; }
+.code-btn {
   -webkit-appearance: none; appearance: none;
+  display: inline-flex; align-items: center; gap: 4px;
   font: 600 11px -apple-system, system-ui, sans-serif;
   padding: 3px 9px; border-radius: 7px;
   border: 1px solid rgba(255,255,255,0.14);
   background: rgba(255,255,255,0.07);
-  color: rgba(255,255,255,0.62);
-  opacity: 0.7; cursor: pointer;
-  transition: opacity 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+  color: rgba(255,255,255,0.74);
+  cursor: pointer;
+  transition: color 0.12s ease, border-color 0.12s ease, background 0.12s ease;
 }
-.code-copy:active { opacity: 1; background: rgba(255,255,255,0.12); }
-.code-copy.is-copied {
-  opacity: 1; color: #57C878; border-color: rgba(87,200,120,0.5);
-}
+.code-btn:active { background: rgba(255,255,255,0.16); color: #fff; }
+.code-copy.is-copied { color: #57C878; border-color: rgba(87,200,120,0.5); }
 
 /* tables */
 table { border-collapse: collapse; width: 100%; margin: 0 0 0.7em; font-size: 0.92em; display: block; overflow-x: auto; }


### PR DESCRIPTION
## What

Two related upgrades to code blocks in the iOS chat:

1. **Expand** — code blocks can now open **full-screen** in a scrollable, pinch-zoomable viewer (syntax highlighting preserved, long lines scroll instead of wrapping). New `ZoomTarget.code` case + `ZoomableCodeView`, routed through the existing tap-to-enlarge zoom surface.
2. **Intuitive copy** — replaced the lone faint floating "Copy" pill with a clear **header bar** on every code block: a language label on the left, and **⤢ Expand** + **Copy** buttons on the right. Copy is also available (prominently) inside the expanded view.

Both are explicit buttons, so reading/scrolling code never triggers them by accident.

## How

- `apps/ios/markdown/entry.mjs` — code blocks render a `.code-toolbar` header (lang + Expand + Copy); new `.code-expand` handler lifts the highlighted `<pre>` + raw text to native via the `enlarge` message (`kind: "code"`). Fixed the copy handler to resolve `<code>` via the `.code-block` ancestor (the button moved into the toolbar).
- `apps/ios/markdown/markdown.css` — `.code-block` container owns the card frame; styled header bar + buttons.
- `Views/MarkdownWebView.swift` — routes `enlarge`/`kind:"code"` to `ContentZoom.code(html:text:)`.
- `Views/ContentZoom.swift` — `ZoomTarget.code`, a Copy button in the full-screen bar (native `UIPasteboard`, uses the raw text), and `ZoomableCodeView`.

`markdown.html` / generated `markdown.css` are gitignored build artifacts — the **renderer source** (`entry.mjs` + source `markdown.css`) and Swift are committed. Regenerate with `node scripts/build-ios-markdown.mjs`. iOS isn't built by CI.

## Verification

- In-bubble: header bar renders with `SWIFT`/`BASH` language labels + Expand/Copy buttons, highlighting intact (screenshot in PR thread).
- Button payloads asserted via a headless harness: Expand posts `{kind:"code", html:<pre>, text}`; Copy posts the raw code text (this caught & fixed an empty-copy regression).
- Expanded viewer renders large, highlighted, horizontally-scrollable code.
- `xcodebuild` for the simulator: **BUILD SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)