### PR TITLE
perf(projects): render-virtualize session rows via content-visibility

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1927,6 +1927,18 @@ select {
 @media (prefers-reduced-motion: reduce) {
   .projects-expand-enter { animation: none; }
 }
+
+/* Projects tab: render-virtualize off-screen session rows (same content-visibility
+   strategy as chat turns + library doc rows). The row IS the focusable element
+   and its only fixed/portaled descendant — the right-click context menu — is a
+   SIBLING, not a child, so layout/paint containment is safe here. The auto
+   intrinsic-size caches each row's real height after first paint (works across
+   comfortable/compact densities), so scroll never jumps. Keeping rows in the DOM
+   (vs JS windowing) preserves keyboard roving, dnd-kit sorting, and find-in-page. */
+.projects-session-row {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 32px;
+}
 .ui-popover-body {
   padding: 6px;
 }

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -7,6 +7,7 @@ const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf
 const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
 const workspaceMode = readFileSync(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
 const iconSource = readFileSync(new URL("../lib/icon.tsx", import.meta.url), "utf8");
+const globalsCss = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 
 assert.match(projectsView, /export function ProjectsView/, "ProjectsView should export the workspace surface");
 assert.match(projectsView, /useProjects\(\{ familiarId: activeFamiliarId \}\)/, "ProjectsView should scope the live projects hook to the active familiar");
@@ -374,5 +375,15 @@ assert.match(
   "undo restores the prior override, or clears it when there wasn't one",
 );
 assert.match(projectsView, /<MoveUndoToast\s+key=\{moveToast\.sessionId\}/, "the toast renders, keyed so a new move restarts its timer");
+
+// Render-virtualization: off-screen session rows skip layout/paint via
+// content-visibility (the repo's established strategy — see chat turns + library
+// doc rows), keeping them in the DOM so keyboard roving / dnd / find still work.
+assert.match(projectsView, /focus-ring projects-session-row/, "each session row carries the render-virtualization class");
+assert.match(
+  globalsCss,
+  /\.projects-session-row \{[\s\S]*?content-visibility:\s*auto;[\s\S]*?contain-intrinsic-size:\s*auto 32px;[\s\S]*?\}/,
+  "session rows set content-visibility:auto with a cached intrinsic-size",
+);
 
 console.log("projects-view.test.ts: ok");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -192,7 +192,7 @@ function ProjectChatRow({
           }
         }}
         data-selected={selectMode && selected ? "true" : undefined}
-        className={`focus-ring flex w-full items-center gap-2 px-4 text-left text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] data-[selected=true]:bg-[var(--accent-presence)]/10 data-[selected=true]:text-[var(--text-primary)] ${density === "compact" ? "py-0.5" : "py-1"}`}
+        className={`focus-ring projects-session-row flex w-full items-center gap-2 px-4 text-left text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] data-[selected=true]:bg-[var(--accent-presence)]/10 data-[selected=true]:text-[var(--text-primary)] ${density === "compact" ? "py-0.5" : "py-1"}`}
       >
         {selectMode ? (
           <span


### PR DESCRIPTION
## What

The deferred performance item from Phase 4. Off-screen session rows now **skip layout/paint** via `content-visibility: auto` with a cached `contain-intrinsic-size`, so a project with many sessions — or many expanded projects — stays smooth without rendering every row.

## Why content-visibility, not a JS windowing library

This matches the repo's **established** virtualization strategy (`.cave-linear-turn` chat turns, `.library-doclist-item` library rows) instead of adding a `react-virtual`/`react-window` dependency. The decisive advantage for *this* surface: **rows stay in the DOM**, so everything built in earlier phases keeps working —
- the **keyboard roving nav** (queries live DOM; JS windowing would drop off-screen rows from the rove set),
- **dnd-kit** sortable reordering,
- the **right-click context menus**,
- and find-in-page.

A JS windowing lib would unmount off-screen rows and regress all of these.

## Why it's safe here

`content-visibility: auto` implies `contain: layout paint`, which makes the element a containing block for `position:fixed` descendants. The row's only fixed/portaled descendant — its context-menu anchor — is a **sibling** of the focusable row element, not a child, so it isn't trapped (the menu still opens at the cursor). The `auto` intrinsic-size caches each row's real height after first paint (across comfortable/compact densities), so scroll never jumps. Same reasoning the `library-doclist-item` comment documents.

## Verification
- `pnpm typecheck` clean · `projects-view.test.ts` extended (asserts the row class + the globals.css rule, mirroring the chat/library render-optimization tests) and green · `check:tests-wired` green (504)
- Live verification via run-cave-app with a long session list: rows render, focus ring intact, context menu still positions at the cursor, keyboard nav + drag still work (screenshots in thread)

No dependency added; no data-model/API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)