### PR TITLE
feat(ios): theme the inset-grouped list surfaces too

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Theme/Theme.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/Theme.swift
@@ -72,8 +72,10 @@ private struct ThemedListBackground: ViewModifier {
 
 extension View {
     /// Reveal the desktop theme's `bgBase` behind a `List` instead of the opaque
-    /// system background. Apply after `.listStyle(…)`. Pair with
-    /// `.listRowBackground(Color.clear)` on rows that set their own fill.
+    /// system background. Apply after `.listStyle(…)`. Works for both `.plain`
+    /// and `.insetGrouped` — the inset cards keep their adaptive system surface
+    /// (which reads as themed cards floating on the `bgBase` floor and preserves
+    /// row contrast), only the floor behind/around them becomes `bgBase`.
     func themedListBackground() -> some View { modifier(ThemedListBackground()) }
 }
 

--- a/apps/ios/CovenCave/CovenCave/Views/CodeBrowserView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/CodeBrowserView.swift
@@ -85,6 +85,7 @@ struct CodeBrowserView: View {
             }
         }
         .listStyle(.plain)
+        .themedListBackground()
     }
 
     // MARK: - Search (scoped to the focused project)
@@ -121,6 +122,7 @@ struct CodeBrowserView: View {
                 }
             }
             .listStyle(.insetGrouped)
+            .themedListBackground()
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
@@ -66,6 +66,7 @@ struct GitHubView: View {
                 }
             }
             .listStyle(.insetGrouped)
+            .themedListBackground()
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -189,6 +189,7 @@ struct TasksView: View {
             }
         }
         .listStyle(.insetGrouped)
+        .themedListBackground()
     }
 
     private var emptyState: some View {

--- a/scripts/ios-theme-list-background.test.mjs
+++ b/scripts/ios-theme-list-background.test.mjs
@@ -19,7 +19,7 @@ assert.match(
   "Theme should expose the themedListBackground() View extension",
 );
 
-// Every primary browse list adopts it after its listStyle so the themed
+// Every primary plain browse list adopts it after its listStyle so the themed
 // background shows through.
 for (const view of [
   "ChatsHomeView.swift",
@@ -32,6 +32,17 @@ for (const view of [
     src,
     /\.listStyle\(\.plain\)\s*\n\s*\.themedListBackground\(\)/,
     `${view} should apply .themedListBackground() right after .listStyle(.plain)`,
+  );
+}
+
+// Inset-grouped surfaces adopt the same modifier (the themed bgBase floor shows
+// behind the cards), applied after .listStyle(.insetGrouped).
+for (const view of ["TasksView.swift", "GitHubView.swift", "CodeBrowserView.swift"]) {
+  const src = await read(`Views/${view}`);
+  assert.match(
+    src,
+    /\.listStyle\(\.insetGrouped\)\s*\n\s*\.themedListBackground\(\)/,
+    `${view} should apply .themedListBackground() right after .listStyle(.insetGrouped)`,
   );
 }
 


### PR DESCRIPTION
Follow-up to #1746 (which themed the plain browse lists). This completes the set by theming the **inset-grouped** surfaces — **Tasks**, **GitHub**, and the **Code** browser's tree + search lists — so the desktop theme's `bgBase` shows behind them too.

## Approach
Reuses the existing `themedListBackground()` (`scrollContentBackground(.hidden)` + `bgBase` fill). I'd planned a separate grouped modifier with `listRowBackground(bgRaised)`, but discovered a **List-level `.listRowBackground` doesn't propagate to inset-grouped rows** — so the cards keep their adaptive system surface. That's actually the better outcome: the cards read as themed cards floating on the `bgBase` floor and keep strong row contrast (mid-`bgRaised` cards would lower text legibility). One modifier now covers both `.plain` and `.insetGrouped`.

## Verified live (simulator)
Published a distinctive theme (`--bg-base #3a1d8a` indigo, `--text-primary #f9f900`) and screenshotted the **Tasks** tab: the list now renders the themed indigo floor with cards floating on it (previously the whole surface was system-dark). Drove the tab via a temporary default-tab change for the screenshot, reverted before commit.

## Tests
- `scripts/ios-theme-list-background.test.mjs` extended to assert Tasks/GitHub/CodeBrowser apply `.themedListBackground()` after `.listStyle(.insetGrouped)`.
- `xcodebuild` (iPhone 16 Pro sim): **BUILD SUCCEEDED**. `check:tests-wired` green (514 files).

Modal sheets (CommandsSheet, LinkedTasksSheet) are intentionally left system-styled — they're transient and not part of the main themed chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)