### PR TITLE
feat(ios): Library surface — saved reading + bookmarks (read-only)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/LibraryItem.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/LibraryItem.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// A saved Library entry, unified across the reading + bookmarks lists for
+/// display. (GitHub saves have their own Developer › GitHub section.)
+struct LibraryItem: Identifiable, Hashable {
+    let id: String
+    let title: String
+    let url: String
+    let subtitle: String?   // article type / domain
+    let familiar: String?
+    let savedAt: String?    // ISO timestamp
+}
+
+// Raw decode shapes — only the fields the app shows.
+struct LibraryReadingRaw: Decodable {
+    let id: String
+    let title: String?
+    let url: String?
+    let sourceType: String?
+    let addedAt: String?
+    let familiar: String?
+}
+struct LibraryBookmarkRaw: Decodable {
+    let id: String
+    let title: String?
+    let url: String?
+    let domain: String?
+    let savedAt: String?
+    let familiar: String?
+}
+struct LibraryReadingResponse: Decodable { let ok: Bool; let items: [LibraryReadingRaw] }
+struct LibraryBookmarksResponse: Decodable { let ok: Bool; let items: [LibraryBookmarkRaw] }

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -421,6 +421,38 @@ struct CaveClient {
         }
     }
 
+    /// `GET /api/library/reading` — saved reading list, mapped for display.
+    func libraryReading() async throws -> [LibraryItem] {
+        let req = try request("api/library/reading")
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        do {
+            return try JSONDecoder().decode(LibraryReadingResponse.self, from: data).items.map {
+                LibraryItem(id: $0.id, title: $0.title ?? $0.url ?? "Untitled",
+                            url: $0.url ?? "", subtitle: $0.sourceType,
+                            familiar: $0.familiar, savedAt: $0.addedAt)
+            }
+        } catch {
+            throw CaveError.decoding(String(describing: error))
+        }
+    }
+
+    /// `GET /api/library/bookmarks` — saved bookmarks, mapped for display.
+    func libraryBookmarks() async throws -> [LibraryItem] {
+        let req = try request("api/library/bookmarks")
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        do {
+            return try JSONDecoder().decode(LibraryBookmarksResponse.self, from: data).items.map {
+                LibraryItem(id: $0.id, title: $0.title ?? $0.domain ?? $0.url ?? "Untitled",
+                            url: $0.url ?? "", subtitle: $0.domain,
+                            familiar: $0.familiar, savedAt: $0.savedAt)
+            }
+        } catch {
+            throw CaveError.decoding(String(describing: error))
+        }
+    }
+
     /// `DELETE /api/inbox/{id}` — remove a reminder.
     func deleteReminder(id: String) async throws {
         let escaped = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id

--- a/apps/ios/CovenCave/CovenCave/Views/DeveloperView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/DeveloperView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /// you reach for between chats. A segmented switcher picks the section; each
 /// section owns its own navigation stack.
 enum DevSection: String, CaseIterable, Identifiable {
-    case code, terminal, github
+    case code, terminal, github, library
 
     var id: String { rawValue }
 
@@ -14,6 +14,7 @@ enum DevSection: String, CaseIterable, Identifiable {
         case .code: return "Code"
         case .terminal: return "Terminal"
         case .github: return "GitHub"
+        case .library: return "Library"
         }
     }
 
@@ -22,6 +23,7 @@ enum DevSection: String, CaseIterable, Identifiable {
         case .code: return "folder"
         case .terminal: return "terminal"
         case .github: return "arrow.triangle.branch"
+        case .library: return "books.vertical"
         }
     }
 }
@@ -54,6 +56,7 @@ struct DeveloperView: View {
             case .code: CodeBrowserView()
             case .terminal: TerminalView()
             case .github: GitHubView()
+            case .library: LibraryView()
             }
         }
     }

--- a/apps/ios/CovenCave/CovenCave/Views/LibraryView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/LibraryView.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+
+/// The Library: saved reading + bookmarks (`GET /api/library/{reading,bookmarks}`),
+/// read-only. A segmented control switches lists; tapping an item opens its URL.
+/// (Saved GitHub items have their own Developer › GitHub section.)
+struct LibraryView: View {
+    @Environment(AppModel.self) private var app
+
+    enum Kind: String, CaseIterable, Identifiable {
+        case reading = "Reading", bookmarks = "Bookmarks"
+        var id: String { rawValue }
+    }
+
+    @State private var kind: Kind = .reading
+    @State private var items: [LibraryItem] = []
+    @State private var loading = true
+    @State private var error: String?
+    @State private var query = ""
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Library")
+                .navigationBarTitleDisplayMode(.inline)
+                .searchable(text: $query, prompt: "Search library")
+                .safeAreaInset(edge: .top) { kindPicker }
+                .task(id: kind) { await load() }
+                .refreshable { await load() }
+        }
+    }
+
+    private var kindPicker: some View {
+        Picker("List", selection: $kind) {
+            ForEach(Kind.allCases) { k in Text(k.rawValue).tag(k) }
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .glassBar()
+    }
+
+    @ViewBuilder private var content: some View {
+        if loading {
+            ProgressView().controlSize(.large).frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error, items.isEmpty {
+            ContentUnavailableView {
+                Label("Couldn’t load the library", systemImage: "exclamationmark.triangle")
+            } description: { Text(error) } actions: {
+                Button("Retry") { Task { await load() } }.buttonStyle(.borderedProminent)
+            }
+        } else if visibleItems.isEmpty {
+            ContentUnavailableView {
+                Label(query.isEmpty ? "Nothing saved yet" : "No matches",
+                      systemImage: kind == .reading ? "book" : "bookmark")
+            } description: {
+                Text(query.isEmpty
+                     ? "Reading and bookmarks you save on the desktop show up here."
+                     : "Try a different search.")
+            }
+        } else {
+            List {
+                ForEach(visibleItems) { item in row(item) }
+            }
+            .listStyle(.plain)
+            .themedListBackground()
+        }
+    }
+
+    @ViewBuilder private func row(_ item: LibraryItem) -> some View {
+        if let url = URL(string: item.url), !item.url.isEmpty {
+            Link(destination: url) { LibraryRow(item: item) }
+                .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+        } else {
+            LibraryRow(item: item)
+                .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+        }
+    }
+
+    private var visibleItems: [LibraryItem] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !q.isEmpty else { return items }
+        return items.filter {
+            $0.title.lowercased().contains(q) || ($0.subtitle?.lowercased().contains(q) ?? false)
+        }
+    }
+
+    private func load() async {
+        loading = true
+        do {
+            switch kind {
+            case .reading: items = try await app.client?.libraryReading() ?? []
+            case .bookmarks: items = try await app.client?.libraryBookmarks() ?? []
+            }
+            error = nil
+        } catch {
+            self.error = error.localizedDescription
+            items = []
+        }
+        loading = false
+    }
+}
+
+private struct LibraryRow: View {
+    @Environment(AppModel.self) private var app
+    let item: LibraryItem
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "doc.text").font(.title3).foregroundStyle(.tint)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(item.title).font(.callout.weight(.medium)).lineLimit(2)
+                HStack(spacing: 6) {
+                    if let subtitle = item.subtitle, !subtitle.isEmpty {
+                        Text(subtitle).font(.caption2).foregroundStyle(.secondary).lineLimit(1)
+                    }
+                    if let by = item.familiar, let familiar = app.familiar(by) {
+                        Text("· \(familiar.displayName)").font(.caption2).foregroundStyle(.tertiary)
+                    }
+                    if let date = caveParseISO(item.savedAt) {
+                        Text(date, format: .relative(presentation: .numeric))
+                            .font(.caption2).foregroundStyle(.tertiary)
+                    }
+                }
+            }
+            Spacer(minLength: 0)
+            Image(systemName: "arrow.up.right.square").font(.caption).foregroundStyle(.tertiary)
+                .accessibilityHidden(true)
+        }
+        .padding(.vertical, 2)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/scripts/ios-no-canvas-tab.test.mjs
+++ b/scripts/ios-no-canvas-tab.test.mjs
@@ -49,7 +49,10 @@ for (const rel of [
 assert.doesNotMatch(model, /canvasArtifacts|generateArtifact|refineArtifact|loadCanvas/, "AppModel should drop canvas state/actions");
 assert.doesNotMatch(model, /loadReading|setReadingStatus|deleteReading|setReadingProgress|var reading:/, "AppModel should drop reading state/actions");
 assert.doesNotMatch(client, /canvasArtifacts|saveCanvasArtifact|deleteCanvasArtifact|api\/canvas/, "CaveClient should drop the canvas endpoints");
-assert.doesNotMatch(client, /func reading\(\)|updateReading|deleteReading|api\/library\/reading/, "CaveClient should drop the reading endpoints");
+// The old *mutable* Reading surface stays gone. The read-only Library
+// (Developer › Library) legitimately GETs /api/library/reading, so that path is
+// allowed — only the removed reading mutations are forbidden.
+assert.doesNotMatch(client, /func reading\(\)|updateReading|deleteReading|setReadingProgress/, "CaveClient should drop the old mutable reading endpoints");
 assert.doesNotMatch(slash, /\/canvas|buildSketchPrompt|case sketch/, "the /canvas slash command should be removed");
 
 console.log("ios-no-canvas-tab.test.mjs: ok");


### PR DESCRIPTION
Adds the Library as a 4th section of the **Developer hub** (Code · Terminal · GitHub · **Library**) — the natural home, since saved GitHub items already live there. Covers the two lists iOS lacked; GitHub saves keep their own section.

## What's in it
- **`Models/LibraryItem.swift`** — a unified display item + raw decode shapes for the reading & bookmarks endpoints.
- **CaveClient** — `libraryReading()` + `libraryBookmarks()` (`GET /api/library/{reading,bookmarks}`), mapped to `LibraryItem`.
- **LibraryView** — a Reading / Bookmarks segmented control, search, and a list of items (title · type/domain · familiar · saved-at) that open their URL on tap (mirrors GitHubView's `Link` rows). Loading / error+Retry / empty states + pull-to-refresh; reloads on segment change via `.task(id:)`.

Read-only on mobile (saving stays on the desktop), per the survey.

## Verified
- `xcodebuild` for the iOS Simulator: **BUILD SUCCEEDED**.
- Ran on the simulator against live `~/.coven` data — the Library lists real reading items (article/paper/repo · familiar · date) and switches to Bookmarks. Screenshot-confirmed.
- Mobile (65) + app (411) source-text suites green.
- Updated `ios-no-canvas-tab` to allow the read-only `/api/library/reading` GET — only the removed *mutable* reading endpoints stay forbidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)