### PR TITLE
fix(project-permissions): let the local human browse projects without a familiar (403 on Code tree)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -465,6 +465,7 @@ export const SUITES = {
     "src/app/api/changes/route.test.ts",
     "src/app/api/project-grants/route.test.ts",
     "src/app/api/project-permission-routes.test.ts",
+    "src/app/api/project-local-human-read.test.ts",
     "src/app/api/project-file/route.test.ts",
     "src/app/api/library/doc/route.test.ts",
     "src/app/api/salem/pathfinder/feedback/route.test.ts",

--- a/src/app/api/project-file/route.ts
+++ b/src/app/api/project-file/route.ts
@@ -166,6 +166,7 @@ export async function GET(req: NextRequest) {
       familiarId: req.nextUrl.searchParams.get("familiarId"),
       path: filePath,
       surface: projectPermissionSurfaceForRequest(req, "file-read"),
+      request: req,
     });
   } catch (error) {
     if (error instanceof ProjectAccessDeniedError) {

--- a/src/app/api/project-local-human-read.test.ts
+++ b/src/app/api/project-local-human-read.test.ts
@@ -1,0 +1,37 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const helper = await readFile(
+  new URL("../../lib/server/project-permission-requests.ts", import.meta.url),
+  "utf8",
+);
+
+// The helper allows the local human (loopback) to use read-only surfaces with
+// no familiar, gated by isLocalOrigin + a read-surface allowlist.
+assert.match(helper, /import \{ isLocalOrigin \} from "@\/lib\/server\/local-origin"/, "imports isLocalOrigin");
+assert.match(
+  helper,
+  /LOCAL_HUMAN_READ_SURFACES: ReadonlySet<ProjectPermissionSurface> = new Set\(\[\s*"file-browse",\s*"file-read",\s*"project-api",\s*\]\)/,
+  "defines the read-only surface allowlist",
+);
+assert.doesNotMatch(helper, /LOCAL_HUMAN_READ_SURFACES[\s\S]*"file-write"/, "writes are NOT in the local-human allowlist");
+assert.match(
+  helper,
+  /if \(args\.request && isLocalOrigin\(args\.request\) && LOCAL_HUMAN_READ_SURFACES\.has\(surface\)\) \{\s*return;/,
+  "allows loopback no-familiar reads of read surfaces",
+);
+assert.match(helper, /throw new ProjectAccessDeniedError\("missing familiarId for project access"\)/, "still throws for non-local / write");
+
+// Every read route forwards the request so the loopback check can run.
+for (const rel of [
+  "./project-tree/route.ts",
+  "./project-file/route.ts",
+  "./project/files/route.ts",
+  "./project/search/route.ts",
+]) {
+  const src = await readFile(new URL(rel, import.meta.url), "utf8");
+  assert.match(src, /request: req,/, `${rel} should forward the request to assertProjectApiAccess`);
+}
+
+console.log("project-local-human-read.test.ts: ok");

--- a/src/app/api/project-tree/route.ts
+++ b/src/app/api/project-tree/route.ts
@@ -67,6 +67,7 @@ export async function GET(req: NextRequest) {
       familiarId: req.nextUrl.searchParams.get("familiarId"),
       path: root,
       surface: projectPermissionSurfaceForRequest(req, "file-browse"),
+      request: req,
     });
   } catch (error) {
     if (error instanceof ProjectAccessDeniedError) {

--- a/src/app/api/project/files/route.ts
+++ b/src/app/api/project/files/route.ts
@@ -142,6 +142,7 @@ export async function GET(req: NextRequest) {
       familiarId: req.nextUrl.searchParams.get("familiarId"),
       path: root,
       surface: projectPermissionSurfaceForRequest(req, "project-api"),
+      request: req,
     });
   } catch (error) {
     if (error instanceof ProjectAccessDeniedError) {

--- a/src/app/api/project/search/route.ts
+++ b/src/app/api/project/search/route.ts
@@ -160,6 +160,7 @@ export async function GET(req: NextRequest) {
       familiarId: sp.get("familiarId"),
       path: root,
       surface: projectPermissionSurfaceForRequest(req, "project-api"),
+      request: req,
     });
   } catch (error) {
     if (error instanceof ProjectAccessDeniedError) {

--- a/src/lib/server/project-permission-requests.ts
+++ b/src/lib/server/project-permission-requests.ts
@@ -8,6 +8,7 @@ import {
   type ProjectPermissionSurface,
 } from "@/lib/project-permissions";
 import { MOBILE_ACCESS_HEADER } from "@/proxy-helpers";
+import { isLocalOrigin } from "@/lib/server/local-origin";
 
 function isWithinRoot(candidate: string, root: string): boolean {
   const relativePath = path.relative(root, candidate);
@@ -30,16 +31,26 @@ function projectRootForPath(value: string, projects: CaveProject[]): CaveProject
   return matches[0]?.project ?? null;
 }
 
+/**
+ * Read-only surfaces the human operator may use WITHOUT a familiar context —
+ * but only from a loopback origin (their own desktop), never the phone /
+ * tailnet. Familiars still require a grant; write surfaces always require a
+ * familiarId.
+ */
+const LOCAL_HUMAN_READ_SURFACES: ReadonlySet<ProjectPermissionSurface> = new Set([
+  "file-browse",
+  "file-read",
+  "project-api",
+]);
+
 export async function assertProjectApiAccess(args: {
   familiarId: string | null | undefined;
   path: string | null | undefined;
   surface: ProjectPermissionSurface;
+  request?: Request;
 }): Promise<void> {
   const { surface } = args;
   const familiarId = args.familiarId?.trim();
-  if (!familiarId) {
-    throw new ProjectAccessDeniedError("missing familiarId for project access");
-  }
   const requestedPath = args.path?.trim();
   if (!requestedPath) {
     throw new ProjectAccessDeniedError("missing project path for permission check");
@@ -48,6 +59,14 @@ export async function assertProjectApiAccess(args: {
   const project = projectRootForPath(requestedPath, projects);
   if (!project) {
     throw new ProjectAccessDeniedError("project is not registered for permission checks");
+  }
+  if (!familiarId) {
+    // The human at their own desktop (loopback) may read a registered project's
+    // files without a familiar. Familiars stay gated; writes still need one.
+    if (args.request && isLocalOrigin(args.request) && LOCAL_HUMAN_READ_SURFACES.has(surface)) {
+      return;
+    }
+    throw new ProjectAccessDeniedError("missing familiarId for project access");
   }
   await assertProjectAccess({ familiarId }, project.id, surface);
 }


### PR DESCRIPTION
## Problem

Opening a project in the Code/Comux workspace that has **no active session** produced a blank file tree, with the console showing:

```
/api/project-tree?...&familiarId=  403 (Forbidden)
/api/project-file?...&familiarId=  403 (Forbidden)
```

The tree is permission-gated by familiar, but `comux-view.tsx`'s `selectedProjectFamiliarId` falls back to `""` when the project has no session (`selectedProjectSessions[0]?.familiarId ?? ""`). The server's `assertProjectApiAccess` then throws `"missing familiarId for project access"` → 403. Both the guard and this empty fallback shipped together in `00c2b4a2` ("Add project permission checks and grant APIs"); the gap is that **a human browsing their own project without a familiar session** was never handled.

## Fix

Allow the **human operator at their own desktop** (loopback origin) to use the **read-only** project surfaces (`file-browse`, `file-read`, `project-api`) **without** a familiar context.

- **Familiars stay fully gated** — a request *with* a familiarId still goes through `assertProjectAccess` (grant required).
- **Writes stay gated** — `file-write` is not in the allowlist, so writes still require a familiarId.
- **Phone / tailnet unaffected** — `isLocalOrigin` only trusts loopback Host; `<name>.ts.net` is rejected by design, so the relaxation never applies off-device.

`assertProjectApiAccess` now resolves the project first, then permits no-familiar reads when `isLocalOrigin(request) && LOCAL_HUMAN_READ_SURFACES.has(surface)`. The four read routes (`project-tree`, `project-file` GET, `project/files`, `project/search`) forward `request: req`.

## Verification

- `pnpm typecheck` → clean.
- New `src/app/api/project-local-human-read.test.ts` + existing `project-permission-routes.test.ts` → pass.

Note: the cross-origin font warnings in the same console are a separate, local-only artifact (a second `next dev` on `:3001` from a concurrent session) — not addressed here.

> To pick this up in your running dev server, pull `main` after merge — the dev server hot-reloads the route/helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)