### PR TITLE
fix(github): use RelativeTime for PR comment timestamps

### DIFF
--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -277,10 +277,11 @@ assert.match(source, /const counts: Record<Filter, number> = useMemo\(/, "the pe
 // In-flight fetch can't setState after unmount.
 assert.match(source, /if \(!mountedRef\.current\) return;/, "fetchActivity guards against setState after unmount");
 
-// GitHub timestamps use the app-canonical relativeTime (which formats "2m ago"
-// / "Jun 12" itself), not a local relTime helper with a manually-appended " ago"
-// that disagreed between call sites.
-assert.ok(source.includes('import { relativeTime } from "@/lib/relative-time"'), "imports shared relativeTime");
+// GitHub timestamps use the app-canonical relative time via the shared
+// <RelativeTime> component (semantic <time>, preference-aware exact-time hover,
+// self-updating) — not a local relTime helper with a manually-appended " ago"
+// that disagreed between call sites, and not a raw ISO string in the title.
+assert.ok(source.includes('import { RelativeTime } from "@/components/ui/relative-time"'), "uses the shared RelativeTime component");
 assert.ok(!source.includes("relTime"), "local relTime helper and its call sites are gone");
 
 // PR rows expose a maintainer-safe merge path that prefers an issue/PR worktree

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -2,7 +2,6 @@
 
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
-import { relativeTime } from "@/lib/relative-time";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -786,9 +785,7 @@ function CommentHeader({ comment }: { comment: GhComment }) {
         <span className="gh-comment-assoc">{comment.authorAssociation.toLowerCase()}</span>
       )}
       {comment.createdAt && (
-        <span className="gh-comment-time" title={comment.createdAt}>
-          {relativeTime(comment.createdAt)}
-        </span>
+        <RelativeTime iso={comment.createdAt} className="gh-comment-time" />
       )}
       {comment.url && (
         <a


### PR DESCRIPTION
## What

A different class of polish from this round's tooltip sweep — fixing a *bad* tooltip rather than adding a missing one.

The GitHub PR comment timestamp (`github-view.tsx:788`) rendered a raw `<span title={comment.createdAt}>` — so hovering showed an unformatted ISO string (`2026-06-24T13:42:12Z`) instead of a readable date. This swaps it for the shared `<RelativeTime>` component, which the same file already uses twice (lines 1227, 1976):

- semantic `<time dateTime>` element
- preference-aware exact-time hover ("June 24, 2026 at 1:42 PM")
- self-updates with the date/time density pref

The now-unused `relativeTime` import is dropped.

## Test update

`github-view-polish.test.ts` pinned the low-level `relativeTime` import. That import is now unused (the component wraps the same canonical formatter), so the assertion is updated to check the `RelativeTime` component import instead — same intent (canonical formatting, no local `relTime` helper), better affordance. Updated in the same commit per the repo's source-text-test convention.

## Verification

- `github-view-polish`, `surface-loading-states`, `modal-trap-adoption` suites pass.
- Source diff is a 1-for-1 component swap + dead-import removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)