### PR TITLE
feat(ios): Reminders view with bulk-select delete

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/Reminder.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/Reminder.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// An inbox item from `GET /api/inbox`. The Reminders view shows the
+/// `kind == "reminder"` items. Only the fields the app uses are modelled —
+/// Codable ignores the rest (recurrence, media, source, …).
+struct Reminder: Identifiable, Codable, Hashable {
+    let id: String
+    var kind: String
+    var title: String
+    var body: String?
+    var status: String
+    var fireAt: String?
+    var firedAt: String?
+    var createdAt: String?
+    var updatedAt: String?
+
+    /// Best timestamp to show / sort by.
+    var whenISO: String? { fireAt ?? firedAt ?? createdAt }
+}
+
+struct InboxResponse: Decodable { let ok: Bool; let items: [Reminder] }

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -363,6 +363,27 @@ struct CaveClient {
         }
     }
 
+    /// `GET /api/inbox` — the reminders/inbox feed, filtered to reminders.
+    func reminders() async throws -> [Reminder] {
+        let req = try request("api/inbox")
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        do {
+            return try JSONDecoder().decode(InboxResponse.self, from: data).items
+                .filter { $0.kind == "reminder" }
+        } catch {
+            throw CaveError.decoding(String(describing: error))
+        }
+    }
+
+    /// `DELETE /api/inbox/{id}` — remove a reminder.
+    func deleteReminder(id: String) async throws {
+        let escaped = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+        let req = try request("api/inbox/\(escaped)", method: "DELETE")
+        let (_, resp) = try await session.data(for: req)
+        try Self.check(resp)
+    }
+
     private struct ReadingPatch: Encodable {
         var id: String
         var status: String

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -99,6 +99,10 @@ final class AppModel {
     var readingError: String?
     var readingLoaded = false
 
+    var reminders: [Reminder] = []
+    var remindersError: String?
+    var remindersLoaded = false
+
     // MARK: - Developer tab
 
     /// Configured project roots, shared across the Code and Terminal surfaces.
@@ -363,6 +367,32 @@ final class AppModel {
         } catch {
             reading = previous
             readingError = error.localizedDescription
+        }
+    }
+
+    // MARK: - Reminders
+
+    func loadReminders() async {
+        guard let client else { return }
+        do {
+            reminders = try await client.reminders()
+            remindersError = nil
+        } catch {
+            remindersError = error.localizedDescription
+        }
+        remindersLoaded = true
+    }
+
+    /// Optimistically remove reminders, then DELETE each; reverts on failure.
+    func deleteReminders(_ ids: Set<String>) async {
+        guard let client, !ids.isEmpty else { return }
+        let previous = reminders
+        reminders.removeAll { ids.contains($0.id) }
+        do {
+            for id in ids { try await client.deleteReminder(id: id) }
+        } catch {
+            reminders = previous
+            remindersError = error.localizedDescription
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/RemindersView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RemindersView.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+
+/// The reminders inbox (`GET /api/inbox`, `kind == "reminder"`). A read-only
+/// list — creating reminders is desktop-only — with a bulk-select mode to
+/// delete several at once (mirrors the chat bulk-delete pattern).
+struct RemindersView: View {
+    @Environment(AppModel.self) private var app
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectMode = false
+    @State private var selectedIds: Set<String> = []
+    @State private var confirmingBulkDelete = false
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Reminders")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Done") { dismiss() }
+                    }
+                    ToolbarItem(placement: .topBarTrailing) {
+                        if selectMode {
+                            Button("Cancel") { exitSelect() }
+                        } else if !app.reminders.isEmpty {
+                            Button("Select") { withAnimation { selectMode = true } }
+                        }
+                    }
+                }
+                .refreshable { await app.loadReminders() }
+                .task { if !app.remindersLoaded { await app.loadReminders() } }
+                .safeAreaInset(edge: .bottom) {
+                    if selectMode {
+                        HStack {
+                            Button(allSelected ? "Deselect All" : "Select All") { toggleSelectAll() }
+                            Spacer()
+                            Button(role: .destructive) { confirmingBulkDelete = true } label: {
+                                Text(selectedIds.isEmpty ? "Delete" : "Delete (\(selectedIds.count))")
+                                    .fontWeight(.semibold)
+                            }
+                            .disabled(selectedIds.isEmpty)
+                        }
+                        .padding(.horizontal, 20).padding(.vertical, 12)
+                        .background(.bar)
+                    }
+                }
+                .confirmationDialog(bulkTitle, isPresented: $confirmingBulkDelete, titleVisibility: .visible) {
+                    Button("Delete \(selectedIds.count)", role: .destructive) {
+                        Task { await app.deleteReminders(selectedIds); exitSelect() }
+                    }
+                    Button("Cancel", role: .cancel) {}
+                }
+        }
+    }
+
+    @ViewBuilder private var content: some View {
+        if !app.remindersLoaded {
+            ProgressView().controlSize(.large).frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error = app.remindersError, app.reminders.isEmpty {
+            ContentUnavailableView {
+                Label("Couldn’t load reminders", systemImage: "exclamationmark.triangle")
+            } description: { Text(error) } actions: {
+                Button("Retry") { Task { await app.loadReminders() } }.buttonStyle(.borderedProminent)
+            }
+        } else if app.reminders.isEmpty {
+            ContentUnavailableView {
+                Label("No reminders", systemImage: "bell")
+            } description: {
+                Text("Reminders you set on the desktop appear here.")
+            }
+        } else {
+            List {
+                ForEach(app.reminders) { reminder in
+                    Button { if selectMode { toggleSelection(reminder.id) } } label: {
+                        HStack(spacing: 12) {
+                            if selectMode {
+                                Image(systemName: selectedIds.contains(reminder.id) ? "checkmark.circle.fill" : "circle")
+                                    .font(.title3)
+                                    .foregroundStyle(selectedIds.contains(reminder.id) ? Color.accentColor : Color.secondary)
+                            }
+                            ReminderRow(reminder: reminder)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                        Button(role: .destructive) {
+                            Task { await app.deleteReminders([reminder.id]) }
+                        } label: { Label("Delete", systemImage: "trash") }
+                    }
+                }
+            }
+            .listStyle(.plain)
+        }
+    }
+
+    private var bulkTitle: String {
+        "Delete \(selectedIds.count) reminder\(selectedIds.count == 1 ? "" : "s")?"
+    }
+    private var allSelected: Bool {
+        !app.reminders.isEmpty && Set(app.reminders.map(\.id)).isSubset(of: selectedIds)
+    }
+    private func toggleSelection(_ id: String) {
+        if selectedIds.contains(id) { selectedIds.remove(id) } else { selectedIds.insert(id) }
+    }
+    private func toggleSelectAll() {
+        if allSelected { selectedIds.removeAll() } else { selectedIds = Set(app.reminders.map(\.id)) }
+    }
+    private func exitSelect() { withAnimation { selectMode = false; selectedIds.removeAll() } }
+}
+
+private struct ReminderRow: View {
+    let reminder: Reminder
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon).font(.title3).foregroundStyle(tint)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(reminder.title).font(.callout.weight(.medium)).lineLimit(2)
+                HStack(spacing: 6) {
+                    if let date = caveParseISO(reminder.whenISO) {
+                        Text(date, format: .relative(presentation: .numeric))
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                    Text(reminder.status.capitalized).font(.caption2).foregroundStyle(.tertiary)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 2)
+        .contentShape(Rectangle())
+    }
+    private var icon: String {
+        switch reminder.status {
+        case "done": return "checkmark.circle.fill"
+        case "snoozed": return "moon.zzz.fill"
+        case "fired": return "bell.fill"
+        default: return "bell"
+        }
+    }
+    private var tint: Color {
+        switch reminder.status {
+        case "done": return .green
+        case "fired": return .orange
+        default: return .secondary
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -19,6 +19,7 @@ struct TasksView: View {
     @State private var path: [BoardCard] = []
     /// A task awaiting delete confirmation (swipe or context menu).
     @State private var pendingDelete: BoardCard?
+    @State private var showReminders = false
 
     /// How the task list is partitioned into sections.
     enum GroupBy: String, CaseIterable, Identifiable {
@@ -51,6 +52,12 @@ struct TasksView: View {
                 .searchable(text: $query, prompt: "Search tasks")
                 .toolbar {
                     ToolbarItem(placement: .topBarTrailing) {
+                        Button { showReminders = true } label: {
+                            Image(systemName: "bell")
+                        }
+                        .accessibilityLabel("Reminders")
+                    }
+                    ToolbarItem(placement: .topBarTrailing) {
                         Menu {
                             Picker("Sort by", selection: $sortByRaw) {
                                 ForEach(SortBy.allCases) { s in
@@ -78,6 +85,7 @@ struct TasksView: View {
                     Button("Delete", role: .destructive) { Task { await app.deleteTask(card) } }
                     Button("Cancel", role: .cancel) {}
                 } message: { card in Text(card.title) }
+                .sheet(isPresented: $showReminders) { RemindersView() }
         }
     }
 

--- a/scripts/ios-reminders-bulk-delete.test.mjs
+++ b/scripts/ios-reminders-bulk-delete.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+const read = (rel) => readFile(new URL(`../${rel}`, import.meta.url), "utf8");
+const iosRoot = "apps/ios/CovenCave/CovenCave";
+
+const model = await read(`${iosRoot}/Models/Reminder.swift`);
+const client = await read(`${iosRoot}/Networking/CaveClient.swift`);
+const app = await read(`${iosRoot}/State/AppModel.swift`);
+const view = await read(`${iosRoot}/Views/RemindersView.swift`);
+const tasks = await read(`${iosRoot}/Views/TasksView.swift`);
+
+// Model + client speak the inbox contract.
+assert.match(model, /struct Reminder: Identifiable, Codable, Hashable/, "a Reminder model exists");
+assert.match(model, /struct InboxResponse: Decodable \{ let ok: Bool; let items: \[Reminder\] \}/, "inbox response wrapper");
+assert.match(client, /func reminders\(\) async throws -> \[Reminder\][\s\S]*request\("api\/inbox"\)[\s\S]*\.filter \{ \$0\.kind == "reminder" \}/, "reminders() GETs /api/inbox and filters reminders");
+assert.match(client, /func deleteReminder\(id: String\) async throws[\s\S]*method: "DELETE"/, "deleteReminder DELETEs /api/inbox/{id}");
+
+// Model bulk-deletes optimistically.
+assert.match(app, /var reminders: \[Reminder\] = \[\]/, "AppModel holds reminders");
+assert.match(app, /func loadReminders\(\) async/, "AppModel loads reminders");
+assert.match(
+  app,
+  /func deleteReminders\(_ ids: Set<String>\) async \{[\s\S]*reminders\.removeAll \{ ids\.contains\(\$0\.id\) \}[\s\S]*for id in ids \{ try await client\.deleteReminder\(id: id\) \}[\s\S]*catch[\s\S]*reminders = previous/,
+  "deleteReminders is optimistic + reverts on failure",
+);
+
+// View: bulk-select mode wired to deleteReminders, reachable from Tasks.
+assert.match(view, /struct RemindersView: View/, "a RemindersView exists");
+assert.match(view, /@State private var selectMode = false/, "view has a select mode");
+assert.match(view, /await app\.deleteReminders\(selectedIds\)/, "bulk delete uses the selection");
+assert.match(view, /Text\(selectedIds\.isEmpty \? "Delete" : "Delete \(\\\(selectedIds\.count\)\)"\)/, "Delete (N) bar");
+assert.match(tasks, /\.sheet\(isPresented: \$showReminders\) \{ RemindersView\(\) \}/, "Tasks tab opens Reminders");
+
+console.log("ios-reminders-bulk-delete.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -517,6 +517,7 @@ export const SUITES = {
     "scripts/ios-export-all-zip.test.mjs",
     "scripts/ios-bulk-delete-threads.test.mjs",
     "scripts/ios-export-selected-zip.test.mjs",
+    "scripts/ios-reminders-bulk-delete.test.mjs",
     "scripts/ios-reorder-familiars.test.mjs",
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/ios-theme.test.mjs",


### PR DESCRIPTION
## What

iOS had **no reminders surface** — Schedules/Reminders were desktop-only (`/inbox` & `/remind` slash commands just say "on the desktop"). This adds a read-only **Reminders** screen with bulk-select delete.

- **`Reminder` model** + `InboxResponse`; **`CaveClient.reminders()`** (GET `/api/inbox`, filtered to `kind=="reminder"`) and **`deleteReminder(id)`** (DELETE `/api/inbox/{id}`). GET/DELETE are reachable from the phone; only *creating* reminders is loopback-gated, so there's no compose here.
- **`AppModel`** — `reminders` state, `loadReminders()`, and **`deleteReminders(_:)`** (optimistic bulk remove, reverts on failure).
- **`RemindersView`** — list with per-row swipe-delete and a **Select** mode (Select All / Deselect All / **Delete (N)** + confirmation), reusing the chat bulk-delete pattern. Shows title, relative fire time, and status with a status icon.
- **`TasksView`** — a **bell** toolbar button opens Reminders as a sheet (reminders are task-adjacent, and the 5 tab slots are already full).

## Verification

- `pnpm test:mobile` → **✓ 41 test file(s) passed** (full suite; new `scripts/ios-reminders-bulk-delete.test.mjs`).
- `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED**.

Interactive flow (open sheet → select → delete) needs gestures I can't drive headlessly without `idb`, so it rests on build + assertion test + the proven optimistic/bulk-select patterns.

> Entry point is a Tasks-toolbar sheet rather than a 6th tab (which would force a "More" overflow on iPhone). Built via an atomic sibling-worktree one-shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)