### PR TITLE
feat(flow): inline-edit and resize sticky notes

### DIFF
--- a/src/components/flow/flow-canvas.tsx
+++ b/src/components/flow/flow-canvas.tsx
@@ -58,6 +58,9 @@ export type FlowCanvasProps = {
   onConnectToNew: (from: FlowConnectFrom, position: FlowPosition) => void;
   /** Clicked the "+" on an edge — splice a node into that connection. */
   onInsertEdge: (edgeId: string) => void;
+  /** Sticky-note inline edits. */
+  onStickyText: (id: string, text: string) => void;
+  onStickySize: (id: string, width: number, height: number) => void;
 };
 
 function FlowCanvasInner(props: FlowCanvasProps) {
@@ -76,6 +79,8 @@ function FlowCanvasInner(props: FlowCanvasProps) {
     onRequestAdd,
     onConnectToNew,
     onInsertEdge,
+    onStickyText,
+    onStickySize,
   } = props;
   const [showMiniMap, setShowMiniMap] = useState(false);
   const { screenToFlowPosition } = useReactFlow();
@@ -93,17 +98,25 @@ function FlowCanvasInner(props: FlowCanvasProps) {
     () =>
       doc.nodes.map((node) => {
         const def = catalogNode(node.type);
+        const isSticky = def?.sticky === true;
         return {
           id: node.id,
-          type: def?.sticky ? "flowSticky" : "flowNode",
+          type: isSticky ? "flowSticky" : "flowNode",
           position: node.position,
-          data: { node, def },
-          ...(def?.sticky
+          data: isSticky
+            ? {
+                node,
+                def,
+                onStickyText: (text: string) => onStickyText(node.id, text),
+                onStickySize: (width: number, height: number) => onStickySize(node.id, width, height),
+              }
+            : { node, def },
+          ...(isSticky
             ? { width: node.sticky?.width ?? 240, height: node.sticky?.height ?? 160 }
             : { width: FLOW_NODE_WIDTH, height: FLOW_NODE_HEIGHT }),
         } satisfies Node<FlowNodeData>;
       }),
-    [doc.nodes],
+    [doc.nodes, onStickyText, onStickySize],
   );
 
   useEffect(() => {
@@ -172,7 +185,12 @@ function FlowCanvasInner(props: FlowCanvasProps) {
   );
 
   const handleNodeDoubleClick: NodeMouseHandler<Node<FlowNodeData>> = useCallback(
-    (_event, node) => onOpenNode(node.id),
+    (_event, node) => {
+      // Sticky notes edit their text inline on double-click; don't also open
+      // the detail view.
+      if (node.type === "flowSticky") return;
+      onOpenNode(node.id);
+    },
     [onOpenNode],
   );
 

--- a/src/components/flow/flow-node.tsx
+++ b/src/components/flow/flow-node.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Handle, Position, type NodeProps, type Node } from "@xyflow/react";
+import { Handle, NodeResizer, Position, type NodeProps, type Node } from "@xyflow/react";
+import { useEffect, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import type { FlowNodeType } from "@/lib/flow/flow-catalog";
 import type { FlowNode } from "@/lib/flow/flow-doc";
@@ -13,6 +14,9 @@ export type FlowNodeData = {
   node: FlowNode;
   def: FlowNodeType | undefined;
   phase?: FlowNodePhase;
+  /** Sticky-only: commit inline-edited text / resized dimensions to the doc. */
+  onStickyText?: (text: string) => void;
+  onStickySize?: (width: number, height: number) => void;
 } & Record<string, unknown>;
 
 export type FlowRFNode = Node<FlowNodeData, "flowNode">;
@@ -88,19 +92,69 @@ export function FlowNodeView({ data, selected }: NodeProps<FlowRFNode>) {
   );
 }
 
-/** Sticky note — a non-executable canvas annotation. */
+/** Sticky note — a non-executable canvas annotation. Double-click to edit its
+ *  text inline; drag the corner handles (when selected) to resize. */
 export function FlowStickyView({ data, selected }: NodeProps<FlowStickyRFNode>) {
   const sticky = data.node.sticky;
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(sticky?.text ?? "");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Re-seed the draft from the doc whenever we're not actively editing.
+  useEffect(() => {
+    if (!editing) setDraft(sticky?.text ?? "");
+  }, [sticky?.text, editing]);
+
+  useEffect(() => {
+    if (editing) textareaRef.current?.focus();
+  }, [editing]);
+
   if (!sticky) return null;
+
+  const commit = () => {
+    setEditing(false);
+    if (draft !== sticky.text) data.onStickyText?.(draft);
+  };
+
   return (
     <div
       className={`flow-sticky flow-sticky-${sticky.color}${selected ? " is-selected" : ""}`}
-      style={{ width: sticky.width, height: sticky.height }}
+      style={{ width: "100%", height: "100%" }}
+      onDoubleClick={() => setEditing(true)}
     >
+      <NodeResizer
+        minWidth={150}
+        minHeight={90}
+        isVisible={selected}
+        lineClassName="flow-sticky-resize-line"
+        handleClassName="flow-sticky-resize-handle"
+        onResizeEnd={(_event, params) =>
+          data.onStickySize?.(Math.round(params.width), Math.round(params.height))
+        }
+      />
       <span className="flow-sticky-grip" aria-hidden>
         <Icon name="ph:note" width={13} />
       </span>
-      <p className="flow-sticky-text">{sticky.text || "Double-click to edit"}</p>
+      {editing ? (
+        <textarea
+          ref={textareaRef}
+          className="flow-sticky-input nodrag nopan"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onBlur={commit}
+          // Stop key events reaching React Flow so Backspace/Delete edit text
+          // instead of deleting the node.
+          onKeyDown={(event) => {
+            event.stopPropagation();
+            if (event.key === "Escape") {
+              setDraft(sticky.text);
+              setEditing(false);
+            }
+          }}
+        />
+      ) : (
+        <p className="flow-sticky-text">{sticky.text || "Double-click to edit"}</p>
+      )}
     </div>
   );
 }

--- a/src/components/flow/flow-view.tsx
+++ b/src/components/flow/flow-view.tsx
@@ -595,6 +595,8 @@ export function FlowView() {
                   onRequestAdd={requestAdd}
                   onConnectToNew={requestConnectToNew}
                   onInsertEdge={requestInsertEdge}
+                  onStickyText={(id, text) => onChangeSticky(id, { text })}
+                  onStickySize={(id, width, height) => onChangeSticky(id, { width, height })}
                 />
                 {selectedNode && (
                   <NodeDetailView

--- a/src/styles/flow.css
+++ b/src/styles/flow.css
@@ -209,6 +209,15 @@
 .flow-sticky-rose { background: #3a1722; }
 .flow-sticky-grip { display: inline-flex; color: color-mix(in oklch, var(--foreground) 55%, transparent); margin-bottom: 6px; }
 .flow-sticky-text { margin: 0; font-size: var(--text-sm); line-height: 1.5; color: color-mix(in oklch, var(--foreground) 88%, transparent); white-space: pre-wrap; word-break: break-word; }
+.flow-sticky-input {
+  width: 100%; height: calc(100% - 22px); box-sizing: border-box;
+  border: 0; outline: none; resize: none; padding: 0;
+  background: transparent; color: color-mix(in oklch, var(--foreground) 92%, transparent);
+  font: inherit; font-size: var(--text-sm); line-height: 1.5;
+}
+/* NodeResizer handles, themed to the cave accent. */
+.react-flow__resize-control.flow-sticky-resize-handle { width: 8px; height: 8px; border-radius: 2px; background: var(--accent-presence); border: 1px solid var(--card); }
+.react-flow__resize-control.flow-sticky-resize-line { border-color: color-mix(in oklch, var(--accent-presence) 60%, transparent); }
 
 /* ---- Node catalog panel ------------------------------------------------- */
 .flow-catalog-scrim { position: absolute; inset: 0; z-index: 20; background: var(--backdrop-scrim); display: flex; justify-content: flex-end; }


### PR DESCRIPTION
## What

PR 4 of the n8n-style Flow editor (builds on #1843, #1850, #1861). Sticky notes become first-class canvas annotations, the n8n way:

- **Double-click** a sticky → edit its text **inline** in place; blur commits, **Escape** cancels. Key events are stopped from reaching React Flow so Backspace/Delete edit the text instead of deleting the node.
- **Select** a sticky → `NodeResizer` corner handles appear; drag to **resize**, and the new dimensions persist on resize-end.
- Double-clicking a sticky no longer also opens the detail view (it edits inline).

## How

Sticky text/size route through the existing `updateSticky` mutation via new `onStickyText`/`onStickySize` canvas callbacks threaded through node data. The sticky div fills the React Flow node box (100%/100%) so `NodeResizer` drives its size.

## Verification

Verified end-to-end in the running app: double-click → inline textarea → typed text **commits and re-renders** (`"edited inline ✏️ new content"`); selecting a sticky shows **4 resize handles**.

- ✅ `pnpm typecheck` 0 errors · app suite (413 files) · `next build && build:server` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)