### PR TITLE
fix(chat): order chat list by last message, not last viewed

### DIFF
--- a/src/lib/session-list-merge.test.ts
+++ b/src/lib/session-list-merge.test.ts
@@ -141,4 +141,54 @@ assert.equal(
   "archived local chats should return when includeArchived is enabled",
 );
 
+// A daemon session whose `updated_at` was bumped by a mere resume/view should
+// order by the matching local conversation's last-message time, not the later
+// view time — so reopening an old chat doesn't float it to the top.
+const viewedDaemon = {
+  id: "chat-7",
+  project_root: "/repo",
+  harness: "codex",
+  title: "Reopened chat",
+  status: "completed",
+  exit_code: 0,
+  archived_at: null,
+  created_at: "2026-06-01T10:00:00.000Z",
+  updated_at: "2026-06-20T09:00:00.000Z", // bumped "now" by opening it
+};
+const chat7Local = {
+  sessionId: "chat-7",
+  familiarId: "charm",
+  updatedAt: "2026-06-02T11:00:00.000Z", // real last message, days earlier
+};
+const recentDaemon = {
+  ...viewedDaemon,
+  id: "chat-9",
+  title: "Genuinely recent chat",
+  created_at: "2026-06-10T10:00:00.000Z",
+  updated_at: "2026-06-10T12:00:00.000Z",
+};
+const chat9Local = {
+  sessionId: "chat-9",
+  familiarId: "cody",
+  updatedAt: "2026-06-10T12:00:00.000Z",
+};
+
+const orderedByMessage = mergeSessionRows({
+  daemonSessions: [viewedDaemon, recentDaemon],
+  localConversations: [chat7Local, chat9Local],
+  state: { sessionFamiliar: {}, sessionTitles: {}, sessionArchived: {}, sessionSacrificed: {} },
+  includeArchived: false,
+});
+
+assert.equal(
+  orderedByMessage.find((s) => s.id === "chat-7")?.updated_at,
+  "2026-06-02T11:00:00.000Z",
+  "a daemon session with a local conversation should use the local last-message time, not the daemon's view-time bump",
+);
+assert.deepEqual(
+  orderedByMessage.map((s) => s.id),
+  ["chat-9", "chat-7"],
+  "the genuinely-recent chat outranks the just-reopened older chat",
+);
+
 console.log("session-list-merge.test.ts: ok");

--- a/src/lib/session-list-merge.ts
+++ b/src/lib/session-list-merge.ts
@@ -80,6 +80,17 @@ export function mergeSessionRows({
   const seen = new Set<string>();
   const rows: SessionRow[] = [];
 
+  // The daemon bumps a session's `updated_at` when it's resumed/attached — i.e.
+  // when you merely *open* a chat — so ordering by it sinks to "last viewed".
+  // For UI-originated chats we also keep a local conversation whose `updatedAt`
+  // is written only when a turn is appended (chat/send), so it tracks the last
+  // message sent or received. Prefer that message-authoritative timestamp so
+  // the list orders by real activity, not by what you last looked at.
+  const localUpdatedById = new Map<string, string>();
+  for (const conv of localConversations) {
+    if (conv.updatedAt) localUpdatedById.set(conv.sessionId, conv.updatedAt);
+  }
+
   for (const session of daemonSessions) {
     if (isValidDaemonProjectRoot && !isValidDaemonProjectRoot(session.project_root)) {
       continue;
@@ -88,8 +99,10 @@ export function mergeSessionRows({
     const titleOverride = state.sessionTitles[session.id];
     const archivedLocal = state.sessionArchived[session.id] ?? null;
     const archived_at = archivedLocal ?? session.archived_at;
+    const localUpdatedAt = localUpdatedById.get(session.id);
     const row: SessionRow = {
       ...session,
+      ...(localUpdatedAt ? { updated_at: localUpdatedAt } : {}),
       // Daemon titles derive from the harness prompt, which the chat route
       // prefixes with the identity canon — sanitize so the preamble never
       // surfaces as a session title.


### PR DESCRIPTION
## Problem

The chat list ordered by `updated_at`. For UI-originated chats — which exist as **both** a coven-daemon session and a local conversation — the daemon row wins the merge, and the daemon bumps its `updated_at` whenever a session is **resumed/attached** (i.e. when you merely *open* the chat). So reopening an old conversation floated it to the top: the list ordered by **last viewed** instead of **last message sent or received**.

(The native iOS chat list was already correct — it sorts a local snapshot whose `updatedAt` is bumped only on message activity, and never fetches the daemon session feed. This fix addresses the shared server feed that the desktop list consumes.)

## Fix

In `mergeSessionRows`, when a daemon session has a matching local conversation, use the **local conversation's `updatedAt`** for the row. The local store is written only when a turn is appended (`chat/send`), so it tracks real message activity rather than attach/view time. Sessions with no local conversation (started outside Cave, e.g. CLI) keep the daemon timestamp as the best available signal.

## Test

Added a regression case to `session-list-merge.test.ts`: a daemon session whose `updated_at` was bumped "now" by a view, but whose local conversation's last message is days earlier, now orders **below** a genuinely-recent chat.

## Tradeoff

If a Cave chat is continued *outside* the Cave UI (e.g. resumed via CLI), the local store won't see those turns, so the row orders by the last Cave-side message. This is rare for UI-driven chats and is the right default for "order by last message" — it deliberately ignores the daemon's view-time bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)