### PR TITLE
fix(workflows): add title tooltips to truncated workflow & step labels

### DIFF
--- a/src/components/workflows/workflow-library.tsx
+++ b/src/components/workflows/workflow-library.tsx
@@ -88,7 +88,7 @@ export function WorkflowLibrary({
         onClick={() => onSelectWorkflow(workflow)}
       >
         <span className="workflow-library-item-title">
-          <span className="workflow-library-item-name">{workflow.name ?? workflow.id}</span>
+          <span className="workflow-library-item-name" title={workflow.name ?? workflow.id}>{workflow.name ?? workflow.id}</span>
           {active && dirty && <span className="workflow-dirty-dot" title="Unsaved changes" />}
           <span
             className={`workflow-origin-dot workflow-origin-dot-${personal ? "personal" : "public"}`}

--- a/src/components/workflows/workflow-step-list.tsx
+++ b/src/components/workflows/workflow-step-list.tsx
@@ -95,8 +95,8 @@ export function WorkflowStepList({
                 </span>
                 <span className="workflow-step-body">
                   <span className="workflow-step-kind">{data.kind}</span>
-                  <span className="workflow-step-label">{data.label}</span>
-                  {data.uses && <span className="workflow-step-uses">{data.uses}</span>}
+                  <span className="workflow-step-label" title={data.label}>{data.label}</span>
+                  {data.uses && <span className="workflow-step-uses" title={data.uses}>{data.uses}</span>}
                 </span>
                 {phase ? (
                   <span className={`workflow-step-pill workflow-node-phase-pill-${phase}`}>


### PR DESCRIPTION
## What

On the Workflows surface, three dynamic spans truncate with ellipsis but offer no hover tooltip — all styled `overflow:hidden; text-overflow:ellipsis; white-space:nowrap`:

| Span | Content | workflows.css |
|---|---|---|
| `workflow-library-item-name` | workflow name (`workflow-library.tsx:91`) | :449 |
| `workflow-step-label` | step label (`workflow-step-list.tsx:98`) | :649 |
| `workflow-step-uses` | step skill/tool id (`workflow-step-list.tsx:99`) | :657 |

This adds `title={...}` to each, matching the calendar (#1786), library doc-list (#1792), and dashboard cockpit (#1795) which already do this.

## Verification

- Workflow test suites pass: `workflow-step-list`, `workflow-studio`, `workflows-view`, `surface-loading-states`, `a11y-audit-fixes`; none pin the changed span markup.
- `tsc --noEmit` clean for both files. 3-line diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)