### PR TITLE
feat(ios): familiar presence dots on the chat list & header

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Theme/Theme.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/Theme.swift
@@ -99,6 +99,32 @@ extension View {
     func themedSheetBackground() -> some View { modifier(ThemedSheetBackground()) }
 }
 
+/// A familiar's live presence, mirroring the desktop `statusMeta()` mapping so
+/// the iOS dots match the colours the daemon publishes.
+enum Presence {
+    /// Dot colour for a daemon status string, or nil when there's nothing
+    /// meaningful to show (no status reported).
+    static func color(for status: String?) -> Color? {
+        switch status?.lowercased() {
+        case "active", "online": return Color(hex: "#4ade80")   // green
+        case "idle": return Color(hex: "#60a5fa")               // blue
+        case "busy", "running": return Color(hex: "#fbbf24")    // amber
+        case "offline": return Color(hex: "#8a8a8e")            // gray
+        case .some(let s) where !s.isEmpty: return Color(hex: "#8a8a8e")
+        default: return nil
+        }
+    }
+
+    /// Whether the status reads as "actively doing something" (drives a subtle
+    /// pulse), matching the desktop's `pulse` flag.
+    static func isActive(_ status: String?) -> Bool {
+        switch status?.lowercased() {
+        case "active", "online", "busy", "running": return true
+        default: return false
+        }
+    }
+}
+
 extension Color {
     /// Parse a `#RRGGBB` / `#RRGGBBAA` hex string. Returns nil if unparseable.
     init?(hex: String?) {

--- a/apps/ios/CovenCave/CovenCave/Views/AvatarView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/AvatarView.swift
@@ -2,9 +2,14 @@ import SwiftUI
 
 /// Circular familiar avatar: remote image if available, else coloured initials.
 struct AvatarView: View {
+    @Environment(\.chrome) private var chrome
     let familiar: Familiar?
     var url: URL?
     var size: CGFloat = 44
+    /// Show a presence dot (online/idle/busy/offline) in the bottom-trailing
+    /// corner when the familiar reports a status. Opt-in so it only appears on
+    /// "who's around" surfaces (chat list, header), not every avatar.
+    var showStatus: Bool = false
 
     var body: some View {
         let color = Theme.color(for: familiar)
@@ -26,6 +31,19 @@ struct AvatarView: View {
         .frame(width: size, height: size)
         .clipShape(Circle())
         .overlay(Circle().strokeBorder(color.opacity(0.35), lineWidth: 1))
+        .overlay(alignment: .bottomTrailing) { statusDot }
+    }
+
+    @ViewBuilder private var statusDot: some View {
+        if showStatus, let dot = Presence.color(for: familiar?.status) {
+            Circle()
+                .fill(dot)
+                // Ring in the surrounding background colour so the dot reads as
+                // separate from the avatar on the themed floor.
+                .overlay(Circle().strokeBorder(chrome.bgBase, lineWidth: max(1.5, size * 0.06)))
+                .frame(width: size * 0.32, height: size * 0.32)
+                .offset(x: size * 0.04, y: size * 0.04)
+        }
     }
 
     private func initials(_ color: Color) -> some View {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -951,7 +951,7 @@ struct FamiliarPickerSheet: View {
                         HStack(spacing: 12) {
                             AvatarView(familiar: familiar,
                                        url: app.client?.avatarURL(for: familiar),
-                                       size: 40)
+                                       size: 40, showStatus: true)
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(familiar.displayName).font(.body).foregroundStyle(.primary)
                                 if let role = familiar.role, !role.isEmpty {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -373,7 +373,7 @@ struct FamiliarRow: View {
         HStack(spacing: 12) {
             AvatarView(familiar: familiar,
                        url: app.client?.avatarURL(for: familiar),
-                       size: 48)
+                       size: 48, showStatus: true)
             VStack(alignment: .leading, spacing: 3) {
                 Text(familiar.displayName).font(.headline).lineLimit(1)
                 if let role = familiar.role, !role.isEmpty {

--- a/apps/ios/CovenCave/CovenCave/Views/NewChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/NewChatView.swift
@@ -37,7 +37,7 @@ struct NewChatView: View {
                             HStack(spacing: 12) {
                                 AvatarView(familiar: familiar,
                                            url: app.client?.avatarURL(for: familiar),
-                                           size: 40)
+                                           size: 40, showStatus: true)
                                 VStack(alignment: .leading, spacing: 2) {
                                     Text(familiar.displayName).font(.body)
                                         .foregroundStyle(.primary)

--- a/scripts/ios-presence-dots.test.mjs
+++ b/scripts/ios-presence-dots.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (p) => readFile(new URL(`../apps/ios/CovenCave/CovenCave/${p}`, import.meta.url), "utf8");
+
+const theme = await read("Theme/Theme.swift");
+
+// Presence maps daemon status strings to the same colours the desktop's
+// statusMeta() uses, so the iOS dots match the web.
+assert.match(theme, /enum Presence \{/, "Theme should define a Presence helper");
+for (const [status, hex] of [
+  ["active", "#4ade80"],
+  ["idle", "#60a5fa"],
+  ["busy", "#fbbf24"],
+  ["offline", "#8a8a8e"],
+]) {
+  assert.match(theme, new RegExp(`"${status}"[\\s\\S]*?Color\\(hex: "${hex}"\\)`), `Presence should map ${status} → ${hex}`);
+}
+assert.match(theme, /static func color\(for status: String\?\) -> Color\?/, "Presence.color(for:) should exist");
+
+// AvatarView gains an opt-in presence dot.
+const avatar = await read("Views/AvatarView.swift");
+assert.match(avatar, /var showStatus: Bool = false/, "AvatarView should expose an opt-in showStatus flag");
+assert.match(
+  avatar,
+  /Presence\.color\(for: familiar\?\.status\)/,
+  "AvatarView should colour the dot from the familiar's status",
+);
+assert.match(avatar, /\.overlay\(alignment: \.bottomTrailing\) \{ statusDot \}/, "the dot sits bottom-trailing");
+
+// The 'who's around' surfaces enable the dot.
+for (const view of ["ChatsHomeView.swift", "ChatView.swift", "NewChatView.swift"]) {
+  const src = await read(`Views/${view}`);
+  assert.match(src, /showStatus: true/, `${view} should enable the presence dot`);
+}
+
+console.log("ios-presence-dots: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -530,6 +530,7 @@ export const SUITES = {
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/ios-theme.test.mjs",
     "scripts/ios-theme-list-background.test.mjs",
+    "scripts/ios-presence-dots.test.mjs",
     "scripts/ios-markdown-accent.test.mjs",
     "scripts/ios-message-forwarding.test.mjs",
     "scripts/ios-chat-thread-no-search.test.mjs",


### PR DESCRIPTION
Second UX improvement. The `Familiar.status` field (online/idle/busy/offline) comes down from `/api/familiars` but was **never shown** on iOS. Now it's a small presence dot.

- **`Presence` helper** (Theme.swift) maps the daemon status to the **same colours the desktop's `statusMeta()` uses**: active→green `#4ade80`, idle→blue `#60a5fa`, busy→amber `#fbbf24`, offline→gray; unknown/absent → no dot.
- **`AvatarView`** gains an opt-in `showStatus` flag — a ringed dot in the bottom-trailing corner (the ring is `bgBase` so it reads against the themed floor).
- Enabled on the **Chats familiar list**, the **chat header**, and the **New-chat picker**. Per-session rows and task assignees keep a plain avatar.

## Verified live (simulator)
With varied statuses injected, the dots render green / amber / blue / gray per status, ringed against the floor — matching the desktop colours.

`xcodebuild` (iPhone 16 Pro sim): **BUILD SUCCEEDED**. New `scripts/ios-presence-dots.test.mjs` (colour mapping + adoption) wired; `check:tests-wired` green (523 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)