### PR TITLE
feat(ios): swipe-to-reply — quote a message into the composer

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -25,6 +25,8 @@ struct ChatView: View {
     @Bindable var thread: ChatThread
     @AppStorage("cave.dev.section") private var devSectionRaw = DevSection.code.rawValue
     @State private var draft: String = ""
+    /// The message being quoted in the next send, if any (swipe-to-reply).
+    @State private var replyingTo: DisplayMessage?
     @FocusState private var composerFocused: Bool
     @State private var showCommands = false
     @State private var showFamiliarPicker = false
@@ -201,7 +203,8 @@ struct ChatView: View {
                                       onSuggestion: { sendSuggestion($0) },
                                       onOpenReader: { openReader(text: $0, familiar: message.familiarId.flatMap(app.familiar)) },
                                       onForward: { beginForward($0) },
-                                      onRetry: canRetry(message) ? { retryAssistant(message) } : nil)
+                                      onRetry: canRetry(message) ? { retryAssistant(message) } : nil,
+                                      onReply: { beginReply($0) })
                         .id(message.id)
                     }
                     Color.clear.frame(height: 1).id("bottom")
@@ -284,10 +287,14 @@ struct ChatView: View {
             if !pendingImages.isEmpty {
                 attachmentPreviews
             }
+            if let replyingTo {
+                replyBanner(replyingTo)
+            }
             composerBar
         }
         .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: showingSlashMenu)
         .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: pendingImages.count)
+        .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: replyingTo?.id)
         .glassBar()
         // Live dictation streams its running transcript into the draft.
         .onAppear { dictation.onUpdate = { draft = $0 } }
@@ -473,10 +480,14 @@ struct ChatView: View {
                 CaveClient.ChatAttachment(name: $0.name, mimeType: $0.mimeType, dataUrl: $0.dataUrl)
             }
             guard !text.isEmpty || !attachments.isEmpty else { return }
+            // Prepend the quoted message when replying, so the familiar sees
+            // exactly what's being answered.
+            let outgoing = replyingTo.map { replyQuote($0) + text } ?? text
             draft = ""
             pendingImages = []
+            replyingTo = nil
             Haptics.tap()
-            thread.send(text, attachments: attachments, client: client) { app.touch(thread) }
+            thread.send(outgoing, attachments: attachments, client: client) { app.touch(thread) }
         }
     }
 
@@ -770,6 +781,57 @@ struct ChatView: View {
     private func beginForward(_ message: DisplayMessage) {
         guard !message.streaming else { return }
         forwardingMessage = message
+    }
+
+    // MARK: - Reply (quote a message into the next send)
+
+    private func beginReply(_ message: DisplayMessage) {
+        replyingTo = message
+        composerFocused = true
+    }
+
+    /// Display name for a message's author, used in the reply banner/quote.
+    private func replyAuthor(_ message: DisplayMessage) -> String {
+        switch message.role {
+        case .user: return "You"
+        case .system: return "System"
+        case .assistant: return message.familiarId.flatMap(app.familiar)?.displayName ?? "Familiar"
+        }
+    }
+
+    /// A Markdown quote of the replied-to message, prepended to the outgoing
+    /// prompt so the familiar sees what's being answered.
+    private func replyQuote(_ message: DisplayMessage) -> String {
+        let snippet = String(message.text.trimmingCharacters(in: .whitespacesAndNewlines).prefix(400))
+        let quoted = snippet
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { "> \($0)" }
+            .joined(separator: "\n")
+        return "Replying to \(replyAuthor(message)):\n\(quoted)\n\n"
+    }
+
+    @ViewBuilder private func replyBanner(_ message: DisplayMessage) -> some View {
+        HStack(spacing: 10) {
+            Rectangle().fill(chrome.accent).frame(width: 3).cornerRadius(1.5)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Replying to \(replyAuthor(message))")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(chrome.accent)
+                Text(message.text.trimmingCharacters(in: .whitespacesAndNewlines))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 4)
+            Button {
+                withAnimation(.snappy(duration: 0.18)) { replyingTo = nil }
+            } label: {
+                Image(systemName: "xmark.circle.fill").foregroundStyle(.tertiary)
+            }
+            .accessibilityLabel("Cancel reply")
+        }
+        .padding(.horizontal, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func forward(_ message: DisplayMessage, to familiar: Familiar) {

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -12,6 +12,12 @@ struct MessageBubble: View {
     var onForward: ((DisplayMessage) -> Void)? = nil
     /// Regenerate this reply (assistant messages only); nil hides the action.
     var onRetry: (() -> Void)? = nil
+    /// Quote this message into the composer — swipe the bubble right, or use the
+    /// long-press menu. nil hides the action.
+    var onReply: ((DisplayMessage) -> Void)? = nil
+
+    /// Horizontal offset while swiping right to reply.
+    @State private var replyDrag: CGFloat = 0
 
     // The bubble's WebView is transparent over a system-coloured bubble, so its
     // prose must follow the app's light/dark appearance (the WebView doesn't
@@ -57,6 +63,14 @@ struct MessageBubble: View {
                 Label("Open in Reader", systemImage: "text.page")
             }
         }
+        if canReply {
+            Button {
+                fireReply()
+                Haptics.tap()
+            } label: {
+                Label("Reply", systemImage: "arrowshape.turn.up.left")
+            }
+        }
         if canForward {
             Button {
                 var forwarded = message
@@ -100,12 +114,52 @@ struct MessageBubble: View {
         !message.streaming && !parsed.visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && onForward != nil
     }
 
+    private var canReply: Bool {
+        onReply != nil && !message.streaming
+            && !parsed.visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// Swipe a bubble to the right to quote it into the composer. Runs alongside
+    /// the scroll view's pan (simultaneousGesture) and only tracks clearly
+    /// horizontal drags, so vertical scrolling is unaffected.
+    private var replySwipe: some Gesture {
+        DragGesture(minimumDistance: 24)
+            .onChanged { value in
+                guard canReply, value.translation.width > 0,
+                      abs(value.translation.width) > abs(value.translation.height) else { return }
+                replyDrag = min(value.translation.width, 64)
+            }
+            .onEnded { _ in
+                if replyDrag > 48 { Haptics.tap(); fireReply() }
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) { replyDrag = 0 }
+            }
+    }
+
+    private func fireReply() {
+        var quoted = message
+        quoted.text = parsed.visible
+        onReply?(quoted)
+    }
+
     var body: some View {
-        if message.role == .system {
-            systemNote
-        } else {
-            chatBubble
+        Group {
+            if message.role == .system {
+                systemNote
+            } else {
+                chatBubble
+            }
         }
+        .offset(x: replyDrag)
+        .overlay(alignment: .leading) {
+            if replyDrag > 6 {
+                Image(systemName: "arrowshape.turn.up.left.fill")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .opacity(Double(min(replyDrag / 50, 1)))
+                    .padding(.leading, 14)
+            }
+        }
+        .simultaneousGesture(replySwipe)
     }
 
     /// Inline slash-command output — a subtle monospaced card so it reads as

--- a/scripts/ios-swipe-reply.test.mjs
+++ b/scripts/ios-swipe-reply.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (p) => readFile(new URL(`../apps/ios/CovenCave/CovenCave/Views/${p}`, import.meta.url), "utf8");
+
+const bubble = await read("MessageBubble.swift");
+// MessageBubble exposes a reply closure, a right-swipe gesture, and a menu item.
+assert.match(bubble, /var onReply: \(\(DisplayMessage\) -> Void\)\? = nil/, "MessageBubble should expose onReply");
+assert.match(bubble, /private var replySwipe: some Gesture/, "MessageBubble should define the reply swipe gesture");
+assert.match(bubble, /DragGesture\(minimumDistance: 24\)/, "reply swipe should be a horizontal drag");
+assert.match(
+  bubble,
+  /abs\(value\.translation\.width\) > abs\(value\.translation\.height\)/,
+  "the swipe should only track clearly-horizontal drags (so scrolling is unaffected)",
+);
+assert.match(bubble, /\.simultaneousGesture\(replySwipe\)/, "the swipe runs alongside the scroll view");
+assert.match(bubble, /Label\("Reply", systemImage: "arrowshape\.turn\.up\.left"\)/, "Reply should also be in the context menu");
+
+const chat = await read("ChatView.swift");
+// ChatView holds the reply state, shows a banner, and prepends the quote.
+assert.match(chat, /@State private var replyingTo: DisplayMessage\?/, "ChatView should track the message being replied to");
+assert.match(chat, /onReply: \{ beginReply\(\$0\) \}/, "ChatView should wire the bubble's onReply");
+assert.match(chat, /func replyBanner\(_ message: DisplayMessage\)/, "ChatView should render a reply banner");
+assert.match(
+  chat,
+  /let outgoing = replyingTo\.map \{ replyQuote\(\$0\) \+ text \} \?\? text/,
+  "send() should prepend the quote when replying",
+);
+assert.match(chat, /"Replying to \\\(replyAuthor\(message\)\):\\n\\\(quoted\)\\n\\n"/, "replyQuote should build a Markdown quote");
+
+console.log("ios-swipe-reply: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -531,6 +531,7 @@ export const SUITES = {
     "scripts/ios-theme.test.mjs",
     "scripts/ios-theme-list-background.test.mjs",
     "scripts/ios-presence-dots.test.mjs",
+    "scripts/ios-swipe-reply.test.mjs",
     "scripts/ios-markdown-accent.test.mjs",
     "scripts/ios-message-forwarding.test.mjs",
     "scripts/ios-chat-thread-no-search.test.mjs",


### PR DESCRIPTION
Third UX improvement. Telegram-style **reply**: swipe a message bubble right (or long-press → **Reply**) to quote it into the composer.

- A banner above the composer shows **who/what you're answering** (accent quote-bar + author + one-line snippet) with a **cancel ✕**.
- On send, the quote is **prepended** to the prompt as Markdown (`Replying to <who>:\n> …`) so the familiar sees exactly what's being answered.
- The swipe is a horizontal `DragGesture` run **simultaneously** with the scroll view and gated on `|Δx| > |Δy|`, so vertical scrolling is unaffected. Reply is also in the long-press menu as a reliable fallback.

## Verified live (simulator)
The reply banner renders above the composer with the accent quote bar, author ("Replying to Nova"), truncated snippet, and cancel button.

`xcodebuild` (iPhone 16 Pro sim): **BUILD SUCCEEDED**. New `scripts/ios-swipe-reply.test.mjs` wired; `check:tests-wired` green (524 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)