### PR TITLE
feat(ios): persist unsent chat drafts per thread

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -36,6 +36,9 @@ struct ChatView: View {
     // from the markdown WebView). Driven by the `.caveZoomContent` notification.
     @State private var zoomTarget: ZoomTarget?
 
+    /// Per-thread key for the persisted unsent draft.
+    private var draftKey: String { "cave.chat.draft.\(thread.id)" }
+
     // The slash autocomplete is driven purely off the in-progress draft: a
     // leading "/" on the first word (no whitespace committed yet).
     private var slashMatches: [SlashCommand] {
@@ -114,6 +117,23 @@ struct ChatView: View {
         // first reply; once streaming stops, push that sessionId onto the card.
         .onChange(of: thread.isStreaming) { _, streaming in
             if !streaming { Task { await app.reconcileCardLinks(for: thread) } }
+        }
+        // Restore an unsent draft for this thread (typed earlier, then the view
+        // was dismissed or the app backgrounded). Only when the live draft is
+        // empty, so a draft already in hand isn't clobbered.
+        .onAppear {
+            if draft.isEmpty, let saved = UserDefaults.standard.string(forKey: draftKey) {
+                draft = saved
+            }
+        }
+        // Persist every edit per-thread; send() clears the draft, which removes
+        // the stored copy here so a sent message leaves nothing behind.
+        .onChange(of: draft) { _, value in
+            if value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                UserDefaults.standard.removeObject(forKey: draftKey)
+            } else {
+                UserDefaults.standard.set(value, forKey: draftKey)
+            }
         }
         // Tap-to-enlarge: any chat subview posts a ZoomTarget; present it full
         // screen here (one cover for native images and lifted table/diagram HTML).


### PR DESCRIPTION
## What

A half-typed chat message lived only in `@State`, so switching tabs, opening another chat, or backgrounding the app silently lost it.

Now the composer draft is persisted **per thread** to `UserDefaults` (key `cave.chat.draft.<threadId>`):
- **Restore on appear** — only when the live draft is empty, so a draft already in hand isn't clobbered.
- **Save on every edit** via `.onChange(of: draft)`.
- **Auto-clear when emptied** — `send()` already resets the draft to `""`, which removes the stored copy, so a sent message leaves nothing behind.

## Files
- `ChatView.swift` — `draftKey` helper + `.onAppear` restore + `.onChange(of: draft)` persist (20 lines)

## Verification
- `xcodebuild` for the iPhone 16 Pro simulator → **BUILD SUCCEEDED**.
- iOS tests `ios-slash-commands`, `ios-message-reader` → **ok**.
- This is behavior-only (type → leave → return), which `simctl` can't drive for a screenshot, so it's verified by build + the straightforward load/save/clear logic rather than a captured image.

> Note: iOS Swift isn't compiled by the required CI checks, so this was verified locally via `xcodebuild` + simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)