### PR TITLE
fix(onboarding): Maintenance prune Check never offered Delete on daemon-native prune

### DIFF
--- a/src/app/api/sessions/prune/route.ts
+++ b/src/app/api/sessions/prune/route.ts
@@ -39,7 +39,21 @@ export async function POST(req: Request) {
   });
 
   if (native.ok && native.data) {
-    return NextResponse.json({ ok: true, pruned: native.data.pruned, method: "daemon" });
+    // For a dry run the daemon reports how many sessions *would* be pruned in
+    // `pruned`; surface it under `wouldPrune` (and keep `pruned: 0`) so the
+    // client reads the count the same way it does for the fallback path below.
+    // Without this the Maintenance "Check" action always saw `wouldPrune`
+    // undefined → count 0 → "Nothing to prune", and the Delete button never
+    // appeared, so a prune could never actually run.
+    return dryRun
+      ? NextResponse.json({
+          ok: true,
+          pruned: 0,
+          wouldPrune: native.data.pruned,
+          dryRun: true,
+          method: "daemon",
+        })
+      : NextResponse.json({ ok: true, pruned: native.data.pruned, method: "daemon" });
   }
 
   // Daemon doesn't support prune natively — do client-side pruning.


### PR DESCRIPTION
## Problem

On the setup / startup page, the **Maintenance → Check** action appeared dead: it always reported *"Nothing to prune."*, the **Delete N** button never showed, and no real error surfaced — so a prune could never actually run.

## Root cause

`MaintenancePanel` (in `onboarding-overlay.tsx`) runs a dry-run prune and reads the count from `json.wouldPrune`. The route `POST /api/sessions/prune` has two paths:

- **Client-side fallback** (daemon lacks prune) — correctly returns `wouldPrune: candidates.length`. ✅
- **Daemon-native path** (`/api/v1/sessions/prune` exists) — returned the count under `pruned` and **never set `wouldPrune`**. ❌

So whenever the daemon supports prune natively, `json.wouldPrune ?? 0` was always `0`.

## Fix

Mirror the fallback contract in the daemon-native branch: on a dry run, return the count under `wouldPrune` with `pruned: 0`. Now **Check** reports the true count → the red **Delete N** button appears → selecting it actually prunes; genuine daemon failures (502) still flow into the panel's red error text as before.

Single-file change; no behavior change for the non-dry-run delete path or the client-side fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)