### PR TITLE
feat(projects): rich session rows + project stat line (native redesign phase 2)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -127,6 +127,8 @@ export const SUITES = {
     "src/components/workflows/workflow-capability-attachments.test.ts",
     "src/components/projects-view.test.ts",
     "src/lib/projects/projects-ui-state.test.ts",
+    "src/lib/projects/session-glyph.test.ts",
+    "src/lib/projects/project-stats.test.ts",
     "src/components/onboarding-guided-steps.test.ts",
     "src/components/familiar-studio.test.ts",
     "src/components/familiar-studio-look-tab.test.ts",

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -247,6 +247,32 @@ assert.match(projectsView, /\{shortRoot\(project\.root\)\}/, "the displayed path
 assert.match(projectsView, /title=\{project\.root\}/, "the full path remains available via the title");
 assert.match(projectsView, /relativeTime\(/, "each row shows a relative last-active label (shared relative-time helper)");
 
+// Phase 2 — rich rows: each session row leads with a derived status glyph
+// (running spinner / failed / task / chat dot), drops the "Task: " text prefix
+// in favor of that glyph, and carries trailing metadata (model · time · diff).
+assert.match(
+  projectsView,
+  /import \{ sessionGlyph, glyphToneClass, stripTaskPrefix \} from "@\/lib\/projects\/session-glyph"/,
+  "session rows use the pure glyph helper",
+);
+assert.match(projectsView, /const glyph = sessionGlyph\(session\)/, "each chat row derives its leading glyph");
+assert.match(projectsView, /stripTaskPrefix\(/, 'the "Task: " label is stripped (shown as a glyph instead)');
+assert.match(projectsView, /glyph\.spin \? "animate-spin"/, "a running glyph spins");
+assert.match(projectsView, /import \{ RelativeTime \} from "@\/components\/ui\/relative-time"/, "rows use the RelativeTime primitive (exact-time tooltip)");
+assert.match(projectsView, /<RelativeTime iso=\{session\.updated_at\}/, "every session row shows a consistent relative timestamp");
+assert.match(projectsView, /import \{ modelIcon, modelLabel \} from "@\/lib\/model-label"/, "rows render a model chip via the shared model-label helper");
+assert.match(projectsView, /modelLabel\(session\.model\)/, "the model chip shows the shortened model label");
+
+// Project headers carry a glanceable stat line (running · tasks · sessions)
+// derived from the pure projectStats helper.
+assert.match(projectsView, /import \{ projectStats \} from "@\/lib\/projects\/project-stats"/, "headers use the pure stats helper");
+assert.match(projectsView, /const stats = projectStats\(chats\)/, "the header derives running/task counts");
+assert.match(projectsView, /stats\.running > 0 \?/, "the stat line shows a running count when any session is running");
+assert.match(projectsView, /stats\.tasks > 0 \?/, "the stat line shows a task count when the project has tasks");
+
+// The project folder icon is tinted by the project's color (when set).
+assert.match(projectsView, /color: project\.color \|\| "var\(--accent-presence\)"/, "the folder icon takes the project color, falling back to the accent");
+
 // A project card expands + scrolls into view when the command palette's
 // "Open project" navigation fires CHAT_FOCUS_PROJECT_EVENT for its root.
 assert.match(

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -4,6 +4,8 @@ import { useEffect, useMemo, useRef, useState, type CSSProperties, type FormEven
 
 import { Icon } from "@/lib/icon";
 import { relativeTime } from "@/lib/relative-time";
+import { RelativeTime } from "@/components/ui/relative-time";
+import { modelIcon, modelLabel } from "@/lib/model-label";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import { useMinuteTick } from "@/lib/use-minute-tick";
 import type { CaveProject } from "@/lib/cave-projects-types";
@@ -23,6 +25,8 @@ import { useProjects } from "@/lib/use-projects";
 import { deriveProjectStatus } from "@/lib/project-status";
 import { useProjectsUiState } from "@/lib/projects/use-projects-ui-state";
 import type { ProjectsDensity } from "@/lib/projects/projects-ui-state";
+import { sessionGlyph, glyphToneClass, stripTaskPrefix } from "@/lib/projects/session-glyph";
+import { projectStats } from "@/lib/projects/project-stats";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
@@ -109,7 +113,11 @@ function ProjectChatRow({
     id: session.id,
   });
   const style: CSSProperties = { transform: CSS.Translate.toString(transform), transition };
-  const title = stripLeadingTrailingEmoji(displayTitle ?? (session.title || "(untitled chat)"));
+  const title = stripLeadingTrailingEmoji(stripTaskPrefix(displayTitle ?? (session.title || "(untitled chat)")));
+  const glyph = sessionGlyph(session);
+  const branch = session.git?.branch ?? null;
+  const diff = session.diff ?? null;
+  const hasDiff = !!diff && (diff.additions > 0 || diff.deletions > 0);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const activate = () => (selectMode ? onToggleSelect(session.id) : onOpen());
@@ -155,8 +163,45 @@ function ProjectChatRow({
             <Icon name="ph:dots-six-vertical" width={10} aria-hidden />
           </button>
         )}
-        <span aria-hidden className={`h-1.5 w-1.5 shrink-0 rounded-full ${chatDotClass(session.status)}`} />
+        <span
+          className={`grid h-3.5 w-3.5 shrink-0 place-items-center ${glyphToneClass(glyph.tone)}`}
+          title={glyph.label}
+          aria-label={glyph.label}
+          role="img"
+        >
+          {glyph.icon ? (
+            <Icon name={glyph.icon} width={13} className={glyph.spin ? "animate-spin" : undefined} aria-hidden />
+          ) : (
+            <span aria-hidden className={`h-1.5 w-1.5 rounded-full ${chatDotClass(session.status)}`} />
+          )}
+        </span>
         <span className="min-w-0 flex-1 truncate" title={title}>{title}</span>
+        {selectMode ? null : (
+          <span className="flex shrink-0 items-center gap-2 text-[10px] text-[var(--text-muted)]">
+            {density === "comfortable" && session.model ? (
+              <span
+                className="hidden items-center gap-0.5 rounded-[4px] bg-[var(--bg-raised)]/70 px-1 py-px font-medium sm:inline-flex"
+                title={`Model: ${session.model}`}
+              >
+                <Icon name={modelIcon(session.model)} width={10} aria-hidden />
+                <span className="truncate">{modelLabel(session.model)}</span>
+              </span>
+            ) : null}
+            {density === "comfortable" && branch ? (
+              <span className="hidden max-w-[10rem] items-center gap-0.5 truncate font-mono sm:inline-flex" title={`Branch: ${branch}`}>
+                <Icon name="ph:git-branch-bold" width={10} aria-hidden />
+                <span className="truncate">{branch}</span>
+              </span>
+            ) : null}
+            {density === "comfortable" && hasDiff ? (
+              <span className="hidden items-center gap-1 font-mono sm:inline-flex" title={`+${diff!.additions} −${diff!.deletions}`}>
+                <span className="text-[var(--color-success)]">+{diff!.additions}</span>
+                <span className="text-[var(--color-danger)]">−{diff!.deletions}</span>
+              </span>
+            ) : null}
+            <RelativeTime iso={session.updated_at} className="tabular-nums" />
+          </span>
+        )}
         {selectMode ? null : confirmDelete ? (
           <span className="flex shrink-0 items-center gap-1">
             <button
@@ -246,6 +291,7 @@ function ProjectRow({
   onSetExpanded,
 }: ProjectRowProps) {
   const chatCount = chats.length;
+  const stats = projectStats(chats);
   // Expanded/collapsed state is lifted to the container and persisted, so a
   // project the user opened stays open across reloads (native-app memory)
   // instead of resetting to a flat collapsed list every visit.
@@ -409,11 +455,13 @@ function ProjectRow({
         >
           <Icon name={expanded ? "ph:caret-down" : "ph:caret-right"} width={12} aria-hidden />
         </button>
-        <span className="relative shrink-0">
+        <span
+          className="relative shrink-0"
+          style={{ color: project.color || "var(--accent-presence)" }}
+        >
           <Icon
             name="ph:folder-open-bold"
             width={15}
-            className="text-[var(--accent-presence)]"
             aria-hidden
           />
           {projectStatus ? (
@@ -460,8 +508,28 @@ function ProjectRow({
           </button>
         )}
 
-        <span className="shrink-0 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">
-          {chatCount} {chatCount === 1 ? "session" : "sessions"}
+        <span className="flex shrink-0 items-center gap-1.5 text-[10px] text-[var(--text-muted)]">
+          {stats.running > 0 ? (
+            <span
+              className="inline-flex items-center gap-1 font-medium text-[var(--accent-presence)]"
+              title={`${stats.running} running`}
+            >
+              <Icon name="ph:circle-notch-bold" width={9} className="animate-spin" aria-hidden />
+              {stats.running}
+            </span>
+          ) : null}
+          {stats.tasks > 0 ? (
+            <span
+              className="inline-flex items-center gap-1"
+              title={`${stats.tasks} ${stats.tasks === 1 ? "task" : "tasks"}`}
+            >
+              <Icon name="ph:check-square" width={10} aria-hidden />
+              {stats.tasks}
+            </span>
+          ) : null}
+          <span className="rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-0.5">
+            {chatCount} {chatCount === 1 ? "session" : "sessions"}
+          </span>
         </span>
 
         {lastActiveLabel ? (

--- a/src/lib/projects/project-stats.test.ts
+++ b/src/lib/projects/project-stats.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+
+import type { SessionRow } from "../types.ts";
+import { projectStats } from "./project-stats.ts";
+
+const row = (over: Partial<SessionRow>): SessionRow => ({
+  id: "x", project_root: "/p", harness: "codex", title: "t", status: "idle",
+  exit_code: null, archived_at: null, created_at: "", updated_at: "", ...over,
+});
+
+assert.deepEqual(projectStats([]), { total: 0, running: 0, tasks: 0, failed: 0 });
+
+const chats = [
+  row({ status: "running" }),
+  row({ status: "running", origin: "board", title: "Task: a" }), // running AND task
+  row({ status: "failed", title: "Task: b" }),                   // failed AND task
+  row({ status: "error" }),
+  row({ status: "done", title: "plain chat" }),
+];
+
+assert.deepEqual(projectStats(chats), { total: 5, running: 2, tasks: 2, failed: 2 });
+
+console.log("project-stats.test.ts: ok");

--- a/src/lib/projects/project-stats.ts
+++ b/src/lib/projects/project-stats.ts
@@ -1,0 +1,24 @@
+// Pure glanceable counts for a project's header stat line (running · tasks ·
+// sessions). Self-contained (no React) so it unit-tests in isolation.
+
+import type { SessionRow } from "../types.ts";
+import { isTaskSession } from "./session-glyph.ts";
+
+export type ProjectStats = {
+  total: number;
+  running: number;
+  tasks: number;
+  failed: number;
+};
+
+export function projectStats(chats: SessionRow[]): ProjectStats {
+  let running = 0;
+  let tasks = 0;
+  let failed = 0;
+  for (const s of chats) {
+    if (s.status === "running") running += 1;
+    if (s.status === "failed" || s.status === "error") failed += 1;
+    if (isTaskSession(s)) tasks += 1;
+  }
+  return { total: chats.length, running, tasks, failed };
+}

--- a/src/lib/projects/session-glyph.test.ts
+++ b/src/lib/projects/session-glyph.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+
+import {
+  glyphToneClass,
+  isTaskSession,
+  sessionGlyph,
+  stripTaskPrefix,
+} from "./session-glyph.ts";
+
+const base = { status: "idle", origin: undefined, title: "Hello" };
+
+// isTaskSession: board origin OR a "Task: " title prefix.
+assert.equal(isTaskSession({ origin: "board", title: "anything" }), true);
+assert.equal(isTaskSession({ origin: "chat", title: "Task: Ship it" }), true);
+assert.equal(isTaskSession({ origin: "chat", title: "task: lowercase" }), true);
+assert.equal(isTaskSession({ origin: "chat", title: "Just a chat" }), false);
+assert.equal(isTaskSession({ origin: undefined, title: "" }), false);
+
+// stripTaskPrefix: removes the label (case/space tolerant), leaves others alone.
+assert.equal(stripTaskPrefix("Task: Review VC"), "Review VC");
+assert.equal(stripTaskPrefix("task:   spaced"), "spaced");
+assert.equal(stripTaskPrefix("No prefix here"), "No prefix here");
+
+// sessionGlyph precedence: running > failed > task > chat.
+assert.deepEqual(sessionGlyph({ ...base, status: "running" }), {
+  kind: "running", tone: "accent", icon: "ph:circle-notch-bold", spin: true, label: "Running",
+});
+assert.equal(sessionGlyph({ ...base, status: "failed" }).kind, "failed");
+assert.equal(sessionGlyph({ ...base, status: "error" }).kind, "failed");
+assert.equal(sessionGlyph({ ...base, status: "error" }).icon, "ph:warning-circle-fill");
+// running wins even for a board task
+assert.equal(sessionGlyph({ status: "running", origin: "board", title: "Task: x" }).kind, "running");
+// task (no failure/run) → check-square, no spin, calm tone
+assert.deepEqual(sessionGlyph({ status: "done", origin: "board", title: "Task: x" }), {
+  kind: "task", tone: "muted", icon: "ph:check-square", spin: false, label: "Task",
+});
+// plain chat → no icon (render the dot)
+const chat = sessionGlyph({ ...base, status: "done" });
+assert.equal(chat.kind, "chat");
+assert.equal(chat.icon, null);
+
+// glyphToneClass maps tones to CSS vars.
+assert.match(glyphToneClass("accent"), /accent-presence/);
+assert.match(glyphToneClass("danger"), /color-danger/);
+assert.match(glyphToneClass("success"), /color-success/);
+assert.match(glyphToneClass("muted"), /text-muted/);
+
+console.log("session-glyph.test.ts: ok");

--- a/src/lib/projects/session-glyph.ts
+++ b/src/lib/projects/session-glyph.ts
@@ -1,0 +1,63 @@
+// Pure derivation of a session row's leading glyph for the Projects tab. Maps a
+// SessionRow to a small descriptor the row renders as either a status icon
+// (running / failed / task) or the calm status dot (plain chat). Self-contained
+// (no React, type-only import) so it unit-tests under the strip-types runner.
+
+import type { SessionRow } from "../types.ts";
+import type { IconName } from "../icon";
+
+export type SessionGlyphKind = "running" | "failed" | "task" | "chat";
+export type SessionGlyphTone = "accent" | "danger" | "success" | "muted";
+
+export type SessionGlyph = {
+  kind: SessionGlyphKind;
+  tone: SessionGlyphTone;
+  /** Phosphor icon name for running/failed/task; null for plain chat (render the dot). */
+  icon: IconName | null;
+  /** Whether the icon should spin (running only). */
+  spin: boolean;
+  /** Accessible label for the glyph (title / aria). */
+  label: string;
+};
+
+const TASK_TITLE_RE = /^\s*task:\s*/i;
+
+/**
+ * A session is "task"-shaped when it was opened from a board card (origin
+ * "board") or its title carries the "Task: " label the board→chat bridge adds.
+ */
+export function isTaskSession(session: Pick<SessionRow, "origin" | "title">): boolean {
+  return session.origin === "board" || TASK_TITLE_RE.test(session.title ?? "");
+}
+
+/** Drop a leading "Task: " label — the kind is shown as a glyph instead. */
+export function stripTaskPrefix(title: string): string {
+  return title.replace(TASK_TITLE_RE, "");
+}
+
+/** Leading glyph for a session row, in precedence order: running > failed > task > chat. */
+export function sessionGlyph(
+  session: Pick<SessionRow, "status" | "origin" | "title">,
+): SessionGlyph {
+  if (session.status === "running")
+    return { kind: "running", tone: "accent", icon: "ph:circle-notch-bold", spin: true, label: "Running" };
+  if (session.status === "failed" || session.status === "error")
+    return { kind: "failed", tone: "danger", icon: "ph:warning-circle-fill", spin: false, label: "Failed" };
+  if (isTaskSession(session))
+    return { kind: "task", tone: "muted", icon: "ph:check-square", spin: false, label: "Task" };
+  return { kind: "chat", tone: "muted", icon: null, spin: false, label: "Chat" };
+}
+
+/** Tailwind text-color class for a glyph tone (shared by icon + dot). */
+export function glyphToneClass(tone: SessionGlyphTone): string {
+  switch (tone) {
+    case "accent":
+      return "text-[var(--accent-presence)]";
+    case "danger":
+      return "text-[var(--color-danger)]";
+    case "success":
+      return "text-[var(--color-success)]";
+    default:
+      return "text-[var(--text-muted)]";
+  }
+}


### PR DESCRIPTION
## What

Phase 2 of the [Projects native redesign](https://github.com/OpenCoven/coven-cave/blob/main/docs/projects-view-native-redesign.md) — **the visual heart**. Session rows become glanceable and metadata-bearing; project headers gain an at-a-glance stat line.

### Session rows
- **Leading status glyph** derived purely: running spinner · failed · task checkbox · plain-chat dot — replacing the single undifferentiated dot.
- The **"Task: " title prefix is dropped** in favor of the task glyph.
- **Trailing metadata** (comfortable density): model chip (shared `modelLabel`/`modelIcon`), git branch, and `+N −M` working-tree diff.
- A **consistent `RelativeTime`** on every row (exact-time tooltip), fixing the previous inconsistent / missing per-row timestamps.
- Compact density stays a tight single line (time only).

### Project headers
- **Stat line** "N running · M tasks · X sessions" from a new pure `projectStats`.
- **Folder icon tinted** by the project's color (falls back to the accent).

## How
- New pure, unit-tested modules `src/lib/projects/{session-glyph,project-stats}.ts` (no React/DOM). `session-glyph` also owns `isTaskSession`/`stripTaskPrefix` so the task heuristic lives in one tested place.
- `projects-view.tsx` integrates them; reuses existing `model-label` + `RelativeTime` primitives.

## Verification
- `pnpm typecheck` — clean
- source-text test extended (glyph, stat line, model chip, RelativeTime, color tint) — green
- new unit tests green, wired into `run-tests.mjs`; `check:tests-wired` green
- visual verification via run-cave-app (screenshots in PR thread)

No data-model/API changes. Icons (`ph:circle-notch-bold`, `ph:warning-circle-fill`, `ph:check-square`, `ph:git-branch-bold`) already allowlisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)