### PR TITLE
fix(ios): remove duplicate @State in TaskDetailView (broke all iOS builds)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
@@ -9,8 +9,6 @@ struct TaskDetailView: View {
     @State private var notesHeight: CGFloat = 0
     @State private var notesReader: ResponseReaderItem?
     @State private var confirmingDelete = false
-    @State private var notesHeight: CGFloat = 0
-    @State private var notesReader: ResponseReaderItem?
 
     /// The current card from the store, so status/priority/step edits made here
     /// reflect immediately; falls back to the passed-in snapshot.


### PR DESCRIPTION
## Problem

`TaskDetailView.swift` declared `notesHeight` and `notesReader` **twice** — two PRs each added the same `@State` and both merged without iOS being compiled in CI (the recurring silently-red-main-for-iOS pattern). Every iOS build fails:

```
error: invalid redeclaration of 'notesHeight'
error: invalid redeclaration of 'notesReader'
```

## Fix

Remove the duplicate pair (kept the first, which the notes card + reader reference). One-line-ish change, no behavior difference.

Found while building `main` for a device deploy — `xcodebuild` now **BUILD SUCCEEDED** with this applied. iOS isn't built by CI, so the required checks were green despite the breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)