### PR TITLE
feat(ios): subtle haptic when a familiar's reply finishes

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -169,7 +169,16 @@ struct ChatView: View {
         // A new chat linked to a task acquires its server session only after the
         // first reply; once streaming stops, push that sessionId onto the card.
         .onChange(of: thread.isStreaming) { _, streaming in
-            if !streaming { Task { await app.reconcileCardLinks(for: thread) } }
+            if !streaming {
+                // A reply just finished streaming — a subtle "done" haptic so you
+                // know it landed without watching. Only for a real assistant
+                // message (not a user cancel or an error placeholder).
+                if let last = thread.messages.last, last.role == .assistant, !last.isError,
+                   !last.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Haptics.success()
+                }
+                Task { await app.reconcileCardLinks(for: thread) }
+            }
         }
         // Restore an unsent draft for this thread (typed earlier, then the view
         // was dismissed or the app backgrounded). Only when the live draft is

--- a/scripts/ios-reply-feedback.test.mjs
+++ b/scripts/ios-reply-feedback.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const chat = await readFile(
+  new URL("../apps/ios/CovenCave/CovenCave/Views/ChatView.swift", import.meta.url),
+  "utf8",
+);
+
+// When streaming ends with a real assistant reply, fire a success haptic — but
+// not for a user cancel or an error placeholder.
+assert.match(
+  chat,
+  /onChange\(of: thread\.isStreaming\)[\s\S]*if !streaming \{[\s\S]*last\.role == \.assistant, !last\.isError,[\s\S]*!last\.text\.trimmingCharacters[\s\S]*Haptics\.success\(\)/,
+  "reply completion should fire Haptics.success() only for a real assistant message",
+);
+
+console.log("ios-reply-feedback: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -535,6 +535,7 @@ export const SUITES = {
     "scripts/ios-unread-badges.test.mjs",
     "scripts/ios-familiar-row-actions.test.mjs",
     "scripts/ios-group-mentions.test.mjs",
+    "scripts/ios-reply-feedback.test.mjs",
     "scripts/ios-markdown-accent.test.mjs",
     "scripts/ios-message-forwarding.test.mjs",
     "scripts/ios-message-retry.test.mjs",


### PR DESCRIPTION
Fresh UX idea #3. There's a haptic when you **send**, but nothing when the reply **lands**. Now a success haptic fires when a thread stops streaming and the last message is a real assistant reply (skipped for a user cancel or an error placeholder) — so you feel the answer arrive without staring at the screen.

Tiny, additive change to the existing `onChange(of: thread.isStreaming)` hook; reuses `Haptics.success()`.

`xcodebuild` (iPhone 16 Pro sim): **BUILD SUCCEEDED**. Source-text test wired (529 files). (Haptics aren't screenshot-able; the gate logic is covered by the test.)

> Note: the "toast when you've navigated away" half of the original idea needs app-level stream observation (not just the in-chat hook) — left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)