### PR TITLE
feat(ios): native /model slash command

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/SlashCommand.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/SlashCommand.swift
@@ -43,6 +43,7 @@ struct SlashCommand: Identifiable, Hashable {
         case saveLink              // /save <url> … — route a URL into the library
         case daemonStatus          // /daemon — fetch + show status inline
         case doctor                // /doctor — run `coven doctor` inline
+        case switchModel           // /model — pick or set the chat model
         case desktopOnly(String)   // recognised, but lives on the desktop
     }
 
@@ -85,9 +86,9 @@ enum SlashCatalog {
                      description: "Show the command reference.",
                      section: .chat, availability: .native, action: .help),
         SlashCommand(name: "/model", aliases: ["/m"], hint: "switch model",
-                     description: "Switch the active model — on the desktop for now.",
+                     description: "Pick or set the model for this chat. Pass an id/name or open the picker.",
                      argPlaceholder: "model", section: .chat,
-                     availability: .desktopOnly, action: .desktopOnly("Model selection")),
+                     availability: .native, action: .switchModel),
 
         // MARK: Familiar
         SlashCommand(name: "/familiar", aliases: ["/agent"], hint: "switch",

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -26,6 +26,9 @@ struct ChatView: View {
     @FocusState private var composerFocused: Bool
     @State private var showCommands = false
     @State private var showFamiliarPicker = false
+    @State private var showModelPicker = false
+    @State private var modelPickerOptions: [ChatModelOption] = []
+    @State private var modelPickerCurrent = ""
     @State private var showTasks = false
     @State private var atBottom = true
     @State private var dictation = SpeechDictation()
@@ -127,6 +130,12 @@ struct ChatView: View {
         }
         .sheet(isPresented: $showCommands) {
             CommandsSheet { command in prefill(command) }
+        }
+        .sheet(isPresented: $showModelPicker) {
+            ModelPickerSheet(options: modelPickerOptions, current: modelPickerCurrent) { id in
+                guard !thread.isGroup, let familiarId = thread.familiarIds.first else { return }
+                Task { await applyModel(id, familiarId: familiarId, sessionId: modelSessionId(familiarId)) }
+            }
         }
         .sheet(isPresented: $showFamiliarPicker) {
             FamiliarPickerSheet { familiar in
@@ -598,6 +607,8 @@ struct ChatView: View {
             Task { await runDaemonStatus() }
         case .doctor:
             Task { await runDoctor() }
+        case .switchModel:
+            Task { await switchModel(args) }
         case .desktopOnly(let surface):
             app.showToast("\(surface) lives on your desktop", systemImage: "desktopcomputer",
                           style: .warning)
@@ -614,6 +625,77 @@ struct ChatView: View {
         }
         app.requestOpen(app.directThread(for: familiar.id))
         app.showToast("Switched to \(familiar.displayName)", systemImage: "arrow.left.arrow.right")
+    }
+
+    /// `/model` — no arg opens the picker; an arg resolves to a model and sets it.
+    /// Direct chats only (a group fan-out has no single model). Options come from
+    /// the server's model-state, so iOS needs no local catalog.
+    private func switchModel(_ args: String) async {
+        guard let client = app.client else { return }
+        guard !thread.isGroup, let familiarId = thread.familiarIds.first else {
+            thread.appendSystem("Switch the model from a direct chat with one familiar.", isError: true)
+            app.touch(thread)
+            return
+        }
+        let sessionId = modelSessionId(familiarId)
+        let resp: ChatModelStateResponse
+        do {
+            resp = try await client.chatModelState(familiarId: familiarId, sessionId: sessionId)
+        } catch {
+            thread.appendSystem("Couldn't load the model list. Is the desktop reachable?", isError: true)
+            app.touch(thread)
+            return
+        }
+        let options = resp.options ?? []
+        let trimmed = args.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if trimmed.isEmpty {
+            guard !options.isEmpty else {
+                thread.appendSystem("This runtime has no model menu — type /model <id> to set one.")
+                app.touch(thread)
+                return
+            }
+            modelPickerOptions = options
+            modelPickerCurrent = resp.state.effectiveModel
+            showModelPicker = true
+            return
+        }
+
+        // Resolve the argument: exact id/label, then substring, else a custom id.
+        let lower = trimmed.lowercased()
+        let match = options.first { $0.id.lowercased() == lower || $0.label.lowercased() == lower }
+            ?? options.first { $0.id.lowercased().contains(lower) || $0.label.lowercased().contains(lower) }
+        let allowCustom = resp.allowCustom ?? true
+        guard let modelId = match?.id ?? (allowCustom ? trimmed : nil) else {
+            thread.appendSystem("Unknown model “\(trimmed)”. Type /model to pick from the list.", isError: true)
+            app.touch(thread)
+            return
+        }
+        await applyModel(modelId, familiarId: familiarId, sessionId: sessionId)
+    }
+
+    /// PATCH the chosen model (session scope when the chat has a server session,
+    /// else the familiar default) and confirm inline.
+    private func applyModel(_ model: String, familiarId: String, sessionId: String?) async {
+        guard let client = app.client else { return }
+        let scope = sessionId != nil ? "session" : "familiar-default"
+        do {
+            let resp = try await client.setChatModel(
+                familiarId: familiarId, sessionId: sessionId, model: model, scope: scope)
+            let label = (resp.options ?? []).first { $0.id == resp.state.effectiveModel }?.label
+                ?? resp.state.effectiveModel
+            thread.appendSystem("Model set to \(label).")
+            app.touch(thread)
+            Haptics.tap()
+        } catch {
+            thread.appendSystem("Couldn't switch the model.", isError: true)
+            app.touch(thread)
+        }
+    }
+
+    private func modelSessionId(_ familiarId: String) -> String? {
+        let id = thread.sessionIds[familiarId]
+        return (id?.isEmpty == false) ? id : nil
     }
 
     private func sendPrompt(_ args: String, command: SlashCommand) {

--- a/scripts/ios-slash-commands.test.mjs
+++ b/scripts/ios-slash-commands.test.mjs
@@ -66,6 +66,23 @@ assert.match(
   "Chat slash dispatch should route Developer commands to the iOS Developer tab",
 );
 
+// /model is native on iOS: it switches the chat model via the model-state API.
+assert.match(
+  iosSlash,
+  /name: "\/model"[\s\S]{0,360}availability: \.native[\s\S]{0,80}action: \.switchModel/,
+  "/model should be a native command wired to .switchModel",
+);
+assert.match(
+  chatView,
+  /case \.switchModel:[\s\S]{0,80}await switchModel\(args\)/,
+  "Chat slash dispatch should handle /model via switchModel",
+);
+assert.match(
+  chatView,
+  /client\.setChatModel\(\s*familiarId:[\s\S]{0,160}scope: scope\)/,
+  "switchModel should PATCH the chosen model through setChatModel",
+);
+
 for (const command of ["/journal", "/inbox", "/remind", "/attach", "/tui", "/toggle-agent"]) {
   const escaped = command.replace("/", "\\/");
   assert.match(


### PR DESCRIPTION
Makes `/model` work natively on the phone (it was a desktop-redirect after the web PR #1739).

## What
- New **`.switchModel`** action in the iOS slash catalog; `/model` is now `.native` (shows in the iOS autocomplete + Commands sheet).
- Dispatch in `ChatView.swift`:
  - **`/model`** → opens the existing `ModelPickerSheet` (options + current pulled from `/api/chat/model-state`).
  - **`/model <id|name>`** → resolves against the runtime's options (id, label, substring, or a custom id) and PATCHes the model — **session** scope in a chat, **familiar-default** otherwise — with an inline confirmation.
- Direct (1:1) chats only; a group fan-out has no single model.

## How
Reuses the existing `CaveClient.chatModelState` / `setChatModel` and `ModelPickerSheet` — the same infrastructure the model chip already uses — so no new catalog or UI.

## Verification
- `xcodebuild` simulator build **SUCCEEDED** (iOS isn't in CI — built locally).
- `scripts/ios-slash-commands.test.mjs` updated (asserts `/model` is native + the `.switchModel` dispatch + the `setChatModel` PATCH); full `test:mobile` (43 files) green.

Note: interactive sim verification isn't automatable here (no idb for taps), so this rests on the build + the reuse of already-working model plumbing. Happy to deploy to a device for a hands-on check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)