### PR TITLE
feat(ios): iPad split-view for the Tasks tab (list + detail)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -16,7 +16,10 @@ struct TasksView: View {
     @AppStorage("cave.tasks.groupBy") private var groupByRaw = GroupBy.status.rawValue
     @AppStorage("cave.tasks.sortBy") private var sortByRaw = SortBy.priority.rawValue
     @State private var query = ""
-    @State private var path: [BoardCard] = []
+    /// The task shown in the detail column. On iPad this fills the detail pane
+    /// beside the list; on iPhone `NavigationSplitView` collapses and selecting a
+    /// row pushes the detail, so the single-column behaviour is unchanged.
+    @State private var selection: BoardCard?
     /// A task awaiting delete confirmation (swipe or context menu).
     @State private var pendingDelete: BoardCard?
     @State private var showReminders = false
@@ -44,11 +47,10 @@ struct TasksView: View {
     private var sortBy: SortBy { SortBy(rawValue: sortByRaw) ?? .priority }
 
     var body: some View {
-        NavigationStack(path: $path) {
+        NavigationSplitView {
             content
                 .navigationTitle("Tasks")
                 .navigationBarTitleDisplayMode(.inline)
-                .navigationDestination(for: BoardCard.self) { TaskDetailView(card: $0) }
                 .searchable(text: $query, prompt: "Search tasks")
                 .toolbar {
                     ToolbarItem(placement: .topBarTrailing) {
@@ -86,7 +88,20 @@ struct TasksView: View {
                     Button("Cancel", role: .cancel) {}
                 } message: { card in Text(card.title) }
                 .sheet(isPresented: $showReminders) { RemindersView() }
+        } detail: {
+            if let selection {
+                NavigationStack { TaskDetailView(card: selection) }
+            } else {
+                ContentUnavailableView {
+                    Label("Select a task", systemImage: "checklist")
+                } description: {
+                    Text("Pick a task to see its details and steps.")
+                }
+            }
         }
+        // Keep the task list visible beside the detail on iPad rather than letting
+        // the detail take over; on iPhone the split view still collapses to a stack.
+        .navigationSplitViewStyle(.balanced)
     }
 
     private var deleteDialogBinding: Binding<Bool> {
@@ -125,7 +140,7 @@ struct TasksView: View {
     /// Consume a cross-tab "open this task" intent set by `requestOpenTask`.
     private func openRequestedCard() {
         guard let card = app.cardToOpen else { return }
-        if path.last?.id != card.id { path.append(card) }
+        if selection?.id != card.id { selection = card }
         app.cardToOpen = nil
     }
 
@@ -157,12 +172,12 @@ struct TasksView: View {
     }
 
     private var taskList: some View {
-        List {
+        List(selection: $selection) {
             ForEach(sections) { section in
                 Section {
                     ForEach(section.cards) { card in
-                        Button { path.append(card) } label: { TaskRow(card: card) }
-                            .buttonStyle(.plain)
+                        TaskRow(card: card)
+                            .tag(card)
                             .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 12))
                             .contextMenu { taskMenu(card) }
                             .swipeActions(edge: .trailing, allowsFullSwipe: true) {
@@ -190,7 +205,6 @@ struct TasksView: View {
         }
         .listStyle(.insetGrouped)
         .themedListBackground()
-        .readableListWidth()
     }
 
     private var emptyState: some View {

--- a/scripts/ios-ipad-split-tasks.test.mjs
+++ b/scripts/ios-ipad-split-tasks.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// On iPad the Tasks tab should be a two-column NavigationSplitView (list + detail)
+// rather than the iPhone single-column stack. NavigationSplitView collapses to a
+// stack automatically on compact width, so iPhone is unchanged. This locks the
+// conversion: a split view driven by a `selection`, with a detail column and a
+// placeholder when nothing is selected.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const src = await read("apps/ios/CovenCave/CovenCave/Views/TasksView.swift");
+
+assert.match(
+  src,
+  /NavigationSplitView \{[\s\S]*\} detail: \{/,
+  "TasksView should use NavigationSplitView with a detail column",
+);
+assert.doesNotMatch(
+  src,
+  /NavigationStack\(path: \$path\)/,
+  "the old path-based NavigationStack should be gone",
+);
+// Selection drives the detail (and the collapsed-stack push on iPhone).
+assert.match(
+  src,
+  /@State private var selection: BoardCard\?/,
+  "TasksView should track the selected card",
+);
+assert.match(
+  src,
+  /List\(selection: \$selection\)/,
+  "the task list should be selection-driven so it adapts across iPad/iPhone",
+);
+assert.match(
+  src,
+  /TaskRow\(card: card\)\s*\n\s*\.tag\(card\)/,
+  "rows should be tagged with their card for selection",
+);
+// Detail shows the selected task, or a placeholder on iPad when none is picked.
+assert.match(
+  src,
+  /\} detail: \{[\s\S]*TaskDetailView\(card: selection\)[\s\S]*ContentUnavailableView/,
+  "the detail column should show the selected task or a 'Select a task' placeholder",
+);
+// Keep the list visible beside the detail on iPad.
+assert.match(
+  src,
+  /\.navigationSplitViewStyle\(\.balanced\)/,
+  "the split view should use the balanced style so the list stays visible on iPad",
+);
+// The chat→task deep link now targets the selection, not a nav path.
+assert.match(
+  src,
+  /func openRequestedCard\(\)[\s\S]*selection = card/,
+  "opening a task from a chat should set the selection",
+);
+
+console.log("ios-ipad-split-tasks: OK");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -511,6 +511,7 @@ export const SUITES = {
     "scripts/ios-task-notes-reader.test.mjs",
     "scripts/ios-task-notes-edit.test.mjs",
     "scripts/ios-task-actions.test.mjs",
+    "scripts/ios-ipad-split-tasks.test.mjs",
     "scripts/ios-task-search-familiar-scope.test.mjs",
     "scripts/ios-thread-rename.test.mjs",
     "scripts/ios-archive-threads.test.mjs",


### PR DESCRIPTION
## What

On iPad the Tasks tab ran the iPhone single-column layout — a list that pushed the detail full-screen, wasting the landscape screen. This converts it to a **`NavigationSplitView`**: the task list in the sidebar, `TaskDetailView` in the detail column (with a "Select a task" placeholder when nothing is picked).

This is the **first** of the iPad split-view work (you picked it from the UX shortlist). Chats (3-column) and Reading will follow as separate PRs — landing it incrementally keeps each change verifiable and low-conflict.

## How

- `NavigationStack(path:)` → `NavigationSplitView { … } detail: { … }`.
- The list is now `List(selection:)` with `.tag(card)` rows; selection drives the detail.
- **iPhone is unchanged**: on compact width `NavigationSplitView` collapses to a stack and selecting a row pushes the detail (same as before).
- `.navigationSplitViewStyle(.balanced)` keeps the list visible beside the detail on iPad.
- The chat→task deep link (`openRequestedCard` / `cardToOpen`) now sets the selection. Dropped the now-unused `.readableListWidth()` (the split view governs width on iPad).

## Verification

- **iPad Pro simulator**: two columns — task list (search, group tabs, "In progress"/"In review" sections with real board cards) on the left, detail placeholder on the right.
- **iPhone 16 Pro simulator**: collapses to the single-column list (no regression); row tap pushes the detail.
- New `scripts/ios-ipad-split-tasks.test.mjs` locks the conversion (wired into CI; `check:tests-wired` green — 531 files); existing `ios-task-actions` / `ios-theme-list-background` / etc. still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)