### PR TITLE
polish(chat): warmer hover affordance + calmer project card on empty state

### DIFF
--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1001,8 +1001,10 @@
   background: color-mix(in oklch, var(--bg-elevated) 78%, transparent);
   padding: 8px 11px;
   color: var(--text-muted);
+  /* Inline metadata card, not a floating modal — keep the lift subtle so it sits
+   * in the page rather than hovering above it. */
   box-shadow:
-    0 4px 16px oklch(0 0 0 / 14%),
+    0 2px 8px oklch(0 0 0 / 10%),
     inset 0 1px 0 oklch(1 0 0 / 5%);
 }
 
@@ -1091,6 +1093,9 @@
 .cave-chat-empty-prompt svg {
   flex: 0 0 auto;
   color: var(--text-muted);
+  transition:
+    color 140ms ease,
+    transform 140ms ease;
 }
 
 .cave-chat-empty-prompt:hover {
@@ -1098,6 +1103,28 @@
   background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-raised));
   color: var(--text-primary);
   transform: translateY(-1px);
+}
+
+/* Arrow leans into the direction of travel on hover, and picks up the accent
+ * so the affordance reads as "this sends" rather than a static glyph. */
+.cave-chat-empty-prompt:hover svg {
+  color: var(--accent-presence);
+  transform: translateX(2px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cave-chat-empty-prompt,
+  .cave-chat-empty-prompt svg {
+    transition: none;
+  }
+
+  .cave-chat-empty-prompt:hover {
+    transform: none;
+  }
+
+  .cave-chat-empty-prompt:hover svg {
+    transform: none;
+  }
 }
 
 .cave-chat-empty-prompt:focus-visible {


### PR DESCRIPTION
## What

Micro-polish on the chat home / empty-state screen (the "Ready for the next thread." launch screen). **CSS only** — no markup changes, no copy changes, no test touches.

- **Starter-prompt arrows** now lean right (`translateX(2px)`) and pick up `--accent-presence` on hover, so each chip reads as "this sends" rather than a static glyph next to the lift animation.
- **Project selector card** drop shadow softened (`0 4px 16px / 14%` → `0 2px 8px / 10%`) so it reads as inline metadata instead of a floating modal hovering above the page.
- **prefers-reduced-motion** honored — chips drop all transforms/transitions.

## Why

Visual-polish pass on `ChatEmptyState`. The chip hover previously lifted the whole button but left the arrow inert; the project card's shadow was modal-weight for an inline control.

## Scope / safety

- Touches only `src/styles/cave-chat.css` (`.cave-chat-empty-*`).
- No change to `chat-view.tsx` markup or the `"Ready for the next thread."` string pinned by `chat-view-polish.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)