### PR TITLE
feat(projects): right-click context menus (native redesign phase 3b)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -354,6 +354,7 @@ export const SUITES = {
     "src/lib/recent-colors.test.ts",
     "src/components/ui/color-picker.test.ts",
     "src/components/ui/popover.test.ts",
+    "src/components/ui/context-menu.test.ts",
     "src/components/ui/modal.test.ts",
     "src/components/ui/relative-time.test.ts",
     "src/lib/workflow-source-bundle.test.ts",

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -328,4 +328,31 @@ assert.match(
   "row actions stay visible on touch/coarse-pointer devices",
 );
 
+// Phase 3b — right-click context menus on project headers and session rows,
+// built on the shared ContextMenu/Popover primitives.
+assert.match(
+  projectsView,
+  /import \{ ContextMenu, openContextMenuAt, type ContextMenuState \} from "@\/components\/ui\/context-menu"/,
+  "uses the shared ContextMenu primitive",
+);
+assert.match(
+  projectsView,
+  /import \{ PopoverItem, PopoverSeparator \} from "@\/components\/ui\/popover"/,
+  "menu items use the shared Popover item/separator",
+);
+// Two onContextMenu triggers: the project header and each session row.
+assert.ok(
+  (projectsView.match(/onContextMenu=\{openContextMenuAt\(setMenu\)\}/g) ?? []).length >= 2,
+  "both the project header and session rows open a context menu at the cursor",
+);
+assert.match(projectsView, /Actions for \$\{project\.name\}/, "the project header has a context menu");
+assert.match(projectsView, /onSelect=\{\(\) => \{ setMenu\(null\); openTerminalHere\(\); \}\}/, "the menu opens a terminal in the project cwd");
+assert.match(projectsView, /Delete project…/, "project menu offers delete (routes through the inline confirm)");
+assert.match(projectsView, /setExpanded\(true\); setConfirmDelete\(true\)/, "menu delete expands the card and shows the two-step confirm");
+assert.match(projectsView, /Actions for \$\{title\}/, "each session row has a context menu");
+assert.match(projectsView, /Delete chat…/, "session menu offers delete (routes through the inline confirm)");
+// The header actions stay visible while a delete confirm is pending, so a
+// menu-triggered delete's Cancel/Delete buttons aren't hidden behind hover.
+assert.match(projectsView, /confirmDelete\s*\?\s*"opacity-100"/, "the action cluster stays visible while confirming a delete");
+
 console.log("projects-view.test.ts: ok");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -28,6 +28,8 @@ import type { ProjectsDensity } from "@/lib/projects/projects-ui-state";
 import { sessionGlyph, glyphToneClass, stripTaskPrefix } from "@/lib/projects/session-glyph";
 import { projectStats } from "@/lib/projects/project-stats";
 import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
+import { ContextMenu, openContextMenuAt, type ContextMenuState } from "@/components/ui/context-menu";
+import { PopoverItem, PopoverSeparator } from "@/components/ui/popover";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
@@ -121,6 +123,7 @@ function ProjectChatRow({
   const hasDiff = !!diff && (diff.additions > 0 || diff.deletions > 0);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [menu, setMenu] = useState<ContextMenuState>(null);
   const activate = () => (selectMode ? onToggleSelect(session.id) : onOpen());
   return (
     <li ref={setNodeRef} style={style} data-dragging={isDragging ? "true" : undefined} className="group/pc relative">
@@ -129,6 +132,7 @@ function ProjectChatRow({
         aria-checked={selectMode ? selected : undefined}
         tabIndex={0}
         data-proj-nav
+        onContextMenu={openContextMenuAt(setMenu)}
         onClick={activate}
         onKeyDown={(e) => {
           // ARIA button/checkbox pattern: Enter and Space both activate.
@@ -246,6 +250,15 @@ function ProjectChatRow({
           </button>
         )}
       </div>
+      <ContextMenu state={menu} onClose={() => setMenu(null)} ariaLabel={`Actions for ${title}`}>
+        <PopoverItem icon="ph:chat-circle-dots-bold" onSelect={() => { setMenu(null); onOpen(); }}>
+          Open chat
+        </PopoverItem>
+        <PopoverSeparator />
+        <PopoverItem icon="ph:trash-bold" danger onSelect={() => { setMenu(null); setConfirmDelete(true); }}>
+          Delete chat…
+        </PopoverItem>
+      </ContextMenu>
     </li>
   );
 }
@@ -387,6 +400,12 @@ function ProjectRow({
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [busy, setBusy] = useState<"name" | "root" | "delete" | null>(null);
   const [copiedRoot, setCopiedRoot] = useState(false);
+  const [menu, setMenu] = useState<ContextMenuState>(null);
+
+  const openTerminalHere = () => {
+    window.dispatchEvent(new CustomEvent("cave:terminal-open", { detail: { projectRoot: project.root } }));
+    window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "terminal" } }));
+  };
 
   const copyRoot = async () => {
     try {
@@ -447,7 +466,7 @@ function ProjectRow({
           : "hover:bg-[var(--bg-raised)]/40",
       ].join(" ")}
     >
-      <div className="flex min-w-0 items-center gap-2">
+      <div className="flex min-w-0 items-center gap-2" onContextMenu={openContextMenuAt(setMenu)}>
         <button
           type="button"
           data-proj-nav
@@ -552,7 +571,13 @@ function ProjectRow({
           </span>
         ) : null}
 
-        <div className="flex shrink-0 items-center gap-1 opacity-100 transition-opacity motion-reduce:transition-none sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100">
+        <div
+          className={`flex shrink-0 items-center gap-1 transition-opacity motion-reduce:transition-none ${
+            confirmDelete
+              ? "opacity-100"
+              : "opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
+          }`}
+        >
           <button
             type="button"
             onClick={() => onNewChat?.(project.root)}
@@ -564,18 +589,10 @@ function ProjectRow({
           </button>
           <button
             type="button"
-            onClick={() => {
-              // Launch a terminal in this project's cwd, then jump to the
-              // Terminal surface. The always-mounted terminal instance creates
-              // the session (spawning the shell in project.root); cave:navigate-mode
-              // brings the Terminal surface to the foreground.
-              window.dispatchEvent(
-                new CustomEvent("cave:terminal-open", { detail: { projectRoot: project.root } }),
-              );
-              window.dispatchEvent(
-                new CustomEvent("cave:navigate-mode", { detail: { mode: "terminal" } }),
-              );
-            }}
+            // Launch a terminal in this project's cwd, then jump to the Terminal
+            // surface (the always-mounted terminal instance spawns the shell in
+            // project.root; cave:navigate-mode brings the surface to the foreground).
+            onClick={openTerminalHere}
             className="focus-ring flex h-7 w-7 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
             title="Open terminal"
             aria-label={`Open terminal in ${project.name}`}
@@ -756,6 +773,24 @@ function ProjectRow({
       )}
         </>
       ) : null}
+      <ContextMenu state={menu} onClose={() => setMenu(null)} ariaLabel={`Actions for ${project.name}`}>
+        <PopoverItem icon="ph:chat-circle-dots-bold" onSelect={() => { setMenu(null); onNewChat?.(project.root); }}>
+          New session
+        </PopoverItem>
+        <PopoverItem icon="ph:terminal-window-bold" onSelect={() => { setMenu(null); openTerminalHere(); }}>
+          Open terminal
+        </PopoverItem>
+        <PopoverItem icon="ph:pencil-simple-bold" onSelect={() => { setMenu(null); setNameDraft(project.name); setEditingName(true); }}>
+          Rename
+        </PopoverItem>
+        <PopoverItem icon={copiedRoot ? "ph:check" : "ph:copy"} onSelect={() => { setMenu(null); void copyRoot(); }}>
+          Copy path
+        </PopoverItem>
+        <PopoverSeparator />
+        <PopoverItem icon="ph:trash-bold" danger onSelect={() => { setMenu(null); setExpanded(true); setConfirmDelete(true); }}>
+          Delete project…
+        </PopoverItem>
+      </ContextMenu>
     </article>
   );
 }

--- a/src/components/ui/context-menu.test.ts
+++ b/src/components/ui/context-menu.test.ts
@@ -1,0 +1,26 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./context-menu.tsx", import.meta.url), "utf8");
+
+// Built on the shared Popover (inherits Escape / outside-click / focus-return).
+assert.match(src, /from "@\/components\/ui\/popover"/, "context menu reuses the Popover primitive");
+assert.match(src, /export function ContextMenu/, "exports ContextMenu");
+assert.match(src, /export function openContextMenuAt/, "exports the onContextMenu helper");
+
+// State is the cursor position or null when closed; open = state !== null.
+assert.match(src, /export type ContextMenuState = \{ x: number; y: number \} \| null/, "state is cursor xy or null");
+assert.match(src, /open=\{state !== null\}/, "menu is open when state is set");
+
+// Anchors to a 0-size element pinned at the cursor so it opens where clicked.
+assert.match(src, /position: "fixed", left: state\?\.x[\s\S]{0,60}width: 0, height: 0/, "anchors a 0-size element at the cursor");
+
+// The helper preventDefaults the native menu and records the click position.
+assert.match(src, /e\.preventDefault\(\)/, "suppresses the browser's native context menu");
+assert.match(src, /set\(\{ x: e\.clientX, y: e\.clientY \}\)/, "reports the cursor position");
+
+// The content is a role=menu container (items are role=menuitem via PopoverItem).
+assert.match(src, /role="menu"/, "menu content has role=menu");
+
+console.log("context-menu.test.ts OK");

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useRef, type ReactNode } from "react";
+
+import { Popover } from "@/components/ui/popover";
+
+/** Cursor position for an open context menu, or null when closed. */
+export type ContextMenuState = { x: number; y: number } | null;
+
+/**
+ * Right-click context menu built on the shared Popover. Instead of anchoring to
+ * a trigger element, it anchors to a 0-size element pinned at the cursor
+ * position, so the menu opens where the user clicked. Inherits the Popover's
+ * Escape / outside-click / viewport-clamp / focus-return behavior.
+ *
+ * Usage: keep a ContextMenuState, set it from `onContextMenu` (preventDefault +
+ * `{ x: e.clientX, y: e.clientY }`), and render <ContextMenu> with PopoverItem
+ * children.
+ */
+export function ContextMenu({
+  state,
+  onClose,
+  ariaLabel,
+  children,
+}: {
+  state: ContextMenuState;
+  onClose: () => void;
+  ariaLabel: string;
+  children: ReactNode;
+}) {
+  const anchorRef = useRef<HTMLSpanElement>(null);
+  return (
+    <>
+      <span
+        ref={anchorRef}
+        aria-hidden
+        style={{ position: "fixed", left: state?.x ?? 0, top: state?.y ?? 0, width: 0, height: 0 }}
+      />
+      <Popover
+        open={state !== null}
+        onOpenChange={(next) => {
+          if (!next) onClose();
+        }}
+        anchorRef={anchorRef}
+        placement="bottom-start"
+        ariaLabel={ariaLabel}
+      >
+        <div role="menu" className="ui-popover-body">
+          {children}
+        </div>
+      </Popover>
+    </>
+  );
+}
+
+/**
+ * Build an `onContextMenu` handler that opens the menu at the cursor. Returns a
+ * handler that preventDefaults the native menu and reports the click position.
+ */
+export function openContextMenuAt(set: (state: ContextMenuState) => void) {
+  return (e: { preventDefault: () => void; clientX: number; clientY: number }) => {
+    e.preventDefault();
+    set({ x: e.clientX, y: e.clientY });
+  };
+}


### PR DESCRIPTION
## What

Phase 3b of the [Projects native redesign](https://github.com/OpenCoven/coven-cave/blob/main/docs/projects-view-native-redesign.md) — the missing native affordance. **Right-clicking** a project header or a session row opens a context menu at the cursor.

- **Project header menu:** New session · Open terminal · Rename · Copy path · **Delete project…**
- **Session row menu:** Open chat · **Delete chat…**

Deletes route through the existing two-step confirm (the menu sets the confirm state rather than deleting outright).

## How
- New reusable **`src/components/ui/context-menu.tsx`** built on the shared `Popover` — inherits Escape / outside-click / viewport-clamp / focus-return for free. It anchors a 0-size element at the cursor (the popover portal is `position:fixed`, so absolute coords are viewport coords), and `openContextMenuAt()` wires `onContextMenu` (preventDefault + `{x,y}`).
- Menu items reuse existing handlers; extracted `openTerminalHere()` shared by the toolbar button and the menu.
- The header action cluster now stays visible while a delete confirm is pending, so a menu-triggered delete's Cancel/Delete aren't hidden behind hover.

## Verification
- `pnpm typecheck` clean · new `context-menu.test.ts` + extended `projects-view.test.ts` green · `check:tests-wired` green (503 wired)
- Live verification via run-cave-app (right-click → menu screenshots in thread)

No data-model/API changes; icons reused from the existing allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)