### PR TITLE
fix(chat): branch the first exchange + validate branch-switch target

### DIFF
--- a/src/app/api/chat/conversation/[id]/route.ts
+++ b/src/app/api/chat/conversation/[id]/route.ts
@@ -252,6 +252,11 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
   if (typeof body.activeLeafId === "string" && body.activeLeafId) {
     const existing = await loadConversation(id);
     if (!existing) return jsonError("not found", 404);
+    // Reject a leaf that isn't an actual turn — persisting a bogus id would make
+    // resolveActivePath silently fall back to showing every turn unfiltered.
+    if (!existing.turns.some((turn) => turn.id === body.activeLeafId)) {
+      return jsonError("unknown activeLeafId", 400);
+    }
     existing.activeLeafId = body.activeLeafId;
     await saveConversation(existing);
     return NextResponse.json({ ok: true, conversation: existing });

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -112,8 +112,10 @@ type SendBody = {
    * projectRoot in the body, so the composer sends the root it knows. */
   mentionedFilesRoot?: string;
   /** Branching: when set, the new user turn is parented here (its prior
-   *  sibling stays in the tree) and the new assistant turn becomes the tip. */
-  parentTurnId?: string;
+   *  sibling stays in the tree) and the new assistant turn becomes the tip.
+   *  Explicit null means "branch at the root" (sibling of a root turn) and is
+   *  distinct from the field being absent (a normal, non-branch send). */
+  parentTurnId?: string | null;
 };
 
 type ReasoningEffort = "low" | "medium" | "high";
@@ -699,7 +701,10 @@ function openClawChatResponse(args: {
           // Branching: same logic as the coven-run path — client-supplied
           // parentTurnId takes precedence; falls back to prior activeLeafId for
           // normal (non-branch) sends so the linear chain is preserved.
-          const branchParentId = args.body.parentTurnId ?? existing?.activeLeafId ?? null;
+          const branchParentId =
+            args.body.parentTurnId !== undefined
+              ? args.body.parentTurnId
+              : existing?.activeLeafId ?? null;
           const conv = existing ?? {
             sessionId,
             familiarId: args.body.familiarId,
@@ -1440,7 +1445,8 @@ export async function POST(req: Request) {
         // (non-branch) send, fall back to the prior activeLeafId so the
         // conversation stays a linear chain identical to the pre-branching
         // behaviour. First turn of a new chat gets null (no parent).
-        const branchParentId = body.parentTurnId ?? existing?.activeLeafId ?? null;
+        const branchParentId =
+          body.parentTurnId !== undefined ? body.parentTurnId : existing?.activeLeafId ?? null;
         const userTurn: ChatTurn = {
           id: userTurnId,
           role: "user",

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1605,7 +1605,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
 ) {
   const [turns, setTurns] = useState<Turn[]>([]);
   const [activeLeafId, setActiveLeafId] = useState<string>("");
-  const [pendingBranchParent, setPendingBranchParent] = useState<string | null>(null);
+  // Branching: undefined = no pending branch; null = branch at the ROOT (the
+  // edited/regenerated turn was itself a root, so its sibling is also a root);
+  // string = branch under that parent turn. The undefined-vs-null distinction
+  // is what lets the first exchange branch instead of silently appending.
+  const [pendingBranchParent, setPendingBranchParent] = useState<string | null | undefined>(undefined);
   const [historyState, setHistoryState] = useState<ChatHistoryState>("idle");
   const [debugModalOpen, setDebugModalOpen] = useState(false);
 
@@ -2528,7 +2532,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     text: string,
     outgoingAttachments: ChatAttachment[] = [],
     outgoingMentions: string[] = [],
-    opts?: { promptOverride?: string; parentTurnId?: string },
+    opts?: { promptOverride?: string; parentTurnId?: string | null },
   ) => {
     const trimmed = text.trim();
     const submitPrompt = opts?.promptOverride?.trim() || trimmed;
@@ -2545,7 +2549,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     liveSessionIdRef.current = currentSessionRef.current;
     setHistoryState("loaded");
 
-    const resolvedParentId = opts?.parentTurnId ?? (activeLeafId || null);
+    // Explicit parentTurnId (including null = root) wins; only fall back to the
+    // current leaf when the caller did not specify a branch point at all.
+    const resolvedParentId =
+      opts?.parentTurnId !== undefined ? opts.parentTurnId : (activeLeafId || null);
     const now = new Date().toISOString();
     const userTurn: Turn = {
       id: crypto.randomUUID(),
@@ -2615,7 +2622,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           // position, send the explicit parent so the server builds the new
           // turn off the right node rather than defaulting to the current
           // active leaf.
-          ...(opts?.parentTurnId ? { parentTurnId: opts.parentTurnId } : {}),
+          ...(opts?.parentTurnId !== undefined ? { parentTurnId: opts.parentTurnId } : {}),
         }),
         signal: controller.signal,
       });
@@ -2772,7 +2779,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     if (!prevUser) return undefined;
     const { text, attachments: prevAttachments, parentId } = prevUser;
     if (!text.trim() && !prevAttachments?.length) return undefined;
-    return () => void sendRaw(text, prevAttachments ?? [], [], { parentTurnId: parentId ?? undefined });
+    // null parentId (root user turn) must be forwarded as null, not undefined,
+    // so the regenerated answer becomes a root sibling rather than appending.
+    return () => void sendRaw(text, prevAttachments ?? [], [], { parentTurnId: parentId ?? null });
   }
 
   // Branch navigator: switch to a sibling turn and make its deepest descendant
@@ -2826,8 +2835,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     // Branching: consume a pending branch parent set by editTurnInComposer.
     // Read-and-clear atomically so it only applies to THIS send.
     const branchParent = pendingBranchParent;
-    setPendingBranchParent(null);
-    await sendRaw(outgoingText, outgoingAttachments, outgoingMentions, branchParent !== null ? { parentTurnId: branchParent } : undefined);
+    setPendingBranchParent(undefined);
+    await sendRaw(outgoingText, outgoingAttachments, outgoingMentions, branchParent !== undefined ? { parentTurnId: branchParent } : undefined);
   };
 
   // Auto-send a prompt handed off from the home composer. Deferred one

--- a/src/lib/conversation-tree.test.ts
+++ b/src/lib/conversation-tree.test.ts
@@ -52,6 +52,16 @@ test("siblingsOf for a turn with no siblings is index 0 of 1", () => {
   assert.equal(r.index, 0);
 });
 
+test("siblingsOf treats multiple root turns (null parent) as siblings", () => {
+  // Branching the first exchange creates a second ROOT user turn; both must be
+  // siblings so the navigator appears at the root. Regression guard for the
+  // root-turn branch fix (undefined-vs-null parent sentinel).
+  const turns = [t("u1", null, 1), t("a1", "u1", 2), t("u1b", null, 3), t("a1b", "u1b", 4)];
+  const r = siblingsOf(turns, "u1");
+  assert.deepEqual(r.siblings.map((x) => x.id), ["u1", "u1b"]);
+  assert.equal(r.index, 0);
+});
+
 test("childLeaf descends to the newest descendant of a sibling", () => {
   const turns = [t("u1", null, 1), t("s", "u1", 2), t("s2", "s", 3), t("s3", "s2", 4)];
   assert.equal(childLeaf(turns, "s"), "s3");


### PR DESCRIPTION
Two follow-ups from the #1645 review of inline conversation branching.

## Bug 1 — first exchange wouldn't branch (Medium)

Editing or regenerating the **very first exchange** (a root turn, `parentId = null`) silently appended a linear continuation instead of creating a sibling. Root cause: `null` was overloaded to mean both "no pending branch" and "branch at the root", so the root case fell through to the `activeLeafId` default.

Fix: an `undefined`-vs-`null` sentinel carried end to end —
- `pendingBranchParent: string | null | undefined` (undefined = none, null = root sibling, string = child of that turn)
- `sendRaw` opts `parentTurnId?: string | null`; forwarded as explicit `null` over the wire when branching at root
- both `/api/chat/send` persistence paths use `body.parentTurnId !== undefined ? … : existing.activeLeafId` so an explicit `null` isn't coalesced away

## Bug 2 — unvalidated branch switch (Low)

`PATCH /api/chat/conversation/:id` accepted any string as `activeLeafId`. A bogus id made `resolveActivePath` silently fall back to showing every turn unfiltered. Now rejected with `400` when the id isn't a real turn.

## Tests

New `conversation-tree` test pins multiple root turns as siblings (the root-branch invariant). `tsc` clean; full `app` suite green (371 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)