### PR TITLE
feat(ios): independent light/dark appearance override

### DIFF
--- a/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
+++ b/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
@@ -3,17 +3,21 @@ import SwiftUI
 @main
 struct CovenCaveApp: App {
     @State private var app = AppModel()
+    @AppStorage(AppearanceMode.storageKey) private var appearanceRaw = AppearanceMode.desktop.rawValue
 
     var body: some Scene {
-        WindowGroup {
+        // Mirror the desktop appearance by default; a fixed Light/Dark override
+        // makes the phone independent (Settings → Appearance).
+        let mode = AppearanceMode(rawValue: appearanceRaw) ?? .desktop
+        let resolved = mode.resolve(desktop: app.chrome)
+        return WindowGroup {
             RootView()
                 .environment(app)
-                // Match the desktop appearance: propagate its palette to every
-                // view, tint app-wide controls with its accent, and follow its
-                // light/dark mode (defaults to dark until a theme loads).
-                .environment(\.chrome, app.chrome)
-                .tint(app.chrome.accent)
-                .preferredColorScheme(app.chrome.colorScheme)
+                // Propagate the chrome palette to every view, tint app-wide
+                // controls with its accent, and apply the resolved light/dark mode.
+                .environment(\.chrome, resolved.chrome)
+                .tint(resolved.chrome.accent)
+                .preferredColorScheme(resolved.scheme)
                 .task {
                     if app.connection != nil {
                         await app.refreshConnection()

--- a/apps/ios/CovenCave/CovenCave/Theme/AppearanceMode.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/AppearanceMode.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+/// How the iOS app picks its light/dark appearance. By default it mirrors the
+/// Cave desktop's published mode; the user can override it to a fixed Light or
+/// Dark so the phone stands alone (e.g. light outdoors while the desktop is
+/// dark). Persisted in UserDefaults via `@AppStorage(AppearanceMode.storageKey)`.
+enum AppearanceMode: String, CaseIterable, Identifiable {
+    case desktop, light, dark
+
+    static let storageKey = "cave.appearance"
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .desktop: return "Match desktop"
+        case .light: return "Light"
+        case .dark: return "Dark"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .desktop: return "desktopcomputer"
+        case .light: return "sun.max"
+        case .dark: return "moon"
+        }
+    }
+
+    /// The effective chrome + color scheme for this mode. `.desktop` passes the
+    /// published palette through untouched; a fixed mode swaps to the built-in
+    /// (system-semantic) palette so every adaptive colour follows the forced
+    /// scheme with no desktop-palette mismatch.
+    func resolve(desktop: ChromePalette) -> (chrome: ChromePalette, scheme: ColorScheme) {
+        switch self {
+        case .desktop:
+            return (desktop, desktop.colorScheme)
+        case .light:
+            var c = ChromePalette.fallback; c.colorScheme = .light
+            return (c, .light)
+        case .dark:
+            var c = ChromePalette.fallback; c.colorScheme = .dark
+            return (c, .dark)
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @Environment(AppModel.self) private var app
+    @AppStorage(AppearanceMode.storageKey) private var appearanceRaw = AppearanceMode.desktop.rawValue
     @State private var editingHost: String = ""
     @State private var showDisconnectConfirm = false
     @State private var exportArchive: ExportArchive?
@@ -34,6 +35,20 @@ struct SettingsView: View {
                     Text("Chats")
                 } footer: {
                     Text("Save every conversation as Markdown files in a single .zip.")
+                }
+
+                Section {
+                    Picker(selection: $appearanceRaw) {
+                        ForEach(AppearanceMode.allCases) { mode in
+                            Label(mode.label, systemImage: mode.icon).tag(mode.rawValue)
+                        }
+                    } label: {
+                        Label("Appearance", systemImage: "circle.lefthalf.filled")
+                    }
+                } header: {
+                    Text("Appearance")
+                } footer: {
+                    Text("“Match desktop” follows your Cave desktop's light/dark mode. Light or Dark sets it just on this phone.")
                 }
 
                 Section("Desktop") {

--- a/scripts/ios-theme.test.mjs
+++ b/scripts/ios-theme.test.mjs
@@ -89,13 +89,16 @@ assert.match(
 
 // --- App chrome applies accent, mode, and propagates the palette ------------
 
-assert.match(app, /\.environment\(\\\.chrome, app\.chrome\)/, "App should inject the chrome palette");
-assert.match(app, /\.tint\(app\.chrome\.accent\)/, "App should tint controls with the desktop accent");
+// Chrome + scheme are resolved through the appearance override (Match desktop /
+// Light / Dark) before being applied.
+assert.match(app, /\.environment\(\\\.chrome, resolved\.chrome\)/, "App should inject the resolved chrome palette");
+assert.match(app, /\.tint\(resolved\.chrome\.accent\)/, "App should tint controls with the resolved accent");
 assert.match(
   app,
-  /\.preferredColorScheme\(app\.chrome\.colorScheme\)/,
-  "App should follow the desktop light/dark mode (not a hardcoded scheme)",
+  /\.preferredColorScheme\(resolved\.scheme\)/,
+  "App should apply the resolved light/dark mode (not a hardcoded scheme)",
 );
+assert.match(app, /mode\.resolve\(desktop: app\.chrome\)/, "App resolves the appearance override against the desktop chrome");
 assert.doesNotMatch(
   app,
   /\.preferredColorScheme\(\.dark\)/,

--- a/src/components/ios-theme-api.test.ts
+++ b/src/components/ios-theme-api.test.ts
@@ -23,7 +23,11 @@ assert.match(appModel, /var chrome:\s*ChromePalette = \.fallback/, "AppModel own
 assert.match(appModel, /func loadTheme\(\) async[\s\S]*client\.fetchTheme\(\)[\s\S]*ChromePalette\(snapshot:\s*snapshot\)/, "AppModel fetches and adopts the desktop palette");
 assert.match(appModel, /connectionState = \.connected[\s\S]*await loadFamiliars\(\)[\s\S]*await loadTheme\(\)/, "AppModel loads the theme after connecting");
 
-assert.match(app, /\.environment\(\\\.chrome,\s*app\.chrome\)[\s\S]*\.tint\(app\.chrome\.accent\)[\s\S]*\.preferredColorScheme\(app\.chrome\.colorScheme\)/, "app scene injects and applies desktop chrome");
+assert.match(app, /\.environment\(\\\.chrome,\s*resolved\.chrome\)[\s\S]*\.tint\(resolved\.chrome\.accent\)[\s\S]*\.preferredColorScheme\(resolved\.scheme\)/, "app scene injects and applies the resolved chrome + scheme");
+// The appearance override (Match desktop / Light / Dark) resolves against the
+// desktop chrome; "Match desktop" passes it through, a fixed mode forces it.
+assert.match(app, /@AppStorage\(AppearanceMode\.storageKey\)/, "app scene reads the persisted appearance override");
+assert.match(app, /mode\.resolve\(desktop:\s*app\.chrome\)/, "appearance mode resolves against the desktop chrome");
 assert.match(root, /@Environment\(\\\.chrome\) private var chrome/, "RootView reads the chrome palette");
 assert.match(root, /\.background\(chrome\.bgBase\.ignoresSafeArea\(\)\)[\s\S]*\.foregroundStyle\(chrome\.textPrimary\)/, "RootView applies desktop background and foreground");
 assert.match(root, /\.toolbarBackground\(chrome\.bgRaised,\s*for:\s*\.navigationBar,\s*\.tabBar\)/, "RootView applies desktop chrome to navigation and tab bars");


### PR DESCRIPTION
## What

The iOS app mirrored the **desktop's** light/dark mode with no way to set the phone independently — so a phone you'd want light (outdoors) was stuck dark whenever the desktop was dark.

Adds a **Settings → Appearance** control: **Match desktop** / **Light** / **Dark** (persisted in `@AppStorage`).
- **Match desktop** (default) keeps today's behavior — follows the desktop's published mode + palette.
- **Light** / **Dark** force the scheme on **this phone only**, swapping to the built-in system-semantic palette so every adaptive colour — including the chat markdown, which already follows the app's color scheme (#1741) — flips cleanly with no desktop-palette mismatch.

## Verification

On the iPhone 16 Pro simulator, with the **sim's system appearance set to the opposite**:
- `Light` → the whole app renders **light** (over a dark system + dark desktop default),
- `Dark` → renders **dark** (over a light system).

The override wins over both the system and the desktop. Clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)