### PR TITLE
feat(projects): keyboard navigation + touch-visible row actions (native redesign phase 3)

### DIFF
--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -291,4 +291,41 @@ assert.match(
   "the card carries a stable id so it can be scrolled into view",
 );
 
+// Phase 3 — keyboard navigation: a roving tabindex (WAI-ARIA) over the
+// flattened list of project headers + their visible session rows. ↑/↓ + Home/End
+// move focus (shared hook); →/← expand/collapse a focused header.
+assert.match(
+  projectsView,
+  /import \{ useRovingTabIndex \} from "@\/lib\/use-roving-tabindex"/,
+  "reuses the shared roving-tabindex hook",
+);
+assert.match(
+  projectsView,
+  /useRovingTabIndex\(\{ containerRef: listRef, itemSelector: "\[data-proj-nav\]", orientation: "vertical" \}\)/,
+  "rove vertically over [data-proj-nav] items in the list container",
+);
+assert.match(projectsView, /<main ref=\{listRef\}/, "the scroll container hosts the roving keydown handler");
+// Both the project header disclosure and each session row are nav stops.
+assert.ok(
+  (projectsView.match(/data-proj-nav/g) ?? []).length >= 2,
+  "header disclosure + session rows are both tagged as rove stops",
+);
+assert.match(
+  projectsView,
+  /e\.key === "ArrowRight" && !expanded[\s\S]{0,80}?setExpanded\(true\)/,
+  "ArrowRight expands a focused, collapsed project header",
+);
+assert.match(
+  projectsView,
+  /e\.key === "ArrowLeft" && expanded[\s\S]{0,80}?setExpanded\(false\)/,
+  "ArrowLeft collapses a focused, expanded project header",
+);
+// Touch: row actions (drag + delete) stay visible on coarse pointers, where
+// there is no hover to reveal them.
+assert.match(
+  projectsView,
+  /\[@media\(pointer:coarse\)\]:opacity-100/,
+  "row actions stay visible on touch/coarse-pointer devices",
+);
+
 console.log("projects-view.test.ts: ok");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -27,6 +27,7 @@ import { useProjectsUiState } from "@/lib/projects/use-projects-ui-state";
 import type { ProjectsDensity } from "@/lib/projects/projects-ui-state";
 import { sessionGlyph, glyphToneClass, stripTaskPrefix } from "@/lib/projects/session-glyph";
 import { projectStats } from "@/lib/projects/project-stats";
+import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
@@ -127,6 +128,7 @@ function ProjectChatRow({
         role={selectMode ? "checkbox" : "button"}
         aria-checked={selectMode ? selected : undefined}
         tabIndex={0}
+        data-proj-nav
         onClick={activate}
         onKeyDown={(e) => {
           // ARIA button/checkbox pattern: Enter and Space both activate.
@@ -158,7 +160,7 @@ function ProjectChatRow({
             onClick={(e) => e.stopPropagation()}
             title="Drag to reorder or move to another project"
             aria-label={`Move ${title}`}
-            className="grid h-4 w-3 shrink-0 cursor-grab touch-none place-items-center text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover/pc:opacity-100"
+            className="grid h-4 w-3 shrink-0 cursor-grab touch-none place-items-center text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover/pc:opacity-100 [@media(pointer:coarse)]:opacity-100"
           >
             <Icon name="ph:dots-six-vertical" width={10} aria-hidden />
           </button>
@@ -238,7 +240,7 @@ function ProjectChatRow({
             }}
             title="Delete chat"
             aria-label={`Delete ${title}`}
-            className="focus-ring grid h-5 w-5 shrink-0 place-items-center rounded text-[var(--text-muted)] opacity-0 transition-opacity hover:bg-[var(--bg-hover)] hover:text-[var(--color-danger)] focus-visible:opacity-100 group-hover/pc:opacity-100"
+            className="focus-ring grid h-5 w-5 shrink-0 place-items-center rounded text-[var(--text-muted)] opacity-0 transition-opacity hover:bg-[var(--bg-hover)] hover:text-[var(--color-danger)] focus-visible:opacity-100 group-hover/pc:opacity-100 [@media(pointer:coarse)]:opacity-100"
           >
             <Icon name="ph:trash-bold" width={11} aria-hidden />
           </button>
@@ -448,7 +450,19 @@ function ProjectRow({
       <div className="flex min-w-0 items-center gap-2">
         <button
           type="button"
+          data-proj-nav
           onClick={() => setExpanded((value) => !value)}
+          onKeyDown={(e) => {
+            // Tree-style disclosure: → expands, ← collapses (no-op when already
+            // in that state). Vertical roving (↑/↓) is handled by the container.
+            if (e.key === "ArrowRight" && !expanded) {
+              e.preventDefault();
+              setExpanded(true);
+            } else if (e.key === "ArrowLeft" && expanded) {
+              e.preventDefault();
+              setExpanded(false);
+            }
+          }}
           aria-expanded={expanded}
           aria-label={`${expanded ? "Collapse" : "Expand"} ${project.name}${statusLabel}`}
           className="focus-ring -ml-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-secondary)]"
@@ -768,6 +782,11 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
   const [sessionError, setSessionError] = useState<string | null>(null);
   const projectOverrides = useProjectOverrides();
   const { density, setDensity, isExpanded, setExpanded } = useProjectsUiState();
+  // Roving keyboard navigation (WAI-ARIA) over the flattened list of project
+  // headers + their visible session rows: ↑/↓ + Home/End move focus, Enter/Space
+  // open/select (per-row handlers), and →/← expand/collapse a focused header.
+  const listRef = useRef<HTMLElement>(null);
+  useRovingTabIndex({ containerRef: listRef, itemSelector: "[data-proj-nav]", orientation: "vertical" });
   const [order, setOrder] = useState<string[]>([]);
   useEffect(() => {
     setOrder(readSessionOrder());
@@ -1055,7 +1074,7 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
         </form>
       ) : null}
 
-      <main className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6">
+      <main ref={listRef} className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6">
         {error && projects.length === 0 ? (
           <ErrorState
             icon="ph:warning"

--- a/src/lib/use-roving-tabindex.test.ts
+++ b/src/lib/use-roving-tabindex.test.ts
@@ -63,4 +63,12 @@ assert.match(
   "clamps activeIndex when the item list shrinks",
 );
 
+// Ignores keystrokes originating in an editable field, so arrow/Home/End move
+// the text caret (e.g. an inline rename input) instead of roving focus.
+assert.match(
+  source,
+  /isContentEditable\s*\|\|\s*\/\^\(INPUT\|TEXTAREA\|SELECT\)\$\/\.test\(\s*t\.tagName\s*\)/,
+  "does not rove while typing in an input/textarea/select/contentEditable",
+);
+
 console.log("use-roving-tabindex.test.ts OK");

--- a/src/lib/use-roving-tabindex.ts
+++ b/src/lib/use-roving-tabindex.ts
@@ -96,6 +96,11 @@ export function useRovingTabIndex({
     }
 
     function onKey(e: KeyboardEvent) {
+      // Never rove while the user is typing in a field inside the container
+      // (e.g. an inline rename/filter input) — arrow keys must move the caret
+      // and Home/End must jump within the text, not the item set.
+      const t = e.target as HTMLElement | null;
+      if (t && (t.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName))) return;
       switch (e.key) {
         case "ArrowDown":
           if (!vert) return;


### PR DESCRIPTION
## What

Phase 3 of the [Projects native redesign](https://github.com/OpenCoven/coven-cave/blob/main/docs/projects-view-native-redesign.md) — **interaction model**. The Projects tab becomes keyboard-drivable like a native list, and its row actions stop hiding on touch.

### Keyboard navigation (reuses the shared WAI-ARIA `useRovingTabIndex`)
- **↑/↓ and Home/End** rove focus across the flattened list of project headers **and** their visible session rows.
- **→/←** expand/collapse a focused project header (tree-style disclosure).
- **Enter/Space** keep their per-row meaning (open / toggle-select).
- The shared hook gains a **universally-safe guard**: it no longer roves while focus is in an input/textarea/select/contentEditable, so inline rename/filter fields type normally. (Fixes a latent issue for *any* caller with editable content in its rove container.)

### Touch
- Drag + delete row actions stay visible on **coarse-pointer** devices (`[@media(pointer:coarse)]`), where there's no hover to reveal them.

## How
- Tag the header disclosure button and each session row with `data-proj-nav`; mount the roving keydown handler on the always-present `<main>` scroll container (so it attaches even though the list renders conditionally — `getItems` queries live DOM at keydown).
- Reuses the existing hook rather than reinventing nav; no new dependencies.

## Verification
- `pnpm typecheck` clean · `projects-view.test.ts` + `use-roving-tabindex.test.ts` extended and green · `check:tests-wired` green
- Live keyboard walkthrough via run-cave-app (screenshots in thread)

No data-model/API changes; no new icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)