### PR TITLE
feat(ios): archive chat threads

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -654,6 +654,15 @@ final class AppModel {
         persistThreads()
     }
 
+    /// Archive or restore a thread; archived threads are hidden from the default
+    /// lists but kept on disk.
+    func setThreadArchived(_ thread: ChatThread, _ archived: Bool) {
+        guard let target = threads.first(where: { $0.id == thread.id }),
+              target.archived != archived else { return }
+        target.archived = archived
+        persistThreads()
+    }
+
     func touch(_ thread: ChatThread) {
         // Move the most recently active thread to the top, then persist.
         if let idx = threads.firstIndex(where: { $0.id == thread.id }), idx != 0 {

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -26,6 +26,8 @@ struct ThreadSnapshot: Codable, Identifiable {
     var sessionIds: [String: String]
     var messages: [DisplayMessage]
     var updatedAt: Date
+    /// Optional so snapshots written before archiving existed still decode.
+    var archived: Bool?
 }
 
 /// A conversation thread. One familiar = a direct chat; several = a group.
@@ -46,6 +48,7 @@ final class ChatThread: Identifiable, Hashable {
     var sessionIds: [String: String]
     var messages: [DisplayMessage]
     var updatedAt: Date
+    var archived: Bool = false
 
     var isGroup: Bool { familiarIds.count > 1 }
     var activeStreams: Int { messages.filter { $0.streaming }.count }
@@ -68,11 +71,13 @@ final class ChatThread: Identifiable, Hashable {
         self.init(id: s.id, title: s.title, familiarIds: s.familiarIds,
                   sessionIds: s.sessionIds, messages: s.messages)
         self.updatedAt = s.updatedAt
+        self.archived = s.archived ?? false
     }
 
     var snapshot: ThreadSnapshot {
         ThreadSnapshot(id: id, title: title, familiarIds: familiarIds,
-                       sessionIds: sessionIds, messages: messages, updatedAt: updatedAt)
+                       sessionIds: sessionIds, messages: messages,
+                       updatedAt: updatedAt, archived: archived)
     }
 
     /// Send a user message and stream replies from every familiar in the thread.

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -20,6 +20,8 @@ struct ChatsHomeView: View {
     /// A group thread awaiting delete confirmation (swipe or context menu).
     @State private var pendingDelete: ChatThread?
     @State private var editMode: EditMode = .inactive
+    /// Reveal archived group chats in the list.
+    @State private var showArchived = false
 
     var body: some View {
         NavigationStack(path: $path) {
@@ -129,8 +131,8 @@ struct ChatsHomeView: View {
                     app.moveFamiliar(fromOffsets: source, toOffset: destination)
                 }
             }
-            if !filteredGroups.isEmpty {
-                Section("Groups") {
+            if !filteredGroups.isEmpty || archivedGroupCount > 0 {
+                Section {
                     ForEach(filteredGroups) { thread in
                         Button { path.append(.thread(thread)) } label: {
                             ThreadRow(thread: thread)
@@ -141,6 +143,11 @@ struct ChatsHomeView: View {
                             Button(role: .destructive) { pendingDelete = thread } label: {
                                 Label("Delete", systemImage: "trash")
                             }
+                            Button { app.setThreadArchived(thread, !thread.archived) } label: {
+                                Label(thread.archived ? "Unarchive" : "Archive",
+                                      systemImage: thread.archived ? "tray.and.arrow.up" : "archivebox")
+                            }
+                            .tint(.indigo)
                         }
                         .swipeActions(edge: .leading) {
                             Button { renamingThread = thread } label: {
@@ -152,10 +159,29 @@ struct ChatsHomeView: View {
                             Button { renamingThread = thread } label: {
                                 Label("Rename", systemImage: "pencil")
                             }
+                            Button { app.setThreadArchived(thread, !thread.archived) } label: {
+                                Label(thread.archived ? "Unarchive" : "Archive",
+                                      systemImage: thread.archived ? "tray.and.arrow.up" : "archivebox")
+                            }
                             Button(role: .destructive) { pendingDelete = thread } label: {
                                 Label("Delete", systemImage: "trash")
                             }
                         }
+                    }
+                } header: {
+                    Text("Groups")
+                } footer: {
+                    if archivedGroupCount > 0 {
+                        Button {
+                            withAnimation { showArchived.toggle() }
+                        } label: {
+                            Label(showArchived ? "Hide archived"
+                                               : "Show \(archivedGroupCount) archived",
+                                  systemImage: showArchived ? "chevron.up" : "archivebox")
+                                .font(.footnote)
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.secondary)
                     }
                 }
             }
@@ -191,10 +217,14 @@ struct ChatsHomeView: View {
     }
 
     /// Group threads matching the search query (title or a member's name).
+    /// Number of archived group chats (drives the show/hide-archived toggle).
+    private var archivedGroupCount: Int { app.groupThreads.filter(\.archived).count }
+
     private var filteredGroups: [ChatThread] {
+        let base = app.groupThreads.filter { showArchived || !$0.archived }
         let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !q.isEmpty else { return app.groupThreads }
-        return app.groupThreads.filter { thread in
+        guard !q.isEmpty else { return base }
+        return base.filter { thread in
             if thread.title.lowercased().contains(q) { return true }
             return thread.familiarIds.compactMap(app.familiar).contains {
                 $0.displayName.lowercased().contains(q)

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -12,6 +12,8 @@ struct FamiliarThreadsView: View {
     @State private var renamingThread: ChatThread?
     /// An on-device thread awaiting delete confirmation (swipe or context menu).
     @State private var pendingDelete: ChatThread?
+    /// Reveal archived on-device threads.
+    @State private var showArchived = false
 
     /// One row in the list: an on-device thread or a server-only session.
     private enum Entry: Identifiable {
@@ -33,15 +35,23 @@ struct FamiliarThreadsView: View {
     }
 
     /// On-device threads + server-only sessions, newest activity first.
+    /// Archived on-device threads stay hidden until the user opts in.
     private var entries: [Entry] {
-        let local = app.directThreads(for: familiar.id).map(Entry.local)
+        let local = app.directThreads(for: familiar.id)
+            .filter { showArchived || !$0.archived }
+            .map(Entry.local)
         let server = app.serverOnlySessions(for: familiar.id).map(Entry.server)
         return (local + server).sorted { $0.date > $1.date }
     }
 
+    /// Number of archived on-device threads (drives the show/hide toggle).
+    private var archivedLocalCount: Int {
+        app.directThreads(for: familiar.id).filter(\.archived).count
+    }
+
     var body: some View {
         Group {
-            if entries.isEmpty {
+            if entries.isEmpty && archivedLocalCount == 0 {
                 emptyState
             } else {
                 threadList
@@ -83,6 +93,11 @@ struct FamiliarThreadsView: View {
                             Button(role: .destructive) { pendingDelete = thread } label: {
                                 Label("Delete", systemImage: "trash")
                             }
+                            Button { app.setThreadArchived(thread, !thread.archived) } label: {
+                                Label(thread.archived ? "Unarchive" : "Archive",
+                                      systemImage: thread.archived ? "tray.and.arrow.up" : "archivebox")
+                            }
+                            .tint(.indigo)
                         }
                     }
                     .swipeActions(edge: .leading) {
@@ -98,11 +113,27 @@ struct FamiliarThreadsView: View {
                             Button { renamingThread = thread } label: {
                                 Label("Rename", systemImage: "pencil")
                             }
+                            Button { app.setThreadArchived(thread, !thread.archived) } label: {
+                                Label(thread.archived ? "Unarchive" : "Archive",
+                                      systemImage: thread.archived ? "tray.and.arrow.up" : "archivebox")
+                            }
                             Button(role: .destructive) { pendingDelete = thread } label: {
                                 Label("Delete", systemImage: "trash")
                             }
                         }
                     }
+            }
+            if archivedLocalCount > 0 {
+                Button {
+                    withAnimation { showArchived.toggle() }
+                } label: {
+                    Label(showArchived ? "Hide archived" : "Show \(archivedLocalCount) archived",
+                          systemImage: showArchived ? "chevron.up" : "archivebox")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
             }
         }
         .listStyle(.plain)

--- a/scripts/ios-archive-threads.test.mjs
+++ b/scripts/ios-archive-threads.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (rel) => readFile(new URL(`../${rel}`, import.meta.url), "utf8");
+const iosRoot = "apps/ios/CovenCave/CovenCave";
+
+const thread = await read(`${iosRoot}/State/ChatThread.swift`);
+const model = await read(`${iosRoot}/State/AppModel.swift`);
+const home = await read(`${iosRoot}/Views/ChatsHomeView.swift`);
+const familiarThreads = await read(`${iosRoot}/Views/FamiliarThreadsView.swift`);
+
+assert.match(thread, /var archived: Bool = false/, "ChatThread should carry an archived flag");
+assert.match(thread, /var archived: Bool\?/, "ThreadSnapshot.archived should be optional for back-compat");
+assert.match(thread, /self\.archived = s\.archived \?\? false/, "snapshot decode should default archived to false");
+assert.match(thread, /ThreadSnapshot\([\s\S]*archived: archived\)/, "snapshot encode should include archived");
+
+assert.match(
+  model,
+  /func setThreadArchived\(_ thread: ChatThread, _ archived: Bool\) \{[\s\S]*target\.archived = archived[\s\S]*persistThreads\(\)/,
+  "AppModel.setThreadArchived should set the flag and persist",
+);
+
+for (const [name, src] of [["ChatsHomeView", home], ["FamiliarThreadsView", familiarThreads]]) {
+  assert.match(src, /showArchived/, `${name} should track a showArchived toggle`);
+  assert.match(src, /app\.setThreadArchived\(thread, !thread\.archived\)/, `${name} should toggle archive state`);
+  assert.match(src, /thread\.archived \? "Unarchive" : "Archive"/, `${name} should label the archive action by state`);
+  assert.match(src, /showArchived \|\| !\$0\.archived/, `${name} should filter out archived by default`);
+  assert.match(src, /"Hide archived"/, `${name} should offer a reveal toggle`);
+}
+
+console.log("ios-archive-threads.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -493,6 +493,7 @@ export const SUITES = {
     "scripts/ios-task-actions.test.mjs",
     "scripts/ios-task-search-familiar-scope.test.mjs",
     "scripts/ios-thread-rename.test.mjs",
+    "scripts/ios-archive-threads.test.mjs",
     "scripts/ios-reorder-familiars.test.mjs",
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/mobile-tailscale.test.mjs",


### PR DESCRIPTION
## What

Threads could be renamed and deleted but not archived. This adds archiving so old chats can be tucked away without losing them.

- **`ChatThread`** — a persisted `archived` flag (`ThreadSnapshot.archived` is optional so files written before archiving still decode).
- **`AppModel.setThreadArchived(_:_:)`** — toggles the flag and persists.
- **`ChatsHomeView`** (group threads) and **`FamiliarThreadsView`** (on-device threads): archived chats are hidden from the list by default; a trailing **swipe action** and a **context-menu** entry archive/unarchive, and a **"Show N archived" / "Hide archived"** toggle reveals them in place. Server-only sessions (which live on the desktop) are unaffected.

## Verification

- `pnpm test:mobile` → **✓ 30 test file(s) passed** (full suite; new `scripts/ios-archive-threads.test.mjs` registered in `run-tests.mjs`).
- `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED**.

Interactive archive (swipe/menu → toggle, reveal) needs gestures I can't drive headlessly without `idb`, so it rests on the build + assertion test + the proven persistence pattern.

> Built off current `main` (includes the reorder feature #1662), in a sibling worktree after the in-repo `.worktrees/` was swept twice by concurrent-session cleanup — committed and pushed before building to avoid losing the work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)