### PR TITLE
feat(chat): inline conversation branching (web) — PR 1 of 2

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -37,6 +37,7 @@ export const SUITES = {
     "src/lib/github-checks.test.ts",
     "src/lib/gfm-autolink.test.ts",
     "src/lib/chat-projects.test.ts",
+    "src/lib/conversation-tree.test.ts",
     "src/lib/chat-project-selection.test.ts",
     "src/lib/chat-session-order.test.ts",
     "src/lib/chat-project-overrides.test.ts",

--- a/src/app/api/chat/conversation/[id]/route.ts
+++ b/src/app/api/chat/conversation/[id]/route.ts
@@ -26,6 +26,7 @@ type ConversationWriteBody = {
   updatedAt?: string;
   turn?: unknown;
   turns?: unknown[];
+  activeLeafId?: unknown;
 };
 
 type ConversationPatchBody = {
@@ -35,6 +36,7 @@ type ConversationPatchBody = {
     applicationState?: unknown;
     reason?: unknown;
   } | null;
+  activeLeafId?: unknown;
 };
 
 function jsonError(error: string, status: number) {
@@ -66,6 +68,12 @@ function normalizeTurn(input: unknown): ChatTurn | null {
     ...(Array.isArray(value.attachments) ? { attachments: value.attachments } : {}),
     ...(typeof value.reasoning === "string" ? { reasoning: value.reasoning } : {}),
     ...(Array.isArray(value.tools) ? { tools: value.tools } : {}),
+    ...(typeof value.parentId === "string" || value.parentId === null
+      ? { parentId: value.parentId }
+      : {}),
+    ...(typeof value.harnessSessionId === "string"
+      ? { harnessSessionId: value.harnessSessionId }
+      : {}),
     createdAt:
       typeof value.createdAt === "string" && value.createdAt.trim()
         ? value.createdAt
@@ -130,6 +138,11 @@ function buildConversation(args: {
         ? args.body.updatedAt
         : args.existing?.updatedAt ?? now,
     turns: args.turns,
+    ...(typeof args.body.activeLeafId === "string" && args.body.activeLeafId
+      ? { activeLeafId: args.body.activeLeafId }
+      : args.existing?.activeLeafId
+        ? { activeLeafId: args.existing.activeLeafId }
+        : {}),
   };
 }
 
@@ -234,6 +247,14 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
   }
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     return jsonError("invalid json body", 400);
+  }
+
+  if (typeof body.activeLeafId === "string" && body.activeLeafId) {
+    const existing = await loadConversation(id);
+    if (!existing) return jsonError("not found", 404);
+    existing.activeLeafId = body.activeLeafId;
+    await saveConversation(existing);
+    return NextResponse.json({ ok: true, conversation: existing });
   }
 
   const existing = await loadConversation(id);

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1463,11 +1463,11 @@ export async function POST(req: Request) {
           createdAt: new Date().toISOString(),
           durationMs: result.duration_ms,
           isError: result.is_error,
-          parentId: userTurnId,
           ...(cancelledByUser ? { cancelled: true } : {}),
           ...(result.usage ? { usage: result.usage } : {}),
           ...(result.costUsd !== undefined ? { costUsd: result.costUsd } : {}),
           ...(persistedTools ? { tools: persistedTools } : {}),
+          parentId: userTurnId,
           responseMetadata,
         };
         const conv = existing ?? {

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -111,6 +111,9 @@ type SendBody = {
   /** Project root the mentions are relative to — resumed sessions don't carry
    * projectRoot in the body, so the composer sends the root it knows. */
   mentionedFilesRoot?: string;
+  /** Branching: when set, the new user turn is parented here (its prior
+   *  sibling stays in the tree) and the new assistant turn becomes the tip. */
+  parentTurnId?: string;
 };
 
 type ReasoningEffort = "low" | "medium" | "high";
@@ -693,6 +696,10 @@ function openClawChatResponse(args: {
           const assistantTurnId = crypto.randomUUID();
           const chatTitle = existing?.title ?? defaultChatTitleForSession(sessionId);
           if (!existing) await setDefaultSessionTitleIfMissing(sessionId, chatTitle);
+          // Branching: same logic as the coven-run path — client-supplied
+          // parentTurnId takes precedence; falls back to prior activeLeafId for
+          // normal (non-branch) sends so the linear chain is preserved.
+          const branchParentId = args.body.parentTurnId ?? existing?.activeLeafId ?? null;
           const conv = existing ?? {
             sessionId,
             familiarId: args.body.familiarId,
@@ -714,6 +721,7 @@ function openClawChatResponse(args: {
               text: args.promptText,
               ...(args.attachments.length ? { attachments: args.attachments } : {}),
               createdAt: now,
+              ...(branchParentId != null ? { parentId: branchParentId } : {}),
             },
             {
               id: assistantTurnId,
@@ -722,10 +730,12 @@ function openClawChatResponse(args: {
               createdAt: new Date().toISOString(),
               durationMs,
               isError,
+              parentId: userTurnId,
               responseMetadata,
               ...(cancelledByUser ? { cancelled: true } : {}),
             },
           );
+          conv.activeLeafId = assistantTurnId;
           await saveConversation(conv);
           pushProgress("save-transcript", "Transcript saved", "done");
           scheduleLinkRoute({
@@ -1425,12 +1435,19 @@ export async function POST(req: Request) {
         const assistantTurnId = crypto.randomUUID();
         const chatTitle = existing?.title ?? defaultChatTitleForSession(finalSessionId);
         if (!existing) await setDefaultSessionTitleIfMissing(finalSessionId, chatTitle);
+        // Branching: when the client passes parentTurnId, the new user turn is
+        // parented there (its prior sibling stays in the tree). For a normal
+        // (non-branch) send, fall back to the prior activeLeafId so the
+        // conversation stays a linear chain identical to the pre-branching
+        // behaviour. First turn of a new chat gets null (no parent).
+        const branchParentId = body.parentTurnId ?? existing?.activeLeafId ?? null;
         const userTurn: ChatTurn = {
           id: userTurnId,
           role: "user",
           text: promptText,
           ...(persistedAttachments.length ? { attachments: persistedAttachments } : {}),
           createdAt: now,
+          ...(branchParentId != null ? { parentId: branchParentId } : {}),
         };
         // Persist the turn's tool rows: the live chips exist only in client
         // state fed by SSE; without this, refresh/chat-switch loses them.
@@ -1446,6 +1463,7 @@ export async function POST(req: Request) {
           createdAt: new Date().toISOString(),
           durationMs: result.duration_ms,
           isError: result.is_error,
+          parentId: userTurnId,
           ...(cancelledByUser ? { cancelled: true } : {}),
           ...(result.usage ? { usage: result.usage } : {}),
           ...(result.costUsd !== undefined ? { costUsd: result.costUsd } : {}),
@@ -1468,6 +1486,7 @@ export async function POST(req: Request) {
         persistSendModelIntent(conv, body, modelState);
         if (harnessSessionId) conv.harnessSessionId = harnessSessionId;
         conv.turns.push(userTurn, assistantTurn);
+        conv.activeLeafId = assistantTurnId;
         await saveConversation(conv);
         pushProgress("save-transcript", "Transcript saved", "done");
 

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -127,7 +127,7 @@ assert.match(
 
 assert.match(
   source,
-  /const send = async \(override\?: string\) => \{[\s\S]*?intentFromSlash\(text\)[\s\S]*?if \(busy\) return;[\s\S]*?setInput\(""\);[\s\S]*?setAttachments\(\[\]\);[\s\S]*?await sendRaw\(outgoingText, outgoingAttachments, outgoingMentions\)/,
+  /const send = async \(override\?: string\) => \{[\s\S]*?intentFromSlash\(text\)[\s\S]*?if \(busy\) return;[\s\S]*?setInput\(""\);[\s\S]*?setAttachments\(\[\]\);[\s\S]*?await sendRaw\(outgoingText, outgoingAttachments, outgoingMentions/,
   "send() must run slash intents first, then bail on busy BEFORE clearing the composer — a mid-stream Enter must not destroy the draft (CHAT-D5-01)",
 );
 
@@ -185,7 +185,7 @@ assert.match(
 
 assert.match(
   source,
-  /function regenerateFor\(turn: Turn\)[\s\S]*?role === "user"[\s\S]*?if \(!prevUser\) return undefined;[\s\S]*?return \(\) => void sendRaw\(text, prevAttachments \?\? \[\]\);/,
+  /function regenerateFor\(turn: Turn\)[\s\S]*?role === "user"[\s\S]*?if \(!prevUser\) return undefined;[\s\S]*?return \(\) => void sendRaw\(text, prevAttachments \?\? \[\]/,
   "Regenerate re-sends the preceding user turn (text + attachments) through the guarded sendRaw path, and hides when no user turn precedes (CHAT-D6-02)",
 );
 
@@ -213,7 +213,7 @@ assert.match(
 // false, error: true) must keep passing it, or the pill below never renders.
 const regenerateForBody =
   source.match(
-    /function regenerateFor\(turn: Turn\)[\s\S]*?return \(\) => void sendRaw\(text, prevAttachments \?\? \[\]\);/,
+    /function regenerateFor\(turn: Turn\)[\s\S]*?return \(\) => void sendRaw\(text, prevAttachments \?\? \[\]/,
   )?.[0] ?? "";
 assert.ok(regenerateForBody, "regenerateFor body should be extractable (CHAT-D12-03)");
 assert.doesNotMatch(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -69,7 +69,7 @@ import { toolInputAsDiff, toolTargetFile } from "@/lib/tool-input-diff";
 import { findMatchingTurnIds } from "@/lib/transcript-find";
 import { isSyntheticLocalModel, type ChatModelState } from "@/lib/chat-model-state";
 import { readComposerHistory, writeComposerHistory } from "@/lib/composer-history";
-import { resolveActivePath } from "@/lib/conversation-tree";
+import { resolveActivePath, siblingsOf, childLeaf } from "@/lib/conversation-tree";
 
 type ToolEvent = {
   id: string;
@@ -1605,6 +1605,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
 ) {
   const [turns, setTurns] = useState<Turn[]>([]);
   const [activeLeafId, setActiveLeafId] = useState<string>("");
+  const [pendingBranchParent, setPendingBranchParent] = useState<string | null>(null);
   const [historyState, setHistoryState] = useState<ChatHistoryState>("idle");
   const [debugModalOpen, setDebugModalOpen] = useState(false);
 
@@ -2527,7 +2528,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     text: string,
     outgoingAttachments: ChatAttachment[] = [],
     outgoingMentions: string[] = [],
-    opts?: { promptOverride?: string },
+    opts?: { promptOverride?: string; parentTurnId?: string },
   ) => {
     const trimmed = text.trim();
     const submitPrompt = opts?.promptOverride?.trim() || trimmed;
@@ -2544,10 +2545,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     liveSessionIdRef.current = currentSessionRef.current;
     setHistoryState("loaded");
 
+    const resolvedParentId = opts?.parentTurnId ?? (activeLeafId || null);
     const now = new Date().toISOString();
     const userTurn: Turn = {
       id: crypto.randomUUID(),
-      parentId: activeLeafId || null,
+      parentId: resolvedParentId,
       role: "user",
       text: trimmed,
       ...(outgoingAttachments.length ? { attachments: outgoingAttachments } : {}),
@@ -2609,6 +2611,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 mentionedFilesRoot: mentionRoot,
               }
             : {}),
+          // Branching: when regenerating or re-editing from a non-leaf
+          // position, send the explicit parent so the server builds the new
+          // turn off the right node rather than defaulting to the current
+          // active leaf.
+          ...(opts?.parentTurnId ? { parentTurnId: opts.parentTurnId } : {}),
         }),
         signal: controller.signal,
       });
@@ -2706,8 +2713,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // server-side context, so locally rewriting the transcript would lie on
   // reload). A non-empty draft is never silently destroyed: we only prefill
   // when the composer is empty, and always hand focus back to it.
+  // When the edited turn is the LAST user turn on the active path, the next
+  // send will branch from its parent (creating a sibling instead of a child).
   function editTurnInComposer(turn: Turn) {
     setInput((current) => (current.trim() ? current : turn.text));
+    const lastUser = [...activePath].reverse().find((t) => t.role === "user");
+    if (lastUser?.id === turn.id) setPendingBranchParent(turn.parentId ?? null);
     inputRef.current?.focus();
   }
 
@@ -2744,21 +2755,46 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
 
   // CHAT-D6-02: regenerate. Re-sends the PRECEDING user turn (text +
   // attachments) through the normal guarded sendRaw path as a new turn pair.
-  // Returns undefined (action hidden) while busy, on pending turns, and on
-  // assistant turns with no preceding user turn (e.g. system-injected).
+  // Returns undefined (action hidden) while busy, on pending turns, on
+  // assistant turns with no preceding user turn (e.g. system-injected), and
+  // on assistant turns that are NOT the last on the active path (only the tip
+  // gets a regenerate button so earlier branches keep their settled answers).
   function regenerateFor(turn: Turn): (() => void) | undefined {
     if (busy || turn.role !== "assistant" || turn.pending) return undefined;
-    const idx = turns.findIndex((t) => t.id === turn.id);
+    if (activePath[activePath.length - 1]?.id !== turn.id) return undefined;
+    const idx = activePath.findIndex((t) => t.id === turn.id);
     if (idx < 0) return undefined;
     let prevUser: Turn | undefined;
     for (let j = idx - 1; j >= 0; j -= 1) {
-      const candidate = turns[j];
+      const candidate = activePath[j];
       if (candidate && candidate.role === "user") { prevUser = candidate; break; }
     }
     if (!prevUser) return undefined;
-    const { text, attachments: prevAttachments } = prevUser;
+    const { text, attachments: prevAttachments, parentId } = prevUser;
     if (!text.trim() && !prevAttachments?.length) return undefined;
-    return () => void sendRaw(text, prevAttachments ?? []);
+    return () => void sendRaw(text, prevAttachments ?? [], [], { parentTurnId: parentId ?? undefined });
+  }
+
+  // Branch navigator: switch to a sibling turn and make its deepest descendant
+  // the new active leaf. Persists the new leaf to the conversation so a reload
+  // restores the same branch. Optimistic — the in-memory switch is immediate;
+  // the PATCH is best-effort (network errors are silently swallowed).
+  async function switchBranch(turnId: string, dir: -1 | 1) {
+    const { siblings, index } = siblingsOf(turns, turnId);
+    const next = siblings[index + dir];
+    if (!next) return;
+    const leaf = childLeaf(turns, next.id);
+    setActiveLeafId(leaf);
+    if (!sessionId) return;
+    try {
+      await fetch(`/api/chat/conversation/${encodeURIComponent(sessionId)}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ activeLeafId: leaf }),
+      });
+    } catch {
+      // optimistic; the in-memory switch already happened
+    }
   }
 
   const send = async (override?: string) => {
@@ -2787,7 +2823,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     setInput("");
     setAttachments([]);
     setMentionedFiles([]);
-    await sendRaw(outgoingText, outgoingAttachments, outgoingMentions);
+    // Branching: consume a pending branch parent set by editTurnInComposer.
+    // Read-and-clear atomically so it only applies to THIS send.
+    const branchParent = pendingBranchParent;
+    setPendingBranchParent(null);
+    await sendRaw(outgoingText, outgoingAttachments, outgoingMentions, branchParent !== null ? { parentTurnId: branchParent } : undefined);
   };
 
   // Auto-send a prompt handed off from the home composer. Deferred one
@@ -3393,6 +3433,16 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   if (gap >= 10 * 60 * 1000) return true;
                   return prev.role !== t.role;
                 })();
+                const singleBranchNav = (() => {
+                  const { siblings, index } = siblingsOf(turns, t.id);
+                  if (siblings.length <= 1) return undefined;
+                  return {
+                    index,
+                    total: siblings.length,
+                    onPrev: () => void switchBranch(t.id, -1),
+                    onNext: () => void switchBranch(t.id, 1),
+                  };
+                })();
                 return (
                   <TurnRow
                     key={t.id}
@@ -3407,6 +3457,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                     onSuggestion={(sug) => void send(sug)}
                     expanded={expandedAvatarTurnId === t.id}
                     onToggleAvatar={() => setExpandedAvatarTurnId((cur) => (cur === t.id ? null : t.id))}
+                    branchNav={singleBranchNav}
                   />
                 );
               }
@@ -3429,6 +3480,16 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                       if (gap >= 10 * 60 * 1000) return true;
                       return prev.role !== t.role;
                     })();
+                    const groupBranchNav = (() => {
+                      const { siblings, index } = siblingsOf(turns, t.id);
+                      if (siblings.length <= 1) return undefined;
+                      return {
+                        index,
+                        total: siblings.length,
+                        onPrev: () => void switchBranch(t.id, -1),
+                        onNext: () => void switchBranch(t.id, 1),
+                      };
+                    })();
                     return (
                       <TurnRow
                         key={t.id}
@@ -3441,8 +3502,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                         onReply={replyFor(t)}
                         onOpenUrl={onOpenUrl}
                         onSuggestion={(sug) => void send(sug)}
-                    expanded={expandedAvatarTurnId === t.id}
+                        expanded={expandedAvatarTurnId === t.id}
                         onToggleAvatar={() => setExpandedAvatarTurnId((cur) => (cur === t.id ? null : t.id))}
+                        branchNav={groupBranchNav}
                       />
                     );
                   })}
@@ -3889,6 +3951,7 @@ function TurnRowImpl({
   expanded = false,
   onToggleAvatar,
   onSuggestion,
+  branchNav,
 }: {
   turn: Turn;
   onSuggestion?: (s: string) => void;
@@ -3907,6 +3970,8 @@ function TurnRowImpl({
   onOpenUrl?: (url: string) => void;
   expanded?: boolean;
   onToggleAvatar?: () => void;
+  /** Branch navigator: shown when this turn has siblings (alternate branches). */
+  branchNav?: { index: number; total: number; onPrev: () => void; onNext: () => void };
 }) {
   // Tool activity renders inline while a turn streams (watching tools run IS the
   // live feedback). Once the turn settles, the prose is shown uninterrupted and
@@ -3974,6 +4039,7 @@ function TurnRowImpl({
             onEdit={onEdit}
             onReply={onReply}
             onOpenUrl={onOpenUrl}
+            branchNav={branchNav}
           />
           {turn.attachments?.length ? <AttachmentList attachments={turn.attachments} /> : null}
         </div>
@@ -4129,6 +4195,7 @@ function TurnRowImpl({
                 // the text segments concatenate to `visible` anyway, so prose
                 // renders identically with the tool blocks omitted.
                 segments={renderSegments}
+                branchNav={branchNav}
               />
             )}
             {/* CHAT-D4-01: tools often run BEFORE the first prose chunk
@@ -4377,7 +4444,12 @@ function areTurnRowPropsEqual(prev: TurnRowProps, next: TurnRowProps): boolean {
     prev.expanded === next.expanded &&
     Boolean(prev.onEdit) === Boolean(next.onEdit) &&
     Boolean(prev.onRegenerate) === Boolean(next.onRegenerate) &&
-    Boolean(prev.onReply) === Boolean(next.onReply)
+    Boolean(prev.onReply) === Boolean(next.onReply) &&
+    // Branch nav: compare by index+total (the displayed position changes when
+    // branches are added); skip closure identity — callbacks are recreated on
+    // every parent render and would defeat memoization.
+    prev.branchNav?.index === next.branchNav?.index &&
+    prev.branchNav?.total === next.branchNav?.total
   );
 }
 

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -69,6 +69,7 @@ import { toolInputAsDiff, toolTargetFile } from "@/lib/tool-input-diff";
 import { findMatchingTurnIds } from "@/lib/transcript-find";
 import { isSyntheticLocalModel, type ChatModelState } from "@/lib/chat-model-state";
 import { readComposerHistory, writeComposerHistory } from "@/lib/composer-history";
+import { resolveActivePath } from "@/lib/conversation-tree";
 
 type ToolEvent = {
   id: string;
@@ -105,6 +106,7 @@ type ChatTurnLifecycle =
 
 type Turn = {
   id: string;
+  parentId?: string | null;
   role: "user" | "assistant" | "system";
   text: string;
   attachments?: ChatAttachment[];
@@ -1602,6 +1604,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   ref,
 ) {
   const [turns, setTurns] = useState<Turn[]>([]);
+  const [activeLeafId, setActiveLeafId] = useState<string>("");
   const [historyState, setHistoryState] = useState<ChatHistoryState>("idle");
   const [debugModalOpen, setDebugModalOpen] = useState(false);
 
@@ -2072,15 +2075,25 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     [turns],
   );
 
+  // Active branch path: when activeLeafId is set (branched conversation), only
+  // the turns on the path from the root to that leaf are rendered. For linear
+  // (non-branched) conversations every turn has exactly one child so
+  // resolveActivePath returns the full list — behaviour is identical.
+  const activePath = useMemo<Turn[]>(() => {
+    if (!activeLeafId) return turns;
+    return resolveActivePath(turns, activeLeafId) as Turn[];
+  }, [turns, activeLeafId]);
+
   // Voice-call grouping + a turn.id → index map for the timestamp-gap logic.
-  // Memoized on `turns` so it's rebuilt only when the transcript changes — NOT
-  // on every composer keystroke / caret move / hover, which all re-render
-  // ChatView but leave `turns` untouched (this was an O(n) rebuild per render).
+  // Memoized on `activePath` so it's rebuilt only when the visible transcript
+  // changes — NOT on every composer keystroke / caret move / hover, which all
+  // re-render ChatView but leave `turns` untouched (this was an O(n) rebuild
+  // per render).
   const { groupedTurns, turnIndexMap } = useMemo(() => {
     type VoiceGroup = { kind: "call"; callId: string; turns: Turn[]; durationSec: number };
     type SingleItem = { kind: "single"; turn: Turn };
     const grouped: Array<VoiceGroup | SingleItem> = [];
-    for (const turn of turns) {
+    for (const turn of activePath) {
       if (turn.voiceCallId) {
         const last = grouped[grouped.length - 1];
         if (last && last.kind === "call" && last.callId === turn.voiceCallId) {
@@ -2096,9 +2109,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       }
     }
     const turnIndexMap = new Map<string, number>();
-    for (let idx = 0; idx < turns.length; idx++) turnIndexMap.set(turns[idx].id, idx);
+    for (let idx = 0; idx < activePath.length; idx++) turnIndexMap.set(activePath[idx].id, idx);
     return { groupedTurns: grouped, turnIndexMap };
-  }, [turns]);
+  }, [activePath]);
 
   useEffect(() => {
     setSlashIdx(0);
@@ -2150,6 +2163,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     setLinkedContext(null);
     if (!sessionId) {
       setTurns([]);
+      setActiveLeafId("");
       setHistoryState("idle");
       return;
     }
@@ -2165,6 +2179,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               return;
             }
             setTurns([]);
+            setActiveLeafId("");
             setHistoryState(res.status === 404 ? "missing" : "error");
           }
           return;
@@ -2173,8 +2188,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           ok?: boolean;
           context?: ChatLinkedContext | null;
           conversation?: {
+            activeLeafId?: string;
             turns?: Array<{
               id: string;
+              parentId?: string | null;
               role: string;
               text: string;
               attachments?: ChatAttachment[];
@@ -2199,6 +2216,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               .filter(
                 (t): t is {
                   id: string;
+                  parentId?: string | null;
                   role: "user" | "assistant";
                   text: string;
                   attachments?: ChatAttachment[];
@@ -2217,6 +2235,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               )
               .map((t) => ({
                   id: t.id,
+                  parentId: t.parentId,
                   role: t.role,
                   text: t.text,
                   attachments: t.attachments,
@@ -2233,6 +2252,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   voiceCallId: t.voiceCallId,
                 })),
           );
+          setActiveLeafId(
+            typeof json.conversation.activeLeafId === "string" ? json.conversation.activeLeafId : "",
+          );
           setHistoryState("loaded");
         } else if (json.ok && json.context) {
           // Known affiliation (e.g. fresh task chat) — no transcript yet.
@@ -2241,6 +2263,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             return;
           }
           setTurns([]);
+          setActiveLeafId("");
           setHistoryState("loaded");
         } else {
           if (keepLiveSession()) {
@@ -2248,6 +2271,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             return;
           }
           setTurns([]);
+          setActiveLeafId("");
           setHistoryState("missing");
         }
       } catch {
@@ -2257,6 +2281,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             return;
           }
           setTurns([]);
+          setActiveLeafId("");
           setHistoryState("error");
         }
       }
@@ -2415,6 +2440,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     if (command === "/clear") {
       liveSessionIdRef.current = null;
       setTurns([]);
+      setActiveLeafId("");
       setInput("");
       return true;
     }
@@ -2521,6 +2547,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     const now = new Date().toISOString();
     const userTurn: Turn = {
       id: crypto.randomUUID(),
+      parentId: activeLeafId || null,
       role: "user",
       text: trimmed,
       ...(outgoingAttachments.length ? { attachments: outgoingAttachments } : {}),
@@ -2529,6 +2556,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     const assistantId = crypto.randomUUID();
     const assistantTurn: Turn = {
       id: assistantId,
+      parentId: userTurn.id,
       role: "assistant",
       text: "",
       pending: true,
@@ -2542,6 +2570,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     };
     appendTurn([userTurn, assistantTurn]);
     setTurns((prev) => [...prev, userTurn, assistantTurn]);
+    setActiveLeafId(assistantTurn.id);
 
     const controller = new AbortController();
     abortRef.current = controller;
@@ -3160,12 +3189,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       clearTranscript: () => {
         liveSessionIdRef.current = null;
         setTurns([]);
+        setActiveLeafId("");
       },
       runSlash: (command: string) => {
         // Push command into the composer + dispatch
         if (command === "/clear") {
           liveSessionIdRef.current = null;
           setTurns([]);
+          setActiveLeafId("");
           return;
         }
         if (command === "/help") {
@@ -3345,9 +3376,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           ) : null}
           {(() => {
             // `groupedTurns` + `turnIndexMap` are memoized above (rebuilt only
-            // when `turns` changes, not on every keystroke). `allTurns` feeds
-            // the per-row prev-turn timestamp-gap lookup.
-            const allTurns = turns;
+            // when `activePath` changes, not on every keystroke). `allTurns`
+            // feeds the per-row prev-turn timestamp-gap lookup and must match
+            // the same sequence used for grouping.
+            const allTurns = activePath;
             return groupedTurns.map((g) => {
               if (g.kind === "single") {
                 const t = g.turn;

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -939,9 +939,17 @@ export type MessageBubbleProps = {
    *  text span streams (progressive markdown + ▌ cursor); earlier spans
    *  render settled. */
   segments?: MessageBubbleSegment[];
+  /** Branching: when a turn has siblings, render a compact ‹ index/total ›
+   *  switcher. Omitted (or total <= 1) hides it. */
+  branchNav?: {
+    index: number; // 0-based
+    total: number;
+    onPrev: () => void;
+    onNext: () => void;
+  };
 };
 
-export function MessageBubble({ role, content, timestamp, showTimestamp = true, pending, isError, label, onEdit, onRegenerate, onReply, onOpenUrl, segments }: MessageBubbleProps) {
+export function MessageBubble({ role, content, timestamp, showTimestamp = true, pending, isError, label, onEdit, onRegenerate, onReply, onOpenUrl, segments, branchNav }: MessageBubbleProps) {
   const [tsVisible, setTsVisible] = useState(false);
   const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -1079,6 +1087,31 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
             >
               <Icon name="ph:arrow-clockwise" width={11} aria-hidden />
             </button>
+          ) : null}
+          {branchNav && branchNav.total > 1 ? (
+            <span className="cave-chat-branch-nav" role="group" aria-label="Switch response branch">
+              <button
+                type="button"
+                className="cave-chat-branch-nav__btn"
+                onClick={branchNav.onPrev}
+                disabled={branchNav.index <= 0}
+                aria-label="Previous response"
+              >
+                ‹
+              </button>
+              <span className="cave-chat-branch-nav__count" aria-live="polite">
+                {branchNav.index + 1}/{branchNav.total}
+              </span>
+              <button
+                type="button"
+                className="cave-chat-branch-nav__btn"
+                onClick={branchNav.onNext}
+                disabled={branchNav.index >= branchNav.total - 1}
+                aria-label="Next response"
+              >
+                ›
+              </button>
+            </span>
           ) : null}
           <ExpandBubble text={content} label={label ?? "Familiar response"} />
           <CopyBubble text={content} />

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -3,11 +3,19 @@ import path from "node:path";
 import { homedir } from "node:os";
 import type { ChatResponseMetadata } from "./chat-response-metadata.ts";
 import type { ModelApplicationState, ModelScope } from "./chat-model-state.ts";
+import { linearizeLegacy } from "./conversation-tree.ts";
 
 const CONV_DIR = path.join(homedir(), ".coven", "cave-conversations");
 
 export type ChatTurn = {
   id: string;
+  /** Branching: the turn this one follows. null/undefined = conversation root.
+   *  Legacy turns lack it and are linearized by createdAt on load. */
+  parentId?: string | null;
+  /** Branching: the harness session id that produced this turn, recorded so a
+   *  branch tip can resume the right rollout. Distinct from the conversation
+   *  field of the same name (which is just the latest). */
+  harnessSessionId?: string;
   role: "user" | "assistant" | "system";
   text: string;
   attachments?: import("./chat-attachments").ChatAttachment[];
@@ -66,6 +74,12 @@ export type ConversationFile = {
   createdAt: string;
   updatedAt: string;
   turns: ChatTurn[];
+  /** Branching: id of the turn at the tip of the currently selected path. The
+   *  rendered conversation is the chain from here to the root. */
+  activeLeafId?: string;
+  /** Branching lineage (set by fork-to-new-thread in a later PR). */
+  parentSessionId?: string;
+  branchedFromTurnId?: string;
 };
 
 async function ensureDir() {
@@ -96,7 +110,16 @@ function pathFor(sessionId: string): string {
 export async function loadConversation(sessionId: string): Promise<ConversationFile | null> {
   try {
     const raw = await readFile(pathFor(sessionId), "utf8");
-    return JSON.parse(raw) as ConversationFile;
+    const conv = JSON.parse(raw) as ConversationFile;
+    // Lazy migration: a pre-branching file has no activeLeafId. Linearize its
+    // turns into a single-path tree so callers always see tree shape. Written
+    // back to disk on the next saveConversation.
+    if (!conv.activeLeafId && conv.turns.length > 0) {
+      const { turns, activeLeafId } = linearizeLegacy(conv.turns);
+      conv.turns = turns;
+      conv.activeLeafId = activeLeafId;
+    }
+    return conv;
   } catch {
     return null;
   }

--- a/src/lib/conversation-tree.test.ts
+++ b/src/lib/conversation-tree.test.ts
@@ -1,0 +1,90 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveActivePath,
+  siblingsOf,
+  childLeaf,
+  linearizeLegacy,
+  type TreeTurn,
+} from "./conversation-tree.ts";
+
+function t(id: string, parentId: string | null, seconds: number): TreeTurn {
+  return { id, parentId, createdAt: `2026-06-23T00:00:${String(seconds).padStart(2, "0")}.000Z` };
+}
+
+test("resolveActivePath walks from activeLeafId to root, root-first", () => {
+  const turns = [t("u1", null, 1), t("a1", "u1", 2), t("u2", "a1", 3), t("a2", "u2", 4)];
+  const path = resolveActivePath(turns, "a2");
+  assert.deepEqual(path.map((x) => x.id), ["u1", "a1", "u2", "a2"]);
+});
+
+test("resolveActivePath picks only the active branch", () => {
+  const turns = [t("u1", null, 1), t("a1", "u1", 2), t("a1b", "u1", 3)];
+  assert.deepEqual(resolveActivePath(turns, "a1").map((x) => x.id), ["u1", "a1"]);
+  assert.deepEqual(resolveActivePath(turns, "a1b").map((x) => x.id), ["u1", "a1b"]);
+});
+
+test("resolveActivePath falls back to createdAt linearization on a bad leaf", () => {
+  const turns = [t("u1", null, 1), t("a1", "u1", 2)];
+  assert.deepEqual(resolveActivePath(turns, "missing").map((x) => x.id), ["u1", "a1"]);
+});
+
+test("resolveActivePath defends against a parent cycle", () => {
+  const turns = [
+    { id: "x", parentId: "y", createdAt: "2026-06-23T00:00:01.000Z" },
+    { id: "y", parentId: "x", createdAt: "2026-06-23T00:00:02.000Z" },
+  ];
+  const path = resolveActivePath(turns, "x");
+  assert.ok(path.length >= 1);
+});
+
+test("siblingsOf returns ordered siblings and the 0-based index", () => {
+  const turns = [t("u1", null, 1), t("a", "u1", 2), t("b", "u1", 3), t("c", "u1", 4)];
+  const r = siblingsOf(turns, "b");
+  assert.deepEqual(r.siblings.map((x) => x.id), ["a", "b", "c"]);
+  assert.equal(r.index, 1);
+});
+
+test("siblingsOf for a turn with no siblings is index 0 of 1", () => {
+  const turns = [t("u1", null, 1), t("a", "u1", 2)];
+  const r = siblingsOf(turns, "a");
+  assert.deepEqual(r.siblings.map((x) => x.id), ["a"]);
+  assert.equal(r.index, 0);
+});
+
+test("childLeaf descends to the newest descendant of a sibling", () => {
+  const turns = [t("u1", null, 1), t("s", "u1", 2), t("s2", "s", 3), t("s3", "s2", 4)];
+  assert.equal(childLeaf(turns, "s"), "s3");
+});
+
+test("childLeaf of a leaf sibling is itself", () => {
+  const turns = [t("u1", null, 1), t("s", "u1", 2)];
+  assert.equal(childLeaf(turns, "s"), "s");
+});
+
+test("linearizeLegacy assigns parents by createdAt and points the leaf at the last turn", () => {
+  const turns = [
+    { id: "a", createdAt: "2026-06-23T00:00:02.000Z" },
+    { id: "b", createdAt: "2026-06-23T00:00:01.000Z" },
+    { id: "c", createdAt: "2026-06-23T00:00:03.000Z" },
+  ];
+  const r = linearizeLegacy(turns);
+  assert.equal(r.activeLeafId, "c");
+  const byId = new Map(r.turns.map((x) => [x.id, x.parentId]));
+  assert.equal(byId.get("b"), null);
+  assert.equal(byId.get("a"), "b");
+  assert.equal(byId.get("c"), "a");
+});
+
+test("linearizeLegacy is idempotent on already-linked turns", () => {
+  const turns = [t("u1", null, 1), t("a1", "u1", 2)];
+  const r = linearizeLegacy(turns);
+  assert.equal(r.activeLeafId, "a1");
+  assert.equal(r.turns.find((x) => x.id === "a1")?.parentId, "u1");
+});
+
+test("linearizeLegacy on an empty array yields an empty path", () => {
+  const r = linearizeLegacy([]);
+  assert.deepEqual(r.turns, []);
+  assert.equal(r.activeLeafId, "");
+});

--- a/src/lib/conversation-tree.ts
+++ b/src/lib/conversation-tree.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure tree operations over a conversation's flat turn array. The durable
+ * store (cave-conversations) keeps every turn across every branch in one flat
+ * array; each turn names its `parentId`, so the array describes a tree. The
+ * rendered conversation is the "active path" — the chain from `activeLeafId`
+ * up to the root. No I/O lives here; everything is a pure function so it can be
+ * unit-tested in isolation.
+ */
+
+/** The minimal turn shape these helpers need. The real ChatTurn is a superset. */
+export type TreeTurn = {
+  id: string;
+  parentId?: string | null;
+  createdAt?: string;
+};
+
+function byCreatedAt<T extends TreeTurn>(turns: T[]): T[] {
+  return [...turns].sort((a, b) => {
+    const ta = a.createdAt ? Date.parse(a.createdAt) : 0;
+    const tb = b.createdAt ? Date.parse(b.createdAt) : 0;
+    if (ta !== tb) return ta - tb;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+}
+
+/**
+ * The chain from `activeLeafId` up to the root, returned root-first. Falls back
+ * to a createdAt linearization when the leaf is missing, and guards against
+ * cycles (a corrupt parent ring) by stopping when it revisits a node.
+ */
+export function resolveActivePath<T extends TreeTurn>(turns: T[], activeLeafId: string): T[] {
+  const byId = new Map(turns.map((x) => [x.id, x]));
+  const leaf = byId.get(activeLeafId);
+  if (!leaf) return byCreatedAt(turns);
+  const chain: T[] = [];
+  const seen = new Set<string>();
+  let current: T | undefined = leaf;
+  while (current && !seen.has(current.id)) {
+    seen.add(current.id);
+    chain.push(current);
+    const parentId = current.parentId;
+    current = parentId ? byId.get(parentId) : undefined;
+  }
+  return chain.reverse();
+}
+
+/**
+ * The ordered set of turns sharing a turn's parent (its siblings), plus the
+ * 0-based index of the given turn within that set. Order is by createdAt so the
+ * navigator is stable. A turn with no siblings returns `{ siblings: [turn], index: 0 }`.
+ */
+export function siblingsOf<T extends TreeTurn>(
+  turns: T[],
+  turnId: string,
+): { siblings: T[]; index: number } {
+  const target = turns.find((x) => x.id === turnId);
+  if (!target) return { siblings: [], index: 0 };
+  const parentId = target.parentId ?? null;
+  const siblings = byCreatedAt(turns.filter((x) => (x.parentId ?? null) === parentId));
+  const index = Math.max(0, siblings.findIndex((x) => x.id === turnId));
+  return { siblings, index };
+}
+
+/**
+ * Given a sibling turn the user switched to, the leaf to activate: descend
+ * through the newest child at each level until a turn has no children. This
+ * remembers the deepest branch under that sibling rather than truncating to it.
+ */
+export function childLeaf<T extends TreeTurn>(turns: T[], turnId: string): string {
+  const childrenByParent = new Map<string, T[]>();
+  for (const turn of turns) {
+    const parentId = turn.parentId ?? null;
+    if (parentId === null) continue;
+    const list = childrenByParent.get(parentId) ?? [];
+    list.push(turn);
+    childrenByParent.set(parentId, list);
+  }
+  let currentId = turnId;
+  const seen = new Set<string>();
+  while (!seen.has(currentId)) {
+    seen.add(currentId);
+    const kids = childrenByParent.get(currentId);
+    if (!kids || kids.length === 0) break;
+    const newest = byCreatedAt(kids)[kids.length - 1];
+    currentId = newest.id;
+  }
+  return currentId;
+}
+
+/**
+ * Upgrade a legacy (pre-branching) turn array — no parentId/activeLeafId — into
+ * the tree shape: sort by createdAt, chain each turn to the previous one, and
+ * point the active leaf at the last turn. Idempotent for already-linked turns.
+ */
+export function linearizeLegacy<T extends TreeTurn>(
+  turns: T[],
+): { turns: T[]; activeLeafId: string } {
+  if (turns.length === 0) return { turns: [], activeLeafId: "" };
+  const ordered = byCreatedAt(turns);
+  const linked = ordered.map((turn, i) => ({
+    ...turn,
+    parentId: i === 0 ? null : ordered[i - 1].id,
+  }));
+  return { turns: linked, activeLeafId: linked[linked.length - 1].id };
+}

--- a/src/lib/conversation-tree.ts
+++ b/src/lib/conversation-tree.ts
@@ -38,7 +38,7 @@ export function resolveActivePath<T extends TreeTurn>(turns: T[], activeLeafId: 
   while (current && !seen.has(current.id)) {
     seen.add(current.id);
     chain.push(current);
-    const parentId = current.parentId;
+    const parentId: string | null | undefined = current.parentId;
     current = parentId ? byId.get(parentId) : undefined;
   }
   return chain.reverse();
@@ -94,7 +94,7 @@ export function childLeaf<T extends TreeTurn>(turns: T[], turnId: string): strin
  */
 export function linearizeLegacy<T extends TreeTurn>(
   turns: T[],
-): { turns: T[]; activeLeafId: string } {
+): { turns: (T & { parentId: string | null })[]; activeLeafId: string } {
   if (turns.length === 0) return { turns: [], activeLeafId: "" };
   const ordered = byCreatedAt(turns);
   const linked = ordered.map((turn, i) => ({

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -794,6 +794,16 @@
   padding: 3px 5px;
 }
 
+/* Branch navigator — compact ‹ n/m › switcher inline with action buttons */
+.cave-chat-branch-nav { display: inline-flex; align-items: center; gap: 2px; }
+.cave-chat-branch-nav__btn {
+  border: none; background: transparent; cursor: pointer;
+  padding: 0 4px; line-height: 1; font-size: 14px; opacity: 0.7;
+}
+.cave-chat-branch-nav__btn:hover:not(:disabled) { opacity: 1; }
+.cave-chat-branch-nav__btn:disabled { opacity: 0.3; cursor: default; }
+.cave-chat-branch-nav__count { font-size: 11px; opacity: 0.7; min-width: 2.4em; text-align: center; }
+
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    EXPAND FOOTER (CHAT-D7-03) — emitted only on blocks tall enough to clamp;
    sticks to the bottom of the wrap's scroll viewport like the header sticks


### PR DESCRIPTION
## What

ChatGPT-style **inline conversation branching** for web chat. Regenerating the latest answer now keeps the old response as a sibling, editing the latest user turn forks a sibling, and a `‹ n/m ›` navigator switches between siblings — all persisted across reload.

This is **PR 1 of 2**. PR 2 adds fork-to-new-thread ("Branch from here") on web + iOS.

## How

- **Tree over the flat turns array.** `ChatTurn.parentId` + `ConversationFile.activeLeafId` describe a tree; the rendered conversation is the active path (leaf → root, reversed). Legacy conversations are lazily linearized on load — zero behavior change for existing chats.
- **Pure `src/lib/conversation-tree.ts`** holds all tree math (`resolveActivePath` / `siblingsOf` / `childLeaf` / `linearizeLegacy`) with 11 unit tests.
- **Persistence** threads `parentId`/`activeLeafId` through both the send route (writes branched turns at the tip; `--continue` head stays valid) and the conversation API (`normalizeTurn` preserves `parentId`; new `PATCH { activeLeafId }` persists a sibling switch).
- **UI**: `‹ n/m ›` navigator in `message-bubble.tsx`; `chat-view.tsx` renders the active path, makes regenerate keep the old answer, and edits-at-tip branch.

## Scope note

Branches are created **at the conversation tip** (regenerate latest / edit latest user turn). Switching between existing siblings works at any depth. Mid-history *new-branch creation* (needs fresh harness seeding) is deferred to a follow-up.

## Tests

`conversation-tree.test.ts` (11 tests, registered in `SUITES.app`); full `app` suite green (371 files); `tsc` clean. Source-text regression pins (CHAT-D5-01/D6-02/D12-02/D12-03) updated where the new `parentTurnId` arg / field shifted them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)