### PR TITLE
feat(chats,projects): make bulk delete undoable

### DIFF
--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -330,9 +330,14 @@ assert.match(source, /setSelectMode\(\(v\) => !v\); setSelectedIds\(new Set\(\)\
 assert.match(source, /useEffect\(\(\) => \{ setSelectMode\(false\); setSelectedIds\(new Set\(\)\); \}, \[familiar\?\.id\]\)/, "selection resets when the active familiar changes");
 assert.match(source, /role=\{selectMode \? "checkbox" : "button"\}/, "rows are checkboxes in select mode");
 assert.match(source, /if \(selectMode\) \{ toggleSelect\(s\.id\); return; \} setActiveId\(s\.id\); onOpen/, "a row click selects in select mode, otherwise opens");
-assert.match(source, /const bulkDelete = async \(\)/, "bulk delete handler exists");
+assert.match(source, /const bulkDelete = \(\) =>/, "bulk delete handler exists (deferred/undoable)");
 assert.match(source, /const bulkArchive = async \(archived: boolean\)/, "bulk archive/unarchive handler exists");
-assert.match(source, /Promise\.all\([\s\S]{0,60}fetch\(`\/api\/chat\/conversation\//, "bulk delete runs the per-chat deletes in parallel");
+assert.match(source, /Promise\.all\([\s\S]{0,80}fetch\(`\/api\/chat\/conversation\//, "bulk delete runs the per-chat deletes in parallel");
+// Bulk delete is deferred + undoable via the shared undo toast.
+assert.match(source, /useUndoDelete<SessionRow\[\]>\(\)/, "bulk delete routes through useUndoDelete");
+assert.match(source, /scheduleBulkDelete\(\s*removed,/, "bulk delete schedules the batch through the undo window");
+assert.match(source, /const hidden = new Set\(\(deletePending\?\.item \?\? \[\]\)\.map\(\(s\) => s\.id\)\)/, "pending-deleted rows are hidden from the list until commit");
+assert.match(source, /<UndoToast[\s\S]{0,160}onUndo=\{undoBulkDelete\}[\s\S]{0,40}onDismiss=\{commitBulkDelete\}/, "an undo toast offers to restore the batch");
 assert.match(source, /const allVisibleSelected = displayIds\.length > 0 && displayIds\.every\(\(id\) => selectedIds\.has\(id\)\)/, "select-all is visible-aware");
 assert.match(source, /\{allVisibleSelected \? "Clear" : "Select all"\}/, "toolbar offers select-all / clear");
 

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -9,6 +9,8 @@ import { useKeySymbols } from "@/lib/platform-keys";
 import { useIsMobile } from "@/lib/use-viewport";
 import { OriginChip } from "@/components/ui/origin-chip";
 import { SessionInitiatorChip } from "@/components/ui/session-initiator-chip";
+import { UndoToast } from "@/components/ui/undo-toast";
+import { useUndoDelete } from "@/lib/use-undo-delete";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { relativeTime, isRelativePhrase } from "@/lib/relative-time";
@@ -268,6 +270,9 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   const [selectMode, setSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
   const [bulkBusy, setBulkBusy] = useState(false);
+  // Bulk delete is deferred + undoable: rows hide immediately, the DELETEs fire
+  // only after the undo window, and Undo restores the batch.
+  const { pending: deletePending, scheduleDelete: scheduleBulkDelete, undo: undoBulkDelete, commit: commitBulkDelete } = useUndoDelete<SessionRow[]>();
   useEffect(() => { setSelectMode(false); setSelectedIds(new Set()); }, [familiar?.id]);
   // Content search (CHAT-D9-02) — hits from /api/chat/search for the current
   // query; cleared the moment the query drops below the 2-char threshold.
@@ -307,8 +312,12 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
       const seen = new Set(sessions.map((s) => s.id));
       rows = [...sessions, ...archivedRows.filter((s) => !seen.has(s.id))];
     }
+    // Hide chats whose bulk delete is pending in the undo window (still on the
+    // server; restored if the user hits Undo).
+    const hidden = new Set((deletePending?.item ?? []).map((s) => s.id));
+    if (hidden.size) rows = rows.filter((s) => !hidden.has(s.id));
     return filterVisibleChatSessions(rows, familiar?.id ?? null);
-  }, [sessions, showArchived, archivedRows, familiar?.id]);
+  }, [sessions, showArchived, archivedRows, familiar?.id, deletePending]);
 
   const filtered = useMemo(() => {
     let rows = mine;
@@ -621,26 +630,31 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     });
   const selectedVisibleCount = displayIds.filter((id) => selectedIds.has(id)).length;
 
-  const bulkDelete = async () => {
-    const ids = displayIds.filter((id) => selectedIds.has(id));
-    if (ids.length === 0) return;
-    setBulkBusy(true);
+  // Deferred + undoable: hide the selected chats now, fire the DELETEs only
+  // after the undo window, refetch once. Undo restores the whole batch.
+  const bulkDelete = () => {
+    const idSet = new Set(displayIds.filter((id) => selectedIds.has(id)));
+    const removed = mine.filter((s) => idSet.has(s.id));
+    if (removed.length === 0) return;
     setError(null);
-    const results = await Promise.all(
-      ids.map((id) =>
-        fetch(`/api/chat/conversation/${encodeURIComponent(id)}`, { method: "DELETE" })
-          .then((r) => r.json().catch(() => ({ ok: false })))
-          .then((j) => !!j.ok)
-          .catch(() => false),
-      ),
-    );
-    setBulkBusy(false);
-    if (results.some(Boolean)) {
-      setActiveId((cur) => (cur && ids.includes(cur) ? null : cur));
-      onSessionsChanged?.();
-    }
-    if (results.some((ok) => !ok)) setError("Some chats couldn't be deleted.");
+    setActiveId((cur) => (cur && idSet.has(cur) ? null : cur));
     exitSelect();
+    scheduleBulkDelete(
+      removed,
+      `${removed.length} chat${removed.length === 1 ? "" : "s"}`,
+      async () => {
+        const results = await Promise.all(
+          removed.map((s) =>
+            fetch(`/api/chat/conversation/${encodeURIComponent(s.id)}`, { method: "DELETE" })
+              .then((r) => r.json().catch(() => ({ ok: false })))
+              .then((j) => !!j.ok)
+              .catch(() => false),
+          ),
+        );
+        if (results.some(Boolean)) onSessionsChanged?.();
+        if (results.some((ok) => !ok)) setError("Some chats couldn't be deleted.");
+      },
+    );
   };
 
   const bulkArchive = async (archived: boolean) => {
@@ -1372,6 +1386,15 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
         {keys.enter} open · {keys.mod}K palette · / commands in chat
       </footer>
       </section>
+      {deletePending ? (
+        <UndoToast
+          key={deletePending.id}
+          message={`Deleted ${deletePending.label}`}
+          undoAriaLabel="Undo delete"
+          onUndo={undoBulkDelete}
+          onDismiss={commitBulkDelete}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -77,7 +77,7 @@ assert.match(
 );
 assert.match(
   projectsView,
-  /Promise\.all\(sessionIds\.map\(\(id\) => deleteOneSession\(id\)\)\)/,
+  /Promise\.all\(removed\.map\(\(s\) => deleteOneSession\(s\.id\)\)\)/,
   "bulk delete runs the per-chat deletes in parallel",
 );
 assert.match(
@@ -85,6 +85,11 @@ assert.match(
   /results\.some\(Boolean\)\) onSessionsChanged/,
   "bulk delete refetches once if any chat was deleted",
 );
+// Bulk delete is deferred + undoable (shared useUndoDelete + UndoToast).
+assert.match(projectsView, /useUndoDelete<SessionRow\[\]>\(\)/, "bulk delete routes through useUndoDelete");
+assert.match(projectsView, /scheduleSessionDelete\(\s*removed,/, "the batch is scheduled through the undo window");
+assert.match(projectsView, /const hidden = new Set\(\(deletePending\?\.item \?\? \[\]\)\.map\(\(s\) => s\.id\)\)/, "pending-deleted chats are hidden until commit");
+assert.match(projectsView, /onUndo=\{undoSessionDelete\}[\s\S]{0,40}onDismiss=\{commitSessionDelete\}/, "an undo toast restores the batch");
 assert.match(
   projectsView,
   /\{allVisibleSelected \? "Clear" : "Select all"\}/,
@@ -107,7 +112,7 @@ assert.match(
   "selection is keyed to the current chat ids",
 );
 assert.match(projectsView, /useDroppable\(\{\s*id: `pcard:/, "project cards are drop targets");
-assert.match(projectsView, /applyProjectOverrides\(sessions, projectOverrides\)/, "chats are grouped with Cave-local project overrides applied");
+assert.match(projectsView, /applyProjectOverrides\(visible, projectOverrides\)/, "chats are grouped with Cave-local project overrides applied (after hiding pending-deleted)");
 assert.match(projectsView, /setProjectOverride\(sessionId, targetRoot\)/, "cross-project move applies a Cave-local project override");
 assert.match(projectsView, /mergeVisibleOrder[\s\S]{0,120}writeSessionOrder/, "same-project drop reorders via the shared manual order");
 assert.match(projectsView, /cave:agents-open-session/, "clicking a chat opens it via the agents-open-session event");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -22,6 +22,7 @@ import { useProjectsUiState } from "@/lib/projects/use-projects-ui-state";
 import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 import { nextTypeAheadIndex } from "@/lib/projects/type-ahead";
 import { UndoToast } from "@/components/ui/undo-toast";
+import { useUndoDelete } from "@/lib/use-undo-delete";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
@@ -68,6 +69,9 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
   const [creating, setCreating] = useState(false);
   const [sessionError, setSessionError] = useState<string | null>(null);
   const [moveToast, setMoveToast] = useState<{ sessionId: string; prevRoot: string | null; label: string } | null>(null);
+  // Bulk delete is deferred + undoable: the rows hide immediately, the actual
+  // DELETEs fire only after the undo window, and Undo restores the batch.
+  const { pending: deletePending, scheduleDelete: scheduleSessionDelete, undo: undoSessionDelete, commit: commitSessionDelete } = useUndoDelete<SessionRow[]>();
   const projectOverrides = useProjectOverrides();
   const { density, setDensity, isExpanded, setExpanded } = useProjectsUiState();
   // Roving keyboard navigation (WAI-ARIA) over the flattened list of project
@@ -140,7 +144,11 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
   // Group sessions under their (override-aware) project root, applying the
   // shared manual order, so each project card lists its chats in drag order.
   const chatsByRoot = useMemo(() => {
-    const overridden = applyProjectOverrides(sessions, projectOverrides);
+    // Hide chats whose delete is pending in the undo window (still on the
+    // server; restored if the user hits Undo).
+    const hidden = new Set((deletePending?.item ?? []).map((s) => s.id));
+    const visible = hidden.size ? sessions.filter((s) => !hidden.has(s.id)) : sessions;
+    const overridden = applyProjectOverrides(visible, projectOverrides);
     const byRoot = new Map<string, SessionRow[]>();
     for (const session of overridden) {
       const root = normalizeProjectRoot(session.project_root);
@@ -150,7 +158,7 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
     }
     for (const [root, list] of byRoot) byRoot.set(root, applyManualOrder(list, order));
     return byRoot;
-  }, [sessions, projectOverrides, order]);
+  }, [sessions, projectOverrides, order, deletePending]);
 
   const rootBySession = useMemo(() => {
     const map = new Map<string, string>();
@@ -276,14 +284,23 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
     if (await deleteOneSession(sessionId)) onSessionsChanged?.();
   };
 
-  // Bulk-delete the chats selected in a project card. Runs the deletes in
-  // parallel, then refetches once if anything succeeded so the surviving rows
-  // (if a delete failed) stay accurate.
+  // Bulk-delete the chats selected in a project card — deferred + undoable:
+  // hide them now, fire the DELETEs only after the undo window, refetch once.
   const handleDeleteSessions = async (sessionIds: string[]) => {
     setSessionError(null);
     if (sessionIds.length === 0) return;
-    const results = await Promise.all(sessionIds.map((id) => deleteOneSession(id)));
-    if (results.some(Boolean)) onSessionsChanged?.();
+    const ids = new Set(sessionIds);
+    const removed = sessions.filter((s) => ids.has(s.id));
+    if (removed.length === 0) return;
+    setMoveToast(null); // one bottom toast at a time
+    scheduleSessionDelete(
+      removed,
+      `${removed.length} chat${removed.length === 1 ? "" : "s"}`,
+      async () => {
+        const results = await Promise.all(removed.map((s) => deleteOneSession(s.id)));
+        if (results.some(Boolean)) onSessionsChanged?.();
+      },
+    );
   };
 
   return (
@@ -540,6 +557,15 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
           onDismiss={() => setMoveToast(null)}
           durationMs={5000}
           autoDismiss
+        />
+      ) : null}
+      {deletePending ? (
+        <UndoToast
+          key={deletePending.id}
+          message={`Deleted ${deletePending.label}`}
+          undoAriaLabel="Undo delete"
+          onUndo={undoSessionDelete}
+          onDismiss={commitSessionDelete}
         />
       ) : null}
     </div>


### PR DESCRIPTION
Finishes the undo-everywhere story. Library bulk delete became undoable in #1735; this brings the same safety to the two most-used surfaces.

## What
Bulk Remove on the **Chats list** and the **Projects tab** previously fired the DELETEs immediately (irreversible). Both now route through the shared **`useUndoDelete` + `ui/undo-toast`**:
- the selected chats **hide at once** (filtered from the list while pending),
- the per-chat `DELETE`s fire **only after the undo window**,
- **Undo** restores the whole batch.

The hook commits on window-elapse or unmount (matching the Library surfaces). On Projects, starting a delete clears any in-flight move toast so only one bottom toast shows.

## Verification
- `pnpm typecheck` clean; `app` → **387 files**, `mobile` → **50 files** — both pass (updated the assertions that pinned the old immediate-delete shape; added undo coverage).
- Browser-driven (Chats): select 2 → Delete → 4→2 rows + undo toast, **no** DELETE yet → **Undo** → back to 4 with **zero** DELETEs, even after the window. Projects uses the identical mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)