### PR TITLE
feat(ios): search messages within a chat thread

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -37,6 +37,11 @@ struct ChatView: View {
     // Tap-to-enlarge target (image attachment, or a table/diagram/image lifted
     // from the markdown WebView). Driven by the `.caveZoomContent` notification.
     @State private var zoomTarget: ZoomTarget?
+    // In-thread message search: the sheet, the message to scroll to after a hit
+    // is picked, and the message briefly highlighted once it scrolls into view.
+    @State private var showSearch = false
+    @State private var searchScrollTarget: String?
+    @State private var highlightedMessageId: String?
 
     /// Per-thread key for the persisted unsent draft.
     private var draftKey: String { "cave.chat.draft.\(thread.id)" }
@@ -86,6 +91,13 @@ struct ChatView: View {
                 .accessibilityLabel("Linked tasks")
             }
             ToolbarItem(placement: .topBarTrailing) {
+                Button { showSearch = true } label: {
+                    Image(systemName: "magnifyingglass")
+                }
+                .accessibilityLabel("Search this chat")
+                .disabled(thread.messages.isEmpty)
+            }
+            ToolbarItem(placement: .topBarTrailing) {
                 Button { showCommands = true } label: {
                     Image(systemName: "command")
                 }
@@ -111,6 +123,17 @@ struct ChatView: View {
         }
         .sheet(isPresented: $showTasks) {
             LinkedTasksSheet(thread: thread)
+        }
+        .sheet(isPresented: $showSearch) {
+            ThreadSearchView(
+                messages: thread.messages,
+                resolveSender: { message in
+                    message.role == .user
+                        ? "You"
+                        : (message.familiarId.flatMap(app.familiar)?.displayName ?? "Assistant")
+                },
+                onSelect: { id in searchScrollTarget = id }
+            )
         }
         .sheet(item: $responseReader) { item in
             ResponseReaderView(item: item)
@@ -161,6 +184,13 @@ struct ChatView: View {
                                       onOpenReader: { openReader(text: $0, familiar: message.familiarId.flatMap(app.familiar)) },
                                       onRetry: canRetry(message) ? { retryAssistant(message) } : nil)
                         .id(message.id)
+                        .background(
+                            message.id == highlightedMessageId
+                                ? Color.accentColor.opacity(0.12)
+                                : Color.clear,
+                            in: RoundedRectangle(cornerRadius: 12)
+                        )
+                        .animation(.easeInOut(duration: 0.3), value: highlightedMessageId)
                     }
                     Color.clear.frame(height: 1).id("bottom")
                 }
@@ -208,6 +238,25 @@ struct ChatView: View {
             }
             .onChange(of: thread.messages.count) { _, _ in
                 withAnimation { proxy.scrollTo("bottom", anchor: .bottom) }
+            }
+            // A search hit was picked: let the sheet dismiss, scroll the message
+            // to centre, flash a highlight, then fade it.
+            .onChange(of: searchScrollTarget) { _, target in
+                guard let target else { return }
+                Task {
+                    try? await Task.sleep(for: .milliseconds(350))
+                    await MainActor.run {
+                        withAnimation(.easeInOut(duration: 0.25)) { proxy.scrollTo(target, anchor: .center) }
+                        highlightedMessageId = target
+                        searchScrollTarget = nil
+                    }
+                    try? await Task.sleep(for: .milliseconds(1600))
+                    await MainActor.run {
+                        if highlightedMessageId == target {
+                            withAnimation(.easeOut(duration: 0.4)) { highlightedMessageId = nil }
+                        }
+                    }
+                }
             }
             .onAppear { proxy.scrollTo("bottom", anchor: .bottom) }
         }

--- a/apps/ios/CovenCave/CovenCave/Views/ThreadSearchView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ThreadSearchView.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+/// Search the messages of one open chat thread. Lists matches newest-first with
+/// a snippet around the hit; picking one dismisses and asks ChatView to scroll
+/// to that message in the full transcript.
+struct ThreadSearchView: View {
+    let messages: [DisplayMessage]
+    /// Human label for a message's author ("You" / familiar name).
+    let resolveSender: (DisplayMessage) -> String
+    let onSelect: (String) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var query = ""
+
+    private var trimmedQuery: String {
+        query.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var results: [DisplayMessage] {
+        let q = trimmedQuery
+        guard !q.isEmpty else { return [] }
+        return messages
+            .filter { $0.role != .system && $0.text.localizedCaseInsensitiveContains(q) }
+            .reversed()
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if trimmedQuery.isEmpty {
+                    ContentUnavailableView(
+                        "Search this chat",
+                        systemImage: "magnifyingglass",
+                        description: Text("Find a message in this conversation.")
+                    )
+                } else if results.isEmpty {
+                    ContentUnavailableView.search(text: query)
+                } else {
+                    List(results) { message in
+                        Button {
+                            onSelect(message.id)
+                            dismiss()
+                        } label: {
+                            VStack(alignment: .leading, spacing: 3) {
+                                HStack(spacing: 6) {
+                                    Text(resolveSender(message))
+                                        .font(.caption.weight(.semibold))
+                                        .foregroundStyle(.secondary)
+                                    Spacer(minLength: 8)
+                                    Text(message.createdAt, format: .relative(presentation: .numeric))
+                                        .font(.caption2)
+                                        .foregroundStyle(.tertiary)
+                                }
+                                Text(snippet(message.text, around: trimmedQuery))
+                                    .font(.callout)
+                                    .foregroundStyle(.primary)
+                                    .lineLimit(2)
+                                    .multilineTextAlignment(.leading)
+                            }
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .listStyle(.plain)
+                }
+            }
+            .navigationTitle("Search")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        .searchable(
+            text: $query,
+            placement: .navigationBarDrawer(displayMode: .always),
+            prompt: "Messages in this chat"
+        )
+    }
+
+    /// A short one-line window of `text` centred on the first match of `query`.
+    private func snippet(_ text: String, around query: String) -> String {
+        let flat = text.replacingOccurrences(of: "\n", with: " ")
+        guard let range = flat.range(of: query, options: .caseInsensitive) else {
+            return String(flat.prefix(120))
+        }
+        let lower = flat.index(range.lowerBound, offsetBy: -40, limitedBy: flat.startIndex) ?? flat.startIndex
+        let upper = flat.index(range.upperBound, offsetBy: 80, limitedBy: flat.endIndex) ?? flat.endIndex
+        var clip = String(flat[lower..<upper])
+        if lower != flat.startIndex { clip = "…" + clip }
+        if upper != flat.endIndex { clip += "…" }
+        return clip
+    }
+}


### PR DESCRIPTION
## What

Finding an old message in a long conversation meant scrolling — ChatView had no in-thread search. (The Chats tab's search, #1669, only matches thread **titles**.)

Adds a **magnifying-glass** button to the chat toolbar that opens a search sheet (`ThreadSearchView`):
- a `.searchable` field filters the thread's messages by text,
- matches list **newest-first** with the author ("You" / familiar name), a relative timestamp, and a **snippet windowed around the hit**,
- picking a result dismisses the sheet, **scrolls that message to centre** in the full transcript, and **flashes a brief highlight** so it's easy to spot.

System / slash-output messages are excluded; the button is disabled on an empty thread.

## Verification

iOS isn't in CI, so verified on the **iPhone 16 Pro simulator**: searching `parser` across a seeded 5-message thread listed exactly the **4 messages containing it** (excluding the one that didn't), each with sender, time, and snippet. Clean simulator build succeeds.

(SwiftUI-only; no web/CI surface. The required checks don't compile `apps/ios`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)