### PR TITLE
feat(journal): day-fetch race guard + keyboard/chronological day nav

### DIFF
--- a/src/components/journal/journal-entries.tsx
+++ b/src/components/journal/journal-entries.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { EmptyState } from "@/components/ui/empty-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
@@ -63,7 +63,10 @@ export function JournalEntries({
   scopeFamiliarIds?: ReadonlySet<string>;
 }) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
-  const today = dateSlug(new Date());
+  // One clock read per render — reused for `today`, list labels, and the detail
+  // heading (was a fresh `new Date()` per row).
+  const now = new Date();
+  const today = dateSlug(now);
   const [days, setDays] = useState<JournalSummary[]>([]);
   const [daysLoaded, setDaysLoaded] = useState(false);
   const [selected, setSelected] = useState<string>(today);
@@ -76,6 +79,14 @@ export function JournalEntries({
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState("");
   const selectedFamiliarId = activeFamiliarId ?? familiars[0]?.id ?? null;
+  // Guard async setState after unmount, and ignore a stale day fetch when the
+  // selection changed before its response arrived (rapid day switching).
+  const mountedRef = useRef(true);
+  const loadDayReqRef = useRef(0);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
 
   const familiarName = useCallback(
     (id: string | null) => (id ? familiars.find((f) => f.id === id)?.display_name ?? id : null),
@@ -111,15 +122,17 @@ export function JournalEntries({
     try {
       const res = await fetch(`/api/journal`, { cache: "no-store" });
       const json = await res.json().catch(() => ({}));
+      if (!mountedRef.current) return;
       if (json.ok) setDays(Array.isArray(json.days) ? json.days : []);
     } catch {
       /* keep prior */
     } finally {
-      setDaysLoaded(true);
+      if (mountedRef.current) setDaysLoaded(true);
     }
   }, []);
 
   const loadDay = useCallback(async (slug: string) => {
+    const reqId = ++loadDayReqRef.current;
     try {
       // Scope the day's memory stats to the single active familiar; with 0 or
       // ≥ 2 selected (activeFamiliarId null) the record + stats are unscoped.
@@ -128,9 +141,11 @@ export function JournalEntries({
         : `date=${encodeURIComponent(slug)}`;
       const res = await fetch(`/api/journal?${detailQuery}`, { cache: "no-store" });
       const json = await res.json().catch(() => ({}));
+      // Drop a stale response: a newer loadDay (different day) superseded it.
+      if (reqId !== loadDayReqRef.current || !mountedRef.current) return;
       if (json.ok) setDay(json as JournalDay);
     } catch {
-      setDay(null);
+      if (reqId === loadDayReqRef.current && mountedRef.current) setDay(null);
     }
   }, [activeFamiliarId]);
 
@@ -156,6 +171,7 @@ export function JournalEntries({
     setError(null);
     setGenerating(true);
     const result = await generateReflection({ familiarId, context: day.context });
+    if (!mountedRef.current) return;
     if (result.error || !result.text) {
       setGenerating(false);
       setError(result.error ?? "No reflection was returned.");
@@ -166,6 +182,7 @@ export function JournalEntries({
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ date: day.date, reflection: result.text, reflectedBy: familiarId }),
     }).catch(() => undefined);
+    if (!mountedRef.current) return;
     setGenerating(false);
     await loadDay(day.date);
     await loadDays();
@@ -201,13 +218,14 @@ export function JournalEntries({
       });
       const json = await res.json().catch(() => ({}));
       if (!res.ok || !json.ok) throw new Error(json.error ?? "Could not save journal entry.");
+      if (!mountedRef.current) return;
       cancelEdit();
       await loadDay(day.date);
       await loadDays();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Could not save journal entry.");
+      if (mountedRef.current) setError(err instanceof Error ? err.message : "Could not save journal entry.");
     } finally {
-      setSaving(false);
+      if (mountedRef.current) setSaving(false);
     }
   }
 
@@ -219,18 +237,45 @@ export function JournalEntries({
       const res = await fetch(`/api/journal?date=${encodeURIComponent(day.date)}`, { method: "DELETE" });
       const json = await res.json().catch(() => ({}));
       if (!res.ok || !json.ok) throw new Error(json.error ?? "Could not delete journal entry.");
+      if (!mountedRef.current) return;
       cancelEdit();
       await loadDay(day.date);
       await loadDays();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Could not delete journal entry.");
+      if (mountedRef.current) setError(err instanceof Error ? err.message : "Could not delete journal entry.");
     } finally {
-      setDeleting(false);
+      if (mountedRef.current) setDeleting(false);
     }
   }
 
   const canGenerate = Boolean(selectedFamiliarId);
   const hasEntry = Boolean(day?.exists && day.entry.reflection.trim());
+
+  // Chronological navigation across the *visible* (scoped + filtered) days.
+  // The list is newest-first, so "newer" = lower index, "older" = higher.
+  const dayIndex = filteredDays.findIndex((d) => d.date === selected);
+  const hasNewer = dayIndex > 0;
+  const hasOlder = dayIndex >= 0 && dayIndex < filteredDays.length - 1;
+  const goToDay = useCallback((index: number) => {
+    const target = filteredDays[index];
+    if (target) setSelected(target.date);
+  }, [filteredDays]);
+  // ↑/↓ + Home/End move selection through the day rail (selection follows focus).
+  const onRailKeyDown = (e: React.KeyboardEvent<HTMLUListElement>) => {
+    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(e.key)) return;
+    const btns = Array.from(e.currentTarget.querySelectorAll<HTMLButtonElement>("button.journal-day"));
+    const i = btns.findIndex((b) => b === document.activeElement);
+    if (i < 0) return;
+    e.preventDefault();
+    const ni =
+      e.key === "ArrowDown" ? Math.min(btns.length - 1, i + 1)
+      : e.key === "ArrowUp" ? Math.max(0, i - 1)
+      : e.key === "Home" ? 0
+      : btns.length - 1;
+    btns[ni]?.focus();
+    const date = filteredDays[ni]?.date;
+    if (date) setSelected(date);
+  };
 
   return (
     <div className="journal-list">
@@ -268,17 +313,18 @@ export function JournalEntries({
         ) : filteredDays.length === 0 ? (
           <div className="journal-empty">No entries match “{filter.trim()}”.</div>
         ) : (
-          <ul className="journal-list__items">
+          <ul className="journal-list__items" onKeyDown={onRailKeyDown}>
             {filteredDays.map((d) => (
               <li key={d.date}>
                 <button
                   type="button"
                   className={`journal-day${d.date === selected ? " is-selected" : ""}`}
+                  aria-current={d.date === selected ? "true" : undefined}
                   onClick={() => setSelected(d.date)}
                 >
                   <span className="journal-day__top">
                     <span className="journal-day__date">
-                      {relativeDayLabel(parseDateSlug(d.date) ?? new Date(), new Date())}
+                      {relativeDayLabel(parseDateSlug(d.date) ?? now, now)}
                     </span>
                     {d.reflectedBy ? <span className="journal-day__by">{familiarName(d.reflectedBy)}</span> : null}
                   </span>
@@ -292,7 +338,33 @@ export function JournalEntries({
       <section className="journal-detail" aria-label="Journal entry">
         {day ? (
           <>
-            <div className="journal-entry__sec">What happened · {longDateLabel(parseDateSlug(day.date) ?? new Date())}</div>
+            <div className="journal-entry__sec journal-entry__sec--nav">
+              <span>What happened · {longDateLabel(parseDateSlug(day.date) ?? now)}</span>
+              {filteredDays.length > 1 ? (
+                <span className="journal-entry__daynav">
+                  <button
+                    type="button"
+                    className="journal-entry__action"
+                    onClick={() => goToDay(dayIndex - 1)}
+                    disabled={!hasNewer}
+                    aria-label="Newer entry"
+                    title="Newer entry"
+                  >
+                    <Icon name="ph:caret-up" width={12} aria-hidden />
+                  </button>
+                  <button
+                    type="button"
+                    className="journal-entry__action"
+                    onClick={() => goToDay(dayIndex + 1)}
+                    disabled={!hasOlder}
+                    aria-label="Older entry"
+                    title="Older entry"
+                  >
+                    <Icon name="ph:caret-down" width={12} aria-hidden />
+                  </button>
+                </span>
+              ) : null}
+            </div>
             <div className="journal-entry__stats">
               <div className="journal-entry__stat"><b>{day.stats.covenOrigin}</b><span>coven files</span></div>
               <div className="journal-entry__stat"><b>{day.stats.externalRuntimes}</b><span>external runtime files</span></div>

--- a/src/components/journal/journal-view.test.ts
+++ b/src/components/journal/journal-view.test.ts
@@ -87,4 +87,23 @@ assert.match(entries, /day\.stats\.covenOrigin[\s\S]*?coven files/, "Journal sta
 assert.match(entries, /day\.stats\.externalRuntimes[\s\S]*?external runtime files/, "Journal stats include external runtime memory files");
 assert.match(entries, /day\.stats\.runtimeMemory[\s\S]*?runtime files/, "Journal stats include runtime memory files");
 
+// ── Day-fetch race + unmount guards ─────────────────────────────────────────
+// Rapid day switching must not let a slow earlier fetch overwrite the current
+// selection, and no async setState may land after unmount.
+assert.match(entries, /const loadDayReqRef = useRef\(0\)/, "loadDay tracks a request id");
+assert.match(entries, /const reqId = \+\+loadDayReqRef\.current/, "each loadDay stamps a request id");
+assert.match(entries, /if \(reqId !== loadDayReqRef\.current \|\| !mountedRef\.current\) return/, "a stale/late day fetch is dropped");
+assert.match(entries, /const mountedRef = useRef\(true\)/, "tracks mounted state for async guards");
+assert.match(entries, /return \(\) => \{ mountedRef\.current = false; \}/, "mountedRef is cleared on unmount");
+
+// ── Selected day is announced + keyboard-navigable ──────────────────────────
+assert.match(entries, /aria-current=\{d\.date === selected \? "true" : undefined\}/, "the open day row is aria-current");
+assert.match(entries, /onKeyDown=\{onRailKeyDown\}/, "the day rail handles arrow-key navigation");
+assert.match(entries, /e\.key === "ArrowDown" \? Math\.min\(btns\.length - 1, i \+ 1\)/, "ArrowDown moves to the next day");
+// Chronological prev/next entry controls in the detail header.
+assert.match(entries, /aria-label="Newer entry"/, "detail header has a newer-entry control");
+assert.match(entries, /aria-label="Older entry"/, "detail header has an older-entry control");
+assert.match(entries, /const hasOlder = dayIndex >= 0 && dayIndex < filteredDays\.length - 1/, "older-entry availability derives from the visible list");
+assert.match(css, /\.journal-entry__sec--nav \{[\s\S]*?justify-content: space-between/, "the heading row lays out the nav controls");
+
 console.log("journal-view.test.ts: ok");

--- a/src/styles/journal.css
+++ b/src/styles/journal.css
@@ -386,6 +386,14 @@
   color: var(--text-muted);
   margin: 0 0 8px;
 }
+/* Heading row with chronological prev/next entry controls on the right. */
+.journal-entry__sec--nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.journal-entry__daynav { display: inline-flex; gap: 4px; }
 .journal-entry__stats { display: flex; gap: 8px; margin-bottom: 18px; }
 .journal-entry__stat {
   flex: 1;


### PR DESCRIPTION
## Journal audit + fixes

Audit pass over the Journal. The two-tab container is already clean (hydration-safe tabs, proper `tabpanel` ARIA); the work was in `JournalEntries`.

### Bugs
- **Day-fetch race.** `loadDay` had no request guard, so rapidly switching days let a slow earlier fetch overwrite the day you actually selected — and the detail endpoint is genuinely slow (~3–8s; it computes per-day memory stats), which makes the race easy to hit. Now stamps a request id and drops superseded responses.
- **Unmount guards.** `loadDay`/`loadDays`/`generate`/`saveEdit`/`deleteEntry` no longer `setState` after their `await`s once the view unmounts (a shared `mountedRef`).

### Accessibility + navigation (features)
- **`aria-current`** on the open day row.
- **Keyboard day rail** — ↑/↓ + Home/End rove and select (selection follows focus).
- **Chronological Newer/Older entry controls** in the detail header, over the visible (scoped + filtered) list, disabled at the ends.

### Perf
- Hoist one `now` per render instead of repeated `new Date()` calls (including one per list row).

## Testing
- **Verified live:** rail arrow-nav moves the selection + updates `aria-current`; once the detail loads, **Newer is correctly disabled on the newest day** and **Older steps to the previous day** (`Today → Yesterday`); no console errors.
- `tsc --noEmit` clean · `pnpm build` clean · full `app` suite: 388 files pass.
- Extended `journal-view.test.ts` with the race-guard, unmount-guard, `aria-current`, rail-keyboard, and Newer/Older assertions.

### Note (out of scope)
The day-detail endpoint (`/api/journal?date=…`) is slow — ~3–8s — because it recomputes memory stats per request; this is pre-existing (reproduces on `main`) and worth a follow-up (caching), but isn't touched here. The new request guard makes the resulting UI behave correctly under that latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)