### PR TITLE
fix(chat): allow familiars to roam granted projects

### DIFF
--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -244,6 +244,18 @@ assert.match(
 
 assert.match(
   chatRoute,
+  /filterProjectsForFamiliar\(projects, body\.familiarId\)/,
+  "Local Cave chat should derive grant-aware project roots for the familiar before building the runtime prompt",
+);
+
+assert.match(
+  chatRoute,
+  /allowedProjectRoots: grantedProjectRoots/,
+  "The runtime prompt should include every project root the familiar is granted, not only the spawn cwd",
+);
+
+assert.match(
+  chatRoute,
   /import \{[\s\S]*ProjectAccessDeniedError,[\s\S]*assertProjectAccess,[\s\S]*\} from "@\/lib\/project-permissions";/,
   "Chat send should import the shared project-permission chokepoint",
 );

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -71,6 +71,7 @@ import {
 import {
   ProjectAccessDeniedError,
   assertProjectAccess,
+  filterProjectsForFamiliar,
 } from "@/lib/project-permissions";
 import {
   buildTaskAwarePrompt,
@@ -184,6 +185,7 @@ async function conversationCwd(sessionId?: string): Promise<string | undefined> 
 }
 
 async function chatProjectAccessId(args: {
+  projects: Awaited<ReturnType<typeof loadProjects>>;
   requestedProjectRoot?: string;
   resumeCwd?: string;
   resolvedCwd: string;
@@ -193,7 +195,7 @@ async function chatProjectAccessId(args: {
   const projectRoot = explicitRoot ?? resumedRoot;
   if (!projectRoot) return null;
 
-  const projects = await loadProjects();
+  const projects = args.projects;
   const project =
     projectForRoot(projectRoot, projects) ??
     projectForRoot(args.resolvedCwd, projects);
@@ -891,9 +893,11 @@ export async function POST(req: Request) {
     }
     throw error;
   }
+  const projects = sshRuntime ? [] : await loadProjects();
   const chatProjectId = sshRuntime
     ? null
     : await chatProjectAccessId({
+        projects,
         requestedProjectRoot: body.projectRoot,
         resumeCwd,
         resolvedCwd: cwd,
@@ -911,6 +915,9 @@ export async function POST(req: Request) {
       throw error;
     }
   }
+  const grantedProjectRoots = sshRuntime
+    ? []
+    : (await filterProjectsForFamiliar(projects, body.familiarId)).map((project) => project.root);
   const resolvedFamiliarWorkspace = !sshRuntime
     ? await resolveFamiliarWorkspace(body.familiarId)
     : undefined;
@@ -927,7 +934,7 @@ export async function POST(req: Request) {
     : undefined;
   const runtimeScope: RuntimeScope = sshRuntime
     ? { kind: "ssh", host: sshRuntime.host, root: sshRuntime.cwd }
-    : { kind: "local", root: familiarCwd ?? cwd };
+    : { kind: "local", root: familiarCwd ?? cwd, allowedProjectRoots: grantedProjectRoots };
   const responseMetadata: ChatResponseMetadata = {
     familiarId: body.familiarId,
     harness: binding.harness,

--- a/src/lib/chat-runtime-scope.test.ts
+++ b/src/lib/chat-runtime-scope.test.ts
@@ -67,6 +67,35 @@ await assert.rejects(
 }
 
 {
+  const docs = path.join(home, "docs");
+  const preamble = buildRuntimeScopePreamble({
+    kind: "local",
+    root: repo,
+    allowedProjectRoots: [repo, docs, repo],
+  });
+  assert.match(preamble, /Runtime filesystem boundary:/);
+  assert.match(preamble, /Primary root:/);
+  assert.match(preamble, /Granted project roots:/);
+  assert.match(preamble, new RegExp(repo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(preamble, new RegExp(docs.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(
+    preamble,
+    /You may read, edit, create, delete, commit, push, and run commands inside the primary root and the granted project roots listed above/,
+    "grant-aware local scopes should permit work inside every granted project root",
+  );
+  assert.doesNotMatch(
+    preamble,
+    /ask the user to reopen/,
+    "grant-aware local scopes should not tell the familiar to reopen when another granted project is requested",
+  );
+  assert.equal(
+    preamble.match(new RegExp(repo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"))?.length,
+    1,
+    "duplicate allowed roots should be listed once",
+  );
+}
+
+{
   const preamble = buildRuntimeScopePreamble({
     kind: "ssh",
     host: "build-box",

--- a/src/lib/chat-runtime-scope.ts
+++ b/src/lib/chat-runtime-scope.ts
@@ -23,7 +23,7 @@ type ResolveLocalRuntimeOptions = {
 };
 
 export type RuntimeScope =
-  | { kind: "local"; root: string }
+  | { kind: "local"; root: string; allowedProjectRoots?: string[] }
   | { kind: "ssh"; host: string; root: string };
 
 /** Normalize a path so Node's fs functions don't EISDIR on bare Windows
@@ -103,6 +103,21 @@ export async function resolveLocalRuntimeCwd(
 }
 
 export function buildRuntimeScopePreamble(scope: RuntimeScope): string {
+  if (scope.kind === "local") {
+    const allowedProjectRoots = uniqueAllowedProjectRoots(scope.root, scope.allowedProjectRoots);
+    if (allowedProjectRoots.length > 0) {
+      return [
+        "Runtime filesystem boundary:",
+        "- This is the local runtime boundary for this Cave session.",
+        `- Primary root: ${scope.root}`,
+        "- Granted project roots:",
+        ...allowedProjectRoots.map((root) => `  - ${root}`),
+        "- You may read, edit, create, delete, commit, push, and run commands inside the primary root and the granted project roots listed above.",
+        "- Do not read, edit, create, delete, commit, push, or run commands against files outside those listed roots.",
+      ].join("\n");
+    }
+  }
+
   const label = scope.kind === "ssh" ? `${scope.host}:${scope.root}` : scope.root;
   const boundary = scope.kind === "ssh"
     ? "This is the remote runtime boundary for this Cave session."
@@ -114,6 +129,19 @@ export function buildRuntimeScopePreamble(scope: RuntimeScope): string {
     "- Do not read, edit, create, delete, commit, push, or run commands against files outside this directory.",
     "- If the user asks for work outside this boundary, ask the user to reopen or start a Cave conversation in that project's runtime instead.",
   ].join("\n");
+}
+
+function uniqueAllowedProjectRoots(primaryRoot: string, roots: string[] | undefined): string[] {
+  const primary = primaryRoot.trim();
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const root of roots ?? []) {
+    const trimmed = root.trim();
+    if (!trimmed || trimmed === primary || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    unique.push(trimmed);
+  }
+  return unique;
 }
 
 export function buildPromptWithRuntimeScope(prompt: string, scope: RuntimeScope): string {

--- a/src/lib/chat-runtime-scope.ts
+++ b/src/lib/chat-runtime-scope.ts
@@ -132,13 +132,15 @@ export function buildRuntimeScopePreamble(scope: RuntimeScope): string {
 }
 
 function uniqueAllowedProjectRoots(primaryRoot: string, roots: string[] | undefined): string[] {
-  const primary = primaryRoot.trim();
+  const normalize = (value: string) => value.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+  const primary = normalize(primaryRoot);
   const seen = new Set<string>();
   const unique: string[] = [];
   for (const root of roots ?? []) {
     const trimmed = root.trim();
-    if (!trimmed || trimmed === primary || seen.has(trimmed)) continue;
-    seen.add(trimmed);
+    const normalized = normalize(trimmed);
+    if (!normalized || normalized === primary || seen.has(normalized)) continue;
+    seen.add(normalized);
     unique.push(trimmed);
   }
   return unique;


### PR DESCRIPTION
## Summary
- make local Cave chat runtime prompts include every project root granted to the familiar
- keep project access enforcement server-side through `assertProjectAccess` before prompt construction
- preserve existing chat cwd/resume behavior so old chats do not need to be erased

## Verification
- `pnpm typecheck`
- `node --experimental-strip-types src/lib/chat-runtime-scope.test.ts && node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts`
- `pnpm test:api`
- `git diff --check`

Co-authored-by: Nova <nova@openclaw.local>