### PR TITLE
fix(gantt): legend labels match the board's actual statuses

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -532,11 +532,15 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
           </div>
 
           {/* Legend */}
+          {/* Bars are coloured by the board's status. The four colours collapse
+              the six statuses: Running, Blocked and Done map 1:1; Backlog, Inbox
+              and Review share the "pending" colour. Labels match those actual
+              statuses (no invented "In Progress"/"At Risk"). */}
           <div className="cg-legend">
             <span className="cg-leg"><span className="cg-sw cg-sw--done" aria-hidden />Done</span>
-            <span className="cg-leg"><span className="cg-sw cg-sw--in-progress" aria-hidden />In Progress</span>
-            <span className="cg-leg"><span className="cg-sw cg-sw--pending" aria-hidden />Pending</span>
-            <span className="cg-leg"><span className="cg-sw cg-sw--at-risk" aria-hidden />At Risk</span>
+            <span className="cg-leg"><span className="cg-sw cg-sw--in-progress" aria-hidden />Running</span>
+            <span className="cg-leg" title="Backlog, Inbox and Review tasks"><span className="cg-sw cg-sw--pending" aria-hidden />Backlog · Inbox · Review</span>
+            <span className="cg-leg"><span className="cg-sw cg-sw--at-risk" aria-hidden />Blocked</span>
             <span className="cg-leg"><span className="cg-diamond cg-diamond--leg" aria-hidden />Milestone</span>
             <span className="cg-leg"><span className="cg-today-sw" aria-hidden />Today</span>
           </div>

--- a/src/components/board-schedule-window.test.ts
+++ b/src/components/board-schedule-window.test.ts
@@ -94,4 +94,13 @@ assert.match(gantt, /const familiarColor = \(id: string \| null\): string \| und
 assert.match(gantt, /color: byFamiliar \? familiarColor\(card\.familiarId\) : undefined/, "rows carry a familiar colour only in by-familiar mode");
 assert.match(gantt, /\.\.\.\(row\.color \? \{ background: row\.color \} : \{\}\)/, "the bar paints the familiar colour when present");
 
+// The legend labels match the board's actual statuses (no invented
+// "In Progress"/"At Risk"): Running, Blocked, Done map 1:1; the shared colour
+// is labelled with the three statuses it represents.
+assert.match(gantt, /cg-sw--in-progress" aria-hidden \/>Running</, "in-progress swatch is labelled Running");
+assert.match(gantt, /cg-sw--at-risk" aria-hidden \/>Blocked</, "at-risk swatch is labelled Blocked");
+assert.match(gantt, /cg-sw--pending" aria-hidden \/>Backlog · Inbox · Review</, "pending swatch lists the statuses it bundles");
+assert.doesNotMatch(gantt, />In Progress</, "the invented 'In Progress' label is gone");
+assert.doesNotMatch(gantt, />At Risk</, "the invented 'At Risk' label is gone");
+
 console.log("board-schedule-window.test.ts: ok");


### PR DESCRIPTION
## What

The Gantt legend used invented category names — **"In Progress"** and **"At Risk"** — that aren't part of the board's status vocabulary (Backlog, Inbox, Running, Review, Blocked, Done).

Relabelled the legend to the **actual statuses**:
- "In Progress" → **Running**
- "At Risk" → **Blocked**
- "Pending" → **Backlog · Inbox · Review** (the three statuses that share the one "pending" colour; also has a tooltip)
- Done / Milestone / Today unchanged

Bar colours and the 4-colour status mapping are unchanged — only the legend text. The legend already wraps (`flex-wrap: wrap`), so the longer label flows cleanly.

## Verification
- `pnpm typecheck` clean; `board-schedule-window.test.ts` passes with new assertions pinning the corrected labels (and asserting the old "In Progress"/"At Risk" strings are gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)