### PR TITLE
docs: define workflow-first branch hygiene

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Coven Cave Agent Notes
+
+## Workflow-First Branch Hygiene
+
+- Treat `main` as the canonical project state. Before starting work, fetch and branch from current `origin/main`.
+- Use branches and worktrees only as short-lived PR transport for active implementation. Do not use branches as durable storage, coordination logs, or half-finished agent memory.
+- Keep durable coordination in tracked workflow artifacts: plans, specs, issues, PR descriptions/checklists, release notes, and handoff docs.
+- Before opening a PR, make the branch PR-shaped: scoped diff, relevant local verification, and a summary of what changed.
+- After a PR merges, delete the remote branch and remove the local worktree/branch. Preserve any intentionally unmerged work as an archive patch or named stash before cleanup.
+- Do not push directly to `main`; use the protected PR path for repository changes.
+- Before release or TestFlight work, reconcile through clean `main`, then verify from that state.
+

--- a/docs/workflows/branching.md
+++ b/docs/workflows/branching.md
@@ -1,0 +1,56 @@
+# Workflow-First Branching
+
+Coven Cave uses `main` as the canonical source of truth. Branches are allowed, but only as short-lived transport for active PR work.
+
+## Canonical State
+
+- `main` is the only long-lived branch.
+- Releases, TestFlight uploads, and updater validation start from clean `main`.
+- Work that needs to survive an agent session belongs in tracked artifacts, not in an abandoned branch.
+
+Durable artifacts include:
+
+- `docs/superpowers/specs/` for product and design intent.
+- `docs/superpowers/plans/` for implementation plans and handoffs.
+- GitHub issues and PR descriptions for active coordination.
+- Release notes, checklists, and verification summaries for ship state.
+
+## Short-Lived Branches
+
+Use a branch when there is active implementation or review work that cannot land directly on protected `main`.
+
+Expected lifecycle:
+
+1. Fetch latest `origin/main`.
+2. Create a scoped worktree/branch from `origin/main`.
+3. Make the diff PR-shaped: focused scope, relevant tests, and no unrelated churn.
+4. Open a PR with the verification performed and any known follow-up work.
+5. Merge through the protected PR path after checks pass.
+6. Delete the remote branch and remove the local worktree/branch.
+
+Branches should not remain open as:
+
+- agent scratchpads
+- long-running state stores
+- hidden task queues
+- backups for unreviewed changes
+- coordination substitutes for docs, issues, or PR text
+
+## WIP Preservation
+
+Before removing a stale branch or worktree, inspect it.
+
+- If the work is merged or patch-equivalent to `main`, delete the branch.
+- If it has useful unmerged commits, archive them with `git format-patch` before deleting.
+- If it has uncommitted work, preserve it with a named stash or archive patch before cleanup.
+- Prefer moving generated leftover directories to Trash over permanent deletion.
+
+## Release And TestFlight
+
+Release work should start only after branch consolidation:
+
+1. Confirm no open PRs are intended for the release.
+2. Confirm `origin/main` is current and local `main` is clean.
+3. Run the release or TestFlight verification from `main`.
+4. Record the build/version, verification, upload artifact, and any App Store Connect status in the release handoff.
+


### PR DESCRIPTION
## What

Codifies workflow-first, branch-light behavior for Coven Cave:

- adds root `AGENTS.md` guidance for agents/contributors
- adds `docs/workflows/branching.md` with canonical state, short-lived branch lifecycle, WIP preservation, and release/TestFlight expectations

## Verification

- `git diff --check`
- pre-commit hook passed during commit
