### PR TITLE
a11y: add accessible names to icon-only close buttons

### DIFF
--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -225,10 +225,10 @@ function DetailPanel({
         <h2 className="text-[13px] font-semibold" style={{ color: "var(--text-primary)" }}>
           {isDailySummary ? "Daily summary details" : "Reminder details"}
         </h2>
-        <button type="button" onClick={onClose}
+        <button type="button" onClick={onClose} aria-label="Close"
           className="focus-ring rounded p-1 transition-colors hover:bg-white/5"
           style={{ color: "var(--text-muted)" }}>
-          <Icon name="ph:x" width={14} />
+          <Icon name="ph:x" width={14} aria-hidden />
         </button>
       </div>
 
@@ -698,10 +698,10 @@ function CodexDetailPanel({
         <h2 className="text-[13px] font-semibold" style={{ color: "var(--text-primary)" }}>
           Automation details
         </h2>
-        <button type="button" onClick={onClose}
+        <button type="button" onClick={onClose} aria-label="Close"
           className="focus-ring rounded p-1 transition-colors hover:bg-white/5"
           style={{ color: "var(--text-muted)" }}>
-          <Icon name="ph:x" width={14} />
+          <Icon name="ph:x" width={14} aria-hidden />
         </button>
       </div>
 

--- a/src/components/github-action-popover.tsx
+++ b/src/components/github-action-popover.tsx
@@ -368,9 +368,10 @@ export function GitHubActionPopover({
         <button
           type="button"
           onClick={onClose}
+          aria-label="Close"
           className="rounded p-0.5 text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)] transition-colors"
         >
-          <Icon name="ph:x" width={12} />
+          <Icon name="ph:x" width={12} aria-hidden />
         </button>
       </div>
 

--- a/src/components/library-github-list.tsx
+++ b/src/components/library-github-list.tsx
@@ -231,8 +231,8 @@ function AttachTaskModal({
         <div className="gh-modal-header">
           <Icon name="ph:clipboard-text" width={14} />
           <span>Attach to Task</span>
-          <button type="button" className="gh-modal-close" onClick={onClose}>
-            <Icon name="ph:x" width={13} />
+          <button type="button" className="gh-modal-close" aria-label="Close" onClick={onClose}>
+            <Icon name="ph:x" width={13} aria-hidden />
           </button>
         </div>
 
@@ -443,8 +443,8 @@ function HandoffModal({
         <div className="gh-modal-header">
           <Icon name="ph:share-network" width={14} />
           <span>Handoff to Familiar</span>
-          <button type="button" className="gh-modal-close" onClick={onClose}>
-            <Icon name="ph:x" width={13} />
+          <button type="button" className="gh-modal-close" aria-label="Close" onClick={onClose}>
+            <Icon name="ph:x" width={13} aria-hidden />
           </button>
         </div>
 


### PR DESCRIPTION
## What

Five icon-only close buttons (content is just `<Icon name="ph:x">`) had no `aria-label`, so screen readers announced them as an unnamed "button":

- `github-action-popover.tsx` (popover close)
- `library-github-list.tsx` ×2 (modal close, both states)
- `automations-view.tsx` ×2 (reminder + summary dialog close)

Adds `aria-label="Close"` — matching the **34** other close buttons in the app that already use it — and marks the now-decorative `ph:x` icon `aria-hidden`.

## Verification

- `a11y-audit-fixes` and `automations-view` suites pass; `tsc` clean for all 3 files.
- Diff is exactly the aria additions (verified against `origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)