### PR TITLE
feat(gantt): auto-center on today, quick-schedule presets, status filter

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -51,6 +51,14 @@ const ZOOM_LABELS: Array<[GanttZoom, string, string, string]> = [
   ["month", "Month", "M", "Zoom out — months fit on screen"],
 ];
 const LEFT_W = 442; // sum of the left table columns (300+58+58+26) — keep in sync with .cg-left
+// Status-filter chips: [category, short chip label, full status names]. Labels
+// match the legend's actual-status wording (Running/Blocked, not In Progress).
+const CATEGORY_CHIPS: Array<[GanttCategory, string, string]> = [
+  ["done", "Done", "Done"],
+  ["in-progress", "Running", "Running"],
+  ["pending", "Pending", "Backlog · Inbox · Review"],
+  ["at-risk", "Blocked", "Blocked"],
+];
 
 function parseDate(value: string | null | undefined): Date | null {
   if (!value) return null;
@@ -122,6 +130,16 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
   // Click a group header to focus it (hide the others); click again to show all.
   const [focusedKey, setFocusedKey] = useState<string | null>(null);
   const [showUnscheduled, setShowUnscheduled] = useState(false);
+  // Status-category filter: chips toggle whole categories off so a busy
+  // timeline can be narrowed (e.g. only Blocked) or de-cluttered (hide Done).
+  const [hiddenCats, setHiddenCats] = useState<Set<GanttCategory>>(() => new Set());
+  const toggleCat = (cat: GanttCategory) =>
+    setHiddenCats((prev) => {
+      const next = new Set(prev);
+      if (next.has(cat)) next.delete(cat);
+      else next.add(cat);
+      return next;
+    });
   // "Today" depends on the clock, so resolve it after mount to avoid an SSR
   // hydration mismatch — the line just isn't drawn on the first client render.
   const [todayMs, setTodayMs] = useState<number | null>(null);
@@ -146,6 +164,12 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
   const dragRef = useRef<{ id: string; mode: DragMode; startX: number; moved: boolean } | null>(null);
   // Suppresses the row's select-click that would otherwise fire after a drag.
   const suppressClickRef = useRef(false);
+  // Center the timeline on "today" the first time it opens, so a long project
+  // doesn't open scrolled to its earliest task. The scroll geometry is computed
+  // below the empty-state early return, so render assigns the scroller into this
+  // ref and the effect (declared above the return) calls through it.
+  const didAutoCenterRef = useRef(false);
+  const centerOnTodayRef = useRef<() => boolean>(() => false);
 
   const beginDrag = (e: React.PointerEvent, rowId: string, mode: DragMode) => {
     if (!draggable) return;
@@ -309,6 +333,26 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
   const unscheduledCards = cards.filter((c) => !placedCardIds.has(c.id));
   const unscheduledCount = unscheduledCards.length;
 
+  // Auto-center on today once the timeline can be drawn (keyed on the clock +
+  // zoom). centerOnTodayRef is assigned during render below; retry until it
+  // succeeds (scroller mounted, today in range), then latch so we never fight a
+  // manual scroll. Declared above the empty-state early return to keep hook order stable.
+  useEffect(() => {
+    if (didAutoCenterRef.current) return;
+    if (centerOnTodayRef.current()) didAutoCenterRef.current = true;
+  }, [todayMs, zoom, allRows.length]);
+
+  // Quick-schedule presets for undated tasks: drop a task onto this/next week
+  // (Mon–Sun) without opening the date pickers.
+  const schedulePreset = (cardId: string, weeksAhead: number) => {
+    if (!onPatch || todayMs === null) return;
+    const now = new Date(todayMs);
+    const todayUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+    const start = addDays(startOfWeekMon(todayUtc), weeksAhead * 7);
+    const end = addDays(start, 6);
+    onPatch(cardId, { startDate: fmtISO(start), endDate: fmtISO(end) });
+  };
+
   // The tasks the timeline can't place (no dates / no scheduled steps) used to
   // be a dead-end count; make it an expandable tray so they can be scheduled.
   const unscheduledTray =
@@ -330,7 +374,9 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
                 <button type="button" onClick={() => onSelect(c.id)} title="Open task" style={{ flex: 1, minWidth: 120, textAlign: "left", background: "none", border: "none", color: "var(--text-secondary)", cursor: "pointer", font: "inherit", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{c.title}</button>
                 <span style={{ fontSize: 11, color: "var(--text-muted)" }}>{ownerName(c.familiarId)}</span>
                 {onPatch ? (
-                  <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                  <span style={{ display: "inline-flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+                    <button type="button" className="cg-preset-btn" disabled={todayMs === null} onClick={() => schedulePreset(c.id, 0)} title="Schedule Mon–Sun this week">This week</button>
+                    <button type="button" className="cg-preset-btn" disabled={todayMs === null} onClick={() => schedulePreset(c.id, 1)} title="Schedule Mon–Sun next week">Next week</button>
                     <input type="date" aria-label={`Start date for ${c.title}`} value={c.startDate ?? ""} onChange={(e) => onPatch(c.id, { startDate: e.target.value || null })} style={{ fontSize: 11, padding: "1px 4px", borderRadius: 4, border: "1px solid var(--border-hairline)", background: "var(--bg-base)", color: "var(--text-secondary)" }} />
                     <span aria-hidden style={{ color: "var(--text-muted)" }}>→</span>
                     <input type="date" aria-label={`End date for ${c.title}`} value={c.endDate ?? ""} onChange={(e) => onPatch(c.id, { endDate: e.target.value || null })} style={{ fontSize: 11, padding: "1px 4px", borderRadius: 4, border: "1px solid var(--border-hairline)", background: "var(--bg-base)", color: "var(--text-secondary)" }} />
@@ -354,7 +400,12 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
 
   // Focus: when a group is clicked, render only it (range stays global so bars don't jump).
   const focused = focusedKey && groups.some((g) => g.key === focusedKey) ? focusedKey : null;
-  const visibleGroups = focused ? groups.filter((g) => g.key === focused) : groups;
+  // Apply the focus narrowing, then drop bars whose status category is filtered
+  // out. The timeline range stays global (computed from all rows) so bars don't
+  // jump when chips toggle.
+  const visibleGroups = (focused ? groups.filter((g) => g.key === focused) : groups)
+    .map((g) => (hiddenCats.size ? { ...g, rows: g.rows.filter((r) => !hiddenCats.has(r.category)) } : g))
+    .filter((g) => g.rows.length > 0);
 
   const min = new Date(Math.min(...allRows.map((r) => r.start.getTime())));
   const max = new Date(Math.max(...allRows.map((r) => r.end.getTime())));
@@ -380,16 +431,37 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
     if (offset >= 0 && offset <= totalDays) todayX = offset * DAY_W + DAY_W / 2;
   }
 
-  // Scroll the timeline so today sits in the middle of the viewport.
-  const scrollToToday = () => {
+  // Scroll the timeline so today sits in the middle of the viewport. Returns
+  // whether it actually scrolled (used by the auto-center effect to know when
+  // the scroller is ready and latch).
+  const scrollToToday = (): boolean => {
     const el = scrollRef.current;
-    if (!el || todayX === null) return;
+    if (!el || todayX === null || el.clientWidth === 0) return false;
     el.scrollLeft = Math.max(0, LEFT_W + todayX - el.clientWidth / 2);
+    return true;
   };
+  centerOnTodayRef.current = scrollToToday;
 
   return (
     <div className="board-gantt">
-      <div className="cg-controls" style={{ display: "flex", gap: 8, alignItems: "center", justifyContent: "flex-end", padding: "2px 8px 6px" }}>
+      <div className="cg-controls" style={{ display: "flex", gap: 8, alignItems: "center", justifyContent: "flex-end", flexWrap: "wrap", padding: "2px 8px 6px" }}>
+        <div className="cg-filter" role="group" aria-label="Filter by status">
+          {CATEGORY_CHIPS.map(([cat, label, full]) => {
+            const off = hiddenCats.has(cat);
+            return (
+              <button
+                key={cat}
+                type="button"
+                className={`cg-filter-chip${off ? " cg-filter-chip--off" : ""}`}
+                aria-pressed={!off}
+                onClick={() => toggleCat(cat)}
+                title={off ? `Show ${full}` : `Hide ${full}`}
+              >
+                <span className={`cg-dot cg-dot--${cat}`} aria-hidden />{label}
+              </button>
+            );
+          })}
+        </div>
         <div className="board-group-toggle" role="group" aria-label="Timeline zoom">
           <span className="cg-zoom-cell" aria-hidden><Icon name="ph:magnifying-glass" width={13} /></span>
           {ZOOM_LABELS.map(([z, full, short, hint]) => (

--- a/src/components/board-schedule-window.test.ts
+++ b/src/components/board-schedule-window.test.ts
@@ -119,4 +119,26 @@ assert.match(gantt, /title=\{`\$\{full\} — \$\{hint\}`\}/, "each zoom button e
 assert.match(gantt, />\s*\{short\}\s*<\/button>/, "buttons render the compact single-letter label");
 assert.match(styles, /\.board-group-toggle \.cg-zoom-cell/, "the zoom glyph cell is styled to match the segmented control");
 
+// Auto-center: opening the Gantt scrolls the timeline to today once (latched,
+// so it never fights a later manual scroll).
+assert.match(gantt, /const didAutoCenterRef = useRef\(false\)/, "auto-center latches after the first center");
+assert.match(gantt, /const scrollToToday = \(\): boolean =>/, "scrollToToday reports whether it scrolled");
+assert.match(gantt, /centerOnTodayRef\.current = scrollToToday/, "render wires the scroller into the auto-center ref");
+assert.match(gantt, /if \(centerOnTodayRef\.current\(\)\) didAutoCenterRef\.current = true/, "the effect centers once the scroller is ready, then latches");
+
+// Quick-schedule presets: undated tasks get one-click This week / Next week.
+assert.match(gantt, /const schedulePreset = \(cardId: string, weeksAhead: number\)/, "a schedulePreset helper sets a Mon–Sun week");
+assert.match(gantt, /addDays\(startOfWeekMon\(todayUtc\), weeksAhead \* 7\)/, "presets anchor on this/next Monday");
+assert.match(gantt, /onClick=\{\(\) => schedulePreset\(c\.id, 0\)\}[\s\S]{0,80}This week/, "the tray offers a This week preset");
+assert.match(gantt, /onClick=\{\(\) => schedulePreset\(c\.id, 1\)\}[\s\S]{0,80}Next week/, "the tray offers a Next week preset");
+assert.match(styles, /\.cg-preset-btn/, "preset buttons are styled");
+
+// Status filter: chips toggle whole categories off; the timeline range stays global.
+assert.match(gantt, /const \[hiddenCats, setHiddenCats\] = useState<Set<GanttCategory>>/, "hidden status categories are tracked in a Set");
+assert.match(gantt, /const CATEGORY_CHIPS: Array<\[GanttCategory, string, string\]>/, "the filter chips are data-driven");
+assert.match(gantt, /aria-label="Filter by status"/, "the filter control is labelled");
+assert.match(gantt, /g\.rows\.filter\(\(r\) => !hiddenCats\.has\(r\.category\)\)/, "filtered categories drop from the visible rows");
+assert.match(gantt, /cg-filter-chip\$\{off \? " cg-filter-chip--off" : ""\}/, "chips show an off state");
+assert.match(styles, /\.cg-filter-chip/, "filter chips are styled");
+
 console.log("board-schedule-window.test.ts: ok");

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1758,6 +1758,18 @@
 .cg-dot--pending { background: var(--color-warning); }
 .cg-dot--at-risk { background: var(--color-danger); }
 
+/* status-filter chips (toolbar) — toggle a whole status category off */
+.cg-filter { display:flex; gap:4px; align-items:center; flex-wrap:wrap; }
+.cg-filter-chip { display:inline-flex; align-items:center; gap:5px; height:24px; padding:0 8px; border:1px solid var(--border-strong); border-radius:999px; background:var(--bg-raised); color:var(--text-secondary); font-size:11px; cursor:pointer; transition:opacity .12s, background .12s; white-space:nowrap; }
+.cg-filter-chip:hover { background:var(--bg-hover); }
+.cg-filter-chip:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }
+.cg-filter-chip--off { opacity:.4; text-decoration:line-through; }
+
+/* quick-schedule preset buttons (unscheduled tray) */
+.cg-preset-btn { height:22px; padding:0 7px; border:1px solid var(--border-hairline); border-radius:5px; background:var(--bg-base); color:var(--text-secondary); font-size:11px; cursor:pointer; transition:background .12s, color .12s; }
+.cg-preset-btn:hover:not(:disabled) { background:var(--bg-hover); color:var(--text-primary); }
+.cg-preset-btn:disabled { opacity:.5; cursor:default; }
+
 /* legend */
 .cg-legend {
   position: sticky; left: 0;


### PR DESCRIPTION
Three Gantt timeline ergonomics wins (from the UX backlog):

## 1. Auto-center on **today** when opened
The Gantt previously opened scrolled to the *earliest* task — on a multi-month project you had to hit "Today" to find now. It now scrolls to today **once** on open (latched via a ref, so it never fights a later manual scroll).

## 2. Quick-schedule presets for undated tasks
The "N tasks without dates" tray gave each row only raw date pickers — painful at scale. Each row now has one-click **This week** / **Next week** (Mon–Sun) buttons alongside the pickers.

## 3. Status filter chips
Toolbar chips (● Done · Running · Pending · Blocked) toggle whole status categories on/off to narrow a busy timeline (hide Done, focus Blocked, …). The timeline **range stays global** so bars don't jump when toggling. (Per-familiar narrowing already exists via clicking a familiar group header to focus it.)

## Verification
- `pnpm typecheck` clean; `node scripts/run-tests.mjs app` → **376 files pass** (new assertions in `board-schedule-window.test.ts`).
- Browser-driven on a live Gantt:
  - auto-center: `scrollLeft` lands on today (not 0) on open;
  - filter: hiding **Done** drops 3→2 bars, chip shows off-state, restores on re-toggle;
  - preset: **This week** on an undated task → `PATCH {startDate:"2026-06-22", endDate:"2026-06-28"}` (correct Mon–Sun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)