### PR TITLE
fix(a11y): pair accent-filled buttons with their semantic foreground

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7451,10 +7451,10 @@ a.mobile-handoff__link:hover {
 }
 .salem-pf__action:hover { color: var(--text-primary); }
 .salem-pf__action--primary {
-  background: var(--accent-presence); border-color: var(--accent-presence); color: #fff;
+  background: var(--accent-presence); border-color: var(--accent-presence); color: var(--accent-presence-foreground);
 }
 .salem-pf__action--save[data-save-state="saved"] {
-  background: var(--accent-presence); border-color: var(--accent-presence); color: #fff;
+  background: var(--accent-presence); border-color: var(--accent-presence); color: var(--accent-presence-foreground);
 }
 .salem-pf__action--save[data-save-state="error"] { border-color: var(--color-danger); color: var(--color-danger); }
 

--- a/src/components/a11y-audit-fixes.test.ts
+++ b/src/components/a11y-audit-fixes.test.ts
@@ -75,3 +75,27 @@ test("nav count badge uses a solid accent fill (WCAG contrast)", async () => {
     /\.menu-bar__badge\s*\{[\s\S]*?background:\s*color-mix\(in oklch, var\(--accent-presence\) 60%, transparent\)/,
   );
 });
+
+test("accent-filled buttons pair the accent with its semantic foreground", async () => {
+  // White / --text-primary on --accent-presence failed AA (~2.8:1 dark). The
+  // accent's paired --accent-presence-foreground adapts per mode, so route to it.
+  const board = await readFile(new URL("../styles/board.css", import.meta.url), "utf8");
+  assert.match(
+    board,
+    /\.board-new-card-btn\s*\{[^}]*background:var\(--accent-presence\)[^}]*color:var\(--accent-presence-foreground\)/,
+  );
+  assert.doesNotMatch(
+    board,
+    /\.board-new-card-btn\s*\{[^}]*background:var\(--accent-presence\)[^}]*color:var\(--text-primary\)/,
+  );
+  const css = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
+  // Both salem accent action states use the paired foreground, not hardcoded #fff.
+  assert.doesNotMatch(
+    css,
+    /\.salem-pf__action--primary\s*\{[^}]*background:\s*var\(--accent-presence\)[^}]*color:\s*#fff/,
+  );
+  assert.match(
+    css,
+    /\.salem-pf__action--primary\s*\{[^}]*color:\s*var\(--accent-presence-foreground\)/,
+  );
+});

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -54,7 +54,7 @@
 .board-view-toggle-btn:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:-1px; z-index:1; position:relative; }
 .board-view-toggle-btn--active { background:color-mix(in oklch,var(--accent-presence) 16%,var(--bg-raised)); color:var(--text-primary); }
 
-.board-new-card-btn { height:30px; padding:0 12px; border-radius:7px; border:1px solid var(--border-strong); background:var(--accent-presence); color:var(--text-primary); font-size:12px; font-weight:500; cursor:pointer; transition:background .12s,transform .1s; white-space:nowrap; }
+.board-new-card-btn { height:30px; padding:0 12px; border-radius:7px; border:1px solid var(--border-strong); background:var(--accent-presence); color:var(--accent-presence-foreground); font-size:12px; font-weight:500; cursor:pointer; transition:background .12s,transform .1s; white-space:nowrap; }
 .board-new-card-btn:hover { background:color-mix(in oklch, var(--accent-presence) 85%, #000); transform:scale(1.02); }
 .board-new-card-btn:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:2px; }
 


### PR DESCRIPTION
Follow-up to the contrast pass (#1791) — the deferred accent-button item.

## Problem
Three buttons filled with `var(--accent-presence)` hardcoded a non-paired text color:
- `board-new-card-btn` → `var(--text-primary)`
- `salem-pf__action--primary` → `#fff`
- `salem-pf__action--save[data-save-state="saved"]` → `#fff`

White/near-white on the pastel accent fell below WCAG AA in dark mode (~2.8:1).

## Fix
Route them to `--accent-presence-foreground` — the token already paired with `--accent-presence`, which flips per light/dark mode so it always contrasts. Measured before→after on the board button in a production build:
- Dark: **2.82 → 6.56:1**
- Light: **3.58 → 4.88:1**

Both AA. Consistent with the nav count badge (#1791). Verified visually — "+ New task" now renders legible dark text on the accent.

## Out of scope (deliberate)
The bulk-select checkmark glyphs (`dash-inbox__check`, `library-bulk-check`) also draw white on `--accent-presence`, but the filled box already conveys checked state, so I left them. The board priority pills (semantic hue) remain a separate call too.

## Tests
- `a11y-audit-fixes.test.ts` asserts the buttons use `--accent-presence-foreground` (and not the old hardcoded colors).
- `pnpm typecheck` clean; `app` suite (389 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)