### PR TITLE
feat(ios): consume /api/theme so the app chrome matches the desktop

### DIFF
--- a/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
+++ b/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
@@ -8,7 +8,12 @@ struct CovenCaveApp: App {
         WindowGroup {
             RootView()
                 .environment(app)
-                .preferredColorScheme(.dark)
+                // Match the desktop appearance: propagate its palette to every
+                // view, tint app-wide controls with its accent, and follow its
+                // light/dark mode (defaults to dark until a theme loads).
+                .environment(\.chrome, app.chrome)
+                .tint(app.chrome.accent)
+                .preferredColorScheme(app.chrome.colorScheme)
                 .task {
                     if app.connection != nil {
                         await app.refreshConnection()

--- a/apps/ios/CovenCave/CovenCave/Models/Models.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/Models.swift
@@ -30,6 +30,23 @@ struct FamiliarsResponse: Codable {
     let familiars: [Familiar]
 }
 
+// MARK: - Theme
+
+/// The desktop's published appearance (`GET /api/theme`). `tokens` are resolved
+/// hex strings keyed by CSS custom-property name (e.g. `--bg-base`), so the app
+/// can use them directly without knowing the desktop's CSS preset definitions.
+struct ThemeSnapshot: Codable {
+    var themeId: String
+    var mode: String
+    var tokens: [String: String]
+    var updatedAt: String
+}
+
+struct ThemeResponse: Codable {
+    let ok: Bool
+    let theme: ThemeSnapshot
+}
+
 // MARK: - Sessions
 
 /// A chat session as returned by `GET /api/sessions/list`.

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -330,6 +330,22 @@ struct CaveClient {
         return try JSONDecoder().decode(RouteLinkResult.self, from: data)
     }
 
+    // MARK: - Theme
+
+    /// `GET /api/theme` — the desktop's active theme + resolved colour tokens, so
+    /// the app chrome can match the desktop appearance. Same connection as
+    /// `api/familiars` etc.; one-way (desktop → iOS).
+    func fetchTheme() async throws -> ThemeSnapshot {
+        let req = try request("api/theme")
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        do {
+            return try JSONDecoder().decode(ThemeResponse.self, from: data).theme
+        } catch {
+            throw CaveError.decoding(String(describing: error))
+        }
+    }
+
     // MARK: - Reading list (library)
 
     private struct ReadingListResponse: Decodable { var items: [ReadingItem] }

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -106,6 +106,24 @@ final class AppModel {
     var projectsError: String?
     var projectsLoaded = false
 
+    // MARK: - Appearance (desktop theme)
+
+    /// App-chrome palette mirrored from the desktop's published theme
+    /// (`GET /api/theme`). Starts at the built-in look and is replaced once the
+    /// desktop theme loads. One-way (desktop → iOS), per the design.
+    var chrome: ChromePalette = .fallback
+
+    /// Fetch the desktop theme and adopt its palette. Best-effort: on any
+    /// failure the current palette stands, so there's no flash back to the
+    /// fallback when a poll briefly can't reach the desktop.
+    func loadTheme() async {
+        guard let client else { return }
+        if let snapshot = try? await client.fetchTheme() {
+            let next = ChromePalette(snapshot: snapshot)
+            if next != chrome { chrome = next }
+        }
+    }
+
     var client: CaveClient? {
         guard let connection else { return nil }
         return CaveClient(connection: connection)
@@ -412,6 +430,7 @@ final class AppModel {
         }
         connectionState = .connected
         await loadFamiliars()
+        await loadTheme()
     }
 
     /// Probe candidate base URLs in order; return the first that answers. Uses a

--- a/apps/ios/CovenCave/CovenCave/Theme/Theme.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/Theme.swift
@@ -1,4 +1,62 @@
 import SwiftUI
+import UIKit
+
+// MARK: - App-chrome palette
+
+/// The desktop's active appearance, resolved from the colour tokens it publishes
+/// at `GET /api/theme`. Every colour defaults to the value the app shipped with,
+/// so a missing or partial payload (the desktop hasn't published a theme yet, or
+/// only sent some tokens) never produces an unreadable screen — and `.fallback`
+/// is exactly the pre-theme look, so nothing changes until a theme arrives.
+struct ChromePalette: Equatable {
+    var bgBase: Color = Color(uiColor: .systemBackground)
+    var bgRaised: Color = Color(uiColor: .secondarySystemBackground)
+    var bgElevated: Color = Color(uiColor: .tertiarySystemBackground)
+    var textPrimary: Color = .primary
+    var textSecondary: Color = .secondary
+    var textMuted: Color = Color(uiColor: .tertiaryLabel)
+    var border: Color = Color(uiColor: .separator)
+    /// `accent` mirrors the asset-catalog accent, so `.tint(accent)` is a no-op
+    /// until the desktop publishes `--accent-presence`.
+    var accent: Color = .accentColor
+    /// Drives `preferredColorScheme` so the whole app flips light/dark with the
+    /// desktop. Defaults to dark — the app's original fixed scheme.
+    var colorScheme: ColorScheme = .dark
+
+    /// The built-in look used before (and as a backstop after) a theme loads.
+    static let fallback = ChromePalette()
+}
+
+extension ChromePalette {
+    /// Build a palette from a published theme, keeping the fallback colour for
+    /// any token the desktop didn't send.
+    init(snapshot: ThemeSnapshot) {
+        self.init()
+        let t = snapshot.tokens
+        if let c = Color(hex: t["--bg-base"]) { bgBase = c }
+        if let c = Color(hex: t["--bg-raised"]) { bgRaised = c }
+        if let c = Color(hex: t["--bg-elevated"]) { bgElevated = c }
+        if let c = Color(hex: t["--text-primary"]) { textPrimary = c }
+        if let c = Color(hex: t["--text-secondary"]) { textSecondary = c }
+        if let c = Color(hex: t["--text-muted"]) { textMuted = c }
+        if let c = Color(hex: t["--border-hairline"]) { border = c }
+        if let c = Color(hex: t["--accent-presence"]) { accent = c }
+        colorScheme = snapshot.mode.lowercased() == "light" ? .light : .dark
+    }
+}
+
+/// Reach the desktop palette from any view (`@Environment(\.chrome)`); defaults
+/// to the built-in look so previews and disconnected screens still render.
+private struct ChromePaletteKey: EnvironmentKey {
+    static let defaultValue: ChromePalette = .fallback
+}
+
+extension EnvironmentValues {
+    var chrome: ChromePalette {
+        get { self[ChromePaletteKey.self] }
+        set { self[ChromePaletteKey.self] = newValue }
+    }
+}
 
 extension Color {
     /// Parse a `#RRGGBB` / `#RRGGBBAA` hex string. Returns nil if unparseable.

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -63,6 +63,15 @@ struct MainTabView: View {
                 .keyboardShortcut(KeyEquivalent(Character("\(index + 1)")), modifiers: .command)
             }
         }
+        // Keep the app chrome in step with desktop theme changes: re-fetch while
+        // connected. `loadTheme` is best-effort and only assigns on change, so an
+        // unchanged theme is a cheap no-op.
+        .task {
+            while !Task.isCancelled {
+                if app.connectionState == .connected { await app.loadTheme() }
+                try? await Task.sleep(for: .seconds(20))
+            }
+        }
     }
 }
 

--- a/scripts/ios-theme.test.mjs
+++ b/scripts/ios-theme.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+
+const base = "apps/ios/CovenCave/CovenCave";
+const models = await read(`${base}/Models/Models.swift`);
+const theme = await read(`${base}/Theme/Theme.swift`);
+const client = await read(`${base}/Networking/CaveClient.swift`);
+const model = await read(`${base}/State/AppModel.swift`);
+const app = await read(`${base}/CovenCaveApp.swift`);
+const root = await read(`${base}/Views/RootView.swift`);
+
+// --- Contract types decode GET /api/theme -----------------------------------
+
+assert.match(
+  models,
+  /struct ThemeSnapshot: Codable \{[\s\S]*var themeId: String[\s\S]*var mode: String[\s\S]*var tokens: \[String: String\][\s\S]*var updatedAt: String/,
+  "Models should define ThemeSnapshot mirroring the /api/theme payload",
+);
+assert.match(
+  models,
+  /struct ThemeResponse: Codable \{[\s\S]*let theme: ThemeSnapshot/,
+  "Models should define the { ok, theme } envelope as ThemeResponse",
+);
+
+// --- ChromePalette resolves token hexes with fallbacks ----------------------
+
+assert.match(theme, /struct ChromePalette: Equatable/, "Theme should define ChromePalette");
+assert.match(
+  theme,
+  /static let fallback = ChromePalette\(\)/,
+  "ChromePalette should expose a built-in fallback palette",
+);
+assert.match(
+  theme,
+  /init\(snapshot: ThemeSnapshot\)/,
+  "ChromePalette should build from a ThemeSnapshot",
+);
+for (const token of [
+  "--bg-base",
+  "--bg-raised",
+  "--bg-elevated",
+  "--text-primary",
+  "--text-secondary",
+  "--text-muted",
+  "--border-hairline",
+  "--accent-presence",
+]) {
+  assert.match(
+    theme,
+    new RegExp(`Color\\(hex: t\\["${token}"\\]\\)`),
+    `ChromePalette should read the ${token} token`,
+  );
+}
+assert.match(
+  theme,
+  /colorScheme = snapshot\.mode\.lowercased\(\) == "light" \? \.light : \.dark/,
+  "ChromePalette should derive light/dark from the theme mode",
+);
+// Exposed through the environment for incremental per-view adoption.
+assert.match(
+  theme,
+  /extension EnvironmentValues \{[\s\S]*var chrome: ChromePalette/,
+  "ChromePalette should be reachable via @Environment(\\.chrome)",
+);
+
+// --- Client fetches the theme -----------------------------------------------
+
+assert.match(
+  client,
+  /func fetchTheme\(\) async throws -> ThemeSnapshot \{[\s\S]*request\("api\/theme"\)[\s\S]*decode\(ThemeResponse\.self/,
+  "CaveClient.fetchTheme should GET api/theme and decode ThemeResponse",
+);
+
+// --- AppModel holds + loads the palette, on connect -------------------------
+
+assert.match(model, /var chrome: ChromePalette = \.fallback/, "AppModel should hold a chrome palette");
+assert.match(
+  model,
+  /func loadTheme\(\) async \{[\s\S]*client\.fetchTheme\(\)[\s\S]*ChromePalette\(snapshot: snapshot\)/,
+  "AppModel.loadTheme should fetch and adopt the desktop palette",
+);
+assert.match(
+  model,
+  /await loadFamiliars\(\)\s*\n\s*await loadTheme\(\)/,
+  "refreshConnection should load the theme on connect",
+);
+
+// --- App chrome applies accent, mode, and propagates the palette ------------
+
+assert.match(app, /\.environment\(\\\.chrome, app\.chrome\)/, "App should inject the chrome palette");
+assert.match(app, /\.tint\(app\.chrome\.accent\)/, "App should tint controls with the desktop accent");
+assert.match(
+  app,
+  /\.preferredColorScheme\(app\.chrome\.colorScheme\)/,
+  "App should follow the desktop light/dark mode (not a hardcoded scheme)",
+);
+assert.doesNotMatch(
+  app,
+  /\.preferredColorScheme\(\.dark\)/,
+  "App should no longer hardcode the dark color scheme",
+);
+
+// --- Theme is kept fresh while connected ------------------------------------
+
+assert.match(
+  root,
+  /connectionState == \.connected \{ await app\.loadTheme\(\) \}/,
+  "MainTabView should poll the theme while connected",
+);
+
+console.log("ios-theme: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -518,6 +518,7 @@ export const SUITES = {
     "scripts/ios-export-selected-zip.test.mjs",
     "scripts/ios-reorder-familiars.test.mjs",
     "scripts/ios-github-comment-attach.test.mjs",
+    "scripts/ios-theme.test.mjs",
     "scripts/mobile-tailscale.test.mjs",
     "scripts/mobile-tailscale-native.test.mjs",
     "src/components/mobile-handoff.test.ts",


### PR DESCRIPTION
Closes #1413.

The desktop publishes its active theme + resolved colour tokens at `GET /api/theme`. The native SwiftUI app now consumes it so its appearance matches the desktop. One-way (desktop → iOS), as requested.

## What changed
- **`CaveClient.fetchTheme()`** — GETs `api/theme` over the same tailnet connection as `api/familiars`, decoding the `{ ok, theme }` envelope (`ThemeSnapshot` / `ThemeResponse` in `Models.swift`).
- **`ChromePalette` (`Theme.swift`)** — builds an app-chrome palette (`bgBase/raised/elevated`, `text*`, `border`, `accent`, `colorScheme`) from the resolved token hexes. Each colour **falls back per-token to the built-in look**, so a missing/partial payload never produces an unreadable screen. Reachable from any view via `@Environment(\.chrome)` for incremental per-view adoption.
- **`AppModel`** — `chrome` palette state + `loadTheme()`; fetched on connect (`refreshConnection`) and polled every 20s while connected (`MainTabView`) so desktop theme changes propagate. Only reassigns on change (cheap no-op otherwise).
- **App root** — tints all controls with `--accent-presence` and follows the desktop **light/dark mode** instead of the previously hardcoded `.preferredColorScheme(.dark)`.

## Scope note
This delivers the full data plumbing + app-wide accent/colour-scheme + an `\.chrome` environment value. Repainting every individual surface's backgrounds/text/borders from the palette is left as **incremental adoption** through `\.chrome` — deliberately, to avoid broad collisions on the coordinated iOS surface (see `docs/ios-native-rebuild.md`). Branched off the latest `origin/main`; no open PR touches these files.

## Verification
- `xcodebuild` for the iPhone 16 Pro simulator: **BUILD SUCCEEDED**.
- New source-text contract test `scripts/ios-theme.test.mjs` (wired into the `mobile` suite); all 24 `ios-*` source-text tests pass; `check:tests-wired` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)