### PR TITLE
feat(projects): persist expand/collapse + list-density toggle

### DIFF
--- a/docs/projects-view-native-redesign.md
+++ b/docs/projects-view-native-redesign.md
@@ -1,0 +1,217 @@
+# Projects View — Native-App Redesign Plan
+
+> Goal: make the **Projects** tab (Sessions · Memory · **Projects**) feel like a
+> first-class native application surface — Linear/Things/Finder-grade density,
+> motion, and keyboard-first interaction — while staying inside Cave's tokenized
+> theme system and the existing data model.
+
+Status: **proposal / awaiting approval.** Implementation is gated behind the
+PR-only-to-`main` rule (see `CLAUDE.md`).
+
+---
+
+## 1. Where we are today
+
+The entire surface is one 1,057-line file: `src/components/projects-view.tsx`
+(`ProjectsView` → `ProjectRow` → `ProjectChatRow`). Data comes from
+`useProjects()` (`GET /api/projects`) plus a `sessions` prop
+(`GET /api/sessions/list`); status from the pure `deriveProjectStatus()`
+(`src/lib/project-status.ts`); ordering from `chat-session-order.ts` +
+`use-project-overrides.ts`. Styling is 100% inline Tailwind against tokens
+(`--bg-base`, `--bg-raised`, `--accent-presence`, `--text-*`,
+`--border-hairline`) defined in `src/app/globals.css` (multi-theme aware).
+
+It already does a lot right: filter, recency sort, status dots, drag-reorder,
+cross-project move, two-step deletes, empty/error/skeleton states, `/`-to-search,
+command-palette focus events, icon allowlist, and a 239-line markup-pinning test
+(`projects-view.test.ts`).
+
+### What keeps it from feeling native (from the screenshot + code)
+
+| # | Gap | Evidence |
+|---|-----|----------|
+| 1 | **Sparse, web-list rhythm.** Big vertical padding (`py-3`), bullet-dot + plain text rows, lots of dead space. No density to scan 57 sessions. | screenshot; `px-2 py-3` rows |
+| 2 | **Inconsistent / missing metadata.** Some rows show time ("Jun 15", "6m ago"), most show nothing. No model, no status glyph, no branch/PR/diff at a glance. `Task:` is a text prefix, not a visual affordance. | screenshot rows |
+| 3 | **State doesn't persist.** Expand/collapse always starts collapsed (`expanded:false`); no density, no sort preference. Every visit loses context. | `projects-view.tsx:241` |
+| 4 | **Reinvented primitives.** Bare `<button>` instead of `ui/button`; a hand-rolled select toolbar instead of `ui/selection-toolbar` + `lib/use-multi-select`. Inconsistent with the rest of the app. | Explore report §6, §9 |
+| 5 | **No keyboard navigation** across rows (arrow up/down, range-select, type-ahead), **no right-click context menu** — both table stakes for native feel. | — |
+| 6 | **Touch / coarse-pointer.** Actions reveal on hover (`group-hover:opacity-100`) — invisible on touch. | `projects-view.tsx` action cluster |
+| 7 | **No virtualization.** "Show all 57 sessions" renders every row; large projects jank. | `CHAT_CAP = 8` + full render |
+| 8 | **No motion.** Expand/collapse is an instant DOM swap; no height animation, no drag drop-indicator, no selection spring. | — |
+| 9 | **Quiet affordances.** Project toolbar (chat/terminal/edit/delete) is icon-only and hover-hidden; discoverability is low. | screenshot |
+
+---
+
+## 2. Design north star
+
+Three reference bars, all reachable with the current data model:
+
+- **Linear** — keyboard-first, instant, dense, every row has consistent leading
+  status + trailing metadata; right-click and `⌘K` do everything.
+- **Things 3** — calm density, springy expand/collapse, generous-but-tight rhythm,
+  comfortable/compact modes.
+- **Finder / Xcode navigator** — disclosure triangles, sticky group headers,
+  type-ahead, range selection, drag with real drop indicators.
+
+### Target row anatomy
+
+```
+PROJECT HEADER (sticky when its list is scrolled)
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ ▸  ◧ Coven Cave            ● 2 running · 3 tasks · 6m ago   [💬][▤][✎][⋯]   │
+│        ~/…/coven-cave  ⧉                                          57 sessions │
+└─────────────────────────────────────────────────────────────────────────────┘
+SESSION ROW (comfortable)                                  SESSION ROW (compact)
+┌─────────────────────────────────────────┐   ┌───────────────────────────────┐
+│ ⟳  Let's do a mermaid diagram…   sonnet  │   │ ⟳ Let's do a mermaid…  6m  ⌫ │
+│    6m ago · main +12 −3            ⌫     │   └───────────────────────────────┘
+└─────────────────────────────────────────┘
+ ↑ leading glyph = status:  ⟳ running (spin) · ☑/☐ task · ✕ failed · · idle
+```
+
+Leading glyph replaces the undifferentiated bullet: running = pulsing spinner,
+failed = danger ✕, **task** = checkbox (the `Task:` text prefix becomes a real
+glyph and the prefix is dropped from the title), plain chat = hairline dot.
+Trailing zone carries model chip + `RelativeTime` (with exact-time tooltip, the
+existing `<RelativeTime>` primitive) + optional branch / `+N −M` diff badges
+(data already on `SessionRow.git` / `.diff` / `.pullRequest`).
+
+---
+
+## 3. Architecture / refactor (do this first, it pays for everything after)
+
+The current monolith is the main obstacle. Split into a small, testable tree —
+**behavior-preserving, no visual change** — so each later phase is a focused diff:
+
+```
+src/components/projects/
+  projects-view.tsx        // container: data, filter, sort, DnD context, layout
+  project-row.tsx          // one project card (header + body)
+  project-header.tsx       // disclosure, name, path, stats, toolbar  (uses ui/button)
+  project-toolbar.tsx      // chat / terminal / rename / delete / overflow ⋯
+  session-row.tsx          // one session/task row (leading glyph + title + meta)
+  session-meta.tsx         // model chip · RelativeTime · branch/diff badges
+  context-menu.tsx         // shared right-click menu (or adopt an existing one if present)
+src/lib/projects/
+  use-projects-ui-state.ts // persisted expand/collapse, density, sort  (localStorage)
+  project-stats.ts         // pure: running/task/recent counts from SessionRow[]  (+unit test)
+  session-glyph.ts         // pure: SessionRow -> {kind, icon, tone, label}        (+unit test)
+```
+
+Reuse what exists instead of reinventing:
+- **`ui/button`** for every actionable control (variants/sizes/icons already match).
+- **`lib/use-multi-select` + `ui/selection-toolbar`** to replace the bespoke
+  select-mode state and inline toolbar (Explore §6).
+- **`ui/relative-time`** everywhere a timestamp renders (kills the "Jun 15" vs
+  "6m ago" vs nothing inconsistency, gives free exact-time tooltips).
+- Keep the pure cores untouched: `project-status.ts`, `chat-session-order.ts`,
+  `use-project-overrides.ts`, `cave-projects-types.ts`.
+
+New persisted localStorage keys (namespaced, matching existing `cave:` convention):
+- `cave:projects:expanded` → `string[]` of expanded project ids
+- `cave:projects:density` → `"comfortable" | "compact"`
+- `cave:projects:sort` → `"recent" | "name" | "active"`
+
+**Test contract:** `projects-view.test.ts` pins markup heavily (roles, icon
+allowlist, hairline divider, ARIA). Per `CLAUDE.md`/memory, update the pinned
+assertions **in the same commit** as each markup change, and **register every new
+`*.test.ts` in `scripts/run-tests.mjs`** (SUITES.app; ALIAS_LOADER if it has a
+`@/` value import) or CI silently skips it. New icons must be added to the icon
+allowlist.
+
+---
+
+## 4. Phased delivery
+
+Each phase is an independently shippable PR (3 required checks green:
+Frontend build, Rust check, CodeQL, E2E). Recommended order:
+
+### Phase 0 — Refactor + adopt shared primitives  *(no visual change)*
+- Split the monolith into the tree in §3; swap bare buttons → `ui/button`,
+  bespoke select → `use-multi-select` + `selection-toolbar`.
+- Add the three pure modules (`project-stats`, `session-glyph`,
+  `use-projects-ui-state`) with unit tests.
+- **Acceptance:** pixel-identical render; existing test green (with mechanical
+  selector updates only); new pure tests pass.
+
+### Phase 1 — Density + persisted state
+- Comfortable/compact density toggle (header control, persisted); tighten
+  comfortable rhythm (≈`py-2`) and add a real compact mode (≈`py-1`, single line).
+- Persist expand/collapse and restore on mount; persist sort; add a sort menu
+  (Recent · Name · Active).
+- **Acceptance:** revisiting the tab restores expanded projects + density + sort;
+  compact mode visibly denser; verified via `run-cave-app` screenshots in 2 themes.
+
+### Phase 2 — Rich rows (the visual heart)
+- **Session row:** leading status glyph via `session-glyph.ts`; drop the `Task:`
+  text prefix in favor of a checkbox glyph; trailing `session-meta` (model chip +
+  `RelativeTime` + branch/`+N −M` when present on `SessionRow`).
+- **Project header:** color swatch from `CaveProject.color`; inline stat line
+  (`N running · M tasks · last active`) from `project-stats.ts`; always-discoverable
+  toolbar with an overflow `⋯` for rename/delete/copy-path.
+- **Acceptance:** every row shows consistent leading status + a timestamp; no
+  more bare bullets; stat line matches `deriveProjectStatus` semantics.
+
+### Phase 3 — Interaction model (native muscle memory)
+- **Keyboard nav:** roving-tabindex list — ↑/↓ move focus across rows *and*
+  project headers, → / ← expand/collapse, Enter opens, Space selects,
+  Shift-click / Shift-↑↓ range-select, ⌘-click toggles, type-ahead jump,
+  ⌘⌫ delete-selected. (Extends the existing command-palette focus events.)
+- **Context menu:** right-click on a project (New chat · Open terminal · Rename ·
+  Copy path · Delete) and on a session (Open · Move to project ▸ · Delete).
+- **Touch:** `@media (pointer: coarse)` → toolbar/actions always visible, 30px hit
+  targets (mirror the comux touch convention from memory).
+- **Acceptance:** full project navigation without a mouse; right-click parity with
+  toolbar; actions tappable on a coarse pointer.
+
+### Phase 4 — Motion + performance
+- **Motion:** animated height expand/collapse (spring, respects
+  `prefers-reduced-motion`); drag drop-indicator line + lifted row; selection and
+  hover transitions; cross-project move emits an **undo toast**.
+- **Virtualization:** when an expanded project exceeds a threshold (~30 rows),
+  virtualize the session list so "Show all 57" stays 60fps. Keep the
+  `CHAT_CAP`/"Show all" affordance as the collapsed default.
+- **Acceptance:** expand/collapse animates (and is instant under reduced-motion);
+  a 200-session project scrolls smoothly; cross-project move is undoable.
+
+### Phase 5 — Verification + review
+- `run-cave-app` screenshots across ≥2 themes + light/dark + compact/comfortable +
+  touch emulation; keyboard-only walkthrough; the daemon-less E2E spec stays
+  self-contained (dismiss onboarding, demo-mode data) per `CLAUDE.md`.
+- `/code-review` (or `requesting-code-review`) before each merge.
+
+---
+
+## 5. Risks & how we de-risk
+
+- **Markup-pinning tests** (`projects-view.test.ts`) break on every visual change
+  → update assertions in the same commit; lean on the pure modules for logic tests
+  so behavior coverage survives re-styling.
+- **Monolith merge conflicts** with concurrent sessions → do the Phase 0 split
+  early in a worktree (`.worktrees/<branch>`), land it fast, rebase later phases on
+  top. Check for other live sessions before structural work (memory + `CLAUDE.md`).
+- **DnD + virtualization interaction** → keep `@dnd-kit` for in-card reorder; only
+  virtualize the rendered window; verify drag-across-projects still resolves
+  `pcard:` drop ids.
+- **Theme breakage** → strictly tokens, no hardcoded colors; verify in ≥2 of the
+  many themes (globals.css has dozens of `--accent-presence` variants).
+- **Scope creep** → each phase is shippable alone; Phases 0–2 already deliver the
+  bulk of the "native" feel if we need to stop early.
+
+## 6. Skills this will use
+
+- **brainstorming** — already feeding §2 anatomy; revisit before Phase 2/3 if the
+  row/interaction model needs another option pass.
+- **test-driven-development** — pure modules (`project-stats`, `session-glyph`,
+  `use-projects-ui-state`) are TDD-shaped; write the spec first.
+- **using-git-worktrees** + the `CLAUDE.md` PR flow — worktree per phase, signed
+  (`-S`) commits, squash-merge through `gh`.
+- **run-cave-app** / **verify** — screenshot + behavior verification each phase.
+- **requesting-code-review** / **/code-review** — before each merge.
+
+## 7. Suggested first PR
+
+**Phase 0 only** — the refactor + primitive adoption with zero visual change. It's
+the lowest-risk, highest-leverage step: it shrinks the 1,057-line monolith into
+testable pieces, aligns with shared UI, and makes Phases 1–4 small, reviewable
+diffs. Everything visible to the user comes after, on a clean foundation.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -126,6 +126,7 @@ export const SUITES = {
     "src/components/workflows/workflow-step-list.test.ts",
     "src/components/workflows/workflow-capability-attachments.test.ts",
     "src/components/projects-view.test.ts",
+    "src/lib/projects/projects-ui-state.test.ts",
     "src/components/onboarding-guided-steps.test.ts",
     "src/components/familiar-studio.test.ts",
     "src/components/familiar-studio-look-tab.test.ts",

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -39,7 +39,7 @@ assert.match(
 );
 assert.match(
   projectsView,
-  /role=\{selectMode \? "checkbox" : "button"\}[\s\S]{0,900}?className="focus-ring /,
+  /role=\{selectMode \? "checkbox" : "button"\}[\s\S]{0,900}?className=\{?["`]focus-ring /,
   "the chat row has a visible keyboard focus ring",
 );
 
@@ -167,7 +167,8 @@ assert.match(
 );
 
 // Project rows render flat — a bottom hairline divider instead of a bordered
-// rounded card box, so the Projects tab reads as a flat list.
+// rounded card box, so the Projects tab reads as a flat list. Vertical padding
+// is density-driven (comfortable vs compact) rather than a fixed py-3.
 assert.doesNotMatch(
   projectsView,
   /group rounded-lg border bg-\[var\(--bg-raised\)\]/,
@@ -175,16 +176,44 @@ assert.doesNotMatch(
 );
 assert.match(
   projectsView,
-  /group border-b border-\[var\(--border-hairline\)\] px-2 py-3/,
+  /group border-b border-\[var\(--border-hairline\)\] px-2 transition-colors/,
   "Project rows should be flat rows separated by a hairline divider",
 );
+assert.match(
+  projectsView,
+  /density === "compact" \? "py-1\.5" : "py-3"/,
+  "project row vertical padding follows the density preference",
+);
 
-// Projects collapse to one scannable row and expand to reveal the path +
-// sessions; every project starts collapsed.
-assert.match(projectsView, /const \[expanded, setExpanded\] = useState\(false\)/, "each project row starts collapsed");
+// Expand/collapse + density are persisted UI state (the surface remembers how
+// you left it) via the shared hook; expansion is keyed per project id.
+assert.match(
+  projectsView,
+  /import \{ useProjectsUiState \} from "@\/lib\/projects\/use-projects-ui-state"/,
+  "uses the persisted Projects UI-state hook",
+);
+assert.match(
+  projectsView,
+  /const \{ density, setDensity, isExpanded, setExpanded \} = useProjectsUiState\(\)/,
+  "ProjectsView reads density + expand state from the hook",
+);
+assert.match(
+  projectsView,
+  /expanded=\{isExpanded\(project\.id\)\}/,
+  "each project card's expanded state comes from persisted UI state",
+);
+assert.match(
+  projectsView,
+  /onSetExpanded=\{\(next\) => setExpanded\(project\.id, next\)\}/,
+  "toggling a card persists its expanded state by project id",
+);
 assert.match(projectsView, /aria-expanded=\{expanded\}/, "the disclosure control reports expanded state");
 assert.match(projectsView, /\{expanded \? \(/, "path + sessions render only when the row is expanded");
-assert.doesNotMatch(projectsView, /defaultExpanded/, "no project auto-expands — the list stays a flat, scannable set of rows");
+assert.doesNotMatch(projectsView, /defaultExpanded/, "expansion is controlled by persisted state, not a defaultExpanded flag");
+
+// A density toggle lets the user choose comfortable vs compact list spacing.
+assert.match(projectsView, /aria-label="List density"/, "there is a labeled density toggle");
+assert.match(projectsView, /aria-pressed=\{density === opt\.value\}/, "the density toggle reflects the active option");
 
 // Projects are ordered by most-recent session activity, not API order.
 assert.match(projectsView, /const sortedProjects = useMemo/, "projects are sorted before rendering");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -21,6 +21,8 @@ import { applyProjectOverrides, setProjectOverride } from "@/lib/chat-project-ov
 import { useProjectOverrides } from "@/lib/use-project-overrides";
 import { useProjects } from "@/lib/use-projects";
 import { deriveProjectStatus } from "@/lib/project-status";
+import { useProjectsUiState } from "@/lib/projects/use-projects-ui-state";
+import type { ProjectsDensity } from "@/lib/projects/projects-ui-state";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
@@ -92,6 +94,7 @@ function ProjectChatRow({
   selectMode,
   selected,
   onToggleSelect,
+  density,
 }: {
   session: SessionRow;
   displayTitle?: string;
@@ -100,6 +103,7 @@ function ProjectChatRow({
   selectMode: boolean;
   selected: boolean;
   onToggleSelect: (id: string) => void;
+  density: ProjectsDensity;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: session.id,
@@ -125,7 +129,7 @@ function ProjectChatRow({
           }
         }}
         data-selected={selectMode && selected ? "true" : undefined}
-        className="focus-ring flex w-full items-center gap-2 px-4 py-1 text-left text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] data-[selected=true]:bg-[var(--accent-presence)]/10 data-[selected=true]:text-[var(--text-primary)]"
+        className={`focus-ring flex w-full items-center gap-2 px-4 text-left text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] data-[selected=true]:bg-[var(--accent-presence)]/10 data-[selected=true]:text-[var(--text-primary)] ${density === "compact" ? "py-0.5" : "py-1"}`}
       >
         {selectMode ? (
           <span
@@ -222,6 +226,9 @@ type ProjectRowProps = {
   onOpenSession?: (sessionId: string) => void;
   onDeleteSession: (sessionId: string) => Promise<void>;
   onDeleteSessions: (sessionIds: string[]) => Promise<void>;
+  density: ProjectsDensity;
+  expanded: boolean;
+  onSetExpanded: (next: boolean) => void;
 };
 
 function ProjectRow({
@@ -234,11 +241,16 @@ function ProjectRow({
   onOpenSession,
   onDeleteSession,
   onDeleteSessions,
+  density,
+  expanded,
+  onSetExpanded,
 }: ProjectRowProps) {
   const chatCount = chats.length;
-  // Every project starts collapsed to a single scannable row; expanding reveals
-  // the path + its sessions.
-  const [expanded, setExpanded] = useState(false);
+  // Expanded/collapsed state is lifted to the container and persisted, so a
+  // project the user opened stays open across reloads (native-app memory)
+  // instead of resetting to a flat collapsed list every visit.
+  const setExpanded = (next: boolean | ((value: boolean) => boolean)) =>
+    onSetExpanded(typeof next === "function" ? next(expanded) : next);
   const cardKey = normalizeProjectRoot(project.root);
 
   // The command palette's "Open project" rows expand + scroll a project into
@@ -380,7 +392,8 @@ function ProjectRow({
       id={`pcard-el:${cardKey}`}
       data-drop-over={isOver ? "true" : undefined}
       className={[
-        "group border-b border-[var(--border-hairline)] px-2 py-3 transition-colors",
+        "group border-b border-[var(--border-hairline)] px-2 transition-colors",
+        density === "compact" ? "py-1.5" : "py-3",
         isOver
           ? "bg-[color-mix(in_oklch,var(--accent-presence)_10%,transparent)]"
           : "hover:bg-[var(--bg-raised)]/40",
@@ -638,6 +651,7 @@ function ProjectRow({
                   selectMode={selectMode}
                   selected={selectedIds.has(session.id)}
                   onToggleSelect={toggleSelect}
+                  density={density}
                 />
               ))}
             </ul>
@@ -685,6 +699,7 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
   const [creating, setCreating] = useState(false);
   const [sessionError, setSessionError] = useState<string | null>(null);
   const projectOverrides = useProjectOverrides();
+  const { density, setDensity, isExpanded, setExpanded } = useProjectsUiState();
   const [order, setOrder] = useState<string[]>([]);
   useEffect(() => {
     setOrder(readSessionOrder());
@@ -849,6 +864,32 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
               : `${projects.length} ${projects.length === 1 ? "project" : "projects"}`}
           </span>
           <div className="flex items-center gap-2">
+            <div
+              role="group"
+              aria-label="List density"
+              className="flex items-center rounded-md border border-[var(--border-hairline)] p-0.5"
+            >
+              {([
+                { value: "comfortable", icon: "ph:rows", label: "Comfortable density" },
+                { value: "compact", icon: "ph:list-bullets-bold", label: "Compact density" },
+              ] as const).map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => setDensity(opt.value)}
+                  aria-pressed={density === opt.value}
+                  aria-label={opt.label}
+                  title={opt.label}
+                  className={`focus-ring flex h-7 w-7 items-center justify-center rounded ${
+                    density === opt.value
+                      ? "bg-[var(--bg-hover)] text-[var(--text-primary)]"
+                      : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                  }`}
+                >
+                  <Icon name={opt.icon} width={14} aria-hidden />
+                </button>
+              ))}
+            </div>
             <button
               type="button"
               onClick={() => void reload()}
@@ -1045,6 +1086,9 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
                     onOpenSession={openSessionById}
                     onDeleteSession={handleDeleteSession}
                     onDeleteSessions={handleDeleteSessions}
+                    density={density}
+                    expanded={isExpanded(project.id)}
+                    onSetExpanded={(next) => setExpanded(project.id, next)}
                   />
                 ))}
               </DndContext>

--- a/src/lib/projects/projects-ui-state.test.ts
+++ b/src/lib/projects/projects-ui-state.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+
+import {
+  PROJECTS_DENSITY_KEY,
+  PROJECTS_EXPANDED_KEY,
+  normalizeDensity,
+  parseExpandedIds,
+  serializeExpandedIds,
+  toggleExpandedId,
+} from "./projects-ui-state.ts";
+
+// Stable storage keys (changing these silently drops everyone's saved state).
+assert.equal(PROJECTS_EXPANDED_KEY, "cave:projects:expanded");
+assert.equal(PROJECTS_DENSITY_KEY, "cave:projects:density");
+
+// parseExpandedIds: clean array out, junk tolerated.
+assert.deepEqual(parseExpandedIds(JSON.stringify(["a", "b"])), ["a", "b"]);
+assert.deepEqual(parseExpandedIds(null), []);
+assert.deepEqual(parseExpandedIds(undefined), []);
+assert.deepEqual(parseExpandedIds("not json"), []);
+assert.deepEqual(parseExpandedIds(JSON.stringify({ a: 1 })), []);
+assert.deepEqual(parseExpandedIds(JSON.stringify(["a", 2, null, "b"])), ["a", "b"]);
+
+// round-trip
+assert.deepEqual(parseExpandedIds(serializeExpandedIds(["x", "y", "x"])), ["x", "y"]);
+
+// toggleExpandedId: add / remove / idempotent
+assert.deepEqual(toggleExpandedId(["a"], "b", true), ["a", "b"]);
+assert.deepEqual(toggleExpandedId(["a", "b"], "a", false), ["b"]);
+assert.deepEqual(toggleExpandedId(["a"], "a", true), ["a"], "adding an existing id is a no-op");
+assert.deepEqual(toggleExpandedId(["a"], "b", false), ["a"], "removing an absent id is a no-op");
+
+// normalizeDensity: only "compact" is special; everything else is comfortable.
+assert.equal(normalizeDensity("compact"), "compact");
+assert.equal(normalizeDensity("comfortable"), "comfortable");
+assert.equal(normalizeDensity(null), "comfortable");
+assert.equal(normalizeDensity("garbage"), "comfortable");
+
+console.log("projects-ui-state.test.ts: ok");

--- a/src/lib/projects/projects-ui-state.ts
+++ b/src/lib/projects/projects-ui-state.ts
@@ -1,0 +1,43 @@
+// Pure, framework-free persistence helpers for the Projects tab's UI state
+// (which project cards are expanded + the list density). Kept self-contained —
+// no React, no direct localStorage — so the parse/serialize/normalize logic can
+// be unit-tested under the strip-types runner. The React glue lives in the
+// `use-projects-ui-state` hook, which calls these.
+
+/** localStorage key holding the JSON array of expanded project ids. */
+export const PROJECTS_EXPANDED_KEY = "cave:projects:expanded";
+/** localStorage key holding the list density preference. */
+export const PROJECTS_DENSITY_KEY = "cave:projects:density";
+
+/** Row density: "comfortable" is the spacious default; "compact" tightens it. */
+export type ProjectsDensity = "comfortable" | "compact";
+
+/** Parse the persisted expanded-ids blob into a clean string[] (ignores junk). */
+export function parseExpandedIds(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((id): id is string => typeof id === "string");
+  } catch {
+    return [];
+  }
+}
+
+/** Serialize a set of expanded ids back to the stored JSON form. */
+export function serializeExpandedIds(ids: Iterable<string>): string {
+  return JSON.stringify([...new Set(ids)]);
+}
+
+/** Toggle one id in the expanded set, returning a new array (stable order). */
+export function toggleExpandedId(ids: Iterable<string>, id: string, next: boolean): string[] {
+  const set = new Set(ids);
+  if (next) set.add(id);
+  else set.delete(id);
+  return [...set];
+}
+
+/** Coerce any stored/unknown value to a valid density (defaults to comfortable). */
+export function normalizeDensity(raw: string | null | undefined): ProjectsDensity {
+  return raw === "compact" ? "compact" : "comfortable";
+}

--- a/src/lib/projects/use-projects-ui-state.ts
+++ b/src/lib/projects/use-projects-ui-state.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  PROJECTS_DENSITY_KEY,
+  PROJECTS_EXPANDED_KEY,
+  normalizeDensity,
+  parseExpandedIds,
+  serializeExpandedIds,
+  toggleExpandedId,
+  type ProjectsDensity,
+} from "./projects-ui-state";
+
+export type ProjectsUiState = {
+  /** Current list density ("comfortable" | "compact"). */
+  density: ProjectsDensity;
+  /** Persist + apply a new density. */
+  setDensity: (density: ProjectsDensity) => void;
+  /** Whether a project card (keyed by project id) is expanded. */
+  isExpanded: (id: string) => boolean;
+  /** Persist + apply an expanded/collapsed state for one project card. */
+  setExpanded: (id: string, next: boolean) => void;
+};
+
+/**
+ * Persisted UI state for the Projects tab: which cards are expanded and the list
+ * density. Both survive reloads (localStorage) so the surface "remembers how you
+ * left it" — native-app behavior rather than resetting to a flat collapsed list
+ * every visit.
+ *
+ * State initializes to defaults and hydrates from localStorage in an effect (not
+ * the useState initializer) so server and first client render agree — the same
+ * approach the session-order state already uses to dodge hydration mismatch.
+ */
+export function useProjectsUiState(): ProjectsUiState {
+  const [density, setDensityState] = useState<ProjectsDensity>("comfortable");
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setDensityState(normalizeDensity(window.localStorage.getItem(PROJECTS_DENSITY_KEY)));
+    setExpandedIds(new Set(parseExpandedIds(window.localStorage.getItem(PROJECTS_EXPANDED_KEY))));
+  }, []);
+
+  const setDensity = useCallback((next: ProjectsDensity) => {
+    setDensityState(next);
+    try {
+      window.localStorage.setItem(PROJECTS_DENSITY_KEY, next);
+    } catch {
+      // Storage unavailable (private mode / quota) — keep the in-memory value.
+    }
+  }, []);
+
+  const isExpanded = useCallback((id: string) => expandedIds.has(id), [expandedIds]);
+
+  const setExpanded = useCallback((id: string, next: boolean) => {
+    setExpandedIds((prev) => {
+      const nextIds = toggleExpandedId(prev, id, next);
+      try {
+        window.localStorage.setItem(PROJECTS_EXPANDED_KEY, serializeExpandedIds(nextIds));
+      } catch {
+        // Storage unavailable — keep the in-memory value.
+      }
+      return new Set(nextIds);
+    });
+  }, []);
+
+  return { density, setDensity, isExpanded, setExpanded };
+}


### PR DESCRIPTION
## What

First increment of the **Projects view → native-app redesign** ([full plan](../blob/projects-native-phase0/docs/projects-view-native-redesign.md), added here).

The Projects tab now **remembers how you left it** — expansion is persisted per project (it previously reset every project to collapsed on every visit) — and gains a **Comfortable / Compact density toggle**. Both prefs survive reloads.

## Why

Returning to a surface and finding your context reset is the opposite of native feel. Persisted disclosure + a density choice are table-stakes for Linear/Things/Mail-grade lists, and they lay the foundation (`useProjectsUiState`) the later phases build on.

## How

- **New pure module** `src/lib/projects/projects-ui-state.ts` — `parse/serialize/toggle/normalize` for the persisted state, fully unit-tested (no React/DOM).
- **`useProjectsUiState` hook** — hydrates from `localStorage` *post-mount* (effect, not the `useState` initializer) to avoid SSR/client hydration mismatch, mirroring the existing session-order pattern.
- **`projects-view.tsx`** — expand state lifted to the container + keyed by project id; density-driven vertical padding on project and chat rows; labeled density toggle (`role="group"`, `aria-pressed`) in the header.
- localStorage keys: `cave:projects:expanded`, `cave:projects:density`.

## Verification

- `pnpm typecheck` — clean
- `src/components/projects-view.test.ts` (source-text) — updated to the new behavior, green
- `src/lib/projects/projects-ui-state.test.ts` (new unit test) — green, wired into `scripts/run-tests.mjs`
- `check:tests-wired` — all wired

No data-model or API changes. Icons used (`ph:rows`, `ph:list-bullets-bold`) are already allowlisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)