### PR TITLE
feat(marketplace): live GitHub token validation

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -44,6 +44,7 @@ export const SUITES = {
     "src/lib/chat-project-overrides.test.ts",
     "src/lib/session-project-scope.test.ts",
     "src/lib/marketplace-catalog.test.ts",
+    "src/lib/secret-validators.test.ts",
     "src/components/chat-project-sidebar-dnd.test.ts",
     "src/lib/workflows.test.ts",
     "src/lib/workflow-generate.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -90,6 +90,7 @@ const contracts: RouteContract[] = [
   { route: "/marketplace/install", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/marketplace/uninstall", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/marketplace/config", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/marketplace/config/validate", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/memory/delete", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/memory/file", methods: ["GET"], kind: "json", pathGuard: true },
   { route: "/memory/inspector", methods: ["GET"], kind: "json" },

--- a/src/app/api/marketplace/config/catalog-config.ts
+++ b/src/app/api/marketplace/config/catalog-config.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared, path-injection-safe catalog lookups for the marketplace config routes.
+ * The request `id` only SELECTS a catalog entry; filesystem paths are built from
+ * the trusted, file-derived name (never from the request string).
+ */
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  requiredConfigFromManifest,
+  type PluginManifest,
+  type RequiredConfigField,
+} from "@/lib/marketplace-catalog";
+
+export const MARKETPLACE_DIR = path.join(process.cwd(), "marketplace");
+
+/** Resolve a request id to the matching catalog entry's own (trusted) name, or null. */
+export async function resolveCatalogName(id: string): Promise<string | null> {
+  try {
+    const raw = JSON.parse(await readFile(path.join(MARKETPLACE_DIR, "marketplace.json"), "utf8"));
+    const plugins = raw && Array.isArray(raw.plugins) ? raw.plugins : [];
+    const match = plugins.find((p: { name?: string }) => p.name === id);
+    return match && typeof match.name === "string" ? match.name : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Required config fields for a trusted plugin name (path built from the name). */
+export async function requiredConfigFor(name: string): Promise<RequiredConfigField[]> {
+  try {
+    const manifest = JSON.parse(
+      await readFile(path.join(MARKETPLACE_DIR, "plugins", name, "plugin.json"), "utf8"),
+    ) as PluginManifest;
+    return requiredConfigFromManifest(manifest);
+  } catch {
+    return [];
+  }
+}

--- a/src/app/api/marketplace/config/route.ts
+++ b/src/app/api/marketplace/config/route.ts
@@ -11,50 +11,15 @@
  */
 
 import { NextResponse } from "next/server";
-import { readFile } from "node:fs/promises";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { canResolve, getVaultStatuses } from "@/lib/vault";
 import { envLocalPath, readEnvLocalValue, upsertEnvContent } from "@/lib/env-file";
-import {
-  requiredConfigFromManifest,
-  type PluginManifest,
-  type RequiredConfigField,
-} from "@/lib/marketplace-catalog";
+import { hasValidator } from "@/lib/secret-validators";
+import { resolveCatalogName, requiredConfigFor } from "./catalog-config";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
-
-const MARKETPLACE_DIR = path.join(process.cwd(), "marketplace");
-
-/**
- * Resolve the user-provided id to the matching catalog entry's OWN name string
- * (from the trusted marketplace.json, not the request). Returns null when the
- * id is not in the catalog. Downstream filesystem paths are built from this
- * file-derived name — the request value only selects from the allowlist, it
- * never constructs a path (avoids js/path-injection).
- */
-async function resolveCatalogName(id: string): Promise<string | null> {
-  try {
-    const raw = JSON.parse(await readFile(path.join(MARKETPLACE_DIR, "marketplace.json"), "utf8"));
-    const plugins = raw && Array.isArray(raw.plugins) ? raw.plugins : [];
-    const match = plugins.find((p: { name?: string }) => p.name === id);
-    return match && typeof match.name === "string" ? match.name : null;
-  } catch {
-    return null;
-  }
-}
-
-async function requiredConfigFor(name: string): Promise<RequiredConfigField[]> {
-  try {
-    const manifest = JSON.parse(
-      await readFile(path.join(MARKETPLACE_DIR, "plugins", name, "plugin.json"), "utf8"),
-    ) as PluginManifest;
-    return requiredConfigFromManifest(manifest);
-  } catch {
-    return [];
-  }
-}
 
 function writeEnvLocal(updates: Record<string, string | null>): void {
   const envPath = envLocalPath();
@@ -82,6 +47,7 @@ export async function GET(req: Request) {
       title: f.title,
       description: f.description ?? null,
       sensitive: f.sensitive,
+      validatable: hasValidator(f.env),
       satisfied,
       source,
       ref: vaultEntry?.ref ?? null, // an op:// reference, never a secret value

--- a/src/app/api/marketplace/config/validate/route.ts
+++ b/src/app/api/marketplace/config/validate/route.ts
@@ -1,0 +1,57 @@
+/**
+ * POST /api/marketplace/config/validate  { id, key }
+ *
+ * Resolves the field's secret server-side (vault op:// or .env.local) and runs
+ * its registered validator (e.g. GitHub /user for the github token). Returns
+ * pass/fail + login. The secret value is never returned or logged. Advisory —
+ * does not change install/config state.
+ */
+
+import { NextResponse } from "next/server";
+import { resolveSecret } from "@/lib/vault";
+import { hasValidator, validateSecret } from "@/lib/secret-validators";
+import { resolveCatalogName, requiredConfigFor } from "../catalog-config";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  let body: { id?: unknown; key?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json" }, { status: 400 });
+  }
+  const id = typeof body?.id === "string" ? body.id : "";
+  const key = typeof body?.key === "string" ? body.key : "";
+
+  const name = id ? await resolveCatalogName(id) : null;
+  if (!name) {
+    return NextResponse.json({ ok: false, error: `unknown plugin "${id}"` }, { status: 400 });
+  }
+  const field = (await requiredConfigFor(name)).find((f) => f.key === key);
+  if (!field) {
+    return NextResponse.json({ ok: false, error: `unknown config key "${key}"` }, { status: 400 });
+  }
+  if (!hasValidator(field.env)) {
+    return NextResponse.json({ ok: false, error: "this field has no validator" }, { status: 400 });
+  }
+
+  const value = resolveSecret(field.env);
+  if (!value) {
+    return NextResponse.json({
+      ok: true,
+      valid: false,
+      login: null,
+      error: "secret is not set or could not be resolved",
+    });
+  }
+
+  const result = await validateSecret(field.env, value);
+  return NextResponse.json({
+    ok: true,
+    valid: result.ok,
+    login: result.login ?? null,
+    error: result.error ?? null,
+  });
+}

--- a/src/components/marketplace/marketplace-configure.tsx
+++ b/src/components/marketplace/marketplace-configure.tsx
@@ -11,6 +11,7 @@ type FieldStatus = {
   title: string;
   description: string | null;
   sensitive: boolean;
+  validatable: boolean;
   satisfied: boolean;
   source: "env" | "vault" | "none";
   ref: string | null;
@@ -30,6 +31,8 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [loaded, setLoaded] = useState(false);
   const [busyKey, setBusyKey] = useState<string | null>(null);
+  type ValidationResult = { state: "idle" | "testing" | "valid" | "invalid"; message?: string };
+  const [results, setResults] = useState<Record<string, ValidationResult>>({});
   const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
@@ -57,6 +60,28 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
 
   const allSatisfied = fields.length > 0 && fields.every((f) => f.satisfied);
 
+  const validate = useCallback(async (field: FieldStatus) => {
+    if (!field.validatable) return;
+    setResults((r) => ({ ...r, [field.key]: { state: "testing" } }));
+    try {
+      const res = await fetch("/api/marketplace/config/validate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: pluginId, key: field.key }),
+      });
+      const json = (await res.json()) as { ok?: boolean; valid?: boolean; login?: string | null; error?: string | null };
+      if (!json.ok) throw new Error(json.error ?? "validation failed");
+      setResults((r) => ({
+        ...r,
+        [field.key]: json.valid
+          ? { state: "valid", message: json.login ? `Valid — @${json.login}` : "Valid" }
+          : { state: "invalid", message: json.error ?? "Invalid" },
+      }));
+    } catch (err) {
+      setResults((r) => ({ ...r, [field.key]: { state: "invalid", message: err instanceof Error ? err.message : "validation failed" } }));
+    }
+  }, [pluginId]);
+
   const save = useCallback(async (field: FieldStatus) => {
     const draft = (drafts[field.key] ?? "").trim();
     if (!draft) return;
@@ -83,12 +108,13 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
       setDrafts((d) => ({ ...d, [field.key]: "" }));
       await load();
       onChanged();
+      if (field.validatable) void validate(field);
     } catch (err) {
       setError(err instanceof Error ? err.message : "save failed");
     } finally {
       setBusyKey(null);
     }
-  }, [drafts, pluginId, load, onChanged]);
+  }, [drafts, pluginId, load, onChanged, validate]);
 
   return (
     <Modal
@@ -139,7 +165,23 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
                 >
                   Save
                 </Button>
+                {f.validatable ? (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    loading={results[f.key]?.state === "testing"}
+                    onClick={() => void validate(f)}
+                  >
+                    Test
+                  </Button>
+                ) : null}
               </div>
+              {results[f.key] && results[f.key].state !== "idle" && results[f.key].state !== "testing" ? (
+                <p className={`inline-flex items-center gap-1 text-[11px] ${results[f.key].state === "valid" ? "text-[var(--text-primary)]" : "text-[var(--text-muted)]"}`}>
+                  <Icon name={results[f.key].state === "valid" ? "ph:check-circle" : "ph:warning"} width={11} aria-hidden />
+                  {results[f.key].message}
+                </p>
+              ) : null}
               {f.sensitive ? (
                 <p className="text-[10px] text-[var(--text-muted)]">
                   Requires the 1Password CLI (op). Manage refs in Settings → Vault.

--- a/src/lib/secret-validators.test.ts
+++ b/src/lib/secret-validators.test.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { hasValidator, validateSecret, validateGithubToken } from "./secret-validators.ts";
+
+const fakeFetch = (status, jsonBody) => async () => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => jsonBody,
+});
+const throwingFetch = async () => { throw new Error("network down"); };
+
+assert.equal(hasValidator("GITHUB_PERSONAL_ACCESS_TOKEN"), true);
+assert.equal(hasValidator("COVEN_MCP_FILESYSTEM_ROOT"), false);
+assert.equal(hasValidator("NOPE"), false);
+
+let r = await validateGithubToken("tok", fakeFetch(200, { login: "octocat" }));
+assert.deepEqual(r, { ok: true, login: "octocat" });
+
+r = await validateGithubToken("tok", fakeFetch(200, {}));
+assert.equal(r.ok, true);
+assert.equal(r.login, undefined);
+
+r = await validateGithubToken("tok", fakeFetch(401, {}));
+assert.equal(r.ok, false);
+assert.match(r.error, /rejected/i);
+
+r = await validateGithubToken("tok", fakeFetch(403, {}));
+assert.equal(r.ok, false);
+
+r = await validateGithubToken("tok", fakeFetch(500, {}));
+assert.equal(r.ok, false);
+assert.match(r.error, /500/);
+
+r = await validateGithubToken("tok", throwingFetch);
+assert.equal(r.ok, false);
+assert.match(r.error, /reach/i);
+
+const vs = await validateSecret("GITHUB_PERSONAL_ACCESS_TOKEN", "tok", fakeFetch(200, { login: "me" }));
+assert.deepEqual(vs, { ok: true, login: "me" });
+
+const none = await validateSecret("UNKNOWN_ENV", "x", fakeFetch(200, {}));
+assert.equal(none.ok, false);
+assert.match(none.error, /no validator/i);
+
+console.log("secret-validators.test.ts: ok");

--- a/src/lib/secret-validators.ts
+++ b/src/lib/secret-validators.ts
@@ -1,0 +1,48 @@
+/**
+ * Pluggable secret validators for Marketplace credential collection. Keyed by
+ * env var. Each validator takes the resolved secret value and an injectable
+ * fetch (so it's unit-testable without the network) and returns pass/fail +
+ * an optional detail. The secret value is never logged or returned.
+ */
+
+export type SecretValidation = { ok: boolean; login?: string; error?: string };
+type FetchLike = typeof fetch;
+type Validator = (value: string, fetchImpl: FetchLike) => Promise<SecretValidation>;
+
+export async function validateGithubToken(value: string, fetchImpl: FetchLike): Promise<SecretValidation> {
+  try {
+    const res = await fetchImpl("https://api.github.com/user", {
+      headers: {
+        Authorization: `Bearer ${value}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      cache: "no-store",
+    });
+    if (res.status === 401 || res.status === 403) return { ok: false, error: "token rejected by GitHub" };
+    if (!res.ok) return { ok: false, error: `GitHub API error (${res.status})` };
+    const data = await res.json().catch(() => null);
+    return { ok: true, login: data?.login ?? undefined };
+  } catch {
+    return { ok: false, error: "could not reach GitHub" };
+  }
+}
+
+const VALIDATORS: Record<string, Validator> = {
+  GITHUB_PERSONAL_ACCESS_TOKEN: validateGithubToken,
+};
+
+export function hasValidator(env: string): boolean {
+  return Object.prototype.hasOwnProperty.call(VALIDATORS, env);
+}
+
+/** Run the registered validator for `env`; defaults fetchImpl to global fetch. */
+export async function validateSecret(
+  env: string,
+  value: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<SecretValidation> {
+  const validator = VALIDATORS[env];
+  if (!validator) return { ok: false, error: "no validator for this field" };
+  return validator(value, fetchImpl);
+}


### PR DESCRIPTION
Adds **advisory** live validation for the github plugin token in the Marketplace Configure modal. Builds on credential collection (#1839).

### What's here
- **Validator registry** `src/lib/secret-validators.ts` — keyed by env var, GitHub-only for now. `validateGithubToken` checks `https://api.github.com/user` (Bearer) and returns pass/fail + login. Injectable `fetchImpl` → unit-tested without the network.
- **`POST /api/marketplace/config/validate {id,key}`** — resolves the field's secret **server-side** (`resolveSecret`: vault `op://` or `.env.local`) and runs its validator. Returns `{ ok, valid, login, error }`; **the token value is never returned or logged**.
- Extracted the path-injection-safe catalog lookup to `catalog-config.ts` (shared by both config routes); `GET /api/marketplace/config` now reports `validatable`.
- **Configure modal**: a **Test** button on validatable fields + auto-validate after a successful save; inline ✓ `Valid — @login` / ✗ error.

### Advisory
Validation does **not** gate the "Configured" chip (still driven by the secret resolving) — robust to GitHub outages/rate-limits.

### Verified
- `secret-validators.test.ts` (injected fetch: 200/401/403/500/throw) + `api-contracts` (126) + full app suite (408) green; `pnpm build` ✅.
- Live: github field shows **Test**; full resolve→GitHub round-trip works (a bogus token → "token rejected by GitHub"); response carries no token; no-validator field and a path-traversal id both 400.

Scope (v1): no scope inspection (just "token works"), GitHub-only (registry-ready), advisory. Spec/plan in `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)