### PR TITLE
fix(workflows): guard runs/layout fetch races + setState-after-unmount

### DIFF
--- a/src/components/workflows-view.test.ts
+++ b/src/components/workflows-view.test.ts
@@ -91,4 +91,18 @@ assert.match(source, /advancePlayback\(current\)/, "A single timer should advanc
 assert.match(source, /const stopPlayback = useCallback/, "View should expose a stop-playback control");
 assert.match(source, /const replayRun = useCallback/, "View should expose replay-on-canvas");
 
+// ── Fetch guards: stale-response races + setState-after-unmount ─────────────
+// loadRuns/loadLayout fire on workflow selection (from ~10 sites), so a fast
+// A→B switch can resolve out of order; a request id drops the stale winner.
+assert.match(source, /const runsReqRef = useRef\(0\)/, "runs loader tracks a request id");
+assert.match(source, /const layoutReqRef = useRef\(0\)/, "layout loader tracks a request id");
+assert.match(source, /const reqId = \+\+runsReqRef\.current/, "each loadRuns stamps a request id");
+assert.match(source, /if \(reqId !== runsReqRef\.current \|\| !mountedRef\.current\) return/, "a stale/late runs fetch is dropped");
+assert.match(source, /if \(reqId !== layoutReqRef\.current \|\| !mountedRef\.current\) return/, "a stale/late layout fetch is dropped");
+// All loaders guard against setState after unmount.
+assert.match(source, /const mountedRef = useRef\(true\)/, "tracks mounted state for async guards");
+assert.match(source, /return \(\) => \{ mountedRef\.current = false; \}/, "mountedRef clears on unmount");
+assert.match(source, /if \(result\.ok && mountedRef\.current\) setFamiliars/, "familiars loader is unmount-guarded");
+assert.match(source, /if \(mountedRef\.current\) setCapabilityUses\(options\)/, "capabilities loader is unmount-guarded");
+
 console.log("workflows-view.test.ts: ok");

--- a/src/components/workflows-view.tsx
+++ b/src/components/workflows-view.tsx
@@ -73,6 +73,15 @@ export function WorkflowsView({
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   // Deep-link target is honored at most once per mount (see selection effect).
   const deepLinkConsumedRef = useRef(false);
+  // Guards async setState after unmount, and (for the selection-driven runs +
+  // layout loaders) drops a stale response when a faster, later selection won.
+  const mountedRef = useRef(true);
+  const runsReqRef = useRef(0);
+  const layoutReqRef = useRef(0);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
   const [draftState, setDraftState] = useState<WorkflowDraftState | null>(null);
   const [runs, setRuns] = useState<WorkflowRunRecord[]>([]);
   const [runsLoading, setRunsLoading] = useState(false);
@@ -112,6 +121,7 @@ export function WorkflowsView({
     if (!refresh) setLoaded(false);
     try {
       const result = await listWorkflows();
+      if (!mountedRef.current) return;
       if (!result.ok) {
         setWorkflows([]);
         setError(result.error ?? "workflows unavailable");
@@ -120,18 +130,24 @@ export function WorkflowsView({
         setError(null);
       }
     } catch (err) {
+      if (!mountedRef.current) return;
       setWorkflows([]);
       setError(err instanceof Error ? err.message : "workflow fetch failed");
     } finally {
-      setLoaded(true);
-      setRefreshing(false);
+      if (mountedRef.current) {
+        setLoaded(true);
+        setRefreshing(false);
+      }
     }
   }, []);
 
   const loadLayout = useCallback(async (workflowId: string) => {
+    const reqId = ++layoutReqRef.current;
     setNodePositions(null);
     try {
       const result = await loadWorkflowLayout(workflowId);
+      // Drop a stale layout: a later selection superseded this one.
+      if (reqId !== layoutReqRef.current || !mountedRef.current) return;
       if (result.ok) setNodePositions(result.positions);
     } catch {
       // layout is a display preference; the layered default always works
@@ -139,21 +155,24 @@ export function WorkflowsView({
   }, []);
 
   const loadRuns = useCallback(async (workflowId: string) => {
+    const reqId = ++runsReqRef.current;
     setRunsLoading(true);
     try {
       const result = await listWorkflowRuns(workflowId);
+      // Drop a stale run list: switching workflows fast can resolve out of order.
+      if (reqId !== runsReqRef.current || !mountedRef.current) return;
       setRuns(result.ok ? result.runs : []);
     } catch {
-      setRuns([]);
+      if (reqId === runsReqRef.current && mountedRef.current) setRuns([]);
     } finally {
-      setRunsLoading(false);
+      if (reqId === runsReqRef.current && mountedRef.current) setRunsLoading(false);
     }
   }, []);
 
   const loadRoles = useCallback(async () => {
     try {
       const result = await listWorkflowRoles();
-      if (result.ok) setRoles(result.roles);
+      if (result.ok && mountedRef.current) setRoles(result.roles);
     } catch {
       // roles are an enhancement; the studio works without them
     }
@@ -163,7 +182,7 @@ export function WorkflowsView({
     try {
       const response = await fetch("/api/familiars", { cache: "no-store" });
       const result = await response.json() as { ok: boolean; familiars?: Familiar[] };
-      if (result.ok) setFamiliars(result.familiars ?? []);
+      if (result.ok && mountedRef.current) setFamiliars(result.familiars ?? []);
     } catch {
       // familiar choices are an enhancement; existing manifest bindings remain selectable
     }
@@ -191,7 +210,7 @@ export function WorkflowsView({
         for (const skill of manifest.skills ?? []) options.push({ value: skill.id, group: "Skill" });
         for (const plugin of manifest.plugins ?? []) options.push({ value: plugin.id, group: "Tool" });
       }
-      setCapabilityUses(options);
+      if (mountedRef.current) setCapabilityUses(options);
     } catch {
       // capability discovery is an enhancement; freeform `uses` still works
     }


### PR DESCRIPTION
## Workflows audit + fix

Audit pass over the Workflows view (`workflows-view.tsx`). The surface is already strong — **a11y is solid** (library rows are `<button aria-pressed>`, the studio is on the shared `<Tabs>` with `role="tabpanel"`, search + origin dots are labelled, Escape-to-clear works), timers self-cancel, and there's a one-time deep-link guard. The gap was that its data loaders had **no async guards**.

- **`loadRuns` / `loadLayout` fire on workflow selection from ~10 call sites** (the selection effect, the select handler, and every save/fork/delete). Switching workflows quickly resolves them out of order, so workflow A's run history or node layout could land on workflow B. Each now stamps a **request id** and drops a superseded response.
- **All six loaders** (`load`, `loadRuns`, `loadLayout`, `loadFamiliars`, `loadRoles`, `loadCapabilities`) now bail before `setState` if the view **unmounted** mid-fetch.

Behavior is unchanged in the happy path — purely defensive against fast selection switching and tab teardown.

## Testing
- `tsc --noEmit` clean · `pnpm build` clean · full `app` suite: 396 files pass.
- Extended `workflows-view.test.ts` with the request-id (`runsReqRef`/`layoutReqRef`, stale-drop) and unmount-guard assertions.
- Smoke-checked the running view: library / canvas empty-state / inspector / runs panel all render with **no console errors** (no regression). The race itself needs daemon-backed workflow data to exercise live, so it's covered by the request-id logic + tests rather than a live repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)