### PR TITLE
feat(marketplace): credential & config collection for needs-setup plugins

### DIFF
--- a/marketplace/catalog.json
+++ b/marketplace/catalog.json
@@ -32,7 +32,8 @@
           "title": "GitHub Token",
           "description": "Personal access token used by the GitHub MCP server.",
           "required": true,
-          "sensitive": true
+          "sensitive": true,
+          "env": "GITHUB_PERSONAL_ACCESS_TOKEN"
         }
       },
       "roleAffinity": [
@@ -301,7 +302,8 @@
           "title": "Allowed Filesystem Root",
           "description": "Root directory the filesystem MCP server may access.",
           "required": true,
-          "sensitive": false
+          "sensitive": false,
+          "env": "COVEN_MCP_FILESYSTEM_ROOT"
         }
       },
       "roleAffinity": [
@@ -339,7 +341,8 @@
           "title": "Git Repository",
           "description": "Repository path the Git MCP server may inspect.",
           "required": true,
-          "sensitive": false
+          "sensitive": false,
+          "env": "COVEN_MCP_GIT_REPOSITORY"
         }
       },
       "roleAffinity": [

--- a/marketplace/plugins/filesystem/plugin.json
+++ b/marketplace/plugins/filesystem/plugin.json
@@ -80,7 +80,8 @@
       "title": "Allowed Filesystem Root",
       "description": "Root directory the filesystem MCP server may access.",
       "required": true,
-      "sensitive": false
+      "sensitive": false,
+      "env": "COVEN_MCP_FILESYSTEM_ROOT"
     }
   }
 }

--- a/marketplace/plugins/git/plugin.json
+++ b/marketplace/plugins/git/plugin.json
@@ -69,7 +69,8 @@
       "title": "Git Repository",
       "description": "Repository path the Git MCP server may inspect.",
       "required": true,
-      "sensitive": false
+      "sensitive": false,
+      "env": "COVEN_MCP_GIT_REPOSITORY"
     }
   }
 }

--- a/marketplace/plugins/github/plugin.json
+++ b/marketplace/plugins/github/plugin.json
@@ -97,7 +97,8 @@
       "title": "GitHub Token",
       "description": "Personal access token used by the GitHub MCP server.",
       "required": true,
-      "sensitive": true
+      "sensitive": true,
+      "env": "GITHUB_PERSONAL_ACCESS_TOKEN"
     }
   }
 }

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -86,6 +86,7 @@ const contracts: RouteContract[] = [
   { route: "/marketplace", methods: ["GET"], kind: "json" },
   { route: "/marketplace/install", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/marketplace/uninstall", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/marketplace/config", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/memory/delete", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/memory/file", methods: ["GET"], kind: "json", pathGuard: true },
   { route: "/memory/inspector", methods: ["GET"], kind: "json" },

--- a/src/app/api/marketplace/config/route.ts
+++ b/src/app/api/marketplace/config/route.ts
@@ -27,20 +27,28 @@ export const runtime = "nodejs";
 
 const MARKETPLACE_DIR = path.join(process.cwd(), "marketplace");
 
-async function inCatalog(id: string): Promise<boolean> {
+/**
+ * Resolve the user-provided id to the matching catalog entry's OWN name string
+ * (from the trusted marketplace.json, not the request). Returns null when the
+ * id is not in the catalog. Downstream filesystem paths are built from this
+ * file-derived name — the request value only selects from the allowlist, it
+ * never constructs a path (avoids js/path-injection).
+ */
+async function resolveCatalogName(id: string): Promise<string | null> {
   try {
     const raw = JSON.parse(await readFile(path.join(MARKETPLACE_DIR, "marketplace.json"), "utf8"));
     const plugins = raw && Array.isArray(raw.plugins) ? raw.plugins : [];
-    return plugins.some((p: { name?: string }) => p.name === id);
+    const match = plugins.find((p: { name?: string }) => p.name === id);
+    return match && typeof match.name === "string" ? match.name : null;
   } catch {
-    return false;
+    return null;
   }
 }
 
-async function requiredConfigFor(id: string): Promise<RequiredConfigField[]> {
+async function requiredConfigFor(name: string): Promise<RequiredConfigField[]> {
   try {
     const manifest = JSON.parse(
-      await readFile(path.join(MARKETPLACE_DIR, "plugins", id, "plugin.json"), "utf8"),
+      await readFile(path.join(MARKETPLACE_DIR, "plugins", name, "plugin.json"), "utf8"),
     ) as PluginManifest;
     return requiredConfigFromManifest(manifest);
   } catch {
@@ -57,10 +65,11 @@ function writeEnvLocal(updates: Record<string, string | null>): void {
 
 export async function GET(req: Request) {
   const id = new URL(req.url).searchParams.get("id") ?? "";
-  if (!id || !(await inCatalog(id))) {
+  const name = id ? await resolveCatalogName(id) : null;
+  if (!name) {
     return NextResponse.json({ ok: false, error: `unknown plugin "${id}"` }, { status: 400 });
   }
-  const fields = await requiredConfigFor(id);
+  const fields = await requiredConfigFor(name);
   const vault = getVaultStatuses();
   const out = fields.map((f) => {
     const inEnv = readEnvLocalValue(f.env) !== undefined || !!process.env[f.env]?.trim();
@@ -91,10 +100,11 @@ export async function POST(req: Request) {
   const id = typeof body?.id === "string" ? body.id : "";
   const key = typeof body?.key === "string" ? body.key : "";
   const value = typeof body?.value === "string" ? body.value : "";
-  if (!id || !(await inCatalog(id))) {
+  const name = id ? await resolveCatalogName(id) : null;
+  if (!name) {
     return NextResponse.json({ ok: false, error: `unknown plugin "${id}"` }, { status: 400 });
   }
-  const field = (await requiredConfigFor(id)).find((f) => f.key === key);
+  const field = (await requiredConfigFor(name)).find((f) => f.key === key);
   if (!field) {
     return NextResponse.json({ ok: false, error: `unknown config key "${key}"` }, { status: 400 });
   }
@@ -121,10 +131,11 @@ export async function DELETE(req: Request) {
   }
   const id = typeof body?.id === "string" ? body.id : "";
   const key = typeof body?.key === "string" ? body.key : "";
-  if (!id || !(await inCatalog(id))) {
+  const name = id ? await resolveCatalogName(id) : null;
+  if (!name) {
     return NextResponse.json({ ok: false, error: `unknown plugin "${id}"` }, { status: 400 });
   }
-  const field = (await requiredConfigFor(id)).find((f) => f.key === key);
+  const field = (await requiredConfigFor(name)).find((f) => f.key === key);
   if (!field || field.sensitive) {
     return NextResponse.json({ ok: false, error: `unknown config key "${key}"` }, { status: 400 });
   }

--- a/src/app/api/marketplace/config/route.ts
+++ b/src/app/api/marketplace/config/route.ts
@@ -1,0 +1,134 @@
+/**
+ * /api/marketplace/config
+ *
+ * GET  ?id=<plugin>   -> per-required-field resolution status (no secret values)
+ * POST { id, key, value } -> save a NON-sensitive plain config value to .env.local
+ * DELETE { id, key }      -> clear a NON-sensitive plain config value
+ *
+ * Sensitive fields are NOT handled here — they go through /api/vault as op://
+ * refs. The env key written is always taken from the trusted plugin manifest
+ * (allowlist-selected via the user's `key`), never built from request strings.
+ */
+
+import { NextResponse } from "next/server";
+import { readFile } from "node:fs/promises";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { canResolve, getVaultStatuses } from "@/lib/vault";
+import { envLocalPath, readEnvLocalValue, upsertEnvContent } from "@/lib/env-file";
+import {
+  requiredConfigFromManifest,
+  type PluginManifest,
+  type RequiredConfigField,
+} from "@/lib/marketplace-catalog";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const MARKETPLACE_DIR = path.join(process.cwd(), "marketplace");
+
+async function inCatalog(id: string): Promise<boolean> {
+  try {
+    const raw = JSON.parse(await readFile(path.join(MARKETPLACE_DIR, "marketplace.json"), "utf8"));
+    const plugins = raw && Array.isArray(raw.plugins) ? raw.plugins : [];
+    return plugins.some((p: { name?: string }) => p.name === id);
+  } catch {
+    return false;
+  }
+}
+
+async function requiredConfigFor(id: string): Promise<RequiredConfigField[]> {
+  try {
+    const manifest = JSON.parse(
+      await readFile(path.join(MARKETPLACE_DIR, "plugins", id, "plugin.json"), "utf8"),
+    ) as PluginManifest;
+    return requiredConfigFromManifest(manifest);
+  } catch {
+    return [];
+  }
+}
+
+function writeEnvLocal(updates: Record<string, string | null>): void {
+  const envPath = envLocalPath();
+  mkdirSync(path.dirname(envPath), { recursive: true });
+  const existing = existsSync(envPath) ? readFileSync(envPath, "utf8") : "";
+  writeFileSync(envPath, upsertEnvContent(existing, updates), "utf8");
+}
+
+export async function GET(req: Request) {
+  const id = new URL(req.url).searchParams.get("id") ?? "";
+  if (!id || !(await inCatalog(id))) {
+    return NextResponse.json({ ok: false, error: `unknown plugin "${id}"` }, { status: 400 });
+  }
+  const fields = await requiredConfigFor(id);
+  const vault = getVaultStatuses();
+  const out = fields.map((f) => {
+    const inEnv = readEnvLocalValue(f.env) !== undefined || !!process.env[f.env]?.trim();
+    const vaultEntry = vault.find((v) => v.key === f.env) ?? null;
+    const satisfied = inEnv || canResolve(f.env);
+    const source = inEnv ? "env" : satisfied ? "vault" : "none";
+    return {
+      key: f.key,
+      env: f.env,
+      title: f.title,
+      description: f.description ?? null,
+      sensitive: f.sensitive,
+      satisfied,
+      source,
+      ref: vaultEntry?.ref ?? null, // an op:// reference, never a secret value
+    };
+  });
+  return NextResponse.json({ ok: true, fields: out });
+}
+
+export async function POST(req: Request) {
+  let body: { id?: unknown; key?: unknown; value?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json" }, { status: 400 });
+  }
+  const id = typeof body?.id === "string" ? body.id : "";
+  const key = typeof body?.key === "string" ? body.key : "";
+  const value = typeof body?.value === "string" ? body.value : "";
+  if (!id || !(await inCatalog(id))) {
+    return NextResponse.json({ ok: false, error: `unknown plugin "${id}"` }, { status: 400 });
+  }
+  const field = (await requiredConfigFor(id)).find((f) => f.key === key);
+  if (!field) {
+    return NextResponse.json({ ok: false, error: `unknown config key "${key}"` }, { status: 400 });
+  }
+  if (field.sensitive) {
+    return NextResponse.json(
+      { ok: false, error: "sensitive fields are set via /api/vault (op:// ref)" },
+      { status: 400 },
+    );
+  }
+  if (!value.trim()) {
+    return NextResponse.json({ ok: false, error: "value is required" }, { status: 400 });
+  }
+  writeEnvLocal({ [field.env]: value });
+  process.env[field.env] = value;
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(req: Request) {
+  let body: { id?: unknown; key?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json" }, { status: 400 });
+  }
+  const id = typeof body?.id === "string" ? body.id : "";
+  const key = typeof body?.key === "string" ? body.key : "";
+  if (!id || !(await inCatalog(id))) {
+    return NextResponse.json({ ok: false, error: `unknown plugin "${id}"` }, { status: 400 });
+  }
+  const field = (await requiredConfigFor(id)).find((f) => f.key === key);
+  if (!field || field.sensitive) {
+    return NextResponse.json({ ok: false, error: `unknown config key "${key}"` }, { status: 400 });
+  }
+  writeEnvLocal({ [field.env]: null });
+  delete process.env[field.env];
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/marketplace/route.ts
+++ b/src/app/api/marketplace/route.ts
@@ -12,6 +12,8 @@ import { NextResponse } from "next/server";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { loadConfig } from "@/lib/cave-config";
+import { canResolve } from "@/lib/vault";
+import { readEnvLocalValue } from "@/lib/env-file";
 import {
   mergeCatalog,
   type MarketplaceJsonPlugin,
@@ -47,6 +49,14 @@ export async function GET() {
   );
 
   const cfg = await loadConfig();
-  const plugins = mergeCatalog(marketplacePlugins, manifests, cfg.marketplace.installed);
+  const merged = mergeCatalog(marketplacePlugins, manifests, cfg.marketplace.installed);
+  const plugins = merged.map((p) => ({
+    ...p,
+    // configured = every required field's env var resolves (vault op:// or
+    // process.env) or is present in .env.local (written but not yet loaded).
+    configured: p.requiredConfig.every(
+      (f) => readEnvLocalValue(f.env) !== undefined || canResolve(f.env),
+    ),
+  }));
   return NextResponse.json({ ok: true, plugins });
 }

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -5,6 +5,7 @@ import { SearchInput } from "@/components/ui/search-input";
 import { EmptyState } from "@/components/ui/empty-state";
 import { MarketplaceCard } from "@/components/marketplace/marketplace-card";
 import { MarketplaceDetail } from "@/components/marketplace/marketplace-detail";
+import { MarketplaceConfigure } from "@/components/marketplace/marketplace-configure";
 import {
   categoriesFrom,
   filterPlugins,
@@ -19,6 +20,7 @@ export function MarketplaceViewSurface() {
   const [category, setCategory] = useState("All");
   const [selected, setSelected] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [configuringId, setConfiguringId] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoaded(false);
@@ -43,6 +45,7 @@ export function MarketplaceViewSurface() {
   const categories = useMemo(() => categoriesFrom(plugins), [plugins]);
   const filtered = useMemo(() => filterPlugins(plugins, { query, category }), [plugins, query, category]);
   const selectedPlugin = useMemo(() => plugins.find((p) => p.id === selected) ?? null, [plugins, selected]);
+  const configuringPlugin = useMemo(() => plugins.find((p) => p.id === configuringId) ?? null, [plugins, configuringId]);
 
   const setInstalled = useCallback((id: string, installed: boolean) => {
     setPlugins((prev) => prev.map((p) => (p.id === id ? { ...p, installed } : p)));
@@ -146,6 +149,7 @@ export function MarketplaceViewSurface() {
                 onOpen={() => setSelected(plugin.id)}
                 onAdd={() => void add(plugin.id)}
                 onRemove={() => void remove(plugin.id)}
+                onConfigure={() => setConfiguringId(plugin.id)}
               />
             ))}
           </div>
@@ -159,6 +163,16 @@ export function MarketplaceViewSurface() {
           onClose={() => setSelected(null)}
           onAdd={() => void add(selectedPlugin.id)}
           onRemove={() => void remove(selectedPlugin.id)}
+        />
+      ) : null}
+
+      {configuringPlugin ? (
+        <MarketplaceConfigure
+          pluginId={configuringPlugin.id}
+          displayName={configuringPlugin.displayName}
+          open={true}
+          onClose={() => setConfiguringId(null)}
+          onChanged={() => void load()}
         />
       ) : null}
     </section>

--- a/src/components/marketplace/marketplace-card.tsx
+++ b/src/components/marketplace/marketplace-card.tsx
@@ -17,9 +17,10 @@ type Props = {
   onOpen: () => void;
   onAdd: () => void;
   onRemove: () => void;
+  onConfigure: () => void;
 };
 
-export function MarketplaceCard({ plugin, busy, onOpen, onAdd, onRemove }: Props) {
+export function MarketplaceCard({ plugin, busy, onOpen, onAdd, onRemove, onConfigure }: Props) {
   const state = pluginBadgeState(plugin);
   return (
     <div className="flex flex-col gap-3 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-panel)] p-4">
@@ -39,7 +40,11 @@ export function MarketplaceCard({ plugin, busy, onOpen, onAdd, onRemove }: Props
             <span className="block truncate text-[12px] text-[var(--text-muted)]">By {plugin.author}</span>
           </span>
         </button>
-        {state === "added" ? (
+        {state === "needs-setup" ? (
+          <Button variant="primary" size="sm" leadingIcon="ph:warning" onClick={onConfigure}>
+            Set up
+          </Button>
+        ) : state === "added" ? (
           <Button variant="secondary" size="sm" leadingIcon="ph:check" loading={busy} onClick={onRemove}>
             Added
           </Button>
@@ -59,6 +64,15 @@ export function MarketplaceCard({ plugin, busy, onOpen, onAdd, onRemove }: Props
           <Icon name="ph:seal-check" width={11} aria-hidden /> {TRUST_LABEL[plugin.trust] ?? plugin.trust}
         </span>
         <span className="rounded-full border border-[var(--border-hairline)] px-2 py-0.5">{plugin.category}</span>
+        {plugin.requiresSetup && plugin.configured ? (
+          <button
+            type="button"
+            onClick={onConfigure}
+            className="focus-ring inline-flex items-center gap-1 rounded-full border border-[var(--border-hairline)] px-2 py-0.5 text-[11px] text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+          >
+            <Icon name="ph:check-circle" width={11} aria-hidden /> Configured
+          </button>
+        ) : null}
         {state === "needs-setup" ? (
           <span className="inline-flex items-center gap-1 rounded-full border border-[var(--border-hairline)] px-2 py-0.5 text-[var(--text-primary)]">
             <Icon name="ph:warning" width={11} aria-hidden /> Needs setup

--- a/src/components/marketplace/marketplace-configure.tsx
+++ b/src/components/marketplace/marketplace-configure.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Modal } from "@/components/ui/modal";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/lib/icon";
+
+type FieldStatus = {
+  key: string;
+  env: string;
+  title: string;
+  description: string | null;
+  sensitive: boolean;
+  satisfied: boolean;
+  source: "env" | "vault" | "none";
+  ref: string | null;
+};
+
+type Props = {
+  pluginId: string;
+  displayName: string;
+  open: boolean;
+  onClose: () => void;
+  /** Called after a successful save so the parent can refetch the grid. */
+  onChanged: () => void;
+};
+
+export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onChanged }: Props) {
+  const [fields, setFields] = useState<FieldStatus[]>([]);
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [loaded, setLoaded] = useState(false);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoaded(false);
+    try {
+      const res = await fetch(`/api/marketplace/config?id=${encodeURIComponent(pluginId)}`, { cache: "no-store" });
+      const json = (await res.json()) as { ok?: boolean; fields?: FieldStatus[]; error?: string };
+      if (!json.ok) throw new Error(json.error ?? `config http ${res.status}`);
+      setFields(json.fields ?? []);
+      setError(null);
+    } catch (err) {
+      setFields([]);
+      setError(err instanceof Error ? err.message : "config unavailable");
+    } finally {
+      setLoaded(true);
+    }
+  }, [pluginId]);
+
+  useEffect(() => {
+    if (open) {
+      setDrafts({});
+      void load();
+    }
+  }, [open, load]);
+
+  const allSatisfied = fields.length > 0 && fields.every((f) => f.satisfied);
+
+  const save = useCallback(async (field: FieldStatus) => {
+    const draft = (drafts[field.key] ?? "").trim();
+    if (!draft) return;
+    if (field.sensitive && !draft.startsWith("op://")) {
+      setError(`${field.title}: enter a 1Password reference (op://Vault/Item/field)`);
+      return;
+    }
+    setBusyKey(field.key);
+    setError(null);
+    try {
+      const res = field.sensitive
+        ? await fetch("/api/vault", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ key: field.env, ref: draft, required: true, description: field.title }),
+          })
+        : await fetch("/api/marketplace/config", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ id: pluginId, key: field.key, value: draft }),
+          });
+      const json = (await res.json()) as { ok?: boolean; error?: string };
+      if (!json.ok) throw new Error(json.error ?? "save failed");
+      setDrafts((d) => ({ ...d, [field.key]: "" }));
+      await load();
+      onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "save failed");
+    } finally {
+      setBusyKey(null);
+    }
+  }, [drafts, pluginId, load, onChanged]);
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      ariaLabel={`Configure ${displayName}`}
+      breadcrumb={["Marketplace", displayName, "Set up"]}
+      footerActions={<Button variant="secondary" size="sm" onClick={onClose}>Done</Button>}
+    >
+      <div className="flex flex-col gap-4">
+        <p className="text-[12px] text-[var(--text-muted)]">
+          {displayName} needs the following before its tools can run. Secrets are stored as 1Password
+          references — Cave never keeps the raw value.
+        </p>
+        {error ? (
+          <p className="rounded-md border border-[var(--danger-border)] bg-[var(--danger-bg)] px-3 py-2 text-[12px] text-[var(--danger-text)]">
+            {error}
+          </p>
+        ) : null}
+        {!loaded ? (
+          <p className="text-[12px] text-[var(--text-muted)]">Loading…</p>
+        ) : (
+          fields.map((f) => (
+            <div key={f.key} className="flex flex-col gap-1.5 rounded-lg border border-[var(--border-hairline)] p-3">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-[13px] font-medium text-[var(--text-primary)]">{f.title}</span>
+                <span className={`inline-flex items-center gap-1 text-[11px] ${f.satisfied ? "text-[var(--text-primary)]" : "text-[var(--text-muted)]"}`}>
+                  <Icon name={f.satisfied ? "ph:check-circle" : "ph:warning"} width={12} aria-hidden />
+                  {f.satisfied ? `Set${f.source === "vault" ? " · 1Password" : ""}` : "Not set"}
+                </span>
+              </div>
+              {f.description ? <p className="text-[11px] text-[var(--text-muted)]">{f.description}</p> : null}
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={drafts[f.key] ?? ""}
+                  onChange={(e) => setDrafts((d) => ({ ...d, [f.key]: e.target.value }))}
+                  placeholder={f.sensitive ? "op://Vault/Item/field" : "Enter a value (e.g. a directory path)"}
+                  aria-label={`${f.title} value`}
+                  className="min-w-0 flex-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 text-[12px] text-[var(--text-primary)] outline-none focus:border-[var(--border-strong)]"
+                  style={{ height: 32 }}
+                />
+                <Button
+                  variant="primary"
+                  size="sm"
+                  loading={busyKey === f.key}
+                  onClick={() => void save(f)}
+                >
+                  Save
+                </Button>
+              </div>
+              {f.sensitive ? (
+                <p className="text-[10px] text-[var(--text-muted)]">
+                  Requires the 1Password CLI (op). Manage refs in Settings → Vault.
+                </p>
+              ) : null}
+            </div>
+          ))
+        )}
+        {allSatisfied ? (
+          <p className="inline-flex items-center gap-1 text-[12px] text-[var(--text-primary)]">
+            <Icon name="ph:check-circle" width={14} aria-hidden /> Configured — all required values are set.
+          </p>
+        ) : null}
+      </div>
+    </Modal>
+  );
+}

--- a/src/lib/marketplace-catalog.test.ts
+++ b/src/lib/marketplace-catalog.test.ts
@@ -6,6 +6,7 @@ import {
   pluginBadgeState,
   filterPlugins,
   categoriesFrom,
+  requiredConfigFromManifest,
 } from "./marketplace-catalog.ts";
 
 const marketplacePlugins = [
@@ -14,7 +15,7 @@ const marketplacePlugins = [
   { name: "legacy", displayName: "Legacy", category: "Other", trust: "preview-local", policy: { installation: "UNAVAILABLE", authentication: "NONE" } },
 ];
 const manifests = {
-  github: { version: "0.1.0", description: "Repos, issues, PRs.", author: { name: "OpenCoven" }, keywords: ["git", "pull-requests"], capabilities: ["network", "mcp"], homepage: "https://opencoven.ai", userConfig: { github_token: { required: true, sensitive: true } } },
+  github: { version: "0.1.0", description: "Repos, issues, PRs.", author: { name: "OpenCoven" }, keywords: ["git", "pull-requests"], capabilities: ["network", "mcp"], homepage: "https://opencoven.ai", userConfig: { github_token: { required: true, sensitive: true, env: "GITHUB_PERSONAL_ACCESS_TOKEN" } } },
   fetch: { version: "0.2.0", description: "HTTP fetch.", author: "Anthropic", keywords: ["http"], capabilities: ["network"] },
   // legacy: intentionally no manifest -> degraded card
 };
@@ -57,7 +58,7 @@ assert.equal(deriveRequiresSetup({ a: { required: true } }), true);
 
 // pluginBadgeState
 assert.equal(pluginBadgeState({ available: false, installed: false, requiresSetup: false }), "unavailable");
-assert.equal(pluginBadgeState({ available: true, installed: true, requiresSetup: true }), "added");
+assert.equal(pluginBadgeState({ available: true, installed: true, requiresSetup: true, configured: true }), "added");
 assert.equal(pluginBadgeState({ available: true, installed: false, requiresSetup: true }), "needs-setup");
 assert.equal(pluginBadgeState({ available: true, installed: false, requiresSetup: false }), "add");
 
@@ -69,5 +70,38 @@ assert.deepEqual(filterPlugins(merged, { query: "", category: "All" }).map((p) =
 
 // categoriesFrom — "All" first, then by count desc then name
 assert.deepEqual(categoriesFrom(merged), ["All", "Developer Tools", "Other"]);
+
+// --- requiredConfig + configured + badge state (credential collection) ---
+const rcManifests = {
+  github: { userConfig: { github_token: { required: true, sensitive: true, title: "GitHub Token", description: "PAT", env: "GITHUB_PERSONAL_ACCESS_TOKEN" } } },
+  fs: { userConfig: { filesystem_root: { required: true, sensitive: false, type: "directory", title: "Root", env: "COVEN_MCP_FILESYSTEM_ROOT" } } },
+  none: { userConfig: { opt: { required: false, env: "X" }, noenv: { required: true } } }, // neither qualifies
+};
+
+assert.deepEqual(requiredConfigFromManifest(rcManifests.github), [
+  { key: "github_token", env: "GITHUB_PERSONAL_ACCESS_TOKEN", title: "GitHub Token", description: "PAT", sensitive: true },
+]);
+assert.deepEqual(requiredConfigFromManifest(rcManifests.fs), [
+  { key: "filesystem_root", env: "COVEN_MCP_FILESYSTEM_ROOT", title: "Root", description: undefined, sensitive: false },
+]);
+assert.deepEqual(requiredConfigFromManifest(rcManifests.none), []); // opt not required; noenv has no env
+assert.deepEqual(requiredConfigFromManifest({}), []);
+
+const rcMerged = mergeCatalog(
+  [{ name: "github", displayName: "GitHub", category: "Developer Tools", trust: "reference-local", policy: { installation: "AVAILABLE", authentication: "ON_INSTALL" } }],
+  { github: rcManifests.github },
+  {},
+);
+const gh = rcMerged[0];
+assert.equal(gh.requiresSetup, true);
+assert.equal(gh.configured, false);
+assert.deepEqual(gh.requiredConfig.map((f) => f.env), ["GITHUB_PERSONAL_ACCESS_TOKEN"]);
+
+assert.equal(pluginBadgeState({ available: true, installed: false, requiresSetup: true, configured: false }), "needs-setup");
+assert.equal(pluginBadgeState({ available: true, installed: true, requiresSetup: true, configured: false }), "needs-setup");
+assert.equal(pluginBadgeState({ available: true, installed: true, requiresSetup: true, configured: true }), "added");
+assert.equal(pluginBadgeState({ available: true, installed: false, requiresSetup: true, configured: true }), "add");
+assert.equal(pluginBadgeState({ available: true, installed: false, requiresSetup: false, configured: false }), "add");
+assert.equal(pluginBadgeState({ available: false, installed: false, requiresSetup: true, configured: false }), "unavailable");
 
 console.log("marketplace-catalog.test.ts: ok");

--- a/src/lib/marketplace-catalog.ts
+++ b/src/lib/marketplace-catalog.ts
@@ -21,6 +21,7 @@ export type PluginUserConfigField = {
   type?: string;
   title?: string;
   description?: string;
+  env?: string;
 };
 
 export type PluginManifest = {
@@ -33,6 +34,28 @@ export type PluginManifest = {
   capabilities?: string[];
   userConfig?: Record<string, PluginUserConfigField>;
 };
+
+export type RequiredConfigField = {
+  key: string;
+  env: string;
+  title: string;
+  description?: string;
+  sensitive: boolean;
+};
+
+/** Required userConfig fields that declare a target env var (collectable). */
+export function requiredConfigFromManifest(manifest: PluginManifest): RequiredConfigField[] {
+  const uc = manifest.userConfig ?? {};
+  return Object.entries(uc)
+    .filter(([, f]) => f?.required === true && typeof f?.env === "string" && f.env.length > 0)
+    .map(([key, f]) => ({
+      key,
+      env: f.env as string,
+      title: f.title ?? key,
+      description: f.description,
+      sensitive: f.sensitive === true,
+    }));
+}
 
 export type InstalledMap = Record<string, { version: string; source: string; installedAt: string }>;
 
@@ -54,6 +77,8 @@ export type MarketplacePlugin = {
   installed: boolean;
   requiresSetup: boolean;
   available: boolean;
+  requiredConfig: RequiredConfigField[];
+  configured: boolean;
 };
 
 export function deriveRequiresSetup(userConfig: PluginManifest["userConfig"]): boolean {
@@ -76,6 +101,7 @@ export function mergeCatalog(
     .map((p) => {
       const manifest = manifests[p.name] ?? {};
       const installation = p.policy?.installation ?? "AVAILABLE";
+      const requiredConfig = requiredConfigFromManifest(manifest);
       return {
         id: p.name,
         displayName: p.displayName ?? p.name,
@@ -95,8 +121,10 @@ export function mergeCatalog(
         kind: "mcp" as const,
         version: manifest.version ?? "0.0.0",
         installed: Boolean(installed[p.name]),
-        requiresSetup: deriveRequiresSetup(manifest.userConfig),
+        requiresSetup: requiredConfig.length > 0,
         available: installation === "AVAILABLE",
+        requiredConfig,
+        configured: false,
       };
     })
     .sort((a, b) => a.displayName.localeCompare(b.displayName));
@@ -105,11 +133,11 @@ export function mergeCatalog(
 export type PluginBadgeState = "add" | "added" | "needs-setup" | "unavailable";
 
 export function pluginBadgeState(
-  p: Pick<MarketplacePlugin, "available" | "installed" | "requiresSetup">,
+  p: Pick<MarketplacePlugin, "available" | "installed" | "requiresSetup" | "configured">,
 ): PluginBadgeState {
   if (!p.available) return "unavailable";
+  if (p.requiresSetup && !p.configured) return "needs-setup";
   if (p.installed) return "added";
-  if (p.requiresSetup) return "needs-setup";
   return "add";
 }
 


### PR DESCRIPTION
Makes "Needs setup" Marketplace plugins configurable. Builds on the Marketplace tab (#1823).

### What's here
- **Declarative field→env mapping**: each required `userConfig` field in `catalog.json` now declares the env var its MCP server resolves (`github_token`→`GITHUB_PERSONAL_ACCESS_TOKEN`, `filesystem_root`→`COVEN_MCP_FILESYSTEM_ROOT`, `git_repository`→`COVEN_MCP_GIT_REPOSITORY`). Regenerated via `sync-marketplace.py`.
- **Helper**: `requiredConfigFromManifest` + `requiredConfig`/`configured` on the card model; `pluginBadgeState` flips **Needs setup → Configured**.
- **API**: `GET /api/marketplace` reports `configured`; new `/api/marketplace/config` (GET status / POST / DELETE) for **non-sensitive** plain values → `.env.local`. The env key is **allowlist-selected from the manifest** (request only selects the field), same path-injection discipline as #1823. Sensitive secrets go through the existing **`/api/vault`** as `op://` refs.
- **UI**: a **Configure** modal — `op://` ref input for secrets, plain input for config — opened from a **Set up** button (needs-setup) and a **Configured** chip (edit later).

### Split by `sensitive`
- `sensitive: true` (e.g. github_token) → 1Password `op://` ref via vault. **Cave never stores the raw secret.**
- `sensitive: false` (filesystem/git directory paths) → plain value in `.env.local`.

### Verified
- Full app suite (401 files) + `api-contracts` (121) green; `pnpm build` ✅.
- Live: github/git show **Set up**; saving a plain filesystem path flips it to **Configured**; the config route rejects sensitive keys (→ vault) and unknown/traversal keys (400). Modal renders op:// vs plain inputs correctly.

Scope (v1): no live secret validation, no OAuth/remote setup, no raw-secret entry (1Password-ref-only). Spec/plan in `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)