### PR TITLE
feat(youtube): world-class collapsed states (mini bar + peek strip)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4278,48 +4278,86 @@ button:active > .edge-rail-chip {
   z-index: 2;
   align-items: flex-start;
   justify-content: center;
-  padding-top: 7px;
+  padding-top: 8px;
   border: 0;
-  /* A soft top fade keeps the caret legible over a bright video; the rest of
-     the overlay stays transparent so the video shows through. */
-  background: linear-gradient(
-    to bottom,
-    color-mix(in oklch, var(--bg-base) 70%, transparent),
-    transparent 38px
-  );
-  color: #fff;
+  background: transparent;
+  color: var(--text-secondary);
   cursor: pointer;
-  transition: background 0.12s;
 }
 
-.companion-rail--video-strip .companion-rail__strip-expand:hover {
-  background: linear-gradient(
-    to bottom,
-    color-mix(in oklch, var(--bg-base) 80%, transparent),
-    color-mix(in oklch, var(--bg-base) 22%, transparent)
-  );
+/* The caret reads as a real button: a small rounded chip pinned at the top. */
+.companion-rail--video-strip .companion-rail__strip-expand > * {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border-hairline);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.25);
+  transition: background 0.12s, color 0.12s, transform 0.12s;
+}
+
+.companion-rail--video-strip .companion-rail__strip-expand:hover > * {
+  background: var(--accent);
+  color: var(--accent-contrast, #fff);
+  transform: scale(1.06);
 }
 
 .companion-rail--video-strip #companion-rail-youtube {
   flex: 1 1 auto !important;
 }
 
-/* Rotate the video to run top→bottom and fill the tall, narrow strip.
-   `container-type: size` lets the iframe size off the frame's box: its
-   pre-rotation width = frame height, height = frame width, so after a 90°
-   turn it covers the frame exactly. */
+/* In the narrow peek strip we DON'T show the video sideways (a 16:9 frame
+   rotated into a ~55px column is a head-tilt sliver). Keep the iframe mounted
+   as an invisible sliver so audio never stops, and hand the strip to a calm,
+   upright "now playing" indicator instead. */
 .companion-rail--video-strip .youtube-viewer__frame {
-  container-type: size;
+  flex: 0 0 1px;
+  min-height: 0;
+  opacity: 0;
+  pointer-events: none;
 }
 
-.companion-rail--video-strip .youtube-viewer__frame iframe {
-  inset: auto;
-  top: 50%;
-  left: 50%;
-  width: 100cqh;
-  height: 100cqw;
-  transform: translate(-50%, -50%) rotate(90deg);
-  transform-origin: center;
+.companion-rail--video-strip .youtube-viewer__strip {
+  display: flex;
+}
+
+/* Vertical now-playing strip — equalizer + upright (vertical) title, centred in
+   the column. Hidden everywhere except the collapsed video strip. */
+.youtube-viewer__strip {
+  display: none;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 40px 4px 18px;
+  background: var(--bg-panel);
+}
+
+.youtube-viewer__strip-title {
+  writing-mode: vertical-rl;
+  max-height: 62%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: var(--text-xs);
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  color: var(--text-secondary);
+}
+
+/* Larger equalizer for the strip. */
+.youtube-viewer__eq--lg {
+  height: 26px;
+  gap: 3px;
+}
+
+.youtube-viewer__eq--lg i {
+  width: 3px;
 }
 
 /* ── Collapse-to-mini player ────────────────────────────────────────────────
@@ -4371,9 +4409,10 @@ button:active > .edge-rail-chip {
   display: flex;
   flex: 1;
   align-items: center;
-  gap: 4px;
-  padding: 0 6px 0 4px;
+  gap: 3px;
+  padding: 0 8px 0 6px;
   background: var(--bg-panel);
+  border-top: 1px solid var(--border-hairline);
 }
 
 .youtube-viewer__mini-btn {
@@ -4381,17 +4420,47 @@ button:active > .edge-rail-chip {
   flex-shrink: 0;
   align-items: center;
   justify-content: center;
-  width: 26px;
+  width: 28px;
   height: 28px;
   border-radius: var(--radius-control);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: color 0.1s, background 0.1s;
+  transition: color 0.1s, background 0.1s, transform 0.1s;
 }
 
 .youtube-viewer__mini-btn:hover {
   background: var(--bg-raised);
   color: var(--text-primary);
+}
+
+.youtube-viewer__mini-btn:active {
+  transform: scale(0.92);
+}
+
+/* The play/pause control reads as primary: a filled accent disc. */
+.youtube-viewer__mini-btn--primary {
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-contrast, #fff);
+}
+
+.youtube-viewer__mini-btn--primary:hover {
+  background: var(--accent);
+  color: var(--accent-contrast, #fff);
+  filter: brightness(1.08);
+}
+
+/* Equalizer + title share the flexible middle so the title truncates, not the
+   controls. */
+.youtube-viewer__nowplaying {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: center;
+  gap: 6px;
+  padding-left: 4px;
 }
 
 .youtube-viewer__mini-title {
@@ -4400,9 +4469,51 @@ button:active > .edge-rail-chip {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  padding: 0 4px;
   font-size: var(--text-xs);
+  font-weight: 500;
   color: var(--text-primary);
+}
+
+/* ── Now-playing equalizer ──────────────────────────────────────────────── */
+.youtube-viewer__eq {
+  display: flex;
+  flex-shrink: 0;
+  align-items: flex-end;
+  gap: 2px;
+  height: 12px;
+}
+
+.youtube-viewer__eq i {
+  width: 2px;
+  height: 100%;
+  border-radius: 1px;
+  background: var(--accent);
+  transform: scaleY(0.35);
+  transform-origin: bottom;
+}
+
+/* Static low bars when paused; lively staggered bounce when playing. */
+.youtube-viewer__eq[data-playing="true"] i {
+  animation: youtube-eq 0.9s ease-in-out infinite;
+}
+
+.youtube-viewer__eq[data-playing="true"] i:nth-child(2) {
+  animation-delay: 0.18s;
+  animation-duration: 1.05s;
+}
+
+.youtube-viewer__eq[data-playing="true"] i:nth-child(3) {
+  animation-delay: 0.36s;
+  animation-duration: 0.78s;
+}
+
+@keyframes youtube-eq {
+  0%, 100% { transform: scaleY(0.3); }
+  50% { transform: scaleY(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .youtube-viewer__eq[data-playing="true"] i { animation: none; transform: scaleY(0.7); }
 }
 
 /* Slim accent volume slider — the filled portion follows --vol (set inline). */
@@ -4447,7 +4558,7 @@ button:active > .edge-rail-chip {
    freed height. react-resizable-panels sets each Panel's size via inline
    `flex`, so the override is `!important`; the resizer is hidden while parked. */
 .companion-rail__split:has(.youtube-viewer[data-collapsed="true"]) #companion-rail-youtube {
-  flex: 0 0 36px !important;
+  flex: 0 0 40px !important;
 }
 
 .companion-rail__split:has(.youtube-viewer[data-collapsed="true"]) #companion-rail-main {

--- a/src/components/right-panel-expand.test.ts
+++ b/src/components/right-panel-expand.test.ts
@@ -76,15 +76,22 @@ assert.match(
   /familiarOpen \|\| rightPanelPeek \? agent : null/,
   "the rail content stays mounted while peeking so the video keeps playing",
 );
+// In the narrow peek strip the video is NOT shown sideways; the iframe stays a
+// hidden sliver (audio keeps playing) and an upright "now playing" strip shows.
 assert.match(
   css,
-  /\.companion-rail--video-strip[\s\S]*?rotate\(90deg\)/,
-  "the collapsed strip rotates the video 90° to run top→bottom",
+  /\.companion-rail--video-strip\s+\.youtube-viewer__frame\s*\{[\s\S]*?flex:\s*0 0 1px[\s\S]*?opacity:\s*0/,
+  "the strip keeps the iframe a hidden sliver (audio continues, no sideways video)",
 );
 assert.match(
   css,
-  /\.companion-rail--video-strip\s+\.youtube-viewer__frame\s*\{[\s\S]*?container-type:\s*size/,
-  "the strip uses a size container so the rotated iframe fills it",
+  /\.companion-rail--video-strip\s+\.youtube-viewer__strip\s*\{[\s\S]*?display:\s*flex/,
+  "the strip shows the upright now-playing indicator",
+);
+assert.match(
+  css,
+  /\.youtube-viewer__strip-title\s*\{[\s\S]*?writing-mode:\s*vertical-rl/,
+  "the strip title runs vertically (upright text, not a rotated video)",
 );
 assert.match(
   css,

--- a/src/components/youtube-collapse.test.ts
+++ b/src/components/youtube-collapse.test.ts
@@ -39,8 +39,21 @@ assert.match(
 );
 assert.match(
   css,
-  /\.companion-rail__split:has\(\.youtube-viewer\[data-collapsed="true"\]\) #companion-rail-youtube \{[\s\S]*?flex: 0 0 36px !important/,
+  /\.companion-rail__split:has\(\.youtube-viewer\[data-collapsed="true"\]\) #companion-rail-youtube \{[\s\S]*?flex: 0 0 40px !important/,
   "collapsed: the bottom pane parks at the mini-bar height so the top pane reclaims the space",
+);
+
+// ── Now-playing polish: primary play disc + an animated equalizer ────────────
+assert.match(
+  view,
+  /youtube-viewer__mini-btn--primary/,
+  "the mini bar's play/pause reads as the primary control",
+);
+assert.match(view, /<Equalizer playing=\{playing\}/, "the mini bar shows a now-playing equalizer");
+assert.match(
+  css,
+  /\.youtube-viewer__eq\[data-playing="true"\] i \{[\s\S]*?animation: youtube-eq/,
+  "the equalizer animates while playing",
 );
 
 console.log("youtube-collapse.test.ts: ok");

--- a/src/components/youtube-viewer.tsx
+++ b/src/components/youtube-viewer.tsx
@@ -326,11 +326,12 @@ export function YoutubeViewer({ defaultSrc = DEFAULT_SRC }: { defaultSrc?: strin
         />
       </div>
       {/* Mini player — shown only when collapsed (CSS). Full width, one row:
-          transport + scrolling title + volume + an expand caret. */}
+          a primary play button, next, a now-playing equalizer + title, volume,
+          and an expand caret. */}
       <div className="youtube-viewer__mini">
         <button
           type="button"
-          className="youtube-viewer__mini-btn focus-ring"
+          className="youtube-viewer__mini-btn youtube-viewer__mini-btn--primary focus-ring"
           onClick={togglePlay}
           aria-label={playing ? "Pause" : "Play"}
           title={playing ? "Pause" : "Play"}
@@ -346,8 +347,11 @@ export function YoutubeViewer({ defaultSrc = DEFAULT_SRC }: { defaultSrc?: strin
         >
           <Icon name="ph:skip-forward-fill" width={13} />
         </button>
-        <span className="youtube-viewer__mini-title" title={title || "YouTube"}>
-          {title || "YouTube"}
+        <span className="youtube-viewer__nowplaying">
+          <Equalizer playing={playing} />
+          <span className="youtube-viewer__mini-title" title={title || "YouTube"}>
+            {title || "YouTube"}
+          </span>
         </span>
         <button
           type="button"
@@ -378,6 +382,31 @@ export function YoutubeViewer({ defaultSrc = DEFAULT_SRC }: { defaultSrc?: strin
           <Icon name="ph:caret-up" width={14} />
         </button>
       </div>
+      {/* Vertical "now playing" strip — shown only when the whole rail is
+          collapsed to its peek width (CSS, under .companion-rail--video-strip).
+          The iframe keeps playing audio (hidden); this is a calm, upright
+          now-playing indicator instead of a sideways-rotated video. The rail's
+          transparent overlay handles tap-to-expand. */}
+      <div className="youtube-viewer__strip" aria-hidden="true">
+        <Equalizer playing={playing} className="youtube-viewer__eq--lg" />
+        <span className="youtube-viewer__strip-title">{title || "YouTube"}</span>
+      </div>
     </div>
+  );
+}
+
+/** A tiny three-bar "now playing" equalizer; the bars animate while `playing`
+ *  and rest at a low flat line when paused. Decorative (aria-hidden). */
+function Equalizer({ playing, className }: { playing: boolean; className?: string }) {
+  return (
+    <span
+      className={`youtube-viewer__eq${className ? ` ${className}` : ""}`}
+      data-playing={playing ? "true" : undefined}
+      aria-hidden="true"
+    >
+      <i />
+      <i />
+      <i />
+    </span>
   );
 }


### PR DESCRIPTION
## What

Both collapsed states of the companion-rail YouTube player looked rough (see the reported screenshot of the peek strip). This polishes both for a world-class feel.

### Collapsed mini bar (player collapsed, rail open)
**Before:** a flat row of equal-weight glyphs, no "now playing" signal.
**After:** the play/pause is a **primary accent disc**; a small **animated equalizer** sits before the title (bars bounce while playing, rest flat when paused, frozen under `prefers-reduced-motion`); refined spacing + a hairline top divider; pane parks at **40px** (was 36).

### Collapsed peek strip (whole rail collapsed while a video plays)
**Before:** the video was **rotated 90°** into a ~55px column — a head-tilt sideways sliver (near-black on dark frames; this is what the screenshot caught).
**After:** a calm, **upright vertical "now playing" strip** — the equalizer + the title in vertical `writing-mode`, centred over the panel background. The iframe stays mounted as a hidden 1px sliver so **audio never stops**. The re-expand affordance is now a clear **rounded caret chip** (was a faint caret over a fade), tinting to the accent on hover.

## Verification

Rendered against the running app (demo familiar → open a session → Video tab):
- **Mini bar** — accent play disc + equalizer + title, screenshotted.
- **Peek strip** — upright now-playing indicator + clear expand chip, replacing the sideways video, screenshotted at the real 55px width.
- **Expanded player** — unchanged.
- `next build` passes (types + lint). Tests that pinned the old `0 0 36px` park height and the `rotate(90deg)` / `container-type: size` strip were updated to the new design; `youtube-collapse`, `right-panel-expand`, `companion-rail` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)