### PR TITLE
feat(board): remove the Owner column from Gantt views

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -31,7 +31,6 @@ type GanttRow = {
   cardId: string;       // the task this row belongs to (selected on click)
   stepId?: string;      // set in task mode — the step this bar drags/patches
   label: string;
-  owner: string;
   start: Date;
   end: Date;
   category: GanttCategory;
@@ -253,7 +252,6 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
           cardId: card.id,
           stepId: step.id,
           label: step.text,
-          owner: ownerName(card.familiarId),
           start: a <= b ? a : b,
           end: a <= b ? b : a,
           category: step.done ? "done" : statusCategory(card.status),
@@ -284,7 +282,6 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
         rowId: card.id,
         cardId: card.id,
         label: card.title,
-        owner: ownerName(card.familiarId),
         start: cr.start,
         end: cr.end,
         category: statusCategory(card.status),
@@ -350,9 +347,6 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
   // Focus: when a group is clicked, render only it (range stays global so bars don't jump).
   const focused = focusedKey && groups.some((g) => g.key === focusedKey) ? focusedKey : null;
   const visibleGroups = focused ? groups.filter((g) => g.key === focused) : groups;
-  // Grouping by familiar already names the owner in every group header, so the
-  // per-row Owner column just repeats it — drop the column in that mode.
-  const hideOwner = groupMode === "familiar";
 
   const min = new Date(Math.min(...allRows.map((r) => r.start.getTime())));
   const max = new Date(Math.max(...allRows.map((r) => r.end.getTime())));
@@ -396,12 +390,11 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
         <button type="button" className="board-group-toggle-btn" onClick={scrollToToday} disabled={todayX === null} title="Scroll the timeline to today">Today</button>
       </div>
       <div className="board-gantt__scroll" ref={scrollRef}>
-        <div className={`cg${hideOwner ? " cg--no-owner" : ""}`} style={{ ["--cg-day" as string]: `${DAY_W}px`, ["--cg-tl" as string]: `${timelineW}px` }}>
+        <div className="cg" style={{ ["--cg-day" as string]: `${DAY_W}px`, ["--cg-tl" as string]: `${timelineW}px` }}>
           {/* Header: left column titles + week band */}
           <div className="cg-head">
             <div className="cg-left cg-left--head">
               <span className="cg-c-task">Group / Task</span>
-              {!hideOwner && <span className="cg-c-owner">Owner</span>}
               <span className="cg-c-date">Start</span>
               <span className="cg-c-date">End</span>
               <span className="cg-c-st">St</span>
@@ -494,7 +487,6 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
                     >
                       <span className="cg-left">
                         <span className="cg-c-task">{row.label}</span>
-                        {!hideOwner && <span className="cg-c-owner">{row.owner}</span>}
                         <span className="cg-c-date">{formatLabel(previewStart)}</span>
                         <span className="cg-c-date">{formatLabel(previewEnd)}</span>
                         <span className="cg-c-st"><span className={`cg-dot cg-dot--${cat}`} aria-hidden /></span>

--- a/src/components/board-schedule-window.test.ts
+++ b/src/components/board-schedule-window.test.ts
@@ -77,17 +77,15 @@ assert.match(
 assert.doesNotMatch(gantt, /const rangeStart = startOfWeekMon\(min\)/, "the leading Monday-snap is gone");
 assert.match(gantt, /width: Math\.min\(7, totalDays - i\)/, "the trailing week column is clamped to the range");
 
-// Grouping by familiar drops the redundant Owner column (header + cells + grid).
-assert.match(gantt, /const hideOwner = groupMode === "familiar"/, "owner column is hidden when grouping by familiar");
-assert.match(gantt, /className=\{`cg\$\{hideOwner \? " cg--no-owner" : ""\}`\}/, "the no-owner modifier class is applied to the grid");
-assert.match(gantt, /\{!hideOwner && <span className="cg-c-owner">Owner<\/span>\}/, "the Owner header is conditional");
-assert.match(gantt, /\{!hideOwner && <span className="cg-c-owner">\{row\.owner\}<\/span>\}/, "the per-row owner cell is conditional");
-assert.match(styles, /\.cg--no-owner \.cg-left \{ flex-basis: 332px; grid-template-columns: 190px 58px 58px 26px; \}/, "the no-owner layout drops the owner column width");
-assert.match(styles, /\.cg--no-owner \.cg-grouprow \.cg-left \{ grid-template-columns: auto 1fr auto; \}/, "group rows keep their own three-column template");
-
-// Task-mode step rows carry the parent card's owner (the Owner column was blank).
-assert.match(gantt, /label: step\.text,\s*owner: ownerName\(card\.familiarId\),/, "task-mode step rows show the card's owner");
-assert.doesNotMatch(gantt, /owner: "",/, "the empty task-mode owner placeholder is gone");
+// The Owner column was removed from every Gantt mode — familiar bar colour now
+// carries the owner cue. No header, per-row cell, grid track, flag, or row field
+// for the owner column remains.
+assert.doesNotMatch(gantt, /hideOwner/, "the hideOwner flag is gone");
+assert.doesNotMatch(gantt, /cg-c-owner/, "no Owner column header/cell remains in the markup");
+assert.doesNotMatch(gantt, /cg--no-owner/, "the no-owner modifier class is gone");
+assert.doesNotMatch(gantt, /row\.owner|owner: ownerName/, "GanttRow no longer carries an owner field");
+assert.doesNotMatch(styles, /cg-c-owner|cg--no-owner/, "Owner column styles are removed");
+assert.match(styles, /\.cg-left \{[\s\S]*?grid-template-columns: 190px 58px 58px 26px;/, "the left table uses the four-column (ownerless) layout");
 
 // By-familiar grouping colour-codes bars by familiar.
 assert.match(gantt, /const familiarColor = \(id: string \| null\): string \| undefined =>/, "a per-familiar colour helper exists");

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1614,19 +1614,15 @@
   position: sticky;
   left: 0;
   z-index: 2;
-  flex: 0 0 416px;
+  flex: 0 0 332px;
   display: grid;
-  grid-template-columns: 190px 84px 58px 58px 26px;
+  grid-template-columns: 190px 58px 58px 26px;
   align-items: center;
   background: var(--bg-base);
   border-right: 1px solid var(--border-strong);
 }
-/* Grouped by familiar: the Owner column is redundant with the group header, so
-   it's dropped from the markup — narrow the left table to its four columns. */
-.cg--no-owner .cg-left { flex-basis: 332px; grid-template-columns: 190px 58px 58px 26px; }
-.cg--no-owner .cg-grouprow .cg-left { grid-template-columns: auto 1fr auto; }
 .cg-left > span { padding: 0 8px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.cg-c-owner, .cg-c-date { font-size: 11px; color: var(--text-secondary); }
+.cg-c-date { font-size: 11px; color: var(--text-secondary); }
 .cg-c-date { text-align: right; }
 .cg-c-st { display: flex; justify-content: center; }
 


### PR DESCRIPTION
Removes the **Owner** column from the Tasks Gantt left table (every grouping mode).

## Why
The column was redundant: group headers already name the owner when grouping by familiar, and #1666's per-familiar **bar colouring** now carries the owner cue in every mode. The text column just repeated it.

## What
- Drop the Owner header span + per-row cell from `board-gantt.tsx`.
- Remove the `GanttRow.owner` field and its assignments, plus the `hideOwner` flag and the `cg--no-owner` conditional.
- Collapse the left table to its always-four-column layout in `board.css` (`190px 58px 58px 26px`, basis 332px); remove the `.cg--no-owner` overrides and `.cg-c-owner` style.
- Update `board-schedule-window.test.ts` to assert the column is gone (and keep the familiar-colour assertions, which are unaffected).

**Unchanged:** familiar bar colouring (#1666), group-header owner names, and the unscheduled-tray owner labels (`ownerName` is still used there).

## Verification
- `tsc --noEmit` clean; `board-schedule-window.test.ts` passes.
- Visual check of the Gantt in-app (screenshot below / in review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)