### PR TITLE
feat(a11y): honor reduced-motion for JS-driven smooth scrolling

### DIFF
--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { Card, CardStatus, CardPriority } from "@/lib/cave-board-types";
 import { scheduleLabel, scheduleUrgency } from "@/lib/board-schedule";
+import { smoothScrollBehavior } from "@/lib/use-prefers-reduced-motion";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import type { CaveProject } from "@/lib/cave-projects";
 import { LifecycleBadge } from "@/components/ui/lifecycle-badge";
@@ -225,7 +226,7 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
   const scroll = (key: string, dir: -1 | 1) => {
     const rail = railRefs.current.get(key);
     if (!rail) return;
-    rail.scrollBy({ left: Math.max(rail.clientWidth * 0.72, 280) * dir, behavior: "smooth" });
+    rail.scrollBy({ left: Math.max(rail.clientWidth * 0.72, 280) * dir, behavior: smoothScrollBehavior() });
   };
 
   // Click-and-drag horizontal scroll ("grabber") for the rail.

--- a/src/components/library-chat-panel.tsx
+++ b/src/components/library-chat-panel.tsx
@@ -24,6 +24,7 @@ import {
   useState,
 } from "react";
 import { Icon } from "@/lib/icon";
+import { prefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
 import { sanitizeHtml } from "@/lib/html-sanitize";
 import type { LibraryDocBody } from "@/lib/library-types";
 
@@ -161,7 +162,9 @@ export function LibraryChatPanel({ doc, familiarId = "sage" }: LibraryChatPanelP
   // ── Auto-scroll ────────────────────────────────────────────────
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
-    messagesEndRef.current?.scrollIntoView({ behavior, block: "end" });
+    // Respect reduced motion: a "smooth" request becomes an instant jump.
+    const effective = behavior === "smooth" && prefersReducedMotion() ? "auto" : behavior;
+    messagesEndRef.current?.scrollIntoView({ behavior: effective, block: "end" });
   }, []);
 
   useLayoutEffect(() => {

--- a/src/components/library-doc-preview.tsx
+++ b/src/components/library-doc-preview.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { Icon } from "@/lib/icon";
+import { smoothScrollBehavior } from "@/lib/use-prefers-reduced-motion";
 import { Skeleton, SkeletonGroup } from "@/components/ui/skeleton";
 import { copyText } from "@/lib/clipboard";
 import { useCopy } from "@/lib/use-copy";
@@ -475,7 +476,7 @@ function TocPanel({ items, activeId, mdRef, readerMode = false }: TocPanelProps)
             ].filter(Boolean).join(" ")}
             onClick={() => {
               const el = mdRef.current?.querySelector(`#${CSS.escape(item.id)}`);
-              el?.scrollIntoView({ behavior: "smooth", block: "start" });
+              el?.scrollIntoView({ behavior: smoothScrollBehavior(), block: "start" });
             }}
             title={item.text}
           >

--- a/src/components/projects/project-row.tsx
+++ b/src/components/projects/project-row.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { Icon } from "@/lib/icon";
+import { smoothScrollBehavior } from "@/lib/use-prefers-reduced-motion";
 import { relativeTime } from "@/lib/relative-time";
 import type { CaveProject } from "@/lib/cave-projects-types";
 import { normalizeProjectRoot } from "@/lib/cave-projects-types";
@@ -80,7 +81,7 @@ export function ProjectRow({
       window.requestAnimationFrame(() => {
         document
           .getElementById(`pcard-el:${cardKey}`)
-          ?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+          ?.scrollIntoView({ block: "nearest", behavior: smoothScrollBehavior() });
       });
     };
     window.addEventListener(CHAT_FOCUS_PROJECT_EVENT, onFocus);

--- a/src/components/salem/salem-widget.tsx
+++ b/src/components/salem/salem-widget.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, type FormEvent } from "react";
 import { Icon } from "@/lib/icon";
+import { smoothScrollBehavior } from "@/lib/use-prefers-reduced-motion";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { useIsCoarsePointer } from "@/lib/use-viewport";
 import { SalemPathfinderCard } from "./salem-pathfinder-card";
@@ -94,7 +95,7 @@ export function SalemChatPanel({ familiarId, model }: { familiarId?: string | nu
   };
 
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    bottomRef.current?.scrollIntoView({ behavior: smoothScrollBehavior() });
   }, [messages]);
 
   const send = async (e?: FormEvent) => {

--- a/src/lib/use-prefers-reduced-motion.test.ts
+++ b/src/lib/use-prefers-reduced-motion.test.ts
@@ -40,4 +40,53 @@ assert.match(
   "hook cleans up the listener on unmount",
 );
 
+// Imperative one-shot helper for event handlers / effects (hooks can't run there).
+assert.match(
+  source,
+  /export function prefersReducedMotion\(\)\s*:\s*boolean/,
+  "exports prefersReducedMotion() for non-hook contexts",
+);
+assert.match(
+  source,
+  /export function prefersReducedMotion[\s\S]{0,160}typeof window === "undefined"/,
+  "prefersReducedMotion() guards window for SSR safety",
+);
+assert.match(
+  source,
+  /export function smoothScrollBehavior\(\)\s*:\s*ScrollBehavior/,
+  "exports smoothScrollBehavior() returning a ScrollBehavior",
+);
+
+// Regression: JS smooth-scroll call sites must gate on the preference, because an
+// explicit `behavior: "smooth"` option overrides the CSS scroll-behavior reset.
+const callSites = [
+  "../components/library-doc-preview.tsx",
+  "../components/projects/project-row.tsx",
+  "../components/board-kanban.tsx",
+  "../components/salem/salem-widget.tsx",
+];
+for (const rel of callSites) {
+  const src = readFileSync(new URL(rel, import.meta.url), "utf8");
+  assert.doesNotMatch(
+    src,
+    /behavior:\s*"smooth"/,
+    `${rel} must not pass a raw behavior: "smooth" (use smoothScrollBehavior())`,
+  );
+  assert.match(
+    src,
+    /smoothScrollBehavior\(\)/,
+    `${rel} must route smooth scrolling through smoothScrollBehavior()`,
+  );
+}
+
+// library-chat-panel keeps its ScrollBehavior param but must gate "smooth" on the preference.
+{
+  const src = readFileSync(new URL("../components/library-chat-panel.tsx", import.meta.url), "utf8");
+  assert.match(
+    src,
+    /prefersReducedMotion\(\)/,
+    "library-chat-panel must gate its smooth auto-scroll on prefersReducedMotion()",
+  );
+}
+
 console.log("use-prefers-reduced-motion.test.ts OK");

--- a/src/lib/use-prefers-reduced-motion.ts
+++ b/src/lib/use-prefers-reduced-motion.ts
@@ -24,3 +24,19 @@ export function usePrefersReducedMotion(): boolean {
 
   return reduced;
 }
+
+/**
+ * Imperative one-shot read of the reduced-motion preference, for event handlers
+ * and effects where a hook can't run. SSR-safe (returns false without a window).
+ * Use to gate JS-driven smooth scrolling, which bypasses the CSS reduced-motion
+ * reset because an explicit `behavior: "smooth"` option overrides scroll-behavior.
+ */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+  return window.matchMedia(QUERY).matches;
+}
+
+/** Reduced-motion-aware scroll behavior: "auto" when the user prefers reduced motion, else "smooth". */
+export function smoothScrollBehavior(): ScrollBehavior {
+  return prefersReducedMotion() ? "auto" : "smooth";
+}


### PR DESCRIPTION
The reduced-motion audit. The CSS reduced-motion reset in `globals.css` already neutralizes every CSS animation/transition (a global `*` kill-switch + zeroed duration tokens), so the CSS side is fully covered. The remaining gap is **JS-driven smooth scrolling**: `scrollIntoView`/`scrollTo`/`scrollBy` with an explicit `behavior: "smooth"` — the option overrides `scroll-behavior`, so the CSS reset can't touch it.

`chat-view` already gated its smooth scroll on the preference (enforced by a test). The rest of the app did not.

## Changes
- New SSR-safe helpers in `use-prefers-reduced-motion.ts`:
  - `prefersReducedMotion()` — imperative one-shot read for event handlers/effects where a hook can't run.
  - `smoothScrollBehavior()` — returns `"auto"` under the preference, else `"smooth"`.
- Routed the unguarded smooth-scroll sites through them:
  - `library-doc-preview` — TOC heading jump
  - `library-chat-panel` — streaming auto-scroll-to-bottom
  - `projects/project-row` — focus-project scroll-into-view
  - `board-kanban` — rail scroll arrows
  - `salem-widget` — new-message scroll-to-bottom

`workflow-canvas`'s `"smoothstep"` is a React Flow edge type, not motion — left alone.

## Verified
- Source/unit test (`use-prefers-reduced-motion.test.ts`) asserts the helpers exist, are SSR-safe, and that each call site no longer passes a raw `behavior: "smooth"`.
- **Runtime (production build, emulated reduced-motion):** a guarded board rail scroll jumps instantly (`early == settled`) while the no-preference case animates (`early=11 → settled=600`).
- `pnpm typecheck` clean; `app` suite (388 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)