### PR TITLE
fix(ios): drop the non-interactive GitHub user chip from the Developer tab

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
@@ -7,8 +7,6 @@ struct GitHubView: View {
     @Environment(AppModel.self) private var app
 
     @State private var items: [GitHubItem] = []
-    @State private var login: String?
-    @State private var authed = false
     @State private var loading = true
     @State private var error: String?
     @State private var hint: String?
@@ -20,14 +18,6 @@ struct GitHubView: View {
                 .searchable(text: $query, prompt: "Search issues & PRs")
                 .navigationDestination(for: GitHubItem.self) { item in
                     GitHubItemDetailView(item: item)
-                }
-                .toolbar {
-                    if let login {
-                        ToolbarItem(placement: .topBarTrailing) {
-                            Label("@\(login)", systemImage: authed ? "person.crop.circle.badge.checkmark" : "person.crop.circle")
-                                .font(.caption).foregroundStyle(.secondary)
-                        }
-                    }
                 }
                 .refreshable { await load() }
                 .task { await load() }
@@ -117,8 +107,6 @@ struct GitHubView: View {
             let resp = try await client.githubActivity()
             if resp.ok {
                 items = resp.items ?? []
-                login = resp.login
-                authed = resp.authed ?? false
                 error = nil
                 hint = nil
             } else {


### PR DESCRIPTION
The GitHub surface (Developer tab) showed a top-right toolbar `Label` of the signed-in account (`@login` + a `person.crop.circle.badge.checkmark` icon). It's not a button — tapping it does nothing — so it just consumed nav-bar space.

Removes the toolbar item plus the now-unused `login`/`authed` view state and their assignments in `load()` (the response fields are left intact). No behaviour change beyond the chip disappearing.

`xcodebuild` (iPhone 16 Pro sim): **BUILD SUCCEEDED**, no unused-var warnings. Existing GitHub iOS tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)