### PR TITLE
feat(library): bulk-select for the Bookmarks & GitHub lists

### DIFF
--- a/src/components/library-bookmarks-list.tsx
+++ b/src/components/library-bookmarks-list.tsx
@@ -179,6 +179,8 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [adding, setAdding] = useState(false);
   const [addError, setAddError] = useState<string | null>(null);
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
   const [addedToBoardId, setAddedToBoardId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -264,6 +266,36 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
     undoDelete();
   }
 
+  // Bulk-select: pick several bookmarks and remove them at once.
+  const allSelected = items.length > 0 && items.every((i) => selectedIds.has(i.id));
+  const selectedCount = items.filter((i) => selectedIds.has(i.id)).length;
+  const toggleSelect = (id: string) =>
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  const exitSelect = () => { setSelectMode(false); setSelectedIds(new Set()); };
+  const toggleSelectAll = () =>
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (allSelected) items.forEach((i) => next.delete(i.id));
+      else items.forEach((i) => next.add(i.id));
+      return next;
+    });
+  function bulkDelete() {
+    const ids = items.filter((i) => selectedIds.has(i.id)).map((i) => i.id);
+    if (ids.length === 0) return;
+    setItems((prev) => prev.filter((i) => !ids.includes(i.id)));
+    void Promise.all(
+      ids.map((id) =>
+        fetch(`/api/library/bookmarks?id=${encodeURIComponent(id)}`, { method: "DELETE" }).then(() => {}).catch(() => {}),
+      ),
+    );
+    exitSelect();
+  }
+
   return (
     <div className="library-list-shell">
       {/* Header */}
@@ -274,6 +306,18 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
           <span className="board-table-group-badge">{items.length}</span>
         </span>
         <div className="library-list-header-controls">
+          {items.length > 0 ? (
+            <button
+              type="button"
+              className="board-toolbar-btn"
+              onClick={() => { setSelectMode((v) => !v); setSelectedIds(new Set()); }}
+              aria-pressed={selectMode}
+              aria-label={selectMode ? "Exit select mode" : "Select multiple bookmarks"}
+              title={selectMode ? "Exit select" : "Select multiple"}
+            >
+              <Icon name="ph:list-checks-bold" width={12} />
+            </button>
+          ) : null}
           <div className="library-bookmark-selector">
             <button
               ref={groupSelectorRef}
@@ -332,6 +376,24 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
           </button>
         </div>
       </div>
+
+      {selectMode ? (
+        <div className="library-bulk-bar">
+          <div className="library-bulk-bar__left">
+            <button type="button" className="library-bulk-bar__link" onClick={toggleSelectAll}>
+              {allSelected ? "Clear" : "Select all"}
+            </button>
+            <span className="library-bulk-bar__count">{selectedCount} selected</span>
+          </div>
+          <div className="library-bulk-bar__right">
+            <button type="button" className="library-bulk-bar__link" onClick={exitSelect}>Cancel</button>
+            <button type="button" className="library-bulk-bar__delete" disabled={selectedCount === 0} onClick={bulkDelete}>
+              <Icon name="ph:trash" width={11} aria-hidden />
+              Remove{selectedCount ? ` ${selectedCount}` : ""}
+            </button>
+          </div>
+        </div>
+      ) : null}
 
       <div className="library-doclist-search">
         <Icon name="ph:magnifying-glass" width={13} className="library-doclist-search-icon" />
@@ -438,10 +500,16 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
                   )}
                   {!collapsed.has(key) && gi.map((item) => (
                     <tr key={`${key}:${item.id || item.url}`}
-                      className={item.id === selectedId ? "selected" : ""}
-                      onClick={() => onSelect(item)}>
+                      className={`${item.id === selectedId ? "selected" : ""}${selectMode && selectedIds.has(item.id) ? " is-selected" : ""}`}
+                      aria-selected={selectMode ? selectedIds.has(item.id) : undefined}
+                      onClick={() => { if (selectMode) { toggleSelect(item.id); return; } onSelect(item); }}>
                       <td>
                         <span className="board-table-title library-title-cell">
+                          {selectMode ? (
+                            <span aria-hidden className="library-bulk-check" data-checked={selectedIds.has(item.id) ? "true" : undefined}>
+                              <Icon name="ph:check-bold" width={10} aria-hidden />
+                            </span>
+                          ) : null}
                           <ItemFavicon url={item.url} title={item.title} />
                           <a
                             href={item.url}
@@ -463,6 +531,7 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
                         <RelativeTime iso={item.savedAt} className="board-table-muted" />
                       </td>
                       <td onClick={(e) => e.stopPropagation()}>
+                        {selectMode ? null : (
                         <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
                           {onAddToBoard && (
                             addedToBoardId === item.id ? (
@@ -499,6 +568,7 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
                             <Icon name="ph:x" width={11} />
                           </button>
                         </span>
+                        )}
                       </td>
                     </tr>
                   ))}

--- a/src/components/library-github-list.tsx
+++ b/src/components/library-github-list.tsx
@@ -592,6 +592,8 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [adding, setAdding] = useState(false);
   const [addError, setAddError] = useState<string | null>(null);
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
   const [attachItem, setAttachItem] = useState<LibraryGitHubItem | null>(null);
   const [handoffItem, setHandoffItem] = useState<LibraryGitHubItem | null>(null);
   const [query, setQuery] = useState("");
@@ -656,6 +658,36 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
     undoDelete();
   }
 
+  // Bulk-select: pick several GitHub items and remove them at once.
+  const allSelected = items.length > 0 && items.every((i) => selectedIds.has(i.id));
+  const selectedCount = items.filter((i) => selectedIds.has(i.id)).length;
+  const toggleSelect = (id: string) =>
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  const exitSelect = () => { setSelectMode(false); setSelectedIds(new Set()); };
+  const toggleSelectAll = () =>
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (allSelected) items.forEach((i) => next.delete(i.id));
+      else items.forEach((i) => next.add(i.id));
+      return next;
+    });
+  function bulkDelete() {
+    const ids = items.filter((i) => selectedIds.has(i.id)).map((i) => i.id);
+    if (ids.length === 0) return;
+    setItems((prev) => prev.filter((i) => !ids.includes(i.id)));
+    void Promise.all(
+      ids.map((id) =>
+        fetch(`/api/library/github?id=${encodeURIComponent(id)}`, { method: "DELETE" }).then(() => {}).catch(() => {}),
+      ),
+    );
+    exitSelect();
+  }
+
   return (
     <div className="library-list-shell">
       {/* Header */}
@@ -666,6 +698,18 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
           <span className="board-table-group-badge">{items.length}</span>
         </span>
         <div className="library-list-header-controls">
+          {items.length > 0 ? (
+            <button
+              type="button"
+              className="board-toolbar-btn"
+              onClick={() => { setSelectMode((v) => !v); setSelectedIds(new Set()); }}
+              aria-pressed={selectMode}
+              aria-label={selectMode ? "Exit select mode" : "Select multiple GitHub items"}
+              title={selectMode ? "Exit select" : "Select multiple"}
+            >
+              <Icon name="ph:list-checks-bold" width={12} />
+            </button>
+          ) : null}
           <select
             className="board-toolbar-select"
             value={groupBy}
@@ -687,6 +731,24 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
           </button>
         </div>
       </div>
+
+      {selectMode ? (
+        <div className="library-bulk-bar">
+          <div className="library-bulk-bar__left">
+            <button type="button" className="library-bulk-bar__link" onClick={toggleSelectAll}>
+              {allSelected ? "Clear" : "Select all"}
+            </button>
+            <span className="library-bulk-bar__count">{selectedCount} selected</span>
+          </div>
+          <div className="library-bulk-bar__right">
+            <button type="button" className="library-bulk-bar__link" onClick={exitSelect}>Cancel</button>
+            <button type="button" className="library-bulk-bar__delete" disabled={selectedCount === 0} onClick={bulkDelete}>
+              <Icon name="ph:trash" width={11} aria-hidden />
+              Remove{selectedCount ? ` ${selectedCount}` : ""}
+            </button>
+          </div>
+        </div>
+      ) : null}
 
       <div className="library-doclist-search">
         <Icon name="ph:magnifying-glass" width={13} className="library-doclist-search-icon" />
@@ -778,11 +840,17 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
                     return (
                       <React.Fragment key={item.id}>
                         <tr
-                          className={`gh-row-main${item.id === selectedId ? " selected" : ""}`}
-                          onClick={() => onSelect(item)}
+                          className={`gh-row-main${item.id === selectedId ? " selected" : ""}${selectMode && selectedIds.has(item.id) ? " is-selected" : ""}`}
+                          aria-selected={selectMode ? selectedIds.has(item.id) : undefined}
+                          onClick={() => { if (selectMode) { toggleSelect(item.id); return; } onSelect(item); }}
                         >
                           <td className="gh-col-title">
                             <div className="gh-title-cell">
+                              {selectMode ? (
+                                <span aria-hidden className="library-bulk-check" data-checked={selectedIds.has(item.id) ? "true" : undefined}>
+                                  <Icon name="ph:check-bold" width={10} aria-hidden />
+                                </span>
+                              ) : null}
                               <span className="board-table-title gh-title-text">{item.title}</span>
                               <a
                                 href={item.url}

--- a/src/components/library-polish.test.ts
+++ b/src/components/library-polish.test.ts
@@ -703,3 +703,14 @@ assert.match(reading, /Promise\.all\(\s*ids\.map\(\(id\) =>\s*fetch\(`\/api\/lib
 assert.match(reading, /\{allSelected \? "Clear" : "Select all"\}/, "the bulk bar offers select-all / clear");
 assert.match(libraryCss, /\.library-bulk-bar \{/, "the bulk toolbar is styled");
 assert.match(libraryCss, /\.library-bulk-check\[data-checked="true"\]/, "the row checkbox has a checked state");
+
+// Bulk-select extends to the bookmarks + GitHub lists (same pattern, same CSS).
+for (const [name, src, api] of [["bookmarks", bookmarks, "bookmarks"], ["github", github, "github"]]) {
+  assert.match(src, /const \[selectMode, setSelectMode\] = useState\(false\)/, `${name} list has a select mode`);
+  assert.match(src, /const \[selectedIds, setSelectedIds\] = useState<Set<string>>/, `${name} selected ids live in a Set`);
+  assert.match(src, /if \(selectMode\) \{ toggleSelect\(item\.id\); return; \}/, `${name} row selects in select mode, otherwise opens`);
+  assert.match(src, /function bulkDelete\(\)/, `${name} has a bulk remove handler`);
+  assert.match(src, new RegExp(`fetch\\(\`/api/library/${api}\\?id=`), `${name} bulk remove hits its delete endpoint`);
+  assert.match(src, /\{allSelected \? "Clear" : "Select all"\}/, `${name} bulk bar offers select-all / clear`);
+  assert.match(src, /className="library-bulk-check"/, `${name} rows show a checkbox in select mode`);
+}


### PR DESCRIPTION
Completes the Library multiselect pattern. The reading list got bulk-select in #1705; this extends the same treatment to the two remaining Library lists.

## What
- **Bookmarks** and **GitHub** lists each get a **Select** toggle in the header → rows become checkboxes (click selects instead of opening) → a toolbar with **Select all / Clear**, **N selected**, **Cancel**, and bulk **Remove**.
- Bulk remove is optimistic and fires the per-item `DELETE /api/library/{bookmarks,github}?id=` calls in parallel.
- Reuses the existing `.library-bulk-*` styles from #1705 — **no new CSS**.

With this, multiselect bulk actions now exist on Projects, Board, Automations, Chats, and all of Library.

## Verification
- `pnpm typecheck` clean; `app` suite → **385 files pass** (assertions added to `library-polish.test.ts` covering both lists).
- Browser-driven (bookmarks): Select → 3 checkboxes → select 2 → "Remove 2" → fires `DELETE` for both. GitHub uses the identical wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)