### PR TITLE
feat(board): flush-left Gantt timeline + drop redundant Owner column in by-familiar view

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -336,17 +336,24 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
   // Focus: when a group is clicked, render only it (range stays global so bars don't jump).
   const focused = focusedKey && groups.some((g) => g.key === focusedKey) ? focusedKey : null;
   const visibleGroups = focused ? groups.filter((g) => g.key === focused) : groups;
+  // Grouping by familiar already names the owner in every group header, so the
+  // per-row Owner column just repeats it — drop the column in that mode.
+  const hideOwner = groupMode === "familiar";
 
   const min = new Date(Math.min(...allRows.map((r) => r.start.getTime())));
   const max = new Date(Math.max(...allRows.map((r) => r.end.getTime())));
-  const rangeStart = startOfWeekMon(min);
+  // Anchor the timeline on the earliest task itself so the first bar sits flush
+  // against the left edge. Snapping back to that week's Monday left a near-empty
+  // leading column whenever the first task started late in its week.
+  const rangeStart = new Date(Date.UTC(min.getUTCFullYear(), min.getUTCMonth(), min.getUTCDate()));
   const rangeEnd = addDays(startOfWeekMon(max), 7); // complete the final week
   const totalDays = Math.max(7, daysBetween(rangeStart, rangeEnd));
   const timelineW = totalDays * DAY_W;
 
   const weeks: Array<{ left: number; width: number; label: string }> = [];
   for (let i = 0; i < totalDays; i += 7) {
-    weeks.push({ left: i * DAY_W, width: 7 * DAY_W, label: `Week ${isoWeek(addDays(rangeStart, i))}` });
+    // Clamp the trailing column: the range no longer ends on a week boundary.
+    weeks.push({ left: i * DAY_W, width: Math.min(7, totalDays - i) * DAY_W, label: `Week ${isoWeek(addDays(rangeStart, i))}` });
   }
 
   let todayX: number | null = null;
@@ -375,12 +382,12 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
         <button type="button" className="board-group-toggle-btn" onClick={scrollToToday} disabled={todayX === null} title="Scroll the timeline to today">Today</button>
       </div>
       <div className="board-gantt__scroll" ref={scrollRef}>
-        <div className="cg" style={{ ["--cg-day" as string]: `${DAY_W}px`, ["--cg-tl" as string]: `${timelineW}px` }}>
+        <div className={`cg${hideOwner ? " cg--no-owner" : ""}`} style={{ ["--cg-day" as string]: `${DAY_W}px`, ["--cg-tl" as string]: `${timelineW}px` }}>
           {/* Header: left column titles + week band */}
           <div className="cg-head">
             <div className="cg-left cg-left--head">
               <span className="cg-c-task">Group / Task</span>
-              <span className="cg-c-owner">Owner</span>
+              {!hideOwner && <span className="cg-c-owner">Owner</span>}
               <span className="cg-c-date">Start</span>
               <span className="cg-c-date">End</span>
               <span className="cg-c-st">St</span>
@@ -473,7 +480,7 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
                     >
                       <span className="cg-left">
                         <span className="cg-c-task">{row.label}</span>
-                        <span className="cg-c-owner">{row.owner}</span>
+                        {!hideOwner && <span className="cg-c-owner">{row.owner}</span>}
                         <span className="cg-c-date">{formatLabel(previewStart)}</span>
                         <span className="cg-c-date">{formatLabel(previewEnd)}</span>
                         <span className="cg-c-st"><span className={`cg-dot cg-dot--${cat}`} aria-hidden /></span>

--- a/src/components/board-schedule-window.test.ts
+++ b/src/components/board-schedule-window.test.ts
@@ -67,4 +67,22 @@ assert.match(gantt, /\{draggable \? resizeHandle\("start"\) : null\}[\s\S]*?\{dr
 assert.match(styles, /\.cg-bar__resize \{/, "resize-handle styles exist");
 assert.match(styles, /cursor: ew-resize/, "resize handles show the horizontal-resize cursor");
 
+// The timeline anchors on the earliest task itself (flush left) rather than
+// snapping back to that week's Monday, which left a near-empty leading column.
+assert.match(
+  gantt,
+  /const rangeStart = new Date\(Date\.UTC\(min\.getUTCFullYear\(\), min\.getUTCMonth\(\), min\.getUTCDate\(\)\)\)/,
+  "the Gantt window starts on the earliest task so the first bar is flush left",
+);
+assert.doesNotMatch(gantt, /const rangeStart = startOfWeekMon\(min\)/, "the leading Monday-snap is gone");
+assert.match(gantt, /width: Math\.min\(7, totalDays - i\)/, "the trailing week column is clamped to the range");
+
+// Grouping by familiar drops the redundant Owner column (header + cells + grid).
+assert.match(gantt, /const hideOwner = groupMode === "familiar"/, "owner column is hidden when grouping by familiar");
+assert.match(gantt, /className=\{`cg\$\{hideOwner \? " cg--no-owner" : ""\}`\}/, "the no-owner modifier class is applied to the grid");
+assert.match(gantt, /\{!hideOwner && <span className="cg-c-owner">Owner<\/span>\}/, "the Owner header is conditional");
+assert.match(gantt, /\{!hideOwner && <span className="cg-c-owner">\{row\.owner\}<\/span>\}/, "the per-row owner cell is conditional");
+assert.match(styles, /\.cg--no-owner \.cg-left \{ flex-basis: 332px; grid-template-columns: 190px 58px 58px 26px; \}/, "the no-owner layout drops the owner column width");
+assert.match(styles, /\.cg--no-owner \.cg-grouprow \.cg-left \{ grid-template-columns: auto 1fr auto; \}/, "group rows keep their own three-column template");
+
 console.log("board-schedule-window.test.ts: ok");

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1621,6 +1621,10 @@
   background: var(--bg-base);
   border-right: 1px solid var(--border-strong);
 }
+/* Grouped by familiar: the Owner column is redundant with the group header, so
+   it's dropped from the markup — narrow the left table to its four columns. */
+.cg--no-owner .cg-left { flex-basis: 332px; grid-template-columns: 190px 58px 58px 26px; }
+.cg--no-owner .cg-grouprow .cg-left { grid-template-columns: auto 1fr auto; }
 .cg-left > span { padding: 0 8px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cg-c-owner, .cg-c-date { font-size: 11px; color: var(--text-secondary); }
 .cg-c-date { text-align: right; }


### PR DESCRIPTION
## Summary

Two Gantt-view refinements:

### 1. Flush-left timeline
The timeline snapped its start back to the earliest task's **Monday**, so a task starting late in its week (e.g. a Sunday) left a near-empty leading column. Now the window anchors on the earliest task itself, so the first bar sits flush against the left edge. The trailing week column is clamped since the range no longer ends on a week boundary.

### 2. Drop the redundant Owner column when grouped by familiar
When the Gantt is grouped **by familiar**, each group header already names the owner, so the per-row Owner column just repeats it. The Owner column (header, cells, and grid track) is dropped **only** in that mode — Project and Task grouping keep it.

## Verification (ran the app, screenshotted both states)
- **Project mode:** Owner column present (Sage/Charm/Cody…); earliest task bar flush left.
- **Familiar mode:** Owner column gone (header is `GROUP/TASK · START · END · ST`); familiar named in each group header; left table cleanly narrowed, no misalignment. `cg-c-owner` element count: 22 (project) → 0 (familiar).
- `tsc --noEmit` clean; `board-schedule-window.test.ts` extended with assertions for both behaviors and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)