### PR TITLE
feat(board): overdue card highlighting + per-column quick-add composer

### DIFF
--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -44,6 +44,13 @@ type Props = {
   isSelected?: (id: string) => boolean;
   onToggleSelect?: (id: string) => void;
   onNewCard: (status: CardStatus) => void;
+  /** Inline quick-add: create a card from just a title in the given column
+      (status), scoped to the swimlane it was added under (familiar/project). */
+  onQuickAdd?: (
+    status: CardStatus,
+    title: string,
+    lane: { familiarId?: string | null; projectId?: string | null },
+  ) => Promise<void> | void;
   onJumpToSession?: (sessionId: string, familiarId: string | null) => void;
   onOpenTaskChat?: (id: string) => Promise<void>;
   chatLinkingId?: string | null;
@@ -79,11 +86,15 @@ function getGroups(cards: Card[], by: GroupBy, familiars: Familiar[], projects: 
   return entries;
 }
 
-export function BoardKanban({ cards, familiars, projects, sessions, groupBy, selectedCardId, onSelect, onMoveStatus, selectMode = false, isSelected, onToggleSelect, onNewCard, onJumpToSession, onOpenTaskChat, chatLinkingId }: Props) {
+export function BoardKanban({ cards, familiars, projects, sessions, groupBy, selectedCardId, onSelect, onMoveStatus, selectMode = false, isSelected, onToggleSelect, onNewCard, onQuickAdd, onJumpToSession, onOpenTaskChat, chatLinkingId }: Props) {
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<CardStatus | null>(null);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const [grabbedCardId, setGrabbedCardId] = useState<string | null>(null);
+  // Inline quick-add: which column's composer is open (`${laneKey}:${colId}`)
+  // and its draft text.
+  const [composerKey, setComposerKey] = useState<string | null>(null);
+  const [composerText, setComposerText] = useState("");
   // Resolved after mount so schedule-urgency colors never trip a hydration
   // mismatch (the server has no "now").
   const [todayMs, setTodayMs] = useState<number | null>(null);
@@ -475,6 +486,71 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
                               onOpenTaskChat={onOpenTaskChat}
                               chatLinking={chatLinkingId === card.id} />
                           ))}
+                          {onQuickAdd && !selectMode && (
+                            <li className="board-kanban-quickadd">
+                              {composerKey === `${key}:${col.id}` ? (
+                                <form
+                                  className="board-kanban-quickadd-form"
+                                  onSubmit={(e) => {
+                                    e.preventDefault();
+                                    const title = composerText.trim();
+                                    if (!title) return;
+                                    const lane =
+                                      groupBy === "familiar"
+                                        ? { familiarId: key === "__unassigned__" ? null : key }
+                                        : groupBy === "project"
+                                        ? { projectId: key === NO_PROJECT_KEY ? null : key }
+                                        : {};
+                                    void onQuickAdd(col.id, title, lane);
+                                    setComposerText("");
+                                  }}
+                                >
+                                  <textarea
+                                    autoFocus
+                                    rows={2}
+                                    value={composerText}
+                                    onChange={(e) => setComposerText(e.target.value)}
+                                    onKeyDown={(e) => {
+                                      if (e.key === "Enter" && !e.shiftKey) {
+                                        e.preventDefault();
+                                        e.currentTarget.form?.requestSubmit();
+                                      } else if (e.key === "Escape") {
+                                        e.preventDefault();
+                                        setComposerKey(null);
+                                        setComposerText("");
+                                      }
+                                    }}
+                                    onBlur={() => { if (!composerText.trim()) setComposerKey(null); }}
+                                    placeholder={`Add to ${col.label}…`}
+                                    aria-label={`New task in ${col.label}`}
+                                    className="board-kanban-quickadd-input"
+                                  />
+                                  <div className="board-kanban-quickadd-actions">
+                                    <button type="submit" className="board-kanban-quickadd-add" disabled={!composerText.trim()}>
+                                      Add
+                                    </button>
+                                    <button
+                                      type="button"
+                                      className="board-kanban-quickadd-cancel"
+                                      onMouseDown={(e) => e.preventDefault()}
+                                      onClick={() => { setComposerKey(null); setComposerText(""); }}
+                                    >
+                                      Cancel
+                                    </button>
+                                  </div>
+                                </form>
+                              ) : (
+                                <button
+                                  type="button"
+                                  className="board-kanban-quickadd-trigger focus-ring"
+                                  onClick={() => { setComposerKey(`${key}:${col.id}`); setComposerText(""); }}
+                                >
+                                  <Icon name="ph:plus" width={11} />
+                                  Add a card
+                                </button>
+                              )}
+                            </li>
+                          )}
                         </ul>
                       </div>
                     );
@@ -537,6 +613,8 @@ function KanbanCard({ card, familiarById, sessionById, todayMs, isDragging, isSe
       }}
       tabIndex={0}
       className={`board-kanban-card board-kanban-card--priority-${card.priority}${
+        urgency === "overdue" ? " board-kanban-card--overdue" : urgency === "due-soon" ? " board-kanban-card--due-soon" : ""
+      }${
         isSelected ? " board-kanban-card--selected" : ""
       }${isDragging ? " board-kanban-card--dragging" : ""}${
         isGrabbed ? " board-kanban-card--grabbed" : ""

--- a/src/components/board-ux-polish.test.ts
+++ b/src/components/board-ux-polish.test.ts
@@ -98,4 +98,36 @@ assert.match(
   "Mobile inspector lifecycle/chat/delete actions should meet the shared touch target",
 );
 
+// ── Schedule urgency surfaced on the card itself (#1) ──
+assert.match(
+  kanban,
+  /urgency === "overdue" \? " board-kanban-card--overdue" : urgency === "due-soon" \? " board-kanban-card--due-soon"/,
+  "the card container carries an urgency modifier, not just the date chip",
+);
+assert.match(
+  styles,
+  /\.board-kanban-card--overdue:not\(\.board-kanban-card--selected\)\s*\{[^}]*--color-danger/,
+  "overdue cards get a danger tint, guarded so selection still wins",
+);
+assert.match(
+  styles,
+  /\.board-kanban-card--due-soon:not\(\.board-kanban-card--selected\)\s*\{[^}]*--color-warning/,
+  "due-soon cards get a warning tint, guarded so selection still wins",
+);
+
+// ── Inline quick-add composer per column (#2) ──
+assert.match(kanban, /onQuickAdd\?:\s*\(/, "BoardKanban accepts an onQuickAdd handler");
+assert.match(kanban, /board-kanban-quickadd-trigger/, "each column has an inline add-a-card trigger");
+assert.match(
+  kanban,
+  /e\.key === "Enter" && !e\.shiftKey[\s\S]*?requestSubmit\(\)/,
+  "Enter submits the quick-add composer (Shift+Enter for a newline)",
+);
+assert.match(
+  kanban,
+  /groupBy === "familiar"[\s\S]*?familiarId: key === "__unassigned__" \? null : key/,
+  "quick-add inherits the swimlane's familiar so the card lands in the right lane",
+);
+assert.match(view, /onQuickAdd=\{quickAdd\}/, "BoardView wires the quick-add create path");
+
 console.log("board-ux-polish.test.ts: ok");

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -301,6 +301,31 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     await load();
   };
 
+  // Inline quick-add from a kanban column: title-only card in that column's
+  // status, scoped to the swimlane it was dropped under (familiar/project) or
+  // the active familiar when ungrouped.
+  const quickAdd = async (
+    status: CardStatus,
+    title: string,
+    lane: { familiarId?: string | null; projectId?: string | null },
+  ) => {
+    await create({
+      title: title.trim(),
+      notes: "",
+      status,
+      priority: "medium",
+      familiarId: lane.familiarId !== undefined ? lane.familiarId : (activeFamiliarId ?? null),
+      sessionId: null,
+      projectId: lane.projectId !== undefined ? lane.projectId : null,
+      cwd: null,
+      links: [],
+      labels: [],
+      startDate: null,
+      endDate: null,
+      template: null,
+    });
+  };
+
   // Schedule a deferred, undoable delete of one or more cards. The cards hide at
   // once (via the `filtered` exclusion), and the actual DELETEs fire only when
   // the undo window lapses; Undo just drops the timer and the cards reappear.
@@ -885,6 +910,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
             onSelect={setSelectedCardId} onMoveStatus={moveCardToStatus}
             selectMode={cardSelect.selectMode} isSelected={cardSelect.isSelected} onToggleSelect={cardSelect.toggle}
             onNewCard={(status) => { setModalDefaultStatus(status); setModalOpen(true); }}
+            onQuickAdd={quickAdd}
             onJumpToSession={onJumpToSession}
             onOpenTaskChat={onOpenTaskChat}
             chatLinkingId={chatLinkingId} />

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -300,6 +300,27 @@
 .board-kanban-card--priority-medium::before { background:var(--accent-presence); }
 .board-kanban-card--priority-low::before { background:color-mix(in oklch,var(--text-muted) 55%,transparent); }
 
+/* Schedule urgency surfaced on the card itself (not just the date chip) so an
+   overdue task is scannable at a glance. The left spine stays priority-coded;
+   urgency is a faint warm tint + border. Selection always wins (:not guard). */
+.board-kanban-card--overdue:not(.board-kanban-card--selected) { background:color-mix(in oklch,var(--color-danger) 7%,var(--bg-base)); border-color:color-mix(in oklch,var(--color-danger) 30%,var(--border-hairline)); }
+.board-kanban-card--overdue:not(.board-kanban-card--selected):hover { background:color-mix(in oklch,var(--color-danger) 10%,var(--bg-base)); border-color:color-mix(in oklch,var(--color-danger) 45%,var(--border-strong)); }
+.board-kanban-card--due-soon:not(.board-kanban-card--selected) { background:color-mix(in oklch,var(--color-warning) 6%,var(--bg-base)); border-color:color-mix(in oklch,var(--color-warning) 26%,var(--border-hairline)); }
+.board-kanban-card--due-soon:not(.board-kanban-card--selected):hover { background:color-mix(in oklch,var(--color-warning) 9%,var(--bg-base)); border-color:color-mix(in oklch,var(--color-warning) 40%,var(--border-strong)); }
+
+/* Inline quick-add composer at the bottom of each column (Trello-style). */
+.board-kanban-quickadd { list-style:none; margin-top:2px; }
+.board-kanban-quickadd-trigger { display:flex; align-items:center; gap:5px; width:100%; padding:6px 9px; border-radius:7px; border:1px dashed var(--border-hairline); background:transparent; color:var(--text-muted); font-size:11.5px; cursor:pointer; transition:background .12s,color .12s,border-color .12s; }
+.board-kanban-quickadd-trigger:hover { background:color-mix(in oklch,var(--bg-hover) 50%,transparent); color:var(--text-secondary); border-color:var(--border-strong); }
+.board-kanban-quickadd-form { display:flex; flex-direction:column; gap:6px; }
+.board-kanban-quickadd-input { width:100%; resize:none; padding:7px 9px; border-radius:7px; border:1px solid color-mix(in oklch,var(--accent-presence) 45%,var(--border-strong)); background:var(--bg-base); color:var(--text-primary); font-size:12px; line-height:1.4; font-family:inherit; outline:none; box-shadow:0 0 0 3px color-mix(in oklch,var(--accent-presence) 16%,transparent); }
+.board-kanban-quickadd-input::placeholder { color:var(--text-muted); }
+.board-kanban-quickadd-actions { display:flex; align-items:center; gap:6px; }
+.board-kanban-quickadd-add { padding:4px 12px; border-radius:6px; border:none; background:var(--accent-presence); color:#fff; font-size:11.5px; font-weight:600; cursor:pointer; }
+.board-kanban-quickadd-add:disabled { opacity:.5; cursor:default; }
+.board-kanban-quickadd-cancel { padding:4px 8px; border-radius:6px; border:none; background:transparent; color:var(--text-muted); font-size:11.5px; cursor:pointer; }
+.board-kanban-quickadd-cancel:hover { color:var(--text-secondary); }
+
 .board-kanban-card-top { display:flex; align-items:center; justify-content:space-between; gap:6px; min-height:18px; }
 .board-kanban-priority-pill { display:inline-flex; align-items:center; padding:1px 7px; border-radius:5px; font-size:9px; font-weight:600; letter-spacing:.06em; text-transform:uppercase; }
 .board-kanban-priority-pill--urgent { background:color-mix(in oklch,var(--color-danger) 18%,transparent); color:color-mix(in oklch,var(--color-danger) 70%,#fff); }


### PR DESCRIPTION
First of the Board UX improvements — two kanban card/column ergonomics.

## 1. Overdue / due-soon card highlighting
The board already computed schedule urgency but only colored the small date *chip*. Now the **card itself** gets a faint warm tint + border — danger for overdue, warning for due-soon — so at-risk work is scannable at a glance (matches what the Gantt does for at-risk bars).

- The priority-coded left spine is untouched; urgency is a separate tint.
- Selection always wins (`:not(.board-kanban-card--selected)` guard).

## 2. Inline quick-add composer per column
A Trello-style **"+ Add a card"** at the bottom of each column. Click → type a title → **Enter** creates a card in that column's status and the composer **stays open** for rapid entry (Shift+Enter = newline, Esc/blur closes). In swimlanes the new card inherits the lane's **familiar/project** so it lands in the right lane. The header **+Add** (full modal) is unchanged — both paths coexist.

`board-view` gains a `quickAdd` create path reusing the existing `POST /api/board`.

## Verification (real app, Playwright)
- A due-soon card renders with the amber tint/border; a far-future card does not
- Clicking "Add a card" → typing → Enter creates a card in the right column (POST body: correct title/status/priority) and reopens the composer

Source-text assertions added to `board-ux-polish.test.ts`; all 13 board tests pass; `tsc` + `check:tests-wired` green.

Follow-ups from the same pitch (not in this PR): WIP limits per column, extended bulk-edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)