### PR TITLE
feat(ios): remove the Canvas bottom tab (open on Chats)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -3,7 +3,7 @@ import Observation
 
 /// The bottom tabs. Lifted out of the view so slash commands (`/board`,
 /// `/chats`) can drive tab selection from anywhere.
-enum AppTab: String { case chats, canvas, read, tasks, dev }
+enum AppTab: String { case chats, read, tasks, dev }
 
 /// A transient confirmation banner shown over the chat after a command runs.
 struct ToastMessage: Identifiable, Equatable {
@@ -35,7 +35,7 @@ final class AppModel {
     // MARK: - Cross-view command routing
 
     /// The selected bottom tab. Bound by `MainTabView`; set by `/board` / `/chats`.
-    var selectedTab: AppTab = .canvas
+    var selectedTab: AppTab = .chats
 
     /// A thread a command asked to open. `ChatsHomeView` observes this, pushes
     /// the thread, and clears it back to nil (one-shot navigation intent).

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -34,9 +34,6 @@ struct MainTabView: View {
             Tab("Chats", systemImage: "bubble.left.and.bubble.right.fill", value: AppTab.chats) {
                 ChatsHomeView()
             }
-            Tab("Canvas", systemImage: "wand.and.stars", value: AppTab.canvas) {
-                CanvasView()
-            }
             Tab("Read", systemImage: "books.vertical.fill", value: AppTab.read) {
                 ReadingView()
             }
@@ -46,14 +43,6 @@ struct MainTabView: View {
             Tab("Developer", systemImage: "chevron.left.forwardslash.chevron.right", value: AppTab.dev) {
                 DeveloperView()
             }
-        }
-        // The app always opens on the Canvas tab. TabView wins a layout race at
-        // cold launch and resets its selection to the first tab, so re-assert
-        // Canvas a beat later — once that settles the binding drives the tab.
-        // In-session, slash commands (`/chats`, `/board`) still move the tab.
-        .task {
-            try? await Task.sleep(for: .milliseconds(300))
-            app.selectedTab = .canvas
         }
         // Command confirmations float above the whole tab bar so they're visible
         // whether a command stays in chat or jumps to the Tasks tab.

--- a/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
@@ -9,8 +9,6 @@ struct TaskDetailView: View {
     @State private var notesHeight: CGFloat = 0
     @State private var notesReader: ResponseReaderItem?
     @State private var confirmingDelete = false
-    @State private var notesHeight: CGFloat = 0
-    @State private var notesReader: ResponseReaderItem?
 
     /// The current card from the store, so status/priority/step edits made here
     /// reflect immediately; falls back to the passed-in snapshot.
@@ -51,9 +49,6 @@ struct TaskDetailView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: { Text(live.title) }
-        .sheet(item: $notesReader) { item in
-            ResponseReaderView(item: item)
-        }
     }
 
     private var actionsMenu: some View {

--- a/scripts/ios-no-canvas-tab.test.mjs
+++ b/scripts/ios-no-canvas-tab.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const model = await readFile(
+  new URL("../apps/ios/CovenCave/CovenCave/State/AppModel.swift", import.meta.url),
+  "utf8",
+);
+const root = await readFile(
+  new URL("../apps/ios/CovenCave/CovenCave/Views/RootView.swift", import.meta.url),
+  "utf8",
+);
+
+// The bottom-tab enum no longer carries a canvas case.
+assert.match(
+  model,
+  /enum AppTab: String \{ case chats, read, tasks, dev \}/,
+  "AppTab should drop the canvas case",
+);
+// The enum line itself must not list a canvas case (dormant canvas *state*
+// elsewhere in the model is intentionally left in place by this minimal scope).
+const appTabLine = model.match(/enum AppTab: String \{[^}]*\}/)?.[0] ?? "";
+assert.doesNotMatch(appTabLine, /\bcanvas\b/, "AppTab case list should not include canvas");
+
+// The app opens on Chats now that Canvas is gone.
+assert.match(model, /var selectedTab: AppTab = \.chats/, "default tab should be chats");
+
+// The tab bar no longer mounts a Canvas tab and no longer re-asserts it.
+assert.doesNotMatch(root, /Tab\("Canvas"/, "RootView should not declare a Canvas tab");
+assert.doesNotMatch(root, /CanvasView\(\)/, "RootView should not instantiate CanvasView");
+assert.doesNotMatch(root, /selectedTab = \.canvas/, "RootView should not re-assert the canvas tab");
+
+console.log("ios-no-canvas-tab.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -481,6 +481,7 @@ export const SUITES = {
     "src/lib/mobile-handoff.test.ts",
     "scripts/ios-app-store-assets.test.mjs",
     "scripts/ios-code-viewer.test.mjs",
+    "scripts/ios-no-canvas-tab.test.mjs",
     "scripts/ios-message-reader.test.mjs",
     "scripts/ios-task-notes-reader.test.mjs",
     "scripts/ios-task-actions.test.mjs",


### PR DESCRIPTION
## What

Removes the **Canvas** tab from the iOS bottom tab bar. The app now opens on **Chats**.

- **`AppModel.swift`** — drop the `canvas` case from `AppTab`; default `selectedTab` to `.chats`.
- **`RootView.swift`** — remove the Canvas `Tab` and the now-moot post-launch re-assert to `.canvas` (the value-based `Tab(value:)` API already honours the initial selection, so first-tab = Chats is stable).
- **`ios-no-canvas-tab.test.mjs`** — new assertion test (enum has no canvas case, default tab is chats, RootView declares no Canvas tab / `CanvasView()` / re-assert), wired into `run-tests.mjs`.

### Scope
Minimal — this removes the **tab entry point** only. The Canvas plumbing (`CanvasView`, `CanvasArtifact`, the `/api/canvas` client methods, and the `canvas*` `AppModel` state) is left **dormant rather than deleted**, and the `/canvas` slash command (a chat sketch prompt, unrelated to the tab) is untouched. Say the word if you want the full Canvas feature ripped out too.

### Drive-by fix (main was red for iOS)
`TaskDetailView.swift` on `main` had **duplicate declarations** — `notesHeight`/`notesReader` and a `.sheet(item: $notesReader)` each declared twice (a botched notes-reader merge). Since iOS isn't built in CI, it landed red. De-duplicated here so the app compiles; without this, no iOS build on current `main` succeeds.

## Verification

- `node scripts/ios-no-canvas-tab.test.mjs` → **ok**.
- `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED** (fails without the dedup fix).

Built in an isolated worktree off `main`; reconstructed cleanly against current `main` because the original change was uncommitted scratch that a branch-consolidation workflow had stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)