### PR TITLE
fix(chat): mark the active conversation row aria-current

### DIFF
--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -1104,6 +1104,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                         <div
                           role={selectMode ? "checkbox" : "button"}
                           aria-checked={selectMode ? selectedIds.has(s.id) : undefined}
+                          aria-current={!selectMode && isActive ? "true" : undefined}
                           tabIndex={0}
                           onClick={() => { if (selectMode) { toggleSelect(s.id); return; } setActiveId(s.id); onOpen(s.id, s.familiarId); }}
                           onKeyDown={(e) => {

--- a/src/components/chat-thread-rail.test.ts
+++ b/src/components/chat-thread-rail.test.ts
@@ -186,4 +186,12 @@ assert.match(
   "Search sits directly under the header and separates the project tree with a hairline",
 );
 
+// The open conversation row announces itself to assistive tech (was visual-only:
+// a background tint + accent bar with no aria-current).
+assert.match(
+  chatList,
+  /aria-current=\{!selectMode && isActive \? "true" : undefined\}/,
+  "the active conversation row is aria-current (not just visually highlighted)",
+);
+
 console.log("chat-thread-rail.test.ts: ok");


### PR DESCRIPTION
## Chat audit + fix

Audit pass over Chat — the largest, most mature surface (`chat-view.tsx` ~4.8k lines, `chat-list.tsx` ~1.4k). Triage found it in strong shape:
- the message stream is **`AbortController`-guarded**,
- **no polling** (SSE-driven),
- `chat-surface` is a fetch-free layout shell,
- list rows are **keyboard-operable** (`role="button"` + Enter/Space; `role="checkbox"` + `aria-checked` in select mode),
- search-result rows correctly have no active state.

The one genuine gap: the **open conversation was conveyed visually only** — a background tint + an accent indicator bar driven by `isActive` — with **no programmatic cue**, so a screen reader couldn't tell which conversation is active.

- The conversation row now sets **`aria-current="true"`** when it's the active thread (and not in select mode). It binds the **same `isActive` boolean** that already renders the visual active bar, so `aria-current` shows exactly when that indicator does.

I scoped to this rather than adding arrow-key roving: every row is already a Tab stop (accessible), and the list is a grouped, sectioned, drag-and-drop-sortable structure where roving would be high-risk for thin benefit.

## Testing
- `tsc --noEmit` clean · `pnpm build` clean · full `app` suite: 404 files pass.
- `chat-thread-rail.test.ts` pins the new `aria-current` attribute.
- Note on live verification: the chat list uses stack-style navigation (opening a thread replaces the list view), so the "list visible + active row" state isn't co-displayed in the quick nav path — but the attribute is a conditional on the existing, proven `isActive` state, so it renders precisely when the visual active indicator does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)