### PR TITLE
feat(board): kanban-shaped loading skeleton instead of a spinner

### DIFF
--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -19,6 +19,7 @@ import { BoardGantt } from "@/components/board-gantt";
 import { BoardTable, type GroupBy } from "@/components/board-table";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
+import { Skeleton, SkeletonRows } from "@/components/ui/skeleton";
 import { BoardCardStack } from "@/components/board-card-stack";
 import { BoardInspector } from "@/components/board-inspector";
 import { useIsMobile } from "@/lib/use-viewport";
@@ -43,6 +44,32 @@ type Props = {
   onJumpToSession?: (sessionId: string, familiarId: string | null) => void;
   onOpenUrl?: (url: string) => void;
 };
+
+// First-load placeholder that previews the kanban structure (ghost columns +
+// cards) instead of a bare spinner, matching the app-wide skeleton convention
+// (library/schedules/chat/board-inspector). Reuses the real column classes so
+// it's pixel-matched and theme-aware; the shimmer comes from <Skeleton>.
+function BoardKanbanSkeleton() {
+  return (
+    <div className="board-kanban-rail-wrap" aria-hidden>
+      <div className="board-kanban-rail">
+        {Array.from({ length: 4 }).map((_, col) => (
+          <div key={col} className="board-kanban-column">
+            <div className="board-kanban-column-header">
+              <Skeleton variant="avatar" width={7} height={7} />
+              <Skeleton variant="text" width={88} />
+            </div>
+            <div className="flex flex-col gap-2 p-3">
+              {Array.from({ length: 3 - (col % 2) }).map((_, card) => (
+                <Skeleton key={card} variant="card" height={66} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliarIds, onJumpToSession, onOpenUrl }: Props) {
   const isMobile = useIsMobile();
@@ -782,8 +809,14 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
           </div>
         )}
         {!hasLoaded && !error ? (
-          <div className="flex h-full items-center justify-center p-6" role="status" aria-label="Loading tasks">
-            <Icon name="ph:circle-notch-bold" width={20} className="animate-spin text-[var(--text-muted)]" aria-hidden />
+          <div className="h-full min-h-0" role="status" aria-label="Loading tasks">
+            {viewMode === "kanban" ? (
+              <BoardKanbanSkeleton />
+            ) : (
+              <div className="p-4">
+                <SkeletonRows count={8} />
+              </div>
+            )}
           </div>
         ) : cards.length === 0 && !error ? (
           <div className="flex h-full items-center justify-center p-6">


### PR DESCRIPTION
## What

The Board — the app's main work surface — rendered a **bare centered spinner** on first load, while every other major surface (library, schedules, chat, board-inspector) shows a **shared skeleton** per the `surface-loading-states` convention ("surfaces must not flash… convert bare spinner/Loading… to the shared skeleton").

This adds `BoardKanbanSkeleton`: 4 ghost columns reusing the **real** `.board-kanban-rail-wrap` / `.board-kanban-rail` / `.board-kanban-column` / `.board-kanban-column-header` classes (so it's pixel-matched and theme-aware) with `<Skeleton>` header + card placeholders. Table/Gantt view modes fall back to the shared `<SkeletonRows>`. The `role="status"` / `aria-label="Loading tasks"` live region is preserved.

Result: the highest-traffic surface previews its structure during load and avoids the jarring spinner→kanban pop-in.

## Verification

- Screenshotted the held loading state in the running app: 4 ghost columns + 18 skeleton elements, **no spinner** (DOM-confirmed + visual).
- Board + loading/error-state suites pass: `board-ux-polish`, `board-grouping`, `board-view-familiar-scope`, `surface-loading-states`, `surface-error-states`, `command-palette`, and 8 more board specs. No test pinned the old spinner markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)