### PR TITLE
feat(ios): iPad split-view for the Chats tab (list + conversation)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -17,7 +17,14 @@ struct ChatsHomeView: View {
     @State private var query = ""
     /// Drives the accent glow on the search field while it's being edited.
     @FocusState private var searchFocused: Bool
-    @State private var path: [ChatRoute] = []
+    /// The sidebar selection: a familiar (drills into its threads in the detail
+    /// column) or a thread/group (opens the chat directly). On iPad the detail
+    /// fills the pane beside the list; on iPhone `NavigationSplitView` collapses
+    /// and selecting pushes, so the drill-down behaviour is unchanged.
+    @State private var selection: ChatRoute?
+    /// Navigation *within* the detail column — e.g. a familiar's thread list
+    /// pushing a conversation. Reset whenever the sidebar selection changes.
+    @State private var detailPath: [ChatRoute] = []
     @State private var renamingThread: ChatThread?
     /// A group thread awaiting delete confirmation (swipe or context menu).
     @State private var pendingDelete: ChatThread?
@@ -26,7 +33,7 @@ struct ChatsHomeView: View {
     @State private var showArchived = false
 
     var body: some View {
-        NavigationStack(path: $path) {
+        NavigationSplitView {
             Group {
                 if app.familiars.isEmpty && app.threads.isEmpty {
                     emptyState
@@ -41,21 +48,13 @@ struct ChatsHomeView: View {
             // every tab's header aligns. Search + compose stay in the bottom bar.
             .toolbar(.hidden, for: .navigationBar)
             .safeAreaInset(edge: .top, spacing: 0) { header }
-            .navigationDestination(for: ChatRoute.self) { route in
-                switch route {
-                case .familiar(let familiar):
-                    FamiliarThreadsView(familiar: familiar, path: $path)
-                case .thread(let thread):
-                    ChatView(thread: thread)
-                }
-            }
             // Search + compose live in a floating bottom bar (iMessage-style),
             // not the top toolbar; Settings is now its own tab.
             .safeAreaInset(edge: .bottom) { bottomBar }
             .sheet(isPresented: $showNewChat) {
                 NewChatView { thread in
                     showNewChat = false
-                    path.append(.thread(thread))
+                    open(.thread(thread))
                 }
             }
             .refreshable {
@@ -65,19 +64,66 @@ struct ChatsHomeView: View {
             .task { await app.loadSessions() }
             .onAppear(perform: openDeepLinkedThread)
             // A slash command (`/new`, `/familiar <name>`) or a task link asked to
-            // open a specific thread — push it straight onto the stack.
+            // open a specific thread — surface it in the detail column.
             .onChange(of: app.threadToOpen) { _, thread in
                 guard let thread else { return }
-                if lastThreadId != thread.id { path.append(.thread(thread)) }
+                if lastThreadId != thread.id { open(.thread(thread)) }
                 app.threadToOpen = nil
+            }
+        } detail: {
+            detailColumn
+        }
+        // Keep the list visible beside the conversation on iPad; on iPhone the
+        // split view still collapses to a single navigation stack.
+        .navigationSplitViewStyle(.balanced)
+        // A new sidebar selection starts a fresh detail navigation (so a familiar
+        // opens at its thread list, not a stale pushed conversation).
+        .onChange(of: selection) { _, _ in detailPath = [] }
+    }
+
+    /// The detail column: the selected familiar's thread list (which pushes a
+    /// conversation onto `detailPath`), the selected conversation directly, or a
+    /// placeholder on iPad when nothing is chosen yet.
+    @ViewBuilder private var detailColumn: some View {
+        NavigationStack(path: $detailPath) {
+            Group {
+                switch selection {
+                case .familiar(let familiar):
+                    FamiliarThreadsView(familiar: familiar, path: $detailPath)
+                case .thread(let thread):
+                    ChatView(thread: thread)
+                case nil:
+                    ContentUnavailableView {
+                        Label("Select a chat", systemImage: "bubble.left.and.bubble.right")
+                    } description: {
+                        Text("Pick a familiar or conversation to start.")
+                    }
+                }
+            }
+            .navigationDestination(for: ChatRoute.self) { route in
+                switch route {
+                case .familiar(let familiar):
+                    FamiliarThreadsView(familiar: familiar, path: $detailPath)
+                case .thread(let thread):
+                    ChatView(thread: thread)
+                }
             }
         }
     }
 
-    /// The id of the thread currently on top of the stack, if any (so a repeat
-    /// `requestOpen` of the same thread doesn't double-push it).
+    /// Open a route in the detail column (clearing any in-progress detail
+    /// navigation first), used by deep links and the new-chat sheet.
+    private func open(_ route: ChatRoute) {
+        detailPath = []
+        selection = route
+    }
+
+    /// The id of the conversation currently shown in the detail column, if any
+    /// (so a repeat `requestOpen` of the same thread doesn't re-select it). Covers
+    /// both a directly-selected thread and one pushed under a familiar.
     private var lastThreadId: String? {
-        if case .thread(let t) = path.last { return t.id }
+        if case .thread(let t) = detailPath.last { return t.id }
+        if case .thread(let t) = selection { return t.id }
         return nil
     }
 
@@ -86,14 +132,14 @@ struct ChatsHomeView: View {
     /// Start a brand-new chat with a familiar and open it (familiar-row action).
     private func startNewChat(with familiar: Familiar) {
         let thread = app.startFreshThread(familiarIds: [familiar.id])
-        path.append(.thread(thread))
+        open(.thread(thread))
     }
 
     private func openDeepLinkedThread() {
-        guard path.isEmpty,
+        guard selection == nil,
               let id = ProcessInfo.processInfo.environment["CAVE_OPEN_THREAD"],
               let thread = app.threads.first(where: { $0.id == id }) else { return }
-        path.append(.thread(thread))
+        open(.thread(thread))
     }
 
     /// Large-title header pinned to the top, mirroring the Read / Tasks tabs
@@ -127,12 +173,11 @@ struct ChatsHomeView: View {
     }
 
     private var homeList: some View {
-        List {
+        List(selection: $selection) {
             Section(filteredFamiliars.isEmpty ? "" : "Familiars") {
                 ForEach(filteredFamiliars) { familiar in
-                    NavigationLink(value: ChatRoute.familiar(familiar)) {
-                        FamiliarRow(familiar: familiar)
-                    }
+                    FamiliarRow(familiar: familiar)
+                    .tag(ChatRoute.familiar(familiar))
                     .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
                     .swipeActions(edge: .leading, allowsFullSwipe: true) {
                         Button { startNewChat(with: familiar) } label: {
@@ -166,10 +211,8 @@ struct ChatsHomeView: View {
             if !filteredGroups.isEmpty || archivedGroupCount > 0 {
                 Section {
                     ForEach(filteredGroups) { thread in
-                        Button { path.append(.thread(thread)) } label: {
-                            ThreadRow(thread: thread)
-                        }
-                        .buttonStyle(.plain)
+                        ThreadRow(thread: thread)
+                        .tag(ChatRoute.thread(thread))
                         .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
                         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                             Button(role: .destructive) { pendingDelete = thread } label: {
@@ -236,10 +279,8 @@ struct ChatsHomeView: View {
             if !matchingThreads.isEmpty {
                 Section("Chats") {
                     ForEach(matchingThreads) { thread in
-                        Button { path.append(.thread(thread)) } label: {
-                            ThreadRow(thread: thread)
-                        }
-                        .buttonStyle(.plain)
+                        ThreadRow(thread: thread)
+                        .tag(ChatRoute.thread(thread))
                         .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
                         .contextMenu {
                             Button { renamingThread = thread } label: {
@@ -270,7 +311,6 @@ struct ChatsHomeView: View {
         }
         .listStyle(.plain)
         .themedListBackground()
-        .readableListWidth()
         .environment(\.editMode, $editMode)
         .threadRenameAlert($renamingThread) { thread, name in app.renameThread(thread, to: name) }
         .confirmationDialog("Delete this chat?",

--- a/scripts/ios-familiar-row-actions.test.mjs
+++ b/scripts/ios-familiar-row-actions.test.mjs
@@ -9,7 +9,7 @@ const home = await readFile(
 // Familiar rows gain quick actions (parity with thread rows).
 assert.match(
   home,
-  /private func startNewChat\(with familiar: Familiar\) \{[\s\S]*startFreshThread\(familiarIds: \[familiar\.id\]\)[\s\S]*path\.append\(\.thread\(thread\)\)/,
+  /private func startNewChat\(with familiar: Familiar\) \{[\s\S]*startFreshThread\(familiarIds: \[familiar\.id\]\)[\s\S]*open\(\.thread\(thread\)\)/,
   "startNewChat should open a fresh thread with the familiar",
 );
 

--- a/scripts/ios-ipad-split-chats.test.mjs
+++ b/scripts/ios-ipad-split-chats.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// On iPad the Chats tab should be a two-column NavigationSplitView: the home list
+// (familiars + groups + search results) in the sidebar, and the selected
+// familiar's threads / a conversation in the detail column. NavigationSplitView
+// collapses to a single stack on iPhone, so the familiars→threads→chat drill is
+// unchanged there. This locks the conversion.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const src = await read("apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift");
+
+assert.match(
+  src,
+  /NavigationSplitView \{[\s\S]*\} detail: \{[\s\S]*detailColumn/,
+  "ChatsHomeView should use NavigationSplitView with a detail column",
+);
+assert.doesNotMatch(
+  src,
+  /NavigationStack\(path: \$path\)/,
+  "the old shared-path NavigationStack should be gone from the home view",
+);
+// Sidebar selection (familiar or thread) + a separate detail navigation path.
+assert.match(src, /@State private var selection: ChatRoute\?/, "should track a sidebar selection");
+assert.match(src, /@State private var detailPath: \[ChatRoute\] = \[\]/, "should track detail-column navigation");
+assert.match(src, /List\(selection: \$selection\)/, "the home list should be selection-driven");
+assert.match(src, /\.tag\(ChatRoute\.familiar\(familiar\)\)/, "familiar rows should be tagged for selection");
+assert.match(src, /\.tag\(ChatRoute\.thread\(thread\)\)/, "thread/group rows should be tagged for selection");
+
+// Detail column: familiar → its thread list (pushing onto detailPath), a thread →
+// the chat, nothing → a placeholder.
+assert.match(
+  src,
+  /private var detailColumn: some View \{[\s\S]*NavigationStack\(path: \$detailPath\)/,
+  "the detail column should own a NavigationStack on detailPath",
+);
+assert.match(
+  src,
+  /case \.familiar\(let familiar\):\s*\n\s*FamiliarThreadsView\(familiar: familiar, path: \$detailPath\)/,
+  "selecting a familiar should show its threads in the detail column",
+);
+assert.match(
+  src,
+  /case nil:\s*\n\s*ContentUnavailableView/,
+  "an unselected detail column should show a placeholder",
+);
+// New selection resets the detail navigation.
+assert.match(
+  src,
+  /\.onChange\(of: selection\) \{ _, _ in detailPath = \[\] \}/,
+  "changing the sidebar selection should reset the detail navigation",
+);
+// Balanced style keeps the list visible on iPad.
+assert.match(src, /\.navigationSplitViewStyle\(\.balanced\)/, "should use the balanced split style");
+
+console.log("ios-ipad-split-chats: OK");

--- a/scripts/ios-thread-search.test.mjs
+++ b/scripts/ios-thread-search.test.mjs
@@ -15,7 +15,9 @@ assert.match(home, /\.filter \{ !\$0\.isGroup && \(showArchived \|\| !\$0\.archi
 
 // A "Chats" results section, shown only when there are matches.
 assert.match(home, /if !matchingThreads\.isEmpty \{[\s\S]*Section\("Chats"\) \{[\s\S]*ForEach\(matchingThreads\)/, "should render a Chats results section");
-assert.match(home, /path\.append\(\.thread\(thread\)\)/, "results should open the thread");
+// Rows are selection-tagged so the split view opens the conversation in the
+// detail column (and pushes it when collapsed on iPhone).
+assert.match(home, /ForEach\(matchingThreads\)[\s\S]*\.tag\(ChatRoute\.thread\(thread\)\)/, "results should open the thread via selection");
 
 // Empty-state accounts for thread matches too.
 assert.match(

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -514,6 +514,7 @@ export const SUITES = {
     "scripts/ios-task-notes-edit.test.mjs",
     "scripts/ios-task-actions.test.mjs",
     "scripts/ios-ipad-split-tasks.test.mjs",
+    "scripts/ios-ipad-split-chats.test.mjs",
     "scripts/ios-task-search-familiar-scope.test.mjs",
     "scripts/ios-thread-rename.test.mjs",
     "scripts/ios-archive-threads.test.mjs",


### PR DESCRIPTION
## What

On iPad the Chats tab ran the iPhone single-column drill (familiars → threads → chat, one pushed view at a time), wasting the landscape screen. This converts it to a two-column **`NavigationSplitView`**: the home list (familiars + groups + search results) in the sidebar, the conversation in the detail column.

Second of the iPad split-view work (after Tasks, #1796); **Reading** to follow.

## How

- `NavigationStack(path:)` → `NavigationSplitView { home } detail: { detailColumn }`.
- The home list is now `List(selection:)` with `.tag(ChatRoute.familiar/.thread)` rows.
  - Select a **familiar** → its thread list (`FamiliarThreadsView`) fills the detail column and pushes the chosen conversation onto a separate `detailPath`.
  - Select a **group / search result** → the chat opens directly.
  - Nothing selected → a "Select a chat" placeholder.
- Changing the sidebar selection resets `detailPath` (a familiar opens at its thread list, not a stale conversation). Deep links + the new-chat sheet route through a small `open(_:)` helper.
- `.navigationSplitViewStyle(.balanced)` keeps the list visible beside the conversation on iPad; dropped the now-unused `.readableListWidth()`.
- **iPhone unchanged**: on compact width the split view collapses to one stack, so the familiars→threads→chat drill with back navigation behaves exactly as before.

## Verification

- **iPad Pro simulator**: two columns — familiars list (with counts) + "Select a chat" detail placeholder.
- **iPhone 16 Pro simulator**: collapses to the single-column familiars list; selecting a familiar pushes its thread list ("Nova / orchestrator" + back button + threads) — no regression. (Verified the collapsed drill by auto-selecting a familiar, since tap-injection isn't available here.)
- Updated the two tests that pinned the old `path.append` (`ios-familiar-row-actions`, `ios-thread-search`); new `ios-ipad-split-chats` locks the conversion; `check:tests-wired` green (535).

🤖 Generated with [Claude Code](https://claude.com/claude-code)