### PR TITLE
feat(ios): thread-list swipe parity, delete confirmation, return-to-send

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -269,6 +269,17 @@ struct ChatView: View {
                     .padding(.leading, 14)
                     .padding(.vertical, 7)
                     .focused($composerFocused)
+                    // Hardware-keyboard ergonomics (iPad / Mac over Tailscale):
+                    // plain Return sends, Shift+Return inserts a newline. The
+                    // software keyboard's return still inserts a newline as usual
+                    // (a vertical-axis field doesn't fire onSubmit), so multi-line
+                    // composing on-device is untouched.
+                    .onKeyPress(keys: [.return]) { press in
+                        guard !press.modifiers.contains(.shift) else { return .ignored }
+                        guard canSend else { return .ignored }
+                        send()
+                        return .handled
+                    }
 
                 Group {
                     if dictation.isRecording {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -17,6 +17,8 @@ struct ChatsHomeView: View {
     @State private var query = ""
     @State private var path: [ChatRoute] = []
     @State private var renamingThread: ChatThread?
+    /// A group thread awaiting delete confirmation (swipe or context menu).
+    @State private var pendingDelete: ChatThread?
 
     var body: some View {
         NavigationStack(path: $path) {
@@ -120,23 +122,42 @@ struct ChatsHomeView: View {
                         }
                         .buttonStyle(.plain)
                         .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                            Button(role: .destructive) { pendingDelete = thread } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                        .swipeActions(edge: .leading) {
+                            Button { renamingThread = thread } label: {
+                                Label("Rename", systemImage: "pencil")
+                            }
+                            .tint(.accentColor)
+                        }
                         .contextMenu {
                             Button { renamingThread = thread } label: {
                                 Label("Rename", systemImage: "pencil")
                             }
-                            Button(role: .destructive) { app.deleteThread(thread) } label: {
+                            Button(role: .destructive) { pendingDelete = thread } label: {
                                 Label("Delete", systemImage: "trash")
                             }
                         }
-                    }
-                    .onDelete { offsets in
-                        offsets.map { filteredGroups[$0] }.forEach(app.deleteThread)
                     }
                 }
             }
         }
         .listStyle(.plain)
         .threadRenameAlert($renamingThread) { thread, name in app.renameThread(thread, to: name) }
+        .confirmationDialog("Delete this group chat?",
+                            isPresented: deleteDialogBinding,
+                            titleVisibility: .visible,
+                            presenting: pendingDelete) { thread in
+            Button("Delete", role: .destructive) { app.deleteThread(thread) }
+            Button("Cancel", role: .cancel) {}
+        } message: { thread in Text(thread.title) }
+    }
+
+    private var deleteDialogBinding: Binding<Bool> {
+        Binding(get: { pendingDelete != nil }, set: { if !$0 { pendingDelete = nil } })
     }
 
     /// Familiars matching the search query (name or role). Empty query → all.

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -10,6 +10,8 @@ struct FamiliarThreadsView: View {
     let familiar: Familiar
     @Binding var path: [ChatRoute]
     @State private var renamingThread: ChatThread?
+    /// An on-device thread awaiting delete confirmation (swipe or context menu).
+    @State private var pendingDelete: ChatThread?
 
     /// One row in the list: an on-device thread or a server-only session.
     private enum Entry: Identifiable {
@@ -73,21 +75,49 @@ struct FamiliarThreadsView: View {
                 Button { open(entry) } label: { row(entry) }
                     .buttonStyle(.plain)
                     .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                    // Only on-device threads can be renamed/deleted from here; a
+                    // server-only session lives on the desktop, so its rows offer
+                    // no swipe actions.
+                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        if case .local(let thread) = entry {
+                            Button(role: .destructive) { pendingDelete = thread } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                    }
+                    .swipeActions(edge: .leading) {
+                        if case .local(let thread) = entry {
+                            Button { renamingThread = thread } label: {
+                                Label("Rename", systemImage: "pencil")
+                            }
+                            .tint(.accentColor)
+                        }
+                    }
                     .contextMenu {
                         if case .local(let thread) = entry {
                             Button { renamingThread = thread } label: {
                                 Label("Rename", systemImage: "pencil")
                             }
-                            Button(role: .destructive) { app.deleteThread(thread) } label: {
+                            Button(role: .destructive) { pendingDelete = thread } label: {
                                 Label("Delete", systemImage: "trash")
                             }
                         }
                     }
             }
-            .onDelete(perform: delete)
         }
         .listStyle(.plain)
         .threadRenameAlert($renamingThread) { thread, name in app.renameThread(thread, to: name) }
+        .confirmationDialog("Delete this chat?",
+                            isPresented: deleteDialogBinding,
+                            titleVisibility: .visible,
+                            presenting: pendingDelete) { thread in
+            Button("Delete", role: .destructive) { app.deleteThread(thread) }
+            Button("Cancel", role: .cancel) {}
+        } message: { thread in Text(thread.title) }
+    }
+
+    private var deleteDialogBinding: Binding<Bool> {
+        Binding(get: { pendingDelete != nil }, set: { if !$0 { pendingDelete = nil } })
     }
 
     @ViewBuilder
@@ -109,14 +139,6 @@ struct FamiliarThreadsView: View {
             // then open it like any other.
             let thread = app.openServerSession(session, familiarId: familiar.id)
             path.append(.thread(thread))
-        }
-    }
-
-    /// Swipe-to-delete removes on-device threads; a server-only session can't be
-    /// deleted from here (it lives on the desktop), so those rows are skipped.
-    private func delete(_ offsets: IndexSet) {
-        for index in offsets {
-            if case .local(let thread) = entries[index] { app.deleteThread(thread) }
         }
     }
 


### PR DESCRIPTION
## What

Three small, self-contained ergonomics fixes on the iOS **Chats** surface.

### 1. Swipe actions on the thread lists (parity with Read/Tasks)
`ChatsHomeView` (group chats) and `FamiliarThreadsView` (a familiar's threads) previously had only a bare `.onDelete` — delete-only, immediate, no rename. They now use explicit `.swipeActions` like Reading and Tasks:
- **Trailing → Delete** (red, `allowsFullSwipe: false`)
- **Leading → Rename** (accent) — surfaces rename without needing a long-press

Server-only sessions ("Synced from another device") intentionally expose no swipe actions, since they live on the desktop.

### 2. Delete confirmation
Deleting a conversation now routes through a `confirmationDialog` (mirrors the existing Tasks delete pattern) instead of removing a whole thread on a single swipe/tap. Applies to both the swipe action and the context-menu Delete.

### 3. Return-to-send for hardware keyboards
In the chat composer, a hardware keyboard's **plain Return sends**, **Shift+Return inserts a newline** (the Slack/iMessage convention) — useful on iPad/Mac over Tailscale. The **software keyboard's return still inserts a newline** as before: a vertical-axis `TextField` doesn't fire `onSubmit`, so I used `.onKeyPress` rather than `submitLabel(.send)` to avoid mislabeling the on-screen return key and breaking on-device multi-line composing.

## Files
- `ChatView.swift` — `.onKeyPress(keys: [.return])` on the composer field
- `ChatsHomeView.swift` — swipe actions + `pendingDelete` confirmation dialog
- `FamiliarThreadsView.swift` — swipe actions + confirmation dialog; removed the now-unused `delete(_:)` helper

## Verification
- `xcodebuild` for the iPhone 16 Pro simulator → **BUILD SUCCEEDED**.
- Installed and launched; Chats surface renders correctly.
- The swipe-reveal and dialog themselves can't be triggered via `simctl` (no gesture command), but the logic is a direct copy of the already-shipped Reading/Tasks swipe + Tasks confirmation patterns.

> Note: iOS Swift isn't compiled by the required CI checks, so this was verified locally via `xcodebuild` + simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)