### PR TITLE
feat(ios): polish code browser file tree

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/CodeBrowserView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/CodeBrowserView.swift
@@ -27,6 +27,7 @@ struct CodeBrowserView: View {
         NavigationStack {
             content
                 .navigationTitle("Code")
+                .navigationBarTitleDisplayMode(.inline)
                 .navigationDestination(for: FileRef.self) { file in
                     CodeEditorView(path: file.path, name: file.name)
                 }
@@ -74,6 +75,7 @@ struct CodeBrowserView: View {
                     isDir: true,
                     searchRoot: project.root,
                     isProject: true,
+                    autoExpand: true,
                     color: Color(hex: project.color) ?? .accentColor,
                     onFocusProject: {
                         focusedRoot = project.root
@@ -82,7 +84,7 @@ struct CodeBrowserView: View {
                 )
             }
         }
-        .listStyle(.insetGrouped)
+        .listStyle(.plain)
     }
 
     // MARK: - Search (scoped to the focused project)
@@ -161,6 +163,7 @@ struct CodeNode: View {
     let isDir: Bool
     let searchRoot: String
     var isProject = false
+    var autoExpand = false
     var color: Color? = nil
     var onFocusProject: (() -> Void)? = nil
 
@@ -189,14 +192,16 @@ struct CodeNode: View {
             }
             .onChange(of: expanded) { _, isExpanded in
                 if isExpanded {
-                    if isProject { onFocusProject?() }
-                    if !loaded { Task { await load() } }
+                    expandAndLoad()
                 }
+            }
+            .onAppear {
+                if autoExpand { expandAndLoad() }
             }
         } else {
             NavigationLink(value: FileRef(path: path, name: name)) {
                 Label {
-                    Text(name)
+                    Text(name).font(.subheadline)
                 } icon: {
                     Image(systemName: fileIcon(name)).foregroundStyle(.secondary)
                 }
@@ -206,13 +211,13 @@ struct CodeNode: View {
 
     @ViewBuilder private var rowLabel: some View {
         if isProject {
-            HStack(spacing: 10) {
-                RoundedRectangle(cornerRadius: 5)
+            HStack(spacing: 9) {
+                Capsule()
                     .fill(color ?? .accentColor)
-                    .frame(width: 8, height: 22)
+                    .frame(width: 3, height: 18)
                 VStack(alignment: .leading, spacing: 1) {
-                    Text(name).font(.callout.weight(.medium))
-                    Text(path)
+                    Text(name).font(.subheadline.weight(.semibold))
+                    Text(compactPath(path))
                         .font(.caption2.monospaced())
                         .foregroundStyle(.tertiary)
                         .lineLimit(1)
@@ -220,12 +225,24 @@ struct CodeNode: View {
                 }
             }
         } else {
-            Label(name, systemImage: "folder.fill").foregroundStyle(.primary)
+            Label {
+                Text(name).font(.subheadline)
+            } icon: {
+                Image(systemName: "folder").foregroundStyle(.secondary)
+            }
         }
+    }
+
+    private func expandAndLoad() {
+        if !expanded { expanded = true }
+        if isProject { onFocusProject?() }
+        guard !loaded, !loading else { return }
+        Task { await load() }
     }
 
     private func load() async {
         guard let client = app.client else { return }
+        guard !loading else { return }
         loading = true
         defer { loading = false }
         do {
@@ -234,6 +251,12 @@ struct CodeNode: View {
         } catch {
             // leave loaded == false so collapsing + re-expanding retries
         }
+    }
+
+    private func compactPath(_ path: String) -> String {
+        let parts = path.split(separator: "/").map(String.init)
+        guard parts.count > 3 else { return path }
+        return ".../" + parts.suffix(3).joined(separator: "/")
     }
 }
 

--- a/apps/ios/CovenCave/CovenCave/Views/ReadingView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ReadingView.swift
@@ -22,6 +22,7 @@ struct ReadingView: View {
                 }
             }
             .navigationTitle("Reading")
+            .navigationBarTitleDisplayMode(.inline)
             .searchable(text: $query, prompt: "Search titles, authors, tags")
             .refreshable { await app.loadReading() }
             .task { if !app.readingLoaded { await app.loadReading() } }

--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -31,6 +31,7 @@ struct TasksView: View {
         NavigationStack(path: $path) {
             content
                 .navigationTitle("Tasks")
+                .navigationBarTitleDisplayMode(.inline)
                 .navigationDestination(for: BoardCard.self) { TaskDetailView(card: $0) }
                 .searchable(text: $query, prompt: "Search tasks")
                 .refreshable { await app.loadTasks() }

--- a/scripts/ios-code-browser-files.test.mjs
+++ b/scripts/ios-code-browser-files.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const browser = await readFile(
+  new URL("../apps/ios/CovenCave/CovenCave/Views/CodeBrowserView.swift", import.meta.url),
+  "utf8",
+);
+const reading = await readFile(
+  new URL("../apps/ios/CovenCave/CovenCave/Views/ReadingView.swift", import.meta.url),
+  "utf8",
+);
+const tasks = await readFile(
+  new URL("../apps/ios/CovenCave/CovenCave/Views/TasksView.swift", import.meta.url),
+  "utf8",
+);
+const runner = await readFile(new URL("./run-tests.mjs", import.meta.url), "utf8");
+
+assert.match(
+  browser,
+  /\.navigationBarTitleDisplayMode\(\.inline\)/,
+  "iOS Code view should use the compact navigation title",
+);
+assert.match(
+  reading,
+  /\.navigationBarTitleDisplayMode\(\.inline\)/,
+  "iOS Reading view should use the compact navigation title",
+);
+assert.match(
+  tasks,
+  /\.navigationBarTitleDisplayMode\(\.inline\)/,
+  "iOS Tasks view should use the compact navigation title",
+);
+assert.match(
+  browser,
+  /CodeNode\([\s\S]*isProject: true,[\s\S]*autoExpand: true,[\s\S]*color:/,
+  "iOS Code view should expand project roots so files are visible immediately",
+);
+assert.match(
+  browser,
+  /private func expandAndLoad\(\)[\s\S]*if isProject \{ onFocusProject\?\(\) \}[\s\S]*Task \{ await load\(\) \}/,
+  "iOS Code view should focus and load project trees from one expansion path",
+);
+assert.match(
+  browser,
+  /\.onAppear \{[\s\S]*if autoExpand \{ expandAndLoad\(\) \}[\s\S]*\}/,
+  "iOS Code view should auto-load expanded project roots on appear",
+);
+assert.match(
+  browser,
+  /\.listStyle\(\.plain\)/,
+  "iOS Code project tree should use a minimal plain list",
+);
+assert.match(
+  browser,
+  /Capsule\(\)[\s\S]*\.frame\(width: 3, height: 18\)/,
+  "iOS Code project rows should use a compact color accent",
+);
+assert.match(
+  browser,
+  /Text\(name\)\.font\(\.subheadline\.weight\(\.semibold\)\)/,
+  "iOS Code project rows should use compact row typography",
+);
+assert.match(
+  runner,
+  /"scripts\/ios-code-browser-files\.test\.mjs"/,
+  "ios-code-browser-files test should be wired into the mobile suite",
+);
+
+console.log("ios-code-browser-files.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -481,6 +481,7 @@ export const SUITES = {
     "src/lib/mobile-access-token.test.ts",
     "src/lib/mobile-handoff.test.ts",
     "scripts/ios-app-store-assets.test.mjs",
+    "scripts/ios-code-browser-files.test.mjs",
     "scripts/ios-code-viewer.test.mjs",
     "scripts/ios-no-canvas-tab.test.mjs",
     "scripts/ios-message-reader.test.mjs",


### PR DESCRIPTION
## What

Preserves and PR-shapes the remaining iOS polish WIP from `main`:

- makes Code/Reading/Tasks use compact inline navigation titles
- auto-expands iOS Code project roots so files are visible immediately
- tightens Code file-tree row styling and project path display
- adds `scripts/ios-code-browser-files.test.mjs` and wires it into the mobile suite

## Verification

- `node scripts/ios-code-browser-files.test.mjs`
- `git diff --check`
- pre-commit hook passed during commit
