### PR TITLE
polish(ux): adopt skeleton/empty/relative-time conventions in 3 stragglers

### DIFF
--- a/src/components/project-tree.tsx
+++ b/src/components/project-tree.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import { Icon } from "@/lib/icon";
 import { SkeletonRows } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/ui/empty-state";
 import { nextVisibleIndex, parentIndexByDepth } from "@/lib/tree-keynav";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -225,9 +226,12 @@ export const ProjectTree = forwardRef<ProjectTreeHandle, Props>(
     }
     if (entries.length === 0) {
       return (
-        <p className="py-3 pl-1 text-[11px] text-[var(--text-muted)]">
-          No files found.
-        </p>
+        <EmptyState
+          compact
+          icon="ph:folder-open"
+          headline="No files found"
+          subtitle="This project has no files, or they're all filtered out."
+        />
       );
     }
 

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { Icon } from "@/lib/icon";
 import { SettingsGroup } from "@/components/ui/settings-group";
+import { RelativeTime } from "@/components/ui/relative-time";
+import { SkeletonRows } from "@/components/ui/skeleton";
 import { FamiliarStudioInlinePanel } from "@/components/familiar-studio-inline";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { FamiliarPinOrder } from "@/components/familiar-pin-order";
@@ -391,7 +393,7 @@ function DaemonSection() {
           <SettingsKV label="Coven version" value={status.covenVersion ?? "—"} />
           <SettingsKV label="API version"   value={status.apiVersion   ?? "—"} />
           <SettingsKV label="Socket"        value={status.daemon?.socket ?? "—"} mono />
-          <SettingsKV label="Started"       value={status.daemon?.startedAt ? new Date(status.daemon.startedAt).toLocaleString() : "—"} />
+          <SettingsKV label="Started"       value={<RelativeTime iso={status.daemon?.startedAt} fallback="—" />} />
           <SettingsKV label="Workspace"     value={status.workspacePath ?? "—"} mono />
         </SettingsGroup>
       )}
@@ -564,7 +566,7 @@ function FamiliarsSection() {
   if (!loaded) {
     return (
       <div className="settings-familiars-panel" role="status" aria-busy="true">
-        <p className="settings-familiars-panel__empty">Loading familiars…</p>
+        <SkeletonRows count={4} />
       </div>
     );
   }
@@ -1444,7 +1446,7 @@ function SettingsRow({ label, description, comingSoon, children }: { label: stri
   );
 }
 
-function SettingsKV({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+function SettingsKV({ label, value, mono }: { label: string; value: ReactNode; mono?: boolean }) {
   return (
     <div className="flex items-center justify-between gap-4 px-4 py-3">
       <span className="text-[12px] text-[var(--text-secondary)]">{label}</span>

--- a/src/components/surface-loading-states.test.ts
+++ b/src/components/surface-loading-states.test.ts
@@ -110,11 +110,17 @@ for (const [file, label] of [
   ["./board-inspector.tsx", "Board inspector linked context"],
   ["./project-tree.tsx", "Project tree"],
   ["./journal/journal-entries.tsx", "Journal entries pane"],
+  ["./workflows/workflow-library.tsx", "Workflow library"],
 ]) {
   const src = read(file);
   assert.doesNotMatch(src, />Loading…</, `${label} no longer shows a bare Loading… line`);
   assert.match(src, /<SkeletonRows/, `${label} shows shared skeleton rows on first load`);
 }
+// Workflow library: a bare "Loading workflow manifests..." string is gone, and
+// the in-list "no search match" case uses the shared EmptyState (not bare text).
+const workflowLib = read("./workflows/workflow-library.tsx");
+assert.doesNotMatch(workflowLib, /Loading workflow manifests/, "Workflow library no longer shows a bare loading line");
+assert.match(workflowLib, /headline="No workflows match"/, "Workflow library search-no-results uses EmptyState");
 const docPreview = read("./library-doc-preview.tsx");
 assert.doesNotMatch(docPreview, /library-preview-empty-text">Loading…</, "Library doc preview no longer shows a bare Loading… line");
 assert.match(docPreview, /<SkeletonGroup[\s\S]{0,200}<Skeleton variant="text"/, "Library doc preview shows a document-shaped skeleton on first load");

--- a/src/components/workflows/workflow-library.tsx
+++ b/src/components/workflows/workflow-library.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { isPersonalWorkflow, isPublicTemplate, type WorkflowSummary } from "@/lib/workflows";
 import { EmptyState } from "@/components/ui/empty-state";
+import { SkeletonRows } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 
 type WorkflowLibraryProps = {
@@ -163,7 +164,7 @@ export function WorkflowLibrary({
       </label>
 
       {!loaded ? (
-        <div className="workflow-library-state">Loading workflow manifests...</div>
+        <SkeletonRows count={6} className="workflow-library-list" />
       ) : error ? (
         <div className="workflow-library-state workflow-library-state-error" role="alert">
           <span className="workflow-library-state-error-msg">
@@ -189,7 +190,12 @@ export function WorkflowLibrary({
       ) : (
         <div className="workflow-library-list">
           {visible.length === 0 && (
-            <div className="workflow-library-state">No workflows match “{query.trim()}”.</div>
+            <EmptyState
+              compact
+              icon="ph:magnifying-glass"
+              headline="No workflows match"
+              subtitle={`Nothing matches “${query.trim()}”. Try a different term or clear the search.`}
+            />
           )}
           {groups.personal.length > 0 && (
             <section className="workflow-library-group" aria-label="Personal workflows">


### PR DESCRIPTION
## What

A few surfaces never adopted the loading / empty / relative-time conventions that #1610, #1607, and #1612 standardized everywhere else. Convention-only cleanup — no behavior change.

| Surface | Before | After |
|---|---|---|
| Settings → Daemon **Started** | raw `toLocaleString()` | `<RelativeTime>` (relative + hover tooltip) |
| Settings → **Familiars** loading | bare `Loading familiars…` | `<SkeletonRows>` |
| Code → **project tree** empty | bare `No files found.` `<p>` | `<EmptyState compact>` |
| Workflows **library** loading / no-match | bare `Loading workflow manifests...` / bare text | `<SkeletonRows>` / `<EmptyState compact>` |

`SettingsKV`'s `value` was widened to `ReactNode` to accept the `<RelativeTime>` node.

## Tests

Extended `surface-loading-states.test.ts` to cover the workflow library (skeleton on load + `EmptyState` headline on no-match). Typecheck clean; settings/project/loading-state suites pass; production build green.

## Verification note

These are mechanical swaps to battle-tested shared components (`RelativeTime`/`SkeletonRows`/`EmptyState`, already used across Board/GitHub/Vault/etc.). The affected states are transient or data-dependent (daemon uptime, a roster mid-fetch, an empty project, a workflow search miss), so verification is via typecheck + the source-guard test + prod build rather than a headless screenshot of each substate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)