### PR TITLE
feat(ios): chat message timestamps + editable task title & dates

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -142,6 +142,24 @@ struct CaveClient {
         return try await patchTask(cardId: cardId, payload: payload)
     }
 
+    /// PATCH a task's title.
+    @discardableResult
+    func updateTaskTitle(cardId: String, title: String) async throws -> BoardCard {
+        let payload = try JSONSerialization.data(withJSONObject: ["title": title])
+        return try await patchTask(cardId: cardId, payload: payload)
+    }
+
+    /// PATCH a task's start/due dates (date-only "yyyy-MM-dd" strings). Both keys
+    /// are always sent so passing nil clears that date.
+    @discardableResult
+    func updateTaskDates(cardId: String, startDate: String?, endDate: String?) async throws -> BoardCard {
+        let payload = try JSONSerialization.data(withJSONObject: [
+            "startDate": startDate.map { $0 as Any } ?? NSNull(),
+            "endDate": endDate.map { $0 as Any } ?? NSNull(),
+        ])
+        return try await patchTask(cardId: cardId, payload: payload)
+    }
+
     /// `DELETE /api/board/{id}` — remove a task.
     func deleteTask(cardId: String) async throws {
         let req = try request("api/board/\(cardId)", method: "DELETE")

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -202,6 +202,37 @@ final class AppModel {
         }
     }
 
+    /// Optimistically rename a task; reconcile/revert like notes.
+    func setTaskTitle(_ card: BoardCard, _ title: String) async {
+        guard let client else { return }
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != card.title else { return }
+        let previous = tasks
+        applyTask(id: card.id) { $0.title = trimmed }
+        do {
+            let updated = try await client.updateTaskTitle(cardId: card.id, title: trimmed)
+            applyTask(id: card.id) { $0 = updated }
+        } catch {
+            tasks = previous
+            tasksError = error.localizedDescription
+        }
+    }
+
+    /// Optimistically set a task's start/due dates (date-only strings, nil to
+    /// clear); reconcile/revert.
+    func setTaskDates(_ card: BoardCard, start: String?, end: String?) async {
+        guard let client, start != card.startDate || end != card.endDate else { return }
+        let previous = tasks
+        applyTask(id: card.id) { $0.startDate = start; $0.endDate = end }
+        do {
+            let updated = try await client.updateTaskDates(cardId: card.id, startDate: start, endDate: end)
+            applyTask(id: card.id) { $0 = updated }
+        } catch {
+            tasks = previous
+            tasksError = error.localizedDescription
+        }
+    }
+
     /// Optimistically remove a task, then DELETE it. Reinserts on failure.
     func deleteTask(_ card: BoardCard) async {
         guard let client else { return }

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -20,6 +20,15 @@ struct MessageBubble: View {
 
     private var isUser: Bool { message.role == .user }
 
+    /// Compact send time under the bubble — time only for today, with an
+    /// abbreviated date for older messages.
+    private var timestampText: String {
+        if Calendar.current.isDateInToday(message.createdAt) {
+            return message.createdAt.formatted(date: .omitted, time: .shortened)
+        }
+        return message.createdAt.formatted(date: .abbreviated, time: .shortened)
+    }
+
     /// Long-press actions shared by the bubble and the system note: copy the
     /// text, optionally retry (regenerate), and delete.
     @ViewBuilder private var messageActions: some View {
@@ -124,6 +133,13 @@ struct MessageBubble: View {
                 if !parsed.visible.isEmpty || message.attachmentDataUrls.isEmpty {
                     bubble
                         .contextMenu { messageActions }
+                }
+
+                if !message.streaming {
+                    Text(timestampText)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .padding(isUser ? .trailing : .leading, 6)
                 }
 
                 if !isUser, isLast, !message.streaming, !parsed.suggestions.isEmpty {

--- a/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
@@ -10,6 +10,8 @@ struct TaskDetailView: View {
     @State private var notesReader: ResponseReaderItem?
     @State private var confirmingDelete = false
     @State private var editingNotes = false
+    @State private var renamingTitle = false
+    @State private var titleDraft = ""
 
     /// The current card from the store, so status/priority/step edits made here
     /// reflect immediately; falls back to the passed-in snapshot.
@@ -24,6 +26,7 @@ struct TaskDetailView: View {
                 chatCard
                 if live.hasSteps { stepsCard }
                 notesSection
+                scheduleCard
                 if !live.labelList.isEmpty { labelsRow }
                 metaCard
             }
@@ -53,6 +56,14 @@ struct TaskDetailView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: { Text(live.title) }
+        .alert("Rename task", isPresented: $renamingTitle) {
+            TextField("Title", text: $titleDraft)
+            Button("Save") {
+                let t = titleDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !t.isEmpty { Task { await app.setTaskTitle(live, t) } }
+            }
+            Button("Cancel", role: .cancel) {}
+        }
     }
 
     private var actionsMenu: some View {
@@ -134,9 +145,24 @@ struct TaskDetailView: View {
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text(live.title)
-                .font(.title2.bold())
-                .fixedSize(horizontal: false, vertical: true)
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text(live.title)
+                    .font(.title2.bold())
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Button {
+                    titleDraft = live.title
+                    renamingTitle = true
+                } label: {
+                    Image(systemName: "square.and.pencil")
+                        .font(.callout.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(7)
+                        .background(.thinMaterial, in: Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Rename task")
+            }
             HStack(spacing: 8) {
                 StatusPill(status: live.status)
                 priorityBadge
@@ -261,12 +287,61 @@ struct TaskDetailView: View {
         }
     }
 
+    // MARK: - Schedule (editable start / due dates)
+
+    /// Date-only ("yyyy-MM-dd") parser/formatter — board cards store schedule
+    /// dates this way (matching the web `<input type="date">`), so the datetime
+    /// `caveParseISO` can't read them.
+    private static let dateOnly: DateFormatter = {
+        let f = DateFormatter()
+        f.calendar = Calendar(identifier: .gregorian)
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+
+    private func parseDateOnly(_ s: String?) -> Date? { s.flatMap { Self.dateOnly.date(from: $0) } }
+    private func formatDateOnly(_ d: Date) -> String { Self.dateOnly.string(from: d) }
+
+    private var scheduleCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Schedule").font(.headline)
+            dateRow("Start", value: live.startDate) { await app.setTaskDates(live, start: $0, end: live.endDate) }
+            Divider()
+            dateRow("Due", value: live.endDate) { await app.setTaskDates(live, start: live.startDate, end: $0) }
+        }
+        .padding(16)
+        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    private func dateRow(_ label: String, value: String?,
+                        set: @escaping (String?) async -> Void) -> some View {
+        HStack {
+            Text(label).foregroundStyle(.secondary)
+            Spacer()
+            if let date = parseDateOnly(value) {
+                DatePicker("", selection: Binding(
+                    get: { date },
+                    set: { newValue in Task { await set(formatDateOnly(newValue)) } }
+                ), displayedComponents: .date)
+                .labelsHidden()
+                Button { Task { await set(nil) } } label: {
+                    Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear \(label) date")
+            } else {
+                Button("Add") { Task { await set(formatDateOnly(Date())) } }
+                    .font(.callout)
+            }
+        }
+    }
+
     private var metaCard: some View {
         VStack(alignment: .leading, spacing: 8) {
             metaRow("Created", caveParseISO(live.createdAt))
             metaRow("Updated", caveParseISO(live.updatedAt))
-            if live.startDate != nil { metaRow("Start", caveParseISO(live.startDate)) }
-            if live.endDate != nil { metaRow("Due", caveParseISO(live.endDate)) }
         }
         .font(.footnote)
     }


### PR DESCRIPTION
## What

Two surfaces, both client-only.

### 1. Chat message timestamps
Each bubble now shows its **send time** below the message — time-only for today, with an abbreviated date for older messages. Messages previously carried no timestamp at all. (`DisplayMessage.createdAt` already existed; this is presentation.)

### 2. Editable task title & dates
`TaskDetailView` could edit notes/status/priority but the **title was read-only** and dates were display-only — renaming or scheduling a task required the desktop. Now:
- **Rename** via a pencil button → alert (matches the app's rename idiom).
- A new **Schedule** section edits **Start / Due** with native date pickers (Add to set, ✕ to clear).

The board PATCH already accepts `title`/`startDate`/`endDate`, so this is purely client: new `CaveClient.updateTaskTitle` / `updateTaskDates` + optimistic `AppModel.setTaskTitle` / `setTaskDates` mirroring `setTaskNotes`.

**Bonus bugfix:** the old read-only Start/Due rows parsed dates with the datetime `caveParseISO`, but board dates are date-only (`yyyy-MM-dd`), so they always rendered "—". The new Schedule section parses them correctly; the meta card keeps Created/Updated.

## Files
- `MessageBubble.swift` — `timestampText` + a subtle caption under each bubble
- `TaskDetailView.swift` — rename alert + pencil, editable Schedule section, date-only helpers, trimmed meta card
- `AppModel.swift` — `setTaskTitle`, `setTaskDates`
- `CaveClient.swift` — `updateTaskTitle`, `updateTaskDates`

## Verification
- `xcodebuild` for the iPhone 16 Pro simulator → **BUILD SUCCEEDED**.
- iOS tests `ios-task-actions`, `ios-task-notes-edit`, `ios-task-notes-reader`, `ios-message-reader`, `ios-no-canvas-tab` → all **ok**.
- Screenshotted the task detail showing the rename pencil + the new Schedule (Start/Due) section. (Chat timestamps live behind thread navigation that `simctl` can't drive, so that half is verified by build + the trivial caption render.)

> Note: iOS Swift isn't compiled by the required CI checks, so this was verified locally via `xcodebuild` + simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)