### PR TITLE
fix(dashboard): add title tooltips to truncated cockpit rows

### DIFF
--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -417,7 +417,7 @@ function BoardSnapshot({ byStatus, total, active, loaded, familiars }: {
             <li key={c.id}>
               <a className="cockpit-cardrow" href={`/#card-${c.id}`}>
                 <span className="cockpit-dot" style={{ background: STATUS_META[c.status].color }} />
-                <span className="cockpit-cardrow__title">{c.title}</span>
+                <span className="cockpit-cardrow__title" title={c.title}>{c.title}</span>
                 {famName(c.familiarId) ? <span className="cockpit-cardrow__who">{famName(c.familiarId)}</span> : null}
               </a>
             </li>
@@ -444,8 +444,8 @@ function AgentsPanel({ familiars, loaded }: { familiars: Familiar[]; loaded: boo
               {active ? <span className="cockpit-agent__on" /> : null}
             </span>
             <span className="cockpit-agent__body">
-              <span className="cockpit-agent__name">{f.display_name}</span>
-              <span className="cockpit-agent__role">{f.role || f.model || "familiar"}</span>
+              <span className="cockpit-agent__name" title={f.display_name}>{f.display_name}</span>
+              <span className="cockpit-agent__role" title={f.role || f.model || "familiar"}>{f.role || f.model || "familiar"}</span>
             </span>
             {active ? <span className="cockpit-agent__busy">{f.active_sessions} active</span> : null}
           </li>
@@ -469,7 +469,7 @@ function GithubPanel({ items, loaded }: { items: GitHubItem[]; loaded: boolean }
         <li key={g.id}>
           <a className="cockpit-ghrow" href={g.url} target="_blank" rel="noreferrer">
             <Icon name={GH_ICON[g.kind]} className="cockpit-ghrow__icon" aria-hidden />
-            <span className="cockpit-ghrow__title">{g.title}</span>
+            <span className="cockpit-ghrow__title" title={g.title}>{g.title}</span>
             <span className="cockpit-ghrow__meta">
               {checkDot(g.checkStatus)}
               <span className="cockpit-ghrow__repo">{shortRepo(g.repo)}{g.number ? ` #${g.number}` : ""}</span>
@@ -500,7 +500,7 @@ function AgendaPanel({ items, now, loaded }: { items: InboxItem[]; now: Date; lo
       {items.map((i) => (
         <li key={i.id} className="cockpit-agendarow">
           <span className="cockpit-agendarow__when">{whenLabel(i.fireAt!, now)}</span>
-          <span className="cockpit-agendarow__title">{i.title}</span>
+          <span className="cockpit-agendarow__title" title={i.title}>{i.title}</span>
         </li>
       ))}
     </ul>
@@ -529,7 +529,7 @@ function ReadingPanel({ items, loaded }: { items: ReadingItem[]; loaded: boolean
           <li key={r.id}>
             <a className="cockpit-readrow" href={r.url || "#"} target={r.url ? "_blank" : undefined} rel="noreferrer">
               <span className="cockpit-dot" style={{ background: reading ? "var(--accent-presence)" : "var(--text-muted)" }} />
-              <span className="cockpit-readrow__title">{r.title}</span>
+              <span className="cockpit-readrow__title" title={r.title}>{r.title}</span>
               {host(r.url) ? <span className="cockpit-readrow__host">{host(r.url)}</span> : null}
             </a>
           </li>


### PR DESCRIPTION
## What

The home cockpit (the app's landing surface) truncates six dynamic text spans with ellipsis but offers no way to read the full value on hover. All six are styled `overflow:hidden; text-overflow:ellipsis; white-space:nowrap` in `dashboard.css`:

| Span | Content | dashboard.css |
|---|---|---|
| `cockpit-cardrow__title` | board card title | :278 |
| `cockpit-agent__name` | familiar name | :290 |
| `cockpit-agent__role` | familiar role/model | :291 |
| `cockpit-ghrow__title` | GitHub PR/issue title | :299 |
| `cockpit-agendarow__title` | upcoming reminder | :306 |
| `cockpit-readrow__title` | reading-queue item | :311 |

This adds `title={...}` to each, matching the board **table** (`board-table.tsx:242`) and library doc-list (#1792) which already carry the same tooltip. Highest-traffic surface, so the broadest hover-readability win of this batch.

## Verification

- `dashboard-page.test.ts` passes; neither dashboard test pins the changed span markup.
- 6-line diff, isolated from this checkout's in-flight familiar-growth work (branched off `origin/main`, only the six spans touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)