### PR TITLE
fix(calendar): add title tooltips to truncated chip titles

### DIFF
--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -212,6 +212,7 @@ function ItemChip({
   return (
     <button
       onClick={onClick}
+      title={item.title}
       className={`focus-ring group flex w-full items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2 py-2.5 text-left text-[13px] transition-colors md:py-1 md:text-[11px] ${done ? "bg-[var(--bg-base)] opacity-60 hover:bg-[var(--bg-raised)]" : "bg-[var(--bg-raised)] hover:bg-[var(--bg-elevated)]"}`}
     >
       {done
@@ -438,6 +439,7 @@ function AllDayStrip({
               <button
                 key={item.id}
                 onClick={() => onOpenItem?.(item)}
+                title={item.title}
                 className="focus-ring-inset flex items-center gap-1 rounded px-1.5 py-0.5 text-[9px] bg-[var(--accent-presence)]/15 border border-[var(--accent-presence)]/30 hover:bg-[var(--accent-presence)]/25 transition-colors w-full text-left truncate"
               >
                 <span role="img" aria-label={urgencyLabel(item)} title={urgencyLabel(item)} className={`h-1.5 w-1.5 shrink-0 rounded-full ${urgencyColor(item)}`} />


### PR DESCRIPTION
## What

In the calendar, two truncated chips drop the item title with no way to read the full text on hover:

- the day-column `ItemChip` button (`calendar-view.tsx:213`)
- the all-day strip chip button (`calendar-view.tsx:438`)

…while the deadline chips (`:491`), week-view events (`:722`), and month chips (`:1102`) already carry a `title` attribute. This adds `title={item.title}` to both so long reminder/task names are readable on hover, making the surface consistent.

## Verification

- Calendar test suites pass: `calendar-view-polish`, `calendar-actions`, `calendar-keyboard`, `a11y-audit-fixes` (no markup-pinned regressions).
- `tsc --noEmit` clean for the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)