### PR TITLE
feat(ux): text filter for vault secrets and the schedules lists

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -144,6 +144,7 @@ export const SUITES = {
     "src/components/board-ux-polish.test.ts",
     "src/components/board-bulk-select.test.ts",
     "src/components/delete-undo-surfaces.test.ts",
+    "src/components/vault-automations-filter.test.ts",
     "src/components/board-link-browser.test.ts",
     "src/components/calendar-view-polish.test.ts",
     "src/lib/calendar-layout.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2637,6 +2637,10 @@ tr[role="checkbox"]:focus-visible {
   flex-direction: column;
   gap: 4px;
 }
+
+.vault-filter {
+  padding: 8px 8px 0;
+}
 .vault-row {
   position: relative;
   display: flex;

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -20,6 +20,7 @@ import { Button } from "@/components/ui/button";
 import { useConfirm } from "@/components/ui/confirm-dialog";
 import { UndoToast } from "@/components/ui/undo-toast";
 import { useUndoDelete } from "@/lib/use-undo-delete";
+import { SearchInput } from "@/components/ui/search-input";
 import { SelectionToolbar } from "@/components/ui/selection-toolbar";
 import { Tabs, type TabItem } from "@/components/ui/tabs";
 import { useMultiSelect } from "@/lib/use-multi-select";
@@ -1326,6 +1327,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   // Deferred + undoable deletes (reminders, automations, bulk): rows hide at
   // once, the DELETEs fire only after the undo window, and Undo restores them.
   const { pending: deletePending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<string[]>();
+  const [query, setQuery] = useState("");
   const [items, setItems] = useState<InboxItem[]>([]);
   const [codexAutos, setCodexAutos] = useState<CodexAutomation[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -1581,11 +1583,13 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   // Ids whose delete is pending in the undo window — hidden everywhere until the
   // window lapses (committing the delete) or Undo restores them.
   const hiddenIds = useMemo(() => new Set(deletePending?.item ?? []), [deletePending]);
+  // Normalized text filter applied to whichever tab is active (title/name).
+  const q = query.trim().toLowerCase();
 
   // ── Sections ──────────────────────────────────────────────────────────────
   const reminderItems = useMemo(() =>
-    items.filter((it) => isScheduleInboxItem(it) && !hiddenIds.has(it.id)),
-    [items, hiddenIds]);
+    items.filter((it) => isScheduleInboxItem(it) && !hiddenIds.has(it.id) && (!q || (it.title ?? "").toLowerCase().includes(q))),
+    [items, hiddenIds, q]);
 
   const current = useMemo(() =>
     reminderItems.filter((it) =>
@@ -1689,20 +1693,20 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   const codexActive = useMemo(
     () =>
       codexAutos.filter(
-        (a) => a.status === "ACTIVE" && !hiddenIds.has(a.id) && automationMatchesFilter(a.familiars, familiarFilter),
+        (a) => a.status === "ACTIVE" && !hiddenIds.has(a.id) && automationMatchesFilter(a.familiars, familiarFilter) && (!q || a.name.toLowerCase().includes(q)),
       ),
-    [codexAutos, familiarFilter, hiddenIds],
+    [codexAutos, familiarFilter, hiddenIds, q],
   );
   const codexPaused = useMemo(
     () =>
       codexAutos.filter(
-        (a) => a.status === "PAUSED" && !hiddenIds.has(a.id) && automationMatchesFilter(a.familiars, familiarFilter),
+        (a) => a.status === "PAUSED" && !hiddenIds.has(a.id) && automationMatchesFilter(a.familiars, familiarFilter) && (!q || a.name.toLowerCase().includes(q)),
       ),
-    [codexAutos, familiarFilter, hiddenIds],
+    [codexAutos, familiarFilter, hiddenIds, q],
   );
 
   // Inbox tab: the FULL feed (every kind), grouped by attention tier.
-  const inboxFeed = useMemo(() => groupInboxFeed(items.filter((it) => !hiddenIds.has(it.id))), [items, hiddenIds]);
+  const inboxFeed = useMemo(() => groupInboxFeed(items.filter((it) => !hiddenIds.has(it.id) && (!q || (it.title ?? "").toLowerCase().includes(q)))), [items, hiddenIds, q]);
   const remindersEmpty = current.length + paused.length + oneShots.length + history.length === 0;
   const automationsEmpty = codexAutos.length === 0;
   const inboxEmpty = items.length === 0;
@@ -1711,6 +1715,8 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
 
   const selectTab = (tab: ScheduleTab) => {
     setActiveTab(tab);
+    setQuery(""); // the filter is scoped to one tab at a time
+
     // Reminders and Inbox both select InboxItems (DetailPanel); Automations
     // selects CodexAutomations. Clear the other selection on switch.
     if (tab === "automations") setSelectedItem(null);
@@ -1775,6 +1781,24 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
           />
         </div>
 
+        {/* Text filter for the active tab. Gated on the UNfiltered presence of
+            rows so filtering to zero never hides the box (you can still clear). */}
+        {initialLoadDone && !reminderSelect.selectMode && (
+          activeTab === "inbox" ? items.length > 0
+          : activeTab === "automations" ? codexAutos.length > 0
+          : items.some(isScheduleInboxItem)
+        ) ? (
+          <div className="px-8 pb-4">
+            <SearchInput
+              value={query}
+              onValueChange={setQuery}
+              onClear={() => setQuery("")}
+              placeholder={activeTab === "automations" ? "Filter automations…" : activeTab === "inbox" ? "Filter inbox…" : "Filter reminders…"}
+              aria-label="Filter schedules"
+            />
+          </div>
+        ) : null}
+
         {error && (
           <div
             role="alert"
@@ -1803,6 +1827,17 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
                 />
               ))}
             </div>
+          ) : q && (
+            (activeTab === "reminders" && remindersEmpty) ||
+            (activeTab === "automations" && codexActive.length + codexPaused.length === 0) ||
+            (activeTab === "inbox" && inboxFeed.needsYou.length + inboxFeed.active.length + inboxFeed.resolved.length === 0)
+          ) ? (
+            <EmptyState
+              className="mt-12"
+              icon="ph:magnifying-glass"
+              headline={`No matches for “${query.trim()}”`}
+              subtitle="Try a different search term."
+            />
           ) : activeTab === "reminders" && remindersEmpty ? (
             <EmptyState
               className="mt-12"

--- a/src/components/schedules-tabs.test.ts
+++ b/src/components/schedules-tabs.test.ts
@@ -45,7 +45,7 @@ assert.match(automations, /id: "inbox"[\s\S]*id: "reminders"[\s\S]*id: "automati
 assert.match(automations, /<Tabs[\s\S]{0,200}variant="segment"/, "Schedules tabs use the shared segment Tabs");
 assert.match(automations, /type ScheduleTab = "reminders" \| "automations" \| "inbox"/, "Schedules tab state should include inbox");
 assert.match(automations, /function InboxFeedList/, "Inbox tab should render through a feed-list component");
-assert.match(automations, /groupInboxFeed\(items\.filter\(\(it\) => !hiddenIds\.has\(it\.id\)\)\)/, "Inbox tab groups the full inbox feed (every kind), minus rows pending an undoable delete");
+assert.match(automations, /groupInboxFeed\(items\.filter\(\(it\) => !hiddenIds\.has\(it\.id\)[\s\S]*?\)\)/, "Inbox tab groups the full inbox feed, minus undo-pending rows (and text-filter non-matches)");
 
 assert.match(
   automations,
@@ -54,8 +54,8 @@ assert.match(
 );
 assert.match(
   automations,
-  /const reminderItems = useMemo\(\(\) =>\s*items\.filter\(\(it\) => isScheduleInboxItem\(it\) && !hiddenIds\.has\(it\.id\)\)/,
-  "Reminders tab should use the schedule inbox item filter (minus rows pending an undoable delete)",
+  /const reminderItems = useMemo\(\(\) =>\s*items\.filter\(\(it\) => isScheduleInboxItem\(it\) && !hiddenIds\.has\(it\.id\)/,
+  "Reminders tab should use the schedule inbox item filter (minus undo-pending rows)",
 );
 assert.match(
   automations,

--- a/src/components/vault-automations-filter.test.ts
+++ b/src/components/vault-automations-filter.test.ts
@@ -1,0 +1,25 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (rel: string) => readFileSync(new URL(rel, import.meta.url), "utf8");
+
+// Both surfaces gain a text filter via the shared SearchInput primitive.
+const vault = read("./vault-panel.tsx");
+assert.match(vault, /import \{ SearchInput \} from "@\/components\/ui\/search-input"/, "vault imports SearchInput");
+assert.match(vault, /<SearchInput[\s\S]*?placeholder="Filter secrets…"/, "vault renders a secrets filter");
+// Filter composes with the undo-pending hide and matches key / ref / description.
+assert.match(vault, /\[m\.key, m\.ref \?\? "", m\.description \?\? ""\]\.join\(" "\)\.toLowerCase\(\)\.includes\(q\)/, "vault filters by key/ref/description");
+assert.match(vault, /No secrets match/, "vault shows a no-matches message");
+
+const auto = read("./automations-view.tsx");
+assert.match(auto, /import \{ SearchInput \} from "@\/components\/ui\/search-input"/, "automations imports SearchInput");
+assert.match(auto, /<SearchInput[\s\S]*?aria-label="Filter schedules"/, "automations renders a schedules filter");
+// The text filter applies to all three tabs' source derivations.
+assert.match(auto, /isScheduleInboxItem\(it\) && !hiddenIds\.has\(it\.id\) && \(!q \|\| \(it\.title \?\? ""\)\.toLowerCase\(\)\.includes\(q\)\)/, "reminders honor the text filter");
+assert.match(auto, /a\.name\.toLowerCase\(\)\.includes\(q\)/, "automations honor the text filter");
+assert.match(auto, /No matches for/, "automations show a no-matches message");
+// The filter is scoped to the active tab — switching tabs clears it.
+assert.match(auto, /setActiveTab\(tab\);\s*setQuery\(""\)/, "switching tabs clears the filter");
+
+console.log("vault-automations-filter.test.ts OK");

--- a/src/components/vault-panel.tsx
+++ b/src/components/vault-panel.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { SearchInput } from "@/components/ui/search-input";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
@@ -144,6 +145,7 @@ export function VaultPanel() {
   const [mappings, setMappings]     = useState<Mapping[]>([]);
   const [loading, setLoading]       = useState(true);
   const [error, setError]           = useState<string | null>(null);
+  const [query, setQuery]           = useState("");
   const [adding, setAdding]         = useState(false);
   const [editing, setEditing]       = useState<Mapping | null>(null);
   const [copiedKey, setCopiedKey]   = useState<string | null>(null);
@@ -192,6 +194,18 @@ export function VaultPanel() {
       }
     });
   }
+
+  // Hide the row pending an undoable delete, then apply the text filter
+  // (key / 1Password reference / description, case-insensitive).
+  const visibleMappings = useMemo(() => {
+    const afterPending = deletePending
+      ? mappings.filter((m) => m.key !== deletePending.item.key)
+      : mappings;
+    const q = query.trim().toLowerCase();
+    if (!q) return afterPending;
+    return afterPending.filter((m) =>
+      [m.key, m.ref ?? "", m.description ?? ""].join(" ").toLowerCase().includes(q));
+  }, [mappings, deletePending, query]);
 
   return (
     <div className="vault-panel">
@@ -265,8 +279,22 @@ export function VaultPanel() {
           }
         />
       ) : (
+        <>
+          {mappings.length > 3 ? (
+            <SearchInput
+              value={query}
+              onValueChange={setQuery}
+              onClear={() => setQuery("")}
+              placeholder="Filter secrets…"
+              aria-label="Filter secrets"
+              containerClassName="vault-filter"
+            />
+          ) : null}
+          {visibleMappings.length === 0 ? (
+            <div className="vault-footer-note">No secrets match “{query.trim()}”.</div>
+          ) : (
         <div className="vault-list">
-          {(deletePending ? mappings.filter((m) => m.key !== deletePending.item.key) : mappings).map((m) => (
+          {visibleMappings.map((m) => (
             <div key={m.key} className={`vault-row${m.status === "error" || m.status === "unresolved" ? " vault-row--warn" : ""}`}>
               <div className="vault-row-main">
                 <code className="vault-row-key">{m.key}</code>
@@ -314,6 +342,8 @@ export function VaultPanel() {
             </div>
           ))}
         </div>
+          )}
+        </>
       )}
 
       {/* Footer note */}


### PR DESCRIPTION
Most list surfaces have a search/filter (board, library, familiars, projects), but **vault** (secrets) and **automations** (reminders + automations + inbox — often dozens of rows) had none. Both now use the shared `ui/SearchInput`.

## Vault
Filters secret mappings by **key / 1Password reference / description**. Appears once there are >3 mappings; composes with the undo-pending hide; shows "No secrets match …" when a query has no hits.

## Automations (Schedules)
One filter under the tabs, **scoped to the active tab** (reminders by title, automations by name, inbox by title) and cleared on tab switch. The box is gated on the **unfiltered** row presence so filtering to zero never hides it (you can always clear), and a "No matches for …" empty state shows on a no-hit query.

## Verified
- **Runtime (production build):** typing "maintainer" on the Reminders tab keeps the matching rows, hides the rest, shows the no-match state for a bad query, and restores on clear — screenshot-confirmed. Vault reuses the identical `SearchInput` + filter pattern (settings-gated surface, verified at source/test level).
- New `vault-automations-filter.test.ts`; `schedules-tabs` source assertions relaxed for the added query clause.
- `pnpm typecheck` clean; `app` suite (397 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)