### PR TITLE
feat(ios): live streaming markdown, user-message markdown, native image zoom, reader upgrades

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -570,29 +570,84 @@ struct ResponseReaderView: View {
     @Environment(\.dismiss) private var dismiss
     let item: ResponseReaderItem
     @State private var mdHeight: CGFloat = 0
+    @AppStorage("cave:reader:fontScale") private var fontScale: Double = 1.0
+    @AppStorage("cave:reader:theme") private var themeRaw: String = ReaderTheme.dark.rawValue
+    @State private var headings: [ReaderHeading] = []
+    @State private var scrollCommand: ReaderScrollCommand?
+    @State private var scrollToken = 0
+
+    private var theme: ReaderTheme { ReaderTheme(rawValue: themeRaw) ?? .dark }
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                MarkdownWebView(markdown: item.markdown, height: $mdHeight)
-                    .frame(height: max(mdHeight, 1))
-                    .padding(20)
+            // The reader's WebView scrolls internally (scrollable: true) so the
+            // TOC can scroll to a heading and font/theme changes preserve the
+            // scroll position. Fills the screen rather than auto-height.
+            MarkdownWebView(markdown: item.markdown, height: $mdHeight,
+                            scrollable: true,
+                            fontScale: CGFloat(fontScale),
+                            theme: theme,
+                            scrollCommand: scrollCommand,
+                            onHeadings: { headings = $0 })
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(theme.background.ignoresSafeArea())
+                .navigationTitle(item.title)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar { readerToolbar }
+        }
+    }
+
+    @ToolbarContentBuilder private var readerToolbar: some ToolbarContent {
+        ToolbarItem(placement: .cancellationAction) {
+            Button {
+                UIPasteboard.general.string = item.markdown
+                Haptics.tap()
+            } label: {
+                Label("Copy", systemImage: "doc.on.doc")
             }
-            .navigationTitle(item.title)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button {
-                        UIPasteboard.general.string = item.markdown
-                        Haptics.tap()
-                    } label: {
-                        Label("Copy", systemImage: "doc.on.doc")
+        }
+        ToolbarItemGroup(placement: .primaryAction) {
+            if !headings.isEmpty {
+                Menu {
+                    ForEach(headings) { h in
+                        Button {
+                            scrollToken += 1
+                            scrollCommand = ReaderScrollCommand(index: h.index, token: scrollToken)
+                            Haptics.tap()
+                        } label: {
+                            // Indent nested headings so the outline reads as a tree.
+                            Text(String(repeating: "   ", count: max(0, h.level - 1)) + h.text)
+                        }
+                    }
+                } label: {
+                    Image(systemName: "list.bullet")
+                }
+                .accessibilityLabel("Table of contents")
+            }
+            Menu {
+                Section("Text size") {
+                    Button { fontScale = min(fontScale + 0.1, 1.8) } label: {
+                        Label("Larger", systemImage: "textformat.size.larger")
+                    }
+                    Button { fontScale = max(fontScale - 0.1, 0.7) } label: {
+                        Label("Smaller", systemImage: "textformat.size.smaller")
+                    }
+                    Button { fontScale = 1.0 } label: {
+                        Label("Reset size", systemImage: "arrow.counterclockwise")
                     }
                 }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") { dismiss() }
+                Section("Theme") {
+                    ForEach(ReaderTheme.allCases) { t in
+                        Button { themeRaw = t.rawValue } label: {
+                            Label(t.label, systemImage: theme == t ? "checkmark" : t.icon)
+                        }
+                    }
                 }
+            } label: {
+                Image(systemName: "textformat.size")
             }
+            .accessibilityLabel("Reading options")
+            Button("Done") { dismiss() }
         }
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Views/MarkdownDetect.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MarkdownDetect.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Cheap heuristic: does this text contain block/inline markdown worth rendering
+/// through the WebView? Assistant replies always render markdown; a *user*
+/// message only does when it actually contains markdown — plain chatter stays
+/// native `Text` (fast, fully selectable).
+enum MarkdownDetect {
+    static func hasMarkdown(_ text: String) -> Bool {
+        if text.isEmpty { return false }
+        // Fenced code anywhere is the strongest signal.
+        if text.contains("```") { return true }
+
+        // Line-anchored block syntax: headings, list markers, blockquotes,
+        // ordered lists, and table rows.
+        for raw in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = raw.drop(while: { $0 == " " })
+            if line.isEmpty { continue }
+            if line.hasPrefix("# ") || line.hasPrefix("## ") || line.hasPrefix("### ")
+                || line.hasPrefix("#### ") || line.hasPrefix("##### ") || line.hasPrefix("###### ") {
+                return true
+            }
+            if line.hasPrefix("- ") || line.hasPrefix("* ") || line.hasPrefix("+ ") || line.hasPrefix("> ") {
+                return true
+            }
+            // Ordered list: "1. " / "12. "
+            if let first = line.first, first.isNumber,
+               let dot = line.firstIndex(of: "."),
+               line[line.startIndex..<dot].allSatisfy(\.isNumber),
+               line.index(after: dot) < line.endIndex,
+               line[line.index(after: dot)] == " " {
+                return true
+            }
+            // Table row: at least two pipes.
+            if line.filter({ $0 == "|" }).count >= 2 { return true }
+        }
+
+        // Inline emphasis / code / links.
+        if text.range(of: #"`[^`]+`"#, options: .regularExpression) != nil { return true }
+        if text.range(of: #"\*\*[^*]+\*\*"#, options: .regularExpression) != nil { return true }
+        if text.range(of: #"\[[^\]]+\]\([^)]+\)"#, options: .regularExpression) != nil { return true }
+        return false
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/MarkdownWebView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MarkdownWebView.swift
@@ -1,30 +1,88 @@
 import SwiftUI
 import WebKit
 
+/// Reader colour theme — overrides the bundle's prose CSS variables. Code blocks
+/// stay dark in every theme (a dark code card on a light page is intentional).
+enum ReaderTheme: String, CaseIterable, Identifiable {
+    case dark, light, sepia
+    var id: String { rawValue }
+    var label: String {
+        switch self {
+        case .dark: return "Dark"
+        case .light: return "Light"
+        case .sepia: return "Sepia"
+        }
+    }
+    var icon: String {
+        switch self {
+        case .dark: return "moon.fill"
+        case .light: return "sun.max.fill"
+        case .sepia: return "book.fill"
+        }
+    }
+    /// SwiftUI page background behind the (transparent) WebView, matched to the
+    /// CSS `bg` the renderer paints so there's no seam at the edges.
+    var background: Color {
+        switch self {
+        case .dark: return .black
+        case .light: return .white
+        case .sepia: return Color(red: 0.957, green: 0.925, blue: 0.847)
+        }
+    }
+}
+
+/// A heading reported by the renderer, used to build the reader's table of
+/// contents. `index` is its document order so native can ask the WebView to
+/// scroll to it without translating coordinates.
+struct ReaderHeading: Identifiable, Equatable {
+    let id = UUID()
+    let index: Int
+    let level: Int
+    let text: String
+}
+
+/// A request to scroll the reader to a heading. The `token` makes repeated taps
+/// on the same heading distinct so the command re-fires.
+struct ReaderScrollCommand: Equatable { var index: Int; var token: Int }
+
 /// Renders markdown with the SAME pipeline as the desktop chat — the bundled
-/// `markdown.html` runs `@create-markdown` + Mermaid in a transparent,
-/// auto-height, non-scrolling WKWebView so assistant replies match the desktop
-/// (code blocks, tables, Mermaid diagrams) while sitting natively in the bubble.
+/// `markdown.html` runs `@create-markdown` + Mermaid in a transparent WKWebView.
+/// Two modes:
+///  - bubble (default): auto-height, non-scrolling, sits inside a chat bubble.
+///    Renders live during streaming (throttled; Mermaid deferred to settle).
+///  - reader (`scrollable: true`): fills the screen, scrolls internally, and
+///    honours `fontScale` / `theme`, with a TOC driven by `scrollCommand`.
 struct MarkdownWebView: UIViewRepresentable {
     let markdown: String
     @Binding var height: CGFloat
+    /// Render live while the reply streams in (bubble mode). Renders are
+    /// throttled and Mermaid is deferred to the final settle.
+    var streaming: Bool = false
+    /// Reader mode: scroll internally + accept font/theme/TOC commands.
+    var scrollable: Bool = false
+    var fontScale: CGFloat = 1
+    var theme: ReaderTheme = .dark
+    var scrollCommand: ReaderScrollCommand? = nil
     /// Called if the bundled renderer can't run (missing/stale `markdown.html`,
     /// `window.caveRender` undefined, or a JS error) so the caller can fall back
     /// to native `Text` instead of leaving the reply as a blank sliver.
     var onFailure: (() -> Void)? = nil
+    /// Reader TOC: the renderer's headings, in document order.
+    var onHeadings: (([ReaderHeading]) -> Void)? = nil
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
-    func makeUIView(context: Context) -> WKWebView {
-        context.coordinator.webView
-    }
+    func makeUIView(context: Context) -> WKWebView { context.coordinator.webView }
 
     func updateUIView(_ uiView: WKWebView, context: Context) {
-        context.coordinator.onHeight = { h in
-            if abs(h - height) > 0.5 { height = h }
-        }
-        context.coordinator.onFailure = onFailure
-        context.coordinator.render(markdown)
+        let c = context.coordinator
+        c.onHeight = { h in if abs(h - height) > 0.5 { height = h } }
+        c.onFailure = onFailure
+        c.onHeadings = onHeadings
+        c.setScrollable(scrollable)
+        c.apply(markdown: markdown, streaming: streaming,
+                fontScale: fontScale, theme: theme, reader: scrollable)
+        c.applyScroll(scrollCommand)
     }
 
     @MainActor
@@ -32,10 +90,25 @@ struct MarkdownWebView: UIViewRepresentable {
         let webView: WKWebView
         var onHeight: ((CGFloat) -> Void)?
         var onFailure: (() -> Void)?
+        var onHeadings: (([ReaderHeading]) -> Void)?
+
         private var ready = false
         private var failed = false
+        private var failedReported = false
         private var pending: String?
-        private var lastRendered: String?
+        private var rendering = false
+        private var throttleScheduled = false
+        private var lastRenderKey: String?
+        private var lastStyleKey: String?
+        private var lastScrollToken: Int?
+
+        private struct Opts {
+            var streaming = false
+            var fontScale: CGFloat = 1
+            var theme: ReaderTheme = .dark
+            var reader = false
+        }
+        private var opts = Opts()
 
         override init() {
             let config = WKWebViewConfiguration()
@@ -60,48 +133,108 @@ struct MarkdownWebView: UIViewRepresentable {
             }
         }
 
-        func render(_ md: String) {
-            guard md != lastRendered else { return }
-            lastRendered = md
-            pending = md
+        func setScrollable(_ on: Bool) {
+            if webView.scrollView.isScrollEnabled != on {
+                webView.scrollView.isScrollEnabled = on
+                webView.scrollView.bounces = on
+            }
+        }
+
+        func apply(markdown md: String, streaming: Bool, fontScale: CGFloat, theme: ReaderTheme, reader: Bool) {
+            opts = Opts(streaming: streaming, fontScale: fontScale, theme: theme, reader: reader)
             if failed { reportFailure(); return }
-            flush()
+            // Markdown / streaming / reader changes need a full re-render; a pure
+            // font-size or theme change is applied without rebuilding the DOM so
+            // the reader's scroll position survives.
+            let renderKey = "\(streaming)|\(reader)|\(md)"
+            let styleKey = "\(fontScale)|\(theme.rawValue)"
+            if renderKey == lastRenderKey {
+                if styleKey != lastStyleKey { lastStyleKey = styleKey; applyStyleOnly() }
+                return
+            }
+            lastRenderKey = renderKey
+            lastStyleKey = styleKey
+            pending = md
+            requestRender()
+        }
+
+        func applyScroll(_ cmd: ReaderScrollCommand?) {
+            guard let cmd, cmd.token != lastScrollToken else { return }
+            lastScrollToken = cmd.token
+            guard ready, !failed else { return }
+            webView.evaluateJavaScript("window.caveScrollToHeading && window.caveScrollToHeading(\(cmd.index))",
+                                       completionHandler: nil)
+        }
+
+        private func applyStyleOnly() {
+            guard ready, !failed else { return }
+            let o = opts
+            let js = "window.caveStyle && window.caveStyle({fontScale:\(Double(o.fontScale)),theme:'\(o.theme.rawValue)',reader:\(o.reader)})"
+            webView.evaluateJavaScript(js, completionHandler: nil)
+        }
+
+        private func requestRender() {
+            if opts.streaming {
+                // Coalesce streaming deltas: render the latest pending markdown at
+                // most every ~150 ms (the heavy pipeline can't run per token).
+                guard !throttleScheduled else { return }
+                throttleScheduled = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
+                    guard let self else { return }
+                    self.throttleScheduled = false
+                    self.flush()
+                }
+            } else {
+                flush()
+            }
+        }
+
+        private func flush() {
+            guard ready, !rendering, let md = pending else { return }
+            pending = nil
+            rendering = true
+            let o = opts
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                do {
+                    let value = try await self.webView.callAsyncJavaScript(
+                        "if (typeof window.caveRender !== 'function') throw new Error('caveRender unavailable'); await window.caveRender(md, opts); return Math.ceil(document.body.getBoundingClientRect().height);",
+                        arguments: [
+                            "md": md,
+                            "opts": [
+                                "streaming": o.streaming,
+                                "fontScale": Double(o.fontScale),
+                                "theme": o.theme.rawValue,
+                                "reader": o.reader,
+                            ],
+                        ],
+                        contentWorld: .page
+                    )
+                    if let h = value as? Double, h > 0 {
+                        self.onHeight?(CGFloat(h))
+                    } else if !o.streaming {
+                        // A settled reply that produced no height is a real failure;
+                        // mid-stream transients are expected, so don't fall back then.
+                        self.reportFailure()
+                    }
+                } catch {
+                    if !o.streaming { self.reportFailure() }
+                }
+                self.rendering = false
+                // Deltas that arrived while this render was in flight: render again.
+                if self.pending != nil { self.requestRender() }
+            }
         }
 
         private func reportFailure() {
             guard !failedReported else { return }
             failedReported = true
             failed = true
-            // Defer past the current SwiftUI update cycle — `render()` runs inside
+            // Defer past the current SwiftUI update cycle — `apply()` runs inside
             // `updateUIView`, and mutating the caller's @State synchronously there
             // is dropped ("Modifying state during view update").
             let callback = onFailure
             DispatchQueue.main.async { callback?() }
-        }
-
-        private var failedReported = false
-
-        private func flush() {
-            guard ready, let md = pending else { return }
-            pending = nil
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                do {
-                    let value = try await self.webView.callAsyncJavaScript(
-                        "if (typeof window.caveRender !== 'function') throw new Error('caveRender unavailable'); await window.caveRender(md); return Math.ceil(document.body.getBoundingClientRect().height);",
-                        arguments: ["md": md],
-                        contentWorld: .page
-                    )
-                    if let h = value as? Double, h > 0 {
-                        self.onHeight?(CGFloat(h))
-                    } else {
-                        // Rendered but produced no measurable content — degrade to Text.
-                        self.reportFailure()
-                    }
-                } catch {
-                    self.reportFailure()
-                }
-            }
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
@@ -115,6 +248,16 @@ struct MarkdownWebView: UIViewRepresentable {
                 switch type {
                 case "height":
                     if let h = body["height"] as? Double { self.onHeight?(CGFloat(h)) }
+                case "headings":
+                    if let arr = body["headings"] as? [[String: Any]] {
+                        let hs: [ReaderHeading] = arr.compactMap { d in
+                            guard let level = d["level"] as? Int,
+                                  let text = d["text"] as? String, !text.isEmpty else { return nil }
+                            let index = (d["index"] as? Int) ?? 0
+                            return ReaderHeading(index: index, level: level, text: text)
+                        }
+                        self.onHeadings?(hs)
+                    }
                 case "link":
                     if let href = body["href"] as? String, let url = URL(string: href) {
                         await UIApplication.shared.open(url)
@@ -125,22 +268,57 @@ struct MarkdownWebView: UIViewRepresentable {
                         Haptics.tap()
                     }
                 case "enlarge":
-                    // A tapped table / Mermaid diagram / inline image, or an
-                    // expanded code block — hand it to the full-screen zoom
-                    // surface (ChatView presents it). Code carries its raw text
-                    // so the zoom view's Copy button works.
-                    if let html = body["html"] as? String, !html.isEmpty {
-                        Haptics.tap()
-                        if body["kind"] as? String == "code" {
-                            ContentZoom.code(html: html, text: body["text"] as? String ?? "")
-                        } else {
-                            ContentZoom.html(html)
-                        }
-                    }
+                    self.handleEnlarge(body)
                 default:
                     break
                 }
             }
+        }
+
+        /// A tapped table / Mermaid diagram / inline image, or an expanded code
+        /// block — hand it to the full-screen zoom surface.
+        private func handleEnlarge(_ body: [String: Any]) {
+            let kind = body["kind"] as? String
+            switch kind {
+            case "code":
+                if let html = body["html"] as? String, !html.isEmpty {
+                    Haptics.tap()
+                    ContentZoom.code(html: html, text: body["text"] as? String ?? "")
+                }
+            case "image":
+                Haptics.tap()
+                presentImage(src: body["src"] as? String, fallbackHTML: body["html"] as? String ?? "")
+            default:
+                if let html = body["html"] as? String, !html.isEmpty {
+                    Haptics.tap()
+                    ContentZoom.html(html)
+                }
+            }
+        }
+
+        /// Decode an inline image's `src` into a `UIImage` for the smooth native
+        /// zoom (pinch/pan/double-tap), matching attachment behaviour. Falls back
+        /// to the HTML zoom for data we can't decode (relative paths, failures).
+        private func presentImage(src: String?, fallbackHTML: String) {
+            if let src, !src.isEmpty {
+                if let img = UIImage.fromDataUrl(src) {
+                    ContentZoom.image(img)
+                    return
+                }
+                if let url = URL(string: src), let scheme = url.scheme,
+                   scheme == "http" || scheme == "https" {
+                    Task { @MainActor in
+                        if let (data, _) = try? await URLSession.shared.data(from: url),
+                           let img = UIImage(data: data) {
+                            ContentZoom.image(img)
+                        } else if !fallbackHTML.isEmpty {
+                            ContentZoom.html(fallbackHTML)
+                        }
+                    }
+                    return
+                }
+            }
+            if !fallbackHTML.isEmpty { ContentZoom.html(fallbackHTML) }
         }
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -54,10 +54,14 @@ struct MessageBubble: View {
         isUser ? (message.text, []) : NextPaths.extract(message.text)
     }
 
-    /// Render the desktop-parity markdown WebView only for a settled, non-error
-    /// assistant reply. Streaming / user / error messages stay native Text.
+    /// Render the desktop-parity markdown WebView. Assistant replies always do —
+    /// now including while streaming (the WebView renders live, throttled). A
+    /// *user* message only renders markdown when it actually contains some, so
+    /// plain chatter stays fast native Text. Error messages stay native Text.
     private var rendersMarkdown: Bool {
-        !isUser && !message.streaming && !message.isError && !parsed.visible.isEmpty && !markdownFailed
+        guard !message.isError, !parsed.visible.isEmpty, !markdownFailed else { return false }
+        if isUser { return MarkdownDetect.hasMarkdown(message.text) }
+        return true
     }
 
     private var canOpenReader: Bool {
@@ -158,6 +162,7 @@ struct MessageBubble: View {
                 .background(bubbleBackground, in: bubbleShape)
         } else if rendersMarkdown {
             MarkdownWebView(markdown: parsed.visible, height: $mdHeight,
+                            streaming: message.streaming && !isUser,
                             onFailure: { markdownFailed = true })
                 .frame(height: max(mdHeight, 1))
                 .padding(.horizontal, 14).padding(.vertical, 10)
@@ -178,6 +183,9 @@ struct MessageBubble: View {
                         .padding(6)
                         .accessibilityLabel("Open response in reader")
                     }
+                }
+                .overlay(alignment: .bottomTrailing) {
+                    if message.streaming && !isUser { StreamingDot().padding(6) }
                 }
         } else {
             Text(parsed.visible.isEmpty ? " " : parsed.visible)

--- a/apps/ios/markdown/entry.mjs
+++ b/apps/ios/markdown/entry.mjs
@@ -89,16 +89,29 @@ function highlightCode(code, rawLang) {
     + `<pre class="hljs"><code class="hljs">${inner}</code></pre></div>`;
 }
 
-async function renderMarkdown(md) {
+// While a reply is still streaming we DON'T run Mermaid: the fence is usually
+// incomplete (so it errors) and re-rendering a diagram on every token is heavy
+// and flickers. Show a lightweight placeholder instead; the real diagram renders
+// once on settle (streaming === false).
+function mermaidPlaceholder(code) {
+  const preview = escapeHtml(code).trim().slice(0, 400);
+  return `<div class="cm-mermaid" style="opacity:.8">`
+    + `<div style="font:600 10.5px ui-monospace,'SF Mono',Menlo,monospace;letter-spacing:.05em;text-transform:uppercase;color:var(--txt-muted);text-align:left;margin-bottom:6px">◇ Diagram · rendering on completion</div>`
+    + `<pre style="margin:0;background:transparent;border:0;padding:0;white-space:pre-wrap;text-align:left;font-size:12px;color:var(--txt-muted)">${preview}</pre></div>`;
+}
+
+async function renderMarkdown(md, { streaming = false } = {}) {
   const blocks = parse(md || "");
   const codeBlocks = blocks.filter((b) => b.type === "codeBlock");
-  const hasMermaid = codeBlocks.some(isMermaid);
+  const hasMermaid = !streaming && codeBlocks.some(isMermaid);
   if (hasMermaid) await initMermaid();
 
   const replacements = new Array(codeBlocks.length);
   codeBlocks.forEach((block, i) => {
-    if (hasMermaid && isMermaid(block)) {
-      replacements[i] = mermaid.renderBlock?.(block, () => "") ?? "";
+    if (isMermaid(block)) {
+      replacements[i] = streaming
+        ? mermaidPlaceholder(codeText(block))
+        : (mermaid.renderBlock?.(block, () => "") ?? "");
       return;
     }
     replacements[i] = highlightCode(codeText(block), block.props?.language ?? block.props?.info ?? "");
@@ -123,25 +136,74 @@ async function renderMarkdown(md) {
   return html;
 }
 
-function reportHeight() {
+// Reader theming: override the prose-level CSS variables (declared on :root in
+// markdown.css) so the same bundle can render dark / light / sepia. Code blocks
+// keep their dark card (we deliberately DON'T touch --code-bg / hljs colours) —
+// a dark code card on a light page is intentional and dodges contrast problems.
+const THEME_VARS = {
+  dark: null,
+  light: { "--txt": "#1c1c22", "--txt-muted": "#5b5b66", "--accent": "#5a51d6", "--hairline": "rgba(0,0,0,0.14)", bg: "#ffffff" },
+  sepia: { "--txt": "#43382a", "--txt-muted": "#7a6a55", "--accent": "#9a5a2a", "--hairline": "rgba(0,0,0,0.16)", bg: "#f4ecd8" },
+};
+const THEME_KEYS = ["--txt", "--txt-muted", "--accent", "--hairline"];
+function applyTheme(name) {
+  const de = document.documentElement;
+  const t = THEME_VARS[name] || null;
+  THEME_KEYS.forEach((k) => de.style.removeProperty(k));
+  if (t) for (const k of THEME_KEYS) if (t[k]) de.style.setProperty(k, t[k]);
+  document.body.style.background = t && t.bg ? t.bg : "";
+}
+
+// fontScale zooms the whole document uniformly (px + em both scale); reader mode
+// adds page padding so the full-screen scroll view isn't edge-to-edge.
+function applyStyle(opts = {}) {
+  const { fontScale = 1, theme = "dark", reader = false } = opts || {};
+  applyTheme(theme);
+  document.body.style.zoom = fontScale && fontScale !== 1 ? String(fontScale) : "";
+  document.body.style.padding = reader ? "18px 18px 80px" : "";
+}
+
+// Heading elements from the last render, in document order, so the reader's TOC
+// can scroll to one by index without round-tripping coordinates.
+let lastHeadingEls = [];
+function reportLayout() {
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
       const h = Math.ceil(document.body.getBoundingClientRect().height);
       window.webkit?.messageHandlers?.cave?.postMessage({ type: "height", height: h });
+      const root = document.getElementById("root");
+      lastHeadingEls = root ? [...root.querySelectorAll("h1,h2,h3,h4,h5,h6")] : [];
+      const headings = lastHeadingEls
+        .map((el, i) => ({ index: i, level: Number(el.tagName[1]), text: (el.textContent || "").trim() }))
+        .filter((x) => x.text);
+      window.webkit?.messageHandlers?.cave?.postMessage({ type: "headings", headings });
     });
   });
 }
 
-window.caveRender = async (md) => {
+window.caveRender = async (md, opts = {}) => {
   const root = document.getElementById("root");
   if (!root) return;
+  applyStyle(opts);
   try {
-    root.innerHTML = await renderMarkdown(md);
+    root.innerHTML = await renderMarkdown(md, { streaming: !!opts.streaming });
   } catch (err) {
     root.textContent = String(md || "");
     window.webkit?.messageHandlers?.cave?.postMessage({ type: "error", message: String(err) });
   }
-  reportHeight();
+  reportLayout();
+};
+
+// Re-style without re-rendering markdown — used when the reader's font size or
+// theme changes, so the scroll position survives (innerHTML is untouched).
+window.caveStyle = (opts = {}) => {
+  applyStyle(opts);
+  reportLayout();
+};
+
+// Reader TOC: scroll the (internally-scrolling) reader WebView to a heading.
+window.caveScrollToHeading = (i) => {
+  lastHeadingEls[i]?.scrollIntoView({ behavior: "smooth", block: "start" });
 };
 
 document.addEventListener("click", (e) => {
@@ -194,10 +256,14 @@ document.addEventListener("click", (e) => {
     hit.tagName?.toLowerCase() === "svg" ? (hit.closest(MERMAID_SEL) || hit) : hit;
   const tag = target.tagName?.toLowerCase();
   const kind = tag === "table" ? "table" : tag === "img" ? "image" : "diagram";
+  // For an <img>, also pass its src so native can decode it into a UIImage and
+  // present the smooth native zoom (pinch/pan/double-tap) instead of a WebView.
+  const src = kind === "image" ? (target.getAttribute("src") || "") : "";
   window.webkit?.messageHandlers?.cave?.postMessage({
     type: "enlarge",
     kind,
     html: target.outerHTML,
+    src,
   });
 });
 

--- a/scripts/ios-message-reader.test.mjs
+++ b/scripts/ios-message-reader.test.mjs
@@ -54,14 +54,20 @@ assert.match(
 
 assert.match(
   chatView,
-  /struct ResponseReaderView: View[\s\S]*MarkdownWebView\(markdown: item\.markdown, height: \$mdHeight\)/,
+  /struct ResponseReaderView: View[\s\S]*MarkdownWebView\(markdown: item\.markdown, height: \$mdHeight,[\s\S]*scrollable: true/,
   "ResponseReaderView should render the full response through the markdown renderer",
 );
 
 assert.match(
   chatView,
-  /ToolbarItem\(placement: \.confirmationAction\) \{[\s\S]*Button\("Done"\)/,
+  /struct ResponseReaderView: View[\s\S]*Button\("Done"\) \{ dismiss\(\) \}/,
   "ResponseReaderView should provide a Done toolbar action",
+);
+
+assert.match(
+  chatView,
+  /struct ResponseReaderView: View[\s\S]*fontScale[\s\S]*Section\("Theme"\)/,
+  "ResponseReaderView should offer reader font-size and theme controls",
 );
 
 assert.match(


### PR DESCRIPTION
Extends the native iOS chat markdown rendering pipeline. No web/desktop changes.

## What
1. **Live streaming markdown** — assistant replies render markdown *while streaming* (previously plain Text until settled). Renders are throttled (~150ms coalescing) and Mermaid is deferred to settle via a lightweight placeholder so diagrams don't re-render on every token.
2. **Markdown in user messages** — a user message renders markdown when it actually contains some (`MarkdownDetect` heuristic: fenced code, tables, lists, headings, links, bold, inline code). Plain chatter stays fast native `Text`.
3. **Native pinch-zoom for inline images** — inline markdown images now open the native `UIImage` zoom (pinch/pan/double-tap), matching attachments. `entry.mjs` passes the img `src`; native decodes data-URL or fetches http(s), falling back to the HTML zoom if undecodable.
4. **Reader mode upgrades** (`ResponseReaderView`) — font-size (A−/A+, persisted), dark/light/sepia theme, and a table-of-contents jump menu. The reader WebView now scrolls internally so TOC navigation and style changes preserve scroll position.

## How
- `MarkdownWebView` gains `streaming` / `scrollable` / `fontScale` / `theme` / `scrollCommand` / `onHeadings` params (defaults preserve current bubble behavior). A coalescing render loop in the Coordinator throttles streaming renders; pure font/theme changes use `caveStyle` (no DOM rebuild → scroll preserved).
- `entry.mjs`: `caveRender(md, opts)` + new `caveStyle` / `caveScrollToHeading`; theme via CSS-variable overrides on `:root` (code blocks stay dark by design); headings reported for the TOC.
- The gitignored `markdown.html` bundle is regenerated by the existing `project.yml` preBuildScript.

## Verification
- Local `xcodebuild` simulator build (iOS not in CI — verified locally).
- Manual sim: stream a reply with headings/table/code/image/mermaid; confirm live formatting, mermaid placeholder→real on settle, native image zoom, reader font/theme/TOC; user message with a code fence renders markdown, "ok" stays plain text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)