### PR TITLE
fix(ios): accessibility pass — VoiceOver, Dynamic Type, reduce-motion

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -122,7 +122,10 @@ struct ChatView: View {
                             }
                         }
                 }
-                .accessibilityLabel("Linked tasks")
+                .accessibilityLabel({
+                    let n = app.linkedTasks(for: thread).count
+                    return n > 0 ? "Linked tasks, \(n)" : "Linked tasks"
+                }())
             }
             ToolbarItem(placement: .topBarTrailing) {
                 Button { showCommands = true } label: {

--- a/apps/ios/CovenCave/CovenCave/Views/ContentZoom.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ContentZoom.swift
@@ -71,7 +71,7 @@ struct ZoomableContentView: View {
                     Button { copy(text) } label: {
                         Label(copied ? "Copied" : "Copy",
                               systemImage: copied ? "checkmark" : "doc.on.doc")
-                            .font(.system(size: 14, weight: .semibold))
+                            .font(.callout.weight(.semibold))
                             .foregroundStyle(.white)
                             .padding(.horizontal, 12).padding(.vertical, 7)
                             .background(copied ? Color.green.opacity(0.85)

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -138,6 +138,7 @@ struct FamiliarThreadsView: View {
                     }
                 }
                     .buttonStyle(.plain)
+                    .accessibilityAddTraits(selectMode && isSelected(entry) ? .isSelected : [])
                     .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
                     // Only on-device threads can be renamed/deleted from here; a
                     // server-only session lives on the desktop, so its rows offer
@@ -255,13 +256,22 @@ struct FamiliarThreadsView: View {
     }
 
     @ViewBuilder private func selectionMark(for entry: Entry) -> some View {
+        // Decorative — selection state is announced via the row's .isSelected trait.
         if case .local(let thread) = entry {
             Image(systemName: selectedIds.contains(thread.id) ? "checkmark.circle.fill" : "circle")
                 .font(.title3)
                 .foregroundStyle(selectedIds.contains(thread.id) ? Color.accentColor : Color.secondary)
+                .accessibilityHidden(true)
         } else {
             Image(systemName: "circle").font(.title3).foregroundStyle(.quaternary)
+                .accessibilityHidden(true)
         }
+    }
+
+    /// Whether a (local) thread row is selected in select mode.
+    private func isSelected(_ entry: Entry) -> Bool {
+        if case .local(let thread) = entry { return selectedIds.contains(thread.id) }
+        return false
     }
 
     @ViewBuilder

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -157,6 +157,7 @@ struct MessageBubble: View {
                     .foregroundStyle(.secondary)
                     .opacity(Double(min(replyDrag / 50, 1)))
                     .padding(.leading, 14)
+                    .accessibilityHidden(true)
             }
         }
         .simultaneousGesture(replySwipe)
@@ -368,7 +369,8 @@ struct SuggestionPills: View {
                 Button { onTap(suggestion) } label: {
                     HStack(spacing: 5) {
                         if index == 0 {
-                            Image(systemName: "sparkle").font(.system(size: 10, weight: .semibold))
+                            Image(systemName: "sparkle").font(.caption2.weight(.semibold))
+                                .accessibilityHidden(true)
                         }
                         Text(suggestion)
                             .font(.caption.weight(.medium))

--- a/apps/ios/CovenCave/CovenCave/Views/ToastView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ToastView.swift
@@ -49,7 +49,7 @@ private struct ToastModifier: ViewModifier {
                     .id(message.id)
                     .onAppear { scheduleDismiss(message.id) }
                     // Tap to dismiss immediately.
-                    .onTapGesture { withAnimation(.snappy) { self.message = nil } }
+                    .onTapGesture { withAnimation(reduceMotion ? nil : .snappy) { self.message = nil } }
             }
         }
         .animation(reduceMotion ? nil : .snappy(duration: 0.28), value: message)


### PR DESCRIPTION
Bounded follow-ups from the iOS survey.

## Fixes
- **FamiliarThreadsView** — the select-mode checkmark is decorative (`.accessibilityHidden`) and the row now exposes selected state via the **`.isSelected` trait**, so VoiceOver announces selection instead of reading a bare "circle" glyph.
- **ChatView** — the linked-tasks toolbar button announces its **count** ("Linked tasks, 3") instead of just "Linked tasks".
- **ContentZoom** — the Copy button label uses **Dynamic Type** (`.callout`) instead of a hardcoded 14pt.
- **MessageBubble** — the swipe-to-reply arrow overlay and the leading ✦ sparkle on suggestion pills are marked decorative (`.accessibilityHidden`); the sparkle also scales (`.caption2`) instead of a fixed 10pt.
- **ToastView** — tap-to-dismiss now honors **Reduce Motion** (the appear path already did; dismiss didn't).

## Verified already-correct (no change)
- The unread-activity dot is covered by the row's combined accessibility label ("…unread…").

## Deferred (flagged)
- The attached-image remove button is an 18pt glyph on a 64pt thumbnail corner — a true 44pt target would overlap the image, and corner placement can't be visually checked headlessly, so it's left for a layout-aware pass.

## Verification
- `xcodebuild` for the iOS Simulator: **BUILD SUCCEEDED**; app launches and runs with no regression.
- Mobile (65) + app (407) source-text suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)