### PR TITLE
feat(ios): paste + cleanup on the connection setup screen

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
@@ -1,10 +1,16 @@
 import SwiftUI
+import UIKit
 
 struct ConnectionView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.chrome) private var chrome
+    @Environment(\.scenePhase) private var scenePhase
     @State private var host: String = ""
     @State private var busy = false
+    /// Whether the clipboard holds text — drives the "Paste" affordance. We only
+    /// READ the clipboard when the user taps Paste, so there's no surprise
+    /// "pasted from" banner just for showing the button.
+    @State private var canPaste = false
     @FocusState private var focused: Bool
 
     var body: some View {
@@ -14,7 +20,18 @@ struct ConnectionView: View {
                     header
 
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("Desktop address").font(.subheadline.weight(.semibold))
+                        HStack {
+                            Text("Desktop address").font(.subheadline.weight(.semibold))
+                            Spacer()
+                            if canPaste {
+                                Button(action: pasteHost) {
+                                    Label("Paste", systemImage: "doc.on.clipboard")
+                                        .font(.subheadline.weight(.medium))
+                                }
+                                .buttonStyle(.borderless)
+                                .accessibilityHint("Pastes the desktop address from the clipboard")
+                            }
+                        }
                         TextField("my-mac.tailnet.ts.net", text: $host)
                             .textInputAutocapitalization(.never)
                             .autocorrectionDisabled()
@@ -23,8 +40,13 @@ struct ConnectionView: View {
                             .padding(12)
                             .glass(.control, cornerRadius: 12)
                             .accentGlow(active: focused)
-                        Text("Your desktop’s Tailscale MagicDNS name or 100.x address. Found in the Cave desktop app under “Open on phone”.")
-                            .font(.footnote).foregroundStyle(.secondary)
+                        if let hostHint {
+                            Label(hostHint, systemImage: "exclamationmark.circle")
+                                .font(.caption).foregroundStyle(.orange)
+                        } else {
+                            Text("Your desktop’s Tailscale MagicDNS name or 100.x address. Found in the Cave desktop app under “Open on phone”.")
+                                .font(.footnote).foregroundStyle(.secondary)
+                        }
                     }
 
                     if case .unreachable(let message) = app.connectionState {
@@ -53,6 +75,12 @@ struct ConnectionView: View {
             .onAppear {
                 host = app.connection?.host ?? ""
                 focused = host.isEmpty
+                canPaste = UIPasteboard.general.hasStrings
+            }
+            // The user may copy the address from the desktop, then return — keep
+            // the Paste affordance in step with the clipboard.
+            .onChange(of: scenePhase) { _, phase in
+                if phase == .active { canPaste = UIPasteboard.general.hasStrings }
             }
         }
     }
@@ -81,10 +109,38 @@ struct ConnectionView: View {
 
     private func connect() {
         focused = false
+        host = cleanHost(host)
         busy = true
         Task {
             await app.configure(host: host)
             busy = false
         }
+    }
+
+    /// Fill the field from the clipboard (only read on this explicit tap), cleaned.
+    private func pasteHost() {
+        guard let pasted = UIPasteboard.general.string else { return }
+        host = cleanHost(pasted)
+        focused = true
+        Haptics.tap()
+    }
+
+    /// Tidy a pasted/typed address: trim whitespace, drop wrapping quotes/brackets
+    /// a copy sometimes carries, and strip a trailing slash. The scheme is left
+    /// intact — a full `http(s)://` URL is trusted verbatim by the connection.
+    private func cleanHost(_ raw: String) -> String {
+        var s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        s = s.trimmingCharacters(in: CharacterSet(charactersIn: "\"'<>"))
+        while s.hasSuffix("/") { s.removeLast() }
+        return s
+    }
+
+    /// A gentle, non-blocking nudge when the address is obviously malformed — most
+    /// commonly a stray space from copying a label along with the host.
+    private var hostHint: String? {
+        let s = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !s.isEmpty else { return nil }
+        if s.contains(" ") { return "That has a space — paste just the address." }
+        return nil
     }
 }

--- a/scripts/ios-connect-paste.test.mjs
+++ b/scripts/ios-connect-paste.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// The connection setup screen — the first thing a new user hits — should help
+// them get the address in: a Paste affordance (clipboard only read on tap, so no
+// surprise "pasted from" banner), input cleanup, and a gentle malformed hint.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const src = await read("apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift");
+
+// --- Paste affordance, gated on clipboard contents (no eager read) -----------
+assert.match(src, /@State private var canPaste = false/, "should track whether the clipboard has text");
+assert.match(
+  src,
+  /canPaste = UIPasteboard\.general\.hasStrings/,
+  "the Paste button should be gated on hasStrings (no eager clipboard read)",
+);
+assert.match(
+  src,
+  /if canPaste \{[\s\S]*?Button\(action: pasteHost\) \{[\s\S]*?Label\("Paste", systemImage: "doc\.on\.clipboard"\)/,
+  "a Paste button should appear when the clipboard has text",
+);
+assert.match(
+  src,
+  /func pasteHost\(\) \{[\s\S]*?UIPasteboard\.general\.string[\s\S]*?host = cleanHost\(pasted\)/,
+  "pasteHost should read the clipboard only on the explicit tap and clean it",
+);
+
+// --- Cleanup: trim + strip wrapping quotes/trailing slash, KEEP the scheme ----
+assert.match(
+  src,
+  /func cleanHost\(_ raw: String\) -> String \{[\s\S]*?trimmingCharacters\(in: \.whitespacesAndNewlines\)[\s\S]*?hasSuffix\("\/"\)/,
+  "cleanHost should trim whitespace and strip a trailing slash",
+);
+assert.match(src, /host = cleanHost\(host\)/, "connect should clean the host before configuring");
+
+// --- Gentle, non-blocking malformed hint -------------------------------------
+assert.match(
+  src,
+  /private var hostHint: String\? \{[\s\S]*?contains\(" "\)/,
+  "a hostHint should nudge when the address has a stray space",
+);
+// The hint must NOT disable Connect — validation stays advisory (the connect flow
+// does the real probing); the button stays gated only on empty/busy.
+assert.match(
+  src,
+  /\.disabled\(host\.trimmingCharacters\(in: \.whitespaces\)\.isEmpty \|\| busy\)/,
+  "Connect should stay enabled regardless of the advisory hint",
+);
+
+console.log("ios-connect-paste: OK");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -537,6 +537,7 @@ export const SUITES = {
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/ios-theme.test.mjs",
     "scripts/ios-auto-reconnect.test.mjs",
+    "scripts/ios-connect-paste.test.mjs",
     "scripts/ios-theme-list-background.test.mjs",
     "scripts/ios-presence-dots.test.mjs",
     "scripts/ios-swipe-reply.test.mjs",


### PR DESCRIPTION
## What

The first screen a new user sees was a bare text field — they had to hand-type their desktop's `*.ts.net` address even though they'd just **copied it** from the desktop app's "Open on phone". This adds a paste affordance + input cleanup.

## How

- A **Paste** button appears in the "Desktop address" row when the clipboard holds text. The clipboard is only **read on the explicit tap** (the button is gated on `UIPasteboard.hasStrings`), so there's no surprise "pasted from…" banner just for showing it; it refreshes on foreground.
- Pasted/typed input is **cleaned** (`cleanHost`): trim whitespace, drop wrapping quotes/brackets, strip a trailing slash. The **scheme is left intact** — a full `http(s)://` URL is still trusted verbatim by the connection layer.
- A gentle, **non-blocking** hint nudges on an obviously malformed address (a stray space from copying a label with the host). Connect stays enabled; the real probing happens in the connect flow.

## Verification

- iPhone 16 Pro simulator: with an address on the clipboard, the **Paste button shows** in the "Desktop address" row (screenshotted). Build clean.
- New `scripts/ios-connect-paste.test.mjs` locks: paste-read-only-on-tap (`hasStrings` gate), `cleanHost` (trim + strip trailing slash, keep scheme), the advisory hint, and that Connect stays enabled regardless of the hint. CI-wired (`check:tests-wired` green — 540).
- Honest caveat: the paste-*fill* on tap couldn't be screenshotted (tap-injection can't reliably hit the small button in this env), but it's covered by the source-text test and is trivial string logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)