### PR TITLE
feat(ios): chat empty state + surface pull-to-refresh errors

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -149,11 +149,14 @@ final class ChatThread: Identifiable, Hashable {
     /// catches up. Direct threads only: a group is N independent sessions with no
     /// shared turn ordering to merge. Skipped while streaming (and when there's no
     /// server session yet) so an in-flight reply is never clobbered.
-    func reload(client: CaveClient) async {
+    /// Re-sync a direct chat from the server. No-ops for groups / streaming /
+    /// unsent threads; THROWS on a real fetch failure so the caller (pull to
+    /// refresh) can surface it instead of failing silently.
+    func reload(client: CaveClient) async throws {
         guard !isGroup, !isStreaming,
               let familiarId = familiarIds.first,
-              let sessionId = sessionIds[familiarId],
-              let convo = try? await client.conversation(sessionId: sessionId) else { return }
+              let sessionId = sessionIds[familiarId] else { return }
+        guard let convo = try await client.conversation(sessionId: sessionId) else { return }
         messages = convo.turns.map { turn in
             let role = DisplayMessage.Role(rawValue: turn.role) ?? .assistant
             return DisplayMessage(role: role,

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -217,9 +217,26 @@ struct ChatView: View {
             // Pull to re-sync a direct chat that may have advanced on another
             // device (no-op for groups / unsent threads, see ChatThread.reload).
             .refreshable {
-                if let client = app.client {
-                    await thread.reload(client: client)
+                guard let client = app.client else { return }
+                do {
+                    try await thread.reload(client: client)
                     app.persistThreads()
+                } catch {
+                    app.showToast("Couldn't refresh this chat",
+                                  systemImage: "exclamationmark.triangle.fill", style: .error)
+                }
+            }
+            // A fresh thread with no messages shouldn't read as a blank void.
+            .overlay {
+                if thread.messages.isEmpty {
+                    ContentUnavailableView {
+                        Label("Start the conversation", systemImage: "bubble.left.and.bubble.right")
+                    } description: {
+                        Text(thread.isGroup
+                             ? "Send a message to all \(thread.familiarIds.count) familiars."
+                             : "Send a message to \(app.familiar(thread.familiarIds.first ?? "")?.displayName ?? "this familiar") to begin.")
+                    }
+                    .allowsHitTesting(false)
                 }
             }
             // Track whether the user is parked at the latest message so a


### PR DESCRIPTION
## What

Two small chat-quality fixes (verified on the iPhone 16 Pro simulator):

1. **Empty-message state** — a fresh thread with no messages rendered a blank void. Now shows a `ContentUnavailableView`: **"Start the conversation"** / "Send a message to *<familiar>* to begin." (group variant counts the familiars), with the composer still ready below.

2. **Surface pull-to-refresh errors** — pulling to refresh a direct chat failed *silently*: `ChatThread.reload` swallowed the fetch error with `try?`. It now **throws** on a real failure (still no-ops for groups / streaming / unsent threads), and the refresh handler catches it and shows an **error toast**.

(`loadReading` / `loadSessions` already set + surface their error state, so those refreshes were correctly left as-is — that part of the original audit was overstated.)

## Verification

iOS isn't in CI. On the simulator, an empty thread shows the "Start the conversation" prompt with the familiar's name resolved ("Charm"); clean build. `reload` is called from exactly one place (the refresh handler), so making it throw is fully contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)