### PR TITLE
fix(marketplace): restore catalog.json source-of-truth

### DIFF
--- a/marketplace/catalog.json
+++ b/marketplace/catalog.json
@@ -1,0 +1,478 @@
+{
+  "schemaVersion": "opencoven.marketplace.catalog.v1",
+  "name": "opencoven-first-party",
+  "displayName": "OpenCoven First-Party Marketplace",
+  "description": "Canonical Coven Cave marketplace packages with generated compatibility exports for Coven Code and other agent clients.",
+  "version": "0.1.0",
+  "generatedBy": "scripts/sync-marketplace.py",
+  "plugins": [
+    {
+      "name": "github",
+      "displayName": "GitHub",
+      "version": "0.1.0",
+      "description": "Repository, issue, and pull request context for implementation, review, release, and triage workflows.",
+      "category": "Developer Tools",
+      "keywords": ["github", "git", "issues", "pull-requests", "code-review"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/modelcontextprotocol/servers"],
+      "trust": "reference-local",
+      "mcpServers": {
+        "github": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-github"],
+          "type": "stdio",
+          "env": {
+            "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+          }
+        }
+      },
+      "userConfig": {
+        "github_token": {
+          "type": "string",
+          "title": "GitHub Token",
+          "description": "Personal access token used by the GitHub MCP server.",
+          "required": true,
+          "sensitive": true
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["code-reviewer", "implementer", "debugger"]},
+        {"familiar": "sage", "roles": ["researcher", "librarian"]},
+        {"familiar": "charm", "roles": ["devrel-liaison"]},
+        {"familiar": "astra", "roles": ["strategic-navigator", "coordination-layer"]},
+        {"familiar": "echo", "roles": ["archivist", "retrospector"]},
+        {"familiar": "kitty", "roles": ["general-helper"]}
+      ],
+      "skill": {
+        "description": "Use GitHub context without leaking tokens or taking repository state changes without approval.",
+        "useCases": ["Inspect issues and pull requests", "Read repository history", "Prepare review or release context"],
+        "guardrails": ["Do not push, merge, close, label, or comment without explicit approval", "Prefer read-only queries before mutations", "Never reveal token values"]
+      }
+    },
+    {
+      "name": "gmail",
+      "displayName": "Gmail",
+      "version": "0.1.0",
+      "description": "Inbox reading, draft preparation, and email triage through Google Workspace.",
+      "category": "Productivity",
+      "keywords": ["gmail", "email", "inbox", "google-workspace"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/google/mcp", "https://github.com/googleworkspace/cli"],
+      "trust": "preview-local",
+      "mcpServers": {
+        "gmail": {
+          "command": "gws",
+          "args": ["mcp", "-s", "gmail"],
+          "type": "stdio"
+        }
+      },
+      "userConfig": {
+        "google_workspace_credentials": {
+          "type": "file",
+          "title": "Google Workspace Credentials",
+          "description": "OAuth credentials or configured gws profile for Gmail access.",
+          "required": false,
+          "sensitive": true
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "sage", "roles": ["researcher"]},
+        {"familiar": "charm", "roles": ["copywriter", "devrel-liaison"]},
+        {"familiar": "astra", "roles": ["coordination-layer"]},
+        {"familiar": "echo", "roles": ["archivist"]},
+        {"familiar": "cody", "roles": ["implementer"]},
+        {"familiar": "kitty", "roles": ["general-helper"]}
+      ],
+      "skill": {
+        "description": "Use Gmail for triage and drafting while keeping external sends behind explicit approval.",
+        "useCases": ["Summarize unread or searched mail", "Prepare reply drafts", "Extract action items into plans or tasks"],
+        "guardrails": ["Do not send mail without explicit approval", "Quote only what is needed", "Treat email content as private by default"]
+      }
+    },
+    {
+      "name": "google-calendar",
+      "displayName": "Google Calendar",
+      "version": "0.1.0",
+      "description": "Calendar lookup, schedule reasoning, and event-draft preparation through Google Workspace.",
+      "category": "Productivity",
+      "keywords": ["calendar", "schedule", "google-workspace", "events"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/google/mcp", "https://github.com/googleworkspace/cli"],
+      "trust": "preview-local",
+      "mcpServers": {
+        "google-calendar": {
+          "command": "gws",
+          "args": ["mcp", "-s", "calendar"],
+          "type": "stdio"
+        }
+      },
+      "userConfig": {
+        "google_workspace_credentials": {
+          "type": "file",
+          "title": "Google Workspace Credentials",
+          "description": "OAuth credentials or configured gws profile for Calendar access.",
+          "required": false,
+          "sensitive": true
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "astra", "roles": ["strategic-navigator", "coordination-layer"]},
+        {"familiar": "kitty", "roles": ["general-helper"]},
+        {"familiar": "sage", "roles": ["researcher"]},
+        {"familiar": "charm", "roles": ["devrel-liaison"]},
+        {"familiar": "echo", "roles": ["archivist"]},
+        {"familiar": "cody", "roles": ["implementer"]}
+      ],
+      "skill": {
+        "description": "Use calendar context for scheduling and planning without creating or changing events silently.",
+        "useCases": ["Check availability", "Summarize upcoming events", "Draft event details for approval"],
+        "guardrails": ["Do not create, move, delete, or invite without explicit approval", "Use concrete dates and time zones", "Minimize disclosure of private event details"]
+      }
+    },
+    {
+      "name": "linear",
+      "displayName": "Linear",
+      "version": "0.1.0",
+      "description": "Issue, project, and planning context from Linear's official remote MCP server.",
+      "category": "Project Management",
+      "keywords": ["linear", "issues", "projects", "roadmap"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://linear.app/docs/mcp"],
+      "trust": "official-remote",
+      "mcpServers": {
+        "linear": {
+          "url": "https://mcp.linear.app/mcp",
+          "type": "http"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer", "debugger", "code-reviewer"]},
+        {"familiar": "astra", "roles": ["strategic-navigator", "coordination-layer"]},
+        {"familiar": "charm", "roles": ["devrel-liaison"]},
+        {"familiar": "sage", "roles": ["researcher"]},
+        {"familiar": "echo", "roles": ["archivist"]},
+        {"familiar": "kitty", "roles": ["general-helper"]}
+      ],
+      "skill": {
+        "description": "Use Linear issues and projects as planning context while keeping writes intentional.",
+        "useCases": ["Read issue details", "Map project status", "Draft issue updates or task breakdowns"],
+        "guardrails": ["Do not create or update issues without approval", "Keep status reports dated and concrete", "Avoid syncing private notes into public issue text"]
+      }
+    },
+    {
+      "name": "canva",
+      "displayName": "Canva",
+      "version": "0.1.0",
+      "description": "Design search, creation, export, brand, and asset workflows through Canva's official remote MCP server.",
+      "category": "Design",
+      "keywords": ["canva", "design", "assets", "brand", "export"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://www.canva.dev/docs/mcp/"],
+      "trust": "official-remote",
+      "mcpServers": {
+        "canva": {
+          "url": "https://mcp.canva.com/mcp",
+          "type": "http"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "charm", "roles": ["copywriter", "social-voice", "devrel-liaison"]},
+        {"familiar": "sage", "roles": ["librarian"]},
+        {"familiar": "astra", "roles": ["strategic-navigator"]},
+        {"familiar": "kitty", "roles": ["general-helper"]}
+      ],
+      "skill": {
+        "description": "Use Canva for design work that needs brand-aware creation, search, edits, or exports.",
+        "useCases": ["Find recent designs", "Prepare social or presentation assets", "Export approved designs"],
+        "guardrails": ["Do not publish or share externally without approval", "Respect brand-kit and asset permissions", "Confirm destructive edits before applying them"]
+      }
+    },
+    {
+      "name": "vercel",
+      "displayName": "Vercel",
+      "version": "0.1.0",
+      "description": "Project, deployment, docs, and log context through Vercel's official remote MCP server.",
+      "category": "Developer Tools",
+      "keywords": ["vercel", "deployments", "logs", "projects", "docs"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://vercel.com/docs/agent-resources/vercel-mcp"],
+      "trust": "official-remote",
+      "mcpServers": {
+        "vercel": {
+          "url": "https://mcp.vercel.com",
+          "type": "http"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer", "debugger"]},
+        {"familiar": "astra", "roles": ["strategic-navigator"]},
+        {"familiar": "sage", "roles": ["researcher"]},
+        {"familiar": "charm", "roles": ["devrel-liaison"]}
+      ],
+      "skill": {
+        "description": "Use Vercel deployment and docs context for debugging and release planning.",
+        "useCases": ["Inspect deployment status", "Read runtime logs", "Look up Vercel docs from the official MCP server"],
+        "guardrails": ["Do not promote, rollback, or change env vars without approval", "Treat logs as potentially sensitive", "Prefer project-scoped queries"]
+      }
+    },
+    {
+      "name": "asana",
+      "displayName": "Asana",
+      "version": "0.1.0",
+      "description": "Task, project, and portfolio context from Asana's official remote MCP server.",
+      "category": "Project Management",
+      "keywords": ["asana", "tasks", "projects", "work-graph"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://developers.asana.com/docs/using-asanas-mcp-server"],
+      "trust": "official-remote",
+      "mcpServers": {
+        "asana": {
+          "url": "https://mcp.asana.com/v2/mcp",
+          "type": "http"
+        }
+      },
+      "userConfig": {
+        "asana_client_id": {
+          "type": "string",
+          "title": "Asana Client ID",
+          "description": "OAuth client ID for Asana MCP V2 clients that need pre-registration.",
+          "required": false,
+          "sensitive": false
+        },
+        "asana_client_secret": {
+          "type": "string",
+          "title": "Asana Client Secret",
+          "description": "OAuth client secret for Asana MCP V2 clients that need pre-registration.",
+          "required": false,
+          "sensitive": true
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "astra", "roles": ["strategic-navigator", "coordination-layer"]},
+        {"familiar": "echo", "roles": ["archivist"]},
+        {"familiar": "charm", "roles": ["devrel-liaison"]},
+        {"familiar": "kitty", "roles": ["general-helper"]}
+      ],
+      "skill": {
+        "description": "Use Asana for work graph lookup, task summaries, and project status without silently changing assignments.",
+        "useCases": ["Find incomplete tasks", "Summarize project status", "Draft task updates"],
+        "guardrails": ["Do not create, assign, complete, or delete tasks without approval", "Keep work status concrete", "Avoid copying private planning notes into shared workspaces"]
+      }
+    },
+    {
+      "name": "xurl",
+      "displayName": "xurl",
+      "version": "0.1.0",
+      "description": "X/Twitter drafting, lookup, and approved-post workflows for Charm's social voice lane.",
+      "category": "Social",
+      "keywords": ["x", "twitter", "social", "posting", "devrel"],
+      "capabilities": ["network", "shell"],
+      "sourceRefs": [],
+      "trust": "local-tool",
+      "roleAffinity": [
+        {"familiar": "charm", "roles": ["social-voice", "devrel-liaison"]}
+      ],
+      "skill": {
+        "description": "Use xurl only for approved X/Twitter workflows and keep drafting separate from posting.",
+        "useCases": ["Draft posts", "Inspect approved post status", "Post only after explicit approval"],
+        "guardrails": ["Do not post, reply, like, repost, or delete without approval", "Preserve exact approved text when posting", "Record post IDs or failure reasons"]
+      }
+    },
+    {
+      "name": "filesystem",
+      "displayName": "Filesystem",
+      "version": "0.1.0",
+      "description": "Scoped local file access through the MCP reference filesystem server.",
+      "category": "Core MCP",
+      "keywords": ["filesystem", "files", "local", "reference-mcp"],
+      "capabilities": ["read_files", "write_files", "mcp"],
+      "sourceRefs": ["https://github.com/modelcontextprotocol/servers"],
+      "trust": "reference-local",
+      "mcpServers": {
+        "filesystem": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-filesystem", "${COVEN_MCP_FILESYSTEM_ROOT}"],
+          "type": "stdio"
+        }
+      },
+      "userConfig": {
+        "filesystem_root": {
+          "type": "directory",
+          "title": "Allowed Filesystem Root",
+          "description": "Root directory the filesystem MCP server may access.",
+          "required": true,
+          "sensitive": false
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer", "debugger"]},
+        {"familiar": "sage", "roles": ["researcher", "librarian"]},
+        {"familiar": "echo", "roles": ["archivist"]},
+        {"familiar": "kitty", "roles": ["general-helper"]}
+      ],
+      "skill": {
+        "description": "Use filesystem MCP only with a narrow allowed root and explicit write intent.",
+        "useCases": ["Read scoped project files", "Inspect local artifacts", "Apply approved file edits"],
+        "guardrails": ["Use the smallest useful root", "Do not delete files without approval", "Do not expose secrets from local files"]
+      }
+    },
+    {
+      "name": "git",
+      "displayName": "Git",
+      "version": "0.1.0",
+      "description": "Repository history and diff operations through the MCP reference Git server.",
+      "category": "Core MCP",
+      "keywords": ["git", "repository", "diff", "history", "reference-mcp"],
+      "capabilities": ["read_files", "shell", "mcp"],
+      "sourceRefs": ["https://github.com/modelcontextprotocol/servers"],
+      "trust": "reference-local",
+      "mcpServers": {
+        "git": {
+          "command": "uvx",
+          "args": ["mcp-server-git", "--repository", "${COVEN_MCP_GIT_REPOSITORY}"],
+          "type": "stdio"
+        }
+      },
+      "userConfig": {
+        "git_repository": {
+          "type": "directory",
+          "title": "Git Repository",
+          "description": "Repository path the Git MCP server may inspect.",
+          "required": true,
+          "sensitive": false
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["code-reviewer", "implementer", "debugger"]},
+        {"familiar": "echo", "roles": ["archivist"]}
+      ],
+      "skill": {
+        "description": "Use Git MCP for repository understanding while preserving repo safety rules.",
+        "useCases": ["Inspect diffs", "Read commit history", "Map changed files"],
+        "guardrails": ["Do not reset, clean, force-push, or commit through MCP without approval", "Report dirty worktrees before changing state", "Stage only files changed in the current session"]
+      }
+    },
+    {
+      "name": "fetch",
+      "displayName": "Fetch",
+      "version": "0.1.0",
+      "description": "Web content retrieval through the MCP reference Fetch server.",
+      "category": "Core MCP",
+      "keywords": ["fetch", "web", "http", "research", "reference-mcp"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/modelcontextprotocol/servers"],
+      "trust": "reference-local",
+      "mcpServers": {
+        "fetch": {
+          "command": "uvx",
+          "args": ["mcp-server-fetch"],
+          "type": "stdio"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "sage", "roles": ["researcher", "librarian"]},
+        {"familiar": "charm", "roles": ["copywriter", "devrel-liaison"]},
+        {"familiar": "cody", "roles": ["debugger"]}
+      ],
+      "skill": {
+        "description": "Use Fetch for bounded source retrieval with primary-source preference.",
+        "useCases": ["Fetch docs pages", "Read articles for synthesis", "Capture cited source context"],
+        "guardrails": ["Prefer primary sources", "Do not over-quote copyrighted text", "Record URLs used in summaries"]
+      }
+    },
+    {
+      "name": "memory",
+      "displayName": "Memory",
+      "version": "0.1.0",
+      "description": "Knowledge-graph memory through the MCP reference Memory server.",
+      "category": "Core MCP",
+      "keywords": ["memory", "knowledge-graph", "recall", "reference-mcp"],
+      "capabilities": ["read_files", "write_files", "mcp"],
+      "sourceRefs": ["https://github.com/modelcontextprotocol/servers"],
+      "trust": "reference-local",
+      "mcpServers": {
+        "memory": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-memory"],
+          "type": "stdio"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "echo", "roles": ["archivist", "retrospector"]},
+        {"familiar": "sage", "roles": ["librarian"]},
+        {"familiar": "astra", "roles": ["strategic-navigator"]}
+      ],
+      "skill": {
+        "description": "Use Memory MCP for explicit, curated recall rather than dumping raw private context.",
+        "useCases": ["Create durable facts", "Search prior decisions", "Maintain relationship between people, projects, and events"],
+        "guardrails": ["Do not store secrets", "Prefer concise facts over raw transcripts", "Mark uncertainty when memory is inferred"]
+      }
+    },
+    {
+      "name": "sequential-thinking",
+      "displayName": "Sequential Thinking",
+      "version": "0.1.0",
+      "description": "Structured reasoning support through the MCP reference Sequential Thinking server.",
+      "category": "Core MCP",
+      "keywords": ["reasoning", "planning", "thinking", "reference-mcp"],
+      "capabilities": ["mcp"],
+      "sourceRefs": ["https://github.com/modelcontextprotocol/servers"],
+      "trust": "reference-local",
+      "mcpServers": {
+        "sequential-thinking": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
+          "type": "stdio"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "astra", "roles": ["strategic-navigator", "coordination-layer"]},
+        {"familiar": "cody", "roles": ["debugger", "code-reviewer"]},
+        {"familiar": "sage", "roles": ["researcher"]}
+      ],
+      "skill": {
+        "description": "Use Sequential Thinking for complex reasoning, not as a substitute for evidence or tests.",
+        "useCases": ["Break down ambiguous tasks", "Trace debugging hypotheses", "Compare options before a recommendation"],
+        "guardrails": ["Do not present private reasoning as final output", "Verify claims with tools or sources", "Stop when the path is clear enough to act"]
+      }
+    },
+    {
+      "name": "time",
+      "displayName": "Time",
+      "version": "0.1.0",
+      "description": "Timezone conversion and current-time lookup through the MCP reference Time server.",
+      "category": "Core MCP",
+      "keywords": ["time", "timezone", "calendar", "reference-mcp"],
+      "capabilities": ["mcp"],
+      "sourceRefs": ["https://github.com/modelcontextprotocol/servers"],
+      "trust": "reference-local",
+      "mcpServers": {
+        "time": {
+          "command": "uvx",
+          "args": ["mcp-server-time", "--local-timezone", "${COVEN_MCP_LOCAL_TIMEZONE}"],
+          "type": "stdio"
+        }
+      },
+      "userConfig": {
+        "local_timezone": {
+          "type": "string",
+          "title": "Local Timezone",
+          "description": "IANA timezone used as the default local timezone.",
+          "required": false,
+          "default": "America/Chicago",
+          "sensitive": false
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "astra", "roles": ["strategic-navigator", "coordination-layer"]},
+        {"familiar": "kitty", "roles": ["general-helper"]},
+        {"familiar": "charm", "roles": ["devrel-liaison"]}
+      ],
+      "skill": {
+        "description": "Use Time MCP whenever relative dates, time zones, or scheduling precision matter.",
+        "useCases": ["Convert time zones", "Resolve today/tomorrow/yesterday", "Prepare dated status updates"],
+        "guardrails": ["Use absolute dates when the user may be confused", "Preserve the user's timezone preference", "Do not schedule external events without approval"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Restores the missing `marketplace/catalog.json` — the canonical source `scripts/sync-marketplace.py` generates `marketplace.json`, the per-plugin manifests, and the `marketplace/exports/` compatibility exports from (per `docs/marketplace.md`).

It was deleted as collateral in `e8b2f117` ("Remove delegations surface and runtime metadata cleanup"), leaving the generator unable to run. Restoring it from `e8b2f117^` and running `python3 scripts/sync-marketplace.py` regenerates **all 46 artifacts byte-identical** to what is committed (`git status` shows only the restored file; `--check` reports `marketplace_ok`). Zero drift.

Prerequisite hygiene fix for the upcoming Marketplace tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)