### PR TITLE
fix(a11y): pair bulk-select checkmark glyphs with the accent foreground

### DIFF
--- a/src/components/a11y-audit-fixes.test.ts
+++ b/src/components/a11y-audit-fixes.test.ts
@@ -119,3 +119,20 @@ test("priority pills darken their text in light mode (WCAG contrast)", async () 
     );
   }
 });
+
+test("bulk-select checkmark glyphs pair with the accent's semantic foreground", async () => {
+  // The check sits on a filled var(--accent-presence) box; white failed the 3:1
+  // non-text-contrast threshold in dark mode. Route to the paired foreground.
+  const dashboard = await readFile(new URL("../styles/dashboard.css", import.meta.url), "utf8");
+  const library = await readFile(new URL("../styles/library.css", import.meta.url), "utf8");
+  assert.match(
+    dashboard,
+    /\.dash-inbox__check\[data-checked="true"\]\s*\{[^}]*color:\s*var\(--accent-presence-foreground\)/,
+  );
+  assert.match(
+    library,
+    /\.library-bulk-check\[data-checked="true"\]\s*\{[^}]*color:\s*var\(--accent-presence-foreground\)/,
+  );
+  assert.doesNotMatch(dashboard, /\.dash-inbox__check\[data-checked="true"\]\s*\{[^}]*color:\s*#fff/);
+  assert.doesNotMatch(library, /\.library-bulk-check\[data-checked="true"\]\s*\{[^}]*color:\s*#fff/);
+});

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -59,7 +59,7 @@
   display: inline-grid; place-items: center; width: 18px; height: 18px; flex: 0 0 auto;
   border: 1px solid var(--border-strong); border-radius: 5px; color: transparent;
 }
-.dash-inbox__check[data-checked="true"] { border-color: var(--accent-presence); background: var(--accent-presence); color: #fff; }
+.dash-inbox__check[data-checked="true"] { border-color: var(--accent-presence); background: var(--accent-presence); color: var(--accent-presence-foreground); }
 .dash-inbox__check svg { width: 11px; height: 11px; }
 
 .dash-inbox__actions {

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -1438,7 +1438,7 @@
 .library-bulk-bar__delete:hover:not(:disabled) { background: color-mix(in oklch, var(--color-danger) 20%, transparent); }
 .library-bulk-bar__delete:disabled { opacity: 0.5; cursor: default; }
 .library-bulk-check { display: inline-grid; place-items: center; width: 16px; height: 16px; border-radius: 4px; border: 1px solid var(--border-strong); color: transparent; flex: 0 0 auto; }
-.library-bulk-check[data-checked="true"] { border-color: var(--accent-presence); background: var(--accent-presence); color: #fff; }
+.library-bulk-check[data-checked="true"] { border-color: var(--accent-presence); background: var(--accent-presence); color: var(--accent-presence-foreground); }
 .library-reading-row.is-selected { background: color-mix(in oklch, var(--accent-presence) 12%, transparent); }
 
 .library-row-delete {


### PR DESCRIPTION
The last deferred contrast item — bulk-select checkmark glyphs.

## Problem
The checked-state checkmark in `.dash-inbox__check` and `.library-bulk-check` sits on a filled `var(--accent-presence)` box but hardcoded a white glyph. White on the pastel accent fell below the WCAG **3:1 non-text-contrast** threshold in dark mode (~2.8:1).

## Fix
Route the glyph to `--accent-presence-foreground` (the per-mode paired color), matching the nav badge (#1791), accent buttons (#1793), and priority pills (#1799). Measured:
- Dark: **2.8 → 6.56:1**
- Light: **4.88:1**

Both clear 3:1 (and even the stricter 4.5:1 text threshold). Verified by computed-contrast measurement in a production build and visually — the dark-mode check is now a legible dark glyph on the accent box.

## Tests
- `a11y-audit-fixes.test.ts` asserts both glyphs use `--accent-presence-foreground` (not `#fff`).
- `pnpm typecheck` clean; `app` suite (391 files) green.

This completes the contrast pass — every measured non-exempt element now meets WCAG AA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)