### PR TITLE
fix(web): stable DndContext ids — fix dashboard hydration mismatch

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -127,6 +127,7 @@ export const SUITES = {
     "src/components/workflows/workflow-step-list.test.ts",
     "src/components/workflows/workflow-capability-attachments.test.ts",
     "src/components/projects-view.test.ts",
+    "src/components/dnd-context-stable-ids.test.ts",
     "src/lib/projects/projects-ui-state.test.ts",
     "src/lib/projects/session-glyph.test.ts",
     "src/lib/projects/project-stats.test.ts",

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -1025,6 +1025,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
           )}
           {visibleRows > 0 && (
           <DndContext
+            id="chat-list"
             sensors={sensors}
             collisionDetection={closestCenter}
             onDragEnd={(event) => handleDragEnd(event, displayIds)}

--- a/src/components/chat-project-sidebar.tsx
+++ b/src/components/chat-project-sidebar.tsx
@@ -506,7 +506,7 @@ export function ChatProjectSidebar({
               No sessions match your search
             </p>
           ) : (
-            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+            <DndContext id="chat-sidebar-projects" sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
               <SortableContext items={displayIds} strategy={verticalListSortingStrategy}>
                 <ul>
                   <li>
@@ -533,7 +533,7 @@ export function ChatProjectSidebar({
           <>
             {hasSearch ? <div className="mt-1 border-t border-[var(--border-hairline)]" /> : null}
 
-            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleFolderDragEnd}>
+            <DndContext id="cps-folders" sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleFolderDragEnd}>
               {groups.map((group) => {
                 const key = selectionKey(group.projectId, group.projectRoot);
                 const expanded = expandedKeys.includes(key);

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -273,7 +273,7 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
       </div>
 
       {/* Main grid — panels drag to rearrange (hover for the grip) */}
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+      <DndContext id="dashboard-cockpit" sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
         <div className="cockpit-grid">
           {(["main", "rail"] as const).map((col) => {
             const ids = layout[col].filter(isVisible);

--- a/src/components/dnd-context-stable-ids.test.ts
+++ b/src/components/dnd-context-stable-ids.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+// @dnd-kit's <DndContext> derives its screen-reader description element id
+// (`DndDescribedBy-N`) from a module-level counter unless given an explicit
+// `id`. With several DndContexts in the app, the counter advances in a
+// different order on the server vs. the client, so an SSR-ed context hydrates
+// with a mismatched `aria-describedby` ("hydration mismatch"). Passing a stable
+// `id` to every DndContext makes those ids deterministic. This guard fails CI if
+// a new DndContext is added without one.
+
+const root = new URL("..", import.meta.url).pathname; // src/
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(p));
+    else if (entry.name.endsWith(".tsx")) out.push(p);
+  }
+  return out;
+}
+
+const offenders: string[] = [];
+for (const file of walk(root)) {
+  const src = readFileSync(file, "utf8");
+  // Each opening <DndContext ...> tag — capture up to the closing '>' of the tag.
+  for (const m of src.matchAll(/<DndContext\b[^>]*>/g)) {
+    if (!/\bid=/.test(m[0])) {
+      offenders.push(`${file.replace(root, "src/")}: ${m[0].slice(0, 60)}…`);
+    }
+  }
+}
+
+assert.equal(
+  offenders.length,
+  0,
+  `Every <DndContext> needs an explicit stable \`id\` to avoid an SSR hydration mismatch on \`aria-describedby\`. Missing on:\n${offenders.join("\n")}`,
+);
+
+console.log("dnd-context-stable-ids: OK");

--- a/src/components/familiar-pin-order.tsx
+++ b/src/components/familiar-pin-order.tsx
@@ -90,7 +90,7 @@ export function FamiliarPinOrder() {
   return (
     <div className="familiar-pin-order">
       {pinned.length > 0 ? (
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <DndContext id="familiar-pin-order" sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
           <SortableContext items={pinnedIds} strategy={verticalListSortingStrategy}>
             <ul className="familiar-pin-order__list" aria-label="Reorder pinned familiars">
               {pinned.map((f) => (

--- a/src/components/familiar-switcher.tsx
+++ b/src/components/familiar-switcher.tsx
@@ -195,7 +195,7 @@ export function FamiliarSwitcher({
           ) : null}
 
           {reordering ? (
-            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+            <DndContext id="familiar-switcher" sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
               <SortableContext items={familiarIds} strategy={verticalListSortingStrategy}>
                 <ul className="familiar-switcher__list" aria-label="Reorder familiars">
                   {familiars.map((f) => (

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -522,7 +522,7 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
                 No projects match “{query.trim()}”.
               </p>
             ) : (
-              <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+              <DndContext id="projects-grid" sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
                 {visibleProjects.map((project) => (
                   <ProjectRow
                     key={project.id}


### PR DESCRIPTION
## Problem

The dashboard (`DashboardPage` cockpit grid) threw a **React hydration mismatch**: each drag handle's `aria-describedby` was `DndDescribedBy-0` on the server but `DndDescribedBy-4` on the client.

`@dnd-kit`'s `DndContext` derives that screen-reader description id from a **module-level counter** when no `id` is given. The app has several `DndContext`s (chat list, familiar switcher, familiar pin-order, chat project sidebar ×2, projects grid, dashboard cockpit). They initialize in a different order on the client than during SSR, so the SSR-ed cockpit context hydrated with a drifted id → mismatch (`won't be patched up`).

## Fix

Give **every** `DndContext` an explicit, stable `id`, so its accessibility ids are deterministic and identical across SSR and hydration regardless of mount order — the documented `@dnd-kit` remedy.

- `dashboard-cockpit` (the reported one), `projects-grid`, `familiar-pin-order`, `familiar-switcher`, `chat-list`, `chat-sidebar-projects`, `cps-folders`.
- New guard test **`dnd-context-stable-ids`** scans all `.tsx` and fails CI if any `<DndContext>` lacks an `id`, so this can't regress.

## Verification

- New guard passes; all four existing tests that pin `DndContext` markup (`chat-list-delete`, `chat-project-sidebar-dnd`, `familiar-pin-order`, `projects-view`) still pass (ids placed first, within their regex budgets); `dashboard-page` test passes.
- `check:tests-wired` green (529 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)