### PR TITLE
feat(flow): drag-to-connect new node + mid-edge "+" insertion

### DIFF
--- a/src/components/flow/flow-canvas.tsx
+++ b/src/components/flow/flow-canvas.tsx
@@ -12,10 +12,12 @@ import {
   useReactFlow,
   type Connection,
   type Edge,
+  type EdgeTypes,
   type Node,
   type NodeChange,
   type NodeMouseHandler,
   type NodeTypes,
+  type OnConnectStartParams,
 } from "@xyflow/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
@@ -29,8 +31,13 @@ import {
   type FlowNodeData,
   type FlowNodePhase,
 } from "./flow-node";
+import { FlowEdge } from "./flow-edge";
 
 const nodeTypes: NodeTypes = { flowNode: FlowNodeView, flowSticky: FlowStickyView };
+const edgeTypes: EdgeTypes = { flowEdge: FlowEdge };
+
+/** A handle a connection was dragged from (output `source` or input `target`). */
+export type FlowConnectFrom = { nodeId: string; handleId: string; handleType: "source" | "target" };
 
 export type FlowCanvasProps = {
   doc: FlowDoc;
@@ -47,6 +54,10 @@ export type FlowCanvasProps = {
   onMoveNodes: (positions: Record<string, FlowPosition>) => void;
   /** Open the node catalog to add a node at this flow-space position. */
   onRequestAdd: (position: FlowPosition) => void;
+  /** Dragged a connection onto empty canvas — add a node wired to that handle. */
+  onConnectToNew: (from: FlowConnectFrom, position: FlowPosition) => void;
+  /** Clicked the "+" on an edge — splice a node into that connection. */
+  onInsertEdge: (edgeId: string) => void;
 };
 
 function FlowCanvasInner(props: FlowCanvasProps) {
@@ -63,9 +74,14 @@ function FlowCanvasInner(props: FlowCanvasProps) {
     onRemoveNode,
     onMoveNodes,
     onRequestAdd,
+    onConnectToNew,
+    onInsertEdge,
   } = props;
   const [showMiniMap, setShowMiniMap] = useState(false);
   const { screenToFlowPosition } = useReactFlow();
+  // The handle a connection drag started from, captured so a drop on empty
+  // canvas can wire the new node back to it.
+  const connectFrom = useRef<FlowConnectFrom | null>(null);
 
   // Nodes live in local state so drags stay smooth; the doc is the source of
   // truth for structure, local state only owns in-flight positions.
@@ -128,13 +144,14 @@ function FlowCanvasInner(props: FlowCanvasProps) {
           target: edge.target,
           sourceHandle: edge.sourceHandle,
           targetHandle: edge.targetHandle,
-          type: "smoothstep",
+          type: "flowEdge",
           animated: isActive,
           className: isActive ? "flow-edge-active" : undefined,
           markerEnd: { type: MarkerType.ArrowClosed, width: 14, height: 14, color: "#7d83a8" },
+          data: { onInsert: () => onInsertEdge(edge.id) },
         } satisfies Edge;
       }),
-    [doc.edges, activeNodeId],
+    [doc.edges, activeNodeId, onInsertEdge],
   );
 
   const handleNodesChange = useCallback((changes: NodeChange<Node<FlowNodeData>>[]) => {
@@ -170,6 +187,34 @@ function FlowCanvasInner(props: FlowCanvasProps) {
       );
     },
     [onConnect],
+  );
+
+  const handleConnectStart = useCallback(
+    (_event: unknown, params: OnConnectStartParams) => {
+      connectFrom.current = params.nodeId
+        ? {
+            nodeId: params.nodeId,
+            handleId: params.handleId ?? (params.handleType === "target" ? "in" : "main"),
+            handleType: params.handleType === "target" ? "target" : "source",
+          }
+        : null;
+    },
+    [],
+  );
+
+  const handleConnectEnd = useCallback(
+    (event: MouseEvent | TouchEvent, connectionState: { isValid: boolean | null }) => {
+      const from = connectFrom.current;
+      connectFrom.current = null;
+      if (!from) return;
+      // A valid drop (onto a handle) becomes a real connection via onConnect.
+      // Only an invalid drop — empty canvas — opens the catalog for a new node.
+      if (connectionState?.isValid) return;
+      const point = "changedTouches" in event ? event.changedTouches[0] : event;
+      const position = screenToFlowPosition({ x: point.clientX, y: point.clientY });
+      onConnectToNew(from, position);
+    },
+    [onConnectToNew, screenToFlowPosition],
   );
 
   const handleEdgesDelete = useCallback(
@@ -226,6 +271,7 @@ function FlowCanvasInner(props: FlowCanvasProps) {
         nodes={renderNodes}
         edges={edges}
         nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
         fitView
         nodesDraggable
         minZoom={0.2}
@@ -234,6 +280,8 @@ function FlowCanvasInner(props: FlowCanvasProps) {
         onNodeDragStop={handleNodeDragStop}
         onNodeClick={handleNodeClick}
         onNodeDoubleClick={handleNodeDoubleClick}
+        onConnectStart={handleConnectStart}
+        onConnectEnd={handleConnectEnd}
         onPaneClick={() => onSelectNode(null)}
         onConnect={handleConnect}
         onEdgesDelete={handleEdgesDelete}

--- a/src/components/flow/flow-edge.tsx
+++ b/src/components/flow/flow-edge.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  getSmoothStepPath,
+  type Edge,
+  type EdgeProps,
+} from "@xyflow/react";
+
+export type FlowEdgeData = {
+  /** Open the node catalog to splice a node into this edge. */
+  onInsert?: () => void;
+} & Record<string, unknown>;
+
+export type FlowRFEdge = Edge<FlowEdgeData, "flowEdge">;
+
+/**
+ * Smoothstep edge with an n8n-style "+" button at its midpoint. Clicking it
+ * asks the editor to splice a new node into the connection (A→B → A→new→B).
+ */
+export function FlowEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  markerEnd,
+  data,
+}: EdgeProps<FlowRFEdge>) {
+  const [path, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+    borderRadius: 12,
+  });
+
+  return (
+    <>
+      <BaseEdge id={id} path={path} markerEnd={markerEnd} />
+      {data?.onInsert && (
+        <EdgeLabelRenderer>
+          <button
+            type="button"
+            className="flow-edge-add nodrag nopan"
+            style={{
+              position: "absolute",
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+              pointerEvents: "all",
+            }}
+            title="Insert a node here"
+            aria-label="Insert a node on this connection"
+            onClick={(event) => {
+              event.stopPropagation();
+              data.onInsert?.();
+            }}
+          >
+            +
+          </button>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
+}

--- a/src/components/flow/flow-view.tsx
+++ b/src/components/flow/flow-view.tsx
@@ -9,6 +9,7 @@ import { Icon } from "@/lib/icon";
 import type { Familiar } from "@/lib/types";
 import { catalogNode, createNode } from "@/lib/flow/flow-catalog";
 import {
+  addConnectedNode,
   connect,
   disconnect,
   emptyFlow,
@@ -21,6 +22,7 @@ import {
   setActive,
   setNodeNotes,
   setNodeParam,
+  spliceNodeOnEdge,
   toggleNodeDisabled,
   updateSticky,
   type FlowDoc,
@@ -43,13 +45,18 @@ import {
   updateFlowRun,
   type FlowRunRecord,
 } from "@/lib/flows";
-import { FlowCanvas } from "./flow-canvas";
+import { FlowCanvas, type FlowConnectFrom } from "./flow-canvas";
 import { FlowExecutions } from "./flow-executions";
 import { FlowLibrary } from "./flow-library";
 import { FlowToolbar, type FlowTab } from "./flow-toolbar";
 import { NodeCatalogPanel } from "./node-catalog-panel";
 import { NodeDetailView, type NodeDetailOption } from "./node-detail-view";
 import { useFlowRun } from "./use-flow-run";
+
+type CatalogIntent =
+  | { kind: "add"; position: FlowPosition }
+  | { kind: "connect"; from: FlowConnectFrom; position: FlowPosition }
+  | { kind: "splice"; edgeId: string };
 
 function slugifyFlowId(name: string): string {
   return (
@@ -87,7 +94,9 @@ export function FlowView() {
   const progress = useFlowRun(activeRun);
   const running = activeRun?.status === "running" && !progress.done;
 
-  const addPositionRef = useRef<FlowPosition>({ x: 160, y: 160 });
+  // What picking a catalog node should do: drop it free, wire it to a dragged
+  // handle, or splice it into an edge.
+  const catalogIntentRef = useRef<CatalogIntent>({ kind: "add", position: { x: 160, y: 160 } });
   const mountedRef = useRef(true);
   const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -428,21 +437,63 @@ export function FlowView() {
 
   // ---- Canvas / node mutation handlers ----
   const requestAdd = useCallback((position: FlowPosition) => {
-    addPositionRef.current = position;
+    catalogIntentRef.current = { kind: "add", position };
+    setCatalogOpen(true);
+  }, []);
+
+  const requestConnectToNew = useCallback((from: FlowConnectFrom, position: FlowPosition) => {
+    catalogIntentRef.current = { kind: "connect", from, position };
+    setCatalogOpen(true);
+  }, []);
+
+  const requestInsertEdge = useCallback((edgeId: string) => {
+    catalogIntentRef.current = { kind: "splice", edgeId };
     setCatalogOpen(true);
   }, []);
 
   const pickNode = useCallback(
     (type: string) => {
+      const intent = catalogIntentRef.current;
       setCatalogOpen(false);
       setDraftState((current) => {
         if (!current) return current;
-        const node = createNode(current.doc, type, addPositionRef.current);
+        const doc = current.doc;
+        const def = catalogNode(type);
+        const inHandle = def?.inputs[0]?.id ?? "in";
+        const outHandle = def?.outputs[0]?.id ?? "main";
+
+        // Splicing positions the node at the edge's midpoint; otherwise use the
+        // intent's drop point.
+        let position: FlowPosition;
+        if (intent.kind === "splice") {
+          const edge = doc.edges.find((e) => e.id === intent.edgeId);
+          const src = edge && doc.nodes.find((n) => n.id === edge.source);
+          const tgt = edge && doc.nodes.find((n) => n.id === edge.target);
+          position =
+            src && tgt
+              ? { x: (src.position.x + tgt.position.x) / 2, y: (src.position.y + tgt.position.y) / 2 }
+              : { x: 200, y: 200 };
+        } else {
+          position = intent.position;
+        }
+
+        const node = createNode(doc, type, position);
         if (!node) return current;
-        // Stagger the next add so repeated picks don't stack exactly.
-        addPositionRef.current = { x: addPositionRef.current.x + 40, y: addPositionRef.current.y + 40 };
+
+        // Sticky notes have no ports — never wire them, just drop them.
+        let next: FlowDoc;
+        if (def?.sticky || intent.kind === "add") {
+          next = { ...doc, nodes: [...doc.nodes, node] };
+        } else if (intent.kind === "connect") {
+          next = addConnectedNode(doc, node, intent.from, inHandle, outHandle);
+        } else {
+          next = spliceNodeOnEdge(doc, intent.edgeId, node, inHandle, outHandle);
+        }
+
+        // Stagger the next plain add so repeated picks don't stack exactly.
+        catalogIntentRef.current = { kind: "add", position: { x: position.x + 40, y: position.y + 40 } };
         setSelectedNodeId(node.id);
-        return flowDraftReducer(current, { type: "apply", next: { ...current.doc, nodes: [...current.doc.nodes, node] } });
+        return flowDraftReducer(current, { type: "apply", next });
       });
     },
     [],
@@ -542,6 +593,8 @@ export function FlowView() {
                   onRemoveNode={onRemoveNode}
                   onMoveNodes={onMoveNodes}
                   onRequestAdd={requestAdd}
+                  onConnectToNew={requestConnectToNew}
+                  onInsertEdge={requestInsertEdge}
                 />
                 {selectedNode && (
                   <NodeDetailView

--- a/src/lib/flow/flow-doc.test.ts
+++ b/src/lib/flow/flow-doc.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+  addConnectedNode,
   addNode,
   connect,
   disconnect,
@@ -14,6 +15,7 @@ import {
   sameDoc,
   setActive,
   setNodeParam,
+  spliceNodeOnEdge,
   uniqueNodeName,
   type FlowDoc,
   type FlowNode,
@@ -149,6 +151,37 @@ function base(): FlowDoc {
   const b = { ...a, updatedAt: "2099-01-01T00:00:00.000Z" };
   assert.equal(sameDoc(a, b), true);
   assert.equal(sameDoc(a, setActive(a, true)), false);
+}
+
+// spliceNodeOnEdge: A→B becomes A→mid→B
+{
+  let doc = base();
+  doc = connect(doc, "a", "main", "b", "in");
+  const eid = doc.edges[0].id;
+  const mid = node("mid", "logic.filter");
+  doc = spliceNodeOnEdge(doc, eid, mid, "in", "main");
+  assert.ok(doc.nodes.some((n) => n.id === "mid"), "node added");
+  assert.ok(!doc.edges.some((e) => e.id === eid), "original edge removed");
+  assert.ok(doc.edges.some((e) => e.source === "a" && e.target === "mid"), "A→mid");
+  assert.ok(doc.edges.some((e) => e.source === "mid" && e.target === "b"), "mid→B");
+  assert.equal(doc.edges.length, 2);
+  // bad edge id → no-op
+  assert.equal(spliceNodeOnEdge(doc, "nope", node("z"), "in", "main").nodes.length, doc.nodes.length);
+}
+
+// addConnectedNode: drag from an output connects output→new
+{
+  let doc = base();
+  doc = addConnectedNode(doc, node("fresh", "familiar"), { nodeId: "a", handleId: "main", handleType: "source" }, "in", "main");
+  assert.ok(doc.nodes.some((n) => n.id === "fresh"));
+  assert.ok(doc.edges.some((e) => e.source === "a" && e.sourceHandle === "main" && e.target === "fresh" && e.targetHandle === "in"));
+}
+
+// addConnectedNode: drag from an input connects new→input
+{
+  let doc = base();
+  doc = addConnectedNode(doc, node("up", "familiar"), { nodeId: "b", handleId: "in", handleType: "target" }, "in", "main");
+  assert.ok(doc.edges.some((e) => e.source === "up" && e.sourceHandle === "main" && e.target === "b" && e.targetHandle === "in"));
 }
 
 console.log("flow-doc.test.ts OK");

--- a/src/lib/flow/flow-doc.ts
+++ b/src/lib/flow/flow-doc.ts
@@ -194,6 +194,48 @@ export function disconnectEndpoints(doc: FlowDoc, source: string, target: string
   return { ...doc, edges: doc.edges.filter((edge) => !(edge.source === source && edge.target === target)) };
 }
 
+/**
+ * Splice a new node into an existing edge: `A → B` becomes `A → node → B`.
+ * The original edge is removed and two new edges wire the node in through its
+ * given input/output handles. No-op if the edge or node is missing.
+ */
+export function spliceNodeOnEdge(
+  doc: FlowDoc,
+  edgeId: string,
+  node: FlowNode,
+  inHandle: string,
+  outHandle: string,
+): FlowDoc {
+  const edge = doc.edges.find((e) => e.id === edgeId);
+  if (!edge) return doc;
+  let next = addNode(doc, node);
+  next = disconnect(next, edgeId);
+  next = connect(next, edge.source, edge.sourceHandle, node.id, inHandle);
+  next = connect(next, node.id, outHandle, edge.target, edge.targetHandle);
+  return next;
+}
+
+/**
+ * Add a node and wire it to a handle a connection was dragged from. Dragging
+ * from an output (`source`) connects that output into the new node's input;
+ * dragging from an input (`target`) connects the new node's output into it.
+ */
+export function addConnectedNode(
+  doc: FlowDoc,
+  node: FlowNode,
+  from: { nodeId: string; handleId: string; handleType: "source" | "target" },
+  inHandle: string,
+  outHandle: string,
+): FlowDoc {
+  let next = addNode(doc, node);
+  if (from.handleType === "target") {
+    next = connect(next, node.id, outHandle, from.nodeId, from.handleId);
+  } else {
+    next = connect(next, from.nodeId, from.handleId, node.id, inHandle);
+  }
+  return next;
+}
+
 function mapNode(doc: FlowDoc, id: string, fn: (node: FlowNode) => FlowNode): FlowDoc {
   let changed = false;
   const nodes = doc.nodes.map((node) => {

--- a/src/styles/flow.css
+++ b/src/styles/flow.css
@@ -130,6 +130,26 @@
 .flow-canvas .react-flow__edge.flow-edge-active .react-flow__edge-path { stroke: var(--accent-presence); stroke-width: 2.4; }
 .flow-canvas .react-flow__connection-path { stroke: var(--accent-presence); stroke-width: 2; }
 
+/* Mid-edge "+" insert button (n8n-style). Subtle until the edge/button is hovered. */
+.flow-edge-add {
+  display: grid; place-items: center;
+  width: 18px; height: 18px; padding: 0;
+  border: 1px solid var(--border); border-radius: 50%;
+  background: var(--bg-elevated); color: var(--text-secondary);
+  font-size: 13px; line-height: 1; font-weight: 600;
+  cursor: pointer; opacity: 0; box-shadow: 0 2px 8px rgb(0 0 0 / 30%);
+  transition: opacity 120ms var(--ease-standard), background 120ms var(--ease-standard), color 120ms var(--ease-standard);
+}
+.react-flow__edge:hover .flow-edge-add,
+.flow-edge-add:hover,
+.flow-edge-add:focus-visible { opacity: 1; }
+.flow-edge-add:hover {
+  background: color-mix(in oklch, var(--accent-presence) 30%, var(--bg-elevated));
+  color: var(--text-primary);
+  border-color: color-mix(in oklch, var(--accent-presence) 55%, var(--border));
+}
+@media (prefers-reduced-motion: reduce) { .flow-edge-add { transition: none; } }
+
 /* ---- Node card ---------------------------------------------------------- */
 .flow-node {
   position: relative; box-sizing: border-box;


### PR DESCRIPTION
## What

PR 3 of the n8n-style Flow editor (builds on #1843, #1850). Two n8n-signature canvas interactions for wiring flows faster:

- **Mid-edge "+"** — a custom edge renders a **+** button at its midpoint; clicking it opens the node catalog and **splices** the picked node into the connection: `A→B` becomes `A→new→B` (new node placed at the edge midpoint).
- **Drag-to-connect** — dragging a connection from a node's port onto **empty canvas** opens the catalog, and the picked node is created at the drop point **already wired** to that handle (output→new, or new→input when dragging from an input).

Both route through one `CatalogIntent` (`add` | `connect` | `splice`) so the existing catalog + NDV flow is reused. Sticky notes are never wired.

## How

- **Pure, unit-tested helpers** in `flow-doc.ts`: `spliceNodeOnEdge` (remove edge → add node → wire `A→new→B`) and `addConnectedNode` (respects drag direction).
- **`flow-edge.tsx`** — `BaseEdge` + `EdgeLabelRenderer` "+" button (subtle until hover/focus).
- **flow-canvas** — `edgeTypes`, `onConnectStart`/`onConnectEnd` (empty-drop detected via React Flow's documented `connectionState.isValid`), new `onConnectToNew`/`onInsertEdge` props.

## Verification

- ✅ **Mid-edge splice verified end-to-end in the running app**: click **+** on the `Manual Trigger → Familiar` edge → pick **HTTP Request** → result is `Manual Trigger → HTTP Request → Familiar` (3 nodes / 2 edges), NDV opens on the new node.
- **Drag-to-connect** uses the same connection lifecycle the editor's existing handle-to-handle `onConnect` already ships (you connect nodes today). React Flow's pointer-capture connection drags aren't drivable by Playwright's synthetic mouse — confirmed by a discriminating test (even a plain handle-to-handle drag creates no edge in the harness) — so it's covered by the unit-tested pure helpers + the official `onConnectStart`/`onConnectEnd` wiring rather than an e2e drag.
- ✅ `pnpm typecheck` 0 errors · app suite (411 files) · `next build && build:server` exit 0 · extended `flow-doc` unit tests (splice + connect-direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)