### PR TITLE
feat(marketplace): remote MCP endpoint validation (Test connection)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -22,6 +22,7 @@ import { fileURLToPath } from "node:url";
 export const SUITES = {
   app: [
     "src/lib/app-version.test.ts",
+    "src/lib/endpoint-validators.test.ts",
     "src/lib/familiar-avatar-src.test.ts",
     "src/lib/app-update.test.ts",
     "src/lib/coven-version.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -91,6 +91,7 @@ const contracts: RouteContract[] = [
   { route: "/marketplace/uninstall", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/marketplace/config", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/marketplace/config/validate", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/marketplace/validate-endpoint", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/memory/delete", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/memory/file", methods: ["GET"], kind: "json", pathGuard: true },
   { route: "/memory/inspector", methods: ["GET"], kind: "json" },

--- a/src/app/api/marketplace/config/catalog-config.ts
+++ b/src/app/api/marketplace/config/catalog-config.ts
@@ -8,6 +8,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import {
   requiredConfigFromManifest,
+  remoteUrlFromManifest,
   type PluginManifest,
   type RequiredConfigField,
 } from "@/lib/marketplace-catalog";
@@ -35,5 +36,17 @@ export async function requiredConfigFor(name: string): Promise<RequiredConfigFie
     return requiredConfigFromManifest(manifest);
   } catch {
     return [];
+  }
+}
+
+/** The remote MCP endpoint URL for a trusted plugin name, or undefined. */
+export async function remoteUrlFor(name: string): Promise<string | undefined> {
+  try {
+    const manifest = JSON.parse(
+      await readFile(path.join(MARKETPLACE_DIR, "plugins", name, "plugin.json"), "utf8"),
+    ) as PluginManifest;
+    return remoteUrlFromManifest(manifest);
+  } catch {
+    return undefined;
   }
 }

--- a/src/app/api/marketplace/validate-endpoint/route.ts
+++ b/src/app/api/marketplace/validate-endpoint/route.ts
@@ -1,0 +1,40 @@
+/**
+ * POST /api/marketplace/validate-endpoint  { id }
+ *
+ * For a remote (URL-based) MCP plugin, probes whether its endpoint is reachable
+ * and speaking MCP. Advisory connectivity check — not user authentication
+ * (remote servers use in-client OAuth). The manifest path is built from the
+ * trusted catalog name, never the request id.
+ */
+
+import { NextResponse } from "next/server";
+import { checkMcpEndpoint } from "@/lib/endpoint-validators";
+import { resolveCatalogName, remoteUrlFor } from "../config/catalog-config";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  let body: { id?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json" }, { status: 400 });
+  }
+  const id = typeof body?.id === "string" ? body.id : "";
+  const name = id ? await resolveCatalogName(id) : null;
+  if (!name) {
+    return NextResponse.json({ ok: false, error: `unknown plugin "${id}"` }, { status: 400 });
+  }
+  const url = await remoteUrlFor(name);
+  if (!url) {
+    return NextResponse.json({ ok: false, error: "not a remote plugin" }, { status: 400 });
+  }
+  const result = await checkMcpEndpoint(url);
+  return NextResponse.json({
+    ok: true,
+    reachable: result.reachable,
+    detail: result.detail ?? null,
+    error: result.error ?? null,
+  });
+}

--- a/src/components/marketplace/marketplace-detail.tsx
+++ b/src/components/marketplace/marketplace-detail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, useState, useCallback } from "react";
 import type { ReactNode } from "react";
 import { Icon } from "@/lib/icon";
 import { Button } from "@/components/ui/button";
@@ -24,6 +24,26 @@ type Props = {
 
 export function MarketplaceDetail({ plugin, busy, onClose, onAdd, onRemove }: Props) {
   const ref = useRef<HTMLDivElement | null>(null);
+  type ConnState = { state: "idle" | "testing" | "reachable" | "unreachable"; message?: string };
+  const [conn, setConn] = useState<ConnState>({ state: "idle" });
+
+  const testConnection = useCallback(async () => {
+    setConn({ state: "testing" });
+    try {
+      const res = await fetch("/api/marketplace/validate-endpoint", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: plugin.id }),
+      });
+      const json = (await res.json()) as { ok?: boolean; reachable?: boolean; detail?: string | null; error?: string | null };
+      if (!json.ok) throw new Error(json.error ?? "check failed");
+      setConn(json.reachable
+        ? { state: "reachable", message: json.detail ?? "Reachable" }
+        : { state: "unreachable", message: json.error ?? "Unreachable" });
+    } catch (err) {
+      setConn({ state: "unreachable", message: err instanceof Error ? err.message : "check failed" });
+    }
+  }, [plugin.id]);
   useFocusTrap(true, ref, { onEscape: onClose });
   const state = pluginBadgeState(plugin);
   return (
@@ -92,6 +112,30 @@ export function MarketplaceDetail({ plugin, busy, onClose, onAdd, onRemove }: Pr
             <p className="text-[12px] text-[var(--text-muted)]">
               This plugin needs credentials before it can run. Adding it now records your choice; credential setup is a later step.
             </p>
+          </Section>
+        ) : null}
+
+        {plugin.remoteUrl ? (
+          <Section title="Connection">
+            <p className="text-[11px] text-[var(--text-muted)]">
+              Authenticates via OAuth when first used — no setup needed here.
+            </p>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                loading={conn.state === "testing"}
+                onClick={() => void testConnection()}
+              >
+                Test connection
+              </Button>
+              {conn.state === "reachable" || conn.state === "unreachable" ? (
+                <span className={`inline-flex items-center gap-1 text-[11px] ${conn.state === "reachable" ? "text-[var(--text-primary)]" : "text-[var(--text-muted)]"}`}>
+                  <Icon name={conn.state === "reachable" ? "ph:check-circle" : "ph:warning"} width={12} aria-hidden />
+                  {conn.message}
+                </span>
+              ) : null}
+            </div>
           </Section>
         ) : null}
 

--- a/src/lib/endpoint-validators.test.ts
+++ b/src/lib/endpoint-validators.test.ts
@@ -1,0 +1,28 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { checkMcpEndpoint } from "./endpoint-validators.ts";
+
+const fakeFetch = (status) => async () => ({ ok: status >= 200 && status < 300, status });
+const throwingFetch = async () => { throw new Error("ECONNREFUSED"); };
+
+let r = await checkMcpEndpoint("https://mcp.example/mcp", fakeFetch(200));
+assert.equal(r.reachable, true);
+assert.match(r.detail, /live/i);
+
+r = await checkMcpEndpoint("https://mcp.example/mcp", fakeFetch(401));
+assert.equal(r.reachable, true);
+assert.match(r.detail, /sign in|connect/i);
+
+r = await checkMcpEndpoint("https://mcp.example/mcp", fakeFetch(403));
+assert.equal(r.reachable, true);
+assert.match(r.detail, /sign in|connect/i);
+
+r = await checkMcpEndpoint("https://mcp.example/mcp", fakeFetch(500));
+assert.equal(r.reachable, true);
+assert.match(r.detail, /500/);
+
+r = await checkMcpEndpoint("https://mcp.example/mcp", throwingFetch);
+assert.equal(r.reachable, false);
+assert.match(r.error, /reach/i);
+
+console.log("endpoint-validators.test.ts: ok");

--- a/src/lib/endpoint-validators.ts
+++ b/src/lib/endpoint-validators.ts
@@ -1,0 +1,31 @@
+/**
+ * Endpoint reachability probe for remote (URL-based) MCP plugins. Posts a
+ * minimal JSON-RPC `initialize` and classifies the response. This checks that
+ * the integration endpoint is LIVE — not that the user is authenticated (remote
+ * MCP servers authenticate via in-client OAuth). Injectable fetch for tests.
+ */
+
+export type EndpointCheck = { reachable: boolean; detail?: string; error?: string };
+type FetchLike = typeof fetch;
+
+export async function checkMcpEndpoint(url: string, fetchImpl: FetchLike = fetch): Promise<EndpointCheck> {
+  try {
+    const res = await fetchImpl(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "coven-cave", version: "0" } },
+      }),
+      signal: AbortSignal.timeout(5000),
+      cache: "no-store",
+    });
+    if (res.status === 401 || res.status === 403) return { reachable: true, detail: "reachable — sign in on connect" };
+    if (res.ok) return { reachable: true, detail: "endpoint live" };
+    return { reachable: true, detail: `reachable (HTTP ${res.status})` };
+  } catch {
+    return { reachable: false, error: "could not reach endpoint" };
+  }
+}

--- a/src/lib/marketplace-catalog.test.ts
+++ b/src/lib/marketplace-catalog.test.ts
@@ -7,6 +7,7 @@ import {
   filterPlugins,
   categoriesFrom,
   requiredConfigFromManifest,
+  remoteUrlFromManifest,
 } from "./marketplace-catalog.ts";
 
 const marketplacePlugins = [
@@ -103,5 +104,26 @@ assert.equal(pluginBadgeState({ available: true, installed: true, requiresSetup:
 assert.equal(pluginBadgeState({ available: true, installed: false, requiresSetup: true, configured: true }), "add");
 assert.equal(pluginBadgeState({ available: true, installed: false, requiresSetup: false, configured: false }), "add");
 assert.equal(pluginBadgeState({ available: false, installed: false, requiresSetup: true, configured: false }), "unavailable");
+
+// --- remoteUrl (remote MCP endpoint) ---
+assert.equal(
+  remoteUrlFromManifest({ mcpServers: { linear: { url: "https://mcp.linear.app/mcp", type: "http" } } }),
+  "https://mcp.linear.app/mcp",
+);
+assert.equal(
+  remoteUrlFromManifest({ mcpServers: { github: { command: "npx" } } }),
+  undefined,
+); // command-only (no url) -> undefined
+assert.equal(remoteUrlFromManifest({}), undefined);
+
+const remoteMerged = mergeCatalog(
+  [{ name: "linear", displayName: "Linear", category: "Project Management", trust: "official-remote", policy: { installation: "AVAILABLE", authentication: "NONE" } }],
+  { linear: { mcpServers: { linear: { url: "https://mcp.linear.app/mcp", type: "http" } } } },
+  {},
+);
+assert.equal(remoteMerged[0].remoteUrl, "https://mcp.linear.app/mcp");
+
+const ghRow = merged.find((p) => p.id === "github");
+assert.equal(ghRow.remoteUrl, undefined); // github fixture has no mcpServers -> undefined
 
 console.log("marketplace-catalog.test.ts: ok");

--- a/src/lib/marketplace-catalog.ts
+++ b/src/lib/marketplace-catalog.ts
@@ -33,6 +33,7 @@ export type PluginManifest = {
   keywords?: string[];
   capabilities?: string[];
   userConfig?: Record<string, PluginUserConfigField>;
+  mcpServers?: Record<string, { url?: string; type?: string; command?: string }>;
 };
 
 export type RequiredConfigField = {
@@ -57,6 +58,15 @@ export function requiredConfigFromManifest(manifest: PluginManifest): RequiredCo
     }));
 }
 
+/** The first remote (url-based) MCP server URL declared by the manifest, if any. */
+export function remoteUrlFromManifest(manifest: PluginManifest): string | undefined {
+  const servers = manifest.mcpServers ?? {};
+  for (const s of Object.values(servers)) {
+    if (s && typeof s.url === "string" && s.url.length > 0) return s.url;
+  }
+  return undefined;
+}
+
 export type InstalledMap = Record<string, { version: string; source: string; installedAt: string }>;
 
 export type MarketplacePlugin = {
@@ -79,6 +89,7 @@ export type MarketplacePlugin = {
   available: boolean;
   requiredConfig: RequiredConfigField[];
   configured: boolean;
+  remoteUrl?: string;
 };
 
 export function deriveRequiresSetup(userConfig: PluginManifest["userConfig"]): boolean {
@@ -125,6 +136,7 @@ export function mergeCatalog(
         available: installation === "AVAILABLE",
         requiredConfig,
         configured: false,
+        remoteUrl: remoteUrlFromManifest(manifest),
       };
     })
     .sort((a, b) => a.displayName.localeCompare(b.displayName));


### PR DESCRIPTION
Adds a **Test connection** affordance for remote MCP plugins (Linear, Vercel, Canva, Asana — any plugin with a remote `mcpServers` URL) in the detail drawer. Builds on the token-validation work (#1849).

### What's here
- **Generic probe** `src/lib/endpoint-validators.ts` — `checkMcpEndpoint(url)` POSTs a JSON-RPC `initialize` (5s timeout) and classifies: 200=`endpoint live`, 401/403=`reachable — sign in on connect`, other status=`reachable (HTTP n)`, throw/timeout=`could not reach endpoint`. Injectable fetch → unit-tested.
- **`remoteUrl`** derived on the card model from the manifest `mcpServers` (pure `remoteUrlFromManifest`).
- **`POST /api/marketplace/validate-endpoint {id}`** — path-safe (`resolveCatalogName` → new `remoteUrlFor`), advisory, returns `{ reachable, detail, error }`. Never sends a secret (these plugins have none).
- **Connection section** in `MarketplaceDetail` (the only home — remote plugins have no Configure modal): OAuth-on-connect note + Test connection + inline ✓/✗.

### Honest framing
This checks the integration **endpoint is live**, not that the user is authenticated — remote MCP servers authenticate via in-client OAuth. A 401/403 is reported as reachable ("sign in on connect"), not a failure.

### Verified (real endpoints)
- `endpoint-validators.test.ts` (200/401/403/500/throw) + `marketplace-catalog` (remoteUrl) + `api-contracts` (127) + app suite (412) green; `pnpm build` ✅.
- Live probe: Linear & Vercel → `reachable — sign in on connect`; github → 400 "not a remote plugin"; traversal id → 400. Detail drawer shows the Connection section + ✓ result; github's drawer has none.

Scope (v1): reachability only (not auth/full-MCP), drawer-only, one generic probe for all remote plugins. Spec/plan in `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)