### PR TITLE
feat(ios): export all chats as a .zip

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -765,6 +765,44 @@ final class AppModel {
         return copy
     }
 
+    /// Bundle every thread's Markdown into a single `.zip` and return its URL.
+    /// Filenames come from titles (de-duplicated); zipping uses NSFileCoordinator's
+    /// `.forUploading`, so there's no third-party dependency.
+    func exportAllThreadsZip() throws -> URL {
+        let fm = FileManager.default
+        let staging = fm.temporaryDirectory
+            .appendingPathComponent("CovenCave Chats-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: staging, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: staging) }
+
+        let invalid = CharacterSet(charactersIn: "/\\:?%*|\"<>")
+        var used = Set<String>()
+        for thread in threads {
+            let trimmed = thread.title.trimmingCharacters(in: .whitespacesAndNewlines)
+            var base = ""
+            for scalar in (trimmed.isEmpty ? "chat" : trimmed).unicodeScalars {
+                base.append(invalid.contains(scalar) ? "-" : Character(scalar))
+            }
+            var name = base
+            var n = 2
+            while used.contains(name.lowercased()) { name = "\(base) \(n)"; n += 1 }
+            used.insert(name.lowercased())
+            try exportMarkdown(thread)
+                .write(to: staging.appendingPathComponent("\(name).md"), atomically: true, encoding: .utf8)
+        }
+
+        var zipURL: URL?
+        var coordError: NSError?
+        NSFileCoordinator().coordinate(readingItemAt: staging, options: .forUploading, error: &coordError) { tmp in
+            let dest = fm.temporaryDirectory.appendingPathComponent("CovenCave Chats.zip")
+            try? fm.removeItem(at: dest)
+            if (try? fm.copyItem(at: tmp, to: dest)) != nil { zipURL = dest }
+        }
+        if let coordError { throw coordError }
+        guard let zipURL else { throw CocoaError(.fileWriteUnknown) }
+        return zipURL
+    }
+
     func touch(_ thread: ChatThread) {
         // Move the most recently active thread to the top, then persist.
         if let idx = threads.firstIndex(where: { $0.id == thread.id }), idx != 0 {

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -5,6 +5,8 @@ struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var editingHost: String = ""
     @State private var showDeveloper = false
+    @State private var exportArchive: ExportArchive?
+    @State private var exportFailed = false
 
     var body: some View {
         NavigationStack {
@@ -20,6 +22,24 @@ struct SettingsView: View {
                     Text("Tools")
                 } footer: {
                     Text("Code browser, terminal, and GitHub.")
+                }
+
+                Section {
+                    Button {
+                        do {
+                            exportArchive = ExportArchive(url: try app.exportAllThreadsZip())
+                        } catch {
+                            exportFailed = true
+                        }
+                    } label: {
+                        Label("Export all chats", systemImage: "square.and.arrow.up.on.square")
+                            .foregroundStyle(.primary)
+                    }
+                    .disabled(app.threads.isEmpty)
+                } header: {
+                    Text("Chats")
+                } footer: {
+                    Text("Save every conversation as Markdown files in a single .zip.")
                 }
 
                 Section("Desktop") {
@@ -68,6 +88,12 @@ struct SettingsView: View {
             .sheet(isPresented: $showDeveloper) {
                 DeveloperView()
                     .presentationDragIndicator(.visible)
+            }
+            .sheet(item: $exportArchive) { archive in
+                ActivityView(items: [archive.url])
+            }
+            .alert("Couldn't export chats", isPresented: $exportFailed) {
+                Button("OK", role: .cancel) {}
             }
         }
     }

--- a/apps/ios/CovenCave/CovenCave/Views/ShareSheet.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ShareSheet.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+import UIKit
+
+/// An exportable archive on disk, wrapped so it can drive a `.sheet(item:)`.
+struct ExportArchive: Identifiable {
+    let id = UUID()
+    let url: URL
+}
+
+/// Minimal `UIActivityViewController` wrapper for sharing file URLs (the system
+/// share sheet — Save to Files, AirDrop, Mail, …).
+struct ActivityView: UIViewControllerRepresentable {
+    let items: [Any]
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+    func updateUIViewController(_ controller: UIActivityViewController, context: Context) {}
+}

--- a/scripts/ios-export-all-zip.test.mjs
+++ b/scripts/ios-export-all-zip.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+const read = (rel) => readFile(new URL(`../${rel}`, import.meta.url), "utf8");
+const iosRoot = "apps/ios/CovenCave/CovenCave";
+
+const model = await read(`${iosRoot}/State/AppModel.swift`);
+const share = await read(`${iosRoot}/Views/ShareSheet.swift`);
+const settings = await read(`${iosRoot}/Views/SettingsView.swift`);
+
+// Model zips every thread's Markdown via NSFileCoordinator (no dependency).
+assert.match(model, /func exportAllThreadsZip\(\) throws -> URL/, "AppModel should zip all threads");
+assert.match(model, /for thread in threads \{[\s\S]*exportMarkdown\(thread\)\s*\.write\(to: staging/, "writes each thread's Markdown");
+assert.match(model, /NSFileCoordinator\(\)\.coordinate\(readingItemAt: staging, options: \.forUploading/, "zips via NSFileCoordinator .forUploading");
+assert.match(model, /while used\.contains\(name\.lowercased\(\)\)/, "de-duplicates filenames");
+
+// Reusable share-sheet wrapper.
+assert.match(share, /struct ActivityView: UIViewControllerRepresentable/, "an ActivityView wrapper should exist");
+assert.match(share, /UIActivityViewController\(activityItems: items/, "wraps UIActivityViewController");
+assert.match(share, /struct ExportArchive: Identifiable/, "an Identifiable archive wrapper should exist");
+
+// Settings exposes the export, disabled when there are no chats, sharing the zip.
+assert.match(settings, /Label\("Export all chats", systemImage: "square\.and\.arrow\.up\.on\.square"\)/, "Settings should offer Export all chats");
+assert.match(settings, /ExportArchive\(url: try app\.exportAllThreadsZip\(\)\)/, "the button builds the archive");
+assert.match(settings, /\.disabled\(app\.threads\.isEmpty\)/, "export is disabled with no chats");
+assert.match(settings, /\.sheet\(item: \$exportArchive\) \{ archive in\s*ActivityView\(items: \[archive\.url\]\)/, "shares the zip via the activity sheet");
+
+console.log("ios-export-all-zip.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -504,6 +504,7 @@ export const SUITES = {
     "scripts/ios-export-markdown.test.mjs",
     "scripts/ios-import-markdown.test.mjs",
     "scripts/ios-duplicate-thread.test.mjs",
+    "scripts/ios-export-all-zip.test.mjs",
     "scripts/ios-reorder-familiars.test.mjs",
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/mobile-tailscale.test.mjs",


### PR DESCRIPTION
## What

Adds **"Export all chats"** to **Settings** → bundles every thread's Markdown transcript into a single **`.zip`** and shares it through the system sheet (Save to Files, AirDrop, Mail, …).

- **`AppModel.exportAllThreadsZip()`** — writes each thread's `exportMarkdown` to a staging folder (titles → de-duplicated filenames), then zips it with **`NSFileCoordinator`'s `.forUploading`** (no third-party dependency). Returns the zip URL.
- **`ShareSheet.swift`** — a reusable **`ActivityView`** (`UIActivityViewController` wrapper) and an `ExportArchive` value for `.sheet(item:)`.
- **`SettingsView`** — a **Chats** section with the export button (disabled when there are no chats) and the share sheet.

Builds on the per-thread Markdown export (#1678).

## Verification

- `pnpm test:mobile` → **✓ 37 test file(s) passed** (full suite; new `scripts/ios-export-all-zip.test.mjs` registered).
- `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED**.

Interactive export (Settings → Export → share sheet) needs gestures I can't drive headlessly without `idb`, so it rests on build + assertion test + the standard `NSFileCoordinator`/`UIActivityViewController` patterns.

> Built via an atomic sibling-worktree one-shot (commit+push before build) because the in-repo `.worktrees/` keeps getting swept by concurrent-session cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)