### PR TITLE
fix(schedules): pause polling while hidden + guard async fetches

### DIFF
--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -60,4 +60,15 @@ assert.match(source, /scheduleDelete\(ids,/, "bulk Delete routes through the def
 // Ephemeral inbox items can't be mutated server-side, so they're filtered out.
 assert.match(source, /\.filter\(\(id\) => !id\.startsWith\("eph:"\)\)/, "bulk actions skip ephemeral (eph:) ids");
 
+// ── Polling pauses while hidden + async fetch guards ────────────────────────
+// The 15s list poll + 2.5s in-flight run poll otherwise keep firing in a
+// backgrounded tab; a refetch on return brings the surface current.
+assert.match(source, /const tick = \(\) => \{ if \(!document\.hidden\) void load\(\); \}/, "the 15s poll skips a hidden tab");
+assert.match(source, /addEventListener\("visibilitychange", onVis\)/, "polling resumes when the tab returns");
+assert.match(source, /if \(document\.hidden\) return;.*don't poll a backgrounded tab/, "the in-flight run poll skips a hidden tab");
+// All loaders guard against setState after unmount; refreshRuns also drops stale responses.
+assert.match(source, /const mountedRef = useRef\(true\)/, "tracks mounted state for async guards");
+assert.match(source, /const runsReqRef = useRef\(0\)/, "refreshRuns tracks a request id");
+assert.match(source, /if \(reqId !== runsReqRef\.current \|\| !mountedRef\.current\) return/, "a stale/late runs fetch is dropped");
+
 console.log("automations-view.test.ts: ok");

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import type { Familiar } from "@/lib/types";
 import type { InboxItem, LinkRef } from "@/lib/cave-inbox";
@@ -1340,6 +1340,14 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   const [createOpen, setCreateOpen] = useState(false);
   const [automationRuns, setAutomationRuns] = useState<AutomationRunRecord[]>([]);
   const [lastRunById, setLastRunById] = useState<Map<string, AutomationRunRecord>>(new Map());
+  // Guards async setState after unmount; runsReqRef drops a stale per-automation
+  // runs fetch when a faster, later selection won.
+  const mountedRef = useRef(true);
+  const runsReqRef = useRef(0);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
 
   const load = useCallback(async () => {
     try {
@@ -1348,22 +1356,27 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
         fetch("/api/codex-automations", { cache: "no-store" }),
       ]);
       const inboxJson = await inboxRes.json();
+      if (!mountedRef.current) return;
       if (!inboxJson.ok) { setError(inboxJson.error ?? "load failed"); return; }
       setItems(inboxJson.items ?? []);
       const codexJson = await codexRes.json();
+      if (!mountedRef.current) return;
       if (codexJson.ok) setCodexAutos(codexJson.automations ?? []);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "fetch failed");
+      if (mountedRef.current) setError(err instanceof Error ? err.message : "fetch failed");
     } finally {
-      setInitialLoadDone(true);
+      if (mountedRef.current) setInitialLoadDone(true);
     }
   }, []);
 
   const refreshRuns = useCallback(async (id: string) => {
+    const reqId = ++runsReqRef.current;
     try {
       const res = await fetch(`/api/codex-automations/${encodeURIComponent(id)}/runs`);
       const json = await res.json().catch(() => null);
+      // Drop a stale runs response: a later selection (or poll) superseded it.
+      if (reqId !== runsReqRef.current || !mountedRef.current) return;
       if (json?.ok && Array.isArray(json.runs)) setAutomationRuns(json.runs);
     } catch {
       /* ignore */
@@ -1380,6 +1393,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
             .catch(() => [a.id, undefined] as const),
         ),
       );
+      if (!mountedRef.current) return;
       const map = new Map<string, AutomationRunRecord>();
       for (const [id, run] of entries) {
         if (run) map.set(id, run);
@@ -1390,10 +1404,19 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     }
   }, [codexAutos]);
 
+  // Background polling pauses while the tab is hidden — Schedules otherwise kept
+  // hitting /api/inbox + /api/codex-automations every 15s with nobody looking.
+  // A refetch on return brings it current immediately.
   useEffect(() => {
     void load();
-    const t = setInterval(load, 15000);
-    return () => clearInterval(t);
+    const tick = () => { if (!document.hidden) void load(); };
+    const t = setInterval(tick, 15000);
+    const onVis = () => { if (!document.hidden) void load(); };
+    document.addEventListener("visibilitychange", onVis);
+    return () => {
+      clearInterval(t);
+      document.removeEventListener("visibilitychange", onVis);
+    };
   }, [load]);
 
   // Keep selectedCodex in sync after reload
@@ -1419,6 +1442,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     if (!automationRuns.some((r) => r.status === "running")) return;
     const id = selectedCodex.id;
     const t = setInterval(() => {
+      if (document.hidden) return; // don't poll a backgrounded tab
       void refreshRuns(id);
       void refreshLastRuns();
     }, 2500);

--- a/src/components/surface-loading-states.test.ts
+++ b/src/components/surface-loading-states.test.ts
@@ -9,7 +9,7 @@ const read = (rel) => readFileSync(new URL(rel, import.meta.url), "utf8");
 const inbox = read("./automations-view.tsx");
 assert.match(
   inbox,
-  /initialLoadDone[\s\S]*?finally \{\s*setInitialLoadDone\(true\);/,
+  /initialLoadDone[\s\S]*?finally \{\s*(?:if \(mountedRef\.current\) )?setInitialLoadDone\(true\);/,
   "Inbox/automations tracks first-fetch settlement (success or failure)",
 );
 assert.match(


### PR DESCRIPTION
## Schedules audit + fix

Audit pass over the Schedules surface (`automations-view.tsx`). It's already strong — shared `<Tabs>`, checkbox reminder rows, run-log viewer, undoable deletes, intervals cleared on unmount. The gaps were in the polling/async layer.

- **Polling pauses while the tab is hidden.** It otherwise ran `load()` (`GET /api/inbox` + `/api/codex-automations`) **every 15s**, a **2.5s** poll while a run is in flight, and a **per-automation last-run fan-out** — all firing in a backgrounded tab. The 15s tick and the 2.5s run poll now skip when `document.hidden`, and a `visibilitychange` listener refetches on return so the surface is current immediately.
- **Unmount guards** on `load`/`refreshRuns`/`refreshLastRuns` (no `setState` after `await` on a dead tree).
- **`refreshRuns` request-id guard** — it's invoked on automation selection and from the run poll, so switching automations fast could land a previous one's runs; the stamp drops stale responses.

Behavior unchanged in the happy path.

## Testing
- `tsc --noEmit` clean · `pnpm build` clean · full `app` suite: 401 files pass.
- Smoke-checked the running surface: 3 tabs render, content loads, **no console errors**.
- Extended `automations-view.test.ts` (hidden-pause + guards) and updated `surface-loading-states.test.ts` for the mounted-guarded `setInitialLoadDone`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)