### PR TITLE
feat(undo): ⌘Z undoes the last delete (all undo surfaces)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -316,6 +316,7 @@ export const SUITES = {
     "src/lib/url-safety.test.ts",
     "src/lib/use-focus-trap.test.ts",
     "src/lib/use-prefers-reduced-motion.test.ts",
+    "src/lib/use-undo-delete-keyboard.test.ts",
     "src/lib/use-roving-tabindex.test.ts",
     "src/lib/vault.test.ts",
     "src/app/globals-background.test.ts",

--- a/src/components/ui/undo-toast.tsx
+++ b/src/components/ui/undo-toast.tsx
@@ -62,6 +62,8 @@ export function UndoToast({
         <span className="library-undo-toast-label">{message}</span>
         <button className="library-undo-toast-undo" onClick={onUndo} aria-label={undoAriaLabel}>
           Undo
+          {/* The same action is bound to ⌘Z while the toast is up (useUndoDelete). */}
+          <kbd className="library-undo-toast-kbd" aria-hidden>⌘Z</kbd>
         </button>
         <button className="library-undo-toast-dismiss" onClick={onDismiss} aria-label="Dismiss">
           <Icon name="ph:x-bold" aria-hidden />

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -103,6 +103,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
     entries: [
       { keys: "⌘,", description: "Open Settings" },
       { keys: "⌘S", description: "Save (daily notes, journal)" },
+      { keys: "⌘Z", description: "Undo the last delete (while the undo toast is showing)" },
       { keys: "⌘↵", description: "Run the refine (artifact viewer)" },
       { keys: "⌘/", description: "Open this shortcuts sheet" },
       { keys: "?", description: "Open the shortcuts sheet (when not typing in a field)" },

--- a/src/lib/use-undo-delete-keyboard.test.ts
+++ b/src/lib/use-undo-delete-keyboard.test.ts
@@ -1,0 +1,27 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const hook = readFileSync(new URL("./use-undo-delete.ts", import.meta.url), "utf8");
+const toast = readFileSync(new URL("../components/ui/undo-toast.tsx", import.meta.url), "utf8");
+const shortcuts = readFileSync(new URL("./keyboard-shortcuts.ts", import.meta.url), "utf8");
+
+// The hook binds ⌘Z / Ctrl+Z to undo while a delete is pending.
+assert.match(hook, /window\.addEventListener\("keydown"/, "useUndoDelete listens for keydown while pending");
+assert.match(hook, /e\.metaKey \|\| e\.ctrlKey/, "undo triggers on ⌘ or Ctrl");
+assert.match(hook, /e\.key !== "z" && e\.key !== "Z"/, "undo binds to the Z key");
+// ⌘⇧Z (redo) and Alt-modified combos are explicitly left alone.
+assert.match(hook, /e\.shiftKey \|\| e\.altKey/, "⌘⇧Z / Alt combos are not hijacked");
+// Native text undo in editable fields is respected.
+assert.match(hook, /INPUT\|TEXTAREA\|SELECT/, "defers to native undo in editable fields");
+assert.match(hook, /isContentEditable/, "defers to native undo in contenteditable");
+// The effect is scoped to a pending entry (handler attaches/detaches with it).
+assert.match(hook, /useEffect\(\(\) => \{\s*if \(!pending\) return;/, "the keydown handler is active only while a delete is pending");
+
+// The toast advertises ⌘Z.
+assert.match(toast, /library-undo-toast-kbd[\s\S]{0,40}⌘Z/, "the undo toast shows a ⌘Z hint");
+
+// The shortcuts sheet documents it.
+assert.match(shortcuts, /keys: "⌘Z", description: "Undo the last delete/, "⌘Z is in the shortcuts catalog");
+
+console.log("use-undo-delete-keyboard.test.ts OK");

--- a/src/lib/use-undo-delete.ts
+++ b/src/lib/use-undo-delete.ts
@@ -58,6 +58,24 @@ export function useUndoDelete<T>() {
     setPending(null);
   }, []);
 
+  // While a delete is pending, ⌘Z / Ctrl+Z undoes it — the keyboard affordance
+  // users reach for. ⌘⇧Z (redo) is left alone, and we defer to native text undo
+  // when focus is in an editable field. One handler per active toast; only one
+  // surface shows a toast at a time, so there's no cross-surface ambiguity.
+  useEffect(() => {
+    if (!pending) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
+      if (e.key !== "z" && e.key !== "Z") return;
+      const t = e.target as HTMLElement | null;
+      if (t && (t.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName))) return;
+      e.preventDefault();
+      undo();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [pending, undo]);
+
   const commit = useCallback(() => {
     if (!pendingRef.current) return;
     clearTimeout(pendingRef.current.timeoutId);

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -3443,6 +3443,9 @@ h3:hover .library-heading-anchor,
 }
 .library-undo-toast-undo {
   flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   font-size: 11px;
   font-weight: 600;
   color: var(--accent-presence);
@@ -3452,6 +3455,16 @@ h3:hover .library-heading-anchor,
   padding: 2px 6px;
   border-radius: 4px;
   transition: background 0.1s;
+}
+.library-undo-toast-kbd {
+  font: inherit;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--text-muted);
+  background: color-mix(in oklch, var(--text-muted) 14%, transparent);
+  border-radius: 3px;
+  padding: 2px 4px;
 }
 .library-undo-toast-undo:hover {
   background: color-mix(in oklch, var(--accent-presence) 15%, transparent);


### PR DESCRIPTION
Undo is the standard across 7 surfaces (board, chat, projects, library, vault, automations, journal) but the `UndoToast` was click-only. `⌘Z` is the affordance users reach for.

## Fix
- `useUndoDelete` attaches a `window` keydown handler **while a delete is pending**: `⌘Z` / `Ctrl+Z` undoes it. `⌘⇧Z` (redo) and Alt-combos are left alone, and it **defers to native text undo** when focus is in an input/textarea/contenteditable. One handler per active toast (only one surface shows a toast at a time) — so a single change in the hook lights up all 7 surfaces.
- `UndoToast` shows a `⌘Z` hint inside the Undo button.
- Added `⌘Z` to the `⌘/` shortcuts catalog.

## Verified (production build)
- Bulk-deleting a board task shows "Deleted 1 task · Undo ⌘Z".
- `⌘Z` restores it (**128 → 127 → 128**) and dismisses the toast — screenshot-confirmed.
- `⌘Z` while focused in a text field does **not** hijack native text undo (toast stays).

## Tests
- New `use-undo-delete-keyboard.test.ts` (keydown wiring, redo/alt guards, editable-field guard, toast hint, catalog entry).
- `pnpm typecheck` clean; `app` suite (398 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)