### PR TITLE
feat(ios): pin chat threads

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -427,13 +427,19 @@ final class AppModel {
     func directThreads(for familiarId: String) -> [ChatThread] {
         threads
             .filter { !$0.isGroup && $0.familiarIds == [familiarId] }
-            .sorted { $0.updatedAt > $1.updatedAt }
+            .sorted { a, b in
+                if a.pinned != b.pinned { return a.pinned }
+                return a.updatedAt > b.updatedAt
+            }
     }
 
     /// Every group thread, newest first — shown as its own rows on the Chats
     /// home (a group has no single familiar to file it under).
     var groupThreads: [ChatThread] {
-        threads.filter(\.isGroup).sorted { $0.updatedAt > $1.updatedAt }
+        threads.filter(\.isGroup).sorted { a, b in
+            if a.pinned != b.pinned { return a.pinned }
+            return a.updatedAt > b.updatedAt
+        }
     }
 
     /// Server sessions for a familiar that no local thread already carries —
@@ -660,6 +666,14 @@ final class AppModel {
         guard let target = threads.first(where: { $0.id == thread.id }),
               target.archived != archived else { return }
         target.archived = archived
+        persistThreads()
+    }
+
+    /// Pin or unpin a thread; pinned threads sort to the top of their list.
+    func setThreadPinned(_ thread: ChatThread, _ pinned: Bool) {
+        guard let target = threads.first(where: { $0.id == thread.id }),
+              target.pinned != pinned else { return }
+        target.pinned = pinned
         persistThreads()
     }
 

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -28,6 +28,7 @@ struct ThreadSnapshot: Codable, Identifiable {
     var updatedAt: Date
     /// Optional so snapshots written before archiving existed still decode.
     var archived: Bool?
+    var pinned: Bool?
 }
 
 /// A conversation thread. One familiar = a direct chat; several = a group.
@@ -49,6 +50,7 @@ final class ChatThread: Identifiable, Hashable {
     var messages: [DisplayMessage]
     var updatedAt: Date
     var archived: Bool = false
+    var pinned: Bool = false
 
     var isGroup: Bool { familiarIds.count > 1 }
     var activeStreams: Int { messages.filter { $0.streaming }.count }
@@ -72,12 +74,13 @@ final class ChatThread: Identifiable, Hashable {
                   sessionIds: s.sessionIds, messages: s.messages)
         self.updatedAt = s.updatedAt
         self.archived = s.archived ?? false
+        self.pinned = s.pinned ?? false
     }
 
     var snapshot: ThreadSnapshot {
         ThreadSnapshot(id: id, title: title, familiarIds: familiarIds,
                        sessionIds: sessionIds, messages: messages,
-                       updatedAt: updatedAt, archived: archived)
+                       updatedAt: updatedAt, archived: archived, pinned: pinned)
     }
 
     /// Send a user message and stream replies from every familiar in the thread.

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -154,10 +154,19 @@ struct ChatsHomeView: View {
                                 Label("Rename", systemImage: "pencil")
                             }
                             .tint(.accentColor)
+                            Button { app.setThreadPinned(thread, !thread.pinned) } label: {
+                                Label(thread.pinned ? "Unpin" : "Pin",
+                                      systemImage: thread.pinned ? "pin.slash" : "pin")
+                            }
+                            .tint(.orange)
                         }
                         .contextMenu {
                             Button { renamingThread = thread } label: {
                                 Label("Rename", systemImage: "pencil")
+                            }
+                            Button { app.setThreadPinned(thread, !thread.pinned) } label: {
+                                Label(thread.pinned ? "Unpin" : "Pin",
+                                      systemImage: thread.pinned ? "pin.slash" : "pin")
                             }
                             Button { app.setThreadArchived(thread, !thread.archived) } label: {
                                 Label(thread.archived ? "Unarchive" : "Archive",
@@ -335,6 +344,10 @@ struct ThreadRow: View {
             VStack(alignment: .leading, spacing: 3) {
                 HStack {
                     Text(thread.title).font(.headline).lineLimit(1)
+                    if thread.pinned {
+                        Image(systemName: "pin.fill")
+                            .font(.caption2).foregroundStyle(.orange)
+                    }
                     if thread.isGroup {
                         Image(systemName: "person.2.fill")
                             .font(.caption2).foregroundStyle(.secondary)

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -106,12 +106,21 @@ struct FamiliarThreadsView: View {
                                 Label("Rename", systemImage: "pencil")
                             }
                             .tint(.accentColor)
+                            Button { app.setThreadPinned(thread, !thread.pinned) } label: {
+                                Label(thread.pinned ? "Unpin" : "Pin",
+                                      systemImage: thread.pinned ? "pin.slash" : "pin")
+                            }
+                            .tint(.orange)
                         }
                     }
                     .contextMenu {
                         if case .local(let thread) = entry {
                             Button { renamingThread = thread } label: {
                                 Label("Rename", systemImage: "pencil")
+                            }
+                            Button { app.setThreadPinned(thread, !thread.pinned) } label: {
+                                Label(thread.pinned ? "Unpin" : "Pin",
+                                      systemImage: thread.pinned ? "pin.slash" : "pin")
                             }
                             Button { app.setThreadArchived(thread, !thread.archived) } label: {
                                 Label(thread.archived ? "Unarchive" : "Archive",

--- a/scripts/ios-archive-threads.test.mjs
+++ b/scripts/ios-archive-threads.test.mjs
@@ -12,7 +12,7 @@ const familiarThreads = await read(`${iosRoot}/Views/FamiliarThreadsView.swift`)
 assert.match(thread, /var archived: Bool = false/, "ChatThread should carry an archived flag");
 assert.match(thread, /var archived: Bool\?/, "ThreadSnapshot.archived should be optional for back-compat");
 assert.match(thread, /self\.archived = s\.archived \?\? false/, "snapshot decode should default archived to false");
-assert.match(thread, /ThreadSnapshot\([\s\S]*archived: archived\)/, "snapshot encode should include archived");
+assert.match(thread, /ThreadSnapshot\([\s\S]*archived: archived/, "snapshot encode should include archived");
 
 assert.match(
   model,

--- a/scripts/ios-pin-threads.test.mjs
+++ b/scripts/ios-pin-threads.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (rel) => readFile(new URL(`../${rel}`, import.meta.url), "utf8");
+const iosRoot = "apps/ios/CovenCave/CovenCave";
+
+const thread = await read(`${iosRoot}/State/ChatThread.swift`);
+const model = await read(`${iosRoot}/State/AppModel.swift`);
+const home = await read(`${iosRoot}/Views/ChatsHomeView.swift`);
+const familiarThreads = await read(`${iosRoot}/Views/FamiliarThreadsView.swift`);
+
+assert.match(thread, /var pinned: Bool = false/, "ChatThread should carry a pinned flag");
+assert.match(thread, /var pinned: Bool\?/, "ThreadSnapshot.pinned should be optional for back-compat");
+assert.match(thread, /self\.pinned = s\.pinned \?\? false/, "snapshot decode should default pinned to false");
+assert.match(thread, /archived: archived, pinned: pinned\)/, "snapshot encode should include pinned");
+
+assert.match(
+  model,
+  /func setThreadPinned\(_ thread: ChatThread, _ pinned: Bool\) \{[\s\S]*target\.pinned = pinned[\s\S]*persistThreads\(\)/,
+  "AppModel.setThreadPinned should set the flag and persist",
+);
+// Both list builders sort pinned threads first.
+const sortCount = (model.match(/if a\.pinned != b\.pinned \{ return a\.pinned \}/g) || []).length;
+assert.ok(sortCount >= 2, `pinned-first sort should apply to both lists (found ${sortCount})`);
+
+for (const [name, src] of [["ChatsHomeView", home], ["FamiliarThreadsView", familiarThreads]]) {
+  assert.match(src, /app\.setThreadPinned\(thread, !thread\.pinned\)/, `${name} should toggle pin state`);
+  assert.match(src, /thread\.pinned \? "Unpin" : "Pin"/, `${name} should label the pin action by state`);
+}
+assert.match(home, /if thread\.pinned \{[\s\S]*pin\.fill/, "ThreadRow should show a pin indicator when pinned");
+
+console.log("ios-pin-threads.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -494,6 +494,7 @@ export const SUITES = {
     "scripts/ios-task-search-familiar-scope.test.mjs",
     "scripts/ios-thread-rename.test.mjs",
     "scripts/ios-archive-threads.test.mjs",
+    "scripts/ios-pin-threads.test.mjs",
     "scripts/ios-reorder-familiars.test.mjs",
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/mobile-tailscale.test.mjs",


### PR DESCRIPTION
## What

Adds pinning so important chats stay at the top of the list.

- **`ChatThread`** — a persisted `pinned` flag (`ThreadSnapshot.pinned` optional for backward-compatible decoding).
- **`AppModel.setThreadPinned(_:_:)`** — toggles + persists; `directThreads` and `groupThreads` now sort **pinned-first, then by recency**.
- **`ChatsHomeView`** (groups) and **`FamiliarThreadsView`** (on-device threads): a **Pin/Unpin** leading-swipe action and context-menu entry. **`ThreadRow`** shows a pin glyph on pinned threads.

## Verification

- `pnpm test:mobile` → **✓ 31 test file(s) passed** (full suite; new `scripts/ios-pin-threads.test.mjs` registered).
- `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED**.
- Caught and fixed a cross-test regression: adding `pinned` to the snapshot literal broke `ios-archive-threads.test.mjs`'s exact-match regex; loosened it (the kind of breakage the full suite is run to catch).

Interactive pin (swipe/menu → toggle, reorder to top) needs gestures I can't drive headlessly without `idb`, so it rests on build + assertion test + the proven persistence pattern.

> Built via an atomic sibling-worktree one-shot (commit+push before build) because the in-repo `.worktrees/` keeps getting swept by concurrent-session cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)