### PR TITLE
fix(api): add API contract entry for /library/chat (un-red main)

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -73,6 +73,7 @@ const contracts: RouteContract[] = [
   { route: "/launch", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/library/all", methods: ["GET"], kind: "json" },
   { route: "/library/bookmarks", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true },
+  { route: "/library/chat", methods: ["POST"], kind: "stream", readsJson: true },
   { route: "/library/doc", methods: ["GET", "PATCH"], kind: "json", readsJson: true, invalidJson: "guarded", pathGuard: true },
   { route: "/library/github", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true },
   { route: "/library/pdf", methods: ["GET"], kind: "stream" },


### PR DESCRIPTION
The new `/library/chat` route (POST, streaming "Chat with this doc") landed without an `api-contracts.test.ts` entry, so `test:api` (part of Frontend build) is red on `main` and **blocks every open PR**.

Adds the missing contract entry: `{ route: "/library/chat", methods: ["POST"], kind: "stream", readsJson: true }`.

Verified: `node scripts/run-tests.mjs api` → 115 contracts pass, 83 api files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)