### PR TITLE
fix(a11y): announce voice-call status + friendly error messages

### DIFF
--- a/src/components/voice-call-overlay.test.ts
+++ b/src/components/voice-call-overlay.test.ts
@@ -65,4 +65,37 @@ assert.match(
   "end-call button reads as the destructive primary action",
 );
 
+// ── Call status + errors are announced to assistive tech ─────────────────────
+// Was: a plain <span> whose text cycled through requesting-mic → connecting →
+// live → error with no live region, so screen readers heard nothing.
+assert.match(
+  component,
+  /className="voice-call-overlay__state" role="status" aria-live="polite"/,
+  "the call-status label is a polite live region so transitions are announced",
+);
+assert.match(
+  component,
+  /className="voice-call-overlay__error" role="alert"/,
+  "the error block is an alert so failures interrupt the screen reader",
+);
+assert.match(
+  component,
+  /aria-describedby=\{state\.state === "error" \? "voice-call-overlay-error" : undefined\}/,
+  "the dialog is described by the error message while in the error state",
+);
+assert.match(
+  component,
+  /<div id="voice-call-overlay-error">\{errorMessage\(state\.errorCode\)\}<\/div>/,
+  "the error headline is a human message, not the raw error code",
+);
+
+// ── Raw error codes map to actionable messages ───────────────────────────────
+assert.match(component, /function errorMessage\(code: string \| undefined\): string/, "errorMessage maps codes to readable text");
+assert.match(component, /case "microphone_denied":[\s\S]*?Microphone access was denied/, "microphone_denied becomes a friendly, actionable message");
+assert.doesNotMatch(
+  component,
+  /<div>\{state\.errorCode\}<\/div>/,
+  "the raw error code is no longer rendered as the headline",
+);
+
 console.log("voice-call-overlay.test.ts: ok");

--- a/src/components/voice-call-overlay.tsx
+++ b/src/components/voice-call-overlay.tsx
@@ -143,19 +143,20 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
         role="dialog"
         aria-modal="true"
         aria-labelledby="voice-call-overlay-title"
+        aria-describedby={state.state === "error" ? "voice-call-overlay-error" : undefined}
         tabIndex={-1}
       >
         <header className="voice-call-overlay__header">
           <div className="voice-call-overlay__heading">
             <strong id="voice-call-overlay-title">{familiar.display_name}</strong>
-            <span className="voice-call-overlay__state">{labelFor(state)}</span>
+            <span className="voice-call-overlay__state" role="status" aria-live="polite">{labelFor(state)}</span>
           </div>
           {state.state === "live" && <span className="voice-call-overlay__duration">{mm}:{ss}</span>}
         </header>
         <div className="voice-call-overlay__body">
           {state.state === "error" && (
-            <div className="voice-call-overlay__error">
-              <div>{state.errorCode}</div>
+            <div className="voice-call-overlay__error" role="alert">
+              <div id="voice-call-overlay-error">{errorMessage(state.errorCode)}</div>
               {state.hint && <div className="voice-call-overlay__hint">{state.hint}</div>}
               <button
                 type="button"
@@ -205,6 +206,23 @@ function labelFor(s: CallState): string {
     case "closed": return "Ended";
     case "error": return "Error";
     default: return "";
+  }
+}
+
+// Turn the machine-readable error code into something a person can act on. The
+// raw code (and any provider detail) still surfaces via the `hint` line below.
+function errorMessage(code: string | undefined): string {
+  switch (code) {
+    case "microphone_denied":
+      return "Microphone access was denied. Allow it in your browser settings to start a call.";
+    case "network":
+      return "Couldn't reach the voice service. Check your connection and try again.";
+    case "internal":
+      return "Something went wrong setting up the call. Please try again.";
+    case "connect_failed":
+      return "The call couldn't connect. Please try again.";
+    default:
+      return "The call ran into a problem. Please try again.";
   }
 }
 


### PR DESCRIPTION
## Voice Call Overlay audit

`VoiceCallOverlay` is a careful component — a reducer-driven state machine, shared focus trap with Escape handling, a portaled `aria-modal` dialog with `aria-labelledby`, `cancelled`-guarded async throughout, and mic-track cleanup. The recurring async/polling defect classes aren't present. Two gaps remained, both about communicating state to the user:

### 1. Call status + errors are announced to assistive tech
The status label cycled through "Requesting microphone…" → "Connecting…" → "Live" → "Ending…" → "Error" in a plain `<span>` with no live region — so a screen-reader user heard none of it (and in a modal, that text *is* the primary information). Now:
- the status label is a `role="status"` / `aria-live="polite"` region,
- the error block is a `role="alert"`,
- the dialog gets `aria-describedby` pointing at the error message while in the error state.

### 2. Friendly error messages instead of raw codes
The error headline rendered `{state.errorCode}` verbatim, so users saw `microphone_denied`, `network`, `internal`, `connect_failed`, or a provider `err.message`. Added an `errorMessage()` map mirroring the existing `labelFor()`; the provider detail still surfaces via the existing `hint` line.

## Verification
- `voice-call-overlay.test.ts` extended (announcements + friendly-message assertions) and `voice-call-overlay-state.test.ts` both pass · `tsc` clean · `pnpm build` clean
- No live Playwright pass: the overlay only mounts behind a real mic-grant + voice-provider connect flow that demo mode can't seed, so the source-text + type + build checks are the verification here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)