### PR TITLE
feat(ios): rename chat threads

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -618,6 +618,15 @@ final class AppModel {
         persistThreads()
     }
 
+    /// Rename a thread (local title only); no-ops on a blank or unchanged name.
+    func renameThread(_ thread: ChatThread, to title: String) {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != thread.title,
+              let target = threads.first(where: { $0.id == thread.id }) else { return }
+        target.title = trimmed
+        persistThreads()
+    }
+
     func touch(_ thread: ChatThread) {
         // Move the most recently active thread to the top, then persist.
         if let idx = threads.firstIndex(where: { $0.id == thread.id }), idx != 0 {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -16,6 +16,7 @@ struct ChatsHomeView: View {
     @State private var showNewChat = false
     @State private var query = ""
     @State private var path: [ChatRoute] = []
+    @State private var renamingThread: ChatThread?
 
     var body: some View {
         NavigationStack(path: $path) {
@@ -119,6 +120,14 @@ struct ChatsHomeView: View {
                         }
                         .buttonStyle(.plain)
                         .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                        .contextMenu {
+                            Button { renamingThread = thread } label: {
+                                Label("Rename", systemImage: "pencil")
+                            }
+                            Button(role: .destructive) { app.deleteThread(thread) } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
                     }
                     .onDelete { offsets in
                         offsets.map { filteredGroups[$0] }.forEach(app.deleteThread)
@@ -127,6 +136,7 @@ struct ChatsHomeView: View {
             }
         }
         .listStyle(.plain)
+        .threadRenameAlert($renamingThread) { thread, name in app.renameThread(thread, to: name) }
     }
 
     /// Familiars matching the search query (name or role). Empty query → all.

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -9,6 +9,7 @@ struct FamiliarThreadsView: View {
     @Environment(AppModel.self) private var app
     let familiar: Familiar
     @Binding var path: [ChatRoute]
+    @State private var renamingThread: ChatThread?
 
     /// One row in the list: an on-device thread or a server-only session.
     private enum Entry: Identifiable {
@@ -72,10 +73,21 @@ struct FamiliarThreadsView: View {
                 Button { open(entry) } label: { row(entry) }
                     .buttonStyle(.plain)
                     .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                    .contextMenu {
+                        if case .local(let thread) = entry {
+                            Button { renamingThread = thread } label: {
+                                Label("Rename", systemImage: "pencil")
+                            }
+                            Button(role: .destructive) { app.deleteThread(thread) } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                    }
             }
             .onDelete(perform: delete)
         }
         .listStyle(.plain)
+        .threadRenameAlert($renamingThread) { thread, name in app.renameThread(thread, to: name) }
     }
 
     @ViewBuilder

--- a/apps/ios/CovenCave/CovenCave/Views/ThreadRename.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ThreadRename.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// Hosts a "Rename chat" alert with a text field. Drive it by setting the bound
+/// `thread`; the alert seeds its field from that thread's title and calls
+/// `onRename` with the new name on submit. Shared by every thread list.
+private struct ThreadRenameModifier: ViewModifier {
+    @Binding var thread: ChatThread?
+    let onRename: (ChatThread, String) -> Void
+    @State private var text = ""
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: thread?.id) { _, _ in text = thread?.title ?? "" }
+            .alert("Rename chat", isPresented: presented) {
+                TextField("Name", text: $text)
+                Button("Cancel", role: .cancel) {}
+                Button("Save") { if let thread { onRename(thread, text) } }
+            }
+    }
+
+    private var presented: Binding<Bool> {
+        Binding(get: { thread != nil }, set: { if !$0 { thread = nil } })
+    }
+}
+
+extension View {
+    /// Attach the shared rename alert, driven by a binding to the thread being
+    /// renamed (set it from a context-menu "Rename" action).
+    func threadRenameAlert(_ thread: Binding<ChatThread?>,
+                           onRename: @escaping (ChatThread, String) -> Void) -> some View {
+        modifier(ThreadRenameModifier(thread: thread, onRename: onRename))
+    }
+}

--- a/scripts/ios-thread-rename.test.mjs
+++ b/scripts/ios-thread-rename.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (rel) => readFile(new URL(`../${rel}`, import.meta.url), "utf8");
+const iosRoot = "apps/ios/CovenCave/CovenCave";
+
+const model = await read(`${iosRoot}/State/AppModel.swift`);
+const rename = await read(`${iosRoot}/Views/ThreadRename.swift`);
+const home = await read(`${iosRoot}/Views/ChatsHomeView.swift`);
+const familiarThreads = await read(`${iosRoot}/Views/FamiliarThreadsView.swift`);
+
+// Model renames a thread (trim + no-op + persist).
+assert.match(
+  model,
+  /func renameThread\(_ thread: ChatThread, to title: String\) \{[\s\S]*trimmingCharacters[\s\S]*guard !trimmed\.isEmpty, trimmed != thread\.title[\s\S]*target\.title = trimmed[\s\S]*persistThreads\(\)/,
+  "AppModel.renameThread should trim, no-op when unchanged, and persist",
+);
+
+// Shared rename alert modifier.
+assert.match(rename, /struct ThreadRenameModifier: ViewModifier/, "a ThreadRenameModifier should exist");
+assert.match(rename, /TextField\("Name", text: \$text\)/, "the rename alert should have a text field");
+assert.match(
+  rename,
+  /func threadRenameAlert\(_ thread: Binding<ChatThread\?>,[\s\S]*onRename: @escaping \(ChatThread, String\) -> Void\) -> some View/,
+  "a threadRenameAlert view modifier should be exposed",
+);
+
+// Both thread lists wire a Rename context-menu action + the alert.
+for (const [name, src] of [["ChatsHomeView", home], ["FamiliarThreadsView", familiarThreads]]) {
+  assert.match(src, /renamingThread = thread/, `${name} should set the renaming thread from a menu`);
+  assert.match(src, /Label\("Rename", systemImage: "pencil"\)/, `${name} should offer a Rename action`);
+  assert.match(
+    src,
+    /\.threadRenameAlert\(\$renamingThread\) \{ thread, name in app\.renameThread\(thread, to: name\) \}/,
+    `${name} should attach the rename alert`,
+  );
+}
+
+// FamiliarThreadsView only renames on-device threads, not server-only sessions.
+assert.match(
+  familiarThreads,
+  /if case \.local\(let thread\) = entry \{[\s\S]*renamingThread = thread/,
+  "FamiliarThreadsView should only rename local threads",
+);
+
+console.log("ios-thread-rename.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -488,6 +488,7 @@ export const SUITES = {
     "scripts/ios-task-notes-reader.test.mjs",
     "scripts/ios-task-notes-edit.test.mjs",
     "scripts/ios-task-actions.test.mjs",
+    "scripts/ios-thread-rename.test.mjs",
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/mobile-tailscale.test.mjs",
     "scripts/mobile-tailscale-native.test.mjs",


### PR DESCRIPTION
## What

Threads could be deleted but not renamed on iOS. Adds a **Rename** action.

- **`AppModel.renameThread(_:to:)`** — sets the local title and persists; no-ops on a blank or unchanged name.
- **`ThreadRename.swift`** — a reusable `.threadRenameAlert(_:onRename:)` view modifier hosting a "Rename chat" alert with a text field, driven by a binding to the thread being renamed (seeds the field from the current title).
- **`ChatsHomeView`** (group threads) and **`FamiliarThreadsView`** (on-device threads only — server-only sessions are skipped) gain a **Rename** context-menu action wired to the shared alert.

`ChatThread` is `@Observable`, so the new title reflects immediately everywhere.

## Verification

- `pnpm test:mobile` → **✓ 26 test file(s) passed** (full suite — new `scripts/ios-thread-rename.test.mjs` registered in `run-tests.mjs`).
- `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED**.

Interactive rename (long-press → Rename → type → Save) needs taps I can't drive headlessly without `idb`, so it rests on the build + assertion test.

Built in an isolated worktree off `main` and rebased onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)