### PR TITLE
refactor(ui): deeper context-menu focus-return + CSS-driven undo toast

### DIFF
--- a/src/components/ui/context-menu.test.ts
+++ b/src/components/ui/context-menu.test.ts
@@ -11,13 +11,16 @@ assert.match(src, /export function openContextMenuAt/, "exports the onContextMen
 
 // State is the cursor position or null when closed; open = state !== null.
 assert.match(src, /export type ContextMenuState = \{ x: number; y: number \} \| null/, "state is cursor xy or null");
-assert.match(src, /open=\{state !== null\}/, "menu is open when state is set");
+assert.match(src, /const open = state !== null/, "open derives from a non-null cursor state");
 
 // Anchors to a 0-size element pinned at the cursor so it opens where clicked.
 assert.match(src, /position: "fixed", left: state\?\.x[\s\S]{0,60}width: 0, height: 0/, "anchors a 0-size element at the cursor");
-// The anchor is programmatically focusable (tabIndex=-1) so the Popover's
-// close-time focus-return works instead of stranding focus on <body>.
-assert.match(src, /tabIndex=\{-1\}/, "the cursor anchor is focusable for focus-return on close");
+// On close, focus returns to the element that had it when the menu opened (the
+// right-clicked row) — not the hidden anchor or <body>. The anchor stays
+// non-focusable aria-hidden (no focusable + aria-hidden conflict).
+assert.doesNotMatch(src, /tabIndex/, "the cursor anchor is not made focusable (avoids the aria-hidden focus conflict)");
+assert.match(src, /returnFocusRef\.current = document\.activeElement/, "captures the focused element when the menu opens");
+assert.match(src, /document\.contains\(el\)[\s\S]{0,40}?el\.focus\(\)/, "restores focus to that element on close if it's still in the DOM");
 
 // The helper preventDefaults the native menu and records the click position.
 assert.match(src, /e\.preventDefault\(\)/, "suppresses the browser's native context menu");

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 
 import { Popover } from "@/components/ui/popover";
 
@@ -29,21 +29,28 @@ export function ContextMenu({
   children: ReactNode;
 }) {
   const anchorRef = useRef<HTMLSpanElement>(null);
+  // Remember the element that had focus when the menu opened (typically the
+  // right-clicked row) so focus can be returned there on close — rather than
+  // stranding it on <body> or on the hidden cursor anchor.
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+  const open = state !== null;
+  useEffect(() => {
+    if (open) returnFocusRef.current = document.activeElement as HTMLElement | null;
+  }, [open]);
   return (
     <>
       <span
         ref={anchorRef}
         aria-hidden
-        tabIndex={-1}
-        // tabIndex makes the anchor programmatically focusable so the Popover's
-        // close-time focus-return (which focuses the anchor when focus would
-        // otherwise be lost to <body>) actually works for keyboard users.
         style={{ position: "fixed", left: state?.x ?? 0, top: state?.y ?? 0, width: 0, height: 0 }}
       />
       <Popover
-        open={state !== null}
+        open={open}
         onOpenChange={(next) => {
-          if (!next) onClose();
+          if (next) return;
+          onClose();
+          const el = returnFocusRef.current;
+          if (el && document.contains(el) && typeof el.focus === "function") el.focus();
         }}
         anchorRef={anchorRef}
         placement="bottom-start"

--- a/src/components/ui/undo-toast.test.ts
+++ b/src/components/ui/undo-toast.test.ts
@@ -10,14 +10,15 @@ assert.match(src, /export function UndoToast/, "exports UndoToast");
 assert.match(src, /message,[\s\S]{0,200}?icon = "ph:trash"/, "message is a prop; icon defaults to trash");
 assert.match(src, /undoAriaLabel = "Undo"/, "the Undo button has a configurable accessible label");
 
-// Countdown progress bar (rAF), like the original.
-assert.match(src, /requestAnimationFrame\(tick\)/, "animates a countdown via requestAnimationFrame");
+// Countdown bar is a single CSS width transition (not a per-frame rAF loop).
+assert.doesNotMatch(src, /requestAnimationFrame\(tick\)/, "no per-frame rAF render loop");
 assert.match(src, /className="library-undo-toast-progress"/, "renders the countdown progress bar");
+assert.match(src, /width: collapsed \? "0%" : "100%", transitionDuration: `\$\{durationMs\}ms`/, "the bar animates 100%→0% over durationMs via CSS");
 
 // autoDismiss is opt-in (off by default) so controller-owned toasts (library)
 // keep their behavior while self-dismissing toasts (projects move) opt in.
 assert.match(src, /autoDismiss = false/, "autoDismiss defaults to off");
-assert.match(src, /remaining > 0[\s\S]{0,80}?else if \(autoDismiss\)[\s\S]{0,40}?dismissRef\.current\(\)/, "autoDismiss fires onDismiss when the bar empties");
+assert.match(src, /autoDismiss\s*\?\s*window\.setTimeout\(\(\) => dismissRef\.current\(\), durationMs\)/, "autoDismiss fires onDismiss via setTimeout (fires even in a backgrounded tab)");
 
 // role=status / aria-live keep it announced.
 assert.match(src, /role="status"[\s\S]{0,40}?aria-live="polite"/, "announced politely to assistive tech");

--- a/src/components/ui/undo-toast.tsx
+++ b/src/components/ui/undo-toast.tsx
@@ -35,26 +35,24 @@ export function UndoToast({
   undoAriaLabel = "Undo",
   autoDismiss = false,
 }: Props) {
-  const [progress, setProgress] = useState(100);
-  const startRef = useRef(Date.now());
-  const rafRef = useRef<number>(0);
+  // The countdown bar is a single CSS width transition (100% → 0% over
+  // durationMs) rather than a per-frame requestAnimationFrame loop, so the toast
+  // doesn't re-render every frame for a decorative bar. autoDismiss is a single
+  // setTimeout — which, unlike rAF, still fires in a backgrounded tab.
+  const [collapsed, setCollapsed] = useState(false);
   const dismissRef = useRef(onDismiss);
   dismissRef.current = onDismiss;
 
   useEffect(() => {
-    startRef.current = Date.now();
-    const tick = () => {
-      const elapsed = Date.now() - startRef.current;
-      const remaining = Math.max(0, 100 - (elapsed / durationMs) * 100);
-      setProgress(remaining);
-      if (remaining > 0) {
-        rafRef.current = requestAnimationFrame(tick);
-      } else if (autoDismiss) {
-        dismissRef.current();
-      }
+    // Flip to 0% on the next frame so the mounted-at-100% bar animates down.
+    const raf = requestAnimationFrame(() => setCollapsed(true));
+    const timer = autoDismiss
+      ? window.setTimeout(() => dismissRef.current(), durationMs)
+      : undefined;
+    return () => {
+      cancelAnimationFrame(raf);
+      if (timer !== undefined) window.clearTimeout(timer);
     };
-    rafRef.current = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(rafRef.current);
   }, [durationMs, autoDismiss]);
 
   return (
@@ -69,7 +67,11 @@ export function UndoToast({
           <Icon name="ph:x-bold" aria-hidden />
         </button>
       </div>
-      <div className="library-undo-toast-progress" style={{ width: `${progress}%` }} aria-hidden />
+      <div
+        className="library-undo-toast-progress"
+        style={{ width: collapsed ? "0%" : "100%", transitionDuration: `${durationMs}ms` }}
+        aria-hidden
+      />
     </div>
   );
 }


### PR DESCRIPTION
Addresses two findings from the `/code-review` of the previous follow-up (#1745).

## 1. Context-menu focus-return (depth / a11y)
The prior fix made the 0-size cursor anchor focusable (`tabIndex={-1}`), but focusing an `aria-hidden` element is itself an anti-pattern (axe `aria-hidden-focus`). Now `ContextMenu` **captures the element focused when the menu opens** (the right-clicked row) and **restores focus to it on close**; the anchor reverts to non-focusable `aria-hidden`.

## 2. Undo-toast countdown (efficiency + background tabs)
The progress bar was a per-frame `requestAnimationFrame` loop (~60fps `setProgress` for the toast's whole life — for the projects move-toast that had replaced a single `setTimeout`). Now it's a **single CSS width transition** (100%→0% over `durationMs`, reusing `.library-undo-toast-progress`'s existing `transition`), and `autoDismiss` is **one `setTimeout`** — no per-frame re-renders, and (unlike rAF) it still fires in a **backgrounded tab**.

## Verification
- `pnpm typecheck` clean · `context-menu`/`undo-toast`/`projects-view` + library `familiars-memory-view-management` tests green · `check:tests-wired` green (514)
- Live: Escape on a context menu returns focus to the right-clicked row; the move-undo toast still renders + auto-dismisses with the countdown bar (screenshots/checks in thread)

Leaves the two noted tech-debt items (the `.library-undo-toast*` class location, the muted-vs-accent arrow color) as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)