### PR TITLE
fix(gantt): standardize the toolbar control styling

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -500,7 +500,7 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
             </button>
           ))}
         </div>
-        <button type="button" className="board-group-toggle-btn" onClick={scrollToToday} disabled={todayX === null} title="Scroll the timeline to today">Today</button>
+        <button type="button" className="board-group-toggle-btn board-group-toggle-btn--solo" onClick={scrollToToday} disabled={todayX === null} title="Scroll the timeline to today">Today</button>
       </div>
       <div className="board-gantt__scroll" ref={scrollRef}>
         <div

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -46,6 +46,7 @@
 .board-group-toggle-btn:hover { background:var(--bg-hover); color:var(--text-secondary); }
 .board-group-toggle-btn:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:-1px; z-index:1; position:relative; }
 .board-group-toggle-btn--active { background:color-mix(in oklch,var(--accent-presence) 16%,var(--bg-raised)); color:var(--text-primary); }
+.board-group-toggle-btn--solo { border:1px solid var(--border-strong); border-radius:7px; }
 .board-view-toggle { display:flex; border:1px solid var(--border-strong); border-radius:7px; overflow:hidden; }
 .board-view-toggle-btn { display:flex; align-items:center; justify-content:center; width:28px; height:28px; background:var(--bg-raised); color:var(--text-muted); border:none; cursor:pointer; transition:background .12s,color .12s; }
 .board-view-toggle-btn+.board-view-toggle-btn { border-left:1px solid var(--border-strong); }
@@ -1871,7 +1872,7 @@
 
 /* status-filter chips (toolbar) — toggle a whole status category off */
 .cg-filter { display:flex; gap:4px; align-items:center; flex-wrap:wrap; }
-.cg-filter-chip { display:inline-flex; align-items:center; gap:5px; height:24px; padding:0 8px; border:1px solid var(--border-strong); border-radius:999px; background:var(--bg-raised); color:var(--text-secondary); font-size:11px; cursor:pointer; transition:opacity .12s, background .12s; white-space:nowrap; }
+.cg-filter-chip { display:inline-flex; align-items:center; gap:5px; height:28px; padding:0 10px; border:1px solid var(--border-strong); border-radius:7px; background:var(--bg-raised); color:var(--text-muted); font-size:12px; font-weight:500; cursor:pointer; transition:opacity .12s, background .12s; white-space:nowrap; }
 .cg-filter-chip:hover { background:var(--bg-hover); }
 .cg-filter-chip:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }
 .cg-filter-chip--off { opacity:.4; text-decoration:line-through; }


### PR DESCRIPTION
## Problem

The Gantt toolbar mixed **three** control styles that didn't line up or read as one set:
- legend filter pills — **24px**, 11px font, **fully rounded** (999px)
- D/W/M + search segmented control — **28px**, 12px font, **7px-radius** rect
- a standalone **"Today"** button — borderless `board-group-toggle-btn` (relied on the group container it wasn't in)

## Fix (per "one cohesive style")

Unify everything to the segmented control's metrics:
- **Legend chips** → 28px height, 7px radius, 12px / 500 weight, muted text, same border (keeps the status dots).
- **Today** → gets the border + radius the grouped container normally supplies (new `--solo` modifier).

Now the legend · D/W/M · search · Today share one control language (height, radius, border, font, color). CSS-only in `board.css` plus a one-class change on the Today button.

## Verification

- `board-schedule-window.test.ts` → **ok** (its `cg-filter-chip` assertions still hold).
- CSS metrics now match the existing toggle buttons exactly, so the controls align.

Pull `main` to see it (hot-reloads), or I can attach a before/after screenshot on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)