### PR TITLE
fix(library): add title tooltip to truncated doc filenames

### DIFF
--- a/src/components/library-doc-list.tsx
+++ b/src/components/library-doc-list.tsx
@@ -178,7 +178,7 @@ export function LibraryDocList({
                   onClick={() => onSelect(doc)}
                 >
                   <div className="library-doclist-item-header">
-                    <span className="library-doclist-item-title">{doc.title}</span>
+                    <span className="library-doclist-item-title" title={doc.title}>{doc.title}</span>
                     <span className="library-doclist-item-date">{relDate(doc.modifiedAt)}</span>
                   </div>
                   <div className="library-doclist-item-meta">


### PR DESCRIPTION
## What

The library doc-list item title (`library-doc-list.tsx:181`) is styled with `overflow:hidden; text-overflow:ellipsis; white-space:nowrap` (`library.css:832`), so a long filename truncates with no way to read the full name on hover. This adds `title={doc.title}` — matching the board **table** view (`board-table.tsx:242`), which already carries the same tooltip.

(The board **kanban** card title was checked and is *not* affected — it uses `word-break:break-word` and wraps rather than truncating.)

## Verification

- Library/a11y test suites pass: `library-polish`, `library-file-actions`, `library-error-retry`, `surface-error-states`, `labels-and-live-regions`.
- 1-line diff; no markup-pinned regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)