### PR TITLE
fix(ios): readable chat markdown in light mode

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -12,6 +12,11 @@ struct MessageBubble: View {
     /// Regenerate this reply (assistant messages only); nil hides the action.
     var onRetry: (() -> Void)? = nil
 
+    // The bubble's WebView is transparent over a system-coloured bubble, so its
+    // prose must follow the app's light/dark appearance (the WebView doesn't
+    // pick up `prefers-color-scheme` on its own).
+    @Environment(\.colorScheme) private var colorScheme
+
     @State private var mdHeight: CGFloat = 0
     /// Set when the markdown WebView can't render (missing/stale bundle, JS
     /// error) — flips this bubble back to plain `Text` so the reply is never
@@ -179,6 +184,7 @@ struct MessageBubble: View {
         } else if rendersMarkdown {
             MarkdownWebView(markdown: parsed.visible, height: $mdHeight,
                             streaming: message.streaming && !isUser,
+                            theme: colorScheme == .light ? .light : .dark,
                             onFailure: { markdownFailed = true })
                 .frame(height: max(mdHeight, 1))
                 .padding(.horizontal, 14).padding(.vertical, 10)

--- a/apps/ios/markdown/entry.mjs
+++ b/apps/ios/markdown/entry.mjs
@@ -142,10 +142,10 @@ async function renderMarkdown(md, { streaming = false } = {}) {
 // a dark code card on a light page is intentional and dodges contrast problems.
 const THEME_VARS = {
   dark: null,
-  light: { "--txt": "#1c1c22", "--txt-muted": "#5b5b66", "--accent": "#5a51d6", "--hairline": "rgba(0,0,0,0.14)", bg: "#ffffff" },
-  sepia: { "--txt": "#43382a", "--txt-muted": "#7a6a55", "--accent": "#9a5a2a", "--hairline": "rgba(0,0,0,0.16)", bg: "#f4ecd8" },
+  light: { "--txt": "#1c1c22", "--txt-muted": "#5b5b66", "--accent": "#5a51d6", "--hairline": "rgba(0,0,0,0.14)", "--code-inline-bg": "rgba(90,81,214,0.12)", "--code-inline-fg": "#4b43c4", "--th-bg": "rgba(0,0,0,0.04)", bg: "#ffffff" },
+  sepia: { "--txt": "#43382a", "--txt-muted": "#7a6a55", "--accent": "#9a5a2a", "--hairline": "rgba(0,0,0,0.16)", "--code-inline-bg": "rgba(154,90,42,0.14)", "--code-inline-fg": "#8a4a1a", "--th-bg": "rgba(0,0,0,0.05)", bg: "#f4ecd8" },
 };
-const THEME_KEYS = ["--txt", "--txt-muted", "--accent", "--hairline"];
+const THEME_KEYS = ["--txt", "--txt-muted", "--accent", "--hairline", "--code-inline-bg", "--code-inline-fg", "--th-bg"];
 function applyTheme(name) {
   const de = document.documentElement;
   const t = THEME_VARS[name] || null;

--- a/apps/ios/markdown/markdown.css
+++ b/apps/ios/markdown/markdown.css
@@ -1,5 +1,8 @@
-/* World-class dark markdown styling for the native iOS chat bubbles.
-   Transparent background so it sits inside the SwiftUI assistant bubble. */
+/* Markdown styling for the native iOS chat bubbles. Transparent background so
+   it sits inside the SwiftUI assistant bubble. Defaults are dark; the renderer
+   injects a `light`/`sepia` palette over these vars (entry.mjs THEME_VARS) so
+   prose stays readable on a light bubble. Code blocks deliberately stay dark in
+   every theme — the syntax-highlight palette + toolbar are tuned for dark. */
 :root {
   --txt: #ECECF1;
   --txt-muted: #A9A9B8;
@@ -7,7 +10,12 @@
   --code-bg: #16161C;
   --code-border: rgba(255,255,255,0.08);
   --hairline: rgba(255,255,255,0.10);
+  /* themeable so inline code + table headers adapt with the prose */
+  --code-inline-bg: rgba(139,133,240,0.16);
+  --code-inline-fg: #C8C2FF;
+  --th-bg: rgba(255,255,255,0.04);
 }
+
 * { box-sizing: border-box; -webkit-text-size-adjust: 100%; }
 html, body { margin: 0; padding: 0; background: transparent; }
 body {
@@ -45,8 +53,8 @@ hr { border: 0; border-top: 1px solid var(--hairline); margin: 1em 0; }
 code {
   font-family: "SF Mono", ui-monospace, Menlo, monospace;
   font-size: 0.88em;
-  background: rgba(139,133,240,0.16);
-  color: #C8C2FF;
+  background: var(--code-inline-bg);
+  color: var(--code-inline-fg);
   padding: 0.12em 0.4em;
   border-radius: 5px;
 }
@@ -114,7 +122,7 @@ pre code {
 /* tables */
 table { border-collapse: collapse; width: 100%; margin: 0 0 0.7em; font-size: 0.92em; display: block; overflow-x: auto; }
 th, td { border: 1px solid var(--hairline); padding: 6px 10px; text-align: left; }
-th { background: rgba(255,255,255,0.04); font-weight: 640; }
+th { background: var(--th-bg); font-weight: 640; }
 
 img { max-width: 100%; border-radius: 8px; }
 


### PR DESCRIPTION
## Problem

Assistant messages were **nearly invisible in light mode**: the chat bubble's markdown WebView always rendered with the **dark** prose palette (near-white text) while sitting on a light `secondarySystemBackground` bubble. The WebView doesn't pick up `prefers-color-scheme` on its own, and `MessageBubble` always passed `theme: .dark`.

## Fix

The renderer already had a light/sepia theme mechanism (`entry.mjs` `THEME_VARS`, injected via JS) — used by the full-screen reader. This routes the chat **bubble** through it too:

- `MessageBubble` reads `@Environment(\.colorScheme)` and passes `theme: .light` / `.dark` to the bubble's `MarkdownWebView`, so prose flips to dark-on-light.
- **Code blocks deliberately stay dark in both modes** (the syntax-highlight palette + toolbar are tuned for a dark card).
- Inline-code and table-header colours are now themeable too (new `--code-inline-bg` / `--code-inline-fg` / `--th-bg` vars), with light + sepia values added to `THEME_VARS`, so they adapt with the prose instead of staying light-on-light.

## Verification

Rendered `markdown.html` headless:
- `theme: light` → **dark prose** (`#1c1c22`), readable inline code, dark code block, readable table.
- `theme: dark` → **unchanged** (`#ECECF1` / `#C8C2FF`).

Clean simulator build. (iOS isn't in CI; the generated `Resources/markdown.{html,css}` are gitignored build artifacts regenerated by the build phase.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)