### PR TITLE
feat(workflows): live per-step run progress + per-step debug detail

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -29,6 +29,7 @@ export const SUITES = {
     "src/components/open-coven-tools-update.test.ts",
     "src/lib/workflow-playback.test.ts",
     "src/lib/workflow-run-prompt.test.ts",
+    "src/lib/workflow-step-progress.test.ts",
     "src/lib/screen-magnification.test.ts",
     "src/lib/demo-mode.test.ts",
     "src/lib/cave-projects.test.ts",

--- a/src/app/api/workflows/run/route.ts
+++ b/src/app/api/workflows/run/route.ts
@@ -173,6 +173,7 @@ async function runViaSession(body: RunBody) {
     })),
     summary: `agent session ${sessionId.slice(0, 8)}`,
     source: "cave",
+    sessionId,
   });
 
   return NextResponse.json({ ok: true, run, sessionId, executor: "session" });

--- a/src/components/workflows/workflow-run-progress.tsx
+++ b/src/components/workflows/workflow-run-progress.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Icon, type IconName } from "@/lib/icon";
+import {
+  parseWorkflowStepProgress,
+  type WorkflowStepProgressStatus,
+} from "@/lib/workflow-step-progress";
+import type { WorkflowRunRecord } from "@/lib/workflows";
+
+const STATUS_ICON: Record<WorkflowStepProgressStatus, IconName> = {
+  pending: "ph:circle-dashed",
+  active: "ph:circle-notch-bold",
+  succeeded: "ph:check-circle",
+  failed: "ph:x-circle-fill",
+};
+
+const POLL_MS = 2500;
+
+/**
+ * Live per-step progress for a session-executor run. Polls the run's agent
+ * session transcript, maps the agent's `@@step-…` markers back onto the
+ * manifest's steps, and shows each step's status with its narration (the
+ * debugging detail) on demand. When the agent emitted no markers, the raw live
+ * output is shown instead so the detail is never hidden.
+ */
+export function WorkflowRunProgress({ run }: { run: WorkflowRunRecord }) {
+  const sessionId = run.sessionId;
+  const live = run.status === "running" || run.status === "queued";
+  const [transcript, setTranscript] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [openStep, setOpenStep] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!sessionId) return;
+    let alive = true;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const tick = async () => {
+      try {
+        const res = await fetch(`/api/chat/conversation/${encodeURIComponent(sessionId)}`, {
+          cache: "no-store",
+        });
+        const json = await res.json().catch(() => null);
+        if (!alive) return;
+        if (json?.ok && Array.isArray(json.conversation?.turns)) {
+          const text = json.conversation.turns
+            .filter((t: { role?: string }) => t.role === "assistant")
+            .map((t: { text?: string }) => t.text ?? "")
+            .join("\n");
+          setTranscript(text);
+          setError(null);
+        } else {
+          setTranscript((prev) => prev ?? "");
+        }
+      } catch {
+        if (alive) setError("Couldn't load the run's session output.");
+      }
+      if (alive && live) timer = setTimeout(tick, POLL_MS);
+    };
+    void tick();
+    return () => {
+      alive = false;
+      if (timer) clearTimeout(timer);
+    };
+  }, [sessionId, live]);
+
+  if (!sessionId) return null;
+
+  const stepIds = run.steps.map((s) => s.id);
+  const progress = parseWorkflowStepProgress(transcript ?? "", stepIds);
+  const active = progress.steps.find((s) => s.id === progress.activeStepId) ?? null;
+  const resolved = progress.steps.filter((s) => s.status === "succeeded" || s.status === "failed").length;
+
+  const headline = progress.done
+    ? `All ${stepIds.length} steps reported`
+    : active
+      ? `Running: ${active.id}`
+      : live
+        ? "Waiting for the agent…"
+        : `${resolved}/${stepIds.length} steps reported`;
+
+  return (
+    <div className="workflow-run-progress">
+      <div className="workflow-run-progress-head">
+        {live && !progress.done && (
+          <Icon name="ph:circle-notch-bold" width={12} className="workflow-spin" aria-hidden />
+        )}
+        <span>{headline}</span>
+      </div>
+
+      {progress.markersFound ? (
+        <ol className="workflow-progress-steps">
+          {progress.steps.map((step) => {
+            const open = openStep === step.id;
+            const hasDetail = step.detail.length > 0;
+            return (
+              <li
+                key={step.id}
+                className={`workflow-progress-step workflow-run-step-${
+                  step.status === "active" ? "ready" : step.status
+                } workflow-progress-step--${step.status}`}
+              >
+                <button
+                  type="button"
+                  className="workflow-progress-step-row"
+                  aria-expanded={hasDetail ? open : undefined}
+                  disabled={!hasDetail}
+                  onClick={() => setOpenStep(open ? null : step.id)}
+                >
+                  <Icon
+                    name={STATUS_ICON[step.status]}
+                    width={13}
+                    className={step.status === "active" ? "workflow-spin" : ""}
+                  />
+                  <span className="workflow-run-step-id">{step.id}</span>
+                  <span className="workflow-run-step-status">{step.status}</span>
+                  {hasDetail && <Icon name={open ? "ph:caret-down" : "ph:caret-right"} width={10} aria-hidden />}
+                </button>
+                {open && hasDetail && <pre className="workflow-progress-step-detail">{step.detail}</pre>}
+              </li>
+            );
+          })}
+        </ol>
+      ) : transcript ? (
+        <pre className="workflow-progress-step-detail workflow-progress-raw">
+          {transcript.slice(-6000) || "…"}
+        </pre>
+      ) : (
+        <p className="workflow-muted">Waiting for the agent's first output…</p>
+      )}
+      {error && <p className="workflow-muted">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/workflows/workflow-runs-panel.tsx
+++ b/src/components/workflows/workflow-runs-panel.tsx
@@ -9,6 +9,7 @@ import { useDateTimePrefs } from "@/lib/datetime-format";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 import type { WorkflowPlaybackState } from "@/lib/workflow-playback";
+import { WorkflowRunProgress } from "@/components/workflows/workflow-run-progress";
 import type {
   WorkflowRunRecord,
   WorkflowRunStepRecord,
@@ -187,21 +188,27 @@ export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayR
                       </div>
                     </dl>
                     {run.summary && <p className="workflow-run-summary-line">{run.summary}</p>}
+                    {/* Session-executor runs derive live per-step progress + debug
+                        detail from the agent transcript; daemon/replay runs keep
+                        the recorded static step list. */}
+                    {run.sessionId && <WorkflowRunProgress run={run} />}
                     {replayable ? (
                       <>
-                        <ol className="workflow-run-steps">
-                          {run.steps.map((step) => (
-                            <li
-                              key={step.id}
-                              className={`workflow-run-step workflow-run-step-${step.status}`}
-                            >
-                              <Icon name={STEP_STATUS_ICON[step.status]} width={13} />
-                              <span className="workflow-run-step-id">{step.id}</span>
-                              <span className="workflow-run-step-kind">{step.kind}</span>
-                              <span className="workflow-run-step-status">{step.status}</span>
-                            </li>
-                          ))}
-                        </ol>
+                        {!run.sessionId && (
+                          <ol className="workflow-run-steps">
+                            {run.steps.map((step) => (
+                              <li
+                                key={step.id}
+                                className={`workflow-run-step workflow-run-step-${step.status}`}
+                              >
+                                <Icon name={STEP_STATUS_ICON[step.status]} width={13} />
+                                <span className="workflow-run-step-id">{step.id}</span>
+                                <span className="workflow-run-step-kind">{step.kind}</span>
+                                <span className="workflow-run-step-status">{step.status}</span>
+                              </li>
+                            ))}
+                          </ol>
+                        )}
                         <div className="workflow-run-actions-row">
                           <button
                             type="button"

--- a/src/lib/workflow-run-prompt.test.ts
+++ b/src/lib/workflow-run-prompt.test.ts
@@ -61,13 +61,25 @@ const dependent: WorkflowSummary = {
   assert.match(missing, /If required workflow input is missing, ask Val for the specific value/);
 }
 
-// A manifest with no steps still produces a usable prompt (no crash, no step block).
+// A manifest with no steps still produces a usable prompt (no crash, no step
+// block, and no progress markers — there's nothing to track).
 {
   const bare: WorkflowSummary = { id: "empty", version: "1.0.0", name: "Empty" };
   assert.deepEqual(orderedWorkflowSteps(bare), []);
   const prompt = buildWorkflowRunPrompt(bare);
   assert.match(prompt, /executing the "Empty" workflow/);
   assert.doesNotMatch(prompt, /Carry out these steps/);
+  assert.doesNotMatch(prompt, /@@step-start/);
+}
+
+// A workflow with steps exposes each step's id and the progress-marker protocol
+// so Cave can map the live transcript back onto the plan.
+{
+  const prompt = buildWorkflowRunPrompt(dependent);
+  assert.match(prompt, /\(id: synth\)/, "each step line shows its id");
+  assert.match(prompt, /@@step-start <id>/, "prompt documents the start marker");
+  assert.match(prompt, /@@step-done <id>/, "prompt documents the done marker");
+  assert.match(prompt, /@@step-fail <id>/, "prompt documents the fail marker");
 }
 
 console.log("workflow-run-prompt.test.ts ✓");

--- a/src/lib/workflow-run-prompt.ts
+++ b/src/lib/workflow-run-prompt.ts
@@ -13,7 +13,7 @@ import type { WorkflowStepSummary, WorkflowSummary } from "./workflows.ts";
  */
 
 function stepLine(step: WorkflowStepSummary, index: number): string {
-  const parts: string[] = [`${index + 1}. [${step.kind}] ${step.name ?? step.id}`];
+  const parts: string[] = [`${index + 1}. [${step.kind}] ${step.name ?? step.id} (id: ${step.id})`];
   if (step.uses) parts.push(`uses: ${step.uses}`);
   if (step.requires && step.requires.length > 0) parts.push(`after: ${step.requires.join(", ")}`);
   if (step.on_error) parts.push(`on_error: ${step.on_error}`);
@@ -98,6 +98,21 @@ export function buildWorkflowRunPrompt(workflow: WorkflowSummary, inputs?: Recor
     "Work through the plan end to end. Where a step names a skill, tool, or sub-workflow, use it.",
     "Stop and ask before any destructive or irreversible action. Report what each step produced as you go.",
   );
+
+  if (steps.length > 0) {
+    // Progress protocol: lets Cave map your live transcript back onto the plan
+    // and show each step's status + output. Keep markers on their own line.
+    lines.push(
+      "",
+      "Progress markers — print these on their own line so progress can be tracked:",
+      "- Before starting a step, print:  @@step-start <id>",
+      "- After a step succeeds, print:    @@step-done <id>",
+      "- If a step fails, print:          @@step-fail <id>",
+      "Use the exact id shown in parentheses for each step above. Between a step's",
+      "start and done markers, narrate what you're doing and show the step's output —",
+      "that narration is surfaced as the step's debugging detail.",
+    );
+  }
 
   return lines.join("\n");
 }

--- a/src/lib/workflow-step-progress.test.ts
+++ b/src/lib/workflow-step-progress.test.ts
@@ -1,0 +1,82 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { parseWorkflowStepProgress } from "./workflow-step-progress.ts";
+
+const ORDER = ["gather", "draft", "review", "publish"];
+
+// 1. No markers at all → everything pending, markersFound false (UI falls back).
+{
+  const r = parseWorkflowStepProgress("just some prose, no markers here", ORDER);
+  assert.equal(r.markersFound, false, "no markers detected");
+  assert.deepEqual(r.steps.map((s) => s.status), ["pending", "pending", "pending", "pending"]);
+  assert.equal(r.activeStepId, null);
+  assert.equal(r.done, false);
+}
+
+// 2. Mid-run: first done, second active.
+{
+  const t = [
+    "@@step-start gather",
+    "pulled 12 sources from the repo",
+    "@@step-done gather",
+    "@@step-start draft",
+    "writing the first pass now…",
+  ].join("\n");
+  const r = parseWorkflowStepProgress(t, ORDER);
+  assert.equal(r.markersFound, true);
+  assert.deepEqual(r.steps.map((s) => s.status), ["succeeded", "active", "pending", "pending"]);
+  assert.equal(r.activeStepId, "draft");
+  assert.equal(r.done, false);
+  assert.match(r.steps[0].detail, /pulled 12 sources/, "gather captures its narration");
+  assert.match(r.steps[1].detail, /writing the first pass/, "draft captures its in-progress narration");
+}
+
+// 3. Full success → all succeeded, done true, no active.
+{
+  const t = ORDER.flatMap((id) => [`@@step-start ${id}`, `did ${id}`, `@@step-done ${id}`]).join("\n");
+  const r = parseWorkflowStepProgress(t, ORDER);
+  assert.deepEqual(r.steps.map((s) => s.status), ["succeeded", "succeeded", "succeeded", "succeeded"]);
+  assert.equal(r.activeStepId, null);
+  assert.equal(r.done, true);
+}
+
+// 4. Failure is terminal for that step.
+{
+  const t = [
+    "@@step-start gather", "ok", "@@step-done gather",
+    "@@step-start draft", "couldn't reach the API", "@@step-fail draft",
+  ].join("\n");
+  const r = parseWorkflowStepProgress(t, ORDER);
+  assert.equal(r.steps[1].status, "failed");
+  assert.match(r.steps[1].detail, /couldn't reach the API/);
+  assert.equal(r.activeStepId, null, "a failed (not running) step isn't active");
+}
+
+// 5. Implicit succession: a step that started but the agent moved on without a
+//    @@step-done is treated as succeeded, not stuck-active.
+{
+  const t = [
+    "@@step-start gather", "forgot to close this one",
+    "@@step-start draft", "moved straight on",
+  ].join("\n");
+  const r = parseWorkflowStepProgress(t, ORDER);
+  assert.equal(r.steps[0].status, "succeeded", "superseded start is implicitly succeeded");
+  assert.equal(r.steps[1].status, "active", "latest open start is active");
+  assert.equal(r.activeStepId, "draft");
+}
+
+// 6. Unknown ids the agent invents (or echoes from the prompt) are ignored.
+{
+  const t = ["@@step-start bogus", "noise", "@@step-start gather", "real work"].join("\n");
+  const r = parseWorkflowStepProgress(t, ORDER);
+  assert.equal(r.activeStepId, "gather");
+  assert.equal(r.steps.find((s) => s.id === "gather").status, "active");
+}
+
+// 7. Markers must be on their own line (won't match mid-sentence prose).
+{
+  const r = parseWorkflowStepProgress("we will @@step-start gather when ready", ORDER);
+  assert.equal(r.markersFound, false, "inline mention is not a marker");
+}
+
+console.log("workflow-step-progress.test.ts: ok");

--- a/src/lib/workflow-step-progress.ts
+++ b/src/lib/workflow-step-progress.ts
@@ -1,0 +1,130 @@
+/**
+ * Derive live per-step progress for a workflow run from the executing agent's
+ * transcript.
+ *
+ * A Cave workflow run is a single agent session carrying out a compiled
+ * step-plan prompt (see `workflow-run-prompt.ts`); there is no server-side step
+ * engine emitting telemetry. To surface "which step are we on, and what is the
+ * agent doing", the run prompt asks the agent to print a marker line as it
+ * enters and leaves each step:
+ *
+ *   @@step-start <id>
+ *   …the agent's work / reasoning / output for that step…
+ *   @@step-done <id>      (or @@step-fail <id>)
+ *
+ * This pure parser maps that transcript back onto the manifest's ordered steps,
+ * capturing the text between a step's start marker and the next marker as that
+ * step's debug detail. It's deliberately tolerant: a step that started and was
+ * superseded by a later start is treated as implicitly succeeded, and a run
+ * whose agent emitted no markers at all reports `markersFound: false` so the UI
+ * can fall back to showing the raw transcript.
+ */
+
+export type WorkflowStepProgressStatus = "pending" | "active" | "succeeded" | "failed";
+
+export type WorkflowStepProgress = {
+  id: string;
+  status: WorkflowStepProgressStatus;
+  /** Agent narration captured while this step was active — the debug detail. */
+  detail: string;
+};
+
+export type WorkflowStepProgressResult = {
+  steps: WorkflowStepProgress[];
+  /** The step currently being worked (last start without a matching done/fail), or null. */
+  activeStepId: string | null;
+  /** True once every step has resolved to succeeded/failed (none pending/active). */
+  done: boolean;
+  /** False when the agent emitted no recognizable step markers at all. */
+  markersFound: boolean;
+};
+
+type Marker = { kind: "start" | "done" | "fail"; id: string; at: number; end: number };
+
+const MARKER_RE = /^[ \t]*@@step-(start|done|fail)[ \t]+(\S+)[ \t]*$/gim;
+const MAX_DETAIL = 4000;
+
+/** Extract every step marker in source order. */
+function findMarkers(transcript: string): Marker[] {
+  const markers: Marker[] = [];
+  MARKER_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = MARKER_RE.exec(transcript)) !== null) {
+    markers.push({ kind: m[1] as Marker["kind"], id: m[2], at: m.index, end: m.index + m[0].length });
+  }
+  return markers;
+}
+
+function clip(text: string): string {
+  const trimmed = text.trim();
+  return trimmed.length > MAX_DETAIL ? `${trimmed.slice(0, MAX_DETAIL)}\n…` : trimmed;
+}
+
+/**
+ * @param transcript  Flattened assistant output for the run's session.
+ * @param orderedStepIds  Manifest step ids in execution order.
+ */
+export function parseWorkflowStepProgress(
+  transcript: string,
+  orderedStepIds: string[],
+): WorkflowStepProgressResult {
+  const markers = findMarkers(transcript ?? "");
+  const known = new Set(orderedStepIds);
+  // Only trust markers that name a real step (guards against the agent echoing
+  // the instruction text or inventing ids).
+  const real = markers.filter((mk) => known.has(mk.id));
+
+  const status = new Map<string, WorkflowStepProgressStatus>();
+  const detail = new Map<string, string>();
+  for (const id of orderedStepIds) status.set(id, "pending");
+
+  // Resolve explicit terminal verdicts first.
+  for (const mk of real) {
+    if (mk.kind === "done") status.set(mk.id, "succeeded");
+    else if (mk.kind === "fail") status.set(mk.id, "failed");
+  }
+
+  // The active step is the LAST start that has no later done/fail for the same id.
+  let activeStepId: string | null = null;
+  for (let i = real.length - 1; i >= 0; i--) {
+    const mk = real[i];
+    if (mk.kind !== "start") continue;
+    const resolvedLater = real
+      .slice(i + 1)
+      .some((n) => n.id === mk.id && (n.kind === "done" || n.kind === "fail"));
+    if (!resolvedLater) {
+      if (status.get(mk.id) === "pending") {
+        status.set(mk.id, "active");
+        activeStepId = mk.id;
+      }
+      break;
+    }
+  }
+
+  // A step that started but was superseded by a later marker (and never got an
+  // explicit done/fail) is implicitly succeeded — the agent moved on.
+  for (const mk of real) {
+    if (mk.kind === "start" && status.get(mk.id) === "pending") {
+      status.set(mk.id, "succeeded");
+    }
+  }
+
+  // Capture each start's detail = text up to the next marker of any step.
+  for (let i = 0; i < real.length; i++) {
+    const mk = real[i];
+    if (mk.kind !== "start") continue;
+    const next = real[i + 1]?.at ?? transcript.length;
+    const slice = clip(transcript.slice(mk.end, next));
+    if (slice) detail.set(mk.id, slice);
+  }
+
+  const steps: WorkflowStepProgress[] = orderedStepIds.map((id) => ({
+    id,
+    status: status.get(id) ?? "pending",
+    detail: detail.get(id) ?? "",
+  }));
+
+  const done = steps.length > 0 && steps.every((s) => s.status === "succeeded" || s.status === "failed");
+
+  return { steps, activeStepId, done, markersFound: real.length > 0 };
+}

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -146,6 +146,11 @@ export type WorkflowRunRecord = {
   steps: WorkflowRunStepRecord[];
   summary?: string;
   source: "cave" | "daemon";
+  /**
+   * The agent session carrying out this run (session executor). Lets the run
+   * panel pull the live transcript to derive per-step progress + debug detail.
+   */
+  sessionId?: string;
 };
 
 export type SaveWorkflowResponse = {

--- a/src/styles/workflows.css
+++ b/src/styles/workflows.css
@@ -2417,3 +2417,85 @@
     transform: rotate(360deg);
   }
 }
+
+/* ── Live per-step run progress (session-executor runs) ───────────────────── */
+.workflow-run-progress {
+  display: grid;
+  gap: 6px;
+  margin: 4px 0 8px;
+}
+
+.workflow-run-progress-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--foreground);
+}
+.workflow-run-progress-head .workflow-spin {
+  color: var(--accent-presence, #8b85f0);
+}
+
+.workflow-progress-steps {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 2px;
+}
+
+.workflow-progress-step {
+  display: grid;
+  gap: 2px;
+}
+
+.workflow-progress-step-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  text-align: left;
+  font-size: 11.5px;
+  padding: 3px 5px;
+  border: none;
+  background: transparent;
+  border-radius: 5px;
+  color: var(--foreground);
+  cursor: pointer;
+}
+.workflow-progress-step-row:hover:not(:disabled) {
+  background: var(--bg-hover, rgba(255, 255, 255, 0.05));
+}
+.workflow-progress-step-row:disabled {
+  cursor: default;
+}
+.workflow-progress-step-row .iconify {
+  flex: none;
+}
+
+/* Status colours mirror the recorded-step palette. */
+.workflow-progress-step--pending .workflow-progress-step-row > .iconify:first-child { color: var(--muted-foreground); }
+.workflow-progress-step--active .workflow-progress-step-row > .iconify:first-child { color: var(--accent-presence, #8b85f0); }
+.workflow-progress-step--succeeded .workflow-progress-step-row > .iconify:first-child { color: var(--color-success, #57c878); }
+.workflow-progress-step--failed .workflow-progress-step-row > .iconify:first-child { color: var(--color-danger, #e5484d); }
+.workflow-progress-step--active .workflow-run-step-status { color: var(--accent-presence, #8b85f0); }
+
+.workflow-progress-step-detail {
+  margin: 0 0 2px 24px;
+  padding: 7px 9px;
+  max-height: 260px;
+  overflow: auto;
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--code-bg, rgba(0, 0, 0, 0.25));
+  border: 1px solid var(--border-hairline);
+  border-radius: 6px;
+  color: var(--text-secondary, var(--foreground));
+}
+.workflow-progress-raw {
+  margin-left: 0;
+  max-height: 320px;
+}


### PR DESCRIPTION
## Problem

A Cave workflow doesn't run step-by-step — the executor compiles the manifest into one prompt and spawns a **single agent session** to carry it out (`runViaSession`). So a running workflow showed only a frozen list of all-`ready` steps, with zero visibility into which step the agent was on or what it was doing.

## Approach

Bridge the gap **without** a daemon step-engine, by reading the agent's own transcript:

1. **Instrument the run prompt** — `workflow-run-prompt.ts` now shows each step's `id` and asks the agent to print `@@step-start <id>` / `@@step-done <id>` / `@@step-fail <id>` markers on their own line, narrating its work in between.
2. **Pure parser** — `workflow-step-progress.ts` maps the transcript back onto the manifest's steps → per-step status (`pending`/`active`/`succeeded`/`failed`) + the narration captured for each step (its **debug detail**). Tolerant: reports `markersFound:false` when the agent emitted nothing parseable (UI falls back to raw output), and handles superseded/implicit completions. **7 unit cases.**
3. **Persist `sessionId`** on the run record so the UI can fetch the transcript.
4. **Live UI** — new `WorkflowRunProgress` polls `/api/chat/conversation/[id]` (which reads the daemon `.jsonl` transcript), parses it, and renders a live step list: status icons, a spinning **active** step, and each step's agent narration on demand. Wired into the runs panel for session runs; daemon/replay runs keep the recorded static list.

## Tests & verification

Parser + prompt-marker guard tests (registered in `scripts/run-tests.mjs`); typecheck clean; prod build green.

Verified on a running server with a mocked run + transcript:

> Header **"Running: draft"** · `gather` → ✅ succeeded (output expandable) · `draft` → ◌ active · `review` / `publish` → pending.

Statuses parsed live as `["succeeded","active","pending","pending"]`.

## Notes / future

This reads what the agent *says* it's doing. It's honest about that — if a daemon-native workflow engine ever lands (the run route already prefers it), the same UI can be fed real step telemetry. A natural follow-up is persisting parsed step outcomes back to the run record so finished runs replay the breakdown offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)