### PR TITLE
feat(ios): reminder actions — done, snooze, dismiss

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -420,6 +420,25 @@ struct CaveClient {
         try Self.check(resp)
     }
 
+    struct ReminderActionResponse: Decodable { var ok: Bool; var error: String?; var item: Reminder? }
+
+    /// `POST /api/inbox/{id}/{action}` — done / dismiss / snooze. Returns the
+    /// server's updated item when present.
+    @discardableResult
+    private func inboxAction(_ id: String, _ action: String, body: Data? = nil) async throws -> Reminder? {
+        let escaped = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+        let req = try request("api/inbox/\(escaped)/\(action)", method: "POST", body: body)
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        return try? JSONDecoder().decode(ReminderActionResponse.self, from: data).item
+    }
+
+    @discardableResult func markReminderDone(id: String) async throws -> Reminder? { try await inboxAction(id, "done") }
+    @discardableResult func dismissReminder(id: String) async throws -> Reminder? { try await inboxAction(id, "dismiss") }
+    @discardableResult func snoozeReminder(id: String, minutes: Int) async throws -> Reminder? {
+        try await inboxAction(id, "snooze", body: try JSONEncoder().encode(["minutes": minutes]))
+    }
+
     private struct ReadingPatch: Encodable {
         var id: String
         var status: String

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -396,6 +396,36 @@ final class AppModel {
         }
     }
 
+    func markReminderDone(_ reminder: Reminder) async {
+        await reminderAction(reminder, optimistic: "done") { try await $0.markReminderDone(id: reminder.id) }
+    }
+    func dismissReminder(_ reminder: Reminder) async {
+        await reminderAction(reminder, optimistic: "dismissed") { try await $0.dismissReminder(id: reminder.id) }
+    }
+    func snoozeReminder(_ reminder: Reminder, minutes: Int) async {
+        await reminderAction(reminder, optimistic: "snoozed") { try await $0.snoozeReminder(id: reminder.id, minutes: minutes) }
+    }
+
+    /// Optimistically set a reminder's status, run the server action, reconcile
+    /// with the echoed item, and revert on failure.
+    private func reminderAction(_ reminder: Reminder, optimistic: String,
+                                _ call: (CaveClient) async throws -> Reminder?) async {
+        guard let client else { return }
+        let previous = reminders
+        applyReminder(id: reminder.id) { $0.status = optimistic }
+        do {
+            if let updated = try await call(client) { applyReminder(id: reminder.id) { $0 = updated } }
+        } catch {
+            reminders = previous
+            remindersError = error.localizedDescription
+        }
+    }
+
+    private func applyReminder(id: String, _ mutate: (inout Reminder) -> Void) {
+        guard let idx = reminders.firstIndex(where: { $0.id == id }) else { return }
+        var r = reminders[idx]; mutate(&r); reminders[idx] = r
+    }
+
     /// Set how far through an item the reader is (0–100), keeping its status.
     /// Optimistic, with rollback on failure.
     func setReadingProgress(_ item: ReadingItem, _ progress: Int) async {

--- a/apps/ios/CovenCave/CovenCave/Views/RemindersView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RemindersView.swift
@@ -88,6 +88,28 @@ struct RemindersView: View {
                             Task { await app.deleteReminders([reminder.id]) }
                         } label: { Label("Delete", systemImage: "trash") }
                     }
+                    .swipeActions(edge: .leading) {
+                        Button { Task { await app.markReminderDone(reminder) } } label: {
+                            Label("Done", systemImage: "checkmark.circle")
+                        }
+                        .tint(.green)
+                    }
+                    .contextMenu {
+                        Button { Task { await app.markReminderDone(reminder) } } label: {
+                            Label("Mark done", systemImage: "checkmark.circle")
+                        }
+                        Menu {
+                            Button("15 minutes") { Task { await app.snoozeReminder(reminder, minutes: 15) } }
+                            Button("1 hour") { Task { await app.snoozeReminder(reminder, minutes: 60) } }
+                            Button("1 day") { Task { await app.snoozeReminder(reminder, minutes: 1440) } }
+                        } label: { Label("Snooze", systemImage: "moon.zzz") }
+                        Button { Task { await app.dismissReminder(reminder) } } label: {
+                            Label("Dismiss", systemImage: "xmark.circle")
+                        }
+                        Button(role: .destructive) { Task { await app.deleteReminders([reminder.id]) } } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
                 }
             }
             .listStyle(.plain)

--- a/scripts/ios-reminder-actions.test.mjs
+++ b/scripts/ios-reminder-actions.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+const read = (rel) => readFile(new URL(`../${rel}`, import.meta.url), "utf8");
+const iosRoot = "apps/ios/CovenCave/CovenCave";
+
+const client = await read(`${iosRoot}/Networking/CaveClient.swift`);
+const app = await read(`${iosRoot}/State/AppModel.swift`);
+const view = await read(`${iosRoot}/Views/RemindersView.swift`);
+
+// Client posts done/dismiss/snooze to /api/inbox/{id}/{action}.
+assert.match(client, /func inboxAction\(_ id: String, _ action: String, body: Data\? = nil\) async throws -> Reminder\?/, "shared inbox action poster");
+assert.match(client, /api\/inbox\/\\\(escaped\)\/\\\(action\)", method: "POST"/, "posts to the action sub-route");
+assert.match(client, /func markReminderDone\(id: String\)[\s\S]*inboxAction\(id, "done"\)/, "done action");
+assert.match(client, /func dismissReminder\(id: String\)[\s\S]*inboxAction\(id, "dismiss"\)/, "dismiss action");
+assert.match(client, /func snoozeReminder\(id: String, minutes: Int\)[\s\S]*"snooze", body: try JSONEncoder\(\)\.encode\(\["minutes": minutes\]\)/, "snooze sends minutes");
+
+// Model applies optimistic status + reconciles from the echoed item.
+assert.match(app, /func markReminderDone\(_ reminder: Reminder\) async/, "AppModel.markReminderDone");
+assert.match(app, /func snoozeReminder\(_ reminder: Reminder, minutes: Int\) async/, "AppModel.snoozeReminder");
+assert.match(app, /func reminderAction\(_ reminder: Reminder, optimistic: String,[\s\S]*applyReminder\(id: reminder\.id\) \{ \$0\.status = optimistic \}[\s\S]*if let updated = try await call\(client\)[\s\S]*catch[\s\S]*reminders = previous/, "optimistic + reconcile + revert");
+
+// View exposes the actions.
+assert.match(view, /Task \{ await app\.markReminderDone\(reminder\) \}/, "Done wired in the view");
+assert.match(view, /Task \{ await app\.snoozeReminder\(reminder, minutes: 60\) \}/, "Snooze durations wired");
+assert.match(view, /Task \{ await app\.dismissReminder\(reminder\) \}/, "Dismiss wired");
+assert.match(view, /Label\("Snooze", systemImage: "moon\.zzz"\)/, "Snooze submenu present");
+
+console.log("ios-reminder-actions.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -520,6 +520,7 @@ export const SUITES = {
     "scripts/ios-bulk-delete-threads.test.mjs",
     "scripts/ios-export-selected-zip.test.mjs",
     "scripts/ios-reminders-bulk-delete.test.mjs",
+    "scripts/ios-reminder-actions.test.mjs",
     "scripts/ios-reorder-familiars.test.mjs",
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/ios-theme.test.mjs",


### PR DESCRIPTION
## What

Deepens the iOS Reminders view (#1728) beyond list + delete with the real inbox actions. All are reachable from the phone (`POST /api/inbox/{id}/{done,dismiss,snooze}` aren't loopback-gated — only *creating* reminders is desktop-only).

- **`CaveClient`** — `markReminderDone` / `dismissReminder` / `snoozeReminder(minutes:)` post to the action sub-routes via a shared `inboxAction` helper and decode the server's echoed item.
- **`AppModel`** — optimistic status updates (`done` / `dismissed` / `snoozed`) that reconcile with the returned item and **revert on failure**.
- **`RemindersView`** — a leading-swipe **Done**, plus a context menu: **Mark done**, **Snooze** (15 min / 1 hour / 1 day), **Dismiss**, **Delete**.

## Verification

- `pnpm test:mobile` → **✓ 42 test file(s) passed** (full suite; new `scripts/ios-reminder-actions.test.mjs`).
- `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED**.

Interactive actions (swipe/long-press → done/snooze/dismiss) need gestures I can't drive headlessly without `idb`, so they rest on build + assertion test + the proven optimistic-reconcile pattern.

> Built via an atomic sibling-worktree one-shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)