### PR TITLE
feat(ios): reorder familiars in the Chats tab

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -29,6 +29,9 @@ final class AppModel {
 
     var familiars: [Familiar] = []
     var familiarsError: String?
+    /// User's preferred familiar order (ids), applied over the server's order
+    /// and persisted locally. Unknown/new familiars fall to the end.
+    var familiarOrder: [String] = []
 
     var threads: [ChatThread] = []
 
@@ -112,6 +115,7 @@ final class AppModel {
         connection = CaveConnection.load()
         loadThreads()
         loadCardLinks()
+        loadFamiliarOrder()
         if connection != nil { connectionState = .checking }
     }
 
@@ -369,11 +373,34 @@ final class AppModel {
     func loadFamiliars() async {
         guard let client else { return }
         do {
-            familiars = try await client.familiars()
+            familiars = applyFamiliarOrder(try await client.familiars())
             familiarsError = nil
         } catch {
             familiarsError = error.localizedDescription
         }
+    }
+
+    /// Drag-reorder familiars in the Chats tab; persists the new order.
+    func moveFamiliar(fromOffsets source: IndexSet, toOffset destination: Int) {
+        familiars.move(fromOffsets: source, toOffset: destination)
+        familiarOrder = familiars.map(\.id)
+        persistFamiliarOrder()
+    }
+
+    /// Sort a freshly-loaded familiar list by the saved order; ids not in the
+    /// saved order (new familiars) keep their server order at the end.
+    private func applyFamiliarOrder(_ loaded: [Familiar]) -> [Familiar] {
+        guard !familiarOrder.isEmpty else { return loaded }
+        let rank = Dictionary(uniqueKeysWithValues: familiarOrder.enumerated().map { ($1, $0) })
+        return loaded.enumerated().sorted { a, b in
+            let ra = rank[a.element.id], rb = rank[b.element.id]
+            switch (ra, rb) {
+            case let (.some(x), .some(y)): return x < y
+            case (.some, .none): return true
+            case (.none, .some): return false
+            case (.none, .none): return a.offset < b.offset   // stable
+            }
+        }.map(\.element)
     }
 
     // MARK: - Sessions (server-side, for per-familiar thread lists)
@@ -685,5 +712,28 @@ final class AppModel {
             return
         }
         cardThreadLinks = map
+    }
+
+    private var familiarOrderFileURL: URL {
+        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("cave-familiar-order.json")
+    }
+
+    private func persistFamiliarOrder() {
+        do {
+            let data = try JSONEncoder().encode(familiarOrder)
+            try data.write(to: familiarOrderFileURL, options: .atomic)
+        } catch {
+            // Non-fatal: best-effort persistence.
+        }
+    }
+
+    private func loadFamiliarOrder() {
+        guard let data = try? Data(contentsOf: familiarOrderFileURL),
+              let order = try? JSONDecoder().decode([String].self, from: data) else {
+            return
+        }
+        familiarOrder = order
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -19,6 +19,7 @@ struct ChatsHomeView: View {
     @State private var renamingThread: ChatThread?
     /// A group thread awaiting delete confirmation (swipe or context menu).
     @State private var pendingDelete: ChatThread?
+    @State private var editMode: EditMode = .inactive
 
     var body: some View {
         NavigationStack(path: $path) {
@@ -92,7 +93,12 @@ struct ChatsHomeView: View {
             Text("Chats")
                 .font(.largeTitle.weight(.bold))
             Spacer()
-            if !app.familiars.isEmpty {
+            if canReorder {
+                Button(editMode.isEditing ? "Done" : "Reorder") {
+                    withAnimation { editMode = editMode.isEditing ? .inactive : .active }
+                }
+                .font(.subheadline.weight(.medium))
+            } else if !app.familiars.isEmpty {
                 Text("^[\(app.familiars.count) familiar](inflect: true)")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
@@ -104,6 +110,12 @@ struct ChatsHomeView: View {
         .background(.bar)
     }
 
+    /// Reordering is only meaningful with ≥2 familiars and no active search
+    /// filter (drag indices must map to the full, unfiltered list).
+    private var canReorder: Bool {
+        app.familiars.count > 1 && query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     private var homeList: some View {
         List {
             Section(filteredFamiliars.isEmpty ? "" : "Familiars") {
@@ -112,6 +124,9 @@ struct ChatsHomeView: View {
                         FamiliarRow(familiar: familiar)
                     }
                     .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                }
+                .onMove { source, destination in
+                    app.moveFamiliar(fromOffsets: source, toOffset: destination)
                 }
             }
             if !filteredGroups.isEmpty {
@@ -146,6 +161,7 @@ struct ChatsHomeView: View {
             }
         }
         .listStyle(.plain)
+        .environment(\.editMode, $editMode)
         .threadRenameAlert($renamingThread) { thread, name in app.renameThread(thread, to: name) }
         .confirmationDialog("Delete this group chat?",
                             isPresented: deleteDialogBinding,
@@ -154,6 +170,11 @@ struct ChatsHomeView: View {
             Button("Delete", role: .destructive) { app.deleteThread(thread) }
             Button("Cancel", role: .cancel) {}
         } message: { thread in Text(thread.title) }
+        // A search filters the list, so indices stop matching the full familiar
+        // array — leave reorder mode if the user starts searching.
+        .onChange(of: query) { _, q in
+            if !q.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { editMode = .inactive }
+        }
     }
 
     private var deleteDialogBinding: Binding<Bool> {

--- a/scripts/ios-reorder-familiars.test.mjs
+++ b/scripts/ios-reorder-familiars.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (rel) => readFile(new URL(`../${rel}`, import.meta.url), "utf8");
+const iosRoot = "apps/ios/CovenCave/CovenCave";
+
+const model = await read(`${iosRoot}/State/AppModel.swift`);
+const home = await read(`${iosRoot}/Views/ChatsHomeView.swift`);
+
+// Persisted custom order, applied over the server's order.
+assert.match(model, /var familiarOrder: \[String\] = \[\]/, "AppModel should hold a familiarOrder");
+assert.match(model, /loadFamiliarOrder\(\)/, "init should load the saved familiar order");
+assert.match(
+  model,
+  /familiars = applyFamiliarOrder\(try await client\.familiars\(\)\)/,
+  "loadFamiliars should apply the saved order",
+);
+assert.match(
+  model,
+  /func moveFamiliar\(fromOffsets source: IndexSet, toOffset destination: Int\) \{[\s\S]*familiars\.move\(fromOffsets: source, toOffset: destination\)[\s\S]*familiarOrder = familiars\.map\(\\\.id\)[\s\S]*persistFamiliarOrder\(\)/,
+  "moveFamiliar should reorder, recompute, and persist the order",
+);
+assert.match(model, /private func applyFamiliarOrder\(_ loaded: \[Familiar\]\) -> \[Familiar\]/, "applyFamiliarOrder should exist");
+assert.match(model, /cave-familiar-order\.json/, "order should persist to cave-familiar-order.json");
+assert.match(model, /private func persistFamiliarOrder\(\)/, "persistFamiliarOrder should exist");
+
+// Chats tab exposes drag-reorder behind an edit toggle.
+assert.match(home, /@State private var editMode: EditMode = \.inactive/, "ChatsHomeView should track edit mode");
+assert.match(
+  home,
+  /\.onMove \{ source, destination in\s*app\.moveFamiliar\(fromOffsets: source, toOffset: destination\)/,
+  "the Familiars list should reorder via moveFamiliar",
+);
+assert.match(home, /\.environment\(\\\.editMode, \$editMode\)/, "the list should bind edit mode");
+assert.match(home, /editMode\.isEditing \? "Done" : "Reorder"/, "the header should toggle a Reorder button");
+assert.match(
+  home,
+  /private var canReorder: Bool \{[\s\S]*app\.familiars\.count > 1[\s\S]*query\.trimmingCharacters[\s\S]*isEmpty/,
+  "reorder should require >1 familiar and no active search",
+);
+
+console.log("ios-reorder-familiars.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -493,6 +493,7 @@ export const SUITES = {
     "scripts/ios-task-actions.test.mjs",
     "scripts/ios-task-search-familiar-scope.test.mjs",
     "scripts/ios-thread-rename.test.mjs",
+    "scripts/ios-reorder-familiars.test.mjs",
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/mobile-tailscale.test.mjs",
     "scripts/mobile-tailscale-native.test.mjs",


### PR DESCRIPTION
## What

Familiars in the Chats tab were shown in server order with no way to rearrange them. This adds drag-to-reorder with a persisted custom order.

- **`AppModel`** — a persisted `familiarOrder` (familiar ids) applied over the server's order on every load (`applyFamiliarOrder`; new/unknown familiars fall to the end, stable). `moveFamiliar(fromOffsets:toOffset:)` reorders the list, recomputes the order, and persists to `cave-familiar-order.json` (mirrors the existing card-links persistence).
- **`ChatsHomeView`** — a **Reorder / Done** toggle in the header drives `EditMode` on the list; the Familiars section gets `.onMove`. Reordering is only offered with **>1 familiar and no active search** (so drag indices map to the full, unfiltered array), and edit mode auto-exits if a search begins.

## Verification

- `pnpm test:mobile` → **✓ 27 test file(s) passed** (full suite; new `scripts/ios-reorder-familiars.test.mjs` registered in `run-tests.mjs`).
- `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED**.

Interactive drag (tap Reorder → drag handles → drop) needs gestures I can't drive headlessly without `idb`, so it rests on the build + assertion test + the proven persistence pattern.

Built in an isolated worktree off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)