### PR TITLE
feat(ios): per-device appearance override (light/dark/system) over desktop sync

### DIFF
--- a/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
+++ b/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
@@ -8,12 +8,12 @@ struct CovenCaveApp: App {
         WindowGroup {
             RootView()
                 .environment(app)
-                // Match the desktop appearance: propagate its palette to every
-                // view, tint app-wide controls with its accent, and follow its
-                // light/dark mode (defaults to dark until a theme loads).
-                .environment(\.chrome, app.chrome)
-                .tint(app.chrome.accent)
-                .preferredColorScheme(app.chrome.colorScheme)
+                // Appearance: mirror the desktop's palette/mode by default, or
+                // honor this device's local override (Light/Dark/System) — the
+                // effective* accessors resolve which applies.
+                .environment(\.chrome, app.effectivePalette)
+                .tint(app.effectivePalette.accent)
+                .preferredColorScheme(app.effectiveColorScheme)
                 .task {
                     if app.connection != nil {
                         await app.refreshConnection()

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import SwiftUI
 
 /// The bottom tabs. Lifted out of the view so slash commands (`/board`,
 /// `/chats`) can drive tab selection from anywhere.
@@ -116,6 +117,31 @@ final class AppModel {
     /// (`GET /api/theme`). Starts at the built-in look and is replaced once the
     /// desktop theme loads. One-way (desktop → iOS), per the design.
     var chrome: ChromePalette = .fallback
+
+    /// This device's appearance choice. `.desktop` mirrors the synced theme;
+    /// the others override it locally and persist across launches.
+    private static let appearanceKey = "cave.appearance"
+    var appearance: AppearancePref = AppModel.loadAppearancePref() {
+        didSet { UserDefaults.standard.set(appearance.rawValue, forKey: AppModel.appearanceKey) }
+    }
+    private static func loadAppearancePref() -> AppearancePref {
+        AppearancePref(rawValue: UserDefaults.standard.string(forKey: appearanceKey) ?? "") ?? .desktop
+    }
+
+    /// The palette actually shown: the desktop's when syncing, otherwise the
+    /// built-in adaptive palette (whose system colours follow the forced mode).
+    var effectivePalette: ChromePalette {
+        appearance == .desktop ? chrome : .fallback
+    }
+    /// The colour scheme to force app-wide; `nil` means follow the OS.
+    var effectiveColorScheme: ColorScheme? {
+        switch appearance {
+        case .desktop: return chrome.colorScheme
+        case .light: return .light
+        case .dark: return .dark
+        case .system: return nil
+        }
+    }
 
     /// Fetch the desktop theme and adopt its palette. Best-effort: on any
     /// failure the current palette stands, so there's no flash back to the

--- a/apps/ios/CovenCave/CovenCave/Theme/Theme.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/Theme.swift
@@ -1,6 +1,28 @@
 import SwiftUI
 import UIKit
 
+// MARK: - Appearance preference (this device)
+
+/// How this device picks its appearance. By default it mirrors the desktop's
+/// published theme; the other options override that sync locally — using the
+/// built-in adaptive palette in the chosen light/dark (or system) mode.
+enum AppearancePref: String, CaseIterable, Identifiable {
+    case desktop
+    case system
+    case light
+    case dark
+
+    var id: String { rawValue }
+    var label: String {
+        switch self {
+        case .desktop: return "Sync with desktop"
+        case .system: return "System"
+        case .light: return "Light"
+        case .dark: return "Dark"
+        }
+    }
+}
+
 // MARK: - App-chrome palette
 
 /// The desktop's active appearance, resolved from the colour tokens it publishes

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -36,6 +36,21 @@ struct SettingsView: View {
                     Text("Save every conversation as Markdown files in a single .zip.")
                 }
 
+                Section {
+                    Picker("Theme", selection: Binding(
+                        get: { app.appearance },
+                        set: { app.appearance = $0 }
+                    )) {
+                        ForEach(AppearancePref.allCases) { pref in
+                            Text(pref.label).tag(pref)
+                        }
+                    }
+                } header: {
+                    Text("Appearance")
+                } footer: {
+                    Text("“Sync with desktop” mirrors your Mac's theme. Light, Dark, or System override it on this device only.")
+                }
+
                 Section("Desktop") {
                     LabeledContent("Address") {
                         Text(app.connection?.host ?? "—")

--- a/scripts/ios-appearance-override.test.mjs
+++ b/scripts/ios-appearance-override.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (rel) => readFile(new URL(`../${rel}`, import.meta.url), "utf8");
+const iosRoot = "apps/ios/CovenCave/CovenCave";
+
+const theme = await read(`${iosRoot}/Theme/Theme.swift`);
+const model = await read(`${iosRoot}/State/AppModel.swift`);
+const appEntry = await read(`${iosRoot}/CovenCaveApp.swift`);
+const settings = await read(`${iosRoot}/Views/SettingsView.swift`);
+
+// A device-local appearance preference exists, defaulting to mirroring desktop.
+assert.match(theme, /enum AppearancePref: String, CaseIterable, Identifiable/, "AppearancePref enum exists");
+for (const c of ["case desktop", "case system", "case light", "case dark"]) {
+  assert.match(theme, new RegExp(c), `AppearancePref has ${c}`);
+}
+
+// The preference is persisted and defaults to .desktop (sync) when unset.
+assert.match(model, /var appearance: AppearancePref = AppModel\.loadAppearancePref\(\)/, "AppModel holds the appearance pref");
+assert.match(model, /UserDefaults\.standard\.set\(appearance\.rawValue, forKey: AppModel\.appearanceKey\)/, "appearance persists on change");
+assert.match(model, /AppearancePref\(rawValue: UserDefaults\.standard\.string\(forKey: appearanceKey\) \?\? ""\) \?\? \.desktop/, "appearance defaults to .desktop when unset");
+
+// Override resolves the effective palette + colour scheme.
+assert.match(model, /var effectivePalette: ChromePalette \{[\s\S]{0,80}appearance == \.desktop \? chrome : \.fallback/, "effectivePalette uses the desktop palette only when syncing");
+assert.match(model, /var effectiveColorScheme: ColorScheme\? \{/, "effectiveColorScheme is optional (system → nil)");
+assert.match(model, /case \.desktop: return chrome\.colorScheme/, "desktop mode follows the synced scheme");
+assert.match(model, /case \.system: return nil/, "system mode follows the OS");
+
+// The app entry applies the effective values (not the raw synced ones).
+assert.match(appEntry, /\.environment\(\\\.chrome, app\.effectivePalette\)/, "app propagates the effective palette");
+assert.match(appEntry, /\.preferredColorScheme\(app\.effectiveColorScheme\)/, "app applies the effective colour scheme");
+
+// Settings exposes the override picker.
+assert.match(settings, /Text\("Appearance"\)/, "Settings has an Appearance section");
+assert.match(settings, /Picker\("Theme", selection: Binding\(/, "Settings has a Theme picker bound to the pref");
+assert.match(settings, /ForEach\(AppearancePref\.allCases\) \{ pref in/, "the picker lists every appearance option");
+
+console.log("ios-appearance-override.test.mjs: ok");

--- a/scripts/ios-theme.test.mjs
+++ b/scripts/ios-theme.test.mjs
@@ -89,12 +89,14 @@ assert.match(
 
 // --- App chrome applies accent, mode, and propagates the palette ------------
 
-assert.match(app, /\.environment\(\\\.chrome, app\.chrome\)/, "App should inject the chrome palette");
-assert.match(app, /\.tint\(app\.chrome\.accent\)/, "App should tint controls with the desktop accent");
+// The app injects the EFFECTIVE palette/scheme, which mirror the desktop by
+// default and honor a per-device Light/Dark/System override otherwise.
+assert.match(app, /\.environment\(\\\.chrome, app\.effectivePalette\)/, "App should inject the effective chrome palette");
+assert.match(app, /\.tint\(app\.effectivePalette\.accent\)/, "App should tint controls with the effective accent");
 assert.match(
   app,
-  /\.preferredColorScheme\(app\.chrome\.colorScheme\)/,
-  "App should follow the desktop light/dark mode (not a hardcoded scheme)",
+  /\.preferredColorScheme\(app\.effectiveColorScheme\)/,
+  "App should follow the effective light/dark mode (desktop or local override)",
 );
 assert.doesNotMatch(
   app,

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -509,6 +509,7 @@ export const SUITES = {
     "scripts/ios-task-notes-edit.test.mjs",
     "scripts/ios-task-actions.test.mjs",
     "scripts/ios-task-search-familiar-scope.test.mjs",
+    "scripts/ios-appearance-override.test.mjs",
     "scripts/ios-thread-rename.test.mjs",
     "scripts/ios-archive-threads.test.mjs",
     "scripts/ios-pin-threads.test.mjs",

--- a/src/components/ios-theme-api.test.ts
+++ b/src/components/ios-theme-api.test.ts
@@ -23,7 +23,7 @@ assert.match(appModel, /var chrome:\s*ChromePalette = \.fallback/, "AppModel own
 assert.match(appModel, /func loadTheme\(\) async[\s\S]*client\.fetchTheme\(\)[\s\S]*ChromePalette\(snapshot:\s*snapshot\)/, "AppModel fetches and adopts the desktop palette");
 assert.match(appModel, /connectionState = \.connected[\s\S]*await loadFamiliars\(\)[\s\S]*await loadTheme\(\)/, "AppModel loads the theme after connecting");
 
-assert.match(app, /\.environment\(\\\.chrome,\s*app\.chrome\)[\s\S]*\.tint\(app\.chrome\.accent\)[\s\S]*\.preferredColorScheme\(app\.chrome\.colorScheme\)/, "app scene injects and applies desktop chrome");
+assert.match(app, /\.environment\(\\\.chrome,\s*app\.effectivePalette\)[\s\S]*\.tint\(app\.effectivePalette\.accent\)[\s\S]*\.preferredColorScheme\(app\.effectiveColorScheme\)/, "app scene injects and applies the effective chrome (desktop or local override)");
 assert.match(root, /@Environment\(\\\.chrome\) private var chrome/, "RootView reads the chrome palette");
 assert.match(root, /\.background\(chrome\.bgBase\.ignoresSafeArea\(\)\)[\s\S]*\.foregroundStyle\(chrome\.textPrimary\)/, "RootView applies desktop background and foreground");
 assert.match(root, /\.toolbarBackground\(chrome\.bgRaised,\s*for:\s*\.navigationBar,\s*\.tabBar\)/, "RootView applies desktop chrome to navigation and tab bars");


### PR DESCRIPTION
## What

iOS mirrored the desktop's published theme **one-way** (`GET /api/theme`) with no local control. This adds a device-local **Appearance** setting:

- **Sync with desktop** (default) — unchanged: adopt the desktop's palette + light/dark mode.
- **System** — follow the iPhone's own light/dark.
- **Light** / **Dark** — force it on this device.

Any non-"desktop" choice overrides the sync using the built-in **adaptive** palette in the chosen mode. The choice **persists** (UserDefaults) and `effectivePalette` / `effectiveColorScheme` resolve which applies, feeding the app scene's `.environment(\.chrome)` / `.tint` / `.preferredColorScheme`.

## Verification

- `xcodebuild` (iOS Simulator) → **BUILD SUCCEEDED** (Swift isn't in CI, so built locally).
- `node scripts/run-tests.mjs mobile` → 45 files; `app` → 386 files — both pass. New `scripts/ios-appearance-override.test.mjs` guards the wiring; updated `ios-theme.test.mjs` / `ios-theme-api.test.ts` for the new effective accessors.
- **Runtime**: ran in the simulator — with the override set to Light, the app renders light (white chrome) instead of the desktop-synced dark, confirming the override actually takes effect. (Default `.desktop` still renders the synced dark, unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)