### PR TITLE
fix(projects): let the human browse familiar workspaces (project-tree 403)

### DIFF
--- a/src/app/api/project-local-human-read.test.ts
+++ b/src/app/api/project-local-human-read.test.ts
@@ -16,12 +16,41 @@ assert.match(
   "defines the read-only surface allowlist",
 );
 assert.doesNotMatch(helper, /LOCAL_HUMAN_READ_SURFACES[\s\S]*"file-write"/, "writes are NOT in the local-human allowlist");
+
+// The human-read predicate covers BOTH the loopback desktop (read surfaces) and
+// the phone (mobile surface, GET only — writes/POST fall through to the familiar
+// requirement).
 assert.match(
   helper,
-  /if \(args\.request && isLocalOrigin\(args\.request\) && LOCAL_HUMAN_READ_SURFACES\.has\(surface\)\) \{\s*return;/,
-  "allows loopback no-familiar reads of read surfaces",
+  /function isHumanRead\(req: Request \| undefined, surface: ProjectPermissionSurface\)/,
+  "defines an isHumanRead predicate",
 );
-assert.match(helper, /throw new ProjectAccessDeniedError\("missing familiarId for project access"\)/, "still throws for non-local / write");
+assert.match(
+  helper,
+  /if \(isLocalOrigin\(req\) && LOCAL_HUMAN_READ_SURFACES\.has\(surface\)\) return true;/,
+  "loopback desktop reads of read surfaces count as a human read",
+);
+assert.match(
+  helper,
+  /if \(surface === "mobile" && \(req\.method \?\? "GET"\)\.toUpperCase\(\) === "GET"\) return true;/,
+  "a mobile GET counts as a human read; a mobile POST (write) does not",
+);
+// Registered-project reads use the predicate, and still throw without it.
+assert.match(helper, /if \(isHumanRead\(args\.request, surface\)\) \{\s*return;/, "registered-project reads gate on isHumanRead");
+assert.match(helper, /throw new ProjectAccessDeniedError\("missing familiarId for project access"\)/, "still throws for non-human / write");
+
+// A familiar's own workspace isn't a *registered* project, but the human may
+// still browse any path the traversal guard allows (resolveAllowedProjectPath).
+assert.match(
+  helper,
+  /import \{ resolveAllowedProjectPath \} from "@\/lib\/server\/project-paths"/,
+  "imports the traversal-guard resolver",
+);
+assert.match(
+  helper,
+  /if \(!familiarId && isHumanRead\(args\.request, surface\) && resolveAllowedProjectPath\(requestedPath\)\) \{\s*return;/,
+  "human reads of an unregistered-but-allowed path (e.g. a familiar workspace) are permitted",
+);
 
 // Every read route forwards the request so the loopback check can run.
 for (const rel of [

--- a/src/lib/server/project-permission-requests.ts
+++ b/src/lib/server/project-permission-requests.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/project-permissions";
 import { MOBILE_ACCESS_HEADER } from "@/proxy-helpers";
 import { isLocalOrigin } from "@/lib/server/local-origin";
+import { resolveAllowedProjectPath } from "@/lib/server/project-paths";
 
 function isWithinRoot(candidate: string, root: string): boolean {
   const relativePath = path.relative(root, candidate);
@@ -43,6 +44,23 @@ const LOCAL_HUMAN_READ_SURFACES: ReadonlySet<ProjectPermissionSurface> = new Set
   "project-api",
 ]);
 
+/**
+ * True when this is the human operator reading (not a familiar, not a write).
+ * Two shapes:
+ *   - their own desktop on a loopback origin, for the read surfaces above;
+ *   - the same human on their own phone — the native app sends the mobile header
+ *     (→ surface "mobile") and only ever GETs to read. The request already
+ *     cleared the server's front gate (token / same-origin / tailnet-trust) to
+ *     reach this route, so a mobile GET is the trusted human; writes (POST) still
+ *     fall through to the familiar requirement.
+ */
+function isHumanRead(req: Request | undefined, surface: ProjectPermissionSurface): boolean {
+  if (!req) return false;
+  if (isLocalOrigin(req) && LOCAL_HUMAN_READ_SURFACES.has(surface)) return true;
+  if (surface === "mobile" && (req.method ?? "GET").toUpperCase() === "GET") return true;
+  return false;
+}
+
 export async function assertProjectApiAccess(args: {
   familiarId: string | null | undefined;
   path: string | null | undefined;
@@ -58,12 +76,22 @@ export async function assertProjectApiAccess(args: {
   const projects = await loadProjects();
   const project = projectRootForPath(requestedPath, projects);
   if (!project) {
+    // Not a *registered* project — but the path may still be a legitimate read
+    // target the traversal guard already permits: a familiar's own workspace
+    // (~/.coven/workspaces/familiars/<id>), an openclaw research dir, or the cwd.
+    // Let the human browse those (the Code tab surfaces familiar workspaces);
+    // familiars still need a real registered-project grant, and writes still need
+    // a familiar.
+    if (!familiarId && isHumanRead(args.request, surface) && resolveAllowedProjectPath(requestedPath)) {
+      return;
+    }
     throw new ProjectAccessDeniedError("project is not registered for permission checks");
   }
   if (!familiarId) {
-    // The human at their own desktop (loopback) may read a registered project's
-    // files without a familiar. Familiars stay gated; writes still need one.
-    if (args.request && isLocalOrigin(args.request) && LOCAL_HUMAN_READ_SURFACES.has(surface)) {
+    // The human (their own desktop, or their phone) may read a registered
+    // project's files without a familiar. Familiars stay gated; writes still
+    // need one.
+    if (isHumanRead(args.request, surface)) {
       return;
     }
     throw new ProjectAccessDeniedError("missing familiarId for project access");


### PR DESCRIPTION
## Problem

Browsing a familiar's workspace from the **Code tab** returned `403 "project is not registered"` (seen live as repeated `GET /api/project-tree?root=…/.coven/workspaces/familiars/nova&depth=1&familiarId=` → 403 from the phone).

Root cause: `/api/familiars` exposes each familiar's `workspace` dir (`~/.coven/workspaces/familiars/<id>`), and the Code surface browses it — but `assertProjectApiAccess` required the path to be a **registered** project. Familiar workspaces aren't registered, so they were denied, *even though* the path-traversal guard (`resolveAllowedProjectPath`) already permits them (they live under the coven workspace root). Separately, over Tailscale the phone couldn't read even registered projects without a familiar, because the human-read exemption was **loopback-only**.

## Fix

One `isHumanRead(req, surface)` predicate gates no-familiar reads:
- the **loopback desktop** for the existing read surfaces, **or**
- the **phone** (mobile surface, **GET only**) — the request already cleared the server's front auth gate (token / same-origin / tailnet-trust) to reach the route, so a mobile GET is the trusted human.

When the path isn't a registered project, a human read is allowed **iff** the traversal guard permits the path (familiar workspaces, openclaw dirs, cwd).

**Unchanged / still gated:** writes (POST) and any `familiarId` path fall through to the registered-project grant / familiar requirement — a mobile POST can't write.

## Verification

On a running server:
- mobile GET of `~/.coven/workspaces/familiars/nova` → **`200`** (was `403`) ✅
- desktop loopback browse → `200` ✅
- **mobile POST write** into that workspace → **still denied** ✅ (writes stay gated)

Updated `project-local-human-read.test.ts`; typecheck + permission suites pass; prod build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)