### PR TITLE
feat(board): familiar colour legend in the by-familiar Gantt

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -285,7 +285,7 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
         start: cr.start,
         end: cr.end,
         category: statusCategory(card.status),
-        color: byFamiliar ? familiarColor(card.familiarId) : undefined,
+        color: byFamiliar ? (familiarColor(card.familiarId) ?? "var(--text-muted)") : undefined,
       });
       group.firstStart = Math.min(group.firstStart, cr.start.getTime());
     }
@@ -529,10 +529,23 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
               and Review share the "pending" colour. Labels match those actual
               statuses (no invented "In Progress"/"At Risk"). */}
           <div className="cg-legend">
-            <span className="cg-leg"><span className="cg-sw cg-sw--done" aria-hidden />Done</span>
-            <span className="cg-leg"><span className="cg-sw cg-sw--in-progress" aria-hidden />Running</span>
-            <span className="cg-leg" title="Backlog, Inbox and Review tasks"><span className="cg-sw cg-sw--pending" aria-hidden />Backlog · Inbox · Review</span>
-            <span className="cg-leg"><span className="cg-sw cg-sw--at-risk" aria-hidden />Blocked</span>
+            {groupMode === "familiar" ? (
+              // Bars are coloured by familiar in this mode, so the legend maps
+              // each familiar's colour to its name instead of the statuses.
+              groups.map((g) => (
+                <span key={g.key} className="cg-leg">
+                  <span className="cg-sw" style={{ background: familiarColor(g.key === "__unassigned__" ? null : g.key) ?? "var(--text-muted)" }} aria-hidden />
+                  {g.name}
+                </span>
+              ))
+            ) : (
+              <>
+                <span className="cg-leg"><span className="cg-sw cg-sw--done" aria-hidden />Done</span>
+                <span className="cg-leg"><span className="cg-sw cg-sw--in-progress" aria-hidden />Running</span>
+                <span className="cg-leg" title="Backlog, Inbox and Review tasks"><span className="cg-sw cg-sw--pending" aria-hidden />Backlog · Inbox · Review</span>
+                <span className="cg-leg"><span className="cg-sw cg-sw--at-risk" aria-hidden />Blocked</span>
+              </>
+            )}
             <span className="cg-leg"><span className="cg-diamond cg-diamond--leg" aria-hidden />Milestone</span>
             <span className="cg-leg"><span className="cg-today-sw" aria-hidden />Today</span>
           </div>

--- a/src/components/board-schedule-window.test.ts
+++ b/src/components/board-schedule-window.test.ts
@@ -89,8 +89,13 @@ assert.match(styles, /\.cg-left \{[\s\S]*?grid-template-columns: 190px 58px 58px
 
 // By-familiar grouping colour-codes bars by familiar.
 assert.match(gantt, /const familiarColor = \(id: string \| null\): string \| undefined =>/, "a per-familiar colour helper exists");
-assert.match(gantt, /color: byFamiliar \? familiarColor\(card\.familiarId\) : undefined/, "rows carry a familiar colour only in by-familiar mode");
+assert.match(gantt, /color: byFamiliar \? \(familiarColor\(card\.familiarId\) \?\? "var\(--text-muted\)"\) : undefined/, "rows carry a familiar colour (or neutral fallback) only in by-familiar mode");
 assert.match(gantt, /\.\.\.\(row\.color \? \{ background: row\.color \} : \{\}\)/, "the bar paints the familiar colour when present");
+
+// The legend swaps to per-familiar swatches when grouping by familiar.
+assert.match(gantt, /\{groupMode === "familiar" \? \(/, "the legend is conditional on by-familiar grouping");
+assert.match(gantt, /groups\.map\(\(g\) => \(/, "the legend renders a swatch per familiar group");
+assert.match(gantt, /background: familiarColor\(g\.key === "__unassigned__" \? null : g\.key\) \?\? "var\(--text-muted\)"/, "familiar legend swatches match the bar colours");
 
 // The legend labels match the board's actual statuses (no invented
 // "In Progress"/"At Risk"): Running, Blocked, Done map 1:1; the shared colour


### PR DESCRIPTION
## Summary

When the Gantt is grouped by familiar, the bars are coloured by familiar (#1666) but the legend still listed status categories — which no longer describe the bars. This swaps the legend, in that mode only, to a **per-familiar swatch + name** list. Project and Task grouping keep the status legend.

Rebased onto **#1671** (which removed the Owner column from Gantt views) — uses `groupMode === "familiar"` rather than the now-removed `hideOwner` flag. With the Owner text column gone, the colour legend is the primary owner cue, so this completes that direction.

- Familiar legend swatches reuse the exact colour the bars use.
- Unassigned rows take a neutral colour so the legend explains every bar.
- Milestone and Today markers stay in both modes.

## Verification (ran the app)
Familiar-grouped legend renders `Sage · Cody · Nova · Charm · Unassigned · Milestone · Today`; each swatch matches its bars (Sage `rgb(69,77,196)`, Cody `rgb(156,69,196)`, Nova `rgb(69,162,196)`), and the left-table headers are `Group / Task · Start · End · St` (no Owner column). `tsc --noEmit` clean; `board-schedule-window.test.ts` extended and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)