### PR TITLE
feat(ios): theme the detail & settings screens with bgBase

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
@@ -170,6 +170,7 @@ struct GitHubItemRow: View {
 /// Full detail of one issue / PR (`GET /api/github/item`).
 struct GitHubItemDetailView: View {
     @Environment(AppModel.self) private var app
+    @Environment(\.chrome) private var chrome
     let item: GitHubItem
 
     @State private var detail: GitHubItemDetail?
@@ -199,6 +200,7 @@ struct GitHubItemDetailView: View {
             }
             .padding(16)
         }
+        .background(chrome.bgBase.ignoresSafeArea())
         .navigationTitle(item.number.map { "#\($0)" } ?? "Item")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -90,6 +90,7 @@ struct SettingsView: View {
                     }
                 }
             }
+            .themedListBackground()
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
             .onAppear { editingHost = app.connection?.host ?? "" }

--- a/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct TaskDetailView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.chrome) private var chrome
     let card: BoardCard
 
     @State private var showFamiliarPicker = false
@@ -33,6 +34,7 @@ struct TaskDetailView: View {
             }
             .padding(20)
         }
+        .background(chrome.bgBase.ignoresSafeArea())
         .navigationTitle("Task")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar { ToolbarItem(placement: .topBarTrailing) { actionsMenu } }


### PR DESCRIPTION
First of the UX improvements. Finishes the desktop-theme coverage: the Chats list, sheets, and chat transcript matched the theme, but the **pushed detail screens still rendered on the system background**. Now they're themed too.

- **Task detail** + **GitHub item detail** — `chrome.bgBase` behind the `ScrollView` (same fix as the chat transcript), so the cards float on the themed floor.
- **Settings** — `themedListBackground()` on the Form (same modifier already used on the inset-grouped surfaces).
- The **code editor** is intentionally left on its syntax-tuned system background.

## Verified live (simulator)
Distinctive theme (`--bg-base #0d4d3a`): the **task detail** screen renders the themed green floor with its cards (assignee / Chat / Steps / Notes) on it, instead of system-black. GitHub item detail is the identical `ScrollView`+`bgBase`; Settings uses the same `themedListBackground` verified earlier.

`xcodebuild` (iPhone 16 Pro sim): **BUILD SUCCEEDED**, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)