### PR TITLE
fix(a11y): keyboard + screen-reader semantics across library, browser, calendar, workflows

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -179,6 +179,7 @@ export const SUITES = {
     "src/components/project-tree-keynav.test.ts",
     "src/components/comux-pane-nav-wiring.test.ts",
     "src/components/library-polish.test.ts",
+    "src/components/a11y-audit-fixes.test.ts",
     "src/components/library-file-actions.test.ts",
     "src/components/eval-loop-panel.test.ts",
     "src/components/retro-runs-view.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -413,6 +413,14 @@ select {
   outline-offset: calc(-1 * var(--ring-width));
 }
 
+/* Bulk-select rows expose role="checkbox" in select mode; give the keyboard
+   focus an inset ring without changing their pinned className strings. */
+tr[role="checkbox"]:focus { outline: none; }
+tr[role="checkbox"]:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: calc(-1 * var(--ring-width));
+}
+
 /* ============================================================
    Shell primitives — the three-pane app chrome.
    Composed by <Shell> in src/components/shell.tsx.

--- a/src/components/a11y-audit-fixes.test.ts
+++ b/src/components/a11y-audit-fixes.test.ts
@@ -1,0 +1,53 @@
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const read = (name: string) => readFile(new URL(name, import.meta.url), "utf8");
+
+test("github library group header is keyboard-operable", async () => {
+  const src = await read("./library-github-list.tsx");
+  assert.match(src, /className="board-table-group-row focus-ring-inset"/);
+  assert.match(src, /role="button"[\s\S]{0,200}aria-expanded=\{!collapsed\.has\(key\)\}/);
+});
+
+test("browser tabs expose an accessible name and pressed state", async () => {
+  const src = await read("./browser-pane.tsx");
+  assert.match(src, /aria-label=\{tabTitles\[tab\.id\] \?\? tab\.title \?\? tab\.url\}/);
+  assert.match(src, /aria-pressed=\{isActive\}/);
+});
+
+test("bulk-select rows are real keyboard checkboxes in select mode", async () => {
+  for (const file of [
+    "./library-reading-list.tsx",
+    "./library-bookmarks-list.tsx",
+    "./library-github-list.tsx",
+  ]) {
+    const src = await read(file);
+    assert.match(src, /role=\{selectMode \? "checkbox" : undefined\}/, file);
+    assert.match(src, /aria-checked=\{selectMode \? selectedIds\.has\(item\.id\) : undefined\}/, file);
+    assert.match(src, /tabIndex=\{selectMode \? 0 : undefined\}/, file);
+  }
+});
+
+test("action-inbox checkbox row carries a focus ring in select mode", async () => {
+  const src = await read("./dashboard/action-inbox.tsx");
+  assert.match(src, /selectMode \? " focus-ring-inset" : ""/);
+});
+
+test("reading status radios have a label and focus ring on every option", async () => {
+  const src = await read("./library-reading-list.tsx");
+  assert.match(src, /role="radio"[\s\S]{0,160}aria-label=\{meta\.label\}/);
+  assert.match(src, /className=\{`library-status-toggle__opt focus-ring-inset/);
+});
+
+test("workflow-library selected item reflects pressed state", async () => {
+  const src = await read("./workflows/workflow-library.tsx");
+  assert.match(src, /aria-pressed=\{active\}/);
+});
+
+test("calendar urgency dots carry a text alternative", async () => {
+  const src = await read("./calendar-view.tsx");
+  assert.match(src, /function urgencyLabel\(item: InboxItem\): string/);
+  assert.match(src, /role="img" aria-label=\{urgencyLabel\(item\)\}/);
+  assert.match(src, /role="img" aria-label=\{urgencyLabel\(ev\.item\)\}/);
+});

--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -707,6 +707,8 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
               key={tab.id}
               role="button"
               tabIndex={0}
+              aria-label={tabTitles[tab.id] ?? tab.title ?? tab.url}
+              aria-pressed={isActive}
               onClick={() => switchTab(tab.id)}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -174,6 +174,15 @@ function urgencyColor(item: InboxItem): string {
   return "bg-[var(--text-muted)]";
 }
 
+/** Text alternative for the color-only urgency dot, so it isn't conveyed by hue alone. */
+function urgencyLabel(item: InboxItem): string {
+  if (isOverdueReminder(item)) return "Overdue";
+  const meta = (item as unknown as { comms?: { urgency?: string } }).comms;
+  if (meta?.urgency === "expiring") return "Expiring";
+  if (meta?.urgency === "time-sensitive") return "Time-sensitive";
+  return "Normal urgency";
+}
+
 function platformIcon(item: InboxItem): IconName {
   if (item.kind === "daily-summary") return "ph:newspaper";
   const meta = (item as unknown as { comms?: { platform?: string } }).comms;
@@ -207,7 +216,7 @@ function ItemChip({
     >
       {done
         ? <Icon name="ph:check-circle" className="shrink-0 text-[var(--text-muted)] text-[12px]" />
-        : <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${urgencyColor(item)}`} />}
+        : <span role="img" aria-label={urgencyLabel(item)} title={urgencyLabel(item)} className={`h-1.5 w-1.5 shrink-0 rounded-full ${urgencyColor(item)}`} />}
       <Icon
         name={platformIcon(item)}
         className="shrink-0 text-[var(--text-muted)] text-[12px]"
@@ -431,7 +440,7 @@ function AllDayStrip({
                 onClick={() => onOpenItem?.(item)}
                 className="focus-ring-inset flex items-center gap-1 rounded px-1.5 py-0.5 text-[9px] bg-[var(--accent-presence)]/15 border border-[var(--accent-presence)]/30 hover:bg-[var(--accent-presence)]/25 transition-colors w-full text-left truncate"
               >
-                <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${urgencyColor(item)}`} />
+                <span role="img" aria-label={urgencyLabel(item)} title={urgencyLabel(item)} className={`h-1.5 w-1.5 shrink-0 rounded-full ${urgencyColor(item)}`} />
                 <span className="truncate text-[var(--text-primary)]">{item.title}</span>
               </button>
             ))}
@@ -725,7 +734,7 @@ function TimeGrid({
                 >
                   {done
                     ? <Icon name="ph:check" width={9} className="shrink-0 text-[var(--text-muted)]" />
-                    : <span className={`inline-block h-1.5 w-1.5 shrink-0 rounded-full ${urgencyColor(ev.item)}`} />}
+                    : <span role="img" aria-label={urgencyLabel(ev.item)} title={urgencyLabel(ev.item)} className={`inline-block h-1.5 w-1.5 shrink-0 rounded-full ${urgencyColor(ev.item)}`} />}
                   <span className={`truncate ${done ? "line-through" : ""}`}>{ev.item.title}</span>
                 </button>
               );
@@ -1095,7 +1104,7 @@ function MonthView({
                       >
                         {done
                           ? <Icon name="ph:check" width={8} className="shrink-0 text-[var(--text-muted)]" />
-                          : <span className={`h-1 w-1 shrink-0 rounded-full ${urgencyColor(item)}`} />}
+                          : <span role="img" aria-label={urgencyLabel(item)} title={urgencyLabel(item)} className={`h-1 w-1 shrink-0 rounded-full ${urgencyColor(item)}`} />}
                         <span className={`truncate text-[var(--text-primary)] ${done ? "line-through" : ""}`}>{item.title}</span>
                       </button>
                       );

--- a/src/components/dashboard/action-inbox.tsx
+++ b/src/components/dashboard/action-inbox.tsx
@@ -151,7 +151,7 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
           return (
           <div
             key={item.id}
-            className={`dr-row dash-inbox__row${selectMode && selectedIds.has(item.id) ? " dash-inbox__row--selected" : ""}`}
+            className={`dr-row dash-inbox__row${selectMode ? " focus-ring-inset" : ""}${selectMode && selectedIds.has(item.id) ? " dash-inbox__row--selected" : ""}`}
             style={{ ["--row-accent" as string]: "var(--color-warning)" }}
             role={selectMode ? "checkbox" : undefined}
             aria-checked={selectMode ? selectedIds.has(item.id) : undefined}

--- a/src/components/library-bookmarks-list.tsx
+++ b/src/components/library-bookmarks-list.tsx
@@ -505,7 +505,11 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
                   {!collapsed.has(key) && gi.map((item) => (
                     <tr key={`${key}:${item.id || item.url}`}
                       className={`${item.id === selectedId ? "selected" : ""}${selectMode && selectedIds.has(item.id) ? " is-selected" : ""}`}
-                      aria-selected={selectMode ? selectedIds.has(item.id) : undefined}
+                      role={selectMode ? "checkbox" : undefined}
+                      aria-checked={selectMode ? selectedIds.has(item.id) : undefined}
+                      aria-label={selectMode ? `Select ${item.title}` : undefined}
+                      tabIndex={selectMode ? 0 : undefined}
+                      onKeyDown={selectMode ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleSelect(item.id); } } : undefined}
                       onClick={() => { if (selectMode) { toggleSelect(item.id); return; } onSelect(item); }}>
                       <td>
                         <span className="board-table-title library-title-cell">

--- a/src/components/library-github-list.tsx
+++ b/src/components/library-github-list.tsx
@@ -829,7 +829,17 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
               {groups.map(({ key, label, items: gi }) => (
                 <React.Fragment key={key}>
                   {groupBy !== "none" && (
-                    <tr className="board-table-group-row" onClick={() => toggleGroup(key)}>
+                    <tr
+                      className="board-table-group-row focus-ring-inset"
+                      role="button"
+                      tabIndex={0}
+                      aria-expanded={!collapsed.has(key)}
+                      aria-label={`${collapsed.has(key) ? "Expand" : "Collapse"} ${label}`}
+                      onClick={() => toggleGroup(key)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleGroup(key); }
+                      }}
+                    >
                       <td colSpan={GITHUB_TABLE_COLUMN_COUNT}>
                         <span className="board-table-group-caret">
                           <Icon name={collapsed.has(key) ? "ph:caret-right" : "ph:caret-down"} width={10} />
@@ -845,7 +855,11 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
                       <React.Fragment key={item.id}>
                         <tr
                           className={`gh-row-main${item.id === selectedId ? " selected" : ""}${selectMode && selectedIds.has(item.id) ? " is-selected" : ""}`}
-                          aria-selected={selectMode ? selectedIds.has(item.id) : undefined}
+                          role={selectMode ? "checkbox" : undefined}
+                          aria-checked={selectMode ? selectedIds.has(item.id) : undefined}
+                          aria-label={selectMode ? `Select ${item.title}` : undefined}
+                          tabIndex={selectMode ? 0 : undefined}
+                          onKeyDown={selectMode ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleSelect(item.id); } } : undefined}
                           onClick={() => { if (selectMode) { toggleSelect(item.id); return; } onSelect(item); }}
                         >
                           <td className="gh-col-title">

--- a/src/components/library-reading-list.tsx
+++ b/src/components/library-reading-list.tsx
@@ -506,7 +506,11 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
                   {!collapsed.has(key) && gi.map((item) => (
                     <tr key={item.id}
                       className={`library-reading-row${item.id === selectedId ? " selected" : ""}${selectMode && selectedIds.has(item.id) ? " is-selected" : ""}`}
-                      aria-selected={selectMode ? selectedIds.has(item.id) : undefined}
+                      role={selectMode ? "checkbox" : undefined}
+                      aria-checked={selectMode ? selectedIds.has(item.id) : undefined}
+                      aria-label={selectMode ? `Select ${item.title}` : undefined}
+                      tabIndex={selectMode ? 0 : undefined}
+                      onKeyDown={selectMode ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleSelect(item.id); } } : undefined}
                       onClick={() => { if (selectMode) { toggleSelect(item.id); return; } onSelect(item); }}>
                       <td className="library-reading-col-title">
                         <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
@@ -541,8 +545,9 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
                                 type="button"
                                 role="radio"
                                 aria-checked={active}
+                                aria-label={meta.label}
                                 data-status={status}
-                                className={`library-status-toggle__opt${active ? " is-active" : ""}`}
+                                className={`library-status-toggle__opt focus-ring-inset${active ? " is-active" : ""}`}
                                 style={active ? statusBadgeStyle(status) : undefined}
                                 title={meta.label}
                                 onClick={(e) => {

--- a/src/components/workflows/workflow-library.tsx
+++ b/src/components/workflows/workflow-library.tsx
@@ -84,6 +84,7 @@ export function WorkflowLibrary({
         key={`${workflow.id}:${workflow.path ?? ""}`}
         type="button"
         className={`workflow-library-item${active ? " is-active" : ""}`}
+        aria-pressed={active}
         onClick={() => onSelectWorkflow(workflow)}
       >
         <span className="workflow-library-item-title">


### PR DESCRIPTION
Accessibility audit follow-up. Fixes the HIGH + MEDIUM findings from the cross-surface a11y sweep.

## Fixes
- **GitHub library group headers** — now keyboard-operable (`role="button"`, `tabIndex`, `aria-expanded`, Enter/Space, focus ring), matching the reading-list pattern.
- **Browser tab strip** — `aria-label` (full tab title) + `aria-pressed` for the active tab.
- **Bulk-select rows** (reading / bookmarks / github) — real `role="checkbox"` with `aria-checked`, `aria-label`, `tabIndex`, and Enter/Space toggling in select mode; CSS `:focus-visible` ring for `tr[role="checkbox"]`.
- **Dashboard action-inbox** — visible focus ring on the checkbox row in select mode.
- **Reading status radios** — `aria-label` on every option (icon-only inactive options previously had no accessible name) + per-option focus ring.
- **Workflow library item** — `aria-pressed` reflects the selected workflow.
- **Calendar urgency dots** — `urgencyLabel()` text alternative via `role="img"` + `aria-label`/`title`, so urgency isn't color-only.

## Verified already-correct (no change)
- Docs "Open" link has a visible text label.
- GitHub "Open on GitHub" is already an `<a>`.
- Workflow dependency chips are named by their visible label text (adding `aria-label` would override the visible name — worse for voice control).

## Tests
- New `a11y-audit-fixes.test.ts` locks in each change; registered in `run-tests.mjs`.
- `pnpm typecheck` clean; `app` (388 files) + `mobile` (50 files) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)