### PR TITLE
feat(ios): drop familiar-tagging from GitHub comments, add file attachments

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PhotosUI
 
 /// GitHub section: the authenticated user's live activity (open PRs, review
 /// requests, assigned issues, notifications) with a tappable detail view.
@@ -282,7 +283,7 @@ private struct GitHubMarkdown: View {
 
 /// Conversation timeline + inline PR review threads for one issue/PR. Reads via
 /// `GET /api/github/comments`, resolves threads, and posts replies with optional
-/// `@familiar` tagging — the iOS half of the desktop GitHub comments surface.
+/// file attachments — the iOS half of the desktop GitHub comments surface.
 private struct GitHubCommentsSection: View {
     @Environment(AppModel.self) private var app
     let item: GitHubItem
@@ -298,6 +299,19 @@ private struct GitHubCommentsSection: View {
     @State private var draft = ""
     @State private var posting = false
     @State private var postError: String?
+
+    // Attachments mirror GitHub's "add files" affordance: picking an image drops
+    // a thumbnail chip and inserts a markdown image placeholder into the body
+    // (the URL is left for the author to fill — the GitHub REST API has no
+    // asset-upload endpoint, so we can't host the bytes ourselves).
+    @State private var photoItems: [PhotosPickerItem] = []
+    @State private var attachments: [CommentAttachment] = []
+
+    struct CommentAttachment: Identifiable {
+        let id = UUID()
+        let name: String
+        let image: UIImage
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -397,22 +411,15 @@ private struct GitHubCommentsSection: View {
     @ViewBuilder private var composer: some View {
         if canComment {
             VStack(alignment: .leading, spacing: 6) {
-                TextField("Reply… tag a familiar with @", text: $draft, axis: .vertical)
+                TextField("Add your comment here, be kind", text: $draft, axis: .vertical)
                     .lineLimit(2...6)
                     .textFieldStyle(.roundedBorder)
+                attachFilesBar
+                if !attachments.isEmpty { attachmentChips }
                 if let postError {
                     Text(postError).font(.caption).foregroundStyle(.red)
                 }
                 HStack {
-                    if !app.familiars.isEmpty {
-                        Menu {
-                            ForEach(app.familiars) { f in
-                                Button(f.displayName) { insertMention(f) }
-                            }
-                        } label: {
-                            Label("Tag familiar", systemImage: "at").font(.caption)
-                        }
-                    }
                     Spacer()
                     Button {
                         post()
@@ -428,9 +435,53 @@ private struct GitHubCommentsSection: View {
                 }
             }
             .padding(.top, 4)
+            .onChange(of: photoItems) { _, items in
+                guard !items.isEmpty else { return }
+                Task { await addAttachments(items) }
+            }
         } else {
             Text("Add a PAT (in the desktop GitHub tab) to reply and resolve review threads.")
                 .font(.caption).foregroundStyle(.secondary)
+        }
+    }
+
+    /// GitHub's "Paste, drop, or click to add files" affordance. A tap opens the
+    /// photo picker; each chosen image inserts a markdown placeholder below.
+    private var attachFilesBar: some View {
+        PhotosPicker(selection: $photoItems, maxSelectionCount: 5, matching: .images) {
+            HStack(spacing: 8) {
+                Image(systemName: "photo.on.rectangle.angled")
+                Text("Paste, drop, or click to add files")
+                Spacer(minLength: 0)
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .padding(8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(.tertiarySystemFill), in: RoundedRectangle(cornerRadius: 8))
+        }
+    }
+
+    private var attachmentChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(attachments) { att in
+                    HStack(spacing: 6) {
+                        Image(uiImage: att.image)
+                            .resizable().scaledToFill()
+                            .frame(width: 28, height: 28)
+                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                        Text(att.name).font(.caption2).lineLimit(1)
+                        Button { removeAttachment(att) } label: {
+                            Image(systemName: "xmark.circle.fill")
+                        }
+                        .foregroundStyle(.secondary)
+                        .accessibilityLabel("Remove \(att.name)")
+                    }
+                    .padding(.leading, 4).padding(.trailing, 6).padding(.vertical, 4)
+                    .background(Color(.secondarySystemBackground), in: Capsule())
+                }
+            }
         }
     }
 
@@ -459,13 +510,37 @@ private struct GitHubCommentsSection: View {
         )
     }
 
-    private func insertMention(_ f: Familiar) {
-        let handle = f.displayName.replacingOccurrences(of: " ", with: "-")
-        if draft.isEmpty || draft.hasSuffix(" ") {
-            draft += "@\(handle) "
-        } else {
-            draft += " @\(handle) "
+    private func addAttachments(_ items: [PhotosPickerItem]) async {
+        for item in items {
+            guard let data = try? await item.loadTransferable(type: Data.self),
+                  let image = UIImage(data: data) else { continue }
+            let name = "image-\(attachments.count + 1).png"
+            attachments.append(CommentAttachment(name: name, image: image.resizedForUpload()))
+            insertImageMarkdown(named: name)
         }
+        photoItems = []
+    }
+
+    /// Append a GitHub markdown image placeholder on its own line — same shape
+    /// GitHub's web composer drops in when you attach a file (the author fills
+    /// the URL once the image is hosted).
+    private func insertImageMarkdown(named name: String) {
+        let md = "![\(name)](url)"
+        if draft.isEmpty {
+            draft = md + "\n"
+        } else if draft.hasSuffix("\n") {
+            draft += md + "\n"
+        } else {
+            draft += "\n" + md + "\n"
+        }
+    }
+
+    private func removeAttachment(_ att: CommentAttachment) {
+        attachments.removeAll { $0.id == att.id }
+        // Strip the matching placeholder line, leaving the rest of the draft intact.
+        let lines = draft.components(separatedBy: "\n")
+        let placeholder = "![\(att.name)](url)"
+        draft = lines.filter { $0 != placeholder }.joined(separator: "\n")
     }
 
     private func toggleResolve(_ thread: GitHubReviewThread) {
@@ -495,6 +570,7 @@ private struct GitHubCommentsSection: View {
                 let r = try await client.postGithubComment(repo: item.repo, number: number, body: text)
                 if r.ok {
                     draft = ""
+                    attachments = []
                     await load()
                 } else {
                     postError = r.error == "auth_required"

--- a/scripts/ios-github-comment-attach.test.mjs
+++ b/scripts/ios-github-comment-attach.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+
+const githubView = read("apps/ios/CovenCave/CovenCave/Views/GitHubView.swift");
+const runner = read("scripts/run-tests.mjs");
+
+// The "tag a familiar" affordance is gone entirely.
+assert.doesNotMatch(
+  githubView,
+  /tag a familiar|Tag familiar|insertMention/,
+  "the GitHub comment composer should no longer offer familiar tagging",
+);
+
+// The composer emulates GitHub's "Paste, drop, or click to add files" bar via a
+// PhotosPicker.
+assert.match(
+  githubView,
+  /import PhotosUI/,
+  "GitHubView should import PhotosUI for the attachment picker",
+);
+
+assert.match(
+  githubView,
+  /PhotosPicker\(selection: \$photoItems, maxSelectionCount: \d+, matching: \.images\)/,
+  "the attach-files bar should be a PhotosPicker over images",
+);
+
+assert.match(
+  githubView,
+  /Text\("Paste, drop, or click to add files"\)/,
+  "the composer should surface GitHub's add-files affordance copy",
+);
+
+// Picking an image inserts a GitHub markdown image placeholder into the body.
+assert.match(
+  githubView,
+  /private func insertImageMarkdown\(named name: String\)[\s\S]*!\[\\\(name\)\]\(url\)/,
+  "attaching an image should insert a markdown image placeholder into the draft",
+);
+
+// Attachments are tracked as removable chips and cleared after a successful post.
+assert.match(
+  githubView,
+  /struct CommentAttachment: Identifiable/,
+  "attachments should be modeled so they can render as chips",
+);
+
+assert.match(
+  githubView,
+  /attachments = \[\][\s\S]*await load\(\)/,
+  "a successful comment post should clear pending attachments",
+);
+
+assert.match(
+  runner,
+  /"scripts\/ios-github-comment-attach\.test\.mjs"/,
+  "mobile test suite should run the GitHub comment attachment coverage",
+);
+
+console.log("ios-github-comment-attach.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -487,6 +487,7 @@ export const SUITES = {
     "scripts/ios-task-notes-reader.test.mjs",
     "scripts/ios-task-actions.test.mjs",
     "scripts/ios-task-notes-reader.test.mjs",
+    "scripts/ios-github-comment-attach.test.mjs",
     "scripts/mobile-tailscale.test.mjs",
     "scripts/mobile-tailscale-native.test.mjs",
     "src/components/mobile-handoff.test.ts",


### PR DESCRIPTION
## Summary

Reworks the iOS GitHub comment composer to match github.com:

- **Removes the "tag a familiar" flow** — the `@`-mention menu, `insertMention`, and the "Reply… tag a familiar with @" placeholder. There's no familiar concept on github.com, and it cluttered the reply box.
- **Adds GitHub's attachment affordance** — a "Paste, drop, or click to add files" bar backed by a `PhotosPicker` (up to 5 images). Each pick drops a removable thumbnail chip and inserts a markdown image placeholder — `![image-N.png](url)` — into the comment body, mirroring github.com's add-files UX.
- Pending attachments clear after a successful post.

### Why a placeholder URL (no real upload)
GitHub's REST API has no public asset-upload endpoint (the web UI uses a private one). So an attached image can't be hosted by us — the composer inserts the same markdown shape github.com drops in, and the author fills the URL once the image is hosted. This was the chosen approach (pick + insert markdown ref).

## Scope
iOS only (`apps/ios/.../GitHubView.swift`) — the surface in the screenshot. The desktop composer is unchanged.

## Tests
- `scripts/ios-github-comment-attach.test.mjs` (registered in `run-tests.mjs`) — asserts familiar-tagging is gone and the PhotosPicker attach bar + markdown-placeholder insertion + post-clear are wired.

## Verification
- `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED** (iOS Swift isn't compiled by the required CI checks; verified locally against `main`).
- New test passes.
- Not visually screenshotted: the composer is gated behind a configured GitHub PAT (`canComment`), which needs live GitHub auth on a running Cave server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)