### PR TITLE
perf(code): optimize fluid-glass Projects explorer + fix sticky-header bleed

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2528,9 +2528,11 @@ tr[role="checkbox"]:focus-visible {
     box-shadow var(--duration-fast, 120ms);
 }
 .comux-project-row:hover {
-  background: color-mix(in oklch, var(--bg-raised) 70%, transparent);
-  backdrop-filter: blur(8px) saturate(130%);
-  -webkit-backdrop-filter: blur(8px) saturate(130%);
+  /* Opaque fill (no backdrop-filter): a blur layer per hovered row is a real
+     GPU cost for negligible gain over a list, since the row sits on a near-
+     opaque column. The frost is reserved for the single persistent --active
+     row below, where it earns its paint. */
+  background: color-mix(in oklch, var(--bg-raised) 92%, transparent);
   border-color: color-mix(in oklch, var(--foreground) 8%, transparent);
   transform: translateY(-1px);
 }
@@ -2566,11 +2568,14 @@ tr[role="checkbox"]:focus-visible {
   background: color-mix(in oklch, var(--tile, var(--accent-presence)) 22%, transparent);
   border-color: color-mix(in oklch, var(--tile, var(--accent-presence)) 40%, transparent);
 }
-/* Frosted, in-flow section header for the merged explorer (projects + search +
-   file tree share one scroll, so a true sticky header would collide with the
-   sections below — we frost it in place instead). */
+/* Frosted PROJECTS header. Sticks flush at the scrollport top (the scroller has
+   no top padding) so rows scrolling past frost under it rather than bleeding
+   into a gap above. Kept mostly opaque — a header, not a pane — so row text
+   doesn't read through; the blur only softens the sliver that shows at the
+   stick line. Releases when its section scrolls away (sticky scoped to the
+   projects wrapper, so it never collides with the search box / file tree). */
 .comux-project-header {
-  background: color-mix(in oklch, var(--bg-base) 70%, transparent);
+  background: color-mix(in oklch, var(--bg-base) 88%, transparent);
   backdrop-filter: blur(12px) saturate(135%);
   -webkit-backdrop-filter: blur(12px) saturate(135%);
 }

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -1476,7 +1476,11 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                       </div>
                     </div>
 
-                    <div className="min-h-0 flex-1 overflow-y-auto p-3">
+                    {/* No top padding on the scroller: the sticky PROJECTS
+                        header must stick flush at the scrollport top, or rows
+                        scrolling up bleed into the gap above it. Top breathing
+                        room lives inside the header instead (its own padding). */}
+                    <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
                     {/* Projects — merged into this column above the file tree so
                         the project switcher and the file browser share one
                         explorer. Collapsible; the Code toolbar's Projects toggle
@@ -1485,7 +1489,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                       <button
                         type="button"
                         onClick={() => setProjectListVisible(projectListCollapsed)}
-                        className="comux-project-header sticky top-0 z-10 -mx-1 flex w-[calc(100%+0.5rem)] items-center gap-1.5 rounded px-2 py-[5px] text-left transition-colors hover:bg-[var(--bg-raised)]"
+                        className="comux-project-header sticky top-0 z-10 -mx-1 flex w-[calc(100%+0.5rem)] items-center gap-1.5 rounded px-2 pb-[6px] pt-2.5 text-left transition-colors hover:bg-[var(--bg-raised)]"
                       >
                         <svg
                           width="7" height="7" viewBox="0 0 8 8"


### PR DESCRIPTION
Two follow-ups to #1832 (the fluid-glass Projects explorer).

## 1. Perf — drop `backdrop-filter` from row hover
A blur layer spun up per *hovered* row is real GPU cost for negligible gain: rows sit on a near-opaque column, so the translucent fill carries the look on its own. Frost is now reserved for the single, persistent `--active` row, where it earns its paint. Hover fill bumped to 92% opacity → look unchanged.

## 2. Fix — sticky PROJECTS header bleed
When scrolling, rows peeked into the scroller's top-padding gap *above* the header, and the 70%-opaque header let row text read through it (looked like a glitch).

- Scroller drops its top padding so the header sticks **flush** at the scrollport top; breathing room moved into the header's own padding.
- Header fill → **88% opaque** so passing rows frost under it instead of bleeding above.

## Verification
Built and driven on the real Code surface (Playwright, mocked sessions), captured **top + mid-scroll**: header sticks clean with no bleed; hover / active pill / identity tiles / depth floor all preserved. `tsc` clean; `code-view` + `comux-chrome-wiring` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)