### PR TITLE
fix(docs): don't iframe un-embeddable tabs + complete tablist a11y

### DIFF
--- a/src/components/docs-pane.test.ts
+++ b/src/components/docs-pane.test.ts
@@ -62,4 +62,21 @@ assert.match(
   "CovenPane keeps an open-in-new-tab link to the active tab",
 );
 
+// Non-embeddable hosts (github.com, x.com refuse framing) don't get a dead
+// iframe — only the embeddable Docs tab is framed; the rest open in a new tab.
+assert.match(source, /label: "Docs"[\s\S]{0,120}?embeddable: true/, "Docs is embeddable");
+assert.match(source, /label: "Feedback"[\s\S]{0,120}?embeddable: false/, "Feedback (github) is not embeddable");
+assert.match(source, /label: "X"[\s\S]{0,120}?embeddable: false/, "X is not embeddable");
+assert.match(source, /\{activeTab\.embeddable \? \([\s\S]*?<iframe/, "the iframe only renders for an embeddable tab");
+assert.match(source, /opens in a new tab/, "non-embeddable tabs show an open-in-new-tab panel");
+assert.match(source, /Open \{activeTab\.label\}/, "the panel has a prominent Open action");
+
+// The tab bar is a complete tablist: roving tabIndex, aria-controls → a labelled
+// tabpanel, and Left/Right arrow navigation.
+assert.match(source, /id=\{`coven-tab-\$\{tab\.id\}`\}/, "each tab has a stable id");
+assert.match(source, /aria-controls="coven-tabpanel"/, "tabs point at the panel");
+assert.match(source, /tabIndex=\{tab\.id === activeTabId \? 0 : -1\}/, "tablist uses a roving tab stop");
+assert.match(source, /role="tabpanel"\s*\n\s*id="coven-tabpanel"\s*\n\s*aria-labelledby=\{`coven-tab-\$\{activeTabId\}`\}/, "the content area is a labelled tabpanel");
+assert.match(source, /function onTablistKeyDown[\s\S]{0,200}?ArrowRight/, "Left/Right arrows navigate the tablist");
+
 console.log("docs-pane.test.ts passed");

--- a/src/components/docs-pane.tsx
+++ b/src/components/docs-pane.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { Icon } from "@/lib/icon";
 
@@ -9,10 +9,13 @@ export const DOCS_URL = "https://docs.opencoven.ai";
 export const FEEDBACK_URL = "https://github.com/OpenCoven/coven-cave/issues/new/choose";
 export const X_URL = "https://x.com/OpenCvn";
 
+// `embeddable: false` for hosts that refuse framing (github.com sends
+// X-Frame-Options: deny + frame-ancestors 'none'; x.com sets frame-ancestors).
+// Iframing them just yields a blank pane, so those tabs open in a new tab.
 const COVEN_TABS = [
-  { id: "docs", label: "Docs", url: DOCS_URL, host: "docs.opencoven.ai", icon: "ph:book-bookmark" },
-  { id: "feedback", label: "Feedback", url: FEEDBACK_URL, host: "github.com/OpenCoven", icon: "ph:chat-circle-dots" },
-  { id: "x", label: "X", url: X_URL, host: "x.com/OpenCvn", icon: "ph:x-logo-bold" },
+  { id: "docs", label: "Docs", url: DOCS_URL, host: "docs.opencoven.ai", icon: "ph:book-bookmark", embeddable: true },
+  { id: "feedback", label: "Feedback", url: FEEDBACK_URL, host: "github.com/OpenCoven", icon: "ph:chat-circle-dots", embeddable: false },
+  { id: "x", label: "X", url: X_URL, host: "x.com/OpenCvn", icon: "ph:x-logo-bold", embeddable: false },
 ] as const;
 
 /**
@@ -25,11 +28,27 @@ export function CovenPane() {
   const [loaded, setLoaded] = useState(false);
   const [reloadNonce, setReloadNonce] = useState(0);
   const activeTab = COVEN_TABS.find((tab) => tab.id === activeTabId) ?? COVEN_TABS[0];
+  const tablistRef = useRef<HTMLDivElement | null>(null);
 
   function selectTab(id: (typeof COVEN_TABS)[number]["id"]) {
     if (id === activeTabId) return;
     setLoaded(false);
     setActiveTabId(id);
+  }
+
+  // APG tablist arrow-key navigation (selection follows focus).
+  function onTablistKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (!["ArrowRight", "ArrowLeft", "Home", "End"].includes(e.key)) return;
+    e.preventDefault();
+    const i = COVEN_TABS.findIndex((tab) => tab.id === activeTabId);
+    const ni =
+      e.key === "ArrowRight" ? (i + 1) % COVEN_TABS.length
+      : e.key === "ArrowLeft" ? (i - 1 + COVEN_TABS.length) % COVEN_TABS.length
+      : e.key === "Home" ? 0
+      : COVEN_TABS.length - 1;
+    const next = COVEN_TABS[ni];
+    selectTab(next.id);
+    tablistRef.current?.querySelector<HTMLButtonElement>(`#coven-tab-${next.id}`)?.focus();
   }
 
   function reloadTab() {
@@ -42,13 +61,22 @@ export function CovenPane() {
       <div className="flex min-h-[42px] items-center gap-2 border-b border-[var(--border-hairline)] bg-[var(--bg-panel)] px-3">
         <Icon name="ph:book-bookmark" width={16} height={16} aria-hidden />
         <span className="text-[13px] font-semibold text-[var(--text-primary)]">Coven</span>
-        <div className="ml-2 flex min-w-0 flex-1 items-center gap-1" role="tablist" aria-label="Coven browser tabs">
+        <div
+          ref={tablistRef}
+          className="ml-2 flex min-w-0 flex-1 items-center gap-1"
+          role="tablist"
+          aria-label="Coven browser tabs"
+          onKeyDown={onTablistKeyDown}
+        >
           {COVEN_TABS.map((tab) => (
             <button
               key={tab.id}
               type="button"
               role="tab"
+              id={`coven-tab-${tab.id}`}
               aria-selected={tab.id === activeTabId}
+              aria-controls="coven-tabpanel"
+              tabIndex={tab.id === activeTabId ? 0 : -1}
               className={[
                 "focus-ring inline-flex h-8 min-w-[88px] items-center justify-center gap-1.5 rounded-md px-3 text-[12px] font-medium transition-colors",
                 tab.id === activeTabId
@@ -67,40 +95,68 @@ export function CovenPane() {
       <div className="flex min-h-[38px] items-center gap-2 border-b border-[var(--border-hairline)] bg-[var(--bg-base)] px-3">
         <span className="inline-flex h-2 w-2 shrink-0 rounded-full bg-[var(--accent-presence)]" aria-hidden />
         <span className="truncate text-[12px] text-[var(--text-muted)]">{activeTab.host}</span>
-        <button
-          type="button"
-          className="ui-btn ui-btn--ghost ui-btn--sm focus-ring ml-auto"
-          onClick={reloadTab}
-          title={`Reload ${activeTab.label}`}
-          aria-label={`Reload ${activeTab.label}`}
-        >
-          <Icon name="ph:arrow-clockwise" width={14} height={14} aria-hidden />
-          Reload
-        </button>
+        {activeTab.embeddable ? (
+          <button
+            type="button"
+            className="ui-btn ui-btn--ghost ui-btn--sm focus-ring ml-auto"
+            onClick={reloadTab}
+            title={`Reload ${activeTab.label}`}
+            aria-label={`Reload ${activeTab.label}`}
+          >
+            <Icon name="ph:arrow-clockwise" width={14} height={14} aria-hidden />
+            Reload
+          </button>
+        ) : null}
         <a
           href={activeTab.url}
           target="_blank"
           rel="noopener noreferrer"
-          className="ui-btn ui-btn--ghost ui-btn--sm focus-ring"
+          className={`ui-btn ui-btn--ghost ui-btn--sm focus-ring${activeTab.embeddable ? "" : " ml-auto"}`}
         >
           <Icon name="ph:arrow-square-out" width={14} height={14} aria-hidden />
           Open
         </a>
       </div>
-      <div className="relative min-h-0 flex-1">
-        {!loaded ? (
-          <div className="absolute inset-0 flex items-center justify-center text-[13px] text-[var(--text-muted)]">
-            Loading Coven...
+      <div
+        role="tabpanel"
+        id="coven-tabpanel"
+        aria-labelledby={`coven-tab-${activeTabId}`}
+        className="relative min-h-0 flex-1"
+      >
+        {activeTab.embeddable ? (
+          <>
+            {!loaded ? (
+              <div className="absolute inset-0 flex items-center justify-center text-[13px] text-[var(--text-muted)]">
+                Loading Coven...
+              </div>
+            ) : null}
+            <iframe
+              key={`${activeTab.id}-${reloadNonce}`}
+              src={activeTab.url}
+              title={`Coven ${activeTab.label}`}
+              onLoad={() => setLoaded(true)}
+              className="absolute inset-0 h-full w-full border-0 bg-[var(--bg-base)]"
+              sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
+            />
+          </>
+        ) : (
+          // github.com / x.com refuse framing, so embedding would only show a
+          // blank pane — present the new-tab escape hatch as the primary action.
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center">
+            <Icon name={activeTab.icon} width={30} height={30} className="text-[var(--text-muted)]" aria-hidden />
+            <p className="text-[13px] text-[var(--text-primary)]">{activeTab.label} opens in a new tab</p>
+            <p className="text-[12px] text-[var(--text-muted)]">{activeTab.host} can&apos;t be embedded here.</p>
+            <a
+              href={activeTab.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ui-btn ui-btn--primary ui-btn--sm focus-ring"
+            >
+              <Icon name="ph:arrow-square-out" width={14} height={14} aria-hidden />
+              Open {activeTab.label}
+            </a>
           </div>
-        ) : null}
-        <iframe
-          key={`${activeTab.id}-${reloadNonce}`}
-          src={activeTab.url}
-          title={`Coven ${activeTab.label}`}
-          onLoad={() => setLoaded(true)}
-          className="absolute inset-0 h-full w-full border-0 bg-[var(--bg-base)]"
-          sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
-        />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Docs audit + fixes

Audit pass over the Docs surface (`CovenPane`, `docs-pane.tsx`).

### Bug — two of three tabs were dead embeds
**Feedback (github.com)** and **X (x.com)** embedded third-party sites that **refuse framing** — github sends `X-Frame-Options: deny` + `frame-ancestors 'none'`, x.com sets `frame-ancestors` — so both rendered as a **blank pane**, and a blocked frame's unreliable `onLoad` could leave the "Loading Coven…" overlay stuck. Only `docs.opencoven.ai` is actually embeddable.

- Tabs gain an `embeddable` flag. **Only the Docs tab is framed**; Feedback/X now render an **"opens in a new tab" panel** (host + a prominent Open button) instead of a dead iframe, and their Reload button (nothing to reload) is hidden.

### A11y — completed the tablist
It had `role="tablist"/tab"` + `aria-selected` but nothing else. Added **roving `tabIndex`**, **`aria-controls` → a `role="tabpanel"`** with `id` + `aria-labelledby`, and **←/→ + Home/End arrow-key navigation** — mirrors the Roles fix (#1817). The docs iframe's no-top-navigation sandbox is unchanged.

## Testing
- **Verified live:** Docs tab still frames the docs site; ArrowRight → Feedback shows the new-tab panel with **no iframe** + Open button; roving `tabIndex` + tabpanel labelling correct; no console errors.
- `tsc --noEmit` clean · `pnpm build` clean · full `app` suite: 400 files pass.
- Extended `docs-pane.test.ts` with the `embeddable`/panel + tablist (roving/tabpanel/arrow-nav) assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)