### PR TITLE
feat(calls): skeleton for the floor instead of bare "Loading…" text

### DIFF
--- a/src/components/coven-floor.tsx
+++ b/src/components/coven-floor.tsx
@@ -7,6 +7,7 @@ import { Icon } from "@/lib/icon";
 import type { CovenStatusResponse, FamiliarCard, SessionSummary } from "@/lib/coven-status-types";
 import { statusColor, statusLabel } from "@/lib/coven-status-types";
 import { SessionInitiatorChip } from "@/components/ui/session-initiator-chip";
+import { SkeletonRows } from "@/components/ui/skeleton";
 
 const MAX_VISIBLE_SESSIONS = 12;
 
@@ -325,7 +326,9 @@ export function CovenFloor() {
         </div>
 
         {loading && sortedFamiliars.length === 0 ? (
-          <div className="flex items-center justify-center py-16 text-sm text-[var(--text-muted)]">Loading…</div>
+          <div className="p-2" role="status" aria-label="Loading the floor">
+            <SkeletonRows count={6} />
+          </div>
         ) : sortedFamiliars.length === 0 ? (
           <div className="flex items-center justify-center rounded-lg border border-dashed border-[var(--border-hairline)] py-16 text-sm text-[var(--text-secondary)]">
             No familiar activity found.


### PR DESCRIPTION
## What

The Calls **floor** rendered a bare centered `Loading…` string while the familiar-status table loads — the last spinner/bare-text loading state I found via the `loadState > 0 && skeleton == 0` scan, against the app-wide `surface-loading-states` convention.

Swaps it for the shared `<SkeletonRows count={6} />` (with a `role="status"` live region), so the floor previews list structure on first load — consistent with the Board (#1811) and session-changes (#1812) skeletons. The populated table and the "No familiar activity" empty state are unchanged.

## Verification

- Suites pass: `coven-floor-table` (pins the populated `<table className="board-table floor-table">`, untouched), `chat-surface`, `surface-loading-states`.
- `tsc --noEmit` clean for the file. 4-line diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)