### PR TITLE
fix(project-api): allow human browse of familiar workspaces with id attached

### DIFF
--- a/src/app/api/project-local-human-read.test.ts
+++ b/src/app/api/project-local-human-read.test.ts
@@ -41,6 +41,8 @@ assert.match(helper, /throw new ProjectAccessDeniedError\("missing familiarId fo
 
 // A familiar's own workspace isn't a *registered* project, but the human may
 // still browse any path the traversal guard allows (resolveAllowedProjectPath).
+// The Code tab attaches the owning familiar's id as context, so the exemption
+// must NOT require its absence — isHumanRead is the gate (read surfaces only).
 assert.match(
   helper,
   /import \{ resolveAllowedProjectPath \} from "@\/lib\/server\/project-paths"/,
@@ -48,8 +50,8 @@ assert.match(
 );
 assert.match(
   helper,
-  /if \(!familiarId && isHumanRead\(args\.request, surface\) && resolveAllowedProjectPath\(requestedPath\)\) \{\s*return;/,
-  "human reads of an unregistered-but-allowed path (e.g. a familiar workspace) are permitted",
+  /if \(isHumanRead\(args\.request, surface\) && resolveAllowedProjectPath\(requestedPath\)\) \{\s*return;/,
+  "human reads of an unregistered-but-allowed path (e.g. a familiar workspace) are permitted, even with a familiar id attached",
 );
 
 // Every read route forwards the request so the loopback check can run.

--- a/src/lib/server/project-permission-requests.ts
+++ b/src/lib/server/project-permission-requests.ts
@@ -79,10 +79,13 @@ export async function assertProjectApiAccess(args: {
     // Not a *registered* project — but the path may still be a legitimate read
     // target the traversal guard already permits: a familiar's own workspace
     // (~/.coven/workspaces/familiars/<id>), an openclaw research dir, or the cwd.
-    // Let the human browse those (the Code tab surfaces familiar workspaces);
-    // familiars still need a real registered-project grant, and writes still need
-    // a familiar.
-    if (!familiarId && isHumanRead(args.request, surface) && resolveAllowedProjectPath(requestedPath)) {
+    // Let the human browse those (the Code tab surfaces familiar workspaces and
+    // attaches the owning familiar's id as context, so we must NOT require its
+    // absence here). isHumanRead is the real gate — only read surfaces
+    // (file-browse/file-read/project-api on loopback, or a mobile GET) qualify;
+    // writes use file-write, which isn't a human-read surface, so they still
+    // fall through to the familiar requirement below.
+    if (isHumanRead(args.request, surface) && resolveAllowedProjectPath(requestedPath)) {
       return;
     }
     throw new ProjectAccessDeniedError("project is not registered for permission checks");


### PR DESCRIPTION
## Symptom

Browsing a familiar's own workspace in the Code tab 403s:

```
GET /api/project-tree?root=/Users/buns/.coven/workspaces/familiars/nova&depth=1&familiarId=nova  → 403
GET /api/project-file?...&familiarId=nova  → 403
```

## Root cause

`~/.coven/workspaces/familiars/<id>` isn't a *registered* project, so it relies on the human-read exemption in `assertProjectApiAccess`. That exemption required the familiar id to be **absent**:

```ts
if (!familiarId && isHumanRead(args.request, surface) && resolveAllowedProjectPath(requestedPath)) return;
```

But the Code tab attaches the owning familiar's id (`familiarId=nova`) as context, so `!familiarId` is false → it falls through to `throw ProjectAccessDeniedError("project is not registered…")` → 403. This regressed the documented intent of #1698 ("let the human browse familiar workspaces").

## Fix (safest, scoped)

Drop the `!familiarId` requirement on **that unregistered-path read branch only**:

```ts
if (isHumanRead(args.request, surface) && resolveAllowedProjectPath(requestedPath)) return;
```

`isHumanRead` is the real gate — it's true only for read surfaces (`file-browse`/`file-read`/`project-api` on a loopback origin, or a mobile GET). Why this is safe:

- **Writes stay gated.** `file-write` is not in `LOCAL_HUMAN_READ_SURFACES`, so `isHumanRead` is false for writes → they still require a real familiar grant.
- **Registered projects unchanged.** The grant check for registered projects (the `if (!familiarId)` / `assertProjectAccess` branches below) is untouched.
- **Traversal still bounded.** `resolveAllowedProjectPath` still limits reads to sanctioned roots (familiar workspaces, cwd, openclaw dirs).
- **Callers are human-UI only.** `/api/project-tree`, `/api/project-file` (GET), `/api/project/files`, `/api/project/search` are all called from the Code-tab UI; the attached familiar id is workspace context, not an agent assertion.

The source-text test `project-local-human-read.test.ts` that pinned the old `!familiarId` condition is updated in the same commit.

## Verification

- `project-local-human-read.test.ts` and `project-permission-routes.test.ts` pass.
- `tsc --noEmit` clean for the changed lib file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)