### PR TITLE
fix(security): guard library chat document reads

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -481,6 +481,7 @@ export const SUITES = {
     "src/app/api/project-local-human-read.test.ts",
     "src/app/api/project-file/route.test.ts",
     "src/app/api/library/doc/route.test.ts",
+    "src/app/api/library/chat/chat-doc-path.test.ts",
     "src/app/api/salem/pathfinder/feedback/route.test.ts",
     "src/app/api/launch/route.test.ts",
     "scripts/sidecar-bundle.test.mjs",

--- a/src/app/api/library/chat/chat-doc-path.test.ts
+++ b/src/app/api/library/chat/chat-doc-path.test.ts
@@ -1,0 +1,40 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const root = await mkdtemp(path.join(tmpdir(), "library-chat-doc-"));
+const researchRoot = path.join(root, "sage", "research");
+const outsideFile = path.join(root, "secret.md");
+
+const { readLibraryChatDocument, resolveLibraryChatDocPath } = await import("./chat-doc-path.ts");
+
+try {
+  await mkdir(path.join(researchRoot, "papers"), { recursive: true });
+  const allowedPath = path.join(researchRoot, "papers", "paper.md");
+  await writeFile(allowedPath, "# Paper\n\nLocal research note.\n", "utf-8");
+  await writeFile(outsideFile, "secret outside research\n", "utf-8");
+  await symlink(outsideFile, path.join(researchRoot, "papers", "secret-link.md"));
+
+  const allowed = readLibraryChatDocument(allowedPath, { researchRoot });
+  assert.equal(allowed.ok, true);
+  assert.equal(allowed.content, "# Paper\n\nLocal research note.\n");
+  assert.equal(allowed.path, await realpath(allowedPath));
+
+  assert.deepEqual(
+    resolveLibraryChatDocPath(path.join(researchRoot, "papers", "..", "..", "..", "secret.md"), { researchRoot }),
+    { ok: false, reason: "forbidden" },
+    "path traversal outside the research root is rejected",
+  );
+
+  assert.deepEqual(
+    readLibraryChatDocument(path.join(researchRoot, "papers", "secret-link.md"), { researchRoot }),
+    { ok: false, reason: "forbidden" },
+    "symlink escapes outside the research root are rejected before reading",
+  );
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+console.log("library chat-doc-path.test.ts: ok");

--- a/src/app/api/library/chat/chat-doc-path.ts
+++ b/src/app/api/library/chat/chat-doc-path.ts
@@ -30,6 +30,45 @@ export type LibraryChatDocResolution =
   | { ok: true; path: string }
   | { ok: false; reason: "forbidden" | "not_found" | "too_large" | "not_file" };
 
+export type LibraryChatDocumentRead =
+  | { ok: true; path: string; content: string }
+  | { ok: false; reason: "forbidden" | "not_found" | "too_large" | "not_file" };
+
+type LibraryChatDocPathOptions = {
+  researchRoot?: string;
+};
+
+function isWithinRoot(value: string, root: string): boolean {
+  const relative = path.relative(root, value);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function listResearchEntries(root: string): Array<{ path: string; isFile: boolean }> {
+  const entries: Array<{ path: string; isFile: boolean }> = [];
+
+  function walk(dir: string) {
+    let dirents: fs.Dirent[];
+    try {
+      dirents = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const dirent of dirents) {
+      const fullPath = path.join(dir, dirent.name);
+      if (dirent.isDirectory()) {
+        entries.push({ path: fullPath, isFile: false });
+        walk(fullPath);
+      } else if (dirent.isFile()) {
+        entries.push({ path: fullPath, isFile: true });
+      }
+    }
+  }
+
+  walk(root);
+  return entries;
+}
+
 /**
  * Resolve and validate a raw (absolute) path for library chat access.
  *
@@ -37,7 +76,10 @@ export type LibraryChatDocResolution =
  * file, and is within the sage research root. Otherwise returns a typed
  * failure reason for the caller to translate to an HTTP status.
  */
-export function resolveLibraryChatDocPath(rawPath: string): LibraryChatDocResolution {
+export function resolveLibraryChatDocPath(
+  rawPath: string,
+  options: LibraryChatDocPathOptions = {},
+): LibraryChatDocResolution {
   // Basic sanity: must be non-empty, no null bytes, must be absolute.
   if (!rawPath || rawPath.includes("\0") || !path.isAbsolute(rawPath)) {
     return { ok: false, reason: "forbidden" };
@@ -49,7 +91,7 @@ export function resolveLibraryChatDocPath(rawPath: string): LibraryChatDocResolu
   // Resolve the real research root (handles symlinks in the home path itself).
   let resolvedRoot: string;
   try {
-    resolvedRoot = fs.realpathSync(SAGE_RESEARCH_ROOT);
+    resolvedRoot = fs.realpathSync(options.researchRoot ?? SAGE_RESEARCH_ROOT);
   } catch {
     // Research root doesn't exist yet — nothing can be found within it.
     return { ok: false, reason: "not_found" };
@@ -65,29 +107,43 @@ export function resolveLibraryChatDocPath(rawPath: string): LibraryChatDocResolu
   }
 
   // Security check: resolved path must be inside the research root.
-  const isWithin =
-    resolvedPath === resolvedRoot ||
-    resolvedPath.startsWith(resolvedRoot + path.sep);
-
-  if (!isWithin) {
+  if (!isWithinRoot(resolvedPath, resolvedRoot)) {
     return { ok: false, reason: "forbidden" };
   }
 
-  // Stat the file.
-  let stat: fs.Stats;
-  try {
-    stat = fs.statSync(resolvedPath);
-  } catch {
+  const matchedEntry = listResearchEntries(resolvedRoot).find((entry) => entry.path === resolvedPath);
+  if (!matchedEntry) {
     return { ok: false, reason: "not_found" };
   }
 
-  if (!stat.isFile()) {
+  if (!matchedEntry.isFile) {
     return { ok: false, reason: "not_file" };
   }
+
+  const stat = fs.statSync(matchedEntry.path);
 
   if (stat.size > MAX_DOC_BYTES) {
     return { ok: false, reason: "too_large" };
   }
 
-  return { ok: true, path: resolvedPath };
+  return { ok: true, path: matchedEntry.path };
+}
+
+export function readLibraryChatDocument(
+  rawPath: string,
+  options: LibraryChatDocPathOptions = {},
+): LibraryChatDocumentRead {
+  const resolution = resolveLibraryChatDocPath(rawPath, options);
+  if (!resolution.ok) return resolution;
+
+  try {
+    return {
+      ok: true,
+      path: resolution.path,
+      // turbopackIgnore: true — path is runtime-validated, not a build-time import.
+      content: fs.readFileSync(/* turbopackIgnore: true */ resolution.path, "utf-8"),
+    };
+  } catch {
+    return { ok: false, reason: "not_found" };
+  }
 }

--- a/src/app/api/library/chat/route.ts
+++ b/src/app/api/library/chat/route.ts
@@ -20,7 +20,6 @@
  */
 
 import { spawn } from "node:child_process";
-import fs from "node:fs";
 import path from "node:path";
 import { stripAnsi } from "@/lib/ansi";
 import {
@@ -35,7 +34,7 @@ import {
   resolveOpenClawAgentId,
   type OpenClawAgentJson,
 } from "@/lib/openclaw-bridge";
-import { resolveLibraryChatDocPath } from "./chat-doc-path";
+import { readLibraryChatDocument } from "./chat-doc-path";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -220,10 +219,10 @@ export async function POST(req: Request): Promise<Response> {
     return errorStream("docPath is required.");
   }
 
-  const resolution = resolveLibraryChatDocPath(body.docPath);
+  const documentRead = readLibraryChatDocument(body.docPath);
 
-  if (!resolution.ok) {
-    switch (resolution.reason) {
+  if (!documentRead.ok) {
+    switch (documentRead.reason) {
       case "forbidden":
         return new Response(
           JSON.stringify({ ok: false, error: "Document path is not allowed." }),
@@ -240,7 +239,7 @@ export async function POST(req: Request): Promise<Response> {
           { status: 400, headers: { "content-type": "application/json" } },
         );
       case "too_large":
-        // too_large from resolveLibraryChatDocPath means the file exceeds our
+        // too_large from readLibraryChatDocument means the file exceeds our
         // 200KB limit even before truncation. We handle truncation ourselves
         // in this route, so this branch is a belt-and-suspenders guard — the
         // resolver uses the same MAX_DOC_BYTES constant. Surface as an error.
@@ -250,17 +249,8 @@ export async function POST(req: Request): Promise<Response> {
     }
   }
 
-  const resolvedDocPath = resolution.path;
-
-  // 3. Read the document
-  let rawContent: string;
-  try {
-    // turbopackIgnore: true — path is runtime-validated, not a build-time import.
-    rawContent = fs.readFileSync(/* turbopackIgnore: true */ resolvedDocPath, "utf-8");
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return errorStream(`Failed to read document: ${msg}`);
-  }
+  const resolvedDocPath = documentRead.path;
+  const rawContent = documentRead.content;
 
   // 4. Truncate if needed
   const { text: docContent, truncated } = truncateAtParagraph(rawContent, MAX_DOC_BYTES);


### PR DESCRIPTION
## Summary
- move library chat document reads behind the validated research-root helper
- enumerate allowed research entries before stat/read so request data cannot drive the filesystem sink
- add regression coverage for allowed reads, traversal escape, and symlink escape

## Test Plan
- `node --experimental-strip-types src/app/api/library/chat/chat-doc-path.test.ts`
- `node --experimental-strip-types src/app/api/api-contracts.test.ts`
- `pnpm check:tests-wired`
- `pnpm typecheck`
- `pnpm test:api`
- `codeql database analyze /tmp/coven-cave-codeql-67-db ~/.codeql/packages/codeql/javascript-queries/2.3.11/Security/CWE-022/TaintedPath.ql --format=sarif-latest --output=/tmp/coven-cave-codeql-67.sarif --rerun` (`library-chat-count 0`)

Resolves code scanning alert #67.