### PR TITLE
feat(ios): rich link previews in chat

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/LinkPreview.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/LinkPreview.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+import UIKit
+import LinkPresentation
+
+/// The first `http(s)` URL in a string (used to preview links in chat bubbles).
+func firstLink(in text: String) -> URL? {
+    guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+    else { return nil }
+    let range = NSRange(text.startIndex..., in: text)
+    for match in detector.matches(in: text, options: [], range: range) {
+        if let url = match.url, let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" {
+            return url
+        }
+    }
+    return nil
+}
+
+/// Process-wide cache of fetched link metadata so a bubble doesn't re-fetch on
+/// every re-render / scroll.
+@MainActor
+final class LinkMetadataCache {
+    static let shared = LinkMetadataCache()
+    private var cache: [String: LPLinkMetadata] = [:]
+
+    func fetch(_ url: URL) async -> LPLinkMetadata? {
+        let key = url.absoluteString
+        if let hit = cache[key] { return hit }
+        let provider = LPMetadataProvider()
+        guard let metadata = try? await provider.startFetchingMetadata(for: url) else { return nil }
+        cache[key] = metadata
+        return metadata
+    }
+}
+
+/// A compact preview card for a URL: site thumbnail/icon + title + host, tappable
+/// to open. Built in SwiftUI (LPLinkView doesn't size reliably inside SwiftUI),
+/// fed by the fetched `LPLinkMetadata`. Renders nothing until metadata loads, so
+/// the markdown link still stands; image falls back to a link glyph.
+struct LinkPreviewCard: View {
+    let url: URL
+    @Environment(\.chrome) private var chrome
+    @State private var metadata: LPLinkMetadata?
+    @State private var image: UIImage?
+
+    var body: some View {
+        Group {
+            if let metadata {
+                Button { UIApplication.shared.open(url) } label: { card(metadata) }
+                    .buttonStyle(.plain)
+            } else {
+                // A zero-height placeholder (not EmptyView) so `.task` actually
+                // runs to fetch the metadata before there's a card to show.
+                Color.clear.frame(width: 1, height: 1)
+            }
+        }
+        .task(id: url) {
+            guard metadata == nil, let m = await LinkMetadataCache.shared.fetch(url) else { return }
+            metadata = m
+            image = await Self.loadImage(m)
+        }
+    }
+
+    private func card(_ m: LPLinkMetadata) -> some View {
+        HStack(spacing: 10) {
+            Group {
+                if let image {
+                    Image(uiImage: image).resizable().scaledToFill()
+                } else {
+                    Image(systemName: "link").font(.title3).foregroundStyle(chrome.accent)
+                }
+            }
+            .frame(width: 52, height: 52)
+            .clipped()
+            .background(chrome.bgElevated)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(m.title ?? url.host ?? url.absoluteString)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                Text(url.host ?? url.absoluteString)
+                    .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+            }
+            .padding(.vertical, 6)
+            .padding(.trailing, 10)
+
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: 280, alignment: .leading)
+        .glassFill(.raised, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(Color(.separator).opacity(0.5), lineWidth: 1)
+        )
+    }
+
+    /// Load the preview image (or favicon) from the metadata's providers.
+    private static func loadImage(_ m: LPLinkMetadata) async -> UIImage? {
+        let provider = m.imageProvider ?? m.iconProvider
+        guard let provider, provider.canLoadObject(ofClass: UIImage.self) else { return nil }
+        return await withCheckedContinuation { cont in
+            provider.loadObject(ofClass: UIImage.self) { obj, _ in
+                cont.resume(returning: obj as? UIImage)
+            }
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -211,6 +211,11 @@ struct MessageBubble: View {
                         .contextMenu { messageActions }
                 }
 
+                // Rich preview card for the first link in a finished message.
+                if !message.streaming, let link = firstLink(in: parsed.visible) {
+                    LinkPreviewCard(url: link)
+                }
+
                 // A failed reply gets a visible Retry button, not just the
                 // long-press menu — a flaky network shouldn't leave a dead-end
                 // red bubble. (Retry re-streams just this bubble's familiar.)

--- a/scripts/ios-link-previews.test.mjs
+++ b/scripts/ios-link-previews.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const base = "../apps/ios/CovenCave/CovenCave/Views";
+const read = (p) => readFile(new URL(`${base}/${p}`, import.meta.url), "utf8");
+
+const lp = await read("LinkPreview.swift");
+assert.match(lp, /import LinkPresentation/, "should use the LinkPresentation framework");
+assert.match(
+  lp,
+  /func firstLink\(in text: String\) -> URL\?[\s\S]*NSDataDetector[\s\S]*scheme == "http" \|\| scheme == "https"/,
+  "firstLink should extract the first http(s) URL via NSDataDetector",
+);
+assert.match(lp, /final class LinkMetadataCache[\s\S]*func fetch\(_ url: URL\) async -> LPLinkMetadata\?/, "metadata should be cached + fetched");
+assert.match(lp, /struct LinkPreviewCard: View[\s\S]*LinkMetadataCache\.shared\.fetch\(url\)/, "LinkPreviewCard should fetch then render");
+// Custom SwiftUI card (LPLinkView doesn't size in SwiftUI) with a non-EmptyView
+// placeholder so the fetch task actually runs.
+assert.doesNotMatch(lp, /LPLinkView\(/, "should not embed an LPLinkView (doesn't size in SwiftUI)");
+assert.match(lp, /Color\.clear\.frame\(width: 1, height: 1\)/, "should keep a non-empty placeholder so .task runs");
+assert.match(lp, /Text\(m\.title \?\? url\.host/, "the card should show the title");
+
+const bubble = await read("MessageBubble.swift");
+assert.match(
+  bubble,
+  /if !message\.streaming, let link = firstLink\(in: parsed\.visible\) \{\s*LinkPreviewCard\(url: link\)/,
+  "MessageBubble should show a LinkPreviewCard for the first link in a finished message",
+);
+
+console.log("ios-link-previews: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -540,6 +540,7 @@ export const SUITES = {
     "scripts/ios-familiar-row-actions.test.mjs",
     "scripts/ios-group-mentions.test.mjs",
     "scripts/ios-reply-feedback.test.mjs",
+    "scripts/ios-link-previews.test.mjs",
     "scripts/ios-markdown-accent.test.mjs",
     "scripts/ios-message-forwarding.test.mjs",
     "scripts/ios-message-retry.test.mjs",


### PR DESCRIPTION
Fresh UX idea #4. Messages with a URL now show a compact **preview card** (site title + host + thumbnail/favicon, tappable to open) below the bubble.

- `firstLink()` extracts the first http(s) URL via `NSDataDetector`.
- `LinkMetadataCache` fetches `LPLinkMetadata` (`LPMetadataProvider`), cached per URL.
- `LinkPreviewCard` is a **custom SwiftUI card** — `LPLinkView` doesn't size reliably inside SwiftUI (renders 0-height), so it's rebuilt natively; the image comes from the metadata's image/icon provider with a link-glyph fallback.

> Two SwiftUI gotchas hit & fixed during this: (1) `LPLinkView` won't size in SwiftUI → custom card; (2) a `Group` that's empty until data loads renders as `EmptyView`, whose `.task` never fires → kept a 1×1 placeholder so the fetch runs.

## Verified live (simulator)
The card renders below the message with the title ("Apple") + host (www.apple.com). It shows nothing until metadata loads, so the markdown link always stands; the live metadata fetch is best-effort and more reliable on a real device than in the sim.

`xcodebuild` (iPhone 16 Pro sim): **BUILD SUCCEEDED**. New `scripts/ios-link-previews.test.mjs` wired; `check:tests-wired` green (530 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)