### PR TITLE
feat(a11y): add skip-to-content link to the app shell

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -413,6 +413,39 @@ select {
   outline-offset: calc(-1 * var(--ring-width));
 }
 
+/* Skip-to-content link: off-screen until it receives keyboard focus, then it
+   slides into the top-left so the first Tab on any surface reaches it. */
+.skip-link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+  margin: 8px;
+  padding: 8px 14px;
+  border-radius: 8px;
+  background: var(--bg-elevated, var(--background));
+  color: var(--fg-base, var(--foreground));
+  border: 1px solid var(--ring-focus);
+  font-size: 13px;
+  font-weight: 600;
+  box-shadow: 0 4px 16px rgb(0 0 0 / 0.25);
+  transform: translateY(-150%);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 120ms ease, opacity 120ms ease;
+}
+.skip-link:focus,
+.skip-link:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 2px;
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+@media (prefers-reduced-motion: reduce) {
+  .skip-link { transition: none; }
+}
+
 /* Bulk-select rows expose role="checkbox" in select mode; give the keyboard
    focus an inset ring without changing their pinned className strings. */
 tr[role="checkbox"]:focus { outline: none; }

--- a/src/components/a11y-audit-fixes.test.ts
+++ b/src/components/a11y-audit-fixes.test.ts
@@ -51,3 +51,13 @@ test("calendar urgency dots carry a text alternative", async () => {
   assert.match(src, /role="img" aria-label=\{urgencyLabel\(item\)\}/);
   assert.match(src, /role="img" aria-label=\{urgencyLabel\(ev\.item\)\}/);
 });
+
+test("shell exposes a skip-to-content link targeting the main landmark", async () => {
+  const shell = await read("./shell.tsx");
+  assert.match(shell, /<a className="skip-link" href="#shell-main-content">Skip to main content<\/a>/);
+  assert.match(shell, /<main className="shell-detail" id="shell-main-content" tabIndex=\{-1\}/);
+  const css = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
+  assert.match(css, /\.skip-link\s*\{[\s\S]*?position:\s*absolute/);
+  // The link must reveal itself on focus, not stay permanently off-screen.
+  assert.match(css, /\.skip-link:focus[\s\S]*?transform:\s*translateY\(0\)/);
+});

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -477,7 +477,7 @@ function ShellInner({
         </>
       )}
       <Panel id="detail" className="shell-detail-panel">
-        <main className="shell-detail" ref={detailElRef}>
+        <main className="shell-detail" id="shell-main-content" tabIndex={-1} ref={detailElRef}>
           <UpdateBannerTrigger />
           <ShellBannerStrip />
           {detail}
@@ -600,6 +600,9 @@ function ShellInner({
       style={shellFrameStyle}
       data-settled={settled ? "" : undefined}
     >
+      {/* Keyboard/SR users can jump straight past the chrome to the active
+          surface. Visually hidden until focused (see .skip-link in globals). */}
+      <a className="skip-link" href="#shell-main-content">Skip to main content</a>
       <div className="shell-top">
         {navToggle}
         <div className="shell-top__bar">{renderedTopBar}</div>


### PR DESCRIPTION
Closes out the accessibility audit with a skip-to-content link.

## Problem
Keyboard and screen-reader users had no way to bypass the nav rail, top bar, and list pane — the first Tab on every surface landed deep inside the chrome.

## Fix
- Adds a **"Skip to main content"** link as the first focusable element in the shell (`shell.tsx`).
- Visually hidden until focused, then slides in at the top-left (`.skip-link` in `globals.css`); honors `prefers-reduced-motion`.
- Activating it moves focus to the main surface: `<main id="shell-main-content" tabIndex={-1}>`.

## Landmark audit (no change needed)
- Shell already exposes `<main>` (`shell-detail`).
- Primary navigation already renders a `<nav>` (`sidebar-minimal.tsx`).

## Verified (production build, real window)
- Link is the **first focusable in source order**.
- Reveals on focus (on-screen, focus ring).
- Activation lands focus on the `<main>` element.
- Hidden again when unfocused.

(Note: the reveal only renders under real window focus — headless Chromium's `:focus` styling quirk — but `el.matches(':focus')` and the shipped CSS confirm correctness.)

## Tests
- Extends `a11y-audit-fixes.test.ts` (skip link markup + main id/tabindex + the off-screen→reveal CSS).
- `pnpm typecheck` clean; `app` suite (388 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)