### PR TITLE
feat(ios): @-mention familiars in group chats

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/MentionInput.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/MentionInput.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Detects and edits an in-progress `@familiar` mention in the composer draft.
+/// Unlike a slash command (which must lead the draft), a mention is the trailing
+/// whitespace-delimited token, so it can appear mid-sentence.
+enum MentionInput {
+    /// The trailing word currently being typed (everything after the last space
+    /// or newline).
+    private static func trailingToken(_ draft: String) -> String {
+        String(String(draft.reversed()).prefix { $0 != " " && $0 != "\n" }.reversed())
+    }
+
+    /// The partial name after a trailing `@` (empty right after typing `@`), or
+    /// nil when the trailing token isn't a mention. A bare `@` with no `@` body
+    /// still matches (returns "") so the picker opens immediately.
+    static func partial(_ draft: String) -> String? {
+        let token = trailingToken(draft)
+        guard token.hasPrefix("@") else { return nil }
+        return String(token.dropFirst())
+    }
+
+    /// Replace the trailing `@token` with `@<name> ` (display name, trailing
+    /// space) so the user can keep typing.
+    static func insert(name: String, into draft: String) -> String {
+        let token = trailingToken(draft)
+        let base = String(draft.dropLast(token.count))
+        return base + "@\(name) "
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -67,6 +67,17 @@ struct ChatView: View {
     }
     private var showingSlashMenu: Bool { !slashMatches.isEmpty }
 
+    // @-mention autocomplete (group chats only): the trailing `@token` matches
+    // the group's familiars by name.
+    private var mentionMatches: [Familiar] {
+        guard thread.isGroup, let partial = MentionInput.partial(draft) else { return [] }
+        let members = thread.familiarIds.compactMap(app.familiar)
+        guard !partial.isEmpty else { return members }
+        let q = partial.lowercased()
+        return members.filter { $0.displayName.lowercased().contains(q) || $0.id.lowercased().contains(q) }
+    }
+    private var showingMentionMenu: Bool { !mentionMatches.isEmpty }
+
     var body: some View {
         VStack(spacing: 0) {
             messageScroll
@@ -286,6 +297,15 @@ struct ChatView: View {
                     .padding(.horizontal, 12)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
+            if showingMentionMenu {
+                MentionMenu(familiars: mentionMatches,
+                            avatarURL: { app.client?.avatarURL(for: $0) }) { familiar in
+                    draft = MentionInput.insert(name: familiar.displayName, into: draft)
+                    composerFocused = true
+                }
+                .padding(.horizontal, 12)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
             if !pendingImages.isEmpty {
                 attachmentPreviews
             }
@@ -295,6 +315,7 @@ struct ChatView: View {
             composerBar
         }
         .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: showingSlashMenu)
+        .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: showingMentionMenu)
         .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: pendingImages.count)
         .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: replyingTo?.id)
         .glassBar()

--- a/apps/ios/CovenCave/CovenCave/Views/MentionMenu.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MentionMenu.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// Autocomplete surface floating above the composer while the user types an
+/// `@mention` in a group chat. Mirrors `SlashCommandMenu`; lists the group's
+/// familiars (avatar + name + role).
+struct MentionMenu: View {
+    let familiars: [Familiar]
+    var avatarURL: (Familiar) -> URL? = { _ in nil }
+    let onSelect: (Familiar) -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(familiars) { familiar in
+                        Button { onSelect(familiar) } label: { row(familiar) }
+                            .buttonStyle(.plain)
+                        if familiar.id != familiars.last?.id {
+                            Divider().padding(.leading, 52)
+                        }
+                    }
+                }
+            }
+            .frame(maxHeight: 248)
+        }
+        .glassFill(.elevated, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(Color(.separator).opacity(0.6), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.14), radius: 16, y: 6)
+    }
+
+    private func row(_ familiar: Familiar) -> some View {
+        HStack(spacing: 10) {
+            AvatarView(familiar: familiar, url: avatarURL(familiar), size: 32)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("@\(familiar.displayName)")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                if let role = familiar.role, !role.isEmpty {
+                    Text(role).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                }
+            }
+            Spacer(minLength: 4)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .contentShape(Rectangle())
+    }
+}

--- a/scripts/ios-group-mentions.test.mjs
+++ b/scripts/ios-group-mentions.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const base = "../apps/ios/CovenCave/CovenCave";
+const read = (p) => readFile(new URL(`${base}/${p}`, import.meta.url), "utf8");
+
+// Pure mention detection/insertion helper.
+const input = await read("Models/MentionInput.swift");
+assert.match(input, /enum MentionInput \{/, "MentionInput helper should exist");
+assert.match(
+  input,
+  /static func partial\(_ draft: String\) -> String\? \{[\s\S]*token\.hasPrefix\("@"\)[\s\S]*token\.dropFirst\(\)/,
+  "partial() should return the text after a trailing @",
+);
+assert.match(
+  input,
+  /static func insert\(name: String, into draft: String\) -> String \{[\s\S]*"@\\\(name\) "/,
+  "insert() should replace the trailing @token with @<name> ",
+);
+
+// A picker view exists.
+const menu = await read("Views/MentionMenu.swift");
+assert.match(menu, /struct MentionMenu: View/, "MentionMenu view should exist");
+assert.match(menu, /AvatarView\(familiar: familiar/, "MentionMenu rows should show avatars");
+
+// ChatView wires the mention menu, group-only, off the trailing @token.
+const chat = await read("Views/ChatView.swift");
+assert.match(
+  chat,
+  /private var mentionMatches: \[Familiar\] \{[\s\S]*thread\.isGroup[\s\S]*MentionInput\.partial\(draft\)/,
+  "mentionMatches should be group-only and driven by MentionInput",
+);
+assert.match(chat, /if showingMentionMenu \{[\s\S]*MentionMenu\(familiars: mentionMatches/, "the composer should show the mention menu");
+assert.match(
+  chat,
+  /draft = MentionInput\.insert\(name: familiar\.displayName, into: draft\)/,
+  "picking a familiar should insert the mention into the draft",
+);
+
+console.log("ios-group-mentions: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -534,6 +534,7 @@ export const SUITES = {
     "scripts/ios-swipe-reply.test.mjs",
     "scripts/ios-unread-badges.test.mjs",
     "scripts/ios-familiar-row-actions.test.mjs",
+    "scripts/ios-group-mentions.test.mjs",
     "scripts/ios-markdown-accent.test.mjs",
     "scripts/ios-message-forwarding.test.mjs",
     "scripts/ios-chat-thread-no-search.test.mjs",


### PR DESCRIPTION
Fresh UX idea #2. In a group thread there was no way to address one familiar. Typing **`@`** now opens an autocomplete of the group's members (avatar + name + role); picking one inserts `@<name> ` into the draft.

- **`MentionInput`** (pure, tested): detects the trailing `@token` *anywhere* in the draft (unlike slash commands, which must lead) and inserts the chosen name.
- **`MentionMenu`** mirrors `SlashCommandMenu` (glass surface, avatar rows).
- **`ChatView`** shows it **group-only**, alongside the existing slash menu (mutually exclusive).

## Verified live (simulator)
Typing `@` in a 3-familiar group surfaced the picker with @Nova / @Sage / @Charm (avatars + roles).

`xcodebuild` (iPhone 16 Pro sim): **BUILD SUCCEEDED**. New `scripts/ios-group-mentions.test.mjs` wired; `check:tests-wired` green (527 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)