### PR TITLE
feat(board): widen the Gantt task column so titles aren't truncated

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -42,7 +42,7 @@ type Group = { key: string; name: string; rows: GanttRow[]; firstStart: number }
 const ZOOM_DAY_W = { day: 22, week: 11, month: 5 } as const; // px per day column at each zoom
 type GanttZoom = keyof typeof ZOOM_DAY_W;
 const ZOOM_LABELS: Array<[GanttZoom, string]> = [["day", "Day"], ["week", "Week"], ["month", "Month"]];
-const LEFT_W = 416; // sum of the left table columns — keep in sync with .cg-left
+const LEFT_W = 442; // sum of the left table columns (300+58+58+26) — keep in sync with .cg-left
 
 function parseDate(value: string | null | undefined): Date | null {
   if (!value) return null;

--- a/src/components/board-schedule-window.test.ts
+++ b/src/components/board-schedule-window.test.ts
@@ -85,7 +85,7 @@ assert.doesNotMatch(gantt, /cg-c-owner/, "no Owner column header/cell remains in
 assert.doesNotMatch(gantt, /cg--no-owner/, "the no-owner modifier class is gone");
 assert.doesNotMatch(gantt, /row\.owner|owner: ownerName/, "GanttRow no longer carries an owner field");
 assert.doesNotMatch(styles, /cg-c-owner|cg--no-owner/, "Owner column styles are removed");
-assert.match(styles, /\.cg-left \{[\s\S]*?grid-template-columns: 190px 58px 58px 26px;/, "the left table uses the four-column (ownerless) layout");
+assert.match(styles, /\.cg-left \{[\s\S]*?grid-template-columns: 300px 58px 58px 26px;/, "the left table uses the four-column (ownerless) layout with a wide task column");
 
 // By-familiar grouping colour-codes bars by familiar.
 assert.match(gantt, /const familiarColor = \(id: string \| null\): string \| undefined =>/, "a per-familiar colour helper exists");

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1614,9 +1614,9 @@
   position: sticky;
   left: 0;
   z-index: 2;
-  flex: 0 0 332px;
+  flex: 0 0 442px;
   display: grid;
-  grid-template-columns: 190px 58px 58px 26px;
+  grid-template-columns: 300px 58px 58px 26px;
   align-items: center;
   background: var(--bg-base);
   border-right: 1px solid var(--border-strong);


### PR DESCRIPTION
## What

The Gantt left-table **task column was 190px**, clipping nearly every task title to an ellipsis (e.g. "coven-github: wire the Cav…"). This widens it to **300px** (left panel 332 → 442px) so far more of each title is readable at a glance.

While here, fixed a **stale constant**: `LEFT_W` was still `416` after the Owner column was removed from the Gantt (the real panel had become 332px). That mismatch offset the **TODAY line** and **scroll-to-today** by 84px. It's now `442`, matching the actual column sum (300+58+58+26), so the today marker lines up with the timeline again.

## Changes
- `board.css` — `.cg-left` `flex-basis` 332 → 442, task column 190px → 300px
- `board-gantt.tsx` — `LEFT_W` 416 → 442 (correct sum; used by the today line + scroll-to-today)
- `board-schedule-window.test.ts` — update the pinned `grid-template-columns` assertion to the new width

## Verification
- `board-schedule-window.test.ts` passes.
- Built and ran the web app; drove the board into Gantt view (demo data). Measured the left panel at **443px** and each `.cg-c-task` cell at **300px**, with full titles like "coven-github: lock the coven-code headless…" now rendering instead of "…Cav…". The TODAY marker aligns with the timeline.

| | |
|---|---|
| Before | task column 190px, titles truncated early |
| After | task column 300px, titles largely visible; today line realigned |

🤖 Generated with [Claude Code](https://claude.com/claude-code)