### PR TITLE
fix(board): gantt cleanup — dead CSS, coalesced keyboard reschedule, task-mode steps, memo

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Card, CardStatus } from "@/lib/cave-board-types";
 import type { Familiar } from "@/lib/types";
 import { useDateTimePrefs, readDateTimePrefs } from "@/lib/datetime-format";
@@ -37,6 +37,12 @@ type GanttRow = {
   category: GanttCategory;
   /** Per-familiar bar colour, set only when grouping by familiar. */
   color?: string;
+  /**
+   * Task mode only: the step had no dates of its own, so its position is an
+   * equal slice of the task's range (a waterfall by step order) rather than a
+   * real schedule. Rendered de-emphasised; dragging promotes it to real dates.
+   */
+  inferred?: boolean;
 };
 type Group = { key: string; name: string; rows: GanttRow[]; firstStart: number };
 
@@ -126,6 +132,16 @@ function statusCategory(status: CardStatus): GanttCategory {
   return "pending"; // backlog · inbox · review
 }
 
+// A card's own date range; start/end fall back to each other. null if neither.
+function cardRange(card: Card): { start: Date; end: Date } | null {
+  const s = parseDate(card.startDate);
+  const e = parseDate(card.endDate);
+  if (!s && !e) return null;
+  const a = s ?? e!;
+  const b = e ?? s!;
+  return a <= b ? { start: a, end: b } : { start: b, end: a };
+}
+
 export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelect, onPatch, groupMode = "project" }: Props) {
   // Click a group header to focus it (hide the others); click again to show all.
   const [focusedKey, setFocusedKey] = useState<string | null>(null);
@@ -165,6 +181,13 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
   const draggable = !!onPatch;
   const [drag, setDrag] = useState<{ id: string; mode: DragMode; deltaDays: number } | null>(null);
   const dragRef = useRef<{ id: string; mode: DragMode; startX: number; moved: boolean } | null>(null);
+  // Keyboard reschedule (←/→ on a focused bar) accumulates consecutive presses
+  // into ONE patch — committing per keystroke would fire a write + an undo
+  // entry on every tap. kbShift drives the same live preview as a pointer drag;
+  // the pending shift flushes on idle, blur, or Escape.
+  const [kbShift, setKbShift] = useState<{ rowId: string; mode: DragMode; delta: number } | null>(null);
+  const kbShiftRef = useRef<{ row: GanttRow; mode: DragMode; delta: number } | null>(null);
+  const kbTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Suppresses the row's select-click that would otherwise fire after a drag.
   const suppressClickRef = useRef(false);
   // Center the timeline on "today" the first time it opens, so a long project
@@ -242,105 +265,147 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
     if (d.moved) commitShift(row, d.mode, active?.deltaDays ?? 0);
   };
 
-  const ownerName = (id: string | null): string =>
-    (id ? familiars?.find((f) => f.id === id)?.display_name : undefined) ?? "—";
-  const projectName = (id: string | null | undefined): string =>
-    (id ? projects?.find((p) => p.id === id)?.name : undefined) ?? "No project";
+  // Commit the accumulated keyboard shift (if any) as a single patch.
+  const flushKbShift = () => {
+    if (kbTimerRef.current) { clearTimeout(kbTimerRef.current); kbTimerRef.current = null; }
+    const pending = kbShiftRef.current;
+    kbShiftRef.current = null;
+    setKbShift(null);
+    if (pending && pending.delta !== 0) commitShift(pending.row, pending.mode, pending.delta);
+  };
+  // Add one arrow-key step to the running shift for this row+mode, restarting
+  // (and flushing the prior) if the target row or mode changed.
+  const pushKbShift = (row: GanttRow, mode: DragMode, dir: number) => {
+    const cur = kbShiftRef.current;
+    if (cur && (cur.row.rowId !== row.rowId || cur.mode !== mode)) {
+      commitShift(cur.row, cur.mode, cur.delta); // different target — commit the old one now
+      kbShiftRef.current = null;
+    }
+    const base = kbShiftRef.current?.delta ?? 0;
+    const next = { row, mode, delta: base + dir };
+    kbShiftRef.current = next;
+    setKbShift({ rowId: row.rowId, mode, delta: next.delta });
+    if (kbTimerRef.current) clearTimeout(kbTimerRef.current);
+    kbTimerRef.current = setTimeout(flushKbShift, 350);
+  };
+  // Drop the pending timer on unmount (the shift itself is best-effort).
+  useEffect(() => () => { if (kbTimerRef.current) clearTimeout(kbTimerRef.current); }, []);
+
+  const ownerName = useCallback(
+    (id: string | null): string =>
+      (id ? familiars?.find((f) => f.id === id)?.display_name : undefined) ?? "—",
+    [familiars],
+  );
+  const projectName = useCallback(
+    (id: string | null | undefined): string =>
+      (id ? projects?.find((p) => p.id === id)?.name : undefined) ?? "No project",
+    [projects],
+  );
   // A stable per-familiar colour for by-familiar bars: the familiar's own
   // colour when set, otherwise a hue derived from its id so distinct familiars
   // stay visually distinct. Unassigned rows keep their status colour.
-  const familiarColor = (id: string | null): string | undefined => {
-    if (!id) return undefined;
-    const set = familiars?.find((f) => f.id === id)?.color;
-    if (set) return set;
-    let h = 0;
-    for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) % 360;
-    return `hsl(${h} 52% 52%)`;
-  };
+  const familiarColor = useCallback(
+    (id: string | null): string | undefined => {
+      if (!id) return undefined;
+      const set = familiars?.find((f) => f.id === id)?.color;
+      if (set) return set;
+      let h = 0;
+      for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) % 360;
+      return `hsl(${h} 52% 52%)`;
+    },
+    [familiars],
+  );
 
-  // A card's own date range; start/end fall back to each other. null if neither.
-  const cardRange = (card: Card): { start: Date; end: Date } | null => {
-    const s = parseDate(card.startDate);
-    const e = parseDate(card.endDate);
-    if (!s && !e) return null;
-    const a = s ?? e!;
-    const b = e ?? s!;
-    return a <= b ? { start: a, end: b } : { start: b, end: a };
-  };
+  // Build the grouped row model. Memoised so a drag/keyboard reschedule (which
+  // re-renders on every pointer move) doesn't rebuild and re-sort every group.
+  const { groups, allRows, unscheduledCards } = useMemo(() => {
+    const groups: Group[] = [];
+    const placedCardIds = new Set<string>();
 
-  const groups: Group[] = [];
-  const placedCardIds = new Set<string>();
-
-  if (groupMode === "task") {
-    // One group per task; one bar per step, placed by the step's own dates and
-    // falling back to the task's range for undated steps.
-    for (const card of cards) {
-      const steps = card.steps ?? [];
-      if (steps.length === 0) continue;
-      const cr = cardRange(card);
-      const rows: GanttRow[] = [];
-      for (const step of steps) {
-        let s = parseDate(step.startDate);
-        let e = parseDate(step.endDate);
-        if (!s && !e) {
-          if (!cr) continue; // no step dates and no task range — can't place it
-          s = cr.start;
-          e = cr.end;
-        }
-        const a = s ?? e!;
-        const b = e ?? s!;
-        rows.push({
-          rowId: `${card.id}:${step.id}`,
-          cardId: card.id,
-          stepId: step.id,
-          label: step.text,
-          start: a <= b ? a : b,
-          end: a <= b ? b : a,
-          category: step.done ? "done" : statusCategory(card.status),
+    if (groupMode === "task") {
+      // One group per task; one bar per step. A step with its own dates uses
+      // them; an undated step is laid out as an equal slice of the task's range
+      // (a waterfall in step order) so undated steps no longer all collapse
+      // onto the full range as identical, overlapping bars.
+      for (const card of cards) {
+        const steps = card.steps ?? [];
+        if (steps.length === 0) continue;
+        const cr = cardRange(card);
+        const rangeDays = cr ? daysBetween(cr.start, cr.end) + 1 : 0;
+        const n = steps.length;
+        const rows: GanttRow[] = [];
+        steps.forEach((step, i) => {
+          let s = parseDate(step.startDate);
+          let e = parseDate(step.endDate);
+          let inferred = false;
+          if (!s && !e) {
+            if (!cr) return; // no step dates and no task range — can't place it
+            inferred = true;
+            // Contiguous equal slice for step i of n across the task range.
+            const sliceStart = Math.floor((i * rangeDays) / n);
+            const sliceEndExcl = Math.floor(((i + 1) * rangeDays) / n);
+            s = addDays(cr.start, sliceStart);
+            e = addDays(cr.start, Math.max(sliceStart, sliceEndExcl - 1));
+          }
+          const a = s ?? e!;
+          const b = e ?? s!;
+          rows.push({
+            rowId: `${card.id}:${step.id}`,
+            cardId: card.id,
+            stepId: step.id,
+            label: step.text,
+            start: a <= b ? a : b,
+            end: a <= b ? b : a,
+            category: step.done ? "done" : statusCategory(card.status),
+            inferred,
+          });
         });
+        if (rows.length === 0) continue;
+        placedCardIds.add(card.id);
+        groups.push({ key: card.id, name: card.title, rows, firstStart: Math.min(...rows.map((r) => r.start.getTime())) });
       }
-      if (rows.length === 0) continue;
-      placedCardIds.add(card.id);
-      groups.push({ key: card.id, name: card.title, rows, firstStart: Math.min(...rows.map((r) => r.start.getTime())) });
-    }
-  } else {
-    // One group per project (or familiar); one bar per scheduled task.
-    const byFamiliar = groupMode === "familiar";
-    const groupMap = new Map<string, Group>();
-    for (const card of cards) {
-      const cr = cardRange(card);
-      if (!cr) continue;
-      placedCardIds.add(card.id);
-      const key = byFamiliar ? (card.familiarId ?? "__unassigned__") : (card.projectId ?? "__none__");
-      let group = groupMap.get(key);
-      if (!group) {
-        const name = byFamiliar
-          ? (card.familiarId ? ownerName(card.familiarId) : "Unassigned")
-          : projectName(card.projectId);
-        group = { key, name, rows: [], firstStart: cr.start.getTime() };
-        groupMap.set(key, group);
+    } else {
+      // One group per project (or familiar); one bar per scheduled task.
+      const byFamiliar = groupMode === "familiar";
+      const groupMap = new Map<string, Group>();
+      for (const card of cards) {
+        const cr = cardRange(card);
+        if (!cr) continue;
+        placedCardIds.add(card.id);
+        const key = byFamiliar ? (card.familiarId ?? "__unassigned__") : (card.projectId ?? "__none__");
+        let group = groupMap.get(key);
+        if (!group) {
+          const name = byFamiliar
+            ? (card.familiarId ? ownerName(card.familiarId) : "Unassigned")
+            : projectName(card.projectId);
+          group = { key, name, rows: [], firstStart: cr.start.getTime() };
+          groupMap.set(key, group);
+        }
+        group.rows.push({
+          rowId: card.id,
+          cardId: card.id,
+          label: card.title,
+          start: cr.start,
+          end: cr.end,
+          category: statusCategory(card.status),
+          color: byFamiliar ? (familiarColor(card.familiarId) ?? "var(--text-muted)") : undefined,
+        });
+        group.firstStart = Math.min(group.firstStart, cr.start.getTime());
       }
-      group.rows.push({
-        rowId: card.id,
-        cardId: card.id,
-        label: card.title,
-        start: cr.start,
-        end: cr.end,
-        category: statusCategory(card.status),
-        color: byFamiliar ? (familiarColor(card.familiarId) ?? "var(--text-muted)") : undefined,
-      });
-      group.firstStart = Math.min(group.firstStart, cr.start.getTime());
+      groups.push(...groupMap.values());
     }
-    groups.push(...groupMap.values());
-  }
 
-  groups.sort((a, b) => a.firstStart - b.firstStart);
-  for (const g of groups) {
-    g.rows.sort((a, b) => a.start.getTime() - b.start.getTime() || a.end.getTime() - b.end.getTime());
-  }
+    groups.sort((a, b) => a.firstStart - b.firstStart);
+    for (const g of groups) {
+      g.rows.sort((a, b) => a.start.getTime() - b.start.getTime() || a.end.getTime() - b.end.getTime());
+    }
 
-  const allRows = groups.flatMap((g) => g.rows);
-  const unscheduledCards = cards.filter((c) => !placedCardIds.has(c.id));
+    return {
+      groups,
+      allRows: groups.flatMap((g) => g.rows),
+      unscheduledCards: cards.filter((c) => !placedCardIds.has(c.id)),
+    };
+  }, [cards, groupMode, ownerName, projectName, familiarColor]);
   const unscheduledCount = unscheduledCards.length;
 
   // Auto-center on today once the timeline can be drawn (keyed on the clock +
@@ -633,9 +698,13 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
                   const offset = Math.max(0, daysBetween(rangeStart, start));
                   const dur = Math.max(1, daysBetween(start, end) + 1);
                   const milestone = dur === 1;
-                  // Live drag state for this row, clamped so a resize can't
-                  // invert the bar. A diamond has no edges, so it only moves.
-                  const active = drag?.id === row.rowId ? drag : null;
+                  // Live reschedule state for this row, clamped so a resize
+                  // can't invert the bar — from a pointer drag or, failing that,
+                  // an in-flight keyboard shift (both preview identically).
+                  const active =
+                    drag?.id === row.rowId ? { mode: drag.mode, deltaDays: drag.deltaDays }
+                    : kbShift?.rowId === row.rowId ? { mode: kbShift.mode, deltaDays: kbShift.delta }
+                    : null;
                   const mode: DragMode = active?.mode ?? "move";
                   const dragDelta = active ? clampDelta(mode, active.deltaDays, dur) : 0;
                   const dragging = active !== null && dragDelta !== 0;
@@ -653,7 +722,7 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
                   const overdue =
                     todayStartMs !== null && cat !== "done" && previewEnd.getTime() < todayStartMs;
                   const barClass = (base: string) =>
-                    `${base}${draggable ? " cg-bar--grab" : ""}${dragging ? " cg-bar--dragging" : ""}${overdue ? " cg-bar--overdue" : ""}`;
+                    `${base}${draggable ? " cg-bar--grab" : ""}${dragging ? " cg-bar--dragging" : ""}${overdue ? " cg-bar--overdue" : ""}${row.inferred ? " cg-bar--inferred" : ""}`;
                   const handlers = draggable
                     ? {
                         onPointerDown: (e: React.PointerEvent) => beginDrag(e, row.rowId, "move"),
@@ -683,14 +752,17 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
                       }}
                       onKeyDown={(e) => {
                         // Keyboard reschedule on the focused bar: ←/→ move both
-                        // dates by a day, Shift+←/→ resize the end. (Tab already
-                        // moves focus between bars.)
+                        // dates by a day, Shift+←/→ resize the end. Consecutive
+                        // presses coalesce into one patch (flushed on idle/blur);
+                        // Escape commits immediately. (Tab moves focus between bars.)
+                        if (e.key === "Escape" && kbShift?.rowId === row.rowId) { e.preventDefault(); flushKbShift(); return; }
                         if (!draggable || (e.key !== "ArrowLeft" && e.key !== "ArrowRight")) return;
                         e.preventDefault();
                         const dir = e.key === "ArrowRight" ? 1 : -1;
-                        commitShift(row, e.shiftKey ? "resize-end" : "move", dir);
+                        pushKbShift(row, e.shiftKey ? "resize-end" : "move", dir);
                       }}
-                      title={`${row.label} · ${formatLabel(previewStart)}–${formatLabel(previewEnd)}${draggable ? " · drag to move, drag edges to resize · ←/→ to reschedule" : ""}`}
+                      onBlur={() => { if (kbShiftRef.current?.row.rowId === row.rowId) flushKbShift(); }}
+                      title={`${row.label} · ${formatLabel(previewStart)}–${formatLabel(previewEnd)}${row.inferred ? " · inferred from task range — drag to set real dates" : ""}${draggable ? " · drag to move, drag edges to resize · ←/→ to reschedule" : ""}`}
                     >
                       <span className="cg-left">
                         <span className="cg-c-task">{row.label}</span>

--- a/src/components/board-schedule-window.test.ts
+++ b/src/components/board-schedule-window.test.ts
@@ -88,7 +88,7 @@ assert.doesNotMatch(styles, /cg-c-owner|cg--no-owner/, "Owner column styles are 
 assert.match(styles, /\.cg-left \{[\s\S]*?grid-template-columns: 300px 58px 58px 26px;/, "the left table uses the four-column (ownerless) layout with a wide task column");
 
 // By-familiar grouping colour-codes bars by familiar.
-assert.match(gantt, /const familiarColor = \(id: string \| null\): string \| undefined =>/, "a per-familiar colour helper exists");
+assert.match(gantt, /const familiarColor = useCallback\(\s*\n\s*\(id: string \| null\): string \| undefined =>/, "a per-familiar colour helper exists");
 assert.match(gantt, /color: byFamiliar \? \(familiarColor\(card\.familiarId\) \?\? "var\(--text-muted\)"\) : undefined/, "rows carry a familiar colour (or neutral fallback) only in by-familiar mode");
 assert.match(gantt, /\.\.\.\(row\.color \? \{ background: row\.color \} : \{\}\)/, "the bar paints the familiar colour when present");
 
@@ -177,7 +177,31 @@ assert.match(gantt, /if \(prevZoomRef\.current === zoom\) return;[\s\S]{0,120}ce
 // Pointer drag-end and keyboard reschedule share one commit path.
 assert.match(gantt, /const commitShift = \(row: GanttRow, mode: DragMode, rawDelta: number\)/, "a shared commitShift applies a day-shift");
 assert.match(gantt, /if \(d\.moved\) commitShift\(row, d\.mode, active\?\.deltaDays \?\? 0\)/, "drag-end routes through commitShift");
-assert.match(gantt, /commitShift\(row, e\.shiftKey \? "resize-end" : "move", dir\)/, "arrow keys reschedule the focused bar (Shift to resize)");
 assert.match(gantt, /e\.key !== "ArrowLeft" && e\.key !== "ArrowRight"/, "only left/right arrows reschedule");
+
+// Keyboard reschedule COALESCES consecutive presses into a single patch (and a
+// single undo entry) instead of committing per keystroke — it accumulates into
+// kbShift, previews live like a drag, and flushes on idle/blur/Escape.
+assert.match(gantt, /pushKbShift\(row, e\.shiftKey \? "resize-end" : "move", dir\)/, "arrow keys feed the coalescing accumulator (Shift to resize)");
+assert.match(gantt, /const flushKbShift = \(\) => \{[\s\S]*?commitShift\(pending\.row, pending\.mode, pending\.delta\)/, "the accumulated keyboard shift commits as one patch");
+assert.match(gantt, /setTimeout\(flushKbShift, 350\)/, "consecutive presses debounce into one flush");
+assert.match(gantt, /onBlur=\{\(\) => \{ if \(kbShiftRef\.current\?\.row\.rowId === row\.rowId\) flushKbShift\(\); \}\}/, "leaving the bar flushes the pending shift");
+assert.match(gantt, /kbShift\?\.rowId === row\.rowId \? \{ mode: kbShift\.mode, deltaDays: kbShift\.delta \}/, "the keyboard shift drives the same live preview as a drag");
+
+// The group model is memoised so a drag/keyboard re-render doesn't rebuild it.
+assert.match(gantt, /const \{ groups, allRows, unscheduledCards \} = useMemo\(\(\) => \{/, "the grouped row model is memoised");
+assert.match(gantt, /\}, \[cards, groupMode, ownerName, projectName, familiarColor\]\);/, "the memo is keyed on its real inputs");
+
+// Task mode: undated steps are laid out as equal slices of the task range (a
+// waterfall by step order), marked `inferred` and rendered de-emphasised —
+// they no longer all collapse onto the full range as identical bars.
+assert.match(gantt, /const sliceStart = Math\.floor\(\(i \* rangeDays\) \/ n\);/, "an undated step takes a contiguous equal slice of the task range");
+assert.match(gantt, /inferred,/, "rows carry whether their dates were inferred");
+assert.match(gantt, /\$\{row\.inferred \? " cg-bar--inferred" : ""\}/, "inferred bars get a de-emphasis class");
+assert.match(styles, /\.cg-bar--inferred \{/, "inferred bars are styled (translucent + dashed)");
+// Milestone diamonds stay a deliberately-neutral glyph (white !important) in
+// every mode, matching the legend's white "Milestone" swatch — so they must NOT
+// be painted with the per-familiar bar colour.
+assert.match(styles, /\.cg-diamond \{[\s\S]*?background: var\(--text-primary\) !important;/, "milestone diamonds are a neutral marker in all modes");
 
 console.log("board-schedule-window.test.ts: ok");

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1542,120 +1542,10 @@
   text-align: center;
   color: var(--text-muted);
 }
-/* Title / timeline / dates columns are fixed so the header axis and the "today"
-   overlay (which reuse this exact grid) line up with the bar tracks. */
-.board-gantt-header {
-  display: grid;
-  grid-template-columns: 180px minmax(0, 1fr) 132px;
-  gap: 10px;
-  /* 11px = a row's 1px border + 10px padding, so the axis column starts exactly
-     where the tracks below it do. */
-  padding: 0 11px 8px;
-  color: var(--text-muted);
-  font-size: 11px;
-  font-variant-numeric: tabular-nums;
-}
-/* The timeline axis cell carries the start/end labels and the "today" caption,
-   positioned by the same percentage the overlay line uses. */
-.board-gantt-axis {
-  position: relative;
-  display: flex;
-  justify-content: space-between;
-}
-.board-gantt-axis__today {
-  position: absolute;
-  top: 0;
-  transform: translateX(-50%);
-  color: var(--accent-presence);
-  font-weight: 650;
-  white-space: nowrap;
-}
-.board-gantt-plot {
-  position: relative;
-}
-.board-gantt-list {
-  display: grid;
-  gap: 4px;
-}
-/* Full-height vertical "today" guide over the whole list. Mirrors a row's grid
-   + 11px inset so its middle column maps onto the bar tracks. */
-.board-gantt-today {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  grid-template-columns: 180px minmax(0, 1fr) 132px;
-  gap: 10px;
-  padding: 0 11px;
-  pointer-events: none;
-  z-index: 1;
-}
-.board-gantt-today__col {
-  position: relative;
-}
-.board-gantt-today__line {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 0;
-  border-left: 1px dashed color-mix(in oklch, var(--accent-presence) 60%, transparent);
-}
-.board-gantt-row {
-  display: grid;
-  grid-template-columns: 180px minmax(0, 1fr) 132px;
-  align-items: center;
-  gap: 10px;
-  width: 100%;
-  min-height: 34px;
-  border: 1px solid var(--border-hairline);
-  border-radius: 8px;
-  background: var(--bg-raised);
-  color: var(--text-primary);
-  padding: 5px 10px;
-  text-align: left;
-  cursor: pointer;
-  transition: border-color .12s, background .12s;
-}
-.board-gantt-row:hover,
-.board-gantt-row--selected {
-  border-color: color-mix(in oklch,var(--accent-presence) 42%,var(--border-hairline));
-  background: color-mix(in oklch,var(--accent-presence) 8%,var(--bg-raised));
-}
-.board-gantt-row__title {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 12px;
-  font-weight: 600;
-}
-.board-gantt-row__track {
-  position: relative;
-  height: 12px;
-  border-radius: 999px;
-  background: var(--bg-base);
-  border: 1px solid var(--border-hairline);
-  overflow: hidden;
-}
-.board-gantt-row__bar {
-  position: absolute;
-  top: 2px;
-  bottom: 2px;
-  min-width: 12px;
-  border-radius: 999px;
-  background: var(--accent-presence);
-}
-.board-gantt-row__bar--urgent { background: var(--color-danger); }
-.board-gantt-row__bar--high { background: var(--color-warning); }
-.board-gantt-row__bar--medium { background: var(--accent-presence); }
-.board-gantt-row__bar--low { background: color-mix(in oklch,var(--text-muted) 55%,transparent); }
-.board-gantt-row__dates {
-  color: var(--text-secondary);
-  font-size: 11px;
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  text-align: right;
-}
+/* NOTE: the pre-rewrite grid/axis/today/priority-bar rules that lived here were
+   removed once the dense `.cg-*` timeline (below) replaced them — they had zero
+   references left in the markup. The current bars + categories are defined in
+   the "Compact Gantt" block further down. */
 .board-gantt-unscheduled {
   margin-top: 10px;
   color: var(--text-muted);
@@ -1850,6 +1740,11 @@
 /* overdue bar: ended before today and not done — outline + danger ring */
 .cg-bar--overdue { outline: 1.5px solid var(--color-danger); outline-offset: 1px; }
 .cg-diamond.cg-bar--overdue { outline: none; box-shadow: 0 0 0 1.5px var(--color-danger); }
+/* Inferred (task-mode) bars: the step had no dates of its own, so its position
+   is an equal slice of the task range — render translucent + dashed so it reads
+   as a hint, not a real schedule. */
+.cg-bar--inferred { opacity: 0.5; border: 1px dashed color-mix(in oklch, var(--text-primary) 45%, transparent); }
+.cg-diamond.cg-bar--inferred { opacity: 0.5; }
 /* drop hint while dragging an undated task onto the timeline */
 .cg-drop-hint { position: absolute; top: 0; bottom: 0; z-index: 3; background: color-mix(in oklch, var(--accent-presence) 22%, transparent); border-left: 2px solid var(--accent-presence); border-right: 2px solid var(--accent-presence); pointer-events: none; }
 .cg-drag-label {


### PR DESCRIPTION
## Gantt audit + fixes

A review pass over the Board → Gantt timeline (`src/components/board-gantt.tsx` + `.cg-*` styles). Five issues, four fixed, one investigated and intentionally left:

### 1. Dead CSS removed (~115 lines)
The pre-rewrite grid/axis/today/priority styles (`.board-gantt-header`, `.board-gantt-axis*`, `.board-gantt-plot`, `.board-gantt-list`, `.board-gantt-today*`, the old `.board-gantt-row` grid + `__title`/`__track`/`__dates`, and the unused `--urgent/high/medium/low` bar colours) had **zero references** in any markup after the `.cg-*` rewrite. Kept the still-used `.board-gantt`, `.board-gantt--empty`, `.board-gantt-unscheduled`.

### 2. Keyboard reschedule no longer storms patches
`←/→` on a focused bar called `commitShift` → `onPatch` on **every keypress**, firing an API write *and* an undo snapshot per tap (undo only reverted the last day). Presses now **coalesce** into one patch via a `kbShift` accumulator, preview live exactly like a pointer drag, and flush on idle (350 ms), blur, or `Escape` → one write, one undo entry.

### 3. Task mode: undated steps render as a waterfall, not a wall
Undated steps all fell back to the full task range, so every step bar was identical and overlapping (visually useless — the common case). They now lay out as **equal contiguous slices** across the task range in step order, marked `inferred` and rendered translucent/dashed; dragging one promotes it to real dates.

| before | after |
|---|---|
| every step bar identical, full-width | de-emphasised waterfall by step order |

### 4. Memoised the group model
`groups`/`allRows`/`unscheduledCards` rebuilt + re-sorted on **every render, including every `pointermove` during a drag**. Now wrapped in `useMemo` keyed on `[cards, groupMode, ownerName, projectName, familiarColor]`.

### Investigated, left as-is
Milestone diamonds render neutral white in *all* modes (`.cg-diamond { background: var(--text-primary) !important }`) — a deliberate marker that matches the legend's white "Milestone" swatch. Painting them with the per-familiar colour (my initial hypothesis) would *diverge* from the legend, so I reverted that change. Caught via screenshot verification.

## Testing
- `board-schedule-window.test.ts` updated (source-text pinned) with assertions for the coalescing accumulator, memoised model, inferred-step slicing/styling, and the neutral-diamond invariant.
- `tsc --noEmit` clean · `pnpm build` (incl. `next lint`) clean · full `app` suite: 386 files pass · visually verified project/task/familiar modes in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)