### PR TITLE
feat(projects): motion polish + cross-project-move undo toast (native redesign phase 4)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1913,6 +1913,20 @@ select {
   from { opacity: 0; transform: translateY(-2px); }
   to   { opacity: 1; transform: translateY(0); }
 }
+
+/* Projects tab: a project's session list slides+fades in when expanded.
+   Enter-only (collapse stays instant) so the section can stay conditionally
+   rendered — keeping collapsed rows out of the DOM for the keyboard rove set. */
+@keyframes projects-expand-enter {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.projects-expand-enter {
+  animation: projects-expand-enter var(--duration-fast, 150ms) var(--ease-decelerate, ease-out);
+}
+@media (prefers-reduced-motion: reduce) {
+  .projects-expand-enter { animation: none; }
+}
 .ui-popover-body {
   padding: 6px;
 }

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -355,4 +355,24 @@ assert.match(projectsView, /Delete chat…/, "session menu offers delete (routes
 // menu-triggered delete's Cancel/Delete buttons aren't hidden behind hover.
 assert.match(projectsView, /confirmDelete\s*\?\s*"opacity-100"/, "the action cluster stays visible while confirming a delete");
 
+// Phase 4 — motion + cross-project-move undo.
+// Expand animates in (enter-only; collapse stays instant so collapsed rows stay
+// out of the DOM / rove set), respecting prefers-reduced-motion (CSS).
+assert.match(projectsView, /className="projects-expand-enter"/, "the session list animates in on expand");
+// Drag feedback: the dragged row lifts; the drop-target card shows an accent ring.
+assert.match(projectsView, /data-\[dragging=true\]:shadow-/, "the dragged row lifts (shadow) while dragging");
+assert.match(projectsView, /isOver[\s\S]{0,140}?ring-1 ring-inset ring-\[var\(--accent-presence\)\]/, "the drop-target project card shows an accent ring");
+// Cross-project move is undoable via a transient toast.
+assert.match(projectsView, /import \{ applyProjectOverrides, setProjectOverride, clearProjectOverride \}/, "imports clearProjectOverride for undo");
+assert.match(projectsView, /function MoveUndoToast/, "a move-undo toast component exists");
+assert.match(projectsView, /window\.setTimeout\(\(\) => dismissRef\.current\(\), 5000\)/, "the toast auto-dismisses");
+assert.match(projectsView, /const prevRoot = projectOverrides\[activeId\] \?\? null/, "the move captures the prior override for a precise undo");
+assert.match(projectsView, /setMoveToast\(\{ sessionId: activeId, prevRoot, label:/, "a cross-project move raises the undo toast");
+assert.match(
+  projectsView,
+  /moveToast\.prevRoot\) setProjectOverride\(moveToast\.sessionId, moveToast\.prevRoot\)[\s\S]{0,90}?clearProjectOverride\(moveToast\.sessionId\)/,
+  "undo restores the prior override, or clears it when there wasn't one",
+);
+assert.match(projectsView, /<MoveUndoToast\s+key=\{moveToast\.sessionId\}/, "the toast renders, keyed so a new move restarts its timer");
+
 console.log("projects-view.test.ts: ok");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -19,7 +19,7 @@ import {
   readSessionOrder,
   writeSessionOrder,
 } from "@/lib/chat-session-order";
-import { applyProjectOverrides, setProjectOverride } from "@/lib/chat-project-overrides";
+import { applyProjectOverrides, setProjectOverride, clearProjectOverride } from "@/lib/chat-project-overrides";
 import { useProjectOverrides } from "@/lib/use-project-overrides";
 import { useProjects } from "@/lib/use-projects";
 import { deriveProjectStatus } from "@/lib/project-status";
@@ -93,6 +93,50 @@ function shortRoot(p: string): string {
 // In select mode the leading drag handle becomes a checkbox and the row's
 // primary click toggles selection instead of opening the chat, so several chats
 // can be deleted together via the card's bulk toolbar.
+// Transient toast shown after a cross-project drag, offering a one-click Undo.
+// Auto-dismisses after a few seconds; remount (via a key) restarts the timer.
+function MoveUndoToast({
+  label,
+  onUndo,
+  onDismiss,
+}: {
+  label: string;
+  onUndo: () => void;
+  onDismiss: () => void;
+}) {
+  const dismissRef = useRef(onDismiss);
+  dismissRef.current = onDismiss;
+  useEffect(() => {
+    const t = window.setTimeout(() => dismissRef.current(), 5000);
+    return () => window.clearTimeout(t);
+  }, []);
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-4 left-1/2 z-50 flex max-w-[90vw] -translate-x-1/2 items-center gap-3 rounded-lg border border-[var(--border-strong)] bg-[var(--bg-elevated)] px-3 py-2 text-[12px] text-[var(--text-primary)] shadow-[0_16px_40px_oklch(0_0_0/45%)]"
+    >
+      <Icon name="ph:arrow-right-bold" width={13} className="shrink-0 text-[var(--accent-presence)]" aria-hidden />
+      <span className="min-w-0 truncate">{label}</span>
+      <button
+        type="button"
+        onClick={onUndo}
+        className="focus-ring shrink-0 rounded px-1.5 py-0.5 font-medium text-[var(--accent-presence)] hover:bg-[var(--bg-hover)]"
+      >
+        Undo
+      </button>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        className="focus-ring shrink-0 rounded p-0.5 text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+      >
+        <Icon name="ph:x-bold" width={12} aria-hidden />
+      </button>
+    </div>
+  );
+}
+
 function ProjectChatRow({
   session,
   displayTitle,
@@ -126,7 +170,12 @@ function ProjectChatRow({
   const [menu, setMenu] = useState<ContextMenuState>(null);
   const activate = () => (selectMode ? onToggleSelect(session.id) : onOpen());
   return (
-    <li ref={setNodeRef} style={style} data-dragging={isDragging ? "true" : undefined} className="group/pc relative">
+    <li
+      ref={setNodeRef}
+      style={style}
+      data-dragging={isDragging ? "true" : undefined}
+      className="group/pc relative rounded-md data-[dragging=true]:z-10 data-[dragging=true]:bg-[var(--bg-raised)] data-[dragging=true]:opacity-90 data-[dragging=true]:shadow-[0_8px_24px_oklch(0_0_0/35%)] data-[dragging=true]:ring-1 data-[dragging=true]:ring-[var(--border-strong)]"
+    >
       <div
         role={selectMode ? "checkbox" : "button"}
         aria-checked={selectMode ? selected : undefined}
@@ -462,7 +511,7 @@ function ProjectRow({
         "group border-b border-[var(--border-hairline)] px-2 transition-colors",
         density === "compact" ? "py-1.5" : "py-3",
         isOver
-          ? "bg-[color-mix(in_oklch,var(--accent-presence)_10%,transparent)]"
+          ? "rounded-md bg-[color-mix(in_oklch,var(--accent-presence)_12%,transparent)] ring-1 ring-inset ring-[var(--accent-presence)]/50"
           : "hover:bg-[var(--bg-raised)]/40",
       ].join(" ")}
     >
@@ -641,7 +690,7 @@ function ProjectRow({
       </div>
 
       {expanded ? (
-        <>
+        <div className="projects-expand-enter">
       <div className="mt-2 flex min-w-0 items-center gap-2 pl-6">
         <Icon
           name="ph:folder-simple-dashed"
@@ -771,7 +820,7 @@ function ProjectRow({
           No sessions yet — drag one here or start a new session.
         </p>
       )}
-        </>
+        </div>
       ) : null}
       <ContextMenu state={menu} onClose={() => setMenu(null)} ariaLabel={`Actions for ${project.name}`}>
         <PopoverItem icon="ph:chat-circle-dots-bold" onSelect={() => { setMenu(null); onNewChat?.(project.root); }}>
@@ -815,6 +864,7 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
   const [rootDraft, setRootDraft] = useState("");
   const [creating, setCreating] = useState(false);
   const [sessionError, setSessionError] = useState<string | null>(null);
+  const [moveToast, setMoveToast] = useState<{ sessionId: string; prevRoot: string | null; label: string } | null>(null);
   const projectOverrides = useProjectOverrides();
   const { density, setDensity, isExpanded, setExpanded } = useProjectsUiState();
   // Roving keyboard navigation (WAI-ARIA) over the flattened list of project
@@ -925,8 +975,23 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
       return;
     }
     // Different project → move (cave-local override; agent cwd untouched).
+    // Capture the prior override first so the move can be undone precisely
+    // (restore the old override, or clear it if there wasn't one).
+    const prevRoot = projectOverrides[activeId] ?? null;
+    const moved = sessions.find((s) => s.id === activeId);
+    const destName =
+      projects.find((p) => normalizeProjectRoot(p.root) === targetRoot)?.name ?? shortRoot(targetRoot);
+    const movedTitle = moved ? stripLeadingTrailingEmoji(stripTaskPrefix(moved.title)) || "chat" : "chat";
     setProjectOverride(activeId, targetRoot);
+    setMoveToast({ sessionId: activeId, prevRoot, label: `Moved “${movedTitle}” to ${destName}` });
   }
+
+  const undoMove = () => {
+    if (!moveToast) return;
+    if (moveToast.prevRoot) setProjectOverride(moveToast.sessionId, moveToast.prevRoot);
+    else clearProjectOverride(moveToast.sessionId);
+    setMoveToast(null);
+  };
 
   const handleCreate = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -1218,6 +1283,14 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
           </div>
         )}
       </main>
+      {moveToast ? (
+        <MoveUndoToast
+          key={moveToast.sessionId}
+          label={moveToast.label}
+          onUndo={undoMove}
+          onDismiss={() => setMoveToast(null)}
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## What

Phase 4 of the [Projects native redesign](https://github.com/OpenCoven/coven-cave/blob/main/docs/projects-view-native-redesign.md) — **motion + reversibility**.

- **Expand animation:** a project's session list slides + fades in when expanded. Enter-only by design (collapse stays instant) so the section stays *conditionally rendered* — collapsed rows stay out of the DOM and the keyboard rove set from Phase 3a. Respects `prefers-reduced-motion`.
- **Drag feedback:** the dragged row now **lifts** (shadow + ring + raised bg); the drop-target project card shows a clear **inset accent ring** instead of just a faint tint.
- **Cross-project move undo:** dragging a chat to another project raises a transient toast — *“Moved “…” to <Project>”* — with a one-click **Undo** that restores the prior override precisely (or clears it when there wasn't one). Auto-dismisses after 5s.

## Deferred: virtualization

Intentionally **not** in this PR. There's no virtualization dependency in the tree, and composing one with the dnd-kit `SortableContext` is a separate, riskier change. The existing **"Show all N" cap** already bounds the default render to 8 rows per project. Noted as a possible follow-up (e.g. `@tanstack/react-virtual`).

## How
- CSS keyframe `projects-expand-enter` in globals.css (reduced-motion guarded); drag/drop feedback via Tailwind `data-[dragging=true]:*` and the `isOver` branch.
- Undo reuses the existing override API (`setProjectOverride` / `clearProjectOverride`); the move captures the prior override first so undo is exact. Small co-located `MoveUndoToast` (auto-dismiss via a ref'd timer, keyed so a new move restarts it).

## Verification
- `pnpm typecheck` clean · `projects-view.test.ts` extended and green · `check:tests-wired` unaffected
- Live verification via run-cave-app: drag a chat across projects → Undo toast; drop-target ring; expand animation (screenshots in thread)

No data-model/API changes; icons (`ph:arrow-right-bold`, `ph:x-bold`) already allowlisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)