### PR TITLE
feat(ios): themed glass on sheets, cards & connection surface (depth pass 1)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -967,6 +967,7 @@ struct FamiliarPickerSheet: View {
                     .buttonStyle(.plain)
                 }
             }
+            .themedListBackground()
             .navigationTitle(title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -975,5 +976,6 @@ struct FamiliarPickerSheet: View {
                 }
             }
         }
+        .themedSheetBackground()
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ConnectionView: View {
     @Environment(AppModel.self) private var app
+    @Environment(\.chrome) private var chrome
     @State private var host: String = ""
     @State private var busy = false
     @FocusState private var focused: Bool
@@ -20,7 +21,8 @@ struct ConnectionView: View {
                             .keyboardType(.URL)
                             .focused($focused)
                             .padding(12)
-                            .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12))
+                            .glass(.control, cornerRadius: 12)
+                            .accentGlow(active: focused)
                         Text("Your desktop’s Tailscale MagicDNS name or 100.x address. Found in the Cave desktop app under “Open on phone”.")
                             .font(.footnote).foregroundStyle(.secondary)
                     }
@@ -46,6 +48,7 @@ struct ConnectionView: View {
                 }
                 .padding(24)
             }
+            .background(chrome.bgBase.ignoresSafeArea())
             .navigationTitle("Coven Cave")
             .onAppear {
                 host = app.connection?.host ?? ""
@@ -73,7 +76,7 @@ struct ConnectionView: View {
                 .font(.caption).foregroundStyle(.secondary)
         }
         .padding(12)
-        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12))
+        .glass(.raised, cornerRadius: 12)
     }
 
     private func connect() {

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -123,8 +123,7 @@ struct MessageBubble: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.horizontal, 14).padding(.vertical, 10)
-        .background(Color(.secondarySystemBackground).opacity(0.6),
-                    in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .glassFill(.raised, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .strokeBorder(Color(.separator).opacity(0.5), lineWidth: 1)

--- a/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
@@ -136,7 +136,7 @@ struct TaskDetailView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)
-        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .glass(.raised, cornerRadius: 14)
     }
 
     private func chatSubtitle(_ thread: ChatThread) -> String {
@@ -195,7 +195,7 @@ struct TaskDetailView: View {
             Spacer()
         }
         .padding(14)
-        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .glass(.raised, cornerRadius: 14)
     }
 
     private var stepsCard: some View {
@@ -247,7 +247,7 @@ struct TaskDetailView: View {
             addStepRow
         }
         .padding(16)
-        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .glass(.raised, cornerRadius: 14)
     }
 
     private var addStepRow: some View {
@@ -321,7 +321,7 @@ struct TaskDetailView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)
-        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .glass(.raised, cornerRadius: 14)
     }
 
     private var labelsRow: some View {
@@ -358,7 +358,7 @@ struct TaskDetailView: View {
             dateRow("Due", value: live.endDate) { await app.setTaskDates(live, start: live.startDate, end: $0) }
         }
         .padding(16)
-        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .glass(.raised, cornerRadius: 14)
     }
 
     private func dateRow(_ label: String, value: String?,
@@ -407,6 +407,7 @@ struct TaskDetailView: View {
 /// actually changes from what was passed in.
 struct NotesEditorView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.chrome) private var chrome
     let initialText: String
     let onSave: (String) -> Void
 
@@ -423,6 +424,8 @@ struct NotesEditorView: View {
         NavigationStack {
             TextEditor(text: $text)
                 .font(.body)
+                .scrollContentBackground(.hidden)
+                .background(chrome.bgBase)
                 .padding(16)
                 .focused($focused)
                 .navigationTitle("Notes")
@@ -438,6 +441,7 @@ struct NotesEditorView: View {
                 }
                 .onAppear { focused = true }
         }
+        .themedSheetBackground()
     }
 }
 


### PR DESCRIPTION
## What
Comprehensive **depth pass (1 of 2)** completing the full liquid-glass redesign. Surfaces that still used opaque system fills (`Color(.secondarySystemBackground)`) or untyped sheet backgrounds now use the shared glass system / `chrome` palette, so they gain layered depth and track the selected appearance.

- **ConnectionView** — themed `bgBase` background; address field → `glass(.control)` with a focus accent-glow; trust-note card → `glass(.raised)`.
- **TaskDetailView** — the 5 detail cards (chat link, assignee, steps, notes, schedule) → `glass(.raised)`; the **NotesEditor** sheet themes its `TextEditor` (`bgBase`) and adds `.themedSheetBackground()`.
- **MessageBubble** system note → `glassFill(.raised)` (keeps its existing hairline stroke — no double border).
- **FamiliarPickerSheet** → `.themedListBackground()` + `.themedSheetBackground()`.

### Deliberately skipped
**ResponseReaderView** — it's a self-themed reader (its own dark/light/sepia `ReaderTheme`); chrome theming would fight its background.

## Verification
- `xcodebuild` **BUILD SUCCEEDED** (iPhone 16 Pro sim).
- All `ios-*` / `mobile-*` source-text tests pass.

## Up next (depth pass 2)
Replace remaining `Color(.system*)`/`tertiarySystemFill` chips & buttons with glass/chrome: ReadingView filter chips, TerminalView keys, GitHubView comment cards/badges, ChatView composer buttons, ChatModelControl chip, AvatarView border, CodeEditorView editor bg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)