### PR TITLE
fix(a11y): make home composer controls keyboard complete

### DIFF
--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -97,8 +97,8 @@ for (const [name, src] of [
   assert.match(src, /aria-haspopup="listbox"/, `${name} composer textarea should advertise the listbox popup`);
   assert.match(
     src,
-    /aria-expanded=\{slashSuggestions\.length > 0\}/,
-    `${name} composer textarea should track whether the slash menu is open`,
+    /aria-expanded=\{(?:menuOpen|slashSuggestions\.length > 0)\}/,
+    `${name} composer textarea should track whether the inline menu is open`,
   );
   assert.doesNotMatch(
     src,
@@ -107,15 +107,41 @@ for (const [name, src] of [
   );
   assert.match(
     src,
-    /aria-controls=\{slashSuggestions\.length > 0 \? slashListboxId : undefined\}/,
+    /aria-controls=\{(?:menuOpen|slashSuggestions\.length > 0) \? slashListboxId : undefined\}/,
     `${name} aria-controls should reference the listbox only while the menu is open`,
   );
   assert.match(
     src,
-    /aria-activedescendant=\{\s*slashSuggestions\.length > 0 \? `\$\{slashListboxId\}-opt-\$\{slashIdx\}` : undefined\s*\}/,
+    /aria-activedescendant=\{\s*(?:menuOpen|slashSuggestions\.length > 0) \? `\$\{slashListboxId\}-opt-\$\{slashIdx\}` : undefined\s*\}/,
     `${name} aria-activedescendant should track the highlighted index and be absent when the menu is closed`,
   );
 }
+
+// ── HomeComposer combobox ARIA covers the /model picker, not just slash ──────
+// Both inline listboxes share the listbox id; menuOpen unifies them so the
+// textarea announces the /model picker too (was: slash-only).
+assert.match(
+  source,
+  /const menuOpen = modelMenuActive \|\| slashSuggestions\.length > 0;/,
+  "HomeComposer combobox ARIA reflects either inline menu (slash or /model)",
+);
+
+// ── Destination pills are an accessible single-select radiogroup ─────────────
+assert.match(
+  source,
+  /className="hc-dest-pills"\s+role="radiogroup"\s+aria-label="Send to"\s+ref=\{destGroupRef\}\s+onKeyDown=\{handleDestKeyDown\}/,
+  "Destination pills form a labelled radiogroup with keyboard navigation",
+);
+assert.match(
+  source,
+  /role="radio"\s+aria-checked=\{destination === d\.id\}\s+tabIndex=\{destination === d\.id \? 0 : -1\}/,
+  "Each destination pill is a radio that announces its checked state and roves the tab stop",
+);
+assert.match(
+  source,
+  /const nav = \["ArrowRight", "ArrowDown", "ArrowLeft", "ArrowUp", "Home", "End"\];/,
+  "The radiogroup supports arrow/Home/End keyboard selection per the ARIA radio pattern",
+);
 
 // ── Model selection moved to the /model slash command ────────────────────────
 assert.doesNotMatch(

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -183,6 +183,9 @@ export function HomeComposer({
     modelState?.harness ?? familiars.find((f) => f.id === selectedFamiliarId)?.harness ?? "claude";
   const modelOptions = useMemo(() => modelSlashOptions(text, modelHarness), [text, modelHarness]);
   const modelMenuActive = (modelOptions?.length ?? 0) > 0;
+  // Either inline listbox (slash commands or the /model picker) shares the same
+  // listbox id, so the textarea's combobox ARIA tracks whichever is open.
+  const menuOpen = modelMenuActive || slashSuggestions.length > 0;
 
   useEffect(() => {
     setSlashIdx(0);
@@ -242,6 +245,31 @@ export function HomeComposer({
     el.style.height = "auto";
     el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
   }, []);
+
+  // Destination pills behave as a single-select radiogroup: arrow/Home/End
+  // move the selection and the roving focus, matching the ARIA radio pattern.
+  const destGroupRef = useRef<HTMLDivElement>(null);
+  const handleDestKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      const nav = ["ArrowRight", "ArrowDown", "ArrowLeft", "ArrowUp", "Home", "End"];
+      if (!nav.includes(e.key)) return;
+      e.preventDefault();
+      const last = DESTINATIONS.length - 1;
+      const cur = DESTINATIONS.findIndex((d) => d.id === destination);
+      let next = cur < 0 ? 0 : cur;
+      if (e.key === "ArrowRight" || e.key === "ArrowDown") next = cur >= last ? 0 : cur + 1;
+      else if (e.key === "ArrowLeft" || e.key === "ArrowUp") next = cur <= 0 ? last : cur - 1;
+      else if (e.key === "Home") next = 0;
+      else if (e.key === "End") next = last;
+      const target = DESTINATIONS[next];
+      if (!target) return;
+      setDestination(target.id);
+      destGroupRef.current
+        ?.querySelectorAll<HTMLButtonElement>('[role="radio"]')
+        [next]?.focus();
+    },
+    [destination],
+  );
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -512,10 +540,10 @@ export function HomeComposer({
           aria-label="Ask anything"
           aria-autocomplete="list"
           aria-haspopup="listbox"
-          aria-expanded={slashSuggestions.length > 0}
-          aria-controls={slashSuggestions.length > 0 ? slashListboxId : undefined}
+          aria-expanded={menuOpen}
+          aria-controls={menuOpen ? slashListboxId : undefined}
           aria-activedescendant={
-            slashSuggestions.length > 0 ? `${slashListboxId}-opt-${slashIdx}` : undefined
+            menuOpen ? `${slashListboxId}-opt-${slashIdx}` : undefined
           }
           inputMode="text"
           enterKeyHint="send"
@@ -548,11 +576,20 @@ export function HomeComposer({
           </label>
 
           {/* Destination pills */}
-          <div className="hc-dest-pills">
+          <div
+            className="hc-dest-pills"
+            role="radiogroup"
+            aria-label="Send to"
+            ref={destGroupRef}
+            onKeyDown={handleDestKeyDown}
+          >
             {DESTINATIONS.map((d) => (
               <button
                 key={d.id}
                 type="button"
+                role="radio"
+                aria-checked={destination === d.id}
+                tabIndex={destination === d.id ? 0 : -1}
                 className={`hc-dest-pill${destination === d.id ? " active" : ""}`}
                 onClick={() => setDestination(d.id)}
                 title={d.label}


### PR DESCRIPTION
## Summary
- Make HomeComposer combobox ARIA track both slash suggestions and the /model picker.
- Convert destination pills into a labelled single-select radiogroup with roving focus.

## Test Plan
- node --experimental-strip-types src/components/home-composer.test.ts
- pnpm typecheck
- pnpm check:tests-wired
- git diff --check

## Note — ChatView shares the same latent gap
`ChatView` has the identical `/model` combobox-ARIA gap and shares the combobox-ARIA test loop, but `chat-view.tsx` is currently checked out with another session's uncommitted edits, so this PR leaves it untouched. The shared test assertions were made tolerant of both the `menuOpen` and slash-only forms. **Follow-up:** apply the same `menuOpen` unification to ChatView.