### PR TITLE
feat(ios): extend liquid-glass to overlays, menus, and tab chrome

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Theme/Glass.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/Glass.swift
@@ -78,10 +78,27 @@ extension View {
         glass(level, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
     }
 
+    /// The frost *only* — material + palette tint + accent wash, no border or shadow.
+    /// For surfaces that already supply their own border/shadow (a toast with a
+    /// status-tinted ring, a menu with a separator stroke) or for bare inline chips
+    /// that shouldn't gain depth. Still degrades to a solid surface under Reduce
+    /// Transparency.
+    func glassFill<S: InsettableShape>(_ level: GlassLevel, in shape: S) -> some View {
+        modifier(GlassBackground(level: level, shape: shape, border: false, shadow: false))
+    }
+
     /// A top or bottom chrome bar (large-title header, floating bottom bar) whose
     /// frost extends under the safe-area inset so it reads as a single sheet of glass.
     func glassChrome(_ edge: Edge.Set) -> some View {
         modifier(GlassChrome(edge: edge))
+    }
+
+    /// A contained, full-width frosted bar — the faithful, theme-aware replacement
+    /// for `.background(.bar)`: fills its own frame (no safe-area bleed), no boxed
+    /// border, just an accent-infused frost with a single hairline divider on the
+    /// given `divider` edge (default top, for a bar that sits below content).
+    func glassBar(divider: Edge.Set = .top) -> some View {
+        modifier(GlassBar(divider: divider))
     }
 
     /// An accent-coloured halo on a selected/active element (the focused search
@@ -98,6 +115,8 @@ extension View {
 private struct GlassBackground<S: InsettableShape>: ViewModifier {
     let level: GlassLevel
     let shape: S
+    var border: Bool = true
+    var shadow: Bool = true
 
     @Environment(\.chrome) private var chrome
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
@@ -109,7 +128,8 @@ private struct GlassBackground<S: InsettableShape>: ViewModifier {
             glassLayers(level: level, shape: shape, chrome: chrome,
                         reduceTransparency: reduceTransparency,
                         increasedContrast: contrast == .increased,
-                        reduceMotion: reduceMotion)
+                        reduceMotion: reduceMotion,
+                        border: border, shadow: shadow)
         }
     }
 }
@@ -133,6 +153,33 @@ private struct GlassChrome: ViewModifier {
     }
 }
 
+/// A contained frosted bar: the layered frost (no box border, no shadow) plus one
+/// hairline divider, so it reads like the system `.bar` material but themed.
+private struct GlassBar: ViewModifier {
+    let divider: Edge.Set
+
+    @Environment(\.chrome) private var chrome
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorSchemeContrast) private var contrast
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func body(content: Content) -> some View {
+        let increasedContrast = contrast == .increased
+        content.background {
+            glassLayers(level: .chrome, shape: Rectangle(), chrome: chrome,
+                        reduceTransparency: reduceTransparency,
+                        increasedContrast: increasedContrast,
+                        reduceMotion: reduceMotion,
+                        border: false, shadow: false)
+                .overlay(alignment: divider == .bottom ? .bottom : .top) {
+                    Rectangle()
+                        .fill(chrome.border.opacity(increasedContrast ? 1.0 : 0.4))
+                        .frame(height: increasedContrast ? 1.0 : 0.5)
+                }
+        }
+    }
+}
+
 /// The shared layer stack, parameterised by the already-resolved environment so
 /// both `glass()` and `glassChrome()` render identically.
 @ViewBuilder
@@ -142,12 +189,14 @@ private func glassLayers<S: InsettableShape>(
     chrome: ChromePalette,
     reduceTransparency: Bool,
     increasedContrast: Bool,
-    reduceMotion: Bool
+    reduceMotion: Bool,
+    border: Bool = true,
+    shadow: Bool = true
 ) -> some View {
     let tintColor = level == .elevated ? chrome.bgElevated : chrome.bgRaised
     let borderOpacity = increasedContrast ? 1.0 : 0.4
     let lineWidth: CGFloat = increasedContrast ? 1.5 : 0.6
-    let showShadow = !reduceTransparency && !increasedContrast && !reduceMotion
+    let showShadow = shadow && !reduceTransparency && !increasedContrast && !reduceMotion
     let s = level.shadow
 
     ZStack {
@@ -164,7 +213,9 @@ private func glassLayers<S: InsettableShape>(
                 shape.fill(chrome.accent.opacity(level.accentOpacity))
             }
         }
-        shape.strokeBorder(chrome.border.opacity(borderOpacity), lineWidth: lineWidth)
+        if border {
+            shape.strokeBorder(chrome.border.opacity(borderOpacity), lineWidth: lineWidth)
+        }
     }
     .compositingGroup()
     .shadow(color: .black.opacity(showShadow ? s.opacity : 0),

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -250,7 +250,7 @@ struct ChatView: View {
                             .font(.system(size: 15, weight: .semibold))
                             .foregroundStyle(.primary)
                             .frame(width: 36, height: 36)
-                            .background(.regularMaterial, in: Circle())
+                            .glassFill(.control, in: Circle())
                             .overlay(Circle().strokeBorder(Color(.separator).opacity(0.4), lineWidth: 1))
                             .shadow(color: .black.opacity(0.15), radius: 6, y: 2)
                     }
@@ -287,7 +287,7 @@ struct ChatView: View {
         }
         .animation(.snappy(duration: 0.18), value: showingSlashMenu)
         .animation(.snappy(duration: 0.18), value: pendingImages.count)
-        .background(.bar)
+        .glassBar()
         // Live dictation streams its running transcript into the draft.
         .onAppear { dictation.onUpdate = { draft = $0 } }
         .onChange(of: photoItems) { _, items in

--- a/apps/ios/CovenCave/CovenCave/Views/CodeEditorView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/CodeEditorView.swift
@@ -181,7 +181,7 @@ struct CodeEditorView: View {
             .foregroundStyle(.secondary)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 16).padding(.vertical, 8)
-            .background(.bar)
+            .glassBar()
     }
 
     private func load() async {

--- a/apps/ios/CovenCave/CovenCave/Views/DeveloperView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/DeveloperView.swift
@@ -46,7 +46,7 @@ struct DeveloperView: View {
             .pickerStyle(.segmented)
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
-            .background(.bar)
+            .glassBar()
 
             Divider()
 

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -108,7 +108,7 @@ struct FamiliarThreadsView: View {
                     .disabled(selectedIds.isEmpty)
                 }
                 .padding(.horizontal, 20).padding(.vertical, 12)
-                .background(.bar)
+                .glassBar()
             }
         }
         .confirmationDialog(bulkDeleteTitle, isPresented: $confirmingBulkDelete, titleVisibility: .visible) {

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -218,7 +218,7 @@ struct MessageBubble: View {
                                 .font(.caption2.weight(.semibold))
                                 .foregroundStyle(.secondary)
                                 .padding(7)
-                                .background(.thinMaterial, in: Circle())
+                                .glassFill(.control, in: Circle())
                         }
                         .buttonStyle(.plain)
                         .padding(6)

--- a/apps/ios/CovenCave/CovenCave/Views/ReadingView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ReadingView.swift
@@ -129,7 +129,7 @@ struct ReadingView: View {
         // A horizontal ScrollView reports a flexible (≈zero) ideal height, so
         // without a fixed height it collapses inside a VStack / safeAreaInset.
         .frame(height: 56)
-        .background(.bar)
+        .glassBar()
     }
 
     private func chip(_ value: ReadingFilter, _ label: String, _ symbol: String) -> some View {

--- a/apps/ios/CovenCave/CovenCave/Views/RemindersView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RemindersView.swift
@@ -67,7 +67,7 @@ struct RemindersView: View {
                             .disabled(selectedIds.isEmpty)
                         }
                         .padding(.horizontal, 20).padding(.vertical, 12)
-                        .background(.bar)
+                        .glassBar()
                     }
                 }
                 .confirmationDialog(bulkTitle, isPresented: $confirmingBulkDelete, titleVisibility: .visible) {

--- a/apps/ios/CovenCave/CovenCave/Views/SlashCommandMenu.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SlashCommandMenu.swift
@@ -26,7 +26,7 @@ struct SlashCommandMenu: View {
 
             footer
         }
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .glassFill(.elevated, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .strokeBorder(Color(.separator).opacity(0.6), lineWidth: 1)

--- a/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
@@ -159,7 +159,7 @@ struct TaskDetailView: View {
                         .font(.callout.weight(.semibold))
                         .foregroundStyle(.secondary)
                         .padding(7)
-                        .background(.thinMaterial, in: Circle())
+                        .glassFill(.control, in: Circle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Rename task")
@@ -297,7 +297,7 @@ struct TaskDetailView: View {
                         .font(.caption2.weight(.semibold))
                         .foregroundStyle(.secondary)
                         .padding(7)
-                        .background(.thinMaterial, in: Circle())
+                        .glassFill(.control, in: Circle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Edit notes")
@@ -309,7 +309,7 @@ struct TaskDetailView: View {
                         .font(.caption2.weight(.semibold))
                         .foregroundStyle(.secondary)
                         .padding(7)
-                        .background(.thinMaterial, in: Circle())
+                        .glassFill(.control, in: Circle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Open notes in reader")

--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -136,7 +136,7 @@ struct TasksView: View {
         .pickerStyle(.segmented)
         .padding(.horizontal, 16)
         .padding(.vertical, 8)
-        .background(.bar)
+        .glassBar()
     }
 
     @ViewBuilder private var content: some View {

--- a/apps/ios/CovenCave/CovenCave/Views/TerminalView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TerminalView.swift
@@ -68,7 +68,7 @@ struct TerminalView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
         }
-        .background(.bar)
+        .glassBar()
     }
 
     /// `label` is the compact glyph shown on the key; `accessibility` spells it

--- a/apps/ios/CovenCave/CovenCave/Views/ToastView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ToastView.swift
@@ -18,7 +18,7 @@ struct ToastView: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 11)
-        .background(.regularMaterial, in: Capsule())
+        .glassFill(.elevated, in: Capsule())
         .overlay(Capsule().strokeBorder(tint.opacity(0.35), lineWidth: 1))
         .shadow(color: .black.opacity(0.12), radius: 12, y: 4)
         .padding(.horizontal, 24)


### PR DESCRIPTION
## What
**PR 2 of the iOS glassmorphic overhaul** (builds on #1770). Routes every remaining translucent surface through the shared, theme-aware glass system so the whole app frosts consistently and tracks the desktop palette — with the same Reduce Transparency / Increase Contrast fallbacks — instead of bare neutral system materials (`.regularMaterial` / `.thinMaterial` / `.background(.bar)`).

## `Theme/Glass.swift` additions
- **`glassBar(divider:)`** — faithful, theme-aware replacement for `.background(.bar)`: a contained full-width frost (no safe-area bleed, no boxed border) with a single hairline divider; solid themed surface under Reduce Transparency.
- **`glassFill(_:in:)`** — the frost *only* (material + tint + accent, no border/shadow), for surfaces that bring their own ring/shadow or bare inline chips that shouldn't gain depth.
- `glassLayers`/`GlassBackground` gain `border`/`shadow` flags to back the above.

## Applied
- **`.background(.bar)` → `.glassBar()`** across 8 bars: Reading filter, Tasks/Developer segmented pickers, CodeEditor status banner, Terminal key row, ChatView composer, and the Familiar/Reminders bulk-selection toolbars.
- **Overlay materials → `glassFill`**: `ToastView` (keeps its status-tint ring + shadow), `SlashCommandMenu` (keeps its separator stroke + shadow), and the circular action chips in `TaskDetailView`, `ChatView`, and `MessageBubble`.

## Verification
- `xcodebuild` **BUILD SUCCEEDED** (iPhone 16 Pro sim).
- All `scripts/ios-*.test.mjs` + `mobile-*.test.mjs` source-text tests pass; no test pinned the `.bar`/material literals that changed.
- Visual matrix (themes, Reduce Transparency, Increase Contrast) recommended on a desktop-connected device.

## Up next (PR 3)
Phase D — judicious Dynamic Type sweep of the remaining fixed `.font(.system(size:))` text/icon sites + a reduce-motion audit of new transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)