### PR TITLE
fix(a11y): announce the /model picker in the chat composer combobox

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2075,6 +2075,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     [input, modelHarness, slashDismissed],
   );
   const modelMenuActive = (modelOptions?.length ?? 0) > 0;
+  // The slash-command and /model pickers are mutually exclusive inline listboxes
+  // sharing one listbox id, so the composer's combobox ARIA tracks whichever is
+  // open (was: slash-only, leaving the /model picker unannounced).
+  const menuOpen = modelMenuActive || slashSuggestions.length > 0;
   // Stable per-mount listbox id — the home composer mounts its own slash menu,
   // so ids must be unique across simultaneously mounted composers.
   const slashListboxId = useId();
@@ -3977,10 +3981,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               aria-label="Message"
               aria-autocomplete="list"
               aria-haspopup="listbox"
-              aria-expanded={slashSuggestions.length > 0}
-              aria-controls={slashSuggestions.length > 0 ? slashListboxId : undefined}
+              aria-expanded={menuOpen}
+              aria-controls={menuOpen ? slashListboxId : undefined}
               aria-activedescendant={
-                slashSuggestions.length > 0 ? `${slashListboxId}-opt-${slashIdx}` : undefined
+                menuOpen ? `${slashListboxId}-opt-${slashIdx}` : undefined
               }
               {...mentionAriaOverrides}
             />

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -97,8 +97,8 @@ for (const [name, src] of [
   assert.match(src, /aria-haspopup="listbox"/, `${name} composer textarea should advertise the listbox popup`);
   assert.match(
     src,
-    /aria-expanded=\{(?:menuOpen|slashSuggestions\.length > 0)\}/,
-    `${name} composer textarea should track whether the inline menu is open`,
+    /aria-expanded=\{menuOpen\}/,
+    `${name} composer textarea should track whether either inline menu (slash or /model) is open`,
   );
   assert.doesNotMatch(
     src,
@@ -107,13 +107,21 @@ for (const [name, src] of [
   );
   assert.match(
     src,
-    /aria-controls=\{(?:menuOpen|slashSuggestions\.length > 0) \? slashListboxId : undefined\}/,
+    /aria-controls=\{menuOpen \? slashListboxId : undefined\}/,
     `${name} aria-controls should reference the listbox only while the menu is open`,
   );
   assert.match(
     src,
-    /aria-activedescendant=\{\s*(?:menuOpen|slashSuggestions\.length > 0) \? `\$\{slashListboxId\}-opt-\$\{slashIdx\}` : undefined\s*\}/,
+    /aria-activedescendant=\{\s*menuOpen \? `\$\{slashListboxId\}-opt-\$\{slashIdx\}` : undefined\s*\}/,
     `${name} aria-activedescendant should track the highlighted index and be absent when the menu is closed`,
+  );
+  // menuOpen unifies the slash-command and /model listboxes (both share the
+  // listbox id), so the combobox ARIA covers the /model picker too — not just
+  // the slash menu. Both composers must use it.
+  assert.match(
+    src,
+    /const menuOpen = modelMenuActive \|\| slashSuggestions\.length > 0;/,
+    `${name} combobox ARIA must reflect either inline menu (slash or /model)`,
   );
 }
 


### PR DESCRIPTION
## Follow-up to #1842 — same gap, ChatView side

The Home composer fix (#1842) noted that `ChatView` had the **identical** latent gap. This closes it.

### The bug
ChatView's composer combobox ARIA (`aria-expanded` / `aria-controls` / `aria-activedescendant`) tracked **only** the slash-command listbox. When the inline `/model …` picker was open, the textarea reported `aria-expanded=false` with no controlled listbox and no active descendant — so a screen-reader user got no announcement of the model options, even though the picker shares the same listbox markup (`role="listbox"` labelled "Models", `role="option"` rows with `aria-selected`).

### The fix
Both inline listboxes are mutually exclusive and share one listbox id, so a new `menuOpen = modelMenuActive || slashSuggestions.length > 0` unifies them — exactly mirroring the HomeComposer fix.

The shared combobox-ARIA test loop (covers HomeComposer **and** ChatView) is tightened back from "tolerant of either form" to requiring `menuOpen`, now that both composers use it.

## Verification
- Full chat-view + home-composer + labels-and-live-regions test suites pass · `tsc --noEmit` clean · `pnpm build` clean
- Live (Playwright): in a chat, typing `/model ` flips the composer to `aria-expanded=true`, `aria-controls`→the "Models" listbox id (4 options), `aria-activedescendant`→`…-opt-0`; idle state reports `expanded=false` with no controlled listbox. `MODEL PICKER ANNOUNCED: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)