### PR TITLE
chore: scrub stray OpenMeow references

### DIFF
--- a/src/app/mockup/page.tsx
+++ b/src/app/mockup/page.tsx
@@ -81,7 +81,7 @@ const SETTINGS_NAV: Array<{ group: string; items: Array<{ id: string; label: str
     ],
   },
   {
-    group: "OpenMeow",
+    group: "Coven",
     items: [
       { id: "general", label: "General", icon: "ph:gear-six" },
       { id: "repositories", label: "Repositories", icon: "ph:git-branch", active: true },

--- a/src/lib/chat-projects.test.ts
+++ b/src/lib/chat-projects.test.ts
@@ -72,7 +72,7 @@ assert.deepEqual(
 
 assert.equal(chatProjectName("/work/alpha", projects), "Alpha");
 assert.equal(chatProjectName("/Users/x/repos/coven-cave", projects), "coven-cave");
-assert.equal(chatProjectName("C:\\repos\\open-meow", projects), "open-meow");
+assert.equal(chatProjectName("C:\\repos\\coven-tools", projects), "coven-tools");
 assert.equal(chatProjectName("/trailing/slash/", projects), "slash");
 assert.equal(chatProjectName(null, projects), "No project");
 assert.equal(chatProjectName("", projects), "No project");


### PR DESCRIPTION
OpenMeow is not an OpenCoven application; CastCodes is the canonical interface. Two stray references remained:

- `src/app/mockup/page.tsx` — settings sidebar group label "OpenMeow" → "Coven"
- `src/lib/chat-projects.test.ts` — Windows-path fixture `open-meow` → `coven-tools`

No runtime behavior changes. Mockup is a static design surface; the test fixture only exercises path parsing.

```
$ pnpm exec node --experimental-strip-types --test src/lib/chat-projects.test.ts
chat-projects.test.ts: ok
```