### PR TITLE
feat(ios): inline nav titles on Read & Tasks to reclaim header space

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ReadingView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ReadingView.swift
@@ -22,6 +22,7 @@ struct ReadingView: View {
                 }
             }
             .navigationTitle("Reading")
+            .navigationBarTitleDisplayMode(.inline)
             .searchable(text: $query, prompt: "Search titles, authors, tags")
             .refreshable { await app.loadReading() }
             .task { if !app.readingLoaded { await app.loadReading() } }

--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -31,6 +31,7 @@ struct TasksView: View {
         NavigationStack(path: $path) {
             content
                 .navigationTitle("Tasks")
+                .navigationBarTitleDisplayMode(.inline)
                 .navigationDestination(for: BoardCard.self) { TaskDetailView(card: $0) }
                 .searchable(text: $query, prompt: "Search tasks")
                 .refreshable { await app.loadTasks() }


### PR DESCRIPTION
## What

Switch the **Read** and **Tasks** tabs to `.navigationBarTitleDisplayMode(.inline)`.

Both screens used the default large-title navigation bar, which reserved ~90pt of vertical space for a title that — sitting directly above a search field and a filter/segment bar — read as dead space on these dense lists (see the empty black block above the search field in the reported screens).

With inline titles, the title collapses into the compact nav bar, the search field rises beneath it, and the chip bar (Read) / segmented control (Tasks) pins right under that. Each screen now opens into content instead of starting a third of the way down.

## Changes

- `ReadingView.swift` — add `.navigationBarTitleDisplayMode(.inline)`
- `TasksView.swift` — add `.navigationBarTitleDisplayMode(.inline)`

Two one-line additions; no behavior or data changes.

## Verification

Built and run on iPhone 16 Pro (iOS 26.5) simulator with live data — `** BUILD SUCCEEDED **`. Confirmed both tabs open with the compact header and content above the fold (Read shows ~5 rows on first load instead of ~1; Tasks shows the segmented control + first "In progress" section immediately).

> Note: iOS Swift isn't compiled by the required CI checks, so this was verified locally via `xcodebuild` + simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)