### PR TITLE
feat(ios): Journal surface — daily reflections (read-only)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/Journal.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/Journal.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// One day in the journal list (`GET /api/journal` → `days`). Only the fields
+/// the app shows are modelled.
+struct JournalDay: Identifiable, Codable, Hashable {
+    let date: String          // yyyy-MM-dd
+    var preview: String?
+    var reflectedBy: String?
+    var modified: String?
+    var id: String { date }
+}
+
+/// A day's reflection (`GET /api/journal?date=` → `entry`). The route always
+/// returns an `entry` (empty reflection when the day has none).
+struct JournalEntry: Codable, Hashable {
+    var reflectedBy: String?
+    var generatedAt: String?
+    var reflection: String
+}
+
+struct JournalDaysResponse: Decodable { let ok: Bool; let days: [JournalDay] }
+struct JournalDayResponse: Decodable { let ok: Bool; let exists: Bool; let entry: JournalEntry }

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -397,6 +397,30 @@ struct CaveClient {
         }
     }
 
+    /// `GET /api/journal` — the list of days that have a reflection.
+    func journalDays() async throws -> [JournalDay] {
+        let req = try request("api/journal")
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        do {
+            return try JSONDecoder().decode(JournalDaysResponse.self, from: data).days
+        } catch {
+            throw CaveError.decoding(String(describing: error))
+        }
+    }
+
+    /// `GET /api/journal?date=yyyy-MM-dd` — one day's reflection.
+    func journalDay(date: String) async throws -> JournalEntry {
+        let req = try request("api/journal?date=\(urlQuery(date))")
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        do {
+            return try JSONDecoder().decode(JournalDayResponse.self, from: data).entry
+        } catch {
+            throw CaveError.decoding(String(describing: error))
+        }
+    }
+
     /// `DELETE /api/inbox/{id}` — remove a reminder.
     func deleteReminder(id: String) async throws {
         let escaped = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -107,6 +107,10 @@ final class AppModel {
     var remindersError: String?
     var remindersLoaded = false
 
+    var journalDays: [JournalDay] = []
+    var journalError: String?
+    var journalLoaded = false
+
     // MARK: - Developer tab
 
     /// Configured project roots, shared across the Code and Terminal surfaces.
@@ -356,6 +360,17 @@ final class AppModel {
             remindersError = error.localizedDescription
         }
         remindersLoaded = true
+    }
+
+    func loadJournal() async {
+        guard let client else { return }
+        do {
+            journalDays = try await client.journalDays()
+            journalError = nil
+        } catch {
+            journalError = error.localizedDescription
+        }
+        journalLoaded = true
     }
 
     /// Optimistically remove reminders, then DELETE each; reverts on failure.

--- a/apps/ios/CovenCave/CovenCave/Views/CalendarView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/CalendarView.swift
@@ -11,12 +11,19 @@ struct CalendarView: View {
     @State private var taskSelection: BoardCard?
     /// A reminder awaiting delete confirmation (swipe or context menu).
     @State private var pendingDelete: Reminder?
+    @State private var showJournal = false
 
     var body: some View {
         NavigationStack {
             content
                 .navigationTitle("Calendar")
                 .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button { showJournal = true } label: { Image(systemName: "book") }
+                            .accessibilityLabel("Journal")
+                    }
+                }
                 .refreshable { await reload() }
                 .task {
                     if !app.remindersLoaded { await app.loadReminders() }
@@ -25,6 +32,7 @@ struct CalendarView: View {
                 .sheet(item: $taskSelection) { card in
                     NavigationStack { TaskDetailView(card: card) }
                 }
+                .sheet(isPresented: $showJournal) { JournalView() }
                 .confirmationDialog("Delete this reminder?",
                                     isPresented: deleteDialogBinding,
                                     titleVisibility: .visible,

--- a/apps/ios/CovenCave/CovenCave/Views/JournalView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/JournalView.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+
+/// Read-only Journal: the list of days with a reflection (`GET /api/journal`),
+/// each opening the day's reflection rendered as markdown. Creating/editing
+/// reflections stays on the desktop. Presented as a sheet from the Calendar tab.
+struct JournalView: View {
+    @Environment(AppModel.self) private var app
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Journal")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) { Button("Done") { dismiss() } }
+                }
+                .refreshable { await app.loadJournal() }
+                .task { if !app.journalLoaded { await app.loadJournal() } }
+        }
+    }
+
+    @ViewBuilder private var content: some View {
+        if !app.journalLoaded {
+            ProgressView().controlSize(.large).frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error = app.journalError, app.journalDays.isEmpty {
+            ContentUnavailableView {
+                Label("Couldn’t load the journal", systemImage: "exclamationmark.triangle")
+            } description: { Text(error) } actions: {
+                Button("Retry") { Task { await app.loadJournal() } }.buttonStyle(.borderedProminent)
+            }
+        } else if app.journalDays.isEmpty {
+            ContentUnavailableView {
+                Label("No journal entries", systemImage: "book.closed")
+            } description: {
+                Text("Daily reflections written on the desktop show up here.")
+            }
+        } else {
+            List {
+                ForEach(app.journalDays) { day in
+                    NavigationLink { JournalDayView(day: day) } label: { JournalDayRow(day: day) }
+                        .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                }
+            }
+            .listStyle(.plain)
+            .themedListBackground()
+        }
+    }
+}
+
+private struct JournalDayRow: View {
+    @Environment(AppModel.self) private var app
+    let day: JournalDay
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Text(JournalDate.label(day.date)).font(.callout.weight(.semibold))
+                Spacer(minLength: 0)
+                if let by = day.reflectedBy, let familiar = app.familiar(by) {
+                    Text(familiar.displayName).font(.caption2).foregroundStyle(.secondary)
+                }
+            }
+            if let preview = day.preview, !preview.isEmpty {
+                Text(preview).font(.caption).foregroundStyle(.secondary).lineLimit(2)
+            }
+        }
+        .padding(.vertical, 2)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// One day's reflection — fetched on appear and rendered as markdown (native
+/// Text fallback if the markdown bundle is unavailable).
+struct JournalDayView: View {
+    @Environment(AppModel.self) private var app
+    @Environment(\.chrome) private var chrome
+    @Environment(\.colorScheme) private var colorScheme
+    let day: JournalDay
+
+    @State private var entry: JournalEntry?
+    @State private var error: String?
+    @State private var loading = true
+    @State private var mdHeight: CGFloat = 1
+    @State private var mdFailed = false
+
+    var body: some View {
+        ScrollView {
+            if loading {
+                ProgressView().controlSize(.large).padding(.top, 60)
+            } else if let error {
+                ContentUnavailableView {
+                    Label("Couldn’t load this entry", systemImage: "exclamationmark.triangle")
+                } description: { Text(error) } actions: {
+                    Button("Retry") { Task { await load() } }.buttonStyle(.borderedProminent)
+                }
+                .padding(.top, 40)
+            } else if let entry, !entry.reflection.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                VStack(alignment: .leading, spacing: 12) {
+                    if mdFailed {
+                        Text(entry.reflection)
+                            .font(.body)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    } else {
+                        MarkdownWebView(markdown: entry.reflection, height: $mdHeight,
+                                        streaming: false,
+                                        theme: colorScheme == .light ? .light : .dark,
+                                        accentHex: chrome.accentHex,
+                                        onFailure: { mdFailed = true })
+                            .frame(height: max(mdHeight, 1))
+                    }
+                    reflectedByLine
+                }
+                .padding(16)
+            } else {
+                ContentUnavailableView {
+                    Label("No reflection", systemImage: "book")
+                } description: {
+                    Text("No familiar wrote a reflection for this day.")
+                }
+                .padding(.top, 40)
+            }
+        }
+        .navigationTitle(JournalDate.label(day.date))
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await load() }
+    }
+
+    @ViewBuilder private var reflectedByLine: some View {
+        if let by = entry?.reflectedBy, let familiar = app.familiar(by) {
+            HStack(spacing: 6) {
+                Image(systemName: "sparkle").accessibilityHidden(true)
+                Text("Reflected by \(familiar.displayName)")
+            }
+            .font(.caption).foregroundStyle(.secondary)
+        }
+    }
+
+    private func load() async {
+        loading = true
+        do {
+            entry = try await app.client?.journalDay(date: day.date)
+            error = nil
+        } catch {
+            self.error = error.localizedDescription
+        }
+        loading = false
+    }
+}
+
+/// Format a `yyyy-MM-dd` journal day for display (Today / Yesterday / a date).
+enum JournalDate {
+    private static let parser: DateFormatter = {
+        let f = DateFormatter()
+        f.calendar = Calendar(identifier: .gregorian)
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = .current
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+    private static let display: DateFormatter = {
+        let f = DateFormatter()
+        f.setLocalizedDateFormatFromTemplate("EEEEMMMMd")
+        return f
+    }()
+    static func label(_ key: String) -> String {
+        guard let date = parser.date(from: key) else { return key }
+        if Calendar.current.isDateInToday(date) { return "Today" }
+        if Calendar.current.isDateInYesterday(date) { return "Yesterday" }
+        return display.string(from: date)
+    }
+}


### PR DESCRIPTION
iOS had no Journal; daily reflections were desktop-only. Adds a read-only Journal reachable from the **Calendar tab** (a book button) — thematically: the Calendar is days, the Journal is daily entries. (Kept off the tab bar, which is already at its 5-tab max.)

## What's in it
- **`Models/Journal.swift`** — `JournalDay` (list) + `JournalEntry` (a day's reflection), matching `GET /api/journal { days }` and `GET /api/journal?date= { entry }`.
- **CaveClient** — `journalDays()` + `journalDay(date:)`.
- **AppModel** — `journalDays` state + `loadJournal()` (mirrors `loadReminders`).
- **JournalView** — a sheet listing days (Today / Yesterday / date · preview · reflected-by familiar); tapping a day opens `JournalDayView`, which fetches the reflection and renders it as **markdown** via the shared `MarkdownWebView` (native `Text` fallback if the bundle is unavailable). Loading / error+Retry / empty states + pull-to-refresh throughout.

Creating/editing reflections stays on the desktop (read-only on mobile), per the survey.

## Verified
- `xcodebuild` for the iOS Simulator: **BUILD SUCCEEDED**.
- Ran on the simulator against live `~/.coven` data — the Journal lists five days (Today/Yesterday/Mon…) with previews + reflecting familiar. Screenshot-confirmed.
- Mobile (65) + app (411) source-text suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)