### PR TITLE
feat(undo): deferred undo for journal, vault & automations deletes

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -142,6 +142,7 @@ export const SUITES = {
     "src/components/board-project-picker.test.ts",
     "src/components/board-ux-polish.test.ts",
     "src/components/board-bulk-select.test.ts",
+    "src/components/delete-undo-surfaces.test.ts",
     "src/components/board-link-browser.test.ts",
     "src/components/calendar-view-polish.test.ts",
     "src/lib/calendar-layout.test.ts",

--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -55,7 +55,8 @@ assert.match(source, /aria-checked=\{selectMode \? checked : undefined\}/, "chec
 // The three bulk actions exist and hit the right transitions.
 assert.match(source, /bulkPatchReminders\(\{ status: "dismissed" \}\)/, "bulk Pause dismisses the selected reminders");
 assert.match(source, /bulkPatchReminders\(\{ status: "pending" \}\)/, "bulk Resume re-pends the selected reminders");
-assert.match(source, /const bulkDeleteReminders = async/, "bulk Delete is wired");
+assert.match(source, /const bulkDeleteReminders = \(\) =>/, "bulk Delete is wired (deferred + undoable, no async confirm)");
+assert.match(source, /scheduleDelete\(ids,/, "bulk Delete routes through the deferred useUndoDelete helper");
 // Ephemeral inbox items can't be mutated server-side, so they're filtered out.
 assert.match(source, /\.filter\(\(id\) => !id\.startsWith\("eph:"\)\)/, "bulk actions skip ephemeral (eph:) ids");
 

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -18,6 +18,8 @@ import { relativeTimeSigned } from "@/lib/relative-time";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
 import { useConfirm } from "@/components/ui/confirm-dialog";
+import { UndoToast } from "@/components/ui/undo-toast";
+import { useUndoDelete } from "@/lib/use-undo-delete";
 import { SelectionToolbar } from "@/components/ui/selection-toolbar";
 import { Tabs, type TabItem } from "@/components/ui/tabs";
 import { useMultiSelect } from "@/lib/use-multi-select";
@@ -1320,7 +1322,10 @@ function InboxFeedList({
 // ── Root ──────────────────────────────────────────────────────────────────────
 export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdit, onOpenLink }: Props) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
-  const confirm = useConfirm();
+  const confirm = useConfirm(); // still used by "Run now" (a non-delete action)
+  // Deferred + undoable deletes (reminders, automations, bulk): rows hide at
+  // once, the DELETEs fire only after the undo window, and Undo restores them.
+  const { pending: deletePending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<string[]>();
   const [items, setItems] = useState<InboxItem[]>([]);
   const [codexAutos, setCodexAutos] = useState<CodexAutomation[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -1465,21 +1470,21 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     } finally { setBusyId(null); }
   }, [load]);
 
-  const removeItem = useCallback(async (id: string) => {
+  const removeItem = useCallback((id: string) => {
     if (id.startsWith("eph:")) return;
     const target = items.find((i) => i.id === id);
-    const label = target?.title ? `“${target.title}”` : "this reminder";
-    if (!(await confirm({ title: `Delete ${label}?`, body: "This can't be undone.", confirmLabel: "Delete", danger: true }))) return;
-    setBusyId(id);
-    try {
-      const res = await fetch(`/api/inbox/${id}`, { method: "DELETE" });
-      if (!res.ok) throw new Error(`http ${res.status}`);
-      setSelectedItem((prev) => prev?.id === id ? null : prev);
-      await load();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "delete failed");
-    } finally { setBusyId(null); }
-  }, [items, load]);
+    const label = target?.title ? `“${target.title}”` : "reminder";
+    setSelectedItem((prev) => prev?.id === id ? null : prev);
+    scheduleDelete([id], label, async () => {
+      setItems((prev) => prev.filter((i) => i.id !== id));
+      try {
+        const res = await fetch(`/api/inbox/${id}`, { method: "DELETE" });
+        if (!res.ok) throw new Error(`http ${res.status}`);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "delete failed");
+      } finally { await load(); }
+    });
+  }, [items, scheduleDelete, load]);
 
   const runNow = (id: string) =>
     patchItem(id, { fireAt: new Date().toISOString(), status: "pending" });
@@ -1528,21 +1533,19 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     }
   }, [load]);
 
-  const deleteCodex = useCallback(async (auto: CodexAutomation) => {
-    if (!(await confirm({ title: `Delete automation “${auto.name}”?`, body: "This removes its file.", confirmLabel: "Delete", danger: true }))) return;
-    setBusyId(auto.id);
-    try {
-      const res = await fetch(`/api/codex-automations/${encodeURIComponent(auto.id)}`, { method: "DELETE" });
-      const json = await res.json().catch(() => null);
-      if (!res.ok || !json?.ok) throw new Error(json?.error ?? `http ${res.status}`);
-      setSelectedCodex(null);
-      await load();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "codex delete failed");
-    } finally {
-      setBusyId(null);
-    }
-  }, [load]);
+  const deleteCodex = useCallback((auto: CodexAutomation) => {
+    setSelectedCodex(null);
+    scheduleDelete([auto.id], `automation “${auto.name}”`, async () => {
+      setCodexAutos((prev) => prev.filter((a) => a.id !== auto.id));
+      try {
+        const res = await fetch(`/api/codex-automations/${encodeURIComponent(auto.id)}`, { method: "DELETE" });
+        const json = await res.json().catch(() => null);
+        if (!res.ok || !json?.ok) throw new Error(json?.error ?? `http ${res.status}`);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "codex delete failed");
+      } finally { await load(); }
+    });
+  }, [scheduleDelete, load]);
 
   const runCodexNow = useCallback(async (auto: CodexAutomation) => {
     if (!(await confirm({ title: `Run “${auto.name}” now?`, body: "This executes the agent immediately.", confirmLabel: "Run now" }))) return;
@@ -1575,10 +1578,14 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     }
   }, [load]);
 
+  // Ids whose delete is pending in the undo window — hidden everywhere until the
+  // window lapses (committing the delete) or Undo restores them.
+  const hiddenIds = useMemo(() => new Set(deletePending?.item ?? []), [deletePending]);
+
   // ── Sections ──────────────────────────────────────────────────────────────
   const reminderItems = useMemo(() =>
-    items.filter(isScheduleInboxItem),
-    [items]);
+    items.filter((it) => isScheduleInboxItem(it) && !hiddenIds.has(it.id)),
+    [items, hiddenIds]);
 
   const current = useMemo(() =>
     reminderItems.filter((it) =>
@@ -1642,22 +1649,21 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     }
   };
 
-  const bulkDeleteReminders = async () => {
+  const bulkDeleteReminders = () => {
     const ids = selectedRealIds();
     if (ids.length === 0) { reminderSelect.exit(); return; }
-    if (!(await confirm({ title: `Delete ${ids.length} reminder${ids.length === 1 ? "" : "s"}?`, body: "This can't be undone.", confirmLabel: "Delete", danger: true }))) return;
-    setBulkBusy(true);
-    try {
-      await Promise.all(ids.map((id) =>
-        fetch(`/api/inbox/${id}`, { method: "DELETE" })
-          .then((r) => { if (!r.ok) throw new Error(`http ${r.status}`); })));
-      await load();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "bulk delete failed");
-    } finally {
-      setBulkBusy(false);
-      reminderSelect.exit();
-    }
+    reminderSelect.exit();
+    scheduleDelete(ids, `${ids.length} reminder${ids.length === 1 ? "" : "s"}`, async () => {
+      const idSet = new Set(ids);
+      setItems((prev) => prev.filter((i) => !idSet.has(i.id)));
+      try {
+        await Promise.all(ids.map((id) =>
+          fetch(`/api/inbox/${id}`, { method: "DELETE" })
+            .then((r) => { if (!r.ok) throw new Error(`http ${r.status}`); })));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "bulk delete failed");
+      } finally { await load(); }
+    });
   };
 
   const resolvedFamiliars = useResolvedFamiliars(familiars);
@@ -1683,20 +1689,20 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   const codexActive = useMemo(
     () =>
       codexAutos.filter(
-        (a) => a.status === "ACTIVE" && automationMatchesFilter(a.familiars, familiarFilter),
+        (a) => a.status === "ACTIVE" && !hiddenIds.has(a.id) && automationMatchesFilter(a.familiars, familiarFilter),
       ),
-    [codexAutos, familiarFilter],
+    [codexAutos, familiarFilter, hiddenIds],
   );
   const codexPaused = useMemo(
     () =>
       codexAutos.filter(
-        (a) => a.status === "PAUSED" && automationMatchesFilter(a.familiars, familiarFilter),
+        (a) => a.status === "PAUSED" && !hiddenIds.has(a.id) && automationMatchesFilter(a.familiars, familiarFilter),
       ),
-    [codexAutos, familiarFilter],
+    [codexAutos, familiarFilter, hiddenIds],
   );
 
   // Inbox tab: the FULL feed (every kind), grouped by attention tier.
-  const inboxFeed = useMemo(() => groupInboxFeed(items), [items]);
+  const inboxFeed = useMemo(() => groupInboxFeed(items.filter((it) => !hiddenIds.has(it.id))), [items, hiddenIds]);
   const remindersEmpty = current.length + paused.length + oneShots.length + history.length === 0;
   const automationsEmpty = codexAutos.length === 0;
   const inboxEmpty = items.length === 0;
@@ -1954,6 +1960,16 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
           onCreate={(i) => void createCodex(i)}
         />
       )}
+
+      {deletePending ? (
+        <UndoToast
+          key={deletePending.id}
+          message={`Deleted ${deletePending.label}`}
+          undoAriaLabel="Undo delete"
+          onUndo={undoDelete}
+          onDismiss={commitDelete}
+        />
+      ) : null}
     </section>
   );
 }

--- a/src/components/delete-undo-surfaces.test.ts
+++ b/src/components/delete-undo-surfaces.test.ts
@@ -1,0 +1,43 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (rel: string) => readFileSync(new URL(rel, import.meta.url), "utf8");
+
+// Each surface defers destructive deletes through the shared useUndoDelete hook
+// and surfaces an UndoToast — the same recoverable pattern as board/chat/library.
+for (const rel of [
+  "./vault-panel.tsx",
+  "./automations-view.tsx",
+  "./journal/journal-entries.tsx",
+]) {
+  const src = read(rel);
+  assert.match(src, /import \{ useUndoDelete \} from "@\/lib\/use-undo-delete"/, `${rel} imports useUndoDelete`);
+  assert.match(src, /import \{ UndoToast \} from "@\/components\/ui\/undo-toast"/, `${rel} imports UndoToast`);
+  assert.match(src, /useUndoDelete</, `${rel} instantiates the undo hook`);
+  assert.match(src, /scheduleDelete\(/, `${rel} schedules a deferred delete`);
+  assert.match(src, /<UndoToast/, `${rel} renders the UndoToast`);
+}
+
+// Vault: the secret row hides during the undo window via a pending-key filter.
+{
+  const src = read("./vault-panel.tsx");
+  assert.match(src, /deletePending\.item\.key/, "vault hides the pending secret row during the undo window");
+}
+
+// Automations: reminders + automations both hide by pending id; reminder, codex,
+// and bulk deletes all route through the deferred helper.
+{
+  const src = read("./automations-view.tsx");
+  assert.match(src, /hiddenIds\.has\(it\.id\)/, "automations hides pending reminders/inbox rows");
+  assert.match(src, /hiddenIds\.has\(a\.id\)/, "automations hides pending codex automations");
+  assert.match(src, /const bulkDeleteReminders = \(\) =>/, "bulk reminder delete is deferred (no async confirm)");
+}
+
+// Journal: a pending date makes the day read as empty without mutating `day`.
+{
+  const src = read("./journal/journal-entries.tsx");
+  assert.match(src, /day\?\.date !== deletePending\?\.item/, "journal treats the pending day as empty during the undo window");
+}
+
+console.log("delete-undo-surfaces.test.ts OK");

--- a/src/components/journal/journal-entries.tsx
+++ b/src/components/journal/journal-entries.tsx
@@ -5,6 +5,8 @@ import { Icon } from "@/lib/icon";
 import { EmptyState } from "@/components/ui/empty-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
+import { UndoToast } from "@/components/ui/undo-toast";
+import { useUndoDelete } from "@/lib/use-undo-delete";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { extractNextPaths } from "@/lib/next-paths";
 import { dateSlug, longDateLabel, relativeDayLabel, relativeTime, parseDateSlug } from "@/lib/daily-report";
@@ -75,7 +77,9 @@ export function JournalEntries({
   const [editing, setEditing] = useState(false);
   const [draftReflection, setDraftReflection] = useState("");
   const [saving, setSaving] = useState(false);
-  const [deleting, setDeleting] = useState(false);
+  // Deferred + undoable delete: the day reads as empty immediately, the DELETE
+  // fires only after the undo window, and Undo restores the reflection.
+  const { pending: deletePending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<string>();
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState("");
   const selectedFamiliarId = activeFamiliarId ?? familiars[0]?.id ?? null;
@@ -229,27 +233,28 @@ export function JournalEntries({
     }
   }
 
-  async function deleteEntry() {
+  function deleteEntry() {
     if (!day || !hasEntry) return;
-    setDeleting(true);
+    const date = day.date;
+    cancelEdit();
     setError(null);
-    try {
-      const res = await fetch(`/api/journal?date=${encodeURIComponent(day.date)}`, { method: "DELETE" });
-      const json = await res.json().catch(() => ({}));
-      if (!res.ok || !json.ok) throw new Error(json.error ?? "Could not delete journal entry.");
-      if (!mountedRef.current) return;
-      cancelEdit();
-      await loadDay(day.date);
-      await loadDays();
-    } catch (err) {
-      if (mountedRef.current) setError(err instanceof Error ? err.message : "Could not delete journal entry.");
-    } finally {
-      if (mountedRef.current) setDeleting(false);
-    }
+    scheduleDelete(date, `entry for ${longDateLabel(parseDateSlug(date) ?? new Date())}`, async () => {
+      try {
+        const res = await fetch(`/api/journal?date=${encodeURIComponent(date)}`, { method: "DELETE" });
+        const json = await res.json().catch(() => ({}));
+        if (!res.ok || !json.ok) throw new Error(json.error ?? "Could not delete journal entry.");
+      } catch (err) {
+        if (mountedRef.current) setError(err instanceof Error ? err.message : "Could not delete journal entry.");
+      } finally {
+        if (mountedRef.current) { await loadDay(date); await loadDays(); }
+      }
+    });
   }
 
   const canGenerate = Boolean(selectedFamiliarId);
-  const hasEntry = Boolean(day?.exists && day.entry.reflection.trim());
+  // A pending delete makes the day read as empty (EmptyState) during the undo
+  // window without touching the loaded `day` — Undo just clears the pending flag.
+  const hasEntry = Boolean(day?.exists && day.entry.reflection.trim()) && day?.date !== deletePending?.item;
 
   // Chronological navigation across the *visible* (scoped + filtered) days.
   // The list is newest-first, so "newer" = lower index, "older" = higher.
@@ -380,7 +385,7 @@ export function JournalEntries({
                         type="button"
                         className="journal-entry__action journal-entry__action--primary"
                         onClick={() => { void saveEdit(); }}
-                        disabled={saving || deleting || !draftReflection.trim()}
+                        disabled={saving || !draftReflection.trim()}
                         aria-label="Save journal entry"
                         title="Save"
                       >
@@ -390,7 +395,7 @@ export function JournalEntries({
                         type="button"
                         className="journal-entry__action"
                         onClick={cancelEdit}
-                        disabled={saving || deleting}
+                        disabled={saving}
                         aria-label="Cancel journal edit"
                         title="Cancel"
                       >
@@ -402,7 +407,7 @@ export function JournalEntries({
                       type="button"
                       className="journal-entry__action"
                       onClick={startEdit}
-                      disabled={saving || deleting}
+                      disabled={saving}
                       aria-label="Edit journal entry"
                       title="Edit"
                     >
@@ -412,8 +417,8 @@ export function JournalEntries({
                   <button
                     type="button"
                     className="journal-entry__action journal-entry__action--danger"
-                    onClick={() => { void deleteEntry(); }}
-                    disabled={saving || deleting}
+                    onClick={() => deleteEntry()}
+                    disabled={saving}
                     aria-label="Delete journal entry"
                     title="Delete"
                   >
@@ -471,6 +476,15 @@ export function JournalEntries({
           <div className="journal-empty journal-empty--pane"><SkeletonRows count={5} /></div>
         )}
       </section>
+      {deletePending ? (
+        <UndoToast
+          key={deletePending.id}
+          message={`Deleted ${deletePending.label}`}
+          undoAriaLabel="Undo delete"
+          onUndo={undoDelete}
+          onDismiss={commitDelete}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/journal/journal-view.test.ts
+++ b/src/components/journal/journal-view.test.ts
@@ -69,8 +69,11 @@ assert.match(entries, /draftReflection,\s*setDraftReflection/, "JournalEntries k
 assert.match(entries, /function startEdit\(\)/, "JournalEntries exposes an edit action");
 assert.match(entries, /async function saveEdit\(\)/, "JournalEntries saves edited reflections");
 assert.match(entries, /fetch\("\/api\/journal",\s*\{[\s\S]*?method:\s*"POST"[\s\S]*?reflection:\s*draftReflection/, "JournalEntries persists edited reflection text through /api/journal POST");
-assert.match(entries, /async function deleteEntry\(\)/, "JournalEntries exposes a delete action");
-assert.match(entries, /fetch\(`\/api\/journal\?date=\$\{encodeURIComponent\(day\.date\)\}`,\s*\{ method: "DELETE" \}/, "JournalEntries deletes the selected persisted day through /api/journal DELETE");
+assert.match(entries, /function deleteEntry\(\)/, "JournalEntries exposes a delete action");
+assert.match(entries, /fetch\(`\/api\/journal\?date=\$\{encodeURIComponent\(date\)\}`,\s*\{ method: "DELETE" \}/, "JournalEntries deletes the selected persisted day through /api/journal DELETE");
+// Delete is deferred + undoable: it routes through the shared useUndoDelete helper.
+assert.match(entries, /scheduleDelete\(date,/, "JournalEntries defers the delete through useUndoDelete");
+assert.match(entries, /<UndoToast/, "JournalEntries renders an UndoToast for deletes");
 assert.match(entries, /aria-label="Edit journal entry"/, "JournalEntries renders an edit affordance");
 assert.match(entries, /aria-label="Delete journal entry"/, "JournalEntries renders a delete affordance");
 assert.match(entries, /onKeyDown=\{\(e\) => \{[\s\S]*?e\.key === "Escape"[\s\S]*?cancelEdit/, "Journal edit textarea cancels on Escape");

--- a/src/components/schedules-tabs.test.ts
+++ b/src/components/schedules-tabs.test.ts
@@ -45,7 +45,7 @@ assert.match(automations, /id: "inbox"[\s\S]*id: "reminders"[\s\S]*id: "automati
 assert.match(automations, /<Tabs[\s\S]{0,200}variant="segment"/, "Schedules tabs use the shared segment Tabs");
 assert.match(automations, /type ScheduleTab = "reminders" \| "automations" \| "inbox"/, "Schedules tab state should include inbox");
 assert.match(automations, /function InboxFeedList/, "Inbox tab should render through a feed-list component");
-assert.match(automations, /groupInboxFeed\(items\)/, "Inbox tab should group the full inbox feed (every kind)");
+assert.match(automations, /groupInboxFeed\(items\.filter\(\(it\) => !hiddenIds\.has\(it\.id\)\)\)/, "Inbox tab groups the full inbox feed (every kind), minus rows pending an undoable delete");
 
 assert.match(
   automations,
@@ -54,8 +54,8 @@ assert.match(
 );
 assert.match(
   automations,
-  /const reminderItems = useMemo\(\(\) =>\s*items\.filter\(isScheduleInboxItem\)/,
-  "Reminders tab should use the schedule inbox item filter",
+  /const reminderItems = useMemo\(\(\) =>\s*items\.filter\(\(it\) => isScheduleInboxItem\(it\) && !hiddenIds\.has\(it\.id\)\)/,
+  "Reminders tab should use the schedule inbox item filter (minus rows pending an undoable delete)",
 );
 assert.match(
   automations,

--- a/src/components/ui/confirm-dialog.test.ts
+++ b/src/components/ui/confirm-dialog.test.ts
@@ -34,9 +34,9 @@ assert.match(src, /onClose=\{\(\) => settle\(false\)\}/, "dismiss (backdrop/Esc)
 assert.match(layout, /import \{ ConfirmProvider \}/, "layout imports ConfirmProvider");
 assert.match(layout, /<ConfirmProvider>/, "layout mounts ConfirmProvider");
 
-// The native window.confirm() is gone from the migrated surfaces.
+// Surfaces still gated by the in-app confirm (non-delete actions like run-now,
+// discard-unsaved, workflow/sketch delete, clear-history).
 for (const rel of [
-  "../vault-panel.tsx",
   "../canvas-artifact-node.tsx",
   "../automations-view.tsx",
   "../workflows-view.tsx",
@@ -45,6 +45,12 @@ for (const rel of [
   const file = readFileSync(new URL(rel, import.meta.url), "utf8");
   assert.doesNotMatch(file, /window\.confirm\(/, `${rel} should not call native window.confirm()`);
   assert.match(file, /useConfirm\(\)/, `${rel} should use the in-app confirm`);
+}
+
+// The native window.confirm() is gone everywhere, including the now-undo surfaces.
+for (const rel of ["../vault-panel.tsx", "../journal/journal-entries.tsx"]) {
+  const file = readFileSync(new URL(rel, import.meta.url), "utf8");
+  assert.doesNotMatch(file, /window\.confirm\(/, `${rel} should not call native window.confirm()`);
 }
 
 console.log("confirm-dialog.test.ts OK");

--- a/src/components/vault-panel.tsx
+++ b/src/components/vault-panel.tsx
@@ -6,7 +6,8 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
-import { useConfirm } from "@/components/ui/confirm-dialog";
+import { UndoToast } from "@/components/ui/undo-toast";
+import { useUndoDelete } from "@/lib/use-undo-delete";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -137,13 +138,14 @@ function AddMappingForm({
 // ── Main panel ────────────────────────────────────────────────────────────────
 
 export function VaultPanel() {
-  const confirm = useConfirm();
+  // Deferred + undoable delete: the row hides immediately, the DELETE fires only
+  // after the undo window, and Undo restores it (recoverable, unlike a confirm).
+  const { pending: deletePending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<Mapping>();
   const [mappings, setMappings]     = useState<Mapping[]>([]);
   const [loading, setLoading]       = useState(true);
   const [error, setError]           = useState<string | null>(null);
   const [adding, setAdding]         = useState(false);
   const [editing, setEditing]       = useState<Mapping | null>(null);
-  const [deleting, setDeleting]     = useState<string | null>(null);
   const [copiedKey, setCopiedKey]   = useState<string | null>(null);
 
   async function handleCopyRef(key: string, ref: string) {
@@ -174,24 +176,21 @@ export function VaultPanel() {
 
   useEffect(() => { void load(); }, []);
 
-  async function handleDelete(key: string) {
-    if (!(await confirm({
-      title: `Delete the secret “${key}”?`,
-      body: "Anything mapped to it will stop resolving. This can't be undone.",
-      confirmLabel: "Delete",
-      danger: true,
-    }))) return;
-    setDeleting(key);
-    try {
-      await fetch("/api/vault", {
-        method: "DELETE",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ key }),
-      });
-      await load();
-    } finally {
-      setDeleting(null);
-    }
+  function handleDelete(key: string) {
+    const mapping = mappings.find((m) => m.key === key);
+    if (!mapping) return;
+    scheduleDelete(mapping, `secret “${key}”`, async () => {
+      setMappings((prev) => prev.filter((m) => m.key !== key));
+      try {
+        await fetch("/api/vault", {
+          method: "DELETE",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ key }),
+        });
+      } finally {
+        await load();
+      }
+    });
   }
 
   return (
@@ -267,7 +266,7 @@ export function VaultPanel() {
         />
       ) : (
         <div className="vault-list">
-          {mappings.map((m) => (
+          {(deletePending ? mappings.filter((m) => m.key !== deletePending.item.key) : mappings).map((m) => (
             <div key={m.key} className={`vault-row${m.status === "error" || m.status === "unresolved" ? " vault-row--warn" : ""}`}>
               <div className="vault-row-main">
                 <code className="vault-row-key">{m.key}</code>
@@ -307,8 +306,7 @@ export function VaultPanel() {
                   type="button"
                   className="vault-action-btn vault-action-btn--danger"
                   title="Remove mapping"
-                  disabled={deleting === m.key}
-                  onClick={() => void handleDelete(m.key)}
+                  onClick={() => handleDelete(m.key)}
                 >
                   <Icon name="ph:trash" width={11} />
                 </button>
@@ -323,6 +321,16 @@ export function VaultPanel() {
         Secrets are never stored on disk — resolved live via <code>op read</code> and
         cached in process memory. Requires 1Password desktop app + CLI authed.
       </div>
+
+      {deletePending ? (
+        <UndoToast
+          key={deletePending.id}
+          message={`Deleted ${deletePending.label}`}
+          undoAriaLabel="Undo delete"
+          onUndo={undoDelete}
+          onDismiss={commitDelete}
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Extends the `useUndoDelete` + `UndoToast` pattern (board/chat/projects/library) to the remaining destructive deletes — replacing the confirms added in #1810 for these delete paths. Deletes now hide immediately, fire only after the 4s window, and **Undo restores them** (recoverable, not merely confirmed).

## Surfaces
- **Vault** — secret-mapping delete. Row hides via a pending-key filter; the native-then-in-app confirm is gone (`useConfirm` dropped from the file).
- **Automations** — reminder delete, automation (codex) delete, and bulk reminder delete. A single `useUndoDelete<string[]>` tracks pending ids; the reminder/inbox lists and the codex lists hide them via a shared `hiddenIds` set. `confirm()` is kept only for **Run now** (a non-delete action).
- **Journal** — entry delete (previously immediate, *no* confirm at all). A pending date makes the day read as the empty state during the window without mutating `day`; Undo just clears the pending flag.

## Verified
- **Runtime (production build):** bulk-deleting reminders on Schedules hides them and shows "Deleted N reminders · Undo"; Undo restores them (**4 → 2 → 4**). Screenshot-confirmed. Vault and journal use the identical shared mechanism.
- New `delete-undo-surfaces.test.ts` asserts the undo wiring (hook + toast + per-surface pending-hide) across all three.
- Updated `automations-view` / `journal-view` / `schedules-tabs` / `confirm-dialog` source tests for the deferred wiring.
- `pnpm typecheck` clean; `app` suite (393 files) green.

## Note
This completes the destructive-action arc: every list/document delete in the app (board, chat, projects, library, vault, automations, journal) is now a recoverable deferred-undo. The remaining `ConfirmDialog` usages are non-delete actions (run-now, discard-unsaved) plus workflow/sketch delete (manifest/file removal that's harder to defer-restore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)