### PR TITLE
feat(ios): bulk actions on selected reminders

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -421,6 +421,36 @@ final class AppModel {
         }
     }
 
+    // MARK: - Bulk reminder actions
+
+    func markRemindersDone(_ ids: Set<String>) async {
+        await bulkReminderAction(ids, optimistic: "done") { try await $0.markReminderDone(id: $1) }
+    }
+    func dismissReminders(_ ids: Set<String>) async {
+        await bulkReminderAction(ids, optimistic: "dismissed") { try await $0.dismissReminder(id: $1) }
+    }
+    func snoozeReminders(_ ids: Set<String>, minutes: Int) async {
+        await bulkReminderAction(ids, optimistic: "snoozed") { try await $0.snoozeReminder(id: $1, minutes: minutes) }
+    }
+
+    /// Apply an action to every selected reminder: optimistic status for all,
+    /// then run each server call reconciling its echoed item; revert all on any
+    /// failure.
+    private func bulkReminderAction(_ ids: Set<String>, optimistic: String,
+                                    _ call: @escaping (CaveClient, String) async throws -> Reminder?) async {
+        guard let client, !ids.isEmpty else { return }
+        let previous = reminders
+        for id in ids { applyReminder(id: id) { $0.status = optimistic } }
+        do {
+            for id in ids {
+                if let updated = try await call(client, id) { applyReminder(id: id) { $0 = updated } }
+            }
+        } catch {
+            reminders = previous
+            remindersError = error.localizedDescription
+        }
+    }
+
     private func applyReminder(id: String, _ mutate: (inout Reminder) -> Void) {
         guard let idx = reminders.firstIndex(where: { $0.id == id }) else { return }
         var r = reminders[idx]; mutate(&r); reminders[idx] = r

--- a/apps/ios/CovenCave/CovenCave/Views/RemindersView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RemindersView.swift
@@ -34,8 +34,24 @@ struct RemindersView: View {
                         HStack {
                             Button(allSelected ? "Deselect All" : "Select All") { toggleSelectAll() }
                             Spacer()
-                            Button(role: .destructive) { confirmingBulkDelete = true } label: {
-                                Text(selectedIds.isEmpty ? "Delete" : "Delete (\(selectedIds.count))")
+                            Menu {
+                                Button { Task { await app.markRemindersDone(selectedIds); exitSelect() } } label: {
+                                    Label("Mark done", systemImage: "checkmark.circle")
+                                }
+                                Menu {
+                                    Button("15 minutes") { Task { await app.snoozeReminders(selectedIds, minutes: 15); exitSelect() } }
+                                    Button("1 hour") { Task { await app.snoozeReminders(selectedIds, minutes: 60); exitSelect() } }
+                                    Button("1 day") { Task { await app.snoozeReminders(selectedIds, minutes: 1440); exitSelect() } }
+                                } label: { Label("Snooze", systemImage: "moon.zzz") }
+                                Button { Task { await app.dismissReminders(selectedIds); exitSelect() } } label: {
+                                    Label("Dismiss", systemImage: "xmark.circle")
+                                }
+                                Divider()
+                                Button(role: .destructive) { confirmingBulkDelete = true } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            } label: {
+                                Text(selectedIds.isEmpty ? "Actions" : "Actions (\(selectedIds.count))")
                                     .fontWeight(.semibold)
                             }
                             .disabled(selectedIds.isEmpty)

--- a/scripts/ios-reminder-bulk-actions.test.mjs
+++ b/scripts/ios-reminder-bulk-actions.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+const read = (rel) => readFile(new URL(`../${rel}`, import.meta.url), "utf8");
+const iosRoot = "apps/ios/CovenCave/CovenCave";
+
+const app = await read(`${iosRoot}/State/AppModel.swift`);
+const view = await read(`${iosRoot}/Views/RemindersView.swift`);
+
+// Model bulk-applies each action across the selection, optimistic + revert.
+for (const fn of ["markRemindersDone", "dismissReminders"]) {
+  assert.match(app, new RegExp(`func ${fn}\\(_ ids: Set<String>\\) async`), `AppModel.${fn}`);
+}
+assert.match(app, /func snoozeReminders\(_ ids: Set<String>, minutes: Int\) async/, "AppModel.snoozeReminders");
+assert.match(
+  app,
+  /func bulkReminderAction\(_ ids: Set<String>, optimistic: String,[\s\S]*for id in ids \{ applyReminder\(id: id\) \{ \$0\.status = optimistic \} \}[\s\S]*for id in ids \{[\s\S]*call\(client, id\)[\s\S]*catch[\s\S]*reminders = previous/,
+  "bulkReminderAction is optimistic-for-all + reconcile + revert",
+);
+
+// Select bar offers all four bulk actions on the selection.
+assert.match(view, /await app\.markRemindersDone\(selectedIds\); exitSelect\(\)/, "bulk Done on the selection");
+assert.match(view, /await app\.snoozeReminders\(selectedIds, minutes: 60\); exitSelect\(\)/, "bulk Snooze on the selection");
+assert.match(view, /await app\.dismissReminders\(selectedIds\); exitSelect\(\)/, "bulk Dismiss on the selection");
+assert.match(view, /Text\(selectedIds\.isEmpty \? "Actions" : "Actions \(\\\(selectedIds\.count\)\)"\)/, "an Actions (N) menu");
+assert.match(view, /Button\(role: \.destructive\) \{ confirmingBulkDelete = true \}/, "Delete stays in the menu");
+
+console.log("ios-reminder-bulk-actions.test.mjs: ok");

--- a/scripts/ios-reminders-bulk-delete.test.mjs
+++ b/scripts/ios-reminders-bulk-delete.test.mjs
@@ -28,7 +28,7 @@ assert.match(
 assert.match(view, /struct RemindersView: View/, "a RemindersView exists");
 assert.match(view, /@State private var selectMode = false/, "view has a select mode");
 assert.match(view, /await app\.deleteReminders\(selectedIds\)/, "bulk delete uses the selection");
-assert.match(view, /Text\(selectedIds\.isEmpty \? "Delete" : "Delete \(\\\(selectedIds\.count\)\)"\)/, "Delete (N) bar");
+assert.match(view, /Text\(selectedIds\.isEmpty \? "Actions" : "Actions \(\\\(selectedIds\.count\)\)"\)/, "an Actions (N) bar (delete + bulk actions)");
 assert.match(tasks, /\.sheet\(isPresented: \$showReminders\) \{ RemindersView\(\) \}/, "Tasks tab opens Reminders");
 
 console.log("ios-reminders-bulk-delete.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -521,6 +521,7 @@ export const SUITES = {
     "scripts/ios-export-selected-zip.test.mjs",
     "scripts/ios-reminders-bulk-delete.test.mjs",
     "scripts/ios-reminder-actions.test.mjs",
+    "scripts/ios-reminder-bulk-actions.test.mjs",
     "scripts/ios-reorder-familiars.test.mjs",
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/ios-theme.test.mjs",


### PR DESCRIPTION
## What

The Reminders **select** mode could only bulk-**delete** (#1728). This adds the other inbox actions to the selection.

- **`AppModel`** — `markRemindersDone` / `dismissReminders` / `snoozeReminders(minutes:)` via a shared `bulkReminderAction`: optimistic status for the whole set, a per-item server call reconciling each echoed item, and **revert-all on any failure**.
- **`RemindersView`** — the select bar's lone Delete button becomes an **"Actions (N)"** menu: **Mark done**, **Snooze** (15 min / 1 hour / 1 day), **Dismiss**, and **Delete**. Each applies to the selection and exits select mode (Delete still confirms first).

## Verification

- `pnpm test:mobile` → **✓ 43 test file(s) passed** (full suite).
- `xcodebuild` → **BUILD SUCCEEDED**.
- Caught + fixed a cross-test regression: changing the select bar's "Delete (N)" button to an "Actions" menu broke the #1728 test's pinned text, so I updated that assertion (the full suite surfaced it).

> Built via an atomic sibling-worktree one-shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)