### PR TITLE
feat(gantt): clearer, narrower timeline-zoom control

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import type { Card, CardStatus } from "@/lib/cave-board-types";
 import type { Familiar } from "@/lib/types";
 import { useDateTimePrefs, readDateTimePrefs } from "@/lib/datetime-format";
+import { Icon } from "@/lib/icon";
 
 type ProjectLike = { id: string; name: string };
 
@@ -41,7 +42,14 @@ type Group = { key: string; name: string; rows: GanttRow[]; firstStart: number }
 
 const ZOOM_DAY_W = { day: 22, week: 11, month: 5 } as const; // px per day column at each zoom
 type GanttZoom = keyof typeof ZOOM_DAY_W;
-const ZOOM_LABELS: Array<[GanttZoom, string]> = [["day", "Day"], ["week", "Week"], ["month", "Month"]];
+// Each zoom sets the column scale (px/day). Compact single-letter buttons keep
+// the control narrow; the full word + what it does live in the title/aria so
+// "D/W/M" next to the magnifier still reads as a timeline zoom.
+const ZOOM_LABELS: Array<[GanttZoom, string, string, string]> = [
+  ["day", "Day", "D", "Zoom in — one fat column per day"],
+  ["week", "Week", "W", "Medium zoom — a week spans the view"],
+  ["month", "Month", "M", "Zoom out — months fit on screen"],
+];
 const LEFT_W = 442; // sum of the left table columns (300+58+58+26) — keep in sync with .cg-left
 
 function parseDate(value: string | null | undefined): Date | null {
@@ -383,8 +391,19 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
     <div className="board-gantt">
       <div className="cg-controls" style={{ display: "flex", gap: 8, alignItems: "center", justifyContent: "flex-end", padding: "2px 8px 6px" }}>
         <div className="board-group-toggle" role="group" aria-label="Timeline zoom">
-          {ZOOM_LABELS.map(([z, label]) => (
-            <button key={z} type="button" className={`board-group-toggle-btn${zoom === z ? " board-group-toggle-btn--active" : ""}`} onClick={() => setZoom(z)} aria-pressed={zoom === z}>{label}</button>
+          <span className="cg-zoom-cell" aria-hidden><Icon name="ph:magnifying-glass" width={13} /></span>
+          {ZOOM_LABELS.map(([z, full, short, hint]) => (
+            <button
+              key={z}
+              type="button"
+              className={`board-group-toggle-btn${zoom === z ? " board-group-toggle-btn--active" : ""}`}
+              onClick={() => setZoom(z)}
+              aria-pressed={zoom === z}
+              aria-label={`Zoom: ${full}`}
+              title={`${full} — ${hint}`}
+            >
+              {short}
+            </button>
           ))}
         </div>
         <button type="button" className="board-group-toggle-btn" onClick={scrollToToday} disabled={todayX === null} title="Scroll the timeline to today">Today</button>

--- a/src/components/board-schedule-window.test.ts
+++ b/src/components/board-schedule-window.test.ts
@@ -108,4 +108,15 @@ assert.match(gantt, /\{groupMode === "familiar" \? \(/, "the legend is condition
 assert.match(gantt, /groups\.map\(\(g\) => \(/, "the legend renders a swatch per familiar group");
 assert.match(gantt, /background: familiarColor\(g\.key === "__unassigned__" \? null : g\.key\) \?\? "var\(--text-muted\)"/, "familiar legend swatches match the bar colours");
 
+// The timeline-zoom control reads as a zoom: a magnifier glyph + compact
+// single-letter buttons (D/W/M), with the full word + what it does in the
+// title/aria so it's clear and narrow (not a "Day/Week/Month" range filter).
+assert.match(gantt, /className="cg-zoom-cell"[\s\S]{0,80}name="ph:magnifying-glass"/, "the zoom control shows a magnifier glyph");
+assert.match(gantt, /\["day", "Day", "D",/, "day zoom carries a short label + hint");
+assert.match(gantt, /\["month", "Month", "M",/, "month zoom carries a short label + hint");
+assert.match(gantt, /aria-label=\{`Zoom: \$\{full\}`\}/, "each zoom button announces the full word");
+assert.match(gantt, /title=\{`\$\{full\} — \$\{hint\}`\}/, "each zoom button explains what the scale does");
+assert.match(gantt, />\s*\{short\}\s*<\/button>/, "buttons render the compact single-letter label");
+assert.match(styles, /\.board-group-toggle \.cg-zoom-cell/, "the zoom glyph cell is styled to match the segmented control");
+
 console.log("board-schedule-window.test.ts: ok");

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -39,6 +39,8 @@
 .board-multiselect-popover { min-width:180px; }
 
 .board-group-toggle { display:flex; border:1px solid var(--border-strong); border-radius:7px; overflow:hidden; }
+/* Leading zoom glyph so the compact D/W/M reads as a timeline zoom, not a range filter. */
+.board-group-toggle .cg-zoom-cell { display:flex; align-items:center; padding:0 4px 0 8px; background:var(--bg-raised); color:var(--text-muted); border-right:1px solid var(--border-strong); }
 .board-group-toggle-btn { display:flex; align-items:center; justify-content:center; padding:0 10px; height:28px; background:var(--bg-raised); color:var(--text-muted); border:none; cursor:pointer; font-size:12px; font-weight:500; transition:background .12s,color .12s; white-space:nowrap; }
 .board-group-toggle-btn+.board-group-toggle-btn { border-left:1px solid var(--border-strong); }
 .board-group-toggle-btn:hover { background:var(--bg-hover); color:var(--text-secondary); }


### PR DESCRIPTION
## What

The Gantt's **Day / Week / Month** control sets the timeline *zoom* (px per day: 22 / 11 / 5), but the bare words read like a date-range filter — and the control was wide.

Now it's a proper zoom control:
- A **magnifier glyph** prefixes the segment so it clearly reads as zoom.
- Buttons shrink to **D / W / M** (much narrower).
- The **full word + what each scale does** lives in each button's `title` and `aria-label` (e.g. "Week — Medium zoom — a week spans the view"), so nothing is lost for clarity or accessibility.

`Today` and the underlying zoom behaviour are unchanged.

## Verification
- `pnpm typecheck` clean; `node scripts/run-tests.mjs app` → **373 files pass** (incl. new assertions in `board-schedule-window.test.ts`).
- Browser-checked on a live Gantt: renders `🔍 [D] W M  Today`, magnifier in its own cell, active state intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)