### PR TITLE
feat(ios): surface silent failures in the Developer surface

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/CodeBrowserView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/CodeBrowserView.swift
@@ -20,6 +20,9 @@ struct CodeBrowserView: View {
     @State private var results: [SearchFile] = []
     @State private var searching = false
     @State private var searchTruncated = false
+    /// Set when a search request itself fails (vs. legitimately finding nothing),
+    /// so the empty state can say "search failed — Retry" instead of "no results".
+    @State private var searchError: String?
 
     private var searchActive: Bool { !query.trimmingCharacters(in: .whitespaces).isEmpty }
 
@@ -92,6 +95,14 @@ struct CodeBrowserView: View {
         if searching {
             ProgressView().controlSize(.large)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let searchError {
+            ContentUnavailableView {
+                Label("Search failed", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(searchError)
+            } actions: {
+                Button("Retry") { Task { await runSearch() } }.buttonStyle(.borderedProminent)
+            }
         } else if results.isEmpty {
             ContentUnavailableView.search(text: query)
         } else {
@@ -127,7 +138,7 @@ struct CodeBrowserView: View {
     private func runSearch() async {
         let q = query.trimmingCharacters(in: .whitespaces)
         guard q.count >= 2, let root = focusedRoot, let client = app.client else {
-            results = []; searchTruncated = false; return
+            results = []; searchTruncated = false; searchError = nil; return
         }
         // Light debounce so each keystroke doesn't spawn a ripgrep run.
         try? await Task.sleep(for: .milliseconds(300))
@@ -139,8 +150,11 @@ struct CodeBrowserView: View {
             if Task.isCancelled { return }
             results = resp.files ?? []
             searchTruncated = resp.truncated ?? false
+            searchError = nil
         } catch {
+            // Surface the failure instead of a misleading empty "no results".
             results = []; searchTruncated = false
+            searchError = error.localizedDescription
         }
     }
 
@@ -171,6 +185,9 @@ struct CodeNode: View {
     @State private var children: [TreeEntry] = []
     @State private var loaded = false
     @State private var loading = false
+    /// Set when loading this folder's children fails, so the row shows an error +
+    /// Retry instead of an ambiguous "Empty folder".
+    @State private var nodeError: String?
 
     var body: some View {
         if isDir {
@@ -179,6 +196,14 @@ struct CodeNode: View {
                     HStack(spacing: 8) {
                         ProgressView().controlSize(.small)
                         Text("Loading…").font(.caption).foregroundStyle(.secondary)
+                    }
+                } else if let nodeError {
+                    HStack(spacing: 8) {
+                        Image(systemName: "exclamationmark.triangle").foregroundStyle(.orange)
+                        Text(nodeError).font(.caption).foregroundStyle(.secondary).lineLimit(2)
+                        Spacer()
+                        Button("Retry") { Task { await load() } }
+                            .font(.caption.weight(.semibold)).buttonStyle(.borderless)
                     }
                 } else if loaded && children.isEmpty {
                     Text("Empty folder").font(.caption).foregroundStyle(.tertiary)
@@ -244,12 +269,16 @@ struct CodeNode: View {
         guard let client = app.client else { return }
         guard !loading else { return }
         loading = true
+        nodeError = nil
         defer { loading = false }
         do {
             children = try await client.projectTree(root: path, depth: 1)
             loaded = true
+            nodeError = nil
         } catch {
-            // leave loaded == false so collapsing + re-expanding retries
+            // Surface the failure (with a Retry) instead of looking like an empty
+            // folder; loaded stays false so collapse + re-expand also retries.
+            nodeError = error.localizedDescription
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/TerminalView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TerminalView.swift
@@ -26,6 +26,20 @@ struct TerminalView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            // The xterm webview renders even when the PTY socket is down, so a
+            // failed connection otherwise looks like a frozen shell. Surface it.
+            if !terminal.connected, let err = terminal.error {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.orange)
+                    Text(err).font(.caption).foregroundStyle(.secondary).lineLimit(2)
+                    Spacer()
+                    Button("Reconnect") { connect() }
+                        .font(.caption.weight(.semibold)).buttonStyle(.borderless)
+                }
+                .padding(.horizontal, 12).padding(.vertical, 8)
+                .frame(maxWidth: .infinity)
+                .background(.ultraThinMaterial)
+            }
             XtermWebView(
                 terminal: terminal,
                 onInput: { terminal.sendInput($0) },

--- a/scripts/ios-surface-failures.test.mjs
+++ b/scripts/ios-surface-failures.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// The Developer surface used to swallow failures silently — a failed code search
+// looked like "no results", a failed tree-node load looked like an empty folder,
+// and a dropped terminal socket looked like a frozen shell. Each should now show
+// an honest error + retry. This locks that wiring.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const code = await read("apps/ios/CovenCave/CovenCave/Views/CodeBrowserView.swift");
+const term = await read("apps/ios/CovenCave/CovenCave/Views/TerminalView.swift");
+
+// --- Code search: track the error, set it in catch, show "Search failed" + Retry
+assert.match(code, /@State private var searchError: String\?/, "search should track an error state");
+assert.match(
+  code,
+  /catch \{[\s\S]*?searchError = error\.localizedDescription/,
+  "a failed search should record the error (not silently empty the results)",
+);
+assert.match(
+  code,
+  /else if let searchError \{[\s\S]*?Label\("Search failed"[\s\S]*?Button\("Retry"\)/,
+  "the search empty-state should show 'Search failed' + Retry when a search errored",
+);
+
+// --- Tree node: track the error, set it in load() catch, show error row + Retry
+assert.match(code, /@State private var nodeError: String\?/, "a tree node should track a load error");
+assert.match(
+  code,
+  /catch \{[\s\S]*?nodeError = error\.localizedDescription/,
+  "a failed folder load should record the error (not look like an empty folder)",
+);
+assert.match(
+  code,
+  /else if let nodeError \{[\s\S]*?Button\("Retry"\) \{ Task \{ await load\(\) \} \}/,
+  "an errored folder should show the error with a Retry that reloads it",
+);
+
+// --- Terminal: show the connection error with a Reconnect when the socket is down
+assert.match(
+  term,
+  /if !terminal\.connected, let err = terminal\.error \{[\s\S]*?Text\(err\)[\s\S]*?Button\("Reconnect"\) \{ connect\(\) \}/,
+  "the terminal should surface its connection error with a Reconnect button",
+);
+
+console.log("ios-surface-failures: OK");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -551,6 +551,7 @@ export const SUITES = {
     "scripts/ios-development-code-title.test.mjs",
     "scripts/ios-development-github-title.test.mjs",
     "scripts/ios-development-terminal-chrome.test.mjs",
+    "scripts/ios-surface-failures.test.mjs",
     "scripts/mobile-tailscale.test.mjs",
     "scripts/mobile-tailscale-native.test.mjs",
     "src/components/mobile-handoff.test.ts",


### PR DESCRIPTION
## Problem

Three spots in the Developer surface swallowed errors and rendered as benign empty/idle states — especially bad on a flaky connection, where the user can't tell "nothing here" from "it broke":

1. **Code search** — a failed ripgrep request silently set `results = []`, showing the normal "no results" state.
2. **Code tree node** — a failed `projectTree` load was caught but unrecorded (left `loaded == false`), reading as "Empty folder".
3. **Terminal** — the xterm webview renders even when the PTY socket is down, so a failed connection looked like a frozen, unresponsive shell.

## Fix

- **Search**: track `searchError`, set it in the `catch`, and show "Search failed — Retry" (instead of the empty state) when a search errored.
- **Tree node**: track `nodeError`, set it in `load()`'s `catch`, and show the error with a **Retry** that reloads just that folder.
- **Terminal**: show a banner with `terminal.error` + a **Reconnect** button when `!terminal.connected && terminal.error != nil`.

All three are **additive error branches** — the success paths (and their source-text tests) are untouched.

## Verification

- Builds clean for the iPhone 16 Pro simulator; the happy-path Developer tests (`ios-code-browser-files`, `ios-code-viewer`, `ios-development-terminal-chrome`, `ios-theme-list-background`) still pass.
- New `scripts/ios-surface-failures.test.mjs` locks all three error states (CI-wired; `check:tests-wired` green — 538).
- Honest caveat: these branches only render on a *live* failure (dead search/tree endpoint, dropped PTY socket), which can't be deterministically injected in the simulator — so, like the failed-reply Retry button, they're build + source-text verified rather than screenshotted.

Completes the connection/resilience pass (auto-reconnect #1808 + this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)