### PR TITLE
feat(gantt): month band, weekend shading & today-column highlight

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -423,6 +423,22 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
     weeks.push({ left: i * DAY_W, width: Math.min(7, totalDays - i) * DAY_W, label: `Week ${isoWeek(addDays(rangeStart, i))}` });
   }
 
+  // Month band above the week ruler so "Week N" has calendar context.
+  const monthFmt = new Intl.DateTimeFormat("en-US", { month: "short", year: "numeric", timeZone: "UTC" });
+  const months: Array<{ key: number; left: number; width: number; label: string }> = [];
+  for (
+    let m = new Date(Date.UTC(rangeStart.getUTCFullYear(), rangeStart.getUTCMonth(), 1));
+    daysBetween(rangeStart, m) < totalDays;
+    m = new Date(Date.UTC(m.getUTCFullYear(), m.getUTCMonth() + 1, 1))
+  ) {
+    const next = new Date(Date.UTC(m.getUTCFullYear(), m.getUTCMonth() + 1, 1));
+    const startDays = Math.max(0, daysBetween(rangeStart, m));
+    const endDays = Math.min(totalDays, daysBetween(rangeStart, next));
+    if (endDays > startDays) {
+      months.push({ key: m.getTime(), left: startDays * DAY_W, width: (endDays - startDays) * DAY_W, label: monthFmt.format(m) });
+    }
+  }
+
   let todayX: number | null = null;
   if (todayMs !== null) {
     const now = new Date(todayMs);
@@ -430,6 +446,12 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
     const offset = daysBetween(rangeStart, todayUtc);
     if (offset >= 0 && offset <= totalDays) todayX = offset * DAY_W + DAY_W / 2;
   }
+
+  // Weekend shading + today-column tint are painted into the track background
+  // via CSS vars (avoids stacking issues). Shift the 2-day weekend band so it
+  // lands on Sat/Sun given the (arbitrary) range start.
+  const weekendShiftPx = ((6 - rangeStart.getUTCDay() + 7) % 7) * DAY_W;
+  const todayColLeftPx = todayX === null ? -9999 : todayX - DAY_W / 2;
 
   // Scroll the timeline so today sits in the middle of the viewport. Returns
   // whether it actually scrolled (used by the auto-center effect to know when
@@ -481,8 +503,16 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
         <button type="button" className="board-group-toggle-btn" onClick={scrollToToday} disabled={todayX === null} title="Scroll the timeline to today">Today</button>
       </div>
       <div className="board-gantt__scroll" ref={scrollRef}>
-        <div className="cg" style={{ ["--cg-day" as string]: `${DAY_W}px`, ["--cg-tl" as string]: `${timelineW}px` }}>
-          {/* Header: left column titles + week band */}
+        <div
+          className="cg"
+          style={{
+            ["--cg-day" as string]: `${DAY_W}px`,
+            ["--cg-tl" as string]: `${timelineW}px`,
+            ["--cg-weekend-shift" as string]: `${weekendShiftPx}px`,
+            ["--cg-today-x" as string]: `${todayColLeftPx}px`,
+          }}
+        >
+          {/* Header: left column titles + month band over the week ruler */}
           <div className="cg-head">
             <div className="cg-left cg-left--head">
               <span className="cg-c-task">Group / Task</span>
@@ -490,12 +520,21 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
               <span className="cg-c-date">End</span>
               <span className="cg-c-st">St</span>
             </div>
-            <div className="cg-weeks" style={{ width: `${timelineW}px` }}>
-              {weeks.map((w) => (
-                <span key={w.left} className="cg-week" style={{ left: `${w.left}px`, width: `${w.width}px` }}>
-                  {w.label}
-                </span>
-              ))}
+            <div className="cg-headstack">
+              <div className="cg-months" style={{ width: `${timelineW}px` }}>
+                {months.map((m) => (
+                  <span key={m.key} className="cg-month" style={{ left: `${m.left}px`, width: `${m.width}px` }}>
+                    {m.label}
+                  </span>
+                ))}
+              </div>
+              <div className="cg-weeks" style={{ width: `${timelineW}px` }}>
+                {weeks.map((w) => (
+                  <span key={w.left} className="cg-week" style={{ left: `${w.left}px`, width: `${w.width}px` }}>
+                    {w.label}
+                  </span>
+                ))}
+              </div>
             </div>
           </div>
 

--- a/src/components/board-schedule-window.test.ts
+++ b/src/components/board-schedule-window.test.ts
@@ -141,4 +141,19 @@ assert.match(gantt, /g\.rows\.filter\(\(r\) => !hiddenCats\.has\(r\.category\)\)
 assert.match(gantt, /cg-filter-chip\$\{off \? " cg-filter-chip--off" : ""\}/, "chips show an off state");
 assert.match(styles, /\.cg-filter-chip/, "filter chips are styled");
 
+// Timeline readability: a month band over the week ruler + weekend shading and
+// a today-column tint painted into the track background.
+assert.match(gantt, /const months: Array<\{ key: number; left: number; width: number; label: string \}>/, "a month band is computed across the range");
+assert.match(gantt, /month: "short", year: "numeric"/, "month labels include the year");
+assert.match(gantt, /<div className="cg-months"/, "the header renders a month band");
+assert.match(gantt, /className="cg-month"/, "month segments render");
+assert.match(gantt, /const weekendShiftPx = \(\(6 - rangeStart\.getUTCDay\(\) \+ 7\) % 7\) \* DAY_W/, "the weekend band is shifted to land on Sat/Sun");
+assert.match(gantt, /const todayColLeftPx = todayX === null \? -9999 : todayX - DAY_W \/ 2/, "the today column resolves to its left edge (off-screen when out of range)");
+assert.match(gantt, /"--cg-weekend-shift" as string\]: `\$\{weekendShiftPx\}px`/, "weekend shift feeds the track via a CSS var");
+assert.match(gantt, /"--cg-today-x" as string\]: `\$\{todayColLeftPx\}px`/, "today column feeds the track via a CSS var");
+assert.match(styles, /\.cg-headstack/, "the header stacks the month band over the week ruler");
+assert.match(styles, /\.cg-month \{/, "month segments are styled");
+assert.match(styles, /var\(--cg-weekend-shift, 0px\) 0/, "weekend shading is offset by the CSS var");
+assert.match(styles, /var\(--cg-today-x, -9999px\)/, "the today column tint reads the CSS var");
+
 console.log("board-schedule-window.test.ts: ok");

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1719,7 +1719,7 @@
 /* header */
 .cg-head {
   position: sticky; top: 0; z-index: 5;
-  display: flex; align-items: stretch; height: 30px;
+  display: flex; align-items: stretch;
   background: var(--bg-raised);
   border-bottom: 1px solid var(--border-strong);
 }
@@ -1727,7 +1727,16 @@
   z-index: 6; background: var(--bg-raised);
   font-size: 10px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; color: var(--text-muted);
 }
-.cg-weeks { position: relative; height: 30px; flex: 0 0 auto; }
+/* stack the month band over the week ruler in the timeline side of the header */
+.cg-headstack { display: flex; flex-direction: column; flex: 0 0 auto; }
+.cg-months { position: relative; height: 16px; flex: 0 0 auto; border-bottom: 1px solid var(--border-hairline); }
+.cg-month {
+  position: absolute; top: 0; bottom: 0;
+  display: flex; align-items: center; padding-left: 7px;
+  font-size: 10px; font-weight: 700; color: var(--text-primary);
+  border-left: 1px solid var(--border-strong); white-space: nowrap; overflow: hidden;
+}
+.cg-weeks { position: relative; height: 28px; flex: 0 0 auto; }
 .cg-week {
   position: absolute; top: 0; bottom: 0;
   display: flex; align-items: center; padding-left: 7px;
@@ -1742,10 +1751,24 @@
 .cg-track, .cg-grouptl {
   position: relative; height: var(--cg-row-h); flex: 0 0 auto;
   background:
+    /* today column tint (off-screen when there's no today in range) */
+    linear-gradient(to right,
+      transparent var(--cg-today-x, -9999px),
+      color-mix(in oklch, var(--accent-presence) 12%, transparent) var(--cg-today-x, -9999px),
+      color-mix(in oklch, var(--accent-presence) 12%, transparent) calc(var(--cg-today-x, -9999px) + var(--cg-day)),
+      transparent calc(var(--cg-today-x, -9999px) + var(--cg-day))),
+    /* weekend shading: 2 shaded days every 7, shifted so they land on Sat/Sun */
+    repeating-linear-gradient(to right,
+      color-mix(in oklch, var(--text-muted) 9%, transparent) 0,
+      color-mix(in oklch, var(--text-muted) 9%, transparent) calc(var(--cg-day) * 2),
+      transparent calc(var(--cg-day) * 2), transparent calc(var(--cg-day) * 7)),
+    /* day (light) + week (strong) gridlines */
     repeating-linear-gradient(to right, transparent 0, transparent calc(var(--cg-day) - 1px),
       color-mix(in oklch, var(--border-hairline) 55%, transparent) calc(var(--cg-day) - 1px), color-mix(in oklch, var(--border-hairline) 55%, transparent) var(--cg-day)),
     repeating-linear-gradient(to right, transparent 0, transparent calc(var(--cg-day) * 7 - 1px),
       var(--border-strong) calc(var(--cg-day) * 7 - 1px), var(--border-strong) calc(var(--cg-day) * 7));
+  background-position: 0 0, var(--cg-weekend-shift, 0px) 0, 0 0, 0 0;
+  background-repeat: no-repeat, repeat, repeat, repeat;
 }
 
 /* group header row */


### PR DESCRIPTION
Two timeline-readability wins (from the UX backlog):

## 1. Month band over the week ruler
The header labelled every 7 days `Week N` with **no month/year** — context-free on anything longer than a few weeks. Now a month band (e.g. **"Jun 2026"**) sits above the week ruler, segmented on real month boundaries, at every zoom.

## 2. Weekend shading + today-column highlight
- **Weekends** get a subtle shade (a 2-day band repeated every 7 days, shifted so it lands on Sat/Sun given the timeline's arbitrary start day).
- The **current day** gets a faint accent column behind the existing TODAY line, so the eye lands on "now".

Both are painted into the `.cg-track` **background via CSS vars** (`--cg-weekend-shift`, `--cg-today-x`) — no extra DOM nodes, no stacking issues.

## Verification
- `pnpm typecheck` clean; `app` suite → **379 files pass** (new assertions in `board-schedule-window.test.ts`).
- Browser-driven on a live Gantt: month band reads "Jun 2026 / Jul 2026"; weekend bands + today column render as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)