### PR TITLE
feat(ios): quick actions on the Chats familiar rows

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -83,6 +83,12 @@ struct ChatsHomeView: View {
 
     /// Open a thread named by the `CAVE_OPEN_THREAD` launch env var. This is the
     /// same hook Phase 2 notification taps will use to jump straight into a chat.
+    /// Start a brand-new chat with a familiar and open it (familiar-row action).
+    private func startNewChat(with familiar: Familiar) {
+        let thread = app.startFreshThread(familiarIds: [familiar.id])
+        path.append(.thread(thread))
+    }
+
     private func openDeepLinkedThread() {
         guard path.isEmpty,
               let id = ProcessInfo.processInfo.environment["CAVE_OPEN_THREAD"],
@@ -128,6 +134,30 @@ struct ChatsHomeView: View {
                         FamiliarRow(familiar: familiar)
                     }
                     .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                    .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                        Button { startNewChat(with: familiar) } label: {
+                            Label("New chat", systemImage: "square.and.pencil")
+                        }
+                        .tint(.accentColor)
+                    }
+                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        if app.hasUnread(familiar.id) {
+                            Button { app.markFamiliarViewed([familiar.id]) } label: {
+                                Label("Mark read", systemImage: "checkmark")
+                            }
+                            .tint(.gray)
+                        }
+                    }
+                    .contextMenu {
+                        Button { startNewChat(with: familiar) } label: {
+                            Label("New chat", systemImage: "square.and.pencil")
+                        }
+                        if app.hasUnread(familiar.id) {
+                            Button { app.markFamiliarViewed([familiar.id]) } label: {
+                                Label("Mark all read", systemImage: "checkmark.circle")
+                            }
+                        }
+                    }
                 }
                 .onMove { source, destination in
                     app.moveFamiliar(fromOffsets: source, toOffset: destination)

--- a/scripts/ios-familiar-row-actions.test.mjs
+++ b/scripts/ios-familiar-row-actions.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const home = await readFile(
+  new URL("../apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift", import.meta.url),
+  "utf8",
+);
+
+// Familiar rows gain quick actions (parity with thread rows).
+assert.match(
+  home,
+  /private func startNewChat\(with familiar: Familiar\) \{[\s\S]*startFreshThread\(familiarIds: \[familiar\.id\]\)[\s\S]*path\.append\(\.thread\(thread\)\)/,
+  "startNewChat should open a fresh thread with the familiar",
+);
+
+// The familiar NavigationLink has a leading swipe to start a new chat…
+assert.match(
+  home,
+  /\.swipeActions\(edge: \.leading[\s\S]*startNewChat\(with: familiar\)[\s\S]*Label\("New chat"/,
+  "leading swipe should start a new chat",
+);
+// …a trailing swipe to mark read when unread…
+assert.match(
+  home,
+  /\.swipeActions\(edge: \.trailing[\s\S]*app\.hasUnread\(familiar\.id\)[\s\S]*markFamiliarViewed\(\[familiar\.id\]\)/,
+  "trailing swipe should mark read when unread",
+);
+// …and a context menu mirroring both.
+assert.match(
+  home,
+  /\.contextMenu \{[\s\S]*startNewChat\(with: familiar\)[\s\S]*Mark all read/,
+  "the context menu should offer New chat and Mark all read",
+);
+
+console.log("ios-familiar-row-actions: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -533,6 +533,7 @@ export const SUITES = {
     "scripts/ios-presence-dots.test.mjs",
     "scripts/ios-swipe-reply.test.mjs",
     "scripts/ios-unread-badges.test.mjs",
+    "scripts/ios-familiar-row-actions.test.mjs",
     "scripts/ios-markdown-accent.test.mjs",
     "scripts/ios-message-forwarding.test.mjs",
     "scripts/ios-chat-thread-no-search.test.mjs",


### PR DESCRIPTION
Fresh UX idea #1. Thread rows have rich swipe + long-press actions, but the **familiar rows** in the Chats list only navigated on tap. Added the obvious quick actions:

- **Leading swipe / context menu** → **New chat** (opens a fresh thread with the familiar).
- **Trailing swipe / context menu** (when unread) → **Mark (all) read** — clears the unread dot via `markFamiliarViewed`.

Reuses existing `AppModel` methods (`startFreshThread`, `markFamiliarViewed`, `hasUnread`) and mirrors the verified thread-row action pattern. Additive — no change to tap-to-open.

`xcodebuild` (iPhone 16 Pro sim): **BUILD SUCCEEDED**. New `scripts/ios-familiar-row-actions.test.mjs` wired; `check:tests-wired` green (526 files). (The swipe/menu UI is gesture-triggered, so not headlessly screenshot-able — same as the swipe-reply PR — but it mirrors the existing thread-row swipe/menu.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)