### PR TITLE
feat(dashboard): bulk triage in the action inbox

### DIFF
--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -26,4 +26,16 @@ assert.match(cockpit, /\/api\/github/, "cockpit pulls GitHub activity");
 assert.match(cockpit, /\/api\/library\/reading/, "cockpit pulls the reading queue");
 assert.match(cockpit, /cockpit-kpis/, "cockpit renders the KPI rail");
 
+// Action inbox supports bulk triage: select several items → done/dismiss/snooze together.
+const inboxUrl = new URL("../components/dashboard/action-inbox.tsx", import.meta.url);
+const inbox = readFileSync(inboxUrl, "utf8");
+assert.match(inbox, /const \[selectMode, setSelectMode\] = useState\(false\)/, "action inbox has a select mode");
+assert.match(inbox, /const \[selectedIds, setSelectedIds\] = useState<Set<string>>/, "selected ids live in a Set");
+assert.match(inbox, /async function bulkAct\(action: Action, minutes = 60\)/, "a bulk action applies to every selected item");
+assert.match(inbox, /Promise\.all\(\s*ids\.map\(\(id\) => fetch\(`\/api\/inbox\/\$\{id\}\/\$\{action\}`/, "bulk action POSTs each item in parallel");
+assert.match(inbox, /onClick=\{selectMode \? \(\) => toggleSelect\(item\.id\) : undefined\}/, "rows select on click in select mode");
+assert.match(inbox, /\{allSelected \? "Clear" : "Select all"\}/, "the bulk bar offers select-all / clear");
+assert.match(inbox, /onClick=\{\(\) => void bulkAct\("done"\)\}/, "bulk Done is wired");
+assert.match(inbox, /void bulkAct\("snooze", minutes\)/, "bulk Snooze is wired through the menu");
+
 console.log("dashboard-page.test.ts: ok");

--- a/src/components/dashboard/action-inbox.tsx
+++ b/src/components/dashboard/action-inbox.tsx
@@ -31,25 +31,63 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
   const [items, setItems] = useState<InboxItem[]>(initialItems);
   const [error, setError] = useState<string | null>(null);
   const [snoozeOpenId, setSnoozeOpenId] = useState<string | null>(null);
+  // Bulk triage: select several items and done/dismiss/snooze them together.
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+  const [bulkSnoozeOpen, setBulkSnoozeOpen] = useState(false);
+  const toggleSelect = (id: string) =>
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  const exitSelect = () => { setSelectMode(false); setSelectedIds(new Set()); };
+  const allSelected = items.length > 0 && items.every((i) => selectedIds.has(i.id));
+  const selectedCount = items.filter((i) => selectedIds.has(i.id)).length;
+  const toggleSelectAll = () =>
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (allSelected) items.forEach((i) => next.delete(i.id));
+      else items.forEach((i) => next.add(i.id));
+      return next;
+    });
+
+  function requestInit(action: Action, minutes: number): RequestInit {
+    return action === "snooze"
+      ? { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ minutes }) }
+      : { method: "POST" };
+  }
 
   async function act(item: InboxItem, action: Action, minutes = 60) {
     const prev = items;
     setItems(nextItemsAfterAction(items, item.id)); // optimistic remove
     setError(null);
     try {
-      const init: RequestInit =
-        action === "snooze"
-          ? {
-              method: "POST",
-              headers: { "content-type": "application/json" },
-              body: JSON.stringify({ minutes }),
-            }
-          : { method: "POST" };
-      const res = await fetch(`/api/inbox/${item.id}/${action}`, init);
+      const res = await fetch(`/api/inbox/${item.id}/${action}`, requestInit(action, minutes));
       if (!res.ok) throw new Error(String(res.status));
     } catch {
       setItems(prev); // revert
       setError("Couldn't update that item — try again.");
+    }
+  }
+
+  // Apply one action to every selected item: optimistic remove + parallel POSTs.
+  async function bulkAct(action: Action, minutes = 60) {
+    const ids = items.filter((i) => selectedIds.has(i.id)).map((i) => i.id);
+    if (ids.length === 0) return;
+    const prev = items;
+    setItems(items.filter((i) => !selectedIds.has(i.id)));
+    exitSelect();
+    setError(null);
+    try {
+      const results = await Promise.all(
+        ids.map((id) => fetch(`/api/inbox/${id}/${action}`, requestInit(action, minutes)).then((r) => r.ok)),
+      );
+      if (results.some((ok) => !ok)) throw new Error("partial");
+    } catch {
+      setItems(prev); // revert the whole batch
+      setError("Couldn't update some items — try again.");
     }
   }
 
@@ -63,7 +101,43 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
           Needs you
         </h2>
         <span className="dr-count">{items.length}</span>
+        {items.length > 1 ? (
+          <button
+            type="button"
+            className="dash-act dash-inbox__select-toggle"
+            aria-pressed={selectMode}
+            onClick={() => { setSelectMode((v) => !v); setSelectedIds(new Set()); }}
+          >
+            <Icon name="ph:list-checks-bold" aria-hidden />
+            {selectMode ? "Done" : "Select"}
+          </button>
+        ) : null}
       </div>
+      {selectMode ? (
+        <div className="dash-inbox__bulkbar">
+          <div className="dash-inbox__bulkbar-left">
+            <button type="button" className="dash-act dash-act--ghost" onClick={toggleSelectAll}>
+              {allSelected ? "Clear" : "Select all"}
+            </button>
+            <span className="dash-inbox__bulkbar-count">{selectedCount} selected</span>
+          </div>
+          <div className="dash-inbox__bulkbar-right">
+            <SnoozeMenu
+              open={bulkSnoozeOpen}
+              onToggle={() => setBulkSnoozeOpen((v) => !v)}
+              onClose={() => setBulkSnoozeOpen(false)}
+              onPick={(minutes) => { setBulkSnoozeOpen(false); void bulkAct("snooze", minutes); }}
+              disabled={selectedCount === 0}
+            />
+            <button type="button" className="dash-act dash-act--primary" disabled={selectedCount === 0} onClick={() => void bulkAct("done")}>
+              Done{selectedCount ? ` ${selectedCount}` : ""}
+            </button>
+            <button type="button" className="dash-act dash-act--ghost" disabled={selectedCount === 0} onClick={() => void bulkAct("dismiss")}>
+              Dismiss
+            </button>
+          </div>
+        </div>
+      ) : null}
       {error ? (
         <div className="dash-inbox__error" role="alert">
           {error}
@@ -77,9 +151,19 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
           return (
           <div
             key={item.id}
-            className="dr-row dash-inbox__row"
+            className={`dr-row dash-inbox__row${selectMode && selectedIds.has(item.id) ? " dash-inbox__row--selected" : ""}`}
             style={{ ["--row-accent" as string]: "var(--color-warning)" }}
+            role={selectMode ? "checkbox" : undefined}
+            aria-checked={selectMode ? selectedIds.has(item.id) : undefined}
+            tabIndex={selectMode ? 0 : undefined}
+            onClick={selectMode ? () => toggleSelect(item.id) : undefined}
+            onKeyDown={selectMode ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleSelect(item.id); } } : undefined}
           >
+            {selectMode ? (
+              <span aria-hidden className="dash-inbox__check" data-checked={selectedIds.has(item.id) ? "true" : undefined}>
+                <Icon name="ph:check-bold" aria-hidden />
+              </span>
+            ) : null}
             <span className="dr-row__icon">
               <Icon name={KIND_ICON[item.kind] as IconName} aria-hidden />
             </span>
@@ -91,6 +175,7 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
                 {when ? <span className="dr-row__time" title={whenTitle}>{when}</span> : null}
               </span>
             </span>
+            {selectMode ? null : (
             <span className="dash-inbox__actions">
               {itemHasTarget(item) ? (
                 <a className="dash-act" href={itemHref(item)}>
@@ -118,6 +203,7 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
                 <Icon name="ph:x" aria-hidden />
               </button>
             </span>
+            )}
           </div>
           );
         })}
@@ -137,11 +223,13 @@ function SnoozeMenu({
   onToggle,
   onClose,
   onPick,
+  disabled = false,
 }: {
   open: boolean;
   onToggle: () => void;
   onClose: () => void;
   onPick: (minutes: number) => void;
+  disabled?: boolean;
 }) {
   const menuRef = useRef<HTMLDivElement>(null);
   useFocusTrap(open, menuRef, { onEscape: onClose });
@@ -152,6 +240,7 @@ function SnoozeMenu({
         className="dash-act"
         aria-haspopup="menu"
         aria-expanded={open}
+        disabled={disabled}
         onClick={onToggle}
       >
         Snooze

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -43,6 +43,24 @@
 }
 
 .dash-inbox__row { align-items: center; }
+.dash-inbox__row--selected { background: color-mix(in oklch, var(--accent-presence) 10%, transparent); }
+.dash-inbox__row[role="checkbox"] { cursor: pointer; }
+
+/* bulk triage: select toggle + bar + row checkbox */
+.dash-inbox__select-toggle { margin-left: auto; }
+.dash-inbox__bulkbar {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  margin: 4px 0 8px; padding: 6px 8px; border-radius: 8px;
+  background: color-mix(in oklch, var(--bg-raised) 60%, transparent);
+}
+.dash-inbox__bulkbar-left, .dash-inbox__bulkbar-right { display: flex; align-items: center; gap: 6px; }
+.dash-inbox__bulkbar-count { font-size: 12px; color: var(--text-muted); }
+.dash-inbox__check {
+  display: inline-grid; place-items: center; width: 18px; height: 18px; flex: 0 0 auto;
+  border: 1px solid var(--border-strong); border-radius: 5px; color: transparent;
+}
+.dash-inbox__check[data-checked="true"] { border-color: var(--accent-presence); background: var(--accent-presence); color: #fff; }
+.dash-inbox__check svg { width: 11px; height: 11px; }
 
 .dash-inbox__actions {
   display: flex;


### PR DESCRIPTION
The dashboard's **"Needs you"** action inbox cleared items one at a time. This adds bulk triage.

## What
- A **Select** toggle in the section header → each row becomes a checkbox (click selects, per-row actions hide).
- A bulk bar: **Select all / Clear**, an **N selected** count, and bulk **Snooze** (with the same duration menu), **Done**, and **Dismiss**.
- `bulkAct` applies one action to every selected item: optimistic remove + parallel `POST /api/inbox/:id/:action`, reverting the whole batch on failure.

## Verification
- `pnpm typecheck` clean; `app` suite → **386 files pass** (assertions added to `dashboard-page.test.ts`).
- Browser-driven on the live dashboard (with 2 temporary items, surgically removed after — your real inbox was never mutated): Select → 3 checkboxes → select 2 → "Done 2" → fired the per-item actions in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)