### PR TITLE
feat(ios): theme the modal sheets

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Theme/Theme.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/Theme.swift
@@ -70,6 +70,16 @@ private struct ThemedListBackground: ViewModifier {
     }
 }
 
+private struct ThemedSheetBackground: ViewModifier {
+    @Environment(\.chrome) private var chrome
+    func body(content: Content) -> some View {
+        // Theme the sheet's own presentation surface so the area around the
+        // List (nav bar, search field, insets) matches the desktop background
+        // rather than the system sheet material.
+        content.presentationBackground(chrome.bgBase)
+    }
+}
+
 extension View {
     /// Reveal the desktop theme's `bgBase` behind a `List` instead of the opaque
     /// system background. Apply after `.listStyle(…)`. Works for both `.plain`
@@ -77,6 +87,11 @@ extension View {
     /// (which reads as themed cards floating on the `bgBase` floor and preserves
     /// row contrast), only the floor behind/around them becomes `bgBase`.
     func themedListBackground() -> some View { modifier(ThemedListBackground()) }
+
+    /// Theme a modal sheet's presentation background to the desktop `bgBase`.
+    /// Apply to the sheet's root (e.g. its `NavigationStack`); pair with
+    /// `.themedListBackground()` on the list inside.
+    func themedSheetBackground() -> some View { modifier(ThemedSheetBackground()) }
 }
 
 extension Color {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatModelControl.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatModelControl.swift
@@ -153,6 +153,7 @@ struct ModelPickerSheet: View {
                     Text("Applies to this chat. The familiar uses the chosen model for its next replies.")
                 }
             }
+            .themedListBackground()
             .navigationTitle("Model")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -162,5 +163,6 @@ struct ModelPickerSheet: View {
             }
         }
         .presentationDetents([.medium, .large])
+        .themedSheetBackground()
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Views/CommandsSheet.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/CommandsSheet.swift
@@ -41,6 +41,7 @@ struct CommandsSheet: View {
                 }
             }
             .listStyle(.insetGrouped)
+            .themedListBackground()
             .navigationTitle("Commands")
             .navigationBarTitleDisplayMode(.inline)
             .searchable(text: $query, placement: .navigationBarDrawer(displayMode: .always),
@@ -51,6 +52,7 @@ struct CommandsSheet: View {
                 }
             }
         }
+        .themedSheetBackground()
     }
 
     private func row(_ command: SlashCommand) -> some View {

--- a/apps/ios/CovenCave/CovenCave/Views/LinkedTasksSheet.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/LinkedTasksSheet.swift
@@ -67,6 +67,7 @@ struct LinkedTasksSheet: View {
                 }
             }
             .listStyle(.insetGrouped)
+            .themedListBackground()
             .searchable(text: $query, prompt: "Search tasks to assign")
             .navigationTitle("Tasks")
             .navigationBarTitleDisplayMode(.inline)
@@ -75,6 +76,7 @@ struct LinkedTasksSheet: View {
             }
             .task { if !app.tasksLoaded { await app.loadTasks() } }
         }
+        .themedSheetBackground()
     }
 
     private func open(_ card: BoardCard) {

--- a/apps/ios/CovenCave/CovenCave/Views/NewChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/NewChatView.swift
@@ -54,6 +54,7 @@ struct NewChatView: View {
                     }
                 }
             }
+            .themedListBackground()
             .navigationTitle("New chat")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -71,6 +72,7 @@ struct NewChatView: View {
                 importFromFile(result)
             }
         }
+        .themedSheetBackground()
     }
 
     /// Read the picked Markdown file into a new thread and open it.

--- a/scripts/ios-theme-list-background.test.mjs
+++ b/scripts/ios-theme-list-background.test.mjs
@@ -46,4 +46,28 @@ for (const view of ["TasksView.swift", "GitHubView.swift", "CodeBrowserView.swif
   );
 }
 
+// Theme.swift exposes the sheet-background modifier (presentationBackground).
+assert.match(
+  theme,
+  /struct ThemedSheetBackground: ViewModifier \{[\s\S]*@Environment\(\\\.chrome\)[\s\S]*\.presentationBackground\(chrome\.bgBase\)/,
+  "Theme should define a ThemedSheetBackground modifier that themes the sheet's presentation surface",
+);
+assert.match(
+  theme,
+  /func themedSheetBackground\(\) -> some View \{ modifier\(ThemedSheetBackground\(\)\) \}/,
+  "Theme should expose the themedSheetBackground() View extension",
+);
+
+// Modal sheets theme both their list and their presentation background.
+for (const view of [
+  "CommandsSheet.swift",
+  "LinkedTasksSheet.swift",
+  "NewChatView.swift",
+  "ChatModelControl.swift",
+]) {
+  const src = await read(`Views/${view}`);
+  assert.match(src, /\.themedListBackground\(\)/, `${view} should theme its list`);
+  assert.match(src, /\.themedSheetBackground\(\)/, `${view} should theme its sheet presentation background`);
+}
+
 console.log("ios-theme-list-background: ok");


### PR DESCRIPTION
Final piece of the iOS theme work (#1413 → #1720/#1725/#1733/#1738/#1746/#1752). The list-bearing **modal sheets** kept the system sheet material while the rest of the app matched the desktop theme. Now they're themed too.

## Change
- New `themedSheetBackground()` modifier — `presentationBackground(chrome.bgBase)` — themes the sheet's own presentation surface (nav bar, search field, insets).
- Applied alongside `themedListBackground()` to the four list sheets: **Commands**, **Linked tasks**, **New chat**, **Model picker**.

## Verified live (simulator)
Published a distinctive theme (`--bg-base #3a1d8a` indigo, `--text-primary #f9f900`) and auto-presented the **New chat** sheet: the entire sheet — nav bar (Cancel/Start), the floor around the list, and the cards — renders the themed indigo with yellow text and red accent buttons, instead of the system sheet material. (Drove it via a temporary auto-present, reverted before commit.)

## Tests
- `scripts/ios-theme-list-background.test.mjs` extended: asserts `ThemedSheetBackground`/`themedSheetBackground()` exist and that each of the four sheets applies both `.themedListBackground()` and `.themedSheetBackground()`.
- `xcodebuild` (iPhone 16 Pro sim): **BUILD SUCCEEDED**. `check:tests-wired` green (520 files).

With this, every primary list surface and modal sheet in the iOS app matches the desktop theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)