### PR TITLE
fix(familiar-studio): clarify inherited runtimes

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -411,6 +411,7 @@ export const SUITES = {
     "scripts/git-hooks-pre-commit.test.mjs",
     "src/lib/coven-paths.test.ts",
     "src/app/api/api-contracts.test.ts",
+    "src/app/api/familiars/route.test.ts",
     "src/app/api/familiars/avatar-route.test.ts",
     "src/app/api/familiars/[id]/notes/route.test.ts",
     "src/app/api/chat/model-state/route.test.ts",

--- a/src/app/api/familiars/route.test.ts
+++ b/src/app/api/familiars/route.test.ts
@@ -1,0 +1,23 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
+
+assert.match(
+  source,
+  /const configEntry = config\.familiars\[f\.id\] \?\? \{\}/,
+  "Familiars API should inspect the raw familiar config entry before resolving defaults",
+);
+assert.match(
+  source,
+  /defaultHarness: config\.defaults\.harness/,
+  "Familiars API should expose the workspace default harness for UI copy",
+);
+assert.match(
+  source,
+  /harnessOverride: configEntry\.harness \?\? null/,
+  "Familiars API should expose whether the familiar has an explicit harness override",
+);
+
+console.log("familiars route.test.ts: ok");

--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -40,6 +40,7 @@ export async function GET() {
   // WebViews. Familiars with no on-disk avatar omit it and render the glyph.
   const familiars = await Promise.all(
     (res.data ?? []).map(async (f) => {
+      const configEntry = config.familiars[f.id] ?? {};
       const binding = bindingFor(config, f.id);
       const avatar = await resolveFamiliarAvatar(f.id);
       return {
@@ -50,6 +51,8 @@ export async function GET() {
         description: binding.description ?? f.description,
         color: binding.color,
         harness: binding.harness,
+        defaultHarness: config.defaults.harness,
+        harnessOverride: configEntry.harness ?? null,
         model: binding.model,
         note: binding.note,
         voiceProvider: binding.voiceProvider,

--- a/src/components/familiar-studio-brain-tab.test.ts
+++ b/src/components/familiar-studio-brain-tab.test.ts
@@ -39,6 +39,21 @@ assert.match(source, /\/api\/config/);
 assert.match(source, /method.*PATCH/);
 assert.match(
   source,
+  /defaultHarnessLabel/,
+  "Brain tab should name the inherited workspace default runtime",
+);
+assert.match(
+  source,
+  /Inherit workspace default: \{defaultHarnessLabel\}/,
+  "Default runtime copy should clarify that this familiar inherits the workspace default",
+);
+assert.match(
+  source,
+  /<optgroup label="Available runtimes">[\s\S]{0,240}harnesses\.map/,
+  "Other available runtimes should be grouped below the inherited default option",
+);
+assert.match(
+  source,
   /\/api\/capabilities\?harness=/,
   "Brain tab should fetch the daemon capabilities manifest for the selected harness",
 );

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -20,10 +20,16 @@ type CapabilitiesResponse = {
   error?: string;
 };
 
+function runtimeLabel(runtimeId: string | null | undefined, harnesses: HarnessReport[]): string {
+  if (!runtimeId) return "workspace default";
+  const fromHarnesses = harnesses.find((h) => h.id === runtimeId)?.label;
+  if (fromHarnesses) return fromHarnesses;
+  return runtimeId;
+}
 
 export function FamiliarStudioBrainTab({ familiar }: Props) {
   const [harnesses, setHarnesses] = useState<HarnessReport[]>([]);
-  const [draftHarness, setDraftHarness] = useState(familiar.harness ?? "");
+  const [draftHarness, setDraftHarness] = useState(familiar.harnessOverride ?? "");
   const [draftModel, setDraftModel] = useState(familiar.model ?? "");
   const [draftNote, setDraftNote] = useState(familiar.note ?? "");
   const [draftVoiceProvider, setDraftVoiceProvider] = useState(familiar.voiceProvider ?? "");
@@ -35,14 +41,14 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
   const [capsOpen, setCapsOpen] = useState(false);
 
   useEffect(() => {
-    setDraftHarness(familiar.harness ?? "");
+    setDraftHarness(familiar.harnessOverride ?? "");
     setDraftModel(familiar.model ?? "");
     setDraftNote(familiar.note ?? "");
     setDraftVoiceProvider(familiar.voiceProvider ?? "");
     setDraftVoiceModel(familiar.voiceModel ?? "");
     setDraftVoiceName(familiar.voiceName ?? "");
     setToast(null);
-  }, [familiar.id, familiar.harness, familiar.model, familiar.note, familiar.voiceProvider, familiar.voiceModel, familiar.voiceName]);
+  }, [familiar.id, familiar.harnessOverride, familiar.model, familiar.note, familiar.voiceProvider, familiar.voiceModel, familiar.voiceName]);
 
   useEffect(() => {
     let cancelled = false;
@@ -56,7 +62,9 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
     return () => { cancelled = true; };
   }, []);
 
-  const harnessId = draftHarness || familiar.harness || "";
+  const defaultHarnessId = familiar.defaultHarness ?? familiar.harness ?? "";
+  const defaultHarnessLabel = runtimeLabel(defaultHarnessId, harnesses);
+  const harnessId = draftHarness || defaultHarnessId;
 
   // Model parity: source the per-familiar model menu from the same runtime →
   // provider catalog the chat picker uses. allowCustom keeps the free-text
@@ -120,7 +128,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
         setToast(`Couldn't save: ${json.error ?? res.statusText}`);
         reportDaemonSyncFailure(`cave-config write: ${json.error ?? res.statusText}`);
         // Revert local draft to last-known value on failure.
-        if ("harness" in patch) setDraftHarness(familiar.harness ?? "");
+        if ("harness" in patch) setDraftHarness(familiar.harnessOverride ?? "");
         if ("model" in patch) setDraftModel(familiar.model ?? "");
         if ("note" in patch) setDraftNote(familiar.note ?? "");
         if ("voiceProvider" in patch) setDraftVoiceProvider(familiar.voiceProvider ?? "");
@@ -153,12 +161,14 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
                     }}
                     className="familiar-studio-brain__input"
                   >
-                    <option value="">— inherit default —</option>
-                    {harnesses.map((h) => (
-                      <option key={h.id} value={h.id}>
-                        {h.label}{h.installed ? "" : " (not installed)"}
-                      </option>
-                    ))}
+                    <option value="">Inherit workspace default: {defaultHarnessLabel}</option>
+                    <optgroup label="Available runtimes">
+                      {harnesses.map((h) => (
+                        <option key={h.id} value={h.id}>
+                          {h.label}{h.installed ? "" : " (not installed)"}
+                        </option>
+                      ))}
+                    </optgroup>
                   </select>
                 </div>
               </label>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,6 +29,8 @@ export type Familiar = {
   avatarUrl?: string;
   // CovenCave-side enrichment from cave-config.json
   harness?: string;
+  defaultHarness?: string;
+  harnessOverride?: string | null;
   model?: string;
   note?: string;
   voiceProvider?: string;


### PR DESCRIPTION
## Summary
- Expose familiar default/override runtime fields from `/api/familiars`.
- Show `Inherit workspace default: <runtime>` in the Brain tab runtime selector.
- Group concrete selectable runtimes under `Available runtimes`.

## Test Plan
- `node --experimental-strip-types src/components/familiar-studio-brain-tab.test.ts`
- `node --experimental-strip-types src/app/api/familiars/route.test.ts`
- `pnpm check:tests-wired`
- `pnpm typecheck`
- `git diff --check`
