### PR TITLE
feat(chat): rename Familiars tab to Chat + enforce familiar→projects mapping in the chat surface

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -41,6 +41,7 @@ export const SUITES = {
     "src/lib/chat-project-selection.test.ts",
     "src/lib/chat-session-order.test.ts",
     "src/lib/chat-project-overrides.test.ts",
+    "src/lib/session-project-scope.test.ts",
     "src/components/chat-project-sidebar-dnd.test.ts",
     "src/lib/workflows.test.ts",
     "src/lib/workflow-generate.test.ts",
@@ -540,6 +541,7 @@ const ALIAS_LOADER = new Set([
   "src/lib/workflow-generate.test.ts",
   "src/lib/server/automation-runner.test.ts",
   "src/lib/server/automation-log-paths.test.ts",
+  "src/lib/session-project-scope.test.ts",
 ]);
 
 /** Build the `node` argv (flags + file) for a single test path. */

--- a/src/app/api/sessions/list/route.ts
+++ b/src/app/api/sessions/list/route.ts
@@ -10,6 +10,9 @@ import {
   mergeSessionRows,
 } from "@/lib/session-list-merge";
 import { loadProjects, projectForRoot } from "@/lib/cave-projects";
+import { filterProjectsForFamiliar } from "@/lib/project-permissions";
+import { scopeSessionsToFamiliarProjects } from "@/lib/session-project-scope";
+import { isValidFamiliarId } from "@/lib/server/familiar-id";
 import type { SessionGitContext, SessionInitiator, SessionRow } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
@@ -177,7 +180,26 @@ function enrichSessionsWithGitContext(sessions: SessionRow[]): SessionRow[] {
   });
 }
 
-async function computeSessionsList(includeArchived: boolean): Promise<SessionsListResult> {
+/**
+ * Scope a session list to a familiar's project grants. Sessions in a known
+ * project the familiar lacks access to are dropped; rootless / unknown-project
+ * sessions pass through (the "(no project)" bucket). A null/empty familiarId
+ * is the unscoped operator view — every session is returned.
+ */
+async function scopeForFamiliar(
+  sessions: SessionRow[],
+  projects: Awaited<ReturnType<typeof loadProjects>>,
+  familiarId: string | null,
+): Promise<SessionRow[]> {
+  if (!familiarId) return sessions;
+  const permitted = await filterProjectsForFamiliar(projects, familiarId);
+  return scopeSessionsToFamiliarProjects(sessions, projects, permitted);
+}
+
+async function computeSessionsList(
+  includeArchived: boolean,
+  familiarId: string | null,
+): Promise<SessionsListResult> {
   const [res, state, projects] = await Promise.all([
     callDaemon<DaemonSession[]>({ path: "/api/v1/sessions" }),
     loadState(),
@@ -192,7 +214,9 @@ async function computeSessionsList(includeArchived: boolean): Promise<SessionsLi
           ok: true,
           degraded: true,
           error: res.error ?? `daemon http ${res.status}`,
-          sessions: enrichSessionsWithGitContext(localSessions),
+          sessions: enrichSessionsWithGitContext(
+            await scopeForFamiliar(localSessions, projects, familiarId),
+          ),
         },
       };
     }
@@ -215,10 +239,15 @@ async function computeSessionsList(includeArchived: boolean): Promise<SessionsLi
     isValidDaemonProjectRoot: isKnownProjectOrValidDir,
   });
 
-  return { payload: { ok: true, sessions: enrichSessionsWithGitContext(sessions) } };
+  const scoped = await scopeForFamiliar(sessions, projects, familiarId);
+  return { payload: { ok: true, sessions: enrichSessionsWithGitContext(scoped) } };
 }
 
-async function cachedSessionsList(cacheKey: string, includeArchived: boolean): Promise<SessionsListResult> {
+async function cachedSessionsList(
+  cacheKey: string,
+  includeArchived: boolean,
+  familiarId: string | null,
+): Promise<SessionsListResult> {
   const now = Date.now();
   const cached = sessionsListCache.get(cacheKey);
   if (cached && cached.expiresAt > now) {
@@ -227,7 +256,7 @@ async function cachedSessionsList(cacheKey: string, includeArchived: boolean): P
   const inFlight = sessionsListInFlight.get(cacheKey);
   if (inFlight) return inFlight;
 
-  const promise = computeSessionsList(includeArchived).then((result) => {
+  const promise = computeSessionsList(includeArchived, familiarId).then((result) => {
     sessionsListCache.set(cacheKey, {
       expiresAt: Date.now() + SESSIONS_LIST_CACHE_MS,
       result,
@@ -245,7 +274,12 @@ async function cachedSessionsList(cacheKey: string, includeArchived: boolean): P
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const includeArchived = url.searchParams.get("includeArchived") === "1";
-  const cacheKey = includeArchived ? "archived" : "active";
-  const result = await cachedSessionsList(cacheKey, includeArchived);
+  const familiarId = url.searchParams.get("familiarId")?.trim() || null;
+  if (familiarId && !isValidFamiliarId(familiarId)) {
+    return NextResponse.json({ ok: false, error: "invalid familiar id", sessions: [] }, { status: 400 });
+  }
+  // Cache per (archived, familiar) — scoped views differ by grant set.
+  const cacheKey = `${includeArchived ? "archived" : "active"}:${familiarId ?? "all"}`;
+  const result = await cachedSessionsList(cacheKey, includeArchived, familiarId);
   return NextResponse.json(result.payload, result.init);
 }

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -231,7 +231,9 @@ function ChatListSection({
 
 export function ChatList({ familiar, familiars = [], sessions, daemonRunning, onOpen, onNewChat, onSessionsChanged, sessionsLoaded = true, compact = false }: Props) {
   useMinuteTick(); // keep the "Xm ago" timestamps current without a data refresh
-  const { projects } = useProjects();
+  // Scope the project rail to what the active familiar is granted; with no
+  // active familiar (all-familiars view) this loads every project as before.
+  const { projects } = useProjects({ familiarId: familiar?.id ?? null });
   const projectOverrides = useProjectOverrides();
   const dtPrefs = useDateTimePrefs();
   const [error, setError] = useState<string | null>(null);
@@ -408,7 +410,10 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch("/api/sessions/list?includeArchived=1", { cache: "no-store" });
+        // Scope archived rows to the active familiar's projects, same as the
+        // live list — keeps forbidden-project sessions out of the archive view.
+        const scope = familiar?.id ? `&familiarId=${encodeURIComponent(familiar.id)}` : "";
+        const res = await fetch(`/api/sessions/list?includeArchived=1${scope}`, { cache: "no-store" });
         const json = await res.json().catch(() => ({ ok: false }));
         if (cancelled || !json.ok || !Array.isArray(json.sessions)) return;
         setArchivedRows((json.sessions as SessionRow[]).filter((s) => s.archived_at));
@@ -417,7 +422,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
       }
     })();
     return () => { cancelled = true; };
-  }, [showArchived, archiveNonce]);
+  }, [showArchived, archiveNonce, familiar?.id]);
 
   // Content search fires only for queries of length ≥2, debounced ~300ms so
   // each keystroke doesn't hit disk; a retype aborts the in-flight fetch.

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -523,7 +523,7 @@ export function ChatSurface({
             }}
           />
         ) : scope === "projects" && !isCodeSurface ? (
-          <ProjectsView sessions={sessions} onNewChat={startProjectChat} onSessionsChanged={onSessionsChanged} />
+          <ProjectsView sessions={sessions} onNewChat={startProjectChat} onSessionsChanged={onSessionsChanged} activeFamiliarId={activeFamiliarId} />
         ) : (
           <Group
             className="flex min-h-0 min-w-0 flex-1"

--- a/src/components/mobile-bottom-tabs.tsx
+++ b/src/components/mobile-bottom-tabs.tsx
@@ -23,7 +23,7 @@ type TabDef = {
 
 const TABS: TabDef[] = [
   { id: "home", label: "Home", ariaLabel: "Home", iconName: "ph:house-bold" },
-  { id: "chat", label: "Familiars", ariaLabel: "Familiars", iconName: "ph:chats" },
+  { id: "chat", label: "Chat", ariaLabel: "Chat", iconName: "ph:chats" },
   { id: "board", label: "Board", ariaLabel: "Board", iconName: "ph:kanban" },
   { id: "inbox", label: "Sched", ariaLabel: "Schedules", iconName: "ph:calendar-bold" },
   { id: "library", label: "Library", ariaLabel: "Library", iconName: "ph:books" },

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -9,7 +9,7 @@ const workspaceMode = readFileSync(new URL("../lib/workspace-mode.ts", import.me
 const iconSource = readFileSync(new URL("../lib/icon.tsx", import.meta.url), "utf8");
 
 assert.match(projectsView, /export function ProjectsView/, "ProjectsView should export the workspace surface");
-assert.match(projectsView, /useProjects\(\)/, "ProjectsView should use the live projects hook");
+assert.match(projectsView, /useProjects\(\{ familiarId: activeFamiliarId \}\)/, "ProjectsView should scope the live projects hook to the active familiar");
 assert.match(projectsView, /createProject\(name, root\)/, "ProjectsView should create projects through the hook");
 assert.match(projectsView, /onRename=\{renameProject\}/, "ProjectsView should wire inline rename");
 assert.match(projectsView, /onUpdateRoot=\{updateRoot\}/, "ProjectsView should wire root updates");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -203,6 +203,8 @@ type ProjectsViewProps = {
   sessions?: SessionRow[];
   onNewChat?: (projectRoot: string) => void;
   onSessionsChanged?: () => void;
+  /** When set, only projects this familiar has been granted are shown. */
+  activeFamiliarId?: string | null;
 };
 
 function openSessionById(sessionId: string): void {
@@ -662,7 +664,7 @@ function ProjectRow({
   );
 }
 
-export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: ProjectsViewProps) {
+export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, activeFamiliarId = null }: ProjectsViewProps) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   useMinuteTick(); // keep the per-project "last active" relative times current
   const {
@@ -674,7 +676,7 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged }: Pr
     updateRoot,
     deleteProject,
     reload,
-  } = useProjects();
+  } = useProjects({ familiarId: activeFamiliarId });
   const [showForm, setShowForm] = useState(false);
   const [query, setQuery] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -118,8 +118,8 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /\{ id: "chat", label: "Familiars", iconName: "ph:chats", group: "work", kbd: "⌘2", description:/,
-  "Familiars should live at the ⌘2 Work shortcut",
+  /\{ id: "chat", label: "Chat", iconName: "ph:chats", group: "work", kbd: "⌘2", description:/,
+  "The Chat surface should live at the ⌘2 Work shortcut",
 );
 
 assert.match(

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -88,7 +88,7 @@ const FOLDER_MODES: Array<{
 }> = [
   // Work
   { id: "home", label: "Home", iconName: "ph:house-bold", group: "work", kbd: "⌘1", description: "Overview and quick actions" },
-  { id: "chat", label: "Familiars", iconName: "ph:chats", group: "work", kbd: "⌘2", description: "Talk with your familiars" },
+  { id: "chat", label: "Chat", iconName: "ph:chats", group: "work", kbd: "⌘2", description: "Talk with your familiars" },
   { id: "board", label: "Board", iconName: "ph:kanban", group: "work", kbd: "⌘3", description: "Track tasks across projects", badge: (p) => badgeText(p.boardOpenCount) },
   { id: "journal", label: "Journal", iconName: "ph:book-open", group: "work", description: "Your daily journal and generated sketches" },
   { id: "calendar", label: "Calendar", iconName: "ph:calendar-blank", group: "work", kbd: "⌘4", description: "Schedule and timeline of work" },

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -518,7 +518,11 @@ export function Workspace() {
         : Promise.resolve(null);
 
       try {
-        const sessionsResult = await fetch("/api/sessions/list", { cache: "no-store" });
+        // Scope the session list to the active familiar's granted projects so
+        // every surface fed by `sessions` enforces the familiar→projects map.
+        // With "All familiars" (activeId null) the unscoped list is returned.
+        const scope = activeId ? `?familiarId=${encodeURIComponent(activeId)}` : "";
+        const sessionsResult = await fetch(`/api/sessions/list${scope}`, { cache: "no-store" });
         const json = await sessionsResult.json();
         if (!json.ok) return;
 
@@ -547,7 +551,7 @@ export function Workspace() {
 
     loadSessionsInFlightRef.current = request;
     return request;
-  }, [addons.github]);
+  }, [addons.github, activeId]);
 
   useEffect(() => {
     loadFamiliars();

--- a/src/lib/session-project-scope.test.ts
+++ b/src/lib/session-project-scope.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import path from "node:path";
+
+import { scopeSessionsToFamiliarProjects } from "@/lib/session-project-scope";
+import type { CaveProject } from "@/lib/cave-projects-types";
+import type { SessionRow } from "@/lib/types";
+
+const proj = (id: string, root: string): CaveProject => ({
+  id,
+  name: id,
+  root,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+});
+
+const session = (id: string, root: string): SessionRow =>
+  ({ id, project_root: root } as SessionRow);
+
+const all = [proj("a", "/work/alpha"), proj("b", "/work/beta")];
+
+test("keeps sessions in a permitted project", () => {
+  const out = scopeSessionsToFamiliarProjects([session("s1", "/work/alpha")], all, [all[0]]);
+  assert.deepEqual(out.map((s) => s.id), ["s1"]);
+});
+
+test("drops sessions in a known but forbidden project", () => {
+  const out = scopeSessionsToFamiliarProjects([session("s2", "/work/beta")], all, [all[0]]);
+  assert.deepEqual(out, []);
+});
+
+test("keeps sessions whose root maps to no known project (the '(no project)' bucket)", () => {
+  const out = scopeSessionsToFamiliarProjects([session("s3", "/tmp/scratch")], all, [all[0]]);
+  assert.deepEqual(out.map((s) => s.id), ["s3"]);
+});
+
+test("keeps rootless sessions", () => {
+  const out = scopeSessionsToFamiliarProjects([session("s4", "")], all, []);
+  assert.deepEqual(out.map((s) => s.id), ["s4"]);
+});
+
+test("supreme familiar (all projects permitted) drops nothing", () => {
+  const sessions = [session("s1", "/work/alpha"), session("s2", "/work/beta")];
+  const out = scopeSessionsToFamiliarProjects(sessions, all, all);
+  assert.deepEqual(out.map((s) => s.id), ["s1", "s2"]);
+});
+
+test("matches roots regardless of trailing slash / separator", () => {
+  const out = scopeSessionsToFamiliarProjects([session("s5", "/work/alpha/")], all, [all[0]]);
+  assert.deepEqual(out.map((s) => s.id), ["s5"]);
+});
+
+// ── Wiring assertions (source-level) ────────────────────────────────────────
+const root = path.resolve(import.meta.dirname, "../..");
+const read = (rel: string) => fs.readFileSync(path.join(root, rel), "utf8");
+
+test("the sessions/list route scopes by familiar grants", () => {
+  const route = read("src/app/api/sessions/list/route.ts");
+  assert.match(route, /filterProjectsForFamiliar/, "imports the grant filter");
+  assert.match(route, /scopeSessionsToFamiliarProjects/, "applies the session scope helper");
+  assert.match(route, /searchParams\.get\("familiarId"\)/, "reads the familiarId param");
+});
+
+test("useProjects scopes the project list by familiarId", () => {
+  const hook = read("src/lib/use-projects.ts");
+  assert.match(hook, /familiarId\s*\?\s*`\/api\/projects\?familiarId=/, "passes familiarId to the API");
+});
+
+test("chat surface consumers pass the active familiar scope", () => {
+  assert.match(read("src/components/chat-list.tsx"), /useProjects\(\{ familiarId: familiar\?\.id/, "chat-list scopes its project rail");
+  assert.match(read("src/components/projects-view.tsx"), /useProjects\(\{ familiarId: activeFamiliarId \}\)/, "ProjectsView scopes its project list");
+  assert.match(read("src/components/workspace.tsx"), /\/api\/sessions\/list\$\{scope\}/, "workspace scopes the session poll by familiar");
+});
+
+test("chat/send still gates project access for the acting familiar", () => {
+  const send = read("src/app/api/chat/send/route.ts");
+  assert.match(send, /assertProjectAccess\(\{ familiarId: body\.familiarId \}, chatProjectId, "chat"\)/, "chat/send enforces project access");
+});

--- a/src/lib/session-project-scope.ts
+++ b/src/lib/session-project-scope.ts
@@ -1,0 +1,34 @@
+/**
+ * session-project-scope.ts
+ *
+ * Pure helper that restricts a session list to what a familiar may see, by
+ * project grant. The actual grant resolution lives in project-permissions.ts
+ * (filesystem + audit); this module only applies an already-resolved permitted
+ * set, so it stays pure and trivially testable.
+ *
+ * Policy (matches the chat surface's "(no project)" bucket):
+ *   - A session whose `project_root` maps to a KNOWN project is kept only when
+ *     that project is in `permittedProjects`.
+ *   - A session whose `project_root` maps to NO known project (rootless or an
+ *     ad-hoc cwd) is always kept — it surfaces under "(no project)".
+ *
+ * The supreme familiar passes the full project list as `permittedProjects`, so
+ * nothing is dropped.
+ */
+
+import { normalizeProjectRoot, type CaveProject } from "@/lib/cave-projects-types";
+import type { SessionRow } from "@/lib/types";
+
+export function scopeSessionsToFamiliarProjects(
+  sessions: SessionRow[],
+  allProjects: CaveProject[],
+  permittedProjects: CaveProject[],
+): SessionRow[] {
+  const knownRoots = new Set(allProjects.map((p) => normalizeProjectRoot(p.root)));
+  const permittedRoots = new Set(permittedProjects.map((p) => normalizeProjectRoot(p.root)));
+  return sessions.filter((session) => {
+    const root = normalizeProjectRoot(session.project_root);
+    if (!knownRoots.has(root)) return true; // unknown project → "(no project)" bucket
+    return permittedRoots.has(root); // known project → only if granted
+  });
+}

--- a/src/lib/use-projects.ts
+++ b/src/lib/use-projects.ts
@@ -17,9 +17,15 @@ export type ProjectsState = {
 
 export type UseProjectsOptions = {
   enabled?: boolean;
+  /**
+   * When set, the list is scoped server-side to the projects this familiar has
+   * been granted access to (`/api/projects?familiarId=`). Omit (or pass null)
+   * to load every project — the unscoped operator view.
+   */
+  familiarId?: string | null;
 };
 
-export function useProjects({ enabled = true }: UseProjectsOptions = {}): ProjectsState {
+export function useProjects({ enabled = true, familiarId = null }: UseProjectsOptions = {}): ProjectsState {
   const [projects, setProjects] = useState<CaveProject[]>([]);
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<string | null>(null);
@@ -33,7 +39,10 @@ export function useProjects({ enabled = true }: UseProjectsOptions = {}): Projec
     setError(null);
 
     try {
-      const res = await fetch("/api/projects", { signal: controller.signal });
+      const url = familiarId
+        ? `/api/projects?familiarId=${encodeURIComponent(familiarId)}`
+        : "/api/projects";
+      const res = await fetch(url, { signal: controller.signal });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = (await res.json()) as { ok?: boolean; projects?: CaveProject[]; error?: string };
       if (!controller.signal.aborted) {
@@ -50,7 +59,7 @@ export function useProjects({ enabled = true }: UseProjectsOptions = {}): Projec
     } finally {
       if (!controller.signal.aborted) setLoading(false);
     }
-  }, []);
+  }, [familiarId]);
 
   useEffect(() => {
     if (!enabled) {

--- a/tests/mobile/command-center-pages.spec.ts
+++ b/tests/mobile/command-center-pages.spec.ts
@@ -59,7 +59,7 @@ test.describe("mobile command center pages", () => {
   });
 
   test("Chat index and new chat detail keep stable mobile geometry", async ({ page }) => {
-    await page.getByRole("tab", { name: "Familiars" }).click();
+    await page.getByRole("tab", { name: "Chat" }).click();
     await page.waitForSelector(".chat-surface");
 
     await expectNoHorizontalOverflow(page, "Chat index");

--- a/tests/mobile/foundations.spec.ts
+++ b/tests/mobile/foundations.spec.ts
@@ -72,7 +72,7 @@ test.describe("mobile foundations", () => {
     await page.goto("/");
     await page.waitForSelector(".shell-frame");
 
-    const surfaces = ["Home", "Familiars", "Board", "Calendar", "Browser", "Terminal", "Code"];
+    const surfaces = ["Home", "Chat", "Board", "Calendar", "Browser", "Terminal", "Code"];
     const sidebar = page.locator(".sidebar-nav-scroll");
 
     for (const surface of surfaces) {


### PR DESCRIPTION
## Summary

Renames the ⌘2 **"Familiars"** navigation tab to **"Chat"**, and enforces the familiar→projects mapping so the chat surface only shows the projects — and chats — a familiar has been granted.

### 1. Rename
- Sidebar (`sidebar-minimal.tsx`) and mobile bottom tabs: **"Familiars" → "Chat"**. (The familiar *roster* subpage and the command-palette familiar category keep their own labels — those name familiar entities, not the tab.)

### 2. Sessions/Projects scoped to the active familiar's grants
The chat surface already groups chats by project (via `ChatProjectSidebar`); the missing piece was permission filtering, now added:
- `useProjects({ familiarId })` scopes `/api/projects` to the familiar's grants (the route already supported `?familiarId=` via `filterProjectsForFamiliar`). The chat-list project rail and the Projects tab both pass the active familiar.
- **`/api/sessions/list?familiarId=`** filters sessions server-side: chats in a *known-but-forbidden* project are dropped; rootless / unknown-project chats pass through to the **"(no project)"** bucket. The **supreme** familiar sees everything. Cache key now keys on `(archived, familiar)`.
- `workspace.tsx` polls the session list scoped to the active familiar (`activeId`); **"All familiars"** stays unscoped. The archived-sessions fetch in `chat-list` is scoped the same way.

### 3. Enforcement
- New pure, tested helper `src/lib/session-project-scope.ts` backs the server filter (the same `(no project)` bucket policy as the UI).
- `/api/chat/send` already gates the **acting** familiar's project access (`assertProjectAccess(..., "chat")`) — the real agent-action boundary; the new test asserts it stays in place.

### Decision notes
- Kept **both** Sessions and Projects tabs rather than merging: the Projects tab is also the project-management surface (create/rename/delete) and the target of many "open project" actions across the app, so removing it would drop functionality. Both are now permission-filtered.
- Filtering by the **active familiar** (one selected → their grants; All-familiars → unscoped). Supreme sees all.

## Tests
- `src/lib/session-project-scope.test.ts` — 10 cases (permitted/forbidden/unknown/rootless/supreme/normalization) + wiring assertions across the route, hook, and consumers.
- Updated `sidebar-minimal.test.ts` (label) and `projects-view.test.ts` (`useProjects` scoping).
- **Full `app` + `mobile` suites pass (398 files); `tsc --noEmit` clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)