### PR TITLE
feat(ios): bulk-delete threads in a familiar's chat list

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -651,6 +651,13 @@ final class AppModel {
         persistThreads()
     }
 
+    /// Delete several threads at once (bulk select); persists once.
+    func deleteThreads(_ ids: Set<String>) {
+        guard !ids.isEmpty else { return }
+        threads.removeAll { ids.contains($0.id) }
+        persistThreads()
+    }
+
     /// Rename a thread (local title only); no-ops on a blank or unchanged name.
     func renameThread(_ thread: ChatThread, to title: String) {
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -14,6 +14,10 @@ struct FamiliarThreadsView: View {
     @State private var pendingDelete: ChatThread?
     /// Reveal archived on-device threads.
     @State private var showArchived = false
+    /// Multi-select bulk-delete mode.
+    @State private var selectMode = false
+    @State private var selectedIds: Set<String> = []
+    @State private var confirmingBulkDelete = false
 
     /// One row in the list: an on-device thread or a server-only session.
     private enum Entry: Identifiable {
@@ -69,20 +73,60 @@ struct FamiliarThreadsView: View {
                 }
             }
             ToolbarItem(placement: .topBarTrailing) {
-                Button(action: startNewChat) {
-                    Image(systemName: "square.and.pencil")
+                if selectMode {
+                    Button("Cancel") { exitSelect() }
+                } else {
+                    Button(action: startNewChat) {
+                        Image(systemName: "square.and.pencil")
+                    }
+                    .accessibilityLabel("New chat")
                 }
-                .accessibilityLabel("New chat")
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                if !selectMode && hasLocalThreads {
+                    Button("Select") { withAnimation { selectMode = true } }
+                }
             }
         }
         .refreshable { await app.loadSessions() }
         .task { await app.loadSessions() }
+        .safeAreaInset(edge: .bottom) {
+            if selectMode {
+                HStack {
+                    Button(allLocalSelected ? "Deselect All" : "Select All") { toggleSelectAll() }
+                    Spacer()
+                    Button(role: .destructive) { confirmingBulkDelete = true } label: {
+                        Text(selectedIds.isEmpty ? "Delete" : "Delete (\(selectedIds.count))")
+                            .fontWeight(.semibold)
+                    }
+                    .disabled(selectedIds.isEmpty)
+                }
+                .padding(.horizontal, 20).padding(.vertical, 12)
+                .background(.bar)
+            }
+        }
+        .confirmationDialog(bulkDeleteTitle, isPresented: $confirmingBulkDelete, titleVisibility: .visible) {
+            Button("Delete \(selectedIds.count)", role: .destructive) {
+                app.deleteThreads(selectedIds)
+                exitSelect()
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+    }
+
+    private var bulkDeleteTitle: String {
+        "Delete \(selectedIds.count) chat\(selectedIds.count == 1 ? "" : "s")?"
     }
 
     private var threadList: some View {
         List {
             ForEach(entries) { entry in
-                Button { open(entry) } label: { row(entry) }
+                Button { tapEntry(entry) } label: {
+                    HStack(spacing: 12) {
+                        if selectMode { selectionMark(for: entry) }
+                        row(entry)
+                    }
+                }
                     .buttonStyle(.plain)
                     .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
                     // Only on-device threads can be renamed/deleted from here; a
@@ -165,6 +209,43 @@ struct FamiliarThreadsView: View {
 
     private var deleteDialogBinding: Binding<Bool> {
         Binding(get: { pendingDelete != nil }, set: { if !$0 { pendingDelete = nil } })
+    }
+
+    // MARK: - Bulk select
+
+    private var localThreads: [ChatThread] {
+        app.directThreads(for: familiar.id).filter { showArchived || !$0.archived }
+    }
+    private var hasLocalThreads: Bool { !app.directThreads(for: familiar.id).isEmpty }
+    private var allLocalSelected: Bool {
+        !localThreads.isEmpty && Set(localThreads.map(\.id)).isSubset(of: selectedIds)
+    }
+
+    private func tapEntry(_ entry: Entry) {
+        if selectMode {
+            if case .local(let thread) = entry { toggleSelection(thread.id) }
+        } else {
+            open(entry)
+        }
+    }
+    private func toggleSelection(_ id: String) {
+        if selectedIds.contains(id) { selectedIds.remove(id) } else { selectedIds.insert(id) }
+    }
+    private func toggleSelectAll() {
+        if allLocalSelected { selectedIds.removeAll() } else { selectedIds = Set(localThreads.map(\.id)) }
+    }
+    private func exitSelect() {
+        withAnimation { selectMode = false; selectedIds.removeAll() }
+    }
+
+    @ViewBuilder private func selectionMark(for entry: Entry) -> some View {
+        if case .local(let thread) = entry {
+            Image(systemName: selectedIds.contains(thread.id) ? "checkmark.circle.fill" : "circle")
+                .font(.title3)
+                .foregroundStyle(selectedIds.contains(thread.id) ? Color.accentColor : Color.secondary)
+        } else {
+            Image(systemName: "circle").font(.title3).foregroundStyle(.quaternary)
+        }
     }
 
     @ViewBuilder

--- a/scripts/ios-bulk-delete-threads.test.mjs
+++ b/scripts/ios-bulk-delete-threads.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+const read = (rel) => readFile(new URL(`../${rel}`, import.meta.url), "utf8");
+const iosRoot = "apps/ios/CovenCave/CovenCave";
+
+const model = await read(`${iosRoot}/State/AppModel.swift`);
+const view = await read(`${iosRoot}/Views/FamiliarThreadsView.swift`);
+
+// Model deletes a set of threads in one persist.
+assert.match(
+  model,
+  /func deleteThreads\(_ ids: Set<String>\) \{[\s\S]*threads\.removeAll \{ ids\.contains\(\$0\.id\) \}\s*persistThreads\(\)/,
+  "AppModel.deleteThreads should bulk-remove and persist",
+);
+
+// View has a select mode, selection marks, and a bulk-delete bar.
+assert.match(view, /@State private var selectMode = false/, "view should have a select mode");
+assert.match(view, /@State private var selectedIds: Set<String> = \[\]/, "view should track selected ids");
+assert.match(view, /if selectMode \{ selectionMark\(for: entry\) \}/, "rows show a selection mark in select mode");
+assert.match(view, /func tapEntry\(_ entry: Entry\) \{[\s\S]*if selectMode \{[\s\S]*toggleSelection\(thread\.id\)/, "tapping a row toggles selection in select mode");
+assert.match(view, /Button\("Select"\) \{ withAnimation \{ selectMode = true \} \}/, "a Select action enters the mode");
+assert.match(view, /Text\(selectedIds\.isEmpty \? "Delete" : "Delete \(\\\(selectedIds\.count\)\)"\)/, "a Delete (N) button reflects the count");
+assert.match(view, /app\.deleteThreads\(selectedIds\)\s*exitSelect\(\)/, "confirming deletes the selection then exits");
+assert.match(view, /Set\(localThreads\.map\(\\\.id\)\)\.isSubset\(of: selectedIds\)/, "Select All covers every local thread");
+// Server-only sessions can't be bulk-deleted.
+assert.match(view, /if case \.local\(let thread\) = entry \{ toggleSelection\(thread\.id\) \}/, "only local threads are selectable");
+
+console.log("ios-bulk-delete-threads.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -505,6 +505,7 @@ export const SUITES = {
     "scripts/ios-import-markdown.test.mjs",
     "scripts/ios-duplicate-thread.test.mjs",
     "scripts/ios-export-all-zip.test.mjs",
+    "scripts/ios-bulk-delete-threads.test.mjs",
     "scripts/ios-reorder-familiars.test.mjs",
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/mobile-tailscale.test.mjs",


### PR DESCRIPTION
## What

Adds a **multi-select mode** to `FamiliarThreadsView` so you can delete several chats with one familiar at once.

- **`AppModel.deleteThreads(_:)`** — removes a set of threads in a single persist.
- **`FamiliarThreadsView`**:
  - A **"Select"** toolbar action enters select mode (replaces the New-chat button with **Cancel**).
  - Rows show a **checkmark circle**; tapping toggles selection. **Server-only sessions** (which live on the desktop) are not selectable.
  - A bottom bar offers **Select All / Deselect All** and a destructive **"Delete (N)"** with a confirmation dialog; **Cancel** exits and clears.

Uses the proven container-scoped select pattern (custom select mode rather than `EditMode`, so it doesn't collide with anything).

## Scope
Per-familiar direct threads (where chats accumulate). Group threads in the Chats home already have swipe + context delete; bulk-select there would collide with the familiar-reorder edit mode, so it's intentionally out of scope here — easy follow-up if you want it.

## Verification

- `pnpm test:mobile` → **✓ 38 test file(s) passed** (full suite; new `scripts/ios-bulk-delete-threads.test.mjs` registered).
- `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED**.

Interactive select/delete needs gestures I can't drive headlessly without `idb`, so it rests on build + assertion test.

> Built via an atomic sibling-worktree one-shot (commit+push before build) because the in-repo `.worktrees/` keeps getting swept by concurrent-session cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)