### PR TITLE
fix(projects): context-menu focus-return + dedup the undo toast

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -357,6 +357,7 @@ export const SUITES = {
     "src/components/ui/color-picker.test.ts",
     "src/components/ui/popover.test.ts",
     "src/components/ui/context-menu.test.ts",
+    "src/components/ui/undo-toast.test.ts",
     "src/components/ui/modal.test.ts",
     "src/components/ui/relative-time.test.ts",
     "src/lib/workflow-source-bundle.test.ts",

--- a/src/components/library-undo-toast.tsx
+++ b/src/components/library-undo-toast.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { Icon } from "@/lib/icon";
+import { UndoToast } from "@/components/ui/undo-toast";
 
 type Props = {
   label: string;
@@ -10,57 +9,20 @@ type Props = {
   durationMs?: number;
 };
 
+/**
+ * Delete-undo toast for the library surfaces. Thin wrapper over the shared
+ * {@link UndoToast}; the surrounding useUndoDelete controller owns the commit
+ * timer, so this only animates the countdown (no self-dismiss).
+ */
 export function LibraryUndoToast({ label, onUndo, onDismiss, durationMs = 4000 }: Props) {
-  const [progress, setProgress] = useState(100);
-  const startRef = useRef(Date.now());
-  const rafRef = useRef<number>(0);
-
-  useEffect(() => {
-    startRef.current = Date.now();
-    const tick = () => {
-      const elapsed = Date.now() - startRef.current;
-      const remaining = Math.max(0, 100 - (elapsed / durationMs) * 100);
-      setProgress(remaining);
-      if (remaining > 0) {
-        rafRef.current = requestAnimationFrame(tick);
-      }
-    };
-    rafRef.current = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(rafRef.current);
-  }, [durationMs]);
-
   return (
-    <div
-      className="library-undo-toast"
-      role="status"
-      aria-live="polite"
-      aria-atomic="true"
-    >
-      <div className="library-undo-toast-content">
-        <Icon name="ph:trash" className="library-undo-toast-icon" aria-hidden />
-        <span className="library-undo-toast-label">
-          Deleted <strong>{label}</strong>
-        </span>
-        <button
-          className="library-undo-toast-undo"
-          onClick={onUndo}
-          aria-label={`Undo delete ${label}`}
-        >
-          Undo
-        </button>
-        <button
-          className="library-undo-toast-dismiss"
-          onClick={onDismiss}
-          aria-label="Dismiss"
-        >
-          <Icon name="ph:x-bold" aria-hidden />
-        </button>
-      </div>
-      <div
-        className="library-undo-toast-progress"
-        style={{ width: `${progress}%` }}
-        aria-hidden
-      />
-    </div>
+    <UndoToast
+      message={<>Deleted <strong>{label}</strong></>}
+      icon="ph:trash"
+      undoAriaLabel={`Undo delete ${label}`}
+      onUndo={onUndo}
+      onDismiss={onDismiss}
+      durationMs={durationMs}
+    />
   );
 }

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -375,8 +375,7 @@ assert.match(projectsView, /data-\[dragging=true\]:shadow-/, "the dragged row li
 assert.match(projectsView, /isOver[\s\S]{0,140}?ring-1 ring-inset ring-\[var\(--accent-presence\)\]/, "the drop-target project card shows an accent ring");
 // Cross-project move is undoable via a transient toast.
 assert.match(projectsView, /import \{ applyProjectOverrides, setProjectOverride, clearProjectOverride \}/, "imports clearProjectOverride for undo");
-assert.match(projectsView, /function MoveUndoToast/, "a move-undo toast component exists");
-assert.match(projectsView, /window\.setTimeout\(\(\) => dismissRef\.current\(\), 5000\)/, "the toast auto-dismisses");
+assert.match(projectsView, /import \{ UndoToast \} from "@\/components\/ui\/undo-toast"/, "uses the shared UndoToast primitive");
 assert.match(projectsView, /const prevRoot = projectOverrides\[sessionId\] \?\? null/, "the move captures the prior override for a precise undo");
 assert.match(projectsView, /setMoveToast\(\{ sessionId, prevRoot, label:/, "a cross-project move raises the undo toast");
 assert.match(
@@ -384,7 +383,11 @@ assert.match(
   /moveToast\.prevRoot\) setProjectOverride\(moveToast\.sessionId, moveToast\.prevRoot\)[\s\S]{0,90}?clearProjectOverride\(moveToast\.sessionId\)/,
   "undo restores the prior override, or clears it when there wasn't one",
 );
-assert.match(projectsView, /<MoveUndoToast\s+key=\{moveToast\.sessionId\}/, "the toast renders, keyed so a new move restarts its timer");
+assert.match(
+  projectsView,
+  /<UndoToast\s+key=\{moveToast\.sessionId\}[\s\S]{0,400}?autoDismiss/,
+  "the toast renders (keyed, self-dismissing) via the shared UndoToast",
+);
 
 // Render-virtualization: off-screen session rows skip layout/paint via
 // content-visibility (the repo's established strategy — see chat turns + library

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -21,6 +21,7 @@ import { useProjects } from "@/lib/use-projects";
 import { useProjectsUiState } from "@/lib/projects/use-projects-ui-state";
 import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 import { nextTypeAheadIndex } from "@/lib/projects/type-ahead";
+import { UndoToast } from "@/components/ui/undo-toast";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
@@ -37,50 +38,6 @@ import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 
 import { ProjectRow } from "./projects/project-row";
 import { lastActiveMs, shortRoot, openSessionById } from "./projects/projects-shared";
-
-// Transient toast shown after a cross-project drag, offering a one-click Undo.
-// Auto-dismisses after a few seconds; remount (via a key) restarts the timer.
-function MoveUndoToast({
-  label,
-  onUndo,
-  onDismiss,
-}: {
-  label: string;
-  onUndo: () => void;
-  onDismiss: () => void;
-}) {
-  const dismissRef = useRef(onDismiss);
-  dismissRef.current = onDismiss;
-  useEffect(() => {
-    const t = window.setTimeout(() => dismissRef.current(), 5000);
-    return () => window.clearTimeout(t);
-  }, []);
-  return (
-    <div
-      role="status"
-      aria-live="polite"
-      className="fixed bottom-4 left-1/2 z-50 flex max-w-[90vw] -translate-x-1/2 items-center gap-3 rounded-lg border border-[var(--border-strong)] bg-[var(--bg-elevated)] px-3 py-2 text-[12px] text-[var(--text-primary)] shadow-[0_16px_40px_oklch(0_0_0/45%)]"
-    >
-      <Icon name="ph:arrow-right-bold" width={13} className="shrink-0 text-[var(--accent-presence)]" aria-hidden />
-      <span className="min-w-0 truncate">{label}</span>
-      <button
-        type="button"
-        onClick={onUndo}
-        className="focus-ring shrink-0 rounded px-1.5 py-0.5 font-medium text-[var(--accent-presence)] hover:bg-[var(--bg-hover)]"
-      >
-        Undo
-      </button>
-      <button
-        type="button"
-        onClick={onDismiss}
-        aria-label="Dismiss"
-        className="focus-ring shrink-0 rounded p-0.5 text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
-      >
-        <Icon name="ph:x-bold" width={12} aria-hidden />
-      </button>
-    </div>
-  );
-}
 
 type ProjectsViewProps = {
   sessions?: SessionRow[];
@@ -574,11 +531,15 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
         )}
       </main>
       {moveToast ? (
-        <MoveUndoToast
+        <UndoToast
           key={moveToast.sessionId}
-          label={moveToast.label}
+          message={moveToast.label}
+          icon="ph:arrow-right-bold"
+          undoAriaLabel="Undo move"
           onUndo={undoMove}
           onDismiss={() => setMoveToast(null)}
+          durationMs={5000}
+          autoDismiss
         />
       ) : null}
     </div>

--- a/src/components/ui/context-menu.test.ts
+++ b/src/components/ui/context-menu.test.ts
@@ -15,6 +15,9 @@ assert.match(src, /open=\{state !== null\}/, "menu is open when state is set");
 
 // Anchors to a 0-size element pinned at the cursor so it opens where clicked.
 assert.match(src, /position: "fixed", left: state\?\.x[\s\S]{0,60}width: 0, height: 0/, "anchors a 0-size element at the cursor");
+// The anchor is programmatically focusable (tabIndex=-1) so the Popover's
+// close-time focus-return works instead of stranding focus on <body>.
+assert.match(src, /tabIndex=\{-1\}/, "the cursor anchor is focusable for focus-return on close");
 
 // The helper preventDefaults the native menu and records the click position.
 assert.match(src, /e\.preventDefault\(\)/, "suppresses the browser's native context menu");

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -34,6 +34,10 @@ export function ContextMenu({
       <span
         ref={anchorRef}
         aria-hidden
+        tabIndex={-1}
+        // tabIndex makes the anchor programmatically focusable so the Popover's
+        // close-time focus-return (which focuses the anchor when focus would
+        // otherwise be lost to <body>) actually works for keyboard users.
         style={{ position: "fixed", left: state?.x ?? 0, top: state?.y ?? 0, width: 0, height: 0 }}
       />
       <Popover

--- a/src/components/ui/undo-toast.test.ts
+++ b/src/components/ui/undo-toast.test.ts
@@ -1,0 +1,30 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./undo-toast.tsx", import.meta.url), "utf8");
+const library = readFileSync(new URL("../library-undo-toast.tsx", import.meta.url), "utf8");
+
+// Generic, reusable undo toast: message + icon are props (not hardcoded).
+assert.match(src, /export function UndoToast/, "exports UndoToast");
+assert.match(src, /message,[\s\S]{0,200}?icon = "ph:trash"/, "message is a prop; icon defaults to trash");
+assert.match(src, /undoAriaLabel = "Undo"/, "the Undo button has a configurable accessible label");
+
+// Countdown progress bar (rAF), like the original.
+assert.match(src, /requestAnimationFrame\(tick\)/, "animates a countdown via requestAnimationFrame");
+assert.match(src, /className="library-undo-toast-progress"/, "renders the countdown progress bar");
+
+// autoDismiss is opt-in (off by default) so controller-owned toasts (library)
+// keep their behavior while self-dismissing toasts (projects move) opt in.
+assert.match(src, /autoDismiss = false/, "autoDismiss defaults to off");
+assert.match(src, /remaining > 0[\s\S]{0,80}?else if \(autoDismiss\)[\s\S]{0,40}?dismissRef\.current\(\)/, "autoDismiss fires onDismiss when the bar empties");
+
+// role=status / aria-live keep it announced.
+assert.match(src, /role="status"[\s\S]{0,40}?aria-live="polite"/, "announced politely to assistive tech");
+
+// LibraryUndoToast is now a thin wrapper over the shared primitive (same API).
+assert.match(library, /import \{ UndoToast \} from "@\/components\/ui\/undo-toast"/, "LibraryUndoToast delegates to UndoToast");
+assert.match(library, /message=\{<>Deleted <strong>\{label\}<\/strong><\/>\}/, "library keeps its 'Deleted <label>' message");
+assert.doesNotMatch(library, /autoDismiss/, "library does not self-dismiss (its useUndoDelete controller owns the timer)");
+
+console.log("undo-toast.test.ts: ok");

--- a/src/components/ui/undo-toast.tsx
+++ b/src/components/ui/undo-toast.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+import { Icon, type IconName } from "@/lib/icon";
+
+type Props = {
+  /** The toast body (e.g. "Deleted <strong>X</strong>" or "Moved X to Y"). */
+  message: ReactNode;
+  onUndo: () => void;
+  onDismiss: () => void;
+  /** Leading icon (default a trash glyph for the common delete-undo case). */
+  icon?: IconName;
+  /** Lifetime of the countdown progress bar, in ms. */
+  durationMs?: number;
+  /** Accessible label for the Undo button. */
+  undoAriaLabel?: string;
+  /** Call onDismiss when the progress bar empties (self-dismissing toasts).
+   *  Off by default — callers whose own controller owns the timer (e.g.
+   *  useUndoDelete) animate the bar but dismiss themselves. */
+  autoDismiss?: boolean;
+};
+
+/**
+ * Bottom-center undo toast with a countdown progress bar and an Undo / dismiss
+ * pair. Shared by the library delete-undo surfaces and the Projects move-undo.
+ * Styles live in the `.library-undo-toast*` rules in src/styles/library.css.
+ */
+export function UndoToast({
+  message,
+  onUndo,
+  onDismiss,
+  icon = "ph:trash",
+  durationMs = 4000,
+  undoAriaLabel = "Undo",
+  autoDismiss = false,
+}: Props) {
+  const [progress, setProgress] = useState(100);
+  const startRef = useRef(Date.now());
+  const rafRef = useRef<number>(0);
+  const dismissRef = useRef(onDismiss);
+  dismissRef.current = onDismiss;
+
+  useEffect(() => {
+    startRef.current = Date.now();
+    const tick = () => {
+      const elapsed = Date.now() - startRef.current;
+      const remaining = Math.max(0, 100 - (elapsed / durationMs) * 100);
+      setProgress(remaining);
+      if (remaining > 0) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else if (autoDismiss) {
+        dismissRef.current();
+      }
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [durationMs, autoDismiss]);
+
+  return (
+    <div className="library-undo-toast" role="status" aria-live="polite" aria-atomic="true">
+      <div className="library-undo-toast-content">
+        <Icon name={icon} className="library-undo-toast-icon" aria-hidden />
+        <span className="library-undo-toast-label">{message}</span>
+        <button className="library-undo-toast-undo" onClick={onUndo} aria-label={undoAriaLabel}>
+          Undo
+        </button>
+        <button className="library-undo-toast-dismiss" onClick={onDismiss} aria-label="Dismiss">
+          <Icon name="ph:x-bold" aria-hidden />
+        </button>
+      </div>
+      <div className="library-undo-toast-progress" style={{ width: `${progress}%` }} aria-hidden />
+    </div>
+  );
+}


### PR DESCRIPTION
Two follow-ups from the `/code-review` of the Projects native redesign.

## 1. Context-menu focus-return (a11y)
The context menu's cursor anchor span wasn't focusable, so `Popover`'s close-time focus-return (focus the anchor when focus would otherwise land on `<body>`) was a no-op for keyboard users. One line: `tabIndex={-1}` on the anchor.

## 2. Dedup the undo toast
There were three copies of the undo-toast shape (library, projects move, inbox). Extract a generic **`src/components/ui/undo-toast.tsx`** (message + icon props, countdown progress bar, opt-in `autoDismiss`) and route both surfaces through it:
- **`LibraryUndoToast` → thin wrapper** over `UndoToast` with identical API, look, and behavior (no self-dismiss — its `useUndoDelete` controller owns the commit timer). The four library call sites and their test are untouched.
- **Projects move-undo** (the bespoke `MoveUndoToast`) now renders `UndoToast` with `autoDismiss` + a 5s countdown, gaining the shared progress bar and styling.

Styles reuse the existing `.library-undo-toast*` rules (zero CSS churn → no library visual change).

## Verification
- `pnpm typecheck` clean · new `undo-toast.test.ts` + updated `context-menu`/`projects-view` tests green · library `familiars-memory-view-management.test` green · `check:tests-wired` green (512)
- Live: projects move-undo toast renders via the shared component; a library delete-undo toast is visually unchanged; Escape on a context menu no longer strands focus on `<body>` (screenshots/checks in thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)