### PR TITLE
feat(board): show owner in task-grouped Gantt + colour bars by familiar

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -35,6 +35,8 @@ type GanttRow = {
   start: Date;
   end: Date;
   category: GanttCategory;
+  /** Per-familiar bar colour, set only when grouping by familiar. */
+  color?: string;
 };
 type Group = { key: string; name: string; rows: GanttRow[]; firstStart: number };
 
@@ -203,6 +205,17 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
     (id ? familiars?.find((f) => f.id === id)?.display_name : undefined) ?? "—";
   const projectName = (id: string | null | undefined): string =>
     (id ? projects?.find((p) => p.id === id)?.name : undefined) ?? "No project";
+  // A stable per-familiar colour for by-familiar bars: the familiar's own
+  // colour when set, otherwise a hue derived from its id so distinct familiars
+  // stay visually distinct. Unassigned rows keep their status colour.
+  const familiarColor = (id: string | null): string | undefined => {
+    if (!id) return undefined;
+    const set = familiars?.find((f) => f.id === id)?.color;
+    if (set) return set;
+    let h = 0;
+    for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) % 360;
+    return `hsl(${h} 52% 52%)`;
+  };
 
   // A card's own date range; start/end fall back to each other. null if neither.
   const cardRange = (card: Card): { start: Date; end: Date } | null => {
@@ -240,7 +253,7 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
           cardId: card.id,
           stepId: step.id,
           label: step.text,
-          owner: "",
+          owner: ownerName(card.familiarId),
           start: a <= b ? a : b,
           end: a <= b ? b : a,
           category: step.done ? "done" : statusCategory(card.status),
@@ -275,6 +288,7 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
         start: cr.start,
         end: cr.end,
         category: statusCategory(card.status),
+        color: byFamiliar ? familiarColor(card.familiarId) : undefined,
       });
       group.firstStart = Math.min(group.firstStart, cr.start.getTime());
     }
@@ -495,7 +509,7 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
                         ) : (
                           <span
                             className={barClass(`board-gantt-row__bar board-gantt-row__bar--${cat} cg-bar`)}
-                            style={{ left: `${left}px`, width: `${Math.max(DAY_W, previewDur * DAY_W - 3)}px`, touchAction: "none" }}
+                            style={{ left: `${left}px`, width: `${Math.max(DAY_W, previewDur * DAY_W - 3)}px`, touchAction: "none", ...(row.color ? { background: row.color } : {}) }}
                             {...handlers}
                           >
                             {draggable ? resizeHandle("start") : null}

--- a/src/components/board-schedule-window.test.ts
+++ b/src/components/board-schedule-window.test.ts
@@ -85,4 +85,13 @@ assert.match(gantt, /\{!hideOwner && <span className="cg-c-owner">\{row\.owner\}
 assert.match(styles, /\.cg--no-owner \.cg-left \{ flex-basis: 332px; grid-template-columns: 190px 58px 58px 26px; \}/, "the no-owner layout drops the owner column width");
 assert.match(styles, /\.cg--no-owner \.cg-grouprow \.cg-left \{ grid-template-columns: auto 1fr auto; \}/, "group rows keep their own three-column template");
 
+// Task-mode step rows carry the parent card's owner (the Owner column was blank).
+assert.match(gantt, /label: step\.text,\s*owner: ownerName\(card\.familiarId\),/, "task-mode step rows show the card's owner");
+assert.doesNotMatch(gantt, /owner: "",/, "the empty task-mode owner placeholder is gone");
+
+// By-familiar grouping colour-codes bars by familiar.
+assert.match(gantt, /const familiarColor = \(id: string \| null\): string \| undefined =>/, "a per-familiar colour helper exists");
+assert.match(gantt, /color: byFamiliar \? familiarColor\(card\.familiarId\) : undefined/, "rows carry a familiar colour only in by-familiar mode");
+assert.match(gantt, /\.\.\.\(row\.color \? \{ background: row\.color \} : \{\}\)/, "the bar paints the familiar colour when present");
+
 console.log("board-schedule-window.test.ts: ok");


### PR DESCRIPTION
## Summary

Two Gantt follow-ups:

### 1. Show the owner in task-grouped Gantt
Task-grouped rows (one bar per step) left the **Owner** column blank (`owner: ""`). Now each step row shows the parent card's owner, so the column is meaningful wherever it appears.

### 2. Colour-code bars by familiar in the by-familiar view
When grouped by familiar, each bar is painted with its familiar's colour (the familiar's own colour, or a stable hue derived from its id) so the chart reads by familiar at a glance. Status is still conveyed by the ST dot. Project and Task grouping keep status colours.

## Verification (ran the app, screenshotted both)
- **Task mode:** Owner column now shows the owner ("Cody") on every step row — previously blank. Bars keep status colours (3 distinct: pending/done/in-progress).
- **Familiar mode:** bars distinctly coloured per familiar (Sage = blue, Cody = purple, Nova = cyan — 5 distinct hues sampled); owner column still hidden (#1664); ST status dots retained.
- `tsc --noEmit` clean; `board-schedule-window.test.ts` extended with assertions for both behaviors and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)