### PR TITLE
feat(ios): scope chat task search to the chat's familiar (or unassigned)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/LinkedTasksSheet.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/LinkedTasksSheet.swift
@@ -13,9 +13,15 @@ struct LinkedTasksSheet: View {
 
     private var assignable: [BoardCard] {
         let q = query.trimmingCharacters(in: .whitespaces).lowercased()
+        // Scope to this chat: only tasks owned by one of the chat's familiar(s)
+        // or tasks with no assigned familiar — never another familiar's tasks.
+        let chatFamiliars = Set(thread.familiarIds)
         return app.tasks.filter { card in
-            !linked.contains(where: { $0.id == card.id })
-                && (q.isEmpty || card.title.lowercased().contains(q))
+            guard !linked.contains(where: { $0.id == card.id }) else { return false }
+            let owner = card.familiarId
+            let belongsHere = owner == nil || owner!.isEmpty || chatFamiliars.contains(owner!)
+            guard belongsHere else { return false }
+            return q.isEmpty || card.title.lowercased().contains(q)
         }
     }
 

--- a/scripts/ios-task-search-familiar-scope.test.mjs
+++ b/scripts/ios-task-search-familiar-scope.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (rel) => readFile(new URL(`../${rel}`, import.meta.url), "utf8");
+const iosRoot = "apps/ios/CovenCave/CovenCave";
+
+const sheet = await read(`${iosRoot}/Views/LinkedTasksSheet.swift`);
+
+// When searching tasks to assign from within a chat, the list is scoped to the
+// chat's familiar(s) or unassigned tasks — another familiar's tasks never show.
+assert.match(
+  sheet,
+  /let chatFamiliars = Set\(thread\.familiarIds\)/,
+  "assignable should derive the chat's familiar set from the thread",
+);
+assert.match(
+  sheet,
+  /let owner = card\.familiarId/,
+  "assignable should read each card's owning familiar",
+);
+assert.match(
+  sheet,
+  /let belongsHere = owner == nil \|\| owner!\.isEmpty \|\| chatFamiliars\.contains\(owner!\)/,
+  "a task is assignable only when unassigned or owned by one of the chat's familiars",
+);
+assert.match(
+  sheet,
+  /guard belongsHere else \{ return false \}/,
+  "tasks belonging to a different familiar are filtered out before the text match",
+);
+// The text-search match still applies on top of the familiar scope.
+assert.match(
+  sheet,
+  /return q\.isEmpty \|\| card\.title\.lowercased\(\)\.contains\(q\)/,
+  "the search query still filters within the familiar-scoped set",
+);
+
+console.log("ios-task-search-familiar-scope.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -489,6 +489,7 @@ export const SUITES = {
     "scripts/ios-task-notes-reader.test.mjs",
     "scripts/ios-task-notes-edit.test.mjs",
     "scripts/ios-task-actions.test.mjs",
+    "scripts/ios-task-search-familiar-scope.test.mjs",
     "scripts/ios-thread-rename.test.mjs",
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/mobile-tailscale.test.mjs",


### PR DESCRIPTION
## What

In iOS chat, the **"Assign a task"** search (`LinkedTasksSheet`) listed **every** task on the board. Per request, it now only shows tasks that belong to **this chat's familiar(s)** or tasks with **no assigned familiar** — never another familiar's tasks.

## How

`assignable` now derives the chat's familiar set from `thread.familiarIds` and keeps a card only when its `familiarId` is `nil`/empty or is one of those familiars. The text query still filters within that scoped set. Works for both 1:1 and group chats (group = union of the chat's familiars). The "Linked to this chat" section is unchanged.

## Verification

- `node scripts/run-tests.mjs mobile` → **27 files pass**, incl. the new `scripts/ios-task-search-familiar-scope.test.mjs`.
- `xcodebuild ... -destination 'generic/platform=iOS Simulator'` → **BUILD SUCCEEDED** (Swift isn't covered by CI, so this was built locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)