### PR TITLE
feat(board): per-column WIP limits

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -176,6 +176,7 @@ export const SUITES = {
     "src/components/calendar-keyboard.test.ts",
     "src/components/task-chat-cwd.test.ts",
     "src/lib/board-search.test.ts",
+    "src/lib/board-wip.test.ts",
     "src/lib/comux-projects.test.ts",
     "src/lib/comux-project-order.test.ts",
     "src/lib/code-lang.test.ts",

--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -13,6 +13,8 @@ import type { GroupBy } from "@/components/board-table";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { useAnnouncer } from "@/components/ui/live-region";
+import { Popover } from "@/components/ui/popover";
+import { type WipLimits, wipState } from "@/lib/board-wip";
 
 const COLUMNS: { id: CardStatus; label: string; hint: string }[] = [
   { id: "backlog",  label: "Backlog",  hint: "Ideas and work not ready to dispatch." },
@@ -44,6 +46,10 @@ type Props = {
   isSelected?: (id: string) => boolean;
   onToggleSelect?: (id: string) => void;
   onNewCard: (status: CardStatus) => void;
+  /** Per-status WIP limits + setter. Shown/edited in status-grouping mode,
+      where a column's count is the unambiguous total for that status. */
+  wipLimits?: WipLimits;
+  onSetWipLimit?: (status: CardStatus, limit: number | null) => void;
   /** Inline quick-add: create a card from just a title in the given column
       (status), scoped to the swimlane it was added under (familiar/project). */
   onQuickAdd?: (
@@ -86,7 +92,76 @@ function getGroups(cards: Card[], by: GroupBy, familiars: Familiar[], projects: 
   return entries;
 }
 
-export function BoardKanban({ cards, familiars, projects, sessions, groupBy, selectedCardId, onSelect, onMoveStatus, selectMode = false, isSelected, onToggleSelect, onNewCard, onQuickAdd, onJumpToSession, onOpenTaskChat, chatLinkingId }: Props) {
+// The column-count badge. In status mode it doubles as a WIP-limit control:
+// click to set/clear a limit; the badge shows "count/limit" and turns danger
+// when the column is over its limit.
+function WipBadge({
+  status,
+  count,
+  limit,
+  onSet,
+}: {
+  status: CardStatus;
+  count: number;
+  limit: number | undefined;
+  onSet: (status: CardStatus, limit: number | null) => void;
+}) {
+  const anchorRef = useRef<HTMLButtonElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState(limit != null ? String(limit) : "");
+  useEffect(() => { setDraft(limit != null ? String(limit) : ""); }, [limit, open]);
+  const state = wipState(count, limit);
+  const commit = () => {
+    const n = parseInt(draft, 10);
+    onSet(status, Number.isFinite(n) && n > 0 ? n : null);
+    setOpen(false);
+  };
+  return (
+    <>
+      <button
+        ref={anchorRef}
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className={`board-kanban-column-count board-kanban-column-count--btn${
+          state === "over" ? " board-kanban-column-count--over" : state === "ok" ? " board-kanban-column-count--wip" : ""
+        }`}
+        title={limit != null ? `${count} of ${limit} — WIP limit (click to change)` : `${count} — set a WIP limit`}
+        aria-label={limit != null ? `${count} of ${limit}, WIP limit. Edit limit.` : `${count} cards. Set a WIP limit.`}
+      >
+        {limit != null ? `${count}/${limit}` : count}
+      </button>
+      <Popover open={open} onOpenChange={setOpen} anchorRef={anchorRef} placement="bottom-end" minWidth={150} ariaLabel={`WIP limit for ${status}`}>
+        <form
+          className="board-wip-form"
+          onSubmit={(e) => { e.preventDefault(); commit(); }}
+        >
+          <label className="board-wip-label">WIP limit</label>
+          <input
+            type="number"
+            min={1}
+            autoFocus
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Escape") { e.preventDefault(); setOpen(false); } }}
+            placeholder="None"
+            className="board-wip-input"
+            aria-label="Maximum cards"
+          />
+          <div className="board-wip-actions">
+            <button type="submit" className="board-wip-set">Set</button>
+            {limit != null && (
+              <button type="button" className="board-wip-clear" onClick={() => { onSet(status, null); setOpen(false); }}>
+                Clear
+              </button>
+            )}
+          </div>
+        </form>
+      </Popover>
+    </>
+  );
+}
+
+export function BoardKanban({ cards, familiars, projects, sessions, groupBy, selectedCardId, onSelect, onMoveStatus, selectMode = false, isSelected, onToggleSelect, onNewCard, wipLimits, onSetWipLimit, onQuickAdd, onJumpToSession, onOpenTaskChat, chatLinkingId }: Props) {
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<CardStatus | null>(null);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
@@ -436,6 +511,11 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
                   {COLUMNS.map((col) => {
                     const rows = grpGrouped.get(col.id) ?? [];
                     const isDrop = dropTarget === col.id;
+                    // WIP limits only apply in status mode, where rows.length is
+                    // the total for that status (not a per-swimlane slice).
+                    const wipEnabled = groupBy === "status" && !!onSetWipLimit;
+                    const wipLimit = wipEnabled ? wipLimits?.[col.id] : undefined;
+                    const wipOver = wipLimit != null && rows.length > wipLimit;
                     return (
                       <div key={col.id}
                         data-kanban-column={col.id}
@@ -444,11 +524,15 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
                         onDragOver={(e) => handleDragOver(e, col.id)}
                         onDragLeave={(e) => handleDragLeave(e, col.id)}
                         onDrop={(e) => handleDrop(e, col.id)}
-                        className={`board-kanban-column${isDrop ? " board-kanban-column--drop" : ""}`}>
+                        className={`board-kanban-column${isDrop ? " board-kanban-column--drop" : ""}${wipOver ? " board-kanban-column--wip-over" : ""}`}>
                         <div className="board-kanban-column-header">
                           <span className={`board-kanban-column-dot board-kanban-column-dot--${col.id}`} aria-hidden />
                           <span className="board-kanban-column-label" title={col.hint}>{col.label}</span>
-                          <span className="board-kanban-column-count">{rows.length}</span>
+                          {wipEnabled ? (
+                            <WipBadge status={col.id} count={rows.length} limit={wipLimit} onSet={onSetWipLimit!} />
+                          ) : (
+                            <span className="board-kanban-column-count">{rows.length}</span>
+                          )}
                           <button
                             type="button"
                             onClick={() => onNewCard(col.id)}

--- a/src/components/board-ux-polish.test.ts
+++ b/src/components/board-ux-polish.test.ts
@@ -130,4 +130,13 @@ assert.match(
 );
 assert.match(view, /onQuickAdd=\{quickAdd\}/, "BoardView wires the quick-add create path");
 
+// ── WIP limits per column (#3) ──
+assert.match(kanban, /wipLimits\?:\s*WipLimits/, "BoardKanban accepts WIP limits");
+assert.match(kanban, /const wipEnabled = groupBy === "status" && !!onSetWipLimit/, "WIP UI is scoped to status grouping where the count is the status total");
+assert.match(kanban, /board-kanban-column--wip-over/, "an over-limit column gets a warning treatment");
+assert.match(kanban, /\{limit != null \? `\$\{count\}\/\$\{limit\}` : count\}/, "the badge shows count/limit when a limit is set");
+assert.match(styles, /\.board-kanban-column-count--over\s*\{[^}]*--color-danger/, "over-limit count badge turns danger");
+assert.match(view, /onSetWipLimit=\{setWipLimitFor\}/, "BoardView wires the WIP-limit setter");
+assert.match(view, /writeWipLimits\(next\)/, "WIP limits persist on change");
+
 console.log("board-ux-polish.test.ts: ok");

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -6,6 +6,7 @@ import type { Familiar, SessionRow } from "@/lib/types";
 import { DEMO_BOARD_CARDS } from "@/lib/demo-seed";
 import { DEMO_MODE_EVENT, isDemoModeEnabled } from "@/lib/demo-mode";
 import { NewCardModal, type NewCardDraft } from "@/components/new-card-modal";
+import { type WipLimits, readWipLimits, writeWipLimits, setWipLimit } from "@/lib/board-wip";
 import { Icon } from "@/lib/icon";
 import { type Card, type CardStatus, STATUSES } from "@/lib/cave-board-types";
 import { cardMatchesBoardSearch } from "@/lib/board-search";
@@ -85,6 +86,16 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
   const [actionError, setActionError] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>(() => loadPref("cave:board:viewMode", "kanban", ["kanban", "table", "gantt"]));
   const [groupBy, setGroupBy] = useState<GroupBy>(() => loadPref("cave:board:groupBy", "status", ["status", "familiar", "project"]));
+  // Per-status WIP limits (loaded after mount to avoid SSR localStorage access).
+  const [wipLimits, setWipLimits] = useState<WipLimits>({});
+  useEffect(() => { setWipLimits(readWipLimits()); }, []);
+  const setWipLimitFor = useCallback((status: CardStatus, limit: number | null) => {
+    setWipLimits((prev) => {
+      const next = setWipLimit(prev, status, limit);
+      writeWipLimits(next);
+      return next;
+    });
+  }, []);
   // Gantt has its own grouping: by project (one bar per task) or by task (one
   // bar per checklist step). Separate from the kanban/table groupBy above.
   const [ganttGroup, setGanttGroup] = useState<"project" | "task" | "familiar">(() => loadPref("cave:board:ganttGroup", "project", ["project", "task", "familiar"]) as "project" | "task" | "familiar");
@@ -910,6 +921,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
             onSelect={setSelectedCardId} onMoveStatus={moveCardToStatus}
             selectMode={cardSelect.selectMode} isSelected={cardSelect.isSelected} onToggleSelect={cardSelect.toggle}
             onNewCard={(status) => { setModalDefaultStatus(status); setModalOpen(true); }}
+            wipLimits={wipLimits} onSetWipLimit={setWipLimitFor}
             onQuickAdd={quickAdd}
             onJumpToSession={onJumpToSession}
             onOpenTaskChat={onOpenTaskChat}

--- a/src/lib/board-wip.test.ts
+++ b/src/lib/board-wip.test.ts
@@ -1,0 +1,38 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { setWipLimit, wipState } from "./board-wip.ts";
+
+// ── setWipLimit: set, update, clear, and purity ──
+{
+  let limits = {};
+  limits = setWipLimit(limits, "running", 5);
+  assert.deepEqual(limits, { running: 5 }, "sets a limit");
+  limits = setWipLimit(limits, "review", 3);
+  assert.deepEqual(limits, { running: 5, review: 3 }, "second status appends");
+  limits = setWipLimit(limits, "running", 8);
+  assert.equal(limits.running, 8, "updates an existing limit");
+  // floor non-integers
+  limits = setWipLimit(limits, "running", 4.7);
+  assert.equal(limits.running, 4, "floors non-integer limits");
+  // clear via null / 0 / negative
+  for (const bad of [null, 0, -2]) {
+    const out = setWipLimit({ running: 5 }, "running", bad);
+    assert.deepEqual(out, {}, `clears the limit for ${bad}`);
+  }
+}
+{
+  const input = { running: 5 };
+  const copy = { ...input };
+  setWipLimit(input, "review", 2);
+  assert.deepEqual(input, copy, "does not mutate the input");
+}
+
+// ── wipState ──
+{
+  assert.equal(wipState(3, undefined), "none", "no limit → none");
+  assert.equal(wipState(3, 5), "ok", "under limit → ok");
+  assert.equal(wipState(5, 5), "ok", "at limit → ok (not over)");
+  assert.equal(wipState(6, 5), "over", "above limit → over");
+}
+
+console.log("board-wip.test.ts: ok");

--- a/src/lib/board-wip.ts
+++ b/src/lib/board-wip.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import type { CardStatus } from "@/lib/cave-board-types";
+
+// Per-status WIP (work-in-progress) limits, persisted board-wide. A status with
+// no entry has no limit. Keyed by status id so it's stable across renders.
+const WIP_KEY = "cave:board:wipLimits";
+
+export type WipLimits = Partial<Record<CardStatus, number>>;
+
+export function readWipLimits(): WipLimits {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(WIP_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    const out: WipLimits = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (typeof v === "number" && Number.isFinite(v) && v > 0) out[k as CardStatus] = Math.floor(v);
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+export function writeWipLimits(limits: WipLimits): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(WIP_KEY, JSON.stringify(limits));
+  } catch {
+    /* quota / private mode — non-fatal */
+  }
+}
+
+/**
+ * Set or clear one status's limit. A null/0/negative/non-integer limit clears
+ * it. Pure — returns a new object, never mutates the input.
+ */
+export function setWipLimit(limits: WipLimits, status: CardStatus, limit: number | null): WipLimits {
+  const next: WipLimits = { ...limits };
+  if (limit == null || !Number.isFinite(limit) || limit <= 0) {
+    delete next[status];
+  } else {
+    next[status] = Math.floor(limit);
+  }
+  return next;
+}
+
+export type WipState = "none" | "ok" | "over";
+
+/** Classify a column's count against its limit (for styling). Pure. */
+export function wipState(count: number, limit: number | undefined): WipState {
+  if (limit == null) return "none";
+  return count > limit ? "over" : "ok";
+}

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -251,6 +251,23 @@
 .board-kanban-column-dot--done { background:var(--color-success); color:var(--color-success); }
 .board-kanban-column-label { flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-size:13px; font-weight:700; color:var(--text-primary); letter-spacing:.01em; }
 .board-kanban-column-count { display:inline-flex; align-items:center; justify-content:center; min-width:18px; height:16px; padding:0 5px; border-radius:8px; background:var(--bg-raised); border:1px solid var(--border-hairline); color:var(--text-secondary); font-size:10px; font-weight:600; }
+/* WIP-limit control: the count badge becomes a clickable button. "n/limit"
+   reads as a budget; over the limit it turns danger and the column gets a
+   subtle warning rail. */
+.board-kanban-column-count--btn { cursor:pointer; font-variant-numeric:tabular-nums; transition:background .12s,color .12s,border-color .12s; }
+.board-kanban-column-count--btn:hover { border-color:var(--border-strong); color:var(--text-primary); }
+.board-kanban-column-count--btn:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }
+.board-kanban-column-count--wip { color:var(--text-primary); }
+.board-kanban-column-count--over { background:color-mix(in oklch,var(--color-danger) 18%,var(--bg-raised)); border-color:color-mix(in oklch,var(--color-danger) 45%,var(--border-hairline)); color:var(--color-danger); }
+.board-kanban-column--wip-over { border-color:color-mix(in oklch,var(--color-danger) 30%,var(--border-hairline)); box-shadow:inset 0 2px 0 color-mix(in oklch,var(--color-danger) 55%,transparent); }
+.board-wip-form { display:flex; flex-direction:column; gap:7px; padding:10px; min-width:150px; }
+.board-wip-label { font-size:11px; font-weight:600; color:var(--text-secondary); }
+.board-wip-input { width:100%; height:30px; padding:0 9px; border-radius:7px; border:1px solid var(--border-strong); background:var(--bg-base); color:var(--text-primary); font-size:13px; outline:none; }
+.board-wip-input:focus { border-color:color-mix(in oklch,var(--accent-presence) 55%,var(--border-strong)); box-shadow:0 0 0 3px color-mix(in oklch,var(--accent-presence) 16%,transparent); }
+.board-wip-actions { display:flex; align-items:center; gap:6px; }
+.board-wip-set { flex:1; height:28px; border-radius:6px; border:none; background:var(--accent-presence); color:#fff; font-size:12px; font-weight:600; cursor:pointer; }
+.board-wip-clear { height:28px; padding:0 10px; border-radius:6px; border:1px solid var(--border-hairline); background:transparent; color:var(--text-secondary); font-size:12px; cursor:pointer; }
+.board-wip-clear:hover { border-color:var(--border-strong); color:var(--text-primary); }
 .board-kanban-column-add { display:grid; place-items:center; width:22px; height:22px; border-radius:6px; border:none; background:transparent; color:var(--text-muted); cursor:pointer; transition:background .12s,color .12s; }
 .board-kanban-column-add:hover { background:var(--bg-hover); color:var(--text-primary); }
 .board-kanban-column-add:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }


### PR DESCRIPTION
Second of the Board UX improvements — work-in-progress limits on kanban columns.

## What
Click a column's **count badge** → set a max. The badge then reads **"count/limit"**; when the count exceeds the limit it turns **danger** and the column gets a red warning rail. Clear it from the same popover. Limits persist board-wide (`localStorage`, keyed by status).

## Scope
Shown/edited only in **status grouping**, where a column's count is the unambiguous total for that status. In familiar/project swimlanes the per-lane count would make a limit misleading, so the plain count is kept there.

## Implementation
- New pure **`board-wip.ts`** (`readWipLimits`/`writeWipLimits`/`setWipLimit`/`wipState`) — unit-tested + wired into the runner.
- Self-contained `WipBadge` (count button + shared `Popover` with a number input) in `board-kanban.tsx`.
- `board-view` owns the `wipLimits` state + persists on change.

## Verification (real app, Playwright)
Set a limit of **2** on a **4-card** "Running" column → badge shows red **"4/2"**, the column gains the warning rail, and `localStorage` holds `{"running":2}`.

Last of the Board pitch still to come: **#4 extended bulk-edit** (priority + labels in the bulk toolbar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)