### PR TITLE
feat(ios): iPad split-view for the Developer → GitHub view

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
@@ -11,17 +11,31 @@ struct GitHubView: View {
     @State private var error: String?
     @State private var hint: String?
     @State private var query = ""
+    /// The PR/issue shown in the detail column. On iPad this fills the pane beside
+    /// the list; on iPhone `NavigationSplitView` collapses and selecting a row
+    /// pushes the detail, so the single-column behaviour is unchanged.
+    @State private var selection: GitHubItem?
 
     var body: some View {
-        NavigationStack {
+        NavigationSplitView {
             content
                 .searchable(text: $query, prompt: "Search issues & PRs")
-                .navigationDestination(for: GitHubItem.self) { item in
-                    GitHubItemDetailView(item: item)
-                }
                 .refreshable { await load() }
                 .task { await load() }
+        } detail: {
+            if let selection {
+                NavigationStack { GitHubItemDetailView(item: selection) }
+            } else {
+                ContentUnavailableView {
+                    Label("Select an item", systemImage: "checklist")
+                } description: {
+                    Text("Pick a pull request or issue to see its details.")
+                }
+            }
         }
+        // Keep the list visible beside the detail on iPad; on iPhone the split
+        // view collapses to a single navigation stack.
+        .navigationSplitViewStyle(.balanced)
     }
 
     @ViewBuilder private var content: some View {
@@ -45,7 +59,7 @@ struct GitHubView: View {
         } else if groups.isEmpty {
             ContentUnavailableView.search(text: query)
         } else {
-            List {
+            List(selection: $selection) {
                 ForEach(groups, id: \.title) { group in
                     Section(group.title) {
                         ForEach(group.items) { item in
@@ -56,13 +70,12 @@ struct GitHubView: View {
             }
             .listStyle(.insetGrouped)
             .themedListBackground()
-            .readableListWidth()
         }
     }
 
     @ViewBuilder private func row(_ item: GitHubItem) -> some View {
         if item.number != nil {
-            NavigationLink(value: item) { GitHubItemRow(item: item) }
+            GitHubItemRow(item: item).tag(item)
         } else if let url = URL(string: item.url) {
             Link(destination: url) { GitHubItemRow(item: item) }
         } else {

--- a/scripts/ios-ipad-split-github.test.mjs
+++ b/scripts/ios-ipad-split-github.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// On iPad the Developer → GitHub view should be a two-column NavigationSplitView
+// (PR/issue list + detail) rather than the iPhone single-column push. It collapses
+// to a stack on iPhone, so the list→detail behaviour there is unchanged. External
+// (numberless) notification rows stay plain Links; only numbered PRs/issues are
+// selection-driven into the detail column.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const src = await read("apps/ios/CovenCave/CovenCave/Views/GitHubView.swift");
+
+assert.match(
+  src,
+  /NavigationSplitView \{[\s\S]*\} detail: \{/,
+  "GitHubView should use NavigationSplitView with a detail column",
+);
+assert.doesNotMatch(
+  src,
+  /NavigationStack \{[\s\S]*navigationDestination\(for: GitHubItem\.self\)/,
+  "the old push-based NavigationStack + navigationDestination should be gone",
+);
+assert.match(src, /@State private var selection: GitHubItem\?/, "should track the selected item");
+assert.match(src, /List\(selection: \$selection\)/, "the list should be selection-driven");
+// Numbered PRs/issues become selectable rows; the external-Link branch stays.
+assert.match(
+  src,
+  /if item\.number != nil \{\s*\n\s*GitHubItemRow\(item: item\)\.tag\(item\)/,
+  "numbered items should be selection-tagged rows",
+);
+assert.match(src, /Link\(destination: url\)/, "numberless items should remain external Links");
+// Detail shows the selected item, or a placeholder on iPad when none is picked.
+assert.match(
+  src,
+  /\} detail: \{[\s\S]*GitHubItemDetailView\(item: selection\)[\s\S]*ContentUnavailableView/,
+  "the detail column should show the selected item or a placeholder",
+);
+assert.match(src, /\.navigationSplitViewStyle\(\.balanced\)/, "should use the balanced split style");
+
+console.log("ios-ipad-split-github: OK");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -515,6 +515,7 @@ export const SUITES = {
     "scripts/ios-task-actions.test.mjs",
     "scripts/ios-ipad-split-tasks.test.mjs",
     "scripts/ios-ipad-split-chats.test.mjs",
+    "scripts/ios-ipad-split-github.test.mjs",
     "scripts/ios-task-search-familiar-scope.test.mjs",
     "scripts/ios-thread-rename.test.mjs",
     "scripts/ios-archive-threads.test.mjs",


### PR DESCRIPTION
## What

On iPad the **Developer → GitHub** view (open PRs, review requests, assigned issues) ran the iPhone single-column push, wasting the landscape screen. This converts it to a two-column **`NavigationSplitView`**: the PR/issue list in the sidebar, `GitHubItemDetailView` in the detail column (with a "Select an item" placeholder).

Completes the iPad split-view sweep of the list→detail surfaces — **Tasks** (#1796), **Chats** (#1802), **GitHub** (here). (The Read tab was removed upstream in #1797; Settings is a form and Code/Terminal are intentionally full-width.)

## How

- `NavigationStack` + `navigationDestination(for: GitHubItem.self)` → `NavigationSplitView { list } detail: { … }`.
- The list is now `List(selection:)`. Numbered PRs/issues are selection-tagged rows (`GitHubItemRow(item).tag(item)`); numberless notification rows keep their external `Link`; plain rows stay plain.
- `.navigationSplitViewStyle(.balanced)` keeps the list visible beside the detail on iPad; dropped the now-unused `.readableListWidth()`.
- **iPhone unchanged**: on compact width the split view collapses to a stack, so selecting a PR pushes its detail as before.

## Verification

- **iPad Pro simulator**: two columns — the GitHub list (Review requests / Your pull requests, live data from the desktop) + "Select an item" detail placeholder.
- **iPhone 16 Pro simulator**: single-column list (Developer → GitHub), no regression.
- New `scripts/ios-ipad-split-github.test.mjs` locks the conversion (wired into CI; `check:tests-wired` green — 536); existing GitHub + theme-list-background source-text tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)