### PR TITLE
feat(ui): in-app ConfirmDialog primitive; replace native window.confirm

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -363,6 +363,7 @@ export const SUITES = {
     "src/components/ui/context-menu.test.ts",
     "src/components/ui/undo-toast.test.ts",
     "src/components/ui/modal.test.ts",
+    "src/components/ui/confirm-dialog.test.ts",
     "src/components/ui/relative-time.test.ts",
     "src/lib/workflow-source-bundle.test.ts",
     "src/lib/vault-bundle.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1000,6 +1000,20 @@ tr[role="checkbox"]:focus-visible {
   flex: 1;
 }
 
+/* In-app confirm dialog (ConfirmProvider) — title + supporting detail. */
+.ui-confirm-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--fg-base, var(--foreground));
+}
+.ui-confirm-body {
+  margin-top: var(--space-2);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
 .ui-modal-footer {
   display: flex;
   align-items: center;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,7 @@ import { CornerRadiusController } from "@/components/corner-radius-controller";
 import { ThemeScript } from "@/components/theme-script";
 import { ShellBannersProvider } from "@/lib/shell-banners";
 import { LiveRegionProvider } from "@/components/ui/live-region";
+import { ConfirmProvider } from "@/components/ui/confirm-dialog";
 import { PwaRegister } from "@/components/pwa-register";
 import { DevCacheResetScript } from "@/components/dev-cache-reset-script";
 
@@ -71,6 +72,7 @@ export default function RootLayout({
         <SidecarAuthBridge />
         <ShellBannersProvider>
           <LiveRegionProvider>
+            <ConfirmProvider>
             <SidecarAuthMonitor />
             <ScreenMagnificationController />
             <ReadingLeadingController />
@@ -83,6 +85,7 @@ export default function RootLayout({
             <CornerRadiusController />
             <PwaRegister />
             {children}
+            </ConfirmProvider>
           </LiveRegionProvider>
         </ShellBannersProvider>
       </body>

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -17,6 +17,7 @@ import { formatTimestamp, formatClock, readDateTimePrefs, useDateTimePrefs } fro
 import { relativeTimeSigned } from "@/lib/relative-time";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 import { SelectionToolbar } from "@/components/ui/selection-toolbar";
 import { Tabs, type TabItem } from "@/components/ui/tabs";
 import { useMultiSelect } from "@/lib/use-multi-select";
@@ -1319,6 +1320,7 @@ function InboxFeedList({
 // ── Root ──────────────────────────────────────────────────────────────────────
 export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdit, onOpenLink }: Props) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
+  const confirm = useConfirm();
   const [items, setItems] = useState<InboxItem[]>([]);
   const [codexAutos, setCodexAutos] = useState<CodexAutomation[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -1467,7 +1469,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     if (id.startsWith("eph:")) return;
     const target = items.find((i) => i.id === id);
     const label = target?.title ? `“${target.title}”` : "this reminder";
-    if (!window.confirm(`Delete ${label}? This can't be undone.`)) return;
+    if (!(await confirm({ title: `Delete ${label}?`, body: "This can't be undone.", confirmLabel: "Delete", danger: true }))) return;
     setBusyId(id);
     try {
       const res = await fetch(`/api/inbox/${id}`, { method: "DELETE" });
@@ -1527,7 +1529,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   }, [load]);
 
   const deleteCodex = useCallback(async (auto: CodexAutomation) => {
-    if (!window.confirm(`Delete automation "${auto.name}"? This removes its file.`)) return;
+    if (!(await confirm({ title: `Delete automation “${auto.name}”?`, body: "This removes its file.", confirmLabel: "Delete", danger: true }))) return;
     setBusyId(auto.id);
     try {
       const res = await fetch(`/api/codex-automations/${encodeURIComponent(auto.id)}`, { method: "DELETE" });
@@ -1543,7 +1545,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   }, [load]);
 
   const runCodexNow = useCallback(async (auto: CodexAutomation) => {
-    if (!window.confirm(`Run "${auto.name}" now? This executes the agent immediately.`)) return;
+    if (!(await confirm({ title: `Run “${auto.name}” now?`, body: "This executes the agent immediately.", confirmLabel: "Run now" }))) return;
     setBusyId(auto.id);
     try {
       const res = await fetch(`/api/codex-automations/${encodeURIComponent(auto.id)}/run`, { method: "POST" });
@@ -1643,7 +1645,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   const bulkDeleteReminders = async () => {
     const ids = selectedRealIds();
     if (ids.length === 0) { reminderSelect.exit(); return; }
-    if (!window.confirm(`Delete ${ids.length} reminder${ids.length === 1 ? "" : "s"}? This can't be undone.`)) return;
+    if (!(await confirm({ title: `Delete ${ids.length} reminder${ids.length === 1 ? "" : "s"}?`, body: "This can't be undone.", confirmLabel: "Delete", danger: true }))) return;
     setBulkBusy(true);
     try {
       await Promise.all(ids.map((id) =>

--- a/src/components/canvas-artifact-node.tsx
+++ b/src/components/canvas-artifact-node.tsx
@@ -3,6 +3,7 @@
 import { NodeResizer, type NodeProps, type Node } from "@xyflow/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 import { buildPreviewSrcDoc, type CanvasArtifact } from "@/lib/canvas-artifacts";
 import { buildReactSrcDoc } from "@/lib/canvas-react-harness";
 
@@ -22,6 +23,7 @@ export type ArtifactFlowNode = Node<ArtifactNodeData & Record<string, unknown>, 
 
 export function ArtifactNode({ data, selected }: NodeProps<ArtifactFlowNode>) {
   const { artifact, view, generating } = data;
+  const confirm = useConfirm();
   const isReact = artifact.kind === "react";
   const frameRef = useRef<HTMLIFrameElement | null>(null);
   const [runtimeError, setRuntimeError] = useState<string | null>(null);
@@ -107,10 +109,10 @@ export function ArtifactNode({ data, selected }: NodeProps<ArtifactFlowNode>) {
             className="canvas-artifact__btn canvas-artifact__btn--danger"
             title="Delete"
             aria-label="Delete"
-            onClick={() => {
+            onClick={async () => {
               // Deleting a sketch is destructive and not undoable, so confirm first.
               const name = artifact.title?.trim() || "this sketch";
-              if (window.confirm(`Delete ${name}? This can't be undone.`)) {
+              if (await confirm({ title: `Delete ${name}?`, body: "This can't be undone.", confirmLabel: "Delete", danger: true })) {
                 data.onDelete(artifact.id);
               }
             }}

--- a/src/components/ui/confirm-dialog.test.ts
+++ b/src/components/ui/confirm-dialog.test.ts
@@ -1,0 +1,50 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./confirm-dialog.tsx", import.meta.url), "utf8");
+const layout = readFileSync(new URL("../../app/layout.tsx", import.meta.url), "utf8");
+
+// Provider + hook are exported.
+assert.match(src, /export function ConfirmProvider/, "exports ConfirmProvider");
+assert.match(src, /export function useConfirm\(\)/, "exports useConfirm hook");
+
+// Promise-based API so call sites keep the `if (!(await confirm(...))) return;` shape.
+assert.match(src, /\(opts: ConfirmOptions\) => Promise<boolean>/, "useConfirm returns a Promise<boolean> factory");
+assert.match(src, /new Promise<boolean>/, "confirm() resolves a boolean promise");
+
+// Built on the shared Modal (focus trap, Esc, backdrop) — not a bespoke overlay.
+assert.match(src, /import \{ Modal \}/, "ConfirmDialog builds on the shared Modal primitive");
+assert.match(src, /import \{ Button \}/, "ConfirmDialog uses the shared Button");
+
+// Danger styling routes to the destructive button variant.
+assert.match(src, /variant=\{pending\.danger \? "danger" : "primary"\}/, "danger option uses the destructive button variant");
+
+// Cancel renders before Confirm so the focus trap lands on the safe action first.
+assert.match(
+  src,
+  /Cancel[\s\S]*?settle\(false\)[\s\S]*?settle\(true\)/,
+  "Cancel precedes Confirm so initial focus is the safe action",
+);
+
+// Backdrop / Escape settle as cancelled.
+assert.match(src, /onClose=\{\(\) => settle\(false\)\}/, "dismiss (backdrop/Esc) resolves as cancelled");
+
+// Mounted once at the app root.
+assert.match(layout, /import \{ ConfirmProvider \}/, "layout imports ConfirmProvider");
+assert.match(layout, /<ConfirmProvider>/, "layout mounts ConfirmProvider");
+
+// The native window.confirm() is gone from the migrated surfaces.
+for (const rel of [
+  "../vault-panel.tsx",
+  "../canvas-artifact-node.tsx",
+  "../automations-view.tsx",
+  "../workflows-view.tsx",
+  "../workflows/workflow-runs-panel.tsx",
+]) {
+  const file = readFileSync(new URL(rel, import.meta.url), "utf8");
+  assert.doesNotMatch(file, /window\.confirm\(/, `${rel} should not call native window.confirm()`);
+  assert.match(file, /useConfirm\(\)/, `${rel} should use the in-app confirm`);
+}
+
+console.log("confirm-dialog.test.ts OK");

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { Modal } from "@/components/ui/modal";
+import { Button } from "@/components/ui/button";
+
+export type ConfirmOptions = {
+  /** Bold heading — the question, e.g. "Delete secret?" */
+  title: string;
+  /** Supporting detail beneath the title (consequences, scope). */
+  body?: ReactNode;
+  /** Primary action label (default "Confirm"). */
+  confirmLabel?: string;
+  /** Dismiss label (default "Cancel"). */
+  cancelLabel?: string;
+  /** Render the primary action in the destructive (red) style. */
+  danger?: boolean;
+};
+
+type Pending = ConfirmOptions & { resolve: (value: boolean) => void };
+
+const ConfirmContext = createContext<((opts: ConfirmOptions) => Promise<boolean>) | null>(null);
+
+/**
+ * Mount once at the root. Replaces native window.confirm() with an in-app,
+ * themed, focus-trapped dialog. Consumers call `await confirm({...})` and get a
+ * boolean — same control flow as `if (!window.confirm(...)) return;`, just async.
+ */
+export function ConfirmProvider({ children }: { children: ReactNode }) {
+  const [pending, setPending] = useState<Pending | null>(null);
+  const pendingRef = useRef<Pending | null>(null);
+  pendingRef.current = pending;
+
+  const confirm = useCallback((opts: ConfirmOptions) => {
+    // Only one dialog at a time — resolve any in-flight request as cancelled.
+    if (pendingRef.current) pendingRef.current.resolve(false);
+    return new Promise<boolean>((resolve) => setPending({ ...opts, resolve }));
+  }, []);
+
+  // Resolve the promise and close. Backdrop/Escape settle as cancelled.
+  const settle = useCallback((value: boolean) => {
+    setPending((p) => {
+      p?.resolve(value);
+      return null;
+    });
+  }, []);
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      <Modal
+        open={!!pending}
+        onClose={() => settle(false)}
+        ariaLabel={pending?.title ?? "Confirm"}
+        footerActions={
+          pending ? (
+            <>
+              {/* Cancel first so it takes the focus-trap's initial focus — the
+                  safe default, especially for destructive confirms. */}
+              <Button variant="secondary" onClick={() => settle(false)}>
+                {pending.cancelLabel ?? "Cancel"}
+              </Button>
+              <Button
+                variant={pending.danger ? "danger" : "primary"}
+                onClick={() => settle(true)}
+              >
+                {pending.confirmLabel ?? "Confirm"}
+              </Button>
+            </>
+          ) : null
+        }
+      >
+        {pending ? (
+          <div className="ui-confirm">
+            <h2 className="ui-confirm-title">{pending.title}</h2>
+            {pending.body ? <div className="ui-confirm-body">{pending.body}</div> : null}
+          </div>
+        ) : null}
+      </Modal>
+    </ConfirmContext.Provider>
+  );
+}
+
+/**
+ * `const confirm = useConfirm()` then `if (!(await confirm({ title: "Delete?",
+ * danger: true }))) return;`. Throws if no provider is in scope.
+ */
+export function useConfirm(): (opts: ConfirmOptions) => Promise<boolean> {
+  const ctx = useContext(ConfirmContext);
+  if (!ctx) throw new Error("useConfirm must be used within a ConfirmProvider");
+  return ctx;
+}

--- a/src/components/vault-panel.tsx
+++ b/src/components/vault-panel.tsx
@@ -6,6 +6,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -136,6 +137,7 @@ function AddMappingForm({
 // ── Main panel ────────────────────────────────────────────────────────────────
 
 export function VaultPanel() {
+  const confirm = useConfirm();
   const [mappings, setMappings]     = useState<Mapping[]>([]);
   const [loading, setLoading]       = useState(true);
   const [error, setError]           = useState<string | null>(null);
@@ -173,7 +175,12 @@ export function VaultPanel() {
   useEffect(() => { void load(); }, []);
 
   async function handleDelete(key: string) {
-    if (!window.confirm(`Delete the secret “${key}”? Anything mapped to it will stop resolving. This can't be undone.`)) return;
+    if (!(await confirm({
+      title: `Delete the secret “${key}”?`,
+      body: "Anything mapped to it will stop resolving. This can't be undone.",
+      confirmLabel: "Delete",
+      danger: true,
+    }))) return;
     setDeleting(key);
     try {
       await fetch("/api/vault", {

--- a/src/components/workflows-view.tsx
+++ b/src/components/workflows-view.tsx
@@ -51,6 +51,7 @@ import {
   type WorkflowStudioActionState,
 } from "./workflows/workflow-studio";
 import type { WorkflowUsesOption } from "./workflows/workflow-inspector";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 
 export function WorkflowsView({
   initialWorkflowId = null,
@@ -61,6 +62,7 @@ export function WorkflowsView({
   /** Called after the deep-link target is selected, so the parent can clear it. */
   onDeepLinkConsumed?: () => void;
 } = {}) {
+  const confirm = useConfirm();
   const [workflows, setWorkflows] = useState<WorkflowSummary[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
@@ -353,14 +355,19 @@ export function WorkflowsView({
     if (typeof window !== "undefined") window.location.hash = `chat-${sessionId}`;
   }, []);
 
-  const confirmDiscard = useCallback((): boolean => {
+  const confirmDiscard = useCallback(async (): Promise<boolean> => {
     if (!dirty) return true;
-    return window.confirm("Discard unsaved workflow changes?");
-  }, [dirty]);
+    return confirm({
+      title: "Discard unsaved workflow changes?",
+      body: "Your edits to this workflow will be lost.",
+      confirmLabel: "Discard",
+      danger: true,
+    });
+  }, [dirty, confirm]);
 
-  const selectWorkflow = (workflow: WorkflowSummary) => {
+  const selectWorkflow = async (workflow: WorkflowSummary) => {
     if (workflow.id === selectedWorkflowId) return;
-    if (!confirmDiscard()) return;
+    if (!(await confirmDiscard())) return;
     setSelectedWorkflowId(workflow.id);
     setSelectedNodeId(null);
     setDraftState(initialWorkflowDraft(workflow));
@@ -535,7 +542,7 @@ export function WorkflowsView({
   );
 
   const handleCreate = async (input: { name: string; pattern: WorkflowPattern; familiar?: string }) => {
-    if (!confirmDiscard()) return;
+    if (!(await confirmDiscard())) return;
     const id = uniqueId(slugifyWorkflowId(input.name));
     const workflow = createWorkflowFromTemplate({
       id,
@@ -558,7 +565,7 @@ export function WorkflowsView({
   };
 
   const handleImport = async (manifest: Record<string, unknown>) => {
-    if (!confirmDiscard()) return;
+    if (!(await confirmDiscard())) return;
     // Land imports in the user's personal library with a unique id; clear the
     // public flag so the runtime routes the copy to ~/.coven (never the repo).
     const rawName = typeof manifest.name === "string" ? manifest.name : "";
@@ -586,7 +593,7 @@ export function WorkflowsView({
   };
 
   const handleCreateFromManifest = async (manifest: Record<string, unknown>) => {
-    if (!confirmDiscard()) return;
+    if (!(await confirmDiscard())) return;
     // Same landing rules as import: personal library, unique id, cave-visible.
     const rawName = typeof manifest.name === "string" && manifest.name.trim() ? manifest.name : "";
     const rawId = typeof manifest.id === "string" && manifest.id.trim() ? manifest.id : rawName || "workflow";
@@ -638,7 +645,7 @@ export function WorkflowsView({
       showNotice("Templates are read-only — duplicate to make an editable copy.");
       return;
     }
-    if (!window.confirm(`Delete workflow \`${workflow.id}\`? The manifest file is removed.`)) return;
+    if (!(await confirm({ title: `Delete workflow “${workflow.id}”?`, body: "The manifest file is removed.", confirmLabel: "Delete", danger: true }))) return;
     const result = await deleteWorkflow(
       workflow.path ? { path: workflow.path } : { id: workflow.id },
     );

--- a/src/components/workflows/workflow-runs-panel.tsx
+++ b/src/components/workflows/workflow-runs-panel.tsx
@@ -10,6 +10,7 @@ import { RelativeTime } from "@/components/ui/relative-time";
 import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 import type { WorkflowPlaybackState } from "@/lib/workflow-playback";
 import { WorkflowRunProgress } from "@/components/workflows/workflow-run-progress";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 import type {
   WorkflowRunRecord,
   WorkflowRunStepRecord,
@@ -80,6 +81,7 @@ function summarizeRuns(runs: WorkflowRunRecord[]): string {
 /** Run history for the selected workflow: plan snapshots and executions. */
 export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayRun, onClearRuns }: WorkflowRunsPanelProps) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
+  const confirm = useConfirm();
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [filter, setFilter] = useState<WorkflowRunFilter>("all");
   const replaying = playback?.source === "replay" && playback.workflowId === workflow?.id;
@@ -87,8 +89,13 @@ export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayR
   const activeFilter = RUN_FILTERS.find((entry) => entry.id === filter) ?? RUN_FILTERS[0];
   const visibleRuns = filter === "all" ? runs : runs.filter(activeFilter.match);
 
-  const handleClear = () => {
-    if (window.confirm("Clear this workflow's run history? Recorded plan snapshots and run records are removed.")) {
+  const handleClear = async () => {
+    if (await confirm({
+      title: "Clear this workflow's run history?",
+      body: "Recorded plan snapshots and run records are removed.",
+      confirmLabel: "Clear history",
+      danger: true,
+    })) {
       onClearRuns();
     }
   };

--- a/src/components/workflows/workflow-studio.test.ts
+++ b/src/components/workflows/workflow-studio.test.ts
@@ -432,7 +432,7 @@ assert.match(css, /\.workflow-manifest-changes/, "CSS should style the unsaved-c
 // The runs panel can clear this workflow's history.
 assert.match(runsPanel, /onClearRuns/, "Runs panel should accept a clear-history handler");
 assert.match(runsPanel, /workflow-runs-clear/, "Runs panel should render a clear-history button");
-assert.match(runsPanel, /window\.confirm/, "Clearing run history should confirm first");
+assert.match(runsPanel, /await confirm\(\{[\s\S]*?Clear this workflow's run history/, "Clearing run history should confirm first (via the in-app ConfirmDialog)");
 assert.match(studio, /onClearRuns=\{props\.onClearRuns\}/, "Studio should thread the clear-history handler");
 assert.match(css, /\.workflow-runs-clear/, "CSS should style the clear-history button");
 


### PR DESCRIPTION
## Problem
Nine destructive/confirm actions used native `window.confirm()` — a blocking, off-brand browser dialog that ignores the app's theme, focus management, and keyboard conventions. There was no reusable in-app confirm primitive (only `ui/modal.tsx`).

## Fix
New **`src/components/ui/confirm-dialog.tsx`**: `ConfirmProvider` + `useConfirm()`.
- **Promise-based** — `if (!(await confirm({ title, body, danger }))) return;` preserves the exact control flow `window.confirm` had, just async.
- Built on the shared **Modal** (focus trap, Esc, backdrop, portal). **Cancel renders first** so the focus trap lands on the safe action; `danger` routes to the destructive (red) button.
- Mounted once at the app root (`layout.tsx`, inside `LiveRegionProvider`).

Migrated **all nine** sites — vault secret delete · canvas sketch delete · automations reminder/automation delete + run-now + bulk reminder delete · workflow discard-unsaved (`confirmDiscard` now async, its 4 callers awaited) + workflow delete · workflow run-history clear.

**No native `window.confirm()` remains in the app.**

## Tests
- New `confirm-dialog.test.ts` — provider/hook exports, Promise API, Modal-based, danger variant, Cancel-first, mounted in layout, and **all 5 migrated files free of `window.confirm` + using `useConfirm`**.
- `workflow-studio.test.ts` updated to expect the in-app confirm for clear-history.
- `pnpm typecheck` clean; `app` suite (392 files) green.

## Verification note
The confirm-bearing surfaces (canvas sketches, workflow studio, schedules row menus) don't mount or expose their controls in the **daemon-less headless harness**, so I verified this at the source / type / test level rather than with a runtime screenshot. The dialog itself is the already-proven `Modal` primitive (its own tests + used across the app) with a thin promise wrapper — the new surface area is the provider wiring, which the test covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)