### PR TITLE
fix(a11y): darken priority-pill text in light mode for WCAG contrast

### DIFF
--- a/src/components/a11y-audit-fixes.test.ts
+++ b/src/components/a11y-audit-fixes.test.ts
@@ -99,3 +99,23 @@ test("accent-filled buttons pair the accent with its semantic foreground", async
     /\.salem-pf__action--primary\s*\{[^}]*color:\s*var\(--accent-presence-foreground\)/,
   );
 });
+
+test("priority pills darken their text in light mode (WCAG contrast)", async () => {
+  const board = await readFile(new URL("../styles/board.css", import.meta.url), "utf8");
+  // The pill text is lightened toward #fff for dark mode; light mode needs the
+  // opposite (mix toward #000) or it fails AA on the faint tint (~2:1).
+  for (const variant of ["urgent", "high", "medium"]) {
+    assert.match(
+      board,
+      new RegExp(`\\[data-mode="light"\\] \\.board-kanban-priority-pill--${variant}\\s*\\{[^}]*color:color-mix\\(in oklch,var\\(--[a-z-]+\\) 76%,#000\\)`),
+      `kanban ${variant} pill must darken text in light mode`,
+    );
+  }
+  for (const variant of ["urgent", "high"]) {
+    assert.match(
+      board,
+      new RegExp(`\\[data-mode="light"\\] \\.board-card-stack__priority-pill--${variant}\\s*\\{[^}]*#000`),
+      `card-stack ${variant} pill must darken text in light mode`,
+    );
+  }
+});

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -306,6 +306,12 @@
 .board-kanban-priority-pill--high { background:color-mix(in oklch,var(--color-warning) 18%,transparent); color:color-mix(in oklch,var(--color-warning) 70%,#fff); }
 .board-kanban-priority-pill--medium { background:color-mix(in oklch,var(--accent-presence) 18%,transparent); color:color-mix(in oklch,var(--accent-presence) 80%,#fff); }
 .board-kanban-priority-pill--low { background:var(--bg-elevated); color:var(--text-muted); }
+/* The pill text is lightened toward #fff for legibility on the dark-mode tint.
+   In light mode that lightened text fails WCAG on the faint tint, so darken it
+   toward #000 instead (≈5.8–7:1 vs the prior 2.0–2.6:1). */
+[data-mode="light"] .board-kanban-priority-pill--urgent { color:color-mix(in oklch,var(--color-danger) 76%,#000); }
+[data-mode="light"] .board-kanban-priority-pill--high { color:color-mix(in oklch,var(--color-warning) 76%,#000); }
+[data-mode="light"] .board-kanban-priority-pill--medium { color:color-mix(in oklch,var(--accent-presence) 76%,#000); }
 
 .board-kanban-card-title { font-size:12.5px; font-weight:500; color:var(--text-primary); line-height:1.4; word-break:break-word; }
 .board-kanban-card-notes { font-size:11px; line-height:1.5; color:var(--text-muted); margin:0; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
@@ -1473,6 +1479,10 @@
   background: color-mix(in oklch, var(--color-warning) 18%, transparent);
   color: var(--color-warning);
 }
+/* Raw danger/warning text reads on the dark-mode tint but fails WCAG on the
+   light-mode tint (warning especially); darken it toward #000 in light mode. */
+[data-mode="light"] .board-card-stack__priority-pill--urgent { color: color-mix(in oklch, var(--color-danger) 76%, #000); }
+[data-mode="light"] .board-card-stack__priority-pill--high { color: color-mix(in oklch, var(--color-warning) 76%, #000); }
 .board-card-stack__row-title {
   font-size: 14px;
   font-weight: 500;


### PR DESCRIPTION
The last open item from the contrast pass — board priority pills.

## Problem
Priority pills (kanban + card-stack) tint their text toward `#fff` (or use the raw semantic color) so it reads on the dark-mode 18% tint. In light mode that same text sits on a near-white tint and fails AA:
- urgent **2.23:1**, high **1.97:1**, medium **2.64:1** (need 4.5)

Dark mode was already fine (5.9–10:1).

## Fix
Light-mode-only overrides that mix the semantic color toward `#000` (76% color / 24% black) instead of toward white. Keeps the red/amber/purple identity while clearing AA:
- urgent **6.93**, high **5.84**, medium **6.72**, low already 4.9

Applied to both `.board-kanban-priority-pill--{urgent,high,medium}` and `.board-card-stack__priority-pill--{urgent,high}`. Dark mode untouched.

## Verified
- Computed-contrast measurement in a production build, both modes.
- Visually — pills stay color-coded and legible on a light board.
- `a11y-audit-fixes.test.ts` asserts the light-mode darkening exists; typecheck clean; `app` suite (391 files) green.

This completes the contrast pass: muted text (already AA), nav badge (#1791), accent buttons (#1793), and now priority pills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)