### PR TITLE
feat(ios): auto-recover the desktop connection (launch backoff + foreground)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
+++ b/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct CovenCaveApp: App {
     @State private var app = AppModel()
     @AppStorage(AppearanceMode.storageKey) private var appearanceRaw = AppearanceMode.desktop.rawValue
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some Scene {
         // Mirror the desktop appearance by default; a fixed Light/Dark override
@@ -20,8 +21,17 @@ struct CovenCaveApp: App {
                 .preferredColorScheme(resolved.scheme)
                 .task {
                     if app.connection != nil {
-                        await app.refreshConnection()
+                        await app.connectWithRetry()
                     }
+                }
+                // Returning to the foreground after the desktop was unreachable
+                // (locked the phone, desktop blipped/restarted) should recover on
+                // its own — retry unless we're already connected or mid-check.
+                .onChange(of: scenePhase) { _, phase in
+                    guard phase == .active, app.connection != nil,
+                          app.connectionState != .connected,
+                          app.connectionState != .checking else { return }
+                    Task { await app.connectWithRetry() }
                 }
         }
     }

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -457,6 +457,29 @@ final class AppModel {
         await loadTheme()
     }
 
+    /// Connect with a few backoff retries before surfacing the "unreachable" setup
+    /// screen — a slow tailnet, or a desktop still spinning up on a cold launch,
+    /// shouldn't read as a configuration failure. Between attempts the state is held
+    /// at `.checking` so a transient miss shows the "Connecting…" screen (cold
+    /// launch) or recovers invisibly in the background (once familiars are loaded),
+    /// never a flash of the unreachable screen. Drives launch + foreground reconnect.
+    func connectWithRetry() async {
+        guard connection != nil else { connectionState = .unconfigured; return }
+        // Delays BETWEEN attempts (4 attempts total, ~7s before giving up).
+        let backoffSeconds: [UInt64] = [1, 2, 4]
+        await refreshConnection()
+        var attempt = 0
+        while connectionState != .connected, attempt < backoffSeconds.count {
+            connectionState = .checking
+            try? await Task.sleep(nanoseconds: backoffSeconds[attempt] * 1_000_000_000)
+            if Task.isCancelled { return }
+            // The user may have disconnected/reconfigured during the wait.
+            guard connection != nil else { connectionState = .unconfigured; return }
+            await refreshConnection()
+            attempt += 1
+        }
+    }
+
     /// Probe candidate base URLs in order; return the first that answers. Uses a
     /// short per-candidate timeout so trying a few ports stays snappy.
     static func discoverBaseURL(_ candidates: [URL]) async -> URL? {

--- a/scripts/ios-auto-reconnect.test.mjs
+++ b/scripts/ios-auto-reconnect.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// The app should recover from a slow/blipping desktop on its own: retry the
+// connection with backoff on launch (instead of dumping straight to the setup
+// screen), and re-probe when it returns to the foreground after being offline.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const model = await read("apps/ios/CovenCave/CovenCave/State/AppModel.swift");
+const app = await read("apps/ios/CovenCave/CovenCave/CovenCaveApp.swift");
+
+// --- AppModel.connectWithRetry: bounded backoff, holds .checking between tries -
+assert.match(
+  model,
+  /func connectWithRetry\(\) async \{/,
+  "AppModel should expose connectWithRetry()",
+);
+assert.match(
+  model,
+  /func connectWithRetry[\s\S]*?let backoffSeconds: \[UInt64\] = \[1, 2, 4\]/,
+  "connectWithRetry should use a bounded backoff schedule",
+);
+assert.match(
+  model,
+  /func connectWithRetry[\s\S]*?while connectionState != \.connected[\s\S]*?connectionState = \.checking[\s\S]*?Task\.sleep[\s\S]*?await refreshConnection\(\)/,
+  "connectWithRetry should retry refreshConnection while held at .checking (no unreachable flash)",
+);
+assert.match(
+  model,
+  /func connectWithRetry[\s\S]*?if Task\.isCancelled \{ return \}/,
+  "connectWithRetry should bail out if the task is cancelled mid-wait",
+);
+
+// --- CovenCaveApp: launch uses the retry, and foreground re-probes when offline -
+assert.match(
+  app,
+  /@Environment\(\\\.scenePhase\) private var scenePhase/,
+  "the app should observe scenePhase",
+);
+assert.match(
+  app,
+  /\.task \{[\s\S]*?await app\.connectWithRetry\(\)/,
+  "launch should connect with retry (not a single probe)",
+);
+assert.match(
+  app,
+  /\.onChange\(of: scenePhase\) \{[\s\S]*?phase == \.active[\s\S]*?connectionState != \.connected[\s\S]*?connectionState != \.checking[\s\S]*?connectWithRetry\(\)/,
+  "returning to the foreground while offline should re-probe the connection",
+);
+
+console.log("ios-auto-reconnect: OK");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -535,6 +535,7 @@ export const SUITES = {
     "scripts/ios-reorder-familiars.test.mjs",
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/ios-theme.test.mjs",
+    "scripts/ios-auto-reconnect.test.mjs",
     "scripts/ios-theme-list-background.test.mjs",
     "scripts/ios-presence-dots.test.mjs",
     "scripts/ios-swipe-reply.test.mjs",


### PR DESCRIPTION
## Problem

Two connection-resilience gaps (first of the resilience pass):
1. The app probed the desktop **once** on launch (`CovenCaveApp.task` → `refreshConnection`); if the tailnet was slow or the desktop was still spinning up, it dropped **straight to the setup screen** — a transient miss read as a config failure.
2. Once offline it **stayed offline** until you manually tapped "Re-check connection" in Settings, even after the desktop came back (e.g. lock phone → desktop blips → unlock → still offline).

## Fix

- **`AppModel.connectWithRetry()`** — probes, then retries with a bounded backoff (1s/2s/4s — 4 attempts, ~7s) before giving up. Between attempts the state is held at `.checking`, so a **cold launch shows "Connecting…"** and a **warm reconnect happens invisibly in the background** — never a flash of the unreachable screen. Bails on task-cancel or if the user disconnects mid-wait.
- **`CovenCaveApp`** calls it on launch and again when the app returns to the **foreground** while not connected (`scenePhase → .active`), so coming back after the desktop blipped recovers on its own. (The Terminal already reconnected on foreground; the app-level connection now does too.)
- `refreshConnection` is unchanged — still the single-probe primitive.

## Verification (iPhone 16 Pro simulator)

- **Dead host** (`127.0.0.1:9`): shows "Connecting to your desktop…" through the retries (~3s, ~10s) and *then* falls back to the setup screen with "Couldn't reach the desktop" — no instant bail.
- **Live host** (`127.0.0.1:3000`): connects straight to the Chats home.
- Foreground reconnect uses the same `connectWithRetry` path (scenePhase trigger), source-text tested.
- New `scripts/ios-auto-reconnect.test.mjs` locks the retry + scenePhase wiring (CI-wired; `check:tests-wired` green — 537); `ios-theme` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)