### PR TITLE
feat(ios): add a System option to AppearanceMode

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Theme/AppearanceMode.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/AppearanceMode.swift
@@ -1,11 +1,12 @@
 import SwiftUI
 
 /// How the iOS app picks its light/dark appearance. By default it mirrors the
-/// Cave desktop's published mode; the user can override it to a fixed Light or
-/// Dark so the phone stands alone (e.g. light outdoors while the desktop is
-/// dark). Persisted in UserDefaults via `@AppStorage(AppearanceMode.storageKey)`.
+/// Cave desktop's published mode; the user can override it to follow this
+/// iPhone's own setting (System) or a fixed Light/Dark so the phone stands
+/// alone (e.g. light outdoors while the desktop is dark). Persisted in
+/// UserDefaults via `@AppStorage(AppearanceMode.storageKey)`.
 enum AppearanceMode: String, CaseIterable, Identifiable {
-    case desktop, light, dark
+    case desktop, system, light, dark
 
     static let storageKey = "cave.appearance"
     var id: String { rawValue }
@@ -13,6 +14,7 @@ enum AppearanceMode: String, CaseIterable, Identifiable {
     var label: String {
         switch self {
         case .desktop: return "Match desktop"
+        case .system: return "System"
         case .light: return "Light"
         case .dark: return "Dark"
         }
@@ -21,19 +23,23 @@ enum AppearanceMode: String, CaseIterable, Identifiable {
     var icon: String {
         switch self {
         case .desktop: return "desktopcomputer"
+        case .system: return "circle.lefthalf.filled"
         case .light: return "sun.max"
         case .dark: return "moon"
         }
     }
 
     /// The effective chrome + color scheme for this mode. `.desktop` passes the
-    /// published palette through untouched; a fixed mode swaps to the built-in
-    /// (system-semantic) palette so every adaptive colour follows the forced
-    /// scheme with no desktop-palette mismatch.
-    func resolve(desktop: ChromePalette) -> (chrome: ChromePalette, scheme: ColorScheme) {
+    /// published palette through untouched; the overrides swap to the built-in
+    /// (system-semantic) palette so every adaptive colour follows the chosen
+    /// scheme with no desktop-palette mismatch. A `nil` scheme means follow the
+    /// device's own light/dark setting (System).
+    func resolve(desktop: ChromePalette) -> (chrome: ChromePalette, scheme: ColorScheme?) {
         switch self {
         case .desktop:
             return (desktop, desktop.colorScheme)
+        case .system:
+            return (.fallback, nil)
         case .light:
             var c = ChromePalette.fallback; c.colorScheme = .light
             return (c, .light)

--- a/scripts/ios-theme.test.mjs
+++ b/scripts/ios-theme.test.mjs
@@ -10,6 +10,7 @@ const client = await read(`${base}/Networking/CaveClient.swift`);
 const model = await read(`${base}/State/AppModel.swift`);
 const app = await read(`${base}/CovenCaveApp.swift`);
 const root = await read(`${base}/Views/RootView.swift`);
+const appearance = await read(`${base}/Theme/AppearanceMode.swift`);
 
 // --- Contract types decode GET /api/theme -----------------------------------
 
@@ -112,5 +113,16 @@ assert.match(
   /connectionState == \.connected \{ await app\.loadTheme\(\) \}/,
   "MainTabView should poll the theme while connected",
 );
+
+// Appearance override offers a System option that follows the device's own
+// light/dark setting (resolve returns a nil scheme so SwiftUI follows the OS).
+assert.match(appearance, /case desktop, system, light, dark/, "AppearanceMode includes a System option");
+assert.match(appearance, /case \.system: return "System"/, "System has a label");
+assert.match(
+  appearance,
+  /func resolve\(desktop: ChromePalette\) -> \(chrome: ChromePalette, scheme: ColorScheme\?\)/,
+  "resolve returns an optional scheme so System can mean follow-the-OS",
+);
+assert.match(appearance, /case \.system:\s*return \(\.fallback, nil\)/, "System resolves to the adaptive palette + nil scheme (follow OS)");
 
 console.log("ios-theme: ok");


### PR DESCRIPTION
Builds on the just-shipped iOS appearance override (`AppearanceMode`: Match desktop / Light / Dark) by adding the missing **System** option.

## What
- **System** follows the iPhone's own light/dark setting. `resolve()` returns the built-in adaptive palette with a **nil** colour scheme, so `.preferredColorScheme(nil)` defers to the OS.
- `resolve()`'s return scheme is now `ColorScheme?`; the app scene already feeds it to `.preferredColorScheme` (which accepts nil) — no call-site change.
- Picker order: Match desktop · System · Light · Dark.

## Verification
- `xcodebuild` (iOS Simulator) → **BUILD SUCCEEDED**.
- `node scripts/run-tests.mjs mobile` → 45 files; `app` → 387 — both pass (assertions added to `ios-theme.test.mjs`).
- **Runtime**: with the mode = System, toggling the simulator's OS appearance flips the app — **light** when the OS is light, **dark** when the OS is dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)