### PR TITLE
Style voice call overlay and add dialog a11y

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -191,6 +191,7 @@ export const SUITES = {
     "src/components/bottom-terminal-sr-mirror.test.ts",
     "src/components/terminal-key-bar.test.ts",
     "src/components/voice-call-overlay-state.test.ts",
+    "src/components/voice-call-overlay.test.ts",
     "src/lib/session-debug.test.ts",
     "src/components/bottom-terminal-ws-bridge.test.ts",
     "src/lib/library-metadata.test.ts",

--- a/src/components/voice-call-overlay.test.ts
+++ b/src/components/voice-call-overlay.test.ts
@@ -1,0 +1,68 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const component = readFileSync(new URL("./voice-call-overlay.tsx", import.meta.url), "utf8");
+const styles = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
+
+assert.match(
+  component,
+  /import\s+\{[^}]*useFocusTrap[^}]*\}\s+from\s+["']@\/lib\/use-focus-trap["']/,
+  "VoiceCallOverlay imports the shared focus trap",
+);
+
+assert.match(
+  component,
+  /useFocusTrap\(true,\s*dialogRef,\s*\{\s*onEscape:\s*\(\)\s*=>\s*dispatch\(\{\s*type:\s*"CLOSE_REQUEST"\s*\}\)\s*\}\)/,
+  "VoiceCallOverlay traps focus and closes cleanly on Escape",
+);
+
+assert.match(
+  component,
+  /role="dialog"[\s\S]{0,160}aria-modal="true"[\s\S]{0,160}aria-labelledby="voice-call-overlay-title"/,
+  "VoiceCallOverlay exposes named modal dialog semantics",
+);
+
+assert.match(
+  component,
+  /id="voice-call-overlay-title"/,
+  "VoiceCallOverlay provides a heading id for aria-labelledby",
+);
+
+assert.match(
+  component,
+  /tabIndex=\{-1\}/,
+  "VoiceCallOverlay dialog can receive fallback focus",
+);
+
+assert.match(
+  component,
+  /className="voice-call-overlay__retry focus-ring"/,
+  "error retry action uses the styled overlay button class",
+);
+
+assert.match(
+  component,
+  /className="voice-call-overlay__control focus-ring"/,
+  "mute action uses the styled overlay control class",
+);
+
+assert.match(
+  styles,
+  /\.voice-call-overlay\s*\{[\s\S]*?position:\s*fixed;[\s\S]*?z-index:\s*1200;[\s\S]*?place-items:\s*center;/,
+  "voice overlay is fixed, centered, and above mobile chrome",
+);
+
+assert.match(
+  styles,
+  /\.voice-call-overlay__dialog\s*\{[\s\S]*?background:\s*var\(--bg-raised\);[\s\S]*?box-shadow:/,
+  "voice overlay dialog has a styled raised surface",
+);
+
+assert.match(
+  styles,
+  /\.voice-call-overlay__end\s*\{[\s\S]*?background:\s*var\(--color-danger\);/,
+  "end-call button reads as the destructive primary action",
+);
+
+console.log("voice-call-overlay.test.ts: ok");

--- a/src/components/voice-call-overlay.tsx
+++ b/src/components/voice-call-overlay.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useEffect, useReducer, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Icon } from "@iconify/react";
 import type { Familiar } from "@/lib/types";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 import { getVoiceProvider } from "@/lib/voice/registry";
 import type { LiveSession, VoiceSessionGrant } from "@/lib/voice/types";
 import { reduce, initialState, type CallState } from "./voice-call-overlay-state";
@@ -19,6 +21,9 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
   const grantRef = useRef<VoiceSessionGrant | null>(null);
   const micStreamRef = useRef<MediaStream | null>(null);
   const audioElRef = useRef<HTMLAudioElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+
+  useFocusTrap(true, dialogRef, { onEscape: () => dispatch({ type: "CLOSE_REQUEST" }) });
 
   useEffect(() => {
     let cancelled = false;
@@ -130,43 +135,64 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
   const mm = String(Math.floor(duration / 60)).padStart(2, "0");
   const ss = String(duration % 60).padStart(2, "0");
 
-  return (
-    <div className="voice-call-overlay">
-      <header className="voice-call-overlay__header">
-        <strong>{familiar.display_name}</strong>
-        <span className="voice-call-overlay__state">{labelFor(state)}</span>
-        {state.state === "live" && <span className="voice-call-overlay__duration">{mm}:{ss}</span>}
-      </header>
-      <div className="voice-call-overlay__body">
-        {state.state === "error" && (
-          <div className="voice-call-overlay__error">
-            <div>{state.errorCode}</div>
-            {state.hint && <div className="voice-call-overlay__hint">{state.hint}</div>}
-            <button type="button" onClick={() => dispatch({ type: "RETRY" })}>Try again</button>
+  const overlay = (
+    <div className="voice-call-overlay" role="presentation">
+      <div
+        ref={dialogRef}
+        className="voice-call-overlay__dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="voice-call-overlay-title"
+        tabIndex={-1}
+      >
+        <header className="voice-call-overlay__header">
+          <div className="voice-call-overlay__heading">
+            <strong id="voice-call-overlay-title">{familiar.display_name}</strong>
+            <span className="voice-call-overlay__state">{labelFor(state)}</span>
           </div>
-        )}
+          {state.state === "live" && <span className="voice-call-overlay__duration">{mm}:{ss}</span>}
+        </header>
+        <div className="voice-call-overlay__body">
+          {state.state === "error" && (
+            <div className="voice-call-overlay__error">
+              <div>{state.errorCode}</div>
+              {state.hint && <div className="voice-call-overlay__hint">{state.hint}</div>}
+              <button
+                type="button"
+                className="voice-call-overlay__retry focus-ring"
+                onClick={() => dispatch({ type: "RETRY" })}
+              >
+                Try again
+              </button>
+            </div>
+          )}
+        </div>
+        <footer className="voice-call-overlay__footer">
+          <button
+            type="button"
+            className="voice-call-overlay__control focus-ring"
+            aria-label={state.muted ? "Unmute" : "Mute"}
+            onClick={() => dispatch({ type: "MUTE_TOGGLE" })}
+            disabled={state.state !== "live"}
+          >
+            <Icon icon={state.muted ? "ph:microphone-slash-fill" : "ph:microphone-fill"} />
+          </button>
+          <button
+            type="button"
+            className="voice-call-overlay__end focus-ring"
+            aria-label="End call"
+            onClick={() => dispatch({ type: "CLOSE_REQUEST" })}
+          >
+            End call
+          </button>
+        </footer>
+        <audio ref={audioElRef} autoPlay hidden />
       </div>
-      <footer className="voice-call-overlay__footer">
-        <button
-          type="button"
-          aria-label={state.muted ? "Unmute" : "Mute"}
-          onClick={() => dispatch({ type: "MUTE_TOGGLE" })}
-          disabled={state.state !== "live"}
-        >
-          <Icon icon={state.muted ? "ph:microphone-slash-fill" : "ph:microphone-fill"} />
-        </button>
-        <button
-          type="button"
-          className="voice-call-overlay__end"
-          aria-label="End call"
-          onClick={() => dispatch({ type: "CLOSE_REQUEST" })}
-        >
-          End call
-        </button>
-      </footer>
-      <audio ref={audioElRef} autoPlay hidden />
     </div>
   );
+
+  if (typeof document === "undefined") return null;
+  return createPortal(overlay, document.body);
 }
 
 function labelFor(s: CallState): string {

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2281,6 +2281,151 @@ details[open] > .cave-tool-summary::before {
   opacity: 0.45;
 }
 
+.voice-call-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: color-mix(in oklch, var(--bg-base) 68%, transparent);
+  backdrop-filter: blur(10px);
+}
+
+.voice-call-overlay__dialog {
+  width: min(360px, calc(100vw - 32px));
+  overflow: hidden;
+  border: 1px solid var(--border-hairline);
+  border-radius: 8px;
+  background: var(--bg-raised);
+  color: var(--text-primary);
+  box-shadow: 0 24px 80px color-mix(in oklch, var(--bg-base) 76%, transparent);
+}
+
+.voice-call-overlay__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px solid var(--border-hairline);
+  padding: 14px 16px;
+}
+
+.voice-call-overlay__heading {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.voice-call-overlay__heading strong {
+  overflow: hidden;
+  font-size: 14px;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.voice-call-overlay__state,
+.voice-call-overlay__duration {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.3;
+}
+
+.voice-call-overlay__duration {
+  flex: 0 0 auto;
+  border: 1px solid var(--border-hairline);
+  border-radius: 999px;
+  padding: 3px 8px;
+  font-variant-numeric: tabular-nums;
+}
+
+.voice-call-overlay__body {
+  display: grid;
+  min-height: 120px;
+  place-items: center;
+  padding: 20px 16px;
+}
+
+.voice-call-overlay__error {
+  display: grid;
+  justify-items: center;
+  gap: 10px;
+  color: var(--color-danger);
+  font-size: 13px;
+  text-align: center;
+}
+
+.voice-call-overlay__hint {
+  max-width: 280px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.voice-call-overlay__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border-top: 1px solid var(--border-hairline);
+  padding: 12px 16px;
+}
+
+.voice-call-overlay__control,
+.voice-call-overlay__retry,
+.voice-call-overlay__end {
+  display: inline-flex;
+  min-height: 34px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-hairline);
+  border-radius: 7px;
+  font-size: 12px;
+  line-height: 1;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard);
+}
+
+.voice-call-overlay__control {
+  width: 34px;
+  background: color-mix(in oklch, var(--bg-base) 54%, transparent);
+  color: var(--text-secondary);
+}
+
+.voice-call-overlay__control:hover:not(:disabled),
+.voice-call-overlay__retry:hover {
+  border-color: color-mix(in oklch, var(--border-strong) 70%, transparent);
+  background: color-mix(in oklch, var(--bg-hover) 70%, transparent);
+  color: var(--text-primary);
+}
+
+.voice-call-overlay__control:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.voice-call-overlay__retry {
+  padding: 0 12px;
+  background: var(--bg-base);
+  color: var(--text-primary);
+}
+
+.voice-call-overlay__end {
+  min-width: 96px;
+  border-color: color-mix(in oklch, var(--color-danger) 70%, transparent);
+  background: var(--color-danger);
+  color: var(--color-on-accent);
+}
+
+.voice-call-overlay__end:hover {
+  border-color: color-mix(in oklch, var(--color-danger) 80%, #000);
+  background: color-mix(in oklch, var(--color-danger) 86%, #000);
+}
+
 @keyframes cave-chat-meta-blip {
   0%, 100% { opacity: 0.45; }
   50%      { opacity: 1; }


### PR DESCRIPTION
## Summary
- make the voice call overlay a portaled fixed dialog with aria-modal/labelledby and the shared focus trap
- add Cave chat styles for the overlay surface, retry/mute/end controls, and raise it above mobile chrome
- add a source regression test and wire it into the app suite

Fixes #1305

## Verification
- node --experimental-strip-types src/components/voice-call-overlay.test.ts
- node --experimental-strip-types src/components/voice-call-overlay-state.test.ts
- pnpm exec tsc --noEmit --pretty false
- pnpm check:tests-wired
- git diff --check
- rendered QA on http://127.0.0.1:3105 with Playwright fallback: mobile Start voice call opens a fixed dialog, role=dialog aria-modal=true aria-labelledby=voice-call-overlay-title, focus lands on End call, backdrop hit-test owns bottom nav area, Escape removes overlay

## Browser QA note
- In-app Browser bootstrap failed before page interaction with an invalid sandbox working-directory URI, so rendered QA used project Playwright instead.