### PR TITLE
fix(chat): add title tooltip to truncated code-block filenames

### DIFF
--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -183,7 +183,7 @@ async function renderCodeBlock(
 
   const labelHtml = `<span class="cave-code-lang">${escHtml(lang)}</span>`;
   const filenameHtml = filename
-    ? `<span class="cave-code-filename">${escHtml(filename)}</span>`
+    ? `<span class="cave-code-filename" title="${escHtml(filename)}">${escHtml(filename)}</span>`
     : "";
   // Collapse toggle (chevron) folds the block down to just this header so a
   // long code dump can be tucked away; blocks render expanded by default. The


### PR DESCRIPTION
## What

Every chat code block that carries a filename renders it in a header bar styled `overflow:hidden; text-overflow:ellipsis; white-space:nowrap` (`cave-chat.css:585`), so a long path (e.g. `src/components/deep/nested/file.tsx`) clips with no way to read the full name on hover.

This adds a `title` attribute to the `cave-code-filename` span (`message-bubble.tsx:186`). `escHtml` already escapes `"`/`'`, so it's safe inside the attribute. Matches the calendar (#1786), library (#1792), dashboard (#1795), and workflow (#1800) surfaces already fixed.

## Verification

- Message-bubble / code-header suites pass: `message-bubble-code-header`, `message-bubble-code-collapse`, `message-bubble-jump-to-line`, `message-bubble-markdown`, `message-bubble-rewire`, `chat-view-render-optimization`. No test pins the filename span markup.
- 1-line diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)