### PR TITLE
fix(roles): accessible tablist + labelled search

### DIFF
--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -134,6 +134,14 @@ export function PluginsView({
   const [busyRoleKey, setBusyRoleKey] = useState<string | null>(null);
   const [selectedSkill, setSelectedSkill] = useState<SkillDetailEntry | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
+  const tablistRef = useRef<HTMLDivElement | null>(null);
+
+  // Switch tabs (clearing the per-tab search). Shared by the tab buttons and
+  // the tablist's arrow-key navigation.
+  const selectTab = useCallback((next: Tab) => {
+    setTab(next);
+    setQuery("");
+  }, []);
 
   const loadRoles = useCallback(async () => {
     setRolesLoaded(false);
@@ -353,20 +361,43 @@ export function PluginsView({
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
                 placeholder={`Search ${TAB_LABEL[tab].toLowerCase()}`}
+                aria-label={`Search ${TAB_LABEL[tab].toLowerCase()}`}
                 className="min-w-0 flex-1 bg-transparent text-[13px] text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)]"
               />
             </label>
           )}
         </div>
-        <div className="mt-4 flex flex-wrap gap-1">
+        <div
+          ref={tablistRef}
+          role="tablist"
+          aria-label="Roles sections"
+          className="mt-4 flex flex-wrap gap-1"
+          onKeyDown={(e) => {
+            if (e.key !== "ArrowRight" && e.key !== "ArrowLeft" && e.key !== "Home" && e.key !== "End") return;
+            e.preventDefault();
+            const i = tabSet.indexOf(tab);
+            const ni =
+              e.key === "ArrowRight" ? (i + 1) % tabSet.length
+              : e.key === "ArrowLeft" ? (i - 1 + tabSet.length) % tabSet.length
+              : e.key === "Home" ? 0
+              : tabSet.length - 1;
+            const next = tabSet[ni];
+            if (next) {
+              selectTab(next);
+              tablistRef.current?.querySelector<HTMLButtonElement>(`#plugins-tab-${next}`)?.focus();
+            }
+          }}
+        >
           {tabSet.map((nextTab) => (
             <button
               key={nextTab}
               type="button"
-              onClick={() => {
-                setTab(nextTab);
-                setQuery("");
-              }}
+              role="tab"
+              id={`plugins-tab-${nextTab}`}
+              aria-selected={tab === nextTab}
+              aria-controls={`plugins-panel-${nextTab}`}
+              tabIndex={tab === nextTab ? 0 : -1}
+              onClick={() => selectTab(nextTab)}
               className={`focus-ring flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[12px] transition-colors ${
                 tab === nextTab
                   ? "bg-[var(--text-primary)] text-[var(--bg-base)]"
@@ -388,11 +419,21 @@ export function PluginsView({
       {tab === "capabilities" ? (
         // Self-contained surface: it owns its own scroll, header, search, and
         // filters, so it renders full-bleed (no shared padding/scroll wrapper).
-        <div className="flex min-h-0 flex-1 flex-col">
+        <div
+          role="tabpanel"
+          id={`plugins-panel-${tab}`}
+          aria-labelledby={`plugins-tab-${tab}`}
+          className="flex min-h-0 flex-1 flex-col"
+        >
           <CapabilitiesViewSurface activeHarness={activeHarness} />
         </div>
       ) : (
-        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6">
+        <div
+          role="tabpanel"
+          id={`plugins-panel-${tab}`}
+          aria-labelledby={`plugins-tab-${tab}`}
+          className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6"
+        >
           {tab === "roles" ? (
             <RolesTab
               roles={filteredRoles}

--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -90,6 +90,16 @@ assert.match(
   "Role cards should explain roles with no MCP server bindings instead of treating MCP as generic tools",
 );
 
+// --- Roles tab bar is an accessible tablist (not just styled buttons) ---
+assert.match(pluginsView, /role="tablist"\s+aria-label="Roles sections"/, "the tab bar is a labelled tablist");
+assert.match(pluginsView, /role="tab"\s*\n\s*id=\{`plugins-tab-\$\{nextTab\}`\}/, "each tab carries role=tab + a stable id");
+assert.match(pluginsView, /aria-selected=\{tab === nextTab\}/, "the active tab is aria-selected");
+assert.match(pluginsView, /aria-controls=\{`plugins-panel-\$\{nextTab\}`\}/, "tabs point at their panel via aria-controls");
+assert.match(pluginsView, /tabIndex=\{tab === nextTab \? 0 : -1\}/, "the tablist uses a roving tab stop");
+assert.match(pluginsView, /e\.key === "ArrowRight"[\s\S]{0,80}?\(i \+ 1\) % tabSet\.length/, "Left/Right arrows move between tabs");
+assert.match(pluginsView, /role="tabpanel"\s*\n\s*id=\{`plugins-panel-\$\{tab\}`\}\s*\n\s*aria-labelledby=\{`plugins-tab-\$\{tab\}`\}/, "the content panels are tabpanels labelled by their tab");
+assert.match(pluginsView, /aria-label=\{`Search \$\{TAB_LABEL\[tab\]\.toLowerCase\(\)\}`\}/, "the search input has an accessible name");
+
 // --- Keyboard shortcuts sheet (CHAT-D11-03) ---
 
 assert.match(


### PR DESCRIPTION
## Roles audit + fix

Audit pass over the Roles view (`plugins-view.tsx`, which hosts the Roles/Workflows/Skills/Capabilities tabs). It's functionally solid — every role card, capability chip, workflow row, and skill card is a real `<button>` with proper error/empty states. The gap was accessibility on the tab bar.

### Accessibility
- **The tab bar is now a real tablist.** It was hand-rolled `<button>`s with a visual-only active style — opaque to assistive tech. Now: `role="tablist"` + `role="tab"`, `aria-selected` on the active tab, `aria-controls` → each panel, a **roving `tabIndex`**, and **←/→ + Home/End arrow-key navigation**. The two content wrappers are `role="tabpanel"` with `id` + `aria-labelledby` tying them to their tab. **Visuals unchanged.**
- **The search input gained an `aria-label`** — its `<label>` wrapped only a magnifier icon + the input, so the placeholder was its only (unreliable) accessible name.
- Extracted a `selectTab()` helper shared by the tab buttons and the arrow-key nav.

## Testing
- **Verified live:** four `role=tab` elements with `aria-selected` + roving `tabIndex` + `aria-controls`; ArrowRight moves selection roles→workflows with focus and the panel's `aria-labelledby` following; search placeholder/label track the tab; no console errors.
- `tsc --noEmit` clean · `pnpm build` clean · full `app` suite: 393 files pass.
- Extended `roles-tools-navigation.test.ts` with the tablist/tab/tabpanel, `aria-selected`, `aria-controls`, roving-tabIndex, arrow-nav, and search-label assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)