### PR TITLE
feat(code): add Retry to the file-preview error state

### DIFF
--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -1959,6 +1959,15 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                               {previewPath ? (
                                 <p className="font-mono text-[10px] text-[var(--text-muted)]">{previewPath.split("/").pop()}</p>
                               ) : null}
+                              {previewPath ? (
+                                <Button
+                                  size="xs"
+                                  leadingIcon="ph:arrow-clockwise"
+                                  onClick={() => void openFilePreview(previewPath, previewLine)}
+                                >
+                                  Retry
+                                </Button>
+                              ) : null}
                             </div>
                           ) : preview?.kind === "image" ? (
                             <div className="flex h-full min-h-[240px] flex-col items-center justify-center gap-3 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] p-4">


### PR DESCRIPTION
## What

When a file preview fails to load in the Code view (a transient error, or a 403 like the familiar-workspace case), the error state rendered a warning icon + message + filename — but **no Retry**. The user had to reselect the file to try again.

This adds a `Retry` button (shared `<Button size="xs">`) that re-invokes `openFilePreview(previewPath, previewLine)`, matching the project-tree error state (which already offers Retry) and the app-wide `ErrorState` + Retry convention. Only rendered when a `previewPath` is known.

## Verification

- Code/comux suites pass: `code-view`, `code-editor`, `comux-view-changes`, `comux-view-search-options`, `comux-view-terminal`, `comux-pane-nav-wiring`. No test pinned the error-preview markup.
- `tsc --noEmit` clean for the file. 9-line diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)