### PR TITLE
feat(familiars): show "no matches" in the switcher filter

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5409,6 +5409,13 @@ button:active > .edge-rail-chip {
   list-style: none;
 }
 
+.familiar-switcher__empty {
+  padding: 10px 12px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
 .familiar-switcher__row {
   position: relative;
   display: flex;

--- a/src/components/familiar-switcher.tsx
+++ b/src/components/familiar-switcher.tsx
@@ -268,6 +268,11 @@ export function FamiliarSwitcher({
                   </li>
                 );
               })}
+              {query.trim() && filtered.length === 0 ? (
+                <li className="familiar-switcher__empty" role="presentation">
+                  No familiars match “{query.trim()}”.
+                </li>
+              ) : null}
             </ul>
           )}
 


### PR DESCRIPTION
## What

The familiar switcher's filter input (shown when >6 familiars) rendered the filtered list directly, so a query matching nothing left only the "All familiars" option with no feedback. Adds a compact `No familiars match …` row when the query is non-empty and the filtered list is empty — matching the filtered-empty pattern the workflow library and doc list already use.

- `familiar-switcher.tsx`: conditional `<li className="familiar-switcher__empty">` after the list map.
- `globals.css`: a small `.familiar-switcher__empty` rule (centered, muted).

## Verification

- Tests pass: `familiar-switcher`, `familiar-quick-switch`, `familiar-menu-bar`, `familiar-switcher-style`. `tsc` clean.
- 12-line diff (re-anchored off `origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)