### PR TITLE
feat(settings): per-familiar project Permissions tab; hide Submissions

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -76,6 +76,7 @@ export const SUITES = {
     "src/components/pwa-register.test.ts",
     "src/lib/readable-text-color.test.ts",
     "src/components/settings-appearance.test.ts",
+    "src/components/settings-permissions.test.ts",
     "src/components/theme-color-editor.test.ts",
     "src/lib/theme-token-hex.test.ts",
     "src/components/roles-tools-navigation.test.ts",

--- a/src/app/api/project-grants/route.ts
+++ b/src/app/api/project-grants/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import {
   grantProjectToFamiliar,
   listProjectGrants,
+  loadHumanPermissionConfig,
   revokeProjectFromFamiliar,
 } from "@/lib/project-permissions";
 
@@ -40,7 +41,13 @@ function grantInput(payload: Record<string, unknown>) {
 }
 
 export async function GET() {
-  return NextResponse.json({ ok: true, grants: await listProjectGrants() });
+  const [grants, config] = await Promise.all([
+    listProjectGrants(),
+    loadHumanPermissionConfig(),
+  ]);
+  // `supremeFamiliarId` has access to every project regardless of grants — the
+  // Permissions UI marks it as all-access and locks its toggles on.
+  return NextResponse.json({ ok: true, grants, supremeFamiliarId: config.supremeFamiliarId });
 }
 
 export async function POST(req: Request) {

--- a/src/components/opencoven-submissions-navigation.test.ts
+++ b/src/components/opencoven-submissions-navigation.test.ts
@@ -7,11 +7,13 @@ const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), 
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const page = readFileSync(new URL("./opencoven-submission-page.tsx", import.meta.url), "utf8");
 
-assert.match(workspaceMode, /\|\s*"submissions"/, "OpenCoven submissions should be a first-class workspace mode");
-assert.match(
+// The mode + page remain (reachable programmatically), but Submissions is hidden
+// from the sidebar nav — it should no longer be listed as a Tools surface.
+assert.match(workspaceMode, /\|\s*"submissions"/, "OpenCoven submissions should remain a workspace mode");
+assert.doesNotMatch(
   sidebar,
-  /\{ id: "submissions", label: "Submissions", iconName: "ph:package-bold", group: "tools"/,
-  "Sidebar should expose the OpenCoven submission page as its own Tools surface",
+  /\{ id: "submissions",/,
+  "Sidebar should NOT expose Submissions as a nav item (it's hidden)",
 );
 assert.match(workspace, /submissions:\s*"Submissions"/, "Workspace h1 title map should cover submissions mode");
 assert.match(workspace, /mode === "submissions" \?\s*\(\s*<OpenCovenSubmissionPage/, "Workspace should render the OpenCoven submission page directly");

--- a/src/components/settings-permissions.test.ts
+++ b/src/components/settings-permissions.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
+const perms = readFileSync(new URL("./settings-permissions.tsx", import.meta.url), "utf8");
+const route = readFileSync(new URL("../app/api/project-grants/route.ts", import.meta.url), "utf8");
+
+// ── Settings wires a Permissions section ─────────────────────────────────────
+assert.match(shell, /"permissions"/, "Section type includes permissions");
+assert.match(
+  shell,
+  /\{ id: "permissions", label: "Permissions",/,
+  "Settings nav lists a Permissions section",
+);
+assert.match(
+  shell,
+  /section === "permissions" && <PermissionsSection \/>/,
+  "Settings renders the PermissionsSection",
+);
+
+// ── PermissionsSection: per-familiar project visibility, editable ────────────
+assert.match(perms, /fetch\("\/api\/familiars"/, "loads familiars");
+assert.match(perms, /fetch\("\/api\/projects"/, "loads projects");
+assert.match(perms, /fetch\("\/api\/project-grants"/, "loads grants + supreme familiar");
+// Toggling a project for a familiar grants (POST) or revokes (DELETE) — sending
+// ONLY targetFamiliarId + projectId (the grant route rejects relayed approvals).
+assert.match(
+  perms,
+  /method: next \? "POST" : "DELETE"/,
+  "toggling on grants, off revokes",
+);
+assert.match(
+  perms,
+  /body: JSON\.stringify\(\{ targetFamiliarId: familiarId, projectId \}\)/,
+  "grant changes send only target familiar + project (human-confirmed)",
+);
+assert.match(perms, /role="switch"/, "each project row is a switch");
+// The supreme familiar is all-access and not toggle-able.
+assert.match(perms, /fam\.id === supremeFamiliarId/, "marks the supreme (all-access) familiar");
+assert.match(perms, /has access to every project/i, "explains the all-access familiar");
+
+// ── API exposes the supreme familiar so the UI can lock it on ────────────────
+assert.match(
+  route,
+  /supremeFamiliarId: config\.supremeFamiliarId/,
+  "the grants GET returns the supreme familiar id",
+);
+
+console.log("settings-permissions.test.ts: ok");

--- a/src/components/settings-permissions.tsx
+++ b/src/components/settings-permissions.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { Icon } from "@/lib/icon";
+import { SettingsGroup } from "@/components/ui/settings-group";
+
+type Familiar = { id: string; displayName?: string; name?: string };
+type Project = { id: string; name: string; root: string; color?: string };
+type Grant = { familiarId: string; projectId: string };
+
+const grantKey = (familiarId: string, projectId: string) => `${familiarId}::${projectId}`;
+
+/**
+ * Settings → Permissions. Per familiar, shows every project and a toggle for
+ * whether that familiar can see/use it. Toggling drives the human-confirmed
+ * `/api/project-grants` grant (POST) / revoke (DELETE). The supreme familiar has
+ * access to every project; its toggles are locked on.
+ */
+export function PermissionsSection() {
+  const [familiars, setFamiliars] = useState<Familiar[]>([]);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [granted, setGranted] = useState<Set<string>>(new Set());
+  const [supremeFamiliarId, setSupremeFamiliarId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  // Keys mid-flight, so a row can't be double-toggled while its request runs.
+  const [pending, setPending] = useState<Set<string>>(new Set());
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [famRes, projRes, grantRes] = await Promise.all([
+        fetch("/api/familiars", { cache: "no-store" }).then((r) => r.json()),
+        fetch("/api/projects", { cache: "no-store" }).then((r) => r.json()),
+        fetch("/api/project-grants", { cache: "no-store" }).then((r) => r.json()),
+      ]);
+      setFamiliars(Array.isArray(famRes?.familiars) ? famRes.familiars : []);
+      setProjects(Array.isArray(projRes?.projects) ? projRes.projects : []);
+      setGranted(
+        new Set(
+          (Array.isArray(grantRes?.grants) ? (grantRes.grants as Grant[]) : []).map((g) =>
+            grantKey(g.familiarId, g.projectId),
+          ),
+        ),
+      );
+      setSupremeFamiliarId(typeof grantRes?.supremeFamiliarId === "string" ? grantRes.supremeFamiliarId : null);
+      setError(null);
+    } catch {
+      setError("Couldn’t load permissions. Is the desktop reachable?");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const toggle = useCallback(
+    async (familiarId: string, projectId: string, next: boolean) => {
+      const key = grantKey(familiarId, projectId);
+      setPending((p) => new Set(p).add(key));
+      // Optimistic.
+      setGranted((g) => {
+        const copy = new Set(g);
+        if (next) copy.add(key);
+        else copy.delete(key);
+        return copy;
+      });
+      try {
+        const res = await fetch("/api/project-grants", {
+          method: next ? "POST" : "DELETE",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ targetFamiliarId: familiarId, projectId }),
+        });
+        if (!res.ok) throw new Error(String(res.status));
+        setError(null);
+      } catch {
+        // Revert on failure.
+        setGranted((g) => {
+          const copy = new Set(g);
+          if (next) copy.delete(key);
+          else copy.add(key);
+          return copy;
+        });
+        setError("Couldn’t update that grant.");
+      } finally {
+        setPending((p) => {
+          const copy = new Set(p);
+          copy.delete(key);
+          return copy;
+        });
+      }
+    },
+    [],
+  );
+
+  const familiarName = (f: Familiar) => f.displayName?.trim() || f.name?.trim() || f.id;
+  const sortedFamiliars = useMemo(
+    () => [...familiars].sort((a, b) => familiarName(a).localeCompare(familiarName(b))),
+    [familiars],
+  );
+
+  if (loading) {
+    return (
+      <div aria-hidden className="animate-pulse space-y-3 px-1 py-2">
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="h-16 rounded-lg bg-[var(--bg-hover)]" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <p className="px-1 text-[12px] text-[var(--text-muted)]">
+        Choose which projects each familiar can see and work in. A familiar only has visibility into
+        the projects granted here (chats, sessions, file access, and the project picker all respect
+        it). Changes apply immediately.
+      </p>
+
+      {error && (
+        <p role="alert" className="px-1 text-[12px] text-[var(--color-danger)]">
+          {error}
+        </p>
+      )}
+
+      {sortedFamiliars.length === 0 ? (
+        <SettingsGroup label="Familiars">
+          <p className="px-4 py-3 text-[13px] text-[var(--text-muted)]">No familiars yet.</p>
+        </SettingsGroup>
+      ) : (
+        sortedFamiliars.map((fam) => {
+          const isSupreme = supremeFamiliarId != null && fam.id === supremeFamiliarId;
+          return (
+            <SettingsGroup
+              key={fam.id}
+              label={familiarName(fam)}
+              description={isSupreme ? "Access to all projects" : undefined}
+            >
+              {isSupreme ? (
+                <p className="flex items-center gap-2 px-4 py-3 text-[12px] text-[var(--text-muted)]">
+                  <Icon name="ph:seal-check" width={15} className="shrink-0 text-[var(--accent-presence)]" />
+                  This familiar has access to every project.
+                </p>
+              ) : projects.length === 0 ? (
+                <p className="px-4 py-3 text-[13px] text-[var(--text-muted)]">
+                  No projects yet — add one in the Code workspace.
+                </p>
+              ) : (
+                projects.map((project) => {
+                  const key = grantKey(fam.id, project.id);
+                  const on = granted.has(key);
+                  const busy = pending.has(key);
+                  return (
+                    <div key={project.id} className="flex items-center justify-between gap-4 px-4 py-3">
+                      <div className="flex min-w-0 items-center gap-3">
+                        <span
+                          aria-hidden
+                          className="size-2.5 shrink-0 rounded-full"
+                          style={{ background: project.color || "var(--text-muted)" }}
+                        />
+                        <div className="min-w-0">
+                          <p className="truncate text-[13px] text-[var(--text-primary)]">{project.name}</p>
+                          <p className="truncate text-[11px] text-[var(--text-muted)]" title={project.root}>
+                            {project.root}
+                          </p>
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={on}
+                        aria-label={`${on ? "Revoke" : "Grant"} ${project.name} for ${familiarName(fam)}`}
+                        disabled={busy}
+                        onClick={() => void toggle(fam.id, project.id, !on)}
+                        className={`focus-ring relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors duration-150 ${
+                          on ? "bg-[var(--accent-presence)]" : "bg-[var(--bg-elevated)]"
+                        } ${busy ? "opacity-60" : ""}`}
+                      >
+                        <span
+                          className={`pointer-events-none mt-0.5 inline-block h-4 w-4 rounded-full bg-white shadow transition-transform duration-150 ${
+                            on ? "translate-x-4" : "translate-x-0.5"
+                          }`}
+                        />
+                      </button>
+                    </div>
+                  );
+                })
+              )}
+            </SettingsGroup>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { Icon } from "@/lib/icon";
 import { SettingsGroup } from "@/components/ui/settings-group";
+import { PermissionsSection } from "@/components/settings-permissions";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { FamiliarStudioInlinePanel } from "@/components/familiar-studio-inline";
@@ -60,12 +61,13 @@ type DaemonStatus = {
   daemon?: { pid: number; startedAt: string; socket: string };
 };
 
-type Section = "general" | "daemon" | "familiars" | "addons" | "mobile" | "appearance" | "about";
+type Section = "general" | "daemon" | "familiars" | "permissions" | "addons" | "mobile" | "appearance" | "about";
 
 const SECTIONS: { id: Section; label: string; icon: string }[] = [
   { id: "general",    label: "General",    icon: "ph:sliders-horizontal" },
   { id: "daemon",     label: "Daemon",     icon: "ph:terminal-window" },
   { id: "familiars",  label: "Familiars",  icon: "ph:users-three" },
+  { id: "permissions", label: "Permissions", icon: "ph:key" },
   { id: "addons",     label: "Add-ons",    icon: "ph:puzzle-piece" },
   { id: "mobile",     label: "Phone",      icon: "ph:device-mobile" },
   { id: "appearance", label: "Appearance", icon: "ph:paint-brush" },
@@ -216,6 +218,7 @@ export function SettingsShell() {
           {section === "general" && <GeneralSection />}
           {section === "daemon"   && <DaemonSection />}
           {section === "familiars" && <FamiliarsSection />}
+          {section === "permissions" && <PermissionsSection />}
           {section === "addons"   && <AddonsSection />}
           {section === "mobile"   && <MobileSection />}
           {section === "appearance" && <AppearanceSection />}

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -105,7 +105,8 @@ const FOLDER_MODES: Array<{
   { id: "docs", label: "Coven", iconName: "ph:book-bookmark", group: "tools", description: "OpenCoven docs, feedback, and social tabs" },
   { id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools", description: "Agent personas, workflows, skills, and the capabilities your familiars can use" },
   { id: "workflows", label: "Workflows", iconName: "ph:git-branch-bold", group: "tools", description: "Multi-step pipelines that orchestrate familiars" },
-  { id: "submissions", label: "Submissions", iconName: "ph:package-bold", group: "tools", description: "Submit OpenCoven runtimes and harnesses" },
+  // Submissions (OpenCoven runtime/harness submit) is hidden from the nav; the
+  // mode + page remain reachable programmatically but aren't surfaced here.
   { id: "calls", label: "Calls", iconName: "ph:graph", group: "tools", kbd: "⌘⇧C", description: "Live familiar activity and delegation traces", badge: (p) => badgeText(p.callsActiveCount) },
   // Add-ons (gated)
   { id: "github", label: "GitHub", iconName: "ph:github-logo", group: "addons", description: "Issues and PRs assigned to you", badge: (p) => badgeText(p.githubAssignedCount) },


### PR DESCRIPTION
## What

1. **Hide the OpenCoven "Submissions" page** from the sidebar nav. The workspace mode + page remain (reachable programmatically) but are no longer surfaced as a Tools surface.

2. **New Settings → Permissions tab** — per familiar, lists every project with a toggle for whether that familiar can see/use it. The single place to see and "unlock" a familiar's visibility into projects.

## How

- **Submissions:** removed the `{ id: "submissions", … }` nav item from `sidebar-minimal.tsx`.
- **Permissions:** new `PermissionsSection` (wired into `settings-shell.tsx` as a `permissions` section, key icon). It loads `/api/familiars`, `/api/projects`, and `/api/project-grants`, then renders per-familiar project toggles. Toggling drives the **existing human-confirmed grant API** — `POST /api/project-grants` to grant, `DELETE` to revoke — sending only `targetFamiliarId` + `projectId` (the route rejects relayed approvals, so a human in Settings is exactly the right place to confirm). Optimistic update with revert-on-error.
- Grants already gate chats, sessions, file access, and the project picker (`filterProjectsForFamiliar`), so this is the one place to manage what each familiar can reach.
- The grants `GET` now also returns **`supremeFamiliarId`**; that familiar has access to every project, so the UI shows an "access to every project" note instead of toggles for it.

## Verification

Driven against the running app:
- **Submissions** no longer appears in the sidebar nav.
- **Permissions** section lists familiars × projects (84 toggles in demo); toggling a switch **on grants** (37→38, `aria-checked=true`) and **off revokes** (38→37), confirmed against `GET /api/project-grants`.
- `next build` clean (types + lint). New `settings-permissions.test.ts` locks the wiring (CI-wired; `check:tests-wired` green — 548); the submissions-nav test was flipped to assert Submissions is hidden; `api-contracts` / `settings-shell-polish` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)