### PR TITLE
feat(projects): type-ahead jump in keyboard navigation

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -129,6 +129,7 @@ export const SUITES = {
     "src/lib/projects/projects-ui-state.test.ts",
     "src/lib/projects/session-glyph.test.ts",
     "src/lib/projects/project-stats.test.ts",
+    "src/lib/projects/type-ahead.test.ts",
     "src/components/onboarding-guided-steps.test.ts",
     "src/components/familiar-studio.test.ts",
     "src/components/familiar-studio-look-tab.test.ts",

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -386,4 +386,20 @@ assert.match(
   "session rows set content-visibility:auto with a cached intrinsic-size",
 );
 
+// Type-ahead jump: typing letters moves focus to the next project/session whose
+// label matches, staying in sync with the roving tab stop (pure matcher).
+assert.match(projectsView, /import \{ nextTypeAheadIndex \} from "@\/lib\/projects\/type-ahead"/, "uses the pure type-ahead matcher");
+assert.match(projectsView, /const \{ setActiveIndex \} = useRovingTabIndex/, "captures the roving setActiveIndex to keep nav in sync");
+// Each rove stop carries a clean label to match against (not the aria-label,
+// which is prefixed with Expand/Collapse).
+assert.match(projectsView, /data-proj-label=\{project\.name\}/, "project headers expose their name for type-ahead");
+assert.match(projectsView, /data-proj-label=\{title\}/, "session rows expose their title for type-ahead");
+// The handler ignores modifiers/fields, accumulates a buffer that resets on a
+// pause, and focuses the match.
+assert.match(projectsView, /e\.key\.length !== 1 \|\| e\.metaKey \|\| e\.ctrlKey \|\| e\.altKey/, "type-ahead only handles plain printable keys");
+assert.match(projectsView, /state\.buffer \+= e\.key/, "keystrokes accumulate into a type-ahead buffer");
+assert.match(projectsView, /typeAheadRef\.current\.buffer = ""/, "the buffer resets after a pause");
+assert.match(projectsView, /const next = nextTypeAheadIndex\(labels, current, state\.buffer\)/, "the next focus comes from the pure matcher");
+assert.match(projectsView, /items\[next\]\.focus\(\);\s*setActiveIndex\(next\)/, "a match focuses the item and updates the roving tab stop");
+
 console.log("projects-view.test.ts: ok");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -28,6 +28,7 @@ import type { ProjectsDensity } from "@/lib/projects/projects-ui-state";
 import { sessionGlyph, glyphToneClass, stripTaskPrefix } from "@/lib/projects/session-glyph";
 import { projectStats } from "@/lib/projects/project-stats";
 import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
+import { nextTypeAheadIndex } from "@/lib/projects/type-ahead";
 import { ContextMenu, openContextMenuAt, type ContextMenuState } from "@/components/ui/context-menu";
 import { PopoverItem, PopoverSeparator } from "@/components/ui/popover";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -181,6 +182,7 @@ function ProjectChatRow({
         aria-checked={selectMode ? selected : undefined}
         tabIndex={0}
         data-proj-nav
+        data-proj-label={title}
         onContextMenu={openContextMenuAt(setMenu)}
         onClick={activate}
         onKeyDown={(e) => {
@@ -519,6 +521,7 @@ function ProjectRow({
         <button
           type="button"
           data-proj-nav
+          data-proj-label={project.name}
           onClick={() => setExpanded((value) => !value)}
           onKeyDown={(e) => {
             // Tree-style disclosure: → expands, ← collapses (no-op when already
@@ -871,7 +874,43 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
   // headers + their visible session rows: ↑/↓ + Home/End move focus, Enter/Space
   // open/select (per-row handlers), and →/← expand/collapse a focused header.
   const listRef = useRef<HTMLElement>(null);
-  useRovingTabIndex({ containerRef: listRef, itemSelector: "[data-proj-nav]", orientation: "vertical" });
+  const { setActiveIndex } = useRovingTabIndex({ containerRef: listRef, itemSelector: "[data-proj-nav]", orientation: "vertical" });
+  // Type-ahead: typing letters jumps focus to the next project / session whose
+  // label starts with what you typed (Finder-style), staying in sync with the
+  // roving tab stop. The buffer resets after a short pause.
+  const typeAheadRef = useRef<{ buffer: string; timer: number }>({ buffer: "", timer: 0 });
+  useEffect(() => {
+    const container = listRef.current;
+    if (!container) return;
+    function onKey(e: KeyboardEvent) {
+      // Only printable single characters, no modifiers; never while typing in a
+      // field, and only when focus is on a navigable item in the list.
+      if (e.key.length !== 1 || e.metaKey || e.ctrlKey || e.altKey) return;
+      const t = e.target as HTMLElement | null;
+      if (!t || t.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName)) return;
+      if (!t.closest("[data-proj-nav]")) return;
+      const root = listRef.current;
+      if (!root) return;
+      const items = Array.from(root.querySelectorAll<HTMLElement>("[data-proj-nav]"));
+      if (items.length === 0) return;
+      e.preventDefault();
+      const state = typeAheadRef.current;
+      window.clearTimeout(state.timer);
+      state.buffer += e.key;
+      state.timer = window.setTimeout(() => {
+        typeAheadRef.current.buffer = "";
+      }, 600);
+      const labels = items.map((el) => el.getAttribute("data-proj-label") ?? el.textContent ?? "");
+      const current = items.indexOf(t.closest("[data-proj-nav]") as HTMLElement);
+      const next = nextTypeAheadIndex(labels, current, state.buffer);
+      if (next >= 0) {
+        items[next].focus();
+        setActiveIndex(next);
+      }
+    }
+    container.addEventListener("keydown", onKey);
+    return () => container.removeEventListener("keydown", onKey);
+  }, [setActiveIndex]);
   const [order, setOrder] = useState<string[]>([]);
   useEffect(() => {
     setOrder(readSessionOrder());

--- a/src/lib/projects/type-ahead.test.ts
+++ b/src/lib/projects/type-ahead.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+
+import { nextTypeAheadIndex } from "./type-ahead.ts";
+
+const labels = ["Alpha", "Beta", "berry", "Cherry", "apple"];
+
+// Empty inputs → no match.
+assert.equal(nextTypeAheadIndex([], 0, "a"), -1);
+assert.equal(nextTypeAheadIndex(labels, 0, ""), -1);
+
+// Single letter: jump to the next item starting with it (case-insensitive),
+// strictly after the current index.
+assert.equal(nextTypeAheadIndex(labels, 0, "b"), 1, "from Alpha, 'b' → Beta");
+assert.equal(nextTypeAheadIndex(labels, 1, "b"), 2, "from Beta, 'b' → berry (cycle)");
+assert.equal(nextTypeAheadIndex(labels, 2, "b"), 1, "from berry, 'b' → wraps back to Beta");
+assert.equal(nextTypeAheadIndex(labels, 0, "c"), 3, "'c' → Cherry");
+
+// Repeated same char ("aa") behaves like the single-letter cycle.
+assert.equal(nextTypeAheadIndex(labels, 0, "aa"), 4, "from Alpha, 'aa' → apple (next a)");
+assert.equal(nextTypeAheadIndex(labels, 4, "a"), 0, "from apple, 'a' → wraps to Alpha");
+
+// Multi-letter distinct buffer: prefix match starting AT current (refine in place).
+assert.equal(nextTypeAheadIndex(labels, 1, "be"), 1, "from Beta, 'be' stays on Beta");
+assert.equal(nextTypeAheadIndex(labels, 1, "ber"), 2, "'ber' → berry");
+assert.equal(nextTypeAheadIndex(labels, 0, "che"), 3, "'che' → Cherry");
+assert.equal(nextTypeAheadIndex(labels, 0, "zz"), -1, "no prefix match → -1");
+
+// Current index out of range is treated as 0.
+assert.equal(nextTypeAheadIndex(labels, -1, "c"), 3);
+// Clamped to 0, then the single-letter cycle advances PAST index 0 → apple (4).
+assert.equal(nextTypeAheadIndex(labels, 99, "a"), 4);
+
+console.log("type-ahead.test.ts: ok");

--- a/src/lib/projects/type-ahead.ts
+++ b/src/lib/projects/type-ahead.ts
@@ -1,0 +1,41 @@
+// Pure type-ahead matching for the Projects list's keyboard navigation: given
+// the visible item labels, the current focus index, and the accumulated typed
+// buffer, decide which item focus should jump to. No DOM — unit-testable.
+
+/**
+ * Next index for a type-ahead jump, or -1 when nothing matches.
+ *
+ * Two modes, matching common file-manager behavior:
+ *  - Buffer of one repeated character ("a", "aa", …) → cycle through items
+ *    starting with that letter, advancing past the current one each press.
+ *  - Any other (multi-character) buffer → match the full prefix, starting at the
+ *    current item so continued typing refines in place ("se" → "ses").
+ * Matching is case-insensitive and wraps around the list.
+ */
+export function nextTypeAheadIndex(
+  labels: readonly string[],
+  current: number,
+  buffer: string,
+): number {
+  const n = labels.length;
+  if (n === 0 || buffer.length === 0) return -1;
+  const buf = buffer.toLowerCase();
+  const from = current < 0 || current >= n ? 0 : current;
+  const allSame = [...buf].every((c) => c === buf[0]);
+
+  if (allSame) {
+    // Cycle by first letter, starting strictly after the current item.
+    for (let i = 1; i <= n; i++) {
+      const idx = (from + i) % n;
+      if (labels[idx].toLowerCase().startsWith(buf[0])) return idx;
+    }
+    return -1;
+  }
+
+  // Prefix match, starting at the current item (so refining keeps focus put).
+  for (let i = 0; i < n; i++) {
+    const idx = (from + i) % n;
+    if (labels[idx].toLowerCase().startsWith(buf)) return idx;
+  }
+  return -1;
+}


### PR DESCRIPTION
## What

A follow-up to the Projects native redesign's keyboard navigation. Typing letters while the Projects list has focus **jumps to the next project or session whose label starts with what you typed** (Finder/file-tree style), composing with the existing roving navigation.

- A single repeated letter cycles through matches; a multi-letter buffer refines in place; case-insensitive, wraps around.
- After a jump, arrow keys continue from the item you landed on (the handler updates the roving tab stop).

## How
- New pure `src/lib/projects/type-ahead.ts` (`nextTypeAheadIndex`) with unit tests — the where-does-focus-go decision lives in one testable place.
- Each rove stop (`[data-proj-nav]`) now also carries a clean `data-proj-label` (project name / session title) to match against — not the `aria-label`, which is prefixed "Expand/Collapse".
- The keydown handler ignores modifiers and text fields (so the inline rename/filter inputs type normally), accumulates a buffer that resets after ~600ms, focuses the match, and calls the roving hook's `setActiveIndex` to stay in sync.

## Verification
- `pnpm typecheck` clean · new `type-ahead.test.ts` + extended `projects-view.test.ts` green · `check:tests-wired` green (506)
- Live verification via run-cave-app: focus the list, type letters → focus jumps to the matching row (screenshots in thread)

No dependency added; no data-model/API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)