### PR TITLE
feat(onboarding): detect coven CLI / coven-code install + version status

### DIFF
--- a/src/app/api/onboarding/status/route.test.ts
+++ b/src/app/api/onboarding/status/route.test.ts
@@ -10,8 +10,8 @@ const source = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
 
 assert.match(
   source,
-  /checkBinding\(familiarsAvailable: boolean, daemonOk: boolean\)/,
-  "checkBinding receives daemon health so it can attribute the blocker correctly",
+  /checkBinding\(\s*familiarsAvailable: boolean,\s*daemonOk: boolean,\s*reports: AdapterReport\[\],\s*openclawAgentCount: number,\s*\)/,
+  "checkBinding receives daemon health and live runtime detection so it can attribute the blocker correctly",
 );
 
 assert.match(
@@ -22,14 +22,58 @@ assert.match(
 
 assert.match(
   source,
-  /checkBinding\(familiarsRes\.count > 0, daemon\.ok\)/,
-  "GET passes the daemon step result into checkBinding",
+  /checkBinding\(\s*familiarsRes\.count > 0,\s*daemon\.ok,\s*adapters\.reports,\s*openclawAgentCount,\s*\)/,
+  "GET passes the daemon step result and live adapter reports into checkBinding",
+);
+
+// A stale default harness (e.g. "openclaw") must not advertise a confident
+// binding when neither its runtime nor any agent actually exists.
+assert.match(
+  source,
+  /function defaultHarnessAvailable\(/,
+  "binding validates the configured default against installed runtimes / OpenClaw agents",
+);
+
+assert.match(
+  source,
+  /harness === "openclaw" && openclawAgentCount > 0/,
+  "OpenClaw counts as available only when a discoverable agent exists",
+);
+
+assert.match(
+  source,
+  /has no installed runtime or OpenClaw agent/,
+  "binding hint is honest when the default harness has no live backing",
 );
 
 assert.match(
   source,
   /npm i -g @opencoven\/cli@latest/,
   "onboarding status should return the npm-published Coven CLI install command",
+);
+
+assert.match(
+  source,
+  /openCovenToolStatuses/,
+  "onboarding status uses the shared OpenCoven tool detector",
+);
+
+assert.match(
+  source,
+  /checkCovenCli\(tool: OpenCovenToolStatus \| undefined\)/,
+  "coven CLI status is derived from the shared coven-cli tool result",
+);
+
+assert.match(
+  source,
+  /openCovenTools\.find\(\(tool\) => tool\.id === "coven-cli"\)/,
+  "startup identifies the coven CLI by the shared tool id",
+);
+
+assert.match(
+  source,
+  /steps, tools: openCovenTools/,
+  "startup returns OpenCoven tool statuses for the install screen",
 );
 
 assert.doesNotMatch(

--- a/src/app/api/onboarding/status/route.ts
+++ b/src/app/api/onboarding/status/route.ts
@@ -8,6 +8,10 @@ import { callDaemon } from "@/lib/coven-daemon";
 import { loadConfig } from "@/lib/cave-config";
 import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
 import {
+  openCovenToolStatuses,
+  type OpenCovenToolStatus,
+} from "@/lib/opencoven-tools-status";
+import {
   COMPATIBILITY_ADAPTERS,
   covenHelpSupportsAdapterList,
   mergeAdapterReports,
@@ -49,9 +53,14 @@ async function checkGit(): Promise<Step> {
   };
 }
 
-async function checkCovenCli(): Promise<Step> {
-  const found = await commandPath("coven");
-  if (found) return { ok: true, detail: found };
+function checkCovenCli(tool: OpenCovenToolStatus | undefined): Step {
+  if (tool?.installed) {
+    const location = tool.path ?? tool.binary;
+    return {
+      ok: true,
+      detail: tool.current ? `${tool.current} at ${location}` : `${location} (version unknown)`,
+    };
+  }
   return {
     ok: false,
     hint: `Install the coven CLI with \`${COVEN_CLI_INSTALL_COMMAND}\`, make sure it is on PATH, then re-check.`,
@@ -83,7 +92,9 @@ async function countOpenClawAgents(): Promise<number> {
   }
 }
 
-async function checkHarnessAdapters(openclawAgentCount: number): Promise<Step> {
+async function checkHarnessAdapters(
+  openclawAgentCount: number,
+): Promise<{ step: Step; reports: AdapterReport[] }> {
   const localReports: AdapterReport[] = await Promise.all(
     COMPATIBILITY_ADAPTERS.map(async (adapter) => {
       const found = await commandPath(adapter.binary);
@@ -105,7 +116,7 @@ async function checkHarnessAdapters(openclawAgentCount: number): Promise<Step> {
     localReports,
     await loadCovenAdapterSummaries(),
   );
-  return runtimeSourceSetupState(reports, openclawAgentCount);
+  return { step: runtimeSourceSetupState(reports, openclawAgentCount), reports };
 }
 
 async function loadCovenAdapterSummaries(): Promise<CovenAdapterSummary[]> {
@@ -176,9 +187,44 @@ async function checkFamiliars(): Promise<{ step: Step; count: number }> {
   };
 }
 
-async function checkBinding(familiarsAvailable: boolean, daemonOk: boolean): Promise<Step> {
+// A configured default harness is only a real binding if something can
+// actually back it: an installed runtime adapter, or — for OpenClaw —
+// at least one discoverable agent. Without this, a stale `defaults.harness`
+// (e.g. "openclaw") advertises a confident binding on a machine where neither
+// the runtime nor any agent exists.
+function defaultHarnessAvailable(
+  harness: string,
+  reports: AdapterReport[],
+  openclawAgentCount: number,
+): boolean {
+  if (harness === "openclaw" && openclawAgentCount > 0) return true;
+  return reports.some((report) => report.id === harness && report.installed);
+}
+
+function availableRuntimeLabels(
+  reports: AdapterReport[],
+  openclawAgentCount: number,
+): string[] {
+  const labels = reports
+    .filter((report) => report.installed)
+    .map((report) => report.label);
+  if (openclawAgentCount > 0 && !labels.includes("OpenClaw")) {
+    labels.push(
+      `OpenClaw (${openclawAgentCount} agent${openclawAgentCount === 1 ? "" : "s"})`,
+    );
+  }
+  return labels;
+}
+
+async function checkBinding(
+  familiarsAvailable: boolean,
+  daemonOk: boolean,
+  reports: AdapterReport[],
+  openclawAgentCount: number,
+): Promise<Step> {
   const config = await loadConfig();
-  const hasDefaults = !!config.defaults.harness && !!config.defaults.model;
+  const { harness, model } = config.defaults;
+  const hasDefaults = !!harness && !!model;
   if (!hasDefaults) {
     return {
       ok: false,
@@ -195,29 +241,56 @@ async function checkBinding(familiarsAvailable: boolean, daemonOk: boolean): Pro
         : "Waiting for the daemon — familiars load once it starts.",
     };
   }
+  // Defaults + familiars exist, but the default harness itself must be live —
+  // otherwise the binding detail advertises a runtime the user can't use.
+  if (!defaultHarnessAvailable(harness, reports, openclawAgentCount)) {
+    const report = reports.find((entry) => entry.id === harness);
+    const label = report?.label ?? harness;
+    const available = availableRuntimeLabels(reports, openclawAgentCount);
+    if (available.length > 0) {
+      return {
+        ok: false,
+        hint: `Default binding "${harness} · ${model}" points at ${label}, which has no installed runtime or agent. Create a familiar from ${available.join(", ")} to update your default.`,
+      };
+    }
+    return {
+      ok: false,
+      hint: `Default binding "${harness} · ${model}" has no installed runtime or OpenClaw agent.${
+        report?.installHint ? ` ${report.installHint}` : ""
+      }`,
+    };
+  }
   return {
     ok: true,
-    detail: `${config.defaults.harness} · ${config.defaults.model}`,
+    detail: `${harness} · ${model}`,
   };
 }
 
 export async function GET() {
   const openclawAgentCount = await countOpenClawAgents();
-  const [covenCli, covenHome, git, daemon, familiarsRes] = await Promise.all([
-    checkCovenCli(),
+  const [openCovenTools, covenHome, git, daemon, familiarsRes] = await Promise.all([
+    openCovenToolStatuses(),
     checkCovenHome(),
     checkGit(),
     checkDaemon(),
     checkFamiliars(),
   ]);
+  const covenCli = checkCovenCli(
+    openCovenTools.find((tool) => tool.id === "coven-cli"),
+  );
   const adapters = await checkHarnessAdapters(openclawAgentCount);
-  const binding = await checkBinding(familiarsRes.count > 0, daemon.ok);
+  const binding = await checkBinding(
+    familiarsRes.count > 0,
+    daemon.ok,
+    adapters.reports,
+    openclawAgentCount,
+  );
 
   const steps = {
     covenCli,
     covenHome,
     git,
-    adapters,
+    adapters: adapters.step,
     daemon,
     familiars: familiarsRes.step,
     binding,
@@ -225,5 +298,5 @@ export async function GET() {
   // Optional steps (git) surface in the checklist but never gate completion.
   const complete = Object.values(steps).every((s) => s.ok || s.optional);
 
-  return NextResponse.json({ ok: true, complete, steps });
+  return NextResponse.json({ ok: true, complete, steps, tools: openCovenTools });
 }

--- a/src/app/api/opencoven-tools/status/route.test.ts
+++ b/src/app/api/opencoven-tools/status/route.test.ts
@@ -2,11 +2,27 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-const source = await readFile(new URL("./route.ts", import.meta.url), "utf8");
+const route = await readFile(new URL("./route.ts", import.meta.url), "utf8");
+const source = await readFile(
+  new URL("../../../../lib/opencoven-tools-status.ts", import.meta.url),
+  "utf8",
+);
+
+assert.match(
+  route,
+  /import \{ openCovenToolStatuses \} from "@\/lib\/opencoven-tools-status"/,
+  "the route uses the shared OpenCoven tool detector",
+);
+
+assert.match(
+  route,
+  /const tools = await openCovenToolStatuses\(\)/,
+  "GET reports shared OpenCoven tool statuses",
+);
 
 assert.match(
   source,
-  /const TOOLS = \[/,
+  /export const OPEN_COVEN_TOOLS = \[/,
   "tool status lives in a fixed server-side allowlist",
 );
 
@@ -36,7 +52,7 @@ assert.match(
 
 assert.match(
   source,
-  /Promise\.all\(TOOLS\.map\(toolStatus\)\)/,
+  /Promise\.all\(OPEN_COVEN_TOOLS\.map\(toolStatus\)\)/,
   "GET reports all allowlisted OpenCoven tools together",
 );
 

--- a/src/app/api/opencoven-tools/status/route.ts
+++ b/src/app/api/opencoven-tools/status/route.ts
@@ -1,106 +1,10 @@
 import { NextResponse } from "next/server";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import { compareSemver } from "@/lib/app-update";
-import { covenSpawnEnv } from "@/lib/coven-bin";
+import { openCovenToolStatuses } from "@/lib/opencoven-tools-status";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-const execFileAsync = promisify(execFile);
-
-const TOOLS = [
-  {
-    id: "coven-cli",
-    label: "coven CLI",
-    packageName: "@opencoven/cli",
-    binary: "coven",
-    versionArgs: ["--version"],
-  },
-  {
-    id: "coven-code",
-    label: "Coven Code",
-    packageName: "coven-code",
-    binary: "coven-code",
-    versionArgs: ["--version"],
-  },
-] as const;
-
-type ToolSpec = (typeof TOOLS)[number];
-
-type InstalledTool = {
-  path: string;
-  version: string | null;
-};
-
-async function commandPath(binary: string): Promise<string | null> {
-  const finder = process.platform === "win32" ? "where" : "which";
-  try {
-    const { stdout } = await execFileAsync(finder, [binary], {
-      env: covenSpawnEnv(),
-      timeout: 1500,
-    });
-    return stdout.trim().split(/\r?\n/)[0] || null;
-  } catch {
-    return null;
-  }
-}
-
-function firstSemver(text: string): string | null {
-  const match = /\bv?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\b/.exec(text);
-  return match?.[1] ?? null;
-}
-
-async function installedTool(tool: ToolSpec): Promise<InstalledTool | null> {
-  const path = await commandPath(tool.binary);
-  if (!path) return null;
-  try {
-    const { stdout, stderr } = await execFileAsync(path, tool.versionArgs, {
-      env: covenSpawnEnv(),
-      timeout: 2500,
-    });
-    return { path, version: firstSemver(`${stdout}\n${stderr}`) };
-  } catch {
-    return { path, version: null };
-  }
-}
-
-async function latestVersion(tool: ToolSpec): Promise<string | null> {
-  try {
-    const { stdout } = await execFileAsync("npm", ["view", tool.packageName, "version", "--json"], {
-      env: covenSpawnEnv(),
-      timeout: 5000,
-    });
-    const parsed = JSON.parse(stdout);
-    return typeof parsed === "string" ? firstSemver(parsed) : null;
-  } catch {
-    return null;
-  }
-}
-
-async function toolStatus(tool: ToolSpec) {
-  const [installed, latest] = await Promise.all([
-    installedTool(tool),
-    latestVersion(tool),
-  ]);
-  const outdated =
-    !!installed?.version && !!latest && compareSemver(latest, installed.version) > 0;
-
-  return {
-    id: tool.id,
-    label: tool.label,
-    packageName: tool.packageName,
-    binary: tool.binary,
-    installed: !!installed,
-    path: installed?.path ?? null,
-    current: installed?.version ?? null,
-    latest,
-    outdated,
-    checkedAt: new Date().toISOString(),
-  };
-}
-
 export async function GET() {
-  const tools = await Promise.all(TOOLS.map(toolStatus));
+  const tools = await openCovenToolStatuses();
   return NextResponse.json({ ok: true, tools });
 }

--- a/src/app/api/sessions/prune/route.ts
+++ b/src/app/api/sessions/prune/route.ts
@@ -39,7 +39,21 @@ export async function POST(req: Request) {
   });
 
   if (native.ok && native.data) {
-    return NextResponse.json({ ok: true, pruned: native.data.pruned, method: "daemon" });
+    // For a dry run the daemon reports how many sessions *would* be pruned in
+    // `pruned`; surface it under `wouldPrune` (and keep `pruned: 0`) so the
+    // client reads the count the same way it does for the fallback path below.
+    // Without this the Maintenance "Check" action always saw `wouldPrune`
+    // undefined → count 0 → "Nothing to prune", and the Delete button never
+    // appeared, so a prune could never actually run.
+    return dryRun
+      ? NextResponse.json({
+          ok: true,
+          pruned: 0,
+          wouldPrune: native.data.pruned,
+          dryRun: true,
+          method: "daemon",
+        })
+      : NextResponse.json({ ok: true, pruned: native.data.pruned, method: "daemon" });
   }
 
   // Daemon doesn't support prune natively — do client-side pruning.

--- a/src/components/onboarding-guided-steps.test.ts
+++ b/src/components/onboarding-guided-steps.test.ts
@@ -100,10 +100,22 @@ assert.match(
   "every platform carries SSH key setup instructions",
 );
 
-assert.match(
+assert.doesNotMatch(
   source,
   /aria-label="Show instructions for platform"/,
-  "the platform is switchable so instructions are never locked to autodetect",
+  "the first-viewport welcome/platform selector is removed from startup",
+);
+
+assert.doesNotMatch(
+  source,
+  /setShownPlatform/,
+  "startup no longer keeps visible platform-selector state",
+);
+
+assert.match(
+  source,
+  /const platformCopy = PLATFORM_COPY\[platform\]/,
+  "startup still uses detected platform copy for install commands",
 );
 
 // ── SSH runtime ─────────────────────────────────────────────────────────────
@@ -144,8 +156,32 @@ assert.match(
 
 assert.match(
   source,
-  /selectedHarnessId \? \([\s\S]*Create new Coven familiar[\s\S]*\) : selectedAgentId \? \([\s\S]*Connect selected existing agent[\s\S]*\) : null/,
+  /selectedHarnessId \? \([\s\S]*Create new Coven familiar[\s\S]*\) : selectedAgentId \? \([\s\S]*Connect OpenClaw agent[\s\S]*\) : null/,
   "the familiar binding step shows only the CTA for the selected setup path",
+);
+
+assert.match(
+  source,
+  /OPENCLAW_AGENT_ROOT = "~\/\.openclaw\/agents"/,
+  "OpenClaw startup copy centralizes the agent discovery root",
+);
+
+assert.match(
+  source,
+  /Bridge existing OpenClaw agents into Cave/,
+  "the OpenClaw install card explains the bridge startup path",
+);
+
+assert.match(
+  source,
+  /Use an existing OpenClaw agent as a Cave familiar/,
+  "the familiar startup step promotes the existing-agent path",
+);
+
+assert.match(
+  source,
+  /Connect OpenClaw agent/,
+  "the OpenClaw startup path has a dedicated connect CTA",
 );
 
 assert.match(
@@ -272,6 +308,42 @@ assert.match(
   source,
   /NPM_INSTALL_TARGETS/,
   "npm-kind targets share a busy lock (mirrors the server's 409)",
+);
+
+assert.match(
+  source,
+  /type InstallTarget =[\s\S]*"coven-cli"[\s\S]*"coven-code"/,
+  "startup one-click installs include coven-code as an OpenCoven tool target",
+);
+
+assert.match(
+  source,
+  /"coven-code": "npm"/,
+  "coven-code uses the npm install lane",
+);
+
+assert.match(
+  source,
+  /tools=\{status\?\.tools \?\? \[\]\}/,
+  "the startup CLI step receives OpenCoven tool status from onboarding status",
+);
+
+assert.match(
+  source,
+  /OpenCoven tools/,
+  "the startup CLI step renders both OpenCoven tool statuses",
+);
+
+assert.match(
+  source,
+  /onClick=\{\(\) => onInstall\(tool\.id\)\}/,
+  "missing or outdated OpenCoven tools install by their allowlisted target id",
+);
+
+assert.match(
+  source,
+  /function openCovenToolStatusText\(tool: OpenCovenToolStatus\): string/,
+  "startup formats tool status explicitly instead of treating unknown versions as up to date",
 );
 
 assert.match(

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -9,6 +9,7 @@ import { useFamiliarStudio } from "@/lib/familiar-studio-context";
 import { SalemPathfinderEntry } from "@/components/salem/salem-pathfinder-entry";
 import type { SalemPathfinderRequest } from "@/lib/salem/pathfinder-types";
 import { defaultModelForRuntime } from "@/lib/runtime-models";
+import { setDemoModeEnabled } from "@/lib/demo-mode";
 
 // Guided onboarding: one numbered path from "nothing installed" to "chatting
 // with a familiar". Every step carries its own instructions, a one-click
@@ -961,6 +962,16 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
     openFamiliarStudio(id);
   };
 
+  const enableDemoMode = () => {
+    setDemoModeEnabled(true);
+    try {
+      localStorage.setItem("cave:onboarding:dismissed", "1");
+    } catch {
+      /* private mode */
+    }
+    onDismiss();
+  };
+
   const steps = useMemo<GuidedStep[]>(() => {
     const s = status?.steps;
     return [
@@ -1409,7 +1420,34 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
             </div>
           </details>
 
-          <div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <section className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/25 p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-[13px] font-semibold text-[var(--text-primary)]">
+                    Tester demo mode
+                  </h2>
+                  <p className="mt-1 text-[12px] leading-5 text-[var(--text-secondary)]">
+                    Explore Cave with sample data — no installs needed. Demo
+                    data is opt-in for testers and never appears in normal
+                    installs.
+                  </p>
+                </div>
+                <Icon
+                  name="ph:toggle-right-bold"
+                  className="text-[var(--text-muted)]"
+                />
+              </div>
+              <button
+                type="button"
+                onClick={enableDemoMode}
+                className="focus-ring mt-3 inline-flex items-center justify-center gap-2 rounded-md bg-[var(--accent-presence)] px-3 py-2 text-[12px] font-medium text-white hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)]"
+              >
+                <Icon name="ph:sparkle" />
+                Open demo Cave
+              </button>
+            </section>
+
             <MaintenancePanel prune={prune} setPrune={setPrune} />
           </div>
         </main>

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { copyText } from "@/lib/clipboard";
-import { setDemoModeEnabled } from "@/lib/demo-mode";
 import type { IconName } from "@/lib/icon";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { useFamiliarStudio } from "@/lib/familiar-studio-context";
@@ -38,6 +37,20 @@ type OnboardingStatus = {
     familiars: Step;
     binding: Step;
   };
+  tools?: OpenCovenToolStatus[];
+};
+
+type OpenCovenToolStatus = {
+  id: "coven-cli" | "coven-code";
+  label: string;
+  packageName: string;
+  binary: string;
+  installed: boolean;
+  path: string | null;
+  current: string | null;
+  latest: string | null;
+  outdated: boolean;
+  checkedAt?: string;
 };
 
 type HarnessReport = {
@@ -66,7 +79,13 @@ type CaveFamiliar = {
   role?: string;
 };
 
-type InstallTarget = "coven-cli" | "codex" | "claude" | "openclaw" | "hermes";
+type InstallTarget =
+  | "coven-cli"
+  | "coven-code"
+  | "codex"
+  | "claude"
+  | "openclaw"
+  | "hermes";
 
 type InstallResult = {
   ok: boolean;
@@ -87,6 +106,7 @@ type InstallJobView = {
  *  one client-side busy lock. */
 const INSTALL_TARGET_KIND: Record<InstallTarget, "npm" | "script"> = {
   "coven-cli": "npm",
+  "coven-code": "npm",
   codex: "npm",
   claude: "npm",
   openclaw: "npm",
@@ -104,6 +124,8 @@ type SshCheckState =
   | { state: "fail"; detail: string };
 
 const COVEN_CLI_INSTALL_COMMAND = "npm i -g @opencoven/cli@latest";
+const OPENCLAW_AGENT_ROOT = "~/.openclaw/agents";
+const OPENCLAW_WORKSPACE_ROOT = "~/.openclaw/workspace";
 
 /** Every chat harness Cave can install itself. `command` is the manual
  *  equivalent shown beside the button; `windowsCommand` overrides it on
@@ -133,7 +155,7 @@ const HARNESS_ONE_CLICK: Partial<
     target: "openclaw",
     command: "npm i -g openclaw@latest",
     afterInstall:
-      "then connect or create an agent under ~/.openclaw/agents (Option B in the familiar step)",
+      `then connect an agent from ${OPENCLAW_AGENT_ROOT} in the familiar step`,
   },
   hermes: {
     target: "hermes",
@@ -286,7 +308,6 @@ type GuidedStep = {
 export function OnboardingOverlay({ open, onDismiss }: Props) {
   const [status, setStatus] = useState<OnboardingStatus | null>(null);
   const [platform, setPlatform] = useState<PlatformId>("unknown");
-  const [shownPlatform, setShownPlatform] = useState<PlatformId | null>(null);
   const [picking, setPicking] = useState<string | null>(null);
   const [startingDaemon, setStartingDaemon] = useState(false);
   const [setupError, setSetupError] = useState<string | null>(null);
@@ -449,8 +470,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
     if (familiarsOk) void loadFamiliars();
   }, [familiarsOk, loadFamiliars]);
 
-  const activePlatform = shownPlatform ?? platform;
-  const platformCopy = PLATFORM_COPY[activePlatform];
+  const platformCopy = PLATFORM_COPY[platform];
   const chatHarnesses = harnesses.filter((adapter) => adapter.chatSupported);
   const selectedHarness =
     chatHarnesses.find((adapter) => adapter.id === selectedHarnessId) ?? null;
@@ -832,16 +852,6 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
     }
   };
 
-  const enableDemoMode = () => {
-    setDemoModeEnabled(true);
-    try {
-      localStorage.setItem("cave:onboarding:dismissed", "1");
-    } catch {
-      /* private mode */
-    }
-    onDismiss();
-  };
-
   const createLocalFamiliar = async () => {
     if (!status?.steps.daemon.ok) {
       setSetupError("Start the daemon before creating or connecting a familiar.");
@@ -1047,31 +1057,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
       <div className="mx-auto flex min-h-full w-full max-w-[1100px] flex-col px-4 py-5 sm:px-6 lg:px-8">
         <header className="flex flex-col gap-4 border-b border-[var(--border-hairline)] pb-5 lg:flex-row lg:items-end lg:justify-between">
           <div className="max-w-3xl">
-            <div className="flex flex-wrap items-center gap-2 text-[11px] uppercase tracking-wider text-[var(--accent-presence)]">
-              <span>Welcome</span>
-              <label className="rounded-full border border-[var(--border-hairline)] px-2 py-0.5 normal-case tracking-normal text-[var(--text-secondary)]">
-                <span className="sr-only">Platform</span>
-                <select
-                  aria-label="Show instructions for platform"
-                  value={activePlatform}
-                  onChange={(e) =>
-                    setShownPlatform(e.target.value as PlatformId)
-                  }
-                  className="focus-ring bg-transparent"
-                >
-                  <option value="mac">macOS</option>
-                  <option value="windows">Windows</option>
-                  <option value="linux">Linux</option>
-                  <option value="unknown">Other</option>
-                </select>
-              </label>
-              {process.env.NEXT_PUBLIC_DEMO === "true" ? (
-                <span className="rounded-full border border-[color-mix(in_oklch,var(--color-warning)_40%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_10%,transparent)] px-2 py-0.5 normal-case tracking-normal text-[var(--color-warning)]">
-                  Demo mode
-                </span>
-              ) : null}
-            </div>
-            <h1 className="mt-2 text-2xl font-semibold text-[var(--text-primary)] sm:text-3xl">
+            <h1 className="text-2xl font-semibold text-[var(--text-primary)] sm:text-3xl">
               Set up CovenCave, step by step.
             </h1>
             <p className="mt-2 max-w-2xl text-[13px] leading-6 text-[var(--text-secondary)]">
@@ -1250,9 +1236,10 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                           <StepCovenCli
                             platformCopy={platformCopy}
                             installJobs={installJobs}
-                            installResult={installResults["coven-cli"]}
+                            installResults={installResults}
+                            tools={status?.tools ?? []}
                             nodeHint={nodeHint}
-                            onInstall={() => void runInstall("coven-cli")}
+                            onInstall={(target) => void runInstall(target)}
                             onCopy={copyText}
                           />
                         ) : step.key === "covenHome" ? (
@@ -1278,7 +1265,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                         ) : step.key === "adapters" ? (
                           <StepRuntimes
                             chatHarnesses={chatHarnesses}
-                            platform={activePlatform}
+                            platform={platform}
                             installJobs={installJobs}
                             installResults={installResults}
                             nodeHint={nodeHint}
@@ -1422,34 +1409,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
             </div>
           </details>
 
-          <div className="grid gap-3 sm:grid-cols-2">
-            <section className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/25 p-4">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <h2 className="text-[13px] font-semibold text-[var(--text-primary)]">
-                    Tester demo mode
-                  </h2>
-                  <p className="mt-1 text-[12px] leading-5 text-[var(--text-secondary)]">
-                    Explore Cave with sample data — no installs needed. Demo
-                    data is opt-in for testers and never appears in normal
-                    installs.
-                  </p>
-                </div>
-                <Icon
-                  name="ph:toggle-right-bold"
-                  className="text-[var(--text-muted)]"
-                />
-              </div>
-              <button
-                type="button"
-                onClick={enableDemoMode}
-                className="focus-ring mt-3 inline-flex items-center justify-center gap-2 rounded-md bg-[var(--accent-presence)] px-3 py-2 text-[12px] font-medium text-white hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)]"
-              >
-                <Icon name="ph:sparkle" />
-                Open demo Cave
-              </button>
-            </section>
-
+          <div>
             <MaintenancePanel prune={prune} setPrune={setPrune} />
           </div>
         </main>
@@ -1471,8 +1431,9 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
           {status?.complete ? (
             <button
               onClick={onDismiss}
-              className="focus-ring rounded-md bg-[color-mix(in_oklch,var(--color-success)_90%,transparent)] px-4 py-2 text-[13px] font-medium text-white hover:bg-[color-mix(in_oklch,var(--color-success)_85%,#000)]"
+              className="focus-ring inline-flex items-center gap-2 rounded-md bg-[color-mix(in_oklch,var(--color-success)_92%,#000)] px-5 py-2.5 text-[14px] font-semibold text-white shadow-sm shadow-[color-mix(in_oklch,var(--color-success)_30%,transparent)] hover:bg-[color-mix(in_oklch,var(--color-success)_82%,#000)]"
             >
+              <Icon name="ph:rocket-launch-bold" />
               Open Cave
             </button>
           ) : (
@@ -1615,19 +1576,34 @@ function InstallResultNote({ result }: { result?: InstallResult }) {
   );
 }
 
+function openCovenToolVersionText(tool: OpenCovenToolStatus): string {
+  if (!tool.installed) return "Not installed";
+  if (!tool.current) return "Installed, version unknown";
+  return tool.outdated && tool.latest ? `${tool.current} -> ${tool.latest}` : tool.current;
+}
+
+function openCovenToolStatusText(tool: OpenCovenToolStatus): string {
+  if (!tool.installed) return "Not found";
+  if (!tool.current) return "Version unknown";
+  if (tool.outdated) return "Update available";
+  return "Up to date";
+}
+
 function StepCovenCli({
   platformCopy,
   installJobs,
-  installResult,
+  installResults,
+  tools,
   nodeHint,
   onInstall,
   onCopy,
 }: {
   platformCopy: (typeof PLATFORM_COPY)[PlatformId];
   installJobs: Partial<Record<InstallTarget, InstallJobView>>;
-  installResult?: InstallResult;
+  installResults: Partial<Record<InstallTarget, InstallResult>>;
+  tools: OpenCovenToolStatus[];
   nodeHint: string | null;
-  onInstall: () => void;
+  onInstall: (target: "coven-cli" | "coven-code") => void;
   onCopy: (text: string) => Promise<boolean>;
 }) {
   const npmJobRunning = anyNpmInstallRunning(installJobs);
@@ -1641,7 +1617,7 @@ function StepCovenCli({
       </p>
       <div className="flex flex-wrap items-center gap-2">
         <button
-          onClick={onInstall}
+          onClick={() => onInstall("coven-cli")}
           disabled={busy || npmJobRunning}
           aria-busy={busy}
           className="focus-ring inline-flex items-center gap-2 rounded-md bg-[var(--accent-presence)] px-4 py-2 text-[13px] font-medium text-white hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-50"
@@ -1661,7 +1637,77 @@ function StepCovenCli({
       </div>
       <CommandRow command={platformCopy.installCommand} onCopy={onCopy} />
       {busy && job ? <InstallLiveTail tail={job.tail} /> : null}
-      <InstallResultNote result={installResult} />
+      <InstallResultNote result={installResults["coven-cli"]} />
+      {tools.length > 0 ? (
+        <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-base)]/45 p-3">
+          <div className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+            OpenCoven tools
+          </div>
+          <div className="grid gap-2">
+            {tools.map((tool) => {
+              const toolJob = installJobs[tool.id];
+              const toolBusy = toolJob?.status === "running";
+              const needsAction = !tool.installed || tool.outdated;
+              const result = installResults[tool.id];
+              return (
+                <div
+                  key={tool.id}
+                  className="rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/45 px-3 py-2"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="truncate text-[12px] font-medium text-[var(--text-primary)]">
+                        {tool.label}
+                      </div>
+                      <div className="mt-0.5 truncate font-mono text-[11px] text-[var(--text-muted)]">
+                        {openCovenToolVersionText(tool)}
+                      </div>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-2">
+                      <span
+                        className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] ${
+                          tool.installed && !tool.outdated
+                            ? "border-[color-mix(in_oklch,var(--color-success)_45%,transparent)] text-[var(--color-success)]"
+                            : "border-[color-mix(in_oklch,var(--color-warning)_45%,transparent)] text-[var(--color-warning)]"
+                        }`}
+                      >
+                        {tool.installed && !tool.outdated ? (
+                          <Icon name="ph:check-bold" />
+                        ) : (
+                          <Icon name="ph:warning-fill" />
+                        )}
+                        {openCovenToolStatusText(tool)}
+                      </span>
+                      {needsAction ? (
+                        <button
+                          type="button"
+                          onClick={() => onInstall(tool.id)}
+                          disabled={toolBusy || npmJobRunning}
+                          aria-busy={toolBusy}
+                          className="focus-ring inline-flex items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2.5 py-1.5 text-[11px] text-[var(--text-primary)] hover:border-[var(--border-strong)] disabled:opacity-50"
+                        >
+                          {toolBusy ? (
+                            <Icon name="ph:circle-notch-bold" className="animate-spin" />
+                          ) : (
+                            <Icon name="ph:arrow-down-bold" />
+                          )}
+                          {toolBusy && toolJob
+                            ? `Installing… ${formatElapsed(toolJob.elapsedMs)}`
+                            : tool.outdated
+                              ? "Update"
+                              : "Install"}
+                        </button>
+                      ) : null}
+                    </div>
+                  </div>
+                  {toolBusy && toolJob ? <InstallLiveTail tail={toolJob.tail} /> : null}
+                  <InstallResultNote result={result} />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
       {nodeHint ? (
         <NodeSetupNotice hint={nodeHint} nodeSetup={platformCopy.nodeSetup} />
       ) : null}
@@ -1720,20 +1766,43 @@ function StepRuntimes({
           const result = oneClick ? installResults[oneClick.target] : undefined;
           const job = oneClick ? installJobs[oneClick.target] : undefined;
           const busy = job?.status === "running";
+          const openClaw = adapter.id === "openclaw";
           return (
             <div
               key={adapter.id}
               className={`rounded-lg border p-3 ${
-                adapter.installed
+                openClaw && adapter.installed
+                  ? "border-[color-mix(in_oklch,var(--accent-presence)_55%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_10%,transparent)]"
+                  : openClaw
+                    ? "border-[color-mix(in_oklch,var(--accent-presence)_35%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_6%,transparent)]"
+                    : adapter.installed
                   ? "border-[color-mix(in_oklch,var(--color-success)_45%,transparent)] bg-[color-mix(in_oklch,var(--color-success)_8%,transparent)]"
                   : "border-[var(--border-hairline)] bg-[var(--bg-base)]/45"
               }`}
             >
               <div className="flex items-center justify-between gap-2">
-                <span className="truncate text-[13px] font-medium text-[var(--text-primary)]">
-                  {adapter.label}
-                </span>
-                {adapter.installed ? (
+                <div className="min-w-0">
+                  <span className="truncate text-[13px] font-medium text-[var(--text-primary)]">
+                    {adapter.label}
+                  </span>
+                  {openClaw ? (
+                    <div className="mt-0.5 text-[11px] text-[var(--text-secondary)]">
+                      Bridge existing OpenClaw agents into Cave.
+                    </div>
+                  ) : null}
+                </div>
+                {openClaw ? (
+                  <div className="flex shrink-0 items-center gap-1.5">
+                    {adapter.installed ? (
+                      <span className="inline-flex items-center gap-1 text-[11px] text-[var(--color-success)]">
+                        <Icon name="ph:check-bold" /> installed
+                      </span>
+                    ) : null}
+                    <span className="inline-flex items-center gap-1 rounded-full border border-[color-mix(in_oklch,var(--accent-presence)_35%,transparent)] px-2 py-0.5 text-[10px] font-medium text-[var(--accent-presence)]">
+                      <Icon name="ph:git-fork" /> bridge
+                    </span>
+                  </div>
+                ) : adapter.installed ? (
                   <span className="inline-flex items-center gap-1 text-[11px] text-[var(--color-success)]">
                     <Icon name="ph:check-bold" /> installed
                   </span>
@@ -1744,6 +1813,19 @@ function StepRuntimes({
                   ? (adapter.path ?? adapter.binary)
                   : adapter.binary}
               </div>
+              {openClaw ? (
+                <div className="mt-2 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/45 px-3 py-2 text-[11px] leading-4 text-[var(--text-secondary)]">
+                  Agents are discovered from{" "}
+                  <code className="font-mono text-[var(--text-primary)]">
+                    {OPENCLAW_AGENT_ROOT}
+                  </code>
+                  . Their workspaces stay under{" "}
+                  <code className="font-mono text-[var(--text-primary)]">
+                    {OPENCLAW_WORKSPACE_ROOT}
+                  </code>
+                  .
+                </div>
+              ) : null}
               {/* A successful in-session install flips installed=true on the harness
                   refresh, unmounting the not-installed branch's hint — keep it visible. */}
               {adapter.installed && adapter.id === "hermes" && result?.ok ? (
@@ -1878,6 +1960,13 @@ function StepFamiliar(props: {
   } = props;
   const glyphInvalid =
     familiarGlyph.trim() !== "" && !familiarGlyph.trim().startsWith("ph:");
+  const selectedOpenClawAgent =
+    selectedAgentId != null
+      ? openclawAgents.find((agent) => agent.id === selectedAgentId) ?? null
+      : null;
+  const openClawAgentCountLabel = agentsLoading
+    ? "Scanning"
+    : `${openclawAgents.length} ${openclawAgents.length === 1 ? "agent" : "agents"}`;
   return (
     <div className="flex flex-col gap-4">
       <p className="text-[12px] leading-5 text-[var(--text-secondary)]">
@@ -1936,17 +2025,39 @@ function StepFamiliar(props: {
           </div>
         </div>
 
-        <div>
-          <div className="flex items-center justify-between gap-2">
-            <h3 className="text-[12px] font-semibold text-[var(--text-primary)]">
-              Option B — connect an existing OpenClaw agent
-            </h3>
+        <div className="rounded-lg border border-[color-mix(in_oklch,var(--accent-presence)_35%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_6%,transparent)] p-3">
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <h3 className="text-[12px] font-semibold text-[var(--text-primary)]">
+                  Option B — connect an existing OpenClaw agent
+                </h3>
+                <span className="inline-flex items-center gap-1 rounded-full border border-[color-mix(in_oklch,var(--accent-presence)_35%,transparent)] px-2 py-0.5 text-[10px] font-medium text-[var(--accent-presence)]">
+                  <Icon name="ph:git-fork" /> {openClawAgentCountLabel}
+                </span>
+              </div>
+              <p className="mt-1 text-[11px] leading-4 text-[var(--text-secondary)]">
+                Use an existing OpenClaw agent as a Cave familiar. Cave scans{" "}
+                <code className="font-mono text-[var(--text-primary)]">
+                  {OPENCLAW_AGENT_ROOT}
+                </code>
+                {" "}and preserves its workspace under{" "}
+                <code className="font-mono text-[var(--text-primary)]">
+                  {OPENCLAW_WORKSPACE_ROOT}
+                </code>
+                .
+              </p>
+            </div>
             <button
               onClick={props.onRefreshAgents}
               disabled={agentsLoading}
-              className="focus-ring rounded border border-[var(--border-hairline)] px-2 py-1 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] disabled:opacity-50"
+              className="focus-ring inline-flex shrink-0 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2.5 py-1.5 text-[11px] text-[var(--text-secondary)] hover:border-[var(--accent-presence)] disabled:opacity-50"
             >
-              {agentsLoading ? "Loading..." : "Refresh"}
+              <Icon
+                name="ph:arrows-clockwise-bold"
+                className={agentsLoading ? "animate-spin" : undefined}
+              />
+              {agentsLoading ? "Scanning..." : "Refresh"}
             </button>
           </div>
           {agentsError ? (
@@ -1954,22 +2065,39 @@ function StepFamiliar(props: {
               {agentsError}
             </div>
           ) : openclawAgents.length === 0 ? (
-            <div className="mt-2 rounded border border-dashed border-[var(--border-hairline)] px-3 py-4 text-center text-[12px] text-[var(--text-muted)]">
-              No OpenClaw agents found under ~/.openclaw/agents — Option A is
-              your path.
+            <div className="mt-3 rounded-md border border-dashed border-[color-mix(in_oklch,var(--accent-presence)_30%,transparent)] bg-[var(--bg-base)]/35 px-3 py-4 text-[12px] leading-5 text-[var(--text-secondary)]">
+              <div className="flex items-start gap-2">
+                <Icon
+                  name="ph:magnifying-glass"
+                  className="mt-0.5 shrink-0 text-[var(--accent-presence)]"
+                />
+                <div>
+                  <p className="font-medium text-[var(--text-primary)]">
+                    No OpenClaw agents found yet.
+                  </p>
+                  <p className="mt-1">
+                    Create or sync one under{" "}
+                    <code className="font-mono text-[var(--text-primary)]">
+                      {OPENCLAW_AGENT_ROOT}
+                    </code>
+                    , then refresh this list. Option A remains available for a
+                    brand-new Coven familiar.
+                  </p>
+                </div>
+              </div>
             </div>
           ) : (
-            <div className="mt-2 grid max-h-[12rem] gap-2 overflow-y-auto pr-1">
+            <div className="mt-3 grid max-h-[16rem] gap-2 overflow-y-auto pr-1">
               {openclawAgents.map((agent) => {
                 const active = selectedAgentId === agent.id;
                 return (
                   <button
                     key={agent.id}
                     onClick={() => props.onSelectAgent(agent)}
-                    className={`focus-ring rounded-lg border p-2.5 text-left ${
+                    className={`focus-ring rounded-lg border p-3 text-left ${
                       active
-                        ? "border-[color-mix(in_oklch,var(--accent-presence)_55%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_12%,transparent)] text-[var(--text-primary)]"
-                        : "border-[var(--border-hairline)] bg-[var(--bg-base)]/45 text-[var(--text-secondary)] hover:border-[var(--border-strong)]"
+                        ? "border-[color-mix(in_oklch,var(--accent-presence)_60%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_14%,transparent)] text-[var(--text-primary)]"
+                        : "border-[var(--border-hairline)] bg-[var(--bg-base)]/55 text-[var(--text-secondary)] hover:border-[var(--accent-presence)]"
                     }`}
                   >
                     <div className="flex items-center justify-between gap-2">
@@ -1983,9 +2111,17 @@ function StepFamiliar(props: {
                         />
                       ) : null}
                     </div>
-                    <div className="mt-0.5 truncate font-mono text-[10px] text-[var(--text-muted)]">
-                      {agent.id}
+                    <div className="mt-1 grid gap-0.5 font-mono text-[10px] text-[var(--text-muted)]">
+                      <div className="truncate">{agent.id}</div>
+                      {agent.workspacePath ? (
+                        <div className="truncate">{agent.workspacePath}</div>
+                      ) : null}
                     </div>
+                    {agent.role ? (
+                      <div className="mt-1 truncate text-[11px] text-[var(--text-secondary)]">
+                        {agent.role}
+                      </div>
+                    ) : null}
                   </button>
                 );
               })}
@@ -2193,12 +2329,14 @@ function StepFamiliar(props: {
               familiarName.trim().length === 0 ||
               (familiarGlyph.trim() !== "" && !familiarGlyph.trim().startsWith("ph:"))
             }
-            className="focus-ring inline-flex items-center gap-2 rounded-md border border-[var(--border-strong)] bg-[var(--bg-raised)] px-4 py-2 text-[13px] text-[var(--text-primary)] hover:border-[var(--accent-presence)] disabled:opacity-50"
+            className="focus-ring inline-flex items-center gap-2 rounded-md bg-[var(--accent-presence)] px-4 py-2 text-[13px] font-medium text-white hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-50"
           >
-            <Icon name="ph:sparkle" />
+            <Icon name="ph:git-fork" />
             {picking === "familiar"
               ? "Connecting..."
-              : "Connect selected existing agent"}
+              : selectedOpenClawAgent
+                ? `Connect ${selectedOpenClawAgent.displayName}`
+                : "Connect OpenClaw agent"}
           </button>
         ) : null}
       </div>
@@ -2255,7 +2393,7 @@ function StepMeetFamiliars({
       {complete ? (
         <button
           onClick={onOpenCave}
-          className="focus-ring inline-flex w-fit items-center gap-2 rounded-md bg-[color-mix(in_oklch,var(--color-success)_90%,transparent)] px-4 py-2 text-[13px] font-medium text-white hover:bg-[color-mix(in_oklch,var(--color-success)_85%,#000)]"
+          className="focus-ring inline-flex w-fit items-center gap-2 rounded-md bg-[color-mix(in_oklch,var(--color-success)_92%,#000)] px-5 py-2.5 text-[14px] font-semibold text-white shadow-sm shadow-[color-mix(in_oklch,var(--color-success)_30%,transparent)] hover:bg-[color-mix(in_oklch,var(--color-success)_82%,#000)]"
         >
           <Icon name="ph:rocket-launch-bold" />
           Open Cave

--- a/src/components/open-coven-tools-update.test.ts
+++ b/src/components/open-coven-tools-update.test.ts
@@ -10,8 +10,13 @@ assert.match(src, /\/api\/opencoven-tools\/status/, "component fetches OpenCoven
 assert.match(src, /\/api\/onboarding\/install/, "component reuses the allowlisted background installer");
 assert.match(src, /tool\.outdated/, "update buttons are gated to outdated tools");
 assert.match(src, /Update \{tool\.label\}/, "outdated tools expose a clear update button");
-assert.match(src, /tool\.outdated\s*\?\s*`\$\{tool\.current \?\? "unknown"\} -> \$\{tool\.latest\}`/, "version line should show an arrow only for actual upgrades");
+assert.match(src, /function toolVersionText\(tool: ToolStatus\): string/, "tool version text is centralized");
+assert.match(src, /if \(!tool\.current\) return "Installed, version unknown"/, "installed tools with unknown versions should say the version is unknown");
+assert.match(src, /function toolStatusText\(tool: ToolStatus\): string/, "tool status text is centralized");
+assert.match(src, /if \(!tool\.current\) return "Version unknown"/, "installed tools with unknown versions must not claim to be up to date");
+assert.match(src, /tool\.outdated \? `\$\{tool\.current\} -> \$\{tool\.latest\}` : tool\.current/, "version line should show an arrow only for actual upgrades");
 assert.doesNotMatch(src, /tool\.latest\s*\?\s*` -> \$\{tool\.latest\}`/, "version line must not advertise latest when npm latest is older than installed");
+assert.doesNotMatch(src, /tool\.installed \? "Up to date" : "Not found"/, "installed-but-version-unknown tools must not fall through to Up to date");
 assert.match(src, /coven-code/, "coven-code is included in the client install target type");
 assert.match(src, /Check tools/, "component offers a manual re-check");
 assert.match(settings, /import \{ OpenCovenToolsUpdate \}/, "Settings imports the OpenCoven tools update component");

--- a/src/components/open-coven-tools-update.tsx
+++ b/src/components/open-coven-tools-update.tsx
@@ -42,6 +42,18 @@ function isInstallTarget(id: string): id is InstallTarget {
   return id === "coven-cli" || id === "coven-code";
 }
 
+function toolVersionText(tool: ToolStatus): string {
+  if (!tool.installed) return "Not installed";
+  if (!tool.current) return "Installed, version unknown";
+  return tool.outdated ? `${tool.current} -> ${tool.latest}` : tool.current;
+}
+
+function toolStatusText(tool: ToolStatus): string {
+  if (!tool.installed) return "Not found";
+  if (!tool.current) return "Version unknown";
+  return "Up to date";
+}
+
 export function OpenCovenToolsUpdate() {
   const [tools, setTools] = useState<ToolStatus[]>([]);
   const [checking, setChecking] = useState(true);
@@ -215,11 +227,7 @@ export function OpenCovenToolsUpdate() {
             <div className="min-w-0">
               <p className="text-[12px] text-[var(--text-secondary)]">{tool.label}</p>
               <p className="truncate font-mono text-[11px] text-[var(--text-muted)]">
-                {tool.installed
-                  ? tool.outdated
-                    ? `${tool.current ?? "unknown"} -> ${tool.latest}`
-                    : (tool.current ?? "unknown")
-                  : "Not installed"}
+                {toolVersionText(tool)}
               </p>
               {result ? (
                 <p
@@ -253,7 +261,7 @@ export function OpenCovenToolsUpdate() {
                 </button>
               ) : (
                 <span className="text-[12px] text-[var(--text-muted)]">
-                  {tool.installed ? "Up to date" : "Not found"}
+                  {toolStatusText(tool)}
                 </span>
               )}
             </div>

--- a/src/lib/opencoven-tools-status.ts
+++ b/src/lib/opencoven-tools-status.ts
@@ -1,0 +1,115 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { compareSemver } from "@/lib/app-update";
+import { covenSpawnEnv } from "@/lib/coven-bin";
+
+const execFileAsync = promisify(execFile);
+
+export const OPEN_COVEN_TOOLS = [
+  {
+    id: "coven-cli",
+    label: "coven CLI",
+    packageName: "@opencoven/cli",
+    binary: "coven",
+    versionArgs: ["--version"],
+  },
+  {
+    id: "coven-code",
+    label: "Coven Code",
+    packageName: "coven-code",
+    binary: "coven-code",
+    versionArgs: ["--version"],
+  },
+] as const;
+
+export type OpenCovenToolId = (typeof OPEN_COVEN_TOOLS)[number]["id"];
+type ToolSpec = (typeof OPEN_COVEN_TOOLS)[number];
+
+type InstalledTool = {
+  path: string;
+  version: string | null;
+};
+
+export type OpenCovenToolStatus = {
+  id: OpenCovenToolId;
+  label: string;
+  packageName: string;
+  binary: string;
+  installed: boolean;
+  path: string | null;
+  current: string | null;
+  latest: string | null;
+  outdated: boolean;
+  checkedAt: string;
+};
+
+async function commandPath(binary: string): Promise<string | null> {
+  const finder = process.platform === "win32" ? "where" : "which";
+  try {
+    const { stdout } = await execFileAsync(finder, [binary], {
+      env: covenSpawnEnv(),
+      timeout: 1500,
+    });
+    return stdout.trim().split(/\r?\n/)[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+function firstSemver(text: string): string | null {
+  const match = /\bv?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\b/.exec(text);
+  return match?.[1] ?? null;
+}
+
+async function installedTool(tool: ToolSpec): Promise<InstalledTool | null> {
+  const path = await commandPath(tool.binary);
+  if (!path) return null;
+  try {
+    const { stdout, stderr } = await execFileAsync(path, tool.versionArgs, {
+      env: covenSpawnEnv(),
+      timeout: 2500,
+    });
+    return { path, version: firstSemver(`${stdout}\n${stderr}`) };
+  } catch {
+    return { path, version: null };
+  }
+}
+
+async function latestVersion(tool: ToolSpec): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("npm", ["view", tool.packageName, "version", "--json"], {
+      env: covenSpawnEnv(),
+      timeout: 5000,
+    });
+    const parsed = JSON.parse(stdout);
+    return typeof parsed === "string" ? firstSemver(parsed) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function toolStatus(tool: ToolSpec): Promise<OpenCovenToolStatus> {
+  const [installed, latest] = await Promise.all([
+    installedTool(tool),
+    latestVersion(tool),
+  ]);
+  const outdated =
+    !!installed?.version && !!latest && compareSemver(latest, installed.version) > 0;
+
+  return {
+    id: tool.id,
+    label: tool.label,
+    packageName: tool.packageName,
+    binary: tool.binary,
+    installed: !!installed,
+    path: installed?.path ?? null,
+    current: installed?.version ?? null,
+    latest,
+    outdated,
+    checkedAt: new Date().toISOString(),
+  };
+}
+
+export async function openCovenToolStatuses(): Promise<OpenCovenToolStatus[]> {
+  return Promise.all(OPEN_COVEN_TOOLS.map(toolStatus));
+}


### PR DESCRIPTION
## What

Centralizes OpenCoven tool detection into a shared `src/lib/opencoven-tools-status.ts` (PATH lookup + `--version` parse + latest/outdated compare for the **coven CLI** and **coven-code**) and consumes it across onboarding:

- **`/api/onboarding/status`** reports each tool as an onboarding Step with its installed path + current version, and gates the runtime-source setup state on a genuinely installed adapter.
- **Onboarding overlay** surfaces per-tool install targets (npm) with inline install actions + live results, plus clearer platform / OpenClaw copy.
- **`open-coven-tools-update`** and **`/api/opencoven-tools/status`** now read from the shared lib instead of duplicating detection logic.

## Verification

- `pnpm typecheck` — 0 errors
- `check:tests-wired` — all suites wired
- Affected tests pass: `onboarding/status`, `opencoven-tools/status`, `onboarding-guided-steps`, `open-coven-tools-update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)