### PR TITLE
feat(gantt): re-center on zoom change + keyboard reschedule

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -173,6 +173,7 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
   // ref and the effect (declared above the return) calls through it.
   const didAutoCenterRef = useRef(false);
   const centerOnTodayRef = useRef<() => boolean>(() => false);
+  const prevZoomRef = useRef(zoom);
 
   const beginDrag = (e: React.PointerEvent, rowId: string, mode: DragMode) => {
     if (!draggable) return;
@@ -191,26 +192,23 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
     if (Math.abs(dx) > 3) d.moved = true;
     setDrag({ id: d.id, mode: d.mode, deltaDays: Math.round(dx / DAY_W) });
   };
-  const endDrag = (e: React.PointerEvent, row: GanttRow) => {
-    const d = dragRef.current;
-    const active = drag;
-    dragRef.current = null;
-    setDrag(null);
-    if (!d) return;
-    if (d.moved) suppressClickRef.current = true; // swallow the trailing click
+  // Apply a day-shift to a row in the given mode, persisting via onPatch.
+  // Shared by pointer drag-end and keyboard reschedule.
+  const commitShift = (row: GanttRow, mode: DragMode, rawDelta: number) => {
+    if (!onPatch) return;
     const dur = daysBetween(row.start, row.end) + 1;
-    const delta = clampDelta(d.mode, active?.deltaDays ?? 0, dur);
-    if (!(d.moved && delta !== 0 && onPatch)) return;
+    const delta = clampDelta(mode, rawDelta, dur);
+    if (delta === 0) return;
     const card = cards.find((c) => c.id === row.cardId);
     if (!card) return;
     const newStart = fmtISO(addDays(row.start, delta));
     const newEnd = fmtISO(addDays(row.end, delta));
     const curStart = fmtISO(row.start);
     const curEnd = fmtISO(row.end);
-    // Resolve the new {start,end} for the dragged mode.
+    // Resolve the new {start,end} for the shifted mode.
     const next =
-      d.mode === "move" ? { startDate: newStart, endDate: newEnd }
-      : d.mode === "resize-start" ? { startDate: newStart, endDate: curEnd }
+      mode === "move" ? { startDate: newStart, endDate: newEnd }
+      : mode === "resize-start" ? { startDate: newStart, endDate: curEnd }
       : { startDate: curStart, endDate: newEnd };
     if (row.stepId) {
       // Task mode: write this step's dates (promoting a card-range fallback to
@@ -223,16 +221,25 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
       // Project mode: a move shifts whichever of the task's own dates are set;
       // a resize sets the dragged end explicitly.
       const patch: Partial<Card> = {};
-      if (d.mode === "move") {
+      if (mode === "move") {
         if (parseDate(card.startDate)) patch.startDate = newStart;
         if (parseDate(card.endDate)) patch.endDate = newEnd;
-      } else if (d.mode === "resize-start") {
+      } else if (mode === "resize-start") {
         patch.startDate = newStart;
       } else {
         patch.endDate = newEnd;
       }
       if (patch.startDate || patch.endDate) onPatch(row.cardId, patch);
     }
+  };
+  const endDrag = (e: React.PointerEvent, row: GanttRow) => {
+    const d = dragRef.current;
+    const active = drag;
+    dragRef.current = null;
+    setDrag(null);
+    if (!d) return;
+    if (d.moved) suppressClickRef.current = true; // swallow the trailing click
+    if (d.moved) commitShift(row, d.mode, active?.deltaDays ?? 0);
   };
 
   const ownerName = (id: string | null): string =>
@@ -344,6 +351,15 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
     if (didAutoCenterRef.current) return;
     if (centerOnTodayRef.current()) didAutoCenterRef.current = true;
   }, [todayMs, zoom, allRows.length]);
+
+  // Changing the zoom rescales every px position, which can scroll "now" out of
+  // view — re-center on today after the new scale lays out (a deliberate user
+  // action, so it won't fight a passive scroll).
+  useEffect(() => {
+    if (prevZoomRef.current === zoom) return;
+    prevZoomRef.current = zoom;
+    requestAnimationFrame(() => centerOnTodayRef.current());
+  }, [zoom]);
 
   // Quick-schedule presets for undated tasks: drop a task onto this/next week
   // (Mon–Sun) without opening the date pickers.
@@ -665,7 +681,16 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
                         if (suppressClickRef.current) { suppressClickRef.current = false; return; }
                         onSelect(row.cardId);
                       }}
-                      title={`${row.label} · ${formatLabel(previewStart)}–${formatLabel(previewEnd)}${draggable ? " · drag to move, drag edges to resize" : ""}`}
+                      onKeyDown={(e) => {
+                        // Keyboard reschedule on the focused bar: ←/→ move both
+                        // dates by a day, Shift+←/→ resize the end. (Tab already
+                        // moves focus between bars.)
+                        if (!draggable || (e.key !== "ArrowLeft" && e.key !== "ArrowRight")) return;
+                        e.preventDefault();
+                        const dir = e.key === "ArrowRight" ? 1 : -1;
+                        commitShift(row, e.shiftKey ? "resize-end" : "move", dir);
+                      }}
+                      title={`${row.label} · ${formatLabel(previewStart)}–${formatLabel(previewEnd)}${draggable ? " · drag to move, drag edges to resize · ←/→ to reschedule" : ""}`}
                     >
                       <span className="cg-left">
                         <span className="cg-c-task">{row.label}</span>

--- a/src/components/board-schedule-window.test.ts
+++ b/src/components/board-schedule-window.test.ts
@@ -58,7 +58,7 @@ assert.match(gantt, /function clampDelta\(mode: DragMode, delta: number, dur: nu
 assert.match(gantt, /if \(mode === "resize-start"\) return Math\.min\(delta, dur - 1\)/, "resize-start can't drag the start past the end");
 assert.match(gantt, /if \(mode === "resize-end"\) return Math\.max\(delta, -\(dur - 1\)\)/, "resize-end can't drag the end past the start");
 // The left edge patches startDate, the right edge patches endDate.
-assert.match(gantt, /d\.mode === "resize-start"[\s\S]*?\{\s*patch\.startDate = newStart;/, "resize-start persists a new startDate");
+assert.match(gantt, /mode === "resize-start"[\s\S]*?\{\s*patch\.startDate = newStart;/, "resize-start persists a new startDate");
 assert.match(gantt, /else \{\s*patch\.endDate = newEnd;/, "resize-end persists a new endDate");
 // Each non-milestone bar renders a grab handle at each edge.
 assert.match(gantt, /const resizeHandle = \(which: "start" \| "end"\)/, "bars render edge resize handles");
@@ -170,5 +170,14 @@ assert.match(gantt, /onPatch\(cardId, \{ startDate: date, endDate: date \}\)/, "
 assert.match(gantt, /onDragOver=\{onTimelineDragOver\}[\s\S]{0,80}onDrop=\{onTimelineDrop\}/, "the body is wired as the drop zone");
 assert.match(gantt, /className="cg-drop-hint"/, "a drop-hint marks the landing day");
 assert.match(styles, /\.cg-drop-hint/, "the drop hint is styled");
+
+// Re-center on zoom change + keyboard reschedule.
+assert.match(gantt, /const prevZoomRef = useRef\(zoom\)/, "tracks the previous zoom to detect changes");
+assert.match(gantt, /if \(prevZoomRef\.current === zoom\) return;[\s\S]{0,120}centerOnTodayRef\.current\(\)/, "zoom change re-centers on today");
+// Pointer drag-end and keyboard reschedule share one commit path.
+assert.match(gantt, /const commitShift = \(row: GanttRow, mode: DragMode, rawDelta: number\)/, "a shared commitShift applies a day-shift");
+assert.match(gantt, /if \(d\.moved\) commitShift\(row, d\.mode, active\?\.deltaDays \?\? 0\)/, "drag-end routes through commitShift");
+assert.match(gantt, /commitShift\(row, e\.shiftKey \? "resize-end" : "move", dir\)/, "arrow keys reschedule the focused bar (Shift to resize)");
+assert.match(gantt, /e\.key !== "ArrowLeft" && e\.key !== "ArrowRight"/, "only left/right arrows reschedule");
 
 console.log("board-schedule-window.test.ts: ok");


### PR DESCRIPTION
Two Gantt navigation wins:

## 1. Re-center on today when zoom changes
Auto-center only fired once on open, so switching Day/Week/Month rescaled every position and could push "now" off-screen. Now a zoom change re-centers on today (only when today is in range) — a deliberate user action, so it won't fight a passive scroll.

## 2. Keyboard reschedule
A focused bar can be rescheduled from the keyboard: **←/→** move both dates by a day, **Shift+←/→** resize the end. (Tab already moves focus between bars.) Drag-end and keyboard now share one `commitShift()` path — no duplicated patch logic.

## Verification
- `pnpm typecheck` clean; `app` suite → **385 files pass** (assertions added; updated one that pinned the refactored variable name).
- Browser-driven: today stays visible after Month→Day zoom; ArrowRight on a focused bar → `PATCH {startDate+1, endDate+1}`; Shift+ArrowRight → `PATCH {endDate+1}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)