### PR TITLE
feat(command-palette): fuzzy search + score ranking

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -85,6 +85,7 @@ export const SUITES = {
     "src/components/command-palette.test.ts",
     "src/components/command-palette-save-link.test.ts",
     "src/lib/command-palette-scope.test.ts",
+    "src/lib/fuzzy-match.test.ts",
     "src/components/home-chat-handoff.test.ts",
     "src/components/home-composer.test.ts",
     "src/components/home-composer-centering.test.ts",

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -8,6 +8,7 @@ import { Icon } from "@/lib/icon";
 import { platformizeHint, useKeySymbols } from "@/lib/platform-keys";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { parseFamiliarToken, resolveFamiliarIds } from "@/lib/command-palette-scope";
+import { fuzzyMatch, bestFuzzyScore } from "@/lib/fuzzy-match";
 import { relativeTime } from "@/lib/relative-time";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import { MarkdownBlock } from "@/components/message-bubble";
@@ -339,6 +340,14 @@ export function CommandPalette({
   const rows: Row[] = useMemo(() => {
     const { token, rest } = parseFamiliarToken(query);
     const q = rest.trim().toLowerCase();
+    // Fuzzy match: power users type subsequences ("brd" → Board). `fz` widens the
+    // per-field predicates; `rank` sorts a matched set by best fuzzy score (over
+    // its label fields) so the closest match floats to the top while searching.
+    const fz = (text: string) => fuzzyMatch(q, text);
+    const rank = <T,>(items: T[], fields: (item: T) => Array<string | null | undefined>): T[] =>
+      q
+        ? [...items].sort((a, b) => (bestFuzzyScore(q, fields(b)) ?? -Infinity) - (bestFuzzyScore(q, fields(a)) ?? -Infinity))
+        : items;
     const scope = resolveFamiliarIds(familiars, token);
     const scoped = scope !== null;
     // When the user has typed `@token` but no familiar matches it yet, we
@@ -346,15 +355,11 @@ export function CommandPalette({
     // and suppress everything else. This is also what we do for a bare `@`.
     const noFamiliarMatch = scoped && scope!.size === 0;
 
-    const familiarSuggestionPool = noFamiliarMatch ? familiars : familiars.filter((f) => {
+    const familiarSuggestionPool = rank(noFamiliarMatch ? familiars : familiars.filter((f) => {
       if (scoped && !scope!.has(f.id)) return false;
       if (!q) return true;
-      return (
-        f.display_name.toLowerCase().includes(q) ||
-        f.role.toLowerCase().includes(q) ||
-        (f.harness ?? "").toLowerCase().includes(q)
-      );
-    });
+      return fz(f.display_name) || fz(f.role) || fz(f.harness ?? "");
+    }), (f) => [f.display_name, f.role, f.harness]);
     const familiarRows: Row[] = familiarSuggestionPool
       .slice(0, RESULT_LIMITS.familiar)
       .map((f) => ({ id: `f:${f.id}`, kind: "familiar", familiar: f }));
@@ -370,21 +375,17 @@ export function CommandPalette({
       if (scoped) {
         if (!scope!.has(s.familiarId)) return false;
         if (!q) return true;
-        return (
-          (s.title ?? "").toLowerCase().includes(q) ||
-          s.harness.toLowerCase().includes(q)
-        );
+        return fz(s.title ?? "") || fz(s.harness);
       }
       // Empty query → the "Recent" jump list: every familiar's sessions, not
       // just the active one. Recency ordering happens below the filter.
       if (!q) return true;
-      return (
-        (s.title ?? "").toLowerCase().includes(q) ||
-        s.harness.toLowerCase().includes(q) ||
-        (s.familiarId ?? "").toLowerCase().includes(q)
-      );
+      return fz(s.title ?? "") || fz(s.harness) || fz(s.familiarId ?? "");
     });
-    const sessionRows: Row[] = (!q ? [...matchedSessions].sort(byRecency) : matchedSessions)
+    // Browse → recency; searching → best fuzzy match first.
+    const sessionRows: Row[] = (!q
+      ? [...matchedSessions].sort(byRecency)
+      : rank(matchedSessions, (s) => [s.title, s.familiarId]))
       .slice(0, RESULT_LIMITS.session)
       .map((s) => ({
         id: `s:${s.id}`,
@@ -393,22 +394,22 @@ export function CommandPalette({
         familiar: s.familiarId ? familiarById.get(s.familiarId) ?? null : null,
       }));
 
-    const cardRows: Row[] = cards
+    const cardRows: Row[] = rank(cards
       .filter((c) => {
         if (scoped) {
           if (!c.familiarId || !scope!.has(c.familiarId)) return false;
         }
         if (!q) return true;
         return (
-          c.title.toLowerCase().includes(q) ||
-          (c.labels ?? []).some((l) => l.toLowerCase().includes(q)) ||
-          c.status.toLowerCase().includes(q) ||
-          c.priority.toLowerCase().includes(q)
+          fz(c.title) ||
+          (c.labels ?? []).some((l) => fz(l)) ||
+          fz(c.status) ||
+          fz(c.priority)
         );
       })
       // Empty query → lead with the most-recently-updated tasks ("recent tasks"
-      // jump-list); while searching keep the match order.
-      .sort((a, b) => (q ? 0 : new Date(b.updatedAt ?? 0).getTime() - new Date(a.updatedAt ?? 0).getTime()))
+      // jump-list); while searching `rank` (below) orders by fuzzy score.
+      .sort((a, b) => (q ? 0 : new Date(b.updatedAt ?? 0).getTime() - new Date(a.updatedAt ?? 0).getTime())), (c) => [c.title, ...(c.labels ?? [])])
       .slice(0, RESULT_LIMITS.card)
       .map((c) => ({
         id: `card:${c.id}`,
@@ -421,11 +422,7 @@ export function CommandPalette({
       .filter((e) => {
         if (scoped && !scope!.has(e.familiar_id)) return false;
         if (!q) return true;
-        return (
-          e.title.toLowerCase().includes(q) ||
-          (e.excerpt ?? "").toLowerCase().includes(q) ||
-          e.familiar_id.toLowerCase().includes(q)
-        );
+        return fz(e.title) || (e.excerpt ?? "").toLowerCase().includes(q) || fz(e.familiar_id);
       })
       .slice(0, RESULT_LIMITS.covenMemory)
       .map((e) => ({
@@ -440,12 +437,7 @@ export function CommandPalette({
     const fsMemoryRows: Row[] = scoped
       ? []
       : fsMemory
-          .filter(
-            (e) =>
-              !q ||
-              e.relPath.toLowerCase().includes(q) ||
-              e.rootLabel.toLowerCase().includes(q),
-          )
+          .filter((e) => !q || fz(e.relPath) || fz(e.rootLabel))
           .slice(0, RESULT_LIMITS.fsMemory)
           .map((e) => ({ id: `fm:${e.fullPath}`, kind: "fs-memory", entry: e }));
 
@@ -503,8 +495,8 @@ export function CommandPalette({
             ? c.name.startsWith(slashToken) ||
               (c.aliases ?? []).some((a) => a.startsWith(slashToken))
             : !q ||
-              c.name.includes(q) ||
-              (c.aliases ?? []).some((a) => a.includes(q)) ||
+              fz(c.name) ||
+              (c.aliases ?? []).some((a) => fz(a)) ||
               c.description.toLowerCase().includes(q),
         )
           // /save renders its dedicated per-destination rows above instead.
@@ -524,7 +516,7 @@ export function CommandPalette({
 
     const shortcutRows: Row[] = [];
     const toggleLabel = "Toggle Familiar Chat";
-    if (!scoped && (!q || toggleLabel.toLowerCase().includes(q) || "⌘⇧b".includes(q))) {
+    if (!scoped && (!q || fz(toggleLabel) || "⌘⇧b".includes(q))) {
       shortcutRows.push({
         id: "shortcut:toggle-agent",
         kind: "shortcut",
@@ -558,18 +550,15 @@ export function CommandPalette({
     // command or a familiar scope (where surface nav would be noise).
     const surfaceRows: Row[] = (scoped || slashToken)
       ? []
-      : FOLDER_MODES.filter((fm) => {
+      : rank(FOLDER_MODES.filter((fm) => {
           if (fm.id === "github") return addons?.github === true;
           if (fm.id === "library") return addons?.library === true;
           return true;
         })
-          .filter(
-            (fm) =>
-              !q ||
-              fm.label.toLowerCase().includes(q) ||
-              fm.id.includes(q) ||
-              fm.description.toLowerCase().includes(q),
-          )
+          // Fuzzy on the short label/id; substring-only on the long description
+          // (subsequence-matching prose surfaces irrelevant items).
+          .filter((fm) => !q || fz(fm.label) || fz(fm.id) || fm.description.toLowerCase().includes(q)),
+          (fm) => [fm.label, fm.id])
           .map((fm) => ({
             id: `surface:${fm.id}`,
             kind: "command" as const,
@@ -582,8 +571,7 @@ export function CommandPalette({
     // expanded + scrolled to that project). Hidden while scoped or typing slash.
     const projectRows: Row[] = (scoped || slashToken)
       ? []
-      : projects
-          .filter((p) => !q || p.name.toLowerCase().includes(q) || p.root.toLowerCase().includes(q))
+      : rank(projects.filter((p) => !q || fz(p.name) || fz(p.root)), (p) => [p.name, p.root])
           .slice(0, 6)
           .map((p) => ({
             id: `project:${p.id}`,
@@ -602,8 +590,7 @@ export function CommandPalette({
     ];
     const boardViewRows: Row[] = (scoped || slashToken)
       ? []
-      : BOARD_VIEWS
-          .filter((v) => !q || v.label.toLowerCase().includes(q) || v.terms.includes(q))
+      : rank(BOARD_VIEWS.filter((v) => !q || fz(v.label) || fz(v.terms)), (v) => [v.label, v.terms])
           .map((v) => ({
             id: `board-view:${v.view}`,
             kind: "command" as const,

--- a/src/lib/command-palette-scope.test.ts
+++ b/src/lib/command-palette-scope.test.ts
@@ -74,7 +74,7 @@ test("command palette renders a scope chip with an accessible label", () => {
 test("no-match regression: an unmatched @token shows suggestions only", () => {
   assert.match(
     source,
-    /const familiarSuggestionPool = noFamiliarMatch \? familiars : familiars\.filter/,
+    /const familiarSuggestionPool = rank\(noFamiliarMatch \? familiars : familiars\.filter/,
     "unmatched @tokens bypass the empty scope filter so familiar suggestions still render",
   );
   assert.match(

--- a/src/lib/fuzzy-match.test.ts
+++ b/src/lib/fuzzy-match.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { fuzzyMatch, fuzzyScore, bestFuzzyScore } from "./fuzzy-match.ts";
+
+test("fuzzyMatch: subsequence + substring + case-insensitive", () => {
+  assert.equal(fuzzyMatch("brd", "Board"), true, "abbreviation/subsequence matches");
+  assert.equal(fuzzyMatch("board", "Board"), true, "substring matches");
+  assert.equal(fuzzyMatch("BOARD", "board"), true, "case-insensitive");
+  assert.equal(fuzzyMatch("gtcal", "Go to Calendar"), true, "spanning word-initials match");
+  assert.equal(fuzzyMatch("", "anything"), true, "empty query matches everything");
+});
+
+test("fuzzyMatch: rejects out-of-order / missing chars", () => {
+  assert.equal(fuzzyMatch("drb", "Board"), false, "wrong order does not match");
+  assert.equal(fuzzyMatch("xyz", "Board"), false, "missing chars do not match");
+  assert.equal(fuzzyMatch("boardx", "Board"), false, "extra trailing char fails");
+});
+
+test("fuzzyScore: substring outranks scattered subsequence", () => {
+  const sub = fuzzyScore("board", "Board: Kanban")!;
+  const scattered = fuzzyScore("board", "Browse old archived records daily")!;
+  assert.ok(sub !== null && scattered !== null);
+  assert.ok(sub > scattered, "a literal 'board' beats a scattered b-o-a-r-d");
+});
+
+test("fuzzyScore: word-boundary and earlier matches score higher", () => {
+  assert.ok(
+    fuzzyScore("cal", "Calendar")! > fuzzyScore("cal", "Vertical scale")!,
+    "start-of-string beats mid-word",
+  );
+  assert.ok(
+    fuzzyScore("set", "Settings")! > fuzzyScore("set", "Reset offset")!,
+    "earlier substring scores higher",
+  );
+});
+
+test("fuzzyScore: null when no match, 0 for empty query", () => {
+  assert.equal(fuzzyScore("zzz", "Board"), null);
+  assert.equal(fuzzyScore("", "Board"), 0);
+});
+
+test("bestFuzzyScore: takes the best across candidate fields (ignores nullish)", () => {
+  const s = bestFuzzyScore("board", ["Open project", null, "Board: Table", undefined]);
+  assert.equal(s, fuzzyScore("board", "Board: Table"));
+  assert.equal(bestFuzzyScore("zzz", ["Board", null]), null, "no field matches → null");
+});
+
+console.log("fuzzy-match.test.ts: ok");

--- a/src/lib/fuzzy-match.ts
+++ b/src/lib/fuzzy-match.ts
@@ -1,0 +1,61 @@
+// Fuzzy matching for the command palette. Power users type abbreviations and
+// subsequences ("brd" → "Board", "gtcal" → "Go to Calendar") rather than exact
+// substrings. `fuzzyScore` returns null for no match, or a number where higher =
+// better; substring matches always outrank scattered subsequence matches, and
+// word-start / contiguous hits score above mid-word ones, so the best label
+// floats to the top when results are sorted by score.
+
+const BOUNDARY = /[\s\-_/.:>]/;
+
+/**
+ * Case-insensitive fuzzy score of `query` against `text`.
+ * - `null` when `query` is not an in-order subsequence of `text`.
+ * - An empty query scores 0 (matches everything — caller decides browse order).
+ * - A substring match scores in a high band (earlier + at a word boundary wins).
+ * - Otherwise an in-order subsequence, rewarded for contiguity and word starts.
+ */
+export function fuzzyScore(query: string, text: string): number | null {
+  const q = query.trim().toLowerCase();
+  if (!q) return 0;
+  const t = text.toLowerCase();
+
+  // Substring: the strongest signal. Keep it in a band above any subsequence
+  // score so "board" ranks the literal "Board" row above scattered matches.
+  const sub = t.indexOf(q);
+  if (sub !== -1) {
+    const atBoundary = sub === 0 || BOUNDARY.test(t[sub - 1]);
+    return 1000 - sub + (atBoundary ? 100 : 0);
+  }
+
+  // In-order subsequence with contiguity + word-boundary bonuses.
+  let ti = 0;
+  let score = 0;
+  let prev = -2;
+  for (let qi = 0; qi < q.length; qi++) {
+    const ch = q[qi];
+    while (ti < t.length && t[ti] !== ch) ti++;
+    if (ti >= t.length) return null;
+    if (ti === prev + 1) score += 8; // contiguous run
+    if (ti === 0 || BOUNDARY.test(t[ti - 1])) score += 6; // start of a word
+    prev = ti;
+    ti++;
+  }
+  // Tighter (shorter) texts edge out longer ones on ties.
+  return score - t.length * 0.05;
+}
+
+/** Whether `query` fuzzy-matches `text` (an in-order, case-insensitive subsequence). */
+export function fuzzyMatch(query: string, text: string): boolean {
+  return fuzzyScore(query, text) !== null;
+}
+
+/** Best fuzzy score of `query` across several candidate strings (null if none match). */
+export function bestFuzzyScore(query: string, texts: Array<string | null | undefined>): number | null {
+  let best: number | null = null;
+  for (const text of texts) {
+    if (text == null) continue;
+    const s = fuzzyScore(query, text);
+    if (s !== null && (best === null || s > best)) best = s;
+  }
+  return best;
+}


### PR DESCRIPTION
## What

The command palette matched with substring `.includes()` only, so power-user abbreviations missed — typing **"brd"** found nothing for **Board**. This adds fuzzy (subsequence) matching with score ranking — the #1 item from the keyboard/power-user efficiency survey.

## How

- New pure **`src/lib/fuzzy-match.ts`**: `fuzzyScore` (null = no match; substring matches sit in a high band above scattered subsequences; word-start + contiguous hits score higher), `fuzzyMatch`, and `bestFuzzyScore` (best over several fields).
- The palette filters every category (familiars, sessions, cards, memory, surfaces, projects, board views, slash commands) by fuzzy match on their **short label/name/title** fields, and ranks matched rows by best fuzzy score **while searching** (the browse/empty-query order — recency, etc. — is unchanged).
- **Long free-text fields stay substring-only** (surface/slash descriptions, memory excerpts): subsequence-matching prose surfaces irrelevant items — e.g. "gtcal" would otherwise hit "Go to Roles" via its description. This was caught and fixed during verification.

## Verification

Driven against the running app (⌘K):
- **"brd"** → "Go to Board" + the three Board views + `/board` + Open-project — all board-relevant, no description-noise rows.
- **"gtcal"** → no spurious surface (Calendar isn't a palette surface; the earlier "Go to Roles" false hit is gone).
- `next build` clean (types + lint); new `fuzzy-match.test.ts` (6 cases) + existing `command-palette` / `command-palette-scope` / `command-palette-save-link` tests pass (the scope test's pinned line updated for the `rank(` wrapper). `check:tests-wired` green (551).

🤖 Generated with [Claude Code](https://claude.com/claude-code)