### PR TITLE
feat(board): familiar colour legend in the by-familiar Gantt

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -285,7 +285,7 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
         start: cr.start,
         end: cr.end,
         category: statusCategory(card.status),
-        color: byFamiliar ? familiarColor(card.familiarId) : undefined,
+        color: byFamiliar ? (familiarColor(card.familiarId) ?? "var(--text-muted)") : undefined,
       });
       group.firstStart = Math.min(group.firstStart, cr.start.getTime());
     }
@@ -523,16 +523,27 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
             ))}
           </div>
 
-          {/* Legend */}
-          {/* Bars are coloured by the board's status. The four colours collapse
-              the six statuses: Running, Blocked and Done map 1:1; Backlog, Inbox
-              and Review share the "pending" colour. Labels match those actual
-              statuses (no invented "In Progress"/"At Risk"). */}
+          {/* Legend: per-familiar colour swatches when grouped by familiar
+              (matching the bars' encoding); otherwise the status categories.
+              The four status colours collapse the six statuses — Running,
+              Blocked and Done map 1:1; Backlog, Inbox and Review share the
+              "pending" colour. */}
           <div className="cg-legend">
-            <span className="cg-leg"><span className="cg-sw cg-sw--done" aria-hidden />Done</span>
-            <span className="cg-leg"><span className="cg-sw cg-sw--in-progress" aria-hidden />Running</span>
-            <span className="cg-leg" title="Backlog, Inbox and Review tasks"><span className="cg-sw cg-sw--pending" aria-hidden />Backlog · Inbox · Review</span>
-            <span className="cg-leg"><span className="cg-sw cg-sw--at-risk" aria-hidden />Blocked</span>
+            {groupMode === "familiar" ? (
+              groups.map((g) => (
+                <span key={g.key} className="cg-leg">
+                  <span className="cg-sw" style={{ background: familiarColor(g.key === "__unassigned__" ? null : g.key) ?? "var(--text-muted)" }} aria-hidden />
+                  {g.name}
+                </span>
+              ))
+            ) : (
+              <>
+                <span className="cg-leg"><span className="cg-sw cg-sw--done" aria-hidden />Done</span>
+                <span className="cg-leg"><span className="cg-sw cg-sw--in-progress" aria-hidden />Running</span>
+                <span className="cg-leg" title="Backlog, Inbox and Review tasks"><span className="cg-sw cg-sw--pending" aria-hidden />Backlog · Inbox · Review</span>
+                <span className="cg-leg"><span className="cg-sw cg-sw--at-risk" aria-hidden />Blocked</span>
+              </>
+            )}
             <span className="cg-leg"><span className="cg-diamond cg-diamond--leg" aria-hidden />Milestone</span>
             <span className="cg-leg"><span className="cg-today-sw" aria-hidden />Today</span>
           </div>

--- a/src/components/board-schedule-window.test.ts
+++ b/src/components/board-schedule-window.test.ts
@@ -89,16 +89,23 @@ assert.match(styles, /\.cg-left \{[\s\S]*?grid-template-columns: 190px 58px 58px
 
 // By-familiar grouping colour-codes bars by familiar.
 assert.match(gantt, /const familiarColor = \(id: string \| null\): string \| undefined =>/, "a per-familiar colour helper exists");
-assert.match(gantt, /color: byFamiliar \? familiarColor\(card\.familiarId\) : undefined/, "rows carry a familiar colour only in by-familiar mode");
+assert.match(gantt, /color: byFamiliar \? \(familiarColor\(card\.familiarId\) \?\? "var\(--text-muted\)"\) : undefined/, "rows carry a familiar colour (or neutral fallback) only in by-familiar mode");
 assert.match(gantt, /\.\.\.\(row\.color \? \{ background: row\.color \} : \{\}\)/, "the bar paints the familiar colour when present");
 
-// The legend labels match the board's actual statuses (no invented
-// "In Progress"/"At Risk"): Running, Blocked, Done map 1:1; the shared colour
-// is labelled with the three statuses it represents.
+// The status legend (shown when NOT grouping by familiar) uses the board's
+// actual statuses (no invented "In Progress"/"At Risk"): Running, Blocked, Done
+// map 1:1; the shared colour is labelled with the three statuses it represents.
 assert.match(gantt, /cg-sw--in-progress" aria-hidden \/>Running</, "in-progress swatch is labelled Running");
 assert.match(gantt, /cg-sw--at-risk" aria-hidden \/>Blocked</, "at-risk swatch is labelled Blocked");
 assert.match(gantt, /cg-sw--pending" aria-hidden \/>Backlog · Inbox · Review</, "pending swatch lists the statuses it bundles");
 assert.doesNotMatch(gantt, />In Progress</, "the invented 'In Progress' label is gone");
 assert.doesNotMatch(gantt, />At Risk</, "the invented 'At Risk' label is gone");
+
+// The legend swaps to per-familiar swatches when grouping by familiar. The Owner
+// column was removed (#1671), so the gate is now `groupMode === "familiar"`
+// directly rather than the old `hideOwner` alias.
+assert.match(gantt, /\{groupMode === "familiar" \? \(/, "the legend is conditional on the by-familiar mode");
+assert.match(gantt, /groups\.map\(\(g\) => \(/, "the legend renders a swatch per familiar group");
+assert.match(gantt, /background: familiarColor\(g\.key === "__unassigned__" \? null : g\.key\) \?\? "var\(--text-muted\)"/, "familiar legend swatches match the bar colours");
 
 console.log("board-schedule-window.test.ts: ok");


### PR DESCRIPTION
## Summary

When the Gantt is grouped by familiar, the bars are coloured by familiar (#1666) but the legend still listed status categories (Done/In Progress/Pending/At Risk) — which no longer describe the bars. This swaps the legend, in that mode only, to a **per-familiar swatch + name** list so the colours are explained. Project and Task grouping keep the status-category legend.

- Familiar legend entries reuse the exact same colour the bars use (the familiar's own colour, or a stable hue from its id).
- Unassigned rows now take a neutral colour so the legend fully explains every bar.
- Milestone and Today markers stay in both modes.

## Verification (ran the app)
Familiar-grouped Gantt legend renders `Sage · Cody · Nova · Charm · Unassigned · Milestone · Today`, and each familiar swatch colour matches its bars exactly (e.g. Sage `rgb(69,77,196)`, Cody `rgb(156,69,196)`, Nova `rgb(69,162,196)`). `tsc --noEmit` clean; `board-schedule-window.test.ts` extended and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)