### PR TITLE
feat(ios): mute chat thread notifications

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -677,6 +677,15 @@ final class AppModel {
         persistThreads()
     }
 
+    /// Mute or unmute a thread's notifications (persisted; honoured by the
+    /// notification path when it lands).
+    func setThreadMuted(_ thread: ChatThread, _ muted: Bool) {
+        guard let target = threads.first(where: { $0.id == thread.id }),
+              target.muted != muted else { return }
+        target.muted = muted
+        persistThreads()
+    }
+
     func touch(_ thread: ChatThread) {
         // Move the most recently active thread to the top, then persist.
         if let idx = threads.firstIndex(where: { $0.id == thread.id }), idx != 0 {

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -29,6 +29,7 @@ struct ThreadSnapshot: Codable, Identifiable {
     /// Optional so snapshots written before archiving existed still decode.
     var archived: Bool?
     var pinned: Bool?
+    var muted: Bool?
 }
 
 /// A conversation thread. One familiar = a direct chat; several = a group.
@@ -51,6 +52,7 @@ final class ChatThread: Identifiable, Hashable {
     var updatedAt: Date
     var archived: Bool = false
     var pinned: Bool = false
+    var muted: Bool = false
 
     var isGroup: Bool { familiarIds.count > 1 }
     var activeStreams: Int { messages.filter { $0.streaming }.count }
@@ -75,12 +77,13 @@ final class ChatThread: Identifiable, Hashable {
         self.updatedAt = s.updatedAt
         self.archived = s.archived ?? false
         self.pinned = s.pinned ?? false
+        self.muted = s.muted ?? false
     }
 
     var snapshot: ThreadSnapshot {
         ThreadSnapshot(id: id, title: title, familiarIds: familiarIds,
                        sessionIds: sessionIds, messages: messages,
-                       updatedAt: updatedAt, archived: archived, pinned: pinned)
+                       updatedAt: updatedAt, archived: archived, pinned: pinned, muted: muted)
     }
 
     /// Send a user message and stream replies from every familiar in the thread.

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -168,6 +168,10 @@ struct ChatsHomeView: View {
                                 Label(thread.pinned ? "Unpin" : "Pin",
                                       systemImage: thread.pinned ? "pin.slash" : "pin")
                             }
+                            Button { app.setThreadMuted(thread, !thread.muted) } label: {
+                                Label(thread.muted ? "Unmute" : "Mute",
+                                      systemImage: thread.muted ? "bell" : "bell.slash")
+                            }
                             Button { app.setThreadArchived(thread, !thread.archived) } label: {
                                 Label(thread.archived ? "Unarchive" : "Archive",
                                       systemImage: thread.archived ? "tray.and.arrow.up" : "archivebox")
@@ -209,6 +213,10 @@ struct ChatsHomeView: View {
                             Button { app.setThreadPinned(thread, !thread.pinned) } label: {
                                 Label(thread.pinned ? "Unpin" : "Pin",
                                       systemImage: thread.pinned ? "pin.slash" : "pin")
+                            }
+                            Button { app.setThreadMuted(thread, !thread.muted) } label: {
+                                Label(thread.muted ? "Unmute" : "Mute",
+                                      systemImage: thread.muted ? "bell" : "bell.slash")
                             }
                             Button { app.setThreadArchived(thread, !thread.archived) } label: {
                                 Label(thread.archived ? "Unarchive" : "Archive",
@@ -395,6 +403,10 @@ struct ThreadRow: View {
                     if thread.pinned {
                         Image(systemName: "pin.fill")
                             .font(.caption2).foregroundStyle(.orange)
+                    }
+                    if thread.muted {
+                        Image(systemName: "bell.slash.fill")
+                            .font(.caption2).foregroundStyle(.secondary)
                     }
                     if thread.isGroup {
                         Image(systemName: "person.2.fill")

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -122,6 +122,10 @@ struct FamiliarThreadsView: View {
                                 Label(thread.pinned ? "Unpin" : "Pin",
                                       systemImage: thread.pinned ? "pin.slash" : "pin")
                             }
+                            Button { app.setThreadMuted(thread, !thread.muted) } label: {
+                                Label(thread.muted ? "Unmute" : "Mute",
+                                      systemImage: thread.muted ? "bell" : "bell.slash")
+                            }
                             Button { app.setThreadArchived(thread, !thread.archived) } label: {
                                 Label(thread.archived ? "Unarchive" : "Archive",
                                       systemImage: thread.archived ? "tray.and.arrow.up" : "archivebox")

--- a/scripts/ios-mute-threads.test.mjs
+++ b/scripts/ios-mute-threads.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+const read = (rel) => readFile(new URL(`../${rel}`, import.meta.url), "utf8");
+const iosRoot = "apps/ios/CovenCave/CovenCave";
+
+const thread = await read(`${iosRoot}/State/ChatThread.swift`);
+const model = await read(`${iosRoot}/State/AppModel.swift`);
+const home = await read(`${iosRoot}/Views/ChatsHomeView.swift`);
+const familiarThreads = await read(`${iosRoot}/Views/FamiliarThreadsView.swift`);
+
+assert.match(thread, /var muted: Bool = false/, "ChatThread should carry a muted flag");
+assert.match(thread, /var muted: Bool\?/, "ThreadSnapshot.muted should be optional for back-compat");
+assert.match(thread, /self\.muted = s\.muted \?\? false/, "snapshot decode should default muted to false");
+assert.match(thread, /pinned: pinned, muted: muted\)/, "snapshot encode should include muted");
+
+assert.match(
+  model,
+  /func setThreadMuted\(_ thread: ChatThread, _ muted: Bool\) \{[\s\S]*target\.muted = muted[\s\S]*persistThreads\(\)/,
+  "AppModel.setThreadMuted should set the flag and persist",
+);
+
+for (const [name, src] of [["ChatsHomeView", home], ["FamiliarThreadsView", familiarThreads]]) {
+  assert.match(src, /app\.setThreadMuted\(thread, !thread\.muted\)/, `${name} should toggle mute state`);
+  assert.match(src, /thread\.muted \? "Unmute" : "Mute"/, `${name} should label the mute action by state`);
+}
+assert.match(home, /if thread\.muted \{[\s\S]*bell\.slash\.fill/, "ThreadRow should show a muted indicator");
+
+console.log("ios-mute-threads.test.mjs: ok");

--- a/scripts/ios-pin-threads.test.mjs
+++ b/scripts/ios-pin-threads.test.mjs
@@ -12,7 +12,7 @@ const familiarThreads = await read(`${iosRoot}/Views/FamiliarThreadsView.swift`)
 assert.match(thread, /var pinned: Bool = false/, "ChatThread should carry a pinned flag");
 assert.match(thread, /var pinned: Bool\?/, "ThreadSnapshot.pinned should be optional for back-compat");
 assert.match(thread, /self\.pinned = s\.pinned \?\? false/, "snapshot decode should default pinned to false");
-assert.match(thread, /archived: archived, pinned: pinned\)/, "snapshot encode should include pinned");
+assert.match(thread, /archived: archived, pinned: pinned/, "snapshot encode should include pinned");
 
 assert.match(
   model,

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -496,6 +496,7 @@ export const SUITES = {
     "scripts/ios-archive-threads.test.mjs",
     "scripts/ios-pin-threads.test.mjs",
     "scripts/ios-thread-search.test.mjs",
+    "scripts/ios-mute-threads.test.mjs",
     "scripts/ios-reorder-familiars.test.mjs",
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/mobile-tailscale.test.mjs",


### PR DESCRIPTION
## What

Adds a per-thread **Mute** toggle so noisy chats can be silenced.

There is **no notification delivery path in the iOS app yet** (it's "Phase 2" — only the `CAVE_OPEN_THREAD` deep-link hook exists). So this **persists the preference and surfaces it**; whatever notification logic lands will read `thread.muted`.

- **`ChatThread.muted`** — persisted flag (optional in `ThreadSnapshot` for backward-compatible decoding).
- **`AppModel.setThreadMuted(_:_:)`** — toggles + persists.
- **`ChatsHomeView`** (group rows + the search-results rows) and **`FamiliarThreadsView`**: a **Mute/Unmute** context-menu entry. **`ThreadRow`** shows a `bell.slash` glyph on muted threads.

## Verification

- `pnpm test:mobile` → **✓ 33 test file(s) passed** (full suite; new `scripts/ios-mute-threads.test.mjs` registered).
- `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED**.
- Pre-empted a cross-test break: adding `muted` to the snapshot literal would have broken `ios-pin-threads.test.mjs`'s exact-paren regex, so I loosened it in the same change (verified green).

Interactive mute (long-press → Mute) needs gestures I can't drive headlessly without `idb`, so it rests on build + assertion test.

> Built via an atomic sibling-worktree one-shot (commit+push before build) because the in-repo `.worktrees/` keeps getting swept by concurrent-session cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)