### PR TITLE
fix(ui): suppress doubled clear glyph on the shared SearchInput

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -372,6 +372,7 @@ export const SUITES = {
     "src/components/ui/popover.test.ts",
     "src/components/ui/context-menu.test.ts",
     "src/components/ui/undo-toast.test.ts",
+    "src/components/ui/search-input.test.ts",
     "src/components/ui/modal.test.ts",
     "src/components/ui/confirm-dialog.test.ts",
     "src/components/ui/relative-time.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1893,6 +1893,13 @@ tr[role="checkbox"]:focus-visible {
 .ui-search-input-field::placeholder {
   color: var(--text-muted);
 }
+/* type="search" draws a native clear glyph that doubles up with our own
+   .ui-search-input-clear button — suppress it so there's a single clear. */
+.ui-search-input-field::-webkit-search-cancel-button,
+.ui-search-input-field::-webkit-search-decoration {
+  appearance: none;
+  -webkit-appearance: none;
+}
 
 @media (max-width: 767px) {
   .ui-search-input-field {

--- a/src/components/ui/search-input.test.ts
+++ b/src/components/ui/search-input.test.ts
@@ -1,0 +1,21 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./search-input.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../../app/globals.css", import.meta.url), "utf8");
+
+// The component owns its single clear button.
+assert.match(src, /export const SearchInput/, "exports SearchInput");
+assert.match(src, /ui-search-input-clear/, "renders its own clear button");
+assert.match(src, /type="search"/, "uses a native search input");
+
+// …so the native type="search" clear glyph must be suppressed, or every shared
+// search field shows a doubled ✕ (our button + the webkit glyph).
+assert.match(
+  css,
+  /\.ui-search-input-field::-webkit-search-cancel-button[\s\S]{0,80}appearance:\s*none/,
+  "globals suppresses the native webkit search-cancel glyph on the shared field",
+);
+
+console.log("search-input.test.ts OK");


### PR DESCRIPTION
`type="search"` draws a browser-native clear (✕) glyph that doubled up with `SearchInput`'s own `.ui-search-input-clear` button — so every shared search field (library, board, vault, automations, settings, …) showed **two** clear buttons. The two bespoke fields (`menu-bar`, `top-bar`) already suppressed it; the shared component didn't.

## Fix
One CSS rule on `.ui-search-input-field` suppresses the native `::-webkit-search-cancel-button` / `::-webkit-search-decoration` — fixing ~10 fields at once.

## Verified
- Production build: the settings search field now shows a **single** clear button (was doubled) — screenshot-confirmed.
- New `search-input.test.ts`; typecheck clean; `app` suite (403 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)