### PR TITLE
Move Vault into familiar settings and expose chat debug controls

### DIFF
--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -127,8 +127,13 @@ assert.match(
 );
 assert.match(
   source,
-  /<HeaderDeleteButton key=\{sessionId\} onDelete=\{\(\) => void deleteChat\(\)\} deleting=\{deleting\} \/>/,
-  "the chat header mounts the standalone delete button (keyed on sessionId) wired to deleteChat",
+  /function HeaderDebugButton[\s\S]*?aria-label="Debug chat"[\s\S]*?<Icon name="ph:bug-bold"/,
+  "HeaderDebugButton renders a visible bug trigger for the debug panel",
+);
+assert.match(
+  source,
+  /<HeaderDebugButton onOpenDebug=\{openDebug\} \/>[\s\S]*?<HeaderDeleteButton key=\{sessionId\} onDelete=\{\(\) => void deleteChat\(\)\} deleting=\{deleting\} \/>/,
+  "the chat header mounts the visible debug bug immediately before the standalone delete button",
 );
 // The overflow (kebab) menu no longer offers delete — it's header-only.
 assert.doesNotMatch(

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -295,8 +295,18 @@ assert.match(
 // The three row action buttons (pin/archive/delete) must be uniform squares.
 {
   const squares = source.match(/touch-always-visible inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md/g) ?? [];
-  assert.equal(squares.length, 3, "pin/archive/delete must be uniform h-6 w-6 square icon buttons");
+  assert.equal(squares.length, 4, "pin/archive/debug/delete must be uniform h-6 w-6 square icon buttons");
 }
+assert.match(
+  source,
+  /aria-label=\{`Debug chat \$\{rowName\}`\}[\s\S]*?<Icon name="ph:bug-bold"/,
+  "Chat rows should expose a bug-icon Debug action next to delete",
+);
+assert.match(
+  source,
+  /window\.dispatchEvent\(new CustomEvent\("cave:debug-open"\)\)/,
+  "Chat row Debug action should reuse the existing debug panel event bridge",
+);
 assert.doesNotMatch(
   source,
   /touch-always-visible shrink-0 rounded border border-\[var\(--border-hairline\)\] px-1\.5 py-0\.5/,

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -536,6 +536,17 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
       return pruned;
     });
   }
+  // ── Row actions ──────────────────────────────────────────────────────────
+
+  const debugSession = (e: React.MouseEvent, session: SessionRow) => {
+    e.stopPropagation();
+    setActiveId(session.id);
+    onOpen(session.id, session.familiarId);
+    window.requestAnimationFrame(() => {
+      window.dispatchEvent(new CustomEvent("cave:debug-open"));
+    });
+  };
+
   // ── Delete (two-step confirm) ────────────────────────────────────────────
 
   const deleteSession = async (e: React.MouseEvent, sessionId: string) => {
@@ -1233,7 +1244,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                               </button>
                             </span>
                           ) : (
-                            /* Row actions — pin (Cave-local), archive (PATCH), delete.
+                            /* Row actions — pin (Cave-local), archive (PATCH), debug, delete.
                                Keyboard Enter on a button must not bubble into the
                                row's open handler. */
                             <span
@@ -1264,6 +1275,15 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                                 className="touch-always-visible inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-[var(--border-hairline)] text-[var(--text-muted)] opacity-0 transition-all hover:border-[var(--border-strong)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover:opacity-100 disabled:opacity-40"
                               >
                                 <Icon name={s.archived_at ? "ph:arrow-counter-clockwise" : "ph:archive"} width={12} aria-hidden />
+                              </button>
+                              <button
+                                type="button"
+                                onClick={(e) => debugSession(e, s)}
+                                title="Debug chat"
+                                aria-label={`Debug chat ${rowName}`}
+                                className="touch-always-visible inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-[var(--border-hairline)] text-[var(--text-muted)] opacity-0 transition-all hover:border-[var(--border-strong)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover:opacity-100"
+                              >
+                                <Icon name="ph:bug-bold" width={12} aria-hidden />
                               </button>
                               <button
                                 type="button"

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -747,6 +747,20 @@ function SessionOverflowMenu({
   );
 }
 
+function HeaderDebugButton({ onOpenDebug }: { onOpenDebug: () => void }) {
+  return (
+    <button
+      type="button"
+      className="focus-ring cave-chat-icon-button"
+      aria-label="Debug chat"
+      title="Debug chat"
+      onClick={onOpenDebug}
+    >
+      <Icon name="ph:bug-bold" width={15} aria-hidden />
+    </button>
+  );
+}
+
 /** Standalone delete control for the chat header — a one-click trash button that
  *  opens a small confirm popover before committing. Mirrors the overflow menu's
  *  two-step guard, but surfaced at the top of the session for quick access. Uses
@@ -3362,6 +3376,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 onPrev={findPrev}
               />
             ) : null}
+            {sessionId && (
+              <HeaderDebugButton onOpenDebug={openDebug} />
+            )}
             {sessionId && (
               <HeaderDeleteButton key={sessionId} onDelete={() => void deleteChat()} deleting={deleting} />
             )}

--- a/src/components/familiar-studio-inline.test.ts
+++ b/src/components/familiar-studio-inline.test.ts
@@ -25,12 +25,14 @@ assert.match(
 assert.doesNotMatch(source, /familiar-studio__scrim/, "Inline panel must not render the modal scrim");
 assert.doesNotMatch(source, /familiar-studio__drawer/, "Inline panel must not render the fixed drawer root");
 
-// All five studio tabs are wired with the same prop shapes the drawer uses.
+// Familiar-specific studio tabs are wired with the same prop shapes the drawer uses.
 for (const tab of ["Identity", "Look", "Brain", "Lifecycle", "Memory"]) {
   assert.match(source, new RegExp(`FamiliarStudio${tab}Tab`), `Wires the ${tab} tab body`);
 }
 assert.match(source, /<FamiliarStudioLookTab familiar=\{familiar\} allFamiliars=\{resolved\} \/>/, "Look tab gets all resolved familiars for group colors");
 assert.match(source, /<FamiliarStudioMemoryTab familiar=\{familiar\} allFamiliars=\{familiars\} \/>/, "Memory tab gets the raw roster");
+assert.match(source, /VaultPanel/, "Wires the Vault settings panel inside familiar settings");
+assert.match(source, /id: "vault", label: "Vault"/, "Exposes Vault as a familiar settings tab");
 
 // Detail pane is never empty on entry: auto-selects the first familiar and
 // recovers when the current selection disappears.

--- a/src/components/familiar-studio-inline.tsx
+++ b/src/components/familiar-studio-inline.tsx
@@ -11,6 +11,7 @@ import { FamiliarStudioLookTab } from "./familiar-studio-look-tab";
 import { FamiliarStudioBrainTab } from "./familiar-studio-brain-tab";
 import { FamiliarStudioLifecycleTab } from "./familiar-studio-lifecycle-tab";
 import { FamiliarStudioMemoryTab } from "./familiar-studio-memory-tab";
+import { VaultPanel } from "./vault-panel";
 import type { Familiar } from "@/lib/types";
 
 type Props = {
@@ -26,13 +27,14 @@ const TABS: Array<{ id: FamiliarStudioTab; label: string; icon: IconName }> = [
   { id: "brain", label: "Brain", icon: "ph:brain" },
   { id: "lifecycle", label: "Lifecycle", icon: "ph:arrows-clockwise" },
   { id: "memory", label: "Memory", icon: "ph:archive" },
+  { id: "vault", label: "Vault", icon: "ph:vault" },
 ];
 
 /**
  * Inline, non-modal Familiar Studio for the Settings → Familiars section.
  *
  * Unlike the global `<FamiliarStudio>` drawer (mounted in the Workspace), this
- * is a master-detail panel: a familiar dropdown above the full five-tab studio
+ * is a master-detail panel: a familiar dropdown above the studio settings tabs
  * for the selected familiar. The Settings route mounts the
  * `FamiliarStudioProvider` but never the drawer, so the per-card "Edit" buttons
  * used to set context state that nothing rendered — this surface is what makes
@@ -138,6 +140,7 @@ export function FamiliarStudioInlinePanel({ familiars, resolved }: Props) {
               {activeTab === "memory" ? (
                 <FamiliarStudioMemoryTab familiar={familiar} allFamiliars={familiars} />
               ) : null}
+              {activeTab === "vault" ? <VaultPanel /> : null}
             </div>
 
             <footer className="familiar-studio__footer">

--- a/src/components/familiar-studio.tsx
+++ b/src/components/familiar-studio.tsx
@@ -51,7 +51,7 @@ export function FamiliarStudio({ familiars }: Props) {
   );
   const drawerOpen = Boolean(activeFamiliarId || listView);
   const disableNonLifecycle = listView && !familiar;
-  const drawerActiveTab = activeTab === "brain" ? "identity" : activeTab;
+  const drawerActiveTab = activeTab === "brain" || activeTab === "vault" ? "identity" : activeTab;
   const openBrainStudio = useCallback(() => {
     setActiveTab("brain");
     window.location.assign("/settings");

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -6,7 +6,6 @@ import type { Familiar } from "@/lib/types";
 import type { InboxItem } from "@/lib/cave-inbox";
 import { SyntaxBlock, MarkdownBlock } from "@/components/message-bubble";
 import { EvalLoopPanel } from "@/components/eval-loop-panel";
-import { VaultPanel } from "@/components/vault-panel";
 import { SnoozeMenu } from "@/components/snooze-menu";
 import { Icon, type IconName } from "@/lib/icon";
 import { SkeletonRows } from "@/components/ui/skeleton";
@@ -18,7 +17,7 @@ import type { AdapterReport } from "@/lib/harness-adapters";
 import { scopeMemoryFilesToFamiliar } from "@/lib/memory-file-scope";
 import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 
-type Tab = "memory" | "familiar" | "inbox" | "vault";
+type Tab = "memory" | "familiar" | "inbox";
 
 
 
@@ -62,10 +61,9 @@ const TAB_LABEL: Record<Tab, string> = {
   memory: "Memory",
   familiar: "Familiar",
   inbox: "Automations",
-  vault: "Vault",
 };
 
-const INSPECTOR_TABS: Tab[] = ["memory", "familiar", "inbox", "vault"];
+const INSPECTOR_TABS: Tab[] = ["memory", "familiar", "inbox"];
 
 function InspectorEmpty({
   icon,
@@ -196,7 +194,6 @@ export function InspectorPane({
             onInboxItemChanged={onInboxItemChanged}
           />
         ) : null}
-        {tab === "vault" ? <VaultPanel /> : null}
       </div>
     </aside>
   );

--- a/src/lib/familiar-studio-context.tsx
+++ b/src/lib/familiar-studio-context.tsx
@@ -10,7 +10,7 @@ import {
   type ReactNode,
 } from "react";
 
-export type FamiliarStudioTab = "identity" | "look" | "brain" | "lifecycle" | "memory" | "contract";
+export type FamiliarStudioTab = "identity" | "look" | "brain" | "lifecycle" | "memory" | "contract" | "vault";
 
 const TAB_STORAGE_KEY = "cave:familiar-studio-tab:v1";
 const DEFAULT_TAB: FamiliarStudioTab = "identity";
@@ -44,7 +44,8 @@ export function FamiliarStudioProvider({ children }: { children: ReactNode }) {
       stored === "brain" ||
       stored === "lifecycle" ||
       stored === "memory" ||
-      stored === "contract"
+      stored === "contract" ||
+      stored === "vault"
     ) {
       setActiveTabState(stored);
     }


### PR DESCRIPTION
## Summary
- move Secret Vault from the inspector rail into Settings -> Familiars as a Vault tab
- add visible bug/debug controls beside chat delete controls in the active chat header and chat list rows
- keep the existing cave:debug-open bridge for the debug panel

## Verification
- node --experimental-strip-types src/components/familiar-studio-inline.test.ts
- node --experimental-strip-types src/components/chat-header-row.test.ts
- node --experimental-strip-types src/components/chat-list-delete.test.ts
- pnpm exec tsc --noEmit --pretty false
- pnpm check:tests-wired
- git diff --check