### PR TITLE
feat(ios): Read sort, chat pull-to-refresh, terminal/icon a11y labels

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -144,6 +144,26 @@ final class ChatThread: Identifiable, Hashable {
         updatedAt = Date()
     }
 
+    /// Re-fetch this thread's conversation from the server and replace the local
+    /// messages — backs pull-to-refresh, so a chat advanced on another device
+    /// catches up. Direct threads only: a group is N independent sessions with no
+    /// shared turn ordering to merge. Skipped while streaming (and when there's no
+    /// server session yet) so an in-flight reply is never clobbered.
+    func reload(client: CaveClient) async {
+        guard !isGroup, !isStreaming,
+              let familiarId = familiarIds.first,
+              let sessionId = sessionIds[familiarId],
+              let convo = try? await client.conversation(sessionId: sessionId) else { return }
+        messages = convo.turns.map { turn in
+            let role = DisplayMessage.Role(rawValue: turn.role) ?? .assistant
+            return DisplayMessage(role: role,
+                                  familiarId: role == .assistant ? familiarId : nil,
+                                  text: turn.text,
+                                  isError: turn.isError ?? false)
+        }
+        updatedAt = Date()
+    }
+
     private func stream(familiarId: String, prompt: String,
                         attachments: [CaveClient.ChatAttachment] = [], into messageId: String,
                         client: CaveClient, onChange: @escaping () -> Void) async {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -138,6 +138,14 @@ struct ChatView: View {
                 .padding(.vertical, 14)
             }
             .scrollDismissesKeyboard(.interactively)
+            // Pull to re-sync a direct chat that may have advanced on another
+            // device (no-op for groups / unsent threads, see ChatThread.reload).
+            .refreshable {
+                if let client = app.client {
+                    await thread.reload(client: client)
+                    app.persistThreads()
+                }
+            }
             // Track whether the user is parked at the latest message so a
             // "jump to bottom" button can appear when they've scrolled up.
             .onScrollGeometryChange(for: Bool.self) { geo in

--- a/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
@@ -216,6 +216,7 @@ struct GitHubItemDetailView: View {
             if let url = URL(string: item.url) {
                 ToolbarItem(placement: .topBarTrailing) {
                     Link(destination: url) { Image(systemName: "safari") }
+                        .accessibilityLabel("Open on GitHub")
                 }
             }
         }
@@ -515,6 +516,7 @@ private struct GitHubCommentsSection: View {
                 if let url = c.url, let u = URL(string: url) {
                     Link(destination: u) { Image(systemName: "arrow.up.right.square") }
                         .font(.caption).foregroundStyle(.secondary)
+                        .accessibilityLabel("Open comment on GitHub")
                 }
             }
             GitHubMarkdown(c.body)

--- a/apps/ios/CovenCave/CovenCave/Views/ReadingView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ReadingView.swift
@@ -8,6 +8,22 @@ struct ReadingView: View {
     @State private var filter: ReadingFilter = .all
     @State private var query = ""
     @State private var reader: ReaderLink?
+    @AppStorage("cave.reading.sortBy") private var sortByRaw = ReadingSort.recent.rawValue
+
+    /// How the reading list is ordered.
+    enum ReadingSort: String, CaseIterable, Identifiable {
+        case recent = "Date added", title = "Title", progress = "Progress"
+        var id: String { rawValue }
+        var systemImage: String {
+            switch self {
+            case .recent: return "clock"
+            case .title: return "textformat"
+            case .progress: return "chart.bar"
+            }
+        }
+    }
+
+    private var sortBy: ReadingSort { ReadingSort(rawValue: sortByRaw) ?? .recent }
 
     var body: some View {
         NavigationStack {
@@ -24,6 +40,19 @@ struct ReadingView: View {
             .navigationTitle("Reading")
             .navigationBarTitleDisplayMode(.inline)
             .searchable(text: $query, prompt: "Search titles, authors, tags")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Menu {
+                        Picker("Sort by", selection: $sortByRaw) {
+                            ForEach(ReadingSort.allCases) { s in
+                                Label(s.rawValue, systemImage: s.systemImage).tag(s.rawValue)
+                            }
+                        }
+                    } label: {
+                        Label("Sort", systemImage: "arrow.up.arrow.down")
+                    }
+                }
+            }
             .refreshable { await app.loadReading() }
             .task { if !app.readingLoaded { await app.loadReading() } }
             .sheet(item: $reader) { link in
@@ -235,7 +264,14 @@ struct ReadingView: View {
                 || (item.domain?.lowercased().contains(q) ?? false)
                 || item.tagList.joined(separator: " ").lowercased().contains(q)
         }
-        return searched.sorted { ($0.addedDate ?? .distantPast) > ($1.addedDate ?? .distantPast) }
+        switch sortBy {
+        case .recent:
+            return searched.sorted { ($0.addedDate ?? .distantPast) > ($1.addedDate ?? .distantPast) }
+        case .title:
+            return searched.sorted { $0.title.lowercased() < $1.title.lowercased() }
+        case .progress:
+            return searched.sorted { ($0.progressPercent ?? 0) > ($1.progressPercent ?? 0) }
+        }
     }
 
     private func count(_ value: ReadingFilter) -> Int {

--- a/apps/ios/CovenCave/CovenCave/Views/TerminalView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TerminalView.swift
@@ -61,16 +61,16 @@ struct TerminalView: View {
     private var keyRow: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
-                keyButton("esc") { terminal.sendInput("\u{1B}") }
-                keyButton("tab") { terminal.sendInput("\t") }
-                keyButton("⌃C") { terminal.sendInput("\u{03}") }
-                keyButton("⌃D") { terminal.sendInput("\u{04}") }
-                keyButton("⌃Z") { terminal.sendInput("\u{1A}") }
-                keyButton("↑") { terminal.sendInput("\u{1B}[A") }
-                keyButton("↓") { terminal.sendInput("\u{1B}[B") }
-                keyButton("←") { terminal.sendInput("\u{1B}[D") }
-                keyButton("→") { terminal.sendInput("\u{1B}[C") }
-                keyButton("clear") { terminal.sendInput("clear\n") }
+                keyButton("esc", "Escape") { terminal.sendInput("\u{1B}") }
+                keyButton("tab", "Tab") { terminal.sendInput("\t") }
+                keyButton("⌃C", "Control C") { terminal.sendInput("\u{03}") }
+                keyButton("⌃D", "Control D") { terminal.sendInput("\u{04}") }
+                keyButton("⌃Z", "Control Z") { terminal.sendInput("\u{1A}") }
+                keyButton("↑", "Up arrow") { terminal.sendInput("\u{1B}[A") }
+                keyButton("↓", "Down arrow") { terminal.sendInput("\u{1B}[B") }
+                keyButton("←", "Left arrow") { terminal.sendInput("\u{1B}[D") }
+                keyButton("→", "Right arrow") { terminal.sendInput("\u{1B}[C") }
+                keyButton("clear", "Clear screen") { terminal.sendInput("clear\n") }
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
@@ -78,7 +78,10 @@ struct TerminalView: View {
         .background(.bar)
     }
 
-    private func keyButton(_ label: String, action: @escaping () -> Void) -> some View {
+    /// `label` is the compact glyph shown on the key; `accessibility` spells it
+    /// out for VoiceOver (e.g. "↑" → "Up arrow", "⌃C" → "Control C").
+    private func keyButton(_ label: String, _ accessibility: String,
+                           action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Text(label)
                 .font(.system(.footnote, design: .monospaced))
@@ -87,6 +90,7 @@ struct TerminalView: View {
         }
         .buttonStyle(.plain)
         .disabled(!terminal.connected)
+        .accessibilityLabel(accessibility)
     }
 
     // MARK: - Toolbar


### PR DESCRIPTION
## What

Three small UX/accessibility polish items, all on the calmer (non-Chats-list) surfaces.

### 1. Read tab — sort
A sort `Menu` (▲▼) in the nav bar orders the reading list by:
- **Date added** — the prior fixed default
- **Title** — A–Z
- **Progress** — most-read first (handy for the "Reading" filter)

Persisted to `@AppStorage("cave.reading.sortBy")`; complements the existing status filter chips.

### 2. Chat — pull-to-refresh
Pulling down a conversation re-fetches it from the server (`ChatThread.reload`) so a chat advanced on **another device** catches up. Scoped deliberately: **direct threads only** (a group is N independent server sessions with no shared turn ordering to merge), and **skipped while streaming** or before a server session exists, so an in-flight reply is never clobbered.

### 3. Accessibility labels
- **Terminal** special-key bar: each key (Esc / Tab / ⌃C / ⌃D / ⌃Z / arrows / clear) now spells itself out for VoiceOver (e.g. "↑" → "Up arrow", "⌃C" → "Control C") instead of reading a bare glyph.
- **GitHub** two icon-only links — the item toolbar "open in Safari" and a review comment's open-link — get labels ("Open on GitHub" / "Open comment on GitHub").
- (Checked CodeBrowserView too — its only button is a text "Retry", already accessible; no change needed.)

## Files
- `ReadingView.swift` — `ReadingSort` enum + `@AppStorage`, toolbar menu, sort applied in `visible`
- `ChatThread.swift` — `reload(client:)`
- `ChatView.swift` — `.refreshable` on the message scroll
- `TerminalView.swift` — `keyButton` gains an explicit accessibility label per key
- `GitHubView.swift` — `.accessibilityLabel` on the two icon-only links

## Verification
- `xcodebuild` for the iPhone 16 Pro simulator → **BUILD SUCCEEDED**.
- iOS tests `ios-task-actions`, `ios-github-comment-attach`, `ios-message-reader`, `ios-code-browser-files` → all **ok**.
- Ran on the simulator: the Read tab shows the new sort control in the nav bar (screenshotted).

> Note: iOS Swift isn't compiled by the required CI checks, so this was verified locally via `xcodebuild` + simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)