### PR TITLE
feat(gantt): overdue bar markers + drag a tray task onto the timeline

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -140,6 +140,9 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
       else next.add(cat);
       return next;
     });
+  // Drag an undated task from the tray onto the timeline to schedule it. dropDay
+  // is the day-offset under the cursor while dragging (drives a drop-hint line).
+  const [dropDay, setDropDay] = useState<number | null>(null);
   // "Today" depends on the clock, so resolve it after mount to avoid an SSR
   // hydration mismatch — the line just isn't drawn on the first client render.
   const [todayMs, setTodayMs] = useState<number | null>(null);
@@ -371,7 +374,15 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
           <ul style={{ listStyle: "none", margin: "6px 0 0", padding: 0, display: "flex", flexDirection: "column", gap: 4 }}>
             {unscheduledCards.map((c) => (
               <li key={c.id} style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 8 }}>
-                <button type="button" onClick={() => onSelect(c.id)} title="Open task" style={{ flex: 1, minWidth: 120, textAlign: "left", background: "none", border: "none", color: "var(--text-secondary)", cursor: "pointer", font: "inherit", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{c.title}</button>
+                <button
+                  type="button"
+                  draggable={!!onPatch}
+                  onDragStart={(e) => { e.dataTransfer.setData("text/cave-gantt-card", c.id); e.dataTransfer.effectAllowed = "move"; }}
+                  onDragEnd={() => setDropDay(null)}
+                  onClick={() => onSelect(c.id)}
+                  title={onPatch ? "Open task · drag onto the timeline to schedule" : "Open task"}
+                  style={{ flex: 1, minWidth: 120, textAlign: "left", background: "none", border: "none", color: "var(--text-secondary)", cursor: onPatch ? "grab" : "pointer", font: "inherit", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+                >{c.title}</button>
                 <span style={{ fontSize: 11, color: "var(--text-muted)" }}>{ownerName(c.familiarId)}</span>
                 {onPatch ? (
                   <span style={{ display: "inline-flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
@@ -440,10 +451,13 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
   }
 
   let todayX: number | null = null;
-  if (todayMs !== null) {
-    const now = new Date(todayMs);
-    const todayUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-    const offset = daysBetween(rangeStart, todayUtc);
+  // UTC midnight of "today" — also used to flag overdue bars (end before today).
+  const todayStartMs =
+    todayMs === null
+      ? null
+      : Date.UTC(new Date(todayMs).getUTCFullYear(), new Date(todayMs).getUTCMonth(), new Date(todayMs).getUTCDate());
+  if (todayStartMs !== null) {
+    const offset = daysBetween(rangeStart, new Date(todayStartMs));
     if (offset >= 0 && offset <= totalDays) todayX = offset * DAY_W + DAY_W / 2;
   }
 
@@ -463,6 +477,31 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
     return true;
   };
   centerOnTodayRef.current = scrollToToday;
+
+  // Drag-from-tray: map the cursor's x (within the scrolled timeline, minus the
+  // sticky left table) to a day-offset in range.
+  const dayFromClientX = (clientX: number): number | null => {
+    const el = scrollRef.current;
+    if (!el) return null;
+    const xInTimeline = clientX - el.getBoundingClientRect().left + el.scrollLeft - LEFT_W;
+    if (xInTimeline < 0) return null;
+    return Math.max(0, Math.min(totalDays - 1, Math.floor(xInTimeline / DAY_W)));
+  };
+  const onTimelineDragOver = (e: React.DragEvent) => {
+    if (!onPatch || !e.dataTransfer.types.includes("text/cave-gantt-card")) return;
+    e.preventDefault(); // allow the drop
+    setDropDay(dayFromClientX(e.clientX));
+  };
+  const onTimelineDrop = (e: React.DragEvent) => {
+    const cardId = e.dataTransfer.getData("text/cave-gantt-card");
+    setDropDay(null);
+    if (!onPatch || !cardId) return;
+    e.preventDefault();
+    const day = dayFromClientX(e.clientX);
+    if (day === null) return;
+    const date = fmtISO(addDays(rangeStart, day));
+    onPatch(cardId, { startDate: date, endDate: date });
+  };
 
   return (
     <div className="board-gantt">
@@ -538,12 +577,21 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
             </div>
           </div>
 
-          {/* Body: today line + grouped rows */}
-          <div className="cg-body">
+          {/* Body: today line + grouped rows. Also the drop zone for scheduling
+              an undated task dragged out of the tray. */}
+          <div
+            className="cg-body"
+            onDragOver={onTimelineDragOver}
+            onDrop={onTimelineDrop}
+            onDragLeave={() => setDropDay(null)}
+          >
             {todayX !== null ? (
               <span className="cg-today" style={{ left: `calc(${LEFT_W}px + ${todayX}px)` }} aria-hidden>
                 <span className="cg-today__flag">TODAY</span>
               </span>
+            ) : null}
+            {dropDay !== null ? (
+              <span className="cg-drop-hint" style={{ left: `calc(${LEFT_W}px + ${dropDay * DAY_W}px)`, width: `${DAY_W}px` }} aria-hidden />
             ) : null}
 
             {visibleGroups.map((g) => (
@@ -584,8 +632,12 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
                   const left = previewOffset * DAY_W;
                   const previewStart = addDays(start, mode === "resize-end" ? 0 : dragDelta);
                   const previewEnd = addDays(end, mode === "resize-start" ? 0 : dragDelta);
+                  // Overdue: bar ends before today and isn't done — mirrors the
+                  // Kanban urgency cue so the timeline shows slipping work.
+                  const overdue =
+                    todayStartMs !== null && cat !== "done" && previewEnd.getTime() < todayStartMs;
                   const barClass = (base: string) =>
-                    `${base}${draggable ? " cg-bar--grab" : ""}${dragging ? " cg-bar--dragging" : ""}`;
+                    `${base}${draggable ? " cg-bar--grab" : ""}${dragging ? " cg-bar--dragging" : ""}${overdue ? " cg-bar--overdue" : ""}`;
                   const handlers = draggable
                     ? {
                         onPointerDown: (e: React.PointerEvent) => beginDrag(e, row.rowId, "move"),

--- a/src/components/board-schedule-window.test.ts
+++ b/src/components/board-schedule-window.test.ts
@@ -156,4 +156,19 @@ assert.match(styles, /\.cg-month \{/, "month segments are styled");
 assert.match(styles, /var\(--cg-weekend-shift, 0px\) 0/, "weekend shading is offset by the CSS var");
 assert.match(styles, /var\(--cg-today-x, -9999px\)/, "the today column tint reads the CSS var");
 
+// Overdue marker: a bar that ends before today and isn't done gets flagged
+// (mirrors the Kanban urgency cue).
+assert.match(gantt, /const overdue =\s*todayStartMs !== null && cat !== "done" && previewEnd\.getTime\(\) < todayStartMs/, "overdue is derived from end-before-today + not done");
+assert.match(gantt, /overdue \? " cg-bar--overdue" : ""/, "overdue bars get a marker class");
+assert.match(styles, /\.cg-bar--overdue/, "overdue bars are styled");
+
+// Drag an undated task from the tray onto the timeline to schedule it.
+assert.match(gantt, /draggable=\{!!onPatch\}/, "tray tasks are draggable when editable");
+assert.match(gantt, /e\.dataTransfer\.setData\("text\/cave-gantt-card", c\.id\)/, "the drag carries the card id");
+assert.match(gantt, /const onTimelineDrop = \(e: React\.DragEvent\)/, "the timeline accepts drops");
+assert.match(gantt, /onPatch\(cardId, \{ startDate: date, endDate: date \}\)/, "dropping schedules the task at the drop day");
+assert.match(gantt, /onDragOver=\{onTimelineDragOver\}[\s\S]{0,80}onDrop=\{onTimelineDrop\}/, "the body is wired as the drop zone");
+assert.match(gantt, /className="cg-drop-hint"/, "a drop-hint marks the landing day");
+assert.match(styles, /\.cg-drop-hint/, "the drop hint is styled");
+
 console.log("board-schedule-window.test.ts: ok");

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1847,6 +1847,11 @@
 .cg-bar--dragging { z-index: 4; filter: brightness(1.12); box-shadow: 0 2px 8px rgb(0 0 0 / 0.35); }
 .cg-diamond.cg-bar--dragging { transform: translate(-50%, -50%) rotate(45deg) scale(1.15); }
 .cg-row:has(.cg-bar--dragging) { user-select: none; }
+/* overdue bar: ended before today and not done — outline + danger ring */
+.cg-bar--overdue { outline: 1.5px solid var(--color-danger); outline-offset: 1px; }
+.cg-diamond.cg-bar--overdue { outline: none; box-shadow: 0 0 0 1.5px var(--color-danger); }
+/* drop hint while dragging an undated task onto the timeline */
+.cg-drop-hint { position: absolute; top: 0; bottom: 0; z-index: 3; background: color-mix(in oklch, var(--accent-presence) 22%, transparent); border-left: 2px solid var(--accent-presence); border-right: 2px solid var(--accent-presence); pointer-events: none; }
 .cg-drag-label {
   position: absolute; top: -2px; transform: translateY(-100%);
   font-size: 10px; font-weight: 600; color: var(--text-primary);


### PR DESCRIPTION
Two Gantt wins (from the UX backlog):

## 1. Overdue bar markers
Kanban/mobile flag overdue work via `scheduleUrgency`, but the Gantt colored bars only by status. Now a bar whose **end is before today and isn't done** gets a red outline (a milestone diamond gets a danger ring), so slipping work is visible on the timeline.

## 2. Drag a tray task onto the timeline to schedule it
Undated tasks in the tray are now **draggable**; dropping one on the timeline sets its start/end to the **drop day**, with a live **drop-hint** marking the landing column. More direct than the existing "This week / Next week" presets (which stay).

## Verification
- `pnpm typecheck` clean; `app` suite → **384 files pass** (assertions added to `board-schedule-window.test.ts`).
- Browser-driven: a task ending before today shows exactly 1 overdue bar; a synthetic tray→timeline drop fires `PATCH {startDate, endDate}` at the drop day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)