### PR TITLE
fix(ios): un-red main — loosen updateTask test assertion after #1651

### DIFF
--- a/scripts/ios-task-actions.test.mjs
+++ b/scripts/ios-task-actions.test.mjs
@@ -18,11 +18,12 @@ const detail = await readFile(
   "utf8",
 );
 
-// Client speaks the board mutation contract.
+// Client speaks the board mutation contract. (Match the core params loosely so
+// adding further optional fields — e.g. notes — doesn't break this assertion.)
 assert.match(
   client,
-  /func updateTask\(cardId: String, status: CardStatus\? = nil,\s*priority: CardPriority\? = nil, steps: \[CardStep\]\? = nil\) async throws -> BoardCard/,
-  "CaveClient should expose updateTask(status:priority:steps:)",
+  /func updateTask\(cardId: String, status: CardStatus\? = nil,[\s\S]*?priority: CardPriority\? = nil,[\s\S]*?steps: \[CardStep\]\? = nil[\s\S]*?\) async throws -> BoardCard/,
+  "CaveClient should expose updateTask(status:priority:steps:…)",
 );
 assert.match(
   client,


### PR DESCRIPTION
## Why

#1651 added a `notes:` parameter to `CaveClient.updateTask`, but `scripts/ios-task-actions.test.mjs` pinned the **exact** old signature (`status:priority:steps:`), so `test:mobile` — and therefore the **Frontend build** required check — went red on `main`.

## Fix

Loosen the `updateTask` signature assertion to match the core params (`status`, `priority`, `steps`) without pinning the full list, so future optional fields don't re-break it.

## Verification

- `pnpm test:mobile` → **✓ 25 test file(s) passed** (the full suite, not just one test — which is how the original miss slipped through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)