### PR TITLE
feat(ios): delete confirmation, haptics, and revert feedback

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Haptics.swift
+++ b/apps/ios/CovenCave/CovenCave/Haptics.swift
@@ -9,4 +9,8 @@ enum Haptics {
     static func success() {
         UINotificationFeedbackGenerator().notificationOccurred(.success)
     }
+
+    static func error() {
+        UINotificationFeedbackGenerator().notificationOccurred(.error)
+    }
 }

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -57,6 +57,14 @@ final class AppModel {
         toast = ToastMessage(text: text, systemImage: systemImage, style: style)
     }
 
+    /// An optimistic edit failed and was reverted: surface a single error toast
+    /// + error haptic so the change doesn't silently snap back. Callers still set
+    /// their `*Error` string for any inline display.
+    private func reportRevert(_ what: String) {
+        showToast("Couldn’t \(what) — reverted", systemImage: "exclamationmark.triangle.fill", style: .error)
+        Haptics.error()
+    }
+
     /// Ask the chat list to open a thread (switches to Chats first).
     func requestOpen(_ thread: ChatThread) {
         selectedTab = .chats
@@ -172,9 +180,11 @@ final class AppModel {
         do {
             let updated = try await client.updateTask(cardId: card.id, status: status)
             applyTask(id: card.id) { $0 = updated }
+            Haptics.tap()
         } catch {
             tasks = previous
             tasksError = error.localizedDescription
+            reportRevert("update the task")
         }
     }
 
@@ -186,9 +196,11 @@ final class AppModel {
         do {
             let updated = try await client.updateTask(cardId: card.id, priority: priority)
             applyTask(id: card.id) { $0 = updated }
+            Haptics.tap()
         } catch {
             tasks = previous
             tasksError = error.localizedDescription
+            reportRevert("update the task")
         }
     }
 
@@ -290,9 +302,11 @@ final class AppModel {
         do {
             let updated = try await client.updateTaskDates(cardId: card.id, startDate: start, endDate: end)
             applyTask(id: card.id) { $0 = updated }
+            Haptics.tap()
         } catch {
             tasks = previous
             tasksError = error.localizedDescription
+            reportRevert("reschedule the task")
         }
     }
 
@@ -303,9 +317,11 @@ final class AppModel {
         tasks.removeAll { $0.id == card.id }
         do {
             try await client.deleteTask(cardId: card.id)
+            Haptics.success()
         } catch {
             tasks = previous
             tasksError = error.localizedDescription
+            reportRevert("delete the task")
         }
     }
 
@@ -349,9 +365,11 @@ final class AppModel {
         reminders.removeAll { ids.contains($0.id) }
         do {
             for id in ids { try await client.deleteReminder(id: id) }
+            Haptics.success()
         } catch {
             reminders = previous
             remindersError = error.localizedDescription
+            reportRevert(ids.count == 1 ? "delete the reminder" : "delete the reminders")
         }
     }
 
@@ -374,9 +392,11 @@ final class AppModel {
         applyReminder(id: reminder.id) { $0.status = optimistic }
         do {
             if let updated = try await call(client) { applyReminder(id: reminder.id) { $0 = updated } }
+            Haptics.success()
         } catch {
             reminders = previous
             remindersError = error.localizedDescription
+            reportRevert("update the reminder")
         }
     }
 
@@ -404,9 +424,11 @@ final class AppModel {
             for id in ids {
                 if let updated = try await call(client, id) { applyReminder(id: id) { $0 = updated } }
             }
+            Haptics.success()
         } catch {
             reminders = previous
             remindersError = error.localizedDescription
+            reportRevert("update the reminders")
         }
     }
 
@@ -816,13 +838,18 @@ final class AppModel {
     func deleteThread(_ thread: ChatThread) {
         threads.removeAll { $0.id == thread.id }
         persistThreads()
+        Haptics.success()
+        showToast("Chat deleted", systemImage: "trash.fill")
     }
 
     /// Delete several threads at once (bulk select); persists once.
     func deleteThreads(_ ids: Set<String>) {
         guard !ids.isEmpty else { return }
+        let n = ids.count
         threads.removeAll { ids.contains($0.id) }
         persistThreads()
+        Haptics.success()
+        showToast("\(n) chat\(n == 1 ? "" : "s") deleted", systemImage: "trash.fill")
     }
 
     /// Rename a thread (local title only); no-ops on a blank or unchanged name.

--- a/apps/ios/CovenCave/CovenCave/Views/CalendarView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/CalendarView.swift
@@ -9,6 +9,8 @@ struct CalendarView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.chrome) private var chrome
     @State private var taskSelection: BoardCard?
+    /// A reminder awaiting delete confirmation (swipe or context menu).
+    @State private var pendingDelete: Reminder?
 
     var body: some View {
         NavigationStack {
@@ -23,7 +25,20 @@ struct CalendarView: View {
                 .sheet(item: $taskSelection) { card in
                     NavigationStack { TaskDetailView(card: card) }
                 }
+                .confirmationDialog("Delete this reminder?",
+                                    isPresented: deleteDialogBinding,
+                                    titleVisibility: .visible,
+                                    presenting: pendingDelete) { reminder in
+                    Button("Delete", role: .destructive) {
+                        Task { await app.deleteReminders([reminder.id]) }
+                    }
+                    Button("Cancel", role: .cancel) {}
+                } message: { reminder in Text(reminder.title) }
         }
+    }
+
+    private var deleteDialogBinding: Binding<Bool> {
+        Binding(get: { pendingDelete != nil }, set: { if !$0 { pendingDelete = nil } })
     }
 
     // MARK: - State buckets
@@ -74,37 +89,37 @@ struct CalendarView: View {
             AgendaReminderRow(reminder: reminder)
                 .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
                 .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                    Button(role: .destructive) {
-                        Haptics.tap(); Task { await app.deleteReminders([reminder.id]) }
-                    } label: { Label("Delete", systemImage: "trash") }
+                    Button(role: .destructive) { pendingDelete = reminder } label: {
+                        Label("Delete", systemImage: "trash")
+                    }
                 }
                 .swipeActions(edge: .leading) {
-                    Button {
-                        Haptics.success(); Task { await app.markReminderDone(reminder) }
-                    } label: { Label("Done", systemImage: "checkmark.circle") }
+                    Button { Task { await app.markReminderDone(reminder) } } label: {
+                        Label("Done", systemImage: "checkmark.circle")
+                    }
                     .tint(.green)
                 }
                 .contextMenu {
-                    Button { Haptics.success(); Task { await app.markReminderDone(reminder) } } label: {
+                    Button { Task { await app.markReminderDone(reminder) } } label: {
                         Label("Mark done", systemImage: "checkmark.circle")
                     }
                     Menu {
-                        Button("15 minutes") { Haptics.tap(); Task { await app.snoozeReminder(reminder, minutes: 15) } }
-                        Button("1 hour") { Haptics.tap(); Task { await app.snoozeReminder(reminder, minutes: 60) } }
-                        Button("1 day") { Haptics.tap(); Task { await app.snoozeReminder(reminder, minutes: 1440) } }
+                        Button("15 minutes") { Task { await app.snoozeReminder(reminder, minutes: 15) } }
+                        Button("1 hour") { Task { await app.snoozeReminder(reminder, minutes: 60) } }
+                        Button("1 day") { Task { await app.snoozeReminder(reminder, minutes: 1440) } }
                     } label: { Label("Snooze", systemImage: "moon.zzz") }
-                    Button(role: .destructive) { Haptics.tap(); Task { await app.deleteReminders([reminder.id]) } } label: {
+                    Button(role: .destructive) { pendingDelete = reminder } label: {
                         Label("Delete", systemImage: "trash")
                     }
                 }
         case .task(let card):
-            Button { Haptics.tap(); taskSelection = card } label: { AgendaTaskRow(card: card) }
+            Button { taskSelection = card } label: { AgendaTaskRow(card: card) }
                 .buttonStyle(.plain)
                 .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
                 .contextMenu {
                     Button { reschedule(card, byDays: 1) } label: { Label("Due tomorrow", systemImage: "calendar.badge.clock") }
                     Button { reschedule(card, byDays: 7) } label: { Label("Due next week", systemImage: "calendar") }
-                    Button { Task { Haptics.tap(); await app.setTaskDates(card, start: card.startDate, end: nil) } } label: {
+                    Button { Task { await app.setTaskDates(card, start: card.startDate, end: nil) } } label: {
                         Label("Clear due date", systemImage: "calendar.badge.minus")
                     }
                 }
@@ -113,7 +128,6 @@ struct CalendarView: View {
 
     private func reschedule(_ card: BoardCard, byDays days: Int) {
         let target = Calendar.current.date(byAdding: .day, value: days, to: Calendar.current.startOfDay(for: Date())) ?? Date()
-        Haptics.tap()
         Task { await app.setTaskDates(card, start: card.startDate, end: Self.dayOnly.string(from: target)) }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/RemindersView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RemindersView.swift
@@ -9,6 +9,8 @@ struct RemindersView: View {
     @State private var selectMode = false
     @State private var selectedIds: Set<String> = []
     @State private var confirmingBulkDelete = false
+    /// A single reminder awaiting delete confirmation (swipe or context menu).
+    @State private var pendingDelete: Reminder?
 
     var body: some View {
         NavigationStack {
@@ -76,6 +78,15 @@ struct RemindersView: View {
                     }
                     Button("Cancel", role: .cancel) {}
                 }
+                .confirmationDialog("Delete this reminder?",
+                                    isPresented: deleteDialogBinding,
+                                    titleVisibility: .visible,
+                                    presenting: pendingDelete) { reminder in
+                    Button("Delete", role: .destructive) {
+                        Task { await app.deleteReminders([reminder.id]) }
+                    }
+                    Button("Cancel", role: .cancel) {}
+                } message: { reminder in Text(reminder.title) }
         }
     }
 
@@ -111,7 +122,7 @@ struct RemindersView: View {
                     .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
                     .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                         Button(role: .destructive) {
-                            Task { await app.deleteReminders([reminder.id]) }
+                            pendingDelete = reminder
                         } label: { Label("Delete", systemImage: "trash") }
                     }
                     .swipeActions(edge: .leading) {
@@ -132,7 +143,7 @@ struct RemindersView: View {
                         Button { Task { await app.dismissReminder(reminder) } } label: {
                             Label("Dismiss", systemImage: "xmark.circle")
                         }
-                        Button(role: .destructive) { Task { await app.deleteReminders([reminder.id]) } } label: {
+                        Button(role: .destructive) { pendingDelete = reminder } label: {
                             Label("Delete", systemImage: "trash")
                         }
                     }
@@ -145,6 +156,9 @@ struct RemindersView: View {
 
     private var bulkTitle: String {
         "Delete \(selectedIds.count) reminder\(selectedIds.count == 1 ? "" : "s")?"
+    }
+    private var deleteDialogBinding: Binding<Bool> {
+        Binding(get: { pendingDelete != nil }, set: { if !$0 { pendingDelete = nil } })
     }
     private var allSelected: Bool {
         !app.reminders.isEmpty && Set(app.reminders.map(\.id)).isSubset(of: selectedIds)


### PR DESCRIPTION
Closes the destructive-action-safety + feedback gaps the iOS survey found.

## Safety
- **Reminder swipe / context delete now confirms** (RemindersView + CalendarView), matching the existing TasksView pattern. Previously a full-swipe deleted a desktop-created reminder instantly — no confirm, no undo.

## Feedback (centralized in `AppModel` so every call site — swipe, context menu, bulk, detail, calendar — behaves consistently)
- **Success haptics** on task status/priority change, task delete, task reschedule, and reminder done/snooze/dismiss/delete (single + bulk).
- **Failed optimistic edits no longer snap back silently** — each revert raises an error toast + error haptic (new `Haptics.error()`) alongside the existing `*Error` string.
- **Chat delete** (single + bulk) confirms with a haptic + "Chat deleted" toast.
- Removed CalendarView's call-site haptics now that they're centralized (no double-buzz).

## Verified
- `xcodebuild` for the iOS Simulator: **BUILD SUCCEEDED**.
- App launches and runs on the simulator with no regression (chat list + 5-tab bar render, no crash from the AppModel changes).
- Mobile (65) + app (407) source-text suites green.
- The swipe→confirm dialogs can't be driven headlessly (simctl has no gesture input), but they mirror the already-shipped TasksView confirmation flow exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)