### PR TITLE
feat(flow): live per-node execution overlay

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -55,6 +55,7 @@ export const SUITES = {
     "src/lib/flow/flow-doc.test.ts",
     "src/lib/flow/flow-catalog.test.ts",
     "src/lib/flow/flow-compile.test.ts",
+    "src/lib/flow/flow-progress.test.ts",
     "src/lib/workflow-source.test.ts",
     "src/lib/workflow-edit.test.ts",
     "src/lib/workflow-draft.test.ts",
@@ -597,6 +598,7 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/lib/flow/flow-progress.test.ts",
   "src/lib/familiar-card-data.test.ts",
   "src/lib/dashboard-model.test.ts",
   "src/lib/slash-commands.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -54,7 +54,7 @@ const contracts: RouteContract[] = [
   { route: "/github/assigned", methods: ["GET"], kind: "json" },
   { route: "/flows", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/flows/run", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
-  { route: "/flows/runs", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/flows/runs", methods: ["GET", "POST", "PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/github/comment", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/github/comments", methods: ["GET"], kind: "json" },
   { route: "/github/item", methods: ["GET"], kind: "json" },

--- a/src/app/api/flows/runs/route.ts
+++ b/src/app/api/flows/runs/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { clearFlowRuns, listFlowRuns, recordFlowRun } from "@/lib/server/flow-store";
+import { clearFlowRuns, listFlowRuns, recordFlowRun, updateFlowRun } from "@/lib/server/flow-store";
 import type { FlowRunRecord } from "@/lib/flows";
 
 export const dynamic = "force-dynamic";
@@ -39,6 +39,29 @@ export async function POST(req: Request) {
     sessionId: typeof body.sessionId === "string" ? body.sessionId : undefined,
   });
   return NextResponse.json({ ok: true, run });
+}
+
+/** Patch a run as it finishes (status / steps / finishedAt). */
+export async function PATCH(req: Request) {
+  let body: { id?: string } & Partial<Omit<FlowRunRecord, "id">>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 });
+  }
+  if (!body.id || typeof body.id !== "string") {
+    return NextResponse.json({ ok: false, error: "id required" }, { status: 400 });
+  }
+  if (body.status && !STATUSES.has(body.status)) {
+    return NextResponse.json({ ok: false, error: "invalid status" }, { status: 400 });
+  }
+  const patch: Partial<Omit<FlowRunRecord, "id">> = {};
+  if (body.status) patch.status = body.status;
+  if (Array.isArray(body.steps)) patch.steps = body.steps;
+  if (typeof body.finishedAt === "string") patch.finishedAt = body.finishedAt;
+  if (typeof body.summary === "string") patch.summary = body.summary;
+  const run = await updateFlowRun(body.id, patch);
+  return NextResponse.json({ ok: Boolean(run), run: run ?? undefined });
 }
 
 /** Clear run history — one flow's runs (`?flowId=`) or the whole store. */

--- a/src/components/flow/flow-node.tsx
+++ b/src/components/flow/flow-node.tsx
@@ -4,9 +4,10 @@ import { Handle, Position, type NodeProps, type Node } from "@xyflow/react";
 import { Icon } from "@/lib/icon";
 import type { FlowNodeType } from "@/lib/flow/flow-catalog";
 import type { FlowNode } from "@/lib/flow/flow-doc";
+import type { FlowNodePhase } from "@/lib/flow/flow-progress";
 
 /** Live run phase overlaid by the canvas while an execution/preview walks. */
-export type FlowNodePhase = "pending" | "running" | "succeeded" | "failed" | "skipped";
+export type { FlowNodePhase };
 
 export type FlowNodeData = {
   node: FlowNode;

--- a/src/components/flow/flow-toolbar.tsx
+++ b/src/components/flow/flow-toolbar.tsx
@@ -14,6 +14,8 @@ export type FlowToolbarProps = {
   tab: FlowTab;
   saving: boolean;
   executing: boolean;
+  /** A live agent-session run is in progress — show Stop instead of Execute. */
+  running: boolean;
   onRename: (name: string) => void;
   onToggleActive: () => void;
   onTab: (tab: FlowTab) => void;
@@ -21,6 +23,7 @@ export type FlowToolbarProps = {
   onRedo: () => void;
   onSave: () => void;
   onExecute: () => void;
+  onStop: () => void;
 };
 
 export function FlowToolbar(props: FlowToolbarProps) {
@@ -95,15 +98,22 @@ export function FlowToolbar(props: FlowToolbarProps) {
         >
           {props.saving ? "Saving…" : "Save"}
         </button>
-        <button
-          type="button"
-          className="flow-toolbar-execute"
-          onClick={props.onExecute}
-          disabled={props.executing}
-        >
-          <Icon name="ph:play" width={13} />
-          {props.executing ? "Running…" : "Execute"}
-        </button>
+        {props.running ? (
+          <button type="button" className="flow-toolbar-stop" onClick={props.onStop}>
+            <span className="flow-toolbar-stop-spinner" aria-hidden />
+            Stop
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="flow-toolbar-execute"
+            onClick={props.onExecute}
+            disabled={props.executing}
+          >
+            <Icon name="ph:play" width={13} />
+            {props.executing ? "Running…" : "Execute"}
+          </button>
+        )}
       </div>
     </header>
   );

--- a/src/components/flow/flow-view.tsx
+++ b/src/components/flow/flow-view.tsx
@@ -31,6 +31,7 @@ import {
   type FlowStickyData,
 } from "@/lib/flow/flow-doc";
 import { flowRunBlockReason } from "@/lib/flow/flow-compile";
+import { finalizeFlowSteps } from "@/lib/flow/flow-progress";
 import {
   clearFlowRuns,
   deleteFlow,
@@ -39,6 +40,7 @@ import {
   recordFlowRun,
   runFlow,
   saveFlow,
+  updateFlowRun,
   type FlowRunRecord,
 } from "@/lib/flows";
 import { FlowCanvas } from "./flow-canvas";
@@ -47,6 +49,7 @@ import { FlowLibrary } from "./flow-library";
 import { FlowToolbar, type FlowTab } from "./flow-toolbar";
 import { NodeCatalogPanel } from "./node-catalog-panel";
 import { NodeDetailView, type NodeDetailOption } from "./node-detail-view";
+import { useFlowRun } from "./use-flow-run";
 
 function slugifyFlowId(name: string): string {
   return (
@@ -76,6 +79,13 @@ export function FlowView() {
   const [runsLoading, setRunsLoading] = useState(false);
   const [familiars, setFamiliars] = useState<Familiar[]>([]);
   const [skills, setSkills] = useState<string[]>([]);
+  // The run currently overlaid on the canvas (live session, or a finished run
+  // whose final state we keep painted until the user switches flows).
+  const [activeRun, setActiveRun] = useState<FlowRunRecord | null>(null);
+
+  // Live per-node phases parsed from the active run's agent-session transcript.
+  const progress = useFlowRun(activeRun);
+  const running = activeRun?.status === "running" && !progress.done;
 
   const addPositionRef = useRef<FlowPosition>({ x: 160, y: 160 });
   const mountedRef = useRef(true);
@@ -137,7 +147,15 @@ export function FlowView() {
     setRunsLoading(true);
     try {
       const result = await listFlowRuns(flowId);
-      if (mountedRef.current) setRuns(result.ok ? result.runs : []);
+      if (!mountedRef.current) return;
+      const list = result.ok ? result.runs : [];
+      setRuns(list);
+      // Resume the live overlay if the newest run is still running and we aren't
+      // already tracking one (e.g. returning to a flow whose execution is live).
+      const top = list[0];
+      if (top?.status === "running" && top.sessionId) {
+        setActiveRun((current) => current ?? top);
+      }
     } finally {
       if (mountedRef.current) setRunsLoading(false);
     }
@@ -168,6 +186,20 @@ export function FlowView() {
   useEffect(() => {
     if (selectedId) void loadRuns(selectedId);
   }, [selectedId, loadRuns]);
+
+  // When the live run's markers report every node resolved, finalize it once:
+  // freeze the overlay at its final colours and persist the verdict + steps.
+  useEffect(() => {
+    if (!activeRun || activeRun.status !== "running" || !progress.done) return;
+    const { steps, status } = finalizeFlowSteps(activeRun.steps, progress.steps);
+    const finishedAt = new Date().toISOString();
+    const finalized: FlowRunRecord = { ...activeRun, status, steps, finishedAt };
+    setActiveRun(finalized); // status flips off "running" → polling stops
+    void updateFlowRun(activeRun.id, { status, steps, finishedAt }).then(() => {
+      if (selectedId) void loadRuns(selectedId);
+    });
+    showNotice(status === "succeeded" ? "Flow finished." : "Flow finished with a failed step.");
+  }, [progress.done, progress.steps, activeRun, selectedId, loadRuns, showNotice]);
 
   const familiarOptions = useMemo<NodeDetailOption[]>(
     () =>
@@ -218,6 +250,7 @@ export function FlowView() {
       if (!flow) return;
       setSelectedId(id);
       setSelectedNodeId(null);
+      setActiveRun(null);
       setTab("editor");
       dispatchDraft({ type: "reset", doc: flow });
     },
@@ -240,6 +273,7 @@ export function FlowView() {
     await loadFlows();
     setSelectedId(result.flow.id);
     setSelectedNodeId(null);
+    setActiveRun(null);
     setTab("editor");
     dispatchDraft({ type: "reset", doc: result.flow });
     showNotice("New flow created.");
@@ -266,6 +300,7 @@ export function FlowView() {
       }
       await loadFlows();
       setSelectedId(result.flow.id);
+      setActiveRun(null);
       dispatchDraft({ type: "reset", doc: result.flow });
       showNotice(`Duplicated as ${result.flow.name}.`);
     },
@@ -353,19 +388,39 @@ export function FlowView() {
         showNotice(result.error ?? "couldn't start the flow");
         return;
       }
-      await loadRuns(doc.id);
-      setTab("executions");
-      if (result.sessionId) {
-        showNotice("Running as a live agent session — open it from Executions.");
+      if (result.run && result.sessionId) {
+        // Live session run — overlay it on the canvas and stay on the editor so
+        // the nodes light up as the agent works through them.
+        setActiveRun(result.run);
+        setSelectedNodeId(null);
+        setTab("editor");
+        showNotice("Running — watch the nodes light up, or open the session in Chat.");
       } else {
         showNotice("Execution started.");
       }
+      await loadRuns(doc.id);
     } catch (err) {
       showNotice(err instanceof Error ? err.message : "run failed");
     } finally {
       setExecuting(false);
     }
   }, [dirty, dispatchDraft, doc, loadRuns, recordFlowRun, runFlow, saveFlow, showNotice]);
+
+  const stop = useCallback(async () => {
+    if (!activeRun) return;
+    if (activeRun.sessionId) {
+      await fetch(`/api/sessions/${encodeURIComponent(activeRun.sessionId)}/kill`, { method: "POST" }).catch(
+        () => undefined,
+      );
+    }
+    const finishedAt = new Date().toISOString();
+    const stopped: FlowRunRecord = { ...activeRun, status: "failed", finishedAt, summary: "stopped" };
+    setActiveRun(stopped);
+    void updateFlowRun(activeRun.id, { status: "failed", finishedAt, summary: "stopped" }).then(() => {
+      if (selectedId) void loadRuns(selectedId);
+    });
+    showNotice("Flow stopped.");
+  }, [activeRun, loadRuns, selectedId, showNotice]);
 
   const openSession = useCallback((sessionId: string) => {
     if (typeof window !== "undefined") window.location.hash = `chat-${sessionId}`;
@@ -466,6 +521,8 @@ export function FlowView() {
               onRedo={() => dispatchDraft({ type: "redo" })}
               onSave={() => void save()}
               onExecute={() => void execute()}
+              running={running}
+              onStop={() => void stop()}
             />
 
             {notice && <div className="flow-notice" role="status">{notice}</div>}
@@ -475,8 +532,8 @@ export function FlowView() {
                 <FlowCanvas
                   doc={doc}
                   selectedNodeId={selectedNodeId}
-                  phases={null}
-                  activeNodeId={null}
+                  phases={activeRun ? progress.phases : null}
+                  activeNodeId={running ? progress.activeNodeId : null}
                   viewResetKey={viewResetKey}
                   onSelectNode={setSelectedNodeId}
                   onOpenNode={setSelectedNodeId}

--- a/src/components/flow/use-flow-run.ts
+++ b/src/components/flow/use-flow-run.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { parseFlowRunProgress, type FlowRunProgress } from "@/lib/flow/flow-progress";
+import type { FlowRunRecord } from "@/lib/flows";
+
+const POLL_MS = 2500;
+
+const EMPTY: FlowRunProgress = {
+  phases: {},
+  activeNodeId: null,
+  done: false,
+  markersFound: false,
+  steps: [],
+};
+
+/**
+ * Live node-phase progress for an active flow run. Polls the run's agent
+ * session transcript (the same `/api/chat/conversation/[id]` endpoint the
+ * Workflow Studio uses) and parses the `@@step-…` markers into per-node phases.
+ * Polling stops once the run is no longer `running` or every node has resolved,
+ * keeping the last parsed phases so the canvas holds the finished state.
+ */
+export function useFlowRun(run: FlowRunRecord | null): FlowRunProgress {
+  const sessionId = run?.sessionId ?? null;
+  const live = run?.status === "running";
+  const [transcript, setTranscript] = useState("");
+
+  useEffect(() => {
+    if (!sessionId) {
+      setTranscript("");
+      return;
+    }
+    let alive = true;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const tick = async () => {
+      try {
+        const res = await fetch(`/api/chat/conversation/${encodeURIComponent(sessionId)}`, {
+          cache: "no-store",
+        });
+        const json = (await res.json().catch(() => null)) as
+          | { ok?: boolean; conversation?: { turns?: Array<{ role?: string; text?: string }> } }
+          | null;
+        if (!alive) return;
+        if (json?.ok && Array.isArray(json.conversation?.turns)) {
+          const text = json.conversation.turns
+            .filter((turn) => turn.role === "assistant")
+            .map((turn) => turn.text ?? "")
+            .join("\n");
+          setTranscript(text);
+        }
+      } catch {
+        // transient — keep the last transcript and retry on the next tick
+      }
+      if (alive && live) timer = setTimeout(tick, POLL_MS);
+    };
+    void tick();
+    return () => {
+      alive = false;
+      if (timer) clearTimeout(timer);
+    };
+  }, [sessionId, live]);
+
+  if (!run) return EMPTY;
+  return parseFlowRunProgress(transcript, run.steps.map((step) => step.id));
+}

--- a/src/lib/flow/flow-progress.test.ts
+++ b/src/lib/flow/flow-progress.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { finalizeFlowSteps, flowPhase, parseFlowRunProgress } from "./flow-progress.ts";
+import type { FlowRunStepRecord } from "../flows.ts";
+
+// flowPhase mapping
+{
+  assert.equal(flowPhase("active"), "running");
+  assert.equal(flowPhase("pending"), "pending");
+  assert.equal(flowPhase("succeeded"), "succeeded");
+  assert.equal(flowPhase("failed"), "failed");
+}
+
+const ORDER = ["t", "a", "b"];
+
+// mid-run: t done, a running, b pending
+{
+  const transcript = ["@@step-start t", "...did t...", "@@step-done t", "@@step-start a", "...working on a..."].join("\n");
+  const p = parseFlowRunProgress(transcript, ORDER);
+  assert.equal(p.phases.t, "succeeded");
+  assert.equal(p.phases.a, "running");
+  assert.equal(p.phases.b, "pending");
+  assert.equal(p.activeNodeId, "a");
+  assert.equal(p.done, false);
+  assert.equal(p.markersFound, true);
+}
+
+// complete run with a failure
+{
+  const transcript = [
+    "@@step-start t",
+    "@@step-done t",
+    "@@step-start a",
+    "@@step-done a",
+    "@@step-start b",
+    "@@step-fail b",
+  ].join("\n");
+  const p = parseFlowRunProgress(transcript, ORDER);
+  assert.equal(p.done, true);
+  assert.equal(p.phases.b, "failed");
+  assert.equal(p.activeNodeId, null);
+}
+
+// no markers → all pending, not done
+{
+  const p = parseFlowRunProgress("the agent rambled without markers", ORDER);
+  assert.equal(p.markersFound, false);
+  assert.equal(p.done, false);
+  assert.deepEqual(Object.values(p.phases), ["pending", "pending", "pending"]);
+}
+
+// finalizeFlowSteps: preserves type, maps statuses, overall verdict
+{
+  const runSteps: FlowRunStepRecord[] = [
+    { id: "t", type: "trigger.manual", status: "pending" },
+    { id: "a", type: "familiar", status: "pending" },
+    { id: "b", type: "data.output", status: "pending" },
+  ];
+  const transcript = ["@@step-start t", "@@step-done t", "@@step-start a", "@@step-done a"].join("\n");
+  const progress = parseFlowRunProgress(transcript, ORDER);
+  const final = finalizeFlowSteps(runSteps, progress.steps);
+  assert.equal(final.steps.find((s) => s.id === "t")?.status, "succeeded");
+  assert.equal(final.steps.find((s) => s.id === "t")?.type, "trigger.manual", "type preserved");
+  assert.equal(final.steps.find((s) => s.id === "b")?.status, "skipped", "never-started → skipped");
+  assert.equal(final.status, "succeeded");
+
+  const failTranscript = ["@@step-start t", "@@step-fail t"].join("\n");
+  const failProgress = parseFlowRunProgress(failTranscript, ORDER);
+  assert.equal(finalizeFlowSteps(runSteps, failProgress.steps).status, "failed");
+}
+
+console.log("flow-progress.test.ts OK");

--- a/src/lib/flow/flow-progress.ts
+++ b/src/lib/flow/flow-progress.ts
@@ -1,0 +1,70 @@
+// Map a running flow's agent-session transcript onto live per-node phases.
+//
+// A flow runs as one agent session that prints `@@step-start/done/fail <id>`
+// markers (see flow-compile.ts) — the same protocol the Workflow Studio uses.
+// This reuses the shared marker parser and projects its step statuses onto the
+// Flow editor's node-phase vocabulary so the canvas can light nodes up live.
+
+import {
+  parseWorkflowStepProgress,
+  type WorkflowStepProgress,
+  type WorkflowStepProgressStatus,
+} from "@/lib/workflow-step-progress";
+import type { FlowRunStepRecord, FlowRunStepStatus, FlowRunStatus } from "@/lib/flows";
+
+/** Phase overlaid on a canvas node while a run/preview walks the graph. */
+export type FlowNodePhase = "pending" | "running" | "succeeded" | "failed" | "skipped";
+
+/** Live marker status → canvas phase. `active` reads as "running". */
+export function flowPhase(status: WorkflowStepProgressStatus): FlowNodePhase {
+  return status === "active" ? "running" : status;
+}
+
+export type FlowRunProgress = {
+  phases: Record<string, FlowNodePhase>;
+  activeNodeId: string | null;
+  done: boolean;
+  markersFound: boolean;
+  steps: WorkflowStepProgress[];
+};
+
+/**
+ * Parse the transcript into per-node phases for the canvas overlay.
+ * `orderedNodeIds` is the run's step ids in execution order.
+ */
+export function parseFlowRunProgress(transcript: string, orderedNodeIds: string[]): FlowRunProgress {
+  const result = parseWorkflowStepProgress(transcript, orderedNodeIds);
+  const phases: Record<string, FlowNodePhase> = {};
+  for (const step of result.steps) phases[step.id] = flowPhase(step.status);
+  return {
+    phases,
+    activeNodeId: result.activeStepId,
+    done: result.done,
+    markersFound: result.markersFound,
+    steps: result.steps,
+  };
+}
+
+/** Live marker status → persisted run-step status (for a finished run). */
+function finalStepStatus(status: WorkflowStepProgressStatus | undefined): FlowRunStepStatus {
+  if (status === "succeeded") return "succeeded";
+  if (status === "failed") return "failed";
+  if (status === "active") return "running";
+  // Never reached (no start marker) → skipped.
+  return "skipped";
+}
+
+/**
+ * Roll a completed run's parsed progress into persisted step records (matched
+ * to the run's existing steps so node types are preserved) plus an overall
+ * verdict: failed if any node failed, otherwise succeeded.
+ */
+export function finalizeFlowSteps(
+  runSteps: FlowRunStepRecord[],
+  progressSteps: WorkflowStepProgress[],
+): { steps: FlowRunStepRecord[]; status: FlowRunStatus } {
+  const byId = new Map(progressSteps.map((step) => [step.id, step.status]));
+  const steps = runSteps.map((step) => ({ ...step, status: finalStepStatus(byId.get(step.id)) }));
+  const status: FlowRunStatus = steps.some((step) => step.status === "failed") ? "failed" : "succeeded";
+  return { steps, status };
+}

--- a/src/lib/flows.ts
+++ b/src/lib/flows.ts
@@ -93,6 +93,18 @@ export async function recordFlowRun(input: Omit<FlowRunRecord, "id">): Promise<{
   return readJson<{ ok: boolean; run?: FlowRunRecord }>(response);
 }
 
+export async function updateFlowRun(
+  id: string,
+  patch: Partial<Pick<FlowRunRecord, "status" | "steps" | "finishedAt" | "summary">>,
+): Promise<{ ok: boolean; run?: FlowRunRecord }> {
+  const response = await fetch("/api/flows/runs", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ id, ...patch }),
+  });
+  return readJson<{ ok: boolean; run?: FlowRunRecord }>(response);
+}
+
 export async function clearFlowRuns(flowId: string): Promise<{ ok: boolean; cleared?: number }> {
   const response = await fetch(`/api/flows/runs?flowId=${encodeURIComponent(flowId)}`, {
     method: "DELETE",

--- a/src/lib/server/flow-store.ts
+++ b/src/lib/server/flow-store.ts
@@ -146,6 +146,27 @@ export async function listFlowRuns(flowId?: string): Promise<FlowRunRecord[]> {
   return file.runs.filter((run) => run.flowId === flowId);
 }
 
+/**
+ * Patch an existing run in place (status/steps/finishedAt as a run finishes).
+ * The run id is immutable; everything else is shallow-merged. Returns the
+ * updated record, or null if no run matched.
+ */
+export async function updateFlowRun(
+  id: string,
+  patch: Partial<Omit<FlowRunRecord, "id">>,
+): Promise<FlowRunRecord | null> {
+  return withRunsLock(async () => {
+    const file = await loadRunsFile();
+    const index = file.runs.findIndex((run) => run.id === id);
+    if (index < 0) return null;
+    const updated: FlowRunRecord = { ...file.runs[index], ...patch, id };
+    file.runs[index] = updated;
+    await mkdir(path.dirname(runsPath()), { recursive: true });
+    await writeJsonAtomic(runsPath(), file);
+    return updated;
+  });
+}
+
 export async function clearFlowRuns(flowId?: string): Promise<number> {
   return withRunsLock(async () => {
     const file = await loadRunsFile();

--- a/src/styles/flow.css
+++ b/src/styles/flow.css
@@ -105,6 +105,9 @@
 .flow-toolbar-execute { display: inline-flex; align-items: center; gap: 5px; padding: 5px 14px; font-size: var(--text-sm); font-weight: 600; border: 1px solid color-mix(in oklch, var(--accent-presence) 60%, transparent); border-radius: var(--radius-control); background: color-mix(in oklch, var(--accent-presence) 26%, var(--bg-elevated)); color: var(--text-primary); cursor: pointer; }
 .flow-toolbar-execute:hover:not(:disabled) { background: color-mix(in oklch, var(--accent-presence) 38%, var(--bg-elevated)); }
 .flow-toolbar-execute:disabled { opacity: 0.6; cursor: default; }
+.flow-toolbar-stop { display: inline-flex; align-items: center; gap: 6px; padding: 5px 14px; font-size: var(--text-sm); font-weight: 600; border: 1px solid color-mix(in oklch, var(--color-danger) 55%, transparent); border-radius: var(--radius-control); background: color-mix(in oklch, var(--color-danger) 22%, var(--bg-elevated)); color: var(--text-primary); cursor: pointer; }
+.flow-toolbar-stop:hover { background: color-mix(in oklch, var(--color-danger) 34%, var(--bg-elevated)); }
+.flow-toolbar-stop-spinner { width: 11px; height: 11px; border-radius: 50%; border: 2px solid color-mix(in oklch, var(--color-danger) 35%, transparent); border-top-color: var(--color-danger); animation: flow-spin 0.7s linear infinite; }
 
 .flow-notice { padding: 7px var(--space-3); font-size: var(--text-sm); color: var(--text-primary); background: color-mix(in oklch, var(--accent-presence) 16%, var(--bg-raised)); border-bottom: 1px solid var(--border-hairline); }
 


### PR DESCRIPTION
## What

PR 2 of the n8n-style Flow editor (builds on #1843). Lights up the canvas **as a flow runs** — n8n's signature live-execution view.

When you press **Execute**, the flow spawns one agent session that prints `@@step-start/done/fail <id>` markers. This PR polls that session's transcript, parses the markers, and overlays each node's live phase on the canvas:

- **pending** → **running** (amber dot + spinner + node glow) → **succeeded** (green) / **failed** (red)
- the edge feeding the active node animates
- the editor stays open during the run (instead of jumping to Executions) so you watch the graph light up
- **Execute** becomes a red **Stop** while a run is live (kills the session)

## How

- **`flow-progress.ts`** (pure, unit-tested) — reuses the shared `parseWorkflowStepProgress` marker parser (same one the Workflow Studio uses) and projects its statuses onto the editor's node-phase vocabulary. `finalizeFlowSteps` rolls a finished run into persisted step records + an overall verdict.
- **`useFlowRun`** hook — polls `/api/chat/conversation/[sessionId]` every 2.5s, stops once the run leaves `running` or every node resolves, keeps the last phases painted.
- **flow-view** — tracks the active run, feeds `phases`/`activeNodeId` to the canvas, finalizes once on completion (persists status + steps), **resumes** the overlay when reopening a flow whose run is still live, clears it on flow switch.
- **Run finalization persistence** — `updateFlowRun` store fn + `PATCH /api/flows/runs` + client helper (api-contracts updated).

## Verification

Confirmed the overlay end-to-end in the running app (route-mocked a live session transcript): the trigger node greens, the downstream Familiar node spins with a glow, the Stop button shows, and the "Running — watch the nodes light up" banner appears.

- ✅ `pnpm typecheck` — 0 errors
- ✅ `next build && pnpm build:server` — exit 0
- ✅ app suite (408 files) + api contracts (125 routes) green
- ✅ new `flow-progress` unit tests (active→running mapping, done detection, finalize verdict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)