### PR TITLE
feat(calendar): keyboard reschedule for time-grid events (Alt+↑/↓)

### DIFF
--- a/src/components/calendar-actions.test.ts
+++ b/src/components/calendar-actions.test.ts
@@ -77,4 +77,12 @@ assert.match(ws, /onComplete=\{completeInboxItem\}/, "CalendarView must receive 
 assert.match(ws, /onDismiss=\{dismissInboxItem\}/, "CalendarView must receive onDismiss");
 assert.match(ws, /onSnooze=\{snoozeInboxItem\}/, "CalendarView must receive onSnooze");
 
+// ── Keyboard reschedule (drag is mouse-only) ────────────────────────────────
+// Time-grid events nudge their start with Alt+↑/↓ (±15min, +Shift = 1h) via the
+// same onReschedule path as drag; plain ↑/↓ stay with the roving focus nav.
+assert.match(view, /if \(!e\.altKey \|\| \(e\.key !== "ArrowUp" && e\.key !== "ArrowDown"\)\) return;/, "events only reschedule on Alt+↑/↓");
+assert.match(view, /const step = \(e\.shiftKey \? 60 : 15\) \* \(e\.key === "ArrowDown" \? 1 : -1\)/, "Alt+↑/↓ nudges ±15min, Alt+Shift by an hour");
+assert.match(view, /onReschedule\(ev\.item\.id, slot\.toISOString\(\)\)/, "keyboard nudge persists through onReschedule");
+assert.match(view, /Alt\+↑↓ reschedule/, "the footer documents the keyboard reschedule");
+
 console.log("calendar-actions.test.ts: ok");

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -721,7 +721,24 @@ function TimeGrid({
                       : undefined
                   }
                   onClick={() => onOpenItem?.(ev.item)}
-                  title={onReschedule ? `${ev.item.title} — drag to reschedule` : ev.item.title}
+                  onKeyDown={
+                    onReschedule
+                      ? (e) => {
+                          // Keyboard reschedule (drag is mouse-only): Alt+↑/↓
+                          // nudges the start ±15 min, Alt+Shift+↑/↓ by an hour.
+                          // Plain ↑/↓ stay with the roving focus nav.
+                          if (!e.altKey || (e.key !== "ArrowUp" && e.key !== "ArrowDown")) return;
+                          e.preventDefault();
+                          const step = (e.shiftKey ? 60 : 15) * (e.key === "ArrowDown" ? 1 : -1);
+                          const minutes = Math.max(0, Math.min(24 * 60 - 15, ev.start + step));
+                          if (minutes === ev.start) return;
+                          const slot = new Date(col.date);
+                          slot.setHours(0, minutes, 0, 0);
+                          onReschedule(ev.item.id, slot.toISOString());
+                        }
+                      : undefined
+                  }
+                  title={onReschedule ? `${ev.item.title} — drag, or Alt+↑/↓, to reschedule` : ev.item.title}
                   className={`focus-ring-inset absolute flex items-center gap-1 rounded px-1.5 py-0.5 text-left text-[10px] border transition-colors overflow-hidden ${
                     done
                       ? "border-[var(--border-hairline)] bg-[var(--bg-raised)] opacity-60"
@@ -1647,7 +1664,7 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
       <footer
         className="hidden shrink-0 border-t border-[var(--border-hairline)] px-3 py-1.5 text-[10px] text-[var(--text-muted)] sm:px-6 md:block"
       >
-        ← → navigate · T today · D Day · W Week · M Month · A Agenda{onAddEntry ? " · N new" : ""}
+        ← → navigate · T today · D Day · W Week · M Month · A Agenda{onAddEntry ? " · N new" : ""}{onReschedule ? " · Alt+↑↓ reschedule" : ""}
       </footer>
       {selectedItem && (
         <ItemDetailPanel

--- a/src/lib/use-roving-tabindex.test.ts
+++ b/src/lib/use-roving-tabindex.test.ts
@@ -71,4 +71,12 @@ assert.match(
   "does not rove while typing in an input/textarea/select/contentEditable",
 );
 
+// Modified arrows (Alt/Cmd/Ctrl) are not roving — they pass through so the
+// focused item can own them (e.g. Alt+↑/↓ to nudge a calendar event's time).
+assert.match(
+  source,
+  /if \(e\.altKey \|\| e\.metaKey \|\| e\.ctrlKey\) return;/,
+  "roving ignores modified arrow keys",
+);
+
 console.log("use-roving-tabindex.test.ts OK");

--- a/src/lib/use-roving-tabindex.ts
+++ b/src/lib/use-roving-tabindex.ts
@@ -101,6 +101,9 @@ export function useRovingTabIndex({
       // and Home/End must jump within the text, not the item set.
       const t = e.target as HTMLElement | null;
       if (t && (t.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName))) return;
+      // Let modified arrows through — they're never roving (e.g. Alt+↑/↓ to
+      // nudge a calendar event's time), so the focused item can handle them.
+      if (e.altKey || e.metaKey || e.ctrlKey) return;
       switch (e.key) {
         case "ArrowDown":
           if (!vert) return;


### PR DESCRIPTION
## Calendar — keyboard reschedule

A follow-up to the earlier Calendar audit (#1751). Calendar events were **draggable** to reschedule but had **no keyboard equivalent** — a keyboard user could arrow between events (roving focus) and open them, but couldn't move an event's time. The Gantt already had ←/→ reschedule; this brings parity to the Calendar.

- A focused time-grid event now nudges its start with **Alt+↑/↓ (±15 min)**, **Alt+Shift+↑/↓ (±1 h)**, clamped to the day and persisted through the **same `onReschedule` path as drag-and-drop**. Plain ↑/↓ stay with the roving focus navigation.
- **`useRovingTabIndex`** now lets **modified arrows (Alt/Cmd/Ctrl) pass through** instead of consuming them, so the focused item can own them. This is universally correct for roving (no surface uses modified arrows to move the tab stop) and is what lets the calendar's Alt+↑/↓ reach the event. (Its own test + the calendar/board/projects/sidepanel roving tests all still pass.)
- The footer documents the shortcut.

## Testing
- **Verified live:** focused the "GitHub Roadmap Webinar" event and pressed Alt+↓ → it moved +15 min (`top` 1020→1034px) and fired a `PATCH /api/inbox/{id}`; no console errors.
- `tsc --noEmit` clean · `pnpm build` clean · full `app` suite: 388 files pass.
- Extended `calendar-actions.test.ts` (Alt+↑/↓ handler, step math, onReschedule, footer) and `use-roving-tabindex.test.ts` (ignores modified arrows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)