### PR TITLE
feat(ios): search individual chat threads from the Chats tab

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -28,7 +28,7 @@ struct ChatsHomeView: View {
             Group {
                 if app.familiars.isEmpty && app.threads.isEmpty {
                     emptyState
-                } else if filteredFamiliars.isEmpty && filteredGroups.isEmpty {
+                } else if filteredFamiliars.isEmpty && filteredGroups.isEmpty && matchingThreads.isEmpty {
                     ContentUnavailableView.search(text: query)
                 } else {
                     homeList
@@ -194,11 +194,38 @@ struct ChatsHomeView: View {
                     }
                 }
             }
+            if !matchingThreads.isEmpty {
+                Section("Chats") {
+                    ForEach(matchingThreads) { thread in
+                        Button { path.append(.thread(thread)) } label: {
+                            ThreadRow(thread: thread)
+                        }
+                        .buttonStyle(.plain)
+                        .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                        .contextMenu {
+                            Button { renamingThread = thread } label: {
+                                Label("Rename", systemImage: "pencil")
+                            }
+                            Button { app.setThreadPinned(thread, !thread.pinned) } label: {
+                                Label(thread.pinned ? "Unpin" : "Pin",
+                                      systemImage: thread.pinned ? "pin.slash" : "pin")
+                            }
+                            Button { app.setThreadArchived(thread, !thread.archived) } label: {
+                                Label(thread.archived ? "Unarchive" : "Archive",
+                                      systemImage: thread.archived ? "tray.and.arrow.up" : "archivebox")
+                            }
+                            Button(role: .destructive) { pendingDelete = thread } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                    }
+                }
+            }
         }
         .listStyle(.plain)
         .environment(\.editMode, $editMode)
         .threadRenameAlert($renamingThread) { thread, name in app.renameThread(thread, to: name) }
-        .confirmationDialog("Delete this group chat?",
+        .confirmationDialog("Delete this chat?",
                             isPresented: deleteDialogBinding,
                             titleVisibility: .visible,
                             presenting: pendingDelete) { thread in
@@ -214,6 +241,27 @@ struct ChatsHomeView: View {
 
     private var deleteDialogBinding: Binding<Bool> {
         Binding(get: { pendingDelete != nil }, set: { if !$0 { pendingDelete = nil } })
+    }
+
+    /// Direct (non-group) threads matching the search query by title, a member's
+    /// name, or message text. Empty while not searching (groups have their own
+    /// section; this surfaces individual conversations otherwise filed under a
+    /// familiar).
+    private var matchingThreads: [ChatThread] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !q.isEmpty else { return [] }
+        return app.threads
+            .filter { !$0.isGroup && (showArchived || !$0.archived) }
+            .filter { thread in
+                if thread.title.lowercased().contains(q) { return true }
+                if thread.familiarIds.compactMap(app.familiar)
+                    .contains(where: { $0.displayName.lowercased().contains(q) }) { return true }
+                return thread.messages.contains { $0.text.lowercased().contains(q) }
+            }
+            .sorted { a, b in
+                if a.pinned != b.pinned { return a.pinned }
+                return a.updatedAt > b.updatedAt
+            }
     }
 
     /// Familiars matching the search query (name or role). Empty query → all.

--- a/scripts/ios-thread-search.test.mjs
+++ b/scripts/ios-thread-search.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const home = await readFile(
+  new URL("../apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift", import.meta.url),
+  "utf8",
+);
+
+// A computed that finds direct threads by title, member name, and message text.
+assert.match(home, /private var matchingThreads: \[ChatThread\]/, "should expose matchingThreads");
+assert.match(home, /thread\.title\.lowercased\(\)\.contains\(q\)/, "should match by thread title");
+assert.match(home, /\$0\.displayName\.lowercased\(\)\.contains\(q\)/, "should match by a member's name");
+assert.match(home, /thread\.messages\.contains \{ \$0\.text\.lowercased\(\)\.contains\(q\) \}/, "should match by message text");
+assert.match(home, /\.filter \{ !\$0\.isGroup && \(showArchived \|\| !\$0\.archived\) \}/, "should search direct, non-archived threads");
+
+// A "Chats" results section, shown only when there are matches.
+assert.match(home, /if !matchingThreads\.isEmpty \{[\s\S]*Section\("Chats"\) \{[\s\S]*ForEach\(matchingThreads\)/, "should render a Chats results section");
+assert.match(home, /path\.append\(\.thread\(thread\)\)/, "results should open the thread");
+
+// Empty-state accounts for thread matches too.
+assert.match(
+  home,
+  /filteredFamiliars\.isEmpty && filteredGroups\.isEmpty && matchingThreads\.isEmpty/,
+  "search empty-state should consider matching threads",
+);
+
+console.log("ios-thread-search.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -495,6 +495,7 @@ export const SUITES = {
     "scripts/ios-thread-rename.test.mjs",
     "scripts/ios-archive-threads.test.mjs",
     "scripts/ios-pin-threads.test.mjs",
+    "scripts/ios-thread-search.test.mjs",
     "scripts/ios-reorder-familiars.test.mjs",
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/mobile-tailscale.test.mjs",


### PR DESCRIPTION
## What

The Chats search only filtered the **familiar roster** and **group threads** — individual **direct-thread conversations were unsearchable** from home, findable only by knowing which familiar they were filed under.

This adds a **"Chats" results section** (shown while searching) listing direct threads whose **title**, a **member's name**, or any **message text** matches the query. Tap a result to open it; rows carry the usual rename / pin / archive / delete context menu. Results are **pinned-first, then newest**.

- New `matchingThreads` computed in `ChatsHomeView` (content + title + member-name search over non-group, non-archived threads).
- Search empty-state (`ContentUnavailableView.search`) now also accounts for thread matches.
- The delete confirmation copy is generalised ("Delete this group chat?" → "Delete this chat?") since it now covers direct threads too.

## Verification

- `pnpm test:mobile` → **✓ 32 test file(s) passed** (full suite; new `scripts/ios-thread-search.test.mjs` registered).
- `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED**.

Interactive search (type a query → tap a result) needs gestures I can't drive headlessly without `idb`, so it rests on build + assertion test.

> Built via an atomic sibling-worktree one-shot (commit+push before build) because the in-repo `.worktrees/` keeps getting swept by concurrent-session cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)