### PR TITLE
feat(ios): export selected threads as a .zip from bulk-select

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -775,7 +775,10 @@ final class AppModel {
     /// Bundle every thread's Markdown into a single `.zip` and return its URL.
     /// Filenames come from titles (de-duplicated); zipping uses NSFileCoordinator's
     /// `.forUploading`, so there's no third-party dependency.
-    func exportAllThreadsZip() throws -> URL {
+    func exportAllThreadsZip() throws -> URL { try exportThreadsZip(threads) }
+
+    /// Bundle the given threads' Markdown into a single `.zip` and return its URL.
+    func exportThreadsZip(_ threads: [ChatThread]) throws -> URL {
         let fm = FileManager.default
         let staging = fm.temporaryDirectory
             .appendingPathComponent("CovenCave Chats-\(UUID().uuidString)", isDirectory: true)

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -18,6 +18,7 @@ struct FamiliarThreadsView: View {
     @State private var selectMode = false
     @State private var selectedIds: Set<String> = []
     @State private var confirmingBulkDelete = false
+    @State private var exportArchive: ExportArchive?
 
     /// One row in the list: an on-device thread or a server-only session.
     private enum Entry: Identifiable {
@@ -95,6 +96,11 @@ struct FamiliarThreadsView: View {
                 HStack {
                     Button(allLocalSelected ? "Deselect All" : "Select All") { toggleSelectAll() }
                     Spacer()
+                    Button { exportSelected() } label: {
+                        Text(selectedIds.isEmpty ? "Export" : "Export (\(selectedIds.count))")
+                    }
+                    .disabled(selectedIds.isEmpty)
+                    Spacer().frame(width: 16)
                     Button(role: .destructive) { confirmingBulkDelete = true } label: {
                         Text(selectedIds.isEmpty ? "Delete" : "Delete (\(selectedIds.count))")
                             .fontWeight(.semibold)
@@ -111,6 +117,9 @@ struct FamiliarThreadsView: View {
                 exitSelect()
             }
             Button("Cancel", role: .cancel) {}
+        }
+        .sheet(item: $exportArchive) { archive in
+            ActivityView(items: [archive.url])
         }
     }
 
@@ -236,6 +245,11 @@ struct FamiliarThreadsView: View {
     }
     private func exitSelect() {
         withAnimation { selectMode = false; selectedIds.removeAll() }
+    }
+    private func exportSelected() {
+        let chosen = localThreads.filter { selectedIds.contains($0.id) }
+        guard !chosen.isEmpty, let url = try? app.exportThreadsZip(chosen) else { return }
+        exportArchive = ExportArchive(url: url)
     }
 
     @ViewBuilder private func selectionMark(for entry: Entry) -> some View {

--- a/scripts/ios-export-selected-zip.test.mjs
+++ b/scripts/ios-export-selected-zip.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+const read = (rel) => readFile(new URL(`../${rel}`, import.meta.url), "utf8");
+const iosRoot = "apps/ios/CovenCave/CovenCave";
+
+const model = await read(`${iosRoot}/State/AppModel.swift`);
+const view = await read(`${iosRoot}/Views/FamiliarThreadsView.swift`);
+
+// Zip helper is parameterized; export-all delegates to it.
+assert.match(model, /func exportThreadsZip\(_ threads: \[ChatThread\]\) throws -> URL/, "AppModel should expose exportThreadsZip(_:)");
+assert.match(model, /func exportAllThreadsZip\(\) throws -> URL \{ try exportThreadsZip\(threads\) \}/, "exportAllThreadsZip should delegate");
+
+// Select bar gains an Export (N) action that zips the selection and shares it.
+assert.match(view, /Button \{ exportSelected\(\) \} label: \{[\s\S]*Text\(selectedIds\.isEmpty \? "Export" : "Export \(\\\(selectedIds\.count\)\)"\)/, "an Export (N) button in the select bar");
+assert.match(view, /let chosen = localThreads\.filter \{ selectedIds\.contains\(\$0\.id\) \}/, "exportSelected uses the selected local threads");
+assert.match(view, /app\.exportThreadsZip\(chosen\)/, "exportSelected zips the chosen threads");
+assert.match(view, /\.sheet\(item: \$exportArchive\) \{ archive in\s*ActivityView\(items: \[archive\.url\]\)/, "shares the zip via the activity sheet");
+
+console.log("ios-export-selected-zip.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -507,6 +507,7 @@ export const SUITES = {
     "scripts/ios-duplicate-thread.test.mjs",
     "scripts/ios-export-all-zip.test.mjs",
     "scripts/ios-bulk-delete-threads.test.mjs",
+    "scripts/ios-export-selected-zip.test.mjs",
     "scripts/ios-reorder-familiars.test.mjs",
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/mobile-tailscale.test.mjs",


### PR DESCRIPTION
## What

Extends the bulk-select mode in a familiar's chat list (#1688) with an **"Export (N)"** action alongside **"Delete (N)"** — zips just the selected conversations and shares them via the system sheet.

- **`AppModel`** — factored the zip writer into **`exportThreadsZip(_:)`**; `exportAllThreadsZip()` now delegates to it (so "export all" and "export selected" share one code path).
- **`FamiliarThreadsView`** — an **Export (N)** button in the select bar (disabled when nothing is selected) that zips the chosen threads and presents the share sheet.

Composes the bulk-select (#1688), per-thread export (#1678), and export-all-zip (#1685) work.

## Verification

- `pnpm test:mobile` → **✓ 39 test file(s) passed** (full suite; new `scripts/ios-export-selected-zip.test.mjs`; the existing export-all test stays green after the refactor).
- `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED**.

> Built via an atomic sibling-worktree one-shot (commit+push before build) because the in-repo `.worktrees/` keeps getting swept by concurrent-session cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)