### PR TITLE
feat(chat): Group Chat ("coven") — broadcast one prompt to many familiars

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -252,6 +252,8 @@ export const SUITES = {
     "src/components/opencoven-submission-panel.test.ts",
     "src/components/opencoven-submissions-navigation.test.ts",
     "src/components/chat-linked-context.test.ts",
+    "src/components/group-chat-view.test.ts",
+    "src/lib/group-chat.test.ts",
     "src/components/chat-send-routes-links.test.ts",
     "src/components/chat-surface-polish.test.ts",
     "src/components/chat-view.test.ts",

--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -1,0 +1,39 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+const view = readFileSync(new URL("./group-chat-view.tsx", import.meta.url), "utf8");
+const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const mode = readFileSync(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
+
+test("GroupChatView broadcasts via /api/chat/send and reuses pure helpers", () => {
+  assert.match(view, /export function GroupChatView/, "exports GroupChatView");
+  // Fan-out: one /api/chat/send per participant carrying the per-familiar id.
+  assert.match(view, /fetch\("\/api\/chat\/send"/, "sends through the chat bridge");
+  assert.match(view, /familiarId: reply\.familiarId/, "each stream targets one familiar");
+  assert.match(view, /Promise\.all\(replies\.map/, "fans out to every participant in parallel");
+  // Reuses the tested pure reducers rather than re-parsing inline.
+  assert.match(view, /applyGroupEvent|parseSseBuffer/, "uses the pure stream reducers");
+  // Per-familiar session pinning so each thread resumes.
+  assert.match(view, /recordSession\(group\.id, reply\.familiarId/, "pins each familiar's session id");
+  // A Stop control aborts the in-flight broadcast.
+  assert.match(view, /abortRef\.current\?\.abort\(\)/, "Stop aborts the broadcast");
+});
+
+test("Group Chat is wired into navigation", () => {
+  assert.match(mode, /\| "groupchat"/, "groupchat is a valid WorkspaceMode");
+  assert.match(sidebar, /id: "groupchat", label: "Group"/, "sidebar exposes the Group surface");
+  assert.match(workspace, /groupchat: "Group Chat"/, "groupchat mode has a title");
+  assert.match(
+    workspace,
+    /mode === "groupchat" \?\s*\(\s*<GroupChatView/,
+    "workspace renders GroupChatView for the groupchat mode",
+  );
+  assert.match(
+    workspace,
+    /import \{ GroupChatView \} from "@\/components\/group-chat-view"/,
+    "workspace imports GroupChatView",
+  );
+});

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -1,0 +1,590 @@
+"use client";
+
+/**
+ * GroupChatView — the "coven" group-chat surface.
+ *
+ * A coven is a saved set of familiars you talk to together. A prompt is
+ * broadcast to every participant in parallel; each familiar answers in its own
+ * resumable `/api/chat/send` session and its reply is attributed inline. This
+ * mirrors the daemon/coven-CLI model — there is no server-side "group session",
+ * so the group lives client-side and simply pins one session id per familiar
+ * (the same fan-out the iOS app uses).
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Icon } from "@/lib/icon";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Popover } from "@/components/ui/popover";
+import { MessageBubble } from "@/components/message-bubble";
+import { FamiliarAvatar } from "@/components/familiar-avatar";
+import { RelativeTime } from "@/components/ui/relative-time";
+import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
+import {
+  applyGroupEvent,
+  parseSseBuffer,
+  defaultGroupName,
+  makeGroup,
+  upsertGroup,
+  removeGroup,
+  setGroupSession,
+  setGroupParticipants,
+  loadGroups,
+  saveGroups,
+  loadTranscript,
+  saveTranscript,
+  type CovenGroup,
+  type GroupTurn,
+  type GroupUserTurn,
+  type GroupReply,
+} from "@/lib/group-chat";
+
+type Props = {
+  familiars: ResolvedFamiliar[];
+  /** Called whenever a participant's session is (re)created, so the host can
+   *  refresh its session list and surface the new threads elsewhere. */
+  onSessionStarted?: (sessionId: string) => void;
+  onOpenUrl?: (url: string) => void;
+};
+
+function newId(): string {
+  return typeof crypto !== "undefined" && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `id-${Math.floor(Math.random() * 1e9)}`;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props) {
+  const [groups, setGroups] = useState<CovenGroup[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [transcript, setTranscript] = useState<GroupTurn[]>([]);
+  const [draft, setDraft] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+
+  const addBtnRef = useRef<HTMLButtonElement | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const groupsRef = useRef<CovenGroup[]>(groups);
+  const transcriptRef = useRef<GroupTurn[]>(transcript);
+  groupsRef.current = groups;
+  transcriptRef.current = transcript;
+
+  const byId = useMemo(() => {
+    const m = new Map<string, ResolvedFamiliar>();
+    for (const f of familiars) m.set(f.id, f);
+    return m;
+  }, [familiars]);
+
+  const activeGroup = useMemo(
+    () => groups.find((g) => g.id === activeId) ?? null,
+    [groups, activeId],
+  );
+  const activeGroupRef = useRef<CovenGroup | null>(activeGroup);
+  activeGroupRef.current = activeGroup;
+
+  // --- load persisted groups once -----------------------------------------
+  useEffect(() => {
+    const loaded = loadGroups();
+    setGroups(loaded);
+    if (loaded.length > 0) setActiveId(loaded[0].id);
+  }, []);
+
+  // --- swap transcript when the active group changes ----------------------
+  useEffect(() => {
+    if (!activeId) {
+      setTranscript([]);
+      return;
+    }
+    setTranscript(loadTranscript(activeId));
+  }, [activeId]);
+
+  // --- persist transcript on settle ---------------------------------------
+  useEffect(() => {
+    if (activeId) saveTranscript(activeId, transcript);
+  }, [activeId, transcript]);
+
+  // --- autoscroll to newest -----------------------------------------------
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [transcript]);
+
+  const persistGroups = useCallback((next: CovenGroup[]) => {
+    setGroups(next);
+    saveGroups(next);
+  }, []);
+
+  const updateReply = useCallback(
+    (replyId: string, fn: (r: GroupReply) => GroupReply) => {
+      setTranscript((prev) =>
+        prev.map((t) =>
+          t.role === "assistant" && t.id === replyId ? fn(t as GroupReply) : t,
+        ),
+      );
+    },
+    [],
+  );
+
+  const recordSession = useCallback(
+    (groupId: string, familiarId: string, sessionId: string) => {
+      const current = groupsRef.current.find((g) => g.id === groupId);
+      if (!current || current.sessions[familiarId] === sessionId) return;
+      persistGroups(
+        upsertGroup(groupsRef.current, setGroupSession(current, familiarId, sessionId, nowIso())),
+      );
+      onSessionStarted?.(sessionId);
+    },
+    [persistGroups, onSessionStarted],
+  );
+
+  // --- group CRUD ----------------------------------------------------------
+  const createGroup = useCallback(() => {
+    const group = makeGroup("New coven", [], nowIso(), newId());
+    persistGroups(upsertGroup(groupsRef.current, group));
+    setActiveId(group.id);
+    setPickerOpen(true);
+  }, [persistGroups]);
+
+  const deleteGroup = useCallback(
+    (id: string) => {
+      const next = removeGroup(groupsRef.current, id);
+      persistGroups(next);
+      if (typeof localStorage !== "undefined") {
+        try {
+          localStorage.removeItem(`cave:group-chat:transcript:${id}`);
+        } catch {
+          /* ignore */
+        }
+      }
+      if (activeId === id) setActiveId(next[0]?.id ?? null);
+    },
+    [persistGroups, activeId],
+  );
+
+  const toggleParticipant = useCallback(
+    (familiarId: string) => {
+      const group = activeGroupRef.current;
+      if (!group) return;
+      const has = group.familiarIds.includes(familiarId);
+      const ids = has
+        ? group.familiarIds.filter((id) => id !== familiarId)
+        : [...group.familiarIds, familiarId];
+      // Auto-name a fresh coven from its members until the user renames it.
+      const autoNamed = group.name === "New coven" || group.name.trim() === "";
+      let next = setGroupParticipants(group, ids, nowIso());
+      if (autoNamed) {
+        next = {
+          ...next,
+          name: defaultGroupName(ids.map((id) => byId.get(id)?.display_name ?? "")),
+        };
+      }
+      persistGroups(upsertGroup(groupsRef.current, next));
+    },
+    [persistGroups, byId],
+  );
+
+  const renameGroup = useCallback(
+    (name: string) => {
+      const group = activeGroupRef.current;
+      if (!group) return;
+      persistGroups(
+        upsertGroup(groupsRef.current, { ...group, name: name.trim() || "Untitled coven", updatedAt: nowIso() }),
+      );
+    },
+    [persistGroups],
+  );
+
+  // --- broadcast send ------------------------------------------------------
+  const streamOne = useCallback(
+    async (group: CovenGroup, reply: GroupReply, prompt: string, signal: AbortSignal) => {
+      try {
+        const res = await fetch("/api/chat/send", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            familiarId: reply.familiarId,
+            prompt,
+            sessionId: reply.sessionId,
+          }),
+          signal,
+        });
+        if (!res.ok || !res.body) {
+          updateReply(reply.id, (r) =>
+            applyGroupEvent(r, { kind: "error", message: `request failed (${res.status})` }),
+          );
+          return;
+        }
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        for (;;) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const { events, rest } = parseSseBuffer(buffer);
+          buffer = rest;
+          for (const ev of events) {
+            if (ev.kind === "session") recordSession(group.id, reply.familiarId, ev.sessionId);
+            if (ev.kind === "done" && ev.sessionId)
+              recordSession(group.id, reply.familiarId, ev.sessionId);
+            updateReply(reply.id, (r) => applyGroupEvent(r, ev));
+          }
+        }
+        // Stream closed without an explicit `done` — settle anything still live.
+        updateReply(reply.id, (r) =>
+          r.status === "streaming" || r.status === "queued" ? { ...r, status: "done", activity: undefined } : r,
+        );
+      } catch (err) {
+        const aborted = (err as Error)?.name === "AbortError";
+        updateReply(reply.id, (r) =>
+          aborted
+            ? { ...r, status: "error", error: "cancelled", activity: undefined }
+            : applyGroupEvent(r, { kind: "error", message: (err as Error)?.message ?? "send failed" }),
+        );
+      }
+    },
+    [updateReply, recordSession],
+  );
+
+  const send = useCallback(async () => {
+    const group = activeGroupRef.current;
+    const text = draft.trim();
+    if (!group || group.familiarIds.length === 0 || !text || busy) return;
+    const at = nowIso();
+    const userTurn: GroupUserTurn = { id: newId(), role: "user", text, createdAt: at };
+    const replies: GroupReply[] = group.familiarIds.map((fid) => ({
+      id: newId(),
+      role: "assistant",
+      familiarId: fid,
+      replyTo: userTurn.id,
+      sessionId: group.sessions[fid] ?? null,
+      text: "",
+      status: "queued",
+      createdAt: at,
+    }));
+    setTranscript((prev) => [...prev, userTurn, ...replies]);
+    setDraft("");
+    setBusy(true);
+    const controller = new AbortController();
+    abortRef.current = controller;
+    await Promise.all(replies.map((r) => streamOne(group, r, text, controller.signal)));
+    abortRef.current = null;
+    setBusy(false);
+  }, [draft, busy, streamOne]);
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  // --- derived transcript view --------------------------------------------
+  // Group replies under the user turn they answer for a clean threaded layout.
+  const threads = useMemo(() => {
+    const users = transcript.filter((t): t is GroupUserTurn => t.role === "user");
+    return users.map((u) => ({
+      user: u,
+      replies: transcript.filter(
+        (t): t is GroupReply => t.role === "assistant" && t.replyTo === u.id,
+      ),
+    }));
+  }, [transcript]);
+
+  const participants = activeGroup
+    ? activeGroup.familiarIds.map((id) => byId.get(id)).filter(Boolean as unknown as (f: ResolvedFamiliar | undefined) => f is ResolvedFamiliar)
+    : [];
+
+  // --- render --------------------------------------------------------------
+  return (
+    <div className="flex h-full min-h-0">
+      {/* Coven list rail */}
+      <aside className="flex w-56 shrink-0 flex-col border-r" style={{ borderColor: "var(--border-hairline)" }}>
+        <div className="flex items-center justify-between gap-2 px-3 py-2.5">
+          <span className="text-[12px] font-semibold uppercase tracking-wide" style={{ color: "var(--text-muted)" }}>
+            Covens
+          </span>
+          <Button size="xs" variant="ghost" leadingIcon="ph:plus-bold" onClick={createGroup}>
+            New
+          </Button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-2">
+          {groups.length === 0 ? (
+            <p className="px-2 py-3 text-[12px] leading-relaxed" style={{ color: "var(--text-muted)" }}>
+              A coven is a group of familiars you talk to together. Create one to broadcast a prompt to all of them at once.
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-0.5">
+              {groups.map((g) => {
+                const members = g.familiarIds.map((id) => byId.get(id)).filter(Boolean) as ResolvedFamiliar[];
+                const isActive = g.id === activeId;
+                return (
+                  <li key={g.id}>
+                    <div
+                      className="group/coven flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5"
+                      style={isActive ? { background: "var(--bg-raised)" } : undefined}
+                      onClick={() => setActiveId(g.id)}
+                    >
+                      <div className="flex -space-x-1.5">
+                        {members.slice(0, 3).map((m) => (
+                          <FamiliarAvatar key={m.id} familiar={m} size="sm" className="rounded-full ring-1 ring-[var(--bg-base)] object-cover" />
+                        ))}
+                        {members.length === 0 && (
+                          <span className="grid h-4 w-4 place-items-center rounded-full" style={{ background: "var(--bg-raised)" }}>
+                            <Icon name="ph:users-three" width={11} height={11} />
+                          </span>
+                        )}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-[13px]" style={{ color: "var(--text-primary)" }} title={g.name}>
+                          {g.name}
+                        </div>
+                        <div className="text-[11px]" style={{ color: "var(--text-muted)" }}>
+                          {members.length} familiar{members.length === 1 ? "" : "s"} · <RelativeTime iso={g.updatedAt} />
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        className="opacity-0 transition-opacity group-hover/coven:opacity-100"
+                        title="Delete coven"
+                        aria-label={`Delete ${g.name}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          deleteGroup(g.id);
+                        }}
+                      >
+                        <Icon name="ph:trash" width={14} height={14} />
+                      </button>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </aside>
+
+      {/* Active coven */}
+      <section className="flex min-w-0 flex-1 flex-col">
+        {!activeGroup ? (
+          <div className="grid flex-1 place-items-center">
+            <EmptyState
+              icon="ph:users-three"
+              headline="No coven selected"
+              subtitle="Create a coven to chat with several familiars at once. Each one answers in its own session, attributed inline."
+              actions={
+                <Button variant="primary" leadingIcon="ph:plus-bold" onClick={createGroup}>
+                  New coven
+                </Button>
+              }
+            />
+          </div>
+        ) : (
+          <>
+            {/* Header */}
+            <header className="flex items-center gap-3 border-b px-4 py-2.5" style={{ borderColor: "var(--border-hairline)" }}>
+              <div className="min-w-0 flex-1">
+                {renaming ? (
+                  <input
+                    autoFocus
+                    defaultValue={activeGroup.name}
+                    className="w-full rounded bg-transparent text-[15px] font-semibold outline-none"
+                    style={{ color: "var(--text-primary)" }}
+                    onBlur={(e) => {
+                      renameGroup(e.target.value);
+                      setRenaming(false);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+                      if (e.key === "Escape") setRenaming(false);
+                    }}
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    className="truncate text-[15px] font-semibold"
+                    style={{ color: "var(--text-primary)" }}
+                    title="Rename coven"
+                    onClick={() => setRenaming(true)}
+                  >
+                    {activeGroup.name}
+                  </button>
+                )}
+                <div className="mt-0.5 flex items-center gap-1.5">
+                  {participants.length === 0 ? (
+                    <span className="text-[12px]" style={{ color: "var(--text-muted)" }}>
+                      No familiars yet — add some to start
+                    </span>
+                  ) : (
+                    participants.map((f) => (
+                      <span key={f.id} className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[11px]" style={{ background: "var(--bg-raised)", color: "var(--text-secondary)" }}>
+                        <FamiliarAvatar familiar={f} size="sm" className="rounded-full object-cover" />
+                        {f.display_name}
+                      </span>
+                    ))
+                  )}
+                </div>
+              </div>
+              <Button
+                ref={addBtnRef}
+                size="sm"
+                variant="secondary"
+                leadingIcon="ph:plus-bold"
+                onClick={() => setPickerOpen((v) => !v)}
+              >
+                Add
+              </Button>
+              <Popover
+                open={pickerOpen}
+                onOpenChange={setPickerOpen}
+                anchorRef={addBtnRef}
+                placement="bottom-end"
+                ariaLabel="Choose familiars"
+                minWidth={240}
+              >
+                <div className="max-h-80 overflow-y-auto p-1">
+                  {familiars.length === 0 ? (
+                    <p className="px-2 py-2 text-[12px]" style={{ color: "var(--text-muted)" }}>
+                      No familiars available.
+                    </p>
+                  ) : (
+                    familiars.map((f) => {
+                      const checked = activeGroup.familiarIds.includes(f.id);
+                      return (
+                        <button
+                          key={f.id}
+                          type="button"
+                          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left hover:bg-[var(--bg-raised)]"
+                          onClick={() => toggleParticipant(f.id)}
+                        >
+                          <FamiliarAvatar familiar={f} size="md" className="rounded-full object-cover" />
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate text-[13px]" style={{ color: "var(--text-primary)" }}>{f.display_name}</div>
+                            <div className="truncate text-[11px]" style={{ color: "var(--text-muted)" }}>{f.role}</div>
+                          </div>
+                          <Icon
+                            name={checked ? "ph:check-circle-fill" : "ph:circle"}
+                            width={18}
+                            height={18}
+                            className={checked ? "text-[var(--accent-presence)]" : "text-[var(--text-muted)]"}
+                          />
+                        </button>
+                      );
+                    })
+                  )}
+                </div>
+              </Popover>
+            </header>
+
+            {/* Transcript */}
+            <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+              {threads.length === 0 ? (
+                <div className="grid h-full place-items-center">
+                  <EmptyState
+                    icon="ph:chats-circle"
+                    headline={participants.length === 0 ? "Add familiars to begin" : "Broadcast your first message"}
+                    subtitle={
+                      participants.length === 0
+                        ? "Use Add to pick the familiars in this coven."
+                        : "Your prompt goes to every familiar in the coven. Each replies in its own thread."
+                    }
+                    compact
+                  />
+                </div>
+              ) : (
+                <div className="mx-auto flex max-w-3xl flex-col gap-5">
+                  {threads.map(({ user, replies }) => (
+                    <div key={user.id} className="flex flex-col gap-2">
+                      <MessageBubble role="user" content={user.text} timestamp={user.createdAt} onOpenUrl={onOpenUrl} />
+                      <div className="flex flex-col gap-3 pl-1">
+                        {replies.map((r) => {
+                          const f = byId.get(r.familiarId);
+                          return (
+                            <div key={r.id} className="flex gap-2">
+                              {f && (
+                                <div className="mt-1 shrink-0">
+                                  <FamiliarAvatar familiar={f} size="md" className="rounded-full object-cover" title={f.display_name} />
+                                </div>
+                              )}
+                              <div className="min-w-0 flex-1">
+                                <MessageBubble
+                                  role="assistant"
+                                  label={f?.display_name ?? r.familiarId}
+                                  content={
+                                    r.text ||
+                                    (r.status === "error"
+                                      ? `⚠️ ${r.error ?? "failed"}`
+                                      : r.activity
+                                        ? `_${r.activity}_`
+                                        : "")
+                                  }
+                                  pending={r.status === "queued" || r.status === "streaming"}
+                                  isError={r.status === "error"}
+                                  timestamp={r.createdAt}
+                                  onOpenUrl={onOpenUrl}
+                                />
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Composer */}
+            <div className="border-t px-4 py-3" style={{ borderColor: "var(--border-hairline)" }}>
+              <div className="mx-auto flex max-w-3xl items-end gap-2">
+                <textarea
+                  value={draft}
+                  onChange={(e) => setDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && !e.shiftKey) {
+                      e.preventDefault();
+                      void send();
+                    }
+                  }}
+                  rows={1}
+                  placeholder={
+                    participants.length === 0
+                      ? "Add familiars to this coven first…"
+                      : `Message ${participants.length} familiar${participants.length === 1 ? "" : "s"}…`
+                  }
+                  disabled={participants.length === 0}
+                  className="max-h-40 min-h-[40px] flex-1 resize-none rounded-lg border px-3 py-2 text-[14px] outline-none disabled:opacity-50"
+                  style={{ borderColor: "var(--border-hairline)", background: "var(--bg-base)", color: "var(--text-primary)" }}
+                />
+                {busy ? (
+                  <Button variant="danger-ghost" leadingIcon="ph:stop-fill" onClick={stop}>
+                    Stop
+                  </Button>
+                ) : (
+                  <Button
+                    variant="primary"
+                    leadingIcon="ph:arrow-up-bold"
+                    disabled={participants.length === 0 || !draft.trim()}
+                    onClick={() => void send()}
+                  >
+                    Send
+                  </Button>
+                )}
+              </div>
+            </div>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default GroupChatView;

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -180,8 +180,12 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
       const ids = has
         ? group.familiarIds.filter((id) => id !== familiarId)
         : [...group.familiarIds, familiarId];
-      // Auto-name a fresh coven from its members until the user renames it.
-      const autoNamed = group.name === "New coven" || group.name.trim() === "";
+      // Keep auto-naming from the roster until the user types their own name.
+      // "Auto" means the current name still matches what the previous roster
+      // would have produced (or the untouched default / empty).
+      const prevAutoName = defaultGroupName(group.familiarIds.map((id) => byId.get(id)?.display_name ?? ""));
+      const autoNamed =
+        group.name === "New coven" || group.name.trim() === "" || group.name === prevAutoName;
       let next = setGroupParticipants(group, ids, nowIso());
       if (autoNamed) {
         next = {

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -24,6 +24,7 @@ export type FolderMode =
   | "agents"
   | "home"
   | "chat"
+  | "groupchat"
   | "board"
   | "calendar"
   | "inbox"
@@ -94,6 +95,7 @@ const FOLDER_MODES: Array<{
   // Work
   { id: "home", label: "Home", iconName: "ph:house-bold", group: "work", kbd: "⌘1", description: "Overview and quick actions" },
   { id: "chat", label: "Chat", iconName: "ph:chats", group: "work", kbd: "⌘2", description: "Talk with your familiars" },
+  { id: "groupchat", label: "Group", iconName: "ph:users-three", group: "work", description: "Group chat — broadcast to a coven of familiars at once" },
   { id: "board", label: "Board", iconName: "ph:kanban", group: "work", kbd: "⌘3", description: "Track tasks across projects", badge: (p) => badgeText(p.boardOpenCount) },
   { id: "journal", label: "Journal", iconName: "ph:book-open", group: "work", description: "Your daily journal and generated sketches" },
   { id: "calendar", label: "Calendar", iconName: "ph:calendar-blank", group: "work", kbd: "⌘4", description: "Schedule and timeline of work" },

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -25,6 +25,7 @@ import { FamiliarStudio } from "@/components/familiar-studio";
 import { CompanionRail, type CompanionTab } from "@/components/companion-rail";
 import { RailInspector } from "@/components/inspector-pane";
 import { FamiliarsView } from "@/components/familiars-view";
+import { GroupChatView } from "@/components/group-chat-view";
 import {
   getFamiliarScope,
   setFamiliarScope,
@@ -87,6 +88,7 @@ const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = {
   agents: "Familiars",
   home: "Home",
   chat: "Familiars",
+  groupchat: "Group Chat",
   board: "Board",
   calendar: "Calendar",
   inbox: "Schedules",
@@ -1762,6 +1764,12 @@ export function Workspace() {
         onInboxItemChanged={refreshInbox}
         onSessionsChanged={loadSessions}
         onOpenTask={(cardId) => onPaletteIntent({ kind: "focus-card", cardId })}
+        onOpenUrl={openUrlInCompanionBrowser}
+      />
+    ) : mode === "groupchat" ? (
+      <GroupChatView
+        familiars={resolvedFamiliars}
+        onSessionStarted={loadSessions}
         onOpenUrl={openUrlInCompanionBrowser}
       />
     ) : mode === "code" ? (

--- a/src/lib/group-chat.test.ts
+++ b/src/lib/group-chat.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  applyGroupEvent,
+  parseSseBuffer,
+  defaultGroupName,
+  makeGroup,
+  upsertGroup,
+  removeGroup,
+  setGroupSession,
+  setGroupParticipants,
+  type GroupReply,
+} from "./group-chat.ts";
+
+function baseReply(overrides: Partial<GroupReply> = {}): GroupReply {
+  return {
+    id: "r1",
+    role: "assistant",
+    familiarId: "aria",
+    replyTo: "u1",
+    sessionId: null,
+    text: "",
+    status: "queued",
+    createdAt: "2026-06-24T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("applyGroupEvent: session captures the session id", () => {
+  const next = applyGroupEvent(baseReply(), { kind: "session", sessionId: "sess-1" });
+  assert.equal(next.sessionId, "sess-1");
+});
+
+test("applyGroupEvent: chunks append and flip status to streaming", () => {
+  let r = baseReply();
+  r = applyGroupEvent(r, { kind: "assistant_chunk", text: "Hel" });
+  r = applyGroupEvent(r, { kind: "assistant_chunk", text: "lo" });
+  assert.equal(r.text, "Hello");
+  assert.equal(r.status, "streaming");
+});
+
+test("applyGroupEvent: progress sets activity but a chunk clears it", () => {
+  let r = baseReply();
+  r = applyGroupEvent(r, { kind: "progress", label: "Thinking", status: "running" });
+  assert.equal(r.activity, "Thinking");
+  assert.equal(r.status, "streaming");
+  r = applyGroupEvent(r, { kind: "assistant_chunk", text: "hi" });
+  assert.equal(r.activity, undefined);
+});
+
+test("applyGroupEvent: tool_use shows the tool name as activity", () => {
+  const r = applyGroupEvent(baseReply(), { kind: "tool_use", name: "Read", status: "running" });
+  assert.equal(r.activity, "Read…");
+});
+
+test("applyGroupEvent: done settles the reply", () => {
+  let r = baseReply();
+  r = applyGroupEvent(r, { kind: "assistant_chunk", text: "done text" });
+  r = applyGroupEvent(r, { kind: "done", durationMs: 1200, costUsd: 0.01 });
+  assert.equal(r.status, "done");
+  assert.equal(r.durationMs, 1200);
+  assert.equal(r.costUsd, 0.01);
+  assert.equal(r.activity, undefined);
+});
+
+test("applyGroupEvent: done with isError flips to error", () => {
+  const r = applyGroupEvent(baseReply(), { kind: "done", isError: true });
+  assert.equal(r.status, "error");
+});
+
+test("applyGroupEvent: error captures the message", () => {
+  const r = applyGroupEvent(baseReply(), { kind: "error", message: "boom" });
+  assert.equal(r.status, "error");
+  assert.equal(r.error, "boom");
+});
+
+test("parseSseBuffer: splits complete frames and keeps the partial tail", () => {
+  const buf =
+    'data: {"kind":"session","sessionId":"s1"}\n\n' +
+    'data: {"kind":"assistant_chunk","text":"hi"}\n\n' +
+    'data: {"kind":"assistant_chunk","text":"par';
+  const { events, rest } = parseSseBuffer(buf);
+  assert.equal(events.length, 2);
+  assert.equal(events[0].kind, "session");
+  assert.equal(rest, 'data: {"kind":"assistant_chunk","text":"par');
+});
+
+test("parseSseBuffer: skips malformed frames without throwing", () => {
+  const { events } = parseSseBuffer('data: not-json\n\ndata: {"kind":"error","message":"x"}\n\n');
+  assert.equal(events.length, 1);
+  assert.equal(events[0].kind, "error");
+});
+
+test("defaultGroupName: friendly summaries by participant count", () => {
+  assert.equal(defaultGroupName([]), "New coven");
+  assert.equal(defaultGroupName(["Aria"]), "Aria");
+  assert.equal(defaultGroupName(["Aria", "Boz"]), "Aria & Boz");
+  assert.equal(defaultGroupName(["Aria", "Boz", "Cy", "Dot"]), "Aria, Boz +2");
+});
+
+test("makeGroup: dedupes participants and defaults the name", () => {
+  const g = makeGroup("  ", ["a", "a", "b"], "2026-06-24T00:00:00.000Z", "g1");
+  assert.deepEqual(g.familiarIds, ["a", "b"]);
+  assert.equal(g.name, "New coven");
+  assert.deepEqual(g.sessions, {});
+});
+
+test("upsertGroup: replaces by id and sorts newest-first", () => {
+  const older = makeGroup("Old", ["a"], "2026-06-24T00:00:00.000Z", "g1");
+  const newer = makeGroup("New", ["b"], "2026-06-24T01:00:00.000Z", "g2");
+  let groups = upsertGroup([], older);
+  groups = upsertGroup(groups, newer);
+  assert.equal(groups[0].id, "g2");
+  const edited = { ...older, name: "Edited", updatedAt: "2026-06-24T02:00:00.000Z" };
+  groups = upsertGroup(groups, edited);
+  assert.equal(groups.length, 2);
+  assert.equal(groups[0].id, "g1");
+  assert.equal(groups[0].name, "Edited");
+});
+
+test("removeGroup: drops the matching id", () => {
+  const g = makeGroup("X", ["a"], "2026-06-24T00:00:00.000Z", "g1");
+  assert.deepEqual(removeGroup([g], "g1"), []);
+});
+
+test("setGroupSession: pins and clears a familiar's session id", () => {
+  let g = makeGroup("X", ["a", "b"], "2026-06-24T00:00:00.000Z", "g1");
+  g = setGroupSession(g, "a", "sess-a", "2026-06-24T01:00:00.000Z");
+  assert.equal(g.sessions.a, "sess-a");
+  assert.equal(g.updatedAt, "2026-06-24T01:00:00.000Z");
+  g = setGroupSession(g, "a", null, "2026-06-24T02:00:00.000Z");
+  assert.equal(g.sessions.a, undefined);
+});
+
+test("setGroupParticipants: drops session pins for removed familiars", () => {
+  let g = makeGroup("X", ["a", "b"], "2026-06-24T00:00:00.000Z", "g1");
+  g = setGroupSession(g, "a", "sess-a", "2026-06-24T01:00:00.000Z");
+  g = setGroupSession(g, "b", "sess-b", "2026-06-24T01:00:00.000Z");
+  g = setGroupParticipants(g, ["a", "c"], "2026-06-24T03:00:00.000Z");
+  assert.deepEqual(g.familiarIds, ["a", "c"]);
+  assert.equal(g.sessions.a, "sess-a");
+  assert.equal(g.sessions.b, undefined);
+});

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -1,0 +1,269 @@
+/**
+ * group-chat.ts — pure model + reducers for the Group Chat ("coven") surface.
+ *
+ * A *coven* is a saved set of familiars you talk to together. Sending a prompt
+ * fans it out to every participant in parallel (one `/api/chat/send` stream per
+ * familiar — the same client-side broadcast model the iOS app uses, since the
+ * daemon/coven CLI has no server-side "group session" concept). Each familiar
+ * keeps its own resumable session; the group just remembers which session id
+ * belongs to which familiar so every thread persists across reloads.
+ *
+ * Everything here is framework-free and deterministic (except the thin
+ * localStorage + id/time wrappers at the bottom) so the streaming reducers and
+ * group bookkeeping are unit-testable without a DOM.
+ */
+
+const GROUPS_KEY = "cave:group-chat:groups:v1";
+const TRANSCRIPTS_KEY_PREFIX = "cave:group-chat:transcript:";
+
+/** A saved group of familiars chatted with together. */
+export type CovenGroup = {
+  id: string;
+  name: string;
+  familiarIds: string[];
+  /** Per-familiar resumed session ids so each thread survives reloads. */
+  sessions: Record<string, string>;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/** One prompt the user broadcast to the whole coven. */
+export type GroupUserTurn = {
+  id: string;
+  role: "user";
+  text: string;
+  createdAt: string;
+};
+
+export type GroupReplyStatus = "queued" | "streaming" | "done" | "error";
+
+/** One familiar's reply to a user turn. There is exactly one per participant. */
+export type GroupReply = {
+  id: string;
+  role: "assistant";
+  familiarId: string;
+  /** Id of the {@link GroupUserTurn} this answers. */
+  replyTo: string;
+  /** Resolved once the stream emits its `session` event. */
+  sessionId: string | null;
+  text: string;
+  status: GroupReplyStatus;
+  /** Latest progress/tool label — the "thinking…" line while streaming. */
+  activity?: string;
+  error?: string;
+  durationMs?: number;
+  costUsd?: number;
+  createdAt: string;
+};
+
+export type GroupTurn = GroupUserTurn | GroupReply;
+
+/**
+ * The subset of `/api/chat/send` stream events the group surface consumes.
+ * Mirrors the shape in chat-view.tsx; unknown kinds are ignored by the reducer.
+ */
+export type GroupStreamEvent =
+  | { kind: "session"; sessionId: string }
+  | { kind: "user"; text: string }
+  | { kind: "assistant_chunk"; text: string }
+  | { kind: "progress"; label?: string; status?: "running" | "done" | "error" }
+  | { kind: "tool_use"; name?: string; status?: "running" | "ok" | "error" }
+  | { kind: "done"; durationMs?: number; isError?: boolean; sessionId?: string; costUsd?: number }
+  | { kind: "error"; message: string; code?: string };
+
+// ---------------------------------------------------------------------------
+// Streaming reducers (pure)
+// ---------------------------------------------------------------------------
+
+/** Apply one stream event to a reply, returning the next immutable state. */
+export function applyGroupEvent(reply: GroupReply, ev: GroupStreamEvent): GroupReply {
+  switch (ev.kind) {
+    case "session":
+      return { ...reply, sessionId: ev.sessionId };
+    case "assistant_chunk":
+      return { ...reply, status: "streaming", activity: undefined, text: reply.text + ev.text };
+    case "progress":
+      return {
+        ...reply,
+        status: reply.status === "queued" ? "streaming" : reply.status,
+        activity: ev.status === "done" ? reply.activity : ev.label ?? reply.activity,
+      };
+    case "tool_use":
+      return {
+        ...reply,
+        status: reply.status === "queued" ? "streaming" : reply.status,
+        activity: ev.name ? `${ev.name}…` : reply.activity,
+      };
+    case "done":
+      return {
+        ...reply,
+        status: ev.isError ? "error" : "done",
+        sessionId: ev.sessionId ?? reply.sessionId,
+        durationMs: ev.durationMs ?? reply.durationMs,
+        costUsd: ev.costUsd ?? reply.costUsd,
+        activity: undefined,
+        error: ev.isError ? reply.error ?? "request failed" : reply.error,
+      };
+    case "error":
+      return { ...reply, status: "error", error: ev.message, activity: undefined };
+    default:
+      return reply;
+  }
+}
+
+/**
+ * Parse the rolling SSE buffer into complete `data:` events, returning the
+ * leftover partial frame. Same `\n\n`-delimited framing as chat-view.tsx.
+ */
+export function parseSseBuffer(buffer: string): { events: GroupStreamEvent[]; rest: string } {
+  const events: GroupStreamEvent[] = [];
+  let rest = buffer;
+  let idx: number;
+  while ((idx = rest.indexOf("\n\n")) >= 0) {
+    const frame = rest.slice(0, idx);
+    rest = rest.slice(idx + 2);
+    if (!frame.startsWith("data:")) continue;
+    const payload = frame.slice(5).trim();
+    if (!payload) continue;
+    try {
+      events.push(JSON.parse(payload) as GroupStreamEvent);
+    } catch {
+      /* skip malformed frame */
+    }
+  }
+  return { events, rest };
+}
+
+// ---------------------------------------------------------------------------
+// Group bookkeeping (pure)
+// ---------------------------------------------------------------------------
+
+/** Derive a friendly default name from participant display names. */
+export function defaultGroupName(names: string[]): string {
+  const clean = names.map((n) => n.trim()).filter(Boolean);
+  if (clean.length === 0) return "New coven";
+  if (clean.length === 1) return clean[0];
+  if (clean.length === 2) return `${clean[0]} & ${clean[1]}`;
+  return `${clean[0]}, ${clean[1]} +${clean.length - 2}`;
+}
+
+export function makeGroup(
+  name: string,
+  familiarIds: string[],
+  now: string,
+  id: string,
+): CovenGroup {
+  return {
+    id,
+    name: name.trim() || "New coven",
+    familiarIds: dedupe(familiarIds),
+    sessions: {},
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/** Insert or replace a group, keeping most-recently-updated first. */
+export function upsertGroup(groups: CovenGroup[], group: CovenGroup): CovenGroup[] {
+  const rest = groups.filter((g) => g.id !== group.id);
+  return [group, ...rest].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+export function removeGroup(groups: CovenGroup[], id: string): CovenGroup[] {
+  return groups.filter((g) => g.id !== id);
+}
+
+/** Record (or clear) the resumed session id for one familiar in a group. */
+export function setGroupSession(
+  group: CovenGroup,
+  familiarId: string,
+  sessionId: string | null,
+  now: string,
+): CovenGroup {
+  const sessions = { ...group.sessions };
+  if (sessionId) sessions[familiarId] = sessionId;
+  else delete sessions[familiarId];
+  return { ...group, sessions, updatedAt: now };
+}
+
+/** Update a group's participant roster, dropping orphaned session pins. */
+export function setGroupParticipants(
+  group: CovenGroup,
+  familiarIds: string[],
+  now: string,
+): CovenGroup {
+  const ids = dedupe(familiarIds);
+  const sessions: Record<string, string> = {};
+  for (const id of ids) {
+    if (group.sessions[id]) sessions[id] = group.sessions[id];
+  }
+  return { ...group, familiarIds: ids, sessions, updatedAt: now };
+}
+
+function dedupe(ids: string[]): string[] {
+  return [...new Set(ids.filter(Boolean))];
+}
+
+// ---------------------------------------------------------------------------
+// Persistence (thin localStorage wrappers — safe to call client-side only)
+// ---------------------------------------------------------------------------
+
+export function loadGroups(): CovenGroup[] {
+  if (typeof localStorage === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(GROUPS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isCovenGroup);
+  } catch {
+    return [];
+  }
+}
+
+export function saveGroups(groups: CovenGroup[]): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(GROUPS_KEY, JSON.stringify(groups));
+  } catch {
+    /* storage full / private mode — keep the in-memory copy */
+  }
+}
+
+export function loadTranscript(groupId: string): GroupTurn[] {
+  if (typeof localStorage === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(TRANSCRIPTS_KEY_PREFIX + groupId);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? (parsed as GroupTurn[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveTranscript(groupId: string, turns: GroupTurn[]): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    // Drop in-flight replies — a reload can't resume a half-finished stream, so
+    // persisting "streaming" state would strand a permanent spinner.
+    const settled = turns.filter(
+      (t) => t.role === "user" || (t as GroupReply).status === "done" || (t as GroupReply).status === "error",
+    );
+    localStorage.setItem(TRANSCRIPTS_KEY_PREFIX + groupId, JSON.stringify(settled));
+  } catch {
+    /* ignore */
+  }
+}
+
+function isCovenGroup(value: unknown): value is CovenGroup {
+  if (!value || typeof value !== "object") return false;
+  const g = value as Record<string, unknown>;
+  return (
+    typeof g.id === "string" &&
+    typeof g.name === "string" &&
+    Array.isArray(g.familiarIds) &&
+    typeof g.sessions === "object" &&
+    g.sessions !== null
+  );
+}

--- a/src/lib/workspace-mode.ts
+++ b/src/lib/workspace-mode.ts
@@ -2,6 +2,7 @@ export type WorkspaceMode =
   | "agents"
   | "home"
   | "chat"
+  | "groupchat"
   | "board"
   | "calendar"
   | "inbox"


### PR DESCRIPTION
## What

Adds a comprehensive **Group Chat** section to the Cave UI, aligned with the coven/coven-code model. You assemble a *coven* — a saved set of familiars — and broadcast a single prompt to all of them at once. Each familiar answers in **its own resumable `/api/chat/send` session**, and replies are attributed inline.

This mirrors how the daemon/coven CLI actually works: there is no server-side "group session" concept, so the group lives client-side and pins one session id per familiar (the same fan-out the iOS app already uses).

## Surface

- **New "Group" surface** in the Work nav group (`ph:users-three`), `groupchat` workspace mode.
- **Coven list rail** — saved covens with stacked participant avatars, member count, and relative last-updated time; create / delete.
- **Participant picker** — popover to toggle familiars in/out; a fresh coven auto-names from its members until renamed.
- **Threaded transcript** — your broadcast on top, each familiar's reply attributed below with avatar + name, full Markdown via the shared `MessageBubble`, live "thinking…" activity, per-reply error state.
- **Broadcast composer** — one prompt fans out to every participant in parallel; **Stop** aborts the in-flight broadcast.
- Per-familiar threads resume across reloads (session ids persisted); settled transcripts cached in `localStorage`.

## Code

- `src/lib/group-chat.ts` — framework-free model + reducers: `applyGroupEvent`, `parseSseBuffer`, group CRUD, session pinning, persistence. **15 unit tests.**
- `src/components/group-chat-view.tsx` — the surface (reuses `MessageBubble`, `FamiliarAvatar`, `EmptyState`, `Popover`, `Button`).
- Navigation wiring: `workspace-mode.ts`, `sidebar-minimal.tsx`, `workspace.tsx`.
- Source-text wiring test; both suites registered in `scripts/run-tests.mjs`.

## Verification

- `pnpm typecheck` — 0 errors
- `group-chat.test.ts` (15) + `group-chat-view.test.ts` (2) + `sidebar-minimal.test.ts` — green
- `check:tests-wired` — all suites wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)