### PR TITLE
feat(code): right-click context menu on Projects explorer rows

### DIFF
--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -63,6 +63,12 @@ assert.match(toolbar, /cave:toggle-right-panel/, "the panel toggle asks the shel
 assert.doesNotMatch(codeView, /toggleProjects|aria-label=\{?"?(Hide|Show) projects/i, "the collapse toggle is not in the Code toolbar anymore");
 assert.match(comux, /onClick=\{\(\) => setProjectListVisible\(projectListCollapsed\)\}/, "the merged Projects section header toggles its own collapse");
 assert.match(comux, /comux-project-row/, "the projects list renders project rows in the explorer column");
+// Right-click a project row → a context menu with cwd-scoped actions.
+assert.match(comux, /onContextMenu=\{\(e\) => \{[\s\S]*?setProjectMenuTarget\(project\);[\s\S]*?openContextMenuAt\(setProjectMenu\)\(e\);/, "project rows open a context menu at the cursor, recording which project");
+assert.match(comux, /ariaLabel=\{projectMenuTarget \? `Actions for \$\{projectMenuTarget\.name\}`/, "the project context menu is labelled per project");
+assert.match(comux, /onNewChat\(projectMenuTarget\.root\)/, "menu can start a chat in the project cwd");
+assert.match(comux, /addSession\(projectMenuTarget\.root\)/, "menu can open a terminal in the project cwd");
+assert.match(comux, /copyText\(projectMenuTarget\.root\)/, "menu can copy the project path");
 assert.match(comux, /Projects — merged into this column/, "the projects list is merged into the file-explorer column");
 assert.match(comux, /\{!projectListCollapsed && \(/, "comux hides the projects list when collapsed");
 assert.match(

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -36,6 +36,8 @@ import {
   type ComuxProject,
 } from "@/lib/comux-projects";
 import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
+import { ContextMenu, openContextMenuAt, type ContextMenuState } from "@/components/ui/context-menu";
+import { PopoverItem, PopoverSeparator } from "@/components/ui/popover";
 import {
   addTerminalSession,
   closeTerminalSession,
@@ -349,6 +351,10 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   const projectFilterRef = useRef<HTMLInputElement>(null);
   const projectListRef = useRef<HTMLDivElement>(null);
   const activeProjectRowRef = useRef<HTMLButtonElement | null>(null);
+  // Right-click context menu for a project row. `menuTarget` records which
+  // project was right-clicked (one menu serves the whole list).
+  const [projectMenu, setProjectMenu] = useState<ContextMenuState>(null);
+  const [projectMenuTarget, setProjectMenuTarget] = useState<ComuxProject | null>(null);
 
   useEffect(() => {
     void (async () => {
@@ -1614,6 +1620,10 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                                 data-project-row
                                 ref={isActive ? activeProjectRowRef : undefined}
                                 onClick={() => selectProject(project)}
+                                onContextMenu={(e) => {
+                                  setProjectMenuTarget(project);
+                                  openContextMenuAt(setProjectMenu)(e);
+                                }}
                                 title={project.root}
                                 aria-current={isActive ? "true" : undefined}
                                 style={{ ["--tile" as string]: projectTint(project.root) }}
@@ -1648,6 +1658,59 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                         </>
                       )}
                     </div>
+                    {/* Right-click a project → act on it without selecting it
+                        first (start a chat/terminal in any project's cwd, copy
+                        or reveal its path). One menu serves the whole list. */}
+                    <ContextMenu
+                      state={projectMenu}
+                      onClose={() => setProjectMenu(null)}
+                      ariaLabel={projectMenuTarget ? `Actions for ${projectMenuTarget.name}` : "Project actions"}
+                    >
+                      {projectMenuTarget && (
+                        <>
+                          <PopoverItem
+                            icon="ph:chat-circle-dots-bold"
+                            onSelect={() => {
+                              setProjectMenu(null);
+                              onNewChat(projectMenuTarget.root);
+                            }}
+                          >
+                            New chat
+                          </PopoverItem>
+                          <PopoverItem
+                            icon="ph:terminal-window-bold"
+                            onSelect={() => {
+                              setProjectMenu(null);
+                              addSession(projectMenuTarget.root);
+                            }}
+                          >
+                            Open terminal
+                          </PopoverItem>
+                          <PopoverSeparator />
+                          <PopoverItem
+                            icon="ph:copy"
+                            onSelect={() => {
+                              setProjectMenu(null);
+                              void copyText(projectMenuTarget.root);
+                            }}
+                          >
+                            Copy path
+                          </PopoverItem>
+                          <PopoverItem
+                            icon="ph:arrow-square-out"
+                            onSelect={() => {
+                              setProjectMenu(null);
+                              const root = projectMenuTarget.root;
+                              if (root.startsWith("/")) {
+                                window.open(`file://${root}`, "_blank", "noopener");
+                              }
+                            }}
+                          >
+                            Reveal in Finder
+                          </PopoverItem>
+                        </>
+                      )}
+                    </ContextMenu>
                     {/* Project-wide code search (CODE-SEARCH-01) */}
                     <div className="mb-3">
                       <div className="relative">


### PR DESCRIPTION
Right-clicking a project row in the Code-surface explorer now opens a context menu (shared `ContextMenu`/`Popover` primitive — same one the Chat-tab projects list uses) with **cwd-scoped actions**, so you can act on *any* project without selecting it first:

- **New chat** — start a chat in that project's cwd (`onNewChat`)
- **Open terminal** — spawn a terminal there (`addSession`)
- ───
- **Copy path** — context-safe `copyText` of the root
- **Reveal in Finder** — open the folder (`file://` — desktop)

One menu serves the whole list; the right-clicked project is recorded in `projectMenuTarget`, and the menu is `aria-label`led per project. Inherits Escape / outside-click / focus-return from the shared Popover.

## Verification
Built and driven on the real Code surface (Playwright, mocked sessions): right-clicking the `sage` row opens the menu at the cursor with exactly `New chat · Open terminal · Copy path · Reveal in Finder`. Source-text assertions added to `code-view.test.ts`; `tsc` clean; `check:tests-wired` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)