### PR TITLE
fix(familiar-studio): stop truncating the section-tab labels (Windows)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5964,7 +5964,7 @@ a.mobile-handoff__link:hover {
   height: 100dvh;
   width: min(496px, 92vw);
   display: grid;
-  grid-template-columns: 72px 1fr;
+  grid-template-columns: max-content 1fr;
   background: var(--bg-base);
   border-left: 1px solid var(--border-hairline);
   box-shadow: -12px 0 40px color-mix(in oklch, var(--text-primary) 16%, transparent);
@@ -5978,6 +5978,7 @@ a.mobile-handoff__link:hover {
 @media (prefers-reduced-motion: reduce) {
   .familiar-studio__drawer { animation: none; }
 }
+.familiar-studio__drawer--empty { grid-template-columns: 1fr; }
 .familiar-studio__main { display: grid; grid-template-rows: auto 1fr auto; min-height: 0; }
 .familiar-studio__header { display: flex; align-items: center; gap: var(--space-3); padding: var(--space-4) var(--space-5); border-bottom: 1px solid var(--border-hairline); }
 .familiar-studio__heading { display: flex; flex-direction: column; gap: 1px; min-width: 0; flex: 1; }


### PR DESCRIPTION
## Problem

In the Familiar Studio drawer, the left section-tab labels render truncated — **"Ide…", "Lo…", "Life…", "Me…", "Con…"** instead of Identity / Look / Lifecycle / Memory / Contract. Reported by a Windows user (screenshot); it's worse there because Windows' wider default system font hits the clip sooner.

## Cause

The drawer is a grid whose tab-rail column is a **fixed `72px`** (`globals.css` → `.familiar-studio__drawer { grid-template-columns: 72px 1fr }`). "Lifecycle" et al. don't fit in 72px, so the shared Tabs component's `truncate` on the label clips them.

## Fix (CSS only)

- Size the rail to its content: `grid-template-columns: max-content 1fr`. The column now fits the longest label on any platform font (no hard-coded px to second-guess), and `truncate` simply never triggers.
- The empty-state drawer (`--empty`, no tab rail) gets an explicit `grid-template-columns: 1fr` so the new content-sized column doesn't affect it.

Scoped entirely to `src/app/globals.css` — does **not** touch the shared `ui/tabs.tsx` (so no other vertical-tab surface changes) or the `familiar-studio*.tsx` files (another session has WIP there).

## Verification

CSS-only, no behavior change. To see it: pull `main` after merge — the dev server hot-reloads `globals.css` and the labels render in full. (I can attach a before/after screenshot on request.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)