### PR TITLE
fix(a11y): solid nav count-badge fill for WCAG contrast

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4839,7 +4839,9 @@ button:active > .edge-rail-chip {
   font-weight: 600;
   line-height: 1;
   color: var(--accent-presence-foreground);
-  background: color-mix(in oklch, var(--accent-presence) 60%, transparent);
+  /* Solid accent so the paired foreground keeps its contrast. A 60%-alpha fill
+     composited over the dark app background dropped the count to ~1:1 (WCAG). */
+  background: var(--accent-presence);
 }
 
 .menu-bar__badge--alert {

--- a/src/components/a11y-audit-fixes.test.ts
+++ b/src/components/a11y-audit-fixes.test.ts
@@ -61,3 +61,17 @@ test("shell exposes a skip-to-content link targeting the main landmark", async (
   // The link must reveal itself on focus, not stay permanently off-screen.
   assert.match(css, /\.skip-link:focus[\s\S]*?transform:\s*translateY\(0\)/);
 });
+
+test("nav count badge uses a solid accent fill (WCAG contrast)", async () => {
+  const css = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
+  // A 60%-alpha accent over the dark app background composited to ~1:1 against
+  // the paired foreground; the fill must be solid so the count stays legible.
+  assert.match(
+    css,
+    /\.menu-bar__badge\s*\{[\s\S]*?color:\s*var\(--accent-presence-foreground\)[\s\S]*?background:\s*var\(--accent-presence\);/,
+  );
+  assert.doesNotMatch(
+    css,
+    /\.menu-bar__badge\s*\{[\s\S]*?background:\s*color-mix\(in oklch, var\(--accent-presence\) 60%, transparent\)/,
+  );
+});


### PR DESCRIPTION
The contrast pass.

## Headline: muted body text already passes AA
I measured the resolved colors (canvas color-resolution + alpha compositing, both light and dark modes) of the muted-text tokens (`--text-muted`, `--fg-muted`, `--text-secondary`) against the surfaces they render on. **They pass WCAG AA in both modes** — so no global color-token changes were made (which keeps the blast radius minimal).

## The one clear bug: nav count badge
`.menu-bar__badge` (the Board/Tasks/Schedules/Calls counts) paired `color: var(--accent-presence-foreground)` — a foreground chosen for a *solid* accent — with `background: color-mix(accent-presence 60%, transparent)`. At 60% alpha the fill composited over the dark app background and darkened until the count hit **~1:1 contrast** (effectively invisible).

**Fix:** solid `var(--accent-presence)` fill (matching the existing `--alert` variant). Measured before→after in a production build:
- Dark: **1.04 → 6.56:1**
- Light: **1.0 → 4.88:1**

Both AA, verified visually (the "99+" badge is now a legible solid pill).

## Deferred (design/semantic judgment calls — flagged, not changed)
These are small graphical UI elements below AA, but changing them touches brand/semantic color choices, so I left them for a deliberate call:
- Accent buttons that hardcode white/`--text-primary` on `--accent-presence` (e.g. `board-new-card-btn`, ~2.8:1 dark) — the fix would be routing them to `--accent-presence-foreground`.
- Bulk-select checkmark glyphs (white check on accent box; the box fill already conveys state).
- Board priority pills (~2.5:1) — colored category chips where hue is the semantic.

## Tests
- `a11y-audit-fixes.test.ts` asserts the badge uses a solid accent fill (and not the 60% color-mix).
- `pnpm typecheck` clean; `app` suite (388 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)