### PR TITLE
feat(ios): search the GitHub tab; sort tasks within groups

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
@@ -12,11 +12,13 @@ struct GitHubView: View {
     @State private var loading = true
     @State private var error: String?
     @State private var hint: String?
+    @State private var query = ""
 
     var body: some View {
         NavigationStack {
             content
                 .navigationTitle("GitHub")
+                .searchable(text: $query, prompt: "Search issues & PRs")
                 .navigationDestination(for: GitHubItem.self) { item in
                     GitHubItemDetailView(item: item)
                 }
@@ -51,6 +53,8 @@ struct GitHubView: View {
             } description: {
                 Text("No open pull requests, review requests, or assigned issues.")
             }
+        } else if groups.isEmpty {
+            ContentUnavailableView.search(text: query)
         } else {
             List {
                 ForEach(groups, id: \.title) { group in
@@ -79,6 +83,18 @@ struct GitHubView: View {
 
     struct Group { let title: String; let items: [GitHubItem] }
 
+    /// Items narrowed by the search field — matches the title, the repo, or a
+    /// "#123"-style issue/PR number. Empty query → everything.
+    private var visibleItems: [GitHubItem] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !q.isEmpty else { return items }
+        return items.filter { item in
+            item.title.lowercased().contains(q)
+                || item.repo.lowercased().contains(q)
+                || (item.number.map { "#\($0)".contains(q) } ?? false)
+        }
+    }
+
     private var groups: [Group] {
         let order: [(String, (GitHubItem) -> Bool)] = [
             ("Review requests", { $0.kind == "review_request" }),
@@ -87,7 +103,7 @@ struct GitHubView: View {
             ("Notifications", { $0.kind == "notification" }),
         ]
         return order.compactMap { title, match in
-            let matched = items.filter(match)
+            let matched = visibleItems.filter(match)
             return matched.isEmpty ? nil : Group(title: title, items: matched)
         }
     }

--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -14,6 +14,7 @@ func caveParseISO(_ iso: String?) -> Date? {
 struct TasksView: View {
     @Environment(AppModel.self) private var app
     @AppStorage("cave.tasks.groupBy") private var groupByRaw = GroupBy.status.rawValue
+    @AppStorage("cave.tasks.sortBy") private var sortByRaw = SortBy.priority.rawValue
     @State private var query = ""
     @State private var path: [BoardCard] = []
     /// A task awaiting delete confirmation (swipe or context menu).
@@ -25,7 +26,21 @@ struct TasksView: View {
         var id: String { rawValue }
     }
 
+    /// How the cards within each section are ordered.
+    enum SortBy: String, CaseIterable, Identifiable {
+        case priority = "Priority", recent = "Recent", title = "Title"
+        var id: String { rawValue }
+        var systemImage: String {
+            switch self {
+            case .priority: return "flag"
+            case .recent: return "clock"
+            case .title: return "textformat"
+            }
+        }
+    }
+
     private var groupBy: GroupBy { GroupBy(rawValue: groupByRaw) ?? .status }
+    private var sortBy: SortBy { SortBy(rawValue: sortByRaw) ?? .priority }
 
     var body: some View {
         NavigationStack(path: $path) {
@@ -34,6 +49,19 @@ struct TasksView: View {
                 .navigationBarTitleDisplayMode(.inline)
                 .navigationDestination(for: BoardCard.self) { TaskDetailView(card: $0) }
                 .searchable(text: $query, prompt: "Search tasks")
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Menu {
+                            Picker("Sort by", selection: $sortByRaw) {
+                                ForEach(SortBy.allCases) { s in
+                                    Label(s.rawValue, systemImage: s.systemImage).tag(s.rawValue)
+                                }
+                            }
+                        } label: {
+                            Label("Sort", systemImage: "arrow.up.arrow.down")
+                        }
+                    }
+                }
                 .refreshable { await app.loadTasks() }
                 .task {
                     if !app.tasksLoaded { await app.loadTasks() }
@@ -243,11 +271,21 @@ struct TasksView: View {
     }
 
     private func sortCards(_ cards: [BoardCard]) -> [BoardCard] {
-        cards.sorted { a, b in
-            if a.priority.rank != b.priority.rank { return a.priority.rank < b.priority.rank }
-            let da = caveParseISO(a.updatedAt) ?? .distantPast
-            let db = caveParseISO(b.updatedAt) ?? .distantPast
-            return da > db
+        switch sortBy {
+        case .priority:
+            // Highest priority first, ties broken by most-recently updated.
+            return cards.sorted { a, b in
+                if a.priority.rank != b.priority.rank { return a.priority.rank < b.priority.rank }
+                let da = caveParseISO(a.updatedAt) ?? .distantPast
+                let db = caveParseISO(b.updatedAt) ?? .distantPast
+                return da > db
+            }
+        case .recent:
+            return cards.sorted {
+                (caveParseISO($0.updatedAt) ?? .distantPast) > (caveParseISO($1.updatedAt) ?? .distantPast)
+            }
+        case .title:
+            return cards.sorted { $0.title.lowercased() < $1.title.lowercased() }
         }
     }
 }


### PR DESCRIPTION
## What

Two self-contained list-ergonomics additions, aimed at the less-churned tabs.

### 1. Search on the GitHub tab
Adds a `.searchable` field that filters the activity list by **title, repo, or `#number`** across all sections (review requests / your PRs / issues / notifications). When a query matches nothing, the standard `ContentUnavailableView.search` no-results state shows. Previously there was no way to narrow a large backlog.

### 2. Sort within Task groups
Adds a sort `Menu` (▲▼) in the Tasks nav bar that orders cards **within each section** by:
- **Priority** — the prior fixed behavior (highest first, ties by most-recent), still the default
- **Recent** — most-recently updated
- **Title** — A–Z

Persisted to `@AppStorage("cave.tasks.sortBy")`, fully independent of the existing group-by control.

## Files
- `GitHubView.swift` — `query` state, `.searchable`, a `visibleItems` filter feeding `groups`, and a search-empty branch
- `TasksView.swift` — `SortBy` enum + `@AppStorage`, a toolbar sort menu, and a `sortBy`-driven `sortCards`

## Verification
- `xcodebuild` for the iPhone 16 Pro simulator → **BUILD SUCCEEDED**.
- iOS tests `ios-github-comment-attach` and `ios-task-actions` (which read these files) → **ok**.
- Ran on the simulator: the Tasks tab shows the new sort control in the nav bar (screenshotted). GitHub search is a standard `.searchable`; the field renders, but the filtered results need live GitHub data + drilling into the Developer→GitHub sub-tab, which `simctl` can't drive, so that path is verified by build + the unchanged grouping logic rather than a screenshot.

> Note: iOS Swift isn't compiled by the required CI checks, so this was verified locally via `xcodebuild` + simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)