### PR TITLE
fix(a11y): inbox feed section headings + selected-row aria-current

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -230,6 +230,7 @@ export const SUITES = {
     "src/components/familiars-view-stats.test.ts",
     "src/components/automations-detail-inputs.test.ts",
     "src/components/automations-view.test.ts",
+    "src/components/inbox-feed-a11y.test.ts",
     "src/components/schedules-tabs.test.ts",
     "src/lib/inbox-feed.test.ts",
     "src/lib/daily-summary-notifications.test.ts",

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import type { Familiar } from "@/lib/types";
 import type { InboxItem, LinkRef } from "@/lib/cave-inbox";
@@ -1219,6 +1219,7 @@ function InboxFeedRow({
       <button
         type="button"
         onClick={() => onSelect(item)}
+        aria-current={selected ? "true" : undefined}
         className="focus-ring-inset automation-list-row group flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors"
         style={{ background: selected ? "rgba(255,255,255,0.05)" : "transparent" }}
         onMouseEnter={(e) => { if (!selected) (e.currentTarget as HTMLButtonElement).style.background = "rgba(255,255,255,0.03)"; }}
@@ -1259,14 +1260,15 @@ function InboxFeedSection({
   familiarLabel: (fid?: string | null) => string | null;
   onSelect: (item: InboxItem) => void;
 }) {
+  const headingId = useId();
   if (items.length === 0) return null;
   return (
-    <div className="mb-6">
+    <section className="mb-6" aria-labelledby={headingId}>
       <div className="flex items-center gap-3 mb-1 rounded-md px-3 py-1.5"
         style={{ background: "color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%)", borderBottom: "1px solid var(--border-hairline)" }}>
-        <span className="text-[12px] font-bold" style={{ color: "var(--text-primary)" }}>
+        <h3 id={headingId} className="text-[12px] font-bold" style={{ color: "var(--text-primary)" }}>
           {title}
-        </span>
+        </h3>
         <span
           className="rounded px-1.5 py-0.5 text-[10px] font-semibold"
           style={
@@ -1278,7 +1280,7 @@ function InboxFeedSection({
           {items.length}
         </span>
       </div>
-      <ul>
+      <ul aria-labelledby={headingId}>
         {items.map((item) => (
           <InboxFeedRow
             key={item.id}
@@ -1289,7 +1291,7 @@ function InboxFeedSection({
           />
         ))}
       </ul>
-    </div>
+    </section>
   );
 }
 

--- a/src/components/inbox-feed-a11y.test.ts
+++ b/src/components/inbox-feed-a11y.test.ts
@@ -1,0 +1,36 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// The Inbox view (mode "inbox") is AutomationsView's Inbox tab, whose feed is
+// InboxFeedSection / InboxFeedRow. These pin the feed's accessibility structure.
+const src = readFileSync(new URL("./automations-view.tsx", import.meta.url), "utf8");
+
+// ── Sections are labelled regions with real headings ─────────────────────────
+// Was: a styled <span> title inside a <div> with a bare <ul> — no heading
+// navigation and no accessible name on the list.
+assert.match(
+  src,
+  /<section className="mb-6" aria-labelledby=\{headingId\}>/,
+  "each inbox feed section is a region labelled by its heading",
+);
+assert.match(
+  src,
+  /<h3 id=\{headingId\} className="text-\[12px\] font-bold"/,
+  "the section title (Needs you / Active / Resolved) is a real heading, not a span",
+);
+assert.match(
+  src,
+  /<ul aria-labelledby=\{headingId\}>/,
+  "the section list is named by its heading so screen readers announce which list it is",
+);
+assert.match(src, /const headingId = useId\(\);/, "each section gets a stable heading id");
+
+// ── Selected inbox row announces itself ──────────────────────────────────────
+assert.match(
+  src,
+  /aria-current=\{selected \? "true" : undefined\}/,
+  "the open inbox row is aria-current, not just a background tint",
+);
+
+console.log("inbox-feed-a11y.test.ts: ok");


### PR DESCRIPTION
## Inbox audit (mode "inbox")

The Inbox view is `InboxEscalationsView`, a thin wrapper around `AutomationsView`'s **Inbox tab**. Its container machinery is already solid — polling-pause-when-hidden + `mountedRef` + request-id guards landed in the Schedules audit (#1834), and the tab bar uses the canonical accessible `ui/tabs`. So this PR targets the two genuinely inbox-specific a11y gaps in the feed (`InboxFeedSection` / `InboxFeedRow`):

### 1. Section structure for screen readers
"Needs you" / "Active" / "Resolved" rendered as styled `<span>`s inside `<div>`s with bare `<ul>`s — no heading navigation, and the lists had no accessible name. Each section is now a `<section aria-labelledby>` with a real `<h3>` heading, and each `<ul aria-labelledby>` is named by its heading.

### 2. Selected row announces itself
The open inbox row was conveyed only by a background tint; added `aria-current` (the rows were already real keyboard `<button>`s).

## Verification
- New `inbox-feed-a11y.test.ts` (wired; `check:tests-wired` ✓) + existing `automations-view.test.ts` pass · `tsc` clean · `pnpm build` clean
- Live (Playwright): after the inbox endpoint settles, 3 feed `section[aria-labelledby]` regions render with their `<h3>`-named lists; skeletons clear and tabs render. (`aria-current` row logic pinned by the source test — feed selection needs escalation data that's awkward to seed live.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)