### PR TITLE
fix(journal): add title tooltips to truncated journal labels

### DIFF
--- a/src/components/journal/canvas-list.tsx
+++ b/src/components/journal/canvas-list.tsx
@@ -365,7 +365,7 @@ export function CanvasList({
                         setView("preview");
                       }}
                     >
-                      <span className="journal-art__title">{a.title || "Untitled sketch"}</span>
+                      <span className="journal-art__title" title={a.title || "Untitled sketch"}>{a.title || "Untitled sketch"}</span>
                       <span className="journal-art__meta">
                         <span className={`journal-kind journal-kind--${a.kind ?? "html"}`}>{a.kind ?? "html"}</span>
                         {generating.has(a.id) ? " · generating…" : ` · ${relativeTime(a.updatedAt)}`}

--- a/src/components/journal/journal-entries.tsx
+++ b/src/components/journal/journal-entries.tsx
@@ -328,7 +328,7 @@ export function JournalEntries({
                     </span>
                     {d.reflectedBy ? <span className="journal-day__by">{familiarName(d.reflectedBy)}</span> : null}
                   </span>
-                  <span className="journal-day__prev">{d.preview || "—"}</span>
+                  <span className="journal-day__prev" title={d.preview || undefined}>{d.preview || "—"}</span>
                 </button>
               </li>
             ))}


### PR DESCRIPTION
## What

Two journal spans truncate with ellipsis but offer no hover tooltip — both `white-space:nowrap; overflow:hidden; text-overflow:ellipsis`:

| Span | Content | journal.css |
|---|---|---|
| `journal-art__title` | sketch/artifact name (`canvas-list.tsx:368`) | :116 |
| `journal-day__prev` | day-entry preview snippet (`journal-entries.tsx:331`) | :381 |

Adds `title=` to both. The preview uses `title={d.preview || undefined}` so an empty row (`—`) shows no useless tooltip. Matches the calendar (#1786), library (#1792), dashboard (#1795), workflow (#1800), and chat-code (#1803) surfaces already fixed this round.

## Verification

- `journal/journal-view.test.ts` passes; it does not pin either span's markup.
- `tsc --noEmit` clean for both files. 2-line diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)