### PR TITLE
feat(ios): per-chat model control — see and change a chat's model

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -187,6 +187,42 @@ struct CaveClient {
         }
     }
 
+    // MARK: - Model control
+
+    private func urlQuery(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
+    }
+
+    /// The model this chat resolves to, plus the pickable menu for its runtime.
+    func chatModelState(familiarId: String, sessionId: String?) async throws -> ChatModelStateResponse {
+        var path = "api/chat/model-state?familiarId=\(urlQuery(familiarId))"
+        if let sessionId, !sessionId.isEmpty { path += "&sessionId=\(urlQuery(sessionId))" }
+        let req = try request(path)
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        do {
+            return try JSONDecoder().decode(ChatModelStateResponse.self, from: data)
+        } catch {
+            throw CaveError.decoding(String(describing: error))
+        }
+    }
+
+    /// Set the model for this chat (`session` scope) or the familiar (`familiar-default`).
+    @discardableResult
+    func setChatModel(familiarId: String, sessionId: String?, model: String, scope: String) async throws -> ChatModelStateResponse {
+        var body: [String: String] = ["familiarId": familiarId, "model": model, "scope": scope]
+        if let sessionId, !sessionId.isEmpty { body["sessionId"] = sessionId }
+        let payload = try JSONEncoder().encode(body)
+        let req = try request("api/chat/model-state", method: "PATCH", body: payload)
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        do {
+            return try JSONDecoder().decode(ChatModelStateResponse.self, from: data)
+        } catch {
+            throw CaveError.decoding(String(describing: error))
+        }
+    }
+
     // MARK: - Chat streaming
 
     /// An image attachment the server delivers to the familiar alongside the

--- a/apps/ios/CovenCave/CovenCave/Views/ChatModelControl.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatModelControl.swift
@@ -1,0 +1,166 @@
+import SwiftUI
+
+// MARK: - Wire types (`GET`/`PATCH /api/chat/model-state`)
+
+struct ChatModelOption: Codable, Hashable, Identifiable {
+    let id: String
+    let label: String
+}
+
+struct ChatModelState: Codable {
+    let familiarId: String
+    let harness: String
+    var runtime: String?
+    let effectiveModel: String
+    let source: String
+    var applicationState: String?
+    var reason: String?
+}
+
+struct ChatModelStateResponse: Codable {
+    let ok: Bool
+    let state: ChatModelState
+    var options: [ChatModelOption]?
+    var allowCustom: Bool?
+}
+
+/// A compact "which model is this chat using" chip above the composer, with a
+/// picker to change it. Shown for direct (non-group) chats whose runtime has a
+/// model menu; hidden when the runtime offers no choices (e.g. openclaw).
+struct ChatModelBar: View {
+    @Environment(AppModel.self) private var app
+    let thread: ChatThread
+    let familiarId: String
+
+    @State private var state: ChatModelState?
+    @State private var options: [ChatModelOption] = []
+    @State private var showPicker = false
+    @State private var busy = false
+
+    private var sessionId: String? {
+        let id = thread.sessionIds[familiarId]
+        return (id?.isEmpty == false) ? id : nil
+    }
+
+    private var label: String {
+        guard let model = state?.effectiveModel else { return "Model" }
+        return options.first(where: { $0.id == model })?.label ?? shortModel(model)
+    }
+
+    var body: some View {
+        // Always render a stable container (zero-height when there's nothing to
+        // show) so `.task` reliably runs the initial load.
+        chip
+            .task(id: sessionId) { await load() }
+            .sheet(isPresented: $showPicker) {
+                ModelPickerSheet(options: options, current: state?.effectiveModel ?? "") { id in
+                    Task { await choose(id) }
+                }
+            }
+    }
+
+    @ViewBuilder private var chip: some View {
+        if state != nil, !options.isEmpty {
+            Button { showPicker = true } label: {
+                HStack(spacing: 5) {
+                    Image(systemName: "cpu").font(.system(size: 11, weight: .medium))
+                    Text(label).font(.caption.weight(.medium)).lineLimit(1)
+                    if busy {
+                        ProgressView().controlSize(.mini)
+                    } else {
+                        Image(systemName: "chevron.up.chevron.down").font(.system(size: 9, weight: .semibold))
+                    }
+                }
+                .padding(.horizontal, 10).padding(.vertical, 5)
+                .foregroundStyle(.secondary)
+                .background(Color(.secondarySystemBackground), in: Capsule())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Model: \(label). Tap to change.")
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 14)
+            .padding(.bottom, 4)
+        } else {
+            Color.clear.frame(height: 0)
+        }
+    }
+
+    private func load() async {
+        guard let client = app.client else { return }
+        do {
+            let resp = try await client.chatModelState(familiarId: familiarId, sessionId: sessionId)
+            state = resp.state
+            options = resp.options ?? []
+        } catch {
+            // Non-fatal: the bar just stays hidden if the state can't be read.
+        }
+    }
+
+    private func choose(_ model: String) async {
+        guard let client = app.client, model != state?.effectiveModel else { return }
+        busy = true
+        defer { busy = false }
+        // Per-chat when the chat has a server session; otherwise change the
+        // familiar's default so the choice still sticks for the next message.
+        let scope = sessionId != nil ? "session" : "familiar-default"
+        do {
+            let resp = try await client.setChatModel(
+                familiarId: familiarId, sessionId: sessionId, model: model, scope: scope)
+            state = resp.state
+            if let opts = resp.options { options = opts }
+            Haptics.tap()
+        } catch {
+            // Leave the prior state in place on failure.
+        }
+    }
+
+    private func shortModel(_ id: String) -> String {
+        id.split(separator: "/").last.map(String.init) ?? id
+    }
+}
+
+struct ModelPickerSheet: View {
+    let options: [ChatModelOption]
+    let current: String
+    let onSelect: (String) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    ForEach(options) { option in
+                        Button {
+                            onSelect(option.id)
+                            dismiss()
+                        } label: {
+                            HStack(spacing: 10) {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(option.label).foregroundStyle(.primary)
+                                    Text(option.id).font(.caption2).foregroundStyle(.secondary)
+                                }
+                                Spacer(minLength: 8)
+                                if option.id == current {
+                                    Image(systemName: "checkmark").foregroundStyle(.tint)
+                                }
+                            }
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                } footer: {
+                    Text("Applies to this chat. The familiar uses the chosen model for its next replies.")
+                }
+            }
+            .navigationTitle("Model")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -67,6 +67,9 @@ struct ChatView: View {
     var body: some View {
         VStack(spacing: 0) {
             messageScroll
+            if !thread.isGroup, let familiarId = thread.familiarIds.first {
+                ChatModelBar(thread: thread, familiarId: familiarId)
+            }
             composer
         }
         .navigationTitle(thread.title)

--- a/src/app/api/chat/model-state/route.ts
+++ b/src/app/api/chat/model-state/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { bindingFor, loadConfig, saveConfig } from "@/lib/cave-config";
 import { loadConversation, saveConversation } from "@/lib/cave-conversations";
 import { cleanModelId, resolveChatModelState } from "@/lib/chat-model-state";
+import { catalogForRuntime } from "@/lib/runtime-models";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -68,7 +69,16 @@ export async function GET(req: Request) {
   if (!familiarId) return jsonError("familiarId is required", 400);
 
   const state = await currentState(familiarId, sessionId);
-  return NextResponse.json({ ok: true, state });
+  // Also hand back the pickable model menu for this chat's runtime so non-web
+  // clients (the iOS app) don't have to mirror the catalog. Web ignores it and
+  // reads the catalog directly. `allowCustom` means a free-typed id is valid.
+  const catalog = catalogForRuntime(state.harness);
+  return NextResponse.json({
+    ok: true,
+    state,
+    options: catalog?.models ?? [],
+    allowCustom: catalog?.allowCustom ?? true,
+  });
 }
 
 export async function PATCH(req: Request) {


### PR DESCRIPTION
## What

iOS chat had **no model UI at all** — the web has full model control. This brings parity for the common case: a compact chip above the composer in a direct chat shows which model the familiar is using, and tapping it opens a picker to change it.

- **Server:** `GET /api/chat/model-state` now also returns the runtime's pickable model menu (`options` + `allowCustom`) from the existing `runtime-models` catalog, so the iOS app doesn't have to mirror it. **Additive** — the web reads the catalog directly and ignores the new fields (api-contracts/route tests still pass).
- **iOS:** `CaveClient.chatModelState` / `setChatModel` wrap the GET/PATCH. `ChatModelBar` (a `cpu · <model> ▾` chip) + `ModelPickerSheet` render the current model and the menu. Picking applies **`session`** scope when the chat has a server session, else **`familiar-default`**, so the choice always sticks. Shown only for **direct** chats whose runtime has a menu (hidden for groups / openclaw).

## Verification

iOS isn't in CI, so verified on the **iPhone 16 Pro simulator**:
- the chip renders above the composer (**"Claude Opus 4.8"**),
- the picker lists all four Claude models (Opus 4.8 / 4.7, Sonnet 4.6, Haiku 4.5) with the current one **checkmarked**, plus an explanatory footer.

Server typecheck clean; `model-state` route / `api-contracts` / `runtime-models` tests pass; clean simulator build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)