### PR TITLE
feat(ios): duplicate a chat thread

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -747,6 +747,24 @@ final class AppModel {
         return thread
     }
 
+    /// Copy a thread into a new, independent local thread — fresh message ids,
+    /// no server session (so sending in the copy starts clean), and reset
+    /// pin/archive/mute. Inserts at the top and persists.
+    @discardableResult
+    func duplicateThread(_ thread: ChatThread) -> ChatThread {
+        let copiedMessages = thread.messages.map { message in
+            DisplayMessage(role: message.role, familiarId: message.familiarId,
+                           text: message.text, isError: message.isError,
+                           attachmentDataUrls: message.attachmentDataUrls)
+        }
+        let copy = ChatThread(title: "\(thread.title) (copy)",
+                              familiarIds: thread.familiarIds,
+                              messages: copiedMessages)
+        threads.insert(copy, at: 0)
+        persistThreads()
+        return copy
+    }
+
     func touch(_ thread: ChatThread) {
         // Move the most recently active thread to the top, then persist.
         if let idx = threads.firstIndex(where: { $0.id == thread.id }), idx != 0 {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -164,6 +164,9 @@ struct ChatsHomeView: View {
                             Button { renamingThread = thread } label: {
                                 Label("Rename", systemImage: "pencil")
                             }
+                            Button { app.duplicateThread(thread) } label: {
+                                Label("Duplicate", systemImage: "plus.square.on.square")
+                            }
                             Button { app.setThreadPinned(thread, !thread.pinned) } label: {
                                 Label(thread.pinned ? "Unpin" : "Pin",
                                       systemImage: thread.pinned ? "pin.slash" : "pin")
@@ -209,6 +212,9 @@ struct ChatsHomeView: View {
                         .contextMenu {
                             Button { renamingThread = thread } label: {
                                 Label("Rename", systemImage: "pencil")
+                            }
+                            Button { app.duplicateThread(thread) } label: {
+                                Label("Duplicate", systemImage: "plus.square.on.square")
                             }
                             Button { app.setThreadPinned(thread, !thread.pinned) } label: {
                                 Label(thread.pinned ? "Unpin" : "Pin",

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -118,6 +118,9 @@ struct FamiliarThreadsView: View {
                             Button { renamingThread = thread } label: {
                                 Label("Rename", systemImage: "pencil")
                             }
+                            Button { app.duplicateThread(thread) } label: {
+                                Label("Duplicate", systemImage: "plus.square.on.square")
+                            }
                             Button { app.setThreadPinned(thread, !thread.pinned) } label: {
                                 Label(thread.pinned ? "Unpin" : "Pin",
                                       systemImage: thread.pinned ? "pin.slash" : "pin")

--- a/scripts/ios-duplicate-thread.test.mjs
+++ b/scripts/ios-duplicate-thread.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+const read = (rel) => readFile(new URL(`../${rel}`, import.meta.url), "utf8");
+const iosRoot = "apps/ios/CovenCave/CovenCave";
+
+const model = await read(`${iosRoot}/State/AppModel.swift`);
+const home = await read(`${iosRoot}/Views/ChatsHomeView.swift`);
+const familiarThreads = await read(`${iosRoot}/Views/FamiliarThreadsView.swift`);
+
+assert.match(model, /func duplicateThread\(_ thread: ChatThread\) -> ChatThread/, "AppModel should duplicate a thread");
+assert.match(model, /title: "\\\(thread\.title\) \(copy\)"/, "the copy's title is suffixed with (copy)");
+assert.match(model, /familiarIds: thread\.familiarIds/, "the copy keeps the participants");
+assert.match(model, /thread\.messages\.map \{ message in[\s\S]*DisplayMessage\(role: message\.role/, "the copy carries fresh message copies");
+assert.match(model, /let copy = ChatThread\(title:[\s\S]*threads\.insert\(copy, at: 0\)\s*persistThreads\(\)/, "inserts and persists the copy");
+// No server session copied — duplicate starts clean.
+assert.doesNotMatch(model, /func duplicateThread[\s\S]*sessionIds/, "the duplicate should not copy server sessionIds");
+
+for (const [name, src] of [["ChatsHomeView", home], ["FamiliarThreadsView", familiarThreads]]) {
+  assert.match(src, /Button \{ app\.duplicateThread\(thread\) \} label: \{[\s\S]*Label\("Duplicate", systemImage: "plus\.square\.on\.square"\)/, `${name} should offer a Duplicate action`);
+}
+
+console.log("ios-duplicate-thread.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -500,6 +500,7 @@ export const SUITES = {
     "scripts/ios-mute-threads.test.mjs",
     "scripts/ios-export-markdown.test.mjs",
     "scripts/ios-import-markdown.test.mjs",
+    "scripts/ios-duplicate-thread.test.mjs",
     "scripts/ios-reorder-familiars.test.mjs",
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/mobile-tailscale.test.mjs",


### PR DESCRIPTION
## What

Adds a **Duplicate** context-menu action (group rows, search-result rows, and per-familiar threads) that copies a conversation into a new, **independent** local thread.

- **`AppModel.duplicateThread(_:)`** copies the title (suffixed **" (copy)"**), the participants, and the messages **with fresh ids**. It deliberately does **not** copy:
  - the server `sessionIds` — so sending in the copy starts a clean session rather than continuing the original's;
  - the pin / archive / mute flags — the copy starts in the default state.

  Inserts at the top of the list and persists.

## Verification

- `pnpm test:mobile` → **✓ 36 test file(s) passed** (full suite; new `scripts/ios-duplicate-thread.test.mjs` registered).
- `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED**.

Interactive duplicate (long-press → Duplicate) needs the context menu I can't drive headlessly without `idb`, so it rests on build + assertion test + the existing thread-creation/persistence pattern.

> Built via an atomic sibling-worktree one-shot (commit+push before build) because the in-repo `.worktrees/` keeps getting swept by concurrent-session cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)