### PR TITLE
fix(ios): give failed chat replies a visible Retry button

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -122,6 +122,25 @@ final class ChatThread: Identifiable, Hashable {
         updatedAt = Date()
     }
 
+    /// Re-run a failed (or the latest) assistant reply in place: reset its bubble
+    /// to streaming and re-stream the SAME familiar with the prompt that produced
+    /// it. Re-streaming one familiar — not `send`'s fan-out — means a single
+    /// familiar's failure in a group is retried without re-firing the others, and
+    /// a 1:1 retry doesn't duplicate the user prompt. No-ops if the bubble has no
+    /// familiar or no preceding user prompt to replay.
+    func retry(_ messageId: String, client: CaveClient, onChange: @escaping () -> Void) {
+        guard let idx = messages.firstIndex(where: { $0.id == messageId }),
+              messages[idx].role == .assistant,
+              let familiarId = messages[idx].familiarId else { return }
+        let prompt = messages[..<idx].last(where: { $0.role == .user })?.text ?? ""
+        guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        mutate(messageId) { $0.text = ""; $0.isError = false; $0.streaming = true }
+        updatedAt = Date()
+        onChange()
+        Task { await self.stream(familiarId: familiarId, prompt: prompt,
+                                 into: messageId, client: client, onChange: onChange) }
+    }
+
     /// Append an inline system note (slash-command output) and return its id so
     /// callers can stream into it — e.g. `/daemon`'s "running…" → result.
     @discardableResult

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -499,28 +499,22 @@ struct ChatView: View {
         thread.send(text, client: client) { app.touch(thread) }
     }
 
-    /// Retry is offered on the latest, settled assistant reply of a 1:1 chat
-    /// (group fan-out would re-trigger every familiar, duplicating replies).
+    /// Retry is offered on a failed reply (any time — a flaky network shouldn't
+    /// leave a dead-end error bubble) or on the latest settled reply (regenerate).
+    /// `ChatThread.retry` re-streams a single familiar in place, so this is safe
+    /// for group threads too — only the one bubble's familiar re-runs.
     private func canRetry(_ message: DisplayMessage) -> Bool {
-        guard !thread.isGroup, message.role == .assistant, !message.streaming,
-              message.id == thread.messages.last?.id,
+        guard message.role == .assistant, !message.streaming,
               let idx = thread.messages.firstIndex(where: { $0.id == message.id }),
-              idx > 0, thread.messages[idx - 1].role == .user else { return false }
-        return true
+              thread.messages[..<idx].contains(where: { $0.role == .user }) else { return false }
+        return message.isError || message.id == thread.messages.last?.id
     }
 
-    /// Regenerate the latest reply: drop it and the user prompt that produced
-    /// it, then re-send that prompt (a clean replace, not a duplicate).
+    /// Re-run a reply in place (re-stream its familiar with the original prompt).
     private func retryAssistant(_ assistant: DisplayMessage) {
-        guard let client = app.client,
-              let idx = thread.messages.firstIndex(where: { $0.id == assistant.id }),
-              idx > 0, thread.messages[idx - 1].role == .user else { return }
-        let userMessage = thread.messages[idx - 1]
-        let prompt = userMessage.text
-        thread.deleteMessage(assistant.id)
-        thread.deleteMessage(userMessage.id)
+        guard let client = app.client else { return }
         Haptics.tap()
-        thread.send(prompt, client: client) { app.touch(thread) }
+        thread.retry(assistant.id, client: client) { app.touch(thread) }
     }
 
     /// Tap a row in the inline autocomplete. Commands that take arguments get

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -211,6 +211,21 @@ struct MessageBubble: View {
                         .contextMenu { messageActions }
                 }
 
+                // A failed reply gets a visible Retry button, not just the
+                // long-press menu — a flaky network shouldn't leave a dead-end
+                // red bubble. (Retry re-streams just this bubble's familiar.)
+                if !isUser, message.isError, let onRetry {
+                    Button(action: onRetry) {
+                        Label("Retry", systemImage: "arrow.clockwise")
+                            .font(.caption.weight(.semibold))
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .tint(.red)
+                    .padding(.leading, 2)
+                    .accessibilityLabel("Retry sending this message")
+                }
+
                 if !message.streaming {
                     Text(timestampText)
                         .font(.caption2)

--- a/scripts/ios-message-retry.test.mjs
+++ b/scripts/ios-message-retry.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// A failed reply should be recoverable with a VISIBLE Retry button (not just the
+// long-press menu), and retrying must re-stream only the failed bubble's familiar
+// — so it works in group chats and doesn't duplicate the user's prompt. This
+// test locks that wiring across the bubble, the view, and the thread model.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+
+const base = "apps/ios/CovenCave/CovenCave";
+const bubble = await read(`${base}/Views/MessageBubble.swift`);
+const view = await read(`${base}/Views/ChatView.swift`);
+const thread = await read(`${base}/State/ChatThread.swift`);
+
+// --- Visible retry button on error bubbles ----------------------------------
+assert.match(
+  bubble,
+  /if !isUser, message\.isError, let onRetry \{[\s\S]*?Label\("Retry", systemImage: "arrow\.clockwise"\)/,
+  "MessageBubble should render a visible Retry button on a failed (isError) reply",
+);
+assert.match(
+  bubble,
+  /\.accessibilityLabel\("Retry sending this message"\)/,
+  "the visible Retry button should carry an accessibility label",
+);
+
+// --- canRetry covers failures (any time) AND groups -------------------------
+// The guard starts on role/streaming — no `!thread.isGroup` exclusion any more
+// (retry is per-familiar in place, so it's safe for groups).
+assert.match(
+  view,
+  /func canRetry\(_ message: DisplayMessage\) -> Bool \{\s*guard message\.role == \.assistant, !message\.streaming,/,
+  "canRetry's guard should no longer exclude group threads",
+);
+assert.match(
+  view,
+  /func canRetry[\s\S]*?return message\.isError \|\| message\.id == thread\.messages\.last\?\.id/,
+  "canRetry should allow retrying a failed reply any time, or the latest reply",
+);
+// Retry routes through the in-place thread.retry (not delete-and-resend).
+assert.match(
+  view,
+  /func retryAssistant[\s\S]*?thread\.retry\(assistant\.id, client: client\)/,
+  "retryAssistant should call thread.retry in place",
+);
+
+// --- thread.retry re-streams a single familiar in place ---------------------
+assert.match(
+  thread,
+  /func retry\(_ messageId: String, client: CaveClient, onChange: @escaping \(\) -> Void\)/,
+  "ChatThread should expose retry(messageId:client:onChange:)",
+);
+assert.match(
+  thread,
+  /func retry[\s\S]*?messages\[\.\.<idx\]\.last\(where: \{ \$0\.role == \.user \}\)/,
+  "retry should replay the nearest preceding user prompt (works for group fan-out order)",
+);
+assert.match(
+  thread,
+  /func retry[\s\S]*?\$0\.text = ""; \$0\.isError = false; \$0\.streaming = true[\s\S]*?stream\(familiarId: familiarId/,
+  "retry should reset the bubble and re-stream only its familiar (not a full send fan-out)",
+);
+
+console.log("ios-message-retry: OK");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -535,6 +535,7 @@ export const SUITES = {
     "scripts/ios-unread-badges.test.mjs",
     "scripts/ios-markdown-accent.test.mjs",
     "scripts/ios-message-forwarding.test.mjs",
+    "scripts/ios-message-retry.test.mjs",
     "scripts/ios-chat-thread-no-search.test.mjs",
     "scripts/ios-development-code-title.test.mjs",
     "scripts/ios-development-github-title.test.mjs",


### PR DESCRIPTION
## Problem

A chat reply that fails to send (network drop, desktop offline) renders as a red error bubble (`ChatThread.stream` sets `isError`), but the **only** way to recover was a long-press → "Retry" — undiscoverable. Worse, `canRetry` excluded group chats entirely (`!thread.isGroup`), so a failure in a group was a dead end.

## Fix

- **Visible Retry button.** `MessageBubble` now renders a red-tinted, small `Retry` button (with an accessibility label) directly beneath a failed (`isError`) reply — no long-press needed.
- **In-place, single-familiar retry.** New `ChatThread.retry(messageId:client:onChange:)` resets just that bubble and re-streams the **same** familiar with the prompt that produced it (the nearest preceding user message). Because it re-streams one familiar instead of `send`'s fan-out:
  - it's **safe in group chats** — only the failed familiar re-runs, not all of them;
  - it **doesn't duplicate** the user's prompt on a 1:1 (the old path deleted + re-sent).
- **`canRetry`** now allows retrying any failed reply (and still the latest reply, for regenerate), dropping the `!thread.isGroup` restriction.

## Verification

- Builds clean for the iPhone 16 Pro simulator; new build launches with **no rendering regression**.
- New `scripts/ios-message-retry.test.mjs` (wired into `run-tests.mjs`; `check:tests-wired` green) locks the full chain: visible button on `isError`, broadened `canRetry`, and `ChatThread.retry` re-streaming a single familiar in place.
- Existing iOS chat/message/theme source-text tests still pass.
- Honest caveat: I seeded a failed-reply thread and confirmed the failure data model loads, but couldn't pixel-verify the button in-sim — driving the error state needs a live failing connection + tap-injection, and the terminal lacks macOS Accessibility permission to post taps. The change is a standard `.bordered` button below the existing red bubble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)