### PR TITLE
feat(ios): add, remove & reorder checklist steps in a task

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -186,6 +186,46 @@ final class AppModel {
         }
     }
 
+    /// Append a new checklist step.
+    func addStep(_ card: BoardCard, text: String) async {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        var steps = card.steps ?? []
+        steps.append(CardStep(id: UUID().uuidString, text: trimmed, done: false, doneAt: nil))
+        await commitSteps(card, steps)
+    }
+
+    /// Remove a checklist step.
+    func deleteStep(_ card: BoardCard, stepId: String) async {
+        guard var steps = card.steps else { return }
+        steps.removeAll { $0.id == stepId }
+        await commitSteps(card, steps)
+    }
+
+    /// Move a step up (delta -1) or down (delta +1) in the list.
+    func moveStep(_ card: BoardCard, stepId: String, by delta: Int) async {
+        guard var steps = card.steps, let i = steps.firstIndex(where: { $0.id == stepId }) else { return }
+        let j = i + delta
+        guard j >= 0, j < steps.count else { return }
+        steps.swapAt(i, j)
+        await commitSteps(card, steps)
+    }
+
+    /// Optimistically persist a new step list, reconciling with the server's
+    /// echoed card (reverts on failure) — shared by add/delete/move.
+    private func commitSteps(_ card: BoardCard, _ steps: [CardStep]) async {
+        guard let client else { return }
+        let previous = tasks
+        applyTask(id: card.id) { $0.steps = steps }
+        do {
+            let updated = try await client.updateTask(cardId: card.id, steps: steps)
+            applyTask(id: card.id) { $0 = updated }
+        } catch {
+            tasks = previous
+            tasksError = error.localizedDescription
+        }
+    }
+
     /// Optimistically set a task's notes (pass "" to clear); reconcile/revert.
     func setTaskNotes(_ card: BoardCard, _ notes: String) async {
         guard let client else { return }

--- a/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
@@ -12,6 +12,7 @@ struct TaskDetailView: View {
     @State private var editingNotes = false
     @State private var renamingTitle = false
     @State private var titleDraft = ""
+    @State private var newStep = ""
 
     /// The current card from the store, so status/priority/step edits made here
     /// reflect immediately; falls back to the passed-in snapshot.
@@ -24,7 +25,7 @@ struct TaskDetailView: View {
                 header
                 if let familiar { assigneeRow(familiar) }
                 chatCard
-                if live.hasSteps { stepsCard }
+                stepsCard
                 notesSection
                 scheduleCard
                 if !live.labelList.isEmpty { labelsRow }
@@ -196,17 +197,22 @@ struct TaskDetailView: View {
     }
 
     private var stepsCard: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        let steps = live.steps ?? []
+        return VStack(alignment: .leading, spacing: 12) {
             HStack {
                 Text("Steps").font(.headline)
                 Spacer()
-                Text("\(live.doneStepCount)/\(live.stepCount)")
-                    .font(.subheadline.monospacedDigit()).foregroundStyle(.secondary)
+                if live.hasSteps {
+                    Text("\(live.doneStepCount)/\(live.stepCount)")
+                        .font(.subheadline.monospacedDigit()).foregroundStyle(.secondary)
+                }
             }
-            ProgressView(value: live.stepFraction)
-                .tint(Theme.color(for: live.status))
+            if live.hasSteps {
+                ProgressView(value: live.stepFraction)
+                    .tint(Theme.color(for: live.status))
+            }
             VStack(alignment: .leading, spacing: 10) {
-                ForEach(live.steps ?? []) { step in
+                ForEach(Array(steps.enumerated()), id: \.element.id) { index, step in
                     Button { Haptics.tap(); Task { await app.toggleStep(live, stepId: step.id) } } label: {
                         HStack(alignment: .top, spacing: 10) {
                             Image(systemName: step.done ? "checkmark.circle.fill" : "circle")
@@ -219,11 +225,49 @@ struct TaskDetailView: View {
                         }
                     }
                     .buttonStyle(.plain)
+                    // Reorder + delete live in a long-press menu so the row itself
+                    // stays a clean tap-to-toggle target (drag-reorder isn't
+                    // available for a VStack inside the detail ScrollView).
+                    .contextMenu {
+                        Button { Task { await app.moveStep(live, stepId: step.id, by: -1) } } label: {
+                            Label("Move up", systemImage: "arrow.up")
+                        }.disabled(index == 0)
+                        Button { Task { await app.moveStep(live, stepId: step.id, by: 1) } } label: {
+                            Label("Move down", systemImage: "arrow.down")
+                        }.disabled(index == steps.count - 1)
+                        Divider()
+                        Button(role: .destructive) { Task { await app.deleteStep(live, stepId: step.id) } } label: {
+                            Label("Delete step", systemImage: "trash")
+                        }
+                    }
                 }
             }
+            addStepRow
         }
         .padding(16)
         .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    private var addStepRow: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "plus.circle.fill")
+                .foregroundStyle(.secondary)
+            TextField("Add step", text: $newStep)
+                .submitLabel(.done)
+                .onSubmit(commitNewStep)
+            if !newStep.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                Button("Add", action: commitNewStep)
+                    .font(.callout.weight(.semibold))
+            }
+        }
+    }
+
+    private func commitNewStep() {
+        let text = newStep.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        newStep = ""
+        Haptics.tap()
+        Task { await app.addStep(live, text: text) }
     }
 
     private var hasNotes: Bool {


### PR DESCRIPTION
## What

Checklist steps were **toggle-only**. With title, notes, and dates already editable on iOS, this finishes "fully edit a task on the phone."

The Steps card now **always renders** (so the first step can be added even on a step-less task) and gains:
- An **"Add step"** field at the bottom — commit on return or tap **Add**.
- A **long-press menu per step**: **Move up** / **Move down** (disabled at the ends) / **Delete**.

Reorder lives in the context menu rather than drag because drag-reorder isn't available for a `VStack` inside the detail `ScrollView`, and it keeps each row a clean tap-to-toggle target.

Client-only — the board PATCH already accepts the full `steps` array, so new `AppModel.addStep`/`deleteStep`/`moveStep` funnel through a shared `commitSteps` that mirrors `toggleStep`'s optimistic update + server reconcile.

## Files
- `AppModel.swift` — `addStep`, `deleteStep`, `moveStep`, `commitSteps`
- `TaskDetailView.swift` — always-on steps card, per-step reorder/delete menu, add-step row

## Verification
- `xcodebuild` for the iPhone 16 Pro simulator → **BUILD SUCCEEDED**.
- iOS tests `ios-task-actions`, `ios-task-notes-edit`, `ios-task-notes-reader` → **ok** (the toggle-step markup the test pins is unchanged).
- Screenshotted the task detail with the Steps card (progress + checked steps) rendering under the new structure; the add-step row sits below the list and reorder/delete are in the long-press menu.

> Note: iOS Swift isn't compiled by the required CI checks, so this was verified locally via `xcodebuild` + simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)