### PR TITLE
feat(ios): Dynamic Type for toast/menu text + Reduce Motion gating

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -21,6 +21,7 @@ struct ChatView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.dismiss) private var dismiss
     @Environment(\.chrome) private var chrome
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Bindable var thread: ChatThread
     @AppStorage("cave.dev.section") private var devSectionRaw = DevSection.code.rawValue
     @State private var draft: String = ""
@@ -285,8 +286,8 @@ struct ChatView: View {
             }
             composerBar
         }
-        .animation(.snappy(duration: 0.18), value: showingSlashMenu)
-        .animation(.snappy(duration: 0.18), value: pendingImages.count)
+        .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: showingSlashMenu)
+        .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: pendingImages.count)
         .glassBar()
         // Live dictation streams its running transcript into the draft.
         .onAppear { dictation.onUpdate = { draft = $0 } }
@@ -428,9 +429,9 @@ struct ChatView: View {
                 }
             }
             .overlay(Capsule().strokeBorder(dictation.isRecording ? Color.red.opacity(0.5) : borderColor, lineWidth: 1))
-            .animation(.snappy(duration: 0.18), value: canSend)
-            .animation(.snappy(duration: 0.18), value: isCommand)
-            .animation(.snappy(duration: 0.18), value: dictation.isRecording)
+            .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: canSend)
+            .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: isCommand)
+            .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: dictation.isRecording)
         }
         .padding(.horizontal, 12)
         .padding(.top, 6)

--- a/apps/ios/CovenCave/CovenCave/Views/SlashCommandMenu.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SlashCommandMenu.swift
@@ -62,9 +62,9 @@ struct SlashCommandMenu: View {
     private var footer: some View {
         HStack(spacing: 4) {
             Image(systemName: "command")
-                .font(.system(size: 9))
+                .font(.caption2)
             Text("Tap to run · type to filter")
-                .font(.system(size: 10))
+                .font(.caption2)
         }
         .foregroundStyle(.tertiary)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/apps/ios/CovenCave/CovenCave/Views/ToastView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ToastView.swift
@@ -9,7 +9,7 @@ struct ToastView: View {
     var body: some View {
         HStack(spacing: 9) {
             Image(systemName: message.systemImage)
-                .font(.system(size: 15, weight: .semibold))
+                .font(.subheadline.weight(.semibold))
                 .foregroundStyle(tint)
             Text(message.text)
                 .font(.subheadline.weight(.medium))
@@ -37,20 +37,22 @@ struct ToastView: View {
 private struct ToastModifier: ViewModifier {
     @Binding var message: ToastMessage?
     @State private var dismissTask: Task<Void, Never>?
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     func body(content: Content) -> some View {
         content.overlay(alignment: .top) {
             if let message {
                 ToastView(message: message)
                     .padding(.top, 6)
-                    .transition(.move(edge: .top).combined(with: .opacity))
+                    // Slide in by default; fade only when Reduce Motion is on.
+                    .transition(reduceMotion ? .opacity : .move(edge: .top).combined(with: .opacity))
                     .id(message.id)
                     .onAppear { scheduleDismiss(message.id) }
                     // Tap to dismiss immediately.
                     .onTapGesture { withAnimation(.snappy) { self.message = nil } }
             }
         }
-        .animation(.snappy(duration: 0.28), value: message)
+        .animation(reduceMotion ? nil : .snappy(duration: 0.28), value: message)
     }
 
     private func scheduleDismiss(_ id: UUID) {


### PR DESCRIPTION
## What
**PR 3 (final) of the iOS glass + accessibility overhaul** (after #1770, #1772). Completes the accessibility commitment.

After auditing **all 20** fixed `.font(.system(size:))` sites, the honest finding is that **most are correctly fixed** — SF Symbol glyphs inside fixed-size frames or sized relative to their container (avatar initials via `size * 0.4`, notification count badges, zoom controls, circular chip icons). Forcing Dynamic Type on those would distort layout, so they're left as-is. This PR converts only the **genuine text** sites and gates decorative motion.

## Changes
- **`ToastView`** — the leading icon → `.subheadline` (scales with the message text it sits beside); the slide-in transition + snappy animation now respect **Reduce Motion** (fade only, no slide).
- **`SlashCommandMenu`** footer — the `command` glyph + hint text → `.caption2` (scalable).
- **`ChatView`** — the five composer `.snappy(0.18)` animations (slash menu, attachments, send/command/dictation state) collapse to no animation under **Reduce Motion**; they're decorative feedback, not essential to understanding state.

## Verification
- `xcodebuild` **BUILD SUCCEEDED** (iPhone 16 Pro sim).
- All `ios-*` / `mobile-*` source-text tests pass.

## Overhaul complete
With #1770 (foundation + Chats), #1772 (overlays + chrome), and this PR, every translucent surface on iOS now uses the shared, accent-infused glass system that tracks the selected appearance and degrades gracefully under Reduce Transparency / Increase Contrast / Reduce Motion, with VoiceOver-grouped rows and Dynamic-Type-aware text where it belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)