### PR TITLE
feat(ios): select reminders by status in bulk-select

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/RemindersView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RemindersView.swift
@@ -32,7 +32,17 @@ struct RemindersView: View {
                 .safeAreaInset(edge: .bottom) {
                     if selectMode {
                         HStack {
-                            Button(allSelected ? "Deselect All" : "Select All") { toggleSelectAll() }
+                            Menu {
+                                Button(allSelected ? "Deselect all" : "Select all") { toggleSelectAll() }
+                                if !statusesPresent.isEmpty {
+                                    Divider()
+                                    ForEach(statusesPresent, id: \.self) { status in
+                                        Button("\(statusLabel(status)) (\(statusCount(status)))") { selectStatus(status) }
+                                    }
+                                }
+                            } label: {
+                                Label("Select", systemImage: "line.3.horizontal.decrease.circle")
+                            }
                             Spacer()
                             Menu {
                                 Button { Task { await app.markRemindersDone(selectedIds); exitSelect() } } label: {
@@ -143,6 +153,21 @@ struct RemindersView: View {
     }
     private func toggleSelectAll() {
         if allSelected { selectedIds.removeAll() } else { selectedIds = Set(app.reminders.map(\.id)) }
+    }
+
+    private let statusOrder = ["pending", "fired", "snoozed", "dismissed", "done"]
+    /// Statuses actually present among the reminders, in a stable order.
+    private var statusesPresent: [String] {
+        let present = Set(app.reminders.map(\.status))
+        return statusOrder.filter(present.contains)
+    }
+    private func statusCount(_ status: String) -> Int {
+        app.reminders.filter { $0.status == status }.count
+    }
+    private func statusLabel(_ status: String) -> String { status.capitalized }
+    /// Add every reminder of a given status to the current selection.
+    private func selectStatus(_ status: String) {
+        selectedIds.formUnion(app.reminders.filter { $0.status == status }.map(\.id))
     }
     private func exitSelect() { withAnimation { selectMode = false; selectedIds.removeAll() } }
 }

--- a/scripts/ios-reminder-select-by-status.test.mjs
+++ b/scripts/ios-reminder-select-by-status.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+const view = await readFile(
+  new URL("../apps/ios/CovenCave/CovenCave/Views/RemindersView.swift", import.meta.url),
+  "utf8",
+);
+
+// Status-aware select: a menu offering Select all + per-status options.
+assert.match(view, /private let statusOrder = \["pending", "fired", "snoozed", "dismissed", "done"\]/, "ordered statuses");
+assert.match(view, /private var statusesPresent: \[String\][\s\S]*statusOrder\.filter\(present\.contains\)/, "only present statuses are offered");
+assert.match(
+  view,
+  /private func selectStatus\(_ status: String\) \{\s*selectedIds\.formUnion\(app\.reminders\.filter \{ \$0\.status == status \}\.map\(\\\.id\)\)/,
+  "selectStatus unions every reminder of that status into the selection",
+);
+assert.match(
+  view,
+  /ForEach\(statusesPresent, id: \\\.self\) \{ status in\s*Button\("\\\(statusLabel\(status\)\) \(\\\(statusCount\(status\)\)\)"\) \{ selectStatus\(status\) \}/,
+  "the Select menu lists each status with its count",
+);
+assert.match(view, /Button\(allSelected \? "Deselect all" : "Select all"\) \{ toggleSelectAll\(\) \}/, "Select/Deselect all stays available");
+
+console.log("ios-reminder-select-by-status.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -522,6 +522,7 @@ export const SUITES = {
     "scripts/ios-reminders-bulk-delete.test.mjs",
     "scripts/ios-reminder-actions.test.mjs",
     "scripts/ios-reminder-bulk-actions.test.mjs",
+    "scripts/ios-reminder-select-by-status.test.mjs",
     "scripts/ios-reorder-familiars.test.mjs",
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/ios-theme.test.mjs",


### PR DESCRIPTION
## What

The Reminders select bar only offered **Select All / Deselect All**. This turns it into a **Select** menu that also lets you select every reminder of a given status at once.

- **`RemindersView`** — the leading button becomes a **"Select"** menu: Select/Deselect all, plus one entry per *present* status (**Pending / Fired / Snoozed / Dismissed / Done**) with its count. Tapping a status **unions** those ids into the selection, so you can stack statuses (e.g. Fired + Pending) and then apply a bulk action (done/snooze/dismiss/delete from #1740).

View-only change — selection is view state.

## Verification

- `pnpm test:mobile` → **✓ 44 test file(s) passed** (full suite; new `scripts/ios-reminder-select-by-status.test.mjs`).
- `xcodebuild` → **BUILD SUCCEEDED**.

> Built via an atomic sibling-worktree one-shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)