### PR TITLE
fix(theme): rasterise theme tokens to sRGB hex (fixes ineffective #1733)

### DIFF
--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -20,7 +20,7 @@ import { APP_VERSION } from "@/lib/app-version";
 import { UpdateSettingsRow } from "@/components/update-available";
 import { useIsMobile } from "@/lib/use-viewport";
 import { ThemeColorEditor } from "@/components/theme-color-editor";
-import { normalizedColorToHex } from "@/lib/theme-token-hex";
+import { rgbaBytesToHex } from "@/lib/theme-token-hex";
 import { FontSettings } from "./settings-fonts";
 import {
   CORNER_RADIUS_OPTIONS,
@@ -640,24 +640,28 @@ const THEME_SYNC_KEYS = [
 ] as const;
 
 /**
- * Resolve any CSS colour string to plain sRGB hex via a `<canvas>` `fillStyle`
- * round-trip. `getComputedStyle` hands back a custom property's *authored* value
- * (`lab(...)`, `oklch(...)`, `color-mix(...)`), which a hex-only client (iOS
- * `Color(hex:)`) can't read; assigning it to a canvas context and reading it
- * back normalises it to `#rrggbb` / `rgba(...)` in sRGB. Falls back to the raw
- * value if the context is unavailable or rejects the colour, so a token is
- * never made worse than it is today.
+ * Resolve any CSS colour string to plain sRGB hex by *rasterising* it: paint the
+ * colour onto a 1×1 canvas and read the pixel back. `getComputedStyle` hands
+ * back a custom property's *authored* value (`lab(...)`, `oklch(...)`,
+ * `color-mix(...)`), which a hex-only client (iOS `Color(hex:)`) can't read.
+ *
+ * NB: reading `ctx.fillStyle` back does NOT down-convert — modern engines keep
+ * `lab()`/`oklch()` there (CSS Color 4). Painting forces conversion into the
+ * canvas's sRGB backing store, so `getImageData` yields real sRGB bytes. Falls
+ * back to the raw value if the context is unavailable or the read throws, so a
+ * token is never made worse than it is today.
  */
 function resolveTokenToHex(ctx: CanvasRenderingContext2D | null, raw: string): string {
   if (!ctx) return raw;
-  const SENTINEL = "#010203";
-  ctx.fillStyle = SENTINEL;
-  ctx.fillStyle = raw;
-  const got = ctx.fillStyle;
-  // An unparseable colour leaves fillStyle at the sentinel — keep the original.
-  if (typeof got !== "string") return raw;
-  if (got.toLowerCase() === SENTINEL && raw.trim().toLowerCase() !== SENTINEL) return raw;
-  return normalizedColorToHex(got);
+  try {
+    ctx.clearRect(0, 0, 1, 1);
+    ctx.fillStyle = raw;
+    ctx.fillRect(0, 0, 1, 1);
+    const [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data;
+    return rgbaBytesToHex(r, g, b, a);
+  } catch {
+    return raw;
+  }
 }
 
 function persistThemeTokens() {
@@ -665,7 +669,9 @@ function persistThemeTokens() {
   try {
     const html = document.documentElement;
     const cs = getComputedStyle(html);
-    const ctx = document.createElement("canvas").getContext("2d");
+    const canvas = document.createElement("canvas");
+    canvas.width = canvas.height = 1;
+    const ctx = canvas.getContext("2d", { willReadFrequently: true });
     const tokens: Record<string, string> = {};
     for (const key of THEME_SYNC_KEYS) {
       const value = cs.getPropertyValue(key).trim();

--- a/src/lib/theme-token-hex.test.ts
+++ b/src/lib/theme-token-hex.test.ts
@@ -2,63 +2,45 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
-import { normalizedColorToHex } from "./theme-token-hex";
+import { rgbaBytesToHex } from "./theme-token-hex";
 
-test("persistThemeTokens resolves tokens to hex via a canvas round-trip before PUT", () => {
-  const src = readFileSync(new URL("../components/settings-shell.tsx", import.meta.url), "utf8");
-  // Tokens must be normalised through the canvas resolver, not posted raw — the
-  // bug was PUTting getComputedStyle's authored lab()/color-mix() values.
-  assert.match(src, /getContext\("2d"\)/, "should create a 2D canvas context to resolve colours");
-  assert.match(src, /resolveTokenToHex\(ctx, value\)/, "tokens should be resolved before being sent");
-  assert.match(src, /normalizedColorToHex\(got\)/, "the canvas result should be normalised to hex");
-  // Guard against a regression back to posting the raw computed value.
-  assert.doesNotMatch(src, /tokens\[key\]\s*=\s*value;/, "must not PUT the raw authored token value");
-});
-
-test("passes through #rrggbb unchanged (lower-cased)", () => {
-  assert.equal(normalizedColorToHex("#9A8ECD"), "#9a8ecd");
-  assert.equal(normalizedColorToHex("#161422"), "#161422");
-});
-
-test("expands #rgb and #rgba shorthand", () => {
-  assert.equal(normalizedColorToHex("#abc"), "#aabbcc");
-  assert.equal(normalizedColorToHex("#abcd"), "#aabbccdd");
-});
-
-test("drops a redundant fully-opaque alpha", () => {
-  assert.equal(normalizedColorToHex("#112233ff"), "#112233");
-  assert.equal(normalizedColorToHex("#abcf"), "#aabbcc");
+test("builds #rrggbb from opaque sRGB bytes", () => {
+  assert.equal(rgbaBytesToHex(154, 142, 205, 255), "#9a8ecd");
+  assert.equal(rgbaBytesToHex(8, 6, 15, 255), "#08060f");
+  assert.equal(rgbaBytesToHex(0, 0, 0), "#000000");
+  assert.equal(rgbaBytesToHex(255, 255, 255), "#ffffff");
 });
 
 test("keeps a meaningful alpha as #rrggbbaa", () => {
-  assert.equal(normalizedColorToHex("#11223380"), "#11223380");
+  // color-mix(... 55%) → white at alpha 0x8c
+  assert.equal(rgbaBytesToHex(250, 250, 250, 140), "#fafafa8c");
+  assert.equal(rgbaBytesToHex(247, 247, 247, 31), "#f7f7f71f");
 });
 
-test("converts rgb() to #rrggbb (canvas serialisation)", () => {
-  assert.equal(normalizedColorToHex("rgb(154, 142, 205)"), "#9a8ecd");
-  assert.equal(normalizedColorToHex("rgb(0, 0, 0)"), "#000000");
-  assert.equal(normalizedColorToHex("rgb(255, 255, 255)"), "#ffffff");
+test("drops a redundant fully-opaque alpha (and defaults to opaque)", () => {
+  assert.equal(rgbaBytesToHex(17, 34, 51, 255), "#112233");
+  assert.equal(rgbaBytesToHex(17, 34, 51), "#112233");
 });
 
-test("converts rgba() with alpha to #rrggbbaa", () => {
-  // 0.5 * 255 = 127.5 → rounds to 128 = 0x80
-  assert.equal(normalizedColorToHex("rgba(17, 34, 51, 0.5)"), "#11223380");
-  // fully opaque rgba collapses to 6 digits
-  assert.equal(normalizedColorToHex("rgba(154, 142, 205, 1)"), "#9a8ecd");
+test("clamps out-of-range channels into the sRGB byte range", () => {
+  assert.equal(rgbaBytesToHex(300, -5, 128), "#ff0080");
+  assert.equal(rgbaBytesToHex(0, 0, 0, 999), "#000000");
 });
 
-test("clamps out-of-range channels into sRGB byte range", () => {
-  assert.equal(normalizedColorToHex("rgb(300, -5, 128)"), "#ff0080");
+test("rounds fractional channels", () => {
+  assert.equal(rgbaBytesToHex(127.5, 127.4, 0.6), "#807f01");
 });
 
-test("tolerates space-separated rgb (color-4 serialisation)", () => {
-  assert.equal(normalizedColorToHex("rgb(154 142 205)"), "#9a8ecd");
-});
-
-test("returns unrecognised input unchanged so callers keep the raw token", () => {
-  // If the canvas round-trip is ever skipped, an unresolved lab()/color-mix()
-  // string must pass through rather than be corrupted.
-  assert.equal(normalizedColorToHex("lab(1.87792% 1.50546 -3.6698)"), "lab(1.87792% 1.50546 -3.6698)");
-  assert.equal(normalizedColorToHex("color-mix(in oklch, white 55%, transparent)"), "color-mix(in oklch, white 55%, transparent)");
-  assert.equal(normalizedColorToHex(""), "");
+test("persistThemeTokens rasterises tokens to sRGB hex before PUT", () => {
+  const src = readFileSync(new URL("../components/settings-shell.tsx", import.meta.url), "utf8");
+  // Must paint + read the pixel — reading fillStyle back doesn't down-convert
+  // lab()/oklch() on modern engines (CSS Color 4).
+  assert.match(src, /getContext\("2d",\s*\{\s*willReadFrequently:\s*true\s*\}\)/, "should request a readback-optimised 2D context");
+  assert.match(src, /ctx\.fillRect\(0,\s*0,\s*1,\s*1\)/, "should paint the colour onto the canvas");
+  assert.match(src, /ctx\.getImageData\(0,\s*0,\s*1,\s*1\)\.data/, "should read the rasterised sRGB pixel");
+  assert.match(src, /rgbaBytesToHex\(r,\s*g,\s*b,\s*a\)/, "should convert the sRGB bytes to hex");
+  // Guard against regressions: never PUT the raw authored token, and don't rely
+  // on the fillStyle round-trip alone.
+  assert.doesNotMatch(src, /tokens\[key\]\s*=\s*value;/, "must not PUT the raw authored token value");
+  assert.doesNotMatch(src, /return normalizedColorToHex\(got\)/, "must not depend on the fillStyle round-trip");
 });

--- a/src/lib/theme-token-hex.ts
+++ b/src/lib/theme-token-hex.ts
@@ -7,11 +7,13 @@
 // a resolved colour. Clients with a plain `#RRGGBB` parser (iOS `Color(hex:)`)
 // can't read those, so they silently fall back.
 //
-// The browser side resolves each token through a `<canvas>` 2D `fillStyle`
-// round-trip — the most reliable CSS-colour→sRGB normaliser available — which
-// yields `#rrggbb` (opaque) or `rgba(r, g, b, a)` (translucent). This module is
-// the pure tail of that: turn a canvas-normalised colour string into the
-// `#RRGGBB` / `#RRGGBBAA` form every client understands.
+// The browser side resolves each token by *rasterising* it: paint the colour
+// onto a 1×1 `<canvas>` (whose backing store is sRGB) and read the pixel back
+// with `getImageData`, which always yields sRGB bytes regardless of the input
+// colour space. Reading `ctx.fillStyle` back is NOT enough — modern engines
+// preserve `lab()`/`oklch()` there (CSS Color 4), so the wide-gamut string
+// would survive untouched. This module is the pure tail of that: turn the
+// sRGB RGBA bytes into the `#RRGGBB` / `#RRGGBBAA` form every client understands.
 
 function clampByte(n: number): number {
   if (!Number.isFinite(n)) return 0;
@@ -23,48 +25,12 @@ function hex2(n: number): string {
 }
 
 /**
- * Convert a canvas-normalised colour string to `#RRGGBB` (opaque) or
- * `#RRGGBBAA` (translucent). Accepts:
- *   - `#rgb` / `#rgba` / `#rrggbb` / `#rrggbbaa` (passed through, expanded, and
- *     lower-cased; a fully-opaque alpha is dropped)
- *   - `rgb(r, g, b)` / `rgba(r, g, b, a)` (canvas's serialisation)
- * Anything unrecognised is returned unchanged, so callers can keep the raw
- * token rather than corrupt it.
+ * Build `#RRGGBB` (opaque) or `#RRGGBBAA` (translucent) from sRGB RGBA byte
+ * channels (0–255), as produced by a canvas `getImageData` read. A fully-opaque
+ * alpha is dropped so the common case stays `#RRGGBB`.
  */
-export function normalizedColorToHex(input: string): string {
-  const value = input.trim();
-  if (!value) return input;
-
-  if (value.startsWith("#")) {
-    const h = value.slice(1).toLowerCase();
-    // #rgb / #rgba → expand each nibble.
-    if (h.length === 3 || h.length === 4) {
-      const expanded = h
-        .split("")
-        .map((c) => c + c)
-        .join("");
-      return collapseOpaque(`#${expanded}`);
-    }
-    if (h.length === 6 || h.length === 8) return collapseOpaque(`#${h}`);
-    return input;
-  }
-
-  const m = value.match(/^rgba?\(([^)]+)\)$/i);
-  if (!m) return input;
-  // Pull the channel numbers out, tolerating both comma- and space-separated
-  // forms. Percentages on RGB channels aren't part of canvas's serialisation,
-  // so a plain numeric parse is sufficient.
-  const nums = m[1].match(/-?[\d.]+/g);
-  if (!nums || nums.length < 3) return input;
-  const r = clampByte(parseFloat(nums[0]));
-  const g = clampByte(parseFloat(nums[1]));
-  const b = clampByte(parseFloat(nums[2]));
-  const a = nums.length >= 4 ? clampByte(parseFloat(nums[3]) * 255) : 255;
-  return a >= 255 ? `#${hex2(r)}${hex2(g)}${hex2(b)}` : `#${hex2(r)}${hex2(g)}${hex2(b)}${hex2(a)}`;
-}
-
-/** Drop a redundant fully-opaque alpha so `#rrggbbff` → `#rrggbb`. */
-function collapseOpaque(hex: string): string {
-  if (hex.length === 9 && hex.slice(7).toLowerCase() === "ff") return hex.slice(0, 7);
-  return hex;
+export function rgbaBytesToHex(r: number, g: number, b: number, a = 255): string {
+  const alpha = clampByte(a);
+  const base = `#${hex2(r)}${hex2(g)}${hex2(b)}`;
+  return alpha >= 255 ? base : `${base}${hex2(alpha)}`;
 }


### PR DESCRIPTION
Verifying #1733 in a real browser revealed it **doesn't actually work** — a corrective follow-up.

## Why #1733 was ineffective
#1733 resolved tokens by assigning the colour to a canvas and reading `ctx.fillStyle` **back**. On modern engines that's a no-op for wide-gamut colours: CSS Color 4 makes the canvas **preserve** `lab()`/`oklch()` in `fillStyle` serialisation. So the live PUT still sent `lab(...)`/`oklch(...)`/`color-mix(...)`, and iOS's `#RRGGBB`-only parser still fell back. Confirmed against Chromium (Chrome for Testing 1223):

```
--bg-base   lab(1.87792% …)  --fillStyle-roundtrip-->  lab(1.87792 …)   ❌ still lab()
```

## The actual fix
Resolve each token by **rasterising** it: paint onto a 1×1 canvas (whose backing store is sRGB) and read the pixel back with `getImageData`, which always yields sRGB bytes regardless of the input colour space. New pure `rgbaBytesToHex(r,g,b,a)` builds `#RRGGBB` / `#RRGGBBAA` (alpha preserved).

```
--bg-base   lab(1.87792% …)  --fillRect+getImageData-->  #08060f   ✅
```

## Verified live (running app, Playwright + Chromium)
Loaded `/settings#appearance` (mounts `SettingsShell` → `persistThemeTokens`), captured the PUT, and read `/api/theme` back:

```
--bg-base #08060f · --bg-raised #0f0c18 · --bg-elevated #161422
--text-primary #fafafa · --text-secondary #92909d · --text-muted #fafafa8c
--border-hairline #f7f7f71f · --accent-presence #9a8ecd
→ allHex=true · anyCssColorFunction=false  ✅
```

(`ChromePalette` was already verified to apply an all-hex theme on the iOS sim, so the end-to-end chain now holds.)

## Verification
- `tsc --noEmit`: 0 errors.
- `theme-token-hex.test.ts` updated: unit cases for `rgbaBytesToHex` (opaque, alpha→`#rrggbbaa`, clamping, rounding) + a source-text guard that `persistThemeTokens` uses `fillRect`/`getImageData` and never PUTs the raw value. `settings-appearance` passes; `check:tests-wired` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)