### PR TITLE
refactor(terminal): dedup xterm setup + touch Find + a11y label

### DIFF
--- a/src/components/bottom-terminal-sr-mirror.test.ts
+++ b/src/components/bottom-terminal-sr-mirror.test.ts
@@ -54,4 +54,13 @@ assert.match(
   "clears pending timer to avoid setState on unmounted component",
 );
 
+// The xterm + addon setup is shared by both transports via one helper (it used
+// to be duplicated verbatim across the Tauri-IPC and WebSocket effects).
+assert.match(source, /async function createXterm\(/, "shared xterm builder helper exists");
+assert.equal((source.match(/new Terminal\(\{/g) ?? []).length, 1, "Terminal is constructed in exactly one place");
+assert.equal((source.match(/attachCustomKeyEventHandler/g) ?? []).length, 1, "the ⌘F handler is wired once, in the helper");
+assert.match(source, /const \{ term, fit, search \} = await createXterm\(wrap, \{/, "both transports build the terminal via createXterm");
+// Search decoration colors are a module constant, not rebuilt each render.
+assert.match(source, /^const SEARCH_DECORATIONS = \{/m, "SEARCH_DECORATIONS is hoisted to module scope");
+
 console.log("bottom-terminal-sr-mirror.test.ts OK");

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -51,6 +51,82 @@ async function loadTauri(): Promise<TauriBridge | null> {
   return { invoke, listen };
 }
 
+// Search match colors (highlights + active match + overview ruler), echoing the
+// terminal theme. Module-level so it isn't rebuilt on every render.
+const SEARCH_DECORATIONS = {
+  matchBackground: "#5b4b8a",
+  activeMatchBackground: "#9a8ecd",
+  matchOverviewRuler: "#5b4b8a",
+  activeMatchColorOverviewRuler: "#cdbff5",
+} as const;
+
+type XtermBundle = {
+  term: import("@xterm/xterm").Terminal;
+  fit: import("@xterm/addon-fit").FitAddon;
+  search: import("@xterm/addon-search").SearchAddon;
+};
+
+// Build the xterm instance + addons shared by both transports (Tauri IPC and the
+// WebSocket bridge). The two effects differ only in how bytes flow to/from the
+// PTY; the terminal, fit/links/search addons, result reporting, and the ⌘F
+// find-bar key handler are identical, so they live here once. JSX-free.
+async function createXterm(
+  wrap: HTMLDivElement,
+  handlers: {
+    /** SearchAddon result count changed — drives the n/N counter. */
+    onResults: (index: number, count: number) => void;
+    /** ⌘F / Ctrl+F pressed inside the terminal — open the find bar. */
+    onRequestFind: () => void;
+  },
+): Promise<XtermBundle> {
+  const [{ Terminal }, { FitAddon }, { WebLinksAddon }, { SearchAddon }] = await Promise.all([
+    import("@xterm/xterm"),
+    import("@xterm/addon-fit"),
+    import("@xterm/addon-web-links"),
+    import("@xterm/addon-search"),
+  ]);
+
+  const term = new Terminal({
+    fontFamily:
+      'ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+    fontSize: 12,
+    lineHeight: 1.2,
+    cursorBlink: true,
+    // Required for the search addon's match decorations (highlights + count).
+    allowProposedApi: true,
+    theme: {
+      background: "oklch(0.11 0.022 293)",
+      foreground: "#e6e6f0",
+      cursor: "#9a8ecd",
+      selectionBackground: "rgba(154,142,205,0.35)",
+    },
+  });
+  const fit = new FitAddon();
+  term.loadAddon(fit);
+  term.loadAddon(new WebLinksAddon());
+  const search = new SearchAddon();
+  term.loadAddon(search);
+  search.onDidChangeResults((e) => {
+    handlers.onResults(e.resultIndex >= 0 ? e.resultIndex + 1 : 0, e.resultCount);
+  });
+  // ⌘F / Ctrl+F opens the in-buffer find bar instead of the browser's.
+  term.attachCustomKeyEventHandler((e) => {
+    if (e.type === "keydown" && (e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === "f") {
+      e.preventDefault();
+      handlers.onRequestFind();
+      return false;
+    }
+    return true;
+  });
+  term.open(wrap);
+  try {
+    fit.fit();
+  } catch {
+    /* DOM not ready yet — first resize event will recover */
+  }
+  return { term, fit, search };
+}
+
 export function BottomTerminal({
   threadId,
   active = true,
@@ -118,13 +194,6 @@ export function BottomTerminal({
     });
     termRef.current?.focus();
   }, []);
-  // Highlight every match plus the active one; colors echo the terminal theme.
-  const SEARCH_DECORATIONS = {
-    matchBackground: "#5b4b8a",
-    activeMatchBackground: "#9a8ecd",
-    matchOverviewRuler: "#5b4b8a",
-    activeMatchColorOverviewRuler: "#cdbff5",
-  } as const;
   const runFind = useCallback((direction: 1 | -1, term?: string) => {
     const q = term ?? findInputRef.current?.value ?? "";
     if (!q) {
@@ -135,6 +204,12 @@ export function BottomTerminal({
     const opts = { decorations: SEARCH_DECORATIONS };
     if (direction === 1) searchRef.current?.findNext(q, opts);
     else searchRef.current?.findPrevious(q, opts);
+  }, []);
+  // Open the find bar and select its input. Shared by the ⌘F key handler and
+  // the touch Find button (soft keyboards can't produce the ⌘F chord).
+  const openFind = useCallback(() => {
+    setFindOpen(true);
+    requestAnimationFrame(() => findInputRef.current?.select());
   }, []);
   const closeFind = useCallback(() => {
     setFindOpen(false);
@@ -248,56 +323,14 @@ export function BottomTerminal({
       }
       log("mount: tauri bridge ready");
 
-      // Lazy-load xterm only on the client + only inside Tauri so SSR and
-      // the in-browser dev path don't try to pull it in.
-      const [{ Terminal }, { FitAddon }, { WebLinksAddon }, { SearchAddon }] = await Promise.all([
-        import("@xterm/xterm"),
-        import("@xterm/addon-fit"),
-        import("@xterm/addon-web-links"),
-        import("@xterm/addon-search"),
-      ]);
-
-      const term = new Terminal({
-        fontFamily:
-          'ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
-        fontSize: 12,
-        lineHeight: 1.2,
-        cursorBlink: true,
-        // Required for the search addon's match decorations (highlights + count).
-        allowProposedApi: true,
-        theme: {
-          background: "oklch(0.11 0.022 293)",
-          foreground: "#e6e6f0",
-          cursor: "#9a8ecd",
-          selectionBackground: "rgba(154,142,205,0.35)",
-        },
+      // Lazy-load + build xterm (only on the client + inside Tauri so SSR and
+      // the in-browser dev path don't pull it in). Shared with the WS path.
+      const { term, fit, search } = await createXterm(wrap, {
+        onResults: (index, count) => setFindInfo({ index, count }),
+        onRequestFind: openFind,
       });
       termRef.current = term;
-      const fit = new FitAddon();
-      term.loadAddon(fit);
-      term.loadAddon(new WebLinksAddon());
-      const search = new SearchAddon();
-      term.loadAddon(search);
       searchRef.current = search;
-      search.onDidChangeResults((e) => {
-        setFindInfo({ index: e.resultIndex >= 0 ? e.resultIndex + 1 : 0, count: e.resultCount });
-      });
-      // ⌘F / Ctrl+F opens the in-buffer find bar instead of the browser's.
-      term.attachCustomKeyEventHandler((e) => {
-        if (e.type === "keydown" && (e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === "f") {
-          e.preventDefault();
-          setFindOpen(true);
-          requestAnimationFrame(() => findInputRef.current?.select());
-          return false;
-        }
-        return true;
-      });
-      term.open(wrap);
-      try {
-        fit.fit();
-      } catch {
-        /* DOM not ready yet — first resize event will recover */
-      }
       log("xterm opened", { cols: term.cols, rows: term.rows });
 
       let stopped = false;
@@ -449,7 +482,7 @@ export function BottomTerminal({
       disposed = true;
       cleanup?.();
     };
-  }, [threadId, platform]);
+  }, [threadId, platform, openFind]);
 
   useEffect(() => {
     const wrap = wrapRef.current;
@@ -463,54 +496,12 @@ export function BottomTerminal({
     let cleanup: (() => void) | null = null;
 
     void (async () => {
-      const [{ Terminal }, { FitAddon }, { WebLinksAddon }, { SearchAddon }] = await Promise.all([
-        import("@xterm/xterm"),
-        import("@xterm/addon-fit"),
-        import("@xterm/addon-web-links"),
-        import("@xterm/addon-search"),
-      ]);
-
-      const term = new Terminal({
-        fontFamily:
-          'ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
-        fontSize: 12,
-        lineHeight: 1.2,
-        cursorBlink: true,
-        // Required for the search addon's match decorations (highlights + count).
-        allowProposedApi: true,
-        theme: {
-          background: "oklch(0.11 0.022 293)",
-          foreground: "#e6e6f0",
-          cursor: "#9a8ecd",
-          selectionBackground: "rgba(154,142,205,0.35)",
-        },
+      const { term, fit, search } = await createXterm(wrap, {
+        onResults: (index, count) => setFindInfo({ index, count }),
+        onRequestFind: openFind,
       });
       termRef.current = term;
-      const fit = new FitAddon();
-      term.loadAddon(fit);
-      term.loadAddon(new WebLinksAddon());
-      const search = new SearchAddon();
-      term.loadAddon(search);
       searchRef.current = search;
-      search.onDidChangeResults((e) => {
-        setFindInfo({ index: e.resultIndex >= 0 ? e.resultIndex + 1 : 0, count: e.resultCount });
-      });
-      // ⌘F / Ctrl+F opens the in-buffer find bar instead of the browser's.
-      term.attachCustomKeyEventHandler((e) => {
-        if (e.type === "keydown" && (e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === "f") {
-          e.preventDefault();
-          setFindOpen(true);
-          requestAnimationFrame(() => findInputRef.current?.select());
-          return false;
-        }
-        return true;
-      });
-      term.open(wrap);
-      try {
-        fit.fit();
-      } catch {
-        /* DOM not ready yet — first resize event will recover */
-      }
 
       const bridge = new PtyWsBridge();
       wsBridgeRef.current = bridge;
@@ -681,7 +672,7 @@ export function BottomTerminal({
       disposed = true;
       cleanup?.();
     };
-  }, [threadId, platform, pushToMirror]);
+  }, [threadId, platform, pushToMirror, openFind]);
 
   if (unavailable) {
     return (
@@ -697,6 +688,10 @@ export function BottomTerminal({
         ref={wrapRef}
         className="min-h-0 w-full flex-1 overflow-hidden"
         style={{ background: "oklch(0.11 0.022 293)", padding: "6px 8px" }}
+        // xterm renders into an opaque <canvas>; label the region so AT can name
+        // it (live output is exposed via the screen-reader mirror below).
+        role="group"
+        aria-label="Terminal"
         // Clicking anywhere in the terminal area refocuses xterm so keyboard
         // input is routed correctly without the user having to click exactly
         // on the cursor.
@@ -760,7 +755,7 @@ export function BottomTerminal({
       {/* Touch accessory bar — only on coarse pointers (phones/tablets), where
           the soft keyboard can't produce Esc/Tab/Ctrl/arrows. */}
       {isCoarse ? (
-        <TerminalKeyBar onKey={sendKey} ctrlActive={ctrlActive} onToggleCtrl={toggleCtrl} />
+        <TerminalKeyBar onKey={sendKey} ctrlActive={ctrlActive} onToggleCtrl={toggleCtrl} onFind={openFind} />
       ) : null}
       {/* Offscreen text mirror of PTY output for screen readers. */}
       <div

--- a/src/components/terminal-key-bar.test.ts
+++ b/src/components/terminal-key-bar.test.ts
@@ -27,4 +27,10 @@ assert.match(
   "sticky Ctrl folds the next character into its C0 control code",
 );
 
+// Touch Find: ⌘F can't be produced by a soft keyboard, so the bar exposes a
+// Find button that opens the in-buffer search.
+assert.match(bar, /onFind\?: \(\) => void/, "the key bar accepts an onFind handler");
+assert.match(bar, /aria-label="Find in terminal"[\s\S]{0,80}ph:magnifying-glass/, "the bar renders a labelled Find button");
+assert.match(term, /<TerminalKeyBar[^>]*onFind=\{openFind\}/, "the terminal wires the bar's Find button to openFind");
+
 console.log("terminal-key-bar.test.ts: ok");

--- a/src/components/terminal-key-bar.tsx
+++ b/src/components/terminal-key-bar.tsx
@@ -25,6 +25,9 @@ type Props = {
    *  itself lives in the terminal's onData handler. */
   ctrlActive: boolean;
   onToggleCtrl: () => void;
+  /** Open the in-buffer find bar. Touch keyboards can't produce the ⌘F chord
+   *  that opens it on desktop, so this is the only way in on a phone/tablet. */
+  onFind?: () => void;
 };
 
 const KEY_CLASS =
@@ -35,7 +38,7 @@ const KEY_CLASS =
  * omit Esc, Tab, Ctrl, and arrow keys — which makes a shell (let alone vim or a
  * TUI) unusable. This bar surfaces them as 44px targets just above the keyboard.
  */
-export function TerminalKeyBar({ onKey, ctrlActive, onToggleCtrl }: Props) {
+export function TerminalKeyBar({ onKey, ctrlActive, onToggleCtrl, onFind }: Props) {
   return (
     <div
       className="terminal-key-bar flex items-center gap-1.5 overflow-x-auto border-t border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2 py-1.5 [padding-bottom:calc(6px+var(--sai-bottom))]"
@@ -60,6 +63,11 @@ export function TerminalKeyBar({ onKey, ctrlActive, onToggleCtrl }: Props) {
       <button type="button" className={KEY_CLASS} onClick={() => onKey(KEYS.tilde)} aria-label="Tilde">~</button>
       <button type="button" className={KEY_CLASS} onClick={() => onKey(KEYS.slash)} aria-label="Slash">/</button>
       <button type="button" className={KEY_CLASS} onClick={() => onKey(KEYS.dash)} aria-label="Dash">-</button>
+      {onFind ? (
+        <button type="button" className={KEY_CLASS} onClick={onFind} aria-label="Find in terminal">
+          <Icon name="ph:magnifying-glass" width={14} aria-hidden />
+        </button>
+      ) : null}
       <span className="flex-1" aria-hidden />
       <ArrowKey label="Left" icon="ph:arrow-left-bold" onClick={() => onKey(KEYS.left)} />
       <ArrowKey label="Up" icon="ph:arrow-up-bold" onClick={() => onKey(KEYS.up)} />


### PR DESCRIPTION
## Terminal audit + fixes

Same audit pass as the Gantt/Calendar/Code-tree, applied to the **Terminal** (`bottom-terminal.tsx` + `terminal-key-bar.tsx`). It's the most battle-hardened surface so far (reconnect/race handling, SR mirror, heavy test pinning), so this is a **cleanup + polish** pass that leaves the transport/reconnect logic entirely untouched.

### Cleanup
1. **Deduped the xterm setup.** The Tauri-IPC and WebSocket effects each built the terminal + fit/links/search addons + result reporting + the ⌘F find-bar key handler with **~40 lines of byte-identical code** (verified via diff). Extracted a shared `createXterm()` helper (also folds in the lazy `@xterm/*` import) — the terminal is now constructed in exactly one place; the two effects keep only their transport-specific byte plumbing.
2. **Hoisted `SEARCH_DECORATIONS`** (the match-highlight colors) to a module constant instead of rebuilding the object every render.

### Polish
3. **Touch Find.** `⌘F` was the *only* way to open in-buffer search, but soft keyboards can't produce that chord — and the `TerminalKeyBar` exists precisely because mobile keyboards lack those keys. The bar (coarse-pointer only) now has a magnifier **Find** button wired to the same `openFind`.
4. **A11y label** on the click-to-focus terminal region (`role="group" aria-label="Terminal"`) since xterm renders into an opaque `<canvas>`; live output stays exposed via the existing screen-reader mirror.

## Testing
- **Verified live in the browser** (WS bridge): a real shell renders, `echo` runs and prints its output, the find bar opens, **no console errors**.
- `tsc --noEmit` clean · `pnpm build` clean · full `app` suite: 387 files pass.
- Extended the source-text tests: `createXterm` exists, `new Terminal(`/`attachCustomKeyEventHandler` appear exactly once, `SEARCH_DECORATIONS` is module-scoped, and the touch Find button is wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)