### PR TITLE
fix(theme): make the theme-store path env-overridable (COVEN_THEME_PATH)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 // Playwright config — three viewport projects so the same specs in
 // tests/mobile/ run against desktop AND two real mobile presets.
@@ -60,6 +62,9 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     env: {
       COVEN_CAVE_E2E: "1",
+      // Redirect theme writes to a throwaway file so an E2E run never clobbers
+      // a real user's ~/.coven/cave-theme.json (which the iOS app polls).
+      COVEN_THEME_PATH: join(tmpdir(), "cave-e2e-theme.json"),
     },
   },
 });

--- a/src/lib/server/theme-store.test.ts
+++ b/src/lib/server/theme-store.test.ts
@@ -33,4 +33,25 @@ assert.match(
   "PUT /api/theme must wrap saveTheme so a write failure returns 500 instead of crashing the server",
 );
 
+// The path is env-overridable so tests / E2E / throwaway servers never write a
+// real user's ~/.coven/cave-theme.json (which the iOS app polls).
+assert.match(
+  store,
+  /function themePath\(\): string/,
+  "the snapshot path is resolved through a themePath() function (call-time, not a module const)",
+);
+assert.match(
+  store,
+  /process\.env\.COVEN_THEME_PATH \?\? path\.join\(homedir\(\), "\.coven", "cave-theme\.json"\)/,
+  "themePath honours COVEN_THEME_PATH, falling back to ~/.coven/cave-theme.json",
+);
+
+// The E2E web server points the theme store at a throwaway file.
+const e2e = await readFile(new URL("../../../playwright.config.ts", import.meta.url), "utf8");
+assert.match(
+  e2e,
+  /COVEN_THEME_PATH: join\(tmpdir\(\)/,
+  "the Playwright web server redirects theme writes to a temp file",
+);
+
 console.log("theme-store.test.ts: ok");

--- a/src/lib/server/theme-store.ts
+++ b/src/lib/server/theme-store.ts
@@ -1,12 +1,18 @@
 // Persists the desktop's active theme + resolved color tokens to
-// ~/.coven/cave-theme.json so other clients (the iOS app over Tailscale)
-// can read it from GET /api/theme. Fixed filename — no user-controlled path.
+// ~/.coven/cave-theme.json so other clients (the iOS app over Tailscale) can
+// read it from GET /api/theme. The location is fixed in normal use, but
+// COVEN_THEME_PATH overrides it so tests / E2E runs / any throwaway server never
+// clobber a real user's theme (mirrors COVEN_AUTOMATION_RUNS_PATH). Not
+// user-request-controlled — only the process environment can set it.
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 import path from "node:path";
 import { homedir } from "node:os";
 
-const THEME_PATH = path.join(homedir(), ".coven", "cave-theme.json");
+// Resolved at call-time so the env can be set before the first read/write.
+function themePath(): string {
+  return process.env.COVEN_THEME_PATH ?? path.join(homedir(), ".coven", "cave-theme.json");
+}
 
 export type ThemeSnapshot = {
   themeId: string;
@@ -29,6 +35,7 @@ function sanitizeTokens(input: unknown): Record<string, string> {
 }
 
 export async function loadTheme(): Promise<ThemeSnapshot> {
+  const THEME_PATH = themePath();
   try {
     const parsed = JSON.parse(await readFile(THEME_PATH, "utf8")) as Partial<ThemeSnapshot>;
     return {
@@ -49,6 +56,7 @@ export async function saveTheme(input: { themeId?: unknown; mode?: unknown; toke
     tokens: sanitizeTokens(input.tokens),
     updatedAt: new Date().toISOString(),
   };
+  const THEME_PATH = themePath();
   await mkdir(path.dirname(THEME_PATH), { recursive: true });
   // Unique temp name per write: a fixed `.tmp` made concurrent PUTs race —
   // both wrote the same file, the first rename consumed it, and the second


### PR DESCRIPTION
The theme snapshot path was hardcoded to `~/.coven/cave-theme.json` with no override, so **any throwaway server or test run that wrote a theme clobbered a real user's file** — which the iOS app polls. Observed live this session: an ad-hoc run overwrote a pinned phone theme.

## Change
- `theme-store.ts`: a `themePath()` function honours **`COVEN_THEME_PATH`** (resolved at call-time; falls back to `~/.coven/cave-theme.json`). Mirrors the existing `COVEN_AUTOMATION_RUNS_PATH` convention. The local `THEME_PATH` name is kept inside the functions so the existing temp-file/race assertions still hold.
- `playwright.config.ts`: the E2E web server sets `COVEN_THEME_PATH` to a temp file, so E2E runs never touch a real theme.

## Verification
- `tsc` clean; `check:tests-wired` ✓; source-text test updated (override + E2E wiring assertions).
- **Functional**: with `COVEN_THEME_PATH` set, `saveTheme` wrote to the temp file and the real `/api/theme` snapshot was unchanged (identical timestamp before/after) — isolation proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)