### PR TITLE
feat(projects): Move to project submenu in the session context menu

### DIFF
--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -99,7 +99,7 @@ assert.match(
 );
 assert.match(projectsView, /useDroppable\(\{\s*id: `pcard:/, "project cards are drop targets");
 assert.match(projectsView, /applyProjectOverrides\(sessions, projectOverrides\)/, "chats are grouped with Cave-local project overrides applied");
-assert.match(projectsView, /setProjectOverride\(activeId, targetRoot\)/, "cross-project drop moves the chat via an override");
+assert.match(projectsView, /setProjectOverride\(sessionId, targetRoot\)/, "cross-project move applies a Cave-local project override");
 assert.match(projectsView, /mergeVisibleOrder[\s\S]{0,120}writeSessionOrder/, "same-project drop reorders via the shared manual order");
 assert.match(projectsView, /cave:agents-open-session/, "clicking a chat opens it via the agents-open-session event");
 // Long chat lists are capped with a Show all / Show less toggle.
@@ -341,9 +341,10 @@ assert.match(
   /import \{ PopoverItem, PopoverSeparator \} from "@\/components\/ui\/popover"/,
   "menu items use the shared Popover item/separator",
 );
-// Two onContextMenu triggers: the project header and each session row.
+// Two onContextMenu triggers: the project header and each session row (the row
+// wraps the helper to reset the menu's drill-in view first).
 assert.ok(
-  (projectsView.match(/onContextMenu=\{openContextMenuAt\(setMenu\)\}/g) ?? []).length >= 2,
+  (projectsView.match(/openContextMenuAt\(setMenu\)/g) ?? []).length >= 2,
   "both the project header and session rows open a context menu at the cursor",
 );
 assert.match(projectsView, /Actions for \$\{project\.name\}/, "the project header has a context menu");
@@ -367,8 +368,8 @@ assert.match(projectsView, /isOver[\s\S]{0,140}?ring-1 ring-inset ring-\[var\(--
 assert.match(projectsView, /import \{ applyProjectOverrides, setProjectOverride, clearProjectOverride \}/, "imports clearProjectOverride for undo");
 assert.match(projectsView, /function MoveUndoToast/, "a move-undo toast component exists");
 assert.match(projectsView, /window\.setTimeout\(\(\) => dismissRef\.current\(\), 5000\)/, "the toast auto-dismisses");
-assert.match(projectsView, /const prevRoot = projectOverrides\[activeId\] \?\? null/, "the move captures the prior override for a precise undo");
-assert.match(projectsView, /setMoveToast\(\{ sessionId: activeId, prevRoot, label:/, "a cross-project move raises the undo toast");
+assert.match(projectsView, /const prevRoot = projectOverrides\[sessionId\] \?\? null/, "the move captures the prior override for a precise undo");
+assert.match(projectsView, /setMoveToast\(\{ sessionId, prevRoot, label:/, "a cross-project move raises the undo toast");
 assert.match(
   projectsView,
   /moveToast\.prevRoot\) setProjectOverride\(moveToast\.sessionId, moveToast\.prevRoot\)[\s\S]{0,90}?clearProjectOverride\(moveToast\.sessionId\)/,
@@ -401,5 +402,26 @@ assert.match(projectsView, /state\.buffer \+= e\.key/, "keystrokes accumulate in
 assert.match(projectsView, /typeAheadRef\.current\.buffer = ""/, "the buffer resets after a pause");
 assert.match(projectsView, /const next = nextTypeAheadIndex\(labels, current, state\.buffer\)/, "the next focus comes from the pure matcher");
 assert.match(projectsView, /items\[next\]\.focus\(\);\s*setActiveIndex\(next\)/, "a match focuses the item and updates the roving tab stop");
+
+// "Move to project" submenu: the session context menu drills into a list of the
+// other projects; selecting one moves the chat there (same move+undo path as
+// drag), shared via the extracted moveSessionToProject.
+assert.match(projectsView, /const moveSessionToProject = \(sessionId: string, targetRoot: string\)/, "the cross-project move is a shared helper");
+assert.match(projectsView, /\/\/ Different project → move[\s\S]{0,80}?moveSessionToProject\(activeId, targetRoot\)/, "drag-and-drop reuses the shared move helper");
+assert.match(projectsView, /onMoveSession=\{moveSessionToProject\}/, "the move helper is wired into project rows");
+assert.match(
+  projectsView,
+  /allProjects[\s\S]{0,160}?normalizeProjectRoot\(p\.root\) !== cardKey/,
+  "each row offers the OTHER projects as move targets",
+);
+assert.match(projectsView, /const \[menuView, setMenuView\] = useState<"root" \| "move">/, "the session menu tracks a root/move drill-in view");
+assert.match(projectsView, /onSelect=\{\(\) => setMenuView\("move"\)\}/, '"Move to project…" drills into the project picker');
+assert.match(projectsView, /Move to project…/, "the session menu offers Move to project");
+assert.match(
+  projectsView,
+  /moveTargets\.map\(\(target\)[\s\S]{0,260}?onMoveSession\(session\.id, target\.root\)/,
+  "picking a target project moves the chat there",
+);
+assert.match(projectsView, /onSelect=\{\(\) => setMenuView\("root"\)\}[\s\S]{0,40}?Back/, "the picker has a Back affordance");
 
 console.log("projects-view.test.ts: ok");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -138,6 +138,9 @@ function MoveUndoToast({
   );
 }
 
+/** A project a chat can be moved into (from the row's context menu). root is normalized. */
+type MoveTarget = { id: string; name: string; root: string };
+
 function ProjectChatRow({
   session,
   displayTitle,
@@ -147,6 +150,8 @@ function ProjectChatRow({
   selected,
   onToggleSelect,
   density,
+  moveTargets,
+  onMoveSession,
 }: {
   session: SessionRow;
   displayTitle?: string;
@@ -156,6 +161,8 @@ function ProjectChatRow({
   selected: boolean;
   onToggleSelect: (id: string) => void;
   density: ProjectsDensity;
+  moveTargets: MoveTarget[];
+  onMoveSession: (sessionId: string, targetRoot: string) => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: session.id,
@@ -169,6 +176,7 @@ function ProjectChatRow({
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [menu, setMenu] = useState<ContextMenuState>(null);
+  const [menuView, setMenuView] = useState<"root" | "move">("root");
   const activate = () => (selectMode ? onToggleSelect(session.id) : onOpen());
   return (
     <li
@@ -183,7 +191,10 @@ function ProjectChatRow({
         tabIndex={0}
         data-proj-nav
         data-proj-label={title}
-        onContextMenu={openContextMenuAt(setMenu)}
+        onContextMenu={(e) => {
+          setMenuView("root");
+          openContextMenuAt(setMenu)(e);
+        }}
         onClick={activate}
         onKeyDown={(e) => {
           // ARIA button/checkbox pattern: Enter and Space both activate.
@@ -301,14 +312,43 @@ function ProjectChatRow({
           </button>
         )}
       </div>
-      <ContextMenu state={menu} onClose={() => setMenu(null)} ariaLabel={`Actions for ${title}`}>
-        <PopoverItem icon="ph:chat-circle-dots-bold" onSelect={() => { setMenu(null); onOpen(); }}>
-          Open chat
-        </PopoverItem>
-        <PopoverSeparator />
-        <PopoverItem icon="ph:trash-bold" danger onSelect={() => { setMenu(null); setConfirmDelete(true); }}>
-          Delete chat…
-        </PopoverItem>
+      <ContextMenu
+        state={menu}
+        onClose={() => { setMenu(null); setMenuView("root"); }}
+        ariaLabel={`Actions for ${title}`}
+      >
+        {menuView === "root" ? (
+          <>
+            <PopoverItem icon="ph:chat-circle-dots-bold" onSelect={() => { setMenu(null); onOpen(); }}>
+              Open chat
+            </PopoverItem>
+            {moveTargets.length > 0 ? (
+              <PopoverItem icon="ph:folder-open-bold" onSelect={() => setMenuView("move")}>
+                Move to project…
+              </PopoverItem>
+            ) : null}
+            <PopoverSeparator />
+            <PopoverItem icon="ph:trash-bold" danger onSelect={() => { setMenu(null); setConfirmDelete(true); }}>
+              Delete chat…
+            </PopoverItem>
+          </>
+        ) : (
+          <>
+            <PopoverItem icon="ph:caret-left" onSelect={() => setMenuView("root")}>
+              Back
+            </PopoverItem>
+            <PopoverSeparator />
+            {moveTargets.map((target) => (
+              <PopoverItem
+                key={target.id}
+                icon="ph:folder-simple-dashed"
+                onSelect={() => { setMenu(null); setMenuView("root"); onMoveSession(session.id, target.root); }}
+              >
+                {target.name}
+              </PopoverItem>
+            ))}
+          </>
+        )}
       </ContextMenu>
     </li>
   );
@@ -340,6 +380,8 @@ type ProjectRowProps = {
   density: ProjectsDensity;
   expanded: boolean;
   onSetExpanded: (next: boolean) => void;
+  allProjects: CaveProject[];
+  onMoveSession: (sessionId: string, targetRoot: string) => void;
 };
 
 function ProjectRow({
@@ -355,6 +397,8 @@ function ProjectRow({
   density,
   expanded,
   onSetExpanded,
+  allProjects,
+  onMoveSession,
 }: ProjectRowProps) {
   const chatCount = chats.length;
   const stats = projectStats(chats);
@@ -364,6 +408,14 @@ function ProjectRow({
   const setExpanded = (next: boolean | ((value: boolean) => boolean)) =>
     onSetExpanded(typeof next === "function" ? next(expanded) : next);
   const cardKey = normalizeProjectRoot(project.root);
+  // Other projects this card's chats can be moved into (normalized roots).
+  const moveTargets = useMemo<MoveTarget[]>(
+    () =>
+      allProjects
+        .filter((p) => normalizeProjectRoot(p.root) !== cardKey)
+        .map((p) => ({ id: p.id, name: p.name, root: normalizeProjectRoot(p.root) })),
+    [allProjects, cardKey],
+  );
 
   // The command palette's "Open project" rows expand + scroll a project into
   // view via this event (the Projects tab is opened first, then focused).
@@ -803,6 +855,8 @@ function ProjectRow({
                   selected={selectedIds.has(session.id)}
                   onToggleSelect={toggleSelect}
                   density={density}
+                  moveTargets={moveTargets}
+                  onMoveSession={onMoveSession}
                 />
               ))}
             </ul>
@@ -1014,16 +1068,22 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
       return;
     }
     // Different project → move (cave-local override; agent cwd untouched).
-    // Capture the prior override first so the move can be undone precisely
-    // (restore the old override, or clear it if there wasn't one).
-    const prevRoot = projectOverrides[activeId] ?? null;
-    const moved = sessions.find((s) => s.id === activeId);
+    moveSessionToProject(activeId, targetRoot);
+  }
+
+  // Move a session to another project (shared by drag-and-drop and the row's
+  // "Move to project" context-menu). targetRoot must be normalized. Captures the
+  // prior override first so the move can be undone precisely (restore the old
+  // override, or clear it if there wasn't one), then raises the undo toast.
+  const moveSessionToProject = (sessionId: string, targetRoot: string) => {
+    const prevRoot = projectOverrides[sessionId] ?? null;
+    const moved = sessions.find((s) => s.id === sessionId);
     const destName =
       projects.find((p) => normalizeProjectRoot(p.root) === targetRoot)?.name ?? shortRoot(targetRoot);
     const movedTitle = moved ? stripLeadingTrailingEmoji(stripTaskPrefix(moved.title)) || "chat" : "chat";
-    setProjectOverride(activeId, targetRoot);
-    setMoveToast({ sessionId: activeId, prevRoot, label: `Moved “${movedTitle}” to ${destName}` });
-  }
+    setProjectOverride(sessionId, targetRoot);
+    setMoveToast({ sessionId, prevRoot, label: `Moved “${movedTitle}” to ${destName}` });
+  };
 
   const undoMove = () => {
     if (!moveToast) return;
@@ -1315,6 +1375,8 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
                     density={density}
                     expanded={isExpanded(project.id)}
                     onSetExpanded={(next) => setExpanded(project.id, next)}
+                    allProjects={projects}
+                    onMoveSession={moveSessionToProject}
                   />
                 ))}
               </DndContext>


### PR DESCRIPTION
## What

The final optional item from the Projects native redesign. Right-clicking a chat now offers **"Move to project…"**, which drills into a list of the other projects; picking one moves the chat there — the same Cave-local override + undo-toast path as dragging it across project cards.

## How
- **Extracted `moveSessionToProject(sessionId, targetRoot)`** from the drag handler so drag-and-drop and the menu share one move+undo implementation (capture prior override → set override → raise the undo toast).
- The session `ContextMenu` gains a **root/move drill-in view** — no new submenu primitive; it reuses the existing `Popover`, whose built-in max-height scrolls the project list when there are many, with a **Back** affordance.
- `ProjectRow` computes the move targets (all projects except its own, normalized roots) and threads them down; `ProjectsView` passes the project list + the shared helper.

## Verification
- `pnpm typecheck` clean · `projects-view.test.ts` extended (and three pre-existing assertions updated for the extracted helper) and green · `check:tests-wired` green (506)
- Live verification via run-cave-app: right-click a chat → Move to project… → pick a project → chat moves + undo toast (screenshots in thread)

No dependency added; no data-model/API changes. The move is the same cave-local override drag already used (agent cwd untouched), and it's undoable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)