### PR TITLE
feat(chat): message-shaped skeleton while restoring chat history

### DIFF
--- a/src/components/chat-linked-context.test.ts
+++ b/src/components/chat-linked-context.test.ts
@@ -107,8 +107,8 @@ assert.match(
 
 assert.match(
   chatView,
-  /historyState === "loading"[\s\S]*Loading chat history/,
-  "ChatView should not show an empty new-chat state while an existing chat history is loading",
+  /historyState === "loading"[\s\S]*ChatHistorySkeleton/,
+  "ChatView should show a message-shaped skeleton (not an empty new-chat state) while an existing chat history is loading",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -11,6 +11,7 @@ import { buildQuotedPrompt, buildReplySnippet, type ReplyTarget } from "@/lib/ch
 import { canonicalize, formatHelp, matchSlash, type SlashCommand } from "@/lib/slash-commands";
 import { slashSaveParse } from "@/lib/slash-save-parser";
 import { Icon, type IconName } from "@/lib/icon";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useKeySymbols } from "@/lib/platform-keys";
 import { useVisualViewport } from "@/lib/use-viewport";
 import { useGlyphOverrides } from "@/lib/cave-glyph-overrides";
@@ -808,6 +809,35 @@ function HeaderDeleteButton({
         </PopoverBody>
       </Popover>
     </>
+  );
+}
+
+// Message-shaped placeholder shown while an existing transcript is restoring —
+// alternating assistant (left) / user (right) ghost bubbles instead of a bare
+// notice, matching the app-wide skeleton convention.
+function ChatHistorySkeleton() {
+  const rows: { side: "left" | "right"; width: string; lines: number }[] = [
+    { side: "left", width: "62%", lines: 3 },
+    { side: "right", width: "46%", lines: 2 },
+    { side: "left", width: "70%", lines: 2 },
+    { side: "right", width: "38%", lines: 1 },
+    { side: "left", width: "56%", lines: 3 },
+  ];
+  return (
+    <div className="flex flex-col gap-5 py-4" role="status" aria-label="Loading chat history">
+      {rows.map((row, i) => (
+        <div key={i} className={`flex ${row.side === "right" ? "justify-end" : "justify-start"}`}>
+          <div
+            className="flex flex-col gap-2 rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 p-3"
+            style={{ width: row.width, maxWidth: "72%" }}
+          >
+            {Array.from({ length: row.lines }).map((_, l) => (
+              <Skeleton key={l} variant="text" width={l === row.lines - 1 ? "70%" : "100%"} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
   );
 }
 
@@ -3469,7 +3499,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         >
           {turns.length === 0 ? (
             historyState === "loading" ? (
-              <ChatHistoryNotice title="Loading chat history" body="Restoring this session transcript..." />
+              <ChatHistorySkeleton />
             ) : historyState === "missing" ? (
               <ChatHistoryNotice
                 title="Chat history unavailable"


### PR DESCRIPTION
## What

While an existing session's transcript loads (`turns.length === 0 && historyState === "loading"`), ChatView showed a centered text notice ("Loading chat history / Restoring this session transcript…"). This replaces it with a `ChatHistorySkeleton` — alternating assistant (left) / user (right) ghost bubbles built from the shared `<Skeleton>` primitive — so the thread previews its conversation shape, consistent with the Board (#1811), session-changes (#1812), and Calls-floor (#1819) skeletons.

The `missing` / `error` history states keep their informative `ChatHistoryNotice` (with retry) — only the *loading* branch changes.

## Verification

- **Visually verified in a built app**: route-mocked a session open with `/api/chat/conversation/**` delayed to hold the loading state. DOM confirmed `aria-label="Loading chat history"` present, **11 skeleton lines**, bubble sides `[left, right, left, right, left]` (alternating as designed), old notice text gone. Screenshot shows message-shaped ghost bubbles in the thread.
- Tests pass: `chat-linked-context` (assertion updated to match the skeleton, same intent), `chat-view-lifecycle`, `chat-view-first-class`, `chat-view-render-optimization`.
- `tsc --noEmit` clean for `chat-view.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)