### PR TITLE
fix(a11y): coven floor — hidden-pause polling, load guard, reduced motion

### DIFF
--- a/src/components/coven-floor-table.test.ts
+++ b/src/components/coven-floor-table.test.ts
@@ -75,3 +75,24 @@ assert.doesNotMatch(
   /FamiliarStatusCard|grid grid-cols-1 gap-3 sm:grid-cols-2/,
   "CovenFloor should not keep the old card-grid Floor layout",
 );
+
+// ── Polling pauses when the tab is hidden + guards stale/unmounted writes ─────
+// Was: setInterval(load, 15_000) that kept fetching /api/coven-status in a
+// backgrounded tab, and load() with no request-id guard (setState-after-unmount).
+assert.match(
+  floor,
+  /setInterval\(\(\) => \{ if \(!document\.hidden\) void load\(\); \}, 15_000\)/,
+  "polling skips the fetch while the tab is hidden",
+);
+assert.match(floor, /addEventListener\("visibilitychange", onVisible\)/, "refetches when the tab becomes visible again");
+assert.match(floor, /removeEventListener\("visibilitychange", onVisible\)/, "the visibility listener is cleaned up");
+assert.match(floor, /const seq = \(loadSeqRef\.current \+= 1\)/, "each load takes a sequence number");
+assert.match(floor, /if \(seq !== loadSeqRef\.current\) return;/, "stale or post-unmount responses are dropped before setState");
+assert.match(floor, /loadSeqRef\.current = -1;/, "unmount parks the seq so in-flight loads are ignored");
+
+// ── Pulse animations respect prefers-reduced-motion ──────────────────────────
+assert.match(
+  floor,
+  /animate-ping[^"]*motion-reduce:hidden/,
+  "the live/active pulse rings are hidden under prefers-reduced-motion",
+);

--- a/src/components/coven-floor.tsx
+++ b/src/components/coven-floor.tsx
@@ -2,7 +2,7 @@
 
 import "@/styles/board.css";
 
-import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import type { CovenStatusResponse, FamiliarCard, SessionSummary } from "@/lib/coven-status-types";
 import { statusColor, statusLabel } from "@/lib/coven-status-types";
@@ -64,7 +64,7 @@ function StatusDot({ status }: { status: FamiliarCard["status"] }) {
   return (
     <span className="relative inline-flex h-2.5 w-2.5 items-center justify-center" aria-hidden>
       {pulse && (
-        <span className="absolute inline-flex h-full w-full animate-ping rounded-full opacity-60" style={{ backgroundColor: color }} />
+        <span className="absolute inline-flex h-full w-full animate-ping rounded-full opacity-60 motion-reduce:hidden" style={{ backgroundColor: color }} />
       )}
       <span className="relative inline-flex h-2 w-2 rounded-full" style={{ backgroundColor: color }} />
     </span>
@@ -247,10 +247,18 @@ export function CovenFloor() {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [showAllSessionIds, setShowAllSessionIds] = useState<Set<string>>(() => new Set());
 
+  // Request-id guard: only the latest load's response is applied. On unmount the
+  // ref is parked at -1 so an in-flight response is dropped rather than calling
+  // setState on a gone component.
+  const loadSeqRef = useRef(0);
+  useEffect(() => () => { loadSeqRef.current = -1; }, []);
+
   const load = useCallback(async () => {
+    const seq = (loadSeqRef.current += 1);
     try {
       const res = await fetch("/api/coven-status", { cache: "no-store" });
       const json = (await res.json()) as CovenStatusResponse | { ok: false; error: string };
+      if (seq !== loadSeqRef.current) return; // superseded or unmounted
       if (!json.ok) {
         setError((json as { ok: false; error: string }).error ?? "status load failed");
         return;
@@ -260,16 +268,25 @@ export function CovenFloor() {
       setComputedAt(data.computedAt);
       setError(null);
     } catch (err) {
+      if (seq !== loadSeqRef.current) return;
       setError(err instanceof Error ? err.message : "fetch failed");
     } finally {
-      setLoading(false);
+      if (seq === loadSeqRef.current) setLoading(false);
     }
   }, []);
 
   useEffect(() => {
     void load();
-    const t = setInterval(load, 15_000);
-    return () => clearInterval(t);
+    // Poll only while the tab is visible — a backgrounded window shouldn't keep
+    // hitting /api/coven-status every 15s. Refetch on re-show so the floor is
+    // fresh the moment the user returns.
+    const t = setInterval(() => { if (!document.hidden) void load(); }, 15_000);
+    const onVisible = () => { if (!document.hidden) void load(); };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      clearInterval(t);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
   }, [load]);
 
   const sortedFamiliars = useMemo(
@@ -305,7 +322,7 @@ export function CovenFloor() {
         <div className="mb-3 flex items-center justify-end gap-2">
           <span className="flex items-center gap-1.5">
             <span className="relative inline-flex h-2 w-2">
-              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[var(--color-success)] opacity-60" />
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[var(--color-success)] opacity-60 motion-reduce:hidden" />
               <span className="relative inline-flex h-2 w-2 rounded-full bg-[var(--color-success)]" />
             </span>
             <span className="text-[10px] text-[var(--text-muted)]">live</span>


### PR DESCRIPTION
## Coven Floor audit

`CovenFloor` (the "Floor" tab of Calls) is well-structured — semantic table, a real `<button>` with `aria-expanded`/`aria-label` for the disclosure, decorative dots `aria-hidden`, honest "Show all N" session cap, loading skeleton + error banner. Three issues remained, all recurring classes:

### 1. Polling pauses when the tab is hidden
`setInterval(load, 15_000)` kept hitting `/api/coven-status` even in a backgrounded window. Now it skips the fetch while `document.hidden` and refetches on `visibilitychange`.

### 2. `load()` drops stale / post-unmount responses
No request-id guard meant a response resolving after unmount called `setFamiliars`/`setError`/`setLoading` on a gone component. Added a seq guard (parked at `-1` on unmount), including in the `finally` that clears `loading`.

### 3. Pulse animations respect `prefers-reduced-motion`
The "live" indicator and the active-familiar `StatusDot` pulsed with `animate-ping` regardless of motion preference. Added `motion-reduce:hidden` to the ping rings (the solid dot remains) — matching the repo's existing reduced-motion convention (`project-row.tsx`, several CSS files).

## Verification
- `coven-floor-table.test.ts` extended for all three (passes) · `tsc` clean · `pnpm build` clean
- (Worktree note: the original `.worktrees/coven-floor` was pruned mid-work by the periodic branch-consolidation automation before any commit; recreated in an external sibling dir per the documented workaround. No work lost.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)