### PR TITLE
feat(ios): unread activity badges on the chat list

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -133,11 +133,16 @@ final class AppModel {
         return CaveClient(connection: connection)
     }
 
+    /// familiarId → when its chats were last viewed. A familiar reads as
+    /// "unread" when its latest activity is newer than this. Persisted.
+    var familiarViews: [String: Date] = [:]
+
     init() {
         connection = CaveConnection.load()
         loadThreads()
         loadCardLinks()
         loadFamiliarOrder()
+        loadFamiliarViews()
         if connection != nil { connectionState = .checking }
     }
 
@@ -554,10 +559,40 @@ final class AppModel {
         guard let client else { return }
         do {
             familiars = applyFamiliarOrder(try await client.familiars())
+            seedFamiliarViews(familiars.map(\.id))
             familiarsError = nil
         } catch {
             familiarsError = error.localizedDescription
         }
+    }
+
+    // MARK: - Unread tracking
+
+    /// True when a familiar has activity newer than the last time its chats were
+    /// viewed. New familiars are seeded as "seen now" (see `seedFamiliarViews`),
+    /// so only genuinely new activity — e.g. a reply that arrived on the desktop
+    /// — flags as unread, not the entire backlog on first launch.
+    func hasUnread(_ familiarId: String) -> Bool {
+        guard let seen = familiarViews[familiarId],
+              let activity = lastActivity(for: familiarId) else { return false }
+        return activity > seen
+    }
+
+    /// Mark a familiar's chats as read (call when opening them).
+    func markFamiliarViewed(_ ids: [String]) {
+        guard !ids.isEmpty else { return }
+        let now = Date()
+        for id in ids { familiarViews[id] = now }
+        persistFamiliarViews()
+    }
+
+    /// Baseline any not-yet-tracked familiar as seen "now" so existing history
+    /// isn't all flagged unread; only later activity counts.
+    private func seedFamiliarViews(_ ids: [String]) {
+        let now = Date()
+        var changed = false
+        for id in ids where familiarViews[id] == nil { familiarViews[id] = now; changed = true }
+        if changed { persistFamiliarViews() }
     }
 
     /// Drag-reorder familiars in the Chats tab; persists the new order.
@@ -1074,5 +1109,28 @@ final class AppModel {
             return
         }
         familiarOrder = order
+    }
+
+    private var familiarViewsFileURL: URL {
+        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("cave-familiar-views.json")
+    }
+
+    private func persistFamiliarViews() {
+        do {
+            let data = try JSONEncoder().encode(familiarViews)
+            try data.write(to: familiarViewsFileURL, options: .atomic)
+        } catch {
+            // Non-fatal: best-effort persistence.
+        }
+    }
+
+    private func loadFamiliarViews() {
+        guard let data = try? Data(contentsOf: familiarViewsFileURL),
+              let views = try? JSONDecoder().decode([String: Date].self, from: data) else {
+            return
+        }
+        familiarViews = views
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -167,6 +167,8 @@ struct ChatView: View {
             if draft.isEmpty, let saved = UserDefaults.standard.string(forKey: draftKey) {
                 draft = saved
             }
+            // Opening the chat clears the unread badge for its familiar(s).
+            app.markFamiliarViewed(thread.familiarIds)
         }
         // Persist every edit per-thread; send() clears the draft, which removes
         // the stored copy here so a sent message leaves nothing behind.

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -367,6 +367,7 @@ struct ChatsHomeView: View {
 /// of how many conversations they have and when they were last active.
 struct FamiliarRow: View {
     @Environment(AppModel.self) private var app
+    @Environment(\.chrome) private var chrome
     let familiar: Familiar
 
     var body: some View {
@@ -375,7 +376,13 @@ struct FamiliarRow: View {
                        url: app.client?.avatarURL(for: familiar),
                        size: 48, showStatus: true)
             VStack(alignment: .leading, spacing: 3) {
-                Text(familiar.displayName).font(.headline).lineLimit(1)
+                HStack(spacing: 6) {
+                    // Unread: activity newer than the last time you opened it.
+                    if app.hasUnread(familiar.id) {
+                        Circle().fill(chrome.accent).frame(width: 7, height: 7)
+                    }
+                    Text(familiar.displayName).font(.headline).lineLimit(1)
+                }
                 if let role = familiar.role, !role.isEmpty {
                     Text(role).font(.subheadline).foregroundStyle(.secondary).lineLimit(1)
                 }
@@ -402,6 +409,7 @@ struct FamiliarRow: View {
     /// One spoken summary of the row: name, role, chat count, last activity.
     private var accessibilityText: String {
         var parts: [String] = [familiar.displayName]
+        if app.hasUnread(familiar.id) { parts.append("unread") }
         if let role = familiar.role, !role.isEmpty { parts.append(role) }
         let count = app.threadCount(for: familiar.id)
         parts.append(count == 1 ? "1 chat" : "\(count) chats")

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -91,6 +91,7 @@ struct FamiliarThreadsView: View {
         }
         .refreshable { await app.loadSessions() }
         .task { await app.loadSessions() }
+        .onAppear { app.markFamiliarViewed([familiar.id]) }
         .safeAreaInset(edge: .bottom) {
             if selectMode {
                 HStack {

--- a/scripts/ios-unread-badges.test.mjs
+++ b/scripts/ios-unread-badges.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (p) => readFile(new URL(`../apps/ios/CovenCave/CovenCave/${p}`, import.meta.url), "utf8");
+
+const model = await read("State/AppModel.swift");
+// Unread = activity newer than last viewed; new familiars seeded so the backlog
+// isn't all flagged on first launch.
+assert.match(model, /var familiarViews: \[String: Date\] = \[:\]/, "AppModel should track per-familiar last-viewed times");
+assert.match(
+  model,
+  /func hasUnread\(_ familiarId: String\) -> Bool \{[\s\S]*lastActivity\(for: familiarId\)[\s\S]*activity > seen/,
+  "hasUnread should compare lastActivity against the seen time",
+);
+assert.match(model, /func markFamiliarViewed\(_ ids: \[String\]\)/, "AppModel should expose markFamiliarViewed");
+assert.match(model, /private func seedFamiliarViews\(_ ids: \[String\]\)/, "AppModel should seed new familiars as seen");
+assert.match(model, /seedFamiliarViews\(familiars\.map\(\\\.id\)\)/, "loadFamiliars should seed views");
+assert.match(model, /loadFamiliarViews\(\)/, "init should load persisted views");
+assert.match(model, /cave-familiar-views\.json/, "views should persist to disk");
+
+// Opening a chat or a familiar's threads marks it read.
+const chat = await read("Views/ChatView.swift");
+assert.match(chat, /app\.markFamiliarViewed\(thread\.familiarIds\)/, "opening a chat marks its familiars read");
+const threads = await read("Views/FamiliarThreadsView.swift");
+assert.match(threads, /app\.markFamiliarViewed\(\[familiar\.id\]\)/, "opening a familiar's threads marks it read");
+
+// The Chats row shows an accent unread dot.
+const home = await read("Views/ChatsHomeView.swift");
+assert.match(
+  home,
+  /if app\.hasUnread\(familiar\.id\) \{\s*Circle\(\)\.fill\(chrome\.accent\)/,
+  "FamiliarRow should show an accent unread dot",
+);
+assert.match(home, /if app\.hasUnread\(familiar\.id\) \{ parts\.append\("unread"\) \}/, "VoiceOver should announce unread");
+
+console.log("ios-unread-badges: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -532,6 +532,7 @@ export const SUITES = {
     "scripts/ios-theme-list-background.test.mjs",
     "scripts/ios-presence-dots.test.mjs",
     "scripts/ios-swipe-reply.test.mjs",
+    "scripts/ios-unread-badges.test.mjs",
     "scripts/ios-markdown-accent.test.mjs",
     "scripts/ios-message-forwarding.test.mjs",
     "scripts/ios-chat-thread-no-search.test.mjs",


### PR DESCRIPTION
Fourth UX improvement. Threads sort by recency, but nothing flagged a familiar that had **new activity since you last looked**. Now an accent dot does.

- **AppModel**: `familiarViews [id: Date]` (persisted to `cave-familiar-views.json`), `hasUnread(_:)`, `markFamiliarViewed(_:)`, and `seedFamiliarViews` — new familiars are baselined as "seen now", so the backlog isn't all flagged on first launch; only **later** activity (e.g. a reply that arrived on the desktop) counts as unread.
- Opening a chat (`ChatView`) or a familiar's threads (`FamiliarThreadsView`) **marks it read**.
- **`FamiliarRow`** shows an accent dot before the name; VoiceOver announces "unread".

## Verified live (simulator)
With unread forced on alternating familiars, the accent dots appear before the names of the unread ones and not the others — distinct from the avatar presence dot.

`xcodebuild` (iPhone 16 Pro sim): **BUILD SUCCEEDED**. New `scripts/ios-unread-badges.test.mjs` wired; `check:tests-wired` green (525 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)