### PR TITLE
feat(calendar): click an empty month day to pre-fill the add form

### DIFF
--- a/src/components/calendar-view-polish.test.ts
+++ b/src/components/calendar-view-polish.test.ts
@@ -175,3 +175,13 @@ assert.ok(
   source.includes("focus-ring-inset flex items-center gap-1 rounded px-1.5 py-0.5 text-[9px]"),
   "all-day event buttons have a focus ring",
 );
+
+// Month view: clicking an empty current-month day pre-fills the add form for
+// that day; the date number still navigates into the day.
+assert.match(source, /const canAdd = isCurrentMonth && !!onAddEntry;/, "month cells know when they can add");
+assert.match(source, /const onCell = \(\) => \{[\s\S]{0,120}onAddEntry!\(\{ fireAt: defaultEntryFireAt\(day\) \}\)[\s\S]{0,40}onDayClick\?\.\(day\)/, "an empty day click adds (current month) or navigates (otherwise)");
+assert.match(source, /onClick=\{onCell\}/, "the day cell click runs the add/navigate handler");
+assert.match(source, /aria-label=\{`Open \$\{fmtDateHeading\(day\)\}`\}/, "the date number is a button labelled to open the day");
+assert.match(source, /onClick=\{\(e\) => \{ e\.stopPropagation\(\); onDayClick\?\.\(day\); \}\}/, "the date number navigates into the day (stops the cell add)");
+
+console.log("calendar-view-polish.test.ts: month click-to-add ok");

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -1023,41 +1023,39 @@ function MonthView({
               const isCurrentMonth = day.getMonth() === anchor.getMonth();
               const isToday = now ? isSameDay(day, now) : false;
 
+              // Clicking an empty part of a current-month day pre-fills the add
+              // form for that day; the date number still navigates into the day.
+              const canAdd = isCurrentMonth && !!onAddEntry;
+              const itemsSuffix = dayItems.length ? `, ${dayItems.length} item${dayItems.length !== 1 ? "s" : ""}` : "";
+              const onCell = () => {
+                if (canAdd) onAddEntry!({ fireAt: defaultEntryFireAt(day) });
+                else onDayClick?.(day);
+              };
               return (
                 <div
                   key={i}
                   role="button"
                   tabIndex={0}
-                  aria-label={`${fmtDateHeading(day)}${dayItems.length ? `, ${dayItems.length} item${dayItems.length !== 1 ? "s" : ""}` : ""}`}
-                  onClick={() => onDayClick?.(day)}
+                  aria-label={`${canAdd ? `Add a reminder on ${fmtDateHeading(day)}` : fmtDateHeading(day)}${itemsSuffix}`}
+                  onClick={onCell}
                   onKeyDown={(e) => {
                     if (e.key === "Enter" || e.key === " ") {
                       e.preventDefault();
-                      onDayClick?.(day);
+                      onCell();
                     }
                   }}
+                  title={canAdd ? "Click to add a reminder — click the date to open the day" : undefined}
                   className={`group relative focus-ring-inset flex cursor-pointer flex-col overflow-hidden p-1.5 transition-colors ${
                     isCurrentMonth
                       ? "bg-[var(--bg-panel)] hover:bg-[var(--bg-raised)]"
                       : "bg-[var(--bg-base)] hover:bg-[var(--bg-panel)]"
                   } ${isToday ? "ring-1 ring-inset ring-[var(--accent-presence)]" : ""}`}
                 >
-                  {onAddEntry && isCurrentMonth && (
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onAddEntry({ fireAt: defaultEntryFireAt(day) });
-                      }}
-                      aria-label={`Add a reminder on ${fmtDateHeading(day)}`}
-                      title="Add reminder"
-                      className="focus-ring absolute right-1 top-1 hidden h-4 w-4 items-center justify-center rounded text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--accent-presence)] group-hover:flex group-focus-within:flex"
-                    >
-                      <Icon name="ph:plus" width={10} aria-hidden />
-                    </button>
-                  )}
-                  <span
-                    className={`mb-1 flex h-5 w-5 items-center justify-center rounded-full text-[11px] font-medium ${
+                  <button
+                    type="button"
+                    onClick={(e) => { e.stopPropagation(); onDayClick?.(day); }}
+                    aria-label={`Open ${fmtDateHeading(day)}`}
+                    className={`focus-ring mb-1 flex h-5 w-5 items-center justify-center rounded-full text-[11px] font-medium ${
                       isToday
                         ? "bg-[var(--accent-presence)] text-white"
                         : isCurrentMonth
@@ -1066,7 +1064,7 @@ function MonthView({
                     }`}
                   >
                     {day.getDate()}
-                  </span>
+                  </button>
                   <div className="flex flex-col gap-0.5 overflow-hidden">
                     {dayDeadlines.slice(0, 2).map((d) => (
                       <DeadlineChip key={d.id} deadline={d} onOpen={onOpenDeadline} size="xs" />


### PR DESCRIPTION
## What

In the calendar **Month** view, clicking a day previously navigated into it, with a small hover **"+"** to add a reminder. Now:
- **Clicking the empty area of a current-month day** opens the New reminder modal **pre-filled with that day** (`defaultEntryFireAt` → 9am, or "now" for past days you can't schedule into).
- The **date number** is a button that still **navigates** into the day.
- The redundant hover "+" is removed.

Item/deadline chips already `stopPropagation`, so clicking an existing entry still opens it (not create). Week/Day views already supported click-empty-slot-to-add; this brings Month view in line.

## Verification
- `pnpm typecheck` clean; `app` suite → **387 files pass** (assertions added to `calendar-view-polish.test.ts`; existing calendar tests still green).
- Browser-driven: clicking the empty **28th** opens the modal prefilled to **2026-06-28 09:00** ("Remind Sun, Jun 28, 9:00 AM"); the date-number button navigates; past days correctly fall back to "now".

🤖 Generated with [Claude Code](https://claude.com/claude-code)