### PR TITLE
test(ios): accept task notes update signature

### DIFF
--- a/scripts/ios-task-actions.test.mjs
+++ b/scripts/ios-task-actions.test.mjs
@@ -21,8 +21,8 @@ const detail = await readFile(
 // Client speaks the board mutation contract.
 assert.match(
   client,
-  /func updateTask\(cardId: String, status: CardStatus\? = nil,\s*priority: CardPriority\? = nil, steps: \[CardStep\]\? = nil\) async throws -> BoardCard/,
-  "CaveClient should expose updateTask(status:priority:steps:)",
+  /func updateTask\(cardId: String, status: CardStatus\? = nil, priority: CardPriority\? = nil,\s*steps: \[CardStep\]\? = nil, notes: String\? = nil\) async throws -> BoardCard/,
+  "CaveClient should expose updateTask(status:priority:steps:notes:)",
 );
 assert.match(
   client,


### PR DESCRIPTION
## What

Fixes the mobile CI regression left after #1651:

- updates `scripts/ios-task-actions.test.mjs` to accept `CaveClient.updateTask(..., notes:)`
- preserves the existing status/priority/steps assertion while adding the notes parameter

## Verification

- `node scripts/ios-task-actions.test.mjs`
- `pnpm test:mobile`
- `git diff --check`
- pre-commit hook passed during commit
