### PR TITLE
Define first-class OpenClaw bridge contract

### DIFF
--- a/src/app/api/capabilities/route.test.ts
+++ b/src/app/api/capabilities/route.test.ts
@@ -28,6 +28,24 @@ assert.match(
 
 assert.match(
   source,
+  /openClawCapabilityManifest\(new Date\(\)\.toISOString\(\)\)/,
+  "OpenClaw should expose a synthetic bridge capability manifest when the daemon has no harness manifest",
+);
+
+assert.match(
+  source,
+  /if \(harness === "openclaw"\)[\s\S]*harness_capabilities: \[manifest\]/,
+  "The per-harness capabilities route should return OpenClaw bridge capabilities directly",
+);
+
+assert.match(
+  source,
+  /bridge_capabilities: openClawBridgeCapabilities\(\)/,
+  "The synthetic OpenClaw manifest should include structured bridge capability flags",
+);
+
+assert.match(
+  source,
   /const missing = COMPATIBILITY_ADAPTERS\.map\(\(adapter\) => adapter\.id\)\.filter\(\(id\) => !present\.has\(id\)\)/,
   "Coverage backfill only fetches harnesses the daemon aggregate omitted",
 );

--- a/src/app/api/capabilities/route.ts
+++ b/src/app/api/capabilities/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { callDaemon } from "@/lib/coven-daemon";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
+import {
+  openClawBridgeCapabilities,
+  type OpenClawBridgeCapabilities,
+} from "@/lib/openclaw-bridge";
 import { scanClaudeUserSkills } from "@/lib/server/skill-scan";
 
 export const dynamic = "force-dynamic";
@@ -48,6 +52,7 @@ export type HarnessCapabilityManifest = {
   skills: HarnessSkill[];
   plugins: HarnessPlugin[];
   warnings: CapabilityWarning[];
+  bridge_capabilities?: OpenClawBridgeCapabilities;
 };
 
 export type CapabilitiesResponse = {
@@ -105,11 +110,54 @@ function isManifest(data: unknown): data is HarnessCapabilityManifest {
 }
 
 async function fetchHarnessManifest(harness: string, refresh: string): Promise<HarnessCapabilityManifest | null> {
+  if (harness === "openclaw") {
+    return openClawCapabilityManifest(new Date().toISOString());
+  }
   const res = await callDaemon<HarnessCapabilityManifest>({
     path: `/api/v1/capabilities/${encodeURIComponent(harness)}${refresh}`,
   });
   if (!res.ok || !isManifest(res.data)) return null;
   return supplementClaudeSkills(res.data);
+}
+
+function openClawCapabilityManifest(scannedAt: string): HarnessCapabilityManifest {
+  return {
+    harness_id: "openclaw",
+    scanned_at: scannedAt,
+    global_instructions: { present: false },
+    skills: [],
+    plugins: [
+      {
+        id: "openclaw-native-bridge",
+        name: "OpenClaw native bridge",
+        source: "cave",
+        harness_id: "openclaw",
+        kind: "bridge",
+        enabled: true,
+        transport: "local-cli",
+        command: "openclaw",
+        args: ["agent", "--json", "--session-key"],
+      },
+    ],
+    warnings: [
+      {
+        kind: "unsupported-local-file-attachments",
+        path: "openclaw://bridge",
+        message: "OpenClaw bridge chat does not deliver local file paths or image payloads.",
+      },
+      {
+        kind: "unsupported-ssh-runtime",
+        path: "openclaw://bridge",
+        message: "OpenClaw over SSH is not supported by Cave's local native bridge.",
+      },
+      {
+        kind: "unsupported-model-override",
+        path: "openclaw://bridge",
+        message: "Cave records OpenClaw model intent but does not pass model overrides to OpenClaw agents.",
+      },
+    ],
+    bridge_capabilities: openClawBridgeCapabilities(),
+  };
 }
 
 /**
@@ -140,6 +188,10 @@ export async function GET(req: Request) {
   const harness = url.searchParams.get("harness");
 
   if (harness) {
+    if (harness === "openclaw") {
+      const manifest = openClawCapabilityManifest(new Date().toISOString());
+      return NextResponse.json({ ok: true, coven_skills: [], harness_capabilities: [manifest], scanned_at: manifest.scanned_at });
+    }
     const res = await callDaemon<HarnessCapabilityManifest>({
       path: `/api/v1/capabilities/${encodeURIComponent(harness)}${refresh}`,
     });

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -78,14 +78,32 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /resolveOpenClawAgentId\(args\.body\.familiarId\)/,
-  "OpenClaw native chat should resolve Cave familiar ids to real OpenClaw agent ids",
+  /resolveOpenClawAgentBinding\(args\.body\.familiarId\)/,
+  "OpenClaw native chat should resolve Cave familiar ids to typed OpenClaw agent bindings",
 );
 
 assert.match(
   chatRoute,
   /import \{ openClawBin, openClawNeedsShell, openClawSpawnArgs, openClawSpawnEnv \} from "@\/lib\/openclaw-bin";/,
   "OpenClaw native chat should use the Windows-aware binary resolver instead of spawning a bare command",
+);
+
+assert.match(
+  openclawBridge,
+  /export interface RuntimeBridge[\s\S]*id: "openclaw";[\s\S]*resolveAgent\(familiarId: string\): Promise<OpenClawAgentBinding>;/,
+  "OpenClaw native chat should expose a typed runtime bridge contract separate from adapter manifests",
+);
+
+assert.match(
+  openclawBridge,
+  /type OpenClawBridgeRequest = \{[\s\S]*familiarId: string;[\s\S]*conversationId\?: string;[\s\S]*controls\?:/,
+  "OpenClaw bridge requests should capture Cave conversation ids, attachments, and response controls",
+);
+
+assert.match(
+  openclawBridge,
+  /export type OpenClawBridgeCapabilities = \{[\s\S]*stableSessionKey: boolean;[\s\S]*localFileAttachments: false;[\s\S]*nativeMemory: true;/,
+  "OpenClaw bridge should expose first-class capability flags for UI/runtime code",
 );
 
 assert.match(
@@ -126,10 +144,25 @@ assert.match(
   /const sessionId: string = conversationId/,
   "Conversation identity stays cave-owned across turns",
 );
+assert.match(
+  chatRoute,
+  /openclawAgentId: agentBinding\.openclawAgentId,[\s\S]*caveSessionId: conversationId,[\s\S]*gatewaySessionId: undefined,[\s\S]*sessionKey: openClawSessionKey\(conversationId\)/,
+  "OpenClaw transcript metadata should persist Cave id, session key, agent id, and diagnostic gateway id separately",
+);
+assert.match(
+  chatRoute,
+  /responseMetadata\.gatewaySessionId = gatewaySessionId;/,
+  "OpenClaw gateway session ids should be surfaced only as response diagnostics",
+);
 assert.doesNotMatch(
   chatRoute,
   /sessionId = extractOpenClawSessionId/,
   "The gateway's rotating session id must never become the conversation key",
+);
+assert.match(
+  chatRoute,
+  /error instanceof OpenClawAgentResolutionError[\s\S]*pushProgress\("openclaw-resolve", "OpenClaw agent resolution failed", "error", error\.message\)/,
+  "Missing OpenClaw agents should stream a clear bridge error before spawning",
 );
 assert.doesNotMatch(
   chatRoute,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -42,11 +42,12 @@ import {
   readFamiliarWorkspaces,
 } from "@/lib/coven-paths";
 import {
+  OpenClawAgentResolutionError,
   extractOpenClawSessionId,
   extractOpenClawText,
   openClawAgentArgs,
   openClawSessionKey,
-  resolveOpenClawAgentId,
+  resolveOpenClawAgentBinding,
   type OpenClawAgentJson,
 } from "@/lib/openclaw-bridge";
 import { isTrustedChatHarness, covenRunSupportsModelFlag } from "@/lib/harness-adapters";
@@ -567,8 +568,25 @@ function openClawChatResponse(args: {
       // off this id, so it survives OpenClaw's internal session-id rotation.
       const conversationId = args.body.sessionId ?? crypto.randomUUID();
       pushProgress("openclaw-resolve", "Resolving OpenClaw agent", "running");
-      const agentId = await resolveOpenClawAgentId(args.body.familiarId);
-      pushProgress("openclaw-resolve", "OpenClaw agent resolved", "done", agentId);
+      let agentBinding;
+      try {
+        agentBinding = await resolveOpenClawAgentBinding(args.body.familiarId);
+      } catch (error) {
+        if (error instanceof OpenClawAgentResolutionError) {
+          pushProgress("openclaw-resolve", "OpenClaw agent resolution failed", "error", error.message);
+          push({ kind: "error", code: error.code, message: error.message });
+          push({
+            kind: "done",
+            durationMs: Date.now() - startedAt,
+            isError: true,
+          });
+          close();
+          return;
+        }
+        throw error;
+      }
+      const agentId = agentBinding.openclawAgentId;
+      pushProgress("openclaw-resolve", "OpenClaw agent resolved", "done", `${agentId} (${agentBinding.source})`);
       const argv = openClawAgentArgs(args.harnessPrompt, agentId, conversationId);
       const spawnArgv = openClawSpawnArgs(argv);
       const cwd = await resolveLocalRuntimeCwd(
@@ -584,6 +602,11 @@ function openClawChatResponse(args: {
         modelSource: args.modelState.source,
         modelApplicationState: args.modelState.applicationState,
         modelApplicationReason: args.modelState.reason,
+        openclawAgentId: agentBinding.openclawAgentId,
+        openclawAgentSource: agentBinding.source,
+        caveSessionId: conversationId,
+        gatewaySessionId: undefined,
+        sessionKey: openClawSessionKey(conversationId),
       };
       pushProgress("openclaw-start", "Starting OpenClaw bridge", "running", cwd);
       const child = spawn(openClawBin(), spawnArgv, {
@@ -657,6 +680,7 @@ function openClawChatResponse(args: {
           try {
             const parsed = JSON.parse(stdout.trim()) as OpenClawAgentJson;
             gatewaySessionId = extractOpenClawSessionId(parsed);
+            if (gatewaySessionId) responseMetadata.gatewaySessionId = gatewaySessionId;
             assistantText = extractOpenClawText(parsed);
             isError = isError || parsed.status === "error";
           } catch {

--- a/src/lib/chat-response-metadata.ts
+++ b/src/lib/chat-response-metadata.ts
@@ -10,6 +10,11 @@ export type ChatResponseMetadata = {
   modelSource?: ModelScope;
   modelApplicationState?: ModelApplicationState;
   modelApplicationReason?: string;
+  openclawAgentId?: string;
+  openclawAgentSource?: "explicit" | "id-match" | "name-match" | "fallback";
+  caveSessionId?: string;
+  gatewaySessionId?: string;
+  sessionKey?: string;
 };
 
 /** Collapse a user home prefix to "~" so the directory reads as a location the

--- a/src/lib/openclaw-bin.test.ts
+++ b/src/lib/openclaw-bin.test.ts
@@ -40,5 +40,15 @@ assert.match(
   /delete env\[key\]/,
   "OpenClaw spawn env should strip forbidden secret keys before subprocess launch",
 );
+assert.match(
+  src,
+  /FORBIDDEN_SPAWN_ENV_RE/,
+  "OpenClaw spawn env should scrub secret-like Cave process variables by pattern, not a single hard-coded key",
+);
+assert.match(
+  src,
+  /OPENCLAW_ALLOW_ENV_KEYS/,
+  "OpenClaw spawn env should require explicit allowlisting before passing secret-like variables through",
+);
 
 console.log("openclaw-bin.test.ts: ok");

--- a/src/lib/openclaw-bin.ts
+++ b/src/lib/openclaw-bin.ts
@@ -10,7 +10,18 @@ import { covenSpawnEnv } from "./coven-bin";
 
 let cachedBin: string | null = null;
 
-const FORBIDDEN_SPAWN_ENV_KEYS = ["GITHUB_PAT"] as const;
+const FORBIDDEN_SPAWN_ENV_KEYS = new Set(["GITHUB_PAT"]);
+const FORBIDDEN_SPAWN_ENV_RE =
+  /(?:^|_)(?:TOKEN|KEY|SECRET|PASSWORD|PASS|PAT|CREDENTIALS?|COOKIE|SESSION)(?:_|$)/i;
+
+function allowedOpenClawEnvKeys(): Set<string> {
+  return new Set(
+    (process.env.OPENCLAW_ALLOW_ENV_KEYS ?? "")
+      .split(",")
+      .map((key) => key.trim())
+      .filter(Boolean),
+  );
+}
 
 function dedupe(values: string[]): string[] {
   const seen = new Set<string>();
@@ -117,8 +128,14 @@ export function openClawSpawnArgs(argv: string[]): string[] {
 
 export function openClawSpawnEnv(): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...covenSpawnEnv() };
-  for (const key of FORBIDDEN_SPAWN_ENV_KEYS) {
-    delete env[key];
+  const allowed = allowedOpenClawEnvKeys();
+  for (const key of Object.keys(env)) {
+    if (
+      (FORBIDDEN_SPAWN_ENV_KEYS.has(key) || FORBIDDEN_SPAWN_ENV_RE.test(key)) &&
+      !allowed.has(key)
+    ) {
+      delete env[key];
+    }
   }
   return env;
 }

--- a/src/lib/openclaw-bridge.test.ts
+++ b/src/lib/openclaw-bridge.test.ts
@@ -4,11 +4,14 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
+  OpenClawAgentResolutionError,
   extractOpenClawSessionId,
   extractOpenClawText,
+  openClawBridgeCapabilities,
   openClawAgentArgs,
   openClawSessionKey,
   readTomlString,
+  resolveOpenClawAgentBindingFromSources,
   resolveOpenClawAgentId,
   resolveOpenClawAgentIdFromSources,
   slugifyOpenClawAgentName,
@@ -28,6 +31,65 @@ const candidateAgents = [
   { id: "cody-main", name: "Cody Main" },
   { id: "identity-hit", identityName: "Release Review" },
 ];
+
+assert.deepEqual(openClawBridgeCapabilities(), {
+  streaming: false,
+  toolEvents: false,
+  stableSessionKey: true,
+  localFileAttachments: false,
+  sshRuntime: false,
+  modelOverride: false,
+  nativeMemory: true,
+  nativeSkills: true,
+  nativeMessaging: true,
+});
+
+assert.deepEqual(
+  resolveOpenClawAgentBindingFromSources("nova", "explicit-nova", candidateAgents),
+  {
+    caveFamiliarId: "nova",
+    openclawAgentId: "explicit-nova",
+    source: "explicit",
+  },
+  "explicit openclaw_agent binding should return typed binding metadata",
+);
+assert.deepEqual(
+  resolveOpenClawAgentBindingFromSources("nova", null, candidateAgents),
+  {
+    caveFamiliarId: "nova",
+    openclawAgentId: "nova",
+    source: "id-match",
+  },
+  "exact agent id should report id-match source metadata",
+);
+assert.deepEqual(
+  resolveOpenClawAgentBindingFromSources("release-review", null, candidateAgents),
+  {
+    caveFamiliarId: "release-review",
+    openclawAgentId: "identity-hit",
+    source: "name-match",
+  },
+  "slugified display or identity-name matches should report name-match source metadata",
+);
+assert.throws(
+  () => resolveOpenClawAgentBindingFromSources("unknown", null, candidateAgents),
+  (error) =>
+    error instanceof OpenClawAgentResolutionError &&
+    error.code === "OPENCLAW_AGENT_NOT_FOUND" &&
+    /No OpenClaw agent is bound to Cave familiar "unknown"/.test(error.message),
+  "missing OpenClaw agent resolution should fail clearly by default",
+);
+assert.deepEqual(
+  resolveOpenClawAgentBindingFromSources("unknown", null, candidateAgents, {
+    allowFallback: true,
+  }),
+  {
+    caveFamiliarId: "unknown",
+    openclawAgentId: "unknown",
+    source: "fallback",
+  },
+  "fallback-to-familiar-id should be explicit and source-tagged",
+);
 
 assert.equal(
   resolveOpenClawAgentIdFromSources("nova", "explicit-nova", candidateAgents),
@@ -50,9 +112,11 @@ assert.equal(
   "slugified identity name should resolve when no exact id or display name exists",
 );
 assert.equal(
-  resolveOpenClawAgentIdFromSources("unknown", null, candidateAgents),
+  resolveOpenClawAgentIdFromSources("unknown", null, candidateAgents, {
+    allowFallback: true,
+  }),
   "unknown",
-  "unknown familiars intentionally fall back to the familiar id",
+  "legacy id-only helper can still opt into fallback-to-familiar-id",
 );
 
 const previousCovenHome = process.env.COVEN_HOME;

--- a/src/lib/openclaw-bridge.ts
+++ b/src/lib/openclaw-bridge.ts
@@ -2,6 +2,8 @@ import { spawn } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { covenHome } from "./coven-paths.ts";
+import type { ChatAttachment } from "./chat-attachments.ts";
+import type { ChatResponseMetadata } from "./chat-response-metadata.ts";
 
 export type OpenClawAgentJson = {
   status?: string;
@@ -21,6 +23,79 @@ export type OpenClawAgentSummary = {
   identityName?: string;
   isDefault?: boolean;
 };
+
+type OpenClawBridgeRequest = {
+  familiarId: string;
+  prompt: string;
+  conversationId?: string;
+  projectRoot?: string;
+  attachments?: ChatAttachment[];
+  controls?: {
+    reasoningEffort?: "low" | "medium" | "high";
+    responseSpeed?: "fast" | "balanced" | "careful";
+  };
+};
+
+export type OpenClawAgentBinding = {
+  caveFamiliarId: string;
+  openclawAgentId: string;
+  source: "explicit" | "id-match" | "name-match" | "fallback";
+};
+
+export type OpenClawBridgeCapabilities = {
+  streaming: boolean;
+  toolEvents: boolean;
+  stableSessionKey: boolean;
+  localFileAttachments: false;
+  sshRuntime: false;
+  modelOverride: false | "agent-owned";
+  nativeMemory: true;
+  nativeSkills: true;
+  nativeMessaging: true;
+};
+
+export type OpenClawBridgeEvent =
+  | { kind: "session"; sessionId: string }
+  | { kind: "user"; text: string }
+  | { kind: "assistant_chunk"; text: string }
+  | { kind: "tool_use"; id?: string; name: string; input?: string; output?: string; status?: string }
+  | { kind: "progress"; id: string; label: string; status: "running" | "done" | "error"; detail?: string }
+  | { kind: "done"; sessionId: string; durationMs: number; isError?: boolean; responseMetadata: ChatResponseMetadata }
+  | { kind: "error"; message: string; code?: string };
+
+export interface RuntimeBridge {
+  id: "openclaw";
+  resolveAgent(familiarId: string): Promise<OpenClawAgentBinding>;
+  capabilities(): OpenClawBridgeCapabilities;
+  send(request: OpenClawBridgeRequest): AsyncIterable<OpenClawBridgeEvent>;
+}
+
+export class OpenClawAgentResolutionError extends Error {
+  readonly code = "OPENCLAW_AGENT_NOT_FOUND";
+  readonly familiarId: string;
+
+  constructor(familiarId: string) {
+    super(
+      `No OpenClaw agent is bound to Cave familiar "${familiarId}". Add familiar.openclaw_agent or create an OpenClaw agent with a matching id/name.`,
+    );
+    this.name = "OpenClawAgentResolutionError";
+    this.familiarId = familiarId;
+  }
+}
+
+export function openClawBridgeCapabilities(): OpenClawBridgeCapabilities {
+  return {
+    streaming: false,
+    toolEvents: false,
+    stableSessionKey: true,
+    localFileAttachments: false,
+    sshRuntime: false,
+    modelOverride: false,
+    nativeMemory: true,
+    nativeSkills: true,
+    nativeMessaging: true,
+  };
+}
 
 export function readTomlString(block: string, key: string): string | null {
   const quoted = block.match(new RegExp(`^\\s*${key}\\s*=\\s*(['"])(.*?)\\1\\s*(?:#.*)?$`, "m"));
@@ -83,28 +158,55 @@ export function resolveOpenClawAgentIdFromSources(
   familiarId: string,
   explicit: string | null,
   agents: OpenClawAgentSummary[],
+  options: { allowFallback?: boolean } = {},
 ): string {
-  if (explicit) return explicit;
+  return resolveOpenClawAgentBindingFromSources(familiarId, explicit, agents, options)
+    .openclawAgentId;
+}
+
+export function resolveOpenClawAgentBindingFromSources(
+  familiarId: string,
+  explicit: string | null,
+  agents: OpenClawAgentSummary[],
+  options: { allowFallback?: boolean } = {},
+): OpenClawAgentBinding {
+  if (explicit) {
+    return { caveFamiliarId: familiarId, openclawAgentId: explicit, source: "explicit" };
+  }
 
   const exact = agents.find((agent) => agent.id === familiarId)?.id;
-  if (exact) return exact;
+  if (exact) {
+    return { caveFamiliarId: familiarId, openclawAgentId: exact, source: "id-match" };
+  }
 
   const named = agents.find(
     (agent) =>
       (agent.name && slugifyOpenClawAgentName(agent.name) === familiarId) ||
       (agent.identityName && slugifyOpenClawAgentName(agent.identityName) === familiarId),
   )?.id;
-  if (named) return named;
+  if (named) {
+    return { caveFamiliarId: familiarId, openclawAgentId: named, source: "name-match" };
+  }
 
-  return familiarId;
+  if (options.allowFallback) {
+    return { caveFamiliarId: familiarId, openclawAgentId: familiarId, source: "fallback" };
+  }
+
+  throw new OpenClawAgentResolutionError(familiarId);
 }
 
 export async function resolveOpenClawAgentId(familiarId: string): Promise<string> {
+  return (await resolveOpenClawAgentBinding(familiarId)).openclawAgentId;
+}
+
+export async function resolveOpenClawAgentBinding(familiarId: string): Promise<OpenClawAgentBinding> {
   const explicit = await readOpenClawAgentBinding(familiarId);
-  if (explicit) return explicit;
+  if (explicit) {
+    return { caveFamiliarId: familiarId, openclawAgentId: explicit, source: "explicit" };
+  }
 
   const agents = await listOpenClawAgents();
-  return resolveOpenClawAgentIdFromSources(familiarId, null, agents);
+  return resolveOpenClawAgentBindingFromSources(familiarId, null, agents);
 }
 
 export function extractOpenClawText(json: OpenClawAgentJson): string {


### PR DESCRIPTION
## Summary
- Add a typed OpenClaw bridge contract covering requests, events, capabilities, and runtime bridge shape.
- Resolve Cave familiars to typed OpenClaw agent bindings with source metadata, and fail clearly when no agent is bound instead of silently falling back.
- Persist OpenClaw diagnostics separately from Cave conversation identity, and expose a synthetic OpenClaw capabilities manifest for unsupported bridge states.
- Broaden OpenClaw spawn env scrubbing for secret-like keys, with `OPENCLAW_ALLOW_ENV_KEYS` as the explicit opt-in escape hatch.

Closes #1613.

## Verification
- `node --experimental-strip-types src/lib/openclaw-bin.test.ts && node --experimental-strip-types src/lib/openclaw-bridge.test.ts && node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts && node --experimental-strip-types src/app/api/capabilities/route.test.ts`
- `pnpm check:tests-wired`
- `pnpm typecheck`
- `pnpm build`

Note: `pnpm build` still emits the existing Turbopack NFT warnings for `next.config.ts` via `src/app/api/roles/workflows/route.ts`; build exits 0.