### PR TITLE
feat(ios): attach multiple images + hardware-keyboard shortcuts

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -29,8 +29,10 @@ struct ChatView: View {
     @State private var showTasks = false
     @State private var atBottom = true
     @State private var dictation = SpeechDictation()
-    @State private var photoItem: PhotosPickerItem?
-    @State private var pendingImage: PendingImage?
+    @State private var photoItems: [PhotosPickerItem] = []
+    @State private var pendingImages: [PendingImage] = []
+    /// How many images one message can carry.
+    private let maxAttachments = 4
     @State private var responseReader: ResponseReaderItem?
     // Tap-to-enlarge target (image attachment, or a table/diagram/image lifted
     // from the markdown WebView). Driven by the `.caveZoomContent` notification.
@@ -200,48 +202,55 @@ struct ChatView: View {
                     .padding(.horizontal, 12)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
-            if let pendingImage {
-                attachmentPreview(pendingImage)
+            if !pendingImages.isEmpty {
+                attachmentPreviews
             }
             composerBar
         }
         .animation(.snappy(duration: 0.18), value: showingSlashMenu)
-        .animation(.snappy(duration: 0.18), value: pendingImage?.id)
+        .animation(.snappy(duration: 0.18), value: pendingImages.count)
         .background(.bar)
         // Live dictation streams its running transcript into the draft.
         .onAppear { dictation.onUpdate = { draft = $0 } }
-        .onChange(of: photoItem) { _, item in
-            guard let item else { return }
-            Task { await loadPickedImage(item) }
+        .onChange(of: photoItems) { _, items in
+            guard !items.isEmpty else { return }
+            let picked = items
+            photoItems = []
+            // Load in order so the thumbnails (and sent attachments) keep the
+            // user's selection order.
+            Task { for item in picked { await loadPickedImage(item) } }
         }
     }
 
-    /// Thumbnail of the attached image above the composer, with a remove button.
-    private func attachmentPreview(_ pending: PendingImage) -> some View {
-        HStack {
-            ZStack(alignment: .topTrailing) {
-                Image(uiImage: pending.image)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(width: 64, height: 64)
-                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                    .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .strokeBorder(Color(.separator).opacity(0.5), lineWidth: 1))
-                Button {
-                    pendingImage = nil
-                    photoItem = nil
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 18))
-                        .foregroundStyle(.white, .black.opacity(0.55))
+    /// A scrollable row of attached-image thumbnails above the composer, each
+    /// with its own remove button.
+    private var attachmentPreviews: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(pendingImages) { pending in
+                    ZStack(alignment: .topTrailing) {
+                        Image(uiImage: pending.image)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: 64, height: 64)
+                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .strokeBorder(Color(.separator).opacity(0.5), lineWidth: 1))
+                        Button {
+                            pendingImages.removeAll { $0.id == pending.id }
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.system(size: 18))
+                                .foregroundStyle(.white, .black.opacity(0.55))
+                        }
+                        .offset(x: 6, y: -6)
+                        .accessibilityLabel("Remove image")
+                    }
                 }
-                .offset(x: 6, y: -6)
-                .accessibilityLabel("Remove image")
             }
-            Spacer()
+            .padding(.horizontal, 14)
+            .padding(.vertical, 4)
         }
-        .padding(.horizontal, 14)
-        .padding(.top, 4)
     }
 
     private func startDictation() {
@@ -259,9 +268,12 @@ struct ChatView: View {
         guard let jpeg = resized.jpegData(compressionQuality: 0.8) else { return }
         let dataUrl = "data:image/jpeg;base64,\(jpeg.base64EncodedString())"
         await MainActor.run {
-            pendingImage = PendingImage(image: resized, dataUrl: dataUrl,
-                                        mimeType: "image/jpeg", name: "photo.jpg")
-            photoItem = nil
+            guard pendingImages.count < maxAttachments else { return }
+            // Unique per-image name so several attachments on one message don't
+            // collide server-side.
+            let name = "photo-\(UUID().uuidString.prefix(8)).jpg"
+            pendingImages.append(PendingImage(image: resized, dataUrl: dataUrl,
+                                              mimeType: "image/jpeg", name: name))
             Haptics.tap()
         }
     }
@@ -269,14 +281,17 @@ struct ChatView: View {
     private var composerBar: some View {
         HStack(alignment: .bottom, spacing: 10) {
             // Attach an image; the server delivers it to the familiar.
-            PhotosPicker(selection: $photoItem, matching: .images, photoLibrary: .shared()) {
+            PhotosPicker(selection: $photoItems,
+                         maxSelectionCount: maxAttachments,
+                         matching: .images,
+                         photoLibrary: .shared()) {
                 Image(systemName: "plus")
                     .font(.system(size: 18, weight: .semibold))
                     .foregroundStyle(.secondary)
                     .frame(width: 34, height: 34)
                     .background(Color(.secondarySystemBackground), in: Circle())
             }
-            .accessibilityLabel("Attach image")
+            .accessibilityLabel("Attach images")
 
             // Hairline capsule with the field and a trailing control inside it:
             // a mic when empty, a filled send/run button once there's text.
@@ -345,7 +360,7 @@ struct ChatView: View {
     }
 
     private var canSend: Bool {
-        !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || pendingImage != nil
+        !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !pendingImages.isEmpty
     }
 
     /// True when the draft is a recognised command — tints the send affordance
@@ -375,12 +390,12 @@ struct ChatView: View {
             app.touch(thread)
         case .prose(let text):
             guard let client = app.client else { return }
-            let attachments = pendingImage.map {
-                [CaveClient.ChatAttachment(name: $0.name, mimeType: $0.mimeType, dataUrl: $0.dataUrl)]
-            } ?? []
+            let attachments = pendingImages.map {
+                CaveClient.ChatAttachment(name: $0.name, mimeType: $0.mimeType, dataUrl: $0.dataUrl)
+            }
             guard !text.isEmpty || !attachments.isEmpty else { return }
             draft = ""
-            pendingImage = nil
+            pendingImages = []
             Haptics.tap()
             thread.send(text, attachments: attachments, client: client) { app.touch(thread) }
         }

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -337,6 +337,7 @@ struct ChatsHomeView: View {
             }
             .buttonStyle(.plain)
             .accessibilityLabel("New chat")
+            .keyboardShortcut("n", modifiers: .command)
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 8)

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -28,6 +28,9 @@ struct RootView: View {
 struct MainTabView: View {
     @Environment(AppModel.self) private var app
 
+    /// Tab order, used to map ⌘1–5 to the right tab.
+    private let tabOrder: [AppTab] = [.chats, .read, .tasks, .dev, .settings]
+
     var body: some View {
         @Bindable var app = app
         TabView(selection: $app.selectedTab) {
@@ -50,6 +53,16 @@ struct MainTabView: View {
         // Command confirmations float above the whole tab bar so they're visible
         // whether a command stays in chat or jumps to the Tasks tab.
         .toast($app.toast)
+        // Hardware-keyboard tab switching (iPad / Mac over Tailscale): ⌘1–5.
+        // Hidden buttons keep the shortcuts active without affecting layout.
+        .background {
+            ForEach(Array(tabOrder.enumerated()), id: \.element) { index, tab in
+                Button {
+                    app.selectedTab = tab
+                } label: { EmptyView() }
+                .keyboardShortcut(KeyEquivalent(Character("\(index + 1)")), modifiers: .command)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## What

Two power-user ergonomics, both clear of the busy Chats-list code.

### 1. Attach multiple images per message
The composer attached exactly one image. Now:
- The picker is **multi-select** (`maxSelectionCount: 4`).
- `pendingImage: PendingImage?` → `pendingImages: [PendingImage]`; the preview is a **scrollable thumbnail row**, each thumbnail individually removable.
- Picks load **in selection order**; each attachment gets a **unique name** (`photo-<uuid>.jpg`) so several on one message don't collide server-side.
- `send()` fans out all attachments; the field clears as before.

### 2. Hardware-keyboard shortcuts (iPad / Mac over Tailscale)
The app had **no** keyboard shortcuts despite heavy iPad use. Added:
- **⌘1–5** — switch tabs (hidden shortcut buttons in the `TabView` background keep them live without affecting layout).
- **⌘N** — new chat (on the Chats compose button).

## Files
- `ChatView.swift` — multi-image state, thumbnail row, multi-select picker, ordered load, send fan-out
- `RootView.swift` — ⌘1–5 tab switching
- `ChatsHomeView.swift` — ⌘N on the compose button

## Verification
- `xcodebuild` for the iPhone 16 Pro simulator → **BUILD SUCCEEDED**.
- iOS tests `ios-no-canvas-tab`, `ios-slash-commands`, `ios-message-reader`, `ios-task-actions` → all **ok**.
- Both features are interaction-driven (the system PhotosPicker for multi-attach; a hardware keyboard for shortcuts), neither of which `simctl` can drive for a screenshot — so verified by build + logic rather than a captured image.

> Note: iOS Swift isn't compiled by the required CI checks, so this was verified locally via `xcodebuild` + simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)