### PR TITLE
feat(board): bulk-select cards — move/assign/delete many at once

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -131,6 +131,7 @@ export const SUITES = {
     "src/components/board-grouping.test.ts",
     "src/components/board-project-picker.test.ts",
     "src/components/board-ux-polish.test.ts",
+    "src/components/board-bulk-select.test.ts",
     "src/components/board-link-browser.test.ts",
     "src/components/calendar-view-polish.test.ts",
     "src/lib/calendar-layout.test.ts",

--- a/src/components/board-bulk-select.test.ts
+++ b/src/components/board-bulk-select.test.ts
@@ -1,0 +1,32 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const view = readFileSync(new URL("./board-view.tsx", import.meta.url), "utf8");
+const kanban = readFileSync(new URL("./board-kanban.tsx", import.meta.url), "utf8");
+const table = readFileSync(new URL("./board-table.tsx", import.meta.url), "utf8");
+
+// board-view drives selection with the shared hook + toolbar.
+assert.match(view, /useMultiSelect\(filtered, \(c\) => c\.id\)/, "board uses the shared useMultiSelect over the filtered cards");
+assert.match(view, /import \{ SelectionToolbar \}/, "board imports the shared SelectionToolbar");
+assert.match(view, /<SelectionToolbar/, "select mode renders the shared SelectionToolbar");
+// The three bulk actions exist.
+assert.match(view, /const bulkMove = async \(status: CardStatus\)/, "bulk move-to-status is wired");
+assert.match(view, /const bulkAssign = async \(familiarId: string\)/, "bulk assign-familiar is wired");
+assert.match(view, /const bulkDelete = async/, "bulk delete is wired");
+// Select mode is threaded into BOTH the kanban and the table.
+assert.match(view, /<BoardKanban[\s\S]*?selectMode=\{cardSelect\.selectMode\}/, "kanban receives select mode");
+assert.match(view, /<BoardTable[\s\S]*?selectMode=\{cardSelect\.selectMode\}/, "table receives select mode");
+// The Select entry button only shows for kanban/table, desktop, with cards.
+assert.match(view, /viewMode === "kanban" \|\| viewMode === "table"[\s\S]*?cardSelect\.setSelectMode\(true\)/, "a Select button enters select mode for kanban/table");
+
+// Kanban cards become checkboxes and stop being draggable in select mode.
+assert.match(kanban, /<li draggable=\{!selectMode\}/, "kanban cards aren't draggable while selecting");
+assert.match(kanban, /role=\{selectMode \? "checkbox" : "button"\}/, "kanban cards flip to checkbox role in select mode");
+assert.match(kanban, /aria-checked=\{selectMode \? isSelected : undefined\}/, "kanban checkboxes expose aria-checked");
+
+// Table rows toggle selection instead of opening in select mode.
+assert.match(table, /onClick=\{\(\) => \(selectMode \? onToggleSelect\?\.\(card\.id\) : onSelect\(card\.id\)\)\}/, "table rows toggle selection in select mode");
+assert.match(table, /aria-checked=\{selectMode \? rowChecked : undefined\}/, "table checkbox rows expose aria-checked");
+
+console.log("board-bulk-select.test.ts: ok");

--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -38,6 +38,10 @@ type Props = {
   selectedCardId: string | null;
   onSelect: (id: string) => void;
   onMoveStatus: (id: string, status: CardStatus) => void;
+  /** Bulk-select mode: cards become checkboxes instead of openers. */
+  selectMode?: boolean;
+  isSelected?: (id: string) => boolean;
+  onToggleSelect?: (id: string) => void;
   onNewCard: (status: CardStatus) => void;
   onJumpToSession?: (sessionId: string, familiarId: string | null) => void;
   onOpenTaskChat?: (id: string) => Promise<void>;
@@ -74,7 +78,7 @@ function getGroups(cards: Card[], by: GroupBy, familiars: Familiar[], projects: 
   return entries;
 }
 
-export function BoardKanban({ cards, familiars, projects, sessions, groupBy, selectedCardId, onSelect, onMoveStatus, onNewCard, onJumpToSession, onOpenTaskChat, chatLinkingId }: Props) {
+export function BoardKanban({ cards, familiars, projects, sessions, groupBy, selectedCardId, onSelect, onMoveStatus, selectMode = false, isSelected, onToggleSelect, onNewCard, onJumpToSession, onOpenTaskChat, chatLinkingId }: Props) {
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<CardStatus | null>(null);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
@@ -459,9 +463,10 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
                           {rows.map((card) => (
                             <KanbanCard key={card.id} card={card} familiarById={familiarById} sessionById={sessionById} todayMs={todayMs}
                               isDragging={draggingId === card.id || touchDragId === card.id}
-                              isSelected={selectedCardId === card.id}
+                              isSelected={selectMode ? !!isSelected?.(card.id) : selectedCardId === card.id}
                               isGrabbed={grabbedCardId === card.id || touchDragId === card.id}
-                              onSelect={() => onSelect(card.id)}
+                              selectMode={selectMode}
+                              onSelect={() => (selectMode ? onToggleSelect?.(card.id) : onSelect(card.id))}
                               onDragStart={(e) => handleDragStart(e, card.id)}
                               onDragEnd={handleDragEnd}
                               onPointerDownTouch={(e) => handleCardPointerDown(e, card)}
@@ -492,9 +497,9 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
   );
 }
 
-function KanbanCard({ card, familiarById, sessionById, todayMs, isDragging, isSelected, isGrabbed, onSelect, onDragStart, onDragEnd, onPointerDownTouch, onJumpToSession, onOpenTaskChat, chatLinking = false }: {
+function KanbanCard({ card, familiarById, sessionById, todayMs, isDragging, isSelected, isGrabbed, selectMode = false, onSelect, onDragStart, onDragEnd, onPointerDownTouch, onJumpToSession, onOpenTaskChat, chatLinking = false }: {
   card: Card; familiarById: Map<string, Familiar>; sessionById: Map<string, SessionRow>; todayMs: number | null;
-  isDragging: boolean; isSelected: boolean; isGrabbed: boolean;
+  isDragging: boolean; isSelected: boolean; isGrabbed: boolean; selectMode?: boolean;
   onSelect: () => void; onDragStart: (e: React.DragEvent) => void; onDragEnd: () => void;
   onPointerDownTouch?: (e: React.PointerEvent) => void;
   onJumpToSession?: (sessionId: string, familiarId: string | null) => void;
@@ -515,16 +520,20 @@ function KanbanCard({ card, familiarById, sessionById, todayMs, isDragging, isSe
   const hasChips = !!schedule || !!card.cwd || card.links.length > 0 || card.labels.length > 0 || !!session;
 
   return (
-    <li draggable
+    <li draggable={!selectMode}
       data-card-id={card.id}
-      role="button"
-      aria-label={`${card.title} — ${pri.label} priority, ${statusLabel}${isSelected ? ", selected" : ""}${isGrabbed ? ", grabbed" : ""}. Enter to open; Space to move.`}
-      aria-keyshortcuts="Enter Space"
-      onDragStart={(e) => { draggedRef.current = true; onDragStart(e); }}
+      role={selectMode ? "checkbox" : "button"}
+      aria-checked={selectMode ? isSelected : undefined}
+      aria-label={`${card.title} — ${pri.label} priority, ${statusLabel}${isSelected ? ", selected" : ""}${isGrabbed ? ", grabbed" : ""}.${selectMode ? " Space to toggle selection." : " Enter to open; Space to move."}`}
+      aria-keyshortcuts={selectMode ? undefined : "Enter Space"}
+      onDragStart={(e) => { if (selectMode) { e.preventDefault(); return; } draggedRef.current = true; onDragStart(e); }}
       onDragEnd={() => { setTimeout(() => { draggedRef.current = false; }, 0); onDragEnd(); }}
-      onPointerDown={onPointerDownTouch}
+      onPointerDown={selectMode ? undefined : onPointerDownTouch}
       onClick={() => { if (draggedRef.current) return; onSelect(); }}
-      onKeyDown={(e) => { if (e.key !== "Enter") return; e.preventDefault(); onSelect(); }}
+      onKeyDown={(e) => {
+        if (selectMode) { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelect(); } return; }
+        if (e.key !== "Enter") return; e.preventDefault(); onSelect();
+      }}
       tabIndex={0}
       className={`board-kanban-card board-kanban-card--priority-${card.priority}${
         isSelected ? " board-kanban-card--selected" : ""
@@ -532,6 +541,21 @@ function KanbanCard({ card, familiarById, sessionById, todayMs, isDragging, isSe
         isGrabbed ? " board-kanban-card--grabbed" : ""
       }`}
     >
+      {selectMode && (
+        <span
+          aria-hidden
+          className="board-kanban-card-check"
+          style={{
+            position: "absolute", top: 8, right: 8,
+            display: "flex", alignItems: "center", justifyContent: "center",
+            height: 18, width: 18, borderRadius: 5,
+            border: `1px solid ${isSelected ? "var(--accent-presence)" : "var(--border-strong)"}`,
+            background: isSelected ? "var(--accent-presence)" : "transparent",
+          }}
+        >
+          {isSelected && <Icon name="ph:check-bold" width={12} className="text-white" />}
+        </span>
+      )}
       <div className="board-kanban-card-top">
         <span className={`board-kanban-priority-pill board-kanban-priority-pill--${card.priority}`}>{pri.label}</span>
         <LifecycleBadge lifecycle={card.lifecycle} needsHuman={card.needsHuman} />

--- a/src/components/board-table.tsx
+++ b/src/components/board-table.tsx
@@ -102,10 +102,14 @@ type Props = {
   groupBy: GroupBy;
   selectedCardId: string | null;
   onSelect: (id: string) => void;
+  /** Bulk-select mode: clicking a row toggles its checkbox instead of opening. */
+  selectMode?: boolean;
+  isSelected?: (id: string) => boolean;
+  onToggleSelect?: (id: string) => void;
   onPatch: (id: string, patch: Partial<Card>) => void;
 };
 
-export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId, onSelect, onPatch }: Props) {
+export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId, onSelect, selectMode = false, isSelected, onToggleSelect, onPatch }: Props) {
   const [sortKey, setSortKey] = useState<SortKey>("updatedAt");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set(["done"]));
@@ -211,13 +215,33 @@ export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId
               </tr>
               {!collapsed.has(key) && gc.map((card) => {
                 const resolvedFamiliar = card.familiarId ? resolvedByIdMap.get(card.familiarId) ?? null : null;
+                const rowChecked = selectMode && !!isSelected?.(card.id);
                 return (
                   <tr key={card.id}
                     data-board-row="true"
                     data-card-id={card.id}
-                    className={selectedCardId === card.id ? "selected" : ""}
-                    onClick={() => onSelect(card.id)}>
-                    <td><span className="board-table-title" title={card.title}>{card.title}</span></td>
+                    role={selectMode ? "checkbox" : undefined}
+                    aria-checked={selectMode ? rowChecked : undefined}
+                    className={(selectMode ? rowChecked : selectedCardId === card.id) ? "selected" : ""}
+                    onClick={() => (selectMode ? onToggleSelect?.(card.id) : onSelect(card.id))}>
+                    <td>
+                      <span className="board-table-title-cell" style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                        {selectMode && (
+                          <span
+                            aria-hidden
+                            style={{
+                              display: "inline-flex", alignItems: "center", justifyContent: "center",
+                              height: 16, width: 16, flexShrink: 0, borderRadius: 4,
+                              border: `1px solid ${rowChecked ? "var(--accent-presence)" : "var(--border-strong)"}`,
+                              background: rowChecked ? "var(--accent-presence)" : "transparent",
+                            }}
+                          >
+                            {rowChecked && <Icon name="ph:check-bold" width={11} className="text-white" />}
+                          </span>
+                        )}
+                        <span className="board-table-title" title={card.title}>{card.title}</span>
+                      </span>
+                    </td>
                     <td>
                       <span className="board-table-cell-status">
                         <span className={`board-table-status-dot board-table-status-dot--${card.status}`} aria-hidden />

--- a/src/components/board-ux-polish.test.ts
+++ b/src/components/board-ux-polish.test.ts
@@ -51,9 +51,9 @@ assert.match(
   /PRIORITIES\.find\(\(p\) => p\.id === card\.priority\) \?\? \{ id: card\.priority, label: card\.priority \}/,
   "Priority lookup must fall back instead of asserting",
 );
-assert.match(kanban, /role="button"/, "Kanban cards must expose a button role");
-assert.match(kanban, /aria-label=\{`\$\{card\.title\}[\s\S]*?priority[\s\S]*?Enter to open; Space to move\.`\}/, "Cards need a descriptive aria-label with the move/open shortcuts");
-assert.match(kanban, /aria-keyshortcuts="Enter Space"/, "Cards must declare their key shortcuts");
+assert.match(kanban, /role=\{selectMode \? "checkbox" : "button"\}/, "Kanban cards expose a button role (checkbox in select mode)");
+assert.match(kanban, /aria-label=\{`\$\{card\.title\}[\s\S]*?priority[\s\S]*?Enter to open; Space to move\./, "Cards need a descriptive aria-label with the move/open shortcuts");
+assert.match(kanban, /aria-keyshortcuts=\{selectMode \? undefined : "Enter Space"\}/, "Cards declare their key shortcuts outside select mode");
 assert.doesNotMatch(kanban, /aria-selected=\{isSelected\}/, "Invalid aria-selected on the card must be removed");
 assert.doesNotMatch(kanban, /aria-grabbed=\{isGrabbed\}/, "Deprecated aria-grabbed must be removed (state is in the label + live announce)");
 // Keyboard DnD contract preserved.

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -7,8 +7,10 @@ import { DEMO_BOARD_CARDS } from "@/lib/demo-seed";
 import { DEMO_MODE_EVENT, isDemoModeEnabled } from "@/lib/demo-mode";
 import { NewCardModal, type NewCardDraft } from "@/components/new-card-modal";
 import { Icon } from "@/lib/icon";
-import { type Card, type CardStatus } from "@/lib/cave-board-types";
+import { type Card, type CardStatus, STATUSES } from "@/lib/cave-board-types";
 import { cardMatchesBoardSearch } from "@/lib/board-search";
+import { useMultiSelect } from "@/lib/use-multi-select";
+import { SelectionToolbar } from "@/components/ui/selection-toolbar";
 import { familiarInScope } from "@/lib/familiar-multiselect";
 import { BoardKanban } from "@/components/board-kanban";
 import { BoardGantt } from "@/components/board-gantt";
@@ -236,6 +238,61 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     const res = await fetch(`/api/board/${id}`, { method: "DELETE" });
     const json = await res.json();
     if (json.ok) { if (selectedCardId === id) setSelectedCardId(null); await load(); }
+  };
+
+  // ── Bulk select (kanban + table) ────────────────────────────────────────────
+  const cardSelect = useMultiSelect(filtered, (c) => c.id);
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const selectedCards = () => cardSelect.selectedFrom(filtered);
+
+  const bulkMove = async (status: CardStatus) => {
+    const ids = selectedCards().map((c) => c.id);
+    if (ids.length === 0) { cardSelect.exit(); return; }
+    setBulkBusy(true);
+    await Promise.all(ids.map((id) => moveCardToStatus(id, status)));
+    setBulkBusy(false);
+    cardSelect.exit();
+  };
+
+  const bulkAssign = async (familiarId: string) => {
+    const ids = selectedCards().map((c) => c.id);
+    if (ids.length === 0) { cardSelect.exit(); return; }
+    setBulkBusy(true);
+    await Promise.all(ids.map((id) => patchCard(id, { familiarId })));
+    setBulkBusy(false);
+    cardSelect.exit();
+  };
+
+  const bulkDelete = async () => {
+    const ids = selectedCards().map((c) => c.id);
+    if (ids.length === 0) { cardSelect.exit(); return; }
+    if (!window.confirm(`Delete ${ids.length} task${ids.length === 1 ? "" : "s"}? This can't be undone.`)) return;
+    setBulkBusy(true);
+    const idSet = new Set(ids);
+    setCards((prev) => prev.filter((c) => !idSet.has(c.id)));
+    if (selectedCardId && idSet.has(selectedCardId)) setSelectedCardId(null);
+    const results = await Promise.all(
+      ids.map(async (id) => {
+        try {
+          const res = await fetch(`/api/board/${id}`, { method: "DELETE" });
+          return (await res.json()).ok as boolean;
+        } catch { return false; }
+      }),
+    );
+    setBulkBusy(false);
+    cardSelect.exit();
+    const failed = results.filter((ok) => !ok).length;
+    if (failed > 0) {
+      setActionError(`Couldn't delete ${failed} of ${ids.length} task${ids.length === 1 ? "" : "s"} — reverted those.`);
+      await load();
+    } else {
+      setActionError(null);
+    }
+  };
+
+  const STATUS_LABELS: Record<CardStatus, string> = {
+    backlog: "Backlog", inbox: "Inbox", running: "Running",
+    review: "Review", blocked: "Blocked", done: "Done",
   };
 
   const handleClearDone = async () => {
@@ -475,6 +532,18 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
             </button>
           </div>
 
+          {!isMobile && (viewMode === "kanban" || viewMode === "table") && filtered.length > 0 && !cardSelect.selectMode && (
+            <button
+              type="button"
+              className="board-toolbar-btn"
+              onClick={() => cardSelect.setSelectMode(true)}
+              title="Select multiple tasks"
+            >
+              <Icon name="ph:check-square" width={13} />
+              Select
+            </button>
+          )}
+
           {clearConfirm ? (
             <div className="board-clear-confirm" role="group" aria-label="Confirm clear done tasks">
               <button
@@ -587,6 +656,48 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
 
       {/* Content */}
       <div style={{ flex: 1, minHeight: 0, overflow: "hidden", display: "flex", flexDirection: "column" }}>
+        {cardSelect.selectMode && (
+          <div className="px-5 pt-3">
+            <SelectionToolbar
+              allSelected={cardSelect.allSelected(filtered)}
+              count={cardSelect.selectedCount}
+              onToggleSelectAll={() => cardSelect.toggleSelectAll(filtered)}
+              onCancel={cardSelect.exit}
+            >
+              <label className="sr-only" htmlFor="board-bulk-move">Move selected tasks to status</label>
+              <select
+                id="board-bulk-move"
+                disabled={bulkBusy || cardSelect.selectedCount === 0}
+                value=""
+                onChange={(e) => { if (e.target.value) void bulkMove(e.target.value as CardStatus); }}
+                className="focus-ring rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-1.5 py-0.5 text-[11px] text-[var(--text-secondary)] disabled:opacity-50"
+              >
+                <option value="">Move to…</option>
+                {STATUSES.map((s) => <option key={s} value={s}>{STATUS_LABELS[s]}</option>)}
+              </select>
+              <label className="sr-only" htmlFor="board-bulk-assign">Assign selected tasks to a familiar</label>
+              <select
+                id="board-bulk-assign"
+                disabled={bulkBusy || cardSelect.selectedCount === 0}
+                value=""
+                onChange={(e) => { if (e.target.value) void bulkAssign(e.target.value); }}
+                className="focus-ring rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-1.5 py-0.5 text-[11px] text-[var(--text-secondary)] disabled:opacity-50"
+              >
+                <option value="">Assign to…</option>
+                {familiars.map((f) => <option key={f.id} value={f.id}>{f.display_name}</option>)}
+              </select>
+              <button
+                type="button"
+                disabled={bulkBusy || cardSelect.selectedCount === 0}
+                onClick={() => void bulkDelete()}
+                className="focus-ring inline-flex items-center gap-1 rounded border border-[var(--color-danger)]/50 bg-[var(--color-danger)]/10 px-1.5 py-0.5 text-[11px] text-[var(--color-danger)] hover:bg-[var(--color-danger)]/15 disabled:opacity-50"
+              >
+                <Icon name="ph:trash-bold" width={11} aria-hidden />
+                {bulkBusy ? "Working…" : `Delete${cardSelect.selectedCount ? ` ${cardSelect.selectedCount}` : ""}`}
+              </button>
+            </SelectionToolbar>
+          </div>
+        )}
         {!hasLoaded && !error ? (
           <div className="flex h-full items-center justify-center p-6" role="status" aria-label="Loading tasks">
             <Icon name="ph:circle-notch-bold" width={20} className="animate-spin text-[var(--text-muted)]" aria-hidden />
@@ -656,6 +767,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
           <BoardKanban cards={filtered} familiars={familiars} projects={projects} sessions={sessions}
             groupBy={effectiveGroupBy} selectedCardId={selectedCardId}
             onSelect={setSelectedCardId} onMoveStatus={moveCardToStatus}
+            selectMode={cardSelect.selectMode} isSelected={cardSelect.isSelected} onToggleSelect={cardSelect.toggle}
             onNewCard={(status) => { setModalDefaultStatus(status); setModalOpen(true); }}
             onJumpToSession={onJumpToSession}
             onOpenTaskChat={onOpenTaskChat}
@@ -670,6 +782,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
           <BoardTable cards={filtered} familiars={familiars} projects={projects}
             groupBy={effectiveGroupBy} selectedCardId={selectedCardId}
             onSelect={setSelectedCardId}
+            selectMode={cardSelect.selectMode} isSelected={cardSelect.isSelected} onToggleSelect={cardSelect.toggle}
             onPatch={patchCard} />
         )}
       </div>


### PR DESCRIPTION
## What

The second half of the bulk-actions effort (after Reminders #1656). Reuses the **shared** `useMultiSelect` hook + `SelectionToolbar` and applies them to the **Board**, across both the **kanban** and **table** views.

- A **Select** button (kanban/table, desktop, when there are cards) enters select mode.
- Toolbar: `Select all / Clear · N selected`, a **Move to status** picker, an **Assign to familiar** picker, **Delete N**, and **Cancel**.
- **Kanban** cards flip from draggable buttons to **checkboxes** (`role="checkbox"` + `aria-checked`, drag disabled, a check indicator top-right); clicking toggles selection instead of opening the inspector.
- **Table** rows toggle selection (`role="checkbox"` + `aria-checked`) with a checkbox in the title cell — no extra column, so the `COLS`/`colSpan` layout is untouched.
- Bulk **delete** is optimistic with a server reconcile on partial failure, mirroring the existing "Clear done" flow.

## Tests

- Updated `board-ux-polish.test.ts` — the kanban card's `role` / `aria-keyshortcuts` are now conditional on select mode.
- Added `board-bulk-select.test.ts` (registered in `scripts/run-tests.mjs`).
- Typecheck clean.

## Verification

Built + run against a server: **Select all → every kanban card and every table row checked**, toolbar shows Move / Assign / Delete. Screenshots for both views captured during review.

Completes the two-PR bulk-actions arc; `useMultiSelect` + `SelectionToolbar` are now shared across Projects chats (#1602 pattern), Reminders, and the Board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)