### PR TITLE
feat(ios): export a chat thread as Markdown

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -686,6 +686,33 @@ final class AppModel {
         persistThreads()
     }
 
+    /// Render a thread's conversation to Markdown for the share/export action.
+    /// Skips empty/streaming-placeholder turns; attributes each to "You", the
+    /// familiar's display name, or "System".
+    func exportMarkdown(_ thread: ChatThread) -> String {
+        var lines: [String] = ["# \(thread.title)", ""]
+        let names = thread.familiarIds.map { familiar($0)?.displayName ?? $0 }
+        if !names.isEmpty {
+            lines.append("_Chat with \(names.joined(separator: ", "))_")
+            lines.append("")
+        }
+        for message in thread.messages {
+            let text = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if text.isEmpty { continue }
+            let who: String
+            switch message.role {
+            case .user: who = "You"
+            case .assistant: who = message.familiarId.flatMap { familiar($0)?.displayName } ?? "Assistant"
+            case .system: who = "System"
+            }
+            lines.append("**\(who)**")
+            lines.append("")
+            lines.append(text)
+            lines.append("")
+        }
+        return lines.joined(separator: "\n")
+    }
+
     func touch(_ thread: ChatThread) {
         // Move the most recently active thread to the top, then persist.
         if let idx = threads.firstIndex(where: { $0.id == thread.id }), idx != 0 {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -86,6 +86,14 @@ struct ChatView: View {
                 }
                 .accessibilityLabel("Commands")
             }
+            ToolbarItem(placement: .topBarTrailing) {
+                ShareLink(item: ThreadMarkdownExport(title: thread.title,
+                                                     markdown: app.exportMarkdown(thread)),
+                          preview: SharePreview(thread.title)) {
+                    Image(systemName: "square.and.arrow.up")
+                }
+                .accessibilityLabel("Export as Markdown")
+            }
         }
         .sheet(isPresented: $showCommands) {
             CommandsSheet { command in prefill(command) }

--- a/apps/ios/CovenCave/CovenCave/Views/ThreadExport.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ThreadExport.swift
@@ -1,0 +1,28 @@
+import CoreTransferable
+import UniformTypeIdentifiers
+
+/// A thread transcript rendered to Markdown, shareable as a `.md` file via
+/// `ShareLink`. The data is materialised only when the user actually shares.
+struct ThreadMarkdownExport: Transferable {
+    let title: String
+    let markdown: String
+
+    static var transferRepresentation: some TransferRepresentation {
+        DataRepresentation(exportedContentType: .plainText) { export in
+            Data(export.markdown.utf8)
+        }
+        .suggestedFileName { export in "\(export.fileBaseName).md" }
+    }
+
+    /// `title` reduced to a filesystem-safe base name (falls back to "chat").
+    var fileBaseName: String {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let base = trimmed.isEmpty ? "chat" : trimmed
+        let invalid = CharacterSet(charactersIn: "/\\:?%*|\"<>")
+        var result = ""
+        for scalar in base.unicodeScalars {
+            result.append(invalid.contains(scalar) ? "-" : Character(scalar))
+        }
+        return result
+    }
+}

--- a/scripts/ios-export-markdown.test.mjs
+++ b/scripts/ios-export-markdown.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+const read = (rel) => readFile(new URL(`../${rel}`, import.meta.url), "utf8");
+const iosRoot = "apps/ios/CovenCave/CovenCave";
+
+const model = await read(`${iosRoot}/State/AppModel.swift`);
+const exportFile = await read(`${iosRoot}/Views/ThreadExport.swift`);
+const chat = await read(`${iosRoot}/Views/ChatView.swift`);
+
+// Markdown renderer attributes each turn and titles the doc.
+assert.match(model, /func exportMarkdown\(_ thread: ChatThread\) -> String/, "AppModel should render a thread to Markdown");
+assert.match(model, /lines: \[String\] = \["# \\\(thread\.title\)", ""\]/, "export should title the document");
+assert.match(model, /case \.user: who = "You"/, "user turns attributed to You");
+assert.match(model, /case \.assistant: who = message\.familiarId\.flatMap \{ familiar\(\$0\)\?\.displayName \} \?\? "Assistant"/, "assistant turns attributed to the familiar");
+assert.match(model, /if text\.isEmpty \{ continue \}/, "empty/streaming turns are skipped");
+
+// Transferable exports a .md file lazily.
+assert.match(exportFile, /struct ThreadMarkdownExport: Transferable/, "a Transferable export type should exist");
+assert.match(exportFile, /DataRepresentation\(exportedContentType: \.plainText\)/, "should export as data");
+assert.match(exportFile, /\.suggestedFileName \{ export in "\\\(export\.fileBaseName\)\.md" \}/, "should suggest a .md filename");
+
+// ChatView wires a share button to the export.
+assert.match(
+  chat,
+  /ShareLink\(item: ThreadMarkdownExport\(title: thread\.title,\s*markdown: app\.exportMarkdown\(thread\)\)/,
+  "ChatView should offer a ShareLink for the Markdown export",
+);
+assert.match(chat, /\.accessibilityLabel\("Export as Markdown"\)/, "the export button should be labelled");
+
+console.log("ios-export-markdown.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -498,6 +498,7 @@ export const SUITES = {
     "scripts/ios-pin-threads.test.mjs",
     "scripts/ios-thread-search.test.mjs",
     "scripts/ios-mute-threads.test.mjs",
+    "scripts/ios-export-markdown.test.mjs",
     "scripts/ios-reorder-familiars.test.mjs",
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/mobile-tailscale.test.mjs",


### PR DESCRIPTION
## What

Adds a **share button** to the chat toolbar that exports the conversation as a **Markdown file** through the iOS share sheet (Save to Files, AirDrop, Mail, etc.).

- **`AppModel.exportMarkdown(_:)`** renders the thread to Markdown — a title, the participant list, and each non-empty turn attributed to **You**, the **familiar's display name**, or **System**. Streaming/empty placeholder turns are skipped.
- **`ThreadMarkdownExport`** (`Transferable`) shares the transcript as a **`<title>.md`** file (filename sanitised); the data is materialised only when the user actually shares.
- **`ChatView`** — a `ShareLink` toolbar item (`square.and.arrow.up`), labelled "Export as Markdown".

## Verification

- `pnpm test:mobile` → **✓ 34 test file(s) passed** (full suite; new `scripts/ios-export-markdown.test.mjs` registered).
- `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED**.

Interactive export (tap share → save/AirDrop) needs the share sheet I can't drive headlessly without `idb`, so it rests on build + assertion test + the existing `ShareLink` pattern (mirrors ReadingView).

> Built via an atomic sibling-worktree one-shot (commit+push before build) because the in-repo `.worktrees/` keeps getting swept by concurrent-session cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)