### PR TITLE
feat(palette): switch board view + recency-sort tasks

### DIFF
--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -115,6 +115,16 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     return () => window.removeEventListener(DEMO_MODE_EVENT, onDemoModeChange);
   }, [load]);
   useEffect(() => { localStorage.setItem("cave:board:viewMode", viewMode); }, [viewMode]);
+  // The command palette can switch the board view directly (e.g. "Board: Gantt
+  // timeline"); honor it live when the board is already mounted.
+  useEffect(() => {
+    const onSetView = (e: Event) => {
+      const v = (e as CustomEvent<{ view?: string }>).detail?.view;
+      if (v === "kanban" || v === "table" || v === "gantt") setViewMode(v);
+    };
+    window.addEventListener("cave:board:set-view", onSetView);
+    return () => window.removeEventListener("cave:board:set-view", onSetView);
+  }, []);
   useEffect(() => { localStorage.setItem("cave:board:groupBy", groupBy); }, [groupBy]);
   useEffect(() => { localStorage.setItem("cave:board:ganttGroup", ganttGroup); }, [ganttGroup]);
 

--- a/src/components/command-palette.test.ts
+++ b/src/components/command-palette.test.ts
@@ -14,6 +14,10 @@ const workspace = readFileSync(
   new URL("./workspace.tsx", import.meta.url),
   "utf8",
 );
+const boardView = readFileSync(
+  new URL("./board-view.tsx", import.meta.url),
+  "utf8",
+);
 
 // Input is labelled.
 assert.match(
@@ -175,6 +179,26 @@ assert.match(
   workspace,
   /intent\.kind === "open-project"[\s\S]{0,320}?CHAT_OPEN_PROJECTS_EVENT[\s\S]{0,200}?CHAT_FOCUS_PROJECT_EVENT, \{ detail: \{ root \} \}/,
   "workspace opens the Projects tab then focuses the chosen project",
+);
+
+// Board view-switch: the palette offers "Board: Kanban/Table/Gantt" rows that
+// jump to the board and set its view; the board honors the live switch.
+assert.match(source, /kind: "set-board-view"; view: "kanban" \| "table" \| "gantt"/, "a set-board-view intent exists");
+assert.match(source, /label: "Board: Gantt timeline"/, "a Gantt board-view row is offered");
+assert.match(source, /intent: \{ kind: "set-board-view", view: v\.view \}/, "board-view rows carry the set-board-view intent");
+assert.match(source, /\.\.\.boardViewRows/, "board-view rows are included in the result list");
+assert.match(
+  workspace,
+  /intent\.kind === "set-board-view"[\s\S]{0,500}cave:board:set-view/,
+  "workspace handles set-board-view by dispatching the live switch event",
+);
+assert.match(boardView, /addEventListener\("cave:board:set-view"/, "board-view listens for the set-view event");
+assert.match(boardView, /=== "gantt"\) setViewMode\(v\)/, "the set-view handler applies the requested view");
+// Recent tasks: empty-query task rows lead with the most-recently-updated.
+assert.match(
+  source,
+  /q \? 0 : new Date\(b\.updatedAt \?\? 0\)\.getTime\(\) - new Date\(a\.updatedAt \?\? 0\)\.getTime\(\)/,
+  "task rows sort by recency when the query is empty",
 );
 
 console.log("command-palette.test.ts OK");

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -70,6 +70,7 @@ type PaletteIntent =
   | { kind: "back-to-list" }
   | { kind: "open-tui-session"; sessionId: string }
   | { kind: "open-board" }
+  | { kind: "set-board-view"; view: "kanban" | "table" | "gantt" }
   | { kind: "go-to-surface"; mode: FolderMode }
   | { kind: "open-project"; root: string }
   | { kind: "focus-card"; cardId: string }
@@ -83,6 +84,7 @@ type Card = {
   priority: string;
   familiarId: string | null;
   labels: string[];
+  updatedAt?: string;
 };
 
 type CovenMemoryEntry = {
@@ -404,6 +406,9 @@ export function CommandPalette({
           c.priority.toLowerCase().includes(q)
         );
       })
+      // Empty query → lead with the most-recently-updated tasks ("recent tasks"
+      // jump-list); while searching keep the match order.
+      .sort((a, b) => (q ? 0 : new Date(b.updatedAt ?? 0).getTime() - new Date(a.updatedAt ?? 0).getTime()))
       .slice(0, RESULT_LIMITS.card)
       .map((c) => ({
         id: `card:${c.id}`,
@@ -588,6 +593,25 @@ export function CommandPalette({
             intent: { kind: "open-project", root: p.root },
           }));
 
+    // "Board: …" rows jump to the board and switch its view directly. Hidden
+    // while scoped or typing a slash command.
+    const BOARD_VIEWS: Array<{ view: "kanban" | "table" | "gantt"; label: string; hint: string; terms: string }> = [
+      { view: "kanban", label: "Board: Kanban", hint: "Columns by status", terms: "board kanban columns" },
+      { view: "table", label: "Board: Table", hint: "Sortable task table", terms: "board table list" },
+      { view: "gantt", label: "Board: Gantt timeline", hint: "Schedule timeline", terms: "board gantt timeline schedule" },
+    ];
+    const boardViewRows: Row[] = (scoped || slashToken)
+      ? []
+      : BOARD_VIEWS
+          .filter((v) => !q || v.label.toLowerCase().includes(q) || v.terms.includes(q))
+          .map((v) => ({
+            id: `board-view:${v.view}`,
+            kind: "command" as const,
+            name: v.label,
+            hint: v.hint,
+            intent: { kind: "set-board-view", view: v.view },
+          }));
+
     // Empty, unscoped query → "browse" mode: lead with the recency jump-list,
     // then the launcher surfaces, and group the rest under section headers
     // (see browseGroup + the render). While the user is typing it falls back to
@@ -614,6 +638,7 @@ export function CommandPalette({
           ...familiarRows,
           ...cardRows,
           ...projectRows,
+          ...boardViewRows,
           ...covenMemoryRows,
           ...fsMemoryRows,
           ...cmdRows,
@@ -628,6 +653,7 @@ export function CommandPalette({
           ...saveRows,
           ...cmdRows,
           ...surfaceRows,
+          ...boardViewRows,
           ...projectRows,
           ...shortcutRows,
           ...createRows,

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1287,6 +1287,17 @@ export function Workspace() {
       setMode("board");
       return;
     }
+    if (intent.kind === "set-board-view") {
+      // Persist for a fresh mount, navigate to the board, then signal a live
+      // switch in case the board is already mounted.
+      try { localStorage.setItem("cave:board:viewMode", intent.view); } catch { /* ignore */ }
+      setMode("board");
+      window.setTimeout(
+        () => window.dispatchEvent(new CustomEvent("cave:board:set-view", { detail: { view: intent.view } })),
+        0,
+      );
+      return;
+    }
     if (intent.kind === "go-to-surface") {
       setMode(intent.mode as WorkspaceMode);
       shellRef.current?.dismissNavMobile();


### PR DESCRIPTION
Two command-palette navigation wins (from the UX backlog):

## 1. Switch board view from the palette
New **"Board: Kanban"**, **"Board: Table"**, **"Board: Gantt timeline"** rows jump to the board and switch its view directly. A new `set-board-view` intent persists the choice (`cave:board:viewMode`), navigates to the board, and dispatches `cave:board:set-view` so an **already-mounted** board switches live (BoardView now listens for that event).

## 2. Recent-tasks jump-list
Task rows now lead with the **most-recently-updated** when the query is empty, so the palette doubles as a "recent tasks" launcher (match order is preserved while searching).

## Verification
- `pnpm typecheck` clean; `app` suite → **383 files pass** (assertions added to `command-palette.test.ts`).
- Browser-driven: ⌘K → type "gantt" → **"Board: Gantt timeline"** appears → select → `viewMode` becomes `gantt` and the Gantt renders live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)