### PR TITLE
feat(ios): restore Settings as a tab (+ About/version, disconnect confirm); step haptics

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -3,7 +3,7 @@ import Observation
 
 /// The bottom tabs. Lifted out of the view so slash commands (`/board`,
 /// `/chats`) can drive tab selection from anywhere.
-enum AppTab: String { case chats, read, tasks, dev }
+enum AppTab: String { case chats, read, tasks, dev, settings }
 
 /// A transient confirmation banner shown over the chat after a command runs.
 struct ToastMessage: Identifiable, Equatable {

--- a/apps/ios/CovenCave/CovenCave/Views/ReadingView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ReadingView.swift
@@ -347,7 +347,7 @@ struct ReadingProgressSlider: View {
     var body: some View {
         HStack(spacing: 10) {
             Slider(value: $value, in: 0...100, step: 1) { editing in
-                if !editing { onCommit(Int(value.rounded())) }
+                if !editing { Haptics.tap(); onCommit(Int(value.rounded())) }
             }
             .tint(.accentColor)
             Text("\(Int(value.rounded()))%")

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -43,6 +43,9 @@ struct MainTabView: View {
             Tab("Developer", systemImage: "chevron.left.forwardslash.chevron.right", value: AppTab.dev) {
                 DeveloperView()
             }
+            Tab("Settings", systemImage: "gearshape.fill", value: AppTab.settings) {
+                SettingsView()
+            }
         }
         // Command confirmations float above the whole tab bar so they're visible
         // whether a command stays in chat or jumps to the Tasks tab.

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -2,28 +2,22 @@ import SwiftUI
 
 struct SettingsView: View {
     @Environment(AppModel.self) private var app
-    @Environment(\.dismiss) private var dismiss
     @State private var editingHost: String = ""
-    @State private var showDeveloper = false
+    @State private var showDisconnectConfirm = false
     @State private var exportArchive: ExportArchive?
     @State private var exportFailed = false
+
+    /// Marketing version + build, e.g. "1.2.0 (34)", read from the bundle.
+    private var appVersion: String {
+        let info = Bundle.main.infoDictionary
+        let version = info?["CFBundleShortVersionString"] as? String ?? "—"
+        let build = info?["CFBundleVersion"] as? String ?? "—"
+        return "\(version) (\(build))"
+    }
 
     var body: some View {
         NavigationStack {
             Form {
-                Section {
-                    Button {
-                        showDeveloper = true
-                    } label: {
-                        Label("Developer", systemImage: "chevron.left.forwardslash.chevron.right")
-                            .foregroundStyle(.primary)
-                    }
-                } header: {
-                    Text("Tools")
-                } footer: {
-                    Text("Code browser, terminal, and GitHub.")
-                }
-
                 Section {
                     Button {
                         do {
@@ -60,34 +54,37 @@ struct SettingsView: View {
                         .autocorrectionDisabled()
                         .keyboardType(.URL)
                     Button("Save & reconnect") {
-                        Task {
-                            await app.configure(host: editingHost)
-                            dismiss()
-                        }
+                        Task { await app.configure(host: editingHost) }
                     }
                     .disabled(editingHost.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
 
                 Section {
                     Button("Disconnect", role: .destructive) {
-                        app.disconnect()
-                        dismiss()
+                        showDisconnectConfirm = true
                     }
                 } footer: {
                     Text("Connection is trusted via your Tailscale network — there is no token or password to manage.")
+                }
+
+                Section("About") {
+                    LabeledContent("Version") {
+                        Text(appVersion)
+                            .font(.callout.monospaced())
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
             .onAppear { editingHost = app.connection?.host ?? "" }
-            // Developer (code/terminal/GitHub) was demoted from a tab; present it
-            // as a full-height sheet so its sub-views' own navigation stacks
-            // render cleanly. Wrapping it in another NavigationStack (e.g. for a
-            // push) would double-nest the nav bars; the sheet's grabber handles
-            // dismissal instead.
-            .sheet(isPresented: $showDeveloper) {
-                DeveloperView()
-                    .presentationDragIndicator(.visible)
+            .confirmationDialog("Disconnect from your desktop?",
+                                isPresented: $showDisconnectConfirm,
+                                titleVisibility: .visible) {
+                Button("Disconnect", role: .destructive) { app.disconnect() }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("You'll need to re-enter your desktop address to reconnect.")
             }
             .sheet(item: $exportArchive) { archive in
                 ActivityView(items: [archive.url])

--- a/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
@@ -181,7 +181,7 @@ struct TaskDetailView: View {
                 .tint(Theme.color(for: live.status))
             VStack(alignment: .leading, spacing: 10) {
                 ForEach(live.steps ?? []) { step in
-                    Button { Task { await app.toggleStep(live, stepId: step.id) } } label: {
+                    Button { Haptics.tap(); Task { await app.toggleStep(live, stepId: step.id) } } label: {
                         HStack(alignment: .top, spacing: 10) {
                             Image(systemName: step.done ? "checkmark.circle.fill" : "circle")
                                 .foregroundStyle(step.done ? Color.green : Color.secondary)

--- a/scripts/ios-no-canvas-tab.test.mjs
+++ b/scripts/ios-no-canvas-tab.test.mjs
@@ -13,7 +13,7 @@ const slash = await read(`${iosRoot}/Models/SlashCommand.swift`);
 // The bottom-tab enum no longer carries a canvas case.
 assert.match(
   model,
-  /enum AppTab: String \{ case chats, read, tasks, dev \}/,
+  /enum AppTab: String \{ case chats, read, tasks, dev, settings \}/,
   "AppTab should drop the canvas case",
 );
 const appTabLine = model.match(/enum AppTab: String \{[^}]*\}/)?.[0] ?? "";

--- a/scripts/ios-task-actions.test.mjs
+++ b/scripts/ios-task-actions.test.mjs
@@ -78,8 +78,8 @@ assert.match(
 assert.match(detail, /private var actionsMenu: some View/, "detail view should have an actions menu");
 assert.match(
   detail,
-  /Button \{ Task \{ await app\.toggleStep\(live, stepId: step\.id\) \} \}/,
-  "detail steps should be tappable to toggle done",
+  /Button \{ Haptics\.tap\(\); Task \{ await app\.toggleStep\(live, stepId: step\.id\) \} \}/,
+  "detail steps should be tappable to toggle done (with haptic confirmation)",
 );
 assert.match(
   detail,


### PR DESCRIPTION
## What

While building the planned Settings polish I found `SettingsView` was **orphaned dead code** — it had been the 4th tab until Developer took that slot, so once connected there was **no way to change host, disconnect, or see app info at all** (you'd have to go unreachable to get `ConnectionView` back). Per a quick check with the requester, the fix is to **restore Settings as a 5th bottom tab** and fold in the two polish items it was going to get.

### Settings (now a real tab again)
- New 5th `Tab` → `SettingsView` (gear icon); `AppTab` gains a `settings` case.
- **About** section showing app version + build (read from the bundle).
- **Disconnect** now goes through a `confirmationDialog` (matching every other destructive action in the app).
- Dropped the now-redundant in-Settings "Developer" shortcut (Developer is its own tab) and the sheet-only `dismiss()` calls that don't apply in a tab context.

### Haptic consistency (already-live surfaces)
- **Task detail**: checking off a checklist step now triggers `Haptics.tap()` (`TaskDetailView`).
- **Reading**: committing the progress slider now taps (`ReadingView`).

## Files
- `AppModel.swift` — `AppTab` gains `settings`
- `RootView.swift` — 5th Settings tab
- `SettingsView.swift` — About/version, disconnect confirmation, drop redundant Developer section + dismiss
- `TaskDetailView.swift`, `ReadingView.swift` — haptics
- `ios-no-canvas-tab.test.mjs` (pins the AppTab enum) + `ios-task-actions.test.mjs` (pins step-toggle markup) — updated to match

## Verification
- `xcodebuild` for the iPhone 16 Pro simulator → **BUILD SUCCEEDED**.
- iOS tests `ios-no-canvas-tab`, `ios-task-actions`, `ios-slash-commands`, `ios-github-comment-attach` → all **ok**.
- Ran on the simulator: the **Settings tab is now present and reachable** (screenshotted), showing Desktop/status, Change host, Disconnect, and About.

> Note: iOS Swift isn't compiled by the required CI checks, so this was verified locally via `xcodebuild` + simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)