### PR TITLE
feat(ios): show the desktop theme background behind the chat transcript

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -20,6 +20,7 @@ struct ResponseReaderItem: Identifiable {
 struct ChatView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.chrome) private var chrome
     @Bindable var thread: ChatThread
     @AppStorage("cave.dev.section") private var devSectionRaw = DevSection.code.rawValue
     @State private var draft: String = ""
@@ -71,6 +72,10 @@ struct ChatView: View {
             }
             composer
         }
+        // Let the desktop theme's base colour show behind the transcript instead
+        // of the opaque system background the navigation stack paints; the
+        // bubbles and composer float on the themed floor.
+        .background(chrome.bgBase.ignoresSafeArea())
         .navigationTitle(thread.title)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {

--- a/scripts/ios-theme-list-background.test.mjs
+++ b/scripts/ios-theme-list-background.test.mjs
@@ -70,4 +70,16 @@ for (const view of [
   assert.match(src, /\.themedSheetBackground\(\)/, `${view} should theme its sheet presentation background`);
 }
 
+// The chat transcript (a ScrollView, not a List) paints bgBase directly so the
+// bubbles float on the themed floor instead of the system navigation background.
+{
+  const chat = await read("Views/ChatView.swift");
+  assert.match(chat, /@Environment\(\\\.chrome\) private var chrome/, "ChatView should read the chrome palette");
+  assert.match(
+    chat,
+    /\.background\(chrome\.bgBase\.ignoresSafeArea\(\)\)/,
+    "ChatView should paint chrome.bgBase behind the transcript",
+  );
+}
+
 console.log("ios-theme-list-background: ok");


### PR DESCRIPTION
While verifying, the **chat transcript** turned out to be the one main surface still showing the system background instead of the desktop theme. It's a `ScrollView` inside the chat's navigation stack, which paints an opaque system background over `RootView`'s `bgBase` — so the message area stayed system-dark while everything else (lists #1746/#1752, sheets #1757) matched the desktop.

## Fix
Paint `chrome.bgBase` behind `ChatView`'s body so the bubbles and composer float on the themed floor.

## Verified live (simulator)
Drove into a chat with a distinctive published theme (`--bg-base #0d4d3a` green):

| before | after |
|---|---|
| transcript system-black behind the bubbles | transcript shows the themed green `bgBase` |

(Drove it via a temporary auto-open-into-chat hook, reverted before commit.)

## Tests
- `scripts/ios-theme-list-background.test.mjs` extended: asserts `ChatView` reads `@Environment(\.chrome)` and paints `chrome.bgBase` behind the transcript.
- `xcodebuild` (iPhone 16 Pro sim): **BUILD SUCCEEDED**. `check:tests-wired` green.

With this, every main surface, modal sheet, and the chat transcript match the desktop theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)