### PR TITLE
fix(ios): keep iPad content in a centred column (don't stretch edge-to-edge)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -72,9 +72,12 @@ struct ChatView: View {
             }
             composer
         }
+        // Keep the conversation in a centred reading column on iPad.
+        .readableWidth(740)
         // Let the desktop theme's base colour show behind the transcript instead
         // of the opaque system background the navigation stack paints; the
-        // bubbles and composer float on the themed floor.
+        // bubbles and composer float on the themed floor (full-width, so the
+        // themed floor fills the iPad side margins too).
         .background(chrome.bgBase.ignoresSafeArea())
         .navigationTitle(thread.title)
         .navigationBarTitleDisplayMode(.inline)

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -238,6 +238,7 @@ struct ChatsHomeView: View {
         }
         .listStyle(.plain)
         .themedListBackground()
+        .readableListWidth()
         .environment(\.editMode, $editMode)
         .threadRenameAlert($renamingThread) { thread, name in app.renameThread(thread, to: name) }
         .confirmationDialog("Delete this chat?",

--- a/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
@@ -66,6 +66,7 @@ struct GitHubView: View {
             }
             .listStyle(.insetGrouped)
             .themedListBackground()
+            .readableListWidth()
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/ReadableWidth.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ReadableWidth.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+extension View {
+    /// Cap content to a centred column so a ScrollView/VStack doesn't stretch
+    /// edge-to-edge on a wide screen (iPad). A no-op on iPhone, where the
+    /// available width is already below `maxWidth`.
+    func readableWidth(_ maxWidth: CGFloat = 620) -> some View {
+        frame(maxWidth: maxWidth)
+            .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    /// Centre a `List`'s rows in a column of at most `maxWidth`. A plain
+    /// `.frame(maxWidth:)` doesn't work on List (it's a greedy container), so
+    /// this insets the scroll content by the leftover space on each side. No-op
+    /// on iPhone (available width ≤ maxWidth → zero inset).
+    func readableListWidth(_ maxWidth: CGFloat = 620) -> some View {
+        modifier(ReadableListWidth(maxWidth: maxWidth))
+    }
+}
+
+private struct ReadableListWidth: ViewModifier {
+    let maxWidth: CGFloat
+
+    func body(content: Content) -> some View {
+        GeometryReader { geo in
+            content.contentMargins(
+                .horizontal,
+                max(0, (geo.size.width - maxWidth) / 2),
+                for: .scrollContent
+            )
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/ReadingView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ReadingView.swift
@@ -101,6 +101,7 @@ struct ReadingView: View {
                 }
                 .listStyle(.plain)
                 .themedListBackground()
+                .readableListWidth()
             }
         }
         // Pin the filter chips above the list (and empty state) with their

--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -190,6 +190,7 @@ struct TasksView: View {
         }
         .listStyle(.insetGrouped)
         .themedListBackground()
+        .readableListWidth()
     }
 
     private var emptyState: some View {


### PR DESCRIPTION
## Problem

The iOS app targets iPad (`TARGETED_DEVICE_FAMILY "1,2"`) but the layout is the iPhone layout stretched to fill the screen. On iPad — especially landscape — list rows pin the title to the far-left edge and fling metadata to the far-right edge with a vast empty middle, and chats run the full width (a too-long line length for reading).

## Fix

New `ReadableWidth.swift` with two helpers that cap content to a centred column. **No-op on iPhone**, where the available width is already below the cap, so iPhone is unchanged.

- `readableWidth(_:)` — frame-based, for the chat (`ScrollView` + composer): 740pt.
- `readableListWidth(_:)` — `List` ignores `.frame(maxWidth:)` (greedy container), so this uses a `GeometryReader` + `.contentMargins(.horizontal, …, for: .scrollContent)` to inset the rows into a centred 620pt column. Applied to **Chats, Reading, Tasks, GitHub**.

The Code editor is intentionally left full-width — code benefits from the space.

## Verification

Built and run on an **iPad Pro 11" simulator**: Chats/Reading/etc. now render as a centred column with side margins (was edge-to-edge); the chat is a centred reading column. Additive-only change — the iOS source-text web tests that read these views (`ios-theme-list-background`, the ChatView readers, etc.) all still pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)