### PR TITLE
feat(nav): ⌘⇧C shortcut + active-call badge for Calls

### DIFF
--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -46,7 +46,7 @@ assert.match(
 // Tools entry. (It was previously removed in e8b2f117; deliberately re-added.)
 assert.match(
   source,
-  /\{ id: "calls", label: "Calls", iconName: "ph:graph", group: "tools", description:/,
+  /\{ id: "calls", label: "Calls", iconName: "ph:graph", group: "tools"/,
   "Calls appears as a Tools surface",
 );
 assert.match(
@@ -55,6 +55,10 @@ assert.match(
   "workspace renders CallsView for the calls mode",
 );
 assert.match(workspace, /calls: "Calls"/, "calls mode has a Calls title");
+// The Calls surface has a ⌘⇧C shortcut and an active-call badge.
+assert.match(source, /id: "calls"[^}]*kbd: "⌘⇧C"/, "Calls has a ⌘⇧C shortcut");
+assert.match(source, /id: "calls"[^}]*badge: \(p\) => badgeText\(p\.callsActiveCount\)/, "Calls shows the active-call badge");
+assert.match(workspace, /e\.key\.toLowerCase\(\) === "c"[\s\S]*setMode\("calls"\)/, "⌘⇧C routes to the calls surface");
 
 assert.match(
   source,

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -68,6 +68,8 @@ export type SidebarMinimalProps = {
   boardOpenCount?: number;
   scheduleNeedsCount?: number;
   githubAssignedCount?: number;
+  /** Number of in-flight delegation calls (status "running"). */
+  callsActiveCount?: number;
 };
 
 // Format a count as a compact nav badge; 0/undefined yields no badge.
@@ -102,7 +104,7 @@ const FOLDER_MODES: Array<{
   { id: "docs", label: "Docs", iconName: "ph:book-bookmark", group: "tools", description: "OpenCoven documentation and guides" },
   { id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools", description: "Agent personas, workflows, skills, and the capabilities your familiars can use" },
   { id: "workflows", label: "Workflows", iconName: "ph:git-branch-bold", group: "tools", description: "Multi-step pipelines that orchestrate familiars" },
-  { id: "calls", label: "Calls", iconName: "ph:graph", group: "tools", description: "Live familiar activity and delegation traces" },
+  { id: "calls", label: "Calls", iconName: "ph:graph", group: "tools", kbd: "⌘⇧C", description: "Live familiar activity and delegation traces", badge: (p) => badgeText(p.callsActiveCount) },
   // Add-ons (gated)
   { id: "github", label: "GitHub", iconName: "ph:github-logo", group: "addons", description: "Issues and PRs assigned to you", badge: (p) => badgeText(p.githubAssignedCount) },
 ];

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -215,6 +215,7 @@ export function Workspace() {
   const [inboxItems, setInboxItems] = useState<InboxItem[]>([]);
   const [escalationsUnresolved, setEscalationsUnresolved] = useState(0);
   const [githubAssignedCount, setGithubAssignedCount] = useState(0);
+  const [callsActiveCount, setCallsActiveCount] = useState(0);
   // Open (not-done) board cards, kept with their familiar so the Tasks badge can
   // show a per-familiar count when a familiar is scoped, and the grand total
   // only when "All familiars" is selected.
@@ -518,6 +519,15 @@ export function Workspace() {
             .then((res) => (res.ok ? res.json() : null))
             .catch(() => null)
         : Promise.resolve(null);
+      // In-flight delegation-call count, surfaced as the Calls nav badge.
+      const callsPromise = fetch("/api/coven-calls", { cache: "no-store" })
+        .then((res) => (res.ok ? res.json() : null))
+        .catch(() => null);
+      void callsPromise.then((callsJson) => {
+        if (callsJson?.ok && Array.isArray(callsJson.calls)) {
+          setCallsActiveCount(callsJson.calls.filter((c: { status?: string }) => c.status === "running").length);
+        }
+      });
 
       try {
         // Scope the session list to the active familiar's granted projects so
@@ -1123,6 +1133,13 @@ export function Workspace() {
         return;
       }
 
+      // ⌘⇧C -> Calls (no free ⌘-digit; the digits 1–9/0 are all assigned).
+      if (meta && !alt && e.shiftKey && e.key.toLowerCase() === "c") {
+        e.preventDefault();
+        setMode("calls");
+        return;
+      }
+
       // ⌘[ / ⌘] -> previous / next surface, cycling through SURFACE_ORDER in the
       // same top-to-bottom order as ⌘1..⌘8 (wraps at the ends). From an off-list
       // surface (Journal/Roles/Workflows), ⌘] lands on the first surface and ⌘[
@@ -1667,6 +1684,7 @@ export function Workspace() {
       boardOpenCount={boardTaskCount}
       scheduleNeedsCount={scheduleNeedsCount}
       githubAssignedCount={githubAssignedCount}
+      callsActiveCount={callsActiveCount}
     />
   );
 

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -46,6 +46,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: "⌘1–⌘8", description: "Jump to a sidebar surface (Home … Code)" },
       { keys: "⌘0", description: "Jump to the Library" },
       { keys: "⌘9", description: "Jump to Projects (Chat surface)" },
+      { keys: "⌘⇧C", description: "Jump to Calls (familiar activity)" },
       { keys: "⌘[ / ⌘]", description: "Previous / next surface" },
       { keys: "⌥1–⌥9", description: "Select the Nth familiar" },
       { keys: "⌘↑ / ⌘↓", description: "Cycle through familiars" },


### PR DESCRIPTION
Two small enhancements to the Calls nav entry (added in #1711).

## ⌘⇧C shortcut
All ⌘-digits are already assigned (⌘1–⌘8 → sidebar surfaces, ⌘9 → Projects, ⌘0 → Library; Journal/Roles/Workflows are intentionally unshortcut), so Calls gets a **⌘⇧C** combo (consistent with the app's existing ⌘⇧ usage). Wired in the global keydown handler, shown as the nav row's kbd hint, and listed in the keyboard-shortcuts catalog (the ⌘/ help sheet).

## Active-call badge
A live nav badge showing the number of **in-flight delegation calls** (`CovenCall` with `status: "running"`), polled alongside the session refresh — matching the existing Board/Schedules/GitHub badge pattern. 0 → no badge.

## Verification
- `tsc` clean; `check:tests-wired` ✓ (504); nav + shortcut tests pass; guard assertions updated to expect the kbd + badge + handler
- Visual check of the badge + ⌘⇧C navigation (screenshot in review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)