### PR TITLE
fix(canvas): guard async setState after the Canvas tab unmounts

### DIFF
--- a/src/components/journal/canvas-list.tsx
+++ b/src/components/journal/canvas-list.tsx
@@ -70,6 +70,13 @@ export function CanvasList({
   const [copied, setCopied] = useState(false);
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => () => { if (copiedTimer.current) clearTimeout(copiedTimer.current); }, []);
+  // Guards async setState after the tab unmounts — generation is a slow LLM
+  // call, so leaving Canvas mid-generate would otherwise setState on a dead tree.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
 
   // Seed the generate composer from an example prompt and focus it, so the
   // empty-state starters are one tap from a ready-to-run sketch.
@@ -91,11 +98,12 @@ export function CanvasList({
     try {
       const res = await fetch("/api/canvas", { cache: "no-store" });
       const json = await res.json().catch(() => ({}));
+      if (!mountedRef.current) return;
       const list: CanvasArtifact[] = Array.isArray(json.artifacts) ? json.artifacts : [];
       setArtifacts(list);
       setSelectedId((prev) => prev ?? list[list.length - 1]?.id ?? null);
     } catch {
-      setArtifacts([]);
+      if (mountedRef.current) setArtifacts([]);
     }
   }, []);
 
@@ -124,6 +132,7 @@ export function CanvasList({
         ? buildRefinePrompt(refineOf.code, ask, refineOf.kind ?? "html")
         : buildSketchPrompt(ask);
       const result = await generateArtifactCode({ prompt: sendPrompt, familiarId });
+      if (!mountedRef.current) return;
       setGenerating((prev) => {
         const next = new Set(prev);
         next.delete(id);

--- a/src/components/journal/journal-view.test.ts
+++ b/src/components/journal/journal-view.test.ts
@@ -109,4 +109,12 @@ assert.match(entries, /aria-label="Older entry"/, "detail header has an older-en
 assert.match(entries, /const hasOlder = dayIndex >= 0 && dayIndex < filteredDays\.length - 1/, "older-entry availability derives from the visible list");
 assert.match(css, /\.journal-entry__sec--nav \{[\s\S]*?justify-content: space-between/, "the heading row lays out the nav controls");
 
+// ── Canvas tab: async setState guarded against unmount ──────────────────────
+// Generation is a slow LLM call; leaving Canvas mid-generate must not setState
+// on a dead tree. load() and runGeneration() bail on a cleared mountedRef.
+assert.match(list, /const mountedRef = useRef\(true\)/, "canvas tracks mounted state");
+assert.match(list, /return \(\) => \{ mountedRef\.current = false; \}/, "canvas clears mountedRef on unmount");
+assert.match(list, /await generateArtifactCode\([\s\S]{0,80}?if \(!mountedRef\.current\) return;/, "runGeneration bails after the LLM call if unmounted");
+assert.match(list, /const json = await res\.json\(\)[\s\S]{0,80}?if \(!mountedRef\.current\) return;/, "load bails after the fetch if unmounted");
+
 console.log("journal-view.test.ts: ok");


### PR DESCRIPTION
## Canvas audit + fix

Audit pass over the Canvas surface (the Journal **Canvas** tab, `canvas-list.tsx`). It's already well-built:
- the preview `<iframe>` is **properly sandboxed** (`allow-scripts`, **no** `allow-same-origin` — generated code can't reach the parent origin),
- **a11y is solid** (`role="tablist"/tab"` + `aria-selected` preview/code toggle, `aria-pressed` fullscreen, `<button>` rail rows, labelled rename, `role="alert"` errors),
- the "copied" timer is cleaned up on unmount.

The one gap was async `setState` without an unmount guard:
- **`runGeneration()` setState's after `generateArtifactCode()` — a slow LLM call** — so leaving the Canvas tab mid-generate would `setState` on an unmounted tree. It now bails on a cleared `mountedRef`.
- **`load()`** likewise bails after its fetch if the tab unmounted.

No stale-overwrite race exists (generation updates only its own artifact by id), so this is purely the setState-after-unmount class.

## Testing
- `tsc --noEmit` clean · `pnpm build` clean · full `app` suite: 397 files pass.
- Smoke-checked the running Canvas tab: composer + preview render, **no console errors** (no regression).
- Extended `journal-view.test.ts` with the `mountedRef` + guarded-`load`/`runGeneration` assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)