### PR TITLE
fix(ios): match chat inline-code colour to the selected desktop theme

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Theme/Theme.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/Theme.swift
@@ -19,6 +19,11 @@ struct ChromePalette: Equatable {
     /// `accent` mirrors the asset-catalog accent, so `.tint(accent)` is a no-op
     /// until the desktop publishes `--accent-presence`.
     var accent: Color = .accentColor
+    /// The raw `--accent-presence` hex, kept alongside `accent` so it can be
+    /// handed to the markdown WebView (which colours inline code / links off a
+    /// CSS `--accent`). `nil` until the desktop publishes a theme, so the chat
+    /// bubble keeps its built-in lavender accent when disconnected.
+    var accentHex: String? = nil
     /// Drives `preferredColorScheme` so the whole app flips light/dark with the
     /// desktop. Defaults to dark — the app's original fixed scheme.
     var colorScheme: ColorScheme = .dark
@@ -40,7 +45,7 @@ extension ChromePalette {
         if let c = Color(hex: t["--text-secondary"]) { textSecondary = c }
         if let c = Color(hex: t["--text-muted"]) { textMuted = c }
         if let c = Color(hex: t["--border-hairline"]) { border = c }
-        if let c = Color(hex: t["--accent-presence"]) { accent = c }
+        if let c = Color(hex: t["--accent-presence"]) { accent = c; accentHex = t["--accent-presence"] }
         colorScheme = snapshot.mode.lowercased() == "light" ? .light : .dark
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Views/MarkdownWebView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MarkdownWebView.swift
@@ -62,6 +62,10 @@ struct MarkdownWebView: UIViewRepresentable {
     var scrollable: Bool = false
     var fontScale: CGFloat = 1
     var theme: ReaderTheme = .dark
+    /// Optional accent (`#rrggbb`) from the desktop theme. When set, the renderer
+    /// colours inline code / links / markers off it so they match the selected
+    /// theme; `nil` keeps the bundle's built-in accent. The reader leaves this nil.
+    var accentHex: String? = nil
     var scrollCommand: ReaderScrollCommand? = nil
     /// Called if the bundled renderer can't run (missing/stale `markdown.html`,
     /// `window.caveRender` undefined, or a JS error) so the caller can fall back
@@ -81,7 +85,7 @@ struct MarkdownWebView: UIViewRepresentable {
         c.onHeadings = onHeadings
         c.setScrollable(scrollable)
         c.apply(markdown: markdown, streaming: streaming,
-                fontScale: fontScale, theme: theme, reader: scrollable)
+                fontScale: fontScale, theme: theme, accentHex: accentHex, reader: scrollable)
         c.applyScroll(scrollCommand)
     }
 
@@ -106,6 +110,7 @@ struct MarkdownWebView: UIViewRepresentable {
             var streaming = false
             var fontScale: CGFloat = 1
             var theme: ReaderTheme = .dark
+            var accentHex: String? = nil
             var reader = false
         }
         private var opts = Opts()
@@ -140,14 +145,14 @@ struct MarkdownWebView: UIViewRepresentable {
             }
         }
 
-        func apply(markdown md: String, streaming: Bool, fontScale: CGFloat, theme: ReaderTheme, reader: Bool) {
-            opts = Opts(streaming: streaming, fontScale: fontScale, theme: theme, reader: reader)
+        func apply(markdown md: String, streaming: Bool, fontScale: CGFloat, theme: ReaderTheme, accentHex: String?, reader: Bool) {
+            opts = Opts(streaming: streaming, fontScale: fontScale, theme: theme, accentHex: accentHex, reader: reader)
             if failed { reportFailure(); return }
             // Markdown / streaming / reader changes need a full re-render; a pure
-            // font-size or theme change is applied without rebuilding the DOM so
-            // the reader's scroll position survives.
+            // font-size / theme / accent change is applied without rebuilding the
+            // DOM so the reader's scroll position survives.
             let renderKey = "\(streaming)|\(reader)|\(md)"
-            let styleKey = "\(fontScale)|\(theme.rawValue)"
+            let styleKey = "\(fontScale)|\(theme.rawValue)|\(accentHex ?? "")"
             if renderKey == lastRenderKey {
                 if styleKey != lastStyleKey { lastStyleKey = styleKey; applyStyleOnly() }
                 return
@@ -169,7 +174,8 @@ struct MarkdownWebView: UIViewRepresentable {
         private func applyStyleOnly() {
             guard ready, !failed else { return }
             let o = opts
-            let js = "window.caveStyle && window.caveStyle({fontScale:\(Double(o.fontScale)),theme:'\(o.theme.rawValue)',reader:\(o.reader)})"
+            let accent = o.accentHex.map { "'\($0)'" } ?? "null"
+            let js = "window.caveStyle && window.caveStyle({fontScale:\(Double(o.fontScale)),theme:'\(o.theme.rawValue)',accent:\(accent),reader:\(o.reader)})"
             webView.evaluateJavaScript(js, completionHandler: nil)
         }
 
@@ -205,6 +211,7 @@ struct MarkdownWebView: UIViewRepresentable {
                                 "streaming": o.streaming,
                                 "fontScale": Double(o.fontScale),
                                 "theme": o.theme.rawValue,
+                                "accent": o.accentHex ?? "",
                                 "reader": o.reader,
                             ],
                         ],

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -17,6 +17,9 @@ struct MessageBubble: View {
     // prose must follow the app's light/dark appearance (the WebView doesn't
     // pick up `prefers-color-scheme` on its own).
     @Environment(\.colorScheme) private var colorScheme
+    // The desktop theme palette: its accent drives inline-code / link colours in
+    // the markdown so they match the selected theme instead of a fixed lavender.
+    @Environment(\.chrome) private var chrome
 
     @State private var mdHeight: CGFloat = 0
     /// Set when the markdown WebView can't render (missing/stale bundle, JS
@@ -200,6 +203,7 @@ struct MessageBubble: View {
             MarkdownWebView(markdown: parsed.visible, height: $mdHeight,
                             streaming: message.streaming && !isUser,
                             theme: colorScheme == .light ? .light : .dark,
+                            accentHex: chrome.accentHex,
                             onFailure: { markdownFailed = true })
                 .frame(height: max(mdHeight, 1))
                 .padding(.horizontal, 14).padding(.vertical, 10)

--- a/apps/ios/markdown/entry.mjs
+++ b/apps/ios/markdown/entry.mjs
@@ -140,10 +140,15 @@ async function renderMarkdown(md, { streaming = false } = {}) {
 // markdown.css) so the same bundle can render dark / light / sepia. Code blocks
 // keep their dark card (we deliberately DON'T touch --code-bg / hljs colours) —
 // a dark code card on a light page is intentional and dodges contrast problems.
+// Inline-code bg/fg are color-mixed off var(--accent) (declared in markdown.css)
+// so they track whatever --accent ends up being — the per-theme accent here, or
+// the desktop's published accent layered on top by applyAccent(). Light/sepia
+// pages mix the pill text toward black (the dark default lifts toward white) so
+// it stays legible on a light bubble.
 const THEME_VARS = {
   dark: null,
-  light: { "--txt": "#1c1c22", "--txt-muted": "#5b5b66", "--accent": "#5a51d6", "--hairline": "rgba(0,0,0,0.14)", "--code-inline-bg": "rgba(90,81,214,0.12)", "--code-inline-fg": "#4b43c4", "--th-bg": "rgba(0,0,0,0.04)", bg: "#ffffff" },
-  sepia: { "--txt": "#43382a", "--txt-muted": "#7a6a55", "--accent": "#9a5a2a", "--hairline": "rgba(0,0,0,0.16)", "--code-inline-bg": "rgba(154,90,42,0.14)", "--code-inline-fg": "#8a4a1a", "--th-bg": "rgba(0,0,0,0.05)", bg: "#f4ecd8" },
+  light: { "--txt": "#1c1c22", "--txt-muted": "#5b5b66", "--accent": "#5a51d6", "--hairline": "rgba(0,0,0,0.14)", "--code-inline-bg": "color-mix(in srgb, var(--accent) 13%, transparent)", "--code-inline-fg": "color-mix(in srgb, var(--accent), #000000 14%)", "--th-bg": "rgba(0,0,0,0.04)", bg: "#ffffff" },
+  sepia: { "--txt": "#43382a", "--txt-muted": "#7a6a55", "--accent": "#9a5a2a", "--hairline": "rgba(0,0,0,0.16)", "--code-inline-bg": "color-mix(in srgb, var(--accent) 15%, transparent)", "--code-inline-fg": "color-mix(in srgb, var(--accent), #000000 22%)", "--th-bg": "rgba(0,0,0,0.05)", bg: "#f4ecd8" },
 };
 const THEME_KEYS = ["--txt", "--txt-muted", "--accent", "--hairline", "--code-inline-bg", "--code-inline-fg", "--th-bg"];
 function applyTheme(name) {
@@ -154,11 +159,25 @@ function applyTheme(name) {
   document.body.style.background = t && t.bg ? t.bg : "";
 }
 
+// Override --accent with the desktop theme's published accent (a `#rrggbb[aa]`)
+// so inline code, links, and list markers match the selected theme rather than
+// the bundle's built-in lavender. Inline-code bg/fg are color-mixed off --accent
+// (markdown.css / THEME_VARS), so they follow this automatically. Runs AFTER
+// applyTheme (which clears --accent), so a falsy/invalid accent cleanly falls
+// back to the per-theme accent.
+function applyAccent(accent) {
+  if (typeof accent !== "string") return;
+  const v = accent.trim();
+  if (!/^#?[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/.test(v)) return;
+  document.documentElement.style.setProperty("--accent", v[0] === "#" ? v : "#" + v);
+}
+
 // fontScale zooms the whole document uniformly (px + em both scale); reader mode
 // adds page padding so the full-screen scroll view isn't edge-to-edge.
 function applyStyle(opts = {}) {
-  const { fontScale = 1, theme = "dark", reader = false } = opts || {};
+  const { fontScale = 1, theme = "dark", reader = false, accent = null } = opts || {};
   applyTheme(theme);
+  applyAccent(accent);
   document.body.style.zoom = fontScale && fontScale !== 1 ? String(fontScale) : "";
   document.body.style.padding = reader ? "18px 18px 80px" : "";
 }

--- a/apps/ios/markdown/markdown.css
+++ b/apps/ios/markdown/markdown.css
@@ -10,9 +10,13 @@
   --code-bg: #16161C;
   --code-border: rgba(255,255,255,0.08);
   --hairline: rgba(255,255,255,0.10);
-  /* themeable so inline code + table headers adapt with the prose */
-  --code-inline-bg: rgba(139,133,240,0.16);
-  --code-inline-fg: #C8C2FF;
+  /* Inline code + links follow --accent so they match the selected desktop
+     theme (the renderer overrides --accent with the published accent). Derived
+     via color-mix off --accent: a translucent pill, with the text lifted toward
+     white on the dark default for contrast. THEME_VARS re-points the text mix
+     toward black on the light/sepia reader pages. */
+  --code-inline-bg: color-mix(in srgb, var(--accent) 18%, transparent);
+  --code-inline-fg: color-mix(in srgb, var(--accent), #ffffff 34%);
   --th-bg: rgba(255,255,255,0.04);
 }
 

--- a/scripts/ios-markdown-accent.test.mjs
+++ b/scripts/ios-markdown-accent.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// The native chat markdown should colour inline code / links / list markers off
+// the *selected* desktop theme's accent, not a fixed lavender. The accent flows:
+//   ChromePalette.accentHex (from --accent-presence)
+//     → MessageBubble passes it to MarkdownWebView
+//     → MarkdownWebView hands it to caveRender/caveStyle as `accent`
+//     → entry.mjs applyAccent() overrides the CSS --accent
+//     → markdown.css inline code is color-mixed off var(--accent), so it follows.
+// This test locks each link of that chain (source-text) so a refactor can't
+// silently drop it. The runtime colour behaviour is covered by a headless render.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+
+const base = "apps/ios/CovenCave/CovenCave";
+const theme = await read(`${base}/Theme/Theme.swift`);
+const bubble = await read(`${base}/Views/MessageBubble.swift`);
+const webview = await read(`${base}/Views/MarkdownWebView.swift`);
+const entry = await read("apps/ios/markdown/entry.mjs");
+const css = await read("apps/ios/markdown/markdown.css");
+
+// --- ChromePalette exposes the published accent as a hex --------------------
+assert.match(
+  theme,
+  /var accentHex: String\?/,
+  "ChromePalette should expose the accent as a hex string for the WebView",
+);
+assert.match(
+  theme,
+  /Color\(hex: t\["--accent-presence"\]\)\s*\{[^}]*accentHex = t\["--accent-presence"\]/,
+  "ChromePalette.init(snapshot:) should capture the --accent-presence hex into accentHex",
+);
+
+// --- MessageBubble threads the chrome accent into the renderer --------------
+assert.match(
+  bubble,
+  /@Environment\(\\\.chrome\) private var chrome/,
+  "MessageBubble should read the chrome palette from the environment",
+);
+assert.match(
+  bubble,
+  /accentHex: chrome\.accentHex/,
+  "MessageBubble should pass chrome.accentHex to MarkdownWebView",
+);
+
+// --- MarkdownWebView carries accentHex into the JS options ------------------
+assert.match(
+  webview,
+  /var accentHex: String\? = nil/,
+  "MarkdownWebView should accept an optional accentHex",
+);
+assert.match(
+  webview,
+  /"accent": o\.accentHex \?\? ""/,
+  "MarkdownWebView should pass the accent into the caveRender opts",
+);
+assert.match(
+  webview,
+  /accent:\\\(accent\)/,
+  "MarkdownWebView should pass the accent into the style-only caveStyle call",
+);
+// A style-only accent change must re-style without a full re-render.
+assert.match(
+  webview,
+  /let styleKey = .*accentHex \?\? ""/,
+  "An accent change should be part of the style key (re-styles in place)",
+);
+
+// --- entry.mjs overrides --accent from the published accent -----------------
+assert.match(
+  entry,
+  /function applyAccent\(accent\)/,
+  "entry.mjs should define applyAccent to override --accent",
+);
+assert.match(
+  entry,
+  /setProperty\("--accent",/,
+  "applyAccent should set the CSS --accent custom property",
+);
+// Validates the hex so junk/empty cleanly falls back to the per-theme accent.
+assert.match(
+  entry,
+  /\[0-9a-fA-F\]\{6\}/,
+  "applyAccent should validate the accent is a hex before applying it",
+);
+assert.match(
+  entry,
+  /applyStyle[\s\S]*applyAccent\(accent\)/,
+  "applyStyle should call applyAccent so renders and style-only updates both apply it",
+);
+
+// --- markdown.css derives inline code off --accent --------------------------
+assert.match(
+  css,
+  /--code-inline-bg: color-mix\(in srgb, var\(--accent\)/,
+  "inline code background should be color-mixed off var(--accent)",
+);
+assert.match(
+  css,
+  /--code-inline-fg: color-mix\(in srgb, var\(--accent\)/,
+  "inline code text should be color-mixed off var(--accent)",
+);
+
+console.log("ios-markdown-accent: OK");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -530,6 +530,7 @@ export const SUITES = {
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/ios-theme.test.mjs",
     "scripts/ios-theme-list-background.test.mjs",
+    "scripts/ios-markdown-accent.test.mjs",
     "scripts/ios-message-forwarding.test.mjs",
     "scripts/ios-chat-thread-no-search.test.mjs",
     "scripts/ios-development-code-title.test.mjs",


### PR DESCRIPTION
## Problem

Inline code in the native chat (and links / list markers) rendered as a fixed **lavender** pill regardless of the selected desktop theme. On a warm/brown theme the code spans clashed with the rest of the bubble — see the reported screenshot where `~/.coven/cave-board.json` is purple inside an otherwise tan/brown bubble.

## Fix

Thread the desktop theme's published accent (`--accent-presence`) into the markdown WebView and colour inline code off it:

- **`ChromePalette`** keeps the accent hex (`accentHex`) alongside the parsed `Color`.
- **`MessageBubble`** passes `chrome.accentHex` to `MarkdownWebView`, which hands it to `caveRender`/`caveStyle` as `accent` (a *style-only* change — no DOM re-render, so streaming/scroll are untouched).
- **`entry.mjs`** `applyAccent()` overrides the CSS `--accent` (validated hex; junk or a disconnected/no-theme state cleanly falls back to the built-in accent).
- **`markdown.css`** derives the inline-code pill from `var(--accent)` via `color-mix` — lifted toward white on the dark bubble, toward black on the light/sepia reader pages for contrast — so it tracks whatever accent is set.

Fenced **code blocks keep their deliberate multi-colour dark syntax palette** — recolouring tokens to a single accent hue would hurt readability.

## Verification

Rendered the **real bundle** headlessly (Playwright) via the same `caveRender(accent)` entry point the app uses:

| accent | inline pill | `--accent` |
|---|---|---|
| none | lavender (unchanged) | `#8B85F0` |
| `#c9a063` (warm tan) | tan, derived | `#c9a063` |
| invalid string | lavender fallback, **no console errors** | `#8B85F0` |

- App builds clean for the iPhone 16 Pro simulator.
- New `scripts/ios-markdown-accent.test.mjs` locks the full Swift→JS→CSS chain (wired into `run-tests.mjs`; `check:tests-wired` green — 522 files).
- Existing iOS theme/markdown source-text tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)