### PR TITLE
fix(theme): publish /api/theme tokens as resolved sRGB hex

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -76,6 +76,7 @@ export const SUITES = {
     "src/lib/readable-text-color.test.ts",
     "src/components/settings-appearance.test.ts",
     "src/components/theme-color-editor.test.ts",
+    "src/lib/theme-token-hex.test.ts",
     "src/components/roles-tools-navigation.test.ts",
     "src/components/top-bar.test.ts",
     "src/components/command-palette.test.ts",
@@ -571,6 +572,7 @@ const ALIAS_LOADER = new Set([
   "src/lib/server/automation-runner.test.ts",
   "src/lib/server/automation-log-paths.test.ts",
   "src/lib/session-project-scope.test.ts",
+  "src/lib/theme-token-hex.test.ts",
 ]);
 
 /** Build the `node` argv (flags + file) for a single test path. */

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -20,6 +20,7 @@ import { APP_VERSION } from "@/lib/app-version";
 import { UpdateSettingsRow } from "@/components/update-available";
 import { useIsMobile } from "@/lib/use-viewport";
 import { ThemeColorEditor } from "@/components/theme-color-editor";
+import { normalizedColorToHex } from "@/lib/theme-token-hex";
 import { FontSettings } from "./settings-fonts";
 import {
   CORNER_RADIUS_OPTIONS,
@@ -638,15 +639,37 @@ const THEME_SYNC_KEYS = [
   "--border-hairline", "--accent-presence",
 ] as const;
 
+/**
+ * Resolve any CSS colour string to plain sRGB hex via a `<canvas>` `fillStyle`
+ * round-trip. `getComputedStyle` hands back a custom property's *authored* value
+ * (`lab(...)`, `oklch(...)`, `color-mix(...)`), which a hex-only client (iOS
+ * `Color(hex:)`) can't read; assigning it to a canvas context and reading it
+ * back normalises it to `#rrggbb` / `rgba(...)` in sRGB. Falls back to the raw
+ * value if the context is unavailable or rejects the colour, so a token is
+ * never made worse than it is today.
+ */
+function resolveTokenToHex(ctx: CanvasRenderingContext2D | null, raw: string): string {
+  if (!ctx) return raw;
+  const SENTINEL = "#010203";
+  ctx.fillStyle = SENTINEL;
+  ctx.fillStyle = raw;
+  const got = ctx.fillStyle;
+  // An unparseable colour leaves fillStyle at the sentinel — keep the original.
+  if (typeof got !== "string") return raw;
+  if (got.toLowerCase() === SENTINEL && raw.trim().toLowerCase() !== SENTINEL) return raw;
+  return normalizedColorToHex(got);
+}
+
 function persistThemeTokens() {
   if (typeof window === "undefined") return;
   try {
     const html = document.documentElement;
     const cs = getComputedStyle(html);
+    const ctx = document.createElement("canvas").getContext("2d");
     const tokens: Record<string, string> = {};
     for (const key of THEME_SYNC_KEYS) {
       const value = cs.getPropertyValue(key).trim();
-      if (value) tokens[key] = value;
+      if (value) tokens[key] = resolveTokenToHex(ctx, value);
     }
     void fetch("/api/theme", {
       method: "PUT",

--- a/src/lib/theme-token-hex.test.ts
+++ b/src/lib/theme-token-hex.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { normalizedColorToHex } from "./theme-token-hex";
+
+test("persistThemeTokens resolves tokens to hex via a canvas round-trip before PUT", () => {
+  const src = readFileSync(new URL("../components/settings-shell.tsx", import.meta.url), "utf8");
+  // Tokens must be normalised through the canvas resolver, not posted raw — the
+  // bug was PUTting getComputedStyle's authored lab()/color-mix() values.
+  assert.match(src, /getContext\("2d"\)/, "should create a 2D canvas context to resolve colours");
+  assert.match(src, /resolveTokenToHex\(ctx, value\)/, "tokens should be resolved before being sent");
+  assert.match(src, /normalizedColorToHex\(got\)/, "the canvas result should be normalised to hex");
+  // Guard against a regression back to posting the raw computed value.
+  assert.doesNotMatch(src, /tokens\[key\]\s*=\s*value;/, "must not PUT the raw authored token value");
+});
+
+test("passes through #rrggbb unchanged (lower-cased)", () => {
+  assert.equal(normalizedColorToHex("#9A8ECD"), "#9a8ecd");
+  assert.equal(normalizedColorToHex("#161422"), "#161422");
+});
+
+test("expands #rgb and #rgba shorthand", () => {
+  assert.equal(normalizedColorToHex("#abc"), "#aabbcc");
+  assert.equal(normalizedColorToHex("#abcd"), "#aabbccdd");
+});
+
+test("drops a redundant fully-opaque alpha", () => {
+  assert.equal(normalizedColorToHex("#112233ff"), "#112233");
+  assert.equal(normalizedColorToHex("#abcf"), "#aabbcc");
+});
+
+test("keeps a meaningful alpha as #rrggbbaa", () => {
+  assert.equal(normalizedColorToHex("#11223380"), "#11223380");
+});
+
+test("converts rgb() to #rrggbb (canvas serialisation)", () => {
+  assert.equal(normalizedColorToHex("rgb(154, 142, 205)"), "#9a8ecd");
+  assert.equal(normalizedColorToHex("rgb(0, 0, 0)"), "#000000");
+  assert.equal(normalizedColorToHex("rgb(255, 255, 255)"), "#ffffff");
+});
+
+test("converts rgba() with alpha to #rrggbbaa", () => {
+  // 0.5 * 255 = 127.5 → rounds to 128 = 0x80
+  assert.equal(normalizedColorToHex("rgba(17, 34, 51, 0.5)"), "#11223380");
+  // fully opaque rgba collapses to 6 digits
+  assert.equal(normalizedColorToHex("rgba(154, 142, 205, 1)"), "#9a8ecd");
+});
+
+test("clamps out-of-range channels into sRGB byte range", () => {
+  assert.equal(normalizedColorToHex("rgb(300, -5, 128)"), "#ff0080");
+});
+
+test("tolerates space-separated rgb (color-4 serialisation)", () => {
+  assert.equal(normalizedColorToHex("rgb(154 142 205)"), "#9a8ecd");
+});
+
+test("returns unrecognised input unchanged so callers keep the raw token", () => {
+  // If the canvas round-trip is ever skipped, an unresolved lab()/color-mix()
+  // string must pass through rather than be corrupted.
+  assert.equal(normalizedColorToHex("lab(1.87792% 1.50546 -3.6698)"), "lab(1.87792% 1.50546 -3.6698)");
+  assert.equal(normalizedColorToHex("color-mix(in oklch, white 55%, transparent)"), "color-mix(in oklch, white 55%, transparent)");
+  assert.equal(normalizedColorToHex(""), "");
+});

--- a/src/lib/theme-token-hex.ts
+++ b/src/lib/theme-token-hex.ts
@@ -1,0 +1,70 @@
+// Resolving published theme tokens to plain sRGB hex.
+//
+// The desktop mirrors its colour tokens to GET /api/theme so other clients (the
+// iOS app) can match the appearance. Those tokens are authored as modern CSS
+// colours — `lab(...)`, `oklch(...)`, `color-mix(in oklch, ...)` — and
+// `getComputedStyle` returns a CSS *custom property* as its authored value, not
+// a resolved colour. Clients with a plain `#RRGGBB` parser (iOS `Color(hex:)`)
+// can't read those, so they silently fall back.
+//
+// The browser side resolves each token through a `<canvas>` 2D `fillStyle`
+// round-trip — the most reliable CSS-colour→sRGB normaliser available — which
+// yields `#rrggbb` (opaque) or `rgba(r, g, b, a)` (translucent). This module is
+// the pure tail of that: turn a canvas-normalised colour string into the
+// `#RRGGBB` / `#RRGGBBAA` form every client understands.
+
+function clampByte(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(255, Math.round(n)));
+}
+
+function hex2(n: number): string {
+  return clampByte(n).toString(16).padStart(2, "0");
+}
+
+/**
+ * Convert a canvas-normalised colour string to `#RRGGBB` (opaque) or
+ * `#RRGGBBAA` (translucent). Accepts:
+ *   - `#rgb` / `#rgba` / `#rrggbb` / `#rrggbbaa` (passed through, expanded, and
+ *     lower-cased; a fully-opaque alpha is dropped)
+ *   - `rgb(r, g, b)` / `rgba(r, g, b, a)` (canvas's serialisation)
+ * Anything unrecognised is returned unchanged, so callers can keep the raw
+ * token rather than corrupt it.
+ */
+export function normalizedColorToHex(input: string): string {
+  const value = input.trim();
+  if (!value) return input;
+
+  if (value.startsWith("#")) {
+    const h = value.slice(1).toLowerCase();
+    // #rgb / #rgba → expand each nibble.
+    if (h.length === 3 || h.length === 4) {
+      const expanded = h
+        .split("")
+        .map((c) => c + c)
+        .join("");
+      return collapseOpaque(`#${expanded}`);
+    }
+    if (h.length === 6 || h.length === 8) return collapseOpaque(`#${h}`);
+    return input;
+  }
+
+  const m = value.match(/^rgba?\(([^)]+)\)$/i);
+  if (!m) return input;
+  // Pull the channel numbers out, tolerating both comma- and space-separated
+  // forms. Percentages on RGB channels aren't part of canvas's serialisation,
+  // so a plain numeric parse is sufficient.
+  const nums = m[1].match(/-?[\d.]+/g);
+  if (!nums || nums.length < 3) return input;
+  const r = clampByte(parseFloat(nums[0]));
+  const g = clampByte(parseFloat(nums[1]));
+  const b = clampByte(parseFloat(nums[2]));
+  const a = nums.length >= 4 ? clampByte(parseFloat(nums[3]) * 255) : 255;
+  return a >= 255 ? `#${hex2(r)}${hex2(g)}${hex2(b)}` : `#${hex2(r)}${hex2(g)}${hex2(b)}${hex2(a)}`;
+}
+
+/** Drop a redundant fully-opaque alpha so `#rrggbbff` → `#rrggbb`. */
+function collapseOpaque(hex: string): string {
+  if (hex.length === 9 && hex.slice(7).toLowerCase() === "ff") return hex.slice(0, 7);
+  return hex;
+}


### PR DESCRIPTION
Follow-up to #1413 (iOS theme consumption), found by verifying the feature in the running app.

## The bug
The desktop mirrors its colour tokens to `GET /api/theme` so other clients (the iOS app) can match the appearance. `persistThemeTokens()` posted `getComputedStyle(html).getPropertyValue(token)` for each — but the **computed value of a CSS custom property is its authored form**, which in this codebase is modern CSS: `lab(...)`, `oklch(...)`, `color-mix(in oklch, …)`.

iOS `Color(hex:)` only parses `#RRGGBB`/`#RRGGBBAA`. So on the **real** live payload, only `--accent-presence` (which happens to be a hex literal) and `mode` actually transferred; `--bg-base`, `--text-*`, and `--border-hairline` (all `lab()`/`color-mix()`) silently fell back to system colours. The issue #1413 contract assumed "resolved hex" — this restores that intent.

## The fix
`persistThemeTokens` now resolves each token through a `<canvas>` `fillStyle` round-trip (the reliable CSS-colour→sRGB normaliser) before PUT, producing `#rrggbb` / `#rrggbbaa`. A new pure helper `normalizedColorToHex` (`src/lib/theme-token-hex.ts`) converts the canvas serialisation (`#rrggbb` or `rgb()/rgba()`) to hex; unparseable input passes through unchanged so a token is **never made worse** than today (graceful for older engines / context-unavailable).

One-way desktop → iOS, unchanged. No iOS changes needed — the existing `ChromePalette` parser now receives hex for every token.

## Verification
- `tsc --noEmit`: 0 errors.
- New `src/lib/theme-token-hex.test.ts` (10 cases: rgb/rgba→hex, alpha rounding, sRGB clamping, shorthand expansion, opaque-alpha collapse, raw-passthrough, + a source-text guard that `persistThemeTokens` resolves via the canvas and never PUTs the raw value). Wired into the app suite + `ALIAS_LOADER`.
- `settings-appearance` + `theme-color-editor` tests still pass; `check:tests-wired` green (507 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)