### PR TITLE
feat(library): make bulk delete undoable

### DIFF
--- a/src/components/library-bookmarks-list.tsx
+++ b/src/components/library-bookmarks-list.tsx
@@ -249,7 +249,7 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
     }
   }
 
-  const { pending: undoPending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<LibraryBookmark>();
+  const { pending: undoPending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<LibraryBookmark | LibraryBookmark[]>();
 
   function handleDelete(item: LibraryBookmark) {
     setItems((prev) => prev.filter((i) => i.id !== item.id));
@@ -262,7 +262,8 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
 
   function handleUndoDelete() {
     if (!undoPending) return;
-    setItems((prev) => [undoPending.item, ...prev]);
+    const restored = undoPending.item;
+    setItems((prev) => [...(Array.isArray(restored) ? restored : [restored]), ...prev]);
     undoDelete();
   }
 
@@ -285,13 +286,16 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
       return next;
     });
   function bulkDelete() {
-    const ids = items.filter((i) => selectedIds.has(i.id)).map((i) => i.id);
-    if (ids.length === 0) return;
+    const removed = items.filter((i) => selectedIds.has(i.id));
+    if (removed.length === 0) return;
+    const ids = removed.map((i) => i.id);
     setItems((prev) => prev.filter((i) => !ids.includes(i.id)));
-    void Promise.all(
-      ids.map((id) =>
+    scheduleDelete(
+      removed,
+      `${removed.length} bookmark${removed.length === 1 ? "" : "s"}`,
+      () => Promise.all(ids.map((id) =>
         fetch(`/api/library/bookmarks?id=${encodeURIComponent(id)}`, { method: "DELETE" }).then(() => {}).catch(() => {}),
-      ),
+      )).then(() => {}),
     );
     exitSelect();
   }

--- a/src/components/library-github-list.tsx
+++ b/src/components/library-github-list.tsx
@@ -641,7 +641,7 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
     }
   }
 
-  const { pending: undoPending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<LibraryGitHubItem>();
+  const { pending: undoPending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<LibraryGitHubItem | LibraryGitHubItem[]>();
 
   function handleDelete(item: LibraryGitHubItem) {
     setItems((prev) => prev.filter((i) => i.id !== item.id));
@@ -654,7 +654,8 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
 
   function handleUndoDelete() {
     if (!undoPending) return;
-    setItems((prev) => [undoPending.item, ...prev]);
+    const restored = undoPending.item;
+    setItems((prev) => [...(Array.isArray(restored) ? restored : [restored]), ...prev]);
     undoDelete();
   }
 
@@ -677,13 +678,16 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
       return next;
     });
   function bulkDelete() {
-    const ids = items.filter((i) => selectedIds.has(i.id)).map((i) => i.id);
-    if (ids.length === 0) return;
+    const removed = items.filter((i) => selectedIds.has(i.id));
+    if (removed.length === 0) return;
+    const ids = removed.map((i) => i.id);
     setItems((prev) => prev.filter((i) => !ids.includes(i.id)));
-    void Promise.all(
-      ids.map((id) =>
+    scheduleDelete(
+      removed,
+      `${removed.length} item${removed.length === 1 ? "" : "s"}`,
+      () => Promise.all(ids.map((id) =>
         fetch(`/api/library/github?id=${encodeURIComponent(id)}`, { method: "DELETE" }).then(() => {}).catch(() => {}),
-      ),
+      )).then(() => {}),
     );
     exitSelect();
   }

--- a/src/components/library-polish.test.ts
+++ b/src/components/library-polish.test.ts
@@ -714,3 +714,12 @@ for (const [name, src, api] of [["bookmarks", bookmarks, "bookmarks"], ["github"
   assert.match(src, /\{allSelected \? "Clear" : "Select all"\}/, `${name} bulk bar offers select-all / clear`);
   assert.match(src, /className="library-bulk-check"/, `${name} rows show a checkbox in select mode`);
 }
+
+// Bulk delete is undoable across all three lists: it routes through the delayed
+// scheduleDelete (not an immediate Promise.all), and undo restores the batch.
+for (const [name, src] of [["reading", reading], ["bookmarks", bookmarks], ["github", github]]) {
+  assert.match(src, /useUndoDelete<\w+ \| \w+\[\]>\(\)/, `${name} undo entry holds a single item or a bulk batch`);
+  assert.match(src, /scheduleDelete\(\s*removed,/, `${name} bulk delete schedules the batch through the undo window`);
+  assert.doesNotMatch(src, /function bulkDelete\(\)[\s\S]*?void Promise\.all/, `${name} bulk delete no longer fires deletes immediately`);
+  assert.match(src, /\[\.\.\.\(Array\.isArray\(restored\) \? restored : \[restored\]\), \.\.\.prev\]/, `${name} undo restores both single and bulk deletes`);
+}

--- a/src/components/library-reading-list.tsx
+++ b/src/components/library-reading-list.tsx
@@ -295,7 +295,8 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
     }
   }
 
-  const { pending: undoPending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<LibraryReadingItem>();
+  // One undo entry holds either a single item or a bulk batch (array).
+  const { pending: undoPending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<LibraryReadingItem | LibraryReadingItem[]>();
 
   function handleDelete(item: LibraryReadingItem) {
     setItems((prev) => prev.filter((i) => i.id !== item.id));
@@ -308,7 +309,8 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
 
   function handleUndoDelete() {
     if (!undoPending) return;
-    setItems((prev) => [undoPending.item, ...prev]);
+    const restored = undoPending.item;
+    setItems((prev) => [...(Array.isArray(restored) ? restored : [restored]), ...prev]);
     undoDelete();
   }
 
@@ -321,15 +323,19 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
       else items.forEach((i) => next.add(i.id));
       return next;
     });
-  // Bulk remove: optimistic drop + fire the per-item deletes in parallel.
+  // Bulk remove: optimistic drop + a single undo entry; the per-item deletes
+  // fire (in parallel) only after the undo window, so Undo fully restores them.
   function bulkDelete() {
-    const ids = items.filter((i) => selectedIds.has(i.id)).map((i) => i.id);
-    if (ids.length === 0) return;
+    const removed = items.filter((i) => selectedIds.has(i.id));
+    if (removed.length === 0) return;
+    const ids = removed.map((i) => i.id);
     setItems((prev) => prev.filter((i) => !ids.includes(i.id)));
-    void Promise.all(
-      ids.map((id) =>
+    scheduleDelete(
+      removed,
+      `${removed.length} item${removed.length === 1 ? "" : "s"}`,
+      () => Promise.all(ids.map((id) =>
         fetch(`/api/library/reading?id=${encodeURIComponent(id)}`, { method: "DELETE" }).then(() => {}).catch(() => {}),
-      ),
+      )).then(() => {}),
     );
     exitSelect();
   }


### PR DESCRIPTION
The Library single-item deletes already use a delayed-delete + **undo toast** (`useUndoDelete`), but the **bulk** Remove I added (#1705, #1723) fired the per-item DELETEs immediately — the most destructive action had no safety net.

## What
Bulk Remove on the **reading**, **bookmarks**, and **GitHub** lists now routes through the same undo mechanism:
- rows drop optimistically,
- the actual `DELETE`s fire only **after the undo window**,
- **Undo** restores the whole batch.

The undo entry type is widened to `Item | Item[]` so one toast/handler covers both single and bulk deletes — no new component, no duplicated logic.

## Verification
- `pnpm typecheck` clean; `app` suite → **385 files pass** (assertions added: bulk routes through `scheduleDelete`, no immediate `Promise.all`, undo restores arrays).
- Browser-driven (reading): select 2 → Remove → 4→2 rows + undo toast → **Undo** → back to 4 with **zero** DELETE calls, even after the 4s window.

(Chats/Projects bulk delete use a server-refetch model where delayed-delete is trickier — left as a follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)